### PR TITLE
test(windows): determinize cave-home reclaim retry timing

### DIFF
--- a/docs/superpowers/specs/2026-07-27-deterministic-cave-home-reclaim-conformance-design.md
+++ b/docs/superpowers/specs/2026-07-27-deterministic-cave-home-reclaim-conformance-design.md
@@ -1,0 +1,93 @@
+# Deterministic Cave-Home Reclaim Conformance Design
+
+## Goal
+
+Make GitHub issue #3940's released-owner reclaim retry scenario independent
+of Windows runner scheduling while preserving the production reconciliation
+lock contract byte-for-byte.
+
+The test must prove that persistent Windows `EPERM` fencing failures retry
+until the configured protocol deadline, time out with `ETIMEDOUT`, and leave
+the owned lock directory intact.
+
+## Confirmed Root Cause
+
+The failure is test-clock nondeterminism, not a production lock regression.
+
+- Windows job `89831971694` ran the reclaim timeout path for roughly 330 ms,
+  completed only one fence attempt, and failed `reclaimAttempts >= 2`.
+- Windows job `89830933193` ran the byte-identical tree, completed the same
+  path in roughly 186 ms, and passed.
+- Commit `52468bb16` made the adjacent candidate-publication scenario use the
+  existing injected `lockNow` clock, but reset the reclaim scenario to a
+  150 ms wall-clock timeout without giving it the same deterministic clock.
+- Production `acquireLock()` already uses `options.lockNow ?? Date.now`, so no
+  runtime seam or behavior change is required.
+
+## Chosen Approach
+
+Use injected monotonic protocol time in every persistent-`EPERM` retry-count
+test.
+
+- Give candidate publication and released-lock fencing a local clock starting
+  at zero.
+- Advance that clock by a fixed amount inside the injected failing rename.
+- Pass the clock through the existing `lockNow` option.
+- Use a fixed protocol deadline and assert the exact number of attempts needed
+  to reach it.
+- Apply the same deterministic pattern to the cross-platform takeover suite,
+  which currently carries equivalent 150 ms wall-clock retry assertions.
+
+This keeps the filesystem and retry loop real while replacing only the
+unstable deadline source.
+
+Rejected alternatives:
+
+- Increasing the wall-clock timeout would make CI slower without making the
+  retry-count assertion deterministic.
+- Weakening or removing the retry assertion would stop testing the behavior
+  that prevented one-shot Windows failures.
+- Injecting a scheduler or changing production backoff would expand the
+  runtime surface without addressing a production defect.
+
+## Test Contract
+
+For a 500 ms protocol deadline and a 100 ms advancement per injected rename
+failure:
+
+1. Five candidate or fence rename attempts occur.
+2. The next acquisition-loop deadline check throws `ETIMEDOUT`.
+3. Candidate publication reuses one candidate directory and cleans it up.
+4. Failed released-lock fencing leaves the lock directory and owner token
+   unchanged.
+5. Real runner latency cannot change the attempt count because `Date.now()` is
+   not consulted by these scenarios.
+
+The active-owner timeout scenario remains wall-clock based. It intentionally
+tests elapsed waiting behavior rather than a retry count and is outside issue
+#3940.
+
+## Verification
+
+- Preserve the live failing Windows job as the RED evidence.
+- Run the focused takeover suite repeatedly, sequentially and concurrently.
+- Run the complete conformance suite locally, acknowledging that the
+  Windows-only test skips on macOS.
+- Run `pnpm lint`, `pnpm typecheck`, `pnpm check:tests-wired`,
+  `pnpm test:app`, `pnpm test:conformance`, `pnpm build`, and
+  `git diff --check`.
+- Push a PR and require successful Ubuntu and Windows conformance legs.
+- Prove two complete conformance matrix executions on the final PR head: the
+  initial pull-request run plus one full workflow rerun. Both Ubuntu and
+  Windows legs and the required aggregate must pass in both attempts.
+- Confirm the production reconciliation files have no diff.
+
+## Completion Criteria
+
+- No persistent-`EPERM` retry-count scenario depends on a real 150 ms window.
+- Production lock timeouts, backoff, reclaim rules, and diagnostics are
+  unchanged.
+- Focused repetition and required cross-environment CI are green on Ubuntu and
+  Windows.
+- The PR is merged, issue #3940 is closed with evidence, and Bead
+  `cave-vjowd` records the final verification.

