### PR TITLE
fix(chat): address Copilot session context findings

### DIFF
--- a/src/components/chat-session-chrome.test.ts
+++ b/src/components/chat-session-chrome.test.ts
@@ -64,6 +64,11 @@ test("2a ③ — the row is presentation over a pure model and never renders emp
     /<ProjectPickerPopover/,
     "the project chip opens the shared project picker rather than a private menu",
   );
+  assert.match(
+    contextRow,
+    /<div className="cave-chat-context-row" role="group" aria-label="Session context">/,
+    "the context row exposes its accessible name through a semantic group",
+  );
 });
 
 test("2a — the title row and turn names wear the display serif", () => {

--- a/src/components/chat-session-context-row.tsx
+++ b/src/components/chat-session-context-row.tsx
@@ -96,7 +96,7 @@ export function ChatSessionContextRow({
   const pickerAvailable = Boolean(onProjectChange) && (projects.length > 0 || Boolean(onAddProject));
 
   return (
-    <div className="cave-chat-context-row" aria-label="Session context">
+    <div className="cave-chat-context-row" role="group" aria-label="Session context">
       <div className="cave-chat-context-row__chips">
         {chips.map((chip) =>
           chip.id === "project" && pickerAvailable ? (

--- a/src/lib/chat-start-from.test.ts
+++ b/src/lib/chat-start-from.test.ts
@@ -25,6 +25,13 @@ test("group headers name the source of the work", () => {
   assert.equal(tasks.note, "1 open on the board");
 });
 
+test("group notes use the same normalized total as their displayed count", () => {
+  assert.equal(startFromGroup("chats", 1, 1.9).count, "1");
+  assert.equal(startFromGroup("chats", 1, 1.9).note, "1 thread to resume");
+  assert.equal(startFromGroup("tasks", 1, 1.9).note, "1 open on the board");
+  assert.equal(startFromGroup("chats", 0, -3).note, "0 threads to resume");
+});
+
 test("the tile badge is the loud priority, else the status — never both", () => {
   assert.equal(taskTileBadge({ status: "running", priority: "urgent" }), "urgent");
   assert.equal(taskTileBadge({ status: "review", priority: "high" }), "high");

--- a/src/lib/chat-start-from.ts
+++ b/src/lib/chat-start-from.ts
@@ -18,22 +18,28 @@ export type StartFromGroupMeta = {
   note: string;
 };
 
+function startFromTotals(shown: number, total: number) {
+  const normalize = (value: number) => (Number.isFinite(value) ? Math.max(0, Math.trunc(value)) : 0);
+  const safeShown = normalize(shown);
+  return { safeShown, safeTotal: Math.max(safeShown, normalize(total)) };
+}
+
 /** "3 of 12" when more exists than fits, else the bare count. */
 export function startFromCount(shown: number, total: number): string {
-  const safeShown = Math.max(0, Math.trunc(shown));
-  const safeTotal = Math.max(safeShown, Math.trunc(total));
+  const { safeShown, safeTotal } = startFromTotals(shown, total);
   return safeTotal > safeShown ? `${safeShown} of ${safeTotal}` : String(safeShown);
 }
 
 export function startFromGroup(kind: StartFromKind, shown: number, total: number): StartFromGroupMeta {
-  const count = startFromCount(shown, total);
+  const { safeShown, safeTotal } = startFromTotals(shown, total);
+  const count = safeTotal > safeShown ? `${safeShown} of ${safeTotal}` : String(safeShown);
   if (kind === "chats") {
     return {
       kind,
       label: "Chats",
       icon: "ph:chat-circle-dots",
       count,
-      note: total === 1 ? "1 thread to resume" : `${Math.max(0, Math.trunc(total))} threads to resume`,
+      note: safeTotal === 1 ? "1 thread to resume" : `${safeTotal} threads to resume`,
     };
   }
   return {
@@ -41,7 +47,7 @@ export function startFromGroup(kind: StartFromKind, shown: number, total: number
     label: "Tasks",
     icon: "ph:kanban",
     count,
-    note: total === 1 ? "1 open on the board" : `${Math.max(0, Math.trunc(total))} open on the board`,
+    note: safeTotal === 1 ? "1 open on the board" : `${safeTotal} open on the board`,
   };
 }
 

--- a/src/lib/chat-start-from.ts
+++ b/src/lib/chat-start-from.ts
@@ -24,15 +24,19 @@ function startFromTotals(shown: number, total: number) {
   return { safeShown, safeTotal: Math.max(safeShown, normalize(total)) };
 }
 
-/** "3 of 12" when more exists than fits, else the bare count. */
-export function startFromCount(shown: number, total: number): string {
-  const { safeShown, safeTotal } = startFromTotals(shown, total);
+function formatStartFromCount({ safeShown, safeTotal }: ReturnType<typeof startFromTotals>) {
   return safeTotal > safeShown ? `${safeShown} of ${safeTotal}` : String(safeShown);
 }
 
+/** "3 of 12" when more exists than fits, else the bare count. */
+export function startFromCount(shown: number, total: number): string {
+  return formatStartFromCount(startFromTotals(shown, total));
+}
+
 export function startFromGroup(kind: StartFromKind, shown: number, total: number): StartFromGroupMeta {
-  const { safeShown, safeTotal } = startFromTotals(shown, total);
-  const count = safeTotal > safeShown ? `${safeShown} of ${safeTotal}` : String(safeShown);
+  const totals = startFromTotals(shown, total);
+  const { safeTotal } = totals;
+  const count = formatStartFromCount(totals);
   if (kind === "chats") {
     return {
       kind,


### PR DESCRIPTION
## Summary
- expose the Chat session context row as a named group
- normalize launcher totals once so counts and singular/plural notes agree
- add regression coverage for both review findings

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `pnpm test:app` (958 files)