### PR TITLE
Daily report: build a missing day's report instead of dead-ending

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -359,8 +359,8 @@ for (const contract of contracts) {
   );
   assert.match(
     dailySummarySource,
-    /media:\s*draft\.media/,
-    "/inbox/daily-summary should persist the generated media card",
+    /media:\s*\{\s*\n\s*\.\.\.draft\.media,/,
+    "/inbox/daily-summary should persist the generated media card (spread, so a backfill can stamp a truthful generatedAt over it)",
   );
   assert.match(
     dailySummarySource,

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -374,8 +374,13 @@ for (const contract of contracts) {
   );
   assert.match(
     dailySummarySource,
-    /fetchMergedPrsForDay\(now\)\.catch\(/,
-    "/inbox/daily-summary should gather merged PRs server-side, degrading to absent on failure",
+    /fetchMergedPrsForDay\(target\)\.catch\(/,
+    "/inbox/daily-summary should gather merged PRs server-side for the TARGET day (today, or a backfilled past day), degrading to absent on failure",
+  );
+  assert.match(
+    dailySummarySource,
+    /body\.backfill !== true/,
+    "/inbox/daily-summary must keep the midnight-rollover guard on the automatic path — only an explicit backfill may target another day",
   );
   assert.match(
     dailySummarySource,

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -128,6 +128,13 @@ export async function POST(req: Request) {
     });
     if (!draft) return null;
 
+    // When backfilling a past day, `target` is midnight of that day, so draft
+    // timestamps (generatedAt/firedAt/fireAt) would be midnight rather than the
+    // real write time. Override them to wall-clock `now` so the byline and
+    // generatedAt remain truthful. Day-selection keys (auto, link) still use
+    // `target`, which is correct.
+    const writeAt = body.backfill === true ? now.toISOString() : undefined;
+
     // Ensure-or-refresh: today's report is rebuilt in place so it tracks the
     // day instead of freezing at the first app-open after midnight.
     const existing = file.items.find((item) => item.auto === dailySummaryAutoKey(target));
@@ -141,6 +148,7 @@ export async function POST(req: Request) {
         // fact-only refresh must not discard the narrative layered on top.
         media: {
           ...draft.media,
+          ...(writeAt ? { generatedAt: writeAt, report: { ...draft.media?.report, refreshedAt: writeAt } } : {}),
           narrative: narrativeInput ?? existing.media?.narrative ?? null,
         },
         updatedAt: now.toISOString(),
@@ -156,17 +164,20 @@ export async function POST(req: Request) {
       title: draft.title,
       body: draft.body,
       status: "fired",
-      createdAt: draft.firedAt,
-      updatedAt: draft.firedAt,
-      fireAt: draft.fireAt,
-      firedAt: draft.firedAt,
+      createdAt: writeAt ?? draft.firedAt,
+      updatedAt: writeAt ?? draft.firedAt,
+      fireAt: writeAt ?? draft.fireAt,
+      firedAt: writeAt ?? draft.firedAt,
       snoozeUntil: null,
       recurrence: draft.recurrence,
       source: "system",
       familiarId: null,
       sessionId: null,
       link: draft.link,
-      media: draft.media,
+      media: {
+        ...draft.media,
+        ...(writeAt ? { generatedAt: writeAt, report: { ...draft.media?.report, refreshedAt: writeAt } } : {}),
+      },
       auto: draft.auto,
     };
     file.items.push(next);

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -128,12 +128,15 @@ export async function POST(req: Request) {
     });
     if (!draft) return null;
 
-    // When backfilling a past day, `target` is midnight of that day, so draft
-    // timestamps (generatedAt/firedAt/fireAt) would be midnight rather than the
-    // real write time. Override them to wall-clock `now` so the byline and
-    // generatedAt remain truthful. Day-selection keys (auto, link) still use
-    // `target`, which is correct.
-    const writeAt = body.backfill === true ? now.toISOString() : undefined;
+    // Backfill splits two different clocks, and they must not be conflated:
+    //   • WHEN IT WAS WRITTEN — media.generatedAt / report.refreshedAt. These
+    //     must be wall-clock `now`, or the report's byline claims a familiar
+    //     wrote it days ago when it was written seconds ago.
+    //   • WHICH DAY IT COVERS — createdAt / fireAt / firedAt stay anchored to
+    //     `target`. The inbox sorts and labels by these, so day-anchoring is
+    //     what makes seven backfilled days list as seven days instead of
+    //     collapsing to "just now" and burying today's report.
+    const writtenAt = body.backfill === true ? now.toISOString() : undefined;
 
     // Ensure-or-refresh: today's report is rebuilt in place so it tracks the
     // day instead of freezing at the first app-open after midnight.
@@ -148,7 +151,16 @@ export async function POST(req: Request) {
         // fact-only refresh must not discard the narrative layered on top.
         media: {
           ...draft.media,
-          ...(writeAt ? { generatedAt: writeAt, report: { ...draft.media?.report, refreshedAt: writeAt } } : {}),
+          ...(writtenAt
+            ? {
+                generatedAt: writtenAt,
+                // `report` is optional on the draft; spreading it when absent
+                // would leave factsHash undefined and break its type.
+                ...(draft.media?.report
+                  ? { report: { ...draft.media.report, refreshedAt: writtenAt } }
+                  : {}),
+              }
+            : {}),
           narrative: narrativeInput ?? existing.media?.narrative ?? null,
         },
         updatedAt: now.toISOString(),
@@ -164,10 +176,10 @@ export async function POST(req: Request) {
       title: draft.title,
       body: draft.body,
       status: "fired",
-      createdAt: writeAt ?? draft.firedAt,
-      updatedAt: writeAt ?? draft.firedAt,
-      fireAt: writeAt ?? draft.fireAt,
-      firedAt: writeAt ?? draft.firedAt,
+      createdAt: draft.firedAt,
+      updatedAt: draft.firedAt,
+      fireAt: draft.fireAt,
+      firedAt: draft.firedAt,
       snoozeUntil: null,
       recurrence: draft.recurrence,
       source: "system",
@@ -176,7 +188,16 @@ export async function POST(req: Request) {
       link: draft.link,
       media: {
         ...draft.media,
-        ...(writeAt ? { generatedAt: writeAt, report: { ...draft.media?.report, refreshedAt: writeAt } } : {}),
+        ...(writtenAt
+            ? {
+                generatedAt: writtenAt,
+                // `report` is optional on the draft; spreading it when absent
+                // would leave factsHash undefined and break its type.
+                ...(draft.media?.report
+                  ? { report: { ...draft.media.report, refreshedAt: writtenAt } }
+                  : {}),
+              }
+            : {}),
       },
       auto: draft.auto,
     };

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -10,6 +10,7 @@ import {
   dateSlug,
   type DailySummaryExtras,
 } from "@/lib/daily-summary-notifications";
+import { parseDateSlug } from "@/lib/daily-report";
 import { completedCardsForDay, unionMergedPrs } from "@/lib/daily-report-facts";
 import { fetchMergedPrsForDay } from "@/lib/server/github-merged";
 import { loadBoard } from "@/lib/cave-board";
@@ -60,6 +61,9 @@ export async function POST(req: Request) {
   let body: {
     sessions?: SessionRow[];
     date?: string;
+    /** Explicit request to build a PAST day's report. The automatic path never
+     *  sets this, so the midnight-rollover guard below still protects it. */
+    backfill?: boolean;
     narrative?: { text?: string; familiarId?: string; familiarName?: string; factsHash?: string };
   } = {};
   try {
@@ -69,10 +73,28 @@ export async function POST(req: Request) {
   }
 
   const now = new Date();
-  // Midnight-rollover race: a client that computed its payload just before the
-  // day flipped must not create or overwrite the new day's report.
-  if (typeof body.date === "string" && body.date !== dateSlug(now)) {
-    return NextResponse.json({ ok: true, created: false, updated: false, dateMismatch: true });
+  const todaySlug = dateSlug(now);
+  const requestedSlug = typeof body.date === "string" ? body.date : null;
+
+  // `target` is the day the report is ABOUT; `now` stays wall-clock for the
+  // write's own timestamps. They differ only on an explicit backfill.
+  let target = now;
+  if (requestedSlug && requestedSlug !== todaySlug) {
+    // Midnight-rollover race: a client that computed its payload just before
+    // the day flipped must not create or overwrite the new day's report. The
+    // automatic refresh never sets `backfill`, so it still lands here.
+    if (body.backfill !== true) {
+      return NextResponse.json({ ok: true, created: false, updated: false, dateMismatch: true });
+    }
+    const parsed = parseDateSlug(requestedSlug);
+    // A day that has not happened has nothing to report.
+    if (!parsed || requestedSlug > todaySlug) {
+      return NextResponse.json(
+        { ok: false, error: "backfill requires a past date" },
+        { status: 400 },
+      );
+    }
+    target = parsed;
   }
 
   const sessions = Array.isArray(body.sessions) ? body.sessions : [];
@@ -86,12 +108,12 @@ export async function POST(req: Request) {
   // lock (GitHub can take seconds; the lock serializes every inbox write).
   // Each source degrades to "absent" — never an error, never a blocked write.
   const [githubPrs, board] = await Promise.all([
-    fetchMergedPrsForDay(now).catch(() => null),
+    fetchMergedPrsForDay(target).catch(() => null),
     loadBoard().catch(() => null),
   ]);
   const extras: DailySummaryExtras = {
-    prsMerged: unionMergedPrs(githubPrs, sessions, now),
-    cardsCompleted: board ? completedCardsForDay(board.cards, now) : undefined,
+    prsMerged: unionMergedPrs(githubPrs, sessions, target),
+    cardsCompleted: board ? completedCardsForDay(board.cards, target) : undefined,
   };
 
   const result = await withInboxLock(async ({ load, save }) => {
@@ -100,13 +122,13 @@ export async function POST(req: Request) {
       items: file.items,
       sessions,
       extras,
-      now,
+      now: target,
     });
     if (!draft) return null;
 
     // Ensure-or-refresh: today's report is rebuilt in place so it tracks the
     // day instead of freezing at the first app-open after midnight.
-    const existing = file.items.find((item) => item.auto === dailySummaryAutoKey(now));
+    const existing = file.items.find((item) => item.auto === dailySummaryAutoKey(target));
     if (existing) {
       const refreshed: InboxItem = {
         ...existing,

--- a/src/app/api/inbox/daily-summary/route.ts
+++ b/src/app/api/inbox/daily-summary/route.ts
@@ -26,6 +26,15 @@ const NARRATIVE_MAX_STORED_CHARS = 4_000;
 
 type NarrativePatch = NonNullable<NonNullable<InboxItem["media"]>["narrative"]>;
 
+type DailySummaryRequest = {
+  sessions?: SessionRow[];
+  date?: string;
+  /** Explicit request to build a PAST day's report. The automatic refresh
+   *  never sets this, so the midnight-rollover guard still protects it. */
+  backfill?: boolean;
+  narrative?: { text?: string; familiarId?: string; familiarName?: string; factsHash?: string };
+};
+
 /** Validate a client-submitted narrative: required fields present, control
  *  characters stripped, length bounded. Returns null (ignored) when invalid. */
 function sanitizeNarrative(
@@ -58,14 +67,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ ok: false, error: "forbidden" }, { status: 403 });
   }
 
-  let body: {
-    sessions?: SessionRow[];
-    date?: string;
-    /** Explicit request to build a PAST day's report. The automatic path never
-     *  sets this, so the midnight-rollover guard below still protects it. */
-    backfill?: boolean;
-    narrative?: { text?: string; familiarId?: string; familiarName?: string; factsHash?: string };
-  } = {};
+  let body: DailySummaryRequest = {};
   try {
     body = await req.json();
   } catch {

--- a/src/app/daily-report-page.test.ts
+++ b/src/app/daily-report-page.test.ts
@@ -19,7 +19,7 @@ const modals = read("../components/daily-report-modals.tsx");
 
 assert.match(page, /loadInbox/, "daily report page should load persisted inbox data");
 assert.match(page, /daily-summary:\$\{date\}/, "daily report page should resolve the daily summary by auto key");
-assert.match(page, /Daily report not found/, "daily report page should have an empty/not-found state");
+assert.match(page, /DailyReportEmpty/, "daily report page should render the no-report state");
 assert.match(page, /breakdownForDay/, "report should compute the live per-day breakdown");
 assert.match(page, /item\.media\?\.report/, "report should read the structured day-in-review facts");
 assert.match(page, /media\?\.narrative\?\.text/, "report should lead with the familiar-written narrative when present");
@@ -162,6 +162,28 @@ assert.match(
     /pr\?: \{ repo: string; number: number \}/,
     "the model carries PR identity so surfaces can open the card",
   );
+}
+
+// ── the no-report day is recoverable, not a dead end ───────────────────────
+// Past days still have their facts on disk (sessions, merged PRs, board
+// cards, rituals), so the empty state offers to build the report rather than
+// telling the reader it happens automatically — which is only true of today.
+
+{
+  const empty = read("../components/daily-report-empty.tsx");
+  assert.match(empty, /backfill: !isToday/, "a past day is generated as an explicit backfill");
+  assert.match(empty, /\/api\/sessions\/list/, "backfill reuses the enriched session list, not a second query");
+  assert.match(empty, /isFuture/, "a day that hasn't happened is never offered a generate button");
+  assert.match(empty, /kind: "empty"/, "an honestly empty day says so instead of reporting failure");
+
+  const route = read("../app/api/inbox/daily-summary/route.ts");
+  // The midnight-rollover guard must survive: only an EXPLICIT backfill may
+  // target another day, and never a future one.
+  assert.match(route, /body\.backfill !== true/, "the automatic path keeps the midnight-rollover guard");
+  assert.match(route, /requestedSlug > todaySlug/, "a future date is refused");
+  assert.match(route, /now: target/, "the report is built for the requested day, not today");
+  assert.match(route, /dailySummaryAutoKey\(target\)/, "the item is keyed to the requested day");
+  assert.match(route, /fetchMergedPrsForDay\(target\)/, "merged PRs are fetched for the requested day");
 }
 
 // ── theme safety ───────────────────────────────────────────────────────────

--- a/src/app/daily-report/[date]/page.tsx
+++ b/src/app/daily-report/[date]/page.tsx
@@ -2,6 +2,7 @@ import { loadInbox } from "@/lib/cave-inbox";
 import { Icon } from "@/lib/icon";
 import { AnalyticsPageShell } from "@/components/analytics-page-shell";
 import { DailyReportDay, type WeekCell } from "@/components/daily-report-day";
+import { DailyReportEmpty } from "@/components/daily-report-empty";
 import {
   breakdownForDay,
   dateSlug,
@@ -48,6 +49,7 @@ export default async function DailyReportPage({ params }: Props) {
   const parsedDate = parseDateSlug(date);
 
   if (!item) {
+    const todaySlug = dateSlug(new Date());
     return (
       <AnalyticsPageShell>
         {/* div, not main: the shell's aps-main is the page's main landmark. */}
@@ -59,28 +61,12 @@ export default async function DailyReportPage({ params }: Props) {
             </a>
           </div>
           <div className="dr-shell">
-            <section className="dr-hero" style={{ marginTop: 64 }}>
-              <p className="dr-eyebrow">
-                <span className="dr-eyebrow__dot" aria-hidden />
-                Daily report
-              </p>
-              <h1 className="dr-title">Daily report not found</h1>
-              <p className="dr-subtitle">
-                No generated daily summary exists for{" "}
-                {parsedDate ? longDateLabel(parsedDate) : date}. Reports are created automatically
-                once there is activity to summarize.
-              </p>
-              <div className="dr-actions">
-                <a className="dr-btn dr-btn--primary" href="/dashboard">
-                  <Icon name="ph:squares-four" aria-hidden />
-                  Go to dashboard
-                </a>
-                <a className="dr-btn" href="/">
-                  <Icon name="ph:house-bold" aria-hidden />
-                  Back to CovenCave
-                </a>
-              </div>
-            </section>
+            <DailyReportEmpty
+              date={date}
+              dateLabel={parsedDate ? longDateLabel(parsedDate) : date}
+              isFuture={date > todaySlug}
+              isToday={date === todaySlug}
+            />
           </div>
         </div>
       </AnalyticsPageShell>
@@ -182,7 +168,6 @@ export default async function DailyReportPage({ params }: Props) {
             narrative={narrative}
             narrativeByline={narrativeByline}
             shareImageUrl={item.media?.imageUrl ?? null}
-            summaryBody={item.body ?? null}
           />
         </div>
       </div>

--- a/src/components/daily-report-day.tsx
+++ b/src/components/daily-report-day.tsx
@@ -54,8 +54,6 @@ type Props = {
   narrative: string | null;
   narrativeByline: string | null;
   shareImageUrl: string | null;
-  /** The frozen summary body — the pre-narrative fallback. */
-  summaryBody: string | null;
 };
 
 const TONE_VAR: Record<DayTone, string> = {
@@ -95,7 +93,6 @@ export function DailyReportDay({
   narrative,
   narrativeByline,
   shareImageUrl,
-  summaryBody,
 }: Props): JSX.Element {
   const router = useRouter();
 
@@ -165,21 +162,25 @@ export function DailyReportDay({
 
   // The whole-day view leads with the familiar's narrative; a chapter view
   // rewrites the page with that chapter's own derived prose.
+  // Only the familiar's narrative is prose. The frozen body is the generated
+  // stats list ("1 reminder fired / 43 PRs merged / …") — the band and the
+  // carousel already say all of it, and setting it in serif reads as if the
+  // cave wrote a shopping list.
   const paragraphs = useMemo(
     () =>
-      (narrative ?? summaryBody ?? "")
+      (narrative ?? "")
         .split(/\n{2,}/)
         .map((p) => p.trim())
         .filter(Boolean),
-    [narrative, summaryBody],
+    [narrative],
   );
 
   const activeChapterIndex = active ? active.index : null;
 
   const readingMinutes = useMemo(() => {
-    const words = (narrative ?? summaryBody ?? "").split(/\s+/).filter(Boolean).length;
+    const words = (narrative ?? "").split(/\s+/).filter(Boolean).length;
     return Math.max(1, Math.round(words / 200));
-  }, [narrative, summaryBody]);
+  }, [narrative]);
 
   return (
     <div className="drd">

--- a/src/components/daily-report-empty.tsx
+++ b/src/components/daily-report-empty.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+// What the daily report shows when no report exists for a date.
+//
+// The old state was a dead end: "Daily report not found … reports are created
+// automatically once there is activity to summarize." That is true of TODAY
+// and false of every past day — the facts for those days are still on disk
+// (sessions in the daemon's store, merged PRs on GitHub, cards on the board),
+// so the report can simply be built now. This offers exactly that, and says
+// plainly when a day really was empty.
+
+import { useCallback, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { Icon } from "@/lib/icon";
+import "@/styles/daily-report-empty.css";
+
+type Phase =
+  | { kind: "idle" }
+  | { kind: "working" }
+  | { kind: "empty" }
+  | { kind: "error"; message: string };
+
+export function DailyReportEmpty({
+  date,
+  dateLabel,
+  isFuture,
+  isToday,
+}: {
+  /** YYYY-MM-DD */
+  date: string;
+  dateLabel: string;
+  isFuture: boolean;
+  isToday: boolean;
+}) {
+  const router = useRouter();
+  const [phase, setPhase] = useState<Phase>({ kind: "idle" });
+
+  const generate = useCallback(async () => {
+    setPhase({ kind: "working" });
+    try {
+      // Sessions come from the same enriched list the automatic refresh uses,
+      // rather than a second, subtly different server-side query.
+      let sessions: unknown[] = [];
+      try {
+        const res = await fetch("/api/sessions/list", { cache: "no-store" });
+        const data = await res.json();
+        if (Array.isArray(data?.sessions)) sessions = data.sessions;
+        else if (Array.isArray(data)) sessions = data;
+      } catch {
+        // No daemon: PRs and cards can still carry the day.
+      }
+
+      const res = await fetch("/api/inbox/daily-summary", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ date, backfill: !isToday, sessions }),
+      });
+      const data = await res.json().catch(() => null);
+
+      if (!res.ok || data?.ok === false) {
+        setPhase({ kind: "error", message: String(data?.error ?? `http ${res.status}`) });
+        return;
+      }
+      // `created: false` with no existing item means the builder found nothing
+      // worth reporting — an honestly empty day, not a failure.
+      if (data?.created || data?.updated) {
+        router.refresh();
+        return;
+      }
+      setPhase({ kind: "empty" });
+    } catch (err) {
+      setPhase({ kind: "error", message: err instanceof Error ? err.message : "generation failed" });
+    }
+  }, [date, isToday, router]);
+
+  return (
+    <section className="dre" aria-live="polite">
+      <p className="dre__kicker">
+        <span className="dre__dot" aria-hidden />
+        Daily report
+      </p>
+      <h1 className="dre__title">{dateLabel}</h1>
+
+      {isFuture ? (
+        <p className="dre__lede">
+          This day hasn&apos;t happened yet. The cave writes a report once there is a day to
+          report on.
+        </p>
+      ) : phase.kind === "empty" ? (
+        <p className="dre__lede">
+          Nothing to report for this day — no sessions, no merges, no cards, no rituals. The
+          cave was quiet.
+        </p>
+      ) : (
+        <p className="dre__lede">
+          No report was written for this day{isToday ? " yet" : ""}. The facts are still on
+          disk, so one can be built now from the sessions, merged pull requests, board cards
+          and rituals that belong to it.
+        </p>
+      )}
+
+      {phase.kind === "error" && (
+        <p className="dre__error">
+          <Icon name="ph:warning" aria-hidden />
+          Couldn&apos;t build it: {phase.message}
+        </p>
+      )}
+
+      <div className="dre__actions">
+        {!isFuture && phase.kind !== "empty" && (
+          <button
+            type="button"
+            className="dre__btn dre__btn--accent"
+            onClick={generate}
+            disabled={phase.kind === "working"}
+          >
+            {phase.kind === "working" ? (
+              <>
+                <Icon name="ph:circle-notch-bold" aria-hidden />
+                Building the day…
+              </>
+            ) : (
+              <>
+                <Icon name="ph:sparkle" aria-hidden />
+                {isToday ? "Write today's report" : "Build this day's report"}
+              </>
+            )}
+          </button>
+        )}
+        <a className="dre__btn" href="/dashboard">
+          <Icon name="ph:squares-four" aria-hidden />
+          Dashboard
+        </a>
+        <a className="dre__btn" href="/">
+          <Icon name="ph:house-bold" aria-hidden />
+          Back to CovenCave
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/daily-report-pr-modal.tsx
+++ b/src/components/daily-report-pr-modal.tsx
@@ -50,6 +50,7 @@ export function DailyReportPrModal({
         role="dialog"
         aria-modal="true"
         aria-label={`Pull request ${label}`}
+        tabIndex={-1}
         onClick={(e) => e.stopPropagation()}
       >
         <header className="drd-pr-head">

--- a/src/styles/daily-report-empty.css
+++ b/src/styles/daily-report-empty.css
@@ -1,0 +1,117 @@
+/* The daily report's no-report state. Sits inside .dr-page, so it inherits
+   the surface's ground; colors come from foundations.css. */
+
+.dre {
+  max-width: 62ch;
+  margin: 0 auto;
+  padding: var(--space-10) 0;
+}
+
+.dre :focus-visible {
+  outline: 2px solid var(--accent-presence);
+  outline-offset: 2px;
+}
+
+.dre__kicker {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-3);
+  font: 400 var(--text-2xs) var(--font-mono);
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--accent-presence);
+}
+
+.dre__dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-presence);
+}
+
+.dre__title {
+  margin: 0 0 var(--space-3);
+  font: 400 2.125rem var(--font-serif);
+  line-height: 1.1;
+  letter-spacing: var(--tracking-tight);
+  color: var(--fg-base);
+}
+
+.dre__lede {
+  margin: 0 0 var(--space-5);
+  font-size: var(--text-md);
+  line-height: var(--leading-relaxed);
+  color: var(--fg-muted);
+}
+
+.dre__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: 0 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-card);
+  border: 1px solid color-mix(in oklch, var(--color-danger) 38%, transparent);
+  background: color-mix(in oklch, var(--color-danger) 10%, transparent);
+  font-size: var(--text-sm);
+  color: var(--fg-base);
+}
+
+.dre__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.dre__btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-control);
+  border: 1px solid var(--border);
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--text-sm);
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+
+.dre__btn:hover {
+  border-color: var(--accent-presence);
+  color: var(--accent-presence);
+}
+
+/* Primary action: an accent outline, never a flood. */
+.dre__btn--accent {
+  border-color: var(--accent-presence);
+  color: var(--accent-presence);
+  font-weight: 600;
+}
+
+.dre__btn--accent:hover {
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+}
+
+.dre__btn:disabled {
+  opacity: var(--opacity-disabled);
+  cursor: default;
+}
+
+.dre__btn:disabled svg {
+  animation: dre-spin 0.7s linear infinite;
+}
+
+@keyframes dre-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dre__btn:disabled svg {
+    animation: none;
+  }
+}

--- a/src/styles/daily-report-empty.css
+++ b/src/styles/daily-report-empty.css
@@ -52,10 +52,10 @@
   margin: 0 0 var(--space-4);
   padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-card);
-  border: 1px solid color-mix(in oklch, var(--color-danger) 38%, transparent);
-  background: color-mix(in oklch, var(--color-danger) 10%, transparent);
+  border: 1px solid var(--danger-border);
+  background: var(--danger-bg);
   font-size: var(--text-sm);
-  color: var(--fg-base);
+  color: var(--danger-text);
 }
 
 .dre__actions {

--- a/src/styles/daily-report-pr-modal.css
+++ b/src/styles/daily-report-pr-modal.css
@@ -3,9 +3,9 @@
    come from foundations.css — the report ships beside 21 themes × 2 modes. */
 
 .drd-pr-scrim {
-  position: absolute;
+  position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: 80;
   display: flex;
   align-items: center;
   justify-content: center;


### PR DESCRIPTION
Stacked on #3993.

The no-report state told the reader *"reports are created automatically once there is activity to summarize."* That's true of **today** and false of **every past day** — those days' facts are still on disk (sessions in the daemon's store, merged PRs on GitHub, cards on the board, rituals in the inbox), so the report can just be built now. This offers exactly that.

## Three honest states

| | |
| --- | --- |
| **Future day** | "This day hasn't happened yet." No generate button — there is nothing to build. |
| **Past/today with facts** | *"Build this day's report"* — and it does. |
| **Genuinely empty day** | "Nothing to report for this day — the cave was quiet." Not an error. |

## The guard stays

I did **not** delete the midnight-rollover guard. It exists because a client that computed its payload just before the day flipped must not overwrite the new day's report. Instead:

- only an explicit `backfill: true` may target another day;
- a **future** date is refused outright (`400`);
- the automatic refresh never sets the flag, so it still lands on the original guard.

Everything downstream was already date-parameterized — `buildDailySummaryContent`, `fetchMergedPrsForDay`, `completedCardsForDay` and `dailySummaryAutoKey` all take the target day. This is a routing change, not new machinery.

Backfill reuses `/api/sessions/list` — the same enriched list the automatic refresh posts — rather than a second, subtly different server-side query.

## Verified end to end

Against a fixture with a past day that had activity but no report:

```
future:  {"lede":"This day hasn't happened yet...","btn":false}   PASS (no generate offered)
past offers generate:                                             PASS
after generate: {"built":true,"headline":"43 merges."}            PASS
```

It built that day from **real GitHub data** — 43 merges across 8 repos — with chapters, spine, and repo chips (`coven-cave 19`, `coven 8`, `coven-code 4`, …). Sessions read 0 because no daemon was reachable in the harness, which is the intended honest degradation rather than a fabricated number.

## Drive-by

Stopped setting the frozen stats body (`"1 reminder fired / 43 PRs merged / …"`) in serif as though it were the familiar's prose — it's a machine-written list, and the band and carousel already say all of it. Only a real narrative renders in the written page now; otherwise it reads *"No written summary for this day yet — the numbers above are the whole record."*

`pnpm test:app` — 954 files pass. `tsc --noEmit` and `pnpm build` clean. No drift movement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)