### PR TITLE
fix(research): clamp mission detail intent to 4 lines with a View more toggle

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -369,7 +369,7 @@ export function ResearchMissionDetail({
                 <time dateTime={mission.updatedAt}>updated {relativeTime(mission.updatedAt) || "just now"}</time>
               </span>
               <h2 id="research-mission-title">{mission.title}</h2>
-              {researchIntentAddsContext(mission) ? <p>{mission.intent}</p> : null}
+              {researchIntentAddsContext(mission) ? <ClampedText lines={4} text={mission.intent} /> : null}
             </div>
             {sessionId ? (
               <Button

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -240,8 +240,9 @@ test("mission list and evidence trajectory expose semantic state", () => {
 
 test("the mission header does not print the intent twice", () => {
   // Short intents become the title verbatim (missionTitle), so the intent
-  // paragraph only renders when it adds information beyond the title.
-  assert.match(detail, /\{researchIntentAddsContext\(mission\) \? <p>\{mission\.intent\}<\/p> : null\}/);
+  // paragraph only renders when it adds information beyond the title — and a
+  // long intent collapses to 4 lines behind ClampedText's View-more toggle.
+  assert.match(detail, /\{researchIntentAddsContext\(mission\) \? <ClampedText lines=\{4\} text=\{mission\.intent\} \/> : null\}/);
 });
 
 test("evidence trajectory statuses come from the shared terminal-truthful reconciler", () => {

--- a/src/components/ui/clamped-text.tsx
+++ b/src/components/ui/clamped-text.tsx
@@ -8,14 +8,19 @@ import { useLayoutEffect, useRef, useState } from "react";
  * the clamp, so short passages render untouched. Pass the surface's own text
  * class through `className` — the clamp composes with its font/colour/rhythm.
  */
+// Static class map — Tailwind only emits classes it can see verbatim.
+const LINE_CLAMP: Record<4 | 8, string> = { 4: "line-clamp-4", 8: "line-clamp-8" };
+
 export function ClampedText({
   text,
   className,
+  lines = 8,
   moreLabel = "View more",
   lessLabel = "View less",
 }: {
   text: string;
   className?: string;
+  lines?: 4 | 8;
   moreLabel?: string;
   lessLabel?: string;
 }) {
@@ -55,7 +60,7 @@ export function ClampedText({
     <div className="flex flex-col items-start gap-1.5">
       <p
         ref={ref}
-        className={`${className ?? ""} ${expanded ? "line-clamp-none" : "line-clamp-8"}`.trim()}
+        className={`${className ?? ""} ${expanded ? "line-clamp-none" : LINE_CLAMP[lines]}`.trim()}
       >
         {text}
       </p>


### PR DESCRIPTION
## Problem

In the research desk mission detail, the intent paragraph under the title rendered in full. A long research prompt (e.g. a multi-paragraph "Research Prompt: 3D Cave Interface…" brief) filled the whole viewport and pushed the stepper, bound meter, and actions below the fold.

## Change

- `src/components/ui/clamped-text.tsx` — added a `lines?: 4 | 8` prop (default `8`) backed by a static class map, so Tailwind emits both `line-clamp-4` and `line-clamp-8`. No behavior change for existing callers.
- `src/components/role-surfaces/research-mission-detail.tsx` — the header intent renders through `<ClampedText lines={4} …/>` instead of a bare `<p>`. The View more / View less toggle only appears when the text actually overflows, so short intents render untouched.
- `src/components/role-surfaces/researcher-surface.test.ts` — updated the markup-pinning assertion for the new element.

Reusing `ClampedText` (rather than a new CSS clamp) keeps the measure-on-reflow, reset-on-text-change, and `aria-expanded` behavior that component already owns.

## Verification

- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --test src/components/ui/clamped-text.test.ts src/components/role-surfaces/researcher-surface.test.ts src/components/role-surfaces/research-tab-desk.test.ts` → 54 pass / 0 fail
- `pnpm exec eslint` on both changed components → clean
- `pnpm exec tsc --noEmit` → clean