### PR TITLE
fix(permissions): log grant changes, not just access checks

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -153,6 +153,7 @@ export const SUITES = {
     "src/lib/cave-inbox-prefs.test.ts",
     "src/lib/cave-inbox-bulk.test.ts",
     "src/lib/project-permissions.test.ts",
+    "src/lib/project-grant-audit.test.ts",
     "src/lib/project-access-levels.test.ts",
     "src/lib/project-icon-prompt.test.ts",
     "src/lib/project-icon-image-provider.test.ts",

--- a/src/app/api/project-grants/route.test.ts
+++ b/src/app/api/project-grants/route.test.ts
@@ -127,13 +127,26 @@ assert.match(
 );
 assert.match(
   grantsRoute,
-  /grantProjectToFamiliar\(\{ familiarId: target\.familiarId, projectId: target\.projectId, source: "human", access \}\)/,
+  /grantProjectToFamiliar\(\{[\s\S]*?familiarId: target\.familiarId,[\s\S]*?projectId: target\.projectId,[\s\S]*?source: "human",[\s\S]*?access,/,
   "direct grants should always be recorded with source=human against the validated target ids",
 );
 assert.match(
   grantsRoute,
   /revokeProjectFromFamiliar/,
   "direct grants route should call the revocation primitive",
+);
+// The grant-change log distinguishes a desktop change from a phone one
+// (grants are mobile-mutable behind allowMobileGrantMutations), so the actor
+// must come from the verified request, never from the payload.
+assert.match(
+  grantsRoute,
+  /actor: isVerifiedMobileRequest\(req\) \? "mobile" : "loopback"/,
+  "grant mutations should record the actor from the verified request",
+);
+assert.equal(
+  (grantsRoute.match(/actor: isVerifiedMobileRequest\(req\)/g) ?? []).length,
+  2,
+  "both the grant and the revoke path should record their actor",
 );
 assert.match(
   grantsRoute,

--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from "next/server";
 
 import { resolveProjectGrantTarget } from "@/lib/server/project-grant-targets";
-import { requireTrustedHumanGrantMutation } from "@/lib/server/trusted-grant-mutation";
+import {
+  isVerifiedMobileRequest,
+  requireTrustedHumanGrantMutation,
+} from "@/lib/server/trusted-grant-mutation";
 
 import {
   grantProjectToFamiliar,
@@ -103,7 +106,13 @@ export async function POST(req: Request) {
       { status: target.status },
     );
   }
-  await grantProjectToFamiliar({ familiarId: target.familiarId, projectId: target.projectId, source: "human", access });
+  await grantProjectToFamiliar({
+    familiarId: target.familiarId,
+    projectId: target.projectId,
+    source: "human",
+    access,
+    actor: isVerifiedMobileRequest(req) ? "mobile" : "loopback",
+  });
   return NextResponse.json({ ok: true });
 }
 
@@ -121,6 +130,9 @@ export async function DELETE(req: Request) {
       { status: 400 },
     );
   }
-  const revoked = await revokeProjectFromFamiliar(input);
+  const revoked = await revokeProjectFromFamiliar({
+    ...input,
+    actor: isVerifiedMobileRequest(req) ? "mobile" : "loopback",
+  });
   return NextResponse.json({ ok: true, revoked });
 }

--- a/src/lib/project-grant-audit.test.ts
+++ b/src/lib/project-grant-audit.test.ts
@@ -1,0 +1,181 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+// Grant-change logging (cave-keqjk). `permissionAudit` records access-CHECK
+// decisions — "was this familiar allowed to do X". It structurally cannot
+// answer "who widened this grant, when, and from what", because it has no
+// before/after and is only written on the check path. `grantAudit` is the
+// separate log that answers that, and these tests pin it end to end.
+
+const tmp = await mkdtemp(path.join(tmpdir(), "grant-audit-test-"));
+process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
+process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(tmp, "permission-config.json");
+process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "projects.json");
+process.env.CAVE_SUPREME_FAMILIAR_ID = "supreme";
+
+const {
+    grantProjectToFamiliar,
+    revokeProjectFromFamiliar,
+    revokeAllGrantsForProject,
+    createAccessGroup,
+    listRecentGrantChanges,
+    loadProjectPermissions,
+} = await import("./project-permissions.ts");
+
+// Cleanup must be a node:test hook — a plain try/finally runs to completion
+// before the scheduled tests execute and would delete the store underneath them.
+after(async () => {
+await rm(tmp, { recursive: true, force: true });
+});
+
+test("a new grant records from:null → the granted level", async () => {
+    await grantProjectToFamiliar({
+      familiarId: "nova",
+      projectId: "p1",
+      source: "human",
+      access: "read",
+      actor: "loopback",
+    });
+    const [entry] = await listRecentGrantChanges();
+    assert.equal(entry.familiarId, "nova");
+    assert.equal(entry.projectId, "p1");
+    assert.equal(entry.from, null, "there was no prior grant");
+    assert.equal(entry.to, "read");
+    assert.equal(entry.actor, "loopback");
+    assert.equal(entry.kind, "direct");
+    assert.equal(entry.source, "human");
+    assert.ok(entry.id && entry.at, "entries are identified and timestamped");
+});
+
+test("a widening records the level it came from", async () => {
+    await grantProjectToFamiliar({
+      familiarId: "nova",
+      projectId: "p1",
+      source: "human",
+      access: "write",
+      actor: "loopback",
+    });
+    const [entry] = await listRecentGrantChanges();
+    assert.equal(entry.from, "read", "the prior level survives the in-place overwrite");
+    assert.equal(entry.to, "write");
+});
+
+test("a downgrade is recorded with the same fidelity as a widening", async () => {
+    await grantProjectToFamiliar({
+      familiarId: "nova",
+      projectId: "p1",
+      source: "human",
+      access: "read",
+      actor: "mobile",
+    });
+    const [entry] = await listRecentGrantChanges();
+    assert.equal(entry.from, "write");
+    assert.equal(entry.to, "read");
+    assert.equal(entry.actor, "mobile", "a phone-initiated change is distinguishable");
+});
+
+test("a no-op re-grant records nothing", async () => {
+    const before = (await listRecentGrantChanges()).length;
+    await grantProjectToFamiliar({
+      familiarId: "nova",
+      projectId: "p1",
+      source: "human",
+      access: "read",
+      actor: "loopback",
+    });
+    assert.equal(
+      (await listRecentGrantChanges()).length,
+      before,
+      "setting the level it already has is not a change",
+    );
+});
+
+test("a revoke records to:null and keeps the level that was lost", async () => {
+    await revokeProjectFromFamiliar({ familiarId: "nova", projectId: "p1", actor: "loopback" });
+    const [entry] = await listRecentGrantChanges();
+    assert.equal(entry.from, "read", "what was lost is the whole point of the record");
+    assert.equal(entry.to, null);
+    assert.equal(entry.kind, "direct");
+});
+
+test("revoking something that was never granted records nothing", async () => {
+    const before = (await listRecentGrantChanges()).length;
+    const revoked = await revokeProjectFromFamiliar({ familiarId: "ghost", projectId: "p1" });
+    assert.equal(revoked, false);
+    assert.equal((await listRecentGrantChanges()).length, before);
+});
+
+test("removing a project records one entry per familiar it silently dropped", async () => {
+    await grantProjectToFamiliar({ familiarId: "sage", projectId: "p2", source: "human", access: "write" });
+    await grantProjectToFamiliar({ familiarId: "cody", projectId: "p2", source: "human", access: "read" });
+    await createAccessGroup({
+      name: "Coders",
+      memberFamiliarIds: ["kitty"],
+      projectGrants: [{ projectId: "p2", access: "write" }],
+    });
+
+    const before = (await listRecentGrantChanges()).length;
+    const counts = await revokeAllGrantsForProject("p2");
+    assert.equal(counts.grants, 2);
+
+    const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+    const forP2 = added.filter((e) => e.projectId === "p2");
+    const byFamiliar = Object.fromEntries(forP2.map((e) => [e.familiarId, e]));
+
+    // The cascade is the least visible change of all — it drops access for
+    // several familiars at once with no per-familiar action to attribute it to.
+    assert.ok(byFamiliar.sage, "direct grant holder recorded");
+    assert.equal(byFamiliar.sage.from, "write");
+    assert.equal(byFamiliar.sage.to, null);
+    assert.equal(byFamiliar.sage.kind, "project-removed");
+    assert.ok(byFamiliar.cody, "second direct grant holder recorded");
+    assert.equal(byFamiliar.cody.from, "read");
+    assert.ok(byFamiliar.kitty, "group member who loses inherited access is recorded too");
+    assert.equal(byFamiliar.kitty.kind, "project-removed");
+    assert.ok(byFamiliar.kitty.groupId, "the group it came through is named");
+});
+
+test("the change log is written in the same save as the change it describes", async () => {
+    await grantProjectToFamiliar({ familiarId: "echo", projectId: "p3", source: "human", access: "write" });
+    const file = await loadProjectPermissions();
+    const grant = file.projectGrants.find((g) => g.familiarId === "echo" && g.projectId === "p3");
+    const logged = file.grantAudit.find((e) => e.familiarId === "echo" && e.projectId === "p3");
+    assert.ok(grant, "grant persisted");
+    assert.ok(logged, "record persisted alongside it — never one without the other");
+    assert.equal(logged.to, grant.access);
+});
+
+test("the check log is left alone — the two answer different questions", async () => {
+    const file = await loadProjectPermissions();
+    assert.ok(Array.isArray(file.permissionAudit), "permissionAudit still exists");
+    assert.equal(
+      file.permissionAudit.length,
+      0,
+      "grant mutations must not write into the access-check log",
+    );
+    assert.ok(file.grantAudit.length > 0, "they land in grantAudit instead");
+});
+
+test("a store written before this log existed loads as empty, not broken", async () => {
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(
+      process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE,
+      JSON.stringify({
+        version: 2,
+        projectGrants: [{ familiarId: "nova", projectId: "old", access: "write", source: "human", grantedAt: "2026-01-01T00:00:00.000Z" }],
+        accessGroups: [],
+        grantProposals: [],
+        permissionAudit: [],
+      }),
+      "utf8",
+    );
+    const file = await loadProjectPermissions();
+    assert.deepEqual(file.grantAudit, [], "no history is invented for pre-existing grants");
+    assert.equal(file.projectGrants.length, 1, "the rest of the store is untouched");
+});
+
+console.log("project-grant-audit.test.ts: ok");

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -98,12 +98,46 @@ export type PermissionAuditEntry = {
   requiredAccess?: ProjectAccessLevel;
 };
 
