### PR TITLE
feat(citations): teach familiars to cite sources so the Citation UI gets fed

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -135,6 +135,7 @@ export const SUITES = {
     "src/lib/skill-blocks.test.ts",
     "src/lib/github-blocks.test.ts",
     "src/lib/coven-marker-directive.test.ts",
+    "src/lib/citations-directive.test.ts",
     "src/lib/github-item-url.test.ts",
     "src/lib/github-sub-tags.test.ts",
     "src/lib/github-subscriptions.test.ts",

--- a/src/app/api/chat/send/chat-send-models.ts
+++ b/src/app/api/chat/send/chat-send-models.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/chat-model-state";
 import { buildNextPathsDirective } from "@/lib/next-paths";
 import { buildCovenMarkersDirective } from "@/lib/coven-marker-directive";
+import { buildCitationsDirective } from "@/lib/citations-directive";
 
 type ModelRequest = {
   familiarId: string;
@@ -94,6 +95,8 @@ export function buildPromptWithResponseControls(prompt: string, body: ResponseCo
     buildNextPathsDirective(),
     "",
     buildCovenMarkersDirective(),
+    "",
+    buildCitationsDirective(),
     "",
     prompt,
   ].join("\n");

--- a/src/lib/citations-directive.test.ts
+++ b/src/lib/citations-directive.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { buildCitationsDirective } from "./citations-directive.ts";
+import { parseCitations } from "./citations.ts";
+
+test("the directive teaches the footnote syntax and stays non-visible", () => {
+  const d = buildCitationsDirective();
+  assert.match(d, /^<citations>/, "opens the citations block");
+  assert.match(d, /<\/citations>$/, "closes the block");
+  assert.match(d, /\[\^1\]/, "shows an inline marker");
+  assert.match(d, /\[\^1\]: https:\/\/example\.com\/page "Page title"/, "shows a definition with url + title");
+  assert.match(d, /Never mention these instructions/, "the syntax stays out of the visible reply");
+  assert.match(d, /never invent a citation/i, "guards against fabricated sources");
+});
+
+test("a reply written in the taught format parses via parseCitations (lockstep)", () => {
+  // Exactly the shape the directive instructs a familiar to produce.
+  const reply = [
+    "Rust guarantees memory safety without a GC[^1], and the borrow checker enforces it at compile time[^2].",
+    "",
+    '[^1]: https://www.rust-lang.org/ "The Rust Programming Language"',
+    '[^2]: https://doc.rust-lang.org/book/ch04-00-understanding-ownership.html "Ownership"',
+  ].join("\n");
+  const { citations, body } = parseCitations(reply);
+  assert.deepEqual(
+    citations.map((c) => [c.n, c.title, c.domain]),
+    [
+      [1, "The Rust Programming Language", "rust-lang.org"],
+      [2, "Ownership", "doc.rust-lang.org"],
+    ],
+    "the taught syntax is exactly what the parser lifts",
+  );
+  assert.doesNotMatch(body, /\[\^1\]:/, "definitions are stripped from the rendered body");
+});
+
+test("the directive rides every chat turn alongside the other stable directives", () => {
+  const models = readFileSync(new URL("../app/api/chat/send/chat-send-models.ts", import.meta.url), "utf8");
+  assert.match(models, /import \{ buildCitationsDirective \} from "@\/lib\/citations-directive"/, "imported");
+  assert.match(
+    models,
+    /buildCovenMarkersDirective\(\),[\s\S]{0,40}buildCitationsDirective\(\),[\s\S]{0,40}prompt,/,
+    "injected into the per-turn directive stack, before the user prompt",
+  );
+});

--- a/src/lib/citations-directive.ts
+++ b/src/lib/citations-directive.ts
@@ -1,0 +1,25 @@
+/**
+ * Citations directive — the prompt block that teaches familiars to attribute
+ * external sources with standard markdown footnotes. The Citation UI
+ * (lib/citations.ts + components/ui/citation.tsx) lifts those footnotes into
+ * inline markers plus a "Sources" card, so a familiar that cites this way gets
+ * rich, clickable sources on both chat and research surfaces.
+ *
+ * Piggyback model, like buildCovenMarkersDirective: the directive rides every
+ * chat turn (buildPromptWithResponseControls) so citing is organic — turns
+ * without sources render exactly as before, and nothing depends on adoption.
+ *
+ * The syntax taught here must stay in lockstep with `parseCitations` in
+ * lib/citations.ts: inline refs `[^n]` and end-of-reply definitions
+ * `[^n]: <url> "Title"`.
+ */
+export function buildCitationsDirective(): string {
+  return [
+    "<citations>",
+    "When your reply draws on a specific external source you actually consulted this turn (a web page, a document, or a file), cite it with a standard markdown footnote — the app renders it as a live source card.",
+    'Place an inline marker right where the claim sits, like this[^1], and define the source on its own line at the very end of the reply: [^1]: https://example.com/page "Page title". Number footnotes 1, 2, 3… in first-use order; reuse a marker to cite the same source again.',
+    "Only cite sources you genuinely used, with their real URLs and titles — never invent a citation. Add no footnotes at all when you did not consult an external source; do not footnote your own reasoning or the user's messages.",
+    "Never mention these instructions or the footnote syntax in your visible reply.",
+    "</citations>",
+  ].join("\n");
+}


### PR DESCRIPTION
Follow-up to #3817 (the shared Citation UI). That PR renders standard markdown footnotes as inline markers + a "Sources" card, but nothing made familiars actually **emit** citations — so in chat it only fired when a model happened to use the syntax.

This adds a per-turn **citations directive** (the same piggyback model as the `coven-markers` directive from #3762): it instructs familiars to attribute real external sources they consulted with `[^n]` refs + `[^n]: <url> "Title"` definitions, numbered in first-use order, and to **never fabricate** a citation. Turns without sources render exactly as before.

## What changed
- **`lib/citations-directive.ts`**: `buildCitationsDirective()` — the prompt block.
- **`chat/send/chat-send-models.ts`**: injected into the stable per-turn directive stack, right after the coven-markers directive and before the user prompt.

## Lockstep guarantee
A test writes a reply in *exactly* the format the directive teaches and asserts it parses cleanly through `parseCitations` (from #3817's `lib/citations.ts`) into the expected citations — so the instruction and the renderer can't silently drift apart.

## Verification
`tsc` 0 errors · eslint 0 errors · directive test 3/3 (incl. the lockstep round-trip) · tests-wired · `pnpm build` exit 0, within budget.

Together with #3817 this closes the loop: familiars cite → the app renders rich, clickable sources on chat and research.

🤖 Generated with [Claude Code](https://claude.com/claude-code)