### PR TITLE
fix(dev): recover the Tauri shell after a Next/Turbopack crash or stale chunk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,19 @@ handoffs because its logs make the startup sequence and selected port obvious.
 Do not background the command when the goal is to verify the app started; a
 detached wrapper can exit without leaving useful Tauri logs.
 
+The wrapper owns everything it starts. `Ctrl-C`, `SIGTERM`, or any other exit
+tears down the Tauri process tree and the Next dev server underneath it, so an
+interrupted run never strands a process holding the port. It also watches the
+loopback origin: if the dev server stays unreachable for 30 s the wrapper shuts
+the window down rather than leaving it attached to a server that is not coming
+back. Override that window with `COVEN_CAVE_DEV_SERVER_GRACE_SECONDS`, or set it
+to `0` to disable the watchdog.
+
+Shorter outages — a Turbopack rebuild, a manual dev-server restart — are handled
+in-app instead. A dev-only recovery overlay replaces the raw `ChunkLoadError` /
+`ERR_CONNECTION_REFUSED` page, polls the origin, and hard-reloads the window as
+soon as the server answers so no stale chunk ids survive the restart.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->
 ## Beads Issue Tracker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,19 @@ handoffs because its logs make the startup sequence and selected port obvious.
 Do not background the command when the goal is to verify the app started; a
 detached wrapper can exit without leaving useful Tauri logs.
 
+The wrapper owns everything it starts. `Ctrl-C`, `SIGTERM`, or any other exit
+tears down the Tauri process tree and the Next dev server underneath it, so an
+interrupted run never strands a process holding the port. It also watches the
+loopback origin: if the dev server stays unreachable for 30 s the wrapper shuts
+the window down rather than leaving it attached to a server that is not coming
+back. Override that window with `COVEN_CAVE_DEV_SERVER_GRACE_SECONDS`, or set it
+to `0` to disable the watchdog.
+
+Shorter outages — a Turbopack rebuild, a manual dev-server restart — are handled
+in-app instead. A dev-only recovery overlay replaces the raw `ChunkLoadError` /
+`ERR_CONNECTION_REFUSED` page, polls the origin, and hard-reloads the window as
+soon as the server answers so no stale chunk ids survive the restart.
+
 ## Diagnosing concurrent sessions
 
 If git operations keep colliding with surprise pulls/merges, multiple Claude sessions are likely on the same checkout. Diagnose:

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@xterm/xterm": "6.0.0",
     "@xyflow/react": "12.11.1",
     "mermaid": "11.16.0",
-    "next": "16.2.9",
+    "next": "16.2.11",
     "node-pty": "1.1.0",
     "qrcode": "1.5.4",
     "react": "19.2.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,8 +111,8 @@ importers:
         specifier: 11.16.0
         version: 11.16.0
       next:
