### PR TITLE
feat(chat): add safe correlated OpenClaw Gateway dispatch

### DIFF
--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -1,6 +1,8 @@
-# OpenClaw Gateway-dispatched tool activity
+# OpenClaw Gateway-dispatch implementation plan
 
-**GitHub:** #3865 (implementation), #3847 (parent compatibility work), supersedes the reverted observer-only approach in #3852.
+**GitHub:** #3865 (implementation issue), #3847 (parent compatibility work),
+and #3852 (the retained safe CLI/plain-chat stop point). This document is a
+planning contract only; it does not enable Gateway dispatch.
 
 ## Decision
 
@@ -37,8 +39,10 @@ reason to guess a field shape.
 
 1. Resolve the local OpenClaw runtime and Gateway endpoint without passing
    Gateway credentials to a fallback child process.
-2. Create or load a paired device identity; authenticate with the reference
-   Gateway client and validate `hello-ok` plus negotiated policy limits.
+2. Create or load a paired device identity from OS-backed secret storage;
+   authenticate with the reference Gateway client and validate `hello-ok` plus
+   negotiated policy limits. Never persist credentials in plaintext or include
+   them in logs, caches, SSE, or diagnostics.
 3. Establish `sessions.subscribe` and the selected canonical-session
    subscription before dispatching the turn.
 4. Send `chat.send` with the Cave message, canonical session key, agent ID,
@@ -50,9 +54,15 @@ reason to guess a field shape.
 6. On terminal chat state, persist the response and reconciled tool cards. On
    cancellation, abort the exact `runId`, close the stream, and settle only its
    unfinished cards.
-7. On authentication, dispatch, validation, sequence, disconnect, or protocol
-   failure, close the Gateway attempt. Fall back to CLI only if no Gateway run
-   was accepted; never execute both transports for one user turn.
+7. Before a `chat.send` acknowledgement, resolve an ambiguous dispatch using
+   its idempotency key and authoritative Gateway status/history. Start the CLI
+   fallback only after acceptance is disproven; a lost acknowledgement is not
+   permission to duplicate the turn.
+8. After acceptance, use the official keepalive/liveness policy. On reconnect,
+   restore both subscriptions, reconcile authoritative history and the active
+   run, then resume only validated frames for the accepted run. If recovery
+   fails, terminate and settle the Gateway-owned turn; never replace it with a
+   CLI invocation.
 
 ## Compatibility and upgrade policy
 

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -52,8 +52,11 @@ reason to guess a field shape.
    a per-run high-water sequence, reject replay, reload history on a forward
    gap, and never treat an unknown event as liveness.
 6. On terminal chat state, persist the response and reconciled tool cards. On
-   cancellation, abort the exact `runId`, close the stream, and settle only its
-   unfinished cards.
+   cancellation, first persist a per-run `cancelled` terminal fence, then abort
+   the exact `runId`, close the stream, and settle only its unfinished cards.
+   Every event, reconciliation, and persistence path checks that fence: a
+   queued or late result for that run may not replace cancelled card or turn
+   state with success.
 7. Before a `chat.send` acknowledgement, resolve an ambiguous dispatch using
    its idempotency key and authoritative Gateway status/history. Start the CLI
    fallback only after acceptance is disproven; a lost acknowledgement is not

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -1,0 +1,89 @@
+# OpenClaw Gateway-dispatched tool activity
+
+**GitHub:** #3865 (implementation), #3847 (parent compatibility work), supersedes the reverted observer-only approach in #3852.
+
+## Decision
+
+Cave must not observe a CLI-created OpenClaw run. The CLI does not expose the
+Gateway's accepted run ID before `session.tool` events may arrive, so such an
+observer cannot attribute tool cards safely when sessions overlap.
+
+When a Gateway meets the supported compatibility contract, Cave dispatches the
+turn through the authenticated Gateway itself. The same Gateway connection owns
+the accepted `runId`, subscribes to session events, and accepts only events
+belonging to that exact run. The current CLI bridge stays the authoritative
+fallback for every other runtime.
+
+## Supported contract
+
+The first supported profile is OpenClaw Gateway protocol v4 using the published
+`@openclaw/gateway-client` and `@openclaw/gateway-protocol` packages pinned in
+Cave's lockfile. Cave requests `operator.read` and `operator.write`, advertises
+only `tool-events` and `session-scoped-events`, validates the negotiated
+role/scopes, and requires the documented `chat.send`, `sessions.subscribe`,
+`sessions.messages.subscribe`, `chat`, and `session.tool` surfaces.
+
+The direct dispatcher supplies an idempotency key, receives the accepted run
+identifier, then binds all live state to `(sessionKey, agentId, runId)`. A tool
+call key is `(runId, toolCallId)`, not a session-wide call ID.
+
+No runtime is upgraded heuristically. Older protocol versions, unavailable
+packages, unpaired devices, missing `operator.write`, an absent capability, or
+an unknown schema use the existing CLI/plain-chat path with a visible
+diagnostic. A protocol-version mismatch is a compatibility boundary, not a
+reason to guess a field shape.
+
+## Runtime sequence
+
+1. Resolve the local OpenClaw runtime and Gateway endpoint without passing
+   Gateway credentials to a fallback child process.
+2. Create or load a paired device identity; authenticate with the reference
+   Gateway client and validate `hello-ok` plus negotiated policy limits.
+3. Establish `sessions.subscribe` and the selected canonical-session
+   subscription before dispatching the turn.
+4. Send `chat.send` with the Cave message, canonical session key, agent ID,
+   and an idempotency key derived from the Cave request ID. Record the
+   Gateway-accepted `runId`.
+5. Project only matching `chat` and `session.tool` events to Cave SSE. Maintain
+   a per-run high-water sequence, reject replay, reload history on a forward
+   gap, and never treat an unknown event as liveness.
+6. On terminal chat state, persist the response and reconciled tool cards. On
+   cancellation, abort the exact `runId`, close the stream, and settle only its
+   unfinished cards.
+7. On authentication, dispatch, validation, sequence, disconnect, or protocol
+   failure, close the Gateway attempt. Fall back to CLI only if no Gateway run
+   was accepted; never execute both transports for one user turn.
+
+## Compatibility and upgrade policy
+
+- Depend on the official protocol/client packages rather than local copies of
+  WebSocket framing, signing, or schemas.
+- Keep an explicit profile table keyed by protocol version and package release
+  range. A profile declares exact methods, events, scopes, payload validators,
+  limits, and migration behavior.
+- Generate/capture protocol conformance fixtures from each supported package
+  release. Include supported, old/unsupported, future/unknown, missing-scope,
+  pairing-required, replay, sequence-gap, disconnect, cancellation, and
+  concurrent-run cases.
+- Upgrade only after the schema diff and fixtures pass. Unknown wire versions
+  fail closed to CLI; a new Cave release adds a tested profile.
+
+## Verification
+
+Add a route-level Gateway fixture that performs the real authenticated
+handshake, subscriptions, `chat.send` acknowledgement, and emitted chat/tool
+lifecycle. It must prove that start/update/result cards reach SSE and
+persistence for the accepted run, and that otherwise-valid concurrent-session
+frames are rejected. Exercise cancellation, reconnect/history reconciliation,
+and every fallback boundary above.
+
+## Delivery slices
+
+1. Add official protocol/client dependencies, capability/profile discovery,
+   paired-device credential storage, and protocol fixtures.
+2. Implement one owned Gateway turn with chat SSE projection and a CLI fallback
+   selected before dispatch.
+3. Implement correlated tool lifecycle, persistence, cancellation, and
+   reconciliation.
+4. Add cross-version conformance and route-level integration tests; document
+   operator setup and upgrade support boundaries.

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -88,19 +88,25 @@ reason to guess a field shape.
 The only published protocol/client release is the `2026.7.2-beta.4` beta
 package pair, negotiating wire protocol v4. It publishes `HelloOkSchema`,
 `ChatEventSchema`, `chat.send`, `chat.abort`, and
-`sessions.messages.subscribe`, so Cave can support a strictly correlated
-chat-only Gateway turn for that exact profile.
+`sessions.messages.subscribe`. Cave validates that exact chat-only contract in
+its dispatcher, including the accepted `(sessionKey, agentId, runId)` tuple.
 
-It does **not** publish a `session.tool` event name, payload schema, or
-validator. Cave must therefore ignore those frames and emit no Gateway tool
-card for this release. A method/event capability string is not a substitute
-for a versioned payload contract. The CLI/plain-chat bridge remains the
-fallback when dispatch cannot prove its accepted run, while the direct path
-may render only validated `chat` lifecycle frames.
+Cave currently keeps the live route fail-closed **before client construction**:
+the reference client delegates device identity, challenge signing, and token
+lifecycle to host-owned `GatewayClientHostDeps`, and Cave does not yet have the
+required cross-platform OS-backed credential-store boundary. In particular,
+`OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_DEVICE_TOKEN` cannot activate a
+write-capable direct turn; the existing CLI/plain-chat bridge remains the
+fallback. This is intentional until real paired-device storage is shipped.
 
-| Package profile | Wire protocol | Validated projection | Tool cards | Upgrade rule |
+The release also does **not** publish a `session.tool` event name, payload
+schema, or validator. Cave emits no Gateway tool card for this release and does
+not request an unpublished tool-event capability. A method/event capability
+string is not a substitute for a versioned payload contract.
+
+| Package profile | Wire protocol | Runtime projection | Tool cards | Upgrade rule |
 | --- | --- | --- | --- | --- |
-| `2026.7.2-beta.4` | v4 only | `chat` frames correlated by session, agent, and accepted run | Disabled: no published schema | Add a fixture and explicit profile only when OpenClaw publishes a stable tool payload validator. |
+| `2026.7.2-beta.4` | v4 only | None until Cave has OS-backed paired-device credentials; dispatcher tests validate only correlated `chat` frames | Disabled: no published schema | Add credential-store integration, then a fixture and explicit profile only when OpenClaw publishes a stable tool payload validator. |
 | Any other version/profile | Not assumed | None | Disabled | Keep CLI/plain chat with a visible compatibility diagnostic. |
 
 Before enabling tool cards, record the package release, exported validator,

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -1,8 +1,9 @@
 # OpenClaw Gateway-dispatch implementation plan
 
 **GitHub:** #3865 (implementation issue), #3847 (parent compatibility work),
-and #3852 (the retained safe CLI/plain-chat stop point). This document is a
-planning contract only; it does not enable Gateway dispatch.
+and #3852 (the retained safe CLI/plain-chat stop point). This document records
+both the shipped chat-only v4 boundary and the remaining plan for full tool
+lifecycle support.
 
 ## Decision
 
@@ -16,14 +17,13 @@ the accepted `runId`, subscribes to session events, and accepts only events
 belonging to that exact run. The current CLI bridge stays the authoritative
 fallback for every other runtime.
 
-## Supported contract
+## Target contract after a tool schema is published
 
-The first supported profile is OpenClaw Gateway protocol v4 using the published
-`@openclaw/gateway-client` and `@openclaw/gateway-protocol` packages pinned in
-Cave's lockfile. Cave requests `operator.read` and `operator.write`, advertises
-only `tool-events` and `session-scoped-events`, validates the negotiated
-role/scopes, and requires the documented `chat.send`, `sessions.subscribe`,
-`sessions.messages.subscribe`, `chat`, and `session.tool` surfaces.
+Full tool activity requires a published, versioned `session.tool` event name,
+payload validator, and lifecycle fixtures. Once those exist, Cave must request
+only the documented capabilities, validate the negotiated role/scopes and
+methods, and bind tool events to the Gateway-accepted run ID. Until then, no
+capability string or observed frame is a substitute for a payload contract.
 
 The direct dispatcher supplies an idempotency key, receives the accepted run
 identifier, then binds all live state to `(sessionKey, agentId, runId)`. A tool
@@ -43,15 +43,17 @@ reason to guess a field shape.
    authenticate with the reference Gateway client and validate `hello-ok` plus
    negotiated policy limits. Never persist credentials in plaintext or include
    them in logs, caches, SSE, or diagnostics.
-3. Establish `sessions.subscribe` and the selected canonical-session
-   subscription before dispatching the turn.
+3. Establish the selected canonical-session subscription before dispatching
+   the turn. Add any additional subscription only when its published schema
+   and contract fixture are available.
 4. Send `chat.send` with the Cave message, canonical session key, agent ID,
    and an idempotency key derived from the Cave request ID. Record the
    Gateway-accepted `runId`.
-5. Project only matching `chat` and `session.tool` events to Cave SSE. Maintain
-   a per-run high-water sequence, reject replay, reload history on a forward
-   gap, and never treat an unknown event as liveness.
-6. On terminal chat state, persist the response and reconciled tool cards. On
+5. Project only matching, schema-validated events to Cave SSE. Maintain a
+   per-run high-water sequence, reject replay, and fail the owned turn on a
+   forward gap until a published history-reconciliation contract is available.
+6. On terminal chat state, persist the response. After a published tool schema
+   is supported, also persist reconciled tool cards. On
    cancellation, first persist a per-run `cancelled` terminal fence, then abort
    the exact `runId`, close the stream, and settle only its unfinished cards.
    Every event, reconciliation, and persistence path checks that fence: a
@@ -62,10 +64,10 @@ reason to guess a field shape.
    fallback only after acceptance is disproven; a lost acknowledgement is not
    permission to duplicate the turn.
 8. After acceptance, use the official keepalive/liveness policy. On reconnect,
-   restore both subscriptions, reconcile authoritative history and the active
-   run, then resume only validated frames for the accepted run. If recovery
-   fails, terminate and settle the Gateway-owned turn; never replace it with a
-   CLI invocation.
+   restore the validated session subscription and resume only validated frames
+   for the accepted run. Add history reconciliation only alongside its
+   published schema; if recovery fails, terminate and settle the Gateway-owned
+   turn, never replacing it with a CLI invocation.
 
 ## Compatibility and upgrade policy
 
