### PR TITLE
fix(release): set Windows MSI v0.2 baseline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,7 @@ jobs:
         run: |
           set -euo pipefail
           git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
-          for tooling_path in scripts/release.sh scripts/sidecar-bundle.sh; do
+          for tooling_path in scripts/release.sh scripts/sidecar-bundle.sh scripts/windows-msi-budget.ps1; do
             git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
             mv "${tooling_path}.recovery" "$tooling_path"
             chmod +x "$tooling_path"

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -217,8 +217,8 @@ test("manual release retries build from the release tag before publishing", () =
   );
   assert.match(
     releaseWorkflow,
-    /scripts\/release\.sh[\s\S]*scripts\/sidecar-bundle\.sh/,
-    "the allowlist must cover only the two packaging scripts needed by v0.2.0 recovery",
+    /scripts\/release\.sh[\s\S]*scripts\/sidecar-bundle\.sh[\s\S]*scripts\/windows-msi-budget\.ps1/,
+    "the allowlist must cover only the three packaging scripts needed by v0.2.0 recovery",
   );
 });
 

--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -7,7 +7,10 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-$rowBudget = 64
+# v0.2.0's measured baseline is 65 rows after adding the pinned Whisper and
+# Piper runtimes. Keep the cap at that exact baseline so expanded sidecar
+# payloads or unreviewed resource growth still fail closed.
+$rowBudget = 65
 $byteBudget = 256MB
 $resolvedMsi = (Resolve-Path -LiteralPath $MsiPath).Path
 $resolvedOutput = [System.IO.Path]::GetFullPath($OutputPath)

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -535,7 +535,7 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
   for (const table of ["File", "Component", "CreateFolder", "Directory"]) {
     assert.match(budget, new RegExp("FROM `" + table + "`"), `budget must inspect MSI ${table} rows`);
   }
-  assert.match(budget, /\$rowBudget = 64/);
+  assert.match(budget, /\$rowBudget = 65/);
   assert.match(budget, /\$byteBudget = 256MB/);
   assert.match(budget, /expected exactly one server\.tar\.zst File row/);
   assert.match(


### PR DESCRIPTION
## Summary
- set the Windows MSI row cap to the measured v0.2.0 baseline of exactly 65
- retain the 256 MiB payload cap and exact-one-server-archive invariant
- add the PowerShell budget guard to the explicit manual recovery overlay
- update release regression coverage for the new exact baseline and allowlist

## Evidence
Recovery runs 30333797867 and 30335492622 both produced one `server.tar.zst` row and exactly 65 File, Component, and CreateFolder rows. The second run measured a 97,579,250-byte MSI and 176,044,823 installed bytes. The older 64-row ceiling predates the pinned Whisper and Piper resources added for v0.2.0; this patch adds no slack above the measured baseline.

## Verification
- `pnpm test:app` — 953 test files passed
- `pnpm check:tests-wired` — all 1312 test files wired
- `node src-tauri/release-runtime.test.mjs` — 23/23 passed
- `node scripts/release-macos-signing.test.mjs` — 11/11 passed
- `node scripts/sidecar-bundle-deps.test.mjs`
- `git diff --check`