### PR TITLE
fix(research): 4xx-map artifact containment errors + isolate finish primary read + rebuild publish-failure banner (cave-v73d, cave-o780)

### DIFF
--- a/src/app/api/research/generations/route.test.ts
+++ b/src/app/api/research/generations/route.test.ts
@@ -27,6 +27,10 @@ test("a mission with nothing to draft from maps to 409, not a fake queued record
   assert.doesNotMatch(route, /queued|drafting|progress/i, "no synthetic progress states");
 });
 
+test("an unreadable (symlinked/oversized/escaping) artifact maps to 422, never 500 (cave-v73d)", () => {
+  assert.match(route, /"artifact-unreadable" \? 422/);
+});
+
 test("delete is by id + familiar and reports misses as 404", () => {
   assert.match(route, /removeResearchGeneration/);
   assert.match(route, /generation not found/);

--- a/src/app/api/research/generations/route.ts
+++ b/src/app/api/research/generations/route.ts
@@ -58,9 +58,15 @@ export async function POST(req: Request) {
   }
   if (!result.ok) {
     // no-artifact is a state conflict, not a client mistake: the mission
-    // exists but has published nothing to draft from yet.
+    // exists but has published nothing to draft from yet. artifact-unreadable
+    // is a workspace-containment failure (symlinked/oversized/escaping
+    // artifact) — a 4xx, never a 500 (cave-v73d). A genuine fs fault throws
+    // and is caught above as a 500.
     const status =
-      result.code === "mission-not-found" ? 404 : result.code === "no-artifact" ? 409 : 500;
+      result.code === "mission-not-found" ? 404
+        : result.code === "no-artifact" ? 409
+        : result.code === "artifact-unreadable" ? 422
+        : 500;
     return NextResponse.json({ ok: false, error: result.error }, { status });
   }
   return NextResponse.json({ ok: true, generation: result.generation });

--- a/src/app/api/research/missions/[id]/actions/route.test.ts
+++ b/src/app/api/research/missions/[id]/actions/route.test.ts
@@ -59,6 +59,11 @@ test("errors map by kind: unknown action 400, client mistakes 400, missing missi
     source,
     /if \(message === "pause the linked automation before running manually"\) return 409;/,
   );
+  // Workspace-containment failures (a symlinked/oversized/escaping artifact
+  // reached during a manual publish/finish) are a typed 4xx, never a 500 — the
+  // request was valid, the file fails the sandbox (cave-v73d).
+  assert.match(source, /isResearchFileIntegrityError\(error\)/);
+  assert.match(source, /\{ status: 422 \}/);
   // The classified messages are the runner's real validation throws.
   for (const known of [
     "Source id and title are required",

--- a/src/app/api/research/missions/[id]/actions/route.ts
+++ b/src/app/api/research/missions/[id]/actions/route.ts
@@ -6,7 +6,10 @@ import {
 } from "@/lib/research-missions";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { makeProductionResearchMissionRunner } from "@/lib/server/research-mission-runner";
-import { isValidResearchMissionId } from "@/lib/server/research-mission-store";
+import {
+  isResearchFileIntegrityError,
+  isValidResearchMissionId,
+} from "@/lib/server/research-mission-store";
 import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
 
 export const dynamic = "force-dynamic";
@@ -87,6 +90,12 @@ export async function POST(
     const mission = await runner.act(id, parsed.body);
     return NextResponse.json({ ok: true, mission });
   } catch (error) {
+    // Workspace-containment failures (symlinked/oversized/escaping artifact
+    // reached during a manual publish/finish) are 4xx — the request was valid,
+    // the target file fails the sandbox — never a 500 (cave-v73d).
+    if (isResearchFileIntegrityError(error)) {
+      return NextResponse.json({ ok: false, error: error.message }, { status: 422 });
+    }
     const message = error instanceof Error ? error.message : "research action failed";
     return NextResponse.json(
       { ok: false, error: message },

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -41,6 +41,7 @@ import { writeJsonAtomic } from "./atomic-write.ts";
 import { corruptAsidePath } from "./corrupt-aside.ts";
 import {
   loadResearchMission,
+  isResearchFileIntegrityError,
   readValidatedMissionFile,
 } from "./research-mission-store.ts";
 
@@ -542,12 +543,19 @@ export async function createResearchGenerationFromMission(
   let markdown: string;
   try {
     markdown = await readValidatedMissionFile(mission.id, artifact.relativePath);
-  } catch {
-    return {
-      ok: false,
-      code: "artifact-unreadable",
-      error: `could not read the mission artifact “${artifact.title}”`,
-    };
+  } catch (error) {
+    // A workspace-containment failure (symlinked/oversized/escaping artifact)
+    // is a client-visible 4xx via the route's artifact-unreadable mapping — the
+    // request was valid, the target file fails the sandbox (cave-v73d). A
+    // genuine fs fault (ENOENT race, EIO, …) is a real 500 — rethrow it.
+    if (isResearchFileIntegrityError(error)) {
+      return {
+        ok: false,
+        code: "artifact-unreadable",
+        error: `could not read the mission artifact “${artifact.title}”`,
+      };
+    }
+    throw error;
   }
   const content = draftGenerationContent(input.kind, {
     mission,

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -4,6 +4,7 @@ import type { ConversationFile } from "../cave-conversations.ts";
 import type { AutomationRunRecord } from "../automation-runs.ts";
 import type { FlowRunRecord } from "../flows.ts";
 import { allowedResearchActions, type ResearchMission, type ResearchSourcePatch } from "../research-missions.ts";
+import { ResearchFileIntegrityError } from "./research-mission-store.ts";
 import {
   makeResearchMissionRunner,
   parseResearchSourcesFile,
@@ -646,8 +647,32 @@ test("publish-artifact publishes one working ref on a settled mission", async ()
   assert.equal(result.status, "checkpoint", "manual publish never changes mission status");
   assert.equal(
     result.lastError,
-    "Artifact publish failed — findings: vault write failed",
-    "publish-failure lastError stays until no unpublished working refs remain",
+    undefined,
+    "publishing the only ref named in the failure banner clears it — it must never keep naming a now-published artifact (cave-o780)",
+  );
+});
+
+test("publish-artifact rebuilds the failure banner from the refs that are STILL failing (cave-o780)", async () => {
+  // Two refs failed to publish; retrying one successfully must drop only its
+  // segment and keep the other's original reason — never keep naming the ref
+  // that just published, and never clear while a real failure remains.
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+      { key: "research-log", kind: "research-log", title: "Research log", relativePath: "research-log.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+    lastError: "Artifact publish failed — findings: vault write failed; research-log: vault write failed",
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async (_id, relativePath) => `# Content of ${relativePath}\n`,
+  }));
+  const result = await runner.act(stored.id, { action: "publish-artifact", artifactKey: "findings" });
+  assert.equal(
+    result.lastError,
+    "Artifact publish failed — research-log: vault write failed",
+    "the just-published ref drops out; the still-failing ref keeps its reason",
   );
 });
 
@@ -777,4 +802,56 @@ test("finish surfaces publish failures without blocking completion", async () =>
   assert.equal(findings?.knowledgeId, undefined);
   const primary = result.artifacts.find((artifact) => artifact.key === "primary");
   assert.equal(primary?.state, "published");
+});
+
+test("finish degrades an unreadable primary instead of 500ing after pauseAutomation (cave-v73d)", async () => {
+  // A symlinked/oversized/escaping primary makes the store throw. Because finish
+  // has already run pauseAutomation, a raw throw would 500 the whole action and
+  // leave automation paused while the mission never settles. The read is now
+  // defensive: the primary degrades to a named publish failure and finish still
+  // completes — no throw escapes act().
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async (_id, relativePath) => {
+      if (relativePath === "artifacts/primary.md") {
+        throw new ResearchFileIntegrityError("research files cannot be symlinks");
+      }
+      return `# Content of ${relativePath}\n`;
+    },
+  }));
+  const result = await runner.act(stored.id, { action: "finish" });
+  assert.equal(result.status, "completed", "finish still settles despite the unreadable primary");
+  const primary = result.artifacts.find((artifact) => artifact.key === "primary");
+  assert.notEqual(primary?.state, "published", "the unreadable primary is not published");
+  const findings = result.artifacts.find((artifact) => artifact.key === "findings");
+  assert.equal(findings?.state, "published", "the readable refs still publish");
+  assert.match(result.lastError ?? "", /primary/, "the failed primary is named in the banner");
+});
+
+test("reject-artifact clears the stale publish-failure banner for the rejected ref (cave-o780)", async () => {
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+    lastError: "Artifact publish failed — findings: vault write failed",
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+  }));
+  const result = await runner.act(stored.id, { action: "reject-artifact", artifactKey: "findings", reason: "bad data" });
+  const findings = result.artifacts.find((artifact) => artifact.key === "findings");
+  assert.equal(findings?.state, "rejected");
+  assert.equal(
+    result.lastError,
+    undefined,
+    "rejecting the last publish-pending ref clears its stale failure banner",
+  );
 });

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -330,8 +330,35 @@ async function publishFinalArtifacts(
   return { artifacts, failures };
 }
 
