### PR TITLE
fix(projects): give repositories a kind treatment of their own

### DIFF
--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -214,6 +214,35 @@ test("each row opens per-project settings with the GitHub repo link", () => {
   assert.match(css, /\.projects-access-kind \{/, "the kind glyph is styled");
 });
 
+// Kind is a category, so each gets its own treatment. Before, only workspaces
+// were styled — a repository was encoded by the ABSENCE of the accent, which
+// reads as "no kind" rather than "repository". Distinct hues aren't available:
+// this system has one accent (--color-info aliases it) and a second hue would
+// have to survive 21 palettes × 2 modes, so the split is fill vs ring.
+test("workspaces and repositories each carry their own kind treatment", () => {
+  assert.match(
+    css,
+    /\.projects-access-kind\.is-workspace \{[^}]*background:\s*color-mix\(in oklch, var\(--accent-presence\)/,
+    "workspaces are the filled, accent-tinted kind",
+  );
+  assert.match(
+    css,
+    /\.projects-access-kind\.is-repo \{[^}]*box-shadow:\s*inset 0 0 0 1px var\(--border-strong\)/,
+    "repositories are ringed rather than filled",
+  );
+  assert.doesNotMatch(
+    css,
+    /\.projects-access-kind \{[^}]*background:\s*color-mix/,
+    "the base glyph carries no kind colour of its own — each kind states itself",
+  );
+  // The dense rows view strips the tile, so neither treatment may leak there.
+  assert.match(
+    css,
+    /\.projects-access-tr-name \.projects-access-kind \{[^}]*box-shadow:\s*none/,
+    "the rows view drops the ring along with the fill",
+  );
+});
+
 test("the settings modal also renames and removes from the registry (issue #3710)", () => {
   assert.match(view, /<ProjectSettingsModal[\s\S]{0,260}onRename=\{renameProjectAndAnnounce\}[\s\S]{0,60}onDelete=\{removeProject\}/, "the modal carries rename + remove handlers");
   assert.match(view, /const ok = await renameProject\(id, name\);/, "rename goes through useProjects().renameProject");

--- a/src/styles/projects.css
+++ b/src/styles/projects.css
@@ -626,6 +626,11 @@
   padding-bottom: 0;
 }
 
+/* Kind is a category, not a state, so the two get distinct TREATMENTS rather
+   than distinct hues — this system has exactly one accent (--color-info is
+   aliased to it) and a second hue would have to survive 21 palettes × 2 modes.
+   Workspace is filled, repository is ringed: both read as deliberate, where
+   before a repo was encoded only by the ABSENCE of the workspace's accent. */
 .projects-access-kind {
   display: grid;
   place-items: center;
@@ -633,13 +638,21 @@
   height: var(--space-6);
   flex: none;
   border-radius: var(--radius-control);
+}
+
+/* Coven-native: solid accent fill. */
+.projects-access-kind.is-workspace {
   background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
   color: var(--accent-presence);
 }
 
+/* Git-backed: a ring, not a fill — the outline reads as "linked elsewhere",
+   and the ink is a tier stronger than the old muted grey so the icon carries
+   as much weight as its filled sibling. */
 .projects-access-kind.is-repo {
-  background: color-mix(in oklch, var(--text-primary) 8%, transparent);
-  color: var(--text-secondary);
+  background: transparent;
+  box-shadow: inset 0 0 0 1px var(--border-strong);
+  color: var(--text-primary);
 }
 
 .projects-access-card-id {
@@ -896,10 +909,14 @@
   flex: none;
 }
 
+/* The dense rows view shows the bare glyph, not the tile — so neither the
+   workspace fill nor the repository ring applies here. The icon itself still
+   differs, and the Scope column names the kind in words. */
 .projects-access-tr-name .projects-access-kind {
   width: auto;
   height: auto;
   background: none;
+  box-shadow: none;
 }
 
 .projects-access-tr-path,


### PR DESCRIPTION
## The actual defect

Workspaces and repositories *did* differ — the base `.projects-access-kind` rule carried the accent and `.is-repo` overrode it to grey. But a repository was encoded by the **absence** of the workspace's accent, which reads as *"no kind"* rather than *"repository"*.

## The fix

Kind is a **category**, not a state, so each carries its own treatment:

| | before | after |
|---|---|---|
| workspace | accent fill (from the base rule) | accent fill, on `.is-workspace` |
| repository | grey, muted ink | **ringed**, full-strength ink |

The accent moves off the base rule onto `.is-workspace`, so neither kind inherits the other's identity.

## Why not the mock's blue

`Projects.dc.html` gives repositories a distinct blue. That isn't available here:

- this system has exactly **one** accent — `--color-info` is literally aliased to `--accent-presence`
- the design language binds state tints to a single token, *never a second hue*
- a categorical blue would have to survive **21 palettes × 2 modes**

Encoding by treatment rather than colour turned out to be load-bearing, not merely compliant. Verified in the app, both glyphs compute to the **same ink** — the active theme's accent resolves near-neutral:

```
workspace   background: oklch(… / 0.14)   box-shadow: none      color: rgb(236,236,236)
repo        background: transparent        box-shadow: inset …   color: rgb(236,236,236)
```

A hue-based split would have been close to invisible in the very theme this was checked under. Fill versus ring still reads, because it doesn't depend on colour at all.

## One trap

The dense **rows** view strips the tile (`width/height: auto; background: none`), so the new ring drew around a bare glyph. It now clears `box-shadow` alongside the fill, and that's pinned.

## Verification

`pnpm lint` 0 · `pnpm test:app` **967/967** · `pnpm build` 0 · codemod no-op · token drift unchanged.

Four new assertions in `projects-view.test.ts`, including a `doesNotMatch` guarding that the base rule never regains a kind colour of its own — the exact shape that produced the original defect.

Screenshot-verified on the Projects surface with real data (8 workspaces, 21 repositories).

🤖 Generated with [Claude Code](https://claude.com/claude-code)