### PR TITLE
fix(home): remove the new-chat dashboard's context rail — board only

### DIFF
--- a/src/components/chat-new-dashboard.test.ts
+++ b/src/components/chat-new-dashboard.test.ts
@@ -5,11 +5,11 @@
 //   (1) chat-view splits its empty state: a null sessionId (brand-new chat)
 //       renders <ChatNewDashboard>; existing zero-turn sessions keep the
 //       task-aware <ChatEmptyState>;
-//   (2) body-only shell: rail + board (ChatView owns the chrome above and
-//       the composer below) — no chrome header, no docked composer;
-//   (3) the rail carries Project · Quick start · Task · Pick up; quick rows
-//       seed the chat composer through onPrompt, the picker is the shared
-//       ProjectPicker, Pick up shows the two most-recent resumable sessions;
+//   (2) board-only shell (ChatView owns the chrome above and the composer
+//       below) — no chrome header, no docked composer;
+//   (3) the context rail (Project · Quick start · Task · Pick up) was removed —
+//       project switching lives in the composer's context pill and quick starts
+//       in the composer; the board stands alone;
 //   (4) the board reads the live Tasks board + the inbox "needs you" tier
 //       and offers the All/Running/Blocked/Inbox filter tabs;
 //   (5) self-contained navigation: the component reaches other surfaces
@@ -36,11 +36,11 @@ assert.match(
   "existing zero-turn sessions keep the task-aware ChatEmptyState",
 );
 
-// ── (2) Body-only shell: rail + board ────────────────────────────────────
+// ── (2) Board-only shell (no rail, no chrome, no dock) ────────────────────
 assert.match(
   dash,
-  /home-dash__body home-dash--embed[\s\S]*?home-dash__rail[\s\S]*?home-dash__board/,
-  "the embed stacks the context rail beside the work board",
+  /home-dash__body home-dash--embed[\s\S]*?home-dash__board/,
+  "the embed renders the work board",
 );
 assert.doesNotMatch(dash, /home-dash__chrome/, "no identity chrome — ChatView's header covers it");
 assert.doesNotMatch(dash, /home-dash__dock/, "no docked composer — ChatView's composer is the intent surface");