+const PUBLISH_FAILURE_PREFIX = "Artifact publish failed — ";
+
 function publishFailureError(failures: string[]): string | undefined {
-  return failures.length ? `Artifact publish failed — ${failures.join("; ")}` : undefined;
+  return failures.length ? `${PUBLISH_FAILURE_PREFIX}${failures.join("; ")}` : undefined;
+}
+
+/**
+ * Rebuild a publish-failure banner after the artifact set changes (a manual
+ * publish succeeds, or a failed ref is rejected), keeping only the segments
+ * whose ref is STILL unpublished-and-working — so the banner never keeps
+ * naming an artifact that is now published or rejected, and clears entirely
+ * once nothing publishable remains (cave-o780). The original per-ref reasons
+ * are preserved by segment; a lastError that isn't ours is returned untouched.
+ */
+function rebuildPublishFailure(
+  lastError: string | undefined,
+  artifacts: ResearchArtifactRef[],
+): string | undefined {
+  if (!lastError?.startsWith(PUBLISH_FAILURE_PREFIX)) return lastError;
+  const stillFailing = new Set(
+    artifacts
+      .filter((artifact) => artifact.state === "working" && !artifact.knowledgeId)
+      .map((artifact) => artifact.key),
+  );
+  const remaining = lastError
+    .slice(PUBLISH_FAILURE_PREFIX.length)
+    .split("; ")
+    .filter((segment) => stillFailing.has(segment.split(":")[0]?.trim() ?? ""));
+  return remaining.length ? `${PUBLISH_FAILURE_PREFIX}${remaining.join("; ")}` : undefined;
 }
 
 const STANDARD_RESEARCH_ARTIFACT_KEYS = new Set(
@@ -684,7 +711,14 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
           };
         });
         if (!found) throw new Error("research artifact not found");
