### PR TITLE
Fix Windows OpenCode JSON capability false negatives

### DIFF
--- a/src/app/api/chat/send/chat-send-capabilities.test.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.test.ts
@@ -73,6 +73,20 @@ const noJsonHelp = await openCodeRunCapabilities("no-json-fixture", async () => 
 }), fallbackIdentity, () => fallbackClock);
 assert.equal(noJsonHelp.probeStatus, "verified");
 assert.equal(noJsonHelp.json, false, "a complete help response without JSON remains a confirmed plain-mode capability");
+const versionlessIdentity = () => "versionless-launcher";
+await openCodeRunCapabilities("versionless-fixture", async () => ({
+  helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), versionlessIdentity, () => fallbackClock);
+await openCodeRunCapabilities("versionless-fixture", async () => ({
+  helpProbe: { complete: true, output: "  --format <format>  Output format: text\n" },
+  versionProbe: { complete: false, output: "" },
+}), versionlessIdentity, () => fallbackClock);
+const versionlessFallback = await openCodeRunCapabilities("versionless-fixture", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), versionlessIdentity, () => fallbackClock);
+assert.equal(versionlessFallback.probeStatus, "unavailable", "a complete capability response without a version invalidates every older launcher contract");
 const raceIdentities = ["launcher-before", "launcher-after"];
 const racedProbe = await openCodeRunCapabilities("probe-race", async () => ({
   helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
@@ -96,14 +110,14 @@ if (process.platform === "win32") {
     writeFileSync(path.join(localBin, "opencode.exe"), "direct-executable");
     const packageExecutable = path.join(packageBin, "opencode.exe");
     writeFileSync(packageExecutable, "package-target-one");
-    const cmdIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
-    const exeIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".EXE;.CMD" }, "win32");
+    const cmdIdentity = await openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
+    const exeIdentity = await openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".EXE;.CMD" }, "win32");
     assert.notEqual(cmdIdentity, exeIdentity, "PATHEXT order selects and fingerprints only the actual Windows launcher");
     const timestamp = new Date("2026-01-01T00:00:00.000Z");
     utimesSync(packageExecutable, timestamp, timestamp);
     writeFileSync(packageExecutable, "package-target-two");
     utimesSync(packageExecutable, timestamp, timestamp);
-    const replacementIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
+    const replacementIdentity = await openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
     assert.notEqual(cmdIdentity, replacementIdentity, "a same-size package replacement with a restored timestamp changes the content fingerprint");
   } finally {
     rmSync(identityRoot, { recursive: true, force: true });

--- a/src/app/api/chat/send/chat-send-capabilities.test.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.test.ts
@@ -1,10 +1,15 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
+  openCodeCapabilityLaunchIdentity,
   openCodeCapabilityProbeCacheable,
   openCodeCapabilityProbeScope,
   openCodeCapabilityProbeTimeoutMs,
   openCodeVerifiedCapabilityFallbackTtlMs,
+  openCodeVerifiedCapabilityFallbackLimit,
   openCodeProbeCleanupGraceMs,
   openCodeProbeSpawnOptions,
   openCodeProbeTreeKillCommand,
@@ -16,6 +21,7 @@ assert.equal(openCodeCapabilityProbeTimeoutMs("linux"), 2_500, "non-Windows capa
 assert.equal(openCodeCapabilityProbeTimeoutMs("win32"), 6_000, "Windows PowerShell/npm launchers receive a bounded cold-start allowance");
 assert.equal(openCodeProbeCleanupGraceMs(), 1_000, "timed-out probe cleanup has a short final deadline so chat can fall back");
 assert.equal(openCodeVerifiedCapabilityFallbackTtlMs(), 60_000, "only a short-lived verified OpenCode contract can survive a transient probe failure");
+assert.equal(openCodeVerifiedCapabilityFallbackLimit(), 64, "verified capability evidence remains bounded across scoped launches");
 assert.equal(openCodeCapabilityProbeCacheable("linux"), false, "POSIX clients are reprobed rather than reusing a same-version help contract");
 assert.equal(openCodeCapabilityProbeCacheable("win32"), false, "Windows launcher shims are reprobed rather than reusing stale downstream capability evidence");
 assert.notEqual(
@@ -29,11 +35,11 @@ assert.deepEqual(openCodeProbeSpawnOptions("win32"), { detached: false }, "Windo
 const firstCapabilities = await openCodeRunCapabilities("probe-fixture", async () => ({
   helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
   versionProbe: { complete: true, output: "opencode 1.0.0" },
-}));
+}), () => "probe-fixture-launcher");
 const replacementCapabilities = await openCodeRunCapabilities("probe-fixture", async () => ({
   helpProbe: { complete: true, output: "  --format <format>  Output format: text\n" },
   versionProbe: { complete: true, output: "opencode 1.0.0" },
-}));
+}), () => "probe-fixture-launcher");
 assert.equal(firstCapabilities.json, true);
 assert.equal(replacementCapabilities.json, false, "an in-place same-version CLI replacement is reprobed before Cave chooses JSON argv");
 
@@ -67,6 +73,56 @@ const noJsonHelp = await openCodeRunCapabilities("no-json-fixture", async () => 
 }), fallbackIdentity, () => fallbackClock);
 assert.equal(noJsonHelp.probeStatus, "verified");
 assert.equal(noJsonHelp.json, false, "a complete help response without JSON remains a confirmed plain-mode capability");
