### PR TITLE
fix(security): bind vaulted hub tokens to origin

### DIFF
--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -4,7 +4,11 @@ import { caveHome } from "./coven-paths.ts";
 import { writeJsonAtomic } from "./server/atomic-write.ts";
 import { withCaveHomeReconciledStore, withCaveHomeReconciledStores } from "./server/cave-home-migration.ts";
 import { invalidateSessionsListCache } from "./server/sessions-list-cache.ts";
-import { rememberHubAccessToken, splitHubAccessToken } from "./hub-access-token.ts";
+import {
+  reconcileHubAccessTokenForOrigin,
+  rememberHubAccessToken,
+  splitHubAccessToken,
+} from "./hub-access-token.ts";
 import {
   type ChatAutoArchivePolicy,
   extendUntilIso,
@@ -381,11 +385,11 @@ async function loadConfigUnlocked(): Promise<CaveConfig> {
         ? { chatAutoRename: normalizeChatAutoRenamePolicy(parsed.chatAutoRename) }
         : {}),
     };
-    // Self-healing migration (cave-1v95): a pre-existing config may still
-    // embed the hub access token in multiHost.hubUrl. Move it to the local
-    // encrypted vault and rewrite the file once, so config.json stops being a
-    // credential store. Best-effort — a failed vault write keeps the embedded
-    // token working exactly as before.
+    // Self-healing migration (cave-1v95): move an embedded token to
+    // origin-bound vault custody and rewrite the config once. Token-free URLs
+    // also reconcile legacy raw custody or clear custody bound to another
+    // origin. Best-effort — a failed vault write keeps an embedded token
+    // working exactly as before.
     if (sanitizeMultiHostHubToken(config)) {
       await writeJsonAtomic(CONFIG_PATH, config).catch(() => {});
     }
@@ -399,13 +403,17 @@ export function loadConfig(): Promise<CaveConfig> {
   return withCaveHomeReconciledStore("cave-config.json", loadConfigUnlocked);
 }
 
