### PR TITLE
feat(voice): signature Piper voice roster + mouth-engine badge parity (cave-vony)

### DIFF
--- a/src/components/voice-call-overlay-state.test.ts
+++ b/src/components/voice-call-overlay-state.test.ts
@@ -60,15 +60,19 @@ test("CONNECTED carries the ears engine label for the live UI (cave-vpe1)", () =
     type: "CONNECTED",
     startedAt: Date.now(),
     earsEngine: "native-on-device",
+    mouthEngine: "sidecar-piper",
   });
   assert.equal(next.state, "live");
   assert.equal(next.earsEngine, "native-on-device");
+  // The mouth engine rides the same event for badge parity (cave-vony).
+  assert.equal(next.mouthEngine, "sidecar-piper");
   // Realtime providers report no ears mode — the field simply stays unset.
   const bare = reduce(
     { ...initialState, state: "connecting", callId: "c1" },
     { type: "CONNECTED", startedAt: 1 },
   );
   assert.equal(bare.earsEngine, undefined);
+  assert.equal(bare.mouthEngine, undefined);
 });
 
 test("connecting → closed on CLOSE_REQUEST (clean cancel, no error)", () => {

--- a/src/components/voice-call-overlay-state.ts
+++ b/src/components/voice-call-overlay-state.ts
@@ -1,4 +1,4 @@
-import type { VoiceEarsEngine } from "@/lib/voice/types";
+import type { VoiceEarsEngine, VoiceMouthEngine } from "@/lib/voice/types";
 
 export type CallStateName =
   | "idle"
@@ -20,6 +20,7 @@ export type CallState = {
   hint?: string;
   /** How a live loop-based call hears (cave-vpe1); unset for realtime providers. */
   earsEngine?: VoiceEarsEngine;
+  mouthEngine?: VoiceMouthEngine;
 };
 
 export const initialState: CallState = { state: "idle", muted: false };
@@ -30,7 +31,7 @@ export type CallEvent =
   | { type: "MIC_DENIED" }
   | { type: "SESSION_GRANTED"; callId: string }
   | { type: "SESSION_FAILED"; errorCode: string; missingKey?: string; hint?: string }
-  | { type: "CONNECTED"; startedAt: number; earsEngine?: VoiceEarsEngine }
+  | { type: "CONNECTED"; startedAt: number; earsEngine?: VoiceEarsEngine; mouthEngine?: VoiceMouthEngine }
   | { type: "DISCONNECTED" }
   | { type: "PROVIDER_ERROR"; errorCode: string; hint?: string }
   | { type: "CLOSE_REQUEST" }
@@ -60,7 +61,7 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
       };
     case "CONNECTED":
       if (s.state !== "connecting") return s;
-      return { ...s, state: "live", startedAt: ev.startedAt, earsEngine: ev.earsEngine };
+      return { ...s, state: "live", startedAt: ev.startedAt, earsEngine: ev.earsEngine, mouthEngine: ev.mouthEngine };
     case "PROVIDER_ERROR":
       // Explicitly clear missingKey — a stale key name from an earlier mint
       // failure must not dress an unrelated connect error as key-fixable.

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -145,8 +145,8 @@ assert.match(
 // dictation/browser modes tell the user their audio rides a service.
 assert.match(
   component,
-  /dispatch\(\{\s*type:\s*"CONNECTED",\s*startedAt:\s*Date\.now\(\),\s*earsEngine:\s*live\.earsEngine\s*\}\)/,
-  "CONNECTED carries the LiveSession's ears engine into call state",
+  /dispatch\(\{\s*type:\s*"CONNECTED",\s*startedAt:\s*Date\.now\(\),\s*earsEngine:\s*live\.earsEngine,\s*mouthEngine:\s*live\.mouthEngine\s*\}\)/,
+  "CONNECTED carries the LiveSession's ears and mouth engines into call state",
 );
 assert.match(
   component,
@@ -155,8 +155,18 @@ assert.match(
 );
 assert.match(
   component,
+  /state\.state === "live" && state\.mouthEngine && \(/,
+  "live calls render the mouth-engine badge when a loop provider reports one (cave-vony)",
+);
+assert.match(
+  component,
   /case "native-on-device": return "Hearing on-device";[\s\S]{0,120}case "native-dictation": return "Hearing via Apple dictation";[\s\S]{0,120}case "web-speech": return "Hearing via browser speech";/,
   "every ears engine mode has an honest human label",
+);
+assert.match(
+  component,
+  /case "sidecar-piper": return "Speaking via local Piper";[\s\S]{0,120}case "elevenlabs": return "Speaking via ElevenLabs";[\s\S]{0,120}case "system-synth": return "Speaking via system voice";/,
+  "every mouth engine mode has an honest human label (cave-vony)",
 );
 assert.match(
   component,

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -8,7 +8,7 @@ import { Icon } from "@iconify/react";
 import type { Familiar } from "@/lib/types";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { getVoiceProvider } from "@/lib/voice/registry";
-import type { LiveSession, VoiceSessionGrant, VoiceEarsEngine } from "@/lib/voice/types";
+import type { LiveSession, VoiceSessionGrant, VoiceEarsEngine, VoiceMouthEngine } from "@/lib/voice/types";
 import { voiceErrorHint } from "@/lib/voice/types";
 import { voiceRecoveryVaultKey } from "@/lib/voice/vault-key-recovery";
 import { reduce, initialState, type CallState } from "./voice-call-overlay-state";
@@ -95,7 +95,7 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           if (cancelled) { await live.close(); return; }
           liveRef.current = live;
           if (audioElRef.current) audioElRef.current.srcObject = live.inboundAudio;
-          dispatch({ type: "CONNECTED", startedAt: Date.now(), earsEngine: live.earsEngine });
+          dispatch({ type: "CONNECTED", startedAt: Date.now(), earsEngine: live.earsEngine, mouthEngine: live.mouthEngine });
         } catch (err) {
           dispatch({
             type: "PROVIDER_ERROR",
@@ -222,6 +222,11 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
               {earsEngineLabel(state.earsEngine)}
             </span>
           )}
+          {state.state === "live" && state.mouthEngine && (
+            <span className="voice-call-overlay__mouth" title="How this call speaks to you">
+              {mouthEngineLabel(state.mouthEngine)}
+            </span>
+          )}
           {state.state === "error" && (
             <div className="voice-call-overlay__error" role="alert">
               <div id="voice-call-overlay-error">{errorMessage(state.errorCode)}</div>
@@ -304,6 +309,16 @@ function earsEngineLabel(engine: VoiceEarsEngine): string {
     case "native-on-device": return "Hearing on-device";
     case "native-dictation": return "Hearing via Apple dictation";
     case "web-speech": return "Hearing via browser speech";
+  }
+}
+
+// Mouth parity with the ears badge (cave-vony): local Piper is the no-cloud
+// promise kept; the other modes tell the user where synthesis runs.
+function mouthEngineLabel(engine: VoiceMouthEngine): string {
+  switch (engine) {
+    case "sidecar-piper": return "Speaking via local Piper";
+    case "elevenlabs": return "Speaking via ElevenLabs";
+    case "system-synth": return "Speaking via system voice";
   }
 }
 

--- a/src/lib/voice/elevenlabs.ts
+++ b/src/lib/voice/elevenlabs.ts
@@ -204,6 +204,7 @@ async function connect(
       voiceId: connection.voiceId || DEFAULT_ELEVENLABS_VOICE_ID,
       modelId: connection.modelId || DEFAULT_ELEVENLABS_MODEL_ID,
     }),
+    mouthEngine: "elevenlabs",
     callbacks,
     brainErrorCode: "familiar_brain_failed",
     brainErrorHint: FAMILIAR_BRAIN_ERROR_HINT,

--- a/src/lib/voice/familiar-brain.ts
+++ b/src/lib/voice/familiar-brain.ts
@@ -132,6 +132,7 @@ async function connect(
     mouth: localVoice
       ? createLocalTtsMouth({ voiceName: localVoice })
       : undefined,
+    mouthEngine: localVoice ? "sidecar-piper" : undefined,
     ears: preferredEars?.factory,
     earsEngine: preferredEars?.engine,
     callbacks,

--- a/src/lib/voice/local-loop.ts
+++ b/src/lib/voice/local-loop.ts
@@ -149,6 +149,7 @@ async function connect(
     mouth: localVoice
       ? createLocalTtsMouth({ voiceName: localVoice })
       : undefined,
+    mouthEngine: localVoice ? "sidecar-piper" : undefined,
     ears: preferredEars?.factory,
     earsEngine: preferredEars?.engine,
     callbacks,

--- a/src/lib/voice/speech-loop.test.ts
+++ b/src/lib/voice/speech-loop.test.ts
@@ -99,7 +99,7 @@ function fakeMouth() {
   };
 }
 
-function loopFixture({ brain, earsEngine } = {}) {
+function loopFixture({ brain, earsEngine, mouthEngine } = {}) {
   const ears = fakeEars();
   const mic = fakeMic();
   const mouth = fakeMouth();
@@ -109,6 +109,7 @@ function loopFixture({ brain, earsEngine } = {}) {
     ears: ears.factory,
     earsEngine,
     mouth: mouth.mouth,
+    mouthEngine,
     callbacks: {
       onUserTranscriptFinal: (t) => events.userFinals.push(t),
       onAssistantTranscriptFinal: (t) => events.assistantFinals.push(t),
@@ -193,6 +194,17 @@ test("the session reports how it hears from the supplied ears' label (cave-vpe1)
   // …and injected ears without a label stay unlabeled rather than lying.
   const unlabeled = loopFixture();
   assert.equal(unlabeled.session.earsEngine, undefined);
+});
+
+test("the session reports how it speaks from the supplied mouth's label (cave-vony)", () => {
+  // Injected mouths surface the provider's engine label…
+  const piper = loopFixture({ mouthEngine: "sidecar-piper" });
+  assert.equal(piper.session.mouthEngine, "sidecar-piper");
+  const eleven = loopFixture({ mouthEngine: "elevenlabs" });
+  assert.equal(eleven.session.mouthEngine, "elevenlabs");
+  // …and injected mouths without a label stay unlabeled rather than lying.
+  const unlabeled = loopFixture();
+  assert.equal(unlabeled.session.mouthEngine, undefined);
 });
 
 test("without injected ears and without a window engine the loop refuses with stt_unavailable", () => {

--- a/src/lib/voice/speech-loop.ts
+++ b/src/lib/voice/speech-loop.ts
@@ -18,7 +18,7 @@
 // talking before the harness turn finishes) while recognition stays hushed
 // until the whole queue drains.
 
-import type { LiveSession, VoiceCallbacks, VoiceEarsEngine } from "./types.ts";
+import type { LiveSession, VoiceCallbacks, VoiceEarsEngine, VoiceMouthEngine } from "./types.ts";
 import { VoiceConnectError } from "./types.ts";
 
 /** One user turn in → the full final reply text out. Implementations may call
@@ -218,6 +218,10 @@ export type SpeechLoopOptions = {
   voiceName?: string;
   /** Custom mouth (e.g. ElevenLabs TTS). Defaults to the system synthesizer. */
   mouth?: SpeechMouth;
+  /** Engine label for the supplied `mouth`, surfaced on the LiveSession so
+   *  the call UI can say how it speaks (cave-vony). Ignored when `mouth` is
+   *  absent — the system-synth fallback labels itself. */
+  mouthEngine?: VoiceMouthEngine;
   /** Custom ears (e.g. the native macOS engine). Defaults to WebSpeech. */
   ears?: SpeechEarsFactory;
   /** Engine label for the supplied `ears`, surfaced on the LiveSession so
@@ -364,6 +368,9 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
     // How this call hears (cave-vpe1): the supplied ears' label, or the
     // WebSpeech fallback labeling itself.
     earsEngine: opts.ears ? opts.earsEngine : "web-speech",
+    // How this call speaks (cave-vony): the supplied mouth's label, or the
+    // system-synth fallback labeling itself.
+    mouthEngine: opts.mouth ? opts.mouthEngine : "system-synth",
     setMuted(next: boolean) {
       muted = next;
       for (const track of mic.getAudioTracks()) track.enabled = !next;

--- a/src/lib/voice/speech-models.test.ts
+++ b/src/lib/voice/speech-models.test.ts
@@ -141,6 +141,50 @@ test("Piper Amy registry metadata matches the reviewed pinned artifact", () => {
   );
 });
 
+// The signature-voice roster (cave-vony): every entry pins the reviewed
+// artifact at the same vetted piper-voices revision as Amy, and only
+// redistribution-safe licenses ship (CC BY-NC-SA and custom-licensed voices
+// were rejected during vetting).
+test("signature voice roster pins reviewed artifacts with vetted licenses", () => {
+  const roster = [
+    {
+      id: "piper-alba-medium-en-gb",
+      sha256: "401369c4a81d09fdd86c32c5c864440811dbdcc66466cde2d64f7133a66ad03b",
+      companionSha256: "aa965a2f02ecced632c2694e1fc72bbff6d65f265fab567ca945918c73dd89f4",
+      license: "CC-BY-4.0",
+    },
+    {
+      id: "piper-joe-medium-en-us",
+      sha256: "58afce0321b8d9c46d7cdf9c16500cc55a793b4220212dba6b70fb788b3baf06",
+      companionSha256: "3d6d5410b3795cb1950595247ef8f06190719e6fdbfa3a2356d8ec368e1aad33",
+      license: "CC0-1.0",
+    },
+    {
+      id: "piper-kristin-medium-en-us",
+      sha256: "5849957f929cbf720c258f8458692d6103fff2f0e3d3b19c8259474bb06a18d4",
+      companionSha256: "5681426d4aead22195de70531eeeeddb46493cfaffc5764b2ea3db73428b651c",
+      license: "Public domain (LibriVox dataset)",
+    },
+  ];
+  for (const expected of roster) {
+    const entry = SPEECH_MODEL_REGISTRY.find((model) => model.id === expected.id);
+    assert.ok(entry, `${expected.id} is registered`);
+    assert.equal(entry.engine, "piper");
+    assert.equal(entry.kind, "tts");
+    assert.equal(entry.sha256, expected.sha256);
+    assert.equal(entry.license, expected.license);
+    // Voice ids double as local TTS voiceNames — they must satisfy the
+    // route's validation pattern or the voice can never synthesize.
+    assert.match(entry.id, /^(?:piper|kokoro)-[a-z0-9][a-z0-9-]*$/);
+    // Piper needs the config beside the weights; an entry without its
+    // companion would advertise an unusable voice.
+    assert.equal(entry.companion?.sha256, expected.companionSha256);
+    // Same pinned revision as Amy: artifacts can't drift under re-review.
+    assert.match(entry.url, /\/resolve\/0d907f158acc877ddeebcbf827659ee13bea8bcd\//);
+    assert.match(entry.companion?.url ?? "", /\/resolve\/0d907f158acc877ddeebcbf827659ee13bea8bcd\//);
+  }
+});
+
 test("Piper readiness requires its verified config companion", async () => {
   const root = testRoot("companion");
   await rm(root, { recursive: true, force: true });

--- a/src/lib/voice/speech-models.ts
+++ b/src/lib/voice/speech-models.ts
@@ -103,6 +103,60 @@ export const SPEECH_MODEL_REGISTRY: readonly SpeechModelRegistryEntry[] = [
       fileName: "en_US-amy-medium.onnx.json",
     },
   },
+  // Signature voice roster (cave-vony): only license-vetted voices ship here.
+  // Rejected during vetting: ryan/hfc_male/hfc_female (CC BY-NC-SA datasets),
+  // lessac (custom Blizzard license).
+  {
+    id: "piper-alba-medium-en-gb",
+    name: "Piper Alba medium en_GB",
+    engine: "piper",
+    kind: "tts",
+    url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_GB/alba/medium/en_GB-alba-medium.onnx",
+    sha256: "401369c4a81d09fdd86c32c5c864440811dbdcc66466cde2d64f7133a66ad03b",
+    sizeBytes: 63_201_294,
+    license: "CC-BY-4.0",
+    fileName: "en_GB-alba-medium.onnx",
+    companion: {
+      url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_GB/alba/medium/en_GB-alba-medium.onnx.json",
+      sha256: "aa965a2f02ecced632c2694e1fc72bbff6d65f265fab567ca945918c73dd89f4",
+      sizeBytes: 4_888,
+      fileName: "en_GB-alba-medium.onnx.json",
+    },
+  },
+  {
+    id: "piper-joe-medium-en-us",
+    name: "Piper Joe medium en_US",
+    engine: "piper",
+    kind: "tts",
+    url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/joe/medium/en_US-joe-medium.onnx",
+    sha256: "58afce0321b8d9c46d7cdf9c16500cc55a793b4220212dba6b70fb788b3baf06",
+    sizeBytes: 63_201_294,
+    license: "CC0-1.0",
+    fileName: "en_US-joe-medium.onnx",
+    companion: {
+      url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/joe/medium/en_US-joe-medium.onnx.json",
+      sha256: "3d6d5410b3795cb1950595247ef8f06190719e6fdbfa3a2356d8ec368e1aad33",
+      sizeBytes: 4_794,
+      fileName: "en_US-joe-medium.onnx.json",
+    },
+  },
+  {
+    id: "piper-kristin-medium-en-us",
+    name: "Piper Kristin medium en_US",
+    engine: "piper",
+    kind: "tts",
+    url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/kristin/medium/en_US-kristin-medium.onnx",
+    sha256: "5849957f929cbf720c258f8458692d6103fff2f0e3d3b19c8259474bb06a18d4",
+    sizeBytes: 63_531_379,
+    license: "Public domain (LibriVox dataset)",
+    fileName: "en_US-kristin-medium.onnx",
+    companion: {
+      url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/kristin/medium/en_US-kristin-medium.onnx.json",
+      sha256: "5681426d4aead22195de70531eeeeddb46493cfaffc5764b2ea3db73428b651c",
+      sizeBytes: 4_968,
+      fileName: "en_US-kristin-medium.onnx.json",
+    },
+  },
 ] as const;
 
 const jobs = new Map<string, SpeechModelDownloadJob>();

--- a/src/lib/voice/types.ts
+++ b/src/lib/voice/types.ts
@@ -56,6 +56,10 @@ export interface LiveSession {
    *  providers (cave-vpe1). Cloud realtime sessions (their model IS the
    *  ears) leave it unset. */
   earsEngine?: VoiceEarsEngine;
+  /** Which synthesis engine this call's mouth speaks through, for loop-based
+   *  providers (cave-vony). Cloud realtime sessions (their model IS the
+   *  mouth) leave it unset. */
+  mouthEngine?: VoiceMouthEngine;
 }
 
 /** Recognition engine behind a speech-loop call's ears:
@@ -72,6 +76,16 @@ export type VoiceEarsEngine =
   | "native-on-device"
   | "native-dictation"
   | "web-speech";
+
+/** Synthesis engine behind a speech-loop call's mouth (cave-vony):
+ *  - "sidecar-piper": a downloaded Piper voice rendered by Cave's local
+ *    sidecar; audio never leaves this device.
+ *  - "elevenlabs": ElevenLabs cloud TTS.
+ *  - "system-synth": the platform's speechSynthesis voices. */
+export type VoiceMouthEngine =
+  | "sidecar-piper"
+  | "elevenlabs"
+  | "system-synth";
 
 /**
  * Connection-phase error: `message` stays a stable machine code (e.g.

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -908,11 +908,14 @@ details[open] > .cave-tool-summary::before {
   display: grid;
   min-height: 120px;
   place-items: center;
+  gap: var(--space-2);
   padding: var(--space-5) var(--space-4);
 }
 
-/* How the call hears (cave-vpe1): honest engine label on live calls. */
-.voice-call-overlay__ears {
+/* How the call hears (cave-vpe1) and speaks (cave-vony): honest engine
+   labels on live calls. */
+.voice-call-overlay__ears,
+.voice-call-overlay__mouth {
   font-size: var(--text-xs);
   color: var(--text-muted);
   border: 1px solid var(--border-hairline);


### PR DESCRIPTION
## What

Closes out the actionable residuals of umbrella bead **cave-vony** (sidecar voice engines).

### 1. Signature voice roster — 3 new license-vetted Piper voices
All pinned at the same `rhasspy/piper-voices` revision (`0d907f15…`) as the existing Amy entry, with sha256+size verified for both the ONNX weights (via HF LFS pointers) and the `.onnx.json` companions (hashed locally):

| id | voice | license |
|---|---|---|
| `piper-alba-medium-en-gb` | Alba, en_GB | CC BY 4.0 |
| `piper-joe-medium-en-us` | Joe, en_US | CC0-1.0 |
| `piper-kristin-medium-en-us` | Kristin, en_US | Public domain (LibriVox) |

Rejected during vetting (documented in-source): ryan / hfc_male / hfc_female (CC BY-NC-SA), lessac (custom Blizzard license). Registry ids double as local-TTS `voiceName`s, so these are downloadable + selectable with zero further wiring.

### 2. `mouthEngine` — badge parity with `earsEngine` (cave-vpe1)
Live calls now say how they **speak**, not just how they hear:
- `VoiceMouthEngine` = `sidecar-piper | elevenlabs | system-synth`; surfaced on `LiveSession`.
- `connectSpeechLoop` mirrors the ears pattern — the system-synth fallback labels itself; suppliers of a custom mouth label it (`local-loop`/`familiar-brain`: `sidecar-piper` only when a local voice actually drives the mouth; `elevenlabs`: its cloud leg).
- Overlay renders "Speaking via local Piper / ElevenLabs / system voice" beside the ears badge.

### 3. Kokoro runtime spun off → **cave-tr09i**
Kokoro is typed and voiceName-validated end-to-end but `local-tts-server.ts` only spawns a piper binary — adding a kokoro registry row today would advertise a voice that can never synthesize. Filed with full scope; no kokoro row ships here.

## Testing
- `speech-models.test.ts`: new roster-pin test (pinned revision, vetted licenses, voiceName pattern, companions present)
- `speech-loop.test.ts`: mouthEngine labeling (supplied label surfaces; unlabeled mouths stay unlabeled)
- `voice-call-overlay-state.test.ts` + `voice-call-overlay.test.ts`: CONNECTED carries mouthEngine; badge + honest-label source pins
- Full app suite, `pnpm typecheck`, `pnpm lint` — green (one unrelated flake, `opencoven-tools-resolve.test.ts`, passes clean on re-run on both this branch and main)

Bead: cave-vony