### PR TITLE
feat(chat): stream Hermes tool activity

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1003,6 +1003,7 @@ export const SUITES = {
     "src/lib/coven-bin.test.ts",
     "src/lib/harness-version.test.ts",
     "src/lib/hermes-shim.test.ts",
+    "src/lib/hermes-responses-stream.test.ts",
     "src/lib/openclaw-bin.test.ts",
     "src/lib/openclaw-bridge.test.ts",
     "src/lib/coven-identity-canon.test.ts",

--- a/src/app/api/chat/send/harness-routing-attachments.test.ts
+++ b/src/app/api/chat/send/harness-routing-attachments.test.ts
@@ -46,8 +46,8 @@ const chatView = await readFile(
 
 assert.match(
   chatRoute,
-  /const imagesSupported = !sshRuntime && binding\.harness !== "openclaw";/,
-  "Image temp-file delivery should be limited to local coven-run harnesses with a Read tool",
+  /const imagesSupported = !sshRuntime && binding\.harness !== "openclaw" &&\s*!\(hermesApi && !hermesApiCanAccessLocalFiles\(hermesApi\)\);/,
+  "Remote Hermes API runs must receive an explicit image-unsupported notice rather than Cave-local file paths",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -86,8 +86,8 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const harnessSessionId = grokDirect\s*\?\s*grokSessionId\s*:\s*hermesDirect && hermesApi\s*\?\s*hermesResponseId \?\? sessionId\s*:\s*sessionId;/,
-  "a failed Grok resume must not overwrite the native resume id with Cave's stable conversation id",
+  /const harnessSessionId = grokDirect\s*\?\s*grokSessionId\s*:\s*hermesDirect && hermesApi\s*\?\s*!result\.is_error && hermesResponseId\s*\?\s*hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? sessionId\s*:\s*sessionId;/,
+  "failed Grok or Hermes resumes must retain their prior native continuation id",
 );
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -86,7 +86,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const harnessSessionId = grokDirect\s*\?\s*grokSessionId\s*:\s*hermesDirect && hermesApi\s*\?\s*!result\.is_error && hermesResponseId\s*\?\s*hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? sessionId\s*:\s*sessionId;/,
+  /const harnessSessionId = grokDirect\s*\?\s*grokSessionId\s*:\s*hermesDirect && hermesApi\s*\?\s*!result\.is_error && hermesResponseId\s*\?\s*hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? null\s*:\s*sessionId;/,
   "failed Grok or Hermes resumes must retain their prior native continuation id",
 );
 assert.match(

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -86,7 +86,7 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const harnessSessionId = grokDirect \? grokSessionId : sessionId;/,
+  /const harnessSessionId = grokDirect\s*\?\s*grokSessionId\s*:\s*hermesDirect && hermesApi\s*\?\s*hermesResponseId \?\? sessionId\s*:\s*sessionId;/,
   "a failed Grok resume must not overwrite the native resume id with Cave's stable conversation id",
 );
 assert.match(

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -563,13 +563,13 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*?pushProgress\(\s*"resume-retry",[\s\S]*?"Fresh chat started",\s*"done",?\s*\)[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
+  /pushProgress\(\s*"resume-retry",[\s\S]*?"Resume failed; starting a fresh chat",\s*"running",?\s*\)[\s\S]*?pushProgress\(\s*"resume-retry",[\s\S]*?"Fresh chat started",\s*"done",?\s*\)[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\), retry\.prompt\)/,
   "Transparent resume fallback should be visible in the progress timeline and settle BEFORE the fresh attempt runs — left running until the attempt ended, 'Resume failed…' headlined the activity strip for the whole reply",
 );
 
 assert.match(
   chatRoute,
-  /const retry = buildResumeRetryPrompt\(harnessPrompt, existingConversation\)[\s\S]*?retry\.replayedHistory[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
+  /const retry = buildResumeRetryPrompt\(harnessPrompt, existingConversation\)[\s\S]*?retry\.replayedHistory[\s\S]*?await runAttempt\(buildArgs\(null, retry\.prompt\), retry\.prompt\)/,
   "Fresh-session retry should replay recent conversation history so the familiar keeps context",
 );
 
@@ -593,7 +593,7 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\)\)/,
+  /stderrTail\.length = 0;[\s\S]*stdoutErrTail\.length = 0;[\s\S]*await runAttempt\(buildArgs\(null, retry\.prompt\), retry\.prompt\)/,
   "Fresh-chat retry should clear stale diagnostic tails before the retry attempt",
 );
 

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -186,6 +186,24 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /redirect: "error"/,
+  "Hermes API requests must reject redirects rather than crossing the validated endpoint boundary",
+);
+
+assert.match(
+  chatRoute,
+  /flattenToolResultContent\(event\.output\) \?\? formatToolInputValue\(event\.output\)/,
+  "structured Hermes function output must display supported text blocks rather than protocol JSON",
+);
+
+assert.match(
+  chatRoute,
+  /if \(event\.message\) recordStdoutErrorTail\(event\.message, true\)/,
+  "terminal Hermes failures must retain their normalized diagnostic",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );
@@ -382,6 +400,11 @@ assert.match(
       { type: "text", text: "two" },
     ]),
     "one\ntwo",
