### PR TITLE
fix(workflows): spawn local copilot workflow sessions directly, not as an orphaned daemon TUI (cave-aikv)

### DIFF
--- a/src/app/api/workflows/run/route.test.ts
+++ b/src/app/api/workflows/run/route.test.ts
@@ -53,5 +53,14 @@ assert.match(
   /binding\.harness === "copilot" \? \{\} : \{ launchMode: "nonInteractive" \}/,
   "non-copilot workflow sessions launch non-interactively (no immortal TUI)",
 );
+// cave-aikv follow-up: a local copilot workflow spawns the CLI directly (its
+// daemon launch is either an immortal TUI or a mangled prompt), whose transcript
+// persists as the Cave conversation the run's chat surface opens — mirroring
+// flows. SSH/hub copilot stays on the daemon.
+assert.match(
+  source,
+  /binding\.harness === "copilot" && !sshBound && !hubAuthority[\s\S]{0,160}startCopilotFlowRun\(/,
+  "a local copilot workflow spawns the CLI directly instead of an orphaned daemon TUI",
+);
 
 console.log("workflow run route.test.ts: ok");

--- a/src/app/api/workflows/run/route.ts
+++ b/src/app/api/workflows/run/route.ts
@@ -7,8 +7,14 @@ import {
   setSessionTitle,
 } from "@/lib/cave-config";
 import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
+import { copilotStreamSpec } from "@/lib/copilot-stream";
+import { isSshRuntime } from "@/lib/familiar-runtime";
+import { familiarWorkspace } from "@/lib/coven-paths";
+import { startCopilotFlowRun } from "@/lib/server/flow-copilot-session";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
 import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
 import { isAllowedHarness, MAX_SESSION_JSON_BYTES, normalizeProjectRoot } from "@/lib/server/session-security";
+import { realpath, stat } from "node:fs/promises";
 import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
 import { buildWorkflowRunPrompt } from "@/lib/workflow-run-prompt";
 import { recordRun } from "@/lib/workflow-runs";
@@ -166,6 +172,32 @@ export async function POST(req: Request) {
   );
 }
 