-/** Split an embedded access token out of `config.multiHost.hubUrl` into the
- *  local encrypted vault, in place. Returns whether the URL was rewritten. */
+/** Reconcile the configured hub URL with origin-bound vault custody, splitting
+ *  an embedded access token in place. Returns whether the URL was rewritten. */
 function sanitizeMultiHostHubToken(config: Pick<CaveConfig, "multiHost">): boolean {
   const { url, token } = splitHubAccessToken(config.multiHost.hubUrl);
-  if (!token || !rememberHubAccessToken(token)) return false;
-  config.multiHost = { ...config.multiHost, hubUrl: url };
-  return true;
+  if (token) {
+    if (!rememberHubAccessToken(token, url)) return false;
+    config.multiHost = { ...config.multiHost, hubUrl: url };
+    return true;
+  }
+  reconcileHubAccessTokenForOrigin(url);
+  return false;
 }
 
 function mergeFamiliarConfigs(

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -107,9 +107,10 @@ function hubTargetFromUrl(rawUrl: string): Extract<DaemonTarget, { mode: "hub" }
   const url = new URL(normalized);
   // An embedded token (a freshly pasted invite URL, or an env-provided URL)
   // wins; otherwise fall back to the out-of-config custody the config
-  // sanitizer maintains (cave-1v95): env override, then the encrypted vault.
+  // sanitizer maintains (cave-1v95): global env override, then encrypted
+  // custody bound to this exact origin.
   const embedded = url.searchParams.get("coven_access_token")?.trim();
-  const accessToken = embedded || storedHubAccessToken() || undefined;
+  const accessToken = embedded || storedHubAccessToken(url.toString()) || undefined;
   url.search = "";
   url.hash = "";
   return {

--- a/src/lib/hub-access-token.test.ts
+++ b/src/lib/hub-access-token.test.ts
@@ -17,12 +17,17 @@ delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
 
 const { splitHubAccessToken, storedHubAccessToken, rememberHubAccessToken, HUB_ACCESS_TOKEN_KEY } =
   await import("./hub-access-token.ts");
-const { getLocalEncryptedSecret } = await import("./local-encrypted-vault.ts");
+const { getLocalEncryptedSecret, setLocalEncryptedSecret } = await import("./local-encrypted-vault.ts");
 const { loadConfig, saveConfig } = await import("./cave-config.ts");
 const { daemonTargetForConfig } = await import("./coven-daemon.ts");
 const { writeJsonAtomic } = await import("./server/atomic-write.ts");
 
 const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
+
+function decodedHubTokenCustody() {
+  const raw = getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY);
+  return raw ? JSON.parse(raw) : null;
+}
 
 // ── splitHubAccessToken is pure and conservative ─────────────────────────────
 {
@@ -52,21 +57,54 @@ const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
 
 // ── vault custody round-trip with env override precedence ────────────────────
 {
-  assert.equal(storedHubAccessToken(), null, "no custody yet → null");
-  assert.equal(rememberHubAccessToken("v1.vaulted"), true, "vault write succeeds");
-  assert.equal(storedHubAccessToken(), "v1.vaulted", "vault value resolves");
+  assert.equal(storedHubAccessToken("https://hub.example"), null, "no custody yet → null");
   assert.equal(
-    getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY),
+    rememberHubAccessToken("v1.vaulted", "https://hub.example"),
+    true,
+    "vault write succeeds",
+  );
+  assert.equal(
+    storedHubAccessToken("https://hub.example/path"),
     "v1.vaulted",
-    "the token lives in the encrypted local vault",
+    "vault value resolves for its origin",
+  );
+  assert.equal(
+    storedHubAccessToken("https://other.example"),
+    null,
+    "vault value is not used for another origin",
+  );
+  assert.deepEqual(
+    decodedHubTokenCustody(),
+    { v: 1, origin: "https://hub.example", token: "v1.vaulted" },
+    "the token lives in the encrypted local vault with its hub origin",
   );
   process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = "v1.env";
-  assert.equal(storedHubAccessToken(), "v1.env", "an explicit env override wins over the vault");
+  assert.equal(
+    storedHubAccessToken("https://other.example"),
+    "v1.env",
+    "an explicit env override wins over the vault",
+  );
   delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
-  assert.equal(rememberHubAccessToken("   "), false, "blank tokens are refused, not parked in the vault");
-  assert.equal(storedHubAccessToken(), "v1.vaulted", "a refused write leaves prior custody intact");
-  assert.equal(rememberHubAccessToken("  v1.padded \n"), true, "padded input is trimmed before storage");
-  assert.equal(storedHubAccessToken(), "v1.padded", "custody resolves trimmed, never truthy-but-padded");
+  assert.equal(
+    rememberHubAccessToken("   ", "https://hub.example"),
+    false,
+    "blank tokens are refused, not parked in the vault",
+  );
+  assert.equal(
+    storedHubAccessToken("https://hub.example"),
+    "v1.vaulted",
+    "a refused write leaves prior custody intact",
+  );
+  assert.equal(
+    rememberHubAccessToken("  v1.padded \n", "https://hub.example"),
+    true,
+    "padded input is trimmed before storage",
+  );
+  assert.equal(
+    storedHubAccessToken("https://hub.example"),
+    "v1.padded",
+    "custody resolves trimmed, never truthy-but-padded",
+  );
 }
 
 // ── saveConfig never persists the embedded token ──────────────────────────────
@@ -81,7 +119,11 @@ const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
   assert.doesNotMatch(saved.multiHost.hubUrl, /coven_access_token|v1\.saved/, "the in-memory result is clean");
   const onDisk = await readFile(CONFIG_PATH, "utf8");
   assert.doesNotMatch(onDisk, /coven_access_token|v1\.saved/, "config.json never contains the credential");
-  assert.equal(getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY), "v1.saved", "the credential moved to the vault");
+  assert.deepEqual(
+    decodedHubTokenCustody(),
+    { v: 1, origin: "https://hub.tailnet.example.ts.net", token: "v1.saved" },
+    "the credential moved to the vault with its origin",
+  );
 }
 
 // ── the daemon target resolves the token back from custody ───────────────────
@@ -117,11 +159,52 @@ const CONFIG_PATH = path.join(process.env.COVEN_HOME, "cave", "config.json");
   });
   const migrated = await loadConfig();
   assert.doesNotMatch(migrated.multiHost.hubUrl, /coven_access_token|v1\.legacy/, "load returns the clean URL");
-  assert.equal(getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY), "v1.legacy", "the legacy token moved to the vault");
+  assert.deepEqual(
+    decodedHubTokenCustody(),
+    { v: 1, origin: "https://hub.tailnet.example.ts.net", token: "v1.legacy" },
+    "the legacy token moved to the vault with its origin",
+  );
   const rewritten = await readFile(CONFIG_PATH, "utf8");
   assert.doesNotMatch(rewritten, /coven_access_token|v1\.legacy/, "the file itself is rewritten clean");
   const target = daemonTargetForConfig(migrated);
   assert.equal(target.accessToken, "v1.legacy", "hub auth survives the migration");
