### PR TITLE
fix(ios): widen task cards and restore chat action contrast

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -144,6 +144,7 @@ struct TaskDetailView: View {
                     else { showFamiliarPicker = true }
                 } label: {
                     Label("Start a chat", systemImage: "plus.bubble.fill")
+                        .foregroundStyle(chrome.accentForeground)
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
@@ -393,6 +394,7 @@ struct TaskDetailView: View {
                 else { showFamiliarPicker = true }
             } label: {
                 Label("Open in chat", systemImage: "bubble.left.and.bubble.right.fill")
+                    .foregroundStyle(chrome.accentForeground)
                     .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent)

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -387,7 +387,7 @@ struct TasksView: View {
                 }
             }
         }
-        .listStyle(.insetGrouped)
+        .listStyle(.plain)
         .themedListBackground()
     }
 

--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -86,5 +86,14 @@ assert.match(
   /Button\("Delete", role: \.destructive\) \{\s*Task \{ await app\.deleteTask\(card\); dismiss\(\) \}/,
   "deleting from the detail view should pop back",
 );
+for (const label of ["Start a chat", "Open in chat"]) {
+  assert.match(
+    detail,
+    new RegExp(
+      `Label\\("${label}",[\\s\\S]{0,120}?\\.foregroundStyle\\(chrome\\.accentForeground\\)`,
+    ),
+    `${label} should use the luminance-aware foreground on its accent-filled button`,
+  );
+}
 
 console.log("ios-task-actions.test.mjs: ok");

--- a/scripts/ios-theme-list-background.test.mjs
+++ b/scripts/ios-theme-list-background.test.mjs
@@ -24,6 +24,7 @@ assert.match(
 for (const view of [
   "ChatsHomeView.swift",
   "FamiliarThreadsView.swift",
+  "TasksView.swift",
 ]) {
   const src = await read(`Views/${view}`);
   assert.match(
@@ -33,14 +34,18 @@ for (const view of [
   );
 }
 
-// Inset-grouped surfaces adopt the same modifier (the themed bgBase floor shows
-// behind the cards), applied after .listStyle(.insetGrouped).
-for (const view of ["TasksView.swift"]) {
-  const src = await read(`Views/${view}`);
+// Task cards keep a single mobile gutter inside the full-width plain list.
+{
+  const tasks = await read("Views/TasksView.swift");
   assert.match(
-    src,
-    /\.listStyle\(\.insetGrouped\)\s*\n\s*\.themedListBackground\(\)/,
-    `${view} should apply .themedListBackground() right after .listStyle(.insetGrouped)`,
+    tasks,
+    /\.listRowInsets\(EdgeInsets\(top: 5, leading: 16, bottom: 5, trailing: 16\)\)/,
+    "TasksView should keep the 16pt task-card gutter",
+  );
+  assert.doesNotMatch(
+    tasks,
+    /\.listStyle\(\.insetGrouped\)/,
+    "TasksView should not add the system inset-grouped gutter around task cards",
   );
 }
 


### PR DESCRIPTION
## Summary

- Switch the native Tasks list from `insetGrouped` to `plain` while retaining its existing 16pt card gutter.
- Use the luminance-aware `chrome.accentForeground` for both accent-filled chat actions so pale themes keep their labels and icons legible.
- Add source-contract regressions for the list width and action contrast.

## Root cause

`TasksView` combined SwiftUI's inset-grouped section padding with explicit 16pt row insets, doubling the intended iPhone gutter. The task-detail chat actions relied on SwiftUI's default prominent-button foreground even though the app tint may be nearly white.

## User impact

Task cards now use the available iPhone width consistently with the other native list surfaces, and `Start a chat` / `Open in chat` remain readable across theme accents.

## Validation

- `pnpm test:mobile` — 73/73 test files passed
- `pnpm lint`
- `xcodebuild test -project CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,id=8E08D33E-D46E-40D6-921C-6B8475046CFC' -only-testing:CovenCaveTests -quiet`
- `git diff --check`
- Simulator inspection confirmed the corrected single Tasks-card gutter

Bead: `cave-1sdy0`