### PR TITLE
fix(chat): complete familiar mentions

### DIFF
--- a/docs/specs/2026-07-26-group-chat-mention-selection-design.md
+++ b/docs/specs/2026-07-26-group-chat-mention-selection-design.md
@@ -37,13 +37,15 @@ targets do not read as distinct tokens, and the coven prompt only explains
 
 ### Completed mention state
 
-The group composer records the display name confirmed through the picker. Its
-active-mention synchronization suppresses the same `@Display Name` query after
-selection, including later prose separated by the inserted space. Moving back
-into and editing the selected name clears that completion guard. A different
-active `@` token also clears it and opens the picker normally.
+The group composer records every picker-confirmed `@Display Name` token as a
+span in its coven-specific draft. Text edits reconcile those spans: tokens
+after an edit shift with the text, while editing a confirmed token removes only
+that token's completion. Starting or canceling another `@` therefore cannot
+make an earlier confirmed mention absorb ordinary prose and reopen the picker.
+A different active `@` token opens the picker normally without discarding prior
+completions.
 
-The guard is an interaction detail, not routing state. `parseMentions` continues
+The spans are interaction details, not routing state. `parseMentions` continues
 to derive recipients from visible text at send time.
 
 ### Standout targets
@@ -83,8 +85,9 @@ whether an `@` mention may dispatch follow-up work.
 
 ## Verification
 
-- Pure tests reproduce selection followed by ordinary prose and a subsequent
-  fresh `@`.
+- Pure tests reproduce selection followed by ordinary prose, canceling a
+  subsequent `@`, preserving two confirmed mentions through prose edits, and
+  invalidating only the confirmed token that is edited.
 - Prompt tests require exact `@display name` guidance.
 - Group-view contract tests pin the persistent hint, plain placeholder,
   completion guard, announcement, and composer/transcript pills.

--- a/docs/specs/2026-07-26-group-chat-mention-selection-design.md
+++ b/docs/specs/2026-07-26-group-chat-mention-selection-design.md
@@ -1,0 +1,94 @@
+# Group chat mention selection
+
+## Problem
+
+Desktop group chat treats a picker-confirmed mention as an unfinished
+multi-word query. Selecting Sage inserts `@Sage `, but the composer immediately
+scans that text again; ordinary prose such as `@Sage what do you think?` keeps
+the mention popover open and eventually shows a false “No matching familiar”
+state.
+
+The interface also hides its `@` instruction inside the placeholder, selected
+targets do not read as distinct tokens, and the coven prompt only explains
+`@display name` addressing inside the narrower delegation protocol.
+
+## Goals
+
+- A picker-confirmed mention closes autocomplete immediately.
+- Ordinary text after that mention stays ordinary text.
+- Typing a new `@` opens a fresh familiar search.
+- Selected `@Display Name` targets stand out in the composer and group
+  transcript.
+- The composer keeps a persistent instruction to use `@` outside its
+  placeholder.
+- Every familiar receives concise coven context explaining that exact
+  `@Display Name` tags address another familiar.
+- Raw message text remains the routing authority and the accessible textarea
+  remains the editing control.
+
+## Non-goals
+
+- Replacing the textarea with a rich-text or `contenteditable` editor.
+- Changing mention parsing, targeted-message routing, or delegation security.
+- Changing one-to-one chat or iOS mention behavior.
+- Adding durable mention metadata to stored transcript records.
+
+## Design
+
+### Completed mention state
+
+The group composer records the display name confirmed through the picker. Its
+active-mention synchronization suppresses the same `@Display Name` query after
+selection, including later prose separated by the inserted space. Moving back
+into and editing the selected name clears that completion guard. A different
+active `@` token also clears it and opens the picker normally.
+
+The guard is an interaction detail, not routing state. `parseMentions` continues
+to derive recipients from visible text at send time.
+
+### Standout targets
+
+The view derives familiar targets from the current raw text with the existing
+mention parser. It renders their literal `@Display Name` labels as compact
+accent-tinted pills:
+
+- in a persistent target strip above the group textarea; and
+- alongside group transcript messages that contain familiar mentions.
+
+The pills use `--accent-presence` with the design system tint recipe, a hairline
+border, and `--radius-pill`. They add no new color vocabulary and survive every
+theme/mode combination. Raw `@` text stays visible in the textarea and message
+body, so copy/paste, editing, persistence, accessibility, and routing do not
+depend on decoration.
+
+When no target is present, the composer strip says “Use @ to tag a familiar.”
+The textarea placeholder returns to the plain composition grammar
+`Message <count> familiar(s)…`.
+
+### Familiar guidance
+
+The coven roster prompt adds one identity-safe instruction after the participant
+list: use another familiar’s exact `@Display Name` when addressing them in this
+chat. Existing delegation instructions remain unchanged and continue to govern
+whether an `@` mention may dispatch follow-up work.
+
+### Accessibility
+
+- Picker selection announces `Tagged <name>.`
+- The persistent target strip exposes a concise tagged-familiar label while
+  decorative pills avoid duplicate announcements.
+- The existing textarea, keyboard navigation, IME guard, Popover focus
+  behavior, and visible focus rings remain intact.
+- Styling is static, so no new motion or reduced-motion handling is needed.
+
+## Verification
+
+- Pure tests reproduce selection followed by ordinary prose and a subsequent
+  fresh `@`.
+- Prompt tests require exact `@display name` guidance.
+- Group-view contract tests pin the persistent hint, plain placeholder,
+  completion guard, announcement, and composer/transcript pills.
+- Focused app tests, test wiring, design lint/codemod checks, typecheck, and the
+  full app suite pass.
+- Native Tauri verification confirms the picker closes after selection, pills
+  render in the composer/transcript, and a new `@` reopens the picker.

--- a/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
+++ b/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
@@ -4,7 +4,7 @@
 
 **Goal:** Make desktop group-chat mentions finish cleanly after picker selection, visibly identify tagged familiars, and teach coven familiars to address one another with exact `@Display Name` tags.
 
-**Architecture:** Keep visible message text as the sole routing/persistence authority. Extend the pure active-mention helper with an optional picker-confirmed name guard, derive visual pills from existing mention parsing, and add one identity-safe instruction to the coven roster prompt. The accessible textarea, Popover, and delegation validator remain unchanged.
+**Architecture:** Keep visible message text as the sole routing/persistence authority. Track picker-confirmed token spans per draft, reconcile unaffected spans across text edits, derive visual pills from existing mention parsing, and add one identity-safe instruction to the coven roster prompt. The accessible textarea, Popover, and delegation validator remain unchanged.
 
 **Tech Stack:** TypeScript, React 19, Node test runner, CSS design tokens, Next.js/Tauri desktop shell.
 
@@ -25,20 +25,38 @@ Add focused cases beside the existing `findActiveMention` tests:
 ```ts
 test("findActiveMention: picker-confirmed mention stays complete while prose continues", () => {
   const selected = applyMention("hello @sa", 6, "sa", "Sage");
-  assert.equal(findActiveMention(selected.text, selected.caret, "Sage"), null);
+  assert.equal(findActiveMention(selected.text, selected.caret, [selected.completion]), null);
 
   const continued = `${selected.text}what do you think?`;
-  assert.equal(findActiveMention(continued, continued.length, "Sage"), null);
+  const completions = reconcileMentionCompletions(
+    selected.text,
+    continued,
+    [selected.completion],
+  );
+  assert.equal(findActiveMention(continued, continued.length, completions), null);
 });
 
-test("findActiveMention: a new @ starts a fresh search after a completed mention", () => {
-  const text = "hello @Sage what do you think? @";
-  assert.deepEqual(findActiveMention(text, text.length, "Sage"), {
-    start: text.length - 1,
+test("mention completions: canceling a second token preserves the first completion", () => {
+  const first = applyMention("hello @sa", 6, "sa", "Sage");
+  const withSecondToken = `${first.text}review this @`;
+  let completions = reconcileMentionCompletions(
+    first.text,
+    withSecondToken,
+    [first.completion],
+  );
+  assert.deepEqual(findActiveMention(withSecondToken, withSecondToken.length, completions), {
+    start: withSecondToken.length - 1,
     query: "",
   });
+
+  const canceled = withSecondToken.slice(0, -1);
+  completions = reconcileMentionCompletions(withSecondToken, canceled, completions);
+  assert.equal(findActiveMention(canceled, canceled.length, completions), null);
 });
 ```
+
+Add lifecycle cases that preserve two confirmed tokens through prose edits and
+discard only the confirmed token whose own text is edited.
 
 Extend the roster prompt test:
 
