### PR TITLE
chore(ios): bump MARKETING_VERSION to 0.2.0

### DIFF
--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.1.0"
+    MARKETING_VERSION: "0.2.0"
     CURRENT_PROJECT_VERSION: "1"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"


### PR DESCRIPTION
Bumps the iOS app's `MARKETING_VERSION` from 0.1.0 → 0.2.0 to track the v0.2.0 desktop release.

- Single source of truth: `apps/ios/CovenCave/project.yml` — both Info.plists interpolate `$(MARKETING_VERSION)`, so no other stamp changes are needed.
- No iOS release pipeline exists (only CodeQL's `xcodegen + xcodebuild` touches iOS), so this is purely the version stamp. 🐾