### PR TITLE
Keep macOS desktop reachable for paired phones

### DIFF
--- a/docs/ios-connection-cloud-plan.md
+++ b/docs/ios-connection-cloud-plan.md
@@ -189,10 +189,12 @@ appears only once the turn *ends*). Buffer stream events per run server-side
 the LIVE run. Re-attach cancels the detach kill (PTY `adoptSession` pattern).
 
 **Phase C3 — keep the desktop reachable.** Prevent-sleep power assertion
-while phones are paired (toggle; wake-on-LAN is NOT feasible over Tailscale —
-document it); optional LaunchAgent daemon mode so the server outlives the app
-(`uninstall-app.sh` already defensively removes the plist path); serve/port
-self-repair on port fallback.
+while phones are paired (opt-in, default off; AC-only by default); optional,
+default-off LaunchAgent daemon mode so the server outlives the app
+(`uninstall-app.sh` unloads the agent before removing its paths); serve/port
+self-repair on port fallback. Wake-on-LAN is NOT feasible over Tailscale:
+the userspace WireGuard daemon sleeps with the Mac, while Bonjour sleep proxy
+is limited to local-network mDNS.
 
 **Phase C4 — background reachability (product call first).** Real background
 push requires APNs — a vendor-cloud departure. Everything through C3 is

--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -57,6 +57,31 @@ The app stores the invite in an HTTP-only cookie after the first successful requ
 
 In the packaged desktop app, click **Open on phone** in the top bar to create the same kind of invite as a QR code. Scan it from a phone signed into the same tailnet.
 
+## Keep the Mac reachable
+
+The packaged macOS app has two explicit, default-off controls under **Settings
+→ Phone → Keep this Mac reachable**:
+
+- **Keep Mac awake for phone** holds a macOS power assertion after a phone has
+  paired. **Only keep awake on power** is on by default, so battery power keeps
+  the Mac's normal sleep policy. Turning either setting off releases the
+  assertion.
+- **Background availability** installs a per-user LaunchAgent. The GUI owns the
+  loopback server while its main window is open; after that window closes, the
+  LaunchAgent starts the bundled `server.mjs` without opening the app. Disabling
+  the option unloads and removes the LaunchAgent.
+
+Both the GUI server and the LaunchAgent server remain bound to
+`127.0.0.1`. Whenever either server chooses a different port, it repoints
+Tailscale Serve at that exact loopback backend. Existing signed phone tokens
+continue to use the same persisted mobile access secret.
+
+Tailscale cannot wake a sleeping Mac. Its userspace WireGuard daemon sleeps
+with the computer, so the phone has no path to deliver a wake packet. Bonjour
+sleep proxy is limited to local-network mDNS and does not make wake-on-LAN work
+across a tailnet. Use the keep-awake option or an always-on Server Hub when the
+phone must remain reachable.
+
 ## Connect Cave to a remote Server Hub
 
 Open **Settings → Daemon → Connection**, choose **Server hub**, and use the **Tailnet devices** list to select the machine running the remote Coven daemon. Cave discovers this device and online peers from `tailscale status --json`; it uses the device's `100.x` address when available and fills the standard daemon port, `8787`. The current machine is labelled **This device**. You can still enter a MagicDNS name or another private HTTP URL manually.