@@ -56,32 +74,36 @@ node --experimental-strip-types --test src/lib/group-chat.test.ts
 
 Expected: FAIL because a picker-confirmed `@Sage ` still returns an active query and the roster lacks general `@` addressing guidance.
 
-- [x] **Step 3: Add the minimal completion guard**
+- [x] **Step 3: Add token-specific completion state**
 
-Extend `findActiveMention` without changing its existing callers:
+Represent picker-confirmed tokens by their draft spans and pass all valid
+completions to `findActiveMention`:
 
 ```ts
+export type MentionCompletion = {
+  start: number;
+  end: number;
+  name: string;
+};
+
 export function findActiveMention(
   text: string,
   caret: number,
-  completedName?: string,
+  completions: readonly MentionCompletion[] = [],
 ): { start: number; query: string } | null {
   let i = caret - 1;
   while (i >= 0 && text[i] !== "@" && text[i] !== "\n") i--;
   if (i < 0 || text[i] !== "@") return null;
   if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) return null;
-  const query = text.slice(i + 1, caret);
-  const completed = completedName?.trim().toLocaleLowerCase();
-  const normalizedQuery = query.toLocaleLowerCase();
-  if (
-    completed &&
-    (normalizedQuery === completed || normalizedQuery.startsWith(`${completed} `))
-  ) {
-    return null;
-  }
-  return { start: i, query };
+  if (completions.some((completion) => completion.start === i)) return null;
+  return { start: i, query: text.slice(i + 1, caret) };
 }
 ```
+
+Add `reconcileMentionCompletions(previousText, nextText, completions)` to shift
+unaffected spans and discard a completion only when its own token is edited or
+ceases to be a standalone mention. `applyMention` returns the new completion
+alongside its rewritten text and caret.
 
 Add this line to `renderCovenRoster` after the participant-count instruction:
 
