### PR TITLE
fix(projects): restore access control semantics

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -150,6 +150,29 @@ test("secondary controls stay quiet until hover or keyboard focus", () => {
   assert.ok(hoverNoneBlocks.length >= 2, "touch devices keep both controls always visible");
 });
 
+test("access controls retain semantic headings and visible keyboard focus", () => {
+  assert.doesNotMatch(
+    view,
+    /<h2 className="projects-access-section-title">/,
+    "the section-toggle button contains phrasing content, not a nested heading",
+  );
+  assert.match(
+    view,
+    /<span className="projects-access-section-title">/,
+    "the section label keeps its presentation class after leaving the heading element",
+  );
+  assert.match(
+    view,
+    /className=\{`projects-access-pill is-\$\{row\.state\}\$\{pending \? " is-pending" : ""\} focus-ring`\}/,
+    "row access pills use the shared visible focus ring",
+  );
+  assert.match(
+    view,
+    /className=\{`projects-access-chip\$\{flashId === row\.id \? " is-flash" : ""\} focus-ring`\}/,
+    "tree access pills use the shared visible focus ring",
+  );
+});
+
 test("pills and states are token-driven for both themes", () => {
   assert.match(css, /\.projects-access-pill\.is-write \{[^}]*background: var\(--accent-presence\)/, "Full pill fills with the accent");
   assert.match(css, /\.projects-access-pill\.is-write \{[^}]*color: var\(--accent-presence-foreground\)/, "Full pill text uses the paired foreground token");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -588,7 +588,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
     return (
       <button
         type="button"
-        className={`projects-access-pill is-${row.state}${pending ? " is-pending" : ""}`}
+        className={`projects-access-pill is-${row.state}${pending ? " is-pending" : ""} focus-ring`}
         disabled={pending || supreme}
         onClick={() => void cycleRow(row)}
         title={
@@ -851,7 +851,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
                     <button
                       type="button"
                       id={`project-access-row:${row.id}`}
-                      className={`projects-access-chip${flashId === row.id ? " is-flash" : ""}`}
+                      className={`projects-access-chip${flashId === row.id ? " is-flash" : ""} focus-ring`}
                       disabled={pendingIds.has(row.id) || supreme}
                       onClick={() => void cycleRow(row)}
                       title={`${row.name} — ${accessStateMeta(row.state).label}. Click to ${accessStateMeta(row.state).action}.`}
@@ -900,7 +900,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
                     width={10}
                     aria-hidden
                   />
-                  <h2 className="projects-access-section-title">{section.label}</h2>
+                  <span className="projects-access-section-title">{section.label}</span>
                   <span className="projects-access-section-count">{rows.length}</span>
                   {/* Folding a section must never hide that something in it is granted. */}
                   {isCollapsed ? (


### PR DESCRIPTION
## Summary

- replace the section-toggle nested heading with phrasing content
- restore shared visible keyboard focus on both project access controls
- pin both accessibility contracts

## Root cause

PR #3994 merged while two Copilot accessibility threads were still unresolved.

## Verification

- `node --experimental-strip-types src/components/projects-view.test.ts` (20/20)
- `pnpm lint`
- `pnpm typecheck`
- `git diff --check`

Tracks `cave-0dlt9`.