### PR TITLE
fix(peel): render the loaded module directly so the enhancement flip single-commits

### DIFF
--- a/src/components/shell-peel-reveal.tsx
+++ b/src/components/shell-peel-reveal.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import dynamic from "next/dynamic";
 import {
   useEffect,
   useRef,
@@ -9,21 +8,29 @@ import {
   type ReactNode,
 } from "react";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+// Type-only: erased at compile time, so the ~22 KB vendored WebGL module
+// still reaches the bundle only through the dynamic import() below.
+import type PeelComponent from "@/components/canvasui/Peel";
 
-// The ~22 KB vendored WebGL file loads only on HTML-in-canvas browsers.
-const Peel = dynamic(() => import("@/components/canvasui/Peel"), { ssr: false });
-
-let peelModuleReady = false;
+/** The loaded vendored component, stashed at module scope once the chunk
+ *  arrives. NOT React.lazy/next/dynamic: a lazy's thenable is always pending
+ *  on its FIRST render even when the chunk is already loaded, so the freshly
+ *  mounted Suspense boundary would commit its null fallback — blanking the
+ *  detail pane (~300ms FALLBACK_THROTTLE_MS) and double-mounting its children
+ *  (state/focus/scroll loss) exactly when `enhanced` flips true (cave-ao2o).
+ *  Rendering the stashed component directly makes the enhancement flip a
+ *  single-commit re-parent. */
+let PeelLive: typeof PeelComponent | null = null;
 const peelReadyListeners = new Set<() => void>();
-/** next/dynamic suspends with a null fallback, and the detail children live
- *  inside <Peel> — switching to the live tree before the chunk arrives would
- *  blank (and double-mount) the whole detail pane. Track module readiness so
- *  the plain tree keeps rendering until the live tree can mount for real. */
+/** The detail children live inside <Peel> — switching to the live tree before
+ *  the chunk arrives would blank the whole detail pane. Track the loaded
+ *  module so the plain tree keeps rendering until the live tree can mount for
+ *  real, in one commit. */
 function subscribePeelReady(listener: () => void) {
-  if (!peelModuleReady) {
+  if (!PeelLive) {
     void import("@/components/canvasui/Peel")
-      .then(() => {
-        peelModuleReady = true;
+      .then((mod) => {
+        PeelLive = mod.default;
         for (const notify of peelReadyListeners) notify();
       })
       // Failed chunk loads self-heal: the next subscribe retries the import.
@@ -32,10 +39,10 @@ function subscribePeelReady(listener: () => void) {
   peelReadyListeners.add(listener);
   return () => peelReadyListeners.delete(listener);
 }
-function getPeelReady() {
-  return peelModuleReady;
+function getPeelLive() {
+  return PeelLive;
 }
-const getPeelReadyServer = () => false;
+const getPeelLiveServer = () => null;
 
 /** Peel geometry while the collapsed rail arms the reveal: 232px of exposed
  *  under-layer matches the hover-peek overlay width; a 120px trigger strip
@@ -103,8 +110,10 @@ const emptySubscribe = () => () => {};
  * reduced-motion users) this renders a bare Fragment: zero wrapper elements,
  * so direct-child selector chains like `.shell-detail > .cave-mode-fade`
  * (see detail-split-host.tsx) keep matching, and the children are never
- * re-parented by `active` changes within a mode. The live tree additionally
- * waits for the vendored chunk so enhancement never blanks the pane mid-load.
+ * re-parented by `active` changes within a mode. The live tree waits for the
+ * vendored chunk and then renders the loaded component directly — no
+ * lazy/Suspense — so the enhancement flip is a single commit: the pane never
+ * blanks on a null fallback and children re-parent exactly once (cave-ao2o).
  * Under the experimental flag those `>` chains do not reach through the
  * vendor's canvas layers — a known, flag-gated divergence (Task 6 QA).
  */
@@ -118,13 +127,13 @@ export function ShellPeelReveal({
   children: ReactNode;
 }) {
   const supported = useSyncExternalStore(emptySubscribe, probeHtmlInCanvas, () => false);
-  const peelReady = useSyncExternalStore(
+  const Peel = useSyncExternalStore(
     supported ? subscribePeelReady : emptySubscribe,
-    getPeelReady,
-    getPeelReadyServer,
+    getPeelLive,
+    getPeelLiveServer,
   );
   const reducedMotion = usePrefersReducedMotion();
-  const enhanced = supported && peelReady && !reducedMotion;
+  const enhanced = supported && Peel !== null && !reducedMotion;
 
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [glEpoch, setGlEpoch] = useState(0);

--- a/src/components/sidepanel-peel-reveal.test.ts
+++ b/src/components/sidepanel-peel-reveal.test.ts
@@ -43,11 +43,34 @@ const vendored = readFileSync(
   "utf8",
 );
 
-// The ~22 KB vendored WebGL file loads lazily and never renders on the server.
+// The ~22 KB vendored WebGL file still reaches the client only through the
+// lazy import() in the readiness store — never statically (the top-of-file
+// import is type-only, erased at compile time) and never on the server.
 assert.match(
   wrapper,
-  /const Peel = dynamic\(\(\) => import\("@\/components\/canvasui\/Peel"\), \{ ssr: false \}\)/,
-  "vendored Peel is dynamically imported with ssr: false",
+  /void import\("@\/components\/canvasui\/Peel"\)/,
+  "vendored Peel loads through the readiness store's dynamic import",
+);
+assert.match(
+  wrapper,
+  /import type PeelComponent from "@\/components\/canvasui\/Peel";/,
+  "the only static reference to the vendored module is type-only",
+);
+// No lazy/Suspense wrapper: a lazy's thenable is always pending on its FIRST
+// render even when the chunk is already loaded, so the freshly-mounted
+// boundary would commit a null fallback — blanking the detail pane (~300ms)
+// and double-mounting its children exactly when enhancement flips (cave-ao2o).
+// The store stashes the loaded component and the wrapper renders it directly:
+// the flip is a single-commit re-parent.
+assert.doesNotMatch(
+  wrapper,
+  /from "next\/dynamic"|dynamic\(\(\) =>|React\.lazy\(|lazy\(\(\) =>|<Suspense/,
+  "live tree renders the stashed component directly — no lazy, no Suspense, no null fallback",
+);
+assert.match(
+  wrapper,
+  /PeelLive = mod\.default;/,
+  "the readiness store stashes the loaded component for direct render",
 );
 
 // Enhancement gates: local capability probe (false on the server) + reduced motion.
@@ -58,7 +81,7 @@ assert.match(
 );
 assert.match(
   wrapper,
-  /const enhanced = supported && peelReady && !reducedMotion;/,
+  /const enhanced = supported && Peel !== null && !reducedMotion;/,
   "reduced motion disables the enhancement entirely",
 );
 
@@ -85,17 +108,17 @@ assert.doesNotMatch(
   "Peel is never conditionally mounted on active",
 );
 
-// The live tree waits for the vendored chunk: no null-fallback blank of the
-// detail pane while next/dynamic suspends.
-assert.match(
-  wrapper,
-  /const enhanced = supported && peelReady && !reducedMotion;/,
-  "enhancement additionally gates on module readiness",
-);
+// The live tree waits for the vendored chunk: the plain tree keeps rendering
+// until the loaded component can mount for real, in one commit.
 assert.match(
   wrapper,
   /supported \? subscribePeelReady : emptySubscribe/,
   "chunk fetch starts only on supporting browsers",
+);
+assert.match(
+  wrapper,
+  /useSyncExternalStore\(\s*supported \? subscribePeelReady : emptySubscribe,\s*getPeelLive,\s*getPeelLiveServer,\s*\)/,
+  "the rendered component comes straight from the module store",
 );
 
 // The revealed sidebar clone is decorative: hidden from AT and uninteractive.


### PR DESCRIPTION
## What

Fixes the detail-pane blank + child double-mount when the peel enhancement flips on (bead `cave-ao2o`, follow-up to #3827 / fbb9af38b).

## Why

The chunk-readiness store guaranteed the vendored module was **loaded** before flipping `enhanced`, but the live tree still rendered it through `next/dynamic`. A React.lazy thenable is **always pending on the lazy's first render** — even with a warm module cache (`loader().then(convertModule)` runs in a microtask). So the freshly mounted Suspense boundary committed its `null` fallback: the detail pane blanked (~300 ms `FALLBACK_THROTTLE_MS`) and its children double-mounted (state/focus/scroll loss) at the exact moment the flip happened. Experimental HTML-in-canvas Chromium only; the plain path is untouched.

## How

- `subscribePeelReady` now stashes `mod.default` in the module store (`PeelLive`); the component reads it via the same `useSyncExternalStore` and **renders it directly** — no lazy, no Suspense → the flip is a single-commit re-parent.
- A **type-only** `import type PeelComponent` keeps typing without bundling: erased at compile time, so the ~22 KB chunk still arrives only through the store's dynamic `import()` (still-lazy contract pin updated to enforce exactly this).
- `enhanced = supported && Peel !== null && !reducedMotion` — TS aliased-condition narrowing keeps `<Peel>` non-null after the early return.

## Evidence

Empirical jsdom + react-dom 19.2.7 harness, `flushSync` at the flip so the DOM is read before microtasks settle:

```
OLD lazy+Suspense: blankWindowAfterFlip=true   (null fallback committed)
NEW direct render: blankWindowAfterFlip=false  settled in the same commit
```

## Verification

- `sidepanel-peel-reveal.test.ts` contract suite ✓ (pins updated: still-lazy via store import + type-only static import; doesNotMatch for `next/dynamic`/`React.lazy`/`<Suspense` usage forms; `PeelLive = mod.default` pin; new `enhanced` gate pin)
- `node scripts/run-tests.mjs app` → 917 ✓
- `pnpm typecheck` ✓, `pnpm lint` ✓

Closes bead `cave-ao2o`.