--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -108,6 +108,9 @@ try {
 
   // Persistent Windows EPERM while publishing candidate directories must stop
   // at the documented deadline and remove every contender-owned candidate.
+  // GitHub's Windows filesystem can consume most of a 150ms deadline in the
+  // first directory operation, before the retry loop gets a second turn.
+  const retryTimeoutMs = 500;
   const candidateFailureHome = path.join(root, "candidate-eperm", ".coven");
   process.env.COVEN_HOME = candidateFailureHome;
   const candidateFailureCave = path.join(candidateFailureHome, "cave");
@@ -122,7 +125,7 @@ try {
     throw error;
   };
   await assert.rejects(
-    migrateCaveHome({ lockTimeoutMs: 150, lockCandidateRename: persistentEperm }),
+    migrateCaveHome({ lockTimeoutMs: retryTimeoutMs, lockCandidateRename: persistentEperm }),
     (error) => error?.code === "ETIMEDOUT",
   );
   assert.ok(candidateAttempts >= 2);
@@ -147,7 +150,7 @@ try {
   let reclaimAttempts = 0;
   await assert.rejects(
     migrateCaveHome({
-      lockTimeoutMs: 150,
+      lockTimeoutMs: retryTimeoutMs,
       lockFenceRename: async () => {
         reclaimAttempts += 1;
         const error = new Error("injected persistent Windows reclaim EPERM") as NodeJS.ErrnoException;

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (relative) => readFile(new URL(relative, import.meta.url), "utf8");
+
+const [
+  reachability,
+  setup,
+  startup,
+  lifecycle,
+  settings,
+  bridge,
+  mobileScript,
+  uninstall,
+  docs,
+] = await Promise.all([
+  read("../src-tauri/src/desktop_reachability.rs"),
+  read("../src-tauri/src/tauri_setup.rs"),
+  read("../src-tauri/src/sidecar_startup.rs"),
+  read("../src-tauri/src/sidecar_lifecycle.rs"),
+  read("../src/components/settings-shell.tsx"),
+  read("../src/lib/desktop-reachability.ts"),
+  read("./mobile-tailscale.sh"),
+  read("./uninstall-app.sh"),
+  read("../docs/mobile-tailscale.md"),
+]);
+
+assert.match(
+  reachability,
+  /prevent_sleep: false,[\s\S]*prevent_sleep_on_ac_only: true,[\s\S]*daemon_mode: false/,
+  "reachability features must remain opt-in while AC-only is the prepared sleep policy",
+);
+assert.match(
+  reachability,
+  /if on_ac_only \{ "-s" \} else \{ "-i" \}[\s\S]*"-w"/,
+  "caffeinate must use an AC-only system assertion by default and bind it to the server pid",
+);
+assert.match(
+  reachability,
+  /paired_phone_seen\(paired_path\)/,
+  "prevent-sleep must be gated on evidence that a phone paired",
+);
+
+assert.match(
+  reachability,
+  /<string>--cave-sidecar-daemon<\/string>[\s\S]*<key>StartInterval<\/key>[\s\S]*<key>SuccessfulExit<\/key>/,
+  "the LaunchAgent must run the dedicated background entrypoint and recover after crashes",
+);
+assert.match(
+  reachability,
+  /\.env\("HOSTNAME", "127\.0\.0\.1"\)/,
+  "the background server must stay loopback-only",
+);
+assert.match(
+  reachability,
+  /load_or_create_mobile_access_token/,
+  "the background server must reuse the persisted mobile access secret",
+);
+assert.match(
+  setup,
+  /run_sidecar_daemon_if_requested\(\)[\s\S]*tauri::Builder::default/,
+  "the background entrypoint must exit before constructing a GUI",
+);
+assert.match(
+  setup,
+  /state\.stop\(\)[\s\S]*sidecar_reachability_stopped[\s\S]*handoff_to_background_daemon/,
+  "window teardown must stop the owned sidecar and its assertion before handing off to launchd",
+);
+assert.match(
+  lifecycle,
+  /pub\(super\) fn id\(&self\) -> u32/,
+  "power assertions must bind to the exact owned sidecar process",
+);
+
+assert.match(
+  startup,
+  /wait_for_sidecar_ready[\s\S]*sidecar_reachability_ready\(app, port, sidecar_pid\)/,
+  "Serve repair and the power monitor must start only after the selected port is ready",
+);
+assert.match(
+  reachability,
+  /format!\("http:\/\/127\.0\.0\.1:\{port\}"\)/,
+  "Serve repair must use the actual selected loopback port",
+);
+assert.match(
+  mobileScript,
+  /exec env PORT="\$free" bash "\$SELF" "\$COMMAND"/,
+  "the dev mobile runner must carry its fallback port into Serve setup",
+);
+
+assert.match(settings, /label="Keep Mac awake for phone"/);
+assert.match(settings, /label="Only keep awake on power"/);
+assert.match(settings, /label="Background availability"/);
+assert.match(
+  bridge,
+  /desktop_reachability_configure/,
+  "the Settings controls must persist through the native macOS authority",
+);
+
+const unload = uninstall.indexOf('forget_launch_agent "$APP_ID"');
+const removeApp = uninstall.indexOf('remove_path "$app_path"');
+assert.ok(unload !== -1 && removeApp !== -1 && unload < removeApp, "uninstall must unload launchd before removing the app");
+assert.match(
+  docs,
+  /Tailscale cannot wake a sleeping Mac[\s\S]*Bonjour\s+sleep proxy is limited to local-network mDNS/,
+  "mobile documentation must state the wake-on-LAN limitation honestly",
+);
+
+console.log("desktop-reachability.test.mjs: ok");

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -43,8 +43,28 @@ assert.match(
 
 assert.match(
   reachability,
-  /<string>--cave-sidecar-daemon<\/string>[\s\S]*<key>StartInterval<\/key>[\s\S]*<key>SuccessfulExit<\/key>/,
-  "the LaunchAgent must run the dedicated background entrypoint and recover after crashes",
+  /<string>--cave-sidecar-daemon<\/string>[\s\S]*<key>SuccessfulExit<\/key>[\s\S]*<key>AbandonProcessGroup<\/key>[\s\S]*<false\/>/,
+  "the LaunchAgent must retain its process group and recover after crashes without periodic GUI churn",
+);
+assert.match(
+  reachability,
+  /create_fresh_log_file[\s\S]*\.truncate\(true\)/,
+  "each daemon launch must discard stale readiness output before repairing Serve",
+);
+assert.match(
+  reachability,
+  /stop_recorded_daemon_sidecar\(app_data_dir\)\?;[\s\S]*bootout_launch_agent\(\)\?;/,
+  "daemon sidecars must be stopped before their LaunchAgent is unloaded",
+);
+assert.match(
+  reachability,
+  /process_identity[\s\S]*lease_matches/,
+  "GUI and daemon ownership markers must validate process identity as well as PID",
+);
+assert.match(
+  reachability,
+  /owned_sidecar_is_live[\s\S]*is_live_with_pid/,
+  "sleep assertions must require a live, retained sidecar process",
 );
 assert.match(
   reachability,
@@ -91,6 +111,7 @@ assert.match(
 assert.match(settings, /label="Keep Mac awake for phone"/);
 assert.match(settings, /label="Only keep awake on power"/);
 assert.match(settings, /label="Background availability"/);
+assert.match(settings, /aria-label=\{[\s\S]*Keep Mac awake for phone/);
 assert.match(
   bridge,
   /desktop_reachability_configure/,
@@ -100,6 +121,11 @@ assert.match(
 const unload = uninstall.indexOf('forget_launch_agent "$APP_ID"');
 const removeApp = uninstall.indexOf('remove_path "$app_path"');
 assert.ok(unload !== -1 && removeApp !== -1 && unload < removeApp, "uninstall must unload launchd before removing the app");
+assert.match(
+  uninstall,
+  /stop_recorded_reachability_sidecar "\$home"\r?\n\s*forget_launch_agent "\$APP_ID"/,
+  "uninstall must terminate the recorded reachability sidecar before unloading launchd",
+);
 assert.match(
   docs,
   /Tailscale cannot wake a sleeping Mac[\s\S]*Bonjour\s+sleep proxy is limited to local-network mDNS/,

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -63,6 +63,16 @@ assert.match(
 );
 assert.match(
   reachability,
+  /background_availability_supported[\s\S]*suspend_background_launch_agent[\s\S]*preserving its saved setting/,
+  "development builds must preserve daemon mode without trying to install a LaunchAgent",
+);
+assert.match(
+  reachability,
+  /let identity = match process_identity\(child_pid\)[\s\S]*child\.kill\(\)[\s\S]*child\.wait\(\)/,
+  "daemon startup must reap a child when its process lease cannot be captured",
+);
+assert.match(
+  reachability,
   /process_identity[\s\S]*lease_matches/,
   "GUI and daemon ownership markers must validate process identity as well as PID",
 );
@@ -88,8 +98,8 @@ assert.match(
 );
 assert.match(
   setup,
-  /state\.stop\(\)[\s\S]*sidecar_reachability_stopped[\s\S]*handoff_to_background_daemon/,
-  "window teardown must stop the owned sidecar and its assertion before handing off to launchd",
+  /sidecar_stopped[\s\S]*state\.stop\(\)[\s\S]*if sidecar_stopped \{[\s\S]*sidecar_reachability_stopped[\s\S]*handoff_to_background_daemon/,
+  "window teardown must hand off to launchd only after stopping the owned sidecar",
 );
 assert.match(
   lifecycle,

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -78,6 +78,16 @@ assert.match(
 );
 assert.match(
   reachability,
+  /acquire_reachability_ownership_lease[\s\S]*file\.lock_exclusive\(\)/,
+  "GUI and daemon ownership must serialize through an exclusive lease",
+);
+assert.match(
+  reachability,
+  /let ownership = acquire_reachability_ownership_lease\(&app_data_dir\)\?[\s\S]*gui_is_active\(&app_data_dir\)[\s\S]*let mut child[\s\S]*write_private_json\(&state_path, &state\)[\s\S]*drop\(ownership\)/,
+  "a daemon must recheck GUI ownership and persist its child before releasing the handoff lease",
+);
+assert.match(
+  reachability,
   /owned_sidecar_is_live[\s\S]*is_live_with_pid/,
   "sleep assertions must require a live, retained sidecar process",
 );
@@ -135,6 +145,11 @@ assert.match(
   bridge,
   /desktop_reachability_configure/,
   "the Settings controls must persist through the native macOS authority",
+);
+assert.match(
+  bridge,
+  /!\("__TAURI_INTERNALS__" in window\)/,
+  "the Tauri runtime guard must remain type-safe in browser builds",
 );
 
 const unload = uninstall.indexOf('forget_launch_agent "$APP_ID"');

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -40,6 +40,11 @@ assert.match(
   /paired_phone_seen\(paired_path\)/,
   "prevent-sleep must be gated on evidence that a phone paired",
 );
+assert.match(
+  reachability,
+  /mobile_mode_enabled_from_preferences[\s\S]*unwrap_or\(true\)/,
+  "mobile mode must preserve its schema default until explicitly disabled",
+);
 
 assert.match(
   reachability,
@@ -130,6 +135,11 @@ assert.match(
   reachability,
   /format!\("http:\/\/127\.0\.0\.1:\{port\}"\)/,
   "Serve repair must use the actual selected loopback port",
+);
+assert.match(
+  reachability,
+  /serve_mode_from_status[\s\S]*TailscaleServeMode::Http[\s\S]*http_serve_arguments\(port, http_port\)/,
+  "Serve repair must preserve an active HTTP fallback while updating its loopback backend",
 );
 assert.match(
   reachability,

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -142,8 +142,13 @@ const removeApp = uninstall.indexOf('remove_path "$app_path"');
 assert.ok(unload !== -1 && removeApp !== -1 && unload < removeApp, "uninstall must unload launchd before removing the app");
 assert.match(
   uninstall,
-  /stop_recorded_reachability_sidecar "\$home"\r?\n\s*forget_launch_agent "\$APP_ID"/,
-  "uninstall must terminate the recorded reachability sidecar before unloading launchd",
+  /forget_launch_agent "\$APP_ID" "\$\{home\}\/Library\/LaunchAgents\/\$\{APP_ID\}\.plist"\r?\n\s*stop_recorded_reachability_sidecar "\$home"/,
+  "uninstall must unload launchd before terminating and waiting for the recorded sidecar",
+);
+assert.match(
+  uninstall,
+  /for \(\(attempt = 0; attempt < 50; attempt \+= 1\)\)[\s\S]*kill -KILL/,
+  "uninstall must wait for the sidecar after launchd is unloaded before removing app paths",
 );
 assert.match(
   docs,

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -58,6 +58,11 @@ assert.match(
 );
 assert.match(
   reachability,
+  /install_daemon_shutdown_handler[\s\S]*DAEMON_SHUTDOWN_REQUESTED[\s\S]*stop_daemon_children/,
+  "a launchd SIGTERM must make the daemon synchronously reap its sidecar and assertion",
+);
+assert.match(
+  reachability,
   /process_identity[\s\S]*lease_matches/,
   "GUI and daemon ownership markers must validate process identity as well as PID",
 );

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -96,6 +96,10 @@ assert.match(
   /run_sidecar_daemon_if_requested\(\)[\s\S]*tauri::Builder::default/,
   "the background entrypoint must exit before constructing a GUI",
 );
+assert.ok(
+  setup.indexOf("check_app_translocation();") < setup.indexOf("prepare_gui_reachability(app.handle())?;"),
+  "AppTranslocation must be rejected before reachability can install a LaunchAgent",
+);
 assert.match(
   setup,
   /sidecar_stopped[\s\S]*state\.stop\(\)[\s\S]*if sidecar_stopped \{[\s\S]*sidecar_reachability_stopped[\s\S]*handoff_to_background_daemon/,

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -166,6 +166,11 @@ assert.match(
   "uninstall must wait for the sidecar after launchd is unloaded before removing app paths",
 );
 assert.match(
+  uninstall,
+  /"identity"[\s\S]*ps -p "\$sidecar_pid" -o lstart= -o comm=[\s\S]*current_identity" == "\$sidecar_identity"/,
+  "uninstall must validate the recorded process identity before signalling a sidecar PID",
+);
+assert.match(
   docs,
   /Tailscale cannot wake a sleeping Mac[\s\S]*Bonjour\s+sleep proxy is limited to local-network mDNS/,
   "mobile documentation must state the wake-on-LAN limitation honestly",

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -132,6 +132,16 @@ assert.match(
   "Serve repair must use the actual selected loopback port",
 );
 assert.match(
+  reachability,
+  /SERVE_REPAIR_STATE[\s\S]*pending_port[\s\S]*thread::spawn\(run_queued_tailscale_serve_repairs\)/,
+  "Serve repairs must coalesce through one worker instead of spawning indefinitely",
+);
+assert.match(
+  reachability,
+  /SERVE_REPAIR_TIMEOUT[\s\S]*child\.try_wait\(\)[\s\S]*child\.kill\(\)[\s\S]*timed out/,
+  "a stalled Tailscale Serve command must be killed after a bounded timeout",
+);
+assert.match(
   mobileScript,
   /exec env PORT="\$free" bash "\$SELF" "\$COMMAND"/,
   "the dev mobile runner must carry its fallback port into Serve setup",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -947,6 +947,7 @@ export const SUITES = {
     "scripts/git-hooks-pre-commit.test.mjs",
     "scripts/secret-preflight.test.mjs",
     "scripts/uninstall-app.test.mjs",
+    "scripts/desktop-reachability.test.mjs",
     "scripts/beads-familiar-workflow.test.mjs",
     "scripts/beads-pr-bridge.test.mjs",
     "scripts/beads-pr-patrol.test.mjs",

--- a/scripts/uninstall-app.sh
+++ b/scripts/uninstall-app.sh
@@ -184,6 +184,25 @@ forget_launch_agent() {
   remove_path "$plist"
 }
 
+stop_recorded_reachability_sidecar() {
+  local home="$1"
+  local state_path="${home}/Library/Application Support/${APP_ID}/desktop-daemon-state.json"
+  [[ -f "$state_path" ]] || return 0
+
+  # The state file is private app data. Still require a numeric PID and the
+  # packaged server entrypoint before signalling anything, so a stale PID can
+  # never target an unrelated user process during uninstall.
+  local sidecar_pid
+  sidecar_pid="$(sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$state_path" | head -n 1)"
+  [[ "$sidecar_pid" =~ ^[0-9]+$ ]] || return 0
+  local command_line
+  command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
+  [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+
+  log "Stopping recorded background CovenCave sidecar ${sidecar_pid} before unloading launchd..."
+  run kill -TERM "$sidecar_pid" || true
+}
+
 remove_macos_artifacts() {
   local home="$HOME"
   log "Uninstalling macOS CovenCave artifacts..."
@@ -191,6 +210,7 @@ remove_macos_artifacts() {
   # Stop background availability before removing its executable, runtime
   # state, or logs. Otherwise launchd can restart the sidecar while uninstall
   # is tearing those paths down.
+  stop_recorded_reachability_sidecar "$home"
   forget_launch_agent "$APP_ID" "${home}/Library/LaunchAgents/${APP_ID}.plist"
   forget_launch_agent "$LEGACY_APP_ID" "${home}/Library/LaunchAgents/${LEGACY_APP_ID}.plist"
   forget_launch_agent "com.opencoven.CovenCave" "${home}/Library/LaunchAgents/com.opencoven.CovenCave.plist"

--- a/scripts/uninstall-app.sh
+++ b/scripts/uninstall-app.sh
@@ -188,6 +188,13 @@ remove_macos_artifacts() {
   local home="$HOME"
   log "Uninstalling macOS CovenCave artifacts..."
 
+  # Stop background availability before removing its executable, runtime
+  # state, or logs. Otherwise launchd can restart the sidecar while uninstall
+  # is tearing those paths down.
+  forget_launch_agent "$APP_ID" "${home}/Library/LaunchAgents/${APP_ID}.plist"
+  forget_launch_agent "$LEGACY_APP_ID" "${home}/Library/LaunchAgents/${LEGACY_APP_ID}.plist"
+  forget_launch_agent "com.opencoven.CovenCave" "${home}/Library/LaunchAgents/com.opencoven.CovenCave.plist"
+
   local app_paths="${COVEN_CAVE_UNINSTALL_APP_PATHS:-/Applications/${APP_NAME}.app:${home}/Applications/${APP_NAME}.app}"
   local app_path
   while IFS= read -r app_path; do
@@ -205,9 +212,6 @@ remove_macos_artifacts() {
   remove_path "${home}/Library/Preferences/${LEGACY_APP_ID}.plist"
   remove_path "${home}/Library/Logs/${APP_NAME}"
 
-  forget_launch_agent "$APP_ID" "${home}/Library/LaunchAgents/${APP_ID}.plist"
-  forget_launch_agent "$LEGACY_APP_ID" "${home}/Library/LaunchAgents/${LEGACY_APP_ID}.plist"
-  forget_launch_agent "com.opencoven.CovenCave" "${home}/Library/LaunchAgents/com.opencoven.CovenCave.plist"
 }
 
 remove_linux_artifacts() {

--- a/scripts/uninstall-app.sh
+++ b/scripts/uninstall-app.sh
@@ -189,9 +189,9 @@ stop_recorded_reachability_sidecar() {
   local state_path="${home}/Library/Application Support/${APP_ID}/desktop-daemon-state.json"
   [[ -f "$state_path" ]] || return 0
 
-  # The state file is private app data. Still require a numeric PID and the
-  # packaged server entrypoint before signalling anything, so a stale PID can
-  # never target an unrelated user process during uninstall.
+  # launchd has already been booted out before this runs. Still require a
+  # numeric PID and the packaged server entrypoint before signalling anything,
+  # so a stale PID can never target an unrelated user process during uninstall.
   local sidecar_pid
   sidecar_pid="$(sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$state_path" | head -n 1)"
   [[ "$sidecar_pid" =~ ^[0-9]+$ ]] || return 0
@@ -199,19 +199,35 @@ stop_recorded_reachability_sidecar() {
   command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
   [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
 
-  log "Stopping recorded background CovenCave sidecar ${sidecar_pid} before unloading launchd..."
+  log "Stopping recorded background CovenCave sidecar ${sidecar_pid} after unloading launchd..."
   run kill -TERM "$sidecar_pid" || true
+
+  [[ "$EXECUTE" == "1" ]] || return 0
+  local attempt
+  for ((attempt = 0; attempt < 50; attempt += 1)); do
+    command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
+    [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+    sleep 0.1
+  done
+  log "warning: background sidecar ${sidecar_pid} did not exit after TERM; sending KILL"
+  run kill -KILL "$sidecar_pid" || true
+  for ((attempt = 0; attempt < 10; attempt += 1)); do
+    command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
+    [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+    sleep 0.1
+  done
+  log "warning: background sidecar ${sidecar_pid} is still present after KILL"
 }
 
 remove_macos_artifacts() {
   local home="$HOME"
   log "Uninstalling macOS CovenCave artifacts..."
 
-  # Stop background availability before removing its executable, runtime
-  # state, or logs. Otherwise launchd can restart the sidecar while uninstall
-  # is tearing those paths down.
-  stop_recorded_reachability_sidecar "$home"
+  # Unload launchd first so KeepAlive cannot replace the sidecar while it is
+  # being reaped. The daemon's SIGTERM handler performs its normal cleanup;
+  # the recorded-state cleanup below is the bounded orphan fallback.
   forget_launch_agent "$APP_ID" "${home}/Library/LaunchAgents/${APP_ID}.plist"
+  stop_recorded_reachability_sidecar "$home"
   forget_launch_agent "$LEGACY_APP_ID" "${home}/Library/LaunchAgents/${LEGACY_APP_ID}.plist"
   forget_launch_agent "com.opencoven.CovenCave" "${home}/Library/LaunchAgents/com.opencoven.CovenCave.plist"
 

--- a/scripts/uninstall-app.sh
+++ b/scripts/uninstall-app.sh
@@ -190,14 +190,21 @@ stop_recorded_reachability_sidecar() {
   [[ -f "$state_path" ]] || return 0
 
   # launchd has already been booted out before this runs. Still require a
-  # numeric PID and the packaged server entrypoint before signalling anything,
-  # so a stale PID can never target an unrelated user process during uninstall.
-  local sidecar_pid
+  # matching process identity before signalling anything, so a stale PID can
+  # never target an unrelated CovenCave server during uninstall.
+  local sidecar_pid sidecar_identity
   sidecar_pid="$(sed -nE 's/.*"pid"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$state_path" | head -n 1)"
+  sidecar_identity="$(sed -nE 's/.*"identity"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/p' "$state_path" | head -n 1)"
   [[ "$sidecar_pid" =~ ^[0-9]+$ ]] || return 0
-  local command_line
-  command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
-  [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+  [[ -n "$sidecar_identity" ]] || return 0
+
+  recorded_reachability_sidecar_matches() {
+    local current_identity
+    current_identity="$(ps -p "$sidecar_pid" -o lstart= -o comm= 2>/dev/null | sed 's/^[[:space:]]*//' || true)"
+    [[ "$current_identity" == "$sidecar_identity" ]]
+  }
+
+  recorded_reachability_sidecar_matches || return 0
 
   log "Stopping recorded background CovenCave sidecar ${sidecar_pid} after unloading launchd..."
   run kill -TERM "$sidecar_pid" || true
@@ -205,15 +212,14 @@ stop_recorded_reachability_sidecar() {
   [[ "$EXECUTE" == "1" ]] || return 0
   local attempt
   for ((attempt = 0; attempt < 50; attempt += 1)); do
-    command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
-    [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+    recorded_reachability_sidecar_matches || return 0
     sleep 0.1
   done
+  recorded_reachability_sidecar_matches || return 0
   log "warning: background sidecar ${sidecar_pid} did not exit after TERM; sending KILL"
   run kill -KILL "$sidecar_pid" || true
   for ((attempt = 0; attempt < 10; attempt += 1)); do
-    command_line="$(ps -p "$sidecar_pid" -o command= 2>/dev/null || true)"
-    [[ "$command_line" == *"/resources/server/server.mjs"* ]] || return 0
+    recorded_reachability_sidecar_matches || return 0
     sleep 0.1
   done
   log "warning: background sidecar ${sidecar_pid} is still present after KILL"

--- a/scripts/uninstall-app.test.mjs
+++ b/scripts/uninstall-app.test.mjs
@@ -221,6 +221,7 @@ if (process.platform !== "win32") {
   assert.match(result.stdout, /Diagnostics:/);
   assert.match(result.stdout, /Diagnostics copied to clipboard/);
   assert.match(await readFile(copiedDiagnostics, "utf8"), /timed out after 1s/);
+  await assert.rejects(access(plist), "uninstall should remove the background availability LaunchAgent");
 }
 
 console.log("uninstall-app.test.mjs: ok");

--- a/scripts/uninstall-app.test.mjs
+++ b/scripts/uninstall-app.test.mjs
@@ -105,6 +105,33 @@ function run(args, env = {}) {
 
 {
   const home = mkdtempSync(path.join(tmpdir(), "coven-cave-uninstall-home-"));
+  const appSupport = path.join(home, "Library", "Application Support", "ai.opencoven.cave");
+  const bin = path.join(home, "bin");
+  mkdirSync(appSupport, { recursive: true });
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(
+    path.join(appSupport, "desktop-daemon-state.json"),
+    JSON.stringify({ pid: 4242, identity: "old daemon identity", port: 3000 }),
+  );
+  writeFileSync(
+    path.join(bin, "ps"),
+    "#!/usr/bin/env bash\nprintf 'new process identity\\n'\n",
+    { mode: 0o755 },
+  );
+
+  const result = run([], {
+    HOME: home,
+    OSTYPE: "darwin22",
+    PATH: `${bin}:${process.env.PATH}`,
+    TMPDIR: path.join(home, "tmp"),
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(result.stdout, /Stopping recorded background CovenCave sidecar/);
+}
+
+{
+  const home = mkdtempSync(path.join(tmpdir(), "coven-cave-uninstall-home-"));
   const stateRoot = path.join(home, ".state");
   const covenHome = path.join(home, ".coven");
   mkdirSync(path.join(stateRoot, "coven-cave"), { recursive: true });

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -93,6 +93,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "signal-hook-registry",
  "tar",
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -69,6 +69,7 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 # the crate compiles everywhere and the call sites are cfg(target_os) gated).
 [target.'cfg(target_os = "macos")'.dependencies]
 window-vibrancy = "0.6"
+signal-hook-registry = "1.4"
 # Raw msg_send access to NSWindow's standard buttons (traffic-light
 # show/hide follows the side panel); already in the tree via tauri/wry.
 objc2 = "0.6"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -70,6 +70,7 @@ windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Securit
 [target.'cfg(target_os = "macos")'.dependencies]
 window-vibrancy = "0.6"
 signal-hook-registry = "1.4"
+fs2 = "0.4.3"
 # Raw msg_send access to NSWindow's standard buttons (traffic-light
 # show/hide follows the side panel); already in the tree via tauri/wry.
 objc2 = "0.6"

--- a/src-tauri/capabilities/loopback-browser.json
+++ b/src-tauri/capabilities/loopback-browser.json
@@ -26,6 +26,8 @@
     "allow-browser-close",
     "allow-browser-deactivate-all",
     "allow-browser-close-all",
-    "allow-browser-reload"
+    "allow-browser-reload",
+    "allow-desktop-reachability-status",
+    "allow-desktop-reachability-configure"
   ]
 }

--- a/src-tauri/permissions/default.toml
+++ b/src-tauri/permissions/default.toml
@@ -23,4 +23,6 @@ permissions = [
   "allow-speech-stt-start",
   "allow-speech-stt-finish",
   "allow-speech-stt-stop",
+  "allow-desktop-reachability-status",
+  "allow-desktop-reachability-configure",
 ]

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -24,6 +24,7 @@ const loopbackSpeechCapability = JSON.parse(
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const speechPermissions = readFileSync(new URL("./speech.toml", import.meta.url), "utf8");
+const reachabilityPermissions = readFileSync(new URL("./desktop-reachability.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
 const browserCommandsRust = readFileSync(new URL("../src/browser_commands.rs", import.meta.url), "utf8");
 const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
@@ -58,6 +59,8 @@ const requiredPermissionIds = [
   "allow-speech-stt-start",
   "allow-speech-stt-finish",
   "allow-speech-stt-stop",
+  "allow-desktop-reachability-status",
+  "allow-desktop-reachability-configure",
 ];
 
 const requiredCommands = [
@@ -79,6 +82,8 @@ const requiredCommands = [
   "sidecar_startup_status",
   "retry_sidecar_startup",
   "cancel_sidecar_startup",
+  "desktop_reachability_status",
+  "desktop_reachability_configure",
 ];
 
 // Node 22 (CI's runtime) has no global URLPattern, so match capability
@@ -136,8 +141,11 @@ test("packaged desktop app can use native browser and terminal commands", () => 
 
   for (const command of requiredCommands) {
     const escapedCommand = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const permissionSource = command.startsWith("desktop_reachability_")
+      ? reachabilityPermissions
+      : commandPermissions;
     assert.match(
-      commandPermissions,
+      permissionSource,
       new RegExp(String.raw`commands\.allow\s*=\s*\[[^\]]*"${escapedCommand}"[^\]]*\]`),
       `${command} must have a Tauri allow permission`,
     );
@@ -225,6 +233,8 @@ test("packaged sidecar loopback origins can use browser commands and main-webvie
     "allow-browser-deactivate-all",
     "allow-browser-close-all",
     "allow-browser-reload",
+    "allow-desktop-reachability-status",
+    "allow-desktop-reachability-configure",
   ]) {
     assert.ok(
       loopbackBrowserCapability.permissions.includes(permission),
@@ -289,6 +299,8 @@ test("native browser children can report metadata but cannot control browser lay
     "allow-browser-deactivate-all",
     "allow-browser-close-all",
     "allow-browser-reload",
+    "allow-desktop-reachability-status",
+    "allow-desktop-reachability-configure",
   ]);
 
   for (const command of [

--- a/src-tauri/permissions/desktop-reachability.toml
+++ b/src-tauri/permissions/desktop-reachability.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-desktop-reachability-status"
+description = "Allows the trusted desktop UI to read reachability status."
+commands.allow = ["desktop_reachability_status"]
+
+[[permission]]
+identifier = "allow-desktop-reachability-configure"
+description = "Allows the trusted desktop UI to configure macOS reachability opt-ins."
+commands.allow = ["desktop_reachability_configure"]

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -1,0 +1,1025 @@
+#![cfg_attr(not(target_os = "macos"), allow(dead_code))]
+
+use super::*;
+
+#[cfg(desktop)]
+use serde::{Deserialize, Serialize};
+#[cfg(desktop)]
+use std::io::Write;
+#[cfg(desktop)]
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+
+#[cfg(desktop)]
+const REACHABILITY_CONFIG_FILE: &str = "desktop-reachability.json";
+#[cfg(desktop)]
+const GUI_ACTIVE_FILE: &str = "desktop-gui-active.json";
+#[cfg(desktop)]
+const DAEMON_STATE_FILE: &str = "desktop-daemon-state.json";
+#[cfg(desktop)]
+const LAUNCH_AGENT_LABEL: &str = "ai.opencoven.cave";
+#[cfg(desktop)]
+const MOBILE_PAIRED_FILE: &str = "mobile-paired.json";
+#[cfg(desktop)]
+const POWER_MONITOR_INTERVAL: Duration = Duration::from_secs(5);
+#[cfg(desktop)]
+const SERVE_REPAIR_INTERVAL: Duration = Duration::from_secs(30);
+
+#[cfg(desktop)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[serde(default, rename_all = "camelCase")]
+pub(super) struct DesktopReachabilityConfig {
+    pub(super) prevent_sleep: bool,
+    pub(super) prevent_sleep_on_ac_only: bool,
+    pub(super) daemon_mode: bool,
+}
+
+#[cfg(desktop)]
+impl Default for DesktopReachabilityConfig {
+    fn default() -> Self {
+        Self {
+            prevent_sleep: false,
+            prevent_sleep_on_ac_only: true,
+            daemon_mode: false,
+        }
+    }
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct DesktopReachabilityStatus {
+    supported: bool,
+    config: DesktopReachabilityConfig,
+    paired_phone_seen: bool,
+    launch_agent_installed: bool,
+    prevent_sleep_active: bool,
+    detail: Option<String>,
+}
+
+#[cfg(desktop)]
+struct PowerAssertion {
+    child: Child,
+    on_ac_only: bool,
+}
+
+#[cfg(desktop)]
+#[derive(Default)]
+pub(super) struct DesktopReachabilityRuntime {
+    target_pid: AtomicU32,
+    power_assertion: Mutex<Option<PowerAssertion>>,
+    monitor_started: AtomicBool,
+}
+
+#[cfg(desktop)]
+impl DesktopReachabilityRuntime {
+    fn set_target_pid(&self, pid: u32) {
+        self.target_pid.store(pid, Ordering::Release);
+    }
+
+    fn clear_target_pid(&self) {
+        self.target_pid.store(0, Ordering::Release);
+    }
+
+    fn target_pid(&self) -> Option<u32> {
+        match self.target_pid.load(Ordering::Acquire) {
+            0 => None,
+            pid => Some(pid),
+        }
+    }
+
+    fn start_monitor(self: &Arc<Self>, config_path: PathBuf, paired_path: PathBuf) {
+        if self.monitor_started.swap(true, Ordering::AcqRel) {
+            return;
+        }
+        let runtime = Arc::downgrade(self);
+        thread::spawn(move || loop {
+            let Some(runtime) = runtime.upgrade() else {
+                break;
+            };
+            runtime.reconcile_power(&config_path, &paired_path);
+            drop(runtime);
+            thread::sleep(POWER_MONITOR_INTERVAL);
+        });
+    }
+
+    fn reconcile_power(&self, config_path: &Path, paired_path: &Path) {
+        #[cfg(target_os = "macos")]
+        {
+            let config = read_reachability_config(config_path);
+            let paired = paired_phone_seen(paired_path);
+            let target_pid = self.target_pid();
+            let desired =
+                config.prevent_sleep && paired && mobile_mode_enabled() && target_pid.is_some();
+            let mut assertion = match self.power_assertion.lock() {
+                Ok(guard) => guard,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+
+            if let Some(current) = assertion.as_mut() {
+                let still_running = current.child.try_wait().ok().flatten().is_none();
+                if !desired
+                    || !still_running
+                    || current.on_ac_only != config.prevent_sleep_on_ac_only
+                {
+                    let _ = current.child.kill();
+                    let _ = current.child.wait();
+                    *assertion = None;
+                }
+            }
+
+            if assertion.is_none() && desired {
+                let pid = target_pid.expect("desired assertion has a target pid");
+                match spawn_power_assertion(pid, config.prevent_sleep_on_ac_only) {
+                    Ok(child) => {
+                        log::info!(
+                            "[cave] prevent-sleep assertion active for sidecar pid {pid} ({})",
+                            if config.prevent_sleep_on_ac_only {
+                                "AC power only"
+                            } else {
+                                "battery and AC power"
+                            }
+                        );
+                        *assertion = Some(PowerAssertion {
+                            child,
+                            on_ac_only: config.prevent_sleep_on_ac_only,
+                        });
+                    }
+                    Err(error) => {
+                        log::warn!("[cave] could not start prevent-sleep assertion: {error}");
+                    }
+                }
+            }
+        }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            let _ = (config_path, paired_path);
+        }
+    }
+
+    fn power_active(&self) -> bool {
+        let mut assertion = match self.power_assertion.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        let Some(current) = assertion.as_mut() else {
+            return false;
+        };
+        if current.child.try_wait().ok().flatten().is_some() {
+            *assertion = None;
+            return false;
+        }
+        true
+    }
+}
+
+#[cfg(desktop)]
+impl Drop for DesktopReachabilityRuntime {
+    fn drop(&mut self) {
+        let assertion = match self.power_assertion.get_mut() {
+            Ok(assertion) => assertion,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(mut assertion) = assertion.take() {
+            let _ = assertion.child.kill();
+            let _ = assertion.child.wait();
+        }
+    }
+}
+
+#[cfg(desktop)]
+fn cave_home_path() -> PathBuf {
+    if let Ok(explicit) = std::env::var("COVEN_CAVE_HOME") {
+        if !explicit.trim().is_empty() {
+            return PathBuf::from(explicit);
+        }
+    }
+    if let Ok(coven_home) = std::env::var("COVEN_HOME") {
+        if !coven_home.trim().is_empty() {
+            return PathBuf::from(coven_home).join("cave");
+        }
+    }
+    let home = std::env::var(if cfg!(target_os = "windows") {
+        "USERPROFILE"
+    } else {
+        "HOME"
+    })
+    .unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(home).join(".coven").join("cave")
+}
+
+#[cfg(desktop)]
+fn paired_phone_path() -> PathBuf {
+    cave_home_path().join(MOBILE_PAIRED_FILE)
+}
+
+#[cfg(desktop)]
+fn paired_phone_seen(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|value| value.get("lastSeenAt").and_then(|seen| seen.as_f64()))
+        .is_some_and(f64::is_finite)
+}
+
+#[cfg(desktop)]
+fn read_reachability_config(path: &Path) -> DesktopReachabilityConfig {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+#[cfg(desktop)]
+fn write_private_json<T: Serialize>(path: &Path, value: &T) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("{} has no parent directory", path.display()))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    let temp = path.with_extension(format!("tmp-{}", std::process::id()));
+    let json = serde_json::to_vec_pretty(value)
+        .map_err(|error| format!("could not serialize {}: {error}", path.display()))?;
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(&temp)
+        .map_err(|error| format!("could not open {}: {error}", temp.display()))?;
+    file.write_all(&json)
+        .and_then(|_| file.sync_all())
+        .map_err(|error| format!("could not write {}: {error}", temp.display()))?;
+    std::fs::rename(&temp, path)
+        .map_err(|error| format!("could not replace {}: {error}", path.display()))
+}
+
+#[cfg(desktop)]
+fn mobile_mode_enabled() -> bool {
+    let path = cave_home_path().join("preferences.json");
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|value| {
+            value
+                .get("phone")
+                .and_then(|phone| phone.get("mobileMode"))
+                .and_then(serde_json::Value::as_bool)
+        })
+        .unwrap_or(false)
+}
+
+#[cfg(desktop)]
+fn power_assertion_arguments(target_pid: u32, on_ac_only: bool) -> Vec<String> {
+    vec![
+        if on_ac_only { "-s" } else { "-i" }.to_string(),
+        "-w".to_string(),
+        target_pid.to_string(),
+    ]
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn spawn_power_assertion(target_pid: u32, on_ac_only: bool) -> std::io::Result<Child> {
+    Command::new("/usr/bin/caffeinate")
+        .args(power_assertion_arguments(target_pid, on_ac_only))
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+}
+
+#[cfg(desktop)]
+fn serve_arguments(port: u16) -> [String; 3] {
+    [
+        "serve".to_string(),
+        "--bg".to_string(),
+        format!("http://127.0.0.1:{port}"),
+    ]
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn tailscale_binary() -> PathBuf {
+    if let Some(explicit) = std::env::var_os("TAILSCALE_BIN") {
+        let path = PathBuf::from(explicit);
+        if path.is_file() {
+            return path;
+        }
+    }
+    [
+        "/Applications/Tailscale.app/Contents/MacOS/tailscale",
+        "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+        "/opt/homebrew/bin/tailscale",
+        "/usr/local/bin/tailscale",
+        "/usr/bin/tailscale",
+        "/bin/tailscale",
+    ]
+    .into_iter()
+    .map(PathBuf::from)
+    .find(|path| path.is_file())
+    .unwrap_or_else(|| PathBuf::from("tailscale"))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+pub(super) fn repair_tailscale_serve_for_port(port: u16) {
+    if !mobile_mode_enabled() {
+        return;
+    }
+    thread::spawn(move || {
+        let args = serve_arguments(port);
+        match Command::new(tailscale_binary())
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .output()
+        {
+            Ok(output) if output.status.success() => {
+                log::info!("[cave] Tailscale Serve points at 127.0.0.1:{port}");
+            }
+            Ok(output) => {
+                let detail = String::from_utf8_lossy(&output.stderr);
+                log::warn!(
+                    "[cave] could not repair Tailscale Serve for port {port}: {}",
+                    detail.trim()
+                );
+            }
+            Err(error) => {
+                log::warn!(
+                    "[cave] could not launch Tailscale Serve repair for port {port}: {error}"
+                );
+            }
+        }
+    });
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+pub(super) fn repair_tailscale_serve_for_port(_port: u16) {}
+
+#[cfg(desktop)]
+fn xml_escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&apos;")
+}
+
+#[cfg(desktop)]
+fn launch_agent_plist(executable: &Path, stdout_path: &Path, stderr_path: &Path) -> String {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>{label}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>{executable}</string>
+    <string>--cave-sidecar-daemon</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StartInterval</key>
+  <integer>30</integer>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>ProcessType</key>
+  <string>Background</string>
+  <key>StandardOutPath</key>
+  <string>{stdout}</string>
+  <key>StandardErrorPath</key>
+  <string>{stderr}</string>
+</dict>
+</plist>
+"#,
+        label = LAUNCH_AGENT_LABEL,
+        executable = xml_escape(&executable.to_string_lossy()),
+        stdout = xml_escape(&stdout_path.to_string_lossy()),
+        stderr = xml_escape(&stderr_path.to_string_lossy()),
+    )
+}
+
+#[cfg(desktop)]
+fn launch_agent_path_for(home: &Path) -> PathBuf {
+    home.join("Library")
+        .join("LaunchAgents")
+        .join(format!("{LAUNCH_AGENT_LABEL}.plist"))
+}
+
+#[cfg(desktop)]
+fn write_launch_agent_file(path: &Path, plist: &str) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| "LaunchAgents path has no parent".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    let temp = path.with_extension(format!("plist.tmp-{}", std::process::id()));
+    std::fs::write(&temp, plist)
+        .map_err(|error| format!("could not write {}: {error}", temp.display()))?;
+    std::fs::rename(&temp, path)
+        .map_err(|error| format!("could not replace {}: {error}", path.display()))
+}
+
+#[cfg(desktop)]
+fn remove_launch_agent_file(path: &Path) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("could not remove {}: {error}", path.display())),
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn launch_agent_path() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME is unavailable".to_string())?;
+    Ok(launch_agent_path_for(Path::new(&home)))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn launch_agent_domain() -> Result<String, String> {
+    let output = Command::new("/usr/bin/id")
+        .arg("-u")
+        .output()
+        .map_err(|error| format!("could not determine macOS user id: {error}"))?;
+    if !output.status.success() {
+        return Err("could not determine macOS user id".to_string());
+    }
+    Ok(format!(
+        "gui/{}",
+        String::from_utf8_lossy(&output.stdout).trim()
+    ))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn launch_agent_service() -> Result<String, String> {
+    Ok(format!("{}/{}", launch_agent_domain()?, LAUNCH_AGENT_LABEL))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_launchctl(args: &[&str]) -> Result<(), String> {
+    let output = Command::new("/bin/launchctl")
+        .args(args)
+        .output()
+        .map_err(|error| format!("could not run launchctl: {error}"))?;
+    if output.status.success() {
+        return Ok(());
+    }
+    Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn bootout_launch_agent() {
+    if let Ok(service) = launch_agent_service() {
+        let _ = run_launchctl(&["bootout", &service]);
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn install_launch_agent(app: &tauri::AppHandle) -> Result<(), String> {
+    let resource_dir = app
+        .path()
+        .resource_dir()
+        .map_err(|error| format!("could not resolve app resources: {error}"))?;
+    if !resource_dir
+        .join("resources")
+        .join("server")
+        .join("server.mjs")
+        .is_file()
+    {
+        return Err(
+            "Background availability requires a packaged CovenCave build with server.mjs."
+                .to_string(),
+        );
+    }
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("could not resolve CovenCave executable: {error}"))?;
+    let log_dir = std::env::var("HOME")
+        .map(PathBuf::from)
+        .map_err(|_| "HOME is unavailable".to_string())?
+        .join("Library")
+        .join("Logs")
+        .join("CovenCave");
+    std::fs::create_dir_all(&log_dir)
+        .map_err(|error| format!("could not create {}: {error}", log_dir.display()))?;
+    let plist_path = launch_agent_path()?;
+    let plist = launch_agent_plist(
+        &executable,
+        &log_dir.join("sidecar-daemon.out.log"),
+        &log_dir.join("sidecar-daemon.err.log"),
+    );
+    write_launch_agent_file(&plist_path, &plist)?;
+
+    bootout_launch_agent();
+    let domain = launch_agent_domain()?;
+    let plist_arg = plist_path.to_string_lossy().into_owned();
+    run_launchctl(&["bootstrap", &domain, &plist_arg])
+        .map_err(|error| format!("could not load background availability: {error}"))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn uninstall_launch_agent() -> Result<(), String> {
+    bootout_launch_agent();
+    remove_launch_agent_file(&launch_agent_path()?)
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn launch_agent_installed() -> bool {
+    launch_agent_path().is_ok_and(|path| path.is_file())
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+fn launch_agent_installed() -> bool {
+    false
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn app_data_path_without_handle() -> Result<PathBuf, String> {
+    let home = std::env::var("HOME").map_err(|_| "HOME is unavailable".to_string())?;
+    Ok(PathBuf::from(home)
+        .join("Library")
+        .join("Application Support")
+        .join(LAUNCH_AGENT_LABEL))
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn process_is_running(pid: u32) -> bool {
+    Command::new("/bin/kill")
+        .args(["-0", &pid.to_string()])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok_and(|status| status.success())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn gui_is_active(app_data_dir: &Path) -> bool {
+    let marker = app_data_dir.join(GUI_ACTIVE_FILE);
+    let pid = std::fs::read_to_string(&marker)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+        .and_then(|value| value.get("pid").and_then(serde_json::Value::as_u64))
+        .and_then(|pid| u32::try_from(pid).ok());
+    match pid {
+        Some(pid) if process_is_running(pid) => true,
+        _ => {
+            let _ = std::fs::remove_file(marker);
+            false
+        }
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) {
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let marker = app_data_dir.join(GUI_ACTIVE_FILE);
+    if let Err(error) =
+        write_private_json(&marker, &serde_json::json!({ "pid": std::process::id() }))
+    {
+        log::warn!("[cave] could not mark desktop GUI active: {error}");
+    }
+
+    let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
+    let config = read_reachability_config(&config_path);
+    if config.daemon_mode {
+        if let Err(error) = install_launch_agent(app) {
+            log::warn!("[cave] could not reconcile background availability: {error}");
+        }
+        if let Ok(service) = launch_agent_service() {
+            let _ = run_launchctl(&["kill", "SIGTERM", &service]);
+        }
+    } else if launch_agent_installed() {
+        if let Err(error) = uninstall_launch_agent() {
+            log::warn!("[cave] could not remove disabled background availability: {error}");
+        }
+    }
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+pub(super) fn prepare_gui_reachability(_app: &tauri::AppHandle) {}
+
+#[cfg(all(desktop, target_os = "macos"))]
+pub(super) fn handoff_to_background_daemon(app: &tauri::AppHandle) {
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let _ = std::fs::remove_file(app_data_dir.join(GUI_ACTIVE_FILE));
+    let config = read_reachability_config(&app_data_dir.join(REACHABILITY_CONFIG_FILE));
+    if !config.daemon_mode {
+        return;
+    }
+    if let Err(error) = install_launch_agent(app) {
+        log::warn!("[cave] could not load background availability: {error}");
+        return;
+    }
+    if let Ok(service) = launch_agent_service() {
+        if let Err(error) = run_launchctl(&["kickstart", "-k", &service]) {
+            log::warn!("[cave] could not start background availability: {error}");
+        }
+    }
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+pub(super) fn handoff_to_background_daemon(_app: &tauri::AppHandle) {}
+
+#[cfg(desktop)]
+pub(super) fn sidecar_reachability_ready(app: &tauri::AppHandle, port: u16, pid: u32) {
+    repair_tailscale_serve_for_port(port);
+    let Some(runtime) = app.try_state::<Arc<DesktopReachabilityRuntime>>() else {
+        return;
+    };
+    runtime.set_target_pid(pid);
+    let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    runtime.start_monitor(
+        app_data_dir.join(REACHABILITY_CONFIG_FILE),
+        paired_phone_path(),
+    );
+}
+
+#[cfg(desktop)]
+pub(super) fn sidecar_reachability_stopped(app: &tauri::AppHandle) {
+    let Some(runtime) = app.try_state::<Arc<DesktopReachabilityRuntime>>() else {
+        return;
+    };
+    runtime.clear_target_pid();
+    if let Ok(app_data_dir) = app.path().app_data_dir() {
+        runtime.reconcile_power(
+            &app_data_dir.join(REACHABILITY_CONFIG_FILE),
+            &paired_phone_path(),
+        );
+    }
+}
+
+#[cfg(desktop)]
+fn status_for_app(app: &tauri::AppHandle) -> Result<DesktopReachabilityStatus, String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("could not resolve app data: {error}"))?;
+    let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
+    let config = read_reachability_config(&config_path);
+    let runtime = app.try_state::<Arc<DesktopReachabilityRuntime>>();
+    Ok(DesktopReachabilityStatus {
+        supported: cfg!(target_os = "macos"),
+        config,
+        paired_phone_seen: paired_phone_seen(&paired_phone_path()),
+        launch_agent_installed: launch_agent_installed(),
+        prevent_sleep_active: runtime
+            .as_ref()
+            .is_some_and(|runtime| runtime.power_active()),
+        detail: if cfg!(target_os = "macos") {
+            None
+        } else {
+            Some("Desktop reachability controls are available in the macOS app.".to_string())
+        },
+    })
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(super) fn desktop_reachability_status(
+    app: tauri::AppHandle,
+) -> Result<DesktopReachabilityStatus, String> {
+    status_for_app(&app)
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+pub(super) fn desktop_reachability_configure(
+    app: tauri::AppHandle,
+    config: DesktopReachabilityConfig,
+) -> Result<DesktopReachabilityStatus, String> {
+    #[cfg(target_os = "macos")]
+    {
+        let app_data_dir = app
+            .path()
+            .app_data_dir()
+            .map_err(|error| format!("could not resolve app data: {error}"))?;
+        let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
+        let previous = read_reachability_config(&config_path);
+        write_private_json(&config_path, &config)?;
+        let launch_agent_result = if config.daemon_mode {
+            install_launch_agent(&app)
+        } else {
+            uninstall_launch_agent()
+        };
+        if let Err(error) = launch_agent_result {
+            let _ = write_private_json(&config_path, &previous);
+            return Err(error);
+        }
+        if let Some(runtime) = app.try_state::<Arc<DesktopReachabilityRuntime>>() {
+            runtime.reconcile_power(&config_path, &paired_phone_path());
+        }
+        return status_for_app(&app);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = config;
+        status_for_app(&app)
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn daemon_resource_dir(executable: &Path) -> Result<PathBuf, String> {
+    let macos_dir = executable
+        .parent()
+        .ok_or_else(|| "daemon executable has no parent".to_string())?;
+    let contents = macos_dir
+        .parent()
+        .ok_or_else(|| "daemon executable is not inside an app bundle".to_string())?;
+    let resources = contents.join("Resources");
+    if !resources.is_dir() {
+        return Err(format!(
+            "packaged resource directory is missing at {}",
+            resources.display()
+        ));
+    }
+    Ok(resources)
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn daemon_port() -> Result<u16, String> {
+    for port in 3000..=3010 {
+        if TcpListener::bind(("127.0.0.1", port)).is_ok() {
+            return Ok(port);
+        }
+    }
+    find_free_port().ok_or_else(|| "no free loopback port is available".to_string())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn append_log_file(path: &Path) -> Option<std::fs::File> {
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .ok()
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn daemon_augmented_path(node: &Path) -> String {
+    let mut directories = Vec::new();
+    if let Some(directory) = node.parent() {
+        directories.push(directory.to_path_buf());
+    }
+    if let Some(coven) = find_coven() {
+        if let Some(directory) = coven.parent() {
+            directories.push(directory.to_path_buf());
+        }
+    }
+    directories.extend(
+        std::env::var_os("PATH")
+            .map(|path| std::env::split_paths(&path).collect::<Vec<_>>())
+            .unwrap_or_else(|| {
+                vec![
+                    PathBuf::from("/usr/bin"),
+                    PathBuf::from("/bin"),
+                    PathBuf::from("/usr/sbin"),
+                    PathBuf::from("/sbin"),
+                ]
+            }),
+    );
+    std::env::join_paths(directories)
+        .unwrap_or_default()
+        .to_string_lossy()
+        .into_owned()
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_sidecar_daemon() -> Result<i32, String> {
+    let app_data_dir = app_data_path_without_handle()?;
+    let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
+    let config = read_reachability_config(&config_path);
+    if !config.daemon_mode || gui_is_active(&app_data_dir) {
+        return Ok(0);
+    }
+
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("could not resolve daemon executable: {error}"))?;
+    let resource_dir = daemon_resource_dir(&executable)?;
+    let server_dir = resource_dir.join("resources").join("server");
+    let server_entry = server_dir.join("server.mjs");
+    if !server_entry.is_file() {
+        return Err(format!(
+            "server.mjs is missing at {}",
+            server_entry.display()
+        ));
+    }
+    let node = find_node(&resource_dir)
+        .ok_or_else(|| "packaged Node.js runtime is unavailable".to_string())?;
+    let port = daemon_port()?;
+    let auth_token = sidecar_auth_token();
+    let mobile_access_token =
+        load_or_create_mobile_access_token(&app_data_dir.join(MOBILE_ACCESS_TOKEN_FILE));
+    let log_dir = std::env::var("HOME")
+        .map(PathBuf::from)
+        .map_err(|_| "HOME is unavailable".to_string())?
+        .join("Library")
+        .join("Logs")
+        .join("CovenCave");
+    std::fs::create_dir_all(&log_dir)
+        .map_err(|error| format!("could not create {}: {error}", log_dir.display()))?;
+    let server_log = log_dir.join("sidecar-daemon-server.log");
+    let stdout = append_log_file(&server_log);
+    let stderr = stdout.as_ref().and_then(|file| file.try_clone().ok());
+
+    let mut command = Command::new(&node);
+    command
+        .arg(&server_entry)
+        .current_dir(&server_dir)
+        .env("PATH", daemon_augmented_path(&node))
+        .env("PORT", port.to_string())
+        .env("HOSTNAME", "127.0.0.1")
+        .env("NODE_ENV", "production")
+        .env("COVEN_CAVE_BUNDLE", "1")
+        .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
+        .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token)
+        .stdin(Stdio::null());
+    if let Some(stdout) = stdout {
+        command.stdout(Stdio::from(stdout));
+    } else {
+        command.stdout(Stdio::null());
+    }
+    if let Some(stderr) = stderr {
+        command.stderr(Stdio::from(stderr));
+    } else {
+        command.stderr(Stdio::null());
+    }
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("could not start background sidecar: {error}"))?;
+    let child_pid = child.id();
+    match wait_for_sidecar_ready(port, &server_log, Duration::from_secs(30), || {
+        gui_is_active(&app_data_dir)
+    }) {
+        PortWaitResult::Ready => {}
+        PortWaitResult::Cancelled => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Ok(0);
+        }
+        PortWaitResult::TimedOut => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err(format!(
+                "background sidecar did not become ready on port {port}"
+            ));
+        }
+    }
+
+    write_private_json(
+        &app_data_dir.join(DAEMON_STATE_FILE),
+        &serde_json::json!({ "pid": child_pid, "port": port }),
+    )?;
+    repair_tailscale_serve_for_port(port);
+
+    let mut assertion: Option<PowerAssertion> = None;
+    let mut last_serve_repair = Instant::now();
+    loop {
+        if gui_is_active(&app_data_dir) || !read_reachability_config(&config_path).daemon_mode {
+            let _ = child.kill();
+            let _ = child.wait();
+            if let Some(mut assertion) = assertion.take() {
+                let _ = assertion.child.kill();
+                let _ = assertion.child.wait();
+            }
+            let _ = std::fs::remove_file(app_data_dir.join(DAEMON_STATE_FILE));
+            return Ok(0);
+        }
+        if let Some(status) = child
+            .try_wait()
+            .map_err(|error| format!("could not inspect background sidecar: {error}"))?
+        {
+            let _ = std::fs::remove_file(app_data_dir.join(DAEMON_STATE_FILE));
+            return Ok(status.code().unwrap_or(1));
+        }
+
+        let current = read_reachability_config(&config_path);
+        let desired_power = current.prevent_sleep
+            && mobile_mode_enabled()
+            && paired_phone_seen(&paired_phone_path());
+        if let Some(active) = assertion.as_mut() {
+            let exited = active.child.try_wait().ok().flatten().is_some();
+            if !desired_power || exited || active.on_ac_only != current.prevent_sleep_on_ac_only {
+                let _ = active.child.kill();
+                let _ = active.child.wait();
+                assertion = None;
+            }
+        }
+        if desired_power && assertion.is_none() {
+            if let Ok(power_child) =
+                spawn_power_assertion(child_pid, current.prevent_sleep_on_ac_only)
+            {
+                assertion = Some(PowerAssertion {
+                    child: power_child,
+                    on_ac_only: current.prevent_sleep_on_ac_only,
+                });
+            }
+        }
+
+        if last_serve_repair.elapsed() >= SERVE_REPAIR_INTERVAL {
+            repair_tailscale_serve_for_port(port);
+            last_serve_repair = Instant::now();
+        }
+        thread::sleep(POWER_MONITOR_INTERVAL);
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+pub(super) fn run_sidecar_daemon_if_requested() -> Option<i32> {
+    if !std::env::args().any(|arg| arg == "--cave-sidecar-daemon") {
+        return None;
+    }
+    Some(match run_sidecar_daemon() {
+        Ok(code) => code,
+        Err(error) => {
+            eprintln!("[cave] background sidecar failed: {error}");
+            1
+        }
+    })
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+pub(super) fn run_sidecar_daemon_if_requested() -> Option<i32> {
+    None
+}
+
+#[cfg(all(test, desktop))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reachability_defaults_are_opt_in_with_ac_only_ready() {
+        assert_eq!(
+            DesktopReachabilityConfig::default(),
+            DesktopReachabilityConfig {
+                prevent_sleep: false,
+                prevent_sleep_on_ac_only: true,
+                daemon_mode: false,
+            }
+        );
+    }
+
+    #[test]
+    fn caffeinate_policy_uses_system_assertion_on_ac_and_idle_assertion_on_battery() {
+        assert_eq!(power_assertion_arguments(42, true), ["-s", "-w", "42"]);
+        assert_eq!(power_assertion_arguments(42, false), ["-i", "-w", "42"]);
+    }
+
+    #[test]
+    fn launch_agent_is_background_retryable_and_runs_the_daemon_entrypoint() {
+        let plist = launch_agent_plist(
+            Path::new("/Applications/Coven&Cave.app/Contents/MacOS/CovenCave"),
+            Path::new("/tmp/cave.out"),
+            Path::new("/tmp/cave.err"),
+        );
+        assert!(plist.contains("<string>ai.opencoven.cave</string>"));
+        assert!(plist.contains("<string>--cave-sidecar-daemon</string>"));
+        assert!(plist.contains("<key>StartInterval</key>"));
+        assert!(plist.contains("<key>SuccessfulExit</key>"));
+        assert!(plist.contains("Coven&amp;Cave.app"));
+    }
+
+    #[test]
+    fn launch_agent_file_installs_and_removes_idempotently() {
+        let home = std::env::temp_dir().join(format!(
+            "coven-launch-agent-test-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let path = launch_agent_path_for(&home);
+        write_launch_agent_file(&path, "<plist/>").expect("install launch agent file");
+        assert_eq!(
+            std::fs::read_to_string(&path).expect("read launch agent file"),
+            "<plist/>"
+        );
+        remove_launch_agent_file(&path).expect("remove launch agent file");
+        remove_launch_agent_file(&path).expect("removing a missing launch agent stays safe");
+        assert!(!path.exists());
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn serve_repair_targets_the_actual_loopback_port() {
+        assert_eq!(
+            serve_arguments(3007),
+            [
+                "serve".to_string(),
+                "--bg".to_string(),
+                "http://127.0.0.1:3007".to_string(),
+            ]
+        );
+    }
+}

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -25,6 +25,9 @@ const POWER_MONITOR_INTERVAL: Duration = Duration::from_secs(5);
 const SERVE_REPAIR_INTERVAL: Duration = Duration::from_secs(30);
 
 #[cfg(desktop)]
+const DAEMON_STOP_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[cfg(desktop)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, rename_all = "camelCase")]
 pub(super) struct DesktopReachabilityConfig {
@@ -63,6 +66,21 @@ struct PowerAssertion {
 }
 
 #[cfg(desktop)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ProcessLease {
+    pid: u32,
+    identity: String,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct DaemonSidecarState {
+    #[serde(flatten)]
+    lease: ProcessLease,
+    port: u16,
+}
+
+#[cfg(desktop)]
 #[derive(Default)]
 pub(super) struct DesktopReachabilityRuntime {
     target_pid: AtomicU32,
@@ -87,7 +105,12 @@ impl DesktopReachabilityRuntime {
         }
     }
 
-    fn start_monitor(self: &Arc<Self>, config_path: PathBuf, paired_path: PathBuf) {
+    fn start_monitor(
+        self: &Arc<Self>,
+        app: tauri::AppHandle,
+        config_path: PathBuf,
+        paired_path: PathBuf,
+    ) {
         if self.monitor_started.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -96,18 +119,23 @@ impl DesktopReachabilityRuntime {
             let Some(runtime) = runtime.upgrade() else {
                 break;
             };
-            runtime.reconcile_power(&config_path, &paired_path);
+            runtime.reconcile_power(&app, &config_path, &paired_path);
             drop(runtime);
             thread::sleep(POWER_MONITOR_INTERVAL);
         });
     }
 
-    fn reconcile_power(&self, config_path: &Path, paired_path: &Path) {
+    fn reconcile_power(&self, app: &tauri::AppHandle, config_path: &Path, paired_path: &Path) {
         #[cfg(target_os = "macos")]
         {
             let config = read_reachability_config(config_path);
             let paired = paired_phone_seen(paired_path);
-            let target_pid = self.target_pid();
+            let target_pid = self
+                .target_pid()
+                .filter(|pid| owned_sidecar_is_live(app, *pid));
+            if target_pid.is_none() {
+                self.clear_target_pid();
+            }
             let desired =
                 config.prevent_sleep && paired && mobile_mode_enabled() && target_pid.is_some();
             let mut assertion = match self.power_assertion.lock() {
@@ -153,7 +181,7 @@ impl DesktopReachabilityRuntime {
 
         #[cfg(not(target_os = "macos"))]
         {
-            let _ = (config_path, paired_path);
+            let _ = (app, config_path, paired_path);
         }
     }
 
@@ -384,13 +412,13 @@ fn launch_agent_plist(executable: &Path, stdout_path: &Path, stderr_path: &Path)
   </array>
   <key>RunAtLoad</key>
   <true/>
-  <key>StartInterval</key>
-  <integer>30</integer>
   <key>KeepAlive</key>
   <dict>
     <key>SuccessfulExit</key>
     <false/>
   </dict>
+  <key>AbandonProcessGroup</key>
+  <false/>
   <key>ProcessType</key>
   <string>Background</string>
   <key>StandardOutPath</key>
@@ -476,14 +504,26 @@ fn run_launchctl(args: &[&str]) -> Result<(), String> {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-fn bootout_launch_agent() {
-    if let Ok(service) = launch_agent_service() {
-        let _ = run_launchctl(&["bootout", &service]);
+fn bootout_launch_agent() -> Result<(), String> {
+    let service = launch_agent_service()?;
+    match run_launchctl(&["bootout", &service]) {
+        Ok(()) => Ok(()),
+        // A missing service is normal on first install and after a clean
+        // handoff. All other launchd failures are ownership failures: do not
+        // start another sidecar until the caller can report/retry them.
+        Err(error)
+            if error.contains("Could not find service")
+                || error.contains("No such process")
+                || error.contains("not found") =>
+        {
+            Ok(())
+        }
+        Err(error) => Err(format!("could not unload background availability: {error}")),
     }
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-fn install_launch_agent(app: &tauri::AppHandle) -> Result<(), String> {
+fn install_launch_agent(app: &tauri::AppHandle, app_data_dir: &Path) -> Result<(), String> {
     let resource_dir = app
         .path()
         .resource_dir()
@@ -501,6 +541,9 @@ fn install_launch_agent(app: &tauri::AppHandle) -> Result<(), String> {
     }
     let executable = std::env::current_exe()
         .map_err(|error| format!("could not resolve CovenCave executable: {error}"))?;
+    // Development binaries can have staged resources but cannot execute as a
+    // LaunchAgent. Validate the exact bundle layout before creating a plist.
+    daemon_resource_dir(&executable)?;
     let log_dir = std::env::var("HOME")
         .map(PathBuf::from)
         .map_err(|_| "HOME is unavailable".to_string())?
@@ -515,18 +558,22 @@ fn install_launch_agent(app: &tauri::AppHandle) -> Result<(), String> {
         &log_dir.join("sidecar-daemon.out.log"),
         &log_dir.join("sidecar-daemon.err.log"),
     );
+    stop_recorded_daemon_sidecar(app_data_dir)?;
+    bootout_launch_agent()?;
     write_launch_agent_file(&plist_path, &plist)?;
-
-    bootout_launch_agent();
     let domain = launch_agent_domain()?;
     let plist_arg = plist_path.to_string_lossy().into_owned();
-    run_launchctl(&["bootstrap", &domain, &plist_arg])
-        .map_err(|error| format!("could not load background availability: {error}"))
+    if let Err(error) = run_launchctl(&["bootstrap", &domain, &plist_arg]) {
+        let _ = remove_launch_agent_file(&plist_path);
+        return Err(format!("could not load background availability: {error}"));
+    }
+    Ok(())
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-fn uninstall_launch_agent() -> Result<(), String> {
-    bootout_launch_agent();
+fn uninstall_launch_agent(app_data_dir: &Path) -> Result<(), String> {
+    stop_recorded_daemon_sidecar(app_data_dir)?;
+    bootout_launch_agent()?;
     remove_launch_agent_file(&launch_agent_path()?)
 }
 
@@ -550,25 +597,13 @@ fn app_data_path_without_handle() -> Result<PathBuf, String> {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-fn process_is_running(pid: u32) -> bool {
-    Command::new("/bin/kill")
-        .args(["-0", &pid.to_string()])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .is_ok_and(|status| status.success())
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
 fn gui_is_active(app_data_dir: &Path) -> bool {
     let marker = app_data_dir.join(GUI_ACTIVE_FILE);
-    let pid = std::fs::read_to_string(&marker)
+    let lease = std::fs::read_to_string(&marker)
         .ok()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
-        .and_then(|value| value.get("pid").and_then(serde_json::Value::as_u64))
-        .and_then(|pid| u32::try_from(pid).ok());
-    match pid {
-        Some(pid) if process_is_running(pid) => true,
+        .and_then(|raw| serde_json::from_str::<ProcessLease>(&raw).ok());
+    match lease {
+        Some(lease) if lease_matches(&lease, process_identity(lease.pid).as_deref()) => true,
         _ => {
             let _ = std::fs::remove_file(marker);
             false
@@ -577,55 +612,50 @@ fn gui_is_active(app_data_dir: &Path) -> bool {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) {
-    let Ok(app_data_dir) = app.path().app_data_dir() else {
-        return;
-    };
+pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), String> {
+    let app_data_dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|error| format!("could not resolve app data: {error}"))?;
     let marker = app_data_dir.join(GUI_ACTIVE_FILE);
-    if let Err(error) =
-        write_private_json(&marker, &serde_json::json!({ "pid": std::process::id() }))
-    {
-        log::warn!("[cave] could not mark desktop GUI active: {error}");
-    }
+    write_private_json(&marker, &current_process_lease()?)?;
 
     let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
     let config = read_reachability_config(&config_path);
     if config.daemon_mode {
-        if let Err(error) = install_launch_agent(app) {
-            log::warn!("[cave] could not reconcile background availability: {error}");
-        }
-        if let Ok(service) = launch_agent_service() {
-            let _ = run_launchctl(&["kill", "SIGTERM", &service]);
-        }
+        install_launch_agent(app, &app_data_dir)?;
     } else if launch_agent_installed() {
-        if let Err(error) = uninstall_launch_agent() {
-            log::warn!("[cave] could not remove disabled background availability: {error}");
-        }
+        uninstall_launch_agent(&app_data_dir)?;
     }
+    Ok(())
 }
 
 #[cfg(all(desktop, not(target_os = "macos")))]
-pub(super) fn prepare_gui_reachability(_app: &tauri::AppHandle) {}
+pub(super) fn prepare_gui_reachability(_app: &tauri::AppHandle) -> Result<(), String> {
+    Ok(())
+}
 
 #[cfg(all(desktop, target_os = "macos"))]
 pub(super) fn handoff_to_background_daemon(app: &tauri::AppHandle) {
     let Ok(app_data_dir) = app.path().app_data_dir() else {
         return;
     };
-    let _ = std::fs::remove_file(app_data_dir.join(GUI_ACTIVE_FILE));
     let config = read_reachability_config(&app_data_dir.join(REACHABILITY_CONFIG_FILE));
     if !config.daemon_mode {
+        let _ = std::fs::remove_file(app_data_dir.join(GUI_ACTIVE_FILE));
         return;
     }
-    if let Err(error) = install_launch_agent(app) {
-        log::warn!("[cave] could not load background availability: {error}");
-        return;
-    }
-    if let Ok(service) = launch_agent_service() {
-        if let Err(error) = run_launchctl(&["kickstart", "-k", &service]) {
-            log::warn!("[cave] could not start background availability: {error}");
+
+    if !launch_agent_installed() {
+        // Keep the marker in place until launchd has started its wrapper. That
+        // wrapper then waits rather than racing the GUI's teardown to spawn a
+        // second sidecar.
+        if let Err(error) = install_launch_agent(app, &app_data_dir) {
+            log::warn!("[cave] could not load background availability: {error}");
+            return;
         }
     }
+    let _ = std::fs::remove_file(app_data_dir.join(GUI_ACTIVE_FILE));
 }
 
 #[cfg(all(desktop, not(target_os = "macos")))]
@@ -642,9 +672,119 @@ pub(super) fn sidecar_reachability_ready(app: &tauri::AppHandle, port: u16, pid:
         return;
     };
     runtime.start_monitor(
+        app.clone(),
         app_data_dir.join(REACHABILITY_CONFIG_FILE),
         paired_phone_path(),
     );
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn process_identity(pid: u32) -> Option<String> {
+    let output = Command::new("/bin/ps")
+        .args(["-o", "lstart=", "-o", "comm=", "-p", &pid.to_string()])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let identity = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    (!identity.is_empty()).then_some(identity)
+}
+
+#[cfg(desktop)]
+fn lease_matches(lease: &ProcessLease, current_identity: Option<&str>) -> bool {
+    current_identity.is_some_and(|current| current == lease.identity)
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn current_process_lease() -> Result<ProcessLease, String> {
+    let pid = std::process::id();
+    let identity = process_identity(pid)
+        .ok_or_else(|| "could not establish the GUI process identity".to_string())?;
+    Ok(ProcessLease { pid, identity })
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn read_daemon_sidecar_state(app_data_dir: &Path) -> Option<DaemonSidecarState> {
+    std::fs::read_to_string(app_data_dir.join(DAEMON_STATE_FILE))
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn wait_for_process_exit(lease: &ProcessLease, timeout: Duration) -> bool {
+    let deadline = Instant::now() + timeout;
+    while Instant::now() < deadline {
+        if !lease_matches(lease, process_identity(lease.pid).as_deref()) {
+            return true;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+    !lease_matches(lease, process_identity(lease.pid).as_deref())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_process_signal(signal: &str, pid: &str) -> Result<(), String> {
+    let output = Command::new("/bin/kill")
+        .args(["-s", signal, pid])
+        .output()
+        .map_err(|error| format!("could not signal background sidecar: {error}"))?;
+    if output.status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "could not signal background sidecar: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        ))
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn stop_recorded_daemon_sidecar(app_data_dir: &Path) -> Result<(), String> {
+    let state_path = app_data_dir.join(DAEMON_STATE_FILE);
+    let Some(state) = read_daemon_sidecar_state(app_data_dir) else {
+        return Ok(());
+    };
+    if !lease_matches(&state.lease, process_identity(state.lease.pid).as_deref()) {
+        let _ = std::fs::remove_file(state_path);
+        return Ok(());
+    }
+    let pid = state.lease.pid.to_string();
+    run_process_signal("TERM", &pid)?;
+    if !wait_for_process_exit(&state.lease, DAEMON_STOP_TIMEOUT) {
+        run_process_signal("KILL", &pid)?;
+        if !wait_for_process_exit(&state.lease, Duration::from_secs(1)) {
+            return Err(format!(
+                "background sidecar {} did not stop",
+                state.lease.pid
+            ));
+        }
+    }
+    let _ = std::fs::remove_file(state_path);
+    Ok(())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn owned_sidecar_is_live(app: &tauri::AppHandle, pid: u32) -> bool {
+    let Some(state) = app.try_state::<SidecarState>() else {
+        return false;
+    };
+    let mut sidecar = match state.0.lock() {
+        Ok(sidecar) => sidecar,
+        Err(_) => return false,
+    };
+    match sidecar.as_mut() {
+        Some(process) => match process.is_live_with_pid(pid) {
+            Ok(live) => live,
+            Err(error) => {
+                log::warn!("[cave] could not verify reachability sidecar ownership: {error}");
+                false
+            }
+        },
+        None => false,
+    }
 }
 
 #[cfg(desktop)]
@@ -655,6 +795,7 @@ pub(super) fn sidecar_reachability_stopped(app: &tauri::AppHandle) {
     runtime.clear_target_pid();
     if let Ok(app_data_dir) = app.path().app_data_dir() {
         runtime.reconcile_power(
+            app,
             &app_data_dir.join(REACHABILITY_CONFIG_FILE),
             &paired_phone_path(),
         );
@@ -710,16 +851,16 @@ pub(super) fn desktop_reachability_configure(
         let previous = read_reachability_config(&config_path);
         write_private_json(&config_path, &config)?;
         let launch_agent_result = if config.daemon_mode {
-            install_launch_agent(&app)
+            install_launch_agent(&app, &app_data_dir)
         } else {
-            uninstall_launch_agent()
+            uninstall_launch_agent(&app_data_dir)
         };
         if let Err(error) = launch_agent_result {
             let _ = write_private_json(&config_path, &previous);
             return Err(error);
         }
         if let Some(runtime) = app.try_state::<Arc<DesktopReachabilityRuntime>>() {
-            runtime.reconcile_power(&config_path, &paired_phone_path());
+            runtime.reconcile_power(&app, &config_path, &paired_phone_path());
         }
         return status_for_app(&app);
     }
@@ -759,13 +900,14 @@ fn daemon_port() -> Result<u16, String> {
     find_free_port().ok_or_else(|| "no free loopback port is available".to_string())
 }
 
-#[cfg(all(desktop, target_os = "macos"))]
-fn append_log_file(path: &Path) -> Option<std::fs::File> {
+#[cfg(desktop)]
+fn create_fresh_log_file(path: &Path) -> Result<std::fs::File, String> {
     std::fs::OpenOptions::new()
         .create(true)
-        .append(true)
+        .write(true)
+        .truncate(true)
         .open(path)
-        .ok()
+        .map_err(|error| format!("could not create {}: {error}", path.display()))
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -801,10 +943,21 @@ fn daemon_augmented_path(node: &Path) -> String {
 fn run_sidecar_daemon() -> Result<i32, String> {
     let app_data_dir = app_data_path_without_handle()?;
     let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
-    let config = read_reachability_config(&config_path);
-    if !config.daemon_mode || gui_is_active(&app_data_dir) {
+    if !read_reachability_config(&config_path).daemon_mode {
         return Ok(0);
     }
+    // Keep one launchd wrapper alive while the GUI owns the server. This gives
+    // crash recovery without StartInterval repeatedly launching app processes.
+    while gui_is_active(&app_data_dir) {
+        if !read_reachability_config(&config_path).daemon_mode {
+            return Ok(0);
+        }
+        thread::sleep(Duration::from_secs(1));
+    }
+    // A previous wrapper can crash without reaping Node. Its signed state is
+    // identity-checked before we stop it, so a restart never creates a second
+    // loopback server on a fallback port.
+    stop_recorded_daemon_sidecar(&app_data_dir)?;
 
     let executable = std::env::current_exe()
         .map_err(|error| format!("could not resolve daemon executable: {error}"))?;
@@ -832,8 +985,10 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     std::fs::create_dir_all(&log_dir)
         .map_err(|error| format!("could not create {}: {error}", log_dir.display()))?;
     let server_log = log_dir.join("sidecar-daemon-server.log");
-    let stdout = append_log_file(&server_log);
-    let stderr = stdout.as_ref().and_then(|file| file.try_clone().ok());
+    let stdout = create_fresh_log_file(&server_log)?;
+    let stderr = stdout
+        .try_clone()
+        .map_err(|error| format!("could not duplicate {}: {error}", server_log.display()))?;
 
     let mut command = Command::new(&node);
     command
@@ -847,16 +1002,8 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
         .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token)
         .stdin(Stdio::null());
-    if let Some(stdout) = stdout {
-        command.stdout(Stdio::from(stdout));
-    } else {
-        command.stdout(Stdio::null());
-    }
-    if let Some(stderr) = stderr {
-        command.stderr(Stdio::from(stderr));
-    } else {
-        command.stderr(Stdio::null());
-    }
+    command.stdout(Stdio::from(stdout));
+    command.stderr(Stdio::from(stderr));
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start background sidecar: {error}"))?;
@@ -879,10 +1026,17 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         }
     }
 
-    write_private_json(
-        &app_data_dir.join(DAEMON_STATE_FILE),
-        &serde_json::json!({ "pid": child_pid, "port": port }),
-    )?;
+    let lease = ProcessLease {
+        pid: child_pid,
+        identity: process_identity(child_pid)
+            .ok_or_else(|| "could not establish background sidecar identity".to_string())?,
+    };
+    let state = DaemonSidecarState { lease, port };
+    if let Err(error) = write_private_json(&app_data_dir.join(DAEMON_STATE_FILE), &state) {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(error);
+    }
     repair_tailscale_serve_for_port(port);
 
     let mut assertion: Option<PowerAssertion> = None;
@@ -987,8 +1141,8 @@ mod tests {
         );
         assert!(plist.contains("<string>ai.opencoven.cave</string>"));
         assert!(plist.contains("<string>--cave-sidecar-daemon</string>"));
-        assert!(plist.contains("<key>StartInterval</key>"));
         assert!(plist.contains("<key>SuccessfulExit</key>"));
+        assert!(plist.contains("<key>AbandonProcessGroup</key>\n  <false/>"));
         assert!(plist.contains("Coven&amp;Cave.app"));
     }
 
@@ -1021,5 +1175,38 @@ mod tests {
                 "http://127.0.0.1:3007".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn process_leases_reject_pid_reuse_with_a_different_identity() {
+        let lease = ProcessLease {
+            pid: 42,
+            identity: "Thu Jul 24 12:00:00 2026 /Applications/CovenCave".to_string(),
+        };
+        assert!(lease_matches(&lease, Some(&lease.identity)));
+        assert!(!lease_matches(
+            &lease,
+            Some("Thu Jul 24 12:00:01 2026 /usr/bin/unrelated")
+        ));
+        assert!(!lease_matches(&lease, None));
+    }
+
+    #[test]
+    fn daemon_readiness_log_is_empty_for_each_launch() {
+        let path = std::env::temp_dir().join(format!(
+            "coven-daemon-ready-test-{}-{:?}.log",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        std::fs::write(&path, "> Ready on http://127.0.0.1:3000\n").expect("seed stale log");
+        let mut fresh = create_fresh_log_file(&path).expect("truncate daemon log");
+        fresh
+            .write_all(b"> Ready on http://127.0.0.1:3007\n")
+            .expect("write new readiness");
+        fresh.sync_all().expect("flush readiness");
+        let log = std::fs::read_to_string(&path).expect("read fresh daemon log");
+        assert!(!log.contains("3000"));
+        assert!(log.contains("3007"));
+        let _ = std::fs::remove_file(path);
     }
 }

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -27,6 +27,9 @@ const SERVE_REPAIR_INTERVAL: Duration = Duration::from_secs(30);
 #[cfg(desktop)]
 const DAEMON_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
+#[cfg(all(desktop, target_os = "macos"))]
+static DAEMON_SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
 #[cfg(desktop)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, rename_all = "camelCase")]
@@ -911,6 +914,53 @@ fn create_fresh_log_file(path: &Path) -> Result<std::fs::File, String> {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
+fn daemon_shutdown_requested() -> bool {
+    DAEMON_SHUTDOWN_REQUESTED.load(Ordering::Acquire)
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn install_daemon_shutdown_handler() -> Result<(), String> {
+    DAEMON_SHUTDOWN_REQUESTED.store(false, Ordering::Release);
+    for signal in [
+        signal_hook_registry::consts::signal::SIGTERM,
+        signal_hook_registry::consts::signal::SIGINT,
+        signal_hook_registry::consts::signal::SIGHUP,
+    ] {
+        unsafe {
+            signal_hook_registry::register(signal, || {
+                DAEMON_SHUTDOWN_REQUESTED.store(true, Ordering::Release);
+            })
+        }
+        .map_err(|error| format!("could not install daemon shutdown handler: {error}"))?;
+    }
+    Ok(())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn wait_for_daemon_activity(duration: Duration) {
+    let deadline = Instant::now() + duration;
+    while !daemon_shutdown_requested() && Instant::now() < deadline {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        thread::sleep(remaining.min(Duration::from_millis(100)));
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn stop_daemon_children(
+    child: &mut std::process::Child,
+    assertion: &mut Option<PowerAssertion>,
+    state_path: &Path,
+) {
+    let _ = child.kill();
+    let _ = child.wait();
+    if let Some(mut assertion) = assertion.take() {
+        let _ = assertion.child.kill();
+        let _ = assertion.child.wait();
+    }
+    let _ = std::fs::remove_file(state_path);
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
 fn daemon_augmented_path(node: &Path) -> String {
     let mut directories = Vec::new();
     if let Some(directory) = node.parent() {
@@ -941,6 +991,7 @@ fn daemon_augmented_path(node: &Path) -> String {
 
 #[cfg(all(desktop, target_os = "macos"))]
 fn run_sidecar_daemon() -> Result<i32, String> {
+    install_daemon_shutdown_handler()?;
     let app_data_dir = app_data_path_without_handle()?;
     let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
     if !read_reachability_config(&config_path).daemon_mode {
@@ -949,10 +1000,13 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     // Keep one launchd wrapper alive while the GUI owns the server. This gives
     // crash recovery without StartInterval repeatedly launching app processes.
     while gui_is_active(&app_data_dir) {
+        if daemon_shutdown_requested() {
+            return Ok(0);
+        }
         if !read_reachability_config(&config_path).daemon_mode {
             return Ok(0);
         }
-        thread::sleep(Duration::from_secs(1));
+        wait_for_daemon_activity(Duration::from_secs(1));
     }
     // A previous wrapper can crash without reaping Node. Its signed state is
     // identity-checked before we stop it, so a restart never creates a second
@@ -1009,7 +1063,7 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         .map_err(|error| format!("could not start background sidecar: {error}"))?;
     let child_pid = child.id();
     match wait_for_sidecar_ready(port, &server_log, Duration::from_secs(30), || {
-        gui_is_active(&app_data_dir)
+        gui_is_active(&app_data_dir) || daemon_shutdown_requested()
     }) {
         PortWaitResult::Ready => {}
         PortWaitResult::Cancelled => {
@@ -1024,6 +1078,12 @@ fn run_sidecar_daemon() -> Result<i32, String> {
                 "background sidecar did not become ready on port {port}"
             ));
         }
+    }
+
+    if daemon_shutdown_requested() {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Ok(0);
     }
 
     let lease = ProcessLease {
@@ -1042,14 +1102,15 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     let mut assertion: Option<PowerAssertion> = None;
     let mut last_serve_repair = Instant::now();
     loop {
-        if gui_is_active(&app_data_dir) || !read_reachability_config(&config_path).daemon_mode {
-            let _ = child.kill();
-            let _ = child.wait();
-            if let Some(mut assertion) = assertion.take() {
-                let _ = assertion.child.kill();
-                let _ = assertion.child.wait();
-            }
-            let _ = std::fs::remove_file(app_data_dir.join(DAEMON_STATE_FILE));
+        if daemon_shutdown_requested()
+            || gui_is_active(&app_data_dir)
+            || !read_reachability_config(&config_path).daemon_mode
+        {
+            stop_daemon_children(
+                &mut child,
+                &mut assertion,
+                &app_data_dir.join(DAEMON_STATE_FILE),
+            );
             return Ok(0);
         }
         if let Some(status) = child
@@ -1087,7 +1148,7 @@ fn run_sidecar_daemon() -> Result<i32, String> {
             repair_tailscale_serve_for_port(port);
             last_serve_repair = Instant::now();
         }
-        thread::sleep(POWER_MONITOR_INTERVAL);
+        wait_for_daemon_activity(POWER_MONITOR_INTERVAL);
     }
 }
 

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -55,6 +55,7 @@ impl Default for DesktopReachabilityConfig {
 #[serde(rename_all = "camelCase")]
 pub(super) struct DesktopReachabilityStatus {
     supported: bool,
+    background_availability_supported: bool,
     config: DesktopReachabilityConfig,
     paired_phone_seen: bool,
     launch_agent_installed: bool,
@@ -581,6 +582,15 @@ fn uninstall_launch_agent(app_data_dir: &Path) -> Result<(), String> {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
+fn suspend_background_launch_agent(app_data_dir: &Path) -> Result<(), String> {
+    stop_recorded_daemon_sidecar(app_data_dir)?;
+    if launch_agent_installed() {
+        bootout_launch_agent()?;
+    }
+    Ok(())
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
 fn launch_agent_installed() -> bool {
     launch_agent_path().is_ok_and(|path| path.is_file())
 }
@@ -626,7 +636,17 @@ pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), Str
     let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
     let config = read_reachability_config(&config_path);
     if config.daemon_mode {
-        install_launch_agent(app, &app_data_dir)?;
+        if background_availability_supported() {
+            install_launch_agent(app, &app_data_dir)?;
+        } else {
+            // A development executable cannot be launched by launchd. Preserve
+            // the user's packaged-build opt-in, but stop any old packaged
+            // daemon before this GUI sidecar takes ownership.
+            suspend_background_launch_agent(&app_data_dir)?;
+            log::info!(
+                "[cave] background availability is unavailable in this development build; preserving its saved setting"
+            );
+        }
     } else if launch_agent_installed() {
         uninstall_launch_agent(&app_data_dir)?;
     }
@@ -644,7 +664,7 @@ pub(super) fn handoff_to_background_daemon(app: &tauri::AppHandle) {
         return;
     };
     let config = read_reachability_config(&app_data_dir.join(REACHABILITY_CONFIG_FILE));
-    if !config.daemon_mode {
+    if !config.daemon_mode || !background_availability_supported() {
         let _ = std::fs::remove_file(app_data_dir.join(GUI_ACTIVE_FILE));
         return;
     }
@@ -816,13 +836,19 @@ fn status_for_app(app: &tauri::AppHandle) -> Result<DesktopReachabilityStatus, S
     let runtime = app.try_state::<Arc<DesktopReachabilityRuntime>>();
     Ok(DesktopReachabilityStatus {
         supported: cfg!(target_os = "macos"),
+        background_availability_supported: background_availability_supported(),
         config,
         paired_phone_seen: paired_phone_seen(&paired_phone_path()),
         launch_agent_installed: launch_agent_installed(),
         prevent_sleep_active: runtime
             .as_ref()
             .is_some_and(|runtime| runtime.power_active()),
-        detail: if cfg!(target_os = "macos") {
+        detail: if cfg!(target_os = "macos") && !background_availability_supported() {
+            Some(
+                "Background availability is available in packaged macOS builds; this development build preserves the saved setting."
+                    .to_string(),
+            )
+        } else if cfg!(target_os = "macos") {
             None
         } else {
             Some("Desktop reachability controls are available in the macOS app.".to_string())
@@ -853,8 +879,10 @@ pub(super) fn desktop_reachability_configure(
         let config_path = app_data_dir.join(REACHABILITY_CONFIG_FILE);
         let previous = read_reachability_config(&config_path);
         write_private_json(&config_path, &config)?;
-        let launch_agent_result = if config.daemon_mode {
+        let launch_agent_result = if config.daemon_mode && background_availability_supported() {
             install_launch_agent(&app, &app_data_dir)
+        } else if config.daemon_mode {
+            suspend_background_launch_agent(&app_data_dir)
         } else {
             uninstall_launch_agent(&app_data_dir)
         };
@@ -891,6 +919,19 @@ fn daemon_resource_dir(executable: &Path) -> Result<PathBuf, String> {
         ));
     }
     Ok(resources)
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn background_availability_supported() -> bool {
+    !cfg!(debug_assertions)
+        && std::env::current_exe()
+            .ok()
+            .is_some_and(|executable| daemon_resource_dir(&executable).is_ok())
+}
+
+#[cfg(all(desktop, not(target_os = "macos")))]
+fn background_availability_supported() -> bool {
+    false
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -1086,10 +1127,17 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         return Ok(0);
     }
 
+    let identity = match process_identity(child_pid) {
+        Some(identity) => identity,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("could not establish background sidecar identity".to_string());
+        }
+    };
     let lease = ProcessLease {
         pid: child_pid,
-        identity: process_identity(child_pid)
-            .ok_or_else(|| "could not establish background sidecar identity".to_string())?,
+        identity,
     };
     let state = DaemonSidecarState { lease, port };
     if let Err(error) = write_private_json(&app_data_dir.join(DAEMON_STATE_FILE), &state) {

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::io::Write;
 #[cfg(desktop)]
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+#[cfg(all(desktop, target_os = "macos"))]
+use std::sync::OnceLock;
 
 #[cfg(desktop)]
 const REACHABILITY_CONFIG_FILE: &str = "desktop-reachability.json";
@@ -27,12 +29,17 @@ const MOBILE_PAIRED_FILE: &str = "mobile-paired.json";
 const POWER_MONITOR_INTERVAL: Duration = Duration::from_secs(5);
 #[cfg(desktop)]
 const SERVE_REPAIR_INTERVAL: Duration = Duration::from_secs(30);
+#[cfg(all(desktop, target_os = "macos"))]
+const SERVE_REPAIR_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(desktop)]
 const DAEMON_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[cfg(all(desktop, target_os = "macos"))]
 static DAEMON_SHUTDOWN_REQUESTED: AtomicBool = AtomicBool::new(false);
+
+#[cfg(all(desktop, target_os = "macos"))]
+static SERVE_REPAIR_STATE: OnceLock<Mutex<ServeRepairState>> = OnceLock::new();
 
 #[cfg(desktop)]
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -86,6 +93,13 @@ struct DaemonSidecarState {
     #[serde(flatten)]
     lease: ProcessLease,
     port: u16,
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+#[derive(Default)]
+struct ServeRepairState {
+    running: bool,
+    pending_port: Option<u16>,
 }
 
 /// An advisory lock shared by GUI startup and the launchd daemon. Holding it
@@ -400,32 +414,95 @@ pub(super) fn repair_tailscale_serve_for_port(port: u16) {
     if !mobile_mode_enabled() {
         return;
     }
-    thread::spawn(move || {
-        let args = serve_arguments(port);
-        match Command::new(tailscale_binary())
-            .args(&args)
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::piped())
-            .output()
-        {
-            Ok(output) if output.status.success() => {
+    let state = SERVE_REPAIR_STATE.get_or_init(|| Mutex::new(ServeRepairState::default()));
+    let should_spawn = {
+        let mut state = match state.lock() {
+            Ok(state) => state,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        state.pending_port = Some(port);
+        if state.running {
+            false
+        } else {
+            state.running = true;
+            true
+        }
+    };
+    if should_spawn {
+        thread::spawn(run_queued_tailscale_serve_repairs);
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_queued_tailscale_serve_repairs() {
+    let state = SERVE_REPAIR_STATE.get_or_init(|| Mutex::new(ServeRepairState::default()));
+    loop {
+        let port = {
+            let mut state = match state.lock() {
+                Ok(state) => state,
+                Err(poisoned) => poisoned.into_inner(),
+            };
+            match state.pending_port.take() {
+                Some(port) => port,
+                None => {
+                    state.running = false;
+                    return;
+                }
+            }
+        };
+        run_tailscale_serve_repair(port);
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_tailscale_serve_repair(port: u16) {
+    let args = serve_arguments(port);
+    let mut child = match Command::new(tailscale_binary())
+        .args(&args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(child) => child,
+        Err(error) => {
+            log::warn!("[cave] could not launch Tailscale Serve repair for port {port}: {error}");
+            return;
+        }
+    };
+    let deadline = Instant::now() + SERVE_REPAIR_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) if status.success() => {
                 log::info!("[cave] Tailscale Serve points at 127.0.0.1:{port}");
+                return;
             }
-            Ok(output) => {
-                let detail = String::from_utf8_lossy(&output.stderr);
+            Ok(Some(status)) => {
                 log::warn!(
-                    "[cave] could not repair Tailscale Serve for port {port}: {}",
-                    detail.trim()
+                    "[cave] could not repair Tailscale Serve for port {port}: exited with {status}"
                 );
+                return;
             }
+            Ok(None) if Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                log::warn!(
+                    "[cave] Tailscale Serve repair for port {port} timed out after {}s",
+                    SERVE_REPAIR_TIMEOUT.as_secs()
+                );
+                return;
+            }
+            Ok(None) => thread::sleep(Duration::from_millis(100)),
             Err(error) => {
+                let _ = child.kill();
+                let _ = child.wait();
                 log::warn!(
-                    "[cave] could not launch Tailscale Serve repair for port {port}: {error}"
+                    "[cave] could not wait for Tailscale Serve repair for port {port}: {error}"
                 );
+                return;
             }
         }
-    });
+    }
 }
 
 #[cfg(all(desktop, not(target_os = "macos")))]

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -2,6 +2,8 @@
 
 use super::*;
 
+#[cfg(all(desktop, target_os = "macos"))]
+use fs2::FileExt;
 #[cfg(desktop)]
 use serde::{Deserialize, Serialize};
 #[cfg(desktop)]
@@ -15,6 +17,8 @@ const REACHABILITY_CONFIG_FILE: &str = "desktop-reachability.json";
 const GUI_ACTIVE_FILE: &str = "desktop-gui-active.json";
 #[cfg(desktop)]
 const DAEMON_STATE_FILE: &str = "desktop-daemon-state.json";
+#[cfg(all(desktop, target_os = "macos"))]
+const OWNERSHIP_LOCK_FILE: &str = "desktop-reachability-ownership.lock";
 #[cfg(desktop)]
 const LAUNCH_AGENT_LABEL: &str = "ai.opencoven.cave";
 #[cfg(desktop)]
@@ -82,6 +86,21 @@ struct DaemonSidecarState {
     #[serde(flatten)]
     lease: ProcessLease,
     port: u16,
+}
+
+/// An advisory lock shared by GUI startup and the launchd daemon. Holding it
+/// from the last GUI-marker check through daemon-state persistence prevents an
+/// unrecorded daemon child from racing a newly-started GUI sidecar.
+#[cfg(all(desktop, target_os = "macos"))]
+struct ReachabilityOwnershipLease {
+    file: std::fs::File,
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+impl Drop for ReachabilityOwnershipLease {
+    fn drop(&mut self) {
+        let _ = FileExt::unlock(&self.file);
+    }
 }
 
 #[cfg(desktop)]
@@ -289,6 +308,28 @@ fn write_private_json<T: Serialize>(path: &Path, value: &T) -> Result<(), String
         .map_err(|error| format!("could not replace {}: {error}", path.display()))
 }
 
+#[cfg(all(desktop, target_os = "macos"))]
+fn acquire_reachability_ownership_lease(
+    app_data_dir: &Path,
+) -> Result<ReachabilityOwnershipLease, String> {
+    std::fs::create_dir_all(app_data_dir)
+        .map_err(|error| format!("could not create {}: {error}", app_data_dir.display()))?;
+    let path = app_data_dir.join(OWNERSHIP_LOCK_FILE);
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).write(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let file = options
+        .open(&path)
+        .map_err(|error| format!("could not open {}: {error}", path.display()))?;
+    file.lock_exclusive()
+        .map_err(|error| format!("could not acquire reachability ownership: {error}"))?;
+    Ok(ReachabilityOwnershipLease { file })
+}
+
 #[cfg(desktop)]
 fn mobile_mode_enabled() -> bool {
     let path = cave_home_path().join("preferences.json");
@@ -491,11 +532,6 @@ fn launch_agent_domain() -> Result<String, String> {
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
-fn launch_agent_service() -> Result<String, String> {
-    Ok(format!("{}/{}", launch_agent_domain()?, LAUNCH_AGENT_LABEL))
-}
-
-#[cfg(all(desktop, target_os = "macos"))]
 fn run_launchctl(args: &[&str]) -> Result<(), String> {
     let output = Command::new("/bin/launchctl")
         .args(args)
@@ -509,8 +545,10 @@ fn run_launchctl(args: &[&str]) -> Result<(), String> {
 
 #[cfg(all(desktop, target_os = "macos"))]
 fn bootout_launch_agent() -> Result<(), String> {
-    let service = launch_agent_service()?;
-    match run_launchctl(&["bootout", &service]) {
+    let domain = launch_agent_domain()?;
+    let plist_path = launch_agent_path()?;
+    let plist_arg = plist_path.to_string_lossy().into_owned();
+    match run_launchctl(&["bootout", &domain, &plist_arg]) {
         Ok(()) => Ok(()),
         // A missing service is normal on first install and after a clean
         // handoff. All other launchd failures are ownership failures: do not
@@ -518,6 +556,7 @@ fn bootout_launch_agent() -> Result<(), String> {
         Err(error)
             if error.contains("Could not find service")
                 || error.contains("No such process")
+                || error.contains("No such file")
                 || error.contains("not found") =>
         {
             Ok(())
@@ -630,6 +669,7 @@ pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), Str
         .path()
         .app_data_dir()
         .map_err(|error| format!("could not resolve app data: {error}"))?;
+    let _ownership = acquire_reachability_ownership_lease(&app_data_dir)?;
     let marker = app_data_dir.join(GUI_ACTIVE_FILE);
     write_private_json(&marker, &current_process_lease()?)?;
 
@@ -661,6 +701,10 @@ pub(super) fn prepare_gui_reachability(_app: &tauri::AppHandle) -> Result<(), St
 #[cfg(all(desktop, target_os = "macos"))]
 pub(super) fn handoff_to_background_daemon(app: &tauri::AppHandle) {
     let Ok(app_data_dir) = app.path().app_data_dir() else {
+        return;
+    };
+    let Ok(_ownership) = acquire_reachability_ownership_lease(&app_data_dir) else {
+        log::warn!("[cave] could not acquire reachability ownership for daemon handoff");
         return;
     };
     let config = read_reachability_config(&app_data_dir.join(REACHABILITY_CONFIG_FILE));
@@ -1099,34 +1143,21 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         .stdin(Stdio::null());
     command.stdout(Stdio::from(stdout));
     command.stderr(Stdio::from(stderr));
+    // Take the same lease as GUI startup immediately before creating the
+    // child. A GUI that wins this lease writes its marker first; a daemon that
+    // wins records its child before releasing it, so the GUI can stop it
+    // during takeover instead of leaving an untracked fallback-port server.
+    let ownership = acquire_reachability_ownership_lease(&app_data_dir)?;
+    if gui_is_active(&app_data_dir)
+        || daemon_shutdown_requested()
+        || !read_reachability_config(&config_path).daemon_mode
+    {
+        return Ok(0);
+    }
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start background sidecar: {error}"))?;
     let child_pid = child.id();
-    match wait_for_sidecar_ready(port, &server_log, Duration::from_secs(30), || {
-        gui_is_active(&app_data_dir) || daemon_shutdown_requested()
-    }) {
-        PortWaitResult::Ready => {}
-        PortWaitResult::Cancelled => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Ok(0);
-        }
-        PortWaitResult::TimedOut => {
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err(format!(
-                "background sidecar did not become ready on port {port}"
-            ));
-        }
-    }
-
-    if daemon_shutdown_requested() {
-        let _ = child.kill();
-        let _ = child.wait();
-        return Ok(0);
-    }
-
     let identity = match process_identity(child_pid) {
         Some(identity) => identity,
         None => {
@@ -1140,11 +1171,41 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         identity,
     };
     let state = DaemonSidecarState { lease, port };
-    if let Err(error) = write_private_json(&app_data_dir.join(DAEMON_STATE_FILE), &state) {
+    let state_path = app_data_dir.join(DAEMON_STATE_FILE);
+    if let Err(error) = write_private_json(&state_path, &state) {
         let _ = child.kill();
         let _ = child.wait();
         return Err(error);
     }
+    drop(ownership);
+
+    match wait_for_sidecar_ready(port, &server_log, Duration::from_secs(30), || {
+        gui_is_active(&app_data_dir) || daemon_shutdown_requested()
+    }) {
+        PortWaitResult::Ready => {}
+        PortWaitResult::Cancelled => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&state_path);
+            return Ok(0);
+        }
+        PortWaitResult::TimedOut => {
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&state_path);
+            return Err(format!(
+                "background sidecar did not become ready on port {port}"
+            ));
+        }
+    }
+
+    if daemon_shutdown_requested() {
+        let _ = child.kill();
+        let _ = child.wait();
+        let _ = std::fs::remove_file(&state_path);
+        return Ok(0);
+    }
+
     repair_tailscale_serve_for_port(port);
 
     let mut assertion: Option<PowerAssertion> = None;

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -6,6 +6,8 @@ use super::*;
 use fs2::FileExt;
 #[cfg(desktop)]
 use serde::{Deserialize, Serialize};
+#[cfg(all(desktop, target_os = "macos"))]
+use std::io::Read;
 #[cfg(desktop)]
 use std::io::Write;
 #[cfg(desktop)]
@@ -93,6 +95,13 @@ struct DaemonSidecarState {
     #[serde(flatten)]
     lease: ProcessLease,
     port: u16,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TailscaleServeMode {
+    Https,
+    Http(u16),
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -347,16 +356,22 @@ fn acquire_reachability_ownership_lease(
 #[cfg(desktop)]
 fn mobile_mode_enabled() -> bool {
     let path = cave_home_path().join("preferences.json");
-    std::fs::read_to_string(path)
-        .ok()
-        .and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
+    let raw = std::fs::read_to_string(path).ok();
+    mobile_mode_enabled_from_preferences(raw.as_deref())
+}
+
+#[cfg(desktop)]
+fn mobile_mode_enabled_from_preferences(raw: Option<&str>) -> bool {
+    raw.and_then(|raw| serde_json::from_str::<serde_json::Value>(&raw).ok())
         .and_then(|value| {
             value
                 .get("phone")
                 .and_then(|phone| phone.get("mobileMode"))
                 .and_then(serde_json::Value::as_bool)
         })
-        .unwrap_or(false)
+        // Match the preference schema: mobile mode is enabled until the user
+        // explicitly persists it as false.
+        .unwrap_or(true)
 }
 
 #[cfg(desktop)]
@@ -385,6 +400,45 @@ fn serve_arguments(port: u16) -> [String; 3] {
         "--bg".to_string(),
         format!("http://127.0.0.1:{port}"),
     ]
+}
+
+#[cfg(desktop)]
+fn http_serve_arguments(port: u16, http_port: u16) -> [String; 4] {
+    [
+        "serve".to_string(),
+        "--bg".to_string(),
+        format!("--http={http_port}"),
+        format!("http://127.0.0.1:{port}"),
+    ]
+}
+
+#[cfg(desktop)]
+fn serve_mode_from_status(status: &serde_json::Value) -> Option<TailscaleServeMode> {
+    let web = status.get("Web")?.as_object()?;
+    if web.is_empty() {
+        return None;
+    }
+    let http_port = status
+        .get("TCP")
+        .and_then(serde_json::Value::as_object)
+        .and_then(|tcp| {
+            tcp.iter().find_map(|(port, config)| {
+                (config.get("HTTP").and_then(serde_json::Value::as_bool) == Some(true))
+                    .then(|| port.parse::<u16>().ok())
+                    .flatten()
+            })
+        })
+        .or_else(|| {
+            web.keys().find_map(|host| {
+                host.rsplit_once(':')
+                    .and_then(|(_, port)| port.parse::<u16>().ok())
+                    .filter(|port| *port != 443)
+            })
+        });
+    Some(match http_port {
+        Some(port) => TailscaleServeMode::Http(port),
+        None => TailscaleServeMode::Https,
+    })
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -456,50 +510,107 @@ fn run_queued_tailscale_serve_repairs() {
 
 #[cfg(all(desktop, target_os = "macos"))]
 fn run_tailscale_serve_repair(port: u16) {
-    let args = serve_arguments(port);
-    let mut child = match Command::new(tailscale_binary())
-        .args(&args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        Ok(child) => child,
+    let status_args = [
+        "serve".to_string(),
+        "status".to_string(),
+        "--json".to_string(),
+    ];
+    let mode = match run_tailscale_command(&status_args) {
+        Ok(output) if output.status.success() => serde_json::from_slice(&output.stdout)
+            .ok()
+            .and_then(|status| serve_mode_from_status(&status)),
+        Ok(output) => {
+            log::warn!(
+                "[cave] could not inspect Tailscale Serve before repairing port {port}: exited with {}",
+                output.status
+            );
+            None
+        }
         Err(error) => {
-            log::warn!("[cave] could not launch Tailscale Serve repair for port {port}: {error}");
-            return;
+            log::warn!(
+                "[cave] could not inspect Tailscale Serve before repairing port {port}: {error}"
+            );
+            None
         }
     };
+    let Some(mode) = mode else {
+        // There is no paired Serve route to repair. Avoid creating an HTTPS
+        // listener that could overwrite an unavailable or managed fallback.
+        return;
+    };
+    let args = match mode {
+        TailscaleServeMode::Https => serve_arguments(port).to_vec(),
+        TailscaleServeMode::Http(http_port) => http_serve_arguments(port, http_port).to_vec(),
+    };
+    match run_tailscale_command(&args) {
+        Ok(output) if output.status.success() => {
+            log::info!("[cave] Tailscale Serve points at 127.0.0.1:{port}");
+        }
+        Ok(output) => {
+            log::warn!(
+                "[cave] could not repair Tailscale Serve for port {port}: exited with {}",
+                output.status
+            );
+        }
+        Err(error) => {
+            log::warn!("[cave] could not repair Tailscale Serve for port {port}: {error}");
+        }
+    }
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+struct TailscaleCommandOutput {
+    status: std::process::ExitStatus,
+    stdout: Vec<u8>,
+}
+
+#[cfg(all(desktop, target_os = "macos"))]
+fn run_tailscale_command(args: &[String]) -> Result<TailscaleCommandOutput, String> {
+    let command_name = args.join(" ");
+    let mut child = Command::new(tailscale_binary())
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .map_err(|error| format!("could not launch Tailscale {command_name}: {error}"))?;
+    let stdout = child.stdout.take().map(|mut stdout| {
+        thread::spawn(move || {
+            let mut output = Vec::new();
+            let _ = stdout.read_to_end(&mut output);
+            output
+        })
+    });
     let deadline = Instant::now() + SERVE_REPAIR_TIMEOUT;
     loop {
         match child.try_wait() {
-            Ok(Some(status)) if status.success() => {
-                log::info!("[cave] Tailscale Serve points at 127.0.0.1:{port}");
-                return;
-            }
             Ok(Some(status)) => {
-                log::warn!(
-                    "[cave] could not repair Tailscale Serve for port {port}: exited with {status}"
-                );
-                return;
+                let stdout = stdout
+                    .and_then(|reader| reader.join().ok())
+                    .unwrap_or_default();
+                return Ok(TailscaleCommandOutput { status, stdout });
             }
             Ok(None) if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
-                log::warn!(
-                    "[cave] Tailscale Serve repair for port {port} timed out after {}s",
+                if let Some(reader) = stdout {
+                    let _ = reader.join();
+                }
+                return Err(format!(
+                    "Tailscale {command_name} timed out after {}s",
                     SERVE_REPAIR_TIMEOUT.as_secs()
-                );
-                return;
+                ));
             }
             Ok(None) => thread::sleep(Duration::from_millis(100)),
             Err(error) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                log::warn!(
-                    "[cave] could not wait for Tailscale Serve repair for port {port}: {error}"
-                );
-                return;
+                if let Some(reader) = stdout {
+                    let _ = reader.join();
+                }
+                return Err(format!(
+                    "could not wait for Tailscale {command_name}: {error}"
+                ));
             }
         }
     }
@@ -1422,6 +1533,46 @@ mod tests {
                 "http://127.0.0.1:3007".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn mobile_mode_uses_the_schema_default_until_explicitly_disabled() {
+        assert!(mobile_mode_enabled_from_preferences(None));
+        assert!(mobile_mode_enabled_from_preferences(Some("{}")));
+        assert!(!mobile_mode_enabled_from_preferences(Some(
+            r#"{"phone":{"mobileMode":false}}"#
+        )));
+    }
+
+    #[test]
+    fn serve_repair_preserves_the_existing_http_fallback_port() {
+        let http_status = serde_json::json!({
+            "TCP": { "3000": { "HTTP": true } },
+            "Web": { "100.101.102.103:3000": { "Handlers": { "/": { "Proxy": "http://127.0.0.1:3000" } } } }
+        });
+        assert_eq!(
+            serve_mode_from_status(&http_status),
+            Some(TailscaleServeMode::Http(3000))
+        );
+        assert_eq!(
+            http_serve_arguments(3007, 3000),
+            [
+                "serve".to_string(),
+                "--bg".to_string(),
+                "--http=3000".to_string(),
+                "http://127.0.0.1:3007".to_string(),
+            ]
+        );
+
+        let https_status = serde_json::json!({
+            "TCP": { "443": { "HTTPS": true } },
+            "Web": { "cave.tailnet.ts.net:443": { "Handlers": { "/": { "Proxy": "http://127.0.0.1:3000" } } } }
+        });
+        assert_eq!(
+            serve_mode_from_status(&https_status),
+            Some(TailscaleServeMode::Https)
+        );
+        assert_eq!(serve_mode_from_status(&serde_json::json!({})), None);
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ mod app_lifecycle_tests;
 #[cfg(desktop)]
 pub mod browser;
 #[cfg(desktop)]
+mod desktop_reachability;
+#[cfg(desktop)]
 mod platform_lifecycle;
 #[cfg(desktop)]
 mod pty;
@@ -71,6 +73,8 @@ mod window_geometry;
 #[cfg(all(desktop, target_os = "windows"))]
 mod windows_process_job;
 
+#[cfg(desktop)]
+use desktop_reachability::*;
 #[cfg(desktop)]
 use platform_lifecycle::*;
 #[cfg(desktop)]

--- a/src-tauri/src/sidecar_lifecycle.rs
+++ b/src-tauri/src/sidecar_lifecycle.rs
@@ -22,6 +22,20 @@ impl SidecarProcess {
     pub(super) fn id(&self) -> u32 {
         self.child.id()
     }
+
+    /// A reachability assertion may only follow the exact child retained by
+    /// this state. PID existence alone is not ownership: the OS may reuse a
+    /// PID after a crashed sidecar exits.
+    #[cfg(target_os = "macos")]
+    pub(super) fn is_live_with_pid(&mut self, pid: u32) -> Result<bool, String> {
+        if self.child.id() != pid {
+            return Ok(false);
+        }
+        self.child
+            .try_wait()
+            .map(|status| status.is_none())
+            .map_err(|error| format!("could not inspect sidecar process: {error}"))
+    }
 }
 
 #[cfg(desktop)]

--- a/src-tauri/src/sidecar_lifecycle.rs
+++ b/src-tauri/src/sidecar_lifecycle.rs
@@ -18,6 +18,10 @@ impl SidecarProcess {
     pub(super) fn new(child: Child) -> Self {
         Self { child }
     }
+
+    pub(super) fn id(&self) -> u32 {
+        self.child.id()
+    }
 }
 
 #[cfg(desktop)]

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -281,6 +281,7 @@ pub(super) fn start_sidecar_runtime(
     };
     #[cfg(not(target_os = "windows"))]
     let child = SidecarProcess::new(child);
+    let sidecar_pid = child.id();
     let sidecar_state = app.state::<SidecarState>();
     match sidecar_state.0.lock() {
         Ok(mut sidecar) => *sidecar = Some(child),
@@ -326,6 +327,8 @@ pub(super) fn start_sidecar_runtime(
             )));
         }
     }
+
+    sidecar_reachability_ready(app, port, sidecar_pid);
 
     #[cfg(target_os = "windows")]
     sidecar_archive::cleanup_stale_sidecar_runtimes(&server_dir_root);

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -298,7 +298,7 @@ pub fn run() {
             }
 
             app.handle().plugin(tauri_plugin_notification::init())?;
-            prepare_gui_reachability(app.handle());
+            prepare_gui_reachability(app.handle())?;
 
             // Desktop auto-update: updater checks/downloads/installs signed
             // release artifacts; process provides relaunch() after install.

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -613,15 +613,22 @@ pub fn run() {
 
             if let tauri::WindowEvent::Destroyed = event {
                 if window.label() == "main" {
-                    if let Some(state) = window.app_handle().try_state::<SidecarState>() {
-                        if let Err(error) = state.stop() {
-                            log::warn!(
-                                "[cave] could not stop sidecar during window teardown: {error}"
-                            );
-                        }
+                    let sidecar_stopped = match window.app_handle().try_state::<SidecarState>() {
+                        Some(state) => match state.stop() {
+                            Ok(()) => true,
+                            Err(error) => {
+                                log::warn!(
+                                    "[cave] could not stop sidecar during window teardown; retaining GUI ownership: {error}"
+                                );
+                                false
+                            }
+                        },
+                        None => true,
+                    };
+                    if sidecar_stopped {
+                        sidecar_reachability_stopped(window.app_handle());
+                        handoff_to_background_daemon(window.app_handle());
                     }
-                    sidecar_reachability_stopped(window.app_handle());
-                    handoff_to_background_daemon(window.app_handle());
                 }
             }
         })

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -297,6 +297,10 @@ pub fn run() {
                 )?;
             }
 
+            // A translocated app exits here, before it can persist a
+            // LaunchAgent that points at the temporary DMG/quarantine path.
+            check_app_translocation();
+
             app.handle().plugin(tauri_plugin_notification::init())?;
             prepare_gui_reachability(app.handle())?;
 
@@ -317,8 +321,6 @@ pub fn run() {
             };
             app.handle().plugin(updater_builder.build())?;
             app.handle().plugin(tauri_plugin_process::init())?;
-
-            check_app_translocation();
 
             // Dev builds: when the configured dev server (tauri.conf.json
             // `build.devUrl` — `pnpm dev`) is live, point the main webview

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -141,6 +141,11 @@ fn webview_probe_report(report: String) -> Result<(), String> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(desktop)]
+    if let Some(code) = run_sidecar_daemon_if_requested() {
+        std::process::exit(code);
+    }
+
     #[cfg(all(desktop, target_os = "windows"))]
     if let Some(code) = windows_process_job::run_gated_child_if_requested() {
         std::process::exit(code);
@@ -229,6 +234,8 @@ pub fn run() {
     #[cfg(desktop)]
     let sidecar_process = Arc::new(Mutex::new(None));
     #[cfg(desktop)]
+    let reachability_runtime = Arc::new(DesktopReachabilityRuntime::default());
+    #[cfg(desktop)]
     let builder = builder
         .invoke_handler(tauri::generate_handler![
             pty::pty_start,
@@ -258,6 +265,8 @@ pub fn run() {
             speech::speech_stt_start,
             speech::speech_stt_finish,
             speech::speech_stt_stop,
+            desktop_reachability_status,
+            desktop_reachability_configure,
             #[cfg(target_os = "windows")]
             sidecar_startup_status,
             #[cfg(target_os = "windows")]
@@ -266,6 +275,7 @@ pub fn run() {
             cancel_sidecar_startup,
         ])
         .manage(SidecarState(Arc::clone(&sidecar_process)))
+        .manage(Arc::clone(&reachability_runtime))
         .manage(browser::BrowserLifecycleState::default());
     #[cfg(all(desktop, target_os = "windows"))]
     let builder = builder.manage(Arc::new(SidecarStartupControl::new()));
@@ -288,6 +298,7 @@ pub fn run() {
             }
 
             app.handle().plugin(tauri_plugin_notification::init())?;
+            prepare_gui_reachability(app.handle());
 
             // Desktop auto-update: updater checks/downloads/installs signed
             // release artifacts; process provides relaunch() after install.
@@ -609,6 +620,8 @@ pub fn run() {
                             );
                         }
                     }
+                    sidecar_reachability_stopped(window.app_handle());
+                    handoff_to_background_daemon(window.app_handle());
                 }
             }
         })

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -403,6 +403,11 @@ assert.match(
 );
 assert.match(
   settings,
-  /<SettingsGroup label="Get the app">(?:(?!<SettingsGroup )[\s\S])*<\/SettingsGroup>\s*<SettingsGroup label="Phone write access">/,
-  "install comes before the deep supporting groups — Phone write access directly follows Get the app",
+  /<SettingsGroup label="Get the app">(?:(?!<SettingsGroup )[\s\S])*<\/SettingsGroup>\s*<SettingsGroup label="Keep this Mac reachable">/,
+  "desktop reachability follows installation as the first supporting group",
+);
+assert.match(
+  settings,
+  /<SettingsGroup label="Keep this Mac reachable">(?:(?!<SettingsGroup )[\s\S])*<\/SettingsGroup>\s*<SettingsGroup label="Phone write access">/,
+  "Phone write access directly follows desktop reachability",
 );

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -10,6 +10,7 @@ import { relativeTime } from "@/lib/relative-time";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { SettingsGroup, settingsGroupId } from "@/components/ui/settings-group";
 import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
 import { IconButton } from "@/components/ui/icon-button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { SettingControlRow, Segmented } from "@/components/ui/settings-controls";
@@ -82,6 +83,12 @@ import {
   reapplyIndependentAppearance,
 } from "@/lib/appearance-restore";
 import type { CustomThemeData } from "@/lib/preferences-schema";
+import {
+  readDesktopReachability,
+  writeDesktopReachability,
+  type DesktopReachabilityConfig,
+  type DesktopReachabilityStatus,
+} from "@/lib/desktop-reachability";
 import { publishFleetTokenStatus } from "@/lib/omnigent/use-fleet-gate";
 import {
   formatHostWorkspaceText,
@@ -2997,6 +3004,148 @@ function MobileModeToggle({ onUseAsHub }: { onUseAsHub: (url: string) => void })
   );
 }
 
+type ReachabilitySettingKey = keyof DesktopReachabilityConfig;
+
+function DesktopReachabilityCard() {
+  const [status, setStatus] = useState<DesktopReachabilityStatus | null>(null);
+  const [busyKey, setBusyKey] = useState<ReachabilitySettingKey | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+  const { announce } = useAnnouncer();
+
+  useEffect(() => {
+    let cancelled = false;
+    setError(null);
+    void readDesktopReachability()
+      .then((next) => {
+        if (!cancelled) setStatus(next);
+      })
+      .catch(() => {
+        if (!cancelled) setError("Couldn't load Mac reachability settings.");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadKey]);
+
+  const update = async (key: ReachabilitySettingKey, enabled: boolean) => {
+    if (!status?.supported || busyKey) return;
+    const config = { ...status.config, [key]: enabled };
+    setBusyKey(key);
+    setError(null);
+    try {
+      const next = await writeDesktopReachability(config);
+      setStatus(next);
+      const labels: Record<ReachabilitySettingKey, string> = {
+        preventSleep: "Keep Mac awake for phone",
+        preventSleepOnAcOnly: "Only keep awake on power",
+        daemonMode: "Background availability",
+      };
+      announce(`${labels[key]} ${enabled ? "enabled" : "disabled"}.`, "polite");
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : "Couldn't update Mac reachability.");
+    } finally {
+      setBusyKey(null);
+    }
+  };
+
+  const switchButton = (key: ReachabilitySettingKey, disabled = false) => {
+    const on = status?.config[key] === true;
+    return (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={on}
+        onClick={() => void update(key, !on)}
+        disabled={!status?.supported || busyKey !== null || disabled}
+        className={`settings-mobile-switch focus-ring shrink-0 rounded-[var(--radius-control)] border px-3 py-1.5 text-[length:var(--text-sm)] transition-colors ${
+          on
+            ? "border-[var(--accent-presence)] bg-[var(--accent-presence)] text-[var(--accent-presence-foreground)]"
+            : "border-[var(--border-hairline)] bg-[var(--bg-base)] text-[var(--text-secondary)]"
+        }`}
+      >
+        {busyKey === key ? "Updating…" : on ? "On" : "Off"}
+      </button>
+    );
+  };
+
+  if (!status && error) {
+    return (
+      <ErrorState
+        compact
+        headline="Couldn't load Mac reachability settings"
+        subtitle={error}
+        actions={
+          <Button size="sm" onClick={() => setReloadKey((key) => key + 1)}>
+            Retry
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (!status) {
+    return (
+      <p role="status" className="px-4 py-3 text-[length:var(--text-sm)] text-[var(--text-muted)]">
+        Loading Mac reachability…
+      </p>
+    );
+  }
+
+  if (!status.supported) {
+    return (
+      <p role="status" className="px-4 py-3 text-[length:var(--text-sm)] text-[var(--text-muted)]">
+        {status.detail ?? "These controls are available in the macOS desktop app."}
+      </p>
+    );
+  }
+
+  return (
+    <>
+      <SettingsRow
+        label="Keep Mac awake for phone"
+        description={
+          status.pairedPhoneSeen
+            ? status.preventSleepActive
+              ? "A paired phone is present, so macOS idle sleep is currently prevented."
+              : "Prevent idle sleep whenever this Mac has a paired phone."
+            : "Starts after a phone pairs. Off leaves the Mac's normal sleep settings unchanged."
+        }
+      >
+        {switchButton("preventSleep")}
+      </SettingsRow>
+      <SettingsRow
+        label="Only keep awake on power"
+        description="Recommended. On battery, the Mac follows its normal sleep settings."
+      >
+        {switchButton("preventSleepOnAcOnly", !status.config.preventSleep)}
+      </SettingsRow>
+      <SettingsRow
+        label="Background availability"
+        description="Keep the Cave server available after the main window closes. A macOS LaunchAgent starts it without opening the app."
+      >
+        {switchButton("daemonMode")}
+      </SettingsRow>
+      <div className="px-4 pb-3 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
+        <p>
+          Tailscale can't wake a sleeping Mac: its network daemon sleeps with the computer, and Bonjour sleep proxy only
+          works on the local network. Use the keep-awake option or an always-on hub when the phone must stay connected.
+        </p>
+        {status.config.daemonMode && status.launchAgentInstalled ? (
+          <p className="mt-2 text-[var(--text-secondary)]">
+            Background availability is installed and takes over when this window closes.
+          </p>
+        ) : null}
+      </div>
+      {error ? (
+        <p role="alert" className="px-4 pb-3 text-[length:var(--text-xs)] text-[var(--color-warning)]">
+          {error}
+        </p>
+      ) : null}
+    </>
+  );
+}
+
 /** Desktop opt-ins for what the paired phone may change (GET/PATCH
  *  /api/mobile-permissions). Both default off; the route only accepts the
  *  PATCH from this desktop (loopback), so the phone can never widen its own
@@ -3194,6 +3343,10 @@ function MobileSection({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
             Setup guide
           </Button>
         </div>
+      </SettingsGroup>
+
+      <SettingsGroup label="Keep this Mac reachable">
+        <DesktopReachabilityCard />
       </SettingsGroup>
 
       <SettingsGroup label="Phone write access">

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -3056,6 +3056,13 @@ function DesktopReachabilityCard() {
         type="button"
         role="switch"
         aria-checked={on}
+        aria-label={
+          {
+            preventSleep: "Keep Mac awake for phone",
+            preventSleepOnAcOnly: "Only keep awake on power",
+            daemonMode: "Background availability",
+          }[key]
+        }
         onClick={() => void update(key, !on)}
         disabled={!status?.supported || busyKey !== null || disabled}
         className={`settings-mobile-switch focus-ring shrink-0 rounded-[var(--radius-control)] border px-3 py-1.5 text-[length:var(--text-sm)] transition-colors ${

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -3107,6 +3107,8 @@ function DesktopReachabilityCard() {
     );
   }
 
+  const backgroundAvailabilityUnavailable = status.backgroundAvailabilitySupported === false;
+
   return (
     <>
       <SettingsRow
@@ -3129,9 +3131,13 @@ function DesktopReachabilityCard() {
       </SettingsRow>
       <SettingsRow
         label="Background availability"
-        description="Keep the Cave server available after the main window closes. A macOS LaunchAgent starts it without opening the app."
+        description={
+          backgroundAvailabilityUnavailable
+            ? "Available in packaged macOS builds. This development build preserves the saved choice without starting a LaunchAgent."
+            : "Keep the Cave server available after the main window closes. A macOS LaunchAgent starts it without opening the app."
+        }
       >
-        {switchButton("daemonMode")}
+        {switchButton("daemonMode", backgroundAvailabilityUnavailable)}
       </SettingsRow>
       <div className="px-4 pb-3 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
         <p>

--- a/src/lib/desktop-reachability.ts
+++ b/src/lib/desktop-reachability.ts
@@ -1,0 +1,49 @@
+"use client";
+
+export type DesktopReachabilityConfig = {
+  preventSleep: boolean;
+  preventSleepOnAcOnly: boolean;
+  daemonMode: boolean;
+};
+
+export type DesktopReachabilityStatus = {
+  supported: boolean;
+  config: DesktopReachabilityConfig;
+  pairedPhoneSeen: boolean;
+  launchAgentInstalled: boolean;
+  preventSleepActive: boolean;
+  detail?: string | null;
+};
+
+const UNSUPPORTED: DesktopReachabilityStatus = {
+  supported: false,
+  config: {
+    preventSleep: false,
+    preventSleepOnAcOnly: true,
+    daemonMode: false,
+  },
+  pairedPhoneSeen: false,
+  launchAgentInstalled: false,
+  preventSleepActive: false,
+  detail: "Desktop reachability controls are available in the macOS app.",
+};
+
+async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): Promise<T | null> {
+  if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return null;
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke<T>(command, args);
+}
+
+export async function readDesktopReachability(): Promise<DesktopReachabilityStatus> {
+  return (await tauriInvoke<DesktopReachabilityStatus>("desktop_reachability_status")) ?? UNSUPPORTED;
+}
+
+export async function writeDesktopReachability(
+  config: DesktopReachabilityConfig,
+): Promise<DesktopReachabilityStatus> {
+  const result = await tauriInvoke<DesktopReachabilityStatus>("desktop_reachability_configure", {
+    config,
+  });
+  if (!result) throw new Error(UNSUPPORTED.detail ?? "Desktop reachability is unavailable.");
+  return result;
+}

--- a/src/lib/desktop-reachability.ts
+++ b/src/lib/desktop-reachability.ts
@@ -8,6 +8,7 @@ export type DesktopReachabilityConfig = {
 
 export type DesktopReachabilityStatus = {
   supported: boolean;
+  backgroundAvailabilitySupported?: boolean;
   config: DesktopReachabilityConfig;
   pairedPhoneSeen: boolean;
   launchAgentInstalled: boolean;

--- a/src/lib/desktop-reachability.ts
+++ b/src/lib/desktop-reachability.ts
@@ -31,6 +31,13 @@ const UNSUPPORTED: DesktopReachabilityStatus = {
 
 async function tauriInvoke<T>(command: string, args?: Record<string, unknown>): Promise<T | null> {
   if (typeof window === "undefined" || !("__TAURI_INTERNALS__" in window)) return null;
+  try {
+    const { platform } = await import("@tauri-apps/plugin-os");
+    const os = platform();
+    if (os === "ios" || os === "android") return null;
+  } catch {
+    // Older desktop builds or minimal shells may not have the OS plugin; assume desktop.
+  }
   const { invoke } = await import("@tauri-apps/api/core");
   return invoke<T>(command, args);
 }


### PR DESCRIPTION
## Summary

- add opt-in macOS prevent-sleep handling for paired-phone/mobile mode sessions, defaulting off with AC-only enabled by default
- add an optional default-off per-user LaunchAgent that runs the bundled loopback-only `server.mjs` after the GUI closes, while preserving the persisted mobile access token
- reconcile Tailscale Serve to the server's actual loopback port after readiness, including fallback ports, and safely unload/remove the agent when disabled or uninstalling
- expose the policies in Settings and document that Tailscale cannot wake a sleeping Mac

Closes #3813
Bead: `cave-xs4m`

## Policy choices

- **Keep Mac awake for phone:** opt-in, default off
- **Only keep awake on power:** default on; uses `caffeinate -s -w <sidecar-pid>`
- **Background availability:** opt-in, default off
- the GUI and LaunchAgent never intentionally own the server simultaneously; the GUI marker and launchd retry policy recover stale ownership after a crash

## Validation

Passed after rebasing onto current `origin/main`:

- `node scripts/desktop-reachability.test.mjs`
- `node scripts/uninstall-app.test.mjs`
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/mobile-handoff.test.ts`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib` (74 passed)
- `pnpm typecheck`
- `pnpm lint` (design codemod check + design ESLint)
- `pnpm check:tests-wired` (1,237 test files wired)
- `pnpm build` (Next production build, server bundle, bundle/standalone budgets)
- `git diff --check`
- GitHub CI: Frontend build, Rust, E2E, Windows/Ubuntu cross-environment and sidecar jobs, required aggregations, and CodeQL all pass

Windows-host limitations encountered before CI confirmation:

- `pnpm test:api` reached and passed the new tests, then stopped at the existing `beads-pr-bridge.test.mjs` POSIX `PATH` construction (`spawnSync ... node.exe ENOENT` on Windows).
- `pnpm test:app` stopped at the existing LF-only regex in `src-tauri/release-runtime.test.mjs` on a CRLF checkout.
- macOS cross-checking from Windows stopped before project compilation because the Apple target requires a macOS C compiler/SDK (`objc2-exception-helper` could not find `cc`).

## Risks and manual macOS verification

The LaunchAgent, `caffeinate`, and Tailscale CLI paths require a packaged macOS build for end-to-end verification:

1. Pair a phone and enable mobile mode; confirm both reachability controls start off and AC-only starts on.
2. Enable keep-awake and inspect `pmset -g assertions` on AC; confirm the assertion follows the owned sidecar PID and releases when disabled or the sidecar stops. Confirm AC-only does not override normal battery sleep.
3. Enable background availability, close the main window, and verify `launchctl print gui/$(id -u)/ai.opencoven.cave`, loopback binding, and phone connectivity without a GUI window.
4. Occupy ports 3000–3006, start on a fallback port, and verify `tailscale serve status --json` points at that exact `127.0.0.1:<port>` backend.
5. Reopen the GUI and verify the daemon yields before the GUI sidecar starts; then disable background availability and verify the service and plist are gone.
6. Run `scripts/uninstall-app.sh` and verify launchd is unloaded before the app executable, state, and logs are removed.
7. Confirm an already-paired phone continues authenticating with its persisted mobile access token across GUI/daemon handoff.