### PR TITLE
fix(settings): unstretch the Listen pill and stack the Backup blocks

### DIFF
--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -559,10 +559,15 @@ assert.match(
   /settings-backup-sync__state[\s\S]*\{enabled \? "On" : "Off"\}/,
   "scheduled sync always names its state",
 );
+// Was a responsive two-column grid. Scheduled sync carries a destination, a
+// passphrase, a retention field and a freshness readout — several times the
+// height of the manual export beside it — so the pair left a dead half-column
+// the length of the taller card. Stacked full-width, each block gets the whole
+// measure and the section reads top to bottom.
 assert.match(
   dashboardCss,
-  /\.settings-backup-grid\s*\{[\s\S]*grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(min\(100%,\s*240px\),\s*1fr\)\)/,
-  "Backup uses the source's responsive two-column grid",
+  /\.settings-backup-grid\s*\{[\s\S]*grid-template-columns:\s*minmax\(0,\s*1fr\)/,
+  "Backup stacks its two blocks full-width instead of pairing them",
 );
 assert.equal(
   dashboardCss.match(/\.settings-backup-grid\s*\{/g)?.length,

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -616,9 +616,14 @@
   color: var(--text-primary);
 }
 
+/* One column, full measure each. Scheduled sync carries a destination, a
+   passphrase, a retention field and a freshness readout — several times the
+   height of the manual export beside it — so side-by-side left a dead
+   half-column the length of the taller card. Stacked, the section reads top to
+   bottom and each block gets the full width its controls want. */
 .settings-backup-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(min(100%, 240px), 1fr));
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-3);
 }
 

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -554,10 +554,13 @@
   gap: var(--space-3);
 }
 
+/* Sized to the copy beside it rather than to itself: at 4.5rem the art was the
+   tallest thing in the row and set the card's height on its own. */
 .settings-about-podcast-art {
   display: inline-flex;
-  width: 4.5rem;
-  height: 4.5rem;
+  width: 3rem;
+  height: 3rem;
+  align-self: center;
   flex: none;
   flex-direction: column;
   align-items: center;
@@ -584,9 +587,17 @@
   line-height: 1;
 }
 
+/* The card stretches its children, which inflated this pill to the card's full
+   height (97px for a one-word label). It centres on its own axis instead, at a
+   fixed control height, so it reads as a button and not a coloured column. */
 .settings-about-link-card__action {
+  display: inline-flex;
+  align-items: center;
+  align-self: center;
+  height: 28px;
+  flex: none;
   margin-left: auto;
-  padding: var(--space-2) var(--space-3);
+  padding: 0 var(--space-3);
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);
   color: var(--text-secondary);


### PR DESCRIPTION
Three layout defects on the Settings surface, each traced to a cause rather than nudged until it looked right.

## `Listen` pill was 97px tall

`.settings-about-link-card` sets `align-items: stretch`, so the pill — a flex child with no axis of its own — grew to the card's full height. A one-word label rendered as a coloured column.

It now centres on its own axis at a fixed 28px control height.

## Podcast art set the card's height by itself

At `4.5rem` the art tile was the tallest thing in the row, so the card sized to the *decoration* rather than to the copy beside it. Down to `3rem`, centred.

## Backup left a dead half-column

`.settings-backup-grid` paired `Encrypted export` with `Scheduled sync` via `repeat(auto-fit, minmax(min(100%, 240px), 1fr))`. Scheduled sync carries a destination, a passphrase, a retention field and a freshness readout — several times the height of the manual export — so side-by-side left an empty half-column the length of the taller card.

Now a single column: each block gets the full measure, and `Encrypted export`'s passphrase field finally spans the width its input wants.

## Measured

| | before | after |
|---|---|---|
| `Listen` pill | **97px** | **28px** |
| art tile | 79px | 53px |
| card | 123px | 123px |

**The card height is unchanged on purpose.** It shares a grid row with the Discord card under `grid-auto-rows: minmax(7rem, auto)`. Shrinking the podcast card alone would leave it floating in a taller row, misaligned with its neighbour. Making the whole row shorter is a change to `grid-auto-rows` affecting every card in the section — a different edit, not this one.

## Test pin updated

`settings-shell-polish.test.ts:562` asserted *"Backup uses the source's responsive two-column grid"*. That pin encoded a deliberate earlier decision that this change supersedes, so it now asserts the stacked layout and carries the reasoning rather than being deleted.

## Verification

`pnpm lint` 0 · `pnpm test:app` **959/959** · codemod no-op · token drift unchanged (`font=151 space=1642 radius=221 hex=0 inline=185`).

Verified on screen in a production build, both regions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)