### PR TITLE
fix(settings): fill About podcast bento row

### DIFF
--- a/docs/superpowers/specs/2026-07-26-settings-about-podcast-bento-design.md
+++ b/docs/superpowers/specs/2026-07-26-settings-about-podcast-bento-design.md
@@ -1,0 +1,63 @@
+# Settings About Podcast Bento Remainder-Fill Design
+
+## Goal
+
+Make the Open Coven Weekly podcast card consume the unused remainder of its
+About-page bento row while preserving the existing card order, content,
+interaction, artwork, and design tokens.
+
+## Current Problem
+
+The About links bento uses four columns by default and two columns below the
+`55rem` container breakpoint. The Discord card occupies one column, while the
+podcast card always spans two:
+
+- in the four-column layout, one column remains empty beside the podcast;
+- in the two-column layout, the podcast cannot fit beside Discord and wraps to
+  a new full-width row.
+
+The existing one-column layout below `36rem` is already correct.
+
+## Chosen Approach
+
+Use breakpoint-aware column spans on the existing podcast card:
+
+- default four-column grid: podcast spans three columns;
+- two-column grid at or below `55rem`: podcast spans one column;
+- one-column grid at or below `36rem`: podcast remains one column.
+
+This lets normal grid auto-placement pair Discord and the podcast without
+hard-coding a start line or changing DOM order.
+
+Rejected alternatives:
+
+- `grid-column: 2 / -1` couples the podcast to Discord's exact placement and
+  needs extra breakpoint overrides.
+- Explicit grid-template areas restructure the whole bento for a one-card
+  geometry correction and add unnecessary maintenance.
+
+## Visual and Interaction Contract
+
+- Desktop: Discord occupies one quarter of the row and the podcast fills the
+  remaining three quarters.
+- Intermediate: Discord and the podcast share one row at equal width.
+- Mobile: the podcast remains full width.
+- Card copy, artwork, click target, focus treatment, hover motion, release
+  rail, and all theme behavior remain unchanged.
+- The grid must not create implicit columns or horizontal overflow.
+
+## Testing
+
+- Add a focused source-contract assertion for the default three-column span
+  and the `55rem` one-column override before changing the stylesheet.
+- Run the focused About component test and the relevant design gates.
+- Render the About surface at representative four-, two-, and one-column
+  widths in light and dark modes.
+- Confirm the podcast fills the intended remainder and no horizontal overflow
+  appears.
+
+## Exclusions
+
+- No markup, copy, navigation, or external-link changes.
+- No changes to any other About card's placement or styling.
+- No new design tokens, breakpoints, or shared grid abstractions.

--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -96,6 +96,30 @@ test("About follows the revised handoff artwork and full-width release rail", ()
   );
 });
 
+test("About podcast fills the default four-column row remainder", () => {
+  const defaultCss =
+    css.split("@container settings-about (max-width: 55rem)")[0] ?? "";
+
+  assert.match(
+    defaultCss,
+    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 3;/,
+  );
+});
+
+test("About podcast shares the intermediate two-column row", () => {
+  const [, afterIntermediateStart = ""] = css.split(
+    "@container settings-about (max-width: 55rem)",
+  );
+  const [intermediateCss = ""] = afterIntermediateStart.split(
+    "@container settings-about (max-width: 36rem)",
+  );
+
+  assert.match(
+    intermediateCss,
+    /\.settings-about-link-card--podcast\s*\{[^}]*grid-column:\s*span 1;/,
+  );
+});
+
 test("About CSS follows the token, focus, motion, and narrow-pane contracts", () => {
   assert.match(css, /\.settings-about\s*\{[\s\S]*container-type:\s*inline-size/);
   assert.match(css, /\.settings-about-control-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(2/);

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -548,7 +548,7 @@
 }
 
 .settings-about-link-card--podcast {
-  grid-column: span 2;
+  grid-column: span 3;
   flex-direction: row;
   align-items: center;
   gap: var(--space-3);
@@ -663,6 +663,10 @@
 
   .settings-about-links-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .settings-about-link-card--podcast {
+    grid-column: span 1;
   }
 }
 


### PR DESCRIPTION
## Summary
- let the Podcast card fill the remaining three columns in the default About link grid
- return it to one column at the intermediate two-column container breakpoint
- preserve the existing one-column narrow layout, release rail, copy, actions, and design tokens

Bead: `cave-xfznz`

## Verification
- `node src/components/settings-about.test.ts` — 9/9
- `node --experimental-strip-types src/lib/design-token-drift.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` — 918/918 test files
- `git diff --check origin/main...HEAD`
- rendered responsive geometry at 1440px / 900px / 520px — 4 / 2 / 1 tracks, no clipping or horizontal overflow

## Review
- final whole-diff review: no Critical, Important, or Minor findings
- Copilot reviewed 3/3 changed files and opened no conversations