### PR TITLE
feat(chat): preview citation sources

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -358,6 +358,7 @@ export const SUITES = {
     "src/components/chat-rail-modern-redesign.test.ts",
     "src/components/message-bubble-markdown.test.ts",
     "src/components/citation.test.ts",
+    "src/lib/citation-preview.test.ts",
     "src/lib/message-markdown-stream.test.ts",
     "src/lib/markdown-preview-shell.test.ts",
     "src/lib/markdown-table-cells.test.ts",

--- a/src/components/citation.test.ts
+++ b/src/components/citation.test.ts
@@ -10,7 +10,72 @@ test("the Citation UI uses the shared Popover and Cave's accent hue", () => {
   assert.match(citation, /export function CitationMarker/, "exports the inline marker");
   assert.match(citation, /export function CitationSources/, "exports the sources list");
   assert.match(citation, /import \{ Popover, PopoverBody \} from "@\/components\/ui\/popover"/, "the marker opens the shared Popover");
+  assert.match(
+    citation,
+    /createCitationPreviewCoordinator/,
+    "source previews coordinate hover and focus across the row and portaled card",
+  );
   assert.match(citation, /var\(--accent-presence\)/, "citations use the accent-presence hue");
+  assert.match(citation, /showHoverPreview = false/, "sources can opt into hover preview cards");
+  assert.match(
+    citation,
+    /onMouseEnter=\{showHoverPreview \? \(\) => preview\.enter\("row-hover"\) : undefined\}/,
+    "rows without previews do not wire hidden hover-open state",
+  );
+  assert.match(
+    citation,
+    /onMouseLeave=\{showHoverPreview \? \(\) => preview\.leave\("row-hover"\) : undefined\}/,
+    "rows without previews do not wire hidden hover-close state",
+  );
+  assert.match(
+    citation,
+    /onFocusCapture=\{showHoverPreview \? \(\) => preview\.enter\("row-focus"\) : undefined\}/,
+    "rows without previews do not wire hidden focus-open state",
+  );
+  assert.match(
+    citation,
+    /onBlurCapture=\{showHoverPreview \? leaveRowFocus : undefined\}/,
+    "rows without previews do not wire hidden focus-close state",
+  );
+  assert.match(citation, /preview\.enter\("row-hover"\)/, "row hover opens a source preview");
+  assert.match(citation, /preview\.leave\("row-hover"\)/, "row hover departure participates in coordinated closing");
+  assert.match(citation, /preview\.enter\("row-focus"\)/, "row focus opens a source preview");
+  assert.match(citation, /preview\.leave\("row-focus"\)/, "row focus departure participates in coordinated closing");
+  assert.match(citation, /preview\.enter\("preview-hover"\)/, "the portaled card can retain the preview across its gap");
+  assert.match(citation, /preview\.leave\("preview-hover"\)/, "the portaled card releases hover ownership");
+  assert.match(citation, /preview\.enter\("preview-focus"\)/, "focus within the portaled card retains the preview");
+  assert.match(citation, /preview\.leave\("preview-focus"\)/, "the portaled card releases focus ownership");
+  assert.match(
+    citation,
+    /const previewTitleIsButton = showHoverPreview && !citation\.url/,
+    "URL-less preview rows get a conditional keyboard target",
+  );
+  assert.match(
+    citation,
+    /previewTitleIsButton \? \(\s*<button[\s\S]*?type="button"[\s\S]*?aria-haspopup="dialog"/,
+    "the URL-less title is a semantic preview button without changing linked rows",
+  );
+  assert.doesNotMatch(
+    citation,
+    /<li[\s\S]*?ref=\{anchorRef\}/,
+    "the preview anchor is never the non-focusable source row",
+  );
+  assert.match(
+    citation,
+    /citation\.url \? \(\s*<a[\s\S]*?ref=\{setAnchorRef\}/,
+    "linked previews anchor to the source link so Popover can return focus",
+  );
+  assert.match(
+    citation,
+    /previewTitleIsButton \? \(\s*<button[\s\S]*?ref=\{setAnchorRef\}/,
+    "URL-less previews anchor to their keyboard target so Popover can return focus",
+  );
+  assert.match(
+    citation,
+    /onClick=\{\(\) => \(open \? preview\.dismiss\(\) : preview\.enter\("row-focus"\)\)\}/,
+    "the URL-less preview control toggles its aria-expanded dialog",
+  );
+  assert.match(citation, /ariaLabel=\{`Source \$\{citation\.n\} preview`\}/, "hover previews are announced accessibly");
   // The sources list rows are anchor targets so inline markers can jump to them.
   assert.match(citation, /id=\{citation\.id\}/, "each source row is an anchor target");
   assert.match(citation, /aria-label=\{`Source \$\{citation\.n\}: \$\{citation\.title\}`\}/, "markers are named for screen readers");
@@ -24,7 +89,11 @@ test("chat renders citations as a footer below the message, not inside the sanit
   // The parsed body (defs stripped, refs rewritten to anchors) feeds the renderer…
   assert.match(bubble, /<MarkdownContent text=\{cited\.body\}/, "the def-stripped body feeds the markdown renderer");
   // …and the sources render as a sibling footer, never inside the HTML string.
-  assert.match(bubble, /cited\.citations\.length > 0 \? <CitationSources citations=\{cited\.citations\}/, "sources render as a footer");
+  assert.match(
+    bubble,
+    /cited\.citations\.length > 0 \? <CitationSources citations=\{cited\.citations\} showHoverPreview \/>/,
+    "chat opts into hover-preview citation sources",
+  );
 });
 
 test("research cites the mission's used sources under the synthesis", () => {

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -966,7 +966,7 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
         ) : (
           <MarkdownContent text={cited.body} pending={pending} onOpenUrl={onOpenUrl} />
         )}
-        {cited.citations.length > 0 ? <CitationSources citations={cited.citations} /> : null}
+        {cited.citations.length > 0 ? <CitationSources citations={cited.citations} showHoverPreview /> : null}
       </div>
       {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
           actions are reachable by keyboard (Tab), screen readers, and touch. */}

--- a/src/components/ui/citation.tsx
+++ b/src/components/ui/citation.tsx
@@ -10,9 +10,10 @@
  * tokens (accent-presence for the citation hue, the type scale for sizing).
  */
 
-import { useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
 import { Icon } from "@/lib/icon";
 import { Popover, PopoverBody } from "@/components/ui/popover";
+import { createCitationPreviewCoordinator } from "@/lib/citation-preview";
 import type { Citation } from "@/lib/citations";
 
 function CitationCard({ citation }: { citation: Citation }) {
@@ -83,14 +84,126 @@ export function CitationMarker({ citation }: { citation: Citation }) {
 }
 
 /** The "Sources" list rendered under a cited body. Anchor targets for markers. */
+function CitationSourceRow({
+  citation,
+  showHoverPreview,
+}: {
+  citation: Citation;
+  showHoverPreview: boolean;
+}) {
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const [open, setOpen] = useState(false);
+  const preview = useMemo(() => createCitationPreviewCoordinator(setOpen), [setOpen]);
+  const previewTitleIsButton = showHoverPreview && !citation.url;
+  const setAnchorRef = useCallback((element: HTMLElement | null) => {
+    anchorRef.current = element;
+  }, []);
+
+  useEffect(() => () => preview.dispose(), [preview]);
+
+  const leaveRowFocus = (event: FocusEvent<HTMLLIElement>) => {
+    const next = event.relatedTarget;
+    if (next instanceof Node && event.currentTarget.contains(next)) return;
+    preview.leave("row-focus");
+  };
+  const leavePreviewFocus = (event: FocusEvent<HTMLDivElement>) => {
+    const next = event.relatedTarget;
+    if (next instanceof Node && event.currentTarget.contains(next)) return;
+    preview.leave("preview-focus");
+  };
+
+  return (
+    <li
+      id={citation.id}
+      className="flex scroll-mt-4 items-start gap-2"
+      onMouseEnter={showHoverPreview ? () => preview.enter("row-hover") : undefined}
+      onMouseLeave={showHoverPreview ? () => preview.leave("row-hover") : undefined}
+      onFocusCapture={showHoverPreview ? () => preview.enter("row-focus") : undefined}
+      onBlurCapture={showHoverPreview ? leaveRowFocus : undefined}
+    >
+      <span
+        aria-hidden
+        className="mt-0.5 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] px-1 text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]"
+      >
+        {citation.n}
+      </span>
+      <div className="min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+          {citation.url ? (
+            <a
+              ref={setAnchorRef}
+              href={citation.url}
+              target="_blank"
+              rel="noreferrer"
+              className="focus-ring inline-flex items-center gap-1 text-[length:var(--text-sm)] font-medium text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
+            >
+              {citation.title}
+              <Icon name="ph:arrow-square-out" width={11} height={11} className="shrink-0" aria-hidden />
+            </a>
+          ) : previewTitleIsButton ? (
+            <button
+              ref={setAnchorRef}
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded={open}
+              onClick={() => (open ? preview.dismiss() : preview.enter("row-focus"))}
+              className="focus-ring text-left text-[length:var(--text-sm)] font-medium text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
+            >
+              {citation.title}
+            </button>
+          ) : (
+            <span className="text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">
+              {citation.title}
+            </span>
+          )}
+          {citation.domain ? (
+            <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">{citation.domain}</span>
+          ) : null}
+        </div>
+        {citation.snippet ? (
+          <p className="mt-0.5 line-clamp-2 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
+            {citation.snippet}
+          </p>
+        ) : null}
+      </div>
+      {showHoverPreview ? (
+        <Popover
+          open={open}
+          onOpenChange={(nextOpen) => {
+            if (nextOpen) setOpen(true);
+            else preview.dismiss();
+          }}
+          anchorRef={anchorRef}
+          placement="top-start"
+          ariaLabel={`Source ${citation.n} preview`}
+          minWidth={260}
+        >
+          <PopoverBody>
+            <div
+              onMouseEnter={() => preview.enter("preview-hover")}
+              onMouseLeave={() => preview.leave("preview-hover")}
+              onFocusCapture={() => preview.enter("preview-focus")}
+              onBlurCapture={leavePreviewFocus}
+            >
+              <CitationCard citation={citation} />
+            </div>
+          </PopoverBody>
+        </Popover>
+      ) : null}
+    </li>
+  );
+}
+
 export function CitationSources({
   citations,
   className = "",
   label = "Sources",
+  showHoverPreview = false,
 }: {
   citations: readonly Citation[];
   className?: string;
   label?: string;
+  showHoverPreview?: boolean;
 }) {
   if (citations.length === 0) return null;
   return (
@@ -103,41 +216,7 @@ export function CitationSources({
       </div>
       <ol className="flex flex-col gap-1.5">
         {citations.map((citation) => (
-          <li key={citation.id} id={citation.id} className="flex scroll-mt-4 items-start gap-2">
-            <span
-              aria-hidden
-              className="mt-0.5 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] px-1 text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]"
-            >
-              {citation.n}
-            </span>
-            <div className="min-w-0">
-              <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                {citation.url ? (
-                  <a
-                    href={citation.url}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="focus-ring inline-flex items-center gap-1 text-[length:var(--text-sm)] font-medium text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
-                  >
-                    {citation.title}
-                    <Icon name="ph:arrow-square-out" width={11} height={11} className="shrink-0" aria-hidden />
-                  </a>
-                ) : (
-                  <span className="text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">
-                    {citation.title}
-                  </span>
-                )}
-                {citation.domain ? (
-                  <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">{citation.domain}</span>
-                ) : null}
-              </div>
-              {citation.snippet ? (
-                <p className="mt-0.5 line-clamp-2 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
-                  {citation.snippet}
-                </p>
-              ) : null}
-            </div>
-          </li>
+          <CitationSourceRow key={citation.id} citation={citation} showHoverPreview={showHoverPreview} />
         ))}
       </ol>
     </section>

--- a/src/lib/citation-preview.test.ts
+++ b/src/lib/citation-preview.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createCitationPreviewCoordinator } from "./citation-preview.ts";
+
+const wait = (milliseconds: number) => new Promise((resolve) => setTimeout(resolve, milliseconds));
+
+test("citation previews stay open until row hover and focus have both left", async (t) => {
+  const changes: boolean[] = [];
+  const preview = createCitationPreviewCoordinator((open) => changes.push(open), 10);
+  t.after(() => preview.dispose());
+
+  preview.enter("row-focus");
+  preview.enter("row-hover");
+  preview.leave("row-hover");
+  await wait(30);
+
+  assert.equal(changes.includes(false), false, "pointer departure must not override retained keyboard focus");
+
+  preview.leave("row-focus");
+  await wait(30);
+
+  assert.equal(changes.at(-1), false, "the preview closes once the final active interaction leaves");
+});
+
+test("citation previews tolerate the gap between a row and its portaled card", async (t) => {
+  const changes: boolean[] = [];
+  const preview = createCitationPreviewCoordinator((open) => changes.push(open), 10);
+  t.after(() => preview.dispose());
+
+  preview.enter("row-hover");
+  preview.leave("row-hover");
+  preview.enter("preview-hover");
+  await wait(30);
+
+  assert.equal(changes.includes(false), false, "entering the card cancels the pending row close");
+
+  preview.leave("preview-hover");
+  await wait(30);
+
+  assert.equal(changes.at(-1), false, "the preview closes after the card is also left");
+});

--- a/src/lib/citation-preview.ts
+++ b/src/lib/citation-preview.ts
@@ -1,0 +1,49 @@
+export type CitationPreviewInteraction = "row-hover" | "row-focus" | "preview-hover" | "preview-focus";
+
+export type CitationPreviewCoordinator = {
+  enter: (interaction: CitationPreviewInteraction) => void;
+  leave: (interaction: CitationPreviewInteraction) => void;
+  dismiss: () => void;
+  dispose: () => void;
+};
+
+export function createCitationPreviewCoordinator(
+  onOpenChange: (open: boolean) => void,
+  closeDelayMs = 180,
+): CitationPreviewCoordinator {
+  const activeInteractions = new Set<CitationPreviewInteraction>();
+  let closeTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const cancelClose = () => {
+    if (closeTimer === undefined) return;
+    clearTimeout(closeTimer);
+    closeTimer = undefined;
+  };
+
+  return {
+    enter(interaction) {
+      activeInteractions.add(interaction);
+      cancelClose();
+      onOpenChange(true);
+    },
+    leave(interaction) {
+      activeInteractions.delete(interaction);
+      if (activeInteractions.size > 0) return;
+
+      cancelClose();
+      closeTimer = setTimeout(() => {
+        closeTimer = undefined;
+        if (activeInteractions.size === 0) onOpenChange(false);
+      }, closeDelayMs);
+    },
+    dismiss() {
+      activeInteractions.clear();
+      cancelClose();
+      onOpenChange(false);
+    },
+    dispose() {
+      activeInteractions.clear();
+      cancelClose();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- add compact source previews when chat citation rows are hovered or focused
- coordinate row/card hover and focus so the portaled preview stays open across the pointer gap
- preserve linked rows as a single anchor tab stop and add a conditional focus target for URL-less sources

## Why

Chat citations currently expose the source title and snippet inline, but reviewing fuller source context requires leaving the response. This adds an optional preview affordance to the shared citation list and enables it only for chat messages.

## Verification

- `node --experimental-strip-types src/lib/citation-preview.test.ts` — 2/2 passed
- `node --experimental-strip-types src/components/citation.test.ts` — 3/3 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,275 files wired
- `pnpm test:app` — 925/925 test files passed
- `git diff --check`

Bead: `cave-73l8x`