### PR TITLE
feat(research): rail becomes one Artifacts|Sources toggle over a full-height pane

### DIFF
--- a/src/components/role-surfaces/research-evidence-ledger.tsx
+++ b/src/components/role-surfaces/research-evidence-ledger.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
-import { Tabs } from "@/components/ui/tabs";
 import { Icon } from "@/lib/icon";
 import {
   researchSourceStatusCounts,
@@ -14,10 +13,27 @@ import {
 import { relativeTime } from "@/lib/relative-time";
 import { ResearchArtifactActions } from "./research-artifact-actions";
 
+export type ResearchOutputTab = "artifacts" | "sources";
+
 type Props = {
   mission: ResearchMission;
   onAction(input: ResearchMissionActionInput): Promise<{ ok: boolean; error?: string }>;
   onOpenUrl(url: string): void;
+  /**
+   * Which pane to show. The tablist lives in the caller (the desk rail owns the
+   * Artifacts/Sources toggle), so the ledger renders one pane's worth of
+   * content and never its own tabs.
+   */
+  tab: ResearchOutputTab;
+  /** One line of run context above the visible pane (pass state, bound progress). */
+  hint?: ReactNode;
+  /**
+   * Checkpoint triage: offer Keep / Reject / Verify next pass on the sources
+   * still awaiting a verdict, alongside the always-available status control.
+   */
+  triage?: boolean;
+  /** Live runs mark the most recently arrived source so streaming reads. */
+  highlightLatest?: boolean;
 };
 
 const SOURCE_STATUSES: ResearchSourceRef["status"][] = [
@@ -27,14 +43,24 @@ const SOURCE_STATUSES: ResearchSourceRef["status"][] = [
   "rejected",
 ];
 
-export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) {
+/** Appended to a source note so "verify next pass" survives into the next run. */
+export const VERIFY_NOTE = "Verify next pass";
+
+export function ResearchEvidenceLedger({
+  mission,
+  onAction,
+  onOpenUrl,
+  tab,
+  hint,
+  triage = false,
+  highlightLatest = false,
+}: Props) {
   const { announce } = useAnnouncer();
   const [title, setTitle] = useState("");
   const [url, setUrl] = useState("");
   const [rejection, setRejection] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [outputTab, setOutputTab] = useState<"artifacts" | "sources">("artifacts");
   const [sourceFilter, setSourceFilter] = useState<"all" | ResearchSourceRef["status"]>("all");
   // Tracks the mission currently on screen so an act that settles after the
   // user switched missions is discarded instead of planting its error/busy
@@ -59,6 +85,12 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
   const visibleSources = sourceFilter === "all"
     ? mission.sources
     : mission.sources.filter((source) => source.status === sourceFilter);
+  // Live runs mark the newest source so a streaming ledger reads as moving.
+  // The ledger is append-ordered, so "newest" is the last entry — no invented
+  // timestamps.
+  const latestSourceId = highlightLatest && mission.sources.length > 0
+    ? mission.sources[mission.sources.length - 1].id
+    : null;
   // Publishing is offered on settled missions only — a cancelled/archived run
   // should not gain a fresh Grimoire entry after the fact.
   const settled = ["checkpoint", "completed", "failed"].includes(mission.status);
@@ -118,33 +150,23 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
   };
 
   return (
-    <aside className="research-output-shelf" aria-label="Research outputs">
-      <Tabs<"artifacts" | "sources">
-        className="research-output-tabs"
-        idPrefix="research-output"
-        ariaLabel="Research output type"
-        size="sm"
-        fill
-        value={outputTab}
-        onChange={setOutputTab}
-        items={[
-          { id: "artifacts", label: "Artifacts", count: mission.artifacts.length },
-          { id: "sources", label: "Sources", count: mission.sources.length },
-        ]}
-      />
+    <div className="research-output-shelf">
       {/* Panels below are keyed by mission so uncontrolled disclosure state
           (reject editors, the attach form) can never survive a mission switch —
           colliding per-mission artifact/source key shapes would otherwise let
           DOM reuse attach open state to the wrong mission's rows. */}
       {error ? <p className="research-mission-error" role="alert">{error}</p> : null}
+      {hint ? <p className="research-desk-rail__hint">{hint}</p> : null}
       <section
         id="research-output-panel-artifacts"
         key={`artifacts-${mission.id}`}
         role="tabpanel"
         aria-labelledby="research-output-tab-artifacts"
-        hidden={outputTab !== "artifacts"}
+        hidden={tab !== "artifacts"}
       >
-        <h3>Artifacts</h3>
+        {/* The rail's toggle is the visible label for this pane; the heading
+            stays for screen readers so the tabpanel keeps a name. */}
+        <h3 className="sr-only">Artifacts</h3>
         {mission.artifacts.length === 0 ? (
           <p className="research-output-empty">Working artifacts appear here.</p>
         ) : (
@@ -201,9 +223,9 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
         key={`sources-${mission.id}`}
         role="tabpanel"
         aria-labelledby="research-output-tab-sources"
-        hidden={outputTab !== "sources"}
+        hidden={tab !== "sources"}
       >
-        <h3>Sources</h3>
+        <h3 className="sr-only">Sources</h3>
         <details className="research-source-attach-disclosure">
           <summary>Attach source</summary>
           <form className="research-source-attach" onSubmit={attach}>
@@ -253,7 +275,10 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
         ) : (
           <ul>
             {visibleSources.map((source) => (
-              <li key={source.id} className="research-source-card">
+              <li
+                key={source.id}
+                className={`research-source-card${source.id === latestSourceId ? " is-latest" : ""}`}
+              >
                 <span className={`research-source-status research-source-status--${source.status}`}>
                   <i aria-hidden />{source.status}
                 </span>
@@ -271,6 +296,57 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
                   <strong>{source.title}</strong>
                 )}
                 {source.claim ? <p>{source.claim}</p> : null}
+                {source.id === latestSourceId ? (
+                  <span className="sr-only">Most recently added</span>
+                ) : null}
+                {/* Checkpoint triage: the verdicts the pass is actually waiting
+                    on, as one-tap buttons. The status control below stays for
+                    revisiting any source at any time. */}
+                {triage && (source.status === "candidate" || source.status === "conflicting") ? (
+                  <div className="research-desk-delta__actions">
+                    <Button
+                      size="xs"
+                      variant="secondary"
+                      disabled={busy}
+                      onClick={() => void act({
+                        action: "update-source",
+                        sourceId: source.id,
+                        patch: { status: "used" },
+                      })}
+                    >
+                      Keep
+                    </Button>
+                    <Button
+                      size="xs"
+                      variant="secondary"
+                      disabled={busy}
+                      onClick={() => void act({
+                        action: "update-source",
+                        sourceId: source.id,
+                        patch: { status: "rejected" },
+                      })}
+                    >
+                      Reject
+                    </Button>
+                    {source.status === "conflicting" ? (
+                      <Button
+                        size="xs"
+                        variant="ghost"
+                        disabled={busy || (source.note ?? "").includes(VERIFY_NOTE)}
+                        onClick={() => void act({
+                          action: "update-source",
+                          sourceId: source.id,
+                          patch: {
+                            status: "conflicting",
+                            note: source.note ? `${source.note}\n${VERIFY_NOTE}` : VERIFY_NOTE,
+                          },
+                        })}
+                      >
+                        Verify next pass
+                      </Button>
+                    ) : null}
+                  </div>
+                ) : null}
                 <label className="research-source-revise">
                   <span className="sr-only">Status of {source.title}</span>
                   <select
@@ -291,6 +367,6 @@ export function ResearchEvidenceLedger({ mission, onAction, onOpenUrl }: Props) 
           </ul>
         )}
       </section>
-    </aside>
+    </div>
   );
 }

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -24,6 +24,7 @@ import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { CitationSources } from "@/components/ui/citation";
 import { ClampedText } from "@/components/ui/clamped-text";
+import { Tabs } from "@/components/ui/tabs";
 import { sourcesToCitations } from "@/lib/citations";
 import { copyText } from "@/lib/clipboard";
 import { Icon } from "@/lib/icon";
@@ -43,7 +44,7 @@ import {
 import { relativeTime } from "@/lib/relative-time";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { ResearchArtifactActions, fetchResearchWorkspacePath } from "./research-artifact-actions";
-import { ResearchEvidenceLedger } from "./research-evidence-ledger";
+import { ResearchEvidenceLedger, type ResearchOutputTab } from "./research-evidence-ledger";
 
 type Props = {
   mission: ResearchMission | null;
@@ -88,7 +89,6 @@ const END_ACTIONS: ReadonlySet<ResearchMissionAction> = new Set(["cancel", "arch
 
 /** Note marker appended by "Verify next pass" — the source stays conflicting
  *  so the agent re-checks it, and the marker records the request. */
-const VERIFY_NOTE = "Verify next pass";
 
 const LIVE_STATUSES = new Set<ResearchMission["status"]>(["queued", "planning", "running"]);
 
@@ -114,6 +114,23 @@ export function ResearchMissionDetail({
   // by copyTimer below.
   const [workspaceCopied, setWorkspaceCopied] = useState(false);
   const missionId = mission?.id ?? null;
+  // Which rail pane opens on a fresh mission: a run still gathering or waiting
+  // on triage opens on Sources; a settled run opens on what it produced.
+  const missionStatus = mission?.status ?? null;
+  const defaultRailTab: ResearchOutputTab = missionStatus
+    && (missionStatus === "checkpoint" || missionStatus === "paused" || LIVE_STATUSES.has(missionStatus))
+    ? "sources"
+    : "artifacts";
+  const [railTab, setRailTab] = useState<ResearchOutputTab>(defaultRailTab);
+  // A mission switch re-opens the rail on that mission's default pane. Deriving
+  // it during render (React's derive-state-from-props pattern) avoids painting
+  // one frame of the previous mission's pane choice; a status change inside the
+  // same mission leaves the reader's chosen pane alone.
+  const [railTabMission, setRailTabMission] = useState(missionId);
+  if (railTabMission !== missionId) {
+    setRailTabMission(missionId);
+    setRailTab(defaultRailTab);
+  }
   // Tracks the mission currently on screen so an action that settles after
   // the user switched missions is discarded instead of applying its
   // busy/error/announce state to the wrong mission's view.
@@ -175,10 +192,20 @@ export function ResearchMissionDetail({
   );
   const isCheckpointLike = mission.status === "checkpoint" || mission.status === "paused";
   const isLive = LIVE_STATUSES.has(mission.status);
+  // One line of run context above the open pane — the state the two stacked
+  // rail panels used to carry in their titles and hints.
+  const railHint = railTab === "sources"
+    ? isCheckpointLike
+      ? `Evidence delta — pass ${iteration?.number ?? 0}. Triage now or leave it for the agent to resolve next pass.`
+      : isLive
+        ? `${mission.sources.length} of ${mission.bounds.sourceTarget} targeted — streaming in, review anytime.`
+        : null
+    : mission.status === "failed" && iteration
+      ? `From pass ${iteration.number}.`
+      : null;
   // Archived missions are read-only: automation controls gate on this the
   // same way "Create schedule" already does.
   const isArchived = mission.status === "archived";
-  const showArtifactRail = !isCheckpointLike && !isLive;
 
   // Root-blocked failures get a self-healing Retry: untouched config clears the
   // rejected root so the retried iteration runs in the mission workspace.
@@ -229,16 +256,6 @@ export function ResearchMissionDetail({
     } finally {
       if (stillCurrent()) setBusy(false);
     }
-  };
-  // Publishing is offered on settled missions only — a cancelled/archived run
-  // should not gain a fresh Grimoire entry after the fact.
-  const settled = ["checkpoint", "completed", "failed"].includes(mission.status);
-  const publishArtifact = (artifactKey: string) => {
-    void runMissionAction(
-      "Artifact could not be published",
-      () => onAction({ action: "publish-artifact", artifactKey }),
-      () => announce("Artifact published to the Grimoire."),
-    );
   };
   const runAction = (input: ResearchMissionActionInput) => runMissionAction(
     "Research action failed",
@@ -296,25 +313,6 @@ export function ResearchMissionDetail({
 
   // Evidence-delta triage reuses the ledger's exact source-update mechanism:
   // Keep → used, Reject → rejected, Verify → stays conflicting + appends note.
-  const keepSource = (source: ResearchSourceRef) => runAction({
-    action: "update-source",
-    sourceId: source.id,
-    patch: { status: "used" },
-  });
-  const rejectSource = (source: ResearchSourceRef) => runAction({
-    action: "update-source",
-    sourceId: source.id,
-    patch: { status: "rejected" },
-  });
-  const verifySourceNextPass = (source: ResearchSourceRef) => runAction({
-    action: "update-source",
-    sourceId: source.id,
-    patch: {
-      status: "conflicting",
-      note: source.note ? `${source.note}\n${VERIFY_NOTE}` : VERIFY_NOTE,
-    },
-  });
-
   const renderActionButton = (action: ResearchMissionAction) => (
     <Button
       key={action}
@@ -340,20 +338,6 @@ export function ResearchMissionDetail({
         ? continueInfo.label
         : action === "retry" ? retryLabel : ACTION_LABELS[action] ?? action}
     </Button>
-  );
-
-  const renderSourceTitle = (source: ResearchSourceRef) => source.url ? (
-    <button
-      type="button"
-      className="research-desk-delta__title"
-      onClick={() => onOpenUrl(source.url!)}
-    >
-      <strong>{source.title}</strong>
-      <Icon name="ph:arrow-square-out" width={11} height={11} aria-hidden />
-      <span className="sr-only"> — opens the source</span>
-    </button>
-  ) : (
-    <strong>{source.title}</strong>
   );
 
   return (
@@ -681,118 +665,36 @@ export function ResearchMissionDetail({
           ) : null}
         </div>
 
-        {/* ── Right rail: state-dependent evidence, quick links, ledger. ── */}
+        {/* ── Right rail: one toggle (Artifacts | Sources) over a pane that
+              spans the rail, plus pinned quick links. The pane is the full
+              evidence ledger — the rail no longer stacks a partial state panel
+              above a collapsed copy of the same data. ── */}
         <aside className="research-desk-rail" aria-label="Run evidence and links">
-          {isCheckpointLike ? (
-            <section className="research-desk-rail__panel" aria-label="Evidence delta">
-              <h3 className="research-desk-rail__title">
-                Evidence delta — pass {iteration?.number ?? 0}
-              </h3>
-              <p className="research-desk-rail__hint">
-                Triage now or leave it for the agent to resolve next pass.
-              </p>
-              {mission.sources.length === 0 ? (
-                <p className="research-desk-block__empty">No sources in the ledger yet.</p>
-              ) : (
-                <ul className="research-desk-delta">
-                  {mission.sources
-                    .filter((source) => source.status !== "rejected")
-                    .slice(-6)
-                    .map((source) => (
-                      <li
-                        key={source.id}
-                        className={`research-desk-delta__card research-desk-delta__card--${source.status}`}
-                      >
-                        <span className={`research-source-status research-source-status--${source.status}`}>
-                          <i aria-hidden />{source.status}
-                        </span>
-                        {renderSourceTitle(source)}
-                        {source.claim ? <p>{source.claim}</p> : null}
-                        {source.status === "conflicting" || source.status === "candidate" ? (
-                          <div className="research-desk-delta__actions">
-                            <Button size="xs" variant="secondary" disabled={busy} onClick={() => void keepSource(source)}>
-                              Keep
-                            </Button>
-                            <Button size="xs" variant="secondary" disabled={busy} onClick={() => void rejectSource(source)}>
-                              Reject
-                            </Button>
-                            {source.status === "conflicting" ? (
-                              <Button
-                                size="xs"
-                                variant="ghost"
-                                disabled={busy || (source.note ?? "").includes(VERIFY_NOTE)}
-                                onClick={() => void verifySourceNextPass(source)}
-                              >
-                                Verify next pass
-                              </Button>
-                            ) : null}
-                          </div>
-                        ) : null}
-                      </li>
-                    ))}
-                </ul>
-              )}
-            </section>
-          ) : null}
-
-          {isLive ? (
-            <section className="research-desk-rail__panel" aria-label="Sources streaming in">
-              <h3 className="research-desk-rail__title">Sources streaming in</h3>
-              <p className="research-desk-rail__hint">
-                {mission.sources.length} of {mission.bounds.sourceTarget} targeted — review anytime.
-              </p>
-              {mission.sources.length === 0 ? (
-                <p className="research-desk-block__empty">No sources recorded yet.</p>
-              ) : (
-                <ul className="research-desk-stream">
-                  {mission.sources.slice(-6).map((source, index, recent) => {
-                    const latest = index === recent.length - 1;
-                    return (
-                      <li key={source.id} className={latest ? "is-latest" : undefined}>
-                        <i aria-hidden />
-                        <span>{source.title}</span>
-                        {latest ? <span className="sr-only"> — most recently added</span> : null}
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-            </section>
-          ) : null}
-
-          {showArtifactRail ? (
-            <section className="research-desk-rail__panel" aria-label="Artifacts">
-              <h3 className="research-desk-rail__title">
-                {mission.status === "failed" && iteration
-                  ? `Artifacts from pass ${iteration.number}`
-                  : "Artifacts"}
-              </h3>
-              {mission.artifacts.length === 0 ? (
-                <p className="research-desk-block__empty">No artifacts yet.</p>
-              ) : (
-                <ul className="research-desk-artifacts">
-                  {mission.artifacts.map((artifact) => (
-                    <li key={artifact.key} className="research-desk-artifact">
-                      <span className="research-desk-artifact__kicker">
-                        {artifact.kind} · {artifact.state}
-                      </span>
-                      <strong>{artifact.title}</strong>
-                      <span className="research-desk-artifact__meta">
-                        iteration {artifact.iteration} ·{" "}
-                        <time dateTime={artifact.updatedAt}>{relativeTime(artifact.updatedAt) || "just now"}</time>
-                      </span>
-                      <ResearchArtifactActions
-                        mission={mission}
-                        artifact={artifact}
-                        busy={busy}
-                        onPublish={settled ? publishArtifact : undefined}
-                      />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </section>
-          ) : null}
+          <Tabs<ResearchOutputTab>
+            className="research-desk-rail__toggle"
+            idPrefix="research-output"
+            ariaLabel="Rail contents"
+            variant="segment"
+            size="sm"
+            fill
+            value={railTab}
+            onChange={setRailTab}
+            items={[
+              { id: "artifacts", label: "Artifacts", count: mission.artifacts.length },
+              { id: "sources", label: "Sources", count: mission.sources.length },
+            ]}
+          />
+          <div className="research-desk-rail__pane">
+            <ResearchEvidenceLedger
+              mission={mission}
+              onAction={onAction}
+              onOpenUrl={onOpenUrl}
+              tab={railTab}
+              hint={railHint}
+              triage={isCheckpointLike}
+              highlightLatest={isLive}
+            />
+          </div>
 
           <div className="research-desk-rail__links">
             {sessionId ? (
@@ -816,18 +718,6 @@ export function ResearchMissionDetail({
               <span className="research-desk-rail__link-chevron" aria-hidden>›</span>
             </button>
           </div>
-
-          {/* Full evidence ledger stays reachable below the state panel. */}
-          <details className="research-desk-rail__ledger">
-            <summary>
-              Evidence ledger
-              <span>
-                {mission.artifacts.length} artifact{mission.artifacts.length === 1 ? "" : "s"} ·{" "}
-                {mission.sources.length} source{mission.sources.length === 1 ? "" : "s"}
-              </span>
-            </summary>
-            <ResearchEvidenceLedger mission={mission} onAction={onAction} onOpenUrl={onOpenUrl} />
-          </details>
         </aside>
       </div>
     </section>

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -74,18 +74,22 @@ test("running and completed blocks stay honest about their data", () => {
   assert.doesNotMatch(detail, /Finding 1|compFindings/);
 });
 
-// ── Evidence delta triage: exact ledger source-update mechanism ─────────────
+// ── Evidence triage: exact ledger source-update mechanism ──────────────────
+// Triage lives in the ledger now — the rail's Sources pane IS the ledger, so
+// the checkpoint verdicts ride the same source cards as the full list.
 
 test("Keep/Reject/Verify map onto the ledger's update-source action", () => {
-  assert.match(detail, /action: "update-source",\s*sourceId: source\.id,\s*patch: \{ status: "used" \}/);
-  assert.match(detail, /action: "update-source",\s*sourceId: source\.id,\s*patch: \{ status: "rejected" \}/);
+  assert.match(ledger, /action: "update-source",\s*sourceId: source\.id,\s*patch: \{ status: "used" \}/);
+  assert.match(ledger, /action: "update-source",\s*sourceId: source\.id,\s*patch: \{ status: "rejected" \}/);
   // Verify keeps the source conflicting and appends a note instead of
   // changing status.
-  assert.match(detail, /status: "conflicting",\s*note: source\.note \? `\$\{source\.note\}\\n\$\{VERIFY_NOTE\}` : VERIFY_NOTE/);
+  assert.match(ledger, /status: "conflicting",\s*note: source\.note \? `\$\{source\.note\}\\n\$\{VERIFY_NOTE\}` : VERIFY_NOTE/);
   // Re-verifying is inert: the button disables once the marker is present.
-  assert.match(detail, /\(source\.note \?\? ""\)\.includes\(VERIFY_NOTE\)/);
-  // Triage actions only appear where they make sense.
-  assert.match(detail, /source\.status === "conflicting" \|\| source\.status === "candidate"/);
+  assert.match(ledger, /\(source\.note \?\? ""\)\.includes\(VERIFY_NOTE\)/);
+  // Triage actions only appear at a checkpoint, on sources still awaiting a
+  // verdict; the status control below them stays available always.
+  assert.match(ledger, /triage && \(source\.status === "candidate" \|\| source\.status === "conflicting"\)/);
+  assert.match(detail, /triage=\{isCheckpointLike\}/);
 });
 
 // ── Command bar: real destinations only ─────────────────────────────────────
@@ -138,17 +142,35 @@ test("planning missions read as active work in the runs rail", () => {
 
 // ── Right rail: state switching + reachable ledger ──────────────────────────
 
-test("the right rail switches panels by mission state", () => {
-  // checkpoint/paused → evidence delta; live → streaming sources;
-  // failed/completed/other settled → artifact cards.
-  assert.match(detail, /mission\.status === "checkpoint" \|\| mission\.status === "paused"/);
-  assert.match(detail, /new Set<ResearchMission\["status"\]>\(\["queued", "planning", "running"\]\)/);
-  assert.match(detail, /const showArtifactRail = !isCheckpointLike && !isLive/);
+test("the right rail is one Artifacts|Sources toggle over a full-height pane", () => {
+  // No stacked state panels: a single segmented toggle drives one pane that
+  // takes the rail's remaining height, with the quick links pinned under it.
+  assert.match(detail, /<Tabs<ResearchOutputTab>/);
+  assert.match(detail, /variant="segment"/);
+  assert.match(detail, /\{ id: "artifacts", label: "Artifacts", count: mission\.artifacts\.length \}/);
+  assert.match(detail, /\{ id: "sources", label: "Sources", count: mission\.sources\.length \}/);
+  assert.match(detail, /className="research-desk-rail__pane"/);
+  assert.match(css, /\.research-desk-rail__pane \{[^}]*flex: 1;[^}]*min-height: 0;[^}]*overflow-y: auto;/);
+  assert.match(css, /\.research-desk-rail__links \{[^}]*flex: none;/);
+  // The old stacked panels are gone.
+  assert.doesNotMatch(detail, /research-desk-rail__panel/);
+  assert.doesNotMatch(detail, /Sources streaming in/);
+});
+
+test("run state picks the opening pane and the pane's context line", () => {
+  // checkpoint/paused/live open on Sources (triage + arrivals); settled runs
+  // open on what they produced. A mission switch re-derives it; a status
+  // change inside one mission leaves the reader's choice alone.
+  assert.match(detail, /missionStatus === "checkpoint" \|\| missionStatus === "paused" \|\| LIVE_STATUSES\.has\(missionStatus\)/);
+  assert.match(detail, /\? "sources"\s*: "artifacts"/);
+  assert.match(detail, /if \(railTabMission !== missionId\) \{\s*setRailTabMission\(missionId\);\s*setRailTab\(defaultRailTab\);\s*\}/);
+  // The context the stacked panel titles used to carry survives as one hint.
   assert.match(detail, /Evidence delta — pass/);
-  assert.match(detail, /Sources streaming in/);
-  assert.match(detail, /Artifacts from pass/);
-  // Streaming list highlights the most recent source without faking times.
-  assert.match(detail, /is-latest/);
+  assert.match(detail, /targeted — streaming in, review anytime/);
+  assert.match(detail, /highlightLatest=\{isLive\}/);
+  // The streaming highlight marks the newest ledger entry without faking times.
+  assert.match(ledger, /mission\.sources\[mission\.sources\.length - 1\]\.id/);
+  assert.match(ledger, /is-latest/);
   assert.doesNotMatch(detail, /Reading: /);
 });
 
@@ -161,11 +183,15 @@ test("quick links exist only when their destinations do", () => {
   assert.doesNotMatch(detail, /Create task/);
 });
 
-test("the full evidence ledger stays reachable inside the rail disclosure", () => {
-  assert.match(detail, /research-desk-rail__ledger/);
-  assert.match(detail, /<ResearchEvidenceLedger mission=\{mission\} onAction=\{onAction\} onOpenUrl=\{onOpenUrl\} \/>/);
-  // The ledger keeps its own tab ids — pinned by researcher-surface.test.ts.
-  assert.match(ledger, /idPrefix="research-output"/);
+test("the full evidence ledger is the rail pane, not a nested disclosure", () => {
+  // One copy of the evidence: the ledger renders the open pane directly, so
+  // there is no collapsed duplicate of the same artifacts/sources below it.
+  assert.match(detail, /<ResearchEvidenceLedger\s+mission=\{mission\}[\s\S]{0,300}tab=\{railTab\}/);
+  assert.doesNotMatch(detail, /research-desk-rail__ledger/);
+  // The tablist moved to the rail, so the ledger renders panels only — their
+  // ids still match the rail toggle's idPrefix.
+  assert.match(detail, /idPrefix="research-output"/);
+  assert.doesNotMatch(ledger, /<Tabs/);
   assert.match(ledger, /id="research-output-panel-artifacts"/);
   assert.match(ledger, /id="research-output-panel-sources"/);
 });
@@ -240,11 +266,11 @@ test("desk-tab responsive collapses match the existing container breakpoints", (
 
 // ── Artifact actions: shared component mounted on rail + saved summary ──────
 
-test("desk rail renders shared artifact actions with publish on settled missions", () => {
-  assert.match(detail, /ResearchArtifactActions/);
-  assert.match(detail, /onPublish=\{settled \? publishArtifact : undefined\}/);
-  assert.match(detail, /action: "publish-artifact"/);
-  assert.match(detail, /Artifact published to the Grimoire\./);
+test("rail artifacts render shared artifact actions with publish on settled missions", () => {
+  assert.match(ledger, /ResearchArtifactActions/);
+  assert.match(ledger, /onPublish=\{settled \? publishArtifact : undefined\}/);
+  assert.match(ledger, /action: "publish-artifact"/);
+  assert.match(ledger, /Artifact published to the Grimoire\./);
 });
 
 test("desk shows a saved-artifacts summary with a copy-workspace-path affordance", () => {

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -274,11 +274,11 @@ test("timestamps are relative and schedules read as prose, not raw data", () => 
 });
 
 test("ledger errors stay visible regardless of the active output tab", () => {
-  // The error paragraph renders between the tab strip and the first tab panel,
-  // not inside a panel that may be hidden.
+  // The error paragraph renders above both tab panels, not inside a panel that
+  // may be hidden. (The tablist itself lives in the rail now.)
   assert.match(
     ledger,
-    /\{error \? <p className="research-mission-error" role="alert">\{error\}<\/p> : null\}\s*<section\s+id="research-output-panel-artifacts"/,
+    /\{error \? <p className="research-mission-error" role="alert">\{error\}<\/p> : null\}\s*\{hint \?[\s\S]{0,140}<section\s+id="research-output-panel-artifacts"/,
   );
 });
 
@@ -406,7 +406,7 @@ test("routed Prompt modes are one-shot — consumed then cleared", () => {
 test("forms expose errors and narrow outputs become keyboard tabs", () => {
   assert.match(composer, /aria-invalid=\{Boolean\(error\) \|\| intentTooShort\}/);
   assert.match(composer, /role="alert"/);
-  assert.match(ledger, /<Tabs<"artifacts" \| "sources">/);
+  assert.match(detail, /<Tabs<ResearchOutputTab>/);
   assert.match(ledger, /role="tabpanel"/);
   assert.match(css, /@media \(prefers-reduced-motion: reduce\)/);
   assert.match(css, /@container research-desk \(max-width: 760px\)/);

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -44,7 +44,7 @@ type TabsProps<T extends string> = {
   onChange: (id: T) => void;
   /** "horizontal" (underline, default) or "vertical" (left-border indicator). */
   orientation?: "horizontal" | "vertical";
-  /** Stretch tabs to fill the track (equal-width). Horizontal only. */
+  /** Stretch tabs to fill the track (equal-width). Horizontal and segment. */
   fill?: boolean;
   /** aria-label for the tablist. */
   ariaLabel?: string;
@@ -124,7 +124,7 @@ export function Tabs<T extends string>({
         const panelId = idPrefix ? `${idPrefix}-panel-${t.id}` : undefined;
 
         const className = segment
-          ? segmentTabClass(isActive, sm)
+          ? segmentTabClass(isActive, fill, sm)
           : vertical
             ? verticalTabClass(isActive, t.disabled, sm)
             : horizontalTabClass(isActive, fill, sm);
@@ -191,10 +191,11 @@ function verticalTabClass(isActive: boolean, disabled: boolean | undefined, sm: 
   ].join(" ");
 }
 
-function segmentTabClass(isActive: boolean, sm: boolean): string {
+function segmentTabClass(isActive: boolean, fill: boolean, sm: boolean): string {
   return [
     "relative inline-flex items-center gap-1.5 outline-none rounded-md",
     sm ? "px-2.5 py-1 text-[length:var(--text-xs)]" : "px-3 py-1.5 text-[length:var(--text-sm)]",
+    fill ? "flex-1 justify-center min-w-0" : "",
     // Every tab carries a transparent border so selecting one (which colours
     // the border) never shifts layout.
     "font-medium transition-colors border border-transparent",

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -482,121 +482,23 @@
 .research-desk-rail {
   display: flex;
   min-width: 0;
+  min-height: 0;
   flex-direction: column;
   gap: 14px;
   padding: var(--space-4) 14px 22px;
   border-left: 1px solid var(--border);
 }
-.research-desk-rail__panel { display: flex; flex-direction: column; gap: 8px; }
-.research-desk-rail__title {
-  margin: 0;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-}
 .research-desk-rail__hint { margin: 0; font-size: var(--text-2xs); color: var(--text-muted); }
 
-.research-desk-delta {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.research-desk-delta__card {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-1);
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
-}
-.research-desk-delta__card--conflicting {
-  border-color: color-mix(in oklch, oklch(0.8 0.13 75) 40%, transparent);
-}
-.research-desk-delta__card strong { font-size: var(--text-xs); font-weight: 500; line-height: 1.3; color: var(--text-primary); }
-.research-desk-delta__card p { margin: 0; font-size: var(--text-2xs); line-height: 1.45; color: var(--text-muted); overflow-wrap: anywhere; }
-.research-desk-delta__title {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: 0;
-  border: 0;
-  background: transparent;
-  text-align: left;
-  cursor: pointer;
-}
-.research-desk-delta__title svg { flex: none; color: var(--research-accent); }
-.research-desk-delta__title:hover strong { color: var(--research-accent); }
-.research-desk-delta__title:focus-visible {
-  outline: var(--ring-width) solid var(--ring-focus);
-  outline-offset: 2px;
-}
+/* Triage buttons on a source card awaiting a verdict. */
 .research-desk-delta__actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 3px; }
 
-.research-desk-stream {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  font-size: var(--text-xs);
-  color: var(--text-secondary);
+/* Live runs mark the newest source in the ledger pane. */
+.research-source-card.is-latest {
+  border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
+  background: var(--research-accent-soft);
 }
-.research-desk-stream li { display: flex; align-items: baseline; gap: 8px; min-width: 0; }
-.research-desk-stream li span {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.research-desk-stream i {
-  flex: none;
-  width: 5px;
-  height: 5px;
-  border-radius: var(--radius-pill);
-  background: oklch(0.72 0.14 155);
-}
-.research-desk-stream li.is-latest i {
-  background: var(--research-accent);
-  box-shadow: 0 0 0 3px var(--research-accent-soft);
-}
-.research-desk-stream li.is-latest span { color: var(--text-primary); }
 
-.research-desk-artifacts {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-.research-desk-artifact {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: var(--space-1);
-  padding: 10px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md);
-  background: color-mix(in oklch, var(--bg-raised) 72%, transparent);
-}
-.research-desk-artifact__kicker {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: var(--text-2xs);
-  text-transform: uppercase;
-  color: var(--research-accent);
-}
-.research-desk-artifact strong { font-size: var(--text-xs); font-weight: 500; line-height: 1.3; color: var(--text-primary); }
-.research-desk-artifact__meta { font-size: var(--text-2xs); color: var(--text-muted); }
-.research-desk-artifact__meta time { text-transform: none; }
 .research-desk-artifact__open {
   display: inline-flex;
   align-items: center;
@@ -617,6 +519,7 @@
 /* Quick links: bordered rows with accent-on-hover (design 238–253). */
 .research-desk-rail__links {
   display: flex;
+  flex: none;
   flex-direction: column;
   gap: 6px;
   padding-top: 14px;
@@ -643,35 +546,20 @@
 }
 .research-desk-rail__link-chevron { margin-left: auto; color: var(--text-muted); }
 
-/* Full evidence ledger folded into a disclosure — always reachable. */
-.research-desk-rail__ledger {
-  padding-top: var(--space-3);
-  border-top: 1px solid var(--border);
-}
-.research-desk-rail__ledger > summary {
+/* ── Rail toggle + pane: one Artifacts|Sources switch over a pane that takes
+   the rail's remaining height, so the open list scrolls on its own instead of
+   pushing the quick links out of reach. ── */
+.research-desk-rail__toggle { flex: none; }
+.research-desk-rail__pane {
   display: flex;
-  align-items: baseline;
-  gap: var(--space-2);
-  width: fit-content;
-  cursor: pointer;
-  list-style: none;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: var(--text-2xs);
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--text-muted);
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
-.research-desk-rail__ledger > summary::-webkit-details-marker { display: none; }
-.research-desk-rail__ledger > summary:hover { color: var(--text-secondary); }
-.research-desk-rail__ledger > summary span {
-  font-family: inherit;
-  font-weight: 400;
-  letter-spacing: normal;
-  text-transform: none;
-  font-size: var(--text-2xs);
-}
-.research-desk-rail__ledger[open] > summary { margin-bottom: 10px; }
+.research-desk-rail__pane > .research-output-shelf { flex: 1; min-height: 0; }
+.research-desk-rail__pane .research-output-shelf > section[hidden] { display: none; }
 
 /* ── Responsive: follow the desk's existing container breakpoints. The
    base overrides above out-specify the workspaces-sheet collapses, so the

--- a/src/styles/globals/surface-role-workspaces.css
+++ b/src/styles/globals/surface-role-workspaces.css
@@ -955,7 +955,6 @@
 .research-mission-decision p { color: var(--text-secondary); }
 
 .research-output-shelf { display: flex; flex-direction: column; gap: 10px; }
-.research-output-tabs { width: 100%; }
 .research-output-shelf > section { padding: 10px; }
 .research-output-shelf > section:focus-visible { outline: var(--ring-width) solid var(--ring-focus); outline-offset: 2px; }
 .research-output-shelf h3 { margin-bottom: 7px; }

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -374,7 +374,7 @@ test.describe("research desk tabs", () => {
     const railTabs = desk.getByRole("tablist", { name: "Rail contents" });
     await expect(railTabs.getByRole("tab", { name: /^Sources/ })).toHaveAttribute("aria-selected", "true");
     const sourcesPane = desk.getByRole("tabpanel", { name: /^Sources/ });
-    await expect(sourcesPane.getByText("Vendor benchmarks blog")).toBeVisible();
+    await expect(sourcesPane.getByRole("button", { name: /^Vendor benchmarks blog/ })).toBeVisible();
     await expect(sourcesPane.getByRole("button", { name: "Verify next pass" })).toBeVisible();
 
     // Toggling shows the artifacts in the same pane — one list at a time, both

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -369,10 +369,20 @@ test.describe("research desk tabs", () => {
     await expect(actions.getByRole("button", { name: "Archive" })).toBeVisible();
     await expect(desk.getByText("Refine direction before continuing")).toBeVisible();
 
-    // The evidence-delta rail triages the conflicting source.
-    const delta = desk.getByRole("region", { name: "Evidence delta" });
-    await expect(delta.getByText("Vendor benchmarks blog")).toBeVisible();
-    await expect(delta.getByRole("button", { name: "Verify next pass" })).toBeVisible();
+    // The rail is one Artifacts|Sources toggle over a single pane. A run at a
+    // checkpoint opens on Sources, where the conflicting source can be triaged.
+    const railTabs = desk.getByRole("tablist", { name: "Rail contents" });
+    await expect(railTabs.getByRole("tab", { name: /^Sources/ })).toHaveAttribute("aria-selected", "true");
+    const sourcesPane = desk.getByRole("tabpanel", { name: /^Sources/ });
+    await expect(sourcesPane.getByText("Vendor benchmarks blog")).toBeVisible();
+    await expect(sourcesPane.getByRole("button", { name: "Verify next pass" })).toBeVisible();
+
+    // Toggling shows the artifacts in the same pane — one list at a time, both
+    // complete, with no second copy stacked below.
+    await railTabs.getByRole("tab", { name: /^Artifacts/ }).click();
+    const artifactsPane = desk.getByRole("tabpanel", { name: /^Artifacts/ });
+    await expect(artifactsPane.getByText("Working synthesis")).toBeVisible();
+    await expect(sourcesPane).toBeHidden();
 
     // Selecting the failed run surfaces its lastError and a Retry action.
     await rail.getByRole("button", { name: /Rust GUI toolkit scan/ }).click();


### PR DESCRIPTION
## Problem

The research desk's right rail stacked **two** sections — a state-dependent evidence panel (checkpoint delta / streaming sources / artifacts) and a links row — and then a *third*, collapsed "Evidence ledger" `<details>` that carried its own Artifacts/Sources tab strip over the same data. Each showed a different slice (the rail truncated to the last six entries), none of them the whole ledger, and the artifacts and sources were never both browsable at once.

## Change

The rail is now a single segmented **Artifacts | Sources** toggle over one pane that takes the rail's remaining height and scrolls on its own, with the quick links pinned beneath it.

The pane *is* the evidence ledger: `ResearchEvidenceLedger` sheds its internal tab strip and renders the pane the rail selects (`tab` prop, ids still under `idPrefix="research-output"`). One copy of each list, both complete.

Nothing the old panels did is lost:

- **Checkpoint triage** (Keep / Reject / Verify next pass) rides the ledger's own source cards, gated on `triage`, so the verdicts appear where the pass is waiting on them — the status `<select>` stays for revisiting any source later.
- **Live runs** still mark the newest source, via `highlightLatest` on the last ledger entry (append order, no invented timestamps).
- The panel titles' context survives as **one hint line** above the open pane.
- The ledger's **status filters** and **attach-source form** are now always reachable instead of hidden behind a disclosure.

Opening pane follows run state: checkpoint / paused / live open on **Sources**; a settled run opens on **Artifacts**. The default re-derives on a mission switch only, so a status change mid-run never yanks the reader's chosen pane.

`Tabs` gains `fill` support for the `segment` variant (equal-width halves) — previously horizontal-only.

Orphaned CSS removed: `.research-desk-rail__panel/__title`, `.research-desk-delta*` (except the still-used `__actions`), `.research-desk-stream*`, `.research-desk-artifacts/.research-desk-artifact` card rules, `.research-desk-rail__ledger*`, `.research-output-tabs`.

## Verification

- `pnpm test:app` → **922 test files passed** (includes the updated `research-tab-desk` / `researcher-surface` markup + CSS contracts)
- `pnpm lint` (design codemod check + design ESLint gate) → clean
- `pnpm exec tsc --noEmit` → clean
- `pnpm build` → succeeds; CSS + standalone budgets within limits

Local Playwright runs of `research-desk-tabs.spec.ts` timed out before `.research-desk` ever mounted (cold-compile/lock contention on this machine, unrelated to the rail) — deferring to the CI `E2E (Playwright)` required check.