@@ -109,11 +111,11 @@ from an observed Gateway frame.
 ## Verification
 
 Add a route-level Gateway fixture that performs the real authenticated
-handshake, subscriptions, `chat.send` acknowledgement, and emitted chat/tool
-lifecycle. It must prove that start/update/result cards reach SSE and
-persistence for the accepted run, and that otherwise-valid concurrent-session
-frames are rejected. Exercise cancellation, reconnect/history reconciliation,
-and every fallback boundary above.
+handshake, subscription, `chat.send` acknowledgement, and emitted chat
+lifecycle. It must prove that matching chat frames reach SSE and persistence
+and that otherwise-valid concurrent-session frames are rejected. Once a
+published tool validator exists, extend it with start/update/result cards,
+history reconciliation, and every fallback boundary above.
 
 ## Delivery slices
 

--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -81,6 +81,31 @@ reason to guess a field shape.
 - Upgrade only after the schema diff and fixtures pass. Unknown wire versions
   fail closed to CLI; a new Cave release adds a tested profile.
 
+## Current release boundary (2026-07-26)
+
+The only published protocol/client release is the `2026.7.2-beta.4` beta
+package pair, negotiating wire protocol v4. It publishes `HelloOkSchema`,
+`ChatEventSchema`, `chat.send`, `chat.abort`, and
+`sessions.messages.subscribe`, so Cave can support a strictly correlated
+chat-only Gateway turn for that exact profile.
+
+It does **not** publish a `session.tool` event name, payload schema, or
+validator. Cave must therefore ignore those frames and emit no Gateway tool
+card for this release. A method/event capability string is not a substitute
+for a versioned payload contract. The CLI/plain-chat bridge remains the
+fallback when dispatch cannot prove its accepted run, while the direct path
+may render only validated `chat` lifecycle frames.
+
+| Package profile | Wire protocol | Validated projection | Tool cards | Upgrade rule |
+| --- | --- | --- | --- | --- |
+| `2026.7.2-beta.4` | v4 only | `chat` frames correlated by session, agent, and accepted run | Disabled: no published schema | Add a fixture and explicit profile only when OpenClaw publishes a stable tool payload validator. |
+| Any other version/profile | Not assumed | None | Disabled | Keep CLI/plain chat with a visible compatibility diagnostic. |
+
+Before enabling tool cards, record the package release, exported validator,
+schema diff, and fixtures for lifecycle, foreign-run rejection, malformed
+payload, replay, gap, disconnect, and cancellation. Do not infer a tool shape
+from an observed Gateway frame.
+
 ## Verification
 
 Add a route-level Gateway fixture that performs the real authenticated

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "@iconify/react": "6.0.2",
     "@lezer/highlight": "1.2.3",
     "@milkdown/crepe": "7.21.2",
+    "@openclaw/gateway-client": "2026.7.2-beta.4",
+    "@openclaw/gateway-protocol": "2026.7.2-beta.4",
     "@tailwindcss/browser": "4.3.1",
     "@tauri-apps/api": "2.11.1",
     "@tauri-apps/plugin-notification": "2.3.3",
@@ -101,6 +103,7 @@
     "sharp": "0.34.5",
     "shiki": "4.3.0",
     "sucrase": "3.35.1",
+    "typebox": "1.3.6",
     "ws": "8.21.0",
     "yaml": "2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,12 @@ importers:
       '@milkdown/crepe':
         specifier: 7.21.2
         version: 7.21.2(prosemirror-model@1.25.9)(prosemirror-state@1.4.4)(prosemirror-view@1.42.0)(typescript@6.0.3)
+      '@openclaw/gateway-client':
+        specifier: 2026.7.2-beta.4
+        version: 2026.7.2-beta.4
+      '@openclaw/gateway-protocol':
+        specifier: 2026.7.2-beta.4
+        version: 2026.7.2-beta.4
       '@tailwindcss/browser':
         specifier: 4.3.1
         version: 4.3.1
@@ -131,6 +137,9 @@ importers:
       sucrase:
         specifier: 3.35.1
         version: 3.35.1
+      typebox:
+        specifier: 1.3.6
+        version: 1.3.6
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -977,6 +986,14 @@ packages:
 
   '@ocavue/utils@1.7.0':
     resolution: {integrity: sha512-yEk9ATNBjTZTtuVFMB/MAIF6zJBvJ2+lVNQvK2+O+ggEBGTgx2tp27d4FPgmD5bRsNHHP3D0SleQia/bvIeV8w==}
+
+  '@openclaw/gateway-client@2026.7.2-beta.4':
+    resolution: {integrity: sha512-iWkaaUQ+sBuLYYw6NkFlmboFJ4ZCIv/5YZiLcCvl8+EsYOyumVim1C+ar9OfIRj/eusMeMbvEpzpkuVfu6WDmg==}
+    engines: {node: '>=22.19.0'}
+
+  '@openclaw/gateway-protocol@2026.7.2-beta.4':
+    resolution: {integrity: sha512-oE2uQYu6/GtIp4eGgkZyDFE2dZ06PMWCPsPKQvKI2DljhVvQ4F9Jn6IPWTHlO8oQqU8zE1Hyu/3Lnqjkc7Ng8w==}
+    engines: {node: '>=22.19.0'}
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
@@ -2244,6 +2261,10 @@ packages:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
 
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -2996,6 +3017,9 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
+  typebox@1.3.6:
+    resolution: {integrity: sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==}
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -3173,6 +3197,18 @@ packages:
 
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4243,6 +4279,19 @@ snapshots:
     optional: true
 
   '@ocavue/utils@1.7.0': {}
+
+  '@openclaw/gateway-client@2026.7.2-beta.4':
+    dependencies:
+      '@openclaw/gateway-protocol': 2026.7.2-beta.4
+      ipaddr.js: 2.4.0
+      ws: 8.21.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@openclaw/gateway-protocol@2026.7.2-beta.4':
+    dependencies:
+      typebox: 1.3.6
 
   '@oxc-project/types@0.133.0': {}
 
@@ -5568,6 +5617,8 @@ snapshots:
 
   internmap@2.0.3: {}
 
+  ipaddr.js@2.4.0: {}
+
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
@@ -6563,6 +6614,8 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
+  typebox@1.3.6: {}
+
   typescript@6.0.3: {}
 
   undici-types@7.18.2: {}
@@ -6715,6 +6768,8 @@ snapshots:
   ws@7.5.11: {}
 
   ws@8.21.0: {}
