### PR TITLE
fix(ios): address PR #3815 review feedback

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -430,67 +430,6 @@ struct ChatsHomeView: View {
     /// Number of archived chats (drives the show/hide-archived toggle).
     private var archivedCount: Int { app.threads.filter(\.archived).count }
 
-    /// Floating bottom bar: a search field beside a circular compose button,
-    /// styled after iOS Messages — accent-infused frosted glass that tracks the
-    /// desktop theme and degrades to a solid surface under Reduce Transparency.
-    private var bottomBar: some View {
-        HStack(spacing: 10) {
-            HStack(spacing: 8) {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.secondary)
-                TextField("Search", text: $query)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .focused($searchFocused)
-                if !query.isEmpty {
-                    Button {
-                        query = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel("Clear search")
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 11)
-            .glass(.control, in: Capsule())
-            .accentGlow(active: searchFocused)
-
-            // The Diary — Pencil-handwriting experiment. iPad only: the page is
-            // sized for Pencil writing, so the entry point hides on iPhone.
-            // Presented from RootView (app.diaryPresented) so a connection
-            // flap swapping the tab tree can't dismiss it mid-reply.
-            if sizeClass == .regular {
-                Button {
-                    app.diaryPresented = true
-                } label: {
-                    Image(systemName: "book.closed")
-                        .font(.system(.title3, weight: .medium))
-                        .scaledControlFrame(50)
-                        .glass(.control, in: Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Open the Diary — write with Apple Pencil")
-            }
-
-            Button {
-                showNewChat = true
-            } label: {
-                Image(systemName: "square.and.pencil")
-                    .font(.system(.title3, weight: .medium))
-                    .scaledControlFrame(50)
-                    .glass(.control, in: Circle())
-                    .accentGlow(active: true)
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("New chat")
-            .keyboardShortcut("n", modifiers: .command)
-        }
-        .padding(.horizontal, 14)
-        .padding(.vertical, 8)
-    }
-
     private var emptyState: some View {
         ContentUnavailableView {
             Label("No familiars yet", systemImage: "bubble.left.and.bubble.right")

--- a/apps/ios/CovenCave/CovenCave/Views/PermissionsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/PermissionsView.swift
@@ -183,7 +183,7 @@ struct PermissionsView: View {
     ) {
         guard mutationsAllowed else { return }
         Haptics.tap()
-        switch effective.direct ?? effective.level {
+        switch effective.direct {
         case nil:
             mutate(key: key) {
                 try await app.client?.grantProject(

--- a/apps/ios/CovenCave/CovenCave/Views/PluginsPanel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/PluginsPanel.swift
@@ -8,7 +8,7 @@ struct PluginsPanel: View {
     @Environment(\.chrome) private var chrome
     @State private var query = ""
     @State private var selected: PluginCatalogItem?
-    @State private var added: Set<String> = []
+    @State private var added: Set<String> = Set(Self.installed.map(\.id))
     let tryInChat: () -> Void
 
     var body: some View {
@@ -30,30 +30,28 @@ struct PluginsPanel: View {
                     }
                     sectionLabel(query.isEmpty ? "Featured" : "Results")
                     ForEach(filtered) { plugin in
-                        Button { selected = plugin } label: {
-                            HStack(spacing: 13) {
-                                pluginTile(plugin, size: 46)
-                                VStack(alignment: .leading, spacing: 3) {
-                                    Text(plugin.name).font(.headline).foregroundStyle(.primary)
-                                    Text(plugin.summary).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
-                                }
-                                Spacer()
-                                Button {
-                                    if added.contains(plugin.id) { added.remove(plugin.id) }
-                                    else { added.insert(plugin.id) }
-                                } label: {
-                                    Image(systemName: added.contains(plugin.id) ? "checkmark" : "plus")
-                                        .frame(width: 34, height: 34)
-                                        .background(added.contains(plugin.id) ? chrome.accent : chrome.bgRaised,
-                                                    in: Circle())
-                                        .foregroundStyle(added.contains(plugin.id) ? chrome.accentForeground : chrome.textPrimary)
-                                }
-                                .buttonStyle(.plain)
-                                .accessibilityLabel(added.contains(plugin.id) ? "Remove \(plugin.name)" : "Add \(plugin.name)")
+                        HStack(spacing: 13) {
+                            pluginTile(plugin, size: 46)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text(plugin.name).font(.headline).foregroundStyle(.primary)
+                                Text(plugin.summary).font(.subheadline).foregroundStyle(.secondary).lineLimit(1)
                             }
-                            .contentShape(Rectangle())
+                            Spacer()
+                            Button {
+                                if added.contains(plugin.id) { added.remove(plugin.id) }
+                                else { added.insert(plugin.id) }
+                            } label: {
+                                Image(systemName: added.contains(plugin.id) ? "checkmark" : "plus")
+                                    .frame(width: 34, height: 34)
+                                    .background(added.contains(plugin.id) ? chrome.accent : chrome.bgRaised,
+                                                in: Circle())
+                                    .foregroundStyle(added.contains(plugin.id) ? chrome.accentForeground : chrome.textPrimary)
+                            }
+                            .buttonStyle(.plain)
+                            .accessibilityLabel(added.contains(plugin.id) ? "Remove \(plugin.name)" : "Add \(plugin.name)")
                         }
-                        .buttonStyle(.plain)
+                        .contentShape(Rectangle())
+                        .onTapGesture { selected = plugin }
                     }
                 }
                 .padding(16)

--- a/apps/ios/CovenCave/CovenCave/Views/ProjectsPanel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ProjectsPanel.swift
@@ -8,6 +8,11 @@ struct ProjectsPanel: View {
     let dismiss: () -> Void
 
     var body: some View {
+        let taskCounts = app.tasks.reduce(into: [String: Int]()) { counts, task in
+            if let projectId = task.projectId {
+                counts[projectId, default: 0] += 1
+            }
+        }
         NavigationStack {
             List(app.projects) { project in
                 HStack(spacing: 13) {
@@ -17,7 +22,7 @@ struct ProjectsPanel: View {
                         .background(chrome.bgRaised, in: RoundedRectangle(cornerRadius: 10))
                     VStack(alignment: .leading, spacing: 3) {
                         Text(project.name).font(.headline)
-                        if let summary = summary(for: project) {
+                        if let summary = summary(for: project, taskCounts: taskCounts) {
                             Text(summary).font(.subheadline).foregroundStyle(.secondary)
                         }
                     }
@@ -53,8 +58,8 @@ struct ProjectsPanel: View {
         .themedSheetBackground()
     }
 
-    private func summary(for project: ProjectInfo) -> String? {
-        let tasks = app.tasks.filter { $0.projectId == project.id }.count
+    private func summary(for project: ProjectInfo, taskCounts: [String: Int]) -> String? {
+        let tasks = taskCounts[project.id, default: 0]
         guard tasks > 0 else { return nil }
         return tasks == 1 ? "1 task" : "\(tasks) tasks"
     }

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -232,15 +232,18 @@ struct SettingsView: View {
         }
     }
 
+    @ViewBuilder
     private func communityLink(_ label: String, value: String, url: String) -> some View {
-        Link(destination: URL(string: url)!) {
-            LabeledContent(label) {
-                Label(value, systemImage: "arrow.up.right")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
+        if let destination = URL(string: url) {
+            Link(destination: destination) {
+                LabeledContent(label) {
+                    Label(value, systemImage: "arrow.up.right")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
             }
+            .foregroundStyle(.primary)
         }
-        .foregroundStyle(.primary)
     }
 
     // MARK: - Change host

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -106,7 +106,7 @@ struct TerminalView: View {
             HStack(spacing: 8) {
                 cwdMenu
                 keyButton("esc", "Escape") { terminal.sendInput("\u{1B}") }
-                ForEach(["git status", "pwd", "clear"], id: \.self) { command in
+                ForEach(["git status", "pwd"], id: \.self) { command in
                     keyButton(command, command) { terminal.sendInput(command + "\n") }
                 }
                 ForEach(shorthands, id: \.self) { command in
@@ -192,13 +192,19 @@ struct TerminalView: View {
     }
 
     private var shorthands: [String] {
-        storedShorthands.split(separator: "|").map(String.init).filter { !$0.isEmpty }
+        if let data = storedShorthands.data(using: .utf8),
+           let decoded = try? JSONDecoder().decode([String].self, from: data) {
+            return decoded
+        }
+        return storedShorthands.split(separator: "|").map(String.init).filter { !$0.isEmpty }
     }
 
     private func addShorthand() {
         let value = newShorthand.trimmingCharacters(in: .whitespacesAndNewlines)
         defer { newShorthand = "" }
         guard !value.isEmpty, !shorthands.contains(value) else { return }
-        storedShorthands = (shorthands + [value]).joined(separator: "|")
+        guard let data = try? JSONEncoder().encode(shorthands + [value]),
+              let encoded = String(data: data, encoding: .utf8) else { return }
+        storedShorthands = encoded
     }
 }

--- a/scripts/ios-diary-page.test.mjs
+++ b/scripts/ios-diary-page.test.mjs
@@ -6,7 +6,7 @@ import { readFile } from "node:fs/promises";
 // locks the load-bearing pieces: PencilKit input that stays Simulator-testable,
 // Vision handwriting recognition composited on white, pen-lift (not per-stroke)
 // submission, the SSE stream feeding a paced reveal loop, session resume for
-// follow-ups, and the iPad-only entry point.
+// follow-ups, and app-level presentation.
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 const diary = await read("apps/ios/CovenCave/CovenCave/Views/DiaryView.swift");
@@ -102,12 +102,12 @@ assert.match(
   "Reduce Motion collapses the reveal/soak animations",
 );
 
-// ── iPad-only entry point, presented above the connection switch ────────────
+// ── Presented above the connection switch ───────────────────────────────────
 const root = await read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
-assert.match(
+assert.doesNotMatch(
   home,
-  /if sizeClass == \.regular \{[\s\S]*?app\.diaryPresented = true/,
-  "the Diary entry point only shows in regular width (iPad) — the page is sized for Pencil writing",
+  /private var bottomBar/,
+  "ChatsHomeView must not retain the disconnected bottom bar that previously held the Diary entry point",
 );
 assert.match(
   root,


### PR DESCRIPTION
Follow-up addressing all 8 unresolved review threads on #3815:

- TerminalView: removed duplicate `clear` quick command (dedicated Clear screen key remains)
- TerminalView: shorthands persisted as JSON with one-time migration from the legacy pipe-delimited format (pipes in commands no longer corrupt storage)
- PluginsPanel: removed nested buttons — row tap opens detail via onTapGesture, inner add/check button toggles independently
- PluginsPanel: `added` initialized from installed plugin IDs so Installed items show as added
- PermissionsView: access cycling keys off the direct grant only; group-derived access no longer triggers a bogus revoke
- ChatsHomeView: deleted dead `bottomBar` implementation (no call sites)
- SettingsView: communityLink no longer force-unwraps URLs; invalid URLs render nothing
- ProjectsPanel: task counts precomputed into a dictionary (was O(projects x tasks))
- scripts/ios-diary-page.test.mjs: updated stale assertion that required the dead bottom bar

Verification: xcodegen OK; iOS Simulator build SUCCEEDED (zero errors, no new warnings); pnpm test:mobile 87/87; git diff --check clean.