### PR TITLE
fix(updater): quote MSI log argument once

### DIFF
--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -228,8 +228,13 @@ test("native updater cleanup stops the sidecar before Windows exits", async () =
   );
   assert.match(
     launcher,
-    /installer_args\(\[[\s\S]*OsString::from\("\/L\*V"\)/,
-    "updater-driven MSI installs must retain a verbose per-run diagnostic log",
+    /fn msi_verbose_log_installer_args\([\s\S]*quoted_log_path\.push\(log_path\.as_os_str\(\)\)[\s\S]*OsString::from\("\/L\*V"\)/,
+    "the extracted updater helper must retain a verbose MSI log argument while preserving the native path",
+  );
+  assert.match(
+    launcher,
+    /updater_builder\.installer_args\(msi_verbose_log_installer_args\(&log_path\)\)/,
+    "updater-driven MSI installs must use the verbose per-run diagnostic log helper",
   );
 });
 

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -1,5 +1,78 @@
 use super::*;
 
+/// Builds the verbose MSI log arguments as command-line segments.
+///
+/// `tauri-plugin-updater` joins `installer_args` into the raw parameter
+/// string supplied to `ShellExecuteW`, rather than passing them through a
+/// process argument API. Keep exactly one pair of quotes around the log path
+/// so msiexec receives a single `/L*V` path even when the app log directory
+/// contains spaces.
+#[cfg(any(target_os = "windows", test))]
+fn msi_verbose_log_installer_args(log_path: &std::path::Path) -> [std::ffi::OsString; 2] {
+    let mut quoted_log_path = std::ffi::OsString::from("\"");
+    quoted_log_path.push(log_path.as_os_str());
+    quoted_log_path.push("\"");
+
+    [std::ffi::OsString::from("/L*V"), quoted_log_path]
+}
+
+#[cfg(test)]
+mod updater_argument_tests {
+    use super::msi_verbose_log_installer_args;
+    use std::{ffi::OsStr, path::Path};
+
+    const UPDATER_JOIN_CONTRACT_VERSION: &str = "2.10.1";
+
+    fn locked_updater_package_entry() -> &'static str {
+        let mut entries = include_str!("../Cargo.lock")
+            .split("[[package]]")
+            .filter(|entry| entry.contains("name = \"tauri-plugin-updater\""));
+        let entry = entries
+            .next()
+            .expect("Cargo.lock must contain tauri-plugin-updater");
+        assert!(
+            entries.next().is_none(),
+            "the updater join-contract test must be revisited when multiple updater versions are locked"
+        );
+        entry
+    }
+
+    #[test]
+    fn msi_verbose_log_path_is_quoted_once_in_shell_execute_parameters() {
+        assert!(
+            locked_updater_package_entry().contains(&format!(
+                "version = \"{UPDATER_JOIN_CONTRACT_VERSION}\""
+            )),
+            "tauri-plugin-updater changed; revalidate its MSI ShellExecuteW argument construction before updating this contract"
+        );
+
+        let log_path = Path::new(
+            r"C:\Users\A Coven\AppData\Local\Coven Cave\logs\msi-upgrade-from-0.1.6-123.log",
+        );
+
+        let installer_args = msi_verbose_log_installer_args(log_path);
+        assert_eq!(installer_args[0], OsStr::new("/L*V"));
+        assert_eq!(
+            installer_args[1],
+            OsStr::new(
+                r#""C:\Users\A Coven\AppData\Local\Coven Cave\logs\msi-upgrade-from-0.1.6-123.log""#
+            )
+        );
+
+        // This mirrors tauri-plugin-updater 2.10.1's `ShellExecuteW`
+        // parameter construction. No quotes would split this spaced path, and
+        // a second pair would end quote mode and split it as well.
+        let parameters = installer_args.join(OsStr::new(" "));
+        assert_eq!(
+            parameters,
+            OsStr::new(
+                r#"/L*V "C:\Users\A Coven\AppData\Local\Coven Cave\logs\msi-upgrade-from-0.1.6-123.log""#
+            )
+        );
+        assert_eq!(parameters.to_string_lossy().matches('"').count(), 2);
+    }
+}
+
 /// Show or hide the macOS traffic lights (close/minimize/zoom) on the
 /// invoking window. The main window's title bar is an Overlay (see the main
 /// window builder), so the buttons float over web content — when the app's
@@ -229,10 +302,7 @@ pub fn run() {
                     std::process::id()
                 ));
                 log::info!("[cave] updater MSI log -> {}", log_path.display());
-                updater_builder.installer_args([
-                    std::ffi::OsString::from("/L*V"),
-                    std::ffi::OsString::from(format!("\"{}\"", log_path.display())),
-                ])
+                updater_builder.installer_args(msi_verbose_log_installer_args(&log_path))
             };
             app.handle().plugin(updater_builder.build())?;
             app.handle().plugin(tauri_plugin_process::init())?;


### PR DESCRIPTION
## Summary

- centralize Windows MSI verbose-log argument construction
- preserve exactly one pair of quotes around the log-file path because `tauri-plugin-updater` 2.10.1 joins installer arguments into the raw `ShellExecuteW` parameter string
- add a regression test for a spaced log path that rejects missing or doubled quoting

## Root cause

The updater receives `installer_args` as raw command-line segments, not process arguments. The log path must be quoted once in the final `msiexec` parameter string so `/L*V` treats a path containing spaces as one argument. The previous inline formatting left this dependency contract implicit and untested.

## Validation

- `rustfmt --edition 2021 --check src/tauri_setup.rs`
- `cargo test msi_verbose_log_path_is_quoted_once_in_shell_execute_parameters --lib`
- `cargo check`
- `cargo test --lib` (70 passed)

`cargo fmt --check` still reports pre-existing formatting drift in unrelated Rust files.

## Follow-up

Closes #3811. Tracks bead `cave-u6ps`.

Real Windows hardware update verification remains required before merge: confirm that `msi-upgrade-from-<version>-<pid>.log` is created and contains verbose MSI output during an upgrade.