### PR TITLE
fix: widen OpenCoven Tools settings control

### DIFF
--- a/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
+++ b/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
@@ -1,0 +1,314 @@
+# OpenCoven Tools Full-Width Settings Control Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the OpenCoven Tools control a full-width desktop row on Settings > About while keeping CovenCave compact and preserving the existing narrow layout.
+
+**Architecture:** Keep the existing two-column `.settings-about-control-grid` and mark only the OpenCoven Tools control with a focused wide modifier. The modifier spans all explicit grid columns; the existing `55rem` single-column container rule continues to handle narrow panes without an override.
+
+**Tech Stack:** React 19, TypeScript, CSS Grid, Node test runner, pnpm, Next.js 16, Playwright via the project `run-cave-app` skill.
+
+---
+
+## File Map
+
+- Modify `src/components/settings-about.test.ts` to pin the OpenCoven Tools
+  modifier and its full-span CSS contract.
+- Modify `src/components/settings-about.tsx` to apply the modifier to the
+  existing OpenCoven Tools control only.
+- Modify `src/styles/settings-about.css` to make the modifier span the controls
+  grid without adding tokens or breakpoints.
+- Keep
+  `docs/superpowers/specs/2026-07-29-opencoven-tools-full-width-design.md` as
+  the source of truth for scope and responsive behavior.
+
+### Task 1: Add the failing layout contract
+
+**Files:**
+- Modify: `src/components/settings-about.test.ts`
+- Test: `src/components/settings-about.test.ts`
+
+- [ ] **Step 1: Install the worktree dependencies**
+
+Run:
+
+```bash
+cd .worktrees/cave-77y74-opencoven-tools-full-width
+pnpm install --frozen-lockfile
+```
+
+Expected: installation succeeds and `git status --short` shows no dependency
+manifest or lockfile changes.
+
+- [ ] **Step 2: Add the source-contract test**
+
+Insert this test after
+`"About ports the Claude Design hero and live control-sheet hierarchy"`:
+
+```ts
+test("About gives OpenCoven Tools a full-width desktop row", () => {
+  assert.match(
+    component,
+    /id=\{settingsGroupId\("OpenCoven tools"\)\}[\s\S]*?className="settings-about-control settings-about-control--wide"/,
+  );
+  assert.match(
+    css,
+    /\.settings-about-control--wide\s*\{[^}]*grid-column:\s*1\s*\/\s*-1;/,
+  );
+});
+```
+
+- [ ] **Step 3: Run the focused test and verify the new contract fails**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/components/settings-about.test.ts
+```
+
+Expected: the new
+`About gives OpenCoven Tools a full-width desktop row` test fails because the
+component does not yet contain `settings-about-control--wide`.
+
+### Task 2: Implement the full-width control
+
+**Files:**
+- Modify: `src/components/settings-about.tsx:466-471`
+- Modify: `src/styles/settings-about.css:181-191`
+- Test: `src/components/settings-about.test.ts`
+
+- [ ] **Step 1: Apply the modifier to OpenCoven Tools only**
+
+Change the existing OpenCoven Tools container to:
+
+```tsx
+<div
+  id={settingsGroupId("OpenCoven tools")}
+  data-settings-group
+  className="settings-about-control settings-about-control--wide"
+>
+```
+
+Leave the CovenCave container as `className="settings-about-control"`.
+
+- [ ] **Step 2: Add the minimal grid-span rule**
+
+Add this rule immediately after `.settings-about-control-grid`:
+
+```css
+.settings-about-control--wide {
+  grid-column: 1 / -1;
+}
+```
+
+Do not add a narrow-pane override: on the existing one-column grid,
+`1 / -1` already spans the single explicit column.
+
+- [ ] **Step 3: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+node --experimental-strip-types --test src/components/settings-about.test.ts
+```
+
+Expected: all About tests pass, including
+`About gives OpenCoven Tools a full-width desktop row`.
+
+- [ ] **Step 4: Check the implementation diff**
+
+Run:
+
+```bash
+git diff --check
+git diff -- src/components/settings-about.tsx \
+  src/styles/settings-about.css \
+  src/components/settings-about.test.ts
+```
+
+Expected: no whitespace errors; the diff contains only the test, one modifier
+class, and one CSS rule.
+
+- [ ] **Step 5: Commit and push the implementation**
+
+Run:
+
+```bash
+git add src/components/settings-about.tsx \
+  src/styles/settings-about.css \
+  src/components/settings-about.test.ts
+git commit -S \
+  -m "fix: widen OpenCoven Tools settings control" \
+  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+Expected: the signed implementation commit succeeds and the remote feature
+branch advances.
+
+### Task 3: Verify design, behavior, and production gates
+
+**Files:**
+- Verify: `src/components/settings-about.tsx`
+- Verify: `src/styles/settings-about.css`
+- Verify: `src/components/settings-about.test.ts`
+
+- [ ] **Step 1: Run the design and type gates**
+
+Run:
+
+```bash
+pnpm lint
+pnpm typecheck
+pnpm check:tests-wired
+```
+
+Expected: all commands exit successfully; no design-token or test-registration
+ratchet changes are required.
+
+- [ ] **Step 2: Run the complete app test suite**
+
+Run:
+
+```bash
+pnpm test:app
+```
+
+Expected: the full app suite passes with no failures.
+
+- [ ] **Step 3: Run the production build and budgets**
+
+Run:
+
+```bash
+pnpm build
+```
+
+Expected: Next.js, the server build, bundle budgets, and standalone budgets all
+pass.
+
+- [ ] **Step 4: Verify the real layout**
+
+Invoke the project `run-cave-app` skill, open Settings > About, and capture:
+
+1. A desktop screenshot wider than the `55rem` About container breakpoint.
+2. A narrow screenshot at or below the breakpoint.
+
+Expected desktop geometry:
+
+- CovenCave remains one grid column.
+- OpenCoven Tools sits on the following row.
+- OpenCoven Tools spans the complete controls-grid width.
+
+Expected narrow geometry:
+
+- Both controls remain in one-column document order.
+- No horizontal overflow appears.
+- Existing actions, focus styles, status text, and tool controls remain
+  unchanged.
+
+- [ ] **Step 5: Record verification in the Bead**
+
+Run:
+
+```bash
+bd update cave-77y74 --append-notes \
+  "Verification: focused About test, lint/design gates, typecheck, test registration, full app suite, production build/budgets, and desktop+narrow real-app layout checks passed."
+```
+
+Expected: Bead `cave-77y74` remains in progress with current verification
+evidence attached.
+
+### Task 4: Review, publish, and merge through protected main
+
+**Files:**
+- Review the complete branch diff against:
+  `docs/superpowers/specs/2026-07-29-opencoven-tools-full-width-design.md`
+
+- [ ] **Step 1: Request an independent code review**
+
+Invoke the `requesting-code-review` skill on the complete branch diff.
+
+Expected: no high-confidence correctness, accessibility, responsive-layout, or
+scope issues remain. If review finds a real issue, fix it, rerun the affected
+checks, commit the fix separately, and push it.
+
+- [ ] **Step 2: Open the focused pull request**
+
+Run:
+
+```bash
+gh pr create \
+  --base main \
+  --head fix/cave-77y74-opencoven-tools-full-width \
+  --title "fix: widen OpenCoven Tools settings control" \
+  --body $'## Summary\n- keep CovenCave compact in the About controls grid\n- place OpenCoven Tools on a full-width row beneath it\n- pin desktop span and preserve the existing narrow layout\n\n## Verification\n- focused About source-contract test\n- lint and design gates\n- typecheck and test registration\n- full app suite\n- production build and budgets\n- desktop and narrow real-app screenshots'
+```
+
+Expected: GitHub returns a new PR URL for the feature branch.
+
+- [ ] **Step 3: Link the PR to the Bead**
+
+Run:
+
+```bash
+bd update cave-77y74 \
+  --external-ref "gh-pr-$(gh pr view --json number --jq .number)" \
+  --append-notes "PR opened: $(gh pr view --json url --jq .url)"
+```
+
+Expected: Bead `cave-77y74` records the PR number and URL.
+
+- [ ] **Step 4: Wait for protected checks and resolve conversations**
+
+Run:
+
+```bash
+gh pr checks --watch --interval 20
+```
+
+Then verify:
+
+```bash
+gh pr view --json mergeable,mergeStateStatus,statusCheckRollup \
+  --jq '{mergeable,mergeStateStatus,nonPassing:[.statusCheckRollup[]|select(.status!="COMPLETED" or (.conclusion!="SUCCESS" and .conclusion!="SKIPPED"))|{name,status,conclusion}]}'
+gh api graphql \
+  -F number="$(gh pr view --json number --jq .number)" \
+  -f query='query($number:Int!) { repository(owner:"OpenCoven", name:"coven-cave") { pullRequest(number:$number) { reviewThreads(first:100) { nodes { isResolved } } } } }' \
+  --jq '{unresolvedThreads:([.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length)}'
+```
+
+Expected: `mergeable` is `MERGEABLE`, `mergeStateStatus` is `CLEAN`, and
+`nonPassing` is empty; `unresolvedThreads` is `0`. Resolve any review thread
+before merging and rerun affected checks after every code change.
+
+- [ ] **Step 5: Squash-merge the PR**
+
+Run:
+
+```bash
+gh pr merge "$(gh pr view --json number --jq .number)" \
+  --squash \
+  --subject "fix: widen OpenCoven Tools settings control" \
+  --body $'Keep CovenCave compact while OpenCoven Tools spans the full Settings > About controls grid on desktop, with the existing narrow layout preserved.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
+```
+
+Expected: the PR state becomes `MERGED`.
+
+- [ ] **Step 6: Close the Bead and clean the feature transport**
+
+From the repository root, run:
+
+```bash
+bd close cave-77y74 \
+  --reason "Full-width OpenCoven Tools layout merged with protected checks passing." \
+  --session c62815d6-4d65-4f8d-a5dc-db27f88d2870
+git worktree remove .worktrees/cave-77y74-opencoven-tools-full-width
+git branch -D fix/cave-77y74-opencoven-tools-full-width
+git push origin --delete fix/cave-77y74-opencoven-tools-full-width
+git worktree list
+```
+
+Expected: the Bead is closed, the local worktree and branch are gone, the
+remote feature branch is deleted, and `main` remains untouched locally except
+for unrelated pre-existing user changes.

--- a/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
+++ b/docs/superpowers/plans/2026-07-29-opencoven-tools-full-width.md
@@ -137,9 +137,7 @@ Run:
 git add src/components/settings-about.tsx \
   src/styles/settings-about.css \
   src/components/settings-about.test.ts
-git commit -S \
-  -m "fix: widen OpenCoven Tools settings control" \
-  -m "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git commit -S -m "fix: widen OpenCoven Tools settings control"
 git push
 ```
 
