### PR TITLE
fix(chat): preflight Copilot JSONL launch plans

### DIFF
--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -322,8 +322,8 @@ assert.doesNotMatch(
 );
 assert.match(
   chatRoute,
-  /copilotStream\s*\?\s*"Copilot failed to start\. Check its installation and try again\."/,
-  "a post-preflight Copilot launch error uses fixed copy instead of Node's path-bearing error message",
+  /localRuntimeLaunchError\(\s*localRuntimePlan\?\.runner \?\? "coven",\s*err\.code,\s*\)/,
+  "a post-preflight Copilot launch error uses the shared fixed runner copy instead of Node's path-bearing error message",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -320,6 +320,11 @@ assert.doesNotMatch(
   /copilot-client-compatibility/,
   "a blocked Copilot launch emits one structured runtime error rather than a duplicate compatibility notice",
 );
+assert.match(
+  chatRoute,
+  /copilotStream\s*\?\s*"Copilot failed to start\. Check its installation and try again\."/,
+  "a post-preflight Copilot launch error uses fixed copy instead of Node's path-bearing error message",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -51,4 +51,15 @@ assert.doesNotMatch(
   "the harness API never copies private Copilot launch-plan data onto availability",
 );
 
+assert.match(
+  source,
+  /probeCopilotCapability\(stream\.executable[\s\S]*?resolveRuntimeCompatibility\("copilot"\)[\s\S]*?resolveCopilotChatRouting\([\s\S]*?requiredFiles: launch\.requiredFiles/,
+  "Copilot status must preflight the same resolved direct launch plan and fixed artifacts as chat send",
+);
+assert.match(
+  source,
+  /routing\.mode === "blocked"[\s\S]*?state: "unsupported_runtime"[\s\S]*?message: routing\.failure\.message/,
+  "an incompatible Copilot stream is surfaced as configuration compatibility, not as a missing CLI",
+);
+
 console.log("harness route tests passed");

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -53,13 +53,8 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /probeCopilotCapability\(stream\.executable[\s\S]*?resolveRuntimeCompatibility\("copilot"\)[\s\S]*?resolveCopilotChatRouting\([\s\S]*?requiredFiles: launch\.requiredFiles/,
-  "Copilot status must preflight the same resolved direct launch plan and fixed artifacts as chat send",
-);
-assert.match(
-  source,
-  /routing\.mode === "blocked"[\s\S]*?state: "unsupported_runtime"[\s\S]*?message: routing\.failure\.message/,
-  "an incompatible Copilot stream is surfaced as configuration compatibility, not as a missing CLI",
+  /resolveCopilotRuntimeLaunch\(stream\.executable,\s*\{\s*spawnEnv: \(\) => harnessSpawnEnv\(null\)/,
+  "Copilot status must resolve the same direct launcher in the shared harness environment as chat send",
 );
 
 console.log("harness route tests passed");

--- a/src/lib/server/copilot-capability-probe.test.ts
+++ b/src/lib/server/copilot-capability-probe.test.ts
@@ -120,6 +120,24 @@ assert.equal(
   "a missing runtime is not collapsed into version-unavailable",
 );
 
+// A bounded launch-identity check can time out before the version process is
+// started. The failed probe must still return its exact resolved plan so chat
+// preflights that plan rather than falling back to a different bare command.
+clearCopilotCapabilityProbeCache();
+const identityTimedOut = await probeCopilotCapability("copilot-identity-timeout-fixture", {
+  binaryIdentity: async () => "",
+  spawnImpl: (() => {
+    throw new Error("the version probe must not run after identity timeout");
+  }) as typeof import("node:child_process").spawn,
+});
+assert.equal(identityTimedOut.version, null);
+assert.equal(identityTimedOut.diagnostic, "probe-timeout");
+assert.deepEqual(
+  identityTimedOut.launchCommand,
+  { command: "copilot-identity-timeout-fixture", fixedArgs: [], requiredFiles: [] },
+  "a timed-out identity check retains the resolved direct launch plan",
+);
+
 // The cache is keyed by the resolved binary identity, not merely its command
 // name. An in-place CLI upgrade must be re-probed before Cave selects JSONL.
 clearCopilotCapabilityProbeCache();

--- a/src/lib/server/copilot-capability-probe.test.ts
+++ b/src/lib/server/copilot-capability-probe.test.ts
@@ -126,6 +126,18 @@ assert.equal(
 clearCopilotCapabilityProbeCache();
 const identityTimedOut = await probeCopilotCapability("copilot-identity-timeout-fixture", {
   binaryIdentity: async () => "",
+  resolveRuntimeLaunch: async () => ({
+    env: { NODE_ENV: "test", PATH: "" },
+    command: "copilot-identity-timeout-fixture",
+    fixedArgs: [],
+    requiredFiles: [],
+    deadline: Date.now() + 1_500,
+    availability: {
+      state: "ready",
+      runner: "copilot",
+      resolvedPath: "copilot-identity-timeout-fixture",
+    },
+  }),
   spawnImpl: (() => {
     throw new Error("the version probe must not run after identity timeout");
   }) as typeof import("node:child_process").spawn,

--- a/src/lib/server/copilot-capability-probe.ts
+++ b/src/lib/server/copilot-capability-probe.ts
@@ -217,11 +217,15 @@ export async function probeCopilotCapability(
     launch.deadline,
     now,
   );
-  if (identity === null || now() >= launch.deadline) {
+  if (!identity || now() >= launch.deadline) {
     return {
       version: null,
       availability: copilotLaunchProbeFailureAvailability("timeout"),
       diagnostic: "probe-timeout",
+      // The send route must still preflight the exact argv-list plan rather
+      // than falling back to a bare `copilot` command after a timed-out
+      // identity check.
+      launchCommand,
     };
   }
   if (

--- a/src/lib/server/copilot-capability-probe.ts
+++ b/src/lib/server/copilot-capability-probe.ts
@@ -5,7 +5,7 @@ import {
   COPILOT_NO_AUTO_UPDATE_ARG,
   parseRuntimeClientVersion,
 } from "../copilot-stream.ts";
-import { type CovenLaunchCommand } from "../coven-bin.ts";
+import { type CopilotLaunchCommand } from "../copilot-bin.ts";
 import { vaultFreeDiscoveryEnv } from "../child-spawn-env.ts";
 import type { RuntimeAvailability } from "../runtime-availability.ts";
 import { loadVaultMap } from "../vault.ts";
@@ -23,7 +23,7 @@ export type CopilotCapabilityDiagnostic =
 export type CopilotCapabilityProbe = {
   version: string | null;
   /** Exact spawn target resolved during this bounded probe, never request argv. */
-  launchCommand?: Pick<CovenLaunchCommand, "command" | "fixedArgs">;
+  launchCommand?: CopilotLaunchCommand;
   /** Passive classification of the exact launch plan used by this probe. */
   availability: RuntimeAvailability;
   /** Only safe, non-payload diagnostic metadata; never command output. */
@@ -117,7 +117,7 @@ async function binaryIdentity(executable: string, env: NodeJS.ProcessEnv): Promi
   return `unresolved:${executable}:${pathValue}`;
 }
 
-async function launchIdentity(launch: CovenLaunchCommand, env: NodeJS.ProcessEnv): Promise<string> {
+async function launchIdentity(launch: CopilotLaunchCommand, env: NodeJS.ProcessEnv): Promise<string> {
   const targets = [launch.command, ...launch.fixedArgs.filter((arg) => isAbsolute(arg))];
   return (await Promise.all(targets.map((target) => binaryIdentity(target, env)))).join("\u0000");
 }
@@ -199,9 +199,10 @@ export async function probeCopilotCapability(
     };
   }
 
-  const launchCommand = {
+  const launchCommand: CopilotLaunchCommand = {
     command: launch.command,
     fixedArgs: launch.fixedArgs,
+    requiredFiles: launch.requiredFiles ?? [],
   };
   // Cache by command name plus canonical PATH, then validate the exact current
   // command/script metadata. A changed npm target is re-probed immediately.


### PR DESCRIPTION
Closes #3857

## Summary
- Reuses the exact resolved Copilot argv-list plan for capability checks, chat preflight, and harness status; Windows Node shims now validate their required entry artifact without exposing local paths.
- Fails closed for configured local Copilot JSONL when the plan cannot be verified or the CLI/schema is incompatible; SSH and intentionally non-direct routing retain their prior paths.
- Separates missing, unlaunchable, probe/config, and post-start authentication outcomes. Direct launches explicitly use `shell: false`.
- Surfaces availability diagnostics consistently in the runtime picker, familiar brain tab, and chat strip.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- Focused runtime, Copilot routing/probe, harness status, UI-source, and route availability integration tests
- `pnpm test:api` is blocked on Windows before feature tests by the existing `scripts/dev-app-teardown.test.mjs` fake bash dev-server bind timeout (reproduces standalone).