### PR TITLE
fix(chat): tighten citation preview density

### DIFF
--- a/src/components/citation.test.ts
+++ b/src/components/citation.test.ts
@@ -16,6 +16,26 @@ test("the Citation UI uses the shared Popover and Cave's accent hue", () => {
     "source previews coordinate hover and focus across the row and portaled card",
   );
   assert.match(citation, /var\(--accent-presence\)/, "citations use the accent-presence hue");
+  assert.match(
+    citation,
+    /max-w-\[var\(--citation-card-w,272px\)\][^"]*gap-1[^"]*p-0/,
+    "preview cards use the compact desktop density contract",
+  );
+  assert.match(
+    citation,
+    /line-clamp-2[^"]*leading-snug/,
+    "long source titles stay compact",
+  );
+  assert.match(
+    citation,
+    /line-clamp-3[^"]*leading-normal/,
+    "source excerpts preserve context without dominating the preview",
+  );
+  assert.match(
+    citation,
+    /className="bg-\[var\(--bg-elevated\)\]"[\s\S]*?ariaLabel=\{`Source \$\{citation\.n\} preview`\}[\s\S]*?minWidth=\{272\}/,
+    "chat previews use the dense opaque evidence-card treatment",
+  );
   assert.match(citation, /showHoverPreview = false/, "sources can opt into hover preview cards");
   assert.match(
     citation,

--- a/src/components/ui/citation.tsx
+++ b/src/components/ui/citation.tsx
@@ -18,8 +18,8 @@ import type { Citation } from "@/lib/citations";
 
 function CitationCard({ citation }: { citation: Citation }) {
   return (
-    <div className="flex max-w-[var(--citation-card-w,320px)] flex-col gap-1.5 p-1">
-      <div className="flex items-center gap-1.5">
+    <div className="flex max-w-[var(--citation-card-w,272px)] flex-col gap-1 p-0">
+      <div className="flex items-center gap-1">
         <span className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] px-1 text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]">
           {citation.n}
         </span>
@@ -34,16 +34,18 @@ function CitationCard({ citation }: { citation: Citation }) {
           href={citation.url}
           target="_blank"
           rel="noreferrer"
-          className="focus-ring inline-flex items-start gap-1 text-[length:var(--text-sm)] font-medium text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
+          className="focus-ring inline-flex w-full items-start gap-1 text-[length:var(--text-sm)] font-medium leading-snug text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
         >
-          <span className="min-w-0">{citation.title}</span>
+          <span className="min-w-0 line-clamp-2 break-words">{citation.title}</span>
           <Icon name="ph:arrow-square-out" width={12} height={12} className="mt-0.5 shrink-0" aria-hidden />
         </a>
       ) : (
-        <span className="text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">{citation.title}</span>
+        <span className="line-clamp-2 break-words text-[length:var(--text-sm)] font-medium leading-snug text-[var(--text-primary)]">
+          {citation.title}
+        </span>
       )}
       {citation.snippet ? (
-        <p className="line-clamp-4 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-secondary)]">
+        <p className="line-clamp-3 text-[length:var(--text-xs)] leading-normal text-[var(--text-secondary)]">
           {citation.snippet}
         </p>
       ) : null}
@@ -175,8 +177,9 @@ function CitationSourceRow({
           }}
           anchorRef={anchorRef}
           placement="top-start"
+          className="bg-[var(--bg-elevated)]"
           ariaLabel={`Source ${citation.n} preview`}
-          minWidth={260}
+          minWidth={272}
         >
           <PopoverBody>
             <div


### PR DESCRIPTION
## Summary

- narrow chat citation hover previews to a denser 272px evidence card
- clamp source titles to two lines and excerpts to three lines
- preserve source number, domain, outbound link, and existing hover/focus coordination
- pin the density contract in the focused citation source test

## Verification

- `node --experimental-strip-types src/components/citation.test.ts` — 3/3
- `node --experimental-strip-types src/lib/citation-preview.test.ts` — 2/2
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1,292 wired, 1 expected allowlist
- `pnpm build` — production build plus bundle and standalone budgets
- `git diff --check`

## Risk

Low. The patch changes presentation density only; citation parsing and preview coordination are unchanged.

## Tracking

Bead: `cave-gq4e0`