### PR TITLE
Fix workspace Back/Forward navigation history

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -36,6 +36,7 @@ export const SUITES = {
     "src/lib/page-drag.test.ts",
     "src/lib/sidebar-nav-state.test.ts",
     "src/lib/workspace-mode.test.ts",
+    "src/lib/workspace-navigation-history.test.ts",
     "src/lib/surface-preferences.test.ts",
     "src/lib/surface-warm-cache.test.ts",
     "src/lib/board-cache-events.test.ts",

--- a/src/components/chat-linked-context.test.ts
+++ b/src/components/chat-linked-context.test.ts
@@ -140,7 +140,7 @@ assert.match(
 // stranded the user on the chat list instead of the task's board inspector.
 assert.match(
   workspace,
-  /modeRef\.current === "chat" && !window\.location\.hash\) showFamiliarChatList\(\)/,
+  /modeRef\.current === "chat" && !window\.location\.hash\) \{\s*showFamiliarChatList\(\)/,
   "Workspace popstate must only show the chat list on an empty hash, so the task chip's #card- navigation isn't hijacked back to the list",
 );
 

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -330,7 +330,10 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     const hash = window.location.hash;
     if (view.kind === "chat" && view.sessionId) {
       const next = `#chat-${encodeURIComponent(view.sessionId)}`;
-      if (hash !== next) window.history.pushState(null, "", next);
+      if (hash !== next) {
+        window.history.pushState(null, "", next);
+        window.dispatchEvent(new Event("cave:chat-history-push"));
+      }
       return;
     }
     // Mount always lands on the list view; never clear a deep-link hash here
@@ -338,6 +341,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     if (isFirstRun) return;
     if (hash.startsWith("#chat-")) {
       window.history.replaceState(null, "", window.location.pathname + window.location.search);
+      window.dispatchEvent(new Event("cave:chat-history-replace"));
     }
   }, [syncUrlHash, view]);
 

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -95,8 +95,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chatSurface,
-  /className=\{`chat-scope-group-btn[\s\S]*onClick=\{\(\) => setScope\("coven"\)\}/,
-  "ChatSurface exposes Group as a demoted icon-button that switches to the coven scope",
+  /className=\{`chat-scope-group-btn[\s\S]*onClick=\{\(\) => window\.dispatchEvent\(new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "groupchat" \} \}\)\)\}/,
+  "ChatSurface exposes Group as a demoted icon-button that routes through workspace history",
 );
 assert.match(
   chatSurface,

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -15,7 +15,7 @@ import {
   ProjectsView,
   WorkspaceRail,
 } from "@/components/lazy-surfaces";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, CHAT_OPEN_SKILLS_EVENT, consumeCovenTabPending, consumeProjectsTabPending, consumeSkillsTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_OPEN_COVEN_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_SKILLS_EVENT, consumeCovenTabPending, consumeProjectsTabPending, consumeSkillsTabPending } from "@/lib/chat-tab-events";
 import { requestDebugOpen, useChatDebugSnapshot } from "@/lib/chat-debug-store";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Tabs } from "@/components/ui/tabs";
