### PR TITLE
fix(canvas): stop the first-sketch composer repeating itself

### DIFF
--- a/src/components/canvas-add-tile.tsx
+++ b/src/components/canvas-add-tile.tsx
@@ -503,9 +503,9 @@ export function CanvasAddTile({
             <h2 className="chat-canvas-add__heading">
               {state.phase === "result" && !generationVisible ? "Your preview" : "What would you like to create?"}
             </h2>
-            {state.phase === "composing" && state.mode === "describe" ? (
-              <p className="chat-canvas-add__subheading">Describe a screen, component, or interaction.</p>
-            ) : null}
+            {/* No subheading here: it read verbatim the same as the textarea's
+                own placeholder directly beneath it. The heading asks; the
+                placeholder answers what to type. */}
           </div>
           <span className="chat-canvas-add__spacer" />
           <button type="button" className="chat-canvas-add__close focus-ring" aria-label="Close composer" onClick={collapse}>
@@ -786,17 +786,23 @@ export function CanvasAddTile({
                 <Icon name="ph:sparkle" aria-hidden /> Create preview
               </button>
             </div>
-            {/* Once there's a description, restate what Create will do rather
-                than leaving a generic tip on screen. Without a familiar picked
-                there is no "who", so the line names the missing step instead. */}
-            <p className="chat-canvas-add__tip">
-              {!state.prompt.trim()
-                ? "Tip: name the surface and the interaction — “a settings pane with grouped toggles that reveal advanced fields”."
-                : activeFamiliarRecord || activeFamiliar
-                  ? `${activeFamiliarLabel} will sketch this · ⌘↵ to run`
-                  : "Pick a familiar to sketch this · ⌘↵ to run"}
-            </p>
-            {!activeFamiliar ? <p className="chat-canvas-add__no-familiar" role="status">Choose a familiar to create a preview.</p> : null}
+            {/* Exactly one line under the controls. The missing-familiar case
+                owns it outright — otherwise the tip, this warning and the
+                disabled Create button all said "pick a familiar" at once. With
+                a familiar chosen the line restates what Create will do; the
+                starting suggestions already carry the "what to write" examples,
+                so the generic tip only appears when they aren't shown. */}
+            {!activeFamiliar ? (
+              <p className="chat-canvas-add__no-familiar" role="status">
+                Choose a familiar to create a preview.
+              </p>
+            ) : state.prompt.trim() ? (
+              <p className="chat-canvas-add__tip">{activeFamiliarLabel} will sketch this · ⌘↵ to run</p>
+            ) : !hero ? (
+              <p className="chat-canvas-add__tip">
+                Tip: name the surface and the interaction — “a settings pane with grouped toggles”.
+              </p>
+            ) : null}
           </>
         ) : (
           <>

--- a/src/styles/chat-canvas.css
+++ b/src/styles/chat-canvas.css
@@ -689,6 +689,16 @@
   flex-wrap: wrap;
   gap: var(--space-1);
 }
+/* Uniform rows, never a ragged last one. Free-wrapping three starter pills in
+   the hero's 560px column lands 2 + 1, which reads as a mistake; one per row
+   keeps the rhythm and lets each suggestion stay on a single line. */
+.chat-canvas-add--hero .chat-canvas-add__suggestions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+}
+.chat-canvas-add--hero .chat-canvas-add__suggestion {
+  text-align: left;
+}
 .chat-canvas-add__suggestion {
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-pill);


### PR DESCRIPTION
The empty-gallery composer — the first thing you meet on Canvas with no sketches — said the same things two and three times over. Reported from a screenshot; all three defects are in code from #3988.

## The subheading was the placeholder

`Describe a screen, component, or interaction.` sat as a subheading directly above a textarea whose placeholder read **`Describe a screen, component, or interaction…`**. You read the same sentence twice in a row.

Removed. The heading asks the question, the placeholder answers what to type — one job each. `.chat-canvas-add__subheading` is *not* orphaned: it still carries the generation-error line at `canvas-add-tile.tsx:557`.

## Three elements said "pick a familiar" simultaneously

The mono tip, the amber warning, and the disabled `Create preview` button all conveyed the same missing step at once.

Now exactly one line lives under the controls:

- **No familiar** → the amber warning owns it outright. It's the only *actionable* one of the three.
- **Familiar + description** → the line restates what Create will do: `Nova will sketch this · ⌘↵ to run`.
- The generic *"name the surface and the interaction"* tip no longer renders in hero mode at all — the three starter pills below the field already **are** the examples it was describing.

## Starter pills wrapped 2 + 1

Free-wrapping three pills in the hero's 560px column landed two on one row and one below, which reads as a mistake rather than a layout — and breaks the standing rule that pill rows are uniform and never ragged.

Hero now grids them one per row: uniform rows, each suggestion on a single line.

## Measured in the DOM

| | before | after |
|---|---|---|
| duplicate subheadings | 1 | **0** |
| lines saying "pick a familiar" | 3 | **1** |
| suggestion rows | 2 + 1 ragged | **3 uniform** |

The card is also visibly shorter — the subheading and the stacked tip were pure vertical waste.

## Verification

`pnpm lint` 0 · `pnpm test:app` **958/958** · `tsc` 0 · codemod no-op · token drift unchanged.

Checked on screen in a production build against a **throwaway `HOME`**, so the empty-gallery state was genuinely empty rather than simulated — the real sketch store was never touched (confirmed unchanged at 16 before and after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)