### PR TITLE
feat(research): refresh Research Desk chrome to match Desk.dc.html (cave-mxqz)

### DIFF
--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -124,11 +124,11 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  min-height: 38px;
+  min-height: 44px;
   padding: 0 14px;
   border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
   color: var(--text-muted);
 }
 .research-desk-querybar__field:focus-within {
@@ -225,7 +225,7 @@
 /* ── Runs rail: 264px per the design; base grid comes from
    .research-desk__workspace in surface-role-workspaces.css. ── */
 .research-desk-tab .research-desk__workspace {
-  grid-template-columns: 264px minmax(0, 1fr);
+  grid-template-columns: 296px minmax(0, 1fr);
   border-top: 1px solid var(--border);
 }
 
@@ -242,7 +242,7 @@
 /* ── Detail: center column + 312px evidence rail. ── */
 .research-desk-tab .research-mission-detail { padding: 0; }
 .research-desk-tab .research-mission-detail__body {
-  grid-template-columns: minmax(0, 1fr) minmax(250px, 312px);
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
   gap: 0;
   flex: 1;
 }
@@ -361,10 +361,10 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  padding: 14px var(--space-4);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
+  padding: 18px var(--space-5);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-raised);
 }
 .research-desk-block__head {
   display: flex;

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -857,8 +857,8 @@
   display: flex;
   width: 100%;
   flex-direction: column;
-  gap: 7px;
-  padding: 9px;
+  gap: var(--space-2);
+  padding: 11px;
   color: var(--text-secondary);
   text-align: left;
   border: 1px solid transparent;
@@ -875,9 +875,9 @@
 }
 
 .research-mission-row:focus-visible { outline: var(--ring-width) solid var(--ring-focus); }
-.research-mission-row__top { display: flex; align-items: flex-start; gap: 7px; }
-.research-mission-row__top strong { font-size: 11.5px; font-weight: 600; line-height: 1.35; }
-.research-mission-row__meta { display: flex; gap: 7px; padding-left: 13px; font-size: 9.5px; text-transform: capitalize; color: var(--text-muted); }
+.research-mission-row__top { display: flex; align-items: flex-start; gap: 8px; }
+.research-mission-row__top strong { font-size: 12.5px; font-weight: 500; line-height: 1.35; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+.research-mission-row__meta { display: flex; gap: 8px; padding-left: 15px; font-size: 10.5px; font-family: var(--font-mono); text-transform: capitalize; color: var(--text-muted); }
 .research-mission-row__meta time { margin-left: auto; text-transform: none; }
 .research-mission-detail__eyebrow time { text-transform: none; letter-spacing: 0.02em; }
 
@@ -916,7 +916,7 @@
 .research-mission-detail { display: flex; min-height: 100%; flex-direction: column; padding: 14px 16px 22px; }
 .research-mission-detail__header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; padding: 4px 2px 14px; }
 .research-mission-detail__header h2 { margin-top: 4px; font-family: var(--font-serif, ui-serif, serif); font-size: clamp(19px, 2.5vw, 28px); font-weight: 500; color: var(--text-primary); }
-.research-mission-detail__header p { max-width: 780px; margin-top: 5px; color: var(--text-secondary); font-size: 11.5px; line-height: 1.5; }
+.research-mission-detail__header p { max-width: 780px; margin-top: 5px; color: var(--text-muted); font-size: var(--text-base); line-height: 1.6; }
 .research-mission-detail__body { display: grid; grid-template-columns: minmax(320px, 1fr) minmax(230px, 300px); gap: 12px; min-height: 0; }
 
 .research-output-shelf > section {


### PR DESCRIPTION
## What

Visual reconciliation of the existing **Research Desk** surface (built under cave-dl74) against the refreshed Claude Design mock **`Desk.dc.html`** (claude_design project `7f3d7e37`). The surface already implemented this design lineage faithfully; this PR applies the mock's newer, roomier rhythm.

## How (CSS-forward — no structural change)

`research-tab-desk.test.ts` and `researcher-surface.test.ts` **source-pin** the detail markup (stepper phases, checkpoint tiles, `research-desk-block__abstract`, refine box, evidence ledger, responsive `@container` rules), so every pinned structure is preserved and the changes are confined to the stylesheets:

- **Roomier workspace grid** — runs rail `264→296px`, evidence rail `312→320px` (matches the mock's `296 / 320` columns).
- **Ask / command bar** — taller (`38→44px`) on a solid raised field (`--bg-raised`, `--radius-control`).
- **Runs rail cards** — roomier padding, `12.5px` title with a **2-line clamp** so long mission titles no longer grow unbounded rows, mono meta at `10.5px`.
- **Mission detail** — description steps up to the base type scale (`13px`); status blocks adopt the mock's panel treatment (`--radius-panel`, solid raised background, `18/20` padding).

Divergences intentionally not applied: the `.hdr` brand band (the role-surface shell owns that chrome) and the tiles→version / bordered-refine simplifications (both are source-pinned structure — changing them would break the contract tests for a marginal visual delta).

## Verification

- `pnpm typecheck` ✓ · `pnpm build` ✓ (bundle-budget within limits) · design-token-drift ✓ (net-neutral, no baseline bump)
- `research-tab-desk.test.ts` 19/19 · `researcher-surface.test.ts` 34/34 (run with the css-source-contract hook)
- `tests/research-desk-tabs.spec.ts` e2e — **5 passed** (single-worker; the parallel run's failures were global `~/.coven` reconciliation-lock contention from concurrent dev servers, not this change)

cave-mxqz

🤖 Generated with [Claude Code](https://claude.com/claude-code)