### PR TITLE
fix(permissions): log access-group edits into the grant-change log

### DIFF
--- a/src/app/api/access-groups/[id]/route.ts
+++ b/src/app/api/access-groups/[id]/route.ts
@@ -82,6 +82,7 @@ export async function PATCH(
       ...(description !== undefined ? { description } : {}),
       ...(memberFamiliarIds !== undefined ? { memberFamiliarIds } : {}),
       ...(projectGrants !== undefined ? { projectGrants } : {}),
+      actor: "loopback",
     });
     return NextResponse.json({ ok: true, group });
   } catch (error) {
@@ -108,7 +109,7 @@ export async function DELETE(
   const rejected = rejectRelayedApproval(payload);
   if (rejected) return rejected;
 
-  const deleted = await deleteAccessGroup(params.id);
+  const deleted = await deleteAccessGroup(params.id, { actor: "loopback" });
   if (!deleted) {
     return NextResponse.json({ ok: false, error: "access group not found" }, { status: 404 });
   }

--- a/src/app/api/access-groups/route.test.ts
+++ b/src/app/api/access-groups/route.test.ts
@@ -85,8 +85,22 @@ assert.match(
 );
 assert.match(
   itemRoute,
-  /deleteAccessGroup\(params\.id\)/,
+  /deleteAccessGroup\(params\.id[,)]/,
   "DELETE should delete the addressed group id",
 );
 
 console.log("access-groups route.test.ts: ok");
+
+// Group mutations feed the grant-change log (cave-8qew1). These routes are
+// isLocalOrigin-only — the phone cannot reach them — so the actor is always
+// loopback; pin it on all three so a later edit can't drop the attribution.
+assert.equal(
+  (listRoute.match(/actor: "loopback"/g) ?? []).length,
+  1,
+  "the create route should record its actor",
+);
+assert.equal(
+  (itemRoute.match(/actor: "loopback"/g) ?? []).length,
+  2,
+  "both the update and delete routes should record their actor",
+);

--- a/src/app/api/access-groups/route.ts
+++ b/src/app/api/access-groups/route.ts
@@ -65,6 +65,9 @@ export async function POST(req: Request) {
     ...(typeof payload.description === "string" ? { description: payload.description } : {}),
     ...(memberFamiliarIds !== undefined ? { memberFamiliarIds } : {}),
     ...(projectGrants !== undefined ? { projectGrants } : {}),
+    // requireLocalHumanGrantMutation is isLocalOrigin-only — the phone cannot
+    // reach group routes at all, so the actor is unambiguous here.
+    actor: "loopback",
   });
   return NextResponse.json({ ok: true, group });
 }

--- a/src/lib/project-grant-audit.test.ts
+++ b/src/lib/project-grant-audit.test.ts
@@ -179,3 +179,140 @@ test("a store written before this log existed loads as empty, not broken", async
 });
 
 console.log("project-grant-audit.test.ts: ok");
