### PR TITLE
Daily report: let the graphs view size to its content

### DIFF
--- a/src/styles/daily-report-carousel.css
+++ b/src/styles/daily-report-carousel.css
@@ -581,10 +581,17 @@
 
 /* ── view 2 · graphs ─────────────────────────────────────────────────────── */
 
+/* Graphs is the one view whose content genuinely exceeds the shared 236px
+   view height — hour heatmap, three charts and four tiles. Capping it clipped
+   the last project row and put a scrollbar inside a dropdown, so this view
+   sizes to its content and the panel grows with it. Swimlanes and cards fit
+   the shared height and keep it, so switching views doesn't jump. */
 .drd-car-view-graphs {
   display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
+  grid-template-rows: auto auto;
   gap: var(--space-3);
+  max-height: none;
+  overflow: visible;
 }
 
 .drd-car-heat {


### PR DESCRIPTION
The three carousel views shared one fixed **236px** height. Swimlanes and cards fit inside it; **graphs doesn't** — it carries the hour heatmap, three charts and four tiles. The cap clipped the last row of "lines by project" and put a **scrollbar inside a dropdown**, which is the one place a scrollbar has no business being.

Graphs now sizes to its content and the panel grows with it. Swimlanes and cards keep the shared height, so switching views still doesn't jump.

## Before / after

Before: `coven-runtimes` clipped, `.drd-car-view-graphs` scrolling `252 > 236`.
After, measured in the built app:

```
1600x1000: graphs panel 328px | panel scrolls=false | inner scrollers=none
1280x700 : graphs panel 328px | panel scrolls=false | inner scrollers=none
```

All four project rows visible; the panel still sits inside the card's `max-height: min(560px, 68vh)` safety net, so a short viewport degrades to the panel's own scroll rather than clipping.

Six lines of CSS. `design-token-drift` and `daily-report-page` tests pass; no drift movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)