### PR TITLE
docs(windows-msi): hardlink/file_count invariant + warm-cache deep-verify note (cave-7kay)

### DIFF
--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -136,6 +136,16 @@ fn cache_is_ready(destination: &Path, manifest: &SidecarArchiveManifest) -> bool
     // start (and is especially expensive under real-time antivirus scanning).
     // Required entrypoints are still checked so common partial-cache damage is
     // repaired automatically.
+    //
+    // Deep-verify consideration (cave-7kay): this warm-path trust lives in
+    // user-writable LocalAppData, which is acceptable because the
+    // authoritative archive sits in admin-protected Program Files and any
+    // failed check funnels back into the fully verified extraction path. For
+    // paranoid/enterprise installs an opt-in deep-verify mode would slot in
+    // here — re-hash the cached tree against manifest.tree_sha256 before
+    // trusting the marker — at the cost of exactly the full-tree read this
+    // fast path exists to avoid. Weigh it against real-time AV overhead
+    // before wiring such a flag.
     if !runtime_has_required_files(destination) {
         return false;
     }

--- a/src-tauri/src/sidecar_archive_extraction.rs
+++ b/src-tauri/src/sidecar_archive_extraction.rs
@@ -3,6 +3,13 @@ use std::path::Component;
 use zstd::stream::read::Decoder as ZstdDecoder;
 
 pub(super) fn tree_metrics(root: &Path) -> Result<(u64, u64, u64, String), String> {
+    // INVARIANT (cave-7kay): file_count here counts materialized regular
+    // files on disk — the same definition the manifest uses
+    // (scripts/sidecar-archive-manifest.mjs). extract_archive()'s per-entry
+    // tally additionally counts hardlink ENTRIES as files; both stay equal
+    // only while archives contain no hardlinks (sidecar-bundle.sh
+    // materializes links via `cp -aL`). If that ever changes, the metrics
+    // gates in extract_archive() fail closed rather than mis-measure.
     let mut pending = vec![root.to_path_buf()];
     let mut paths = Vec::new();
     let mut file_count = 0_u64;
@@ -143,6 +150,15 @@ pub(super) fn extract_archive(
         }
 
         let entry_type = entry.header().entry_type();
+        // INVARIANT (cave-7kay): this tally treats hardlink entries as files,
+        // while the manifest's file_count (scripts/sidecar-archive-manifest.mjs)
+        // and tree_metrics() above count materialized regular files. The
+        // tallies agree only while archives carry no hardlink entries — which
+        // holds today because scripts/sidecar-bundle.sh materializes every
+        // link via `cp -aL` before packing. A future bundle that encodes
+        // hardlinks fails the metrics gates below (fail-closed, by design):
+        // teach the bundler, the manifest walk, and both counters together
+        // before shipping such an archive.
         if entry_type.is_file() || entry_type.is_hard_link() {
             archive_file_count = archive_file_count
                 .checked_add(1)


### PR DESCRIPTION
Follow-up from the PR #2905 review (cave-7kay, gh-2905): two hardening notes recorded as comments at the code they govern. **Comment-only — no behavior change.**

## 1. Hardlink/file_count invariant (both counter sites)

`extract_archive()`'s per-entry tally counts hardlink entries toward `archive_file_count`, while the manifest walk (`scripts/sidecar-archive-manifest.mjs`) and post-extraction `tree_metrics()` count materialized regular files. Today the tallies agree because `scripts/sidecar-bundle.sh` materializes every link via `cp -aL` (line 228) before packing — so archives carry no hardlink entries.

The new comments at **both** sites state the invariant and the failure mode: a future hardlink-bearing archive fails the metrics gates closed (by design), and the fix is to teach the bundler, the manifest walk, and both counters together — not to loosen a gate.

## 2. Warm-cache deep-verify consideration

`cache_is_ready()` trusts the `.complete.json` marker + 7 required paths in user-writable LocalAppData. The appended comment records why that's acceptable (authoritative archive in admin-protected Program Files; any failed check funnels into the fully verified extraction path) and where an opt-in deep-verify mode for paranoid/enterprise installs would slot in (re-hash the cached tree against `manifest.tree_sha256`), with the cost that motivates keeping it opt-in: exactly the full-tree read + real-time-AV overhead the fast path exists to avoid.

## Verification
- `cargo fmt --check` — no diff on touched files
- `cargo check --no-default-features` — clean (module is `cfg(windows)`-gated; comments are inert)

Closes cave-7kay.
