### PR TITLE
Daily report: one screen at md+, and never page past the current week

### DIFF
--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -86,6 +86,59 @@ assert.match(view, /no line counts/, "cast members without line counts say so");
 // The share card reuses the frozen image when one exists.
 assert.match(modals, /shareImageUrl/, "the share modal renders the frozen generated card");
 
+// ── one screen at md and up ────────────────────────────────────────────────
+// The report is a single screen from 768px: the page itself must not scroll,
+// the columns take their own scrollbars instead. `.dr-page` is its own scroll
+// container nested inside `.aps-main`, so the lock has to clamp the day
+// variant or the outer pane picks the scroll back up.
+
+{
+  const css = read("../styles/daily-report-day.css");
+  const md = css.match(/@media \(min-width: 768px\)\s*\{[\s\S]*?\n\}/);
+  assert.ok(md, "daily-report-day.css must carry a min-width: 768px block");
+  assert.match(md[0], /\.dr-page--day\s*\{[^}]*overflow:\s*hidden/, "the day page must not scroll at md+");
+  assert.match(md[0], /\.dr-page--day \.drd\b[^{]*\{[^}]*min-height:\s*0/, "the card must be allowed to shrink");
+  assert.match(md[0], /\.dr-page--day \.drd-body[^{]*\{[^}]*(flex|overflow)/, "the body row absorbs the leftover height");
+  // Below md the page scrolls normally — that is correct for a phone. Scope
+  // the check to the mobile block itself by brace-matching; a loose regex
+  // here just reaches forward into the md block and always "passes".
+  const blockAt = (source, header) => {
+    const start = source.indexOf(header);
+    if (start === -1) return "";
+    let depth = 0;
+    for (let i = source.indexOf("{", start); i < source.length; i++) {
+      if (source[i] === "{") depth++;
+      else if (source[i] === "}" && --depth === 0) return source.slice(start, i + 1);
+    }
+    return "";
+  };
+  const mobile = blockAt(css, "@media (max-width: 760px)");
+  assert.ok(mobile, "the mobile band block should still exist");
+  assert.doesNotMatch(mobile, /overflow:\s*hidden/, "the mobile band must keep its normal page scroll");
+  assert.match(
+    css,
+    /@media \(min-width: 1025px\)[\s\S]*?\.dr-page--day \.drd-rail/,
+    "from lg each column takes its own scrollbar",
+  );
+}
+
+// ── the week strip never pages into the future ─────────────────────────────
+
+assert.match(page, /const canGoForward = dateSlug\(day\) < todaySlug/, "forward paging stops at the current week");
+assert.match(
+  page,
+  /dateSlug\(nextWeek\) > todaySlug \? todaySlug : dateSlug\(nextWeek\)/,
+  "the last forward step clamps to today rather than overshooting",
+);
+assert.match(page, /isFuture,/, "week cells know whether they are in the future");
+assert.match(view, /canGoForward \?/, "the next-week control is dead on the current week");
+assert.match(view, /day\.isFuture \?/, "a future day renders as a dead cell, not a link");
+assert.match(
+  read("../styles/daily-report-day.css"),
+  /\.drd-week__step\[data-disabled\][\s\S]{0,160}pointer-events:\s*none/,
+  "the disabled step must not be clickable",
+);
+
 // ── theme safety ───────────────────────────────────────────────────────────
 // This surface ships beside 21 themes × 2 modes. A literal color from the
 // mock would break the other 41 combinations, so the sheets must be

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -120,10 +120,12 @@ export default async function DailyReportPage({ params }: Props) {
   }
   const weekMerges = weekDates.map((d) => statBySlug.get(dateSlug(d))?.prsMerged ?? 0);
   const peakMerges = Math.max(...weekMerges, 0);
+  const todaySlug = dateSlug(new Date());
   const week: WeekCell[] = weekDates.map((d, i) => {
     const slug = dateSlug(d);
     const dayStats = statBySlug.get(slug);
     const merges = weekMerges[i];
+    const isFuture = slug > todaySlug;
     return {
       slug,
       letter: WEEKDAY_LETTER[d.getDay()],
@@ -131,19 +133,27 @@ export default async function DailyReportPage({ params }: Props) {
       level: peakMerges > 0 ? merges / peakMerges : 0,
       selected: slug === dateSlug(day),
       hasReport: Boolean(dayStats),
-      title: `${d.toDateString()} · ${dayStats ? `${merges} ${merges === 1 ? "merge" : "merges"}` : "no report"}`,
+      isFuture,
+      title: isFuture
+        ? `${d.toDateString()} · hasn't happened yet`
+        : `${d.toDateString()} · ${dayStats ? `${merges} ${merges === 1 ? "merge" : "merges"}` : "no report"}`,
     };
   });
 
   const prevWeek = new Date(day);
   prevWeek.setDate(day.getDate() - 7);
+  // Forward paging stops at the current week — the cave cannot report on a day
+  // that has not happened. The last step clamps to today rather than
+  // overshooting into a week of empty cells.
   const nextWeek = new Date(day);
   nextWeek.setDate(day.getDate() + 7);
+  const nextWeekSlug = dateSlug(nextWeek) > todaySlug ? todaySlug : dateSlug(nextWeek);
+  const canGoForward = dateSlug(day) < todaySlug;
 
   // media.generatedAt moves on every in-place refresh; firedAt stays at the
   // day's first generation, so prefer the former for a truthful timestamp.
   const generatedAt = item.media?.generatedAt ?? item.firedAt ?? item.updatedAt ?? null;
-  const isToday = dateSlug(day) === dateSlug(new Date());
+  const isToday = dateSlug(day) === todaySlug;
 
   // The familiar's narrative, with the piggybacked next-paths block stripped.
   const rawNarrative = item.media?.narrative?.text ?? null;
@@ -166,7 +176,8 @@ export default async function DailyReportPage({ params }: Props) {
             week={week}
             weekLabel={`${shortDate(weekDates[0])} — ${shortDate(weekDates[6])}`}
             prevWeekSlug={dateSlug(prevWeek)}
-            nextWeekSlug={dateSlug(nextWeek)}
+            nextWeekSlug={nextWeekSlug}
+            canGoForward={canGoForward}
             isToday={isToday}
             narrative={narrative}
             narrativeByline={narrativeByline}

--- a/src/components/daily-report-day.tsx
+++ b/src/components/daily-report-day.tsx
@@ -27,6 +27,8 @@ export type WeekCell = {
   level: number;
   selected: boolean;
   hasReport: boolean;
+  /** After today — there is nothing to report yet, so it is not navigable. */
+  isFuture: boolean;
   title: string;
 };
 
@@ -43,6 +45,9 @@ type Props = {
   weekLabel: string;
   prevWeekSlug: string;
   nextWeekSlug: string;
+  /** False once the strip has reached the current week — the cave cannot
+   *  report on a day that has not happened, so forward paging stops here. */
+  canGoForward: boolean;
   isToday: boolean;
   /** The familiar-written narrative, next-paths already stripped. */
   narrative: string | null;
@@ -84,6 +89,7 @@ export function DailyReportDay({
   weekLabel,
   prevWeekSlug,
   nextWeekSlug,
+  canGoForward,
   isToday,
   narrative,
   narrativeByline,
@@ -187,25 +193,52 @@ export function DailyReportDay({
             <a className="drd-week__step" href={`/daily-report/${prevWeekSlug}`} aria-label="Previous week">
               <Icon name="ph:caret-left" aria-hidden />
             </a>
-            {week.map((day) => (
-              <a
-                key={day.slug}
-                className="drd-week__day"
-                href={`/daily-report/${day.slug}`}
-                title={day.title}
-                aria-current={day.selected ? "date" : undefined}
-                data-selected={day.selected || undefined}
-                data-empty={!day.hasReport || undefined}
-                style={{ ["--drd-level" as string]: `${Math.round(day.level * 100)}%` }}
-              >
-                <span className="drd-week__letter">{day.letter}</span>
-                <span className="drd-week__num">{day.num}</span>
-                <span className="drd-week__bar" aria-hidden />
+            {week.map((day) => {
+              const cell = (
+                <>
+                  <span className="drd-week__letter">{day.letter}</span>
+                  <span className="drd-week__num">{day.num}</span>
+                  <span className="drd-week__bar" aria-hidden />
+                </>
+              );
+              const shared = {
+                className: "drd-week__day",
+                title: day.title,
+                "data-selected": day.selected || undefined,
+                "data-empty": !day.hasReport || undefined,
+                style: { ["--drd-level" as string]: `${Math.round(day.level * 100)}%` },
+              };
+              // A future day has nothing to report — render it as a dead cell
+              // rather than a link into an empty "not found" page.
+              return day.isFuture ? (
+                <span key={day.slug} {...shared} data-future aria-disabled="true">
+                  {cell}
+                </span>
+              ) : (
+                <a
+                  key={day.slug}
+                  {...shared}
+                  href={`/daily-report/${day.slug}`}
+                  aria-current={day.selected ? "date" : undefined}
+                >
+                  {cell}
+                </a>
+              );
+            })}
+            {canGoForward ? (
+              <a className="drd-week__step" href={`/daily-report/${nextWeekSlug}`} aria-label="Next week">
+                <Icon name="ph:caret-right" aria-hidden />
               </a>
-            ))}
-            <a className="drd-week__step" href={`/daily-report/${nextWeekSlug}`} aria-label="Next week">
-              <Icon name="ph:caret-right" aria-hidden />
-            </a>
+            ) : (
+              <span
+                className="drd-week__step"
+                data-disabled
+                aria-disabled="true"
+                title="This is the current week"
+              >
+                <Icon name="ph:caret-right" aria-hidden />
+              </span>
+            )}
           </div>
 
           <span className="drd-week__label">{weekLabel}</span>
@@ -302,7 +335,16 @@ export function DailyReportDay({
 
       {/* ── the day, three ways ──────────────────────────────────────── */}
       <div className="drd-panelhost">
-        <DayCarousel model={model} open={carouselOpen} onToggle={() => setCarouselOpen((v) => !v)} />
+        <DayCarousel
+          model={model}
+          open={carouselOpen}
+          onToggle={() =>
+            setCarouselOpen((v) => {
+              if (!v) setShipOpen(false);
+              return !v;
+            })
+          }
+        />
       </div>
 
       {/* ── chapters | page | cast ───────────────────────────────────── */}
@@ -556,7 +598,16 @@ export function DailyReportDay({
 
       {/* ── shipped ──────────────────────────────────────────────────── */}
       <div className="drd-panelhost drd-panelhost--shipped">
-        <ShippedPanel model={model} open={shipOpen} onToggle={() => setShipOpen((v) => !v)} />
+        <ShippedPanel
+          model={model}
+          open={shipOpen}
+          onToggle={() =>
+            setShipOpen((v) => {
+              if (!v) setCarouselOpen(false);
+              return !v;
+            })
+          }
+        />
       </div>
 
       <DayModals

--- a/src/styles/daily-report-day.css
+++ b/src/styles/daily-report-day.css
@@ -140,6 +140,15 @@
   color: var(--fg-base);
 }
 
+/* The current week is the end of the road: forward paging is dead rather than
+   hidden, so the strip keeps its shape and the reason lives in the tooltip. */
+.drd-week__step[data-disabled],
+.drd-week__day[data-future] {
+  opacity: var(--opacity-disabled);
+  cursor: default;
+  pointer-events: none;
+}
+
 .drd-week__day {
   display: flex;
   align-items: center;
@@ -1062,4 +1071,81 @@
   color: var(--fg-muted);
   font-style: italic;
   white-space: normal;
+}
+
+/* ── the day fills the viewport at md and up ──────────────────────────────
+   From 768px the report is a single screen: the page itself never scrolls,
+   and the three columns each take their own scrollbar instead. Below md the
+   columns stack and the page scrolls normally, which is the right behaviour
+   for a phone.
+
+   `.dr-page` is its own scroll container (surface-reporting.css) nested inside
+   `.aps-main`, which is another one — so the lock has to clamp the day
+   variant, not just the card, or the outer pane picks the scroll back up. */
+@media (min-width: 768px) {
+  .dr-page--day {
+    overflow: hidden;
+  }
+
+  .dr-page--day .dr-shell--wide {
+    box-sizing: border-box;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+  }
+
+  .dr-page--day .drd {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  /* The body row absorbs whatever the chrome, band and panel strips leave. */
+  .dr-page--day .drd-body {
+    flex: 1 1 auto;
+    min-height: 0;
+  }
+
+  /* Between md and lg the cast folds into a second row, so the body scrolls
+     as one region — per-column scrollbars there would each be a few pixels
+     tall and useless. */
+  .dr-page--day .drd-body {
+    overflow-y: auto;
+  }
+
+  /* On a short viewport the overlay panels must not outgrow the card they are
+     clipped to — they scroll internally instead of being cut off. */
+  .dr-page--day .drd-panelhost [data-panel] {
+    max-height: min(560px, 68vh);
+    overflow-y: auto;
+  }
+}
+
+/* From lg the three columns are side by side again and each takes its own
+   scrollbar, so picking a chapter never scrolls the rail or the cast out of
+   reach. */
+@media (min-width: 1025px) {
+  .dr-page--day .drd-body {
+    overflow: hidden;
+  }
+
+  .dr-page--day .drd-rail,
+  .dr-page--day .drd-page,
+  .dr-page--day .drd-cast {
+    min-height: 0;
+  }
+
+  .dr-page--day .drd-rail,
+  .dr-page--day .drd-page,
+  .dr-page--day .drd-cast__body {
+    overflow-y: auto;
+  }
+}
+
+/* Both overlay panels open across the same band — the carousel downward, the
+   shipped table upward — so whichever is open has to out-rank the other host's
+   strip. Without this the shipped rows render underneath the carousel trigger
+   on a short viewport. */
+.drd-panelhost:has([data-panel]) {
+  z-index: 30;
 }


### PR DESCRIPTION
Two fixes to the chaptered day (follow-up to #3981).

## The page no longer scrolls vertically from 768px

At `md` and up the report is a single screen. `.dr-page--day` clamps, the card absorbs the remaining height, and overflow moves into the surface itself:

- **md → lg** (768–1024), where the cast folds into a second row: the body scrolls as **one** region — per-column scrollbars there would each be a few pixels tall and useless.
- **lg and up**: the three columns are side by side again and each takes its **own** scrollbar, so picking a chapter never scrolls the rail or the cast out of reach.
- **Below md**: unchanged — the columns stack and the page scrolls, which is right for a phone.

The lock has to clamp the **day variant**, not just the card: `.dr-page` is its own scroll container nested inside `.aps-main`, which is another one, so constraining only `.drd` leaves the outer pane to pick the scroll back up.

## Forward paging stops at the current week

The cave can't report on a day that hasn't happened:

- the **next-week control is dead** once the strip reaches today (`pointer-events: none`, no `href`, tooltip says why) rather than being hidden, so the strip keeps its shape;
- a **day cell after today** renders as a dead cell instead of a link into a "not found" page;
- stepping forward from an older week **clamps to today** rather than overshooting into a week of empty cells.

## Also fixed: an overlay stacking collision

Found while verifying the above. Both panels open across the same band — the carousel downward, the shipped table upward — so on a short viewport the shipped rows rendered *underneath* the carousel trigger. They're now mutually exclusive, and whichever host holds the open panel out-ranks the other.

| before | after |
| --- | --- |
| carousel strip bleeding through the shipped rows at 1280×640 | panel bounded to the card, rows legible, scrolls internally |

## Verification

Measured **real scroll heights** in the built app across the boundary:

```
PASS 768x700   doc=0 body=0 aps=0 drPage=0  inner=[drd-body(auto)]
PASS 768x900   doc=0 body=0 aps=0 drPage=0  inner=[drd-body(auto)]
PASS 1024x768  doc=0 body=0 aps=0 drPage=0  inner=[drd-body(auto)]
PASS 1280x800  doc=0 body=0 aps=0 drPage=0  inner=[drd-rail, drd-page, drd-cast__body]
PASS 1440x900  doc=0 body=0 aps=0 drPage=0  inner=[]
PASS 1920x1080 doc=0 body=0 aps=0 drPage=0  inner=[]
PASS 1280x640  doc=0 body=0 aps=0 drPage=0  inner=[drd-rail, drd-page, drd-cast__body]

PASS 600x800   dr-page scrollable by 1108px   (mobile keeps its scroll)
PASS 390x844   dr-page scrollable by 1210px

PASS current week cannot page forward  (<span> data-disabled, no href, pointer-events:none)
PASS past week clamps forward to today (href=/daily-report/<today>)
```

No console or page errors. The contract is pinned in `daily-report-page.test.ts` — the md block must clamp `.dr-page--day`, the mobile block must **not** (checked by brace-matching the block, since a loose regex just reaches forward into the md block and always passes), and the forward-gating logic is pinned in both the page and the view.

`pnpm test:app` (954 files), `pnpm lint`, `tsc --noEmit` and `pnpm build` all green; zero drift-ratchet movement.