### PR TITLE
ci(release): dispatch-only bypass for unconfigured schema registries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,11 @@ on:
           - macos
           - linux
           - windows
+      allow_unconfigured_registries:
+        description: "EMERGENCY ONLY: skip the signed OpenCode/Grok schema-registry gates and ship with the built-in baseline parsers. Tag pushes always stay fail-closed."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.ref }}
@@ -215,6 +220,9 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Require signed OpenCode compatibility registry
+        # Skippable only via manual workflow_dispatch with an explicit flag;
+        # tag-push releases remain fail-closed (docs/opencode-compatibility-registry.md).
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.allow_unconfigured_registries }}
         shell: bash
         env:
           NEXT_PUBLIC_COVEN_OPENCODE_SCHEMA_REGISTRY_URL: ${{ secrets.OPENCODE_SCHEMA_REGISTRY_URL }}
@@ -235,6 +243,9 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Require signed Grok compatibility registry
+        # Skippable only via manual workflow_dispatch with an explicit flag;
+        # tag-push releases remain fail-closed (docs/grok-compatibility-registry.md).
+        if: ${{ github.event_name != 'workflow_dispatch' || !inputs.allow_unconfigured_registries }}
         shell: bash
         env:
           NEXT_PUBLIC_COVEN_GROK_SCHEMA_REGISTRY_URL: ${{ secrets.GROK_SCHEMA_REGISTRY_URL }}


### PR DESCRIPTION
Adds a `workflow_dispatch`-only boolean input `allow_unconfigured_registries` that skips the two signed schema-registry gates (OpenCode + Grok) — and only those gates — when a release is manually re-dispatched with the flag explicitly set.

**Why:** v0.2.0 is blocked. The tag's Release run fails closed on `Require signed OpenCode compatibility registry` because the 8 registry secrets (`OPENCODE_SCHEMA_REGISTRY_*`, `GROK_SCHEMA_REGISTRY_*`) are not yet provisioned — the registries themselves don't exist yet. Without registry config, Cave falls back to the built-in baseline parsers, which is exactly what v0.1.6 users run today, so shipping without it is a capability limitation, not a security regression.

**Fail-closed design preserved:**
- Tag-push releases remain unconditionally fail-closed — the gates cannot be skipped on `push`.
- The bypass requires a human to manually dispatch the workflow AND explicitly check the flag (default `false`).
- All artifact security (DMG signing, notarization + spctl verification, Tauri updater signatures) is untouched.

**Follow-up:** stand up both registries and provision the secrets before v0.3.0 so this flag never needs to be used again.

Approved by Val ("go bypass", 2026-07-27 16:27 CDT) to unblock the overdue v0.2.0 release.