### PR TITLE
fix(release): enforce measured MSI table baselines

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,11 @@ on:
         required: false
         default: false
         type: boolean
+      windows_diagnostics_only:
+        description: "RECOVERY ONLY: build and measure the selected Windows MSI without uploading artifacts or editing release metadata."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.ref }}
@@ -85,6 +90,18 @@ jobs:
     name: Verify matching Coven daemon package
     runs-on: ubuntu-24.04
     steps:
+      - name: Validate Windows diagnostics mode
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.windows_diagnostics_only }}
+        shell: bash
+        env:
+          SELECTED_PLATFORM: ${{ inputs.platform }}
+        run: |
+          set -euo pipefail
+          if [ "$SELECTED_PLATFORM" != "windows" ]; then
+            echo "::error::windows_diagnostics_only requires platform=windows"
+            exit 1
+          fi
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
@@ -423,7 +440,8 @@ jobs:
       - name: Publish validated Windows MSI
         if: >-
           matrix.family == 'windows' &&
-          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows') &&
+          (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only)
         shell: powershell
         env:
           GH_TOKEN: ${{ github.token }}
@@ -463,7 +481,8 @@ jobs:
           ) ||
           (
             matrix.family == 'windows' &&
-            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows')
+            (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows') &&
+            (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only)
           )
         shell: bash
         env:
@@ -712,7 +731,7 @@ jobs:
     name: Publish SHA256SUMS
     needs: build
     runs-on: ubuntu-24.04
-    if: success()
+    if: ${{ success() && (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -815,7 +834,7 @@ jobs:
     # cave-updater: also guard against build being *skipped* (upstream job
     # failure, e.g. daemon-package gate), which means no release was ever
     # created — gh release view would return "release not found" in that case.
-    if: ${{ !cancelled() && needs.build.result != 'cancelled' && needs.build.result != 'skipped' }}
+    if: ${{ !cancelled() && needs.build.result != 'cancelled' && needs.build.result != 'skipped' && (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -158,6 +158,11 @@ assert.doesNotMatch(
   /placeholder\.txt/,
   "the generated Piper payload must not spend an MSI row on the source-tree placeholder",
 );
+assert.doesNotMatch(
+  src.slice(src.indexOf('echo "==> staging Node runtime'), src.indexOf('echo "==> staging bundled Whisper runtime"')),
+  /placeholder\.txt/,
+  "the generated Node payload must not spend an MSI row on the source-tree placeholder",
+);
 assert.match(src, /WINDOWS_ARCHIVE/, "Windows sidecar must be emitted as a tar.zst archive");
 assert.match(src, /BUILD_PLATFORM="\$\(node -p 'process\.platform'\)"/, "Windows packaging must derive the host platform from Node, not shell environment");
 assert.match(src, /\[ "\$BUILD_PLATFORM" = "win32" \]/, "Windows archive and node naming must work from Git Bash as well as CI");

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -24,6 +24,15 @@ const [
 const baseConfig = JSON.parse(baseConfigSource);
 const windowsConfig = JSON.parse(windowsConfigSource);
 
+function sourceSection(source, startMarker, endMarker, label) {
+  const startIndex = source.indexOf(startMarker);
+  const endIndex = source.indexOf(endMarker);
+  assert.notEqual(startIndex, -1, `${label} start marker must exist`);
+  assert.notEqual(endIndex, -1, `${label} end marker must exist`);
+  assert.ok(startIndex < endIndex, `${label} markers must stay in source order`);
+  return source.slice(startIndex, endIndex);
+}
+
 // Must use locked pnpm install (frozen lockfile prevents supply chain attacks)
 assert.match(src, /pnpm install --prod --frozen-lockfile/, "sidecar must install from locked pnpm lockfile");
 
@@ -154,12 +163,17 @@ assert.match(
   "Piper's mode-0644 macOS espeak-ng helper must be normalized as executable",
 );
 assert.doesNotMatch(
-  src.slice(src.indexOf("bundle_piper_runtime()"), src.indexOf("fix_node_pty_spawn_helpers()")),
+  sourceSection(src, "bundle_piper_runtime()", "fix_node_pty_spawn_helpers()", "Piper staging section"),
   /placeholder\.txt/,
   "the generated Piper payload must not spend an MSI row on the source-tree placeholder",
 );
 assert.doesNotMatch(
-  src.slice(src.indexOf('echo "==> staging Node runtime'), src.indexOf('echo "==> staging bundled Whisper runtime"')),
+  sourceSection(
+    src,
+    'echo "==> staging Node runtime',
+    'echo "==> staging bundled Whisper runtime"',
+    "Node staging section",
+  ),
   /placeholder\.txt/,
   "the generated Node payload must not spend an MSI row on the source-tree placeholder",
 );

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -333,7 +333,6 @@ cp "$NODE_BIN" "$BUNDLED_NODE_DIR/bin/$NODE_NAME"
 chmod +x "$BUNDLED_NODE_DIR/bin/$NODE_NAME" 2>/dev/null || true
 copy_node_shared_runtime "$NODE_BIN" "$BUNDLED_NODE_DIR"
 "$BUNDLED_NODE_DIR/bin/$NODE_NAME" -e "process.exit(0)" >/dev/null
-printf "generated at release build time\n" > "$BUNDLED_NODE_DIR/placeholder.txt"
 
 echo "==> staging bundled Whisper runtime"
 bash "$ROOT/scripts/whisper-runtime-bundle.sh"

--- a/scripts/stamp-release.test.mjs
+++ b/scripts/stamp-release.test.mjs
@@ -72,14 +72,40 @@ assert.equal(findOpenStampPr([{ title: "feat: x" }, { title: "chore(release): st
 
 // ── release.yml resilience pins ───────────────────────────────────────────────
 const yml = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+
+function workflowJob(source, jobName) {
+  const marker = `\n  ${jobName}:\n`;
+  const markerIndex = source.indexOf(marker);
+  assert.notEqual(markerIndex, -1, `${jobName} job must exist`);
+  const startIndex = markerIndex + 1;
+  const nextJob = /\n  [A-Za-z0-9_-]+:\n/g;
+  nextJob.lastIndex = markerIndex + marker.length;
+  const nextMatch = nextJob.exec(source);
+  return source.slice(startIndex, nextMatch?.index ?? source.length);
+}
+
 assert.match(yml, /daemon-package:\s*\n\s+name: Verify matching Coven daemon package/, "release has a daemon package gate");
 assert.match(yml, /npm view "@opencoven\/cli@latest" version/, "daemon gate verifies the package installed by the client");
 assert.match(yml, /process\.argv\[2\], process\.argv\[3\]\) >= 0/, "daemon gate requires latest CLI to satisfy the Cave version");
 assert.match(yml, /build:[\s\S]{0,100}needs: daemon-package/, "desktop builds wait for the daemon package gate");
+const updaterManifestJob = workflowJob(yml, "updater-manifest");
+const updaterManifestCondition = /^    if: (.+)$/m.exec(updaterManifestJob)?.[1];
+assert.ok(updaterManifestCondition, "updater-manifest must have a job-level condition");
+assert.match(updaterManifestCondition, /!cancelled\(\)/, "updater-manifest does not run after cancellation");
 assert.match(
-  yml,
-  /updater-manifest:[\s\S]{0,900}if: \$\{\{ !cancelled\(\) && needs\.build\.result != 'cancelled' && needs\.build\.result != 'skipped' \}\}/,
-  "updater-manifest runs after partial build failures but not when the build was skipped entirely",
+  updaterManifestCondition,
+  /needs\.build\.result != 'cancelled'/,
+  "updater-manifest rejects a cancelled build",
+);
+assert.match(
+  updaterManifestCondition,
+  /needs\.build\.result != 'skipped'/,
+  "updater-manifest rejects a build that was skipped entirely",
+);
+assert.doesNotMatch(
+  updaterManifestCondition,
+  /success\(\)/,
+  "updater-manifest still runs after a partial build failure",
 );
 assert.match(yml, /PLATFORM_COUNT=\$count.*GITHUB_ENV/, "platform count exported for the body note");
 assert.match(yml, /Flag partial updater coverage in the release body/, "partial coverage is flagged on the release itself");

--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -7,10 +7,14 @@ param(
 )
 
 $ErrorActionPreference = "Stop"
-# Keep the last independently reviewed cap until diagnostics establish a real
-# replacement. Row inspection is bounded separately so an overflow reports the
-# actual table size instead of always returning rowBudget + 1.
-$rowBudget = 65
+# Keep exact, independently reviewed baselines per table. Sharing the largest
+# value would leave silent slack in smaller tables and hide package growth.
+$rowBudgets = [ordered]@{
+    fileRows = 382
+    componentRows = 387
+    createFolderRows = 382
+    directoryRows = 50
+}
 $rowInspectionLimit = 4096
 $byteBudget = 256MB
 $resolvedMsi = (Resolve-Path -LiteralPath $MsiPath).Path
@@ -160,7 +164,28 @@ try {
             directory = $directory
         })
     }
-    $createFolderRows = Read-MsiRows -Query 'SELECT `Directory_` FROM `CreateFolder`' -OnRow { param($record) }
+    $createFolderEntries = [System.Collections.Generic.List[object]]::new()
+    $createFolderRows = Read-MsiRows -Query 'SELECT `Directory_`, `Component_` FROM `CreateFolder`' -OnRow {
+        param($record)
+        $directory = $record.GetType().InvokeMember(
+            "StringData",
+            [System.Reflection.BindingFlags]::GetProperty,
+            $null,
+            $record,
+            @(1)
+        )
+        $component = $record.GetType().InvokeMember(
+            "StringData",
+            [System.Reflection.BindingFlags]::GetProperty,
+            $null,
+            $record,
+            @(2)
+        )
+        [void]$script:createFolderEntries.Add([ordered]@{
+            directory = $directory
+            component = $component
+        })
+    }
     $directoryEntries = [System.Collections.Generic.List[object]]::new()
     $directoryRows = Read-MsiRows -Query 'SELECT `Directory`, `Directory_Parent`, `DefaultDir` FROM `Directory`' -OnRow {
         param($record)
@@ -193,7 +218,7 @@ try {
     }
 
     $metrics = [ordered]@{
-        schemaVersion = 1
+        schemaVersion = 2
         msiPath = $resolvedMsi
         msiBytes = (Get-Item -LiteralPath $resolvedMsi).Length
         installedFileBytes = $installedFileBytes
@@ -202,10 +227,11 @@ try {
         componentRows = $componentRows
         componentEntries = @($componentEntries)
         createFolderRows = $createFolderRows
+        createFolderEntries = @($createFolderEntries)
         directoryRows = $directoryRows
         directoryEntries = @($directoryEntries)
         serverArchiveRows = $serverArchiveRows
-        rowBudget = $rowBudget
+        rowBudgets = $rowBudgets
         byteBudget = $byteBudget
     }
     $json = $metrics | ConvertTo-Json -Depth 4
@@ -215,8 +241,9 @@ try {
 
     $violations = @()
     foreach ($metric in @("fileRows", "componentRows", "createFolderRows", "directoryRows")) {
-        if ($metrics[$metric] -gt $rowBudget) {
-            $violations += "$metric exceeds $rowBudget"
+        $limit = [int]$rowBudgets[$metric]
+        if ($metrics[$metric] -gt $limit) {
+            $violations += "$metric exceeds $limit"
         }
     }
     foreach ($metric in @("msiBytes", "installedFileBytes")) {

--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -8,8 +8,9 @@ param(
 
 $ErrorActionPreference = "Stop"
 # Keep exact, independently reviewed baselines per table. Sharing the largest
-# value would leave silent slack in smaller tables and hide package growth.
-$rowBudgets = [ordered]@{
+# value would leave silent slack in smaller tables; upper bounds would also hide
+# missing or incorrectly staged resources when a table unexpectedly shrinks.
+$rowBaselines = [ordered]@{
     fileRows = 382
     componentRows = 387
     createFolderRows = 382
@@ -231,7 +232,7 @@ try {
         directoryRows = $directoryRows
         directoryEntries = @($directoryEntries)
         serverArchiveRows = $serverArchiveRows
-        rowBudgets = $rowBudgets
+        rowBaselines = $rowBaselines
         byteBudget = $byteBudget
     }
     $json = $metrics | ConvertTo-Json -Depth 4
@@ -241,9 +242,10 @@ try {
 
     $violations = @()
     foreach ($metric in @("fileRows", "componentRows", "createFolderRows", "directoryRows")) {
-        $limit = [int]$rowBudgets[$metric]
-        if ($metrics[$metric] -gt $limit) {
-            $violations += "$metric exceeds $limit"
+        $expected = [int]$rowBaselines[$metric]
+        $actual = [int]$metrics[$metric]
+        if ($actual -ne $expected) {
+            $violations += "$metric expected $expected; found $actual"
         }
     }
     foreach ($metric in @("msiBytes", "installedFileBytes")) {

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -535,7 +535,25 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
   for (const table of ["File", "Component", "CreateFolder", "Directory"]) {
     assert.match(budget, new RegExp("FROM `" + table + "`"), `budget must inspect MSI ${table} rows`);
   }
-  assert.match(budget, /\$rowBudget = 65/);
+  for (const [metric, limit] of Object.entries({
+    fileRows: 382,
+    componentRows: 387,
+    createFolderRows: 382,
+    directoryRows: 50,
+  })) {
+    assert.match(
+      budget,
+      new RegExp(`${metric} = ${limit}`),
+      `${metric} must stay pinned to the independently measured post-placeholder baseline`,
+    );
+  }
+  assert.doesNotMatch(
+    budget,
+    /\$rowBudget\s*=/,
+    "unlike table sizes must not share one cap that leaves hidden slack",
+  );
+  assert.match(budget, /rowBudgets = \$rowBudgets/);
+  assert.match(budget, /\$limit = \[int\]\$rowBudgets\[\$metric\]/);
   assert.match(
     budget,
     /\$rowInspectionLimit = 4096/,
@@ -549,7 +567,9 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
   assert.match(budget, /\$count -gt \$rowInspectionLimit/);
   assert.match(budget, /fileEntries = @\(\$fileEntries\)/);
   assert.match(budget, /componentEntries = @\(\$componentEntries\)/);
+  assert.match(budget, /createFolderEntries = @\(\$createFolderEntries\)/);
   assert.match(budget, /directoryEntries = @\(\$directoryEntries\)/);
+  assert.match(budget, /schemaVersion = 2/);
   assert.match(budget, /\$byteBudget = 256MB/);
   assert.match(budget, /expected exactly one server\.tar\.zst File row/);
   assert.doesNotMatch(
@@ -569,6 +589,32 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
     /if ! gh release create "\$RELEASE_TAG"[\s\S]*for attempt in 1 2 3; do[\s\S]*if gh release view "\$RELEASE_TAG"/,
     "macOS release creation must tolerate the other matrix leg winning the race",
   );
+  assert.match(workflow, /windows_diagnostics_only:/);
+  assert.match(workflow, /Validate Windows diagnostics mode/);
+  const publishStart = workflow.indexOf("- name: Publish validated Windows MSI");
+  const signStart = workflow.indexOf("- name: Sign Linux/Windows updater artifact");
+  const publishBlock = workflow.slice(publishStart, signStart);
+  assert.match(
+    publishBlock,
+    /!inputs\.windows_diagnostics_only/,
+    "a Windows diagnostics run must not publish the measured MSI",
+  );
+  const signEnd = workflow.indexOf("- name: Strip bundled GLib/libmount from AppImage");
+  const signBlock = workflow.slice(signStart, signEnd);
+  assert.match(
+    signBlock,
+    /!inputs\.windows_diagnostics_only/,
+    "a Windows diagnostics run must not upload an updater signature",
+  );
+  const checksumsStart = workflow.indexOf("\n  checksums:");
+  const updaterManifestStart = workflow.indexOf("\n  updater-manifest:");
+  const checksumsHeader = workflow.slice(checksumsStart, workflow.indexOf("\n    steps:", checksumsStart));
+  const updaterManifestHeader = workflow.slice(
+    updaterManifestStart,
+    workflow.indexOf("\n    steps:", updaterManifestStart),
+  );
+  assert.match(checksumsHeader, /!inputs\.windows_diagnostics_only/);
+  assert.match(updaterManifestHeader, /!inputs\.windows_diagnostics_only/);
   assert.match(
     workflow,
     /Build Windows MSI without publishing[\s\S]*Measure and enforce Windows MSI budget[\s\S]*Publish validated Windows MSI/,

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -552,8 +552,19 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
     /\$rowBudget\s*=/,
     "unlike table sizes must not share one cap that leaves hidden slack",
   );
-  assert.match(budget, /rowBudgets = \$rowBudgets/);
-  assert.match(budget, /\$limit = \[int\]\$rowBudgets\[\$metric\]/);
+  assert.match(budget, /rowBaselines = \$rowBaselines/);
+  assert.match(budget, /\$expected = \[int\]\$rowBaselines\[\$metric\]/);
+  assert.match(budget, /\$actual = \[int\]\$metrics\[\$metric\]/);
+  assert.match(
+    budget,
+    /if \(\$actual -ne \$expected\)/,
+    "every MSI table must equal its independently measured baseline",
+  );
+  assert.match(
+    budget,
+    /\$violations \+= "\$metric expected \$expected; found \$actual"/,
+    "baseline drift must report both the expected and actual row count",
+  );
   assert.match(
     budget,
     /\$rowInspectionLimit = 4096/,


### PR DESCRIPTION
## Root cause

Windows diagnostic run [30401048207](https://github.com/OpenCoven/coven-cave/actions/runs/30401048207) proved the old shared cap never measured the package. The complete v0.2.0 MSI contained 383 `File`, 388 `Component`, 383 `CreateFolder`, and 50 `Directory` rows. Every earlier 65/66 result was the old `rowBudget + 1` overflow sentinel.

The retained inventory also identified one source-only `resources/node/placeholder.txt` row left after `node.exe` was staged.

## Changes

- Remove the generated Node placeholder from packaged resources.
- Enforce exact post-prune baselines independently per table: 382 files, 387 components, 382 create-folder rows, and 50 directories.
- Reject both growth and shrinkage with expected/actual diagnostics, while retaining the independent 4096-row inspection ceiling and 256 MiB byte cap.
- Emit all four table inventories in schema v2 diagnostics.
- Add a Windows-only diagnostics dispatch that skips MSI/signature uploads, checksums, updater-manifest edits, and Homebrew notification.
- Make source-section tests fail closed when markers disappear or move.
- Scope the updater-manifest resilience test to that YAML job so added guards cannot break it through a fixed character window.

## Live verification

Non-publishing run [30403086438](https://github.com/OpenCoven/coven-cave/actions/runs/30403086438) passed strict enforcement on release-tooling head `ef8c9229b`:

- 382 `File` rows
- 387 `Component` rows
- 382 `CreateFolder` rows
- 50 `Directory` rows
- exactly one `server.tar.zst`
- no placeholder file entry
- 97,591,397 MSI bytes / 190,084,164 installed bytes

The MSI build, measurement, and retained diagnostics succeeded. MSI publication, updater signing, checksums, `latest.json`, and Homebrew were all skipped. A before/after GitHub Release snapshot remained identical: nine assets, unchanged timestamps, unchanged body, and no MSI or checksum upload.

Final PR head `fc090c204` changes only `scripts/stamp-release.test.mjs` after that run; `.github/workflows/release.yml` and all overlaid release-tooling blobs are byte-identical to `ef8c9229b`.

## Local verification

- TDD red reproduced the placeholder, shared-cap, upper-bound-only, and fixed-window failures.
- `pnpm test:app` — all 953 test files passed after the final change.
- `pnpm check:tests-wired` — all 1,312 test files wired (1 allowlisted).
- `pnpm typecheck`.
- `pnpm lint`.
- `node --test src-tauri/release-runtime.test.mjs scripts/sidecar-bundle-deps.test.mjs` — 24 passed.
- `node scripts/stamp-release.test.mjs`.
- PowerShell parser check for `scripts/windows-msi-budget.ps1`.
- `bash -n scripts/sidecar-bundle.sh`.
- `git diff --check`.
- staged secret/privacy guards passed for every commit.
