### PR TITLE
Familiar Studio: multiselect Type picker

### DIFF
--- a/docs/specs/2026-07-24-familiar-type-multiselect-design.md
+++ b/docs/specs/2026-07-24-familiar-type-multiselect-design.md
@@ -18,8 +18,10 @@ picker is an artificial cap.
 
 The stored value stays a single string — `familiarType?: string` — now
 encoded as comma-separated type ids, e.g. `"coding,research"`. A single
-selection keeps its exact current encoding (`"coding"`), and General stays the
-empty string / absent field.
+selection keeps its exact current encoding (`"coding"`). An absent/empty
+field still means General; an *explicit* return to General stores the
+literal `"general"` sentinel (see UI section — an empty string would merely
+clear the override and let a daemon-provided base type resurface).
 
 Why: the field flows through five layers (`FamiliarOverride` →
 `ConfigPatch` (`string | null`) → cave-config → daemon → `Familiar` /
@@ -70,12 +72,19 @@ change** — it already spreads this list into the grant set.
   `--active` classes — no CSS changes.
 - Clicking a type chip **toggles** it in the selection. The stored value is
   the selected ids comma-joined in `FAMILIAR_TYPES` table order (stable,
-  canonical); an empty selection stores `""` (which
-  `configPatchForOverridePatch` already maps to a clearing `null`).
+  canonical); an empty selection stores the `"general"` sentinel.
 - **General chip = empty state**: `aria-checked` only when no types are
-  selected; clicking it clears the selection (`familiarType: ""`).
-  Deselecting the last type likewise returns to General. General and real
-  types are mutually exclusive by construction.
+  selected; clicking it stores `familiarType: "general"`. Deselecting the
+  last type likewise stores the sentinel. The sentinel — rather than `""` —
+  is required because `configPatchForOverridePatch` maps empty strings to a
+  clearing `null`, which only deletes the override and lets a
+  daemon-provided base type win again on resolve
+  (`ov.familiarType ?? base.familiarType`); the parser already treats
+  `"general"` as the empty selection. General and real types are mutually
+  exclusive by construction.
+- Every chip click announces the resulting selection via `useAnnouncer()`
+  ("Type set to General" / "Type set to <labels>"), since toggling a type
+  also flips `aria-checked` on the non-focused General chip.
 - **Hint text (stacked)**: with types selected, render one
   `<p className="familiar-studio-identity__hint">` per selected type, each
   showing that type's unlock description (table order). Empty selection
@@ -98,6 +107,7 @@ change** — it already spreads this list into the grant set.
 - `src/lib/role-surfaces.test.ts`: multi-type familiar gets both rooms'
   grant ids.
 - `src/components/familiar-studio-identity-tab.test.ts`: source pins for
-  `role="checkbox"` and `parseFamiliarTypeIds` usage.
+  `role="checkbox"`, `parseFamiliarTypeIds` usage, and the
+  `familiarType: "general"` sentinel store.
 
 All three run in the app suite (`node scripts/run-tests.mjs app`).