+
+// ── Access-group edits (cave-8qew1) ────────────────────────────────────────
+// Group edits are logged by DIFFING effective access, not by echoing the edit.
+// A member who already holds a level directly gains nothing from a group grant,
+// and removing a group grant takes nothing away if another group still confers
+// it — logging the edit itself would claim changes that never happened.
+
+const {
+  updateAccessGroup,
+  deleteAccessGroup,
+} = await import("./project-permissions.ts");
+
+test("creating a populated group logs what each member actually gained", async () => {
+  const before = (await listRecentGrantChanges()).length;
+  const group = await createAccessGroup({
+    name: "Readers",
+    memberFamiliarIds: ["ada", "brie"],
+    projectGrants: [{ projectId: "g1", access: "read" }],
+    actor: "loopback",
+  });
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  const forG1 = added.filter((e) => e.projectId === "g1");
+  assert.equal(forG1.length, 2, "one entry per member who gained access");
+  for (const entry of forG1) {
+    assert.equal(entry.from, null);
+    assert.equal(entry.to, "read");
+    assert.equal(entry.kind, "group");
+    assert.equal(entry.groupId, group.id);
+    assert.equal(entry.actor, "loopback");
+  }
+});
+
+test("adding a member logs only the access they did not already hold", async () => {
+  // cyd already holds write DIRECTLY on g1 — a group read grant gives nothing.
+  await grantProjectToFamiliar({ familiarId: "cyd", projectId: "g1", source: "human", access: "write" });
+  const groups = await (await import("./project-permissions.ts")).listAccessGroups();
+  const readers = groups.find((g) => g.name === "Readers");
+
+  const before = (await listRecentGrantChanges()).length;
+  await updateAccessGroup({
+    groupId: readers.id,
+    memberFamiliarIds: ["ada", "brie", "cyd", "dov"],
+    actor: "loopback",
+  });
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  const names = added.filter((e) => e.projectId === "g1").map((e) => e.familiarId);
+  assert.deepEqual(names.sort(), ["dov"], "only the member whose effective level moved is logged");
+});
+
+test("removing a member logs the access they lost", async () => {
+  const groups = await (await import("./project-permissions.ts")).listAccessGroups();
+  const readers = groups.find((g) => g.name === "Readers");
+  const before = (await listRecentGrantChanges()).length;
+  await updateAccessGroup({
+    groupId: readers.id,
+    memberFamiliarIds: ["ada", "brie", "cyd"],
+    actor: "loopback",
+  });
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  const dov = added.find((e) => e.familiarId === "dov" && e.projectId === "g1");
+  assert.ok(dov, "the removed member is logged");
+  assert.equal(dov.from, "read");
+  assert.equal(dov.to, null);
+});
+
+test("a member with a direct grant loses nothing when the group drops them", async () => {
+  const groups = await (await import("./project-permissions.ts")).listAccessGroups();
+  const readers = groups.find((g) => g.name === "Readers");
+  const before = (await listRecentGrantChanges()).length;
+  await updateAccessGroup({
+    groupId: readers.id,
+    memberFamiliarIds: ["ada", "brie"],
+    actor: "loopback",
+  });
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  assert.equal(
+    added.filter((e) => e.familiarId === "cyd").length,
+    0,
+    "cyd keeps write via its direct grant — nothing changed, so nothing is logged",
+  );
+});
+
+test("deleting a group logs every member's loss and names the group", async () => {
+  const groups = await (await import("./project-permissions.ts")).listAccessGroups();
+  const readers = groups.find((g) => g.name === "Readers");
+  const before = (await listRecentGrantChanges()).length;
+  const deleted = await deleteAccessGroup(readers.id, { actor: "loopback" });
+  assert.equal(deleted, true);
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  const forG1 = added.filter((e) => e.projectId === "g1");
+  assert.deepEqual(forG1.map((e) => e.familiarId).sort(), ["ada", "brie"]);
+  for (const entry of forG1) {
+    assert.equal(entry.from, "read");
+    assert.equal(entry.to, null);
+    assert.equal(entry.kind, "group");
+    assert.equal(entry.groupId, readers.id, "the group that conferred it is named");
+  }
+});
+
+test("a no-op group edit logs nothing", async () => {
+  const group = await createAccessGroup({
+    name: "Noop",
+    memberFamiliarIds: ["ada"],
+    projectGrants: [{ projectId: "g2", access: "read" }],
+    actor: "loopback",
+  });
+  const before = (await listRecentGrantChanges()).length;
+  await updateAccessGroup({ groupId: group.id, name: "Noop renamed", actor: "loopback" });
+  assert.equal(
+    (await listRecentGrantChanges()).length,
+    before,
+    "renaming a group changes no access, so it writes no access record",
+  );
+});
+
+test("overlapping groups: losing one grant is not a loss when another still confers it", async () => {
+  const a = await createAccessGroup({
+    name: "OverlapA",
+    memberFamiliarIds: ["eve"],
+    projectGrants: [{ projectId: "g3", access: "read" }],
+    actor: "loopback",
+  });
+  await createAccessGroup({
+    name: "OverlapB",
+    memberFamiliarIds: ["eve"],
+    projectGrants: [{ projectId: "g3", access: "read" }],
+    actor: "loopback",
+  });
+  const before = (await listRecentGrantChanges()).length;
+  await deleteAccessGroup(a.id, { actor: "loopback" });
+  const added = (await listRecentGrantChanges()).slice(0, (await listRecentGrantChanges()).length - before);
+  assert.equal(
+    added.filter((e) => e.familiarId === "eve" && e.projectId === "g3").length,
+    0,
+    "OverlapB still grants read — effective access did not move, so nothing is logged",
+  );
+});

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -589,6 +589,81 @@ function recordGrantChange(
 }
 
 /**
+ * Effective access for a set of (familiar, project) pairs, as one snapshot.
+ *
+ * Group edits are logged by DIFFING effective access, not by echoing the edit:
+ * adding a member to a group grants nothing they already hold directly, and
+ * removing a group grant takes nothing away if another group still confers it.
+ * Logging the edit itself would claim changes that did not happen.
+ */
+type EffectivePair = { familiarId: string; projectId: string };
+
+function pairKey(familiarId: string, projectId: string): string {
+  return `${familiarId}\u0000${projectId}`;
+}
+
+function effectiveSnapshot(
+  file: ProjectPermissionsFile,
+  pairs: readonly EffectivePair[],
+): Map<string, ProjectAccessLevel | null> {
+  const snapshot = new Map<string, ProjectAccessLevel | null>();
+  for (const { familiarId, projectId } of pairs) {
+    snapshot.set(
+      pairKey(familiarId, projectId),
+      effectiveProjectAccess(file, familiarId, projectId).level ?? null,
+    );
+  }
+  return snapshot;
+}
+
+/**
+ * Every (familiar, project) pair a group edit could move: the union of members
+ * and project grants on BOTH sides of the edit, so removals are covered too.
+ */
+function groupPairs(
+  before: Pick<FamiliarAccessGroup, "memberFamiliarIds" | "projectGrants"> | null,
+  after: Pick<FamiliarAccessGroup, "memberFamiliarIds" | "projectGrants"> | null,
+): EffectivePair[] {
+  const familiars = new Set<string>([
+    ...(before?.memberFamiliarIds ?? []),
+    ...(after?.memberFamiliarIds ?? []),
+  ]);
+  const projects = new Set<string>([
+    ...(before?.projectGrants ?? []).map((grant) => grant.projectId),
+    ...(after?.projectGrants ?? []).map((grant) => grant.projectId),
+  ]);
+  const pairs: EffectivePair[] = [];
+  for (const familiarId of familiars) {
+    for (const projectId of projects) pairs.push({ familiarId, projectId });
+  }
+  return pairs;
+}
+
+/** Record one entry per pair whose EFFECTIVE level actually moved. */
+function recordGroupEffectiveChanges(
+  file: ProjectPermissionsFile,
+  pairs: readonly EffectivePair[],
+  before: Map<string, ProjectAccessLevel | null>,
+  groupId: string,
+  actor: GrantChangeActor,
+): void {
+  for (const { familiarId, projectId } of pairs) {
+    const from = before.get(pairKey(familiarId, projectId)) ?? null;
+    const to = effectiveProjectAccess(file, familiarId, projectId).level ?? null;
+    if (from === to) continue;
+    recordGrantChange(file, {
+      familiarId,
+      projectId,
+      from,
+      to,
+      actor,
+      kind: "group",
+      groupId,
+    });
+  }
+}
+
+/**
  * Most-recent grant changes, newest first, capped to `limit`.
  *
  * Ties on `at` break on append order, not arbitrarily: a bulk "Set all" writes
@@ -901,6 +976,8 @@ export async function createAccessGroup(input: {
   description?: string;
   memberFamiliarIds?: string[];
   projectGrants?: { projectId: string; access?: ProjectAccessLevel }[];
+  /** Who is making the change; defaults to the app itself. */
+  actor?: GrantChangeActor;
 }): Promise<FamiliarAccessGroup> {
   const name = input.name.trim();
   if (!name) throw new Error("access group name is required");
@@ -916,7 +993,12 @@ export async function createAccessGroup(input: {
       createdAt: now,
       updatedAt: now,
     };
+    // A group can arrive already populated with members AND project grants,
+    // granting several familiars access in one call.
+    const pairs = groupPairs(null, group);
+    const before = effectiveSnapshot(file, pairs);
     file.accessGroups.push(group);
+    recordGroupEffectiveChanges(file, pairs, before, group.id, input.actor ?? "system");
     await saveProjectPermissions(file);
     return group;
   }));
