### PR TITLE
feat(projects): support typed and hidden-folder selection

### DIFF
--- a/src-tauri/src/shell_open_commands.rs
+++ b/src-tauri/src/shell_open_commands.rs
@@ -76,7 +76,7 @@ pub(super) fn shell_pick_directory() -> Result<Option<String>, String> {
                 "-e",
                 "tell application \"System Events\" to activate",
                 "-e",
-                "POSIX path of (choose folder with prompt \"Choose a folder for CovenCave\")",
+                "POSIX path of (choose folder with prompt \"Choose a folder for CovenCave\" invisibles true)",
             ])
             .output()
             .map_err(|e| e.to_string())?;
@@ -93,12 +93,112 @@ pub(super) fn shell_pick_directory() -> Result<Option<String>, String> {
 
     #[cfg(target_os = "windows")]
     {
-        // A bare FolderBrowserDialog has no owner window, so Windows opens it
-        // *behind* every other window, unfocused, with no taskbar entry — it
-        // looks like the click did nothing (issue #2614b). Give it a TopMost,
-        // ShowInTaskbar owner form (created off-screen) and pass that form as
-        // the ShowDialog owner so the picker is summoned to the foreground.
-        let script = r#"Add-Type -AssemblyName System.Windows.Forms; $owner = New-Object System.Windows.Forms.Form; $owner.TopMost = $true; $owner.ShowInTaskbar = $false; $owner.StartPosition = 'Manual'; $owner.Location = New-Object System.Drawing.Point(-32000, -32000); $owner.Size = New-Object System.Drawing.Size(1, 1); $owner.Show(); $owner.Activate(); $d = New-Object System.Windows.Forms.FolderBrowserDialog; $d.Description = 'Choose a folder for CovenCave'; $result = $d.ShowDialog($owner); $owner.Close(); if ($result -eq [System.Windows.Forms.DialogResult]::OK) { [Console]::Write($d.SelectedPath) }"#;
+        // Windows PowerShell's .NET Framework FolderBrowserDialog cannot force
+        // hidden items visible, so use IFileOpenDialog with FOS_FORCESHOWHIDDEN.
+        // Give it a TopMost, off-screen owner form so the picker is summoned to
+        // the foreground instead of opening behind Cave (issue #2614b).
+        let script = r#"
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+
+[ComImport]
+[Guid("DC1C5A9C-E88A-4DDE-A5A1-60F82A20AEF7")]
+internal class FileOpenDialogCom {}
+
+[ComImport]
+[Guid("42F85136-DB7E-439C-85F1-E4075D135FC8")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IFileDialog
+{
+    [PreserveSig]
+    int Show(IntPtr owner);
+    void SetFileTypes(uint count, IntPtr filterSpec);
+    void SetFileTypeIndex(uint index);
+    void GetFileTypeIndex(out uint index);
+    void Advise(IntPtr events, out uint cookie);
+    void Unadvise(uint cookie);
+    void SetOptions(uint options);
+    void GetOptions(out uint options);
+    void SetDefaultFolder(IShellItem item);
+    void SetFolder(IShellItem item);
+    void GetFolder(out IShellItem item);
+    void GetCurrentSelection(out IShellItem item);
+    void SetFileName([MarshalAs(UnmanagedType.LPWStr)] string name);
+    void GetFileName([MarshalAs(UnmanagedType.LPWStr)] out string name);
+    void SetTitle([MarshalAs(UnmanagedType.LPWStr)] string title);
+    void SetOkButtonLabel([MarshalAs(UnmanagedType.LPWStr)] string text);
+    void SetFileNameLabel([MarshalAs(UnmanagedType.LPWStr)] string label);
+    void GetResult(out IShellItem item);
+}
+
+[ComImport]
+[Guid("43826D1E-E718-42EE-BC55-A1E261C37BFE")]
+[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+internal interface IShellItem
+{
+    void BindToHandler(IntPtr bindingContext, ref Guid handler, ref Guid interfaceId, out IntPtr result);
+    void GetParent(out IShellItem parent);
+    void GetDisplayName(uint displayName, out IntPtr name);
+    void GetAttributes(uint mask, out uint attributes);
+    void Compare(IShellItem item, uint hint, out int order);
+}
+
+public static class CovenFolderPicker
+{
+    private const uint FOS_PICKFOLDERS = 0x00000020;
+    private const uint FOS_FORCEFILESYSTEM = 0x00000040;
+    private const uint FOS_FORCESHOWHIDDEN = 0x10000000;
+    private const uint SIGDN_FILESYSPATH = 0x80058000;
+    private const int ERROR_CANCELLED = unchecked((int)0x800704C7);
+
+    public static string Pick(IntPtr owner)
+    {
+        IFileDialog dialog = null;
+        IShellItem item = null;
+        IntPtr path = IntPtr.Zero;
+        try
+        {
+            dialog = (IFileDialog)new FileOpenDialogCom();
+            uint options;
+            dialog.GetOptions(out options);
+            dialog.SetOptions(options | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM | FOS_FORCESHOWHIDDEN);
+            dialog.SetTitle("Choose a folder for CovenCave");
+
+            int result = dialog.Show(owner);
+            if (result == ERROR_CANCELLED) return null;
+            Marshal.ThrowExceptionForHR(result);
+
+            dialog.GetResult(out item);
+            item.GetDisplayName(SIGDN_FILESYSPATH, out path);
+            return Marshal.PtrToStringUni(path);
+        }
+        finally
+        {
+            if (path != IntPtr.Zero) Marshal.FreeCoTaskMem(path);
+            if (item != null) Marshal.FinalReleaseComObject(item);
+            if (dialog != null) Marshal.FinalReleaseComObject(dialog);
+        }
+    }
+}
+'@
+
+$owner = New-Object System.Windows.Forms.Form
+$owner.TopMost = $true
+$owner.ShowInTaskbar = $false
+$owner.StartPosition = 'Manual'
+$owner.Location = New-Object System.Drawing.Point(-32000, -32000)
+$owner.Size = New-Object System.Drawing.Size(1, 1)
+$owner.Show()
+$owner.Activate()
+try {
+    $selected = [CovenFolderPicker]::Pick($owner.Handle)
+    if ($null -ne $selected) { [Console]::Write($selected) }
+} finally {
+    $owner.Close()
+}
+"#;
         let output = std::process::Command::new("powershell.exe")
             .args(["-NoProfile", "-Sta", "-Command", script])
             .output()
@@ -120,6 +220,7 @@ pub(super) fn shell_pick_directory() -> Result<Option<String>, String> {
             .args([
                 "--file-selection",
                 "--directory",
+                "--show-hidden",
                 "--modal",
                 "--title",
                 "Choose a folder for CovenCave",

--- a/src-tauri/src/shell_open_tests.rs
+++ b/src-tauri/src/shell_open_tests.rs
@@ -53,10 +53,11 @@ fn normalizes_only_absolute_existing_picked_directories() {
 #[test]
 fn folder_picker_is_summoned_to_the_foreground() {
     let src = include_str!("shell_open_commands.rs");
-    // Windows: the FolderBrowserDialog gets a TopMost owner form passed to
-    // ShowDialog so it can't open buried/unfocused.
+    // Windows: IFileOpenDialog gets a TopMost owner form handle so it cannot
+    // open buried or unfocused.
     assert!(
-        src.contains("$owner.TopMost = $true") && src.contains("$d.ShowDialog($owner)"),
+        src.contains("$owner.TopMost = $true")
+            && src.contains("[CovenFolderPicker]::Pick($owner.Handle)"),
         "the Windows folder picker must own its dialog with a TopMost form (foreground)",
     );
     // macOS: activate before `choose folder` so it comes to the front.
@@ -68,5 +69,26 @@ fn folder_picker_is_summoned_to_the_foreground() {
     assert!(
         src.contains("--file-selection") && src.contains("--modal"),
         "the Linux (zenity) folder picker must run modal",
+    );
+}
+
+#[test]
+fn folder_picker_shows_hidden_directories() {
+    let src = include_str!("shell_open_commands.rs");
+    assert!(
+        src.contains("invisibles true"),
+        "the macOS folder picker must show dot-prefixed directories",
+    );
+    assert!(
+        src.contains("--show-hidden"),
+        "the Linux (zenity) folder picker must show dot-prefixed directories",
+    );
+    assert!(
+        src.contains("FOS_FORCESHOWHIDDEN"),
+        "the Windows folder picker must request hidden directories from IFileOpenDialog",
+    );
+    assert!(
+        !src.contains("$d.ShowHiddenFiles"),
+        "Windows PowerShell uses .NET Framework, whose FolderBrowserDialog lacks ShowHiddenFiles",
     );
 }

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -25,7 +25,22 @@ assert.match(src, /DirectoryPickerModal/, "web fallback directory browser");
 assert.match(src, /export function ProjectPicker\(/, "picker exported");
 assert.match(src, /onChange\(NO_PROJECT_ID\);/, "explicit No-project row");
 assert.match(src, /Add project…/, "proactive add affordance (not 403-recovery-only)");
-assert.match(src, /aria-label="Filter projects"/, "filter input for long lists");
+assert.match(src, /aria-label="Filter projects"/, "typed project-name input is always available");
+assert.doesNotMatch(
+  src,
+  /projects\.length > 6 \? \([\s\S]*?aria-label="Filter projects"/,
+  "small project lists must not hide manual name entry",
+);
+assert.match(
+  src,
+  /projectForPickerQuery\(sortedProjects, query\)/,
+  "Enter resolves through the shared exact-name-first matcher",
+);
+assert.match(
+  src,
+  /event\.key !== "Enter"[\s\S]*?event\.preventDefault\(\);[\s\S]*?onChange\(match\.id\);[\s\S]*?close\(\);/,
+  "Enter selects the typed match and closes the picker",
+);
 assert.match(src, /aria-haspopup="dialog"/, "trigger announces the popover");
 assert.match(src, /role="alert"/, "add-flow failures surface inline, not silently");
 assert.match(src, /sortProjectsAlphabetically\(projects\)/, "picker renders projects alphabetically");

--- a/src/components/project-picker.tsx
+++ b/src/components/project-picker.tsx
@@ -14,7 +14,11 @@ import { DirectoryPickerModal } from "@/components/directory-picker-modal";
 import { ProjectAvatar } from "@/components/project-avatar";
 import { addChatProject, type CreateProjectOptions } from "@/lib/chat-add-project";
 import { NO_PROJECT_ID } from "@/lib/chat-projects";
-import { sortProjectsAlphabetically, type CaveProject } from "@/lib/cave-projects-types";
+import {
+  projectForPickerQuery,
+  sortProjectsAlphabetically,
+  type CaveProject,
+} from "@/lib/cave-projects-types";
 import { projectAccessLabel } from "@/lib/project-access-levels";
 import { isTauri } from "@/lib/tauri-platform";
 
@@ -191,16 +195,22 @@ export function ProjectPickerPopover({
       ariaLabel={ariaLabel}
     >
       <PopoverBody>
-        {projects.length > 6 ? (
-          <input
-            type="text"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Filter projects…"
-            aria-label="Filter projects"
-            className="cave-project-picker__filter focus-ring-inset"
-          />
-        ) : null}
+        <input
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key !== "Enter" || event.nativeEvent.isComposing) return;
+            event.preventDefault();
+            const match = projectForPickerQuery(sortedProjects, query);
+            if (!match) return;
+            onChange(match.id);
+            close();
+          }}
+          placeholder="Filter projects…"
+          aria-label="Filter projects"
+          className="cave-project-picker__filter focus-ring-inset"
+        />
         <PopoverLabel>Project</PopoverLabel>
         {allowNoProject ? (
           <PopoverItem

--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -65,3 +65,27 @@ export function dedupeProjectsByRoot(
 export function sortProjectsAlphabetically(projects: CaveProject[]): CaveProject[] {
   return dedupeProjectsByRoot(projects).sort(compareProjectsAlphabetically);
 }
+
+/**
+ * Resolve a manually typed picker query to one project. Exact project names
+ * win; otherwise the first alphabetized name/root match mirrors the visible
+ * picker order. Blank or unmatched queries select nothing.
+ */
+export function projectForPickerQuery(
+  projects: CaveProject[],
+  query: string,
+): CaveProject | null {
+  const normalizedQuery = query.trim().toLowerCase();
+  if (!normalizedQuery) return null;
+
+  const visible = sortProjectsAlphabetically(projects).filter(
+    (project) =>
+      project.name.toLowerCase().includes(normalizedQuery) ||
+      project.root.toLowerCase().includes(normalizedQuery),
+  );
+  return (
+    visible.find((project) => project.name.trim().toLowerCase() === normalizedQuery) ??
+    visible[0] ??
+    null
+  );
+}

--- a/src/lib/cave-projects.test.ts
+++ b/src/lib/cave-projects.test.ts
@@ -19,6 +19,7 @@ try {
     seedDefaultProjectsIfEmpty,
     sortProjectsAlphabetically,
   } = await import("./cave-projects.ts");
+  const { projectForPickerQuery } = await import("./cave-projects-types.ts");
   const source = await readFile(new URL("./cave-projects.ts", import.meta.url), "utf8");
 
   assert.equal(
@@ -253,6 +254,28 @@ try {
     ["new", "solo", "z"],
     "shared project sorting deduplicates by normalized root before alphabetical order",
   );
+
+  assert.equal(
+    typeof projectForPickerQuery,
+    "function",
+    "the shared picker exposes a pure typed-query resolver",
+  );
+  const pickerProjects = [
+    { id: "partial", name: "Alpha Coven tools", root: "/work/alpha", createdAt: "", updatedAt: "" },
+    { id: "exact", name: "Coven", root: "/work/coven", createdAt: "", updatedAt: "" },
+    { id: "root", name: "Toolkit", root: "/work/coven-runtime", createdAt: "", updatedAt: "" },
+  ];
+  assert.equal(
+    projectForPickerQuery(pickerProjects, "  COVEN  ")?.id,
+    "exact",
+    "an exact project-name match wins over an alphabetically earlier partial match",
+  );
+  assert.equal(
+    projectForPickerQuery(pickerProjects, "coven-r")?.id,
+    "root",
+    "typed queries retain the picker's existing root matching",
+  );
+  assert.equal(projectForPickerQuery(pickerProjects, "   "), null, "blank input selects nothing");
 
   console.log("cave-projects.test.ts: ok");
 } finally {

--- a/src/lib/server/home-browse.test.ts
+++ b/src/lib/server/home-browse.test.ts
@@ -7,6 +7,7 @@ import {
   createSubdirInBrowsableDir,
   createSubdirWithinRoot,
   homeRoot,
+  listSubdirs,
   listSystemRoots,
   resolveBrowsableDir,
   resolveWithinRoot,
@@ -212,5 +213,23 @@ test("createSubdirInBrowsableDir creates beneath absolute parents via their volu
       ok: false,
       reason: "invalid-parent",
     });
+  });
+});
+
+test("listSubdirs exposes dot folders while retaining non-dot noise filtering", () => {
+  withScratchDir((base) => {
+    for (const name of [".git", ".next", "visible", "node_modules", "dist"]) {
+      fs.mkdirSync(path.join(base, name));
+    }
+    fs.writeFileSync(path.join(base, ".env"), "not a directory");
+
+    const names = listSubdirs(base).map((entry) => entry.name);
+
+    assert.ok(names.includes(".git"), "ordinary dot folders are visible");
+    assert.ok(names.includes(".next"), "dot-prefixed build folders are visible too");
+    assert.ok(names.includes("visible"), "ordinary folders remain visible");
+    assert.ok(!names.includes("node_modules"), "non-dot dependency noise stays hidden");
+    assert.ok(!names.includes("dist"), "non-dot build noise stays hidden");
+    assert.ok(!names.includes(".env"), "files are never returned as folders");
   });
 });

--- a/src/lib/server/home-browse.ts
+++ b/src/lib/server/home-browse.ts
@@ -2,11 +2,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { homedir } from "node:os";
 
-// Build-artifact / noise directories the folder browser hides. Dotfiles are
-// hidden separately (Finder-style), so a picker over $HOME stays readable.
+// Non-dot build-artifact / noise directories the folder browser hides. Dot
+// folders stay visible because they may themselves be intentional project
+// roots (for example, a configuration repository).
 const SKIP = new Set([
   "node_modules",
-  ".next",
   "dist",
   "build",
   "target",
@@ -202,7 +202,7 @@ export function createSubdirInBrowsableDir(
   return createSubdirWithinRoot(root, raw, requestedName);
 }
 
-/** Immediate visible subdirectories of `dir` (one level), sorted, noise-skipped. */
+/** Immediate subdirectories of `dir` (one level), sorted and noise-skipped. */
 export function listSubdirs(dir: string): DirEntry[] {
   let dirents: fs.Dirent[];
   try {
@@ -211,7 +211,7 @@ export function listSubdirs(dir: string): DirEntry[] {
     return [];
   }
   return dirents
-    .filter((d) => d.isDirectory() && !d.name.startsWith(".") && !SKIP.has(d.name))
+    .filter((d) => d.isDirectory() && !SKIP.has(d.name))
     .map((d) => ({ name: d.name, path: path.join(dir, d.name) }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }


### PR DESCRIPTION
## Summary

- show dot-prefixed directories in home browsing and native folder pickers
- let an exact typed project name be selected even when it is not in the filtered suggestion set
- preserve existing project-access labels while reconciling the picker with current `main`
- cover browser, picker, project-model, and native shell behavior with focused tests

## Why

Project selection could not reach hidden folders, and the combobox only accepted visible suggestion rows. That blocked valid local project paths and made typed selection appear available without actually being actionable.

## Verification

- `pnpm test:app` — 921 test files passed
- `pnpm build`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,268 tests wired; 1 allowlisted
- focused project/home browser tests
- `cargo test --no-default-features shell_open_tests` — 8 passed
- `cargo check --no-default-features`
- Rust formatting, PowerShell syntax, and embedded C# compilation checks
- `git diff --check origin/main...HEAD`

Bead: `cave-vwu7u`