--- a/docs/specs/2026-07-24-familiar-type-multiselect-design.md
+++ b/docs/specs/2026-07-24-familiar-type-multiselect-design.md
@@ -1,0 +1,103 @@
+# Familiar Type multiselect
+
+**Date:** 2026-07-24
+**Status:** Approved
+**Surface:** Familiar Studio → Identity → Type picker
+
+## Problem
+
+A familiar's Type (cave-cc5r) is single-select: picking Research replaces
+Coding. Types are purely *additive* role grants — each one unlocks a Role
+Surface room and never subtracts anything — so there is no semantic reason a
+familiar can't be both a Coding and a Research familiar. The single-select
+picker is an artificial cap.
+
+## Design
+
+### Storage: comma-separated ids in the existing field
+
+The stored value stays a single string — `familiarType?: string` — now
+encoded as comma-separated type ids, e.g. `"coding,research"`. A single
+selection keeps its exact current encoding (`"coding"`), and General stays the
+empty string / absent field.
+
+Why: the field flows through five layers (`FamiliarOverride` →
+`ConfigPatch` (`string | null`) → cave-config → daemon → `Familiar` /
+`familiar-resolve`), all typed `string`. Comma encoding means **zero schema
+churn** across that chain — only the two endpoints (the parser in
+`familiar-types.ts` and the picker UI) change. Existing stored single values
+parse unchanged; no migration.
+
+### Parsing: `parseFamiliarTypeIds`
+
+New function in `src/lib/familiar-types.ts`:
+
+```ts
+parseFamiliarTypeIds(value: string | undefined | null): FamiliarTypeId[]
+```
+
+- Split on `,`, trim + lowercase each token.
+- Keep only tokens where `isFamiliarTypeId` holds; unknown/stale ids are
+  silently dropped (same degrade-to-General spirit as today's
+  `resolveFamiliarType` fallback).
+- `"general"` never appears in the result — General is the *empty state*,
+  not a member type.
+- Dedupe, preserving first-occurrence order.
+- `undefined` / `null` / `""` → `[]`.
+
+`resolveFamiliarTypes(value): FamiliarTypeSpec[]` maps parsed ids to table
+entries (`[]` means General). `resolveFamiliarType` (singular) remains for
+single-value semantics: first parsed type's spec, else General — so
+`resolveFamiliarType("coding,research").id === "coding"` and all existing
+single-value behavior (case/whitespace tolerance, unknown → General) is
+unchanged.
+
+### Grants: union
+
+`familiarTypeRoleIds(value)` unions grants across every parsed type: for each
+spec it contributes `[spec.id, spec.roleToken]`, deduped, in parse order.
+`"coding,research"` → `["coding", "coder", "research", "researcher"]`.
+Empty/General → `[]` exactly as today. `role-surfaces.ts` needs **no
+change** — it already spreads this list into the grant set.
+
+### UI: checkbox chips, General as the empty state
+
+`FamiliarTypePicker` in `familiar-studio-identity-tab.tsx`:
+
+- The chip row becomes a checkbox group: container `role="group"`
+  (aria-labelledby unchanged), each chip `role="checkbox"` +
+  `aria-checked` by membership. Same `.familiar-studio-type-chip` /
+  `--active` classes — no CSS changes.
+- Clicking a type chip **toggles** it in the selection. The stored value is
+  the selected ids comma-joined in `FAMILIAR_TYPES` table order (stable,
+  canonical); an empty selection stores `""` (which
+  `configPatchForOverridePatch` already maps to a clearing `null`).
+- **General chip = empty state**: `aria-checked` only when no types are
+  selected; clicking it clears the selection (`familiarType: ""`).
+  Deselecting the last type likewise returns to General. General and real
+  types are mutually exclusive by construction.
+- **Hint text (stacked)**: with types selected, render one
+  `<p className="familiar-studio-identity__hint">` per selected type, each
+  showing that type's unlock description (table order). Empty selection
+  renders General's description — identical to today. Single selection
+  renders identically to today.
+
+### Non-goals
+
+- No changes to the daemon, cave-config schema, `/api/familiars`, or
+  `familiar-resolve` — the string passes through untouched.
+- No cap on selections (all eight types may be active; grants are additive
+  room unlocks).
+- No reordering UI — canonical order is the table order.
+
+## Testing
+
+- `src/lib/familiar-types.test.ts`: parse (multi, whitespace/case, dedupe,
+  unknown-dropped, general-excluded, empty/null), union grants, singular
+  resolve-first behavior.
+- `src/lib/role-surfaces.test.ts`: multi-type familiar gets both rooms'
+  grant ids.
+- `src/components/familiar-studio-identity-tab.test.ts`: source pins for
+  `role="checkbox"` and `parseFamiliarTypeIds` usage.
+
+All three run in the app suite (`node scripts/run-tests.mjs app`).

--- a/src/components/familiar-studio-identity-tab.test.ts
+++ b/src/components/familiar-studio-identity-tab.test.ts
@@ -16,5 +16,8 @@ assert.match(source, /setFamiliarOverride/);
 assert.match(source, /clearFamiliarOverrideField/);
 assert.match(source, /role="checkbox"/);
 assert.match(source, /parseFamiliarTypeIds/);
+// General must be stored as the explicit sentinel, not "" — an empty string
+// only clears the override and lets a daemon-provided type win (cave-gud8).
+assert.match(source, /familiarType: "general"/);
 
 console.log("familiar-studio-identity-tab.test.ts: ok");

