### PR TITLE
ci: enforce 40-branch repository cap

### DIFF
--- a/.github/workflows/branch-cap.yml
+++ b/.github/workflows/branch-cap.yml
@@ -1,0 +1,34 @@
+# GitHub.com has no native numeric branch-count rule. This workflow rolls back
+# only the newly created topic branch when the repository exceeds 40 branches.
+# Automatic head-branch deletion after merge is enabled separately in the
+# repository settings so normal PR completion continuously frees capacity.
+
+name: Enforce repository branch cap
+
+on:
+  create:
+
+permissions:
+  contents: write
+
+jobs:
+  enforce:
+    if: github.event.ref_type == 'branch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Check out trusted enforcement code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Enforce 40-branch cap
+        env:
+          CREATED_BRANCH: ${{ github.event.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          MAX_BRANCHES: "40"
+        run: node scripts/enforce-branch-cap.mjs

--- a/.github/workflows/branch-cap.yml
+++ b/.github/workflows/branch-cap.yml
@@ -31,4 +31,9 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           MAX_BRANCHES: "40"
-        run: node scripts/enforce-branch-cap.mjs
+        run: |
+          if [[ ! -f scripts/enforce-branch-cap.mjs ]]; then
+            echo "::notice::Branch-cap enforcement is not installed on the default branch yet; allowing the bootstrap event."
+            exit 0
+          fi
+          node scripts/enforce-branch-cap.mjs

--- a/scripts/branch-cap-workflow.test.mjs
+++ b/scripts/branch-cap-workflow.test.mjs
@@ -31,12 +31,18 @@ assert.equal(
 );
 assert.equal(checkout.with["persist-credentials"], false);
 
-const enforcement = job.steps.find((step) => step.run === "node scripts/enforce-branch-cap.mjs");
+const enforcement = job.steps.find((step) => step.name === "Enforce 40-branch cap");
 assert.ok(enforcement, "workflow executes the tested enforcement module");
 assert.equal(enforcement.env.MAX_BRANCHES, "40");
 assert.equal(enforcement.env.CREATED_BRANCH, "${{ github.event.ref }}");
 assert.equal(enforcement.env.DEFAULT_BRANCH, "${{ github.event.repository.default_branch }}");
 assert.equal(enforcement.env.GITHUB_API_URL, "${{ github.api_url }}");
 assert.equal(enforcement.env.GITHUB_TOKEN, "${{ github.token }}");
+assert.match(
+  enforcement.run,
+  /if \[\[ ! -f scripts\/enforce-branch-cap\.mjs \]\]; then/,
+  "the workflow allows only its one-time pre-merge bootstrap when main lacks the module",
+);
+assert.match(enforcement.run, /node scripts\/enforce-branch-cap\.mjs/);
 
 console.log("branch-cap-workflow.test.mjs: ok");

--- a/scripts/branch-cap-workflow.test.mjs
+++ b/scripts/branch-cap-workflow.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { parse } from "yaml";
+
+const source = await readFile(
+  new URL("../.github/workflows/branch-cap.yml", import.meta.url),
+  "utf8",
+);
+const workflow = parse(source);
+
+assert.equal(workflow.name, "Enforce repository branch cap");
+assert.deepEqual(workflow.on, { create: null }, "only new refs trigger cap enforcement");
+assert.deepEqual(workflow.permissions, { contents: "write" });
+
+const job = workflow.jobs.enforce;
+assert.equal(job.if, "github.event.ref_type == 'branch'");
+assert.equal(job["runs-on"], "ubuntu-latest");
+assert.equal(job["timeout-minutes"], 2);
+
+const checkout = job.steps.find((step) => step.uses?.startsWith("actions/checkout@"));
+assert.ok(checkout, "workflow checks out the enforcement script");
+assert.match(
+  checkout.uses,
+  /^actions\/checkout@[0-9a-f]{40}$/,
+  "checkout stays pinned to a full commit SHA",
+);
+assert.equal(
+  checkout.with.ref,
+  "${{ github.event.repository.default_branch }}",
+  "an untrusted created branch cannot replace its own enforcement code",
+);
+assert.equal(checkout.with["persist-credentials"], false);
+
+const enforcement = job.steps.find((step) => step.run === "node scripts/enforce-branch-cap.mjs");
+assert.ok(enforcement, "workflow executes the tested enforcement module");
+assert.equal(enforcement.env.MAX_BRANCHES, "40");
+assert.equal(enforcement.env.CREATED_BRANCH, "${{ github.event.ref }}");
+assert.equal(enforcement.env.DEFAULT_BRANCH, "${{ github.event.repository.default_branch }}");
+assert.equal(enforcement.env.GITHUB_API_URL, "${{ github.api_url }}");
+assert.equal(enforcement.env.GITHUB_TOKEN, "${{ github.token }}");
+
+console.log("branch-cap-workflow.test.mjs: ok");

--- a/scripts/enforce-branch-cap.mjs
+++ b/scripts/enforce-branch-cap.mjs
@@ -1,0 +1,142 @@
+import { pathToFileURL } from "node:url";
+
+export const BRANCH_CAP = 40;
+
+export function decideBranchCap({
+  branchCount,
+  createdBranch,
+  defaultBranch,
+  maxBranches = BRANCH_CAP,
+}) {
+  if (!Number.isInteger(branchCount) || branchCount < 0) {
+    throw new Error(`branch count must be a non-negative integer; received ${branchCount}`);
+  }
+  if (!Number.isInteger(maxBranches) || maxBranches < 1 || maxBranches >= 100) {
+    throw new Error(`branch cap must be an integer from 1 through 99; received ${maxBranches}`);
+  }
+  if (!createdBranch) throw new Error("created branch is required");
+  if (!defaultBranch) throw new Error("default branch is required");
+
+  if (branchCount <= maxBranches) {
+    return { action: "allow", branchCount, maxBranches };
+  }
+  if (createdBranch === defaultBranch) {
+    return {
+      action: "refuse-default",
+      branchCount,
+      maxBranches,
+      branch: createdBranch,
+    };
+  }
+  return {
+    action: "delete-created",
+    branchCount,
+    maxBranches,
+    branch: createdBranch,
+  };
+}
+
+export function encodeBranchRef(branch) {
+  if (!branch) throw new Error("branch is required");
+  return encodeURIComponent(`heads/${branch}`);
+}
+
+export async function runBranchCap({
+  env = process.env,
+  fetchImpl = globalThis.fetch,
+  log = console.log,
+  error = console.error,
+} = {}) {
+  if (typeof fetchImpl !== "function") throw new Error("fetch implementation is required");
+
+  const token = requiredEnv(env, "GITHUB_TOKEN");
+  const repository = requiredEnv(env, "GITHUB_REPOSITORY");
+  const createdBranch = requiredEnv(env, "CREATED_BRANCH");
+  const defaultBranch = requiredEnv(env, "DEFAULT_BRANCH");
+  const apiUrl = (env.GITHUB_API_URL || "https://api.github.com").replace(/\/+$/, "");
+  const maxBranches = parseBranchCap(env.MAX_BRANCHES);
+  const repositoryPath = repository
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+  const headers = {
+    accept: "application/vnd.github+json",
+    authorization: `Bearer ${token}`,
+    "x-github-api-version": "2022-11-28",
+  };
+
+  const branchesResponse = await fetchImpl(
+    `${apiUrl}/repos/${repositoryPath}/branches?per_page=100`,
+    { headers },
+  );
+  if (!branchesResponse.ok) {
+    throw new Error(`failed to list repository branches (HTTP ${branchesResponse.status})`);
+  }
+
+  const branches = await branchesResponse.json();
+  if (!Array.isArray(branches)) throw new Error("branch-list response was not an array");
+
+  const decision = decideBranchCap({
+    branchCount: branches.length,
+    createdBranch,
+    defaultBranch,
+    maxBranches,
+  });
+
+  if (decision.action === "allow") {
+    log(`Branch count ${decision.branchCount}/${decision.maxBranches}; creation allowed.`);
+    return 0;
+  }
+
+  if (decision.action === "refuse-default") {
+    throw new Error(
+      `repository branch cap ${decision.maxBranches} exceeded (${decision.branchCount} branches); ` +
+        `refusing to delete the default branch '${decision.branch}'`,
+    );
+  }
+
+  const deleteResponse = await fetchImpl(
+    `${apiUrl}/repos/${repositoryPath}/git/refs/${encodeBranchRef(decision.branch)}`,
+    { method: "DELETE", headers },
+  );
+  if (!deleteResponse.ok) {
+    throw new Error(
+      `failed to delete over-cap branch '${decision.branch}' (HTTP ${deleteResponse.status})`,
+    );
+  }
+
+  error(
+    `::error::Deleted '${decision.branch}': repository branch cap ` +
+      `${decision.maxBranches} exceeded (${decision.branchCount} branches).`,
+  );
+  return 1;
+}
+
+function requiredEnv(env, name) {
+  const value = env[name]?.trim();
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function parseBranchCap(value) {
+  if (value === undefined || value === "") return BRANCH_CAP;
+  if (!/^[1-9]\d*$/.test(value)) throw new Error(`MAX_BRANCHES must be a positive integer; received '${value}'`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed >= 100) {
+    throw new Error(`MAX_BRANCHES must be from 1 through 99; received '${value}'`);
+  }
+  return parsed;
+}
+
+const isDirectRun =
+  process.argv[1] !== undefined && pathToFileURL(process.argv[1]).href === import.meta.url;
+
+if (isDirectRun) {
+  try {
+    process.exitCode = await runBranchCap();
+  } catch (cause) {
+    const message = cause instanceof Error ? cause.message : String(cause);
+    console.error(`::error::${message}`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/enforce-branch-cap.test.mjs
+++ b/scripts/enforce-branch-cap.test.mjs
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import {
+  BRANCH_CAP,
+  decideBranchCap,
+  encodeBranchRef,
+  runBranchCap,
+} from "./enforce-branch-cap.mjs";
+
+assert.equal(BRANCH_CAP, 40, "the repository cap stays explicit and reviewable");
+
+assert.deepEqual(
+  decideBranchCap({
+    branchCount: 40,
+    createdBranch: "feat/allowed",
+    defaultBranch: "main",
+  }),
+  {
+    action: "allow",
+    branchCount: 40,
+    maxBranches: 40,
+  },
+);
+
+assert.deepEqual(
+  decideBranchCap({
+    branchCount: 41,
+    createdBranch: "feat/over-cap",
+    defaultBranch: "main",
+  }),
+  {
+    action: "delete-created",
+    branchCount: 41,
+    maxBranches: 40,
+    branch: "feat/over-cap",
+  },
+);
+
+assert.deepEqual(
+  decideBranchCap({
+    branchCount: 41,
+    createdBranch: "main",
+    defaultBranch: "main",
+  }),
+  {
+    action: "refuse-default",
+    branchCount: 41,
+    maxBranches: 40,
+    branch: "main",
+  },
+);
+
+assert.equal(
+  encodeBranchRef("feat/slash#safe"),
+  "heads%2Ffeat%2Fslash%23safe",
+  "branch refs are encoded as one API path parameter",
+);
+
+{
+  const calls = [];
+  const messages = [];
+  const status = await runBranchCap({
+    env: {
+      CREATED_BRANCH: "feat/allowed",
+      DEFAULT_BRANCH: "main",
+      GITHUB_API_URL: "https://api.github.test",
+      GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+      GITHUB_TOKEN: "test-token",
+      MAX_BRANCHES: "40",
+    },
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url, options });
+      return jsonResponse(Array.from({ length: 40 }, (_, index) => ({ name: `branch-${index}` })));
+    },
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  });
+
+  assert.equal(status, 0);
+  assert.equal(calls.length, 1, "an allowed branch only lists repository branches");
+  assert.match(calls[0].url, /branches\?per_page=100$/);
+  assert.equal(calls[0].options.headers.authorization, "Bearer test-token");
+  assert.deepEqual(messages, ["Branch count 40/40; creation allowed."]);
+}
+
+{
+  const calls = [];
+  const messages = [];
+  const status = await runBranchCap({
+    env: {
+      CREATED_BRANCH: "feat/over-cap",
+      DEFAULT_BRANCH: "main",
+      GITHUB_API_URL: "https://api.github.test",
+      GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+      GITHUB_TOKEN: "test-token",
+      MAX_BRANCHES: "40",
+    },
+    fetchImpl: async (url, options = {}) => {
+      calls.push({ url, options });
+      if (options.method === "DELETE") return emptyResponse(204);
+      return jsonResponse(Array.from({ length: 41 }, (_, index) => ({ name: `branch-${index}` })));
+    },
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  });
+
+  assert.equal(status, 1, "rolling back an over-cap branch stays visible as a failed workflow");
+  assert.equal(calls.length, 2);
+  assert.equal(calls[1].options.method, "DELETE");
+  assert.match(calls[1].url, /git\/refs\/heads%2Ffeat%2Fover-cap$/);
+  assert.deepEqual(messages, [
+    "::error::Deleted 'feat/over-cap': repository branch cap 40 exceeded (41 branches).",
+  ]);
+}
+
+{
+  const calls = [];
+  await assert.rejects(
+    runBranchCap({
+      env: {
+        CREATED_BRANCH: "main",
+        DEFAULT_BRANCH: "main",
+        GITHUB_API_URL: "https://api.github.test",
+        GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+        GITHUB_TOKEN: "test-token",
+        MAX_BRANCHES: "40",
+      },
+      fetchImpl: async (url, options = {}) => {
+        calls.push({ url, options });
+        return jsonResponse(Array.from({ length: 41 }, (_, index) => ({ name: `branch-${index}` })));
+      },
+      log: () => {},
+      error: () => {},
+    }),
+    /refusing to delete the default branch 'main'/,
+  );
+  assert.equal(calls.length, 1, "the default branch is never sent to the deletion endpoint");
+}
+
+function jsonResponse(value, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => value,
+    text: async () => JSON.stringify(value),
+  };
+}
+
+function emptyResponse(status) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => undefined,
+    text: async () => "",
+  };
+}
+
+console.log("enforce-branch-cap.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -102,6 +102,8 @@ export const SUITES = {
     "scripts/codemods/tokenize-tsx-design.test.mjs",
     "scripts/eslint/design-system-plugin.test.mjs",
     "scripts/bundle-budget.test.mjs",
+    "scripts/enforce-branch-cap.test.mjs",
+    "scripts/branch-cap-workflow.test.mjs",
     "scripts/check-opencode-registry-release.test.mjs",
     "src/components/open-coven-tools-update.test.ts",
     "src/lib/opencoven-tools-state.test.ts",


### PR DESCRIPTION
## Summary

- enforce a 40-branch repository cap on branch creation, counting `main`
- delete only the newly created non-default branch when the repository is over cap
- check out trusted enforcement code from the default branch and cover the decision/API/workflow contracts with focused tests
- enable automatic merged-head deletion in repository settings so normal PR completion frees capacity

## Validation

- `pnpm test:app` — 915 test files passed
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired` — all 1255 test files wired
- `node scripts/enforce-branch-cap.test.mjs`
- `node scripts/branch-cap-workflow.test.mjs`
- `git diff --check`
- live read-only API smoke — 29/40 branches, no deletion
- repository API — `delete_branch_on_merge=true`

Tracks `cave-ow60b`.