### PR TITLE
feat(research): improve Resources intake and grouping

### DIFF
--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -120,7 +120,22 @@ test("resources expose a labeled multiline batch intake with truthful preview", 
   assert.match(source, /<textarea[\s\S]*id="research-resource-intake"/);
   assert.match(
     source,
+    /className="research-res__paste focus-ring"/,
+    "the new textarea uses the shared focus-ring contract",
+  );
+  assert.doesNotMatch(
+    styles,
+    /\.research-res__paste:focus-visible/,
+    "surface CSS must not override the shared focus-ring token",
+  );
+  assert.match(
+    source,
     /aria-describedby="research-resource-intake-help research-resource-intake-preview"/,
+  );
+  assert.match(
+    source,
+    /aria-keyshortcuts="Meta\+Enter Control\+Enter"/,
+    "the advertised submit shortcut is exposed to assistive technology",
   );
   assert.match(
     source,
@@ -133,11 +148,15 @@ test("resources expose a labeled multiline batch intake with truthful preview", 
 });
 
 test("batch save feedback uses resource vocabulary and preserves duplicate-only drafts", () => {
-  assert.match(source, /const result = await save\(draft\)/);
+  assert.match(source, /const submittedDraft = draft;\s*setSaving\(true\);\s*const result = await save\(submittedDraft\)/);
   assert.match(source, /No links found\. Paste full http:\/\/ or https:\/\/ URLs\./);
   assert.match(source, /All \$\{result\.duplicates\}[\s\S]{0,160}already saved/);
   assert.match(source, /Saved \$\{result\.added\}[\s\S]{0,160}resource/);
-  assert.match(source, /if \(result\.added > 0\)[\s\S]*setDraft\(""\)/);
+  assert.match(
+    source,
+    /if \(result\.added > 0\)[\s\S]*setDraft\(\(current\) => current === submittedDraft \? "" : current\)/,
+    "a completed save only clears the batch that was actually submitted",
+  );
   assert.match(source, /role="status"/);
 });
 

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -3,6 +3,10 @@ import { readFileSync } from "node:fs";
 import test from "node:test";
 
 const source = readFileSync(new URL("./research-tab-resources.tsx", import.meta.url), "utf8");
+const styles = readFileSync(
+  new URL("../../styles/globals/surface-research-resources.css", import.meta.url),
+  "utf8",
+);
 
 test("resources render real SavedLink fields only — no fabricated stats", () => {
   // The store holds url/title/category/addedAt/source; everything shown is
@@ -29,9 +33,13 @@ test("cited-by is derived by cross-referencing normalized mission source urls", 
   assert.match(source, /for \(const mission of research\.missions\)/);
   assert.match(source, /if \(source\.url\) urls\.add\(normalizeLinkUrl\(source\.url\)\)/);
   assert.match(source, /citedByIndex\.get\(normalizeLinkUrl\(link\.url\)\)/);
-  // Cards surface the count only when N > 0.
-  assert.match(source, /cited\.length > 0 \?/);
-  assert.match(source, /cited by \{cited\.length\} run\{cited\.length === 1 \? "" : "s"\}/);
+  // Cards surface an honest citation state for both cited and uncited links.
+  assert.match(source, /cited\.length > 0\s*\?/);
+  assert.match(
+    source,
+    /`Cited by \$\{cited\.length\} \$\{cited\.length === 1 \? "run" : "runs"\}`/,
+  );
+  assert.match(source, /"Not cited yet"/);
   // Overlay chips jump to the citing run on the Desk.
   assert.match(source, /onNavigate\("desk", \{ missionId: mission\.id \}\)/);
   // The uncited nudge is derived from the same cross-reference and routes to
@@ -49,9 +57,13 @@ test("add-to-run uses the evidence ledger's attach-source candidate mechanism", 
   assert.match(source, /status: "candidate"/);
   assert.match(source, /sourceType: "web"/);
   assert.match(source, /await act\(selectedMission\.id, \{/);
-  // Disabled with a hint when no mission is selected.
-  assert.match(source, /disabled=\{!selectedMission \|\| attachBusy/);
+  // No-mission and already-attached states are explicit instead of presenting
+  // an unexplained disabled action.
+  assert.match(source, /\) : selectedMission \? \(/);
+  assert.match(source, /disabled=\{attachBusy\}/);
   assert.match(source, /Select a run on the Desk first/);
+  assert.match(source, /Select a run to add/);
+  assert.match(source, /In this run/);
   // Already-attached links (normalized-url match) can't be attached twice.
   assert.match(source, /selectedMission\.sources\.some\(\s*\(source\) => source\.url && normalizeLinkUrl\(source\.url\) === key/);
 });
@@ -102,11 +114,53 @@ test("detail overlay is a focus-trapped dialog with honest copy/open actions", (
   assert.match(source, /context\.openUrl\(openLink\.url\)/);
 });
 
-test("save row reports the extraction result honestly via role=status", () => {
-  // The dashed paste target is a real input wired to useResearchLinks.save;
-  // added/duplicates/no-links outcomes each get their own truthful line.
+test("resources expose a labeled multiline batch intake with truthful preview", () => {
+  assert.match(source, /summarizeLinkIntake\(draft, links\)/);
+  assert.match(source, /<label htmlFor="research-resource-intake">Add resources<\/label>/);
+  assert.match(source, /<textarea[\s\S]*id="research-resource-intake"/);
+  assert.match(
+    source,
+    /aria-describedby="research-resource-intake-help research-resource-intake-preview"/,
+  );
+  assert.match(
+    source,
+    /Paste up to \{MAX_LINKS_PER_SAVE\} links, separated by commas or line breaks\./,
+  );
+  assert.match(source, /event\.metaKey \|\| event\.ctrlKey/);
+  assert.match(source, /event\.currentTarget\.form\?\.requestSubmit\(\)/);
+  assert.match(source, />\s*Save resources\s*<\/Button>/);
+  assert.doesNotMatch(source, /research-res__saverow/);
+});
+
+test("batch save feedback uses resource vocabulary and preserves duplicate-only drafts", () => {
   assert.match(source, /const result = await save\(draft\)/);
-  assert.match(source, /No links found in that text\./);
-  assert.match(source, /skipped \$\{result\.duplicates\} duplicate/);
+  assert.match(source, /No links found\. Paste full http:\/\/ or https:\/\/ URLs\./);
+  assert.match(source, /All \$\{result\.duplicates\}[\s\S]{0,160}already saved/);
+  assert.match(source, /Saved \$\{result\.added\}[\s\S]{0,160}resource/);
+  assert.match(source, /if \(result\.added > 0\)[\s\S]*setDraft\(""\)/);
   assert.match(source, /role="status"/);
+});
+
+test("resources filter by type before workflow-first grouping", () => {
+  assert.match(
+    source,
+    /groupSavedLinksByUsage\(\s*visibleLinks,\s*citedByIndex,\s*selectedMission\?\.id/,
+  );
+  assert.doesNotMatch(source, /groupSavedLinks\(/);
+  assert.match(source, /<SearchInput/);
+  assert.match(source, /placeholder="Search resources…"/);
+  assert.match(source, /setQuery\(""\);\s*setFilter\("all"\)/);
+  assert.match(source, />\s*Clear filters\s*<\/Button>/);
+});
+
+test("resource cards and details keep actions in predictable footers", () => {
+  assert.match(source, /className="research-res-card__footer"/);
+  assert.match(source, /context\.openUrl\(link\.url\)/);
+  assert.match(source, />\s*Open link\s*<\/Button>/);
+  assert.match(source, /In this run/);
+  assert.match(source, /Select a run to add/);
+  assert.match(source, /className="research-res-overlay__primary-actions"/);
+  assert.match(source, /context\.openUrl\(openLink\.url\)/);
+  assert.match(styles, /\.research-res-card__footer/);
+  assert.match(styles, /@container research-desk \(max-width: 560px\)/);
 });

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -211,8 +211,9 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const onSave = async (event: FormEvent) => {
     event.preventDefault();
     if (saving || !intake.canSubmit) return;
+    const submittedDraft = draft;
     setSaving(true);
-    const result = await save(draft);
+    const result = await save(submittedDraft);
     setSaving(false);
 
     let message: string;
@@ -234,7 +235,9 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
             }`
           : ""
       }.`;
-      if (result.added > 0) setDraft("");
+      if (result.added > 0) {
+        setDraft((current) => current === submittedDraft ? "" : current);
+      }
     }
     setSaveStatus(message);
     announce(message, result.ok ? "polite" : "assertive");
@@ -315,7 +318,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
         </div>
         <textarea
           id="research-resource-intake"
-          className="research-res__paste"
+          className="research-res__paste focus-ring"
           rows={3}
           value={draft}
           onChange={(event) => {
@@ -325,6 +328,7 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
           onKeyDown={onIntakeKeyDown}
           placeholder="e.g., https://docs.example.com, https://arxiv.org/…"
           aria-describedby="research-resource-intake-help research-resource-intake-preview"
+          aria-keyshortcuts="Meta+Enter Control+Enter"
         />
         <div className="research-res__intake-footer">
           <div

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -14,17 +14,28 @@
  * (`attach-source` action) so triage semantics stay identical.
  */
 
-import { useCallback, useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+  type KeyboardEvent,
+} from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { RelativeTime } from "@/components/ui/relative-time";
+import { SearchInput } from "@/components/ui/search-input";
 import { copyText } from "@/lib/clipboard";
 import { Icon } from "@/lib/icon";
 import {
+  groupSavedLinksByUsage,
   linkCategoryMeta,
   LINK_CATEGORY_ORDER,
-  groupSavedLinks,
+  MAX_LINKS_PER_SAVE,
   normalizeLinkUrl,
+  summarizeLinkIntake,
   type LinkCategory,
   type SavedLink,
 } from "@/lib/link-organizer";
@@ -46,17 +57,6 @@ function readStoredView(): ResourceView {
     return "grid";
   }
 }
-
-/** Group blurbs per the design, adapted to the repo's real link categories. */
-const CATEGORY_DESCRIPTIONS: Record<LinkCategory, string> = {
-  github: "repositories & issues",
-  docs: "official documentation",
-  paper: "academic papers",
-  article: "posts & essays",
-  video: "talks & recordings",
-  social: "community threads",
-  other: "everything else",
-};
 
 function linkDomain(rawUrl: string): string {
   try {
@@ -80,6 +80,9 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
   const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [copied, setCopied] = useState(false);
   const [attachBusy, setAttachBusy] = useState(false);
+  const selectedMission = research.selected;
+  const act = research.act;
+  const intake = useMemo(() => summarizeLinkIntake(draft, links), [draft, links]);
 
   const selectView = useCallback((next: ResourceView) => {
     setView(next);
@@ -139,14 +142,31 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
       (!q || `${link.title} ${link.url}`.toLowerCase().includes(q)));
   }, [links, trimmedQuery, activeFilter]);
 
-  const groups = useMemo(() => groupSavedLinks(visibleLinks), [visibleLinks]);
+  const groups = useMemo(
+    () => groupSavedLinksByUsage(visibleLinks, citedByIndex, selectedMission?.id),
+    [visibleLinks, citedByIndex, selectedMission?.id],
+  );
+  const intakeMessage = !draft.trim()
+    ? "Paste links to preview the batch."
+    : intake.detectedCount === 0
+      ? "No links found. Paste full http:// or https:// URLs."
+      : intake.overLimit
+        ? `${intake.detectedCount} links detected · maximum ${MAX_LINKS_PER_SAVE}.`
+        : intake.ready.length === 0
+          ? `All ${intake.duplicates.length} ${
+              intake.duplicates.length === 1 ? "resource is" : "resources are"
+            } already saved.`
+          : `${intake.ready.length} ${
+              intake.ready.length === 1 ? "resource" : "resources"
+            } ready${
+              intake.duplicates.length > 0
+                ? ` · ${intake.duplicates.length} already saved`
+                : ""
+            }.`;
 
   // ── Add to run: same mechanism as the evidence ledger's manual attach —
   // an `attach-source` action landing the link as a candidate source on the
   // currently selected mission.
-  const selectedMission = research.selected;
-  const act = research.act;
-
   const attachedToSelected = useCallback((link: SavedLink) => {
     if (!selectedMission) return false;
     const key = normalizeLinkUrl(link.url);
@@ -186,30 +206,45 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
         ? "Already a source on the selected run"
         : `Add to “${selectedMission.title}” as a candidate source`;
 
-  // ── Save row: the dashed paste target is a real input; the result line
-  // reports exactly what the server extracted (added / duplicates / nothing).
+  // ── Batch intake: the client preview is advisory; this result line reports
+  // exactly what the authoritative server accepted or skipped.
   const onSave = async (event: FormEvent) => {
     event.preventDefault();
-    if (saving || !draft.trim()) return;
+    if (saving || !intake.canSubmit) return;
     setSaving(true);
     const result = await save(draft);
     setSaving(false);
+
     let message: string;
     if (!result.ok) {
-      message = result.error ?? "Couldn’t save.";
-    } else if (result.added === 0 && result.duplicates === 0) {
-      message = "No links found in that text.";
+      message = result.error ?? "Couldn’t save resources.";
+    } else if (result.added === 0 && result.duplicates > 0) {
+      message = `All ${result.duplicates} ${
+        result.duplicates === 1 ? "resource was" : "resources were"
+      } already saved.`;
+    } else if (result.added === 0) {
+      message = "No links found. Paste full http:// or https:// URLs.";
     } else {
-      const parts: string[] = [];
-      if (result.added > 0) parts.push(`Saved ${result.added} link${result.added === 1 ? "" : "s"}`);
-      if (result.duplicates > 0) {
-        parts.push(`skipped ${result.duplicates} duplicate${result.duplicates === 1 ? "" : "s"}`);
-      }
-      message = `${parts.join(" · ")}.`;
-      setDraft("");
+      message = `Saved ${result.added} ${
+        result.added === 1 ? "resource" : "resources"
+      }${
+        result.duplicates > 0
+          ? ` · skipped ${result.duplicates} ${
+              result.duplicates === 1 ? "duplicate" : "duplicates"
+            }`
+          : ""
+      }.`;
+      if (result.added > 0) setDraft("");
     }
     setSaveStatus(message);
     announce(message, result.ok ? "polite" : "assertive");
+  };
+
+  const onIntakeKeyDown = (event: KeyboardEvent<HTMLTextAreaElement>) => {
+    const submitsBatch = event.key === "Enter" && (event.metaKey || event.ctrlKey);
+    if (!submitsBatch) return;
+    event.preventDefault();
+    if (intake.canSubmit && !saving) event.currentTarget.form?.requestSubmit();
   };
 
   // ── Detail overlay: focus-trapped dialog over the open link.
@@ -268,31 +303,72 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
         </span>
       </header>
 
-      <form className="research-res__saverow" onSubmit={onSave}>
-        <input
-          className="research-res__search"
-          type="search"
-          value={query}
-          onChange={(event) => setQuery(event.target.value)}
-          placeholder="Search resources…"
-          aria-label="Search resources"
-        />
-        <input
+      <form className="research-res__intake" onSubmit={onSave}>
+        <div className="research-res__intake-head">
+          <div>
+            <label htmlFor="research-resource-intake">Add resources</label>
+            <p id="research-resource-intake-help">
+              Paste up to {MAX_LINKS_PER_SAVE} links, separated by commas or line breaks.
+            </p>
+          </div>
+          <kbd>⌘/Ctrl + Enter</kbd>
+        </div>
+        <textarea
+          id="research-resource-intake"
           className="research-res__paste"
+          rows={3}
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
-          placeholder="Paste a link or a block of text — every URL is extracted, titled, and filed automatically"
-          aria-label="Paste links to save"
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setSaveStatus(null);
+          }}
+          onKeyDown={onIntakeKeyDown}
+          placeholder="e.g., https://docs.example.com, https://arxiv.org/…"
+          aria-describedby="research-resource-intake-help research-resource-intake-preview"
         />
-        <Button type="submit" size="sm" variant="primary" loading={saving} disabled={saving || !draft.trim()}>
-          Save
-        </Button>
+        <div className="research-res__intake-footer">
+          <div
+            id="research-resource-intake-preview"
+            className="research-res__intake-preview"
+            role="status"
+          >
+            <span>{intakeMessage}</span>
+            {intake.detectedCount > 0 ? (
+              <span className="research-res__intake-types">
+                {LINK_CATEGORY_ORDER.filter((category) => intake.categoryCounts[category]).map(
+                  (category) => (
+                    <span key={category}>
+                      {linkCategoryMeta(category).label} {intake.categoryCounts[category]}
+                    </span>
+                  ),
+                )}
+              </span>
+            ) : null}
+          </div>
+          <Button
+            type="submit"
+            size="sm"
+            variant="primary"
+            loading={saving}
+            disabled={saving || !intake.canSubmit}
+          >
+            Save resources
+          </Button>
+        </div>
       </form>
       {saveStatus ? (
         <p className="research-res__save-status" role="status">{saveStatus}</p>
       ) : null}
 
       <div className="research-res__toolbar">
+        <SearchInput
+          value={query}
+          onValueChange={setQuery}
+          onClear={() => setQuery("")}
+          placeholder="Search resources…"
+          aria-label="Search resources"
+          containerClassName="research-res__search"
+        />
         <div className="research-res__chips" role="group" aria-label="Filter resources by category">
           <button
             type="button"
@@ -338,21 +414,31 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
           Nothing saved yet — paste a link above, or use /save in chat.
         </p>
       ) : groups.length === 0 ? (
-        <p className="research-res__empty">
-          Nothing matches “{trimmedQuery}” — try a different term or clear the filter.
-        </p>
+        <div className="research-res__empty research-res__empty--filtered">
+          <span>Nothing matches “{trimmedQuery}” — try a different term or clear the filter.</span>
+          <Button
+            size="xs"
+            variant="ghost"
+            onClick={() => {
+              setQuery("");
+              setFilter("all");
+            }}
+          >
+            Clear filters
+          </Button>
+        </div>
       ) : (
         groups.map((group) => (
           <section
-            key={group.category}
+            key={group.id}
             className="research-res__group"
             aria-label={`${group.label} resources`}
           >
             <header className="research-res__group-head">
-              <i className="research-res__group-mark" data-category={group.category} aria-hidden />
+              <i className="research-res__group-mark" data-group={group.id} aria-hidden />
               <h3>{group.label}</h3>
               <span className="research-res__group-count">{group.links.length}</span>
-              <span className="research-res__group-desc">{CATEGORY_DESCRIPTIONS[group.category]}</span>
+              <span className="research-res__group-desc">{group.description}</span>
             </header>
             <div className="research-res__items" data-view={view}>
               {group.links.map((link) => {
@@ -370,11 +456,9 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                         <Icon name={linkCategoryMeta(link.category).icon} width={11} height={11} aria-hidden />
                         {linkCategoryMeta(link.category).label}
                       </span>
-                      {view === "grid" ? (
-                        <span className="research-res-card__saved">
-                          saved <RelativeTime iso={link.addedAt} fallback="just now" />
-                        </span>
-                      ) : null}
+                      <span className="research-res-card__saved">
+                        saved <RelativeTime iso={link.addedAt} fallback="just now" />
+                      </span>
                     </div>
                     <button
                       type="button"
@@ -388,26 +472,41 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                       <span className="sr-only"> — open details</span>
                     </button>
                     <span className="research-res-card__sub">{linkDomain(link.url)}</span>
-                    <div className="research-res-card__actions">
-                      <button
-                        type="button"
-                        className="research-res-card__add"
-                        disabled={!selectedMission || attachBusy || inRun}
-                        title={addHint(link)}
-                        onClick={() => void attachToRun(link)}
-                      >
-                        <Icon name="ph:plus" width={11} height={11} aria-hidden />
-                        {inRun ? "In run" : "Add to run"}
-                        <span className="sr-only"> — {addHint(link)}</span>
-                      </button>
+                    <div className="research-res-card__footer">
                       <span className="research-res-card__meta">
-                        {cited.length > 0 ? (
-                          <span>cited by {cited.length} run{cited.length === 1 ? "" : "s"}</span>
-                        ) : null}
-                        {view === "rows" ? (
-                          <span>saved <RelativeTime iso={link.addedAt} fallback="just now" /></span>
-                        ) : null}
+                        {cited.length > 0
+                          ? `Cited by ${cited.length} ${cited.length === 1 ? "run" : "runs"}`
+                          : "Not cited yet"}
                       </span>
+                      <div className="research-res-card__buttons">
+                        <Button
+                          size="xs"
+                          variant="ghost"
+                          trailingIcon="ph:arrow-square-out"
+                          onClick={() => context.openUrl(link.url)}
+                        >
+                          Open link
+                        </Button>
+                        {inRun ? (
+                          <span className="research-res-card__state">
+                            <Icon name="ph:check" width={11} height={11} aria-hidden />
+                            In this run
+                          </span>
+                        ) : selectedMission ? (
+                          <Button
+                            size="xs"
+                            variant="secondary"
+                            leadingIcon="ph:plus"
+                            disabled={attachBusy}
+                            title={addHint(link)}
+                            onClick={() => void attachToRun(link)}
+                          >
+                            Add to run
+                          </Button>
+                        ) : (
+                          <span className="research-res-card__hint">Select a run to add</span>
+                        )}
+                      </div>
                     </div>
                   </article>
                 );
@@ -484,14 +583,6 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                 <Icon name={copied ? "ph:check" : "ph:copy"} width={11} height={11} aria-hidden />
                 {copied ? "Copied" : "Copy"}
               </button>
-              <button
-                type="button"
-                className="research-res-overlay__source-btn"
-                onClick={() => context.openUrl(openLink.url)}
-              >
-                Open
-                <Icon name="ph:arrow-square-out" width={11} height={11} aria-hidden />
-              </button>
             </div>
 
             <div className="research-res-overlay__body">
@@ -541,21 +632,6 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
             </div>
 
             <footer className="research-res-overlay__actions">
-              <Button
-                size="sm"
-                variant="primary"
-                leadingIcon="ph:plus"
-                disabled={!selectedMission || attachBusy || attachedToSelected(openLink)}
-                title={addHint(openLink)}
-                onClick={() => void attachToRun(openLink)}
-              >
-                {attachedToSelected(openLink) ? "In run" : "Add to run"}
-              </Button>
-              {!selectedMission ? (
-                <span className="research-res-overlay__hint">
-                  Select a run on the Desk to attach sources.
-                </span>
-              ) : null}
               <div className="research-res-overlay__remove">
                 {confirmingRemove ? (
                   <>
@@ -574,6 +650,38 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
                     Remove from saves
                   </Button>
                 )}
+              </div>
+              <div className="research-res-overlay__primary-actions">
+                {!selectedMission ? (
+                  <span className="research-res-overlay__hint">
+                    Select a run to add this resource.
+                  </span>
+                ) : null}
+                <Button
+                  size="sm"
+                  variant="secondary"
+                  trailingIcon="ph:arrow-square-out"
+                  onClick={() => context.openUrl(openLink.url)}
+                >
+                  Open link
+                </Button>
+                {attachedToSelected(openLink) ? (
+                  <span className="research-res-card__state">
+                    <Icon name="ph:check" width={11} height={11} aria-hidden />
+                    In this run
+                  </span>
+                ) : selectedMission ? (
+                  <Button
+                    size="sm"
+                    variant="primary"
+                    leadingIcon="ph:plus"
+                    disabled={attachBusy}
+                    title={addHint(openLink)}
+                    onClick={() => void attachToRun(openLink)}
+                  >
+                    Add to run
+                  </Button>
+                ) : null}
               </div>
             </footer>
           </div>

--- a/src/lib/link-extractor.test.ts
+++ b/src/lib/link-extractor.test.ts
@@ -6,6 +6,18 @@ const CASES = [
   // happy path
   ["check https://github.com/foo/bar for context", ["https://github.com/foo/bar"]],
   ["two links: https://a.com and https://b.com", ["https://a.com/", "https://b.com/"]],
+  [
+    "comma-separated links without spaces https://a.example/one,https://b.example/two",
+    ["https://a.example/one", "https://b.example/two"],
+  ],
+  [
+    "line-separated links\nhttps://a.example/one\nhttps://b.example/two",
+    ["https://a.example/one", "https://b.example/two"],
+  ],
+  [
+    "commas that belong to one URL stay intact https://example.com/search?q=a,b",
+    ["https://example.com/search?q=a,b"],
+  ],
 
   // dedup within input
   ["https://a.com twice https://a.com", ["https://a.com/"]],

--- a/src/lib/link-extractor.ts
+++ b/src/lib/link-extractor.ts
@@ -18,7 +18,10 @@ export function extractLinks(text: string): string[] {
     .replace(IMAGE_TARGET, " ")
     .replace(INLINE_CODE, " ");
 
-  const found = cleaned.match(URL_RE) ?? [];
+  // A pasted batch may place the next URL directly after a comma. Split only
+  // that boundary so commas inside a path or query remain part of the URL.
+  const separated = cleaned.replace(/,(?=\s*https?:\/\/)/gi, " ");
+  const found = separated.match(URL_RE) ?? [];
 
   const out: string[] = [];
   const seen = new Set<string>();

--- a/src/lib/link-organizer.test.ts
+++ b/src/lib/link-organizer.test.ts
@@ -6,11 +6,13 @@ import { test } from "node:test";
 import {
   categorizeLink,
   deriveLinkTitle,
-  groupSavedLinks,
+  groupSavedLinksByUsage,
   LINK_CATEGORY_META,
   linkCategoryMeta,
   LINK_CATEGORY_ORDER,
+  MAX_LINKS_PER_SAVE,
   normalizeLinkUrl,
+  summarizeLinkIntake,
   type SavedLink,
 } from "./link-organizer.ts";
 
@@ -81,26 +83,102 @@ test("normalizeLinkUrl produces one key per page", () => {
   );
 });
 
-// ── grouping ──────────────────────────────────────────────────────────────────
+// ── intake preview ────────────────────────────────────────────────────────────
 
-test("groupSavedLinks orders shelves by category and omits empty groups", () => {
-  const link = (url: string, addedAt: string): SavedLink => ({
-    id: url,
-    url,
-    category: categorizeLink(url),
-    title: deriveLinkTitle(url),
-    addedAt,
+test("summarizeLinkIntake previews unique ready and already-saved resources", () => {
+  const saved: SavedLink[] = [{
+    id: "saved",
+    url: "https://example.com/post",
+    category: "other",
+    title: "Saved",
+    addedAt: "2026-07-26T00:00:00Z",
     source: "desk",
-  });
-  const groups = groupSavedLinks([
-    link("https://example.com/blog/a", "2026-07-15T01:00:00Z"),
-    link("https://github.com/a/b", "2026-07-15T02:00:00Z"),
-    link("https://github.com/c/d", "2026-07-15T03:00:00Z"),
+  }];
+
+  const summary = summarizeLinkIntake(
+    [
+      "https://github.com/OpenCoven/coven-cave,https://arxiv.org/abs/2404.12345",
+      "https://example.com/post#section",
+      "https://example.com/post/",
+    ].join("\n"),
+    saved,
+  );
+
+  assert.equal(summary.detectedCount, 4);
+  assert.deepEqual(
+    summary.ready.map((item) => item.category),
+    ["github", "paper"],
+  );
+  assert.deepEqual(
+    summary.duplicates.map((item) => item.url),
+    ["https://example.com/post#section"],
+  );
+  assert.deepEqual(summary.categoryCounts, { github: 1, paper: 1, article: 1 });
+  assert.equal(summary.overLimit, false);
+  assert.equal(summary.canSubmit, true);
+});
+
+test("summarizeLinkIntake exposes the shared save limit", () => {
+  const text = Array.from(
+    { length: MAX_LINKS_PER_SAVE + 1 },
+    (_, index) => `https://bulk.example.com/${index}`,
+  ).join("\n");
+  const summary = summarizeLinkIntake(text, []);
+  assert.equal(summary.detectedCount, MAX_LINKS_PER_SAVE + 1);
+  assert.equal(summary.overLimit, true);
+  assert.equal(summary.canSubmit, false);
+});
+
+// ── workflow grouping ─────────────────────────────────────────────────────────
+
+const savedLink = (id: string, url: string): SavedLink => ({
+  id,
+  url,
+  category: categorizeLink(url),
+  title: deriveLinkTitle(url),
+  addedAt: "2026-07-26T00:00:00Z",
+  source: "desk",
+});
+
+test("groupSavedLinksByUsage prioritizes selected, uncited, and other-run links", () => {
+  const selected = savedLink("selected", "https://example.com/selected");
+  const uncited = savedLink("uncited", "https://example.com/uncited");
+  const other = savedLink("other", "https://example.com/other");
+  const citedBy = new Map<string, { id: string }[]>([
+    [normalizeLinkUrl(selected.url), [{ id: "mission-selected" }]],
+    [normalizeLinkUrl(other.url), [{ id: "mission-other" }]],
   ]);
-  assert.deepEqual(groups.map((g) => g.category), ["github", "article"]);
-  assert.equal(groups[0].links.length, 2);
-  assert.equal(groups[0].label, LINK_CATEGORY_META.github.label);
-  // Every category has display metadata and a place in the order.
+
+  const groups = groupSavedLinksByUsage(
+    [selected, uncited, other],
+    citedBy,
+    "mission-selected",
+  );
+
+  assert.deepEqual(groups.map((group) => group.id), ["selected", "uncited", "cited"]);
+  assert.deepEqual(groups.map((group) => group.label), [
+    "In this run",
+    "Uncited",
+    "Used in other runs",
+  ]);
+  assert.deepEqual(groups.map((group) => group.links.map((link) => link.id)), [
+    ["selected"],
+    ["uncited"],
+    ["other"],
+  ]);
+});
+
+test("groupSavedLinksByUsage omits selected grouping without a selected mission", () => {
+  const uncited = savedLink("uncited", "https://example.com/uncited");
+  const cited = savedLink("cited", "https://example.com/cited");
+  const citedBy = new Map<string, { id: string }[]>([
+    [normalizeLinkUrl(cited.url), [{ id: "mission-one" }]],
+  ]);
+
+  const groups = groupSavedLinksByUsage([uncited, cited], citedBy);
+  assert.deepEqual(groups.map((group) => group.id), ["uncited", "cited"]);
+  assert.deepEqual(groups.map((group) => group.label), ["Uncited", "Used in runs"]);
+  // Every category keeps display metadata for intake/category filters.
   for (const category of LINK_CATEGORY_ORDER) {
     assert.ok(LINK_CATEGORY_META[category].label);
     assert.ok(LINK_CATEGORY_META[category].icon.startsWith("ph:"));
@@ -144,7 +222,11 @@ test("the Research desk consumes the same links store", () => {
     "utf8",
   );
   assert.match(resources, /useResearchLinks/, "Resources reads through the shared hook");
-  assert.match(resources, /groupSavedLinks\(/, "Resources renders auto-organized groups");
+  assert.match(
+    resources,
+    /groupSavedLinksByUsage\(/,
+    "Resources renders workflow-first organized groups",
+  );
 
   const prompt = readFileSync(
     path.join(repoRoot, "src/components/role-surfaces/research-tab-prompt.tsx"),
@@ -166,9 +248,9 @@ test("unknown categories degrade to Other instead of crashing a surface", () => 
     source: "chat" as const,
   };
   assert.equal(linkCategoryMeta("newsletter").label, "Other");
-  const groups = groupSavedLinks([foreign]);
+  const groups = groupSavedLinksByUsage([foreign], new Map());
   assert.equal(groups.length, 1);
-  assert.equal(groups[0].category, "other");
+  assert.equal(groups[0].id, "uncited");
   // Surfaces go through the tolerant accessor, not raw table indexing.
   for (const rel of [
     "src/components/role-surfaces/research-tab-resources.tsx",

--- a/src/lib/link-organizer.ts
+++ b/src/lib/link-organizer.ts
@@ -9,6 +9,7 @@
  */
 
 import type { IconName } from "./icon.tsx";
+import { extractLinks } from "./link-extractor.ts";
 
 export type LinkCategory =
   | "github"
@@ -39,6 +40,8 @@ export const LINK_CATEGORY_META: Record<LinkCategory, { label: string; icon: Ico
   social: { label: "Discussions", icon: "ph:chats-circle" },
   other: { label: "Other", icon: "ph:link" },
 };
+
+export const MAX_LINKS_PER_SAVE = 50;
 
 export type SavedLink = {
   id: string;
@@ -211,6 +214,63 @@ export function normalizeLinkUrl(rawUrl: string): string {
   return out;
 }
 
+export type LinkIntakeItem = {
+  url: string;
+  category: LinkCategory;
+  alreadySaved: boolean;
+};
+
+export type LinkIntakeSummary = {
+  detectedCount: number;
+  ready: LinkIntakeItem[];
+  duplicates: LinkIntakeItem[];
+  categoryCounts: Partial<Record<LinkCategory, number>>;
+  overLimit: boolean;
+  canSubmit: boolean;
+};
+
+/**
+ * Build the Resources intake preview from the same extraction and normalized
+ * dedupe rules the server uses. This is advisory; the server remains the
+ * authoritative validator and writer.
+ */
+export function summarizeLinkIntake(
+  text: string,
+  savedLinks: readonly Pick<SavedLink, "url">[],
+): LinkIntakeSummary {
+  const extracted = extractLinks(text);
+  const existing = new Set(savedLinks.map((link) => normalizeLinkUrl(link.url)));
+  const unique = new Map<string, LinkIntakeItem>();
+
+  for (const url of extracted) {
+    const key = normalizeLinkUrl(url);
+    if (unique.has(key)) continue;
+    unique.set(key, {
+      url,
+      category: categorizeLink(url),
+      alreadySaved: existing.has(key),
+    });
+  }
+
+  const items = [...unique.values()];
+  const ready = items.filter((item) => !item.alreadySaved);
+  const duplicates = items.filter((item) => item.alreadySaved);
+  const categoryCounts: Partial<Record<LinkCategory, number>> = {};
+  for (const item of items) {
+    categoryCounts[item.category] = (categoryCounts[item.category] ?? 0) + 1;
+  }
+  const overLimit = extracted.length > MAX_LINKS_PER_SAVE;
+
+  return {
+    detectedCount: extracted.length,
+    ready,
+    duplicates,
+    categoryCounts,
+    overLimit,
+    canSubmit: extracted.length > 0 && ready.length > 0 && !overLimit,
+  };
+}
+
 /**
  * Meta for a category, tolerating unknown values. The links store is shared
  * across app versions (chat /save, desk, future writers) — an unrecognized
@@ -220,20 +280,58 @@ export function linkCategoryMeta(category: string): { label: string; icon: IconN
   return LINK_CATEGORY_META[category as LinkCategory] ?? LINK_CATEGORY_META.other;
 }
 
-/** Group saved links into ordered category shelves (empty groups omitted). */
-export function groupSavedLinks(
+export type LinkUsageGroupId = "selected" | "uncited" | "cited";
+
+export type LinkUsageGroup = {
+  id: LinkUsageGroupId;
+  label: string;
+  description: string;
+  links: SavedLink[];
+};
+
+/** Group links by how they relate to the selected and prior research runs. */
+export function groupSavedLinksByUsage<TMission extends { id: string }>(
   links: SavedLink[],
-): { category: LinkCategory; label: string; icon: IconName; links: SavedLink[] }[] {
-  const byCategory = new Map<LinkCategory, SavedLink[]>();
+  citedByUrl: ReadonlyMap<string, readonly TMission[]>,
+  selectedMissionId?: string,
+): LinkUsageGroup[] {
+  const selected: SavedLink[] = [];
+  const uncited: SavedLink[] = [];
+  const cited: SavedLink[] = [];
+
   for (const link of links) {
-    const category = LINK_CATEGORY_META[link.category] ? link.category : "other";
-    const bucket = byCategory.get(category) ?? [];
-    bucket.push(link);
-    byCategory.set(category, bucket);
+    const missions = citedByUrl.get(normalizeLinkUrl(link.url)) ?? [];
+    if (selectedMissionId && missions.some((mission) => mission.id === selectedMissionId)) {
+      selected.push(link);
+    } else if (missions.length === 0) {
+      uncited.push(link);
+    } else {
+      cited.push(link);
+    }
   }
-  return LINK_CATEGORY_ORDER.filter((category) => byCategory.has(category)).map((category) => ({
-    category,
-    ...LINK_CATEGORY_META[category],
-    links: byCategory.get(category)!,
-  }));
+
+  const groups: LinkUsageGroup[] = [];
+  if (selectedMissionId) {
+    groups.push({
+      id: "selected",
+      label: "In this run",
+      description: "Already attached to the selected run",
+      links: selected,
+    });
+  }
+  groups.push({
+    id: "uncited",
+    label: "Uncited",
+    description: "Not used by any research run yet",
+    links: uncited,
+  });
+  groups.push({
+    id: "cited",
+    label: selectedMissionId ? "Used in other runs" : "Used in runs",
+    description: selectedMissionId
+      ? "Used elsewhere and available to add here"
+      : "Used by one or more research runs",
+    links: cited,
+  });
+  return groups.filter((group) => group.links.length > 0);
 }

--- a/src/lib/server/research-links.ts
+++ b/src/lib/server/research-links.ts
@@ -15,6 +15,7 @@ import {
   categorizeLink,
   deriveLinkTitle,
   LINK_CATEGORY_ORDER,
+  MAX_LINKS_PER_SAVE,
   normalizeLinkUrl,
   type LinkCategory,
   type SavedLink,
@@ -23,8 +24,9 @@ import { caveHome } from "../coven-paths.ts";
 import { corruptAsidePath } from "./corrupt-aside.ts";
 import { writeJsonAtomic } from "./atomic-write.ts";
 
+export { MAX_LINKS_PER_SAVE };
+
 export const MAX_SAVED_LINKS = 500;
-export const MAX_LINKS_PER_SAVE = 50;
 
 type ResearchLinksFile = {
   version: 1;

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -1,7 +1,7 @@
 /* ═══ Research Desk — Resources tab (cave-dl74, Phase B5 owns this file) ═══
    Saved-links browser: save row, category filter chips, grid/rows layouts,
    grouped shelves, uncited nudge, and the focus-trapped detail overlay.
-   Semantic tokens only — 16 themes × dark/light must hold. --research-accent
+   Semantic tokens only — 21 palettes × dark/light must hold. --research-accent
    is scoped on .research-desk (surface-role-workspaces.css:683). Layout
    numbers follow the design (lines 623–762) adapted to the desk's container
    breakpoints (760/560). */
@@ -35,36 +35,87 @@
   color: var(--text-muted);
 }
 
-/* ── Save row: search + dashed paste target (a real input) + Save. ── */
-.research-res__saverow {
+/* ── Batch intake: explicit multiline target + live advisory preview. ── */
+.research-res__intake {
   display: flex;
-  gap: 10px;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--bg-raised);
+  border: 1px dashed var(--border-strong);
+  border-radius: var(--radius-card);
+}
+.research-res__intake-head,
+.research-res__intake-footer,
+.research-res-card__footer,
+.research-res-card__buttons,
+.research-res-overlay__primary-actions {
+  display: flex;
   align-items: center;
-  flex-wrap: wrap;
+  gap: var(--space-2);
 }
-.research-res__search,
-.research-res__paste {
-  min-height: 32px;
-  padding: 0 var(--space-3);
-  font-size: var(--text-base);
+.research-res__intake-head {
+  justify-content: space-between;
+}
+.research-res__intake-head label {
+  display: block;
+  font-size: var(--text-md);
+  font-weight: 600;
   color: var(--text-primary);
-  background: transparent;
-  border: 1px solid var(--input, var(--border));
-  border-radius: var(--radius-md);
 }
-.research-res__search { flex: none; width: min(300px, 100%); }
+.research-res__intake-head p,
+.research-res__intake-head kbd,
+.research-res-card__hint,
+.research-res-overlay__hint {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+}
+.research-res__intake-head kbd {
+  flex: none;
+  font-family: var(--font-mono, ui-monospace, monospace);
+}
 .research-res__paste {
-  flex: 1;
-  min-width: 220px;
-  font-size: var(--text-sm);
-  border-style: dashed; /* dashed = invitation: this field takes the paste */
+  min-block-size: calc(var(--space-10) + var(--space-10));
+  padding: var(--space-3);
+  resize: vertical;
+  font: inherit;
+  font-size: var(--text-base);
+  line-height: 1.5;
+  color: var(--text-primary);
+  background: var(--bg-base);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-control);
 }
-.research-res__search::placeholder,
-.research-res__paste::placeholder { color: var(--text-muted); }
-.research-res__search:focus-visible,
+.research-res__paste::placeholder {
+  color: var(--text-muted);
+}
 .research-res__paste:focus-visible {
   outline: 2px solid var(--ring);
   outline-offset: 1px;
+}
+.research-res__intake-preview {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+.research-res__intake-types {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+.research-res__intake-types > span,
+.research-res-card__state {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
 }
 .research-res__save-status {
   margin: 0;
@@ -78,6 +129,10 @@
   align-items: center;
   gap: var(--space-2);
   flex-wrap: wrap;
+}
+.research-res__search {
+  flex: 1 1 var(--shell-list-width);
+  max-width: calc(var(--shell-list-width) + var(--space-10));
 }
 .research-res__chips {
   display: flex;
@@ -133,6 +188,12 @@
   font-size: var(--text-base);
   color: var(--text-muted);
 }
+.research-res__empty--filtered {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
 .research-res__error {
   display: flex;
   align-items: center;
@@ -166,12 +227,9 @@
   border-radius: 2px;
   background: var(--text-muted);
 }
-.research-res__group-mark[data-category="github"] { background: var(--text-secondary); }
-.research-res__group-mark[data-category="paper"],
-.research-res__group-mark[data-category="video"] { background: var(--research-accent); }
-.research-res__group-mark[data-category="docs"] {
-  background: color-mix(in oklch, var(--research-accent) 55%, var(--text-secondary));
-}
+.research-res__group-mark[data-group="selected"] { background: var(--research-accent); }
+.research-res__group-mark[data-group="uncited"] { background: var(--text-muted); }
+.research-res__group-mark[data-group="cited"] { background: var(--text-secondary); }
 .research-res__group-count { font-size: var(--text-xs); color: var(--text-muted); }
 .research-res__group-desc {
   overflow: hidden;
@@ -256,37 +314,23 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.research-res-card__actions {
-  display: flex;
-  align-items: center;
-  gap: var(--space-3);
-  margin-top: 2px;
+.research-res-card__footer {
+  margin-top: auto;
+  justify-content: space-between;
   font-size: var(--text-xs);
 }
-.research-res-card__add {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  flex: none;
-  padding: 3px var(--space-3);
-  font-size: var(--text-xs);
-  color: var(--research-accent);
-  background: transparent;
-  border: 1px solid color-mix(in oklch, var(--research-accent) 45%, transparent);
-  border-radius: var(--radius-pill);
-  cursor: pointer;
-}
-.research-res-card__add:hover:not(:disabled) {
-  background: var(--research-accent-soft);
-  border-color: var(--research-accent);
-}
-.research-res-card__add:disabled { opacity: 0.55; cursor: default; }
-.research-res-card__meta {
-  display: inline-flex;
-  gap: var(--space-2);
+.research-res-card__buttons {
   margin-left: auto;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
+.research-res-card__meta {
   color: var(--text-muted);
   white-space: nowrap;
+}
+.research-res-card__state {
+  flex: none;
+  color: var(--research-accent);
 }
 
 /* Rows variant: one horizontal line per resource. */
@@ -305,7 +349,7 @@
   white-space: nowrap;
 }
 .research-res-card[data-view="rows"] .research-res-card__sub { flex: 1; }
-.research-res-card[data-view="rows"] .research-res-card__actions {
+.research-res-card[data-view="rows"] .research-res-card__footer {
   flex: none;
   margin-top: 0;
   margin-left: auto;
@@ -405,7 +449,7 @@
 }
 .research-res-overlay__close:hover { color: var(--text-primary); background: var(--bg-subtle); }
 
-/* Source bar: url + Copy / Open. */
+/* Source bar: URL + its local copy action. */
 .research-res-overlay__source {
   display: flex;
   align-items: center;
@@ -524,7 +568,7 @@
   background: color-mix(in oklch, var(--research-accent) 7%, transparent);
 }
 
-/* Action bar: add-to-run + two-step remove confirm. */
+/* Action bar: destructive management left, workflow actions right. */
 .research-res-overlay__actions {
   display: flex;
   align-items: center;
@@ -539,17 +583,20 @@
   display: flex;
   align-items: center;
   gap: var(--space-2);
-  margin-left: auto;
+  margin-right: auto;
   flex-wrap: wrap;
-  justify-content: flex-end;
 }
 .research-res-overlay__remove-warn { font-size: var(--text-xs); color: var(--destructive); }
+.research-res-overlay__primary-actions {
+  margin-left: auto;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+}
 
 /* Focus visibility for the custom (non-Button) controls. */
 .research-res__chip:focus-visible,
 .research-res__seg button:focus-visible,
 .research-res-card__title:focus-visible,
-.research-res-card__add:focus-visible,
 .research-res-overlay__close:focus-visible,
 .research-res-overlay__source-btn:focus-visible,
 .research-res-overlay__runs-chips button:focus-visible {
@@ -564,14 +611,38 @@
 /* ── Responsive: follow the desk's container breakpoints. ── */
 @container research-desk (max-width: 760px) {
   .research-res { padding: 16px 18px 24px; }
-  .research-res__search { width: 100%; }
+  .research-res__search {
+    flex-basis: 100%;
+    max-width: none;
+    width: 100%;
+  }
   .research-res-card[data-view="rows"] .research-res-card__title { max-width: 220px; }
 }
 
 @container research-desk (max-width: 560px) {
   .research-res { padding: 14px 12px 20px; }
+  .research-res__intake-head {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+  .research-res__intake-footer,
+  .research-res-card__footer {
+    align-items: stretch;
+    flex-direction: column;
+  }
+  .research-res__intake-footer .ui-btn { width: 100%; }
   .research-res__items[data-view="grid"] { grid-template-columns: 1fr; }
   .research-res-card[data-view="rows"] { flex-wrap: wrap; }
   .research-res-card[data-view="rows"] .research-res-card__sub { flex-basis: 100%; order: 3; }
+  .research-res-card[data-view="rows"] .research-res-card__footer {
+    flex-basis: 100%;
+    margin-left: 0;
+    order: 4;
+  }
+  .research-res-card__buttons,
+  .research-res-overlay__primary-actions {
+    width: 100%;
+    margin-left: 0;
+  }
   .research-res-overlay__actions { align-items: flex-start; }
 }

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -90,10 +90,6 @@
 .research-res__paste::placeholder {
   color: var(--text-muted);
 }
-.research-res__paste:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 1px;
-}
 .research-res__intake-preview {
   display: flex;
   flex: 1;

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -89,6 +89,13 @@ const CHECKPOINT_MISSION = {
       status: "used",
     },
     {
+      id: "s-resource-selected",
+      title: "Qdrant guide",
+      url: "https://docs.qdrant.tech/guide",
+      sourceType: "web",
+      status: "used",
+    },
+    {
       id: "s-conflict-1",
       title: "Vendor benchmarks blog",
       url: "https://example.com/benchmarks",
@@ -216,6 +223,13 @@ const COMPLETED_MISSION = {
       id: "s-done-1",
       title: "DuckDB embedded guide",
       url: "https://example.com/duckdb-embedded",
+      sourceType: "web",
+      status: "used",
+    },
+    {
+      id: "s-resource-other",
+      title: "Efficient ANN search",
+      url: "https://arxiv.org/abs/2401.01234",
       sourceType: "web",
       status: "used",
     },
@@ -490,7 +504,7 @@ test.describe("research desk tabs", () => {
     await expect(viewer.locator(".research-studio__code")).toContainText("graph TD;");
   });
 
-  test("Resources groups links by category and the detail overlay opens and closes with focus handling", async ({ page }) => {
+  test("Resources previews URL batches, groups by workflow, filters by type, and restores detail focus", async ({ page }) => {
     await openResearchDesk(page);
     await deskTab(page, /^Resources/).click();
 
@@ -498,15 +512,46 @@ test.describe("research desk tabs", () => {
     await expect(res).toBeVisible();
     await expect(res.getByText("3 saved", { exact: false })).toBeVisible();
 
-    // Category groups in shelf order, each with its own links.
-    const github = res.getByRole("region", { name: "GitHub resources" });
-    await expect(github).toBeVisible();
-    await expect(github.getByRole("button", { name: /acme\/vector-bench/ })).toBeVisible();
-    await expect(res.getByRole("region", { name: "Docs resources" })).toContainText("Qdrant guide");
-    await expect(res.getByRole("region", { name: "Papers resources" })).toContainText("Efficient ANN search");
+    // Comma/newline batches get one live, categorized preview before saving.
+    const intake = res.getByLabel("Add resources");
+    await expect(intake).toHaveClass(/focus-ring/);
+    await expect(intake).toHaveAttribute("aria-keyshortcuts", "Meta+Enter Control+Enter");
+    await intake.fill([
+      "https://github.com/OpenCoven/coven-cave,https://arxiv.org/abs/2404.12345",
+      "https://example.com/article",
+    ].join("\n"));
+    const preview = res.locator("#research-resource-intake-preview");
+    await expect(preview).toContainText("3 resources ready.");
+    await expect(preview).toContainText("GitHub 1");
+    await expect(preview).toContainText("Papers 1");
+    await expect(preview).toContainText("Articles 1");
+    await intake.fill("");
+
+    // Workflow shelves are exclusive and ordered around the selected run.
+    const groups = res.locator(".research-res__group");
+    await expect(groups).toHaveCount(3);
+    await expect(groups.nth(0)).toHaveAttribute("aria-label", "In this run resources");
+    await expect(groups.nth(1)).toHaveAttribute("aria-label", "Uncited resources");
+    await expect(groups.nth(2)).toHaveAttribute("aria-label", "Used in other runs resources");
+
+    const selected = res.getByRole("region", { name: "In this run resources" });
+    const uncited = res.getByRole("region", { name: "Uncited resources" });
+    const usedElsewhere = res.getByRole("region", { name: "Used in other runs resources" });
+    await expect(selected).toContainText("Qdrant guide");
+    await expect(uncited.getByRole("button", { name: /acme\/vector-bench/ })).toBeVisible();
+    await expect(usedElsewhere).toContainText("Efficient ANN search");
+
+    // Source-type filtering narrows the workflow shelves without changing
+    // their meaning, and All restores the complete workflow view.
+    await res.getByRole("button", { name: /^Docs 1$/ }).click();
+    await expect(selected).toContainText("Qdrant guide");
+    await expect(uncited).toHaveCount(0);
+    await expect(usedElsewhere).toHaveCount(0);
+    await res.getByRole("button", { name: /^All 3$/ }).click();
+    await expect(uncited).toBeVisible();
 
     // Detail overlay: opens focus-trapped, closes back to the trigger.
-    const opener = github.getByRole("button", { name: /acme\/vector-bench — open details/ });
+    const opener = uncited.getByRole("button", { name: /acme\/vector-bench — open details/ });
     await opener.click();
     const overlay = page.getByRole("dialog", { name: "acme/vector-bench" });
     await expect(overlay).toBeVisible();
@@ -522,6 +567,56 @@ test.describe("research desk tabs", () => {
     await expect(page.getByRole("dialog")).toHaveCount(0);
     // Focus returns to the card title that opened it.
     await expect(opener).toBeFocused();
+  });
+
+  test("Resources preserves a new batch typed while the previous save is in flight", async ({ page }) => {
+    await openResearchDesk(page);
+
+    let postedDraft: string | null = null;
+    let releaseSaveResponse!: () => void;
+    const saveResponse = new Promise<void>((resolve) => {
+      releaseSaveResponse = resolve;
+    });
+    await page.route("**/api/research/links", async (route) => {
+      if (route.request().method() !== "POST") {
+        await route.fallback();
+        return;
+      }
+      postedDraft = (route.request().postDataJSON() as { text?: string }).text ?? null;
+      await saveResponse;
+      await route.fulfill({
+        json: {
+          ok: true,
+          added: [
+            {
+              id: "l-new",
+              url: postedDraft,
+              category: "other",
+              title: "First batch",
+              addedAt: iso(0),
+              source: "desk",
+            },
+          ],
+          duplicates: [],
+        },
+      });
+    });
+
+    await deskTab(page, /^Resources/).click();
+    const res = page.locator(".research-res");
+    const intake = res.getByLabel("Add resources");
+    const firstBatch = "https://example.com/first-batch";
+    const nextBatch = "https://example.com/next-batch";
+
+    await intake.fill(firstBatch);
+    await res.getByRole("button", { name: "Save resources" }).click();
+    await expect.poll(() => postedDraft).toBe(firstBatch);
+
+    await intake.fill(nextBatch);
+    releaseSaveResponse();
+
+    await expect(res.getByRole("status").filter({ hasText: "Saved 1 resource." })).toBeVisible();
+    await expect(intake).toHaveValue(nextBatch);
   });
 
   test("Prompt shows the composer, opens the slash palette on '/', and mode cards track typed intent", async ({ page }) => {


### PR DESCRIPTION
## Summary

Improves the Research Desk Resources surface so people can paste URL batches separated by commas or line breaks, understand what will be saved, and act on resources from workflow-first groups.

Bead: `cave-vi75u`

## Why

The existing single-line intake and category-only shelves made multi-link capture difficult and did not surface the relationship between a saved resource and the selected or previous research runs. Resource actions were also split between card and detail locations without a stable hierarchy.

## Changes

- Add a labeled multiline intake for up to 50 URLs with comma/newline parsing, normalized duplicate detection, category preview, Cmd/Ctrl+Enter submission, and server-authoritative result copy.
- Preserve a newer batch typed while an earlier save is in flight, expose the submit shortcut to assistive technology, and use the shared focus-ring contract.
- Share the per-save limit between client preview and server persistence without changing the store schema or API response shape.
- Group filtered resources into **In this run**, **Uncited**, and **Used in other runs** shelves while retaining source-type filters and search.
- Place **Open link**, **Add to run**, and the attached state in predictable card and detail footers across grid, row, and narrow layouts.
- Extend extraction, organization, server-store, component-contract, and Playwright coverage.

## Verification

- `pnpm typecheck`
- `pnpm lint` — design codemod reports zero drift
- `pnpm check:tests-wired` — all 1,275 test files wired (1 allowlisted)
- Focused tests: link extractor (19), organizer (10), research-links store (7), Resources component contracts (10)
- `pnpm test:app` — all 925 test files pass
- `pnpm build` — Next.js, server build, bundle budgets, and standalone budget pass
- `pnpm exec playwright test tests/research-desk-tabs.spec.ts --project=desktop --no-deps --retries=0 --workers=1` — full desktop Research Desk spec passes
- `git diff --check`
- Real app audit via `bash scripts/dev-app.sh`: verified a three-URL comma/newline save, category preview, duplicate-only preservation, workflow grouping, search/clear, grid/rows, detail actions, and responsive layouts at approximately 1200/720/520 px with zero console errors

## Risk + rollout notes

- No saved-link schema or API shape change.
- Existing normalization, citation lookup, selected-run attachment, copy/open/remove, focus trap, and announcer behavior remain intact.
- Fresh CI run 9908 and CodeQL run 2242 pass on head `8ce91ead1`.