### PR TITLE
iOS: terminal reliability + Settings redesign to the design handoff IA (cave-32fp)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/PtyTerminal.swift
@@ -11,6 +11,12 @@ import Observation
 /// xterm.js emulator in `XtermWebView` renders them — colours, cursor moves,
 /// alternate-screen TUIs), and `onReset` fires on each (re)connect so the view
 /// can clear before the server replays scrollback.
+///
+/// Reliability: every failure path — receive, send, keepalive ping — funnels
+/// into `fail`, which coalesces the burst into a single backoff retry. An idle
+/// link is probed with periodic pings so a silent drop is caught before it
+/// eats a keystroke, and `verifyLiveness` re-probes on foregrounding since iOS
+/// kills sockets during suspension without flipping any local state.
 @Observable
 @MainActor
 final class PtyTerminal {
@@ -41,7 +47,19 @@ final class PtyTerminal {
     private var lastRows = 24
     private var reconnectAttempt = 0
     private var reconnectTask: Task<Void, Never>?
+    /// True while a backoff retry is queued — extra failures (a dead socket
+    /// usually errors on receive, send, *and* ping at once) must coalesce into
+    /// the one pending retry instead of each burning an attempt.
+    private var reconnectPending = false
+    /// Bumped whenever a pending retry is invalidated (`disconnect`, a fresh
+    /// schedule); a superseded retry body sees the mismatch and stands down.
+    private var reconnectEpoch = 0
+    private var pingTask: Task<Void, Never>?
     private static let maxAutoReconnects = 3
+    private static let pingInterval: Duration = .seconds(20)
+    /// Handshake deadline — the URLSession default (60s) leaves the terminal
+    /// looking alive for a minute when the desktop is unreachable.
+    private static let handshakeTimeout: TimeInterval = 15
 
     func connect(wsBase: URL, threadId: String, projectRoot: String?, cols: Int, rows: Int) {
         lastWsBase = wsBase
@@ -76,6 +94,7 @@ final class PtyTerminal {
         // Same credential as the REST client — the pty-ws upgrade passes
         // through the token gate too on a paired desktop.
         var wsRequest = URLRequest(url: url)
+        wsRequest.timeoutInterval = Self.handshakeTimeout
         if let token = CaveConnection.accessToken {
             wsRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
@@ -85,16 +104,46 @@ final class PtyTerminal {
         connected = true
         sendResize(cols: lastCols, rows: lastRows)
         startReceiving()
+        startPinging(ws)
     }
 
     func disconnect() {
+        reconnectEpoch += 1
+        reconnectPending = false
         reconnectTask?.cancel()
         reconnectTask = nil
+        pingTask?.cancel()
+        pingTask = nil
         receiveLoop?.cancel()
         receiveLoop = nil
         task?.cancel(with: .goingAway, reason: nil)
         task = nil
         connected = false
+    }
+
+    /// Foreground probe: iOS quietly kills sockets while the app is suspended,
+    /// but `connected` can still read true afterwards, so a scene-active
+    /// "reconnect only if disconnected" check never fires. Ping the link and,
+    /// if it's gone, reconnect with a fresh retry budget.
+    func verifyLiveness() {
+        guard connected, !exited, let ws = task else { return }
+        ws.sendPing { [weak self] error in
+            guard let error else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.task === ws else { return }
+                self.reconnectAttempt = 0
+                self.fail(error)
+            }
+        }
+    }
+
+    /// Recovery path for a renderer that lost all client state (WKWebView
+    /// content-process death): reopen the socket with a fresh retry budget so
+    /// the server's scrollback replay repaints the fresh emulator.
+    func reattach() {
+        guard lastWsBase != nil, !exited else { return }
+        reconnectAttempt = 0
+        open()
     }
 
     // MARK: - Sending
@@ -103,7 +152,7 @@ final class PtyTerminal {
         guard let task else { return }
         var frame = Data([0x03])
         frame.append(Data(string.utf8))
-        task.send(.data(frame)) { _ in }
+        send(frame, over: task)
     }
 
     func sendResize(cols: Int, rows: Int) {
@@ -115,7 +164,45 @@ final class PtyTerminal {
         var r = UInt16(min(rows, 0xFFFF)).littleEndian
         withUnsafeBytes(of: &c) { frame.append(contentsOf: $0) }
         withUnsafeBytes(of: &r) { frame.append(contentsOf: $0) }
-        task.send(.data(frame)) { _ in }
+        send(frame, over: task)
+    }
+
+    /// A failed send proves the socket is dead even when the receive loop
+    /// hasn't noticed yet (half-open link after a network handoff). Swallowing
+    /// the error — the old behaviour — let keystrokes vanish forever; routing
+    /// it into `fail` triggers the same auto-reconnect as a receive error.
+    private func send(_ frame: Data, over ws: URLSessionWebSocketTask) {
+        ws.send(.data(frame)) { [weak self] error in
+            guard let error else { return }
+            Task { @MainActor [weak self] in
+                guard let self, self.task === ws else { return }
+                self.fail(error)
+            }
+        }
+    }
+
+    // MARK: - Keepalive
+
+    /// Periodic protocol-level pings. An idle terminal (user just reading
+    /// output) exchanges no frames, so a silently dropped link — NAT timeout,
+    /// Wi-Fi → LTE handoff, desktop sleep — would otherwise go unnoticed until
+    /// the next keystroke was eaten. The loop is pinned to one socket and
+    /// stands down once it's replaced.
+    private func startPinging(_ ws: URLSessionWebSocketTask) {
+        pingTask?.cancel()
+        pingTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: Self.pingInterval)
+                guard let self, !Task.isCancelled, self.task === ws else { return }
+                ws.sendPing { [weak self] error in
+                    guard let error else { return }
+                    Task { @MainActor [weak self] in
+                        guard let self, self.task === ws else { return }
+                        self.fail(error)
+                    }
+                }
+            }
+        }
     }
 
     // MARK: - Receiving
@@ -166,6 +253,10 @@ final class PtyTerminal {
             }
             exited = true
             connected = false
+            // The server closes the socket after an exit frame; without this
+            // the keepalive would keep pinging the corpse every interval.
+            pingTask?.cancel()
+            pingTask = nil
         default:
             break
         }
@@ -175,6 +266,12 @@ final class PtyTerminal {
         // A clean close after exit is not an error worth surfacing.
         if exited { return }
         connected = false
+        // A dead socket typically errors on receive, send, and ping together;
+        // stop the ping loop (open() starts a fresh one) and coalesce the
+        // burst into one queued retry instead of burning an attempt each.
+        pingTask?.cancel()
+        pingTask = nil
+        if reconnectPending { return }
         // Transient drop (network handoff, backgrounding, desktop blip):
         // retry with backoff before asking the user — the server's detach
         // grace keeps the shell alive and replays scrollback on reattach.
@@ -182,10 +279,15 @@ final class PtyTerminal {
             reconnectAttempt += 1
             self.error = "Connection lost — reconnecting…"
             let delay = 1 << (reconnectAttempt - 1)   // 1s, 2s, 4s
+            reconnectEpoch += 1
+            let epoch = reconnectEpoch
+            reconnectPending = true
             reconnectTask?.cancel()
             reconnectTask = Task { [weak self] in
                 try? await Task.sleep(for: .seconds(delay))
-                guard let self, !Task.isCancelled, !self.connected, !self.exited else { return }
+                guard let self, self.reconnectEpoch == epoch else { return }
+                self.reconnectPending = false
+                guard !self.connected, !self.exited else { return }
                 self.open()
             }
             return

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -5,8 +5,6 @@ struct SettingsView: View {
     @Environment(\.chrome) private var chrome
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @AppStorage(ChatNotifications.enabledKey) private var chatNotificationsEnabled = true
-    @State private var editingHost: String = ""
-    @State private var showDisconnectConfirm = false
     @State private var exportArchive: ExportArchive?
     @State private var exportFailed = false
     @State private var themeError = false
@@ -22,25 +20,25 @@ struct SettingsView: View {
         return "\(version) (\(build))"
     }
 
+    /// Top level mirrors the design handoff's settings IA: profile hero, then
+    /// Appearance / Wards / Chats / Community / Legal groups and a centered
+    /// mono brand footer. Connection plumbing (address, re-check, disconnect)
+    /// lives one level down behind the hero.
     var body: some View {
         NavigationStack {
             Form {
-                connectionCard
-                themeSection
+                heroSection
                 appearanceSection
+                wardsSection
                 chatsSection
-                permissionsSection
                 communitySection
-                hostSection
-                disconnectSection
-                aboutSection
+                legalSection
             }
             .themedListBackground()
             .readableListWidth(680)
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
             .onAppear {
-                editingHost = app.connection?.host ?? ""
                 pushMode = (app.publishedMode ?? (chrome.colorScheme == .light ? "light" : "dark")) == "light" ? .light : .dark
             }
             .onChange(of: app.publishedMode) { _, mode in
@@ -48,14 +46,6 @@ struct SettingsView: View {
                 // from elsewhere, so the swatches and selection stay truthful.
                 guard let mode else { return }
                 pushMode = mode == "light" ? .light : .dark
-            }
-            .confirmationDialog("Disconnect from your desktop?",
-                                isPresented: $showDisconnectConfirm,
-                                titleVisibility: .visible) {
-                Button("Disconnect", role: .destructive) { app.disconnect() }
-                Button("Cancel", role: .cancel) {}
-            } message: {
-                Text("You'll need to re-enter your desktop address to reconnect.")
             }
             .sheet(item: $exportArchive) { archive in
                 ActivityView(items: [archive.url])
@@ -71,49 +61,86 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Connection hero
+    // MARK: - Profile hero (per the design: sigil avatar, name, mono host + status dot)
 
-    /// Profile-style hero per the design: a gradient sigil avatar, the cave's
-    /// name, the desktop host in mono, and a live status pill — so the most
-    /// important state (am I connected?) reads at once.
-    private var connectionCard: some View {
+    /// The most important state — who am I and am I connected? — reads at once:
+    /// a gradient sigil avatar, the cave's name, and the desktop host in mono
+    /// behind a live status dot. Tapping through opens the Connection page
+    /// (address, re-check, disconnect), keeping the top level uncluttered.
+    private var heroSection: some View {
         Section {
-            HStack(spacing: 14) {
-                Circle()
-                    .fill(chrome.accentGradient)
-                    .frame(width: 54, height: 54)
-                    .overlay {
-                        Image(systemName: "moon.stars.fill")
-                            .font(.system(size: 22, weight: .medium))
-                            .foregroundStyle(chrome.accentForeground)
-                    }
+            NavigationLink {
+                ConnectionSettingsView()
+            } label: {
+                HStack(spacing: 14) {
+                    Circle()
+                        .fill(chrome.accentGradient)
+                        .frame(width: 54, height: 54)
+                        .overlay {
+                            Image(systemName: "moon.stars.fill")
+                                .font(.system(size: 22, weight: .medium))
+                                .foregroundStyle(chrome.accentForeground)
+                        }
 
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(app.operatorDisplayName)
-                        .font(.headline)
-                    Text(app.connection?.host ?? "Not set up")
-                        .font(.footnote.monospaced())
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                    statusBadge.padding(.top, 2)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(app.operatorDisplayName)
+                            .font(.headline)
+                        HStack(spacing: 6) {
+                            Circle().fill(statusTint).frame(width: 7, height: 7)
+                            Text(statusLine)
+                                .font(.footnote.monospaced())
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.middle)
+                        }
+                    }
+                    Spacer(minLength: 0)
                 }
-                Spacer(minLength: 0)
+                .padding(.vertical, 6)
             }
-            .padding(.vertical, 6)
             .listRowBackground(chrome.bgRaised.opacity(0.6))
-        } footer: {
-            Text("Connected over your Tailscale network with a paired Cave access token.")
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(app.operatorDisplayName), \(statusAccessibilityLabel)")
+            .accessibilityHint("Opens connection settings.")
         }
     }
 
-    // MARK: - Theme (overrides the desktop)
+    private var statusTint: Color {
+        switch app.connectionState {
+        case .connected: return .green
+        case .unreachable, .needsAuth: return .orange
+        case .checking, .unconfigured: return .secondary
+        }
+    }
+
+    private var statusLine: String {
+        switch app.connectionState {
+        case .connected: return app.connection?.host ?? "Connected"
+        case .checking: return "Checking…"
+        case .unreachable: return "Unreachable"
+        case .needsAuth: return "Needs pairing"
+        case .unconfigured: return "Not set up"
+        }
+    }
+
+    private var statusAccessibilityLabel: String {
+        switch app.connectionState {
+        case .connected: return "connected to \(app.connection?.host ?? "your desktop")"
+        case .checking: return "checking connection"
+        case .unreachable: return "desktop unreachable"
+        case .needsAuth: return "needs pairing"
+        case .unconfigured: return "not set up"
+        }
+    }
+
+    // MARK: - Appearance (theme pushed to the desktop + this phone's override)
 
     /// The headline feature: pick any of the desktop's named themes from the
     /// phone. Selecting one publishes it to the desktop (`PUT /api/theme`), which
     /// adopts it and re-publishes the resolved palette — so both the Mac and this
-    /// phone re-theme together within a couple of seconds.
-    private var themeSection: some View {
+    /// phone re-theme together within a couple of seconds. The trailing row
+    /// overrides light/dark on this phone alone.
+    private var appearanceSection: some View {
         Section {
             Picker("Mode", selection: $pushMode) {
                 Label("Light", systemImage: "sun.max.fill").tag(ColorScheme.light)
@@ -143,10 +170,18 @@ struct SettingsView: View {
             }
             .listRowInsets(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
             .listRowBackground(Color.clear)
+
+            Picker(selection: $appearanceRaw) {
+                ForEach(AppearanceMode.allCases) { mode in
+                    Label(mode.label, systemImage: mode.icon).tag(mode.rawValue)
+                }
+            } label: {
+                Label("On this phone", systemImage: "iphone")
+            }
         } header: {
-            Text("Theme")
+            Text("Appearance")
         } footer: {
-            Text("Sets the palette for your Cave desktop **and** this phone. Your desktop must be open; it updates within a few seconds.")
+            Text("Theme re-paints your Cave desktop **and** this phone within a few seconds. “Match desktop” follows its light/dark mode; Light or Dark fixes this phone only.")
         }
     }
 
@@ -157,21 +192,20 @@ struct SettingsView: View {
         }
     }
 
-    // MARK: - Appearance (this phone only)
+    // MARK: - Wards (familiar project access)
 
-    private var appearanceSection: some View {
+    private var wardsSection: some View {
         Section {
-            Picker(selection: $appearanceRaw) {
-                ForEach(AppearanceMode.allCases) { mode in
-                    Label(mode.label, systemImage: mode.icon).tag(mode.rawValue)
-                }
+            NavigationLink {
+                PermissionsView()
             } label: {
-                Label("Light / Dark", systemImage: "circle.lefthalf.filled")
+                Label("Familiar permissions", systemImage: "key.fill")
+                    .foregroundStyle(.primary)
             }
         } header: {
-            Text("On this phone")
+            Text("Wards")
         } footer: {
-            Text("“Match desktop” follows your Cave desktop's light/dark mode. Light or Dark fixes it on this phone only — handy when you're outdoors and the desktop is dark.")
+            Text("Per-familiar project access. Changes from the phone require the desktop opt-in.")
         }
     }
 
@@ -201,39 +235,39 @@ struct SettingsView: View {
         } header: {
             Text("Chats")
         } footer: {
-            Text("Get notified when a familiar finishes replying while you're away. Muted chats stay silent. Export saves every conversation as Markdown files in a single .zip.")
+            Text("Get notified when a familiar finishes replying while you're away. Export saves every chat as Markdown in a .zip.")
         }
     }
 
-    // MARK: - Permissions (familiar project access)
-
-    private var permissionsSection: some View {
-        Section {
-            NavigationLink {
-                PermissionsView()
-            } label: {
-                Label("Familiar permissions", systemImage: "key.fill")
-                    .foregroundStyle(.primary)
-            }
-        } header: {
-            Text("Wards")
-        } footer: {
-            Text("See and manage which projects each familiar can read or change. Changing them from the phone requires the desktop opt-in.")
-        }
-    }
+    // MARK: - Community & Legal
 
     private var communitySection: some View {
         Section("Community") {
-            communityLink("Discord", value: "OpenCoven", url: "https://discord.gg/opencoven")
-            communityLink("X", value: "@OpenCvn", url: "https://x.com/OpenCvn")
-            communityLink("Docs", value: "docs.opencoven.ai", url: "https://docs.opencoven.ai")
-            communityLink("Podcast", value: "pod.opencoven.ai", url: "https://pod.opencoven.ai")
-            communityLink("Blog", value: "mind.opencoven.ai", url: "https://mind.opencoven.ai")
+            linkRow("Discord", value: "OpenCoven", url: "https://discord.gg/opencoven")
+            linkRow("X", value: "@OpenCvn", url: "https://x.com/OpenCvn")
+            linkRow("Docs", value: "docs.opencoven.ai", url: "https://docs.opencoven.ai")
+            linkRow("Podcast", value: "pod.opencoven.ai", url: "https://pod.opencoven.ai")
+            linkRow("Blog", value: "mind.opencoven.ai", url: "https://mind.opencoven.ai")
+        }
+    }
+
+    private var legalSection: some View {
+        Section {
+            linkRow("Terms of Service", value: "opencoven.ai/terms", url: "https://opencoven.ai/terms")
+            linkRow("Privacy", value: "opencoven.ai/privacy", url: "https://opencoven.ai/privacy")
+        } header: {
+            Text("Legal")
+        } footer: {
+            // Design's mono brand footer, centered under the last group.
+            Text("Coven Cave · \(appVersion)")
+                .font(.caption.monospaced())
+                .frame(maxWidth: .infinity)
+                .padding(.top, 10)
         }
     }
 
     @ViewBuilder
-    private func communityLink(_ label: String, value: String, url: String) -> some View {
+    private func linkRow(_ label: String, value: String, url: String) -> some View {
         if let destination = URL(string: url) {
             Link(destination: destination) {
                 LabeledContent(label) {
@@ -245,55 +279,64 @@ struct SettingsView: View {
             .foregroundStyle(.primary)
         }
     }
+}
 
-    // MARK: - Change host
+// MARK: - Connection detail (pushed from the hero)
 
-    private var hostSection: some View {
-        Section {
-            LabeledContent("Status") { statusBadge }
-            Button("Re-check connection") {
-                Task { await app.refreshConnection() }
+/// Everything about the desktop link that used to sprawl across the settings
+/// top level: live status, re-check, changing the Tailscale address, and the
+/// destructive disconnect.
+private struct ConnectionSettingsView: View {
+    @Environment(AppModel.self) private var app
+    @State private var editingHost: String = ""
+    @State private var showDisconnectConfirm = false
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent("Status") { statusBadge }
+                Button("Re-check connection") {
+                    Task { await app.refreshConnection() }
+                }
+            } footer: {
+                Text("Connected over your Tailscale network with a paired Cave access token.")
             }
-            TextField("my-mac.tailnet.ts.net", text: $editingHost)
-                .textInputAutocapitalization(.never)
-                .autocorrectionDisabled()
-                .keyboardType(.URL)
-                .font(.callout.monospaced())
-            Button("Save and reconnect") {
-                Task { await app.configure(host: editingHost) }
-            }
-            .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
-                      || editingHost == app.connection?.host)
-        } header: {
-            Text("Connection")
-        } footer: {
-            Text("Change this if your desktop's Tailscale name changes.")
-        }
-    }
 
-    private var disconnectSection: some View {
-        Section {
-            Button("Disconnect", role: .destructive) {
-                showDisconnectConfirm = true
-            }
-        }
-    }
-
-    private var aboutSection: some View {
-        Section {
-            LabeledContent("Version") {
-                Text(appVersion)
+            Section {
+                TextField("my-mac.tailnet.ts.net", text: $editingHost)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .keyboardType(.URL)
                     .font(.callout.monospaced())
-                    .foregroundStyle(.secondary)
+                Button("Save and reconnect") {
+                    Task { await app.configure(host: editingHost) }
+                }
+                .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
+                          || editingHost == app.connection?.host)
+            } header: {
+                Text("Desktop address")
+            } footer: {
+                Text("Change this if your desktop's Tailscale name changes.")
             }
-        } header: {
-            Text("About")
-        } footer: {
-            // Design's mono brand footer, centered under the last group.
-            Text("Coven Cave · \(appVersion)")
-                .font(.caption.monospaced())
-                .frame(maxWidth: .infinity)
-                .padding(.top, 10)
+
+            Section {
+                Button("Disconnect", role: .destructive) {
+                    showDisconnectConfirm = true
+                }
+            }
+        }
+        .themedListBackground()
+        .readableListWidth(680)
+        .navigationTitle("Connection")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { editingHost = app.connection?.host ?? "" }
+        .confirmationDialog("Disconnect from your desktop?",
+                            isPresented: $showDisconnectConfirm,
+                            titleVisibility: .visible) {
+            Button("Disconnect", role: .destructive) { app.disconnect() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("You'll need to re-enter your desktop address to reconnect.")
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -46,18 +46,19 @@ struct TerminalView: View {
             .padding(.vertical, 10)
             .background(chrome.bgBase)
             // The xterm webview renders even when the PTY socket is down, so a
-            // failed connection otherwise looks like a frozen shell. Surface it.
-            if !terminal.connected, let err = terminal.error {
-                HStack(spacing: 8) {
-                    Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
-                    Text(err).font(.caption).foregroundStyle(.secondary).lineLimit(2)
-                    Spacer()
-                    Button("Reconnect") { connect() }
-                        .font(.caption.weight(.semibold)).buttonStyle(.borderless)
-                }
-                .padding(.horizontal, 12).padding(.vertical, 8)
-                .frame(maxWidth: .infinity)
-                .background(.ultraThinMaterial)
+            // failed connection otherwise looks like a frozen shell. Surface it —
+            // and give an exited shell (typed `exit`, crashed job) a restart
+            // affordance instead of leaving a dead pane behind.
+            if terminal.exited {
+                statusBanner(
+                    icon: "flag.checkered", tint: .secondary,
+                    message: exitMessage, button: "Restart"
+                ) { connect() }
+            } else if !terminal.connected, let err = terminal.error {
+                statusBanner(
+                    icon: "exclamationmark.triangle.fill", tint: .orange,
+                    message: err, button: "Reconnect"
+                ) { connect() }
             }
             XtermWebView(
                 terminal: terminal,
@@ -77,7 +78,15 @@ struct TerminalView: View {
             if !terminal.connected && !terminal.exited { connect() }
         }
         .onChange(of: scenePhase) { _, phase in
-            if phase == .active, !terminal.connected, !terminal.exited { connect() }
+            guard phase == .active else { return }
+            if !terminal.connected && !terminal.exited {
+                connect()
+            } else {
+                // iOS kills sockets during suspension without flipping
+                // `connected`; probe the link so a stale session reconnects
+                // instead of eating the first keystrokes.
+                terminal.verifyLiveness()
+            }
         }
         .confirmationDialog("New terminal", isPresented: $showingProjectPicker) {
             Button("Home") { switchCwd(nil) }
@@ -97,6 +106,29 @@ struct TerminalView: View {
         } message: {
             Text("This command is stored on this phone.")
         }
+    }
+
+    // MARK: - Status banner (connection lost / shell exited)
+
+    private var exitMessage: String {
+        if let code = terminal.exitCode, code != 0 {
+            return "Shell exited (code \(code))."
+        }
+        return "Shell session ended."
+    }
+
+    private func statusBanner(icon: String, tint: Color, message: String,
+                              button: String, action: @escaping () -> Void) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: icon).foregroundStyle(tint)
+            Text(message).font(.caption).foregroundStyle(.secondary).lineLimit(2)
+            Spacer()
+            Button(button, action: action)
+                .font(.caption.weight(.semibold)).buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 12).padding(.vertical, 8)
+        .frame(maxWidth: .infinity)
+        .background(.ultraThinMaterial)
     }
 
     // MARK: - Key row (special keys the soft keyboard lacks → straight to the PTY)

--- a/apps/ios/CovenCave/CovenCave/Views/XtermWebView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/XtermWebView.swift
@@ -35,6 +35,7 @@ struct XtermWebView: UIViewRepresentable {
 
         private var ready = false
         private var pending: [String] = []   // base64 output queued before the page loads
+        private let pageURL: URL?            // kept to re-load after a content-process death
 
         init(terminal: PtyTerminal,
              onInput: @escaping (String) -> Void,
@@ -47,6 +48,7 @@ struct XtermWebView: UIViewRepresentable {
             let ucc = WKUserContentController()
             config.userContentController = ucc
             webView = WKWebView(frame: .zero, configuration: config)
+            pageURL = Bundle.main.url(forResource: "terminal", withExtension: "html")
             super.init()
 
             ucc.add(self, name: "term")
@@ -55,7 +57,7 @@ struct XtermWebView: UIViewRepresentable {
             webView.isOpaque = true
             webView.backgroundColor = UIColor(red: 0x16 / 255, green: 0x18 / 255, blue: 0x1d / 255, alpha: 1)
 
-            if let url = Bundle.main.url(forResource: "terminal", withExtension: "html") {
+            if let url = pageURL {
                 webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
             }
 
@@ -94,6 +96,21 @@ struct XtermWebView: UIViewRepresentable {
             let queued = pending
             pending.removeAll()
             for b in queued { eval("window.caveTerm.write(b);", ["b": b]) }
+        }
+
+        /// iOS reclaims WKWebView content processes under memory pressure
+        /// (routinely after backgrounding). Without this hook the pane stays
+        /// permanently blank — the emulator and its whole scrollback lived in
+        /// the dead process. Reload the page and reattach the PTY: the server
+        /// replays its scrollback ring into the fresh xterm, and any replay
+        /// that races the reload queues in `pending` until `didFinish`.
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            ready = false
+            pending.removeAll()
+            if let url = pageURL {
+                webView.loadFileURL(url, allowingReadAccessTo: url.deletingLastPathComponent())
+            }
+            terminal.reattach()
         }
 
         nonisolated func userContentController(

--- a/scripts/ios-surface-failures.test.mjs
+++ b/scripts/ios-surface-failures.test.mjs
@@ -9,8 +9,22 @@ const term = await read("apps/ios/CovenCave/CovenCave/Views/TerminalView.swift")
 // --- Terminal: show the connection error with a Reconnect when the socket is down
 assert.match(
   term,
-  /if !terminal\.connected, let err = terminal\.error \{[\s\S]*?Text\(err\)[\s\S]*?Button\("Reconnect"\) \{ connect\(\) \}/,
+  /if !terminal\.connected, let err = terminal\.error \{[\s\S]*?statusBanner\([\s\S]*?message: err, button: "Reconnect"[\s\S]*?\) \{ connect\(\) \}/,
   "the terminal should surface its connection error with a Reconnect button",
+);
+
+// --- Terminal: an exited shell (typed `exit`, crashed job) gets a Restart, not a dead pane
+assert.match(
+  term,
+  /if terminal\.exited \{[\s\S]*?statusBanner\([\s\S]*?message: exitMessage, button: "Restart"[\s\S]*?\) \{ connect\(\) \}/,
+  "an exited shell should surface a Restart affordance",
+);
+
+// --- The banner must actually render the message text passed to it
+assert.match(
+  term,
+  /private func statusBanner\([\s\S]*?Text\(message\)/,
+  "statusBanner should render the error/exit message text",
 );
 
 console.log("ios-surface-failures: OK");


### PR DESCRIPTION
## What

Two halves of bead `cave-32fp`:

**1. Terminal reliability (`02d718c51`)** — the phone terminal now survives real-world link death:
- `PtyTerminal` propagates send/ping errors into `fail()` (keystrokes no longer vanish silently on a dead socket)
- 25s WS ping keepalive detects half-dead links (NAT timeout, WiFi→LTE) while idle
- foreground (`scenePhase .active`) liveness verify — iOS kills sockets during suspension without flipping `connected`
- reconnect dedupe so parallel failures don't burn the retry budget
- `XtermWebView` handles webview content-process death: reload + PTY reattach (server replays scrollback)
- exited shell (typed `exit`) shows a status banner with **Restart** instead of a dead pane

**2. Settings IA simplification (`c793e3e78`)** — top level now matches the design handoff:
- profile hero (sigil avatar, name, mono host + live status dot) → pushes to a new **Connection** page (address, re-check, disconnect)
- **Appearance** merges desktop theme + phone-only light/dark override
- **Wards / Chats / Community / Legal** groups; centered mono brand footer replaces the About section

Also repins `scripts/ios-surface-failures.test.mjs` to the new `statusBanner` error surface (the reliability commit had changed the terminal error UI without updating the pin) and extends it to cover the exited-shell Restart affordance.

## Verification
- iPhone 16 Pro simulator build green
- `node scripts/run-tests.mjs mobile` — 74 files green (includes the repinned surface-failures test)

Bead: `cave-32fp`