### PR TITLE
fix(shell): fall back to plain pane after peel context-loss cap (cave-yqlt)

### DIFF
--- a/src/components/shell-peel-reveal.tsx
+++ b/src/components/shell-peel-reveal.tsx
@@ -74,7 +74,12 @@ const OFF_OPTIONS = {
 
 /** How many times a lost WebGL context earns a fresh mount before giving up —
  *  a crashing GPU/driver loop should not thrash remounts forever (mirrors
- *  cave-backdrop-blaze.tsx, bead cave-kbh1). */
+ *  cave-backdrop-blaze.tsx, bead cave-kbh1). Unlike Blaze — a decorative
+ *  backdrop that may acceptably stay blank past the cap — the peel wraps
+ *  primary content and its WebGL output canvas is the pane's only paint path
+ *  (the vendored createPeel has no context-loss recovery), so giving up here
+ *  permanently falls back to the plain bare-Fragment path instead of
+ *  stranding a blank but still hit-testable pane (cave-yqlt). */
 const MAX_CONTEXT_RESTARTS = 3;
 
 type ProbeCanvas = HTMLCanvasElement & { requestPaint?: () => void };
@@ -116,6 +121,9 @@ const emptySubscribe = () => () => {};
  * blanks on a null fallback and children re-parent exactly once (cave-ao2o).
  * Under the experimental flag those `>` chains do not reach through the
  * vendor's canvas layers — a known, flag-gated divergence (Task 6 QA).
