### PR TITLE
Add persistent history navigation to destination pages

### DIFF
--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -9,7 +9,10 @@ async function source(path: string) {
 const routePage = await source("app/familiars/[id]/analytics/page.tsx");
 const dashPage = await source("app/dashboard/familiars/[id]/analytics/page.tsx");
 const shell = await source("components/analytics-page-shell.tsx");
+const workspaceShell = await source("components/shell.tsx");
 const css = await source("styles/analytics-page-shell.css");
+const desktopChrome = await source("styles/globals/desktop-chrome.css");
+const historyNav = await source("components/desktop-history-nav.tsx");
 
 // ── The canonical analytics route wraps the view in the left-sidepanel shell ──
 assert.match(dashPage, /import \{ AnalyticsPageShell \} from "@\/components\/analytics-page-shell"/, "/dashboard/familiars/[id]/analytics imports the shell");
@@ -36,9 +39,28 @@ assert.match(shell, /href: "\/\?mode=chat"/, "rail deep-links Chat");
 assert.match(shell, /href: "\/\?mode=board"/, "rail deep-links Tasks");
 assert.match(shell, /href="\/dashboard"/, "rail links to the Dashboard route");
 
+// â”€â”€ Destination routes share the desktop Shell chrome â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
+assert.match(shell, /import \{ DesktopHistoryNav \} from "@\/components\/desktop-history-nav"/, "standalone shell reuses the shared history controls");
+assert.match(shell, /const isMobile = useIsMobile\(\)/, "standalone desktop chrome follows the shared mobile breakpoint");
+assert.match(shell, /const railOpen = navOpen \|\| isMobile/, "mobile retains its existing primary rail when desktop navigation is collapsed");
+assert.match(shell, /className="aps-top shell-top"/, "standalone shell mounts the shared desktop title bar");
+assert.match(shell, /aria-label=\{navOpen \? "Collapse navigation" : "Expand navigation"\}/, "standalone title bar exposes the navigation toggle state");
+assert.match(shell, /<DesktopHistoryNav \/>/, "standalone title bar includes the Back\/Forward pair");
+assert.match(historyNav, /aria-label="Go back"/, "shared history navigation exposes Back accessibly");
+assert.match(historyNav, /aria-label="Go forward"/, "shared history navigation exposes Forward accessibly");
+assert.equal((historyNav.match(/className="shell-top-toggle focus-ring"/g) ?? []).length, 2, "both history controls retain visible keyboard focus");
+assert.equal((historyNav.match(/width=\{CAVE_ICON_SIZE\.shellToggle\}\s+height=\{CAVE_ICON_SIZE\.shellToggle\}/g) ?? []).length, 2, "both history controls use the shared shell icon size");
+assert.match(historyNav, /window\.history\.back\(\)/, "Back drives browser history");
+assert.match(historyNav, /window\.history\.forward\(\)/, "Forward drives browser history");
+assert.equal((workspaceShell.match(/<DesktopHistoryNav/g) ?? []).length, 1, "workspace renders one shared history group");
+
 // ── Persistent at EVERY screen size — the rail must not be hidden on small widths ─
 assert.match(css, /\.aps-rail\s*\{/, "the rail has base styles");
 assert.doesNotMatch(css, /\.aps-rail[^{]*\{[^}]*display:\s*none/, "the rail is never display:none");
 assert.doesNotMatch(css, /@media[^{]*\{[^}]*\.aps-rail[^}]*display:\s*none/, "no media query hides the rail on small screens");
+assert.match(css, /@media \(max-width: 1023px\) \{[\s\S]*?\.aps-top\s*\{[\s\S]*?display:\s*none/, "mobile hides only the desktop title bar");
+assert.match(css, /\.aps-main > \.dr-page\s*\{[\s\S]*?min-height:\s*100%;[\s\S]*?height:\s*100%;/, "reporting pages stay within the pane below desktop chrome instead of adding a second page scrollbar");
+assert.match(desktopChrome, /@media \(min-width: 1024px\) \{[\s\S]*?\.aps-top \+ \.aps-body \.settings-shell__header\s*\{[\s\S]*?padding-left:\s*var\(--space-3\)/, "destination settings header avoids a duplicate traffic-light inset only with visible desktop chrome");
+assert.match(desktopChrome, /@media \(min-width: 1024px\) \{[\s\S]*?\.aps-top \+ \.aps-body \.dr-topbar\s*\{[\s\S]*?padding-left:\s*clamp\(20px, 5vw, 64px\)/, "destination report breadcrumbs avoid a duplicate traffic-light inset only with visible desktop chrome");
 
 console.log("analytics-page-shell guard passed");

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
+import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
+import { useIsMobile } from "@/lib/use-viewport";
 import "@/styles/analytics-page-shell.css";
 
 type RailDest = { href: string; label: string; icon: IconName };
@@ -39,32 +41,64 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
   // into the SPA at `/`, which this shell never wraps.
   const pathname = usePathname();
   const onDashboard = pathname === "/dashboard";
+  const isMobile = useIsMobile();
+  const [navOpen, setNavOpen] = useState(true);
+  // Mobile keeps its persistent rail even if this shell was collapsed before a
+  // viewport resize. Its existing navigation remains the mobile fallback.
+  const railOpen = navOpen || isMobile;
+
+  const desktopChrome = !isMobile ? (
+    <header className="aps-top shell-top" data-tauri-drag-region="deep">
+      <div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" />
+      <button
+        type="button"
+        className={`shell-top-toggle shell-top-toggle--nav focus-ring${navOpen ? " shell-top-toggle--active" : ""}`}
+        aria-label={navOpen ? "Collapse navigation" : "Expand navigation"}
+        aria-expanded={navOpen}
+        title={navOpen ? "Collapse navigation" : "Expand navigation"}
+        onClick={() => setNavOpen((open) => !open)}
+      >
+        <Icon
+          name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"}
+          width={CAVE_ICON_SIZE.shellToggle}
+          height={CAVE_ICON_SIZE.shellToggle}
+        />
+      </button>
+      <DesktopHistoryNav />
+    </header>
+  ) : null;
+
   return (
     <div className="aps">
-      <nav className="aps-rail" aria-label="Primary">
-        <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
-          <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-        </a>
-        <ul className="aps-rail-list">
-          {PRIMARY.map((d) => (
-            <li key={d.href}>
-              <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
-                <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
-              </a>
-            </li>
-          ))}
-        </ul>
-        <a
-          className="aps-rail-link aps-rail-foot"
-          href="/dashboard"
-          aria-label="Dashboard"
-          title="Dashboard"
-          aria-current={onDashboard ? "page" : undefined}
-        >
-          <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-        </a>
-      </nav>
-      <main className="aps-main">{children}</main>
+      {desktopChrome}
+      <div className="aps-body">
+        {railOpen ? (
+          <nav className="aps-rail" aria-label="Primary">
+            <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
+              <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            </a>
+            <ul className="aps-rail-list">
+              {PRIMARY.map((d) => (
+                <li key={d.href}>
+                  <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
+                    <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
+                  </a>
+                </li>
+              ))}
+            </ul>
+            <a
+              className="aps-rail-link aps-rail-foot"
+              href="/dashboard"
+              aria-label="Dashboard"
+              title="Dashboard"
+              aria-current={onDashboard ? "page" : undefined}
+            >
+              <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            </a>
+          </nav>
+        ) : null}
+        <main className="aps-main">{children}</main>
+      </div>
     </div>
   );
 }

--- a/src/components/desktop-history-nav.tsx
+++ b/src/components/desktop-history-nav.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { CAVE_ICON_SIZE, Icon } from "@/lib/icon";
+
+/** Shared browser-history controls for the workspace and standalone shells. */
+export function DesktopHistoryNav() {
+  return (
+    <div className="shell-top-history" role="group" aria-label="History">
+      <button
+        type="button"
+        className="shell-top-toggle focus-ring"
+        aria-label="Go back"
+        title="Back"
+        onClick={() => window.history.back()}
+      >
+        <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+      </button>
+      <button
+        type="button"
+        className="shell-top-toggle focus-ring"
+        aria-label="Go forward"
+        title="Forward"
+        onClick={() => window.history.forward()}
+      >
+        <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+      </button>
+    </div>
+  );
+}

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -16,6 +16,7 @@ import { useShellBanners } from "@/lib/shell-banners";
 import { UpdateBannerTrigger } from "@/components/update-available";
 import { OpenCovenToolsBannerTrigger } from "@/components/open-coven-tools-update";
 import { CaveHomeMigrationBannerTrigger } from "@/components/cave-home-migration-banner";
+import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { useIsMobile } from "@/lib/use-viewport";
 import { isMacDesktopShell } from "@/lib/tauri-platform";
 import { MobileDrawer, type MobileDrawerSlot } from "@/components/mobile-drawer";
@@ -961,31 +962,34 @@ function ShellInner({
       <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
     </button>
   ) : null;
-  // Workspace owns the destination stack. Keeping it app-scoped means these
-  // controls never escape into an unrelated webview page at the boundary.
+  // Workspace owns its destination stack, while the other shell surfaces use
+  // browser history. Keep the app-scoped boundary controls intact there and
+  // reuse the shared browser controls everywhere else.
   const historyNav = !isMobile ? (
-    <div className="shell-top-history" role="group" aria-label="History">
-      <button
-        type="button"
-        className="shell-top-toggle focus-ring"
-        aria-label="Go back"
-        title={historyNavigation?.canGoBack ? "Back" : "No previous destination"}
-        disabled={!historyNavigation?.canGoBack}
-        onClick={historyNavigation?.goBack}
-      >
-        <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
-      </button>
-      <button
-        type="button"
-        className="shell-top-toggle focus-ring"
-        aria-label="Go forward"
-        title={historyNavigation?.canGoForward ? "Forward" : "No next destination"}
-        disabled={!historyNavigation?.canGoForward}
-        onClick={historyNavigation?.goForward}
-      >
-        <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
-      </button>
-    </div>
+    historyNavigation ? (
+      <div className="shell-top-history" role="group" aria-label="History">
+        <button
+          type="button"
+          className="shell-top-toggle focus-ring"
+          aria-label="Go back"
+          title={historyNavigation.canGoBack ? "Back" : "No previous destination"}
+          disabled={!historyNavigation?.canGoBack}
+          onClick={historyNavigation.goBack}
+        >
+          <Icon name="ph:caret-left" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+        </button>
+        <button
+          type="button"
+          className="shell-top-toggle focus-ring"
+          aria-label="Go forward"
+          title={historyNavigation.canGoForward ? "Forward" : "No next destination"}
+          disabled={!historyNavigation?.canGoForward}
+          onClick={historyNavigation.goForward}
+        >
+          <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
+        </button>
+      </div>
+    ) : <DesktopHistoryNav />
   ) : null;
 
   return (

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -4,9 +4,20 @@
 
 .aps {
   display: flex;
-  min-height: 100vh;
-  min-height: 100dvh;
+  flex-direction: column;
+  height: 100vh;
+  height: 100dvh;
   background: var(--bg-base);
+}
+
+.aps-body {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.aps-top {
+  width: 100%;
 }
 
 .aps-rail {
@@ -19,14 +30,9 @@
   padding: 10px 0 var(--space-3);
   border-right: 1px solid var(--border-hairline);
   background: var(--bg-elevated);
-  /* Sticks to the viewport so the rail is always in reach as analytics scrolls. */
-  position: sticky;
-  top: 0;
-  align-self: flex-start;
-  height: 100vh;
-  height: 100dvh;
-  /* Clear the native/Tauri title bar so the brand mark isn't under the traffic
-     lights on desktop; harmless (0) on web. */
+  height: auto;
+  /* The standalone desktop title bar owns the Tauri traffic-light reserve.
+     Mobile keeps the rail at the window edge, including its safe-area inset. */
   padding-top: max(10px, env(safe-area-inset-top));
 }
 
@@ -87,7 +93,28 @@
 .aps-main {
   flex: 1 1 auto;
   min-width: 0;
-  height: 100vh;
-  height: 100dvh;
+  min-height: 0;
   overflow-y: auto;
+}
+
+/* Settings previously filled the full route viewport. Within the standalone
+   shell it fills the remaining pane beneath the shared desktop title bar. */
+.aps-main > .settings-shell {
+  height: 100%;
+}
+
+/* Reporting pages own their scroll container and previously filled the whole
+   viewport. Keep that contract scoped to the space below the desktop chrome so
+   the parent does not acquire a second scrollbar for the title-bar height. */
+.aps-main > .dr-page {
+  min-height: 100%;
+  height: 100%;
+}
+
+/* The history controls are mounted after hydration on mobile; hide the
+   SSR-safe first render at the same breakpoint so mobile keeps its own chrome. */
+@media (max-width: 1023px) {
+  .aps-top {
+    display: none;
+  }
 }

--- a/src/styles/globals/desktop-chrome.css
+++ b/src/styles/globals/desktop-chrome.css
@@ -159,6 +159,22 @@ button:active > .edge-rail-chip {
 }
 
 @media (min-width: 1024px) {
+  /* Destination shells provide their own visible top-level shell bar on
+     desktop, so it owns the traffic-light reserve. Their route-local headers
+     sit below it and must keep their normal content alignment rather than
+     leaving a second, empty inset. Below this breakpoint .aps-top is hidden,
+     while macOS traffic lights remain visible, so those headers retain their
+     base --titlebar-lights-inset. */
+  :root[data-tauri-titlebar] .aps-top + .aps-body .settings-shell__header {
+    padding-left: var(--space-3);
+  }
+  :root[data-tauri-titlebar] .aps-top + .aps-body .dr-topbar {
+    padding-left: clamp(20px, 5vw, 64px);
+  }
+  :root[data-tauri-titlebar] .aps-top + .aps-body .fa-topbar {
+    padding-left: var(--space-6);
+  }
+
   :root[data-tauri-titlebar] .shell-top {
     /* The slim 29px band hugs the 28px controls so the bar doesn't tower
        over the lights (was 36px — user asked for ~20% shorter). */


### PR DESCRIPTION
## Summary

- add shared desktop Back/Forward controls to every `destination` route through `AnalyticsPageShell`
- preserve the Workspace as the single existing instance of its chrome and retain route breadcrumbs as supplemental hierarchy
- keep mobile on its existing rail without desktop chrome
- constrain destination page scroll containers below the added title bar and avoid a duplicate macOS traffic-light inset on nested destination headers

## Root cause

Standalone destination routes live outside the Workspace `Shell`, so they did not receive its persistent desktop navigation controls. Adding shared desktop chrome also requires destination content to use the remaining pane and avoid retaining titlebar-only offsets below the new bar.

## Validation

- focused analytics-page-shell, route-inventory, and shell-edge-rails regression tests
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`
- `git diff --check`

`pnpm test:app` exercised 74 files before the unrelated CRLF-sensitive `src-tauri/release-runtime.test.mjs` assertion stopped the suite in this Windows `core.autocrlf=true` checkout. The focused navigation tests pass.

Fixes #3832
Tracks Beads `cave-wy0`.
Supersedes #3834 and #3836 because GitHub cannot change a pull request's head branch.