+}
+
+// ── raw vaulted custody migrates once to the configured hub origin ──────────
+{
+  setLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY, "v1.raw-vault");
+  const migrated = await loadConfig();
+  assert.deepEqual(
+    decodedHubTokenCustody(),
+    { v: 1, origin: "https://hub.tailnet.example.ts.net", token: "v1.raw-vault" },
+    "pre-origin custody is rebound once to the current configured hub",
+  );
+  const target = daemonTargetForConfig(migrated);
+  assert.equal(target.accessToken, "v1.raw-vault", "raw-custody migration preserves hub auth");
+}
+
+// ── changing to a tokenless hub URL does not leak prior custody ──────────────
+{
+  const switched = await saveConfig({
+    multiHost: {
+      mode: "hub",
+      hubUrl: "https://attacker.example",
+      executorUrls: [],
+    },
+  });
+  const target = daemonTargetForConfig(switched);
+  assert.equal(target.mode, "hub");
+  assert.equal(target.url, "https://attacker.example");
+  assert.equal(
+    target.accessToken,
+    undefined,
+    "prior hub token is not attached to a different origin",
+  );
+  assert.equal(
+    getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY),
+    null,
+    "origin change clears stale vaulted custody",
+  );
 }
 
 console.log("hub-access-token.test.ts OK");

--- a/src/lib/hub-access-token.ts
+++ b/src/lib/hub-access-token.ts
@@ -1,4 +1,8 @@
-import { getLocalEncryptedSecret, setLocalEncryptedSecret } from "./local-encrypted-vault.ts";
+import {
+  deleteLocalEncryptedSecret,
+  getLocalEncryptedSecret,
+  setLocalEncryptedSecret,
+} from "./local-encrypted-vault.ts";
 
 /**
  * Hub access token custody (cave-1v95, persistence P0).
@@ -13,6 +17,56 @@ import { getLocalEncryptedSecret, setLocalEncryptedSecret } from "./local-encryp
  * before anything touches disk.
  */
 export const HUB_ACCESS_TOKEN_KEY = "COVEN_CAVE_HUB_ACCESS_TOKEN";
+
+type StoredHubAccessToken = {
+  v: 1;
+  origin: string;
+  token: string;
+};
+
+type DecodedHubAccessToken =
+  | { kind: "bound"; value: StoredHubAccessToken }
+  | { kind: "legacy"; token: string }
+  | { kind: "invalid" };
+
+function hubAccessTokenOrigin(rawUrl: string): string | null {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) return null;
+  try {
+    return new URL(/^https?:\/\//i.test(trimmed) ? trimmed : `http://${trimmed}`).origin;
+  } catch {
+    return null;
+  }
+}
+
+function decodeStoredHubAccessToken(value: string | null): DecodedHubAccessToken | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return { kind: "legacy", token: trimmed };
+  }
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    (parsed as Partial<StoredHubAccessToken>).v === 1 &&
+    typeof (parsed as Partial<StoredHubAccessToken>).origin === "string" &&
+    typeof (parsed as Partial<StoredHubAccessToken>).token === "string"
+  ) {
+    const origin = hubAccessTokenOrigin((parsed as StoredHubAccessToken).origin);
+    const token = (parsed as StoredHubAccessToken).token.trim();
+    if (origin && token) {
+      return { kind: "bound", value: { v: 1, origin, token } };
+    }
+  }
+  return { kind: "invalid" };
+}
+
+function serializeStoredHubAccessToken(origin: string, token: string): string {
+  return JSON.stringify({ v: 1, origin, token } satisfies StoredHubAccessToken);
+}
 
 /** Split an embedded `coven_access_token` out of a hub URL. Pure: returns the
  *  URL unchanged (and no token) when there is nothing to split — including
@@ -36,30 +90,71 @@ export function splitHubAccessToken(rawUrl: string): { url: string; token?: stri
   return { url: cleaned.replace(/\?$/, ""), token };
 }
 
-/** The hub access token from its out-of-config homes: explicit env override
- *  first, then the local encrypted vault. Values are trimmed; blank custody
- *  resolves to null rather than a truthy-but-invalid credential. */
-export function storedHubAccessToken(): string | null {
+/** Resolve the hub access token from its out-of-config homes. The explicit
+ *  env override is intentionally global; vaulted custody is returned only
+ *  when its stored origin matches the requested hub. */
+export function storedHubAccessToken(rawUrl: string): string | null {
   const env = process.env[HUB_ACCESS_TOKEN_KEY]?.trim();
   if (env) return env;
+  const origin = hubAccessTokenOrigin(rawUrl);
+  if (!origin) return null;
   try {
-    return getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY)?.trim() || null;
+    const stored = decodeStoredHubAccessToken(
+      getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY),
+    );
+    return stored?.kind === "bound" && stored.value.origin === origin
+      ? stored.value.token
+      : null;
   } catch {
     return null;
   }
 }
 
