### PR TITLE
feat(mobile): config-gated install-the-app QR on the Phone card (cave-jr4r.3)

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -18,6 +18,7 @@ import {
   withChatFragment,
   MOBILE_INVITE_TTL_MS,
   nativeAppDiscoveryProof,
+  resolveIosInstallUrl,
   tailnetDiscoveryProof,
   tailscaleBin,
   tailscaleSpawnEnv,
@@ -579,6 +580,21 @@ export async function POST(req: Request) {
   // Tailscale spawn, no Serve reconcile — just the last token-refresh beat.
   if (action === "status") {
     return NextResponse.json({ ok: true, lastSeenAt: await readMobileLastSeen() });
+  }
+
+  // Install-the-app QR (cave-jr4r.3): cheap like "status" — no Tailscale
+  // spawn, no invented URL. `configured:false` until the TestFlight link
+  // exists (fill in OFFICIAL_IOS_INSTALL_URL, or set COVEN_CAVE_IOS_INSTALL_URL).
+  if (action === "install-info") {
+    const installUrl = resolveIosInstallUrl();
+    if (!installUrl) return NextResponse.json({ ok: true, configured: false });
+    const installQrSvg = await QRCode.toString(installUrl, {
+      type: "svg",
+      margin: 1,
+      width: 256,
+      errorCorrectionLevel: "M",
+    });
+    return NextResponse.json({ ok: true, configured: true, url: installUrl, qrSvg: installQrSvg });
   }
 
   if (action === "app-start") {

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -360,3 +360,40 @@ assert.match(
 assert.match(css, /\.mobile-handoff__warning/, "the non-fatal warning has stable styling");
 
 console.log("mobile-handoff.test.ts OK");
+
+// ─── Install-the-app QR (cave-jr4r.3, #3802) ─────────────────────────────────
+// The Phone card leads its Get-the-app group with an install QR — a phone
+// without the app can't act on the pairing code. Config-gated: the route only
+// reports a URL when a real TestFlight/App Store link is configured, so
+// nothing is ever invented.
+assert.match(
+  handoffRoute,
+  /if \(action === "install-info"\) \{[\s\S]{0,120}resolveIosInstallUrl\(\)/,
+  "the route answers install-info from the config-gated resolver",
+);
+assert.match(
+  handoffRoute,
+  /if \(!installUrl\) return NextResponse\.json\(\{ ok: true, configured: false \}\)/,
+  "an unconfigured install link reports configured:false — never an invented URL",
+);
+assert.match(settings, /action: "install-info"/, "the Phone card asks the route for the install link");
+assert.match(
+  settings,
+  /aria-label="Install code for your iPhone camera"[\s\S]{0,80}dangerouslySetInnerHTML=\{\{ __html: install\.qrSvg \}\}/,
+  "the Phone card renders the install QR when configured",
+);
+assert.match(
+  settings,
+  /if \(!install\) return null;/,
+  "without a configured link the install card renders nothing",
+);
+assert.match(
+  settings,
+  /<SettingsGroup label="Get the app">\s*<IosInstallQrCard \/>/,
+  "the install QR leads the Get-the-app group",
+);
+assert.match(
+  settings,
+  /<\/SettingsGroup>\s*<SettingsGroup label="Get the app">[\s\S]{0,900}<SettingsGroup label="Phone write access">/,
+  "Get the app sits directly after Pair — install comes before the deep supporting groups",
+);

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -3112,6 +3112,63 @@ function MobileWriteAccessCard() {
   );
 }
 
+// ─── Section: Mobile — install-the-app QR ─────────────────────────────────────
+
+/** Install-the-app QR (cave-jr4r.3, #3802): a phone without the app can't act
+ *  on the pairing code, so the Get-the-app group leads with an install QR.
+ *  Config-gated — the card renders only when the route reports a real
+ *  TestFlight/App Store link (OFFICIAL_IOS_INSTALL_URL or
+ *  COVEN_CAVE_IOS_INSTALL_URL); until O4 (cave-f1wo) publishes one, the group
+ *  keeps its Xcode row only. */
+function IosInstallQrCard() {
+  const [install, setInstall] = useState<{ url: string; qrSvg: string } | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetch("/api/mobile-handoff", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ action: "install-info" }),
+      signal: controller.signal,
+    })
+      .then((res) => res.json())
+      .then((json: { ok?: boolean; configured?: boolean; url?: string; qrSvg?: string }) => {
+        if (controller.signal.aborted) return;
+        if (json?.ok && json.configured && json.url && json.qrSvg) {
+          setInstall({ url: json.url, qrSvg: json.qrSvg });
+        }
+      })
+      .catch(() => {
+        // Not configured / route unavailable — the card simply doesn't render.
+      });
+    return () => controller.abort();
+  }, []);
+
+  if (!install) return null;
+
+  return (
+    <div className="flex flex-col items-center gap-2.5 px-4 py-3">
+      <div
+        className="mobile-handoff-qr__svg overflow-hidden rounded-[var(--radius-card)] border border-[var(--border-hairline)] bg-white p-2"
+        role="img"
+        aria-label="Install code for your iPhone camera"
+        dangerouslySetInnerHTML={{ __html: install.qrSvg }}
+      />
+      <p className="text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+        Scan with your iPhone camera to install the app via TestFlight.
+      </p>
+      <Button
+        size="xs"
+        variant="secondary"
+        leadingIcon="ph:arrow-square-out"
+        onClick={() => openExternalUrl(install.url)}
+      >
+        Open install link
+      </Button>
+    </div>
+  );
+}
+
 function MobileSection({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
   return (
     <SettingsPage
@@ -3121,6 +3178,22 @@ function MobileSection({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
     >
       <SettingsGroup label="Pair">
         <MobileModeToggle onUseAsHub={onUseAsHub} />
+      </SettingsGroup>
+
+      <SettingsGroup label="Get the app">
+        <IosInstallQrCard />
+        <SettingsRow label="Build it with Xcode" description="apps/ios/CovenCave — open in Xcode and run on your device, or install the TestFlight build." />
+        <div className="flex flex-wrap gap-2 px-4 py-3">
+          <Button
+            variant="secondary"
+            size="sm"
+            className="settings-touch-action"
+            onClick={() => openExternalUrl("https://github.com/OpenCoven/coven-cave/blob/main/docs/ios-native-rebuild.md")}
+            leadingIcon="ph:file-text"
+          >
+            Setup guide
+          </Button>
+        </div>
       </SettingsGroup>
 
       <SettingsGroup label="Phone write access">
@@ -3134,21 +3207,6 @@ function MobileSection({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
             Being on your Tailscale network <em>is</em> the credential. The desktop only serves the mobile API over the
             tailnet — encrypted and private — so nothing is exposed to the public internet, and there’s no token to copy.
           </p>
-        </div>
-      </SettingsGroup>
-
-      <SettingsGroup label="Get the app">
-        <SettingsRow label="Build it with Xcode" description="apps/ios/CovenCave — open in Xcode and run on your device, or install the TestFlight build." />
-        <div className="flex flex-wrap gap-2 px-4 py-3">
-          <Button
-            variant="secondary"
-            size="sm"
-            className="settings-touch-action"
-            onClick={() => openExternalUrl("https://github.com/OpenCoven/coven-cave/blob/main/docs/ios-native-rebuild.md")}
-            leadingIcon="ph:file-text"
-          >
-            Setup guide
-          </Button>
         </div>
       </SettingsGroup>
     </SettingsPage>

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -10,6 +10,8 @@ import {
   magicDnsHost,
   magicDnsServeUrl,
   nativeAppDiscoveryProof,
+  OFFICIAL_IOS_INSTALL_URL,
+  resolveIosInstallUrl,
   resolveTailscaleBin,
   tailnetDiscoveryProof,
   tailscaleIpHost,
@@ -363,3 +365,44 @@ console.log("mobile-handoff.test.ts OK");
 }
 
 console.log("pairing checklist: ok");
+
+// ─── resolveIosInstallUrl (cave-jr4r.3, #3802) ────────────────────────────────
+// Config-gated install link: only real Apple install destinations qualify,
+// everything else — unset, junk, http, wrong host — resolves to null so the
+// Phone card never shows an invented URL.
+{
+  assert.equal(resolveIosInstallUrl({}), null, "unset resolves to null");
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: "   " }),
+    null,
+    "blank env resolves to null",
+  );
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: "not a url" }),
+    null,
+    "unparseable value resolves to null",
+  );
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: "http://testflight.apple.com/join/AbC123" }),
+    null,
+    "http is rejected — Apple install links are https",
+  );
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: "https://example.com/join/AbC123" }),
+    null,
+    "non-Apple hosts are rejected",
+  );
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: "https://testflight.apple.com/join/AbC123" }),
+    "https://testflight.apple.com/join/AbC123",
+    "a TestFlight public link resolves",
+  );
+  assert.equal(
+    resolveIosInstallUrl({ COVEN_CAVE_IOS_INSTALL_URL: " https://apps.apple.com/app/id0000000000 " }),
+    "https://apps.apple.com/app/id0000000000",
+    "an App Store link resolves, trimmed",
+  );
+  // The checked-in default is still the O4 fill-in: null until the TestFlight
+  // lane publishes a public link.
+  assert.equal(OFFICIAL_IOS_INSTALL_URL, null, "no official link is baked in yet (O4 owns producing one)");
+}

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -516,3 +516,39 @@ export function buildPairingSteps(outcome: {
   }
   return steps;
 }
