### PR TITLE
feat(projects): grouped/flat toggle + minimal UI pass on Project access

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -27,11 +27,12 @@ test("the surface keeps its mount contract with ChatSurface", () => {
   assert.match(chatSurface, /scope === "projects" \? \(/, "ChatSurface still branches to the Projects surface");
 });
 
-test("the header is the cave-typography access hero", () => {
+test("the header is the compact cave-typography access header", () => {
   assert.match(view, /className="projects-access-eyebrow">Familiars</, "eyebrow reads Familiars");
-  assert.match(view, /className="projects-access-title">Project access</, "serif display title");
-  assert.match(view, /Choose what each familiar can see and touch\./, "subtitle explains the page");
+  assert.match(view, /className="projects-access-title">Project access</, "serif title");
+  assert.match(view, /Click a project to cycle access — none, read, full\./, "one-line subtitle explains the cycle");
   assert.match(css, /\.projects-access-title \{[^}]*font-family: var\(--font-serif, ui-serif, serif\)/, "title uses the cave serif");
+  assert.match(css, /\.projects-access-title \{[^}]*font-size: var\(--text-xl\)/, "title sits on the type scale, not a display hero");
   assert.match(css, /\.projects-access-eyebrow \{[^}]*font-family: var\(--font-mono, ui-monospace, monospace\)/, "eyebrow is mono");
   assert.match(css, /\.projects-access-eyebrow \{[^}]*text-transform: uppercase/, "eyebrow is uppercase");
   assert.match(css, /\.projects-access-eyebrow \{[^}]*color: var\(--accent-presence\)/, "eyebrow carries the accent");
@@ -58,7 +59,7 @@ test("rows cycle a direct grant against /api/project-grants", () => {
   assert.match(view, /resolveEffectiveAccess\(\{/, "pills show the effective level (direct ∪ groups)");
   assert.match(view, /setOptimistic\(/, "mutations render optimistically");
   assert.match(view, /await loadGrants\(\)/, "server snapshot is re-fetched after a mutation");
-  assert.match(view, /splitProjectsBySection\(filtered\)/, "sections derive from the pure splitter");
+  assert.match(view, /sectionModels\(filtered, grouped\)/, "sections derive from the pure grouping-aware splitter");
   assert.match(view, /setAllOps\(/, "bulk actions compute the minimal op set");
   assert.match(view, /keeps \$\{accessStateMeta\(row\.state\)\.label\} via/, "group-held access explains itself instead of firing a no-op revoke");
 });
@@ -76,11 +77,34 @@ test("command-palette focus scrolls and flashes the row", () => {
   assert.match(view, /scrollIntoView\(\{ block: "center", behavior: smoothScrollBehavior\(\) \}\)/, "respects reduced motion");
 });
 
+test("a persisted toolbar toggle switches grouped sections to one flat list", () => {
+  assert.match(view, /const GROUPED_STORAGE_KEY = "cave:projects:grouped"/, "preference key follows the cave:<surface>:<pref> convention");
+  assert.match(view, /window\.localStorage\.getItem\(GROUPED_STORAGE_KEY\) !== "0"/, "grouped stays the default until explicitly turned off");
+  assert.match(view, /window\.localStorage\.setItem\(GROUPED_STORAGE_KEY, next \? "1" : "0"\)/, "toggling persists the preference");
+  assert.match(view, /<IconButton[\s\S]{0,240}active=\{grouped\}/, "the toolbar control is an aria-pressed IconButton");
+  assert.match(view, /aria-label="Group projects by type"/, "the toggle keeps a stable accessible name");
+  assert.match(view, /icon=\{grouped \? "ph:stack" : "ph:rows"\}/, "the glyph mirrors the current mode");
+  assert.match(view, /announce\(next \? "Projects grouped by type\." : "Projects shown as one flat list\."\)/, "mode changes are announced");
+  assert.match(view, /onClick=\{toggleGrouped\}/, "clicking flips the mode");
+  assert.match(css, /\.projects-access-grouping \{/, "the toggle is styled into the toolbar");
+});
+
+test("secondary controls stay quiet until hover or keyboard focus", () => {
+  assert.match(css, /\.projects-access-setall \{[^}]*opacity: 0/, "Set-all rests invisible");
+  assert.match(css, /\.projects-access-section-head:hover \.projects-access-setall,\n\.projects-access-section-head:focus-within \.projects-access-setall \{[^}]*opacity: 1/, "hover or focus reveals Set-all");
+  assert.match(view, /className="projects-access-setall-btn focus-ring"/, "revealed Set-all buttons carry the focus ring");
+  assert.match(css, /\.projects-access-row-settings \{[^}]*opacity: 0/, "the row gear rests invisible");
+  assert.match(css, /\.projects-access-rowwrap:hover \.projects-access-row-settings,\n\.projects-access-rowwrap:focus-within \.projects-access-row-settings \{[^}]*opacity: 1/, "row hover or focus reveals the gear");
+  const hoverNoneBlocks = css.match(/@media \(hover: none\)/g) ?? [];
+  assert.ok(hoverNoneBlocks.length >= 2, "touch devices keep both controls always visible");
+});
+
 test("pills and states are token-driven for both themes", () => {
   assert.match(css, /\.projects-access-pill\.is-write \{[^}]*background: var\(--accent-presence\)/, "Full pill fills with the accent");
   assert.match(css, /\.projects-access-pill\.is-write \{[^}]*color: var\(--accent-presence-foreground\)/, "Full pill text uses the paired foreground token");
   assert.match(css, /\.projects-access-pill\.is-read \{[^}]*color-mix\(in oklch, var\(--accent-presence\) 12%, transparent\)/, "Read pill is an accent tint");
   assert.match(css, /\.projects-access-pill\.is-none \{[^}]*color: var\(--text-muted\)/, "No-access pill stays muted");
+  assert.match(css, /\.projects-access-pill\.is-none \{[^}]*border-color: transparent/, "No-access pill drops the chip border — quietest state");
   assert.doesNotMatch(css, /#[0-9a-fA-F]{3,8}\b/, "no hard-coded hex colors — theme tokens only");
   assert.match(css, /\.projects-access-row\.is-flash/, "flash state is styled");
   assert.match(css, /\.projects-access-rule \{[^}]*background: var\(--border-hairline\)/, "section rules are hairlines");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -22,22 +22,21 @@ import {
   type ProjectAccessLevel,
 } from "@/lib/project-access-levels";
 import {
-  SECTION_LABELS,
-  SECTION_ORDER,
   accessCounts,
   accessStateMeta,
   filterProjectsByQuery,
   nextAccessState,
+  sectionModels,
   setAllOps,
-  splitProjectsBySection,
   type AccessOp,
   type AccessState,
-  type ProjectSection,
+  type SectionModel,
 } from "@/lib/projects/access-page";
 import { smoothScrollBehavior } from "@/lib/use-prefers-reduced-motion";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useConfirm } from "@/components/ui/confirm-dialog";
 import { Button } from "@/components/ui/button";
+import { IconButton } from "@/components/ui/icon-button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
@@ -87,10 +86,14 @@ async function runAccessOp(familiarId: string, op: AccessOp): Promise<void> {
   if (!res.ok) throw new Error(String(res.status));
 }
 
+/** Grouping preference: "1" (default) = workspaces/repositories, "0" = flat. */
+const GROUPED_STORAGE_KEY = "cave:projects:grouped";
+
 /**
  * The Chat → Projects surface: one familiar's project-access map. Pick a
- * familiar, see every registered project split into workspaces and
- * repositories, and click a row to cycle its direct grant — no access → read
+ * familiar, see every registered project — grouped into workspaces and
+ * repositories, or flattened into one list via the toolbar toggle (persisted
+ * per profile) — and click a row to cycle its direct grant — no access → read
  * → full → none — against /api/project-grants. Effective levels fold in
  * access-group grants (union-max), and the supreme familiar renders locked
  * at Full everywhere.
@@ -261,11 +264,25 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
     [rowByProject],
   );
 
-  // ── Search ─────────────────────────────────────────────────────────────
+  // ── Search & grouping ──────────────────────────────────────────────────
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement | null>(null);
+  // Grouped by default; the preference survives reloads per profile.
+  const [grouped, setGrouped] = useState<boolean>(
+    () => typeof window === "undefined" || window.localStorage.getItem(GROUPED_STORAGE_KEY) !== "0",
+  );
+  const toggleGrouped = useCallback(() => {
+    const next = !grouped;
+    setGrouped(next);
+    try {
+      window.localStorage.setItem(GROUPED_STORAGE_KEY, next ? "1" : "0");
+    } catch {
+      // Storage failures (private mode) only lose the preference, not the view.
+    }
+    announce(next ? "Projects grouped by type." : "Projects shown as one flat list.");
+  }, [grouped, announce]);
   const filtered = useMemo(() => filterProjectsByQuery(projects, query), [projects, query]);
-  const sections = useMemo(() => splitProjectsBySection(filtered), [filtered]);
+  const sections = useMemo(() => sectionModels(filtered, grouped), [filtered, grouped]);
 
   // "/" jumps to the search box (unless focus is already in an editable).
   useEffect(() => {
@@ -383,8 +400,8 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
   );
 
   const setAllInSection = useCallback(
-    (section: ProjectSection, target: AccessState) => {
-      const ids = sections[section].map((p) => p.id);
+    (section: SectionModel<CaveProject>, target: AccessState) => {
+      const ids = section.projects.map((p) => p.id);
       const ops = setAllOps(ids, directByProject, target);
       if (ops.length === 0) {
         announce("Nothing to change.");
@@ -392,10 +409,10 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
       }
       void applyOps(
         ops,
-        `${SECTION_LABELS[section]}: ${ops.length} ${ops.length === 1 ? "project" : "projects"} set to ${accessStateMeta(target).label}.`,
+        `${section.label}: ${ops.length} ${ops.length === 1 ? "project" : "projects"} set to ${accessStateMeta(target).label}.`,
       );
     },
-    [sections, directByProject, applyOps, announce],
+    [directByProject, applyOps, announce],
   );
 
   const resetAll = useCallback(async () => {
@@ -481,7 +498,6 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
       />
     );
   } else {
-    const visibleSections = SECTION_ORDER.filter((section) => sections[section].length > 0);
     body = (
       <>
         {supreme && familiar ? (
@@ -500,17 +516,17 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
             {addFlow.addError}
           </p>
         ) : null}
-        {visibleSections.length === 0 ? (
+        {sections.length === 0 ? (
           <p className="projects-access-nomatch" role="status">
             No projects match “{query.trim()}”.
           </p>
         ) : (
-          visibleSections.map((section) => (
-            <section key={section} className="projects-access-section" aria-label={SECTION_LABELS[section]}>
+          sections.map((section) => (
+            <section key={section.key} className="projects-access-section" aria-label={section.label}>
               <header className="projects-access-section-head">
                 <h2 className="projects-access-section-title">
-                  {SECTION_LABELS[section]}
-                  <span className="projects-access-section-count">{sections[section].length}</span>
+                  {section.label}
+                  <span className="projects-access-section-count">{section.projects.length}</span>
                 </h2>
                 <span className="projects-access-rule" aria-hidden />
                 <span className="projects-access-setall">
@@ -519,7 +535,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
                     <button
                       key={target}
                       type="button"
-                      className="projects-access-setall-btn"
+                      className="projects-access-setall-btn focus-ring"
                       disabled={controlsDisabled}
                       onClick={() => setAllInSection(section, target)}
                     >
@@ -529,7 +545,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
                 </span>
               </header>
               <ul className="projects-access-list">
-                {sections[section].map((project) => {
+                {section.projects.map((project) => {
                   const row = rowByProject.get(project.id) ?? {
                     project,
                     state: "none" as AccessState,
@@ -558,7 +574,6 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
                           }
                           aria-label={`${project.name}: ${meta.label}${viaGroups}. ${supreme ? "Locked for the supreme familiar." : `Click to ${meta.action}.`}`}
                         >
-                          <Icon className="projects-access-row-icon" name="ph:folder" width={15} aria-hidden />
                           <span className="projects-access-row-name">{project.name}</span>
                           {project.repoUrl ? (
                             <Icon
@@ -613,8 +628,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
           <p className="projects-access-eyebrow">Familiars</p>
           <h1 className="projects-access-title">Project access</h1>
           <p className="projects-access-subtitle">
-            Choose what each familiar can see and touch. Click any project to cycle its access —
-            none, read, or full.
+            Click a project to cycle access — none, read, full.
           </p>
         </header>
 
@@ -639,6 +653,19 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
               aria-label="Find a project"
             />
           </label>
+          <IconButton
+            icon={grouped ? "ph:stack" : "ph:rows"}
+            size="sm"
+            active={grouped}
+            className="projects-access-grouping"
+            aria-label="Group projects by type"
+            title={
+              grouped
+                ? "Grouped into workspaces and repositories — click for one flat list"
+                : "Flat list — click to group into workspaces and repositories"
+            }
+            onClick={toggleGrouped}
+          />
           <span className="projects-access-counts" title={`${counts.none} without access · ${counts.read} read · ${counts.write} full`}>
             <span className="projects-access-count is-none">
               <span className="projects-access-dot" aria-hidden />

--- a/src/lib/projects/access-page.test.ts
+++ b/src/lib/projects/access-page.test.ts
@@ -7,6 +7,7 @@ import {
   classifyProjectSection,
   filterProjectsByQuery,
   nextAccessState,
+  sectionModels,
   setAllOps,
   splitProjectsBySection,
 } from "./access-page.ts";
@@ -59,6 +60,54 @@ describe("splitProjectsBySection", () => {
       split.repositories.map((p) => p.root),
       ["/repo/a", "/repo/b"],
     );
+  });
+});
+
+describe("sectionModels", () => {
+  const projects = [
+    { root: "/repo/a" },
+    { root: "/u/.coven/workspaces/familiars/nova" },
+    { root: "/repo/b" },
+  ];
+
+  it("grouped: yields the workspaces/repositories split in section order", () => {
+    const models = sectionModels(projects, true);
+    assert.deepEqual(
+      models.map((m) => m.key),
+      ["workspaces", "repositories"],
+    );
+    assert.deepEqual(
+      models.map((m) => m.label),
+      ["Workspaces", "Repositories"],
+    );
+    assert.deepEqual(
+      models[1].projects.map((p) => p.root),
+      ["/repo/a", "/repo/b"],
+    );
+  });
+
+  it("grouped: omits empty sections", () => {
+    const models = sectionModels([{ root: "/repo/only" }], true);
+    assert.deepEqual(
+      models.map((m) => m.key),
+      ["repositories"],
+    );
+  });
+
+  it("flat: yields a single All-projects section preserving input order", () => {
+    const models = sectionModels(projects, false);
+    assert.equal(models.length, 1);
+    assert.equal(models[0].key, "all");
+    assert.equal(models[0].label, "All projects");
+    assert.deepEqual(
+      models[0].projects.map((p) => p.root),
+      ["/repo/a", "/u/.coven/workspaces/familiars/nova", "/repo/b"],
+    );
+  });
+
+  it("returns no sections for an empty list in either mode", () => {
+    assert.deepEqual(sectionModels([], true), []);
+    assert.deepEqual(sectionModels([], false), []);
   });
 });
 

--- a/src/lib/projects/access-page.ts
+++ b/src/lib/projects/access-page.ts
@@ -48,6 +48,35 @@ export function splitProjectsBySection<T extends { root: string }>(
   return { workspaces, repositories };
 }
 
+/** One renderable section: a labeled, ordered slice of the project list. */
+export type SectionModel<T> = {
+  key: ProjectSection | "all";
+  label: string;
+  projects: T[];
+};
+
+/**
+ * The list the page actually renders, per the grouping toggle. Grouped mode
+ * yields the workspaces/repositories split (empty sections omitted); flat
+ * mode yields a single "All projects" section, preserving the input order
+ * (the registry is already sorted alphabetically). Uniform shape either way,
+ * so section heads and Set-all render identically in both modes.
+ */
+export function sectionModels<T extends { root: string }>(
+  projects: readonly T[],
+  grouped: boolean,
+): SectionModel<T>[] {
+  if (!grouped) {
+    return projects.length > 0 ? [{ key: "all", label: "All projects", projects: [...projects] }] : [];
+  }
+  const split = splitProjectsBySection(projects);
+  return SECTION_ORDER.filter((section) => split[section].length > 0).map((section) => ({
+    key: section,
+    label: SECTION_LABELS[section],
+    projects: split[section],
+  }));
+}
+
 /** Click cycle on a row: none → read → full (write) → none. */
 export function nextAccessState(current: AccessState): AccessState {
   if (current === "none") return "read";

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -1,11 +1,14 @@
 /*
  * projects.css — the Chat → Projects "Project access" surface.
  *
- * One familiar's access map: serif display header, a toolbar (familiar
- * picker, search, tally, reset), then WORKSPACES / REPOSITORIES sections
+ * One familiar's access map: compact serif header, a quiet toolbar (familiar
+ * picker, search, grouping toggle, tally, reset), then project sections —
+ * grouped into WORKSPACES / REPOSITORIES or one flat ALL PROJECTS list —
  * whose rows carry a tri-state pill — No access · Read · Full — that cycles
- * on click. Every color routes through theme tokens so the page holds up in
- * light mode and custom accents; the filled "Full" pill pairs
+ * on click. Secondary controls (per-section Set all, the row gear) stay
+ * invisible until hover or keyboard focus reaches them, keeping the resting
+ * page minimal. Every color routes through theme tokens so the page holds up
+ * in light mode and custom accents; the filled "Full" pill pairs
  * --accent-presence with --accent-presence-foreground for contrast.
  */
 
@@ -18,7 +21,7 @@
 
 .projects-access-inner {
   /* Full-width (2026-07-23): the access map spans the pane (was 920px). */
-  padding: clamp(20px, 4vh, 44px) clamp(16px, 4vw, 40px) calc(var(--space-8) * 2);
+  padding: clamp(16px, 3vh, 32px) clamp(16px, 4vw, 40px) calc(var(--space-8) * 2);
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
@@ -45,7 +48,8 @@
 .projects-access-title {
   margin: 0;
   font-family: var(--font-serif, ui-serif, serif);
-  font-size: clamp(26px, 3.2vw, 34px);
+  /* Compact header (minimal pass): one type-scale step, not a display hero. */
+  font-size: var(--text-xl);
   font-weight: 500;
   line-height: 1.1;
   letter-spacing: 0.01em;
@@ -53,11 +57,11 @@
 }
 
 .projects-access-subtitle {
-  margin: var(--space-1) 0 0;
+  margin: 0;
   max-width: 56ch;
-  font-size: var(--text-base);
+  font-size: var(--text-sm);
   line-height: 1.5;
-  color: var(--text-secondary);
+  color: var(--text-muted);
 }
 
 /* ── Toolbar ────────────────────────────────────────────────────────── */
@@ -124,7 +128,7 @@
 .projects-access-counts {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-3);
+  gap: var(--space-2);
   margin-left: auto;
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--text-xs);
@@ -147,6 +151,10 @@
 
 .projects-access-count.is-write {
   color: var(--accent-presence);
+}
+
+.projects-access-grouping {
+  flex: 0 0 auto;
 }
 
 .projects-access-reset {
@@ -232,6 +240,22 @@
   display: inline-flex;
   align-items: center;
   font-size: var(--text-xs);
+  /* Quiet chrome: invisible until the section head is hovered or a Set-all
+     button holds keyboard focus (opacity-only — reduced-motion safe). */
+  opacity: 0;
+  transition: opacity 120ms ease;
+}
+
+.projects-access-section-head:hover .projects-access-setall,
+.projects-access-section-head:focus-within .projects-access-setall {
+  opacity: 1;
+}
+
+/* No hover on touch — keep the controls always visible there. */
+@media (hover: none) {
+  .projects-access-setall {
+    opacity: 1;
+  }
 }
 
 .projects-access-setall-label {
@@ -298,7 +322,20 @@
   background: transparent;
   color: var(--text-muted);
   cursor: pointer;
-  transition: background 120ms ease, color 120ms ease, border-color 120ms ease;
+  /* Quiet chrome: revealed by row hover or its own keyboard focus. */
+  opacity: 0;
+  transition: background 120ms ease, color 120ms ease, border-color 120ms ease, opacity 120ms ease;
+}
+
+.projects-access-rowwrap:hover .projects-access-row-settings,
+.projects-access-rowwrap:focus-within .projects-access-row-settings {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .projects-access-row-settings {
+    opacity: 1;
+  }
 }
 
 .projects-access-row-settings:hover {
@@ -353,11 +390,6 @@
   background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
 }
 
-.projects-access-row-icon {
-  flex: 0 0 auto;
-  color: var(--text-muted);
-}
-
 .projects-access-row-name {
   flex: 1 1 auto;
   min-width: 0;
@@ -394,6 +426,8 @@
 }
 
 .projects-access-pill.is-none {
+  /* Quietest state: plain muted text, no chip chrome. */
+  border-color: transparent;
   color: var(--text-muted);
 }
 


### PR DESCRIPTION
## What

UI/UX pass on the **Chat → Projects** surface (`projects-view.tsx`) toward a minimal, clean resting state, plus a **grouping toggle**.

### Grouping toggle
- Compact toolbar `IconButton` (`ph:stack` ⇄ `ph:rows`, `aria-pressed`, stable accessible name) after search.
- Grouped (Workspaces / Repositories) by default; flat mode renders one **All projects** section so per-section *Set all* keeps working in both modes.
- Persisted per profile under `localStorage["cave:projects:grouped"]` (`cave:<surface>:<pref>` convention); mode changes announced via `useAnnouncer`.
- New pure helper `sectionModels(projects, grouped)` in `src/lib/projects/access-page.ts` — unit-tested, uniform section shape for both modes.

### Minimalism pass (design-language token contract)
- **Compact header** — title `clamp(26–34px)` → `var(--text-xl)`; subtitle down to one muted line.
- **Quiet chrome** — per-section *Set all* strip and the per-row gear rest at `opacity: 0`, revealed on `:hover` / `:focus-within` (opacity-only ⇒ reduced-motion safe; `@media (hover: none)` keeps them always visible on touch; Set-all buttons gain `.focus-ring`).
- **Row declutter** — redundant per-row folder glyph removed; *No access* pill drops its chip border and reads as plain muted text (Read/Full pills unchanged).
- **Toolbar tidy** — tally gap tightened to the 4px grid; reduced page top padding.

## Validation
- `node --test src/lib/projects/access-page.test.ts src/components/projects-view.test.ts` — 32/32 pass (new `sectionModels` unit tests; pin tests updated + new toggle/quiet-chrome pins)
- `pnpm typecheck` ✓ · `pnpm lint` (design codemod check + eslint) ✓ · `design-token-drift` ratchet ✓ (tokenize-css stays a no-op)
- `pnpm test` — full app suite, **917 test files pass**
- No new icons (both glyphs already in `ICON_NAMES`) — no subset regen.

Bead: **cave-bjud**