### PR TITLE
feat(research-studio): render mermaid diagrams, budget-aware threads, source dropdowns

### DIFF
--- a/src/components/mermaid-viewer.ts
+++ b/src/components/mermaid-viewer.ts
@@ -228,19 +228,38 @@ export function openMermaidViewer(source: SVGSVGElement): void {
     downOnBackdrop = false;
   };
 
+  // Registered capture-phase with stopPropagation so a host surface's own
+  // window-level key handling (e.g. a modal focus trap under the overlay —
+  // the Research Studio viewer hosts diagrams inside one) never sees the keys
+  // this top layer consumes: one Escape peels one layer, and Tab cycles the
+  // overlay's toolbar instead of being recaptured by the trap underneath.
   const onKey = (event: KeyboardEvent) => {
     if (event.key === "Escape") {
       event.preventDefault();
+      event.stopPropagation();
       close();
     } else if (event.key === "+" || event.key === "=") {
       event.preventDefault();
+      event.stopPropagation();
       zoomCenter(ZOOM_STEP);
     } else if (event.key === "-" || event.key === "_") {
       event.preventDefault();
+      event.stopPropagation();
       zoomCenter(1 / ZOOM_STEP);
     } else if (event.key === "0") {
       event.preventDefault();
+      event.stopPropagation();
       fit();
+    } else if (event.key === "Tab") {
+      event.preventDefault();
+      event.stopPropagation();
+      const buttons = Array.from(
+        overlay.querySelectorAll<HTMLElement>("button:not([disabled])"),
+      );
+      if (buttons.length === 0) return;
+      const index = buttons.indexOf(document.activeElement as HTMLElement);
+      const step = event.shiftKey ? -1 : 1;
+      buttons[(index + step + buttons.length) % buttons.length].focus();
     }
   };
 