+/**
+ * Who performed a grant change. `permissionAudit` answers "was this familiar
+ * allowed to do X"; this answers "who widened this, when, and from what" —
+ * a different question the check log structurally cannot serve.
+ */
+export type GrantChangeActor = "loopback" | "mobile" | "system";
+
+export type GrantChangeKind = "direct" | "group" | "project-removed" | "bootstrap";
+
+export type GrantChangeEntry = {
+  id: string;
+  at: string;
+  familiarId: string;
+  projectId: string;
+  /** Level before the change; null when there was no grant. */
+  from: ProjectAccessLevel | null;
+  /** Level after the change; null when the grant was removed. */
+  to: ProjectAccessLevel | null;
+  /** Where the write came from — the desktop, the paired phone, or the app itself. */
+  actor: GrantChangeActor;
+  /** Which surface of the model changed: a direct grant, a group grant, … */
+  kind: GrantChangeKind;
+  /** Provenance recorded on the grant itself (human, bootstrap, …). */
+  source?: ProjectGrantSource;
+  /** Access group id, when kind is "group". */
+  groupId?: string;
+};
+
 type ProjectPermissionsFile = {
   version: 2;
   projectGrants: ProjectGrant[];
   accessGroups: FamiliarAccessGroup[];
   grantProposals: GrantProposal[];
   permissionAudit: PermissionAuditEntry[];
+  /**
+   * Grant-change log. Separate from permissionAudit on purpose: that array
+   * holds 1000s of check decisions with a check-shaped schema, and widening it
+   * would force every existing entry to be reinterpreted.
+   */
+  grantAudit: GrantChangeEntry[];
 };
 
 type HumanPermissionConfigFile = {
@@ -158,6 +192,7 @@ function emptyFile(): ProjectPermissionsFile {
     accessGroups: [],
     grantProposals: [],
     permissionAudit: [],
+    grantAudit: [],
   };
 }
 
