### PR TITLE
fix(ui): ClampedText resets on text change and guards ResizeObserver (cave-wv9v)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -57,6 +57,7 @@ export const SUITES = {
     "src/components/role-surfaces/research-artifact-actions.test.ts",
     "src/components/role-surfaces/research-tab-prompt.test.ts",
     "src/components/role-surfaces/research-tab-desk.test.ts",
+    "src/components/ui/clamped-text.test.ts",
     "src/components/role-surfaces/research-tab-library.test.ts",
     "src/components/role-surfaces/research-tab-studio.test.ts",
     "src/components/role-surfaces/research-tab-resources.test.ts",

--- a/src/components/ui/clamped-text.test.ts
+++ b/src/components/ui/clamped-text.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Copilot review follow-ups on #3879: a ClampedText instance is reused across
+// passages (mission/iteration switches), so its state must not outlive `text`,
+// and measurement must not assume ResizeObserver exists.
+
+const source = await readFile(new URL("./clamped-text.tsx", import.meta.url), "utf8");
+
+// A new passage starts collapsed and re-measured — the reset happens during
+// render (derive-state-from-props), so the stale expanded frame never paints.
+assert.match(
+  source,
+  /const \[prevText, setPrevText\] = useState\(text\);\s*if \(prevText !== text\) \{\s*setPrevText\(text\);\s*setExpanded\(false\);\s*setOverflows\(false\);\s*\}/,
+  "text changes reset expansion + overflow verdict during render",
+);
+
+// Measure once, then observe reflow only where ResizeObserver exists (house
+// rule — mirrors Sparkline's guard).
+assert.match(
+  source,
+  /measure\(\);\s*if \(typeof ResizeObserver === "undefined"\) return;\s*const observer = new ResizeObserver\(measure\);/,
+  "ResizeObserver is guarded, with a one-shot measure fallback",
+);
+
+console.log("clamped-text source assertions passed");

--- a/src/components/ui/clamped-text.tsx
+++ b/src/components/ui/clamped-text.tsx
@@ -23,15 +23,29 @@ export function ClampedText({
   const [overflows, setOverflows] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
+  // A new passage starts collapsed and re-measured: without this, swapping the
+  // `text` under one instance (switching missions/iterations) keeps the prior
+  // expansion and overflow verdict, so a short summary would render un-clamped
+  // behind a lingering "View less". Adjusting state during render (React's
+  // derive-state-from-props pattern) avoids ever painting that stale frame.
+  const [prevText, setPrevText] = useState(text);
+  if (prevText !== text) {
+    setPrevText(text);
+    setExpanded(false);
+    setOverflows(false);
+  }
+
   // Measure only while collapsed: an expanded (un-clamped) paragraph has
   // scrollHeight === clientHeight, so we keep the prior overflow verdict and
   // leave the toggle in place rather than recomputing it away. A ResizeObserver
-  // re-checks on reflow (container resize, late-loading fonts).
+  // re-checks on reflow (container resize, late-loading fonts); where it's
+  // unavailable (house rule — see Sparkline) we still measure once.
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el || expanded) return;
     const measure = () => setOverflows(el.scrollHeight - el.clientHeight > 1);
     measure();
+    if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(measure);
     observer.observe(el);
     return () => observer.disconnect();


### PR DESCRIPTION
## What

Addresses the two Copilot review comments #3879 merged with (threads [1](https://github.com/OpenCoven/coven-cave/pull/3879#discussion_r3652051275), [2](https://github.com/OpenCoven/coven-cave/pull/3879#discussion_r3652051288)):

1. **Stale state across passages** — `expanded`/`overflows` persisted when `text` changed under one instance (switching missions/iterations), so a short new summary rendered un-clamped behind a lingering *View less*. State now resets during render (React derive-state-from-props), so the stale frame never paints — one step stricter than the suggested layout-effect reset.
2. **Unguarded `ResizeObserver`** — now gated on `typeof ResizeObserver === "undefined"` with a one-shot measure fallback, mirroring `Sparkline`'s house guard.

Adds `src/components/ui/clamped-text.test.ts` pinning both behaviors, wired into the app suite.

## Verification
- clamped-text + research-tab-desk pins green; `check-tests-wired` 1243 green
- `tsc --noEmit` clean; eslint clean

Bead: `cave-wv9v` · Follow-up to #3879