+/**
+ * The familiar's own workspace, trusted at the harness level (`--add-dir`) so a
+ * copilot one-shot can reach it for memory / self-report writes the workflow
+ * prompt directs there. The spawn cwd (projectRoot) is already trusted and must
+ * not be listed. Mirrors flow-executor's flowFamiliarAddDirs (cave-n1yc).
+ */
+async function workflowFamiliarAddDirs(
+  familiarId: string | null,
+  projectRoot: string,
+): Promise<string[]> {
+  if (!familiarId || !isValidFamiliarId(familiarId)) return [];
+  try {
+    const workspace = await realpath(await familiarWorkspace(familiarId));
+    if (!(await stat(workspace)).isDirectory()) return [];
+    let root = projectRoot;
+    try {
+      root = await realpath(projectRoot);
+    } catch {
+      /* keep the normalized form for comparison */
+    }
+    return workspace === root ? [] : [workspace];
+  } catch {
+    return [];
+  }
+}
+
 /** Spawn a real agent session that carries out the workflow plan. */
 async function runViaSession(body: RunBody) {
   const workflow = await resolveWorkflow(body);
@@ -191,6 +223,60 @@ async function runViaSession(body: RunBody) {
   }
 
   const prompt = buildWorkflowRunPrompt(workflow, body.inputs);
+
+  // Persist the started session onto a running workflow-run record and return —
+  // shared by the daemon and copilot-direct spawn paths. Session-executed
+  // workflow runs have no status reconcile loop: the record stays "running" and
+  // the chat surface opens the session's transcript, so both paths behave the
+  // same from the store's view.
+  const finishSession = async (sessionId: string) => {
+    await Promise.all([
+      familiarId ? recordSessionFamiliar(sessionId, familiarId) : Promise.resolve(),
+      setSessionTitle(sessionId, `Workflow: ${workflow.name ?? workflow.id}`),
+    ]);
+    const run = await recordRun({
+      workflowId: workflow.id,
+      version: workflow.version,
+      kind: "execution",
+      status: "running",
+      startedAt: new Date().toISOString(),
+      steps: (workflow.steps ?? []).map((step) => ({
+        id: step.id,
+        kind: step.kind,
+        status: "ready" as const,
+      })),
+      summary: `agent session ${sessionId.slice(0, 8)}`,
+      source: "cave",
+      sessionId,
+    });
+    return NextResponse.json({ ok: true, run, sessionId, executor: "session" });
+  };
+
+  // Copilot: spawn the CLI directly (cave-aikv). Its interactive daemon launch
+  // is an immortal, never-attached TUI that redraw-spams coven.sqlite3, and its
+  // nonInteractive daemon launch mangles multi-word prompts — so, exactly as
+  // flows do (flow-executor.ts, cave-yesg), a local copilot workflow runs as a
+  // non-interactive one-shot whose transcript persists as the Cave conversation
+  // the run's chat surface opens. SSH/hub copilot stays on the daemon (remote
+  // host / hub authority boundary).
+  const sshBound = "runtime" in binding && isSshRuntime(binding.runtime);
+  const hubAuthority = config.multiHost?.mode === "hub";
+  if (binding.harness === "copilot" && !sshBound && !hubAuthority) {
+    const spec = copilotStreamSpec();
+    if (spec) {
+      const { sessionId } = startCopilotFlowRun({
+        spec,
+        prompt,
+        projectRoot,
+        familiarId,
+        familiarName: "display_name" in binding ? binding.display_name : undefined,
+        familiarRole: "role" in binding ? binding.role : undefined,
+        addDirs: await workflowFamiliarAddDirs(familiarId, projectRoot),
+      });
+      return finishSession(sessionId);
+    }
+  }
+
   const res = await callDaemon<{ id: string; status: string }>({
     method: "POST",
     path: "/api/v1/sessions",
@@ -227,27 +313,5 @@ async function runViaSession(body: RunBody) {
     );
   }
 
-  const sessionId = res.data.id;
-  await Promise.all([
-    familiarId ? recordSessionFamiliar(sessionId, familiarId) : Promise.resolve(),
-    setSessionTitle(sessionId, `Workflow: ${workflow.name ?? workflow.id}`),
-  ]);
-
-  const run = await recordRun({
-    workflowId: workflow.id,
-    version: workflow.version,
-    kind: "execution",
-    status: "running",
-    startedAt: new Date().toISOString(),
-    steps: (workflow.steps ?? []).map((step) => ({
-      id: step.id,
-      kind: step.kind,
-      status: "ready" as const,
-    })),
-    summary: `agent session ${sessionId.slice(0, 8)}`,
-    source: "cave",
-    sessionId,
-  });
-
-  return NextResponse.json({ ok: true, run, sessionId, executor: "session" });
+  return finishSession(res.data.id);
 }


### PR DESCRIPTION
Completes the `workflows/run` half of cave-aikv. #3798 made **non-copilot** session-executed workflow runs launch non-interactively, but **copilot** stayed on the daemon's interactive launch — an immortal, never-attached TUI that redraw-spams `coven.sqlite3` — because its `nonInteractive` daemon launch mangles multi-word prompts.

**Fix (mirrors `flow-executor.ts` / cave-yesg):** a **local** copilot workflow now runs as a non-interactive one-shot via `startCopilotFlowRun`, whose transcript persists as the Cave conversation the run's chat surface opens — no orphaned daemon session. SSH/hub copilot stays on the daemon (remote-host / hub-authority boundary).

**Why it's safe:** session-executed workflow runs have **no status-reconcile loop** — the record stays `running` and the chat surface is the view — so a copilot-direct session (which persists a Cave conversation, same as the daemon session) integrates identically. Verified `runViaSession` has no session-status polling.

Extracted the shared success path into `finishSession()`; the familiar add-dirs helper mirrors `flow-executor`'s `flowFamiliarAddDirs`.

## Verification
- ✅ 907 app test files pass · `tsc` clean · new source pin (copilot direct-spawn) alongside the existing nonInteractive pin
- ⚠️ End-to-end needs a live daemon + a copilot familiar — recommend a quick in-app smoke test (run a workflow with a copilot familiar → confirm it executes via the native one-shot and the chat opens the transcript).

Both Cave interactive-session spawners are now fully fixed. Remaining on cave-aikv: the upstream `OpenCoven/coven` daemon reaper + event-log compaction for the already-accumulated 1.4GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)