### PR TITLE
feat(chat): slim the new-chat dashboard — no rail, capped open work, never scrolls

### DIFF
--- a/src/components/chat-new-dashboard.test.ts
+++ b/src/components/chat-new-dashboard.test.ts
@@ -1,17 +1,16 @@
 // @ts-nocheck
-// New-chat dashboard — the work-led dashboard (launcher 3a) relocated from
-// Home into the brand-new-chat view; Home went back to the quiet hearth.
-// Pins:
+// New-chat dashboard — the slimmed work board that greets a brand-new chat
+// (Home stays the quiet hearth). Pins:
 //   (1) chat-view splits its empty state: a null sessionId (brand-new chat)
 //       renders <ChatNewDashboard>; existing zero-turn sessions keep the
 //       task-aware <ChatEmptyState>;
-//   (2) body-only shell: rail + board (ChatView owns the chrome above and
-//       the composer below) — no chrome header, no docked composer;
-//   (3) the rail carries Project · Quick start · Task · Pick up; quick rows
-//       seed the chat composer through onPrompt, the picker is the shared
-//       ProjectPicker, Pick up shows the two most-recent resumable sessions;
-//   (4) the board reads the live Tasks board + the inbox "needs you" tier
-//       and offers the All/Running/Blocked/Inbox filter tabs;
+//   (2) single-pane, board-only shell: NO context rail (the composer's footer
+//       band owns project · model · linked-work), no chrome header, no docked
+//       composer — ChatView owns the chrome above and the composer below;
+//   (3) reduced open work: no filter tabs; the rows are capped (WORK_CAP)
+//       with the overflow deferred to "+N more in Tasks", and Recent threads
+//       is capped too (RECENT_CAP) — so the board never scrolls;
+//   (4) the board reads the live Tasks board + the inbox "needs you" tier;
 //   (5) self-contained navigation: the component reaches other surfaces
 //       through the established window-event bridges, not prop drilling;
 //   (6) Home is the hearth again — home-composer neither renders the
@@ -36,12 +35,16 @@ assert.match(
   "existing zero-turn sessions keep the task-aware ChatEmptyState",
 );
 
-// ── (2) Body-only shell: rail + board ────────────────────────────────────
+// ── (2) Single-pane, board-only shell ────────────────────────────────────
 assert.match(
   dash,
-  /home-dash__body home-dash--embed[\s\S]*?home-dash__rail[\s\S]*?home-dash__board/,
-  "the embed stacks the context rail beside the work board",
+  /home-dash__body home-dash--embed[\s\S]*?home-dash__board/,
+  "the embed is the work board alone",
 );
