### PR TITLE
fix(home): Task placeholder addresses selected familiar, not hardcoded Nova (#3962)

### DIFF
--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -8,8 +8,18 @@ const destinations = await readFile(new URL("./home/home-destinations.ts", impor
 // ───────── Task 1: Destination-aware placeholder + drop subtitle ─────────
 assert.match(
   destinations,
-  /const PLACEHOLDERS: Record<Destination, string> = \{[\s\S]*?chat:[\s\S]*?board:[\s\S]*?\}/,
-  "PLACEHOLDERS must be a Record<Destination, string> with chat/board keys",
+  /export function placeholderFor\([\s\S]*?familiarName: string \| null[\s\S]*?\): string/,
+  "placeholderFor must be a template fn taking (destination, familiarName)",
+);
+assert.doesNotMatch(
+  destinations,
+  /Nova/,
+  "Task placeholder must not hardcode a seed familiar name (#3962)",
+);
+assert.match(
+  destinations,
+  /familiarName\?\.trim\(\) \|\| "a familiar"/,
+  "Empty familiar state falls back to neutral copy, not a name",
 );
 assert.doesNotMatch(
   source,
@@ -18,8 +28,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /placeholder=\{PLACEHOLDERS\[destination\]\}/,
-  "textarea must use placeholder={PLACEHOLDERS[destination]}",
+  /placeholder=\{placeholderFor\(destination, selectedFamiliar\?\.display_name \?\? null\)\}/,
+  "textarea must wire placeholderFor(destination, selectedFamiliar name)",
 );
 assert.doesNotMatch(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -76,7 +76,7 @@ import {
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
 import { greetingForHour } from "@/lib/home-greeting";
-import { DESTINATIONS, PLACEHOLDERS, type Destination } from "@/components/home/home-destinations";
+import { DESTINATIONS, placeholderFor, type Destination } from "@/components/home/home-destinations";
 import { resolveHomeComposerFamiliar, resolveHomeComposerProject } from "@/lib/home-composer-context";
 import { publishBoardChanged } from "@/lib/board-cache-events";
 
@@ -937,7 +937,7 @@ export function HomeComposer({
         <textarea
           ref={textareaRef}
           className="hc-textarea cave-composer-input w-full resize-none bg-transparent px-4 pt-3 pb-2 leading-6 text-[var(--text-primary)] outline-none placeholder:text-[color-mix(in_oklch,var(--foreground)_45%,transparent)] md:text-sm"
-          placeholder={PLACEHOLDERS[destination]}
+          placeholder={placeholderFor(destination, selectedFamiliar?.display_name ?? null)}
           rows={1}
           value={text}
           readOnly={!draftRestored}

--- a/src/components/home/home-destinations.ts
+++ b/src/components/home/home-destinations.ts
@@ -7,7 +7,18 @@ export const DESTINATIONS: { id: Destination; label: string; icon: IconName }[] 
   { id: "board", label: "Task", icon: "ph:kanban" },
 ];
 
-export const PLACEHOLDERS: Record<Destination, string> = {
-  chat: "Summon something magical",
-  board: "Describe what you want Nova to complete…",
-};
+/**
+ * Placeholder copy for the Home composer textarea.
+ *
+ * Task mode addresses the *selected* familiar by name so the surface never
+ * hardcodes a single seed familiar (see #3962). Falls back to neutral copy
+ * when no familiar is selected.
+ */
+export function placeholderFor(
+  destination: Destination,
+  familiarName: string | null,
+): string {
+  if (destination === "chat") return "Summon something magical";
+  const who = familiarName?.trim() || "a familiar";
+  return `Describe what you want ${who} to complete…`;
+}


### PR DESCRIPTION
Fixes #3962.

## Problem
The Home composer **Task** mode placeholder hardcoded **Nova** (`Describe what you want Nova to complete…`) even when another familiar (e.g. Gordo) was the active/selected one. The subtitle already resolved the correct familiar; only the textarea placeholder was wrong.

## Fix
- `src/components/home/home-destinations.ts`: replaced the static `PLACEHOLDERS` Record with a `placeholderFor(destination, familiarName)` template function. Task copy interpolates the selected familiar's display name; falls back to neutral `a familiar` when none is selected. Chat copy stays generic.
- `src/components/home-composer.tsx`: wires `placeholderFor(destination, selectedFamiliar?.display_name ?? null)` — the component already resolves `selectedFamiliar`.
- `src/components/home-composer-polish.test.ts`: updated assertions — require the template function + neutral fallback, assert no hardcoded `Nova`, and verify the new call wiring.

## Sweep for similar slips
Grepped all of `src/**` for seed-familiar names in placeholder/copy contexts. **This was the only production hardcode.** Other hits are legitimate: `e.g. Nova` input *example* hints, `@sage summarize…` generic example prompts, and journal-prompt substitution *tests*.

## Acceptance
- [x] Task placeholder interpolates `selectedFamiliar.display_name`
- [x] No hardcoded `Nova` in home composer placeholders
- [x] No-familiar state uses neutral fallback
- [x] Polish test updated (dynamic wiring asserted; `Nova` lock removed)

Local: `home-composer-polish.test.ts` passes; tsc clean on touched files.