@@ -115,9 +137,9 @@ const covenStyles = readFileSync(new URL("../styles/coven-tab.css", import.meta.
 Add a focused test that requires:
 
 ```ts
-assert.match(view, /const completedMentionNameRef = useRef<string \| null>\(null\)/);
-assert.match(view, /findActiveMention\([\s\S]*completedMentionNameRef\.current \?\? undefined/);
-assert.match(view, /completedMentionNameRef\.current = f\.name\.trim\(\)/);
+assert.match(view, /const completedMentionsRef = useRef<MentionCompletion\[]>\(\[\]\)/);
+assert.match(view, /findActiveMention\([\s\S]*completedMentionsRef\.current/);
+assert.match(view, /reconcileMentionCompletions\(/);
 assert.match(view, /announce\(`Tagged \$\{f\.name\}\.`\)/);
 assert.match(view, /Use @ to tag a familiar/);
 assert.match(view, /<CovenMentionPills[\s\S]*familiars=\{composerTargets\}/);
@@ -186,36 +208,42 @@ function CovenMentionPills({
 Add the ref near the existing textarea refs:
 
 ```ts
-const completedMentionNameRef = useRef<string | null>(null);
+const completedMentionsRef = useRef<MentionCompletion[]>([]);
 ```
 
-Update `syncMention` to compare the raw active token with the guarded result:
+Update `syncMention` to pass every valid picker-confirmed token:
 
 ```ts
-const raw = findActiveMention(el.value, el.selectionStart ?? el.value.length);
 const next = findActiveMention(
   el.value,
   el.selectionStart ?? el.value.length,
-  completedMentionNameRef.current ?? undefined,
+  completedMentionsRef.current,
 );
-if (raw && next && completedMentionNameRef.current) {
-  completedMentionNameRef.current = null;
-}
 setMention(next);
 ```
 
-Before rewriting the draft in `chooseMention`, record and announce selection:
+Before rewriting the draft in `chooseMention`, reconcile earlier completions,
+record the new token, and announce selection:
 
 ```ts
-completedMentionNameRef.current = f.name.trim();
+const { text, caret, completion } = applyMention(
+  draft,
+  mention.start,
+  mention.query,
+  f.name,
+);
+completedMentionsRef.current = [
+  ...reconcileMentionCompletions(draft, text, completedMentionsRef.current),
+  completion,
+];
 announce(`Tagged ${f.name}.`);
 ```
 
 Include `announce` in that callback’s dependency list.
 
-Clear `completedMentionNameRef.current` when a message is sent and when the
-active coven swaps, alongside the existing `setDraft` / `setMention` resets, so
-picker state never leaks across drafts or covens.
+Reconcile the spans from the old draft to `e.target.value` in `onChange`. Stash
+and restore the span list with each coven draft, and clear it when a message is
+sent, so picker state never leaks across drafts or covens.
 
 - [x] **Step 3: Derive current composer and reply targets**
 

--- a/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
+++ b/docs/specs/2026-07-26-group-chat-mention-selection-plan.md
@@ -1,0 +1,386 @@
+# Group Chat Mentions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make desktop group-chat mentions finish cleanly after picker selection, visibly identify tagged familiars, and teach coven familiars to address one another with exact `@Display Name` tags.
+
+**Architecture:** Keep visible message text as the sole routing/persistence authority. Extend the pure active-mention helper with an optional picker-confirmed name guard, derive visual pills from existing mention parsing, and add one identity-safe instruction to the coven roster prompt. The accessible textarea, Popover, and delegation validator remain unchanged.
+
+**Tech Stack:** TypeScript, React 19, Node test runner, CSS design tokens, Next.js/Tauri desktop shell.
+
+**Authority note:** Commit steps are intentionally omitted. The active conservative profile permits tracked edits and verification but does not grant commit or push authority.
+
+---
+
+### Task 1: Pin completed mentions and familiar prompt guidance
+
+**Files:**
+- Modify: `src/lib/group-chat.test.ts`
+- Modify: `src/lib/group-chat.ts`
+
+- [x] **Step 1: Write the failing completed-selection tests**
+
+Add focused cases beside the existing `findActiveMention` tests:
+
+```ts
+test("findActiveMention: picker-confirmed mention stays complete while prose continues", () => {
+  const selected = applyMention("hello @sa", 6, "sa", "Sage");
+  assert.equal(findActiveMention(selected.text, selected.caret, "Sage"), null);
+
+  const continued = `${selected.text}what do you think?`;
+  assert.equal(findActiveMention(continued, continued.length, "Sage"), null);
+});
+
+test("findActiveMention: a new @ starts a fresh search after a completed mention", () => {
+  const text = "hello @Sage what do you think? @";
+  assert.deepEqual(findActiveMention(text, text.length, "Sage"), {
+    start: text.length - 1,
+    query: "",
+  });
+});
+```
+
+Extend the roster prompt test:
+
+```ts
+assert.match(out, /tag them with @ followed by their exact display name/i);
+```
+
+- [x] **Step 2: Run the focused model test and verify RED**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/group-chat.test.ts
+```
+
+Expected: FAIL because a picker-confirmed `@Sage ` still returns an active query and the roster lacks general `@` addressing guidance.
+
+- [x] **Step 3: Add the minimal completion guard**
+
+Extend `findActiveMention` without changing its existing callers:
+
+```ts
+export function findActiveMention(
+  text: string,
+  caret: number,
+  completedName?: string,
+): { start: number; query: string } | null {
+  let i = caret - 1;
+  while (i >= 0 && text[i] !== "@" && text[i] !== "\n") i--;
+  if (i < 0 || text[i] !== "@") return null;
+  if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) return null;
+  const query = text.slice(i + 1, caret);
+  const completed = completedName?.trim().toLocaleLowerCase();
+  const normalizedQuery = query.toLocaleLowerCase();
+  if (
+    completed &&
+    (normalizedQuery === completed || normalizedQuery.startsWith(`${completed} `))
+  ) {
+    return null;
+  }
+  return { start: i, query };
+}
+```
+
+Add this line to `renderCovenRoster` after the participant-count instruction:
+
+```ts
+"When addressing another familiar in this coven, tag them with @ followed by their exact display name as listed above.",
+```
+
+- [x] **Step 4: Run the focused model test and verify GREEN**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/lib/group-chat.test.ts
+```
+
+Expected: PASS with zero failures.
+
+### Task 2: Pin the group-chat interaction and visual contract
+
+**Files:**
+- Modify: `src/components/group-chat-view.test.ts`
+
+- [x] **Step 1: Add failing source-contract assertions**
+
+Read `src/styles/coven-tab.css` in the test setup:
+
+```ts
+const covenStyles = readFileSync(new URL("../styles/coven-tab.css", import.meta.url), "utf8");
+```
+
+Add a focused test that requires:
+
+```ts
+assert.match(view, /const completedMentionNameRef = useRef<string \| null>\(null\)/);
+assert.match(view, /findActiveMention\([\s\S]*completedMentionNameRef\.current \?\? undefined/);
+assert.match(view, /completedMentionNameRef\.current = f\.name\.trim\(\)/);
+assert.match(view, /announce\(`Tagged \$\{f\.name\}\.`\)/);
+assert.match(view, /Use @ to tag a familiar/);
+assert.match(view, /<CovenMentionPills[\s\S]*familiars=\{composerTargets\}/);
+assert.match(view, /<CovenMentionPills familiars=\{targets \?\? \[\]\}/);
+assert.match(view, /<CovenMentionPills familiars=\{replyTargets\}/);
+assert.match(
+  view,
+  /`Message \$\{participants\.length\} familiar\$\{participants\.length === 1 \? "" : "s"\}…`/,
+);
+assert.match(covenStyles, /\.coven-tab__mention-chip[\s\S]*var\(--accent-presence\)/);
+assert.match(covenStyles, /\.coven-tab__composer-field/);
+```
+
+- [x] **Step 2: Run the group-view test and verify RED**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/components/group-chat-view.test.ts
+```
+
+Expected: FAIL because the completion ref, announcement, pills, persistent hint, and styles do not exist.
+
+### Task 3: Implement the composer and transcript affordances
+
+**Files:**
+- Modify: `src/components/group-chat-view.tsx`
+- Modify: `src/styles/coven-tab.css`
+
+- [x] **Step 1: Add a local pill primitive**
+
+Add a group-chat-specific component after `Props`:
+
+```tsx
+function CovenMentionPills({
+  familiars,
+  emptyHint,
+  align = "start",
+}: {
+  familiars: ResolvedFamiliar[];
+  emptyHint?: string;
+  align?: "start" | "end";
+}) {
+  if (familiars.length === 0 && !emptyHint) return null;
+  const names = familiars.map((f) => f.display_name);
+  return (
+    <div
+      className={`coven-tab__mention-strip${align === "end" ? " coven-tab__mention-strip--end" : ""}`}
+      aria-label={names.length > 0 ? `Tagged familiars: ${names.join(", ")}` : emptyHint}
+    >
+      <span className="coven-tab__mention-guidance">
+        {names.length > 0 ? "Tagged" : emptyHint}
+      </span>
+      {familiars.map((f) => (
+        <span key={f.id} className="coven-tab__mention-chip" aria-hidden="true">
+          @{f.display_name}
+        </span>
+      ))}
+    </div>
+  );
+}
+```
+
+- [x] **Step 2: Wire picker-confirmed completion**
+
+Add the ref near the existing textarea refs:
+
+```ts
+const completedMentionNameRef = useRef<string | null>(null);
+```
+
+Update `syncMention` to compare the raw active token with the guarded result:
+
+```ts
+const raw = findActiveMention(el.value, el.selectionStart ?? el.value.length);
+const next = findActiveMention(
+  el.value,
+  el.selectionStart ?? el.value.length,
+  completedMentionNameRef.current ?? undefined,
+);
+if (raw && next && completedMentionNameRef.current) {
+  completedMentionNameRef.current = null;
+}
+setMention(next);
+```
+
+Before rewriting the draft in `chooseMention`, record and announce selection:
+
+```ts
+completedMentionNameRef.current = f.name.trim();
+announce(`Tagged ${f.name}.`);
+```
+
+Include `announce` in that callback’s dependency list.
+
+Clear `completedMentionNameRef.current` when a message is sent and when the
+active coven swaps, alongside the existing `setDraft` / `setMention` resets, so
+picker state never leaks across drafts or covens.
+
+- [x] **Step 3: Derive current composer and reply targets**
+
+After `mentionable`, derive composer targets with the existing parser:
+
+```ts
+const composerTargets = useMemo(
+  () =>
+    parseMentions(draft, mentionable)
+      .map((id) => byId.get(id))
+      .filter((f): f is ResolvedFamiliar => Boolean(f)),
+  [draft, mentionable, byId],
+);
+```
+
+Inside each assistant reply render, derive `replyTargets` from `visibleText` the same way:
+
+```ts
+const replyTargets = parseMentions(visibleText, mentionable)
+  .map((id) => byId.get(id))
+  .filter((target): target is ResolvedFamiliar => Boolean(target));
+```
+
+- [x] **Step 4: Render pills and persistent composer guidance**
+
+Replace the old `to <names>` target line with:
+
+```tsx
+<CovenMentionPills familiars={targets ?? []} align="end" />
+```
+
+Render `<CovenMentionPills familiars={replyTargets} />` between each assistant meta row and `MessageBubble`.
+
+Wrap the textarea in:
+
+```tsx
+<div className="coven-tab__composer-field">
+  <CovenMentionPills
+    familiars={composerTargets}
+    emptyHint="Use @ to tag a familiar"
+  />
+  <textarea ... />
+</div>
+```
+
+Change the populated placeholder to:
+
+```tsx
+`Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}…`
+```
+
+- [x] **Step 5: Add token-only styles**
+
+Add to the composer section of `src/styles/coven-tab.css`:
+
+```css
+.coven-tab__composer-field {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.coven-tab__mention-strip {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.coven-tab__mention-strip--end {
+  justify-content: flex-end;
+}
+
+.coven-tab__mention-guidance {
+  margin-inline-end: var(--space-1);
+}
+
+.coven-tab__mention-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--space-6);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--accent-presence);
+  font-weight: 600;
+  line-height: 1;
+}
+```
+
+- [x] **Step 6: Run focused tests and verify GREEN**
+
+Run:
+
+```bash
+node --experimental-strip-types --test \
+  src/lib/group-chat.test.ts \
+  src/components/group-chat-view.test.ts
+```
+
+Expected: PASS with zero failures.
+
+### Task 4: Verify design, types, suite coverage, and native behavior
+
+**Files:**
+- Verify: `src/lib/group-chat.ts`
+- Verify: `src/components/group-chat-view.tsx`
+- Verify: `src/styles/coven-tab.css`
+- Verify: `docs/specs/2026-07-26-group-chat-mention-selection-design.md`
+
+- [x] **Step 1: Run static gates**
+
+Run:
+
+```bash
+pnpm check:tests-wired
+pnpm lint
+pnpm typecheck
+git diff --check
+```
+
+Expected: every command exits 0.
+
+- [x] **Step 2: Run the full app suite**
+
+Run:
+
+```bash
+pnpm test:app
+```
+
+Expected: all app test files pass with zero failures.
+
+- [x] **Step 3: Launch the native app**
+
+Run in the foreground:
+
+```bash
+bash scripts/dev-app.sh
+```
+
+Expected: Next reports a loopback URL and Tauri reports `Running DevCommand`.
+
+- [x] **Step 4: Verify the exact interaction in the Tauri window**
+
+In a coven with Sage:
+
+1. Type `hello @sa`.
+2. Select Sage from the picker.
+3. Confirm the picker closes and an accent `@Sage` pill appears.
+4. Type ` what do you think?`; confirm the picker stays closed.
+5. Type another ` @`; confirm the picker opens again.
+6. Send the message; confirm the transcript shows the `@Sage` pill.
+7. Confirm the roster prompt coverage pins exact `@Display Name` addressing
+   guidance for every familiar.
+
+- [x] **Step 5: Record evidence without committing**
+
+Update Bead `cave-w4ldv` with the branch, worktree, changed files, exact
+verification commands, native observations, and remaining commit/push step.
+Leave the Bead open unless the user explicitly declares the unmerged local work
+complete.

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -119,41 +119,50 @@ test("@mentions target a subset of the coven", () => {
   assert.match(view, /targetFamiliarIds: targeted \? targetIds : undefined/, "records targeted ids on the user turn");
   assert.match(view, /replies: GroupReply\[\] = orderedTargetIds\.map/, "only the targets reply, in the selected mode's order");
   // Composer autocomplete reuses the tested pure helpers.
-  assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");
+  assert.match(view, /findActiveMention\(\s*el\.value/, "detects the active mention token");
   assert.match(view, /matchMentions\(mention\.query, mentionable\)/, "filters the roster by the query");
-  assert.match(view, /applyMention\(draft, mention\.start, mention\.query/, "inserts the chosen familiar");
+  assert.match(
+    view,
+    /applyMention\(\s*draft,\s*mention\.start,\s*mention\.query/,
+    "inserts the chosen familiar",
+  );
 });
 
 test("completed @mentions close autocomplete and render as standout targets", () => {
   assert.match(
     view,
-    /const completedMentionNameRef = useRef<string \| null>\(null\)/,
-    "tracks the picker-confirmed familiar separately from routing state",
+    /const completedMentionsRef = useRef<MentionCompletion\[]>\(\[\]\)/,
+    "tracks every picker-confirmed token separately from routing state",
   );
   assert.match(
     view,
-    /const completedMentionsByGroupRef = useRef\(new Map<string, string>\(\)\)/,
+    /const completedMentionsByGroupRef = useRef\(\s*new Map<string, MentionCompletion\[]>\(\),?\s*\)/,
     "keeps picker-confirmed completion state with each coven draft",
   );
   assert.match(
     view,
-    /completedMentionsByGroupRef\.current\.set\(outgoingGroupId, completedName\)/,
+    /completedMentionsByGroupRef\.current\.set\(outgoingGroupId, completions\)/,
     "stashes the outgoing coven's completion state",
   );
   assert.match(
     view,
-    /completedMentionNameRef\.current = activeId[\s\S]{0,180}completedMentionsByGroupRef\.current\.get\(activeId\)/,
+    /completedMentionsRef\.current = activeId[\s\S]{0,180}completedMentionsByGroupRef\.current\.get\(activeId\)/,
     "restores the incoming coven's completion state",
   );
   assert.match(
     view,
-    /findActiveMention\([\s\S]*completedMentionNameRef\.current \?\? undefined/,
-    "suppresses autocomplete for the picker-confirmed mention",
+    /findActiveMention\([\s\S]{0,180}completedMentionsRef\.current/,
+    "suppresses autocomplete for every picker-confirmed token",
   );
   assert.match(
     view,
-    /completedMentionNameRef\.current = f\.name\.trim\(\)/,
-    "records the exact selected display name",
+    /reconcileMentionCompletions\(\s*draftRef\.current,\s*nextDraft,\s*completedMentionsRef\.current,\s*\)/,
+    "carries unaffected completions across textarea edits",
+  );
+  assert.match(
+    view,
+    /completedMentionsRef\.current = \[[\s\S]{0,260}\.\.\.reconcileMentionCompletions\([\s\S]{0,260}completion/,
+    "adds each selected token without discarding prior completions",
   );
   assert.match(view, /announce\(`Tagged \$\{f\.name\}\.`\)/, "announces the selected familiar");
 
@@ -481,7 +490,7 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
   }
   assert.match(
     view,
-    /const outgoingGroupId = draftOwnerRef\.current;[\s\S]{0,180}?draftsByGroupRef\.current\.set\(outgoingGroupId, draftRef\.current\);[\s\S]{0,520}?setDraft\(activeId \? draftsByGroupRef\.current\.get\(activeId\) \?\? "" : ""\);/,
+    /const outgoingGroupId = draftOwnerRef\.current;[\s\S]{0,180}?draftsByGroupRef\.current\.set\(outgoingGroupId, draftRef\.current\);[\s\S]{0,700}?const incomingDraft = activeId[\s\S]{0,160}?draftsByGroupRef\.current\.get\(activeId\)[\s\S]{0,160}?setDraft\(incomingDraft\);/,
     "switching covens stashes the outgoing draft and restores the incoming one (no cross-coven bleed)",
   );
   assert.match(

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -9,6 +9,7 @@ const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const transcript = readFileSync(new URL("../lib/group-chat-transcript.ts", import.meta.url), "utf8");
+const covenStyles = readFileSync(new URL("../styles/coven-tab.css", import.meta.url), "utf8");
 
 test("GroupChatView schedules Broadcast and Round robin replies through /api/chat/send", () => {
   assert.match(view, /export function GroupChatView/, "exports GroupChatView");
@@ -121,6 +122,87 @@ test("@mentions target a subset of the coven", () => {
   assert.match(view, /findActiveMention\(el\.value/, "detects the active mention token");
   assert.match(view, /matchMentions\(mention\.query, mentionable\)/, "filters the roster by the query");
   assert.match(view, /applyMention\(draft, mention\.start, mention\.query/, "inserts the chosen familiar");
+});
+
+test("completed @mentions close autocomplete and render as standout targets", () => {
+  assert.match(
+    view,
+    /const completedMentionNameRef = useRef<string \| null>\(null\)/,
+    "tracks the picker-confirmed familiar separately from routing state",
+  );
+  assert.match(
+    view,
+    /const completedMentionsByGroupRef = useRef\(new Map<string, string>\(\)\)/,
+    "keeps picker-confirmed completion state with each coven draft",
+  );
+  assert.match(
+    view,
+    /completedMentionsByGroupRef\.current\.set\(outgoingGroupId, completedName\)/,
+    "stashes the outgoing coven's completion state",
+  );
+  assert.match(
+    view,
+    /completedMentionNameRef\.current = activeId[\s\S]{0,180}completedMentionsByGroupRef\.current\.get\(activeId\)/,
+    "restores the incoming coven's completion state",
+  );
+  assert.match(
+    view,
+    /findActiveMention\([\s\S]*completedMentionNameRef\.current \?\? undefined/,
+    "suppresses autocomplete for the picker-confirmed mention",
+  );
+  assert.match(
+    view,
+    /completedMentionNameRef\.current = f\.name\.trim\(\)/,
+    "records the exact selected display name",
+  );
+  assert.match(view, /announce\(`Tagged \$\{f\.name\}\.`\)/, "announces the selected familiar");
+
+  assert.match(view, /function CovenMentionPills/, "owns one group-specific mention-pill primitive");
+  assert.match(
+    view,
+    /function CovenMentionPills[\s\S]{0,700}<div[\s\S]{0,200}role="note"[\s\S]{0,200}aria-label=/,
+    "exposes the pill summary through a valid named ARIA role",
+  );
+  assert.match(view, /Use @ to tag a familiar/, "keeps the @ instruction visible outside the placeholder");
+  assert.match(view, /const mentionGuidanceId = useId\(\)/, "gives the persistent guidance a stable local id");
+  assert.match(
+    view,
+    /aria-describedby=\{participants\.length > 0 \? mentionGuidanceId : undefined\}/,
+    "connects the textarea only when persistent @ guidance is rendered",
+  );
+  assert.match(
+    view,
+    /<CovenMentionPills[\s\S]*familiars=\{composerTargets\}/,
+    "shows parsed targets in the composer",
+  );
+  assert.match(
+    view,
+    /<CovenMentionPills familiars=\{targets \?\? \[\]\} align="end" \/>/,
+    "shows target pills on sent user turns",
+  );
+  assert.match(
+    view,
+    /<CovenMentionPills familiars=\{replyTargets\} \/>/,
+    "shows familiar tags on assistant turns",
+  );
+  assert.match(
+    view,
+    /`Message \$\{participants\.length\} familiar\$\{participants\.length === 1 \? "" : "s"\}…`/,
+    "keeps the populated placeholder focused on composition",
+  );
+  assert.doesNotMatch(view, /\(@ to tag one\)/, "does not hide required mention guidance in the placeholder");
+
+  assert.match(covenStyles, /\.coven-tab__composer-field/, "composer field makes room for persistent target guidance");
+  assert.match(
+    covenStyles,
+    /\.coven-tab__mention-chip[\s\S]*var\(--accent-presence\)/,
+    "mention pills derive their standout state from the presence accent",
+  );
+  assert.match(
+    covenStyles,
+    /\.coven-tab__mention-chip[\s\S]*color-mix\(in oklch,[\s\S]*14%/,
+    "mention pills use the design-system tint recipe",
+  );
 });
 
 test("completed familiar delegation trailers route bounded, attributable follow-up work", () => {
@@ -399,7 +481,7 @@ test("Group chat is a world-class chat surface (a11y + resilience)", () => {
   }
   assert.match(
     view,
-    /if \(draftOwnerRef\.current\) draftsByGroupRef\.current\.set\(draftOwnerRef\.current, draftRef\.current\);[\s\S]{0,220}?setDraft\(activeId \? draftsByGroupRef\.current\.get\(activeId\) \?\? "" : ""\);/,
+    /const outgoingGroupId = draftOwnerRef\.current;[\s\S]{0,180}?draftsByGroupRef\.current\.set\(outgoingGroupId, draftRef\.current\);[\s\S]{0,520}?setDraft\(activeId \? draftsByGroupRef\.current\.get\(activeId\) \?\? "" : ""\);/,
     "switching covens stashes the outgoing draft and restores the incoming one (no cross-coven bleed)",
   );
   assert.match(

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -18,6 +18,7 @@ import "@/styles/coven-tab.css";
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -99,6 +100,38 @@ type Props = {
   onDebugSession?: (sessionId: string, familiarId: string) => void;
 };
 
+function CovenMentionPills({
+  familiars,
+  emptyHint,
+  align = "start",
+  id,
+}: {
+  familiars: ResolvedFamiliar[];
+  emptyHint?: string;
+  align?: "start" | "end";
+  id?: string;
+}) {
+  if (familiars.length === 0 && !emptyHint) return null;
+  const names = familiars.map((f) => f.display_name);
+  return (
+    <div
+      id={id}
+      role="note"
+      className={`coven-tab__mention-strip${align === "end" ? " coven-tab__mention-strip--end" : ""}`}
+      aria-label={names.length > 0 ? `Tagged familiars: ${names.join(", ")}` : emptyHint}
+    >
+      <span className="coven-tab__mention-guidance">
+        {names.length > 0 ? "Tagged" : emptyHint}
+      </span>
+      {familiars.map((f) => (
+        <span key={f.id} className="coven-tab__mention-chip" aria-hidden="true">
+          @{f.display_name}
+        </span>
+      ))}
+    </div>
+  );
+}
+
 const EMPTY_FAMILIAR_IDS: readonly string[] = [];
 
 export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugSession }: Props) {
@@ -124,6 +157,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const dtPrefs = useDateTimePrefs();
   const confirm = useConfirm();
   const { announce } = useAnnouncer();
+  const mentionGuidanceId = useId();
 
   const addBtnRef = useRef<HTMLButtonElement | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -141,6 +175,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   // Caret to restore after we programmatically rewrite the draft (mention insert).
   const pendingCaretRef = useRef<number | null>(null);
+  // Picker-confirmed names stay complete while the user continues ordinary
+  // prose. This is autocomplete state only; visible text remains authoritative.
+  const completedMentionNameRef = useRef<string | null>(null);
   const groupsRef = useRef<CovenGroup[]>(groups);
   groupsRef.current = groups;
   // Live mirror of the transcript so retry can read the answered user turn
@@ -153,6 +190,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const draftsByGroupRef = useRef(new Map<string, string>());
+  const completedMentionsByGroupRef = useRef(new Map<string, string>());
   const draftOwnerRef = useRef<string | null>(null);
   // Which group the in-memory transcript belongs to (set by the swap effect).
   // The persist effect must not save until the swap has caught up, or the
@@ -231,10 +269,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
     // Swap the composer draft along with the transcript: stash the outgoing
     // coven's draft and restore the incoming one's (or a clean slate).
     if (draftOwnerRef.current !== activeId) {
-      if (draftOwnerRef.current) draftsByGroupRef.current.set(draftOwnerRef.current, draftRef.current);
+      const outgoingGroupId = draftOwnerRef.current;
+      if (outgoingGroupId) {
+        draftsByGroupRef.current.set(outgoingGroupId, draftRef.current);
+        const completedName = completedMentionNameRef.current;
+        if (completedName) {
+          completedMentionsByGroupRef.current.set(outgoingGroupId, completedName);
+        } else {
+          completedMentionsByGroupRef.current.delete(outgoingGroupId);
+        }
+      }
       draftOwnerRef.current = activeId;
       setDraft(activeId ? draftsByGroupRef.current.get(activeId) ?? "" : "");
       setMention(null);
+      completedMentionNameRef.current = activeId
+        ? completedMentionsByGroupRef.current.get(activeId) ?? null
+        : null;
     }
     if (!activeId) {
       setTranscript([]);
@@ -396,6 +446,11 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
         }
       }
       draftsByGroupRef.current.delete(id);
+      completedMentionsByGroupRef.current.delete(id);
+      if (draftOwnerRef.current === id) {
+        draftOwnerRef.current = null;
+        completedMentionNameRef.current = null;
+      }
       if (typeof localStorage !== "undefined") {
         try {
           localStorage.removeItem(`cave:group-chat:transcript:${id}`);
@@ -656,6 +711,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
       setTranscript((prev) => [...prev, userTurn, ...replies]);
       setDraft("");
       setMention(null);
+      completedMentionNameRef.current = null;
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
@@ -947,6 +1003,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
     () => (mention ? matchMentions(mention.query, mentionable) : []),
     [mention, mentionable],
   );
+  const composerTargets = useMemo(
+    () =>
+      parseMentions(draft, mentionable)
+        .map((id) => byId.get(id))
+        .filter((f): f is ResolvedFamiliar => Boolean(f)),
+    [draft, mentionable, byId],
+  );
   // Open whenever an @token is being typed (a no-match query shows the
   // "No matching familiar in this coven" empty state instead of vanishing);
   // key navigation below only engages while there are matches.
@@ -956,7 +1019,16 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const syncMention = useCallback(() => {
     const el = textareaRef.current;
     if (!el) return;
-    const next = findActiveMention(el.value, el.selectionStart ?? el.value.length);
+    const caret = el.selectionStart ?? el.value.length;
+    const raw = findActiveMention(el.value, caret);
+    const next = findActiveMention(
+      el.value,
+      caret,
+      completedMentionNameRef.current ?? undefined,
+    );
+    if (raw && next && completedMentionNameRef.current) {
+      completedMentionNameRef.current = null;
+    }
     setMention(next);
     setMentionIndex(0);
   }, []);
@@ -965,11 +1037,13 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
     (f: MentionableFamiliar) => {
       if (!mention) return;
       const { text, caret } = applyMention(draft, mention.start, mention.query, f.name);
+      completedMentionNameRef.current = f.name.trim();
       pendingCaretRef.current = caret;
       setDraft(text);
       setMention(null);
+      announce(`Tagged ${f.name}.`);
     },
-    [mention, draft],
+    [mention, draft, announce],
   );
 
   // --- derived transcript view --------------------------------------------
@@ -1384,14 +1458,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                       : undefined;
                     return (
                     <div key={user.id} className="flex flex-col gap-2">
-                      {targets && targets.length > 0 && (
-                        <div className="flex items-center gap-1.5 self-end text-[length:var(--text-xs)] [color:var(--text-muted)]!">
-                          <Icon name="ph:at" width={12} height={12} />
-                          <span>
-                            to {targets.map((f) => f.display_name).join(", ")}
-                          </span>
-                        </div>
-                      )}
+                      <CovenMentionPills familiars={targets ?? []} align="end" />
                       <div className="cave-group-chat-turn cave-group-chat-turn--user">
                         {delegator ? (
                           <div className="cave-group-chat-avatar">
@@ -1423,6 +1490,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                           // The parsed lines render as click-to-send chips below.
                           const { visible: withoutNextPaths, suggestions } = extractNextPaths(r.text);
                           const { visible: visibleText } = extractCovenDelegations(withoutNextPaths);
+                          const replyTargets = parseMentions(visibleText, mentionable)
+                            .map((id) => byId.get(id))
+                            .filter((target): target is ResolvedFamiliar => Boolean(target));
                           return (
                             <div key={r.id} className="cave-group-chat-turn cave-group-chat-turn--assistant">
                               <div className="cave-group-chat-avatar">
@@ -1443,6 +1513,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                                     {formatChatRecency(r.createdAt, dtPrefs)}
                                   </time>
                                 </div>
+                                <CovenMentionPills familiars={replyTargets} />
                                 <MessageBubble
                                   role="assistant"
                                   label={f?.display_name ?? r.familiarId}
@@ -1548,61 +1619,69 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                 </p>
               ) : null}
               <div ref={composerRef} className="mx-auto flex max-w-3xl items-end gap-2">
-                <textarea
-                  ref={textareaRef}
-                  value={draft}
-                  onChange={(e) => {
-                    setDraft(e.target.value);
-                    syncMention();
-                  }}
-                  onKeyUp={syncMention}
-                  onClick={syncMention}
-                  onBlur={() => setMention(null)}
-                  onKeyDown={(e) => {
-                    // `isComposing` is true for the Enter/Tab that confirms an
-                    // IME candidate (CJK input) — confirming a character must
-                    // never pick a mention or broadcast the half-composed
-                    // draft. Mirrors ChatView's composer guard.
-                    if (e.nativeEvent.isComposing) return;
-                    if (mentionOpen) {
-                      if (e.key === "ArrowDown" && mentionMatches.length > 0) {
-                        e.preventDefault();
-                        setMentionIndex((i) => (i + 1) % mentionMatches.length);
-                        return;
+                <div className="coven-tab__composer-field">
+                  <CovenMentionPills
+                    id={mentionGuidanceId}
+                    familiars={composerTargets}
+                    emptyHint={participants.length > 0 ? "Use @ to tag a familiar" : undefined}
+                  />
+                  <textarea
+                    ref={textareaRef}
+                    value={draft}
+                    onChange={(e) => {
+                      setDraft(e.target.value);
+                      syncMention();
+                    }}
+                    onKeyUp={syncMention}
+                    onClick={syncMention}
+                    onBlur={() => setMention(null)}
+                    onKeyDown={(e) => {
+                      // `isComposing` is true for the Enter/Tab that confirms an
+                      // IME candidate (CJK input) — confirming a character must
+                      // never pick a mention or broadcast the half-composed
+                      // draft. Mirrors ChatView's composer guard.
+                      if (e.nativeEvent.isComposing) return;
+                      if (mentionOpen) {
+                        if (e.key === "ArrowDown" && mentionMatches.length > 0) {
+                          e.preventDefault();
+                          setMentionIndex((i) => (i + 1) % mentionMatches.length);
+                          return;
+                        }
+                        if (e.key === "ArrowUp" && mentionMatches.length > 0) {
+                          e.preventDefault();
+                          setMentionIndex((i) => (i - 1 + mentionMatches.length) % mentionMatches.length);
+                          return;
+                        }
+                        if ((e.key === "Enter" || e.key === "Tab") && mentionMatches.length > 0) {
+                          e.preventDefault();
+                          chooseMention(mentionMatches[mentionIndex] ?? mentionMatches[0]);
+                          return;
+                        }
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          setMention(null);
+                          return;
+                        }
                       }
-                      if (e.key === "ArrowUp" && mentionMatches.length > 0) {
+                      if (e.key === "Enter" && !e.shiftKey) {
                         e.preventDefault();
-                        setMentionIndex((i) => (i - 1 + mentionMatches.length) % mentionMatches.length);
-                        return;
+                        void send();
                       }
-                      if ((e.key === "Enter" || e.key === "Tab") && mentionMatches.length > 0) {
-                        e.preventDefault();
-                        chooseMention(mentionMatches[mentionIndex] ?? mentionMatches[0]);
-                        return;
-                      }
-                      if (e.key === "Escape") {
-                        e.preventDefault();
-                        setMention(null);
-                        return;
-                      }
+                    }}
+                    rows={1}
+                    aria-label={activeGroup ? `Message the ${activeGroup.name} coven` : "Message the coven"}
+                    aria-describedby={participants.length > 0 ? mentionGuidanceId : undefined}
+                    placeholder={
+                      participants.length === 0
+                        ? "Add familiars to this coven first…"
+                        : !projectLaunchReady
+                          ? "Choose a shared project above…"
+                        : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}…`
                     }
-                    if (e.key === "Enter" && !e.shiftKey) {
-                      e.preventDefault();
-                      void send();
-                    }
-                  }}
-                  rows={1}
-                  aria-label={activeGroup ? `Message the ${activeGroup.name} coven` : "Message the coven"}
-                  placeholder={
-                    participants.length === 0
-                      ? "Add familiars to this coven first…"
-                      : !projectLaunchReady
-                        ? "Choose a shared project above…"
-                      : `Message ${participants.length} familiar${participants.length === 1 ? "" : "s"}… (@ to tag one)`
-                  }
-                  disabled={participants.length === 0}
-                  className="max-h-40 min-h-[var(--space-10)] flex-1 resize-none rounded-lg border px-3 py-2 text-[length:var(--text-md)] outline-none disabled:opacity-50 [border-color:var(--border-hairline)]! [background:color-mix(in_oklch,var(--bg-raised)_70%,transparent)]! [color:var(--text-primary)]!"
-                />
+                    disabled={participants.length === 0}
+                    className="max-h-40 min-h-[var(--space-10)] w-full resize-none rounded-lg border px-3 py-2 text-[length:var(--text-md)] outline-none disabled:opacity-50 [border-color:var(--border-hairline)]! [background:color-mix(in_oklch,var(--bg-raised)_70%,transparent)]! [color:var(--text-primary)]!"
+                  />
+                </div>
                 <Popover
                   open={mentionOpen}
                   onOpenChange={(next) => {

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -71,6 +71,7 @@ import {
   runCovenReplySchedule,
   COVEN_RESPONSE_MODES,
   findActiveMention,
+  reconcileMentionCompletions,
   matchMentions,
   applyMention,
   loadGroups,
@@ -81,6 +82,7 @@ import {
   type GroupTurn,
   type GroupUserTurn,
   type GroupReply,
+  type MentionCompletion,
   type MentionableFamiliar,
   type RosterParticipant,
   type CovenResponseMode,
@@ -175,9 +177,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   // Caret to restore after we programmatically rewrite the draft (mention insert).
   const pendingCaretRef = useRef<number | null>(null);
-  // Picker-confirmed names stay complete while the user continues ordinary
-  // prose. This is autocomplete state only; visible text remains authoritative.
-  const completedMentionNameRef = useRef<string | null>(null);
+  // Picker-confirmed token spans stay complete while the user continues
+  // ordinary prose. This is autocomplete state only; visible text remains
+  // authoritative.
+  const completedMentionsRef = useRef<MentionCompletion[]>([]);
   const groupsRef = useRef<CovenGroup[]>(groups);
   groupsRef.current = groups;
   // Live mirror of the transcript so retry can read the answered user turn
@@ -190,7 +193,9 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const draftsByGroupRef = useRef(new Map<string, string>());
-  const completedMentionsByGroupRef = useRef(new Map<string, string>());
+  const completedMentionsByGroupRef = useRef(
+    new Map<string, MentionCompletion[]>(),
+  );
   const draftOwnerRef = useRef<string | null>(null);
   // Which group the in-memory transcript belongs to (set by the swap effect).
   // The persist effect must not save until the swap has caught up, or the
@@ -272,19 +277,23 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
       const outgoingGroupId = draftOwnerRef.current;
       if (outgoingGroupId) {
         draftsByGroupRef.current.set(outgoingGroupId, draftRef.current);
-        const completedName = completedMentionNameRef.current;
-        if (completedName) {
-          completedMentionsByGroupRef.current.set(outgoingGroupId, completedName);
+        const completions = completedMentionsRef.current;
+        if (completions.length > 0) {
+          completedMentionsByGroupRef.current.set(outgoingGroupId, completions);
         } else {
           completedMentionsByGroupRef.current.delete(outgoingGroupId);
         }
       }
       draftOwnerRef.current = activeId;
-      setDraft(activeId ? draftsByGroupRef.current.get(activeId) ?? "" : "");
+      const incomingDraft = activeId
+        ? draftsByGroupRef.current.get(activeId) ?? ""
+        : "";
+      draftRef.current = incomingDraft;
+      setDraft(incomingDraft);
       setMention(null);
-      completedMentionNameRef.current = activeId
-        ? completedMentionsByGroupRef.current.get(activeId) ?? null
-        : null;
+      completedMentionsRef.current = activeId
+        ? [...(completedMentionsByGroupRef.current.get(activeId) ?? [])]
+        : [];
     }
     if (!activeId) {
       setTranscript([]);
@@ -449,7 +458,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
       completedMentionsByGroupRef.current.delete(id);
       if (draftOwnerRef.current === id) {
         draftOwnerRef.current = null;
-        completedMentionNameRef.current = null;
+        completedMentionsRef.current = [];
       }
       if (typeof localStorage !== "undefined") {
         try {
@@ -709,9 +718,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
       stickToBottomRef.current = true;
       setShowJump(false);
       setTranscript((prev) => [...prev, userTurn, ...replies]);
+      draftRef.current = "";
       setDraft("");
       setMention(null);
-      completedMentionNameRef.current = null;
+      completedMentionsRef.current = [];
       setBusy(true);
       const controller = new AbortController();
       abortRef.current = controller;
@@ -1020,15 +1030,11 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
     const el = textareaRef.current;
     if (!el) return;
     const caret = el.selectionStart ?? el.value.length;
-    const raw = findActiveMention(el.value, caret);
     const next = findActiveMention(
       el.value,
       caret,
-      completedMentionNameRef.current ?? undefined,
+      completedMentionsRef.current,
     );
-    if (raw && next && completedMentionNameRef.current) {
-      completedMentionNameRef.current = null;
-    }
     setMention(next);
     setMentionIndex(0);
   }, []);
@@ -1036,8 +1042,21 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
   const chooseMention = useCallback(
     (f: MentionableFamiliar) => {
       if (!mention) return;
-      const { text, caret } = applyMention(draft, mention.start, mention.query, f.name);
-      completedMentionNameRef.current = f.name.trim();
+      const { text, caret, completion } = applyMention(
+        draft,
+        mention.start,
+        mention.query,
+        f.name,
+      );
+      completedMentionsRef.current = [
+        ...reconcileMentionCompletions(
+          draftRef.current,
+          text,
+          completedMentionsRef.current,
+        ),
+        completion,
+      ].sort((a, b) => a.start - b.start);
+      draftRef.current = text;
       pendingCaretRef.current = caret;
       setDraft(text);
       setMention(null);
@@ -1629,7 +1648,14 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                     ref={textareaRef}
                     value={draft}
                     onChange={(e) => {
-                      setDraft(e.target.value);
+                      const nextDraft = e.target.value;
+                      completedMentionsRef.current = reconcileMentionCompletions(
+                        draftRef.current,
+                        nextDraft,
+                        completedMentionsRef.current,
+                      );
+                      draftRef.current = nextDraft;
+                      setDraft(nextDraft);
                       syncMention();
                     }}
                     onKeyUp={syncMention}

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -504,6 +504,33 @@ test("findActiveMention: bare @ has an empty query", () => {
   assert.deepEqual(findActiveMention(text, text.length), { start: 4, query: "" });
 });
 
+test("findActiveMention: picker-confirmed mention stays complete while prose continues", () => {
+  const selected = applyMention("hello @sa", 6, "sa", "Sage");
+  assert.equal(findActiveMention(selected.text, selected.caret, "Sage"), null);
+
+  const continued = `${selected.text}what do you think?`;
+  assert.equal(findActiveMention(continued, continued.length, "Sage"), null);
+});
+
+test("findActiveMention: picker-confirmed mention stays complete before punctuation", () => {
+  const punctuated = "@Sage, what do you think?";
+  assert.equal(findActiveMention(punctuated, punctuated.length, "Sage"), null);
+
+  const longerName = "@Sagebrush";
+  assert.deepEqual(findActiveMention(longerName, longerName.length, "Sage"), {
+    start: 0,
+    query: "Sagebrush",
+  });
+});
+
+test("findActiveMention: a new @ starts a fresh search after a completed mention", () => {
+  const text = "hello @Sage what do you think? @";
+  assert.deepEqual(findActiveMention(text, text.length, "Sage"), {
+    start: text.length - 1,
+    query: "",
+  });
+});
+
 test("findActiveMention: not in a token returns null", () => {
   assert.equal(findActiveMention("plain text", 5), null);
 });
@@ -558,6 +585,7 @@ test("renderCovenRoster: marks only the receiving familiar (you)", () => {
 test("renderCovenRoster: instructs the model to count everyone present", () => {
   const out = renderCovenRoster(COVEN, "nova");
   assert.match(out, /count everyone/i);
+  assert.match(out, /tag them with @ followed by their exact display name/i);
   assert.match(out, /<coven_roster>[\s\S]*<\/coven_roster>/);
 });
 

--- a/src/lib/group-chat.test.ts
+++ b/src/lib/group-chat.test.ts
@@ -27,6 +27,7 @@ import {
   loadGroups,
   saveGroups,
   findActiveMention,
+  reconcileMentionCompletions,
   matchMentions,
   applyMention,
   capTranscript,
@@ -506,43 +507,140 @@ test("findActiveMention: bare @ has an empty query", () => {
 
 test("findActiveMention: picker-confirmed mention stays complete while prose continues", () => {
   const selected = applyMention("hello @sa", 6, "sa", "Sage");
-  assert.equal(findActiveMention(selected.text, selected.caret, "Sage"), null);
+  assert.equal(findActiveMention(selected.text, selected.caret, [selected.completion]), null);
 
   const continued = `${selected.text}what do you think?`;
-  assert.equal(findActiveMention(continued, continued.length, "Sage"), null);
+  const completions = reconcileMentionCompletions(
+    selected.text,
+    continued,
+    [selected.completion],
+  );
+  assert.equal(findActiveMention(continued, continued.length, completions), null);
 });
 
 test("findActiveMention: picker-confirmed mention stays complete before punctuation", () => {
+  const selected = applyMention("@sa", 0, "sa", "Sage");
   const punctuated = "@Sage, what do you think?";
-  assert.equal(findActiveMention(punctuated, punctuated.length, "Sage"), null);
+  const completions = reconcileMentionCompletions(
+    selected.text,
+    punctuated,
+    [selected.completion],
+  );
+  assert.equal(findActiveMention(punctuated, punctuated.length, completions), null);
 
   const longerName = "@Sagebrush";
-  assert.deepEqual(findActiveMention(longerName, longerName.length, "Sage"), {
+  const editedCompletions = reconcileMentionCompletions(
+    punctuated,
+    longerName,
+    completions,
+  );
+  assert.deepEqual(findActiveMention(longerName, longerName.length, editedCompletions), {
     start: 0,
     query: "Sagebrush",
   });
 });
 
-test("findActiveMention: picker completion uses locale-independent case folding", () => {
+test("findActiveMention: picker completion never uses locale-sensitive case folding", () => {
   const originalToLocaleLowerCase = String.prototype.toLocaleLowerCase;
+  let localeFoldCalls = 0;
   String.prototype.toLocaleLowerCase = function (this: string): string {
+    localeFoldCalls++;
     return originalToLocaleLowerCase.call(this, "tr");
   };
 
   try {
-    const text = "@iris ";
-    assert.equal(findActiveMention(text, text.length, "IRIS"), null);
+    const selected = applyMention("@ir", 0, "ir", "IRIS");
+    assert.equal(
+      findActiveMention(selected.text, selected.text.length, [selected.completion]),
+      null,
+    );
+    assert.equal(localeFoldCalls, 0);
   } finally {
     String.prototype.toLocaleLowerCase = originalToLocaleLowerCase;
   }
 });
 
 test("findActiveMention: a new @ starts a fresh search after a completed mention", () => {
-  const text = "hello @Sage what do you think? @";
-  assert.deepEqual(findActiveMention(text, text.length, "Sage"), {
+  const selected = applyMention("hello @sa", 6, "sa", "Sage");
+  const text = `${selected.text}what do you think? @`;
+  const completions = reconcileMentionCompletions(
+    selected.text,
+    text,
+    [selected.completion],
+  );
+  assert.deepEqual(findActiveMention(text, text.length, completions), {
     start: text.length - 1,
     query: "",
   });
+});
+
+test("mention completions: canceling a second token preserves the first completion", () => {
+  const first = applyMention("hello @sa", 6, "sa", "Sage");
+  const withSecondToken = `${first.text}review this @`;
+  let completions = reconcileMentionCompletions(
+    first.text,
+    withSecondToken,
+    [first.completion],
+  );
+  assert.deepEqual(findActiveMention(withSecondToken, withSecondToken.length, completions), {
+    start: withSecondToken.length - 1,
+    query: "",
+  });
+
+  const canceled = withSecondToken.slice(0, -1);
+  completions = reconcileMentionCompletions(withSecondToken, canceled, completions);
+  assert.deepEqual(completions, [first.completion]);
+  assert.equal(findActiveMention(canceled, canceled.length, completions), null);
+});
+
+test("mention completions: prose edits preserve two confirmed tokens", () => {
+  const first = applyMention("@sa", 0, "sa", "Sage");
+  const secondDraft = `${first.text}asks @no`;
+  let completions = reconcileMentionCompletions(
+    first.text,
+    secondDraft,
+    [first.completion],
+  );
+  const second = applyMention(
+    secondDraft,
+    secondDraft.lastIndexOf("@"),
+    "no",
+    "Nova",
+  );
+  completions = [
+    ...reconcileMentionCompletions(secondDraft, second.text, completions),
+    second.completion,
+  ];
+
+  const edited = second.text.replace("asks", "politely asks");
+  completions = reconcileMentionCompletions(second.text, edited, completions);
+  assert.equal(completions.length, 2);
+  assert.equal(findActiveMention(edited, edited.indexOf("@Nova"), completions), null);
+  assert.equal(findActiveMention(edited, edited.length, completions), null);
+});
+
+test("mention completions: editing one confirmed token preserves the other", () => {
+  const first = applyMention("@sa", 0, "sa", "Sage");
+  const secondDraft = `${first.text}@no`;
+  const second = applyMention(
+    secondDraft,
+    secondDraft.lastIndexOf("@"),
+    "no",
+    "Nova",
+  );
+  const completions = [
+    ...reconcileMentionCompletions(first.text, second.text, [first.completion]),
+    second.completion,
+  ];
+
+  const edited = second.text.replace("@Sage", "@Stage");
+  const reconciled = reconcileMentionCompletions(second.text, edited, completions);
+  assert.deepEqual(reconciled.map(({ name }) => name), ["Nova"]);
+  assert.deepEqual(findActiveMention(edited, "@Stage".length, reconciled), {
+    start: 0,
+    query: "Stage",
+  });
+  assert.equal(findActiveMention(edited, edited.length, reconciled), null);
 });
 
 test("findActiveMention: not in a token returns null", () => {
@@ -574,6 +672,7 @@ test("applyMention: replaces the token with '@name ' and moves caret after", () 
   const out = applyMention("hey @Nov rest", 4, "Nov", "Nova");
   assert.equal(out.text, "hey @Nova  rest");
   assert.equal(out.caret, "hey @Nova ".length);
+  assert.deepEqual(out.completion, { start: 4, end: 9, name: "Nova" });
 });
 
 const COVEN: RosterParticipant[] = [

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -378,17 +378,29 @@ export function mentionSuggestionAuthor(suggestion: string, displayName: string)
  * Locate the `@mention` token the caret is currently editing, for autocomplete.
  * Returns the `@`'s index and the partial query typed after it, or `null` when
  * the caret is not inside a mention. The token starts at an `@` preceded by
- * whitespace/start and does not span an `@` or newline.
+ * whitespace/start and does not span an `@` or newline. A picker-confirmed
+ * display name keeps that token complete while ordinary prose continues.
  */
 export function findActiveMention(
   text: string,
   caret: number,
+  completedName?: string,
 ): { start: number; query: string } | null {
   let i = caret - 1;
   while (i >= 0 && text[i] !== "@" && text[i] !== "\n") i--;
   if (i < 0 || text[i] !== "@") return null;
   if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) return null;
-  return { start: i, query: text.slice(i + 1, caret) };
+  const query = text.slice(i + 1, caret);
+  const completed = completedName?.trim().toLocaleLowerCase();
+  const normalizedQuery = query.toLocaleLowerCase();
+  if (
+    completed &&
+    normalizedQuery.startsWith(completed) &&
+    !isWordChar(normalizedQuery[completed.length])
+  ) {
+    return null;
+  }
+  return { start: i, query };
 }
 
 /**
@@ -600,6 +612,7 @@ export function renderCovenRoster(
     'You are in a group chat ("coven") with these participants:',
     ...lines,
     "When asked who is present or how many are in this chat, count everyone listed above (including yourself and the human).",
+    "When addressing another familiar in this coven, tag them with @ followed by their exact display name as listed above.",
     "</coven_roster>",
   ].join("\n");
 }

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -374,33 +374,104 @@ export function mentionSuggestionAuthor(suggestion: string, displayName: string)
   return `@${displayName.trim()} ${suggestion.trim()}`.trim();
 }
 
+/** A picker-confirmed mention token in the current composer draft. */
+export type MentionCompletion = {
+  start: number;
+  end: number;
+  name: string;
+};
+
+function isMentionCompletionValid(
+  text: string,
+  completion: MentionCompletion,
+): boolean {
+  const name = completion.name.trim();
+  return (
+    name.length > 0 &&
+    completion.start >= 0 &&
+    completion.end === completion.start + name.length + 1 &&
+    text.slice(completion.start, completion.end) === `@${name}` &&
+    isMentionBoundary(completion.start === 0 ? "" : text[completion.start - 1]) &&
+    !isWordChar(text[completion.end])
+  );
+}
+
+/**
+ * Carry picker-confirmed mention spans across one textarea edit. Spans after
+ * the edit shift with the text; a span is discarded only when the edit touches
+ * its token or makes that token cease to be a valid standalone mention.
+ */
+export function reconcileMentionCompletions(
+  previousText: string,
+  nextText: string,
+  completions: readonly MentionCompletion[],
+): MentionCompletion[] {
+  let changeStart = 0;
+  const sharedLength = Math.min(previousText.length, nextText.length);
+  while (
+    changeStart < sharedLength &&
+    previousText[changeStart] === nextText[changeStart]
+  ) {
+    changeStart++;
+  }
+
+  let previousEnd = previousText.length;
+  let nextEnd = nextText.length;
+  while (
+    previousEnd > changeStart &&
+    nextEnd > changeStart &&
+    previousText[previousEnd - 1] === nextText[nextEnd - 1]
+  ) {
+    previousEnd--;
+    nextEnd--;
+  }
+
+  const delta = nextText.length - previousText.length;
+  const reconciled: MentionCompletion[] = [];
+  for (const completion of completions) {
+    let nextCompletion = completion;
+    if (previousEnd <= completion.start) {
+      nextCompletion = {
+        ...completion,
+        start: completion.start + delta,
+        end: completion.end + delta,
+      };
+    } else if (changeStart < completion.end) {
+      continue;
+    }
+    if (isMentionCompletionValid(nextText, nextCompletion)) {
+      reconciled.push(nextCompletion);
+    }
+  }
+  return reconciled;
+}
+
 /**
  * Locate the `@mention` token the caret is currently editing, for autocomplete.
  * Returns the `@`'s index and the partial query typed after it, or `null` when
  * the caret is not inside a mention. The token starts at an `@` preceded by
- * whitespace/start and does not span an `@` or newline. A picker-confirmed
- * display name keeps that token complete while ordinary prose continues.
+ * whitespace/start and does not span an `@` or newline. Picker-confirmed token
+ * spans stay complete while ordinary prose around them changes.
  */
 export function findActiveMention(
   text: string,
   caret: number,
-  completedName?: string,
+  completions: readonly MentionCompletion[] = [],
 ): { start: number; query: string } | null {
   let i = caret - 1;
   while (i >= 0 && text[i] !== "@" && text[i] !== "\n") i--;
   if (i < 0 || text[i] !== "@") return null;
   if (!isMentionBoundary(i === 0 ? "" : text[i - 1])) return null;
-  const query = text.slice(i + 1, caret);
-  const completed = completedName?.trim().toLowerCase();
-  const normalizedQuery = query.toLowerCase();
   if (
-    completed &&
-    normalizedQuery.startsWith(completed) &&
-    !isWordChar(normalizedQuery[completed.length])
+    completions.some(
+      (completion) =>
+        completion.start === i &&
+        isMentionCompletionValid(text, completion),
+    )
   ) {
     return null;
   }
-  return { start: i, query };
+  return { start: i, query: text.slice(i + 1, caret) };
 }
 
 /**
@@ -425,10 +496,19 @@ export function applyMention(
   start: number,
   query: string,
   name: string,
-): { text: string; caret: number } {
-  const insert = `@${name} `;
+): { text: string; caret: number; completion: MentionCompletion } {
+  const completedName = name.trim();
+  const insert = `@${completedName} `;
   const end = start + 1 + query.length;
-  return { text: text.slice(0, start) + insert + text.slice(end), caret: start + insert.length };
+  return {
+    text: text.slice(0, start) + insert + text.slice(end),
+    caret: start + insert.length,
+    completion: {
+      start,
+      end: start + completedName.length + 1,
+      name: completedName,
+    },
+  };
 }
 
 export function makeGroup(

--- a/src/styles/coven-tab.css
+++ b/src/styles/coven-tab.css
@@ -381,6 +381,45 @@ textarea.coven-tab__field-input {
 
 /* ── Composer ────────────────────────────────────────────────────────────── */
 
+.coven-tab__composer-field {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.coven-tab__mention-strip {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.coven-tab__mention-strip--end {
+  justify-content: flex-end;
+}
+
+.coven-tab__mention-guidance {
+  margin-inline-end: var(--space-1);
+}
+
+.coven-tab__mention-chip {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--space-6);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--accent-presence);
+  font-weight: 600;
+  line-height: 1;
+}
+
 /* Stop keeps the mock's accent stop mark on a quiet secondary button. */
 .coven-tab__stop svg {
   color: var(--accent-presence);


### PR DESCRIPTION
## Summary

- treat picker-selected `@Display Name` mentions as complete so continued prose does not keep autocomplete open, while a fresh `@` starts a new search
- render token-derived familiar mention pills in the composer and group transcript, with persistent accessible tagging guidance
- teach every familiar in coven roster context to address peers using their exact `@Display Name`

## Root cause

The active-mention scanner treated everything after the most recent `@` on a line as one multi-word query. After picker selection inserted `@Sage `, ordinary following prose was therefore reinterpreted as an unfinished mention and the picker continued searching.

## User impact

Selecting a familiar now closes the picker immediately. Tagged familiars remain visually distinct without replacing the raw textarea text that routing, persistence, copying, and accessibility rely on.

## Validation

- `node --experimental-strip-types --test src/lib/group-chat.test.ts src/components/group-chat-view.test.ts` — 89/89 passed
- `pnpm check:tests-wired` — all 1,282 current test files wired
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` — all 932 app test files passed
- `pnpm build` — Next/server build and bundle/standalone budgets passed
- `git diff --check origin/main...HEAD`
- native Tauri flow: selected Sage, continued prose without reopening, started a fresh `@` search, selected Echo, and confirmed both accent pills persisted into the sent transcript

## Tracking

- Bead: `cave-w4ldv`