### PR TITLE
feat(voice): Kokoro TTS synthesis via sherpa-onnx runtime (cave-tr09i)

### DIFF
--- a/src/app/api/voice/engines/route.test.ts
+++ b/src/app/api/voice/engines/route.test.ts
@@ -38,7 +38,9 @@ test("GET /api/voice/engines advertises readonly readiness and management endpoi
     assert.ok(body.root.endsWith("voice-models"));
     assert.ok(body.stt.some((model: any) => model.engine === "whisper" && model.ready === false));
     assert.ok(body.tts.some((model: any) => model.engine === "piper" && model.verified === false));
+    assert.ok(body.tts.some((model: any) => model.engine === "kokoro" && model.verified === false));
     assert.equal(typeof body.runtimes?.piper?.available, "boolean");
+    assert.equal(typeof body.runtimes?.kokoro?.available, "boolean");
   });
 });
 

--- a/src/app/api/voice/engines/route.ts
+++ b/src/app/api/voice/engines/route.ts
@@ -1,21 +1,25 @@
 import { NextResponse } from "next/server.js";
 import { speechEnginesReadiness } from "../../../../lib/voice/speech-models.ts";
-import { piperRuntimeAvailability } from "../../../../lib/voice/local-tts-server.ts";
+import {
+  kokoroRuntimeAvailability,
+  piperRuntimeAvailability,
+} from "../../../../lib/voice/local-tts-server.ts";
 import { whisperRuntimeAvailable } from "../../../../lib/voice/sidecar-whisper.ts";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function GET() {
-  const [engines, piper, whisperAvailable] = await Promise.all([
+  const [engines, piper, kokoro, whisperAvailable] = await Promise.all([
     speechEnginesReadiness(),
     piperRuntimeAvailability(),
+    kokoroRuntimeAvailability(),
     whisperRuntimeAvailable(),
   ]);
   return NextResponse.json(
     {
       ...engines,
-      runtimes: { piper, whisper: { available: whisperAvailable } },
+      runtimes: { piper, kokoro, whisper: { available: whisperAvailable } },
     },
     { headers: { "cache-control": "no-store" } },
   );

--- a/src/app/api/voice/local/tts/route.test.ts
+++ b/src/app/api/voice/local/tts/route.test.ts
@@ -185,7 +185,7 @@ test("POST local TTS rejects unknown, unready, and unsupported-engine voices", a
     {
       readiness: async () => ({
         ...readyVoice,
-        engine: "kokoro",
+        engine: "espeak",
       }),
     },
   );
@@ -194,6 +194,66 @@ test("POST local TTS rejects unknown, unready, and unsupported-engine voices", a
     (await unsupported.json()).error,
     "local_tts_engine_unavailable",
   );
+});
+
+test("POST local TTS dispatches Kokoro voices with their positional companions", async () => {
+  let invocation = null;
+  const req = request({ text: "  Hello locally.  ", voiceName: "kokoro-en-v0-19" });
+  const res = await handleLocalTtsPost(
+    req,
+    {
+      readiness: async (voiceName) => {
+        assert.equal(voiceName, "kokoro-en-v0-19");
+        return {
+          ...readyVoice,
+          id: "kokoro-en-v0-19",
+          engine: "kokoro",
+          // Registry order contract: [voices.bin, tokens.txt].
+          companionPaths: ["C:\\voice-models\\voices.bin", "C:\\voice-models\\tokens.txt"],
+        };
+      },
+      kokoro: async (assets, text, signal) => {
+        invocation = { assets, text, signal };
+        return new Uint8Array([82, 73, 70, 70]);
+      },
+    },
+  );
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "audio/wav");
+  assert.deepEqual(invocation, {
+    assets: {
+      modelPath: readyVoice.path,
+      voicesPath: "C:\\voice-models\\voices.bin",
+      tokensPath: "C:\\voice-models\\tokens.txt",
+      // kokoroSpeakerId comes from the reviewed registry entry, not readiness.
+      speakerId: 0,
+    },
+    text: "Hello locally.",
+    signal: req.signal,
+  });
+});
+
+test("POST local TTS refuses a Kokoro voice whose companions are missing", async () => {
+  let ran = false;
+  const res = await handleLocalTtsPost(
+    request({ text: "hello", voiceName: "kokoro-en-v0-19" }),
+    {
+      readiness: async () => ({
+        ...readyVoice,
+        id: "kokoro-en-v0-19",
+        engine: "kokoro",
+        companionPaths: ["C:\\voice-models\\voices.bin"],
+      }),
+      kokoro: async () => {
+        ran = true;
+        return new Uint8Array([82]);
+      },
+    },
+  );
+  assert.equal(res.status, 409);
+  assert.equal((await res.json()).error, "local_voice_not_ready");
+  assert.equal(ran, false, "an incomplete Kokoro bundle must never reach the runner");
 });
 
 test("POST local TTS preserves runner machine codes and hints", async () => {

--- a/src/app/api/voice/local/tts/route.ts
+++ b/src/app/api/voice/local/tts/route.ts
@@ -7,7 +7,9 @@ import {
 } from "../../../../../lib/voice/speech-models.ts";
 import {
   LocalTtsSynthesisError,
+  runKokoro,
   runPiper,
+  type KokoroRunner,
   type PiperRunner,
 } from "../../../../../lib/voice/local-tts-server.ts";
 import {
@@ -27,6 +29,7 @@ export const LOCAL_TTS_MAX_BODY_BYTES = LOCAL_TTS_MAX_CHARS * 4 + 1_024;
 type LocalTtsRouteDependencies = {
   readiness?: (voiceName: string) => Promise<SpeechModelReadiness | null>;
   piper?: PiperRunner;
+  kokoro?: KokoroRunner;
 };
 
 async function defaultReadiness(
@@ -135,7 +138,37 @@ export async function handleLocalTtsPost(
           { status: 409 },
         );
       }
-      if (readiness.engine !== "piper") {
+      let audio: Uint8Array;
+      if (readiness.engine === "piper") {
+        audio = await (dependencies.piper ?? runPiper)(
+          readiness.path,
+          text,
+          req.signal,
+        );
+      } else if (readiness.engine === "kokoro") {
+        // Companion order is a registry contract: [voices.bin, tokens.txt].
+        const [voicesPath, tokensPath] = readiness.companionPaths ?? [];
+        if (!voicesPath || !tokensPath) {
+          return NextResponse.json(
+            {
+              ok: false,
+              error: "local_voice_not_ready",
+              hint: `Download and verify ${readiness.name} in Settings before using it.`,
+            },
+            { status: 409 },
+          );
+        }
+        audio = await (dependencies.kokoro ?? runKokoro)(
+          {
+            modelPath: readiness.path,
+            voicesPath,
+            tokensPath,
+            speakerId: registeredVoice.kokoroSpeakerId ?? 0,
+          },
+          text,
+          req.signal,
+        );
+      } else {
         return NextResponse.json(
           {
             ok: false,
@@ -145,12 +178,6 @@ export async function handleLocalTtsPost(
           { status: 503 },
         );
       }
-
-      const audio = await (dependencies.piper ?? runPiper)(
-        readiness.path,
-        text,
-        req.signal,
-      );
       const body = Uint8Array.from(audio).buffer;
       return new Response(body, {
         status: 200,

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -232,13 +232,13 @@ assert.match(
 );
 assert.match(
   source,
-  /voice\?\.ready === true[\s\S]{0,120}voice\?\.verified === true[\s\S]{0,120}voice\.engine === "piper"[\s\S]{0,80}piperAvailable/,
-  "only verified Piper voices with an available runner become selectable",
+  /voice\?\.ready === true[\s\S]{0,120}voice\?\.verified === true[\s\S]{0,120}\(voice\.engine === "piper" \|\| voice\.engine === "kokoro"\)[\s\S]{0,80}runtimeAvailable\(voice\.engine\)/,
+  "only verified local voices whose engine runtime is available become selectable",
 );
 assert.match(
   source,
-  /const piperAvailable = piper\?\.available === true;[\s\S]{0,100}const piperUnavailable = !piperAvailable/,
-  "a missing or malformed runtime report must not make a Piper voice selectable",
+  /const runtimeAvailable = \(engine: LocalTtsVoice\["engine"\]\) =>\s*runtimes\?\.\[engine\]\?\.available === true;/,
+  "a missing or malformed runtime report must not make a local voice selectable",
 );
 assert.match(
   source,

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -496,25 +496,45 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
           });
           return;
         }
-        const piper = json.runtimes?.piper as PiperRuntime | undefined;
+        const runtimes = json.runtimes as
+          | Partial<Record<LocalTtsVoice["engine"], PiperRuntime>>
+          | undefined;
         // Treat an absent/malformed runtime report as unavailable. A ready
         // model alone cannot synthesize, and offering it during a sidecar
         // version mismatch only leads to a failing preview/call.
-        const piperAvailable = piper?.available === true;
-        const piperUnavailable = !piperAvailable;
+        const runtimeAvailable = (engine: LocalTtsVoice["engine"]) =>
+          runtimes?.[engine]?.available === true;
         const verifiedVoices = json.tts.filter(
           (voice: LocalTtsVoice) =>
             voice?.ready === true &&
             voice?.verified === true &&
-            voice.engine === "piper" &&
-            piperAvailable,
+            (voice.engine === "piper" || voice.engine === "kokoro") &&
+            runtimeAvailable(voice.engine),
         );
+        const piperUnavailable = !runtimeAvailable("piper");
+        // Kokoro is additive: only surface its runtime hint when it hides a
+        // downloaded voice, so Piper-only setups never see noise about a
+        // runtime they don't use.
+        const kokoroHidden =
+          !runtimeAvailable("kokoro") &&
+          json.tts.some(
+            (voice: LocalTtsVoice) =>
+              voice?.ready === true &&
+              voice?.verified === true &&
+              voice.engine === "kokoro",
+          );
+        const runtimeNotes = [
+          ...(piperUnavailable
+            ? [runtimes?.piper?.hint ?? "The local Piper runtime isn't available on this device."]
+            : []),
+          ...(kokoroHidden
+            ? [runtimes?.kokoro?.hint ?? "The local Kokoro runtime isn't available on this device."]
+            : []),
+        ];
         setLocalVoiceCatalog({
           status: "ready",
           voices: verifiedVoices,
-          note: piperUnavailable
-            ? piper?.hint ?? "The local Piper runtime isn't available on this device."
-            : undefined,
+          note: runtimeNotes.length ? runtimeNotes.join(" ") : undefined,
         });
       } catch {
         if (!cancelled) {

--- a/src/components/voice-engine-settings.tsx
+++ b/src/components/voice-engine-settings.tsx
@@ -40,7 +40,7 @@ function downloadLabel(job: DownloadJob | undefined): string | null {
 export function VoiceEngineSettings() {
   const [models, setModels] = useState<VoiceModel[]>([]);
   const [jobs, setJobs] = useState<DownloadJob[]>([]);
-  const [runtime, setRuntime] = useState<RuntimeStatus | null>(null);
+  const [runtimes, setRuntimes] = useState<{ piper?: RuntimeStatus; kokoro?: RuntimeStatus } | null>(null);
   const [status, setStatus] = useState<"loading" | "ready" | "error">("loading");
   const [busyModelId, setBusyModelId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -55,14 +55,17 @@ export function VoiceEngineSettings() {
         fetch("/api/voice/engines", { cache: "no-store" }),
         fetch("/api/voice/engines/downloads", { cache: "no-store" }),
       ]);
-      const engines = await enginesResponse.json().catch(() => null) as { ok?: unknown; tts?: unknown; runtimes?: { piper?: RuntimeStatus } } | null;
+      const engines = await enginesResponse.json().catch(() => null) as { ok?: unknown; tts?: unknown; runtimes?: { piper?: RuntimeStatus; kokoro?: RuntimeStatus } } | null;
       const downloadJobs = await jobsResponse.json().catch(() => null) as { ok?: unknown; jobs?: unknown } | null;
       if (!enginesResponse.ok || engines?.ok !== true || !Array.isArray(engines.tts) || !jobsResponse.ok || downloadJobs?.ok !== true || !Array.isArray(downloadJobs.jobs)) {
         throw new Error("The local speech service returned an invalid response.");
       }
       setModels(engines.tts.filter(isVoiceModel));
       setJobs(downloadJobs.jobs.filter(isDownloadJob));
-      setRuntime(engines.runtimes?.piper ?? { available: false });
+      setRuntimes({
+        piper: engines.runtimes?.piper ?? { available: false },
+        kokoro: engines.runtimes?.kokoro ?? { available: false },
+      });
       setStatus("ready");
     } catch (cause) {
       setStatus("error");
@@ -117,9 +120,16 @@ export function VoiceEngineSettings() {
   return (
     <SettingsGroup label="Local speech" description="Downloaded voices stay on this device and are verified before Piper can use them.">
       <div className="flex items-center justify-between gap-3 border-b border-[var(--border-hairline)] px-4 py-3">
-        <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]" role="status">
-          {status === "loading" ? "Loading local voices…" : runtime?.available === true ? "Piper runtime ready." : runtime?.hint ?? "Piper runtime unavailable. Downloaded voices remain unavailable until Piper is installed."}
-        </p>
+        <div className="min-w-0">
+          <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]" role="status">
+            {status === "loading" ? "Loading local voices…" : runtimes?.piper?.available === true ? "Piper runtime ready." : runtimes?.piper?.hint ?? "Piper runtime unavailable. Downloaded voices remain unavailable until Piper is installed."}
+          </p>
+          {status !== "loading" && models.some((model) => model.engine === "kokoro") ? (
+            <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
+              {runtimes?.kokoro?.available === true ? "Kokoro runtime ready." : runtimes?.kokoro?.hint ?? "Kokoro runtime unavailable. Kokoro voices remain unavailable until it is installed."}
+            </p>
+          ) : null}
+        </div>
         <Button size="xs" variant="ghost" onClick={() => void refresh()} loading={status === "loading"} leadingIcon="ph:arrows-clockwise">Refresh</Button>
       </div>
       {models.map((model) => {

--- a/src/lib/voice/local-tts-server.test.ts
+++ b/src/lib/voice/local-tts-server.test.ts
@@ -8,10 +8,13 @@ import path from "node:path";
 import { PassThrough } from "node:stream";
 import { test } from "node:test";
 import {
+  kokoroExecutable,
   LocalTtsSynthesisError,
   piperExecutable,
   piperSpawnEnv,
+  probeKokoroRuntime,
   probePiperRuntime,
+  runKokoroWithDependencies,
   runPiperWithDependencies,
 } from "./local-tts-server.ts";
 
@@ -270,4 +273,148 @@ test("packaged builds require the managed Piper resource instead of PATH", () =>
     null,
   );
   assert.equal(piperExecutable({ PATH: "development-path" }), "piper");
+});
+
+const kokoroAssets = {
+  modelPath: "kokoro-model.onnx",
+  voicesPath: "voices.bin",
+  tokensPath: "tokens.txt",
+  speakerId: 4,
+};
+
+test("Kokoro runner passes the utterance as argv and cleans its bounded WAV output", async () => {
+  let command = null;
+  let argv = null;
+  let options = null;
+  let outputDirectory = null;
+  const fakeRunner = (receivedCommand, receivedArgs, receivedOptions) => {
+    command = receivedCommand;
+    argv = receivedArgs;
+    options = receivedOptions;
+    const child = new EventEmitter();
+    child.stderr = new PassThrough();
+    child.kill = () => true;
+    const outputPath = receivedArgs
+      .find((arg) => arg.startsWith("--output-filename="))
+      .slice("--output-filename=".length);
+    outputDirectory = path.dirname(outputPath);
+    assert.notEqual(outputDirectory, os.tmpdir());
+    assert.match(path.basename(outputDirectory), /^coven-kokoro-/);
+    writeFileSync(outputPath, Buffer.from("RIFF"));
+    queueMicrotask(() => child.emit("close", 0));
+    return child;
+  };
+
+  const wav = await runKokoroWithDependencies(
+    kokoroAssets,
+    "  Hello from\r\nKokoro.  ",
+    undefined,
+    { spawnImpl: fakeRunner },
+  );
+
+  assert.equal(command, "sherpa-onnx-offline-tts");
+  assert.deepEqual(argv.slice(0, 3), [
+    "--kokoro-model=kokoro-model.onnx",
+    "--kokoro-voices=voices.bin",
+    "--kokoro-tokens=tokens.txt",
+  ]);
+  assert.ok(argv.includes("--sid=4"));
+  // sherpa-onnx ignores stdin: the normalized utterance must be the final
+  // positional argument, and no stdin pipe is opened at all.
+  assert.equal(argv[argv.length - 1], "Hello from Kokoro.");
+  assert.equal(options.stdio[0], "ignore");
+  assert.equal(options.windowsHide, true);
+  assert.deepEqual([...wav], [82, 73, 70, 70]);
+  assert.equal(existsSync(outputDirectory), false, "the private audio directory is removed");
+});
+
+test("Kokoro runner passes the managed runtime's espeak data directory", async () => {
+  const runtimeDir = await mkdtemp(path.join(os.tmpdir(), "coven-kokoro-runtime-"));
+  await mkdir(path.join(runtimeDir, "espeak-ng-data"));
+  let argv = null;
+  const fakeRunner = (_command, args) => {
+    argv = args;
+    const child = new EventEmitter();
+    child.stderr = new PassThrough();
+    child.kill = () => true;
+    const outputPath = args
+      .find((arg) => arg.startsWith("--output-filename="))
+      .slice("--output-filename=".length);
+    writeFileSync(outputPath, Buffer.from("RIFF"));
+    queueMicrotask(() => child.emit("close", 0));
+    return child;
+  };
+
+  try {
+    await runKokoroWithDependencies(kokoroAssets, "Packaged voice.", undefined, {
+      executable: path.join(runtimeDir, process.platform === "win32" ? "sherpa-onnx-offline-tts.exe" : "sherpa-onnx-offline-tts"),
+      spawnImpl: fakeRunner,
+    });
+    assert.ok(
+      argv.includes(`--kokoro-data-dir=${path.join(runtimeDir, "espeak-ng-data")}`),
+    );
+  } finally {
+    await remove(runtimeDir, { recursive: true, force: true });
+  }
+});
+
+test("Kokoro runner rejects invalid speaker ids and empty utterances before spawning", async () => {
+  let spawned = false;
+  const mustNotSpawn = () => { spawned = true; throw new Error("must not spawn"); };
+  await assert.rejects(
+    () => runKokoroWithDependencies({ ...kokoroAssets, speakerId: 1.5 }, "Hello.", undefined, {
+      spawnImpl: mustNotSpawn,
+    }),
+    (error) => error instanceof LocalTtsSynthesisError && error.code === "local_tts_failed",
+  );
+  await assert.rejects(
+    () => runKokoroWithDependencies(kokoroAssets, " \n\t ", undefined, {
+      spawnImpl: mustNotSpawn,
+    }),
+    (error) => error instanceof LocalTtsSynthesisError && error.code === "local_tts_failed",
+  );
+  assert.equal(spawned, false);
+});
+
+test("Kokoro runner reports a missing runtime as engine-unavailable", async () => {
+  const missingRunner = () => {
+    const child = new EventEmitter();
+    child.stderr = new PassThrough();
+    child.kill = () => true;
+    queueMicrotask(() => child.emit("error", Object.assign(new Error("missing"), { code: "ENOENT" })));
+    return child;
+  };
+  await assert.rejects(
+    () => runKokoroWithDependencies(kokoroAssets, "Hello locally.", undefined, { spawnImpl: missingRunner }),
+    (error) =>
+      error instanceof LocalTtsSynthesisError &&
+      error.code === "local_tts_engine_unavailable" &&
+      /sherpa-onnx/.test(error.message),
+  );
+});
+
+test("Kokoro availability probe mirrors the Piper probe contract", async () => {
+  const healthy = () => {
+    const child = new EventEmitter();
+    child.kill = () => true;
+    queueMicrotask(() => child.emit("close", 0));
+    return child;
+  };
+  assert.deepEqual(
+    await probeKokoroRuntime("sherpa-onnx-offline-tts", { spawnImpl: healthy }),
+    { available: true },
+  );
+
+  const missing = () => { throw new Error("spawn ENOENT"); };
+  const unavailable = await probeKokoroRuntime("sherpa-onnx-offline-tts", { spawnImpl: missing });
+  assert.equal(unavailable.available, false);
+  assert.match(unavailable.hint, /sherpa-onnx/);
+});
+
+test("packaged builds require a managed Kokoro resource instead of PATH", () => {
+  assert.equal(
+    kokoroExecutable({ COVEN_CAVE_BUNDLE: "1", PATH: "untrusted-path" }),
+    null,
+  );
+  assert.equal(kokoroExecutable({ PATH: "development-path" }), "sherpa-onnx-offline-tts");
 });

--- a/src/lib/voice/local-tts-server.ts
+++ b/src/lib/voice/local-tts-server.ts
@@ -92,9 +92,18 @@ const defaultPiperTiming: PiperTiming = {
   forceKillSettleMs: PIPER_FORCE_KILL_SETTLE_MS,
 };
 
-/** Probe Piper with the same bounded termination policy as synthesis. */
-export async function probePiperRuntime(
+type LocalTtsProbeHints = {
+  /** The runtime binary could not be spawned at all. */
+  install: string;
+  /** The runtime spawned but had to be terminated after the probe timeout. */
+  unresponsive: string;
+  /** The runtime exited with a non-zero status. */
+  broken: string;
+};
+
+async function probeLocalTtsRuntime(
   executable: string,
+  hints: LocalTtsProbeHints,
   dependencies: {
     spawnImpl?: PiperSpawn;
     timeoutMs?: number;
@@ -125,7 +134,7 @@ export async function probePiperRuntime(
         windowsHide: true,
       });
     } catch {
-      finish({ available: false, hint: "Install the local Piper runtime before selecting a Piper voice." });
+      finish({ available: false, hint: hints.install });
       return;
     }
     timeout = setTimeout(() => {
@@ -137,29 +146,43 @@ export async function probePiperRuntime(
       }
       // A corrupted runtime can ignore SIGTERM on POSIX. Escalate before
       // reporting it unavailable so repeated catalog refreshes cannot leak
-      // background Piper probes.
+      // background probe processes.
       forceKillTimer = setTimeout(() => {
         try {
           child.kill("SIGKILL");
         } catch {
           // The process may have exited while the timer was pending.
         }
-        finish({ available: false, hint: "Piper did not respond. Install the supported local Piper runtime." });
+        finish({ available: false, hint: hints.unresponsive });
       }, terminationGraceMs);
     }, timeoutMs);
     child.once("error", () => {
-      finish(terminating
-        ? { available: false, hint: "Piper did not respond. Install the supported local Piper runtime." }
-        : { available: false, hint: "Install the local Piper runtime before selecting a Piper voice." });
+      finish({ available: false, hint: terminating ? hints.unresponsive : hints.install });
     });
     child.once("close", (code) => {
       finish(terminating
-        ? { available: false, hint: "Piper did not respond. Install the supported local Piper runtime." }
+        ? { available: false, hint: hints.unresponsive }
         : code === 0
           ? { available: true }
-          : { available: false, hint: "The local Piper runtime is unavailable. Check its installation." });
+          : { available: false, hint: hints.broken });
     });
   });
+}
+
+/** Probe Piper with the same bounded termination policy as synthesis. */
+export async function probePiperRuntime(
+  executable: string,
+  dependencies: {
+    spawnImpl?: PiperSpawn;
+    timeoutMs?: number;
+    terminationGraceMs?: number;
+  } = {},
+): Promise<PiperRuntimeAvailability> {
+  return probeLocalTtsRuntime(executable, {
+    install: "Install the local Piper runtime before selecting a Piper voice.",
+    unresponsive: "Piper did not respond. Install the supported local Piper runtime.",
+    broken: "The local Piper runtime is unavailable. Check its installation.",
+  }, dependencies);
 }
 
 /** Probe the controlled, minimal environment used for synthesis. */
@@ -179,59 +202,99 @@ export async function piperRuntimeAvailability(): Promise<PiperRuntimeAvailabili
   return value;
 }
 
-export async function runPiperWithDependencies(
-  modelPath: string,
-  text: string,
-  signal?: AbortSignal,
+let kokoroAvailability: { checkedAt: number; value: PiperRuntimeAvailability } | null = null;
+
+/**
+ * Kokoro synthesis runs through the sherpa-onnx offline TTS CLI. Packaged
+ * builds will inject COVEN_KOKORO_BIN once the runtime ships as a signed app
+ * resource (packaging follow-up to cave-tr09i); until then PATH resolution is
+ * development-only so a packaged app never executes an arbitrary binary.
+ */
+export function kokoroExecutable(env: NodeJS.ProcessEnv = process.env): string | null {
+  const configured = env.COVEN_KOKORO_BIN?.trim();
+  if (configured) return existsSync(configured) ? configured : null;
+  return env.COVEN_CAVE_BUNDLE === "1" ? null : "sherpa-onnx-offline-tts";
+}
+
+/** Probe the sherpa-onnx Kokoro runtime with the same termination policy. */
+export async function probeKokoroRuntime(
+  executable: string,
   dependencies: {
     spawnImpl?: PiperSpawn;
-    executable?: string | null;
-    timing?: Partial<PiperTiming>;
-    removeImpl?: typeof rm;
+    timeoutMs?: number;
+    terminationGraceMs?: number;
   } = {},
-): Promise<Uint8Array> {
-  const spawnImpl = dependencies.spawnImpl ?? spawn;
-  const removeImpl = dependencies.removeImpl ?? rm;
-  const timing = { ...defaultPiperTiming, ...dependencies.timing };
-  const executable = dependencies.executable ?? piperExecutable();
+): Promise<PiperRuntimeAvailability> {
+  return probeLocalTtsRuntime(executable, {
+    install: "Install the sherpa-onnx-offline-tts runtime before selecting a Kokoro voice.",
+    unresponsive: "The Kokoro runtime did not respond. Install the supported sherpa-onnx-offline-tts runtime.",
+    broken: "The local Kokoro runtime is unavailable. Check its installation.",
+  }, dependencies);
+}
+
+export async function kokoroRuntimeAvailability(): Promise<PiperRuntimeAvailability> {
+  if (kokoroAvailability && Date.now() - kokoroAvailability.checkedAt < PIPER_PROBE_TIMEOUT_MS) {
+    return kokoroAvailability.value;
+  }
+  const executable = kokoroExecutable();
   if (!executable) {
-    throw new LocalTtsSynthesisError(
-      "local_tts_engine_unavailable",
-      "The bundled Piper runtime is missing. Reinstall CovenCave before selecting a Piper voice.",
-    );
+    return {
+      available: false,
+      hint: "This CovenCave build doesn't bundle the Kokoro runtime yet. Kokoro voices need the sherpa-onnx-offline-tts runtime.",
+    };
   }
-  // Piper consumes stdin line-by-line. Collapse all user whitespace before
-  // adding the one protocol newline so a streamed response cannot become
-  // multiple synthesis requests writing to the same WAV path.
-  const utterance = text.replace(/\s+/gu, " ").trim();
-  if (!utterance) {
-    throw new LocalTtsSynthesisError("local_tts_failed", "Piper received an empty utterance.");
-  }
+  const value = await probeKokoroRuntime(executable);
+  kokoroAvailability = { checkedAt: Date.now(), value };
+  return value;
+}
+
+// Both local runtimes consume exactly one utterance per request. Collapse all
+// user whitespace up front so streamed text cannot become multiple synthesis
+// requests (Piper treats each stdin line as a request) or mangled argv
+// (Kokoro receives the utterance as a positional argument).
+function normalizeLocalTtsUtterance(text: string): string {
+  return text.replace(/\s+/gu, " ").trim();
+}
+
+type LocalTtsChildRequest = {
+  /** Prefix for user-facing failure messages, e.g. "Piper failed: …". */
+  label: "Piper" | "Kokoro";
+  /** mkdtemp prefix for the private WAV output directory. */
+  tempPrefix: string;
+  executable: string;
+  /** argv given the private WAV output path chosen by the harness. */
+  buildArgs: (outputPath: string) => string[];
+  /** When set, written to the child's stdin with the protocol newline;
+   *  otherwise stdin is not opened at all. */
+  stdinUtterance?: string;
+  /** ENOENT at spawn time, phrased per engine. */
+  engineUnavailableMessage: string;
+  signal?: AbortSignal;
+  spawnImpl: PiperSpawn;
+  timing: PiperTiming;
+  removeImpl: typeof rm;
+};
+
+/**
+ * Shared hardened child-to-WAV harness: private 0o700 temp directory,
+ * scrubbed environment, bounded runtime with SIGTERM→SIGKILL escalation,
+ * bounded output size, and guaranteed temp cleanup.
+ */
+async function synthesizeWithLocalTtsChild(request: LocalTtsChildRequest): Promise<Uint8Array> {
+  const { label, signal, spawnImpl, timing, removeImpl } = request;
   const outputDirectory = await mkdtemp(
-    path.join(/* turbopackIgnore: true */ os.tmpdir(), "coven-piper-"),
+    path.join(/* turbopackIgnore: true */ os.tmpdir(), request.tempPrefix),
   );
   const outputPath = path.join(/* turbopackIgnore: true */ outputDirectory, "speech.wav");
   try {
     // mkdtemp creates a private directory on POSIX; chmod makes that privacy
-    // boundary explicit before Piper receives a path to write conversational
-    // audio into. Windows ignores POSIX permission bits safely.
+    // boundary explicit before the runtime receives a path to write
+    // conversational audio into. Windows ignores POSIX permission bits safely.
     await chmod(/* turbopackIgnore: true */ outputDirectory, 0o700);
     await new Promise<void>((resolve, reject) => {
-      // Piper's Windows/macOS/Linux archives keep espeak-ng-data beside the
-      // executable. The sidecar runs from resources/server, so leaving this to
-      // Piper's cwd-relative default makes every packaged voice fail to
-      // phonemize despite the bundled runtime being present.
-      const bundledEspeakData = path.join(
-        /* turbopackIgnore: true */ path.dirname(executable),
-        "espeak-ng-data",
-      );
-      const args = ["-m", modelPath, "-f", outputPath];
-      if (existsSync(bundledEspeakData)) {
-        args.push("--espeak_data", bundledEspeakData);
-      }
-      const child: ChildProcess = spawnImpl(executable, args, {
+      const child: ChildProcess = spawnImpl(request.executable, request.buildArgs(outputPath), {
         env: piperSpawnEnv(),
-        stdio: ["pipe", "ignore", "pipe"],
+        stdio: [request.stdinUtterance === undefined ? "ignore" : "pipe", "ignore", "pipe"],
         windowsHide: true,
       });
       let stderr = "";
@@ -282,7 +345,7 @@ export async function runPiperWithDependencies(
       ));
       const timeout = setTimeout(() => terminate(new LocalTtsSynthesisError(
         "local_tts_failed",
-        "Piper took too long to synthesize this utterance.",
+        `${label} took too long to synthesize this utterance.`,
       )), timing.timeoutMs);
       const fileCheck = setInterval(() => {
         if (checkingFile || terminating) return;
@@ -292,7 +355,7 @@ export async function runPiperWithDependencies(
             if (info.size > MAX_AUDIO_BYTES) {
               terminate(new LocalTtsSynthesisError(
                 "local_tts_failed",
-                "Piper produced oversized audio.",
+                `${label} produced oversized audio.`,
               ));
             }
           })
@@ -312,14 +375,14 @@ export async function runPiperWithDependencies(
         if (terminating) return;
         terminate(new LocalTtsSynthesisError(
           "local_tts_failed",
-          `Piper input stream failed (${error.message}).`,
+          `${label} input stream failed (${error.message}).`,
         ));
       });
       child.on("error", (error: NodeJS.ErrnoException) => {
         if (terminating) return finish(terminating);
         finish(error.code === "ENOENT"
-          ? new LocalTtsSynthesisError("local_tts_engine_unavailable", "The local Piper runtime isn't available. Install it before selecting a Piper voice.")
-          : new LocalTtsSynthesisError("local_tts_failed", `Piper couldn't start (${error.message}).`));
+          ? new LocalTtsSynthesisError("local_tts_engine_unavailable", request.engineUnavailableMessage)
+          : new LocalTtsSynthesisError("local_tts_failed", `${label} couldn't start (${error.message}).`));
       });
       child.on("close", (code) => {
         if (terminating) return finish(terminating);
@@ -327,19 +390,19 @@ export async function runPiperWithDependencies(
         const detail = stderr.trim();
         finish(new LocalTtsSynthesisError(
           "local_tts_failed",
-          detail ? `Piper failed: ${detail}` : `Piper exited with code ${code ?? "unknown"}.`,
+          detail ? `${label} failed: ${detail}` : `${label} exited with code ${code ?? "unknown"}.`,
         ));
       });
       if (signal?.aborted) abort();
       else signal?.addEventListener("abort", abort, { once: true });
-      // Piper reads one utterance per stdin line. Do not pass text as argv:
-      // that path is rejected by Piper's argument parser.
-      child.stdin?.end(`${utterance}\n`);
+      if (request.stdinUtterance !== undefined) {
+        child.stdin?.end(`${request.stdinUtterance}\n`);
+      }
     });
 
     const info = await stat(/* turbopackIgnore: true */ outputPath);
     if (!info.isFile() || info.size === 0 || info.size > MAX_AUDIO_BYTES) {
-      throw new LocalTtsSynthesisError("local_tts_failed", "Piper returned invalid or oversized audio.");
+      throw new LocalTtsSynthesisError("local_tts_failed", `${label} returned invalid or oversized audio.`);
     }
     return new Uint8Array(await readFile(/* turbopackIgnore: true */ outputPath));
   } finally {
@@ -355,10 +418,148 @@ export async function runPiperWithDependencies(
   }
 }
 
+export async function runPiperWithDependencies(
+  modelPath: string,
+  text: string,
+  signal?: AbortSignal,
+  dependencies: {
+    spawnImpl?: PiperSpawn;
+    executable?: string | null;
+    timing?: Partial<PiperTiming>;
+    removeImpl?: typeof rm;
+  } = {},
+): Promise<Uint8Array> {
+  const executable = dependencies.executable ?? piperExecutable();
+  if (!executable) {
+    throw new LocalTtsSynthesisError(
+      "local_tts_engine_unavailable",
+      "The bundled Piper runtime is missing. Reinstall CovenCave before selecting a Piper voice.",
+    );
+  }
+  const utterance = normalizeLocalTtsUtterance(text);
+  if (!utterance) {
+    throw new LocalTtsSynthesisError("local_tts_failed", "Piper received an empty utterance.");
+  }
+  return synthesizeWithLocalTtsChild({
+    label: "Piper",
+    tempPrefix: "coven-piper-",
+    executable,
+    buildArgs: (outputPath) => {
+      // Piper's Windows/macOS/Linux archives keep espeak-ng-data beside the
+      // executable. The sidecar runs from resources/server, so leaving this to
+      // Piper's cwd-relative default makes every packaged voice fail to
+      // phonemize despite the bundled runtime being present.
+      const bundledEspeakData = path.join(
+        /* turbopackIgnore: true */ path.dirname(executable),
+        "espeak-ng-data",
+      );
+      const args = ["-m", modelPath, "-f", outputPath];
+      if (existsSync(bundledEspeakData)) {
+        args.push("--espeak_data", bundledEspeakData);
+      }
+      return args;
+    },
+    // Piper reads one utterance per stdin line. Do not pass text as argv:
+    // that path is rejected by Piper's argument parser.
+    stdinUtterance: utterance,
+    engineUnavailableMessage:
+      "The local Piper runtime isn't available. Install it before selecting a Piper voice.",
+    signal,
+    spawnImpl: dependencies.spawnImpl ?? spawn,
+    timing: { ...defaultPiperTiming, ...dependencies.timing },
+    removeImpl: dependencies.removeImpl ?? rm,
+  });
+}
+
 /**
  * Run Piper as a local child of the Node sidecar. Packaged builds use the
  * signed resource path injected by the desktop launcher.
  */
 export const runPiper: PiperRunner = async (modelPath, text, signal) => {
   return runPiperWithDependencies(modelPath, text, signal);
+};
+
+export type KokoroModelAssets = {
+  modelPath: string;
+  voicesPath: string;
+  tokensPath: string;
+  /** Registry-pinned row inside the voices file (sherpa-onnx --sid). */
+  speakerId: number;
+};
+
+export type KokoroRunner = (
+  assets: KokoroModelAssets,
+  text: string,
+  signal?: AbortSignal,
+) => Promise<Uint8Array>;
+
+export async function runKokoroWithDependencies(
+  assets: KokoroModelAssets,
+  text: string,
+  signal?: AbortSignal,
+  dependencies: {
+    spawnImpl?: PiperSpawn;
+    executable?: string | null;
+    timing?: Partial<PiperTiming>;
+    removeImpl?: typeof rm;
+  } = {},
+): Promise<Uint8Array> {
+  const executable = dependencies.executable ?? kokoroExecutable();
+  if (!executable) {
+    throw new LocalTtsSynthesisError(
+      "local_tts_engine_unavailable",
+      "This CovenCave build doesn't bundle the Kokoro runtime yet. Kokoro voices need the sherpa-onnx-offline-tts runtime.",
+    );
+  }
+  // The speaker id is registry data, but it still becomes argv for a child
+  // process: reject anything that isn't a plain non-negative integer.
+  if (!Number.isSafeInteger(assets.speakerId) || assets.speakerId < 0) {
+    throw new LocalTtsSynthesisError("local_tts_failed", "Kokoro received an invalid speaker id.");
+  }
+  const utterance = normalizeLocalTtsUtterance(text);
+  if (!utterance) {
+    throw new LocalTtsSynthesisError("local_tts_failed", "Kokoro received an empty utterance.");
+  }
+  return synthesizeWithLocalTtsChild({
+    label: "Kokoro",
+    tempPrefix: "coven-kokoro-",
+    executable,
+    buildArgs: (outputPath) => {
+      // sherpa-onnx archives keep espeak-ng-data beside the executable,
+      // mirroring Piper's layout. Kokoro phonemization needs the explicit
+      // path for the same reason Piper does: the sidecar's cwd is not the
+      // runtime directory.
+      const bundledEspeakData = path.join(
+        /* turbopackIgnore: true */ path.dirname(executable),
+        "espeak-ng-data",
+      );
+      return [
+        `--kokoro-model=${assets.modelPath}`,
+        `--kokoro-voices=${assets.voicesPath}`,
+        `--kokoro-tokens=${assets.tokensPath}`,
+        ...(existsSync(bundledEspeakData)
+          ? [`--kokoro-data-dir=${bundledEspeakData}`]
+          : []),
+        `--sid=${assets.speakerId}`,
+        `--output-filename=${outputPath}`,
+        // sherpa-onnx-offline-tts takes the utterance as its positional
+        // argument and ignores stdin entirely (the opposite of Piper).
+        utterance,
+      ];
+    },
+    engineUnavailableMessage:
+      "The local Kokoro runtime isn't available. Install sherpa-onnx-offline-tts before selecting a Kokoro voice.",
+    signal,
+    spawnImpl: dependencies.spawnImpl ?? spawn,
+    timing: { ...defaultPiperTiming, ...dependencies.timing },
+    removeImpl: dependencies.removeImpl ?? rm,
+  });
+}
+
+/**
+ * Run Kokoro (via sherpa-onnx) as a local child of the Node sidecar, under
+ * the same isolation contract as Piper.
+ */
+export const runKokoro: KokoroRunner = async (assets, text, signal) => {
+  return runKokoroWithDependencies(assets, text, signal);
 };

--- a/src/lib/voice/speech-models.test.ts
+++ b/src/lib/voice/speech-models.test.ts
@@ -11,7 +11,7 @@ import {
   runSpeechModelDownload,
   type SpeechModelRegistryEntry,
   speechEnginesReadiness,
-  speechModelCompanionPath,
+  speechModelCompanionPaths,
   speechModelPath,
   speechModelReadiness,
   startSpeechModelDownload,
@@ -51,10 +51,10 @@ test("speech registry is static, reviewed, and grouped for readiness consumers",
     assert.match(model.sha256, /^[a-f0-9]{64}$/);
     assert.ok(model.sizeBytes > 0);
     assert.ok(model.license.length > 0);
-    if (model.companion) {
-      assert.match(model.companion.url, /^https:\/\//);
-      assert.match(model.companion.sha256, /^[a-f0-9]{64}$/);
-      assert.ok(model.companion.sizeBytes > 0);
+    for (const companion of model.companions ?? []) {
+      assert.match(companion.url, /^https:\/\//);
+      assert.match(companion.sha256, /^[a-f0-9]{64}$/);
+      assert.ok(companion.sizeBytes > 0);
     }
   }
   const root = testRoot("empty");
@@ -178,10 +178,34 @@ test("signature voice roster pins reviewed artifacts with vetted licenses", () =
     assert.match(entry.id, /^(?:piper|kokoro)-[a-z0-9][a-z0-9-]*$/);
     // Piper needs the config beside the weights; an entry without its
     // companion would advertise an unusable voice.
-    assert.equal(entry.companion?.sha256, expected.companionSha256);
+    assert.equal(entry.companions?.[0]?.sha256, expected.companionSha256);
     // Same pinned revision as Amy: artifacts can't drift under re-review.
     assert.match(entry.url, /\/resolve\/0d907f158acc877ddeebcbf827659ee13bea8bcd\//);
-    assert.match(entry.companion?.url ?? "", /\/resolve\/0d907f158acc877ddeebcbf827659ee13bea8bcd\//);
+    assert.match(entry.companions?.[0]?.url ?? "", /\/resolve\/0d907f158acc877ddeebcbf827659ee13bea8bcd\//);
+  }
+});
+
+// Kokoro (cave-tr09i): one reviewed model bundle, addressed by voiceName like
+// any Piper voice. The companions order [voices.bin, tokens.txt] is a pinned
+// contract — the TTS route hands companionPaths[0]/[1] to the runner
+// positionally.
+test("kokoro registry entry pins reviewed artifacts and companion order", () => {
+  const entry = SPEECH_MODEL_REGISTRY.find((model) => model.id === "kokoro-en-v0-19");
+  assert.ok(entry, "kokoro-en-v0-19 is registered");
+  assert.equal(entry.engine, "kokoro");
+  assert.equal(entry.kind, "tts");
+  assert.equal(entry.license, "Apache-2.0");
+  assert.match(entry.id, /^(?:piper|kokoro)-[a-z0-9][a-z0-9-]*$/);
+  assert.equal(entry.sha256, "10ff414106a038ce7e9e0126c6461e4dc8a86efaa89dc91d2009d69fe635e339");
+  assert.equal(entry.kokoroSpeakerId, 0);
+  // Pinned HF revision: artifacts can't drift under re-review.
+  assert.match(entry.url, /\/resolve\/92805c485745946a0d945562d3aba19e7cbb2104\//);
+  assert.deepEqual(
+    entry.companions?.map((companion) => companion.fileName),
+    ["voices.bin", "tokens.txt"],
+  );
+  for (const companion of entry.companions ?? []) {
+    assert.match(companion.url, /\/resolve\/92805c485745946a0d945562d3aba19e7cbb2104\//);
   }
 });
 
@@ -196,15 +220,15 @@ test("Piper readiness requires its verified config companion", async () => {
     engine: "piper",
     kind: "tts",
     fileName: "voice.onnx",
-    companion: {
+    companions: [{
       url: "https://example.invalid/voice.onnx.json",
       sha256: sha256(configBody),
       sizeBytes: Buffer.byteLength(configBody),
       fileName: "voice.onnx.json",
-    },
+    }],
   };
   const modelPath = speechModelPath(model, root);
-  const companionPath = speechModelCompanionPath(model, root);
+  const [companionPath] = speechModelCompanionPaths(model, root);
   assert.ok(companionPath);
   await mkdir(path.dirname(modelPath), { recursive: true });
   await writeFile(modelPath, modelBody);
@@ -215,7 +239,7 @@ test("Piper readiness requires its verified config companion", async () => {
   await writeFile(companionPath, configBody);
   const ready = await speechModelReadiness(model, root);
   assert.equal(ready.ready, true);
-  assert.equal(ready.companionPath, companionPath);
+  assert.deepEqual(ready.companionPaths, [companionPath]);
   assert.equal(
     ready.diskSizeBytes,
     Buffer.byteLength(modelBody) + Buffer.byteLength(configBody),
@@ -283,12 +307,12 @@ test("download publishes Piper weights and config as one ready directory", async
     engine: "piper",
     kind: "tts",
     fileName: "voice.onnx",
-    companion: {
+    companions: [{
       url: "https://example.invalid/voice.onnx.json",
       sha256: sha256(configBody),
       sizeBytes: Buffer.byteLength(configBody),
       fileName: "voice.onnx.json",
-    },
+    }],
   };
   const now = new Date().toISOString();
   const job = {
@@ -296,7 +320,7 @@ test("download publishes Piper weights and config as one ready directory", async
     modelId: model.id,
     status: "running" as const,
     receivedBytes: 0,
-    totalBytes: model.sizeBytes + model.companion!.sizeBytes,
+    totalBytes: model.sizeBytes + model.companions![0].sizeBytes,
     startedAt: now,
     updatedAt: now,
   };
@@ -311,7 +335,7 @@ test("download publishes Piper weights and config as one ready directory", async
 
   assert.equal(await readFile(speechModelPath(model, root), "utf8"), modelBody);
   assert.equal(
-    await readFile(speechModelCompanionPath(model, root)!, "utf8"),
+    await readFile(speechModelCompanionPaths(model, root)[0], "utf8"),
     configBody,
   );
   assert.equal((await speechModelReadiness(model, root)).ready, true);

--- a/src/lib/voice/speech-models.ts
+++ b/src/lib/voice/speech-models.ts
@@ -7,6 +7,13 @@ import { covenHome } from "../coven-paths.ts";
 
 export type SpeechEngineKind = "stt" | "tts";
 
+export type SpeechModelCompanionAsset = {
+  url: string;
+  sha256: string;
+  sizeBytes: number;
+  fileName: string;
+};
+
 export type SpeechModelRegistryEntry = {
   id: string;
   name: string;
@@ -17,12 +24,13 @@ export type SpeechModelRegistryEntry = {
   sizeBytes: number;
   license: string;
   fileName: string;
-  companion?: {
-    url: string;
-    sha256: string;
-    sizeBytes: number;
-    fileName: string;
-  };
+  /** Additional verified artifacts required beside the weights (Piper's
+   *  voice config; Kokoro's speaker embeddings and token table). Order is
+   *  part of the contract — consumers address companions by fileName. */
+  companions?: readonly SpeechModelCompanionAsset[];
+  /** Kokoro packs many speakers into one voices file; this selects the
+   *  reviewed default speaker for the entry's voiceName. */
+  kokoroSpeakerId?: number;
 };
 
 export type SpeechModelReadiness = SpeechModelRegistryEntry & {
@@ -30,7 +38,8 @@ export type SpeechModelReadiness = SpeechModelRegistryEntry & {
   verified: boolean;
   diskSizeBytes: number;
   path: string;
-  companionPath?: string;
+  /** Absolute paths for each registry companion, in registry order. */
+  companionPaths?: string[];
   missingReason?: "missing" | "size_mismatch" | "checksum_mismatch" | "unreadable";
 };
 
@@ -96,12 +105,12 @@ export const SPEECH_MODEL_REGISTRY: readonly SpeechModelRegistryEntry[] = [
     // Piper requires the voice config beside the ONNX weights. Treat both as
     // one verified model so /api/voice/engines never advertises an unusable
     // voice as ready.
-    companion: {
+    companions: [{
       url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/amy/medium/en_US-amy-medium.onnx.json",
       sha256: "95a23eb4d42909d38df73bb9ac7f45f597dbfcde2d1bf9526fdeaf5466977d77",
       sizeBytes: 4_882,
       fileName: "en_US-amy-medium.onnx.json",
-    },
+    }],
   },
   // Signature voice roster (cave-vony): only license-vetted voices ship here.
   // Rejected during vetting: ryan/hfc_male/hfc_female (CC BY-NC-SA datasets),
@@ -116,12 +125,12 @@ export const SPEECH_MODEL_REGISTRY: readonly SpeechModelRegistryEntry[] = [
     sizeBytes: 63_201_294,
     license: "CC-BY-4.0",
     fileName: "en_GB-alba-medium.onnx",
-    companion: {
+    companions: [{
       url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_GB/alba/medium/en_GB-alba-medium.onnx.json",
       sha256: "aa965a2f02ecced632c2694e1fc72bbff6d65f265fab567ca945918c73dd89f4",
       sizeBytes: 4_888,
       fileName: "en_GB-alba-medium.onnx.json",
-    },
+    }],
   },
   {
     id: "piper-joe-medium-en-us",
@@ -133,12 +142,12 @@ export const SPEECH_MODEL_REGISTRY: readonly SpeechModelRegistryEntry[] = [
     sizeBytes: 63_201_294,
     license: "CC0-1.0",
     fileName: "en_US-joe-medium.onnx",
-    companion: {
+    companions: [{
       url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/joe/medium/en_US-joe-medium.onnx.json",
       sha256: "3d6d5410b3795cb1950595247ef8f06190719e6fdbfa3a2356d8ec368e1aad33",
       sizeBytes: 4_794,
       fileName: "en_US-joe-medium.onnx.json",
-    },
+    }],
   },
   {
     id: "piper-kristin-medium-en-us",
@@ -150,12 +159,44 @@ export const SPEECH_MODEL_REGISTRY: readonly SpeechModelRegistryEntry[] = [
     sizeBytes: 63_531_379,
     license: "Public domain (LibriVox dataset)",
     fileName: "en_US-kristin-medium.onnx",
-    companion: {
+    companions: [{
       url: "https://huggingface.co/rhasspy/piper-voices/resolve/0d907f158acc877ddeebcbf827659ee13bea8bcd/en/en_US/kristin/medium/en_US-kristin-medium.onnx.json",
       sha256: "5681426d4aead22195de70531eeeeddb46493cfaffc5764b2ea3db73428b651c",
       sizeBytes: 4_968,
       fileName: "en_US-kristin-medium.onnx.json",
-    },
+    }],
+  },
+  // Kokoro (cave-tr09i): one reviewed model bundle serves many speakers via
+  // the voices file. The runner additionally needs espeak-ng-data, which
+  // ships with the sherpa-onnx runtime beside its executable (like Piper's),
+  // not through this flat-file downloader.
+  {
+    id: "kokoro-en-v0-19",
+    name: "Kokoro English v0.19",
+    engine: "kokoro",
+    kind: "tts",
+    url: "https://huggingface.co/csukuangfj/kokoro-en-v0_19/resolve/92805c485745946a0d945562d3aba19e7cbb2104/model.onnx",
+    sha256: "10ff414106a038ce7e9e0126c6461e4dc8a86efaa89dc91d2009d69fe635e339",
+    sizeBytes: 345_555_491,
+    license: "Apache-2.0",
+    fileName: "model.onnx",
+    // Speaker 0 ("af", the reviewed default blend) keeps this entry a single
+    // selectable voiceName; the roster of named speakers is follow-up work.
+    kokoroSpeakerId: 0,
+    companions: [
+      {
+        url: "https://huggingface.co/csukuangfj/kokoro-en-v0_19/resolve/92805c485745946a0d945562d3aba19e7cbb2104/voices.bin",
+        sha256: "a372c67b056ef0b695c375d39b99630d23fb07ad4c8d87aa32a19a62fca523ad",
+        sizeBytes: 5_755_904,
+        fileName: "voices.bin",
+      },
+      {
+        url: "https://huggingface.co/csukuangfj/kokoro-en-v0_19/resolve/92805c485745946a0d945562d3aba19e7cbb2104/tokens.txt",
+        sha256: "4f31c71282d14af4e926cd12462078fe9d20d00c589e63fe2750a8f56d6d7f7b",
+        sizeBytes: 1_078,
+        fileName: "tokens.txt",
+      },
+    ],
   },
 ] as const;
 
@@ -238,13 +279,13 @@ export function speechModelPath(model: SpeechModelRegistryEntry, root = speechMo
   return speechModelAssetPath(model, model.fileName, root);
 }
 
-export function speechModelCompanionPath(
+export function speechModelCompanionPaths(
   model: SpeechModelRegistryEntry,
   root = speechModelsRoot(),
-): string | null {
-  return model.companion
-    ? speechModelAssetPath(model, model.companion.fileName, root)
-    : null;
+): string[] {
+  return (model.companions ?? []).map((companion) =>
+    speechModelAssetPath(model, companion.fileName, root),
+  );
 }
 
 function speechModelAssetPath(
@@ -283,16 +324,14 @@ export async function speechModelReadiness(
   root = speechModelsRoot(),
 ): Promise<SpeechModelReadiness> {
   const modelPath = speechModelPath(model, root);
-  const companionPath = speechModelCompanionPath(model, root);
+  const companionPaths = speechModelCompanionPaths(model, root);
   const assets = [
     { path: modelPath, sizeBytes: model.sizeBytes, sha256: model.sha256 },
-    ...(model.companion && companionPath
-      ? [{
-          path: companionPath,
-          sizeBytes: model.companion.sizeBytes,
-          sha256: model.companion.sha256,
-        }]
-      : []),
+    ...(model.companions ?? []).map((companion, index) => ({
+      path: companionPaths[index],
+      sizeBytes: companion.sizeBytes,
+      sha256: companion.sha256,
+    })),
   ];
   let diskSizeBytes = 0;
   for (const asset of assets) {
@@ -306,7 +345,7 @@ export async function speechModelReadiness(
           verified: false,
           diskSizeBytes,
           path: modelPath,
-          ...(companionPath ? { companionPath } : {}),
+          ...(companionPaths.length ? { companionPaths } : {}),
           missingReason: "unreadable",
         };
       }
@@ -317,7 +356,7 @@ export async function speechModelReadiness(
           verified: false,
           diskSizeBytes,
           path: modelPath,
-          ...(companionPath ? { companionPath } : {}),
+          ...(companionPaths.length ? { companionPaths } : {}),
           missingReason: "size_mismatch",
         };
       }
@@ -328,7 +367,7 @@ export async function speechModelReadiness(
           verified: false,
           diskSizeBytes,
           path: modelPath,
-          ...(companionPath ? { companionPath } : {}),
+          ...(companionPaths.length ? { companionPaths } : {}),
           missingReason: "checksum_mismatch",
         };
       }
@@ -339,7 +378,7 @@ export async function speechModelReadiness(
         verified: false,
         diskSizeBytes,
         path: modelPath,
-        ...(companionPath ? { companionPath } : {}),
+        ...(companionPaths.length ? { companionPaths } : {}),
         missingReason:
           (error as NodeJS.ErrnoException).code === "ENOENT" ? "missing" : "unreadable",
       };
@@ -351,7 +390,7 @@ export async function speechModelReadiness(
     verified: true,
     diskSizeBytes,
     path: modelPath,
-    ...(companionPath ? { companionPath } : {}),
+    ...(companionPaths.length ? { companionPaths } : {}),
   };
 }
 
@@ -528,7 +567,7 @@ export async function runSpeechModelDownload(
     /* turbopackIgnore: true */ path.dirname(dir),
     `.${model.id}.${job.id}.download`,
   );
-  const totalBytes = model.sizeBytes + (model.companion?.sizeBytes ?? 0);
+  const totalBytes = model.sizeBytes + (model.companions ?? []).reduce((sum, companion) => sum + companion.sizeBytes, 0);
   const assets = [
     {
       url: model.url,
@@ -536,7 +575,7 @@ export async function runSpeechModelDownload(
       sizeBytes: model.sizeBytes,
       fileName: model.fileName,
     },
-    ...(model.companion ? [model.companion] : []),
+    ...(model.companions ?? []),
   ];
   try {
     if (cancelledDownloadJobs.has(job.id)) throw new Error("download_cancelled");
@@ -628,7 +667,7 @@ export async function startSpeechModelDownload(
       modelId: model.id,
       status: "cancelled",
       receivedBytes: 0,
-      totalBytes: model.sizeBytes + (model.companion?.sizeBytes ?? 0),
+      totalBytes: model.sizeBytes + (model.companions ?? []).reduce((sum, companion) => sum + companion.sizeBytes, 0),
       startedAt: now,
       updatedAt: now,
       ready: false,
@@ -642,7 +681,7 @@ export async function startSpeechModelDownload(
       modelId: model.id,
       status: "done",
       receivedBytes: ready.diskSizeBytes,
-      totalBytes: model.sizeBytes + (model.companion?.sizeBytes ?? 0),
+      totalBytes: model.sizeBytes + (model.companions ?? []).reduce((sum, companion) => sum + companion.sizeBytes, 0),
       startedAt: now,
       updatedAt: now,
       ready: true,
@@ -657,7 +696,7 @@ export async function startSpeechModelDownload(
     modelId: model.id,
     status: "running",
     receivedBytes: 0,
-    totalBytes: model.sizeBytes + (model.companion?.sizeBytes ?? 0),
+    totalBytes: model.sizeBytes + (model.companions ?? []).reduce((sum, companion) => sum + companion.sizeBytes, 0),
     startedAt: now,
     updatedAt: now,
   });


### PR DESCRIPTION
## Summary
PR 1 of cave-tr09i (approved incremental plan): make the already-typed `kokoro` engine actually synthesize, dev-runtime first.

- **Registry**: `kokoro-en-v0-19` pinned to HF `csukuangfj/kokoro-en-v0_19` @ `92805c48` — sha256-verified model.onnx (330MB), voices.bin, tokens.txt; Apache-2.0; speaker 0. Registry `companions` becomes an ordered list; order `[voices.bin, tokens.txt]` is a documented contract.
- **Runner**: shared hardened child-to-WAV harness (scrubbed env, private 0o700 tmp, bounded runtime + output, SIGTERM→SIGKILL) parameterizes Piper + Kokoro. Kokoro runs `sherpa-onnx-offline-tts` with the utterance as positional argv (`--sid`, `--kokoro-data-dir` beside the binary). `COVEN_KOKORO_BIN` respected; PATH fallback refused when `COVEN_CAVE_BUNDLE=1`.
- **Routes**: tts route dispatches per engine (409 on incomplete kokoro bundle); engines route reports `runtimes.kokoro`.
- **UI**: per-engine gating in the Familiar Studio voice picker + Kokoro status line in Settings (only when a kokoro model is cataloged).

Packaging follow-up (bundle sherpa-onnx into desktop builds, launcher env, CI smoke): **cave-2svvx**.

## Verification
- `pnpm typecheck`, `pnpm lint` green
- Full app suite: **922 test files pass**
- New tests: kokoro registry pin (incl. companion order), runner argv/espeak/probe/executable contracts, route dispatch + incomplete-bundle 409, engines runtimes.kokoro

## Beads
cave-tr09i (in progress → PR 1), cave-2svvx (packaging follow-up, blocked on this)