### PR TITLE
fix(chat): tolerate cold Copilot capability probes

### DIFF
--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -60,8 +60,8 @@ assert.deepEqual(
     model: null,
     permissionMode: "full",
     addDirs: [],
-  }).slice(0, 5),
-  ["--allow-all", "--output-format", "json", "--stream", "on"],
+  }).slice(0, 6),
+  ["--no-auto-update", "--allow-all", "--output-format", "json", "--stream", "on"],
   "the direct full-mode routing decision keeps its approval flag before the reviewed JSONL launch contract",
 );
 

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -311,6 +311,7 @@ const freshArgs = buildCopilotStreamArgs({
 assert.deepEqual(
   freshArgs,
   [
+    "--no-auto-update",
     "--session-id",
     "11111111-2222-4333-8444-555555555555",
     "--model",
@@ -342,6 +343,7 @@ const resumeArgs = buildCopilotStreamArgs({
 assert.deepEqual(
   resumeArgs,
   [
+    "--no-auto-update",
     "--resume",
     "aaaa1111-2222-4333-8444-555555555555",
     "--add-dir",
@@ -385,6 +387,7 @@ const unattendedArgs = buildCopilotStreamArgs({
 assert.deepEqual(
   unattendedArgs,
   [
+    "--no-auto-update",
     "--session-id",
     "22222222-3333-4444-8555-666666666666",
     "--add-dir",

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -263,6 +263,11 @@ export type CopilotStreamSpec = {
 // shipped in every CLI version this stream path supports (verified 1.0.70).
 const COPILOT_ADD_DIR_FLAG = "--add-dir";
 
+// Versioned direct streams must execute the same runtime the capability probe
+// selected. An in-process auto-update could otherwise replace the CLI after
+// schema selection and before its first JSONL frame.
+export const COPILOT_NO_AUTO_UPDATE_ARG = "--no-auto-update";
+
 // Approval argv for unattended one-shot runs (flow sessions). A `-p` spawn
 // cannot answer approval prompts, so without these the CLI auto-denies every
 // tool — the "mission workspace was read-only all session" failure that left
@@ -466,7 +471,7 @@ export function isSafeCopilotResumeSessionId(value: string | null | undefined): 
  *  the prefix args; the prompt trails the prefix's `-p` flag. */
 export function buildCopilotStreamArgs(launch: CopilotStreamLaunch): string[] {
   const { spec } = launch;
-  const args: string[] = [];
+  const args: string[] = [COPILOT_NO_AUTO_UPDATE_ARG];
   // Resume ids are runtime data, never options. Reject control characters and
   // flag-shaped values before argv construction rather than relying on a
   // particular CLI parser's treatment of `--resume --flag`.

--- a/src/lib/server/copilot-capability-probe.test.ts
+++ b/src/lib/server/copilot-capability-probe.test.ts
@@ -1,13 +1,55 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import {
   clearCopilotCapabilityProbeCache,
   probeCopilotCapability,
 } from "./copilot-capability-probe.ts";
 
+function delayedVersionSpawn(
+  delayMs: number,
+  onSpawn?: (
+    args: readonly string[],
+    options: import("node:child_process").SpawnOptions | undefined,
+  ) => void,
+): typeof import("node:child_process").spawn {
+  return ((
+    _command: string,
+    args: readonly string[] = [],
+    options?: import("node:child_process").SpawnOptions,
+  ) => {
+    onSpawn?.(args, options);
+    const child = new EventEmitter() as EventEmitter & {
+      stdout: PassThrough;
+      stderr: PassThrough;
+      kill: () => boolean;
+    };
+    child.stdout = new PassThrough();
+    child.stderr = new PassThrough();
+    let killed = false;
+    child.kill = () => {
+      killed = true;
+      return true;
+    };
+    setTimeout(() => {
+      if (killed) return;
+      child.stdout.end(
+        "GitHub Copilot CLI 1.0.75.\nRun 'copilot update' to check for updates.\n",
+      );
+      child.stderr.end();
+      child.emit("close", 0);
+    }, delayMs);
+    return child;
+  }) as unknown as typeof import("node:child_process").spawn;
+}
+
 clearCopilotCapabilityProbeCache();
-const nodeProbe = await probeCopilotCapability(process.execPath);
-assert.match(nodeProbe.version ?? "", /^\d+\.\d+\.\d+$/, "normalizes a safe local --version probe");
-assert.equal(nodeProbe.diagnostic, undefined);
+const supportedProbe = await probeCopilotCapability("copilot", {
+  binaryIdentity: async () => "copilot-supported-fixture",
+  spawnImpl: delayedVersionSpawn(0),
+});
+assert.equal(supportedProbe.version, "1.0.75", "normalizes a safe local --version probe");
+assert.equal(supportedProbe.diagnostic, undefined);
 
 const unavailable = await probeCopilotCapability("definitely-not-a-cave-runtime");
 assert.equal(unavailable.version, null);
@@ -18,18 +60,61 @@ assert.equal(unavailable.diagnostic, "version-unavailable");
 clearCopilotCapabilityProbeCache();
 const identityA = async () => "copilot-shim:old";
 const identityB = async () => "copilot-shim:new";
-const cached = await probeCopilotCapability(process.execPath, { binaryIdentity: identityA });
+const cached = await probeCopilotCapability("copilot", {
+  binaryIdentity: identityA,
+  spawnImpl: delayedVersionSpawn(0),
+});
 assert.ok(cached.version, "the initial binary identity is probed");
-const fromCache = await probeCopilotCapability(process.execPath, {
+const fromCache = await probeCopilotCapability("copilot", {
   binaryIdentity: identityA,
   spawnImpl: (() => { throw new Error("cache miss"); }) as typeof import("node:child_process").spawn,
 });
 assert.equal(fromCache.version, cached.version, "the unchanged binary may use the short-lived cache");
-const afterUpgrade = await probeCopilotCapability(process.execPath, {
+const afterUpgrade = await probeCopilotCapability("copilot", {
   binaryIdentity: identityB,
   spawnImpl: (() => { throw new Error("re-probed after binary change"); }) as typeof import("node:child_process").spawn,
 });
 assert.equal(afterUpgrade.version, null, "a changed binary identity never reuses the old supported capability");
 assert.equal(afterUpgrade.diagnostic, "version-unavailable");
+
+clearCopilotCapabilityProbeCache();
+let coldStartArgs: readonly string[] = [];
+const coldStart = await probeCopilotCapability("copilot", {
+  binaryIdentity: async () => "copilot-cold-start-fixture",
+  spawnImpl: delayedVersionSpawn(2_750, (args) => {
+    coldStartArgs = args;
+  }),
+});
+assert.equal(
+  coldStart.version,
+  "1.0.75",
+  "a valid cold-starting CLI gets a version-process budget independent of launcher resolution",
+);
+assert.equal(coldStart.diagnostic, undefined);
+assert.deepEqual(
+  coldStartArgs.slice(-2),
+  ["--no-auto-update", "--version"],
+  "the compatibility probe must not update the runtime between version selection and launch",
+);
+
+clearCopilotCapabilityProbeCache();
+let canonicalProbePath: string | undefined;
+const canonicalEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  PATH: "/cave/canonical-harness-path",
+};
+const canonicalEnvProbe = await probeCopilotCapability("copilot", {
+  binaryIdentity: async () => "copilot-canonical-env-fixture",
+  spawnEnv: () => canonicalEnv,
+  spawnImpl: delayedVersionSpawn(0, (_args, options) => {
+    canonicalProbePath = options?.env?.PATH;
+  }),
+});
+assert.equal(canonicalEnvProbe.version, "1.0.75");
+assert.equal(
+  canonicalProbePath,
+  canonicalEnv.PATH,
+  "the capability probe resolves and launches with Cave's canonical harness environment",
+);
 
 console.log("copilot-capability-probe: ok");

--- a/src/lib/server/copilot-capability-probe.ts
+++ b/src/lib/server/copilot-capability-probe.ts
@@ -1,9 +1,16 @@
 import { spawn } from "node:child_process";
 import { realpath, stat } from "node:fs/promises";
 import { delimiter, isAbsolute, join } from "node:path";
-import { parseRuntimeClientVersion } from "../copilot-stream.ts";
+import {
+  COPILOT_NO_AUTO_UPDATE_ARG,
+  parseRuntimeClientVersion,
+} from "../copilot-stream.ts";
 import { resolveCopilotLaunchCommand } from "../copilot-bin.ts";
-import { scrubSidecarInternalEnv, type CovenLaunchCommand } from "../coven-bin.ts";
+import {
+  covenSpawnEnv,
+  scrubSidecarInternalEnv,
+  type CovenLaunchCommand,
+} from "../coven-bin.ts";
 import { loadVaultMap } from "../vault.ts";
 
 export type CopilotCapabilityProbe = {
@@ -22,16 +29,20 @@ type ProbeCacheEntry = {
 };
 const cache = new Map<string, ProbeCacheEntry>();
 const CACHE_MS = 5 * 60_000;
-const TIMEOUT_MS = 2_500;
+const RESOLUTION_TIMEOUT_MS = 2_500;
+// Copilot's npm/native loader can take tens of seconds to page in after an
+// install or update before `--version` emits. Keep launcher discovery short,
+// but give a successfully resolved version process its own bounded budget.
+const VERSION_PROCESS_TIMEOUT_MS = 30_000;
 
 /**
  * Capability discovery has no familiar context and must never execute an
- * arbitrary PATH launcher with shared or vault-managed credentials. It also
- * deliberately avoids covenSpawnEnv's synchronous login-shell discovery: the
- * entire probe decision stays within TIMEOUT_MS on cold POSIX starts.
+ * arbitrary PATH launcher with shared or vault-managed credentials. Resolve
+ * through the same canonical PATH as the eventual harness spawn, then remove
+ * every vault-managed key before launching the untrusted runtime.
  */
-function probeSpawnEnv(): NodeJS.ProcessEnv {
-  const env = scrubSidecarInternalEnv({ ...process.env });
+function probeSpawnEnv(baseEnv: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  const env = scrubSidecarInternalEnv({ ...baseEnv });
   for (const key of Object.keys(loadVaultMap(true))) delete env[key];
   return env;
 }
@@ -101,11 +112,16 @@ export async function probeCopilotCapability(
     now?: () => number;
     spawnImpl?: typeof spawn;
     binaryIdentity?: (executable: string) => Promise<string>;
+    /** Test seam; production defaults to the exact Cave harness PATH. */
+    spawnEnv?: () => NodeJS.ProcessEnv;
   } = {},
 ): Promise<CopilotCapabilityProbe> {
   const now = options.now ?? Date.now;
-  const deadline = Date.now() + TIMEOUT_MS;
-  const probeEnv = probeSpawnEnv();
+  // covenSpawnEnv() may synchronously recover a Finder-launched app's login
+  // PATH. Start the asynchronous launcher deadline after that one-time work;
+  // the eventual harness spawn uses the cached result.
+  const probeEnv = probeSpawnEnv(options.spawnEnv?.() ?? covenSpawnEnv());
+  const resolutionDeadline = Date.now() + RESOLUTION_TIMEOUT_MS;
   // Cache by command name plus PATH, then validate the *previously launched*
   // command's binary/script metadata. This keeps normal turns off `where`
   // while invalidating immediately when an npm shim target is updated.
@@ -114,18 +130,24 @@ export async function probeCopilotCapability(
   if (cached && cached.expiresAt > now()) {
     const identity = options.binaryIdentity
       ? await options.binaryIdentity(cached.launchCommand.command)
-      : await identityBeforeDeadline(() => launchIdentity(cached.launchCommand, probeEnv), deadline);
+      : await identityBeforeDeadline(
+          () => launchIdentity(cached.launchCommand, probeEnv),
+          resolutionDeadline,
+        );
     if (identity && identity === cached.identity) return cached.value;
   }
   const launch = await resolveCopilotLaunchCommand(executable, {
-    timeoutMs: Math.max(1, deadline - Date.now()),
+    timeoutMs: Math.max(1, resolutionDeadline - Date.now()),
     env: probeEnv,
   });
   if (launch.resolutionTimedOut) return { version: null, diagnostic: "probe-timeout" };
   if (launch.unresolvedWindowsShim) return { version: null, diagnostic: "version-unavailable" };
   const identity = options.binaryIdentity
     ? await options.binaryIdentity(launch.command)
-    : await identityBeforeDeadline(() => launchIdentity(launch, probeEnv), deadline);
+    : await identityBeforeDeadline(
+        () => launchIdentity(launch, probeEnv),
+        resolutionDeadline,
+      );
   if (!identity) return { version: null, diagnostic: "probe-timeout" };
   const childSpawn = options.spawnImpl ?? spawn;
   const value = await new Promise<CopilotCapabilityProbe>((resolve) => {
@@ -138,11 +160,15 @@ export async function probeCopilotCapability(
     };
     let child: ReturnType<typeof spawn>;
     try {
-      child = childSpawn(launch.command, [...launch.fixedArgs, "--version"], {
-        stdio: ["ignore", "pipe", "pipe"],
-        windowsHide: true,
-        env: probeEnv,
-      });
+      child = childSpawn(
+        launch.command,
+        [...launch.fixedArgs, COPILOT_NO_AUTO_UPDATE_ARG, "--version"],
+        {
+          stdio: ["ignore", "pipe", "pipe"],
+          windowsHide: true,
+          env: probeEnv,
+        },
+      );
     } catch {
       settle({ version: null, diagnostic: "version-unavailable" });
       return;
@@ -159,7 +185,7 @@ export async function probeCopilotCapability(
       }, 250);
       forceKill.unref?.();
       settle({ version: null, diagnostic: "probe-timeout" });
-    }, Math.max(1, deadline - Date.now()));
+    }, VERSION_PROCESS_TIMEOUT_MS);
     child.stdout?.on("data", (chunk: Buffer | string) => {
       if (stdout.length < 4_096) stdout += String(chunk).slice(0, 4_096 - stdout.length);
     });


### PR DESCRIPTION
## Summary

- resolve Copilot capability probes through the same canonical PATH used by harness spawns
- give launcher discovery and cold `--version` execution separate bounded deadlines
- prevent auto-update between schema selection and direct JSONL execution
- cover delayed cold starts, canonical spawn environment, probe argv, and direct stream argv

## Root cause

A supported Copilot 1.x CLI could take longer than the former aggregate 2.5 second probe deadline on a cold start. The probe then returned `probe-timeout`, which chat rendered as a schema incompatibility. The probe also resolved against the server process PATH rather than Cave’s canonical harness PATH.

## Verification

- focused Copilot capability, stream, routing, and compatibility-registry tests
- `pnpm lint`
- `pnpm check:tests-wired` (1,249 test files wired)
- live installed Copilot 1.0.75 gate: `direct-jsonl` / `copilot-jsonl-v1` / null diagnostic
- `pnpm build` including TypeScript, bundle budget, and standalone budget
- independent pre-merge review: no findings, ready to merge

## Known baseline failure

`pnpm test:api` reaches 24 passing files, then the unrelated `src/app/api/beads/route.test.ts:77` fixture fails because macOS reports `/private/var/...` while the assertion expects `/var/...`. This reproduces on clean `main` and is tracked as `cave-altjo`.

Related to #3857.

Bead: `cave-98c9s.1.1`