### PR TITLE
familiars: shrink the Type vocabulary to a curated core set (cave-lgcb)

### DIFF
--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -41,9 +41,19 @@ Analyst"` → `research-analyst` + `research` + `analyst`):
 - an **active** role manifest (`/api/roles` entry) with that id or name.
 
 A surface may also declare `aliases` — synonym roles matched exactly like its
-primary `role`. The Chart Room serves `navigator` + `planner`; the Writing
-Desk serves `scribe` + `editor`/`writer`; the Review Deck serves `reviewer` +
-`review`; The Archive serves `indexer` + `archivist`.
+primary `role`. The Chart Room serves `navigator` + `planner`/`planning`; the
+Writing Desk serves `scribe` + `editor`/`writer`/`writing`; the Review Deck
+serves `reviewer` + `review`; The Archive serves `indexer` +
+`archivist`/`indexing`; the Watchtower serves `sentinel` + `watch`/`guardian`.
+
+Familiars can also carry an explicit **Type** (Familiar Studio → Identity;
+`FAMILIAR_TYPES` in `src/lib/familiar-types.ts`) that grants its room's role
+token on top of the role label. The Type vocabulary is a deliberately small
+core — General, Coding, Research, Review, Comms. Four earlier types (`watch`,
+`planning`, `writing`, `indexing`) were retired in the 2026-07-24 vocabulary
+reduction (cave-lgcb): stored values still resolve safely through
+`RETIRED_FAMILIAR_TYPE_SUCCESSORS`, and their rooms stay reachable because
+the registry carries the retired words as aliases (above).
 
 ## Adding a new role surface
 

--- a/docs/specs/2026-07-23-code-coding-familiar-room-design.md
+++ b/docs/specs/2026-07-23-code-coding-familiar-room-design.md
@@ -75,6 +75,13 @@ free-text role labels.
 
 ### 4. Explicit familiar Type
 