-        return saveUpdated({ ...mission, artifacts });
+        // Rejecting a ref makes it no longer publish-pending — rebuild any
+        // publish-failure banner so it stops naming the rejected ref and
+        // clears when that was the last publish-pending one (cave-o780).
+        return saveUpdated({
+          ...mission,
+          artifacts,
+          lastError: rebuildPublishFailure(mission.lastError, artifacts),
+        });
       }
       if (input.action === "publish-artifact") {
         if (!["checkpoint", "completed", "failed"].includes(mission.status)) {
@@ -715,13 +749,15 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
             ? { ...item, knowledgeId: entry.id, state: "published" as const, updatedAt: timestamp }
             : item
         ));
-        // The publish-failure lastError clears once nothing publishable is
-        // left unpublished; any other lastError is not ours to clear.
-        const publishPending = artifacts.some((item) => item.state === "working" && !item.knowledgeId);
-        const lastError = mission.lastError?.startsWith("Artifact publish failed") && !publishPending
-          ? undefined
-          : mission.lastError;
-        return saveUpdated({ ...mission, artifacts, lastError });
+        // Rebuild the publish-failure banner from what's still unpublished:
+        // retrying one artifact successfully must drop it from the banner (and
+        // clear it entirely once nothing publishable is left), never keep
+        // naming a now-published ref. A non-publish lastError is left alone.
+        return saveUpdated({
+          ...mission,
+          artifacts,
+          lastError: rebuildPublishFailure(mission.lastError, artifacts),
+        });
       }
 
       if (!allowedResearchActions(mission).includes(input.action)) return mission;
