### PR TITLE
feat(settings): redesign About control sheet

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -288,6 +288,7 @@ export const SUITES = {
     "src/lib/app-preferences-runtime.test.ts",
     "src/lib/app-preferences-paint-bootstrap.test.ts",
     "src/components/settings-appearance.test.ts",
+    "src/components/settings-about.test.ts",
     "src/components/settings-github.test.ts",
     "src/components/settings-profile.test.ts",
     "src/components/settings-search.test.ts",

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const src = await readFile(new URL("./open-coven-tools-update.tsx", import.meta.url), "utf8");
-const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const about = await readFile(new URL("./settings-about.tsx", import.meta.url), "utf8");
 const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
 const status = await readFile(new URL("../lib/opencoven-tools-status.ts", import.meta.url), "utf8");
 const statusDisplay = await readFile(new URL("../lib/opencoven-tools-status-display.ts", import.meta.url), "utf8");
@@ -133,8 +133,8 @@ assert.match(status, /const compatible =[\s\S]*packageVerified[\s\S]*!!probe\.ve
 assert.match(status, /const state = openCovenToolState/, "server status derives a truthful explicit state");
 assert.match(status, /state,/, "server status returns the derived state");
 assert.match(status, /verifyOpenCovenToolInstall[\s\S]*refreshCovenSpawnEnv\(\)/, "post-install verification refreshes PATH before probing the selected tool");
-assert.match(settings, /import \{ OpenCovenToolsUpdate \}/, "Settings imports the OpenCoven tools update component");
-assert.match(settings, /<SettingsGroup label="OpenCoven tools">[\s\S]*<OpenCovenToolsUpdate \/>/, "About settings renders the OpenCoven tools group");
+assert.match(about, /import \{ OpenCovenToolsUpdate \}/, "About imports the OpenCoven tools update component");
+assert.match(about, /<OpenCovenToolsUpdate showDiagnosticsAction=\{false\} \/>/, "About renders the live OpenCoven tools control sheet without a duplicate diagnostics action");
 assert.match(runner, /src\/components\/open-coven-tools-update\.test\.ts/, "OpenCoven tools update test is wired into the test:app suite (scripts/run-tests.mjs)");
 assert.match(runner, /src\/lib\/opencoven-tools-state\.test\.ts/, "OpenCoven tool state tests are wired into the test suite");
 assert.match(runner, /src\/lib\/opencoven-tool-verification\.test\.ts/, "post-install verification scenarios are wired into the app test suite");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -326,7 +326,11 @@ export function OpenCovenToolsBannerTrigger() {
   return null;
 }
 
-export function OpenCovenToolsUpdate() {
+export function OpenCovenToolsUpdate({
+  showDiagnosticsAction = true,
+}: {
+  showDiagnosticsAction?: boolean;
+} = {}) {
   const { dismissBanner } = useShellBanners();
   const [tools, setTools] = useState<ToolStatus[]>([]);
   const [checking, setChecking] = useState(true);
@@ -727,27 +731,29 @@ export function OpenCovenToolsUpdate() {
           </p>
         </div>
         <div className="flex shrink-0 flex-wrap items-center gap-2">
-          <Button
-            variant="secondary"
-            size="xs"
-            onClick={() => void copyDiagnostics()}
-            className={`${ghostBtn} cave-fill-btn`}
-            data-state={diagnosticsStatus}
-            aria-live="polite"
-            leadingIcon={
-              diagnosticsStatus === "copied"
-                ? "ph:check-bold"
+          {showDiagnosticsAction ? (
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => void copyDiagnostics()}
+              className={`${ghostBtn} cave-fill-btn`}
+              data-state={diagnosticsStatus}
+              aria-live="polite"
+              leadingIcon={
+                diagnosticsStatus === "copied"
+                  ? "ph:check-bold"
+                  : diagnosticsStatus === "failed"
+                    ? "ph:warning"
+                    : "ph:copy"
+              }
+            >
+              {diagnosticsStatus === "copied"
+                ? "Copied"
                 : diagnosticsStatus === "failed"
-                  ? "ph:warning"
-                  : "ph:copy"
-            }
-          >
-            {diagnosticsStatus === "copied"
-              ? "Copied"
-              : diagnosticsStatus === "failed"
-                ? "Copy failed"
-                : "Copy diagnostics (safe)"}
-          </Button>
+                  ? "Copy failed"
+                  : "Copy diagnostics (safe)"}
+            </Button>
+          ) : null}
           <Button variant="secondary" size="xs" onClick={() => void load(true)} className={ghostBtn} disabled={checking}>
             Check tools
           </Button>

--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import test from "node:test";
+
+const componentUrl = new URL("./settings-about.tsx", import.meta.url);
+const component = existsSync(componentUrl) ? readFileSync(componentUrl, "utf8") : "";
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const cssUrl = new URL("../styles/settings-about.css", import.meta.url);
+const css = existsSync(cssUrl) ? readFileSync(cssUrl, "utf8") : "";
+
+test("Settings delegates the About surface to a focused component", () => {
+  assert.match(shell, /import \{ AboutSection \} from "\.\/settings-about"/);
+  assert.match(shell, /section === "about"\s*&&\s*<AboutSection \/>/);
+  assert.doesNotMatch(shell, /function AboutSection\(/);
+  assert.match(component, /import "@\/styles\/settings-about\.css";/);
+});
+
+test("About ports the Claude Design hero and live control-sheet hierarchy", () => {
+  assert.match(component, /className="settings-about"/);
+  assert.match(component, /className="settings-about-hero"/);
+  assert.match(component, />Settings · About</);
+  assert.match(component, /<h1[^>]*>About<\/h1>/);
+  assert.match(component, /className="settings-about-hero__chips"/);
+  assert.match(component, /Copy diagnostics/);
+  assert.match(component, /updateActionRef/);
+  assert.match(component, /className="settings-about-control-grid"/);
+  assert.match(component, />CovenCave</);
+  assert.match(
+    component,
+    /<SectionRule[\s\S]*?>\s*OpenCoven tools\s*<\/SectionRule>/,
+  );
+  assert.match(component, /<UpdateSettingsRow[\s\S]*actionRef=\{updateActionRef\}/);
+  assert.match(component, /<OpenCovenToolsUpdate showDiagnosticsAction=\{false\} \/>/);
+});
+
+test("About preserves truthful live status and safe diagnostic behavior", () => {
+  assert.match(component, /classifyAboutDaemonStatus/);
+  assert.match(component, /fetch\("\/api\/daemon\/status"/);
+  assert.match(component, /fetch\("\/api\/onboarding\/update"/);
+  assert.match(component, /buildSafeToolDiagnostics/);
+  assert.match(component, /copyText/);
+  assert.match(component, /useAnnouncer/);
+  assert.match(component, /role="status"/);
+  assert.doesNotMatch(component, /\b(?:stable|beta) channel\b/i);
+  assert.doesNotMatch(component, /tailscale.*1password-cli.*piper/s);
+});
+
+test("About ports the handoff link grid with production destinations", () => {
+  assert.match(component, /className="settings-about-elsewhere"/);
+  assert.match(component, />The Coven, elsewhere</);
+  assert.match(component, /https:\/\/github\.com\/OpenCoven\/coven-cave/);
+  assert.match(component, /https:\/\/docs\.opencoven\.ai/);
+  assert.match(component, /https:\/\/x\.com\/OpenCvn/);
+  assert.match(component, /https:\/\/discord\.gg\/opencoven/);
+  assert.match(component, /https:\/\/mind\.opencoven\.ai/);
+  assert.match(component, /https:\/\/pod\.opencoven\.ai/);
+  assert.match(component, /openExternalUrl/);
+  assert.match(component, /git clone https:\/\/github\.com\/OpenCoven\/coven-cave\.git/);
+});
+
+test("About follows the revised handoff artwork and full-width release rail", () => {
+  assert.match(component, /className="settings-about-grimoire-mark"/);
+  assert.match(component, />Open Coven Weekly</);
+  assert.match(component, />Shipping notes, every Friday\.</);
+  assert.match(component, />OCW</);
+  assert.match(
+    css,
+    /\.settings-about-release-card\s*\{[\s\S]*grid-column:\s*1\s*\/\s*-1/,
+  );
+  assert.match(
+    css,
+    /\.settings-about-grimoire-mark\s*\{[\s\S]*position:\s*absolute[\s\S]*top:\s*var\(--space-3\)[\s\S]*right:\s*var\(--space-3\)/,
+  );
+});
+
+test("About CSS follows the token, focus, motion, and narrow-pane contracts", () => {
+  assert.match(css, /\.settings-about\s*\{[\s\S]*container-type:\s*inline-size/);
+  assert.match(css, /\.settings-about-control-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(2/);
+  assert.match(css, /\.settings-about-links-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(4/);
+  assert.match(css, /@container settings-about/);
+  assert.match(css, /@media \(prefers-reduced-motion:\s*reduce\)/);
+  assert.match(css, /var\(--accent-presence\)/);
+  assert.match(css, /var\(--border-hairline\)/);
+  assert.match(css, /var\(--font-serif\)/);
+  assert.match(css, /var\(--font-mono\)/);
+  assert.doesNotMatch(css, /#[0-9a-f]{3,8}\b/i);
+});

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -1,0 +1,649 @@
+"use client";
+
+import "@/styles/settings-about.css";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { OpenCovenToolsUpdate } from "@/components/open-coven-tools-update";
+import {
+  UpdateSettingsRow,
+  type UpdateSettingsActionHandle,
+} from "@/components/update-available";
+import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { settingsGroupId } from "@/components/ui/settings-group";
+import {
+  buildSafeToolDiagnostics,
+  sanitizeAboutDiagnosticText,
+} from "@/lib/about-diagnostics";
+import {
+  classifyAboutDaemonStatus,
+  type AboutDaemonState,
+} from "@/lib/about-status";
+import { APP_VERSION } from "@/lib/app-version";
+import { copyText } from "@/lib/clipboard";
+import { Icon, type IconName } from "@/lib/icon";
+import { openExternalUrl } from "@/lib/open-external";
+import type { OpenCovenToolStatus } from "@/lib/opencoven-tools-status";
+import { relativeTime } from "@/lib/relative-time";
+
+const STACK = ["Next.js", "React", "Tauri", "Tailwind"] as const;
+const SIDECAR_TOKEN_STORAGE_KEY = "coven-cave:sidecar-auth-token";
+const CLONE_COMMAND = "git clone https://github.com/OpenCoven/coven-cave.git";
+
+type ToolSnapshot = {
+  tools: OpenCovenToolStatus[];
+  checking: boolean;
+  checkedAt: string | null;
+  error: string | null;
+};
+
+type LinkCard = {
+  label: string;
+  hint: string;
+  href: string;
+  icon: IconName;
+};
+
+const SMALL_LINKS: LinkCard[] = [
+  {
+    label: "Docs",
+    hint: "docs.opencoven.ai",
+    href: "https://docs.opencoven.ai",
+    icon: "ph:file-text",
+  },
+  {
+    label: "X",
+    hint: "@OpenCvn",
+    href: "https://x.com/OpenCvn",
+    icon: "ph:x-logo-bold",
+  },
+  {
+    label: "Discord",
+    hint: "the coven hall",
+    href: "https://discord.gg/opencoven",
+    icon: "ph:discord-logo",
+  },
+];
+
+function daemonPresentation(state: AboutDaemonState): {
+  label: string;
+  detail: string;
+  tone: "success" | "warning" | "danger" | "muted";
+} {
+  if (state.kind === "running") {
+    return {
+      label: state.version ? `daemon v${state.version}` : "daemon running",
+      detail: state.version ? `Running v${state.version}` : "Running (version unavailable)",
+      tone: "success",
+    };
+  }
+  if (state.kind === "stopped") {
+    return { label: "daemon stopped", detail: "Stopped", tone: "warning" };
+  }
+  if (state.kind === "unreachable") {
+    return { label: "daemon unreachable", detail: "Unreachable", tone: "danger" };
+  }
+  if (state.kind === "failed-to-check") {
+    return { label: "daemon unknown", detail: "Failed to check", tone: "danger" };
+  }
+  return { label: "checking daemon", detail: "Checking…", tone: "muted" };
+}
+
+function safeDaemonDiagnostics(state: AboutDaemonState) {
+  if (state.kind === "checking") return { state: "checking" };
+  if (state.kind === "running") {
+    return {
+      state: "running",
+      version: state.version,
+      checkedAt: state.checkedAt,
+    };
+  }
+  return {
+    state: state.kind,
+    checkedAt: state.checkedAt,
+    reason: state.reason ? sanitizeAboutDiagnosticText(state.reason) : null,
+  };
+}
+
+function sidecarTokenPresent(): boolean {
+  try {
+    return Boolean(window.sessionStorage.getItem(SIDECAR_TOKEN_STORAGE_KEY));
+  } catch {
+    return false;
+  }
+}
+
+function AboutDaemonStatusRow({
+  state,
+  onRefresh,
+}: {
+  state: AboutDaemonState;
+  onRefresh: () => void;
+}) {
+  const presentation = daemonPresentation(state);
+  const reason =
+    state.kind === "checking" || state.kind === "running" ? null : state.reason;
+  const checkedAt = state.kind === "checking" ? null : state.checkedAt;
+
+  return (
+    <div className="settings-about-row settings-about-daemon-row">
+      <span className="settings-about-row__label">Daemon</span>
+      <div className="settings-about-row__value">
+        <span
+          className={`settings-about-status settings-about-status--${presentation.tone}`}
+          title={reason ?? checkedAt ?? undefined}
+        >
+          <span className="settings-about-status__dot" aria-hidden="true" />
+          {presentation.detail}
+          {checkedAt ? ` · checked ${relativeTime(checkedAt)}` : ""}
+        </span>
+        <Button
+          variant="secondary"
+          size="xs"
+          onClick={onRefresh}
+          disabled={state.kind === "checking"}
+          className="settings-tool-action"
+        >
+          {state.kind === "checking" ? "Checking…" : "Retry"}
+        </Button>
+      </div>
+      {reason ? <p className="settings-about-row__reason">{reason}</p> : null}
+    </div>
+  );
+}
+
+function SectionRule({
+  children,
+  aside,
+}: {
+  children: string;
+  aside?: string;
+}) {
+  return (
+    <div className="settings-about-rule">
+      <h2>{children}</h2>
+      {aside ? <span>{aside}</span> : null}
+      <i aria-hidden="true" />
+    </div>
+  );
+}
+
+function ElsewhereCard({
+  card,
+}: {
+  card: LinkCard;
+}) {
+  return (
+    <Button
+      variant="ghost"
+      className="settings-about-link-card settings-about-link-card--small focus-ring"
+      onClick={() => openExternalUrl(card.href)}
+      aria-label={`Open ${card.label}`}
+    >
+      <span className="settings-about-link-card__glyph" aria-hidden="true">
+        <Icon name={card.icon} width={16} />
+      </span>
+      <span className="settings-about-link-card__copy">
+        <strong>{card.label}</strong>
+        <small>{card.hint}</small>
+      </span>
+    </Button>
+  );
+}
+
+export function AboutSection() {
+  const { announce } = useAnnouncer();
+  const updateActionRef = useRef<UpdateSettingsActionHandle>(null);
+  const daemonRequestRef = useRef<AbortController | null>(null);
+  const diagnosticsRequestRef = useRef<AbortController | null>(null);
+  const diagnosticsResetRef = useRef<number | null>(null);
+  const [daemonState, setDaemonState] = useState<AboutDaemonState>({
+    kind: "checking",
+  });
+  const [toolSnapshot, setToolSnapshot] = useState<ToolSnapshot>({
+    tools: [],
+    checking: true,
+    checkedAt: null,
+    error: null,
+  });
+  const toolSnapshotRef = useRef(toolSnapshot);
+  const [diagnosticsStatus, setDiagnosticsStatus] = useState<
+    "idle" | "copying" | "copied" | "failed"
+  >("idle");
+  const [sigilPokes, setSigilPokes] = useState(0);
+  const sigilOpen = sigilPokes >= 5;
+
+  const refreshDaemon = useCallback(() => {
+    daemonRequestRef.current?.abort();
+    const controller = new AbortController();
+    daemonRequestRef.current = controller;
+    setDaemonState({ kind: "checking" });
+    void fetch("/api/daemon/status", {
+      cache: "no-store",
+      signal: controller.signal,
+    })
+      .then(async (response) => {
+        const payload = await response.json().catch(() => null);
+        if (controller.signal.aborted) return;
+        setDaemonState(
+          classifyAboutDaemonStatus({
+            responseOk: response.ok,
+            payload,
+            checkedAt: new Date().toISOString(),
+          }),
+        );
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setDaemonState(
+          classifyAboutDaemonStatus({
+            responseOk: false,
+            payload: null,
+            checkedAt: new Date().toISOString(),
+            error:
+              error instanceof Error ? error.message : "status request failed",
+          }),
+        );
+      });
+  }, []);
+
+  const loadToolSnapshot = useCallback(
+    async (
+      force = false,
+      signal?: AbortSignal,
+    ): Promise<ToolSnapshot | null> => {
+      const checkingSnapshot: ToolSnapshot = {
+        ...toolSnapshotRef.current,
+        checking: true,
+        error: force ? toolSnapshotRef.current.error : null,
+      };
+      toolSnapshotRef.current = checkingSnapshot;
+      setToolSnapshot(checkingSnapshot);
+      try {
+        const response = await fetch("/api/onboarding/update", {
+          method: force ? "POST" : "GET",
+          cache: "no-store",
+          signal,
+        });
+        const payload = (await response.json()) as {
+          ok?: boolean;
+          tools?: OpenCovenToolStatus[];
+          checkedAt?: string | null;
+          error?: string | null;
+        };
+        if (!response.ok || payload.ok === false) {
+          throw new Error(payload.error ?? "tool check failed");
+        }
+        const next: ToolSnapshot = {
+          tools: Array.isArray(payload.tools) ? payload.tools : [],
+          checking: false,
+          checkedAt:
+            payload.checkedAt ??
+            (Array.isArray(payload.tools) ? payload.tools[0]?.checkedAt : null) ??
+            null,
+          error: payload.error ?? null,
+        };
+        if (!signal?.aborted) {
+          toolSnapshotRef.current = next;
+          setToolSnapshot(next);
+        }
+        return next;
+      } catch (error) {
+        if (signal?.aborted) return null;
+        const message =
+          error instanceof Error ? error.message : "tool check failed";
+        const failedSnapshot: ToolSnapshot = {
+          ...toolSnapshotRef.current,
+          checking: false,
+          error: message,
+        };
+        toolSnapshotRef.current = failedSnapshot;
+        setToolSnapshot(failedSnapshot);
+        return failedSnapshot;
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    refreshDaemon();
+    const controller = new AbortController();
+    void loadToolSnapshot(false, controller.signal);
+    return () => {
+      controller.abort();
+      daemonRequestRef.current?.abort();
+      diagnosticsRequestRef.current?.abort();
+      if (diagnosticsResetRef.current !== null) {
+        window.clearTimeout(diagnosticsResetRef.current);
+      }
+    };
+  }, [loadToolSnapshot, refreshDaemon]);
+
+  const handleCopyDiagnostics = useCallback(async () => {
+    if (diagnosticsStatus === "copying") return;
+    setDiagnosticsStatus("copying");
+    diagnosticsRequestRef.current?.abort();
+    const controller = new AbortController();
+    diagnosticsRequestRef.current = controller;
+    const refreshed = await loadToolSnapshot(false, controller.signal);
+    if (controller.signal.aborted) return;
+    const snapshot = refreshed ?? toolSnapshot;
+    const safeToolDiagnostics = JSON.parse(
+      buildSafeToolDiagnostics({
+        tools: snapshot.tools,
+        checking: snapshot.checking,
+        error: snapshot.error,
+        lastSuccessfulCheckedAt: snapshot.checkedAt,
+        installJobs: {},
+        installResults: {},
+        href: window.location.href,
+        sidecarTokenPresent: sidecarTokenPresent(),
+        tauriInternalsPresent: "__TAURI_INTERNALS__" in window,
+      }),
+    ) as Record<string, unknown>;
+    const text = JSON.stringify(
+      {
+        ...safeToolDiagnostics,
+        application: {
+          name: "CovenCave",
+          version: APP_VERSION,
+          builtWith: STACK,
+        },
+        daemon: safeDaemonDiagnostics(daemonState),
+      },
+      null,
+      2,
+    );
+    const copied = await copyText(text);
+    setDiagnosticsStatus(copied ? "copied" : "failed");
+    announce(
+      copied
+        ? "Safe About diagnostics copied."
+        : "About diagnostics could not be copied.",
+    );
+    if (diagnosticsResetRef.current !== null) {
+      window.clearTimeout(diagnosticsResetRef.current);
+    }
+    diagnosticsResetRef.current = window.setTimeout(
+      () => setDiagnosticsStatus("idle"),
+      1800,
+    );
+  }, [
+    announce,
+    daemonState,
+    diagnosticsStatus,
+    loadToolSnapshot,
+    toolSnapshot,
+  ]);
+
+  const pokeSigil = () => {
+    const next = Math.min(sigilPokes + 1, 5);
+    setSigilPokes(next);
+    if (next === 5 && sigilPokes < 5) {
+      announce("The sigil yields its build marks.");
+    }
+  };
+
+  const daemon = daemonPresentation(daemonState);
+  const readyTools = toolSnapshot.tools.filter(
+    (tool) =>
+      tool.installed &&
+      tool.compatible &&
+      tool.packageVerified &&
+      tool.executableVerified,
+  ).length;
+  const toolsChip =
+    toolSnapshot.checking && toolSnapshot.tools.length === 0
+      ? "checking tools"
+      : toolSnapshot.error && toolSnapshot.tools.length === 0
+        ? "tools unavailable"
+        : `${readyTools}/${toolSnapshot.tools.length} tools ready`;
+  const toolsTone =
+    toolSnapshot.error || readyTools < toolSnapshot.tools.length
+      ? "warning"
+      : "success";
+  const diagnosticsLabel =
+    diagnosticsStatus === "copied"
+      ? "Copied"
+      : diagnosticsStatus === "failed"
+        ? "Copy failed"
+        : "Copy diagnostics";
+
+  return (
+    <section
+      className="settings-about"
+      aria-labelledby="settings-about-title"
+    >
+      <header className="settings-about-hero">
+        <Button
+          variant="ghost"
+          className="settings-about-sigil focus-ring"
+          onClick={pokeSigil}
+          data-pokes={sigilPokes}
+          aria-expanded={sigilOpen}
+          aria-controls="settings-about-build-sigil"
+          title="Poke the sigil"
+        >
+          <Icon name="ph:sparkle" width={20} aria-hidden />
+          <span className="sr-only">Poke the sigil</span>
+        </Button>
+        <div className="settings-about-hero__identity">
+          <p className="settings-about-hero__kicker">Settings · About</p>
+          <h1 id="settings-about-title">About</h1>
+          <div className="settings-about-hero__chips">
+            <span className="settings-about-chip">
+              <i aria-hidden="true" />
+              v{APP_VERSION}
+            </span>
+            <span
+              className={`settings-about-chip settings-about-chip--${daemon.tone}`}
+            >
+              <i aria-hidden="true" />
+              {daemon.label}
+            </span>
+            <span
+              className={`settings-about-chip settings-about-chip--${toolsTone}`}
+            >
+              <i aria-hidden="true" />
+              {toolsChip}
+            </span>
+          </div>
+        </div>
+        <div className="settings-about-hero__actions">
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon={
+              diagnosticsStatus === "copied"
+                ? "ph:check-bold"
+                : diagnosticsStatus === "failed"
+                  ? "ph:warning"
+                  : "ph:copy"
+            }
+            loading={diagnosticsStatus === "copying"}
+            onClick={() => void handleCopyDiagnostics()}
+          >
+            {diagnosticsLabel}
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            leadingIcon="ph:arrow-clockwise-bold"
+            onClick={() => {
+              updateActionRef.current?.check();
+              announce("Checking for Cave updates.");
+            }}
+          >
+            Check for updates
+          </Button>
+        </div>
+      </header>
+
+      <div className="settings-about-control-grid">
+        <div
+          id={settingsGroupId("CovenCave")}
+          data-settings-group
+          className="settings-about-control"
+        >
+          <SectionRule aside="This build">CovenCave</SectionRule>
+          <div className="settings-about-sheet">
+            <div className="settings-about-row">
+              <span className="settings-about-row__label">App version</span>
+              <code className="settings-about-row__code">v{APP_VERSION}</code>
+            </div>
+            <UpdateSettingsRow actionRef={updateActionRef} />
+            <AboutDaemonStatusRow
+              state={daemonState}
+              onRefresh={refreshDaemon}
+            />
+            <div className="settings-about-row settings-about-row--stack">
+              <span className="settings-about-row__label">Built with</span>
+              <span className="settings-about-stack">
+                {STACK.map((item) => (
+                  <span key={item}>{item}</span>
+                ))}
+              </span>
+            </div>
+            {sigilOpen ? (
+              <div
+                id="settings-about-build-sigil"
+                className="settings-about-build-sigil"
+                role="status"
+              >
+                <strong>Build sigil</strong>
+                <span>
+                  CovenCave v{APP_VERSION} · {STACK.join(" + ")}
+                </span>
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        <div
+          id={settingsGroupId("OpenCoven tools")}
+          data-settings-group
+          className="settings-about-control"
+        >
+          <SectionRule
+            aside={
+              toolSnapshot.checking
+                ? "Checking"
+                : toolSnapshot.error
+                  ? "Check incomplete"
+                  : `${readyTools} ready`
+            }
+          >
+            OpenCoven tools
+          </SectionRule>
+          <div className="settings-about-sheet settings-about-tools">
+            <OpenCovenToolsUpdate showDiagnosticsAction={false} />
+          </div>
+        </div>
+      </div>
+
+      <div
+        id={settingsGroupId("Links")}
+        data-settings-group
+        className="settings-about-elsewhere"
+      >
+        <SectionRule aside="6 places">The Coven, elsewhere</SectionRule>
+        <div className="settings-about-links-grid">
+          <Button
+            variant="ghost"
+            className="settings-about-link-card settings-about-link-card--grimoire focus-ring"
+            onClick={() => openExternalUrl("https://mind.opencoven.ai")}
+            aria-label="Open the Grimoire"
+          >
+            <span className="settings-about-grimoire-art" aria-hidden="true">
+              <span className="settings-about-grimoire-mark">
+                <Icon name="ph:book-open" width={24} />
+              </span>
+            </span>
+            <span className="settings-about-link-card__copy">
+              <small>Grimoire</small>
+              <strong>The shared knowledge base</strong>
+              <span>
+                Every familiar reads from it. Pages bind from chat, and
+                citations survive the session.
+              </span>
+            </span>
+          </Button>
+
+          <Button
+            variant="ghost"
+            className="settings-about-link-card settings-about-link-card--github focus-ring"
+            onClick={() =>
+              openExternalUrl("https://github.com/OpenCoven/coven-cave")
+            }
+            aria-label="Open CovenCave on GitHub"
+          >
+            <span className="settings-about-link-card__heading">
+              <Icon name="ph:github-logo" width={16} aria-hidden />
+              <strong>GitHub</strong>
+              <small>source · issues</small>
+            </span>
+            <code>{CLONE_COMMAND}</code>
+          </Button>
+
+          {SMALL_LINKS.map((card) => (
+            <ElsewhereCard key={card.href} card={card} />
+          ))}
+
+          <Button
+            variant="ghost"
+            className="settings-about-link-card settings-about-link-card--podcast focus-ring"
+            onClick={() => openExternalUrl("https://pod.opencoven.ai")}
+            aria-label="Listen to the OpenCoven podcast"
+          >
+            <span className="settings-about-podcast-art" aria-hidden="true">
+              <Icon name="ph:waveform-bold" width={24} />
+              <small>OCW</small>
+            </span>
+            <span className="settings-about-link-card__copy">
+              <small>Podcast</small>
+              <strong>Open Coven Weekly</strong>
+              <span>Shipping notes, every Friday.</span>
+            </span>
+            <span className="settings-about-link-card__action">Listen</span>
+          </Button>
+
+          <div className="settings-about-release-card">
+            <div>
+              <small>Release notes · v{APP_VERSION}</small>
+              <strong>What changed in this Cave</strong>
+            </div>
+            <ul>
+              <li>Features and fixes</li>
+              <li>Signed desktop installers</li>
+              <li>Upgrade guidance</li>
+            </ul>
+            <Button
+              variant="secondary"
+              size="xs"
+              trailingIcon="ph:arrow-square-out"
+              onClick={() =>
+                openExternalUrl(
+                  "https://github.com/OpenCoven/coven-cave/releases/latest",
+                )
+              }
+            >
+              View latest release
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      <p
+        className="settings-about-copy-status sr-only"
+        role="status"
+        aria-live="polite"
+      >
+        {diagnosticsStatus === "copied"
+          ? "Safe diagnostics copied."
+          : diagnosticsStatus === "failed"
+            ? "Diagnostics could not be copied."
+            : ""}
+      </p>
+    </section>
+  );
+}

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -6,6 +6,10 @@ const settings = await readFile(
   new URL("./settings-shell.tsx", import.meta.url),
   "utf8",
 );
+const about = await readFile(
+  new URL("./settings-about.tsx", import.meta.url),
+  "utf8",
+);
 const themeBootScript = await readFile(
   new URL("../../public/scripts/theme-init.js", import.meta.url),
   "utf8",
@@ -144,20 +148,20 @@ assert.match(
 );
 
 assert.match(
-  settings,
+  about,
   /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
   "About settings must import the shared app version source",
 );
 
 assert.match(
-  settings,
-  /<SettingsKV label="App version" value=\{APP_VERSION\} \/>/,
+  about,
+  /settings-about-row__label">App version<[\s\S]*v\{APP_VERSION\}/,
   "About settings must render the shared app version instead of a literal",
 );
 
 assert.doesNotMatch(
-  settings,
-  /<SettingsKV label="App version" value="[\d.]+"/,
+  about,
+  /settings-about-row__label">App version<[\s\S]{0,180}>\s*v?[\d.]+\s*</,
   "About settings must not hardcode an app version literal",
 );
 

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -45,6 +45,7 @@ test("the overview header renders mark, kicker, title, description, and the stri
 
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const profile = readFileSync(new URL("./settings-profile.tsx", import.meta.url), "utf8");
+const about = readFileSync(new URL("./settings-about.tsx", import.meta.url), "utf8");
 
 test("the shell sources sections from settings-sections and renders the overview", () => {
   assert.match(shell, /import \{ SettingsOverview \} from "\.\/settings-overview"/);
@@ -58,9 +59,14 @@ test("the shell sources sections from settings-sections and renders the overview
   assert.doesNotMatch(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
   // Each SettingsPage-based section opts into its overview header.
   assert.match(profile, /section="profile"/, "profile page passes its section from the split panel");
-  for (const id of ["general", "daemon", "mobile", "appearance", "about"]) {
+  for (const id of ["general", "daemon", "mobile", "appearance"]) {
     assert.match(shell, new RegExp(`section="${id}"`), `${id} page passes its section`);
   }
+  assert.match(
+    about,
+    /aria-labelledby="settings-about-title"[\s\S]*<h1 id="settings-about-title">About<\/h1>/,
+    "About replaces the generic overview with its accessible handoff hero",
+  );
   assert.doesNotMatch(shell, /section="addons"|AddonsSection|Add-ons/, "Add-ons is not a settings section");
 });
 

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -14,8 +14,20 @@ const globals = readFileSync(
   new URL("../app/globals.css", import.meta.url),
   "utf8",
 );
+const shellResponsiveCss = readFileSync(
+  new URL("../styles/globals/shell-responsive.css", import.meta.url),
+  "utf8",
+);
 const dashboardCssUrl = new URL("../styles/dashboard.css", import.meta.url);
 const dashboardCss = existsSync(dashboardCssUrl) ? readFileSync(dashboardCssUrl, "utf8") : "";
+const aboutSource = readFileSync(
+  new URL("./settings-about.tsx", import.meta.url),
+  "utf8",
+);
+const aboutCss = readFileSync(
+  new URL("../styles/settings-about.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(
   source,
@@ -63,7 +75,7 @@ assert.match(
   "Settings back control should expose a mobile hit-area hook",
 );
 assert.match(
-  globals,
+  shellResponsiveCss,
   /@media \(max-width: 767px\) \{[\s\S]*\.settings-back-button\s*\{[\s\S]*min-height:\s*var\(--touch-target\)/,
   "Settings mobile back control should meet the shared touch target",
 );
@@ -147,9 +159,14 @@ assert.match(
   "Mobile setup guide link should use the shared Settings action touch target",
 );
 assert.match(
-  source,
-  /className="settings-touch-action[\s\S]*\{l\.label\}/,
-  "About external links should use the shared Settings action touch target",
+  aboutSource,
+  /settings-about-link-card[\s\S]*focus-ring/,
+  "About external cards should keep the shared keyboard focus treatment",
+);
+assert.match(
+  aboutCss,
+  /@media \(hover: none\) and \(pointer: coarse\)[\s\S]*\.settings-about-link-card[\s\S]*min-height:\s*var\(--touch-target\)/,
+  "About external cards should meet the shared touch-target floor on coarse pointers",
 );
 // Settings section nav exposes the active section to assistive tech.
 assert.match(

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -22,15 +22,11 @@ import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
 import { PairingStepsList } from "@/components/pairing-steps-list";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
-import { OpenCovenToolsUpdate } from "@/components/open-coven-tools-update";
 import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-palettes";
 import type { Mode, ModePref } from "@/lib/theme-storage";
 import { ModeToggle } from "@/components/mode-toggle";
 import { FamiliarStudioProvider, useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
 import { FamiliarSummoningCircle } from "@/components/familiar-summoning-circle";
-import { APP_VERSION } from "@/lib/app-version";
-import { UpdateSettingsRow } from "@/components/update-available";
-import { classifyAboutDaemonStatus, type AboutDaemonState } from "@/lib/about-status";
 import { useIsMobile } from "@/lib/use-viewport";
 import { useCelebrationsEnabled, writeCelebrationsEnabled } from "@/lib/celebrations-pref";
 import {
@@ -52,6 +48,7 @@ import { ProfileSection } from "./settings-profile";
 import { GithubSection } from "./settings-github";
 import { AccessGroupsSection } from "./access-groups-section";
 import { SettingsOverview } from "./settings-overview";
+import { AboutSection } from "./settings-about";
 import {
   SECTIONS,
   SETTINGS_INDEX,
@@ -3554,123 +3551,6 @@ function MobileSection({ onUseAsHub }: { onUseAsHub: (url: string) => void }) {
             Being on your Tailscale network <em>is</em> the credential. The desktop only serves the mobile API over the
             tailnet — encrypted and private — so nothing is exposed to the public internet, and there’s no token to copy.
           </p>
-        </div>
-      </SettingsGroup>
-    </SettingsPage>
-  );
-}
-
-// ─── Section: About ───────────────────────────────────────────────────────────
-
-function AboutDaemonStatusRow() {
-  const [state, setState] = useState<AboutDaemonState>({ kind: "checking" });
-  const requestRef = useRef<AbortController | null>(null);
-
-  const refresh = useCallback(() => {
-    requestRef.current?.abort();
-    const controller = new AbortController();
-    requestRef.current = controller;
-    setState({ kind: "checking" });
-    void fetch("/api/daemon/status", { cache: "no-store", signal: controller.signal })
-      .then(async (response) => {
-        const payload = await response.json().catch(() => null);
-        if (controller.signal.aborted) return;
-        setState(classifyAboutDaemonStatus({
-          responseOk: response.ok,
-          payload,
-          checkedAt: new Date().toISOString(),
-        }));
-      })
-      .catch((error) => {
-        if (controller.signal.aborted) return;
-        setState(classifyAboutDaemonStatus({
-          responseOk: false,
-          payload: null,
-          checkedAt: new Date().toISOString(),
-          error: error instanceof Error ? error.message : "status request failed",
-        }));
-      });
-  }, []);
-
-  useEffect(() => {
-    refresh();
-    return () => requestRef.current?.abort();
-  }, [refresh]);
-
-  const detail =
-    state.kind === "running"
-      ? state.version ? `Running v${state.version}` : "Running (version unavailable)"
-      : state.kind === "stopped"
-        ? "Stopped"
-        : state.kind === "unreachable"
-          ? "Unreachable"
-          : state.kind === "failed-to-check"
-            ? "Failed to check"
-            : "Checking…";
-  const reason = state.kind === "checking" || state.kind === "running" ? null : state.reason;
-  const checkedAt = state.kind === "checking" ? null : state.checkedAt;
-  const tone =
-    state.kind === "running"
-      ? "text-[var(--color-success)]"
-      : state.kind === "checking"
-        ? "text-[var(--text-muted)]"
-        : state.kind === "stopped"
-          ? "text-[var(--color-warning)]"
-          : "text-[var(--color-danger)]";
-
-  return (
-    <div className="flex flex-wrap items-center justify-between gap-2 px-4 py-3">
-      <span className="text-[length:var(--text-sm)] text-[var(--text-secondary)]">Daemon</span>
-      <div className="flex min-w-0 items-center gap-2">
-        <span className={`truncate text-right text-[length:var(--text-sm)] ${tone}`} title={reason ?? checkedAt ?? undefined}>
-          {detail}{checkedAt ? ` · checked ${relativeTime(checkedAt)}` : ""}
-        </span>
-        <Button variant="secondary" size="xs" onClick={refresh} disabled={state.kind === "checking"}>
-          {state.kind === "checking" ? "Checking…" : "Retry"}
-        </Button>
-      </div>
-      {reason ? (
-        <p className="basis-full text-right text-[length:var(--text-xs)] text-[var(--text-muted)]">
-          {reason}
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-function AboutSection() {
-  return (
-    <SettingsPage section="about" title="About" description="Version and build information.">
-      <SettingsGroup label="CovenCave">
-        <SettingsKV label="App version" value={APP_VERSION} />
-        <UpdateSettingsRow />
-        <AboutDaemonStatusRow />
-        <SettingsKV label="Built with" value="Next.js · React · Tauri · Tailwind" />
-      </SettingsGroup>
-      <SettingsGroup label="OpenCoven tools">
-        <OpenCovenToolsUpdate />
-      </SettingsGroup>
-      <SettingsGroup label="Links">
-        <div className="flex flex-wrap gap-2 px-4 py-3">
-          {[
-            { label: "GitHub",   href: "https://github.com/OpenCoven/coven-cave", icon: "ph:github-logo" as const },
-            { label: "Docs",     href: "https://docs.opencoven.ai",               icon: "ph:file-text" as const },
-            { label: "X",        href: "https://x.com/OpenCvn",                   icon: "ph:x-logo-bold" as const },
-            { label: "Discord",  href: "https://discord.gg/opencoven",            icon: "ph:discord-logo" as const },
-            { label: "Grimoire", href: "https://mind.opencoven.ai",               icon: "ph:book-open" as const },
-            { label: "Podcast",  href: "https://pod.opencoven.ai",                icon: "ph:waveform-bold" as const },
-          ].map((l) => (
-            <Button
-              key={l.href}
-              variant="secondary"
-              size="xs"
-              className="settings-touch-action settings-tool-action gap-1.5 px-2.5 text-[length:var(--text-xs)]"
-              onClick={() => openExternalUrl(l.href)}
-              leadingIcon={l.icon}
-            >
-              {l.label}
-            </Button>
-          ))}
         </div>
       </SettingsGroup>
     </SettingsPage>

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -554,7 +554,7 @@ export function UpdateSettingsRow({
     });
   }, []);
 
-  useImperativeHandle(actionRef ?? null, () => ({ check }), [check]);
+  useImperativeHandle(actionRef, () => ({ check }), [check]);
 
   useEffect(() => {
     mounted.current = true;

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  useState,
+  type ReactNode,
+  type Ref,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { isTauri, useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useShellBanners } from "@/lib/shell-banners";
@@ -501,11 +509,19 @@ type LastKnownUpdate =
   | { kind: "current"; checkedAt: string }
   | { kind: "available"; version: string; checkedAt: string };
 
+export type UpdateSettingsActionHandle = {
+  check: () => void;
+};
+
 /**
  * Settings ▸ About row. Desktop uses the signed native updater when available;
  * the web surface truthfully renders the same release-route fallback state.
  */
-export function UpdateSettingsRow() {
+export function UpdateSettingsRow({
+  actionRef,
+}: {
+  actionRef?: Ref<UpdateSettingsActionHandle>;
+} = {}) {
   const [state, setState] = useState<RowState>({ phase: "checking" });
   const mounted = useRef(true);
   const activeCancellation = useRef<CancellationSignal | null>(null);
@@ -537,6 +553,8 @@ export function UpdateSettingsRow() {
       }
     });
   }, []);
+
+  useImperativeHandle(actionRef ?? null, () => ({ check }), [check]);
 
   useEffect(() => {
     mounted.current = true;
@@ -807,7 +825,7 @@ export function UpdateSettingsRow() {
   }
 
   return (
-    <div className="flex items-center justify-between gap-4 px-4 py-3">
+    <div className="settings-about-update-row flex items-center justify-between gap-4 px-4 py-3">
       <span className="text-[length:var(--text-sm)] text-[var(--text-secondary)]">Updates</span>
       <div className="flex items-center gap-2">{control}</div>
     </div>

--- a/src/lib/open-external.test.ts
+++ b/src/lib/open-external.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const helper = await readFile(new URL("./open-external.ts", import.meta.url), "utf8");
-const settings = await readFile(new URL("../components/settings-shell.tsx", import.meta.url), "utf8");
+const about = await readFile(new URL("../components/settings-about.tsx", import.meta.url), "utf8");
 
 assert.match(
   helper,
@@ -42,9 +42,9 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  settings,
+  about,
   /import \{ openExternalUrl \} from "@\/lib\/open-external"/,
-  "Settings should use the shared in-app browser URL helper",
+  "About should use the shared in-app browser URL helper",
 );
 for (const [label, href] of [
   ["GitHub", "https://github.com/OpenCoven/coven-cave"],
@@ -55,19 +55,20 @@ for (const [label, href] of [
   ["Podcast", "https://pod.opencoven.ai"],
 ]) {
   const escapedHref = href.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  assert.match(
-    settings,
-    new RegExp(`label: "${label}"[\\s\\S]{0,80}href: "${escapedHref}"`),
-    `${label} routes to its exact Settings destination`,
-  );
+  assert.match(about, new RegExp(escapedHref), `${label} keeps its exact Settings destination`);
 }
 assert.match(
-  settings,
-  /\]\.map\(\(l\) => \([\s\S]{0,300}onClick=\{\(\) => openExternalUrl\(l\.href\)\}/,
-  "every Settings link routes through the acknowledged in-app Browser handoff",
+  about,
+  /onClick=\{\(\) => openExternalUrl\(card\.href\)\}/,
+  "mapped Settings links route through the acknowledged in-app Browser handoff",
+);
+assert.match(
+  about,
+  /onClick=\{\(\) =>\s*openExternalUrl\("https:\/\/mind\.opencoven\.ai"\)\s*\}/,
+  "featured Settings links route through the acknowledged in-app Browser handoff",
 );
 assert.doesNotMatch(
-  settings,
+  about,
   /target="_blank"/,
   "Settings links should not bypass the app with new external tabs",
 );

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -1,0 +1,739 @@
+.settings-about {
+  container-name: settings-about;
+  container-type: inline-size;
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.settings-about-hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  overflow: hidden;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background:
+    linear-gradient(
+      110deg,
+      color-mix(in oklch, var(--accent-presence) 10%, transparent),
+      transparent 34%
+    ),
+    var(--bg-panel);
+}
+
+.settings-about-hero::after {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--space-1);
+  background: var(--accent-presence);
+  content: "";
+  opacity: 0.72;
+}
+
+.settings-about .settings-about-sigil {
+  width: var(--space-10);
+  height: var(--space-10);
+  flex: none;
+  padding: 0;
+  border: 1px solid
+    color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(
+    in oklch,
+    var(--accent-presence) 14%,
+    transparent
+  );
+  color: var(--accent-presence);
+  transition:
+    transform var(--duration-base) var(--ease-emphasized),
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.settings-about .settings-about-sigil:hover {
+  border-color: color-mix(
+    in oklch,
+    var(--accent-presence) 54%,
+    transparent
+  );
+  background: color-mix(
+    in oklch,
+    var(--accent-presence) 20%,
+    transparent
+  );
+}
+
+.settings-about-sigil[data-pokes="1"] {
+  transform: rotate(8deg);
+}
+
+.settings-about-sigil[data-pokes="2"] {
+  transform: rotate(16deg);
+}
+
+.settings-about-sigil[data-pokes="3"] {
+  transform: rotate(24deg);
+}
+
+.settings-about-sigil[data-pokes="4"] {
+  transform: rotate(32deg);
+}
+
+.settings-about-sigil[data-pokes="5"] {
+  transform: rotate(40deg);
+}
+
+.settings-about-hero__identity {
+  min-width: 0;
+  flex: 1 1 15rem;
+}
+
+.settings-about-hero__kicker,
+.settings-about-rule h2,
+.settings-about-rule > span,
+.settings-about-link-card small,
+.settings-about-release-card small,
+.settings-about-build-sigil strong {
+  font-family: var(--font-mono);
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-eyebrow);
+}
+
+.settings-about-hero__kicker {
+  margin: 0 0 var(--space-2);
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.settings-about-hero h1 {
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-serif);
+  font-size: var(--text-display);
+  font-weight: 500;
+  letter-spacing: var(--tracking-tight);
+  line-height: var(--leading-tight);
+}
+
+.settings-about-hero__chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.settings-about-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.settings-about-chip i,
+.settings-about-status__dot {
+  width: var(--space-1);
+  height: var(--space-1);
+  flex: none;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+}
+
+.settings-about-chip--success i {
+  background: var(--color-success);
+}
+
+.settings-about-chip--warning i {
+  background: var(--color-warning);
+}
+
+.settings-about-chip--danger i {
+  background: var(--color-danger);
+}
+
+.settings-about-chip--muted i {
+  background: var(--text-muted);
+}
+
+.settings-about-hero__actions {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.settings-about-control-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-items: start;
+  gap: var(--space-3);
+}
+
+.settings-about-control,
+.settings-about-elsewhere {
+  min-width: 0;
+}
+
+.settings-about-rule {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--space-6);
+  margin-bottom: var(--space-2);
+}
+
+.settings-about-rule h2 {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.settings-about-rule > span {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.settings-about-rule i {
+  height: 1px;
+  flex: 1;
+  background: var(--border-hairline);
+}
+
+.settings-about-sheet {
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--border-hairline);
+}
+
+.settings-about-sheet > * {
+  background: var(--bg-panel);
+}
+
+.settings-about-sheet > * + * {
+  border-top: 1px solid var(--border-hairline);
+}
+
+.settings-about-row,
+.settings-about-update-row {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+}
+
+.settings-about-row__label {
+  min-width: 0;
+  flex: 1;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+}
+
+.settings-about-row__code {
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.settings-about-row__value {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-2);
+}
+
+.settings-about-status {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.settings-about-status--success {
+  color: var(--color-success);
+}
+
+.settings-about-status--warning {
+  color: var(--color-warning);
+}
+
+.settings-about-status--danger {
+  color: var(--color-danger);
+}
+
+.settings-about-status__dot {
+  background: currentColor;
+}
+
+.settings-about-row__reason {
+  width: 100%;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  text-align: right;
+}
+
+.settings-about-daemon-row {
+  flex-wrap: wrap;
+}
+
+.settings-about-stack {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+.settings-about-stack > span {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 500;
+  line-height: 1;
+}
+
+.settings-about-build-sigil {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(
+    in oklch,
+    var(--accent-presence) 8%,
+    var(--bg-panel)
+  );
+}
+
+.settings-about-build-sigil strong {
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  line-height: 1;
+}
+
+.settings-about-build-sigil span {
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+}
+
+.settings-about-tools > div {
+  min-width: 0;
+}
+
+.settings-about-links-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-auto-flow: dense;
+  grid-auto-rows: minmax(7rem, auto);
+  gap: var(--space-2);
+}
+
+.settings-about .settings-about-link-card {
+  position: relative;
+  display: flex;
+  width: 100%;
+  height: auto;
+  min-width: 0;
+  overflow: hidden;
+  align-items: stretch;
+  justify-content: flex-start;
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+  color: var(--text-primary);
+  text-align: left;
+  white-space: normal;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.settings-about .settings-about-link-card:hover {
+  border-color: var(--border-strong);
+  background: color-mix(
+    in oklch,
+    var(--accent-presence) 6%,
+    var(--bg-panel)
+  );
+  transform: translateY(calc(var(--space-1) / -2));
+}
+
+.settings-about-link-card__copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+.settings-about-link-card__copy strong,
+.settings-about-link-card__heading strong,
+.settings-about-release-card strong {
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 600;
+  line-height: var(--leading-tight);
+}
+
+.settings-about-link-card__copy small,
+.settings-about-release-card small {
+  color: var(--accent-presence);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  line-height: 1;
+}
+
+.settings-about-link-card__copy > span {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 400;
+  line-height: var(--leading-normal);
+}
+
+.settings-about-link-card--grimoire {
+  grid-column: span 2;
+  grid-row: span 2;
+  min-height: 14rem;
+  justify-content: flex-end;
+}
+
+.settings-about-link-card--grimoire::after {
+  position: absolute;
+  inset: 30% 0 0;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    color-mix(in oklch, var(--bg-panel) 92%, transparent)
+  );
+  content: "";
+  pointer-events: none;
+}
+
+.settings-about-grimoire-art {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(
+      120% 90% at 78% 12%,
+      color-mix(in oklch, var(--accent-presence) 34%, transparent),
+      transparent 62%
+    ),
+    linear-gradient(155deg, var(--bg-raised), var(--bg-sunken) 70%);
+  color: var(--accent-presence);
+}
+
+.settings-about-grimoire-mark {
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
+  display: inline-flex;
+  width: calc(var(--space-10) + var(--space-3));
+  height: calc(var(--space-10) + var(--space-3));
+  align-items: center;
+  justify-content: center;
+  border: 1px solid
+    color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  border-radius: var(--radius-panel);
+  background: color-mix(
+    in oklch,
+    var(--accent-presence) 18%,
+    transparent
+  );
+}
+
+.settings-about-link-card--grimoire .settings-about-link-card__copy {
+  position: relative;
+  z-index: 1;
+  max-width: 36ch;
+  margin-top: auto;
+}
+
+.settings-about-link-card--grimoire
+  .settings-about-link-card__copy
+  strong {
+  font-family: var(--font-serif);
+  font-size: var(--text-xl);
+  font-weight: 500;
+}
+
+.settings-about-link-card--github {
+  grid-column: span 2;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+.settings-about-link-card__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-about-link-card__heading small {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 400;
+}
+
+.settings-about-link-card--github code {
+  overflow: hidden;
+  padding: var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-sunken);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-about-link-card--small {
+  flex-direction: column;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.settings-about-link-card__glyph {
+  display: inline-flex;
+  width: var(--space-8);
+  height: var(--space-8);
+  flex: none;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-sunken);
+  color: var(--text-secondary);
+}
+
+.settings-about-link-card--podcast {
+  grid-column: span 2;
+  flex-direction: row;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-about-podcast-art {
+  display: inline-flex;
+  width: 4.5rem;
+  height: 4.5rem;
+  flex: none;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  border: 1px solid
+    color-mix(in oklch, var(--accent-presence) 34%, transparent);
+  border-radius: var(--radius-card);
+  background:
+    linear-gradient(
+      145deg,
+      color-mix(in oklch, var(--accent-presence) 26%, transparent),
+      color-mix(in oklch, var(--accent-presence) 8%, var(--bg-sunken))
+    );
+  color: var(--accent-presence);
+}
+
+.settings-about-podcast-art small {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  line-height: 1;
+}
+
+.settings-about-link-card__action {
+  margin-left: auto;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.settings-about-release-card {
+  grid-column: 1 / -1;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+}
+
+.settings-about-release-card > div {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settings-about-release-card ul {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: var(--leading-normal);
+  list-style: none;
+}
+
+.settings-about-release-card li {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.settings-about-release-card li::before {
+  width: var(--space-1);
+  height: var(--space-1);
+  flex: none;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+  content: "";
+}
+
+.settings-about-copy-status {
+  margin: 0;
+}
+
+@container settings-about (max-width: 55rem) {
+  .settings-about-hero {
+    align-items: flex-start;
+    flex-wrap: wrap;
+  }
+
+  .settings-about-hero__actions {
+    width: 100%;
+    margin-left: calc(var(--space-10) + var(--space-3));
+  }
+
+  .settings-about-control-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-about-links-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container settings-about (max-width: 36rem) {
+  .settings-about-hero__actions {
+    margin-left: 0;
+  }
+
+  .settings-about-hero__actions > * {
+    flex: 1;
+  }
+
+  .settings-about-links-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-about-link-card--grimoire,
+  .settings-about-link-card--github,
+  .settings-about-link-card--podcast,
+  .settings-about-release-card {
+    grid-column: span 1;
+  }
+
+  .settings-about-link-card--grimoire {
+    grid-row: span 1;
+    min-height: 12rem;
+  }
+
+  .settings-about-link-card--podcast {
+    align-items: flex-start;
+  }
+
+  .settings-about-link-card__action {
+    display: none;
+  }
+
+  .settings-about-release-card {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .settings-about-row,
+  .settings-about-update-row {
+    align-items: flex-start;
+  }
+
+  .settings-about-row--stack {
+    flex-direction: column;
+  }
+
+  .settings-about-stack {
+    justify-content: flex-start;
+  }
+}
+
+@media (hover: none) and (pointer: coarse) {
+  .settings-about .settings-about-sigil,
+  .settings-about-hero__actions .ui-btn,
+  .settings-about-link-card,
+  .settings-about-release-card .ui-btn {
+    min-height: var(--touch-target);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-about .settings-about-sigil,
+  .settings-about .settings-about-link-card {
+    transition: none;
+  }
+
+  .settings-about .settings-about-link-card:hover,
+  .settings-about-sigil[data-pokes] {
+    transform: none;
+  }
+}


### PR DESCRIPTION
## Summary

- port the Settings > About redesign from Val's handoff into a focused, accessible control sheet
- preserve live daemon, updater, OpenCoven tools, diagnostics, version, and external-link behavior
- add responsive token-only styling for desktop, tablet, and mobile across light and dark modes
- add focused regression coverage and wire it into the app test suite

## Source

- handoff: `settings-about-redesign-handoff.zip`
- SHA-256: `319f41892b60b37f7425bd22604df3b4f8c658532b61859a1baaf02e391b8cc5`
- Bead: `cave-e0kzq`

## Verification

- `pnpm typecheck`
- `pnpm lint`
- affected test set: 14/14 passed
- `pnpm check:tests-wired` (1248 test files wired; 1 allowlisted)
- `node scripts/ui-consistency.test.mjs`
- `node --experimental-strip-types src/lib/design-token-drift.test.ts`
- `node scripts/codemods/tokenize-css.mjs --check`
- `git diff --check`
- rendered at 1440, 700, and 520 px in light and dark modes with no horizontal overflow

The prior monolithic app run reached 831 files before the unrelated load-sensitive `vault-ref-cold-start` assertion failed; that exact test passed four isolated reruns and the remaining 78-file suffix passed. Follow-up is tracked in `cave-u5eyw`.