+
+// ─── Install-the-app QR (cave-jr4r.3, #3802) ─────────────────────────────────
+//
+// The Phone card shows an install-the-app QR before the pairing QR matters —
+// a phone without the app can't act on the pairing code. No public TestFlight
+// link exists yet (O4, cave-f1wo, owns producing one), so the source is
+// config-gated rather than invented: fill in OFFICIAL_IOS_INSTALL_URL once the
+// lane publishes a link, or set COVEN_CAVE_IOS_INSTALL_URL to test a manual
+// build. Anything that isn't a real Apple install link resolves to null and
+// the card simply doesn't render.
+
+/** One-line fill-in once O4 publishes the TestFlight public link
+ *  (e.g. "https://testflight.apple.com/join/XXXXXXXX"). */
+export const OFFICIAL_IOS_INSTALL_URL: string | null = null;
+
+export const IOS_INSTALL_URL_ENV = "COVEN_CAVE_IOS_INSTALL_URL";
+
+/** Only real Apple install destinations qualify — a typo'd or placeholder
+ *  value must yield "not configured", never a QR pointing somewhere weird. */
+const IOS_INSTALL_HOSTS = new Set(["testflight.apple.com", "apps.apple.com"]);
+
+export function resolveIosInstallUrl(
+  env: Record<string, string | undefined> = process.env,
+): string | null {
+  const candidate = env[IOS_INSTALL_URL_ENV]?.trim() || OFFICIAL_IOS_INSTALL_URL;
+  if (!candidate) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(candidate);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:") return null;
+  if (!IOS_INSTALL_HOSTS.has(parsed.hostname)) return null;
+  return parsed.toString();
+}