@@ -928,11 +1010,19 @@ export async function updateAccessGroup(input: {
   description?: string | null;
   memberFamiliarIds?: string[];
   projectGrants?: { projectId: string; access?: ProjectAccessLevel }[];
+  /** Who is making the change; defaults to the app itself. */
+  actor?: GrantChangeActor;
 }): Promise<FamiliarAccessGroup> {
   return withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
     const group = file.accessGroups.find((candidate) => candidate.id === input.groupId);
     if (!group) throw new AccessGroupNotFoundError();
+    // Snapshot BEFORE the in-place edit — members and grants are rewritten
+    // wholesale, so the prior side is otherwise unrecoverable.
+    const priorShape = {
+      memberFamiliarIds: [...group.memberFamiliarIds],
+      projectGrants: group.projectGrants.map((grant) => ({ ...grant })),
+    };
     if (input.name !== undefined) {
       const name = input.name.trim();
       if (!name) throw new Error("access group name is required");
@@ -948,17 +1038,38 @@ export async function updateAccessGroup(input: {
     }
     group.projectGrants = normalizeGroupGrants(input.projectGrants, group.projectGrants);
     group.updatedAt = new Date().toISOString();
+    const pairs = groupPairs(priorShape, group);
+    // Recompute "before" against the pre-edit shape: swap the prior members and
+    // grants back in, measure, then restore. Cheaper and less error-prone than
+    // cloning the whole file.
+    const editedMembers = group.memberFamiliarIds;
+    const editedGrants = group.projectGrants;
+    group.memberFamiliarIds = priorShape.memberFamiliarIds;
+    group.projectGrants = priorShape.projectGrants;
+    const before = effectiveSnapshot(file, pairs);
+    group.memberFamiliarIds = editedMembers;
+    group.projectGrants = editedGrants;
+    recordGroupEffectiveChanges(file, pairs, before, group.id, input.actor ?? "system");
     await saveProjectPermissions(file);
     return group;
   }));
 }
 
