### PR TITLE
feat(research): clamp long mission summaries with a "View more" toggle

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -23,6 +23,7 @@ import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { CitationSources } from "@/components/ui/citation";
+import { ClampedText } from "@/components/ui/clamped-text";
 import { sourcesToCitations } from "@/lib/citations";
 import { copyText } from "@/lib/clipboard";
 import { Icon } from "@/lib/icon";
@@ -475,7 +476,7 @@ export function ResearchMissionDetail({
                 ) : null}
               </div>
               {iteration?.summary ? (
-                <p className="research-desk-block__note">{iteration.summary}</p>
+                <ClampedText className="research-desk-block__note" text={iteration.summary} />
               ) : null}
               {/* The sources the mission actually leaned on, rendered as
                   citations under the synthesis (the same shared component the
@@ -527,7 +528,7 @@ export function ResearchMissionDetail({
                 </span>
               </div>
               {iteration?.summary ? (
-                <p className="research-desk-block__abstract">{iteration.summary}</p>
+                <ClampedText className="research-desk-block__abstract" text={iteration.summary} />
               ) : (
                 <p className="research-desk-block__empty">
                   The run finished without a written summary — open the artifacts for the findings.

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -67,7 +67,9 @@ test("running and completed blocks stay honest about their data", () => {
   assert.doesNotMatch(detail, /1[34]:\d\d/); // no fake clock times
   // Completed abstract is the iteration summary; meta counts are real; the
   // design's findings chips are not derivable and are skipped.
-  assert.match(detail, /research-desk-block__abstract"?>\{iteration\.summary\}/);
+  // …rendered through the line-clamp so a long abstract stays compact with a
+  // "View more" toggle, but it is still the raw iteration summary.
+  assert.match(detail, /<ClampedText className="research-desk-block__abstract" text=\{iteration\.summary\} \/>/);
   assert.match(detail, /\{mission\.sources\.length\} sources · \{sourceCounts\.used\} used/);
   assert.doesNotMatch(detail, /Finding 1|compFindings/);
 });

--- a/src/components/ui/clamped-text.tsx
+++ b/src/components/ui/clamped-text.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useLayoutEffect, useRef, useState } from "react";
+
+/**
+ * Long-form text collapsed to a fixed maximum number of lines with a
+ * "View more" toggle. The toggle only appears when the text actually overflows
+ * the clamp, so short passages render untouched. Pass the surface's own text
+ * class through `className` — the clamp composes with its font/colour/rhythm.
+ */
+export function ClampedText({
+  text,
+  className,
+  moreLabel = "View more",
+  lessLabel = "View less",
+}: {
+  text: string;
+  className?: string;
+  moreLabel?: string;
+  lessLabel?: string;
+}) {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [overflows, setOverflows] = useState(false);
+  const [expanded, setExpanded] = useState(false);
+
+  // Measure only while collapsed: an expanded (un-clamped) paragraph has
+  // scrollHeight === clientHeight, so we keep the prior overflow verdict and
+  // leave the toggle in place rather than recomputing it away. A ResizeObserver
+  // re-checks on reflow (container resize, late-loading fonts).
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el || expanded) return;
+    const measure = () => setOverflows(el.scrollHeight - el.clientHeight > 1);
+    measure();
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [text, expanded]);
+
+  return (
+    <div className="flex flex-col items-start gap-1.5">
+      <p
+        ref={ref}
+        className={`${className ?? ""} ${expanded ? "line-clamp-none" : "line-clamp-8"}`.trim()}
+      >
+        {text}
+      </p>
+      {overflows ? (
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          aria-expanded={expanded}
+          className="focus-ring text-[length:var(--text-2xs)] font-semibold uppercase tracking-widest text-[var(--accent-presence)] hover:underline"
+        >
+          {expanded ? lessLabel : moreLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

In the Research surface, a mission's detail summary — the checkpoint *"what changed in pass X"* note and the completed-run **abstract** — rendered as a full-height paragraph. A long summary pushed the sources list and the rest of the desk far down the pane.

This clamps those summaries to a **max of 8 lines** with a **"View more" / "View less"** toggle.

## How

- New reusable `ClampedText` (`src/components/ui/clamped-text.tsx`): collapses its text to a fixed line count (Tailwind `line-clamp-8`, un-clamped when expanded) and renders the toggle **only when the text actually overflows the clamp** — short summaries render untouched with no button. A `ResizeObserver` re-checks overflow on reflow (container resize, late-loading fonts). It takes the surface's own text class through `className`, so the mission's font/colour/rhythm are preserved.
- `research-mission-detail.tsx`: both `iteration.summary` blocks (`research-desk-block__note` and `research-desk-block__abstract`) now render through `ClampedText`.
- Works on iOS and desktop — the iOS build is a Tauri webview of this same React component.

## Verification

- `tsc --noEmit` clean, `eslint` clean
- `research-tab-desk.test.ts` (19/19) and `researcher-surface.test.ts` (34/34) pass — the abstract source-pin was repointed to the new `ClampedText` markup while still asserting it renders the raw `iteration.summary`
- `pnpm build` green (within all budgets; Tailwind emits `line-clamp-8`)

The 8-line limit is a single-token change if you'd prefer a different maximum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)