### PR TITLE
fix(github): remove authenticated status chip

### DIFF
--- a/src/app/api/github/activity/route.test.ts
+++ b/src/app/api/github/activity/route.test.ts
@@ -57,11 +57,6 @@ assert.doesNotMatch(
 );
 assert.match(
   githubView,
-  /Authenticated — private repos included/,
-  "authenticated GitHub auth chip should make private repo visibility explicit",
-);
-assert.match(
-  githubView,
   /\.\.\.filtered\.map\(\(i\) => orgOf\(i\.repo\)\)/,
   "organization options derive from the orgs present in the current table rows, not from every membership",
 );

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -93,6 +93,16 @@ assert.match(
   /\{patStatus\?\.hasPat \? \(\s*<>\s*<PopoverSeparator \/>\s*<PopoverItem icon="ph:key" onSelect=\{\(\) => setShowPatModal\(true\)\}>/,
   "connected state moves PAT management into the overflow menu",
 );
+assert.doesNotMatch(
+  source,
+  /activity\?\.authed === true|>\s*authenticated\s*</,
+  "authenticated state does not render a persistent status chip",
+);
+assert.doesNotMatch(
+  boardCss,
+  /\.gh-compact-auth--authed/,
+  "the retired authenticated status chip leaves no dead modifier styles",
+);
 
 assert.match(
   source,

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -2716,14 +2716,6 @@ export function GitHubView({
               public API
             </span>
           )}
-          {activity?.authed === true && (
-            <span
-              className="gh-compact-auth gh-compact-auth--authed"
-              title="Authenticated — private repos included"
-            >
-              authenticated
-            </span>
-          )}
 
           {activity?.rateLimit && (
             <span
@@ -3188,9 +3180,8 @@ export function GitHubView({
         )}
       </div>
 
-      {/* Keyboard hints moved to the ⌘/ Shortcuts sheet (§8 chrome diet); the
-          low-rate warning lives beside the header rate chip context, and the
-          auth state is already the header's gh-compact-auth chip. */}
+      {/* Keyboard hints moved to the ⌘/ Shortcuts sheet (§8 chrome diet); only
+          the actionable low-rate warning remains in this footer. */}
       {activity?.rateLimit && activity.rateLimit.remaining < 10 && (
         <footer className="github-surface-footer shrink-0 px-5 py-1.5 text-[length:var(--text-2xs)] flex items-center justify-end">
           <span className="inline-flex items-center gap-1 text-[var(--color-warning)]">

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -53,11 +53,6 @@
   line-height:1;
   color:var(--text-muted);
 }
-.gh-compact-auth--authed {
-  border-color:color-mix(in oklab,var(--color-success) 42%,transparent);
-  background:color-mix(in oklab,var(--color-success) 10%,transparent);
-  color:var(--color-success);
-}
 /* Rejected/expired PAT: a clickable chip (opens the PAT modal) in danger tint. */
 .gh-compact-auth--invalid {
   border-color:color-mix(in oklab,var(--color-danger) 42%,transparent);


### PR DESCRIPTION
## Summary
- remove the persistent positive authenticated chip from the GitHub header
- preserve public API, invalid-token, and rate-limit states
- add a source regression pin and remove the retired modifier styles

## Test plan
- [x] `pnpm test:app`
- [x] `node --experimental-strip-types src/components/github-view-polish.test.ts`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `git diff --check`

Bead: `cave-e57q2`