@@ -57,16 +57,12 @@ assert.match(
 assert.doesNotMatch(css, /home-dash__chrome/, "the retired chrome styles are gone");
 assert.doesNotMatch(css, /home-dash__dock/, "the retired dock styles are gone");
 
-// ── (3) Context rail — Project · Quick start · Task · Pick up ────────────
-assert.match(dash, /home-dash__rail-label">Project</, "the rail leads with the Project group");
-assert.match(dash, /<ProjectPicker/, "the project control is the shared ProjectPicker");
-assert.match(dash, /home-dash__rail-label">Quick start</, "the rail carries a Quick start group");
-assert.match(dash, /home-dash__quick-row[\s\S]*?onPrompt\(/, "quick-start rows seed the chat composer draft");
-assert.match(dash, /onClick=\{onOpenPromptSnippets\}/, "a quick-start row opens the prompt-snippets modal");
-assert.match(dash, /home-dash__rail-label">Task</, "the rail keeps the task-arming group");
-assert.match(dash, /cave-chat-empty-task-armed/, "arming shows the linked-card banner");
-assert.match(dash, /home-dash__rail-label">Pick up</, "the rail surfaces a Pick up group");
-assert.match(dash, /resumableSessions\(sessions, 2\)/, "Pick up shows the two most-recent resumable sessions");
+// ── (3) The context rail was removed ─────────────────────────────────────
+assert.doesNotMatch(dash, /home-dash__rail-group/, "the context rail groups are gone");
+assert.doesNotMatch(dash, /<ProjectPicker/, "no project picker on the board — it lives in the composer's context pill");
+assert.doesNotMatch(dash, /home-dash__quick/, "no Quick start rail group");
+assert.doesNotMatch(dash, /home-dash__pick-card/, "no Pick up rail group");
+assert.doesNotMatch(dash, /home-dash__project-/, "no project meta rows from the rail");
 
 // ── (4) Open-work board — live data + filter tabs ────────────────────────
 assert.match(dash, /const boardCards = useDashboardBoard\(\)/, "the board reads the live Tasks board");

--- a/src/components/chat-new-dashboard.tsx
+++ b/src/components/chat-new-dashboard.tsx
@@ -5,11 +5,11 @@ import "@/styles/home-dashboard.css";
 
 // ── ChatNewDashboard ──────────────────────────────────────────────────────────
 // The work-led dashboard (launcher 3a), relocated from Home to the brand-new
-// chat view: a context rail (project · quick start · task arming · pick up)
-// beside an open-work board (greeting + filter tabs · open work · recent
+// chat view: an open-work board (greeting + filter tabs · open work · recent
 // threads). Home went back to the quiet hearth; THIS surface greets a new
 // chat, where the work you resume lands anyway. ChatView supplies the chrome
-// above and the real composer below, so the component is body-only.
+// above and the real composer below (project switcher, quick starts, and task
+// arming all live in that composer), so the component is board-only.
 //
 // Renders inside the transcript's role="log" container as the empty state for
 // `sessionId === null` chats (existing zero-turn sessions keep ChatEmptyState).
@@ -22,15 +22,11 @@ import "@/styles/home-dashboard.css";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { Familiar, SessionRow } from "@/lib/types";
-import type { CaveProject } from "@/lib/cave-projects-types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { Icon } from "@/lib/icon";
-import { ProjectPicker } from "@/components/project-picker";
-import { NO_PROJECT_ID, chatProjectById } from "@/lib/chat-projects";
 import { groupInboxFeed } from "@/lib/inbox-feed";
 import { greetingForHour } from "@/lib/home-greeting";
 import { relativeAge } from "@/lib/rss";
-import { resumableSessions } from "@/components/home/home-continue";
 import { useDashboardBoard } from "@/components/home/use-dashboard-board";
 import {
   OPEN_WORK_FILTERS,
@@ -44,7 +40,6 @@ import {
 } from "@/components/home/dashboard-open-work";
 import { LifecycleBadge } from "@/components/ui/lifecycle-badge";
 import { useRefreshOnFocus } from "@/lib/use-refresh-on-focus";
-import { useAnnouncer } from "@/components/ui/live-region";
 
 /** One-shot inbox snapshot for the "needs you" tier of the open-work board.
  *  Abort-guarded like useBoardCards; mount + window refocus are the only
@@ -99,49 +94,16 @@ const markInboxItemRead = (id: string) => {
 
 export function ChatNewDashboard({
   familiar,
-  onPrompt,
-  onOpenPromptSnippets,
-  projectId,
-  onProjectChange,
-  projects,
-  createProject,
-  fileMentions = false,
   sessions = [],
   modelId = null,
-  taskArmed = false,
-  onArmTask,
-  onDisarmTask,
 }: {
   familiar: Familiar;
-  /** Drops a starter prompt into the chat composer for editing before send. */
-  onPrompt?: (text: string) => void;
-  /** Opens the Prompt snippets modal (templates dropped into the composer). */
-  onOpenPromptSnippets?: () => void;
-  /** Selected predetermined project for the chat runtime root. */
-  projectId?: string | null;
-  /** Updates the project used for the next send. */
-  onProjectChange?: (value: string) => void;
-  projects: CaveProject[];
-  /** From useProjects() — enables the picker's "Add project…" row. */
-  createProject?: (name: string, root: string) => Promise<CaveProject | null>;
-  /** True when the chat knows a project root, so `@` opens the file picker. */
-  fileMentions?: boolean;
-  /** Workspace-owned session list; powers Pick up / Recent threads without a fetch. */
+  /** Workspace-owned session list; powers Recent threads without a fetch. */
   sessions?: SessionRow[];
   /** Effective model for the board-head meta row (quiet text, not a badge). */
   modelId?: string | null;
-  /** True while chat-view has a pending linked-card creation armed. */
-  taskArmed?: boolean;
-  onArmTask?: () => void;
-  onDisarmTask?: () => void;
 }) {
-  const { announce } = useAnnouncer();
   const [nowMs] = useState(() => Date.now());
-
-  const project =
-    projectId === NO_PROJECT_ID
-      ? null
-      : (projectId ? chatProjectById(projectId, projects) ?? projects[0] : projects[0]) ?? null;
 
   // Time-of-day greeting for the board eyebrow. Sampled after mount,
   // client-only, to avoid SSR hydration drift.
@@ -186,162 +148,16 @@ export function ChatNewDashboard({
     () => filterOpenWork(openWork, workFilter),
     [openWork, workFilter],
   );
-  // Rail "Pick up": the two most-recent resumable sessions. Recent threads:
-  // the next titled sessions, newest-first, minus the two already surfaced.
-  const pickUp = useMemo(() => resumableSessions(sessions, 2), [sessions]);
+  // Recent threads: the most-recent titled sessions, newest-first.
   const recentThreads = useMemo(() => {
-    const skip = new Set(pickUp.map((s) => s.id));
     return sessions
-      .filter(
-        (s) => !s.archived_at && !s.generated && Boolean(s.title?.trim()) && !skip.has(s.id),
-      )
+      .filter((s) => !s.archived_at && !s.generated && Boolean(s.title?.trim()))
       .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
-      .slice(0, 4);
-  }, [sessions, pickUp]);
+      .slice(0, 6);
+  }, [sessions]);
 
   return (
     <div className="home-dash__body home-dash--embed select-none" data-testid="chat-new-dashboard">
-
-      {/* Context rail */}
-      <aside className="home-dash__rail" aria-label="Context">
-        {onProjectChange ? (
-          <div className="home-dash__rail-group">
-            <div className="home-dash__rail-label">Project</div>
-            <ProjectPicker
-              projects={projects}
-              value={projectId ?? null}
-              onChange={onProjectChange}
-              allowNoProject
-              familiarId={familiar.id}
-              createProject={createProject}
-              ariaLabel="Project for this chat"
-            />
-            {project?.root ? (
-              <div className="home-dash__project-path" title={project.root}>{project.root}</div>
-            ) : null}
-            {project && fileMentions ? (
-              <span className="home-dash__project-ready">project files ready</span>
-            ) : null}
-          </div>
-        ) : null}
-
-        <div className="home-dash__divider" />
-
-        <div className="home-dash__rail-group">
-          <div className="home-dash__rail-label">Quick start</div>
-          <div className="home-dash__quick">
-            {onPrompt ? (
-              <>
-                <button
-                  type="button"
-                  className="home-dash__quick-row"
-                  onClick={() => onPrompt("Summarise everything that happened today.")}
-                >
-                  <span className="home-dash__quick-icon home-dash__quick-icon--accent" aria-hidden>
-                    <Icon name="ph:sparkle" width={15} />
-                  </span>
-                  <span className="home-dash__quick-label">Summarise today</span>
-                  <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-                </button>
-                <button
-                  type="button"
-                  className="home-dash__quick-row"
-                  onClick={() => onPrompt("Review my recent changes and flag anything risky.")}
-                >
-                  <span className="home-dash__quick-icon" aria-hidden>
-                    <Icon name="ph:git-diff" width={15} />
-                  </span>
-                  <span className="home-dash__quick-label">Review recent changes</span>
-                  <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-                </button>
-              </>
-            ) : null}
-            {onOpenPromptSnippets ? (
-              <button
-                type="button"
-                className="home-dash__quick-row"
-                onClick={onOpenPromptSnippets}
-              >
-                <span className="home-dash__quick-icon" aria-hidden>
-                  <Icon name="ph:chat-centered-text" width={15} />
-                </span>
-                <span className="home-dash__quick-label">Prompt snippets</span>
-                <Icon name="ph:arrow-right-bold" width={14} className="home-dash__quick-go" aria-hidden />
-              </button>
-            ) : null}
-          </div>
-        </div>
-
-        {project && onArmTask ? (
-          <div className="home-dash__rail-group">
-            <div className="home-dash__rail-label">Task</div>
-            {taskArmed ? (
-              <div className="cave-chat-empty-task-armed" role="status">
-                <Icon name="ph:kanban" width={13} aria-hidden />
-                <span>Describe the task below — sending creates a linked board card.</span>
-                {onDisarmTask ? (
-                  <button
-                    type="button"
-                    className="cave-chat-empty-task-armed-dismiss"
-                    aria-label="Cancel task creation"
-                    onClick={onDisarmTask}
-                  >
-                    <Icon name="ph:x-bold" width={11} aria-hidden />
-                  </button>
-                ) : null}
-              </div>
-            ) : (
-              <button
-                type="button"
-                className="cave-chat-empty-task-tile"
-                onClick={() => {
-                  onArmTask();
-                  announce("Describe the task in the message box; sending creates a linked board card.");
-                }}
-              >
-                <Icon name="ph:kanban" width={14} aria-hidden />
-                <span className="cave-chat-empty-task-tile-label">Start a task in {project.name}</span>
-                <span className="cave-chat-empty-task-tile-hint">creates a linked card</span>
-              </button>
-            )}
-          </div>
-        ) : null}
-
-        {pickUp.length > 0 ? (
-          <>
-            <div className="home-dash__divider" />
-            <div className="home-dash__rail-group">
-              <div className="home-dash__rail-label">Pick up</div>
-              <div className="home-dash__pick">
-                {pickUp.map((s) => {
-                  const running = s.status === "running";
-                  const age = relativeAge(s.updated_at, nowMs);
-                  return (
-                    <button
-                      key={s.id}
-                      type="button"
-                      className="home-dash__pick-card"
-                      onClick={() => openSession(s.id, s.familiarId ?? null)}
-                      title={`Resume “${s.title}”`}
-                    >
-                      <span className="home-dash__pick-glyph" aria-hidden>
-                        <Icon
-                          name={running ? "ph:terminal-window" : "ph:chat-circle-dots"}
-                          width={15}
-                        />
-                      </span>
-                      <span className="home-dash__pick-body">
-                        <span className="home-dash__pick-title">{s.title}</span>
-                        <span className="home-dash__pick-time">{age}</span>
-                      </span>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </>
-        ) : null}
-      </aside>
 
       {/* Work board */}
       <main className="home-dash__board" aria-label="Work board">

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5624,25 +5624,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               // linked context) keep the quieter ChatEmptyState below.
               <ChatNewDashboard
                 familiar={familiar}
-                onPrompt={(text) => {
-                  setInput(text);
-                  inputRef.current?.focus();
-                }}
-                onOpenPromptSnippets={() => setPromptSnippetsOpen(true)}
-                projectId={resolvedProjectId}
-                onProjectChange={setProjectIdDraft}
-                projects={projects}
-                createProject={createProject}
-                fileMentions={Boolean(mentionRoot)}
                 sessions={sessions}
                 modelId={
                   modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
                     ? modelState.effectiveModel
                     : familiar.model ?? null
                 }
-                taskArmed={taskArmed}
-                onArmTask={armTask}
-                onDisarmTask={disarmTask}
               />
             ) : (
               <ChatEmptyState

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 
 // Verifies the chat surface landing: opening chat (home-first boot means via
 // ?mode=chat) paints the brand-new-chat dashboard (ChatNewDashboard — the
-// work-led rail + open-work board relocated off Home — over ChatView's real
+// work-led open-work board relocated off Home — over ChatView's real
 // composer) without waiting for /api/sessions/list — the fetch that used to
 // gate the boot-compose effect and left users on the ChatList skeleton wall
 // for its full duration. Also pins the landing affordances: the live board's
@@ -159,12 +159,6 @@ test.describe("chat boot landing", () => {
     await expect(workRow).toContainText("Resume");
     // …and the headline counts it.
     await expect(dash.locator(".home-dash__headline")).toContainText("1 thread open.");
-
-    // Quick start seeds the composer, never auto-sends.
-    await dash.locator(".home-dash__quick-row", { hasText: "Summarise today" }).click();
-    const composer = page.getByPlaceholder(/Message Nova/);
-    await expect(composer).toHaveValue(/Summarise everything that happened today\./);
-    await expect(dash).toBeVisible();
 
     // Voice no longer needs a session: the call action is a direct button from
     // turn zero, while the overflow has moved to the dedicated Chat options trigger.


### PR DESCRIPTION
Removes the left **context rail** (Project · Quick start · Task · Pick up) from the work-led new-chat dashboard, leaving just the open-work board.

## What changed
- Deleted the `<aside class="home-dash__rail">` block; the board is now the whole surface. It already fills and centers on its own (`.home-dash__board` is `flex:1` with a centered `max-width` inner), so no layout CSS change was needed.
- Trimmed `ChatNewDashboard` to the board-only props (`familiar`, `sessions`, `modelId`), dropped the rail-only props from both the component and its single caller (`chat-view.tsx`), and removed six now-dead imports.
- `recentThreads` now shows the top **6** titled sessions (it no longer skips the two the removed "Pick up" group surfaced), so nothing disappears.

## No functional loss
Project switching stays available in the **composer's context pill** (`ProjectPickerPopover`), and the composer keeps the quick-start / task-arming handlers — so `chat-view`'s state is untouched; only the props it passed *to the dashboard* are dropped (verified: eslint clean, no orphaned vars).

## Tests
- Updated `chat-new-dashboard.test.ts` (was pinning the rail groups) to assert the board-only shape.
- Updated the `chat-boot-landing` e2e (it clicked a quick-start row) to drop that interaction.

## Verification
`tsc` 0 errors · eslint clean · full app suite 0 failures · `pnpm build` exit 0, within budget. Net **−207 lines**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)