### PR TITLE
fix(shell): make the sidebar version line open Settings → About

### DIFF
--- a/src/components/sidebar-footer.test.ts
+++ b/src/components/sidebar-footer.test.ts
@@ -16,6 +16,33 @@ assert.match(footer, /export function SidebarFooter\(\{ onOpenSettings \}/, "Sid
 assert.match(footer, /href="\/dashboard"/, "footer links to the Dashboard route");
 assert.match(footer, /onClick=\{onOpenSettings\}[\s\S]*?aria-label="Settings"/, "footer Settings button calls onOpenSettings");
 assert.match(footer, /className="sidebar-version"[\s\S]*?v\{APP_VERSION\}/, "footer shows the app version line");
+// The version line is the shortest path to what it's about: Settings → About
+// carries the version, updates and project links, and the settings shell
+// honours the `#about` section hash. It's a real link to the standalone route
+// (same idiom as the Dashboard link above), not an onOpenSettings caller —
+// which also keeps middle-click / open-in-new-window working.
+assert.match(footer, /href="\/settings#about"/, "the version line deep-links to Settings → About");
+assert.match(
+  footer,
+  /className="sidebar-version"[\s\S]{0,240}?aria-label=\{`CovenCave v\$\{APP_VERSION\} — open About in Settings`\}/,
+  "the version link says where it goes, since 'v0.2.0' alone is not an action",
+);
+const aboutSection = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
+assert.match(aboutSection, /id: "about"/, "the About section id the version line targets exists");
+
+// Quiet at rest, and only admits to being a link on hover/focus — the footer's
+// calm is the point.
+const shellChrome = readFileSync(new URL("../styles/sidebar-minimal/shell-chrome.css", import.meta.url), "utf8");
+assert.match(
+  shellChrome,
+  /\.sidebar-version:hover,\s*\n\.sidebar-version:focus-visible \{\s*\n\s*color: var\(--text-primary\);/,
+  "the version link brightens on hover and keyboard focus",
+);
+assert.match(
+  shellChrome,
+  /\.sidebar-version \{[\s\S]*?text-decoration: none;/,
+  "no underline — it stays the calmest line in the footer",
+);
 
 // Each alternate nav host renders it, so the active footer cannot drift…
 assert.match(minimal, /import \{ SidebarFooter \} from "@\/components\/sidebar-footer"/, "SidebarMinimal imports the shared footer");

--- a/src/components/sidebar-footer.tsx
+++ b/src/components/sidebar-footer.tsx
@@ -45,10 +45,21 @@ export function SidebarFooter({ onOpenSettings }: { onOpenSettings: () => void }
         </button>
       </div>
 
-      {/* Bottommost: app version — one minimal-height muted line. */}
-      <div className="sidebar-version" title={`CovenCave v${APP_VERSION}`}>
+      {/* Bottommost: app version — one minimal-height muted line, and the
+          shortest path to what it's about. "Which version am I on, and is
+          there a newer one?" is answered in Settings → About (version,
+          updates, project links), so the line links there instead of being
+          the one dead label in the footer. A real <a> to the standalone
+          /settings route, matching the Dashboard link above; the #about hash
+          is the section deep-link the settings shell already honours. */}
+      <a
+        className="sidebar-version"
+        href="/settings#about"
+        title={`CovenCave v${APP_VERSION} — version, updates and project links`}
+        aria-label={`CovenCave v${APP_VERSION} — open About in Settings`}
+      >
         v{APP_VERSION}
-      </div>
+      </a>
     </>
   );
 }

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -408,9 +408,11 @@ assert.match(
   /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
   "the shared footer reads the version from the shared app-version module",
 );
+// It became a link to Settings → About (see sidebar-footer.test.ts); still one
+// minimal-height muted line, still the bottommost element.
 assert.match(
   footer,
-  /className="sidebar-version"[\s\S]{0,120}?v\{APP_VERSION\}[\s\S]{0,40}?<\/div>/,
+  /className="sidebar-version"[\s\S]{0,280}?v\{APP_VERSION\}[\s\S]{0,40}?<\/a>/,
   "the version line is the bottommost element of the shared footer",
 );
 // Phase D (chat-revamp): the rail-only account avatar circle closes the nav,

--- a/src/styles/sidebar-minimal/shell-chrome.css
+++ b/src/styles/sidebar-minimal/shell-chrome.css
@@ -368,13 +368,23 @@
 /* Bottommost element: the app version. One minimal-height line — small,
    muted, unselectable; the footer above keeps its calm hairline boundary. */
 .sidebar-version {
+  display: block;
   flex-shrink: 0;
   padding: 3px 6px var(--space-1);
   font-size: 10.5px;
   line-height: 1;
   text-align: center;
   color: var(--text-muted);
+  text-decoration: none;
   user-select: none;
+  transition: color 0.12s ease;
+}
+
+/* Quiet at rest — it stays the calmest thing in the footer — and only
+   admits to being a link on hover/focus. */
+.sidebar-version:hover,
+.sidebar-version:focus-visible {
+  color: var(--text-primary);
 }
 
 .sidebar-foot-bell:hover,


### PR DESCRIPTION
`v0.2.0` sat at the bottom of the side panel as the one dead label in it — directly under the Settings button, and the exact question it raises ("which version am I on, and is there a newer one?") is answered one click away in **Settings → About**: app version, update check, daemon build, project links.

It now links there.

## Why a link, not a button

A real `<a href="/settings#about">`, matching the **Dashboard** link two rows above it — both are standalone Next routes rather than workspace modes. That keeps middle-click and open-in-new-window working, which an `onClick` handler would silently break. `#about` is the section hash the settings shell already honours (`settings-shell.tsx` reads `location.hash` against the `SECTIONS` ids).

## Still the calmest line in the footer

Same muted 10.5px line, no underline; it only admits to being a link on hover and keyboard focus. Unchanged in the 56px icon rail, where an existing rule hides the version entirely for want of room.

## Verification

Driven in the running app:

- the link renders as `<a href="/settings#about">` with aria-label `CovenCave v0.2.0 — open About in Settings` and no underline
- with the nav expanded it's a 211×18 hit area; clicking it lands on `/settings#about` with **About** the active section
- collapsed to the rail it stays hidden, as before

| Gate | Result |
|---|---|
| `pnpm build` | pass |
| `pnpm test:app` | 965 files pass |
| `typecheck` · `lint` · token-drift | pass |

Two existing pins updated for the element change (`</div>` → `</a>`): `sidebar-footer.test.ts` and `sidebar-minimal.test.ts` — both keep asserting the version is the footer's bottommost line, and the footer test now also pins the destination, the accessible name, and the quiet-at-rest styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)