### PR TITLE
feat(ios): redesign v2 — Chats/Tasks/Terminal/Settings tabs, session details, plugins panel, task board restyle (cave-4bsu)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -5,19 +5,19 @@ import WidgetKit
 
 /// The bottom tabs. Lifted out of the view so slash commands (`/board`,
 /// `/chats`) can drive tab selection from anywhere.
-enum AppTab: String, CaseIterable { case chats, canvas, tasks, calendar, dev, settings, search }
+enum AppTab: String, CaseIterable { case chats, tasks, terminal, settings, canvas, search, calendar, dev }
 
 extension AppTab {
     /// Tabs pinned to the tab bar. Search is separate — it's declared with
     /// `role: .search` so the system gives it the trailing search treatment.
-    static let barTabs: [AppTab] = [.chats, .tasks, .canvas]
+    static let barTabs: [AppTab] = [.chats, .tasks, .terminal, .settings]
     /// Occasional surfaces grouped under "More": shown in the sidebar on iPad
     /// (`.sidebarAdaptable`), hidden from the iPhone tab bar. Still reachable
     /// there via the chat drawer, the avatar button (Settings), ⌘ shortcuts,
     /// slash commands, and deep links — hidden tabs remain selectable.
-    static let moreTabs: [AppTab] = [.calendar, .dev, .settings]
-    /// ⌘1–N keyboard-shortcut order: bar tabs, then search, then More.
-    static let shortcutOrder: [AppTab] = barTabs + [.search] + moreTabs
+    static let moreTabs: [AppTab] = [.canvas, .search, .calendar, .dev]
+    /// ⌘1–N keyboard-shortcut order: visible tabs, then sidebar-only surfaces.
+    static let shortcutOrder: [AppTab] = barTabs + moreTabs
 }
 
 /// A transient confirmation banner shown over the chat after a command runs.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -35,6 +35,7 @@ struct ChatView: View {
     @State private var modelPickerOptions: [ChatModelOption] = []
     @State private var modelPickerCurrent = ""
     @State private var showTasks = false
+    @State private var showSessionDetails = false
     @State private var atBottom = true
     /// Coalesces streaming auto-scroll: several text flushes can land inside
     /// one display frame (group fan-out, resume replay) — issue one scrollTo.
