### PR TITLE
feat(projects): validate the setup modal's fields and add a repo picker

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -197,6 +197,7 @@ export const SUITES = {
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/chat-add-project.test.ts",
     "src/lib/project-setup-offer.test.ts",
+    "src/lib/project-setup-validation.test.ts",
     "src/lib/project-registry-events.test.ts",
     "src/lib/first-project-gate-retry.test.ts",
     "src/lib/first-project-gate-policy.test.ts",
@@ -1367,6 +1368,8 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  // Imports the module under test, which resolves "@/lib/github-repo-link".
+  "src/lib/project-setup-validation.test.ts",
   "src/lib/use-role-surfaces-loader.test.ts",
   "src/components/role-surfaces/researcher-status.test.ts",
   "src/lib/dev-shell-recovery.test.ts",

--- a/src/components/project-setup-modal.test.ts
+++ b/src/components/project-setup-modal.test.ts
@@ -63,4 +63,57 @@ assert.match(
   "create failures surface the server's error body, not a generic guess",
 );
 
+// ── Live field validation (Projects.dc.html handoff) ───────────────────────
+// The submit gate and the per-field messages must come from ONE module, or
+// they drift and a field goes green on input the submit then rejects.
+assert.match(
+  src,
+  /import \{[\s\S]{0,240}?projectSetupBlocked,[\s\S]{0,240}?\} from "@\/lib\/project-setup-validation"/,
+  "field rules and the submit gate come from the shared validation module",
+);
+assert.match(
+  src,
+  /const blocked = projectSetupBlocked\(name, repoDraft\)/,
+  "the submit gate is computed from the same inputs the fields validate",
+);
+assert.match(src, /disabled=\{blocked\}/, "Create is blocked while any field is invalid");
+// Errors wait for a touch so an opening modal never greets you in red.
+assert.match(
+  src,
+  /const \[touched, setTouched\]/,
+  "field messages are gated on a touch, not shown from first render",
+);
+assert.match(
+  src,
+  /aria-invalid=\{touched\.name && nameError \? true : undefined\}/,
+  "an invalid name is announced, not only coloured",
+);
+assert.match(
+  src,
+  /aria-describedby=\{touched\.repo && repoError \? "project-setup-repo-error" : undefined\}/,
+  "the repo error is wired to its field for assistive tech",
+);
+
+// ── Repository suggester ───────────────────────────────────────────────────
+assert.match(
+  src,
+  /fetch\("\/api\/github\/repos"/,
+  "suggestions come from the existing repos route, not a new backend",
+);
+assert.match(
+  src,
+  /if \(!repoPickerOpen \|\| repos !== null \|\| reposState === "loading"\) return;/,
+  "the repo list is fetched lazily on first open, never on mount",
+);
+assert.match(
+  src,
+  /data\?\.configured === false[\s\S]{0,160}?setReposState\("unconfigured"\)/,
+  "a missing GitHub token says so instead of rendering an empty list",
+);
+assert.match(
+  src,
+  /applyRepoSuggestion\(repo, name\)/,
+  "picking a suggestion routes through the shared fill rule",
+);
+
 console.log("project-setup-modal.test.ts OK");

--- a/src/components/project-setup-modal.tsx
+++ b/src/components/project-setup-modal.tsx
@@ -1,12 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Icon } from "@/lib/icon";
 import type { CaveProject } from "@/lib/cave-projects-types";
 import { projectNameForRoot, type CreateProjectOptions } from "@/lib/chat-add-project";
 import { projectTint } from "@/lib/comux-projects";
 import { normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
+import type { RepoItem } from "@/lib/home-feed";
+import {
+  applyRepoSuggestion,
+  filterRepoSuggestions,
+  formatPushedAt,
+  projectSetupBlocked,
+  validateProjectName,
+  validateRepoDraft,
+} from "@/lib/project-setup-validation";
+import { Popover, PopoverBody } from "@/components/ui/popover";
 import type { ProjectAccessLevel } from "@/lib/project-access-levels";
 import { emitProjectRegistryMutation } from "@/lib/project-registry-events";
 import { PROJECT_SETUP_COLOR_CHOICES } from "@/lib/project-setup-offer";
@@ -71,6 +81,14 @@ export function ProjectSetupModal({
   const [createdProject, setCreatedProject] = useState<CaveProject | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Field messages appear only once a field has been touched, so a freshly
+  // opened modal never greets you in red — but the submit gate below applies
+  // from the first render regardless.
+  const [touched, setTouched] = useState<{ name: boolean; repo: boolean }>({ name: false, repo: false });
+  const [repoPickerOpen, setRepoPickerOpen] = useState(false);
+  const [repos, setRepos] = useState<RepoItem[] | null>(null);
+  const [reposState, setReposState] = useState<"idle" | "loading" | "error" | "unconfigured">("idle");
+  const repoPickerRef = useRef<HTMLButtonElement | null>(null);
 
   // Re-seed per folder: prefill the name from the leaf, probe groups +
   // supreme (one grants fetch) and the git origin (GitHub prefill). Both
@@ -86,6 +104,8 @@ export function ProjectSetupModal({
     setCreatedProject(null);
     setBusy(false);
     setError(null);
+    setTouched({ name: false, repo: false });
+    setRepoPickerOpen(false);
     let cancelled = false;
     void (async () => {
       try {
@@ -123,8 +143,45 @@ export function ProjectSetupModal({
     };
   }, [root]);
 
+  // The repo list is fetched the first time the picker opens, never on mount —
+  // opening this modal shouldn't spend a GitHub round-trip you may not want.
+  useEffect(() => {
+    if (!repoPickerOpen || repos !== null || reposState === "loading") return;
+    let cancelled = false;
+    setReposState("loading");
+    void (async () => {
+      try {
+        const res = await fetch("/api/github/repos", { cache: "no-store" });
+        const data = (await res.json()) as { items?: RepoItem[]; configured?: boolean };
+        if (cancelled) return;
+        // No token: say so plainly instead of showing an empty list that reads
+        // as "you have no repositories".
+        if (data?.configured === false) {
+          setReposState("unconfigured");
+          return;
+        }
+        setRepos(Array.isArray(data?.items) ? data.items : []);
+        setReposState("idle");
+      } catch {
+        if (!cancelled) setReposState("error");
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [repoPickerOpen, repos, reposState]);
+
+  const suggestions = useMemo(
+    () => (repos ? filterRepoSuggestions(repos, repoDraft) : []),
+    [repos, repoDraft],
+  );
+
   if (!root) return null;
 
+  const nameError = validateProjectName(name);
+  const repoError = validateRepoDraft(repoDraft);
+  // Gates submit from the first render; the messages wait for a touch.
+  const blocked = projectSetupBlocked(name, repoDraft);
   const isSupremeFamiliar = Boolean(familiar.id) && familiar.id === supremeFamiliarId;
   const memberGroups = familiar.id
     ? groups.filter((group) => group.memberFamiliarIds.includes(familiar.id as string))
@@ -237,7 +294,13 @@ export function ProjectSetupModal({
           <Button variant="ghost" onClick={onClose} disabled={busy}>
             Cancel
           </Button>
-          <Button variant="primary" onClick={() => void submit()} loading={busy}>
+          <Button
+            variant="primary"
+            onClick={() => void submit()}
+            loading={busy}
+            disabled={blocked}
+            title={blocked ? (nameError ?? repoError ?? undefined) : undefined}
+          >
             {busy ? "Creating…" : "Create project"}
           </Button>
         </>
@@ -263,11 +326,21 @@ export function ProjectSetupModal({
         <input
           value={name}
           onChange={(e) => setName(e.target.value)}
+          onBlur={() => setTouched((prev) => ({ ...prev, name: true }))}
           aria-label="Project name"
+          aria-invalid={touched.name && nameError ? true : undefined}
+          aria-describedby={touched.name && nameError ? "project-setup-name-error" : undefined}
           spellCheck={false}
-          className="focus-ring w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none"
+          className={`focus-ring w-full rounded-[var(--radius-control)] border bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none ${
+            touched.name && nameError ? "border-[var(--danger-border)]" : "border-[var(--border-hairline)]"
+          }`}
         />
       </label>
+      {touched.name && nameError ? (
+        <p id="project-setup-name-error" className="mt-1.5 text-[length:var(--text-xs)] text-[var(--danger-text)]">
+          {nameError}
+        </p>
+      ) : null}
 
       <div className="mt-4">
         <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
@@ -305,27 +378,112 @@ export function ProjectSetupModal({
         </p>
       </div>
 
-      <label className="mt-4 block">
-        <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
-          GitHub repository
-        </div>
-        <input
-          value={repoDraft}
-          onChange={(e) => {
-            setRepoDraft(e.target.value);
-            setError(null);
-          }}
-          placeholder="owner/repo or https://github.com/owner/repo"
-          aria-label="GitHub repository"
-          spellCheck={false}
-          autoCapitalize="off"
-          autoCorrect="off"
-          className="focus-ring w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
-        />
-      </label>
-      <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-        Optional — ties the project to a repository. Leave empty to skip.
-      </p>
+      <div className="mt-4">
+        <label className="block">
+          <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+            GitHub repository
+          </div>
+          <div
+            className={`focus-within:ring-1 flex items-center rounded-[var(--radius-control)] border bg-[var(--bg-base)] ${
+              touched.repo && repoError ? "border-[var(--danger-border)]" : "border-[var(--border-hairline)]"
+            }`}
+          >
+            <input
+              value={repoDraft}
+              onChange={(e) => {
+                setRepoDraft(e.target.value);
+                setError(null);
+              }}
+              onBlur={() => setTouched((prev) => ({ ...prev, repo: true }))}
+              placeholder="owner/repo or https://github.com/owner/repo"
+              aria-label="GitHub repository"
+              aria-invalid={touched.repo && repoError ? true : undefined}
+              aria-describedby={touched.repo && repoError ? "project-setup-repo-error" : undefined}
+              spellCheck={false}
+              autoCapitalize="off"
+              autoCorrect="off"
+              className="focus-ring min-w-0 flex-1 rounded-[var(--radius-control)] bg-transparent px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+            />
+            {/* Typing owner/repo from memory is the slow path; this is the list. */}
+            <button
+              ref={repoPickerRef}
+              type="button"
+              className="focus-ring flex flex-none items-center gap-1.5 self-stretch border-l border-[var(--border-hairline)] px-2.5 text-[length:var(--text-2xs)] uppercase tracking-wider text-[var(--text-muted)] hover:text-[var(--text-primary)]"
+              aria-haspopup="menu"
+              aria-expanded={repoPickerOpen}
+              aria-label="Pick from your GitHub repositories"
+              title="Pick from your GitHub repositories"
+              onClick={() => setRepoPickerOpen((open) => !open)}
+            >
+              <Icon name="ph:github-logo" width={13} aria-hidden />
+              Pick
+            </button>
+          </div>
+        </label>
+        <Popover
+          open={repoPickerOpen}
+          onOpenChange={setRepoPickerOpen}
+          anchorRef={repoPickerRef}
+          placement="bottom-end"
+          minWidth={320}
+          ariaLabel="Your GitHub repositories"
+        >
+          <PopoverBody role="menu" ariaLabel="Your GitHub repositories">
+            {reposState === "loading" ? (
+              <p className="px-2 py-2 text-[length:var(--text-xs)] text-[var(--text-muted)]">Loading repositories…</p>
+            ) : reposState === "unconfigured" ? (
+              <p className="px-2 py-2 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                Add a GitHub token in Settings to pick from your repositories.
+              </p>
+            ) : reposState === "error" ? (
+              <p className="px-2 py-2 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                Couldn’t reach GitHub — type <code>owner/repo</code> instead.
+              </p>
+            ) : suggestions.length === 0 ? (
+              <p className="px-2 py-2 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                No repository matches — keep typing <code>owner/repo</code>, or paste a link.
+              </p>
+            ) : (
+              suggestions.slice(0, 12).map((repo) => (
+                <button
+                  key={repo.id}
+                  type="button"
+                  role="menuitem"
+                  className="focus-ring flex w-full items-center gap-2 rounded-[var(--radius-sm)] px-2 py-1.5 text-left hover:bg-[var(--bg-hover)]"
+                  onClick={() => {
+                    const next = applyRepoSuggestion(repo, name);
+                    setRepoDraft(next.repoDraft);
+                    setName(next.name);
+                    setError(null);
+                    setRepoPickerOpen(false);
+                  }}
+                >
+                  <span className="min-w-0 flex-1 truncate font-mono text-[length:var(--text-xs)] text-[var(--text-primary)]">
+                    {repo.fullName}
+                  </span>
+                  {repo.language ? (
+                    <span className="flex-none text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                      {repo.language}
+                    </span>
+                  ) : null}
+                  <span className="w-16 flex-none text-right text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                    {formatPushedAt(repo.pushedAt, Date.now())}
+                  </span>
+                </button>
+              ))
+            )}
+          </PopoverBody>
+        </Popover>
+        {touched.repo && repoError ? (
+          <p id="project-setup-repo-error" className="mt-1.5 text-[length:var(--text-xs)] text-[var(--danger-text)]">
+            {repoError}
+          </p>
+        ) : (
+          <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+            Optional — ties the project to a repository. Leave empty to skip.
+          </p>
+        )}
+      </div>
 
       <div className="mt-4">
         <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">

--- a/src/lib/project-setup-validation.test.ts
+++ b/src/lib/project-setup-validation.test.ts
@@ -1,0 +1,97 @@
+// Rules for the "Set up as project" modal's fields and repo suggester.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  PROJECT_NAME_MAX,
+  applyRepoSuggestion,
+  filterRepoSuggestions,
+  formatPushedAt,
+  projectSetupBlocked,
+  titleCaseProjectName,
+  validateProjectName,
+  validateRepoDraft,
+} from "./project-setup-validation.ts";
+
+test("a project must be named, and briefly", () => {
+  assert.equal(validateProjectName("Coven Cave"), null);
+  assert.match(validateProjectName("") ?? "", /Give the project a name/);
+  assert.match(validateProjectName("   ") ?? "", /Give the project a name/, "whitespace is not a name");
+  assert.equal(validateProjectName("x".repeat(PROJECT_NAME_MAX)), null, "the limit itself is allowed");
+  assert.match(validateProjectName("x".repeat(PROJECT_NAME_MAX + 1)) ?? "", /under 48 characters/);
+});
+
+test("the repository is optional, but a non-empty one must be a real GitHub repo", () => {
+  assert.equal(validateRepoDraft(""), null, "unlinked projects are first-class");
+  assert.equal(validateRepoDraft("   "), null);
+  assert.equal(validateRepoDraft("OpenCoven/coven-cave"), null);
+  assert.equal(validateRepoDraft("https://github.com/OpenCoven/coven-cave"), null);
+  assert.match(validateRepoDraft("not a repo") ?? "", /owner\/repo/);
+  assert.match(validateRepoDraft("https://gitlab.com/a/b") ?? "", /owner\/repo/, "only GitHub links normalize");
+});
+
+// The bug this guards: live validation and submit validation written twice
+// drift, and a field goes green on input that submit then rejects.
+test("the submit gate agrees with the per-field rules", () => {
+  assert.equal(projectSetupBlocked("Coven Cave", ""), false);
+  assert.equal(projectSetupBlocked("Coven Cave", "OpenCoven/coven-cave"), false);
+  assert.equal(projectSetupBlocked("", "OpenCoven/coven-cave"), true, "a bad name blocks");
+  assert.equal(projectSetupBlocked("Coven Cave", "nonsense"), true, "a bad repo blocks");
+});
+
+test("repo slugs become names a human would have typed", () => {
+  assert.equal(titleCaseProjectName("hekate-agent"), "Hekate Agent");
+  assert.equal(titleCaseProjectName("coven_cli"), "Coven CLI");
+  assert.equal(titleCaseProjectName("terminal-ui"), "Terminal UI");
+  assert.equal(titleCaseProjectName("coven-cave"), "Coven Cave");
+  assert.equal(titleCaseProjectName("iosApp"), "iOS App", "camelCase splits before the acronym map applies");
+  assert.equal(titleCaseProjectName("opencoven"), "OpenCoven");
+  assert.equal(titleCaseProjectName(""), "");
+  // Typing "coven-" mid-word must not jam the next word onto the last one.
+  assert.equal(titleCaseProjectName("coven-"), "Coven ");
+});
+
+test("suggestions narrow by what is typed, including a pasted URL", () => {
+  const repos = [
+    { fullName: "OpenCoven/coven-cave", owner: "OpenCoven", name: "coven-cave" },
+    { fullName: "OpenCoven/coven-code", owner: "OpenCoven", name: "coven-code" },
+    { fullName: "OpenKnots/terminal-ui", owner: "OpenKnots", name: "terminal-ui" },
+  ];
+  assert.equal(filterRepoSuggestions(repos, "").length, 3, "an empty query shows everything");
+  assert.deepEqual(
+    filterRepoSuggestions(repos, "terminal").map((r) => r.fullName),
+    ["OpenKnots/terminal-ui"],
+  );
+  assert.equal(filterRepoSuggestions(repos, "OPENCOVEN").length, 2, "matching is case-insensitive");
+  assert.deepEqual(
+    filterRepoSuggestions(repos, "https://github.com/OpenCoven/coven-code").map((r) => r.fullName),
+    ["OpenCoven/coven-code"],
+    "a pasted URL still finds the row it names",
+  );
+  assert.equal(filterRepoSuggestions(repos, "nothing-here").length, 0);
+});
+
+test("picking a suggestion fills the repo, and the name only when it is free", () => {
+  const repo = { fullName: "OpenCoven/hekate-agent", owner: "OpenCoven", name: "hekate-agent" };
+  assert.deepEqual(applyRepoSuggestion(repo, ""), {
+    repoDraft: "OpenCoven/hekate-agent",
+    name: "Hekate Agent",
+  });
+  assert.deepEqual(
+    applyRepoSuggestion(repo, "My Deliberate Name"),
+    { repoDraft: "OpenCoven/hekate-agent", name: "My Deliberate Name" },
+    "a name the user already wrote is never overwritten by a later repo pick",
+  );
+});
+
+test("pushed-at reads as an age, and never as NaN", () => {
+  const now = Date.parse("2026-07-29T12:00:00Z");
+  assert.equal(formatPushedAt(new Date(now - 30_000).toISOString(), now), "just now");
+  assert.equal(formatPushedAt(new Date(now - 27 * 60_000).toISOString(), now), "27m ago");
+  assert.equal(formatPushedAt(new Date(now - 2 * 3_600_000).toISOString(), now), "2h ago");
+  assert.equal(formatPushedAt(new Date(now - 3 * 86_400_000).toISOString(), now), "3d ago");
+  assert.equal(formatPushedAt(null, now), "", "a repo with no push date shows nothing");
+  assert.equal(formatPushedAt("not-a-date", now), "", "an unparseable date shows nothing, not NaN");
+});
+
+console.log("project-setup-validation.test.ts ✓");

--- a/src/lib/project-setup-validation.ts
+++ b/src/lib/project-setup-validation.ts
@@ -1,0 +1,156 @@
+// Field rules and repository-suggestion helpers for the "Set up as project"
+// modal (Projects.dc.html handoff). Kept pure and free of React/DOM so the
+// rules can be tested directly and — critically — so the modal validates a
+// field with the SAME function that gates its submit. When live validation and
+// submit validation are written twice they drift, and the field goes green on
+// input the submit then rejects.
+
+import { normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
+
+/** `null` = the field is acceptable; a string is the message to show. */
+export type FieldError = string | null;
+
+/** Longest project name the registry and the rails render without truncating. */
+export const PROJECT_NAME_MAX = 48;
+
+/**
+ * Words that must not be sentence-cased when a repo slug becomes a project
+ * name. Keyed lowercase; the value is the exact casing to emit.
+ */
+const PRESERVED_CASE: Record<string, string> = {
+  api: "API",
+  cli: "CLI",
+  css: "CSS",
+  db: "DB",
+  html: "HTML",
+  id: "ID",
+  ios: "iOS",
+  js: "JS",
+  json: "JSON",
+  macos: "macOS",
+  mcp: "MCP",
+  msi: "MSI",
+  npm: "npm",
+  os: "OS",
+  pat: "PAT",
+  pr: "PR",
+  sdk: "SDK",
+  ts: "TS",
+  tts: "TTS",
+  ui: "UI",
+  ux: "UX",
+  yaml: "YAML",
+  ci: "CI",
+  github: "GitHub",
+  gitlab: "GitLab",
+  opencoven: "OpenCoven",
+  openknots: "OpenKnots",
+  covencave: "CovenCave",
+  cave: "Cave",
+};
+
+/**
+ * Turn a repo/folder leaf into a project name a human would have typed:
+ * `hekate-agent` → `Hekate Agent`, `coven_cli` → `Coven CLI`, `iosApp` → `iOS App`.
+ * Splits on hyphens, underscores, whitespace and camelCase boundaries.
+ */
+export function titleCaseProjectName(raw: string): string {
+  if (typeof raw !== "string") return "";
+  // A trailing separator means the user is mid-word; keep the space so typing
+  // "coven-" then "cave" doesn't jam into "CovenCave".
+  const trailingSpace = /[-_\s]$/.test(raw) ? " " : "";
+  const words = raw
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[-_\s]+/)
+    .filter(Boolean);
+  if (words.length === 0) return trailingSpace;
+  return (
+    words
+      .map((word) => PRESERVED_CASE[word.toLowerCase()] ?? word.charAt(0).toUpperCase() + word.slice(1))
+      .join(" ") + trailingSpace
+  );
+}
+
+/** A project must be named, and briefly. */
+export function validateProjectName(value: string): FieldError {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return "Give the project a name.";
+  if (trimmed.length > PROJECT_NAME_MAX) return `Keep it under ${PROJECT_NAME_MAX} characters.`;
+  return null;
+}
+
+/**
+ * The repository link is OPTIONAL here (unlike the mock, where a remote is
+ * required) — an unlinked project is a first-class thing in the Cave. So an
+ * empty field is valid; only a non-empty one that isn't a GitHub repo fails.
+ * Delegates to the same normalizer the submit path uses.
+ */
+export function validateRepoDraft(value: string): FieldError {
+  const trimmed = (value ?? "").trim();
+  if (!trimmed) return null;
+  if (!normalizeGitHubRepoUrl(trimmed)) {
+    return "Expected owner/repo or a https://github.com/owner/repo link.";
+  }
+  return null;
+}
+
+/** True when every field is acceptable — the submit gate. */
+export function projectSetupBlocked(name: string, repoDraft: string): boolean {
+  return Boolean(validateProjectName(name) || validateRepoDraft(repoDraft));
+}
+
+/** Minimal shape the suggester needs; matches RepoItem structurally. */
+export type RepoSuggestion = {
+  fullName: string;
+  owner: string;
+  name: string;
+  language?: string | null;
+  pushedAt?: string | null;
+};
+
+/**
+ * Narrow the repo list by what's already typed. The query is matched against
+ * `owner/repo` after stripping any github.com prefix, so pasting a full URL
+ * still finds the row it names.
+ */
+export function filterRepoSuggestions<T extends RepoSuggestion>(repos: T[], query: string): T[] {
+  const needle = (query ?? "")
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/^www\./i, "")
+    .replace(/^github\.com\//i, "")
+    .toLowerCase();
+  if (!needle) return repos;
+  return repos.filter((repo) => repo.fullName.toLowerCase().includes(needle));
+}
+
+/**
+ * What picking a suggestion writes into the form. The mock fills remote, local
+ * path and name together; we own no local-path field here, so it fills the two
+ * we do have — and the name only when the user hasn't already written one, so
+ * a deliberate name is never overwritten by a later repo pick.
+ */
+export function applyRepoSuggestion(
+  repo: RepoSuggestion,
+  currentName: string,
+): { repoDraft: string; name: string } {
+  return {
+    repoDraft: repo.fullName,
+    name: currentName.trim() ? currentName : titleCaseProjectName(repo.name),
+  };
+}
+
+/** "2h ago" / "Jul 6" for the suggestion row's trailing column. */
+export function formatPushedAt(iso: string | null | undefined, now: number): string {
+  if (!iso) return "";
+  const then = Date.parse(iso);
+  if (!Number.isFinite(then)) return "";
+  const minutes = Math.floor((now - then) / 60000);
+  if (minutes < 1) return "just now";
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(then).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}


### PR DESCRIPTION
Closes the two validation/suggester gaps `Projects.dc.html` (design project `e13203e0`) specifies in the new-project flow. Bead `cave-mrwv9`.

`ProjectSetupModal` — the app's only name / repository / access form — validated the repository **on submit only** and offered no way to pick a repo except typing `owner/repo` from memory.

## Validation

Field rules and the submit gate now come from one module, `src/lib/project-setup-validation.ts`. Live validation and submit validation written separately drift, and a field goes green on input that submit then rejects — so repo validation delegates to the same `normalizeGitHubRepoUrl` the submit path already used. There's a test pinning exactly that agreement.

- Messages wait for a blur, so opening the modal never greets you in red — but the `Create` gate applies from the first render.
- Invalid fields carry `aria-invalid` and point at their message with `aria-describedby`.

## Repository picker

A `Pick` button in the repository field opens a popover over the **existing** `/api/github/repos` route — no new backend.

- Filters by what's already typed; a pasted `https://github.com/owner/repo` URL still finds its row.
- Picking fills the repository and title-cases the name **only when the name is still untouched**, so a deliberate name is never overwritten by a later pick.
- Fetched on first open, never on mount — opening the modal shouldn't spend a GitHub round-trip you may not want.
- `configured: false` says "add a GitHub token" rather than rendering an empty list that reads as *"you have no repositories"*.
- Shows language + a relative pushed-at. The mock's public/private badge has **no field behind it** in `RepoItem`, so I show what the data actually has rather than inventing it. Adding the badge would be a change to `/api/github/repos`.

`titleCaseProjectName` carries the mock's acronym map (`API`, `CLI`, `UI`, `iOS`, `macOS`, `npm`, `GitHub`, `OpenCoven`…), so `hekate-agent` → `Hekate Agent` and `coven_cli` → `Coven CLI`.

## Verification

`tsc` 0 · `pnpm lint` 0 · `pnpm test:app` **959/959** · token drift unchanged (`inline=185`).

7 unit tests for the pure rules + 10 source pins on the component, wired into `run-tests.mjs` with the alias loader.

**Not verified visually, deliberately.** `ProjectSetupModal` mounts only at `chat-view.tsx:5769`, for the chat-side "register this ad-hoc folder" offer — reaching it needs a live chat session whose folder isn't a registered project, and manufacturing that state would write into the real session store. Covered by tests and pins instead of a fabricated screenshot.

## Scope notes

Two things I initially mis-scoped, corrected here for the record:

- The mock's **folder browser already exists** as `directory-picker-modal.tsx` (578 lines: breadcrumbs, up-one-folder, filter, new-folder). Not rebuilt.
- The Projects page's **New project** button runs `useAddProjectFlow` → `DirectoryPickerModal` → `addChatProject` and never opens `ProjectSetupModal`. The mock's field form still corresponds to this modal — it's the only one of its kind — but its entry point is chat, not that button.

Still open from the same audit, not in this PR: row-wise card expand (the mock expands a card's whole 4-up row so rows never go ragged) and kind colour-coding (`.projects-access-kind.is-workspace` has no rule, so workspaces and repos render identically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)