### PR TITLE
fix(shell): keep standalone navigation visible

### DIFF
--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -33,16 +33,26 @@ assert.match(
 assert.doesNotMatch(routePage, /AnalyticsPageShell/, "the stub renders nothing of its own");
 
 // ── The shell renders a real left nav rail into the app's SPA surfaces ──────────
-assert.match(shell, /<nav className="aps-rail" aria-label="Primary">/, "shell renders a labelled left nav rail");
+assert.match(
+  shell,
+  /className=\{`aps-rail\$\{isExpanded \? " aps-rail--expanded" : ""\}`\}/,
+  "shell renders a labelled rail with an explicit expanded state",
+);
 assert.match(shell, /href: "\/\?mode=home"/, "rail deep-links Home into the SPA");
 assert.match(shell, /href: "\/\?mode=chat"/, "rail deep-links Chat");
 assert.match(shell, /href: "\/\?mode=board"/, "rail deep-links Tasks");
 assert.match(shell, /href="\/dashboard"/, "rail links to the Dashboard route");
+assert.match(shell, /<span className="aps-rail-label">Dashboard<\/span>/, "expanded rail links have visible labels");
 
 // â”€â”€ Destination routes share the desktop Shell chrome â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€
 assert.match(shell, /import \{ DesktopHistoryNav \} from "@\/components\/desktop-history-nav"/, "standalone shell reuses the shared history controls");
 assert.match(shell, /const isMobile = useIsMobile\(\)/, "standalone desktop chrome follows the shared mobile breakpoint");
-assert.match(shell, /const railOpen = navOpen \|\| isMobile/, "mobile retains its existing primary rail when desktop navigation is collapsed");
+assert.match(shell, /const NAV_OPEN_PREF_KEY = "cave:shell:nav-open"/, "standalone routes share the workspace navigation preference");
+assert.match(shell, /const \[navOpen, setNavOpen\] = useState\(false\)/, "SSR starts from the compact navigation rail");
+assert.match(shell, /useLayoutEffect\(\(\) => \{[\s\S]*?const pref = readNavOpenPref\(\)/, "desktop restores its preference before paint");
+assert.match(shell, /const pref = readNavOpenPref\(\)/, "standalone routes restore the shared navigation preference after hydration");
+assert.match(shell, /writeNavOpenPref\(next\)/, "standalone route toggles persist the shared navigation preference");
+assert.match(shell, /const isExpanded = !isMobile && navOpen/, "mobile always keeps the compact icon rail");
 assert.match(shell, /className="aps-top shell-top"/, "standalone shell mounts the shared desktop title bar");
 assert.match(shell, /aria-label=\{navOpen \? "Collapse navigation" : "Expand navigation"\}/, "standalone title bar exposes the navigation toggle state");
 assert.match(shell, /<DesktopHistoryNav \/>/, "standalone title bar includes the Back\/Forward pair");
@@ -56,7 +66,13 @@ assert.equal((workspaceShell.match(/<DesktopHistoryNav/g) ?? []).length, 1, "wor
 
 // ── Persistent at EVERY screen size — the rail must not be hidden on small widths ─
 assert.match(css, /\.aps-rail\s*\{/, "the rail has base styles");
-assert.doesNotMatch(css, /\.aps-rail[^{]*\{[^}]*display:\s*none/, "the rail is never display:none");
+assert.match(css, /\.aps-rail\s*\{[\s\S]*?overflow-x:\s*hidden/, "width transitions clip only the horizontal axis");
+assert.doesNotMatch(css, /\.aps-rail\s*\{[^}]*overflow:\s*hidden/, "the rail never clips short viewport navigation vertically");
+assert.match(css, /\.aps-rail-list\s*\{[\s\S]*?min-height:\s*0;[\s\S]*?overflow-y:\s*auto/, "short viewports scroll the destination list while keeping rail chrome fixed");
+assert.match(css, /\.aps-rail-label\s*\{[\s\S]*?display:\s*none/, "labels stay hidden in the compact rail");
+assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.aps-rail--expanded\s*\{[\s\S]*?width:\s*var\(--shell-nav-width\)/, "only desktop can expand the rail");
+assert.match(css, /@media \(min-width: 1024px\) \{[\s\S]*?\.aps-rail--expanded \.aps-rail-label\s*\{[\s\S]*?display:\s*block/, "expanded desktop rail reveals labels");
+assert.doesNotMatch(css, /\.aps-rail\s*\{[^}]*display:\s*none/, "the rail is never display:none");
 assert.doesNotMatch(css, /@media[^{]*\{[^}]*\.aps-rail[^}]*display:\s*none/, "no media query hides the rail on small screens");
 assert.match(css, /@media \(max-width: 1023px\) \{[\s\S]*?\.aps-top\s*\{[\s\S]*?display:\s*none/, "mobile hides only the desktop title bar");
 assert.match(css, /\.aps-main > \.dr-page\s*\{[\s\S]*?min-height:\s*100%;[\s\S]*?height:\s*100%;/, "reporting pages stay within the pane below desktop chrome instead of adding a second page scrollbar");

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -1,11 +1,34 @@
 "use client";
 
-import { useState, type ReactNode } from "react";
+import { useLayoutEffect, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { DesktopHistoryNav } from "@/components/desktop-history-nav";
 import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
 import "@/styles/analytics-page-shell.css";
+
+// Shared with shell.tsx so the nav open/closed preference is consistent across
+// all routes — standalone pages and the SPA workspace stay in sync.
+const NAV_OPEN_PREF_KEY = "cave:shell:nav-open";
+
+function readNavOpenPref(): boolean | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(NAV_OPEN_PREF_KEY);
+    return raw === "1" ? true : raw === "0" ? false : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeNavOpenPref(open: boolean): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(NAV_OPEN_PREF_KEY, open ? "1" : "0");
+  } catch {
+    /* ignore — strict privacy mode or storage quota */
+  }
+}
 
 type RailDest = { href: string; label: string; icon: IconName };
 
@@ -31,10 +54,11 @@ const NAV_ICON = CAVE_ICON_SIZE.sidePanelNav;
  * /proposals, /settings, /profile, /daily-report, familiar analytics) render
  * OUTSIDE the SPA workspace (which owns SidebarMinimal), so on their own they
  * have no nav. This shell gives every one of them the app's left rail at EVERY
- * screen size: a compact, always-visible icon column of the primary
- * destinations (deep-linking back into the SPA) plus Dashboard — so you can
- * navigate away without a browser Back. route-inventory.test.ts enforces that
- * every destination page mounts it.
+ * screen size, matching the main shell's sidebar behavior:
+ * - Expanded (navOpen): 240px with icons + labels, synced via NAV_OPEN_PREF_KEY.
+ * - Collapsed (!navOpen on desktop): 56px icon-only rail — never fully hidden.
+ * - Mobile: always shows the 56px icon rail.
+ * route-inventory.test.ts enforces that every destination page mounts it.
  */
 export function AnalyticsPageShell({ children }: { children: ReactNode }) {
   // Only the Dashboard foot link can be "current" — the PRIMARY rows deep-link
@@ -42,10 +66,25 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const onDashboard = pathname === "/dashboard";
   const isMobile = useIsMobile();
-  const [navOpen, setNavOpen] = useState(true);
-  // Mobile keeps its persistent rail even if this shell was collapsed before a
-  // viewport resize. Its existing navigation remains the mobile fallback.
-  const railOpen = navOpen || isMobile;
+
+  // Match the main shell's compact SSR default, then restore the shared desktop
+  // preference before paint. CSS keeps mobile compact during viewport hydration.
+  const [navOpen, setNavOpen] = useState(false);
+  useLayoutEffect(() => {
+    const pref = readNavOpenPref();
+    if (pref !== null) setNavOpen(pref);
+  }, []);
+
+  const handleToggleNav = () => {
+    const next = !navOpen;
+    setNavOpen(next);
+    writeNavOpenPref(next);
+  };
+
+  // On mobile the sidebar is always the 56px icon rail; on desktop it
+  // expands/collapses based on preference. The rail is never fully hidden —
+  // collapsing only switches from 240px+labels to 56px icons.
+  const isExpanded = !isMobile && navOpen;
 
   const desktopChrome = !isMobile ? (
     <header className="aps-top shell-top" data-tauri-drag-region="deep">
@@ -56,7 +95,7 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
         aria-label={navOpen ? "Collapse navigation" : "Expand navigation"}
         aria-expanded={navOpen}
         title={navOpen ? "Collapse navigation" : "Expand navigation"}
-        onClick={() => setNavOpen((open) => !open)}
+        onClick={handleToggleNav}
       >
         <Icon
           name={navOpen ? "ph:sidebar-simple-fill" : "ph:sidebar-simple"}
@@ -72,31 +111,37 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
     <div className="aps">
       {desktopChrome}
       <div className="aps-body">
-        {railOpen ? (
-          <nav className="aps-rail" aria-label="Primary">
-            <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
-              <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-            </a>
-            <ul className="aps-rail-list">
-              {PRIMARY.map((d) => (
-                <li key={d.href}>
-                  <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
-                    <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
-                  </a>
-                </li>
-              ))}
-            </ul>
-            <a
-              className="aps-rail-link aps-rail-foot"
-              href="/dashboard"
-              aria-label="Dashboard"
-              title="Dashboard"
-              aria-current={onDashboard ? "page" : undefined}
-            >
-              <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
-            </a>
-          </nav>
-        ) : null}
+        {/* The rail is always rendered — collapsing shrinks it to 56px icons,
+            never hides it, matching the main shell's collapsed-nav behavior. */}
+        <nav
+          className={`aps-rail${isExpanded ? " aps-rail--expanded" : ""}`}
+          aria-label="Primary"
+        >
+          <a className="aps-brand" href="/" aria-label="CovenCave home" title="CovenCave">
+            <Icon name="ph:sparkle-bold" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            <span className="aps-rail-label aps-brand-label">CovenCave</span>
+          </a>
+          <ul className="aps-rail-list">
+            {PRIMARY.map((d) => (
+              <li key={d.href}>
+                <a className="aps-rail-link" href={d.href} aria-label={d.label} title={d.label}>
+                  <Icon name={d.icon} width={NAV_ICON} height={NAV_ICON} aria-hidden />
+                  <span className="aps-rail-label">{d.label}</span>
+                </a>
+              </li>
+            ))}
+          </ul>
+          <a
+            className="aps-rail-link aps-rail-foot"
+            href="/dashboard"
+            aria-label="Dashboard"
+            title="Dashboard"
+            aria-current={onDashboard ? "page" : undefined}
+          >
+            <Icon name="ph:squares-four" width={NAV_ICON} height={NAV_ICON} aria-hidden />
+            <span className="aps-rail-label">Dashboard</span>
+          </a>
+        </nav>
         <main className="aps-main">{children}</main>
       </div>
     </div>

--- a/src/styles/analytics-page-shell.css
+++ b/src/styles/analytics-page-shell.css
@@ -1,6 +1,9 @@
 /* Standalone-route left side-panel (analytics-page-shell.tsx). A persistent icon
    rail shown at EVERY screen size, so the familiar-analytics route carries the
-   app's left sidepanel even though it renders outside the SPA workspace. */
+   app's left sidepanel even though it renders outside the SPA workspace.
+   Two states mirror the main shell's sidebar behavior:
+   - Collapsed (default / mobile): 56px icon-only rail, never fully hidden.
+   - Expanded (.aps-rail--expanded, desktop only): 240px with icons + labels. */
 
 .aps {
   display: flex;
@@ -31,6 +34,9 @@
   border-right: 1px solid var(--border-hairline);
   background: var(--bg-elevated);
   height: auto;
+  overflow-x: hidden;
+  /* Smooth expand/collapse matching the main shell's panel transition. */
+  transition: width var(--duration-base) var(--ease-standard);
   /* The standalone desktop title bar owns the Tauri traffic-light reserve.
      Mobile keeps the rail at the window edge, including its safe-area inset. */
   padding-top: max(10px, env(safe-area-inset-top));
@@ -55,6 +61,9 @@
   flex-direction: column;
   gap: 2px;
   flex: 1 1 auto;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
 }
 
 .aps-rail-link {
@@ -85,6 +94,25 @@
   border-color: color-mix(in oklch, var(--accent-presence) 35%, transparent);
 }
 
+/* Labels — hidden in the 56px collapsed rail, shown in the expanded state. */
+.aps-rail-label {
+  display: none;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--text-base);
+  color: inherit;
+  min-width: 0;
+}
+
+.aps-brand-label {
+  font-size: var(--text-base);
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+}
+
 .aps-rail-foot {
   margin-top: auto;
   flex-shrink: 0;
@@ -109,6 +137,47 @@
 .aps-main > .dr-page {
   min-height: 100%;
   height: 100%;
+}
+
+/* Expansion is desktop-only in CSS as well as React, so SSR and viewport
+   hydration can never flash wide navigation or labels on mobile. */
+@media (min-width: 1024px) {
+  .aps-rail--expanded {
+    width: var(--shell-nav-width);
+    align-items: stretch;
+    padding-left: var(--space-2);
+    padding-right: var(--space-2);
+    gap: 0;
+  }
+
+  .aps-rail--expanded .aps-brand {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: 40px;
+    gap: var(--space-2);
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-control);
+    margin-bottom: var(--space-2);
+  }
+
+  .aps-rail--expanded .aps-rail-list {
+    padding: var(--space-1) 0;
+  }
+
+  .aps-rail--expanded .aps-rail-link {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    height: var(--space-8);
+    gap: var(--space-2);
+    padding: 0 var(--space-2);
+    border-radius: var(--radius-control);
+  }
+
+  .aps-rail--expanded .aps-rail-label {
+    display: block;
+  }
 }
 
 /* The history controls are mounted after hydration on mobile; hide the


### PR DESCRIPTION
## Summary
- synchronize standalone routes with the shared `cave:shell:nav-open` preference
- show the 240px labeled sidebar on desktop while retaining the 56px icon rail when collapsed or on mobile
- add source guards for persisted state, desktop-only expansion, and always-visible navigation

## Verification
- `pnpm test:app` (955 test files)
- `pnpm typecheck`
- `pnpm lint`

Bead: `cave-ytzk1`