### PR TITLE
test(mobile): make the install-QR group-order pin actually enforce adjacency (cave-jc3l)

### DIFF
--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -392,8 +392,17 @@ assert.match(
   /<SettingsGroup label="Get the app">\s*<IosInstallQrCard \/>/,
   "the install QR leads the Get-the-app group",
 );
+// Tempered scans: the window between the named groups may contain anything
+// EXCEPT another group opening, so an interposed group fails the pin (a
+// plain `[\s\S]{0,N}` window matched any group's closing tag and let
+// backtracking absorb an injected group — review follow-up, cave-jc3l).
 assert.match(
   settings,
-  /<\/SettingsGroup>\s*<SettingsGroup label="Get the app">[\s\S]{0,900}<SettingsGroup label="Phone write access">/,
-  "Get the app sits directly after Pair — install comes before the deep supporting groups",
+  /<SettingsGroup label="Pair">(?:(?!<SettingsGroup )[\s\S])*<\/SettingsGroup>\s*<SettingsGroup label="Get the app">/,
+  "Get the app sits directly after Pair — no group can slip between them",
+);
+assert.match(
+  settings,
+  /<SettingsGroup label="Get the app">(?:(?!<SettingsGroup )[\s\S])*<\/SettingsGroup>\s*<SettingsGroup label="Phone write access">/,
+  "install comes before the deep supporting groups — Phone write access directly follows Get the app",
 );


### PR DESCRIPTION
Review follow-up to #3818 (bead `cave-jc3l`). Test-only.

## Problem

The group-order pin in `src/components/mobile-handoff.test.ts` claimed *Get the app sits directly after Pair*, but its regex `/<\/SettingsGroup>\s*<SettingsGroup label="Get the app">[\s\S]{0,900}…/` matched **any** group's closing tag — backtracking absorbs an injected group between Pair and Get-the-app, so the invariant it was written to protect was unenforced. In a repo whose regression net is source pins, that's a silent hole.

## Fix

Two tempered-scan pins: the window between the named groups may contain anything **except another `<SettingsGroup ` opening**. Also drops the brittle 900-char width limit (the gap was already at 662/900, so ordinary growth of the group would have tripped a false failure before any real reorder did).

## Mutation-verified

- Inject `<SettingsGroup label="Injected">…` between Pair and Get-the-app → **pin 1 fails** (old regex provably kept passing)
- Move Get-the-app after Phone write access → **both pins fail**
- Clean source → both pass

`node scripts/run-tests.mjs mobile` — 87 files ✓