### PR TITLE
chore(release): stamp v0.2.1

### DIFF
--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.2.0"
+    MARKETING_VERSION: "0.2.1"
     CURRENT_PROJECT_VERSION: "1"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",
   "author": "OpenCoven contributors",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "block2",
  "fs2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.2.0"
+version = "0.2.1"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Version stamp for **v0.2.1**. 383 commits since `v0.2.0`.

Highlights since the last release:
- **Daily report** — the chaptered-day redesign (#3981), single-screen at md+ with no forward paging past today (#3982), viewport fill (#3986), graphs sized to content (#3989), pull requests opening in the app's own GitHub card (#3993), historical backfill + a graceful empty state (#3996), and its own row in Rituals out of "Needs you" (#3999).
- **Chat** — session/new-session/sessions-list rebuild, Queue and Reviews groups in the new-session launcher.
- **Fixes** — nested page navigation, permissions grant logging, Memories search visibility, GitHub incomplete-activity disclosure.

## The stamp

Five locations, all pinned by `src/lib/app-version.test.ts`:

| File | |
| --- | --- |
| `package.json` | top-level `version` |
| `src-tauri/Cargo.toml` | `[package] version` |
| `src-tauri/tauri.conf.json` | bundle `version` |
| `src-tauri/Cargo.lock` | the **`app`** package block only |
| `apps/ios/CovenCave/project.yml` | `MARKETING_VERSION` |

⚠️ The `Cargo.lock` edit is deliberately surgical: several unrelated crates (`core-graphics-types`, `foldhash`, `option-ext`, `ordered-stream`, `powerfmt`, `windows-collections`, `windows-numerics`) also sit at `0.2.0`, and a blanket replace would have corrupted their pins. The diff is one line inside the `[[package]] name = "app"` block — visible in the diff below.

`app-version.test.ts` passes. Once this merges I'll push the signed `v0.2.1` tag to trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)