+const raceIdentities = ["launcher-before", "launcher-after"];
+const racedProbe = await openCodeRunCapabilities("probe-race", async () => ({
+  helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), () => raceIdentities.shift() ?? "launcher-after", () => fallbackClock);
+assert.equal(racedProbe.probeStatus, "verified", "a complete probe remains usable for its current turn even when the launcher changes during probing");
+const racedFallback = await openCodeRunCapabilities("probe-race", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), () => "launcher-after", () => fallbackClock);
+assert.equal(racedFallback.probeStatus, "unavailable", "a launcher changed during a complete probe cannot seed later fallback evidence");
+
+if (process.platform === "win32") {
+  const identityRoot = mkdtempSync(path.join(tmpdir(), "cave-opencode-identity-"));
+  try {
+    const localBin = path.join(identityRoot, "node_modules", ".bin");
+    const packageBin = path.join(identityRoot, "node_modules", "opencode-ai", "bin");
+    mkdirSync(localBin, { recursive: true });
+    mkdirSync(packageBin, { recursive: true });
+    writeFileSync(path.join(localBin, "opencode.cmd"), "@echo off\r\n");
+    writeFileSync(path.join(localBin, "opencode.exe"), "direct-executable");
+    const packageExecutable = path.join(packageBin, "opencode.exe");
+    writeFileSync(packageExecutable, "package-target-one");
+    const cmdIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
+    const exeIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".EXE;.CMD" }, "win32");
+    assert.notEqual(cmdIdentity, exeIdentity, "PATHEXT order selects and fingerprints only the actual Windows launcher");
+    const timestamp = new Date("2026-01-01T00:00:00.000Z");
+    utimesSync(packageExecutable, timestamp, timestamp);
+    writeFileSync(packageExecutable, "package-target-two");
+    utimesSync(packageExecutable, timestamp, timestamp);
+    const replacementIdentity = openCodeCapabilityLaunchIdentity({ PATH: localBin, PATHEXT: ".CMD;.EXE" }, "win32");
+    assert.notEqual(cmdIdentity, replacementIdentity, "a same-size package replacement with a restored timestamp changes the content fingerprint");
+  } finally {
+    rmSync(identityRoot, { recursive: true, force: true });
+  }
+}
+
+const boundedClock = 10_000;
+for (let index = 0; index <= openCodeVerifiedCapabilityFallbackLimit(); index += 1) {
+  const identity = () => `bounded-launcher-${index}`;
+  await openCodeRunCapabilities(`bounded-${index}`, async () => ({
+    helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
+    versionProbe: { complete: true, output: "opencode 1.18.5" },
+  }), identity, () => boundedClock);
+}
+const evictedFallback = await openCodeRunCapabilities("bounded-0", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), () => "bounded-launcher-0", () => boundedClock);
+assert.equal(evictedFallback.probeStatus, "unavailable", "bounded evidence evicts the oldest verified contract rather than retaining it indefinitely");
 assert.deepEqual(
   openCodeProbeTreeKillCommand(4242, "win32"),
   { command: "taskkill.exe", args: ["/PID", "4242", "/T", "/F"] },

--- a/src/app/api/chat/send/chat-send-capabilities.test.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   openCodeCapabilityProbeCacheable,
   openCodeCapabilityProbeScope,
   openCodeCapabilityProbeTimeoutMs,
+  openCodeVerifiedCapabilityFallbackTtlMs,
   openCodeProbeCleanupGraceMs,
   openCodeProbeSpawnOptions,
   openCodeProbeTreeKillCommand,
@@ -14,6 +15,7 @@ import {
 assert.equal(openCodeCapabilityProbeTimeoutMs("linux"), 2_500, "non-Windows capability probes retain the short bounded deadline");
 assert.equal(openCodeCapabilityProbeTimeoutMs("win32"), 6_000, "Windows PowerShell/npm launchers receive a bounded cold-start allowance");
 assert.equal(openCodeProbeCleanupGraceMs(), 1_000, "timed-out probe cleanup has a short final deadline so chat can fall back");
+assert.equal(openCodeVerifiedCapabilityFallbackTtlMs(), 60_000, "only a short-lived verified OpenCode contract can survive a transient probe failure");
 assert.equal(openCodeCapabilityProbeCacheable("linux"), false, "POSIX clients are reprobed rather than reusing a same-version help contract");
 assert.equal(openCodeCapabilityProbeCacheable("win32"), false, "Windows launcher shims are reprobed rather than reusing stale downstream capability evidence");
 assert.notEqual(
@@ -34,6 +36,37 @@ const replacementCapabilities = await openCodeRunCapabilities("probe-fixture", a
 }));
 assert.equal(firstCapabilities.json, true);
 assert.equal(replacementCapabilities.json, false, "an in-place same-version CLI replacement is reprobed before Cave chooses JSON argv");
+
+let fallbackClock = 1_000;
+const fallbackIdentity = () => "C:\\npm\\opencode.cmd\0 42\0 100";
+const fallbackSeed = await openCodeRunCapabilities("fallback-fixture", async () => ({
+  helpProbe: { complete: true, output: "  --format <format>  Output format: text, json\n" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), fallbackIdentity, () => fallbackClock);
+assert.equal(fallbackSeed.probeStatus, "verified");
+const transientFallback = await openCodeRunCapabilities("fallback-fixture", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), fallbackIdentity, () => fallbackClock);
+assert.equal(transientFallback.probeStatus, "fallback", "a failed help probe can use only a recent complete contract for the same launcher");
+assert.equal(transientFallback.json, true, "the verified JSON contract survives a transient probe failure without guessing new argv");
+const changedIdentity = await openCodeRunCapabilities("fallback-fixture", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), () => "C:\\npm\\opencode.cmd\0 43\0 101", () => fallbackClock);
+assert.equal(changedIdentity.probeStatus, "unavailable", "a changed launcher file never inherits a prior capability contract");
+fallbackClock += openCodeVerifiedCapabilityFallbackTtlMs();
+const expiredFallback = await openCodeRunCapabilities("fallback-fixture", async () => ({
+  helpProbe: { complete: false, output: "" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), fallbackIdentity, () => fallbackClock);
+assert.equal(expiredFallback.probeStatus, "unavailable", "expired verified evidence cannot mask a later failed probe");
+const noJsonHelp = await openCodeRunCapabilities("no-json-fixture", async () => ({
+  helpProbe: { complete: true, output: "  --format <format>  Output format: text\n" },
+  versionProbe: { complete: true, output: "opencode 1.18.5" },
+}), fallbackIdentity, () => fallbackClock);
+assert.equal(noJsonHelp.probeStatus, "verified");
+assert.equal(noJsonHelp.json, false, "a complete help response without JSON remains a confirmed plain-mode capability");
 assert.deepEqual(
   openCodeProbeTreeKillCommand(4242, "win32"),
   { command: "taskkill.exe", args: ["/PID", "4242", "/T", "/F"] },

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { covenLaunchCommand } from "@/lib/coven-bin";
 import {
@@ -20,6 +21,10 @@ const DEFAULT_CAPABILITY_PROBE_TIMEOUT_MS = 2_500;
 const WINDOWS_CAPABILITY_PROBE_TIMEOUT_MS = 6_000;
 const OPENCODE_PROBE_CLEANUP_GRACE_MS = 1_000;
 const OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS = 60_000;
+const MAX_VERIFIED_OPENCODE_CAPABILITIES = 64;
+// The current Windows OpenCode executable is roughly 175 MB. Bound hashing
+// enough to cover supported releases while refusing an arbitrary PATH target.
+const MAX_OPENCODE_IDENTITY_FILE_BYTES = 256 * 1024 * 1024;
 
 type OpenCodeRunContractProbe = { helpProbe: ProbeOutput; versionProbe: ProbeOutput };
 type CapabilityIdentityProbe = (env: NodeJS.ProcessEnv) => string | null;
@@ -47,6 +52,12 @@ export function openCodeProbeCleanupGraceMs(): number {
 /** Exposed for fixtures; this is a fallback lifetime, not a probe cache TTL. */
 export function openCodeVerifiedCapabilityFallbackTtlMs(): number {
   return OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS;
+}
+
+/** A hard cap keeps per-familiar, short-lived evidence from accumulating in a
+ * long-running desktop process. */
+export function openCodeVerifiedCapabilityFallbackLimit(): number {
+  return MAX_VERIFIED_OPENCODE_CAPABILITIES;
 }
 
 /** The help text is the executable contract, and an installed OpenCode may
@@ -387,6 +398,30 @@ async function probeOpenCodeRunContract(env: NodeJS.ProcessEnv): Promise<OpenCod
  * npm PowerShell shim and its package executable both participate: package
  * upgrades can replace the latter while leaving the small `.cmd` shim intact.
  */
+function fileIdentity(file: string, platform: NodeJS.Platform): string | null {
+  try {
+    // Resolve a symlink before reading it so changing its target changes the
+    // identity even when the link itself keeps its old metadata.
+    const resolved = realpathSync(file);
+    const entry = statSync(resolved);
+    if (!entry.isFile() || entry.size > MAX_OPENCODE_IDENTITY_FILE_BYTES) return null;
+    const stablePath = platform === "win32" ? resolved.toLowerCase() : resolved;
+    const digest = createHash("sha256").update(readFileSync(resolved)).digest("hex");
+    return `${stablePath}\0${entry.size}\0${entry.mtimeMs}\0${digest}`;
+  } catch {
+    return null;
+  }
+}
+
+function npmPackageExecutable(directory: string, pathApi: typeof path.win32): string {
+  // A project-local npm shim sits at node_modules/.bin/opencode.cmd; global
+  // npm shims conventionally sit beside their node_modules directory.
+  const packageRoot = pathApi.basename(directory).toLowerCase() === ".bin"
+    ? pathApi.dirname(directory)
+    : pathApi.join(directory, "node_modules");
+  return pathApi.join(packageRoot, "opencode-ai", "bin", "opencode.exe");
+}
+
 export function openCodeCapabilityLaunchIdentity(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
@@ -396,44 +431,39 @@ export function openCodeCapabilityLaunchIdentity(
   const separator = platform === "win32" ? ";" : ":";
   const pathApi = platform === "win32" ? path.win32 : path.posix;
   const extensions = platform === "win32"
-    ? [".PS1", ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)]
+    ? [...new Set([".PS1", ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)].map((extension) => extension.toLowerCase()))]
     : [""];
   for (const directory of rawPath.split(separator).filter(Boolean).slice(0, 512)) {
-    const entries: string[] = [];
     for (const extension of extensions) {
       const candidate = pathApi.join(directory, `${openCodeCommand()}${extension}`);
-      try {
-        const entry = statSync(candidate);
-        if (!entry.isFile()) continue;
-        const stablePath = platform === "win32" ? candidate.toLowerCase() : candidate;
-        entries.push(`${stablePath}\0${entry.size}\0${entry.mtimeMs}`);
-      } catch {
-        // A missing, unreadable, or otherwise unverifiable launcher cannot
-        // itself contribute to launch identity evidence.
-      }
+      const launcher = fileIdentity(candidate, platform);
+      if (!launcher) continue;
+      if (platform !== "win32" || extension === ".exe" || extension === ".com") return launcher;
+
+      // A cmd/bat/PowerShell wrapper can dispatch to a mutable downstream
+      // executable. Permit fallback only for npm's known layout, and include
+      // the resolved package executable in the fingerprint. Unknown wrappers
+      // deliberately receive no fallback evidence.
+      const packageTarget = fileIdentity(npmPackageExecutable(directory, pathApi), platform);
+      return packageTarget ? `${launcher}\0${packageTarget}` : null;
     }
-    if (!entries.length) continue;
-    // npm's Windows wrappers dispatch to this package-local executable. It is
-    // optional because alternate installations can legitimately use another
-    // launch layout; when present it prevents a changed runtime from sharing
-    // the wrapper's prior capability result.
-    if (platform === "win32") {
-      const packageExecutable = pathApi.join(directory, "node_modules", "opencode-ai", "bin", "opencode.exe");
-      try {
-        const entry = statSync(packageExecutable);
-        if (entry.isFile()) entries.push(`${packageExecutable.toLowerCase()}\0${entry.size}\0${entry.mtimeMs}`);
-      } catch {
-        // The wrapper itself remains valid identity evidence for non-npm
-        // launchers; no guessed package target is ever added.
-      }
-    }
-    return entries.sort().join("\0");
   }
   return null;
 }
 
 function capabilityKey(scope: string, launcherIdentity: string, version: string): string {
   return `${scope}\0${launcherIdentity}\0${version}`;
+}
+
+function pruneVerifiedOpenCodeCapabilities(now: number): void {
+  for (const [key, evidence] of verifiedOpenCodeCapabilities) {
+    if (evidence.expiresAt <= now) verifiedOpenCodeCapabilities.delete(key);
+  }
+  while (verifiedOpenCodeCapabilities.size > MAX_VERIFIED_OPENCODE_CAPABILITIES) {
+    const oldest = verifiedOpenCodeCapabilities.keys().next().value;
+    if (oldest === undefined) break;
+    verifiedOpenCodeCapabilities.delete(oldest);
+  }
 }
 
 function advertisedFormatProtocols(
@@ -551,12 +581,21 @@ export async function openCodeRunCapabilities(
   // string alone is not a safe cache key: package managers and shims can
   // replace a CLI in place while preserving both PATH and `--version`.
   const env = openCodeSpawnEnv(familiarId);
-  const launcherIdentity = capabilityIdentity(env);
+  const launcherIdentityBeforeProbe = capabilityIdentity(env);
   const { helpProbe, versionProbe } = await probeRunContract(env);
+  const launcherIdentityAfterProbe = capabilityIdentity(env);
+  // A launcher update during the probe leaves no trustworthy association
+  // between its output and a later invocation, so fail closed for caching and
+  // fallback even if the reported version is unchanged.
+  const launcherIdentity = launcherIdentityBeforeProbe && launcherIdentityBeforeProbe === launcherIdentityAfterProbe
+    ? launcherIdentityAfterProbe
+    : null;
   const version = versionProbe.complete
     ? versionProbe.output.match(/\b\d+(?:\.\d+){1,3}(?:[-+][\w.-]+)?\b/)?.[0] ?? null
     : null;
   const scope = openCodeCapabilityProbeScope(familiarId);
+  const observedNow = now();
+  pruneVerifiedOpenCodeCapabilities(observedNow);
   if (helpProbe.complete) {
     const capabilities = {
       ...parseOpenCodeRunCapabilitiesHelp(helpProbe.output, version),
@@ -567,9 +606,10 @@ export async function openCodeRunCapabilities(
     // PATH, or a failed version probe therefore falls back to plain mode.
     if (launcherIdentity && version) {
       verifiedOpenCodeCapabilities.set(capabilityKey(scope, launcherIdentity, version), {
-        expiresAt: now() + OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS,
+        expiresAt: observedNow + OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS,
         capabilities,
       });
+      pruneVerifiedOpenCodeCapabilities(observedNow);
     }
     return capabilities;
   }
@@ -581,7 +621,7 @@ export async function openCodeRunCapabilities(
   if (launcherIdentity && version) {
     const key = capabilityKey(scope, launcherIdentity, version);
     const fallback = verifiedOpenCodeCapabilities.get(key);
-    if (fallback && fallback.expiresAt > now()) {
+    if (fallback && fallback.expiresAt > observedNow) {
       return { ...fallback.capabilities, probeStatus: "fallback" };
     }
     if (fallback) verifiedOpenCodeCapabilities.delete(key);

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -1,6 +1,7 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, realpathSync, statSync } from "node:fs";
+import { createReadStream } from "node:fs";
+import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import { covenLaunchCommand } from "@/lib/coven-bin";
 import {
@@ -22,12 +23,13 @@ const WINDOWS_CAPABILITY_PROBE_TIMEOUT_MS = 6_000;
 const OPENCODE_PROBE_CLEANUP_GRACE_MS = 1_000;
 const OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS = 60_000;
 const MAX_VERIFIED_OPENCODE_CAPABILITIES = 64;
+const MAX_OPENCODE_FILE_IDENTITIES = 128;
 // The current Windows OpenCode executable is roughly 175 MB. Bound hashing
 // enough to cover supported releases while refusing an arbitrary PATH target.
 const MAX_OPENCODE_IDENTITY_FILE_BYTES = 256 * 1024 * 1024;
 
 type OpenCodeRunContractProbe = { helpProbe: ProbeOutput; versionProbe: ProbeOutput };
-type CapabilityIdentityProbe = (env: NodeJS.ProcessEnv) => string | null;
+type CapabilityIdentityProbe = (env: NodeJS.ProcessEnv) => string | null | Promise<string | null>;
 type CapabilityClock = () => number;
 type VerifiedCapability = {
   expiresAt: number;
@@ -38,6 +40,7 @@ type VerifiedCapability = {
 // skip that probe: it only avoids turning a transient launcher failure into a
 // false claim that an otherwise unchanged OpenCode lacks JSON support.
 const verifiedOpenCodeCapabilities = new Map<string, VerifiedCapability>();
+const openCodeFileIdentities = new Map<string, string>();
 
 /** PowerShell/npm shims can be delayed by cold start or Defender scanning. */
 export function openCodeCapabilityProbeTimeoutMs(platform: NodeJS.Platform = process.platform): number {
@@ -398,16 +401,51 @@ async function probeOpenCodeRunContract(env: NodeJS.ProcessEnv): Promise<OpenCod
  * npm PowerShell shim and its package executable both participate: package
  * upgrades can replace the latter while leaving the small `.cmd` shim intact.
  */
-function fileIdentity(file: string, platform: NodeJS.Platform): string | null {
+function rememberOpenCodeFileIdentity(key: string, identity: string): void {
+  openCodeFileIdentities.delete(key);
+  openCodeFileIdentities.set(key, identity);
+  while (openCodeFileIdentities.size > MAX_OPENCODE_FILE_IDENTITIES) {
+    const oldest = openCodeFileIdentities.keys().next().value;
+    if (oldest === undefined) break;
+    openCodeFileIdentities.delete(oldest);
+  }
+}
+
+async function hashFile(file: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(file);
+    stream.on("data", (chunk: string | Buffer) => { hash.update(chunk); });
+    stream.once("error", reject);
+    stream.once("end", () => resolve(hash.digest("hex")));
+  });
+}
+
+async function fileIdentity(file: string, platform: NodeJS.Platform): Promise<string | null> {
   try {
     // Resolve a symlink before reading it so changing its target changes the
     // identity even when the link itself keeps its old metadata.
-    const resolved = realpathSync(file);
-    const entry = statSync(resolved);
+    const resolved = await realpath(file);
+    const entry = await stat(resolved);
     if (!entry.isFile() || entry.size > MAX_OPENCODE_IDENTITY_FILE_BYTES) return null;
     const stablePath = platform === "win32" ? resolved.toLowerCase() : resolved;
-    const digest = createHash("sha256").update(readFileSync(resolved)).digest("hex");
-    return `${stablePath}\0${entry.size}\0${entry.mtimeMs}\0${digest}`;
+    // ctime and inode invalidate a retained digest for ordinary in-place
+    // replacements even when an updater preserves the size and mtime.
+    const metadataKey = `${stablePath}\0${entry.size}\0${entry.mtimeMs}\0${entry.ctimeMs}\0${entry.ino}`;
+    const cached = openCodeFileIdentities.get(metadataKey);
+    if (cached) {
+      rememberOpenCodeFileIdentity(metadataKey, cached);
+      return cached;
+    }
+    const digest = await hashFile(resolved);
+    const after = await stat(resolved);
+    const afterKey = `${stablePath}\0${after.size}\0${after.mtimeMs}\0${after.ctimeMs}\0${after.ino}`;
+    // An update racing the stream makes the hash ambiguous. Do not cache or
+    // reuse it; the caller will safely fall back to plain mode for this turn.
+    if (afterKey !== metadataKey) return null;
+    const identity = `${metadataKey}\0${digest}`;
+    rememberOpenCodeFileIdentity(metadataKey, identity);
+    return identity;
   } catch {
     return null;
   }
@@ -422,10 +460,10 @@ function npmPackageExecutable(directory: string, pathApi: typeof path.win32): st
   return pathApi.join(packageRoot, "opencode-ai", "bin", "opencode.exe");
 }
 
-export function openCodeCapabilityLaunchIdentity(
+export async function openCodeCapabilityLaunchIdentity(
   env: NodeJS.ProcessEnv,
   platform: NodeJS.Platform = process.platform,
-): string | null {
+): Promise<string | null> {
   const rawPath = env.PATH ?? env.Path ?? env.path;
   if (!rawPath) return null;
   const separator = platform === "win32" ? ";" : ":";
@@ -436,7 +474,7 @@ export function openCodeCapabilityLaunchIdentity(
   for (const directory of rawPath.split(separator).filter(Boolean).slice(0, 512)) {
     for (const extension of extensions) {
       const candidate = pathApi.join(directory, `${openCodeCommand()}${extension}`);
-      const launcher = fileIdentity(candidate, platform);
+      const launcher = await fileIdentity(candidate, platform);
       if (!launcher) continue;
       if (platform !== "win32" || extension === ".exe" || extension === ".com") return launcher;
 
@@ -444,7 +482,7 @@ export function openCodeCapabilityLaunchIdentity(
       // executable. Permit fallback only for npm's known layout, and include
       // the resolved package executable in the fingerprint. Unknown wrappers
       // deliberately receive no fallback evidence.
-      const packageTarget = fileIdentity(npmPackageExecutable(directory, pathApi), platform);
+      const packageTarget = await fileIdentity(npmPackageExecutable(directory, pathApi), platform);
       return packageTarget ? `${launcher}\0${packageTarget}` : null;
     }
   }
@@ -463,6 +501,13 @@ function pruneVerifiedOpenCodeCapabilities(now: number): void {
     const oldest = verifiedOpenCodeCapabilities.keys().next().value;
     if (oldest === undefined) break;
     verifiedOpenCodeCapabilities.delete(oldest);
+  }
+}
+
+function discardVerifiedOpenCodeCapabilities(scope: string, launcherIdentity: string): void {
+  const prefix = `${scope}\0${launcherIdentity}\0`;
+  for (const key of verifiedOpenCodeCapabilities.keys()) {
+    if (key.startsWith(prefix)) verifiedOpenCodeCapabilities.delete(key);
   }
 }
 
@@ -581,13 +626,16 @@ export async function openCodeRunCapabilities(
   // string alone is not a safe cache key: package managers and shims can
   // replace a CLI in place while preserving both PATH and `--version`.
   const env = openCodeSpawnEnv(familiarId);
-  const launcherIdentityBeforeProbe = capabilityIdentity(env);
+  // Hashing a large npm executable is streamed asynchronously and overlaps
+  // the help/version children, so it never blocks the request event loop.
+  const launcherIdentityBeforeProbe = Promise.resolve(capabilityIdentity(env));
   const { helpProbe, versionProbe } = await probeRunContract(env);
-  const launcherIdentityAfterProbe = capabilityIdentity(env);
+  const launcherIdentityAfterProbe = await capabilityIdentity(env);
+  const launcherIdentityBefore = await launcherIdentityBeforeProbe;
   // A launcher update during the probe leaves no trustworthy association
   // between its output and a later invocation, so fail closed for caching and
   // fallback even if the reported version is unchanged.
-  const launcherIdentity = launcherIdentityBeforeProbe && launcherIdentityBeforeProbe === launcherIdentityAfterProbe
+  const launcherIdentity = launcherIdentityBefore && launcherIdentityBefore === launcherIdentityAfterProbe
     ? launcherIdentityAfterProbe
     : null;
   const version = versionProbe.complete
@@ -604,7 +652,13 @@ export async function openCodeRunCapabilities(
     // Require both an exact launch-file fingerprint and a completed version
     // response before retaining evidence. A replacement in place, a changed
     // PATH, or a failed version probe therefore falls back to plain mode.
-    if (launcherIdentity && version) {
+    if (launcherIdentity && !version) {
+      // Complete help is authoritative capability evidence. Without a usable
+      // version it cannot be retained, so erase every prior version for this
+      // scope/launcher rather than allowing a later failed probe to revive a
+      // contradicted JSON contract.
+      discardVerifiedOpenCodeCapabilities(scope, launcherIdentity);
+    } else if (launcherIdentity && version) {
       verifiedOpenCodeCapabilities.set(capabilityKey(scope, launcherIdentity, version), {
         expiresAt: observedNow + OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS,
         capabilities,

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -1,4 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { statSync } from "node:fs";
+import path from "node:path";
 import { covenLaunchCommand } from "@/lib/coven-bin";
 import {
   covenRunSupportsAddDirFlag,
@@ -6,7 +8,7 @@ import {
   covenRunSupportsPermissionFlag,
 } from "@/lib/harness-adapters";
 import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
-import { openCodeLaunch, openCodeSpawnEnv, writeOpenCodeLaunchInput } from "@/lib/opencode-bin";
+import { openCodeCommand, openCodeLaunch, openCodeSpawnEnv, writeOpenCodeLaunchInput } from "@/lib/opencode-bin";
 import type { OpenCodeRunCapabilities } from "@/lib/opencode-compatibility";
 
 let modelFlagProbe: Promise<boolean> | null = null;
@@ -17,6 +19,20 @@ let openCodeModelFlagProbe: Promise<boolean> | null = null;
 const DEFAULT_CAPABILITY_PROBE_TIMEOUT_MS = 2_500;
 const WINDOWS_CAPABILITY_PROBE_TIMEOUT_MS = 6_000;
 const OPENCODE_PROBE_CLEANUP_GRACE_MS = 1_000;
+const OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS = 60_000;
+
+type OpenCodeRunContractProbe = { helpProbe: ProbeOutput; versionProbe: ProbeOutput };
+type CapabilityIdentityProbe = (env: NodeJS.ProcessEnv) => string | null;
+type CapabilityClock = () => number;
+type VerifiedCapability = {
+  expiresAt: number;
+  capabilities: OpenCodeRunCapabilities;
+};
+
+// The help surface is re-probed on every turn. This cache is never used to
+// skip that probe: it only avoids turning a transient launcher failure into a
+// false claim that an otherwise unchanged OpenCode lacks JSON support.
+const verifiedOpenCodeCapabilities = new Map<string, VerifiedCapability>();
 
 /** PowerShell/npm shims can be delayed by cold start or Defender scanning. */
 export function openCodeCapabilityProbeTimeoutMs(platform: NodeJS.Platform = process.platform): number {
@@ -26,6 +42,11 @@ export function openCodeCapabilityProbeTimeoutMs(platform: NodeJS.Platform = pro
 /** Cleanup remains best-effort: a hung launcher must never block chat fallback. */
 export function openCodeProbeCleanupGraceMs(): number {
   return OPENCODE_PROBE_CLEANUP_GRACE_MS;
+}
+
+/** Exposed for fixtures; this is a fallback lifetime, not a probe cache TTL. */
+export function openCodeVerifiedCapabilityFallbackTtlMs(): number {
+  return OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS;
 }
 
 /** The help text is the executable contract, and an installed OpenCode may
@@ -350,8 +371,6 @@ function advertisedStructuredSwitches(options: string[], noValueOptions: string[
   });
 }
 
-type OpenCodeRunContractProbe = { helpProbe: ProbeOutput; versionProbe: ProbeOutput };
-
 async function probeOpenCodeRunContract(env: NodeJS.ProcessEnv): Promise<OpenCodeRunContractProbe> {
   const helpLaunch = openCodeLaunch(["run", "--help"]);
   const versionLaunch = openCodeLaunch(["--version"]);
@@ -360,6 +379,61 @@ async function probeOpenCodeRunContract(env: NodeJS.ProcessEnv): Promise<OpenCod
     probeOutput(versionLaunch.command, versionLaunch.args, env, versionLaunch.input),
   ]);
   return { helpProbe, versionProbe };
+}
+
+/**
+ * Return a local-only fingerprint for the exact command files PowerShell or
+ * spawn can resolve. It is intentionally never rendered or persisted. The
+ * npm PowerShell shim and its package executable both participate: package
+ * upgrades can replace the latter while leaving the small `.cmd` shim intact.
+ */
+export function openCodeCapabilityLaunchIdentity(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const rawPath = env.PATH ?? env.Path ?? env.path;
+  if (!rawPath) return null;
+  const separator = platform === "win32" ? ";" : ":";
+  const pathApi = platform === "win32" ? path.win32 : path.posix;
+  const extensions = platform === "win32"
+    ? [".PS1", ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";").filter(Boolean)]
+    : [""];
+  for (const directory of rawPath.split(separator).filter(Boolean).slice(0, 512)) {
+    const entries: string[] = [];
+    for (const extension of extensions) {
+      const candidate = pathApi.join(directory, `${openCodeCommand()}${extension}`);
+      try {
+        const entry = statSync(candidate);
+        if (!entry.isFile()) continue;
+        const stablePath = platform === "win32" ? candidate.toLowerCase() : candidate;
+        entries.push(`${stablePath}\0${entry.size}\0${entry.mtimeMs}`);
+      } catch {
+        // A missing, unreadable, or otherwise unverifiable launcher cannot
+        // itself contribute to launch identity evidence.
+      }
+    }
+    if (!entries.length) continue;
+    // npm's Windows wrappers dispatch to this package-local executable. It is
+    // optional because alternate installations can legitimately use another
+    // launch layout; when present it prevents a changed runtime from sharing
+    // the wrapper's prior capability result.
+    if (platform === "win32") {
+      const packageExecutable = pathApi.join(directory, "node_modules", "opencode-ai", "bin", "opencode.exe");
+      try {
+        const entry = statSync(packageExecutable);
+        if (entry.isFile()) entries.push(`${packageExecutable.toLowerCase()}\0${entry.size}\0${entry.mtimeMs}`);
+      } catch {
+        // The wrapper itself remains valid identity evidence for non-npm
+        // launchers; no guessed package target is ever added.
+      }
+    }
+    return entries.sort().join("\0");
+  }
+  return null;
+}
+
+function capabilityKey(scope: string, launcherIdentity: string, version: string): string {
+  return `${scope}\0${launcherIdentity}\0${version}`;
 }
 
 function advertisedFormatProtocols(
@@ -470,18 +544,60 @@ export function openCodeRunSupportsModel(): Promise<boolean> {
 export async function openCodeRunCapabilities(
   familiarId?: string,
   probeRunContract: (env: NodeJS.ProcessEnv) => Promise<OpenCodeRunContractProbe> = probeOpenCodeRunContract,
+  capabilityIdentity: CapabilityIdentityProbe = openCodeCapabilityLaunchIdentity,
+  now: CapabilityClock = Date.now,
 ): Promise<OpenCodeRunCapabilities> {
   // Probe the exact scoped environment used for this chat turn. A version
   // string alone is not a safe cache key: package managers and shims can
   // replace a CLI in place while preserving both PATH and `--version`.
   const env = openCodeSpawnEnv(familiarId);
+  const launcherIdentity = capabilityIdentity(env);
   const { helpProbe, versionProbe } = await probeRunContract(env);
   const version = versionProbe.complete
     ? versionProbe.output.match(/\b\d+(?:\.\d+){1,3}(?:[-+][\w.-]+)?\b/)?.[0] ?? null
     : null;
-  // Partial, timed-out, non-zero, or oversized help is never capability
-  // evidence. Re-probe on the next turn instead of risking unsupported argv.
-  return !helpProbe.complete
-    ? { version, json: false, model: false, session: false, protocols: [], options: [], valueOptions: [], noValueOptions: [], endOfOptions: false, structuredSwitches: [], structuredOutputs: [] }
-    : parseOpenCodeRunCapabilitiesHelp(helpProbe.output, version);
+  const scope = openCodeCapabilityProbeScope(familiarId);
+  if (helpProbe.complete) {
+    const capabilities = {
+      ...parseOpenCodeRunCapabilitiesHelp(helpProbe.output, version),
+      probeStatus: "verified" as const,
+    };
+    // Require both an exact launch-file fingerprint and a completed version
+    // response before retaining evidence. A replacement in place, a changed
+    // PATH, or a failed version probe therefore falls back to plain mode.
+    if (launcherIdentity && version) {
+      verifiedOpenCodeCapabilities.set(capabilityKey(scope, launcherIdentity, version), {
+        expiresAt: now() + OPENCODE_VERIFIED_CAPABILITY_FALLBACK_TTL_MS,
+        capabilities,
+      });
+    }
+    return capabilities;
+  }
+
+  // A partial, timed-out, non-zero, or oversized help response is never new
+  // argv evidence. It may use only a recent complete contract for the same
+  // familiar scope, launcher file, and reported version; it never bypasses a
+  // fresh probe on the next turn.
+  if (launcherIdentity && version) {
+    const key = capabilityKey(scope, launcherIdentity, version);
+    const fallback = verifiedOpenCodeCapabilities.get(key);
+    if (fallback && fallback.expiresAt > now()) {
+      return { ...fallback.capabilities, probeStatus: "fallback" };
+    }
+    if (fallback) verifiedOpenCodeCapabilities.delete(key);
+  }
+  return {
+    version,
+    probeStatus: "unavailable",
+    json: false,
+    model: false,
+    session: false,
+    protocols: [],
+    options: [],
+    valueOptions: [],
+    noValueOptions: [],
+    endOfOptions: false,
+    structuredSwitches: [],
+    structuredOutputs: [],
+  };
 }

--- a/src/app/api/chat/send/harness-routing-opencode.test.ts
+++ b/src/app/api/chat/send/harness-routing-opencode.test.ts
@@ -147,6 +147,11 @@ assert.match(
   /compatibility registry is unavailable; continuing in plain chat without tool activity/,
   "an unavailable expired registry accurately reports plain fallback rather than a parser that is not active",
 );
+assert.match(
+  route,
+  /Couldn't verify OpenCode JSON events; continuing in plain chat without tool activity[\s\S]*?capability-probe-unavailable[\s\S]*?capability-probe-fallback[\s\S]*?\? "done"\s*:\s*"error"/,
+  "an unavailable capability probe is distinct from confirmed JSON incompatibility and does not create a false error issue",
+);
 assert.doesNotMatch(
   route,
   /openCodeStructuredIncompatibility|structured-stream-quarantined/,
@@ -255,7 +260,7 @@ assert.match(
 assert.doesNotMatch(
   capabilities,
   /openCodeCapabilitiesProbe/,
-  "OpenCode must not retain capability evidence that could be stale after an in-place same-version CLI upgrade; chat-send-capabilities tests this behavior with two probes",
+  "OpenCode does not use a normal TTL cache that would skip re-probing after an in-place same-version CLI upgrade",
 );
 
 console.log("opencode harness routing tests passed");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2489,7 +2489,11 @@ export async function POST(req: Request) {
         if (!line && !(openCodeDirect && openCodeCompatibility?.mode === "plain")) return;
         if (openCodeDirect && !openCodeCompatibilityHealthNoticeSent && openCodeCompatibility?.diagnostic) {
           openCodeCompatibilityHealthNoticeSent = true;
-          const diagnostic = openCodeCompatibility.diagnostic === "json-format-unavailable"
+          const diagnostic = openCodeCompatibility.diagnostic === "capability-probe-unavailable"
+            ? "Couldn't verify OpenCode JSON events; continuing in plain chat without tool activity"
+            : openCodeCompatibility.diagnostic === "capability-probe-fallback"
+              ? "OpenCode capability probe was unavailable; using recently verified JSON event support"
+            : openCodeCompatibility.diagnostic === "json-format-unavailable"
             ? "This OpenCode client does not advertise JSON events; continuing without tool activity"
             : openCodeCompatibility.diagnostic === "no-compatible-schema"
               ? "This OpenCode client has no verified tool-event schema; continuing without tool activity"
@@ -2500,7 +2504,14 @@ export async function POST(req: Request) {
               : openCodeCompatibility.bundleSource === "built-in"
                 ? "OpenCode schema refresh was not trusted; using the shipped compatible parser"
                 : "OpenCode schema refresh was not trusted; using the last known compatible parser";
-          pushProgress("opencode-compatibility", diagnostic, "error", openCodeCompatibility.diagnostic);
+          pushProgress(
+            "opencode-compatibility",
+            diagnostic,
+            openCodeCompatibility.diagnostic === "capability-probe-unavailable" || openCodeCompatibility.diagnostic === "capability-probe-fallback"
+              ? "done"
+              : "error",
+            openCodeCompatibility.diagnostic,
+          );
         }
         const openCodePlainFallback = openCodeDirect && openCodeCompatibility?.mode === "plain";
         // Plain OpenCode has no structured error envelope, so stdout cannot
@@ -3237,7 +3248,11 @@ export async function POST(req: Request) {
       // stdout. Announce it before spawning instead of relying on handleLine.
       if (openCodeDirect && !openCodeCompatibilityHealthNoticeSent && openCodeCompatibility?.diagnostic) {
         openCodeCompatibilityHealthNoticeSent = true;
-        const diagnostic = openCodeCompatibility.diagnostic === "json-format-unavailable"
+        const diagnostic = openCodeCompatibility.diagnostic === "capability-probe-unavailable"
+          ? "Couldn't verify OpenCode JSON events; continuing in plain chat without tool activity"
+          : openCodeCompatibility.diagnostic === "capability-probe-fallback"
+            ? "OpenCode capability probe was unavailable; using recently verified JSON event support"
+          : openCodeCompatibility.diagnostic === "json-format-unavailable"
           ? "This OpenCode client does not advertise JSON events; continuing without tool activity"
           : openCodeCompatibility.diagnostic === "no-compatible-schema"
             ? "This OpenCode client has no verified tool-event schema; continuing without tool activity"
@@ -3248,7 +3263,14 @@ export async function POST(req: Request) {
             : openCodeCompatibility.bundleSource === "built-in"
               ? "OpenCode schema refresh was not trusted; using the shipped compatible parser"
               : "OpenCode schema refresh was not trusted; using the last known compatible parser";
-        pushProgress("opencode-compatibility", diagnostic, "error", openCodeCompatibility.diagnostic);
+        pushProgress(
+          "opencode-compatibility",
+          diagnostic,
+          openCodeCompatibility.diagnostic === "capability-probe-unavailable" || openCodeCompatibility.diagnostic === "capability-probe-fallback"
+            ? "done"
+            : "error",
+          openCodeCompatibility.diagnostic,
+        );
       }
       if (openCodeFreshSessionForCompatibility) {
         pushProgress(

--- a/src/lib/opencode-compatibility.test.ts
+++ b/src/lib/opencode-compatibility.test.ts
@@ -406,6 +406,18 @@ const offlineBaseline = await resolveOpenCodeCompatibility(
 assert.equal(offlineBaseline.mode, "structured", "a first offline launch keeps the shipped matching parser usable");
 assert.equal(offlineBaseline.bundleSource, "built-in");
 assert.equal(offlineBaseline.diagnostic, "schema-registry-refresh-rejected", "the built-in recovery remains visible to the user");
+const fallbackOfflineBaseline = await resolveOpenCodeCompatibility(
+  { version: "current", probeStatus: "fallback", json: true, model: false, session: true, protocols: ["json"] },
+  {
+    cacheFile: path.join(await mkdtemp(path.join(tmpdir(), "cave-opencode-schema-fallback-baseline-")), "bundle.json"),
+    publicKey: publicPem,
+    url: "https://registry.invalid/opencode.json",
+    now: () => now,
+    fetch: async () => { throw new Error("offline"); },
+  },
+);
+assert.equal(fallbackOfflineBaseline.mode, "structured");
+assert.equal(fallbackOfflineBaseline.diagnostic, "schema-registry-refresh-rejected", "a probe fallback never hides a schema-registry health diagnostic");
 
 const expiredOfflineBaseline = await resolveOpenCodeCompatibility(
   { version: "current", json: true, model: false, session: true, protocols: ["json"] },

--- a/src/lib/opencode-compatibility.test.ts
+++ b/src/lib/opencode-compatibility.test.ts
@@ -332,9 +332,32 @@ assert.equal(rejectedRollback.diagnostic, "schema-registry-refresh-rejected", "r
 const plain = await resolveOpenCodeCompatibility({ version: "9.9.9", json: false, model: true, session: true, protocols: [] });
 assert.equal(plain.mode, "plain");
 assert.equal(plain.diagnostic, "json-format-unavailable", "capabilities, not version thresholds, decide fallback");
+const unavailableProbe = await resolveOpenCodeCompatibility({
+  version: "9.9.9",
+  probeStatus: "unavailable",
+  json: false,
+  model: false,
+  session: false,
+  protocols: [],
+});
+assert.equal(unavailableProbe.mode, "plain");
+assert.equal(unavailableProbe.diagnostic, "capability-probe-unavailable", "an incomplete probe is not presented as proof that OpenCode lacks JSON");
 const structured = await resolveOpenCodeCompatibility({ version: null, json: true, model: false, session: true, protocols: ["json"] });
 assert.equal(structured.mode, "structured");
 assert.equal(structured.schema?.id, "opencode-run-json-v1", "new schemas are chosen by observed capabilities, not a version threshold");
+const fallbackStructured = await resolveOpenCodeCompatibility({
+  version: "1.18.5",
+  probeStatus: "fallback",
+  json: true,
+  model: false,
+  session: true,
+  protocols: ["json"],
+  options: ["--format", "--session"],
+  valueOptions: ["--format", "--session"],
+  structuredOutputs: [{ option: "--format", values: ["json"] }],
+});
+assert.equal(fallbackStructured.mode, "structured");
+assert.equal(fallbackStructured.diagnostic, "capability-probe-fallback", "a recent verified capability remains visible when the fresh probe is unavailable");
 const missingSession = await resolveOpenCodeCompatibility({ version: "1.2.3", json: true, model: true, session: false, protocols: ["json"] });
 assert.equal(missingSession.mode, "plain");
 assert.equal(missingSession.diagnostic, "no-compatible-schema", "an envelope that cannot be distinguished by observed capabilities fails closed");

--- a/src/lib/opencode-compatibility.ts
+++ b/src/lib/opencode-compatibility.ts
@@ -10,6 +10,9 @@ function requireRegistryFs(): RegistryFs {
 
 export type OpenCodeRunCapabilities = {
   version: string | null;
+  /** Whether this capability record came from a complete probe, a bounded
+   * same-launcher fallback, or no usable probe at all. */
+  probeStatus?: "verified" | "fallback" | "unavailable";
   json: boolean;
   model: boolean;
   session: boolean;
@@ -122,6 +125,8 @@ export type OpenCodeCompatibility = {
 
 /** These stable codes are intentionally safe to render or log. Never include event payloads. */
 export type OpenCodeCompatibilityDiagnostic =
+  | "capability-probe-unavailable"
+  | "capability-probe-fallback"
   | "json-format-unavailable"
   | "no-compatible-schema"
   | "schema-quarantined"
@@ -1292,6 +1297,14 @@ export async function resolveOpenCodeCompatibility(
   capabilities: OpenCodeRunCapabilities,
   source?: OpenCodeSchemaBundleSource,
 ): Promise<OpenCodeCompatibility> {
+  if (capabilities.probeStatus === "unavailable") {
+    return {
+      mode: "plain",
+      capabilities,
+      bundleSource: "built-in",
+      diagnostic: "capability-probe-unavailable",
+    };
+  }
   if (!capabilities.json) {
     return {
       mode: "plain",
@@ -1371,6 +1384,8 @@ export async function resolveOpenCodeCompatibility(
     // The shipped parser is a source-trusted offline baseline. A failed
     // registry refresh must not remove otherwise compatible tool activity,
     // but callers still surface the value-free recovery state.
-    diagnostic: loaded.diagnostic,
+    diagnostic: capabilities.probeStatus === "fallback"
+      ? "capability-probe-fallback"
+      : loaded.diagnostic,
   };
 }

--- a/src/lib/opencode-compatibility.ts
+++ b/src/lib/opencode-compatibility.ts
@@ -1384,8 +1384,9 @@ export async function resolveOpenCodeCompatibility(
     // The shipped parser is a source-trusted offline baseline. A failed
     // registry refresh must not remove otherwise compatible tool activity,
     // but callers still surface the value-free recovery state.
-    diagnostic: capabilities.probeStatus === "fallback"
-      ? "capability-probe-fallback"
-      : loaded.diagnostic,
+    // Registry health remains the primary diagnostic. A probe fallback is a
+    // useful non-error notice only when schema loading has no warning to
+    // surface; it must never hide a rejected or unavailable registry refresh.
+    diagnostic: loaded.diagnostic ?? (capabilities.probeStatus === "fallback" ? "capability-probe-fallback" : undefined),
   };
 }


### PR DESCRIPTION
## What changed

- preserve a recently verified OpenCode JSON capability only when a new Windows help probe is transiently unavailable
- bind that fallback to the familiar scope, launcher fingerprint, reported version, and a 60-second lifetime
- distinguish an unavailable capability probe from a confirmed lack of JSON support, avoiding a false error issue in progress UI

## Why

PowerShell/npm launcher cold starts or transient failures can leave `opencode run --help` incomplete. The previous implementation treated this lack of evidence as proof that JSON was unsupported, disabling tool activity even when the installed client supports `--format json`.

## Impact

Windows users retain structured OpenCode tool activity across a short transient probe failure when the same launcher was just verified. New, changed, expired, or unverified launchers still fail closed to plain chat.

## Validation

- `chat-send-capabilities.test.ts`
- `opencode-compatibility.test.ts`
- `harness-routing-opencode.test.ts`
- live capability check against installed OpenCode 1.18.5: verified JSON support resolves to `opencode-run-json-v1`