+assert.doesNotMatch(dash, /home-dash__rail/, "no context rail — the composer footer band owns project/task context");
+assert.doesNotMatch(dash, /<ProjectPicker/, "no rail project picker — the composer's project chip covers it");
+assert.doesNotMatch(dash, /home-dash__quick/, "no quick-start rows — the composer is the intent surface");
+assert.doesNotMatch(dash, /home-dash__pick/, "no Pick up cards — Recent threads is the single resume list");
 assert.doesNotMatch(dash, /home-dash__chrome/, "no identity chrome — ChatView's header covers it");
 assert.doesNotMatch(dash, /home-dash__dock/, "no docked composer — ChatView's composer is the intent surface");
 assert.match(
@@ -54,37 +57,48 @@ assert.match(
   /\.cave-chat-transcript:has\(\.home-dash--embed\) \.cave-chat-thread \{[\s\S]{0,200}?max-width: none/,
   "the thread releases its centered reading measure for the board",
 );
+assert.doesNotMatch(css, /home-dash__rail/, "the retired rail styles are gone");
+assert.doesNotMatch(css, /home-dash__quick/, "the retired quick-start styles are gone");
+assert.doesNotMatch(css, /home-dash__pick/, "the retired pick-up styles are gone");
 assert.doesNotMatch(css, /home-dash__chrome/, "the retired chrome styles are gone");
 assert.doesNotMatch(css, /home-dash__dock/, "the retired dock styles are gone");
 
-// ── (3) Context rail — Project · Quick start · Task · Pick up ────────────
-assert.match(dash, /home-dash__rail-label">Project</, "the rail leads with the Project group");
-assert.match(dash, /<ProjectPicker/, "the project control is the shared ProjectPicker");
-assert.match(dash, /home-dash__rail-label">Quick start</, "the rail carries a Quick start group");
-assert.match(dash, /home-dash__quick-row[\s\S]*?onPrompt\(/, "quick-start rows seed the chat composer draft");
-assert.match(dash, /onClick=\{onOpenPromptSnippets\}/, "a quick-start row opens the prompt-snippets modal");
-assert.match(dash, /home-dash__rail-label">Task</, "the rail keeps the task-arming group");
-assert.match(dash, /cave-chat-empty-task-armed/, "arming shows the linked-card banner");
-assert.match(dash, /home-dash__rail-label">Pick up</, "the rail surfaces a Pick up group");
-assert.match(dash, /resumableSessions\(sessions, 2\)/, "Pick up shows the two most-recent resumable sessions");
-
-// ── (4) Open-work board — live data + filter tabs ────────────────────────
-assert.match(dash, /const boardCards = useDashboardBoard\(\)/, "the board reads the live Tasks board");
-assert.match(dash, /fetch\("\/api\/inbox", \{ cache: "no-store"/, "the needs-you tier reads the live inbox");
-assert.match(dash, /groupInboxFeed\(items\)\.needsYou/, "needs-you uses the same attention tier as the bell");
-assert.match(dash, /OPEN_WORK_FILTERS\.map/, "the board renders the All/Running/Blocked/Inbox filter tabs");
+// ── (3) Reduced open work, no scrolling ──────────────────────────────────
+assert.doesNotMatch(dash, /OPEN_WORK_FILTERS/, "the filter tabs are gone");
+assert.doesNotMatch(dash, /role="tablist"/, "no tablist chrome on the board head");
+assert.match(dash, /const WORK_CAP = \d+/, "open-work rows are capped");
+assert.match(dash, /openWork\.slice\(0, WORK_CAP\)/, "the board renders at most WORK_CAP rows");
+assert.match(dash, /\+\{moreWork\} more in Tasks/, "overflow defers to Tasks instead of scrolling");
+assert.match(dash, /const RECENT_CAP = \d+/, "recent threads are capped");
+assert.match(
+  dash,
+  /el\.scrollHeight > el\.clientHeight \+ 1 && shed < maxShed/,
+  "a pre-paint fit pass sheds tail rows until the board fits its pane",
+);
+assert.match(dash, /new ResizeObserver\(\(\) => dispatchShed\("reset"\)\)/, "pane resizes re-converge the fit pass");
+assert.match(
+  css,
+  /\.home-dash__board \{[\s\S]{0,200}?overflow: hidden/,
+  "the board pane does not scroll — capped content fits it",
+);
+assert.doesNotMatch(css, /\.home-dash__board \{[\s\S]{0,200}?overflow-y: auto/, "no board scrollbar");
 assert.match(
   dash,
   /\$\{openWork\.length\} thread\$\{openWork\.length === 1 \? "" : "s"\} open\./,
   "the headline counts the open threads",
 );
 assert.match(dash, /home-dash__work-resume/, "work rows keep the visual Resume CTA");
-assert.match(dash, /home-dash__rail-label">Recent threads</, "a Recent threads list renders under Open work");
+assert.match(dash, /home-dash__section-label">Recent threads</, "a Recent threads list renders under Open work");
 assert.match(
   dash,
   /home-dash__meta">[\s\S]*?\{familiar\.harness\}[\s\S]*?\{modelId \? <span>\{modelId\}<\/span> : null\}/,
   "the board head carries the harness · model identity meta (runtime-chip probe)",
 );
+
+// ── (4) Open-work board — live data ──────────────────────────────────────
+assert.match(dash, /const boardCards = useDashboardBoard\(\)/, "the board reads the live Tasks board");
+assert.match(dash, /fetch\("\/api\/inbox", \{ cache: "no-store"/, "the needs-you tier reads the live inbox");
+assert.match(dash, /groupInboxFeed\(items\)\.needsYou/, "needs-you uses the same attention tier as the bell");
 
 // ── (5) Self-contained navigation — window-event bridges ─────────────────
 assert.match(
@@ -111,3 +125,5 @@ assert.doesNotMatch(
   /home-dashboard\.css/,
   "Home no longer imports the dashboard sheet (it ships with the new-chat view)",
 );
+
+console.log("chat-new-dashboard.test.ts: ok");

--- a/src/components/chat-new-dashboard.tsx
+++ b/src/components/chat-new-dashboard.tsx
@@ -4,12 +4,11 @@ import "@/styles/cave-chat.css";
 import "@/styles/home-dashboard.css";
 
 // ── ChatNewDashboard ──────────────────────────────────────────────────────────
-// The work-led dashboard (launcher 3a), relocated from Home to the brand-new
-// chat view: a context rail (project · quick start · task arming · pick up)
-// beside an open-work board (greeting + filter tabs · open work · recent
-// threads). Home went back to the quiet hearth; THIS surface greets a new
-// chat, where the work you resume lands anyway. ChatView supplies the chrome
-// above and the real composer below, so the component is body-only.
+// The work board that greets a brand-new chat, slimmed to a single pane: no
+// context rail (the composer's footer band already owns project · model ·
+// linked-work) and no filter tabs — just the greeting, a capped stack of open
+// work, and a short recent-threads list. Everything fits the pane without
+// scrolling; overflow defers to "+N more in Tasks".
 //
 // Renders inside the transcript's role="log" container as the empty state for
 // `sessionId === null` chats (existing zero-turn sessions keep ChatEmptyState).
@@ -19,32 +18,29 @@ import "@/styles/home-dashboard.css";
 //   • cave:navigate-mode      (workspace switches surface: Tasks, Schedules)
 //   • cave:agents-open-session (ChatSurface routes into an existing session)
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useReducer, useRef, useState } from "react";
 
 import type { Familiar, SessionRow } from "@/lib/types";
-import type { CaveProject } from "@/lib/cave-projects-types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { Icon } from "@/lib/icon";
-import { ProjectPicker } from "@/components/project-picker";
-import { NO_PROJECT_ID, chatProjectById } from "@/lib/chat-projects";
 import { groupInboxFeed } from "@/lib/inbox-feed";
 import { greetingForHour } from "@/lib/home-greeting";
 import { relativeAge } from "@/lib/rss";
-import { resumableSessions } from "@/components/home/home-continue";
 import { useDashboardBoard } from "@/components/home/use-dashboard-board";
 import {
-  OPEN_WORK_FILTERS,
-  OPEN_WORK_FILTER_LABEL,
-  filterOpenWork,
-  openWorkCounts,
   openWorkPriorityLabel,
   openWorkRows,
   runningTimeoutBadge,
-  type OpenWorkFilter,
 } from "@/components/home/dashboard-open-work";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
-import { useAnnouncer } from "@/components/ui/live-region";
+
+/** The board stays scroll-free: this many open-work rows at most, with the
+ *  overflow deferred to "+N more in Tasks" (chat-empty-state precedent). When
+ *  even the capped stack overflows a short pane, whole tail rows are shed —
+ *  recent threads first, then work rows down to one — until it fits. */
+const WORK_CAP = 4;
+const RECENT_CAP = 3;
 
 /** One-shot inbox snapshot for the "needs you" tier of the open-work board.
  *  Abort-guarded like useBoardCards; mount + window refocus are the only
@@ -99,49 +95,16 @@ const markInboxItemRead = (id: string) => {
 
 export function ChatNewDashboard({
   familiar,
-  onPrompt,
-  onOpenPromptSnippets,
-  projectId,
-  onProjectChange,
-  projects,
-  createProject,
-  fileMentions = false,
   sessions = [],
   modelId = null,
-  taskArmed = false,
-  onArmTask,
-  onDisarmTask,
 }: {
   familiar: Familiar;
-  /** Drops a starter prompt into the chat composer for editing before send. */
-  onPrompt?: (text: string) => void;
-  /** Opens the Prompt snippets modal (templates dropped into the composer). */
-  onOpenPromptSnippets?: () => void;
-  /** Selected predetermined project for the chat runtime root. */
-  projectId?: string | null;
-  /** Updates the project used for the next send. */
-  onProjectChange?: (value: string) => void;
-  projects: CaveProject[];
-  /** From useProjects() — enables the picker's "Add project…" row. */
-  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
-  /** True when the chat knows a project root, so `@` opens the file picker. */
-  fileMentions?: boolean;
-  /** Workspace-owned session list; powers Pick up / Recent threads without a fetch. */
+  /** Workspace-owned session list; powers Recent threads without a fetch. */
   sessions?: SessionRow[];
   /** Effective model for the board-head meta row (quiet text, not a badge). */
   modelId?: string | null;
-  /** True while chat-view has a pending linked-card creation armed. */
-  taskArmed?: boolean;
-  onArmTask?: () => void;
-  onDisarmTask?: () => void;
 }) {
-  const { announce } = useAnnouncer();
   const [nowMs] = useState(() => Date.now());
-
-  const project =
-    projectId === NO_PROJECT_ID
-      ? null
-      : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
 
   // Time-of-day greeting for the board eyebrow. Sampled after mount,
   // client-only, to avoid SSR hydration drift.
@@ -150,7 +113,7 @@ export function ChatNewDashboard({
     setGreeting(greetingForHour(new Date().getHours()));
   }, []);
 
-  // ── Dashboard model (launcher 3a) ──────────────────────────────────────────
+  // ── Dashboard model ────────────────────────────────────────────────────────
   // Open work = the Tasks board's live cards, followed by the "needs you"
   // attention tier (fired reminders / response-needed) as inbox rows. Each row
   // carries its own open handler: board rows jump to Tasks, needs-you rows open
@@ -180,171 +143,55 @@ export function ChatNewDashboard({
     }));
     return [...board, ...needs];
   }, [boardCards, needsYou]);
-  const [workFilter, setWorkFilter] = useState<OpenWorkFilter>("all");
-  const workCounts = useMemo(() => openWorkCounts(openWork), [openWork]);
-  const visibleWork = useMemo(
-    () => filterOpenWork(openWork, workFilter),
-    [openWork, workFilter],
+  const visibleWork = useMemo(() => openWork.slice(0, WORK_CAP), [openWork]);
+  const recentPool = useMemo(
+    () =>
+      sessions
+        .filter((s) => !s.archived_at && !s.generated && Boolean(s.title?.trim()))
+        .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
+        .slice(0, RECENT_CAP),
+    [sessions],
   );
-  // Rail "Pick up": the two most-recent resumable sessions. Recent threads:
-  // the next titled sessions, newest-first, minus the two already surfaced.
-  const pickUp = useMemo(() => resumableSessions(sessions, 2), [sessions]);
-  const recentThreads = useMemo(() => {
-    const skip = new Set(pickUp.map((s) => s.id));
-    return sessions
-      .filter(
-        (s) => !s.archived_at && !s.generated && Boolean(s.title?.trim()) && !skip.has(s.id),
-      )
-      .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
-      .slice(0, 4);
-  }, [sessions, pickUp]);
+
+  // ── No-scroll fit pass ─────────────────────────────────────────────────────
+  // The caps fit a normal pane; on a short one the board would clip. Instead,
+  // shed whole tail rows pre-paint — recent threads first, then work rows down
+  // to one — re-measuring each commit until the content fits. "+N more in
+  // Tasks" absorbs whatever was shed. Resets (and re-converges) when the row
+  // inventory or the pane size changes.
+  const boardRef = useRef<HTMLElement | null>(null);
+  const [shed, dispatchShed] = useReducer(
+    (n: number, action: "bump" | "reset") => (action === "bump" ? n + 1 : 0),
+    0,
+  );
+  const recentShed = Math.min(shed, recentPool.length);
+  const workShed = Math.min(
+    Math.max(0, shed - recentPool.length),
+    Math.max(0, visibleWork.length - 1),
+  );
+  const maxShed = recentPool.length + Math.max(0, visibleWork.length - 1);
+  const shownWork = workShed > 0 ? visibleWork.slice(0, visibleWork.length - workShed) : visibleWork;
+  const recentThreads = recentShed > 0 ? recentPool.slice(0, recentPool.length - recentShed) : recentPool;
+  const moreWork = openWork.length - shownWork.length;
+
+  useLayoutEffect(() => {
+    dispatchShed("reset");
+  }, [openWork.length, recentPool.length]);
+  useLayoutEffect(() => {
+    const el = boardRef.current;
+    if (el && el.scrollHeight > el.clientHeight + 1 && shed < maxShed) dispatchShed("bump");
+  });
+  useEffect(() => {
+    const el = boardRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => dispatchShed("reset"));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
 
   return (
     <div className="home-dash__body home-dash--embed select-none" data-testid="chat-new-dashboard">
-
-      {/* Context rail */}
-      <aside className="home-dash__rail" aria-label="Context">
-        {onProjectChange ? (
-          <div className="home-dash__rail-group">
-            <div className="home-dash__rail-label">Project</div>
-            <ProjectPicker
-              projects={projects}
-              value={projectId ?? null}
-              onChange={onProjectChange}
-              allowNoProject
-              familiarId={familiar.id}
-              createProject={createProject}
-              ariaLabel="Project for this chat"
-            />
-            {project?.root ? (
-              <div className="home-dash__project-path" title={project.root}>{project.root}</div>
-            ) : null}
-            {project && fileMentions ? (
-              <span className="home-dash__project-ready">project files ready</span>
-            ) : null}
-          </div>
-        ) : null}
-
-        <div className="home-dash__divider" />
-
-        <div className="home-dash__rail-group">
-          <div className="home-dash__rail-label">Quick start</div>
-          <div className="home-dash__quick">
-            {onPrompt ? (
-              <>
-                <button
-                  type="button"
-                  className="home-dash__quick-row"
-                  onClick={() => onPrompt("Summarise everything that happened today.")}
-                >
-                  <span className="home-dash__quick-icon home-dash__quick-icon--accent" aria-hidden>
-                    <Icon name="ph:sparkle" width={15} />
-                  </span>
-                  <span className="home-dash__quick-label">Summarise today</span>
-                  <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className="home-dash__quick-row"
-                  onClick={() => onPrompt("Review my recent changes and flag anything risky.")}
-                >
-                  <span className="home-dash__quick-icon" aria-hidden>
-                    <Icon name="ph:git-diff" width={15} />
-                  </span>
-                  <span className="home-dash__quick-label">Review recent changes</span>
-                  <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-                </button>
-              </>
-            ) : null}
-            {onOpenPromptSnippets ? (
-              <button
-                type="button"
-                className="home-dash__quick-row"
-                onClick={onOpenPromptSnippets}
-              >
-                <span className="home-dash__quick-icon" aria-hidden>
-                  <Icon name="ph:chat-centered-text" width={15} />
-                </span>
-                <span className="home-dash__quick-label">Prompt snippets</span>
-                <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-              </button>
-            ) : null}
-          </div>
-        </div>
-
-        {project && onArmTask ? (
-          <div className="home-dash__rail-group">
-            <div className="home-dash__rail-label">Task</div>
-            {taskArmed ? (
-              <div className="cave-chat-empty-task-armed" role="status">
-                <Icon name="ph:kanban" width={13} aria-hidden />
-                <span>Describe the task below — sending creates a linked board card.</span>
-                {onDisarmTask ? (
-                  <button
-                    type="button"
-                    className="cave-chat-empty-task-armed-dismiss"
-                    aria-label="Cancel task creation"
-                    onClick={onDisarmTask}
-                  >
-                    <Icon name="ph:x-bold" width={11} aria-hidden />
-                  </button>
-                ) : null}
-              </div>
-            ) : (
-              <button
-                type="button"
-                className="cave-chat-empty-task-tile"
-                onClick={() => {
-                  onArmTask();
-                  announce("Describe the task in the message box; sending creates a linked board card.");
-                }}
-              >
-                <Icon name="ph:kanban" width={14} aria-hidden />
-                <span className="cave-chat-empty-task-tile-label">Start a task in {project.name}</span>
-                <span className="cave-chat-empty-task-tile-hint">creates a linked card</span>
-              </button>
-            )}
-          </div>
-        ) : null}
-
-        {pickUp.length > 0 ? (
-          <>
-            <div className="home-dash__divider" />
-            <div className="home-dash__rail-group">
-              <div className="home-dash__rail-label">Pick up</div>
-              <div className="home-dash__pick">
-                {pickUp.map((s) => {
-                  const running = s.status === "running";
-                  const age = relativeAge(s.updated_at, nowMs);
-                  return (
-                    <button
-                      key={s.id}
-                      type="button"
-                      className="home-dash__pick-card"
-                      onClick={() => openSession(s.id, s.familiarId ?? null)}
-                      title={`Resume “${s.title}”`}
-                    >
-                      <span className="home-dash__pick-glyph" aria-hidden>
-                        <Icon
-                          name={running ? "ph:terminal-window" : "ph:chat-circle-dots"}
-                          width={15}
-                        />
-                      </span>
-                      <span className="home-dash__pick-body">
-                        <span className="home-dash__pick-title">{s.title}</span>
-                        <span className="home-dash__pick-time">{age}</span>
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </>
-        ) : null}
-      </aside>
-
-      {/* Work board */}
-      <main className="home-dash__board" aria-label="Work board">
+      <main ref={boardRef} className="home-dash__board" aria-label="Work board">
         <div className="home-dash__board-inner">
 
           <div className="home-dash__board-head">
@@ -365,56 +212,27 @@ export function ChatNewDashboard({
                 {modelId ? <span>{modelId}</span> : null}
               </p>
             </div>
-            <div className="home-dash__filters" role="tablist" aria-label="Filter open work">
-              {OPEN_WORK_FILTERS.map((f) => (
-                <button
-                  key={f}
-                  type="button"
-                  role="tab"
-                  aria-selected={workFilter === f}
-                  className={`home-dash__filter${workFilter === f ? " is-active" : ""}`}
-                  onClick={() => setWorkFilter(f)}
-                >
-                  {OPEN_WORK_FILTER_LABEL[f]}
-                  {workCounts[f] > 0 ? (
-                    <span className="home-dash__filter-count">{workCounts[f]}</span>
-                  ) : null}
-                </button>
-              ))}
-            </div>
           </div>
 
           {/* Open work */}
           <section className="home-dash__section" aria-label="Open work">
             <div className="home-dash__section-head">
-              <div className="home-dash__rail-label">Open work</div>
-              {workFilter === "inbox" && needsYou.length > 0 ? (
-                <button
-                  type="button"
-                  className="home-dash__section-link"
-                  onClick={() => navigateMode("inbox")}
-                >
-                  View all in Rituals →
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  className="home-dash__section-link"
-                  onClick={() => navigateMode("board")}
-                >
-                  View all in Tasks →
-                </button>
-              )}
+              <div className="home-dash__section-label">Open work</div>
+              <button
+                type="button"
+                className="home-dash__section-link"
+                onClick={() => navigateMode("board")}
+              >
+                View all in Tasks →
+              </button>
             </div>
             <div className="home-dash__work">
-              {visibleWork.length === 0 ? (
+              {shownWork.length === 0 ? (
                 <div className="home-dash__work-empty">
-                  {openWork.length === 0
-                    ? "No open work — start something below."
-                    : `Nothing ${OPEN_WORK_FILTER_LABEL[workFilter].toLowerCase()} right now.`}
+                  No open work — start something below.
                 </div>
               ) : (
-                visibleWork.map((row) => {
+                shownWork.map((row) => {
                   const priority = openWorkPriorityLabel(row.priority);
                   const badge =
                     row.kind === "running"
@@ -452,13 +270,16 @@ export function ChatNewDashboard({
                   );
                 })
               )}
+              {moreWork > 0 ? (
+                <span className="home-dash__work-more">+{moreWork} more in Tasks</span>
+              ) : null}
             </div>
           </section>
 
           {/* Recent threads */}
           {recentThreads.length > 0 ? (
             <section className="home-dash__section" aria-label="Recent threads">
-              <div className="home-dash__rail-label">Recent threads</div>
+              <div className="home-dash__section-label">Recent threads</div>
               <div className="home-dash__recent">
                 {recentThreads.map((s) => (
                   <button

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5618,31 +5618,20 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onBack={onBack}
               />
             ) : sessionId === null ? (
-              // Brand-new chat (no session yet): the work-led dashboard that
-              // used to be Home — rail + open-work board over ChatView's own
-              // composer. Existing zero-turn sessions (fresh task chats with
-              // linked context) keep the quieter ChatEmptyState below.
+              // Brand-new chat (no session yet): the slimmed work board that
+              // used to be Home — greeting + capped open work over ChatView's
+              // own composer (whose footer band owns project · model ·
+              // linked-work, so no context rail). Existing zero-turn sessions
+              // (fresh task chats with linked context) keep the quieter
+              // ChatEmptyState below.
               <ChatNewDashboard
                 familiar={familiar}
-                onPrompt={(text) => {
-                  setInput(text);
-                  inputRef.current?.focus();
-                }}
-                onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
-                projectId={resolvedProjectId}
-                onProjectChange={setProjectIdDraft}
-                projects={projects}
-                createProject={createProject}
-                fileMentions={Boolean(mentionRoot)}
                 sessions={sessions}
                 modelId={
                   modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
                     ? modelState.effectiveModel
                     : familiar.model ?? null
                 }
-                taskArmed={taskArmed}
-                onArmTask={armTask}
-                onDisarmTask={disarmTask}
               />
             ) : (
               <ChatEmptyState

--- a/src/components/home/dashboard-open-work.test.ts
+++ b/src/components/home/dashboard-open-work.test.ts
@@ -1,13 +1,10 @@
 // @ts-nocheck
-// Pure derivations for the Home dashboard's Open-work board (launcher 3a).
+// Pure derivations for the new-chat dashboard's Open-work board.
 import assert from "node:assert/strict";
 import {
-  filterOpenWork,
-  openWorkCounts,
   openWorkPriorityLabel,
   openWorkRows,
   runningTimeoutBadge,
-  OPEN_WORK_FILTERS,
 } from "./dashboard-open-work.ts";
 
 const card = (over = {}) => ({
@@ -46,32 +43,6 @@ const card = (over = {}) => ({
   assert.deepEqual(rows.map((r) => r.id), ["urg", "hi"], "urgent sorts before high");
 }
 
-// ── filterOpenWork: "all" passes through; kind tabs match one-to-one, and the
-//    generic signature preserves caller-attached fields (e.g. onOpen).
-{
-  const rows = openWorkRows([
-    card({ id: "r", status: "running" }),
-    card({ id: "b", status: "blocked" }),
-    card({ id: "i", status: "inbox" }),
-  ]).map((r) => ({ ...r, onOpen: () => r.id }));
-  assert.equal(filterOpenWork(rows, "all").length, 3);
-  assert.deepEqual(filterOpenWork(rows, "running").map((r) => r.id), ["r"]);
-  assert.deepEqual(filterOpenWork(rows, "blocked").map((r) => r.id), ["b"]);
-  assert.equal(typeof filterOpenWork(rows, "running")[0].onOpen, "function", "onOpen survives filtering");
-}
-
-// ── openWorkCounts: per-tab totals
-{
-  const rows = openWorkRows([
-    card({ id: "r1", status: "running" }),
-    card({ id: "r2", status: "running" }),
-    card({ id: "b", status: "blocked" }),
-    card({ id: "i", status: "inbox" }),
-    card({ id: "bk", status: "backlog" }),
-  ]);
-  assert.deepEqual(openWorkCounts(rows), { all: 5, running: 2, blocked: 1, inbox: 1 });
-}
-
 // ── openWorkPriorityLabel: only high/urgent earn a label
 assert.equal(openWorkPriorityLabel("urgent"), "urgent");
 assert.equal(openWorkPriorityLabel("high"), "high");
@@ -87,8 +58,5 @@ assert.equal(openWorkPriorityLabel("low"), null);
   assert.equal(runningTimeoutBadge(since, 0, now), null, "no timeout → no badge");
   assert.equal(runningTimeoutBadge(since, 1000, new Date("2026-07-23T00:00:00Z").getTime()), null, "negative elapsed → no badge");
 }
-
-// The tab order the UI relies on.
-assert.deepEqual(OPEN_WORK_FILTERS, ["all", "running", "blocked", "inbox"]);
 
 console.log("dashboard-open-work.test.ts: ok");

--- a/src/components/home/dashboard-open-work.ts
+++ b/src/components/home/dashboard-open-work.ts
@@ -1,26 +1,15 @@
-// Pure derivations for the Home dashboard's "Open work" board (launcher 3a):
-// map board cards to display rows, order them, bucket them for the filter
-// tabs, and format the running-card timeout badge. Kept side-effect-free and
-// clock-injected (nowMs) so it unit-tests exactly. The component owns the
-// fetch (use-dashboard-board) and the click handlers.
+// Pure derivations for the new-chat dashboard's "Open work" board: map board
+// cards to display rows, order them, and format the running-card timeout
+// badge. Kept side-effect-free and clock-injected (nowMs) so it unit-tests
+// exactly. The component owns the fetch (use-dashboard-board), the click
+// handlers, and the row cap (the board renders a fixed number of rows and
+// defers the rest to Tasks — no filter tabs).
 
 import type { CardPriority, CardStatus } from "@/lib/cave-board-types";
 import type { DashboardCard } from "@/components/home/use-dashboard-board";
 
 /** Row kinds the board renders (board columns minus "done", which is not open work). */
 export type OpenWorkKind = "running" | "blocked" | "inbox" | "review" | "backlog";
-
-/** The filter tabs. Mirrors the mock: All · Running · Blocked · Inbox. */
-export type OpenWorkFilter = "all" | "running" | "blocked" | "inbox";
-
-export const OPEN_WORK_FILTERS: OpenWorkFilter[] = ["all", "running", "blocked", "inbox"];
-
-export const OPEN_WORK_FILTER_LABEL: Record<OpenWorkFilter, string> = {
-  all: "All",
-  running: "Running",
-  blocked: "Blocked",
-  inbox: "Inbox",
-};
 
 export type OpenWorkRow = {
   id: string;
@@ -78,24 +67,6 @@ export function openWorkRows(cards: DashboardCard[]): OpenWorkRow[] {
     return 0;
   });
   return rows;
-}
-
-/** Which rows a given filter tab shows. "all" is everything; the others match
- *  their kind one-to-one with the chip on the row. Generic so callers that
- *  attach their own fields (e.g. an onOpen handler) keep the richer row type. */
-export function filterOpenWork<T extends OpenWorkRow>(rows: T[], filter: OpenWorkFilter): T[] {
-  if (filter === "all") return rows;
-  return rows.filter((r) => r.kind === filter);
-}
-
-/** Per-tab counts for the filter pills. */
-export function openWorkCounts(rows: OpenWorkRow[]): Record<OpenWorkFilter, number> {
-  return {
-    all: rows.length,
-    running: rows.filter((r) => r.kind === "running").length,
-    blocked: rows.filter((r) => r.kind === "blocked").length,
-    inbox: rows.filter((r) => r.kind === "inbox").length,
-  };
 }
 
 /** Only high/urgent priorities earn a colored label on the row (mock parity —

--- a/src/styles/home-dashboard.css
+++ b/src/styles/home-dashboard.css
@@ -1,15 +1,15 @@
-/* New-chat dashboard — launcher direction 3a ("work-led dashboard"),
- * relocated from Home to the brand-new chat view (Home went back to the quiet
- * hearth). A left context rail (project · quick start · task · pick up) beside
- * a scrolling work board (greeting + filter tabs · open work · recent
- * threads). ChatView supplies the chrome above and the real composer below, so
- * only the body ships. Everything is token-driven so the themes × dark/light
- * and the Appearance corner-radius setting all apply. */
+/* New-chat dashboard — the work board that greets a brand-new chat, slimmed
+ * to a single pane: no context rail (the composer's footer band owns project ·
+ * model · linked-work) and no filter tabs. Content is capped in the component
+ * (WORK_CAP / RECENT_CAP + "+N more in Tasks") so the board fits the pane
+ * without scrolling. ChatView supplies the chrome above and the real composer
+ * below, so only the body ships. Everything is token-driven so the themes ×
+ * dark/light and the Appearance corner-radius setting all apply. */
 
 /* ── Embedded shell — fills the empty transcript ────────────────────────── */
 /* The dashboard renders inside the chat transcript (role="log") as the empty
    state of a brand-new chat. The transcript flexes so the embed stretches to
-   the pane's height; rail and board keep their own internal scroll. The
+   the pane's height; the capped content means nothing inside scrolls. The
    thread's centered reading measure is released — the board wants the pane. */
 .cave-chat-transcript:has(.home-dash--embed) {
   display: flex;
@@ -29,7 +29,7 @@
   overflow: hidden;
 }
 
-/* ── Body: rail + board ─────────────────────────────────────────────────── */
+/* ── Body: single work board ────────────────────────────────────────────── */
 .home-dash__body {
   flex: 1;
   min-height: 0;
@@ -37,159 +37,11 @@
   align-items: stretch;
 }
 
-/* ── Context rail ───────────────────────────────────────────────────────── */
-.home-dash__rail {
-  width: 320px;
-  flex-shrink: 0;
-  background: var(--bg-panel);
-  border-right: 1px solid var(--border-hairline);
-  padding: var(--space-5) 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 18px;
-  overflow-y: auto;
-}
-.home-dash__rail-group {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-.home-dash__rail-label {
-  font: 600 10px var(--font-jetbrains-mono), monospace;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
-.home-dash__divider {
-  height: 1px;
-  background: var(--border-hairline);
-}
-
-/* Project group — the picker itself is the shared ProjectPicker control;
-   only the path + readiness meta lines are dashboard-specific. */
-.home-dash__project-path {
-  font-family: var(--font-jetbrains-mono), monospace;
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-  line-height: 1.5;
-  word-break: break-all;
-}
-.home-dash__project-ready {
-  align-self: flex-start;
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
-  padding: var(--space-1) 9px;
-  border-radius: var(--radius-pill);
-  background: color-mix(in oklch, var(--color-success) 12%, transparent);
-  border: 1px solid color-mix(in oklch, var(--color-success) 32%, var(--border-hairline));
-  font-size: var(--text-2xs);
-  color: var(--color-success);
-}
-.home-dash__project-ready::before {
-  content: "";
-  width: 5px;
-  height: 5px;
-  border-radius: var(--radius-pill);
-  background: currentColor;
-}
-
-/* Quick start rows */
-.home-dash__quick {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-1);
-}
-.home-dash__quick-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: var(--space-2) 10px;
-  border-radius: var(--radius-control);
-  cursor: pointer;
-  width: 100%;
-  text-align: left;
-  background: transparent;
-  border: 0;
-  transition: background var(--duration-fast, 120ms) var(--ease-standard, ease);
-}
-.home-dash__quick-row:hover {
-  background: var(--bg-hover);
-}
-.home-dash__quick-icon {
-  display: inline-flex;
-  color: var(--text-secondary);
-  flex-shrink: 0;
-}
-.home-dash__quick-icon--accent {
-  color: var(--accent-presence);
-}
-.home-dash__quick-label {
-  flex: 1;
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-}
-.home-dash__quick-go {
-  color: var(--text-muted);
-  flex-shrink: 0;
-}
-
-/* Pick-up cards */
-.home-dash__pick {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-}
-.home-dash__pick-card {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  padding: 11px;
-  background: var(--bg-raised);
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-control);
-  cursor: pointer;
-  width: 100%;
-  text-align: left;
-  transition: border-color var(--duration-fast, 120ms), transform var(--duration-fast, 120ms);
-}
-.home-dash__pick-card:hover {
-  border-color: var(--border-strong);
-  transform: translateY(-1px);
-}
-.home-dash__pick-glyph {
-  width: 26px;
-  height: 26px;
-  border-radius: var(--radius-control);
-  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
-  color: var(--accent-presence);
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-}
-.home-dash__pick-body {
-  min-width: 0;
-  flex: 1;
-}
-.home-dash__pick-title {
-  font-size: var(--text-sm);
-  color: var(--text-primary);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.home-dash__pick-time {
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-  margin-top: 2px;
-}
-
-/* ── Work board ─────────────────────────────────────────────────────────── */
+/* ── Work board — non-scrolling; the component caps its content ─────────── */
 .home-dash__board {
   flex: 1;
   min-width: 0;
-  overflow-y: auto;
+  overflow: hidden;
   padding: 26px var(--space-8) var(--space-6);
 }
 .home-dash__board-inner {
@@ -197,7 +49,7 @@
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 26px;
+  gap: var(--space-6);
 }
 .home-dash__board-head {
   display: flex;
@@ -275,54 +127,25 @@
   margin-right: var(--space-2);
 }
 
-/* Filter tabs */
-.home-dash__filters {
-  display: inline-flex;
-  padding: 3px;
-  gap: 2px;
-  background: var(--bg-sunken);
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-pill);
-}
-.home-dash__filter {
-  padding: 5px 13px;
-  border-radius: var(--radius-pill);
-  font-size: var(--text-xs);
-  color: var(--text-muted);
-  cursor: pointer;
-  background: transparent;
-  border: 0;
-  white-space: nowrap;
-  transition: color var(--duration-fast, 120ms), background var(--duration-fast, 120ms);
-}
-.home-dash__filter:hover {
-  color: var(--text-secondary);
-}
-.home-dash__filter.is-active {
-  background: var(--bg-elevated);
-  color: var(--text-primary);
-  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
-}
-.home-dash__filter-count {
-  color: var(--text-muted);
-  margin-left: 5px;
-  font-family: var(--font-jetbrains-mono), monospace;
-  font-size: var(--text-2xs);
-}
-.home-dash__filter.is-active .home-dash__filter-count {
-  color: var(--text-secondary);
-}
-
-/* Section scaffold (Open work / Recent threads) */
+/* Section scaffold (Open work / Recent threads) — rigid: sections keep their
+   natural height so a short pane clips at the board edge instead of letting
+   later sections compress and overlap earlier ones. */
 .home-dash__section {
   display: flex;
   flex-direction: column;
   gap: 11px;
+  flex-shrink: 0;
 }
 .home-dash__section-head {
   display: flex;
   align-items: center;
   justify-content: space-between;
+}
+.home-dash__section-label {
+  font: 600 10px var(--font-jetbrains-mono), monospace;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
 }
 .home-dash__section-link {
   font-size: var(--text-xs);
@@ -421,6 +244,12 @@
   border-color: var(--border-strong);
   color: var(--text-primary);
 }
+/* Overflow deferral — the rows are capped; the rest lives in Tasks. */
+.home-dash__work-more {
+  padding-left: 2px;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
 .home-dash__work-empty {
   padding: 22px 15px;
   border: 1px dashed var(--border-hairline);
@@ -464,27 +293,4 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
   flex-shrink: 0;
-}
-
-/* ── Responsive: fold the rail under a narrow surface ───────────────────── */
-@media (max-width: 900px) {
-  .home-dash__body {
-    flex-direction: column;
-    overflow-y: auto;
-  }
-  .home-dash__rail {
-    width: 100%;
-    border-right: 0;
-    border-bottom: 1px solid var(--border-hairline);
-    flex-direction: row;
-    flex-wrap: wrap;
-    overflow: visible;
-  }
-  .home-dash__rail-group {
-    flex: 1;
-    min-width: 220px;
-  }
-  .home-dash__board {
-    overflow-y: visible;
-  }
 }

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -2,12 +2,11 @@ import { expect, test, type Page } from "@playwright/test";
 
 // Verifies the chat surface landing: opening chat (home-first boot means via
 // ?mode=chat) paints the brand-new-chat dashboard (ChatNewDashboard — the
-// work-led rail + open-work board relocated off Home — over ChatView's real
+// slimmed single-pane work board relocated off Home — over ChatView's real
 // composer) without waiting for /api/sessions/list — the fetch that used to
 // gate the boot-compose effect and left users on the ChatList skeleton wall
 // for its full duration. Also pins the landing affordances: the live board's
-// open-work rows, quick-start rows that seed (never send) the composer, and
-// the hidden-not-disabled pre-session Voice button.
+// open-work rows and the hidden-not-disabled pre-session Voice button.
 //
 // Desktop only (compose-first boot is a desktop affordance — mobile keeps
 // the thread list as the chat home). /api/familiars, /api/sessions/list and
@@ -128,7 +127,7 @@ test.describe("chat boot landing", () => {
     await expect(takeover).toHaveCount(0, { timeout: 15_000 });
   });
 
-  test("landing surfaces board work, quick-start seeds the composer, voice call from turn zero", async ({ page }) => {
+  test("landing surfaces board work, voice call from turn zero", async ({ page }) => {
     await seed(page);
     let voiceConversationCreateCalls = 0;
     await page.route("**/api/sessions/list**", (route) =>
@@ -160,11 +159,10 @@ test.describe("chat boot landing", () => {
     // …and the headline counts it.
     await expect(dash.locator(".home-dash__headline")).toContainText("1 thread open.");
 
-    // Quick start seeds the composer, never auto-sends.
-    await dash.locator(".home-dash__quick-row", { hasText: "Summarise today" }).click();
-    const composer = page.getByPlaceholder(/Message Nova/);
-    await expect(composer).toHaveValue(/Summarise everything that happened today\./);
-    await expect(dash).toBeVisible();
+    // The slimmed board ships no context rail and no filter tabs — the
+    // composer's footer band owns project/model context.
+    await expect(dash.locator(".home-dash__rail")).toHaveCount(0);
+    await expect(dash.getByRole("tablist")).toHaveCount(0);
 
     // Voice no longer needs a session: the call action is a direct button from
     // turn zero, while the overflow has moved to the dedicated Chat options trigger.


### PR DESCRIPTION
## What

Slims `ChatNewDashboard` — the work-led surface that greets a brand-new chat (relocated from Home in #3777). Requested: *remove sidepanel in new session state, reduce options in the open work, and no scrolling*.

- **Context rail removed** (project picker · quick start · task arming · pick up). The composer footer band already owns project/model/branch chips and the linked-work strip, and prompt snippets stay reachable via the composer **+** menu — the rail was pure duplication.
- **Open-work board reduced**: filter tabs gone; rows cap at **4 work + 3 recent threads** with an inline **“+N more in Tasks”** overflow line.
- **Never scrolls**: board is `overflow: hidden`; a pre-paint measure-and-shed pass (`useLayoutEffect` + `ResizeObserver`) sheds tail rows — recent threads first, then work down to a floor of one — until content fits the pane. The +N count stays honest as rows shed.
- **Overlap bug fixed en route**: `min-height: 0` sections + `height: 100%` board-inner let Recent threads compress *over* work rows; sections are now `flex-shrink: 0`.

Net: **−431 lines**.

## Validation

- `pnpm typecheck` ✅ · `pnpm lint` (design gate) ✅
- `pnpm test` — 902 app test files ✅
- `COVEN_CAVE_E2E=1 playwright test tests/chat-boot-landing.spec.ts` — 7/7 ✅ (spec updated: asserts rail/tablist absent)
- Screenshot-verified at 1440×1050 (full caps fit, no scroll) and 1280×720 (sheds to 2 work rows + “+10 more in Tasks”, recent tier shed, no clipping)