@@ -290,7 +288,7 @@ Run:
 gh pr merge "$(gh pr view --json number --jq .number)" \
   --squash \
   --subject "fix: widen OpenCoven Tools settings control" \
-  --body $'Keep CovenCave compact while OpenCoven Tools spans the full Settings > About controls grid on desktop, with the existing narrow layout preserved.\n\nCo-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>'
+  --body "Keep CovenCave compact while OpenCoven Tools spans the full Settings > About controls grid on desktop, with the existing narrow layout preserved."
 ```
 
 Expected: the PR state becomes `MERGED`.

--- a/docs/superpowers/specs/2026-07-29-opencoven-tools-full-width-design.md
+++ b/docs/superpowers/specs/2026-07-29-opencoven-tools-full-width-design.md
@@ -1,0 +1,65 @@
+# OpenCoven Tools Full-Width Settings Control Design
+
+## Goal
+
+Make the OpenCoven Tools control on Settings > About use the full available
+content width on desktop while keeping the CovenCave control compact and
+preserving the existing mobile layout.
+
+## Current Problem
+
+The About controls use a two-column grid. CovenCave and OpenCoven Tools each
+occupy one column, so the denser OpenCoven Tools content is constrained to half
+the available width even though it benefits from a wider row.
+
+## Chosen Approach
+
+Keep the existing grid and add a focused wide modifier to the OpenCoven Tools
+control:
+
+- CovenCave remains in the first column at its current width.
+- OpenCoven Tools moves to the next row and spans the full grid with
+  `grid-column: 1 / -1`.
+- The existing `55rem` container breakpoint continues to collapse the grid to
+  one column, so mobile and narrow-pane behavior remain unchanged.
+
+This is preferred over making every control full width because it preserves the
+compact treatment of the smaller CovenCave section. It is also preferred over
+introducing template areas or a separate grid because a single semantic
+modifier expresses the layout requirement without restructuring the surface.
+
+## Component and Styling Contract
+
+- Add `settings-about-control--wide` to the existing OpenCoven Tools control
+  container only.
+- Define the modifier beside the controls-grid rules in
+  `src/styles/settings-about.css`.
+- Use the existing grid, breakpoint, spacing, and design tokens without adding
+  new tokens or hardcoded dimensions.
+- Do not change OpenCoven Tools behavior, copy, diagnostics, update actions, or
+  accessibility semantics.
+- Do not change the CovenCave control or the About links bento.
+
+## Responsive Behavior
+
+- Desktop: CovenCave occupies one grid column; OpenCoven Tools spans both
+  columns on the row below.
+- At or below the existing `55rem` container breakpoint: both controls remain
+  in the current single-column flow.
+- The modifier must not create implicit columns or horizontal overflow.
+
+## Testing and Verification
+
+- Add a source-contract test that pins the modifier to the OpenCoven Tools
+  container and pins `grid-column: 1 / -1` in the stylesheet.
+- Run the focused About component test, design lint and codemod checks, the
+  relevant app suite, typecheck, and production build.
+- Render Settings > About in the real app at desktop and narrow widths and
+  confirm the intended row geometry without overflow.
+
+## Exclusions
+
+- No changes to update logic, daemon status, diagnostics, external links, copy,
+  or navigation.
+- No redesign of the About page, links grid, cards, or responsive breakpoints.
+- No new shared layout abstraction for this one-control geometry change.

--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -49,6 +49,17 @@ test("About ports the Claude Design hero and live control-sheet hierarchy", () =
   );
 });
 
+test("About gives OpenCoven Tools a full-width desktop row", () => {
+  assert.match(
+    component,
+    /id=\{settingsGroupId\("OpenCoven tools"\)\}[\s\S]*?className="settings-about-control settings-about-control--wide"/,
+  );
+  assert.match(
+    css,
+    /\.settings-about-control--wide\s*\{[^}]*grid-column:\s*1\s*\/\s*-1;/,
+  );
+});
+
 test("About preserves truthful live status and safe diagnostic behavior", () => {
   assert.match(component, /classifyAboutDaemonStatus/);
   assert.match(component, /fetch\("\/api\/daemon\/status"/);

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -466,7 +466,7 @@ export function AboutSection() {
         <div
           id={settingsGroupId("OpenCoven tools")}
           data-settings-group
-          className="settings-about-control"
+          className="settings-about-control settings-about-control--wide"
         >
           <SectionRule
             aside={

--- a/src/styles/settings-about.css
+++ b/src/styles/settings-about.css
@@ -185,6 +185,10 @@
   gap: var(--space-3);
 }
 
+.settings-about-control--wide {
+  grid-column: 1 / -1;
+}
+
 .settings-about-control,
 .settings-about-elsewhere {
   min-width: 0;


### PR DESCRIPTION
## Summary
- keep CovenCave compact in the Settings → About controls grid
- move OpenCoven Tools to a full-width row beneath it
- pin the desktop span while preserving the existing one-column narrow layout

## Verification
- focused About source-contract test
- lint and design gates
- typecheck and test registration
- 970 app test files
- production build and bundle/standalone budgets
- real-app desktop: 1,072px tools row across the full controls grid
- real-app narrow: both controls use the 682px single column
- no horizontal overflow at either measured width
- independent spec, code-quality, and whole-branch reviews approved