### PR TITLE
test(opencoven): stop asserting a UI latency budget in the launcher e2e test

### DIFF
--- a/src/lib/opencoven-tools-resolve.test.ts
+++ b/src/lib/opencoven-tools-resolve.test.ts
@@ -364,39 +364,39 @@ test("end-to-end on a real filesystem: stale launcher removed, fresh copy verifi
   }
   const root = await mkdtemp(path.join(os.tmpdir(), "coven-resolve-e2e-"));
   try {
-  const makeInstall = async (prefix: string, version: string) => {
-    const pkg = path.join(prefix, "lib", "node_modules", "@opencoven", "cli");
-    const bin = path.join(prefix, "bin");
-    await mkdir(path.join(pkg, "bin"), { recursive: true });
-    await mkdir(bin, { recursive: true });
-    await writeFile(
-      path.join(pkg, "package.json"),
-      JSON.stringify({ name: "@opencoven/cli", version, bin: { coven: "bin/coven.js" } }),
-    );
-    await writeFile(
-      path.join(pkg, "bin", "coven.js"),
-      `#!/usr/bin/env node\nconsole.log("coven v${version}");\n`,
-      { mode: 0o755 },
-    );
-    await symlink(
-      path.relative(bin, path.join(pkg, "bin", "coven.js")),
-      path.join(bin, "coven"),
-    );
-    return { launcher: path.join(bin, "coven") };
-  };
+    const makeInstall = async (prefix: string, version: string) => {
+      const pkg = path.join(prefix, "lib", "node_modules", "@opencoven", "cli");
+      const bin = path.join(prefix, "bin");
+      await mkdir(path.join(pkg, "bin"), { recursive: true });
+      await mkdir(bin, { recursive: true });
+      await writeFile(
+        path.join(pkg, "package.json"),
+        JSON.stringify({ name: "@opencoven/cli", version, bin: { coven: "bin/coven.js" } }),
+      );
+      await writeFile(
+        path.join(pkg, "bin", "coven.js"),
+        `#!/usr/bin/env node\nconsole.log("coven v${version}");\n`,
+        { mode: 0o755 },
+      );
+      await symlink(
+        path.relative(bin, path.join(pkg, "bin", "coven.js")),
+        path.join(bin, "coven"),
+      );
+      return { launcher: path.join(bin, "coven") };
+    };
 
-  const stale = await makeInstall(path.join(root, "stale"), "0.0.54");
-  const good = await makeInstall(path.join(root, "good"), LATEST);
-  const covenPath = [
-    path.join(root, "stale", "bin"),
-    path.join(root, "good", "bin"),
-    path.dirname(process.execPath),
-    // `which` and realpath live in the system dirs on every CI platform.
-    "/usr/bin",
-    "/bin",
-  ].join(path.delimiter);
+    const stale = await makeInstall(path.join(root, "stale"), "0.0.54");
+    const good = await makeInstall(path.join(root, "good"), LATEST);
+    const covenPath = [
+      path.join(root, "stale", "bin"),
+      path.join(root, "good", "bin"),
+      path.dirname(process.execPath),
+      // `which` and realpath live in the system dirs on every CI platform.
+      "/usr/bin",
+      "/bin",
+    ].join(path.delimiter);
 
-  const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, {
+    const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, {
       refreshEnv: () => ({ ...process.env, PATH: covenPath }),
       npmGlobalPrefix: async () => path.join(root, "good"),
       // This test spawns real child processes (`which`, then `node coven.js

--- a/src/lib/opencoven-tools-resolve.test.ts
+++ b/src/lib/opencoven-tools-resolve.test.ts
@@ -346,11 +346,15 @@ test("npmGlobalPrefixFromNpmPath routes Windows npm.cmd through node npm-cli.js"
 
 test("removeLauncherFile deletes files but refuses directories", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "coven-resolve-"));
-  const file = path.join(dir, "coven");
-  await writeFile(file, "#!/bin/sh\n");
+  try {
+    const file = path.join(dir, "coven");
+    await writeFile(file, "#!/bin/sh\n");
 
-  await removeLauncherFile(file);
-  await assert.rejects(() => removeLauncherFile(dir), /is not a launcher file/);
+    await removeLauncherFile(file);
+    await assert.rejects(() => removeLauncherFile(dir), /is not a launcher file/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });
 
 test("end-to-end on a real filesystem: stale launcher removed, fresh copy verifies", async (t) => {
@@ -359,6 +363,7 @@ test("end-to-end on a real filesystem: stale launcher removed, fresh copy verifi
     return;
   }
   const root = await mkdtemp(path.join(os.tmpdir(), "coven-resolve-e2e-"));
+  try {
   const makeInstall = async (prefix: string, version: string) => {
     const pkg = path.join(prefix, "lib", "node_modules", "@opencoven", "cli");
     const bin = path.join(prefix, "bin");
@@ -392,15 +397,27 @@ test("end-to-end on a real filesystem: stale launcher removed, fresh copy verifi
   ].join(path.delimiter);
 
   const resolution = await resolveStaleOpenCovenLaunchers("coven-cli", LATEST, {
-    refreshEnv: () => ({ ...process.env, PATH: covenPath }),
-    npmGlobalPrefix: async () => path.join(root, "good"),
-  });
+      refreshEnv: () => ({ ...process.env, PATH: covenPath }),
+      npmGlobalPrefix: async () => path.join(root, "good"),
+      // This test spawns real child processes (`which`, then `node coven.js
+      // --version`). The production budgets are UI latency deadlines — 1.5s
+      // and 2.5s — and inheriting them here makes the assertion a race with
+      // whatever else the machine is doing: every gate below declines when a
+      // probe times out, and the failure reads as a bare `removed: []`.
+      // What is under test is the DECISION, not how fast the box answers.
+      probeTimeoutMs: 30_000,
+    });
 
-  assert.deepEqual(resolution.removed, [stale.launcher]);
-  assert.ok(resolution.verification?.ok, "fresh copy verifies after real removal");
-  assert.equal(resolution.verification?.current, LATEST);
-  assert.equal(resolution.verification?.path, good.launcher);
-  await rm(root, { recursive: true, force: true });
+    // Every gate that declines explains itself in `log`; without it a failure
+    // here is just an empty array with no way to tell which one gave up.
+    const why = resolution.log.join(" | ") || "(no log lines)";
+    assert.deepEqual(resolution.removed, [stale.launcher], `stale launcher not removed — ${why}`);
+    assert.ok(resolution.verification?.ok, `fresh copy did not verify — ${why}`);
+    assert.equal(resolution.verification?.current, LATEST);
+    assert.equal(resolution.verification?.path, good.launcher);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
 });
 
 console.log("opencoven-tools-resolve.test.ts: ok");

--- a/src/lib/opencoven-tools-resolve.ts
+++ b/src/lib/opencoven-tools-resolve.ts
@@ -67,6 +67,10 @@ export type StaleLauncherResolution = {
 
 export type StaleLauncherDependencies = {
   platform?: NodeJS.Platform;
+  /** Child-process budget for the real PATH lookup and `--version` probes.
+   *  Defaults to the UI latency budgets in opencoven-tools-status. Raise it
+   *  when the caller needs the true answer more than a fast one. */
+  probeTimeoutMs?: number;
   refreshEnv?: () => NodeJS.ProcessEnv;
   /** Resolve npm's global prefix (`npm prefix -g`). */
   npmGlobalPrefix?: (env: NodeJS.ProcessEnv) => Promise<string | null>;
@@ -260,11 +264,14 @@ export async function resolveStaleOpenCovenLaunchers(
   const platform = dependencies.platform ?? process.platform;
   const refreshEnv = dependencies.refreshEnv ?? refreshCovenSpawnEnv;
   const npmGlobalPrefix = dependencies.npmGlobalPrefix ?? defaultNpmGlobalPrefix;
+  const probeTimeoutMs = dependencies.probeTimeoutMs;
   const discover =
     dependencies.discover ??
     ((spec: OpenCovenToolSpec, env: NodeJS.ProcessEnv) =>
-      discoverOpenCovenTool(spec, { env }));
-  const probeAt = dependencies.probeAt ?? probeOpenCovenBinaryAt;
+      discoverOpenCovenTool(spec, { env, timeoutMs: probeTimeoutMs }));
+  const probeAt =
+    dependencies.probeAt ??
+    ((spec, binaryPath, env) => probeOpenCovenBinaryAt(spec, binaryPath, env, { timeoutMs: probeTimeoutMs }));
   const fileExists = dependencies.fileExists ?? defaultFileExists;
   const removeFile = dependencies.removeFile ?? removeLauncherFile;
 

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -123,14 +123,26 @@ function firstSemver(text: string): string | null {
   return match?.[1] ?? null;
 }
 
+/** How long a PATH lookup (`which`/`where`) may take before we treat the tool
+ *  as absent, and how long a launcher may take to answer `--version`.
+ *
+ *  These are UI latency budgets, not correctness thresholds: a wedged launcher
+ *  must not stall the settings surface behind it. Callers that care about the
+ *  ANSWER rather than the wait — an end-to-end test on a loaded machine, say —
+ *  pass their own budget instead of inheriting a deadline tuned for a
+ *  responsive UI, which is otherwise a coin flip they'd lose occasionally. */
+const LOOKUP_TIMEOUT_MS = 1500;
+const VERSION_PROBE_TIMEOUT_MS = 2500;
+
 async function commandPath(
   binary: string,
-  options: { env?: NodeJS.ProcessEnv; refresh?: boolean } = {},
+  options: { env?: NodeJS.ProcessEnv; refresh?: boolean; timeoutMs?: number } = {},
 ): Promise<CommandPathResult> {
   const finder = process.platform === "win32" ? "where" : "which";
+  const timeout = options.timeoutMs ?? LOOKUP_TIMEOUT_MS;
   const find = async (env: NodeJS.ProcessEnv): Promise<CommandPathResult> => {
     try {
-      const { stdout } = await execFileAsync(finder, [binary], { env, timeout: 1500 });
+      const { stdout } = await execFileAsync(finder, [binary], { env, timeout });
       const lines = stdout.split(/\r?\n/);
       return {
         path:
@@ -227,10 +239,10 @@ async function packageIdentityForExecutable(
 
 export async function discoverOpenCovenTool(
   tool: OpenCovenToolSpec,
-  options: { env?: NodeJS.ProcessEnv } = {},
+  options: { env?: NodeJS.ProcessEnv; timeoutMs?: number } = {},
 ): Promise<OpenCovenToolProbe> {
   const env = options.env ?? refreshCovenSpawnEnv();
-  const located = await commandPath(tool.binary, { env });
+  const located = await commandPath(tool.binary, { env, timeoutMs: options.timeoutMs });
   if (!located.path) {
     return {
       path: null,
@@ -241,7 +253,7 @@ export async function discoverOpenCovenTool(
       packagePath: null,
     };
   }
-  return probeOpenCovenBinaryAt(tool, located.path, env);
+  return probeOpenCovenBinaryAt(tool, located.path, env, { timeoutMs: options.timeoutMs });
 }
 
 /** Probe one explicit launcher path (no PATH lookup): resolve its executable
@@ -252,6 +264,7 @@ export async function probeOpenCovenBinaryAt(
   tool: Pick<OpenCovenToolSpec, "binary" | "versionArgs">,
   binaryPath: string,
   env: NodeJS.ProcessEnv = refreshCovenSpawnEnv(),
+  options: { timeoutMs?: number } = {},
 ): Promise<OpenCovenToolProbe> {
   const executablePath = await resolvedExecutablePath(binaryPath);
   const identity = executablePath
@@ -273,7 +286,7 @@ export async function probeOpenCovenBinaryAt(
     const { stdout, stderr } = await execFileAsync(
       launch.command,
       [...launch.fixedArgs, ...tool.versionArgs],
-      { env, timeout: 2500 },
+      { env, timeout: options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS },
     );
     const version = firstSemver(`${stdout}\n${stderr}`);
     return {


### PR DESCRIPTION
`src/lib/opencoven-tools-resolve.test.ts` has been failing intermittently, always with the same uninformative message: `removed` was `[]` instead of the stale launcher.

## Root cause (reproduced, not guessed)

The end-to-end test spawns **real child processes** — `which coven`, then `node coven.js --version` — and inherited production's timeouts: **1.5 s** for the PATH lookup, **2.5 s** for the version probe.

Those are *UI latency budgets*: a wedged launcher must not stall the settings surface behind it. As a **test deadline** they're a race with whatever else the machine is doing. When the probe loses that race, gate 0 declines — *"the copy at … did not verify as the freshly installed @opencoven/cli"* — and every later gate follows, producing exactly `removed: []`.

Demonstrated by driving the real resolver at two budgets:

| probe budget | `removed` | first log line |
|---|---|---|
| 1 ms | `[]` | `Stale-launcher cleanup skipped: the copy at … did not verify` |
| 30 000 ms | `["…/stale/bin/coven"]` | `Removed stale coven launcher at …` |

The top row is byte-for-byte the observed failure. **The decision logic was never wrong — only the deadline was.**

## The fix

- The two budgets become named constants (`LOOKUP_TIMEOUT_MS`, `VERSION_PROBE_TIMEOUT_MS`) with a comment stating what they're for, overridable via `probeTimeoutMs` on the resolver's dependencies, threaded into the real discovery/probe path. **Production values unchanged.**
- The e2e test passes 30 s. It still spawns the real processes against a real filesystem — what's under test is the *decision*, not how fast the box answers.
- **Failures now explain themselves**: `resolution.log` rides in the assertion message, so the next failure names the gate that declined instead of showing a bare empty array.
- Both temp-dir tests clean up in a `finally` — previously an assertion failure leaked the directory into `os.tmpdir()`.

| Gate | Result |
|---|---|
| `pnpm test:app` | 967 files pass |
| `typecheck` · `lint` | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)