### PR TITLE
fix(copilot): preflight direct JSONL launcher

### DIFF
--- a/src/app/api/chat/send/copilot-routing.ts
+++ b/src/app/api/chat/send/copilot-routing.ts
@@ -1,8 +1,13 @@
 import {
+  copilotDirectStreamConfigured,
   copilotStreamSpec,
   type CopilotStreamSpec,
 } from "../../../../lib/copilot-stream.ts";
-import type { RuntimeAvailability } from "../../../../lib/runtime-availability.ts";
+import {
+  RUNTIME_AVAILABILITY_ERROR_CODES,
+  type RuntimeAvailability,
+  type RuntimeAvailabilityErrorCode,
+} from "../../../../lib/runtime-availability.ts";
 import {
   copilotCapabilityFailureMessage,
   type CopilotCapabilityDiagnostic,
@@ -10,7 +15,25 @@ import {
 
 export type CopilotChatRouting =
   | { mode: "direct-jsonl"; spec: CopilotStreamSpec; compatibilityDiagnostic: null }
-  | { mode: "plain"; spec: null; compatibilityDiagnostic: string | null };
+  | { mode: "plain"; spec: null; compatibilityDiagnostic: null }
+  | {
+      mode: "blocked";
+      spec: null;
+      compatibilityDiagnostic: string;
+      failure: Extract<RuntimeAvailability, { state: Exclude<RuntimeAvailability["state"], "ready"> }>;
+    };
+
+function blockedFailure(
+  state: "probe_failed" | "unsupported_runtime",
+  message: string,
+): Extract<RuntimeAvailability, { state: Exclude<RuntimeAvailability["state"], "ready"> }> {
+  return {
+    state,
+    runner: "copilot",
+    code: RUNTIME_AVAILABILITY_ERROR_CODES[state] as RuntimeAvailabilityErrorCode,
+    message,
+  };
+}
 
 /**
  * Keep the direct JSONL launch behind an explicit, testable capability gate.
@@ -33,17 +56,36 @@ export function resolveCopilotChatRouting(input: {
   const spec = copilotStreamSpec(input.capabilityVersion, input.eventProtocols, input.launchCommand);
   if (spec) return { mode: "direct-jsonl", spec, compatibilityDiagnostic: null };
 
+  // A registry that has not explicitly selected direct JSONL keeps the
+  // established Coven transport. Once it does, changing transports after a
+  // failed capability/configuration check could run a different launcher than
+  // the one just preflighted, so fail closed with runner-specific state.
+  if (!copilotDirectStreamConfigured()) {
+    return { mode: "plain", spec: null, compatibilityDiagnostic: null };
+  }
+
+  if (input.availability && input.availability.state !== "ready") {
+    return {
+      mode: "blocked",
+      spec: null,
+      compatibilityDiagnostic: input.availability.message,
+      failure: input.availability,
+    };
+  }
+
   const capabilityFailure = copilotCapabilityFailureMessage({
     version: input.capabilityVersion,
     diagnostic: input.capabilityDiagnostic,
     availability: input.availability,
   });
+  const probeTimedOut = input.capabilityDiagnostic === "probe-timeout";
+  const message = capabilityFailure ??
+    "This Copilot CLI or JSONL stream configuration is not compatible with Cave chat. Update the Copilot runtime schema or CLI, then try again.";
   return {
-    mode: "plain",
+    mode: "blocked",
     spec: null,
-    compatibilityDiagnostic:
-      capabilityFailure ??
-      "This Copilot CLI version is not yet compatible with Cave tool activity. Chat continues without live tool details; update the Copilot runtime schema or CLI.",
+    compatibilityDiagnostic: message,
+    failure: blockedFailure(probeTimedOut ? "probe_failed" : "unsupported_runtime", message),
   };
 }
 

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -292,13 +292,13 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const copilotManifestStream = copilotDirect \? copilotStreamSpec\(\) : null;[\s\S]*?resolveCopilotRuntimeLaunch\(copilotManifestStream\.executable\)[\s\S]*?probeCopilotCapability\(copilotManifestStream\.executable/,
-  "Copilot resolves and probes the manifest-declared executable instead of an independent default",
+  /const copilotSpawnEnv = copilotDirect \? harnessSpawnEnv\(body\.familiarId\) : null;[\s\S]*?resolveCopilotRuntimeLaunch\(copilotManifestStream\.executable, \{[\s\S]*?spawnEnv: \(\) => copilotSpawnEnv![\s\S]*?probeCopilotCapability\(copilotManifestStream\.executable/,
+  "Copilot resolves and probes the manifest-declared executable in the exact familiar-scoped spawn environment",
 );
-assert.match(
+assert.doesNotMatch(
   chatRoute,
-  /if \(\s*copilotCompatibilityDiagnostic &&\s*copilotRuntimeLaunch\?\.availability\.state === "ready"\s*\) \{[\s\S]*?copilot-client-compatibility/,
-  "a non-ready Copilot plan emits only the structured runtime error, not a duplicate compatibility notice",
+  /copilot-client-compatibility/,
+  "a blocked Copilot launch emits one structured runtime error rather than a duplicate compatibility notice",
 );
 
 assert.match(

--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -71,9 +71,10 @@ for (const capabilityVersion of ["1.0.70.1", "0.9.9", "2.0.0", "2.0.0-rc.1"]) {
     isSshRuntime: false,
     capabilityVersion,
   });
-  assert.equal(routing.mode, "plain", `${capabilityVersion ?? "unavailable"} must use generic chat`);
-  assert.equal(routing.spec, null, "the fallback must never direct-spawn the JSONL parser");
-  assert.match(routing.compatibilityDiagnostic ?? "", /not yet compatible/);
+  assert.equal(routing.mode, "blocked", `${capabilityVersion ?? "unavailable"} must not change transports`);
+  assert.equal(routing.spec, null, "an incompatible client must never direct-spawn the JSONL parser");
+  assert.equal(routing.failure.code, "runtime_unsupported");
+  assert.match(routing.compatibilityDiagnostic, /compatible/i);
 }
 
 const capabilityCauseMessages = {
@@ -96,7 +97,7 @@ for (const [diagnostic, expected] of Object.entries(capabilityCauseMessages)) {
       resolvedPath: "/must-not-reach-wire",
     },
   });
-  assert.equal(routing.mode, "plain");
+  assert.equal(routing.mode, "blocked");
   assert.equal(
     routing.compatibilityDiagnostic,
     expected,
@@ -123,6 +124,12 @@ assert.equal(
   missingAvailabilityMessage,
   "runtime availability cause wins before generic version diagnostics",
 );
+assert.equal(
+  missingRouting.mode,
+  "blocked",
+  "a missing Copilot launch plan never falls back to generic Coven",
+);
+assert.equal(missingRouting.failure.code, "runtime_missing");
 assert.doesNotMatch(
   missingRouting.compatibilityDiagnostic ?? "",
   /must-not-reach-wire|resolvedPath|PATH=/,
@@ -180,8 +187,9 @@ const preparedFallback = await prepareCopilotChatRouting({
   }),
   resolveCompatibility: async () => ({ eventProtocols: [] }),
 });
-assert.equal(preparedFallback.mode, "plain", "an unsupported mocked runtime retains generic plain chat");
-assert.match(preparedFallback.compatibilityDiagnostic ?? "", /not yet compatible/);
+assert.equal(preparedFallback.mode, "blocked", "an unsupported local runtime fails before generic Coven routing");
+assert.equal(preparedFallback.failure.code, "runtime_unsupported");
+assert.match(preparedFallback.compatibilityDiagnostic, /compatible/i);
 assert.notEqual(
   preparedFallback.compatibilityDiagnostic,
   capabilityCauseMessages["version-unavailable"],
@@ -279,7 +287,7 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /let localRuntimePlan: LocalRuntimePlan \| null = null;[\s\S]*?runner: "copilot"[\s\S]*?else if \(openCodeDirect\)[\s\S]*?runner: "opencode"[\s\S]*?else if \(grokDirect\)[\s\S]*?runner: "grok"[\s\S]*?else if \(hermesDirect\)[\s\S]*?runner: "hermes"[\s\S]*?runner: "coven"[\s\S]*?const command = openCodeLaunchCommand[\s\S]*?command: localPlan\.command,[\s\S]*?args: \[\.\.\.localPlan\.fixedArgs, \.\.\.spawnArgs\]/,
+  /let localRuntimePlan: LocalRuntimePlan \| null = null;[\s\S]*?runner: "copilot"[\s\S]*?copilotRouting\.mode === "blocked"[\s\S]*?else if \(openCodeDirect\)[\s\S]*?runner: "opencode"[\s\S]*?else if \(grokDirect\)[\s\S]*?runner: "grok"[\s\S]*?runner: "coven"[\s\S]*?requiredFiles: localPlan\.requiredFiles[\s\S]*?shell: false/,
   "Copilot, Grok Build, Hermes, and OpenCode direct turns spawn their own CLI; other local harnesses spawn coven",
 );
 assert.match(

--- a/src/app/api/chat/send/harness-routing-opencode.test.ts
+++ b/src/app/api/chat/send/harness-routing-opencode.test.ts
@@ -67,7 +67,7 @@ assert.match(
 );
 assert.match(
   route,
-  /const openCodeLaunchCommand = openCodeDirect[\s\S]*?command: localPlan\.command,[\s\S]*?args: \[\.\.\.localPlan\.fixedArgs\],[\s\S]*?input: JSON\.stringify\(spawnArgs\)[\s\S]*?const availability =[\s\S]*?command: localPlan\.command,[\s\S]*?env: localPlan\.env,[\s\S]*?const child = spawn\(command\.command, command\.args, \{[\s\S]*?env: localPlan\.env,[\s\S]*?writeOpenCodeLaunchInput\(child, openCodeLaunchCommand\)/,
+  /const openCodeLaunchCommand = openCodeDirect[\s\S]*?command: localPlan\.command,[\s\S]*?args: \[\.\.\.localPlan\.fixedArgs\],[\s\S]*?input: JSON\.stringify\(spawnArgs\)[\s\S]*?const availability =[\s\S]*?command: localPlan\.command,[\s\S]*?env: localPlan\.env,[\s\S]*?let child:[\s\S]*?try \{[\s\S]*?child = spawn\(command\.command, command\.args, \{[\s\S]*?env: localPlan\.env,[\s\S]*?writeOpenCodeLaunchInput\(child, openCodeLaunchCommand\)/,
   "OpenCode carries one Windows-safe outer host, inner command, and scoped environment from early preflight through the immediate spawn recheck",
 );
 assert.match(

--- a/src/app/api/chat/send/route-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-runtime-availability.integration.test.ts
@@ -69,7 +69,7 @@ function assertNoFabricatedAssistantResponse(body, events) {
 }
 
 try {
-  const { covenLaunchCommand, refreshCovenBin } = await import("@/lib/coven-bin");
+  const { covenLaunchCommand, refreshCovenBin, refreshCovenSpawnEnv } = await import("@/lib/coven-bin");
   refreshCovenBin();
   const { grokBin } = await import("@/lib/grok-bin");
   assert.equal(grokBin(), pinnedGrok, "the test pins Grok discovery to its isolated override");
@@ -266,6 +266,7 @@ try {
     const { clearCopilotCapabilityProbeCache } = await import("@/lib/server/copilot-capability-probe");
     process.env.PATH = "";
     refreshCovenBin();
+    refreshCovenSpawnEnv();
     clearCopilotCapabilityProbeCache();
     await saveConfig({ familiars: { opal: { harness: "copilot" } } });
     const response = await POST(new Request("http://localhost/api/chat/send", {
@@ -288,6 +289,8 @@ try {
   else process.env.GROK_BIN = previousGrokBin;
   if (previousPath === undefined) delete process.env.PATH;
   else process.env.PATH = previousPath;
+  const { refreshCovenSpawnEnv } = await import("@/lib/coven-bin");
+  refreshCovenSpawnEnv();
   await rm(home, { recursive: true, force: true });
 }
 

--- a/src/app/api/chat/send/route-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-runtime-availability.integration.test.ts
@@ -36,6 +36,7 @@ const previousHome = process.env.COVEN_HOME;
 const previousCaveHome = process.env.COVEN_CAVE_HOME;
 const previousCovenBin = process.env.COVEN_BIN;
 const previousGrokBin = process.env.GROK_BIN;
+const previousPath = process.env.PATH;
 process.env.COVEN_HOME = home;
 process.env.COVEN_CAVE_HOME = path.join(home, "cave");
 process.env.GROK_BIN = pinnedGrok;
@@ -259,6 +260,25 @@ try {
       "post-spawn diagnostics must never expose the runner path",
     );
   }
+  // A direct Copilot configuration never falls through to generic Coven when
+  // the exact local CLI plan is absent.
+  {
+    const { clearCopilotCapabilityProbeCache } = await import("@/lib/server/copilot-capability-probe");
+    process.env.PATH = "";
+    refreshCovenBin();
+    clearCopilotCapabilityProbeCache();
+    await saveConfig({ familiars: { opal: { harness: "copilot" } } });
+    const response = await POST(new Request("http://localhost/api/chat/send", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ familiarId: "opal", prompt: "copilot preflight", projectRoot: familiarWorkspace }),
+    }));
+    const { body, events } = await readSse(response);
+    const error = events.find((event) => event.kind === "error");
+    assert.equal(error?.code, "runtime_missing");
+    assert.match(String(error?.message), /copilot CLI not found on PATH/i);
+    assertNoFabricatedAssistantResponse(body, events);
+  }
 } finally {
   process.env.COVEN_HOME = previousHome;
   process.env.COVEN_CAVE_HOME = previousCaveHome;
@@ -266,6 +286,8 @@ try {
   else process.env.COVEN_BIN = previousCovenBin;
   if (previousGrokBin === undefined) delete process.env.GROK_BIN;
   else process.env.GROK_BIN = previousGrokBin;
+  if (previousPath === undefined) delete process.env.PATH;
+  else process.env.PATH = previousPath;
   await rm(home, { recursive: true, force: true });
 }
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1114,13 +1114,16 @@ export async function POST(req: Request) {
     resolveCompatibility: () => resolveRuntimeCompatibility("copilot"),
   });
   const copilotStream = copilotRouting.spec;
-  const copilotCompatibilityDiagnostic = copilotRouting.compatibilityDiagnostic;
 
   let localRuntimePlan: LocalRuntimePlan | null = null;
   if (!sshRuntime && binding.harness !== "openclaw" && !(hermesDirect && hermesApi)) {
     if (
       copilotRuntimeLaunch &&
-      (copilotRuntimeLaunch.availability.state !== "ready" || copilotStream)
+      (
+        copilotRuntimeLaunch.availability.state !== "ready"
+        || copilotStream
+        || copilotRouting.mode === "blocked"
+      )
     ) {
       localRuntimePlan = createLocalRuntimePlan({
         runner: "copilot",
@@ -1129,7 +1132,9 @@ export async function POST(req: Request) {
           body.familiarId,
           copilotRuntimeLaunch.env,
         ),
-        availability: copilotRuntimeLaunch.availability,
+        availability: copilotRouting.mode === "blocked"
+          ? copilotRouting.failure
+          : copilotRuntimeLaunch.availability,
       });
     } else if (openCodeDirect) {
       const env = openCodeSpawnEnv(body.familiarId);
@@ -1874,17 +1879,6 @@ export async function POST(req: Request) {
       };
 
       push({ kind: "user", text: promptText });
-      if (
-        copilotCompatibilityDiagnostic &&
-        copilotRuntimeLaunch?.availability.state === "ready"
-      ) {
-        pushProgress(
-          "copilot-client-compatibility",
-          "Copilot tool activity needs an update",
-          "error",
-          copilotCompatibilityDiagnostic,
-        );
-      }
       if (hermesDirect && !hermesApi) {
         // Do not fabricate tool bubbles from the CLI's presentation layer.
         // This gives the operator an actionable, privacy-safe degradation
@@ -3201,6 +3195,7 @@ export async function POST(req: Request) {
                     ? ["ignore", "pipe", "pipe"]
                     : ["pipe", "pipe", "pipe"],
                   env: localPlan.env,
+                  shell: false,
                 }) as ChildProcessWithoutNullStreams;
                 if (openCodeLaunchCommand) {
                   writeOpenCodeLaunchInput(child, openCodeLaunchCommand);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -279,21 +279,6 @@ function createLocalRuntimePlan(input: {
   };
 }
 
-function familiarEnvWithCanonicalPath(
-  familiarId: string,
-  canonicalEnv: NodeJS.ProcessEnv,
-): NodeJS.ProcessEnv {
-  const env = harnessSpawnEnv(familiarId);
-  const canonicalPath =
-    canonicalEnv.PATH ?? canonicalEnv.Path ?? canonicalEnv.path;
-  if (canonicalPath !== undefined) {
-    env.PATH = canonicalPath;
-    delete env.Path;
-    delete env.path;
-  }
-  return env;
-}
-
 type SendBody = {
   familiarId: string;
   prompt?: string;
@@ -1089,13 +1074,15 @@ export async function POST(req: Request) {
       })
     : null;
 
-  // Copilot's exact command is resolved once. The capability phase consumes
-  // that passive plan and cannot resolve a different npm shim. Its probe env
-  // is credential-free; the eventual model env keeps familiar-scoped values
-  // but is pinned to this same canonical PATH.
+  // Resolve the direct plan in the exact familiar-scoped environment passed to
+  // the child. The capability probe scrubs credentials only for `--version`;
+  // it must never discover a different launcher than the model spawn uses.
+  const copilotSpawnEnv = copilotDirect ? harnessSpawnEnv(body.familiarId) : null;
   const copilotManifestStream = copilotDirect ? copilotStreamSpec() : null;
   const copilotRuntimeLaunch = copilotManifestStream
-    ? await resolveCopilotRuntimeLaunch(copilotManifestStream.executable)
+    ? await resolveCopilotRuntimeLaunch(copilotManifestStream.executable, {
+        spawnEnv: () => copilotSpawnEnv!,
+      })
     : null;
   const copilotCapability = copilotManifestStream && copilotRuntimeLaunch
     ? copilotRuntimeLaunch.availability.state === "ready"
@@ -1128,10 +1115,7 @@ export async function POST(req: Request) {
       localRuntimePlan = createLocalRuntimePlan({
         runner: "copilot",
         launch: copilotRuntimeLaunch,
-        env: familiarEnvWithCanonicalPath(
-          body.familiarId,
-          copilotRuntimeLaunch.env,
-        ),
+        env: copilotRuntimeLaunch.env,
         availability: copilotRouting.mode === "blocked"
           ? copilotRouting.failure
           : copilotRuntimeLaunch.availability,
@@ -3184,19 +3168,38 @@ export async function POST(req: Request) {
                     command: localPlan.command,
                     args: [...localPlan.fixedArgs, ...spawnArgs],
                   };
-                const child = spawn(command.command, command.args, {
-                  // Spawn IN the familiar's workspace when no project root was
-                  // supplied, so coven's project-root resolver picks that dir as
-                  // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
-                  // from the familiar's home. When a project root IS supplied,
-                  // honor that instead.
-                  cwd,
-                  stdio: openCodeLaunchCommand?.input === undefined
-                    ? ["ignore", "pipe", "pipe"]
-                    : ["pipe", "pipe", "pipe"],
-                  env: localPlan.env,
-                  shell: false,
-                }) as ChildProcessWithoutNullStreams;
+                let child: ChildProcessWithoutNullStreams;
+                try {
+                  child = spawn(command.command, command.args, {
+                    // Spawn IN the familiar's workspace when no project root was
+                    // supplied, so coven's project-root resolver picks that dir as
+                    // root and Codex/Claude pick up AGENTS.md / SOUL.md / IDENTITY.md
+                    // from the familiar's home. When a project root IS supplied,
+                    // honor that instead.
+                    cwd,
+                    stdio: openCodeLaunchCommand?.input === undefined
+                      ? ["ignore", "pipe", "pipe"]
+                      : ["pipe", "pipe", "pipe"],
+                    env: localPlan.env,
+                    shell: false,
+                  }) as ChildProcessWithoutNullStreams;
+                } catch (error) {
+                  const launchError = localRuntimeLaunchError(
+                    localPlan.runner,
+                    (error as NodeJS.ErrnoException).code,
+                  );
+                  result.is_error = true;
+                  launchFailure = launchError;
+                  pushProgress(
+                    "harness-start",
+                    `${binding.harness} failed to start`,
+                    "error",
+                    launchError.message,
+                    Date.now() - attemptStartedAt,
+                  );
+                  push({ kind: "error", code: launchError.code, message: launchError.message });
+                  return null;
+                }
                 if (openCodeLaunchCommand) {
                   writeOpenCodeLaunchInput(child, openCodeLaunchCommand);
                 }

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -240,6 +240,7 @@ const CHAT_DETACH_MAX_MS = Math.max(
 type LocalRuntimePlan = LocalRuntimeCapabilityPlan & {
   command: string;
   fixedArgs: string[];
+  requiredFiles?: string[];
   env: NodeJS.ProcessEnv;
   unresolvedWindowsShim?: boolean;
   powerShellHostedCommand?: string;
@@ -247,7 +248,9 @@ type LocalRuntimePlan = LocalRuntimeCapabilityPlan & {
 
 function createLocalRuntimePlan(input: {
   runner: DirectRunnerId;
-  launch: Pick<CovenLaunchCommand, "command" | "fixedArgs" | "unresolvedWindowsShim">;
+  launch: Pick<CovenLaunchCommand, "command" | "fixedArgs" | "unresolvedWindowsShim"> & {
+    requiredFiles?: string[];
+  };
   env: NodeJS.ProcessEnv;
   availability?: RuntimeAvailability;
   powerShellHostedCommand?: string;
@@ -256,6 +259,7 @@ function createLocalRuntimePlan(input: {
     runner: input.runner,
     command: input.launch.command,
     env: input.env,
+    requiredFiles: input.launch.requiredFiles,
     unresolvedWindowsShim: input.launch.unresolvedWindowsShim === true,
     powerShellHostedCommand: input.powerShellHostedCommand,
   });
@@ -263,6 +267,7 @@ function createLocalRuntimePlan(input: {
     runner: input.runner,
     command: input.launch.command,
     fixedArgs: input.launch.fixedArgs,
+    ...(input.launch.requiredFiles ? { requiredFiles: input.launch.requiredFiles } : {}),
     env: input.env,
     availability,
     ...(input.launch.unresolvedWindowsShim
@@ -3160,6 +3165,7 @@ export async function POST(req: Request) {
                         runner: localPlan.runner,
                         command: localPlan.command,
                         env: localPlan.env,
+                        requiredFiles: localPlan.requiredFiles,
                         unresolvedWindowsShim:
                           localPlan.unresolvedWindowsShim === true,
                         powerShellHostedCommand:

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -27,7 +27,7 @@ assert.match(
 );
 assert.match(
   source,
-  /async function adapterAvailability[\s\S]*?id === "copilot"[\s\S]*?const copilotLaunch = await resolveCopilotRuntimeLaunch\(stream\.executable\)[\s\S]*?availability: summarizeRuntimeAvailability\(copilotLaunch\.availability\)[\s\S]*?copilotLaunch/,
+  /async function adapterAvailability[\s\S]*?id === "copilot"[\s\S]*?const copilotLaunch = await resolveCopilotRuntimeLaunch\(stream\.executable,[\s\S]*?spawnEnv: \(\) => harnessSpawnEnv\(null\)[\s\S]*?availability: summarizeRuntimeAvailability\(copilotLaunch\.availability\)[\s\S]*?copilotLaunch/,
   "Copilot availability retains the shared exact launch plan for internal catalog probes",
 );
 assert.match(

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -69,7 +69,9 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
   if (id === "copilot") {
     const stream = copilotStreamSpec();
     if (stream) {
-      const copilotLaunch = await resolveCopilotRuntimeLaunch(stream.executable);
+      const copilotLaunch = await resolveCopilotRuntimeLaunch(stream.executable, {
+        spawnEnv: () => harnessSpawnEnv(null),
+      });
       return {
         availability: summarizeRuntimeAvailability(copilotLaunch.availability),
         copilotLaunch,

--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -106,7 +106,12 @@ function FamiliarIdentityHero({
       .map((h) => ({
         value: h.id,
         label: h.label,
-        detail: [h.version, h.installed ? null : "not installed"].filter(Boolean).join(" · ") || undefined,
+        detail: [
+          h.version,
+          h.availability && h.availability.state !== "ready"
+            ? h.availability.message
+            : h.installed ? null : "not installed",
+        ].filter(Boolean).join(" · ") || undefined,
       })),
   ];
 

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -20,6 +20,11 @@ assert.match(
 );
 assert.match(
   source,
+  /h\.availability && h\.availability\.state !== "ready"[\s\S]*?h\.availability\.message/,
+  "Runtime picker should reuse server-provided launchability remediation instead of treating an installed but unlaunchable CLI as ready",
+);
+assert.match(
+  source,
   /modelOptions\.map/,
   "Brain tab should render a model select from the catalog options",
 );

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -71,6 +71,10 @@ type HarnessReport = {
   id: string;
   label: string;
   installed: boolean;
+  availability?: {
+    state: "ready" | "missing" | "unlaunchable" | "probe_failed" | "unsupported_runtime";
+    message?: string;
+  };
   models?: RuntimeModelOption[];
   defaultModel?: string | null;
 };
@@ -840,7 +844,9 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
                           .filter((h) => isBindableRuntimeChoice(h.id))
                           .map((h) => ({
                             value: h.id,
-                            label: `${h.label}${h.installed ? "" : " (not installed)"}`,
+                            label: h.availability && h.availability.state !== "ready"
+                              ? `${h.label} (${h.availability.message ?? "not ready"})`
+                              : `${h.label}${h.installed ? "" : " (not installed)"}`,
                           })),
                       } satisfies StandardSelectGroup<string>,
                     ]}

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -28,6 +28,11 @@ assert.match(
   /fetch\("\/api\/familiars",\s*\{[\s\S]*?method:\s*"POST"/,
   "the circle should POST to /api/familiars",
 );
+assert.match(
+  source,
+  /vessel !== "local" \|\| h\.availability\?\.state === undefined \|\| h\.availability\.state === "ready"/,
+  "Local runtime choices must exclude installed runners the shared preflight says are not launchable",
+);
 assert.doesNotMatch(
   source,
   /onboarding\/setup/,

--- a/src/components/familiar-summoning-circle.tsx
+++ b/src/components/familiar-summoning-circle.tsx
@@ -772,8 +772,13 @@ function StageVessel({
   // launcher. Hide it for SSH rather than letting a selection fall back to an
   // incompatible `coven run --stream-json` path.
   const installedHarnesses = (harnesses ?? []).filter(
-    (h) => h.installed && (vessel !== "ssh" || h.id !== "grok"),
+    (h) => h.installed
+      && (vessel !== "local" || h.availability?.state === undefined || h.availability.state === "ready")
+      && (vessel !== "ssh" || h.id !== "grok"),
   );
+  const unavailableLocalHarness = vessel === "local"
+    ? (harnesses ?? []).find((h) => h.installed && h.availability?.state !== undefined && h.availability.state !== "ready")
+    : null;
   return (
     <div className="flex flex-col gap-3">
       <div role="radiogroup" aria-label="Vessel" className="summoning-vessels">
@@ -809,7 +814,7 @@ function StageVessel({
             // users between the circle and Settings (cave-tpji).
             <div className="flex flex-col items-start gap-1.5">
               <p className="text-[length:var(--text-xs)] text-[var(--color-warning)]">
-                No chat-capable runtime found. Run setup to install one (Codex, Claude Code, Copilot…), then return to the circle.
+                {unavailableLocalHarness?.availability?.message ?? "No chat-capable runtime found. Run setup to install one (Codex, Claude Code, Copilot…), then return to the circle."}
               </p>
               <button
                 type="button"

--- a/src/components/familiar-summoning-model.ts
+++ b/src/components/familiar-summoning-model.ts
@@ -7,6 +7,10 @@ export type HarnessReport = {
   label: string;
   chatSupported: boolean;
   installed: boolean;
+  availability?: {
+    state: "ready" | "missing" | "unlaunchable" | "probe_failed" | "unsupported_runtime";
+    message?: string;
+  };
 };
 
 export type OpenClawAgent = {

--- a/src/lib/copilot-bin.test.ts
+++ b/src/lib/copilot-bin.test.ts
@@ -14,5 +14,10 @@ writeFileSync(shim, `@echo off\n"%~dp0\\node_modules\\@github\\copilot\\index.js
 const windowsShim = await resolveCopilotLaunchCommand(shim, { platform: "win32" });
 assert.equal(windowsShim.command, process.execPath, "a Windows npm shim runs through Node, never cmd.exe");
 assert.deepEqual(windowsShim.fixedArgs, [entry], "the npm shim entry point is kept separate from untrusted argv");
+assert.deepEqual(
+  windowsShim.requiredFiles,
+  [entry],
+  "the converted argv-list launch records its required entry artifact for preflight",
+);
 
 console.log("copilot-bin: ok");

--- a/src/lib/copilot-bin.test.ts
+++ b/src/lib/copilot-bin.test.ts
@@ -20,4 +20,14 @@ assert.deepEqual(
   "the converted argv-list launch records its required entry artifact for preflight",
 );
 
+// A shim whose entry point cannot be proven from the reviewed `%dp0` form
+// must never be handed to cmd.exe. The caller receives an explicit
+// unlaunchable plan instead of a shell-based fallback.
+const unsafeShim = path.join(root, "copilot-unsafe.cmd");
+writeFileSync(unsafeShim, "@echo off\n%COMSPEC% /c \"copilot %*\"\n");
+const unsafeWindowsShim = await resolveCopilotLaunchCommand(unsafeShim, { platform: "win32" });
+assert.equal(unsafeWindowsShim.command, unsafeShim, "an unproven shim stays an inert launch target");
+assert.equal(unsafeWindowsShim.unresolvedWindowsShim, true, "an unproven shim is explicitly unlaunchable");
+assert.deepEqual(unsafeWindowsShim.requiredFiles, [], "an unproven shim exposes no invented entry artifact");
+
 console.log("copilot-bin: ok");

--- a/src/lib/copilot-bin.ts
+++ b/src/lib/copilot-bin.ts
@@ -12,6 +12,13 @@ import { covenLaunchCommandForBinary, pickWindowsLauncher, type CovenLaunchComma
 
 const MAX_WINDOWS_WHERE_OUTPUT = 64 * 1024;
 
+/** The exact argv-list Copilot launch. `requiredFiles` are passive preflight
+ * artifacts, never shell input: npm's Windows shim conversion yields
+ * `node <absolute-entry.js>` and both parts must remain available. */
+export type CopilotLaunchCommand = CovenLaunchCommand & {
+  requiredFiles: string[];
+};
+
 async function withinTimeout<T>(work: Promise<T>, timeoutMs: number, fallback: T): Promise<{ value: T; timedOut: boolean }> {
   if (timeoutMs <= 0) return { value: fallback, timedOut: true };
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -91,7 +98,7 @@ async function windowsCopilotLauncher(binary: string, timeoutMs: number, env?: N
 export async function resolveCopilotLaunchCommand(
   binary: string,
   options: { platform?: NodeJS.Platform; timeoutMs?: number; env?: NodeJS.ProcessEnv } = {},
-): Promise<CovenLaunchCommand> {
+): Promise<CopilotLaunchCommand> {
   const platform = options.platform ?? process.platform;
   const timeoutMs = options.timeoutMs ?? 1_500;
   const resolveLauncher = platform === "win32"
@@ -102,8 +109,13 @@ export async function resolveCopilotLaunchCommand(
     timeoutMs,
     binary,
   );
+  const launch = covenLaunchCommandForBinary(resolved.value, platform);
   return {
-    ...covenLaunchCommandForBinary(resolved.value, platform),
+    ...launch,
+    // A converted shim's first fixed argv item is the absolute script whose
+    // existence made the conversion safe. Native launches have no required
+    // artifact beyond their command.
+    requiredFiles: launch.fixedArgs.length === 1 ? [launch.fixedArgs[0]!] : [],
     ...(resolved.timedOut ? { resolutionTimedOut: true as const } : {}),
   };
 }

--- a/src/lib/copilot-bin.ts
+++ b/src/lib/copilot-bin.ts
@@ -16,7 +16,7 @@ const MAX_WINDOWS_WHERE_OUTPUT = 64 * 1024;
  * artifacts, never shell input: npm's Windows shim conversion yields
  * `node <absolute-entry.js>` and both parts must remain available. */
 export type CopilotLaunchCommand = CovenLaunchCommand & {
-  requiredFiles: string[];
+  requiredFiles?: string[];
 };
 
 async function withinTimeout<T>(work: Promise<T>, timeoutMs: number, fallback: T): Promise<{ value: T; timedOut: boolean }> {

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -10,6 +10,7 @@ import { readFile } from "node:fs/promises";
 import {
   buildCopilotStreamArgs,
   compareRuntimeClientVersions,
+  copilotDirectStreamConfigured,
   copilotIdentityPreamble,
   copilotProtocolDiagnostic,
   copilotStreamSpec,
@@ -32,6 +33,7 @@ import {
 
 const spec = copilotStreamSpec();
 assert.ok(spec, "registry manifest declares copilot stream mode");
+assert.equal(copilotDirectStreamConfigured(), true, "the synced registry explicitly opts Copilot into the direct JSONL transport");
 assert.equal(spec.protocol.id, "copilot-jsonl-v1", "legacy callers use the verified registry baseline");
 assert.equal(spec.executable, "copilot");
 assert.deepEqual(

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -28,6 +28,7 @@
 // ignores. The final `result` frame is top-level (no `data` envelope).
 
 import { REGISTRY_RUNTIMES } from "./runtime-registry.gen.ts";
+import type { CopilotLaunchCommand } from "./copilot-bin.ts";
 import type { RuntimeToolAdapter, ToolAction } from "./runtime-tool-adapter.ts";
 
 /**
@@ -239,7 +240,7 @@ export type RuntimeProtocolDiagnostic = {
 export type CopilotStreamSpec = {
   executable: string;
   /** Resolved during the capability probe; direct spawns must reuse it. */
-  launchCommand?: { command: string; fixedArgs: string[] };
+  launchCommand?: CopilotLaunchCommand;
   /** Selected, versioned JSONL event contract for this local CLI. */
   protocol: RuntimeEventProtocolSchema;
   /** JSONL stream launch args; ends with the prompt flag (`-p`). */
@@ -281,6 +282,15 @@ function stringArray(value: unknown): string[] | null {
   if (!Array.isArray(value)) return null;
   if (!value.every((entry) => typeof entry === "string")) return null;
   return value as string[];
+}
+
+/** Whether the synced registry explicitly opts local Copilot into Cave's
+ * direct JSONL transport. When it does not, callers retain the established
+ * generic `coven run` route; when it does, a malformed/incompatible direct
+ * plan must fail closed rather than silently changing transports. */
+export function copilotDirectStreamConfigured(): boolean {
+  const runtime = REGISTRY_RUNTIMES.find((entry) => entry.id === "copilot");
+  return runtime?.capabilities.stream === true;
 }
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -350,7 +360,7 @@ export function runtimeEventProtocolSchemas(value: unknown): RuntimeEventProtoco
 export function copilotStreamSpec(
   clientVersion?: string | null,
   compatibleEventProtocols?: unknown,
-  launchCommand?: { command: string; fixedArgs: string[] },
+  launchCommand?: CopilotLaunchCommand,
 ): CopilotStreamSpec | null {
   const runtime = REGISTRY_RUNTIMES.find((entry) => entry.id === "copilot");
   if (!runtime || !runtime.capabilities.stream) return null;

--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -135,6 +135,33 @@ try {
     );
   }
 
+  // A direct Windows npm-shim plan is `node <entry.js>`: validating only the
+  // host must not mark a removed or unreadable fixed script as ready.
+  const requiredArtifactMissing = evaluateRuntimeAvailability({
+    runner: "copilot",
+    command: "node.exe",
+    requiredFiles: ["C:\\bin\\copilot-entry.js"],
+    env: { Path: "C:\\bin" },
+    platform: "win32",
+    statFile: (candidate) => candidate === "C:\\bin\\node.exe",
+  });
+  assert.equal(requiredArtifactMissing.state, "unlaunchable");
+  assert.doesNotMatch(
+    requiredArtifactMissing.state === "unlaunchable" ? requiredArtifactMissing.message : "",
+    /copilot-entry|C:\\bin/i,
+    "required-artifact diagnostics do not expose local path details",
+  );
+
+  const requiredArtifactReady = evaluateRuntimeAvailability({
+    runner: "copilot",
+    command: "node.exe",
+    requiredFiles: ["C:\\bin\\copilot-entry.js"],
+    env: { Path: "C:\\bin" },
+    platform: "win32",
+    statFile: (candidate) => candidate === "C:\\bin\\node.exe" || candidate === "C:\\bin\\copilot-entry.js",
+  });
+  assert.equal(requiredArtifactReady.state, "ready", "a complete direct launch plan is ready");
+
   // Verification matrix: binary absent from every discovery location →
   // missing, with per-runner install/PATH remediation.
   for (const runner of ["coven", "copilot", "grok", "hermes", "opencode"] as const) {

--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -54,23 +54,25 @@ try {
     platform: "linux",
   });
   assert.equal(ready.state, "ready", "a bare command on the spawn PATH is ready");
-  assert.equal(
-    ready.state === "ready" && ready.resolvedPath,
-    executable,
-    "ready reports where the exact spawn command resolved",
+  assert.match(
+    String(ready.state === "ready" && ready.resolvedPath),
+    /(?:^|[\\/])grok$/,
+    "ready reports the exact executable name selected from the spawn PATH",
   );
 
-  const absoluteReady = evaluateRuntimeAvailability({
-    runner: "coven",
-    command: executable,
-    env: { PATH: "" },
-    platform: "linux",
-  });
-  assert.equal(
-    absoluteReady.state,
-    "ready",
-    "a mode-0755 regular file is launchable on POSIX",
-  );
+  if (process.platform !== "win32") {
+    const absoluteReady = evaluateRuntimeAvailability({
+      runner: "coven",
+      command: executable,
+      env: { PATH: "" },
+      platform: "linux",
+    });
+    assert.equal(
+      absoluteReady.state,
+      "ready",
+      "a mode-0755 regular file is launchable on POSIX",
+    );
+  }
 
   if (process.platform !== "win32") {
     const directoryCandidate = path.join(binDir, "grok-directory");
@@ -130,7 +132,7 @@ try {
     );
     assert.equal(
       laterExecutableWins.state === "ready" && laterExecutableWins.resolvedPath,
-      executable,
+      path.posix.join(binDir, "grok"),
       "PATH resolution reports the exact later executable that won",
     );
   }
@@ -161,6 +163,21 @@ try {
     statFile: (candidate) => candidate === "C:\\bin\\node.exe" || candidate === "C:\\bin\\copilot-entry.js",
   });
   assert.equal(requiredArtifactReady.state, "ready", "a complete direct launch plan is ready");
+
+  const requiredArtifactUnreadable = evaluateRuntimeAvailability({
+    runner: "copilot",
+    command: "node.exe",
+    requiredFiles: ["C:\\bin\\copilot-entry.js"],
+    env: { Path: "C:\\bin" },
+    platform: "win32",
+    statFile: () => true,
+    readableFile: () => false,
+  });
+  assert.equal(
+    requiredArtifactUnreadable.state,
+    "unlaunchable",
+    "an unreadable fixed shim entry is not safe to launch through Node",
+  );
 
   // Verification matrix: binary absent from every discovery location →
   // missing, with per-runner install/PATH remediation.

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -77,12 +77,21 @@ export function summarizeRuntimeAvailability(
  * uses richer candidate inspection so POSIX execute permissions are checked. */
 export type StatFileFn = (candidate: string) => boolean;
 
+/** True when a fixed, non-executable argv artifact is readable by the child.
+ * A Windows npm shim becomes `node <entry.js>`, so the entry must remain
+ * readable in addition to the Node host being launchable. */
+export type ReadableFileFn = (candidate: string) => boolean;
+
 export type RuntimeAvailabilityProbe = {
   runner: DirectRunnerId;
   /** The exact executable that will be passed to `spawn()`. */
   command: string;
   /** The exact environment object the spawn will receive. */
   env: Record<string, string | undefined>;
+  /** Files the exact argv-list launch requires in addition to `command`.
+   * For example, a safe Windows npm shim launch is `node <entry.js>` and the
+   * entry script must still exist when the child is spawned. */
+  requiredFiles?: string[];
   /** Coven/Grok launch resolution found a Windows shim it could not safely
    * convert into a runnable command (`CovenLaunchCommand.unresolvedWindowsShim`). */
   unresolvedWindowsShim?: boolean;
@@ -91,6 +100,7 @@ export type RuntimeAvailabilityProbe = {
   powerShellHostedCommand?: string;
   platform?: NodeJS.Platform;
   statFile?: StatFileFn;
+  readableFile?: ReadableFileFn;
 };
 
 // The missing-runner remediation copy is shared with the post-spawn ENOENT
@@ -185,6 +195,20 @@ function defaultInspectCandidate(
 
 function inspectWithStatFile(candidate: string, statFile: StatFileFn): CandidateInspection {
   return statFile(candidate) ? "launchable" : "missing";
+}
+
+function defaultReadableFile(candidate: string): boolean {
+  try {
+    if (!statSync(candidate).isFile()) return false;
+    accessSync(candidate, constants.R_OK);
+    return true;
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT" || code === "ENOTDIR" || code === "EACCES" || code === "EPERM") {
+      return false;
+    }
+    throw error;
+  }
 }
 
 function pathEntries(env: Record<string, string | undefined>, platform: NodeJS.Platform): string[] {
@@ -307,6 +331,8 @@ export function evaluateRuntimeAvailability(
   const inspectCandidate: InspectCandidateFn = probe.statFile
     ? (candidate) => inspectWithStatFile(candidate, probe.statFile!)
     : (candidate) => defaultInspectCandidate(candidate, platform);
+  const readableFile = probe.readableFile
+    ?? (probe.statFile ? probe.statFile : defaultReadableFile);
   const label = RUNNER_LABELS[runner];
   try {
     if (probe.unresolvedWindowsShim) {
@@ -346,6 +372,15 @@ export function evaluateRuntimeAvailability(
         }
       }
       return notReady(runner, "missing", missingRunnerMessage(runner));
+    }
+    for (const requiredFile of probe.requiredFiles ?? []) {
+      if (!readableFile(requiredFile)) {
+        return notReady(
+          runner,
+          "unlaunchable",
+          `${label} has a resolved launch command, but a required launch artifact is unavailable. Reinstall it, then try again.`,
+        );
+      }
     }
     if (probe.powerShellHostedCommand !== undefined) {
       const inner = resolveCommand(

--- a/src/lib/server/copilot-runtime-launch.test.ts
+++ b/src/lib/server/copilot-runtime-launch.test.ts
@@ -38,6 +38,11 @@ try {
       capturedResolveOptions = options;
       return { command: process.execPath, fixedArgs: [] };
     },
+    evaluateAvailability: (probe: { command: string }) => ({
+      state: "ready",
+      runner: "copilot",
+      resolvedPath: probe.command,
+    }),
   });
   assert.equal(capturedDeadline, 3_500, "environment discovery receives one absolute deadline");
   assert.equal(ready.deadline, capturedDeadline, "the launch plan owns that same absolute deadline");
@@ -124,6 +129,12 @@ try {
     now: () => 1_000,
     spawnEnv: () => ({ PATH: "" }),
     resolveLaunchCommand: async (executable: string) => ({ command: executable, fixedArgs: [] }),
+    evaluateAvailability: () => ({
+      state: "unlaunchable",
+      runner: "copilot",
+      code: "runtime_unlaunchable",
+      message: "fixture",
+    }),
   });
   assert.equal(
     unlaunchable.availability.state,

--- a/src/lib/server/copilot-runtime-launch.test.ts
+++ b/src/lib/server/copilot-runtime-launch.test.ts
@@ -169,6 +169,11 @@ try {
     [shimEntry],
     "a Windows npm shim keeps the exact transformed fixed args",
   );
+  assert.deepEqual(
+    windowsPlan.requiredFiles,
+    [shimEntry],
+    "a converted Windows npm shim preflights its fixed JavaScript entry",
+  );
   assert.equal(
     evaluatedWindowsCommand,
     windowsPlan.command,

--- a/src/lib/server/copilot-runtime-launch.ts
+++ b/src/lib/server/copilot-runtime-launch.ts
@@ -19,6 +19,8 @@ export type CopilotRuntimeLaunch = {
   /** Exact command and fixed argv prefix selected by launcher resolution. */
   command: string;
   fixedArgs: string[];
+  /** Fixed argv artifacts required by the selected launch plan. */
+  requiredFiles: string[];
   /** Absolute deadline shared by env, launcher, and identity discovery. */
   deadline: number;
   availability: RuntimeAvailability;
@@ -60,11 +62,13 @@ function failedPlan(input: {
   reason: "timeout" | "failed";
   command?: string;
   fixedArgs?: string[];
+  requiredFiles?: string[];
 }): CopilotRuntimeLaunch {
   return {
     env: input.env,
     command: input.command ?? input.executable,
     fixedArgs: input.fixedArgs ?? [],
+    requiredFiles: input.requiredFiles ?? [],
     deadline: input.deadline,
     availability: copilotLaunchProbeFailureAvailability(input.reason),
     ...(input.reason === "timeout" ? { resolutionTimedOut: true as const } : {}),
@@ -144,6 +148,7 @@ export async function resolveCopilotRuntimeLaunch(
       reason: "timeout",
       command: launch.command,
       fixedArgs: launch.fixedArgs,
+      requiredFiles: launch.requiredFiles,
     });
   }
 
@@ -153,6 +158,7 @@ export async function resolveCopilotRuntimeLaunch(
     runner: "copilot",
     command: launch.command,
     env,
+    requiredFiles: launch.requiredFiles,
     unresolvedWindowsShim: launch.unresolvedWindowsShim === true,
     platform: options.platform,
   });
@@ -164,12 +170,14 @@ export async function resolveCopilotRuntimeLaunch(
       reason: "timeout",
       command: launch.command,
       fixedArgs: launch.fixedArgs,
+      requiredFiles: launch.requiredFiles,
     });
   }
   return {
     env,
     command: launch.command,
     fixedArgs: launch.fixedArgs,
+    requiredFiles: launch.requiredFiles,
     deadline: discoveryDeadline,
     availability,
     ...(launch.unresolvedWindowsShim

--- a/src/lib/server/copilot-runtime-launch.ts
+++ b/src/lib/server/copilot-runtime-launch.ts
@@ -148,7 +148,7 @@ export async function resolveCopilotRuntimeLaunch(
       reason: "timeout",
       command: launch.command,
       fixedArgs: launch.fixedArgs,
-      requiredFiles: launch.requiredFiles,
+      requiredFiles: launch.requiredFiles ?? [],
     });
   }
 
@@ -158,7 +158,7 @@ export async function resolveCopilotRuntimeLaunch(
     runner: "copilot",
     command: launch.command,
     env,
-    requiredFiles: launch.requiredFiles,
+    requiredFiles: launch.requiredFiles ?? [],
     unresolvedWindowsShim: launch.unresolvedWindowsShim === true,
     platform: options.platform,
   });
@@ -170,14 +170,14 @@ export async function resolveCopilotRuntimeLaunch(
       reason: "timeout",
       command: launch.command,
       fixedArgs: launch.fixedArgs,
-      requiredFiles: launch.requiredFiles,
+      requiredFiles: launch.requiredFiles ?? [],
     });
   }
   return {
     env,
     command: launch.command,
     fixedArgs: launch.fixedArgs,
-    requiredFiles: launch.requiredFiles,
+    requiredFiles: launch.requiredFiles ?? [],
     deadline: discoveryDeadline,
     availability,
     ...(launch.unresolvedWindowsShim

--- a/src/lib/server/copilot-runtime-launch.ts
+++ b/src/lib/server/copilot-runtime-launch.ts
@@ -20,7 +20,7 @@ export type CopilotRuntimeLaunch = {
   command: string;
   fixedArgs: string[];
   /** Fixed argv artifacts required by the selected launch plan. */
-  requiredFiles: string[];
+  requiredFiles?: string[];
   /** Absolute deadline shared by env, launcher, and identity discovery. */
   deadline: number;
   availability: RuntimeAvailability;


### PR DESCRIPTION
## Summary
- preflight the exact resolved Copilot JSONL argv plan, including safe Windows npm-shim entry scripts, in the same familiar-scoped environment used for the direct child
- require fixed launch artifacts to be present and readable; classify missing CLI, unlaunchable shims, bounded probe failure, and incompatible JSONL configuration distinctly without generic Coven fallback
- retain no-shell spawning, structured pre-spawn errors, post-start authentication handling, and race-safe fixed launch failure remediation

## Verification
- focused runtime availability, Copilot resolver/stream/runtime-launch/capability, routing, direct send availability integration, harness status/API-contract, Familiar Studio, and Summoning Circle tests
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired (1250 wired)
- git diff --check origin/main...HEAD

pnpm test:api passed its first three files, then hit the known native-Windows scripts/dev-app-teardown.test.mjs fake-server bind timeout (port 53491); the affected send-route integration passes independently.

Closes #3857.