### PR TITLE
feat(memories): navigator title + familiar scoping; fix(shell): persist nav toggle from latest state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,4 @@ ds-bundle/
 /.worktrees
 /.cave-trash
 /.opencode
+/.copilot

--- a/src/components/analytics-page-shell.test.ts
+++ b/src/components/analytics-page-shell.test.ts
@@ -67,7 +67,11 @@ assert.match(shell, /const NAV_OPEN_PREF_KEY = "cave:shell:nav-open"/, "standalo
 assert.match(shell, /const \[navOpen, setNavOpen\] = useState\(false\)/, "SSR starts from the compact navigation rail");
 assert.match(shell, /useLayoutEffect\(\(\) => \{[\s\S]*?const pref = readNavOpenPref\(\)/, "desktop restores its preference before paint");
 assert.match(shell, /const pref = readNavOpenPref\(\)/, "standalone routes restore the shared navigation preference after hydration");
-assert.match(shell, /writeNavOpenPref\(next\)/, "standalone route toggles persist the shared navigation preference");
+assert.match(
+  shell,
+  /setNavOpen\(\(current\) => \{\s*const next = !current;\s*writeNavOpenPref\(next\);\s*return next;\s*}\)/,
+  "standalone route toggles derive and persist the preference from the latest state",
+);
 assert.match(shell, /const isExpanded = !isMobile && navOpen/, "mobile always keeps the compact icon rail");
 assert.match(shell, /className="aps-top shell-top"/, "standalone shell mounts the shared desktop title bar");
 assert.match(shell, /aria-label=\{navOpen \? "Collapse navigation" : "Expand navigation"\}/, "standalone title bar exposes the navigation toggle state");

--- a/src/components/analytics-page-shell.tsx
+++ b/src/components/analytics-page-shell.tsx
@@ -68,9 +68,11 @@ export function AnalyticsPageShell({ children }: { children: ReactNode }) {
   }, []);
 
   const handleToggleNav = () => {
-    const next = !navOpen;
-    setNavOpen(next);
-    writeNavOpenPref(next);
+    setNavOpen((current) => {
+      const next = !current;
+      writeNavOpenPref(next);
+      return next;
+    });
   };
 
   // On mobile the sidebar is always the 56px icon rail; on desktop it

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -109,10 +109,51 @@ assert.match(
   /\{navigatorCollapsedForDisplay \? \(/,
   "the compact navigator branch is suppressed while searching",
 );
+// Span widened from 240 to 800: the toggle row now carries a Navigator title
+// before the button, so onClick sits further from the opening <div>.
 assert.match(
   view,
-  /\{!q \? \(\s*<div[\s\S]{0,240}onClick=\{toggleNavigator\}/,
+  /\{!q \? \(\s*<div[\s\S]{0,800}onClick=\{toggleNavigator\}/,
   "the collapse toggle is hidden while search forces the navigator open",
+);
+
+// The expanded rail's toggle row is titled — a bare right-aligned button gave
+// the sidebar no visible name of its own.
+assert.match(
+  view,
+  /navigatorCollapsed \? null : \(\s*<h2[\s\S]{0,240}>\s*Navigator\s*<\/h2>\s*\)\}\s*<button[\s\S]{0,200}onClick=\{toggleNavigator\}/,
+  "the expanded navigator's toggle row shows a Navigator title to the left of the collapse toggle",
+);
+assert.match(
+  view,
+  /navigatorCollapsed \? "justify-center p-1" : "justify-between gap-2 p-1\.5"/,
+  "the toggle row splits title-left / toggle-right when expanded and centers the toggle when collapsed",
+);
+
+// ── Memory is scoped to the shell's familiar multiselect ────────────────────
+// The Memories surface used to list every familiar's memory files regardless
+// of the sidebar selection. Empty selection is still "All" (familiarInScope).
+assert.match(view, /scopeFamiliarIds\?: ReadonlySet<string>/, "GrimoireView accepts the familiar scope");
+assert.match(
+  view,
+  /const memoryScope = scopeFamiliarIds \?\? EMPTY_FAMILIAR_SCOPE/,
+  "an absent scope falls back to the canonical empty (All) selection",
+);
+assert.match(
+  view,
+  /const scopedMemory = useMemo\(\s*\(\) => \(memory \?\? \[\]\)\.filter\(\(e\) => familiarInScope\(memoryScope, e\.familiarId\)\)/,
+  "memory files are filtered by the selected familiars before search",
+);
+assert.match(view, /memory=\{scopedMemory\}/, "the launcher's memory stats/jumps use the same scoped list as the rail");
+assert.match(
+  view,
+  /No memory for \$\{memoryScopeLabel\} yet/,
+  "a scoped-but-empty Memory section says which familiars it is narrowed to",
+);
+assert.match(
+  workspace,
+  /<GrimoireView[\s\S]{0,240}scopeFamiliarIds=\{scopeIds\}/,
+  "the Workspace hands Memories the same familiar scope as Tasks and Schedules",
 );
 
 // ── Detail: the right transport per source ───────────────────────────────────

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -28,6 +28,7 @@ import "@/styles/journal.css";
 import "@/styles/grimoire-launcher.css";
 import { GrimoireLauncher } from "@/components/grimoire-launcher";
 import type { Familiar } from "@/lib/types";
+import { familiarInScope } from "@/lib/familiar-multiselect";
 import { serializeMdDocument } from "@/lib/md-frontmatter";
 import { relativeTime } from "@/lib/relative-time";
 import {
@@ -108,6 +109,9 @@ type MemoryEntry = {
 };
 
 type JournalSummary = { date: string; preview: string; reflectedBy: string | null; modified: string | null };
+
+/** The canonical "All familiars" scope — an empty selection filters nothing. */
+const EMPTY_FAMILIAR_SCOPE: ReadonlySet<string> = new Set<string>();
 
 function compactPath(path: string): string {
   const collapsed = path.replace(/^\/Users\/[^/]+/, "~");
@@ -716,6 +720,7 @@ export function GrimoireView({
   onViewChange,
   familiars = [],
   activeFamiliarId = null,
+  scopeFamiliarIds,
 }: {
   /** Which tab shows. Controlled by the Workspace so the Journal nav row can
    *  route straight into the Journal tab; falls back to internal state when the
@@ -725,6 +730,11 @@ export function GrimoireView({
   /** Roster for the Journal tab (reflection filter + attribution). */
   familiars?: Familiar[];
   activeFamiliarId?: string | null;
+  /** The shell's familiar multiselect. Empty = All. When familiars are
+   *  selected, the Memory navigator shows only those familiars' own memory —
+   *  ownerless shared pools drop out, matching the app-wide familiar-memory
+   *  rule documented in `@/lib/memory-file-scope`. */
+  scopeFamiliarIds?: ReadonlySet<string>;
 } = {}) {
   const [knowledge, setKnowledge] = useState<KnowledgeEntry[] | null>(null);
   const [collections, setCollections] = useState<KnowledgeCollectionSummary[] | null>(null);
@@ -1090,9 +1100,26 @@ export function GrimoireView({
       return next;
     });
   }, []);
+  // The shell's familiar multiselect scopes the Memory navigator: an empty
+  // selection is "All", otherwise only the selected familiars' own memory
+  // files survive (ownerless shared pools are another familiar's business).
+  const memoryScope = scopeFamiliarIds ?? EMPTY_FAMILIAR_SCOPE;
+  const memoryScoped = memoryScope.size > 0;
+  /** Who the Memory section is currently narrowed to, for scoped empty copy. */
+  const memoryScopeLabel = useMemo(() => {
+    if (memoryScope.size === 0) return null;
+    if (memoryScope.size > 2) return `the ${memoryScope.size} selected familiars`;
+    return [...memoryScope]
+      .map((id) => familiars.find((f) => f.id === id)?.display_name ?? id)
+      .join(" and ");
+  }, [familiars, memoryScope]);
+  const scopedMemory = useMemo(
+    () => (memory ?? []).filter((e) => familiarInScope(memoryScope, e.familiarId)),
+    [memory, memoryScope],
+  );
   const visibleMemory = useMemo(
-    () => (memory ?? []).filter((e) => matches(e.relPath, e.fullPath, e.rootLabel, e.familiarId)),
-    [memory, matches],
+    () => scopedMemory.filter((e) => matches(e.relPath, e.fullPath, e.rootLabel, e.familiarId)),
+    [scopedMemory, matches],
   );
   // Runtime roots write thousands of timestamp-named session files; rendered
   // flat they drown Stitches and Journal. Group memory by its source root —
@@ -1332,7 +1359,7 @@ export function GrimoireView({
       // points — all driven by the lists this view already loaded.
       <GrimoireLauncher
         knowledge={knowledge ?? []}
-        memory={memory ?? []}
+        memory={scopedMemory}
         journal={journal ?? []}
         graph={graph}
         journalTitle={(date) => journalDayLabel(date, dateTimePrefs)}
@@ -1523,15 +1550,27 @@ export function GrimoireView({
         }`}
       >
         {/* Title, surface verbs, and the doc search all live in the compact
-            band above — the rail is purely the grouped navigator now. */}
+            band above — the rail is purely the grouped navigator now. Its own
+            header row names the rail so the collapse toggle isn't a floating,
+            unlabelled control. The row is suppressed while a search is running,
+            because the rail force-expands to keep results reachable. */}
         {!q ? (
-          <div className={`flex shrink-0 ${navigatorCollapsed ? "justify-center p-1" : "justify-end p-1.5"}`}>
+          <div
+            className={`flex shrink-0 items-center ${
+              navigatorCollapsed ? "justify-center p-1" : "justify-between gap-2 p-1.5"
+            }`}
+          >
+            {navigatorCollapsed ? null : (
+              <h2 className="min-w-0 truncate pl-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wide text-[var(--text-muted)]">
+                Navigator
+              </h2>
+            )}
             <button
               type="button"
               onClick={toggleNavigator}
               aria-label={navigatorCollapsed ? "Expand Memories sidebar" : "Collapse Memories sidebar"}
               title={navigatorCollapsed ? "Expand Memories sidebar" : "Collapse Memories sidebar"}
-              className="focus-ring-inset inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
+              className="focus-ring-inset inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-[var(--text-muted)] hover:bg-[var(--bg-elevated)] hover:text-[var(--text-primary)]"
             >
               <Icon name="ph:sidebar-simple" width={14} aria-hidden />
             </button>
@@ -1681,14 +1720,22 @@ export function GrimoireView({
                 ariaLabel="Memory files"
                 icon="ph:brain"
                 label="Memory"
-                description="Files your familiars and runtimes write as they work — editable in place"
+                description={
+                  memoryScoped
+                    ? `Memory files for ${memoryScopeLabel} — editable in place`
+                    : "Files your familiars and runtimes write as they work — editable in place"
+                }
                 count={visibleMemory.length}
                 collapsed={!q && collapsedSections.memory}
                 onToggle={() => toggleSection("memory")}
               >
                 {visibleMemory.length === 0 ? (
                   <p className="px-2 py-1 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-                    {q ? "No matches." : "No memory yet — it fills in as your familiars work and remember."}
+                    {q
+                      ? "No matches."
+                      : memoryScoped
+                        ? `No memory for ${memoryScopeLabel} yet — clear the familiar filter to see everything.`
+                        : "No memory yet — it fills in as your familiars work and remember."}
                   </p>
                 ) : (
                   memoryGroups.map((group) => {

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3031,6 +3031,7 @@ export function Workspace() {
         onViewChange={selectGrimoireView}
         familiars={familiars}
         activeFamiliarId={activeId}
+        scopeFamiliarIds={scopeIds}
       />
     ) : mode === "inbox" || mode === "calendar" ? (
       // Calendar and crons are one Schedules surface. The "calendar" mode still resolves


### PR DESCRIPTION
## What

Two commits.

**1. `feat(memories)` — Memories surface** (recovered from uncommitted edits stranded in the shared primary checkout, the failure mode behind `258af8d` / #585)

- **Navigator title.** The expanded navigator's toggle row gets a `Navigator` heading, so the collapse control is no longer a floating unlabelled button. The row is suppressed while a search is running, because the rail force-expands to keep results reachable (`navigatorCollapsedForDisplay`, from #3995).
- **Familiar-scoped Memories.** Scoped to the shell's familiar multiselect via `familiarInScope`; an empty selection still means All. It previously listed every familiar's memory files regardless of the sidebar selection. A scoped-but-empty section names the familiars it's narrowed to.
- Plus one `.gitignore` line (`/.copilot`).

**2. `fix(shell)` — standalone nav toggle**

`handleToggleNav` now uses functional `setNavOpen((current) => …)`, so the persisted preference derives from the latest state rather than a possibly-stale closure. Test assertion updated to match.

## Scope notes

This PR originally also carried the standalone-rail work (nav-open persistence + always-mounted 56px/240px rail). **That was dropped as redundant** — `86a0c7b38`, merged to main via #4000, landed the same feature from the same stranded edits and does it better: `useLayoutEffect` + `useState(false)` restores the preference before paint (no expanded flash), and the rail width uses `var(--shell-nav-width)`, so it needs no design-token-drift banking. The baseline stays at **1642**.

The `fix(shell)` commit above is a follow-up to that now-merged code.

## Verification

Run on a worktree pinned to this PR's exact head `437a35c7c`, isolated so no concurrent session could mutate the tree mid-run (`HEAD_BEFORE == HEAD_AFTER`, working tree clean). Exit codes captured unpiped:

- `pnpm typecheck` — 0
- `pnpm lint` (codemod drift-check + eslint) — 0
- `pnpm check:tests-wired` — 0
- `pnpm test:app` — 0, **967 test files passed**

Visually verified in the real app: the Navigator title row renders left of the collapse toggle, and collapsing hides the title and yields the 44px compact rail. The familiar-scoping filter itself was not visually A/B'd, so that path rests on the source-pin tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)