### PR TITLE
fix(release): recover v0.2.0 packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ on:
         required: false
         default: false
         type: boolean
+      use_current_release_tooling:
+        description: "RECOVERY ONLY: build tag source with the audited release.sh and sidecar-bundle.sh from this workflow commit. Tag pushes always use tag tooling."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.ref }}
@@ -172,6 +177,29 @@ jobs:
           # checkout provenance tied to RELEASE_TAG prevents manual retries from
           # signing and publishing assets from an unrelated ref.
           ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Overlay audited recovery release tooling
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.use_current_release_tooling }}
+        shell: bash
+        env:
+          RECOVERY_TOOLING_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
+          for tooling_path in scripts/release.sh scripts/sidecar-bundle.sh; do
+            git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
+            mv "${tooling_path}.recovery" "$tooling_path"
+            chmod +x "$tooling_path"
+            expected_blob="$(git rev-parse "${RECOVERY_TOOLING_SHA}:${tooling_path}")"
+            actual_blob="$(git hash-object "$tooling_path")"
+            if [ "$actual_blob" != "$expected_blob" ]; then
+              echo "::error::Recovery tooling blob mismatch for $tooling_path"
+              exit 1
+            fi
+            echo "$actual_blob  $tooling_path"
+          done
+          git diff --check
+          echo "Using release tooling from reviewed workflow commit $RECOVERY_TOOLING_SHA against tag source."
 
       - name: Set release metadata
         shell: bash

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -20,10 +20,20 @@ const sidecarTargetModule = readFileSync(
   "utf8",
 );
 
-test("macOS release signing includes node-pty spawn-helper Mach-O files", () => {
+test("macOS release signing includes native files without executable mode", () => {
   assert.match(
     releaseScript,
-    /-name "\*\.node" -o -name "spawn-helper" -o -perm \+111/,
+    /-name "\*\.node" -o -name "spawn-helper" -o -name "espeak-ng" -o -perm \+111/,
+  );
+  const nativeSigning = releaseScript.slice(
+    releaseScript.indexOf('echo "==> Signing every native binary inside the bundle"'),
+    releaseScript.indexOf('echo "==> Sealing the .app envelope"'),
+  );
+  assert.match(nativeSigning, /! retry 3 10 codesign[\s\S]*exit 1/);
+  assert.doesNotMatch(
+    nativeSigning,
+    /failed to sign[\s\S]*\n\s*\}/,
+    "a nested signing failure must not be downgraded to a warning",
   );
 });
 
@@ -189,6 +199,26 @@ test("manual release retries build from the release tag before publishing", () =
     releaseWorkflow,
     /RAW_RELEASE_TAG: \$\{\{ github\.event\.inputs\.tag \|\| github\.ref_name \}\}/,
     "release attachment metadata must continue to come from the tag input",
+  );
+  assert.match(
+    releaseWorkflow,
+    /use_current_release_tooling:[\s\S]*default: false[\s\S]*type: boolean/,
+    "recovery tooling overlay must require an explicit manual-dispatch input",
+  );
+  assert.match(
+    releaseWorkflow,
+    /name: Overlay audited recovery release tooling[\s\S]*github\.event_name == 'workflow_dispatch' && inputs\.use_current_release_tooling/,
+    "tag pushes must never overlay release tooling",
+  );
+  assert.match(
+    releaseWorkflow,
+    /RECOVERY_TOOLING_SHA: \$\{\{ github\.sha \}\}[\s\S]*git fetch --no-tags --depth=1 origin "\$RECOVERY_TOOLING_SHA"/,
+    "manual recovery tooling must be pinned to the reviewed workflow commit",
+  );
+  assert.match(
+    releaseWorkflow,
+    /scripts\/release\.sh[\s\S]*scripts\/sidecar-bundle\.sh/,
+    "the allowlist must cover only the two packaging scripts needed by v0.2.0 recovery",
   );
 });
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -376,26 +376,29 @@ echo "==> Signing every native binary inside the bundle"
 # Apple deprecated --deep; sign inner native binaries explicitly so each one
 # gets a hardened runtime + secure timestamp before we seal the envelope.
 # Find: shared libs (.dylib), Node native modules (.node), node-pty's
-# spawn-helper Mach-O files, and any nested executable files that aren't
-# already symlinks, including the bundled Node runtime staged for the sidecar.
+# spawn-helper Mach-O files, Piper's mode-0644 espeak-ng Mach-O helper, and any
+# nested executable files that aren't already symlinks, including the bundled
+# Node runtime staged for the sidecar.
 NATIVE_FILES_TMP=$(mktemp)
 find "$APP_PATH" \