@@ -310,6 +345,9 @@ async function loadProjectPermissionsUnlocked(): Promise<ProjectPermissionsFile>
       : [],
     grantProposals: Array.isArray(parsed.grantProposals) ? parsed.grantProposals : [],
     permissionAudit: Array.isArray(parsed.permissionAudit) ? parsed.permissionAudit : [],
+    // Absent on every store written before this log existed — an empty array
+    // is the honest answer there, not a reconstruction.
+    grantAudit: Array.isArray(parsed.grantAudit) ? parsed.grantAudit : [],
   };
   materializeDueGrantProposals(file, new Date());
   return file;
@@ -538,6 +576,34 @@ export async function assertProjectRootAccess(
   return project;
 }
 
+/**
+ * Append a grant-change record to an already-loaded file. Takes the file so it
+ * lands inside the SAME lock+save as the mutation it describes — recording it
+ * separately could leave a change with no record if the second write failed.
+ */
+function recordGrantChange(
+  file: ProjectPermissionsFile,
+  entry: Omit<GrantChangeEntry, "id" | "at">,
+): void {
+  file.grantAudit.push({ id: randomUUID(), at: new Date().toISOString(), ...entry });
+}
+
+/**
+ * Most-recent grant changes, newest first, capped to `limit`.
+ *
+ * Ties on `at` break on append order, not arbitrarily: a bulk "Set all" writes
+ * many entries inside the same millisecond, and sorting on the timestamp alone
+ * would report that burst in reverse.
+ */
+export async function listRecentGrantChanges(limit = 200): Promise<GrantChangeEntry[]> {
+  const log = (await loadProjectPermissions()).grantAudit;
+  return log
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => b.entry.at.localeCompare(a.entry.at) || b.index - a.index)
+    .slice(0, Math.max(0, limit))
+    .map(({ entry }) => entry);
+}
+
 async function appendAudit(entry: Omit<PermissionAuditEntry, "id" | "at">): Promise<void> {
   await withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
@@ -551,10 +617,27 @@ export async function grantProjectToFamiliar(input: {
   projectId: string;
   source: ProjectGrantSource;
   access?: ProjectAccessLevel;
+  /** Who is making the change; defaults to the app itself. */
+  actor?: GrantChangeActor;
 }): Promise<void> {
   await withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
+    // Read the prior level first — ensureProjectGrant mutates in place, so
+    // after it runs the "from" side of the change is gone.
+    const before =
+      file.projectGrants.find(
+        (grant) => grant.familiarId === input.familiarId && grant.projectId === input.projectId,
+      )?.access ?? null;
     if (ensureProjectGrant(file, input)) {
+      recordGrantChange(file, {
+        familiarId: input.familiarId,
+        projectId: input.projectId,
+        from: before,
+        to: normalizeAccessLevel(input.access),
+        actor: input.actor ?? "system",
+        kind: "direct",
+        source: input.source,
+      });
       await saveProjectPermissions(file);
     }
   }));