-        specifier: 16.2.9
-        version: 16.2.9(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 16.2.11
+        version: 16.2.11(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       node-pty:
         specifier: 1.1.0
         version: 1.1.0
@@ -942,57 +942,57 @@ packages:
   '@next/bundle-analyzer@16.2.9':
     resolution: {integrity: sha512-yGWyLbC8MMn+hk9j6l6GammpbUz5S3yZzl3lpoWfVXhIpJfh6kAWG7JwF4WoG3f0VnYRY959yo1QQEI8mV/+jg==}
 
-  '@next/env@16.2.9':
-    resolution: {integrity: sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
-  '@next/swc-darwin-arm64@16.2.9':
-    resolution: {integrity: sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.9':
-    resolution: {integrity: sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.9':
-    resolution: {integrity: sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.9':
-    resolution: {integrity: sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.9':
-    resolution: {integrity: sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.9':
-    resolution: {integrity: sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.9':
-    resolution: {integrity: sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.9':
-    resolution: {integrity: sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2606,8 +2606,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.2.9:
-    resolution: {integrity: sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -4298,30 +4298,30 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@16.2.9': {}
+  '@next/env@16.2.11': {}
 
-  '@next/swc-darwin-arm64@16.2.9':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.9':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.9':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.9':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.9':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.9':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.9':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.9':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@ocavue/utils@1.7.0': {}
@@ -6170,9 +6170,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.9(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  next@16.2.11(@playwright/test@1.61.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
-      '@next/env': 16.2.9
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.40
       caniuse-lite: 1.0.30001799
@@ -6181,14 +6181,14 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       styled-jsx: 5.1.6(react@19.2.7)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.9
-      '@next/swc-darwin-x64': 16.2.9
-      '@next/swc-linux-arm64-gnu': 16.2.9
-      '@next/swc-linux-arm64-musl': 16.2.9
-      '@next/swc-linux-x64-gnu': 16.2.9
-      '@next/swc-linux-x64-musl': 16.2.9
-      '@next/swc-win32-arm64-msvc': 16.2.9
-      '@next/swc-win32-x64-msvc': 16.2.9
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@playwright/test': 1.61.1
       babel-plugin-react-compiler: 1.0.0
       sharp: 0.34.5

--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -1,0 +1,162 @@
+// Interrupting the dev launcher must not strand the process tree it owns.
+// A stranded Next dev server keeps the port bound, so the next `pnpm dev:app`
+// silently attaches the desktop shell to the previous run's stale server.
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { chmodSync, mkdirSync, mkdtempSync, copyFileSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import net from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function probePort(port) {
+  return new Promise((resolve) => {
+    const socket = net.connect({ host: "127.0.0.1", port });
+    const settle = (listening) => {
+      socket.destroy();
+      resolve(listening);
+    };
+    socket.setTimeout(300);
+    socket.on("connect", () => settle(true));
+    socket.on("timeout", () => settle(false));
+    socket.on("error", () => settle(false));
+  });
+}
+
+async function waitFor(predicate, { timeoutMs = 20_000, label }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await sleep(100);
+  }
+  assert.fail(`timed out waiting for ${label}`);
+}
+
+async function freePort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.on("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const { port } = server.address();
+      server.close(() => resolve(port));
+    });
+  });
+}
+
+const isAlive = (pid) => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const root = mkdtempSync(path.join(tmpdir(), "dev-app-teardown-"));
+const fakeScripts = path.join(root, "scripts");
+const fakeBin = path.join(root, "bin");
+mkdirSync(fakeScripts, { recursive: true });
+mkdirSync(fakeBin, { recursive: true });
+
+copyFileSync(path.join(scriptsDir, "dev-app.sh"), path.join(fakeScripts, "dev-app.sh"));
+chmodSync(path.join(fakeScripts, "dev-app.sh"), 0o755);
+writeFileSync(path.join(fakeScripts, "whisper-runtime-dev-env.sh"), "# stub for tests\n");
+
+const fakePnpm = (port, pidFile) => `#!/usr/bin/env bash
+echo "tauri $$" >>"${pidFile}"
+node -e '
+  const net = require("net");
+  const fs = require("fs");
+  const server = net.createServer(() => {});
+  server.listen(${port}, "127.0.0.1", () => {
+    fs.appendFileSync("${pidFile}", "server " + process.pid + "\\n");
+  });
+  setInterval(() => {}, 1000);
+' &
+child=$!
+wait "$child"
+`;
+
+const readPids = (pidFile) =>
+  Object.fromEntries(
+    readFileSync(pidFile, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => line.split(" ")),
+  );
+
+// The signal is delivered to the launcher alone, not to its process group. A
+// terminal Ctrl-C also reaches the children directly, which would hide an
+// orphan; supervisors, IDE stop buttons, and `kill <pid>` do not.
+async function assertTeardown(signal) {
+  const port = await freePort();
+  const pidFile = path.join(root, `pids-${signal}.txt`);
+  writeFileSync(path.join(fakeBin, "pnpm"), fakePnpm(port, pidFile));
+  chmodSync(path.join(fakeBin, "pnpm"), 0o755);
+
+  const wrapper = spawn("bash", [path.join(fakeScripts, "dev-app.sh")], {
+    cwd: root,
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      PORT: String(port),
+      COVEN_CAVE_AUTH_TOKEN: "",
+      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "0",
+    },
+  });
+  wrapper.unref();
+
+  let pids = {};
+  try {
+    await waitFor(() => probePort(port), {
+      label: `the fake dev server to bind port ${port}`,
+    });
+    pids = readPids(pidFile);
+    assert.ok(pids.tauri, "the launcher must actually start the Tauri child");
+    assert.ok(pids.server, "the Tauri child must own the dev server process");
+
+    process.kill(wrapper.pid, signal);
+
+    await waitFor(() => !isAlive(wrapper.pid), {
+      label: `the launcher to exit after ${signal}`,
+    });
+    await waitFor(async () => !(await probePort(port)), {
+      label: `port ${port} to be released after ${signal}`,
+    });
+
+    assert.equal(
+      isAlive(Number(pids.tauri)),
+      false,
+      `${signal} to the launcher must not strand the Tauri process`,
+    );
+    assert.equal(
+      isAlive(Number(pids.server)),
+      false,
+      `${signal} to the launcher must not strand the dev server it owns`,
+    );
+  } finally {
+    for (const pid of [wrapper.pid, Number(pids.tauri), Number(pids.server)]) {
+      if (Number.isFinite(pid) && pid > 0) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+    }
+  }
+}
+
+try {
+  await assertTeardown("SIGTERM");
+  await assertTeardown("SIGINT");
+} finally {
+  rmSync(root, { recursive: true, force: true });
+}
+
+console.log("dev-app-teardown: ok");

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -54,8 +54,66 @@ else
 fi
 
 TAURI_OVERRIDE_CONFIG="$(mktemp)"
-cleanup() { rm -f "$TAURI_OVERRIDE_CONFIG"; }
+WATCHDOG_VERDICT="$(mktemp)"
+tauri_pid=""
+watchdog_pid=""
+
+# Every descendant of a pid, children before parents. Tauri's `beforeDevCommand`
+# runs as its child, so walking the tree from the Tauri pid reaches the Next dev
+# server without ever guessing at unrelated processes that merely hold the port.
+list_process_tree() {
+  local pid="$1" child
+  if command -v pgrep >/dev/null 2>&1; then
+    for child in $(pgrep -P "$pid" 2>/dev/null || true); do
+      list_process_tree "$child"
+    done
+  fi
+  printf '%s\n' "$pid"
+}
+
+signal_process_tree() {
+  local pid="$1" signal="$2" member
+  if command -v taskkill >/dev/null 2>&1 && [ "$signal" = "KILL" ]; then
+    taskkill //PID "$pid" //T //F >/dev/null 2>&1 || true
+    return
+  fi
+  for member in $(list_process_tree "$pid"); do
+    kill -"$signal" "$member" 2>/dev/null || true
+  done
+}
+
+# Give the tree a chance to flush and shut down, then insist. Without this an
+# interrupted wrapper leaves an orphaned Next dev server holding the port and a
+# detached Tauri window attached to it.
+terminate_process_tree() {
+  local pid="$1" waited=0
+  [ -n "$pid" ] || return 0
+  kill -0 "$pid" 2>/dev/null || return 0
+  signal_process_tree "$pid" TERM
+  while [ "$waited" -lt 50 ] && kill -0 "$pid" 2>/dev/null; do
+    sleep 0.1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    signal_process_tree "$pid" KILL
+  fi
+}
+
+cleanup() {
+  trap - EXIT INT TERM HUP
+  if [ -n "$watchdog_pid" ]; then
+    kill "$watchdog_pid" 2>/dev/null || true
+    watchdog_pid=""
+  fi
+  terminate_process_tree "$tauri_pid"
+  if [ "${should_start_server:-false}" = true ] && port_is_listening "$dev_port" >/dev/null 2>&1; then
+    echo "[dev:app] warning: 127.0.0.1:${dev_port} is still listening after teardown" >&2
+  fi
+  rm -f "$TAURI_OVERRIDE_CONFIG" "$WATCHDOG_VERDICT"
+}
 trap cleanup EXIT
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM HUP
 
 # A Tauri dev process and its `beforeDevCommand` inherit this secret together.
 # The server therefore requires the browser-side bridge token too; carry it in
@@ -88,4 +146,55 @@ else
 CONF
 fi
 
-exec pnpm exec tauri dev --config "$TAURI_OVERRIDE_CONFIG" "$@"
+# The desktop shell must not stay attached to a loopback origin that is never
+# coming back. The in-app recovery overlay covers restarts, so the watchdog only
+# fires after a long silence: past that, the dev server is gone for good and a
+# surviving window would just show stale Turbopack chunks.
+DEV_SERVER_GRACE_SECONDS="${COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-30}"
+case "$DEV_SERVER_GRACE_SECONDS" in
+  ''|*[!0-9]*)
+    echo "[dev:app] ERROR: COVEN_CAVE_DEV_SERVER_GRACE_SECONDS must be a whole number of seconds" >&2
+    exit 1
+    ;;
+esac
+
+watch_dev_server() {
+  local down_for=0
+  # Only start judging once the server has actually come up.
+  until port_is_listening "$dev_port" >/dev/null 2>&1; do
+    kill -0 "$tauri_pid" 2>/dev/null || return 0
+    sleep 2
+  done
+  while kill -0 "$tauri_pid" 2>/dev/null; do
+    if port_is_listening "$dev_port" >/dev/null 2>&1; then
+      down_for=0
+    else
+      down_for=$((down_for + 2))
+      if [ "$down_for" -ge "$DEV_SERVER_GRACE_SECONDS" ]; then
+        echo "[dev:app] dev server on 127.0.0.1:${dev_port} has been unreachable for ${down_for}s; shutting the desktop shell down" >&2
+        printf 'dev-server-lost\n' >"$WATCHDOG_VERDICT"
+        terminate_process_tree "$tauri_pid"
+        return 0
+      fi
+    fi
+    sleep 2
+  done
+}
+
+pnpm exec tauri dev --config "$TAURI_OVERRIDE_CONFIG" "$@" &
+tauri_pid=$!
+
+if [ "$DEV_SERVER_GRACE_SECONDS" -gt 0 ]; then
+  watch_dev_server &
+  watchdog_pid=$!
+fi
+
+tauri_status=0
+wait "$tauri_pid" || tauri_status=$?
+tauri_pid=""
+
+if [ -s "$WATCHDOG_VERDICT" ]; then
+  exit 1
+fi
+
+exit "$tauri_status"

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -40,4 +40,35 @@ assert.match(
   "both launcher paths must use the token-bearing dev URL",
 );
 
+assert.doesNotMatch(
+  source,
+  /^exec pnpm exec tauri dev/m,
+  "the launcher must stay alive to own teardown instead of exec'ing into Tauri",
+);
+assert.match(
+  source,
+  /trap cleanup EXIT[\s\S]*?trap 'cleanup; exit 130' INT[\s\S]*?trap 'cleanup; exit 143' TERM HUP/,
+  "an interrupted launcher must run the same teardown as a clean exit",
+);
+assert.match(
+  source,
+  /terminate_process_tree\(\) \{[\s\S]*?signal_process_tree "\$pid" TERM[\s\S]*?signal_process_tree "\$pid" KILL/,
+  "teardown must escalate from TERM to KILL so no owned process survives",
+);
+assert.match(
+  source,
+  /cleanup\(\) \{[\s\S]*?terminate_process_tree "\$tauri_pid"[\s\S]*?rm -f "\$TAURI_OVERRIDE_CONFIG"/,
+  "cleanup must reap the Tauri tree and remove the generated override config",
+);
+assert.match(
+  source,
+  /DEV_SERVER_GRACE_SECONDS="\$\{COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-30\}"/,
+  "the dev-server watchdog must have a documented, overridable grace window",
+);
+assert.match(
+  source,
+  /watch_dev_server\(\) \{[\s\S]*?down_for=\$\(\(down_for \+ 2\)\)[\s\S]*?terminate_process_tree "\$tauri_pid"/,
+  "the shell must not outlive a loopback dev server that is never coming back",
+);
+
 console.log("dev-app: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -763,6 +763,7 @@ export const SUITES = {
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",
     "src/lib/design-token-drift.test.ts",
+    "src/lib/dev-shell-recovery.test.ts",
     "src/lib/cave-backdrop.test.ts",
     "src/lib/cave-backdrop-blaze.test.ts",
     "src/components/backdrop-scrim.test.ts",
@@ -948,6 +949,7 @@ export const SUITES = {
     "scripts/dependency-policy.test.mjs",
     "scripts/build-sandbox-runtime.test.mjs",
     "scripts/dev-app.test.mjs",
+    "scripts/dev-app-teardown.test.mjs",
     "scripts/sync-runtimes.test.mjs",
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",
@@ -1295,6 +1297,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/dev-shell-recovery.test.ts",
   "src/lib/opencode-compatibility.test.ts",
   "src/lib/opencode-stream.test.ts",
   "src/lib/cave-conversations.test.ts",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,7 @@ import { LiveRegionProvider } from "@/components/ui/live-region";
 import { ConfirmProvider } from "@/components/ui/confirm-dialog";
 import { PwaRegister } from "@/components/pwa-register";
 import { DevCacheResetScript } from "@/components/dev-cache-reset-script";
+import { DevShellRecovery } from "@/components/dev-shell-recovery";
 import { WebVitalsReporter } from "@/components/perf/web-vitals-reporter";
 import { PerfOverlay } from "@/components/perf/perf-overlay";
 import { PreferencesBootstrapController } from "@/components/preferences-bootstrap-controller";
@@ -82,6 +83,7 @@ export default function RootLayout({
       </head>
       <body className="h-full flex flex-col">
         <DevCacheResetScript />
+        <DevShellRecovery />
         <SidecarAuthBridge />
         <ShellBannersProvider>
           <DaemonReleaseAlignmentTrigger />

--- a/src/components/dev-shell-recovery.tsx
+++ b/src/components/dev-shell-recovery.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import {
+  type DevShellRecoveryState,
+  createDevShellRecovery,
+} from "@/lib/dev-shell-recovery";
+
+import "@/styles/dev-shell-recovery.css";
+
+const HEARTBEAT_INTERVAL_MS = 5_000;
+const RELOAD_MARKER_KEY = "coven-cave:dev-shell-recovery:reloaded-at";
+
+async function probeOrigin(): Promise<boolean> {
+  try {
+    // Any answer at all proves the dev server is back; the status does not
+    // matter, only that the loopback origin is no longer refusing connections.
+    await fetch(`${window.location.origin}/?__devShellProbe=${Date.now()}`, {
+      method: "HEAD",
+      cache: "no-store",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Keeps the desktop dev window from sitting silently on a dead loopback origin.
+ * Without this the window keeps the last-rendered document forever, and the
+ * first navigation reports a raw ChunkLoadError or ERR_CONNECTION_REFUSED with
+ * no way back short of hunting the process tree by hand.
+ */
+export function DevShellRecovery() {
+  // A build-time constant, so production drops the overlay and its heartbeat.
+  if (process.env.NODE_ENV !== "development") return null;
+  return <DevShellRecoveryOverlay />;
+}
+
+function DevShellRecoveryOverlay() {
+  const [state, setState] = useState<DevShellRecoveryState>("healthy");
+  const [reloadBlocked, setReloadBlocked] = useState(false);
+  const controllerRef = useRef<ReturnType<typeof createDevShellRecovery> | null>(null);
+
+  useEffect(() => {
+    const controller = createDevShellRecovery({
+      probe: probeOrigin,
+      reload: () => window.location.reload(),
+      onStateChange: (next) => {
+        setState(next);
+        setReloadBlocked(controllerRef.current?.reloadBlocked ?? false);
+      },
+      readLastReloadAt: () => {
+        const raw = window.sessionStorage.getItem(RELOAD_MARKER_KEY);
+        const parsed = raw === null ? Number.NaN : Number(raw);
+        return Number.isFinite(parsed) ? parsed : null;
+      },
+      writeLastReloadAt: (at) => {
+        window.sessionStorage.setItem(RELOAD_MARKER_KEY, String(at));
+      },
+    });
+    controllerRef.current = controller;
+
+    const onError = (event: ErrorEvent) => controller.report(event.error ?? event.message);
+    const onRejection = (event: PromiseRejectionEvent) => controller.report(event.reason);
+    window.addEventListener("error", onError);
+    window.addEventListener("unhandledrejection", onRejection);
+
+    // The passive listeners above only fire when the app happens to reach for
+    // the server, so poll as well: a window left idle must still notice.
+    const heartbeat = window.setInterval(() => {
+      if (document.hidden) return;
+      void probeOrigin().then((reachable) => {
+        if (!reachable) controller.observeOriginLost();
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(heartbeat);
+      window.removeEventListener("error", onError);
+      window.removeEventListener("unhandledrejection", onRejection);
+      controller.stop();
+      controllerRef.current = null;
+    };
+  }, []);
+
+  const retry = useCallback(() => {
+    controllerRef.current?.retry();
+    setReloadBlocked(false);
+  }, []);
+
+  if (state === "healthy") return null;
+  const reloading = state === "reloading";
+  const body = reloading
+    ? "The dev server answered. Reloading to pick up the new build."
+    : reloadBlocked
+      ? "Reloading did not clear the failure, so Cave stopped retrying. Restart the dev server, then reconnect."
+      : "The dev server stopped answering. Cave will reconnect on its own as soon as it comes back.";
+
+  return (
+    <div className="dev-shell-recovery" role="alert" aria-live="assertive">
+      <div className="dev-shell-recovery__card">
+        <h2 className="dev-shell-recovery__title">Dev server unreachable</h2>
+        <p className="dev-shell-recovery__body">{body}</p>
+        <p className="dev-shell-recovery__origin">{typeof window === "undefined" ? "" : window.location.origin}</p>
+        {!reloading ? (
+          <div className="dev-shell-recovery__actions">
+            <button type="button" className="dev-shell-recovery__button focus-ring" onClick={retry}>
+              Reconnect
+            </button>
+          </div>
+        ) : null}
+        <p className="dev-shell-recovery__status">
+          <span className="dev-shell-recovery__pulse" aria-hidden="true" />
+          {state === "checking" ? "Checking the dev server…" : null}
+          {state === "unreachable" && !reloadBlocked ? "Waiting for the dev server…" : null}
+          {state === "unreachable" && reloadBlocked ? "Paused after a failed reload." : null}
+          {reloading ? "Reloading…" : null}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/dev-shell-recovery.test.ts
+++ b/src/lib/dev-shell-recovery.test.ts
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+
+import {
+  RELOAD_LOOP_WINDOW_MS,
+  createDevShellRecovery,
+  isRecoverableShellFailure,
+  nextProbeDelayMs,
+} from "@/lib/dev-shell-recovery";
+
+// Classification: only reload-curable failures may take over the window.
+{
+  const chunkError = new Error("Loading chunk 4821 failed.");
+  chunkError.name = "ChunkLoadError";
+  assert.equal(isRecoverableShellFailure(chunkError), true);
+  assert.equal(
+    isRecoverableShellFailure(
+      new Error("Failed to fetch dynamically imported module: http://127.0.0.1:3000/_next/x.js"),
+    ),
+    true,
+  );
+  assert.equal(isRecoverableShellFailure("Loading CSS chunk app-layout failed"), true);
+  assert.equal(isRecoverableShellFailure("error loading dynamically imported module"), true);
+
+  assert.equal(
+    isRecoverableShellFailure(new TypeError("Cannot read properties of undefined")),
+    false,
+    "ordinary app errors must reach the real error boundaries instead",
+  );
+  assert.equal(isRecoverableShellFailure(undefined), false);
+  assert.equal(isRecoverableShellFailure({}), false);
+}
+
+// Backoff stays quick at first, then settles, and never runs off the end.
+{
+  assert.equal(nextProbeDelayMs(0), 500);
+  assert.equal(nextProbeDelayMs(1), 1000);
+  assert.deepEqual(nextProbeDelayMs(99), nextProbeDelayMs(4));
+  assert.equal(nextProbeDelayMs(-3), 500, "a negative attempt must not produce a negative delay");
+}
+
+type Harness = ReturnType<typeof harness>;
+
+function harness(overrides: { probeResults?: boolean[]; lastReloadAt?: number | null } = {}) {
+  const probeResults = [...(overrides.probeResults ?? [])];
+  const timers: Array<{ handler: () => void; delayMs: number }> = [];
+  const reloads: number[] = [];
+  const states: string[] = [];
+  let clock = 1_000_000;
+  let lastReloadAt = overrides.lastReloadAt ?? null;
+
+  const controller = createDevShellRecovery({
+    probe: async () => probeResults.shift() ?? false,
+    reload: () => reloads.push(clock),
+    onStateChange: (state) => states.push(state),
+    readLastReloadAt: () => lastReloadAt,
+    writeLastReloadAt: (at) => {
+      lastReloadAt = at;
+    },
+    now: () => clock,
+    setTimer: (handler, delayMs) => {
+      timers.push({ handler, delayMs });
+      return timers.length - 1;
+    },
+    clearTimer: (handle) => {
+      const index = handle as number;
+      if (timers[index]) timers[index] = { handler: () => {}, delayMs: 0 };
+    },
+  });
+
+  return {
+    controller,
+    reloads,
+    states,
+    timers,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    fireTimer: async () => {
+      const pending = timers.pop();
+      assert.ok(pending, "expected a scheduled probe");
+      pending.handler();
+      await flush();
+    },
+  };
+}
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+// A restarted server: the origin answers, so the stale chunk ids are dropped by
+// a hard reload rather than surfacing as a raw ChunkLoadError.
+{
+  const h: Harness = harness({ probeResults: [true] });
+  h.controller.report(new Error("ChunkLoadError: Loading chunk 12 failed"));
+  await flush();
+  assert.equal(h.reloads.length, 1, "a reachable origin must trigger the recovering reload");
+  assert.equal(h.controller.state, "reloading");
+  assert.deepEqual(h.states, ["checking", "reloading"]);
+}
+
+// A dead server: hold the recovery surface, poll, and reload once it returns.
+{
+  const h: Harness = harness({ probeResults: [false, false, true] });
+  h.controller.report("Failed to fetch dynamically imported module");
+  await flush();
+  assert.equal(h.controller.state, "unreachable");
+  assert.equal(h.reloads.length, 0, "an unreachable origin must not be reloaded into");
+  assert.equal(h.timers.at(-1)?.delayMs, 500);
+
+  await h.fireTimer();
+  assert.equal(h.controller.state, "unreachable");
+  assert.equal(h.timers.at(-1)?.delayMs, 1000, "repeated failures must back off");
+
+  await h.fireTimer();
+  assert.equal(h.reloads.length, 1, "the shell must recover itself once the origin returns");
+  assert.equal(h.controller.state, "reloading");
+}
+
+// Unrelated errors must not hijack the window.
+{
+  const h: Harness = harness({ probeResults: [true] });
+  h.controller.report(new TypeError("x is not a function"));
+  await flush();
+  assert.equal(h.controller.state, "healthy");
+  assert.equal(h.reloads.length, 0);
+  assert.deepEqual(h.states, []);
+}
+
+// A failure that survives its own reload must not spin the window forever.
+{
+  const h: Harness = harness({ probeResults: [true], lastReloadAt: 1_000_000 - 1_000 });
+  h.controller.report("ChunkLoadError");
+  await flush();
+  assert.equal(h.reloads.length, 0, "a just-reloaded shell must not reload again automatically");
+  assert.equal(h.controller.state, "unreachable");
+  assert.equal(h.controller.reloadBlocked, true, "the surface must explain that it stopped retrying");
+}
+
+// Past the loop window the same situation recovers normally again.
+{
+  const h: Harness = harness({
+    probeResults: [true],
+    lastReloadAt: 1_000_000 - RELOAD_LOOP_WINDOW_MS - 1,
+  });
+  h.controller.report("ChunkLoadError");
+  await flush();
+  assert.equal(h.reloads.length, 1);
+}
+
+// An explicit retry is a deliberate act and overrides the loop guard.
+{
+  const h: Harness = harness({ probeResults: [true, true], lastReloadAt: 1_000_000 });
+  h.controller.report("ChunkLoadError");
+  await flush();
+  assert.equal(h.reloads.length, 0);
+  assert.equal(h.controller.reloadBlocked, true);
+
+  h.controller.retry();
+  await flush();
+  assert.equal(h.reloads.length, 1, "retry must reload even inside the loop window");
+  assert.equal(h.controller.reloadBlocked, false);
+}
+
+// Unmounting must leave no timer able to reload a torn-down window.
+{
+  const h: Harness = harness({ probeResults: [false, true] });
+  h.controller.report("ChunkLoadError");
+  await flush();
+  h.controller.stop();
+  h.controller.retry();
+  h.controller.report("ChunkLoadError");
+  await flush();
+  assert.equal(h.reloads.length, 0, "a stopped controller must stay inert");
+}
+
+console.log("dev-shell-recovery: ok");

--- a/src/lib/dev-shell-recovery.ts
+++ b/src/lib/dev-shell-recovery.ts
@@ -1,0 +1,212 @@
+/**
+ * Dev-shell recovery: keeping the desktop window honest about a dead dev server.
+ *
+ * When the Next/Turbopack dev server dies or restarts under a running Tauri
+ * window, the WebView keeps the last-rendered document. Any navigation or lazy
+ * import then fails — a raw `ChunkLoadError` if the server is gone, or a stale
+ * chunk id if it came back with a fresh build. Neither of the app's error
+ * boundaries can help: `reset()` cannot refetch, and a reload lands on
+ * `ERR_CONNECTION_REFUSED`.
+ *
+ * This module owns the decision-making only; the DOM lives in the component so
+ * every transition here stays testable without a browser.
+ */
+
+export type DevShellRecoveryState =
+  /** Nothing has failed, or a probe proved the origin is fine. */
+  | "healthy"
+  /** A recoverable failure was seen; probing the origin right now. */
+  | "checking"
+  /** The origin refused the probe; polling until it comes back. */
+  | "unreachable"
+  /** The origin answered; a hard reload is in flight. */
+  | "reloading";
+
+const RECOVERABLE_PATTERNS = [
+  /ChunkLoadError/i,
+  /Loading chunk \S+ failed/i,
+  /Loading CSS chunk \S+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /Importing a module script failed/i,
+  /Failed to load (?:script|resource|chunk)/i,
+];
+
+function messageOf(reason: unknown): string {
+  if (typeof reason === "string") return reason;
+  if (reason instanceof Error) return `${reason.name}: ${reason.message}`;
+  if (reason && typeof reason === "object") {
+    const record = reason as { name?: unknown; message?: unknown };
+    const name = typeof record.name === "string" ? record.name : "";
+    const message = typeof record.message === "string" ? record.message : "";
+    if (name || message) return `${name}: ${message}`;
+  }
+  return "";
+}
+
+/**
+ * Only failures that a reload can actually cure. Ordinary app exceptions must
+ * fall through to the real error boundaries, which give a far better report.
+ */
+export function isRecoverableShellFailure(reason: unknown): boolean {
+  const message = messageOf(reason);
+  if (!message) return false;
+  return RECOVERABLE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+const PROBE_BACKOFF_MS = [500, 1000, 2000, 3000, 5000];
+
+/** Poll quickly at first — most dev restarts finish in a second or two. */
+export function nextProbeDelayMs(attempt: number): number {
+  const index = Math.min(Math.max(attempt, 0), PROBE_BACKOFF_MS.length - 1);
+  return PROBE_BACKOFF_MS[index];
+}
+
+/**
+ * A reload that immediately fails the same way would spin forever, so a reload
+ * is only automatic when the previous one is old enough to have been a genuine
+ * recovery rather than part of a loop.
+ */
+export const RELOAD_LOOP_WINDOW_MS = 10_000;
+
+export interface DevShellRecoveryOptions {
+  /** Resolves true when the dev origin serves a request again. */
+  probe: () => Promise<boolean>;
+  /** Hard-reloads the document, dropping stale Turbopack chunk ids. */
+  reload: () => void;
+  onStateChange?: (state: DevShellRecoveryState) => void;
+  /** Epoch ms of the last recovery reload, or null when there was none. */
+  readLastReloadAt?: () => number | null;
+  writeLastReloadAt?: (at: number) => void;
+  now?: () => number;
+  setTimer?: (handler: () => void, delayMs: number) => unknown;
+  clearTimer?: (handle: unknown) => void;
+}
+
+export interface DevShellRecoveryController {
+  readonly state: DevShellRecoveryState;
+  /** True when a reload was suppressed to avoid a reload loop. */
+  readonly reloadBlocked: boolean;
+  /** Feed a caught error or rejection reason; non-recoverable ones are ignored. */
+  report: (reason: unknown) => void;
+  /** Enter recovery with no error to classify, e.g. from the origin heartbeat. */
+  observeOriginLost: () => void;
+  /** Probe now, bypassing both the backoff timer and the loop guard. */
+  retry: () => void;
+  stop: () => void;
+}
+
+export function createDevShellRecovery(
+  options: DevShellRecoveryOptions,
+): DevShellRecoveryController {
+  const {
+    probe,
+    reload,
+    onStateChange,
+    readLastReloadAt = () => null,
+    writeLastReloadAt = () => {},
+    now = () => Date.now(),
+    setTimer = (handler, delayMs) => setTimeout(handler, delayMs),
+    clearTimer = (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>),
+  } = options;
+
+  let state: DevShellRecoveryState = "healthy";
+  let reloadBlocked = false;
+  let attempt = 0;
+  let timer: unknown = null;
+  let probing = false;
+  let stopped = false;
+
+  const setState = (next: DevShellRecoveryState) => {
+    if (state === next) return;
+    state = next;
+    onStateChange?.(state);
+  };
+
+  const cancelTimer = () => {
+    if (timer !== null) {
+      clearTimer(timer);
+      timer = null;
+    }
+  };
+
+  const performReload = (force: boolean) => {
+    const lastReloadAt = readLastReloadAt();
+    if (!force && lastReloadAt !== null && now() - lastReloadAt < RELOAD_LOOP_WINDOW_MS) {
+      // Reloading again would just replay the same failure. Hold the recovery
+      // surface up and let the developer decide when to retry.
+      reloadBlocked = true;
+      setState("unreachable");
+      return;
+    }
+    reloadBlocked = false;
+    writeLastReloadAt(now());
+    setState("reloading");
+    reload();
+  };
+
+  const runProbe = (force: boolean) => {
+    if (stopped || probing || state === "reloading") return;
+    probing = true;
+    setState("checking");
+    void probe()
+      .then((reachable) => {
+        probing = false;
+        if (stopped) return;
+        if (reachable) {
+          performReload(force);
+          return;
+        }
+        setState("unreachable");
+        scheduleProbe();
+      })
+      .catch(() => {
+        probing = false;
+        if (stopped) return;
+        setState("unreachable");
+        scheduleProbe();
+      });
+  };
+
+  const scheduleProbe = () => {
+    if (stopped) return;
+    cancelTimer();
+    const delay = nextProbeDelayMs(attempt);
+    attempt += 1;
+    timer = setTimer(() => {
+      timer = null;
+      runProbe(false);
+    }, delay);
+  };
+
+  const beginRecovery = () => {
+    if (stopped || state !== "healthy") return;
+    attempt = 0;
+    runProbe(false);
+  };
+
+  return {
+    get state() {
+      return state;
+    },
+    get reloadBlocked() {
+      return reloadBlocked;
+    },
+    report(reason: unknown) {
+      if (!isRecoverableShellFailure(reason)) return;
+      beginRecovery();
+    },
+    observeOriginLost: beginRecovery,
+    retry() {
+      if (stopped) return;
+      cancelTimer();
+      attempt = 0;
+      // An explicit retry is a deliberate act, so the loop guard steps aside.
+      runProbe(true);
+    },
+    stop() {
+      stopped = true;
+      cancelTimer();
+    },
+  };
+}

--- a/src/styles/dev-shell-recovery.css
+++ b/src/styles/dev-shell-recovery.css
@@ -1,0 +1,106 @@
+/* Dev-only recovery surface shown when the Next/Turbopack dev server dies under
+ * a running desktop window. It has to stay legible even if the app's own chunks
+ * are the thing that failed, so it leans only on foundation tokens. */
+
+.dev-shell-recovery {
+  position: fixed;
+  inset: 0;
+  z-index: 2147483000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: color-mix(in oklch, var(--background) 88%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.dev-shell-recovery__card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 420px;
+  padding: var(--space-6);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-panel);
+  background: var(--surface-raised, var(--background));
+  box-shadow: var(--shadow-panel, none);
+  text-align: left;
+}
+
+.dev-shell-recovery__title {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.dev-shell-recovery__body {
+  margin: 0;
+  font-size: var(--text-md);
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.dev-shell-recovery__origin {
+  font-family: var(--font-mono, monospace);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}
+
+.dev-shell-recovery__actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.dev-shell-recovery__button {
+  padding: var(--space-2) var(--space-4);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-primary);
+  font-size: var(--text-md);
+  cursor: pointer;
+}
+
+.dev-shell-recovery__button:hover {
+  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
+}
+
+.dev-shell-recovery__pulse {
+  width: var(--space-2);
+  height: var(--space-2);
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
+  animation: dev-shell-recovery-pulse 1.4s ease-in-out infinite;
+}
+
+.dev-shell-recovery__status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+@keyframes dev-shell-recovery-pulse {
+  0%,
+  100% {
+    opacity: 0.25;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dev-shell-recovery {
+    backdrop-filter: none;
+  }
+
+  .dev-shell-recovery__pulse {
+    animation: none;
+    opacity: 0.7;
+  }
+}


### PR DESCRIPTION
Closes #3854. Bead: `cave-jbi4`.

## Problem

When the Next/Turbopack dev server dies under a running Tauri window, the WebView keeps the last-rendered document. The next navigation or lazy import fails with a raw `ChunkLoadError` (server gone) or a stale chunk id (server came back with a fresh build). Neither error boundary helps — `reset()` cannot refetch, and a reload lands on `ERR_CONNECTION_REFUSED`. Recovery meant hunting the process tree by hand.

## Changes

**1. Next 16.2.9 → 16.2.11.** Focused patch bump; React and Tauri unchanged.

**2. `scripts/dev-app.sh` owns its process tree.** It no longer `exec`s into Tauri, so its traps actually run — previously the `EXIT` trap was discarded and the generated override config leaked on every run. INT/TERM/HUP/EXIT now walk the Tauri process tree (which includes the `beforeDevCommand` Next server) and escalate TERM → KILL, then warn if the port is somehow still bound.

**3. Dev-server watchdog.** Once the origin has been unreachable for 30 s the wrapper shuts the shell down rather than leaving it attached to a server that is not coming back. Overridable via `COVEN_CAVE_DEV_SERVER_GRACE_SECONDS`; `0` disables it. The grace window exists so ordinary restarts are handled in-app instead.

**4. In-app recovery.** `src/lib/dev-shell-recovery.ts` is a pure controller: it classifies chunk-load / dynamic-import failures (ordinary app errors still fall through to the real error boundaries), probes the origin on a 500 ms → 5 s backoff, and hard-reloads once it answers so stale Turbopack chunk ids are dropped. A loop guard refuses to auto-reload within 10 s of the last recovery reload, so a failure that survives its own reload cannot spin the window. A dev-only overlay (`src/components/dev-shell-recovery.tsx`) explains the wait and offers **Reconnect**, which overrides the guard. A 5 s heartbeat means an idle window notices too. Production drops the whole thing at build time.

## Coverage

- `scripts/dev-app-teardown.test.mjs` — runs the **real** wrapper in a temp repo against a fake Tauri tree that binds a port, then signals the launcher alone (not the process group, which would mask the orphan) with SIGTERM and SIGINT and asserts nothing survives. Verified to **fail against the previous script** (times out waiting for the port to be released) and pass against this one.
- `src/lib/dev-shell-recovery.test.ts` — classification, backoff schedule, restart path (reachable → reload), outage path (poll → recover → reload), loop guard, forced retry, and inertness after `stop()`.

## Validation

`pnpm typecheck`, `pnpm lint` (design codemod + ESLint gate), `pnpm build` (root CSS 636/660 KB, standalone 6809/7000 files — both in budget), `check-tests-wired`, `ui-consistency`, and the new + adjacent tests all pass locally.

**Correction (post-merge):** an earlier revision of this description claimed `src/lib/design-token-drift.test.ts` was failing on clean `origin/main`. That was my mistake — I ran it with `--require ./scripts/css-source-contract-hook.cjs`, which `run-tests.mjs` deliberately omits for this file (`RAW_CSS_SCANNER_TESTS`). The hook resolves CSS import facades, so the scanner double-counted the inlined cascade. Run as CI runs it, the test passes with every ratchet exactly at baseline: `font=152 space=1537 radius=209 hex=0 inline=230`. There is no drift, pre-existing or otherwise.

Windows is covered by the Cross-environment and Sidecar runtime CI legs.
