### PR TITLE
fix(shell): stabilize first paint hydration

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -417,6 +417,7 @@ export const SUITES = {
     "src/components/recent-activity-rollup.test.ts",
     "src/components/sidebar-familiar-filter.test.ts",
     "src/components/shell-edge-rails.test.ts",
+    "src/components/shell-first-paint.test.ts",
     "src/components/shell-left-panels-fit.test.ts",
     "src/components/shell-nav-memory.test.ts",
     "src/components/workflows-view.test.ts",

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -556,8 +556,13 @@ assert.doesNotMatch(
 // these pins hold the call sites, the hook test holds the semantics.
 assert.match(
   source,
-  /const \[text, setText\] = useState\(\(\) => readComposerDraft\(HOME_DRAFT_KEY\)\)/,
-  "home composer text initialises from the persisted draft",
+  /const \[text, setText\] = useState\(""\);[\s\S]{0,260}?const \[draftRestored, setDraftRestored\] = useState\(false\);[\s\S]{0,260}?useLayoutEffect\(\(\) => \{\s*setText\(readComposerDraft\(HOME_DRAFT_KEY\)\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
+  "home composer restores the persisted draft before paint from an SSR-stable empty snapshot",
+);
+assert.match(
+  source,
+  /<textarea[\s\S]{0,420}?readOnly=\{!draftRestored\}/,
+  "the SSR textarea stays read-only until draft restoration so pre-hydration input cannot be overwritten",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -14,6 +14,7 @@ import {
   type KeyboardEvent,
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -135,7 +136,14 @@ export function HomeComposer({
   onOpenSession,
   onStartVoiceCall,
 }: Props) {
-  const [text, setText] = useState(() => readComposerDraft(HOME_DRAFT_KEY));
+  // Hydrate from the same empty draft SSR emitted, then restore local storage
+  // before paint so textarea and Send-button state update in one React commit.
+  const [text, setText] = useState("");
+  const [draftRestored, setDraftRestored] = useState(false);
+  useLayoutEffect(() => {
+    setText(readComposerDraft(HOME_DRAFT_KEY));
+    setDraftRestored(true);
+  }, []);
   const [destination, setDestination] = useState<Destination>("chat");
   const [sending, setSending] = useState(false);
   // In-flight guard for the voice-call mint: onStartVoiceCall is an async
@@ -932,6 +940,7 @@ export function HomeComposer({
           placeholder={PLACEHOLDERS[destination]}
           rows={1}
           value={text}
+          readOnly={!draftRestored}
           onChange={(e) => setText(e.target.value)}
           onPaste={handlePaste}
           onKeyDown={handleKeyDown}

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -53,6 +53,31 @@ assert.match(
   /Those tabs live in normal shell flow[\s\S]{0,220}\.shell-detail\s*\{[\s\S]{0,80}padding-bottom:\s*0;/,
   "Mobile shell detail should not reserve extra space above bottom tabs",
 );
+assert.match(
+  shell,
+  /const navToggle = \(/,
+  "desktop nav toggle should stay in hydration-stable markup and defer viewport visibility to CSS",
+);
+assert.match(
+  shell,
+  /const historyNav = historyNavigation \? \(/,
+  "desktop history controls should stay in hydration-stable markup and defer viewport visibility to CSS",
+);
+assert.match(
+  shell,
+  /\{mobileTabs \?\? null\}/,
+  "mobile bottom tabs should stay in hydration-stable markup on the first render",
+);
+assert.match(
+  globals,
+  /\.mobile-bottom-tabs\s*\{[\s\S]{0,220}?display:\s*none;/,
+  "mobile bottom tabs should be hidden by default on desktop",
+);
+assert.match(
+  globals,
+  /@media \(max-width: 1023px\)\s*\{[\s\S]{0,420}?\.shell-top > \.shell-top-toggle--nav,[\s\S]{0,120}?\.shell-top > \.shell-top-history\s*\{[\s\S]{0,80}?display:\s*none;[\s\S]{0,420}?\.mobile-bottom-tabs\s*\{[\s\S]{0,80}?display:\s*flex;/,
+  "mobile media queries should swap desktop title-bar controls for bottom tabs before hydration",
+);
 
 assert.match(
   mobileTabs,

--- a/src/components/shell-edge-rails.test.ts
+++ b/src/components/shell-edge-rails.test.ts
@@ -31,11 +31,12 @@ assert.doesNotMatch(
 );
 
 // The panel toggles are hoisted into the top bar (a flex row wrapping the
-// rendered top bar), desktop-only — they're built only when !isMobile.
+// rendered top bar). They remain in hydration-stable markup and CSS hides them
+// below the desktop breakpoint.
 assert.match(
   shell,
-  /const navToggle = !isMobile/,
-  "shell builds the nav toggle on desktop only",
+  /const navToggle = \(/,
+  "shell keeps the nav toggle in hydration-stable markup",
 );
 assert.match(
   shell,
@@ -52,8 +53,8 @@ assert.match(
 // explicit remote-scoped grant; without it start_dragging is silently denied).
 assert.equal(
   shell.match(/<div className="shell-top" data-tauri-drag-region="deep">/g)?.length,
-  2,
-  "both shell top bars (placeholder + desktop) should expose the deep Tauri drag region on the titlebar container",
+  1,
+  "the hydration-stable shell should expose one deep Tauri drag region on the titlebar container",
 );
 assert.doesNotMatch(
   shell,
@@ -62,8 +63,8 @@ assert.doesNotMatch(
 );
 assert.equal(
   shell.match(/<div className="shell-top__bar" data-tauri-drag-region="deep">/g)?.length,
-  2,
-  "both rendered top-bar wrappers should remain draggable when their empty chrome is clicked",
+  1,
+  "the hydration-stable top-bar wrapper should remain draggable when its empty chrome is clicked",
 );
 assert.match(
   shell,

--- a/src/components/shell-first-paint.test.ts
+++ b/src/components/shell-first-paint.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const shell = await readFile(new URL("./shell.tsx", import.meta.url), "utf8");
+const homeComposer = await readFile(new URL("./home-composer.tsx", import.meta.url), "utf8");
+
+assert.doesNotMatch(
+  shell,
+  /if \(!mounted\) \{[\s\S]{0,700}?<div className="shell-root flex-1 min-h-0" \/>/,
+  "Shell must not paint an empty content root while waiting for a passive mount effect",
+);
+
+assert.match(
+  shell,
+  /<div className="shell-body flex flex-1 min-h-0">[\s\S]{0,900}?\b(?:horizontalGroup|<Group)\b/,
+  "the first shell render must include the real panel group",
+);
+
+assert.match(
+  shell,
+  /const layoutStorage = mounted \? shellStorage : hydrationShellStorage/,
+  "the first client render must use the same inert layout-storage snapshot as SSR",
+);
+
+assert.match(
+  shell,
+  /useDefaultLayout\(\{[\s\S]{0,180}?storage: layoutStorage/,
+  "persisted panel layout reads must begin only after hydration",
+);
+
+assert.match(
+  shell,
+  /useLayoutEffect\(\(\) => setMounted\(true\), \[\]\)/,
+  "the client must restore the live shell before its first post-hydration paint",
+);
+
+assert.match(
+  shell,
+  /const \[navOpen, setNavOpen\] = useState\(chatContextual\)/,
+  "the server and first client render must share the collapsed default for non-contextual navigation",
+);
+
+assert.match(
+  shell,
+  /const defaultNavSize = chatContextual\s*\? "260px"\s*: mounted\s*\? `\$\{NAV_OPEN_PX\}px`\s*: `\$\{NAV_RAIL_PX\}px`/,
+  "the first non-contextual panel paint must use the collapsed rail width",
+);
+
+assert.match(
+  shell,
+  /<Panel[\s\S]{0,240}?id="nav"[\s\S]{0,320}?defaultSize=\{defaultNavSize\}/,
+  "the nav panel must consume the hydration-stable first-paint size",
+);
+
+assert.match(
+  homeComposer,
+  /const \[text, setText\] = useState\(""\)/,
+  "HomeComposer must hydrate from the same empty draft snapshot emitted by SSR",
+);
+
+assert.match(
+  homeComposer,
+  /useLayoutEffect\(\(\) => \{\s*setText\(readComposerDraft\(HOME_DRAFT_KEY\)\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
+  "HomeComposer must restore a persisted draft before paint without hydrating mismatched controls",
+);
+
+console.log("shell-first-paint.test.ts OK");

--- a/src/components/shell-left-panels-fit.test.ts
+++ b/src/components/shell-left-panels-fit.test.ts
@@ -8,11 +8,17 @@ const foundations = await readFile(new URL("../styles/globals/foundations.css", 
 // The left panels are PIXEL-sized so they stop scaling with monitor width —
 // a 24%-wide nav is 826px on a 3440px ultrawide for a ~240px rail of labels.
 // The detail panel has no size props and absorbs everything the left releases.
-// Normal navigation keeps its 240px default, while Chat's contextual sidebar
-// gets the wider list-like sizing it needs for workspace/session content.
+// Normal navigation hydrates at its 56px rail, then restores its 240px expanded
+// size before paint. Chat's contextual sidebar keeps the wider list-like sizing
+// it needs for workspace/session content.
 assert.match(
   shell,
-  /id="nav"[\s\S]{0,700}?defaultSize=\{chatContextual \? "260px" : "240px"\}[\s\S]{0,120}?minSize=\{chatContextual \? "220px" : "200px"\}[\s\S]{0,60}?maxSize="420px"/,
+  /const defaultNavSize = chatContextual\s*\? "260px"\s*: mounted\s*\? `\$\{NAV_OPEN_PX\}px`\s*: `\$\{NAV_RAIL_PX\}px`/,
+  "normal nav hydrates at the icon rail before restoring its expanded size",
+);
+assert.match(
+  shell,
+  /id="nav"[\s\S]{0,700}?defaultSize=\{defaultNavSize\}[\s\S]{0,120}?minSize=\{chatContextual \? "220px" : "200px"\}[\s\S]{0,60}?maxSize="420px"/,
   "Chat's contextual nav defaults to 260px within a 220–420px band while normal nav keeps 240/200 sizing",
 );
 // Minimized by default via the group's setLayout (sets ALL panels at once) —

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -96,6 +96,18 @@ const shellStorage = {
   },
 };
 
+// SSR and the first client render must see the same panel snapshot. Reading
+// localStorage during hydration makes react-resizable-panels emit different
+// inline flex values from the server markup. The real store is swapped in
+// after mount; the existing layout effect then restores the saved group before
+// enabling transitions.
+const hydrationShellStorage = {
+  getItem(_key: string): null {
+    return null;
+  },
+  setItem(_key: string, _value: string): void {},
+};
+
 function togglePanel(panel: PanelImperativeHandle | null) {
   if (!panel) return;
   if (panel.isCollapsed()) panel.expand();
@@ -228,9 +240,8 @@ function ShellInner({
   onCloseSplitTile?: (id: string) => void;
   onPromoteSplitTile?: (id: string) => void;
   onDropSplitPage?: (mode: string, side: "left" | "right") => void;
-  /** Mobile/tablet-only bottom tab bar. Rendered after `.shell-body`
-   *  inside `.shell-frame`, but only when the viewport matches the
-   *  mobile breakpoint (≤1023px). */
+  /** Mobile/tablet-only bottom tab bar. Kept in hydration-stable markup after
+   *  `.shell-body`; CSS displays it only at the mobile breakpoint (≤1023px). */
   mobileTabs?: ReactNode;
   onNavOpenChange?: (open: boolean) => void;
   navPolicy?: ShellNavPolicy;
@@ -254,7 +265,8 @@ function ShellInner({
   const railAutoCollapsedNavRef = useRef(false);
   const userOverrodeNavRef = useRef(false);
   const [mounted, setMounted] = useState(false);
-  useEffect(() => setMounted(true), []);
+  useLayoutEffect(() => setMounted(true), []);
+  const layoutStorage = mounted ? shellStorage : hydrationShellStorage;
 
   // Mobile drawer: which of the nav/list/agent panels is currently slid in
   // as a full-height overlay. On desktop this stays null and react-resizable-
@@ -376,19 +388,21 @@ function ShellInner({
   const { defaultLayout, onLayoutChanged } = useDefaultLayout({
     id: groupId,
     panelIds,
-    storage: shellStorage,
+    storage: layoutStorage,
   });
 
   const groupRef = useRef<GroupImperativeHandle | null>(null);
   const groupElementRef = useRef<HTMLDivElement | null>(null);
 
-  const [navOpen, setNavOpen] = useState(() => {
-    // Mobile keeps its drawer. On desktop, start closed so the rail content paints
-    // from the first frame on a fresh minimize; onResize settles it to the real
-    // width once the library (or the minimize effect) has applied the layout.
-    if (isMobile) return true;
-    return shellMinimizeApplied(groupId);
-  });
+  // Non-contextual navigation defaults to its icon rail, so SSR and hydration
+  // match the Cave's minimized default. The mounted layout effects restore a
+  // remembered open panel before the first post-hydration paint.
+  const [navOpen, setNavOpen] = useState(chatContextual);
+  const defaultNavSize = chatContextual
+    ? "260px"
+    : mounted
+      ? `${NAV_OPEN_PX}px`
+      : `${NAV_RAIL_PX}px`;
 
   // Hover-to-peek: when the desktop nav is collapsed to its icon rail, hovering
   // floats it open as an overlay (navPeeking) without changing the collapse
@@ -794,20 +808,6 @@ function ShellInner({
     }
   }, [isMobile]);
 
-  if (!mounted) {
-    return (
-      <div className="shell-frame flex h-full w-full flex-col">
-        <div className="shell-top" data-tauri-drag-region="deep">
-          <div className="shell-titlebar-drag-lane" data-tauri-drag-region="deep" aria-hidden="true" />
-          <div className="shell-top__bar" data-tauri-drag-region="deep">{renderedTopBar}</div>
-        </div>
-        <div className="shell-body flex flex-1 min-h-0">
-          <div className="shell-root flex-1 min-h-0" />
-        </div>
-      </div>
-    );
-  }
-
   const horizontalGroup = (
     <Group
       className="shell-root flex-1 min-h-0"
@@ -843,7 +843,7 @@ function ShellInner({
         className={`shell-nav-panel${navOpen ? " shell-nav-panel--open" : ""}`}
         // Chat uses list-like sizing for contextual workspace/session content.
         // Normal navigation keeps NAV_OPEN_PX as the ⌘B / hover-peek target.
-        defaultSize={chatContextual ? "260px" : "240px"}
+        defaultSize={defaultNavSize}
         minSize={chatContextual ? "220px" : "200px"}
         maxSize="420px"
         collapsible
@@ -950,7 +950,7 @@ function ShellInner({
     if (panel.isCollapsed()) { panel.expand(); setNavOpen(true); }
     else { panel.collapse(); setNavOpen(false); }
   };
-  const navToggle = !isMobile ? (
+  const navToggle = (
     <button
       type="button"
       className={`shell-top-toggle shell-top-toggle--nav focus-ring${navOpen ? " shell-top-toggle--active" : ""}`}
@@ -973,12 +973,11 @@ function ShellInner({
     >
       <Icon name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"} width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
     </button>
-  ) : null;
+  );
   // Workspace owns its destination stack, while the other shell surfaces use
   // browser history. Keep the app-scoped boundary controls intact there and
   // reuse the shared browser controls everywhere else.
-  const historyNav = !isMobile ? (
-    historyNavigation ? (
+  const historyNav = historyNavigation ? (
       <div className="shell-top-history" role="group" aria-label="History">
         <button
           type="button"
@@ -1001,8 +1000,7 @@ function ShellInner({
           <Icon name="ph:caret-right" width={CAVE_ICON_SIZE.shellToggle} height={CAVE_ICON_SIZE.shellToggle} />
         </button>
       </div>
-    ) : <DesktopHistoryNav />
-  ) : null;
+    ) : <DesktopHistoryNav />;
 
   return (
     <div
@@ -1052,7 +1050,7 @@ function ShellInner({
           horizontalGroup
         )}
       </div>
-      {isMobile && mobileTabs ? mobileTabs : null}
+      {mobileTabs ?? null}
       <MobileDrawer
         open={isMobile ? mobileDrawer : null}
         onClose={() => setMobileDrawer(null)}

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -1343,7 +1343,7 @@
   left: 0;
   right: 0;
   z-index: 150;
-  display: flex;
+  display: none;
   align-items: stretch;
   justify-content: space-around;
   gap: 0;
@@ -1356,6 +1356,16 @@
   backdrop-filter: blur(18px) saturate(145%);
   border-top: 1px solid color-mix(in oklch, var(--border-hairline) 88%, transparent);
   box-shadow: 0 -14px 32px color-mix(in oklch, black 18%, transparent);
+}
+@media (max-width: 1023px) {
+  .shell-top > .shell-top-toggle--nav,
+  .shell-top > .shell-top-history {
+    display: none;
+  }
+
+  .mobile-bottom-tabs {
+    display: flex;
+  }
 }
 .mobile-bottom-tab {
   position: relative;

--- a/tests/chat-sidebar-nav.spec.ts
+++ b/tests/chat-sidebar-nav.spec.ts
@@ -30,10 +30,20 @@ const SESSIONS = [
 async function ensureChatSurface(page: Page) {
   await page.waitForSelector(".shell-frame", { timeout: 30_000 });
   const surface = page.locator(".chat-surface");
-  if (!(await surface.isVisible().catch(() => false))) {
-    await page.locator('aside[aria-label="Sidebar"]').getByRole("button", { name: /^Chat\b/ }).first().click();
+  try {
+    await surface.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    const chatDestination = page
+      .locator('aside[aria-label="Sidebar"]')
+      .getByRole("button", { name: /^Chat\b/ })
+      .first();
+    if (!(await chatDestination.isVisible().catch(() => false))) {
+      const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+      if (await openNav.isVisible().catch(() => false)) await openNav.click();
+    }
+    await chatDestination.click();
+    await surface.waitFor({ state: "visible", timeout: 30_000 });
   }
-  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
   await page.waitForSelector('aside[aria-label="Sidebar"] .chat-sidebar', { timeout: 30_000 });
 }
 


### PR DESCRIPTION
## Summary

- render the real resizable shell on the server and first client pass instead of an empty placeholder
- defer persisted panel-layout reads until hydration, then restore them in the pre-paint layout phase
- keep desktop title-bar controls and mobile tabs in stable markup, using the existing breakpoint CSS for visibility
- hydrate Home’s persisted composer draft from an SSR-stable empty value before paint and prevent pre-restoration input loss
- add first-paint, responsive-shell, and draft-restoration contracts to the wired app suite

## Why

The shell’s SSR placeholder and client-only viewport/storage branches changed substantial markup and panel sizing during hydration. That produced an empty/flickering first frame, while Home’s local-storage state could also disagree with the server-rendered textarea.

## Verification

- `pnpm test:app` — 922 test files passed
- `pnpm build` — production build and bundle/standalone budgets passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,269 tests wired; 1 allowlisted
- focused shell first-paint, edge-rail, panel-fit, mobile-shell, and Home composer tests
- `git diff --check origin/main...HEAD`

Bead: `cave-3e50n`