### PR TITLE
Daily report: fill the viewport instead of a centred column

### DIFF
--- a/src/styles/daily-report-day.css
+++ b/src/styles/daily-report-day.css
@@ -1087,9 +1087,15 @@
     overflow: hidden;
   }
 
+  /* Fill the pane. The report it replaced was a centred 1060px reading column,
+     but the chaptered day is a dashboard — three columns plus two full-width
+     panel strips, all of which want every pixel. The gutter stays small and
+     even so the card reads as the surface rather than floating on one. */
   .dr-page--day .dr-shell--wide {
     box-sizing: border-box;
+    max-width: none;
     height: 100%;
+    padding: var(--space-2);
     display: flex;
     flex-direction: column;
     min-height: 0;
@@ -1148,4 +1154,17 @@
    on a short viewport. */
 .drd-panelhost:has([data-panel]) {
   z-index: 30;
+}
+
+/* On a very wide window the middle column would balloon while the prose keeps
+   its reading measure. Give the rail and the cast a little more of that space
+   so the three columns stay in proportion instead of stranding it. */
+@media (min-width: 1600px) {
+  .dr-page--day .drd-body {
+    grid-template-columns: 232px minmax(0, 1fr) 320px;
+  }
+
+  .dr-page--day .drd-cast {
+    width: 320px;
+  }
 }


### PR DESCRIPTION
The chaptered day inherited the older report's centred reading shell (1060px, widened to 1400px in #3981). That's right for a single column of prose and wrong for this surface — it's a dashboard: three columns plus two full-width panel strips. Above 1400px it left a band of dead canvas down both sides while the written column stayed cramped.

**At md and up the shell now fills the pane** with a small, even gutter, so the card reads as the surface rather than something floating on one.

**Above 1600px the rail and cast take a little more of the extra width** (232px / 320px). The written column keeps its reading measure, so without this the middle column just ballooned and stranded the space; handing it to the two side columns keeps the three in proportion.

Vertical behaviour is unchanged — still one screen from md up (#3982), still a normally scrolling page below it.

## Verification

Rendered in the built app against a real-shaped 33-merge day:

| viewport | page scroll |
| --- | --- |
| 1440×900 | `doc=0` `dr-page=0` |
| 1920×1080 | `doc=0` `dr-page=0` |

`pnpm test:app` — 954 files pass. `pnpm lint` clean. Zero drift-ratchet movement (the codemod reports no drift; the change is one `max-width`, one `padding`, and a `min-width: 1600px` block using existing tokens).

🤖 Generated with [Claude Code](https://claude.com/claude-code)