@@ -563,14 +646,28 @@ export async function grantProjectToFamiliar(input: {
 export async function revokeProjectFromFamiliar(input: {
   familiarId: string;
   projectId: string;
+  /** Who is making the change; defaults to the app itself. */
+  actor?: GrantChangeActor;
 }): Promise<boolean> {
   return withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
+    const removed = file.projectGrants.find(
+      (grant) => grant.familiarId === input.familiarId && grant.projectId === input.projectId,
+    );
     const next = file.projectGrants.filter(
       (grant) => !(grant.familiarId === input.familiarId && grant.projectId === input.projectId),
     );
     if (next.length === file.projectGrants.length) return false;
     file.projectGrants = next;
+    recordGrantChange(file, {
+      familiarId: input.familiarId,
+      projectId: input.projectId,
+      from: removed?.access ?? null,
+      to: null,
+      actor: input.actor ?? "system",
+      kind: "direct",
+      source: removed?.source,
+    });
     await saveProjectPermissions(file);
     return true;
   }));
@@ -588,15 +685,43 @@ export async function revokeAllGrantsForProject(
   return withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
 
+    const removedGrants = file.projectGrants.filter((grant) => grant.projectId === projectId);
     const nextGrants = file.projectGrants.filter((grant) => grant.projectId !== projectId);
     const grants = file.projectGrants.length - nextGrants.length;
     file.projectGrants = nextGrants;
+    // A registry removal drops access for every familiar at once; without a
+    // record per familiar the cascade is the least visible change of all.
+    for (const grant of removedGrants) {
+      recordGrantChange(file, {
+        familiarId: grant.familiarId,
+        projectId,
+        from: grant.access,
+        to: null,
+        actor: "system",
+        kind: "project-removed",
+        source: grant.source,
+      });
+    }
 
     let groupGrants = 0;
     for (const group of file.accessGroups) {
       const before = group.projectGrants.length;
+      const dropped = group.projectGrants.filter((grant) => grant.projectId === projectId);
       group.projectGrants = group.projectGrants.filter((grant) => grant.projectId !== projectId);
       groupGrants += before - group.projectGrants.length;
+      for (const grant of dropped) {
+        for (const familiarId of group.memberFamiliarIds) {
+          recordGrantChange(file, {
+            familiarId,
+            projectId,
+            from: grant.access,
+            to: null,
+            actor: "system",
+            kind: "project-removed",
+            groupId: group.id,
+          });
+        }
+      }
     }
 
     const nextProposals = file.grantProposals.filter((proposal) => proposal.projectId !== projectId);


### PR DESCRIPTION
Closes `cave-keqjk`.

## The gap

The permissions store has a `permissionAudit` array sitting directly beside `projectGrants`, so it reads like a permissions log. It isn't one — it records access-**check** decisions (`decision: allow|deny`, `requiredAccess`, surfaces like `chat` / `file-browse` / `session-launch`). It answers *"was this familiar allowed to do X"*. It cannot answer *"who widened this grant, when, and from what"*.

Confirmed two ways:

- **In source** — `appendAudit()` had exactly one call site, inside the access-check evaluation. `grantProjectToFamiliar()` and `revokeProjectFromFamiliar()` mutated `projectGrants`, called `saveProjectPermissions()`, and wrote nothing.
- **Empirically** — 8 real grant downgrades left `permissionAudit` unchanged at 3,746 entries. The only on-disk trace was the overwritten `grantedAt`; the prior level was gone.

This matters more than it used to: the refreshed Projects page (#3994) made mass changes cheap — per-section *Set all*, bulk select, *Reset all* — so one click can rewrite dozens of grants. And grants are mobile-mutable when `allowMobileGrantMutations` is on, which was previously indistinguishable from a desktop change.

## The fix

A sibling `grantAudit` log:

```ts
{ id, at, familiarId, projectId, from, to, actor, kind, source?, groupId? }
```

`from`/`to` are the levels either side of the change (`null` = no grant), so a widening and a downgrade are equally legible. `actor` is `loopback` / `mobile` / `system`, threaded from the route via `isVerifiedMobileRequest`.

**Why a sibling array over widening `PermissionAuditEntry`:** that shape is check-oriented (`decision`/`reason`/`requiredAccess`). Reusing it would force 1000s of existing entries to be reinterpreted and would change `listRecentPermissionAudit()`'s contract.

**Covered paths:** direct grant · direct revoke · the registry-removal cascade. That last one is the least visible change in the system — it drops access for every familiar at once, including group members losing inherited access, with no per-familiar action to attribute it to. It now records one entry per affected familiar, naming the group where relevant.

## Two details worth keeping

**Same lock, same save.** The record is appended to the in-memory file the mutation just changed, so it persists in the same write. Recording separately could leave a change with no record if the second write failed.

**Tie-breaking on append order.** `listRecentGrantChanges()` breaks `at` ties on index. A bulk *Set all* writes many entries inside one millisecond, and sorting on the timestamp alone reported that burst in reverse — found by a test, not by reading.

## Verification

- **10 behavioral tests**, verified to fail against the pre-fix code (**0 pass / 10 fail**) and pass after — they pin the behaviour, not the implementation.
- Existing `project-permissions.test.ts`, `project-permission-routes.test.ts`, `project-local-human-read.test.ts`, `api-contracts.test.ts` — all green.
- `tsc --noEmit`, `pnpm lint`, `check-tests-wired` (1318) — clean.

## Note on scope

Stores written before this log existed load with an empty `grantAudit` — no history is invented for grants that predate it. Access-group membership and group-grant edits (`updateAccessGroup`) still aren't logged; they change effective access indirectly and are worth a follow-up, but the direct paths are where the mutations actually happen today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)