-export async function deleteAccessGroup(groupId: string): Promise<boolean> {
+export async function deleteAccessGroup(
+  groupId: string,
+  options: { actor?: GrantChangeActor } = {},
+): Promise<boolean> {
   return withProjectPermissionsStore(() => withWriteMutex(async () => {
     const file = await loadProjectPermissionsUnlocked();
+    const removed = file.accessGroups.find((group) => group.id === groupId) ?? null;
     const next = file.accessGroups.filter((group) => group.id !== groupId);
     if (next.length === file.accessGroups.length) return false;
+    // Deleting a group takes away everything it conferred, from every member
+    // at once — the widest single change the model allows.
+    const pairs = groupPairs(removed, null);
+    const before = effectiveSnapshot(file, pairs);
     file.accessGroups = next;
+    recordGroupEffectiveChanges(file, pairs, before, groupId, options.actor ?? "system");
     await saveProjectPermissions(file);
     return true;
   }));


### PR DESCRIPTION
Closes `cave-8qew1`. Follow-up to #4003, which gave **direct** grant mutations a `grantAudit` trail.

## The gap

Group mutations wrote nothing — and they're the higher-leverage path, since one edit can move N familiars × M projects at once. Three mutators were silent:

| mutator | what it can do silently |
|---|---|
| `createAccessGroup` | arrive with members **and** project grants already populated, granting several familiars in one call |
| `updateAccessGroup` | rewrites members and grants wholesale — adding one member grants them everything the group holds; dropping a grant takes it from every member |
| `deleteAccessGroup` | every member loses everything the group conferred |

## Logged by diffing, not by echoing the edit

For every `(familiar, project)` pair the edit could touch — the union of members and grants on **both** sides — this snapshots the effective level, mutates, recomputes, and writes an entry only where it *actually moved*.

So:
- a member who already holds `write` directly gains nothing from a group `read` grant → no entry
- dropping a member who has a direct grant takes nothing away → no entry
- deleting one of two overlapping groups changes nothing while the other still confers it → no entry

That last case is why diffing rather than echoing: a naive implementation would report a revocation that never happened. There's a test for exactly it.

## Two implementation notes

**`updateAccessGroup` edits in place**, so the prior side is unrecoverable by the time you'd measure it. It snapshots the shape first, then briefly swaps the old members/grants back to measure "before" against the real file — cheaper and less error-prone than cloning the store.

**Actor is `loopback` unconditionally**, not `isVerifiedMobileRequest`. These routes are gated by `requireLocalHumanGrantMutation`, which is `isLocalOrigin`-only — the phone can't reach them at all, unlike direct grants. Copying the mobile-aware pattern from #4003 would imply a distinction that doesn't exist.

**No schema change** — `GrantChangeKind: "group"` and the optional `groupId` were already in the type from #4003, previously used only by the project-removal cascade.

## Verification

- **7 new behavioral tests** (17 total in the file). 4 of the 7 fail against the pre-fix code; the other 3 are negative assertions guarding against *over*-logging, which pass trivially when nothing is ever logged — noting that rather than claiming all 7 are regression-proof.
- **Full suites, not just touched files:** `test:api` 289 files and `test:app` 962 files, both exit 0. #4003's CI failure was a source-pin I'd missed by running only the files I edited, so this time both suites ran locally first.
- `tsc --noEmit`, `pnpm lint`, `check-tests-wired` (1321) — clean.

Also relaxes a route pin that required `deleteAccessGroup(params.id)` to close immediately, and adds pins asserting the `loopback` actor on all three routes so a later edit can't silently drop attribution from one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)