@@ -258,7 +277,7 @@ export function openMermaidViewer(source: SVGSVGElement): void {
     stage.removeEventListener("pointerdown", onPointerDown);
     window.removeEventListener("pointermove", onPointerMove);
     window.removeEventListener("pointerup", endDrag);
-    window.removeEventListener("keydown", onKey);
+    window.removeEventListener("keydown", onKey, { capture: true });
     stage.removeEventListener("dblclick", onDblClick);
     overlay.remove();
     previousActive?.focus?.();
@@ -273,7 +292,7 @@ export function openMermaidViewer(source: SVGSVGElement): void {
   stage.addEventListener("pointerdown", onPointerDown);
   window.addEventListener("pointermove", onPointerMove);
   window.addEventListener("pointerup", endDrag);
-  window.addEventListener("keydown", onKey);
+  window.addEventListener("keydown", onKey, { capture: true });
   stage.addEventListener("dblclick", onDblClick);
 
   const previousActive = document.activeElement as HTMLElement | null;

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -34,6 +34,7 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { copyText } from "@/lib/clipboard";
 import {
   RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH,
+  RESEARCH_THREAD_POST_MAX_CHARS,
   type ResearchGeneration,
   type ResearchGenerationKind,
   type ResearchGenerationMediaKind,
@@ -112,7 +113,7 @@ export const STUDIO_MEDIA_PRESENTATION: Record<
  * pickSourceArtifact rule (server/research-generations.ts): a markdown
  * artifact that is published or still working — rejected never qualifies.
  * Creating against anything else earns the POST's 409, which we surface, but
- * the chips should not offer dead ends in the first place.
+ * the source dropdown should not offer dead ends in the first place.
  */
 export function missionHasMarkdownArtifact(
   mission: Pick<ResearchMission, "artifacts">,
@@ -126,6 +127,22 @@ export function missionHasMarkdownArtifact(
 
 export function countWords(text: string): number {
   return text.split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Rendered mermaid diagram — the exact pipeline chat messages use.
+ * MarkdownBlock renders the ```mermaid fence via @create-markdown/preview-mermaid
+ * (lazy singleton, app theme variables), and the shared post-render wiring
+ * (useWireCopyButtons → wireMermaidDiagrams) adds the expand affordance that
+ * opens the fullscreen zoom/pan viewer. Render failures fall back to the
+ * plugin's own error placeholder — never a blank box.
+ */
+export function StudioMermaidDiagram({ mermaid }: { mermaid: string }) {
+  return (
+    <div className="research-studio__diagram">
+      <MarkdownBlock text={`\`\`\`mermaid\n${mermaid}\n\`\`\``} />
+    </div>
+  );
 }
 
 /** Display title. Real data only: the blog draft's first heading, the slide
@@ -385,26 +402,27 @@ export function GenerationConfigModal({
       </header>
       <div className="research-studio-modal__body">
         <div className="research-studio-config__sources">
-          <span className="research-studio-config__label" id="research-studio-config-source-label">
-            Source
-          </span>
-          <div
-            className="research-studio__chips"
-            role="group"
-            aria-labelledby="research-studio-config-source-label"
+          <label
+            className="research-studio-config__label"
+            htmlFor="research-studio-config-source"
+          >
+            Research run
+          </label>
+          <select
+            id="research-studio-config-source"
+            className="research-studio__select"
+            value={selectedSourceId ?? ""}
+            onChange={(event) => onSelectSource(event.target.value)}
           >
             {sources.map((source) => (
-              <button
-                key={source.id}
-                type="button"
-                className="research-studio__chip"
-                aria-pressed={source.id === selectedSourceId}
-                onClick={() => onSelectSource(source.id)}
-              >
+              <option key={source.id} value={source.id}>
                 {source.title}
-              </button>
+              </option>
             ))}
-          </div>
+          </select>
+          <span className="research-studio-config__hint">
+            The draft extracts from this run&rsquo;s newest markdown artifact.
+          </span>
         </div>
         <div className="research-studio-config__field">
           <label className="research-studio-config__label" htmlFor="research-studio-directions">
@@ -575,13 +593,23 @@ export function GenerationViewerModal({
 
   const points =
     content?.kind === "thread"
-      ? { label: "Thread", rows: content.posts.map((post) => ({ pre: post.pre, text: post.text })) }
+      ? {
+          label: "Thread",
+          rows: content.posts.map((post) => ({
+            pre: post.pre,
+            text: post.text,
+            // Post length against the social budget — honest posting aid, and
+            // the count is real data, not decoration.
+            note: `${post.text.length}/${RESEARCH_THREAD_POST_MAX_CHARS}`,
+          })),
+        }
       : content?.kind === "infographic"
         ? {
             label: "Stat sheet",
             rows: content.stats.map((stat) => ({
               pre: stat.value,
               text: stat.context,
+              note: null,
             })),
           }
         : null;
@@ -634,9 +662,13 @@ export function GenerationViewerModal({
         {content?.kind === "slides" ? <SlidesViewer generation={generation} /> : null}
 
         {content?.kind === "diagram" ? (
-          <div className="research-studio-viewer__code-wrap">
-            <span className="research-studio-viewer__label">Mermaid source</span>
-            <pre className="research-studio__code">{content.mermaid}</pre>
+          <div className="research-studio-viewer__diagram">
+            <span className="research-studio-viewer__label">Diagram</span>
+            <StudioMermaidDiagram mermaid={content.mermaid} />
+            <details className="research-studio-viewer__code-details">
+              <summary>Mermaid source</summary>
+              <pre className="research-studio__code">{content.mermaid}</pre>
+            </details>
           </div>
         ) : null}
 
@@ -667,7 +699,12 @@ export function GenerationViewerModal({
               {points.rows.map((row, rowIndex) => (
                 <li key={rowIndex} className="research-studio-viewer__point">
                   <span className="research-studio-viewer__point-pre">{row.pre}</span>
-                  <span className="research-studio-viewer__point-text">{row.text}</span>
+                  <span className="research-studio-viewer__point-text">
+                    {row.text}
+                    {row.note ? (
+                      <span className="research-studio-viewer__point-note">{row.note}</span>
+                    ) : null}
+                  </span>
                   <button
                     type="button"
                     className="research-studio-act research-studio-act--tiny"

--- a/src/components/role-surfaces/research-tab-studio.test.ts
+++ b/src/components/role-surfaces/research-tab-studio.test.ts
@@ -38,8 +38,8 @@ test("create failures surface the server's message inline (409 no-artifact inclu
   assert.match(tab, /setCreateError\(result\.error \?\? "Generation failed"\)/);
   assert.match(modals, /role="alert"/);
   assert.match(modals, /\{error\}/);
-  // The chips only offer missions the server would draft from — mirroring the
-  // published-or-working markdown artifact rule.
+  // The source dropdown only offers missions the server would draft from —
+  // mirroring the published-or-working markdown artifact rule.
   assert.match(modals, /endsWith\("\.md"\)/);
   assert.match(modals, /artifact\.state === "published" \|\| artifact\.state === "working"/);
 });
@@ -129,9 +129,9 @@ test("filter chips cover only kinds that can exist, with real counts", () => {
   assert.match(tab, /disabled=\{\(counts\.get\(kind\) \?\? 0\) === 0\}/);
 });
 
-test("per-kind actions stay honest: mermaid inline + copy, open per kind, no fake exports", () => {
-  assert.match(tab, /⌗ Hide Mermaid/);
-  assert.match(tab, /⌗ View Mermaid/);
+test("per-kind actions stay honest: diagram renders + copy, open per kind, no fake exports", () => {
+  assert.match(tab, /◇ Hide diagram/);
+  assert.match(tab, /◇ View diagram/);
   assert.match(tab, /⧉ Copy Mermaid/);
   assert.match(tab, /↗ Open draft/);
   // Remove confirms inline — never a native confirm dialog.
@@ -141,6 +141,43 @@ test("per-kind actions stay honest: mermaid inline + copy, open per kind, no fak
   assert.match(modals, /Download \.md/);
   assert.match(modals, /new Blob\(\[markdown\], \{ type: "text\/markdown" \}\)/);
   assert.doesNotMatch(source, /Export (pptx|pdf|png|mp3|mp4)/i);
+});
+
+test("diagrams render through the chat mermaid pipeline, source stays inspectable", () => {
+  // One shared renderer: StudioMermaidDiagram wraps MarkdownBlock with a
+  // ```mermaid fence, so the Studio inherits the chat pipeline (sanitized
+  // SVG, theme-aware, expand-to-fullscreen wiring) instead of a raw <pre>.
+  assert.match(modals, /function StudioMermaidDiagram/);
+  assert.match(modals, /```mermaid/);
+  assert.match(modals, /<MarkdownBlock/);
+  // Row toggle and viewer modal both render the diagram…
+  assert.match(tab, /<StudioMermaidDiagram mermaid=\{mermaid\} \/>/);
+  assert.match(modals, /<StudioMermaidDiagram mermaid=\{content\.mermaid\} \/>/);
+  // …and the viewer keeps the mermaid source readable under a disclosure.
+  assert.match(modals, /Mermaid source/);
+  assert.match(modals, /research-studio-viewer__code-details/);
+});
+
+test("source runs pick from a labelled dropdown — tab and config modal", () => {
+  // Tab-level picker: a real <select> with a visible label, valued by mission
+  // id, listing only qualifying sources.
+  assert.match(tab, /htmlFor="research-studio-source"/);
+  assert.match(tab, /id="research-studio-source"/);
+  assert.match(tab, /className="research-studio__select"/);
+  assert.match(tab, /\{sources\.map\(\(source\) => \(\s*<option/);
+  // Config modal mirrors it (same class, own id + label).
+  assert.match(modals, /htmlFor="research-studio-config-source"/);
+  assert.match(modals, /id="research-studio-config-source"/);
+  // Sources are no longer chip buttons anywhere.
+  assert.doesNotMatch(source, /research-studio__chip"[\s\S]{0,120}aria-pressed/);
+});
+
+test("thread viewer shows each post's length against the shared budget", () => {
+  // The 280 budget lives in the lib (server clamps with it; viewer counts
+  // with it) — no magic numbers in the surface.
+  assert.match(modals, /RESEARCH_THREAD_POST_MAX_CHARS/);
+  assert.match(modals, /\$\{post\.text\.length\}\/\$\{RESEARCH_THREAD_POST_MAX_CHARS\}/);
+  assert.doesNotMatch(source, /\/280/);
 });
 
 test("familiar switches can't leak another familiar's generations (loadSeq guard)", () => {

--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -7,8 +7,8 @@
  *
  * Honesty contract (see src/lib/research-generations.ts):
  * - Sources are ONLY missions with a live markdown artifact (published or
- *   working) — the same rule the server's drafting uses, so the chips never
- *   offer a run the POST would 409.
+ *   working) — the same rule the server's drafting uses, so the source
+ *   dropdown never offers a run the POST would 409.
  * - The five creatable kinds come from RESEARCH_GENERATION_KINDS; the three
  *   media kinds (podcast / short video / long video) render from
  *   RESEARCH_GENERATION_MEDIA_KINDS as visibly disabled cards with their
@@ -39,6 +39,7 @@ import {
   MarkdownEditorModal,
   STUDIO_KIND_META,
   STUDIO_MEDIA_PRESENTATION,
+  StudioMermaidDiagram,
   generationStatusText,
   generationTitle,
   missionHasMarkdownArtifact,
@@ -211,26 +212,32 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
         <p>Turn finished research into shareable drafts — extracted from each run&rsquo;s cited findings.</p>
       </header>
 
-      <div className="research-studio__sources" role="group" aria-label="Generation source">
-        <span className="research-studio__sources-label">Source:</span>
+      <div className="research-studio__sources">
         {sources.length === 0 ? (
-          <span className="research-studio__sources-hint">
-            No runs with a markdown artifact yet — the Studio drafts from finished research.
-          </span>
+          <>
+            <span className="research-studio__sources-label">Draft from</span>
+            <span className="research-studio__sources-hint">
+              No runs with a markdown artifact yet — the Studio drafts from finished research.
+            </span>
+          </>
         ) : (
-          <div className="research-studio__chips">
-            {sources.map((source) => (
-              <button
-                key={source.id}
-                type="button"
-                className="research-studio__chip"
-                aria-pressed={source.id === effectiveSourceId}
-                onClick={() => setSourceId(source.id)}
-              >
-                {source.title}
-              </button>
-            ))}
-          </div>
+          <>
+            <label className="research-studio__sources-label" htmlFor="research-studio-source">
+              Draft from
+            </label>
+            <select
+              id="research-studio-source"
+              className="research-studio__select"
+              value={effectiveSourceId ?? ""}
+              onChange={(event) => setSourceId(event.target.value)}
+            >
+              {sources.map((source) => (
+                <option key={source.id} value={source.id}>
+                  {source.title}
+                </option>
+              ))}
+            </select>
+          </>
         )}
       </div>
 
@@ -410,7 +417,11 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
                 <span className="research-studio-row__status" data-status={generation.status}>
                   {generationStatusText(generation)}
                 </span>
-                {mermaidOpen ? <pre className="research-studio__code">{mermaid}</pre> : null}
+                {mermaidOpen ? (
+                  <div className="research-studio-row__diagram">
+                    <StudioMermaidDiagram mermaid={mermaid} />
+                  </div>
+                ) : null}
                 {removeError?.id === generation.id ? (
                   <span className="research-studio__error" role="alert">
                     {removeError.message}
@@ -430,7 +441,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
                         )
                       }
                     >
-                      {mermaidOpen ? "⌗ Hide Mermaid" : "⌗ View Mermaid"}
+                      {mermaidOpen ? "◇ Hide diagram" : "◇ View diagram"}
                     </button>
                     <button
                       type="button"

--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -77,9 +77,20 @@ export type ResearchGenerationSlide = {
 export type ResearchGenerationThreadPost = {
   /** Position marker, e.g. "1/4" — pure structure, not content. */
   pre: string;
-  /** Post text lifted from the mission title or artifact claims. */
+  /**
+   * Post text lifted from the mission title or artifact claims, clamped to
+   * RESEARCH_THREAD_POST_MAX_CHARS at a word boundary (mechanical truncation
+   * marked with "…" — never rephrased).
+   */
   text: string;
 };
+
+/**
+ * Social post budget: the thread drafter clamps each post's text to this many
+ * characters (the common short-post ceiling), and the Studio viewer shows the
+ * per-post count against it.
+ */
+export const RESEARCH_THREAD_POST_MAX_CHARS = 280;
 
 export type ResearchGenerationStat = {
   /** The extracted number token, e.g. "4–9×", "$120", "68%". */

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -8,6 +8,7 @@ import type {
   ResearchArtifactRef,
   ResearchMission,
 } from "../research-missions.ts";
+import { RESEARCH_THREAD_POST_MAX_CHARS } from "../research-generations.ts";
 
 const tmp = await mkdtemp(path.join(tmpdir(), "cave-research-generations-"));
 const originalGenerationsDir = process.env.COVEN_RESEARCH_GENERATIONS_DIR;
@@ -333,9 +334,14 @@ test("thread = hook from the mission title + claims from bold lines and headings
   assert.equal(content?.kind, "thread");
   if (content?.kind !== "thread") return;
   const total = content.posts.length;
+  assert.ok(total <= 8, "the thread never exceeds MAX_THREAD_POSTS");
   assert.equal(content.posts[0].text, "Eval-harness pricing landscape", "hook = mission title");
   content.posts.forEach((post, index) => {
     assert.equal(post.pre, `${index + 1}/${total}`, "n/N prefixes are pure structure");
+    assert.ok(
+      post.text.length <= RESEARCH_THREAD_POST_MAX_CHARS,
+      `post ${index + 1} fits the social budget`,
+    );
   });
   assert.ok(
     content.posts.some((post) => post.text === "Retrieval beats stuffing on cost across model families."
@@ -346,6 +352,51 @@ test("thread = hook from the mission title + claims from bold lines and headings
     content.posts.some((post) => post.text.startsWith("Key numbers — ")),
     "heading claims pair the heading with its first bullet",
   );
+  // The closer is fixed boilerplate around verbatim titles (same shape as the
+  // blog provenance line) — the thread always says where it came from.
+  const closer = content.posts[total - 1].text;
+  assert.match(closer, /^Full findings: /);
+  assert.ok(closer.includes("Findings — eval pricing"), "closer names the artifact");
+  assert.ok(closer.includes("Eval-harness pricing landscape"), "closer names the run");
+  // Remaining room is filled with the sections' other bullets, verbatim.
+  assert.ok(
+    content.posts.some((post) => post.text === "200K-token synthesis threshold"),
+    "extra section bullets fill remaining posts",
+  );
+});
+
+test("thread posts clamp at a word boundary and dedupe against the hook", () => {
+  const longClaim =
+    "Retrieval-augmented evaluation pipelines consistently outperform naive context stuffing on both cost and accuracy across every model family we measured, with the gap widening as corpora grow beyond the two-hundred-thousand-token synthesis threshold that hosted tiers meter so aggressively today";
+  assert.ok(longClaim.length > RESEARCH_THREAD_POST_MAX_CHARS, "fixture must exceed the budget");
+  const markdown = [
+    "# Doc",
+    "",
+    `**${longClaim}**`,
+    "",
+    "**Eval-harness pricing landscape** repeated as bold.",
+    "",
+  ].join("\n");
+  const content = draftGenerationContent("thread", {
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown,
+  });
+  assert.equal(content.kind, "thread");
+  if (content.kind !== "thread") return;
+  const clamped = content.posts.find((post) => post.text.endsWith("…"));
+  assert.ok(clamped, "over-budget claims are clamped with a visible ellipsis");
+  assert.ok(clamped.text.length <= RESEARCH_THREAD_POST_MAX_CHARS);
+  assert.ok(
+    longClaim.startsWith(clamped.text.slice(0, -1)),
+    "clamp truncates verbatim text — never rephrases",
+  );
+  assert.notEqual(clamped.text.at(-2), " ", "clamp cuts at a word boundary");
+  // A bold line repeating the mission title doesn't produce a duplicate post.
+  const hookMatches = content.posts.filter(
+    (post) => post.text === "Eval-harness pricing landscape",
+  );
+  assert.equal(hookMatches.length, 1, "the hook is never duplicated by a bold claim");
 });
 
 test("diagram = mermaid built from phase steps + artifact section structure", async () => {

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -7,8 +7,10 @@
  * back to the mission's newest published/working markdown artifact when no
  * primary-lineage ref exists — see pickGenerationSourceArtifact) plus the
  * mission's own phase/step structure. Every content string either comes from
- * the artifact/mission fields verbatim or is pure structure ("graph TD",
- * slide numbering, "1/4" thread markers) — nothing is invented.
+ * the artifact/mission fields verbatim or is pure structure/provenance
+ * boilerplate ("graph TD", slide numbering, "1/4" thread markers, the blog
+ * and thread provenance lines naming the artifact and run) — no facts are
+ * invented.
  *
  * The optional `directions` field is stored verbatim on the record so the UI
  * can display it and a future generation pipeline can consume it, but it is
@@ -27,6 +29,7 @@ import {
   isResearchGenerationStatus,
   isValidResearchGenerationFamiliarId,
   RESEARCH_GENERATION_DIRECTIONS_MAX_LENGTH,
+  RESEARCH_THREAD_POST_MAX_CHARS,
   type CreateResearchGenerationInput,
   type ResearchGeneration,
   type ResearchGenerationContent,
@@ -356,6 +359,19 @@ const MAX_THREAD_POSTS = 8;
 const MAX_INFOGRAPHIC_STATS = 12;
 const MAX_DIAGRAM_SECTIONS = 8;
 
+/**
+ * Word-boundary clamp to the social post budget. Mechanical truncation only —
+ * the ellipsis marks the cut, nothing is rephrased. Cutting mid-word is
+ * avoided unless the first word alone would blow half the budget.
+ */
+function clampThreadPostText(text: string): string {
+  if (text.length <= RESEARCH_THREAD_POST_MAX_CHARS) return text;
+  const slice = text.slice(0, RESEARCH_THREAD_POST_MAX_CHARS - 1);
+  const lastSpace = slice.lastIndexOf(" ");
+  const cut = lastSpace > RESEARCH_THREAD_POST_MAX_CHARS / 2 ? slice.slice(0, lastSpace) : slice;
+  return `${cut.trimEnd()}…`;
+}
+
 export type GenerationDraftSource = {
   mission: Pick<ResearchMission, "id" | "title" | "iterations">;
   artifact: Pick<ResearchArtifactRef, "key" | "title">;
@@ -385,11 +401,19 @@ export function draftSlidesContent(source: GenerationDraftSource): ResearchGener
   return { kind: "slides", slides };
 }
 
-/** Hook from the mission title + key claims from headings and bold lines. */
+/**
+ * Thread: hook from the mission title, claims from bold lines and headings,
+ * extra section bullets while room remains, then a provenance closer naming
+ * the artifact and run (the same fixed-boilerplate-plus-verbatim-titles shape
+ * as the blog draft's provenance line). Every post is clamped to the social
+ * budget at a word boundary.
+ */
 export function draftThreadContent(source: GenerationDraftSource): ResearchGenerationContent {
   const { sections } = extractMarkdownSections(source.markdown);
   const claims: string[] = [];
-  const seen = new Set<string>();
+  // Seed with the hook so a bold line or heading repeating the mission title
+  // can't produce a duplicate post.
+  const seen = new Set<string>([source.mission.title]);
   const push = (text: string) => {
     if (text && !seen.has(text)) {
       seen.add(text);
@@ -401,7 +425,17 @@ export function draftThreadContent(source: GenerationDraftSource): ResearchGener
     const headline = section.bullets[0] ?? section.firstLine;
     push(headline ? `${section.title} — ${headline}` : section.title);
   }
-  const texts = [source.mission.title, ...claims].slice(0, MAX_THREAD_POSTS);
+  // Fill any remaining room with the sections' other bullets, in document
+  // order — more of the artifact's own words, never padding.
+  for (const section of sections) {
+    for (const bullet of section.bullets.slice(1)) push(bullet);
+  }
+  const closer = `Full findings: “${source.artifact.title}” — from the research run “${source.mission.title}”.`;
+  const texts = [
+    source.mission.title,
+    ...claims.slice(0, Math.max(0, MAX_THREAD_POSTS - 2)),
+    closer,
+  ].map(clampThreadPostText);
   const posts: ResearchGenerationThreadPost[] = texts.map((text, index) => ({
     pre: `${index + 1}/${texts.length}`,
     text,

--- a/src/styles/globals/surface-research-studio.css
+++ b/src/styles/globals/surface-research-studio.css
@@ -118,6 +118,35 @@
   color: var(--text-muted);
   font-style: italic;
 }
+/* Native select for the source research run — labelled, one obvious current
+   value, and it scales past the handful of runs chips could. Chevron follows
+   the .required-inputs-select recipe (primitives.css). */
+.research-studio__select {
+  appearance: none;
+  -webkit-appearance: none;
+  max-width: 100%;
+  min-width: 0;
+  padding: var(--space-1) var(--space-8) var(--space-1) var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background-color: color-mix(in oklch, var(--bg-base) 55%, transparent);
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position: calc(100% - 16px) center, calc(100% - 11px) center;
+  background-size: 5px 5px, 5px 5px;
+  background-repeat: no-repeat;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: border-color 120ms ease;
+}
+.research-studio__select:hover {
+  border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
+}
+.research-studio__select:focus-visible {
+  outline: none;
+  border-color: var(--accent-presence, var(--research-accent));
+}
 
 /* ── Generation type grid (design 320–329) ── */
 .research-studio__grid {
@@ -404,6 +433,17 @@
   overflow-x: auto;
   white-space: pre;
 }
+/* Rendered mermaid diagram — MarkdownBlock's .cave-md carries the chat
+   diagram card (cave-md/tables-mermaid.css); this wrapper only sizes it. */
+.research-studio__diagram {
+  min-width: 0;
+}
+.research-studio__diagram .cave-md > .cm-mermaid-diagram {
+  margin: 0;
+}
+.research-studio-row__diagram {
+  margin-top: var(--space-2);
+}
 
 /* ── Notes / errors / empty state ── */
 .research-studio__note {
@@ -577,6 +617,10 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
+.research-studio-config__hint {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
 .research-studio-config__error {
   margin: 0;
   font-size: var(--text-sm);
@@ -712,10 +756,23 @@
   background: var(--research-accent);
 }
 .research-studio-viewer__code-wrap,
-.research-studio-viewer__points {
+.research-studio-viewer__points,
+.research-studio-viewer__diagram {
   display: flex;
   flex-direction: column;
   gap: 6px;
+}
+/* Collapsible mermaid source under the rendered diagram. */
+.research-studio-viewer__code-details summary {
+  cursor: pointer;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.research-studio-viewer__code-details summary:hover {
+  color: var(--text-secondary);
+}
+.research-studio-viewer__code-details[open] summary {
+  margin-bottom: var(--space-2);
 }
 .research-studio-viewer__point-list {
   list-style: none;
@@ -744,6 +801,14 @@
   font-size: var(--text-sm);
   line-height: 1.5;
   color: var(--text-secondary);
+}
+/* Per-post length against the social budget (thread viewer). */
+.research-studio-viewer__point-note {
+  display: block;
+  margin-top: var(--space-1);
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
 }
 .research-studio-viewer__point .research-studio-act--tiny {
   margin-left: auto;
@@ -839,6 +904,7 @@
    Studio moves for users who asked it not to. ── */
 @media (prefers-reduced-motion: reduce) {
   .research-studio__chip,
+  .research-studio__select,
   .research-studio-card,
   .research-studio-act {
     transition: none;

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -439,13 +439,14 @@ test.describe("research desk tabs", () => {
       await expect(media.filter({ hasText: label })).toContainText("not available yet");
     }
 
-    // Create a diagram from the completed mission.
+    // Create a diagram from the completed mission — the source is a labelled
+    // dropdown valued by mission id.
     await studio.locator('button.research-studio-card[data-kind="diagram"]').click();
     const dialog = page.getByRole("dialog", { name: "Generate Diagram" });
     await expect(dialog).toBeVisible();
-    const doneChip = dialog.getByRole("button", { name: COMPLETED_MISSION.title });
-    await doneChip.click();
-    await expect(doneChip).toHaveAttribute("aria-pressed", "true");
+    const sourceSelect = dialog.getByLabel("Research run");
+    await sourceSelect.selectOption(COMPLETED_MISSION.id);
+    await expect(sourceSelect).toHaveValue(COMPLETED_MISSION.id);
     await dialog.getByRole("button", { name: "✦ Generate Diagram" }).click();
 
     // The POST carried the selected mission (directions empty → omitted).
@@ -453,13 +454,30 @@ test.describe("research desk tabs", () => {
       .poll(() => handles.createdGenerationBodies.at(-1))
       .toEqual({ familiarId: FAMILIAR_ID, kind: "diagram", sourceMissionId: COMPLETED_MISSION.id });
 
-    // The ready record renders as a row; its Mermaid is viewable verbatim.
+    // The ready record renders as a row; its diagram renders through the chat
+    // mermaid pipeline (real SVG, not raw source in a <pre>).
     await expect(dialog).toHaveCount(0);
     const row = studio.locator(".research-studio-row", { hasText: "Diagram — Embedded analytics benchmark" });
     await expect(row).toBeVisible();
     await expect(row).toContainText("ready · mermaid");
-    await row.getByRole("button", { name: "⌗ View Mermaid" }).click();
-    await expect(row.locator(".research-studio__code")).toContainText("graph TD;");
+    await row.getByRole("button", { name: "◇ View diagram" }).click();
+    // Two SVGs live in the diagram card (flowchart + expand-button icon) —
+    // assert the mermaid document itself.
+    await expect(
+      row.locator(".cm-mermaid-diagram svg[aria-roledescription]"),
+    ).toBeVisible({ timeout: 20_000 });
+    await row.getByRole("button", { name: "◇ Hide diagram" }).click();
+    await expect(row.locator(".cm-mermaid-diagram")).toHaveCount(0);
+
+    // The viewer modal (opened from the row title) renders the diagram too,
+    // with the mermaid source still inspectable under a disclosure.
+    await row.getByRole("button", { name: "Diagram — Embedded analytics benchmark" }).click();
+    const viewer = page.getByRole("dialog", { name: /Diagram — Embedded analytics benchmark/ });
+    await expect(
+      viewer.locator(".cm-mermaid-diagram svg[aria-roledescription]"),
+    ).toBeVisible({ timeout: 20_000 });
+    await viewer.getByText("Mermaid source").click();
+    await expect(viewer.locator(".research-studio__code")).toContainText("graph TD;");
   });
 
   test("Resources groups links by category and the detail overlay opens and closes with focus handling", async ({ page }) => {


### PR DESCRIPTION
## What

Three Research Desk → Studio improvements (bead `cave-s9uf`):

### 1. Diagram generations render as real mermaid diagrams
- New shared `StudioMermaidDiagram` wraps `MarkdownBlock` with a ````mermaid```` fence, so the Studio inherits the exact chat pipeline: sanitized SVG via `@create-markdown/preview-mermaid`, app theme variables, and the expand-to-fullscreen wiring (`useWireCopyButtons → wireMermaidDiagrams`).
- Row toggle (`◇ View diagram`) and the viewer modal both render the diagram; the viewer keeps the mermaid source inspectable under a `<details>` disclosure, and `⧉ Copy Mermaid` stays.
- `mermaid-viewer.ts` now handles its keys capture-phase with `stopPropagation` and its own Tab cycle, so the fullscreen overlay stacked over the Studio viewer modal doesn't fight the modal's focus trap — one Escape peels one layer.

### 2. Sturdier social-thread drafting (still honest/extractive)
- Every post clamps to a shared 280-char budget (`RESEARCH_THREAD_POST_MAX_CHARS`) at a word boundary — mechanical truncation marked with `…`, never rephrased.
- Hook seeds the dedupe set (a bold line repeating the mission title can't duplicate); leftover room fills with the sections' other bullets verbatim; a provenance closer names the artifact + run (same boilerplate-plus-verbatim-titles shape as the blog provenance line).
- Thread viewer shows each post's length against the budget (`n/280`).

### 3. Source selection is a labelled dropdown
- Tab header ("Draft from") and config modal ("Research run") replace the chip buttons with a native `<select>` (custom-chevron recipe from `.required-inputs-select`) — one obvious current value, scales past a handful of runs, still only offering missions with a live markdown artifact.

## Verification

- `pnpm typecheck`, `pnpm lint` (design gates) clean
- `pnpm test` — 921 files pass; token-drift ratchet unchanged (new CSS fully on-scale)
- Server drafting tests 18/18 incl. new clamp/dedupe/closer coverage
- `tests/research-desk-tabs.spec.ts` — 8/8 pass (desktop, serial); the Studio test now asserts a rendered `.cm-mermaid-diagram` SVG, dropdown `selectOption` flow, and the viewer's source disclosure
- Pre-existing, unrelated: `src/app/api/beads/route.test.ts` fails locally on macOS (`/private/var` tmpdir realpath) — fails identically on `main`; CI (Linux) unaffected.