### PR TITLE
fix(board): launch task-chat sessions non-interactively so they stop bloating coven.sqlite3 (cave-aikv)

### DIFF
--- a/src/app/api/board/[id]/chat/route.ts
+++ b/src/app/api/board/[id]/chat/route.ts
@@ -255,6 +255,20 @@ export async function POST(
     return reserveNativeChatTask();
   }
 
+  // Copilot's daemon session is the worst offender behind cave-aikv: the daemon
+  // spawns `copilot --interactive=<prompt>` as an immortal PTY child whose
+  // redraw output pumps millions of events into coven.sqlite3, and nothing in
+  // Cave ever attaches to it (task chat drives a native coven run instead). Its
+  // nonInteractive launch also mangles multi-word prompts. So — exactly as flows
+  // do (flow-executor.ts, cave-yesg) — a local copilot task takes the native
+  // Chat bridge, spawning the CLI directly with no orphaned daemon TUI. SSH/hub
+  // copilot must stay on the daemon path (remote host / hub authority boundary).
+  const sshBound = isSshRuntime(binding.runtime);
+  const hubAuthority = config.multiHost?.mode === "hub";
+  if (binding.harness === "copilot" && !sshBound && !hubAuthority) {
+    return reserveNativeChatTask();
+  }
+
   const res = await callDaemon<{ id: string; status: string }>({
     method: "POST",
     path: "/api/v1/sessions",
@@ -263,6 +277,13 @@ export async function POST(
       harness: binding.harness,
       model: taskModelOverride ?? binding.model,
       prompt: buildInitialTaskChatPrompt(card),
+      // Non-interactive launch: the daemon streams the initial prompt's
+      // assistant output instead of spawning a fullscreen, never-reaped harness
+      // TUI (cave-aikv). Copilot only reaches here when SSH/hub-bound — where it
+      // must stay on the daemon — and there its nonInteractive prompt-mangling
+      // is the pre-existing limitation, so keep its historical interactive
+      // launch rather than regress it.
+      ...(binding.harness === "copilot" ? {} : { launchMode: "nonInteractive" }),
     },
     timeoutMs: 8000,
   });

--- a/src/components/board-task-model.test.ts
+++ b/src/components/board-task-model.test.ts
@@ -43,6 +43,21 @@ assert.match(
 assert.match(taskRoute, /card\.modelOverride && card\.modelOverrideHarness === binding\.harness/, "new task sessions only use an override from the familiar's current runtime");
 assert.match(taskRoute, /updateCard\(card\.id, \{ modelOverride: null, modelOverrideHarness: null \}\)/, "a stale task model is cleared before launch");
 assert.match(taskRoute, /model: taskModelOverride \?\? binding\.model/, "new task sessions otherwise use the familiar default model");
+// cave-aikv: board task sessions must never spawn an immortal, never-attached
+// interactive harness TUI. A local copilot task takes the native Chat bridge
+// (its daemon PTY is the worst offender + nonInteractive mangles its prompt);
+// every other daemon task launches non-interactively so the event stream is the
+// prompt's output, not a fullscreen TUI.
+assert.match(
+  taskRoute,
+  /binding\.harness === "copilot" && !sshBound && !hubAuthority[\s\S]{0,80}return reserveNativeChatTask\(\)/,
+  "a local copilot task takes the native bridge instead of an orphaned daemon TUI",
+);
+assert.match(
+  taskRoute,
+  /binding\.harness === "copilot" \? \{\} : \{ launchMode: "nonInteractive" \}/,
+  "non-copilot daemon task sessions launch non-interactively (no immortal TUI)",
+);
 assert.match(inspector, /const pendingModelSaveRef = useRef<Promise<boolean> \| null>\(null\)/, "the inspector tracks a pending model save");
 assert.match(inspector, /const previous = pendingModelSaveRef\.current \?\? Promise\.resolve\(true\)/, "model saves serialize back-to-back blur and familiar changes");
 assert.match(inspector, /await \(pendingModelSaveRef\.current \?\? Promise\.resolve\(true\)\)/, "starting work waits for the pending model save");


### PR DESCRIPTION
## Problem (cave-aikv)

Board task-chat (`board/[id]/chat/route.ts`) POSTed `/api/v1/sessions` with a prompt but **no `launchMode`**, so the daemon spawned an interactive harness TUI — `copilot --interactive=<prompt>` — as an immortal PTY child. **Nothing in Cave ever attaches to it**: `/api/sessions/[id]/input` has zero UI callers, and task chat drives a native coven run instead. So the TUIs idle forever (forensics: 2 alive 1.5–2.3 days, 125–235 CPU-min each) and their redraw output pumped **~3.67M of the DB's 3.86M events** — `coven.sqlite3` reached 1.4GB.

## Fix

Mirrors `flow-executor.ts` (cave-yesg) — the exact pattern flows already use for the same daemon deficiency:

- **Local copilot** tasks take the native Chat bridge (`reserveNativeChatTask`). Copilot is the worst offender: its daemon PTY is interactive *and* its `nonInteractive` launch mangles multi-word prompts (unquoted argv split). So it spawns the CLI directly via the native path — no orphaned daemon session. SSH/hub copilot stays on the daemon (remote-host / hub-authority boundary) with its historical interactive launch, to avoid introducing the prompt-mangle regression there.
- **Every other daemon task** now launches with `launchMode: "nonInteractive"`, so the daemon streams the initial prompt's assistant output instead of a never-reaped fullscreen TUI. (`launchMode` is an existing daemon contract — `flow-executor` uses the same value.)

This stops Cave from **creating** the immortal sessions at the source.

## Out of scope (follow-ups on cave-aikv)

- Daemon-side idle-PTY reaper + event-log compaction for already-accumulated bloat — **upstream in `OpenCoven/coven`** (`crates/coven-cli/{daemon.rs,pty_runner.rs}`).
- `workflows/run/route.ts` has the same POST shape (no `launchMode`) — a likely sibling, left for a focused change.

## Verification

- ✅ 907 app test files pass · `tsc` clean · new source pins in `board-task-model.test.ts`
- ⚠️ Recommend a quick in-app smoke test with a live daemon: start a copilot board task (native bridge) and a non-copilot daemon task (nonInteractive) to confirm both still chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)