### PR TITLE
chore(claude): allowlist read-only gate commands to cut permission prompts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,7 +39,23 @@
   "permissions": {
     "allow": [
       "WebSearch",
-      "WebFetch"
+      "WebFetch",
+      "Bash(git fetch *)",
+      "Bash(pnpm build)",
+      "Bash(pnpm test:app)",
+      "Bash(pnpm lint)",
+      "Bash(pnpm typecheck)",
+      "Bash(pnpm lint:design)",
+      "Bash(pnpm codemod:design:check)",
+      "Bash(pnpm check:tests-wired)",
+      "Bash(pnpm exec tsc --noEmit *)",
+      "Bash(pnpm exec eslint *)",
+      "Bash(bd show *)",
+      "Bash(bd ready*)",
+      "Bash(bd list *)",
+      "mcp__claude-design__read_file",
+      "mcp__claude-design__list_files",
+      "mcp__claude-design__list_projects"
     ]
   }
 }


### PR DESCRIPTION
## What & why

Scanned **all 2,104 session transcripts** in `~/.claude/projects/` to find where permission prompts actually originate, then allowlisted the read-only commands that account for the avoidable ones.

**Findings — when/why prompts fire.** Three gates, in order:

1. **Permission mode.** Recorded across all history: `bypassPermissions` **7,847** · `auto` **3,337** · `plan` 85 · `default` 32. ~69% of the time nothing can prompt; ~30% (`auto`) prompts only for what isn't classed read-only.
2. **Built-in read-only classifier.** `cat`/`ls`/`grep`/`sed`/`jq`/`sort`/`find` and every read-only `git`/`gh` subcommand are auto-allowed already.
3. **The allowlist** — the only lever we control, and it only applies in `auto`/`default`/`plan`.

Hard denials all-time: **28** (`Read` 16, `WebFetch` 4, `Edit` 3, `AskUserQuestion` 2, Vercel MCP 2, `Agent` 1) — **zero for Bash**. Transcripts record refusals, not approvals, so that's a floor. The fossil record of prompts actually hit is `.claude/settings.local.json`, which has accumulated "always allow" clicks for `git push`, `pnpm install`, `rm -rf .worktrees/…`, and `pkill`.

## Added, ranked by observed frequency

| Pattern | Count | Notes |
|---|---|---|
| `Bash(git fetch *)` | 105 | updates remote-tracking refs only |
| `Bash(pnpm build)` | 60 | required CI gate |
| `Bash(bd show *)` | 48 | bead inspection |
| `Bash(pnpm exec eslint *)` | 37 | lint gate |
| `Bash(pnpm test:app)` | 36 | test gate |
| `Bash(pnpm exec tsc --noEmit *)` | 35 | `--noEmit` pinned in the pattern |
| `Bash(bd ready*)` | 19 | ready-work query |
| `Bash(bd list *)` | 15 | bead list |
| `Bash(pnpm lint)` / `Bash(pnpm typecheck)` | 14 / 14 | gate aliases |
| `Bash(pnpm codemod:design:check)` | 8 | drift check |
| `Bash(pnpm lint:design)` | 5 | design lint |
| `Bash(pnpm check:tests-wired)` | 4 | wiring check |
| `mcp__claude-design__read_file` | 46 | design-handoff reads |
| `mcp__claude-design__list_files` | 9 | " |
| `mcp__claude-design__list_projects` | 4 | " |

## Deliberately excluded

- **Arbitrary code execution** (~865 segments, the largest remaining bucket): `node` (596), `python3` (117), `awk` (118 — `system()` is a shell escape), `npx` (33). Allowlisting any of these is equivalent to blanket exec.
- **`curl`** (74): even an `-o /dev/null` prefix permits arbitrary URLs, i.e. a query-string exfil channel.
- **Mutating**: `git push`/`add`/`commit`/`branch -D`, `rm` (90), `pkill` (49), `gh pr merge`/`create`/`close`, `bd update`/`close`/`create`.
- **Already auto-allowed** (~11,600 segments — no entry needed): `echo` 4,147 · `grep` 2,727 · `cd` 1,901 · `head` 1,708 · `tail` 1,286, plus all read-only `git`/`gh`.
- **Glaze MCP**: traces to other projects, and its top tool (`LiveAppEvaluate`) is arbitrary JS eval.

## Reviewer note — three judgment calls

`pnpm build`, `pnpm test:app` and `pnpm exec eslint *` are **not** strictly side-effect-free: they write gitignored build output, spawn test servers, and prefix matching can't exclude a hypothetical `eslint --fix`. They're included because they're the highest-frequency required gates and every effect is gitignored or git-recoverable. Easy to drop if you'd rather be strict.

`.claude/settings.json` is repo-tracked, so these apply to every contributor — the entries are all project gate commands or read-only queries, which is why they went here rather than `settings.local.json`.