### PR TITLE
fix(runtime): verify required artifact readability

### DIFF
--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -204,8 +204,23 @@ try {
     env: { Path: "C:\\bin" },
     platform: "win32",
     statFile: (candidate) => candidate === "C:\\bin\\node.exe" || candidate === "C:\\bin\\copilot-entry.js",
+    readableFile: (candidate) => candidate === "C:\\bin\\copilot-entry.js",
   });
   assert.equal(requiredArtifactReady.state, "ready", "a complete direct launch plan is ready");
+
+  const statOnlyArtifact = evaluateRuntimeAvailability({
+    runner: "copilot",
+    command: "node.exe",
+    requiredFiles: [path.join(scratch, "missing-required-artifact.js")],
+    env: { Path: "C:\\bin" },
+    platform: "win32",
+    statFile: () => true,
+  });
+  assert.equal(
+    statOnlyArtifact.state,
+    "unlaunchable",
+    "a command stat double cannot silently stand in for required-artifact readability",
+  );
 
   const requiredArtifactUnreadable = evaluateRuntimeAvailability({
     runner: "copilot",
@@ -422,6 +437,7 @@ try {
     platform: "win32",
     requiredFiles: [openCodeTarget],
     statFile: winStats([nodeHost, openCodeTarget]),
+    readableFile: winStats([openCodeTarget]),
   });
   assert.equal(
     openCodeWinReady.state,
@@ -436,6 +452,7 @@ try {
     platform: "win32",
     requiredFiles: [openCodeTarget],
     statFile: winStats([nodeHost]),
+    readableFile: winStats([]),
   });
   assert.equal(
     openCodeTargetGone.state,

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -411,8 +411,7 @@ export function evaluateRuntimeAvailability(
   const inspectCandidate: InspectCandidateFn = probe.statFile
     ? (candidate) => inspectWithStatFile(candidate, probe.statFile!)
     : (candidate) => defaultInspectCandidate(candidate, platform);
-  const readableFile = probe.readableFile
-    ?? (probe.statFile ? probe.statFile : defaultReadableFile);
+  const readableFile = probe.readableFile ?? defaultReadableFile;
   const label = RUNNER_LABELS[runner];
   try {
     if (probe.resolutionFailed) {


### PR DESCRIPTION
## Summary

- keep injected command-stat probes scoped to executable discovery
- verify required launch artifacts with the real readability check unless a dedicated readable-file test double is supplied
- add deterministic regression coverage for the post-merge Copilot finding on #3927

## Verification

- red regression confirmed against the old `statFile` fallback
- focused `runtime-availability.test.ts` passes on current `origin/main`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,274 files wired, 1 allowlisted
- `git diff --check origin/main...HEAD`
- `pnpm test:api` — 279/279 files passed before the overlapping Hermes #3911 base advance; on exact current base, the suite reaches an existing `route-hermes-availability.integration.test.ts` failure (`runtime_process_failed` vs `runtime_missing`) that reproduces identically on a clean detached `origin/main` checkout at `25d817c0b`

Follow-up to #3927.