### PR TITLE
feat(analytics): contract review launch + empty-results grid layout

### DIFF
--- a/src/components/familiar-analytics-content.tsx
+++ b/src/components/familiar-analytics-content.tsx
@@ -27,6 +27,7 @@ import { formatTimeToFirstReply, timeToFirstReplyMs } from "@/lib/first-run-stam
 import { SessionTraceOverlay, type TraceTarget } from "@/components/session-trace-overlay";
 import { pulseTotal, sessionDayKey, type PulseDay } from "@/lib/session-pulse";
 import { requestAgentsNewChat } from "@/lib/agents-new-chat";
+import { buildRehabilitationBrief } from "@/lib/familiar-rehabilitation";
 import {
   aggregateThreadSignals,
   type ContextPressure,
@@ -883,7 +884,14 @@ function contractPropertyDetail(
   };
 }
 
-const ContractCompliance = memo(function ContractCompliance({ report }: { report: ContractReport | null }) {
+const ContractCompliance = memo(function ContractCompliance({
+  report,
+  onReview,
+}: {
+  report: ContractReport | null;
+  /** Direct-launch a review thread for a failing report (parent owns the launch). */
+  onReview: () => void;
+}) {
   const [activeProperty, setActiveProperty] = useState<FamiliarProperty | null>(null);
   const passCount = report ? report.properties.filter((property) => property.pass).length : 0;
   const active = report && activeProperty
@@ -935,6 +943,20 @@ const ContractCompliance = memo(function ContractCompliance({ report }: { report
                 ))}
               </div>
             </div>
+          ) : null}
+          {/* Failing contract = operating as an agent. Mirror the Studio
+              Contract tab: direct-launch a chat seeded with the rehabilitation
+              brief so investigation and resolution start in one click. */}
+          {!report.pass ? (
+            <Button
+              variant="primary"
+              size="sm"
+              className="self-start"
+              leadingIcon="ph:sparkle"
+              onClick={onReview}
+            >
+              Review and resolve
+            </Button>
           ) : null}
         </>
       ) : (
@@ -1386,6 +1408,18 @@ export function FamiliarAnalyticsContent({
     setHealAllOpen(false);
   }, [actionModal, announce, model.familiarId]);
 
+  // Contract review: direct-launch a thread seeded with the rehabilitation
+  // brief — the same "Rite of Binding" flow as the Studio Contract tab.
+  const reviewContract = useCallback(() => {
+    if (!model.contractReport) return;
+    requestAgentsNewChat({
+      familiarId: model.familiarId,
+      initialPrompt: `${buildRehabilitationBrief(familiarName, model.contractReport)}\n\nAnalytics source: /dashboard/familiars/${encodeURIComponent(model.familiarId)}/analytics`,
+      origin: "chat" as const,
+    });
+    announce(`Opening a review thread to repair ${familiarName}'s contract.`);
+  }, [announce, familiarName, model.contractReport, model.familiarId]);
+
   const handleSelectDay = useCallback((day: PulseDay) => {
     setSelectedDay((prev) => {
       const next = prev?.key === day.key ? null : day;
@@ -1552,7 +1586,7 @@ export function FamiliarAnalyticsContent({
           <ModelFeedbackSection rollup={model.modelFeedback} />
         </FaCollapsibleSection>
 
-        <ContractCompliance report={model.contractReport} />
+        <ContractCompliance report={model.contractReport} onReview={reviewContract} />
       </div>
 
       {traceTarget ? (

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -501,6 +501,22 @@ describe("FamiliarAnalyticsView", () => {
     assert.ok(sessionsIndex >= 0 && sessionsIndex < contractIndex, "contract compliance closes the grid after the sessions pair");
   });
 
+  it("stretches grid rows and centers empty states so short empty cards don't leave holes", () => {
+    const faCss = readFileSync(new URL("../styles/familiar-analytics.css", import.meta.url), "utf8");
+    const grid = faCss.match(/\.fa-grid\s*\{[^}]*\}/);
+    assert.ok(grid, ".fa-grid rule should exist");
+    assert.doesNotMatch(
+      grid![0],
+      /align-items:\s*start/,
+      "grid rows stretch (the default), so an empty card fills its row instead of floating over a blank gap",
+    );
+    assert.match(
+      faCss,
+      /\.fa-section > \.ui-empty-state,\s*\.fa-section > \.fa-thread-empty\s*\{[^}]*margin-block:\s*auto/,
+      "empty states center vertically inside a stretched card",
+    );
+  });
+
   it("makes .fa-page own its vertical scroll (html/body are overflow:hidden)", () => {
     const faCss = readFileSync(new URL("../styles/familiar-analytics.css", import.meta.url), "utf8");
     const block = faCss.match(/\.fa-page\s*\{[^}]*\}/);

--- a/src/components/familiar-analytics-view.test.ts
+++ b/src/components/familiar-analytics-view.test.ts
@@ -507,13 +507,48 @@ describe("FamiliarAnalyticsView", () => {
     assert.ok(grid, ".fa-grid rule should exist");
     assert.doesNotMatch(
       grid![0],
-      /align-items:\s*start/,
+      /align-items:/,
       "grid rows stretch (the default), so an empty card fills its row instead of floating over a blank gap",
     );
     assert.match(
       faCss,
       /\.fa-section > \.ui-empty-state,\s*\.fa-section > \.fa-thread-empty\s*\{[^}]*margin-block:\s*auto/,
       "empty states center vertically inside a stretched card",
+    );
+  });
+
+  it("offers a direct review launch when the contract fails", () => {
+    // Same flow as the Studio Contract tab: seed a chat with the shared,
+    // deterministic rehabilitation brief. No confirm modal — direct launch.
+    assert.match(
+      source,
+      /import \{ buildRehabilitationBrief \} from "@\/lib\/familiar-rehabilitation";/,
+      "content reuses the shared rehabilitation brief builder",
+    );
+    assert.match(
+      source,
+      /buildRehabilitationBrief\(familiarName, model\.contractReport\)/,
+      "the review thread is seeded with the brief for this familiar's failing report",
+    );
+    assert.match(
+      source,
+      /\{!report\.pass \? \([\s\S]*?Review and resolve[\s\S]*?\) : null\}/,
+      "the Review and resolve button renders only for failing reports",
+    );
+    assert.match(
+      source,
+      /onReview=\{reviewContract\}/,
+      "the contract section is wired to the parent-owned launch callback",
+    );
+    assert.match(
+      source,
+      /const reviewContract = useCallback\(\(\) => \{[\s\S]*?requestAgentsNewChat\(\{[\s\S]*?familiarId: model\.familiarId,[\s\S]*?origin: "chat"/,
+      "review launches a familiar-scoped working thread via the agents-new-chat bridge",
+    );
+    assert.match(
+      source,
+      /announce\(`Opening a review thread to repair \$\{familiarName\}'s contract\.`\)/,
+      "the launch is announced to assistive tech",
     );
   });
 

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -372,12 +372,13 @@
 .fa-kpi--warn .fa-kpi__value { color: var(--color-warning); }
 .fa-kpi--bad .fa-kpi__value { color: var(--color-danger); }
 .fa-kpi__sub { color: var(--text-muted); font-size: 11px; }
-/* Sections flow in two columns on wide panes; `--wide` spans both. */
+/* Sections flow in two columns on wide panes; `--wide` spans both. Rows
+   stretch (grid default) so a short card sharing a row with a tall neighbor
+   fills the cell instead of floating over a blank gap. */
 .fa-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 18px;
-  align-items: start;
 }
 .fa-section--wide { grid-column: 1 / -1; }
 .fa-section {
@@ -391,6 +392,11 @@
   /* KPI drill-throughs land clear of the sticky breadcrumb. */
   scroll-margin-top: 64px;
 }
+/* Inside a stretched card, an empty-state notice centers in the leftover
+   space instead of hugging the top. Covers both shapes that occur as direct
+   section children: the shared EmptyState and thread-signals' wrapper. */
+.fa-section > .ui-empty-state,
+.fa-section > .fa-thread-empty { margin-block: auto; }
 /* Arriving via a drill-through flashes the section border once, so the eye
    lands where the jump did. */
 .fa-section:target {


### PR DESCRIPTION
## Summary

Two Familiar Analytics fixes:

**1. Empty-results grid layout** (screenshot-reported): short empty-state cards (e.g. "No signals yet", "No violations") floated at the top of tall grid rows, leaving a large blank hole beside populated cards. `.fa-grid` had `align-items: start`; removing it restores the stretch default so cards fill their row, and `margin-block: auto` on `.fa-section`'s empty states centers them vertically in the now-full-height card.

**2. Contract Compliance review launch**: a failing contract report previously dead-ended — violations were listed with no action. `ContractCompliance` now renders a **Review and resolve** button (section-level, shown only when `!report.pass`) that directly launches an investigation/resolution chat via the existing `buildRehabilitationBrief` (same brief the Studio Contract tab uses), with an analytics provenance line and a11y announce, navigating through `requestAgentsNewChat`.

## Testing

- `src/components/familiar-analytics-view.test.ts` — 31/31 pass, including two new tests: grid-stretch/empty-centering pin (asserts no `align-items:` on `.fa-grid` and the `margin-block: auto` rule) and review-launch coverage (button gated on failing report, brief content, provenance, `origin:"chat"`, announce).
- `design-token-drift.test.ts`, `thread-signals-section.test.ts`, `familiar-rehabilitation.test.ts`, `familiar-studio-contract-tab.test.ts` — pass.
- `pnpm codemod:design:check` clean; `tsc` clean; `eslint` clean.
- Each commit passed a spec-compliance review and a code-quality review; whole-branch final review: ready to merge.
