### PR TITLE
fix(settings): update Coven CLI to latest

### DIFF
--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -8,10 +8,20 @@ const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 const installOutput = await readFile(new URL("./install-job-output.ts", import.meta.url), "utf8");
 
 assert.match(source, /"managed-node": \{[\s\S]*kind: "managed-node"/);
-for (const id of ["coven-cli", "runtime-codex", "runtime-claude", "runtime-copilot", "runtime-openclaw"]) {
+assert.match(
+  source,
+  /"coven-cli": \{[\s\S]*packageName: "@opencoven\/cli@latest"/,
+  "the Coven CLI update action installs the latest published package",
+);
+for (const id of ["runtime-codex", "runtime-claude", "runtime-copilot", "runtime-openclaw"]) {
   assert.match(source, new RegExp(`reviewedPackage\\("${id}"\\)`));
 }
-assert.doesNotMatch(source, /@latest|curl -fsSL|\birm https?:\/\//i, "one-click installs never use mutable package or script targets");
+assert.equal(
+  source.match(/@latest/g)?.length,
+  1,
+  "only the Coven CLI self-update action may use a mutable package target",
+);
+assert.doesNotMatch(source, /curl -fsSL|\birm https?:\/\//i, "one-click installs never use mutable script targets");
 assert.doesNotMatch(source, /installHermesShim|targetName === "hermes"/, "Hermes remains manual-only");
 assert.match(source, /await probeManagedNodeToolchain\(\)/, "npm plans require the Cave-managed toolchain");
 assert.match(source, /managedNpmLaunch\(managed\.paths\)/, "npm runs through owned node and npm-cli.js");

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -52,7 +52,7 @@ export const runtime = "nodejs";
 
 const execFileAsync = promisify(execFile);
 
-function reviewedPackage(id: Extract<PrerequisiteId, "coven-cli" | "runtime-codex" | "runtime-claude" | "runtime-copilot" | "runtime-openclaw">): string {
+function reviewedPackage(id: Extract<PrerequisiteId, "runtime-codex" | "runtime-claude" | "runtime-copilot" | "runtime-openclaw">): string {
   const install = prerequisiteById(id).install;
   if (install.kind !== "managed-npm") throw new Error(`${id} must use the managed npm manifest lane`);
   return `${install.package.packageName}@${install.package.version}`;
@@ -66,7 +66,7 @@ function reviewedPackage(id: Extract<PrerequisiteId, "coven-cli" | "runtime-code
  * a shell:
  *
  *   - kind "managed-node": Cave-owned, exact Node/npm archive installation
- *   - kind "npm":            `node npm-cli.js install -g <pinned package>`
+ *   - kind "npm":            `node npm-cli.js install -g <allowlisted package>`
  *                              from that managed toolchain, never host PATH.
  */
 const INSTALL_TARGETS = {
@@ -79,7 +79,7 @@ const INSTALL_TARGETS = {
   "coven-cli": {
     kind: "npm",
     label: "Coven CLI",
-    packageName: reviewedPackage("coven-cli"),
+    packageName: "@opencoven/cli@latest",
     binary: "coven",
     timeoutMs: 240_000,
   },

--- a/src/app/onboarding-install-route.test.ts
+++ b/src/app/onboarding-install-route.test.ts
@@ -61,8 +61,8 @@ assert.match(
 
 assert.match(
   route,
-  /"coven-cli": \{[\s\S]*?packageName: reviewedPackage\("coven-cli"\)/,
-  "Coven install resolves its pinned package from the reviewed prerequisite manifest",
+  /"coven-cli": \{[\s\S]*?packageName: "@opencoven\/cli@latest"/,
+  "the Coven CLI button installs the latest published package",
 );
 assert.doesNotMatch(
   route,


### PR DESCRIPTION
## Summary
- restore the Coven CLI update button to `@opencoven/cli@latest`
- keep runtime prerequisite installs pinned and preserve the managed npm, shell-free execution path
- add regression coverage for the button target and mutable-package boundary

## Verification
- `pnpm typecheck`
- `node --experimental-strip-types src/app/api/onboarding/install/route.test.ts`
- `node --experimental-strip-types src/app/onboarding-install-route.test.ts`
- `node --experimental-strip-types src/components/open-coven-tools-update.test.ts`
- `node --experimental-strip-types src/lib/opencoven-tools-install.test.ts`

Bead: `cave-3eqem`