### PR TITLE
feat(chat): stream thinking and group tool runs

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -493,14 +493,14 @@ assert.match(
 
 // ── CHAT-D12-01: consolidate simultaneous streaming status signals ──
 
-// (a) While the turn's own live indicator shows (pending, no visible text),
-// the Queued/Connecting/Writing chip in the same meta row is redundant —
-// suppressed until text flows or the turn settles. One shared flag gates both
-// so the chip and the indicator can never double up.
+// (a) While the turn has neither visible text nor streamed reasoning, the
+// generic ThinkingIndicator owns the status. As soon as reasoning arrives,
+// its inline disclosure becomes the live surface instead, avoiding duplicate
+// thinking chrome. One shared flag gates both the chip and the fallback.
 assert.match(
   source,
-  /const indicatorVisible = Boolean\(turn\.pending\) && !visible;/,
-  "TurnRow derives a single indicator-visibility flag from pending + visible text (CHAT-D12-01)",
+  /const indicatorVisible = Boolean\(turn\.pending\) && !visible && !reasoning;/,
+  "TurnRow reserves the generic indicator for pending turns without visible text or streamed reasoning (CHAT-D12-01)",
 );
 assert.match(
   source,

--- a/src/components/chat-view-polish-tools-activity.test.ts
+++ b/src/components/chat-view-polish-tools-activity.test.ts
@@ -54,8 +54,19 @@ assert.match(
 // reasoning block at once via a controlled `open` (default-collapsed in markup).
 assert.match(
   source,
-  /function ReasoningBlock[\s\S]*const \[showThinking\] = useShowThinking\(\)[\s\S]*open=\{showThinking \|\| undefined\}/,
-  "ReasoningBlock open state is driven by the global Show-thinking preference",
+  /function ReasoningBlock[\s\S]*const \[showThinking\] = useShowThinking\(\)[\s\S]*open=\{pending \|\| showThinking \|\| undefined\}/,
+  "ReasoningBlock settles to the global Show-thinking preference after live streaming",
+);
+
+assert.match(
+  source,
+  /function ReasoningBlock\(\{ reasoning, durationMs, pending \}[\s\S]*open=\{pending \|\| showThinking \|\| undefined\}/,
+  "live reasoning stays open while a turn is pending, then returns to the Show-thinking preference",
+);
+assert.match(
+  turnRow,
+  /<ReasoningBlock reasoning=\{reasoning\} durationMs=\{turn\.durationMs\} pending=\{!!turn\.pending\} \/>[\s\S]*?<MessageBubble/,
+  "assistant reasoning renders before the streamed answer instead of trailing it",
 );
 assert.match(
   sessionHeader,
@@ -71,8 +82,24 @@ assert.match(
 
 assert.match(
   source,
-  /function ToolGroup[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*Tool activity[\s\S]*tools\.map[\s\S]*<ToolBlock/,
-  "ToolGroup should render tool calls in a collapsed disclosure",
+  /function ToolGroup[\s\S]*<details[\s\S]*data-default-collapsed="true"[\s\S]*Tool activity[\s\S]*<ToolRuns tools=\{tools\}/,
+  "ToolGroup should render tool calls through the shared grouped disclosure path",
+);
+
+assert.match(
+  source,
+  /function ToolRuns[\s\S]*groupConsecutiveTools\(tools\)[\s\S]*<ToolRunGroup[\s\S]*<ToolBlock/,
+  "adjacent repeated tool calls roll into an expandable run while one-off calls retain their existing block",
+);
+assert.match(
+  source,
+  /function ToolRunGroup[\s\S]*<details[\s\S]*\{tools\.length\} \{tools\.length === 1 \? "call" : "calls"\}[\s\S]*tools\.map\(\(tool\) => <ToolBlock/,
+  "a tool run advertises its call count and expands to every underlying tool block",
+);
+assert.match(
+  source,
+  /function ToolRunGroup[\s\S]*onToggle=\{\(event\) => setOpen\(event\.currentTarget\.open\)\}/,
+  "a tool run derives disclosure state from its own details element, not a nested toggle target",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -18,7 +18,7 @@ import { ChatEnvironmentPanel } from "@/components/chat-environment-panel";
 import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib/canvas-artifacts";
 import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { SETTLE_MIN_RUN_MS, shouldFlare } from "@/lib/flare-cooldown";
-import { segmentTurn } from "@/lib/turn-segments";
+import { groupConsecutiveTools, segmentTurn } from "@/lib/turn-segments";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { invalidateConversation, readCachedConversation, storeConversation } from "@/lib/conversation-cache";
@@ -7099,7 +7099,7 @@ function TurnRowImpl({
   // duplicates it — suppress the chip until text flows or the turn settles.
   // Settled chips never hit this (pending is false by then), so the Failed
   // chip that anchors the Retry pill (#416/#420) always renders.
-  const indicatorVisible = Boolean(turn.pending) && !visible;
+  const indicatorVisible = Boolean(turn.pending) && !visible && !reasoning;
 
   // CHAT-D4-01: when every tool event carries a textOffset (live turns from
   // this session), render the turn as ordered segments — prose spans with
@@ -7118,13 +7118,9 @@ function TurnRowImpl({
       : {
           kind: "block" as const,
           key: `tools-${seg.tools[0]?.id ?? i}`,
-          // Reuse the EXISTING collapsed ToolBlock (arg summary + diff
-          // inputs); same-offset tools render consecutively in one group.
-          node: (
-            <div className="space-y-2">
-              {seg.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
-            </div>
-          ),
+          // Each chronology-preserving segment only rolls consecutive calls
+          // with the same name; prose and a new offset stay hard boundaries.
+          node: <ToolRuns tools={seg.tools} />,
         },
   );
 
@@ -7253,6 +7249,7 @@ function TurnRowImpl({
           </div>
 
           <div className="cave-linear-turn-body">
+            {reasoning ? <ReasoningBlock reasoning={reasoning} durationMs={turn.durationMs} pending={!!turn.pending} /> : null}
             {/* Chat-revamp 1b: the collapsed agent-work line sits ABOVE the
                 answer, so the reader sees "Worked for … · N steps" first and
                 the prose below reads uninterrupted. */}
@@ -7289,10 +7286,10 @@ function TurnRowImpl({
                 they don't teleport out of a rollup once text arrives. */}
             {indicatorVisible && segments?.length ? (
               <div className="mt-3 space-y-2">
-                {segments.flatMap((seg) =>
+                {segments.map((seg, index) =>
                   seg.kind === "tools"
-                    ? seg.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)
-                    : [],
+                    ? <ToolRuns key={`tools-${seg.tools[0]?.id ?? index}`} tools={seg.tools} />
+                    : null,
                 )}
               </div>
             ) : null}
@@ -7318,7 +7315,6 @@ function TurnRowImpl({
               </div>
             ) : null}
             {turn.progress?.length ? <ProgressGroup progress={turn.progress} pending={!!turn.pending} /> : null}
-            {reasoning ? <ReasoningBlock reasoning={reasoning} durationMs={turn.durationMs} /> : null}
             {/* Edit cards on settled turns (the work line above the answer
                 already collapsed everything else). */}
             {!turn.pending && turn.tools?.length && editCards.length
@@ -7407,7 +7403,7 @@ function TurnRowImpl({
   );
 }
 
-function ReasoningBlock({ reasoning, durationMs }: { reasoning: string; durationMs?: number }) {
+function ReasoningBlock({ reasoning, durationMs, pending }: { reasoning: string; durationMs?: number; pending: boolean }) {
   // The global "Show thinking" toggle (header) opens every reasoning block at
   // once; an individual block can still be collapsed/expanded locally. The
   // disclosure stays default-collapsed in markup — `open` is driven by the
@@ -7421,9 +7417,10 @@ function ReasoningBlock({ reasoning, durationMs }: { reasoning: string; duration
     <details
       className="cave-reasoning-block mt-3"
       data-default-collapsed="true"
-      open={showThinking || undefined}
+      data-streaming={pending || undefined}
+      open={pending || showThinking || undefined}
     >
-      <summary className="cave-tool-summary">
+      <summary className="cave-tool-summary focus-ring">
         <span className="inline-flex items-center gap-1.5">
           <Icon name="ph:brain" width={12} aria-hidden />
           Thinking
@@ -7572,6 +7569,56 @@ function ToolGroup({ tools, durationMs }: { tools: ToolEvent[]; durationMs?: num
         </span>
       </summary>
       <div className="mt-2 space-y-2 border-t border-[var(--border-hairline)]/70 pt-2">
+        <ToolRuns tools={tools} />
+      </div>
+    </details>
+  );
+}
+
+function ToolRuns({ tools }: { tools: ToolEvent[] }) {
+  return groupConsecutiveTools(tools).map((run) => {
+    // File-mutation cards carry review/undo affordances. Keeping each one
+    // standalone means a repeated edit never hides an actionable change.
+    const containsEdit = run.tools.some((tool) => toolInputAsDiff(tool.name, tool.input) != null);
+    if (run.tools.length > 1 && !containsEdit) {
+      return <ToolRunGroup key={run.tools.map((tool) => tool.id).join(":")} name={run.name} tools={run.tools} />;
+    }
+    return (
+      <Fragment key={run.tools.map((tool) => tool.id).join(":")}>
+        {run.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
+      </Fragment>
+    );
+  });
+}
+
+function ToolRunGroup({ name, tools }: { name: string; tools: ToolEvent[] }) {
+  const [open, setOpen] = useState(false);
+  const visual = toolVisual(name);
+  const displayName = name.trim() || "Tool";
+  const running = tools.filter((tool) => tool.status === "running").length;
+  const errors = tools.filter((tool) => tool.status === "error").length;
+
+  return (
+    <details
+      className="cave-tool-run"
+      data-default-collapsed="true"
+      data-tool-category={visual.category}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary
+        className="cave-tool-summary focus-ring"
+        aria-expanded={open}
+        aria-label={`${displayName}, ${tools.length} ${tools.length === 1 ? "call" : "calls"}`}
+      >
+        <Icon name={visual.icon} width={12} className="cave-tool-icon shrink-0" aria-hidden />
+        <span className="cave-tool-run__name">{displayName}</span>
+        <span className="cave-tool-count">{tools.length} {tools.length === 1 ? "call" : "calls"}</span>
+        <span className="ml-auto flex items-center gap-1.5 font-mono text-[length:var(--text-2xs)] normal-case tracking-normal text-[var(--text-muted)]">
+          {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
+          {errors ? <span className="cave-tool-count cave-tool-count--error">{errors} {errors === 1 ? "error" : "errors"}</span> : null}
+        </span>
+      </summary>
+      <div className="cave-tool-run__list">
         {tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
       </div>
     </details>

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -322,7 +322,7 @@ console.log("session-debug core assertions passed");
 // ═══════════════════════════════════════════════════════════════════════════
 
 import { readFileSync } from "node:fs";
-import { segmentTurn } from "./turn-segments.ts";
+import { groupConsecutiveTools, segmentTurn } from "./turn-segments.ts";
 
 // ── Legacy passthrough: turns without offsets render exactly as today ──────
 assert.equal(segmentTurn("some text", undefined), null, "no tools → null (legacy)");
@@ -419,6 +419,36 @@ assert.equal(
   assert.deepEqual(segs.map((s) => s.kind), ["tools"]);
 }
 
+// ── Consecutive repeated tool runs stay bounded by a different tool ───────
+{
+  const runs = groupConsecutiveTools([
+    { id: "read-1", name: "Read" },
+    { id: "read-2", name: " read " },
+    { id: "grep-1", name: "Grep" },
+    { id: "read-3", name: "Read" },
+  ]);
+  assert.deepEqual(
+    runs.map((run) => run.tools.map((tool) => tool.id)),
+    [["read-1", "read-2"], ["grep-1"], ["read-3"]],
+    "only adjacent calls with the same normalized name roll up",
+  );
+  assert.deepEqual(
+    runs.map((run) => run.name),
+    ["Read", "Grep", "Read"],
+    "each run retains the first call's display name",
+  );
+
+  const separatedByProse = groupConsecutiveTools([
+    { id: "read-before", name: "Read", textOffset: 0 },
+    { id: "read-after", name: "Read", textOffset: 24 },
+  ]);
+  assert.deepEqual(
+    separatedByProse.map((run) => run.tools.map((tool) => tool.id)),
+    [["read-before"], ["read-after"]],
+    "same-name calls captured on opposite sides of prose never roll up",
+  );
+}
+
 // ── Source pins ─────────────────────────────────────────────────────────────
 const chatViewSource = readFileSync(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 const bubbleSource = readFileSync(new URL("../components/message-bubble.tsx", import.meta.url), "utf8");
@@ -465,8 +495,8 @@ assert.match(
 );
 assert.match(
   chatViewSource,
-  /seg\.tools\.map\(\(tool\) => <ToolBlock key=\{tool\.id\} tool=\{tool\} \/>\)/,
-  "CHAT-D4-01: interleaved tools reuse the existing collapsed ToolBlock",
+  /node: <ToolRuns tools=\{seg\.tools\} \/>/,
+  "CHAT-D4-01: interleaved tools retain their chronology while the shared run renderer preserves each ToolBlock",
 );
 
 // MessageBubble: only the LAST text span streams (progressive markdown +

--- a/src/lib/turn-segments.ts
+++ b/src/lib/turn-segments.ts
@@ -38,6 +38,36 @@ export type TurnSegment<T extends SegmentedTool> =
   | { kind: "text"; text: string }
   | { kind: "tools"; tools: T[] };
 
+export type ConsecutiveToolRun<T extends { name: string; textOffset?: number }> = {
+  /** The first tool's display name, retained for the run summary. */
+  name: string;
+  tools: T[];
+};
+
+/**
+ * Partition tool activity into maximal adjacent runs with the same name.
+ *
+ * This is deliberately presentation-only: callers already decide the
+ * chronological boundary (a streamed `TurnSegment`, or the legacy tool
+ * rollup) and retain the original ToolEvent records inside every run.
+ */
+export function groupConsecutiveTools<T extends { name: string; textOffset?: number }>(tools: readonly T[]): ConsecutiveToolRun<T>[] {
+  const runs: ConsecutiveToolRun<T>[] = [];
+  for (const tool of tools) {
+    const normalizedName = tool.name.trim().toLowerCase();
+    const previous = runs[runs.length - 1];
+    const previousTool = previous?.tools[previous.tools.length - 1];
+    const bothOffsetsKnown = Number.isFinite(previousTool?.textOffset) && Number.isFinite(tool.textOffset);
+    const sameOffset = !bothOffsetsKnown || previousTool?.textOffset === tool.textOffset;
+    if (previous && previous.name.trim().toLowerCase() === normalizedName && sameOffset) {
+      previous.tools.push(tool);
+    } else {
+      runs.push({ name: tool.name, tools: [tool] });
+    }
+  }
+  return runs;
+}
+
 /**
  * Offsets (into `text`) where the document can be split without landing
  * inside a code fence: the start of each line that follows a blank line,

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -192,6 +192,15 @@
   padding: 10px var(--space-3);
 }
 
+.cave-reasoning-block[data-streaming] {
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 7%, var(--bg-panel));
+}
+
+.cave-reasoning-block[data-streaming] > .cave-tool-summary {
+  color: var(--accent-presence);
+}
+
 .cave-tool-summary {
   display: flex;
   align-items: center;
@@ -328,18 +337,48 @@ details[open] > .cave-tool-summary::before {
   --tool-accent: var(--text-muted);
   border-left: 2px solid color-mix(in oklch, var(--tool-accent) 70%, transparent);
 }
+
+.cave-tool-run {
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-subtle);
+  padding: var(--space-2);
+}
+
+.cave-tool-run > .cave-tool-summary {
+  letter-spacing: normal;
+  text-transform: none;
+}
+
+.cave-tool-run__name {
+  min-width: 0;
+  overflow: hidden;
+  color: color-mix(in oklch, var(--tool-accent) 80%, var(--text-secondary));
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cave-tool-run__list {
+  display: grid;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+  border-top: 1px solid color-mix(in oklch, var(--foreground) 7%, transparent);
+  padding-top: var(--space-2);
+}
+
 .cave-tool-icon { color: var(--tool-accent); }
 .cave-tool-name { color: color-mix(in oklch, var(--tool-accent) 80%, var(--text-secondary)); }
 
-.cave-tool-block[data-tool-category="shell"]  { --tool-accent: oklch(0.80 0.15 150); } /* green */
-.cave-tool-block[data-tool-category="read"]   { --tool-accent: oklch(0.74 0.13 235); } /* blue */
-.cave-tool-block[data-tool-category="search"] { --tool-accent: oklch(0.74 0.16 295); } /* violet */
-.cave-tool-block[data-tool-category="edit"]   { --tool-accent: oklch(0.82 0.14 75); }  /* amber */
-.cave-tool-block[data-tool-category="agent"]  { --tool-accent: oklch(0.74 0.18 350); } /* magenta */
-.cave-tool-block[data-tool-category="web"]    { --tool-accent: oklch(0.78 0.12 200); } /* teal */
-.cave-tool-block[data-tool-category="task"]   { --tool-accent: oklch(0.80 0.13 95); }  /* lime */
-.cave-tool-block[data-tool-category="mcp"]    { --tool-accent: oklch(0.72 0.14 270); } /* indigo */
-.cave-tool-block[data-tool-category="other"]  { --tool-accent: var(--text-muted); }
+.cave-tool-block[data-tool-category="shell"], .cave-tool-run[data-tool-category="shell"]  { --tool-accent: oklch(0.80 0.15 150); } /* green */
+.cave-tool-block[data-tool-category="read"], .cave-tool-run[data-tool-category="read"]   { --tool-accent: oklch(0.74 0.13 235); } /* blue */
+.cave-tool-block[data-tool-category="search"], .cave-tool-run[data-tool-category="search"] { --tool-accent: oklch(0.74 0.16 295); } /* violet */
+.cave-tool-block[data-tool-category="edit"], .cave-tool-run[data-tool-category="edit"]   { --tool-accent: oklch(0.82 0.14 75); }  /* amber */
+.cave-tool-block[data-tool-category="agent"], .cave-tool-run[data-tool-category="agent"]  { --tool-accent: oklch(0.74 0.18 350); } /* magenta */
+.cave-tool-block[data-tool-category="web"], .cave-tool-run[data-tool-category="web"]    { --tool-accent: oklch(0.78 0.12 200); } /* teal */
+.cave-tool-block[data-tool-category="task"], .cave-tool-run[data-tool-category="task"]   { --tool-accent: oklch(0.80 0.13 95); }  /* lime */
+.cave-tool-block[data-tool-category="mcp"], .cave-tool-run[data-tool-category="mcp"]    { --tool-accent: oklch(0.72 0.14 270); } /* indigo */
+.cave-tool-block[data-tool-category="other"], .cave-tool-run[data-tool-category="other"]  { --tool-accent: var(--text-muted); }
 
 /* CHAT-D4-07: expanded tool I/O is secondary context — clamp it tighter than
    prose code blocks (which cap at min(60vh, 520px), CHAT-D7-03). 360px sits


### PR DESCRIPTION
## Summary
- Stream inline thinking ahead of the assistant answer, open while the turn is active and compact after it settles.
- Roll consecutive same-name tool calls into expandable `Tool · N calls` runs without crossing prose or hiding edit cards.
- Add chronology and rendering regression coverage for live and completed transcript paths.

## Validation
- `node --experimental-strip-types src/lib/session-debug.test.ts`
- `node --experimental-strip-types src/components/chat-view-polish-tools-activity.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:app`
- `pnpm build`
