### PR TITLE
fix: keep familiar rooms reachable at compact widths

### DIFF
--- a/src/components/role-surfaces/indexer-surface.test.ts
+++ b/src/components/role-surfaces/indexer-surface.test.ts
@@ -75,3 +75,22 @@ test("memory details wait for the inventory source before exposing selection con
     /entriesError\s*\?\s*\([\s\S]*?<SurfaceError[\s\S]*?live=\{false\}[\s\S]*?\)\s*:\s*entries == null\s*\?\s*\([\s\S]*?<SurfaceLoading[\s\S]*?live=\{false\}[\s\S]*?\)\s*:\s*!selected/,
   );
 });
+
+test("compact Collections and Memory details rails stay mutually exclusive", () => {
+  assert.match(
+    surface,
+    /const setCollectionsRailExpanded = \(next: boolean\) => \{\s*setCollectionsExpanded\(next\);\s*if \(next\) setDetailsExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /const setDetailsRailExpanded = \(next: boolean\) => \{\s*setDetailsExpanded\(next\);\s*if \(next\) setCollectionsExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="left"\s+label="Collections"\s+expanded=\{collectionsExpanded\}\s+onExpandedChange=\{setCollectionsRailExpanded\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="right"\s+label="Memory details"\s+expanded=\{detailsExpanded\}\s+onExpandedChange=\{setDetailsRailExpanded\}/,
+  );
+});

--- a/src/components/role-surfaces/indexer-surface.tsx
+++ b/src/components/role-surfaces/indexer-surface.tsx
@@ -95,6 +95,15 @@ export function IndexerSurface({ context }: { context: RoleSurfaceContext }) {
     [entries, state.selectedPath],
   );
   const [detailsExpanded, setDetailsExpanded] = useActiveSelectionRail(state.selectedPath);
+  const [collectionsExpanded, setCollectionsExpanded] = useState(false);
+  const setCollectionsRailExpanded = (next: boolean) => {
+    setCollectionsExpanded(next);
+    if (next) setDetailsExpanded(false);
+  };
+  const setDetailsRailExpanded = (next: boolean) => {
+    setDetailsExpanded(next);
+    if (next) setCollectionsExpanded(false);
+  };
 
   // Selected memory content, read through the shared adapter (redacted).
   const fetchContent = useCallback(async () => {
@@ -186,7 +195,12 @@ export function IndexerSurface({ context }: { context: RoleSurfaceContext }) {
         </div>
       }
     >
-      <SurfaceRail side="left" label="Collections">
+      <SurfaceRail
+        side="left"
+        label="Collections"
+        expanded={collectionsExpanded}
+        onExpandedChange={setCollectionsRailExpanded}
+      >
         <RailSection title="Knowledge collections" iconName="ph:folder">
           {entriesError ? (
             <SurfaceError
@@ -272,7 +286,7 @@ export function IndexerSurface({ context }: { context: RoleSurfaceContext }) {
                     className={`role-surface-card focus-ring${entry.fullPath === state.selectedPath ? " role-surface-card--active" : ""}`}
                     onClick={() => {
                       patch({ selectedPath: entry.fullPath });
-                      setDetailsExpanded(true);
+                      setDetailsRailExpanded(true);
                     }}
                   >
                     <span className="role-surface-memory-path">{entry.relPath}</span>
@@ -296,7 +310,7 @@ export function IndexerSurface({ context }: { context: RoleSurfaceContext }) {
         side="right"
         label="Memory details"
         expanded={detailsExpanded}
-        onExpandedChange={setDetailsExpanded}
+        onExpandedChange={setDetailsRailExpanded}
       >
         {entriesError ? (
           <RailSection title="Details" iconName="ph:note">

--- a/src/components/role-surfaces/navigator-surface.test.ts
+++ b/src/components/role-surfaces/navigator-surface.test.ts
@@ -195,6 +195,25 @@ test("card details wait for the board source before exposing move controls", () 
   );
 });
 
+test("compact Course and Card details rails stay mutually exclusive", () => {
+  assert.match(
+    surface,
+    /const setCourseRailExpanded = \(next: boolean\) => \{\s*setCourseExpanded\(next\);\s*if \(next\) setDetailsExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /const setDetailsRailExpanded = \(next: boolean\) => \{\s*setDetailsExpanded\(next\);\s*if \(next\) setCourseExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="left"\s+label="Course"\s+expanded=\{courseExpanded\}\s+onExpandedChange=\{setCourseRailExpanded\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="right"\s+label="Card details"\s+expanded=\{detailsExpanded\}\s+onExpandedChange=\{setDetailsRailExpanded\}/,
+  );
+});
+
 test("registration names the Chart Room with its own accent and drawer chrome", () => {
   assert.match(register, /id: NAVIGATOR_SURFACE_ID/);
   assert.match(register, /role: "navigator"/);

--- a/src/components/role-surfaces/navigator-surface.tsx
+++ b/src/components/role-surfaces/navigator-surface.tsx
@@ -113,6 +113,15 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
     [cards, state.selectedId],
   );
   const [detailsExpanded, setDetailsExpanded] = useActiveSelectionRail(state.selectedId);
+  const [courseExpanded, setCourseExpanded] = useState(false);
+  const setCourseRailExpanded = (next: boolean) => {
+    setCourseExpanded(next);
+    if (next) setDetailsExpanded(false);
+  };
+  const setDetailsRailExpanded = (next: boolean) => {
+    setDetailsExpanded(next);
+    if (next) setCourseExpanded(false);
+  };
   const today = new Date().toISOString().slice(0, 10);
   const legs = useMemo(() => upcomingLegs(cards ?? [], today), [cards, today]);
   const recentlyDone = useMemo(
@@ -245,7 +254,12 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
         </div>
       }
     >
-      <SurfaceRail side="left" label="Course">
+      <SurfaceRail
+        side="left"
+        label="Course"
+        expanded={courseExpanded}
+        onExpandedChange={setCourseRailExpanded}
+      >
         <RailSection title="Chart a task" iconName="ph:compass">
           <form
             className="role-surface-inline-form"
@@ -376,7 +390,7 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
                       aria-current={card.id === state.selectedId ? "true" : undefined}
                       onClick={() => {
                         patch({ selectedId: card.id });
-                        setDetailsExpanded(true);
+                        setDetailsRailExpanded(true);
                       }}
                     >
                       <span className="role-surface-card-tags">
@@ -409,7 +423,7 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
         side="right"
         label="Card details"
         expanded={detailsExpanded}
-        onExpandedChange={setDetailsExpanded}
+        onExpandedChange={setDetailsRailExpanded}
       >
         {boardError && cards == null ? (
           <RailSection title="Details" iconName="ph:note">

--- a/src/components/role-surfaces/register.tsx
+++ b/src/components/role-surfaces/register.tsx
@@ -336,7 +336,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: NAVIGATOR_SURFACE_ID,
   role: "navigator",
-  aliases: ["planner", "planning"],
+  aliases: ["planner", "planning", "navigation"],
   title: "Chart Room",
   iconName: "ph:compass",
   description: "Course lanes, scheduled legs, and real board moves",
@@ -462,7 +462,7 @@ registerRoleSurface({
 registerRoleSurface({
   id: INDEXER_SURFACE_ID,
   role: "indexer",
-  aliases: ["archivist", "indexing"],
+  aliases: ["archivist", "indexing", "memory", "reflection"],
   title: "The Archive",
   iconName: "ph:tree-structure",
   description: "Long-term knowledge, memory, indexes, and provenance",

--- a/src/components/role-surfaces/reviewer-surface.test.ts
+++ b/src/components/role-surfaces/reviewer-surface.test.ts
@@ -21,6 +21,7 @@ import {
 const surface = readFileSync(new URL("./reviewer-surface.tsx", import.meta.url), "utf8");
 const register = readFileSync(new URL("./register.tsx", import.meta.url), "utf8");
 const docs = readFileSync(new URL("../../../docs/role-surfaces.md", import.meta.url), "utf8");
+const reviewDeckCss = readFileSync(new URL("../../styles/review-deck.css", import.meta.url), "utf8");
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -199,6 +200,21 @@ test("registration names the Review Deck with its own accent and drawer chrome",
 
 test("the Review Deck is documented as an initial room", () => {
   assert.match(docs, /\*\*Review Deck\*\* \(`reviewer-review-deck`, role `reviewer`\)/);
+});
+
+test("the Review Deck stacks its tri-pane layout before verdict actions clip", () => {
+  assert.match(
+    reviewDeckCss,
+    /@container role-surface-host \(max-width: 1080px\) \{[\s\S]*?\.rd-stage \{[\s\S]*?overflow-y: auto;/,
+  );
+  assert.match(
+    reviewDeckCss,
+    /@container role-surface-host \(max-width: 1080px\) \{[\s\S]*?\.rd-grid[\s\S]*?grid-template-columns: minmax\(0, 1fr\);/,
+  );
+  assert.match(
+    reviewDeckCss,
+    /@container role-surface-host \(max-width: 1080px\) \{[\s\S]*?\.rd-verdict-bar \{[\s\S]*?flex-wrap: wrap;/,
+  );
 });
 
 // ── Type, lifecycle & verdict derivation ─────────────────────────────────────

--- a/src/components/role-surfaces/sentinel-surface.test.ts
+++ b/src/components/role-surfaces/sentinel-surface.test.ts
@@ -251,6 +251,25 @@ test("alert details wait for the source before exposing triage controls", () => 
   );
 });
 
+test("compact Watch status and Alert details rails stay mutually exclusive", () => {
+  assert.match(
+    surface,
+    /const setWatchRailExpanded = \(next: boolean\) => \{\s*setWatchExpanded\(next\);\s*if \(next\) setDetailsExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /const setDetailsRailExpanded = \(next: boolean\) => \{\s*setDetailsExpanded\(next\);\s*if \(next\) setWatchExpanded\(false\);\s*\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="left"\s+label="Watch status"\s+expanded=\{watchExpanded\}\s+onExpandedChange=\{setWatchRailExpanded\}/,
+  );
+  assert.match(
+    surface,
+    /<SurfaceRail\s+side="right"\s+label="Alert details"\s+expanded=\{detailsExpanded\}\s+onExpandedChange=\{setDetailsRailExpanded\}/,
+  );
+});
+
 test("registration names the Watchtower with its own accent and drawer chrome", () => {
   assert.match(register, /id: SENTINEL_SURFACE_ID/);
   assert.match(register, /role: "sentinel"/);

--- a/src/components/role-surfaces/sentinel-surface.tsx
+++ b/src/components/role-surfaces/sentinel-surface.tsx
@@ -138,6 +138,15 @@ export function SentinelSurface({ context }: { context: RoleSurfaceContext }) {
     [alerts, state.selectedId],
   );
   const [detailsExpanded, setDetailsExpanded] = useActiveSelectionRail(state.selectedId);
+  const [watchExpanded, setWatchExpanded] = useState(false);
+  const setWatchRailExpanded = (next: boolean) => {
+    setWatchExpanded(next);
+    if (next) setDetailsExpanded(false);
+  };
+  const setDetailsRailExpanded = (next: boolean) => {
+    setDetailsExpanded(next);
+    if (next) setWatchExpanded(false);
+  };
   const watch = useMemo(() => watchSessions(context.runtimeState.sessions), [context.runtimeState.sessions]);
   const recentlyClosed = useMemo(
     () =>
@@ -264,7 +273,12 @@ export function SentinelSurface({ context }: { context: RoleSurfaceContext }) {
         </div>
       }
     >
-      <SurfaceRail side="left" label="Watch status">
+      <SurfaceRail
+        side="left"
+        label="Watch status"
+        expanded={watchExpanded}
+        onExpandedChange={setWatchRailExpanded}
+      >
         <RailSection title="Watch status" iconName="ph:heartbeat">
           <ul className="role-surface-list">
             <li className="role-surface-list-row">
@@ -414,7 +428,7 @@ export function SentinelSurface({ context }: { context: RoleSurfaceContext }) {
                     aria-current={item.id === state.selectedId ? "true" : undefined}
                     onClick={() => {
                       patch({ selectedId: item.id });
-                      setDetailsExpanded(true);
+                      setDetailsRailExpanded(true);
                     }}
                   >
                     <span className="role-surface-card-tags">
@@ -441,7 +455,7 @@ export function SentinelSurface({ context }: { context: RoleSurfaceContext }) {
         side="right"
         label="Alert details"
         expanded={detailsExpanded}
-        onExpandedChange={setDetailsExpanded}
+        onExpandedChange={setDetailsRailExpanded}
       >
         {alertsError && alerts == null ? (
           <RailSection title="Details" iconName="ph:note">

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -107,6 +107,32 @@ test("surfaceMatchesRoles honors alias roles with the same normalization", () =>
   assert.ok(!surfaceMatchesRoles({ role: "navigator", aliases: ["editor"] }, planner));
 });
 
+test("room aliases cover the live navigation and memory role labels", () => {
+  const navigator = familiarRoleIds({
+    id: "astra",
+    role: "Strategy / Navigation",
+    familiarType: "planning",
+  });
+  assert.ok(
+    surfaceMatchesRoles(
+      { role: "navigator", aliases: ["planner", "planning", "navigation"] },
+      navigator,
+    ),
+  );
+
+  const indexer = familiarRoleIds({
+    id: "echo",
+    role: "Memory / Reflection",
+    familiarType: "indexing",
+  });
+  assert.ok(
+    surfaceMatchesRoles(
+      { role: "indexer", aliases: ["archivist", "indexing", "memory", "reflection"] },
+      indexer,
+    ),
+  );
+});
+
 test("familiarRoleIds grants the explicit familiar Type's tokens (cave-cc5r)", () => {
   const ids = familiarRoleIds({ id: "f", role: "Orchestrator", familiarType: "coding" });
   assert.ok(ids.has("coding"));
@@ -230,17 +256,20 @@ test("matchesShortcutCombo honors mod aliasing and rejects extra modifiers", () 
   assert.ok(!matchesShortcutCombo({ ...base, key: "f", metaKey: true }, "mod+e")); // wrong key
 });
 
-test("registry keeps retired familiar-type words as aliases (cave-lgcb)", () => {
+test("registry keeps retired types and their live role labels reachable (cave-lgcb)", () => {
   // The vocabulary reduction removed watch/planning/writing/indexing from the
-  // Type picker; their rooms stay reachable through Role labels only because
-  // register.tsx carries these alias words. Pin them so the continuity story
-  // can't silently drift from the shapes asserted in familiar-types.test.ts.
+  // Type picker. Their rooms stay reachable through free-text Role labels only
+  // because register.tsx carries both retired vocabulary and the labels used by
+  // the production familiars. Pin both so continuity cannot silently drift.
   const source = readFileSync(
     new URL("../components/role-surfaces/register.tsx", import.meta.url),
     "utf8",
   );
   assert.match(source, /aliases:\s*\["watch",\s*"guardian"\]/);
-  assert.match(source, /aliases:\s*\["planner",\s*"planning"\]/);
+  assert.match(source, /aliases:\s*\["planner",\s*"planning",\s*"navigation"\]/);
   assert.match(source, /aliases:\s*\["editor",\s*"writer",\s*"writing"\]/);
-  assert.match(source, /aliases:\s*\["archivist",\s*"indexing"\]/);
+  assert.match(
+    source,
+    /aliases:\s*\["archivist",\s*"indexing",\s*"memory",\s*"reflection"\]/,
+  );
 });

--- a/src/styles/review-deck.css
+++ b/src/styles/review-deck.css
@@ -801,6 +801,96 @@
 .rd-scroll::-webkit-scrollbar { width: 8px; height: 8px; }
 .rd-scroll::-webkit-scrollbar-thumb { background: var(--border-strong); border-radius: var(--radius-pill); }
 
+/* The fixed tri-pane furniture needs more width than a narrow workspace can
+   offer. Stack it before the center viewer collapses under the two rails, and
+   let the room itself own the resulting vertical scroll. */
+@container role-surface-host (max-width: 1080px) {
+  .rd-stage {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+  }
+
+  .rd-summary {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .rd-grid {
+    flex: none;
+    min-height: auto;
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .rd-queue {
+    min-height: 320px;
+    max-height: 420px;
+  }
+
+  .rd-viewer {
+    min-height: 480px;
+  }
+
+  .rd-context {
+    max-height: 360px;
+  }
+
+  .rd-collapsed {
+    min-height: var(--touch-target);
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: var(--space-2);
+  }
+
+  .rd-collapsed-label {
+    flex: none;
+    writing-mode: horizontal-tb;
+    transform: none;
+  }
+
+  .rd-verdict-bar {
+    flex-wrap: wrap;
+  }
+
+  .rd-verdict-lead {
+    flex: 1 1 100%;
+    flex-wrap: wrap;
+  }
+
+  .rd-verdict-bar > .rd-spacer {
+    display: none;
+  }
+
+  .rd-verdict-bar > .rd-btn {
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
+@container role-surface-host (max-width: 680px) {
+  .rd-stage {
+    gap: var(--space-2);
+    padding: var(--space-3);
+  }
+
+  .rd-stat {
+    gap: var(--space-2);
+    padding: var(--space-3);
+  }
+
+  .rd-stat-label {
+    white-space: normal;
+  }
+
+  .rd-verdict-bar {
+    gap: var(--space-2);
+    padding: var(--space-3);
+  }
+
+  .rd-verdict-bar > .rd-btn {
+    min-height: var(--touch-target);
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .rd-grid,
   .rd-row,


### PR DESCRIPTION
## Summary

Follow-up to #3945 and `cave-vv8m5`.

- Match live `Strategy / Navigation` and `Memory / Reflection` role labels to the Chart Room and Archive.
- Stack the Review Deck before its tri-pane layout clips verdict actions.
- Keep compact Chart Room, Archive, and Watchtower rails mutually exclusive while preserving Escape and focus-return behavior.

## Verification

- Focused role-surface contracts: 83/83 tests
- `pnpm typecheck`
- `pnpm lint` (design codemod: 0 drift)
- `pnpm check:tests-wired` (1282 wired; 1 allowlisted)
- `pnpm test:app` (932/932 files)
- `pnpm build` (bundle and standalone budgets pass)
- Native Tauri launch plus default-browser audit: 8 rooms × 3 widths × 3 theme/mode combinations = 72 layouts, with compact rail focus/Escape checks and 0 failures
- `git diff --check`
