### PR TITLE
fix(workflows): launch session-executed workflow runs non-interactively (cave-aikv)

### DIFF
--- a/src/app/api/workflows/run/route.test.ts
+++ b/src/app/api/workflows/run/route.test.ts
@@ -44,5 +44,14 @@ assert.match(source, /source:\s*"cave"/, "a session-executed run is sourced to c
 // Honesty: only a truly unreachable daemon yields `unavailable: true`.
 assert.match(source, /engine\.status === 0[\s\S]{0,120}unavailable:\s*true/, "an offline daemon yields unavailable, not a fake run");
 assert.match(source, /res\.status === 0[\s\S]{0,120}unavailable:\s*true/, "a daemon that drops during spawn yields unavailable");
+// cave-aikv: a session-executed workflow must not spawn an immortal, never-
+// attached fullscreen harness TUI. Non-copilot sessions launch non-interactively
+// (copilot exempt — its nonInteractive launch mangles multi-word prompts and
+// this path has no native bridge to route it to).
+assert.match(
+  source,
+  /binding\.harness === "copilot" \? \{\} : \{ launchMode: "nonInteractive" \}/,
+  "non-copilot workflow sessions launch non-interactively (no immortal TUI)",
+);
 
 console.log("workflow run route.test.ts: ok");

--- a/src/app/api/workflows/run/route.ts
+++ b/src/app/api/workflows/run/route.ts
@@ -204,6 +204,14 @@ async function runViaSession(body: RunBody) {
       model: binding.model,
       prompt,
       ...(familiarId ? { familiarId } : {}),
+      // Non-interactive launch: the daemon streams the orchestration prompt's
+      // assistant output instead of spawning a fullscreen, never-reaped harness
+      // TUI that nothing attaches to and that redraw-spams coven.sqlite3
+      // (cave-aikv, same fix as board task chat). Copilot is exempt — its
+      // nonInteractive launch mangles multi-word prompts (flow-executor.ts), and
+      // unlike board chat this path has no native bridge to route it to, so keep
+      // its historical interactive launch until it gets a direct-spawn.
+      ...(binding.harness === "copilot" ? {} : { launchMode: "nonInteractive" }),
     },
     timeoutMs: 8000,
   });


### PR DESCRIPTION
Sibling of #3796. The `workflows/run` session executor (the daemon-has-no-engine fallback, `runViaSession`) spawned its agent session via `POST /api/v1/sessions` with a prompt but **no `launchMode`** — the same immortal interactive-TUI leak as board task chat (cave-aikv). Nothing attaches to the TUI (the run lands in history; the chat surface opens the session's transcript), so it idles forever and redraw-spams `coven.sqlite3`.

**Fix:** add `launchMode: "nonInteractive"` so the daemon streams the orchestration prompt's assistant output instead of a fullscreen harness TUI. **Copilot is exempt** — its `nonInteractive` launch mangles multi-word prompts (`flow-executor.ts`), and unlike board chat this path has no native bridge to route it to, so it keeps its historical interactive launch until it gets a direct-spawn (follow-up on cave-aikv).

**Verification:** 907 app test files pass · `tsc` clean · new source pin in `workflows/run/route.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)