### PR TITLE
fix(vault): use warning color for cautions

### DIFF
--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -31,7 +31,7 @@ const STATUS_META: Record<VaultStatus, { label: string; color: string; icon: str
   resolved:   { label: "1Password",   color: "var(--color-success)", icon: "ph:vault" },
   encrypted:  { label: "encrypted",   color: "var(--accent-presence)", icon: "ph:lock-key" },
   "env-only": { label: "env only",    color: "oklch(0.75 0.15 80)", icon: "ph:file-text" },
-  unresolved: { label: "unresolved",  color: "var(--color-danger)", icon: "ph:warning" },
+  unresolved: { label: "unresolved",  color: "var(--color-warning)", icon: "ph:warning" },
   error:      { label: "error",       color: "var(--color-danger)", icon: "ph:x-circle" },
   "no-ref":   { label: "no ref",      color: "var(--text-muted)", icon: "ph:minus" },
 };

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -16,6 +16,7 @@ const routeSource = readFileSync(new URL("../app/api/vault/route.ts", import.met
 const githubPatRouteSource = readFileSync(new URL("../app/api/github/pat/route.ts", import.meta.url), "utf8");
 const panelSource = readFileSync(new URL("../components/vault-panel.tsx", import.meta.url), "utf8");
 const marketplaceConfigureSource = readFileSync(new URL("../components/marketplace/marketplace-configure.tsx", import.meta.url), "utf8");
+const themesSource = readFileSync(new URL("../styles/globals/themes.css", import.meta.url), "utf8");
 
 assert.match(vaultSource, /getLocalEncryptedSecret/, "vault resolver can load locally encrypted secrets");
 assert.match(vaultSource, /"encrypted"/, "vault statuses include encrypted local storage");
@@ -26,6 +27,26 @@ assert.match(githubPatRouteSource, /setLocalEncryptedSecret\(PAT_KEY, pat\)/, "G
 assert.doesNotMatch(githubPatRouteSource, /updates\[PAT_KEY\] = pat/, "GitHub PAT setup does not write tokens to .env.local");
 assert.match(panelSource, /Local encrypted/, "Vault panel exposes local encrypted storage as a first-class option");
 assert.match(panelSource, /type="password"/, "Vault panel uses a password input for raw local secrets");
+assert.match(
+  panelSource,
+  /unresolved:\s*\{[^}]*color:\s*"var\(--color-warning\)"[^}]*icon:\s*"ph:warning"/,
+  "Vault unresolved status uses the warning token",
+);
+assert.match(
+  panelSource,
+  /error:\s*\{[^}]*color:\s*"var\(--color-danger\)"/,
+  "Vault error status keeps the danger token",
+);
+assert.match(
+  themesSource,
+  /\.vault-row--warn\s*\{\s*border-color:\s*color-mix\(in oklch,\s*var\(--color-warning\)\s+35%,\s*transparent\);\s*\}/,
+  "Vault warning rows use the warning token",
+);
+assert.match(
+  themesSource,
+  /\.vault-row-error\s*\{[^}]*color:\s*var\(--color-danger\)/,
+  "Vault row errors keep the danger token",
+);
 assert.match(marketplaceConfigureSource, /storage: "encrypted", value: draft/, "Marketplace sensitive config can save raw values through the encrypted vault");
 
 assert.match(

--- a/src/styles/globals/themes.css
+++ b/src/styles/globals/themes.css
@@ -57,7 +57,7 @@
   transition: border-color 0.12s;
 }
 .vault-row:hover { border-color: var(--border-strong); }
-.vault-row--warn { border-color: color-mix(in oklch, var(--color-danger) 35%, transparent); }
+.vault-row--warn { border-color: color-mix(in oklch, var(--color-warning) 35%, transparent); }
 
 .vault-row-main {
   display: flex;


### PR DESCRIPTION
## Summary

Updates Vault caution states to use the semantic orange warning token while keeping actual errors red.

## Why

Bead: `cave-6iflc`

The unresolved status badge and `.vault-row--warn` border were wired to `--color-danger`, so non-error cautions rendered with the same red treatment as failures.

## Changes

- Map the Vault `unresolved` warning badge to `--color-warning`.
- Derive warning-row borders from `--color-warning`.
- Add regression assertions pinning warnings to orange and errors to red.

## Verification

- `node --experimental-strip-types src/lib/vault.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` — 912 app test files passed
- `git diff --check`

## Risk + rollout notes

Low risk: this only changes two semantic token mappings in the Vault surface. Error labels, error copy, critical states, and destructive actions remain on `--color-danger`.