+
+  ws@8.21.1: {}
 
   y18n@4.0.3: {}
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1007,6 +1007,7 @@ export const SUITES = {
     "src/lib/hermes-responses-stream.test.ts",
     "src/lib/openclaw-bin.test.ts",
     "src/lib/openclaw-bridge.test.ts",
+    "src/lib/openclaw-gateway.test.ts",
     "src/lib/coven-identity-canon.test.ts",
     "src/lib/familiar-runtime.test.ts",
     "src/lib/harness-adapters.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -433,8 +433,8 @@ for (const contract of contracts) {
   const runRegistrations = [...sendSource.matchAll(/= registerChatRun\(/g)];
   assert.equal(
     runRegistrations.length,
-    2,
-    "/chat/send: both adapter paths must register with the stop registry",
+    3,
+    "/chat/send: all three dispatch paths must register with the stop registry",
   );
   assert.match(
     sendSource,
@@ -485,8 +485,8 @@ for (const contract of contracts) {
   ];
   assert.equal(
     cancelledFlags.length,
-    2,
-    "/chat/send: both adapter paths must persist cancelled: true on the assistant turn",
+    4,
+    "/chat/send: every adapter path must mark both its assistant turn and terminal event as cancelled",
   );
   assert.match(
     sendSource,

--- a/src/app/api/chat/send/first-turn-stub.test.ts
+++ b/src/app/api/chat/send/first-turn-stub.test.ts
@@ -64,8 +64,8 @@ assert.match(
 
 assert.equal(
   (chatRoute.match(/const hadFirstTurnStub = existing\s*\? stripConversationStubTurn\(existing, pendingUserTurnId\)\s*: false;/g) ?? []).length,
-  2,
-  "both save paths must strip the stub turn so the authoritative user turn re-lands cleanly",
+  3,
+  "all save paths must strip the stub turn so the authoritative user turn re-lands cleanly",
 );
 
 assert.equal(

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -36,6 +36,22 @@ const chatView = await readFile(
   new URL("../../../../components/chat-view.tsx", import.meta.url),
   "utf8",
 );
+
+assert.match(
+  chatRoute,
+  /dispatchOpenClawGatewayTurn\([\s\S]*?sessionKey: openClawSessionKey\(conversationId\),[\s\S]*?agentId,[\s\S]*?message: args\.harnessPrompt/,
+  "OpenClaw uses the Gateway-owned dispatcher with the canonical session key and agent id before selecting the CLI fallback",
+);
+assert.match(
+  chatRoute,
+  /gatewayDispatch\.kind === "accepted"[\s\S]*?return;[\s\S]*?pushProgress\("openclaw-start", "Starting OpenClaw bridge"/,
+  "an accepted Gateway turn exits before the CLI branch, preventing duplicate transport ownership",
+);
+assert.match(
+  chatRoute,
+  /gatewayDispatch\.kind === "indeterminate"[\s\S]*?openclaw_gateway_indeterminate[\s\S]*?return;/,
+  "an ambiguous Gateway acknowledgement produces a terminal error instead of a duplicate CLI turn",
+);
 // ── Tool-event fidelity (CHAT-D4-03 + CHAT-D4-04) ──────────────────────────
 // Source pins: the route must route BOTH tool-event sources through the
 // shared ToolCallTracker — hook lines and stream-json envelope blocks — and

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -52,6 +52,16 @@ assert.match(
   /gatewayDispatch\.kind === "indeterminate"[\s\S]*?openclaw_gateway_indeterminate[\s\S]*?return;/,
   "an ambiguous Gateway acknowledgement produces a terminal error instead of a duplicate CLI turn",
 );
+assert.match(
+  chatRoute,
+  /if \(event\.replace\) \{[\s\S]*?gatewayAssistantText = event\.text;[\s\S]*?kind: "assistant_replace"/,
+  "a published Gateway replacement delta corrects both the live stream and persisted transcript",
+);
+assert.match(
+  chatRoute,
+  /event\.kind === "final" && event\.text[\s\S]*?gatewayAssistantText !== event\.text[\s\S]*?kind: "assistant_replace"/,
+  "the terminal Gateway message reconciles divergent streamed text for connected clients",
+);
 // ── Tool-event fidelity (CHAT-D4-03 + CHAT-D4-04) ──────────────────────────
 // Source pins: the route must route BOTH tool-event sources through the
 // shared ToolCallTracker — hook lines and stream-json envelope blocks — and

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -44,6 +44,11 @@ assert.match(
 );
 assert.match(
   chatRoute,
+  /openClawGatewayPairedDeviceAuthStatus\(\)[\s\S]*?gatewayAuth\.available[\s\S]*?dispatchOpenClawGatewayTurn/,
+  "the route must retain the CLI fallback until an OS-backed paired-device credential store can activate Gateway dispatch",
+);
+assert.match(
+  chatRoute,
   /gatewayDispatch\.kind === "accepted"[\s\S]*?return;[\s\S]*?pushProgress\("openclaw-start", "Starting OpenClaw bridge"/,
   "an accepted Gateway turn exits before the CLI branch, preventing duplicate transport ownership",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -129,6 +129,7 @@ import {
 } from "@/lib/server/chat-project-launch";
 import { validateCaveProjectRoot } from "@/lib/server/project-paths";
 import { openClawLaunchCommand, openClawSpawnEnv } from "@/lib/openclaw-bin";
+import { dispatchOpenClawGatewayTurn } from "@/lib/openclaw-gateway";
 import {
   OpenClawAgentResolutionError,
   extractOpenClawSessionId,
@@ -607,30 +608,6 @@ function openClawChatResponse(args: {
       }
       const agentId = agentBinding.openclawAgentId;
       pushProgress("openclaw-resolve", "OpenClaw agent resolved", "done", `${agentId} (${agentBinding.source})`);
-      const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
-      const openclawLaunch = openClawLaunchCommand();
-      if (openclawLaunch.unresolvedWindowsShim) {
-        pushProgress(
-          "openclaw-start",
-          "OpenClaw bridge cannot start safely",
-          "error",
-          "The resolved OpenClaw Windows npm shim could not be mapped to its JavaScript entry point. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
-        );
-        push({
-          kind: "error",
-          code: "openclaw_unsafe_shell",
-          message:
-            "OpenClaw chat is unavailable because its Windows npm shim could not be launched without shell parsing. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
-        });
-        push({
-          kind: "done",
-          durationMs: Date.now() - startedAt,
-          isError: true,
-        });
-        close();
-        return;
-      }
-      const spawnArgv = [...openclawLaunch.fixedArgs, ...argv];
       let cwd: string;
       try {
         cwd = await resolveLocalRuntimeCwd(
@@ -669,6 +646,205 @@ function openClawChatResponse(args: {
         gatewaySessionId: undefined,
         sessionKey: openClawSessionKey(conversationId),
       };
+
+      // Gateway dispatch owns a turn only after it returns the authoritative
+      // run id. Until then this branch leaves the existing CLI bridge as the
+      // safe compatibility fallback; after a request might have reached the
+      // Gateway it deliberately never starts a second CLI turn.
+      let gatewayAssistantText = "";
+      let gatewayAssistantTextEmitted = false;
+      const gatewayDispatch = await dispatchOpenClawGatewayTurn({
+        sessionKey: openClawSessionKey(conversationId),
+        agentId,
+        message: args.harnessPrompt,
+        onEvent: (event) => {
+          if (event.kind === "status") {
+            pushProgress("openclaw-gateway", "OpenClaw Gateway", "running", event.phase);
+            return;
+          }
+          if (event.kind === "delta") {
+            // The published v4 delta schema is append-oriented. A future
+            // replace-capable UI must consume `replace` explicitly; we keep
+            // the complete terminal message authoritative for persistence.
+            gatewayAssistantText += event.text;
+            gatewayAssistantTextEmitted = true;
+            push({ kind: "assistant_chunk", text: event.text });
+            return;
+          }
+          if (event.kind === "final" && event.text) {
+            gatewayAssistantText = event.text;
+          }
+          if (event.kind === "error") {
+            pushProgress("openclaw-gateway", "OpenClaw Gateway", "error", event.message);
+          }
+        },
+      });
+      if (gatewayDispatch.kind === "indeterminate") {
+        pushProgress("openclaw-gateway", "OpenClaw Gateway dispatch is indeterminate", "error", gatewayDispatch.reason);
+        push({ kind: "error", code: "openclaw_gateway_indeterminate", message: gatewayDispatch.reason });
+        push({ kind: "done", durationMs: Date.now() - startedAt, isError: true, responseMetadata });
+        close();
+        return;
+      }
+      if (gatewayDispatch.kind === "accepted") {
+        responseMetadata.gatewaySessionId = gatewayDispatch.runId;
+        pushProgress("openclaw-gateway", "OpenClaw Gateway dispatch accepted", "done", `run ${gatewayDispatch.runId}`);
+        const pendingUserTurnId = crypto.randomUUID();
+        const stubTitle = chatTitleFromPrompt(args.promptText) ?? defaultChatTitleForSession(conversationId);
+        void setDefaultSessionTitleIfMissing(conversationId, stubTitle).catch(() => undefined);
+        const stubWrite = createConversationStub({
+          sessionId: conversationId,
+          familiarId: args.body.familiarId,
+          harness: "openclaw",
+          ...(responseMetadata.model ? { model: responseMetadata.model } : {}),
+          ...(responseMetadata.runtime ? { runtime: responseMetadata.runtime } : {}),
+          title: stubTitle,
+          ...(args.body.origin ? { origin: args.body.origin } : {}),
+          userTurn: {
+            id: pendingUserTurnId,
+            text: args.promptText,
+            ...(args.attachments.length ? { attachments: args.attachments } : {}),
+          },
+        }).catch(() => undefined);
+        const stopGateway = () => {
+          void gatewayDispatch.abort();
+        };
+        const runHandle = registerChatRun([args.body.runId, conversationId], stopGateway);
+        let detachKillTimer: ReturnType<typeof setTimeout> | null = null;
+        const armDetachKill = () => {
+          if (runHandle.stopRequested || detachKillTimer != null) return;
+          detachKillTimer = setTimeout(stopGateway, CHAT_DETACH_MAX_MS);
+        };
+        runBuffer = openRunBuffer([args.body.runId, conversationId], {
+          attach: () => {
+            if (detachKillTimer != null) {
+              clearTimeout(detachKillTimer);
+              detachKillTimer = null;
+            }
+          },
+          detach: () => {
+            if (args.req.signal.aborted) armDetachKill();
+          },
+        });
+        const onAbort = () => armDetachKill();
+        args.req.signal.addEventListener("abort", onAbort, { once: true });
+        pushProgress("openclaw-response", "Waiting for OpenClaw Gateway response", "running");
+        const gatewayResult = await gatewayDispatch.done;
+        args.req.signal.removeEventListener("abort", onAbort);
+        if (detachKillTimer != null) clearTimeout(detachKillTimer);
+        unregisterChatRun(runHandle);
+        const durationMs = Date.now() - startedAt;
+        const cancelledByUser = runHandle.stopRequested || gatewayResult.state === "aborted";
+        const isError = gatewayResult.state === "error";
+        if (!gatewayAssistantText.trim()) {
+          gatewayAssistantText = cancelledByUser
+            ? "(cancelled)"
+            : gatewayResult.message ?? "_The OpenClaw Gateway returned no text._";
+        }
+        pushProgress(
+          "openclaw-response",
+          isError ? "OpenClaw Gateway response failed" : "OpenClaw Gateway response received",
+          isError ? "error" : "done",
+          gatewayResult.message,
+          durationMs,
+        );
+        push({ kind: "session", sessionId: conversationId });
+        if (!gatewayAssistantTextEmitted) push({ kind: "assistant_chunk", text: gatewayAssistantText });
+        pushProgress("save-transcript", "Saving transcript", "running");
+        await recordSessionFamiliar(conversationId, args.body.familiarId);
+        await stubWrite;
+        const existing = await loadConversation(conversationId);
+        const hadFirstTurnStub = existing ? stripConversationStubTurn(existing, pendingUserTurnId) : false;
+        const isFirstExchange = !existing || hadFirstTurnStub;
+        const now = new Date().toISOString();
+        const chatTitle = existing?.title ?? defaultChatTitleForSession(conversationId);
+        if (!existing) await setDefaultSessionTitleIfMissing(conversationId, chatTitle);
+        const branchParentId =
+          args.body.parentTurnId !== undefined ? args.body.parentTurnId : existing?.activeLeafId ?? null;
+        const conv = existing ?? {
+          sessionId: conversationId,
+          familiarId: args.body.familiarId,
+          harness: "openclaw",
+          model: responseMetadata.model,
+          runtime: responseMetadata.runtime,
+          title: chatTitle,
+          ...(args.body.origin ? { origin: args.body.origin } : {}),
+          createdAt: now,
+          updatedAt: now,
+          turns: [],
+        };
+        conv.model = responseMetadata.model;
+        conv.runtime = responseMetadata.runtime;
+        persistSendModelIntent(conv, args.body, args.modelState);
+        const workBranch = await captureWorkBranch(cwdFromConversationRuntime(conv.runtime));
+        if (workBranch) conv.branch = workBranch;
+        const reportedPrUrl = latestPrUrlFromText(gatewayAssistantText);
+        if (reportedPrUrl) conv.prUrl = reportedPrUrl;
+        const assistantTurnId = crypto.randomUUID();
+        conv.turns.push(
+          {
+            id: pendingUserTurnId,
+            role: "user",
+            text: args.promptText,
+            ...(args.attachments.length ? { attachments: args.attachments } : {}),
+            createdAt: now,
+            ...(branchParentId != null ? { parentId: branchParentId } : {}),
+          },
+          {
+            id: assistantTurnId,
+            role: "assistant",
+            text: gatewayAssistantText.trim(),
+            createdAt: new Date().toISOString(),
+            durationMs,
+            isError,
+            parentId: pendingUserTurnId,
+            responseMetadata,
+            ...(cancelledByUser ? { cancelled: true } : {}),
+          },
+        );
+        conv.activeLeafId = assistantTurnId;
+        await saveConversation(conv);
+        if (isFirstExchange && !isError) await autoNameSessionFromFirstExchange(conversationId, args.promptText);
+        if (!isError) await maybeAutoRenameFromContext(conversationId, args.promptText);
+        pushProgress("save-transcript", "Transcript saved", "done");
+        push({
+          kind: "done",
+          durationMs,
+          isError,
+          sessionId: conversationId,
+          ...(cancelledByUser ? { cancelled: true } : {}),
+          responseMetadata,
+        });
+        gatewayDispatch.close();
+        runBuffer?.finish();
+        await sleep(20);
+        close();
+        return;
+      }
+      const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId);
+      const openclawLaunch = openClawLaunchCommand();
+      if (openclawLaunch.unresolvedWindowsShim) {
+        pushProgress(
+          "openclaw-start",
+          "OpenClaw bridge cannot start safely",
+          "error",
+          "The resolved OpenClaw Windows npm shim could not be mapped to its JavaScript entry point. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
+        );
+        push({
+          kind: "error",
+          code: "openclaw_unsafe_shell",
+          message:
+            "OpenClaw chat is unavailable because its Windows npm shim could not be launched without shell parsing. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
+        });
+        push({
+          kind: "done",
+          durationMs: Date.now() - startedAt,
+          isError: true,
+        });
+        close();
+        return;
+      }
+      const spawnArgv = [...openclawLaunch.fixedArgs, ...argv];
       pushProgress("openclaw-start", "Starting OpenClaw bridge", "running", cwd);
       const child = spawn(openclawLaunch.command, spawnArgv, {
         cwd,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -667,15 +667,21 @@ function openClawChatResponse(args: {
             return;
           }
           if (event.kind === "delta") {
-            // The published v4 delta schema is append-oriented. A future
-            // replace-capable UI must consume `replace` explicitly; we keep
-            // the complete terminal message authoritative for persistence.
+            if (event.replace) {
+              gatewayAssistantText = event.text;
+              gatewayAssistantTextEmitted = true;
+              push({ kind: "assistant_replace", text: event.text });
+              return;
+            }
             gatewayAssistantText += event.text;
             gatewayAssistantTextEmitted = true;
             push({ kind: "assistant_chunk", text: event.text });
             return;
           }
           if (event.kind === "final" && event.text) {
+            if (gatewayAssistantTextEmitted && gatewayAssistantText !== event.text) {
+              push({ kind: "assistant_replace", text: event.text });
+            }
             gatewayAssistantText = event.text;
           }
           if (event.kind === "error") {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -657,6 +657,10 @@ function openClawChatResponse(args: {
         sessionKey: openClawSessionKey(conversationId),
         agentId,
         message: args.harnessPrompt,
+        // A direct Gateway turn is only safe when Cave has the caller's
+        // stable request id. Reusing it as Gateway's idempotency key makes a
+        // retry observable to the Gateway instead of creating another run.
+        idempotencyKey: args.body.runId ?? "",
         onEvent: (event) => {
           if (event.kind === "status") {
             pushProgress("openclaw-gateway", "OpenClaw Gateway", "running", event.phase);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -129,7 +129,10 @@ import {
 } from "@/lib/server/chat-project-launch";
 import { validateCaveProjectRoot } from "@/lib/server/project-paths";
 import { openClawLaunchCommand, openClawSpawnEnv } from "@/lib/openclaw-bin";
-import { dispatchOpenClawGatewayTurn } from "@/lib/openclaw-gateway";
+import {
+  dispatchOpenClawGatewayTurn,
+  openClawGatewayPairedDeviceAuthStatus,
+} from "@/lib/openclaw-gateway";
 import {
   OpenClawAgentResolutionError,
   extractOpenClawSessionId,
@@ -653,7 +656,9 @@ function openClawChatResponse(args: {
       // Gateway it deliberately never starts a second CLI turn.
       let gatewayAssistantText = "";
       let gatewayAssistantTextEmitted = false;
-      const gatewayDispatch = await dispatchOpenClawGatewayTurn({
+      const gatewayAuth = openClawGatewayPairedDeviceAuthStatus();
+      const gatewayDispatch = gatewayAuth.available
+        ? await dispatchOpenClawGatewayTurn({
         sessionKey: openClawSessionKey(conversationId),
         agentId,
         message: args.harnessPrompt,
@@ -688,7 +693,8 @@ function openClawChatResponse(args: {
             pushProgress("openclaw-gateway", "OpenClaw Gateway", "error", event.message);
           }
         },
-      });
+      })
+        : { kind: "unavailable" as const, reason: gatewayAuth.reason ?? "Gateway paired-device authentication is unavailable" };
       if (gatewayDispatch.kind === "indeterminate") {
         pushProgress("openclaw-gateway", "OpenClaw Gateway dispatch is indeterminate", "error", gatewayDispatch.reason);
         push({ kind: "error", code: "openclaw_gateway_indeterminate", message: gatewayDispatch.reason });

--- a/src/app/api/chat/stream/route.test.ts
+++ b/src/app/api/chat/stream/route.test.ts
@@ -81,7 +81,7 @@ test("send route tees both harness stream paths through the run buffer", () => {
   const seqEmits = send.match(/controller\.enqueue\(chatSse\(e(?:vent)?, seq\)\)/g);
   assert.equal(seqEmits?.length, 2, "both paths emit the seq as the SSE id — live clients always hold a resume cursor");
   const opens = send.match(/openRunBuffer\(\[/g);
-  assert.equal(opens?.length, 2, "both paths open a buffer under runId + conversation keys");
+  assert.equal(opens?.length, 3, "all three dispatch paths (harness, OpenClaw CLI, OpenClaw Gateway) open a buffer under runId + conversation keys");
   const finishes = send.match(/runBuffer\?\.finish\(\)/g);
   assert.ok((finishes?.length ?? 0) >= 3, "every stream exit (error + close paths) finishes the buffer");
 });
@@ -93,5 +93,5 @@ test("re-attach disarms the detach-cap kill; the last tail re-arms only after th
     "attach hook cancels the pending kill",
   );
   const rearms = send.match(/detach: \(\) => \{\s*if \((?:args\.)?req\.signal\.aborted\) armDetachKill\(\);/g);
-  assert.equal(rearms?.length, 2, "detach hooks re-arm only when the original request is gone — a resume tail closing can't kill a still-attached turn");
+  assert.equal(rearms?.length, 3, "detach hooks re-arm only when the original request is gone — a resume tail closing can't kill a still-attached turn");
 });

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -83,13 +83,13 @@ assert.match(
 );
 assert.match(
   src,
-  /const GATEWAY_AUTH_ENV_KEYS = new Set\(\[[\s\S]*OPENCLAW_GATEWAY_TOKEN[\s\S]*OPENCLAW_GATEWAY_DEVICE_TOKEN[\s\S]*\]\);/,
-  "Gateway authentication values have an explicit fallback-child denylist",
+  /const GATEWAY_ENV_PREFIX = "OPENCLAW_GATEWAY_"/,
+  "the whole Gateway namespace has an explicit fallback-child denylist",
 );
 assert.match(
   src,
-  /const mustNotReachFallback = GATEWAY_AUTH_ENV_KEYS\.has\(key\);[\s\S]*if \([\s\S]*mustNotReachFallback \|\|[\s\S]*genericSecret && !allowed\.has\(key\)/,
-  "Gateway auth cannot be reintroduced by the generic OpenClaw credential allow-list",
+  /const mustNotReachFallback = key\.startsWith\(GATEWAY_ENV_PREFIX\);[\s\S]*if \([\s\S]*mustNotReachFallback \|\|[\s\S]*genericSecret && !allowed\.has\(key\)/,
+  "Gateway settings cannot be reintroduced by the generic OpenClaw credential allow-list",
 );
 
 console.log("openclaw-bin.test.ts: ok");

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -81,5 +81,15 @@ assert.match(
   /const grantedVaultTokenKeys = new Set(?:<string>)?\([\s\S]*GITHUB_HARNESS_TOKEN_ENV_KEYS\.filter\([\s\S]*isVaultKeyGrantedTo\(map\[key\]\)[\s\S]*!grantedVaultTokenKeys\.has\(key\)/,
   "OpenClaw must retain a shared Vault-managed GitHub credential through its final secret scrub",
 );
+assert.match(
+  src,
+  /const GATEWAY_AUTH_ENV_KEYS = new Set\(\[[\s\S]*OPENCLAW_GATEWAY_TOKEN[\s\S]*OPENCLAW_GATEWAY_DEVICE_TOKEN[\s\S]*\]\);/,
+  "Gateway authentication values have an explicit fallback-child denylist",
+);
+assert.match(
+  src,
+  /const mustNotReachFallback = GATEWAY_AUTH_ENV_KEYS\.has\(key\);[\s\S]*if \([\s\S]*mustNotReachFallback \|\|[\s\S]*genericSecret && !allowed\.has\(key\)/,
+  "Gateway auth cannot be reintroduced by the generic OpenClaw credential allow-list",
+);
 
 console.log("openclaw-bin.test.ts: ok");

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -22,6 +22,17 @@ import { isVaultKeyGrantedTo, loadVaultMap } from "./vault";
 let cachedBin: string | null = null;
 
 const FORBIDDEN_SPAWN_ENV_KEYS = new Set(["GITHUB_PAT"]);
+// The Gateway dispatcher reads these only in Cave's server process. They must
+// never cross the fallback boundary, even if a broad harness allow-list was
+// configured for a different OpenClaw integration.
+const GATEWAY_AUTH_ENV_KEYS = new Set([
+  "OPENCLAW_GATEWAY_TOKEN",
+  "OPENCLAW_GATEWAY_DEVICE_TOKEN",
+  "OPENCLAW_GATEWAY_BOOTSTRAP_TOKEN",
+  "OPENCLAW_GATEWAY_PASSWORD",
+  "OPENCLAW_GATEWAY_APPROVAL_RUNTIME_TOKEN",
+  "OPENCLAW_GATEWAY_AGENT_RUNTIME_IDENTITY_TOKEN",
+]);
 const FORBIDDEN_SPAWN_ENV_RE =
   /(?:^|_)(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PAT|CREDENTIALS?|COOKIE|SESSION)(?:_|$)/i;
 
@@ -177,10 +188,12 @@ export function openClawSpawnEnv(): NodeJS.ProcessEnv {
   restoreAllowedGitHubTokenEnv(env, allowed, new Set(Object.keys(map)));
 
   for (const key of Object.keys(env)) {
+    const mustNotReachFallback = GATEWAY_AUTH_ENV_KEYS.has(key);
+    const genericSecret =
+      FORBIDDEN_SPAWN_ENV_KEYS.has(key) || FORBIDDEN_SPAWN_ENV_RE.test(key);
     if (
-      (FORBIDDEN_SPAWN_ENV_KEYS.has(key) || FORBIDDEN_SPAWN_ENV_RE.test(key)) &&
-      !allowed.has(key) &&
-      !grantedVaultTokenKeys.has(key)
+      mustNotReachFallback ||
+      (genericSecret && !allowed.has(key) && !grantedVaultTokenKeys.has(key))
     ) {
       delete env[key];
     }

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -25,14 +25,11 @@ const FORBIDDEN_SPAWN_ENV_KEYS = new Set(["GITHUB_PAT"]);
 // The Gateway dispatcher reads these only in Cave's server process. They must
 // never cross the fallback boundary, even if a broad harness allow-list was
 // configured for a different OpenClaw integration.
-const GATEWAY_AUTH_ENV_KEYS = new Set([
-  "OPENCLAW_GATEWAY_TOKEN",
-  "OPENCLAW_GATEWAY_DEVICE_TOKEN",
-  "OPENCLAW_GATEWAY_BOOTSTRAP_TOKEN",
-  "OPENCLAW_GATEWAY_PASSWORD",
-  "OPENCLAW_GATEWAY_APPROVAL_RUNTIME_TOKEN",
-  "OPENCLAW_GATEWAY_AGENT_RUNTIME_IDENTITY_TOKEN",
-]);
+// Keep the entire direct-Gateway namespace in Cave's server process. An
+// explicit generic harness allow-list must not turn a future Gateway token,
+// device identity, private key, or signing value into a CLI child credential.
+// The CLI compatibility path has no supported need for these settings.
+const GATEWAY_ENV_PREFIX = "OPENCLAW_GATEWAY_";
 const FORBIDDEN_SPAWN_ENV_RE =
   /(?:^|_)(?:TOKEN|KEY|SECRET|PASSWORD|PASS|PAT|CREDENTIALS?|COOKIE|SESSION)(?:_|$)/i;
 
@@ -188,7 +185,7 @@ export function openClawSpawnEnv(): NodeJS.ProcessEnv {
   restoreAllowedGitHubTokenEnv(env, allowed, new Set(Object.keys(map)));
 
   for (const key of Object.keys(env)) {
-    const mustNotReachFallback = GATEWAY_AUTH_ENV_KEYS.has(key);
+    const mustNotReachFallback = key.startsWith(GATEWAY_ENV_PREFIX);
     const genericSecret =
       FORBIDDEN_SPAWN_ENV_KEYS.has(key) || FORBIDDEN_SPAWN_ENV_RE.test(key);
     if (

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -56,6 +56,24 @@ assert.equal(
 );
 assert.equal(textFromOpenClawGatewayMessage({ raw: "not published" }), undefined);
 
+const missingRequestId = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  idempotencyKey: "",
+  env: {
+    OPENCLAW_GATEWAY_DISPATCH: "1",
+    OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+  },
+  onEvent: () => assert.fail("a Gateway without a Cave request id must not emit events"),
+  clientFactory: () => assert.fail("a Gateway without a Cave request id must not connect"),
+});
+assert.deepEqual(
+  missingRequestId,
+  { kind: "unavailable", reason: "Gateway dispatch requires a Cave request id" },
+  "without a stable Cave request id the route retains the CLI fallback",
+);
+
 // The direct dispatcher is tested through the same official-client callback
 // contract that production uses: it waits for hello and subscription, binds
 // the acknowledged run id, and ignores a foreign run with the same session.
@@ -65,6 +83,7 @@ const dispatch = await dispatchOpenClawGatewayTurn({
   sessionKey: expected.sessionKey,
   agentId: expected.agentId,
   message: "hello",
+  idempotencyKey: "cave-request-123",
   env: {
     OPENCLAW_GATEWAY_DISPATCH: "1",
     OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
@@ -92,8 +111,9 @@ const dispatch = await dispatchOpenClawGatewayTurn({
         );
       },
       stop() {},
-      async request(method, _params, requestOptions) {
+      async request(method, params, requestOptions) {
         if (method === "chat.send") {
+          assert.equal(params.idempotencyKey, "cave-request-123", "Gateway receives Cave's stable request id");
           requestOptions?.onSent?.();
           queueMicrotask(() => {
             options.onEvent?.({

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -76,9 +76,18 @@ const dispatch = await dispatchOpenClawGatewayTurn({
       start() {
         queueMicrotask(() =>
           options.onHelloOk?.({
+            type: "hello-ok",
             protocol: 4,
+            server: { version: "2026.7.2-beta.4", connId: "test-connection" },
             features: { methods: ["chat.send", "sessions.messages.subscribe"], events: ["chat"] },
+            snapshot: {
+              presence: [],
+              health: {},
+              stateVersion: { presence: 0, health: 0 },
+              uptimeMs: 0,
+            },
             auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
+            policy: { maxPayload: 1024, maxBufferedBytes: 1024, tickIntervalMs: 1000 },
           }),
         );
       },

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -282,8 +282,9 @@ if (gappedDispatch.kind === "accepted") {
 assert.deepEqual(gappedEvents, [{ kind: "error", message: "Gateway event sequence gap" }]);
 
 // A reconnect is not an excuse to trust an event before the documented
-// session subscription returns. The queued frame is accepted only after the
-// re-subscription succeeds.
+// session subscription returns. A callback delivered while the old socket is
+// closed has no transport-generation provenance, so it is dropped rather
+// than being replayed after the next subscription succeeds.
 let reconnectOptions;
 let releaseFirstResubscribe;
 let releaseSecondResubscribe;
@@ -372,8 +373,14 @@ await Promise.resolve();
 await Promise.resolve();
 assert.deepEqual(
   reconnectEvents,
+  [],
+  "a frame delivered after transport close is never replayed on the reconnected stream",
+);
+reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });
+assert.deepEqual(
+  reconnectEvents,
   [{ kind: "delta", text: "Hello", replace: false }],
-  "the queued frame is projected after re-subscription succeeds",
+  "a new frame is projected only after re-subscription succeeds",
 );
 reconnectOptions.onEvent?.({
   type: "event",

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -90,6 +90,27 @@ assert.deepEqual(
   "without a stable Cave request id the route retains the CLI fallback",
 );
 
+const unpairedDispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  idempotencyKey: "cave-request-unpaired",
+  env: {
+    OPENCLAW_GATEWAY_DISPATCH: "1",
+    OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+    OPENCLAW_GATEWAY_TOKEN: "must-not-activate-direct-dispatch",
+  },
+  onEvent: () => assert.fail("an unpaired Gateway must not emit events"),
+});
+assert.deepEqual(
+  unpairedDispatch,
+  {
+    kind: "unavailable",
+    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+  },
+  "an environment token alone must never activate a write-capable Gateway dispatch",
+);
+
 // The direct dispatcher is tested through the same official-client callback
 // contract that production uses: it waits for hello and subscription, binds
 // the acknowledged run id, and ignores a foreign run with the same session.
@@ -103,10 +124,19 @@ const dispatch = await dispatchOpenClawGatewayTurn({
   env: {
     OPENCLAW_GATEWAY_DISPATCH: "1",
     OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+    OPENCLAW_GATEWAY_TOKEN: "must-not-reach-the-client",
+    OPENCLAW_GATEWAY_DEVICE_TOKEN: "must-not-reach-the-client",
   },
   onEvent: (event) => emitted.push(event),
   clientFactory: (options) => {
     clientOptions = options;
+    assert.equal(options.token, undefined, "Gateway process tokens must not reach the client");
+    assert.equal(options.deviceToken, undefined, "Gateway process device tokens must not reach the client");
+    assert.deepEqual(
+      options.env,
+      { NODE_ENV: process.env.NODE_ENV ?? "production" },
+      "Gateway auth must not inherit Cave's process environment",
+    );
     assert.equal(options.caps, undefined, "chat-only dispatch must not request unpublished tool-event capabilities");
     return {
       start() {

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -222,6 +222,10 @@ function helloOk() {
 }
 
 assert.equal(reconnectDispatch.kind, "accepted");
+// The published client reports a failed *reconnect attempt* through
+// onConnectError before it retries. That must not terminate a Gateway-owned
+// run; a subsequent authenticated hello restores the subscription.
+reconnectOptions.onConnectError?.(new Error("transient reconnect failure"));
 reconnectOptions.onHelloOk?.(helloOk());
 reconnectOptions.onHelloOk?.(helloOk());
 reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -55,11 +55,12 @@ assert.equal(
   "unpublished tool payload shapes fail closed instead of becoming cards",
 );
 
-assert.equal(textFromOpenClawGatewayMessage("plain"), "plain");
-assert.equal(textFromOpenClawGatewayMessage({ text: "envelope" }), "envelope");
+assert.equal(textFromOpenClawGatewayMessage("plain"), undefined);
+assert.equal(textFromOpenClawGatewayMessage({ text: "envelope" }), undefined);
 assert.equal(
   textFromOpenClawGatewayMessage({ content: [{ type: "text", text: "a" }, { type: "text", text: "b" }] }),
-  "ab",
+  undefined,
+  "the published ChatEvent schema leaves message opaque, so its observed contents must not reach Cave output",
 );
 assert.equal(textFromOpenClawGatewayMessage({ raw: "not published" }), undefined);
 assert.deepEqual(
@@ -168,13 +169,51 @@ assert.equal(clientOptions.caps, undefined, "chat-only dispatch must not request
 assert.equal(clientOptions.minProtocol, 4);
 assert.equal(clientOptions.maxProtocol, 4);
 if (dispatch.kind === "accepted") {
-  assert.deepEqual(await dispatch.done, { state: "final", message: "Hello" });
+  assert.deepEqual(await dispatch.done, { state: "final" });
 }
 assert.deepEqual(
   emitted.filter((event) => event.kind === "delta"),
   [{ kind: "delta", text: "Hello", replace: false }],
   "only the accepted run reaches Cave output; a foreign same-session run is rejected",
 );
+assert.ok(
+  emitted.some((event) => event.kind === "final" && !("text" in event)),
+  "an opaque final message never becomes assistant-visible text",
+);
+
+const gappedEvents = [];
+const gappedDispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "gap",
+  idempotencyKey: "cave-request-gap",
+  env: { OPENCLAW_GATEWAY_DISPATCH: "1", OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789" },
+  onEvent: (event) => gappedEvents.push(event),
+  clientFactory: (options) => ({
+    start() { queueMicrotask(() => options.onHelloOk?.(helloOk())); },
+    stop() {},
+    async request(method, _params, requestOptions) {
+      if (method === "chat.send") {
+        requestOptions?.onSent?.();
+        queueMicrotask(() => options.onEvent?.({
+          type: "event",
+          event: "chat",
+          payload: { ...delta, seq: 1 },
+        }));
+        return { runId: expected.runId };
+      }
+      return { subscribed: true };
+    },
+  }),
+});
+if (gappedDispatch.kind === "accepted") {
+  assert.deepEqual(
+    await gappedDispatch.done,
+    { state: "error", message: "Gateway event sequence gap" },
+    "the first accepted event must be sequence zero; otherwise the Gateway turn is incomplete",
+  );
+}
+assert.deepEqual(gappedEvents, [{ kind: "error", message: "Gateway event sequence gap" }]);
 
 // A reconnect is not an excuse to trust an event before the documented
 // session subscription returns. The queued frame is accepted only after the
@@ -272,7 +311,7 @@ reconnectOptions.onEvent?.({
   },
 });
 if (reconnectDispatch.kind === "accepted") {
-  assert.deepEqual(await reconnectDispatch.done, { state: "final", message: "done" });
+  assert.deepEqual(await reconnectDispatch.done, { state: "final" });
 }
 
 console.log("openclaw Gateway run correlation tests passed");

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -160,4 +160,92 @@ assert.deepEqual(
   "only the accepted run reaches Cave output; a foreign same-session run is rejected",
 );
 
+// A reconnect is not an excuse to trust an event before the documented
+// session subscription returns. The queued frame is accepted only after the
+// re-subscription succeeds.
+let reconnectOptions;
+let releaseResubscribe;
+let subscriptionCalls = 0;
+const reconnectEvents = [];
+const reconnectDispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello again",
+  idempotencyKey: "cave-request-reconnect",
+  env: {
+    OPENCLAW_GATEWAY_DISPATCH: "1",
+    OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+  },
+  onEvent: (event) => reconnectEvents.push(event),
+  clientFactory: (options) => {
+    reconnectOptions = options;
+    return {
+      start() {
+        queueMicrotask(() => options.onHelloOk?.(helloOk()));
+      },
+      stop() {},
+      async request(method, _params, requestOptions) {
+        if (method === "sessions.messages.subscribe") {
+          subscriptionCalls += 1;
+          if (subscriptionCalls === 1) return { subscribed: true };
+          return new Promise((resolve) => {
+            releaseResubscribe = () => resolve({ subscribed: true });
+          });
+        }
+        if (method === "chat.send") {
+          requestOptions?.onSent?.();
+          return { runId: expected.runId };
+        }
+        return {};
+      },
+    };
+  },
+});
+
+function helloOk() {
+  return {
+    type: "hello-ok",
+    protocol: 4,
+    server: { version: "2026.7.2-beta.4", connId: "reconnect-connection" },
+    features: { methods: ["chat.send", "sessions.messages.subscribe"], events: ["chat"] },
+    snapshot: {
+      presence: [],
+      health: {},
+      stateVersion: { presence: 0, health: 0 },
+      uptimeMs: 0,
+    },
+    auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
+    policy: { maxPayload: 1024, maxBufferedBytes: 1024, tickIntervalMs: 1000 },
+  };
+}
+
+assert.equal(reconnectDispatch.kind, "accepted");
+reconnectOptions.onHelloOk?.(helloOk());
+reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });
+await Promise.resolve();
+assert.deepEqual(reconnectEvents, [], "a pre-subscription reconnect frame is not projected");
+releaseResubscribe();
+await Promise.resolve();
+await Promise.resolve();
+assert.deepEqual(
+  reconnectEvents,
+  [{ kind: "delta", text: "Hello", replace: false }],
+  "the queued frame is projected after re-subscription succeeds",
+);
+reconnectOptions.onEvent?.({
+  type: "event",
+  event: "chat",
+  payload: {
+    runId: expected.runId,
+    sessionKey: expected.sessionKey,
+    agentId: expected.agentId,
+    seq: 1,
+    state: "final",
+    message: { text: "done" },
+  },
+});
+if (reconnectDispatch.kind === "accepted") {
+  assert.deepEqual(await reconnectDispatch.done, { state: "final", message: "done" });
+}
+
 console.log("openclaw Gateway run correlation tests passed");

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -164,7 +164,8 @@ assert.deepEqual(
 // session subscription returns. The queued frame is accepted only after the
 // re-subscription succeeds.
 let reconnectOptions;
-let releaseResubscribe;
+let releaseFirstResubscribe;
+let releaseSecondResubscribe;
 let subscriptionCalls = 0;
 const reconnectEvents = [];
 const reconnectDispatch = await dispatchOpenClawGatewayTurn({
@@ -189,7 +190,8 @@ const reconnectDispatch = await dispatchOpenClawGatewayTurn({
           subscriptionCalls += 1;
           if (subscriptionCalls === 1) return { subscribed: true };
           return new Promise((resolve) => {
-            releaseResubscribe = () => resolve({ subscribed: true });
+            if (subscriptionCalls === 2) releaseFirstResubscribe = () => resolve({ subscribed: true });
+            else releaseSecondResubscribe = () => resolve({ subscribed: true });
           });
         }
         if (method === "chat.send") {
@@ -221,10 +223,15 @@ function helloOk() {
 
 assert.equal(reconnectDispatch.kind, "accepted");
 reconnectOptions.onHelloOk?.(helloOk());
+reconnectOptions.onHelloOk?.(helloOk());
 reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });
 await Promise.resolve();
 assert.deepEqual(reconnectEvents, [], "a pre-subscription reconnect frame is not projected");
-releaseResubscribe();
+releaseFirstResubscribe();
+await Promise.resolve();
+await Promise.resolve();
+assert.deepEqual(reconnectEvents, [], "a stale reconnect subscription cannot reopen a newer connection's stream");
+releaseSecondResubscribe();
 await Promise.resolve();
 await Promise.resolve();
 assert.deepEqual(

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -111,6 +111,33 @@ assert.deepEqual(
   "an environment token alone must never activate a write-capable Gateway dispatch",
 );
 
+let stoppedAfterStartupFailure = false;
+const startupFailure = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  idempotencyKey: "cave-request-startup-failure",
+  env: { OPENCLAW_GATEWAY_DISPATCH: "1", OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789" },
+  onEvent: () => assert.fail("a Gateway that fails to start must not emit events"),
+  clientFactory: () => ({
+    start() {
+      throw new Error("Gateway client startup failed");
+    },
+    stop() {
+      stoppedAfterStartupFailure = true;
+    },
+    async request() {
+      assert.fail("a Gateway that failed to start must not dispatch");
+    },
+  }),
+});
+assert.deepEqual(
+  startupFailure,
+  { kind: "unavailable", reason: "Gateway client startup failed" },
+  "a pre-dispatch client startup failure retains the CLI fallback",
+);
+assert.equal(stoppedAfterStartupFailure, true, "a partially started Gateway client is stopped before fallback");
+
 // The direct dispatcher is tested through the same official-client callback
 // contract that production uses: it waits for hello and subscription, binds
 // the acknowledged run id, and ignores a foreign run with the same session.

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -145,7 +145,11 @@ const dispatch = await dispatchOpenClawGatewayTurn({
             type: "hello-ok",
             protocol: 4,
             server: { version: "2026.7.2-beta.4", connId: "test-connection" },
-            features: { methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"], events: ["chat"] },
+            features: {
+              methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"],
+              events: ["chat"],
+              capabilities: ["chat-send-routing-contract"],
+            },
             snapshot: {
               presence: [],
               health: {},
@@ -209,6 +213,38 @@ assert.deepEqual(
 assert.ok(
   emitted.some((event) => event.kind === "final" && !("text" in event)),
   "an opaque final message never becomes assistant-visible text",
+);
+
+const missingRoutingCapability = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "capability check",
+  idempotencyKey: "cave-request-missing-routing-capability",
+  env: { OPENCLAW_GATEWAY_DISPATCH: "1", OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789" },
+  onEvent: () => assert.fail("an incompatible Gateway must not emit events"),
+  clientFactory: (options) => ({
+    start() {
+      queueMicrotask(() => options.onHelloOk?.({
+        ...helloOk(),
+        features: {
+          ...helloOk().features,
+          capabilities: [],
+        },
+      }));
+    },
+    stop() {},
+    async request() {
+      assert.fail("a Gateway without the routing capability must not dispatch");
+    },
+  }),
+});
+assert.deepEqual(
+  missingRoutingCapability,
+  {
+    kind: "unavailable",
+    reason: "Gateway does not advertise the required chat-send-routing-contract capability",
+  },
+  "agent and session routing must not be trusted without the published routing capability",
 );
 
 const gappedEvents = [];
@@ -294,7 +330,11 @@ function helloOk() {
     type: "hello-ok",
     protocol: 4,
     server: { version: "2026.7.2-beta.4", connId: "reconnect-connection" },
-    features: { methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"], events: ["chat"] },
+    features: {
+      methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"],
+      events: ["chat"],
+      capabilities: ["chat-send-routing-contract"],
+    },
     snapshot: {
       presence: [],
       health: {},

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  dispatchOpenClawGatewayTurn,
+  normalizeOpenClawGatewayChatEvent,
+  textFromOpenClawGatewayMessage,
+} from "./openclaw-gateway.ts";
+
+const expected = {
+  runId: "run-accepted",
+  sessionKey: "agent:nova:explicit:cave-123",
+  agentId: "nova",
+};
+
+const delta = {
+  runId: expected.runId,
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  seq: 4,
+  state: "delta",
+  deltaText: "Hello",
+};
+
+assert.deepEqual(
+  normalizeOpenClawGatewayChatEvent(delta, expected),
+  delta,
+  "published v4 chat deltas remain available to the run that Gateway accepted",
+);
+
+assert.equal(
+  normalizeOpenClawGatewayChatEvent({ ...delta, runId: "another-run" }, expected),
+  null,
+  "a valid frame from another run in the exact same session must never reach this turn",
+);
+assert.equal(
+  normalizeOpenClawGatewayChatEvent({ ...delta, agentId: "other-agent" }, expected),
+  null,
+  "agent-scoped routing is required in addition to canonical session keys",
+);
+assert.equal(
+  normalizeOpenClawGatewayChatEvent({ ...delta, seq: "4" }, expected),
+  null,
+  "the official schema rejects malformed sequence values before lifecycle reconciliation",
+);
+assert.equal(
+  normalizeOpenClawGatewayChatEvent({ ...delta, state: "tool" }, expected),
+  null,
+  "unpublished tool payload shapes fail closed instead of becoming cards",
+);
+
+assert.equal(textFromOpenClawGatewayMessage("plain"), "plain");
+assert.equal(textFromOpenClawGatewayMessage({ text: "envelope" }), "envelope");
+assert.equal(
+  textFromOpenClawGatewayMessage({ content: [{ type: "text", text: "a" }, { type: "text", text: "b" }] }),
+  "ab",
+);
+assert.equal(textFromOpenClawGatewayMessage({ raw: "not published" }), undefined);
+
+// The direct dispatcher is tested through the same official-client callback
+// contract that production uses: it waits for hello and subscription, binds
+// the acknowledged run id, and ignores a foreign run with the same session.
+let clientOptions;
+const emitted = [];
+const dispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  env: {
+    OPENCLAW_GATEWAY_DISPATCH: "1",
+    OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789",
+  },
+  onEvent: (event) => emitted.push(event),
+  clientFactory: (options) => {
+    clientOptions = options;
+    return {
+      start() {
+        queueMicrotask(() =>
+          options.onHelloOk?.({
+            protocol: 4,
+            features: { methods: ["chat.send", "sessions.messages.subscribe"], events: ["chat"] },
+            auth: { role: "operator", scopes: ["operator.read", "operator.write"] },
+          }),
+        );
+      },
+      stop() {},
+      async request(method, _params, requestOptions) {
+        if (method === "chat.send") {
+          requestOptions?.onSent?.();
+          queueMicrotask(() => {
+            options.onEvent?.({
+              type: "event",
+              event: "chat",
+              payload: { ...delta, runId: "foreign-run", seq: 0 },
+            });
+            options.onEvent?.({
+              type: "event",
+              event: "chat",
+              payload: { ...delta, seq: 0 },
+            });
+            options.onEvent?.({
+              type: "event",
+              event: "chat",
+              payload: {
+                runId: expected.runId,
+                sessionKey: expected.sessionKey,
+                agentId: expected.agentId,
+                seq: 1,
+                state: "final",
+                message: { text: "Hello" },
+              },
+            });
+          });
+          return { runId: expected.runId };
+        }
+        return { subscribed: true, key: expected.sessionKey };
+      },
+    };
+  },
+});
+
+assert.equal(dispatch.kind, "accepted", "a documented accepted run id enables Gateway ownership");
+assert.equal(clientOptions.caps?.[0], "tool-events", "the official client requests tool events without parsing unpublished tools");
+assert.equal(clientOptions.minProtocol, 4);
+assert.equal(clientOptions.maxProtocol, 4);
+if (dispatch.kind === "accepted") {
+  assert.deepEqual(await dispatch.done, { state: "final", message: "Hello" });
+}
+assert.deepEqual(
+  emitted.filter((event) => event.kind === "delta"),
+  [{ kind: "delta", text: "Hello", replace: false }],
+  "only the accepted run reaches Cave output; a foreign same-session run is rejected",
+);
+
+console.log("openclaw Gateway run correlation tests passed");

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -37,6 +37,12 @@ assert.equal(
   null,
   "agent-scoped routing is required in addition to canonical session keys",
 );
+const { agentId: _omittedAgentId, ...chatEventWithoutAgentId } = delta;
+assert.equal(
+  normalizeOpenClawGatewayChatEvent(chatEventWithoutAgentId, expected),
+  null,
+  "frames without the dispatched agent id cannot be attributed to this turn",
+);
 assert.equal(
   normalizeOpenClawGatewayChatEvent({ ...delta, seq: "4" }, expected),
   null,
@@ -91,6 +97,7 @@ const dispatch = await dispatchOpenClawGatewayTurn({
   onEvent: (event) => emitted.push(event),
   clientFactory: (options) => {
     clientOptions = options;
+    assert.equal(options.caps, undefined, "chat-only dispatch must not request unpublished tool-event capabilities");
     return {
       start() {
         queueMicrotask(() =>
@@ -98,7 +105,7 @@ const dispatch = await dispatchOpenClawGatewayTurn({
             type: "hello-ok",
             protocol: 4,
             server: { version: "2026.7.2-beta.4", connId: "test-connection" },
-            features: { methods: ["chat.send", "sessions.messages.subscribe"], events: ["chat"] },
+            features: { methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"], events: ["chat"] },
             snapshot: {
               presence: [],
               health: {},
@@ -148,7 +155,7 @@ const dispatch = await dispatchOpenClawGatewayTurn({
 });
 
 assert.equal(dispatch.kind, "accepted", "a documented accepted run id enables Gateway ownership");
-assert.equal(clientOptions.caps?.[0], "tool-events", "the official client requests tool events without parsing unpublished tools");
+assert.equal(clientOptions.caps, undefined, "chat-only dispatch must not request unpublished tool-event capabilities");
 assert.equal(clientOptions.minProtocol, 4);
 assert.equal(clientOptions.maxProtocol, 4);
 if (dispatch.kind === "accepted") {
@@ -209,7 +216,7 @@ function helloOk() {
     type: "hello-ok",
     protocol: 4,
     server: { version: "2026.7.2-beta.4", connId: "reconnect-connection" },
-    features: { methods: ["chat.send", "sessions.messages.subscribe"], events: ["chat"] },
+    features: { methods: ["chat.send", "chat.abort", "sessions.messages.subscribe"], events: ["chat"] },
     snapshot: {
       presence: [],
       health: {},

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   dispatchOpenClawGatewayTurn,
   normalizeOpenClawGatewayChatEvent,
+  openClawGatewayPairedDeviceAuthStatus,
   textFromOpenClawGatewayMessage,
 } from "./openclaw-gateway.ts";
 
@@ -61,6 +62,14 @@ assert.equal(
   "ab",
 );
 assert.equal(textFromOpenClawGatewayMessage({ raw: "not published" }), undefined);
+assert.deepEqual(
+  openClawGatewayPairedDeviceAuthStatus(),
+  {
+    available: false,
+    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+  },
+  "Cave must not activate the Gateway route before its host-owned paired-device credentials are secure",
+);
 
 const missingRequestId = await dispatchOpenClawGatewayTurn({
   sessionKey: expected.sessionKey,

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -351,6 +351,13 @@ assert.equal(reconnectDispatch.kind, "accepted");
 // onConnectError before it retries. That must not terminate a Gateway-owned
 // run; a subsequent authenticated hello restores the subscription.
 reconnectOptions.onConnectError?.(new Error("transient reconnect failure"));
+reconnectOptions.onClose?.(1006, "network reset");
+reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });
+assert.deepEqual(
+  reconnectEvents,
+  [],
+  "a closed transport cannot project a buffered frame before its reconnect hello re-subscribes",
+);
 reconnectOptions.onHelloOk?.(helloOk());
 reconnectOptions.onHelloOk?.(helloOk());
 reconnectOptions.onEvent?.({ type: "event", event: "chat", payload: { ...delta, seq: 0 } });

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -155,6 +155,10 @@ export async function dispatchOpenClawGatewayTurn(args: {
   let helloResolve: (() => void) | undefined;
   let helloReject: ((error: Error) => void) | undefined;
   let connected = false;
+  // Each authenticated hello represents a new transport generation. A
+  // subscription completion from an older connection must never make the
+  // newest connection's stream trusted again.
+  let connectionGeneration = 0;
   let expectedRunId: string | undefined;
   let streamReady = false;
   let highestSequence = -1;
@@ -225,6 +229,15 @@ export async function dispatchOpenClawGatewayTurn(args: {
     settle("error", message);
   };
 
+  const subscribeToSession = async (generation: number): Promise<boolean> => {
+    if (generation === connectionGeneration) streamReady = false;
+    await client.request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId });
+    if (generation !== connectionGeneration || settled) return false;
+    streamReady = true;
+    drainQueuedChatEvents();
+    return true;
+  };
+
   const hello = new Promise<void>((resolve, reject) => {
     helloResolve = resolve;
     helloReject = reject;
@@ -262,6 +275,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
       }
       if (!connected) {
         connected = true;
+        connectionGeneration += 1;
         helloResolve?.();
         return;
       }
@@ -270,14 +284,10 @@ export async function dispatchOpenClawGatewayTurn(args: {
       // that arrive during this window remain queued until that subscription
       // has succeeded, so a reconnect never turns an unverified stream into
       // accepted lifecycle state.
-      streamReady = false;
-      void client
-        .request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId })
-        .then(() => {
-          streamReady = true;
-          drainQueuedChatEvents();
-        })
+      const generation = ++connectionGeneration;
+      void subscribeToSession(generation)
         .catch(() => {
+          if (generation !== connectionGeneration || settled) return;
           const message = "Gateway reconnect could not restore the session stream";
           args.onEvent({ kind: "error", message });
           settle("error", message);
@@ -308,8 +318,18 @@ export async function dispatchOpenClawGatewayTurn(args: {
   client.start();
   try {
     await withTimeout(hello, STARTUP_TIMEOUT_MS, "Gateway did not complete its authenticated hello");
-    await client.request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId });
-    streamReady = true;
+    // A reconnect can arrive while the initial subscription is in flight.
+    // Retry until the completion belongs to the latest authenticated hello;
+    // an old socket's rejection is similarly irrelevant once a newer hello
+    // has already arrived.
+    for (;;) {
+      const generation = connectionGeneration;
+      try {
+        if (await subscribeToSession(generation)) break;
+      } catch (error) {
+        if (generation === connectionGeneration) throw error;
+      }
+    }
   } catch (error) {
     client.stop();
     return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway is unavailable" };

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -210,8 +210,18 @@ export async function dispatchOpenClawGatewayTurn(args: {
   };
 
   const processChatEvent = (payload: unknown) => {
-    if (!expectedRunId || !streamReady || settled) {
+    if (settled) return;
+    // Until `chat.send` returns, events cannot yet be correlated to a Cave
+    // turn. Hold a bounded set so an accepted response can bind them to its
+    // run id. Once a run has been accepted, however, a disconnect or a
+    // reconnect subscription gap is a hard fence: an event callback has no
+    // transport-generation provenance, so accepting it after the next hello
+    // could expose a late frame buffered by the old socket.
+    if (!expectedRunId) {
       if (queuedChatEvents.length < 128) queuedChatEvents.push(payload);
+      return;
+    }
+    if (!streamReady) {
       return;
     }
     const event = normalizeOpenClawGatewayChatEvent(payload, {

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -339,6 +339,15 @@ export async function dispatchOpenClawGatewayTurn(args: {
       settle("error", message);
       client.stop();
     },
+    onClose: () => {
+      // A socket close invalidates the subscription immediately, not only
+      // when the next hello arrives. The Gateway client retries in the
+      // background, and a buffered callback from the closed transport must
+      // not be accepted in the interval before that new hello restores the
+      // session subscription.
+      streamReady = false;
+      connectionGeneration += 1;
+    },
     onEvent: (frame) => {
       if (frame.event === "chat") processChatEvent(frame.payload);
     },

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -96,17 +96,16 @@ function supportedHello(hello: GatewayHello): string | null {
   return null;
 }
 
-/** Extract text only from the documented chat envelope shapes. */
+/**
+ * The published v4 ChatEvent schema deliberately leaves `message` opaque.
+ * Do not infer a content envelope from an opaque value: doing so would make
+ * unversioned Gateway payloads assistant-visible. Text reaches Cave only via
+ * the schema's `deltaText` field until a versioned final-message validator is
+ * published.
+ */
 export function textFromOpenClawGatewayMessage(message: unknown): string | undefined {
-  if (typeof message === "string") return message;
-  if (!isRecord(message)) return undefined;
-  if (typeof message.text === "string") return message.text;
-  if (!Array.isArray(message.content)) return undefined;
-  const text = message.content
-    .map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : ""))
-    .filter(Boolean)
-    .join("");
-  return text || undefined;
+  void message;
+  return undefined;
 }
 
 /**
@@ -211,7 +210,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
     // history-reconciliation schema, so finish this Gateway-owned turn as an
     // error instead of pretending its stream is complete.
     if (event.seq <= highestSequence) return;
-    if (highestSequence >= 0 && event.seq !== highestSequence + 1) {
+    if (event.seq !== highestSequence + 1) {
       args.onEvent({ kind: "error", message: "Gateway event sequence gap" });
       settle("error", "Gateway event sequence gap");
       client.stop();

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -179,7 +179,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
   const url = env[GATEWAY_URL_ENV];
   if (!nonEmptyString(url)) return { kind: "unavailable", reason: "Gateway URL is not configured" };
 
-  let client: GatewayClientPort;
+  let client!: GatewayClientPort;
   let helloResolve: (() => void) | undefined;
   let helloReject: ((error: Error) => void) | undefined;
   let connected = false;
@@ -369,10 +369,13 @@ export async function dispatchOpenClawGatewayTurn(args: {
       client.stop();
     },
   };
-  client = args.clientFactory?.(clientOptions) ?? new GatewayClient(clientOptions);
-
-  client.start();
   try {
+    // Construction and `start()` are both pre-dispatch compatibility steps.
+    // Treat a malformed endpoint or a host-client startup failure exactly like
+    // a failed hello so the caller can retain the CLI fallback before any
+    // `chat.send` request might have left Cave.
+    client = args.clientFactory?.(clientOptions) ?? new GatewayClient(clientOptions);
+    client.start();
     await withTimeout(hello, STARTUP_TIMEOUT_MS, "Gateway did not complete its authenticated hello");
     // A reconnect can arrive while the initial subscription is in flight.
     // Retry until the completion belongs to the latest authenticated hello;
@@ -387,7 +390,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
       }
     }
   } catch (error) {
-    client.stop();
+    client?.stop();
     return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway is unavailable" };
   }
 

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -296,11 +296,18 @@ export async function dispatchOpenClawGatewayTurn(args: {
     },
     onConnectError: (error) => {
       if (!connected) helloReject?.(error);
-      else if (!settled) {
-        args.onEvent({ kind: "error", message: "Gateway connection failed after dispatch" });
-        settle("error", "Gateway connection failed after dispatch");
-        client.stop();
-      }
+      // GatewayClient reports failures while attempting its *next* socket as
+      // onConnectError too. Once the first hello has completed, stopping here
+      // would defeat the client's documented reconnect policy before a later
+      // hello can restore the subscription. A terminal reconnect pause is
+      // handled below instead.
+    },
+    onReconnectPaused: () => {
+      if (settled) return;
+      const message = "Gateway reconnect was paused after dispatch";
+      args.onEvent({ kind: "error", message });
+      settle("error", message);
+      client.stop();
     },
     onEvent: (frame) => {
       if (frame.event === "chat") processChatEvent(frame.payload);

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -132,6 +132,12 @@ export async function dispatchOpenClawGatewayTurn(args: {
   sessionKey: string;
   agentId: string;
   message: string;
+  /**
+   * Cave's stable per-request id. It is sent verbatim to Gateway so a client
+   * retry can be reconciled by the remote idempotency contract; generating a
+   * fresh value here would make an acknowledgement loss duplicate work.
+   */
+  idempotencyKey: string;
   onEvent: (event: OpenClawGatewayChatEvent) => void;
   env?: NodeJS.ProcessEnv;
   /** Injectable only so the official-client lifecycle can be tested without a live Gateway. */
@@ -139,6 +145,9 @@ export async function dispatchOpenClawGatewayTurn(args: {
 }): Promise<OpenClawGatewayDispatch> {
   const env = args.env ?? process.env;
   if (!gatewayDispatchEnabled(env)) return { kind: "unavailable", reason: "Gateway dispatch is disabled" };
+  if (!nonEmptyString(args.idempotencyKey)) {
+    return { kind: "unavailable", reason: "Gateway dispatch requires a Cave request id" };
+  }
   const url = env[GATEWAY_URL_ENV];
   if (!nonEmptyString(url)) return { kind: "unavailable", reason: "Gateway URL is not configured" };
 
@@ -290,14 +299,13 @@ export async function dispatchOpenClawGatewayTurn(args: {
     return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway is unavailable" };
   }
 
-  const idempotencyKey = crypto.randomUUID();
   let response: unknown;
   try {
     response = await client.request("chat.send", {
       sessionKey: args.sessionKey,
       agentId: args.agentId,
       message: args.message,
-      idempotencyKey,
+      idempotencyKey: args.idempotencyKey,
     }, {
       onSent: () => {
         dispatchSent = true;

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,5 +1,9 @@
 import { GatewayClient } from "@openclaw/gateway-client";
-import { ChatEventSchema, HelloOkSchema } from "@openclaw/gateway-protocol";
+import {
+  ChatEventSchema,
+  GATEWAY_SERVER_CAPS,
+  HelloOkSchema,
+} from "@openclaw/gateway-protocol";
 import { PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
 import { Value } from "typebox/value";
 
@@ -13,6 +17,7 @@ const GATEWAY_DISPATCH_ENV = "OPENCLAW_GATEWAY_DISPATCH";
 const GATEWAY_URL_ENV = "OPENCLAW_GATEWAY_URL";
 const STARTUP_TIMEOUT_MS = 3_000;
 const REQUIRED_GATEWAY_METHODS = ["chat.send", "chat.abort", "sessions.messages.subscribe"];
+const REQUIRED_GATEWAY_CAPABILITIES = [GATEWAY_SERVER_CAPS.CHAT_SEND_ROUTING_CONTRACT];
 
 export type OpenClawGatewayChatEvent =
   | { kind: "status"; phase: string }
@@ -89,6 +94,10 @@ function supportedHello(hello: GatewayHello): string | null {
   const methods = new Set(hello.features.methods);
   if (REQUIRED_GATEWAY_METHODS.some((method) => !methods.has(method))) {
     return "Gateway does not advertise the required chat.send, chat.abort, and sessions.messages.subscribe methods";
+  }
+  const capabilities = new Set(hello.features.capabilities ?? []);
+  if (REQUIRED_GATEWAY_CAPABILITIES.some((capability) => !capabilities.has(capability))) {
+    return "Gateway does not advertise the required chat-send-routing-contract capability";
   }
   if (!hello.features.events.includes("chat")) return "Gateway does not advertise the versioned chat event";
   return null;

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -156,6 +156,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
   let helloReject: ((error: Error) => void) | undefined;
   let connected = false;
   let expectedRunId: string | undefined;
+  let streamReady = false;
   let highestSequence = -1;
   let dispatchSent = false;
   let settled = false;
@@ -171,8 +172,13 @@ export async function dispatchOpenClawGatewayTurn(args: {
     doneResolve({ state, ...(message ? { message } : {}) });
   };
 
+  const drainQueuedChatEvents = () => {
+    if (!expectedRunId || !streamReady || settled) return;
+    for (const queued of queuedChatEvents.splice(0)) processChatEvent(queued);
+  };
+
   const processChatEvent = (payload: unknown) => {
-    if (!expectedRunId || settled) {
+    if (!expectedRunId || !streamReady || settled) {
       if (queuedChatEvents.length < 128) queuedChatEvents.push(payload);
       return;
     }
@@ -260,9 +266,17 @@ export async function dispatchOpenClawGatewayTurn(args: {
         return;
       }
       // The official client reconnects after a transport loss. Restore the
-      // documented session stream before accepting resumed chat frames.
+      // documented session stream before accepting resumed chat frames. Frames
+      // that arrive during this window remain queued until that subscription
+      // has succeeded, so a reconnect never turns an unverified stream into
+      // accepted lifecycle state.
+      streamReady = false;
       void client
         .request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId })
+        .then(() => {
+          streamReady = true;
+          drainQueuedChatEvents();
+        })
         .catch(() => {
           const message = "Gateway reconnect could not restore the session stream";
           args.onEvent({ kind: "error", message });
@@ -275,6 +289,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
       else if (!settled) {
         args.onEvent({ kind: "error", message: "Gateway connection failed after dispatch" });
         settle("error", "Gateway connection failed after dispatch");
+        client.stop();
       }
     },
     onEvent: (frame) => {
@@ -294,6 +309,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
   try {
     await withTimeout(hello, STARTUP_TIMEOUT_MS, "Gateway did not complete its authenticated hello");
     await client.request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId });
+    streamReady = true;
   } catch (error) {
     client.stop();
     return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway is unavailable" };
@@ -331,7 +347,7 @@ export async function dispatchOpenClawGatewayTurn(args: {
     };
   }
   expectedRunId = runId;
-  for (const queued of queuedChatEvents.splice(0)) processChatEvent(queued);
+  drainQueuedChatEvents();
 
   return {
     kind: "accepted",

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,0 +1,348 @@
+import { GatewayClient } from "@openclaw/gateway-client";
+import { ChatEventSchema } from "@openclaw/gateway-protocol";
+import { PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
+import { Value } from "typebox/value";
+
+/**
+ * The direct Gateway transport is intentionally opt-in.  It owns a turn only
+ * after `chat.send` returns the Gateway-generated run id; before that point
+ * callers may retain the existing CLI fallback without risking a duplicate
+ * agent turn.
+ */
+const GATEWAY_DISPATCH_ENV = "OPENCLAW_GATEWAY_DISPATCH";
+const GATEWAY_URL_ENV = "OPENCLAW_GATEWAY_URL";
+const GATEWAY_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN";
+const GATEWAY_DEVICE_TOKEN_ENV = "OPENCLAW_GATEWAY_DEVICE_TOKEN";
+const STARTUP_TIMEOUT_MS = 3_000;
+
+export type OpenClawGatewayChatEvent =
+  | { kind: "status"; phase: string }
+  | { kind: "delta"; text: string; replace: boolean }
+  | { kind: "final"; text?: string }
+  | { kind: "aborted"; message?: string }
+  | { kind: "error"; message: string };
+
+export type OpenClawGatewayDispatch =
+  | { kind: "unavailable"; reason: string }
+  | { kind: "indeterminate"; reason: string }
+  | {
+      kind: "accepted";
+      runId: string;
+      done: Promise<{ state: "final" | "aborted" | "error"; message?: string }>;
+      abort: () => Promise<void>;
+      close: () => void;
+    };
+
+type GatewayClientPort = Pick<GatewayClient, "start" | "stop" | "request">;
+type GatewayClientFactory = (options: ConstructorParameters<typeof GatewayClient>[0]) => GatewayClientPort;
+
+type GatewayChatPayload = {
+  runId: string;
+  sessionKey: string;
+  agentId?: string;
+  seq: number;
+  state: "status" | "delta" | "final" | "aborted" | "error";
+  phase?: string;
+  deltaText?: string;
+  replace?: boolean;
+  message?: unknown;
+  errorMessage?: string;
+};
+
+type GatewayHello = {
+  protocol: number;
+  features: { methods: string[]; events: string[]; capabilities?: string[] };
+  auth: { role: string; scopes: string[] };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function gatewayDispatchEnabled(env: NodeJS.ProcessEnv): boolean {
+  return env[GATEWAY_DISPATCH_ENV] === "1" || env[GATEWAY_DISPATCH_ENV] === "true";
+}
+
+function supportedHello(hello: GatewayHello): string | null {
+  if (hello.protocol !== PROTOCOL_VERSION) return `Gateway protocol ${hello.protocol} is not supported`;
+  if (hello.auth.role !== "operator") return "Gateway did not grant the operator role";
+  const scopes = new Set(hello.auth.scopes);
+  if (!scopes.has("operator.read") || !scopes.has("operator.write")) {
+    return "Gateway did not grant operator.read and operator.write";
+  }
+  const methods = new Set(hello.features.methods);
+  if (!methods.has("chat.send") || !methods.has("sessions.messages.subscribe")) {
+    return "Gateway does not advertise the required chat.send and sessions.messages.subscribe methods";
+  }
+  if (!hello.features.events.includes("chat")) return "Gateway does not advertise the versioned chat event";
+  return null;
+}
+
+/** Extract text only from the documented chat envelope shapes. */
+export function textFromOpenClawGatewayMessage(message: unknown): string | undefined {
+  if (typeof message === "string") return message;
+  if (!isRecord(message)) return undefined;
+  if (typeof message.text === "string") return message.text;
+  if (!Array.isArray(message.content)) return undefined;
+  const text = message.content
+    .map((part) => (isRecord(part) && typeof part.text === "string" ? part.text : ""))
+    .filter(Boolean)
+    .join("");
+  return text || undefined;
+}
+
+/**
+ * Validate a published v4 `chat` payload and reject any event not belonging
+ * to the single Gateway run accepted for this Cave turn.
+ */
+export function normalizeOpenClawGatewayChatEvent(
+  payload: unknown,
+  expected: { runId: string; sessionKey: string; agentId: string },
+): GatewayChatPayload | null {
+  if (!Value.Check(ChatEventSchema, payload)) return null;
+  const event = payload as GatewayChatPayload;
+  if (event.runId !== expected.runId || event.sessionKey !== expected.sessionKey) return null;
+  if (event.agentId !== undefined && event.agentId !== expected.agentId) return null;
+  return event;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      timer.unref?.();
+    }),
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Dispatch a Cave turn through the supported Gateway v4 client.  The helper
+ * never guesses a run id and never permits a caller to fall back to the CLI
+ * once a request might have reached the Gateway.
+ */
+export async function dispatchOpenClawGatewayTurn(args: {
+  sessionKey: string;
+  agentId: string;
+  message: string;
+  onEvent: (event: OpenClawGatewayChatEvent) => void;
+  env?: NodeJS.ProcessEnv;
+  /** Injectable only so the official-client lifecycle can be tested without a live Gateway. */
+  clientFactory?: GatewayClientFactory;
+}): Promise<OpenClawGatewayDispatch> {
+  const env = args.env ?? process.env;
+  if (!gatewayDispatchEnabled(env)) return { kind: "unavailable", reason: "Gateway dispatch is disabled" };
+  const url = env[GATEWAY_URL_ENV];
+  if (!nonEmptyString(url)) return { kind: "unavailable", reason: "Gateway URL is not configured" };
+
+  let client: GatewayClientPort;
+  let helloResolve: (() => void) | undefined;
+  let helloReject: ((error: Error) => void) | undefined;
+  let connected = false;
+  let expectedRunId: string | undefined;
+  let highestSequence = -1;
+  let dispatchSent = false;
+  let settled = false;
+  const queuedChatEvents: unknown[] = [];
+  let doneResolve!: (value: { state: "final" | "aborted" | "error"; message?: string }) => void;
+  const done = new Promise<{ state: "final" | "aborted" | "error"; message?: string }>((resolve) => {
+    doneResolve = resolve;
+  });
+
+  const settle = (state: "final" | "aborted" | "error", message?: string) => {
+    if (settled) return;
+    settled = true;
+    doneResolve({ state, ...(message ? { message } : {}) });
+  };
+
+  const processChatEvent = (payload: unknown) => {
+    if (!expectedRunId || settled) {
+      if (queuedChatEvents.length < 128) queuedChatEvents.push(payload);
+      return;
+    }
+    const event = normalizeOpenClawGatewayChatEvent(payload, {
+      runId: expectedRunId,
+      sessionKey: args.sessionKey,
+      agentId: args.agentId,
+    });
+    if (!event) return;
+    // Per-run ordering is authoritative. A duplicate or replay may not
+    // mutate a completed card/turn; a gap is unsafe without a published
+    // history-reconciliation schema, so finish this Gateway-owned turn as an
+    // error instead of pretending its stream is complete.
+    if (event.seq <= highestSequence) return;
+    if (highestSequence >= 0 && event.seq !== highestSequence + 1) {
+      args.onEvent({ kind: "error", message: "Gateway event sequence gap" });
+      settle("error", "Gateway event sequence gap");
+      client.stop();
+      return;
+    }
+    highestSequence = event.seq;
+    if (event.state === "status" && nonEmptyString(event.phase)) {
+      args.onEvent({ kind: "status", phase: event.phase });
+      return;
+    }
+    if (event.state === "delta" && typeof event.deltaText === "string") {
+      args.onEvent({ kind: "delta", text: event.deltaText, replace: event.replace === true });
+      return;
+    }
+    const text = textFromOpenClawGatewayMessage(event.message);
+    if (event.state === "final") {
+      args.onEvent({ kind: "final", ...(text ? { text } : {}) });
+      settle("final", text);
+      return;
+    }
+    if (event.state === "aborted") {
+      const message = event.errorMessage ?? text;
+      args.onEvent({ kind: "aborted", ...(message ? { message } : {}) });
+      settle("aborted", message);
+      return;
+    }
+    const message = event.errorMessage ?? text ?? "Gateway chat run failed";
+    args.onEvent({ kind: "error", message });
+    settle("error", message);
+  };
+
+  const hello = new Promise<void>((resolve, reject) => {
+    helloResolve = resolve;
+    helloReject = reject;
+  });
+
+  const clientOptions: ConstructorParameters<typeof GatewayClient>[0] = {
+    url,
+    token: env[GATEWAY_TOKEN_ENV],
+    deviceToken: env[GATEWAY_DEVICE_TOKEN_ENV],
+    clientName: "gateway-client",
+    clientDisplayName: "Coven Cave",
+    clientVersion: "2026.7.2-beta.4",
+    platform: process.platform,
+    mode: "backend",
+    role: "operator",
+    scopes: ["operator.read", "operator.write"],
+    caps: ["tool-events"],
+    minProtocol: PROTOCOL_VERSION,
+    maxProtocol: PROTOCOL_VERSION,
+    connectChallengeTimeoutMs: STARTUP_TIMEOUT_MS,
+    requestTimeoutMs: STARTUP_TIMEOUT_MS,
+    onHelloOk: (rawHello) => {
+      const failure = supportedHello(rawHello as GatewayHello);
+      if (failure) {
+        const error = new Error(failure);
+        helloReject?.(error);
+        if (connected) {
+          args.onEvent({ kind: "error", message: failure });
+          settle("error", failure);
+        }
+        client.stop();
+        return;
+      }
+      if (!connected) {
+        connected = true;
+        helloResolve?.();
+        return;
+      }
+      // The official client reconnects after a transport loss. Restore the
+      // documented session stream before accepting resumed chat frames.
+      void client
+        .request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId })
+        .catch(() => {
+          const message = "Gateway reconnect could not restore the session stream";
+          args.onEvent({ kind: "error", message });
+          settle("error", message);
+          client.stop();
+        });
+    },
+    onConnectError: (error) => {
+      if (!connected) helloReject?.(error);
+      else if (!settled) {
+        args.onEvent({ kind: "error", message: "Gateway connection failed after dispatch" });
+        settle("error", "Gateway connection failed after dispatch");
+      }
+    },
+    onEvent: (frame) => {
+      if (frame.event === "chat") processChatEvent(frame.payload);
+    },
+    onGap: () => {
+      if (!expectedRunId || settled) return;
+      const message = "Gateway transport sequence gap";
+      args.onEvent({ kind: "error", message });
+      settle("error", message);
+      client.stop();
+    },
+  };
+  client = args.clientFactory?.(clientOptions) ?? new GatewayClient(clientOptions);
+
+  client.start();
+  try {
+    await withTimeout(hello, STARTUP_TIMEOUT_MS, "Gateway did not complete its authenticated hello");
+    await client.request("sessions.messages.subscribe", { key: args.sessionKey, agentId: args.agentId });
+  } catch (error) {
+    client.stop();
+    return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway is unavailable" };
+  }
+
+  const idempotencyKey = crypto.randomUUID();
+  let response: unknown;
+  try {
+    response = await client.request("chat.send", {
+      sessionKey: args.sessionKey,
+      agentId: args.agentId,
+      message: args.message,
+      idempotencyKey,
+    }, {
+      onSent: () => {
+        dispatchSent = true;
+      },
+    });
+  } catch (error) {
+    client.stop();
+    if (dispatchSent) {
+      return {
+        kind: "indeterminate",
+        reason: "Gateway dispatch acknowledgement was lost; Cave will not start a duplicate CLI turn",
+      };
+    }
+    return { kind: "unavailable", reason: error instanceof Error ? error.message : "Gateway dispatch failed" };
+  }
+
+  const runId = isRecord(response) && nonEmptyString(response.runId) ? response.runId : undefined;
+  if (!runId) {
+    client.stop();
+    return {
+      kind: "indeterminate",
+      reason: "Gateway accepted a dispatch without a usable run id; Cave will not start a duplicate CLI turn",
+    };
+  }
+  expectedRunId = runId;
+  for (const queued of queuedChatEvents.splice(0)) processChatEvent(queued);
+
+  return {
+    kind: "accepted",
+    runId,
+    done,
+    abort: async () => {
+      if (settled) return;
+      // This fence is deliberately settled before the socket is stopped so a
+      // queued or late final frame cannot turn a user-cancelled turn into ok.
+      settle("aborted", "Cancelled by user");
+      args.onEvent({ kind: "aborted", message: "Cancelled by user" });
+      try {
+        await client.request("chat.abort", {
+          sessionKey: args.sessionKey,
+          agentId: args.agentId,
+          runId,
+        });
+      } finally {
+        client.stop();
+      }
+    },
+    close: () => client.stop(),
+  };
+}

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -11,8 +11,6 @@ import { Value } from "typebox/value";
  */
 const GATEWAY_DISPATCH_ENV = "OPENCLAW_GATEWAY_DISPATCH";
 const GATEWAY_URL_ENV = "OPENCLAW_GATEWAY_URL";
-const GATEWAY_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN";
-const GATEWAY_DEVICE_TOKEN_ENV = "OPENCLAW_GATEWAY_DEVICE_TOKEN";
 const STARTUP_TIMEOUT_MS = 3_000;
 const REQUIRED_GATEWAY_METHODS = ["chat.send", "chat.abort", "sessions.messages.subscribe"];
 
@@ -158,6 +156,14 @@ export async function dispatchOpenClawGatewayTurn(args: {
 }): Promise<OpenClawGatewayDispatch> {
   const env = args.env ?? process.env;
   if (!gatewayDispatchEnabled(env)) return { kind: "unavailable", reason: "Gateway dispatch is disabled" };
+  const pairedDeviceAuth = openClawGatewayPairedDeviceAuthStatus();
+  // Keep this guard in the dispatcher as well as the route. A future caller
+  // must not be able to turn an environment token into a write-capable
+  // Gateway session simply by bypassing the route-level fallback choice. The
+  // injectable port is test-only and cannot create a real Gateway connection.
+  if (!pairedDeviceAuth.available && !args.clientFactory) {
+    return { kind: "unavailable", reason: pairedDeviceAuth.reason ?? "Gateway paired-device authentication is unavailable" };
+  }
   if (!nonEmptyString(args.idempotencyKey)) {
     return { kind: "unavailable", reason: "Gateway dispatch requires a Cave request id" };
   }
@@ -258,8 +264,11 @@ export async function dispatchOpenClawGatewayTurn(args: {
 
   const clientOptions: ConstructorParameters<typeof GatewayClient>[0] = {
     url,
-    token: env[GATEWAY_TOKEN_ENV],
-    deviceToken: env[GATEWAY_DEVICE_TOKEN_ENV],
+    // Never let the Gateway client read Cave's process environment. The
+    // future paired-device boundary must provide identity and token lifecycle
+    // through hostDeps, rather than reviving token/device-token env auth.
+    // `GatewayClientOptions.env` requires NODE_ENV, which is non-secret.
+    env: { NODE_ENV: process.env.NODE_ENV ?? "production" },
     clientName: "gateway-client",
     clientDisplayName: "Coven Cave",
     clientVersion: "2026.7.2-beta.4",

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -14,6 +14,7 @@ const GATEWAY_URL_ENV = "OPENCLAW_GATEWAY_URL";
 const GATEWAY_TOKEN_ENV = "OPENCLAW_GATEWAY_TOKEN";
 const GATEWAY_DEVICE_TOKEN_ENV = "OPENCLAW_GATEWAY_DEVICE_TOKEN";
 const STARTUP_TIMEOUT_MS = 3_000;
+const REQUIRED_GATEWAY_METHODS = ["chat.send", "chat.abort", "sessions.messages.subscribe"];
 
 export type OpenClawGatewayChatEvent =
   | { kind: "status"; phase: string }
@@ -75,8 +76,8 @@ function supportedHello(hello: GatewayHello): string | null {
     return "Gateway did not grant operator.read and operator.write";
   }
   const methods = new Set(hello.features.methods);
-  if (!methods.has("chat.send") || !methods.has("sessions.messages.subscribe")) {
-    return "Gateway does not advertise the required chat.send and sessions.messages.subscribe methods";
+  if (REQUIRED_GATEWAY_METHODS.some((method) => !methods.has(method))) {
+    return "Gateway does not advertise the required chat.send, chat.abort, and sessions.messages.subscribe methods";
   }
   if (!hello.features.events.includes("chat")) return "Gateway does not advertise the versioned chat event";
   return null;
@@ -106,7 +107,7 @@ export function normalizeOpenClawGatewayChatEvent(
   if (!Value.Check(ChatEventSchema, payload)) return null;
   const event = payload as GatewayChatPayload;
   if (event.runId !== expected.runId || event.sessionKey !== expected.sessionKey) return null;
-  if (event.agentId !== undefined && event.agentId !== expected.agentId) return null;
+  if (event.agentId !== expected.agentId) return null;
   return event;
 }
 
@@ -254,7 +255,6 @@ export async function dispatchOpenClawGatewayTurn(args: {
     mode: "backend",
     role: "operator",
     scopes: ["operator.read", "operator.write"],
-    caps: ["tool-events"],
     minProtocol: PROTOCOL_VERSION,
     maxProtocol: PROTOCOL_VERSION,
     connectChallengeTimeoutMs: STARTUP_TIMEOUT_MS,

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,5 +1,5 @@
 import { GatewayClient } from "@openclaw/gateway-client";
-import { ChatEventSchema } from "@openclaw/gateway-protocol";
+import { ChatEventSchema, HelloOkSchema } from "@openclaw/gateway-protocol";
 import { PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
 import { Value } from "typebox/value";
 
@@ -232,7 +232,9 @@ export async function dispatchOpenClawGatewayTurn(args: {
     connectChallengeTimeoutMs: STARTUP_TIMEOUT_MS,
     requestTimeoutMs: STARTUP_TIMEOUT_MS,
     onHelloOk: (rawHello) => {
-      const failure = supportedHello(rawHello as GatewayHello);
+      const failure = Value.Check(HelloOkSchema, rawHello)
+        ? supportedHello(rawHello as GatewayHello)
+        : "Gateway returned an invalid hello response for the pinned v4 schema";
       if (failure) {
         const error = new Error(failure);
         helloReject?.(error);

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -68,6 +68,19 @@ function gatewayDispatchEnabled(env: NodeJS.ProcessEnv): boolean {
   return env[GATEWAY_DISPATCH_ENV] === "1" || env[GATEWAY_DISPATCH_ENV] === "true";
 }
 
+/**
+ * The published client delegates device-identity creation, challenge signing,
+ * and device-token lifecycle to hostDeps. Cave has not yet implemented the
+ * required cross-platform OS credential-store boundary, so the route must not
+ * activate a write-capable Gateway transport with process-environment tokens.
+ */
+export function openClawGatewayPairedDeviceAuthStatus(): { available: boolean; reason?: string } {
+  return {
+    available: false,
+    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+  };
+}
+
 function supportedHello(hello: GatewayHello): string | null {
   if (hello.protocol !== PROTOCOL_VERSION) return `Gateway protocol ${hello.protocol} is not supported`;
   if (hello.auth.role !== "operator") return "Gateway did not grant the operator role";

--- a/src/lib/server/chat-work-branch.test.ts
+++ b/src/lib/server/chat-work-branch.test.ts
@@ -68,8 +68,8 @@ const captures = sendRoute.match(
 );
 assert.equal(
   captures?.length,
-  2,
-  "both saveConversation paths (OpenClaw bridge + coven-run) must record the work branch",
+  3,
+  "all saveConversation paths (OpenClaw Gateway, bridge, and coven-run) must record the work branch",
 );
 
 console.log("chat-work-branch.test.ts: all assertions passed");


### PR DESCRIPTION
### DO NOT MERGE - INCOMPLETE DRAFT ###

## Scope and pinned compatibility profile

This PR adds a **chat-only, fail-closed** direct OpenClaw Gateway dispatch foundation. It pins official published packages:

- `@openclaw/gateway-client@2026.7.2-beta.4`
- `@openclaw/gateway-protocol@2026.7.2-beta.4`
- `typebox@1.3.6`
- wire protocol **v4** only

The dispatcher validates published `HelloOkSchema` and `ChatEventSchema`, exact v4 negotiation, `operator` role, `operator.read`/`operator.write`, `chat.send`, `chat.abort`, `sessions.messages.subscribe`, the versioned `chat` event, and `GATEWAY_SERVER_CAPS.CHAT_SEND_ROUTING_CONTRACT`. A frame is accepted only when its exact `(sessionKey, agentId, runId)` matches the run returned by `chat.send`.

## Completed and evidenced

- Stable Cave `runId` is the Gateway `idempotencyKey`; callers without one safely retain CLI/plain-chat.
- A sent-but-unacknowledged `chat.send` is indeterminate and never starts a replacement CLI turn; compatibility, auth, client-construction/startup, and subscription failures before dispatch retain fallback.
- Foreign same-session runs, malformed, replayed, out-of-order, gapped, unsupported, disconnected, and pre-resubscription frames fail closed. Behavioral regressions prove frames delivered after transport close are dropped and never replayed after reconnect.
- Cancellation settles before `chat.abort`; late terminal frames cannot overwrite cancelled state.
- Gateway process settings are removed from CLI fallback, including all `OPENCLAW_GATEWAY_*` settings and Vault/allow-list restoration paths.
- Gateway route scaffolding preserves stop registry, stream resume, first-turn stub, identity, response metadata, transcript persistence/naming, work-branch capture, and cancelled flags.

## Deliberate security boundary / unresolved acceptance criteria

**This PR does not complete #3865 and must remain a draft.**

1. The exact published `2026.7.2-beta.4` protocol tarball contains no versioned `session.tool` event/payload validator. Cave ignores tool-shaped frames and emits no Gateway tool cards.
2. Cave has no verified cross-platform OS-backed paired-device identity/token store. The official client's `GatewayClientHostDeps` requires host-owned identity creation, challenge signing, and token load/store/rotation/clear. The direct path therefore fails closed before client construction; Gateway env tokens, passwords, bootstrap/device tokens, private keys, and signing values cannot activate it.

No plaintext credential storage, `.env` activation, unencrypted config, or credential logging is added. CLI/plain-chat remains the fallback.

## Review, CI, and local validation

- Reviewed #3865, #3847, #3852, reference PR #3866, the full implementation and callers, lockfile, and exact official npm tarballs. GraphQL review-thread inspection found no comments, review submissions, or unresolved threads.
- Review remediation: post-close transport callbacks previously could be buffered then replayed after a reconnect subscription. Commit `58e0fdf68fee448ac7444670e2ad32c27f355eab` drops them because they lack transport-generation provenance. Commit `f55039c938a28aaa2b223a9a9a34d8f61e76221b` additionally converts synchronous Gateway construction/start failures into pre-dispatch unavailability, stops a partially started client, and retains CLI fallback.
- Rebased cleanly onto `origin/main@147809878f3fc29d691323421c9bb9ab2cc9e59c`; branch head is `f55039c938a28aaa2b223a9a9a34d8f61e76221b`.
- Passed: Gateway/bin/bridge, routing, first-turn-stub, stream-resume (5 behavioral tests using the alias loader), API-contract, and work-branch tests; `pnpm check:tests-wired` (1254), `pnpm exec tsc --noEmit --pretty false`, `pnpm lint`, and `git diff --check`.
- `pnpm test:api` reaches a native-Windows failure in unchanged `scripts/dev-app-teardown.test.mjs` before affected tests: fake dev-server bind timeout (branch port 58033). Current `origin/main@147809878f3fc29d691323421c9bb9ab2cc9e59c` fails in the same unchanged test after a frozen install (Windows EPERM removing its temporary fixture), so it is not attributable.
- CI `30217506119` (including Frontend full app/API/mobile/build, E2E, cross-environment, Rust, and sidecar jobs) and CodeQL `30217506126` passed for `58e0fdf68fee448ac7444670e2ad32c27f355eab`. The rebase cancelled the prior in-flight run; fresh CI is queued for `f55039c938a28aaa2b223a9a9a34d8f61e76221b`.

Keep this PR draft and do not close #3865 until both external blockers are resolved.