+  );
+  assert.equal(
+    flattenToolResultContent([{ type: "input_text", text: "tool output" }]),
+    "tool output",
+    "Responses function output blocks flatten to their text rather than protocol scaffolding",
   );
   assert.equal(flattenToolResultContent(null), undefined);
 }

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -216,8 +216,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /if \(event\.message\) recordStdoutErrorTail\(event\.message, true\)/,
-  "terminal Hermes failures must retain their normalized diagnostic",
+  /if \(event\.isError\) recordStdoutErrorTail\("Hermes API stream failed", true\)[\s\S]*?recordStdoutErrorTail\("Hermes API stream failed", true\)/,
+  "terminal Hermes failures must persist only a fixed diagnostic, never endpoint-provided error text",
 );
 
 assert.match(
@@ -240,8 +240,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /hermesDirect && hermesApi\s*\? !result\.is_error && hermesResponseId\s*\? hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? sessionId/,
-  "failed Hermes API turns must retain the prior successful Responses id for the next continuation",
+  /hermesDirect && hermesApi\s*\? !result\.is_error && hermesResponseId\s*\? hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? null/,
+  "failed Hermes API turns must retain only a prior successful Responses id, never a failed first-turn id",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -150,6 +150,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /if \(abort\.signal\.aborted\) \{[\s\S]*?!runHandle\.stopRequested[\s\S]*?Hermes API stream aborted after client disconnect/,
+  "a detach-time Hermes fetch abort must persist as an error while explicit Stop remains a cancellation",
+);
+
+assert.match(
+  chatRoute,
   /isHermesInvalidPreviousResponseIdError\(apiError\)[\s\S]*?resumeFailed = true/,
   "only a structured invalid previous Responses id may use the fresh-session retry",
 );
@@ -224,6 +230,12 @@ assert.match(
   chatRoute,
   /case "done":\s*if \(event\.id\) \{\s*hermesResponseId = event\.id;\s*if \(!sessionId\) announceSession\(event\.id\);/,
   "terminal Responses events must retain response ids even when no earlier session event arrived",
+);
+
+assert.match(
+  chatRoute,
+  /hermesDirect && hermesApi\s*\? !result\.is_error && hermesResponseId\s*\? hermesResponseId\s*:\s*existingConversation\?\.harnessSessionId \?\? sessionId/,
+  "failed Hermes API turns must retain the prior successful Responses id for the next continuation",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -216,6 +216,18 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /JSON\.parse\(frame\.data\)[\s\S]*?Hermes API protocol error: malformed SSE payload[\s\S]*?return true/,
+  "malformed Hermes SSE data must fail and terminate the attempt rather than allowing a later terminal frame to succeed",
+);
+
+assert.match(
+  chatRoute,
+  /case "done":\s*if \(event\.id\) \{\s*hermesResponseId = event\.id;\s*if \(!sessionId\) announceSession\(event\.id\);/,
+  "terminal Responses events must retain response ids even when no earlier session event arrived",
+);
+
+assert.match(
+  chatRoute,
   /hermesCallNamesById\.set\(event\.id, event\.name\)[\s\S]*?if \(event\.isFinal\) \{\s*const name = hermesCallNamesById\.get\(id\);\s*if \(name\) boundarySentinel\?\.observe\(name, next\);/,
   "final streamed Hermes tool arguments must pass through the runtime boundary sentinel",
 );

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -144,6 +144,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /!terminal && !abort\.signal\.aborted[\s\S]*?Hermes API stream ended before a terminal event/,
+  "an SSE EOF without a terminal event must be persisted as an error, never a completed response",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -228,6 +228,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /if \(!frame\.data\.trim\(\)\) return false;[\s\S]*?if \(frame\.data === "\[DONE\]"\) return true;/,
+  "empty Hermes SSE keepalive frames must be ignored before JSON parsing",
+);
+
+assert.match(
+  chatRoute,
   /case "done":\s*if \(event\.id\) \{\s*hermesResponseId = event\.id;\s*if \(!sessionId\) announceSession\(event\.id\);/,
   "terminal Responses events must retain response ids even when no earlier session event arrived",
 );

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -168,6 +168,24 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /pushProgress\("harness-start", "Starting Hermes API", "running"\);/,
+  "Hermes API progress must not disclose the configured endpoint",
+);
+
+assert.doesNotMatch(
+  chatRoute,
+  /Starting Hermes API", "running", hermesApi\.baseUrl/,
+  "Hermes API URLs may contain reverse-proxy credentials and must never reach the stream",
+);
+
+assert.match(
+  chatRoute,
+  /envelopeToolUse\(event\.id, event\.name, input, assistantText\.length\)[\s\S]*?envelopeToolInput\(event\.id, input\)/,
+  "a canonical duplicate Hermes tool start must refresh the existing bubble input",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );
@@ -213,6 +231,24 @@ assert.match(
   assert.deepEqual(partial, { id: "call-args", name: "shell", input: '{"command":', status: "running" });
   const complete = tracker.envelopeToolInput("call-args", '{"command":"pwd"}');
   assert.deepEqual(complete, { id: "call-args", name: "shell", input: '{"command":"pwd"}', status: "running" });
+  assert.equal(tracker.snapshot()[0]?.input, '{"command":"pwd"}');
+}
+
+// Hermes progress may announce the native id before the canonical Responses
+// item supplies final arguments. The route's duplicate-start update preserves
+// the one stable bubble while replacing that incomplete input.
+{
+  const tracker = new ToolCallTracker();
+  tracker.envelopeToolUse("call-progress", "shell");
+  assert.equal(
+    tracker.envelopeToolUse("call-progress", "shell", '{"command":"pwd"}'),
+    null,
+    "the canonical duplicate start keeps the existing stable id",
+  );
+  const refreshed = tracker.envelopeToolInput("call-progress", '{"command":"pwd"}');
+  assert.deepEqual(refreshed, {
+    id: "call-progress", name: "shell", input: '{"command":"pwd"}', status: "running",
+  });
   assert.equal(tracker.snapshot()[0]?.input, '{"command":"pwd"}');
 }
 

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -204,6 +204,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /hermesCallNamesById\.set\(event\.id, event\.name\)[\s\S]*?if \(event\.isFinal\) \{\s*const name = hermesCallNamesById\.get\(id\);\s*if \(name\) boundarySentinel\?\.observe\(name, next\);/,
+  "final streamed Hermes tool arguments must pass through the runtime boundary sentinel",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -120,6 +120,30 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /previous_response_id: previousResponseId/,
+  "Hermes API follow-ups must continue from the stored Responses id, not Cave's stable conversation id",
+);
+
+assert.match(
+  chatRoute,
+  /req\.signal\.addEventListener\("abort", onAbort, \{ once: true \}\)[\s\S]*?req\.signal\.removeEventListener\("abort", onAbort\)/,
+  "Hermes API attempts must arm and clean up the shared detached-stream deadline",
+);
+
+assert.match(
+  chatRoute,
+  /text\/event-stream[\s\S]*?Hermes API protocol error/,
+  "Hermes API attempts must reject successful non-SSE responses",
+);
+
+assert.match(
+  chatRoute,
+  /frame\.data === "\[DONE\]"\) return true[\s\S]*?await reader\.cancel\(\)/,
+  "the Responses DONE sentinel must stop a still-open SSE reader",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );
@@ -152,6 +176,20 @@ assert.match(
   assert.equal(secondDone.id, second.id, "second post pairs with the remaining open call");
   assert.equal(secondDone.status, "error");
   assert.equal(secondDone.durationMs, 300, "duration measured from the second call's own start");
+}
+
+// Responses function calls are announced before their standard argument-delta
+// stream completes. Updating the same envelope id must replace the partial
+// input in both the live event and the persisted snapshot.
+{
+  const tracker = new ToolCallTracker();
+  const started = tracker.envelopeToolUse("call-args", "shell");
+  assert.ok(started);
+  const partial = tracker.envelopeToolInput("call-args", '{"command":');
+  assert.deepEqual(partial, { id: "call-args", name: "shell", input: '{"command":', status: "running" });
+  const complete = tracker.envelopeToolInput("call-args", '{"command":"pwd"}');
+  assert.deepEqual(complete, { id: "call-args", name: "shell", input: '{"command":"pwd"}', status: "running" });
+  assert.equal(tracker.snapshot()[0]?.input, '{"command":"pwd"}');
 }
 
 // Behavioral: a post with no open call still surfaces, under a fresh id.

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -162,6 +162,12 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /response\.status === 404 && isHermesMissingPreviousResponseError\(apiError\)/,
+  "Hermes's documented missing previous-response 404 must use the safe fresh-session retry",
+);
+
+assert.match(
+  chatRoute,
   /event\.isError && previousResponseId && event\.invalidPreviousResponseId[\s\S]*?previousResponseId && event\.invalidPreviousResponseId/,
   "streamed model and tool failures must not retry unless they explicitly reject the previous Responses id",
 );

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -150,6 +150,24 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /previousResponseId && response\.status >= 400 && response\.status < 500[\s\S]*?resumeFailed = true/,
+  "an invalid stored Responses id must use the existing one-time fresh-session retry",
+);
+
+assert.match(
+  chatRoute,
+  /await response\.body\?\.cancel\(\)\.catch\(\(\) => undefined\)/,
+  "rejected Hermes responses must cancel their body before returning the connection to the pool",
+);
+
+assert.match(
+  chatRoute,
+  /settleOpenHermesTools[\s\S]*?toolTracker\.failOpenCalls[\s\S]*?kind: "tool_use"/,
+  "every terminal Hermes attempt must emit interrupted updates for open tool calls",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );
@@ -196,6 +214,25 @@ assert.match(
   const complete = tracker.envelopeToolInput("call-args", '{"command":"pwd"}');
   assert.deepEqual(complete, { id: "call-args", name: "shell", input: '{"command":"pwd"}', status: "running" });
   assert.equal(tracker.snapshot()[0]?.input, '{"command":"pwd"}');
+}
+
+// A terminal stream failure must settle the SAME live tool id, so the UI and
+// persisted turn agree instead of leaving a running bubble until refresh.
+{
+  let t = 0;
+  const tracker = new ToolCallTracker(() => t);
+  const started = tracker.envelopeToolUse("call-interrupted", "shell", '{"command":"pwd"}');
+  assert.ok(started);
+  t = 250;
+  assert.deepEqual(tracker.failOpenCalls("[stream ended]"), [{
+    id: "call-interrupted",
+    name: "shell",
+    output: "[stream ended]",
+    status: "error",
+    durationMs: 250,
+  }]);
+  assert.deepEqual(tracker.failOpenCalls(), [], "settling open calls twice must not duplicate tool events");
+  assert.equal(tracker.snapshot()[0]?.status, "error");
 }
 
 // Behavioral: a post with no open call still surfaces, under a fresh id.

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -216,8 +216,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /flattenToolResultContent\(event\.output\) \?\? formatToolInputValue\(event\.output\)/,
-  "structured Hermes function output must display supported text blocks rather than protocol JSON",
+  /redactSecretsDeep\(event\.output\)[\s\S]*?flattenToolResultContent\(safeOutput\) \?\? formatToolInputValue\(safeOutput\)/,
+  "structured Hermes function output must display supported text blocks without exposing tool-supplied credentials",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -150,8 +150,20 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /previousResponseId && response\.status >= 400 && response\.status < 500[\s\S]*?resumeFailed = true/,
-  "an invalid stored Responses id must use the existing one-time fresh-session retry",
+  /isHermesInvalidPreviousResponseIdError\(apiError\)[\s\S]*?resumeFailed = true/,
+  "only a structured invalid previous Responses id may use the fresh-session retry",
+);
+
+assert.match(
+  chatRoute,
+  /event\.isError && previousResponseId && event\.invalidPreviousResponseId[\s\S]*?previousResponseId && event\.invalidPreviousResponseId/,
+  "streamed model and tool failures must not retry unless they explicitly reject the previous Responses id",
+);
+
+assert.match(
+  chatRoute,
+  /await runAttempt\(buildArgs\(null, retry\.prompt\), retry\.prompt\);/,
+  "the Responses fresh-session retry must receive replayed conversation context",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -96,6 +96,30 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /hermesApiConfig\(harnessSpawnEnv\(body\.familiarId\) as \{/,
+  "Hermes API credentials must come through the familiar-scoped environment boundary",
+);
+
+assert.match(
+  chatRoute,
+  /if \(hermesApi\) return runHermesApiAttempt\(apiPrompt\);/,
+  "a configured Hermes API must use the structured Responses SSE transport rather than terminal scraping",
+);
+
+assert.match(
+  chatRoute,
+  /hermesDirect && !hermesApi[\s\S]*?Hermes tool activity unavailable[\s\S]*?HERMES_API_URL/,
+  "the CLI fallback must disclose that structured tool activity is unavailable and how to enable it",
+);
+
+assert.match(
+  chatRoute,
+  /parseHermesResponsesEvent\(frame\.event, payload\)[\s\S]*?toolTracker\.envelopeToolUse\([\s\S]*?toolTracker\.envelopeToolResult\(/,
+  "Hermes structured tool starts and completions must flow through the shared persistent tracker",
+);
+
+assert.match(
+  chatRoute,
   /\.\.\.\(persistedTools \? \{ tools: persistedTools \} : \{\}\)/,
   "tools persist on the assistant turn alongside usage and cost",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2058,6 +2058,9 @@ export async function POST(req: Request) {
           const response = await fetch(hermesResponsesUrl(hermesApi), {
             method: "POST",
             signal: abort.signal,
+            // Do not let a configured server redirect prompts or bearer
+            // credentials past the validated endpoint boundary.
+            redirect: "error",
             headers: {
               "content-type": "application/json",
               accept: "text/event-stream",
@@ -2138,15 +2141,14 @@ export async function POST(req: Request) {
                 return false;
               }
               case "tool_end": {
-                const output = typeof event.output === "string"
-                  ? event.output
-                  : formatToolInputValue(event.output);
+                const output = flattenToolResultContent(event.output) ?? formatToolInputValue(event.output);
                 const toolEv = toolTracker.envelopeToolResult(event.id, output, event.isError);
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
                 return false;
               }
               case "done":
                 result = { ...result, is_error: event.isError };
+                if (event.message) recordStdoutErrorTail(event.message, true);
                 if (event.isError && previousResponseId) resumeFailed = true;
                 return true;
               case "error":

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1510,6 +1510,12 @@ export async function POST(req: Request) {
       // Keep it separately so the next Grok turn resumes the actual CLI
       // session rather than Cave's conversation id.
       let grokSessionId: string | null = null;
+      // Responses API ids rotate per turn like other harness session ids, but
+      // Cave's `sessionId` remains the stable conversation identity. Preserve
+      // the latest response id separately so follow-ups send
+      // `previous_response_id` instead of accidentally resuming from Cave's
+      // UUID.
+      let hermesResponseId: string | null = null;
       // First-turn visibility (cave-0g2x): the id of the in-flight user turn,
       // minted up front so the announce-time stub conversation and the
       // end-of-stream authoritative save agree on the turn's identity.
@@ -2027,7 +2033,14 @@ export async function POST(req: Request) {
         const abort = new AbortController();
         currentHermesAbort = abort;
         pushProgress("harness-start", "Starting Hermes API", "running", hermesApi.baseUrl);
+        const onAbort = () => {
+          // Transport loss is resumable, not a user Stop: keep consuming until
+          // the shared detach deadline, exactly like a child-process attempt.
+          armDetachKill();
+        };
+        req.signal.addEventListener("abort", onAbort, { once: true });
         try {
+          const previousResponseId = existingConversation?.harnessSessionId;
           const response = await fetch(hermesResponsesUrl(hermesApi), {
             method: "POST",
             signal: abort.signal,
@@ -2036,41 +2049,68 @@ export async function POST(req: Request) {
               accept: "text/event-stream",
               ...(hermesApi.apiKey ? { authorization: `Bearer ${hermesApi.apiKey}` } : {}),
             },
-            body: JSON.stringify({ model: forwardModel ?? desiredModel, input: apiPrompt, stream: true }),
+            body: JSON.stringify({
+              model: forwardModel ?? desiredModel,
+              input: apiPrompt,
+              stream: true,
+              ...(previousResponseId ? { previous_response_id: previousResponseId } : {}),
+            }),
           });
-          if (!response.ok || !response.body) {
+          const contentType = response.headers.get("content-type") ?? "";
+          if (!response.ok || !response.body || !/^text\/event-stream(?:\s*;|$)/i.test(contentType)) {
             result = { ...result, is_error: true };
-            recordStdoutErrorTail(`Hermes API request failed (${response.status})`, true);
+            recordStdoutErrorTail(
+              !response.ok
+                ? `Hermes API request failed (${response.status})`
+                : `Hermes API protocol error: expected text/event-stream, received ${contentType || "no content type"}`,
+              true,
+            );
             return;
           }
           const reader = response.body.getReader();
           const utf8 = new TextDecoder();
           const decoder = new HermesSseDecoder();
-          const consume = (frame: { event: string; data: string }) => {
-            if (frame.data === "[DONE]") return;
+          const hermesCallIdsByItemId = new Map<string, string>();
+          const hermesArgumentBuffers = new Map<string, string>();
+          const consume = (frame: { event: string; data: string }): boolean => {
+            if (frame.data === "[DONE]") return true;
             let payload: unknown;
             try {
               payload = JSON.parse(frame.data);
             } catch {
               // Future/non-JSON frames cannot safely become a tool bubble.
               recordStdoutErrorTail(frame.data);
-              return;
+              return false;
             }
             const event = parseHermesResponsesEvent(frame.event, payload);
             switch (event.kind) {
               case "session":
+                hermesResponseId = event.id;
                 if (!sessionId) announceSession(event.id);
-                return;
+                return false;
               case "text":
                 assistantText += event.text;
                 push({ kind: "assistant_chunk", text: event.text });
-                return;
+                return false;
               case "tool_start": {
                 const input = formatToolInputValue(event.input);
+                if (event.itemId) hermesCallIdsByItemId.set(event.itemId, event.id);
+                if (input !== undefined) hermesArgumentBuffers.set(event.id, input);
                 boundarySentinel?.observe(event.name, input ?? "");
                 const toolEv = toolTracker.envelopeToolUse(event.id, event.name, input, assistantText.length);
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
-                return;
+                return false;
+              }
+              case "tool_input": {
+                const id = event.id ?? (event.itemId ? hermesCallIdsByItemId.get(event.itemId) : undefined);
+                if (!id) return false;
+                const next = event.isFinal
+                  ? event.input
+                  : `${hermesArgumentBuffers.get(id) ?? ""}${event.input}`;
+                hermesArgumentBuffers.set(id, next);
+                const toolEv = toolTracker.envelopeToolInput(id, formatToolInputValue(next));
+                if (toolEv) push({ kind: "tool_use", ...toolEv });
+                return false;
               }
               case "tool_end": {
                 const output = typeof event.output === "string"
@@ -2078,26 +2118,48 @@ export async function POST(req: Request) {
                   : formatToolInputValue(event.output);
                 const toolEv = toolTracker.envelopeToolResult(event.id, output, event.isError);
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
-                return;
+                return false;
               }
               case "done":
                 result = { ...result, is_error: event.isError };
-                return;
+                return true;
               case "error":
                 result = { ...result, is_error: true };
                 recordStdoutErrorTail(event.message, true);
-                return;
+                return true;
               case "ignore":
-                return;
+                return false;
             }
           };
-          while (true) {
-            const { value, done } = await reader.read();
-            if (done) break;
-            for (const frame of decoder.push(utf8.decode(value, { stream: true }))) consume(frame);
+          try {
+            let terminal = false;
+            while (true) {
+              const { value, done } = await reader.read();
+              if (done) break;
+              for (const frame of decoder.push(utf8.decode(value, { stream: true }))) {
+                terminal = consume(frame) || terminal;
+                if (terminal) break;
+              }
+              if (terminal) {
+                await reader.cancel();
+                break;
+              }
+            }
+            if (!terminal) {
+              for (const frame of decoder.push(utf8.decode())) {
+                terminal = consume(frame) || terminal;
+                if (terminal) break;
+              }
+            }
+            if (!terminal) {
+              for (const frame of decoder.finish()) {
+                terminal = consume(frame) || terminal;
+                if (terminal) break;
+              }
+            }
+          } finally {
+            reader.releaseLock();
           }
-          for (const frame of decoder.push(utf8.decode())) consume(frame);
-          for (const frame of decoder.finish()) consume(frame);
         } catch (error) {
           if (!abort.signal.aborted) {
             result = { ...result, is_error: true };
@@ -2107,9 +2169,16 @@ export async function POST(req: Request) {
             );
           }
         } finally {
+          req.signal.removeEventListener("abort", onAbort);
           if (currentHermesAbort === abort) currentHermesAbort = null;
           result.duration_ms = Date.now() - attemptStartedAt;
-          pushProgress("harness-start", "Hermes API stream finished", "done", undefined, result.duration_ms);
+          pushProgress(
+            "harness-start",
+            result.is_error ? "Hermes API stream failed" : "Hermes API stream finished",
+            result.is_error ? "error" : "done",
+            undefined,
+            result.duration_ms,
+          );
         }
       };
 
@@ -2457,7 +2526,11 @@ export async function POST(req: Request) {
       // do not overwrite the previous native id (or record a changed sandbox
       // profile) and accidentally let a later read turn resume the old full
       // access session.
-      const harnessSessionId = grokDirect ? grokSessionId : sessionId;
+      const harnessSessionId = grokDirect
+        ? grokSessionId
+        : hermesDirect && hermesApi
+          ? hermesResponseId ?? sessionId
+          : sessionId;
       // OpenCode's JSON event protocol does not echo the selected model. Its
       // direct argv proves the selection was forwarded, while a successful
       // exit is the only confirmation it was applied. Preserve an explicit

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -67,6 +67,7 @@ import { parseOpenCodeRunEvent } from "@/lib/opencode-stream";
 import {
   HermesSseDecoder,
   hermesApiConfig,
+  hermesApiCanAccessLocalFiles,
   hermesResponsesUrl,
   isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
@@ -1166,10 +1167,11 @@ export async function POST(req: Request) {
   });
   if (offlineChatResponse) return offlineChatResponse;
 
-  // Image delivery channel: only local coven-run harnesses can Read files on
-  // this machine. The OpenClaw bridge and SSH runtimes cannot, so their
-  // prompts carry an explicit unsupported notice instead of a dead path.
-  const imagesSupported = !sshRuntime && binding.harness !== "openclaw";
+  // Image delivery channel: only harnesses that can read Cave's local temp
+  // files may receive image paths. Remote Hermes Responses endpoints cannot,
+  // so they receive the same explicit unsupported notice as bridge/SSH runs.
+  const imagesSupported = !sshRuntime && binding.harness !== "openclaw" &&
+    !(hermesApi && !hermesApiCanAccessLocalFiles(hermesApi));
   const imageFilePaths = imagesSupported
     ? await writeImageAttachmentsToTemp(attachments)
     : new Map<number, string>();
@@ -2099,6 +2101,7 @@ export async function POST(req: Request) {
           const hermesCallNamesById = new Map<string, string>();
           const hermesArgumentBuffers = new Map<string, string>();
           const consume = (frame: { event: string; data: string }): boolean => {
+            if (!frame.data.trim()) return false;
             if (frame.data === "[DONE]") return true;
             let payload: unknown;
             try {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -68,11 +68,13 @@ import {
   HermesSseDecoder,
   hermesApiConfig,
   hermesApiCanAccessLocalFiles,
+  isHermesResponsesEventName,
   isHermesMissingPreviousResponseError,
   hermesResponsesUrl,
   isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
 } from "@/lib/hermes-responses-stream";
+import { redactSecretText, redactSecretsDeep } from "@/lib/secret-redaction";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import {
   buildPromptWithKnowledgeVault,
@@ -1026,6 +1028,18 @@ export async function POST(req: Request) {
       { status: 501, headers: { "content-type": "application/json" } },
     );
   }
+  // The Responses API does not expose a documented, enforceable equivalent of
+  // Cave's read-only sandbox. Do not downgrade that security promise to a
+  // prompt merely because a familiar opted into the structured transport.
+  if (hermesDirect && hermesApi && body.permissionMode === "read") {
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error: "Hermes API does not support Cave's Read-only mode yet. Switch Access to Full access to run it.",
+      }),
+      { status: 501, headers: { "content-type": "application/json" } },
+    );
+  }
   if (sshRuntime && binding.harness === "openclaw") {
     return new Response(
       JSON.stringify({
@@ -1496,7 +1510,7 @@ export async function POST(req: Request) {
           "hermes-tool-activity",
           "Hermes tool activity unavailable",
           "error",
-          "Configure HERMES_API_URL for the versioned structured event transport.",
+          "Configure valid HERMES_API_URL and HERMES_API_KEY values for the versioned structured event transport.",
         );
       }
       if (grokFreshSessionForSandbox) {
@@ -1524,6 +1538,12 @@ export async function POST(req: Request) {
       // not a Responses id. If the API rejects it, the shared resume fallback
       // replays saved context into one fresh Responses turn instead.
       let hermesPreviousResponseId = existingConversation?.harnessSessionId ?? null;
+      // Legacy/failed conversations may not have a usable Responses id. A
+      // fresh API request must receive saved context rather than silently
+      // answering only the newest prompt.
+      const hermesNeedsContextReplay = Boolean(
+        hermesApi && body.sessionId && !hermesPreviousResponseId,
+      );
       // First-turn visibility (cave-0g2x): the id of the in-flight user turn,
       // minted up front so the announce-time stub conversation and the
       // end-of-stream authoritative save agree on the turn's identity.
@@ -2057,6 +2077,10 @@ export async function POST(req: Request) {
           armDetachKill();
         };
         req.signal.addEventListener("abort", onAbort, { once: true });
+        // AbortSignal does not replay an already-fired event. Route setup can
+        // outlive a client disconnect, so arm the shared deadline before the
+        // remote request starts in that race as well.
+        if (req.signal.aborted) onAbort();
         try {
           const previousResponseId = hermesPreviousResponseId;
           const response = await fetch(hermesResponsesUrl(hermesApi), {
@@ -2068,7 +2092,7 @@ export async function POST(req: Request) {
             headers: {
               "content-type": "application/json",
               accept: "text/event-stream",
-              ...(hermesApi.apiKey ? { authorization: `Bearer ${hermesApi.apiKey}` } : {}),
+              authorization: `Bearer ${hermesApi.apiKey}`,
             },
             body: JSON.stringify({
               model: forwardModel ?? desiredModel,
@@ -2079,7 +2103,7 @@ export async function POST(req: Request) {
           });
           const contentType = response.headers.get("content-type") ?? "";
           if (!response.ok || !response.body || !/^text\/event-stream(?:\s*;|$)/i.test(contentType)) {
-            const apiError = !response.ok && /\bapplication\/json\b/i.test(contentType)
+            const apiError = !response.ok && /^application\/(?:[a-z0-9.-]+\+)?json(?:\s*;|$)/i.test(contentType)
               ? await response.json().catch(() => undefined)
               : undefined;
             if (
@@ -2108,6 +2132,12 @@ export async function POST(req: Request) {
           const consume = (frame: { event: string; data: string }): boolean => {
             if (!frame.data.trim()) return false;
             if (frame.data === "[DONE]") return true;
+            // Extensions commonly emit textual pings/progress. Unknown named
+            // events are deliberately forward-compatible; only supported
+            // protocol events must parse as JSON.
+            if (frame.event && frame.event !== "message" && !isHermesResponsesEventName(frame.event)) {
+              return false;
+            }
             let payload: unknown;
             try {
               payload = JSON.parse(frame.data);
@@ -2130,7 +2160,7 @@ export async function POST(req: Request) {
                 push({ kind: "assistant_chunk", text: event.text });
                 return false;
               case "tool_start": {
-                const input = formatToolInputValue(event.input);
+                const input = formatToolInputValue(redactSecretsDeep(event.input));
                 if (event.itemId) hermesCallIdsByItemId.set(event.itemId, event.id);
                 hermesCallNamesById.set(event.id, event.name);
                 if (input !== undefined) hermesArgumentBuffers.set(event.id, input);
@@ -2161,12 +2191,14 @@ export async function POST(req: Request) {
                   const name = hermesCallNamesById.get(id);
                   if (name) boundarySentinel?.observe(name, next);
                 }
-                const toolEv = toolTracker.envelopeToolInput(id, formatToolInputValue(next));
+                const toolEv = toolTracker.envelopeToolInput(id, formatToolInputValue(redactSecretText(next)));
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
                 return false;
               }
               case "tool_end": {
-                const output = flattenToolResultContent(event.output) ?? formatToolInputValue(event.output);
+                const safeOutput = redactSecretsDeep(event.output);
+                const rawOutput = flattenToolResultContent(safeOutput) ?? formatToolInputValue(safeOutput);
+                const output = rawOutput === undefined ? undefined : redactSecretText(rawOutput);
                 const toolEv = toolTracker.envelopeToolResult(event.id, output, event.isError);
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
                 return false;
@@ -2238,10 +2270,7 @@ export async function POST(req: Request) {
             }
           } else {
             result = { ...result, is_error: true };
-            recordStdoutErrorTail(
-              error instanceof Error ? `Hermes API request failed: ${error.message}` : "Hermes API request failed",
-              true,
-            );
+            recordStdoutErrorTail("Hermes API request failed", true);
           }
         } finally {
           settleOpenHermesTools(
@@ -2417,7 +2446,19 @@ export async function POST(req: Request) {
       // First attempt — uses --continue if body.sessionId was set.
       };
       const turnSpawnStartMs = Date.now();
-      await runAttempt(args);
+      if (hermesNeedsContextReplay) {
+        const replay = buildResumeRetryPrompt(harnessPrompt, existingConversation);
+        pushProgress(
+          "resume-retry",
+          replay.replayedHistory
+            ? "No Responses session found; replaying recent context into a fresh chat"
+            : "No Responses session found; starting a fresh chat",
+          "done",
+        );
+        await runAttempt(buildArgs(null, replay.prompt), replay.prompt);
+      } else {
+        await runAttempt(args);
+      }
 
       // Self-heal (cave-1c05): a stale scaffolded manifest whose id the
       // installed CLI now ships as a built-in harness makes the registry load

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2219,7 +2219,16 @@ export async function POST(req: Request) {
             reader.releaseLock();
           }
         } catch (error) {
-          if (!abort.signal.aborted) {
+          if (abort.signal.aborted) {
+            // A detach deadline aborts the fetch just like a child kill. It
+            // never received a protocol terminal, so do not persist partial
+            // output as a resumable completed turn. Explicit Stop follows the
+            // cancellation path below and remains intentionally non-error.
+            if (!runHandle.stopRequested) {
+              result = { ...result, is_error: true };
+              recordStdoutErrorTail("Hermes API stream aborted after client disconnect", true);
+            }
+          } else {
             result = { ...result, is_error: true };
             recordStdoutErrorTail(
               error instanceof Error ? `Hermes API request failed: ${error.message}` : "Hermes API request failed",
@@ -2594,7 +2603,9 @@ export async function POST(req: Request) {
       const harnessSessionId = grokDirect
         ? grokSessionId
         : hermesDirect && hermesApi
-          ? hermesResponseId ?? sessionId
+          ? !result.is_error && hermesResponseId
+            ? hermesResponseId
+            : existingConversation?.harnessSessionId ?? sessionId
           : sessionId;
       // OpenCode's JSON event protocol does not echo the selected model. Its
       // direct argv proves the selection was forwarded, while a successful

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1516,6 +1516,10 @@ export async function POST(req: Request) {
       // `previous_response_id` instead of accidentally resuming from Cave's
       // UUID.
       let hermesResponseId: string | null = null;
+      // A conversation created by Hermes CLI has a CLI-native session id here,
+      // not a Responses id. If the API rejects it, the shared resume fallback
+      // replays saved context into one fresh Responses turn instead.
+      let hermesPreviousResponseId = existingConversation?.harnessSessionId ?? null;
       // First-turn visibility (cave-0g2x): the id of the in-flight user turn,
       // minted up front so the announce-time stub conversation and the
       // end-of-stream authoritative save agree on the turn's identity.
@@ -2032,6 +2036,14 @@ export async function POST(req: Request) {
         const attemptStartedAt = Date.now();
         const abort = new AbortController();
         currentHermesAbort = abort;
+        let hermesToolsSettled = false;
+        const settleOpenHermesTools = (reason: string) => {
+          if (hermesToolsSettled) return;
+          hermesToolsSettled = true;
+          for (const toolEv of toolTracker.failOpenCalls(reason)) {
+            push({ kind: "tool_use", ...toolEv });
+          }
+        };
         pushProgress("harness-start", "Starting Hermes API", "running", hermesApi.baseUrl);
         const onAbort = () => {
           // Transport loss is resumable, not a user Stop: keep consuming until
@@ -2040,7 +2052,7 @@ export async function POST(req: Request) {
         };
         req.signal.addEventListener("abort", onAbort, { once: true });
         try {
-          const previousResponseId = existingConversation?.harnessSessionId;
+          const previousResponseId = hermesPreviousResponseId;
           const response = await fetch(hermesResponsesUrl(hermesApi), {
             method: "POST",
             signal: abort.signal,
@@ -2058,6 +2070,9 @@ export async function POST(req: Request) {
           });
           const contentType = response.headers.get("content-type") ?? "";
           if (!response.ok || !response.body || !/^text\/event-stream(?:\s*;|$)/i.test(contentType)) {
+            if (previousResponseId && response.status >= 400 && response.status < 500) {
+              resumeFailed = true;
+            }
             result = { ...result, is_error: true };
             recordStdoutErrorTail(
               !response.ok
@@ -2065,6 +2080,7 @@ export async function POST(req: Request) {
                 : `Hermes API protocol error: expected text/event-stream, received ${contentType || "no content type"}`,
               true,
             );
+            await response.body?.cancel().catch(() => undefined);
             return;
           }
           const reader = response.body.getReader();
@@ -2122,9 +2138,11 @@ export async function POST(req: Request) {
               }
               case "done":
                 result = { ...result, is_error: event.isError };
+                if (event.isError && previousResponseId) resumeFailed = true;
                 return true;
               case "error":
                 result = { ...result, is_error: true };
+                if (previousResponseId) resumeFailed = true;
                 recordStdoutErrorTail(event.message, true);
                 return true;
               case "ignore":
@@ -2177,6 +2195,11 @@ export async function POST(req: Request) {
             );
           }
         } finally {
+          settleOpenHermesTools(
+            abort.signal.aborted
+              ? "[tool interrupted because the Hermes stream was cancelled]"
+              : "[tool did not settle before the Hermes stream ended]",
+          );
           req.signal.removeEventListener("abort", onAbort);
           if (currentHermesAbort === abort) currentHermesAbort = null;
           result.duration_ms = Date.now() - attemptStartedAt;
@@ -2407,6 +2430,8 @@ export async function POST(req: Request) {
           "running",
         );
         sessionId = null;
+        hermesResponseId = null;
+        hermesPreviousResponseId = null;
         assistantFilter = new AssistantFilter({ passthrough: rawStdoutHarness });
         assistantText = "";
         jsonBuf = "";

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -68,6 +68,7 @@ import {
   HermesSseDecoder,
   hermesApiConfig,
   hermesApiCanAccessLocalFiles,
+  isHermesMissingPreviousResponseError,
   hermesResponsesUrl,
   isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
@@ -2081,7 +2082,11 @@ export async function POST(req: Request) {
             const apiError = !response.ok && /\bapplication\/json\b/i.test(contentType)
               ? await response.json().catch(() => undefined)
               : undefined;
-            if (previousResponseId && isHermesInvalidPreviousResponseIdError(apiError)) {
+            if (
+              previousResponseId &&
+              (isHermesInvalidPreviousResponseIdError(apiError) ||
+                (response.status === 404 && isHermesMissingPreviousResponseError(apiError)))
+            ) {
               resumeFailed = true;
             }
             result = { ...result, is_error: true };

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2044,7 +2044,9 @@ export async function POST(req: Request) {
             push({ kind: "tool_use", ...toolEv });
           }
         };
-        pushProgress("harness-start", "Starting Hermes API", "running", hermesApi.baseUrl);
+        // Endpoint paths can carry reverse-proxy credentials; never put a
+        // configured URL in browser-visible progress or run-replay events.
+        pushProgress("harness-start", "Starting Hermes API", "running");
         const onAbort = () => {
           // Transport loss is resumable, not a user Stop: keep consuming until
           // the shared detach deadline, exactly like a child-process attempt.
@@ -2115,6 +2117,13 @@ export async function POST(req: Request) {
                 boundarySentinel?.observe(event.name, input ?? "");
                 const toolEv = toolTracker.envelopeToolUse(event.id, event.name, input, assistantText.length);
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
+                else if (input !== undefined) {
+                  // Hermes progress can announce a call before the canonical
+                  // Responses item. Keep the same bubble id but replace its
+                  // preliminary input when the canonical item is complete.
+                  const updated = toolTracker.envelopeToolInput(event.id, input);
+                  if (updated) push({ kind: "tool_use", ...updated });
+                }
                 return false;
               }
               case "tool_input": {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -64,6 +64,12 @@ import {
 import { grokLaunchCommand } from "@/lib/grok-bin";
 import { openCodeLaunch, openCodeSpawnEnv, writeOpenCodeLaunchInput } from "@/lib/opencode-bin";
 import { parseOpenCodeRunEvent } from "@/lib/opencode-stream";
+import {
+  HermesSseDecoder,
+  hermesApiConfig,
+  hermesResponsesUrl,
+  parseHermesResponsesEvent,
+} from "@/lib/hermes-responses-stream";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
 import {
   buildPromptWithKnowledgeVault,
@@ -930,9 +936,19 @@ export async function POST(req: Request) {
   // harness uses coven run's capability probe.
   const hermesDirect = !sshRuntime && binding.harness === "hermes";
   const openCodeDirect = !sshRuntime && binding.harness === "opencode";
+  // Tool activity from Hermes is only reliable over its documented structured
+  // API. The quiet CLI mode intentionally hides terminal tool previews, so it
+  // remains an explicit plain-text fallback when no API server is configured.
+  // Read credentials from the familiar-scoped env boundary, never a request.
+  const hermesApi = hermesDirect
+    ? hermesApiConfig(harnessSpawnEnv(body.familiarId) as {
+        HERMES_API_URL?: string;
+        HERMES_API_KEY?: string;
+      })
+    : null;
   const modelForwardingEnabled =
     hermesDirect
-      ? await hermesChatSupportsModel()
+      ? hermesApi !== null || await hermesChatSupportsModel()
       : openCodeDirect
         ? await openCodeRunSupportsModel()
         : binding.harness === "grok" ||
@@ -1468,6 +1484,17 @@ export async function POST(req: Request) {
       };
 
       push({ kind: "user", text: promptText });
+      if (hermesDirect && !hermesApi) {
+        // Do not fabricate tool bubbles from the CLI's presentation layer.
+        // This gives the operator an actionable, privacy-safe degradation
+        // notice while preserving normal CLI chat output.
+        pushProgress(
+          "hermes-tool-activity",
+          "Hermes tool activity unavailable",
+          "error",
+          "Configure HERMES_API_URL for the versioned structured event transport.",
+        );
+      }
       if (grokFreshSessionForSandbox) {
         pushProgress(
           "grok-sandbox-restart",
@@ -1959,9 +1986,11 @@ export async function POST(req: Request) {
       // run as user-cancelled. A bare transport abort no longer kills — the
       // turn finishes and persists, bounded by the detach cap.
       let currentChild: ReturnType<typeof spawn> | null = null;
+      let currentHermesAbort: AbortController | null = null;
       const killCurrentChild = () => {
         try {
           currentChild?.kill("SIGTERM");
+          currentHermesAbort?.abort();
         } catch {
           /* ignore */
         }
@@ -1990,8 +2019,103 @@ export async function POST(req: Request) {
         },
       });
 
-      const runAttempt = (spawnArgs: string[]): Promise<void> =>
-        new Promise((resolve) => {
+      const runHermesApiAttempt = async (apiPrompt: string): Promise<void> => {
+        // This is an opt-in local/API-server transport. Hermes quiet CLI output
+        // is intentionally not treated as a versioned tool-event protocol.
+        if (!hermesApi) return;
+        const attemptStartedAt = Date.now();
+        const abort = new AbortController();
+        currentHermesAbort = abort;
+        pushProgress("harness-start", "Starting Hermes API", "running", hermesApi.baseUrl);
+        try {
+          const response = await fetch(hermesResponsesUrl(hermesApi), {
+            method: "POST",
+            signal: abort.signal,
+            headers: {
+              "content-type": "application/json",
+              accept: "text/event-stream",
+              ...(hermesApi.apiKey ? { authorization: `Bearer ${hermesApi.apiKey}` } : {}),
+            },
+            body: JSON.stringify({ model: forwardModel ?? desiredModel, input: apiPrompt, stream: true }),
+          });
+          if (!response.ok || !response.body) {
+            result = { ...result, is_error: true };
+            recordStdoutErrorTail(`Hermes API request failed (${response.status})`, true);
+            return;
+          }
+          const reader = response.body.getReader();
+          const utf8 = new TextDecoder();
+          const decoder = new HermesSseDecoder();
+          const consume = (frame: { event: string; data: string }) => {
+            if (frame.data === "[DONE]") return;
+            let payload: unknown;
+            try {
+              payload = JSON.parse(frame.data);
+            } catch {
+              // Future/non-JSON frames cannot safely become a tool bubble.
+              recordStdoutErrorTail(frame.data);
+              return;
+            }
+            const event = parseHermesResponsesEvent(frame.event, payload);
+            switch (event.kind) {
+              case "session":
+                if (!sessionId) announceSession(event.id);
+                return;
+              case "text":
+                assistantText += event.text;
+                push({ kind: "assistant_chunk", text: event.text });
+                return;
+              case "tool_start": {
+                const input = formatToolInputValue(event.input);
+                boundarySentinel?.observe(event.name, input ?? "");
+                const toolEv = toolTracker.envelopeToolUse(event.id, event.name, input, assistantText.length);
+                if (toolEv) push({ kind: "tool_use", ...toolEv });
+                return;
+              }
+              case "tool_end": {
+                const output = typeof event.output === "string"
+                  ? event.output
+                  : formatToolInputValue(event.output);
+                const toolEv = toolTracker.envelopeToolResult(event.id, output, event.isError);
+                if (toolEv) push({ kind: "tool_use", ...toolEv });
+                return;
+              }
+              case "done":
+                result = { ...result, is_error: event.isError };
+                return;
+              case "error":
+                result = { ...result, is_error: true };
+                recordStdoutErrorTail(event.message, true);
+                return;
+              case "ignore":
+                return;
+            }
+          };
+          while (true) {
+            const { value, done } = await reader.read();
+            if (done) break;
+            for (const frame of decoder.push(utf8.decode(value, { stream: true }))) consume(frame);
+          }
+          for (const frame of decoder.push(utf8.decode())) consume(frame);
+          for (const frame of decoder.finish()) consume(frame);
+        } catch (error) {
+          if (!abort.signal.aborted) {
+            result = { ...result, is_error: true };
+            recordStdoutErrorTail(
+              error instanceof Error ? `Hermes API request failed: ${error.message}` : "Hermes API request failed",
+              true,
+            );
+          }
+        } finally {
+          if (currentHermesAbort === abort) currentHermesAbort = null;
+          result.duration_ms = Date.now() - attemptStartedAt;
+          pushProgress("harness-start", "Hermes API stream finished", "done", undefined, result.duration_ms);
+        }
+      };
+
+      const runAttempt = (spawnArgs: string[], apiPrompt = harnessPrompt): Promise<void> => {
+        if (hermesApi) return runHermesApiAttempt(apiPrompt);
+        return new Promise((resolve) => {
           const attemptStartedAt = Date.now();
           pushProgress(
             "harness-start",
@@ -2142,6 +2266,7 @@ export async function POST(req: Request) {
         });
 
       // First attempt — uses --continue if body.sessionId was set.
+      };
       const turnSpawnStartMs = Date.now();
       await runAttempt(args);
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2157,6 +2157,14 @@ export async function POST(req: Request) {
                 if (terminal) break;
               }
             }
+            if (!terminal && !abort.signal.aborted) {
+              // EOF without an explicit protocol terminal means a proxy or
+              // server cut the response short. Preserve any partial text for
+              // diagnostics, but never present or persist it as a completed
+              // model turn.
+              result = { ...result, is_error: true };
+              recordStdoutErrorTail("Hermes API stream ended before a terminal event", true);
+            }
           } finally {
             reader.releaseLock();
           }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2172,13 +2172,13 @@ export async function POST(req: Request) {
                   if (!sessionId) announceSession(event.id);
                 }
                 result = { ...result, is_error: event.isError };
-                if (event.message) recordStdoutErrorTail(event.message, true);
+                if (event.isError) recordStdoutErrorTail("Hermes API stream failed", true);
                 if (event.isError && previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
                 return true;
               case "error":
                 result = { ...result, is_error: true };
                 if (previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
-                recordStdoutErrorTail(event.message, true);
+                recordStdoutErrorTail("Hermes API stream failed", true);
                 return true;
               case "ignore":
                 return false;
@@ -2608,7 +2608,7 @@ export async function POST(req: Request) {
         : hermesDirect && hermesApi
           ? !result.is_error && hermesResponseId
             ? hermesResponseId
-            : existingConversation?.harnessSessionId ?? sessionId
+            : existingConversation?.harnessSessionId ?? null
           : sessionId;
       // OpenCode's JSON event protocol does not echo the selected model. Its
       // direct argv proves the selection was forwarded, while a successful

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2104,9 +2104,12 @@ export async function POST(req: Request) {
             try {
               payload = JSON.parse(frame.data);
             } catch {
-              // Future/non-JSON frames cannot safely become a tool bubble.
-              recordStdoutErrorTail(frame.data);
-              return false;
+              // A malformed event can hide text or a tool transition. Do not
+              // present a later terminal frame as a completed response after
+              // silently discarding it.
+              result = { ...result, is_error: true };
+              recordStdoutErrorTail("Hermes API protocol error: malformed SSE payload", true);
+              return true;
             }
             const event = parseHermesResponsesEvent(frame.event, payload);
             switch (event.kind) {
@@ -2161,6 +2164,10 @@ export async function POST(req: Request) {
                 return false;
               }
               case "done":
+                if (event.id) {
+                  hermesResponseId = event.id;
+                  if (!sessionId) announceSession(event.id);
+                }
                 result = { ...result, is_error: event.isError };
                 if (event.message) recordStdoutErrorTail(event.message, true);
                 if (event.isError && previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2092,6 +2092,7 @@ export async function POST(req: Request) {
           const utf8 = new TextDecoder();
           const decoder = new HermesSseDecoder();
           const hermesCallIdsByItemId = new Map<string, string>();
+          const hermesCallNamesById = new Map<string, string>();
           const hermesArgumentBuffers = new Map<string, string>();
           const consume = (frame: { event: string; data: string }): boolean => {
             if (frame.data === "[DONE]") return true;
@@ -2116,6 +2117,7 @@ export async function POST(req: Request) {
               case "tool_start": {
                 const input = formatToolInputValue(event.input);
                 if (event.itemId) hermesCallIdsByItemId.set(event.itemId, event.id);
+                hermesCallNamesById.set(event.id, event.name);
                 if (input !== undefined) hermesArgumentBuffers.set(event.id, input);
                 boundarySentinel?.observe(event.name, input ?? "");
                 const toolEv = toolTracker.envelopeToolUse(event.id, event.name, input, assistantText.length);
@@ -2136,6 +2138,14 @@ export async function POST(req: Request) {
                   ? event.input
                   : `${hermesArgumentBuffers.get(id) ?? ""}${event.input}`;
                 hermesArgumentBuffers.set(id, next);
+                // Standard Responses calls often arrive with empty arguments
+                // and stream their actual path-bearing input afterward. Check
+                // the assembled final value at the same runtime boundary as
+                // the initial tool announcement.
+                if (event.isFinal) {
+                  const name = hermesCallNamesById.get(id);
+                  if (name) boundarySentinel?.observe(name, next);
+                }
                 const toolEv = toolTracker.envelopeToolInput(id, formatToolInputValue(next));
                 if (toolEv) push({ kind: "tool_use", ...toolEv });
                 return false;

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -68,6 +68,7 @@ import {
   HermesSseDecoder,
   hermesApiConfig,
   hermesResponsesUrl,
+  isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
 } from "@/lib/hermes-responses-stream";
 import { buildPromptWithCovenIdentityCanon } from "@/lib/coven-identity-canon";
@@ -2075,7 +2076,10 @@ export async function POST(req: Request) {
           });
           const contentType = response.headers.get("content-type") ?? "";
           if (!response.ok || !response.body || !/^text\/event-stream(?:\s*;|$)/i.test(contentType)) {
-            if (previousResponseId && response.status >= 400 && response.status < 500) {
+            const apiError = !response.ok && /\bapplication\/json\b/i.test(contentType)
+              ? await response.json().catch(() => undefined)
+              : undefined;
+            if (previousResponseId && isHermesInvalidPreviousResponseIdError(apiError)) {
               resumeFailed = true;
             }
             result = { ...result, is_error: true };
@@ -2159,11 +2163,11 @@ export async function POST(req: Request) {
               case "done":
                 result = { ...result, is_error: event.isError };
                 if (event.message) recordStdoutErrorTail(event.message, true);
-                if (event.isError && previousResponseId) resumeFailed = true;
+                if (event.isError && previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
                 return true;
               case "error":
                 result = { ...result, is_error: true };
-                if (previousResponseId) resumeFailed = true;
+                if (previousResponseId && event.invalidPreviousResponseId) resumeFailed = true;
                 recordStdoutErrorTail(event.message, true);
                 return true;
               case "ignore":
@@ -2475,7 +2479,7 @@ export async function POST(req: Request) {
             : "Fresh chat started",
           "done",
         );
-        await runAttempt(buildArgs(null, retry.prompt));
+        await runAttempt(buildArgs(null, retry.prompt), retry.prompt);
       }
 
       // User cancel (CHAT-D5-02): when the client stops the response

--- a/src/lib/chat-tool-events.ts
+++ b/src/lib/chat-tool-events.ts
@@ -67,7 +67,9 @@ export function flattenToolResultContent(content: unknown): string | undefined {
       if (
         block &&
         typeof block === "object" &&
-        (block as { type?: unknown }).type === "text" &&
+        (["text", "input_text", "output_text"] as unknown[]).includes(
+          (block as { type?: unknown }).type,
+        ) &&
         typeof (block as { text?: unknown }).text === "string"
       ) {
         parts.push((block as { text: string }).text);

--- a/src/lib/chat-tool-events.ts
+++ b/src/lib/chat-tool-events.ts
@@ -268,6 +268,29 @@ export class ToolCallTracker {
   }
 
   /**
+   * Settles every currently open call as interrupted. A stream can terminate
+   * after announcing a function call but before its execution/result event;
+   * emit final updates so the live UI never retains a permanent spinner and
+   * persistence matches what the user saw.
+   */
+  failOpenCalls(output = "[tool did not settle before the stream ended]"): ToolStreamEvent[] {
+    const calls = Array.from(this.open.values()).flat();
+    return calls.map((call) => {
+      const durationMs = this.now() - call.startedAt;
+      this.settle(call);
+      const ev: ToolStreamEvent = {
+        id: call.id,
+        name: call.name,
+        output,
+        status: "error",
+        durationMs,
+      };
+      this.record(ev);
+      return ev;
+    });
+  }
+
+  /**
    * stream-json `tool_result` block (from the follow-up user message).
    * Returns null when the matching call was already settled by a post hook
    * (hook output + duration win) or was never announced.

--- a/src/lib/chat-tool-events.ts
+++ b/src/lib/chat-tool-events.ts
@@ -248,6 +248,26 @@ export class ToolCallTracker {
   }
 
   /**
+   * Updates an already-announced native tool call as its input becomes
+   * available. Responses-style protocols may announce an empty function call
+   * and stream its arguments afterwards; keep the same UI/persistence id
+   * rather than creating a second bubble or retaining a partial payload.
+   */
+  envelopeToolInput(toolUseId: string, input: string | undefined): ToolStreamEvent | null {
+    if (input === undefined || this.settledEnvelopeIds.has(toolUseId)) return null;
+    const call = this.byEnvelopeId.get(toolUseId);
+    if (!call) return null;
+    const ev: ToolStreamEvent = { id: call.id, name: call.name, input, status: "running" };
+    const prev = this.recorded.get(call.id);
+    if (prev) {
+      this.recorded.set(call.id, { ...prev, ...ev, input });
+    } else {
+      this.record(ev);
+    }
+    return ev;
+  }
+
+  /**
    * stream-json `tool_result` block (from the follow-up user message).
    * Returns null when the matching call was already settled by a post hook
    * (hook output + duration win) or was never announced.

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   HermesSseDecoder,
   hermesApiConfig,
+  hermesApiCanAccessLocalFiles,
   hermesResponsesUrl,
   isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
@@ -76,6 +77,18 @@ test("Hermes extension and malformed/future events fail closed", () => {
     parseHermesResponsesEvent("hermes.tool.progress", { tool_call_id: "call-2", status: "failed", output: "no" }),
     { kind: "tool_end", id: "call-2", output: "no", isError: true },
   );
+  assert.deepEqual(
+    parseHermesResponsesEvent("hermes.tool.progress", {
+      toolCallId: "call-camel", tool: "read_file", status: "running", input: { path: "a.ts" },
+    }),
+    { kind: "tool_start", id: "call-camel", name: "read_file", input: { path: "a.ts" } },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("hermes.tool.progress", {
+      toolCallId: "call-camel", status: "completed", output: "ok",
+    }),
+    { kind: "tool_end", id: "call-camel", output: "ok", isError: false },
+  );
   assert.deepEqual(parseHermesResponsesEvent("response.output_item.added", { item: { name: "missing-id" } }), { kind: "ignore" });
   assert.deepEqual(parseHermesResponsesEvent("new.future.event", { surprise: true }), { kind: "ignore" });
 });
@@ -118,6 +131,8 @@ test("structured transport is opt-in and refuses non-HTTP endpoint values", () =
   assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://[::1]:8080" }), {
     baseUrl: "http://[::1]:8080",
   });
+  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "https://hermes.example.test" }), false);
+  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "http://127.0.0.1:8080" }), true);
   assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://127.0.0.1:8080/", HERMES_API_KEY: " scoped " }), {
     baseUrl: "http://127.0.0.1:8080",
     apiKey: "scoped",

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -78,6 +78,13 @@ test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () =>
     { event: "one", data: "1" },
     { event: "two", data: "2" },
   ]);
+
+  const crOnly = new HermesSseDecoder();
+  assert.deepEqual(crOnly.push("event: one\rdata: 1\r\r"), []);
+  assert.deepEqual(crOnly.push("event: two\rdata: 2\r\r"), [
+    { event: "one", data: "1" },
+  ]);
+  assert.deepEqual(crOnly.finish(), [{ event: "two", data: "2" }]);
 });
 
 test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -20,6 +20,10 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
     { kind: "text", text: "hello" },
   );
   assert.deepEqual(
+    parseHermesResponsesEvent("message", { type: "response.output_text.delta", delta: "wrapped" }),
+    { kind: "text", text: "wrapped" },
+  );
+  assert.deepEqual(
     parseHermesResponsesEvent("response.output_item.added", {
       item: { type: "function_call", call_id: "call-1", name: "shell", arguments: { command: "pwd" } },
     }),
@@ -28,6 +32,18 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
   assert.deepEqual(
     parseHermesResponsesEvent("response.function_call_output", { call_id: "call-1", output: "C:/repo" }),
     { kind: "tool_end", id: "call-1", output: "C:/repo", isError: false },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.output_item.done", {
+      item: { call_id: "call-failed", status: "failed", error: { message: "denied" } },
+    }),
+    { kind: "tool_end", id: "call-failed", output: { message: "denied" }, isError: true },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.output_item.done", {
+      item: { call_id: "call-item-error", error: { message: "blocked" } },
+    }),
+    { kind: "tool_end", id: "call-item-error", output: { message: "blocked" }, isError: true },
   );
   assert.deepEqual(
     parseHermesResponsesEvent("response.completed", { response: { id: "resp-terminal" } }),
@@ -68,6 +84,10 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
       item: { id: "item-1", type: "function_call", call_id: "call-1", name: "shell", arguments: "" },
     }),
     { kind: "tool_start", id: "call-1", itemId: "item-1", name: "shell", input: "" },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.created", { response: { id: "../../unsafe" } }),
+    { kind: "error", message: "Hermes API protocol error: invalid response id" },
   );
 });
 
@@ -131,23 +151,28 @@ test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () =>
 
 test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {
   assert.equal(hermesApiConfig({}), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "https://hermes.example.test" }), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "https://hermes.example.test", HERMES_API_KEY: "bad\nkey" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "file:///tmp/hermes" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "http://hermes.example.test:8080" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "http://192.168.1.20:8080" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "https://user:token@example.test" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "https://example.test?api_key=token" }), null);
-  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "https://hermes.example.test:8443" }), {
+  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "https://hermes.example.test:8443", HERMES_API_KEY: "scoped" }), {
     baseUrl: "https://hermes.example.test:8443",
+    apiKey: "scoped",
   });
-  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://[::1]:8080" }), {
+  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://[::1]:8080", HERMES_API_KEY: "scoped" }), {
     baseUrl: "http://[::1]:8080",
+    apiKey: "scoped",
   });
-  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "https://hermes.example.test" }), false);
-  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "http://127.0.0.1:8080" }), true);
+  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "https://hermes.example.test", apiKey: "scoped" }), false);
+  assert.equal(hermesApiCanAccessLocalFiles({ baseUrl: "http://127.0.0.1:8080", apiKey: "scoped" }), true);
   assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://127.0.0.1:8080/", HERMES_API_KEY: " scoped " }), {
     baseUrl: "http://127.0.0.1:8080",
     apiKey: "scoped",
   });
-  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080" }), "http://127.0.0.1:8080/v1/responses");
-  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080/v1" }), "http://127.0.0.1:8080/v1/responses");
+  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080", apiKey: "scoped" }), "http://127.0.0.1:8080/v1/responses");
+  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080/v1", apiKey: "scoped" }), "http://127.0.0.1:8080/v1/responses");
+  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080/v1/responses", apiKey: "scoped" }), "http://127.0.0.1:8080/v1/responses");
 });

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -27,6 +27,24 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
     { kind: "tool_end", id: "call-1", output: "C:/repo", isError: false },
   );
   assert.deepEqual(parseHermesResponsesEvent("response.completed", {}), { kind: "done", isError: false });
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.function_call_arguments.delta", {
+      item_id: "item-1", delta: '{"command":',
+    }),
+    { kind: "tool_input", itemId: "item-1", input: '{"command":', isFinal: false },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.function_call_arguments.done", {
+      item_id: "item-1", arguments: '{"command":"pwd"}',
+    }),
+    { kind: "tool_input", itemId: "item-1", input: '{"command":"pwd"}', isFinal: true },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.output_item.added", {
+      item: { id: "item-1", type: "function_call", call_id: "call-1", name: "shell", arguments: "" },
+    }),
+    { kind: "tool_start", id: "call-1", itemId: "item-1", name: "shell", input: "" },
+  );
 });
 
 test("Hermes extension and malformed/future events fail closed", () => {
@@ -53,11 +71,20 @@ test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () =>
   assert.deepEqual(decoder.push("event: x\ndata: first\ndata: second\n\n"), [
     { event: "x", data: "first\nsecond" },
   ]);
+
+  const crlf = new HermesSseDecoder();
+  assert.deepEqual(crlf.push("event: one\r\ndata: 1\r"), []);
+  assert.deepEqual(crlf.push("\n\r\nevent: two\r\ndata: 2\r\n\r\n"), [
+    { event: "one", data: "1" },
+    { event: "two", data: "2" },
+  ]);
 });
 
 test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {
   assert.equal(hermesApiConfig({}), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "file:///tmp/hermes" }), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "https://user:token@example.test" }), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "https://example.test?api_key=token" }), null);
   assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://127.0.0.1:8080/", HERMES_API_KEY: " scoped " }), {
     baseUrl: "http://127.0.0.1:8080",
     apiKey: "scoped",

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -4,6 +4,7 @@ import {
   HermesSseDecoder,
   hermesApiConfig,
   hermesResponsesUrl,
+  isHermesInvalidPreviousResponseIdError,
   parseHermesResponsesEvent,
 } from "./hermes-responses-stream.ts";
 
@@ -30,6 +31,16 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
   assert.deepEqual(
     parseHermesResponsesEvent("response.failed", { response: { error: { message: "invalid model" } } }),
     { kind: "done", isError: true, message: "invalid model" },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.failed", {
+      response: { error: { message: "Previous response does not exist", param: "previous_response_id" } },
+    }),
+    { kind: "done", isError: true, message: "Previous response does not exist", invalidPreviousResponseId: true },
+  );
+  assert.equal(
+    isHermesInvalidPreviousResponseIdError({ error: { code: "previous_response_not_found" } }),
+    true,
   );
   assert.deepEqual(
     parseHermesResponsesEvent("response.function_call_arguments.delta", {

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -83,8 +83,16 @@ test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () =>
 test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {
   assert.equal(hermesApiConfig({}), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "file:///tmp/hermes" }), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "http://hermes.example.test:8080" }), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "http://192.168.1.20:8080" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "https://user:token@example.test" }), null);
   assert.equal(hermesApiConfig({ HERMES_API_URL: "https://example.test?api_key=token" }), null);
+  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "https://hermes.example.test:8443" }), {
+    baseUrl: "https://hermes.example.test:8443",
+  });
+  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://[::1]:8080" }), {
+    baseUrl: "http://[::1]:8080",
+  });
   assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://127.0.0.1:8080/", HERMES_API_KEY: " scoped " }), {
     baseUrl: "http://127.0.0.1:8080",
     apiKey: "scoped",

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -28,6 +28,10 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
   );
   assert.deepEqual(parseHermesResponsesEvent("response.completed", {}), { kind: "done", isError: false });
   assert.deepEqual(
+    parseHermesResponsesEvent("response.failed", { response: { error: { message: "invalid model" } } }),
+    { kind: "done", isError: true, message: "invalid model" },
+  );
+  assert.deepEqual(
     parseHermesResponsesEvent("response.function_call_arguments.delta", {
       item_id: "item-1", delta: '{"command":',
     }),

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -27,10 +27,13 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
     parseHermesResponsesEvent("response.function_call_output", { call_id: "call-1", output: "C:/repo" }),
     { kind: "tool_end", id: "call-1", output: "C:/repo", isError: false },
   );
-  assert.deepEqual(parseHermesResponsesEvent("response.completed", {}), { kind: "done", isError: false });
   assert.deepEqual(
-    parseHermesResponsesEvent("response.failed", { response: { error: { message: "invalid model" } } }),
-    { kind: "done", isError: true, message: "invalid model" },
+    parseHermesResponsesEvent("response.completed", { response: { id: "resp-terminal" } }),
+    { kind: "done", isError: false, id: "resp-terminal" },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.failed", { response: { id: "resp-failed", error: { message: "invalid model" } } }),
+    { kind: "done", isError: true, id: "resp-failed", message: "invalid model" },
   );
   assert.deepEqual(
     parseHermesResponsesEvent("response.failed", {

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -6,6 +6,7 @@ import {
   hermesApiCanAccessLocalFiles,
   hermesResponsesUrl,
   isHermesInvalidPreviousResponseIdError,
+  isHermesMissingPreviousResponseError,
   parseHermesResponsesEvent,
 } from "./hermes-responses-stream.ts";
 
@@ -44,6 +45,10 @@ test("Hermes Responses events normalise text, calls, output, session, and comple
   );
   assert.equal(
     isHermesInvalidPreviousResponseIdError({ error: { code: "previous_response_not_found" } }),
+    true,
+  );
+  assert.equal(
+    isHermesMissingPreviousResponseError({ error: { message: "Previous response not found: resp-evicted" } }),
     true,
   );
   assert.deepEqual(
@@ -116,6 +121,12 @@ test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () =>
     { event: "one", data: "1" },
   ]);
   assert.deepEqual(crOnly.finish(), [{ event: "two", data: "2" }]);
+
+  const bareFields = new HermesSseDecoder();
+  assert.deepEqual(bareFields.push("event: stale\nevent\ndata: {\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}\n\n"), [
+    { event: "", data: "{\"type\":\"response.output_text.delta\",\"delta\":\"ok\"}" },
+  ]);
+  assert.deepEqual(bareFields.push("data\n\n"), [{ event: "", data: "" }]);
 });
 
 test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {

--- a/src/lib/hermes-responses-stream.test.ts
+++ b/src/lib/hermes-responses-stream.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  HermesSseDecoder,
+  hermesApiConfig,
+  hermesResponsesUrl,
+  parseHermesResponsesEvent,
+} from "./hermes-responses-stream.ts";
+
+test("Hermes Responses events normalise text, calls, output, session, and completion", () => {
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.created", { response: { id: "resp-1" } }),
+    { kind: "session", id: "resp-1" },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.output_text.delta", { delta: "hello" }),
+    { kind: "text", text: "hello" },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.output_item.added", {
+      item: { type: "function_call", call_id: "call-1", name: "shell", arguments: { command: "pwd" } },
+    }),
+    { kind: "tool_start", id: "call-1", name: "shell", input: { command: "pwd" } },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("response.function_call_output", { call_id: "call-1", output: "C:/repo" }),
+    { kind: "tool_end", id: "call-1", output: "C:/repo", isError: false },
+  );
+  assert.deepEqual(parseHermesResponsesEvent("response.completed", {}), { kind: "done", isError: false });
+});
+
+test("Hermes extension and malformed/future events fail closed", () => {
+  assert.deepEqual(
+    parseHermesResponsesEvent("hermes.tool.progress", {
+      tool_call_id: "call-2", tool_name: "read_file", status: "running", input: { path: "a.ts" },
+    }),
+    { kind: "tool_start", id: "call-2", name: "read_file", input: { path: "a.ts" } },
+  );
+  assert.deepEqual(
+    parseHermesResponsesEvent("hermes.tool.progress", { tool_call_id: "call-2", status: "failed", output: "no" }),
+    { kind: "tool_end", id: "call-2", output: "no", isError: true },
+  );
+  assert.deepEqual(parseHermesResponsesEvent("response.output_item.added", { item: { name: "missing-id" } }), { kind: "ignore" });
+  assert.deepEqual(parseHermesResponsesEvent("new.future.event", { surprise: true }), { kind: "ignore" });
+});
+
+test("SSE decoder handles arbitrary chunk boundaries and multi-line data", () => {
+  const decoder = new HermesSseDecoder();
+  assert.deepEqual(decoder.push("event: response.output_text.delta\ndata: {\"de"), []);
+  assert.deepEqual(decoder.push("lta\":\"hi\"}\n\n"), [
+    { event: "response.output_text.delta", data: "{\"delta\":\"hi\"}" },
+  ]);
+  assert.deepEqual(decoder.push("event: x\ndata: first\ndata: second\n\n"), [
+    { event: "x", data: "first\nsecond" },
+  ]);
+});
+
+test("structured transport is opt-in and refuses non-HTTP endpoint values", () => {
+  assert.equal(hermesApiConfig({}), null);
+  assert.equal(hermesApiConfig({ HERMES_API_URL: "file:///tmp/hermes" }), null);
+  assert.deepEqual(hermesApiConfig({ HERMES_API_URL: "http://127.0.0.1:8080/", HERMES_API_KEY: " scoped " }), {
+    baseUrl: "http://127.0.0.1:8080",
+    apiKey: "scoped",
+  });
+  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080" }), "http://127.0.0.1:8080/v1/responses");
+  assert.equal(hermesResponsesUrl({ baseUrl: "http://127.0.0.1:8080/v1" }), "http://127.0.0.1:8080/v1/responses");
+});

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -38,7 +38,8 @@ function responseId(value: unknown): string | undefined {
 
 function toolId(value: RecordValue): string | undefined {
   const item = record(value.item);
-  return string(value.call_id) ?? string(value.tool_call_id) ?? string(item?.call_id) ?? string(item?.id);
+  return string(value.call_id) ?? string(value.tool_call_id) ?? string(value.toolCallId) ??
+    string(item?.call_id) ?? string(item?.id);
 }
 
 function toolItemId(value: RecordValue): string | undefined {
@@ -48,7 +49,8 @@ function toolItemId(value: RecordValue): string | undefined {
 
 function toolName(value: RecordValue): string | undefined {
   const item = record(value.item);
-  return string(value.name) ?? string(value.tool_name) ?? string(item?.name) ?? string(item?.tool_name);
+  return string(value.name) ?? string(value.tool_name) ?? string(value.tool) ??
+    string(item?.name) ?? string(item?.tool_name);
 }
 
 function toolInput(value: RecordValue): unknown {
@@ -271,6 +273,15 @@ function isLiteralLoopbackHost(host: string): boolean {
   return octets.length === 4 &&
     octets[0] === "127" &&
     octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+}
+
+/** Remote Hermes servers cannot read Cave's temporary image files. */
+export function hermesApiCanAccessLocalFiles(config: HermesApiConfig): boolean {
+  try {
+    return isLiteralLoopbackHost(new URL(config.baseUrl).hostname);
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -15,7 +15,7 @@ export type HermesResponsesEvent =
   | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
-  | { kind: "done"; isError: boolean; message?: string; invalidPreviousResponseId?: boolean }
+  | { kind: "done"; isError: boolean; id?: string; message?: string; invalidPreviousResponseId?: boolean }
   | { kind: "error"; message: string; invalidPreviousResponseId?: boolean }
   | { kind: "ignore" };
 
@@ -162,14 +162,19 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
     return { kind: "tool_end", id, output: toolOutput(value), isError: failed };
   }
 
-  if (type === "response.completed") return { kind: "done", isError: false };
+  if (type === "response.completed") {
+    const id = responseId(value);
+    return { kind: "done", isError: false, ...(id ? { id } : {}) };
+  }
   if (type === "response.failed" || type === "response.incomplete") {
     const response = record(value.response);
     const error = record(response?.error) ?? record(value.error);
     const message = string(error?.message) ?? string(value.message);
+    const id = responseId(value);
     return {
       kind: "done",
       isError: true,
+      ...(id ? { id } : {}),
       ...(message ? { message } : {}),
       ...(isHermesInvalidPreviousResponseIdError(value) ? { invalidPreviousResponseId: true } : {}),
     };

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -209,10 +209,12 @@ export class HermesSseDecoder {
       }
       this.eventName = "";
       this.data = [];
-    } else if (line.startsWith("event:")) {
-      this.eventName = line.slice("event:".length).trim();
-    } else if (line.startsWith("data:")) {
-      this.data.push(line.slice("data:".length).replace(/^ /, ""));
+    } else {
+      const colon = line.indexOf(":");
+      const field = colon < 0 ? line : line.slice(0, colon);
+      const value = colon < 0 ? "" : line.slice(colon + 1).replace(/^ /, "");
+      if (field === "event") this.eventName = value;
+      else if (field === "data") this.data.push(value);
     }
   }
 
@@ -273,6 +275,16 @@ function isLiteralLoopbackHost(host: string): boolean {
   return octets.length === 4 &&
     octets[0] === "127" &&
     octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+}
+
+/** Hermes's pre-stream 404 omits param/code but has this stable diagnostic.
+ * Callers must additionally require HTTP 404 before treating it as resumable. */
+export function isHermesMissingPreviousResponseError(payload: unknown): boolean {
+  const value = record(payload);
+  if (!value) return false;
+  const response = record(value.response);
+  const error = record(response?.error) ?? record(value.error) ?? value;
+  return /^Previous response not found:\s*\S/i.test(string(error.message) ?? "");
 }
 
 /** Remote Hermes servers cannot read Cave's temporary image files. */

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -11,7 +11,8 @@
 
 export type HermesResponsesEvent =
   | { kind: "text"; text: string }
-  | { kind: "tool_start"; id: string; name: string; input?: unknown }
+  | { kind: "tool_start"; id: string; name: string; input?: unknown; itemId?: string }
+  | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
   | { kind: "done"; isError: boolean }
@@ -38,6 +39,11 @@ function responseId(value: unknown): string | undefined {
 function toolId(value: RecordValue): string | undefined {
   const item = record(value.item);
   return string(value.call_id) ?? string(value.tool_call_id) ?? string(item?.call_id) ?? string(item?.id);
+}
+
+function toolItemId(value: RecordValue): string | undefined {
+  const item = record(value.item);
+  return string(value.item_id) ?? string(item?.id);
 }
 
 function toolName(value: RecordValue): string | undefined {
@@ -74,18 +80,46 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
   // A function-call item is the canonical Responses announcement. Hermes can
   // also emit its progress extension before the item is finalised; both map to
   // the same native call id and ToolCallTracker deduplicates them.
-  if (
-    type === "response.output_item.added" ||
-    type === "response.function_call_arguments.delta" ||
-    type === "hermes.tool.progress"
-  ) {
+  if (type === "response.function_call_arguments.delta") {
+    const delta = string(value.delta);
+    const id = string(value.call_id);
+    const itemId = toolItemId(value);
+    return delta
+      ? {
+          kind: "tool_input",
+          ...(id ? { id } : {}),
+          ...(itemId ? { itemId } : {}),
+          input: delta,
+          isFinal: false,
+        }
+      : { kind: "ignore" };
+  }
+
+  if (type === "response.function_call_arguments.done") {
+    const input = string(value.arguments) ?? string(value.delta);
+    const id = string(value.call_id);
+    const itemId = toolItemId(value);
+    return input
+      ? {
+          kind: "tool_input",
+          ...(id ? { id } : {}),
+          ...(itemId ? { itemId } : {}),
+          input,
+          isFinal: true,
+        }
+      : { kind: "ignore" };
+  }
+
+  if (type === "response.output_item.added" || type === "hermes.tool.progress") {
     const id = toolId(value);
     const name = toolName(value);
     const status = string(value.status);
     if (id && (status === "completed" || status === "complete" || status === "error" || status === "failed")) {
       return { kind: "tool_end", id, output: toolOutput(value), isError: status === "error" || status === "failed" };
     }
-    return id && name ? { kind: "tool_start", id, name, input: toolInput(value) } : { kind: "ignore" };
+    return id && name
+      ? { kind: "tool_start", id, name, input: toolInput(value), ...(toolItemId(value) ? { itemId: toolItemId(value) } : {}) }
+      : { kind: "ignore" };
   }
 
   if (
@@ -105,7 +139,9 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
       toolOutput(value) === undefined
     ) {
       const name = toolName(value);
-      return name ? { kind: "tool_start", id, name, input: toolInput(value) } : { kind: "ignore" };
+      return name
+        ? { kind: "tool_start", id, name, input: toolInput(value), ...(toolItemId(value) ? { itemId: toolItemId(value) } : {}) }
+        : { kind: "ignore" };
     }
     const failed = value.error === true || string(value.status) === "error" || string(value.status) === "failed";
     return { kind: "tool_end", id, output: toolOutput(value), isError: failed };
@@ -131,12 +167,15 @@ export class HermesSseDecoder {
   private data: string[] = [];
 
   push(chunk: string): Array<{ event: string; data: string }> {
-    this.buffer += chunk.replace(/\r\n/g, "\n");
+    // Keep CRLF normalization at the line boundary: a `\r` may arrive at the
+    // end of one network chunk and its `\n` in the next.
+    this.buffer += chunk;
     const frames: Array<{ event: string; data: string }> = [];
     let next: number;
     while ((next = this.buffer.indexOf("\n")) >= 0) {
-      const line = this.buffer.slice(0, next);
+      const rawLine = this.buffer.slice(0, next);
       this.buffer = this.buffer.slice(next + 1);
+      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
       if (!line) {
         if (this.data.length) {
           frames.push({ event: this.eventName, data: this.data.join("\n") });
@@ -155,7 +194,8 @@ export class HermesSseDecoder {
   finish(): Array<{ event: string; data: string }> {
     // SSE servers normally terminate frames with a blank line. Treat a final
     // unterminated data line as a frame too, because proxies sometimes omit it.
-    if (this.buffer.startsWith("data:")) this.data.push(this.buffer.slice(5).replace(/^ /, ""));
+    const tail = this.buffer.endsWith("\r") ? this.buffer.slice(0, -1) : this.buffer;
+    if (tail.startsWith("data:")) this.data.push(tail.slice(5).replace(/^ /, ""));
     this.buffer = "";
     if (!this.data.length) return [];
     const frame = { event: this.eventName, data: this.data.join("\n") };
@@ -180,7 +220,13 @@ export function hermesApiConfig(
   if (!raw) return null;
   try {
     const url = new URL(raw);
-    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (
+      (url.protocol !== "http:" && url.protocol !== "https:") ||
+      url.username ||
+      url.password ||
+      url.search ||
+      url.hash
+    ) return null;
     return {
       baseUrl: url.toString().replace(/\/$/, ""),
       ...(env.HERMES_API_KEY?.trim() ? { apiKey: env.HERMES_API_KEY.trim() } : {}),

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -166,42 +166,61 @@ export class HermesSseDecoder {
   private eventName = "";
   private data: string[] = [];
 
-  push(chunk: string): Array<{ event: string; data: string }> {
-    // Keep CRLF normalization at the line boundary: a `\r` may arrive at the
-    // end of one network chunk and its `\n` in the next.
-    this.buffer += chunk;
-    const frames: Array<{ event: string; data: string }> = [];
-    let next: number;
-    while ((next = this.buffer.indexOf("\n")) >= 0) {
-      const rawLine = this.buffer.slice(0, next);
-      this.buffer = this.buffer.slice(next + 1);
-      const line = rawLine.endsWith("\r") ? rawLine.slice(0, -1) : rawLine;
-      if (!line) {
-        if (this.data.length) {
-          frames.push({ event: this.eventName, data: this.data.join("\n") });
-        }
-        this.eventName = "";
-        this.data = [];
-      } else if (line.startsWith("event:")) {
-        this.eventName = line.slice("event:".length).trim();
-      } else if (line.startsWith("data:")) {
-        this.data.push(line.slice("data:".length).replace(/^ /, ""));
+  private consumeLine(line: string, frames: Array<{ event: string; data: string }>) {
+    if (!line) {
+      if (this.data.length) {
+        frames.push({ event: this.eventName, data: this.data.join("\n") });
       }
+      this.eventName = "";
+      this.data = [];
+    } else if (line.startsWith("event:")) {
+      this.eventName = line.slice("event:".length).trim();
+    } else if (line.startsWith("data:")) {
+      this.data.push(line.slice("data:".length).replace(/^ /, ""));
     }
+  }
+
+  /** Drain complete lines. A trailing CR remains buffered until the next chunk
+   * proves whether it begins CRLF; at end-of-stream a lone CR is final. */
+  private drain(final: boolean): Array<{ event: string; data: string }> {
+    const frames: Array<{ event: string; data: string }> = [];
+    let cursor = 0;
+    while (cursor < this.buffer.length) {
+      const lf = this.buffer.indexOf("\n", cursor);
+      const cr = this.buffer.indexOf("\r", cursor);
+      const next = lf < 0 ? cr : cr < 0 ? lf : Math.min(lf, cr);
+      if (next < 0) break;
+      const terminator = this.buffer[next];
+      // CR at a chunk edge might still pair with a following LF.
+      if (terminator === "\r" && next === this.buffer.length - 1 && !final) break;
+      const line = this.buffer.slice(cursor, next);
+      cursor = next + 1;
+      if (terminator === "\r" && this.buffer[cursor] === "\n") cursor += 1;
+      this.consumeLine(line, frames);
+    }
+    this.buffer = this.buffer.slice(cursor);
     return frames;
   }
 
+  push(chunk: string): Array<{ event: string; data: string }> {
+    this.buffer += chunk;
+    return this.drain(false);
+  }
+
   finish(): Array<{ event: string; data: string }> {
+    const frames = this.drain(true);
     // SSE servers normally terminate frames with a blank line. Treat a final
     // unterminated data line as a frame too, because proxies sometimes omit it.
-    const tail = this.buffer.endsWith("\r") ? this.buffer.slice(0, -1) : this.buffer;
-    if (tail.startsWith("data:")) this.data.push(tail.slice(5).replace(/^ /, ""));
-    this.buffer = "";
-    if (!this.data.length) return [];
-    const frame = { event: this.eventName, data: this.data.join("\n") };
-    this.eventName = "";
-    this.data = [];
-    return [frame];
+    if (this.buffer) {
+      this.consumeLine(this.buffer, frames);
+      this.buffer = "";
+    }
+    if (this.data.length) {
+      frames.push({ event: this.eventName, data: this.data.join("\n") });
+      this.eventName = "";
+      this.data = [];
+    }
+    return frames;
   }
 }
 

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -15,7 +15,7 @@ export type HermesResponsesEvent =
   | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
-  | { kind: "done"; isError: boolean }
+  | { kind: "done"; isError: boolean; message?: string }
   | { kind: "error"; message: string }
   | { kind: "ignore" };
 
@@ -148,7 +148,12 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
   }
 
   if (type === "response.completed") return { kind: "done", isError: false };
-  if (type === "response.failed" || type === "response.incomplete") return { kind: "done", isError: true };
+  if (type === "response.failed" || type === "response.incomplete") {
+    const response = record(value.response);
+    const error = record(response?.error) ?? record(value.error);
+    const message = string(error?.message) ?? string(value.message);
+    return { kind: "done", isError: true, ...(message ? { message } : {}) };
+  }
   if (type === "error") {
     const error = record(value.error);
     return { kind: "error", message: string(error?.message) ?? string(value.message) ?? "Hermes API failed" };

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -1,0 +1,196 @@
+// Hermes Agent Responses API stream compatibility.
+//
+// Hermes exposes a documented OpenAI-compatible Responses SSE endpoint.  The
+// CLI's quiet mode intentionally suppresses its terminal tool previews, so a
+// parser for terminal decoration would be both lossy and version-fragile.
+// This module is deliberately small and defensive: it accepts the stable
+// Responses event vocabulary plus Hermes's documented `hermes.tool.progress`
+// extension, ignores unfamiliar frames, and never invents a tool call from
+// incomplete data.  The normalised events are fed to ToolCallTracker by the
+// chat route, retaining Cave's stable-id, persistence, and resume semantics.
+
+export type HermesResponsesEvent =
+  | { kind: "text"; text: string }
+  | { kind: "tool_start"; id: string; name: string; input?: unknown }
+  | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
+  | { kind: "session"; id: string }
+  | { kind: "done"; isError: boolean }
+  | { kind: "error"; message: string }
+  | { kind: "ignore" };
+
+type RecordValue = Record<string, unknown>;
+
+function record(value: unknown): RecordValue | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as RecordValue
+    : null;
+}
+
+function string(value: unknown): string | undefined {
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function responseId(value: unknown): string | undefined {
+  const root = record(value);
+  return string(root?.response_id) ?? string(record(root?.response)?.id) ?? string(root?.id);
+}
+
+function toolId(value: RecordValue): string | undefined {
+  const item = record(value.item);
+  return string(value.call_id) ?? string(value.tool_call_id) ?? string(item?.call_id) ?? string(item?.id);
+}
+
+function toolName(value: RecordValue): string | undefined {
+  const item = record(value.item);
+  return string(value.name) ?? string(value.tool_name) ?? string(item?.name) ?? string(item?.tool_name);
+}
+
+function toolInput(value: RecordValue): unknown {
+  const item = record(value.item);
+  return value.arguments ?? value.input ?? item?.arguments ?? item?.input;
+}
+
+function toolOutput(value: RecordValue): unknown {
+  const item = record(value.item);
+  return value.output ?? value.result ?? item?.output ?? item?.result;
+}
+
+/** Parse one complete SSE frame. Unknown/future frame types are safely ignored. */
+export function parseHermesResponsesEvent(eventName: string, payload: unknown): HermesResponsesEvent {
+  const value = record(payload);
+  if (!value) return { kind: "ignore" };
+  const type = eventName || string(value.type) || "";
+
+  if (type === "response.output_text.delta" || type === "response.text.delta") {
+    const text = string(value.delta) ?? string(value.text);
+    return text ? { kind: "text", text } : { kind: "ignore" };
+  }
+
+  if (type === "response.created" || type === "response.in_progress") {
+    const id = responseId(value);
+    return id ? { kind: "session", id } : { kind: "ignore" };
+  }
+
+  // A function-call item is the canonical Responses announcement. Hermes can
+  // also emit its progress extension before the item is finalised; both map to
+  // the same native call id and ToolCallTracker deduplicates them.
+  if (
+    type === "response.output_item.added" ||
+    type === "response.function_call_arguments.delta" ||
+    type === "hermes.tool.progress"
+  ) {
+    const id = toolId(value);
+    const name = toolName(value);
+    const status = string(value.status);
+    if (id && (status === "completed" || status === "complete" || status === "error" || status === "failed")) {
+      return { kind: "tool_end", id, output: toolOutput(value), isError: status === "error" || status === "failed" };
+    }
+    return id && name ? { kind: "tool_start", id, name, input: toolInput(value) } : { kind: "ignore" };
+  }
+
+  if (
+    type === "response.output_item.done" ||
+    type === "response.function_call_output" ||
+    type === "hermes.tool.completed"
+  ) {
+    const id = toolId(value);
+    if (!id) return { kind: "ignore" };
+    const item = record(value.item);
+    // `output_item.done` with a function_call marks a completed model output,
+    // not necessarily completed tool execution. Do not settle that bubble
+    // until an output/progress completion arrives.
+    if (
+      type === "response.output_item.done" &&
+      string(item?.type) === "function_call" &&
+      toolOutput(value) === undefined
+    ) {
+      const name = toolName(value);
+      return name ? { kind: "tool_start", id, name, input: toolInput(value) } : { kind: "ignore" };
+    }
+    const failed = value.error === true || string(value.status) === "error" || string(value.status) === "failed";
+    return { kind: "tool_end", id, output: toolOutput(value), isError: failed };
+  }
+
+  if (type === "response.completed") return { kind: "done", isError: false };
+  if (type === "response.failed" || type === "response.incomplete") return { kind: "done", isError: true };
+  if (type === "error") {
+    const error = record(value.error);
+    return { kind: "error", message: string(error?.message) ?? string(value.message) ?? "Hermes API failed" };
+  }
+  return { kind: "ignore" };
+}
+
+/**
+ * Incremental SSE decoder. Chunk boundaries are arbitrary and `data:` may be
+ * split over lines, so callers must feed bytes rather than trying to split a
+ * Fetch body on `\n\n` themselves.
+ */
+export class HermesSseDecoder {
+  private buffer = "";
+  private eventName = "";
+  private data: string[] = [];
+
+  push(chunk: string): Array<{ event: string; data: string }> {
+    this.buffer += chunk.replace(/\r\n/g, "\n");
+    const frames: Array<{ event: string; data: string }> = [];
+    let next: number;
+    while ((next = this.buffer.indexOf("\n")) >= 0) {
+      const line = this.buffer.slice(0, next);
+      this.buffer = this.buffer.slice(next + 1);
+      if (!line) {
+        if (this.data.length) {
+          frames.push({ event: this.eventName, data: this.data.join("\n") });
+        }
+        this.eventName = "";
+        this.data = [];
+      } else if (line.startsWith("event:")) {
+        this.eventName = line.slice("event:".length).trim();
+      } else if (line.startsWith("data:")) {
+        this.data.push(line.slice("data:".length).replace(/^ /, ""));
+      }
+    }
+    return frames;
+  }
+
+  finish(): Array<{ event: string; data: string }> {
+    // SSE servers normally terminate frames with a blank line. Treat a final
+    // unterminated data line as a frame too, because proxies sometimes omit it.
+    if (this.buffer.startsWith("data:")) this.data.push(this.buffer.slice(5).replace(/^ /, ""));
+    this.buffer = "";
+    if (!this.data.length) return [];
+    const frame = { event: this.eventName, data: this.data.join("\n") };
+    this.eventName = "";
+    this.data = [];
+    return [frame];
+  }
+}
+
+export type HermesApiConfig = { baseUrl: string; apiKey?: string };
+
+/**
+ * Opt in to the structured transport with a local/API-server endpoint. The
+ * key is read from the familiar-scoped spawn environment by the caller, never
+ * from a request body or persisted transcript. Invalid/non-HTTP values fall
+ * back to the CLI, which remains functional but cannot promise tool bubbles.
+ */
+export function hermesApiConfig(
+  env: Partial<Record<"HERMES_API_URL" | "HERMES_API_KEY", string | undefined>>,
+): HermesApiConfig | null {
+  const raw = env.HERMES_API_URL?.trim();
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    return {
+      baseUrl: url.toString().replace(/\/$/, ""),
+      ...(env.HERMES_API_KEY?.trim() ? { apiKey: env.HERMES_API_KEY.trim() } : {}),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Accept either the server origin or an already-versioned `/v1` base URL. */
+export function hermesResponsesUrl(config: HermesApiConfig): string {
+  return `${config.baseUrl.endsWith("/v1") ? config.baseUrl : `${config.baseUrl}/v1`}/responses`;
+}

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -33,7 +33,20 @@ function string(value: unknown): string | undefined {
 
 function responseId(value: unknown): string | undefined {
   const root = record(value);
-  return string(root?.response_id) ?? string(record(root?.response)?.id) ?? string(root?.id);
+  const id = string(root?.response_id) ?? string(record(root?.response)?.id) ?? string(root?.id);
+  return id && isSafeHermesResponseId(id) ? id : undefined;
+}
+
+/** Response ids become Cave conversation ids for first API turns, so they
+ * must be safe to use as a local transcript filename. */
+export function isSafeHermesResponseId(id: string): boolean {
+  return id.length <= 240 && id !== "." && id !== ".." && !/[\\/\0]/.test(id);
+}
+
+function hasUnsafeResponseId(value: unknown): boolean {
+  const root = record(value);
+  const id = string(root?.response_id) ?? string(record(root?.response)?.id) ?? string(root?.id);
+  return Boolean(id && !isSafeHermesResponseId(id));
 }
 
 function toolId(value: RecordValue): string | undefined {
@@ -60,7 +73,15 @@ function toolInput(value: RecordValue): unknown {
 
 function toolOutput(value: RecordValue): unknown {
   const item = record(value.item);
-  return value.output ?? value.result ?? item?.output ?? item?.result;
+  return value.output ?? value.result ?? item?.output ?? item?.result ?? item?.error ?? value.error;
+}
+
+function toolFailed(value: RecordValue, item: RecordValue | null): boolean {
+  const failedStatuses = new Set(["error", "failed", "cancelled", "canceled", "incomplete"]);
+  const hasError = (error: unknown) => error !== undefined && error !== null && error !== false;
+  return hasError(value.error) || hasError(item?.error) ||
+    failedStatuses.has(string(value.status) ?? "") ||
+    failedStatuses.has(string(item?.status) ?? "");
 }
 
 /** A fresh retry is safe only when the API explicitly rejects the stored
@@ -78,11 +99,32 @@ export function isHermesInvalidPreviousResponseIdError(payload: unknown): boolea
     code === "previous_response_not_found";
 }
 
+/** Unknown named extension frames may lawfully carry non-JSON keepalive text. */
+export function isHermesResponsesEventName(eventName: string): boolean {
+  return new Set([
+    "response.output_text.delta", "response.text.delta", "response.created", "response.in_progress",
+    "response.function_call_arguments.delta", "response.function_call_arguments.done",
+    "response.output_item.added", "response.output_item.done", "response.function_call_output",
+    "response.completed", "response.failed", "response.incomplete", "hermes.tool.progress",
+    "hermes.tool.completed", "error",
+  ]).has(eventName);
+}
+
 /** Parse one complete SSE frame. Unknown/future frame types are safely ignored. */
 export function parseHermesResponsesEvent(eventName: string, payload: unknown): HermesResponsesEvent {
   const value = record(payload);
   if (!value) return { kind: "ignore" };
-  const type = eventName || string(value.type) || "";
+  // `message` is SSE's default event type. Servers may send it explicitly
+  // while carrying the actual Responses name in the JSON payload.
+  const type = !eventName || eventName === "message" ? string(value.type) || "" : eventName;
+
+  if (
+    (type === "response.created" || type === "response.in_progress" ||
+      type === "response.completed" || type === "response.failed" || type === "response.incomplete") &&
+    hasUnsafeResponseId(value)
+  ) {
+    return { kind: "error", message: "Hermes API protocol error: invalid response id" };
+  }
 
   if (type === "response.output_text.delta" || type === "response.text.delta") {
     const text = string(value.delta) ?? string(value.text);
@@ -132,7 +174,7 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
     const name = toolName(value);
     const status = string(value.status);
     if (id && (status === "completed" || status === "complete" || status === "error" || status === "failed")) {
-      return { kind: "tool_end", id, output: toolOutput(value), isError: status === "error" || status === "failed" };
+      return { kind: "tool_end", id, output: toolOutput(value), isError: toolFailed(value, record(value.item)) };
     }
     return id && name
       ? { kind: "tool_start", id, name, input: toolInput(value), ...(toolItemId(value) ? { itemId: toolItemId(value) } : {}) }
@@ -153,14 +195,15 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
     if (
       type === "response.output_item.done" &&
       string(item?.type) === "function_call" &&
-      toolOutput(value) === undefined
+      toolOutput(value) === undefined &&
+      !toolFailed(value, item)
     ) {
       const name = toolName(value);
       return name
         ? { kind: "tool_start", id, name, input: toolInput(value), ...(toolItemId(value) ? { itemId: toolItemId(value) } : {}) }
         : { kind: "ignore" };
     }
-    const failed = value.error === true || string(value.status) === "error" || string(value.status) === "failed";
+    const failed = toolFailed(value, item);
     return { kind: "tool_end", id, output: toolOutput(value), isError: failed };
   }
 
@@ -262,7 +305,7 @@ export class HermesSseDecoder {
   }
 }
 
-export type HermesApiConfig = { baseUrl: string; apiKey?: string };
+export type HermesApiConfig = { baseUrl: string; apiKey: string };
 
 /** Plain HTTP is only safe for a numeric loopback listener. Do not resolve
  * names here: a hostname such as `localhost` can be redirected by local DNS or
@@ -307,7 +350,10 @@ export function hermesApiConfig(
   env: Partial<Record<"HERMES_API_URL" | "HERMES_API_KEY", string | undefined>>,
 ): HermesApiConfig | null {
   const raw = env.HERMES_API_URL?.trim();
-  if (!raw) return null;
+  const apiKey = env.HERMES_API_KEY?.trim();
+  // Invalid configuration must select the unchanged CLI fallback rather than
+  // letting fetch echo a malformed authorization value in an error message.
+  if (!raw || !apiKey || /[\0-\x1F\x7F]/.test(apiKey)) return null;
   try {
     const url = new URL(raw);
     if (
@@ -320,7 +366,7 @@ export function hermesApiConfig(
     ) return null;
     return {
       baseUrl: url.toString().replace(/\/$/, ""),
-      ...(env.HERMES_API_KEY?.trim() ? { apiKey: env.HERMES_API_KEY.trim() } : {}),
+      apiKey,
     };
   } catch {
     return null;
@@ -329,5 +375,6 @@ export function hermesApiConfig(
 
 /** Accept either the server origin or an already-versioned `/v1` base URL. */
 export function hermesResponsesUrl(config: HermesApiConfig): string {
-  return `${config.baseUrl.endsWith("/v1") ? config.baseUrl : `${config.baseUrl}/v1`}/responses`;
+  const baseUrl = config.baseUrl.replace(/\/v1\/responses$/, "");
+  return `${baseUrl.endsWith("/v1") ? baseUrl : `${baseUrl}/v1`}/responses`;
 }

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -15,8 +15,8 @@ export type HermesResponsesEvent =
   | { kind: "tool_input"; id?: string; itemId?: string; input: string; isFinal: boolean }
   | { kind: "tool_end"; id: string; output?: unknown; isError: boolean }
   | { kind: "session"; id: string }
-  | { kind: "done"; isError: boolean; message?: string }
-  | { kind: "error"; message: string }
+  | { kind: "done"; isError: boolean; message?: string; invalidPreviousResponseId?: boolean }
+  | { kind: "error"; message: string; invalidPreviousResponseId?: boolean }
   | { kind: "ignore" };
 
 type RecordValue = Record<string, unknown>;
@@ -59,6 +59,21 @@ function toolInput(value: RecordValue): unknown {
 function toolOutput(value: RecordValue): unknown {
   const item = record(value.item);
   return value.output ?? value.result ?? item?.output ?? item?.result;
+}
+
+/** A fresh retry is safe only when the API explicitly rejects the stored
+ * Responses continuation token. Textual error matching would retry genuine
+ * model/tool failures after users have already seen streamed side effects. */
+export function isHermesInvalidPreviousResponseIdError(payload: unknown): boolean {
+  const value = record(payload);
+  if (!value) return false;
+  const response = record(value.response);
+  const error = record(response?.error) ?? record(value.error) ?? value;
+  const param = string(error.param);
+  const code = string(error.code);
+  return param === "previous_response_id" ||
+    code === "invalid_previous_response_id" ||
+    code === "previous_response_not_found";
 }
 
 /** Parse one complete SSE frame. Unknown/future frame types are safely ignored. */
@@ -152,11 +167,20 @@ export function parseHermesResponsesEvent(eventName: string, payload: unknown): 
     const response = record(value.response);
     const error = record(response?.error) ?? record(value.error);
     const message = string(error?.message) ?? string(value.message);
-    return { kind: "done", isError: true, ...(message ? { message } : {}) };
+    return {
+      kind: "done",
+      isError: true,
+      ...(message ? { message } : {}),
+      ...(isHermesInvalidPreviousResponseIdError(value) ? { invalidPreviousResponseId: true } : {}),
+    };
   }
   if (type === "error") {
     const error = record(value.error);
-    return { kind: "error", message: string(error?.message) ?? string(value.message) ?? "Hermes API failed" };
+    return {
+      kind: "error",
+      message: string(error?.message) ?? string(value.message) ?? "Hermes API failed",
+      ...(isHermesInvalidPreviousResponseIdError(value) ? { invalidPreviousResponseId: true } : {}),
+    };
   }
   return { kind: "ignore" };
 }

--- a/src/lib/hermes-responses-stream.ts
+++ b/src/lib/hermes-responses-stream.ts
@@ -207,11 +207,25 @@ export class HermesSseDecoder {
 
 export type HermesApiConfig = { baseUrl: string; apiKey?: string };
 
+/** Plain HTTP is only safe for a numeric loopback listener. Do not resolve
+ * names here: a hostname such as `localhost` can be redirected by local DNS or
+ * hosts-file policy, which would put prompts and bearer credentials on the
+ * network. */
+function isLiteralLoopbackHost(host: string): boolean {
+  const normalized = host.replace(/^\[|\]$/g, "").toLowerCase();
+  if (normalized === "::1") return true;
+  const octets = normalized.split(".");
+  return octets.length === 4 &&
+    octets[0] === "127" &&
+    octets.every((octet) => /^\d{1,3}$/.test(octet) && Number(octet) <= 255);
+}
+
 /**
- * Opt in to the structured transport with a local/API-server endpoint. The
- * key is read from the familiar-scoped spawn environment by the caller, never
- * from a request body or persisted transcript. Invalid/non-HTTP values fall
- * back to the CLI, which remains functional but cannot promise tool bubbles.
+ * Opt in to the structured transport with a local/API-server endpoint. Remote
+ * endpoints must use HTTPS; HTTP is limited to literal loopback listeners.
+ * The key is read from the familiar-scoped spawn environment by the caller,
+ * never from a request body or persisted transcript. Invalid values fall back
+ * to the CLI, which remains functional but cannot promise tool bubbles.
  */
 export function hermesApiConfig(
   env: Partial<Record<"HERMES_API_URL" | "HERMES_API_KEY", string | undefined>>,
@@ -225,7 +239,8 @@ export function hermesApiConfig(
       url.username ||
       url.password ||
       url.search ||
-      url.hash
+      url.hash ||
+      (url.protocol === "http:" && !isLiteralLoopbackHost(url.hostname))
     ) return null;
     return {
       baseUrl: url.toString().replace(/\/$/, ""),

--- a/src/lib/server/stuck-created-sweep.test.ts
+++ b/src/lib/server/stuck-created-sweep.test.ts
@@ -102,8 +102,8 @@ const OPTS = { cwd: CWD, prompt: "ping", sinceMs: Date.parse("2026-07-12T07:53:0
   );
   assert.match(
     route,
-    /const turnSpawnStartMs = Date\.now\(\);\s*await runAttempt\(args\);/,
-    "turn window anchor is captured immediately before the first attempt",
+    /const turnSpawnStartMs = Date\.now\(\);\s*if \(hermesNeedsContextReplay\) \{[\s\S]*?await runAttempt\(buildArgs\(null, replay\.prompt\), replay\.prompt\);[\s\S]*?\} else \{\s*await runAttempt\(args\);/,
+    "turn window anchor is captured before either the context-replay or normal first attempt",
   );
 }
 


### PR DESCRIPTION
## Summary

- prefer Hermes Agent's documented Responses SSE transport when `HERMES_API_URL` is configured, keeping the quiet CLI as a safe plain-text fallback
- normalize text, response sessions, function calls, Hermes tool-progress, completion, and error events into the existing stable tool-bubble tracker
- preserve scoped credentials, cancellation, persisted tool rows, and an explicit degraded-mode diagnostic

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `node --experimental-strip-types --test src/lib/hermes-responses-stream.test.ts src/app/api/chat/send/harness-routing-tool-events.test.ts src/app/api/chat/send/harness-routing-host-session.test.ts`
- `git diff --check`
- `pnpm test:api` was attempted; it stopped after six passing files because this Windows host's WSL cannot execute `/bin/bash` for the existing `scripts/git-hooks-pre-commit.test.mjs` fixture.

## Follow-up boundary

The current `coven-runtimes` Hermes manifest (1.0.2) declares no structured stream schema, signed registry feed, or trust root. This draft is deliberately fail-closed: it uses the documented API only when the operator configures it, and does not claim automatic untrusted schema downloads. A signed canonical schema feed must be added upstream before that portion of #3844 can be completed safely.

Refs #3844