### PR TITLE
chore: ignore repository-local OpenCode state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ ds-bundle/
 .design-sync/node_modules
 /.worktrees
 /.cave-trash
+/.opencode


### PR DESCRIPTION
## Summary

- Ignore the repository-root `/.opencode` workspace directory.
- Keep OpenCode databases, package metadata, and installed dependencies out of Git status.
- Leave runtime behavior unchanged.

## Tracking

- Bead: `cave-8rmrv`
- Branch: `agent/ignore-opencode-state`
- Worktree: `.worktrees/agent-ignore-opencode-state`

## Verification

- `git check-ignore -v --no-index .opencode/opencode.db .opencode/node_modules/example .opencode/package.json`
- `pnpm check:tests-wired` — 1,282 files wired
- `pnpm typecheck`
- clean-baseline `pnpm test:app` — 932 test files passed
- `git diff --check`

## Risk / follow-up

- Scope is one `.gitignore` line; no application code or Beads export is included.
- No follow-up work identified.