### PR TITLE
fix: complete compact familiar-room review follow-up

### DIFF
--- a/src/components/role-surfaces/navigator-surface.test.ts
+++ b/src/components/role-surfaces/navigator-surface.test.ts
@@ -214,12 +214,12 @@ test("compact Course and Card details rails stay mutually exclusive", () => {
   );
   assert.match(
     surface,
-    /onClick=\{\(\) => \{\s*patch\(\{ selectedId: card\.id, lane: "blocked" \}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
+    /onClick=\{\(\) => \{\s*patch\(\{(?=[^}]*\bselectedId:\s*card\.id)(?=[^}]*\blane:\s*"blocked")[^}]*\}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
     "blocked-card selection closes Course before opening Card details",
   );
   assert.match(
     surface,
-    /onClick=\{\(\) => \{\s*patch\(\{ selectedId: leg\.card\.id \}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
+    /onClick=\{\(\) => \{\s*patch\(\{(?=[^}]*\bselectedId:\s*leg\.card\.id)[^}]*\}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
     "upcoming-leg selection closes Course before opening Card details",
   );
 });

--- a/src/components/role-surfaces/navigator-surface.test.ts
+++ b/src/components/role-surfaces/navigator-surface.test.ts
@@ -212,6 +212,16 @@ test("compact Course and Card details rails stay mutually exclusive", () => {
     surface,
     /<SurfaceRail\s+side="right"\s+label="Card details"\s+expanded=\{detailsExpanded\}\s+onExpandedChange=\{setDetailsRailExpanded\}/,
   );
+  assert.match(
+    surface,
+    /onClick=\{\(\) => \{\s*patch\(\{ selectedId: card\.id, lane: "blocked" \}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
+    "blocked-card selection closes Course before opening Card details",
+  );
+  assert.match(
+    surface,
+    /onClick=\{\(\) => \{\s*patch\(\{ selectedId: leg\.card\.id \}\);\s*setDetailsRailExpanded\(true\);\s*\}\}/,
+    "upcoming-leg selection closes Course before opening Card details",
+  );
 });
 
 test("registration names the Chart Room with its own accent and drawer chrome", () => {

--- a/src/components/role-surfaces/navigator-surface.tsx
+++ b/src/components/role-surfaces/navigator-surface.tsx
@@ -241,7 +241,10 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
                     <button
                       type="button"
                       className="role-surface-row-btn focus-ring-inset"
-                      onClick={() => patch({ selectedId: card.id, lane: "blocked" })}
+                      onClick={() => {
+                        patch({ selectedId: card.id, lane: "blocked" });
+                        setDetailsRailExpanded(true);
+                      }}
                     >
                       {card.title}
                       <span className="role-surface-tag">{card.priority}</span>
@@ -341,7 +344,10 @@ export function NavigatorSurface({ context }: { context: RoleSurfaceContext }) {
                   <button
                     type="button"
                     className="role-surface-row-btn focus-ring-inset"
-                    onClick={() => patch({ selectedId: leg.card.id })}
+                    onClick={() => {
+                      patch({ selectedId: leg.card.id });
+                      setDetailsRailExpanded(true);
+                    }}
                   >
                     {leg.card.title}
                     <span className={leg.overdue ? "role-surface-tag role-surface-metric-warn" : "role-surface-tag"}>

--- a/src/lib/role-surfaces.test.ts
+++ b/src/lib/role-surfaces.test.ts
@@ -111,7 +111,6 @@ test("room aliases cover the live navigation and memory role labels", () => {
   const navigator = familiarRoleIds({
     id: "astra",
     role: "Strategy / Navigation",
-    familiarType: "planning",
   });
   assert.ok(
     surfaceMatchesRoles(
@@ -123,7 +122,6 @@ test("room aliases cover the live navigation and memory role labels", () => {
   const indexer = familiarRoleIds({
     id: "echo",
     role: "Memory / Reflection",
-    familiarType: "indexing",
   });
   assert.ok(
     surfaceMatchesRoles(


### PR DESCRIPTION
## Summary

Forward-only follow-up to #3947:

- keep the compact Chart Room Course and Card details panels mutually exclusive when selecting blocked cards or upcoming legs
- make the live-role regression fixtures role-only, so they cannot pass through retired `planning` / `indexing` type aliases
- pin both missed Chart Room selection paths with focused contracts

## Root cause

#3947 routed main-canvas selections through the exclusive details handler, but two secondary selection paths still patched `selectedId` directly. `useActiveSelectionRail` then opened Card details without closing an already-open Course panel.

## Verification

- focused room contracts: 83/83 plus shared room contract
- `pnpm test:app` (932/932 files)
- `pnpm typecheck`
- `pnpm lint` (0 design drift)
- `pnpm check:tests-wired` (1282 wired, 1 allowlisted)
- `pnpm build` (bundle and standalone budgets pass)
- `git diff --check`

The full verification ran on a byte-identical combined tree before this signed forward commit.

Supersedes the narrower open PR #3946. Bead: `cave-vv8m5`.