### PR TITLE
feat(permissions): surface the grant-change log in the console

### DIFF
--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -10,6 +10,7 @@ import {
   grantProjectToFamiliar,
   listAccessGroups,
   listProjectGrants,
+  listRecentGrantChanges,
   listRecentPermissionAudit,
   loadHumanPermissionConfig,
   revokeProjectFromFamiliar,
@@ -55,10 +56,11 @@ function accessInput(payload: Record<string, unknown>): "read" | "write" | null 
 }
 
 export async function GET() {
-  const [grants, config, audit, accessGroups] = await Promise.all([
+  const [grants, config, audit, grantChanges, accessGroups] = await Promise.all([
     listProjectGrants(),
     loadHumanPermissionConfig(),
     listRecentPermissionAudit(),
+    listRecentGrantChanges(),
     listAccessGroups(),
   ]);
   // `supremeFamiliarId` has access to every project regardless of grants — the
@@ -74,6 +76,9 @@ export async function GET() {
     supremeFamiliarId: config.supremeFamiliarId,
     mobileMutationsAllowed: config.allowMobileGrantMutations,
     audit,
+    // Access CHANGES — who widened or narrowed a grant. Distinct from
+    // `audit`, which is the access-CHECK decision log.
+    grantChanges,
   });
 }
 

--- a/src/components/familiar-studio-projects-tab.test.ts
+++ b/src/components/familiar-studio-projects-tab.test.ts
@@ -95,3 +95,42 @@ assert.match(
 assert.match(tab, /const ok = await deleteProject\(id\);\s*if \(ok\) void load\(\);/, "removing a project reloads the access snapshot");
 
 console.log("familiar-studio-projects-tab.test.ts: ok");
+
+// ── Grant-change log surfaced in the console (cave-kbniv) ─────────────────
+// grantAudit was write-only until this: #4003/#4010 recorded every change and
+// nothing rendered it. These pin the read path end to end.
+assert.match(
+  route,
+  /listRecentGrantChanges/,
+  "the grants GET returns a recent grant-CHANGE window alongside the decision audit",
+);
+assert.match(
+  route,
+  /\n    grantChanges,/,
+  "the change window ships in the GET payload",
+);
+assert.match(
+  tab,
+  /Array\.isArray\(grantRes\?\.grantChanges\)/,
+  "the console reads the change window defensively",
+);
+assert.match(
+  tab,
+  /Recent access changes \(\$\{famChanges\.length\}\)/,
+  "changes render in their own group, separate from Recent decisions",
+);
+assert.match(
+  tab,
+  /const famChanges = useMemo\(/,
+  "changes are scoped to the selected familiar",
+);
+assert.match(
+  tab,
+  /\{grantLevelLabel\(e\.from\)\} → \{grantLevelLabel\(e\.to\)\}/,
+  "each line shows the levels either side of the change",
+);
+assert.match(
+  tab,
+  /grantChangeOriginLabel\(e\)/,
+  "each line says where the change came from",
+);

--- a/src/components/familiar-studio-projects-tab.tsx
+++ b/src/components/familiar-studio-projects-tab.tsx
@@ -18,6 +18,9 @@ import {
   accessLevelMeta,
   auditDecisionMeta,
   auditReasonLabel,
+  grantChangeMeta,
+  grantChangeOriginLabel,
+  grantLevelLabel,
   effectiveAccessRows,
   grantKey,
   grantSourceMeta,
@@ -29,6 +32,7 @@ import {
   surfaceLabel,
   type ConsoleAccessGroup,
   type ConsoleAuditEntry,
+  type ConsoleGrantChange,
   type ConsoleGrant,
   type ConsoleProject,
   type ConsoleProposal,
@@ -99,6 +103,7 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
   const [supremeFamiliarId, setSupremeFamiliarId] = useState<string | null>(null);
   const [proposals, setProposals] = useState<ConsoleProposal[]>([]);
   const [audit, setAudit] = useState<ConsoleAuditEntry[]>([]);
+  const [grantChanges, setGrantChanges] = useState<ConsoleGrantChange[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   // Keys mid-flight, so a row can't be double-toggled while its request runs.
@@ -124,6 +129,9 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
         typeof grantRes?.supremeFamiliarId === "string" ? grantRes.supremeFamiliarId : null,
       );
       setAudit(Array.isArray(grantRes?.audit) ? (grantRes.audit as ConsoleAuditEntry[]) : []);
+      setGrantChanges(
+        Array.isArray(grantRes?.grantChanges) ? (grantRes.grantChanges as ConsoleGrantChange[]) : [],
+      );
       setProposals(Array.isArray(proposalRes?.proposals) ? proposalRes.proposals : []);
       setError(null);
     } catch {
@@ -309,6 +317,14 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
     () => audit.filter((e) => e.familiarId === familiar.id).sort((a, b) => b.at.localeCompare(a.at)),
     [audit, familiar.id],
   );
+  // Access CHANGES for this familiar. The server already returns them newest
+  // first (ties broken on append order, so a bulk edit reads in the order it
+  // happened); filtering preserves that, so no re-sort here.
+  const famChanges = useMemo(
+    () => grantChanges.filter((e) => e.familiarId === familiar.id),
+    [grantChanges, familiar.id],
+  );
+  const [showAllChanges, setShowAllChanges] = useState(false);
 
   if (loading) {
     return (
@@ -607,6 +623,52 @@ export function FamiliarStudioProjectsTab({ familiar }: Props) {
               </div>
             );
           })}
+        </SettingsGroup>
+      )}
+
+      {/* ── Access CHANGES for this familiar ──
+          Distinct from the decision log below: this records who widened or
+          narrowed a grant and from what, which the check log cannot answer. */}
+      {famChanges.length > 0 && (
+        <SettingsGroup label={`Recent access changes (${famChanges.length})`}>
+          {(showAllChanges ? famChanges : famChanges.slice(0, AUDIT_PREVIEW)).map((e) => {
+            const meta = grantChangeMeta(e);
+            return (
+              <div key={e.id} className="flex flex-wrap items-center justify-between gap-3 px-4 py-2.5">
+                <div className="flex min-w-0 items-center gap-3">
+                  <ToneIcon tone={meta.tone} icon={meta.icon} size={15} />
+                  <div className="min-w-0">
+                    <p className="truncate text-[length:var(--text-sm)] text-[var(--text-primary)]">
+                      {projectName(e.projectId)}
+                    </p>
+                    <p className="mt-0.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+                      {meta.label} · {grantLevelLabel(e.from)} → {grantLevelLabel(e.to)}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <MetaChip title="Where this change came from">
+                    {grantChangeOriginLabel(e)}
+                  </MetaChip>
+                  <RelativeTime iso={e.at} className="text-[length:var(--text-xs)] text-[var(--text-muted)]" />
+                </div>
+              </div>
+            );
+          })}
+          {famChanges.length > AUDIT_PREVIEW ? (
+            <div className="border-t border-[var(--border-hairline)] px-2 py-1">
+              <Button
+                variant="ghost"
+                size="sm"
+                fullWidth
+                className="justify-start"
+                onClick={() => setShowAllChanges((v) => !v)}
+                aria-expanded={showAllChanges}
+              >
+                {showAllChanges ? "Show recent only" : `Show all ${famChanges.length} changes`}
+              </Button>
+            </div>
+          ) : null}
         </SettingsGroup>
       )}
 

--- a/src/lib/permissions-console.test.ts
+++ b/src/lib/permissions-console.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 
 import {
+  grantChangeMeta,
+  grantChangeOriginLabel,
+  grantLevelLabel,
   accessLevelMeta,
   accessSummary,
   auditDecisionMeta,
@@ -189,3 +192,44 @@ assert.deepEqual(
 assert.deepEqual(groupsForFamiliar(groups, "ghost"), [], "non-members get no groups");
 
 console.log("permissions-console.test.ts: ok");
+
+// ── Grant-change log rendering (cave-kbniv) ───────────────────────────────
+// Direction is DERIVED from the two levels rather than stored, so a widening
+// can never be mislabeled as a narrowing by a bad writer.
+
+assert.equal(grantLevelLabel("write"), "Full");
+assert.equal(grantLevelLabel("read"), "Read");
+assert.equal(grantLevelLabel(null), "No access");
+
+assert.equal(grantChangeMeta({ from: null, to: "read" }).label, "Widened");
+assert.equal(grantChangeMeta({ from: "read", to: "write" }).label, "Widened");
+assert.equal(grantChangeMeta({ from: "write", to: "read" }).label, "Narrowed");
+assert.equal(grantChangeMeta({ from: "read", to: null }).label, "Narrowed");
+assert.equal(grantChangeMeta({ from: null, to: null }).label, "Changed");
+
+// A widening takes the accent so it is scannable, but NOT the danger tone —
+// red on every legitimate grant would cry wolf.
+assert.equal(grantChangeMeta({ from: null, to: "write" }).tone, "pending");
+assert.notEqual(
+  grantChangeMeta({ from: null, to: "write" }).tone,
+  "negative",
+  "a legitimate widening must not render as an error",
+);
+assert.equal(grantChangeMeta({ from: "write", to: null }).tone, "neutral");
+assert.equal(grantChangeMeta({ from: null, to: "write" }).icon, "ph:arrow-up");
+assert.equal(grantChangeMeta({ from: "write", to: null }).icon, "ph:arrow-down");
+
+// Origin tells the human where a change came from — the phone is the one that
+// matters most, since it is the remote surface.
+assert.equal(grantChangeOriginLabel({ actor: "loopback", kind: "direct" }), "on this desktop");
+assert.equal(grantChangeOriginLabel({ actor: "mobile", kind: "direct" }), "from the phone");
+assert.equal(
+  grantChangeOriginLabel({ actor: "loopback", kind: "group" }),
+  "via an access group · on this desktop",
+);
+assert.equal(
+  grantChangeOriginLabel({ actor: "system", kind: "project-removed" }),
+  "project removed from the registry",
+);
+
+console.log("permissions-console grant-change assertions: ok");

--- a/src/lib/permissions-console.ts
+++ b/src/lib/permissions-console.ts
@@ -73,6 +73,73 @@ export type ConsoleAuditEntry = {
   requiredAccess?: ProjectAccessLevel;
 };
 
+/**
+ * One entry from the grant-CHANGE log — who widened or narrowed access, and
+ * from what. Distinct from ConsoleAuditEntry, which records access-check
+ * decisions; the two answer different questions and are rendered separately.
+ */
+export type ConsoleGrantChange = {
+  id: string;
+  at: string;
+  familiarId: string;
+  projectId: string;
+  /** Level before the change; null when there was no access. */
+  from: ProjectAccessLevel | null;
+  /** Level after the change; null when access was removed. */
+  to: ProjectAccessLevel | null;
+  actor: "loopback" | "mobile" | "system";
+  kind: "direct" | "group" | "project-removed" | "bootstrap";
+  groupId?: string;
+};
+
+/** Level name for a change log line; null is the no-access end of the range. */
+export function grantLevelLabel(level: ProjectAccessLevel | null): string {
+  if (level === "write") return "Full";
+  if (level === "read") return "Read";
+  return "No access";
+}
+
+/**
+ * How a change reads at a glance. Direction is derived from the levels rather
+ * than stored, so a widening and a narrowing are never mislabeled: rank the
+ * two ends and compare.
+ */
+export function grantChangeMeta(change: Pick<ConsoleGrantChange, "from" | "to">): {
+  label: string;
+  icon: IconName;
+  tone: Tone;
+} {
+  const rank = (level: ProjectAccessLevel | null): number =>
+    level === "write" ? 2 : level === "read" ? 1 : 0;
+  const direction = rank(change.to) - rank(change.from);
+  // The arrow carries the direction; the tone only controls emphasis. A
+  // widening is what you scan an audit log FOR, so it takes the accent — but
+  // not the danger tone, which would cry wolf on every legitimate grant.
+  if (direction > 0) {
+    return { label: "Widened", icon: "ph:arrow-up", tone: "pending" };
+  }
+  if (direction < 0) {
+    return { label: "Narrowed", icon: "ph:arrow-down", tone: "neutral" };
+  }
+  return { label: "Changed", icon: "ph:arrows-clockwise", tone: "neutral" };
+}
+
+/** Where the change came from, in the console's words. */
+export function grantChangeOriginLabel(change: Pick<ConsoleGrantChange, "actor" | "kind">): string {
+  const where =
+    change.actor === "mobile" ? "from the phone" : change.actor === "loopback" ? "on this desktop" : "by the app";
+  switch (change.kind) {
+    case "group":
+      return `via an access group · ${where}`;
+    case "project-removed":
+      return "project removed from the registry";
+    case "bootstrap":
+      return "bootstrap";
+    default:
+      return where;
+  }
+}
+
 export type PermissionTab = "access" | "requests" | "audit";
 export type AuditFilter = "all" | AuditDecision;
 


### PR DESCRIPTION
Closes `cave-kbniv`. Completes the arc started in #4003 / #4010.

## The gap

Those PRs made every grant change *recorded*. They didn't make it *readable* — `listRecentGrantChanges()` had zero consumers. The store could answer "who widened this grant, when, and from what"; no human could get the answer out.

## What this adds

A **Recent access changes** group in the Permissions console (Familiar Studio → Projects), above *Recent decisions* since a change is higher-signal than a check:

```
Coven Cave
Narrowed · Full → Read                    on this desktop    2h ago
```

`GET /api/project-grants` now returns `grantChanges` alongside the existing `audit`. The two stay separate — they answer different questions and share no schema.

## Two decisions, both pinned

**Direction is derived, never stored.** `grantChangeMeta` ranks `from` and `to` and compares, so a widening cannot be mislabeled by a bad writer. Tested across every transition, including `null → read` and `read → null`.

**A widening takes the accent tone, not the danger tone.** `negative` maps to `--color-danger`, and painting every legitimate grant red would train you to ignore the log. The arrow carries direction; colour carries only scannability. Pinned with an explicit `notEqual(..., "negative")` so it isn't "fixed" later.

**Origin is spelled out** per line — `on this desktop` / `from the phone` / `via an access group · …` / `project removed from the registry`. The phone case matters most: it's the remote surface, and grants are mobile-mutable behind `allowMobileGrantMutations`.

## Verification

- `tsc --noEmit`, `pnpm lint`, `check-tests-wired` (1326) — all clean
- `permissions-console.test.ts` and `familiar-studio-projects-tab.test.ts` — verified by **exit code**, not by grepping for TAP output (these files use plain top-level asserts, so failures throw rather than emit `not ok`; that distinction cost a CI cycle on #4010)

## Note on what you'll see

Existing stores have zero entries — the log only records changes made from now on, and no history was invented for grants that predate it. The block is `famChanges.length > 0`-gated, so it stays hidden rather than rendering an empty shell until the next grant change happens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)