### PR TITLE
fix(github): only list orgs that have rows in the current table

### DIFF
--- a/src/app/api/github/activity/route.test.ts
+++ b/src/app/api/github/activity/route.test.ts
@@ -62,8 +62,8 @@ assert.match(
 );
 assert.match(
   githubView,
-  /\.\.\.\(activity\?\.organizations \?\? \[\]\)/,
-  "organization options should include authenticated memberships even without open activity",
+  /\.\.\.filtered\.map\(\(i\) => orgOf\(i\.repo\)\)/,
+  "organization options derive from the orgs present in the current table rows, not from every membership",
 );
 assert.match(
   githubView,

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2468,16 +2468,16 @@ export function GitHubView({
     return orgScope.length === 0 ? byKind : byKind.filter((i) => orgScope.includes(orgOf(i.repo)));
   }, [items, filter, orgScope]);
 
-  // Memberships define the account's organization scope; activity adds any
-  // organization represented by the current items. Repository options still
-  // narrow to the chosen org so the two selects cascade (org → repo).
+  // Only organizations that actually have rows in the current GitHub table are
+  // offered — a membership that returned no items is not listed (filtering to it
+  // would just show an empty table). The active filter is still included so a
+  // selection whose rows dropped out doesn't fall out of the select's options.
   const orgOptions = useMemo(
     () => Array.from(new Set([
-      ...(activity?.organizations ?? []).filter((o) => orgScope.length === 0 || orgScope.includes(o)),
       ...filtered.map((i) => orgOf(i.repo)),
       ...(orgFilter === "all" ? [] : [orgFilter]),
     ])).sort((a, b) => a.localeCompare(b)),
-    [activity?.organizations, filtered, orgFilter, orgScope],
+    [filtered, orgFilter],
   );
   const repoOptions = useMemo(() => {
     const base = orgFilter === "all" ? filtered : filtered.filter((i) => orgOf(i.repo) === orgFilter);

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2468,9 +2468,9 @@ export function GitHubView({
     return orgScope.length === 0 ? byKind : byKind.filter((i) => orgScope.includes(orgOf(i.repo)));
   }, [items, filter, orgScope]);
 
-  // Only organizations that actually have rows in the current GitHub table are
-  // offered — a membership that returned no items is not listed (filtering to it
-  // would just show an empty table). The active filter is still included so a
+  // Org filter options are derived only from organizations represented in the
+  // current base item set (after kind + orgScope filtering, but before org/repo
+  // filters and the search query). The active orgFilter is still included so a
   // selection whose rows dropped out doesn't fall out of the select's options.
   const orgOptions = useMemo(
     () => Array.from(new Set([

--- a/src/components/settings-github.test.ts
+++ b/src/components/settings-github.test.ts
@@ -32,6 +32,7 @@ test("the GitHub surface applies the configured org scope", () => {
   assert.match(view, /const orgScope = useAppPreferences\(\)\.github\.orgScope;/);
   // filtered items are constrained to the scope when non-empty
   assert.match(view, /orgScope\.length === 0 \? byKind : byKind\.filter\(\(i\) => orgScope\.includes\(orgOf\(i\.repo\)\)\)/);
-  // the org dropdown only lists scoped memberships
-  assert.match(view, /orgScope\.length === 0 \|\| orgScope\.includes\(o\)/);
+  // the org dropdown derives from the (already scope-constrained) filtered rows,
+  // so it only lists orgs that actually have items in the current table
+  assert.match(view, /\.\.\.filtered\.map\(\(i\) => orgOf\(i\.repo\)\)/);
 });


### PR DESCRIPTION
## What

The GitHub surface's **org filter** dropdown was seeded from `activity.organizations` — every organization the account belongs to. So a membership with no assigned items still appeared as an option, and picking it just showed an empty table.

This derives the org options **solely from the orgs represented in the current items** (`filtered.map(orgOf)`), plus the active `orgFilter` as a guard so a selection whose rows just dropped out doesn't fall out of the select. An org now appears in the dropdown only when it actually has a return value in the table.

## Behavior

- Org membership that returns no items → no longer offered (was: offered, filtered to an empty table).
- Composes with the existing org-scope preference (#3788): scope narrows the items → `filtered` → the dropdown reflects orgs-with-rows within scope.

## Verification

- `tsc --noEmit` clean, `eslint` clean
- `github-view-polish.test.ts` passes (org-filter source pins intact)
- `pnpm build` green (within all budgets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)