-/** Persist the hub access token to the local encrypted vault (0600 key file,
- *  AES-256-GCM store — see local-encrypted-vault.ts). Trims first and refuses
- *  blank values, so a caller can never park an invalid truthy credential.
- *  Best-effort: a vault write failure must not take config saves down with
- *  it; the caller keeps the embedded token in that case. Returns whether the
- *  token is stored. */
-export function rememberHubAccessToken(token: string): boolean {
+/** Persist the hub access token and its canonical origin to the local
+ *  encrypted vault (0600 key file, AES-256-GCM store — see
+ *  local-encrypted-vault.ts). Best-effort: a vault write failure must not
+ *  take config saves down with it; the caller keeps the embedded token in
+ *  that case. Returns whether the token is stored. */
+export function rememberHubAccessToken(token: string, rawUrl: string): boolean {
   const trimmed = token.trim();
-  if (!trimmed) return false;
+  const origin = hubAccessTokenOrigin(rawUrl);
+  if (!trimmed || !origin) return false;
   try {
-    setLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY, trimmed);
+    setLocalEncryptedSecret(
+      HUB_ACCESS_TOKEN_KEY,
+      serializeStoredHubAccessToken(origin, trimmed),
+    );
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Reconcile vaulted custody with the configured hub origin.
+ *
+ * The pre-origin format was the raw token string. Config load/save is the
+ * only trusted migration boundary: it binds that legacy value once to the
+ * currently configured origin. A versioned token for another origin is
+ * removed instead of being forwarded to the new hub.
+ */
+export function reconcileHubAccessTokenForOrigin(rawUrl: string): boolean {
+  const origin = hubAccessTokenOrigin(rawUrl);
+  if (!origin) return false;
+  try {
+    const stored = decodeStoredHubAccessToken(
+      getLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY),
+    );
+    if (!stored) return false;
+    if (stored.kind === "legacy") {
+      setLocalEncryptedSecret(
+        HUB_ACCESS_TOKEN_KEY,
+        serializeStoredHubAccessToken(origin, stored.token),
+      );
+      return true;
+    }
+    if (stored.kind === "bound" && stored.value.origin === origin) return false;
+    deleteLocalEncryptedSecret(HUB_ACCESS_TOKEN_KEY);
     return true;
   } catch {
     return false;


### PR DESCRIPTION
### Motivation
- A vaulted hub token was stored under a single global key and could be attached to any tokenless hub URL, allowing a previously paired token to be sent to a different origin and leak credentials.

### Description
- Store vaulted tokens as a small versioned JSON object containing `origin` + `token`, with helpers `hubAccessTokenOrigin`, `parseStoredHubAccessToken`, and `serializeStoredHubAccessToken` in `src/lib/hub-access-token.ts`.
- Make `rememberHubAccessToken` accept the raw hub URL and persist origin-bound custody, make `storedHubAccessToken` resolve only when the stored origin matches the requested hub, and add `clearHubAccessTokenForDifferentOrigin` to drop stale custody.
- Update config sanitization in `sanitizeMultiHostHubToken` (in `src/lib/cave-config.ts`) to store the token with its cleaned URL origin and to clear stale vaulted custody on tokenless hub URL changes; update daemon resolution in `src/lib/coven-daemon.ts` to call `storedHubAccessToken(url)` so vaulted tokens are only applied for the matching origin.
- Add and extend regression tests in `src/lib/hub-access-token.test.ts` to cover origin-bound storage, env override precedence, legacy migration, and that switching to a tokenless different hub does not leak prior tokens.

### Testing
- Ran targeted unit suites: `node --experimental-strip-types src/lib/travel-offline-replay.test.ts`, `node --experimental-strip-types src/lib/hub-access-token.test.ts`, and `node --experimental-strip-types src/lib/coven-daemon.test.ts`, all succeeded.
- Ran typecheck `pnpm exec tsc --noEmit`, which succeeded.
- Ran full app test suite `pnpm test:app` (724 test files), which completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a575ae3b234832791950ef3a7bef2c4)