@@ -775,6 +811,19 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       }
       if (input.action === "finish") {
         mission = await pauseAutomation(mission, "Mission finished");
+        // Read the primary defensively — like the `complete` path does. A
+        // symlinked/oversized/escaping primary must NOT throw here: pauseAutomation
+        // has already flipped the automation store, so a raw throw would 500 the
+        // whole finish and leave automation paused while the mission never
+        // settles (status divergence, cave-v73d). An unreadable primary degrades:
+        // publishFinalArtifacts isolates it as a named publish failure and the
+        // mission still finishes.
+        let primaryMarkdown: string | null = null;
+        try {
+          primaryMarkdown = await deps.readMissionFile(mission.id, "artifacts/primary.md");
+        } catch {
+          primaryMarkdown = null;
+        }
         // Finishing by hand saves the same final artifacts a `complete`
         // decision would — the checkpointed files are the deliverables.
         const outcome = await publishFinalArtifacts({
@@ -783,7 +832,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
             artifact.state === "rejected" ? artifact : { ...artifact, updatedAt: timestamp }
           )),
           sources: mission.sources,
-          primaryMarkdown: await deps.readMissionFile(mission.id, "artifacts/primary.md"),
+          primaryMarkdown,
           provenance: latestIterationProvenance(mission, timestamp),
           deps,
         });

--- a/src/lib/server/research-mission-store.test.ts
+++ b/src/lib/server/research-mission-store.test.ts
@@ -14,7 +14,9 @@ import path from "node:path";
 import type { ResearchMission } from "../research-missions.ts";
 import {
   MAX_RESEARCH_FILE_BYTES,
+  ResearchFileIntegrityError,
   createResearchMissionWorkspace,
+  isResearchFileIntegrityError,
   listResearchMissions,
   loadResearchMission,
   missionArtifactPath,
@@ -123,6 +125,31 @@ test("validated reads remain contained in the mission workspace", async () => {
     () => readValidatedMissionFile(created.id, "../mission.json"),
     /outside mission workspace/i,
   );
+});
+
+test("containment failures throw the typed integrity error; a missing file does not (cave-v73d)", async () => {
+  const created = await createResearchMissionWorkspace(mission("typed-integrity"));
+  await symlink("/etc/hosts", missionArtifactPath(created.id, "primary.md"));
+
+  // Symlink, escape, and oversized reads are all ResearchFileIntegrityError so
+  // routes can map them to 4xx by type instead of brittle message matching.
+  for (const relativePath of ["artifacts/primary.md", "../mission.json"]) {
+    const error = await readValidatedMissionFile(created.id, relativePath).then(
+      () => null,
+      (caught) => caught,
+    );
+    assert.ok(isResearchFileIntegrityError(error), `${relativePath} is a typed integrity error`);
+    assert.ok(error instanceof ResearchFileIntegrityError);
+  }
+
+  // A genuinely missing file carries Node's ENOENT and is NOT an integrity
+  // failure — callers (the runner's readMissionFile) special-case it to null.
+  const missing = await readValidatedMissionFile(created.id, "artifacts/nope.md").then(
+    () => null,
+    (caught) => caught,
+  );
+  assert.equal(isResearchFileIntegrityError(missing), false);
+  assert.equal((missing as NodeJS.ErrnoException).code, "ENOENT");
 });
 
 test("loadResearchMission backfills standard artifact refs on legacy missions", async (t) => {

--- a/src/lib/server/research-mission-store.ts
+++ b/src/lib/server/research-mission-store.ts
@@ -17,6 +17,27 @@ const ARTIFACT_FILE_RE = /^[a-z0-9][a-z0-9._-]{0,127}$/i;
 
 export const MAX_RESEARCH_FILE_BYTES = 2 * 1024 * 1024;
 
+/**
+ * A mission-file read that fails the workspace sandbox: the path escapes the
+ * mission workspace, resolves through a symlink, isn't a regular file, or
+ * exceeds the read cap. The request was well-formed — these are client-visible
+ * *containment* outcomes, not server faults — so routes surface them as 4xx,
+ * never 500 (cave-v73d). Missing files (ENOENT) are NOT integrity failures:
+ * they carry Node's errno code and callers special-case them separately.
+ */
+export class ResearchFileIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ResearchFileIntegrityError";
+  }
+}
+
+export function isResearchFileIntegrityError(
+  error: unknown,
+): error is ResearchFileIntegrityError {
+  return error instanceof Error && error.name === "ResearchFileIntegrityError";
+}
+
 declare global {
   var __caveResearchMissionLocks: Map<string, Promise<void>> | undefined;
 }