+ * WebGL context loss remounts the live tree at most MAX_CONTEXT_RESTARTS
+ * times; one loss past the cap permanently downgrades to the bare-Fragment
+ * path (cave-yqlt).
  */
 export function ShellPeelReveal({
   active,
@@ -133,19 +141,35 @@ export function ShellPeelReveal({
     getPeelLiveServer,
   );
   const reducedMotion = usePrefersReducedMotion();
-  const enhanced = supported && Peel !== null && !reducedMotion;
 
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const [glEpoch, setGlEpoch] = useState(0);
+  /** Epochs 1..MAX_CONTEXT_RESTARTS are fresh mounts; one more loss means the
+   *  GPU/driver is hopeless and the dead live tree would paint nothing while
+   *  still swallowing hits — fall back to the plain path for good. */
+  const glPermanentlyLost = glEpoch > MAX_CONTEXT_RESTARTS;
+  const enhanced =
+    supported && Peel !== null && !reducedMotion && !glPermanentlyLost;
 
   // webglcontextlost fires on the vendor's output canvas and does not bubble,
-  // but a capture-phase listener on the wrapper still sees it.
+  // but a capture-phase listener on the wrapper still sees it. Only the
+  // peel's own output canvas — a direct child of the .shell-peel-fill root —
+  // counts: the detail children live inside the source canvas subtree, so a
+  // context loss from any future WebGL canvas nested in the detail content
+  // must not remount (or permanently downgrade) the whole pane.
   useEffect(() => {
     if (!enhanced) return;
     const node = wrapRef.current;
     if (!node) return;
-    const onContextLost = () => {
-      setGlEpoch((epoch) => (epoch < MAX_CONTEXT_RESTARTS ? epoch + 1 : epoch));
+    const onContextLost = (event: Event) => {
+      const target = event.target;
+      if (
+        !(target instanceof HTMLCanvasElement) ||
+        !target.parentElement?.classList.contains("shell-peel-fill")
+      ) {
+        return;
+      }
+      setGlEpoch((epoch) => Math.min(epoch + 1, MAX_CONTEXT_RESTARTS + 1));
     };
     node.addEventListener("webglcontextlost", onContextLost, true);
     return () => node.removeEventListener("webglcontextlost", onContextLost, true);

--- a/src/components/sidepanel-peel-reveal.test.ts
+++ b/src/components/sidepanel-peel-reveal.test.ts
@@ -81,7 +81,7 @@ assert.match(
 );
 assert.match(
   wrapper,
-  /const enhanced = supported && Peel !== null && !reducedMotion;/,
+  /const enhanced =\s*supported && Peel !== null && !reducedMotion && !glPermanentlyLost;/,
   "reduced motion disables the enhancement entirely",
 );
 
@@ -134,6 +134,37 @@ assert.match(
   wrapper,
   /MAX_CONTEXT_RESTARTS = 3/,
   "context-loss restarts are capped",
+);
+// One loss past the cap must NOT strand the dead live tree: the vendored
+// createPeel has no context-loss recovery and its WebGL output canvas is the
+// pane's only paint path, so the wrapper flips a permanent-failure state and
+// rejoins the plain bare-Fragment path instead of leaving primary content
+// blank but still hit-testable (cave-yqlt). (Blaze may stay blank past its
+// cap — it's a decorative backdrop; this wraps the detail pane.)
+assert.match(
+  wrapper,
+  /setGlEpoch\(\(epoch\) => Math\.min\(epoch \+ 1, MAX_CONTEXT_RESTARTS \+ 1\)\)/,
+  "the epoch saturates one past the cap so the final loss escapes the live tree",
+);
+assert.match(
+  wrapper,
+  /const glPermanentlyLost = glEpoch > MAX_CONTEXT_RESTARTS;/,
+  "past-cap context loss is a permanent-failure state",
+);
+assert.match(
+  wrapper,
+  /&& !glPermanentlyLost;/,
+  "permanent loss gates `enhanced` off — the existing bare-Fragment fallback, no new rendering mode",
+);
+// The capture-phase listener reacts only to the peel's own output canvas (a
+// direct child of the .shell-peel-fill root). The detail children render
+// inside the source canvas subtree, so a context loss from any future WebGL
+// canvas nested in the detail content must not bump the epoch — that would
+// remount (or, past the cap, permanently downgrade) the whole pane.
+assert.match(
+  wrapper,
+  /!\(target instanceof HTMLCanvasElement\) \|\|\s*!target\.parentElement\?\.classList\.contains\("shell-peel-fill"\)/,
+  "context-loss handler is scoped to the peel's own output canvas",
 );
 
 // Plain path is a bare Fragment: several production rules use direct-child


### PR DESCRIPTION
Fixes bead **cave-yqlt**, filed from the post-merge review of fbb9af38b (PR #3827).

## Bug

`src/components/shell-peel-reveal.tsx` remounts the vendored WebGL `<Peel>` on `webglcontextlost`, capped at `MAX_CONTEXT_RESTARTS` (3). A **fourth** context loss bailed out via a same-value `setGlEpoch` call, leaving the dead live tree mounted. The vendored `createPeel` has no context-loss handling and the WebGL output canvas is the pane's only paint path (the `layoutsubtree` children never paint natively; the 2D source canvas is reset after capture) — so the detail pane went **permanently blank yet still hit-testable** until reload. Unlike the Blaze precedent (`cave-backdrop-blaze.tsx`, a decorative backdrop where staying blank is acceptable), this sacrifices primary content while a GPU-free bare-Fragment render path already exists in the same component.

## Fix

- **Permanent fallback past the cap:** the epoch now saturates one past the cap (`Math.min(epoch + 1, MAX_CONTEXT_RESTARTS + 1)`), and `glPermanentlyLost = glEpoch > MAX_CONTEXT_RESTARTS` gates `enhanced` off — so a loss past the cap permanently rejoins the **existing** bare-Fragment path (real content, no WebGL, no wrapper elements). No new rendering mode.
- **Listener scoping (latent bug):** the capture-phase `webglcontextlost` listener on the wrapper div used to catch context losses from *any* nested WebGL canvas in the detail content and remount the whole pane. The handler now only reacts when `event.target` is the peel's own output canvas (a canvas that is a direct child of the `.shell-peel-fill` root; the detail children live inside the source-canvas subtree, so nested canvases can never match).
- Feature remains flag-gated Chromium-only (`probeHtmlInCanvas` + reduced-motion gates untouched); no styling changes.

Tests extended in `src/components/sidepanel-peel-reveal.test.ts` (existing source-assertion style): (a) past-cap loss flips the permanent-failure state and gates the bare-Fragment fallback, (b) the handler is scoped so nested non-peel canvases can't bump the epoch.

## Verification

- `node --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts` — ok
- `pnpm test` (`node scripts/run-tests.mjs app`) — ✓ 918 test file(s) passed [app]
- `pnpm typecheck` (`tsc --noEmit`) — clean
- `pnpm lint` (`codemod:design:check` + `eslint src/components --max-warnings=0`) — 0 drift, 0 warnings