### PR TITLE
Add persistent history navigation to destination pages

### DIFF
--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -54,5 +54,6 @@ assert.match(css, /\.aps-rail\s*\{/, "the rail has base styles");
 assert.doesNotMatch(css, /\.aps-rail[^{]*\{[^}]*display:\s*none/, "the rail is never display:none");
 assert.doesNotMatch(css, /@media[^{]*\{[^}]*\.aps-rail[^}]*display:\s*none/, "no media query hides the rail on small screens");
 assert.match(css, /@media \(max-width: 1023px\) \{[\s\S]*?\.aps-top\s*\{[\s\S]*?display:\s*none/, "mobile hides only the desktop title bar");
+assert.match(css, /\.aps-main > \.dr-page\s*\{[\s\S]*?min-height:\s*100%;[\s\S]*?height:\s*100%;/, "reporting pages stay within the pane below desktop chrome instead of adding a second page scrollbar");
 
 console.log("analytics-page-shell guard passed");

--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -10,6 +10,7 @@ const routePage = await source("app/familiars/[id]/analytics/page.tsx");
 const dashPage = await source("app/dashboard/familiars/[id]/analytics/page.tsx");
 const shell = await source("components/analytics-page-shell.tsx");
 const css = await source("styles/analytics-page-shell.css");
+const historyNav = await source("components/desktop-history-nav.tsx");
 
 // ── The canonical analytics route wraps the view in the left-sidepanel shell ──
 assert.match(dashPage, /import \{ AnalyticsPageShell \} from "@\/components\/analytics-page-shell"/, "/dashboard/familiars/[id]/analytics imports the shell");
@@ -36,9 +37,22 @@ assert.match(shell, /href: "\/\?mode=chat"/, "rail deep-links Chat");
 assert.match(shell, /href: "\/\?mode=board"/, "rail deep-links Tasks");
 assert.match(shell, /href="\/dashboard"/, "rail links to the Dashboard route");
 
+// â”€â”€ Destination routes share the desktop Shell chrome â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+assert.match(shell, /import \{ DesktopHistoryNav \} from "@\/components\/desktop-history-nav"/, "standalone shell reuses the shared history controls");
+assert.match(shell, /const isMobile = useIsMobile\(\)/, "standalone desktop chrome follows the shared mobile breakpoint");
+assert.match(shell, /const railOpen = navOpen \|\| isMobile/, "mobile retains its existing primary rail when desktop navigation is collapsed");
+assert.match(shell, /className="aps-top shell-top"/, "standalone shell mounts the shared desktop title bar");
+assert.match(shell, /aria-label=\{navOpen \? "Collapse navigation" : "Expand navigation"\}/, "standalone title bar exposes the navigation toggle state");
+assert.match(shell, /<DesktopHistoryNav \/>/, "standalone title bar includes the Back\/Forward pair");
+assert.match(historyNav, /aria-label="Go back"/, "shared history navigation exposes Back accessibly");
+assert.match(historyNav, /aria-label="Go forward"/, "shared history navigation exposes Forward accessibly");
+assert.match(historyNav, /window\.history\.back\(\)/, "Back drives browser history");
+assert.match(historyNav, /window\.history\.forward\(\)/, "Forward drives browser history");
+
 // ── Persistent at EVERY screen size — the rail must not be hidden on small widths ─
 assert.match(css, /\.aps-rail\s*\{/, "the rail has base styles");
 assert.doesNotMatch(css, /\.aps-rail[^{]*\{[^}]*display:\s*none/, "the rail is never display:none");
 assert.doesNotMatch(css, /@media[^{]*\{[^}]*\.aps-rail[^}]*display:\s*none/, "no media query hides the rail on small screens");
+assert.match(css, /@media \(max-width: 1023px\) \{[\s\S]*?\.aps-top\s*\{[\s\S]*?display:\s*none/, "mobile hides only the desktop title bar");
 
 console.log("analytics-page-shell guard passed");

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
+import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
+import { useIsMobile } from "@/lib/use-viewport";
 import "@/styles/analytics-page-shell.css";
 
 type RailDest = { href: string; label: string; icon: IconName };
@@ -39,32 +41,64 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
   // into the SPA at `/`, which this shell never wraps.
   const pathname = usePathname();
   const onDashboard = pathname === "/dashboard";
+  const isMobile = useIsMobile();
+  const [navOpen, setNavOpen] = useState(true);
+  // Mobile keeps its persistent rail even if this shell was collapsed before a
+  // viewport resize. Its existing navigation remains the mobile fallback.
+  const railOpen = navOpen || isMobile;
+
+  const desktopChrome = !isMobile ? (
+    <header className="aps-top shell-top" data-tauri-drag-region="deep">
+      <div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" />
+      <button
+        type="button"
+        className={`shell-top-toggle shell-top-toggle--nav focus-ring${navOpen ? " shell-top-toggle--active" : ""}`}
+        aria-label={navOpen ? "Collapse navigation" : "Expand navigation"}
+        aria-expanded={navOpen}
+        title={navOpen ? "Collapse navigation" : "Expand navigation"}
+        onClick={() => setNavOpen((open) => !open)}
+      >
+        <Icon
+          name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"}
+          width={CAVE_ICON_SIZE.shellToggle}
+          height={CAVE_ICON_SIZE.shellToggle}
+        />
+      </button>
+      <DesktopHistoryNav />
+    </header>
+  ) : null;
+
   return (
     <div className="aps">
-      <nav className="aps-rail" aria-label="Primary">
-        <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
-          <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-        </a>
-        <ul className="aps-rail-list">
-          {PRIMARY.map((d) => (
-            <li key={d.href}>
-              <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
-                <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
-              </a>
-            </li>
-          ))}
-        </ul>
-        <a
-          className="aps-rail-link aps-rail-foot"
-          href="/dashboard"
-          aria-label="Dashboard"
-          title="Dashboard"
-          aria-current={onDashboard ? "page" : undefined}
-        >
-          <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-        </a>
-      </nav>
-      <main className="aps-main">{children}</main>
+      {desktopChrome}
+      <div className="aps-body">
+        {railOpen ? (
+          <nav className="aps-rail" aria-label="Primary">
+            <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
+              <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            </a>
+            <ul className="aps-rail-list">
+              {PRIMARY.map((d) => (
+                <li key={d.href}>
+                  <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
+                    <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <a
+              className="aps-rail-link aps-rail-foot"
+              href="/dashboard"
+              aria-label="Dashboard"
+              title="Dashboard"
+              aria-current={onDashboard ? "page" : undefined}
+            >
+              <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            </a>
+          </nav>
+        ) : null}
+        <main className="aps-main">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/components/desktop-history-nav.tsx
+++ b/src/components/desktop-history-nav.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { CAVE_ICON_SIZE, Icon } from "@/lib/icon";
+
+/** Shared browser-history controls for the workspace and standalone shells. */
+export function DesktopHistoryNav() {
+  return (
+    <div className="shell-top-history" role="group" aria-label="History">
+      <button
+        type="button"
+        className="shell-top-toggle focus-ring"
+        aria-label="Go back"
+        title="Back"
+        onClick={() => window.history.back()}
+      >
+        <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+      </button>
+      <button
+        type="button"
+        className="shell-top-toggle focus-ring"
+        aria-label="Go forward"
+        title="Forward"
+        onClick={() => window.history.forward()}
+      >
+        <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -16,6 +16,7 @@ import { useShellBanners } from "@/lib/shell-banners";
 import { UpdateBannerTrigger } from "@/components/update-available";
 import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { CaveHomeMigrationBannerTrigger } from "@/components/cave-home-migration-banner";
+import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { useIsMobile } from "@/lib/use-viewport";
 import { isMacDesktopShell } from "@/lib/tauri-platform";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
@@ -954,31 +955,10 @@ function ShellInner({
       <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
     </button>
   ) : null;
-  // Codex-style history controls beside the nav toggle: browser Back/Forward
-  // drive the app's own history entries (chat hashes and surface deep links
-  // already push state and handle popstate in workspace.tsx).
-  const historyNav = !isMobile ? (
-    <div className="shell-top-history" role="group" aria-label="History">
-      <button
-        type="button"
-        className="shell-top-toggle focus-ring"
-        aria-label="Go back"
-        title="Back"
-        onClick={() => window.history.back()}
-      >
-        <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
-      </button>
-      <button
-        type="button"
-        className="shell-top-toggle focus-ring"
-        aria-label="Go forward"
-        title="Forward"
-        onClick={() => window.history.forward()}
-      >
-        <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
-      </button>
-    </div>
-  ) : null;
+  // Codex-style history controls beside the nav toggle are shared with
+  // standalone destinations, keeping browser Back/Forward consistent across
+  // every main page.
+  const historyNav = !isMobile ? <DesktopHistoryNav /> : null;
 
   return (
     <div

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -4,9 +4,20 @@
 
 .aps {
   display: flex;
-  min-height: 100vh;
-  min-height: 100dvh;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
   background: var(--bg-base);
+}
+
+.aps-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.aps-top {
+  width: 100%;
 }
 
 .aps-rail {
@@ -19,14 +30,9 @@
   padding: 10px 0 var(--space-3);
   border-right: 1px solid var(--border-hairline);
   background: var(--bg-elevated);
-  /* Sticks to the viewport so the rail is always in reach as analytics scrolls. */
-  position: sticky;
-  top: 0;
-  align-self: flex-start;
-  height: 100vh;
-  height: 100dvh;
-  /* Clear the native/Tauri title bar so the brand mark isn't under the traffic
-     lights on desktop; harmless (0) on web. */
+  height: auto;
+  /* The standalone desktop title bar owns the Tauri traffic-light reserve.
+     Mobile keeps the rail at the window edge, including its safe-area inset. */
   padding-top: max(10px, env(safe-area-inset-top));
 }
 
@@ -87,7 +93,20 @@
 .aps-main {
   flex: 1 1 auto;
   min-width: 0;
-  height: 100vh;
-  height: 100dvh;
+  min-height: 0;
   overflow-y: auto;
+}
+
+/* Settings previously filled the full route viewport. Within the standalone
+   shell it fills the remaining pane beneath the shared desktop title bar. */
+.aps-main > .settings-shell {
+  height: 100%;
+}
+
+/* The history controls are mounted after hydration on mobile; hide the
+   SSR-safe first render at the same breakpoint so mobile keeps its own chrome. */
+@media (max-width: 1023px) {
+  .aps-top {
+    display: none;
+  }
 }

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -103,6 +103,14 @@
   height: 100%;
 }
 
+/* Reporting pages own their scroll container and previously filled the whole
+   viewport. Keep that contract scoped to the space below the desktop chrome so
+   the parent does not acquire a second scrollbar for the title-bar height. */
+.aps-main > .dr-page {
+  min-height: 100%;
+  height: 100%;
+}
+
 /* The history controls are mounted after hydration on mobile; hide the
    SSR-safe first render at the same breakpoint so mobile keeps its own chrome. */
 @media (max-width: 1023px) {


### PR DESCRIPTION
## Summary

- add a shared desktop browser-history control group and use it in both the Workspace `Shell` and `AnalyticsPageShell`
- give every standalone destination route the same desktop top-left navigation toggle plus Back/Forward controls through `AnalyticsPageShell`
- preserve route-specific breadcrumbs as supplemental hierarchy and keep the existing mobile rail without desktop chrome
- constrain reporting pages to the pane below the new title bar so the extra chrome does not create a second scrollbar

## Root cause

Standalone destination routes render outside the Workspace `Shell`, so they had a compact left rail and occasional contextual back links but no persistent browser-history controls. Adding the title bar also reduced the available content pane, while reporting pages still sized themselves to the full viewport.

## Behavior

All routes classified as `destination` in `src/app/route-inventory.test.ts` receive the desktop navigation toggle and accessible Back/Forward controls. Workspace still renders the controls once, breadcrumbs remain supplemental, and mobile, dev-only, redirect, and `/quick-chat` routes remain out of scope.

Fixes #3832
Tracks Beads `cave-wy0`.
Supersedes #3834 because GitHub cannot retarget a pull request's head branch.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- focused shell, route-inventory, accessibility, and icon-size regression tests
- `git diff --check`
- existing PR #3834 CI: all required checks passed

`pnpm test:app` was also run locally; it reached the unrelated `src-tauri/release-runtime.test.mjs` line-ending-sensitive assertion and stopped there under this Windows checkout (`core.autocrlf=true`). The original PR's Windows cross-environment CI check passed.