### PR TITLE
fix(grimoire): keep New stitch + Blank entry on one row, match search radius (cave-g7h9)

### DIFF
--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -1447,7 +1447,7 @@ export function GrimoireView({
               <button
                 type="button"
                 onClick={() => openDoc({ kind: "knowledge-new" })}
-                className="focus-ring inline-flex h-[26px] items-center gap-1 rounded-md border border-[var(--border-hairline)] px-2 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+                className="focus-ring inline-flex h-[26px] shrink-0 items-center gap-1 whitespace-nowrap rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
               >
                 <Icon name="ph:plus" width={11} aria-hidden />
                 Blank entry

--- a/src/styles/grimoire-launcher.css
+++ b/src/styles/grimoire-launcher.css
@@ -51,7 +51,7 @@
   color: var(--text-primary);
 }
 
-/* The prototype's dashed "New stitch" pill — thread waiting to be sewn. */
+/* The prototype's dashed "New stitch" chip — thread waiting to be sewn. */
 .grimoire-newstitch {
   display: inline-flex;
   align-items: center;

--- a/src/styles/grimoire-launcher.css
+++ b/src/styles/grimoire-launcher.css
@@ -56,9 +56,14 @@
   display: inline-flex;
   align-items: center;
   gap: var(--space-1);
+  flex: none;
   height: 26px;
   padding: 0 var(--space-3);
-  border-radius: var(--radius-pill);
+  white-space: nowrap;
+  /* Match the "Search documents…" input radius (--radius-control) rather than a
+     pill so the header actions read as one family and the label stays on a
+     single row when the bar is tight. */
+  border-radius: var(--radius-control);
   border: 1.5px dashed color-mix(in oklch, var(--accent-presence) 60%, transparent);
   background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
   font-size: var(--text-xs);


### PR DESCRIPTION
In the **Memories** (grimoire) header, **New stitch** and **Blank entry** sat next to the *Search documents…* input. On a tight bar their labels wrapped to two lines, and *New stitch* was a pill (`--radius-pill`) while the search uses `--radius-control`.

**Fix:** both buttons get `flex:none` + `white-space:nowrap` (single row each); *New stitch* `--radius-pill`→`--radius-control` and *Blank entry* `rounded-md`→`rounded-[var(--radius-control)]` so both match the search radius.

Measured in-app (1440px): search / New stitch / Blank entry all compute to **8px**, each a single **26px** row (was New stitch 999px pill + wrapped labels).

Verified: typecheck, build, lint:design, drift (token→token, neutral), codemod, grimoire-launcher + grimoire-view suites, visual.

cave-g7h9

🤖 Generated with [Claude Code](https://claude.com/claude-code)