+> **Amended 2026-07-24 (cave-lgcb, familiar-type vocabulary reduction):** the
+> shipped table was later trimmed to General, Coding, Research, Review, and
+> Comms. Watch/Planning/Writing/Indexing were retired on usage evidence
+> (~2% of sessions combined); their ids resolve through
+> `RETIRED_FAMILIAR_TYPE_SUCCESSORS` and their rooms stay reachable via
+> registry aliases. The paragraphs below describe the original design.
+
 - New `src/lib/familiar-types.ts`: a static `FAMILIAR_TYPES` table —
   General (default, grants nothing), Coding → `coder`, Research →
   `researcher`, Review → `reviewer`, Writing → `scribe`, Comms →

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -205,6 +205,10 @@ registerRoleSurface({
 registerRoleSurface({
   id: SENTINEL_SURFACE_ID,
   role: "sentinel",
+  // "watch" was a familiar Type until the vocabulary reduction (cave-lgcb);
+  // these aliases keep the Watchtower reachable from Role labels like
+  // "guardian-watch" now that the type no longer grants it.
+  aliases: ["watch", "guardian"],
   title: "Watchtower",
   iconName: "ph:binoculars",
   description: "Alerts, session watch, and perimeter reachability",
@@ -267,7 +271,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: SCRIBE_SURFACE_ID,
   role: "scribe",
-  aliases: ["editor", "writer"],
+  aliases: ["editor", "writer", "writing"],
   title: "Writing Desk",
   iconName: "ph:feather",
   description: "Drafts, source material, and publishing into the Knowledge Vault",
@@ -323,7 +327,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: NAVIGATOR_SURFACE_ID,
   role: "navigator",
-  aliases: ["planner"],
+  aliases: ["planner", "planning"],
   title: "Chart Room",
   iconName: "ph:compass",
   description: "Course lanes, scheduled legs, and real board moves",
@@ -449,7 +453,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: INDEXER_SURFACE_ID,
   role: "indexer",
-  aliases: ["archivist"],
+  aliases: ["archivist", "indexing"],
   title: "The Archive",
   iconName: "ph:tree-structure",
   description: "Long-term knowledge, memory, indexes, and provenance",

--- a/src/lib/familiar-types.test.ts
+++ b/src/lib/familiar-types.test.ts
@@ -7,6 +7,7 @@ import assert from "node:assert/strict";
 import {
   DEFAULT_FAMILIAR_TYPE,
   FAMILIAR_TYPES,
+  RETIRED_FAMILIAR_TYPE_SUCCESSORS,
   familiarTypeRoleIds,
   isFamiliarTypeId,
   resolveFamiliarType,
@@ -28,15 +29,13 @@ test("every non-General type grants its room's role token", () => {
   );
   // The registered rooms' roles (role-surfaces/register.tsx). If a room's
   // role changes, this table — the Studio picker's contract — must follow.
+  // Reduced to the curated core set on 2026-07-24 (cave-lgcb); retired
+  // types are pinned separately below.
   assert.deepEqual(tokens, {
     coding: "coder",
     research: "researcher",
     review: "reviewer",
-    writing: "scribe",
     comms: "messenger",
-    watch: "sentinel",
-    planning: "navigator",
-    indexing: "indexer",
   });
 });
 
@@ -57,6 +56,36 @@ test("resolveFamiliarType falls back to General on unknown/stale values", () => 
   assert.equal(resolveFamiliarType(undefined).id, "general");
   assert.ok(isFamiliarTypeId("coding"));
   assert.ok(!isFamiliarTypeId("coder")); // token, not a type id
+});
+
+test("every retired type id maps to a documented, still-valid successor", () => {
+  // The vocabulary-reduction contract (cave-lgcb): a type may only leave the
+  // picker with a successor mapping, so stale stored configs resolve safely.
+  assert.deepEqual(Object.keys(RETIRED_FAMILIAR_TYPE_SUCCESSORS).sort(), [
+    "indexing",
+    "planning",
+    "watch",
+    "writing",
+  ]);
+  for (const [retired, successor] of Object.entries(RETIRED_FAMILIAR_TYPE_SUCCESSORS)) {
+    assert.ok(!isFamiliarTypeId(retired), `${retired} must no longer be a live type id`);
+    assert.ok(isFamiliarTypeId(successor), `${retired}'s successor ${successor} must be live`);
+    assert.equal(resolveFamiliarType(retired).id, successor);
+    assert.equal(resolveFamiliarType(` ${retired.toUpperCase()} `).id, successor);
+  }
+});
+
+test("retired types grant exactly their successor's roles (general grants none)", () => {
+  for (const retired of Object.keys(RETIRED_FAMILIAR_TYPE_SUCCESSORS)) {
+    assert.deepEqual(
+      familiarTypeRoleIds(retired),
+      familiarTypeRoleIds(RETIRED_FAMILIAR_TYPE_SUCCESSORS[retired]),
+    );
+  }
+  assert.deepEqual(familiarTypeRoleIds("watch"), []);
+  assert.deepEqual(familiarTypeRoleIds("planning"), []);
+  assert.deepEqual(familiarTypeRoleIds("writing"), []);
+  assert.deepEqual(familiarTypeRoleIds("indexing"), []);
 });
 
 test("familiarTypeRoleIds grants the type id AND its role token", () => {
@@ -94,4 +123,41 @@ test("a non-coding type still unlocks its own room", () => {
   const ids = familiarRoleIds({ id: "fam-1", role: "Orchestrator", familiarType: "research" });
   assert.ok(surfaceMatchesRoles({ role: "researcher" }, ids));
   assert.ok(!surfaceMatchesRoles(codeRoomShape, ids));
+});
+
+// Retired-type continuity (cave-lgcb): the four rooms whose types left the
+// picker stay reachable through free-text Role labels, because the registry
+// carries the retired words as aliases (register.tsx).
+const retiredRoomShapes = {
+  watch: { role: "sentinel", aliases: ["watch", "guardian"] },
+  planning: { role: "navigator", aliases: ["planner", "planning"] },
+  writing: { role: "scribe", aliases: ["editor", "writer", "writing"] },
+  indexing: { role: "indexer", aliases: ["archivist", "indexing"] },
+};
+
+test("a retired type value no longer unlocks its old room", () => {
+  for (const [retired, shape] of Object.entries(retiredRoomShapes)) {
+    const ids = familiarRoleIds({ id: "fam-1", role: "Orchestrator", familiarType: retired });
+    assert.ok(!surfaceMatchesRoles(shape, ids), `${retired} type must not grant its old room`);
+  }
+});
+
+test("role labels using retired words still reach the room via aliases", () => {
+  const cases: Array<[string, keyof typeof retiredRoomShapes]> = [
+    ["guardian-watch", "watch"],
+    ["Watch", "watch"],
+    ["Planning", "planning"],
+    ["Planner", "planning"],
+    ["Writer", "writing"],
+    ["Writing", "writing"],
+    ["Indexing", "indexing"],
+    ["Archivist", "indexing"],
+  ];
+  for (const [label, room] of cases) {
+    const ids = familiarRoleIds({ id: "fam-1", role: label });
+    assert.ok(
+      surfaceMatchesRoles(retiredRoomShapes[room], ids),
+      `role label "${label}" must still reach the ${room} room`,
+    );
+  }
 });

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -10,6 +10,11 @@
  * The table is static on purpose: it is the single documented mapping from
  * "what the user picks in Familiar Studio → Identity" to "which room opens",
  * unit-testable without the component registry.
+ *
+ * The vocabulary is deliberately small (cave-lgcb): usage evidence trimmed
+ * it from nine types to this core set. Retired ids stay resolvable through
+ * RETIRED_FAMILIAR_TYPE_SUCCESSORS, and their rooms remain reachable via
+ * free-text Role labels and registry aliases.
  */
 
 import type { IconName } from "./icon.tsx";
@@ -19,11 +24,23 @@ export type FamiliarTypeId =
   | "coding"
   | "research"
   | "review"
-  | "writing"
-  | "comms"
-  | "watch"
-  | "planning"
-  | "indexing";
+  | "comms";
+
+/**
+ * Retired type ids → successor type (familiar-type vocabulary reduction,
+ * cave-lgcb, 2026-07-24). Usage evidence showed these four types carried
+ * ~2% of sessions combined, so they left the picker. Every retired id maps
+ * to a documented successor so stale stored configs resolve safely — the
+ * picker never hides and matching never crashes. Their rooms stay
+ * registered and reachable through free-text Role labels (the registry
+ * carries watch/planning/writing/indexing aliases for exactly this).
+ */
+export const RETIRED_FAMILIAR_TYPE_SUCCESSORS: Readonly<Record<string, FamiliarTypeId>> = {
+  watch: "general",
+  planning: "general",
+  writing: "general",
+  indexing: "general",
+};
 
 export type FamiliarTypeSpec = {
   id: FamiliarTypeId;
@@ -41,11 +58,7 @@ export const FAMILIAR_TYPES: readonly FamiliarTypeSpec[] = [
   { id: "coding", label: "Coding", roleToken: "coder", description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
   { id: "research", label: "Research", roleToken: "researcher", description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
   { id: "review", label: "Review", roleToken: "reviewer", description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
-  { id: "writing", label: "Writing", roleToken: "scribe", description: "Unlocks the Writing Desk — drafts, revisions, and publishing flow.", iconName: "ph:pencil-simple" },
   { id: "comms", label: "Comms", roleToken: "messenger", description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
-  { id: "watch", label: "Watch", roleToken: "sentinel", description: "Unlocks the Watchtower — monitors, alerts, and incident timelines.", iconName: "ph:shield-warning" },
-  { id: "planning", label: "Planning", roleToken: "navigator", description: "Unlocks the Chart Room — plans, milestones, and course corrections.", iconName: "ph:compass" },
-  { id: "indexing", label: "Indexing", roleToken: "indexer", description: "Unlocks the Index — corpus health, coverage, and retrieval quality.", iconName: "ph:books" },
 ];
 
 /** The explicit default: a familiar with no stored type is General. */
@@ -55,11 +68,14 @@ export function isFamiliarTypeId(value: string): value is FamiliarTypeId {
   return FAMILIAR_TYPES.some((t) => t.id === value);
 }
 
-/** Stored value → table entry; unknown/absent values resolve to General so a
- *  stale config never hides the picker or crashes matching. */
+/** Stored value → table entry; retired ids resolve to their documented
+ *  successor, and unknown/absent values resolve to General — so a stale
+ *  config never hides the picker or crashes matching. */
 export function resolveFamiliarType(value: string | undefined | null): FamiliarTypeSpec {
   const id = (value ?? "").trim().toLowerCase();
-  return FAMILIAR_TYPES.find((t) => t.id === id) ?? FAMILIAR_TYPES[0];
+  const successor = RETIRED_FAMILIAR_TYPE_SUCCESSORS[id];
+  const resolved = successor ?? id;
+  return FAMILIAR_TYPES.find((t) => t.id === resolved) ?? FAMILIAR_TYPES[0];
 }
 
 /**

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -1,5 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import {
   clearRoleSurfacesForTest,
   familiarRoleIds,
@@ -219,4 +220,19 @@ test("matchesShortcutCombo honors mod aliasing and rejects extra modifiers", () 
   assert.ok(!matchesShortcutCombo({ ...base, metaKey: true, shiftKey: true }, "mod+e")); // extra shift
   assert.ok(matchesShortcutCombo({ ...base, metaKey: true, shiftKey: true }, "mod+shift+e"));
   assert.ok(!matchesShortcutCombo({ ...base, key: "f", metaKey: true }, "mod+e")); // wrong key
+});
+
+test("registry keeps retired familiar-type words as aliases (cave-lgcb)", () => {
+  // The vocabulary reduction removed watch/planning/writing/indexing from the
+  // Type picker; their rooms stay reachable through Role labels only because
+  // register.tsx carries these alias words. Pin them so the continuity story
+  // can't silently drift from the shapes asserted in familiar-types.test.ts.
+  const source = readFileSync(
+    new URL("../components/role-surfaces/register.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(source, /aliases:\s*\["watch",\s*"guardian"\]/);
+  assert.match(source, /aliases:\s*\["planner",\s*"planning"\]/);
+  assert.match(source, /aliases:\s*\["editor",\s*"writer",\s*"writing"\]/);
+  assert.match(source, /aliases:\s*\["archivist",\s*"indexing"\]/);
 });


### PR DESCRIPTION
## What

Reduces the familiar Type picker from **nine** types to a curated core of **five**: General, Coding, Research, Review, Comms. The other four — watch, planning, writing, indexing — are retired with a documented successor mapping, not hidden.

## Why (usage evidence, 2026-07-24 audit)

1675 sessions / 1392 conversations across the 9 live familiars (one per type):

| type | sessions | convs 30d/7d | last active |
|---|---|---|---|
| general | 655 | 504/323 | 07-24 |
| coding | 628 | 560/271 | 07-24 |
| research | 223 | 148/60 | 07-24 |
| review | 77 | 62/28 | 07-22 |
| comms | 55 | 38/15 | 07-24 |
| indexing | 16 | 10/1 | 07-21 |
| planning | 10 | 9/0 | 07-12 |
| watch | 9 | 9/0 | 07-10 |
| writing | 2 | 2/2 | 07-24 |

The kept five carry ~98% of sessions; planning and watch had zero conversations in the last week. Full evidence + keep/merge/retire matrix: `.copilot/goals.md` goal `familiar-type-vocabulary-reduction`.

## How

- `FamiliarTypeId` union + `FAMILIAR_TYPES` narrowed to 5; picker narrows automatically.
- New `RETIRED_FAMILIAR_TYPE_SUCCESSORS` (watch/planning/writing/indexing → general) routed through `resolveFamiliarType()` — stale stored configs resolve safely, picker never hides, matching never crashes.
- **Rooms stay registered.** Registry gains the retired words as aliases (sentinel +`watch`+`guardian`, navigator +`planning`, scribe +`writing`, indexer +`indexing`) so Role labels like `guardian-watch` or `Writer` keep unlocking their rooms — honest retirement: type grants change, reachability survives.
- `/api/familiars` needs no change (passthrough string; resolution is client-side).
- Docs: `docs/role-surfaces.md` documents the reduced vocabulary; cave-cc5r spec carries a dated amendment.

## Testing

- `familiar-types.test.ts`: successor-contract pins (retired ids not live, successors live, case-insensitive resolution), grants parity (`familiarTypeRoleIds(retired) === []`), retired-type-no-longer-unlocks, and role-label alias continuity cases.
- `role-surfaces.test.ts`: source pin on the registry alias words.
- Full app suite: **907 test files pass**; `pnpm typecheck` and `pnpm lint` clean.

## Coordination

Branch `familiar-type-multiselect` (cave-gud8, no PR yet) touches the same files; whichever lands second rebases — the successor mapping drops cleanly into its `parseFamiliarTypeIds()` token loop.

Bead: cave-lgcb (phase 3 of goal `familiar-type-vocabulary-reduction`).