### PR TITLE
feat(projects): registry CRUD from the project-access surfaces (#3710)

### DIFF
--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 
 import { deleteProject, patchProject } from "@/lib/cave-projects";
+import { revokeAllGrantsForProject } from "@/lib/project-permissions";
 import { normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
 import {
@@ -95,5 +96,8 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ id: s
   const { id } = await params;
   const deleted = await deleteProject(id);
   if (!deleted) return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
-  return NextResponse.json({ ok: true });
+  // Cascade: a removed project must leave no orphaned access behind (a reused
+  // id could otherwise silently inherit stale grants).
+  const cleaned = await revokeAllGrantsForProject(id);
+  return NextResponse.json({ ok: true, cleaned });
 }

--- a/src/components/familiar-studio-projects-tab.test.ts
+++ b/src/components/familiar-studio-projects-tab.test.ts
@@ -75,4 +75,23 @@ assert.match(route, /supremeFamiliarId: config\.supremeFamiliarId/, "the grants 
 assert.match(route, /listRecentPermissionAudit/, "the grants GET returns a recent audit window");
 assert.match(route, /listAccessGroups/, "the grants GET rides access groups along for effective access");
 
+// ── Registry CRUD from the access surface (issue #3710) ──────────────────────
+assert.match(tab, /import \{ useProjects \} from "@\/lib\/use-projects"/, "pulls the registry hook for CRUD");
+assert.match(tab, /import \{ useAddProjectFlow \} from "@\/components\/project-picker"/, "reuses the shared add-project flow");
+assert.match(tab, /import \{ ProjectSettingsModal \} from "@\/components\/project-settings-modal"/, "opens the shared project settings modal");
+assert.match(
+  tab,
+  /createProject,\s*renameProject,\s*deleteProject,\s*updateRepoUrl,\s*\} = useProjects\(\{ familiarId: familiar\.id \}\)/,
+  "the registry mutations come from useProjects",
+);
+assert.match(tab, /onClick=\{addFlow\.beginAddProject\}/, "an Add project affordance exists");
+assert.match(tab, /\{addFlow\.addProjectModal\}/, "the add-project directory browser is mounted");
+assert.match(tab, /icon="ph:gear-six"[\s\S]{0,220}onClick=\{\(\) => setSettingsProjectId\(project\.id\)\}/, "each row opens per-project settings");
+assert.match(
+  tab,
+  /<ProjectSettingsModal[\s\S]{0,240}onRename=\{renameRegistryProject\}[\s\S]{0,60}onDelete=\{removeRegistryProject\}/,
+  "the modal carries rename + remove handlers",
+);
+assert.match(tab, /const ok = await deleteProject\(id\);\s*if \(ok\) void load\(\);/, "removing a project reloads the access snapshot");
+
 console.log("familiar-studio-projects-tab.test.ts: ok");

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -9,6 +9,9 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { SettingsGroup } from "@/components/ui/settings-group";
 import { Segmented } from "@/components/ui/settings-controls";
+import { ProjectSettingsModal } from "@/components/project-settings-modal";
+import { useAddProjectFlow } from "@/components/project-picker";
+import { useProjects } from "@/lib/use-projects";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import { useUserProfile, userDisplayName } from "@/lib/user-profile";
 import {
@@ -133,6 +136,45 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  // ── Registry CRUD (add · rename · relink · remove) ─────────────────────────
+  // The grant matrix above manages *access*; these manage the registry itself.
+  // useProjects supplies full CaveProject rows (with repoUrl) + the mutations;
+  // every write refreshes the tab's own grant snapshot so the list stays honest.
+  const {
+    projects: registryProjects,
+    createProject,
+    renameProject,
+    deleteProject,
+    updateRepoUrl,
+  } = useProjects({ familiarId: familiar.id });
+  const [settingsProjectId, setSettingsProjectId] = useState<string | null>(null);
+  const settingsProject = useMemo(
+    () => registryProjects.find((project) => project.id === settingsProjectId) ?? null,
+    [registryProjects, settingsProjectId],
+  );
+  const addFlow = useAddProjectFlow({
+    familiarId: familiar.id,
+    createProject,
+    projects: registryProjects,
+    onAdded: () => void load(),
+  });
+  const renameRegistryProject = useCallback(
+    async (id: string, name: string) => {
+      const ok = await renameProject(id, name);
+      if (ok) void load();
+      return ok;
+    },
+    [renameProject, load],
+  );
+  const removeRegistryProject = useCallback(
+    async (id: string) => {
+      const ok = await deleteProject(id);
+      if (ok) void load();
+      return ok;
+    },
+    [deleteProject, load],
+  );
 
   const toggle = useCallback(
     async (projectId: string, next: boolean, access: ProjectAccessLevel = "write") => {
@@ -305,7 +347,12 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
         <EmptyState
           icon="ph:folder"
           headline="No projects yet"
-          subtitle="Add a project in the Code workspace, then grant it here."
+          subtitle="Register a project folder to grant this familiar access to it."
+          actions={
+            <Button variant="primary" size="sm" leadingIcon="ph:plus-bold" onClick={addFlow.beginAddProject}>
+              Add project
+            </Button>
+          }
           compact
         />
       ) : (
@@ -313,6 +360,11 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
           label="Project access"
           description={`${grantedCount} of ${projects.length} granted`}
         >
+          <div className="flex justify-end border-b border-[var(--border-hairline)] px-4 py-2">
+            <Button variant="secondary" size="sm" leadingIcon="ph:plus-bold" onClick={addFlow.beginAddProject}>
+              Add project
+            </Button>
+          </div>
           {projects.length > 6 ? (
             <div className="border-b border-[var(--border-hairline)] px-4 py-2">
               <label className="flex items-center gap-2">
@@ -398,6 +450,13 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
                   </div>
                 </div>
                 <div className="flex shrink-0 items-center gap-2.5">
+                  <IconButton
+                    icon="ph:gear-six"
+                    size="xs"
+                    aria-label={`Project settings for ${project.name}`}
+                    title="Rename, link a repository, or remove this project"
+                    onClick={() => setSettingsProjectId(project.id)}
+                  />
                   {on && (
                     <div className={busy ? "pointer-events-none opacity-60" : ""}>
                       <Segmented
@@ -592,6 +651,15 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
           ) : null}
         </SettingsGroup>
       )}
+
+      <ProjectSettingsModal
+        project={settingsProject}
+        onClose={() => setSettingsProjectId(null)}
+        onSaveRepoUrl={updateRepoUrl}
+        onRename={renameRegistryProject}
+        onDelete={removeRegistryProject}
+      />
+      {addFlow.addProjectModal}
     </div>
   );
 }

--- a/src/components/project-settings-modal.test.ts
+++ b/src/components/project-settings-modal.test.ts
@@ -23,15 +23,15 @@ test("input normalizes before save and rejects non-GitHub links client-side", ()
     /import \{ gitHubRepoSlug, normalizeGitHubRepoUrl \} from "@\/lib\/github-repo-link"/,
     "validation goes through the shared normalizer — the same one the API enforces",
   );
-  assert.match(modal, /const normalized = trimmed \? normalizeGitHubRepoUrl\(trimmed\) : null;/, "normalizes the draft");
+  assert.match(modal, /const normalizedRepo = trimmedRepo \? normalizeGitHubRepoUrl\(trimmedRepo\) : null;/, "normalizes the draft");
   assert.match(
     modal,
-    /if \(trimmed && !normalized\) \{[\s\S]{0,200}doesn’t look like a GitHub repository/,
+    /if \(trimmedRepo && !normalizedRepo\) \{[\s\S]{0,200}doesn’t look like a GitHub repository/,
     "invalid input errors locally instead of round-tripping a doomed PUT",
   );
   assert.match(
     modal,
-    /await onSaveRepoUrl\(project\.id, trimmed \? normalized : null\)/,
+    /await onSaveRepoUrl\(project\.id, trimmedRepo \? normalizedRepo : null\)/,
     "saves the canonical link — an emptied field unlinks with null",
   );
   assert.match(modal, /placeholder="owner\/repo or https:\/\/github\.com\/owner\/repo"/, "placeholder teaches both spellings");
@@ -45,10 +45,23 @@ test("the linked repository is visible and opens safely", () => {
 });
 
 test("edit state re-seeds per project and failures announce themselves", () => {
-  assert.match(modal, /useEffect\(\(\) => \{[\s\S]{0,120}setDraft\(projectRepoUrl\);/, "reopening a different project reseeds the field");
+  assert.match(modal, /useEffect\(\(\) => \{[\s\S]{0,160}setRepoDraft\(projectRepoUrl\);/, "reopening a different project reseeds the field");
   assert.match(modal, /Couldn’t save the repository link\./, "server failures surface in the sheet");
   assert.match(modal, /role="alert"/, "errors are announced");
   assert.match(modal, /loading=\{saving\}/, "the save button reflects the in-flight PUT");
+});
+
+test("registry management: rename and remove (with confirm) when handlers are given", () => {
+  // Rename field — only shown when onRename is wired.
+  assert.match(modal, /onRename\?: \(id: string, name: string\) => Promise<boolean>;/, "optional rename handler");
+  assert.match(modal, /if \(onRename && trimmedName !== project\.name\) \{[\s\S]{0,120}await onRename\(project\.id, trimmedName\)/, "save renames only when the name changed");
+  assert.match(modal, /if \(onRename && !trimmedName\) \{[\s\S]{0,80}Give the project a name/, "blocks an empty rename");
+  // Remove — danger action behind a two-step confirm.
+  assert.match(modal, /onDelete\?: \(id: string\) => Promise<boolean>;/, "optional delete handler");
+  assert.match(modal, /if \(!confirmingDelete\) \{[\s\S]{0,80}setConfirmingDelete\(true\)/, "first click arms the confirm");
+  assert.match(modal, /await onDelete\(project\.id\)/, "second click removes the project");
+  assert.match(modal, /Unregisters the project and revokes its access grants\./, "copy is honest about the grant cascade + that the folder is untouched");
+  assert.match(modal, /variant="danger"/, "the confirmed remove is a danger action");
 });
 
 console.log("project-settings-modal.test.ts: ok");

--- a/src/components/project-settings-modal.tsx
+++ b/src/components/project-settings-modal.tsx
@@ -9,54 +9,108 @@ import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 
 /**
- * Per-project settings sheet, opened from the Chat → Projects rows. Its one
- * job today: tie the project to a GitHub repository. Input accepts any
- * spelling normalizeGitHubRepoUrl understands (owner/repo, full URL, SSH
- * remote); the canonical https link is what gets persisted via the caller's
- * updateRepoUrl (PUT /api/projects/[id]). Clearing the field unlinks.
+ * Per-project settings sheet — the registry-management surface behind both the
+ * Chat → Projects rows and the Settings → Familiars → Projects tab. Renames the
+ * project, ties it to a GitHub repository (any spelling normalizeGitHubRepoUrl
+ * understands; the canonical https link persists via updateRepoUrl), and removes
+ * it from the registry (with a two-step confirm; the DELETE cascade revokes the
+ * project's grants server-side). All writes go through PUT/DELETE
+ * /api/projects/[id] via the caller's useProjects handlers.
  */
 export function ProjectSettingsModal({
   project,
   onClose,
   onSaveRepoUrl,
+  onRename,
+  onDelete,
 }: {
   /** The project being edited, or null when the modal is closed. */
   project: CaveProject | null;
   onClose: () => void;
   /** From useProjects().updateRepoUrl — null unlinks. Resolves false on failure. */
   onSaveRepoUrl: (id: string, repoUrl: string | null) => Promise<boolean>;
+  /** From useProjects().renameProject. Omit to hide the name field. */
+  onRename?: (id: string, name: string) => Promise<boolean>;
+  /** From useProjects().deleteProject. Omit to hide the remove action. */
+  onDelete?: (id: string) => Promise<boolean>;
 }) {
-  const [draft, setDraft] = useState("");
+  const [nameDraft, setNameDraft] = useState("");
+  const [repoDraft, setRepoDraft] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
 
-  // Re-seed the field whenever a (different) project opens the sheet.
+  // Re-seed the fields whenever a (different) project opens the sheet.
   const projectId = project?.id ?? null;
+  const projectName = project?.name ?? "";
   const projectRepoUrl = project?.repoUrl ?? "";
   useEffect(() => {
-    setDraft(projectRepoUrl);
+    setNameDraft(projectName);
+    setRepoDraft(projectRepoUrl);
     setError(null);
     setSaving(false);
-  }, [projectId, projectRepoUrl]);
+    setConfirmingDelete(false);
+    setDeleting(false);
+  }, [projectId, projectName, projectRepoUrl]);
 
   if (!project) return null;
 
-  const trimmed = draft.trim();
-  const normalized = trimmed ? normalizeGitHubRepoUrl(trimmed) : null;
+  const trimmedRepo = repoDraft.trim();
+  const normalizedRepo = trimmedRepo ? normalizeGitHubRepoUrl(trimmedRepo) : null;
   const linkedSlug = project.repoUrl ? gitHubRepoSlug(project.repoUrl) : null;
+  const trimmedName = nameDraft.trim();
+  const busy = saving || deleting;
 
   const save = async () => {
-    if (saving) return;
-    if (trimmed && !normalized) {
+    if (busy) return;
+    if (onRename && !trimmedName) {
+      setError("Give the project a name.");
+      return;
+    }
+    if (trimmedRepo && !normalizedRepo) {
       setError("That doesn’t look like a GitHub repository. Try owner/repo or a https://github.com/owner/repo link.");
       return;
     }
     setSaving(true);
     setError(null);
-    const ok = await onSaveRepoUrl(project.id, trimmed ? normalized : null);
-    setSaving(false);
+    try {
+      if (onRename && trimmedName !== project.name) {
+        const ok = await onRename(project.id, trimmedName);
+        if (!ok) {
+          setError("Couldn’t rename the project. Is the desktop reachable?");
+          return;
+        }
+      }
+      if ((trimmedRepo ? normalizedRepo : null) !== (project.repoUrl ?? null)) {
+        const ok = await onSaveRepoUrl(project.id, trimmedRepo ? normalizedRepo : null);
+        if (!ok) {
+          setError("Couldn’t save the repository link. Is the desktop reachable?");
+          return;
+        }
+      }
+      onClose();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const remove = async () => {
+    if (busy || !onDelete) return;
+    if (!confirmingDelete) {
+      setConfirmingDelete(true);
+      setError(null);
+      return;
+    }
+    setDeleting(true);
+    setError(null);
+    const ok = await onDelete(project.id);
+    setDeleting(false);
     if (ok) onClose();
-    else setError("Couldn’t save the repository link. Is the desktop reachable?");
+    else {
+      setConfirmingDelete(false);
+      setError("Couldn’t remove the project. Is the desktop reachable?");
+    }
   };
 
   return (
@@ -66,10 +120,10 @@ export function ProjectSettingsModal({
       breadcrumb={["Projects", project.name]}
       footerActions={
         <>
-          <Button variant="ghost" onClick={onClose} disabled={saving}>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={() => void save()} loading={saving}>
+          <Button variant="primary" onClick={() => void save()} loading={saving} disabled={deleting}>
             Save
           </Button>
         </>
@@ -82,14 +136,38 @@ export function ProjectSettingsModal({
         </span>
       </div>
 
+      {onRename ? (
+        <label className="mb-4 block">
+          <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-muted-foreground">
+            Name
+          </div>
+          <input
+            value={nameDraft}
+            onChange={(e) => {
+              setNameDraft(e.target.value);
+              setError(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                void save();
+              }
+            }}
+            placeholder="Project name"
+            aria-label="Project name"
+            className="w-full rounded-[var(--radius-control)] border border-border bg-background px-3 py-2 text-sm text-foreground outline-none placeholder:text-muted-foreground focus:border-border-strong"
+          />
+        </label>
+      ) : null}
+
       <label className="block">
         <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-muted-foreground">
           GitHub repository
         </div>
         <input
-          value={draft}
+          value={repoDraft}
           onChange={(e) => {
-            setDraft(e.target.value);
+            setRepoDraft(e.target.value);
             setError(null);
           }}
           onKeyDown={(e) => {
@@ -108,10 +186,10 @@ export function ProjectSettingsModal({
       </label>
       <p className="mt-1.5 text-xs text-muted-foreground">
         Ties this project to a repository — leave empty to unlink.
-        {trimmed && normalized && normalized !== project.repoUrl ? (
+        {trimmedRepo && normalizedRepo && normalizedRepo !== project.repoUrl ? (
           <>
             {" "}
-            Will link <span className="text-foreground">{gitHubRepoSlug(normalized)}</span>.
+            Will link <span className="text-foreground">{gitHubRepoSlug(normalizedRepo)}</span>.
           </>
         ) : null}
       </p>
@@ -133,6 +211,38 @@ export function ProjectSettingsModal({
         <p className="mt-3 rounded-[var(--radius-control)] border border-border bg-card px-3 py-1.5 text-xs text-muted-foreground" role="alert">
           {error}
         </p>
+      ) : null}
+
+      {onDelete ? (
+        <div className="mt-5 flex flex-wrap items-center justify-between gap-2 border-t border-border pt-4">
+          <div className="min-w-0">
+            <div className="text-[length:var(--text-sm)] text-foreground">Remove from registry</div>
+            <p className="text-xs text-muted-foreground">
+              Unregisters the project and revokes its access grants. The folder on disk is untouched.
+            </p>
+          </div>
+          {confirmingDelete ? (
+            <div className="flex shrink-0 items-center gap-2">
+              <Button variant="ghost" size="sm" onClick={() => setConfirmingDelete(false)} disabled={deleting}>
+                Cancel
+              </Button>
+              <Button variant="danger" size="sm" leadingIcon="ph:trash" loading={deleting} onClick={() => void remove()}>
+                Remove
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="danger-ghost"
+              size="sm"
+              leadingIcon="ph:trash"
+              className="shrink-0"
+              onClick={() => void remove()}
+              disabled={busy}
+            >
+              Remove project
+            </Button>
+          )}
+        </div>
       ) : null}
     </Modal>
   );

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -50,7 +50,7 @@ test("the toolbar carries picker, search, tally, and reset", () => {
 });
 
 test("rows cycle a direct grant against /api/project-grants", () => {
-  assert.match(view, /const \{ projects, loading: projectsLoading, error: projectsError, reload, createProject, updateRepoUrl \} = useProjects\(\)/, "projects load unscoped — access is managed over every project");
+  assert.match(view, /const \{ projects, loading: projectsLoading, error: projectsError, reload, createProject, updateRepoUrl, renameProject, deleteProject \} = useProjects\(\)/, "projects load unscoped — access is managed over every project");
   assert.match(view, /fetch\("\/api\/project-grants", \{ cache: "no-store" \}\)/, "grants snapshot comes from the console API");
   assert.match(view, /method: op\.op === "grant" \? "POST" : "DELETE"/, "grant/revoke map to POST/DELETE");
   assert.match(view, /targetFamiliarId: familiarId/, "mutations target the picked familiar");
@@ -95,7 +95,7 @@ test("empty projects offer New project and Ask Salem", () => {
 test("the toolbar creates projects through the one shared add flow", () => {
   assert.match(view, /import \{ useAddProjectFlow \} from "@\/components\/project-picker"/, "creation reuses the shared add-project flow (native dialog + web fallback + grant)");
   assert.match(view, /const addFlow = useAddProjectFlow\(\{[\s\S]{0,200}familiarId: familiar\?\.id \?\? null/, "the new project is granted to the picked familiar");
-  assert.match(view, /createProject, updateRepoUrl \} = useProjects\(\)/, "creation + repo-link mutations come from useProjects");
+  assert.match(view, /createProject, updateRepoUrl, renameProject, deleteProject \} = useProjects\(\)/, "creation + repo-link + rename/remove mutations come from useProjects");
   assert.match(view, /onAdded: \(\) => \{[\s\S]{0,120}reload\(\);[\s\S]{0,120}void loadGrants\(\);/, "a successful add refreshes both the registry and the grants snapshot");
   assert.match(view, /className="projects-access-new"[\s\S]{0,220}onClick=\{addFlow\.beginAddProject\}/, "the toolbar exposes the New project button");
   assert.match(view, />\s*\{addFlow\.adding \? "Adding…" : "New project"\}\s*</, "the button reflects the in-flight add");
@@ -114,4 +114,13 @@ test("each row opens per-project settings with the GitHub repo link", () => {
   assert.match(css, /\.projects-access-rowwrap \{/, "rowwrap layout is styled");
   assert.match(css, /\.projects-access-row-settings \{/, "settings trigger is styled");
   assert.match(css, /\.projects-access-row-repo \{/, "GitHub indicator is styled");
+});
+
+test("the settings modal also renames and removes from the registry (issue #3710)", () => {
+  assert.match(view, /<ProjectSettingsModal[\s\S]{0,260}onRename=\{renameProjectAndAnnounce\}[\s\S]{0,60}onDelete=\{removeProject\}/, "the modal carries rename + remove handlers");
+  assert.match(view, /const ok = await renameProject\(id, name\);/, "rename goes through useProjects().renameProject");
+  assert.match(view, /const ok = await deleteProject\(id\);/, "remove goes through useProjects().deleteProject");
+  // Removing a project must refresh the grant matrix — the DELETE cascade
+  // revoked its grants server-side, so the stale rows have to drop out.
+  assert.match(view, /await deleteProject\(id\);[\s\S]{0,160}void loadGrants\(\);/, "a removal reloads the grants snapshot");
 });

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -100,7 +100,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
   const confirm = useConfirm();
   // Unscoped: access is managed over EVERY registered project, not just the
   // ones the active familiar can already see.
-  const { projects, loading: projectsLoading, error: projectsError, reload, createProject, updateRepoUrl } = useProjects();
+  const { projects, loading: projectsLoading, error: projectsError, reload, createProject, updateRepoUrl, renameProject, deleteProject } = useProjects();
 
   const [grantsData, setGrantsData] = useState<GrantsSnapshot | null>(null);
   const [grantsLoading, setGrantsLoading] = useState(true);
@@ -173,6 +173,25 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
       return ok;
     },
     [updateRepoUrl, announce],
+  );
+  const renameProjectAndAnnounce = useCallback(
+    async (id: string, name: string) => {
+      const ok = await renameProject(id, name);
+      if (ok) announce("Project renamed.");
+      return ok;
+    },
+    [renameProject, announce],
+  );
+  const removeProject = useCallback(
+    async (id: string) => {
+      const ok = await deleteProject(id);
+      if (ok) {
+        announce("Project removed from the registry.");
+        void loadGrants(); // the delete cascade revoked its grants server-side
+      }
+      return ok;
+    },
+    [deleteProject, announce, loadGrants],
   );
 
   // ── Mutation state ─────────────────────────────────────────────────────
@@ -664,6 +683,8 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
         project={settingsProject}
         onClose={() => setSettingsProjectId(null)}
         onSaveRepoUrl={saveRepoUrl}
+        onRename={renameProjectAndAnnounce}
+        onDelete={removeProject}
       />
       {addFlow.addProjectModal}
     </div>

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -23,6 +23,8 @@ try {
     filterFamiliarsForProject,
     filterProjectsForFamiliar,
     grantProjectToFamiliar,
+    revokeAllGrantsForProject,
+    listProjectGrants,
     listAccessibleProjects,
     loadHumanPermissionConfig,
     loadMobileWriteAccess,
@@ -395,6 +397,23 @@ try {
   const junk = await loadMobileWriteAccess();
   assert.equal(junk.allowMobileFileWrites, false, "non-boolean flag values fail closed");
   assert.equal(junk.allowMobileCanvasWrites, false, "non-boolean canvas flag fails closed");
+
+  // ── revokeAllGrantsForProject: removing a project leaves no orphaned access ──
+  await grantProjectToFamiliar({ familiarId: "cascade-a", projectId: "cave", source: "human" });
+  await grantProjectToFamiliar({ familiarId: "cascade-b", projectId: "cave", source: "human" });
+  await grantProjectToFamiliar({ familiarId: "cascade-a", projectId: "docs", source: "human" });
+  const cascadeCleaned = await revokeAllGrantsForProject("cave");
+  assert.ok(cascadeCleaned.grants >= 2, "the cascade revokes every direct grant on the removed project");
+  const afterCascade = await listProjectGrants();
+  assert.equal(
+    afterCascade.some((grant) => grant.projectId === "cave"),
+    false,
+    "no grant for the removed project survives (a reused id can't inherit stale access)",
+  );
+  assert.ok(
+    afterCascade.some((grant) => grant.projectId === "docs" && grant.familiarId === "cascade-a"),
+    "grants for other projects are untouched by the cascade",
+  );
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -576,6 +576,38 @@ export async function revokeProjectFromFamiliar(input: {
   }));
 }
 
+/**
+ * Remove every trace of a project from the permission store — direct grants,
+ * access-group project grants, and pending proposals. Called when the project
+ * is removed from the registry so no grant is orphaned (and can't silently
+ * reactivate if the same project id is ever reused). Returns the counts cleaned.
+ */
+export async function revokeAllGrantsForProject(
+  projectId: string,
+): Promise<{ grants: number; groupGrants: number; proposals: number }> {
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
+
+    const nextGrants = file.projectGrants.filter((grant) => grant.projectId !== projectId);
+    const grants = file.projectGrants.length - nextGrants.length;
+    file.projectGrants = nextGrants;
+
+    let groupGrants = 0;
+    for (const group of file.accessGroups) {
+      const before = group.projectGrants.length;
+      group.projectGrants = group.projectGrants.filter((grant) => grant.projectId !== projectId);
+      groupGrants += before - group.projectGrants.length;
+    }
+
+    const nextProposals = file.grantProposals.filter((proposal) => proposal.projectId !== projectId);
+    const proposals = file.grantProposals.length - nextProposals.length;
+    file.grantProposals = nextProposals;
+
+    if (grants > 0 || groupGrants > 0 || proposals > 0) await saveProjectPermissions(file);
+    return { grants, groupGrants, proposals };
+  }));
+}
+
 export async function bootstrapSupremeProjectGrants(projects: CaveProject[]): Promise<void> {
   const { supremeFamiliarId } = await loadHumanPermissionConfig();
   for (const project of projects) {


### PR DESCRIPTION
Implements **issue #3710** — restore project-registry CRUD (add · rename · relink · remove) to the two project-access surfaces, which previously managed only a familiar's *access* to already-registered projects.

The CRUD backend already existed (`POST/PUT/DELETE /api/projects` + the `useProjects` hook); this adds the UI entry points and a delete cascade.

## What changed
- **Shared `ProjectSettingsModal`** grows from GitHub-link-only into a project manager: **rename**, GitHub link, and **remove-from-registry** behind a two-step confirm. `onRename`/`onDelete` are optional, so the modal degrades gracefully.
- **Chat → Projects** (`projects-view.tsx`): the per-row gear now renames + removes (Add already existed); a removal reloads the grant matrix.
- **Settings → Familiars → Projects** (`FamiliarStudioProjectsTab`): adds an **"Add project"** affordance (empty state + populated group), a **per-row settings gear** opening the modal, and full CRUD via `useProjects` — every write refreshes the tab's grant snapshot.
- **Delete cascade** (`revokeAllGrantsForProject`): `DELETE /api/projects/[id]` now clears the removed project's **direct grants, access-group grants, and pending proposals**, so no access is orphaned (and a reused id can't silently inherit stale grants). The response returns the `cleaned` counts.

## Acceptance criteria (#3710)
- ✅ Both access surfaces can now **add**, **rename**, **relink**, and **remove** registered projects — not just toggle access.
- ✅ Removal is safe: grants cascade-cleaned; the folder on disk is untouched (copy in the confirm text is explicit).

## Verification
- `tsc` 0 errors · eslint 0 errors · full **app suite** 0 failures · `api-contracts` pass · `pnpm build` exit 0, within budget.
- Tests: expanded the modal, both surface, and `project-permissions` suites; the cascade is covered **behaviorally** against the real temp-store harness (direct grants revoked, other projects untouched).
- Note: the `test:api` suite's `beads/route.test.ts` fails only in a bare local worktree (it spawns `git`/beads and needs env this checkout lacks); it's unchanged from `main` and passes in CI.

Closes #3710.

🤖 Generated with [Claude Code](https://claude.com/claude-code)