@@ -64,6 +65,7 @@ struct ChatView: View {
     @State private var showPhotosPicker = false
     @State private var showCamera = false
     @State private var showFileImporter = false
+    @State private var showPlugins = false
     @State private var responseReader: ResponseReaderItem?
     // Tap-to-enlarge target (image attachment, or a table/diagram/image lifted
     // from the markdown WebView). Driven by the `.caveZoomContent` notification.
@@ -161,30 +163,27 @@ struct ChatView: View {
         .toolbar(.hidden, for: .tabBar)
         .toolbar {
             ToolbarItem(placement: .principal) {
-                // Agent pill: who you're talking to, and (direct chats) the door
-                // to the model/agent picker. Groups keep a static pill — the
-                // fan-out has no single model to switch.
-                if thread.isGroup {
-                    PillSelector(label: thread.title,
-                                 sublabel: "\(thread.familiarIds.count) familiars",
-                                 chevron: false,
-                                 accessibilityHint: nil,
-                                 action: {}) {
-                        AvatarView(familiar: nil, size: 22,
-                                   fallbackName: thread.title)
-                    }
-                    .disabled(true)
-                } else {
-                    let familiar = app.familiar(thread.familiarIds.first ?? "")
-                    PillSelector(label: thread.title,
-                                 sublabel: familiar?.role,
-                                 accessibilityHint: "Opens the model and agent picker",
-                                 action: { Task { await switchModel("") } }) {
-                        AvatarView(familiar: familiar,
-                                   url: familiar.flatMap { app.client?.avatarURL(for: $0) },
-                                   size: 22)
+                Button {
+                    Haptics.tap()
+                    showSessionDetails.toggle()
+                } label: {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(thread.isStreaming ? Color.orange : Color.green)
+                            .frame(width: 7, height: 7)
+                        Text(thread.isGroup
+                             ? thread.title
+                             : (app.familiar(thread.familiarIds.first ?? "")?.displayName ?? thread.title))
+                            .font(.subheadline.weight(.semibold))
+                            .lineLimit(1)
+                        Image(systemName: showSessionDetails ? "chevron.up" : "chevron.down")
+                            .font(.caption2.weight(.bold))
+                            .foregroundStyle(.secondary)
                     }
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Session details for \(thread.title)")
+                .accessibilityValue(showSessionDetails ? "Expanded" : "Collapsed")
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button { showTasks = true } label: {
@@ -210,8 +209,23 @@ struct ChatView: View {
             // in the composer's + menu (same sheet), and Markdown export stays
             // on the thread list's flows — neither earns a toolbar slot here.
         }
+        .overlay(alignment: .top) {
+            if showSessionDetails {
+                sessionDetailsCard
+                    .padding(.horizontal, 24)
+                    .padding(.top, 6)
+                    .transition(reduceMotion ? .opacity : .move(edge: .top).combined(with: .opacity))
+                    .zIndex(20)
+            }
+        }
         .sheet(isPresented: $showCommands) {
             CommandsSheet { command in prefill(command) }
+        }
+        .fullScreenCover(isPresented: $showPlugins) {
+            PluginsPanel {
+                showPlugins = false
+                composerFocused = true
+            }
         }
         .sheet(isPresented: $showModelPicker) {
             ModelPickerSheet(options: modelPickerOptions, current: modelPickerCurrent, onSelect: { id in
@@ -284,6 +298,68 @@ struct ChatView: View {
         .fullScreenCover(item: $zoomTarget) { target in
             ZoomableContentView(target: target)
         }
+    }
+
+    private var sessionDetailsCard: some View {
+        VStack(spacing: 0) {
+            Button {
+                showSessionDetails = false
+                Task { await switchModel("") }
+            } label: {
+                sessionDetailRow("Model", value: "Choose", systemImage: "cpu", showsChevron: true)
+            }
+            .buttonStyle(.plain)
+            .disabled(thread.isGroup)
+
+            Divider()
+            // TODO(no backend): expose the toggle when a real per-session thinking-level API exists.
+            HStack(spacing: 10) {
+                Image(systemName: "brain")
+                    .foregroundStyle(chrome.accent)
+                    .frame(width: 22)
+                Toggle("Think", isOn: .constant(false))
+                    .disabled(true)
+            }
+            .font(.callout)
+            .padding(.horizontal, 14)
+            .frame(minHeight: 44)
+            .accessibilityHint("Thinking level is not available from the current backend")
+            Divider()
+            // TODO(no backend): these values are presentation-only until session metadata exposes them.
+            sessionDetailRow("Mode", value: "Chat", systemImage: "bubble.left")
+            Divider()
+            sessionDetailRow("Runtime", value: "Desktop", systemImage: "desktopcomputer")
+            Divider()
+            sessionDetailRow("Intelligence", value: "Default", systemImage: "sparkles")
+            Divider()
+            sessionDetailRow("Speed", value: "Default", systemImage: "gauge.with.dots.needle.50percent")
+        }
+        .padding(.vertical, 4)
+        .frame(maxWidth: 420)
+        .glass(.raised, cornerRadius: 16)
+        .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
+    }
+
+    private func sessionDetailRow(
+        _ label: String, value: String, systemImage: String, showsChevron: Bool = false
+    ) -> some View {
+        HStack(spacing: 10) {
+            Image(systemName: systemImage)
+                .foregroundStyle(chrome.accent)
+                .frame(width: 22)
+            Text(label).foregroundStyle(.primary)
+            Spacer()
+            Text(value).foregroundStyle(.secondary)
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .font(.callout)
+        .padding(.horizontal, 14)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
     }
 
     private var messageScroll: some View {
@@ -606,6 +682,7 @@ struct ChatView: View {
             FloatingAction(id: "camera", systemImage: "camera", label: "Camera") { showCamera = true },
             FloatingAction(id: "photos", systemImage: "photo.on.rectangle", label: "Photos") { showPhotosPicker = true },
             FloatingAction(id: "files", systemImage: "folder", label: "Files") { showFileImporter = true },
+            FloatingAction(id: "plugins", systemImage: "puzzlepiece.extension", label: "Plugins") { showPlugins = true },
             FloatingAction(id: "commands", systemImage: "command", label: "Commands") { showCommands = true },
         ]
     }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -15,6 +15,7 @@ enum ChatRoute: Hashable {
 /// the conversation.
 struct ChatsHomeView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     @Environment(\.horizontalSizeClass) private var sizeClass
     @State private var showNewChat = false
     @State private var query = ""
@@ -40,6 +41,7 @@ struct ChatsHomeView: View {
     @State private var drawerOpen = false
     /// All-familiars roster sheet (drawer's Familiars destination).
     @State private var showFamiliars = false
+    @State private var showProjects = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Anchors the iOS 18 zoom transition: thread rows mark themselves as
     /// sources; the pushed conversation zooms out of its row.
@@ -94,15 +96,14 @@ struct ChatsHomeView: View {
             // every tab's header aligns. Search + compose stay in the bottom bar.
             .toolbar(.hidden, for: .navigationBar)
             .safeAreaInset(edge: .top, spacing: 0) { header }
-            // Search + compose live in a floating bottom bar (iMessage-style),
-            // not the top toolbar; Settings lives behind the avatar button in
-            // the header (and in the drawer / iPad sidebar).
-            .safeAreaInset(edge: .bottom) { bottomBar }
             .sheet(isPresented: $showNewChat) {
                 NewChatView { thread in
                     showNewChat = false
                     open(.thread(thread))
                 }
+            }
+            .fullScreenCover(isPresented: $showProjects) {
+                ProjectsPanel { showProjects = false }
             }
             .refreshable {
                 await app.loadFamiliars()
@@ -221,35 +222,50 @@ struct ChatsHomeView: View {
     /// Large-title header pinned to the top, mirroring the Read / Tasks tabs
     /// so every tab's title aligns at the same flush position.
     private var header: some View {
-        HStack(spacing: 12) {
-            CircularIconButton(systemImage: "line.3.horizontal",
-                               active: drawerOpen,
-                               label: "Menu") {
-                drawerOpen = true
+        VStack(spacing: 12) {
+            HStack(spacing: 10) {
+                CircularIconButton(systemImage: "line.3.horizontal",
+                                   active: drawerOpen,
+                                   label: "Menu") {
+                    drawerOpen = true
+                }
+                Text("Chats")
+                    .font(.largeTitle.weight(.bold))
+                Spacer()
+                if canReorder {
+                    Button("Reorder") { showReorder = true }
+                        .font(.subheadline.weight(.medium))
+                }
+                CircularIconButton(systemImage: "folder",
+                                   label: "Projects") {
+                    showProjects = true
+                }
+                CircularIconButton(systemImage: "square.and.pencil",
+                                   label: "New chat") {
+                    showNewChat = true
+                }
             }
-            Text("Chats")
-                .font(.title2.weight(.bold))
-            Spacer()
-            if canReorder {
-                Button("Reorder") { showReorder = true }
-                    .font(.subheadline.weight(.medium))
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundStyle(.secondary)
+                TextField("Search chats…", text: $query)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .focused($searchFocused)
+                if !query.isEmpty {
+                    Button {
+                        query = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
             }
-            // Telegram-style profile entry: Settings moved off the tab bar
-            // and lives behind the operator's avatar here.
-            Button {
-                app.selectedTab = .settings
-            } label: {
-                AvatarView(familiar: nil,
-                           url: app.operatorAvatarURL,
-                           size: ChatChrome.control,
-                           fallbackName: app.operatorDisplayName)
-            }
-            .buttonStyle(.glassPress)
-            .accessibilityLabel("Settings")
-            CircularIconButton(systemImage: "square.and.pencil",
-                               label: "New chat") {
-                showNewChat = true
-            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(chrome.bgRaised, in: Capsule())
+            .overlay(Capsule().stroke(chrome.border.opacity(0.7), lineWidth: 1))
         }
         .padding(.horizontal, 16)
         .padding(.top, 8)
@@ -265,14 +281,6 @@ struct ChatsHomeView: View {
 
     private var homeList: some View {
         List(selection: $selection) {
-            if !filteredFamiliars.isEmpty {
-                Section {
-                    familiarRail
-                        .listRowInsets(EdgeInsets())
-                        .listRowSeparator(.hidden)
-                        .listRowBackground(Color.clear)
-                }
-            }
             Section {
                 ForEach(recentThreads) { thread in
                     RecentThreadRow(thread: thread)
@@ -564,11 +572,11 @@ struct RecentThreadRow: View {
     var body: some View {
         HStack(spacing: 13) {
             if thread.isGroup {
-                AvatarClusterView(familiars: familiars, size: 46)
+                AvatarClusterView(familiars: familiars, size: 42)
             } else {
                 AvatarView(familiar: familiars.first,
                            url: familiars.first.flatMap { app.client?.avatarURL(for: $0) },
-                           size: 46, showStatus: true)
+                           size: 42, showStatus: true)
             }
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
@@ -598,7 +606,11 @@ struct RecentThreadRow: View {
                     .lineLimit(1)
             }
             if isUnread {
-                Circle().fill(chrome.accent).frame(width: 9, height: 9)
+                Text("1")
+                    .font(.caption2.weight(.bold))
+                    .foregroundStyle(chrome.accentForeground)
+                    .frame(minWidth: 20, minHeight: 20)
+                    .background(chrome.accent, in: Capsule())
             }
         }
         .padding(.vertical, 3)

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -399,8 +399,20 @@ struct MessageBubble: View {
         }
     }
 
-    private var bubbleShape: RoundedRectangle {
-        RoundedRectangle(cornerRadius: isUser ? 22 : 26, style: .continuous)
+    private var bubbleShape: UnevenRoundedRectangle {
+        if isUser {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 18, bottomLeadingRadius: 18,
+                bottomTrailingRadius: 6, topTrailingRadius: 18,
+                style: .continuous
+            )
+        } else {
+            UnevenRoundedRectangle(
+                topLeadingRadius: 18, bottomLeadingRadius: 6,
+                bottomTrailingRadius: 18, topTrailingRadius: 18,
+                style: .continuous
+            )
+        }
     }
 
     /// Bubble fills: errors stay red; the user's bubble is a soft vertical

--- a/apps/ios/CovenCave/CovenCave/Views/PermissionsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/PermissionsView.swift
@@ -93,75 +93,113 @@ struct PermissionsView: View {
     // MARK: - Access pane
 
     private var accessPane: some View {
-        List {
-            if scopedFamiliarId == nil {
-                Section {
-                    Picker("Familiar", selection: familiarSelection) {
-                        Text("Choose a familiar").tag(String?.none)
-                        ForEach(app.familiars) { familiar in
-                            Text(familiar.displayName).tag(String?.some(familiar.id))
-                        }
-                    }
-                } footer: {
-                    Text("Pick a familiar to see and change which projects it can touch.")
+        ScrollView {
+            LazyVStack(spacing: 14) {
+                ForEach(accessFamiliars) { familiar in
+                    familiarAccessCard(familiar)
+                }
+                if accessFamiliars.isEmpty {
+                    ContentUnavailableView("No familiars", systemImage: "person.2")
                 }
             }
+            .padding(16)
+            .readableWidth(680)
+        }
+        .background(chrome.bgBase)
+    }
 
-            if let familiarId {
-                if isSupreme {
-                    Section {
-                        Label("Supreme familiar — always has access to every project. Its grants can’t be edited.",
-                              systemImage: "crown.fill")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
+    private var accessFamiliars: [Familiar] {
+        guard let scopedFamiliarId else { return app.familiars }
+        return app.familiars.filter { $0.id == scopedFamiliarId }
+    }
+
+    private func familiarAccessCard(_ familiar: Familiar) -> some View {
+        let supreme = familiar.id == supremeFamiliarId
+        return VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 10) {
+                AvatarView(familiar: familiar, url: app.client?.avatarURL(for: familiar), size: 34)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(familiar.displayName).font(.headline)
+                    if supreme {
+                        Text("Supreme familiar · all access")
+                            .font(.caption).foregroundStyle(.secondary)
                     }
                 }
-                Section("Projects") {
-                    if projects.isEmpty {
-                        Text("No projects registered on the desktop.")
-                            .foregroundStyle(.secondary)
-                    }
-                    ForEach(projects) { project in
-                        projectRow(project: project, familiarId: familiarId)
-                    }
+                Spacer()
+            }
+            .padding(14)
+
+            if projects.isEmpty {
+                Divider()
+                Text("No projects registered on the desktop.")
+                    .font(.footnote).foregroundStyle(.secondary).padding(14)
+            } else {
+                ForEach(projects) { project in
+                    Divider().padding(.leading, 14)
+                    projectRow(project: project, familiarId: familiar.id, supreme: supreme)
                 }
             }
         }
-        .listStyle(.insetGrouped)
-        .themedListBackground()
-    }
-
-    private var familiarSelection: Binding<String?> {
-        Binding(get: { selectedFamiliarId }, set: { selectedFamiliarId = $0 })
+        .glass(.raised, cornerRadius: 16)
     }
 
     @ViewBuilder
-    private func projectRow(project: ProjectInfo, familiarId: String) -> some View {
+    private func projectRow(project: ProjectInfo, familiarId: String, supreme: Bool) -> some View {
         let effective = PermissionModels.resolveEffectiveAccess(
             directGrants: grants, groups: groups,
             familiarId: familiarId, projectId: project.id
         )
         let key = "\(familiarId)::\(project.id)"
-        HStack(spacing: 12) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(project.name).font(.body)
-                if isSupreme {
-                    Text("All access").font(.caption).foregroundStyle(.secondary)
-                } else if let groupNames = groupHint(effective) {
-                    Text(groupNames).font(.caption).foregroundStyle(.secondary)
+        Button {
+            cycleAccess(project: project, familiarId: familiarId, effective: effective, key: key)
+        } label: {
+            HStack(spacing: 12) {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(project.name).font(.body).foregroundStyle(.primary)
+                    if supreme {
+                        Text("All access").font(.caption).foregroundStyle(.secondary)
+                    } else if let groupNames = groupHint(effective) {
+                        Text(groupNames).font(.caption).foregroundStyle(.secondary)
+                    }
+                }
+                Spacer(minLength: 8)
+                if busyKeys.contains(key) {
+                    ProgressView().controlSize(.small)
+                } else {
+                    accessBadge(supreme ? .write : effective.level)
                 }
             }
-            Spacer(minLength: 8)
-            if busyKeys.contains(key) {
-                ProgressView().controlSize(.small)
-            } else {
-                accessBadge(isSupreme ? .write : effective.level)
+            .padding(.horizontal, 14).padding(.vertical, 11)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(supreme || !mutationsAllowed || busyKeys.contains(key))
+        .accessibilityHint(mutationsAllowed ? "Cycles no access, read, and write" : "Phone permission changes are disabled")
+    }
+
+    private func cycleAccess(
+        project: ProjectInfo, familiarId: String,
+        effective: EffectiveProjectAccess, key: String
+    ) {
+        guard mutationsAllowed else { return }
+        Haptics.tap()
+        switch effective.direct ?? effective.level {
+        case nil:
+            mutate(key: key) {
+                try await app.client?.grantProject(
+                    targetFamiliarId: familiarId, projectId: project.id, access: .read)
             }
-            if !isSupreme && mutationsAllowed {
-                accessMenu(project: project, familiarId: familiarId, effective: effective, key: key)
+        case .read:
+            mutate(key: key) {
+                try await app.client?.grantProject(
+                    targetFamiliarId: familiarId, projectId: project.id, access: .write)
+            }
+        case .write:
+            mutate(key: key) {
+                try await app.client?.revokeProject(
+                    targetFamiliarId: familiarId, projectId: project.id)
             }
         }
-        .contentShape(Rectangle())
     }
 
     private func groupHint(_ effective: EffectiveProjectAccess) -> String? {

--- a/apps/ios/CovenCave/CovenCave/Views/PluginsPanel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/PluginsPanel.swift
@@ -1,0 +1,205 @@
+import SwiftUI
+
+/// Local catalog until the Cave API publishes connector/skill discovery.
+/// Installed toggles are intentionally session-local; they do not imply that a
+/// desktop connector was installed or authorized.
+struct PluginsPanel: View {
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.chrome) private var chrome
+    @State private var query = ""
+    @State private var selected: PluginCatalogItem?
+    @State private var added: Set<String> = []
+    let tryInChat: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    if query.isEmpty {
+                        sectionLabel("Installed")
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 14) {
+                                ForEach(Self.installed) { plugin in
+                                    VStack(spacing: 6) {
+                                        pluginTile(plugin, size: 50)
+                                        Text(plugin.name).font(.caption).foregroundStyle(.secondary)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    sectionLabel(query.isEmpty ? "Featured" : "Results")
+                    ForEach(filtered) { plugin in
+                        Button { selected = plugin } label: {
+                            HStack(spacing: 13) {
+                                pluginTile(plugin, size: 46)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(plugin.name).font(.headline).foregroundStyle(.primary)
+                                    Text(plugin.summary).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
+                                }
+                                Spacer()
+                                Button {
+                                    if added.contains(plugin.id) { added.remove(plugin.id) }
+                                    else { added.insert(plugin.id) }
+                                } label: {
+                                    Image(systemName: added.contains(plugin.id) ? "checkmark" : "plus")
+                                        .frame(width: 34, height: 34)
+                                        .background(added.contains(plugin.id) ? chrome.accent : chrome.bgRaised,
+                                                    in: Circle())
+                                        .foregroundStyle(added.contains(plugin.id) ? chrome.accentForeground : chrome.textPrimary)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel(added.contains(plugin.id) ? "Remove \(plugin.name)" : "Add \(plugin.name)")
+                            }
+                            .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(16)
+            }
+            .background(chrome.bgBase)
+            .navigationTitle("Plugins")
+            .navigationBarTitleDisplayMode(.inline)
+            .searchable(text: $query, prompt: "Search plugins…")
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button { dismiss() } label: { Image(systemName: "chevron.left") }
+                }
+            }
+            .navigationDestination(item: $selected) { plugin in
+                PluginDetailView(plugin: plugin) {
+                    dismiss()
+                    tryInChat()
+                }
+            }
+        }
+        .themedSheetBackground()
+    }
+
+    private var filtered: [PluginCatalogItem] {
+        guard !query.isEmpty else { return Self.featured }
+        return Self.featured.filter {
+            $0.name.localizedCaseInsensitiveContains(query)
+                || $0.summary.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    private func sectionLabel(_ title: String) -> some View {
+        Text(title.uppercased())
+            .font(.caption2.weight(.semibold)).kerning(1)
+            .foregroundStyle(.secondary)
+    }
+
+    private func pluginTile(_ plugin: PluginCatalogItem, size: CGFloat) -> some View {
+        Image(systemName: plugin.symbol)
+            .font(.system(size: size * 0.45, weight: .semibold))
+            .foregroundStyle(.white)
+            .frame(width: size, height: size)
+            .background(plugin.gradient, in: RoundedRectangle(cornerRadius: size * 0.24))
+    }
+
+    // TODO: Replace this catalog with CaveClient connector/skill discovery once
+    // the desktop API exposes a stable endpoint for mobile.
+    static let installed = [
+        PluginCatalogItem("GitHub", "Triage pull requests and issues", "chevron.left.forwardslash.chevron.right", [.gray, .black]),
+        PluginCatalogItem("Gmail", "Search and work with mail", "envelope.fill", [.red, .orange]),
+        PluginCatalogItem("Calendar", "Plan around your calendar", "calendar", [.blue, .indigo]),
+        PluginCatalogItem("Linear", "Track issues and projects", "point.topleft.down.curvedto.point.bottomright.up", [.indigo, .purple]),
+    ]
+    static let featured = installed + [
+        PluginCatalogItem("Data Analytics", "Answer product and business questions", "chart.bar.fill", [.cyan, .blue]),
+        PluginCatalogItem("Google Drive", "Work across Drive, Docs, Sheets, and Slides", "externaldrive.fill", [.green, .yellow]),
+        PluginCatalogItem("Notion", "Search and read workspace content", "doc.text.fill", [.gray, .black]),
+        PluginCatalogItem("Figma", "Design-to-code workflows", "paintpalette.fill", [.orange, .purple]),
+    ]
+}
+
+struct PluginCatalogItem: Identifiable, Hashable {
+    let id: String
+    let name: String
+    let summary: String
+    let symbol: String
+    let colors: [Color]
+    var gradient: LinearGradient { LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing) }
+
+    init(_ name: String, _ summary: String, _ symbol: String, _ colors: [Color]) {
+        id = name
+        self.name = name
+        self.summary = summary
+        self.symbol = symbol
+        self.colors = colors
+    }
+}
+
+private struct PluginDetailView: View {
+    @Environment(\.chrome) private var chrome
+    let plugin: PluginCatalogItem
+    let tryInChat: () -> Void
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                Image(systemName: plugin.symbol)
+                    .font(.system(size: 30, weight: .semibold)).foregroundStyle(.white)
+                    .frame(width: 64, height: 64)
+                    .background(plugin.gradient, in: RoundedRectangle(cornerRadius: 15))
+                Text(plugin.name).font(.largeTitle.bold())
+                Text(plugin.summary).foregroundStyle(.secondary)
+                RoundedRectangle(cornerRadius: 18)
+                    .fill(plugin.gradient.opacity(0.42))
+                    .frame(height: 155)
+                    .overlay {
+                        Text("@\(plugin.name) \(plugin.summary)")
+                            .padding(16)
+                            .background(chrome.bgElevated, in: RoundedRectangle(cornerRadius: 14))
+                            .padding(22)
+                    }
+                detailSection("Apps") {
+                    Label(plugin.name, systemImage: plugin.symbol)
+                }
+                detailSection("Skills") {
+                    HStack {
+                        skillChip("Overview")
+                        skillChip("Quick start")
+                    }
+                }
+                detailSection("Information") {
+                    LabeledContent("Capabilities", value: "Interactive, Write")
+                    Divider()
+                    LabeledContent("Developer", value: "OpenCoven")
+                    Divider()
+                    LabeledContent("Version", value: "0.1.8")
+                }
+            }
+            .padding(20)
+        }
+        .safeAreaInset(edge: .bottom) {
+            Button(action: tryInChat) {
+                Label("Try in chat", systemImage: "bubble.left.fill")
+                    .frame(maxWidth: .infinity).padding(.vertical, 12)
+            }
+            .buttonStyle(.borderedProminent)
+            .padding(16)
+            .background(chrome.bgBase)
+        }
+        .background(chrome.bgBase)
+        .navigationTitle(plugin.name)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func detailSection<Content: View>(_ title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title).font(.title3.bold())
+            content()
+        }
+    }
+
+    private func skillChip(_ text: String) -> some View {
+        Label(text, systemImage: "cube.fill")
+            .font(.subheadline)
+            .padding(.horizontal, 12).padding(.vertical, 7)
+            .background(chrome.bgRaised, in: Capsule())
+            .overlay(Capsule().stroke(chrome.border))
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/ProjectsPanel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ProjectsPanel.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+/// Full-screen project browser from the Chats header. Counts are derived from
+/// the real board and chat metadata; absent project links simply render no count.
+struct ProjectsPanel: View {
+    @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
+    let dismiss: () -> Void
+
+    var body: some View {
+        NavigationStack {
+            List(app.projects) { project in
+                HStack(spacing: 13) {
+                    Image(systemName: "folder.fill")
+                        .foregroundStyle(chrome.accent)
+                        .frame(width: 36, height: 36)
+                        .background(chrome.bgRaised, in: RoundedRectangle(cornerRadius: 10))
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(project.name).font(.headline)
+                        if let summary = summary(for: project) {
+                            Text(summary).font(.subheadline).foregroundStyle(.secondary)
+                        }
+                    }
+                    Spacer()
+                    if let updated = caveParseISO(project.updatedAt) {
+                        Text(updated, format: .relative(presentation: .numeric))
+                            .font(.caption).foregroundStyle(.tertiary)
+                    }
+                }
+                .padding(.vertical, 5)
+                .listRowBackground(chrome.bgBase)
+            }
+            .listStyle(.plain)
+            .themedListBackground()
+            .overlay {
+                if app.projectsLoaded && app.projects.isEmpty {
+                    ContentUnavailableView("No projects", systemImage: "folder")
+                }
+            }
+            .navigationTitle("Projects")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action: dismiss) { Image(systemName: "chevron.left") }
+                        .accessibilityLabel("Close projects")
+                }
+            }
+            .task {
+                if !app.projectsLoaded { await app.loadProjects() }
+                if !app.tasksLoaded { await app.loadTasks() }
+            }
+        }
+        .themedSheetBackground()
+    }
+
+    private func summary(for project: ProjectInfo) -> String? {
+        let tasks = app.tasks.filter { $0.projectId == project.id }.count
+        guard tasks > 0 else { return nil }
+        return tasks == 1 ? "1 task" : "\(tasks) tasks"
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -197,21 +197,24 @@ struct MainTabView: View {
             Tab("Tasks", systemImage: "checklist", value: AppTab.tasks) {
                 TasksView()
             }
-            Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
-                CanvasView()
+            Tab("Terminal", systemImage: "terminal.fill", value: AppTab.terminal) {
+                TerminalView()
             }
-            Tab(value: .search, role: .search) {
-                SearchView()
+            Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
+                SettingsView()
             }
             TabSection("More") {
+                Tab("Canvas", systemImage: "wand.and.stars", value: AppTab.canvas) {
+                    CanvasView()
+                }
+                Tab(value: .search, role: .search) {
+                    SearchView()
+                }
                 Tab("Calendar", systemImage: "calendar", value: AppTab.calendar) {
                     CalendarView()
                 }
                 Tab("Developer", systemImage: "chevron.left.forwardslash.chevron.right", value: AppTab.dev) {
                     DeveloperView()
-                }
-                Tab("Settings", systemImage: "gearshape.fill", value: AppTab.settings) {
-                    SettingsView()
                 }
             }
             // Keep occasional surfaces out of the iPhone tab bar; they stay

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -30,6 +30,7 @@ struct SettingsView: View {
                 appearanceSection
                 chatsSection
                 permissionsSection
+                communitySection
                 hostSection
                 disconnectSection
                 aboutSection
@@ -88,7 +89,7 @@ struct SettingsView: View {
                     }
 
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("Your Cave")
+                    Text(app.operatorDisplayName)
                         .font(.headline)
                     Text(app.connection?.host ?? "Not set up")
                         .font(.footnote.monospaced())
@@ -219,6 +220,27 @@ struct SettingsView: View {
         } footer: {
             Text("See and manage which projects each familiar can read or change. Changing them from the phone requires the desktop opt-in.")
         }
+    }
+
+    private var communitySection: some View {
+        Section("Community") {
+            communityLink("Discord", value: "OpenCoven", url: "https://discord.gg/opencoven")
+            communityLink("X", value: "@OpenCvn", url: "https://x.com/OpenCvn")
+            communityLink("Docs", value: "docs.opencoven.ai", url: "https://docs.opencoven.ai")
+            communityLink("Podcast", value: "pod.opencoven.ai", url: "https://pod.opencoven.ai")
+            communityLink("Blog", value: "mind.opencoven.ai", url: "https://mind.opencoven.ai")
+        }
+    }
+
+    private func communityLink(_ label: String, value: String, url: String) -> some View {
+        Link(destination: URL(string: url)!) {
+            LabeledContent(label) {
+                Label(value, systemImage: "arrow.up.right")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .foregroundStyle(.primary)
     }
 
     // MARK: - Change host

--- a/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SlashCommandMenu.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// a `/command`. Mirrors the web composer popover for native iOS commands:
 /// name · description · arg hint.
 struct SlashCommandMenu: View {
+    @Environment(\.chrome) private var chrome
     /// Commands matching the current partial token.
     let commands: [SlashCommand]
     /// Invoked when a row is tapped.
@@ -40,7 +41,7 @@ struct SlashCommandMenu: View {
                 HStack(spacing: 6) {
                     Text(command.name)
                         .font(.system(.subheadline, design: .monospaced).weight(.semibold))
-                        .foregroundStyle(.primary)
+                        .foregroundStyle(chrome.accent)
                     if let arg = command.argPlaceholder {
                         Text(arg)
                             .font(.system(.caption2, design: .monospaced))

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -25,13 +25,14 @@ struct TaskDetailView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 20) {
                 header
-                if let familiar { assigneeRow(familiar) }
+                propertyGrid
                 chatCard
                 stepsCard
                 notesSection
                 scheduleCard
                 if !live.labelList.isEmpty { labelsRow }
                 metaCard
+                bottomActions
             }
             .padding(20)
             .readableWidth(680)
@@ -167,6 +168,10 @@ struct TaskDetailView: View {
                     .font(.title2.bold())
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .onTapGesture(count: 2) {
+                        titleDraft = live.title
+                        renamingTitle = true
+                    }
                 Button {
                     titleDraft = live.title
                     renamingTitle = true
@@ -186,6 +191,48 @@ struct TaskDetailView: View {
                 if live.needsHuman == true { NeedsYouBadge() }
             }
         }
+    }
+
+    private var propertyGrid: some View {
+        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 10) {
+            cycleChip("Status", value: live.status.label, color: Theme.color(for: live.status)) {
+                guard let index = CardStatus.allCases.firstIndex(of: live.status) else { return }
+                let next = CardStatus.allCases[(index + 1) % CardStatus.allCases.count]
+                Task { await app.setTaskStatus(live, next) }
+            }
+            cycleChip("Priority", value: live.priority.label, color: Theme.color(for: live.priority)) {
+                guard let index = CardPriority.allCases.firstIndex(of: live.priority) else { return }
+                let next = CardPriority.allCases[(index + 1) % CardPriority.allCases.count]
+                Task { await app.setTaskPriority(live, next) }
+            }
+            // TODO(no backend): task project mutation is not exposed by CaveClient.
+            displayChip("Project", value: live.projectId.flatMap(app.project)?.name ?? "None")
+            // TODO(no backend): task assignee mutation is not exposed by CaveClient.
+            displayChip("Assignee", value: familiar?.displayName ?? "Unassigned")
+        }
+    }
+
+    private func cycleChip(_ label: String, value: String, color: Color,
+                           action: @escaping () -> Void) -> some View {
+        Button { Haptics.tap(); action() } label: {
+            propertyChip(label, value: value, color: color)
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Double tap to cycle")
+    }
+
+    private func displayChip(_ label: String, value: String) -> some View {
+        propertyChip(label, value: value, color: .secondary)
+    }
+
+    private func propertyChip(_ label: String, value: String, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label).font(.caption).foregroundStyle(.secondary)
+            Text(value).font(.callout.weight(.semibold)).foregroundStyle(color).lineLimit(1)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .glass(.control, cornerRadius: 12)
     }
 
     private var priorityBadge: some View {
@@ -216,7 +263,7 @@ struct TaskDetailView: View {
         let steps = live.steps ?? []
         return VStack(alignment: .leading, spacing: 12) {
             HStack {
-                Text("Steps").font(.headline)
+            Text("Activity").font(.headline)
                 Spacer()
                 if live.hasSteps {
                     Text("\(live.doneStepCount)/\(live.stepCount)")
@@ -336,6 +383,29 @@ struct TaskDetailView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(16)
         .glass(.raised, cornerRadius: 14)
+        .onTapGesture(count: 2) { editingNotes = true }
+    }
+
+    private var bottomActions: some View {
+        VStack(spacing: 10) {
+            Button {
+                if live.familiarId != nil { app.openChat(for: live) }
+                else { showFamiliarPicker = true }
+            } label: {
+                Label("Open in chat", systemImage: "bubble.left.and.bubble.right.fill")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                Task { await app.setTaskStatus(live, .done) }
+            } label: {
+                Label("Mark done", systemImage: "checkmark.circle")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+            .disabled(live.status == .done)
+        }
     }
 
     private var labelsRow: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -43,6 +43,7 @@ struct TasksView: View {
     /// A task awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: BoardCard?
     @State private var showReminders = false
+    @State private var collapsedSections: Set<String> = []
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
 
     /// How the task list is partitioned into sections.
@@ -346,11 +347,15 @@ struct TasksView: View {
         List(selection: $selection) {
             ForEach(sections) { section in
                 Section {
-                    ForEach(section.cards) { card in
-                        TaskRow(card: card)
-                            .tag(card)
-                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 12))
-                            .contextMenu { taskMenu(card) }
+                    if !collapsedSections.contains(section.id) {
+                        ForEach(section.cards) { card in
+                            TaskRow(card: card)
+                                .tag(card)
+                                .padding(12)
+                                .glass(.raised, cornerRadius: 14)
+                                .listRowInsets(EdgeInsets(top: 5, leading: 16, bottom: 5, trailing: 16))
+                                .listRowBackground(Color.clear)
+                                .contextMenu { taskMenu(card) }
                             // Trailing = destructive (delete); leading = the
                             // positive quick-action (done/reopen), full-swipe to
                             // complete — matching RemindersView + iOS convention.
@@ -366,16 +371,35 @@ struct TasksView: View {
                                 }
                                 .tint(card.status == .done ? .orange : .green)
                             }
+                        }
                     }
                 } header: {
-                    HStack(spacing: 6) {
-                        if let image = section.systemImage { Image(systemName: image).accessibilityHidden(true) }
-                        Text(section.title)
-                        Spacer()
-                        Text("\(section.cards.count)").monospacedDigit()
+                    Button {
+                        Haptics.tap()
+                        if collapsedSections.contains(section.id) {
+                            collapsedSections.remove(section.id)
+                        } else {
+                            collapsedSections.insert(section.id)
+                        }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: collapsedSections.contains(section.id) ? "chevron.right" : "chevron.down")
+                                .font(.caption.weight(.bold))
+                            Circle().fill(section.tint ?? .secondary).frame(width: 8, height: 8)
+                            Text(section.title)
+                            Spacer()
+                            Text("\(section.cards.count)")
+                                .font(.caption.weight(.semibold).monospacedDigit())
+                                .padding(.horizontal, 7).padding(.vertical, 2)
+                                .background(Color.secondary.opacity(0.14), in: Capsule())
+                        }
+                        .contentShape(Rectangle())
                     }
+                    .buttonStyle(.plain)
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(section.tint ?? .secondary)
+                    .accessibilityLabel("\(section.title), \(section.cards.count) tasks")
+                    .accessibilityValue(collapsedSections.contains(section.id) ? "Collapsed" : "Expanded")
                 }
             }
         }
@@ -507,59 +531,41 @@ struct TaskRow: View {
     let card: BoardCard
 
     private var familiar: Familiar? { card.familiarId.flatMap(app.familiar) }
+    private var project: ProjectInfo? { card.projectId.flatMap(app.project) }
 
     var body: some View {
-        HStack(alignment: .top, spacing: 12) {
-            Capsule()
-                .fill(Theme.color(for: card.status))
-                .frame(width: 3)
-                .frame(maxHeight: .infinity)
-
-            VStack(alignment: .leading, spacing: 6) {
-                HStack(spacing: 6) {
-                    if card.priority == .urgent || card.priority == .high {
-                        Image(systemName: "flag.fill")
-                            .font(.caption2)
-                            .foregroundStyle(Theme.color(for: card.priority))
-                            .accessibilityLabel("\(card.priority.label) priority")
-                    }
-                    Text(card.title)
-                        .font(.callout.weight(.medium))
-                        .foregroundStyle(.primary)
-                        .lineLimit(2)
+        VStack(alignment: .leading, spacing: 10) {
+            Text(card.title)
+                .font(.callout.weight(.semibold))
+                .foregroundStyle(.primary)
+                .lineLimit(2)
+            HStack(spacing: 7) {
+                TaskMetadataPill(text: card.priority.label, color: Theme.color(for: card.priority))
+                if let project {
+                    TaskMetadataPill(text: project.name, color: .secondary)
                 }
-
-                HStack(spacing: 8) {
-                    if card.needsHuman == true { NeedsYouBadge() }
-                    if card.hasSteps {
-                        Label("\(card.doneStepCount)/\(card.stepCount)", systemImage: "checklist")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                    }
-                    if app.hasLinkedChat(card) {
-                        Image(systemName: "bubble.left.and.bubble.right.fill")
-                            .font(.caption2)
-                            .foregroundStyle(.tint)
-                            .accessibilityLabel("Has linked chat")
-                    }
-                    ForEach(card.labelList.prefix(2), id: \.self) { LabelChip(text: $0) }
-                    if let updated = caveParseISO(card.updatedAt) {
-                        Text(updated, format: .relative(presentation: .numeric))
-                            .font(.caption2).foregroundStyle(.tertiary)
-                    }
+                if let familiar {
+                    TaskMetadataPill(text: familiar.displayName, color: .secondary)
                 }
-            }
-
-            Spacer(minLength: 0)
-
-            if let familiar {
-                AvatarView(familiar: familiar,
-                           url: app.client?.avatarURL(for: familiar),
-                           size: 30)
+                Spacer(minLength: 0)
             }
         }
         .padding(.vertical, 2)
         .contentShape(Rectangle())
+    }
+}
+
+private struct TaskMetadataPill: View {
+    let text: String
+    let color: Color
+    var body: some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .lineLimit(1)
+            .padding(.horizontal, 7).padding(.vertical, 3)
+            .background(color.opacity(0.14), in: Capsule())
+            .overlay(Capsule().stroke(color.opacity(0.38), lineWidth: 1))
+            .foregroundStyle(color)
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -7,12 +7,17 @@ import SwiftUI
 /// server adopts the session and replays scrollback on reconnect).
 struct TerminalView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.chrome) private var chrome
     @Environment(\.scenePhase) private var scenePhase
+    @AppStorage("cave.terminal.shorthands") private var storedShorthands = "git status|pnpm test:mobile"
 
     @State private var terminal = PtyTerminal()
     @State private var cwd: String?      // nil = Home
     @State private var cols = 80
     @State private var rows = 24
+    @State private var showingNewShorthand = false
+    @State private var showingProjectPicker = false
+    @State private var newShorthand = ""
 
     /// Per-cwd thread id → one durable shell per working directory.
     private var threadId: String { "ios-terminal::" + (cwd ?? "home") }
@@ -26,6 +31,20 @@ struct TerminalView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Text("Terminal")
+                    .font(.largeTitle.weight(.bold))
+                cwdMenu
+                Spacer()
+                CircularIconButton(systemImage: "plus", label: "New terminal") {
+                    // PtyTerminal supports one durable session per project root;
+                    // selecting a root creates/adopts that real server session.
+                    showingProjectPicker = true
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(chrome.bgBase)
             // The xterm webview renders even when the PTY socket is down, so a
             // failed connection otherwise looks like a frozen shell. Surface it.
             if !terminal.connected, let err = terminal.error {
@@ -60,6 +79,24 @@ struct TerminalView: View {
         .onChange(of: scenePhase) { _, phase in
             if phase == .active, !terminal.connected, !terminal.exited { connect() }
         }
+        .confirmationDialog("New terminal", isPresented: $showingProjectPicker) {
+            Button("Home") { switchCwd(nil) }
+            ForEach(app.projects) { project in
+                Button(project.name) { switchCwd(project.root) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Choose a project for the terminal session.")
+        }
+        .alert("New shorthand", isPresented: $showingNewShorthand) {
+            TextField("Command", text: $newShorthand)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+            Button("Add") { addShorthand() }
+            Button("Cancel", role: .cancel) { newShorthand = "" }
+        } message: {
+            Text("This command is stored on this phone.")
+        }
     }
 
     // MARK: - Key row (special keys the soft keyboard lacks → straight to the PTY)
@@ -69,6 +106,21 @@ struct TerminalView: View {
             HStack(spacing: 8) {
                 cwdMenu
                 keyButton("esc", "Escape") { terminal.sendInput("\u{1B}") }
+                ForEach(["git status", "pwd", "clear"], id: \.self) { command in
+                    keyButton(command, command) { terminal.sendInput(command + "\n") }
+                }
+                ForEach(shorthands, id: \.self) { command in
+                    keyButton(command, "Run \(command)") { terminal.sendInput(command + "\n") }
+                }
+                Button {
+                    showingNewShorthand = true
+                } label: {
+                    Label("Shorthand", systemImage: "plus")
+                        .font(.system(.footnote, design: .monospaced))
+                        .padding(.horizontal, 10).padding(.vertical, 5)
+                        .overlay(Capsule().stroke(style: StrokeStyle(lineWidth: 1, dash: [4])))
+                }
+                .buttonStyle(.plain)
                 keyButton("tab", "Tab") { terminal.sendInput("\t") }
                 keyButton("⌃C", "Control C") { terminal.sendInput("\u{03}") }
                 keyButton("⌃D", "Control D") { terminal.sendInput("\u{04}") }
@@ -137,5 +189,16 @@ struct TerminalView: View {
         guard root != cwd else { return }
         cwd = root
         connect()   // threadId is derived from cwd → fresh/persistent per directory
+    }
+
+    private var shorthands: [String] {
+        storedShorthands.split(separator: "|").map(String.init).filter { !$0.isEmpty }
+    }
+
+    private func addShorthand() {
+        let value = newShorthand.trimmingCharacters(in: .whitespacesAndNewlines)
+        defer { newShorthand = "" }
+        guard !value.isEmpty, !shorthands.contains(value) else { return }
+        storedShorthands = (shorthands + [value]).joined(separator: "|")
     }
 }

--- a/scripts/ios-chat-restyle.test.mjs
+++ b/scripts/ios-chat-restyle.test.mjs
@@ -31,13 +31,19 @@ assert.match(drawer, /struct NavRow: View/, "drawer destination rows are a dedic
 assert.match(drawer, /accessibilityAddTraits\(active \? \[\.isSelected\] : \[\]\)/, "active drawer row is exposed as selected to AT");
 assert.match(chrome, /struct EmptyChatSuggestionRow: View/, "empty-state suggestion rows are a shared component");
 
-// ── ChatView header: the agent pill opens the model/agent picker ────────────
+// ── ChatView header: session details preserve the real model flow ───────────
 assert.match(
   chatView,
-  /PillSelector\(label: thread\.title,[\s\S]{0,200}?action: \{ Task \{ await switchModel\(""\) \} \}/,
-  "the direct-chat agent pill opens the model picker via the existing /model path",
+  /showSessionDetails\.toggle\(\)/,
+  "the centered familiar control toggles session details",
 );
-assert.match(chatView, /if thread\.isGroup \{[\s\S]{0,300}?chevron: false/, "group chats keep a static pill (no single model to switch)");
+assert.match(chatView, /private var sessionDetailsCard: some View/, "session details render in a dedicated dropdown card");
+assert.match(
+  chatView,
+  /showSessionDetails = false\s*\n\s*Task \{ await switchModel\(""\) \}/,
+  "the dropdown model row preserves the existing /model path",
+);
+assert.match(chatView, /TODO\(no backend\)/, "unsupported session metadata is explicitly non-persisted");
 assert.doesNotMatch(chatView, /ChatModelBar\(thread:/, "the between-list model bar is retired — model access lives in the header pill");
 
 // ── Composer "+" menu: fan-out + all three dismissal paths ───────────────────


### PR DESCRIPTION
Implements the Claude Design iOS handoff (Coven Cave App.dc.html) in the native SwiftUI app.

## Scope
- Tab bar: Chats / Tasks / Terminal / Settings visible; Canvas, Search, Calendar, Developer kept in the More/sidebar section; keyboard shortcuts preserved
- Chats home: large title, Projects + New Chat controls, search, 42pt avatars with presence dots, sender-prefixed group previews, unread capsules / relative times
- Projects panel: new full-screen slide-over backed by real project/task metadata
- Conversation: spec bubble radii, themed surfaces, restyled slash-command menu, session-details dropdown (Model wired to real /model flow; rows without backend are display-only with TODO), Plugins entry in the plus menu
- Plugins panel: searchable catalog with installed tiles, featured rows, detail page (static catalog + TODO — no stable mobile plugin API yet)
- Tasks: collapsible real-status sections, colored headers + count chips, priority/project/familiar pills; task detail with double-tap editing, 2x2 property grid (real status/priority cycling), activity from real steps
- Permissions: per-familiar cards with cycling None/Read/Write pills, real CaveClient+Permissions wiring kept, phone-writes lock enforced
- Terminal: real PTY/xterm untouched; project picker, quick-command chips, persistent user shorthands
- Settings: profile header with real host, Community links, real version footer; existing functional rows preserved

## Not fabricated (deliberate)
- No PR/issue linked-context strip: thread/task models expose no real PR/issue URLs
- No fake plugin install persistence, no fake Runtime/Intelligence/Speed session controls

## Verification
- xcodegen generate: OK
- iOS Simulator build (post-rebase on main): BUILD SUCCEEDED, zero errors, no new warnings
- pnpm test:mobile: 87/87 test files passed (post-rebase)
- git diff --check: clean
- Installed and launched on iPhone 16 Pro simulator

Bead: cave-4bsu