### PR TITLE
feat(canvas): preview expand toggle, edge-to-edge editor stage, opaque grounds over backdrop

### DIFF
--- a/src/components/chat-canvas-view.tsx
+++ b/src/components/chat-canvas-view.tsx
@@ -47,6 +47,9 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
   const [q, setQ] = useState("");
   const [kindFilter, setKindFilter] = useState<CanvasKindFilter>("all");
   const [previewId, setPreviewId] = useState<string | null>(null);
+  // In-place expand: the preview dialog grows to fill the viewport. Reset per
+  // sketch so the next preview always opens at the normal size.
+  const [previewExpanded, setPreviewExpanded] = useState(false);
   const [editorId, setEditorId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [activeComposerId, setActiveComposerId] = useState<string | null>(null);
@@ -166,6 +169,10 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
     () => (editorId ? (artifacts.find((a) => a.id === editorId) ?? null) : null),
     [editorId, artifacts],
   );
+
+  useEffect(() => {
+    setPreviewExpanded(false);
+  }, [previewId]);
 
   useFocusTrap(preview !== null, previewDialogRef, {
     onEscape: () => {
@@ -340,12 +347,14 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
       {preview ? (
         <div
           className="chat-canvas-preview-backdrop"
+          data-expanded={previewExpanded || undefined}
           role="presentation"
           onClick={() => setPreviewId(null)}
         >
           <div
             ref={previewDialogRef}
             className="chat-canvas-preview"
+            data-expanded={previewExpanded || undefined}
             role="dialog"
             aria-modal="true"
             aria-label={`Sketch preview: ${preview.title}`}
@@ -358,6 +367,16 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
                 {galleryArtifactKind(preview) === "react" ? "React" : "HTML"}
                 {(() => { const when = formatArtifactWhen(preview.updatedAt); return when ? ` · ${when}` : ""; })()}
               </span>
+              <button
+                type="button"
+                className="chat-canvas-preview__expand focus-ring"
+                title={previewExpanded ? "Restore preview" : "Expand preview"}
+                aria-label={previewExpanded ? "Restore preview" : "Expand preview"}
+                aria-pressed={previewExpanded}
+                onClick={() => setPreviewExpanded((current) => !current)}
+              >
+                <Icon name={previewExpanded ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={15} aria-hidden />
+              </button>
               <button
                 type="button"
                 className="chat-canvas-preview__close focus-ring"

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -153,6 +153,16 @@ html[data-backdrop-on] .familiar-tab {
   --text-muted: var(--text-secondary);
 }
 
+/* Chat Settings tab: same dense small-type-on-photo problem as the familiar
+   tab (kickers, row descriptions, hints sit straight on the image), so it
+   earns the same deep-blur glass ground. */
+html[data-backdrop-on] .chat-settings-view {
+  background: color-mix(in oklch, var(--bg-base) 62%, transparent);
+  backdrop-filter: blur(50px) saturate(var(--glass-saturate));
+  border-radius: var(--radius-xl);
+  --text-muted: var(--text-secondary);
+}
+
 /* And the same quiet-text contrast lift Home-side. */
 html[data-backdrop-on] .home-composer-root {
   --text-muted: var(--text-secondary);
@@ -166,6 +176,7 @@ html[data-backdrop-on] .home-composer-root {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
   }
 
+  html[data-backdrop-on] .chat-settings-view,
   html[data-backdrop-on] .cave-chat-empty-shell,
   html[data-backdrop-on] .familiar-tab {
     background: color-mix(in oklch, var(--bg-base) 92%, transparent);
@@ -203,6 +214,12 @@ html[data-backdrop-on] .home-composer-root {
 
   /* No image layer → the familiar tab sits on the base surface again. */
   html[data-backdrop-on] .familiar-tab {
+    background: transparent;
+    backdrop-filter: none;
+  }
+
+  /* Same for the chat settings tab. */
+  html[data-backdrop-on] .chat-settings-view {
     background: transparent;
     backdrop-filter: none;
   }

--- a/src/styles/canvas-editor.css
+++ b/src/styles/canvas-editor.css
@@ -129,17 +129,21 @@
   overflow: auto;
   display: grid;
   place-items: center;
+  /* Fill preset: the sketch owns the whole stage — no gutter. */
+  padding: 0;
+}
+/* Sized device presets keep breathing room around the scaled frame (and the
+   scale math reads this padding back, so the footprint never touches edges). */
+.canvas-editor__stage:has(.canvas-editor__frame-shell--viewport) {
   padding: var(--space-6);
 }
 .canvas-editor__frame-shell {
   position: relative;
-  width: min(900px, 100%);
+  /* Fill preset: edge-to-edge — the aside's own border draws the seam. */
+  width: 100%;
   height: 100%;
   min-height: 240px;
-  border: 1px solid var(--border-hairline);
-  border-radius: var(--radius-card);
   background: var(--bg-panel);
-  box-shadow: 0 4px 16px rgb(0 0 0 / 0.25);
   overflow: hidden;
 }
 .canvas-editor__frame {
@@ -237,6 +241,10 @@
   width: 320px;
   flex: none;
   border-left: 1px solid var(--border-hairline);
+  /* Solid panel ground — side panes stay opaque so the chat backdrop image
+     never bleeds through the inspector/design-chat column (backdrop.css
+     side-pane contract). */
+  background: var(--bg-panel);
   display: flex;
   flex-direction: column;
   min-height: 0;

--- a/src/styles/chat-canvas.css
+++ b/src/styles/chat-canvas.css
@@ -254,7 +254,8 @@
   border-radius: var(--radius-pill);
   padding: var(--space-1) var(--space-2);
 }
-.chat-canvas-preview__close {
+.chat-canvas-preview__close,
+.chat-canvas-preview__expand {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -267,9 +268,21 @@
   color: var(--text-muted);
   cursor: pointer;
 }
-.chat-canvas-preview__close:hover {
+.chat-canvas-preview__close:hover,
+.chat-canvas-preview__expand:hover {
   color: var(--text-primary);
   background: var(--bg-raised);
+}
+/* Expanded: the dialog fills the viewport edge-to-edge (chrome drops with it,
+   same idiom as the editor's in-app expand). */
+.chat-canvas-preview-backdrop[data-expanded] {
+  padding: 0;
+}
+.chat-canvas-preview[data-expanded] {
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: 0;
 }
 .chat-canvas-preview__body {
   display: flex;


### PR DESCRIPTION
## What

Four coordinated Canvas/chat-surface polish changes (user-requested during a live design pass):

1. **Preview (focus) dialog expand toggle** — the Canvas gallery's sketch preview modal gains an expand button next to the close ✕ (`ph:arrows-out-simple`/`ph:arrows-in-simple`, `aria-pressed`). Expanded, the dialog fills the viewport edge-to-edge (backdrop padding drops with it); the state resets per sketch.
2. **Editor stage fills with the preview** — the canvas editor's fill preset now renders the sketch across the stage's full width and height: no gutter, no `min(900px, 100%)` cap, no border/radius/shadow. Sized device presets keep their `--space-6` breathing room via `.canvas-editor__stage:has(…--viewport)` (the viewport-scale math reads that padding back).
3. **Inspector aside gets a solid ground** — `.canvas-editor__aside` now sits on `var(--bg-panel)`, so the chat backdrop image no longer bleeds through the Selection/Design-chat column (backdrop.css side-pane contract).
4. **Chat Settings tab gets the glass ground** — `html[data-backdrop-on] .chat-settings-view` earns the familiar-tab treatment (62% bg-base + 50px blur + radius-xl + muted→secondary lift), including the `@supports not (backdrop-filter…)` near-opaque fallback and the `prefers-reduced-transparency` reset.

## Verification

- `node --experimental-strip-types` on the pinned source-contract tests: `chat-canvas-tab`, `canvas-editor`, `backdrop-scrim`, `chat-settings-view`, `chat-canvas-command`, `chat-view-canvas-artifact`, `design-token-drift` — all pass (re-run on this branch's base).
- `pnpm lint` (tokenize-tsx-design check + design ESLint gate) — clean.
- `pnpm typecheck` — clean.

Tokens only throughout; the expand button reuses the existing 28px icon-button recipe and already-registered Phosphor icons.