--- a/src/components/familiar-studio-identity-tab.test.ts
+++ b/src/components/familiar-studio-identity-tab.test.ts
@@ -14,5 +14,7 @@ assert.match(source, /pronouns/);
 assert.match(source, /description/);
 assert.match(source, /setFamiliarOverride/);
 assert.match(source, /clearFamiliarOverrideField/);
+assert.match(source, /role="checkbox"/);
+assert.match(source, /parseFamiliarTypeIds/);
 
 console.log("familiar-studio-identity-tab.test.ts: ok");

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/lib/cave-familiar-overrides";
 import { FAMILIAR_TYPES, parseFamiliarTypeIds } from "@/lib/familiar-types";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { FamiliarStudioLookTab } from "@/components/familiar-studio-look-tab";
 import { FamiliarLifecycleSection } from "@/components/familiar-lifecycle-section";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
@@ -75,10 +76,18 @@ export function FamiliarStudioIdentityTab({
  * Cave override and synced to cave-config like every other identity field.
  * Each selected type ADDS its role token to the familiar's Role Surface
  * grants; the free-text Role label below keeps working exactly as before.
- * General is the empty state — it is checked when nothing is selected, and
- * clicking it clears all selections.
+ * General is the empty state — it is checked when nothing is selected.
+ * Picking General, or unchecking the last selected type, stores the literal
+ * `"general"` sentinel rather than an empty string: an empty string would
+ * only *clear* the override (see cave-familiar-overrides.ts) and let a
+ * daemon-provided `familiarType` win on resolution, making General a
+ * visible no-op. `"general"` is already treated as the empty state
+ * everywhere downstream (parseFamiliarTypeIds excludes it,
+ * familiarTypeRoleIds grants nothing, resolveFamiliarType falls back to
+ * General), so it safely beats any base value.
  */
 function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
+  const { announce } = useAnnouncer();
   const selectedIds = parseFamiliarTypeIds(familiar.familiarType);
   const labelId = `familiar-type-label-${familiar.id}`;
   return (
@@ -99,12 +108,19 @@ function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
               className={`focus-ring familiar-studio-type-chip${isChecked ? " familiar-studio-type-chip--active" : ""}`}
               onClick={() => {
                 if (t.id === "general") {
-                  setFamiliarOverride(familiar.id, { familiarType: "" });
+                  setFamiliarOverride(familiar.id, { familiarType: "general" });
+                  announce("Type set to General");
                 } else {
                   const next = new Set(selectedIds);
                   if (next.has(t.id)) next.delete(t.id); else next.add(t.id);
-                  const value = FAMILIAR_TYPES.filter((s) => next.has(s.id)).map((s) => s.id).join(",");
+                  const selected = FAMILIAR_TYPES.filter((s) => next.has(s.id));
+                  const value = selected.length === 0 ? "general" : selected.map((s) => s.id).join(",");
                   setFamiliarOverride(familiar.id, { familiarType: value });
+                  announce(
+                    selected.length === 0
+                      ? "Type set to General"
+                      : `Type set to ${selected.map((s) => s.label).join(", ")}`,
+                  );
                 }
               }}
             >

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -8,7 +8,7 @@ import {
   useFamiliarOverrides,
   type FamiliarOverride,
 } from "@/lib/cave-familiar-overrides";
-import { FAMILIAR_TYPES, resolveFamiliarType } from "@/lib/familiar-types";
+import { FAMILIAR_TYPES, parseFamiliarTypeIds } from "@/lib/familiar-types";
 import { Icon } from "@/lib/icon";
 import { FamiliarStudioLookTab } from "@/components/familiar-studio-look-tab";
 import { FamiliarLifecycleSection } from "@/components/familiar-lifecycle-section";
@@ -69,42 +69,58 @@ export function FamiliarStudioIdentityTab({
 }
 
 /**
- * The explicit familiar Type picker (cave-cc5r): a chip radio-row over the
- * static FAMILIAR_TYPES table. The choice is stored as a Cave override
- * (`familiarType`) and synced to cave-config like every other identity field;
- * it ADDS the type's role token to the familiar's Role Surface grants, so the
- * free-text Role label below keeps working exactly as before. Picking General
- * (the default) clears the override.
+ * The explicit familiar Type picker (cave-cc5r / cave-gud8): a chip
+ * checkbox-row over the static FAMILIAR_TYPES table. Multiple types may be
+ * selected; the choice is stored comma-separated in the same `familiarType`
+ * Cave override and synced to cave-config like every other identity field.
+ * Each selected type ADDS its role token to the familiar's Role Surface
+ * grants; the free-text Role label below keeps working exactly as before.
+ * General is the empty state — it is checked when nothing is selected, and
+ * clicking it clears all selections.
  */
 function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
-  const selected = resolveFamiliarType(familiar.familiarType);
+  const selectedIds = parseFamiliarTypeIds(familiar.familiarType);
   const labelId = `familiar-type-label-${familiar.id}`;
   return (
     <div className="familiar-studio-identity__row">
       <span className="familiar-studio-identity__label" id={labelId}>
         Type
       </span>
-      <div role="radiogroup" aria-labelledby={labelId} className="familiar-studio-identity__types">
-        {FAMILIAR_TYPES.map((t) => (
-          <button
-            key={t.id}
-            type="button"
-            role="radio"
-            aria-checked={selected.id === t.id}
-            title={t.description}
-            className={`focus-ring familiar-studio-type-chip${selected.id === t.id ? " familiar-studio-type-chip--active" : ""}`}
-            onClick={() =>
-              setFamiliarOverride(familiar.id, {
-                familiarType: t.id === "general" ? "" : t.id,
-              })
-            }
-          >
-            <Icon name={t.iconName} width={12} height={12} aria-hidden />
-            {t.label}
-          </button>
-        ))}
+      <div role="group" aria-labelledby={labelId} className="familiar-studio-identity__types">
+        {FAMILIAR_TYPES.map((t) => {
+          const isChecked = t.id === "general" ? selectedIds.length === 0 : selectedIds.includes(t.id);
+          return (
+            <button
+              key={t.id}
+              type="button"
+              role="checkbox"
+              aria-checked={isChecked}
+              title={t.description}
+              className={`focus-ring familiar-studio-type-chip${isChecked ? " familiar-studio-type-chip--active" : ""}`}
+              onClick={() => {
+                if (t.id === "general") {
+                  setFamiliarOverride(familiar.id, { familiarType: "" });
+                } else {
+                  const next = new Set(selectedIds);
+                  if (next.has(t.id)) next.delete(t.id); else next.add(t.id);
+                  const value = FAMILIAR_TYPES.filter((s) => next.has(s.id)).map((s) => s.id).join(",");
+                  setFamiliarOverride(familiar.id, { familiarType: value });
+                }
+              }}
+            >
+              <Icon name={t.iconName} width={12} height={12} aria-hidden />
+              {t.label}
+            </button>
+          );
+        })}
       </div>
-      <p className="familiar-studio-identity__hint">{selected.description}</p>
+      {selectedIds.length === 0 ? (
+        <p className="familiar-studio-identity__hint">{FAMILIAR_TYPES[0].description}</p>
+      ) : (
+        FAMILIAR_TYPES.filter((s) => selectedIds.includes(s.id)).map((s) => (
+          <p key={s.id} className="familiar-studio-identity__hint">{s.description}</p>
+        ))
+      )}
     </div>
   );
 }

--- a/src/components/settings-action-buttons.test.ts
+++ b/src/components/settings-action-buttons.test.ts
@@ -46,7 +46,7 @@ function jsxElementBlocks(fileName: string, source: string, tagName: string): st
 }
 
 const reviewedSemanticControl = (button: string): boolean =>
-  /goToSetting\(e\)|selectDevice\(device\)|settings-nav__item|role="switch"|aria-pressed=|aria-label=\{`Pick \$\{label\} color`\}|aria-haspopup="dialog"|role="option"|role="radio"|setEnlarged\(true\)|Drag to reorder|familiar-studio-lifecycle__row-main/.test(
+  /goToSetting\(e\)|selectDevice\(device\)|settings-nav__item|role="switch"|aria-pressed=|aria-label=\{`Pick \$\{label\} color`\}|aria-haspopup="dialog"|role="option"|role="radio"|role="checkbox"|setEnlarged\(true\)|Drag to reorder|familiar-studio-lifecycle__row-main/.test(
     button,
   );
 

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -165,7 +165,8 @@ export type FamiliarBinding = {
   model: string;
   display_name?: string;
   role?: string;
-  /** Explicit familiar Type id (familiar-types.ts). Absent = "general". */
+  /** Explicit familiar Type id(s) (familiar-types.ts). May be a single id or
+   *  comma-separated list of ids for multi-type selection. Absent/empty = "general". */
   familiarType?: string;
   pronouns?: string;
   description?: string;

--- a/src/lib/cave-familiar-overrides.ts
+++ b/src/lib/cave-familiar-overrides.ts
@@ -20,7 +20,9 @@ const OVERRIDES_KEY = "cave:familiar-overrides:v1";
 export type FamiliarOverride = {
   display_name?: string;
   role?: string;
-  /** Explicit familiar Type id (familiar-types.ts). Empty string clears. */
+  /** Explicit familiar Type id(s) (familiar-types.ts), comma-separated for
+   *  multi-type selection. "general" or empty string = General; empty also
+   *  clears the override (falls through to the daemon value). */
   familiarType?: string;
   pronouns?: string;
   description?: string;

--- a/src/lib/familiar-types.test.ts
+++ b/src/lib/familiar-types.test.ts
@@ -84,6 +84,14 @@ test("parseFamiliarTypeIds dedupes repeated ids (first-occurrence order)", () =>
   assert.deepEqual(parseFamiliarTypeIds("coding,coding,research"), ["coding", "research"]);
 });
 
+test("parseFamiliarTypeIds preserves parse order, not table order", () => {
+  assert.deepEqual(parseFamiliarTypeIds("research,coding,research"), ["research", "coding"]);
+});
+
+test("parseFamiliarTypeIds dedupes case-varied duplicates", () => {
+  assert.deepEqual(parseFamiliarTypeIds("CODING,coding"), ["coding"]);
+});
+
 test("parseFamiliarTypeIds silently drops unknown ids", () => {
   assert.deepEqual(parseFamiliarTypeIds("coding,retired-type,research"), ["coding", "research"]);
 });
@@ -114,6 +122,10 @@ test("familiarTypeRoleIds unions grants across multiple types", () => {
 
 test("resolveFamiliarType on a multi-value string returns the first parsed type", () => {
   assert.equal(resolveFamiliarType("coding,research").id, "coding");
+});
+
+test("resolveFamiliarType on out-of-table-order input returns the first parsed type", () => {
+  assert.equal(resolveFamiliarType("research,coding").id, "research");
 });
 
 // ── Integration with the Role Surface matcher ────────────────────────────────

--- a/src/lib/familiar-types.test.ts
+++ b/src/lib/familiar-types.test.ts
@@ -9,7 +9,9 @@ import {
   FAMILIAR_TYPES,
   familiarTypeRoleIds,
   isFamiliarTypeId,
+  parseFamiliarTypeIds,
   resolveFamiliarType,
+  resolveFamiliarTypes,
 } from "./familiar-types.ts";
 import { familiarRoleIds, normalizeRoleId, surfaceMatchesRoles } from "./role-surfaces.ts";
 
@@ -62,6 +64,56 @@ test("resolveFamiliarType falls back to General on unknown/stale values", () => 
 test("familiarTypeRoleIds grants the type id AND its role token", () => {
   assert.deepEqual(familiarTypeRoleIds("coding"), ["coding", "coder"]);
   assert.deepEqual(familiarTypeRoleIds("research"), ["research", "researcher"]);
+});
+
+// ── Multi-value familiarType ─────────────────────────────────────────────────
+
+test("parseFamiliarTypeIds parses a single type", () => {
+  assert.deepEqual(parseFamiliarTypeIds("coding"), ["coding"]);
+});
+
+test("parseFamiliarTypeIds parses comma-separated types", () => {
+  assert.deepEqual(parseFamiliarTypeIds("coding,research"), ["coding", "research"]);
+});
+
+test("parseFamiliarTypeIds trims and lowercases each token", () => {
+  assert.deepEqual(parseFamiliarTypeIds(" CODING , research "), ["coding", "research"]);
+});
+
+test("parseFamiliarTypeIds dedupes repeated ids (first-occurrence order)", () => {
+  assert.deepEqual(parseFamiliarTypeIds("coding,coding,research"), ["coding", "research"]);
+});
+
+test("parseFamiliarTypeIds silently drops unknown ids", () => {
+  assert.deepEqual(parseFamiliarTypeIds("coding,retired-type,research"), ["coding", "research"]);
+});
+
+test("parseFamiliarTypeIds treats general as empty state — never a member", () => {
+  assert.deepEqual(parseFamiliarTypeIds("general,coding"), ["coding"]);
+  assert.deepEqual(parseFamiliarTypeIds("general"), []);
+});
+
+test("parseFamiliarTypeIds returns [] for empty/absent values", () => {
+  assert.deepEqual(parseFamiliarTypeIds(""), []);
+  assert.deepEqual(parseFamiliarTypeIds(undefined), []);
+  assert.deepEqual(parseFamiliarTypeIds(null), []);
+});
+
+test("resolveFamiliarTypes returns the ordered specs for valid ids", () => {
+  const specs = resolveFamiliarTypes("coding,research");
+  assert.deepEqual(specs.map((s) => s.id), ["coding", "research"]);
+});
+
+test("resolveFamiliarTypes returns [] for empty value", () => {
+  assert.deepEqual(resolveFamiliarTypes(""), []);
+});
+
+test("familiarTypeRoleIds unions grants across multiple types", () => {
+  assert.deepEqual(familiarTypeRoleIds("coding,research"), ["coding", "coder", "research", "researcher"]);
+});
+
+test("resolveFamiliarType on a multi-value string returns the first parsed type", () => {
+  assert.equal(resolveFamiliarType("coding,research").id, "coding");
 });
 
 // ── Integration with the Role Surface matcher ────────────────────────────────

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -7,6 +7,10 @@
  * room registry (role-surfaces.ts) matches surfaces against the combined set,
  * so types ADD grants and never subtract what a role label already gives.
  *
+ * The stored `familiarType` field is a comma-separated list of type ids
+ * (e.g. `"coding,research"`). General is the empty state and never appears
+ * as a member. Role grants are the union across all selected types.
+ *
  * The table is static on purpose: it is the single documented mapping from
  * "what the user picks in Familiar Studio → Identity" to "which room opens",
  * unit-testable without the component registry.
@@ -55,19 +59,44 @@ export function isFamiliarTypeId(value: string): value is FamiliarTypeId {
   return FAMILIAR_TYPES.some((t) => t.id === value);
 }
 
-/** Stored value → table entry; unknown/absent values resolve to General so a
- *  stale config never hides the picker or crashes matching. */
-export function resolveFamiliarType(value: string | undefined | null): FamiliarTypeSpec {
-  const id = (value ?? "").trim().toLowerCase();
-  return FAMILIAR_TYPES.find((t) => t.id === id) ?? FAMILIAR_TYPES[0];
+/**
+ * Parse a comma-separated type string into an ordered, deduped list of valid
+ * type ids. General is the empty state and is never included in the result.
+ */
+export function parseFamiliarTypeIds(value: string | undefined | null): FamiliarTypeId[] {
+  const seen = new Set<FamiliarTypeId>();
+  for (const token of (value ?? "").split(",")) {
+    const id = token.trim().toLowerCase();
+    if (id === "general" || !isFamiliarTypeId(id)) continue;
+    seen.add(id);
+  }
+  return [...seen];
 }
 
 /**
- * Role-id grants for a stored type value: the type id itself plus its role
- * token (both already normalizeRoleId-shaped). General grants nothing.
+ * Resolve a comma-separated type string to an ordered array of specs. Returns
+ * an empty array when the value is absent or resolves to no valid types.
+ */
+export function resolveFamiliarTypes(value: string | undefined | null): FamiliarTypeSpec[] {
+  return parseFamiliarTypeIds(value).map((id) => FAMILIAR_TYPES.find((t) => t.id === id)!);
+}
+
+/** Stored value → table entry; unknown/absent values (including multi-value
+ *  strings where the first token is valid) resolve to the first valid type, or
+ *  General so a stale config never hides the picker or crashes matching. */
+export function resolveFamiliarType(value: string | undefined | null): FamiliarTypeSpec {
+  return resolveFamiliarTypes(value)[0] ?? FAMILIAR_TYPES[0];
+}
+
+/**
+ * Role-id grants for a stored type value: unions the type id and role token
+ * for every parsed type. General grants nothing.
  */
 export function familiarTypeRoleIds(value: string | undefined | null): string[] {
-  const spec = resolveFamiliarType(value);
-  if (!spec.roleToken) return [];
-  return [spec.id, spec.roleToken];
+  const grants = new Set<string>();
+  for (const spec of resolveFamiliarTypes(value)) {
+    grants.add(spec.id);
+    if (spec.roleToken) grants.add(spec.roleToken);
+  }
+  return [...grants];
 }

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -81,9 +81,10 @@ export function resolveFamiliarTypes(value: string | undefined | null): Familiar
   return parseFamiliarTypeIds(value).map((id) => FAMILIAR_TYPES.find((t) => t.id === id)!);
 }
 
-/** Stored value → table entry; unknown/absent values (including multi-value
- *  strings where the first token is valid) resolve to the first valid type, or
- *  General so a stale config never hides the picker or crashes matching. */
+/** Stored value → table entry: the first valid type found among the
+ *  comma-separated tokens (skipping "general" and unknown/stale ids), or
+ *  General when none are valid or the value is absent — so a stale config
+ *  never hides the picker or crashes matching. */
 export function resolveFamiliarType(value: string | undefined | null): FamiliarTypeSpec {
   return resolveFamiliarTypes(value)[0] ?? FAMILIAR_TYPES[0];
 }

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -122,6 +122,14 @@ test("a General or absent familiar Type grants no extra tokens", () => {
   assert.ok(!surfaceMatchesRoles({ role: "coder" }, unknown));
 });
 
+test("a multi-value familiarType unions grants from all types (cave-gud8)", () => {
+  const ids = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "coding,research" });
+  assert.ok(ids.has("coding"));
+  assert.ok(ids.has("coder"));
+  assert.ok(ids.has("research"));
+  assert.ok(ids.has("researcher"));
+});
+
 test("resolveVisibleRoleSurfaces shows alias-matched rooms", () => {
   clearRoleSurfacesForTest();
   const context = makeContext();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -30,9 +30,10 @@ export type Familiar = {
   // CovenCave-side enrichment from cave-config.json
   harness?: string;
   /**
-   * Explicit familiar Type (FamiliarTypeId from familiar-types.ts): the
-   * user-modifiable vocation that unlocks Role Surface rooms alongside the
-   * free-text `role` label. Absent = "general".
+   * Explicit familiar Type id(s) (FamiliarTypeId from familiar-types.ts): the
+   * user-modifiable vocation(s) that unlock Role Surface rooms alongside the
+   * free-text `role` label. May be a single id or a comma-separated list of
+   * ids for multi-type selection. "general" or absent/empty = General.
    */
   familiarType?: string;
   defaultHarness?: string;


### PR DESCRIPTION
A familiar's Type is an additive Role Surface grant, so there is no reason a familiar can't be both Coding and Research. The Identity-tab Type picker is now a checkbox chip row.

- Storage stays the single `familiarType` string, comma-encoded (`"coding,research"`, canonical table order) — zero schema churn across overrides → cave-config → daemon → resolve; existing single values parse unchanged.
- `parseFamiliarTypeIds` / `resolveFamiliarTypes` in familiar-types.ts; `familiarTypeRoleIds` unions grants across all selected types (Coding+Research unlocks both rooms).
- General = the empty state; explicit return to General stores the `"general"` sentinel so it overrides a daemon-provided base type instead of silently clearing the override.
- Checkbox a11y (`role=group`/`checkbox`), every toggle announced via `useAnnouncer`; settings raw-button gate allowlist now accepts `role="checkbox"`.

Spec: docs/specs/2026-07-24-familiar-type-multiselect-design.md. Bead: cave-gud8.

Verified: app suite 907/907, tsc clean, pnpm lint clean; per-task spec+quality reviews plus final integration review (READY).