### PR TITLE
chore(runtimes): sync accepted registry from coven-runtimes

### DIFF
--- a/src/lib/runtime-registry.gen.ts
+++ b/src/lib/runtime-registry.gen.ts
@@ -2,7 +2,7 @@
 // Re-generate with: pnpm sync:runtimes
 //
 // Source: OpenCoven/coven-runtimes canonical registry index
-//   ref:      v0.2.0
+//   ref:      main
 //   blob sha: ced69d5b532f7c1478a1f45d00c0701ab948e221
 //
 // Every entry passed coven-runtimes acceptance (conformance + review), so
@@ -38,7 +38,7 @@ export type RegistryRuntime = {
 
 export const REGISTRY_SOURCE = {
   repo: "OpenCoven/coven-runtimes",
-  ref: "v0.2.0",
+  ref: "main",
   blobSha: "ced69d5b532f7c1478a1f45d00c0701ab948e221",
 } as const;
 


### PR DESCRIPTION
Automated sync of the accepted runtime registry from `OpenCoven/coven-runtimes`.

## Accepted runtimes
- `copilot@1.0.0` — GitHub Copilot CLI
- `grok@1.0.0` — Grok Build
- `hermes@1.0.3` — Hermes Agent
- `opencode@0.1.1` — OpenCode

Source blob: `ced69d5b532f7c1478a1f45d00c0701ab948e221` (ref `main`)

Review the diff, wait for required checks, then merge. Generated by the `Sync runtimes registry` workflow.