### PR TITLE
fix(windows): preserve archive on manifest publish failure

### DIFF
--- a/scripts/sidecar-archive-manifest.mjs
+++ b/scripts/sidecar-archive-manifest.mjs
@@ -2,7 +2,7 @@
 import { createHash } from "node:crypto";
 import { once } from "node:events";
 import { createReadStream, createWriteStream } from "node:fs";
-import { lstat, mkdir, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
+import { copyFile, lstat, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import zlib from "node:zlib";
@@ -20,6 +20,8 @@ const TAR_END_BYTES = TAR_BLOCK_BYTES * 2;
 const NORMALIZED_DIRECTORY_MODE = 0o755;
 const NORMALIZED_FILE_MODE = 0o644;
 const COMPLETION_MARKER_PATH = ".complete.json";
+const PUBLICATION_LOCK_WAIT_MS = 30_000;
+const MALFORMED_PUBLICATION_LOCK_STALE_MS = 5_000;
 
 // Windows runners expose different tar implementations over time. Keep this
 // small writer in-process so ordering and metadata are part of our format,
@@ -300,27 +302,256 @@ export async function writeSidecarArchiveManifest(sourceRoot, archivePath, outpu
   return manifest;
 }
 
+async function fileExists(file) {
+  try {
+    await lstat(file);
+    return true;
+  } catch (error) {
+    if (error?.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function removeFileWithRetries(file) {
+  let failure;
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    try {
+      const metadata = await lstat(file).catch((error) => {
+        if (error?.code === "ENOENT") return null;
+        throw error;
+      });
+      if (!metadata) return;
+      if (!metadata.isFile()) {
+        throw new Error(`refusing to remove non-file sidecar publication path: ${file}`);
+      }
+      await rm(file, { force: true });
+      return;
+    } catch (error) {
+      failure = error;
+      if (!["EACCES", "EBUSY", "EPERM"].includes(error?.code) || attempt === 3) break;
+      await new Promise((resolve) => setTimeout(resolve, 100 * (attempt + 1)));
+    }
+  }
+  throw failure;
+}
+
+async function archiveMatchesManifest(archivePath, manifestPath) {
+  try {
+    const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+    return typeof manifest.archiveSha256 === "string"
+      && manifest.archiveSha256 === await sha256File(archivePath);
+  } catch {
+    return false;
+  }
+}
+
+async function recoverPreviousPublication(
+  archivePath,
+  manifestPath,
+  previousArchivePath,
+  previousManifestPath,
+) {
+  const [hasPreviousArchive, hasPreviousManifest] = await Promise.all([
+    fileExists(previousArchivePath),
+    fileExists(previousManifestPath),
+  ]);
+  if (await archiveMatchesManifest(archivePath, manifestPath)) {
+    if (hasPreviousArchive) await removeFileWithRetries(previousArchivePath);
+    if (hasPreviousManifest) await removeFileWithRetries(previousManifestPath);
+    return;
+  }
+
+  if (!hasPreviousArchive) {
+    // A partial rollback may already have restored the archive while its
+    // manifest remains in the private backup. Resume that exact state first.
+    if (hasPreviousManifest && await archiveMatchesManifest(archivePath, previousManifestPath)) {
+      await removeFileWithRetries(manifestPath);
+      await rename(previousManifestPath, manifestPath);
+      return;
+    }
+
+    // A first publication, or an orphaned manifest, has no coherent archive
+    // pair to restore. If the archive reached its public path before the
+    // manifest failed, remove it while preserving the public manifest.
+    if (await fileExists(archivePath)) await removeFileWithRetries(archivePath);
+    if (hasPreviousManifest) await removeFileWithRetries(previousManifestPath);
+    return;
+  }
+
+  // If the old manifest survived a failed final rename, it already matches
+  // the archived prior payload. Restore that archive first; this does not
+  // require deleting a Windows-locked manifest.
+  if (hasPreviousArchive && await archiveMatchesManifest(previousArchivePath, manifestPath)) {
+    await removeFileWithRetries(archivePath);
+    await rename(previousArchivePath, archivePath);
+    if (hasPreviousManifest) await removeFileWithRetries(previousManifestPath);
+    return;
+  }
+
+  // A prior rollback may have restored the archive before it could restore
+  // the manifest. Resume from that state without deleting the restored file.
+  if (hasPreviousManifest && await archiveMatchesManifest(archivePath, previousManifestPath)) {
+    await removeFileWithRetries(manifestPath);
+    await rename(previousManifestPath, manifestPath);
+    return;
+  }
+
+  if (!hasPreviousArchive || !hasPreviousManifest) {
+    throw new Error("sidecar archive recovery is missing one half of its prior publication");
+  }
+
+  // Neither public resource belongs to the prior pair. Remove the candidate
+  // and restore the prior archive before replacing the manifest. If the
+  // manifest has become an unexpected non-file, the old archive is still
+  // preserved and the manifest backup can complete recovery later.
+  await removeFileWithRetries(archivePath);
+  await rename(previousArchivePath, archivePath);
+  await removeFileWithRetries(manifestPath);
+  await rename(previousManifestPath, manifestPath);
+}
+
+async function acquirePublicationLock(archivePath) {
+  const lockPath = `${archivePath}.publish.lock`;
+  const deadline = Date.now() + PUBLICATION_LOCK_WAIT_MS;
+  await mkdir(path.dirname(lockPath), { recursive: true });
+  while (true) {
+    try {
+      const handle = await open(lockPath, "wx");
+      await handle.writeFile(`${process.pid}\n`);
+      return {
+        async release() {
+          await handle.close();
+          await removeFileWithRetries(lockPath);
+        },
+      };
+    } catch (error) {
+      if (error?.code !== "EEXIST" || Date.now() >= deadline) {
+        throw new Error(`sidecar archive publication is already in progress: ${lockPath}`, { cause: error });
+      }
+      try {
+        const owner = Number.parseInt((await readFile(lockPath, "utf8")).trim(), 10);
+        if (Number.isSafeInteger(owner) && owner > 0) {
+          try {
+            process.kill(owner, 0);
+          } catch (ownerError) {
+            if (ownerError?.code === "ESRCH") {
+              await removeFileWithRetries(lockPath);
+              continue;
+            }
+          }
+        } else {
+          const metadata = await stat(lockPath);
+          if (Date.now() - metadata.mtimeMs >= MALFORMED_PUBLICATION_LOCK_STALE_MS) {
+            await removeFileWithRetries(lockPath);
+            continue;
+          }
+        }
+      } catch (lockError) {
+        if (lockError?.code === "ENOENT") continue;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+  }
+}
+
+function publicationFailure(error, failures) {
+  if (failures.length === 0) return error;
+  return new AggregateError(
+    [error, ...failures],
+    `sidecar archive publication failed and recovery is pending: ${error.message}`,
+  );
+}
+
+async function publishSidecarArchiveUnlocked(
+  sourceRoot,
+  temporaryArchivePath,
+  archivePath,
+  manifestPath,
+  temporaryManifestPath = `${manifestPath}.${process.pid}.tmp`,
+  { beforeManifestPublish } = {},
+) {
+  const previousArchivePath = `${archivePath}.previous`;
+  const previousManifestPath = `${manifestPath}.previous`;
+  let manifestPublished = false;
+  try {
+    await recoverPreviousPublication(
+      archivePath,
+      manifestPath,
+      previousArchivePath,
+      previousManifestPath,
+    );
+    const manifest = await writeSidecarArchiveManifest(sourceRoot, temporaryArchivePath, temporaryManifestPath);
+    // Both files are fully written, hashed, and budgeted before either public
+    // path changes. Publish the manifest last so readers never accept a new
+    // archive using stale integrity metadata. Move a coherent prior manifest
+    // out of the public path before the candidate archive is published: a
+    // Windows lock then fails before publication instead of leaving stale
+    // metadata beside a locked candidate. An orphan manifest stays public.
+    const hasPublicArchive = await fileExists(archivePath);
+    if (await fileExists(manifestPath)) {
+      if (hasPublicArchive) {
+        await rename(manifestPath, previousManifestPath);
+      } else {
+        await copyFile(manifestPath, previousManifestPath);
+      }
+    }
+    try {
+      await rename(archivePath, previousArchivePath);
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+    await rename(temporaryArchivePath, archivePath);
+    await beforeManifestPublish?.();
+    await rename(temporaryManifestPath, manifestPath);
+    manifestPublished = true;
+    await removeFileWithRetries(previousArchivePath);
+    await removeFileWithRetries(previousManifestPath);
+    return manifest;
+  } catch (error) {
+    const failures = [];
+    if (!manifestPublished) {
+      try {
+        await recoverPreviousPublication(
+          archivePath,
+          manifestPath,
+          previousArchivePath,
+          previousManifestPath,
+        );
+      } catch (recoveryError) {
+        failures.push(recoveryError);
+      }
+    }
+    for (const temporaryPath of [temporaryArchivePath, temporaryManifestPath]) {
+      try {
+        await removeFileWithRetries(temporaryPath);
+      } catch (cleanupError) {
+        failures.push(cleanupError);
+      }
+    }
+    throw publicationFailure(error, failures);
+  }
+}
+
 export async function publishSidecarArchive(
   sourceRoot,
   temporaryArchivePath,
   archivePath,
   manifestPath,
   temporaryManifestPath = `${manifestPath}.${process.pid}.tmp`,
+  options,
 ) {
+  const lock = await acquirePublicationLock(archivePath);
   try {
-    const manifest = await writeSidecarArchiveManifest(sourceRoot, temporaryArchivePath, temporaryManifestPath);
-    // Both files are fully written, hashed, and budgeted before either public
-    // path changes. Publish the manifest last so readers never accept a new
-    // archive using stale integrity metadata.
-    await rename(temporaryArchivePath, archivePath);
-    await rename(temporaryManifestPath, manifestPath);
-    return manifest;
-  } catch (error) {
-    await Promise.all([
-      rm(temporaryArchivePath, { force: true }),
-      rm(temporaryManifestPath, { force: true }),
-    ]);
-    throw error;
+    return await publishSidecarArchiveUnlocked(
+      sourceRoot,
+      temporaryArchivePath,
+      archivePath,
+      manifestPath,
+      temporaryManifestPath,
+      options,
+    );
+  } finally {
+    await lock.release();
   }
 }
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { access, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, rename, rm, symlink, utimes, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -11,7 +11,7 @@ import {
   SIDECAR_RUNTIME_BUDGETS,
   verifySidecarRuntime,
 } from "./sidecar-runtime-closure.mjs";
-import { publishSidecarArchive } from "./sidecar-archive-manifest.mjs";
+import { publishSidecarArchive, writeSidecarArchiveManifest } from "./sidecar-archive-manifest.mjs";
 
 async function write(root, relativePath, contents = "fixture\n") {
   const output = path.join(root, relativePath);
@@ -175,8 +175,6 @@ try {
   const publishedManifest = path.join(fixture, "published", "manifest.json");
   const interruptedArchive = path.join(fixture, "published", ".server.tar.zst.interrupted.tmp");
   await mkdir(path.dirname(publishedArchive), { recursive: true });
-  await writeFile(publishedArchive, "previous archive\n");
-  await writeFile(publishedManifest, "previous manifest\n");
   await writeFile(interruptedArchive, "candidate archive\n");
   await assert.rejects(
     publishSidecarArchive(
@@ -188,8 +186,8 @@ try {
     /ENOENT/,
     "failed verification must interrupt publication",
   );
-  assert.equal(await readFile(publishedArchive, "utf8"), "previous archive\n");
-  assert.equal(await readFile(publishedManifest, "utf8"), "previous manifest\n");
+  assert.ok(await missing(publishedArchive), "failed first publication must not leave a public archive");
+  assert.ok(await missing(publishedManifest), "failed first publication must not leave a public manifest");
   assert.ok(await missing(interruptedArchive), "failed publication must remove its staged archive");
 
   const verifiedArchive = path.join(fixture, "published", ".server.tar.zst.verified.tmp");
@@ -201,9 +199,197 @@ try {
     publishedManifest,
   );
   const publishedArchiveBytes = await readFile(publishedArchive);
+  const publishedManifestBytes = await readFile(publishedManifest);
   assert.equal(createHash("sha256").update(publishedArchiveBytes).digest("hex"), published.archiveSha256);
   assert.deepEqual(JSON.parse(await readFile(publishedManifest, "utf8")), published);
   assert.ok(await missing(verifiedArchive), "successful publication must consume its staged archive");
+  assert.ok(await missing(`${publishedArchive}.previous`), "successful publication must remove its archive backup");
+  assert.ok(await missing(`${publishedManifest}.previous`), "successful publication must remove its manifest backup");
+
+  await write(projectRoot, "public/sandbox/tailwind.js", "changed runtime\n");
+  const candidateArchive = path.join(fixture, "published", ".server.tar.zst.candidate.tmp");
+  const candidateManifest = path.join(fixture, "published", ".manifest.json.candidate.tmp");
+  await writeSidecarArchiveManifest(path.join(projectRoot, "public"), candidateArchive, candidateManifest);
+  const candidateArchiveBytes = await readFile(candidateArchive);
+  const candidateManifestBytes = await readFile(candidateManifest);
+  assert.notDeepEqual(candidateArchiveBytes, publishedArchiveBytes, "rollback candidate must differ from the prior archive");
+
+  const failedManifestArchive = path.join(fixture, "published", ".server.tar.zst.failed-manifest.tmp");
+  const failedManifestTemp = path.join(fixture, "published", ".manifest.json.failed-manifest.tmp");
+  const failedManifestSentinel = path.join(publishedManifest, "unrelated.txt");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(projectRoot, "public"),
+      failedManifestArchive,
+      publishedArchive,
+      publishedManifest,
+      failedManifestTemp,
+      {
+        beforeManifestPublish: async () => {
+          await rm(publishedManifest, { force: true });
+          await mkdir(publishedManifest);
+          await writeFile(failedManifestSentinel, "must survive rollback\n");
+        },
+      },
+    ),
+    /EISDIR|EPERM|ENOTDIR|EACCES/,
+    "final manifest publication failure must reject",
+  );
+  assert.deepEqual(
+    await readFile(publishedArchive),
+    publishedArchiveBytes,
+    "final failure must restore the prior archive before manifest recovery is pending",
+  );
+  assert.equal(await readFile(failedManifestSentinel, "utf8"), "must survive rollback\n");
+  assert.ok(await missing(failedManifestArchive), "final failure must remove its staged archive");
+  assert.ok(await missing(failedManifestTemp), "final failure must remove its staged manifest");
+  assert.ok(await missing(`${publishedArchive}.previous`), "final failure must consume its restored archive backup");
+  assert.equal(await missing(`${publishedManifest}.previous`), false, "final failure must retain its manifest backup");
+
+  await rm(publishedManifest, { recursive: true });
+  const rollbackArchive = path.join(fixture, "published", ".server.tar.zst.rollback.tmp");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(fixture, "missing-runtime"),
+      rollbackArchive,
+      publishedArchive,
+      publishedManifest,
+    ),
+    /ENOENT/,
+    "the next publication must recover the preserved prior pair",
+  );
+  assert.deepEqual(await readFile(publishedArchive), publishedArchiveBytes, "recovery must restore the prior public archive");
+  assert.deepEqual(await readFile(publishedManifest), publishedManifestBytes, "recovery must restore the prior manifest");
+  assert.ok(await missing(rollbackArchive), "recovery failure must remove its staged archive");
+  assert.ok(await missing(`${publishedArchive}.previous`), "recovery must consume the prior archive backup");
+  assert.ok(await missing(`${publishedManifest}.previous`), "recovery must consume the prior manifest backup");
+
+  const previousArchive = `${publishedArchive}.previous`;
+  const previousManifest = `${publishedManifest}.previous`;
+  await rename(publishedArchive, previousArchive);
+  await writeFile(publishedArchive, candidateArchiveBytes);
+  await writeFile(previousManifest, publishedManifestBytes);
+  await rm(candidateArchive);
+  await rm(candidateManifest);
+
+  const interruptedRollbackArchive = path.join(fixture, "published", ".server.tar.zst.interrupted-rollback.tmp");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(fixture, "missing-runtime"),
+      interruptedRollbackArchive,
+      publishedArchive,
+      publishedManifest,
+    ),
+    /ENOENT/,
+    "recovery must preserve the original publication when the next build fails",
+  );
+  assert.deepEqual(
+    await readFile(publishedArchive),
+    publishedArchiveBytes,
+    "recovery must restore the prior public archive",
+  );
+  assert.deepEqual(await readFile(publishedManifest), publishedManifestBytes, "recovery must restore the prior manifest");
+  assert.ok(await missing(interruptedRollbackArchive), "failed publication must remove its staged archive");
+  assert.ok(await missing(previousArchive), "recovery must consume the prior archive backup");
+  assert.ok(await missing(previousManifest), "recovery must consume the prior manifest backup");
+
+  await writeFile(previousManifest, publishedManifestBytes);
+  await writeFile(publishedManifest, candidateManifestBytes);
+  const partialRestoreArchive = path.join(fixture, "published", ".server.tar.zst.partial-restore.tmp");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(fixture, "missing-runtime"),
+      partialRestoreArchive,
+      publishedArchive,
+      publishedManifest,
+    ),
+    /ENOENT/,
+    "recovery must resume after restoring an archive before its manifest",
+  );
+  assert.deepEqual(await readFile(publishedArchive), publishedArchiveBytes, "partial recovery must retain the restored archive");
+  assert.deepEqual(await readFile(publishedManifest), publishedManifestBytes, "partial recovery must restore its manifest");
+  assert.ok(await missing(previousManifest), "partial recovery must consume the prior manifest backup");
+
+  const noPriorArchive = path.join(fixture, "no-prior", "server.tar.zst");
+  const noPriorManifest = path.join(fixture, "no-prior", "manifest.json");
+  const noPriorTemporaryArchive = path.join(fixture, "no-prior", ".server.tar.zst.tmp");
+  const noPriorTemporaryManifest = path.join(fixture, "no-prior", ".manifest.json.tmp");
+  await mkdir(path.dirname(noPriorArchive), { recursive: true });
+  await writeFile(`${noPriorArchive}.publish.lock`, "999999999\n");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(projectRoot, "public"),
+      noPriorTemporaryArchive,
+      noPriorArchive,
+      noPriorManifest,
+      noPriorTemporaryManifest,
+      {
+        beforeManifestPublish: async () => {
+          await mkdir(noPriorManifest, { recursive: true });
+          await writeFile(path.join(noPriorManifest, "unrelated.txt"), "must survive first publish failure\n");
+        },
+      },
+    ),
+    /EISDIR|EPERM|ENOTDIR|EACCES/,
+    "a no-prior publication failure must reject",
+  );
+  assert.ok(await missing(noPriorArchive), "a no-prior failure must not leave a public archive");
+  assert.ok(await missing(noPriorTemporaryArchive), "a no-prior failure must remove its staged archive");
+  assert.ok(await missing(noPriorTemporaryManifest), "a no-prior failure must remove its staged manifest");
+  assert.equal(
+    await readFile(path.join(noPriorManifest, "unrelated.txt"), "utf8"),
+    "must survive first publish failure\n",
+  );
+  assert.ok(await missing(`${noPriorArchive}.publish.lock`), "a stale publication lock must be reclaimed");
+
+  const malformedLockArchive = path.join(fixture, "malformed-lock", "server.tar.zst");
+  const malformedLockManifest = path.join(fixture, "malformed-lock", "manifest.json");
+  const malformedLockTemporaryArchive = path.join(fixture, "malformed-lock", ".server.tar.zst.tmp");
+  const malformedLockPath = `${malformedLockArchive}.publish.lock`;
+  await mkdir(path.dirname(malformedLockArchive), { recursive: true });
+  await writeFile(malformedLockPath, "");
+  await utimes(malformedLockPath, 1, 1);
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(fixture, "missing-runtime"),
+      malformedLockTemporaryArchive,
+      malformedLockArchive,
+      malformedLockManifest,
+    ),
+    /ENOENT/,
+    "a malformed stale publication lock must not block recovery",
+  );
+  assert.ok(await missing(malformedLockPath), "a malformed stale publication lock must be reclaimed");
+
+  const orphanArchive = path.join(fixture, "orphan", "server.tar.zst");
+  const orphanManifest = path.join(fixture, "orphan", "manifest.json");
+  const orphanTemporaryArchive = path.join(fixture, "orphan", ".server.tar.zst.tmp");
+  const orphanTemporaryManifest = path.join(fixture, "orphan", ".manifest.json.tmp");
+  await mkdir(path.dirname(orphanArchive), { recursive: true });
+  await writeFile(orphanManifest, "stale manifest\n");
+  await assert.rejects(
+    publishSidecarArchive(
+      path.join(projectRoot, "public"),
+      orphanTemporaryArchive,
+      orphanArchive,
+      orphanManifest,
+      orphanTemporaryManifest,
+      {
+        beforeManifestPublish: async () => {
+          const error = new Error("EPERM: injected final manifest rename failure");
+          error.code = "EPERM";
+          throw error;
+        },
+      },
+    ),
+    /EPERM/,
+    "an orphaned manifest publication failure must reject",
+  );
+  assert.ok(await missing(orphanArchive), "an orphaned manifest must not retain the candidate archive");
+  assert.equal(await readFile(orphanManifest, "utf8"), "stale manifest\n");
+  assert.ok(await missing(`${orphanManifest}.previous`), "orphan recovery must remove its private manifest copy");
+  assert.ok(await missing(orphanTemporaryArchive), "orphan recovery must remove its staged archive");
+  assert.ok(await missing(orphanTemporaryManifest), "orphan recovery must remove its staged manifest");
 
   await writeFile(tracePath, `${JSON.stringify({ version: 1, files: ["../../../outside.txt"] })}\n`, "utf8");
   await assert.rejects(


### PR DESCRIPTION
## Summary

- preserve the previously published sidecar archive until the schema-3 manifest has been successfully published
- restore the prior archive when final manifest publication fails, preventing a mismatched archive/manifest pair
- add a regression test for the failed final rename path

Fixes #3806

## Verification

- `pnpm exec node --test scripts/sidecar-archive-manifest.test.mjs scripts/sidecar-bundle-deps.test.mjs scripts/sidecar-runtime-closure.test.mjs`
- `cargo test --manifest-path src-tauri/Cargo.toml --locked --lib`
- `pnpm lint`
- `git diff --check`