### PR TITLE
fix(chat): stop chat page blinking on backdrop toggle + cached thread reopen (cave-se3v)

### DIFF
--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3352,6 +3352,19 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             return;
           }
           storeConversation(sessionId, json);
+          // Revalidation no-op guard: when the cache already painted this exact
+          // conversation, skip re-applying it. applyConversationPayload maps
+          // fresh turn objects every call, so an identical re-apply rebuilds the
+          // whole transcript — a visible flicker on heavy blocks (code, images)
+          // every time a cached thread is reopened. Content-equal → leave the
+          // painted turns untouched; only a real change re-renders.
+          if (
+            cachedConversation &&
+            JSON.stringify(json.conversation) === JSON.stringify(cachedConversation.conversation)
+          ) {
+            setHistoryState("loaded");
+            return;
+          }
           applyConversationPayload(json);
         } else if (json.ok && json.context) {
           // Known affiliation (e.g. fresh task chat) — no transcript yet.

--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -63,6 +63,42 @@ html[data-backdrop] .cave-backdrop-layer::after {
   }
 }
 
+/* Crossfade the surface/thread washes in step with the scrim's opacity fade.
+   Toggling a backdrop (entering chat, switching familiar/mode) flips
+   html[data-backdrop-on], which swaps these backgrounds and blurs; without a
+   transition they pop solid↔translucent one frame ahead of the 260ms scrim
+   fade — the visible "blink". Declared on the base selectors so it eases in
+   BOTH directions; only background/backdrop-filter animate (padding/radius
+   snap to avoid reflow jank). */
+.shell-root,
+.shell-detail,
+.chat-surface,
+.cave-chat-linear,
+.cave-chat-linear .cave-chat-thread,
+.cave-chat-linear-header,
+.cave-group-chat-shell,
+.cave-chat-empty-shell,
+.home-hearth-card,
+.familiar-tab {
+  transition:
+    background var(--duration-slow, 260ms) ease,
+    backdrop-filter var(--duration-slow, 260ms) ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .shell-root,
+  .shell-detail,
+  .chat-surface,
+  .cave-chat-linear,
+  .cave-chat-linear .cave-chat-thread,
+  .cave-chat-linear-header,
+  .cave-group-chat-shell,
+  .cave-chat-empty-shell,
+  .home-hearth-card,
+  .familiar-tab {
+    transition: none;
+  }
+}
+
 /* The big opaque paints over the layer go translucent while a backdrop
    surface (home/chat) is frontmost — the layer component flips
    html[data-backdrop-on]. Side panes (nav, list) keep their own solid


### PR DESCRIPTION
## What

Two independent chat-page flashes, patched together.

### 1. Backdrop toggle pop (entering chat / switching familiar or mode)
Toggling a backdrop flips `html[data-backdrop-on]`, which swaps the surface/thread backgrounds and applies `backdrop-filter` **instantly**, while only the scrim layer has a 260ms opacity transition (`backdrop.css` L19). The content area therefore jumped solid↔translucent one frame ahead of the fade — the visible blink.

**Fix:** add a matching `background` + `backdrop-filter` transition to the surfaces that change on `data-backdrop-on` (`.shell-root/.shell-detail`, `.chat-surface`, `.cave-chat-linear`, `.cave-chat-thread`, `.cave-chat-linear-header`, `.cave-group-chat-shell`, `.cave-chat-empty-shell`, `.home-hearth-card`, `.familiar-tab`). Declared on the base selectors so it eases in **both** directions; `padding`/`border-radius` still snap (no reflow animation); disabled under `prefers-reduced-motion`.

### 2. Cached thread reopen flicker
On reopening a cached thread, the revalidation fetch re-applied an identical conversation through `applyConversationPayload`, which maps **fresh** turn objects every call and rebuilds the entire transcript — a flicker on heavy blocks (code, images).

**Fix:** a revalidation no-op guard in `chat-view.tsx` — when the cache already painted this exact conversation (`JSON.stringify` content-equal), skip the re-apply and leave the painted turns untouched. Any real change still re-renders as before.

(The thread-switch skeleton was already sound — it's gated by `turns.length === 0`, so it never blanks a visible transcript.)

## Verification
`pnpm typecheck` ✓ · `pnpm build` ✓ (bundle + standalone budgets within limits) · `lint:design` ✓ · design-token-drift ✓ · `codemod:design:check` ✓ (transition props aren't token-governed) · relevant suites green: `backdrop-scrim`, `chat-router-switching`, `chat-view-lifecycle`, `chat-view-transcript-memo`, `chat-view-render-cap`, `chat-view`, `chat-view-scroll-pin`, `chat-empty-state`.

cave-se3v

🤖 Generated with [Claude Code](https://claude.com/claude-code)