### PR TITLE
fix(chat): make the new-chat fit tiers actually restyle the board padding

### DIFF
--- a/src/components/chat-new-dashboard.test.ts
+++ b/src/components/chat-new-dashboard.test.ts
@@ -90,13 +90,28 @@ assert.match(
 );
 assert.match(
   css,
-  /@container \(max-height: 600px\) \{[\s\S]{0,120}?\.home-dash__section--recent \{[\s\S]{0,40}?display: none/,
+  /@container \(max-height: 650px\) \{[\s\S]{0,120}?\.home-dash__section--recent \{[\s\S]{0,40}?display: none/,
   "short panes shed Recent threads instead of clipping",
 );
 assert.match(
   css,
-  /@container \(max-height: 430px\) \{[\s\S]{0,600}?\.home-dash__work-row:nth-child\(n \+ 4\) \{[\s\S]{0,40}?display: none/,
+  /@container \(max-height: 480px\) \{[\s\S]{0,600}?\.home-dash__work-row:nth-child\(n \+ 4\) \{[\s\S]{0,40}?display: none/,
   "very short panes trim open work to three rows",
+);
+// An element can never match its own @container query — a `.home-dash__board`
+// rule inside a tier is silently dead (shipped once: the 430px tier's padding
+// shrink never applied). Tiers may restyle descendants only.
+for (const [, tier] of css.matchAll(/@container[^{]*\{([\s\S]*?)\n\}/g)) {
+  assert.doesNotMatch(
+    tier,
+    /\.home-dash__board\s*[{,]/,
+    "fit tiers must not target .home-dash__board itself — it is the query container",
+  );
+}
+assert.match(
+  css,
+  /\.home-dash__board-inner \{[\s\S]{0,200}?padding: var\(--space-6\) 0/,
+  "vertical board padding lives on the inner wrapper so tiers can shrink it",
 );
 
 // ── (4) Open-work board — live data + trimmed filter tabs ────────────────

--- a/src/styles/home-dashboard.css
+++ b/src/styles/home-dashboard.css
@@ -49,14 +49,19 @@
   flex: 1;
   min-width: 0;
   overflow: hidden;
-  padding: var(--space-6) var(--space-8);
   /* Height container for the no-scroll tiers below: the board never scrolls,
-     so on short panes it sheds sections instead of clipping them. */
+     so on short panes it sheds sections instead of clipping them. Vertical
+     padding lives on __board-inner, NOT here — the tiers restyle it, and a
+     @container rule can only match descendants of the queried container,
+     never the container itself. Keep this element padding-free vertically so
+     the queried height equals the pane height. */
+  padding: 0 var(--space-8);
   container-type: size;
 }
 .home-dash__board-inner {
   max-width: 860px;
   margin: 0 auto;
+  padding: var(--space-6) 0;
   display: flex;
   flex-direction: column;
   gap: var(--space-5);
@@ -330,20 +335,22 @@
 
 /* ── No-scroll fit tiers ────────────────────────────────────────────────── */
 /* The board never scrolls (overflow: hidden), so short panes shed the
-   quietest content instead of clipping it. Queries measure the board's
-   content box (~455px inside a 900px-tall window): the full board needs
-   ≈590px, ≈420px without Recent threads. Kept last in the file so these
-   equal-specificity overrides win the cascade. */
-@container (max-height: 600px) {
+   quietest content instead of clipping it. The board carries no vertical
+   padding, so the queried height equals the pane height. Measured budgets:
+   full board ≈635px, ≈503px without Recent threads (of which 24px is bottom
+   padding — panes down to 480 clip padding only, never content), ≈294px at
+   the tight tier, ≈198px at the floor. Rules target only descendants of
+   .home-dash__board (an element can never match its own @container query),
+   and stay last in the file so these equal-specificity overrides win the
+   cascade. */
+@container (max-height: 650px) {
   .home-dash__section--recent {
     display: none;
   }
 }
-@container (max-height: 430px) {
-  .home-dash__board {
-    padding: var(--space-4) var(--space-8);
-  }
+@container (max-height: 480px) {
   .home-dash__board-inner {
+    padding: var(--space-4) 0;
     gap: var(--space-3);
   }
   .home-dash__eyebrow,
@@ -351,6 +358,14 @@
     display: none;
   }
   .home-dash__work-row:nth-child(n + 4) {
+    display: none;
+  }
+}
+@container (max-height: 300px) {
+  .home-dash__section-head {
+    display: none;
+  }
+  .home-dash__work-row:nth-child(n + 3) {
     display: none;
   }
 }


### PR DESCRIPTION
## What

Post-merge `/review` of #3789 caught a dead CSS rule: the tight fit tier restyled `.home-dash__board`'s padding from **inside the board's own `@container` block** — per the CSS Containment spec an element can never match its own container query, so the padding shrink silently never applied. Pane heights between tier budgets also clipped content under `overflow: hidden`.

## Fix

- **Vertical padding moves off the query container** onto `.home-dash__board-inner` (board keeps horizontal padding only) — every tier rule now targets descendants, and the queried height equals the pane height.
- **Thresholds recalibrated to measured budgets**: shed Recent threads ≤650px, tight tier ≤480px (panes 480–502 clip bottom padding only, never content), and a new **floor tier ≤300px** (hide section head, trim to 2 rows) closing the clip window probes found at 620px-tall windows.
- **Regression guard** in `chat-new-dashboard.test.ts`: scans every `@container` block and fails if any rule targets `.home-dash__board` itself; also pins the inner wrapper owning the vertical padding.

## Verification

- Unit pins + drift ratchet unchanged (1565); `pnpm lint` + `tsc --noEmit` clean
- E2E: `chat-boot-landing` + `composer-runtime-chip` — 8 passed (1 unrelated pre-existing flaky, passed on retry)
- Prod-build Playwright probes at 1440×900 / 1280×720 / 1280×620: tier padding now **applies** (16px at the tight tier vs. dead rule before), zero scrollable regions, no clipping at any height — 900 shows the full 5-row board, 620 (formerly clipped 71px) degrades to a clean 2-row floor

Bead: cave-c9ke · Review finding from PR #3789