### PR TITLE
fix: repair nested page navigation

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -36,6 +36,7 @@ export const SUITES = {
     "src/lib/page-drag.test.ts",
     "src/lib/sidebar-nav-state.test.ts",
     "src/lib/workspace-mode.test.ts",
+    "src/lib/workspace-navigation.test.ts",
     "src/lib/workspace-navigation-history.test.ts",
     "src/lib/surface-preferences.test.ts",
     "src/lib/surface-warm-cache.test.ts",
@@ -1527,10 +1528,10 @@ const ALIAS_LOADER = new Set([
   "src/lib/voice/elevenlabs.test.ts",
 ]);
 
-// This gate measures the physical CSS tree, where facade imports are part of
-// the source structure. Every other source contract reads the effective
-// cascade through the hook below.
-const RAW_CSS_SCANNER_TESTS = new Set([
+// These gates inspect physical source files. The CSS facade expander would
+// change what they are measuring and makes recursive route-source scans slow.
+const RAW_SOURCE_SCANNER_TESTS = new Set([
+  "src/app/route-inventory.test.ts",
   "src/lib/design-token-drift.test.ts",
 ]);
 
@@ -1548,7 +1549,7 @@ const VITEST_TESTS = new Set([
 
 /** Build the `node` argv (flags + file) for a single test path. */
 export function nodeArgsFor(file) {
-  const args = RAW_CSS_SCANNER_TESTS.has(file)
+  const args = RAW_SOURCE_SCANNER_TESTS.has(file)
     ? []
     : ["--require", "./scripts/css-source-contract-hook.cjs"];
   if (file.endsWith(".ts") || STRIP_TYPES_MJS.has(file)) {

--- a/src/app/proposals/page.tsx
+++ b/src/app/proposals/page.tsx
@@ -15,9 +15,13 @@ export default function ProposalsPage() {
       <div className="dr-page">
         <div className="dr-topbar" data-tauri-drag-region="deep">
           <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-            <a className="dr-back" href="/">
+            <a className="dr-back" href="/?mode=grimoire">
               <Icon name="ph:arrow-left" aria-hidden />
-              CovenCave
+              Memories
+            </a>
+            <span className="dr-crumb-sep" aria-hidden>/</span>
+            <a className="dr-back" href="/weaves">
+              Weaves
             </a>
             <span className="dr-crumb-sep" aria-hidden>/</span>
             <span className="dr-crumb-current">Proposals</span>

--- a/src/app/route-inventory.test.ts
+++ b/src/app/route-inventory.test.ts
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import { readFileSync, readdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
+import { isWorkspaceMode } from "../lib/workspace-mode.ts";
 
 const appDir = fileURLToPath(new URL(".", import.meta.url));
 
@@ -22,15 +23,69 @@ const appDir = fileURLToPath(new URL(".", import.meta.url));
 //   dev-only    — design/review reference pages; never linked from nav hosts
 const ROUTE_INVENTORY = {
   "/": { kind: "workspace" },
-  "/dashboard": { kind: "destination" },
-  "/dashboard/familiars/growth": { kind: "destination" },
-  "/dashboard/familiars/[id]/analytics": { kind: "destination" },
-  "/dashboard/familiars/[id]/profile": { kind: "destination" },
-  "/settings": { kind: "destination" },
-  "/weaves": { kind: "destination" },
-  "/proposals": { kind: "destination" },
-  "/profile": { kind: "destination" },
-  "/daily-report/[date]": { kind: "destination" },
+  "/dashboard": {
+    kind: "destination",
+    entry: {
+      file: "../components/sidebar-footer.tsx",
+      pattern: /href="\/dashboard"/,
+    },
+  },
+  "/dashboard/familiars/growth": {
+    kind: "destination",
+    entry: {
+      file: "../components/dashboard/bento-dashboard.tsx",
+      pattern: /href="\/dashboard\/familiars\/growth"/,
+    },
+  },
+  "/dashboard/familiars/[id]/analytics": {
+    kind: "destination",
+    entry: {
+      file: "../components/familiars-view-sections.tsx",
+      pattern: /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/analytics`\}/,
+    },
+  },
+  "/dashboard/familiars/[id]/profile": {
+    kind: "destination",
+    entry: {
+      file: "../components/familiars-view-sections.tsx",
+      pattern: /href=\{`\/dashboard\/familiars\/\$\{encodeURIComponent\(familiar\.id\)\}\/profile`\}/,
+    },
+  },
+  "/settings": {
+    kind: "destination",
+    entry: {
+      file: "../components/workspace.tsx",
+      pattern: /nextRouter\.push\("\/settings"\)/,
+    },
+  },
+  "/weaves": {
+    kind: "destination",
+    entry: {
+      file: "../components/grimoire-view.tsx",
+      pattern: /href="\/weaves"/,
+    },
+  },
+  "/proposals": {
+    kind: "destination",
+    entry: {
+      file: "weaves/page.tsx",
+      pattern: /href="\/proposals"/,
+    },
+  },
+  "/profile": {
+    kind: "destination",
+    entry: {
+      file: "../components/settings-profile.tsx",
+      pattern: /href="\/profile"/,
+    },
+  },
+  "/daily-report/[date]": {
+    kind: "destination",
+    entry: {
+      file: "../lib/daily-summary-notifications.ts",
+      pattern: /return `\/daily-report\/\$\{dateSlug\(now\)\}`/,
+    },
+  },
   "/quick-chat": { kind: "window-host" },
   "/retro": { kind: "redirect", target: "/dashboard/familiars/growth" },
   "/dashboard/retro": { kind: "redirect", target: "/dashboard/familiars/growth" },
@@ -114,6 +169,44 @@ for (const [route, spec] of Object.entries(ROUTE_INVENTORY)) {
     source.includes("AnalyticsPageShell"),
     `${route} is a destination route — it must mount AnalyticsPageShell so the left side-panel is present on every page (cave-4i6u)`,
   );
+  assert.ok(spec.entry, `${route} is a destination route — declare its in-app entry point`);
+  const entrySource = readFileSync(path.resolve(appDir, spec.entry.file), "utf8");
+  assert.match(
+    entrySource,
+    spec.entry.pattern,
+    `${route} must stay reachable from ${spec.entry.file}`,
+  );
+}
+
+// ── Static workspace deep links use the accepted mode vocabulary ────────────
+// A typo such as `/?mode=familiars` silently falls back to the startup surface
+// because readModeParam rejects it. Scan production source strings so invalid
+// links fail here instead of becoming dead-end UI.
+function discoverSourceFiles(dir) {
+  const files = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) files.push(...discoverSourceFiles(fullPath));
+    else if (
+      (entry.name.endsWith(".ts") || entry.name.endsWith(".tsx")) &&
+      !entry.name.includes(".test.")
+    ) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+const srcDir = path.resolve(appDir, "..");
+for (const file of discoverSourceFiles(srcDir)) {
+  const source = readFileSync(file, "utf8");
+  for (const match of source.matchAll(/(["'`])\/\?mode=([a-z-]+)(?=[&#"'`])/g)) {
+    const mode = match[2];
+    assert.ok(
+      isWorkspaceMode(mode),
+      `${path.relative(srcDir, file)} links to invalid workspace mode "${mode}"`,
+    );
+  }
 }
 
 // ── Dev-only pages stay out of every navigation host ─────────────────────────

--- a/src/app/weaves/page.tsx
+++ b/src/app/weaves/page.tsx
@@ -15,13 +15,18 @@ export default function WeavesPage() {
       <div className="dr-page">
         <div className="dr-topbar" data-tauri-drag-region="deep">
           <nav className="dr-topbar__crumbs" aria-label="Breadcrumb">
-            <a className="dr-back" href="/">
+            <a className="dr-back" href="/?mode=grimoire">
               <Icon name="ph:arrow-left" aria-hidden />
-              CovenCave
+              Memories
             </a>
             <span className="dr-crumb-sep" aria-hidden>/</span>
             <span className="dr-crumb-current">Weaves</span>
           </nav>
+          <div className="dr-topbar__actions">
+            <a className="dr-back" href="/proposals">
+              Review proposals →
+            </a>
+          </div>
         </div>
         <div className="px-4 pb-6">
           <p className="mb-3 max-w-2xl text-xs text-[var(--text-muted)]">

--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -13,6 +13,7 @@ const workspaceShell = await source("components/shell.tsx");
 const css = await source("styles/analytics-page-shell.css");
 const desktopChrome = await source("styles/globals/desktop-chrome.css");
 const historyNav = await source("components/desktop-history-nav.tsx");
+const navigation = await source("lib/workspace-navigation.ts");
 
 // ── The canonical analytics route wraps the view in the left-sidepanel shell ──
 assert.match(dashPage, /import \{ AnalyticsPageShell \} from "@\/components\/analytics-page-shell"/, "/dashboard/familiars/[id]/analytics imports the shell");
@@ -38,9 +39,24 @@ assert.match(
   /className=\{`aps-rail\$\{isExpanded \? " aps-rail--expanded" : ""\}`\}/,
   "shell renders a labelled rail with an explicit expanded state",
 );
-assert.match(shell, /href: "\/\?mode=home"/, "rail deep-links Home into the SPA");
-assert.match(shell, /href: "\/\?mode=chat"/, "rail deep-links Chat");
-assert.match(shell, /href: "\/\?mode=board"/, "rail deep-links Tasks");
+assert.match(
+  shell,
+  /import \{ VISIBLE_WORKSPACE_NAV_ITEMS \} from "@\/lib\/workspace-navigation"/,
+  "standalone routes consume the same navigation registry as the workspace sidebar",
+);
+assert.match(
+  shell,
+  /const PRIMARY = VISIBLE_WORKSPACE_NAV_ITEMS\.map/,
+  "the standalone rail derives its destinations from the shared visible registry",
+);
+assert.doesNotMatch(
+  shell,
+  /\{ href: "\/\?mode=/,
+  "the standalone rail must not hand-copy workspace deep links",
+);
+assert.match(navigation, /\{ id: "home", label: "Home"/, "canonical navigation registry includes Home");
+assert.match(navigation, /\{ id: "chat", label: "Chat"/, "canonical navigation registry includes Chat");
+assert.match(navigation, /\{ id: "board", label: "Tasks"/, "canonical navigation registry includes Tasks");
 assert.match(shell, /href="\/dashboard"/, "rail links to the Dashboard route");
 assert.match(shell, /<span className="aps-rail-label">Dashboard<\/span>/, "expanded rail links have visible labels");
 

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -3,8 +3,9 @@
 import { useLayoutEffect, useState, type ReactNode } from "react";
 import { usePathname } from "next/navigation";
 import { DesktopHistoryNav } from "@/components/desktop-history-nav";
-import { Icon, CAVE_ICON_SIZE, type IconName } from "@/lib/icon";
+import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { useIsMobile } from "@/lib/use-viewport";
+import { VISIBLE_WORKSPACE_NAV_ITEMS } from "@/lib/workspace-navigation";
 import "@/styles/analytics-page-shell.css";
 
 // Shared with shell.tsx so the nav open/closed preference is consistent across
@@ -30,22 +31,13 @@ function writeNavOpenPref(open: boolean): void {
   }
 }
 
-type RailDest = { href: string; label: string; icon: IconName };
-
-// Mirror the app's primary sidebar destinations (sidebar-minimal FOLDER_MODES)
-// as deep links the SPA resolves via `?mode=` (workspace readModeParam). Kept as
-// plain <a> links because this shell wraps STANDALONE routes that live outside
-// the SPA workspace which owns SidebarMinimal.
-const PRIMARY: RailDest[] = [
-  { href: "/?mode=home", label: "Home", icon: "ph:house-bold" },
-  { href: "/?mode=chat", label: "Chat", icon: "ph:chats" },
-  { href: "/?mode=board", label: "Tasks", icon: "ph:kanban" },
-  { href: "/?mode=inbox", label: "Rituals", icon: "ph:calendar-check" },
-  { href: "/?mode=journal", label: "Journal", icon: "ph:book-open" },
-  { href: "/?mode=grimoire", label: "Memories", icon: "ph:books" },
-  { href: "/?mode=marketplace", label: "Marketplace", icon: "ph:storefront-bold" },
-  { href: "/?mode=github", label: "GitHub", icon: "ph:github-logo" },
-];
+// Standalone pages use the workspace sidebar's canonical visible destinations
+// instead of maintaining a second list that can drift in names or reachability.
+const PRIMARY = VISIBLE_WORKSPACE_NAV_ITEMS.map((item) => ({
+  href: `/?mode=${item.id}`,
+  label: item.label,
+  icon: item.iconName,
+}));
 
 const NAV_ICON = CAVE_ICON_SIZE.sidePanelNav;
 

--- a/src/components/canonical-nav-names.test.ts
+++ b/src/components/canonical-nav-names.test.ts
@@ -1,14 +1,15 @@
 // @ts-nocheck
 // Canonical navigation vocabulary (issue #3283, bead cave-m4ih.1): one surface,
-// one user-facing name, on every platform. The desktop sidebar's FOLDER_MODES
-// is the source of truth; the mobile bottom tabs and the workspace sr-title map
+// one user-facing name, on every platform. The lightweight workspace navigation
+// registry is the source of truth; the desktop sidebar, mobile bottom tabs, and
+// workspace sr-title map
 // must agree with it for every destination they share. This pin exists because
 // the same surface previously shipped as "Tasks" (desktop) / "Board" (mobile)
 // and "Rituals" (desktop) / "Rites" (mobile) at the same time.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const registry = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const mobileTabs = readFileSync(new URL("./mobile-bottom-tabs.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 
@@ -24,50 +25,45 @@ function extractLabels(source, blockName, blockRe) {
   return labels;
 }
 
-const sidebarLabels = extractLabels(
-  sidebar,
-  "FOLDER_MODES",
-  /const FOLDER_MODES[\s\S]*?\n\];/,
+const registryLabels = extractLabels(
+  registry,
+  "WORKSPACE_NAV_ITEMS",
+  /export const WORKSPACE_NAV_ITEMS[\s\S]*?\n\];/,
 );
 
-// ── Mobile bottom tabs DERIVE from the sidebar's primary cluster ─────────────
+// ── Mobile bottom tabs DERIVE from the shared primary cluster ────────────────
 // Parity by construction (issue #3283 acceptance: "Desktop and mobile present
-// the same conceptual hierarchy"): the tab strip maps FOLDER_MODES rows that
-// are neither quiet nor navHidden, reusing the canonical label as both the
-// visible label and the accessible name. No hand-copied row list may return.
+// the same conceptual hierarchy"): the registry owns the quiet/navHidden
+// filtering, and the tab strip maps the resulting primary rows while reusing
+// the canonical label as both the visible label and accessible name.
 assert.match(
   mobileTabs,
-  /import \{ FOLDER_MODES \} from "@\/components\/sidebar-minimal";/,
-  "mobile tabs must import the sidebar's FOLDER_MODES source of truth",
+  /import \{ PRIMARY_WORKSPACE_NAV_ITEMS \} from "@\/lib\/workspace-navigation";/,
+  "mobile tabs must import the shared primary navigation registry",
 );
 const tabsDeclaration = mobileTabs.match(
-  /const\s+TABS\s*=\s*FOLDER_MODES[\s\S]*?;(?=\s*\n)/,
+  /const\s+TABS\s*=\s*PRIMARY_WORKSPACE_NAV_ITEMS\.map\([\s\S]*?\n\);/,
 )?.[0];
-assert.ok(tabsDeclaration, "mobile tabs must derive TABS directly from FOLDER_MODES");
-assert.match(
-  tabsDeclaration,
-  /\.filter\(\s*\(?\s*fm\s*\)?\s*=>\s*!fm\.quiet\s*&&\s*!fm\.navHidden\s*\)/,
-  "mobile tabs must be derived from the sidebar's primary (non-quiet, non-hidden) cluster",
-);
+assert.ok(tabsDeclaration, "mobile tabs must derive TABS directly from PRIMARY_WORKSPACE_NAV_ITEMS");
 for (const field of ["id", "label", "ariaLabel", "iconName"]) {
   const sourceField = field === "ariaLabel" ? "label" : field;
   assert.match(
     tabsDeclaration,
     new RegExp(`\\b${field}\\s*:\\s*fm\\.${sourceField}\\b`),
-    `mobile tabs must derive ${field} from the canonical FOLDER_MODES row`,
+    `mobile tabs must derive ${field} from the canonical workspace navigation row`,
   );
 }
 assert.doesNotMatch(
   mobileTabs,
   /\{ id: "[a-z-]+", label: "/,
-  "mobile tabs must not hand-copy id/label rows — derive them from FOLDER_MODES",
+  "mobile tabs must not hand-copy id/label rows — derive them from the shared registry",
 );
 
 // The primary cluster the tabs mirror stays the four daily destinations, and
-// the drawer keeps the rest reachable: quiet rows exist in FOLDER_MODES.
+// the drawer keeps the rest reachable: quiet rows exist in WORKSPACE_NAV_ITEMS.
 const primaryIds = [];
-const folderBlock = sidebar.match(/const FOLDER_MODES[\s\S]*?\n\];/)[0];
-for (const row of folderBlock.matchAll(/\{[\s\S]*?\}/g)) {
+const registryBlock = registry.match(/export const WORKSPACE_NAV_ITEMS[\s\S]*?\n\];/)[0];
+for (const row of registryBlock.matchAll(/\{[\s\S]*?\}/g)) {
   const id = row[0].match(/\bid\s*:\s*"([a-z-]+)"/)?.[1];
   if (!id) continue;
   if (!/\bquiet\s*:\s*true\b/.test(row[0]) && !/\bnavHidden\s*:\s*true\b/.test(row[0])) {
@@ -89,13 +85,13 @@ const modeTitles = new Map();
 for (const m of titlesBlock.matchAll(/"?([a-z-]+)"?: "([^"]+)"/g)) {
   modeTitles.set(m[1], m[2]);
 }
-for (const [id, canonical] of sidebarLabels) {
+for (const [id, canonical] of registryLabels) {
   const title = modeTitles.get(id);
   if (title === undefined) continue;
   assert.equal(
     title,
     canonical,
-    `WORKSPACE_MODE_TITLES["${id}"] must use the canonical sidebar label "${canonical}", got "${title}"`,
+    `WORKSPACE_MODE_TITLES["${id}"] must use the canonical navigation label "${canonical}", got "${title}"`,
   );
 }
 

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -17,6 +17,7 @@ import { readFile } from "node:fs/promises";
 
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = await readFile(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const codeView = await readFile(new URL("./code-view.tsx", import.meta.url), "utf8");
 const lazySurfaces = await readFile(new URL("./lazy-surfaces.tsx", import.meta.url), "utf8");
@@ -128,14 +129,19 @@ assert.match(
 // row arrives via the registry-driven roleSurfaces cluster, and the GitHub
 // row hides while the room is visible (the room carries its own GitHub tab).
 assert.match(
+  navigation,
+  /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"[^}]*quiet: true \}/,
+  "the GitHub quiet row owns the canonical navigation slot",
+);
+assert.match(
   sidebar,
-  /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"[\s\S]{0,300}?badge: \(p\) => badgeText\(p\.githubAssignedCount\)/,
-  "the GitHub quiet row owns the slot and carries the assigned-work badge",
+  /github: \(props\) => badgeText\(props\.githubAssignedCount\)/,
+  "the sidebar adds the assigned-work badge to the canonical GitHub row",
 );
 assert.doesNotMatch(
-  sidebar,
+  navigation,
   /\{ id: "code", label: "Code"/,
-  "no static Code row survives in FOLDER_MODES — the room row is registry-driven",
+  "no static Code row survives in workspace navigation — the room row is registry-driven",
 );
 assert.match(
   workspace,

--- a/src/components/command-palette.test.ts
+++ b/src/components/command-palette.test.ts
@@ -149,13 +149,13 @@ assert.ok(stripMatch, "create-task title strips a leading /task prefix via repla
 // ── Surface navigation ("Go to <surface>") makes ⌘K a launcher ──
 assert.match(
   source,
-  /kind:\s*"go-to-surface";\s*mode:\s*FolderMode/,
+  /kind:\s*"go-to-surface";\s*mode:\s*WorkspaceNavMode/,
   "palette exposes a go-to-surface intent",
 );
 assert.match(
   source,
-  /import \{ FOLDER_MODES[\s\S]*?from "@\/components\/sidebar-minimal"/,
-  "surface rows are built from the shared FOLDER_MODES list (single source of truth)",
+  /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
+  "surface rows are built from the shared workspace navigation registry",
 );
 assert.match(
   source,

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -11,7 +11,7 @@ import { fuzzyMatch, bestFuzzyScore } from "@/lib/fuzzy-match";
 import { relativeTime } from "@/lib/relative-time";
 import { useDateTimePrefs } from "@/lib/datetime-format";
 import { MarkdownBlock } from "@/components/message-bubble";
-import { FOLDER_MODES, type FolderMode } from "@/components/sidebar-minimal";
+import { WORKSPACE_NAV_ITEMS, type WorkspaceNavMode } from "@/lib/workspace-navigation";
 import { useProjects } from "@/lib/use-projects";
 import {
   PALETTE_CATEGORIES,
@@ -55,7 +55,7 @@ type PaletteIntent =
   | { kind: "open-tui-session"; sessionId: string }
   | { kind: "open-board" }
   | { kind: "set-board-view"; view: "kanban" | "table" | "gantt" }
-  | { kind: "go-to-surface"; mode: FolderMode | `surface:${string}` }
+  | { kind: "go-to-surface"; mode: WorkspaceNavMode | `surface:${string}` }
   | { kind: "open-project"; root: string }
   | { kind: "focus-card"; cardId: string }
   | { kind: "create-task"; title: string }
@@ -528,14 +528,14 @@ export function CommandPalette({
       ? [{ id: "create-task", kind: "create-task", title: trimmedTitle }]
       : [];
 
-    // "Go to <surface>" rows make ⌘K a launcher for the visible sidebar
-    // surfaces. Hidden while typing a slash command or a familiar scope (where
-    // surface nav would be noise). Role Surface rooms (cave-cc5r) append with
-    // the same treatment so "Go to Code Workshop" works like any surface.
+    // "Go to <surface>" rows make ⌘K a launcher for every canonical workspace
+    // destination, including on-demand rows hidden from the sidebar. Hidden
+    // while typing a slash command or a familiar scope (where surface nav would
+    // be noise). Role Surface rooms (cave-cc5r) append with the same treatment.
     const surfaceRows: Row[] = (scoped || slashToken)
       ? []
       : [
-          ...rank(FOLDER_MODES
+          ...rank(WORKSPACE_NAV_ITEMS
           // Fuzzy on the short label/id; substring-only on the long description
           // (subsequence-matching prose surfaces irrelevant items).
           .filter((fm) => !q || fz(fm.label) || fz(fm.id) || fm.description.toLowerCase().includes(q)),

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -9,6 +9,7 @@ const view = [
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 const modeType = await readFile(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
+const navigation = await readFile(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const warmupRegistry = await readFile(new URL("../lib/surface-warmup-registry.ts", import.meta.url), "utf8");
 
 // ── Surface registration: mode, title, render branch, sidebar row ────────────
@@ -19,8 +20,15 @@ assert.match(workspace, /mode === "grimoire" \? \(\s*<GrimoireView\s+view=\{grim
 // Journal is now a tab inside Grimoire: the nav/deep-link `journal` mode opens
 // Grimoire on its Journal tab instead of redirecting to Settings.
 assert.match(workspace, /if \(next === "journal"\) \{[\s\S]{0,400}setGrimoireView\("journal"\);\s*\n\s*commitMode\("grimoire", "journal"\);/, "the journal mode routes into the Grimoire Journal tab and preserves that destination in history");
-assert.match(sidebar, /export type FolderMode = WorkspaceMode/, "the sidebar's FolderMode is the WorkspaceMode union (no drifting copy), so grimoire is a FolderMode");
-assert.match(sidebar, /id: "grimoire", label: "Memories"/, "grimoire has a sidebar row labeled Memories (and ⌘K palette entry via FOLDER_MODES)");
+assert.match(navigation, /export type WorkspaceNavMode = WorkspaceMode/, "the shared registry uses the WorkspaceMode union (no drifting copy)");
+assert.match(navigation, /id: "grimoire", label: "Memories"/, "grimoire has a navigation row labeled Memories (and a ⌘K palette entry)");
+assert.match(sidebar, /VISIBLE_WORKSPACE_NAV_ITEMS/, "the sidebar renders visible rows from the shared registry");
+assert.match(
+  view,
+  /href="\/weaves"/,
+  "Memories exposes its nested protected-memory Weaves destination",
+);
+assert.match(view, />\s*Weaves\s*<\/Link>/, "the protected-memory destination has a visible label");
 
 // ── Navigator: three sources, searchable, new-entry affordance ───────────────
 

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -19,6 +19,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import Link from "next/link";
 import { Icon, type IconName } from "@/lib/icon";
 import { MdEditor, type MdEditorSaveResult } from "@/components/md-editor/md-editor";
 import { MemoryMdEditor } from "@/components/md-editor/memory-md-editor";
@@ -1480,6 +1481,13 @@ export function GrimoireView({
               containerClassName="surface-compact-search"
             />
           ) : null}
+          <Link
+            href="/weaves"
+            className="focus-ring inline-flex h-[26px] shrink-0 items-center gap-1 whitespace-nowrap rounded-[var(--radius-control)] border border-[var(--border-hairline)] px-2 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+          >
+            <Icon name="ph:path" width={11} aria-hidden />
+            Weaves
+          </Link>
           {view === "docs" ? (
             <>
               <button

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -5,7 +5,7 @@ import { readFileSync } from "node:fs";
 
 const view = readFileSync(new URL("./group-chat-view.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const transcript = readFileSync(new URL("../lib/group-chat-transcript.ts", import.meta.url), "utf8");
@@ -296,9 +296,9 @@ test("Group Chat is a tab inside the Chat surface, not a standalone page", () =>
 
   // The standalone left-nav destination is gone.
   assert.doesNotMatch(
-    sidebar,
+    navigation,
     /id: "groupchat", label: "Group"/,
-    "sidebar no longer exposes a standalone Group destination",
+    "workspace navigation no longer exposes a standalone Group destination",
   );
 
   // ChatSurface owns Group Chat now: it imports GroupChatView, offers a Group

--- a/src/components/journal-redirect.test.ts
+++ b/src/components/journal-redirect.test.ts
@@ -60,6 +60,7 @@ assert.doesNotMatch(entriesSrc, /standalone/, "journal-entries no longer carries
 
 const ws = read("./workspace.tsx");
 const sidebar = read("./sidebar-minimal.tsx");
+const navigation = read("../lib/workspace-navigation.ts");
 const pageDrag = read("../lib/page-drag.ts");
 const slash = read("../lib/slash-commands.ts");
 
@@ -78,8 +79,9 @@ assert.match(ws, /case "\/journal":\s*\n\s*setMode\("journal"\)/, "/journal rout
 // ── Sidebar: the Journal mode stays reachable (⌘K palette + deep links via
 // navHidden) even though its dedicated row is retired — it's a tab inside
 // Memories now. ─────
-assert.match(sidebar, /id: "journal", label: "Journal", iconName: "ph:book-open"/, "sidebar keeps the Journal FOLDER_MODES entry for the palette");
-assert.doesNotMatch(sidebar, /generated sketches/, "sidebar description no longer promises the canvas");
+assert.match(navigation, /id: "journal", label: "Journal", iconName: "ph:book-open"/, "the navigation registry keeps Journal reachable through the palette");
+assert.doesNotMatch(navigation, /generated sketches/, "the Journal description no longer promises the canvas");
+assert.match(sidebar, /VISIBLE_WORKSPACE_NAV_ITEMS/, "the sidebar consumes the shared visible registry");
 
 // ── A redirect is not a page: journal can't be dragged into a split ─────────
 assert.match(pageDrag, /NON_SPLITTABLE = new Set\(\["terminal", "journal"\]\)/, "journal is excluded from drag-to-split");

--- a/src/components/mobile-bottom-tabs.tsx
+++ b/src/components/mobile-bottom-tabs.tsx
@@ -2,13 +2,13 @@
 
 /**
  * MobileBottomTabs — fixed/sticky bottom navigation strip for mobile/tablet
- * viewports. Surfaces the desktop sidebar's primary cluster (the non-quiet,
- * non-hidden FOLDER_MODES rows — Home, Chat, Tasks, Rituals) as a tablist
+ * viewports. Surfaces the shared primary workspace cluster (Home, Chat, Tasks,
+ * Rituals) as a tablist
  * with icon + label and an active highlight. Tabs are DERIVED from
- * FOLDER_MODES rather than hand-copied so desktop and mobile present the
- * same conceptual hierarchy by construction (issue #3283 — one surface, one
- * name; the quiet cluster and footer stay reachable via the nav drawer,
- * which hosts the full sidebar).
+ * PRIMARY_WORKSPACE_NAV_ITEMS rather than hand-copied so desktop and mobile
+ * present the same conceptual hierarchy by construction (issue #3283 — one
+ * surface, one name; the quiet cluster and footer stay reachable via the nav
+ * drawer, which hosts the full sidebar).
  *
  * Renders only when the parent shell is in mobile mode (≤1023px); Shell is
  * responsible for that conditional render — this component itself doesn't
@@ -16,11 +16,11 @@
  */
 
 import { Icon } from "@/lib/icon";
-import { FOLDER_MODES } from "@/components/sidebar-minimal";
+import { PRIMARY_WORKSPACE_NAV_ITEMS } from "@/lib/workspace-navigation";
 
 // Primary daily destinations: exactly the rows the desktop sidebar promotes
 // (quiet rows live in the drawer's full sidebar; navHidden are on-demand).
-const TABS = FOLDER_MODES.filter((fm) => !fm.quiet && !fm.navHidden).map(
+const TABS = PRIMARY_WORKSPACE_NAV_ITEMS.map(
   (fm) => ({ id: fm.id, label: fm.label, ariaLabel: fm.label, iconName: fm.iconName }),
 );
 

--- a/src/components/mobile-shell-smoke.test.ts
+++ b/src/components/mobile-shell-smoke.test.ts
@@ -81,8 +81,8 @@ assert.match(
 
 assert.match(
   mobileTabs,
-  /FOLDER_MODES\.filter\(\(fm\) => !fm\.quiet && !fm\.navHidden\)/,
-  "Mobile bottom tabs should derive from the desktop sidebar's primary cluster, inheriting canonical names (Rituals included) by construction",
+  /PRIMARY_WORKSPACE_NAV_ITEMS\.map/,
+  "Mobile bottom tabs should derive from the shared primary navigation cluster, inheriting canonical names (Rituals included) by construction",
 );
 
 assert.match(

--- a/src/components/opencoven-submissions-navigation.test.ts
+++ b/src/components/opencoven-submissions-navigation.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const workspaceMode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const page = readFileSync(new URL("./opencoven-submission-page.tsx", import.meta.url), "utf8");
 
@@ -11,9 +11,9 @@ const page = readFileSync(new URL("./opencoven-submission-page.tsx", import.meta
 // from the sidebar nav — it should no longer be listed as a Tools surface.
 assert.match(workspaceMode, /\|\s*"submissions"/, "OpenCoven submissions should remain a workspace mode");
 assert.doesNotMatch(
-  sidebar,
+  navigation,
   /\{ id: "submissions",/,
-  "Sidebar should NOT expose Submissions as a nav item (it's hidden)",
+  "The navigation registry should NOT expose Submissions as a nav item",
 );
 assert.match(workspace, /submissions:\s*"Submissions"/, "Workspace h1 title map should cover submissions mode");
 assert.match(workspace, /mode === "submissions" \?\s*\(\s*<OpenCovenSubmissionPage/, "Workspace should render the OpenCoven submission page directly");

--- a/src/components/palette-canonical-names.test.ts
+++ b/src/components/palette-canonical-names.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 // Canonical names in the command palette + shortcut help (issue #3283, bead
 // cave-m4ih.6): the ⌘K launcher and the shortcuts sheet must speak the same
-// vocabulary as the sidebar. "Go to …" rows already derive from FOLDER_MODES
-// at runtime, so this pins the derivation itself plus the two hand-written
+// vocabulary as the shared workspace navigation registry. "Go to …" rows
+// already derive from WORKSPACE_NAV_ITEMS at runtime, so this pins the
+// derivation itself plus the two hand-written
 // spots that CAN drift: the "Tasks: …" board-view rows and the ⌘1–⌘5 help
 // entry, both cross-checked against the sidebar's labels so a future rename
 // fails here instead of shipping a stale name.
@@ -10,28 +11,28 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const palette = readFileSync(new URL("./command-palette.tsx", import.meta.url), "utf8");
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const registry = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const shortcuts = readFileSync(new URL("../lib/keyboard-shortcuts.ts", import.meta.url), "utf8");
 const sheet = readFileSync(new URL("./shortcuts-sheet.tsx", import.meta.url), "utf8");
 
-// Canonical id -> label (and id -> kbd) from the sidebar's FOLDER_MODES —
-// the same source of truth canonical-nav-names.test.ts pins mobile against.
-const folderModesBlock = sidebar.match(/const FOLDER_MODES[\s\S]*?\n\];/)?.[0];
-assert.ok(folderModesBlock, "FOLDER_MODES block should be extractable");
+// Canonical id -> label (and id -> kbd) from WORKSPACE_NAV_ITEMS — the same
+// source of truth canonical-nav-names.test.ts pins all navigation hosts against.
+const navigationBlock = registry.match(/export const WORKSPACE_NAV_ITEMS[\s\S]*?\n\];/)?.[0];
+assert.ok(navigationBlock, "WORKSPACE_NAV_ITEMS block should be extractable");
 const labels = new Map();
 const kbds = new Map();
-for (const m of folderModesBlock.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"(?:[^\n]*?kbd: "([^"]+)")?/g)) {
+for (const m of navigationBlock.matchAll(/\{ id: "([a-z-]+)", label: "([^"]+)"(?:[^\n]*?kbd: "([^"]+)")?/g)) {
   labels.set(m[1], m[2]);
   if (m[3]) kbds.set(m[1], m[3]);
 }
-assert.ok(labels.size > 0, "FOLDER_MODES should declare id/label rows");
+assert.ok(labels.size > 0, "WORKSPACE_NAV_ITEMS should declare id/label rows");
 
-// ── "Go to <surface>" rows derive from FOLDER_MODES at runtime ───────────────
+// ── "Go to <surface>" rows derive from WORKSPACE_NAV_ITEMS at runtime ────────
 assert.match(
   palette,
-  /import \{ FOLDER_MODES, type FolderMode \} from "@\/components\/sidebar-minimal"/,
-  "the palette imports the sidebar's FOLDER_MODES rather than its own surface list",
+  /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
+  "the palette imports the shared workspace navigation registry rather than its own surface list",
 );
 assert.match(
   palette,

--- a/src/components/profile-card.test.ts
+++ b/src/components/profile-card.test.ts
@@ -75,6 +75,13 @@ describe("Profile card wiring (cave-ujbr)", () => {
     assert.match(settings, /View profile card →/);
   });
 
+  it("returns familiar and human profiles to real parent destinations", () => {
+    const source = read("./profile-card.tsx");
+    assert.match(source, /href="\/\?mode=agents"/, "familiar profiles return to the Familiars surface");
+    assert.match(source, /href="\/settings"/, "the human profile returns to Settings");
+    assert.doesNotMatch(source, /\/\?mode=(?:familiars|settings)/, "profile navigation never targets invalid workspace modes");
+  });
+
   it("keeps the profile card fixed-dark and monospace, scoped under .pfc-*", () => {
     const css = readFileSync(new URL("../styles/profile-card.css", import.meta.url), "utf8");
     assert.match(css, /\.pfc-page \{/);

--- a/src/components/profile-card.tsx
+++ b/src/components/profile-card.tsx
@@ -137,7 +137,7 @@ export function ProfileCardView({ kind, familiarId }: { kind: ProfileKind; famil
           headline="Familiar not found"
           subtitle={`No familiar with id “${familiarId}”. It may have been retired, or the daemon is offline.`}
           actions={
-            <Link className="focus-ring pfc-retry" href="/?mode=familiars">
+            <Link className="focus-ring pfc-retry" href="/?mode=agents">
               Back to familiars
             </Link>
           }
@@ -173,9 +173,15 @@ export function ProfileCard({
   return (
     <main className="pfc-page" aria-busy={refreshing ? "true" : undefined}>
       <nav className="pfc-topnav" aria-label="Profile">
-        <Link className="focus-ring pfc-topnav-link" href="/?mode=familiars">
-          ← Familiars
-        </Link>
+        {vm.kind === "familiar" ? (
+          <Link className="focus-ring pfc-topnav-link" href="/?mode=agents">
+            ← Familiars
+          </Link>
+        ) : (
+          <Link className="focus-ring pfc-topnav-link" href="/settings">
+            ← Settings
+          </Link>
+        )}
         {vm.kind === "familiar" && vm.familiar ? (
           <Link
             className="focus-ring pfc-topnav-link"
@@ -183,11 +189,7 @@ export function ProfileCard({
           >
             Analytics →
           </Link>
-        ) : (
-          <Link className="focus-ring pfc-topnav-link" href="/?mode=settings">
-            Settings →
-          </Link>
-        )}
+        ) : null}
       </nav>
 
       {error || vm.errors.length > 0 ? (

--- a/src/components/proposal-approval.test.ts
+++ b/src/components/proposal-approval.test.ts
@@ -110,5 +110,7 @@ assert.match(flow, /meta\.sourceCursor/, "freshness footer present");
 // page: never applies edits itself, daemon re-validates
 assert.match(page, /data, not authority/, "page states the staged-write rule");
 assert.match(page, /never applies edits\s+itself/, "page denies a UI write path");
+assert.match(page, /href="\/weaves"/, "proposal decisions breadcrumb back to Weaves");
+assert.match(page, /href="\/\?mode=grimoire"/, "proposal decisions preserve the Memories parent path");
 
 console.log("proposal-approval wiring: all assertions passed");

--- a/src/components/rituals-tabs.test.ts
+++ b/src/components/rituals-tabs.test.ts
@@ -10,7 +10,7 @@ const automations = [
   readFileSync(new URL("./automations/ritual-overview.tsx", import.meta.url), "utf8"),
 ].join("\n");
 const menuBar = readFileSync(new URL("./familiar-menu-bar.tsx", import.meta.url), "utf8");
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const calendar = readFileSync(new URL("./calendar-view.tsx", import.meta.url), "utf8");
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
@@ -20,9 +20,9 @@ const slashCommands = readFileSync(new URL("../lib/slash-commands.ts", import.me
 
 // ── The surface is "Rituals" everywhere it's named ──────────────────────────
 assert.match(
-  sidebar,
+  navigation,
   /\{ id: "inbox", label: "Rituals", iconName: "ph:calendar-check"/,
-  "Sidebar should label the slim surface Rituals",
+  "The navigation registry should label the slim surface Rituals",
 );
 assert.match(
   workspace,
@@ -31,8 +31,8 @@ assert.match(
 );
 assert.match(
   mobileTabs,
-  /const\s+TABS\s*=\s*FOLDER_MODES[\s\S]*?\.filter\([\s\S]*?!fm\.quiet\s*&&\s*!fm\.navHidden[\s\S]*?\.map\([\s\S]*?label\s*:\s*fm\.label[\s\S]*?ariaLabel\s*:\s*fm\.label/,
-  "Mobile bottom tabs derive visible and accessible labels from the canonical FOLDER_MODES rows (one surface, one name — issue #3283)",
+  /const\s+TABS\s*=\s*PRIMARY_WORKSPACE_NAV_ITEMS\.map\([\s\S]*?label\s*:\s*fm\.label[\s\S]*?ariaLabel\s*:\s*fm\.label/,
+  "Mobile bottom tabs derive visible and accessible labels from the canonical primary navigation rows (one surface, one name — issue #3283)",
 );
 assert.match(
   notificationBell,
@@ -167,7 +167,7 @@ assert.match(
 );
 assert.match(automations, /function useRitualNow\(\): Date \| null[\s\S]{0,560}setNow\(new Date\(\)\);[\s\S]{0,80}scheduleMidnight/, "the hydration-stable week clock starts in the browser and refreshes at local midnight");
 assert.match(automations, /ritualNow \? buildRitualWeek\(inboxVisible, ritualNow\) : \[\]/, "the week ribbon waits for the browser-local date before derivation");
-assert.doesNotMatch(sidebar, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");
+assert.doesNotMatch(navigation, /\{ id: "flow", label: "Flow"/, "Flow nav is hidden from the active branch");
 
 assert.doesNotMatch(automations, /listFlows\(\)/, "Rituals does not load flow docs");
 assert.doesNotMatch(automations, /runFlow\(flow\.id\)/, "Rituals does not run flows");

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 const sidebar = await readFile(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = await readFile(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const palette = await readFile(new URL("./command-palette.tsx", import.meta.url), "utf8");
 const workspace = await readFile(new URL("./workspace.tsx", import.meta.url), "utf8");
 const settings = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
@@ -52,16 +53,16 @@ assert.doesNotMatch(
   "Workspace should not expose a top-level Workflows page",
 );
 
-// ── Sidebar: one Tools entry for the merged hub ──────────────────────────────
+// ── Navigation: one Tools entry for the merged hub ───────────────────────────
 assert.match(
-  sidebar,
+  navigation,
   /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' crafts and skills", quiet: true \},/,
-  "Sidebar navigation should expose the merged Marketplace hub with a description covering both halves",
+  "The navigation registry should expose the merged Marketplace hub with a description covering both halves",
 );
 assert.doesNotMatch(
-  sidebar,
+  navigation,
   /\{ id: "roles", label: "Roles"/,
-  "The separate Roles sidebar entry is retired — roles live inside the Marketplace hub",
+  "The separate Roles navigation entry is retired — roles live inside the Marketplace hub",
 );
 assert.doesNotMatch(sidebar, /addons\?\.roles/, "The roles add-on gate is retired from the sidebar");
 assert.doesNotMatch(palette, /addons\?\.roles/, "The roles add-on gate is retired from the command palette");

--- a/src/components/salem/salem-home-entry.test.ts
+++ b/src/components/salem/salem-home-entry.test.ts
@@ -6,6 +6,7 @@ const read = (rel) => readFile(new URL(rel, import.meta.url), "utf8");
 const card = await read("./salem-pathfinder-card.tsx");
 const widget = await read("./salem-widget.tsx");
 const sidebar = await read("../sidebar-minimal.tsx");
+const navigation = await read("../../lib/workspace-navigation.ts");
 const projects = await read("../projects-view.tsx");
 const boardRoute = await read("../../app/api/board/route.ts");
 
@@ -21,14 +22,14 @@ assert.match(card, /salem-pf__action--save/, "renders a dedicated save button");
 assert.doesNotMatch(widget, /saveCardToBoard|\/api\/board|SalemPathfinderCard/, "rail chat omits dormant Pathfinder save plumbing");
 
 // Sidebar: the Ask Salem entry was removed from the left side panel. The mode
-// exists as a FOLDER_MODES row (object literal, not JSX) but must stay
+// exists in the workspace navigation registry but must stay
 // navHidden so it never renders as a sidebar entry — it's summoned via Home,
 // the ⌘K palette, deep links, or the widget's expand button.
 assert.doesNotMatch(sidebar, /label="Ask Salem"/, "sidebar no longer exposes an Ask Salem entry");
 assert.match(
-  sidebar,
+  navigation,
   /id: "salem", label: "Ask Salem",[^\n]*navHidden: true/,
-  "salem FOLDER_MODES row stays navHidden (palette/deep-link only, no sidebar row)",
+  "salem navigation row stays navHidden (palette/deep-link only, no sidebar row)",
 );
 
 // Projects empty state offers Ask Salem.

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
 const source = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 // The footer (Dashboard + Settings + version) lives in a shared component so it
 // stays identical when Chat replaces SidebarMinimal with WorkspaceSidebar.
@@ -79,25 +80,25 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /props\.hideGithubRow \? VISIBLE_MODES\.filter\(\(fm\) => fm\.id !== "github"\) : VISIBLE_MODES/,
+  /props\.hideGithubRow[\s\S]{0,120}\? VISIBLE_WORKSPACE_NAV_ITEMS\.filter\(\(item\) => item\.id !== "github"\)[\s\S]{0,80}: VISIBLE_WORKSPACE_NAV_ITEMS/,
   "Sidebar renders the visible folder modes, dropping the GitHub row while the Code room already carries a GitHub tab (cave-cc5r)",
 );
 assert.match(
   source,
-  /const VISIBLE_MODES = FOLDER_MODES\.filter\(\(fm\) => !fm\.navHidden\)/,
-  "VISIBLE_MODES drops navHidden surfaces (Browser) from the rendered nav",
+  /import \{[\s\S]*VISIBLE_WORKSPACE_NAV_ITEMS,[\s\S]*\} from "@\/lib\/workspace-navigation"/,
+  "the sidebar consumes the shared registry's already-filtered visible rows",
 );
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "home", label: "Home"/,
-  "Home is the first Work surface",
+  "Home is the first workspace destination",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "agents", label: "Familiars"/,
-  "Familiars subpage should not appear as a Work navigation row",
+  "Familiars subpage should not appear as a workspace navigation row",
 );
 
 // The horizontal dock is gone, and the profile switcher no longer lives in the
@@ -122,31 +123,31 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description:/,
   "The Chat surface should keep the ⌘2 shortcut",
 );
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description:/,
   "the Tasks surface (mode id 'board') sits on the ⌘3 shortcut",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "calendar", label: "Calendar"/,
   "Calendar should not appear as a standalone sidebar row after merging into Schedules",
 );
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description:/,
   "Rituals should own the old Calendar shortcut as the active schedule surface",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "library", label: "Library"/,
   "Library should not be an integrated sidebar surface while it lives on feature/library",
 );
@@ -154,7 +155,7 @@ assert.doesNotMatch(
 // The "Coven" surface was purged — its docs/feedback/social are now default
 // Browser tabs, so no nav entry should remain.
 assert.doesNotMatch(
-  source,
+  navigation,
   /id: "docs"|label: "Coven"/,
   "the removed Coven (docs) surface should have no sidebar nav entry",
 );
@@ -165,60 +166,60 @@ assert.doesNotMatch(
   "Library should not be a root add-on gate in the integrated sidebar",
 );
 
-// Browser stays in FOLDER_MODES (so ⌘5 + the ⌘K "Go to" launcher still reach
+// Browser stays in the shared registry (so ⌘5 + the ⌘K "Go to" launcher reach
 // it) but is navHidden, so it renders no sidebar row — summoned on demand.
 assert.match(
-  source,
+  navigation,
   /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
   "Browser is kept for ⌘5/palette but hidden from the sidebar rows (navHidden)",
 );
 
-assert.doesNotMatch(source, /id:\s*"terminal"/, "Terminal is not a standalone sidebar destination");
+assert.doesNotMatch(navigation, /id:\s*"terminal"/, "Terminal is not a standalone sidebar destination");
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description:/,
   "The merged Marketplace hub should appear as a Tools surface",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "roles", label: "Roles"/,
   "Roles is no longer a standalone nav entry — it merged into the Marketplace hub",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "workflows", label: "Workflows"/,
   "Workflows should not appear as a top-level Tools surface",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "flow", label: "Flow", iconName: "ph:flow-arrow", description:/,
   "Flow should not appear as a top-level Tools surface on the active branch",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "capabilities",/,
   "Capabilities is no longer a standalone nav entry — it is a section of the Marketplace hub",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "sessions"/,
   "Sessions row removed — folded into Chat surface as History sub-view",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "schedules"/,
   "Schedules uses the existing inbox mode instead of a second schedules mode",
 );
 
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "plugins"/,
   "Plugins row removed — moved into Settings · Plugins",
 );
@@ -268,18 +269,18 @@ assert.doesNotMatch(
 // (navHidden), so it must NOT appear among the rendered VISIBLE_MODES rows.
 // (Capabilities moved to a tab on the Roles page — no standalone entry.)
 assert.match(
-  source,
+  navigation,
   /id:\s*"browser"[^}]*navHidden:\s*true/,
   "browser is navHidden (kept for ⌘5/palette, not a sidebar row)",
 );
-assert.doesNotMatch(source, /id:\s*"terminal"/, "terminal does not stay visible");
+assert.doesNotMatch(navigation, /id:\s*"terminal"/, "terminal does not stay visible");
 assert.match(
-  source,
+  navigation,
   /id:\s*"marketplace"[^}]*label:\s*"Marketplace"/,
   "marketplace stays visible",
 );
 assert.doesNotMatch(
-  source,
+  navigation,
   /id:\s*"flow"[^}]*label:\s*"Flow"/,
   "flow does not stay in Tools",
 );
@@ -291,12 +292,12 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  source,
+  navigation,
   /\{ id: "github", label: "GitHub", iconName: "ph:github-logo"/,
   "The standalone GitHub row is back (cave-cc5r): Code lives in the Coding familiar's room",
 );
 assert.doesNotMatch(
-  source,
+  navigation,
   /\{ id: "code", label: "Code"/,
   "Code is no longer a static folder row — the Coding familiar's room row arrives via roleSurfaces (cave-cc5r)",
 );
@@ -385,7 +386,7 @@ assert.match(
 // Every surface carries a one-line description, and FolderRow surfaces it as a
 // title (hover tooltip / touch long-press hint / AT description).
 assert.match(
-  source,
+  navigation,
   /id: "marketplace"[\s\S]*?description: "Browse the store/,
   "Marketplace is described as the store + setup hub",
 );
@@ -436,22 +437,22 @@ assert.match(
 // ⌘-numbered daily set (Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4); Memories
 // leads the quiet cluster, followed by Marketplace/GitHub/Work Queue.
 assert.match(
-  source,
+  navigation,
   /\{ id: "journal",[^}]*navHidden: true \}/,
   "Journal keeps no sidebar row — it's a tab inside Memories (palette/deep-link reachability stays via navHidden)",
 );
 assert.match(
-  source,
+  navigation,
   /\{ id: "grimoire", label: "Memories",[^}]*quiet: true \}/,
   "Memories (grimoire) is in the quiet cluster (cave-xsq.8)",
 );
 assert.match(
-  source,
+  navigation,
   /id: "inbox",[\s\S]*?\{ id: "grimoire"/,
   "the ⌘-numbered prominent cluster (…Schedules) renders above the quiet cluster",
 );
 assert.match(
-  source,
+  navigation,
   /\{ id: "marketplace",[^}]*quiet: true \}/,
   "Marketplace is in the quiet cluster",
 );

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -26,11 +26,11 @@ import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
 import type { InboxPrefs } from "@/lib/cave-inbox-prefs";
-import type { WorkspaceMode } from "@/lib/workspace-mode";
-
-/** The sidebar's mode vocabulary IS the workspace's — one union, no copy.
- *  (Was a hand-maintained duplicate that drifted; cave-m4ih.3.) */
-export type FolderMode = WorkspaceMode;
+import {
+  VISIBLE_WORKSPACE_NAV_ITEMS,
+  type WorkspaceNavItem,
+  type WorkspaceNavMode,
+} from "@/lib/workspace-navigation";
 
 export type SidebarRoleSurfaceRow = {
   /** Generic workspace mode string (`surface:<id>`) — the sidebar never
@@ -85,69 +85,11 @@ function badgeText(n?: number): string | undefined {
   return n > 99 ? "99+" : String(n);
 }
 
-type FolderModeRow = {
-  id: FolderMode;
-  label: string;
-  iconName: Parameters<typeof Icon>[0]["name"];
-  badge?: (props: SidebarMinimalProps) => string | undefined;
-  kbd?: string;
-  // One-line hover/long-press help. Differentiates surfaces that read alike at
-  // a glance.
-  description: string;
-  /** Visual demotion (§8 quiet hierarchy): still one flat list — same roving
-   *  tabindex, same click targets — but quiet rows render muted-until-hover
-   *  and the first one opens a spacing gap, so daily destinations read first. */
-  quiet?: boolean;
-  /** Kept in the list (so the command palette's "Go to" launcher and the
-   *  ⌘-number shortcut still reach it) but NOT rendered as a sidebar row. For
-   *  surfaces you summon on demand rather than navigate to daily — the Browser
-   *  opens itself when a link/URL is clicked, so it needn't sit in the nav. */
-  navHidden?: boolean;
+const MODE_BADGES: Partial<Record<WorkspaceNavMode, (props: SidebarMinimalProps) => string | undefined>> = {
+  board: (props) => badgeText(props.boardOpenCount),
+  inbox: (props) => badgeText(props.scheduleNeedsCount),
+  github: (props) => badgeText(props.githubAssignedCount),
 };
-
-const FOLDER_MODES: Array<FolderModeRow> = [
-  { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
-  // Group Chat ("coven") is no longer a standalone destination — it lives as the
-  // Group tab inside Chat. The `groupchat` mode still exists as a redirect target.
-  { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", badge: (p) => badgeText(p.boardOpenCount) },
-  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Inbox, calendar, and scheduled jobs in one place", badge: (p) => badgeText(p.scheduleNeedsCount) },
-  // Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
-  // ⌘-numbered daily destinations (Home · Chat · Tasks · Schedules — Schedules
-  // also carries the needs-you badge). Memories joins the quiet cluster: same
-  // flat list, same reachability (rows, palette, deep links), just
-  // muted-until-hover so the conversation-first surfaces read first.
-  // Journal keeps no row of its own — it's a tab inside Memories, and a
-  // dedicated row double-listed the same surface. navHidden keeps the mode in
-  // the ⌘K palette and as a deep-link target (setMode remaps it to the
-  // Memories surface's Journal tab).
-  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in Memories", quiet: true, navHidden: true },
-  { id: "grimoire", label: "Memories", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
-  // Browser is summoned on demand (a clicked link/URL opens it, plus ⌘5 and the
-  // ⌘K palette) rather than navigated to daily, so it's kept in the list for
-  // those launchers but hidden from the sidebar rows.
-  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true },
-  // Ask Salem is a destination you summon (Home entry, ⌘K "Go to", deep link,
-  // or the split-pane widget's expand button) — deliberately NOT a sidebar row
-  // (see salem-home-entry.test.ts). navHidden keeps it reachable everywhere else.
-  { id: "salem", label: "Ask Salem", iconName: "ph:cat", description: "Ask the docs familiar — grounded answers from the Coven index and your Cave", navHidden: true },
-  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' crafts and skills", quiet: true },
-  // Submissions (OpenCoven runtime/harness submit) is hidden from the nav; the
-  // mode + page remain reachable programmatically but aren't surfaced here.
-  //
-  // GitHub — the standalone assigned-work surface, restored when the Code
-  // workbench moved into the Coding familiar's room (cave-cc5r). Every
-  // familiar keeps this row (with the assigned-work badge) EXCEPT while the
-  // Code room is visible for the active familiar — the room carries its own
-  // GitHub tab, so the workspace passes hideGithubRow to avoid double-listing.
-  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Assigned PRs, issues, and review requests across your repos", badge: (p) => badgeText(p.githubAssignedCount), quiet: true },
-];
-
-// Rows actually rendered in the sidebar — everything except on-demand surfaces
-// (navHidden), which stay in FOLDER_MODES for the ⌘K palette + ⌘-number launcher.
-const VISIBLE_MODES = FOLDER_MODES.filter((fm) => !fm.navHidden);
-
-export { FOLDER_MODES };
 
 
 function FolderRow({
@@ -245,7 +187,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
 
   // Projects lives only inside the Familiars surface's Projects tab now (and ⌘9 /
   // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
-  const handleModeSelect = (id: FolderMode) => {
+  const handleModeSelect = (id: WorkspaceNavMode) => {
     onModeChange(id);
   };
 
@@ -292,7 +234,10 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        {(props.hideGithubRow ? VISIBLE_MODES.filter((fm) => fm.id !== "github") : VISIBLE_MODES).map((fm, i, rows) => (
+        {(props.hideGithubRow
+          ? VISIBLE_WORKSPACE_NAV_ITEMS.filter((item) => item.id !== "github")
+          : VISIBLE_WORKSPACE_NAV_ITEMS
+        ).map((fm: WorkspaceNavItem, i, rows) => (
           <FolderRow
             key={fm.id}
             id={fm.id}
@@ -302,7 +247,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             // Marketplace hub lit); pages open as split tiles get a lighter
             // "open in split" state instead. Derivation in lib/sidebar-nav-state.
             state={sidebarRowState(fm.id, mode, props.splitPageModes)}
-            badge={fm.badge?.(props)}
+            badge={MODE_BADGES[fm.id]?.(props)}
             kbd={fm.kbd}
             description={fm.description}
             quiet={fm.quiet}

--- a/src/components/sidepanel-badges.test.ts
+++ b/src/components/sidepanel-badges.test.ts
@@ -10,9 +10,10 @@ assert.match(sidebar, /function badgeText\(n\?: number\)/, "badge formatter exis
 assert.match(sidebar, /boardOpenCount\?: number/, "sidebar accepts a board count");
 assert.match(sidebar, /scheduleNeedsCount\?: number/, "sidebar accepts a schedules count");
 assert.match(sidebar, /githubAssignedCount\?: number/, "sidebar accepts a github count");
-assert.match(sidebar, /badge: \(p\) => badgeText\(p\.boardOpenCount\)/, "Board nav badge wired");
-assert.match(sidebar, /badge: \(p\) => badgeText\(p\.scheduleNeedsCount\)/, "Schedules nav badge wired");
-assert.match(sidebar, /badge: \(p\) => badgeText\(p\.githubAssignedCount\)/, "GitHub nav badge wired");
+assert.match(sidebar, /board: \(props\) => badgeText\(props\.boardOpenCount\)/, "Board nav badge wired");
+assert.match(sidebar, /inbox: \(props\) => badgeText\(props\.scheduleNeedsCount\)/, "Rituals nav badge wired");
+assert.match(sidebar, /github: \(props\) => badgeText\(props\.githubAssignedCount\)/, "GitHub nav badge wired");
+assert.match(sidebar, /badge=\{MODE_BADGES\[fm\.id\]\?\.\(props\)\}/, "registry rows receive host-specific badges");
 
 assert.match(workspace, /boardOpenCount=\{boardTaskCount\}/, "board count passed to sidebar");
 assert.match(workspace, /scheduleNeedsCount=\{scheduleNeedsCount\}/, "schedules count passed");

--- a/src/components/terminal-scope.test.ts
+++ b/src/components/terminal-scope.test.ts
@@ -6,7 +6,7 @@ const read = (rel) => readFileSync(new URL(rel, import.meta.url), "utf8");
 
 const workspaceMode = read("../lib/workspace-mode.ts");
 const workspace = read("./workspace.tsx");
-const sidebar = read("./sidebar-minimal.tsx");
+const navigation = read("../lib/workspace-navigation.ts");
 const settings = read("./settings-shell.tsx");
 const config = read("../lib/cave-config.ts");
 const slashCommands = read("../lib/slash-commands.ts");
@@ -16,7 +16,7 @@ assert.doesNotMatch(workspaceMode, /[|]\s*"terminal"/, "terminal is not a standa
 assert.doesNotMatch(workspace, /terminal:\s*"Terminal"/, "workspace title map does not expose a Terminal page");
 assert.doesNotMatch(workspace, /setMode\("terminal"\)/, "workspace never navigates to a standalone Terminal page");
 assert.doesNotMatch(workspace, /mode === "terminal"/, "workspace does not branch around a standalone Terminal page");
-assert.doesNotMatch(sidebar, /id:\s*"terminal"/, "sidebar has no Terminal nav row");
+assert.doesNotMatch(navigation, /id:\s*"terminal"/, "the navigation registry has no Terminal row");
 assert.doesNotMatch(settings, /key:\s*"terminal"/, "settings add-ons do not expose Terminal as an add-on");
 assert.doesNotMatch(config, /terminal\?:\s*boolean|terminal:\s*false|terminal:\s*parsed\.addons\?\.terminal/, "config has no terminal add-on flag");
 assert.doesNotMatch(slashCommands, /\/terminal|\/comux|integrated terminal view/i, "slash commands do not open a standalone Terminal page");

--- a/src/components/weave-rail.test.ts
+++ b/src/components/weave-rail.test.ts
@@ -57,6 +57,8 @@ assert.match(view, /binds one protected surface to one\s+writer/, "thread refere
 // --- page shell --------------------------------------------------------------
 assert.match(page, /dr-page/, "page uses the standard shell");
 assert.match(page, /Weaves<\/span>/, "breadcrumb names the surface");
+assert.match(page, /href="\/\?mode=grimoire"/, "Weaves breadcrumbs back to Memories");
+assert.match(page, /href="\/proposals"/, "Weaves exposes the nested proposal decision queue");
 assert.match(page, /never healthy/, "page states the fail-closed rendering rule");
 
 console.log("weave-rail wiring: all assertions passed");

--- a/src/components/workflows-view.test.ts
+++ b/src/components/workflows-view.test.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 const mode = readFileSync(new URL("../lib/workspace-mode.ts", import.meta.url), "utf8");
 const client = readFileSync(new URL("../lib/workflows.ts", import.meta.url), "utf8");
@@ -11,7 +11,7 @@ const client = readFileSync(new URL("../lib/workflows.ts", import.meta.url), "ut
 assert.doesNotMatch(workspace, /import \{ WorkflowsView \}/, "Workspace should not import the legacy Workflows page");
 assert.doesNotMatch(workspace, /mode === "workflows"/, "Workspace should not route to a Workflows page");
 assert.doesNotMatch(workspace, /setMode\("workflows"\)/, "Workspace should not navigate into the removed Workflows page");
-assert.doesNotMatch(sidebar, /\{ id: "workflows", label: "Workflows"/, "Sidebar should not expose Workflows as a page");
+assert.doesNotMatch(navigation, /\{ id: "workflows", label: "Workflows"/, "The navigation registry should not expose Workflows as a page");
 assert.doesNotMatch(mode, /\|\s*"workflows"/, "WorkspaceMode should not include the removed Workflows page");
 assert.doesNotMatch(globals, /workflows\.css/, "Global CSS should not import the removed Workflow page styles");
 assert.equal(existsSync(new URL("./workflows-view.tsx", import.meta.url)), false, "Legacy Workflows page component should be removed");

--- a/src/components/workspace-alias-modes.test.ts
+++ b/src/components/workspace-alias-modes.test.ts
@@ -13,6 +13,7 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 const urlState = readFileSync(new URL("../lib/workspace-url-state.ts", import.meta.url), "utf8");
 const navState = readFileSync(new URL("../lib/sidebar-nav-state.ts", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 
 // ── Rewrite aliases: setMode replaces them, so `mode` never holds them ───────
 
@@ -106,9 +107,14 @@ assert.match(
   "sidebar-nav-state derives row highlighting from the shared MODE_ALIASES table",
 );
 assert.match(
+  navigation,
+  /export type WorkspaceNavMode = WorkspaceMode/,
+  "the shared navigation registry reuses the WorkspaceMode union instead of a drifting copy",
+);
+assert.match(
   sidebar,
-  /export type FolderMode = WorkspaceMode/,
-  "the sidebar reuses the WorkspaceMode union instead of a drifting copy",
+  /type WorkspaceNavMode,[\s\S]*from "@\/lib\/workspace-navigation"/,
+  "the sidebar consumes the registry's mode type instead of declaring a component-local alias",
 );
 
 console.log("workspace-alias-modes: ok");

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
+const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
 const topBar = readFileSync(new URL("./top-bar.tsx", import.meta.url), "utf8");
 const workspaceMode = readFileSync(
   new URL("../lib/workspace-mode.ts", import.meta.url),
@@ -167,9 +168,9 @@ assert.doesNotMatch(
 );
 
 assert.doesNotMatch(
-  sidebar,
+  navigation,
   /\{ id: "agents", label: "Familiars"/,
-  "Sidebar should not expose a Familiars subpage in Work",
+  "The navigation registry should not expose a Familiars subpage",
 );
 
 assert.doesNotMatch(
@@ -293,17 +294,17 @@ assert.doesNotMatch(
 );
 
 assert.match(
-  sidebar,
+  navigation,
   /\{ id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description:/,
-  "Sidebar Home keeps its shortcut hint",
+  "Home keeps its canonical shortcut hint",
 );
 
 assert.match(
-  sidebar,
+  navigation,
   /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
-  "Browser is kept for ⌘5/palette but navHidden from the sidebar rows",
+  "Browser is kept for ⌘5/palette but navHidden from rendered navigation rows",
 );
 
-assert.doesNotMatch(sidebar, /id:\s*"terminal"/, "Sidebar does not expose Terminal as a standalone destination");
+assert.doesNotMatch(navigation, /id:\s*"terminal"/, "Navigation does not expose Terminal as a standalone destination");
 
 console.log("workspace-familiars-landing: all assertions passed");

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+function read(relativePath) {
+  try {
+    return readFileSync(new URL(relativePath, import.meta.url), "utf8");
+  } catch {
+    return "";
+  }
+}
+
+const registry = read("./workspace-navigation.ts");
+const sidebar = read("../components/sidebar-minimal.tsx");
+const standalone = read("../components/analytics-page-shell.tsx");
+const mobile = read("../components/mobile-bottom-tabs.tsx");
+const palette = read("../components/command-palette.tsx");
+
+assert.match(
+  registry,
+  /export const WORKSPACE_NAV_ITEMS/,
+  "workspace navigation metadata lives in a lightweight shared registry",
+);
+assert.match(
+  registry,
+  /export const VISIBLE_WORKSPACE_NAV_ITEMS = WORKSPACE_NAV_ITEMS\.filter\(\(item\) => !item\.navHidden\)/,
+  "the registry owns visible navigation derivation",
+);
+assert.match(
+  registry,
+  /export const PRIMARY_WORKSPACE_NAV_ITEMS = VISIBLE_WORKSPACE_NAV_ITEMS\.filter\(\(item\) => !item\.quiet\)/,
+  "the registry owns the promoted mobile destinations",
+);
+
+assert.match(
+  sidebar,
+  /import \{[\s\S]*?VISIBLE_WORKSPACE_NAV_ITEMS,[\s\S]*?type WorkspaceNavItem,[\s\S]*?type WorkspaceNavMode,[\s\S]*?\} from "@\/lib\/workspace-navigation"/,
+  "the desktop sidebar consumes the shared visible registry",
+);
+assert.doesNotMatch(sidebar, /const FOLDER_MODES/, "the sidebar no longer owns a duplicate route registry");
+assert.doesNotMatch(sidebar, /export \{ FOLDER_MODES \}/, "the obsolete component-level registry export is removed");
+assert.doesNotMatch(sidebar, /export type FolderMode/, "the obsolete component-level mode alias is removed");
+
+assert.match(
+  standalone,
+  /import \{ VISIBLE_WORKSPACE_NAV_ITEMS \} from "@\/lib\/workspace-navigation"/,
+  "standalone pages consume the lightweight registry without importing SidebarMinimal",
+);
+assert.match(
+  mobile,
+  /import \{ PRIMARY_WORKSPACE_NAV_ITEMS \} from "@\/lib\/workspace-navigation"/,
+  "mobile tabs consume the promoted registry",
+);
+assert.match(
+  palette,
+  /import \{ WORKSPACE_NAV_ITEMS, type WorkspaceNavMode \} from "@\/lib\/workspace-navigation"/,
+  "the command palette consumes all canonical and on-demand destinations",
+);
+
+console.log("workspace-navigation registry: ok");

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -1,0 +1,31 @@
+import type { IconName } from "@/lib/icon";
+import type { WorkspaceMode } from "@/lib/workspace-mode";
+
+export type WorkspaceNavMode = WorkspaceMode;
+
+export type WorkspaceNavItem = {
+  id: WorkspaceNavMode;
+  label: string;
+  iconName: IconName;
+  kbd?: string;
+  description: string;
+  quiet?: boolean;
+  navHidden?: boolean;
+};
+
+export const WORKSPACE_NAV_ITEMS: readonly WorkspaceNavItem[] = [
+  { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
+  { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects" },
+  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Inbox, calendar, and scheduled jobs in one place" },
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in Memories", quiet: true, navHidden: true },
+  { id: "grimoire", label: "Memories", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
+  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true },
+  { id: "salem", label: "Ask Salem", iconName: "ph:cat", description: "Ask the docs familiar — grounded answers from the Coven index and your Cave", navHidden: true },
+  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Browse the store and manage your familiars' crafts and skills", quiet: true },
+  { id: "github", label: "GitHub", iconName: "ph:github-logo", description: "Assigned PRs, issues, and review requests across your repos", quiet: true },
+];
+
+export const VISIBLE_WORKSPACE_NAV_ITEMS = WORKSPACE_NAV_ITEMS.filter((item) => !item.navHidden);
+
+export const PRIMARY_WORKSPACE_NAV_ITEMS = VISIBLE_WORKSPACE_NAV_ITEMS.filter((item) => !item.quiet);


### PR DESCRIPTION
## Summary
- centralize workspace navigation metadata for desktop, mobile, command palette, and standalone rails
- add clear Memories → Weaves → Proposals entry and return paths and repair profile parent links
- enforce route reachability and reject invalid static workspace-mode links

## Verification
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm check:tests-wired` (1,318 files)
- [x] `pnpm test:app` (959 files)
- [x] `pnpm build`
- [x] Chromium walkthrough: Memories → Weaves → Proposals → Weaves → Memories; familiar profile → Familiars; human profile → Settings; standalone rail destinations

## Tracking
- Bead: `cave-uzkht`