### PR TITLE
feat(settings): redesign Familiars control room

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -296,6 +296,7 @@ export const SUITES = {
     "src/lib/server/daemon-probe.test.ts",
     "src/lib/server/tailscale-devices.test.ts",
     "src/components/settings-familiars-section.test.ts",
+    "src/components/settings-familiars-control-sheet.test.ts",
     "src/components/familiar-studio-projects-tab.test.ts",
     "src/components/access-groups-section.test.ts",
     "src/lib/theme-token-hex.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -233,7 +233,7 @@ const contracts: RouteContract[] = [
   { route: "/threads/[id]/audit", methods: ["GET"], kind: "json" },
   { route: "/threads/[id]/strands", methods: ["GET"], kind: "json" },
   { route: "/travel/client", methods: ["GET", "PATCH"], kind: "json", readsJson: true },
-  { route: "/vault", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/vault", methods: ["GET", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
   { route: "/voice/elevenlabs/catalog", methods: ["GET"], kind: "json" },
   { route: "/voice/elevenlabs/tts", methods: ["POST"], kind: "stream", readsJson: true },
   { route: "/voice/engines", methods: ["GET"], kind: "json" },

--- a/src/app/api/vault/route.ts
+++ b/src/app/api/vault/route.ts
@@ -8,6 +8,8 @@
  *          { key, ref, description?, required? } for 1Password refs, or
  *          { key, storage: "encrypted", value, description?, required? } for local encrypted secrets.
  *
+ * PATCH  — grants or revokes one familiar without rewriting the secret.
+ *
  * DELETE — removes a mapping: { key }
  */
 
@@ -19,13 +21,17 @@ import {
 import {
   canMirrorVaultKeyToProcessEnv,
   getVaultStatuses,
+  grantVaultScope,
   loadVaultMap,
   mirrorVaultSecretToProcessEnv,
+  normalizeVaultScope,
   refStorage,
+  revokeVaultScope,
   saveVaultMap,
   validateRef,
   type VaultEntry,
 } from "@/lib/vault";
+import { isValidFamiliarId } from "@/lib/server/familiar-id";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -35,7 +41,14 @@ export const runtime = "nodejs";
 export async function GET() {
   try {
     const statuses = getVaultStatuses();
-    return NextResponse.json({ ok: true, mappings: statuses });
+    const map = loadVaultMap();
+    return NextResponse.json({
+      ok: true,
+      mappings: statuses.map((status) => ({
+        ...status,
+        scope: normalizeVaultScope(map[status.key]?.scope),
+      })),
+    });
   } catch (e) {
     return NextResponse.json({ ok: false, error: String(e) }, { status: 500 });
   }
@@ -51,6 +64,7 @@ export async function POST(req: NextRequest) {
     value?: string;
     description?: string;
     required?: boolean;
+    scope?: unknown;
   } = {};
   try { body = await req.json(); } catch { /**/ }
 
@@ -69,6 +83,9 @@ export async function POST(req: NextRequest) {
     // mapping here must not silently reset a key back to shared.
     scope: map[key]?.scope,
   };
+  if (body.scope !== undefined) {
+    baseEntry.scope = normalizeVaultScope(body.scope);
+  }
 
   let entry: VaultEntry;
   if (storage === "encrypted") {
@@ -98,6 +115,49 @@ export async function POST(req: NextRequest) {
     ref: entry.ref ?? null,
     storage: entry.storage ?? (entry.ref ? refStorage(entry.ref) : "1password"),
   });
+}
+
+// ── PATCH — update one familiar grant without touching the secret ────────────
+
+export async function PATCH(req: NextRequest) {
+  let body: {
+    key?: string;
+    action?: "grant" | "revoke";
+    familiarId?: string;
+  } = {};
+  try { body = await req.json(); } catch { /**/ }
+
+  const key = typeof body.key === "string"
+    ? body.key.trim().toUpperCase().replace(/[^A-Z0-9_]/g, "_")
+    : "";
+  const familiarId = typeof body.familiarId === "string"
+    ? body.familiarId.trim().toLowerCase()
+    : "";
+  const action = body.action;
+
+  if (!key) {
+    return NextResponse.json({ ok: false, error: "key is required" }, { status: 400 });
+  }
+  if (!isValidFamiliarId(familiarId)) {
+    return NextResponse.json({ ok: false, error: "invalid familiar id" }, { status: 400 });
+  }
+  if (action !== "grant" && action !== "revoke") {
+    return NextResponse.json({ ok: false, error: "action must be grant or revoke" }, { status: 400 });
+  }
+
+  const map = loadVaultMap(true);
+  const entry = map[key];
+  if (!entry) {
+    return NextResponse.json({ ok: false, error: "key not found" }, { status: 404 });
+  }
+
+  const scope = action === "grant"
+    ? grantVaultScope(entry.scope, familiarId)
+    : revokeVaultScope(entry.scope, familiarId);
+  map[key] = { ...entry, scope };
+  saveVaultMap(map);
+
+  return NextResponse.json({ ok: true, key, scope });
 }
 
 // ── DELETE — remove a mapping ─────────────────────────────────────────────────

--- a/src/app/css-module-order.test.ts
+++ b/src/app/css-module-order.test.ts
@@ -15,6 +15,7 @@ const FACADES: Record<string, string[]> = {
     "../styles/globals/themes.css",
     "../styles/globals/desktop-chrome.css",
     "../styles/globals/shell-responsive.css",
+    "../styles/settings-familiars.css",
     "../styles/globals/calendar-agenda.css",
     "../styles/globals/surface-compact-calendar.css",
     "../styles/globals/surface-reporting.css",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,6 +13,7 @@
 @import "../styles/globals/themes.css";
 @import "../styles/globals/desktop-chrome.css";
 @import "../styles/globals/shell-responsive.css";
+@import "../styles/settings-familiars.css";
 @import "../styles/globals/calendar-agenda.css";
 @import "../styles/globals/surface-compact-calendar.css";
 @import "../styles/globals/surface-reporting.css";

--- a/src/components/access-groups-section.test.ts
+++ b/src/components/access-groups-section.test.ts
@@ -4,11 +4,17 @@ import { readFileSync } from "node:fs";
 
 const section = readFileSync(new URL("./access-groups-section.tsx", import.meta.url), "utf8");
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const inline = readFileSync(new URL("./familiar-studio-inline.tsx", import.meta.url), "utf8");
 const sections = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
 
 // ── Access groups management lives in Settings → Familiars ───────────────────
 assert.match(section, /export function AccessGroupsSection/, "exports the access groups section");
-assert.match(shell, /<AccessGroupsSection familiars=\{familiars\} \/>/, "FamiliarsSection mounts the access groups manager");
+assert.doesNotMatch(shell, /<AccessGroupsSection/, "the shell does not duplicate access groups below the control sheet");
+assert.match(
+  inline,
+  /<AccessGroupsSection familiars=\{resolved\} \/>/,
+  "the Projects tab mounts the access groups manager",
+);
 assert.match(sections, /group: "Access groups"/, "settings search indexes the access groups group");
 
 // ── Speaks the access-groups API, human-confirmed ─────────────────────────────

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { IconButton } from "@/components/ui/icon-button";
+import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import {
   setFamiliarOverride,
   clearFamiliarOverrideField,
@@ -13,6 +16,7 @@ import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { FamiliarStudioLookTab } from "@/components/familiar-studio-look-tab";
 import { FamiliarLifecycleSection } from "@/components/familiar-lifecycle-section";
+import type { ContractReport } from "@/lib/familiar-contract";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
 type Props = {
@@ -63,9 +67,171 @@ export function FamiliarStudioIdentityTab({
           onReset={() => clearFamiliarOverrideField(familiar.id, f.key)}
         />
       ))}
+      <FamiliarGrimoireFiles familiarId={familiar.id} />
       <FamiliarStudioLookTab familiar={familiar} allFamiliars={allFamiliars} />
       <FamiliarLifecycleSection familiar={familiar} onRosterChanged={onRosterChanged} />
     </div>
+  );
+}
+
+type ContractFileKey = "soul" | "identity" | "ward" | "memory";
+
+type ContractPayload = {
+  ok?: boolean;
+  present?: Record<ContractFileKey, boolean>;
+  report?: ContractReport;
+  error?: string;
+};
+
+type ContractState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | {
+      status: "ready";
+      present: Record<ContractFileKey, boolean>;
+      report: ContractReport;
+    };
+
+const GRIMOIRE_FILES: Array<{
+  key: ContractFileKey;
+  name: string;
+  kind: string;
+  description: string;
+}> = [
+  {
+    key: "soul",
+    name: "SOUL.md",
+    kind: "MD",
+    description: "Voice, temperament, and reasoning style.",
+  },
+  {
+    key: "identity",
+    name: "IDENTITY.md",
+    kind: "MD",
+    description: "Name, pronouns, avatar, and public identity.",
+  },
+  {
+    key: "ward",
+    name: "ward.toml",
+    kind: "TOML",
+    description: "Guardrails, protected files, and approval tiers.",
+  },
+  {
+    key: "memory",
+    name: "MEMORY.md",
+    kind: "MD",
+    description: "Long-term memory; manage entries from the Memory tab.",
+  },
+];
+
+function FamiliarGrimoireFiles({ familiarId }: { familiarId: string }) {
+  const [state, setState] = useState<ContractState>({ status: "loading" });
+
+  const load = useCallback(async (signal?: AbortSignal) => {
+    setState({ status: "loading" });
+    try {
+      const response = await fetch(
+        `/api/familiars/${encodeURIComponent(familiarId)}/contract`,
+        { cache: "no-store", signal },
+      );
+      const payload = await response.json().catch(() => null) as ContractPayload | null;
+      if (signal?.aborted) return;
+      if (!response.ok || !payload?.ok || !payload.present || !payload.report) {
+        throw new Error(payload?.error || `contract check failed (${response.status})`);
+      }
+      setState({
+        status: "ready",
+        present: payload.present,
+        report: payload.report,
+      });
+    } catch (error) {
+      if (signal?.aborted) return;
+      setState({
+        status: "error",
+        message: error instanceof Error ? error.message : "Contract check failed",
+      });
+    }
+  }, [familiarId]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void load(controller.signal);
+    return () => controller.abort();
+  }, [load]);
+
+  return (
+    <section
+      className="familiar-studio-grimoire"
+      aria-labelledby={`familiar-grimoire-heading-${familiarId}`}
+      tabIndex={-1}
+    >
+      <div className="familiar-studio-grimoire__heading">
+        <h2 id={`familiar-grimoire-heading-${familiarId}`}>Grimoire files</h2>
+        {state.status === "ready" ? (
+          <>
+            <span className="familiar-studio-grimoire__count">
+              {Object.values(state.present).filter(Boolean).length} of {GRIMOIRE_FILES.length} found
+            </span>
+            <span
+              className="familiar-studio-grimoire__compliance"
+              data-pass={state.report.pass || undefined}
+            >
+              {state.report.pass
+                ? "Compliant"
+                : `${state.report.violations.length} ${state.report.violations.length === 1 ? "issue" : "issues"}`}
+            </span>
+          </>
+        ) : null}
+        <span className="familiar-studio-grimoire__rule" aria-hidden />
+      </div>
+
+      {state.status === "loading" ? (
+        <div role="status" aria-label="Checking Grimoire files">
+          <SkeletonRows count={2} />
+        </div>
+      ) : state.status === "error" ? (
+        <ErrorState
+          compact
+          headline="Couldn't check Grimoire files"
+          subtitle={state.message}
+          actions={(
+            <Button size="xs" leadingIcon="ph:arrow-clockwise" onClick={() => void load()}>
+              Retry
+            </Button>
+          )}
+        />
+      ) : (
+        <div className="familiar-studio-grimoire__grid">
+          {GRIMOIRE_FILES.map((file) => {
+            const present = state.present[file.key];
+            const issues = state.report.violations.filter(
+              (violation) => violation.file === file.name,
+            ).length;
+            return (
+              <article
+                key={file.key}
+                className="familiar-studio-grimoire__file"
+                data-present={present || undefined}
+              >
+                <div className="familiar-studio-grimoire__file-head">
+                  <span className="familiar-studio-grimoire__kind">{file.kind}</span>
+                  <code>{file.name}</code>
+                  <span className="familiar-studio-grimoire__state">
+                    {present ? "Found" : "Missing"}
+                  </span>
+                </div>
+                <p>{file.description}</p>
+                {issues > 0 ? (
+                  <span className="familiar-studio-grimoire__issues">
+                    {issues} {issues === 1 ? "issue" : "issues"}
+                  </span>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      )}
+    </section>
   );
 }
 

--- a/src/components/familiar-studio-inline.test.ts
+++ b/src/components/familiar-studio-inline.test.ts
@@ -1,125 +1,123 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./familiar-studio-inline.tsx", import.meta.url), "utf8");
-const pickerUrl = new URL("./settings-familiar-picker.tsx", import.meta.url);
-const pickerExists = existsSync(pickerUrl);
-const picker = pickerExists ? readFileSync(pickerUrl, "utf8") : "";
-const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
-const inlineStyles = globals.slice(
-  globals.indexOf("/* Inline Familiar Studio"),
-  globals.indexOf(".familiar-studio-identity"),
-);
+const picker = readFileSync(new URL("./settings-familiar-picker.tsx", import.meta.url), "utf8");
+const styles = readFileSync(new URL("../styles/settings-familiars.css", import.meta.url), "utf8");
+const identityTab = readFileSync(new URL("./familiar-studio-identity-tab.tsx", import.meta.url), "utf8");
+const memoryTab = readFileSync(new URL("./familiar-studio-memory-tab.tsx", import.meta.url), "utf8");
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 
-assert.match(source, /export function FamiliarStudioInlinePanel/, "Must export the inline panel");
-
-// Master-detail shell delegates roster scale + interaction to one focused,
-// controlled picker instead of growing a wrapping chip wall without bound.
-assert.equal(pickerExists, true, "Settings has a dedicated scalable familiar picker");
-assert.match(source, /SettingsFamiliarPicker/, "Renders the scalable familiar picker");
-assert.match(source, /familiars=\{resolved\}/, "Picker receives the resolved roster in daemon order");
-assert.match(source, /value=\{activeFamiliarId\}/, "Picker is controlled by Familiar Studio selection");
+assert.match(source, /export function FamiliarStudioInlinePanel/, "Exports the inline control sheet");
+assert.match(source, /SettingsFamiliarPicker/, "Renders the persistent familiar roster");
+assert.match(source, /familiars=\{resolved\}/, "Roster receives resolved familiars in daemon order");
+assert.match(source, /value=\{activeFamiliarId\}/, "Roster is controlled by Studio selection");
 assert.match(
   source,
   /onChange=\{\(id\) => openFamiliarStudio\(id, activeTab\)\}/,
-  "Picker selection opens the familiar at the current Studio tab",
+  "Roster selection preserves the active Studio tab",
 );
-assert.match(source, /onSummon=\{onSummon\}/, "Summoning stays attached to familiar selection");
-assert.doesNotMatch(source, /role="radiogroup"/, "The unbounded chip radiogroup is retired");
-assert.doesNotMatch(source, /familiar-studio-inline__chip/, "Inline panel no longer owns roster chips");
-assert.match(source, /familiar-studio-inline__detail/, "Renders the detail pane");
+assert.match(source, /onSummon=\{onSummon\}/, "Summoning stays attached to the roster");
+assert.match(source, /onManageLifecycle=\{openLifecycle\}/, "Roster removal routes to safe lifecycle controls");
 
-// Reuses the Studio context for selection + tab persistence, NOT selection
-// state inside the picker, so deep links and last-tab memory carry over.
-assert.match(source, /useFamiliarStudio\(\)/, "Uses the Familiar Studio context for selection");
-
-// The popup is a searchable, bounded combobox/listbox. Keyboard highlight is
-// separate from the committed aria-selected familiar.
-assert.match(picker, /aria-haspopup="dialog"/, "Picker trigger identifies its popover");
-assert.match(picker, /aria-expanded=\{open\}/, "Picker trigger exposes expanded state");
-assert.match(picker, /role="combobox"/, "Search field uses editable combobox semantics");
-assert.match(picker, /aria-autocomplete="list"/, "Combobox announces list autocomplete");
-assert.match(picker, /aria-controls=\{LISTBOX_ID\}/, "Combobox controls the result listbox");
-assert.match(picker, /aria-activedescendant=/, "Combobox exposes the keyboard-highlighted option");
-assert.match(picker, /role="listbox"/, "Filtered familiar results are a listbox");
-assert.match(picker, /role="option"/, "Each familiar result is an option");
-assert.match(picker, /aria-selected=\{selected\}/, "Committed familiar selection is announced");
+// The handoff's roster is always visible, bounded, searchable and keyboard
+// navigable; it no longer hides the coven behind a popover.
+assert.match(picker, /<aside[\s\S]*aria-label="Familiar roster"/, "Picker renders as a roster pane");
+assert.doesNotMatch(picker, /Popover/, "The dropdown picker is retired");
+assert.match(picker, /<SearchInput/, "Roster has a shared search primitive");
+assert.match(picker, /placeholder="Find a familiar…"/, "Roster uses handoff copy");
+assert.doesNotMatch(picker, /role="listbox"/, "Roster actions are not nested in an ARIA listbox");
+assert.match(picker, /aria-current=\{selected \? "page" : undefined\}/, "Committed selection is announced");
+assert.match(picker, /moveFamiliarPickerIndex/, "Arrow navigation uses the tested helper");
+assert.match(picker, /optionRefs\.current\[next\]\?\.focus\(\)/, "Arrow navigation moves real focus");
+assert.match(picker, /aria-live="polite"/, "Search result count is announced");
+assert.match(picker, /Summon familiar/, "Summon remains in the roster header");
+assert.match(picker, /archiveFamiliar/, "Archive uses the production store");
+assert.match(picker, /unarchiveFamiliar/, "Archived roster rows can be restored in place");
 assert.match(
   picker,
-  /role="option"[\s\S]{0,180}tabIndex=\{-1\}/,
-  "Listbox options use active-descendant navigation instead of adding one Tab stop per familiar",
+  /familiar\.archived\s*\?\s*unarchiveFamiliar\(familiar\.id\)\s*:\s*archiveFamiliar\(familiar\.id\)/,
+  "The roster archive action toggles instead of making an archived familiar unreachable",
+);
+assert.match(picker, /data-archived=\{familiar\.archived \|\| undefined\}/, "Archived rows expose a visual state");
+assert.match(picker, /reveal-scope/, "Row actions follow shared progressive disclosure");
+assert.match(
+  shell,
+  /useResolvedFamiliars\(rawFamiliars,\s*\{\s*includeArchived:\s*true\s*\}\)/,
+  "Settings keeps archived familiars in the lifecycle control sheet",
 );
 assert.match(
-  picker,
-  /scrollStrategy="content"/,
-  "The picker keeps search and Summon fixed while its result list owns scrolling",
+  styles,
+  /\.settings-familiar-roster__list\s*\{[\s\S]*?min-height:\s*0[\s\S]*?overflow-y:\s*auto/,
+  "Large rosters own a bounded scroll region",
 );
 assert.match(
-  picker,
-  /compactAtHeight=\{184\}/,
-  "Picker compaction follows the Popover's visual-viewport-aware available height",
+  styles,
+  /\.settings-familiar-roster\[data-collapsed\]/,
+  "Roster collapses to the avatar rail",
 );
-assert.match(picker, /moveFamiliarPickerIndex/, "Arrow navigation uses the tested index helper");
-assert.match(picker, /event\.key === "Enter"/, "Enter commits the highlighted familiar");
-assert.match(picker, /aria-live="polite"/, "Search result changes are announced");
 
-const resultsPosition = picker.indexOf('className="familiar-studio-picker__results"');
-const footerPosition = picker.indexOf('className="familiar-studio-picker__footer"');
-assert.ok(resultsPosition >= 0, "Picker renders a dedicated scrollable results region");
-assert.ok(footerPosition > resultsPosition, "Summon footer stays outside and after the results scroller");
-assert.match(picker, /Summon familiar/, "Summon remains reachable from the picker footer");
-assert.match(
-  inlineStyles,
-  /\.familiar-studio-picker__trigger\s*\{[\s\S]*?width:\s*100%[\s\S]*?min-height:\s*48px/,
-  "Picker trigger is one constant-height row",
-);
-assert.match(
-  inlineStyles,
-  /\.familiar-studio-picker__results\s*\{[\s\S]*?max-height:[\s\S]*?overflow-y:\s*auto/,
-  "Large rosters scroll inside a bounded result list",
-);
-assert.match(
-  inlineStyles,
-  /\.familiar-studio-picker__popover\s*\{[\s\S]*?background:\s*var\(--bg-elevated\)/,
-  "Dense familiar rows use an opaque elevated surface instead of unreadable glass",
-);
-assert.match(
-  inlineStyles,
-  /@media \(max-width: 640px\)[\s\S]*?\.familiar-studio-picker__summon\s*\{[\s\S]*?min-height:\s*44px/,
-  "The summon action keeps a touch-sized target in narrow Settings layouts",
-);
-assert.doesNotMatch(inlineStyles, /\.familiar-studio-inline__picker\s*\{/, "Wrapping roster CSS is retired");
+// Non-modal detail pane with the handoff identity hero.
+assert.doesNotMatch(source, /familiar-studio__scrim/, "Inline panel has no modal scrim");
+assert.doesNotMatch(source, /familiar-studio__drawer/, "Inline panel has no fixed drawer root");
+assert.match(source, /familiar-studio-control__hero/, "Renders the identity hero");
+assert.match(source, /requestAgentsNewChat/, "Open chat uses the shared handoff");
+assert.match(source, /streamFamiliarText/, "Test run uses the sanctioned stream");
+assert.match(source, /useFamiliarImageUpload/, "Hero avatar uses the shared upload behavior");
 
-// Non-modal: it must NOT render the drawer chrome (scrim / fixed drawer root).
-assert.doesNotMatch(source, /familiar-studio__scrim/, "Inline panel must not render the modal scrim");
-assert.doesNotMatch(source, /familiar-studio__drawer/, "Inline panel must not render the fixed drawer root");
-
-// Familiar-specific studio tabs are wired with the same prop shapes the drawer uses.
-for (const tab of ["Identity", "Brain", "Memory"]) {
-  assert.match(source, new RegExp("FamiliarStudio" + tab + "Tab"), "Wires the " + tab + " tab body");
+// Five real Studio surfaces; Look and Lifecycle remain merged into Identity.
+for (const tab of ["Identity", "Brain", "Memory", "Projects"]) {
+  assert.match(source, new RegExp(`FamiliarStudio${tab}Tab`), `Wires the ${tab} tab body`);
 }
-// Look and Lifecycle merged into Identity: the tab strip is exactly these five.
 for (const gone of ["look", "lifecycle", "journal"]) {
-  assert.doesNotMatch(source, new RegExp('id: "' + gone + '"'), "No standalone " + gone + " tab remains");
+  assert.doesNotMatch(source, new RegExp(`id: "${gone}"`), `No standalone ${gone} tab remains`);
 }
 assert.match(source, /id: "identity", label: "Identity"/, "Identity leads the tab strip");
-const identityTab = readFileSync(new URL("./familiar-studio-identity-tab.tsx", import.meta.url), "utf8");
-assert.match(identityTab, /<FamiliarStudioLookTab familiar=\{familiar\} allFamiliars=\{allFamiliars\} \/>/, "Identity hosts the Look sections with all resolved familiars for group colors");
-assert.match(source, /allFamiliars=\{resolved\}/, "Identity tab gets the resolved roster for the appearance controls");
-assert.match(source, /<FamiliarStudioMemoryTab familiar=\{familiar\} allFamiliars=\{familiars\} \/>/, "Memory tab gets the raw roster");
-assert.match(source, /VaultPanel/, "Wires the Vault settings panel inside familiar settings");
-assert.match(source, /id: "vault", label: "Vault"/, "Exposes Vault as a familiar settings tab");
+assert.match(
+  source,
+  /const displayedTab = activeTab === "contract" \? "identity" : activeTab/,
+  "Retired Contract tab handoffs resolve onto the five-tab Identity surface",
+);
+assert.match(source, /value=\{displayedTab\}/, "The visible tab strip never receives the retired Contract value");
+assert.match(
+  identityTab,
+  /<FamiliarStudioLookTab familiar=\{familiar\} allFamiliars=\{allFamiliars\} \/>/,
+  "Identity hosts appearance controls",
+);
+assert.match(identityTab, /Grimoire files/, "Identity keeps the handoff's Grimoire file section");
+assert.match(
+  identityTab,
+  /fetch\(\s*`\/api\/familiars\/\$\{encodeURIComponent\(familiarId\)\}\/contract`/,
+  "Grimoire file state comes from the real familiar contract route",
+);
+assert.match(source, /allFamiliars=\{resolved\}/, "Identity receives the resolved roster");
+assert.match(
+  source,
+  /<FamiliarStudioMemoryTab[\s\S]*?allFamiliars=\{familiars\}/,
+  "Memory receives the raw daemon roster",
+);
+assert.match(memoryTab, /<FamiliarDailyNotes familiar=\{familiar\} \/>/, "Add note uses the real per-familiar notes editor");
+assert.match(memoryTab, />\s*Add note\s*</, "Memory exposes the handoff's Add note action");
+assert.match(memoryTab, /breadcrumb=\{\["Familiars", familiar\.display_name, "Add note"\]\}/, "Notes open in the shared modal");
+assert.match(source, /<VaultPanel familiarId=\{familiar\.id\}/, "Vault is scoped to the active familiar");
+assert.match(source, /id: "vault", label: "Vault"/, "Vault remains a Studio tab");
+assert.match(source, /<AccessGroupsSection familiars=\{resolved\}/, "Cross-familiar access groups remain reachable in Projects");
 
-// Detail pane is never empty on entry: auto-selects a familiar (the one-shot
-// "Open Brain Studio" handoff id when present, else the first) and recovers when
-// the current selection disappears.
-assert.match(source, /resolved\.some\(\(f\) => f\.id === activeFamiliarId\)/, "Recovers when the selected familiar vanishes");
-assert.match(source, /openFamiliarStudio\(handoff \?\? resolved\[0\]\.id\)/, "Auto-selects the Brain Studio handoff familiar, falling back to the first");
-assert.match(source, /BRAIN_STUDIO_FAMILIAR_KEY/, "Reads the one-shot Brain Studio handoff key");
+// Entry selection and cross-page handoff behavior remain intact.
+assert.match(
+  source,
+  /resolved\.some\(\(item\) => item\.id === activeFamiliarId\)/,
+  "Recovers when the selected familiar vanishes",
+);
+assert.match(
+  source,
+  /openFamiliarStudio\(handoff \?\? resolved\[0\]\.id\)/,
+  "Uses the Brain Studio handoff, then falls back to the first familiar",
+);
+assert.match(source, /BRAIN_STUDIO_FAMILIAR_KEY/, "Reads the one-shot handoff key");
 
-// Autosave footer carries over from the drawer.
 assert.match(source, /Changes save automatically/, "Shows the autosave footer");
-assert.match(source, /Saved locally, daemon offline/, "Shows the daemon-offline indicator");
+assert.match(source, /Saved locally, daemon offline/, "Shows daemon-offline state");
 
 console.log("familiar-studio-inline.test.ts: ok");

--- a/src/components/familiar-studio-inline.tsx
+++ b/src/components/familiar-studio-inline.tsx
@@ -1,27 +1,53 @@
 "use client";
 
-import { useEffect, useMemo, type CSSProperties } from "react";
-import { Icon, type IconName } from "@/lib/icon";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type DragEvent,
+} from "react";
+
+import { AccessGroupsSection } from "@/components/access-groups-section";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { FamiliarStudioBrainTab } from "@/components/familiar-studio-brain-tab";
+import { FamiliarStudioIdentityTab } from "@/components/familiar-studio-identity-tab";
+import { FamiliarStudioMemoryTab } from "@/components/familiar-studio-memory-tab";
+import { FamiliarStudioProjectsTab } from "@/components/familiar-studio-projects-tab";
+import { SettingsFamiliarPicker } from "@/components/settings-familiar-picker";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
 import { Tabs } from "@/components/ui/tabs";
-import { useFamiliarStudio, BRAIN_STUDIO_FAMILIAR_KEY, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
+import { VaultPanel } from "@/components/vault-panel";
 import { useDaemonSyncStatus } from "@/lib/daemon-sync-status";
+import {
+  BRAIN_STUDIO_FAMILIAR_KEY,
+  useFamiliarStudio,
+  type FamiliarStudioTab,
+} from "@/lib/familiar-studio-context";
+import {
+  FAMILIAR_IMAGE_ACCEPT,
+  useFamiliarImageUpload,
+} from "@/lib/familiar-image-upload";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
-import { FamiliarStudioIdentityTab } from "./familiar-studio-identity-tab";
-import { FamiliarStudioBrainTab } from "./familiar-studio-brain-tab";
-import { FamiliarStudioMemoryTab } from "./familiar-studio-memory-tab";
-import { FamiliarStudioProjectsTab } from "./familiar-studio-projects-tab";
-import { SettingsFamiliarPicker } from "./settings-familiar-picker";
-import { VaultPanel } from "./vault-panel";
+import { resolveFamiliarTypes, FAMILIAR_TYPES } from "@/lib/familiar-types";
+import { streamFamiliarText } from "@/lib/familiar-stream";
+import { runtimeDisplayLabel } from "@/lib/harness-adapters";
+import { Icon, type IconName } from "@/lib/icon";
+import { requestAgentsNewChat } from "@/lib/agents-new-chat";
 import type { Familiar } from "@/lib/types";
+import { useProjects } from "@/lib/use-projects";
 
 type Props = {
-  /** Raw daemon roster — fed to the tab bodies that diff against pre-override values. */
+  /** Raw daemon roster — fed to tab bodies that diff against pre-override values. */
   familiars: Familiar[];
-  /** Resolved roster (cave overrides applied) — drives the master list + tab bodies. */
+  /** Resolved roster (Cave overrides applied) — drives the roster and Studio. */
   resolved: ResolvedFamiliar[];
-  /** Opens the summoning circle from the familiar picker's fixed footer. */
+  /** Opens the production summoning circle. */
   onSummon?: () => void;
-  /** Re-fetch the roster after the Identity tab's lifecycle section removes/restores a familiar. */
+  /** Re-fetch after lifecycle controls remove or restore a familiar. */
   onRosterChanged?: () => void;
 };
 
@@ -34,49 +60,88 @@ const TABS: Array<{ id: FamiliarStudioTab; label: string; icon: IconName }> = [
 ];
 
 /**
- * Inline, non-modal Familiar Studio for the Settings → Familiars section.
+ * Settings → Familiars control sheet.
  *
- * Unlike the global `<FamiliarStudio>` drawer (mounted in the Workspace), this
- * is a master-detail panel: a familiar dropdown above the studio settings tabs
- * for the selected familiar. The Settings route mounts the
- * `FamiliarStudioProvider` but never the drawer, so the per-card "Edit" buttons
- * used to set context state that nothing rendered — this surface is what makes
- * editing a familiar actually work inside Settings.
- *
- * It reuses the same context for selection (so `activeTab` persistence and the
- * deep-link `openFamiliarStudio(id, tab)` semantics carry over) and the same
- * tab-body components as the drawer. The Settings provider instance is isolated
- * from the Workspace one, so selecting here never auto-opens the drawer there.
+ * The Settings shell already owns the app navigation rail. This component
+ * supplies the second and third panes from the handoff: a persistent familiar
+ * roster and one scroll-contained detail sheet. The existing Studio tabs,
+ * mutations, summoning circle, lifecycle flow, and daemon-sync contracts stay
+ * authoritative underneath the new layout.
  */
-export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRosterChanged }: Props) {
-  const { activeFamiliarId, activeTab, setActiveTab, openFamiliarStudio } = useFamiliarStudio();
+export function FamiliarStudioInlinePanel({
+  familiars,
+  resolved,
+  onSummon,
+  onRosterChanged,
+}: Props) {
+  const {
+    activeFamiliarId,
+    activeTab,
+    setActiveTab,
+    openFamiliarStudio,
+  } = useFamiliarStudio();
   const daemonSync = useDaemonSyncStatus();
+  const [testRunOpen, setTestRunOpen] = useState(false);
 
   const familiar = useMemo(
-    () => resolved.find((f) => f.id === activeFamiliarId) ?? null,
+    () => resolved.find((item) => item.id === activeFamiliarId) ?? null,
     [resolved, activeFamiliarId],
   );
+  const { projects, loading: projectsLoading } = useProjects({
+    familiarId: familiar?.id ?? null,
+    enabled: Boolean(familiar),
+  });
+  const memoryCount = useFamiliarMemoryCount(familiar?.id ?? null);
+  const displayedTab = activeTab === "contract" ? "identity" : activeTab;
 
   // Auto-select a familiar so the detail pane is never empty on entry, and
-  // recover if the current selection vanishes (archived/removed) while open.
-  // Prefer the one-shot handoff id written by "Open Brain Studio" so the right
-  // familiar opens (not just the first), then fall back to the first.
+  // recover if the current selection vanishes after archive/removal. Prefer
+  // the one-shot "Open Brain Studio" handoff id when present.
   useEffect(() => {
     if (resolved.length === 0) return;
-    if (!activeFamiliarId || !resolved.some((f) => f.id === activeFamiliarId)) {
+    if (!activeFamiliarId || !resolved.some((item) => item.id === activeFamiliarId)) {
       let handoff: string | null = null;
       try {
         const stored = window.localStorage.getItem(BRAIN_STUDIO_FAMILIAR_KEY);
         if (stored) {
           window.localStorage.removeItem(BRAIN_STUDIO_FAMILIAR_KEY);
-          if (resolved.some((f) => f.id === stored)) handoff = stored;
+          if (resolved.some((item) => item.id === stored)) handoff = stored;
         }
       } catch {
-        /* ignore storage failures */
+        /* storage can be unavailable */
       }
       openFamiliarStudio(handoff ?? resolved[0].id);
     }
   }, [resolved, activeFamiliarId, openFamiliarStudio]);
+
+  // Contract used to be a standalone Studio tab. The handoff folds its
+  // Grimoire files into Identity, so old links and persisted tab state land on
+  // the real section instead of leaving the new five-tab sheet blank.
+  useEffect(() => {
+    if (activeTab !== "contract") return;
+    setActiveTab("identity");
+    const raf = requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>(".familiar-studio-grimoire")?.focus({
+        preventScroll: true,
+      });
+      document.querySelector<HTMLElement>(".familiar-studio-grimoire")?.scrollIntoView({
+        block: "nearest",
+      });
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [activeTab, setActiveTab]);
+
+  const openLifecycle = useCallback(
+    (id: string) => {
+      openFamiliarStudio(id, "identity");
+      requestAnimationFrame(() => {
+        const lifecycle = document.querySelector<HTMLElement>(".familiar-studio-lifecycle");
+        lifecycle?.scrollIntoView({ block: "start" });
+        lifecycle?.querySelector<HTMLElement>("button")?.focus({ preventScroll: true });
+      });
+    },
+    [openFamiliarStudio],
+  );
 
   if (resolved.length === 0) {
     return (
@@ -91,56 +156,87 @@ export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRos
   return (
     <div
       className="familiar-studio-inline"
-      style={familiar ? ({ ["--familiar-accent"]: familiar.color } as CSSProperties) : undefined}
+      style={familiar
+        ? ({ ["--familiar-accent"]: familiar.color } as CSSProperties)
+        : undefined}
     >
       <SettingsFamiliarPicker
         familiars={resolved}
         value={activeFamiliarId}
         onChange={(id) => openFamiliarStudio(id, activeTab)}
         onSummon={onSummon}
+        onManageLifecycle={openLifecycle}
       />
 
       <div className="familiar-studio-inline__detail">
         {familiar ? (
           <>
-            <Tabs
-              variant="underline"
-              idPrefix="familiar-studio-inline"
-              ariaLabel="Studio sections"
-              value={activeTab}
-              onChange={setActiveTab}
-              items={TABS.map((t) => ({ id: t.id, label: t.label, icon: t.icon }))}
+            <FamiliarStudioHero
+              familiar={familiar}
+              projectCount={projects.length}
+              projectsLoading={projectsLoading}
+              memoryCount={memoryCount}
+              onTestRun={() => setTestRunOpen(true)}
             />
+
+            <div className="familiar-studio-inline__tabs">
+              <Tabs
+                variant="underline"
+                idPrefix="familiar-studio-inline"
+                ariaLabel="Studio sections"
+                value={displayedTab}
+                onChange={setActiveTab}
+                items={TABS.map((tab) => ({
+                  id: tab.id,
+                  label: tab.label,
+                  icon: tab.icon,
+                }))}
+              />
+            </div>
 
             <div
               role="tabpanel"
-              id={`familiar-studio-inline-panel-${activeTab}`}
-              aria-labelledby={`familiar-studio-inline-tab-${activeTab}`}
+              id={`familiar-studio-inline-panel-${displayedTab}`}
+              aria-labelledby={`familiar-studio-inline-tab-${displayedTab}`}
               className="familiar-studio__body familiar-studio-inline__body"
             >
-              {activeTab === "identity" ? (
+              {displayedTab === "identity" ? (
                 <FamiliarStudioIdentityTab
                   familiar={familiar}
                   rawDaemonValues={{
-                    display_name: familiars.find((f) => f.id === familiar.id)?.display_name,
-                    role: familiars.find((f) => f.id === familiar.id)?.role,
-                    pronouns: familiars.find((f) => f.id === familiar.id)?.pronouns,
-                    description: familiars.find((f) => f.id === familiar.id)?.description,
+                    display_name: familiars.find((item) => item.id === familiar.id)?.display_name,
+                    role: familiars.find((item) => item.id === familiar.id)?.role,
+                    pronouns: familiars.find((item) => item.id === familiar.id)?.pronouns,
+                    description: familiars.find((item) => item.id === familiar.id)?.description,
                   }}
                   allFamiliars={resolved}
                   onRosterChanged={onRosterChanged}
                 />
               ) : null}
-              {activeTab === "brain" ? <FamiliarStudioBrainTab familiar={familiar} /> : null}
-              {activeTab === "memory" ? (
-                <FamiliarStudioMemoryTab familiar={familiar} allFamiliars={familiars} />
+              {activeTab === "brain" ? (
+                <FamiliarStudioBrainTab familiar={familiar} />
               ) : null}
-              {activeTab === "projects" ? <FamiliarStudioProjectsTab familiar={familiar} /> : null}
-              {activeTab === "vault" ? <VaultPanel /> : null}
+              {activeTab === "memory" ? (
+                <FamiliarStudioMemoryTab
+                  familiar={familiar}
+                  allFamiliars={familiars}
+                />
+              ) : null}
+              {activeTab === "projects" ? (
+                <div className="familiar-studio-control__projects">
+                  <FamiliarStudioProjectsTab familiar={familiar} />
+                  <AccessGroupsSection familiars={resolved} />
+                </div>
+              ) : null}
+              {activeTab === "vault" ? (
+                <VaultPanel familiarId={familiar.id} />
+              ) : null}
             </div>
 
             <footer className="familiar-studio__footer">
-              <span className="familiar-studio__autosave">Changes save automatically</span>
+              <span className="familiar-studio__autosave">
+                Changes save automatically
+              </span>
               {daemonSync.offline ? (
                 <span
                   className="familiar-studio__sync-warn"
@@ -150,8 +246,19 @@ export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRos
                   <Icon name="ph:warning-circle" width={11} />
                   Saved locally, daemon offline
                 </span>
-              ) : null}
+              ) : (
+                <span className="familiar-studio-control__current">
+                  {familiar.display_name}
+                </span>
+              )}
             </footer>
+
+            <FamiliarTestRunModal
+              familiar={familiar}
+              open={testRunOpen}
+              onClose={() => setTestRunOpen(false)}
+              memoryCount={memoryCount}
+            />
           </>
         ) : (
           <div className="familiar-studio__empty">Select a familiar to edit.</div>
@@ -159,4 +266,348 @@ export function FamiliarStudioInlinePanel({ familiars, resolved, onSummon, onRos
       </div>
     </div>
   );
+}
+
+function FamiliarStudioHero({
+  familiar,
+  projectCount,
+  projectsLoading,
+  memoryCount,
+  onTestRun,
+}: {
+  familiar: ResolvedFamiliar;
+  projectCount: number;
+  projectsLoading: boolean;
+  memoryCount: number | null;
+  onTestRun: () => void;
+}) {
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [dragging, setDragging] = useState(false);
+  const { onFile, toast } = useFamiliarImageUpload(familiar.id);
+  const types = resolveFamiliarTypes(familiar.familiarType);
+  const visibleTypes = types.length > 0 ? types : [FAMILIAR_TYPES[0]];
+  const runtime = familiar.harness ?? familiar.defaultHarness ?? "";
+  const voice = familiar.voiceProvider === "off"
+    ? "Text only"
+    : familiar.voiceName || familiar.voiceProvider || "Voice inherited";
+  const status = familiar.status || (
+    (familiar.active_sessions ?? 0) > 0 ? "working" : "status unknown"
+  );
+  const stats = [
+    {
+      label: runtime ? runtimeDisplayLabel(runtime) : "Runtime inherited",
+      tone: "success",
+    },
+    { label: familiar.model || "Model inherited", tone: "accent" },
+    { label: voice, tone: familiar.voiceProvider === "off" ? "muted" : "success" },
+    {
+      label: projectsLoading
+        ? "Projects…"
+        : `${projectCount} ${projectCount === 1 ? "project" : "projects"}`,
+      tone: projectCount > 0 ? "accent" : "muted",
+    },
+    {
+      label: memoryCount === null
+        ? "Memories…"
+        : `${memoryCount} ${memoryCount === 1 ? "memory" : "memories"}`,
+      tone: (memoryCount ?? 0) > 0 ? "accent" : "muted",
+    },
+  ];
+
+  const acceptAvatar = (file: File | undefined) => {
+    if (file) void onFile(file);
+  };
+  const dropAvatar = (event: DragEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    setDragging(false);
+    acceptAvatar(event.dataTransfer.files[0]);
+  };
+
+  return (
+    <header className="familiar-studio-control__hero">
+      <div className="familiar-studio-control__avatar-wrap">
+        <button
+          type="button"
+          className="familiar-studio-control__avatar focus-ring"
+          data-dragging={dragging || undefined}
+          aria-label={`Replace ${familiar.display_name}'s portrait`}
+          title="Click or drop an image to replace the portrait"
+          onClick={() => inputRef.current?.click()}
+          onDragOver={(event) => {
+            event.preventDefault();
+            setDragging(true);
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={dropAvatar}
+        >
+          <FamiliarAvatar
+            familiar={familiar}
+            size="xl"
+            className="familiar-studio-control__avatar-image"
+          />
+        </button>
+        <input
+          ref={inputRef}
+          type="file"
+          hidden
+          accept={FAMILIAR_IMAGE_ACCEPT}
+          onChange={(event) => {
+            acceptAvatar(event.target.files?.[0]);
+            event.target.value = "";
+          }}
+        />
+        {toast ? (
+          <span className="familiar-studio-control__avatar-note" role="status">
+            {toast}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="familiar-studio-control__identity">
+        <div className="familiar-studio-control__name-row">
+          <h1>{familiar.display_name}</h1>
+          {familiar.role ? (
+            <span className="familiar-studio-control__role">{familiar.role}</span>
+          ) : null}
+        </div>
+        <div className="familiar-studio-control__meta">
+          <div className="familiar-studio-control__types" aria-label="Familiar types">
+            {visibleTypes.map((type) => (
+              <span key={type.id}>{type.label}</span>
+            ))}
+          </div>
+          <span className="familiar-studio-control__divider" aria-hidden />
+          <div className="familiar-studio-control__stats">
+            {stats.map((stat) => (
+              <span
+                key={stat.label}
+                className="familiar-studio-control__stat"
+                title={stat.label}
+              >
+                <span data-tone={stat.tone} aria-hidden />
+                {stat.label}
+              </span>
+            ))}
+          </div>
+        </div>
+        <span className="sr-only">Status: {status}</span>
+      </div>
+
+      <div className="familiar-studio-control__actions">
+        <Button
+          variant="primary"
+          size="sm"
+          leadingIcon="ph:chat-circle-dots"
+          onClick={() => requestAgentsNewChat({ familiarId: familiar.id })}
+        >
+          Open chat
+        </Button>
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="ph:sparkle"
+          onClick={onTestRun}
+        >
+          Test run
+        </Button>
+      </div>
+    </header>
+  );
+}
+
+function FamiliarTestRunModal({
+  familiar,
+  open,
+  onClose,
+  memoryCount,
+}: {
+  familiar: ResolvedFamiliar;
+  open: boolean;
+  onClose: () => void;
+  memoryCount: number | null;
+}) {
+  const [state, setState] = useState<"idle" | "running" | "done" | "error">("idle");
+  const [response, setResponse] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const controllerRef = useRef<AbortController | null>(null);
+
+  const run = useCallback(async () => {
+    controllerRef.current?.abort();
+    const controller = new AbortController();
+    controllerRef.current = controller;
+    setState("running");
+    setResponse("");
+    setError(null);
+    try {
+      const result = await streamFamiliarText({
+        familiarId: familiar.id,
+        prompt: "Reply with one short sentence confirming your identity and readiness. Do not call tools or change files.",
+        origin: "enhance",
+        permissionMode: "read",
+        signal: controller.signal,
+        onText: setResponse,
+      });
+      if (controller.signal.aborted) return;
+      if (result.error) {
+        setError(result.error);
+        setState("error");
+        return;
+      }
+      setResponse(result.text);
+      setState("done");
+    } catch (cause) {
+      if (controller.signal.aborted) return;
+      setError(cause instanceof Error ? cause.message : "Test run failed");
+      setState("error");
+    }
+  }, [familiar.id]);
+
+  useEffect(() => {
+    if (!open) return;
+    void run();
+    return () => controllerRef.current?.abort();
+  }, [open, run]);
+
+  const close = () => {
+    controllerRef.current?.abort();
+    onClose();
+  };
+  const runtime = familiar.harness ?? familiar.defaultHarness;
+  const checks = [
+    {
+      label: "Runtime",
+      detail: runtime ? runtimeDisplayLabel(runtime) : "Inherited from Coven",
+      status: "ready",
+    },
+    {
+      label: "Model",
+      detail: familiar.model || "Runtime default",
+      status: "ready",
+    },
+    {
+      label: "Voice",
+      detail: familiar.voiceProvider === "off"
+        ? "Off for this familiar"
+        : familiar.voiceName || familiar.voiceProvider || "Inherited",
+      status: familiar.voiceProvider === "off" ? "skipped" : "ready",
+    },
+    {
+      label: "Memory",
+      detail: memoryCount === null
+        ? "Count unavailable"
+        : `${memoryCount} ${memoryCount === 1 ? "entry" : "entries"} visible`,
+      status: memoryCount === null ? "unknown" : "ready",
+    },
+    {
+      label: "Live response",
+      detail: state === "running"
+        ? "Waiting for a read-only reply…"
+        : state === "done"
+          ? "Response received"
+          : state === "error"
+            ? error || "Run failed"
+            : "Queued",
+      status: state,
+    },
+  ];
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      dismissOnBackdrop={state !== "running"}
+      dismissOnEscape={state !== "running"}
+      breadcrumb={["Familiars", familiar.display_name, "Test run"]}
+      footerActions={(
+        <>
+          <Button variant="secondary" onClick={close}>Close</Button>
+          <Button
+            variant="primary"
+            leadingIcon="ph:sparkle"
+            loading={state === "running"}
+            onClick={() => void run()}
+          >
+            Run again
+          </Button>
+        </>
+      )}
+    >
+      <div className="familiar-test-run">
+        <div className="familiar-test-run__summary">
+          <div>
+            <h2>Read-only readiness check</h2>
+            <p>Confirms the configured route and asks the familiar for one harmless reply.</p>
+          </div>
+          <span data-state={state}>{state}</span>
+        </div>
+        <div className="familiar-test-run__checks">
+          {checks.map((check) => (
+            <div key={check.label} className="familiar-test-run__check">
+              <span className="familiar-test-run__check-icon" data-state={check.status} aria-hidden>
+                {check.status === "ready" || check.status === "done"
+                  ? "✓"
+                  : check.status === "running"
+                    ? "•"
+                    : "–"}
+              </span>
+              <span>
+                <strong>{check.label}</strong>
+                <small>{check.detail}</small>
+              </span>
+              <span className="familiar-test-run__badge" data-state={check.status}>
+                {check.status}
+              </span>
+            </div>
+          ))}
+        </div>
+        {response ? (
+          <div className="familiar-test-run__response" aria-live="polite">
+            <span>Response</span>
+            <p>{response}</p>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  );
+}
+
+function useFamiliarMemoryCount(familiarId: string | null): number | null {
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!familiarId) {
+      setCount(null);
+      return;
+    }
+    const controller = new AbortController();
+    setCount(null);
+    const loadEntries = async (url: string) => {
+      const response = await fetch(url, {
+        cache: "no-store",
+        signal: controller.signal,
+      });
+      if (!response.ok) throw new Error("Memory count unavailable");
+      return response.json();
+    };
+    void Promise.all([
+      loadEntries("/api/coven-memory"),
+      loadEntries("/api/memory"),
+    ])
+      .then(([coven, files]) => {
+        if (controller.signal.aborted) return;
+        const covenCount = Array.isArray(coven?.entries)
+          ? coven.entries.filter((entry: { familiar_id?: string }) => entry.familiar_id === familiarId).length
+          : 0;
+        const fileCount = Array.isArray(files?.entries)
+          ? files.entries.filter((entry: { familiarId?: string }) => entry.familiarId === familiarId).length
+          : 0;
+        setCount(covenCount + fileCount);
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setCount(null);
+      });
+    return () => controller.abort();
+  }, [familiarId]);
+
+  return count;
 }

--- a/src/components/familiar-studio-memory-tab.tsx
+++ b/src/components/familiar-studio-memory-tab.tsx
@@ -1,8 +1,13 @@
 "use client";
 
+import { useState } from "react";
+
+import { FamiliarDailyNotes } from "@/components/familiar-daily-notes";
+import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
+import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
-import { FamiliarsMemoryView } from "@/components/familiars-memory-view";
 
 type Props = {
   familiar: ResolvedFamiliar;
@@ -10,11 +15,44 @@ type Props = {
 };
 
 export function FamiliarStudioMemoryTab({ familiar, allFamiliars }: Props) {
+  const [noteOpen, setNoteOpen] = useState(false);
+
   return (
-    <FamiliarsMemoryView
-      familiars={allFamiliars}
-      activeFamiliar={familiar}
-      lockToFamiliar
-    />
+    <>
+      <div className="familiar-studio-memory">
+        <div className="familiar-studio-memory__toolbar">
+          <p>Browse durable memory and add a dated note for {familiar.display_name}.</p>
+          <Button
+            variant="secondary"
+            size="sm"
+            leadingIcon="ph:plus"
+            onClick={() => setNoteOpen(true)}
+          >
+            Add note
+          </Button>
+        </div>
+        <FamiliarsMemoryView
+          familiars={allFamiliars}
+          activeFamiliar={familiar}
+          lockToFamiliar
+        />
+      </div>
+
+      <Modal
+        open={noteOpen}
+        wide
+        onClose={() => setNoteOpen(false)}
+        breadcrumb={["Familiars", familiar.display_name, "Add note"]}
+        footerActions={(
+          <Button variant="secondary" onClick={() => setNoteOpen(false)}>
+            Close
+          </Button>
+        )}
+      >
+        <div className="familiar-studio-note-editor">
+          <FamiliarDailyNotes familiar={familiar} />
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/src/components/familiar-studio-projects-tab.test.ts
+++ b/src/components/familiar-studio-projects-tab.test.ts
@@ -14,8 +14,8 @@ assert.match(context, /"projects"/, "studio tab union includes projects");
 assert.match(inline, /id: "projects", label: "Projects"/, "inline studio exposes a Projects tab");
 assert.match(
   inline,
-  /activeTab === "projects" \? <FamiliarStudioProjectsTab familiar=\{familiar\} \/>/,
-  "inline studio renders the Projects tab body for the selected familiar",
+  /activeTab === "projects" \? \([\s\S]*?<FamiliarStudioProjectsTab familiar=\{familiar\} \/>[\s\S]*?<AccessGroupsSection familiars=\{resolved\} \/>[\s\S]*?\) : null/,
+  "inline studio renders project grants and access groups together for the selected familiar",
 );
 
 // ── The standalone Settings → Permissions section is gone ────────────────────

--- a/src/components/settings-action-buttons.test.ts
+++ b/src/components/settings-action-buttons.test.ts
@@ -2,12 +2,13 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import ts from "typescript";
+import cssContract from "../../scripts/css-source-contract.cjs";
 
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const daemon = readFileSync(new URL("./settings-daemon.tsx", import.meta.url), "utf8");
 const picker = readFileSync(new URL("./settings-familiar-picker.tsx", import.meta.url), "utf8");
 const controls = readFileSync(new URL("./ui/settings-controls.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = cssContract.readEffectiveCssSync("src/app/globals.css", "utf8");
 const studioSources = [
   "familiar-studio-brain-tab.tsx",
   "familiar-studio-identity-tab.tsx",

--- a/src/components/settings-familiar-picker.tsx
+++ b/src/components/settings-familiar-picker.tsx
@@ -1,17 +1,22 @@
 "use client";
 
 import {
-  useEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
   type KeyboardEvent,
 } from "react";
+
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { Button } from "@/components/ui/button";
-import { Popover } from "@/components/ui/popover";
-import { Icon } from "@/lib/icon";
+import { IconButton } from "@/components/ui/icon-button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { SearchInput } from "@/components/ui/search-input";
+import {
+  archiveFamiliar,
+  unarchiveFamiliar,
+} from "@/lib/cave-familiar-archive";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import {
   familiarRosterCountLabel,
@@ -24,258 +29,179 @@ type Props = {
   value: string | null;
   onChange: (id: string) => void;
   onSummon?: () => void;
+  /** Opens the selected familiar's existing undo-safe lifecycle controls. */
+  onManageLifecycle?: (id: string) => void;
 };
 
-const LISTBOX_ID = "settings-familiar-picker-listbox";
-const OPTION_ID_PREFIX = "settings-familiar-picker-option-";
-
-function optionId(index: number): string {
-  return OPTION_ID_PREFIX + index;
-}
-
-export function SettingsFamiliarPicker({ familiars, value, onChange, onSummon }: Props) {
-  const [open, setOpen] = useState(false);
+export function SettingsFamiliarPicker({
+  familiars,
+  value,
+  onChange,
+  onSummon,
+  onManageLifecycle,
+}: Props) {
+  const [collapsed, setCollapsed] = useState(false);
   const [query, setQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(-1);
-  const triggerRef = useRef<HTMLButtonElement | null>(null);
-  const searchRef = useRef<HTMLInputElement | null>(null);
   const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const { announce } = useAnnouncer();
 
-  const active = useMemo(
-    () => familiars.find((familiar) => familiar.id === value) ?? null,
-    [familiars, value],
-  );
   const filtered = useMemo(
     () => filterSettingsFamiliars(familiars, query),
     [familiars, query],
   );
   const rosterCount = familiarRosterCountLabel(familiars.length);
 
-  const resetAndClose = () => {
-    setOpen(false);
-    setQuery("");
-    setHighlightedIndex(-1);
+  const moveFocus = (
+    event: KeyboardEvent<HTMLButtonElement>,
+    index: number,
+  ) => {
+    if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+    event.preventDefault();
+    event.stopPropagation();
+    const next = moveFamiliarPickerIndex(index, event.key, filtered.length);
+    optionRefs.current[next]?.focus();
   };
-
-  const updateOpen = (next: boolean) => {
-    if (!next) {
-      resetAndClose();
-      return;
-    }
-    setQuery("");
-    const selectedIndex = familiars.findIndex((familiar) => familiar.id === value);
-    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : familiars.length > 0 ? 0 : -1);
-    setOpen(true);
-  };
-
-  const selectFamiliar = (id: string) => {
-    onChange(id);
-    resetAndClose();
-  };
-
-  useEffect(() => {
-    if (!open) return;
-    searchRef.current?.focus({ preventScroll: true });
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) return;
-    setHighlightedIndex((current) => {
-      if (filtered.length === 0) return -1;
-      if (current < 0) return 0;
-      return Math.min(current, filtered.length - 1);
-    });
-  }, [filtered.length, open]);
-
-  useEffect(() => {
-    if (!open || highlightedIndex < 0) return;
-    optionRefs.current[highlightedIndex]?.scrollIntoView({ block: "nearest" });
-  }, [filtered, highlightedIndex, open]);
-
-  const handleQueryChange = (nextQuery: string) => {
-    setQuery(nextQuery);
-    const nextFiltered = filterSettingsFamiliars(familiars, nextQuery);
-    const selectedIndex = nextFiltered.findIndex((familiar) => familiar.id === value);
-    setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : nextFiltered.length > 0 ? 0 : -1);
-  };
-
-  const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-    const key = event.key;
-    if (key === "ArrowDown" || key === "ArrowUp") {
-      event.preventDefault();
-      setHighlightedIndex((current) =>
-        moveFamiliarPickerIndex(current, key, filtered.length),
-      );
-      return;
-    }
-    if (event.key === "Enter") {
-      const familiar = filtered[highlightedIndex];
-      if (!familiar) return;
-      event.preventDefault();
-      selectFamiliar(familiar.id);
-    }
-  };
-
-  const activeDescendant =
-    highlightedIndex >= 0 && filtered[highlightedIndex]
-      ? optionId(highlightedIndex)
-      : undefined;
-  const triggerLabel = active
-    ? "Choose familiar to edit. Current: " + active.display_name + ". " + rosterCount + "."
-    : "Choose familiar to edit. " + rosterCount + ".";
-  const resultSummary = query.trim()
-    ? filtered.length + " of " + rosterCount
-    : rosterCount;
 
   return (
-    <div className="familiar-studio-inline__selector">
-      <span className="familiar-studio-inline__selector-label" id="settings-familiar-picker-label">
-        Familiar
-      </span>
-      <button
-        ref={triggerRef}
-        type="button"
-        className="familiar-studio-picker__trigger"
-        aria-haspopup="dialog"
-        aria-expanded={open}
-        aria-label={triggerLabel}
-        onClick={() => updateOpen(!open)}
-        style={
-          active
-            ? ({ ["--familiar-accent"]: active.color } as CSSProperties)
-            : undefined
-        }
-      >
-        <span className="familiar-studio-picker__trigger-avatar" aria-hidden>
-          {active ? (
-            <FamiliarAvatar familiar={active} size="md" />
-          ) : (
-            <Icon name="ph:sparkle" width={16} />
-          )}
-        </span>
-        <span className="familiar-studio-picker__trigger-copy">
-          <span className="familiar-studio-picker__trigger-name">
-            {active?.display_name ?? "Select a familiar"}
-          </span>
-          <span className="familiar-studio-picker__trigger-role">
-            {active?.role || active?.id || "Choose who to edit"}
-          </span>
-        </span>
-        <span className="familiar-studio-picker__trigger-count">{rosterCount}</span>
-        <Icon
-          name="ph:caret-up-down-bold"
-          width={12}
-          className="familiar-studio-picker__trigger-caret"
-          aria-hidden
-        />
-      </button>
-
-      <Popover
-        open={open}
-        onOpenChange={updateOpen}
-        anchorRef={triggerRef}
-        placement="bottom-start"
-        minWidth={240}
-        scrollStrategy="content"
-        compactAtHeight={184}
-        className="familiar-studio-picker__popover"
-        ariaLabel="Choose familiar to edit"
-      >
-        <div className="familiar-studio-picker">
-          <div className="familiar-studio-picker__search-shell">
-            <Icon name="ph:magnifying-glass" width={14} aria-hidden />
-            <input
-              ref={searchRef}
-              type="search"
-              value={query}
-              onChange={(event) => handleQueryChange(event.target.value)}
-              onKeyDown={handleSearchKeyDown}
-              role="combobox"
-              aria-label="Search familiars"
-              aria-expanded={open}
-              aria-autocomplete="list"
-              aria-controls={LISTBOX_ID}
-              aria-activedescendant={activeDescendant}
-              autoComplete="off"
-              placeholder="Search name, role, or ID…"
-              className="familiar-studio-picker__search"
-            />
-          </div>
-          <div className="familiar-studio-picker__result-summary" aria-live="polite">
-            {resultSummary}
-          </div>
-
-          <ul
-            id={LISTBOX_ID}
-            className="familiar-studio-picker__results"
-            role="listbox"
-            aria-label="Familiars"
-          >
-            {filtered.map((familiar, index) => {
-              const selected = familiar.id === value;
-              const highlighted = index === highlightedIndex;
-              return (
-                <li key={familiar.id} role="presentation">
-                  <button
-                    ref={(node) => {
-                      optionRefs.current[index] = node;
-                    }}
-                    id={optionId(index)}
-                    type="button"
-                    role="option"
-                    aria-selected={selected}
-                    tabIndex={-1}
-                    data-selected={selected || undefined}
-                    data-highlighted={highlighted || undefined}
-                    className="familiar-studio-picker__option"
-                    style={{ ["--familiar-accent"]: familiar.color } as CSSProperties}
-                    onMouseEnter={() => setHighlightedIndex(index)}
-                    onClick={() => selectFamiliar(familiar.id)}
-                    title={familiar.display_name + " — " + (familiar.role || familiar.id)}
-                  >
-                    <span className="familiar-studio-picker__option-avatar" aria-hidden>
-                      <FamiliarAvatar familiar={familiar} size="sm" />
-                    </span>
-                    <span className="familiar-studio-picker__option-copy">
-                      <span className="familiar-studio-picker__option-name">
-                        {familiar.display_name}
-                      </span>
-                      <span className="familiar-studio-picker__option-meta">
-                        {familiar.role ? familiar.role + " · " : ""}
-                        <span>{familiar.id}</span>
-                      </span>
-                    </span>
-                    {selected ? <Icon name="ph:check-bold" width={13} aria-hidden /> : null}
-                  </button>
-                </li>
-              );
-            })}
-            {filtered.length === 0 ? (
-              <li className="familiar-studio-picker__empty" role="presentation">
-                No familiars match “{query.trim()}”.
-              </li>
-            ) : null}
-          </ul>
-
-          {onSummon ? (
-            <div className="familiar-studio-picker__footer">
-              <Button
-                variant="primary"
-                size="lg"
-                fullWidth
-                className="familiar-studio-picker__summon"
-                onClick={() => {
-                  resetAndClose();
-                  onSummon();
-                }}
-                leadingIcon="ph:magic-wand-fill"
-              >
-                Summon familiar
-              </Button>
-            </div>
-          ) : null}
+    <aside
+      className="settings-familiar-roster"
+      data-collapsed={collapsed || undefined}
+      aria-label="Familiar roster"
+    >
+      <div className="settings-familiar-roster__header">
+        <div className="settings-familiar-roster__heading">
+          <span>Familiars</span>
+          <span className="settings-familiar-roster__count">{familiars.length}</span>
         </div>
-      </Popover>
-    </div>
+        {onSummon ? (
+          <IconButton
+            icon="ph:plus"
+            size="sm"
+            className="settings-familiar-roster__summon focus-ring"
+            aria-label="Summon familiar"
+            title="Summon familiar"
+            onClick={onSummon}
+          />
+        ) : null}
+        <IconButton
+          icon="ph:sidebar-simple"
+          size="sm"
+          className="settings-familiar-roster__collapse focus-ring"
+          aria-label={collapsed ? "Expand familiar list" : "Collapse familiar list"}
+          title={collapsed ? "Expand familiar list" : "Collapse familiar list"}
+          onClick={() => setCollapsed((current) => !current)}
+        />
+      </div>
+
+      <SearchInput
+        value={query}
+        onValueChange={setQuery}
+        onClear={() => setQuery("")}
+        placeholder="Find a familiar…"
+        aria-label="Find a familiar"
+        containerClassName="settings-familiar-roster__search"
+      />
+
+      <div className="settings-familiar-roster__summary" aria-live="polite">
+        {query.trim()
+          ? `${filtered.length} of ${rosterCount}`
+          : rosterCount}
+      </div>
+
+      <ul
+        className="settings-familiar-roster__list"
+        aria-label="Familiars"
+      >
+        {filtered.map((familiar, index) => {
+          const selected = familiar.id === value;
+          return (
+            <li
+              key={familiar.id}
+              className="settings-familiar-roster__row reveal-scope"
+              style={{ ["--familiar-accent"]: familiar.color } as CSSProperties}
+              data-selected={selected || undefined}
+              data-archived={familiar.archived || undefined}
+            >
+              <Button
+                ref={(node) => {
+                  optionRefs.current[index] = node;
+                }}
+                variant="ghost"
+                fullWidth
+                aria-current={selected ? "page" : undefined}
+                className="settings-familiar-roster__option focus-ring"
+                title={`${familiar.display_name} — ${familiar.role || familiar.id}`}
+                onClick={() => onChange(familiar.id)}
+                onKeyDown={(event) => moveFocus(event, index)}
+              >
+                <span className="settings-familiar-roster__avatar" aria-hidden>
+                  <FamiliarAvatar
+                    familiar={familiar}
+                    size="md"
+                    className="settings-familiar-roster__avatar-image"
+                  />
+                </span>
+                <span className="settings-familiar-roster__copy">
+                  <span className="settings-familiar-roster__name">
+                    {familiar.display_name}
+                  </span>
+                  <span className="settings-familiar-roster__role">
+                    {familiar.role || familiar.id}
+                  </span>
+                </span>
+                <span className="sr-only">
+                  {familiar.archived ? "Archived. " : ""}
+                  Status: {familiar.status || "unknown"}
+                </span>
+              </Button>
+
+              <span
+                className="settings-familiar-roster__presence"
+                data-status={familiar.status || "unknown"}
+                title={familiar.status ? `Status: ${familiar.status}` : "Status unknown"}
+                aria-hidden
+              />
+
+              <span className="settings-familiar-roster__actions reveal-on-hover">
+                <IconButton
+                  icon={familiar.archived ? "ph:arrow-counter-clockwise" : "ph:archive"}
+                  size="xs"
+                  aria-label={`${familiar.archived ? "Unarchive" : "Archive"} ${familiar.display_name}`}
+                  title={familiar.archived
+                    ? "Unarchive — return to active switchers"
+                    : "Archive — hide from switchers; restore from this roster"}
+                  onClick={() => {
+                    familiar.archived
+                      ? unarchiveFamiliar(familiar.id)
+                      : archiveFamiliar(familiar.id);
+                    announce(
+                      `${familiar.archived ? "Unarchived" : "Archived"} ${familiar.display_name}.`,
+                    );
+                  }}
+                />
+                {onManageLifecycle ? (
+                  <IconButton
+                    icon="ph:trash"
+                    size="xs"
+                    danger
+                    aria-label={`Dismiss ${familiar.display_name}`}
+                    title="Dismiss — review the undo-safe remove controls"
+                    onClick={() => {
+                      onChange(familiar.id);
+                      onManageLifecycle(familiar.id);
+                    }}
+                  />
+                ) : null}
+              </span>
+            </li>
+          );
+        })}
+        {filtered.length === 0 ? (
+          <li className="settings-familiar-roster__empty" role="presentation">
+            No familiar matches that.
+          </li>
+        ) : null}
+      </ul>
+    </aside>
   );
 }

--- a/src/components/settings-familiars-control-sheet.test.ts
+++ b/src/components/settings-familiars-control-sheet.test.ts
@@ -1,0 +1,130 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+
+const inline = readFileSync(new URL("./familiar-studio-inline.tsx", import.meta.url), "utf8");
+const picker = readFileSync(new URL("./settings-familiar-picker.tsx", import.meta.url), "utf8");
+const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const vault = readFileSync(new URL("./vault-panel.tsx", import.meta.url), "utf8");
+const vaultRoute = readFileSync(new URL("../app/api/vault/route.ts", import.meta.url), "utf8");
+const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const stylesUrl = new URL("../styles/settings-familiars.css", import.meta.url);
+const styles = existsSync(stylesUrl) ? readFileSync(stylesUrl, "utf8") : "";
+
+// Familiars owns the content viewport. The app settings rail remains the first
+// pane; this surface supplies the always-visible roster and detail panes.
+assert.match(
+  shell,
+  /section === "familiars" \? "settings-shell__content--familiars" : ""/,
+  "Settings removes generic page padding/scroll only for the Familiars control sheet",
+);
+assert.match(
+  globals,
+  /@import "\.\.\/styles\/settings-familiars\.css";/,
+  "The focused Familiars control-sheet stylesheet is wired through the global facade",
+);
+assert.match(
+  styles,
+  /\.familiar-studio-inline\s*\{[\s\S]*?grid-template-columns:\s*var\(--familiar-roster-width\)\s+minmax\(0,\s*1fr\)/,
+  "The Studio is a roster/detail grid rather than a dropdown over one column",
+);
+assert.match(
+  styles,
+  /\.familiar-studio-inline\s*\{[\s\S]*?grid-template-rows:\s*minmax\(0,\s*1fr\)[\s\S]*?border:\s*0[\s\S]*?border-radius:\s*0/,
+  "The control sheet resets the legacy card rows and border so both panes fill the viewport",
+);
+
+// The familiar roster is persistent, searchable, collapsible, and keyboard
+// selectable. Summon stays in the roster header; lifecycle remains safe.
+assert.match(picker, /<aside[\s\S]*?className="settings-familiar-roster"/, "Renders an always-visible familiar roster");
+assert.match(picker, /placeholder="Find a familiar…"/, "Uses the handoff search copy");
+assert.match(picker, /aria-label=\{collapsed \? "Expand familiar list" : "Collapse familiar list"\}/, "Roster can collapse to its avatar rail");
+assert.doesNotMatch(picker, /role="listbox"/, "Row actions are not nested inside an ARIA listbox");
+assert.match(picker, /aria-current=\{selected \? "page" : undefined\}/, "The selected familiar is announced");
+assert.match(picker, /className="sr-only"[\s\S]*?Status:/, "Roster status has a non-color screen-reader channel");
+assert.match(picker, /archiveFamiliar/, "Roster archive action uses the production archive store");
+assert.match(picker, /onManageLifecycle/, "Dismiss routes through the existing undo-safe lifecycle controls");
+assert.doesNotMatch(picker, /<Popover/, "The Familiars handoff retires the dropdown picker");
+assert.match(
+  styles,
+  /@container familiar-studio \(max-width: 560px\)[\s\S]*?settings-familiar-roster__summon[\s\S]*?display:\s*inline-grid/,
+  "The narrow roster keeps Summon reachable when the expand control is hidden",
+);
+const narrowLayout = styles.slice(
+  styles.indexOf("@container familiar-studio (max-width: 560px)"),
+  styles.indexOf("@media (prefers-reduced-motion: reduce)"),
+);
+assert.doesNotMatch(
+  narrowLayout,
+  /\.settings-familiar-roster :is\([\s\S]*?settings-familiar-roster__search/,
+  "The narrow roster keeps search, copy, status, and row actions available",
+);
+assert.doesNotMatch(
+  narrowLayout,
+  /\.settings-familiar-roster__collapse\s*\{[^}]*display:\s*none/,
+  "The narrow roster remains collapsible",
+);
+assert.match(
+  narrowLayout,
+  /\.settings-familiar-roster\[data-collapsed\] \.settings-familiar-roster__list\s*\{[^}]*display:\s*none/,
+  "Collapsing the narrow roster frees the vertical space used by its list",
+);
+
+// The detail hero is live production UI: avatar upload, runtime/model/voice
+// facts, chat handoff, and a real read-only one-shot smoke test.
+assert.match(inline, /useFamiliarImageUpload/, "Hero avatar uses the shared image upload contract");
+assert.match(inline, /FAMILIAR_IMAGE_ACCEPT/, "Hero and Identity accept the same image formats");
+assert.match(inline, /requestAgentsNewChat\(\{ familiarId: familiar\.id \}\)/, "Open chat uses the cross-route production handoff");
+assert.match(inline, /streamFamiliarText/, "Test run uses the sanctioned familiar stream");
+assert.match(inline, /permissionMode: "read"/, "Test run is a non-mutating read-only smoke test");
+assert.match(
+  inline,
+  /streamFamiliarText\(\{[\s\S]*?origin: "enhance",[\s\S]*?permissionMode: "read"/,
+  "The projectless readiness check uses an approved hidden-generation origin",
+);
+assert.match(inline, /catch \(cause\)/, "Aborting or failing a streamed smoke test cannot reject unhandled");
+assert.match(inline, /className="familiar-studio-control__hero"/, "Renders the handoff identity hero");
+assert.match(inline, /className="familiar-studio-control__stats"/, "Renders production runtime/model/voice/status facts");
+assert.match(inline, /Open chat/, "Hero exposes the primary chat action");
+assert.match(inline, /Test run/, "Hero exposes the smoke-test action");
+assert.match(inline, /breadcrumb=\{\["Familiars", familiar\.display_name, "Test run"\]\}/, "Smoke test opens in the shared modal");
+assert.match(
+  inline,
+  /if \(!response\.ok\) throw new Error\("Memory count unavailable"\)/,
+  "Failed memory APIs stay unknown instead of being reported as zero entries",
+);
+assert.match(inline, /<VaultPanel familiarId=\{familiar\.id\}/, "Vault receives the selected familiar scope");
+assert.match(vault, /export function VaultPanel\(\{ familiarId \}/, "Vault accepts a familiar scope");
+assert.match(vault, /method: "PATCH"/, "Familiar Vault grants update scope without rewriting or deleting the secret");
+assert.match(vault, /Grant to familiar/, "Familiar Vault can grant an existing scoped key");
+assert.match(vault, /Revoke from familiar/, "Familiar Vault can revoke only the selected familiar's grant");
+assert.match(
+  vault,
+  /familiarId \?[\s\S]*?updateFamiliarGrant[\s\S]*?:[\s\S]*?handleDelete/,
+  "The familiar-scoped action cannot invoke the global secret deletion path",
+);
+assert.match(vaultRoute, /normalizeVaultScope\(body\.scope\)/, "Vault writes can persist a familiar grant");
+assert.match(vaultRoute, /export async function PATCH/, "Vault exposes a scope-only mutation");
+
+// Preserve the five real Studio surfaces and the fixed autosave/offline footer.
+for (const label of ["Identity", "Brain", "Memory", "Projects", "Vault"]) {
+  assert.match(inline, new RegExp(`label: "${label}"`), `${label} remains in the Studio`);
+}
+assert.match(inline, /Changes save automatically/, "The fixed save-status footer remains");
+assert.match(
+  styles,
+  /@media \(prefers-reduced-motion: reduce\)/,
+  "The control sheet supplies a reduced-motion story",
+);
+assert.match(
+  styles,
+  /@container familiar-studio/,
+  "The roster/detail layout adapts to its Settings content container",
+);
+assert.match(
+  styles,
+  /\.familiar-studio-grimoire:focus\s*\{/,
+  "The programmatic Contract redirect always leaves a visible Grimoire focus ring",
+);
+
+console.log("settings-familiars-control-sheet.test.ts: ok");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -46,7 +46,6 @@ import { SettingsTabbed } from "./settings-section-tabs";
 import type { TabItem } from "@/components/ui/tabs";
 import { ProfileSection } from "./settings-profile";
 import { GithubSection } from "./settings-github";
-import { AccessGroupsSection } from "./access-groups-section";
 import { SettingsOverview } from "./settings-overview";
 import { AboutSection } from "./settings-about";
 import {
@@ -334,7 +333,13 @@ export function SettingsShell() {
         {/* Content */}
         <main
           hidden={showPicker}
-          className="settings-shell__content min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8 [padding-bottom:calc(1.5rem_+_var(--sai-bottom))]!"
+          className={`settings-shell__content min-h-0 flex-1 ${
+            section === "familiars" ? "settings-shell__content--familiars" : ""
+          } ${
+            section === "familiars"
+              ? "overflow-hidden"
+              : "overflow-y-auto px-4 py-6 md:px-8 [padding-bottom:calc(1.5rem_+_var(--sai-bottom))]!"
+          }`}
         >
           {section === "profile" && <ProfileSection />}
           {section === "general" && <GeneralSection />}
@@ -1086,7 +1091,7 @@ function FamiliarsSection({
   const [createOpen, setCreateOpen] = useState(false);
   const [starting, setStarting] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
-  const familiars = useResolvedFamiliars(rawFamiliars);
+  const familiars = useResolvedFamiliars(rawFamiliars, { includeArchived: true });
   // This renders below FamiliarStudioProvider (the shell mounts it), so the
   // studio tab state is reachable here even though the shell body can't.
   const { setActiveTab, openFamiliarStudio } = useFamiliarStudio();
@@ -1230,20 +1235,12 @@ function FamiliarsSection({
 
   return (
     <>
-      {/* Summon lives in the familiar picker's fixed footer, alongside the
-          roster it extends instead of floating above the Studio. */}
       <FamiliarStudioInlinePanel
         familiars={rawFamiliars}
         resolved={familiars}
         onSummon={() => setCreateOpen(true)}
         onRosterChanged={() => void load()}
       />
-      {/* Cross-familiar access groups — shared base project grants at read or
-          write level; per-familiar effective access renders in the studio's
-          Projects tab. */}
-      <div className="mt-4">
-        <AccessGroupsSection familiars={familiars} />
-      </div>
       {createDialog}
     </>
   );

--- a/src/components/vault-panel.tsx
+++ b/src/components/vault-panel.tsx
@@ -7,6 +7,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { UndoToast } from "@/components/ui/undo-toast";
 import { useUndoDelete } from "@/lib/use-undo-delete";
 
@@ -18,6 +19,7 @@ type Mapping = {
   key: string;
   ref: string | null;
   storage: "1password" | "encrypted" | "dashlane" | null;
+  scope: "shared" | string[];
   description: string | null;
   required: boolean;
   status: VaultStatus;
@@ -57,10 +59,12 @@ function StatusBadge({ status, storage }: { status: VaultStatus; storage?: Mappi
 
 function AddMappingForm({
   initial,
+  familiarId,
   onSaved,
   onCancel,
 }: {
   initial?: Mapping;
+  familiarId?: string;
   onSaved: () => void;
   onCancel: () => void;
 }) {
@@ -87,8 +91,21 @@ function AddMappingForm({
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify(storage === "encrypted"
-          ? { key, storage: "encrypted", value: secret, description: desc || undefined, required }
-          : { key, ref, description: desc || undefined, required }),
+          ? {
+              key,
+              storage: "encrypted",
+              value: secret,
+              description: desc || undefined,
+              required,
+              scope: initial?.scope ?? (familiarId ? [familiarId] : undefined),
+            }
+          : {
+              key,
+              ref,
+              description: desc || undefined,
+              required,
+              scope: initial?.scope ?? (familiarId ? [familiarId] : undefined),
+            }),
       });
       const j = await res.json() as { ok: boolean; error?: string };
       if (!j.ok) throw new Error(j.error ?? "Failed to save");
@@ -201,7 +218,7 @@ function AddMappingForm({
 
 // ── Main panel ────────────────────────────────────────────────────────────────
 
-export function VaultPanel() {
+export function VaultPanel({ familiarId }: { familiarId?: string }) {
   // Deferred + undoable delete: the row hides immediately, the DELETE fires only
   // after the undo window, and Undo restores it (recoverable, unlike a confirm).
   const { pending: deletePending, scheduleDelete, undo: undoDelete, commit: commitDelete } = useUndoDelete<Mapping>();
@@ -212,6 +229,9 @@ export function VaultPanel() {
   const [adding, setAdding]         = useState(false);
   const [editing, setEditing]       = useState<Mapping | null>(null);
   const [copiedKey, setCopiedKey]   = useState<string | null>(null);
+  const [grantBusyKey, setGrantBusyKey] = useState<string | null>(null);
+  const [grantError, setGrantError] = useState<string | null>(null);
+  const { announce } = useAnnouncer();
 
   async function handleCopyRef(key: string, ref: string) {
     try {
@@ -258,8 +278,44 @@ export function VaultPanel() {
     });
   }
 
+  async function updateFamiliarGrant(mapping: Mapping, granted: boolean) {
+    if (!familiarId || mapping.scope === "shared") return;
+    setGrantBusyKey(mapping.key);
+    setGrantError(null);
+    try {
+      const response = await fetch("/api/vault", {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          key: mapping.key,
+          familiarId,
+          action: granted ? "revoke" : "grant",
+        }),
+      });
+      const payload = await response.json() as {
+        ok?: boolean;
+        scope?: Mapping["scope"];
+        error?: string;
+      };
+      if (!response.ok || !payload.ok || !payload.scope) {
+        throw new Error(payload.error || "Couldn't update the familiar grant.");
+      }
+      setMappings((current) => current.map((item) =>
+        item.key === mapping.key ? { ...item, scope: payload.scope! } : item));
+      announce(
+        `${granted ? "Revoked" : "Granted"} ${mapping.key} ${granted ? "from" : "to"} ${familiarId}.`,
+      );
+    } catch (cause) {
+      setGrantError(
+        cause instanceof Error ? cause.message : "Couldn't update the familiar grant.",
+      );
+    } finally {
+      setGrantBusyKey(null);
+    }
+  }
+
   // Hide the row pending an undoable delete, then apply the text filter
-  // (key / 1Password reference / description, case-insensitive).
+  // (key / provider reference / description, case-insensitive).
   const visibleMappings = useMemo(() => {
     const afterPending = deletePending
       ? mappings.filter((m) => m.key !== deletePending.item.key)
@@ -278,7 +334,11 @@ export function VaultPanel() {
           <Icon name="ph:vault" width={14} />
           Secret Vault
         </div>
-        <span className="vault-header-sub">env vars → encrypted local secrets, 1Password, or Dashlane references</span>
+        <span className="vault-header-sub">
+          {familiarId
+            ? `shared, granted, and available keys for ${familiarId}`
+            : "env vars → encrypted local secrets, 1Password, or Dashlane references"}
+        </span>
         <button
           type="button"
           className="vault-btn vault-btn--primary [margin-left:auto]!"
@@ -303,6 +363,7 @@ export function VaultPanel() {
         <div className="vault-add-wrapper">
           <AddMappingForm
             initial={editing ?? undefined}
+            familiarId={familiarId}
             onSaved={() => { setAdding(false); setEditing(null); void load(); }}
             onCancel={() => { setAdding(false); setEditing(null); }}
           />
@@ -327,8 +388,10 @@ export function VaultPanel() {
         <EmptyState
           compact
           icon="ph:vault"
-          headline="No mappings yet"
-          subtitle="Add one to store a local encrypted secret or pull from 1Password."
+          headline={familiarId ? "No secrets available" : "No mappings yet"}
+          subtitle={familiarId
+            ? "Add a secret scoped to this familiar."
+            : "Add one to store a local encrypted secret or pull from 1Password."}
           actions={
             <Button
               size="xs"
@@ -356,12 +419,24 @@ export function VaultPanel() {
             <div className="vault-footer-note">No secrets match “{query.trim()}”.</div>
           ) : (
         <div className="vault-list">
-          {visibleMappings.map((m) => (
-            <div key={m.key} className={`vault-row${m.status === "error" || m.status === "unresolved" ? " vault-row--warn" : ""}`}>
+          {visibleMappings.map((m) => {
+            const granted = m.scope === "shared" ||
+              m.scope.includes(familiarId?.trim().toLowerCase() ?? "");
+            return (
+            <div
+              key={m.key}
+              className={`vault-row${m.status === "error" || m.status === "unresolved" ? " vault-row--warn" : ""}`}
+              data-granted={familiarId ? granted : undefined}
+            >
               <div className="vault-row-main">
                 <code className="vault-row-key">{m.key}</code>
                 <StatusBadge status={m.status} storage={m.storage} />
                 {m.required && <span className="vault-required-pill">required</span>}
+                {familiarId ? (
+                  <span className="vault-required-pill">
+                    {m.scope === "shared" ? "shared" : granted ? "granted" : "not granted"}
+                  </span>
+                ) : null}
               </div>
               {m.ref && (
                 <div className="vault-row-ref">{m.ref}</div>
@@ -387,25 +462,46 @@ export function VaultPanel() {
                     <Icon name={copiedKey === m.key ? "ph:check" : "ph:copy"} width={11} />
                   </button>
                 )}
-                <button
-                  type="button"
-                  className="vault-action-btn"
-                  title="Edit"
-                  onClick={() => { setEditing(m); setAdding(false); }}
-                >
-                  <Icon name="ph:pencil-simple" width={11} />
-                </button>
-                <button
-                  type="button"
-                  className="vault-action-btn vault-action-btn--danger"
-                  title="Remove mapping"
-                  onClick={() => handleDelete(m.key)}
-                >
-                  <Icon name="ph:trash" width={11} />
-                </button>
+                {familiarId ? (
+                  m.scope === "shared" ? null : (
+                    <button
+                      type="button"
+                      className="vault-action-btn"
+                      title={granted ? "Revoke from familiar" : "Grant to familiar"}
+                      aria-label={`${granted ? "Revoke" : "Grant"} ${m.key} ${granted ? "from" : "to"} ${familiarId}`}
+                      disabled={grantBusyKey === m.key}
+                      onClick={() => void updateFamiliarGrant(m, granted)}
+                    >
+                      <Icon
+                        name={granted ? "ph:minus-circle" : "ph:key"}
+                        width={11}
+                      />
+                    </button>
+                  )
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      className="vault-action-btn"
+                      title="Edit"
+                      onClick={() => { setEditing(m); setAdding(false); }}
+                    >
+                      <Icon name="ph:pencil-simple" width={11} />
+                    </button>
+                    <button
+                      type="button"
+                      className="vault-action-btn vault-action-btn--danger"
+                      title="Remove mapping"
+                      onClick={() => handleDelete(m.key)}
+                    >
+                      <Icon name="ph:trash" width={11} />
+                    </button>
+                  </>
+                )}
               </div>
             </div>
-          ))}
+            );
+          })}
         </div>
           )}
         </>
@@ -416,6 +512,9 @@ export function VaultPanel() {
         Local secrets are encrypted on disk with a machine-local Cave key. 1Password
         entries are resolved live via <code>op read</code> and cached in process memory.
       </div>
+      {grantError ? (
+        <div className="vault-row-error" role="alert">{grantError}</div>
+      ) : null}
 
       {deletePending ? (
         <UndoToast

--- a/src/lib/settings-familiar-picker.test.ts
+++ b/src/lib/settings-familiar-picker.test.ts
@@ -20,6 +20,23 @@ test("an empty query preserves daemon roster order", () => {
   );
 });
 
+test("archived familiars stay recoverable after active familiars", () => {
+  const withArchived = [
+    { ...roster[0], archived: true },
+    roster[1],
+    { ...roster[2], archived: true },
+  ];
+
+  assert.deepEqual(
+    filterSettingsFamiliars(withArchived, "").map((familiar) => familiar.id),
+    ["nova-research", "sage-main", "cody-build"],
+  );
+  assert.deepEqual(
+    filterSettingsFamiliars(withArchived, "sage").map((familiar) => familiar.id),
+    ["sage-main"],
+  );
+});
+
 test("search is case-insensitive across display name, role, and id", () => {
   assert.deepEqual(filterSettingsFamiliars(roster, "SAGE").map((familiar) => familiar.id), ["sage-main"]);
   assert.deepEqual(filterSettingsFamiliars(roster, "research").map((familiar) => familiar.id), ["nova-research"]);
@@ -68,4 +85,3 @@ test("arrow navigation starts at an edge and wraps across the result list", () =
   assert.equal(moveFamiliarPickerIndex(0, "ArrowUp", 3), 2);
   assert.equal(moveFamiliarPickerIndex(1, "ArrowDown", 3), 2);
 });
-

--- a/src/lib/settings-familiar-picker.ts
+++ b/src/lib/settings-familiar-picker.ts
@@ -2,6 +2,7 @@ export type SettingsFamiliarSearchItem = {
   id: string;
   display_name: string;
   role?: string | null;
+  archived?: boolean;
 };
 
 export function filterSettingsFamiliars<T extends SettingsFamiliarSearchItem>(
@@ -9,14 +10,21 @@ export function filterSettingsFamiliars<T extends SettingsFamiliarSearchItem>(
   query: string,
 ): T[] {
   const tokens = query.trim().toLocaleLowerCase().split(/\s+/).filter(Boolean);
-  if (tokens.length === 0) return [...familiars];
+  const matched = tokens.length === 0
+    ? [...familiars]
+    : familiars.filter((familiar) => {
+        const searchable = [familiar.id, familiar.display_name, familiar.role ?? ""]
+          .join(" ")
+          .toLocaleLowerCase();
+        return tokens.every((token) => searchable.includes(token));
+      });
 
-  return familiars.filter((familiar) => {
-    const searchable = [familiar.id, familiar.display_name, familiar.role ?? ""]
-      .join(" ")
-      .toLocaleLowerCase();
-    return tokens.every((token) => searchable.includes(token));
-  });
+  // The handoff keeps archived familiars recoverable at the end of the roster.
+  // Partition instead of sorting so daemon order remains stable in both groups.
+  return [
+    ...matched.filter((familiar) => !familiar.archived),
+    ...matched.filter((familiar) => familiar.archived),
+  ];
 }
 
 export function familiarRosterCountLabel(count: number): string {

--- a/src/lib/vault.test.ts
+++ b/src/lib/vault.test.ts
@@ -1,11 +1,43 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import * as vaultModule from "./vault.ts";
 import {
   canMirrorVaultKeyToProcessEnv,
   mirrorVaultSecretToProcessEnv,
   validateOpRef,
 } from "./vault.ts";
+
+assert.equal(
+  typeof vaultModule.grantVaultScope,
+  "function",
+  "vault scopes expose a grant helper",
+);
+assert.equal(
+  typeof vaultModule.revokeVaultScope,
+  "function",
+  "vault scopes expose a revoke helper",
+);
+assert.deepEqual(
+  vaultModule.grantVaultScope(["sage"], "Nova"),
+  ["sage", "nova"],
+  "granting normalizes and appends a familiar without widening the key to shared",
+);
+assert.deepEqual(
+  vaultModule.grantVaultScope(["sage", "nova"], "NOVA"),
+  ["sage", "nova"],
+  "granting is idempotent",
+);
+assert.deepEqual(
+  vaultModule.revokeVaultScope(["sage", "nova"], "NOVA"),
+  ["sage"],
+  "revoking removes only the selected familiar",
+);
+assert.equal(
+  vaultModule.revokeVaultScope("shared", "nova"),
+  "shared",
+  "a per-familiar action cannot narrow a globally shared key",
+);
 
 assert.equal(validateOpRef("op://Personal/GitHub/token"), null);
 assert.equal(validateOpRef(42), "ref must be a string");
@@ -74,6 +106,11 @@ assert.match(routeSource, /setLocalEncryptedSecret/, "/api/vault can save encryp
 assert.match(routeSource, /deleteLocalEncryptedSecret/, "/api/vault deletes encrypted local secrets");
 assert.match(
   routeSource,
+  /export async function PATCH[\s\S]*?action === "grant"[\s\S]*?grantVaultScope[\s\S]*?revokeVaultScope/,
+  "/api/vault updates one familiar grant without rewriting the secret mapping",
+);
+assert.match(
+  routeSource,
   /mirrorVaultSecretToProcessEnv\(key, body\.value\)/,
   "/api/vault routes encrypted values through the process-env safety gate",
 );
@@ -82,6 +119,16 @@ assert.match(githubPatRouteSource, /setLocalEncryptedSecret\(PAT_KEY, pat\)/, "G
 assert.doesNotMatch(githubPatRouteSource, /updates\[PAT_KEY\] = pat/, "GitHub PAT setup does not write tokens to .env.local");
 assert.match(panelSource, /Local encrypted/, "Vault panel exposes local encrypted storage as a first-class option");
 assert.match(panelSource, /type="password"/, "Vault panel uses a password input for raw local secrets");
+assert.match(
+  panelSource,
+  /method: "PATCH"[\s\S]*?action: granted \? "revoke" : "grant"/,
+  "Familiar Vault rows grant or revoke scope through the non-destructive API",
+);
+assert.match(
+  panelSource,
+  /familiarId \?[\s\S]*?updateFamiliarGrant[\s\S]*?:[\s\S]*?handleDelete/,
+  "The scoped Vault action cannot call the global delete path",
+);
 assert.match(
   panelSource,
   /unresolved:\s*\{[^}]*color:\s*"var\(--color-warning\)"[^}]*icon:\s*"ph:warning"/,

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -92,6 +92,24 @@ export function normalizeVaultScope(scope: unknown): VaultScope {
   return [];
 }
 
+/** Add one familiar to an already-scoped key without ever widening it. */
+export function grantVaultScope(scope: unknown, familiarId: string): VaultScope {
+  const current = normalizeVaultScope(scope);
+  if (current === "shared") return current;
+  const normalizedId = familiarId.trim().toLowerCase();
+  if (!normalizedId || current.includes(normalizedId)) return current;
+  return [...current, normalizedId];
+}
+
+/** Remove only one familiar from a scoped key. Shared keys stay shared. */
+export function revokeVaultScope(scope: unknown, familiarId: string): VaultScope {
+  const current = normalizeVaultScope(scope);
+  if (current === "shared") return current;
+  const normalizedId = familiarId.trim().toLowerCase();
+  if (!normalizedId) return current;
+  return current.filter((id) => id !== normalizedId);
+}
+
 /** Whether a vault entry's value may be injected into a spawn for `familiarId`
  *  (no familiar context — probes, runners, the daemon — gets shared keys only). */
 export function isVaultKeyGrantedTo(entry: VaultEntry | undefined, familiarId?: string | null): boolean {

--- a/src/styles/settings-familiars.css
+++ b/src/styles/settings-familiars.css
@@ -1,0 +1,909 @@
+/* Settings → Familiars control sheet.
+   The Settings shell owns pane one; this sheet owns the persistent roster and
+   familiar detail panes from the Claude Design handoff. */
+
+.settings-shell__content--familiars {
+  min-width: 0;
+  min-height: 0;
+  padding: 0;
+  container: familiar-studio / inline-size;
+}
+
+.familiar-studio-inline {
+  --familiar-roster-width: calc(15 * var(--space-4) + var(--space-2));
+  display: grid;
+  grid-template-columns: var(--familiar-roster-width) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border: 0;
+  border-radius: 0;
+  background: var(--bg-base);
+}
+
+.familiar-studio-inline:has(.settings-familiar-roster[data-collapsed]) {
+  --familiar-roster-width: calc(3 * var(--space-4) + var(--space-3));
+}
+
+/* ── Roster pane ─────────────────────────────────────────────────────────── */
+
+.settings-familiar-roster {
+  display: grid;
+  grid-template-rows: auto auto auto minmax(0, 1fr);
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  border-right: 1px solid var(--border-hairline);
+  background: var(--bg-panel);
+}
+
+.settings-familiar-roster__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+  padding: var(--space-3) var(--space-3) var(--space-2);
+}
+
+.settings-familiar-roster__heading {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.settings-familiar-roster__count {
+  font-weight: 500;
+  letter-spacing: 0;
+}
+
+.settings-familiar-roster__summon {
+  margin-left: auto;
+}
+
+.settings-familiar-roster__search {
+  padding: 0 var(--space-3) var(--space-2);
+}
+
+.settings-familiar-roster__summary {
+  padding: 0 var(--space-3) var(--space-2);
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+}
+
+.settings-familiar-roster__list {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0 var(--space-2) var(--space-3);
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  list-style: none;
+}
+
+.settings-familiar-roster__row {
+  position: relative;
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--text-secondary);
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    box-shadow var(--duration-fast) var(--ease-standard);
+}
+
+.settings-familiar-roster__row:hover {
+  background: var(--bg-hover);
+}
+
+.settings-familiar-roster__row[data-selected] {
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 14%, transparent);
+  box-shadow: inset 2px 0 0 var(--familiar-accent, var(--accent-presence));
+}
+
+.settings-familiar-roster__row[data-archived] {
+  opacity: 0.55;
+}
+
+.settings-familiar-roster__option {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  min-height: var(--touch-target);
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border: 0;
+  border-radius: inherit;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+}
+
+.settings-familiar-roster__avatar {
+  display: grid;
+  width: var(--space-8);
+  height: var(--space-8);
+  flex: 0 0 auto;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 14%, var(--bg-raised));
+  color: var(--familiar-accent, var(--accent-presence));
+}
+
+.settings-familiar-roster__avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.settings-familiar-roster__copy {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.settings-familiar-roster__name,
+.settings-familiar-roster__role {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-familiar-roster__name {
+  color: var(--text-primary);
+  font-size: var(--text-base);
+  font-weight: 600;
+  line-height: 1.2;
+}
+
+.settings-familiar-roster__role {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: 1.2;
+}
+
+.settings-familiar-roster__presence {
+  position: absolute;
+  right: var(--space-3);
+  width: calc(var(--space-1) + 1px);
+  height: calc(var(--space-1) + 1px);
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
+}
+
+.settings-familiar-roster__presence[data-status="active"] {
+  background: var(--color-success);
+}
+
+.settings-familiar-roster__presence:is([data-status="busy"], [data-status="running"], [data-status="working"]) {
+  background: var(--color-warning);
+}
+
+.settings-familiar-roster__presence[data-status="idle"] {
+  background: var(--accent-presence);
+}
+
+.settings-familiar-roster__actions {
+  position: absolute;
+  right: var(--space-1);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding-left: var(--space-2);
+  background: linear-gradient(90deg, transparent, var(--bg-hover) var(--space-3));
+}
+
+.settings-familiar-roster__row:focus-within .settings-familiar-roster__presence,
+.settings-familiar-roster__row:hover .settings-familiar-roster__presence {
+  opacity: 0;
+}
+
+.settings-familiar-roster__empty {
+  padding: var(--space-6) var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  text-align: center;
+}
+
+.settings-familiar-roster[data-collapsed] {
+  grid-template-rows: auto minmax(0, 1fr);
+}
+
+.settings-familiar-roster[data-collapsed] :is(
+  .settings-familiar-roster__heading,
+  .settings-familiar-roster__summon,
+  .settings-familiar-roster__search,
+  .settings-familiar-roster__summary,
+  .settings-familiar-roster__copy,
+  .settings-familiar-roster__presence,
+  .settings-familiar-roster__actions
+) {
+  display: none;
+}
+
+.settings-familiar-roster[data-collapsed] .settings-familiar-roster__header {
+  justify-content: center;
+  padding-inline: var(--space-1);
+}
+
+.settings-familiar-roster[data-collapsed] .settings-familiar-roster__collapse {
+  width: 100%;
+}
+
+.settings-familiar-roster[data-collapsed] .settings-familiar-roster__list {
+  align-items: center;
+  padding-inline: var(--space-1);
+}
+
+.settings-familiar-roster[data-collapsed] .settings-familiar-roster__option {
+  justify-content: center;
+  padding-inline: var(--space-1);
+}
+
+/* ── Detail pane + identity hero ─────────────────────────────────────────── */
+
+.familiar-studio-inline__detail {
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.familiar-studio-control__hero {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
+  border-bottom: 1px solid var(--border-hairline);
+  background: linear-gradient(
+    120deg,
+    color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 16%, transparent),
+    color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 6%, transparent) 42%,
+    transparent 78%
+  );
+}
+
+.familiar-studio-control__avatar-wrap {
+  position: relative;
+  flex: 0 0 auto;
+}
+
+.familiar-studio-control__avatar {
+  display: grid;
+  width: calc(var(--space-8) + var(--space-6));
+  height: calc(var(--space-8) + var(--space-6));
+  place-items: center;
+  overflow: hidden;
+  padding: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 18%, var(--bg-raised));
+  color: var(--familiar-accent, var(--accent-presence));
+  box-shadow: 0 0 0 var(--space-1) color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 12%, transparent);
+  cursor: pointer;
+  transition:
+    box-shadow var(--duration-fast) var(--ease-standard),
+    transform var(--duration-fast) var(--ease-standard);
+}
+
+.familiar-studio-control__avatar:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 0 0 var(--space-1) color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 20%, transparent);
+}
+
+.familiar-studio-control__avatar[data-dragging] {
+  box-shadow:
+    0 0 0 1px var(--familiar-accent, var(--accent-presence)),
+    0 0 0 var(--space-1) color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 28%, transparent);
+}
+
+.familiar-studio-control__avatar-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.familiar-studio-control__avatar-note {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  z-index: 2;
+  width: max-content;
+  max-width: 16rem;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  box-shadow: var(--shadow-popover);
+}
+
+.familiar-studio-control__identity {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.familiar-studio-control__name-row {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.familiar-studio-control__name-row h1 {
+  overflow: hidden;
+  margin: 0;
+  color: var(--text-primary);
+  font-family: var(--font-serif), ui-serif, serif;
+  font-size: var(--text-display);
+  font-weight: 500;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.familiar-studio-control__role {
+  overflow: hidden;
+  max-width: 24rem;
+  color: var(--familiar-accent, var(--accent-presence));
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-overflow: ellipsis;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.familiar-studio-control__meta,
+.familiar-studio-control__types,
+.familiar-studio-control__stats {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.familiar-studio-control__types > span,
+.familiar-studio-control__stat {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  white-space: nowrap;
+}
+
+.familiar-studio-control__types > span {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 40%, transparent);
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 14%, transparent);
+  color: var(--familiar-accent, var(--accent-presence));
+  font-size: var(--text-2xs);
+  font-weight: 600;
+}
+
+.familiar-studio-control__divider {
+  width: 1px;
+  height: var(--space-3);
+  margin-inline: var(--space-1);
+  background: var(--border-hairline);
+}
+
+.familiar-studio-control__stats {
+  flex: 1 1 auto;
+}
+
+.familiar-studio-control__stat {
+  max-width: 13rem;
+  gap: var(--space-1);
+  overflow: hidden;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  background: var(--bg-sunken);
+  color: var(--text-secondary);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+}
+
+.familiar-studio-control__stat > span {
+  width: calc(var(--space-1) + 1px);
+  height: calc(var(--space-1) + 1px);
+  flex: 0 0 auto;
+  border-radius: var(--radius-pill);
+  background: var(--text-muted);
+}
+
+.familiar-studio-control__stat > span[data-tone="success"] {
+  background: var(--color-success);
+}
+
+.familiar-studio-control__stat > span[data-tone="accent"] {
+  background: var(--familiar-accent, var(--accent-presence));
+}
+
+.familiar-studio-control__actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: var(--space-2);
+  margin-left: auto;
+}
+
+.familiar-studio-inline__tabs {
+  min-width: 0;
+  padding: var(--space-3) var(--space-6) 0;
+  overflow-x: auto;
+  border-bottom: 1px solid var(--border-hairline);
+  scrollbar-width: none;
+}
+
+.familiar-studio-inline__tabs::-webkit-scrollbar {
+  display: none;
+}
+
+.familiar-studio-inline__body {
+  min-height: 0;
+  max-height: none;
+  padding: var(--space-4) var(--space-6) var(--space-5);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.familiar-studio-control__projects {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+}
+
+.familiar-studio-memory {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.familiar-studio-memory__toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+}
+
+.familiar-studio-memory__toolbar p {
+  min-width: 0;
+  flex: 1 1 auto;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+.familiar-studio-note-editor {
+  display: flex;
+  min-height: min(62vh, 36rem);
+  max-height: 72vh;
+  overflow: hidden;
+}
+
+.familiar-studio-grimoire {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  outline: none;
+}
+
+.familiar-studio-grimoire:focus {
+  border-radius: var(--radius-card);
+  box-shadow: 0 0 0 2px var(--ring-focus);
+}
+
+.familiar-studio-grimoire__heading {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.familiar-studio-grimoire__heading h2,
+.familiar-studio-grimoire__count {
+  margin: 0;
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+}
+
+.familiar-studio-grimoire__heading h2 {
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.familiar-studio-grimoire__count {
+  font-weight: 500;
+}
+
+.familiar-studio-grimoire__rule {
+  min-width: var(--space-5);
+  height: 1px;
+  flex: 1 1 auto;
+  background: var(--border-hairline);
+}
+
+.familiar-studio-grimoire__compliance,
+.familiar-studio-grimoire__issues,
+.familiar-studio-grimoire__state,
+.familiar-studio-grimoire__kind {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius-pill);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+}
+
+.familiar-studio-grimoire__compliance {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.familiar-studio-grimoire__compliance[data-pass] {
+  border-color: color-mix(in oklch, var(--color-success) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--color-success) 12%, transparent);
+  color: var(--color-success);
+}
+
+.familiar-studio-grimoire__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: var(--space-2);
+}
+
+.familiar-studio-grimoire__file {
+  position: relative;
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+}
+
+.familiar-studio-grimoire__file[data-present] {
+  border-color: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 30%, var(--border-hairline));
+}
+
+.familiar-studio-grimoire__file-head {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-sunken);
+}
+
+.familiar-studio-grimoire__file-head code {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--text-primary);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.familiar-studio-grimoire__kind {
+  padding: var(--space-1) var(--space-2);
+  background: color-mix(in oklch, var(--familiar-accent, var(--accent-presence)) 14%, transparent);
+  color: var(--familiar-accent, var(--accent-presence));
+  letter-spacing: 0.05em;
+}
+
+.familiar-studio-grimoire__state {
+  color: var(--text-muted);
+}
+
+.familiar-studio-grimoire__file[data-present] .familiar-studio-grimoire__state {
+  color: var(--color-success);
+}
+
+.familiar-studio-grimoire__file > p {
+  min-height: calc(2 * 1.5em);
+  margin: 0;
+  padding: var(--space-3);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+.familiar-studio-grimoire__issues {
+  margin: 0 var(--space-3) var(--space-3);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.familiar-studio-control__current {
+  overflow: hidden;
+  color: var(--text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── Real one-shot test modal ────────────────────────────────────────────── */
+
+.familiar-test-run {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.familiar-test-run__summary {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-sunken);
+}
+
+.familiar-test-run__summary h2 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-md);
+  font-weight: 600;
+}
+
+.familiar-test-run__summary p {
+  margin: var(--space-1) 0 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+}
+
+.familiar-test-run__summary > span,
+.familiar-test-run__badge {
+  flex: 0 0 auto;
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.familiar-test-run__summary > span[data-state="done"],
+.familiar-test-run__badge:is([data-state="ready"], [data-state="done"]) {
+  border-color: color-mix(in oklch, var(--color-success) 40%, transparent);
+  background: color-mix(in oklch, var(--color-success) 12%, transparent);
+  color: var(--color-success);
+}
+
+.familiar-test-run__summary > span[data-state="running"],
+.familiar-test-run__badge[data-state="running"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--accent-presence);
+}
+
+.familiar-test-run__summary > span[data-state="error"],
+.familiar-test-run__badge[data-state="error"] {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.familiar-test-run__checks {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.familiar-test-run__check {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  min-width: 0;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+}
+
+.familiar-test-run__check-icon {
+  display: grid;
+  width: var(--space-5);
+  height: var(--space-5);
+  flex: 0 0 auto;
+  place-items: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-xs);
+}
+
+.familiar-test-run__check-icon:is([data-state="ready"], [data-state="done"]) {
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.familiar-test-run__check-icon[data-state="running"] {
+  border-color: var(--accent-presence);
+  color: var(--accent-presence);
+}
+
+.familiar-test-run__check > span:nth-child(2) {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.familiar-test-run__check strong {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  font-weight: 600;
+}
+
+.familiar-test-run__check small {
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.familiar-test-run__response {
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 32%, var(--border-hairline));
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent-presence) 8%, var(--bg-panel));
+}
+
+.familiar-test-run__response > span {
+  color: var(--text-muted);
+  font-family: var(--font-mono), ui-monospace, monospace;
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.familiar-test-run__response p {
+  margin: var(--space-2) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+/* ── Container-responsive layout ─────────────────────────────────────────── */
+
+@container familiar-studio (max-width: 860px) {
+  .familiar-studio-control__hero {
+    align-items: flex-start;
+    flex-wrap: wrap;
+    padding: var(--space-4);
+  }
+
+  .familiar-studio-control__actions {
+    width: 100%;
+    margin-left: calc(var(--space-8) + var(--space-6) + var(--space-4));
+  }
+
+  .familiar-studio-inline__tabs,
+  .familiar-studio-inline__body {
+    padding-inline: var(--space-4);
+  }
+}
+
+@container familiar-studio (max-width: 560px) {
+  .familiar-studio-inline {
+    --familiar-roster-width: 100%;
+    grid-template-columns: minmax(0, 1fr);
+    grid-template-rows: auto minmax(0, 1fr);
+  }
+
+  .settings-familiar-roster {
+    max-height: calc(7 * var(--touch-target));
+    min-height: 0;
+    border-right: 0;
+    border-bottom: 1px solid var(--border-hairline);
+  }
+
+  .settings-familiar-roster[data-collapsed] {
+    grid-template-rows: auto;
+    max-height: none;
+  }
+
+  .settings-familiar-roster[data-collapsed] .settings-familiar-roster__heading {
+    display: flex;
+  }
+
+  .settings-familiar-roster[data-collapsed] .settings-familiar-roster__summon {
+    display: inline-grid;
+    margin-left: auto;
+  }
+
+  .settings-familiar-roster[data-collapsed] .settings-familiar-roster__header {
+    justify-content: flex-start;
+    padding-inline: var(--space-3);
+  }
+
+  .settings-familiar-roster[data-collapsed] .settings-familiar-roster__list {
+    display: none;
+  }
+
+  .familiar-studio-control__hero {
+    gap: var(--space-3);
+  }
+
+  .familiar-studio-control__avatar {
+    width: var(--touch-target);
+    height: var(--touch-target);
+    border-radius: var(--radius-card);
+  }
+
+  .familiar-studio-control__name-row h1 {
+    font-size: var(--text-xl);
+  }
+
+  .familiar-studio-control__divider,
+  .familiar-studio-control__stats {
+    display: none;
+  }
+
+  .familiar-studio-control__actions {
+    margin-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .familiar-studio-control__avatar,
+  .familiar-studio-control__avatar:hover {
+    transform: none;
+  }
+}

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -17,7 +17,9 @@ async function gotoFamiliarSettings(page: Page) {
     route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
   );
   await page.goto("/settings#familiars");
-  await expect(page.locator(".familiar-studio-picker__trigger")).toBeVisible({
+  await expect(
+    page.getByRole("complementary", { name: "Familiar roster" }),
+  ).toBeVisible({
     timeout: 30_000,
   });
 }
@@ -49,63 +51,58 @@ async function expectContained(inner: Locator, outer: Locator) {
     outer.boundingBox(),
   ]);
   expect(innerBox, "inner control has layout bounds").not.toBeNull();
-  expect(outerBox, "popover has layout bounds").not.toBeNull();
-  expect(innerBox!.y, "control top stays inside the popover").toBeGreaterThanOrEqual(
+  expect(outerBox, "container has layout bounds").not.toBeNull();
+  expect(innerBox!.y, "control top stays inside the container").toBeGreaterThanOrEqual(
     outerBox!.y - 1,
   );
   expect(
     innerBox!.y + innerBox!.height,
-    "control bottom stays inside the popover",
+    "control bottom stays inside the container",
   ).toBeLessThanOrEqual(outerBox!.y + outerBox!.height + 1);
 }
 
-test("a keyboard-shrunk visual viewport keeps fixed controls and one full result", async ({ page }) => {
+test("a keyboard-shrunk visual viewport keeps roster controls and one full result", async ({ page }) => {
   // Mobile keyboards can shrink visualViewport without changing the CSS layout
-  // viewport. Keep the latter tall so a max-height media query cannot make this
-  // pass accidentally; Popover must propagate its computed available height.
+  // viewport. The persistent roster must keep its controls fixed while only
+  // the familiar list scrolls.
   await page.setViewportSize({ width: 390, height: 720 });
-  // 270px puts both sides of the anchor below Popover's 120px safety floor.
   await emulateVisualViewport(page, 390, 270);
   await gotoFamiliarSettings(page);
 
-  await page.locator(".familiar-studio-picker__trigger").click();
-  const popover = page.locator(".familiar-studio-picker__popover");
-  const search = page.getByRole("combobox", { name: "Search familiars" });
+  const roster = page.getByRole("complementary", { name: "Familiar roster" });
+  const search = page.getByRole("searchbox", { name: "Find a familiar" });
   const summon = page.getByRole("button", { name: "Summon familiar" });
-  const results = page.getByRole("listbox", { name: "Familiars" });
-  await expect(popover).toBeVisible();
-  await expect.poll(() => popover.evaluate((element) => element.style.maxHeight)).toBe("120px");
+  const results = page.getByRole("list", { name: "Familiars" });
+  const options = results.locator(".settings-familiar-roster__option");
+  const first = options.first();
+  const last = options.last();
 
-  await expectContained(search, popover);
-  await expectContained(summon, popover);
+  await expect(options).toHaveCount(60);
+  await expectContained(search, roster);
+  await expectContained(summon, roster);
 
-  // Wrapping from the first result to the last scrolls the result list. It must
-  // not scroll the containing dialog and carry the still-focused search field
-  // out of view (the failure mode seen with mobile keyboards / short windows).
-  await search.press("ArrowUp");
-  await expect(search).toBeFocused();
-  await expect(search).toHaveAttribute(
-    "aria-activedescendant",
-    "settings-familiar-picker-option-59",
-  );
-  await expectContained(search, popover);
-  await expectContained(summon, popover);
-  const highlighted = page.locator(".familiar-studio-picker__option[data-highlighted]");
-  await expect(highlighted).toContainText("Familiar 60");
+  // Wrapping from the first result to the last must scroll only the roster list
+  // and leave the search and summon controls in place.
+  await first.focus();
+  await first.press("ArrowUp");
+  await expect(last).toBeFocused();
+  await expect(last).toContainText("Familiar 60");
+  await expectContained(search, roster);
+  await expectContained(summon, roster);
   const resultsBox = await results.boundingBox();
   expect(resultsBox, "the result scroller has layout bounds").not.toBeNull();
-  expect(resultsBox!.height, "the exact floor preserves a full 44px option").toBeGreaterThanOrEqual(44);
-  await expectContained(highlighted, results);
+  expect(resultsBox!.height, "the roster preserves a full touch target").toBeGreaterThanOrEqual(44);
+  await expectContained(last, results);
 
-  const scrollState = await popover.evaluate((element) => ({
+  const scrollState = await roster.evaluate((element) => ({
     scrollTop: element.scrollTop,
     scrollHeight: element.scrollHeight,
     clientHeight: element.clientHeight,
   }));
-  expect(scrollState.scrollTop, "the outer dialog must stay fixed").toBe(0);
+  expect(scrollState.scrollTop, "the roster shell must stay fixed").toBe(0);
   expect(
     scrollState.scrollHeight - scrollState.clientHeight,
-    "the outer dialog itself must not be the scrolling region",
+    "the roster shell itself must not be the scrolling region",
   ).toBeLessThanOrEqual(1);
 });
 
@@ -113,33 +110,35 @@ test("a 60-familiar roster stays compact, searchable, and keyboard-selectable", 
   await page.setViewportSize({ width: 1280, height: 720 });
   await gotoFamiliarSettings(page);
 
-  const trigger = page.locator(".familiar-studio-picker__trigger");
-  await expect(trigger).toContainText("60 familiars");
-  const triggerBox = await trigger.boundingBox();
-  expect(triggerBox, "the familiar trigger has layout bounds").not.toBeNull();
-  expect(triggerBox!.height, "roster size must not grow the Settings header").toBeLessThanOrEqual(50);
-
-  await trigger.click();
-  const results = page.getByRole("listbox", { name: "Familiars" });
-  await expect(results.getByRole("option")).toHaveCount(60);
+  const roster = page.getByRole("complementary", { name: "Familiar roster" });
+  const summary = roster.locator(".settings-familiar-roster__summary");
+  const results = page.getByRole("list", { name: "Familiars" });
+  const options = results.locator(".settings-familiar-roster__option");
+  await expect(summary).toHaveText("60 familiars");
+  await expect(options).toHaveCount(60);
+  const rosterBox = await roster.boundingBox();
+  expect(rosterBox, "the familiar roster has layout bounds").not.toBeNull();
+  expect(rosterBox!.width, "the persistent roster stays compact").toBeLessThanOrEqual(260);
   const resultsScroll = await results.evaluate((element) => ({
     clientHeight: element.clientHeight,
     scrollHeight: element.scrollHeight,
   }));
-  expect(resultsScroll.clientHeight, "the roster has a bounded viewport").toBeLessThanOrEqual(320);
-  expect(resultsScroll.scrollHeight, "large rosters scroll inside the popup").toBeGreaterThan(
+  expect(resultsScroll.scrollHeight, "large rosters scroll inside the roster").toBeGreaterThan(
     resultsScroll.clientHeight,
   );
 
-  const search = page.getByRole("combobox", { name: "Search familiars" });
+  await options.first().focus();
+  await options.first().press("ArrowDown");
+  await expect(options.nth(1)).toBeFocused();
+
+  const search = page.getByRole("searchbox", { name: "Find a familiar" });
   await search.fill("Researcher familiar-60");
-  const match = results.getByRole("option");
+  const match = results.locator(".settings-familiar-roster__option");
   await expect(match).toHaveCount(1);
   await expect(match).toContainText("Familiar 60");
   await expect(match).toContainText("Researcher");
-  await expect(match).toContainText("familiar-60");
 
-  await search.press("Enter");
-  await expect(page.locator(".familiar-studio-picker__popover")).toHaveCount(0);
-  await expect(trigger).toContainText("Familiar 60");
+  await match.press("Enter");
+  await expect(match).toHaveAttribute("aria-current", "page");
+  await expect(page.getByRole("heading", { name: "Familiar 60" })).toBeVisible();
 });


### PR DESCRIPTION
## Summary
- rebuild Settings → Familiars from the supplied zip as a responsive control-room layout
- keep production roster, lifecycle, Brain, Memory, Projects, and Vault mutation contracts
- add archived recovery, Grimoire status, daily notes, scoped Vault grants, and a read-only Test run

## Verification
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired`
- [x] `pnpm test:app` — 914 test files
- [x] `node scripts/codemods/tokenize-css.mjs --check`
- [x] `pnpm build` — bundle and standalone budgets pass
- [x] native Tauri launch and responsive surface inspection
- [x] fresh-context maintainer review; all Important findings resolved

Bead: `cave-ufvel`