### PR TITLE
fix(desktop): stage Whisper runtime for development

### DIFF
--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -13,6 +13,11 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+# The desktop shell may need its bundled sidecar before the dev server is
+# reachable, so a clean checkout must stage whisper-cli before Tauri starts.
+echo "[dev:app] staging bundled Whisper runtime"
+bash scripts/whisper-runtime-bundle.sh
+
 port_is_listening() {
   node -e "const net=require('net');const s=net.connect({host:'127.0.0.1',port:Number(process.argv[1])});s.setTimeout(300);s.on('connect',()=>process.exit(0));s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1));" "$1"
 }

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -14,9 +14,8 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 # The desktop shell may need its bundled sidecar before the dev server is
-# reachable, so a clean checkout must stage whisper-cli before Tauri starts.
-echo "[dev:app] staging bundled Whisper runtime"
-bash scripts/whisper-runtime-bundle.sh
+# reachable. Source the helper so the Next process inherits its absolute CLI.
+source scripts/whisper-runtime-dev-env.sh
 
 port_is_listening() {
   node -e "const net=require('net');const s=net.connect({host:'127.0.0.1',port:Number(process.argv[1])});s.setTimeout(300);s.on('connect',()=>process.exit(0));s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1));" "$1"

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -9,8 +9,8 @@ const source = readFileSync(
 
 assert.match(
   source,
-  /bash scripts\/whisper-runtime-bundle\.sh/,
-  "the development launcher must stage Whisper before starting Tauri",
+  /source scripts\/whisper-runtime-dev-env\.sh/,
+  "the development launcher must stage and export Whisper before starting Tauri",
 );
 
 assert.match(

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -9,6 +9,12 @@ const source = readFileSync(
 
 assert.match(
   source,
+  /bash scripts\/whisper-runtime-bundle\.sh/,
+  "the development launcher must stage Whisper before starting Tauri",
+);
+
+assert.match(
+  source,
   /MINGW\*\|MSYS\*\|CYGWIN\*\) before_dev_command="set HOSTNAME=127\.0\.0\.1&& set PORT=\$\{dev_port\}&& pnpm dev"/,
   "Windows Tauri launches must bind loopback and use cmd.exe's set syntax",
 );

--- a/scripts/dev-server-with-whisper.sh
+++ b/scripts/dev-server-with-whisper.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Direct `tauri dev` launcher: stage and export Whisper for the Next process.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+source scripts/whisper-runtime-dev-env.sh
+exec pnpm dev

--- a/scripts/whisper-runtime-bundle.sh
+++ b/scripts/whisper-runtime-bundle.sh
@@ -123,7 +123,10 @@ stage_macos() {
     -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON
   cmake --build "$source/build" --target whisper-cli --parallel 2
   cp "$source/build/bin/whisper-cli" "$DEST/whisper-cli"
-  find "$source/build/bin" -maxdepth 1 -type f -name '*.dylib' -exec cp {} "$DEST/" \;
+  # Preserve the versioned dylibs and their SONAME links. whisper-cli loads
+  # names such as libwhisper.1.dylib through @rpath, not just the concrete
+  # versioned file, after the temporary build tree has been removed.
+  find "$source/build/bin" -maxdepth 1 \( -type f -o -type l \) -name '*.dylib' -exec cp -P {} "$DEST/" \;
   chmod 755 "$DEST/whisper-cli"
 }
 

--- a/scripts/whisper-runtime-dev-env.sh
+++ b/scripts/whisper-runtime-dev-env.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Source this from a desktop development launcher before starting Next/Tauri.
+# The sidecar route runs in the Next process during development, so it must
+# receive the same bundled executable path that production receives from Rust.
+
+set -euo pipefail
+
+WHISPER_DEV_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WHISPER_DEV_BIN="$WHISPER_DEV_ROOT/src-tauri/resources/whisper/whisper-cli"
+
+bash "$WHISPER_DEV_ROOT/scripts/whisper-runtime-bundle.sh"
+
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*)
+    WHISPER_DEV_BIN+=".exe"
+    if command -v cygpath >/dev/null 2>&1; then
+      WHISPER_DEV_BIN="$(cygpath -w "$WHISPER_DEV_BIN")"
+    fi
+    ;;
+esac
+
+export COVEN_WHISPER_CPP_BIN="$WHISPER_DEV_BIN"
+echo "[dev:whisper] using bundled runtime: $COVEN_WHISPER_CPP_BIN"

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -179,6 +179,11 @@ test("release bundle includes and prefers bundled Node and Whisper runtimes", as
   );
   assert.match(whisperBundleScript, /f049fff95a089aa9969deb009cdd4892b3e74916/, "macOS must build the pinned Whisper release commit");
   assert.match(whisperBundleScript, /CMAKE_INSTALL_RPATH='@loader_path'/, "macOS Whisper must resolve copied dylibs relative to its executable");
+  assert.match(
+    whisperBundleScript,
+    /-type f -o -type l[\s\S]*?\.dylib' -exec cp -P/,
+    "macOS Whisper staging must preserve dylib SONAME links",
+  );
   assert.doesNotMatch(whisperBundleScript, /install_name_tool -add_rpath/, "macOS Whisper must not add a duplicate CMake-provided rpath");
   assert.match(whisperBundleScript, /cp -P/, "Linux Whisper staging must preserve SONAME links");
   assert.match(whisperBundleScript, /checksum mismatch/, "Whisper artifact downloads must be hash-verified");

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -154,6 +154,11 @@ test("release bundle includes and prefers bundled Node and Whisper runtimes", as
     "sidecar resources must be generated before Tauri validates bundle resource globs",
   );
   assert.match(
+    tauriConfig,
+    /"beforeDevCommand": "bash scripts\/whisper-runtime-bundle\.sh && pnpm dev"/,
+    "direct Tauri development launches must stage the mandatory Whisper runtime",
+  );
+  assert.match(
     bundleScript,
     /BUNDLED_NODE_DIR=/,
     "sidecar bundle script must stage the runner Node binary",

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -123,11 +123,13 @@ async function readNativeHost(...modules) {
 }
 
 test("release bundle includes and prefers bundled Node and Whisper runtimes", async () => {
-  const [tauriConfig, windowsConfig, bundleScript, whisperBundleScript, launcher] = await Promise.all([
+  const [tauriConfig, windowsConfig, bundleScript, whisperBundleScript, devWhisperEnv, devServerScript, launcher] = await Promise.all([
     readFile(new URL("./tauri.conf.json", import.meta.url), "utf8"),
     readFile(new URL("./tauri.windows.conf.json", import.meta.url), "utf8"),
     readFile(new URL("../scripts/sidecar-bundle.sh", import.meta.url), "utf8"),
     readFile(new URL("../scripts/whisper-runtime-bundle.sh", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/whisper-runtime-dev-env.sh", import.meta.url), "utf8"),
+    readFile(new URL("../scripts/dev-server-with-whisper.sh", import.meta.url), "utf8"),
     readNativeHost("sidecar_discovery.rs", "sidecar_startup.rs"),
   ]);
 
@@ -155,9 +157,12 @@ test("release bundle includes and prefers bundled Node and Whisper runtimes", as
   );
   assert.match(
     tauriConfig,
-    /"beforeDevCommand": "bash scripts\/whisper-runtime-bundle\.sh && pnpm dev"/,
-    "direct Tauri development launches must stage the mandatory Whisper runtime",
+    /"beforeDevCommand": "bash scripts\/dev-server-with-whisper\.sh"/,
+    "direct Tauri development launches must stage and export the mandatory Whisper runtime",
   );
+  assert.match(devServerScript, /source scripts\/whisper-runtime-dev-env\.sh/, "direct Tauri development must load the Whisper environment");
+  assert.match(devWhisperEnv, /whisper-runtime-bundle\.sh/, "development must stage the bundled Whisper runtime");
+  assert.match(devWhisperEnv, /export COVEN_WHISPER_CPP_BIN=/, "development must export the bundled Whisper executable to Next");
   assert.match(
     bundleScript,
     /BUNDLED_NODE_DIR=/,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",
     "devUrl": "http://localhost:3000",
-    "beforeDevCommand": "bash scripts/whisper-runtime-bundle.sh && pnpm dev",
+    "beforeDevCommand": "bash scripts/dev-server-with-whisper.sh",
     "beforeBuildCommand": "bash scripts/sidecar-bundle.sh"
   },
   "app": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",
     "devUrl": "http://localhost:3000",
-    "beforeDevCommand": "pnpm dev",
+    "beforeDevCommand": "bash scripts/whisper-runtime-bundle.sh && pnpm dev",
     "beforeBuildCommand": "bash scripts/sidecar-bundle.sh"
   },
   "app": {

--- a/src/app/api/voice/engines/whisper/route.test.ts
+++ b/src/app/api/voice/engines/whisper/route.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { POST } from "./route.ts";
+import { normalizeWhisperLanguage, POST } from "./route.ts";
 
 function request(form: FormData, host = "localhost", bounded = true) {
   return new Request(`http://${host}/api/voice/engines/whisper`, {
@@ -45,4 +45,11 @@ test("Whisper endpoint rejects multipart bodies without a declared bound", async
   const response = await POST(request(form, "localhost", false));
   assert.equal(response.status, 400);
   assert.equal((await response.json()).error, "invalid_audio");
+});
+
+test("Whisper endpoint normalizes browser locale tags to CLI language IDs", () => {
+  assert.equal(normalizeWhisperLanguage("fr-FR"), "fr");
+  assert.equal(normalizeWhisperLanguage("ZH_hant"), "zh");
+  assert.equal(normalizeWhisperLanguage("not a locale"), "auto");
+  assert.equal(normalizeWhisperLanguage(null), "auto");
 });

--- a/src/app/api/voice/engines/whisper/route.ts
+++ b/src/app/api/voice/engines/whisper/route.ts
@@ -24,6 +24,13 @@ function eventKind(value: FormDataEntryValue | null): "partial" | "final" | null
   return value === "partial" || value === "final" ? value : null;
 }
 
+/** Normalize browser BCP-47 tags before they become whisper.cpp CLI args. */
+export function normalizeWhisperLanguage(value: FormDataEntryValue | null): string {
+  if (typeof value !== "string") return "auto";
+  const language = value.trim().split(/[-_]/)[0]?.toLowerCase();
+  return language && /^[a-z]{2,3}$/.test(language) ? language : "auto";
+}
+
 /** Transcribe one browser-captured PCM WAV with the first verified local model. */
 export async function POST(req: Request) {
   if (!isLocalOrigin(req)) {
@@ -62,13 +69,12 @@ export async function POST(req: Request) {
       hint: "Download a Whisper model in Settings before using local voice.",
     }, { status: 409 });
   }
-  const lang = form.get("lang");
   try {
     const text = await transcribeSidecarWav(
       new Uint8Array(await audio.arrayBuffer()),
       model,
       {
-        lang: typeof lang === "string" && /^[A-Za-z]{2,3}(?:-[A-Za-z]{2})?$/.test(lang) ? lang : undefined,
+        lang: normalizeWhisperLanguage(form.get("lang")),
         signal: req.signal,
       },
     );

--- a/src/lib/voice/sidecar-whisper-ears.ts
+++ b/src/lib/voice/sidecar-whisper-ears.ts
@@ -34,6 +34,7 @@ type TimerOptions = {
   stabilityMs?: number;
   maxUtteranceMs?: number;
   voiceThreshold?: number;
+  locale?: string;
   fetchImpl?: typeof fetch;
   setTimeout?: (fn: () => void, ms: number) => unknown;
   clearTimeout?: (handle: unknown) => void;
@@ -48,6 +49,12 @@ export function whisperModelSupportsLocale(modelId: string | undefined, locale?:
   if (!language || language === "en") return true;
   if (!modelId) return false;
   return !/(?:[-_.]en)$/i.test(modelId);
+}
+
+/** whisper.cpp expects an ISO language ID, not a browser BCP-47 tag. */
+export function normalizeWhisperLanguage(locale?: string): string {
+  const language = locale?.trim().split(/[-_]/)[0]?.toLowerCase();
+  return language && /^[a-z]{2,3}$/.test(language) ? language : "auto";
 }
 
 /** True only for a verified downloaded Whisper model advertised by the sidecar
@@ -168,6 +175,9 @@ export function createSidecarWhisperEars(options: TimerOptions = {}): SpeechEars
   const stabilityMs = options.stabilityMs ?? WHISPER_SILENCE_MS;
   const maxUtteranceMs = options.maxUtteranceMs ?? WHISPER_MAX_UTTERANCE_MS;
   const threshold = options.voiceThreshold ?? WHISPER_VOICE_THRESHOLD;
+  const recognitionLanguage = normalizeWhisperLanguage(
+    options.locale ?? (typeof navigator !== "undefined" ? navigator.language : undefined),
+  );
   const request = options.fetchImpl ?? fetch;
   const schedule = options.setTimeout ?? ((fn: () => void, ms: number) => setTimeout(fn, ms));
   const unschedule = options.clearTimeout ?? ((handle: unknown) => clearTimeout(handle as number));
@@ -246,6 +256,7 @@ export function createSidecarWhisperEars(options: TimerOptions = {}): SpeechEars
       const form = new FormData();
       form.set("session", String(session));
       form.set("kind", kind);
+      form.set("lang", recognitionLanguage);
       const wavBuffer = wav.buffer.slice(wav.byteOffset, wav.byteOffset + wav.byteLength) as ArrayBuffer;
       form.set("audio", new Blob([wavBuffer], { type: "audio/wav" }), "utterance.wav");
       return request(SIDECAR_WHISPER_ENDPOINT, { method: "POST", body: form, signal })

--- a/src/lib/voice/sidecar-whisper.test.ts
+++ b/src/lib/voice/sidecar-whisper.test.ts
@@ -18,6 +18,7 @@ import {
   sidecarWhisperAvailable,
   WHISPER_SAMPLE_RATE,
   whisperModelSupportsLocale,
+  normalizeWhisperLanguage,
 } from "./sidecar-whisper-ears.ts";
 
 const cacheRoot = path.join(process.cwd(), "node_modules", ".cache", "coven-cave-tests", "sidecar-whisper");
@@ -138,6 +139,8 @@ test("English-only Whisper models do not claim non-English locales", async () =>
   assert.equal(await sidecarWhisperAvailable(englishModel, "en-US"), true);
   assert.equal(await sidecarWhisperAvailable(englishModel, "fr-FR"), false);
   assert.equal(whisperModelSupportsLocale("whisper-small", "fr-FR"), true, "multilingual models may auto-detect French");
+  assert.equal(normalizeWhisperLanguage("fr-FR"), "fr");
+  assert.equal(normalizeWhisperLanguage("not a locale"), "auto");
 });
 
 function fakeTimers() {
@@ -326,12 +329,16 @@ test("voice activity drops leading silence before sending the final Whisper WAV"
   }
   globalThis.window = { AudioContext };
   let wavBytes = 0;
+  let language = "";
   const ears = createSidecarWhisperEars({
     stabilityMs: 1,
     maxUtteranceMs: 99,
+    locale: "fr-FR",
     fetchImpl: async (_url, init) => {
-      const audio = (init.body as FormData).get("audio") as Blob;
+      const form = init.body as FormData;
+      const audio = form.get("audio") as Blob;
       wavBytes = audio.size;
+      language = String(form.get("lang"));
       return new Response(JSON.stringify({ ok: true, session: 1, kind: "final", text: "heard" }));
     },
     setTimeout: timers.setTimeout,
@@ -348,6 +355,7 @@ test("voice activity drops leading silence before sending the final Whisper WAV"
       44 + 2 * Math.round(4_096 * WHISPER_SAMPLE_RATE / 48_000),
       "the final WAV contains the voiced buffer but not the preceding silent buffer",
     );
+    assert.equal(language, "fr", "capture sends the primary language to Whisper");
   } finally {
     ears.close();
     globalThis.window = priorWindow;


### PR DESCRIPTION
Stages the bundled Whisper runtime before both the documented dev wrapper and direct Tauri dev launches.\n\nThis prevents clean desktop debug startup from failing the mandatory sidecar runtime probe.\n\nValidated with:\n- node scripts/dev-app.test.mjs\n- node src-tauri/release-runtime.test.mjs\n- Bash syntax check for scripts/dev-app.sh