--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -108,9 +108,9 @@ try {
 
   // Persistent Windows EPERM while publishing candidate directories must stop
   // at the documented deadline and remove every contender-owned candidate.
-  // GitHub's Windows filesystem can consume most of a 150ms deadline in the
-  // first directory operation, before the retry loop gets a second turn.
   const retryTimeoutMs = 500;
+  const retryStepMs = 100;
+  const expectedRetryAttempts = retryTimeoutMs / retryStepMs;
   const candidateFailureHome = path.join(root, "candidate-eperm", ".coven");
   process.env.COVEN_HOME = candidateFailureHome;
   const candidateFailureCave = path.join(candidateFailureHome, "cave");
@@ -120,7 +120,7 @@ try {
   const candidates = new Set<string>();
   const persistentEperm = async (candidate: string) => {
     candidateAttempts += 1;
-    candidateClock += 100;
+    candidateClock += retryStepMs;
     candidates.add(candidate);
     const error = new Error("injected persistent Windows EPERM") as NodeJS.ErrnoException;
     error.code = "EPERM";
@@ -134,7 +134,7 @@ try {
     }),
     (error) => error?.code === "ETIMEDOUT",
   );
-  assert.ok(candidateAttempts >= 2, "the injected monotonic clock permits the intended retry sequence independent of CI scheduling");
+  assert.equal(candidateAttempts, expectedRetryAttempts, "candidate publication retries exactly until the injected deadline");
   assert.equal(candidates.size, 1, "candidate retries reuse one directory on Windows");
   assert.equal(
     (await readdir(candidateFailureCave)).some((name) => name.startsWith(".migration.lock.candidate-")),
@@ -154,11 +154,14 @@ try {
     releasedAt: new Date().toISOString(),
   }));
   let reclaimAttempts = 0;
