### PR TITLE
fix: keep familiar rooms reachable

### DIFF
--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -336,7 +336,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: NAVIGATOR_SURFACE_ID,
   role: "navigator",
-  aliases: ["planner", "planning"],
+  aliases: ["planner", "planning", "navigation"],
   title: "Chart Room",
   iconName: "ph:compass",
   description: "Course lanes, scheduled legs, and real board moves",
@@ -462,7 +462,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: INDEXER_SURFACE_ID,
   role: "indexer",
-  aliases: ["archivist", "indexing"],
+  aliases: ["archivist", "indexing", "memory", "reflection"],
   title: "The Archive",
   iconName: "ph:tree-structure",
   description: "Long-term knowledge, memory, indexes, and provenance",

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -111,7 +111,6 @@ test("room aliases cover the live navigation and memory role labels", () => {
   const navigator = familiarRoleIds({
     id: "astra",
     role: "Strategy / Navigation",
-    familiarType: "planning",
   });
   assert.ok(
     surfaceMatchesRoles(
@@ -123,7 +122,6 @@ test("room aliases cover the live navigation and memory role labels", () => {
   const indexer = familiarRoleIds({
     id: "echo",
     role: "Memory / Reflection",
-    familiarType: "indexing",
   });
   assert.ok(
     surfaceMatchesRoles(

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -107,6 +107,32 @@ test("surfaceMatchesRoles honors alias roles with the same normalization", () =>
   assert.ok(!surfaceMatchesRoles({ role: "navigator", aliases: ["editor"] }, planner));
 });
 
+test("room aliases cover the live navigation and memory role labels", () => {
+  const navigator = familiarRoleIds({
+    id: "astra",
+    role: "Strategy / Navigation",
+    familiarType: "planning",
+  });
+  assert.ok(
+    surfaceMatchesRoles(
+      { role: "navigator", aliases: ["planner", "planning", "navigation"] },
+      navigator,
+    ),
+  );
+
+  const indexer = familiarRoleIds({
+    id: "echo",
+    role: "Memory / Reflection",
+    familiarType: "indexing",
+  });
+  assert.ok(
+    surfaceMatchesRoles(
+      { role: "indexer", aliases: ["archivist", "indexing", "memory", "reflection"] },
+      indexer,
+    ),
+  );
+});
+
 test("familiarRoleIds grants the explicit familiar Type's tokens (cave-cc5r)", () => {
   const ids = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "coding" });
   assert.ok(ids.has("coding"));
@@ -230,17 +256,20 @@ test("matchesShortcutCombo honors mod aliasing and rejects extra modifiers", () 
   assert.ok(!matchesShortcutCombo({ ...base, key: "f", metaKey: true }, "mod+e")); // wrong key
 });
 
-test("registry keeps retired familiar-type words as aliases (cave-lgcb)", () => {
+test("registry keeps retired types and their live role labels reachable (cave-lgcb)", () => {
   // The vocabulary reduction removed watch/planning/writing/indexing from the
-  // Type picker; their rooms stay reachable through Role labels only because
-  // register.tsx carries these alias words. Pin them so the continuity story
-  // can't silently drift from the shapes asserted in familiar-types.test.ts.
+  // Type picker. Their rooms stay reachable through free-text Role labels only
+  // because register.tsx carries both retired vocabulary and the labels used by
+  // the production familiars. Pin both so continuity cannot silently drift.
   const source = readFileSync(
     new URL("../components/role-surfaces/register.tsx", import.meta.url),
     "utf8",
   );
   assert.match(source, /aliases:\s*\["watch",\s*"guardian"\]/);
-  assert.match(source, /aliases:\s*\["planner",\s*"planning"\]/);
+  assert.match(source, /aliases:\s*\["planner",\s*"planning",\s*"navigation"\]/);
   assert.match(source, /aliases:\s*\["editor",\s*"writer",\s*"writing"\]/);
-  assert.match(source, /aliases:\s*\["archivist",\s*"indexing"\]/);
+  assert.match(
+    source,
+    /aliases:\s*\["archivist",\s*"indexing",\s*"memory",\s*"reflection"\]/,
+  );
 });


### PR DESCRIPTION
## Summary

- map the live `Strategy / Navigation` role label to the Navigator Chart Room
- map the live `Memory / Reflection` role label to the Indexer Archive
- pin both compound-label behaviors and registry aliases with focused regression coverage

## Root cause

The room registry retained the retired type aliases (`planning`, `indexing`) but not every token used by current free-text role labels, so role-only familiars could lose their specialized room.

## Verification

- `node --experimental-strip-types src/lib/role-surfaces.test.ts` (17/17)
- `pnpm test:app` (932/932 files)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1282 wired, 1 allowlisted)
- `git diff --check`

Bead: `cave-vv8m5`