### PR TITLE
feat(settings): redesign operator profile

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -77,6 +77,7 @@ export const SUITES = {
     "src/lib/app-version.test.ts",
     "src/lib/endpoint-validators.test.ts",
     "src/lib/mcp-doctor.test.ts",
+    "src/lib/settings-profile-form.test.ts",
     "src/lib/user-profile-shared.test.ts",
     "src/lib/user-profile.test.ts",
     "src/lib/legacy-svg-avatar-hint.test.ts",

--- a/src/components/profile-card.tsx
+++ b/src/components/profile-card.tsx
@@ -165,7 +165,7 @@ export function ProfileCard({
   const profile = isHuman ? vm.userProfile ?? snapshot?.profile ?? null : null;
 
   const name = isHuman ? userDisplayName(profile) : vm.familiar?.display_name ?? "familiar";
-  const handle = isHuman ? humanHandle(profile?.name) : vm.familiar?.id ?? "";
+  const handle = isHuman ? humanHandle(name === "You" ? null : name) : vm.familiar?.id ?? "";
   const bio = isHuman
     ? [profile?.pronouns, profile?.bio].filter(Boolean).join(" · ") || "operator of this coven"
     : [vm.familiar?.role, vm.familiar?.description].filter(Boolean).join(" · ");

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -58,8 +58,11 @@ test("the shell sources sections from settings-sections and renders the overview
   assert.match(shell, /section \? \(\s*<SettingsOverview section=\{section\} \/>/);
   // The shared search index is sourced from settings-sections.
   assert.doesNotMatch(shell, /const SETTINGS_INDEX: SettingsIndexEntry\[\]/);
-  // Each SettingsPage-based section opts into its overview header.
-  assert.match(profile, /section="profile"/, "profile page passes its section from the split panel");
+  // Each SettingsPage-based section opts into its overview header. Profile,
+  // Daemon, and About use their approved richer heroes instead.
+  assert.match(profile, /<header className="settings-profile__hero">/, "profile renders its control-sheet hero");
+  assert.match(profile, />SETTINGS · PROFILE</, "profile hero preserves settings wayfinding");
+  assert.doesNotMatch(profile, /<SettingsOverview/, "profile does not duplicate the generic overview");
   for (const id of ["general", "mobile", "appearance"]) {
     assert.match(shell, new RegExp(`section="${id}"`), `${id} page passes its section`);
   }

--- a/src/components/settings-profile.test.ts
+++ b/src/components/settings-profile.test.ts
@@ -22,27 +22,58 @@ describe("Settings → Profile", () => {
   it("is searchable (name, pronouns, timezone, avatar, links)", () => {
     const entries = SETTINGS_INDEX.filter((e) => e.section === "profile");
     const keywords = entries.map((e) => e.keywords).join(" ");
-    for (const term of ["name", "pronouns", "timezone", "avatar", "bio", "links"]) {
+    for (const term of ["name", "pronouns", "timezone", "avatar", "bio", "personality", "mbti", "links"]) {
       assert.match(keywords, new RegExp(term));
     }
     assert.ok(entries.some((e) => e.group === "Links" && /\blinks\b/.test(e.keywords)));
+  });
+
+  it("gives every Profile search target a stable settings-group anchor", () => {
+    const groups = [
+      ...new Set(
+        SETTINGS_INDEX
+          .filter((entry) => entry.section === "profile")
+          .map((entry) => entry.group)
+          .filter((group): group is string => Boolean(group)),
+      ),
+    ];
+    assert.deepEqual(groups, ["Identity", "Context", "Personality", "Links"]);
+    for (const group of groups) {
+      assert.ok(panel.includes(`id={settingsGroupId("${group}")}`), `${group} has a search anchor`);
+    }
   });
 
   it("shell renders the panel for the profile section", () => {
     assert.match(shell, /section === "profile"\s*&&\s*<ProfileSection \/>/);
   });
 
-  it("saves text fields on blur through the shared store and announces outcomes", () => {
+  it("uses a reviewable Save changes / Discard workflow and announces outcomes", () => {
     assert.match(panel, /saveUserProfile/);
-    assert.match(panel, /onBlur/);
+    assert.match(panel, /Save changes/);
+    assert.match(panel, /Discard/);
+    assert.match(panel, /metaKey|ctrlKey/);
+    assert.match(panel, /⌘S save/);
+    assert.doesNotMatch(panel, /Esc back/);
     assert.match(panel, /useAnnouncer/);
   });
 
+  it("keeps the saved form snapshot aligned with persisted nonblank links", () => {
+    assert.match(panel, /compactProfileLinkDrafts/);
+    assert.match(panel, /links:\s*compactProfileLinkDrafts\(next\.links\)/);
+    assert.match(panel, /setSavedForm\(cloneForm\(persistedForm\)\)/);
+  });
+
+  it("keeps oversized structured names out of the capped legacy name field", () => {
+    assert.match(panel, /legacyProfileName/);
+    assert.match(panel, /name:\s*legacyProfileName\(displayName\(form\)\)/);
+  });
+
   it("uploads through the shared image prepare pipeline and the server store", () => {
-    assert.match(panel, /<SettingsGroup label="Image"/);
     assert.match(panel, /prepareFamiliarImage/);
     assert.match(panel, /uploadUserProfileAvatar/);
     assert.match(panel, /removeUserProfileAvatar/);
+    assert.match(panel, /className="settings-profile__portrait reveal-scope"/);
+    assert.match(panel, /className="settings-profile__portrait-actions reveal-on-hover"/);
   });
 
   it("keeps the legacy SVG hint without importing the retired avatar store", () => {
@@ -53,5 +84,78 @@ describe("Settings → Profile", () => {
   it("timezone options come from Intl with a system default", () => {
     assert.match(panel, /supportedValuesOf\("timeZone"\)/);
     assert.match(panel, /resolvedOptions\(\)\.timeZone/);
+    assert.match(panel, /Familiars receive this timezone in your profile context\./);
+    assert.doesNotMatch(panel, /Schedules and digests follow this clock/);
+  });
+
+  it("routes external destinations through Cave's Browser surface", () => {
+    assert.match(panel, /openExternalUrl/);
+    assert.match(panel, /openExternalUrl\("https:\/\/www\.16personalities\.com\/free-personality-test"\)/);
+    assert.match(panel, /openExternalUrl\(stored\.url\)/);
+    assert.doesNotMatch(panel, /target="_blank"|window\.open\(/);
+  });
+
+  it("implements the imported control-sheet sections and preview", () => {
+    assert.match(panel, /SETTINGS · PROFILE/);
+    assert.match(panel, /Profile completion/);
+    assert.match(panel, /IDENTITY/);
+    assert.match(panel, /CONTEXT/);
+    assert.match(panel, /PERSONALITY/);
+    assert.match(panel, /LINKS/);
+    assert.match(panel, /Show profile card|Hide profile card/);
+    assert.match(panel, /First name/);
+    assert.match(panel, /Nickname/);
+    assert.match(panel, /Fine-tune axes/);
+    assert.match(panel, /16personalities\.com\/free-personality-test/);
+  });
+
+  it("keeps field labels visible and connects custom-link errors to their input", () => {
+    for (const label of ["First name", "Last name", "Nickname", "Link label", "Link URL"]) {
+      assert.match(panel, new RegExp(`className="settings-profile__input-label">${label}`));
+    }
+    assert.match(
+      panel,
+      /aria-describedby=\{invalid \? `\$\{baseId\}-link-\$\{link\.id\}-url-error` : undefined\}/,
+    );
+    assert.match(panel, /id=\{`\$\{baseId\}-link-\$\{link\.id\}-url-error`\}/);
+    assert.match(panel, /Enter a complete http\(s\) URL\./);
+    assert.doesNotMatch(panel, /placeholder="First"|placeholder="Last"|placeholder="https:\/\/"/);
+  });
+
+  it("keeps the imported hero-name rename interaction", () => {
+    assert.match(panel, /title="Double-click to rename"/);
+    assert.match(panel, /onDoubleClick=\{\(\) => setEditingName\(true\)\}/);
+    assert.match(panel, /aria-label="Display name"/);
+    assert.match(panel, /nameEditRef\.current\?\.select\(\)/);
+  });
+
+  it("allows exact percentage entry for tuned personality axes", () => {
+    assert.match(panel, /title="Double-click to set exactly"/);
+    assert.match(panel, /type="number"/);
+    assert.match(panel, /Math\.max\(0, Math\.min\(100,/);
+    assert.match(panel, /percentEditRef\.current\?\.select\(\)/);
+    assert.match(panel, /className="settings-profile__type-percent-input focus-ring-inset"/);
+  });
+
+  it("drafts a bio through the selected familiar with an undo path", () => {
+    assert.match(panel, /streamFamiliarText/);
+    assert.match(panel, /permissionMode:\s*"read"/);
+    assert.match(panel, /Draft with/);
+    assert.match(panel, /Undo/);
+  });
+
+  it("surfaces familiar loading failures with an explicit retry", () => {
+    assert.match(panel, /familiarLoadState/);
+    assert.match(panel, /familiarLoadNonce/);
+    assert.match(panel, /<ErrorState[\s\S]*headline="Couldn’t load familiars"/);
+    assert.match(panel, /setFamiliarLoadNonce\(\(nonce\) => nonce \+ 1\)/);
+    assert.match(panel, />\s*Retry\s*</);
+    assert.doesNotMatch(panel, /\.catch\(\(\) => \{\}\)/);
+  });
+
+  it("uses a dedicated tokenized stylesheet for responsive profile layout", () => {
+    assert.match(panel, /@\/styles\/settings-profile\.css/);
+    assert.match(panel, /className="settings-profile__link-row reveal-scope"/);
+    assert.match(panel, /className="settings-profile__link-actions reveal-on-hover"/);
   });
 });

--- a/src/components/settings-profile.tsx
+++ b/src/components/settings-profile.tsx
@@ -1,98 +1,330 @@
 "use client";
 
-import { useEffect, useId, useMemo, useRef, useState, type ChangeEvent, type FocusEvent, type ReactNode } from "react";
 import Link from "next/link";
-import { SettingsOverview } from "@/components/settings-overview";
-import { SettingsGroup } from "@/components/ui/settings-group";
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type ReactNode,
+} from "react";
 import { Button } from "@/components/ui/button";
+import { ErrorState } from "@/components/ui/error-state";
+import { IconButton } from "@/components/ui/icon-button";
 import { useAnnouncer } from "@/components/ui/live-region";
-import { useArmedConfirm } from "@/lib/use-armed-confirm";
+import { StandardSelect } from "@/components/ui/select";
+import { settingsGroupId } from "@/components/ui/settings-group";
+import { TextArea } from "@/components/ui/text-area";
+import { TextInput } from "@/components/ui/text-input";
+import { extractNextPaths } from "@/lib/next-paths";
 import { FAMILIAR_IMAGE_ACCEPT, prepareFamiliarImage } from "@/lib/familiar-image-upload";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import { streamFamiliarText } from "@/lib/familiar-stream";
+import { hasLegacySvgUserAvatar } from "@/lib/legacy-svg-avatar-hint";
 import { Icon } from "@/lib/icon";
+import { openExternalUrl } from "@/lib/open-external";
+import {
+  PROFILE_LINK_SITES,
+  PROFILE_PERSONALITY_AXES,
+  PROFILE_TYPE_GROUPS,
+  PROFILE_TYPE_NAMES,
+  buildProfileBioPrompt,
+  compactProfileLinkDrafts,
+  legacyProfileName,
+  mbtiAdaptation,
+  mbtiCode,
+  profileCompletion,
+  profileLinkDraft,
+  profileLinkValue,
+  seedPersonalityAxes,
+  type ProfileLinkDraft,
+  type ProfileLinkSite,
+} from "@/lib/settings-profile-form";
+import type { Familiar } from "@/lib/types";
+import { useArmedConfirm } from "@/lib/use-armed-confirm";
+import { useMinuteTick } from "@/lib/use-minute-tick";
 import {
   removeUserProfileAvatar,
   saveUserProfile,
   uploadUserProfileAvatar,
   useUserProfile,
   userAvatarUrl,
-  userDisplayName,
   type UserProfileSnapshot,
 } from "@/lib/user-profile";
-import { PROFILE_LIMITS, type ProfileLink, type UserProfilePatch } from "@/lib/user-profile-shared";
-import { hasLegacySvgUserAvatar } from "@/lib/legacy-svg-avatar-hint";
+import {
+  MBTI_TYPES,
+  PROFILE_LIMITS,
+  type MbtiType,
+  type ProfileLink,
+  type ProfilePersonality,
+  type ProfilePersonalityAxes,
+  type UserProfilePatch,
+} from "@/lib/user-profile-shared";
+import "@/styles/settings-profile.css";
 
 const PROFILE_IMAGE_ACCEPT = FAMILIAR_IMAGE_ACCEPT
   .split(",")
   .filter((mime) => mime !== "image/svg+xml")
   .join(",");
+const PROFILE_BIO_GUIDE_MAX = 280;
+const SYSTEM_TIMEZONE_VALUE = "__system__";
+const PRONOUN_PRESETS = [
+  { value: "she / her", label: "she" },
+  { value: "he / him", label: "he" },
+  { value: "they / them", label: "they" },
+] as const;
 
-type TextField = "name" | "pronouns" | "bio";
+type ProfileForm = {
+  firstName: string;
+  lastName: string;
+  nickname: string;
+  pronouns: string;
+  bio: string;
+  timezone: string;
+  personality: ProfilePersonality | null;
+  links: ProfileLinkDraft[];
+};
+
+type PreparedProfileImage = {
+  dataUrl: string;
+  mime: string;
+  downsized?: boolean;
+};
+
+type PendingAvatar =
+  | { kind: "keep" }
+  | { kind: "upload"; image: PreparedProfileImage }
+  | { kind: "remove" };
 
 function systemTimezone(): string {
-  return Intl.DateTimeFormat().resolvedOptions().timeZone || "local time";
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC";
 }
 
 function supportedTimezones(systemTz: string): string[] {
-  const supportedValuesOf = (Intl as typeof Intl & { supportedValuesOf?: (key: "timeZone") => string[] })
-    .supportedValuesOf;
-  if (typeof supportedValuesOf === "function") {
-    try {
-      return supportedValuesOf("timeZone");
-    } catch {
-      return [systemTz].filter(Boolean);
-    }
+  const supportedValuesOf = (
+    Intl as typeof Intl & { supportedValuesOf?: (key: "timeZone") => string[] }
+  ).supportedValuesOf;
+  if (typeof supportedValuesOf !== "function") return [systemTz, "UTC"];
+  try {
+    return supportedValuesOf("timeZone");
+  } catch {
+    return [systemTz, "UTC"];
   }
-  return [systemTz].filter(Boolean);
 }
 
-function profileValue(snapshot: UserProfileSnapshot | null, field: TextField | "timezone"): string {
-  return snapshot?.profile[field] ?? "";
+function emptyForm(): ProfileForm {
+  return {
+    firstName: "",
+    lastName: "",
+    nickname: "",
+    pronouns: "",
+    bio: "",
+    timezone: "",
+    personality: null,
+    links: [],
+  };
 }
 
-function normalizeLinks(links: ProfileLink[]): ProfileLink[] {
-  return links.map((link) => ({ label: link.label.trim(), url: link.url.trim() }));
+function cloneForm(form: ProfileForm): ProfileForm {
+  return JSON.parse(JSON.stringify(form)) as ProfileForm;
 }
 
-function linksMatch(left: ProfileLink[] | undefined, right: ProfileLink[]): boolean {
-  return JSON.stringify(normalizeLinks(left ?? [])) === JSON.stringify(normalizeLinks(right));
+function formFromSnapshot(snapshot: UserProfileSnapshot): ProfileForm {
+  const profile = snapshot.profile;
+  const hasStructuredName = Boolean(profile.firstName || profile.lastName || profile.nickname);
+  return {
+    firstName: profile.firstName ?? (hasStructuredName ? "" : profile.name ?? ""),
+    lastName: profile.lastName ?? "",
+    nickname: profile.nickname ?? "",
+    pronouns: profile.pronouns ?? "",
+    bio: profile.bio ?? "",
+    timezone: profile.timezone ?? "",
+    personality: profile.personality ?? null,
+    links: (profile.links ?? []).map((link, index) => profileLinkDraft(link, String(index + 1))),
+  };
 }
 
-function avatarInitial(snapshot: UserProfileSnapshot | null): string {
-  const display = userDisplayName(snapshot?.profile);
-  // "You" is the unnamed fallback, not a name — let the icon branch render.
-  if (display === "You") return "";
-  return display.trim().charAt(0).toUpperCase();
+function normalizedForm(form: ProfileForm): ProfileForm {
+  return {
+    ...form,
+    firstName: form.firstName.trim(),
+    lastName: form.lastName.trim(),
+    nickname: form.nickname.trim(),
+    pronouns: form.pronouns.trim(),
+    bio: form.bio.trim(),
+    links: form.links.map((link) => ({
+      ...link,
+      user: link.user.trim(),
+      label: link.label.trim(),
+      url: link.url.trim(),
+    })),
+  };
+}
+
+function fullName(form: ProfileForm): string {
+  return [form.firstName, form.lastName].map((part) => part.trim()).filter(Boolean).join(" ");
+}
+
+function displayName(form: ProfileForm): string {
+  return form.nickname.trim() || fullName(form);
+}
+
+function initials(form: ProfileForm): string {
+  return (displayName(form) || "?")
+    .split(/\s+/)
+    .map((word) => word[0])
+    .join("")
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function httpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function storedLinks(
+  drafts: ProfileLinkDraft[],
+): { ok: true; links: ProfileLink[] } | { ok: false; error: string } {
+  const links: ProfileLink[] = [];
+  for (const draft of drafts) {
+    const blank = draft.site === "custom"
+      ? !draft.label.trim() && !draft.url.trim()
+      : !draft.user.trim();
+    if (blank) continue;
+    const value = profileLinkValue(draft);
+    if (!value) {
+      return { ok: false, error: "Each custom link needs both a label and a URL." };
+    }
+    if (!httpUrl(value.url)) {
+      return { ok: false, error: `${value.label} needs a valid http(s) URL.` };
+    }
+    links.push(value);
+  }
+  return { ok: true, links };
+}
+
+function zoneClock(now: number, timeZone: string): {
+  time: string;
+  meridiem: string;
+  date: string;
+} {
+  try {
+    const timeParts = new Intl.DateTimeFormat("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
+      timeZone,
+    }).formatToParts(new Date(now));
+    return {
+      time: timeParts
+        .filter((part) => part.type === "hour" || part.type === "literal" || part.type === "minute")
+        .map((part) => part.value)
+        .join("")
+        .trim(),
+      meridiem: timeParts.find((part) => part.type === "dayPeriod")?.value ?? "",
+      date: new Intl.DateTimeFormat("en-US", {
+        weekday: "short",
+        month: "short",
+        day: "numeric",
+        timeZone,
+      }).format(new Date(now)).toUpperCase(),
+    };
+  } catch {
+    return { time: "—", meridiem: "", date: "" };
+  }
+}
+
+function profilePatch(form: ProfileForm, links: ProfileLink[]): UserProfilePatch {
+  return {
+    name: legacyProfileName(displayName(form)),
+    firstName: form.firstName || null,
+    lastName: form.lastName || null,
+    nickname: form.nickname || null,
+    pronouns: form.pronouns || null,
+    bio: form.bio || null,
+    timezone: form.timezone || null,
+    personality: form.personality,
+    links: links.length ? links : null,
+  };
+}
+
+function isMbtiType(value: string): value is MbtiType {
+  return (MBTI_TYPES as readonly string[]).includes(value);
 }
 
 export function ProfileSection() {
   const snapshot = useUserProfile();
   const { announce } = useAnnouncer();
-  const hydratedRef = useRef(false);
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const baseId = useId();
-  const systemTz = useMemo(systemTimezone, []);
-  const timezoneOptions = useMemo(() => supportedTimezones(systemTz), [systemTz]);
-
-  const [name, setName] = useState("");
-  const [pronouns, setPronouns] = useState("");
-  const [bio, setBio] = useState("");
-  const [timezone, setTimezone] = useState("");
-  const [links, setLinks] = useState<ProfileLink[]>([]);
-  const [error, setError] = useState<string | null>(null);
-  const [linkHint, setLinkHint] = useState<string | null>(null);
-  const [saving, setSaving] = useState<string | null>(null);
-  const [avatarBusy, setAvatarBusy] = useState(false);
-  // One-click removals with no undo → two-step (cave-5lsj). Links arm per-row.
+  const hydratedRef = useRef(false);
+  const nextLinkIdRef = useRef(1);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const nameEditRef = useRef<HTMLInputElement>(null);
+  const percentEditRef = useRef<HTMLInputElement>(null);
+  const saveCommandRef = useRef<() => void>(() => {});
+  const bioAbortRef = useRef<AbortController | null>(null);
+  const savedBadgeTimerRef = useRef<number | null>(null);
   const avatarRemoveConfirm = useArmedConfirm();
-  const [armedLinkIndex, setArmedLinkIndex] = useState<number | null>(null);
-  useEffect(() => {
-    if (armedLinkIndex === null) return;
-    const t = window.setTimeout(() => setArmedLinkIndex(null), 4000);
-    return () => window.clearTimeout(t);
-  }, [armedLinkIndex]);
+
+  const systemTz = useMemo(systemTimezone, []);
+  const timezoneOptions = useMemo(() => {
+    const zones = [...new Set([systemTz, "UTC", ...supportedTimezones(systemTz)])];
+    return [
+      { value: SYSTEM_TIMEZONE_VALUE, label: `System (${systemTz})` },
+      ...zones.map((zone) => ({ value: zone, label: zone })),
+    ];
+  }, [systemTz]);
+
+  const [form, setForm] = useState<ProfileForm>(emptyForm);
+  const [savedForm, setSavedForm] = useState<ProfileForm>(emptyForm);
+  const [pendingAvatar, setPendingAvatar] = useState<PendingAvatar>({ kind: "keep" });
+  const [preparingAvatar, setPreparingAvatar] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [justSaved, setJustSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const [legacySvgAvatar, setLegacySvgAvatar] = useState(false);
+  const [cardOpen, setCardOpen] = useState(false);
+  const [editingName, setEditingName] = useState(false);
+  const [customPronoun, setCustomPronoun] = useState(false);
+  const [pickerOpen, setPickerOpen] = useState(true);
+  const [tuningOpen, setTuningOpen] = useState(false);
+  const [editingAxis, setEditingAxis] = useState<keyof ProfilePersonalityAxes | null>(null);
+  const [percentDraft, setPercentDraft] = useState("");
+  const [armedLinkId, setArmedLinkId] = useState<string | null>(null);
+  const minuteTick = useMinuteTick();
+  const now = useMemo(() => Date.now(), [minuteTick]);
+  const [rawFamiliars, setRawFamiliars] = useState<Familiar[]>([]);
+  const familiars = useResolvedFamiliars(rawFamiliars);
+  const [familiarLoadState, setFamiliarLoadState] = useState<"loading" | "ready" | "error">("loading");
+  const [familiarLoadNonce, setFamiliarLoadNonce] = useState(0);
+  const [drafterId, setDrafterId] = useState("");
+  const [drafting, setDrafting] = useState(false);
+  const [previousBio, setPreviousBio] = useState("");
+  const [draftNote, setDraftNote] = useState("");
+
   useEffect(() => {
-    if (snapshot?.avatar.present) {
+    if (!snapshot || hydratedRef.current) return;
+    const next = formFromSnapshot(snapshot);
+    setForm(next);
+    setSavedForm(cloneForm(next));
+    setCustomPronoun(
+      Boolean(next.pronouns)
+      && !PRONOUN_PRESETS.some((preset) => preset.value === next.pronouns),
+    );
+    setPickerOpen(!next.personality);
+    setTuningOpen(Boolean(next.personality?.tuned));
+    nextLinkIdRef.current = next.links.length + 1;
+    hydratedRef.current = true;
+  }, [snapshot]);
+
+  useEffect(() => {
+    if (snapshot?.avatar.present || pendingAvatar.kind === "upload") {
       setLegacySvgAvatar(false);
       return;
     }
@@ -100,363 +332,1135 @@ export function ProfileSection() {
     void hasLegacySvgUserAvatar().then((hasSvg) => {
       if (!cancelled) setLegacySvgAvatar(hasSvg);
     });
-    return () => { cancelled = true; };
-  }, [snapshot?.avatar.present]);
+    return () => {
+      cancelled = true;
+    };
+  }, [pendingAvatar.kind, snapshot?.avatar.present]);
 
   useEffect(() => {
-    if (!snapshot || hydratedRef.current) return;
-    setName(snapshot.profile.name ?? "");
-    setPronouns(snapshot.profile.pronouns ?? "");
-    setBio(snapshot.profile.bio ?? "");
-    setTimezone(snapshot.profile.timezone ?? "");
-    setLinks(snapshot.profile.links ?? []);
-    hydratedRef.current = true;
-  }, [snapshot]);
+    if (!editingName) return;
+    nameEditRef.current?.focus();
+    nameEditRef.current?.select();
+  }, [editingName]);
+
+  useEffect(() => {
+    if (editingAxis === null) return;
+    percentEditRef.current?.focus();
+    percentEditRef.current?.select();
+  }, [editingAxis]);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setFamiliarLoadState("loading");
+    void fetch("/api/familiars", { cache: "no-store", signal: controller.signal })
+      .then(async (response) => {
+        if (!response.ok) throw new Error(`Failed to load familiars (${response.status})`);
+        const data = (await response.json()) as { ok?: boolean; familiars?: Familiar[] };
+        if (!data.ok || !Array.isArray(data.familiars)) {
+          throw new Error("Familiars response was invalid");
+        }
+        if (controller.signal.aborted) return;
+        setRawFamiliars(data.familiars);
+        setFamiliarLoadState("ready");
+      })
+      .catch(() => {
+        if (!controller.signal.aborted) setFamiliarLoadState("error");
+      });
+    return () => controller.abort();
+  }, [familiarLoadNonce]);
+
+  useEffect(() => {
+    if (drafterId && familiars.some((familiar) => familiar.id === drafterId)) return;
+    setDrafterId(familiars[0]?.id ?? "");
+  }, [drafterId, familiars]);
+
+  useEffect(() => {
+    if (armedLinkId === null) return;
+    const timeout = window.setTimeout(() => setArmedLinkId(null), 4_000);
+    return () => window.clearTimeout(timeout);
+  }, [armedLinkId]);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === "s") {
+        event.preventDefault();
+        saveCommandRef.current();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      bioAbortRef.current?.abort();
+      if (savedBadgeTimerRef.current) window.clearTimeout(savedBadgeTimerRef.current);
+    };
+  }, []);
 
   const disabled = !snapshot;
-  const avatarSrc = userAvatarUrl(snapshot);
-
-  async function savePatch(patch: UserProfilePatch, success: string, savingKey: string) {
-    setError(null);
-    setSaving(savingKey);
-    const result = await saveUserProfile(patch);
-    setSaving(null);
-    if (!result.ok) {
-      setError(result.reason);
-      announce(result.reason, "assertive");
-      return false;
-    }
-    announce(success);
-    return true;
-  }
-
-  async function saveTextField(field: TextField, value: string) {
-    if (!snapshot) return;
-    const next = value.trim();
-    if (next === profileValue(snapshot, field)) return;
-    if (field === "name") setName(next);
-    if (field === "pronouns") setPronouns(next);
-    if (field === "bio") setBio(next);
-    await savePatch({ [field]: next === "" ? null : next }, "Profile saved.", field);
-  }
-
-  async function saveTimezone(next: string) {
-    setTimezone(next);
-    if (!snapshot || next === profileValue(snapshot, "timezone")) return;
-    await savePatch({ timezone: next === "" ? null : next }, "Timezone saved.", "timezone");
-  }
+  const formDirty = JSON.stringify(form) !== JSON.stringify(savedForm);
+  const avatarDirty = pendingAvatar.kind !== "keep";
+  const dirty = formDirty || avatarDirty;
+  const currentZone = form.timezone || systemTz;
+  const clock = zoneClock(now, currentZone);
+  const effectiveType = mbtiCode(form.personality);
+  const linksResult = storedLinks(form.links);
+  const liveLinks = linksResult.ok ? linksResult.links : [];
+  const avatarSrc = pendingAvatar.kind === "upload"
+    ? pendingAvatar.image.dataUrl
+    : pendingAvatar.kind === "remove"
+      ? null
+      : userAvatarUrl(snapshot);
+  const avatarPresent = pendingAvatar.kind === "upload"
+    || (pendingAvatar.kind === "keep" && Boolean(snapshot?.avatar.present));
+  const completion = profileCompletion({
+    displayName: displayName(form),
+    pronouns: form.pronouns,
+    avatar: avatarPresent,
+    bio: form.bio,
+    links: liveLinks.length,
+  });
+  const headerMeta = [
+    form.pronouns.trim(),
+    currentZone,
+    effectiveType,
+    `${liveLinks.length} ${liveLinks.length === 1 ? "link" : "links"}`,
+  ].filter(Boolean).join(" · ");
+  const drafter = familiars.find((familiar) => familiar.id === drafterId) ?? null;
 
   async function onAvatarFile(event: ChangeEvent<HTMLInputElement>) {
     const file = event.target.files?.[0];
     event.target.value = "";
     if (!file) return;
-    setAvatarBusy(true);
+    setPreparingAvatar(true);
     setError(null);
     try {
-      const prepared = await prepareFamiliarImage(file);
-      const result = await uploadUserProfileAvatar(prepared);
-      if (!result.ok) {
-        setError(result.reason);
-        announce(result.reason, "assertive");
-        return;
-      }
-      announce(prepared.downsized ? "Profile image updated. Image was downsized for Cave." : "Profile image updated.");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Could not read image.";
+      const image = await prepareFamiliarImage(file);
+      setPendingAvatar({ kind: "upload", image });
+      avatarRemoveConfirm.disarm();
+      announce(
+        image.downsized
+          ? "Portrait ready to save. The image was downsized for Cave."
+          : "Portrait ready to save.",
+      );
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Could not read image.";
       setError(message);
       announce(message, "assertive");
     } finally {
-      setAvatarBusy(false);
+      setPreparingAvatar(false);
     }
   }
 
-  async function removeAvatar() {
-    setAvatarBusy(true);
+  function stageAvatarRemoval() {
+    avatarRemoveConfirm.trigger(() => {
+      setPendingAvatar({ kind: "remove" });
+      announce("Portrait removal ready to save.");
+    });
+  }
+
+  function discard() {
+    const restored = cloneForm(savedForm);
+    setForm(restored);
+    setPendingAvatar({ kind: "keep" });
+    setCustomPronoun(
+      Boolean(restored.pronouns)
+      && !PRONOUN_PRESETS.some((preset) => preset.value === restored.pronouns),
+    );
+    setPickerOpen(!restored.personality);
+    setTuningOpen(Boolean(restored.personality?.tuned));
+    setDraftNote("");
     setError(null);
-    try {
-      const result = await removeUserProfileAvatar();
-      if (!result.ok) {
-        setError(result.reason);
-        announce(result.reason, "assertive");
-        return;
-      }
-      announce("Profile image removed.");
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Could not remove image.";
-      setError(message);
-      announce(message, "assertive");
-    } finally {
-      setAvatarBusy(false);
-    }
+    setJustSaved(false);
+    avatarRemoveConfirm.disarm();
+    announce("Unsaved profile changes discarded.");
   }
 
-  function updateLink(index: number, patch: Partial<ProfileLink>) {
-    setLinks((current) => current.map((link, i) => (i === index ? { ...link, ...patch } : link)));
-  }
-
-  async function saveLinks(nextLinks = links) {
-    if (!snapshot) return;
-    // Fully-blank rows (a fresh "Add link") don't block saving the rest —
-    // only rows with exactly one filled field are incomplete.
-    const normalized = normalizeLinks(nextLinks).filter((link) => link.label || link.url);
-    const incomplete = normalized.some((link) => !link.label || !link.url);
-    if (incomplete) {
-      setLinkHint("Each link needs both a label and a URL before it can be saved.");
+  async function save() {
+    if (!snapshot || !dirty || saving) return;
+    const next = normalizedForm(form);
+    const nextLinks = storedLinks(next.links);
+    if (!nextLinks.ok) {
+      setError(nextLinks.error);
+      announce(nextLinks.error, "assertive");
       return;
     }
-    setLinkHint(null);
-    if (linksMatch(snapshot.profile.links, normalized)) return;
-    await savePatch({ links: normalized.length ? normalized : null }, "Profile links saved.", "links");
+    setSaving(true);
+    setError(null);
+    try {
+      if (formDirty) {
+        const result = await saveUserProfile(profilePatch(next, nextLinks.links));
+        if (!result.ok) {
+          setError(result.reason);
+          announce(result.reason, "assertive");
+          return;
+        }
+        const persistedForm = {
+          ...next,
+          links: compactProfileLinkDrafts(next.links),
+        };
+        setForm(persistedForm);
+        setSavedForm(cloneForm(persistedForm));
+      }
+
+      if (pendingAvatar.kind === "upload") {
+        const result = await uploadUserProfileAvatar({
+          dataUrl: pendingAvatar.image.dataUrl,
+          mime: pendingAvatar.image.mime,
+        });
+        if (!result.ok) {
+          setError(result.reason);
+          announce(result.reason, "assertive");
+          return;
+        }
+        setPendingAvatar({ kind: "keep" });
+      } else if (pendingAvatar.kind === "remove") {
+        const result = await removeUserProfileAvatar();
+        if (!result.ok) {
+          setError(result.reason);
+          announce(result.reason, "assertive");
+          return;
+        }
+        setPendingAvatar({ kind: "keep" });
+      }
+
+      setJustSaved(true);
+      if (savedBadgeTimerRef.current) window.clearTimeout(savedBadgeTimerRef.current);
+      savedBadgeTimerRef.current = window.setTimeout(() => setJustSaved(false), 2_400);
+      announce("Profile saved.");
+    } finally {
+      setSaving(false);
+    }
   }
 
-  async function removeLink(index: number) {
-    const next = links.filter((_, i) => i !== index);
-    setLinks(next);
-    await saveLinks(next);
+  saveCommandRef.current = () => {
+    void save();
+  };
+
+  function patchForm(patch: Partial<ProfileForm>) {
+    setForm((current) => ({ ...current, ...patch }));
+    setJustSaved(false);
   }
 
-  const bioNearLimit = bio.length >= PROFILE_LIMITS.bio * 0.9;
+  function pickPronouns(value: string) {
+    setCustomPronoun(false);
+    patchForm({ pronouns: form.pronouns === value ? "" : value });
+  }
+
+  function chooseType(type: MbtiType) {
+    if (effectiveType === type) {
+      patchForm({ personality: null });
+      setPickerOpen(true);
+      setTuningOpen(false);
+      return;
+    }
+    patchForm({
+      personality: { type, tuned: false, axes: seedPersonalityAxes(type) },
+    });
+    setPickerOpen(false);
+    setTuningOpen(false);
+  }
+
+  function flipPersonalityAxis(index: number) {
+    const personality = form.personality;
+    if (!personality) return;
+    const axis = PROFILE_PERSONALITY_AXES[index];
+    if (personality.tuned) {
+      patchForm({
+        personality: {
+          ...personality,
+          axes: {
+            ...personality.axes,
+            [axis.key]: 100 - personality.axes[axis.key],
+          },
+        },
+      });
+      return;
+    }
+    const code = personality.type.split("");
+    code[index] = code[index] === axis.a ? axis.b : axis.a;
+    const nextType = code.join("");
+    if (!isMbtiType(nextType)) return;
+    patchForm({
+      personality: {
+        type: nextType,
+        tuned: false,
+        axes: seedPersonalityAxes(nextType),
+      },
+    });
+  }
+
+  function toggleTuning() {
+    const personality = form.personality;
+    if (!personality) return;
+    if (personality.tuned) {
+      const type = mbtiCode(personality);
+      if (!isMbtiType(type)) return;
+      patchForm({ personality: { ...personality, type, tuned: false } });
+      setTuningOpen(false);
+      return;
+    }
+    patchForm({
+      personality: {
+        ...personality,
+        tuned: true,
+        axes: seedPersonalityAxes(personality.type),
+      },
+    });
+    setTuningOpen(true);
+  }
+
+  function setPersonalityAxis(key: keyof ProfilePersonalityAxes, value: number) {
+    if (!form.personality) return;
+    patchForm({
+      personality: {
+        ...form.personality,
+        axes: { ...form.personality.axes, [key]: value },
+      },
+    });
+  }
+
+  function commitExactPercent(index: number) {
+    const personality = form.personality;
+    const axis = PROFILE_PERSONALITY_AXES[index];
+    if (!personality || !axis) {
+      setEditingAxis(null);
+      return;
+    }
+    const parsed = Number.parseInt(percentDraft, 10);
+    if (!Number.isNaN(parsed)) {
+      const percent = Math.max(0, Math.min(100, parsed));
+      const letter = effectiveType[index];
+      setPersonalityAxis(axis.key, letter === axis.a ? 100 - percent : percent);
+    }
+    setEditingAxis(null);
+  }
+
+  function updateLink(id: string, patch: Partial<ProfileLinkDraft>) {
+    patchForm({
+      links: form.links.map((link) => link.id === id ? { ...link, ...patch } : link),
+    });
+  }
+
+  function addLink() {
+    if (form.links.length >= PROFILE_LIMITS.links) return;
+    const id = String(nextLinkIdRef.current++);
+    patchForm({
+      links: [...form.links, { id, site: "github", user: "", label: "", url: "" }],
+    });
+  }
+
+  function removeLink(id: string) {
+    if (armedLinkId !== id) {
+      setArmedLinkId(id);
+      announce("Press remove again to confirm.");
+      return;
+    }
+    setArmedLinkId(null);
+    patchForm({ links: form.links.filter((link) => link.id !== id) });
+    announce("Link removed from the draft.");
+  }
+
+  async function draftBio() {
+    if (!drafter || drafting) return;
+    const currentLinks = storedLinks(form.links);
+    if (!currentLinks.ok) {
+      setError(currentLinks.error);
+      announce(currentLinks.error, "assertive");
+      return;
+    }
+    const controller = new AbortController();
+    bioAbortRef.current?.abort();
+    bioAbortRef.current = controller;
+    setDrafting(true);
+    setError(null);
+    const priorBio = form.bio;
+    try {
+      const result = await streamFamiliarText({
+        familiarId: drafter.id,
+        prompt: buildProfileBioPrompt({
+          familiarName: drafter.display_name,
+          firstName: form.firstName,
+          lastName: form.lastName,
+          nickname: form.nickname,
+          pronouns: form.pronouns,
+          timezone: currentZone,
+          personality: form.personality,
+          links: currentLinks.links,
+        }),
+        permissionMode: "read",
+        origin: "enhance",
+        signal: controller.signal,
+      });
+      const text = extractNextPaths(result.text).visible
+        .trim()
+        .replace(/^["“]|["”]$/g, "")
+        .slice(0, PROFILE_LIMITS.bio);
+      if (result.error || !text) {
+        throw new Error(result.error || `${drafter.display_name} did not return a bio.`);
+      }
+      setPreviousBio(priorBio);
+      patchForm({ bio: text });
+      setDraftNote(
+        `Drafted by ${drafter.display_name} from your name, type, timezone, and links.`,
+      );
+      announce(`Bio drafted by ${drafter.display_name}.`);
+    } catch (cause) {
+      if (controller.signal.aborted) return;
+      const message = cause instanceof Error ? cause.message : "Could not draft the bio.";
+      setError(message);
+      announce(message, "assertive");
+    } finally {
+      if (bioAbortRef.current === controller) bioAbortRef.current = null;
+      setDrafting(false);
+    }
+  }
 
   return (
-    <section className="max-w-none space-y-6" aria-labelledby={`${baseId}-title`}>
+    <section className="settings-profile" aria-labelledby={`${baseId}-title`}>
       <h2 id={`${baseId}-title`} className="sr-only">Profile</h2>
-      <SettingsOverview section="profile" />
 
-      <Link
-        href="/profile"
-        className="focus-ring inline-flex items-center gap-1 rounded-[var(--radius-sm)] text-[length:var(--text-sm)] text-[var(--text-muted)] transition-colors hover:text-[var(--accent-presence)]"
-        aria-label="Open your profile card"
-      >
-        View profile card →
-      </Link>
+      <header className="settings-profile__hero">
+        <button
+          type="button"
+          className="settings-profile__hero-avatar focus-ring"
+          onClick={() => setCardOpen((open) => !open)}
+          aria-expanded={cardOpen}
+          aria-controls={`${baseId}-profile-card`}
+          title={cardOpen ? "Hide profile card" : "Show profile card"}
+        >
+          {avatarSrc ? <img src={avatarSrc} alt="" /> : <span aria-hidden="true">{initials(form)}</span>}
+        </button>
+        <div className="settings-profile__hero-copy">
+          <p className="settings-profile__eyebrow">SETTINGS · PROFILE</p>
+          {editingName ? (
+            <TextInput
+              ref={nameEditRef}
+              className="settings-profile__hero-name-input focus-ring-inset"
+              defaultValue={displayName(form)}
+              aria-label="Display name"
+              maxLength={PROFILE_LIMITS.nickname}
+              onChange={(event) => patchForm({ nickname: event.target.value })}
+              onBlur={() => setEditingName(false)}
+              onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return;
+                if (event.key === "Enter" || event.key === "Escape") {
+                  event.preventDefault();
+                  setEditingName(false);
+                }
+              }}
+            />
+          ) : (
+            <h3>
+              <button
+                type="button"
+                className="settings-profile__hero-name focus-ring"
+                title="Double-click to rename"
+                aria-label={`Rename profile display name: ${displayName(form) || "User profile"}`}
+                onDoubleClick={() => setEditingName(true)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault();
+                    setEditingName(true);
+                  }
+                }}
+              >
+                {displayName(form) || "User profile"}
+              </button>
+            </h3>
+          )}
+          <p className="settings-profile__meta">{headerMeta}</p>
+        </div>
+        <div className="settings-profile__hero-status">
+          {justSaved && !dirty ? (
+            <span className="settings-profile__saved">
+              <Icon name="ph:check" aria-hidden />
+              Saved
+            </span>
+          ) : null}
+          <div className="settings-profile__completion">
+            <span>{completion.filled}/{completion.total} complete</span>
+            <progress
+              aria-label="Profile completion"
+              max={completion.total}
+              value={completion.filled}
+            />
+          </div>
+        </div>
+      </header>
+
+      {cardOpen ? (
+        <aside
+          id={`${baseId}-profile-card`}
+          className="settings-profile__preview"
+          aria-label="Profile card preview"
+        >
+          <div className="settings-profile__preview-avatar">
+            {avatarSrc ? <img src={avatarSrc} alt="" /> : <span aria-hidden="true">{initials(form)}</span>}
+          </div>
+          <div className="settings-profile__preview-copy">
+            <div className="settings-profile__preview-name">
+              <strong>{displayName(form) || "Unnamed operator"}</strong>
+              <span>{[form.pronouns, currentZone].filter(Boolean).join(" · ")}</span>
+            </div>
+            <p className={form.bio.trim() ? "" : "is-placeholder"}>
+              {form.bio.trim() || "No bio yet — familiars will default to a neutral voice."}
+            </p>
+            <div className="settings-profile__preview-links">
+              {liveLinks.map((link) => <span key={`${link.label}:${link.url}`}>{link.label}</span>)}
+            </div>
+          </div>
+          <IconButton
+            icon="ph:x"
+            size="sm"
+            aria-label="Close profile card"
+            onClick={() => setCardOpen(false)}
+          />
+        </aside>
+      ) : null}
 
       {disabled ? (
-        <p className="rounded-xl border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-3 text-[length:var(--text-sm)] text-[var(--text-muted)]">
+        <p className="settings-profile__notice">
           Daemon offline — profile unavailable.
         </p>
       ) : null}
-
       {error ? (
-        <p className="rounded-xl border border-[var(--color-danger)] bg-[color-mix(in_oklch,var(--color-danger)_12%,transparent)] px-4 py-3 text-[length:var(--text-sm)] text-[var(--color-danger)]">
+        <p className="settings-profile__notice settings-profile__notice--danger" role="alert">
           {error}
         </p>
       ) : null}
 
-      <SettingsGroup label="Identity" description="The name and pronouns familiars use for you.">
-        <div className="grid gap-4 px-4 py-4 md:grid-cols-2">
-          <ProfileField label="Display name" htmlFor={`${baseId}-name`} hint={saving === "name" ? "Saving…" : undefined}>
-            <input
-              id={`${baseId}-name`}
-              value={name}
-              maxLength={PROFILE_LIMITS.name}
-              disabled={disabled}
-              onChange={(event) => setName(event.target.value)}
-              onBlur={() => void saveTextField("name", name)}
-              className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-            />
-          </ProfileField>
-
-          <ProfileField label="Pronouns" htmlFor={`${baseId}-pronouns`} hint={saving === "pronouns" ? "Saving…" : undefined}>
-            <input
-              id={`${baseId}-pronouns`}
-              value={pronouns}
-              maxLength={PROFILE_LIMITS.pronouns}
-              disabled={disabled}
-              onChange={(event) => setPronouns(event.target.value)}
-              onBlur={() => void saveTextField("pronouns", pronouns)}
-              className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-            />
-          </ProfileField>
-        </div>
-      </SettingsGroup>
-
-      <SettingsGroup label="Image" description="The profile image that appears beside your operator profile.">
-        <div className="flex flex-wrap items-center gap-4 px-4 py-4">
-          <div className="flex h-24 w-24 items-center justify-center overflow-hidden rounded-3xl border border-[var(--border-hairline)] bg-[var(--bg-base)] text-[length:var(--text-display)] font-semibold text-[var(--text-secondary)]">
-            {avatarSrc ? (
-              <img src={avatarSrc} alt="" className="h-full w-full object-cover" />
-            ) : avatarInitial(snapshot) ? (
-              <span aria-hidden="true">{avatarInitial(snapshot)}</span>
-            ) : (
-              <Icon name="ph:user" width={34} aria-hidden={true} />
-            )}
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap gap-2">
-              <label htmlFor={`${baseId}-avatar`} className="sr-only">Upload profile image</label>
+      <div className="settings-profile__body">
+        <section
+          id={settingsGroupId("Identity")}
+          data-settings-group
+          className="settings-profile__section"
+          aria-labelledby={`${baseId}-identity`}
+        >
+          <ProfileSectionHeading id={`${baseId}-identity`} label="IDENTITY" />
+          <div className="settings-profile__identity">
+            <div className="settings-profile__portrait reveal-scope">
+              <div className="settings-profile__portrait-image">
+                {avatarSrc ? (
+                  <img src={avatarSrc} alt="Current portrait preview" />
+                ) : (
+                  <span>
+                    <strong aria-hidden="true">{initials(form)}</strong>
+                    <small>No portrait</small>
+                  </span>
+                )}
+              </div>
+              <div className="settings-profile__portrait-actions reveal-on-hover">
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  leadingIcon="ph:camera"
+                  disabled={disabled || preparingAvatar || saving}
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  {preparingAvatar ? "Preparing…" : "Upload"}
+                </Button>
+                {pendingAvatar.kind === "remove" ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    disabled={saving}
+                    onClick={() => setPendingAvatar({ kind: "keep" })}
+                  >
+                    Keep
+                  </Button>
+                ) : avatarPresent ? (
+                  <Button
+                    variant="danger-ghost"
+                    size="sm"
+                    disabled={saving}
+                    onClick={stageAvatarRemoval}
+                  >
+                    {avatarRemoveConfirm.armed ? "Really remove?" : "Remove"}
+                  </Button>
+                ) : null}
+              </div>
+              <label className="sr-only" htmlFor={`${baseId}-avatar`}>Upload portrait</label>
               <input
                 ref={fileInputRef}
                 id={`${baseId}-avatar`}
                 type="file"
                 accept={PROFILE_IMAGE_ACCEPT}
-                disabled={disabled || avatarBusy}
+                disabled={disabled || preparingAvatar || saving}
                 onChange={onAvatarFile}
                 className="sr-only"
               />
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={disabled || avatarBusy}
-                onClick={() => fileInputRef.current?.click()}
-              >
-                {avatarBusy ? "Updating…" : "Upload image"}
-              </Button>
-              {snapshot?.avatar.present ? (
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  disabled={avatarBusy}
-                  onClick={() => avatarRemoveConfirm.trigger(() => void removeAvatar())}
-                >
-                  {avatarRemoveConfirm.armed ? "Really remove?" : "Remove"}
-                </Button>
+            </div>
+
+            <div className="settings-profile__identity-fields">
+              <p className="settings-profile__field-title">Name &amp; pronouns</p>
+              <div className="settings-profile__name-row">
+                <label className="settings-profile__input-field">
+                  <span className="settings-profile__input-label">First name</span>
+                  <TextInput
+                    value={form.firstName}
+                    maxLength={PROFILE_LIMITS.firstName}
+                    disabled={disabled || saving}
+                    onChange={(event) => patchForm({ firstName: event.target.value })}
+                    placeholder="e.g., Valentina"
+                    aria-label="First name"
+                  />
+                </label>
+                <label className="settings-profile__input-field">
+                  <span className="settings-profile__input-label">Last name</span>
+                  <TextInput
+                    value={form.lastName}
+                    maxLength={PROFILE_LIMITS.lastName}
+                    disabled={disabled || saving}
+                    onChange={(event) => patchForm({ lastName: event.target.value })}
+                    placeholder="e.g., Alexander"
+                    aria-label="Last name"
+                  />
+                </label>
+                <label className="settings-profile__input-field">
+                  <span className="settings-profile__input-label">Nickname <small>Optional</small></span>
+                  <TextInput
+                    value={form.nickname}
+                    maxLength={PROFILE_LIMITS.nickname}
+                    disabled={disabled || saving}
+                    onChange={(event) => patchForm({ nickname: event.target.value })}
+                    placeholder="e.g., Val"
+                    aria-label="Nickname"
+                  />
+                </label>
+                <div className="settings-profile__pronouns" aria-label="Pronouns">
+                  {PRONOUN_PRESETS.map((preset) => (
+                    <button
+                      key={preset.value}
+                      type="button"
+                      className="focus-ring"
+                      aria-pressed={!customPronoun && form.pronouns === preset.value}
+                      title={preset.value}
+                      disabled={disabled || saving}
+                      onClick={() => pickPronouns(preset.value)}
+                    >
+                      {preset.label}
+                    </button>
+                  ))}
+                  <button
+                    type="button"
+                    className="focus-ring"
+                    aria-pressed={customPronoun}
+                    aria-label="Write custom pronouns"
+                    title="Write your own"
+                    disabled={disabled || saving}
+                    onClick={() => setCustomPronoun(true)}
+                  >
+                    <Icon name="ph:pencil-simple" aria-hidden />
+                  </button>
+                </div>
+                {customPronoun ? (
+                  <label className="settings-profile__custom-pronouns">
+                    <span className="sr-only">Custom pronouns</span>
+                    <TextInput
+                      autoFocus
+                      value={form.pronouns}
+                      maxLength={PROFILE_LIMITS.pronouns}
+                      disabled={disabled || saving}
+                      onChange={(event) => patchForm({ pronouns: event.target.value })}
+                      placeholder="ze / hir"
+                      aria-label="Custom pronouns"
+                    />
+                  </label>
+                ) : null}
+              </div>
+              <p className="settings-profile__hint">
+                PNG, JPEG, or WebP — hover the portrait to upload or remove.
+              </p>
+              {legacySvgAvatar ? (
+                <p className="settings-profile__hint">
+                  Your previous avatar was an SVG, which can no longer be used — re-upload it as PNG, JPEG, or WebP.
+                </p>
               ) : null}
             </div>
-            <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">PNG, JPEG, or WebP. Large files are downsized before upload.</p>
-            {legacySvgAvatar ? (
-              <p className="text-[length:var(--text-xs)] text-[var(--text-muted)]">
-                Your previous avatar was an SVG, which can no longer be used — re-upload it as PNG, JPEG, or WebP.
+          </div>
+        </section>
+
+        <section
+          id={settingsGroupId("Context")}
+          data-settings-group
+          className="settings-profile__section"
+          aria-labelledby={`${baseId}-context`}
+        >
+          <ProfileSectionHeading id={`${baseId}-context`} label="CONTEXT" />
+          <div className="settings-profile__context">
+            <article className="settings-profile__clock">
+              <div>
+                <span>TIMEZONE</span>
+                <span>{clock.date}</span>
+              </div>
+              <p>
+                <strong>{clock.time}</strong>
+                <span>{clock.meridiem}</span>
+              </p>
+              <small>Familiars receive this timezone in your profile context.</small>
+            </article>
+
+            <article className="settings-profile__bio">
+              <header>
+                <span>BIO</span>
+                <div className="settings-profile__bio-actions">
+                  <StandardSelect
+                    label="Bio drafting familiar"
+                    value={drafterId}
+                    onChange={setDrafterId}
+                    options={familiars.map((familiar) => ({
+                      value: familiar.id,
+                      label: familiar.display_name,
+                      detail: familiar.role,
+                    }))}
+                    placeholder={familiarLoadState === "loading"
+                      ? "Loading familiars…"
+                      : familiarLoadState === "ready" && familiars.length === 0
+                        ? "No familiars available"
+                        : "Choose familiar"}
+                    className="settings-profile__select settings-profile__select--compact"
+                    disabled={disabled || saving || drafting || familiars.length === 0}
+                  />
+                  <Button
+                    variant="secondary"
+                    size="xs"
+                    leadingIcon="ph:sparkle"
+                    loading={drafting}
+                    disabled={disabled || saving || !drafter}
+                    onClick={() => void draftBio()}
+                  >
+                    {drafting
+                      ? "Drafting…"
+                      : form.bio.trim()
+                        ? `Redraft with ${drafter?.display_name ?? "familiar"}`
+                        : `Draft with ${drafter?.display_name ?? "familiar"}`}
+                  </Button>
+                </div>
+              </header>
+              {familiarLoadState === "error" ? (
+                <ErrorState
+                  compact
+                  headline="Couldn’t load familiars"
+                  subtitle="Bio drafting is unavailable until the roster reconnects."
+                  actions={(
+                    <Button
+                      variant="secondary"
+                      size="xs"
+                      onClick={() => setFamiliarLoadNonce((nonce) => nonce + 1)}
+                    >
+                      Retry
+                    </Button>
+                  )}
+                />
+              ) : null}
+              <div className="settings-profile__bio-editor">
+                <TextArea
+                  rows={4}
+                  value={form.bio}
+                  maxLength={PROFILE_LIMITS.bio}
+                  disabled={disabled || saving || drafting}
+                  onChange={(event) => {
+                    patchForm({ bio: event.target.value });
+                    setDraftNote("");
+                  }}
+                  placeholder="Product designer. Terse over polite. Ship the small thing first."
+                  aria-label="Bio"
+                />
+                <span className={form.bio.length > PROFILE_BIO_GUIDE_MAX ? "is-over" : ""}>
+                  {form.bio.length} / {PROFILE_BIO_GUIDE_MAX}
+                </span>
+              </div>
+              <footer>Shapes how familiars write for you.</footer>
+              {draftNote ? (
+                <div className="settings-profile__draft-note">
+                  <span>{draftNote}</span>
+                  <button
+                    type="button"
+                    className="focus-ring"
+                    onClick={() => {
+                      patchForm({ bio: previousBio });
+                      setDraftNote("");
+                      announce("Bio draft undone.");
+                    }}
+                  >
+                    Undo
+                  </button>
+                </div>
+              ) : null}
+            </article>
+          </div>
+
+          <div className="settings-profile__timezone-select">
+            <label htmlFor={`${baseId}-timezone`}>TIMEZONE</label>
+            <StandardSelect
+              id={`${baseId}-timezone`}
+              label="Timezone"
+              value={form.timezone || SYSTEM_TIMEZONE_VALUE}
+              onChange={(value) => patchForm({
+                timezone: value === SYSTEM_TIMEZONE_VALUE ? "" : value,
+              })}
+              options={timezoneOptions}
+              className="settings-profile__select"
+              disabled={disabled || saving}
+            />
+          </div>
+        </section>
+
+        <section
+          id={settingsGroupId("Personality")}
+          data-settings-group
+          className="settings-profile__section"
+          aria-labelledby={`${baseId}-personality`}
+        >
+          <ProfileSectionHeading id={`${baseId}-personality`} label="PERSONALITY" detail="MBTI" />
+          <div className="settings-profile__personality">
+            <div className="settings-profile__personality-top">
+              <div>
+                <strong>Type</strong>
+                <span>Shapes tone, not content</span>
+              </div>
+              <button
+                type="button"
+                className="settings-profile__picker-toggle focus-ring"
+                aria-expanded={pickerOpen}
+                onClick={() => setPickerOpen((open) => !open)}
+                disabled={disabled || saving}
+              >
+                <Icon name="ph:caret-down" aria-hidden />
+                {form.personality ? "Change type" : "Choose your type"}
+              </button>
+              {form.personality ? (
+                <div className="settings-profile__type-tiles">
+                  {PROFILE_PERSONALITY_AXES.map((axis, index) => {
+                    const letter = effectiveType[index];
+                    const value = form.personality!.axes[axis.key];
+                    const percent = letter === axis.a ? 100 - value : value;
+                    return editingAxis === axis.key ? (
+                      <div
+                        key={axis.key}
+                        className="settings-profile__type-tile is-editing"
+                      >
+                        <strong>{letter}</strong>
+                        <input
+                          ref={percentEditRef}
+                          type="number"
+                          min="0"
+                          max="100"
+                          className="settings-profile__type-percent-input focus-ring-inset"
+                          value={percentDraft}
+                          aria-label={`Percent for ${axis.aWord} to ${axis.bWord}`}
+                          onChange={(event) => setPercentDraft(event.target.value)}
+                          onBlur={() => commitExactPercent(index)}
+                          onClick={(event) => event.stopPropagation()}
+                          onKeyDown={(event) => {
+                            event.stopPropagation();
+                            if (event.key === "Enter") {
+                              event.preventDefault();
+                              commitExactPercent(index);
+                            } else if (event.key === "Escape") {
+                              event.preventDefault();
+                              setEditingAxis(null);
+                            }
+                          }}
+                        />
+                      </div>
+                    ) : (
+                      <button
+                        key={axis.key}
+                        type="button"
+                        className="settings-profile__type-tile focus-ring"
+                        title={`Switch to ${letter === axis.a ? axis.bWord : axis.aWord}`}
+                        disabled={disabled || saving}
+                        onClick={() => flipPersonalityAxis(index)}
+                      >
+                        <strong>{letter}</strong>
+                        {form.personality?.tuned ? (
+                          <span
+                            title="Double-click to set exactly"
+                            onClick={(event) => event.stopPropagation()}
+                            onDoubleClick={(event) => {
+                              event.stopPropagation();
+                              setPercentDraft(String(Math.round(percent)));
+                              setEditingAxis(axis.key);
+                            }}
+                          >
+                            {Math.round(percent)}%
+                          </span>
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  className="settings-profile__personality-test focus-ring"
+                  onClick={() => openExternalUrl("https://www.16personalities.com/free-personality-test")}
+                >
+                  <Icon name="ph:sparkle" aria-hidden />
+                  Take the 12-minute test
+                  <Icon name="ph:arrow-square-out" aria-hidden />
+                </button>
+              )}
+            </div>
+
+            {pickerOpen ? (
+              <div className="settings-profile__type-picker">
+                {PROFILE_TYPE_GROUPS.map((group) => (
+                  <div key={group.name}>
+                    <span>{group.name.toUpperCase()}</span>
+                    <div>
+                      {group.codes.map((type) => (
+                        <button
+                          key={type}
+                          type="button"
+                          className="focus-ring"
+                          aria-pressed={effectiveType === type}
+                          title={PROFILE_TYPE_NAMES[type]}
+                          disabled={disabled || saving}
+                          onClick={() => chooseType(type)}
+                        >
+                          {type}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            ) : null}
+
+            {form.personality ? (
+              <>
+                <div className="settings-profile__type-summary">
+                  <strong>{PROFILE_TYPE_NAMES[effectiveType as MbtiType]} · {effectiveType}</strong>
+                  <span>{mbtiAdaptation(effectiveType)}</span>
+                  <button
+                    type="button"
+                    className="focus-ring"
+                    aria-expanded={tuningOpen}
+                    disabled={disabled || saving}
+                    onClick={toggleTuning}
+                  >
+                    <Icon name="ph:caret-down" aria-hidden />
+                    {form.personality.tuned ? "Hide axes" : "Fine-tune axes"}
+                  </button>
+                </div>
+
+                {form.personality.tuned && tuningOpen ? (
+                  <div className="settings-profile__axes">
+                    {PROFILE_PERSONALITY_AXES.map((axis) => {
+                      const value = form.personality!.axes[axis.key];
+                      const towardB = value >= 50;
+                      return (
+                        <label key={axis.key}>
+                          <span className={!towardB ? "is-active" : ""}>{axis.a}</span>
+                          <input
+                            type="range"
+                            min="0"
+                            max="100"
+                            step="1"
+                            value={value}
+                            disabled={disabled || saving}
+                            aria-label={`${axis.aWord} to ${axis.bWord}`}
+                            onChange={(event) => setPersonalityAxis(axis.key, Number(event.target.value))}
+                          />
+                          <span className={towardB ? "is-active" : ""}>{axis.b}</span>
+                          <output>
+                            {Math.round(towardB ? value : 100 - value)}%
+                          </output>
+                        </label>
+                      );
+                    })}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
+          </div>
+        </section>
+
+        <section
+          id={settingsGroupId("Links")}
+          data-settings-group
+          className="settings-profile__section"
+          aria-labelledby={`${baseId}-links`}
+        >
+          <ProfileSectionHeading
+            id={`${baseId}-links`}
+            label="LINKS"
+            detail={String(form.links.length)}
+            action={(
+              <Button
+                variant="ghost"
+                size="xs"
+                leadingIcon="ph:plus"
+                disabled={disabled || saving || form.links.length >= PROFILE_LIMITS.links}
+                onClick={addLink}
+              >
+                Add link
+              </Button>
+            )}
+          />
+          <div className="settings-profile__links">
+            {form.links.map((link) => {
+              const site = PROFILE_LINK_SITES.find((candidate) => candidate.value === link.site)
+                ?? PROFILE_LINK_SITES.at(-1)!;
+              const stored = profileLinkValue(link);
+              const invalid = link.site === "custom"
+                && Boolean(link.url.trim())
+                && !httpUrl(link.url.trim());
+              return (
+                <div className="settings-profile__link-row reveal-scope" key={link.id}>
+                  <span className={invalid ? "settings-profile__link-mark is-invalid" : "settings-profile__link-mark"}>
+                    {site.monogram}
+                  </span>
+                  <StandardSelect<ProfileLinkSite>
+                    label="Link type"
+                    value={link.site}
+                    onChange={(value) => updateLink(link.id, { site: value })}
+                    options={PROFILE_LINK_SITES.map((option) => ({
+                      value: option.value,
+                      label: option.label,
+                    }))}
+                    className="settings-profile__select"
+                    disabled={disabled || saving}
+                  />
+                  {link.site === "custom" ? (
+                    <div className="settings-profile__custom-link">
+                      <label className="settings-profile__input-field">
+                        <span className="settings-profile__input-label">Link label</span>
+                        <TextInput
+                          value={link.label}
+                          maxLength={PROFILE_LIMITS.linkLabel}
+                          disabled={disabled || saving}
+                          onChange={(event) => updateLink(link.id, { label: event.target.value })}
+                          placeholder="e.g., Portfolio"
+                          aria-label="Link label"
+                        />
+                      </label>
+                      <label className="settings-profile__input-field">
+                        <span className="settings-profile__input-label">Link URL</span>
+                        <TextInput
+                          value={link.url}
+                          maxLength={PROFILE_LIMITS.linkUrl}
+                          disabled={disabled || saving}
+                          onChange={(event) => updateLink(link.id, { url: event.target.value })}
+                          placeholder="e.g., https://example.com"
+                          inputMode="url"
+                          aria-label="Link URL"
+                          aria-invalid={invalid || undefined}
+                          aria-describedby={invalid ? `${baseId}-link-${link.id}-url-error` : undefined}
+                        />
+                        {invalid ? (
+                          <span
+                            id={`${baseId}-link-${link.id}-url-error`}
+                            className="settings-profile__field-error"
+                          >
+                            Enter a complete http(s) URL.
+                          </span>
+                        ) : null}
+                      </label>
+                    </div>
+                  ) : (
+                    <label className="settings-profile__preset-link">
+                      <span>{site.prefix}</span>
+                      <TextInput
+                        value={link.user}
+                        maxLength={PROFILE_LIMITS.linkUrl}
+                        disabled={disabled || saving}
+                        onChange={(event) => updateLink(link.id, { user: event.target.value })}
+                        placeholder={site.placeholder}
+                        aria-label={`${site.label} username`}
+                      />
+                    </label>
+                  )}
+                  <div className="settings-profile__link-actions reveal-on-hover">
+                    <IconButton
+                      icon="ph:arrow-square-out"
+                      size="sm"
+                      aria-label="Open link"
+                      disabled={!stored || !httpUrl(stored.url)}
+                      onClick={() => {
+                        if (stored && httpUrl(stored.url)) {
+                          openExternalUrl(stored.url);
+                        }
+                      }}
+                    />
+                    <IconButton
+                      icon={armedLinkId === link.id ? "ph:check" : "ph:trash"}
+                      size="sm"
+                      danger
+                      aria-label={armedLinkId === link.id ? "Confirm remove link" : "Remove link"}
+                      disabled={disabled || saving}
+                      onClick={() => removeLink(link.id)}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+            {form.links.length === 0 ? (
+              <p className="settings-profile__links-empty">
+                No links yet. Socials, portfolios, and references familiars can cite.
               </p>
             ) : null}
           </div>
-        </div>
-      </SettingsGroup>
+        </section>
+      </div>
 
-      <SettingsGroup label="Details" description="Context that helps familiars adapt their voice and schedules.">
-        <div className="grid gap-4 px-4 py-4">
-          <ProfileField label="Timezone" htmlFor={`${baseId}-timezone`} hint={saving === "timezone" ? "Saving…" : undefined}>
-            <select
-              id={`${baseId}-timezone`}
-              value={timezone}
-              disabled={disabled}
-              onChange={(event) => void saveTimezone(event.target.value)}
-              className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-            >
-              <option value="">System ({systemTz})</option>
-              {timezoneOptions.map((tz) => (
-                <option key={tz} value={tz}>{tz}</option>
-              ))}
-            </select>
-          </ProfileField>
-
-          <ProfileField
-            label="Bio"
-            htmlFor={`${baseId}-bio`}
-            hint={bioNearLimit ? `${bio.length}/${PROFILE_LIMITS.bio}` : saving === "bio" ? "Saving…" : undefined}
+      <footer className="settings-profile__actions">
+        <span className="settings-profile__shortcut">⌘S save</span>
+        <span className="settings-profile__action-meta">
+          {[currentZone, effectiveType, `${liveLinks.length} links`].filter(Boolean).join(" · ")}
+        </span>
+        <span className={dirty ? "settings-profile__save-state is-dirty" : "settings-profile__save-state"}>
+          {saving ? "Saving…" : dirty ? "Unsaved changes" : "All changes saved"}
+        </span>
+        <div>
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!dirty || saving}
+            onClick={discard}
           >
-            <textarea
-              id={`${baseId}-bio`}
-              value={bio}
-              maxLength={PROFILE_LIMITS.bio}
-              disabled={disabled}
-              rows={5}
-              onChange={(event) => setBio(event.target.value)}
-              onBlur={() => void saveTextField("bio", bio)}
-              className="focus-ring min-h-28 w-full resize-y rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-            />
-          </ProfileField>
+            Discard
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            loading={saving}
+            disabled={disabled || !dirty}
+            onClick={() => void save()}
+          >
+            Save changes
+          </Button>
         </div>
-      </SettingsGroup>
+      </footer>
 
-      <SettingsGroup label="Links" description="Socials, portfolios, and references familiars can cite.">
-        <div className="grid gap-3 px-4 py-4">
-          {links.length === 0 ? (
-            <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">No links yet.</p>
-          ) : null}
-          {links.map((link, index) => {
-            const labelId = `${baseId}-link-${index}-label`;
-            const urlId = `${baseId}-link-${index}-url`;
-            const rowIncomplete = Boolean((link.label.trim() || link.url.trim()) && (!link.label.trim() || !link.url.trim()));
-            return (
-              <div
-                key={index}
-                className="grid gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-base)] p-3 md:grid-cols-[1fr_2fr_auto]"
-                onBlur={(event: FocusEvent<HTMLDivElement>) => {
-                  if (!event.currentTarget.contains(event.relatedTarget as Node | null)) void saveLinks();
-                }}
-              >
-                <ProfileField label="Label" htmlFor={labelId}>
-                  <input
-                    id={labelId}
-                    value={link.label}
-                    maxLength={PROFILE_LIMITS.linkLabel}
-                    disabled={disabled}
-                    onChange={(event) => updateLink(index, { label: event.target.value })}
-                    className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-                  />
-                </ProfileField>
-                <ProfileField label="URL" htmlFor={urlId}>
-                  <input
-                    id={urlId}
-                    value={link.url}
-                    maxLength={PROFILE_LIMITS.linkUrl}
-                    disabled={disabled}
-                    inputMode="url"
-                    onChange={(event) => updateLink(index, { url: event.target.value })}
-                    className="focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[length:var(--text-base)] text-[var(--text-primary)] disabled:opacity-50"
-                  />
-                </ProfileField>
-                <div className="flex items-end">
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    disabled={disabled}
-                    onClick={() => {
-                      if (armedLinkIndex === index) {
-                        setArmedLinkIndex(null);
-                        void removeLink(index);
-                      } else {
-                        setArmedLinkIndex(index);
-                      }
-                    }}
-                  >
-                    {armedLinkIndex === index ? "Really remove?" : "Remove"}
-                  </Button>
-                </div>
-                {rowIncomplete ? (
-                  <p className="text-[length:var(--text-xs)] text-[var(--color-danger)] md:col-span-3">Add both fields to save this link.</p>
-                ) : null}
-              </div>
-            );
-          })}
-          {linkHint ? <p className="text-[length:var(--text-xs)] text-[var(--color-danger)]">{linkHint}</p> : null}
-          <div>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={disabled || links.length >= PROFILE_LIMITS.links}
-              onClick={() => setLinks((current) => [...current, { label: "", url: "" }])}
-            >
-              Add link
-            </Button>
-            {saving === "links" ? <span className="ml-3 text-[length:var(--text-xs)] text-[var(--text-muted)]">Saving…</span> : null}
-          </div>
-        </div>
-      </SettingsGroup>
+      <Link className="settings-profile__card-link focus-ring" href="/profile">
+        View profile card →
+      </Link>
     </section>
   );
 }
 
-function ProfileField({
+function ProfileSectionHeading({
+  id,
   label,
-  htmlFor,
-  hint,
-  children,
+  detail,
+  action,
 }: {
+  id: string;
   label: string;
-  htmlFor: string;
-  hint?: string;
-  children: ReactNode;
+  detail?: string;
+  action?: ReactNode;
 }) {
   return (
-    <div className="grid gap-1.5">
-      <div className="flex items-baseline justify-between gap-3">
-        <label htmlFor={htmlFor} className="text-[length:var(--text-sm)] font-medium text-[var(--text-secondary)]">
-          {label}
-        </label>
-        {hint ? <span className="text-[length:var(--text-xs)] text-[var(--text-muted)]">{hint}</span> : null}
-      </div>
-      {children}
+    <div className="settings-profile__section-heading">
+      <h3 id={id}>{label}</h3>
+      {detail ? <span>{detail}</span> : null}
+      <span aria-hidden="true" />
+      {action}
     </div>
   );
 }

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -36,7 +36,7 @@ export const SECTIONS: SectionMeta[] = [
 ];
 
 export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
-  profile: ["Display name & pronouns", "Profile image", "Bio, timezone & links"],
+  profile: ["Identity & pronouns", "Context & personality", "Portrait & links"],
   general: ["Workspace path", "Encrypted backup", "Launch behavior"],
   daemon: ["Runtime health", "Local/hub routing", "Socket & version"],
   familiars: ["Roster & identity", "Per-familiar permissions", "Pinned strip order"],
@@ -47,8 +47,9 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
 
 export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "profile", group: "Identity", keywords: "profile name display pronouns identity operator user you" },
-  { section: "profile", group: "Image", keywords: "avatar image photo picture upload face profile" },
-  { section: "profile", group: "Details", keywords: "bio about timezone time zone" },
+  { section: "profile", group: "Identity", keywords: "avatar image photo picture upload face profile" },
+  { section: "profile", group: "Context", keywords: "bio about timezone time zone familiar draft" },
+  { section: "profile", group: "Personality", keywords: "personality mbti type axes tone familiar" },
   { section: "profile", group: "Links", keywords: "links github socials url website portfolio" },
   { section: "general", group: "Workspace", keywords: "workspace directory root folder project path" },
   { section: "general", group: "Home", keywords: "news headlines rss carousel media home digest daily summary" },

--- a/src/lib/server/familiar-startup-context.ts
+++ b/src/lib/server/familiar-startup-context.ts
@@ -1,6 +1,7 @@
 import { readFile, stat } from "node:fs/promises";
 import path from "node:path";
-import type { UserProfile } from "../user-profile-shared.ts";
+import { userDisplayName, userFullName, type UserProfile } from "../user-profile-shared.ts";
+import { mbtiAxisSummary, mbtiCode } from "../settings-profile-form.ts";
 
 export type FamiliarStartupContextFile = {
   relativePath: string;
@@ -57,9 +58,17 @@ export function buildOperatorProfileContext(
 ): FamiliarStartupContextFile | null {
   if (!profile) return null;
   const lines: string[] = [];
-  if (profile.name) lines.push(`Name: ${profile.name}`);
+  const displayName = userDisplayName(profile);
+  const fullName = userFullName(profile);
+  if (displayName !== "You") lines.push(`Name: ${displayName}`);
+  if (fullName && fullName !== displayName) lines.push(`Full name: ${fullName}`);
   if (profile.pronouns) lines.push(`Pronouns: ${profile.pronouns}`);
   if (profile.timezone) lines.push(`Timezone: ${profile.timezone}`);
+  if (profile.personality) {
+    lines.push(
+      `Personality: ${mbtiCode(profile.personality)} (${mbtiAxisSummary(profile.personality)})`,
+    );
+  }
   if (profile.bio) lines.push(`Bio: ${profile.bio}`);
   if (profile.links?.length) {
     lines.push("Links:");

--- a/src/lib/server/operator-profile-context.test.ts
+++ b/src/lib/server/operator-profile-context.test.ts
@@ -19,4 +19,20 @@ describe("buildOperatorProfileContext", () => {
     const ctx = buildOperatorProfileContext({ links: [{ label: "GitHub", url: "https://github.com/x" }] });
     assert.match(ctx!.contents, /GitHub — https:\/\/github\.com\/x/);
   });
+  it("renders structured identity and the selected personality", () => {
+    const ctx = buildOperatorProfileContext({
+      firstName: "Valentina",
+      lastName: "Alexander",
+      nickname: "Val",
+      personality: {
+        type: "INTJ",
+        tuned: true,
+        axes: { ei: 72, sn: 18, tf: 31, jp: 24 },
+      },
+    });
+    assert.match(ctx!.contents, /Name: Val/);
+    assert.match(ctx!.contents, /Full name: Valentina Alexander/);
+    assert.match(ctx!.contents, /Personality: INTJ/);
+    assert.match(ctx!.contents, /I 72% · N 82% · T 69% · J 76%/);
+  });
 });

--- a/src/lib/settings-profile-form.test.ts
+++ b/src/lib/settings-profile-form.test.ts
@@ -1,0 +1,125 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import * as profileFormHelpers from "./settings-profile-form.ts";
+import {
+  buildProfileBioPrompt,
+  mbtiAdaptation,
+  mbtiCode,
+  profileCompletion,
+  profileLinkDraft,
+  profileLinkValue,
+  seedPersonalityAxes,
+} from "./settings-profile-form.ts";
+
+describe("Settings Profile form helpers", () => {
+  it("seeds and derives MBTI axes using the imported control-sheet model", () => {
+    assert.deepEqual(seedPersonalityAxes("INTJ"), { ei: 75, sn: 25, tf: 25, jp: 25 });
+    assert.equal(
+      mbtiCode({ type: "INTJ", tuned: true, axes: { ei: 20, sn: 80, tf: 70, jp: 55 } }),
+      "ESFP",
+    );
+    assert.match(mbtiAdaptation("INTJ"), /keep openers brief/);
+    assert.match(mbtiAdaptation("INTJ"), /close with a decision/);
+  });
+
+  it("round-trips known social links while preserving custom URLs", () => {
+    const github = profileLinkDraft({ label: "GitHub", url: "https://github.com/BunsDev" }, "1");
+    assert.deepEqual(github, {
+      id: "1",
+      site: "github",
+      user: "BunsDev",
+      label: "",
+      url: "",
+    });
+    assert.deepEqual(profileLinkValue(github), {
+      label: "GitHub",
+      url: "https://github.com/BunsDev",
+    });
+
+    const custom = profileLinkDraft({ label: "Work", url: "https://example.com/about" }, "2");
+    assert.equal(custom.site, "custom");
+    assert.deepEqual(profileLinkValue(custom), {
+      label: "Work",
+      url: "https://example.com/about",
+    });
+  });
+
+  it("preserves a custom label when a URL matches a known social site", () => {
+    const original = {
+      label: "Work samples",
+      url: "https://github.com/BunsDev",
+    };
+
+    assert.deepEqual(profileLinkValue(profileLinkDraft(original, "3")), original);
+  });
+
+  it("drops blank link rows from the saved draft snapshot", () => {
+    const compactProfileLinkDrafts = (
+      profileFormHelpers as Record<string, unknown>
+    ).compactProfileLinkDrafts;
+    assert.equal(typeof compactProfileLinkDrafts, "function");
+    const compact = compactProfileLinkDrafts as (
+      drafts: Array<ReturnType<typeof profileLinkDraft>>,
+    ) => Array<ReturnType<typeof profileLinkDraft>>;
+    const github = profileLinkDraft(
+      { label: "GitHub", url: "https://github.com/BunsDev" },
+      "1",
+    );
+
+    assert.deepEqual(
+      compact([
+        github,
+        { id: "2", site: "github", user: "", label: "", url: "" },
+        { id: "3", site: "custom", user: "", label: "", url: "" },
+      ]),
+      [github],
+    );
+  });
+
+  it("only mirrors display names that fit the legacy name field", () => {
+    const legacyProfileName = (
+      profileFormHelpers as Record<string, unknown>
+    ).legacyProfileName;
+    assert.equal(typeof legacyProfileName, "function");
+    const legacyName = legacyProfileName as (value: string) => string | null;
+
+    assert.equal(legacyName("Val"), "Val");
+    assert.equal(legacyName("x".repeat(65)), null);
+  });
+
+  it("counts the five completion channels", () => {
+    assert.deepEqual(
+      profileCompletion({
+        displayName: "Val",
+        pronouns: "she / her",
+        avatar: true,
+        bio: "",
+        links: 2,
+      }),
+      { filled: 4, total: 5, percent: 80 },
+    );
+  });
+
+  it("builds a bounded third-person bio prompt from current form context", () => {
+    const prompt = buildProfileBioPrompt({
+      familiarName: "Sage",
+      firstName: "Valentina",
+      lastName: "Alexander",
+      nickname: "Val",
+      pronouns: "she / her",
+      timezone: "America/Chicago",
+      personality: {
+        type: "INTJ",
+        tuned: false,
+        axes: { ei: 75, sn: 25, tf: 25, jp: 25 },
+      },
+      links: [{ label: "GitHub", url: "https://github.com/BunsDev" }],
+    });
+    assert.match(prompt, /You are Sage/);
+    assert.match(prompt, /under 240 characters/);
+    assert.match(prompt, /Name: Valentina Alexander/);
+    assert.match(prompt, /Nickname: Val/);
+    assert.match(prompt, /MBTI: INTJ/);
+    assert.match(prompt, /Return only the bio text/);
+  });
+});

--- a/src/lib/settings-profile-form.ts
+++ b/src/lib/settings-profile-form.ts
@@ -1,0 +1,193 @@
+import {
+  PROFILE_LIMITS,
+  type MbtiType,
+  type ProfileLink,
+  type ProfilePersonality,
+  type ProfilePersonalityAxes,
+} from "./user-profile-shared.ts";
+
+export function legacyProfileName(displayName: string): string | null {
+  const name = displayName.trim();
+  return name && name.length <= PROFILE_LIMITS.name ? name : null;
+}
+
+export const PROFILE_TYPE_NAMES: Record<MbtiType, string> = {
+  INTJ: "The Architect",
+  INTP: "The Logician",
+  ENTJ: "The Commander",
+  ENTP: "The Debater",
+  INFJ: "The Advocate",
+  INFP: "The Mediator",
+  ENFJ: "The Protagonist",
+  ENFP: "The Campaigner",
+  ISTJ: "The Logistician",
+  ISFJ: "The Defender",
+  ESTJ: "The Executive",
+  ESFJ: "The Consul",
+  ISTP: "The Virtuoso",
+  ISFP: "The Adventurer",
+  ESTP: "The Entrepreneur",
+  ESFP: "The Entertainer",
+};
+
+export const PROFILE_TYPE_GROUPS: Array<{ name: string; codes: MbtiType[] }> = [
+  { name: "Analysts", codes: ["INTJ", "INTP", "ENTJ", "ENTP"] },
+  { name: "Diplomats", codes: ["INFJ", "INFP", "ENFJ", "ENFP"] },
+  { name: "Sentinels", codes: ["ISTJ", "ISFJ", "ESTJ", "ESFJ"] },
+  { name: "Explorers", codes: ["ISTP", "ISFP", "ESTP", "ESFP"] },
+];
+
+export const PROFILE_PERSONALITY_AXES = [
+  { key: "ei", a: "E", b: "I", aWord: "Extraversion", bWord: "Introversion" },
+  { key: "sn", a: "N", b: "S", aWord: "Intuition", bWord: "Sensing" },
+  { key: "tf", a: "T", b: "F", aWord: "Thinking", bWord: "Feeling" },
+  { key: "jp", a: "J", b: "P", aWord: "Judging", bWord: "Perceiving" },
+] as const;
+
+const PROFILE_PERSONALITY_CLAUSES: Record<string, string> = {
+  E: "think out loud",
+  I: "keep openers brief",
+  S: "lead with specifics",
+  N: "lead with the pattern",
+  T: "name tradeoffs bluntly",
+  F: "keep the phrasing warm",
+  J: "close with a decision",
+  P: "close with options",
+};
+
+export function seedPersonalityAxes(code: string): ProfilePersonalityAxes {
+  const axes = {} as ProfilePersonalityAxes;
+  PROFILE_PERSONALITY_AXES.forEach((axis, index) => {
+    const letter = code[index];
+    axes[axis.key] = letter === axis.a ? 25 : letter === axis.b ? 75 : 50;
+  });
+  return axes;
+}
+
+export function mbtiCode(personality: ProfilePersonality | null | undefined): string {
+  if (!personality) return "";
+  if (!personality.tuned) return personality.type;
+  return PROFILE_PERSONALITY_AXES
+    .map((axis) => (personality.axes[axis.key] < 50 ? axis.a : axis.b))
+    .join("");
+}
+
+export function mbtiAdaptation(code: string): string {
+  if (code.length !== PROFILE_PERSONALITY_AXES.length) return "";
+  const clauses = code.split("").map((letter) => PROFILE_PERSONALITY_CLAUSES[letter]).filter(Boolean);
+  if (clauses.length !== PROFILE_PERSONALITY_AXES.length) return "";
+  return `Familiars ${clauses.slice(0, -1).join(", ")}, and ${clauses.at(-1)}.`;
+}
+
+export function mbtiAxisSummary(personality: ProfilePersonality): string {
+  const code = mbtiCode(personality);
+  return PROFILE_PERSONALITY_AXES.map((axis, index) => {
+    const value = personality.axes[axis.key];
+    const letter = code[index] || (value < 50 ? axis.a : axis.b);
+    const percent = letter === axis.a ? 100 - value : value;
+    return `${letter} ${Math.round(percent)}%`;
+  }).join(" · ");
+}
+
+export type ProfileLinkSite = "github" | "x" | "linkedin" | "bluesky" | "dribbble" | "custom";
+
+export type ProfileLinkDraft = {
+  id: string;
+  site: ProfileLinkSite;
+  user: string;
+  label: string;
+  url: string;
+};
+
+export const PROFILE_LINK_SITES: Array<{
+  value: ProfileLinkSite;
+  label: string;
+  prefix: string;
+  urlPrefix: string;
+  placeholder: string;
+  monogram: string;
+}> = [
+  { value: "github", label: "GitHub", prefix: "github.com/", urlPrefix: "https://github.com/", placeholder: "username", monogram: "GH" },
+  { value: "x", label: "X", prefix: "x.com/", urlPrefix: "https://x.com/", placeholder: "handle", monogram: "X" },
+  { value: "linkedin", label: "LinkedIn", prefix: "linkedin.com/in/", urlPrefix: "https://linkedin.com/in/", placeholder: "slug", monogram: "in" },
+  { value: "bluesky", label: "Bluesky", prefix: "bsky.app/profile/", urlPrefix: "https://bsky.app/profile/", placeholder: "you.bsky.social", monogram: "BS" },
+  { value: "dribbble", label: "Dribbble", prefix: "dribbble.com/", urlPrefix: "https://dribbble.com/", placeholder: "username", monogram: "DR" },
+  { value: "custom", label: "Custom URL", prefix: "", urlPrefix: "", placeholder: "https://", monogram: "↗" },
+];
+
+export function profileLinkDraft(link: ProfileLink, id: string): ProfileLinkDraft {
+  for (const site of PROFILE_LINK_SITES) {
+    if (site.value === "custom" || !link.url.startsWith(site.urlPrefix)) continue;
+    return {
+      id,
+      site: site.value,
+      user: link.url.slice(site.urlPrefix.length),
+      label: link.label === site.label ? "" : link.label,
+      url: "",
+    };
+  }
+  return { id, site: "custom", user: "", label: link.label, url: link.url };
+}
+
+export function profileLinkValue(draft: ProfileLinkDraft): ProfileLink | null {
+  const site = PROFILE_LINK_SITES.find((candidate) => candidate.value === draft.site)
+    ?? PROFILE_LINK_SITES.at(-1)!;
+  if (draft.site === "custom") {
+    const label = draft.label.trim();
+    const url = draft.url.trim();
+    return label && url ? { label, url } : null;
+  }
+  const user = draft.user.trim().replace(/^@/, "");
+  return user
+    ? { label: draft.label.trim() || site.label, url: `${site.urlPrefix}${user}` }
+    : null;
+}
+
+export function compactProfileLinkDrafts(drafts: ProfileLinkDraft[]): ProfileLinkDraft[] {
+  return drafts.filter((draft) => profileLinkValue(draft) !== null);
+}
+
+export function profileCompletion(input: {
+  displayName: string;
+  pronouns: string;
+  avatar: boolean;
+  bio: string;
+  links: number;
+}): { filled: number; total: 5; percent: number } {
+  const filled = [
+    Boolean(input.displayName.trim()),
+    Boolean(input.pronouns.trim()),
+    input.avatar,
+    Boolean(input.bio.trim()),
+    input.links > 0,
+  ].filter(Boolean).length;
+  return { filled, total: 5, percent: filled * 20 };
+}
+
+export function buildProfileBioPrompt(input: {
+  familiarName: string;
+  firstName: string;
+  lastName: string;
+  nickname: string;
+  pronouns: string;
+  timezone: string;
+  personality: ProfilePersonality | null;
+  links: ProfileLink[];
+}): string {
+  const fullName = [input.firstName, input.lastName].map((part) => part.trim()).filter(Boolean).join(" ");
+  const code = mbtiCode(input.personality);
+  const sites = input.links.map((link) => link.label).filter(Boolean).join(", ");
+  return [
+    `You are ${input.familiarName}, a familiar who has worked alongside this operator for months.`,
+    "Write their profile bio in third person, 2 sentences, under 240 characters.",
+    "Terse, warm, specific, sentence case, no emoji, no hashtags, no quotes around the output.",
+    "Return only the bio text.",
+    "",
+    `Name: ${fullName || input.nickname.trim() || "unknown"}`,
+    `Nickname: ${input.nickname.trim() || "unstated"}`,
+    `Pronouns: ${input.pronouns.trim() || "unstated"}`,
+    `Timezone: ${input.timezone}`,
+    `MBTI: ${code || "unstated"}${code ? ` (${PROFILE_TYPE_NAMES[code as MbtiType]})` : ""}`,
+    `Links: ${sites || "none"}`,
+  ].join("\n");
+}

--- a/src/lib/user-profile-shared.test.ts
+++ b/src/lib/user-profile-shared.test.ts
@@ -11,12 +11,31 @@ import {
 describe("normalizeUserProfilePatch", () => {
   it("trims and accepts valid fields", () => {
     const res = normalizeUserProfilePatch({
-      name: "  Buns ", pronouns: "they/them", bio: "hi", timezone: "America/Chicago",
+      name: "  Buns ",
+      firstName: "  Valentina ",
+      lastName: " Alexander ",
+      nickname: " Val ",
+      pronouns: "they/them",
+      bio: "hi",
+      timezone: "America/Chicago",
+      personality: {
+        type: "INTJ",
+        tuned: true,
+        axes: { ei: 72, sn: 18, tf: 31, jp: 24 },
+      },
       links: [{ label: "GitHub", url: "https://github.com/BunsDev" }],
     });
     assert.ok(res.ok);
     if (!res.ok) return;
     assert.equal(res.patch.name, "Buns");
+    assert.equal(res.patch.firstName, "Valentina");
+    assert.equal(res.patch.lastName, "Alexander");
+    assert.equal(res.patch.nickname, "Val");
+    assert.deepEqual(res.patch.personality, {
+      type: "INTJ",
+      tuned: true,
+      axes: { ei: 72, sn: 18, tf: 31, jp: 24 },
+    });
     assert.equal(res.patch.links?.[0].url, "https://github.com/BunsDev");
   });
   it("empty string clears a field (null in patch)", () => {
@@ -25,11 +44,27 @@ describe("normalizeUserProfilePatch", () => {
     if (!res.ok) return;
     assert.equal(res.patch.name, null);
   });
+  it("accepts explicit nulls from the client patch contract", () => {
+    const res = normalizeUserProfilePatch({
+      name: null,
+      timezone: null,
+      personality: null,
+      links: null,
+    });
+    assert.ok(res.ok);
+    if (!res.ok) return;
+    assert.deepEqual(res.patch, {
+      name: null,
+      timezone: null,
+      personality: null,
+      links: null,
+    });
+  });
   it("rejects unknown keys", () => {
-    const res = normalizeUserProfilePatch({ nickname: "x" } as Record<string, unknown>);
+    const res = normalizeUserProfilePatch({ favoriteColor: "violet" } as Record<string, unknown>);
     assert.ok(!res.ok);
     if (res.ok) return;
-    assert.match(res.error, /unknown field: nickname/);
+    assert.match(res.error, /unknown field: favoriteColor/);
   });
   it("rejects over-limit lengths", () => {
     const res = normalizeUserProfilePatch({ name: "x".repeat(PROFILE_LIMITS.name + 1) });
@@ -41,6 +76,17 @@ describe("normalizeUserProfilePatch", () => {
     assert.ok(!normalizeUserProfilePatch({ timezone: "Mars/Olympus" }).ok);
     assert.ok(!normalizeUserProfilePatch({ links: [{ label: "x", url: "javascript:alert(1)" }] }).ok);
     assert.ok(!normalizeUserProfilePatch({ links: Array.from({ length: 9 }, (_, i) => ({ label: `l${i}`, url: "https://a.b" })) }).ok);
+  });
+  it("rejects malformed personality values", () => {
+    assert.ok(!normalizeUserProfilePatch({
+      personality: { type: "AAAA", tuned: false, axes: { ei: 50, sn: 50, tf: 50, jp: 50 } },
+    }).ok);
+    assert.ok(!normalizeUserProfilePatch({
+      personality: { type: "INTJ", tuned: true, axes: { ei: 101, sn: 50, tf: 50, jp: 50 } },
+    }).ok);
+    assert.ok(!normalizeUserProfilePatch({
+      personality: { type: "INTJ", tuned: "yes", axes: { ei: 50, sn: 50, tf: 50, jp: 50 } },
+    }).ok);
   });
   it("rejects non-object bodies without throwing", () => {
     const resNull = normalizeUserProfilePatch(null as unknown);
@@ -91,12 +137,30 @@ describe("applyUserProfilePatch", () => {
     const result = applyUserProfilePatch({ name: "x", bio: "b" }, { name: null, bio: null });
     assert.equal(result, undefined);
   });
+  it("applies and clears structured identity and personality", () => {
+    const personality = {
+      type: "ENFP" as const,
+      tuned: false,
+      axes: { ei: 25, sn: 25, tf: 75, jp: 75 },
+    };
+    const result = applyUserProfilePatch(
+      { name: "legacy" },
+      { firstName: "Val", nickname: "Buns", personality },
+    );
+    assert.deepEqual(result, { name: "legacy", firstName: "Val", nickname: "Buns", personality });
+    assert.deepEqual(
+      applyUserProfilePatch(result, { nickname: null, personality: null }),
+      { name: "legacy", firstName: "Val" },
+    );
+  });
 });
 
 describe("userDisplayName", () => {
-  it("falls back to You", () => {
+  it("prefers nickname, then structured name, legacy name, and finally You", () => {
     assert.equal(userDisplayName(null), "You");
     assert.equal(userDisplayName({ name: "  " }), "You");
     assert.equal(userDisplayName({ name: "Buns" }), "Buns");
+    assert.equal(userDisplayName({ name: "Legacy", firstName: "Valentina", lastName: "Alexander" }), "Valentina Alexander");
+    assert.equal(userDisplayName({ firstName: "Valentina", lastName: "Alexander", nickname: "Val" }), "Val");
   });
 });

--- a/src/lib/user-profile-shared.ts
+++ b/src/lib/user-profile-shared.ts
@@ -8,17 +8,51 @@
 
 export type ProfileLink = { label: string; url: string };
 
+export const MBTI_TYPES = [
+  "INTJ", "INTP", "ENTJ", "ENTP",
+  "INFJ", "INFP", "ENFJ", "ENFP",
+  "ISTJ", "ISFJ", "ESTJ", "ESFJ",
+  "ISTP", "ISFP", "ESTP", "ESFP",
+] as const;
+
+export type MbtiType = (typeof MBTI_TYPES)[number];
+
+export type ProfilePersonalityAxes = {
+  /** 0 = Extraversion, 100 = Introversion. */
+  ei: number;
+  /** 0 = Intuition, 100 = Sensing. */
+  sn: number;
+  /** 0 = Thinking, 100 = Feeling. */
+  tf: number;
+  /** 0 = Judging, 100 = Perceiving. */
+  jp: number;
+};
+
+export type ProfilePersonality = {
+  type: MbtiType;
+  tuned: boolean;
+  axes: ProfilePersonalityAxes;
+};
+
 export type UserProfile = {
+  /** Legacy display-name field retained for existing cave-config files. */
   name?: string;
+  firstName?: string;
+  lastName?: string;
+  nickname?: string;
   pronouns?: string;
   bio?: string;
   /** IANA timezone id. Unset = system. */
   timezone?: string;
+  personality?: ProfilePersonality;
   links?: ProfileLink[];
 };
 
 export const PROFILE_LIMITS = {
   name: 64,
+  firstName: 64,
+  lastName: 64,
+  nickname: 64,
   pronouns: 32,
   bio: 2000,
   linkLabel: 32,
@@ -26,15 +60,31 @@ export const PROFILE_LIMITS = {
   links: 8,
 } as const;
 
-const PATCH_KEYS = new Set(["name", "pronouns", "bio", "timezone", "links"]);
+const PATCH_KEYS = new Set([
+  "name",
+  "firstName",
+  "lastName",
+  "nickname",
+  "pronouns",
+  "bio",
+  "timezone",
+  "personality",
+  "links",
+]);
+const PERSONALITY_KEYS = new Set(["type", "tuned", "axes"]);
+const PERSONALITY_AXIS_KEYS = ["ei", "sn", "tf", "jp"] as const;
 
 /** Patch semantics: string fields — trimmed value sets, "" clears (null).
  *  `links` — array replaces, [] clears (null). Absent keys untouched. */
 export type UserProfilePatch = {
   name?: string | null;
+  firstName?: string | null;
+  lastName?: string | null;
+  nickname?: string | null;
   pronouns?: string | null;
   bio?: string | null;
   timezone?: string | null;
+  personality?: ProfilePersonality | null;
   links?: ProfileLink[] | null;
 };
 
@@ -61,14 +111,72 @@ function isHttpUrl(value: string): boolean {
 }
 
 function normText(
-  value: unknown, field: "name" | "pronouns" | "bio",
+  value: unknown,
+  field: "name" | "firstName" | "lastName" | "nickname" | "pronouns" | "bio",
 ): { ok: true; value: string | null } | { ok: false; error: string } {
+  if (value === null) return { ok: true, value: null };
   if (typeof value !== "string") return { ok: false, error: `${field} must be a string` };
   const trimmed = value.trim();
   if (trimmed.length > PROFILE_LIMITS[field]) {
     return { ok: false, error: `${field} is too long (max ${PROFILE_LIMITS[field]} characters)` };
   }
   return { ok: true, value: trimmed === "" ? null : trimmed };
+}
+
+function normPersonality(
+  value: unknown,
+): { ok: true; value: ProfilePersonality | null } | { ok: false; error: string } {
+  if (value === null) return { ok: true, value: null };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    return { ok: false, error: "personality must be an object" };
+  }
+  const personality = value as Record<string, unknown>;
+  for (const key of Object.keys(personality)) {
+    if (!PERSONALITY_KEYS.has(key)) {
+      return { ok: false, error: `unknown personality field: ${key}` };
+    }
+  }
+  if (typeof personality.type !== "string") {
+    return { ok: false, error: "personality type must be an MBTI type" };
+  }
+  const type = personality.type.trim().toUpperCase();
+  if (!(MBTI_TYPES as readonly string[]).includes(type)) {
+    return { ok: false, error: `unknown personality type: ${type}` };
+  }
+  if (typeof personality.tuned !== "boolean") {
+    return { ok: false, error: "personality tuned must be a boolean" };
+  }
+  if (
+    typeof personality.axes !== "object"
+    || personality.axes === null
+    || Array.isArray(personality.axes)
+  ) {
+    return { ok: false, error: "personality axes must be an object" };
+  }
+  const rawAxes = personality.axes as Record<string, unknown>;
+  const rawAxisKeys = Object.keys(rawAxes);
+  if (
+    rawAxisKeys.length !== PERSONALITY_AXIS_KEYS.length
+    || rawAxisKeys.some((key) => !PERSONALITY_AXIS_KEYS.includes(key as typeof PERSONALITY_AXIS_KEYS[number]))
+  ) {
+    return { ok: false, error: "personality axes must contain ei, sn, tf, and jp" };
+  }
+  const axes = {} as ProfilePersonalityAxes;
+  for (const key of PERSONALITY_AXIS_KEYS) {
+    const axis = rawAxes[key];
+    if (typeof axis !== "number" || !Number.isInteger(axis) || axis < 0 || axis > 100) {
+      return { ok: false, error: `personality axis ${key} must be an integer from 0 to 100` };
+    }
+    axes[key] = axis;
+  }
+  return {
+    ok: true,
+    value: {
+      type: type as MbtiType,
+      tuned: personality.tuned,
+      axes,
+    },
+  };
 }
 
 export function normalizeUserProfilePatch(body: unknown): NormalizeResult {
@@ -80,7 +188,14 @@ export function normalizeUserProfilePatch(body: unknown): NormalizeResult {
     if (!PATCH_KEYS.has(key)) return { ok: false, error: `unknown field: ${key}` };
   }
   const patch: UserProfilePatch = {};
-  for (const field of ["name", "pronouns", "bio"] as const) {
+  for (const field of [
+    "name",
+    "firstName",
+    "lastName",
+    "nickname",
+    "pronouns",
+    "bio",
+  ] as const) {
     if (field in obj) {
       const res = normText(obj[field], field);
       if (!res.ok) return res;
@@ -88,13 +203,25 @@ export function normalizeUserProfilePatch(body: unknown): NormalizeResult {
     }
   }
   if ("timezone" in obj) {
-    if (typeof obj.timezone !== "string") return { ok: false, error: "timezone must be a string" };
-    const tz = obj.timezone.trim();
-    if (tz === "") patch.timezone = null;
-    else if (!isValidTimezone(tz)) return { ok: false, error: `unknown timezone: ${tz}` };
-    else patch.timezone = tz;
+    if (obj.timezone === null) patch.timezone = null;
+    else if (typeof obj.timezone !== "string") return { ok: false, error: "timezone must be a string" };
+    else {
+      const tz = obj.timezone.trim();
+      if (tz === "") patch.timezone = null;
+      else if (!isValidTimezone(tz)) return { ok: false, error: `unknown timezone: ${tz}` };
+      else patch.timezone = tz;
+    }
+  }
+  if ("personality" in obj) {
+    const result = normPersonality(obj.personality);
+    if (!result.ok) return result;
+    patch.personality = result.value;
   }
   if ("links" in obj) {
+    if (obj.links === null) {
+      patch.links = null;
+      return { ok: true, patch };
+    }
     if (!Array.isArray(obj.links)) return { ok: false, error: "links must be an array" };
     if (obj.links.length > PROFILE_LIMITS.links) {
       return { ok: false, error: `too many links (max ${PROFILE_LIMITS.links})` };
@@ -117,7 +244,17 @@ export function applyUserProfilePatch(
   current: UserProfile | undefined, patch: UserProfilePatch,
 ): UserProfile | undefined {
   const next: UserProfile = { ...(current ?? {}) };
-  for (const key of ["name", "pronouns", "bio", "timezone", "links"] as const) {
+  for (const key of [
+    "name",
+    "firstName",
+    "lastName",
+    "nickname",
+    "pronouns",
+    "bio",
+    "timezone",
+    "personality",
+    "links",
+  ] as const) {
     if (!(key in patch)) continue;
     const value = patch[key];
     if (value === null) delete next[key];
@@ -126,6 +263,16 @@ export function applyUserProfilePatch(
   return Object.keys(next).length === 0 ? undefined : next;
 }
 
+export function userFullName(profile: UserProfile | null | undefined): string {
+  return [profile?.firstName, profile?.lastName]
+    .map((value) => value?.trim() ?? "")
+    .filter(Boolean)
+    .join(" ");
+}
+
 export function userDisplayName(profile: UserProfile | null | undefined): string {
-  return profile?.name?.trim() || "You";
+  return profile?.nickname?.trim()
+    || userFullName(profile)
+    || profile?.name?.trim()
+    || "You";
 }

--- a/src/styles/settings-profile.css
+++ b/src/styles/settings-profile.css
@@ -1,0 +1,1116 @@
+.settings-profile {
+  container-type: inline-size;
+  display: grid;
+  gap: var(--space-4);
+  max-width: 96rem;
+  margin-inline: auto;
+  padding-bottom: var(--space-4);
+  color: var(--text-primary);
+}
+
+.settings-profile__hero,
+.settings-profile__preview,
+.settings-profile__notice,
+.settings-profile__actions {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-panel);
+  background: var(--bg-panel);
+}
+
+.settings-profile__hero {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3) var(--space-4);
+}
+
+.settings-profile__hero-avatar {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+  width: 3.5rem;
+  height: 3.5rem;
+  padding: 0;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-raised);
+  color: var(--accent-presence);
+  font: 500 var(--text-xl)/1 var(--font-serif);
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--ease-standard),
+    background var(--duration-fast) var(--ease-standard);
+}
+
+.settings-profile__hero-avatar:hover,
+.settings-profile__hero-avatar[aria-expanded="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 55%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, var(--bg-raised));
+}
+
+.settings-profile__hero-avatar img,
+.settings-profile__preview-avatar img,
+.settings-profile__portrait-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.settings-profile__hero-copy {
+  min-width: 0;
+  flex: 1 1 16rem;
+}
+
+.settings-profile__eyebrow,
+.settings-profile__section-heading h3,
+.settings-profile__section-heading > span:not(:nth-last-child(1)),
+.settings-profile__clock > div,
+.settings-profile__bio > header > span,
+.settings-profile__timezone-select > label,
+.settings-profile__type-picker > div > span {
+  font: 600 var(--text-2xs)/1 var(--font-mono);
+  letter-spacing: 0.12em;
+}
+
+.settings-profile__eyebrow {
+  margin: 0 0 var(--space-2);
+  color: var(--accent-presence);
+  letter-spacing: 0.16em;
+}
+
+.settings-profile__hero-copy h3 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--text-primary);
+  font: 500 var(--text-display)/1.05 var(--font-serif);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-profile__hero-name {
+  display: block;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: text;
+}
+
+.settings-profile__hero-name-input {
+  width: 100%;
+  padding-block: var(--space-1);
+  color: var(--text-primary);
+  font: 500 var(--text-display)/1.05 var(--font-serif);
+}
+
+.settings-profile__meta {
+  margin: var(--space-1) 0 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-profile__hero-status {
+  display: flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-3);
+  margin-left: auto;
+}
+
+.settings-profile__saved {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--color-success) 40%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--color-success) 14%, transparent);
+  color: var(--color-success);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.settings-profile__completion {
+  display: grid;
+  justify-items: end;
+  gap: var(--space-2);
+}
+
+.settings-profile__completion span {
+  color: var(--text-muted);
+  font: 500 var(--text-2xs)/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-profile__completion progress {
+  width: 8.25rem;
+  height: var(--space-1);
+  overflow: hidden;
+  appearance: none;
+  border: 0;
+  border-radius: var(--radius-pill);
+  background: var(--bg-sunken);
+}
+
+.settings-profile__completion progress::-webkit-progress-bar {
+  background: var(--bg-sunken);
+}
+
+.settings-profile__completion progress::-webkit-progress-value {
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+  transition: width var(--duration-base) var(--ease-standard);
+}
+
+.settings-profile__completion progress::-moz-progress-bar {
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+}
+
+.settings-profile__preview {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  border-color: color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  background: var(--bg-raised);
+}
+
+.settings-profile__preview-avatar {
+  display: inline-flex;
+  flex: none;
+  width: 5.75rem;
+  height: 5.75rem;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+  color: var(--accent-presence);
+  font: 500 var(--text-display)/1 var(--font-serif);
+}
+
+.settings-profile__preview-copy {
+  display: grid;
+  min-width: 15rem;
+  flex: 1 1 20rem;
+  gap: var(--space-2);
+}
+
+.settings-profile__preview-name {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.settings-profile__preview-name strong {
+  font: 500 var(--text-xl)/1.15 var(--font-serif);
+}
+
+.settings-profile__preview-name span,
+.settings-profile__preview-copy p {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.settings-profile__preview-copy p {
+  margin: 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+  text-wrap: pretty;
+}
+
+.settings-profile__preview-copy p.is-placeholder {
+  color: var(--text-muted);
+}
+
+.settings-profile__preview-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.settings-profile__preview-links span {
+  display: inline-flex;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-panel);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 500;
+}
+
+.settings-profile__notice {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.settings-profile__notice--danger {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.settings-profile__body {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.settings-profile__section {
+  min-width: 0;
+}
+
+.settings-profile__section-heading {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+}
+
+.settings-profile__section-heading h3 {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
+.settings-profile__section-heading > span {
+  color: var(--text-muted);
+}
+
+.settings-profile__section-heading > span:last-of-type {
+  min-width: var(--space-4);
+  height: 1px;
+  flex: 1;
+  background: var(--border-hairline);
+}
+
+.settings-profile__identity {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: stretch;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+}
+
+.settings-profile__portrait {
+  position: relative;
+  width: 5.25rem;
+  height: 5.25rem;
+  flex: none;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-raised);
+}
+
+.settings-profile__portrait-image {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  color: var(--accent-presence);
+}
+
+.settings-profile__portrait-image > span {
+  display: grid;
+  justify-items: center;
+  gap: var(--space-1);
+}
+
+.settings-profile__portrait-image strong {
+  font: 500 var(--text-display)/1 var(--font-serif);
+}
+
+.settings-profile__portrait-image small {
+  color: var(--text-muted);
+  font: 500 var(--text-2xs)/1 var(--font-mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-profile__portrait-actions {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  background: color-mix(in oklch, var(--background) 78%, transparent);
+}
+
+.settings-profile__identity-fields {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 20rem;
+  flex-direction: column;
+  justify-content: center;
+  gap: var(--space-2);
+}
+
+.settings-profile__field-title {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+  font-weight: 500;
+}
+
+.settings-profile__name-row {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(6rem, 1fr)) auto;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.settings-profile__name-row > label,
+.settings-profile__custom-pronouns {
+  min-width: 0;
+}
+
+.settings-profile__input-field {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-1);
+}
+
+.settings-profile__input-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  font-weight: 600;
+}
+
+.settings-profile__input-label small {
+  color: var(--text-muted);
+  font: inherit;
+  font-weight: 400;
+}
+
+.settings-profile__field-error {
+  color: var(--danger-text);
+  font-size: var(--text-xs);
+  line-height: 1.3;
+}
+
+.settings-profile__pronouns {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-sunken);
+}
+
+.settings-profile__pronouns button {
+  display: inline-flex;
+  min-height: 1.75rem;
+  padding: var(--space-1) var(--space-3);
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.settings-profile__pronouns button:hover {
+  color: var(--text-primary);
+}
+
+.settings-profile__pronouns button[aria-pressed="true"] {
+  background: color-mix(in oklch, var(--accent-presence) 22%, transparent);
+  color: var(--accent-presence);
+}
+
+.settings-profile__custom-pronouns {
+  grid-column: span 1;
+}
+
+.settings-profile__hint {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}
+
+.settings-profile__context {
+  display: grid;
+  grid-template-columns: minmax(14rem, 18rem) minmax(20rem, 1fr);
+  gap: var(--space-4);
+  align-items: stretch;
+  padding: var(--space-2) 0;
+}
+
+.settings-profile__clock,
+.settings-profile__bio {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+}
+
+.settings-profile__clock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+}
+
+.settings-profile__clock > div {
+  display: flex;
+  justify-content: space-between;
+  gap: var(--space-2);
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+}
+
+.settings-profile__clock > p {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-1);
+  margin: var(--space-1) 0;
+}
+
+.settings-profile__clock > p strong {
+  color: var(--accent-presence);
+  font: 500 2.5rem/1 var(--font-mono);
+  letter-spacing: -0.03em;
+}
+
+.settings-profile__clock > p span {
+  color: var(--text-muted);
+  font: 500 var(--text-md)/1 var(--font-mono);
+}
+
+.settings-profile__clock small {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: 1.4;
+}
+
+.settings-profile__bio {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-profile__bio > header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+}
+
+.settings-profile__bio-actions {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-profile__bio-actions .ui-btn {
+  white-space: nowrap;
+}
+
+.settings-profile__bio-editor {
+  position: relative;
+  padding: var(--space-3) var(--space-3) 0;
+}
+
+.settings-profile__bio-editor .ui-text-area {
+  min-height: 6.5rem;
+  padding-bottom: var(--space-6);
+}
+
+.settings-profile__bio-editor > span {
+  position: absolute;
+  right: var(--space-4);
+  bottom: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--bg-panel);
+  color: var(--text-muted);
+  font: 500 var(--text-2xs)/1 var(--font-mono);
+  pointer-events: none;
+}
+
+.settings-profile__bio-editor > span.is-over {
+  color: var(--danger-text);
+}
+
+.settings-profile__bio > footer {
+  margin-top: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid var(--border-hairline);
+  background: var(--bg-sunken);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}
+
+.settings-profile__draft-note {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-top: 1px solid color-mix(in oklch, var(--accent-presence) 32%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+}
+
+.settings-profile__draft-note span {
+  min-width: 0;
+}
+
+.settings-profile__draft-note button {
+  margin-left: auto;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-presence);
+  font: 500 var(--text-xs)/1 var(--font-sans);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.settings-profile__timezone-select {
+  display: grid;
+  grid-template-columns: auto minmax(14rem, 1fr);
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0 0;
+}
+
+.settings-profile__timezone-select > label {
+  color: var(--text-muted);
+}
+
+.settings-profile__select {
+  width: 100%;
+  min-height: 2.25rem;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-size: var(--text-base);
+}
+
+.settings-profile__select:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+}
+
+.settings-profile__select--compact {
+  min-width: 7rem;
+  min-height: 1.75rem;
+  padding-block: var(--space-1);
+  font-size: var(--text-xs);
+}
+
+.settings-profile__personality {
+  display: grid;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+}
+
+.settings-profile__personality-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settings-profile__personality-top > div:first-child {
+  display: grid;
+  flex: 0 0 9.5rem;
+  gap: var(--space-1);
+}
+
+.settings-profile__personality-top > div:first-child strong {
+  font-size: var(--text-base);
+  font-weight: 500;
+}
+
+.settings-profile__personality-top > div:first-child span {
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.settings-profile__picker-toggle,
+.settings-profile__type-summary button {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-raised);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+}
+
+.settings-profile__picker-toggle {
+  margin-left: auto;
+}
+
+.settings-profile__picker-toggle svg,
+.settings-profile__type-summary button svg {
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+
+.settings-profile__picker-toggle[aria-expanded="true"] svg,
+.settings-profile__type-summary button[aria-expanded="true"] svg {
+  transform: rotate(180deg);
+}
+
+.settings-profile__type-tiles {
+  display: flex;
+  gap: var(--space-1);
+}
+
+.settings-profile__type-tile {
+  display: flex;
+  width: 2.5rem;
+  min-height: 2.5rem;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 48%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent-presence) 18%, transparent);
+  color: var(--accent-presence);
+  cursor: pointer;
+}
+
+.settings-profile__type-tile strong {
+  font: 500 var(--text-lg)/1 var(--font-serif);
+}
+
+.settings-profile__type-tile span {
+  margin-top: var(--space-1);
+  font: 500 var(--text-2xs)/1 var(--font-mono);
+  opacity: 0.72;
+  cursor: text;
+}
+
+.settings-profile__type-tile.is-editing {
+  cursor: default;
+}
+
+.settings-profile__type-percent-input {
+  width: var(--space-8);
+  margin-top: var(--space-1);
+  padding: 0;
+  border: 0;
+  border-bottom: 1px solid currentcolor;
+  background: transparent;
+  color: currentcolor;
+  font: 500 var(--text-2xs)/1.2 var(--font-mono);
+  text-align: center;
+}
+
+.settings-profile__personality-test {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 40%, transparent);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--accent-presence);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.settings-profile__type-picker,
+.settings-profile__axes {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(9rem, 1fr));
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: var(--bg-panel);
+}
+
+.settings-profile__type-picker > div {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-2);
+}
+
+.settings-profile__type-picker > div > span {
+  color: var(--text-muted);
+  letter-spacing: 0.14em;
+}
+
+.settings-profile__type-picker > div > div {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+}
+
+.settings-profile__type-picker button {
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+  color: var(--text-muted);
+  font: 600 var(--text-xs)/1 var(--font-mono);
+  cursor: pointer;
+}
+
+.settings-profile__type-picker button:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.settings-profile__type-picker button[aria-pressed="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 50%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
+  color: var(--accent-presence);
+}
+
+.settings-profile__type-summary {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: var(--space-2);
+}
+
+.settings-profile__type-summary > strong {
+  font: 500 var(--text-lg)/1.2 var(--font-serif);
+}
+
+.settings-profile__type-summary > span {
+  min-width: 0;
+  flex: 1 1 15rem;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  text-wrap: pretty;
+}
+
+.settings-profile__type-summary button {
+  flex: none;
+  padding: var(--space-1) var(--space-3);
+  background: transparent;
+  color: var(--text-muted);
+}
+
+.settings-profile__axes {
+  grid-template-columns: repeat(2, minmax(13rem, 1fr));
+  gap: var(--space-2) var(--space-6);
+}
+
+.settings-profile__axes label {
+  display: grid;
+  grid-template-columns: 1rem minmax(3rem, 1fr) 1rem 2.25rem;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-profile__axes label > span,
+.settings-profile__axes output {
+  color: var(--text-muted);
+  font: 600 var(--text-xs)/1 var(--font-mono);
+  text-align: center;
+}
+
+.settings-profile__axes label > span.is-active {
+  color: var(--accent-presence);
+}
+
+.settings-profile__axes input {
+  width: 100%;
+  accent-color: var(--accent-presence);
+  cursor: pointer;
+}
+
+.settings-profile__axes output {
+  font-weight: 500;
+  text-align: right;
+}
+
+.settings-profile__links {
+  display: grid;
+  gap: var(--space-2);
+  padding-top: var(--space-2);
+}
+
+.settings-profile__link-row {
+  display: grid;
+  grid-template-columns: 2.25rem 9.75rem minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-profile__link-mark {
+  display: inline-flex;
+  width: 2.25rem;
+  height: 2.25rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 42%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--accent-presence);
+  font: 600 var(--text-xs)/1 var(--font-mono);
+}
+
+.settings-profile__link-mark.is-invalid {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger-text);
+}
+
+.settings-profile__preset-link {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-profile__preset-link > span {
+  flex: none;
+  color: var(--text-muted);
+  font: 500 var(--text-sm)/1 var(--font-mono);
+}
+
+.settings-profile__preset-link .ui-text-input {
+  min-width: 0;
+}
+
+.settings-profile__custom-link {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(7rem, 0.35fr) minmax(10rem, 1fr);
+  gap: var(--space-2);
+}
+
+.settings-profile__link-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-1);
+}
+
+.settings-profile__links-empty {
+  margin: 0;
+  padding: var(--space-4) var(--space-3);
+  border: 1px dashed var(--border-hairline);
+  border-radius: var(--radius-control);
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.settings-profile__actions {
+  position: sticky;
+  z-index: 3;
+  bottom: var(--space-2);
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  box-shadow: var(--shadow-popover);
+}
+
+.settings-profile__shortcut,
+.settings-profile__action-meta {
+  overflow: hidden;
+  color: var(--text-muted);
+  font: 400 var(--text-xs)/1 var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.settings-profile__action-meta {
+  min-width: 0;
+}
+
+.settings-profile__save-state {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-size: var(--text-base);
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.settings-profile__save-state.is-dirty {
+  color: var(--text-primary);
+}
+
+.settings-profile__actions > div {
+  display: flex;
+  flex: none;
+  gap: var(--space-2);
+}
+
+.settings-profile__card-link {
+  display: inline-flex;
+  width: max-content;
+  align-items: center;
+  gap: var(--space-1);
+  border-radius: var(--radius-control);
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+  text-decoration: none;
+}
+
+.settings-profile__card-link:hover {
+  color: var(--accent-presence);
+}
+
+@container (max-width: 56rem) {
+  .settings-profile__name-row {
+    grid-template-columns: repeat(2, minmax(6rem, 1fr));
+  }
+
+  .settings-profile__context {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-profile__clock {
+    min-height: 10rem;
+  }
+
+  .settings-profile__type-picker {
+    grid-template-columns: repeat(2, minmax(9rem, 1fr));
+  }
+
+  .settings-profile__link-row {
+    grid-template-columns: 2.25rem minmax(8rem, 0.4fr) minmax(0, 1fr) auto;
+  }
+}
+
+@container (max-width: 38rem) {
+  .settings-profile__hero-status {
+    width: 100%;
+    margin-left: 4.5rem;
+  }
+
+  .settings-profile__name-row,
+  .settings-profile__type-picker,
+  .settings-profile__axes {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-profile__pronouns,
+  .settings-profile__custom-pronouns {
+    width: 100%;
+  }
+
+  .settings-profile__timezone-select {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-profile__personality-top > div:first-child {
+    flex-basis: 100%;
+  }
+
+  .settings-profile__picker-toggle {
+    margin-left: 0;
+  }
+
+  .settings-profile__link-row {
+    grid-template-columns: 2.25rem minmax(0, 1fr) auto;
+    padding: var(--space-2) 0;
+    border-bottom: 1px solid var(--border-hairline);
+  }
+
+  .settings-profile__link-row > :nth-child(3) {
+    grid-column: 1 / -1;
+    grid-row: 2;
+  }
+
+  .settings-profile__link-actions {
+    grid-column: 3;
+    grid-row: 1;
+  }
+
+  .settings-profile__custom-link {
+    grid-template-columns: 1fr;
+  }
+
+  .settings-profile__shortcut,
+  .settings-profile__action-meta {
+    display: none;
+  }
+
+  .settings-profile__save-state {
+    margin-left: 0;
+    margin-right: auto;
+  }
+}
+
+@media (hover: none) {
+  .settings-profile__portrait {
+    width: 100%;
+    height: auto;
+    min-height: 5.25rem;
+    padding-right: 10rem;
+  }
+
+  .settings-profile__portrait-image {
+    width: 5.25rem;
+    height: 5.25rem;
+  }
+
+  .settings-profile__portrait-actions {
+    left: auto;
+    width: 10rem;
+    flex-direction: row;
+    background: transparent;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .settings-profile__hero-avatar,
+  .settings-profile__completion progress::-webkit-progress-value,
+  .settings-profile__picker-toggle svg,
+  .settings-profile__type-summary button svg {
+    transition: none;
+  }
+}


### PR DESCRIPTION
## Summary

- rebuild Settings → Profile as the ZIP handoff’s control sheet, with structured identity, timezone, personality tuning, bio drafting, links, completion state, and live preview
- persist the structured profile through the existing profile API and expose it consistently in operator context and profile-card surfaces
- keep the surface responsive, tokenized, searchable, accessible, and routed through Cave Browser for external destinations

## Review hardening

- preserve custom labels for known social URLs and compact blank link rows after save
- keep oversized structured names out of the capped legacy name field
- add stable search anchors, persistent labels, described invalid-link errors, and accurate timezone copy
- surface familiar roster failures with retry instead of swallowing them

## Source handoff

Implemented from `settings-profile-redesign-handoff.zip` (SHA-256 `40ce4ea5b3e9bb17f99eef825357e609ae8d5cccf857765b6db4e3ad275557c3`).

## Verification

- 8 focused profile test files
- `pnpm check:tests-wired` — 1,262 files wired, 1 allowlisted
- `pnpm typecheck`
- `pnpm lint` — zero design-token drift
- `pnpm test:app` — 915 files passed before final conflict-free rebase; focused coverage rerun after rebase
- `pnpm build` — production build and bundle/standalone budgets passed
- `PORT=3001 bash scripts/dev-app.sh` — native Tauri startup confirmed; standard and narrow profile layouts smoke-tested without saving

Bead: `cave-ajli6`