-  \( -name "*.dylib" -o -name "*.so" -o -name "*.node" -o -name "spawn-helper" -o -perm +111 \) \
+  \( -name "*.dylib" -o -name "*.so" -o -name "*.node" -o -name "spawn-helper" -o -name "espeak-ng" -o -perm +111 \) \
   -type f -print > "$NATIVE_FILES_TMP"
 NATIVE_COUNT=$(wc -l < "$NATIVE_FILES_TMP" | tr -d ' ')
 echo "    found $NATIVE_COUNT native files"
 while IFS= read -r f; do
   if [ "$f" = "$APP_PATH/Contents/Resources/resources/node/bin/node" ]; then
-    retry 3 10 codesign --force --options runtime --timestamp \
+    if ! retry 3 10 codesign --force --options runtime --timestamp \
       --entitlements "$NODE_ENTITLEMENTS" \
-      --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
-        echo "    ! failed to sign bundled Node with entitlements: $f" >&2
-      }
+      --sign "$SIGNING_IDENTITY" "$f"; then
+      echo "    ! failed to sign bundled Node with entitlements: $f" >&2
+      exit 1
+    fi
   else
-    retry 3 10 codesign --force --options runtime --timestamp \
-      --sign "$SIGNING_IDENTITY" "$f" >/dev/null 2>&1 || {
-        echo "    ! failed to sign: $f" >&2
-      }
+    if ! retry 3 10 codesign --force --options runtime --timestamp \
+      --sign "$SIGNING_IDENTITY" "$f"; then
+      echo "    ! failed to sign: $f" >&2
+      exit 1
+    fi
   fi
 done < "$NATIVE_FILES_TMP"
 rm "$NATIVE_FILES_TMP"

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -148,6 +148,16 @@ assert.ok(
 );
 assert.match(src, /bundle_piper_runtime\(\)/, "release bundling must provision the pinned Piper runtime");
 assert.match(src, /Piper runtime checksum mismatch/, "Piper runtime downloads must be integrity-checked");
+assert.match(
+  src,
+  /if \[ -f "\$PIPER_RUNTIME_DIR\/espeak-ng" \]; then[\s\S]*chmod \+x "\$PIPER_RUNTIME_DIR\/espeak-ng"/,
+  "Piper's mode-0644 macOS espeak-ng helper must be normalized as executable",
+);
+assert.doesNotMatch(
+  src.slice(src.indexOf("bundle_piper_runtime()"), src.indexOf("fix_node_pty_spawn_helpers()")),
+  /placeholder\.txt/,
+  "the generated Piper payload must not spend an MSI row on the source-tree placeholder",
+);
 assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.zst archive");
 assert.match(src, /BUILD_PLATFORM="\$\(node -p 'process\.platform'\)"/, "Windows packaging must derive the host platform from Node, not shell environment");
 assert.match(src, /\[ "\$BUILD_PLATFORM" = "win32" \]/, "Windows archive and node naming must work from Git Bash as well as CI");

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -88,7 +88,9 @@ bundle_piper_runtime() {
   fi
   cp -a "$runtime_root/." "$PIPER_RUNTIME_DIR/"
   chmod +x "$PIPER_RUNTIME_DIR/$executable" 2>/dev/null || true
-  printf "generated at release build time\n" > "$PIPER_RUNTIME_DIR/placeholder.txt"
+  if [ -f "$PIPER_RUNTIME_DIR/espeak-ng" ]; then
+    chmod +x "$PIPER_RUNTIME_DIR/espeak-ng"
+  fi
 }
 
 fix_node_pty_spawn_helpers() {


### PR DESCRIPTION
## Summary

- add an explicit manual-only recovery input that overlays only the reviewed `release.sh` and `sidecar-bundle.sh` blobs onto the immutable v0.2.0 tag checkout
- sign Piper's mode-0644 `espeak-ng` Mach-O helper and fail closed on nested signing errors
- remove the generated Piper placeholder so Windows stays within the 64-row MSI guard

Normal tag-push releases and manual dispatches without the recovery input continue to use the exact tag tooling.

## Proven failures repaired

- Linux release run 30307893857 lacked `libespeak-ng.so.1`; current `main` already installs `libespeak-ng1`
- Apple notarization rejected the unsigned bundled `resources/piper/espeak-ng`
- Windows produced 65 File/Component/CreateFolder rows because `piper/placeholder.txt` consumed the extra row

## Verification

- `pnpm test:app` — 953 test files passed
- `node scripts/release-macos-signing.test.mjs` — 11/11 passed
- `node scripts/sidecar-bundle-deps.test.mjs`
- `node scripts/stamp-release.test.mjs`
- `bash -n scripts/release.sh scripts/sidecar-bundle.sh`
- `pnpm check:tests-wired` — all 1,312 test files wired
- `git diff --check`

Bead: `cave-ud7nz`