+  let reclaimClock = 0;
   await assert.rejects(
     migrateCaveHome({
-      lockTimeoutMs: 150,
+      lockTimeoutMs: retryTimeoutMs,
+      lockNow: () => reclaimClock,
       lockFenceRename: async () => {
         reclaimAttempts += 1;
+        reclaimClock += retryStepMs;
         const error = new Error("injected persistent Windows reclaim EPERM") as NodeJS.ErrnoException;
         error.code = "EPERM";
         throw error;
@@ -166,7 +169,7 @@ try {
     }),
     (error) => error?.code === "ETIMEDOUT",
   );
-  assert.ok(reclaimAttempts >= 2);
+  assert.equal(reclaimAttempts, expectedRetryAttempts, "released-lock fencing retries exactly until the injected deadline");
   assert.equal((await lstat(reclaimFailureLock)).isDirectory(), true);
   console.log("cave-home-migration-windows.test.ts: ok");
 } finally {

--- a/scripts/cave-home-migration-windows.test.ts
+++ b/scripts/cave-home-migration-windows.test.ts
@@ -107,10 +107,10 @@ try {
   assert.deepEqual(JSON.parse(await readFile(path.join(reusedPidCave, "config.json"), "utf8")), { windows: true });
 
   // Persistent Windows EPERM while publishing candidate directories must stop
-  // at the documented deadline and remove every contender-owned candidate.
+  // at the injected deadline and remove every contender-owned candidate.
   const retryTimeoutMs = 500;
   const retryStepMs = 100;
-  const expectedRetryAttempts = retryTimeoutMs / retryStepMs;
+  const expectedRetryAttempts = Math.ceil(retryTimeoutMs / retryStepMs);
   const candidateFailureHome = path.join(root, "candidate-eperm", ".coven");
   process.env.COVEN_HOME = candidateFailureHome;
   const candidateFailureCave = path.join(candidateFailureHome, "cave");

--- a/src/lib/server/cave-home-migration-locks-takeover.test.ts
+++ b/src/lib/server/cave-home-migration-locks-takeover.test.ts
@@ -43,7 +43,7 @@ async function denySymlink() {
 
 const RETRY_TEST_TIMEOUT_MS = 500;
 const RETRY_TEST_STEP_MS = 100;
-const RETRY_TEST_ATTEMPTS = RETRY_TEST_TIMEOUT_MS / RETRY_TEST_STEP_MS;
+const RETRY_TEST_ATTEMPTS = Math.ceil(RETRY_TEST_TIMEOUT_MS / RETRY_TEST_STEP_MS);
 
 const baseState = () => ({
   sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {},

--- a/src/lib/server/cave-home-migration-locks-takeover.test.ts
+++ b/src/lib/server/cave-home-migration-locks-takeover.test.ts
@@ -41,6 +41,10 @@ async function denySymlink() {
   throw error;
 }
 
+const RETRY_TEST_TIMEOUT_MS = 500;
+const RETRY_TEST_STEP_MS = 100;
+const RETRY_TEST_ATTEMPTS = RETRY_TEST_TIMEOUT_MS / RETRY_TEST_STEP_MS;
+
 const baseState = () => ({
   sessionFamiliar: {}, sessionTitles: {}, sessionArchived: {}, sessionSacrificed: {},
   sessionKeep: {}, sessionArchiveExtendedUntil: {}, sessionOwned: {}, mergedPrAutoArchived: {},
@@ -535,19 +539,25 @@ try {
     const { cave } = await home("candidate-eperm-timeout");
     await mkdir(cave, { recursive: true });
     let renameAttempts = 0;
+    let retryClock = 0;
     const candidates = new Set<string>();
     const epermRename = async (candidate: string) => {
       renameAttempts += 1;
+      retryClock += RETRY_TEST_STEP_MS;
       candidates.add(candidate);
       const error = new Error("injected Windows candidate failure") as NodeJS.ErrnoException;
       error.code = "EPERM";
       throw error;
     };
     await assert.rejects(
-      migrateCaveHome({ lockTimeoutMs: 150, lockCandidateRename: epermRename }),
+      migrateCaveHome({
+        lockTimeoutMs: RETRY_TEST_TIMEOUT_MS,
+        lockNow: () => retryClock,
+        lockCandidateRename: epermRename,
+      }),
       (error) => error?.code === "ETIMEDOUT",
     );
-    assert.ok(renameAttempts >= 2, "candidate publication retries until the deadline");
+    assert.equal(renameAttempts, RETRY_TEST_ATTEMPTS, "candidate publication retries exactly until the injected deadline");
     assert.equal(candidates.size, 1, "candidate publication reuses one directory for every retry");
     assert.equal(
       (await readdir(cave)).some((name) => name.startsWith(".migration.lock.candidate-")),
@@ -569,17 +579,23 @@ try {
       releasedAt: new Date().toISOString(),
     }));
     let fenceAttempts = 0;
+    let retryClock = 0;
     const epermRename = async () => {
       fenceAttempts += 1;
+      retryClock += RETRY_TEST_STEP_MS;
       const error = new Error("injected Windows reclaim failure") as NodeJS.ErrnoException;
       error.code = "EPERM";
       throw error;
     };
     await assert.rejects(
-      migrateCaveHome({ lockTimeoutMs: 150, lockFenceRename: epermRename }),
+      migrateCaveHome({
+        lockTimeoutMs: RETRY_TEST_TIMEOUT_MS,
+        lockNow: () => retryClock,
+        lockFenceRename: epermRename,
+      }),
       (error) => error?.code === "ETIMEDOUT",
     );
-    assert.ok(fenceAttempts >= 2, "released-lock fencing retries until the deadline");
+    assert.equal(fenceAttempts, RETRY_TEST_ATTEMPTS, "released-lock fencing retries exactly until the injected deadline");
     assert.equal(await kind(lock), "dir", "failed fencing never removes the owned lock");
     assert.equal((await json(path.join(lock, "owner.json"))).token, "released-owner");
   }


### PR DESCRIPTION
## Summary
- replace wall-clock retry-count assertions with injected monotonic protocol time
- assert exact bounded attempts in Windows and platform-neutral lock coverage
- leave production lock behavior unchanged

## Verification
- 20/20 sequential focused runs
- 32/32 focused runs under 4-way concurrency
- lint, typecheck, test wiring, conformance, app suite, build, and diff check

Closes #3940
Bead: cave-vjowd