### PR TITLE
fix(ui): gate Modal Escape dismissal while a submit is in flight (cave-0g9u)

### DIFF
--- a/src/components/composer-host-chip.tsx
+++ b/src/components/composer-host-chip.tsx
@@ -64,6 +64,7 @@ export function ConnectHostDialog({ onClose, onConnected }: { onClose: () => voi
       onClose={onClose}
       breadcrumb={["Chat", "Connect a new host"]}
       dismissOnBackdrop={!pending}
+      dismissOnEscape={!pending}
       footerActions={
         <>
           <Button variant="ghost" onClick={onClose} disabled={pending}>

--- a/src/components/marketplace/knowledge-pack-seed-modal.tsx
+++ b/src/components/marketplace/knowledge-pack-seed-modal.tsx
@@ -177,6 +177,7 @@ export function KnowledgePackSeedModal({ open, manifest, alreadyInstalled, onClo
       breadcrumb={["Marketplace", manifest.displayName, "Seed"]}
       footerActions={footerActions}
       dismissOnBackdrop={!busy}
+      dismissOnEscape={!busy}
     >
       <div className="flex flex-col gap-5" aria-live="polite">
         <section className="flex flex-col gap-2">

--- a/src/components/project-setup-modal.test.ts
+++ b/src/components/project-setup-modal.test.ts
@@ -41,6 +41,12 @@ assert.match(src, /current\.trim\(\) \? current : /, "prefill never clobbers wha
 
 // ── Primitives + a11y ───────────────────────────────────────────────────────
 assert.match(src, /<Modal\b/, "built on the shared Modal (focus trap + return)");
+assert.match(src, /dismissOnBackdrop=\{!busy\}/, "backdrop dismiss is blocked mid-submit");
+assert.match(
+  src,
+  /dismissOnEscape=\{!busy\}/,
+  "Escape dismiss is blocked mid-submit too (cave-0g9u)",
+);
 assert.match(src, /useAnnouncer\(\)/, "completion is announced");
 assert.match(src, /StandardSelect/, "access levels use the shared select primitive");
 assert.match(src, /aria-pressed=/, "color swatches expose pressed state");

--- a/src/components/project-setup-modal.tsx
+++ b/src/components/project-setup-modal.tsx
@@ -230,6 +230,7 @@ export function ProjectSetupModal({
       open
       onClose={onClose}
       dismissOnBackdrop={!busy}
+      dismissOnEscape={!busy}
       breadcrumb={["Projects", "Set up project"]}
       footerActions={
         <>

--- a/src/components/ui/modal.test.ts
+++ b/src/components/ui/modal.test.ts
@@ -25,4 +25,16 @@ assert.match(
   "the breadcrumb header carries the id referenced by aria-labelledby",
 );
 
+// Escape dismissal must be gateable (cave-0g9u): callers with an in-flight
+// submit pass dismissOnEscape={!busy} so Esc can't close the dialog
+// mid-mutation, mirroring the existing dismissOnBackdrop gate. The trap stays
+// active either way — only its onEscape callback is withheld.
+assert.match(src, /dismissOnEscape\?: boolean/, "Modal exposes a dismissOnEscape prop");
+assert.match(src, /dismissOnEscape = true/, "dismissOnEscape defaults to true");
+assert.match(
+  src,
+  /useFocusTrap\(open, dialogRef, \{ onEscape: dismissOnEscape \? onClose : undefined \}\)/,
+  "the trap stays active while busy; only the Esc dismissal callback is gated",
+);
+
 console.log("modal.test.ts: ok");

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -18,6 +18,10 @@ type ModalProps = {
   wide?: boolean;
   /** Click-outside dismiss (default true). */
   dismissOnBackdrop?: boolean;
+  /** Escape-key dismiss (default true). Pass `{!busy}` while a submit is in
+   *  flight so Esc can't close the dialog mid-mutation — the focus trap
+   *  itself stays active either way; only dismissal is gated. */
+  dismissOnEscape?: boolean;
   /** Accessible label when there is no breadcrumb. */
   ariaLabel?: string;
 };
@@ -31,12 +35,15 @@ export function Modal({
   children,
   wide,
   dismissOnBackdrop = true,
+  dismissOnEscape = true,
   ariaLabel,
 }: ModalProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const headingId = useId();
 
-  useFocusTrap(open, dialogRef, { onEscape: onClose });
+  // Keep the trap active regardless of dismissability — an undefined onEscape
+  // makes Esc a no-op without releasing Tab cycling or focus return.
+  useFocusTrap(open, dialogRef, { onEscape: dismissOnEscape ? onClose : undefined });
 
   if (!open || typeof document === "undefined") return null;
 

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -45,6 +45,16 @@ assert.match(
   "stores onEscape in a ref to avoid effect re-runs on callback identity change",
 );
 
+// Escape dismissal is optional: the handler must optional-chain the ref so an
+// undefined onEscape is a safe no-op. Callers (Modal's dismissOnEscape gate,
+// cave-0g9u) rely on this to block Esc dismissal mid-submit while the trap —
+// Tab cycling and focus return — stays active.
+assert.match(
+  source,
+  /onEscapeRef\.current\?\.\(\)/,
+  "an undefined onEscape no-ops on Esc without deactivating the trap",
+);
+
 // onEscape must NOT appear in the trap effect's dep array.
 const trapEffect = source.match(/useEffect\(\s*\(\)\s*=>\s*\{[\s\S]*?\},\s*\[([^\]]*)\]\s*\)/g) ?? [];
 const trapDeps = trapEffect.find((b) => b.includes('e.key === "Tab"')) ?? "";


### PR DESCRIPTION
## Bug (bead `cave-0g9u`, P3)

Found during the project-setup-from-chat reviews (PR #3835): `src/components/ui/modal.tsx` wired `useFocusTrap`'s Escape handler unconditionally — `useFocusTrap(open, dialogRef, { onEscape: onClose })` — so **Esc always dismissed the modal, even while a submit was in flight**. ProjectSetupModal gates backdrop dismissal via `dismissOnBackdrop={!busy}` but had no way to gate Esc, so a stray Escape mid-create could unmount the dialog in the middle of its create → grant → group-patch sequence. Platform-level: shared by every sibling modal.

## Fix

`Modal` now accepts `dismissOnEscape?: boolean` (default `true`), mirroring the existing `dismissOnBackdrop` gate's naming and semantics. When `false`, Modal withholds the trap's `onEscape` callback:

```tsx
useFocusTrap(open, dialogRef, { onEscape: dismissOnEscape ? onClose : undefined });
```

`useFocusTrap` already optional-chains its onEscape ref (`onEscapeRef.current?.()`), so no hook changes were needed — Esc becomes a safe no-op while **the trap itself stays fully active** (Tab/Shift+Tab cycling, focus recapture, and focus return are untouched; only dismissal is gated). No a11y regression.

## Callers wired

Only the modals with a real in-flight state (per the bead's scope — no speculative changes):

- `project-setup-modal.tsx` → `dismissOnEscape={!busy}` (the motivating case)
- `marketplace/knowledge-pack-seed-modal.tsx` → `dismissOnEscape={!busy}`
- `composer-host-chip.tsx` → `dismissOnEscape={!pending}`

## Tests

Extended the existing source-pin suites in-style:

- `ui/modal.test.ts` — pins the prop, its `= true` default, and the exact gated trap wiring (trap active regardless; only the callback gated)
- `lib/use-focus-trap.test.ts` — pins the optional-chained Esc path (`onEscapeRef.current?.()`) that the gate relies on
- `project-setup-modal.test.ts` — pins `dismissOnBackdrop={!busy}` and `dismissOnEscape={!busy}`

## Verification

- `node --experimental-strip-types --test` on the three touched test files — pass
- `pnpm typecheck` — pass
- `pnpm lint` (incl. design gate + codemod check) — pass
- `node scripts/run-tests.mjs app` — **917/917 test files pass**