@@ -189,15 +210,15 @@ export async function readValidatedMissionFile(
   const directory = await assertRealMissionDirectory(id);
   const candidate = path.resolve(/* turbopackIgnore: true */ directory, relativePath);
   if (!relativePath || path.isAbsolute(relativePath) || !isWithin(candidate, directory)) {
-    throw new Error("file is outside mission workspace");
+    throw new ResearchFileIntegrityError("file is outside mission workspace");
   }
   const stat = await lstat(/* turbopackIgnore: true */ candidate);
-  if (stat.isSymbolicLink()) throw new Error("research files cannot be symlinks");
-  if (!stat.isFile()) throw new Error("research path is not a file");
-  if (stat.size > MAX_RESEARCH_FILE_BYTES) throw new Error("research file is too large");
+  if (stat.isSymbolicLink()) throw new ResearchFileIntegrityError("research files cannot be symlinks");
+  if (!stat.isFile()) throw new ResearchFileIntegrityError("research path is not a file");
+  if (stat.size > MAX_RESEARCH_FILE_BYTES) throw new ResearchFileIntegrityError("research file is too large");
   const resolvedCandidate = await realpath(/* turbopackIgnore: true */ candidate);
   if (!isWithin(resolvedCandidate, directory)) {
-    throw new Error("file is outside mission workspace");
+    throw new ResearchFileIntegrityError("file is outside mission workspace");
   }
   return readFile(/* turbopackIgnore: true */ resolvedCandidate, "utf8");
 }


### PR DESCRIPTION
Fast-follow review fixes for the research-final-artifacts feature just merged in **#3786** (cave-v73d, cave-o780). Built against #3786's head and rebased onto main after it landed — additive, no conflicts.

## cave-v73d — containment errors are 4xx, never 500

Spec §4 promises 4xx-never-500 for workspace containment, but `readValidatedMissionFile`'s throws (outside-workspace, symlink, not-a-file, over-cap) were code-less `Error`s that both routes surfaced as **500**, and the runner's `finish` read them unguarded.

- **store** — those four containment throws are now a typed `ResearchFileIntegrityError` (+ `isResearchFileIntegrityError` guard). Missing files keep Node's `ENOENT` and are **not** flagged (callers special-case them to `null`).
- **actions route** — a manual publish/finish that reaches a compromised artifact returns **422**, not 500.
- **generations "files" route** — `artifact-unreadable` (integrity) → **422**; a genuine fs fault rethrows → 500.
- **runner `finish`** — the primary read ran *after* `pauseAutomation` flipped the automation store, so a symlinked primary 500'd the whole finish and left automation paused while the mission never settled (status divergence). It now reads defensively like `complete`: the primary degrades to a named publish failure and the mission still finishes.

## cave-o780 — publish-failure banner tracks reality

The banner was kept verbatim until *zero* unpublished working refs remained, so retrying one artifact successfully left the banner naming a now-published one; rejecting a failed ref never cleared it.

- **manual publish success** — rebuild the banner from the refs **still failing** (drop the just-published one; clear when none remain), preserving each remaining ref's original reason.
- **reject-artifact** — rebuild too, so rejecting the last publish-pending ref clears its stale message.

## Tests

Typed-integrity + ENOENT-not-integrity store cases; finish-degrades-unreadable-primary; publish rebuilds/clears; reject clears; route 422 source mappings.

- ✅ 904 app test files pass · `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)