### PR DESCRIPTION
Closes #3802 (bead `cave-jr4r.3`, parent O2 `cave-jr4r`).

## What

The Settings → Phone card's **Get the app** group now leads with an install-the-app QR — a phone without the app can't act on the pairing code, so the install code comes before the pairing QR matters in the journey. The group also moved directly under **Pair** (ahead of the write-access / no-password explainers).

## The blocker, honored

The issue is explicitly blocked on product input: **no TestFlight public link exists yet** (O4 / `cave-f1wo` owns producing one), and it instructs *do not invent a URL*. This ships the feature config-gated instead:

- `resolveIosInstallUrl()` (in `src/lib/mobile-handoff.ts`) resolves the link from `OFFICIAL_IOS_INSTALL_URL` — a checked-in constant that is `null` today and becomes a **one-line fill-in** once O4 publishes the link — or the `COVEN_CAVE_IOS_INSTALL_URL` env override for manual builds.
- Validation is strict: https + `testflight.apple.com` / `apps.apple.com` hosts only. Unset, junk, http, or non-Apple values resolve to `null`.
- The route's new `install-info` action (cheap, like `status` — no Tailscale spawn) answers `{ ok, configured:false }` until configured; the card renders **nothing** in that state, so today's UI is unchanged except the group reorder.
- When configured: QR SVG (existing `qrcode` dep, same rendering pattern as the pairing QR) + an *Open install link* button.

The user question was surfaced first per the issue (autopilot: user unavailable) — this config-gated default keeps the O4 dependency a one-liner rather than a UI change.

## Verification

- `node scripts/run-tests.mjs mobile` — 87 files ✓ (includes new resolver matrix + source pins for route action, card render, no-render-when-unconfigured, and group order)
- `node scripts/run-tests.mjs app` — 907 files ✓
- `pnpm typecheck` ✓ · `pnpm lint` ✓ · `pnpm codemod:design:check` ✓
- api lane: `src/app/api/beads/route.test.ts` fails identically on pristine `origin/main` (pre-existing `@/lib` alias resolution, unrelated to this diff)