### PR TITLE
fix(ui): eliminate mode and chat rendering flicker

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -525,6 +525,7 @@ export const SUITES = {
     "src/lib/reply-recommendation.test.ts",
     "src/lib/comux-projects.test.ts",
     "src/lib/code-lang.test.ts",
+    "src/lib/shiki-highlighter.test.ts",
     "src/lib/session-title.test.ts",
     "src/lib/home-suggestions.test.ts",
     "src/lib/project-search.test.ts",

--- a/src/app/globals.css.test.ts
+++ b/src/app/globals.css.test.ts
@@ -120,22 +120,14 @@ assert.doesNotMatch(salemBlock, /#(?:d1c4e9|e8e0f0|c9a7ff|d26bff|a855f7|a89ac0)\
 
 console.log("globals.css.test.ts (salem tokens) OK");
 
-// The mode-transition wrapper must never RETAIN a transform after its
-// entrance animation: fill-mode `both` kept the final keyframe's transform
-// (even identity), turning every .cave-mode-fade into the containing block
-// for position:fixed descendants — fixed overlays inside surfaces resolved
-// against the mode area instead of the viewport and forced portal-to-body
-// workarounds (#537, #1984, github-view card, cave-nv3). Bead cave-cco.
-const modeFadeRule = css.match(/\.cave-mode-fade\s*\{([\s\S]*?)\}/)?.[1] ?? "";
-assert.match(
-  modeFadeRule,
-  /animation:\s*cave-mode-in\s+120ms\s+ease-out\s+backwards/,
-  ".cave-mode-fade must use fill-mode backwards (nothing retained after the entrance)",
-);
+// The mode wrapper stays continuously visible. Animating the full pane from
+// opacity 0 caused every mode change to flash blank, while an animated
+// transform also turned the wrapper into a containing block for fixed
+// descendants (#537, #1984, github-view card, cave-nv3). Bead cave-cco.
 assert.doesNotMatch(
-  modeFadeRule,
-  /\bboth\b|\bforwards\b/,
-  ".cave-mode-fade must not retain end-state animation styles (containing-block trap, cave-cco)",
+  css,
+  /@keyframes\s+cave-mode-in|\.cave-mode-fade\s*\{[\s\S]*?(?:animation|opacity|transform)\s*:/,
+  ".cave-mode-fade must stay continuously visible and must not become a containing block",
 );
 
 // The chat/code sidebar responds to its own panel width, not the viewport —

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -400,7 +400,7 @@ assert.match(
 // line map must be dropped there or markers would be attached twice.
 assert.match(
   bubbleSource,
-  /highlighted = `<pre><code>\$\{escHtml\(code\)\}<\/code><\/pre>`;\s*\n\s*diffLines = null/,
+  /highlighted = plainCodeHtml\(code\);\s*\n\s*diffLines = null/,
   "highlight-failure fallback clears diffLines so markers are not doubled",
 );
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -203,6 +203,12 @@ import { streamFamiliarText } from "@/lib/familiar-stream";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
 import { AttachmentList, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment } from "./chat-attachment-cards";
+import { preloadMarkdownPreview } from "@/lib/markdown-preview";
+
+// Chat history commonly arrives before syntax highlighting is needed. Warm the
+// lightweight browser-only serializer while that request is in flight so
+// settled messages do not first paint as raw Markdown.
+preloadMarkdownPreview();
 
 // CHAT-D3-07 perf: `replyFor` runs for every row on every render and parses the
 // turn text (strip reasoning + Next paths) to decide whether the Reply action

--- a/src/components/gh-diff-view.tsx
+++ b/src/components/gh-diff-view.tsx
@@ -47,7 +47,7 @@ export function DiffHunk({
     let cancelled = false;
     (async () => {
       try {
-        const hl = await getShikiHighlighter();
+        const hl = await getShikiHighlighter(lang);
         // Highlight the hunk as one document (meta rows blanked) so tokens
         // stay line-aligned with the parsed rows.
         const code = lines

--- a/src/components/message-bubble-code-header.test.ts
+++ b/src/components/message-bubble-code-header.test.ts
@@ -310,11 +310,14 @@ assert.doesNotMatch(
   "The tool clamp must not introduce a second scroll container — the wrap already scrolls",
 );
 
-const renderCodeBlockFn = /async function renderCodeBlock\([\s\S]*?\n\}/.exec(source)?.[0] ?? "";
+const frameStart = source.indexOf("function renderCodeBlockFrame");
+const frameEnd = source.indexOf("\nasync function renderCodeBlock", frameStart);
+const renderCodeBlockFrameFn =
+  frameStart >= 0 && frameEnd > frameStart ? source.slice(frameStart, frameEnd) : "";
 assert.match(
-  renderCodeBlockFn,
+  renderCodeBlockFrameFn,
   /cave-code-expand-btn/,
-  "renderCodeBlock must emit the Show more footer button for clamp-height blocks",
+  "the shared plain/highlighted code frame must emit the Show more footer for clamp-height blocks",
 );
 assert.match(
   source,

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -55,6 +55,16 @@ assert.match(
 );
 assert.match(
   markdownPreview,
+  /Load the browser-only serializer once per app runtime/,
+  "the loader comment documents its module-level lifetime accurately",
+);
+assert.doesNotMatch(
+  markdownPreview,
+  /once for every Chat message/,
+  "the loader comment must not imply a separate chunk load for each message",
+);
+assert.match(
+  markdownPreview,
   /previewPromise = import\("@create-markdown\/preview"\)\.catch\(\(error\) => \{[\s\S]*?previewPromise = null;[\s\S]*?throw error;/,
   "a failed preview chunk clears the memoized promise so a later render can retry",
 );
@@ -182,18 +192,43 @@ assert.match(
 // commits if newer than the last applied stamp.
 assert.match(
   markdownContent,
-  /\+\+renderStampRef\.current/,
+  /const stamp = renderGate\.issue\(\)/,
   "Each render takes a monotonically increasing stamp",
 );
 assert.match(
   markdownContent,
-  /if \(stamp <= appliedStampRef\.current\) return;/,
+  /if \(!renderGate\.apply\(stamp\)\) return;/,
   "A render result only commits if its stamp is newer than the last applied one",
 );
 assert.match(
   markdownContent,
-  /if \(stamp < settledBarrierRef\.current\) return;[\s\S]*?settledBarrierRef\.current = plainStamp;/,
-  "settling a turn invalidates older transient renders before the final async pass resolves",
+  /if \(wasPendingRef\.current && !pending\) \{\s*renderGate\.settle\(\);\s*\}[\s\S]*?useEffect\(\(\) =>/,
+  "the pending-to-settled render boundary invalidates transient work before the passive effect runs",
+);
+assert.match(
+  markdownContent,
+  /useLayoutEffect\(\(\) => \{\s*wasPendingRef\.current = Boolean\(pending\);\s*\}, \[pending\]\);/,
+  "the previous pending marker updates only after React commits the render",
+);
+assert.doesNotMatch(
+  markdownContent,
+  /\}\s*wasPendingRef\.current = Boolean\(pending\);\s*\/\/ Throttle bookkeeping/,
+  "render must not mutate the commit-owned previous pending marker",
+);
+assert.match(
+  markdownContent,
+  /mdToHtml\(closeTrailingFence\(text\), \{ transient: true, highlightCode: false \}\)[\s\S]*?if \(!renderGate\.apply\(stamp\)\) return;/,
+  "transient promises consult the shared render gate before committing HTML",
+);
+assert.match(
+  markdownContent,
+  /const stamp = renderGate\.issue\(\);\s*const run = \(\) => \{[\s\S]*?setTimeout\(run, wait\)/,
+  "a trailing render takes its stamp when scheduled, before its timer can cross settlement",
+);
+assert.doesNotMatch(
+  markdownContent,
+  /const run = \(\) => \{[\s\S]{0,160}?const stamp = renderGate\.issue\(\)/,
+  "a delayed render must not issue a fresh post-settlement stamp when its timer fires",
 );
 
 // Streaming cursor: with rendered HTML during pending, the ▌ affordance must
@@ -245,6 +280,11 @@ assert.match(
   source,
   /class="shiki mood-c-dark cave-code-plain" tabindex="0"/,
   "the pre-highlight code pass paints a keyboard-scrollable fixed-dark code body",
+);
+assert.match(
+  source,
+  /const focusableOpen = open\.includes\("tabindex="\)[\s\S]*?open\.replace\("<pre", '<pre tabindex="0"'\)/,
+  "the shared frame keeps highlighted and plain code bodies keyboard-scrollable",
 );
 assert.match(
   source,

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -6,6 +6,8 @@ import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./message-bubble.tsx", import.meta.url), "utf8");
 const markdownStream = readFileSync(new URL("../lib/message-markdown-stream.ts", import.meta.url), "utf8");
+const markdownPreview = readFileSync(new URL("../lib/markdown-preview.ts", import.meta.url), "utf8");
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const domWiring = readFileSync(new URL("./message-dom-wiring.ts", import.meta.url), "utf8");
 
 // StrictMode regression guard: a ref-based "same text" check poisons itself
@@ -45,6 +47,36 @@ assert.match(
   source,
   /renderAsync\(blocks,\s*\{[\s\S]*customRenderers:/,
   "Chat markdown should use @create-markdown/preview renderAsync with scoped custom renderers",
+);
+assert.match(
+  markdownPreview,
+  /let previewPromise: Promise<MarkdownPreviewModule> \| null = null;/,
+  "the browser-only Markdown preview chunk is memoized behind one shared promise",
+);
+assert.match(
+  markdownPreview,
+  /previewPromise = import\("@create-markdown\/preview"\)\.catch\(\(error\) => \{[\s\S]*?previewPromise = null;[\s\S]*?throw error;/,
+  "a failed preview chunk clears the memoized promise so a later render can retry",
+);
+assert.match(
+  markdownPreview,
+  /void loadMarkdownPreview\(\)\.catch\(\(\) => \{\}\);/,
+  "preloading handles a chunk failure instead of emitting an unhandled rejection",
+);
+assert.match(
+  source,
+  /const \{ renderAsync \} = await loadMarkdownPreview\(\);/,
+  "message rendering uses the shared preview loader",
+);
+assert.doesNotMatch(
+  source,
+  /import\("@create-markdown\/preview"\)/,
+  "individual message renders must not start their own preview dynamic import",
+);
+assert.match(
+  chatView,
+  /preloadMarkdownPreview\(\);/,
+  "Chat starts loading the lightweight Markdown renderer before history messages mount",
 );
 assert.match(
   source,
@@ -126,8 +158,8 @@ assert.doesNotMatch(
 );
 assert.match(
   markdownContent,
-  /if \(pending\) \{[\s\S]*?mdToHtml\(/,
-  "While pending, the accumulated text re-renders through mdToHtml",
+  /if \(pending\) \{[\s\S]*?mdToHtml\(closeTrailingFence\(text\), \{ transient: true, highlightCode: false \}\)/,
+  "While pending, accumulated text renders as structured Markdown without launching transient Shiki work",
 );
 assert.match(
   source,
@@ -157,6 +189,11 @@ assert.match(
   markdownContent,
   /if \(stamp <= appliedStampRef\.current\) return;/,
   "A render result only commits if its stamp is newer than the last applied one",
+);
+assert.match(
+  markdownContent,
+  /if \(stamp < settledBarrierRef\.current\) return;[\s\S]*?settledBarrierRef\.current = plainStamp;/,
+  "settling a turn invalidates older transient renders before the final async pass resolves",
 );
 
 // Streaming cursor: with rendered HTML during pending, the ▌ affordance must
@@ -189,13 +226,40 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(!opts\?\.transient\) renderCacheSet\(markdown, sanitizedHtml\);/,
-  "Transient mid-stream renders never write to the cache",
+  /if \(canUseCache\) renderCacheSet\(markdown, sanitizedHtml\);/,
+  "Transient and plain-first renders never write to the final cache",
+);
+assert.match(
+  source,
+  /const canUseCache = !opts\?\.transient && opts\?\.highlightCode !== false;/,
+  "Only settled, highlighted Markdown reads or writes the final-render cache",
+);
+
+// ── Stable first paint: structure before syntax color ───────────────────────
+assert.match(
+  source,
+  /function renderCodeBlockFrame\(/,
+  "plain and highlighted code share one geometry-producing frame function",
+);
+assert.match(
+  source,
+  /class="shiki mood-c-dark cave-code-plain" tabindex="0"/,
+  "the pre-highlight code pass paints a keyboard-scrollable fixed-dark code body",
+);
+assert.match(
+  source,
+  /renderCodeBlock\(code, info, \{\s*highlightCode: opts\?\.highlightCode !== false,\s*\}\)/,
+  "mdToHtml explicitly selects plain or highlighted code while preserving the same frame",
 );
 assert.match(
   markdownContent,
-  /mdToHtml\(closeTrailingFence\(text\), \{ transient: true \}\)/,
-  "Streaming renders are marked transient (and auto-close a trailing unterminated fence)",
+  /useState<string \| null>\(\s*\(\) => pending \? null : renderCacheGet\(text\) \?\? null,\s*\)/,
+  "settled messages synchronously reuse final HTML on remount instead of flashing raw Markdown",
+);
+assert.match(
+  markdownContent,
+  /mdToHtml\(text, \{ highlightCode: false \}\)[\s\S]*?mdToHtml\(text\)/,
+  "a cold settled message applies stable structure before its highlighted enhancement",
 );
 
 assert.match(
@@ -214,7 +278,16 @@ assert.match(
   "Markdown link clicks should prevent normal navigation and open in the provided browser target",
 );
 
-const css = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"]
+const css = [
+  "cave-md/prose",
+  "cave-md/tables-mermaid",
+  "cave-md/code",
+  "cave-md/interactions",
+  "cave-composer",
+  "chat-list",
+  "calendar",
+  "cave-chat/bubbles",
+]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 assert.match(
@@ -288,8 +361,8 @@ assert.match(
 // Only on settled snapshots — mid-stream the fence is usually incomplete.
 assert.match(
   source,
-  /!opts\?\.transient && codeBlocks\.some\(isMermaidCodeBlock\)/,
-  "diagrams render only on non-transient (settled) snapshots",
+  /canUseCache && codeBlocks\.some\(isMermaidCodeBlock\)/,
+  "diagrams render only on settled, final-highlight snapshots",
 );
 assert.match(
   css,

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -27,6 +27,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -51,8 +52,10 @@ import { loadMarkdownPreview } from "@/lib/markdown-preview";
 import {
   cacheRenderedMarkdown as renderCacheSet,
   closeTrailingFence,
+  createMarkdownRenderGate,
   getRenderedMarkdown as renderCacheGet,
   scanFenceFilenames,
+  type MarkdownRenderGate,
 } from "@/lib/message-markdown-stream";
 import { FileLinkResolverContext, useWireCopyButtons } from "./message-dom-wiring";
 export { FileLinkResolverContext } from "./message-dom-wiring";
@@ -133,6 +136,9 @@ function renderCodeBlockFrame({
   const lineWrapped = highlighted.replace(
     /(<pre[^>]*>)([\s\S]*)(<\/pre>)/,
     (_match, open, inner, close) => {
+      const focusableOpen = open.includes("tabindex=")
+        ? open
+        : open.replace("<pre", '<pre tabindex="0"');
       const codeInner = inner.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, (_m2: string, co: string, codeContent: string, cc: string) => {
         const rawLines = codeContent.split("\n");
         // Remove trailing empty line Shiki adds.
@@ -178,7 +184,7 @@ function renderCodeBlockFrame({
         });
         return `${co}${wrappedLines.join("")}${cc}`;
       });
-      return `${open}${codeInner}${close}`;
+      return `${focusableOpen}${codeInner}${close}`;
     },
   );
 
@@ -693,18 +699,19 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
   // under the session's project root. No resolver ⇒ refs stay plain text.
   const fileLinkResolver = useContext(FileLinkResolverContext);
   const containerRef = useWireCopyButtons(html, onOpenUrl, fileLinkResolver);
-  // Out-of-order guard: mdToHtml is async and during streaming several
-  // renders can be in flight at once. Every render takes a monotonically
-  // increasing stamp, and a result only commits if it is newer than the
-  // last committed one — a slower earlier render never overwrites a newer
-  // one (including the final settled render).
-  const renderStampRef = useRef(0);
-  const appliedStampRef = useRef(0);
-  // Once a turn settles, transient work that started during streaming must
-  // not paint while the final plain/highlighted pass is still resolving.
-  // This separate barrier preserves progressive streaming: newer pending
-  // renders do not invalidate older in-flight ones and cause starvation.
-  const settledBarrierRef = useRef(0);
+  // mdToHtml is async and several streaming renders can be in flight at once.
+  // The gate orders their commits and invalidates pre-settle work synchronously
+  // during render, before React runs passive-effect cleanup or the final pass.
+  const renderGateRef = useRef<MarkdownRenderGate | null>(null);
+  if (!renderGateRef.current) renderGateRef.current = createMarkdownRenderGate();
+  const renderGate = renderGateRef.current;
+  const wasPendingRef = useRef(Boolean(pending));
+  if (wasPendingRef.current && !pending) {
+    renderGate.settle();
+  }
+  useLayoutEffect(() => {
+    wasPendingRef.current = Boolean(pending);
+  }, [pending]);
   // Throttle bookkeeping for streaming renders. Lives in a ref because the
   // effect re-fires on every streamed chunk: a per-effect trailing debounce
   // would be reset by each chunk and never fire under a steady stream.
@@ -732,14 +739,12 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
       // commits and nothing would paint until the turn settles (starvation).
       // The stamp guard above provides ordering safety instead; a commit
       // after unmount is a no-op state update that React drops.
+      const stamp = renderGate.issue();
       const run = () => {
         lastStreamRenderRef.current = Date.now();
-        const stamp = ++renderStampRef.current;
         mdToHtml(closeTrailingFence(text), { transient: true, highlightCode: false })
           .then((h) => {
-            if (stamp < settledBarrierRef.current) return;
-            if (stamp <= appliedStampRef.current) return; // stale out-of-order render
-            appliedStampRef.current = stamp;
+            if (!renderGate.apply(stamp)) return;
             setHtml(h);
           })
           .catch((err) => { console.error("[MarkdownContent] mdToHtml failed", err); });
@@ -759,30 +764,22 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
     let cancelled = false;
     const cached = renderCacheGet(text);
     if (cached !== undefined) {
-      const stamp = ++renderStampRef.current;
-      settledBarrierRef.current = stamp;
-      if (stamp > appliedStampRef.current) {
-        appliedStampRef.current = stamp;
-        setHtml(cached);
-      }
+      const stamp = renderGate.issue();
+      if (renderGate.apply(stamp)) setHtml(cached);
       return () => { cancelled = true; };
     }
 
-    const plainStamp = ++renderStampRef.current;
-    settledBarrierRef.current = plainStamp;
+    const plainStamp = renderGate.issue();
     mdToHtml(text, { highlightCode: false })
       .then((plainHtml) => {
         if (cancelled) return;
-        if (plainStamp > appliedStampRef.current) {
-          appliedStampRef.current = plainStamp;
-          setHtml(plainHtml);
-        }
+        if (!renderGate.apply(plainStamp)) return;
+        setHtml(plainHtml);
 
-        const highlightedStamp = ++renderStampRef.current;
+        const highlightedStamp = renderGate.issue();
         return mdToHtml(text).then((highlightedHtml) => {
           if (cancelled) return;
-          if (highlightedStamp <= appliedStampRef.current) return;
-          appliedStampRef.current = highlightedStamp;
+          if (!renderGate.apply(highlightedStamp)) return;
           setHtml(highlightedHtml);
         });
       })

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -40,13 +40,14 @@ import { getShikiHighlighter } from "@/lib/shiki-highlighter";
 import { Icon } from "@/lib/icon";
 import { renderCitedBody } from "@/lib/citations";
 import { CitationSources } from "@/components/ui/citation";
-import { classifyDiffLines, parseFenceInfo } from "@/lib/message-code-fences";
+import { classifyDiffLines, parseFenceInfo, type DiffLine } from "@/lib/message-code-fences";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { resolveShikiLang, diffContentLang } from "@/lib/code-lang";
 import { unwrapPreviewShell } from "@/lib/markdown-preview-shell";
+import { loadMarkdownPreview } from "@/lib/markdown-preview";
 import {
   cacheRenderedMarkdown as renderCacheSet,
   closeTrailingFence,
@@ -72,12 +73,6 @@ export function fmtBubbleTime(iso?: string): string {
     return Date.now() - d.getTime() > ONE_DAY ? dateFmt.format(d) : timeFmt.format(d);
   } catch { return ""; }
 }
-
-// ---------------------------------------------------------------------------
-// Shiki singleton — lazy, client-only (shared app-wide via lib/shiki-highlighter)
-// ---------------------------------------------------------------------------
-
-const getHighlighter = getShikiHighlighter;
 
 // ---------------------------------------------------------------------------
 // Parse fence info → { lang, filename }
@@ -110,52 +105,37 @@ function plainTextFromHtmlLine(line: string): string {
 // uniformly "inserted"-colored lines. Diffs whose target has no resolvable
 // grammar keep the bundled `diff` grammar (whole-line coloring) below.
 
-async function renderCodeBlock(
-  code: string,
-  info: string,
-): Promise<string> {
-  const { lang, filename } = parseFenceInfo(info);
-  const isDiff = lang === "diff";
-  const diffLang = isDiff ? diffContentLang(code) : "text";
-  let diffLines = isDiff && diffLang !== "text" ? classifyDiffLines(code) : null;
+function plainCodeHtml(code: string): string {
+  return `<pre class="shiki mood-c-dark cave-code-plain" tabindex="0"><code>${escHtml(code)}</code></pre>`;
+}
 
-  let highlighted: string;
-  try {
-    const hl = await getHighlighter();
-    // Language-aware diffs feed the grammar the diff's content with markers
-    // stripped and meta rows blanked — one line per original line, so the
-    // highlighted output stays index-aligned with the classification.
-    const doc = diffLines ? diffLines.map((l) => l.content).join("\n") : code;
-    highlighted = hl.codeToHtml(doc, {
-      // resolveShikiLang maps both fence names (`typescript`) AND bare file
-      // extensions (`ts`, `tsx`, `rs`) to a loadable grammar — without it the
-      // Projects file preview, which passes raw extensions, fell back to the
-      // unhighlighted "text" grammar for every file.
-      lang: diffLines ? diffLang : resolveShikiLang(lang),
-      theme: "mood-c-dark",
-    });
-  } catch (err) {
-    console.error("[renderCodeBlock] Shiki highlight failed", err);
-    // Fallback renders the ORIGINAL code (markers intact) — drop the
-    // language-aware line map so markers aren't re-attached twice.
-    highlighted = `<pre><code>${escHtml(code)}</code></pre>`;
-    diffLines = null;
-  }
-
+function renderCodeBlockFrame({
+  code,
+  lang,
+  filename,
+  highlighted,
+  isDiff,
+  diffLines,
+}: {
+  code: string;
+  lang: string;
+  filename?: string;
+  highlighted: string;
+  isDiff: boolean;
+  diffLines: DiffLine[] | null;
+}): string {
   const lines = code.split("\n");
   const showLineNums = lines.length > 5;
 
-  // Build line-numbered version by splitting Shiki's output into lines.
-  // Shiki wraps each token in <span>; the outer <pre><code> contains one
-  // line per logical source line (separated by \n in the token stream).
-  // We post-process to wrap each line in a <span class="cave-line"> for
-  // gutter rendering.
+  // Both the plain and Shiki passes flow through this exact frame. Syntax
+  // highlighting can therefore change token color without changing the code
+  // card's header, gutters, line metrics, controls, or scroll geometry.
   const lineWrapped = highlighted.replace(
     /(<pre[^>]*>)([\s\S]*)(<\/pre>)/,
     (_match, open, inner, close) => {
       const codeInner = inner.replace(/(<code[^>]*>)([\s\S]*)(<\/code>)/, (_m2: string, co: string, codeContent: string, cc: string) => {
         const rawLines = codeContent.split("\n");
-        // Remove trailing empty line Shiki adds
+        // Remove trailing empty line Shiki adds.
         if (rawLines[rawLines.length - 1] === "") rawLines.pop();
         const wrappedLines = rawLines.map((line: string, i: number) => {
           let content = line;
@@ -223,6 +203,52 @@ async function renderCodeBlock(
   return `<div class="cave-code-wrap">${headerHtml}${lineWrapped}${expandHtml}</div>`;
 }
 
+async function renderCodeBlock(
+  code: string,
+  info: string,
+  { highlightCode = true }: { highlightCode?: boolean } = {},
+): Promise<string> {
+  const { lang, filename } = parseFenceInfo(info);
+  const isDiff = lang === "diff";
+  const diffLang = isDiff ? diffContentLang(code) : "text";
+  let diffLines = isDiff && diffLang !== "text" ? classifyDiffLines(code) : null;
+  const doc = diffLines ? diffLines.map((line) => line.content).join("\n") : code;
+
+  let highlighted: string;
+  if (!highlightCode) {
+    highlighted = plainCodeHtml(doc);
+  } else {
+    try {
+      // Language-aware diffs feed the grammar the diff's content with markers
+      // stripped and meta rows blanked — one line per original line, so the
+      // highlighted output stays index-aligned with the classification.
+      const resolvedLang = diffLines ? diffLang : resolveShikiLang(lang);
+      const hl = await getShikiHighlighter(resolvedLang);
+      highlighted = hl.codeToHtml(doc, {
+        // resolveShikiLang maps both fence names (`typescript`) AND bare file
+        // extensions (`ts`, `tsx`, `rs`) to a loadable grammar.
+        lang: resolvedLang,
+        theme: "mood-c-dark",
+      });
+    } catch (err) {
+      console.error("[renderCodeBlock] Shiki highlight failed", err);
+      // Fallback renders the ORIGINAL code (markers intact) — drop the
+      // language-aware line map so markers aren't re-attached twice.
+      highlighted = plainCodeHtml(code);
+      diffLines = null;
+    }
+  }
+
+  return renderCodeBlockFrame({
+    code,
+    lang,
+    filename,
+    highlighted,
+    isDiff,
+    diffLines,
+  });
+}
+
 /**
  * Highlight a snippet to a *bare* Shiki `<pre class="shiki">…</pre>` — no
  * cave-code-wrap header, copy button, or line gutters. For surfaces that
@@ -231,8 +257,9 @@ async function renderCodeBlock(
  * same lazy singleton as the chat code blocks, so no extra Shiki/WASM load.
  */
 export async function highlightToHtml(code: string, lang: string): Promise<string> {
-  const hl = await getHighlighter();
-  return hl.codeToHtml(code, { lang: resolveShikiLang(lang), theme: "mood-c-dark" });
+  const resolvedLang = resolveShikiLang(lang);
+  const hl = await getShikiHighlighter(resolvedLang);
+  return hl.codeToHtml(code, { lang: resolvedLang, theme: "mood-c-dark" });
 }
 
 // ---------------------------------------------------------------------------
@@ -556,11 +583,17 @@ function isMermaidCodeBlock(block: Block): boolean {
   return lang === "mermaid";
 }
 
-async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promise<string> {
-  const cached = renderCacheGet(markdown);
-  if (cached !== undefined) return cached;
+async function mdToHtml(
+  markdown: string,
+  opts?: { transient?: boolean; highlightCode?: boolean },
+): Promise<string> {
+  const canUseCache = !opts?.transient && opts?.highlightCode !== false;
+  if (canUseCache) {
+    const cached = renderCacheGet(markdown);
+    if (cached !== undefined) return cached;
+  }
 
-  const { renderAsync } = await import("@create-markdown/preview");
+  const { renderAsync } = await loadMarkdownPreview();
 
   // @create-markdown/core's fenced-code parser rejects any info string that
   // contains a colon (e.g. ```ts:example.ts), treating the opener as a
@@ -581,7 +614,7 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
   // fence is usually incomplete, so the mermaid source shows as a code block
   // until the message finishes, then swaps to the rendered diagram.
   const mermaidPlugin =
-    !opts?.transient && codeBlocks.some(isMermaidCodeBlock) ? await getMermaidPlugin() : null;
+    canUseCache && codeBlocks.some(isMermaidCodeBlock) ? await getMermaidPlugin() : null;
   const codeReplacements: string[] = new Array(codeBlocks.length);
   await Promise.all(
     codeBlocks.map(async (block, i) => {
@@ -602,7 +635,9 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
       const rawInfo = cb.props.info ?? cb.props.language ?? "";
       const filename = fenceFilenames[i] ?? null;
       const info = filename ? `${rawInfo}:${filename}` : rawInfo;
-      codeReplacements[i] = await renderCodeBlock(code, info);
+      codeReplacements[i] = await renderCodeBlock(code, info, {
+        highlightCode: opts?.highlightCode !== false,
+      });
     }),
   );
 
@@ -640,7 +675,7 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
   // Transient (mid-stream) snapshots are never requested again once the
   // stream advances past them — caching one per throttle tick would churn
   // settled entries out of the LRU for no hit-rate gain.
-  if (!opts?.transient) renderCacheSet(markdown, sanitizedHtml);
+  if (canUseCache) renderCacheSet(markdown, sanitizedHtml);
   return sanitizedHtml;
 }
 
@@ -650,7 +685,9 @@ async function mdToHtml(markdown: string, opts?: { transient?: boolean }): Promi
 // ---------------------------------------------------------------------------
 
 function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?: boolean; onOpenUrl?: (url: string) => void }) {
-  const [html, setHtml] = useState<string | null>(null);
+  const [html, setHtml] = useState<string | null>(
+    () => pending ? null : renderCacheGet(text) ?? null,
+  );
   // Chat prose file references (`src/foo.ts:42`) open in Code — but only when
   // the surface's resolver (FileLinkResolverContext) confirms the file exists
   // under the session's project root. No resolver ⇒ refs stay plain text.
@@ -663,6 +700,11 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
   // one (including the final settled render).
   const renderStampRef = useRef(0);
   const appliedStampRef = useRef(0);
+  // Once a turn settles, transient work that started during streaming must
+  // not paint while the final plain/highlighted pass is still resolving.
+  // This separate barrier preserves progressive streaming: newer pending
+  // renders do not invalidate older in-flight ones and cause starvation.
+  const settledBarrierRef = useRef(0);
   // Throttle bookkeeping for streaming renders. Lives in a ref because the
   // effect re-fires on every streamed chunk: a per-effect trailing debounce
   // would be reset by each chunk and never fire under a steady stream.
@@ -693,8 +735,9 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
       const run = () => {
         lastStreamRenderRef.current = Date.now();
         const stamp = ++renderStampRef.current;
-        mdToHtml(closeTrailingFence(text), { transient: true })
+        mdToHtml(closeTrailingFence(text), { transient: true, highlightCode: false })
           .then((h) => {
+            if (stamp < settledBarrierRef.current) return;
             if (stamp <= appliedStampRef.current) return; // stale out-of-order render
             appliedStampRef.current = stamp;
             setHtml(h);
@@ -710,18 +753,38 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
       return () => { clearTimeout(timer); };
     }
 
-    // Settled (`pending` → false): final immediate render on the verbatim
-    // text, keeping the original async-cancellation discipline — once the
-    // turn is done there is no starvation risk, and cancellation keeps a
-    // stale effect run from committing.
+    // Settled (`pending` → false): paint document + code-card geometry first,
+    // then enhance that stable frame with Shiki token colors. A cached final
+    // render resolves immediately and never regresses to the plain stage.
     let cancelled = false;
-    const stamp = ++renderStampRef.current;
-    mdToHtml(text)
-      .then((h) => {
-        if (cancelled) return;
-        if (stamp <= appliedStampRef.current) return; // stale out-of-order render
+    const cached = renderCacheGet(text);
+    if (cached !== undefined) {
+      const stamp = ++renderStampRef.current;
+      settledBarrierRef.current = stamp;
+      if (stamp > appliedStampRef.current) {
         appliedStampRef.current = stamp;
-        setHtml(h);
+        setHtml(cached);
+      }
+      return () => { cancelled = true; };
+    }
+
+    const plainStamp = ++renderStampRef.current;
+    settledBarrierRef.current = plainStamp;
+    mdToHtml(text, { highlightCode: false })
+      .then((plainHtml) => {
+        if (cancelled) return;
+        if (plainStamp > appliedStampRef.current) {
+          appliedStampRef.current = plainStamp;
+          setHtml(plainHtml);
+        }
+
+        const highlightedStamp = ++renderStampRef.current;
+        return mdToHtml(text).then((highlightedHtml) => {
+          if (cancelled) return;
+          if (highlightedStamp <= appliedStampRef.current) return;
+          appliedStampRef.current = highlightedStamp;
+          setHtml(highlightedHtml);
+        });
       })
       .catch((err) => { console.error("[MarkdownContent] mdToHtml failed", err); });
     return () => { cancelled = true; };
@@ -1102,13 +1165,10 @@ function MarkdownExpandModal({
     copyTimer.current = setTimeout(() => setCopied(false), 2000);
   }, [text]);
 
-  // Portal to <body>: the chat transcript lives under `.cave-mode-fade` (which
-  // sets `transform`) and `.cave-linear-turn` (`content-visibility: auto`), and
-  // both establish a containing block for `position: fixed`. Rendered inline the
-  // overlay is clamped to the message's turn box instead of the viewport, so the
-  // "Expand" reading view never actually goes full-screen (it sits in a small
-  // box with a huge empty area beside/below it). Portaling escapes those
-  // ancestors so `inset-0` resolves to the real viewport. See ui/modal.tsx.
+  // Portal to <body>: transcript rows use `content-visibility: auto`, which
+  // establishes layout containment around the message. Rendered inline, the
+  // overlay can be clamped to that turn instead of the viewport. Portaling
+  // keeps `inset-0` anchored to the real viewport. See ui/modal.tsx.
   return createPortal(
     <div
       className="fixed inset-0 z-[60] flex items-center justify-center bg-black/75 backdrop-blur-sm"

--- a/src/components/workspace-mode-fade.test.ts
+++ b/src/components/workspace-mode-fade.test.ts
@@ -2,13 +2,16 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Workspace mode-transition crossfade + no-terminal-subtree pins. Formerly
-// part of comux-view-terminal.test.ts; the ComuxView host was deleted
-// (cave-c3yt) and these live workspace pins moved here — this behavior has
-// silently regressed TWICE, keep it pinned.
+// Workspace detail stability + no-terminal-subtree pins. Formerly part of
+// comux-view-terminal.test.ts; the ComuxView host was deleted (cave-c3yt) and
+// these live workspace pins moved here.
 
 const workspace = readFileSync(
   new URL("./workspace.tsx", import.meta.url),
+  "utf8",
+);
+const primitives = readFileSync(
+  new URL("../styles/globals/primitives.css", import.meta.url),
   "utf8",
 );
 
@@ -18,26 +21,30 @@ assert.doesNotMatch(
   /<div key=\{mode\} className="cave-mode-fade/,
   "Workspace detail must not force a full remount on every surface switch",
 );
-// ...but the mode-transition crossfade must STILL fire on every switch. The
-// `.cave-mode-fade` CSS animation only plays on the wrapper's initial mount, so
-// a mode change replays an opacity-only fade via WAAPI on the *persistent*
-// wrapper (no remount, no transform → no containing-block trap; cave-cco).
-// This has silently regressed twice (UX-004 added it via key={mode}; the
-// terminal-keepalive PR removed the key and killed the switch fade) — pin it.
 assert.match(
   workspace,
-  /ref=\{detailFadeRef\}/,
-  "detail wrapper wires the mode-fade ref so switches can re-fire the fade",
+  /className="cave-mode-fade relative h-full min-h-0 flex flex-col overflow-hidden"/,
+  "Workspace keeps the stable detail wrapper required by shell layout selectors",
 );
 assert.match(
   workspace,
-  /el\.animate\(\s*\[\{ opacity: 0 \}, \{ opacity: 1 \}\],\s*\{ duration: 120, easing: "ease-out" \}/,
-  "a mode switch replays a 120ms opacity-only fade on the detail wrapper",
+  /const detailContent = renderSurface\(mode\);[\s\S]*?\{detailContent\}/,
+  "surface content swaps inside the persistent detail wrapper",
 );
-assert.match(
+assert.doesNotMatch(
   workspace,
-  /prefers-reduced-motion: reduce/,
-  "the mode-fade retrigger honors prefers-reduced-motion",
+  /detailFadeRef|modeFadeAnimRef|modeFadeReadyRef/,
+  "surface switches must not drive the whole detail pane through opacity zero",
+);
+assert.doesNotMatch(
+  workspace,
+  /\.animate\(\s*\[\{ opacity: 0 \}, \{ opacity: 1 \}\]/,
+  "Workspace must not replay a blank-to-visible full-pane animation",
+);
+assert.doesNotMatch(
+  primitives,
+  /@keyframes\s+cave-mode-in|\.cave-mode-fade\s*\{[\s\S]*?(?:animation|opacity|transform)\s*:/,
+  ".cave-mode-fade must stay continuously visible and must not become a containing block",
 );
 
 console.log("workspace-mode-fade.test.ts: ok");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -542,34 +542,6 @@ export function Workspace() {
     }
   }, []);
 
-  // ── Mode-transition crossfade ──────────────────────────────────────────
-  // The `.cave-mode-fade` CSS animation only plays on the wrapper's *initial*
-  // mount. Re-firing it on a mode switch would need `key={mode}` on the
-  // wrapper, which is deliberately forbidden — the key remounts keepalive
-  // surfaces (it once killed the terminal's PTYs on every switch; pinned in
-  // comux-view-terminal.test.ts). Instead, replay a short opacity fade on the
-  // (persistent) wrapper via WAAPI whenever `mode` changes. Opacity-only, so it
-  // never applies a transform and therefore never becomes the containing block
-  // for position:fixed descendants (the cave-cco trap that forced 4 portal
-  // workarounds). Skips the first run (initial entrance is the CSS animation)
-  // and honors prefers-reduced-motion.
-  const detailFadeRef = useRef<HTMLDivElement>(null);
-  const modeFadeAnimRef = useRef<Animation | null>(null);
-  const modeFadeReadyRef = useRef(false);
-  useLayoutEffect(() => {
-    if (!modeFadeReadyRef.current) {
-      modeFadeReadyRef.current = true;
-      return;
-    }
-    const el = detailFadeRef.current;
-    if (!el || typeof el.animate !== "function") return;
-    if (window.matchMedia?.("(prefers-reduced-motion: reduce)").matches) return;
-    modeFadeAnimRef.current?.cancel();
-    modeFadeAnimRef.current = el.animate(
-      [{ opacity: 0 }, { opacity: 1 }],
-      { duration: 120, easing: "ease-out" },
-    );
-  }, [mode]);
   // Drag-to-split: up to three secondary surfaces opened beside the primary
   // one (four visible pages total). Targets are draggable pages or companion
   // surfaces (Salem / Memory / Browser) re-homed from the removed right rail.
@@ -3056,10 +3028,7 @@ export function Workspace() {
 
   const detailContent = renderSurface(mode);
   const detail = (
-    <div
-      ref={detailFadeRef}
-      className="cave-mode-fade relative h-full min-h-0 flex flex-col overflow-hidden"
-    >
+    <div className="cave-mode-fade relative h-full min-h-0 flex flex-col overflow-hidden">
       <h1 className="sr-only">
         {(isRoleSurfaceMode(mode)
           ? getRoleSurface(parseRoleSurfaceMode(mode) ?? "")?.title

--- a/src/lib/markdown-preview.ts
+++ b/src/lib/markdown-preview.ts
@@ -1,0 +1,20 @@
+type MarkdownPreviewModule = typeof import("@create-markdown/preview");
+
+let previewPromise: Promise<MarkdownPreviewModule> | null = null;
+
+/** Load the browser-only serializer once for every Chat message. */
+export function loadMarkdownPreview(): Promise<MarkdownPreviewModule> {
+  if (!previewPromise) {
+    previewPromise = import("@create-markdown/preview").catch((error) => {
+      previewPromise = null;
+      throw error;
+    });
+  }
+  return previewPromise;
+}
+
+/** Start the preview chunk early without evaluating it during server render. */
+export function preloadMarkdownPreview(): void {
+  if (typeof window === "undefined") return;
+  void loadMarkdownPreview().catch(() => {});
+}

--- a/src/lib/markdown-preview.ts
+++ b/src/lib/markdown-preview.ts
@@ -2,7 +2,7 @@ type MarkdownPreviewModule = typeof import("@create-markdown/preview");
 
 let previewPromise: Promise<MarkdownPreviewModule> | null = null;
 
-/** Load the browser-only serializer once for every Chat message. */
+/** Load the browser-only serializer once per app runtime. */
 export function loadMarkdownPreview(): Promise<MarkdownPreviewModule> {
   if (!previewPromise) {
     previewPromise = import("@create-markdown/preview").catch((error) => {

--- a/src/lib/message-markdown-stream.test.ts
+++ b/src/lib/message-markdown-stream.test.ts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { cacheRenderedMarkdown, closeTrailingFence, getRenderedMarkdown, scanFenceFilenames } from "./message-markdown-stream.ts";
+import * as markdownStream from "./message-markdown-stream.ts";
+
+const {
+  cacheRenderedMarkdown,
+  closeTrailingFence,
+  getRenderedMarkdown,
+  scanFenceFilenames,
+} = markdownStream;
 
 test("markdown stream helpers preserve filename fences and close only incomplete fences", () => {
   assert.equal(closeTrailingFence("```ts\nconst x = 1"), "```ts\nconst x = 1\n```");
@@ -11,4 +18,67 @@ test("markdown stream helpers preserve filename fences and close only incomplete
 test("rendered markdown cache refreshes recency before eviction", () => {
   cacheRenderedMarkdown("first", "one");
   assert.equal(getRenderedMarkdown("first"), "one");
+});
+
+test("settling synchronously rejects a deferred transient render", async () => {
+  type RenderGate = {
+    issue(): number;
+    settle(): void;
+    apply(stamp: number): boolean;
+  };
+  const createRenderGate = (
+    markdownStream as typeof markdownStream & {
+      createMarkdownRenderGate?: () => RenderGate;
+    }
+  ).createMarkdownRenderGate;
+  assert.equal(
+    typeof createRenderGate,
+    "function",
+    "the stream state machine exposes a render gate",
+  );
+  if (!createRenderGate) return;
+
+  const gate = createRenderGate();
+  const transientStamp = gate.issue();
+  let releaseTransient!: (html: string) => void;
+  const transient = new Promise<string>((resolve) => {
+    releaseTransient = resolve;
+  });
+  const commits: string[] = [];
+  const commitTransient = transient.then((html) => {
+    if (gate.apply(transientStamp)) commits.push(html);
+  });
+
+  // This mirrors an interrupted pending=true → pending=false render: settle
+  // advances, a trailing stream timer issues more work, and the restarted
+  // settled render advances the still-uncommitted transition again.
+  gate.settle();
+  const trailingStamp = gate.issue();
+  let releaseTrailing!: (html: string) => void;
+  const trailing = new Promise<string>((resolve) => {
+    releaseTrailing = resolve;
+  });
+  const commitTrailing = trailing.then((html) => {
+    if (gate.apply(trailingStamp)) commits.push(html);
+  });
+  gate.settle();
+
+  releaseTransient("obsolete stream snapshot");
+  releaseTrailing("late obsolete stream snapshot");
+  await Promise.all([commitTransient, commitTrailing]);
+
+  assert.deepEqual(commits, []);
+  const settledStamp = gate.issue();
+  assert.equal(gate.apply(settledStamp), true);
+});
+
+test("a trailing callback keeps the stamp issued before a single settle", async () => {
+  const gate = markdownStream.createMarkdownRenderGate();
+  const scheduledStamp = gate.issue();
+  gate.settle();
+
+  // The callback starts only after settlement, but it carries the stamp from
+  // scheduling time and therefore cannot cross the settled barrier.
+  await Promise.resolve();
+  assert.equal(gate.apply(scheduledStamp), false);
 });

--- a/src/lib/message-markdown-stream.ts
+++ b/src/lib/message-markdown-stream.ts
@@ -1,6 +1,37 @@
 const RENDER_CACHE_MAX = 200;
 const renderCache = new Map<string, string>();
 
+export interface MarkdownRenderGate {
+  issue(): number;
+  settle(): void;
+  apply(stamp: number): boolean;
+}
+
+/**
+ * Orders async Markdown renders and synchronously invalidates work issued
+ * before a pending turn settles.
+ */
+export function createMarkdownRenderGate(): MarkdownRenderGate {
+  let issuedStamp = 0;
+  let appliedStamp = 0;
+  let settledBarrier = 0;
+
+  return {
+    issue() {
+      issuedStamp += 1;
+      return issuedStamp;
+    },
+    settle() {
+      settledBarrier = Math.max(settledBarrier, issuedStamp + 1);
+    },
+    apply(stamp) {
+      if (stamp < settledBarrier || stamp <= appliedStamp) return false;
+      appliedStamp = stamp;
+      return true;
+    },
+  };
+}
+
 /** Small LRU keyed by final markdown snapshots; transient stream frames never enter it. */
 export function getRenderedMarkdown(key: string): string | undefined {
   const value = renderCache.get(key);

--- a/src/lib/shiki-highlighter.test.ts
+++ b/src/lib/shiki-highlighter.test.ts
@@ -1,0 +1,77 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createLanguageHighlighterLoader } from "./shiki-language-loader.ts";
+
+const source = readFileSync(new URL("./shiki-highlighter.ts", import.meta.url), "utf8");
+
+assert.match(
+  source,
+  /langs:\s*\[\]/,
+  "the base Shiki singleton starts without eagerly loading the full grammar catalog",
+);
+assert.doesNotMatch(
+  source,
+  /langs:\s*\[\.\.\.SHIKI_LANGS\]/,
+  "the Shiki singleton must not request every configured grammar on first use",
+);
+assert.match(
+  source,
+  /if \(language === "text"\) return loadShikiHighlighter\(\);/,
+  "plain text uses Shiki's grammar-free built-in path without a redundant language load",
+);
+
+const loaded = new Set<string>();
+const loadCalls: string[] = [];
+let baseCalls = 0;
+let rejectRustOnce = true;
+const fakeHighlighter = {
+  getLoadedLanguages: () => [...loaded],
+  loadLanguage: async (lang: string) => {
+    loadCalls.push(lang);
+    await Promise.resolve();
+    if (lang === "rust" && rejectRustOnce) {
+      rejectRustOnce = false;
+      throw new Error("synthetic grammar failure");
+    }
+    loaded.add(lang);
+  },
+};
+const getForLanguage = createLanguageHighlighterLoader(async () => {
+  baseCalls += 1;
+  return fakeHighlighter;
+});
+
+const [first, second] = await Promise.all([
+  getForLanguage("typescript"),
+  getForLanguage("typescript"),
+]);
+assert.equal(first, fakeHighlighter, "the loader returns the shared highlighter");
+assert.equal(second, fakeHighlighter, "concurrent callers receive the same highlighter");
+assert.equal(baseCalls, 2, "the wrapper may consult the memoized base loader per caller");
+assert.deepEqual(
+  loadCalls,
+  ["typescript"],
+  "concurrent requests for one language share a single grammar load",
+);
+
+await getForLanguage("python");
+assert.deepEqual(
+  loadCalls,
+  ["typescript", "python"],
+  "a later language request loads only that additional grammar",
+);
+
+await assert.rejects(
+  getForLanguage("rust"),
+  /synthetic grammar failure/,
+  "grammar load errors reach the caller",
+);
+await getForLanguage("rust");
+assert.deepEqual(
+  loadCalls,
+  ["typescript", "python", "rust", "rust"],
+  "a failed grammar request is removed from the in-flight map and can retry",
+);
+
+console.log("shiki-highlighter.test.ts: ok");

--- a/src/lib/shiki-highlighter.ts
+++ b/src/lib/shiki-highlighter.ts
@@ -2,7 +2,7 @@
 // shiki-highlighter — the app-wide lazy Shiki singleton
 // ---------------------------------------------------------------------------
 //
-// One highlighter instance (theme + full grammar set from SHIKI_LANGS) shared
+// One highlighter instance (theme + on-demand grammars) shared
 // by every surface that colors code: chat code fences (message-bubble.tsx)
 // and the GitHub review-thread diff renderer (gh-diff-view.tsx). Shiki + its
 // WASM engine are heavy, so the import is dynamic and the instance is created
@@ -10,11 +10,12 @@
 
 import type { Highlighter } from "shiki";
 import moodCTheme from "@/styles/shiki/mood-c-dark.json";
-import { SHIKI_LANGS } from "@/lib/code-lang";
+import type { ShikiLang } from "@/lib/code-lang";
+import { createLanguageHighlighterLoader } from "@/lib/shiki-language-loader";
 
 let highlighterPromise: Promise<Highlighter> | null = null;
 
-export function getShikiHighlighter(): Promise<Highlighter> {
+function loadShikiHighlighter(): Promise<Highlighter> {
   if (!highlighterPromise) {
     highlighterPromise = (async () => {
       const { createHighlighter } = await import("shiki");
@@ -24,9 +25,24 @@ export function getShikiHighlighter(): Promise<Highlighter> {
         // code-editor-theme.ts reads the same object — so hand Shiki a clone,
         // never the module instance (cave-h1hi).
         themes: [structuredClone(moodCTheme) as Parameters<typeof createHighlighter>[0]["themes"][number]],
-        langs: [...SHIKI_LANGS],
+        // Loading the complete language catalog here made the first Chat code
+        // fence request 41 grammar chunks before any formatted prose painted.
+        // The wrapper below adds only the resolved grammar a caller needs.
+        langs: [],
       });
     })();
   }
   return highlighterPromise;
+}
+
+const loadForLanguage = createLanguageHighlighterLoader<ShikiLang, Highlighter>(
+  loadShikiHighlighter,
+);
+
+export function getShikiHighlighter(language: ShikiLang): Promise<Highlighter> {
+  // Shiki treats `text` as a grammar-free built-in and intentionally omits it
+  // from getLoadedLanguages(), so routing it through the loader would repeat a
+  // no-op load for every unknown/plain fence.
+  if (language === "text") return loadShikiHighlighter();
+  return loadForLanguage(language);
 }

--- a/src/lib/shiki-language-loader.ts
+++ b/src/lib/shiki-language-loader.ts
@@ -1,0 +1,34 @@
+type LoadableLanguageHighlighter<Language> = {
+  getLoadedLanguages(): string[];
+  loadLanguage(...languages: Language[]): Promise<void>;
+};
+
+/**
+ * Wrap a memoized Shiki factory with per-language loading. The in-flight map
+ * prevents concurrent code blocks from requesting the same grammar twice;
+ * completed entries leave the map because Shiki itself becomes the durable
+ * source of truth through getLoadedLanguages().
+ */
+export function createLanguageHighlighterLoader<
+  Language extends string,
+  Highlighter extends LoadableLanguageHighlighter<Language>,
+>(
+  loadHighlighter: () => Promise<Highlighter>,
+): (language: Language) => Promise<Highlighter> {
+  const inFlight = new Map<Language, Promise<void>>();
+
+  return async (language: Language) => {
+    const highlighter = await loadHighlighter();
+    if (highlighter.getLoadedLanguages().includes(language)) return highlighter;
+
+    let languagePromise = inFlight.get(language);
+    if (!languagePromise) {
+      languagePromise = highlighter.loadLanguage(language).finally(() => {
+        if (inFlight.get(language) === languagePromise) inFlight.delete(language);
+      });
+      inFlight.set(language, languagePromise);
+    }
+    await languagePromise;
+    return highlighter;
+  };
+}

--- a/src/styles/cave-md/code.css
+++ b/src/styles/cave-md/code.css
@@ -164,6 +164,12 @@
   background: transparent !important;
 }
 
+/* Stable first pass while the encountered Shiki grammar loads. It uses the
+   exact highlighted block geometry; only token colors arrive later. */
+.cave-code-wrap pre.cave-code-plain {
+  color: var(--code-chrome-ink);
+}
+
 .cave-code-wrap pre::-webkit-scrollbar { height: 4px; }
 .cave-code-wrap pre::-webkit-scrollbar-track { background: transparent; }
 .cave-code-wrap pre::-webkit-scrollbar-thumb {

--- a/src/styles/globals/primitives.css
+++ b/src/styles/globals/primitives.css
@@ -1661,23 +1661,6 @@ html[data-backdrop-on] .glass-overlay {
   color: var(--text-muted);
 }
 
-/* ── UX-004: Mode transition crossfade ──────────────────────────────────── */
-@keyframes cave-mode-in {
-  from { opacity: 0; transform: translateY(4px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
-/* fill-mode MUST stay `backwards` (cave-cco): `both` retained the final
-   keyframe's transform forever, and any transform — even identity — makes
-   this wrapper the containing block for every position:fixed descendant.
-   Fixed overlays inside surfaces then resolved against the mode area
-   instead of the viewport, which forced portal-to-body workarounds (#537,
-   #1984, the github-view card, cave-nv3). During the 120ms entrance the
-   wrapper is still a containing block; after it, fixed descendants get the
-   true viewport. */
-.cave-mode-fade {
-  animation: cave-mode-in 120ms ease-out backwards;
-}
-
 /* Left nav collapsed strip -- mirrors the agent tab on the right */
 /* Left-rail toggle tab — full-height strip, exact mirror of .shell-familiar-tab */
 .shell-nav-tab {


### PR DESCRIPTION
## Summary

Eliminates recurring blank-frame interface flicker during workspace mode changes and stabilizes Chat Markdown/code rendering while browser-only formatting assets load.

## Why

Tracking: `cave-hj82a`

Two independent runtime causes were confirmed:

- the persistent workspace detail wrapper intentionally animated from opacity `0` to `1` on initial paint and every mode change, producing a visible blank frame;
- Chat painted before its browser-only Markdown serializer was ready, then the first code fence triggered an eager 41-grammar Shiki load. A stale transient render could also land after the turn settled.

## Changes

- Keep the workspace detail wrapper continuously visible while preserving its stable DOM identity and existing layout-selector contract.
- Preload and memoize the browser-only Markdown preview module when Chat loads.
- Render streaming and cold settled code blocks through one stable plain/highlighted geometry, then enhance only token color when Shiki is ready.
- Add a settle barrier so obsolete transient work cannot repaint after `pending` becomes false, and reuse cached settled HTML synchronously on remount.
- Load only the encountered Shiki grammar, deduplicate concurrent language requests, allow failed grammar loads to retry, and route GitHub diff highlighting through the same loader.
- Add source-contract and behavioral regressions for the mode wrapper, Markdown lifecycle, and grammar loader.

## Verification

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired` — all 1,283 test files wired
- [x] `pnpm test:app` — 933 test files passed
- [x] `pnpm exec next build`
- [x] `pnpm build:server`
- [x] `git diff --check`
- [x] Production browser replay: 157 mocked SSE frames completed with one shell/frame/chat/transcript/thread node identity and opacity `1` throughout; the settled enhancement shift was `0.000021437`; only the TypeScript/JSDoc grammar chunk loaded; no page errors.
- [x] Chat → Home → Chat frame sampler: 47 frames, one persistent wrapper node, opacity `1`, transform `none`, animation `none`, and zero active animations.

## Risk + rollout notes

The `.cave-mode-fade` class remains as a layout hook because existing shell selectors depend on it; only the blank-to-visible animation behavior is removed. Total stream CLS remains about `0.059` because the response intentionally grows the transcript line by line; that value matches the baseline and is not caused by blanking or remounting. No migration or release-note entry is required.