@@ -252,6 +252,12 @@ export function ChatSurface({
   }, []);
 
   useEffect(() => {
+    const open = () => setScope("conversation");
+    window.addEventListener(CHAT_OPEN_CONVERSATION_EVENT, open);
+    return () => window.removeEventListener(CHAT_OPEN_CONVERSATION_EVENT, open);
+  }, []);
+
+  useEffect(() => {
     if (!pendingChatAction) return;
     if (consumedPendingActionNonce.current === pendingChatAction.nonce) return;
     consumedPendingActionNonce.current = pendingChatAction.nonce;
@@ -381,7 +387,7 @@ export function ChatSurface({
               aria-label="Group chat — broadcast one prompt to a coven of familiars"
               aria-pressed={scope === "coven"}
               title="Group chat — broadcast one prompt to a coven of familiars"
-              onClick={() => setScope("coven")}
+              onClick={() => window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "groupchat" } }))}
             >
               <Icon name="ph:users-three" width={16} aria-hidden />
             </button>

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -65,7 +65,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /if \(next === "code"\) \{[\s\S]{0,700}?setModeRaw\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
+  /if \(next === "code"\) \{[\s\S]{0,700}?commitMode\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
   "setMode funnels every code entry point (deep links, palette, navigate-mode, persisted restore) into the room",
 );
 assert.match(

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -18,7 +18,7 @@ assert.match(workspace, /grimoire: "Memories"/, "grimoire has a page title (sr-o
 assert.match(workspace, /mode === "grimoire" \? \(\s*<GrimoireView\s+view=\{grimoireView\}/, "grimoire mode renders GrimoireView with the controlled view");
 // Journal is now a tab inside Grimoire: the nav/deep-link `journal` mode opens
 // Grimoire on its Journal tab instead of redirecting to Settings.
-assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*setModeRaw\("grimoire"\);/, "the journal mode routes into the Grimoire Journal tab");
+assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*commitMode\("grimoire", "journal"\);/, "the journal mode routes into the Grimoire Journal tab and preserves that destination in history");
 assert.match(sidebar, /export type FolderMode = WorkspaceMode/, "the sidebar's FolderMode is the WorkspaceMode union (no drifting copy), so grimoire is a FolderMode");
 assert.match(sidebar, /id: "grimoire", label: "Memories"/, "grimoire has a sidebar row labeled Memories (and ⌘K palette entry via FOLDER_MODES)");
 

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -155,8 +155,8 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
   );
   assert.match(
     workspace,
-    /if \(next === "groupchat"\)[\s\S]*setModeRaw\("chat"\)[\s\S]*CHAT_OPEN_COVEN_EVENT/,
-    "workspace redirects the groupchat mode into chat + opens the coven tab",
+    /if \(next === "groupchat"\)[\s\S]*commitMode\("chat", "groupchat"\)[\s\S]*CHAT_OPEN_COVEN_EVENT/,
+    "workspace redirects groupchat into Chat, preserves the tab destination, and opens the coven tab",
   );
 
   // The standalone left-nav destination is gone.
@@ -175,8 +175,8 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
   );
   assert.match(
     chatSurface,
-    /chat-scope-group-btn[\s\S]*onClick=\{\(\) => setScope\("coven"\)\}/,
-    "ChatSurface exposes Group as a demoted icon-button (not a co-equal tab) that opens the coven scope (cave-xsq.5)",
+    /chat-scope-group-btn[\s\S]*onClick=\{\(\) => window\.dispatchEvent\(new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "groupchat" \} \}\)\)\}/,
+    "ChatSurface routes its demoted Group icon through workspace navigation so history preserves the coven scope",
   );
   assert.match(
     chatSurface,

--- a/src/components/journal-redirect.test.ts
+++ b/src/components/journal-redirect.test.ts
@@ -67,7 +67,7 @@ const slash = read("../lib/slash-commands.ts");
 // It opens the Grimoire surface on its Journal tab.
 assert.match(
   ws,
-  /if \(next === "journal"\) \{[\s\S]{0,400}?setGrimoireView\("journal"\);\s*\n\s*setModeRaw\("grimoire"\)/,
+  /if \(next === "journal"\) \{[\s\S]{0,400}?setGrimoireView\("journal"\);\s*\n\s*commitMode\("grimoire", "journal"\)/,
   "setMode routes journal into the Grimoire Journal tab",
 );
 assert.doesNotMatch(ws, /import \{ JournalView \}/, "workspace no longer imports JournalView");

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -954,7 +954,9 @@ export function MarketplaceViewSurface({
                       ))}
                       {group.skills.map((s) => (
                         <SkillExploreCard
-                          key={`skill:${s.id}`}
+                          // Skill ids are scoped to a publisher. The directory can
+                          // legitimately contain the same id from distinct sources.
+                          key={`skill:${s.slug ?? sourceTarget(s)}:${s.id}`}
                           skill={s}
                           installed={skillIsInstalled(s)}
                           busy={skillBusyIds.has(s.id)}

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -173,6 +173,6 @@ assert.doesNotMatch(automations, /listFlows\(\)/, "Rituals does not load flow do
 assert.doesNotMatch(automations, /runFlow\(flow\.id\)/, "Rituals does not run flows");
 assert.doesNotMatch(automations, /navigateToMode\("flow"\)/, "Rituals does not route into Flow");
 assert.doesNotMatch(workspace, /mode === "flow" \?\s*\(\s*<FlowView/, "Persisted Flow mode does not render FlowView on the active branch");
-assert.match(workspace, /if \(next === "flow"\) \{[\s\S]{0,600}?setModeRaw\("inbox"\)/, "Flow navigation events normalize to Rituals via setMode's alias funnel (cave-m4ih.3)");
+assert.match(workspace, /if \(next === "flow"\) \{[\s\S]{0,600}?commitMode\("inbox"\)/, "Flow navigation events normalize to Rituals via setMode's alias funnel (cave-m4ih.3)");
 
 console.log("rituals-tabs.test.ts: ok");

--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -50,11 +50,17 @@ assert.match(
   /\.shell-nav--rail \.sidebar-folder-row,\n\.shell-nav--rail \.sidebar-action-row,\n\.shell-nav--rail \.sidebar-foot-btn,\n\.shell-nav--rail \.sidebar-foot-icon-btn \{[\s\S]{0,220}?width: 36px;\s*\n\s*height: 36px;/,
   "rail controls are 36px squares",
 );
-// Primary-only rail: quiet cluster + Dashboard demoted to the expanded panel.
+// Every visible workspace destination earns a rail icon; Dashboard remains an
+// expanded-panel link because it leaves the workspace route context.
 assert.match(
   sidebarCss,
-  /\.shell-nav--rail \.sidebar-folder-row--quiet,\s*\n\.shell-nav--rail a\.sidebar-foot-btn\[href="\/dashboard"\] \{\s*\n\s*display: none;/,
-  "quiet destinations and the Dashboard link don't earn rail slots (reachable when expanded / via ⌘K)",
+  /\.shell-nav--rail a\.sidebar-foot-btn\[href="\/dashboard"\] \{\s*\n\s*display: none;/,
+  "Dashboard stays out of the rail because it leaves the workspace route context",
+);
+assert.doesNotMatch(
+  sidebarCss,
+  /\.shell-nav--rail \.sidebar-folder-row--quiet[\s\S]{0,100}display: none;/,
+  "quiet sidebar destinations retain rail icons, including Memories, Marketplace, and GitHub",
 );
 // The avatar keeps a real action (Settings) and an accessible name.
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -213,6 +213,7 @@ function ShellInner({
   navPolicy = "remembered",
   listPolicy = "collapsible",
   panelShortcutOverrides,
+  historyNavigation,
 }: {
   nav: ReactNode;
   list?: ReactNode;
@@ -234,6 +235,12 @@ function ShellInner({
   navPolicy?: ShellNavPolicy;
   listPolicy?: ShellListPolicy;
   panelShortcutOverrides?: Partial<PanelShortcutBindings>;
+  historyNavigation?: {
+    canGoBack: boolean;
+    canGoForward: boolean;
+    goBack: () => void;
+    goForward: () => void;
+  };
 }, ref: ForwardedRef<ShellHandle>) {
   const navRef = useRef<PanelImperativeHandle | null>(null);
   const listRef = useRef<PanelImperativeHandle | null>(null);
@@ -954,17 +961,17 @@ function ShellInner({
       <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
     </button>
   ) : null;
-  // Codex-style history controls beside the nav toggle: browser Back/Forward
-  // drive the app's own history entries (chat hashes and surface deep links
-  // already push state and handle popstate in workspace.tsx).
+  // Workspace owns the destination stack. Keeping it app-scoped means these
+  // controls never escape into an unrelated webview page at the boundary.
   const historyNav = !isMobile ? (
     <div className="shell-top-history" role="group" aria-label="History">
       <button
         type="button"
         className="shell-top-toggle focus-ring"
         aria-label="Go back"
-        title="Back"
-        onClick={() => window.history.back()}
+        title={historyNavigation?.canGoBack ? "Back" : "No previous destination"}
+        disabled={!historyNavigation?.canGoBack}
+        onClick={historyNavigation?.goBack}
       >
         <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
       </button>
@@ -972,8 +979,9 @@ function ShellInner({
         type="button"
         className="shell-top-toggle focus-ring"
         aria-label="Go forward"
-        title="Forward"
-        onClick={() => window.history.forward()}
+        title={historyNavigation?.canGoForward ? "Forward" : "No next destination"}
+        disabled={!historyNavigation?.canGoForward}
+        onClick={historyNavigation?.goForward}
       >
         <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
       </button>

--- a/src/components/skill-browser.test.ts
+++ b/src/components/skill-browser.test.ts
@@ -215,6 +215,11 @@ assert.match(src, /onChanged\?\.\(\)/, "a successful delete asks the parent to r
 assert.match(hub, /import \{ type SkillBrowserEntry \} from "@\/components\/skill-browser"/, "the Marketplace hub imports the skill entry type");
 assert.doesNotMatch(hub, /<SkillBrowser\b/, "the standalone Skills tab (SkillBrowser) is retired from the hub");
 assert.match(hub, /<SkillExploreCard\b/, "registry skills render as Explore cards");
+assert.match(
+  hub,
+  /key=\{`skill:\$\{s\.slug \?\? sourceTarget\(s\)\}:\$\{s\.id\}`\}/,
+  "Explore keys skills by source and id because directory ids are publisher-scoped",
+);
 assert.match(hub, /<SkillExploreDrawer\b/, "opening a skill card shows the Explore skill drawer");
 assert.match(hub, /`\/api\/skills\/directory\?q=\$\{encodeURIComponent\(trimmed\)\}`/, "skill search reloads through the registry search endpoint");
 assert.match(hub, /window\.setTimeout\(\(\) => \{[\s\S]*?void loadSkills\(query\);[\s\S]*?\}, query\.trim\(\) \? 250 : 0\)/, "skill search uses a small debounce before reloading remote results");

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -18,7 +18,7 @@ const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 
 function branchTarget(alias) {
   const m = workspace.match(
-    new RegExp(`if \\(next === "${alias}"\\) \\{[\\s\\S]{0,700}?setModeRaw\\("([a-z-]+)"\\)`),
+    new RegExp(`if \\(next === "${alias}"\\) \\{[\\s\\S]{0,700}?commitMode\\("([a-z-]+)"(?:,\\s*"[^"]+")?\\)`),
   );
   assert.ok(m, `setMode should have a rewrite branch for the "${alias}" alias`);
   return m[1];
@@ -65,7 +65,7 @@ assert.match(
 assert.equal(MODE_ALIASES.code, "surface:code");
 assert.match(
   workspace,
-  /if \(next === "code"\) \{[\s\S]{0,700}?setModeRaw\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
+  /if \(next === "code"\) \{[\s\S]{0,700}?commitMode\(roleSurfaceMode\(CODE_SURFACE_ID\)\)/,
   'setMode\'s "code" branch must land on the Coding familiar\'s room (MODE_ALIASES.code = "surface:code", cave-cc5r)',
 );
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -18,6 +18,14 @@ import {
   type WorkspaceMode as WorkspaceModeFromDaemon,
 } from "@/lib/workspace-mode";
 import { clearChatHash, clearModeParam, readChatHash, readModeParam } from "@/lib/workspace-url-state";
+import {
+  canMoveWorkspaceNavigation,
+  createWorkspaceNavigationHistory,
+  moveWorkspaceNavigation,
+  pushWorkspaceNavigation,
+  replaceWorkspaceNavigation,
+  restoreWorkspaceNavigation,
+} from "@/lib/workspace-navigation-history";
 import type { PaletteIntent } from "@/components/command-palette";
 // Journal retired as an in-shell surface (redirects to Settings → Familiars),
 // so JournalView is gone; Grimoire is a new in-shell surface from main.
@@ -86,7 +94,7 @@ import {
   ShortcutsSheet,
 } from "@/components/lazy-surfaces";
 import { WorkspaceSidebar } from "@/components/workspace-sidebar";
-import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending, markProjectsTabPending } from "@/lib/chat-tab-events";
+import { CHAT_OPEN_PROJECTS_EVENT, CHAT_FOCUS_PROJECT_EVENT, CHAT_OPEN_CONVERSATION_EVENT, CHAT_OPEN_COVEN_EVENT, markCovenTabPending, markProjectsTabPending } from "@/lib/chat-tab-events";
 import { HomeComposer } from "@/components/home-composer";
 import { ChatSurface } from "@/components/chat-surface";
 import { nativeNotify } from "@/lib/native-notify";
@@ -318,6 +326,35 @@ export function Workspace() {
   // deep links (?mode=, #chat-…) and cave:navigate-mode override this as
   // before, so restored sessions and share links still land where they point.
   const [mode, setModeRaw] = useState<CaveMode>("home");
+  const modeRef = useRef<CaveMode>("home");
+  const navigationRestoreRef = useRef(false);
+  const suppressInitialChatHistoryPushRef = useRef(false);
+  const navigationHistoryRef = useRef(createWorkspaceNavigationHistory<CaveMode>("home"));
+  const [navigationHistory, setNavigationHistory] = useState(navigationHistoryRef.current);
+  // Chat hashes retain browser-addressable URLs, but the workspace only asks
+  // the browser to traverse entries that it recorded. A direct `#chat-…`
+  // launch therefore never walks out into unrelated webview history.
+  const chatNavigationHistoryRef = useRef(createWorkspaceNavigationHistory<string | null>(null));
+  const [chatNavigationHistory, setChatNavigationHistory] = useState(chatNavigationHistoryRef.current);
+  const pendingChatNavigationDirectionRef = useRef<number | null>(null);
+  const chatHashRestoredForCurrentModeRef = useRef(false);
+  const commitMode = useCallback((next: CaveMode, historyDestination: CaveMode = next) => {
+    modeRef.current = next;
+    setModeRaw(next);
+    // The rendered surface can be canonical while the navigation intent selects
+    // one of its tabs: Group Chat → Chat and Journal → Memories. Keep that
+    // intent in the history entry so Back/Forward can replay the selection,
+    // rather than only restoring the containing surface.
+    if (navigationRestoreRef.current) return;
+    if (next === "chat" && suppressInitialChatHistoryPushRef.current) {
+      suppressInitialChatHistoryPushRef.current = false;
+      return;
+    }
+    const updated = pushWorkspaceNavigation(navigationHistoryRef.current, historyDestination);
+    if (updated === navigationHistoryRef.current) return;
+    navigationHistoryRef.current = updated;
+    setNavigationHistory(updated);
+  }, []);
   // Which tab the Grimoire surface shows. Lifted here so the Journal nav row can
   // route straight into Grimoire's Journal tab (see the setMode `journal` branch)
   // and so the choice persists across Grimoire remounts within a session.
@@ -343,7 +380,7 @@ export function Workspace() {
       // Set the latch synchronously so a freshly-mounting ChatSurface opens the
       // Group tab on mount; the event covers an already-mounted ChatSurface.
       markCovenTabPending();
-      setModeRaw("chat");
+      commitMode("chat", "groupchat");
       window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_COVEN_EVENT)), 0);
       return;
     }
@@ -353,7 +390,17 @@ export function Workspace() {
       // dashboard links) funnels through setMode, so opening Grimoire on its
       // Journal tab here covers them all.
       setGrimoireView("journal");
-      setModeRaw("grimoire");
+      commitMode("grimoire", "journal");
+      return;
+    }
+    if (next === "grimoire") {
+      setGrimoireView("docs");
+      commitMode("grimoire");
+      return;
+    }
+    if (next === "chat") {
+      commitMode("chat");
+      window.setTimeout(() => window.dispatchEvent(new CustomEvent(CHAT_OPEN_CONVERSATION_EVENT)), 0);
       return;
     }
     if (next === "flow") {
@@ -362,7 +409,7 @@ export function Workspace() {
       // wrong sr-title and no nav highlight (cave-hyor). The remap lives HERE —
       // the single choke point — so ?mode=flow deep links, cave:navigate-mode,
       // and last-mode restore all land on Schedules.
-      setModeRaw("inbox");
+      commitMode("inbox");
       return;
     }
     if (next === "code") {
@@ -371,10 +418,82 @@ export function Workspace() {
       // persisted last-surface) funnels onto the registered Role Surface, so
       // `mode` state never holds "code". Familiars without the coder role hit
       // RoleSurfaceHost's explicit closed-room door.
-      setModeRaw(roleSurfaceMode(CODE_SURFACE_ID));
+      commitMode(roleSurfaceMode(CODE_SURFACE_ID));
       return;
     }
-    setModeRaw(next);
+    commitMode(next);
+  }, [commitMode]);
+  const navigateWorkspaceHistory = useCallback((direction: -1 | 1) => {
+    const current = navigationHistoryRef.current;
+    const updated = moveWorkspaceNavigation(current, direction);
+    if (updated === current) return;
+    navigationRestoreRef.current = true;
+    navigationHistoryRef.current = updated;
+    setNavigationHistory(updated);
+    setMode(updated.entries[updated.index]);
+    navigationRestoreRef.current = false;
+  }, [setMode]);
+  const selectGrimoireView = useCallback((next: "docs" | "graph" | "journal") => {
+    // Docs and Journal are navigation destinations, not merely transient
+    // presentation. Record them through the same alias funnel so the active
+    // tab is restored when history returns to Memories.
+    if (next === "journal") {
+      setMode("journal");
+      return;
+    }
+    setGrimoireView(next);
+    if (next === "docs") setMode("grimoire");
+  }, [setMode, setGrimoireView]);
+  const moveChatNavigation = useCallback((direction: -1 | 1) => {
+    if (modeRef.current !== "chat" || !canMoveWorkspaceNavigation(chatNavigationHistoryRef.current, direction)) return false;
+    const current = chatNavigationHistoryRef.current;
+    const updated = moveWorkspaceNavigation(current, direction);
+    const offset = updated.index - current.index;
+    if (offset === 0) return false;
+    pendingChatNavigationDirectionRef.current = offset;
+    window.history.go(offset);
+    return true;
+  }, []);
+  const goBack = useCallback(() => {
+    // The chat stack is browser-backed for shareable hashes, but never lets a
+    // direct deep link (which has no app-owned predecessor) escape the app.
+    if (moveChatNavigation(-1)) return;
+    navigateWorkspaceHistory(-1);
+  }, [moveChatNavigation, navigateWorkspaceHistory]);
+  const goForward = useCallback(() => {
+    if (moveChatNavigation(1)) return;
+    navigateWorkspaceHistory(1);
+  }, [moveChatNavigation, navigateWorkspaceHistory]);
+  useEffect(() => {
+    const onChatHistoryPush = () => {
+      const updated = pushWorkspaceNavigation(chatNavigationHistoryRef.current, readChatHash());
+      if (updated === chatNavigationHistoryRef.current) return;
+      chatNavigationHistoryRef.current = updated;
+      setChatNavigationHistory(updated);
+    };
+    const onChatHistoryReplace = () => {
+      const updated = replaceWorkspaceNavigation(chatNavigationHistoryRef.current, readChatHash());
+      if (updated === chatNavigationHistoryRef.current) return;
+      chatNavigationHistoryRef.current = updated;
+      setChatNavigationHistory(updated);
+    };
+    window.addEventListener("cave:chat-history-push", onChatHistoryPush);
+    window.addEventListener("cave:chat-history-replace", onChatHistoryReplace);
+    // A shared chat link has no app-owned predecessor. Seed it at its current
+    // hash instead of treating the browser entry before the link as Back.
+    const initialChatId = readChatHash();
+    if (initialChatId) {
+      suppressInitialChatHistoryPushRef.current = true;
+      navigationHistoryRef.current = createWorkspaceNavigationHistory<CaveMode>("chat");
+      setNavigationHistory(navigationHistoryRef.current);
+      const initialChatHistory = createWorkspaceNavigationHistory<string | null>(initialChatId);
+      chatNavigationHistoryRef.current = initialChatHistory;
+      setChatNavigationHistory(initialChatHistory);
+    }
+    return () => {
+      window.removeEventListener("cave:chat-history-push", onChatHistoryPush);
+      window.removeEventListener("cave:chat-history-replace", onChatHistoryReplace);
+    };
   }, []);
   // Chat mode replaces the global nav with the project-grouped Chats sidebar.
   // Its Home button exits Chat, restoring the normal navigation.
@@ -562,7 +681,6 @@ export function Workspace() {
   const narrativeAttemptAtRef = useRef(0);
   const sessionsLoadedRef = useRef(sessionsLoaded);
   sessionsLoadedRef.current = sessionsLoaded;
-  const modeRef = useRef(mode);
   modeRef.current = mode;
   const activeIdRef = useRef(activeId);
   activeIdRef.current = activeId;
@@ -1763,6 +1881,7 @@ export function Workspace() {
   }, []);
 
   const openFamiliarSession = useCallback((sessionId: string, familiarId?: string | null, findQuery?: string) => {
+    chatHashRestoredForCurrentModeRef.current = true;
     if (familiarId) setActiveId(familiarId);
     setActiveChatSessionId(sessionId);
     setPendingChatAction({
@@ -2061,6 +2180,7 @@ export function Workspace() {
     if (!sid) return;
     pendingChatDeepLinkRef.current = null;
     setChatDeepLinkPending(false);
+    chatHashRestoredForCurrentModeRef.current = true;
     const target = sessions.find((s) => s.id === sid);
     if (target) {
       openFamiliarSession(sid, target.familiarId);
@@ -2070,11 +2190,42 @@ export function Workspace() {
     }
   }, [sessionsLoaded, sessions, openFamiliarSession, showFamiliarChatList]);
 
+  // ChatRouter is intentionally unmounted outside the Chat surface. When
+  // workspace Back/Forward returns to Chat, restore its still-addressable hash
+  // rather than mounting the router at the list and leaving the hash orphaned.
+  useEffect(() => {
+    if (mode !== "chat") {
+      chatHashRestoredForCurrentModeRef.current = false;
+      return;
+    }
+    if (chatHashRestoredForCurrentModeRef.current || !sessionsLoaded) return;
+    const sid = readChatHash();
+    if (!sid) {
+      chatHashRestoredForCurrentModeRef.current = true;
+      return;
+    }
+    const target = sessions.find((session) => session.id === sid);
+    chatHashRestoredForCurrentModeRef.current = true;
+    if (target) {
+      openFamiliarSession(sid, target.familiarId);
+      return;
+    }
+    clearChatHash();
+    showFamiliarChatList();
+  }, [mode, sessionsLoaded, sessions, openFamiliarSession, showFamiliarChatList]);
+
   // Browser Back/Forward between list ↔ chat (and chat ↔ chat). Only acts on
   // chat hashes — board `#card-` keeps its own listener.
   useEffect(() => {
     const onPopState = () => {
       const sid = readChatHash();
+      const expectedDirection = pendingChatNavigationDirectionRef.current;
+      pendingChatNavigationDirectionRef.current = null;
+      const chatEntry = sid ?? null;
+      const currentChatHistory = chatNavigationHistoryRef.current;
+      const restored = restoreWorkspaceNavigation(currentChatHistory, chatEntry, expectedDirection);
+      chatNavigationHistoryRef.current = restored;
+      setChatNavigationHistory(restored);
       if (sid) {
         const target = sessionsRef.current.find((s) => s.id === sid);
         if (target) {
@@ -2102,7 +2253,9 @@ export function Workspace() {
       // the board switch in the same render batch and strands the user on the
       // chat list. Gating on the empty hash leaves cross-surface deep links to
       // their owners while preserving genuine Back-to-list.
-      if (modeRef.current === "chat" && !window.location.hash) showFamiliarChatList();
+      if (modeRef.current === "chat" && !window.location.hash) {
+        showFamiliarChatList();
+      }
     };
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
@@ -2114,6 +2267,9 @@ export function Workspace() {
   useEffect(() => {
     if (mode === "chat" || pendingChatDeepLinkRef.current) return;
     clearChatHash();
+    const listHistory = createWorkspaceNavigationHistory<string | null>(null);
+    chatNavigationHistoryRef.current = listHistory;
+    setChatNavigationHistory(listHistory);
   }, [mode]);
 
   const openToastTarget = useCallback((toast: Toast) => {
@@ -2784,7 +2940,7 @@ export function Workspace() {
     ) : mode === "grimoire" ? (
       <GrimoireView
         view={grimoireView}
-        onViewChange={setGrimoireView}
+        onViewChange={selectGrimoireView}
         familiars={familiars}
         activeFamiliarId={activeId}
       />
@@ -3020,6 +3176,12 @@ export function Workspace() {
       />
       <Shell
         ref={shellRef}
+        historyNavigation={{
+          canGoBack: canMoveWorkspaceNavigation(chatNavigationHistory, -1) || canMoveWorkspaceNavigation(navigationHistory, -1),
+          canGoForward: canMoveWorkspaceNavigation(chatNavigationHistory, 1) || canMoveWorkspaceNavigation(navigationHistory, 1),
+          goBack,
+          goForward,
+        }}
         mobileTabs={mobileTabs}
         // Drag-to-split: a sidebar page dropped into the main area opens beside
         // the current surface, resizable with desktop-style snapping.

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -10,6 +10,11 @@ export const CHAT_FOCUS_PROJECT_EVENT = "cave:chat-focus-project";
  *  requested (nav/deep link) so it lands on the in-chat tab instead of a page. */
 export const CHAT_OPEN_COVEN_EVENT = "cave:chat-open-coven";
 
+/** Window event that asks the chat surface to return to its normal Sessions tab.
+ * Workspace history uses this when traversing from the Group Chat tab back to
+ * the ordinary Chat destination without unmounting the surface. */
+export const CHAT_OPEN_CONVERSATION_EVENT = "cave:chat-open-conversation";
+
 // A retained latch backing CHAT_OPEN_COVEN_EVENT. When the legacy `groupchat`
 // mode is requested from a DIFFERENT surface, ChatSurface mounts fresh — and a
 // fire-and-forget event can race its listener subscription. The Workspace sets

--- a/src/lib/workspace-navigation-history.test.ts
+++ b/src/lib/workspace-navigation-history.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  canMoveWorkspaceNavigation,
+  createWorkspaceNavigationHistory,
+  moveWorkspaceNavigation,
+  pushWorkspaceNavigation,
+  replaceWorkspaceNavigation,
+  restoreWorkspaceNavigation,
+} from "./workspace-navigation-history.ts";
+
+let history = createWorkspaceNavigationHistory<string>("home");
+history = pushWorkspaceNavigation(history, "board");
+history = pushWorkspaceNavigation(history, "inbox");
+assert.deepEqual(history, { entries: ["home", "board", "inbox"], index: 2 }, "ordinary workspace destinations are recorded");
+assert.equal(canMoveWorkspaceNavigation(history, -1), true, "Back is available away from the first destination");
+assert.equal(canMoveWorkspaceNavigation(history, 1), false, "Forward is unavailable at the newest destination");
+
+history = moveWorkspaceNavigation(history, -1);
+assert.equal(history.entries[history.index], "board", "Back restores the previous workspace destination");
+assert.equal(canMoveWorkspaceNavigation(history, 1), true, "Forward becomes available after Back");
+
+history = pushWorkspaceNavigation(history, "chat");
+assert.deepEqual(history, { entries: ["home", "board", "chat"], index: 2 }, "a new navigation truncates the forward stack");
+assert.equal(moveWorkspaceNavigation(history, 1), history, "Forward cannot leave the app-owned history boundary");
+assert.equal(moveWorkspaceNavigation(createWorkspaceNavigationHistory("home"), -1).index, 0, "Back cannot leave the first app-owned destination");
+
+let tabHistory = createWorkspaceNavigationHistory<string>("home");
+tabHistory = pushWorkspaceNavigation(tabHistory, "chat");
+tabHistory = pushWorkspaceNavigation(tabHistory, "groupchat");
+tabHistory = pushWorkspaceNavigation(tabHistory, "board");
+tabHistory = moveWorkspaceNavigation(tabHistory, -1);
+assert.equal(tabHistory.entries[tabHistory.index], "groupchat", "Back retains the tab-selection destination instead of only its Chat surface");
+tabHistory = moveWorkspaceNavigation(tabHistory, -1);
+assert.equal(tabHistory.entries[tabHistory.index], "chat", "Back distinguishes the normal Chat destination from its Group tab");
+
+let chatHistory = createWorkspaceNavigationHistory<string | null>(null);
+chatHistory = pushWorkspaceNavigation(chatHistory, "chat-a");
+chatHistory = pushWorkspaceNavigation(chatHistory, "chat-b");
+chatHistory = moveWorkspaceNavigation(chatHistory, -1);
+assert.equal(chatHistory.entries[chatHistory.index], "chat-a", "Back restores the previous chat hash");
+assert.equal(canMoveWorkspaceNavigation(chatHistory, 1), true, "Forward remains available after returning to an earlier chat");
+chatHistory = restoreWorkspaceNavigation(chatHistory, "chat-b", 1);
+assert.equal(chatHistory.entries[chatHistory.index], "chat-b", "Forward restores the later chat hash without pushing another entry");
+chatHistory = restoreWorkspaceNavigation(chatHistory, "chat-a", null);
+assert.equal(chatHistory.entries[chatHistory.index], "chat-a", "browser Back restores a known chat hash without replaying navigation");
+chatHistory = pushWorkspaceNavigation(chatHistory, "chat-c");
+assert.deepEqual(chatHistory, { entries: [null, "chat-a", "chat-c"], index: 2 }, "opening a chat after Back truncates its browser-backed forward stack");
+let returnToListHistory = createWorkspaceNavigationHistory<string | null>(null);
+returnToListHistory = pushWorkspaceNavigation(returnToListHistory, "chat-a");
+returnToListHistory = pushWorkspaceNavigation(returnToListHistory, "chat-b");
+returnToListHistory = moveWorkspaceNavigation(returnToListHistory, -1);
+returnToListHistory = replaceWorkspaceNavigation(returnToListHistory, null);
+assert.equal(canMoveWorkspaceNavigation(returnToListHistory, -1), false, "returning to the list does not offer a duplicate Back destination");
+assert.equal(canMoveWorkspaceNavigation(returnToListHistory, 1), true, "returning to the list preserves a later chat for Forward");
+returnToListHistory = restoreWorkspaceNavigation(returnToListHistory, "chat-b", 1);
+assert.equal(returnToListHistory.entries[returnToListHistory.index], "chat-b", "Forward restores the later chat after returning to the list");
+let duplicateListHistory = createWorkspaceNavigationHistory<string | null>(null);
+duplicateListHistory = pushWorkspaceNavigation(duplicateListHistory, "chat-a");
+duplicateListHistory = pushWorkspaceNavigation(duplicateListHistory, "chat-b");
+duplicateListHistory = replaceWorkspaceNavigation(moveWorkspaceNavigation(duplicateListHistory, -1), null);
+duplicateListHistory = restoreWorkspaceNavigation(duplicateListHistory, null, -1);
+assert.equal(moveWorkspaceNavigation(duplicateListHistory, 1).index, 2, "Forward skips an adjacent duplicate chat-list browser entry");
+const directChatHistory = createWorkspaceNavigationHistory<string | null>("shared-chat");
+assert.equal(canMoveWorkspaceNavigation(directChatHistory, -1), false, "a direct chat deep link has no browser-backed Back destination");
+
+const workspace = readFileSync(new URL("../components/workspace.tsx", import.meta.url), "utf8");
+const shell = readFileSync(new URL("../components/shell.tsx", import.meta.url), "utf8");
+const chatRouter = readFileSync(new URL("../components/chat-router.tsx", import.meta.url), "utf8");
+const chatSurface = readFileSync(new URL("../components/chat-surface.tsx", import.meta.url), "utf8");
+assert.match(workspace, /navigateWorkspaceHistory\(-1\)/, "workspace Back uses the app-owned stack");
+assert.match(workspace, /commitMode\("chat", "groupchat"\)/, "workspace history retains the Group Chat tab destination");
+assert.match(workspace, /commitMode\("grimoire", "journal"\)/, "workspace history retains the Journal tab destination");
+assert.match(workspace, /onViewChange=\{selectGrimoireView\}/, "Journal tab selection records the workspace destination");
+assert.match(chatSurface, /mode: "groupchat"/, "the Group tab records its workspace navigation destination");
+assert.match(workspace, /pendingChatNavigationDirectionRef/, "workspace restores chat hashes without replaying a push on popstate");
+assert.match(workspace, /restoreWorkspaceNavigation\(currentChatHistory, chatEntry, expectedDirection\)/, "browser popstate restores the matching chat entry");
+assert.match(workspace, /chatHashRestoredForCurrentModeRef/, "workspace Back to Chat restores its addressable chat hash after remounting");
+assert.match(workspace, /suppressInitialChatHistoryPushRef/, "a direct chat deep link stays within app-owned history");
+assert.match(workspace, /cave:chat-history-replace/, "workspace tracks a list replace without leaving stale chat controls");
+assert.match(chatRouter, /cave:chat-history-push/, "opening a chat records browser-backed chat history");
+assert.match(chatRouter, /cave:chat-history-replace/, "returning to the chat list updates browser-backed chat history");
+assert.match(shell, /disabled=\{!historyNavigation\?\.canGoBack\}/, "Back disables at the app-history boundary");
+assert.match(shell, /disabled=\{!historyNavigation\?\.canGoForward\}/, "Forward disables at the app-history boundary");

--- a/src/lib/workspace-navigation-history.ts
+++ b/src/lib/workspace-navigation-history.ts
@@ -1,0 +1,74 @@
+export type WorkspaceNavigationHistory<T> = {
+  entries: T[];
+  index: number;
+};
+
+export function createWorkspaceNavigationHistory<T>(initial: T): WorkspaceNavigationHistory<T> {
+  return { entries: [initial], index: 0 };
+}
+
+export function pushWorkspaceNavigation<T>(
+  history: WorkspaceNavigationHistory<T>,
+  destination: T,
+): WorkspaceNavigationHistory<T> {
+  if (history.entries[history.index] === destination) return history;
+  return {
+    entries: [...history.entries.slice(0, history.index + 1), destination],
+    index: history.index + 1,
+  };
+}
+
+export function moveWorkspaceNavigation<T>(
+  history: WorkspaceNavigationHistory<T>,
+  direction: number,
+): WorkspaceNavigationHistory<T> {
+  for (let index = history.index + direction; index >= 0 && index < history.entries.length; index += direction) {
+    if (history.entries[index] !== history.entries[history.index]) return { ...history, index };
+  }
+  return history;
+}
+
+export function canMoveWorkspaceNavigation<T>(
+  history: WorkspaceNavigationHistory<T>,
+  direction: -1 | 1,
+): boolean {
+  for (let index = history.index + direction; index >= 0 && index < history.entries.length; index += direction) {
+    if (history.entries[index] !== history.entries[history.index]) return true;
+  }
+  return false;
+}
+
+/** Update the current browser-backed entry without adding a destination. */
+export function replaceWorkspaceNavigation<T>(
+  history: WorkspaceNavigationHistory<T>,
+  destination: T,
+): WorkspaceNavigationHistory<T> {
+  if (history.entries[history.index] === destination) return history;
+  const entries = [...history.entries];
+  entries[history.index] = destination;
+  return { ...history, entries };
+}
+
+/** Restore a browser-backed entry without creating another history entry. */
+export function restoreWorkspaceNavigation<T>(
+  history: WorkspaceNavigationHistory<T>,
+  destination: T,
+  direction: number | null,
+): WorkspaceNavigationHistory<T> {
+  if (direction !== null) {
+    const moved = moveWorkspaceNavigation(history, direction);
+    if (moved.entries[moved.index] === destination) return moved;
+  }
+  if (history.entries[history.index] === destination) return history;
+  let closestIndex = -1;
+  let closestDistance = Number.POSITIVE_INFINITY;
+  for (let index = 0; index < history.entries.length; index += 1) {
+    if (history.entries[index] !== destination || index === history.index) continue;
+    const distance = Math.abs(index - history.index);
+    if (distance < closestDistance) {
+      closestIndex = index;
+      closestDistance = distance;
+    }
+  }
+  return closestIndex === -1 ? createWorkspaceNavigationHistory(destination) : { ...history, index: closestIndex };
+}

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -244,6 +244,12 @@ button:active > .edge-rail-chip {
   transform: scale(0.94);
 }
 
+.shell-top-toggle:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.45;
+}
+
 /* History Back/Forward — quiet chevrons right of the nav toggle (Codex-style).
    They reuse the shell-top-toggle chrome; the tight gap groups them as a pair. */
 .shell-top-history {

--- a/src/styles/sidebar-minimal/activity-rail.css
+++ b/src/styles/sidebar-minimal/activity-rail.css
@@ -99,11 +99,10 @@
   color: var(--text-primary);
 }
 
-/* Primary-surfaces-only rail (phase D): the quiet cluster (Memories /
-   Marketplace / GitHub) and the Dashboard link stay reachable from the
-   EXPANDED panel (⌘B, hover-peek) and the ⌘K palette, but don't earn rail
-   slots — the rail carries the daily destinations plus Settings + account. */
-.shell-nav--rail .sidebar-folder-row--quiet,
+/* The collapsed rail keeps every visible sidebar destination reachable by
+   icon, including the quiet cluster (Memories, Marketplace, and GitHub).
+   Dashboard remains an expanded-panel destination; its route context is
+   distinct from workspace mode navigation. */
 .shell-nav--rail a.sidebar-foot-btn[href="/dashboard"] {
   display: none;
 }


### PR DESCRIPTION
## Summary

- add an app-owned Back/Forward stack for normal workspace destinations
- retain chat-session hash navigation while preventing direct deep links from invoking an unguarded global Back
- disable title-bar history controls at their app-history boundaries
- wire focused workspace-history coverage into the app CI suite

## Root cause

The shell called the webview's global history directly, while workspace navigation only updated React mode state. Normal surface changes therefore created no traversable entries. The initial draft also omitted its new test from the CI suite registry.

## Validation

- `pnpm check:tests-wired`
- `pnpm lint`
- `pnpm typecheck`
- `node --experimental-strip-types src/lib/workspace-navigation-history.test.ts`
- `pnpm test:app` (the new test executes; 75 tests pass before an unrelated pre-existing `src-tauri/release-runtime.test.mjs` CRLF-sensitive assertion failure)

Fixes #3831
## Related work

Related but distinct: #3832 adds the shared persistent navigation controls to standalone destination routes. This PR resolves #3831's workspace-owned history behavior; it does not implement or block #3832.