### PR TITLE
fix(release): remove Windows archive placeholder

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -166,6 +166,11 @@ assert.match(src, /piper_linux_x86_64\.tar\.gz/, "Linux sidecar CI builds must p
 assert.match(src, /sidecar-archive-manifest\.mjs/, "archive generation must emit its integrity and size manifest");
 assert.match(src, /\.server\.tar\.zst\.\$\$\.tmp/, "archive generation must use a same-directory staging path");
 assert.match(src, /sidecar-archive-manifest\.mjs" --publish/, "verified archive publication must use the atomic publisher");
+assert.match(
+  src,
+  /sidecar-archive-manifest\.mjs" --publish[\s\S]*rm -f "\$WINDOWS_ARCHIVE_DIR\/placeholder\.txt"/,
+  "a published Windows archive must remove the source-only glob placeholder before WiX counts resources",
+);
 assert.doesNotMatch(
   src,
   /tar -czf "\$WINDOWS_ARCHIVE/,

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -295,6 +295,7 @@ write_windows_sidecar_archive() {
     "$DEST" "$WINDOWS_ARCHIVE_TEMP" \
     "$WINDOWS_ARCHIVE" "$WINDOWS_ARCHIVE_MANIFEST" \
     "$WINDOWS_ARCHIVE_MANIFEST_TEMP"
+  rm -f "$WINDOWS_ARCHIVE_DIR/placeholder.txt"
 
   # Keep the expanded tree out of the Windows build workspace as a second
   # guard against accidentally reintroducing thousands of WiX components.


### PR DESCRIPTION
## Summary
- remove the source-only Windows archive glob placeholder after verified atomic archive publication
- prevent the placeholder from consuming an MSI File/Component/CreateFolder row
- add a regression assertion for the cleanup ordering

## Verification
- `pnpm test:app` — 953 test files passed
- `pnpm check:tests-wired` — all 1312 test files wired
- `node scripts/sidecar-bundle-deps.test.mjs`
- `node scripts/release-macos-signing.test.mjs` — 11/11 passed
- `bash -n scripts/sidecar-bundle.sh`
- `git diff --check`

## Release evidence
Recovery run 30333797867 built the MSI successfully, then measured exactly 65 File, Component, and CreateFolder rows against a budget of 64. The tracked `src-tauri/resources/server-archive/placeholder.txt` survives archive publication and is the one source-only resource removed here.