### PR TITLE
Tasks: trash button owns Clear done; remove the header overflow menu (cave-zngl)

### DIFF
--- a/docs/diagrams/navigation/04-menus-and-overlays.mmd
+++ b/docs/diagrams/navigation/04-menus-and-overlays.mmd
@@ -72,9 +72,9 @@ flowchart TB
 
   subgraph SURFACEMENUS["Surface-level progressive disclosure"]
     direction LR
-    UI --> BOARDMENU["Tasks · More task actions"]:::submenu
-    BOARDMENU --> BMULTI["Select multiple"]:::action
-    BOARDMENU --> BCLEAR["Clear done → inline confirm"]:::danger
+    UI --> BOARDTRASH["Tasks · Trash button"]:::action
+    BOARDTRASH --> BDELSEL["Delete selected → confirm popover"]:::danger
+    BOARDTRASH --> BCLEAR["Clear done → inline confirm"]:::danger
     UI --> PROJECTMENU["Project options"]:::submenu
     PROJECTMENU --> PEDIT["Rename · Edit folder"]:::action
     PROJECTMENU --> PICON["Upload / generate / remove image"]:::action

--- a/src/components/board-bulk-select.test.ts
+++ b/src/components/board-bulk-select.test.ts
@@ -45,12 +45,14 @@ assert.match(view, /<StandardSelect<CardPriority \| "">[\s\S]*?onChange=\{\(next
 assert.match(view, /list="board-bulk-label-options"/, "label input is backed by a datalist of existing labels");
 assert.match(view, /void bulkAddLabel\(labelDraft\)/, "label form submits bulkAddLabel");
 
-// Redesign: Select-multiple and Delete-selected are first-class toolbar verbs
-// (visible icon buttons), while the overflow keeps the occasional Clear-done.
-assert.match(
+// Redesign: Select-multiple and the trash are first-class toolbar verbs
+// (visible icon buttons). The trash owns BOTH destructive flows — delete the
+// selection in select mode, clear done otherwise — so the tasks header no
+// longer carries an overflow menu.
+assert.doesNotMatch(
   view,
-  /<OverflowMenu ariaLabel="More task actions">/,
-  "board header renders the shared overflow menu",
+  /<OverflowMenu/,
+  "the tasks header overflow menu is gone — the trash button owns clear-done",
 );
 assert.match(
   view,
@@ -59,8 +61,8 @@ assert.match(
 );
 assert.match(
   view,
-  /icon="ph:trash"\s*\n\s*danger\s*\n\s*disabled=\{doneCards\.length === 0\}/,
-  "Clear done remains the overflow-menu item",
+  /if \(cardSelect\.selectMode\) \{\s*if \(hasSelection\) setToolbarDeleteConfirm\(true\);\s*\} else if \(doneCards\.length > 0\) \{\s*setClearConfirm\(true\);\s*\}/,
+  "the trash button routes to delete-selected in select mode and clear-done otherwise",
 );
 
 console.log("board-bulk-select.test.ts: ok");

--- a/src/components/board-clear-done.test.ts
+++ b/src/components/board-clear-done.test.ts
@@ -11,16 +11,20 @@ assert.match(
   "doneCards memo filters the current-scope `filtered` list by status done",
 );
 
-// Toolbar control + gating + inline confirm. Clear-done is an occasional
-// destructive verb, so it lives in the shared overflow menu (§8 chrome
-// budget); the confirm group replaces the menu inline while deciding.
+// Toolbar control + gating + inline confirm. The trash icon button owns the
+// destructive verbs: outside select mode it is Clear done, gated on the
+// done-card count; the confirm group replaces it inline while deciding.
 assert.match(source, /Clear done/, "Clear done control label present");
 assert.match(
   source,
-  /<PopoverItem\s*icon="ph:trash"\s*danger\s*disabled=\{doneCards\.length === 0\}\s*onSelect=\{\(\) => setClearConfirm\(true\)\}/,
-  "Clear done is a danger overflow-menu item, gated on done-card count",
+  /title=\{cardSelect\.selectMode \? "Delete selected" : "Clear done"\}/,
+  "the trash button reads Clear done outside select mode, Delete selected inside",
 );
-assert.match(source, /disabled=\{doneCards\.length === 0\}/, "Clear done gated on done-card count");
+assert.match(
+  source,
+  /disabled=\{cardSelect\.selectMode \? !hasSelection : doneCards\.length === 0\}/,
+  "Clear done gated on done-card count; Delete selected on the selection",
+);
 assert.match(source, /setClearConfirm\(true\)/, "clicking the control opens an inline confirm");
 assert.match(source, /Clear \{doneCards\.length\} done/, "confirm names the count");
 

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -16,8 +16,6 @@ import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { useMultiSelect } from "@/lib/use-multi-select";
 import { SelectionToolbar } from "@/components/ui/selection-toolbar";
-import { OverflowMenu } from "@/components/ui/overflow-menu";
-import { PopoverItem } from "@/components/ui/popover";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 import { familiarInScope } from "@/lib/familiar-multiselect";
@@ -1123,49 +1121,22 @@ export function BoardView({
             </button>
           </div>
 
-          {/* Redesign: Select-multiple and Delete-selected are first-class
-              toolbar verbs (visible icon buttons), not overflow items. Delete
-              routes through an inline confirm popover. Select/delete apply to
-              the kanban + table surfaces (the gantt has no row selection). */}
+          {/* Redesign: Select-multiple is a first-class toolbar verb (a
+              visible icon button), not an overflow item. It applies to the
+              kanban + table surfaces (the gantt has no row selection). */}
           {!isMobile && (viewMode === "kanban" || viewMode === "table") ? (
-            <>
-              <button
-                type="button"
-                className={`board-icon-btn${cardSelect.selectMode ? " board-icon-btn--active" : ""}`}
-                title="Select multiple"
-                aria-pressed={cardSelect.selectMode}
-                onClick={() => cardSelect.setSelectMode(!cardSelect.selectMode)}
-              >
-                <Icon name="ph:check-square" width={16} />
-                {cardSelect.selectMode && selectionCount > 0 ? (
-                  <span className="board-icon-btn-count">{selectionCount}</span>
-                ) : null}
-              </button>
-              <div className="board-icon-wrap">
-                <button
-                  type="button"
-                  className={`board-icon-btn${hasSelection ? " board-icon-btn--danger" : ""}`}
-                  title="Delete selected"
-                  disabled={!hasSelection}
-                  onClick={() => { if (hasSelection) setToolbarDeleteConfirm(true); }}
-                >
-                  <Icon name="ph:trash" width={16} />
-                </button>
-                {toolbarDeleteConfirm && hasSelection ? (
-                  <>
-                    <div className="board-confirm-scrim" onClick={() => setToolbarDeleteConfirm(false)} />
-                    <div className="board-confirm-pop" role="dialog" aria-label="Confirm delete tasks">
-                      <div className="board-confirm-title">Delete {selectionCount} {selectionCount === 1 ? "task" : "tasks"}?</div>
-                      <div className="board-confirm-desc">This removes them from the queue. Undo is available briefly.</div>
-                      <div className="board-confirm-actions">
-                        <button type="button" className="board-toolbar-btn" onClick={() => setToolbarDeleteConfirm(false)}>Cancel</button>
-                        <button type="button" className="board-confirm-delete" onClick={() => { bulkDelete(); setToolbarDeleteConfirm(false); }}>Delete</button>
-                      </div>
-                    </div>
-                  </>
-                ) : null}
-              </div>
-            </>
+            <button
+              type="button"
+              className={`board-icon-btn${cardSelect.selectMode ? " board-icon-btn--active" : ""}`}
+              title="Select multiple"
+              aria-pressed={cardSelect.selectMode}
+              onClick={() => cardSelect.setSelectMode(!cardSelect.selectMode)}
+            >
+              <Icon name="ph:check-square" width={16} />
+              {cardSelect.selectMode && selectionCount > 0 ? (
+                <span className="board-icon-btn-count">{selectionCount}</span>
+              ) : null}
+            </button>
           ) : null}
 
           {/* Redesign: Filter dropdown narrows by the grouped dimension. */}
@@ -1184,8 +1155,12 @@ export function BoardView({
             />
           ) : null}
 
-          {/* Clear-done stays reachable for table/gantt (the kanban Done column
-              also exposes it inline). Occasional verb → compact overflow. */}
+          {/* The trash button owns both destructive verbs: in select mode it
+              deletes the selection (inline confirm popover); otherwise it
+              clears the done tasks in view (the confirm group replaces it
+              while deciding). That keeps clear-done reachable on every
+              surface — table/gantt/phone included — without an overflow menu;
+              the kanban Done column also exposes it inline. */}
           {clearConfirm ? (
             <div className="board-clear-confirm" role="group" aria-label="Confirm clear done tasks">
               <button
@@ -1205,17 +1180,36 @@ export function BoardView({
               </button>
             </div>
           ) : (
-            <OverflowMenu ariaLabel="More task actions">
-              <PopoverItem
-                icon="ph:trash"
-                danger
-                disabled={doneCards.length === 0}
-                onSelect={() => setClearConfirm(true)}
-                title="Remove all done tasks in view"
+            <div className="board-icon-wrap">
+              <button
+                type="button"
+                className={`board-icon-btn${hasSelection ? " board-icon-btn--danger" : ""}`}
+                title={cardSelect.selectMode ? "Delete selected" : "Clear done"}
+                disabled={cardSelect.selectMode ? !hasSelection : doneCards.length === 0}
+                onClick={() => {
+                  if (cardSelect.selectMode) {
+                    if (hasSelection) setToolbarDeleteConfirm(true);
+                  } else if (doneCards.length > 0) {
+                    setClearConfirm(true);
+                  }
+                }}
               >
-                Clear done
-              </PopoverItem>
-            </OverflowMenu>
+                <Icon name="ph:trash" width={16} />
+              </button>
+              {toolbarDeleteConfirm && hasSelection ? (
+                <>
+                  <div className="board-confirm-scrim" onClick={() => setToolbarDeleteConfirm(false)} />
+                  <div className="board-confirm-pop" role="dialog" aria-label="Confirm delete tasks">
+                    <div className="board-confirm-title">Delete {selectionCount} {selectionCount === 1 ? "task" : "tasks"}?</div>
+                    <div className="board-confirm-desc">This removes them from the queue. Undo is available briefly.</div>
+                    <div className="board-confirm-actions">
+                      <button type="button" className="board-toolbar-btn" onClick={() => setToolbarDeleteConfirm(false)}>Cancel</button>
+                      <button type="button" className="board-confirm-delete" onClick={() => { bulkDelete(); setToolbarDeleteConfirm(false); }}>Delete</button>
+                    </div>
+                  </div>
+                </>
+              ) : null}
+            </div>
           )}
 
           <button


### PR DESCRIPTION
## What

The tasks-header ellipses (`OverflowMenu`) carried a single item — **Clear done** — so the trash icon button now owns both destructive verbs and the menu is removed:

- **In select mode:** trash = *Delete selected* (unchanged confirm popover → `bulkDelete`), disabled until a selection exists.
- **Otherwise:** trash = *Clear done*, disabled when the view has no done tasks; clicking swaps the button for the existing inline `Clear N done / Cancel` confirm group.

Reachability is preserved: the trash now renders on every surface where the overflow used to (table, gantt, phone — where select mode doesn't exist, so it's purely Clear done there), and the kanban Done column keeps its inline clear.

Also:
- `board-clear-done.test.ts` / `board-bulk-select.test.ts` repinned; bulk-select now asserts the overflow menu is **gone** from the header.
- `docs/diagrams/navigation/04-menus-and-overlays.mmd` updated (BOARDMENU → BOARDTRASH).
- Dead `OverflowMenu`/`PopoverItem` imports dropped from `board-view.tsx`.

## Verification
- `board-clear-done.test.ts` + `board-bulk-select.test.ts` green
- `tsc --noEmit` clean; `eslint` clean on the changed component

Bead: `cave-zngl`