### PR TITLE
fix(chat): harden project-gated runtime launches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -231,6 +231,10 @@ jobs:
           fi
           echo "RELEASE_TAG=$TAG" >> "$GITHUB_ENV"
           echo "RELEASE_VERSION=${TAG#v}" >> "$GITHUB_ENV"
+          # This public value is compiled into the desktop shell and its
+          # bundled sidecar, so support diagnostics can identify the exact
+          # source artifact that was packaged for a release.
+          echo "NEXT_PUBLIC_COVEN_CAVE_BUILD_REVISION=$(git rev-parse --verify HEAD)" >> "$GITHUB_ENV"
 
       - name: Install Linux dependencies
         if: >-

--- a/docs/project-permission-integrity.md
+++ b/docs/project-permission-integrity.md
@@ -1,0 +1,29 @@
+# Project permission integrity
+
+## Why this exists
+
+Project access is authorized by a registered project ID. Older local state can
+contain direct grants, access-group grants, or pending proposals for a project
+that has since been removed from the registry. Those records are no longer a
+valid authority boundary and must not be silently treated as access.
+
+## Detection and repair
+
+`GET /api/project-grants` includes a read-only `integrity` report with counts
+for stale direct grants, group grants, proposals, and their orphan project IDs.
+The Chat → Projects screen presents a repair action only when that report is
+non-empty.
+
+Repair requires an explicit local human confirmation. `POST /api/project-grants`
+with `{ "repairOrphans": true }` removes only records whose project ID is no
+longer registered. It never creates a project, grants a permission, or changes
+a valid record. The permission store writes a timestamped repair-audit entry,
+so the operation is reviewable and safe to retry after interruption.
+
+## Upgrade behavior
+
+No startup migration runs automatically. On upgrade, existing permission data
+is inspected without mutation. If stale records are present, an authorized
+person can review the count in Projects and choose **Repair stale permissions**.
+If no action is taken, server-side chat launch remains fail-closed: a session
+still cannot start without an authorized, registered project root.

--- a/scripts/canonical-memory-smoke-lifecycle.test.mjs
+++ b/scripts/canonical-memory-smoke-lifecycle.test.mjs
@@ -79,7 +79,12 @@ function launchFixture(mode, tempParent, extraEnv = {}) {
     cwd: path.dirname(path.dirname(SCRIPT)),
     env: {
       ...process.env,
+      // Node's tmpdir() prefers TEMP/TMP on Windows over TMPDIR. Override all
+      // three so the lifecycle fixture and this test observe the same guarded
+      // root on every supported platform.
       TMPDIR: tempParent,
+      TMP: tempParent,
+      TEMP: tempParent,
       [TEST_MODE_ENV]: mode,
       COVEN_REPO: path.join(tempParent, "must-not-resolve-coven"),
       COVEN_MEMORY_REPO: path.join(
@@ -411,22 +416,28 @@ if (process.platform !== "win32") {
     });
   });
 }
-await runSelected(
-  "late-browser-close-reject",
-  () =>
-    lateResolvingBrowserFailureRetainsOwnership({
-      mode: "late-browser-close-reject",
-      maximumDurationMs: 2_000,
-    }),
-);
-await runSelected(
-  "late-browser-close-timeout",
-  () =>
-    lateResolvingBrowserFailureRetainsOwnership({
-      mode: "late-browser-close-timeout",
-      maximumDurationMs: 3_000,
-    }),
-);
+// Windows does not deliver SIGTERM to a child Node process as a catchable
+// signal; ChildProcess.kill() terminates it directly. The cleanup ownership
+// assertion below is therefore a POSIX signal-semantics test, like the signal
+// suite above, rather than a false Windows regression.
+if (process.platform !== "win32") {
+  await runSelected(
+    "late-browser-close-reject",
+    () =>
+      lateResolvingBrowserFailureRetainsOwnership({
+        mode: "late-browser-close-reject",
+        maximumDurationMs: 2_000,
+      }),
+  );
+  await runSelected(
+    "late-browser-close-timeout",
+    () =>
+      lateResolvingBrowserFailureRetainsOwnership({
+        mode: "late-browser-close-timeout",
+        maximumDurationMs: 3_000,
+      }),
+  );
+}
 await runSelected(
   "browser-close-reject",
   () =>

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -644,6 +644,7 @@ export const SUITES = {
     "src/components/thread-signals-section.test.ts",
     "src/lib/thread-signal-dismissals.test.ts",
     "src/components/chat-view.test.ts",
+    "src/components/chat-error-redaction.test.ts",
     "src/components/chat-composer-rec-autofill.test.ts",
     "src/components/familiars-view-stats.test.ts",
     "src/components/automations-detail-inputs.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -458,6 +458,7 @@ export const SUITES = {
     "src/components/shell-nav-memory.test.ts",
     "src/components/workflows-view.test.ts",
     "src/components/projects-view.test.ts",
+    "src/components/projects-view-repair-behavior.test.tsx",
     "src/components/project-settings-modal.test.ts",
     "src/lib/projects/access-page.test.ts",
     "src/lib/projects/access-views.test.ts",
@@ -1559,6 +1560,7 @@ const VITEST_TESTS = new Set([
   "src/components/command-palette-canonical-memory-behavior.test.tsx",
   "src/components/workspace-canonical-memory-navigation-behavior.test.tsx",
   "src/components/workspace-canonical-memory-lazy-familiar.test.tsx",
+  "src/components/projects-view-repair-behavior.test.tsx",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_794/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_799/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -139,7 +139,10 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // 2026-07-29 (typed chat follow-ups): the reusable Reply/Task/Action
   // components trace two additional Windows runtime files (5,784). Preserve
   // the established ten-file cross-platform headroom without relaxing bytes.
-  fileCount: 5_794,
+  // 2026-07-29 (daemon launch cleanup): Windows packaging of the owned
+  // readiness-timeout path measured 5,789 files. Retain the established ten
+  // files of cross-platform headroom without relaxing the byte ceiling.
+  fileCount: 5_799,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_794);
+  assert.ok(metrics.fileCount <= 5_799);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_794,
+    fileCount: 5_799,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -284,6 +284,19 @@ async function main() {
     assert.equal(meta.width, 256, "avatar should be downscaled to the packaged route max dimension");
     assert.equal(meta.height, 128, "avatar should preserve aspect ratio during sidecar transcode");
 
+    const buildInfoResponse = await fetch(`${baseUrl}/api/app/build-info`, {
+      headers: authenticatedHeaders(baseUrl),
+    });
+    assert.equal(buildInfoResponse.status, 200, "packaged sidecar must expose its artifact identity");
+    const buildInfo = await buildInfoResponse.json();
+    assert.match(buildInfo.version, /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/);
+    assert.match(buildInfo.revision, /^(?:development|[a-f0-9]{7,64})$/);
+    assert.equal(
+      buildInfo.identity,
+      `v${buildInfo.version}+${buildInfo.revision}`,
+      "packaged sidecar build identity must be internally consistent",
+    );
+
     const enginesResponse = await fetch(`${baseUrl}/api/voice/engines`, {
       headers: authenticatedHeaders(baseUrl),
     });

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -205,18 +205,22 @@ async function waitForProcessExit(pid, timeoutMs = 5_000) {
 
 async function writeHangingDaemonFixture(rootDir, marker) {
   const fixture = path.join(rootDir, process.platform === "win32" ? "hanging-coven.cmd" : "hanging-coven.sh");
-  const nodeExpression = "const fs=require('node:fs');fs.writeFileSync(process.env.COVEN_DAEMON_SMOKE_CHILD_PID,String(process.pid));setInterval(()=>{},1000)";
+  const daemonScript = path.join(rootDir, "hanging-daemon-child.cjs");
+  // The harness spawn boundary deliberately removes Cave-internal env before
+  // it launches a daemon. Embed this smoke-only marker and bundled Node path
+  // into the fixture instead of weakening that production scrubber.
+  const nodeExpression = `const fs=require('node:fs');fs.writeFileSync(${JSON.stringify(marker)},String(process.pid));setInterval(()=>{},1000)`;
+  await writeFile(daemonScript, nodeExpression, "utf8");
   if (process.platform === "win32") {
     await writeFile(
       fixture,
-      `@echo off\r\n"%COVEN_DAEMON_SMOKE_NODE%" -e "${nodeExpression}"\r\n`,
+      `@echo off\r\n"${bundledNode}" "${daemonScript}"\r\n`,
       "utf8",
     );
   } else {
-    const shellSafeExpression = nodeExpression.replaceAll("'", "'\\''");
     await writeFile(
       fixture,
-      `#!/bin/sh\n"$COVEN_DAEMON_SMOKE_NODE" -e '${shellSafeExpression}'\n`,
+      `#!/bin/sh\nexec "${bundledNode}" "${daemonScript}"\n`,
       "utf8",
     );
     await chmod(fixture, 0o755);
@@ -228,8 +232,6 @@ async function writeHangingDaemonFixture(rootDir, marker) {
       COVEN_SOCKET: process.platform === "win32"
         ? `coven-cave-smoke-unready-${process.pid}-${Date.now()}`
         : path.join(rootDir, "unready.sock"),
-      COVEN_DAEMON_SMOKE_CHILD_PID: marker,
-      COVEN_DAEMON_SMOKE_NODE: bundledNode,
     },
   };
 }
@@ -423,8 +425,12 @@ async function main() {
       headers: authenticatedHeaders(baseUrl, "application/json"),
       body: JSON.stringify({ restart: true }),
     });
-    assert.equal(daemonStartResponse.status, 504, "an unready packaged daemon launch must return a structured timeout");
     const daemonStart = await daemonStartResponse.json();
+    assert.equal(
+      daemonStartResponse.status,
+      504,
+      `an unready packaged daemon launch must return a structured timeout: ${JSON.stringify(daemonStart)}`,
+    );
     assert.equal(daemonStart.code, "readiness_timeout");
     assert.deepEqual(
       daemonStart.cleanup,

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -107,7 +107,7 @@ function attachOutput(child) {
   };
 }
 
-function launchSidecar({ sidecarServer, sidecarRoot, covenHome, port }) {
+function launchSidecar({ sidecarServer, sidecarRoot, covenHome, port, environment = {} }) {
   const baseUrl = `http://127.0.0.1:${port}`;
   const child = spawn(bundledNode, [sidecarServer], {
     cwd: sidecarRoot,
@@ -123,6 +123,7 @@ function launchSidecar({ sidecarServer, sidecarRoot, covenHome, port }) {
       COVEN_CAVE_AUTH_TOKEN: token,
       COVEN_HOME: covenHome,
       NEXT_TELEMETRY_DISABLED: "1",
+      ...environment,
     },
   });
   return { baseUrl, child, output: attachOutput(child) };
@@ -153,8 +154,8 @@ function authenticatedHeaders(baseUrl, contentType) {
 }
 
 /** Verify that a staged or extracted runtime actually retained a behavioral
- * guard. This complements the live HTTP assertion below: the archive must not
- * silently omit the compiled project gate or daemon readiness implementation. */
+ * guard. This complements the live HTTP assertions below: the archive must not
+ * silently omit the compiled project gate. */
 async function runtimeContainsText(rootDir, expectedText) {
   const pending = [rootDir];
   while (pending.length) {
@@ -174,6 +175,65 @@ async function runtimeContainsText(rootDir, expectedText) {
   return false;
 }
 
+async function waitForText(file, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = await readFile(file, "utf8").catch(() => "");
+    if (value.trim()) return value.trim();
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  throw new Error(`timed out waiting for fixture output: ${path.basename(file)}`);
+}
+
+function processAlive(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+async function waitForProcessExit(pid, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processAlive(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.fail(`daemon timeout fixture child ${pid} survived owned-tree cleanup`);
+}
+
+async function writeHangingDaemonFixture(rootDir, marker) {
+  const fixture = path.join(rootDir, process.platform === "win32" ? "hanging-coven.cmd" : "hanging-coven.sh");
+  const nodeExpression = "const fs=require('node:fs');fs.writeFileSync(process.env.COVEN_DAEMON_SMOKE_CHILD_PID,String(process.pid));setInterval(()=>{},1000)";
+  if (process.platform === "win32") {
+    await writeFile(
+      fixture,
+      `@echo off\r\n"%COVEN_DAEMON_SMOKE_NODE%" -e "${nodeExpression}"\r\n`,
+      "utf8",
+    );
+  } else {
+    const shellSafeExpression = nodeExpression.replaceAll("'", "'\\''");
+    await writeFile(
+      fixture,
+      `#!/bin/sh\n"$COVEN_DAEMON_SMOKE_NODE" -e '${shellSafeExpression}'\n`,
+      "utf8",
+    );
+    await chmod(fixture, 0o755);
+  }
+  return {
+    fixture,
+    environment: {
+      COVEN_BIN: fixture,
+      COVEN_SOCKET: process.platform === "win32"
+        ? `coven-cave-smoke-unready-${process.pid}-${Date.now()}`
+        : path.join(rootDir, "unready.sock"),
+      COVEN_DAEMON_SMOKE_CHILD_PID: marker,
+      COVEN_DAEMON_SMOKE_NODE: bundledNode,
+    },
+  };
+}
+
 async function main() {
   let extractedSidecarRoot = null;
   let sidecarRoot = stagedSidecarRoot;
@@ -186,7 +246,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_794);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_799);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));
@@ -269,6 +329,8 @@ async function main() {
   );
 
   const covenHome = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-"));
+  const daemonMarker = path.join(covenHome, "daemon-timeout-child.pid");
+  const hangingDaemon = await writeHangingDaemonFixture(covenHome, daemonMarker);
   const avatarDir = path.join(covenHome, "workspaces", "familiars", "smoke", "avatars");
   await mkdir(avatarDir, { recursive: true });
   await mkdir(path.join(covenHome, "cave"), { recursive: true });
@@ -301,6 +363,7 @@ async function main() {
     sidecarRoot,
     covenHome,
     port: firstPort,
+    environment: hangingDaemon.environment,
   });
 
   try {
@@ -350,15 +413,31 @@ async function main() {
       "projectless packaged launches must not persist a conversation",
     );
     assert.equal(
-      await runtimeContainsText(sidecarRoot, "daemon readiness timed out"),
-      true,
-      "packaged runtime must retain daemon readiness timeout handling",
-    );
-    assert.equal(
       await runtimeContainsText(sidecarRoot, "project_root_required"),
       true,
       "packaged runtime must retain the project-root refusal gate",
     );
+
+    const daemonStartResponse = await fetch(`${baseUrl}/api/daemon/start`, {
+      method: "POST",
+      headers: authenticatedHeaders(baseUrl, "application/json"),
+      body: JSON.stringify({ restart: true }),
+    });
+    assert.equal(daemonStartResponse.status, 504, "an unready packaged daemon launch must return a structured timeout");
+    const daemonStart = await daemonStartResponse.json();
+    assert.equal(daemonStart.code, "readiness_timeout");
+    assert.deepEqual(
+      daemonStart.cleanup,
+      {
+        attempted: true,
+        completed: true,
+        mode: process.platform === "win32" ? "windows-tree" : "process-group",
+      },
+      "the packaged timeout must report completed cleanup of Cave's owned launch tree",
+    );
+    const daemonChildPid = Number(await waitForText(daemonMarker));
+    assert.ok(Number.isSafeInteger(daemonChildPid) && daemonChildPid > 0, "fixture must report its actual daemon descendant PID");
+    await waitForProcessExit(daemonChildPid);
 
     const enginesResponse = await fetch(`${baseUrl}/api/voice/engines`, {
       headers: authenticatedHeaders(baseUrl),

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { spawn, spawnSync } from "node:child_process";
-import { access, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -152,6 +152,28 @@ function authenticatedHeaders(baseUrl, contentType) {
   };
 }
 
+/** Verify that a staged or extracted runtime actually retained a behavioral
+ * guard. This complements the live HTTP assertion below: the archive must not
+ * silently omit the compiled project gate or daemon readiness implementation. */
+async function runtimeContainsText(rootDir, expectedText) {
+  const pending = [rootDir];
+  while (pending.length) {
+    const current = pending.pop();
+    const entries = await readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        pending.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !/\.(?:js|mjs|json)$/i.test(entry.name)) continue;
+      const contents = await readFile(fullPath, "utf8").catch(() => "");
+      if (contents.includes(expectedText)) return true;
+    }
+  }
+  return false;
+}
+
 async function main() {
   let extractedSidecarRoot = null;
   let sidecarRoot = stagedSidecarRoot;
@@ -249,6 +271,19 @@ async function main() {
   const covenHome = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-smoke-"));
   const avatarDir = path.join(covenHome, "workspaces", "familiars", "smoke", "avatars");
   await mkdir(avatarDir, { recursive: true });
+  await mkdir(path.join(covenHome, "cave"), { recursive: true });
+  // This familiar makes the project boundary test reach authorization rather
+  // than fail earlier as an unknown familiar. No project is registered or
+  // granted: a projectless launch must fail closed without creating a session.
+  await writeFile(
+    path.join(covenHome, "cave", "config.json"),
+    JSON.stringify({
+      version: 1,
+      defaults: { harness: "codex", model: "openai/gpt-5.6-sol" },
+      familiars: { smoke: { harness: "codex", model: "openai/gpt-5.6-sol" } },
+    }),
+    "utf8",
+  );
   await sharp({
     create: {
       width: 640,
@@ -295,6 +330,34 @@ async function main() {
       buildInfo.identity,
       `v${buildInfo.version}+${buildInfo.revision}`,
       "packaged sidecar build identity must be internally consistent",
+    );
+
+    const projectlessConversation = await fetch(`${baseUrl}/api/chat/conversation`, {
+      method: "POST",
+      headers: authenticatedHeaders(baseUrl, "application/json"),
+      body: JSON.stringify({ familiarId: "smoke" }),
+    });
+    assert.equal(
+      projectlessConversation.status,
+      400,
+      "packaged sidecar must reject a projectless conversation before session creation",
+    );
+    const projectlessBody = await projectlessConversation.json();
+    assert.equal(projectlessBody.code, "project_root_required");
+    await assert.rejects(
+      access(path.join(covenHome, "cave", "conversations")),
+      { code: "ENOENT" },
+      "projectless packaged launches must not persist a conversation",
+    );
+    assert.equal(
+      await runtimeContainsText(sidecarRoot, "daemon readiness timed out"),
+      true,
+      "packaged runtime must retain daemon readiness timeout handling",
+    );
+    assert.equal(
+      await runtimeContainsText(sidecarRoot, "project_root_required"),
+      true,
+      "packaged runtime must retain the project-root refusal gate",
     );
 
     const enginesResponse = await fetch(`${baseUrl}/api/voice/engines`, {

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -20,6 +20,7 @@ type RouteContract = {
 const contracts: RouteContract[] = [
   { route: "/access-groups", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/access-groups/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  { route: "/app/build-info", methods: ["GET"], kind: "json" },
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
   { route: "/asana/assigned", methods: ["GET"], kind: "json" },
   { route: "/asana/workspaces", methods: ["GET"], kind: "json" },

--- a/src/app/api/app/build-info/route.ts
+++ b/src/app/api/app/build-info/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { APP_BUILD_IDENTITY, APP_BUILD_REVISION, APP_VERSION } from "@/lib/app-version";
+
+export const dynamic = "force-dynamic";
+
+/** Public, value-free artifact identity for support and packaged-runtime smoke checks. */
+export async function GET() {
+  return NextResponse.json({
+    name: "CovenCave",
+    version: APP_VERSION,
+    revision: APP_BUILD_REVISION,
+    identity: APP_BUILD_IDENTITY,
+  });
+}

--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -28,10 +28,11 @@ const shim = [
   "const { appendFileSync } = require('node:fs');",
   "appendFileSync(process.env.COVEN_TEST_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
   "if (process.argv[2] === 'adapter' && process.argv[3] === 'list' && process.argv[4] === '--json') {",
-  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: process.env.COVEN_TEST_MODE === 'post-start' }]));",
+  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit'].includes(process.env.COVEN_TEST_MODE) }]));",
   "  process.exit(0);",
   "}",
   "if (process.argv[2] === 'run' && process.argv[3] === 'codex') {",
+  "  if (process.env.COVEN_TEST_MODE === 'silent-exit') process.exit(1);",
   "  process.stdout.write('unsupported harness `codex`');",
   "  process.exit(1);",
   "}",
@@ -131,6 +132,26 @@ try {
     callsAfterStart.some((args) => args[0] === "run" && args[1] === "codex" && args.includes("--stream-json")),
     "the post-start fixture exercises a real Coven run after the availability probe passed",
   );
+
+  // A process can start successfully and still exit before Coven emits any
+  // JSONL. That is neither an adapter-discovery failure nor evidence that
+  // Codex is signed out. It must remain a structured runtime-process error
+  // instead of fabricating the completed-but-empty authentication hint.
+  process.env.COVEN_TEST_MODE = "silent-exit";
+  const silentExitResponse = await POST(new Request("http://localhost/api/chat/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ familiarId: "opal", prompt: "silent child", projectRoot: familiarWorkspace }),
+  }));
+  const { body: silentExitBody, events: silentExitEvents } = await readSse(silentExitResponse);
+  const silentExitError = silentExitEvents.find((event) => event.kind === "error");
+  assert.ok(silentExitError, "a silent non-zero Codex exit produces a structured error event");
+  assert.equal(silentExitError.code, "runtime_process_failed");
+  assert.match(silentExitError.message, /Codex CLI exited with an error/);
+  assert.doesNotMatch(silentExitBody, /installed but not authenticated|produced no output/i);
+  assert.ok(!silentExitEvents.some((event) => event.kind === "assistant_chunk"));
+  const silentDone = silentExitEvents.findLast((event) => event.kind === "done");
+  assert.equal(silentDone?.isError, true);
 } finally {
   if (previousHome === undefined) delete process.env.COVEN_HOME;
   else process.env.COVEN_HOME = previousHome;

--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -28,11 +28,20 @@ const shim = [
   "const { appendFileSync } = require('node:fs');",
   "appendFileSync(process.env.COVEN_TEST_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
   "if (process.argv[2] === 'adapter' && process.argv[3] === 'list' && process.argv[4] === '--json') {",
-  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit'].includes(process.env.COVEN_TEST_MODE) }]));",
+  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit', 'assistant-envelope'].includes(process.env.COVEN_TEST_MODE) }]));",
   "  process.exit(0);",
   "}",
   "if (process.argv[2] === 'run' && process.argv[3] === 'codex') {",
   "  if (process.env.COVEN_TEST_MODE === 'silent-exit') process.exit(1);",
+  "  if (process.env.COVEN_TEST_MODE === 'assistant-envelope') {",
+  "    const events = [",
+  "      { type: 'system', subtype: 'init', model: 'gpt-5.6-sol', session_id: 'coven-envelope-session' },",
+  "      { type: 'assistant', message: { content: [{ type: 'text', text: 'Coven envelope response' }] }, session_id: 'coven-envelope-session' },",
+  "      { type: 'result', subtype: 'success', is_error: false, session_id: 'coven-envelope-session' },",
+  "    ];",
+  "    process.stdout.write(events.map((event) => JSON.stringify(event)).join('\\n') + '\\n');",
+  "    process.exit(0);",
+  "  }",
   "  process.stdout.write('unsupported harness `codex`');",
   "  process.exit(1);",
   "}",
@@ -132,6 +141,26 @@ try {
     callsAfterStart.some((args) => args[0] === "run" && args[1] === "codex" && args.includes("--stream-json")),
     "the post-start fixture exercises a real Coven run after the availability probe passed",
   );
+
+  // Coven's current Codex adapter emits its completed reply as a normal
+  // stream-json assistant envelope.  The route must emit that text directly;
+  // it is already structured assistant data and must not enter Codex's raw
+  // transcript filter, which expects an interactive marker line first.
+  process.env.COVEN_TEST_MODE = "assistant-envelope";
+  const envelopeResponse = await POST(new Request("http://localhost/api/chat/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ familiarId: "opal", prompt: "decode Coven envelope", projectRoot: familiarWorkspace }),
+  }));
+  const { events: envelopeEvents } = await readSse(envelopeResponse);
+  const envelopeChunks = envelopeEvents.filter((event) => event.kind === "assistant_chunk");
+  assert.deepEqual(
+    envelopeChunks.map((event) => event.text),
+    ["Coven envelope response"],
+    "a successful Coven Codex assistant envelope reaches the chat stream",
+  );
+  assert.equal(envelopeEvents.find((event) => event.kind === "error"), undefined);
+  assert.equal(envelopeEvents.findLast((event) => event.kind === "done")?.isError, false);
 
   // A process can start successfully and still exit before Coven emits any
   // JSONL. That is neither an adapter-discovery failure nor evidence that

--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -19,6 +19,7 @@ const previousCaveHome = process.env.COVEN_CAVE_HOME;
 const previousCovenBin = process.env.COVEN_BIN;
 const previousCovenTestLog = process.env.COVEN_TEST_LOG;
 const previousCovenTestMode = process.env.COVEN_TEST_MODE;
+const previousCovenCancelReady = process.env.COVEN_TEST_CANCEL_READY;
 process.env.COVEN_HOME = home;
 process.env.COVEN_CAVE_HOME = path.join(home, "cave");
 process.env.COVEN_TEST_LOG = log;
@@ -28,11 +29,16 @@ const shim = [
   "const { appendFileSync } = require('node:fs');",
   "appendFileSync(process.env.COVEN_TEST_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
   "if (process.argv[2] === 'adapter' && process.argv[3] === 'list' && process.argv[4] === '--json') {",
-  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit', 'assistant-envelope'].includes(process.env.COVEN_TEST_MODE) }]));",
+  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit', 'assistant-envelope', 'cancel'].includes(process.env.COVEN_TEST_MODE) }]));",
   "  process.exit(0);",
   "}",
   "if (process.argv[2] === 'run' && process.argv[3] === 'codex') {",
   "  if (process.env.COVEN_TEST_MODE === 'silent-exit') process.exit(1);",
+  "  if (process.env.COVEN_TEST_MODE === 'cancel') {",
+  "    appendFileSync(process.env.COVEN_TEST_CANCEL_READY, 'started');",
+  "    setInterval(() => {}, 1000);",
+  "    return;",
+  "  }",
   "  if (process.env.COVEN_TEST_MODE === 'assistant-envelope') {",
   "    const events = [",
   "      { type: 'system', subtype: 'init', model: 'gpt-5.6-sol', session_id: 'coven-envelope-session' },",
@@ -70,6 +76,18 @@ async function readSse(response) {
   return { body, events };
 }
 
+async function waitForText(file, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      return await readFile(file, "utf8");
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+  }
+  assert.fail(`timed out waiting for fixture marker ${file}`);
+}
+
 try {
   const { refreshCovenBin } = await import("@/lib/coven-bin");
   refreshCovenBin();
@@ -77,6 +95,7 @@ try {
   const { loadConversation } = await import("@/lib/cave-conversations");
   const { createProject } = await import("@/lib/cave-projects");
   const { grantProjectToFamiliar } = await import("@/lib/project-permissions");
+  const { requestChatStop } = await import("@/lib/server/chat-stop-registry");
   const { POST } = await import("./route.ts");
   await saveConfig({ familiars: { opal: { harness: "codex" } } });
   const project = await createProject({ name: "Codex availability fixture", root: familiarWorkspace });
@@ -181,6 +200,47 @@ try {
   assert.ok(!silentExitEvents.some((event) => event.kind === "assistant_chunk"));
   const silentDone = silentExitEvents.findLast((event) => event.kind === "done");
   assert.equal(silentDone?.isError, true);
+
+  // Stop is an expected interruption, not evidence that Coven or Codex
+  // failed. Its child commonly closes with a null exit code after SIGTERM;
+  // the route must preserve the user's cancelled turn without emitting a
+  // runtime-process failure or failed progress state.
+  const cancelReady = path.join(home, "cancel-ready");
+  process.env.COVEN_TEST_MODE = "cancel";
+  process.env.COVEN_TEST_CANCEL_READY = cancelReady;
+  const cancelledSessionId = "cancelled-codex-session";
+  const cancelledRunId = "cancelled-codex-run";
+  const cancelResponse = await POST(new Request("http://localhost/api/chat/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      familiarId: "opal",
+      prompt: "stop this silent Codex run",
+      projectRoot: familiarWorkspace,
+      sessionId: cancelledSessionId,
+      runId: cancelledRunId,
+    }),
+  }));
+  await waitForText(cancelReady);
+  assert.equal(requestChatStop(cancelledRunId), true, "the explicit Stop registry signal reaches the live run");
+  const { events: cancelledEvents } = await readSse(cancelResponse);
+  assert.equal(
+    cancelledEvents.find((event) => event.kind === "error"),
+    undefined,
+    "an explicit stop never emits an error event",
+  );
+  assert.equal(
+    cancelledEvents.find((event) => event.kind === "progress" && event.status === "error"),
+    undefined,
+    `an explicit stop never creates failed progress state: ${JSON.stringify(cancelledEvents)}`,
+  );
+  assert.equal(cancelledEvents.findLast((event) => event.kind === "done")?.isError, false);
+  const cancelledConversation = await loadConversation(cancelledSessionId);
+  const cancelledTurn = cancelledConversation?.turns.at(-1);
+  assert.equal(cancelledTurn?.role, "assistant");
+  assert.equal(cancelledTurn?.text, "(cancelled)");
+  assert.equal(cancelledTurn?.cancelled, true);
+  assert.equal(cancelledTurn?.isError, false);
 } finally {
   if (previousHome === undefined) delete process.env.COVEN_HOME;
   else process.env.COVEN_HOME = previousHome;
@@ -192,6 +252,8 @@ try {
   else process.env.COVEN_TEST_LOG = previousCovenTestLog;
   if (previousCovenTestMode === undefined) delete process.env.COVEN_TEST_MODE;
   else process.env.COVEN_TEST_MODE = previousCovenTestMode;
+  if (previousCovenCancelReady === undefined) delete process.env.COVEN_TEST_CANCEL_READY;
+  else process.env.COVEN_TEST_CANCEL_READY = previousCovenCancelReady;
   await rm(home, { recursive: true, force: true });
 }
 

--- a/src/app/api/chat/send/route-grok-compatibility.integration.test.ts
+++ b/src/app/api/chat/send/route-grok-compatibility.integration.test.ts
@@ -231,6 +231,10 @@ try {
     body: JSON.stringify({ familiarId: "opal", prompt: "exit error", projectRoot: familiarWorkspace }),
   })));
   assert.equal(exited.events.findLast((event) => event.kind === "done")?.isError, true, "a non-zero Grok process cannot be persisted as a successful turn");
+  const exitFailure = exited.events.find((event) => event.kind === "error");
+  assert.equal(exitFailure?.code, "runtime_process_failed", "a silent Grok process failure is not downgraded to the empty-output fallback");
+  assert.match(exitFailure?.message ?? "", /interactive sign-in.*`grok`/i, "the direct Grok failure gives the actionable first-run sign-in recovery");
+  assert.doesNotMatch(exited.body, /No error output captured|produced no output/i, "Grok's silent exit must not render the ambiguous empty-output diagnosis");
   assert.doesNotMatch(exited.body, /private Grok stderr payload/, "Grok stderr values never enter assistant-visible or persisted diagnostics");
 } finally {
   if (previousHome === undefined) delete process.env.COVEN_HOME; else process.env.COVEN_HOME = previousHome;

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -3930,6 +3930,8 @@ export async function POST(req: Request) {
             covenBackedProcessFailed ||=
               !sshRuntime &&
               localRuntimePlan?.runner === "coven" &&
+              !runHandle.stopRequested &&
+              typeof code === "number" &&
               code !== 0;
             if (covenBackedProcessFailed) {
               result = { ...result, is_error: true };
@@ -4139,7 +4141,7 @@ export async function POST(req: Request) {
       // bounded preflight passed. Coven has started in this branch, so map
       // only its adapter-level evidence back to the same actionable Codex
       // state; provider/auth errors intentionally remain untouched.
-      if (!launchFailure && binding.harness === "codex" && !assistantText.trim()) {
+      if (!launchFailure && !runHandle.stopRequested && binding.harness === "codex" && !assistantText.trim()) {
         const adapterFailure = codexAdapterFailure
           ?? codexAdapterFailureAvailability([...stderrTail, ...stdoutErrTail].join("\n"));
         if (adapterFailure) {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2202,6 +2202,10 @@ export async function POST(req: Request) {
       // (a never-launched CLI must not be diagnosed as "installed but not
       // authenticated") and skips persisting a fabricated assistant turn.
       let launchFailure: { code: string; message: string } | null = null;
+      // A Coven-backed child can exit non-zero before it writes even one
+      // stream frame. Defer classifying that condition until all buffered
+      // stdout has passed through the more-specific adapter failure parser.
+      let covenBackedProcessFailed = false;
       // Coven can send adapter startup failures through stdout, where Codex's
       // transcript filter intentionally suppresses pre-assistant noise. Keep
       // only the classified, fixed remediation so those failures cannot fall
@@ -3892,6 +3896,19 @@ export async function POST(req: Request) {
               assistantText += tail;
               push({ kind: "assistant_chunk", text: tail });
             }
+            // `coven run` is the outer launch vehicle for Codex, Claude, and
+            // compatible Coven-backed adapters. Process every final stdout
+            // fragment first: an adapter failure can arrive without a
+            // trailing newline and has more specific remediation. If the
+            // child was truly silent, a non-zero exit is a real runtime
+            // failure, not a successful-but-empty assistant response.
+            covenBackedProcessFailed ||=
+              !sshRuntime &&
+              localRuntimePlan?.runner === "coven" &&
+              code !== 0;
+            if (covenBackedProcessFailed) {
+              result = { ...result, is_error: true };
+            }
             req.signal.removeEventListener("abort", onAbort);
             resolve();
           });
@@ -4106,6 +4123,19 @@ export async function POST(req: Request) {
           pushProgress("harness-start", "codex failed to start", "error", adapterFailure.message);
           push({ kind: "error", code: adapterFailure.code, message: adapterFailure.message });
       }
+      }
+
+      if (!launchFailure && covenBackedProcessFailed && !assistantText.trim()) {
+        const failedRunner = binding.harness === "codex"
+          ? "codex"
+          : binding.harness === "claude"
+            ? "claude"
+            : "coven";
+        const failure = runtimeProcessFailure(failedRunner);
+        launchFailure = failure;
+        result.is_error = true;
+        pushProgress("harness-start", `${binding.harness} exited with an error`, "error", failure.message);
+        push({ kind: "error", code: failure.code, message: failure.message });
       }
 
       // User cancel (CHAT-D5-02): when the client stops the response

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2206,6 +2206,10 @@ export async function POST(req: Request) {
       // stream frame. Defer classifying that condition until all buffered
       // stdout has passed through the more-specific adapter failure parser.
       let covenBackedProcessFailed = false;
+      // Grok Build is launched directly. Its initial interactive sign-in
+      // failure can exit non-zero without emitting stdout or stderr, so retain
+      // the child outcome until buffered stream text has been fully decoded.
+      let grokProcessFailed = false;
       // Coven can send adapter startup failures through stdout, where Codex's
       // transcript filter intentionally suppresses pre-assistant noise. Keep
       // only the classified, fixed remediation so those failures cannot fall
@@ -3870,6 +3874,9 @@ export async function POST(req: Request) {
             if ((openCodeDirect || copilotStream || grokDirect) && code !== 0) {
               result = { ...result, is_error: true };
             }
+            if (grokDirect && code !== 0 && !runHandle.stopRequested) {
+              grokProcessFailed = true;
+            }
             if (binding.harness === "claude" && claudeInnerLaunchMissing) {
               const message = missingRunnerMessage("claude");
               result = { ...result, is_error: true };
@@ -4153,6 +4160,14 @@ export async function POST(req: Request) {
         launchFailure = failure;
         result.is_error = true;
         pushProgress("harness-start", `${binding.harness} exited with an error`, "error", failure.message);
+        push({ kind: "error", code: failure.code, message: failure.message });
+      }
+
+      if (!launchFailure && grokProcessFailed && !assistantText.trim()) {
+        const failure = runtimeProcessFailure("grok");
+        launchFailure = failure;
+        result.is_error = true;
+        pushProgress("harness-start", "Grok Build needs interactive sign-in", "error", failure.message);
         push({ kind: "error", code: failure.code, message: failure.message });
       }
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -3103,6 +3103,24 @@ export async function POST(req: Request) {
                 push({ kind: "assistant_chunk", text: filtered });
               }
             } else if (
+              // Coven's native stream-json transport represents completed
+              // Codex replies as an `assistant` envelope, just like the
+              // adapter's direct CLI output.  This is structured assistant
+              // content, not raw Codex transcript text, so it must bypass
+              // AssistantFilter's marker-phase gate.  Previously only the
+              // Claude compatibility branch decoded this shape; a successful
+              // Coven Codex reply was therefore discarded and misreported as
+              // an empty/authentication failure.
+              binding.harness !== "claude" &&
+              ev.type === "assistant" &&
+              Array.isArray(ev.message?.content)
+            ) {
+              for (const block of ev.message.content) {
+                if (block?.type !== "text" || typeof block.text !== "string" || !block.text) continue;
+                assistantText += block.text;
+                push({ kind: "assistant_chunk", text: block.text });
+              }
+            } else if (
               binding.harness === "claude" &&
               claudeCompatibility?.kind === "compatible" &&
               !claudeCompatibility.stale &&

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -85,6 +85,16 @@ assert.doesNotMatch(
   /availability:\s*\{[\s\S]{0,200}\b(?:command|fixedArgs|env|resolvedPath)\b/,
   "the harness API never copies private Copilot launch-plan data onto availability",
 );
+assert.match(
+  source,
+  /listOpenClawAgents\(\)/,
+  "OpenClaw status should count the live CLI registry used by chat resolution",
+);
+assert.doesNotMatch(
+  source,
+  /readdir\([\s\S]*?\.openclaw[\s\S]*?agents/,
+  "stale OpenClaw agent directories must not be reported as runnable agents",
+);
 
 assert.match(
   source,

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -1,8 +1,6 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
-import { readdir } from "node:fs/promises";
-import { homedir, hostname } from "node:os";
-import path from "node:path";
+import { hostname } from "node:os";
 import { pickVersionLine } from "@/lib/harness-version";
 import {
   COMPATIBILITY_ADAPTERS,
@@ -18,6 +16,7 @@ import { probeCodexRuntimeAvailability } from "@/lib/codex-runtime-availability"
 import { grokBin, grokLaunchCommandForBinary } from "@/lib/grok-bin";
 import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { openCodeAvailabilityProbe, openCodeLaunch, openCodeSpawnEnv } from "@/lib/opencode-bin";
+import { listOpenClawAgents } from "@/lib/openclaw-bridge";
 import { parseGrokModels, type RuntimeModelOption } from "@/lib/grok-build";
 import {
   resolveCopilotRuntimeLaunch,
@@ -287,16 +286,7 @@ function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
 }
 
 async function countOpenClawAgents(): Promise<number> {
-  try {
-    const entries = await readdir(path.join(homedir(), ".openclaw", "agents"), {
-      withFileTypes: true,
-    });
-    return entries.filter(
-      (entry) => entry.isDirectory() && !entry.name.startsWith("."),
-    ).length;
-  } catch {
-    return 0;
-  }
+  return (await listOpenClawAgents()).length;
 }
 
 export async function GET() {

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -23,8 +23,13 @@ assert.equal(
 );
 assert.match(
   source,
-  /targetName === "coven-cli"[\s\S]*covenBin\(\)[\s\S]*npmBesideDetectedCoven\(detected\)/,
-  "the Coven CLI update uses npm beside the detected CLI instead of requiring Cave-managed Node",
+  /targetName === "coven-cli"[\s\S]*covenBin\(\)[\s\S]*npmForDetectedCoven\(detected\)/,
+  "the Coven CLI update resolves host npm for the detected CLI instead of requiring Cave-managed Node",
+);
+assert.match(
+  source,
+  /async function npmForDetectedCoven[\s\S]*npmBesideDetectedCoven\(detected\)[\s\S]*commandPath\("npm", \{ refresh: true, refreshOnMiss: true \}\)/,
+  "a user-scoped Coven launcher may use host npm when npm is not colocated with the global bin",
 );
 assert.match(source, /targetName === "coven-cli"[\s\S]*npmLaunchCommandForPath/);
 assert.match(
@@ -48,7 +53,7 @@ assert.match(source, /await probeManagedNodeToolchain\(\)/, "pinned prerequisite
 assert.match(source, /managedNpmLaunch\(managed\.paths\)/, "npm runs through owned node and npm-cli.js");
 assert.match(source, /args: \[\.\.\.launch\.args, "install", "--global", target\.packageName\]/, "npm argv is fixed and reviewed");
 assert.match(source, /shell: false/, "installer spawns never use a shell");
-assert.doesNotMatch(source, /commandPath\("npm"/, "host npm/PATH is not a prerequisite");
+assert.match(source, /commandPath\("npm", \{ refresh: true, refreshOnMiss: true \}\)/, "Coven CLI repair falls back to verified host npm only for its detected prefix");
 assert.match(source, /installManagedNodeToolchain\(/, "managed Node installer is routed through the endpoint");
 assert.match(source, /controller\.abort\(\)/, "managed Node installation supports cancellation");
 assert.match(source, /reserveGlobalNpmInstall\(targetName\)/, "managed toolchain and npm operations serialize");

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -406,10 +406,9 @@ function daemonLifecycleDependencies(job: InstallJob): DaemonUpdateDependencies 
             : "daemon start completed",
         };
       }
-      const details = "error" in started
-        ? started.error
-        : [started.stderr, started.stdout].filter(Boolean).join("\n") || `exit ${started.exitCode ?? "unknown"}`;
-      return { ok: false, detail: details };
+      // Every non-success result from startLocalDaemon has a stable, redacted
+      // error code/message. Do not fall back to raw launcher output here.
+      return { ok: false, detail: started.error };
     },
     refreshExecutable: () => {
       refreshCovenBin();

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -192,6 +192,25 @@ function npmBesideDetectedCoven(detected: string): { npmPath: string; prefix: st
   };
 }
 
+/**
+ * A global npm bin commonly contains `coven.cmd` but not `npm.cmd` on
+ * Windows: npm itself lives beside node.exe while its configured global prefix
+ * is user-scoped. Prefer a colocated launcher when one exists, then resolve a
+ * host npm from the refreshed environment while retaining the detected CLI's
+ * prefix. This keeps the update in the same verified global installation
+ * without falsely asking a healthy CLI to be reinstalled.
+ */
+async function npmForDetectedCoven(detected: string): Promise<{ npmPath: string; prefix: string } | null> {
+  const adjacent = npmBesideDetectedCoven(detected);
+  if (adjacent) return adjacent;
+  const resolved = await commandPath("npm", { refresh: true, refreshOnMiss: true });
+  if (!resolved.path || !path.isAbsolute(resolved.path)) return null;
+  return {
+    npmPath: resolved.path,
+    prefix: process.platform === "win32" ? path.dirname(detected) : path.dirname(path.dirname(detected)),
+  };
+}
+
 function hostNpmSpawnEnv(npmPath: string, prefix: string): NodeJS.ProcessEnv {
   const env = caveToolSpawnEnv();
   for (const key of Object.keys(env)) {
@@ -220,18 +239,18 @@ async function spawnPlanFor(
     if (targetName === "coven-cli") {
       const detected = covenBin();
       if (path.isAbsolute(detected)) {
-        const adjacent = npmBesideDetectedCoven(detected);
-        if (!adjacent) return { npmMissing: true };
-        const launch = npmLaunchCommandForPath(adjacent.npmPath);
+        const npm = await npmForDetectedCoven(detected);
+        if (!npm) return { npmMissing: true };
+        const launch = npmLaunchCommandForPath(npm.npmPath);
         if (!launch) return { npmMissing: true };
         return {
           command: launch.command,
           args: [...launch.fixedArgs, "install", "--global", target.packageName],
-          env: hostNpmSpawnEnv(adjacent.npmPath, adjacent.prefix),
+          env: hostNpmSpawnEnv(npm.npmPath, npm.prefix),
           shell: false,
           verificationPath: detected,
           traceLines: [
-            "npm discovery: launcher beside the detected Coven CLI.",
+            "npm discovery: verified host npm for the detected Coven CLI prefix.",
             "Installer launch: host npm with fixed argv; shell disabled.",
           ],
         };

--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -39,6 +39,16 @@ assert.match(
   /harness === "openclaw" && openclawAgentCount > 0/,
   "OpenClaw counts as available only when a discoverable agent exists",
 );
+assert.match(
+  source,
+  /listOpenClawAgents\(\)/,
+  "onboarding should use the same live OpenClaw registry as chat resolution",
+);
+assert.doesNotMatch(
+  source,
+  /readdir\([\s\S]*?\.openclaw[\s\S]*?agents/,
+  "stale OpenClaw agent directories must not satisfy onboarding readiness",
+);
 
 assert.match(
   source,

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { execFile } from "node:child_process";
-import { readdir, stat } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -19,6 +19,7 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
+import { listOpenClawAgents } from "@/lib/openclaw-bridge";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -94,15 +95,7 @@ async function commandPath(binary: string): Promise<string | null> {
 }
 
 async function countOpenClawAgents(): Promise<number> {
-  const agentsRoot = path.join(homedir(), ".openclaw", "agents");
-  try {
-    const entries = await readdir(agentsRoot, { withFileTypes: true });
-    return entries.filter(
-      (entry) => entry.isDirectory() && !entry.name.startsWith("."),
-    ).length;
-  } catch {
-    return 0;
-  }
+  return (await listOpenClawAgents()).length;
 }
 
 async function checkHarnessAdapters(

--- a/src/app/api/openclaw-agents/route.ts
+++ b/src/app/api/openclaw-agents/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 import { summarizeOpenClawAgent } from "@/lib/openclaw-agents";
+import { listOpenClawAgents } from "@/lib/openclaw-bridge";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -19,23 +20,21 @@ export async function GET() {
   const home = homedir();
   const agentsRoot = path.join(home, ".openclaw", "agents");
   const workspaceRoot = path.join(home, ".openclaw", "workspace");
-
-  let entries;
-  try {
-    entries = await readdir(agentsRoot, { withFileTypes: true });
-  } catch {
-    return NextResponse.json({ ok: true, agents: [], agentsRoot });
-  }
+  const registeredAgents = await listOpenClawAgents();
 
   const agents = await Promise.all(
-    entries
-      .filter((entry) => entry.isDirectory() && !entry.name.startsWith("."))
-      .map(async (entry) => {
-        const id = entry.name;
-        const workspacePath = path.join(workspaceRoot, id);
+    registeredAgents
+      .map(async (agent) => {
+        const id = agent.id;
+        const workspacePath = agent.workspace?.trim() || path.join(workspaceRoot, id);
         const exists = await stat(workspacePath).then((s) => s.isDirectory()).catch(() => false);
         const identity = exists ? await readIdentity(workspacePath) : null;
-        return summarizeOpenClawAgent(id, identity, exists ? workspacePath : null);
+        const summary = summarizeOpenClawAgent(id, identity, exists ? workspacePath : null);
+        return {
+          ...summary,
+          displayName: agent.name?.trim() || agent.identityName?.trim() || summary.displayName,
+          isDefault: agent.isDefault === true,
+        };
       }),
   );
 

--- a/src/app/api/project-grants/route.test.ts
+++ b/src/app/api/project-grants/route.test.ts
@@ -153,6 +153,12 @@ assert.match(
   /listAccessGroups/,
   "grants GET should ride access groups along so one fetch renders effective access",
 );
+assert.match(grantsRoute, /inspectProjectPermissionIntegrity/, "grants GET exposes orphan-grant integrity for operator remediation");
+assert.match(
+  grantsRoute,
+  /payload\.repairOrphans === true[\s\S]*repairOrphanProjectPermissions/,
+  "a trusted human may explicitly repair orphan grants without granting access",
+);
 assert.match(
   grantsRoute,
   /if \(payload\.access === undefined\) return "write";/,

--- a/src/app/api/project-grants/route.ts
+++ b/src/app/api/project-grants/route.ts
@@ -12,6 +12,8 @@ import {
   listProjectGrants,
   listRecentPermissionAudit,
   loadHumanPermissionConfig,
+  inspectProjectPermissionIntegrity,
+  repairOrphanProjectPermissions,
   revokeProjectFromFamiliar,
 } from "@/lib/project-permissions";
 
@@ -55,11 +57,12 @@ function accessInput(payload: Record<string, unknown>): "read" | "write" | null 
 }
 
 export async function GET() {
-  const [grants, config, audit, accessGroups] = await Promise.all([
+  const [grants, config, audit, accessGroups, integrity] = await Promise.all([
     listProjectGrants(),
     loadHumanPermissionConfig(),
     listRecentPermissionAudit(),
     listAccessGroups(),
+    inspectProjectPermissionIntegrity(),
   ]);
   // `supremeFamiliarId` has access to every project regardless of grants — the
   // Permissions UI marks it as all-access and locks its toggles on. `audit` is a
@@ -74,6 +77,7 @@ export async function GET() {
     supremeFamiliarId: config.supremeFamiliarId,
     mobileMutationsAllowed: config.allowMobileGrantMutations,
     audit,
+    integrity,
   });
 }
 
@@ -85,6 +89,10 @@ export async function POST(req: Request) {
   if (payload instanceof Response) return payload;
   const rejected = rejectRelayedApproval(payload);
   if (rejected) return rejected;
+  if (payload.repairOrphans === true) {
+    const integrity = await repairOrphanProjectPermissions();
+    return NextResponse.json({ ok: true, repaired: integrity });
+  }
   const input = grantInput(payload);
   if (!input) {
     return NextResponse.json(

--- a/src/components/chat-error-redaction.test.ts
+++ b/src/components/chat-error-redaction.test.ts
@@ -1,0 +1,19 @@
+// @ts-nocheck
+// The chat error strip is a support boundary. Raw tool I/O may include local
+// paths, project content, or credentials, so it must not reach rendered or
+// copied diagnostics even though the recovery classifier may inspect it.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+
+assert.match(source, /const recoveryText = useMemo/, "raw context is isolated for recovery classification");
+assert.match(source, /const detailText = useMemo[\s\S]{0,700}Chat request did not complete/, "copied detail uses a fixed safe summary");
+assert.match(source, /onClick=\{\(\) => copy\(detailText\)\}/, "copy only receives the safe detail summary");
+assert.match(source, /parseHarnessFailure\(recoveryText\)/, "recovery can classify raw failures without rendering them");
+assert.match(source, /input and output are withheld to protect project data/, "tool I/O is explicitly withheld in the UI");
+assert.match(source, /detail is withheld to protect project data/, "step detail is explicitly withheld in the UI");
+
+const errorStrip = source.slice(source.indexOf("function ChatErrorStrip"), source.indexOf("function AuthFixRow"));
+assert.doesNotMatch(errorStrip, /<pre className=\{pre\}>\{t\.(?:input|output)\}<\/pre>/, "raw tool I/O is not rendered");
+assert.doesNotMatch(errorStrip, /<pre className=\{pre\}>\{p\.(?:detail|label)\}<\/pre>/, "raw progress detail is not rendered");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -521,9 +521,10 @@ type ErrorStripStep = { id: string; label: string; detail?: string; status: "run
 type ErrorStripTurn = { tools?: ErrorStripTool[]; progress?: ErrorStripStep[]; lifecycle?: string };
 
 /** Inline error/debug strip between the transcript and the composer. Shows the
- *  latest chat error message + code, and (expandable) the failing turn's errored
- *  tool/step output so the debug detail is visible without opening the side
- *  Debug pane. Auto-expands on every new error (keyed on `errorSeq`). */
+ *  latest chat error message + code plus metadata-only failure diagnostics.
+ *  Tool input/output and step detail can contain project content, paths, or
+ *  credentials, so they are deliberately never rendered or copied here.
+ *  Auto-expands on every new error (keyed on `errorSeq`). */
 function ChatErrorStrip({
   message,
   code,
@@ -589,7 +590,10 @@ function ChatErrorStrip({
     setOpen(true);
   }, [errorSeq]);
 
-  const detailText = useMemo(() => {
+  // Keep the unredacted failure context in-memory solely for established
+  // recovery classification (adapter switch and sign-in remediation). It must
+  // never be rendered, copied, or included in telemetry/diagnostics.
+  const recoveryText = useMemo(() => {
     const lines: string[] = [message];
     if (code) lines.push(`code: ${code}`);
     for (const t of erroredTools) {
@@ -605,15 +609,26 @@ function ChatErrorStrip({
     return lines.join("\n");
   }, [message, code, erroredTools, erroredSteps]);
 
+  // This is the only diagnostic text that leaves the component. Keep it
+  // deliberately structural: no dynamic tool names, input, output, labels,
+  // or error detail can cross this boundary.
+  const detailText = useMemo(() => {
+    const lines: string[] = ["Chat request did not complete."];
+    if (code && /^[a-z0-9_]{1,80}$/i.test(code)) lines.push(`code: ${code}`);
+    if (erroredTools.length) lines.push(`failed tools: ${erroredTools.length}`);
+    if (erroredSteps.length) lines.push(`failed steps: ${erroredSteps.length}`);
+    return lines.join("\n");
+  }, [code, erroredTools.length, erroredSteps.length]);
+
   // Harness/runtime failures get an inline fix row (switch adapter / copy the
   // quoted `coven adapter …` commands) instead of ending at the message.
-  const harnessFailure = useMemo(() => parseHarnessFailure(detailText), [detailText]);
+  const harnessFailure = useMemo(() => parseHarnessFailure(recoveryText), [recoveryText]);
   // Sign-in failures land here at the FIRST message (the wizard greens on
   // install, never auth) — surface the runtime's login command instead of
   // ending at raw stderr (cave-f6ol).
   const authFailure = useMemo(
-    () => parseHarnessAuthFailure(detailText, harnessId),
-    [detailText, harnessId],
+    () => parseHarnessAuthFailure(recoveryText, harnessId),
+    [recoveryText, harnessId],
   );
   // A preflight-confirmed missing runtime (or the legacy Coven ENOENT path)
   // gets a soft Setup recovery instead of a bare error + generic Retry. The
@@ -769,17 +784,16 @@ function ChatErrorStrip({
             {erroredTools.map((t) => (
               <div key={t.id}>
                 <div className={kicker}>
-                  tool: {t.name}
+                  tool failure
                   {t.durationMs != null ? ` · ${fmtDuration(t.durationMs)}` : ""}
                 </div>
-                {t.input ? <pre className={pre}>{t.input}</pre> : null}
-                {t.output ? <pre className={pre}>{t.output}</pre> : null}
+                <pre className={pre}>A tool failed. Its input and output are withheld to protect project data.</pre>
               </div>
             ))}
             {erroredSteps.map((p) => (
               <div key={p.id}>
-                <div className={kicker}>step{p.detail ? `: ${p.label}` : ""}</div>
-                <pre className={pre}>{p.detail || p.label}</pre>
+                <div className={kicker}>step failure</div>
+                <pre className={pre}>A runtime step failed. Its detail is withheld to protect project data.</pre>
               </div>
             ))}
             {erroredTools.length === 0 && erroredSteps.length === 0 ? (

--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -24,15 +24,17 @@ test("the first-project gate is a non-modal detail-scoped panel with no dismiss 
 
 test("the gate copy makes project creation mandatory for chat", () => {
   const src = read("./first-project-gate.tsx");
-  assert.match(src, />\s*Create your first project\s*</, "headline names the first-project task directly");
+  assert.match(src, /Create your first project/, "the no-project state names the first-project task directly");
+  assert.match(src, /Give this familiar project access/, "an existing project gets an explicit access-recovery state");
   assert.match(src, /Chat requires a project/, "copy explains that chat cannot proceed without a project");
+  assert.match(src, /Grant access so this familiar can use it in chat/, "registered-but-inaccessible projects are explained truthfully");
 });
 
 test("the gate stays prop-driven and focuses the correct first control on first visibility", () => {
   const src = read("./first-project-gate.tsx");
   assert.match(
     src,
-    /type FirstProjectGateProps = \{[\s\S]*open: boolean;[\s\S]*familiarId: string \| null;[\s\S]*pendingGrant: PendingFirstProjectAccessSnapshot \| null;[\s\S]*onPendingGrantChange: \(snapshot: PendingFirstProjectAccessSnapshot \| null\) => void;[\s\S]*loadingProjects: boolean;[\s\S]*projectsError: string \| null;[\s\S]*createProjectOrThrow: \(\s*name: string,\s*root: string,\s*options\?: CreateProjectOptions,\s*\) => Promise<CaveProject>;\s*reloadProjects: \(\) => void;/,
+    /type FirstProjectGateProps = \{[\s\S]*open: boolean;[\s\S]*familiarId: string \| null;[\s\S]*pendingGrant: PendingFirstProjectAccessSnapshot \| null;[\s\S]*onPendingGrantChange: \(snapshot: PendingFirstProjectAccessSnapshot \| null\) => void;[\s\S]*loadingProjects: boolean;[\s\S]*projectsError: string \| null;[\s\S]*registeredProjects: CaveProject\[\];[\s\S]*createProjectOrThrow: \(\s*name: string,\s*root: string,\s*options\?: CreateProjectOptions,\s*\) => Promise<CaveProject>;\s*reloadProjects: \(\) => void;/,
     "the gate stays prop-driven with the required integration fields",
   );
   assert.match(src, /const nameInputRef = useRef<HTMLInputElement \| null>\(null\);/, "keeps a stable ref for the project-name field");
@@ -44,8 +46,8 @@ test("the gate stays prop-driven and focuses the correct first control on first 
   );
   assert.match(
     src,
-    /const initialFocusTarget = registeredProject \? submitButtonRef\.current : nameInputRef\.current;[\s\S]*window\.requestAnimationFrame\(\(\) => \{\s*initialFocusTarget\?\.focus\(\{ preventScroll: true \}\);\s*\}\);/,
-    "requestAnimationFrame restores initial focus to Retry access when pending, otherwise the name field",
+    /const initialFocusTarget = lockedProject \? submitButtonRef\.current : nameInputRef\.current;[\s\S]*window\.requestAnimationFrame\(\(\) => \{\s*initialFocusTarget\?\.focus\(\{ preventScroll: true \}\);\s*\}\);/,
+    "requestAnimationFrame restores initial focus to a grant or retry action when a project is selected, otherwise the name field",
   );
   assert.match(src, /ref=\{nameInputRef\}/, "the stable focus ref is wired to the project-name input");
   assert.match(src, /ref=\{submitButtonRef\}/, "the stable submit ref is wired to the primary action");
@@ -158,7 +160,7 @@ test("the gate keeps drafts through failures, blocks blank or busy submits, and 
   assert.match(src, /const submitRoot = lockedProject\?\.root \?\? rootDraft\.trim\(\);/, "retries use the stored project root instead of mutable drafts");
   assert.match(
     src,
-    /if \(submitFamiliarId && !pendingGrant && !canPersistPendingFirstProjectAccessSnapshot\(\)\) \{[\s\S]*setSubmitError\(STORAGE_REQUIRED_ERROR\);[\s\S]*return;[\s\S]*\}/,
+    /if \(submitFamiliarId && !pendingGrant && !lockedProject && !canPersistPendingFirstProjectAccessSnapshot\(\)\) \{[\s\S]*setSubmitError\(STORAGE_REQUIRED_ERROR\);[\s\S]*return;[\s\S]*\}/,
     "first-time create is blocked before project registration when session storage cannot durably hold the retry snapshot",
   );
   assert.match(
@@ -166,13 +168,11 @@ test("the gate keeps drafts through failures, blocks blank or busy submits, and 
     /if \(submitFamiliarId && pendingGrant && !writePendingFirstProjectAccessSnapshot\(pendingGrant\)\) \{[\s\S]*setSubmitError\(STORAGE_RETRY_ERROR\);[\s\S]*return;[\s\S]*\}/,
     "retry access re-attempts persistence before the grant call and stays blocked when storage is still unavailable",
   );
-  assert.match(src, /existingProjectId: pendingGrant\?\.project\.id/, "retries grant against the already-created project instead of creating a duplicate");
+  assert.match(src, /existingProjectId: lockedProject\?\.id/, "retries and existing-project grants use the registered id instead of creating a duplicate");
   assert.match(src, /name: submitName/, "passes the stored-or-drafted name through addChatProject");
-  assert.match(
-    src,
-    /if \(result\.ok\) \{[\s\S]*const createdProjectName = registeredProject\?\.name \?\? submitName;[\s\S]*clearPendingFirstProjectAccessSnapshot\(\);[\s\S]*onPendingGrantChange\(null\);[\s\S]*announce\(`Created project \$\{createdProjectName\}\. Chat is ready\.`\);/,
-    "announces the stored project name on success and clears persisted retry state only after the grant succeeds",
-  );
+  assert.match(src, /const createdProjectName = lockedProject\?\.name \?\? submitName;/, "success uses the existing project name when granting access");
+  assert.match(src, /clearPendingFirstProjectAccessSnapshot\(\);[\s\S]*onPendingGrantChange\(null\);/, "success clears persisted retry state only after the grant succeeds");
+  assert.match(src, /lockedProject \? "Granted" : "Created"/, "the live announcement distinguishes a grant from project creation");
   assert.match(src, /if \(submitting \|\| loadingProjects \|\| Boolean\(projectsError\)\) return;/, "the submit handler rejects busy or registry-blocked submits before any mutation");
   assert.match(src, /if \(!lockedProject && !submitName\) \{[\s\S]*setSubmitError\("Enter a project name\."\);/, "blank project names are blocked before the first registration");
   assert.match(src, /if \(!lockedProject && !submitRoot\) \{[\s\S]*setSubmitError\("Enter an absolute project root\."\);/, "blank project roots are blocked before the first registration");
@@ -183,7 +183,7 @@ test("the gate keeps drafts through failures, blocks blank or busy submits, and 
   assert.match(src, /onClick=\{reloadProjects\}/, "project-list failures expose a Retry action");
   assert.match(src, /disabled=\{submitting \|\| loadingProjects \|\| Boolean\(projectsError\) \|\| !canSubmit\}/, "creation stays blocked while the registry is still loading or errored");
   assert.match(src, /disabled=\{Boolean\(registeredProject\) \|\| submitting\}/, "name, root, and Browse controls lock once only the access grant needs retry");
-  assert.match(src, /\{registeredProject \? "Retry access" : "Create"\}/, "the submit action relabels to Retry access for partial-grant retries");
+  assert.match(src, /\{registeredProject \? "Retry access" : lockedProject \? "Grant access" : "Create"\}/, "the submit action distinguishes retry, existing-project grant, and creation");
   assert.match(src, /ref=\{submitButtonRef\}/, "Retry access can receive initial focus via the enabled submit button");
   assert.match(src, /Project <span className="font-medium text-\[var\(--text-primary\)\]">\{registeredProject\.name\}<\/span> was[\s\S]*Retry access so the required familiar can use[\s\S]*\{registeredProject\.root\}/, "copy explains that the project was created and only access still needs retry without rebinding to another familiar");
   assert.doesNotMatch(src, /Project created, but chat still needs access:/, "retry context lives in the descriptive copy, not as a prefixed error wrapper");
@@ -199,7 +199,7 @@ test("the gate exposes the exact root field plus Browse and Create-or-retry acti
   assert.match(src, /placeholder="\/absolute\/path\/to\/project"/, "the root field explains the required absolute-path format");
   assert.match(src, />\s*Browse\s*</, "the gate exposes a Browse action next to the root field");
   assert.match(src, /"Create"/, "the gate exposes a Create action for the first project");
-  assert.match(src, /\{registeredProject \? "Retry access" : "Create"\}/, "the primary action swaps from Create to Retry access after registration succeeds");
+  assert.match(src, /\{registeredProject \? "Retry access" : lockedProject \? "Grant access" : "Create"\}/, "the primary action distinguishes Create, Grant access, and Retry access");
 });
 
 console.log("first-project-gate.test.ts OK");

--- a/src/components/first-project-gate.tsx
+++ b/src/components/first-project-gate.tsx
@@ -31,6 +31,8 @@ type FirstProjectGateProps = {
   onPendingGrantChange: (snapshot: PendingFirstProjectAccessSnapshot | null) => void;
   loadingProjects: boolean;
   projectsError: string | null;
+  /** The operator-visible registry. Existing entries are grantable without a duplicate create. */
+  registeredProjects: CaveProject[];
   createProjectOrThrow: (
     name: string,
     root: string,
@@ -51,6 +53,7 @@ export function FirstProjectGate({
   onPendingGrantChange,
   loadingProjects,
   projectsError,
+  registeredProjects: availableProjects,
   createProjectOrThrow,
   reloadProjects,
 }: FirstProjectGateProps) {
@@ -60,6 +63,7 @@ export function FirstProjectGate({
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
+  const [selectedExistingProjectId, setSelectedExistingProjectId] = useState("");
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const wasVisibleRef = useRef(false);
@@ -67,11 +71,19 @@ export function FirstProjectGate({
   const copyId = useId();
   const rootHintId = useId();
   const registeredProject = pendingGrant?.project ?? null;
+  const selectedExistingProject = availableProjects.find(
+    (project) => project.id === selectedExistingProjectId,
+  ) ?? null;
   const submitFamiliarId = pendingGrant?.familiarId ?? familiarId;
-  const lockedProject = registeredProject;
+  const lockedProject = registeredProject ?? selectedExistingProject;
   const submitName = lockedProject?.name ?? nameDraft.trim();
   const submitRoot = lockedProject?.root ?? rootDraft.trim();
   const canSubmit = lockedProject ? true : Boolean(nameDraft.trim() && rootDraft.trim() && isAbsolutePath(rootDraft));
+
+  useEffect(() => {
+    if (registeredProject || selectedExistingProjectId || availableProjects.length === 0) return;
+    setSelectedExistingProjectId(availableProjects[0]!.id);
+  }, [availableProjects, registeredProject, selectedExistingProjectId]);
 
   useEffect(() => {
     if (!open) {
@@ -81,12 +93,12 @@ export function FirstProjectGate({
     if (wasVisibleRef.current) return;
 
     wasVisibleRef.current = true;
-    const initialFocusTarget = registeredProject ? submitButtonRef.current : nameInputRef.current;
+    const initialFocusTarget = lockedProject ? submitButtonRef.current : nameInputRef.current;
     const frame = window.requestAnimationFrame(() => {
       initialFocusTarget?.focus({ preventScroll: true });
     });
     return () => window.cancelAnimationFrame(frame);
-  }, [open, registeredProject]);
+  }, [open, lockedProject]);
 
   const applyPickedRoot = useCallback((dir: string) => {
     const trimmed = dir.trim();
@@ -149,7 +161,7 @@ export function FirstProjectGate({
       setSubmitError("Project root must be an absolute path.");
       return;
     }
-    if (submitFamiliarId && !pendingGrant && !canPersistPendingFirstProjectAccessSnapshot()) {
+    if (submitFamiliarId && !pendingGrant && !lockedProject && !canPersistPendingFirstProjectAccessSnapshot()) {
       setSubmitError(STORAGE_REQUIRED_ERROR);
       return;
     }
@@ -165,15 +177,15 @@ export function FirstProjectGate({
         root: submitRoot,
         familiarId: submitFamiliarId,
         createProject: createProjectWithRegistration,
-        existingProjectId: pendingGrant?.project.id,
+        existingProjectId: lockedProject?.id,
         name: submitName,
       });
       if (result.ok) {
-        const createdProjectName = registeredProject?.name ?? submitName;
+        const createdProjectName = lockedProject?.name ?? submitName;
         clearPendingFirstProjectAccessSnapshot();
         onPendingGrantChange(null);
         setSubmitError(null);
-        announce(`Created project ${createdProjectName}. Chat is ready.`);
+        announce(`${lockedProject ? "Granted" : "Created"} project ${createdProjectName}. Chat is ready.`);
       } else {
         setSubmitError(result.error);
       }
@@ -182,7 +194,7 @@ export function FirstProjectGate({
     } finally {
       setSubmitting(false);
     }
-  }, [announce, createProjectWithRegistration, loadingProjects, pendingGrant, projectsError, registeredProject, submitFamiliarId, submitName, submitRoot, submitting, lockedProject, onPendingGrantChange]);
+  }, [announce, createProjectWithRegistration, loadingProjects, pendingGrant, projectsError, submitFamiliarId, submitName, submitRoot, submitting, lockedProject, onPendingGrantChange]);
 
   if (!open) return null;
 
@@ -202,7 +214,7 @@ export function FirstProjectGate({
                   Project required
                 </p>
                 <h2 id={titleId} className="mt-2 text-[length:var(--text-display)] font-semibold leading-tight text-[var(--text-primary)]">
-                  Create your first project
+                  {lockedProject ? "Give this familiar project access" : "Create your first project"}
                 </h2>
                 <p id={copyId} className="mt-2 max-w-2xl text-[length:var(--text-md)] leading-6 text-[var(--text-secondary)]">
                   {registeredProject ? (
@@ -213,6 +225,11 @@ export function FirstProjectGate({
                       <span className="font-mono text-[var(--text-primary)]">{registeredProject.root}</span>
                       {" "}
                       in chat.
+                    </>
+                  ) : selectedExistingProject ? (
+                    <>
+                      Project <span className="font-medium text-[var(--text-primary)]">{selectedExistingProject.name}</span> is
+                      already registered. Grant access so this familiar can use it in chat.
                     </>
                   ) : (
                     "Chat requires a project. Add the absolute root for the codebase you want this familiar to use before you start chatting."
@@ -255,7 +272,36 @@ export function FirstProjectGate({
                   </p>
                 ) : null}
 
-                <div className="space-y-2">
+                {!registeredProject && availableProjects.length > 0 ? (
+                  <div className="space-y-2">
+                    <label
+                      htmlFor="first-project-gate-existing"
+                      className="block text-[length:var(--text-xs)] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]"
+                    >
+                      Registered project
+                    </label>
+                    <select
+                      id="first-project-gate-existing"
+                      value={selectedExistingProjectId}
+                      onChange={(event) => {
+                        setSelectedExistingProjectId(event.target.value);
+                        setSubmitError(null);
+                      }}
+                      disabled={submitting}
+                      className="focus-ring h-10 w-full rounded-[var(--radius-control)] border border-[var(--border-strong)] bg-[var(--bg-base)] px-3 text-[length:var(--text-md)] text-[var(--text-primary)]"
+                    >
+                      <option value="">Add a different project…</option>
+                      {availableProjects.map((project) => (
+                        <option key={project.id} value={project.id}>{project.name}</option>
+                      ))}
+                    </select>
+                    <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
+                      Choose an existing project to grant access, or add a different project folder.
+                    </p>
+                  </div>
+                ) : null}
+
+                {!lockedProject ? <div className="space-y-2">
                   <label
                     htmlFor="first-project-gate-name"
                     className="block text-[length:var(--text-xs)] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]"
@@ -274,9 +320,9 @@ export function FirstProjectGate({
                     disabled={Boolean(registeredProject) || submitting}
                     className="focus-ring h-10 w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 text-[length:var(--text-md)] text-[var(--text-primary)] placeholder:text-[var(--text-muted)]"
                   />
-                </div>
+                </div> : null}
 
-                <div className="space-y-2">
+                {!lockedProject ? <div className="space-y-2">
                   <label
                     htmlFor="first-project-gate-root"
                     className="block text-[length:var(--text-xs)] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]"
@@ -311,7 +357,7 @@ export function FirstProjectGate({
                   <p id={rootHintId} className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
                     Pick the repository root you want chat to run inside.
                   </p>
-                </div>
+                </div> : null}
 
                 <div className="flex items-center justify-end">
                   <Button
@@ -323,7 +369,7 @@ export function FirstProjectGate({
                     disabled={submitting || loadingProjects || Boolean(projectsError) || !canSubmit}
                     className="!h-10 rounded-[var(--radius-control)] px-4 text-[length:var(--text-sm)] font-medium disabled:opacity-50"
                   >
-                    {registeredProject ? "Retry access" : "Create"}
+                    {registeredProject ? "Retry access" : lockedProject ? "Grant access" : "Create"}
                   </Button>
                 </div>
               </form>

--- a/src/components/harness-fix-actions.test.ts
+++ b/src/components/harness-fix-actions.test.ts
@@ -52,12 +52,12 @@ import { readFile } from "node:fs/promises";
   );
   assert.match(
     source,
-    /parseHarnessFailure\(detailText\)/,
-    "ChatErrorStrip should parse the full detail text (message + code + tool/step output)",
+    /parseHarnessFailure\(recoveryText\)/,
+    "ChatErrorStrip should parse raw in-memory recovery context without exposing it in copied diagnostics",
   );
   assert.match(
     source,
-    /parseHarnessAuthFailure\(detailText, harnessId\)/,
+    /parseHarnessAuthFailure\(recoveryText, harnessId\)/,
     "ChatErrorStrip should detect runtime sign-in failures with the failing send's runtime (cave-f6ol)",
   );
   assert.match(

--- a/src/components/open-coven-tools-update.test.ts
+++ b/src/components/open-coven-tools-update.test.ts
@@ -78,6 +78,7 @@ assert.match(src, /export function OpenCovenToolsBannerTrigger/, "exports a shel
 assert.match(src, /coven-cave:tool-update:dismissed:/, "tool update banners persist dismissal per released tool version");
 assert.match(src, /pushBanner\(/, "tool update trigger publishes through the shared shell banner system");
 assert.match(src, /const incompatibleTools = tools\.filter\(toolNeedsCompatibilityUpdate\)/, "global banner only warns for installed tools below the Cave floor");
+assert.match(src, /tool\.id !== "coven-cli" && tool\.compatible && tool\.outdated/, "ordinary CLI availability is shown only in the detailed About tools surface");
 assert.match(src, /severity: incompatibleTools\.length > 0 \? "warning" : "info"/, "compatibility failures get stronger warning severity than ordinary updates");
 assert.match(src, /Review tools/, "tool update banner sends users to the settings tool surface");
 assert.match(shell, /OpenCovenToolsBannerTrigger/, "Shell imports and mounts the OpenCoven tools banner trigger");

--- a/src/components/open-coven-tools-update.tsx
+++ b/src/components/open-coven-tools-update.tsx
@@ -294,7 +294,11 @@ export function OpenCovenToolsBannerTrigger() {
           if (cancelled || !json?.ok) return;
           const tools = (json.tools ?? []).filter((tool) => isInstallTarget(tool.id));
           const incompatibleTools = tools.filter(toolNeedsCompatibilityUpdate);
-          const outdatedTools = tools.filter((tool) => tool.compatible && tool.outdated);
+          const outdatedTools = tools
+            // CLI update details and the explicit action live in Settings →
+            // About. Do not duplicate an ordinary availability notice in the
+            // chat header; compatibility failures remain banner-worthy.
+            .filter((tool) => tool.id !== "coven-cli" && tool.compatible && tool.outdated);
           const bannerTools = incompatibleTools.length > 0 ? incompatibleTools : outdatedTools;
           if (bannerTools.length === 0) {
             dismissBanner(TOOL_UPDATE_BANNER_ID);

--- a/src/components/projects-view-repair-behavior.test.tsx
+++ b/src/components/projects-view-repair-behavior.test.tsx
@@ -1,0 +1,200 @@
+// @ts-nocheck
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+import { ProjectsView } from "./projects-view";
+
+const observed = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  announcements: [] as string[],
+}));
+
+vi.mock("@/lib/use-projects", () => ({
+  useProjects: () => ({
+    projects: [],
+    loading: false,
+    error: null,
+    reload: vi.fn(),
+    createProject: vi.fn(),
+    updateRepoUrl: vi.fn(),
+    renameProject: vi.fn(),
+    deleteProject: vi.fn(),
+  }),
+}));
+vi.mock("@/lib/use-refresh-on-focus", () => ({ useRefreshOnFocus: vi.fn() }));
+vi.mock("@/components/project-picker", () => ({
+  useAddProjectFlow: () => ({
+    beginAddProject: vi.fn(),
+    addProjectModal: null,
+    adding: false,
+    addError: null,
+  }),
+}));
+vi.mock("@/components/ui/confirm-dialog", () => ({
+  useConfirm: () => observed.confirm,
+}));
+vi.mock("@/components/ui/live-region", () => ({
+  useAnnouncer: () => ({
+    announce: (message: string) => observed.announcements.push(message),
+  }),
+}));
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, ...props }: { children: unknown }) => <button {...props}>{children}</button>,
+}));
+vi.mock("@/components/ui/empty-state", () => ({ EmptyState: () => <div /> }));
+vi.mock("@/components/ui/error-state", () => ({ ErrorState: () => <div /> }));
+vi.mock("@/components/ui/skeleton", () => ({ SkeletonRows: () => <div /> }));
+vi.mock("@/components/ui/select", () => ({
+  StandardSelect: (props: Record<string, unknown>) => <select {...props} />,
+}));
+vi.mock("@/components/project-settings-modal", () => ({
+  ProjectSettingsModal: () => null,
+}));
+vi.mock("@/lib/icon", () => ({ Icon: () => <span /> }));
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const staleIntegrity = {
+  directGrants: 1,
+  groupGrants: 0,
+  proposals: 0,
+  orphanProjectIds: ["removed-project"],
+};
+const repairedIntegrity = {
+  directGrants: 0,
+  groupGrants: 0,
+  proposals: 0,
+  orphanProjectIds: [],
+};
+
+function response(body: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+function textContent(node: unknown): string {
+  if (typeof node === "string" || typeof node === "number") return String(node);
+  if (Array.isArray(node)) return node.map(textContent).join("");
+  if (node && typeof node === "object" && "children" in node) {
+    return textContent((node as { children: unknown }).children);
+  }
+  return "";
+}
+
+function repairButton(renderer: ReactTestRenderer) {
+  const button = renderer.root.findAllByType("button").find((candidate) =>
+    textContent(candidate.children).includes("Repair stale permissions"),
+  );
+  expect(button).toBeDefined();
+  return button!;
+}
+
+async function settle(): Promise<void> {
+  for (let index = 0; index < 6; index += 1) await Promise.resolve();
+}
+
+beforeEach(() => {
+  observed.confirm.mockReset();
+  observed.confirm.mockResolvedValue(false);
+  observed.announcements.length = 0;
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: () => null,
+      setItem: () => undefined,
+    },
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    },
+    setTimeout,
+    clearTimeout,
+    dispatchEvent: () => true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+test("stale-permission repair requires confirmation, mutates once, then refreshes its rendered integrity state", async () => {
+  const originalFetch = globalThis.fetch;
+  let grantsReads = 0;
+  const repairs: RequestInit[] = [];
+  let resolveRepair: (value: Response) => void;
+  const repairResponse = new Promise<Response>((resolve) => {
+    resolveRepair = resolve;
+  });
+  globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    if (url !== "/api/project-grants") throw new Error(`Unexpected request: ${url}`);
+    if (init?.method === "POST") {
+      repairs.push(init);
+      return await repairResponse;
+    }
+    grantsReads += 1;
+    return response({
+      grants: [],
+      accessGroups: [],
+      supremeFamiliarId: null,
+      integrity: grantsReads === 1 ? staleIntegrity : repairedIntegrity,
+    });
+  }) as typeof fetch;
+
+  let renderer: ReactTestRenderer | null = null;
+  try {
+    await act(async () => {
+      renderer = create(
+        <ProjectsView
+          familiars={[{ id: "wren", display_name: "Wren", role: "researcher" }]}
+          onSessionsDeleted={() => undefined}
+        />,
+      );
+      await settle();
+    });
+
+    await act(async () => {
+      repairButton(renderer!).props.onClick();
+      await settle();
+    });
+    expect(observed.confirm).toHaveBeenCalledTimes(1);
+    expect(repairs).toEqual([]);
+    expect(grantsReads).toBe(1);
+
+    observed.confirm.mockResolvedValueOnce(true);
+    await act(async () => {
+      repairButton(renderer!).props.onClick();
+      await settle();
+    });
+
+    expect(repairs).toHaveLength(1);
+    expect(repairs[0]?.body).toBe(JSON.stringify({ repairOrphans: true }));
+    const pendingButton = renderer!.root.findAllByType("button").find((candidate) =>
+      textContent(candidate.children).includes("Repairing…"),
+    );
+    expect(pendingButton?.props.disabled).toBe(true);
+
+    await act(async () => {
+      resolveRepair!(response({ ok: true }));
+      await settle();
+    });
+
+    expect(grantsReads).toBe(2);
+    expect(observed.announcements).toContain("Stale project permissions repaired.");
+    expect(
+      renderer!.root.findAllByType("button").some((candidate) =>
+        textContent(candidate.children).includes("Repair stale permissions"),
+      ),
+    ).toBe(false);
+  } finally {
+    await act(async () => {
+      renderer?.unmount();
+    });
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -154,7 +154,7 @@ test("secondary controls stay quiet until hover or keyboard focus", () => {
   assert.match(css, /\.projects-access-setall \{[^}]*opacity: 0/, "Set-all rests invisible");
   assert.match(css, /\.projects-access-section-head:hover \.projects-access-setall,\r?\n\.projects-access-section-head:focus-within \.projects-access-setall \{[^}]*opacity: 1/, "hover or focus reveals Set-all");
   assert.match(view, /className=\{`projects-access-setall-btn is-\$\{target\} focus-ring`\}/, "revealed Set-all buttons carry the level and the focus ring");
-  assert.match(css, /\.projects-access-disclose,\n\.projects-access-gear \{[^}]*opacity: 0/, "the card gear and disclosure rest invisible");
+  assert.match(css, /\.projects-access-disclose,\r?\n\.projects-access-gear \{[^}]*opacity: 0/, "the card gear and disclosure rest invisible");
   assert.match(css, /\.projects-access-card:focus-within \.projects-access-gear,/, "card hover or focus reveals them");
   assert.match(css, /\.projects-access-disclose\[aria-expanded="true"\] \{[^}]*opacity: 1/, "an open disclosure stays visible after the pointer leaves");
   const hoverNoneBlocks = css.match(/@media \(hover: none\)/g) ?? [];

--- a/src/components/projects-view.test.ts
+++ b/src/components/projects-view.test.ts
@@ -64,6 +64,17 @@ test("rows cycle a direct grant against /api/project-grants", () => {
   assert.match(view, /keeps \$\{accessStateMeta\(row\.state\)\.label\} via/, "group-held access explains itself instead of firing a no-op revoke");
 });
 
+test("stale project permissions are visible and repaired only after an explicit human confirmation", () => {
+  assert.match(view, /integrity:\s*\{/, "grant snapshots carry the server's read-only integrity report");
+  assert.match(view, /orphanPermissionRecords/, "the surface derives a visible stale-record count");
+  assert.match(view, /Repair stale project permissions\?/, "repair is explicitly confirmation-gated");
+  assert.match(view, /This only revokes stale access; it never grants access\./, "the destructive scope is truthful");
+  assert.match(view, /body: JSON\.stringify\(\{ repairOrphans: true \}\)/, "the explicit repair endpoint is used");
+  assert.match(view, /Repair stale permissions/, "the actionable remediation is visible in the project-access surface");
+  assert.match(view, /await loadGrants\(\)/, "repair rechecks the authoritative grant snapshot");
+  assert.match(view, /Stale project permissions repaired\./, "repair completion is announced to assistive technology");
+});
+
 test("the supreme familiar renders locked at Full", () => {
   assert.match(view, /isSupreme\(familiar\.id, grantsData\?\.supremeFamiliarId \?\? null\)/, "supreme comes from the console API");
   assert.match(view, /state: "write", direct: "write", groupNames: \[\] \}/, "supreme rows pin to Full");
@@ -141,7 +152,7 @@ test("a card renames in place", () => {
 
 test("secondary controls stay quiet until hover or keyboard focus", () => {
   assert.match(css, /\.projects-access-setall \{[^}]*opacity: 0/, "Set-all rests invisible");
-  assert.match(css, /\.projects-access-section-head:hover \.projects-access-setall,\n\.projects-access-section-head:focus-within \.projects-access-setall \{[^}]*opacity: 1/, "hover or focus reveals Set-all");
+  assert.match(css, /\.projects-access-section-head:hover \.projects-access-setall,\r?\n\.projects-access-section-head:focus-within \.projects-access-setall \{[^}]*opacity: 1/, "hover or focus reveals Set-all");
   assert.match(view, /className=\{`projects-access-setall-btn is-\$\{target\} focus-ring`\}/, "revealed Set-all buttons carry the level and the focus ring");
   assert.match(css, /\.projects-access-disclose,\n\.projects-access-gear \{[^}]*opacity: 0/, "the card gear and disclosure rest invisible");
   assert.match(css, /\.projects-access-card:focus-within \.projects-access-gear,/, "card hover or focus reveals them");

--- a/src/components/projects-view.tsx
+++ b/src/components/projects-view.tsx
@@ -70,6 +70,12 @@ type GrantsSnapshot = {
   grants: ConsoleGrant[];
   groups: ConsoleAccessGroup[];
   supremeFamiliarId: string | null;
+  integrity: {
+    directGrants: number;
+    groupGrants: number;
+    proposals: number;
+    orphanProjectIds: string[];
+  };
 };
 
 type RowModel = {
@@ -122,6 +128,7 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
   const [grantsLoading, setGrantsLoading] = useState(true);
   const [grantsError, setGrantsError] = useState<string | null>(null);
   const [mutateError, setMutateError] = useState<string | null>(null);
+  const [repairingOrphans, setRepairingOrphans] = useState(false);
 
   const loadGrants = useCallback(async () => {
     try {
@@ -132,6 +139,20 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
         groups: Array.isArray(data?.accessGroups) ? (data.accessGroups as ConsoleAccessGroup[]) : [],
         supremeFamiliarId:
           typeof data?.supremeFamiliarId === "string" ? data.supremeFamiliarId : null,
+        integrity: {
+          directGrants: Number.isSafeInteger(data?.integrity?.directGrants)
+            ? Math.max(0, data.integrity.directGrants)
+            : 0,
+          groupGrants: Number.isSafeInteger(data?.integrity?.groupGrants)
+            ? Math.max(0, data.integrity.groupGrants)
+            : 0,
+          proposals: Number.isSafeInteger(data?.integrity?.proposals)
+            ? Math.max(0, data.integrity.proposals)
+            : 0,
+          orphanProjectIds: Array.isArray(data?.integrity?.orphanProjectIds)
+            ? data.integrity.orphanProjectIds.filter((id: unknown): id is string => typeof id === "string")
+            : [],
+        },
       });
       setGrantsError(null);
     } catch {
@@ -160,6 +181,36 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
     [familiars, pickedFamiliarId],
   );
   const supreme = familiar ? isSupreme(familiar.id, grantsData?.supremeFamiliarId ?? null) : false;
+  const orphanPermissionRecords = grantsData
+    ? grantsData.integrity.directGrants + grantsData.integrity.groupGrants + grantsData.integrity.proposals
+    : 0;
+
+  const repairOrphanPermissions = useCallback(async () => {
+    if (repairingOrphans || orphanPermissionRecords === 0) return;
+    const ok = await confirm({
+      title: "Repair stale project permissions?",
+      body: `Removes ${orphanPermissionRecords} permission record${orphanPermissionRecords === 1 ? "" : "s"} for project folders no longer registered in Cave. This only revokes stale access; it never grants access.`,
+      confirmLabel: "Repair permissions",
+      danger: true,
+    });
+    if (!ok) return;
+    setRepairingOrphans(true);
+    setMutateError(null);
+    try {
+      const response = await fetch("/api/project-grants", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repairOrphans: true }),
+      });
+      if (!response.ok) throw new Error("repair failed");
+      await loadGrants();
+      announce("Stale project permissions repaired.");
+    } catch {
+      setMutateError("Couldn’t repair stale project permissions. Nothing was granted; try again.");
+    } finally {
+      setRepairingOrphans(false);
+    }
+  }, [announce, confirm, loadGrants, orphanPermissionRecords, repairingOrphans]);
 
   // ── New project ────────────────────────────────────────────────────────
   // The shared add flow (native folder dialog on desktop, in-app browser on
@@ -1093,6 +1144,21 @@ export function ProjectsView({ familiars = [], activeFamiliarId = null }: Projec
           <p className="projects-access-error" role="alert">
             {mutateError}
           </p>
+        ) : null}
+        {orphanPermissionRecords > 0 ? (
+          <div className="projects-access-error" role="alert">
+            <p>
+              {orphanPermissionRecords} stale permission record{orphanPermissionRecords === 1 ? "" : "s"} refer to {grantsData?.integrity.orphanProjectIds.length === 1 ? "a project folder" : "project folders"} no longer registered in Cave. Repair removes only those stale records; it never grants access.
+            </p>
+            <Button
+              variant="secondary"
+              size="xs"
+              onClick={() => void repairOrphanPermissions()}
+              disabled={repairingOrphans}
+            >
+              {repairingOrphans ? "Repairing…" : "Repair stale permissions"}
+            </Button>
+          </div>
         ) : null}
         {addFlow.addError ? (
           <p className="projects-access-error" role="alert">

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -22,7 +22,7 @@ import {
   classifyAboutDaemonStatus,
   type AboutDaemonState,
 } from "@/lib/about-status";
-import { APP_VERSION } from "@/lib/app-version";
+import { APP_BUILD_IDENTITY, APP_BUILD_REVISION, APP_VERSION } from "@/lib/app-version";
 import { copyText } from "@/lib/clipboard";
 import { exactSemver } from "@/lib/exact-semver";
 import { Icon, type IconName } from "@/lib/icon";
@@ -288,6 +288,8 @@ export function AboutSection() {
         application: {
           name: "CovenCave",
           version: APP_VERSION,
+          revision: APP_BUILD_REVISION,
+          identity: APP_BUILD_IDENTITY,
           builtWith: STACK,
         },
         daemon: safeDaemonDiagnostics(daemonState),
@@ -432,6 +434,10 @@ export function AboutSection() {
               <span className="settings-about-row__label">App version</span>
               <code className="settings-about-row__code">v{APP_VERSION}</code>
             </div>
+            <div className="settings-about-row">
+              <span className="settings-about-row__label">Build revision</span>
+              <code className="settings-about-row__code">{APP_BUILD_REVISION}</code>
+            </div>
             <UpdateSettingsRow
               actionRef={updateActionRef}
               onCheckAvailabilityChange={setUpdateCheckAvailable}
@@ -456,7 +462,7 @@ export function AboutSection() {
               >
                 <strong>Build sigil</strong>
                 <span>
-                  CovenCave v{APP_VERSION} · {STACK.join(" + ")}
+                  CovenCave {APP_BUILD_IDENTITY} · {STACK.join(" + ")}
                 </span>
               </div>
             ) : null}

--- a/src/components/settings-appearance.test.ts
+++ b/src/components/settings-appearance.test.ts
@@ -149,7 +149,7 @@ assert.match(
 
 assert.match(
   about,
-  /import \{ APP_VERSION \} from "@\/lib\/app-version"/,
+  /import\s*\{[\s\S]*?\bAPP_VERSION\b[\s\S]*?\}\s*from "@\/lib\/app-version"/,
   "About settings must import the shared app version source",
 );
 

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -67,12 +67,13 @@ assert.match(src, /resolveDownloadUrl\(combined\.status\)/, "fallback download U
 // Both surfaces are exported and resolve native-first.
 assert.match(src, /export function UpdateBannerTrigger/, "exports the banner trigger");
 assert.match(src, /export function DaemonReleaseAlignmentTrigger/, "reconciles the daemon after the new Cave version starts");
-assert.match(src, /updateDaemonForCaveUpdate\(APP_VERSION/, "startup reconciliation targets the running Cave version");
+assert.match(src, /updateCovenCli\(\)/, "startup reconciliation checks the independently versioned CLI");
+assert.doesNotMatch(src, /APP_VERSION/, "the running Cave version is never treated as a CLI version requirement");
 assert.match(src, /process\.env\.NODE_ENV !== "production"/, "development launches never mutate the global CLI");
-assert.match(src, /const start = \(confirmInstall = false\)/, "startup reconciliation never silently confirms a global install");
-assert.match(src, /result === "confirmation-required"/, "startup reconciliation offers confirmation instead of reporting a failed install");
-assert.match(src, /start\(true\)/, "the daemon update CTA records the user's install confirmation");
-assert.match(src, /\.then\(\(result\) => \{[\s\S]*dismissBanner\(DAEMON_ALIGNMENT_BANNER_ID\)/, "a successful retry clears the failure banner even when the CLI is already current");
+assert.match(src, /const start = \(\) =>/, "startup reconciliation never silently confirms a global install");
+assert.match(src, /updateCovenCli\(\)\.then\(\(\) =>/, "startup reconciliation is a quiet status check only");
+assert.doesNotMatch(src, /Update Coven CLI/, "ordinary CLI update actions stay out of the chat header");
+assert.match(src, /updateCovenCli\(\)\.then\(\(\) => \{[\s\S]*dismissBanner\(DAEMON_ALIGNMENT_BANNER_ID\)/, "the quiet startup check clears any stale CLI banner");
 assert.match(
   layoutSrc,
   /<ShellBannersProvider>[\s\S]{0,100}<DaemonReleaseAlignmentTrigger \/>/,

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -33,8 +33,7 @@ import {
   adoptNativeUpdateResult,
   nativeUpdateCoordinator,
 } from "@/lib/native-update-coordinator";
-import { updateDaemonForCaveUpdate } from "@/lib/app-update-daemon";
-import { APP_VERSION } from "@/lib/app-version";
+import { updateCovenCli } from "@/lib/app-update-daemon";
 
 const BANNER_ID = "update-available";
 const DAEMON_ALIGNMENT_BANNER_ID = "daemon-release-alignment";
@@ -106,10 +105,10 @@ async function installPreparedUpdate(update: NativeUpdateHandle): Promise<void> 
 }
 
 /**
- * The updater that installs a release belongs to the previous Cave version.
- * Reconcile once after the new shell starts so the first release containing
- * this behavior also aligns the separately installed Coven CLI. The CLI owns
- * the daemon lifecycle; it is not itself the daemon process.
+ * On desktop startup, inspect the separately installed Coven CLI. Cave, the
+ * CLI, and its daemon are independently versioned, so an unavailable
+ * background availability check remains silent and no Cave version is used as
+ * a CLI requirement. A global install is always user-confirmed.
  */
 export function DaemonReleaseAlignmentTrigger() {
   const isDesktop = useIsTauriDesktop();
@@ -121,55 +120,21 @@ export function DaemonReleaseAlignmentTrigger() {
     let active = true;
     let running = false;
 
-    const start = (confirmInstall = false) => {
+    const start = () => {
       if (!active || running) return;
       attempted.current = true;
       running = true;
-      void updateDaemonForCaveUpdate(APP_VERSION, {
-        confirmInstall,
-        onUpdateStart: () => {
-          if (active) {
-            pushBanner({
-              id: DAEMON_ALIGNMENT_BANNER_ID,
-              severity: "info",
-              title: `Updating Coven CLI for Cave v${APP_VERSION}…`,
-            });
-          }
-        },
-      }).then((result) => {
+      void updateCovenCli().then(() => {
         running = false;
         if (!active) return;
-        if (result === "confirmation-required") {
-          pushBanner({
-            id: DAEMON_ALIGNMENT_BANNER_ID,
-            severity: "info",
-            title: `Coven CLI v${APP_VERSION} is ready to install`,
-            cta: {
-              label: "Update Coven CLI",
-              onClick: () => {
-                attempted.current = false;
-                start(true);
-              },
-            },
-          });
-        } else {
-          dismissBanner(DAEMON_ALIGNMENT_BANNER_ID);
-        }
-      }).catch((error) => {
+        // Ordinary CLI availability and update actions live in Settings →
+        // About. Keep chat headers focused on chat; only that surface has the
+        // detailed version, verification, and installer state needed to act.
+        dismissBanner(DAEMON_ALIGNMENT_BANNER_ID);
+      }).catch(() => {
         running = false;
         if (!active) return;
-        pushBanner({
-          id: DAEMON_ALIGNMENT_BANNER_ID,
-          severity: "warning",
-          title: `Coven CLI update failed (${errorMessage(error, "update failed")})`,
-          cta: {
-            label: "Retry CLI update",
-            onClick: () => {
-              attempted.current = false;
-              start(true);
-            },
-          },
-        });
+        dismissBanner(DAEMON_ALIGNMENT_BANNER_ID);
       });
     };
 

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -112,7 +112,7 @@ async function installPreparedUpdate(update: NativeUpdateHandle): Promise<void> 
  */
 export function DaemonReleaseAlignmentTrigger() {
   const isDesktop = useIsTauriDesktop();
-  const { pushBanner, dismissBanner } = useShellBanners();
+  const { dismissBanner } = useShellBanners();
   const attempted = useRef(false);
 
   useEffect(() => {
@@ -142,7 +142,7 @@ export function DaemonReleaseAlignmentTrigger() {
     return () => {
       active = false;
     };
-  }, [dismissBanner, isDesktop, pushBanner]);
+  }, [dismissBanner, isDesktop]);
 
   return null;
 }

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -108,7 +108,8 @@ async function installPreparedUpdate(update: NativeUpdateHandle): Promise<void> 
 /**
  * The updater that installs a release belongs to the previous Cave version.
  * Reconcile once after the new shell starts so the first release containing
- * this behavior also aligns the separately installed CLI/daemon.
+ * this behavior also aligns the separately installed Coven CLI. The CLI owns
+ * the daemon lifecycle; it is not itself the daemon process.
  */
 export function DaemonReleaseAlignmentTrigger() {
   const isDesktop = useIsTauriDesktop();
@@ -131,7 +132,7 @@ export function DaemonReleaseAlignmentTrigger() {
             pushBanner({
               id: DAEMON_ALIGNMENT_BANNER_ID,
               severity: "info",
-              title: `Updating Coven daemon to match Cave v${APP_VERSION}…`,
+              title: `Updating Coven CLI for Cave v${APP_VERSION}…`,
             });
           }
         },
@@ -142,9 +143,9 @@ export function DaemonReleaseAlignmentTrigger() {
           pushBanner({
             id: DAEMON_ALIGNMENT_BANNER_ID,
             severity: "info",
-            title: `Coven daemon v${APP_VERSION} is ready to install`,
+            title: `Coven CLI v${APP_VERSION} is ready to install`,
             cta: {
-              label: "Update Coven daemon",
+              label: "Update Coven CLI",
               onClick: () => {
                 attempted.current = false;
                 start(true);
@@ -160,9 +161,9 @@ export function DaemonReleaseAlignmentTrigger() {
         pushBanner({
           id: DAEMON_ALIGNMENT_BANNER_ID,
           severity: "warning",
-          title: `Coven daemon update failed (${errorMessage(error, "update failed")})`,
+          title: `Coven CLI update failed (${errorMessage(error, "update failed")})`,
           cta: {
-            label: "Retry daemon update",
+            label: "Retry CLI update",
             onClick: () => {
               attempted.current = false;
               start(true);
@@ -401,7 +402,7 @@ export function UpdateBannerTrigger() {
                         pushBanner({
                           id: BANNER_ID,
                           severity: "info",
-                          title: `Updating Coven daemon and installing Cave v${r.version}…`,
+                          title: `Installing CovenCave v${r.version}…`,
                         });
                         void installPreparedUpdate(r.update).catch(async (error) => {
                           await nativeUpdateCoordinator.finishAction(owner);

--- a/src/components/workspace-canonical-memory-navigation.test.ts
+++ b/src/components/workspace-canonical-memory-navigation.test.ts
@@ -15,7 +15,7 @@ assert.match(
 );
 
 const intentBranch = workspace.match(
-  /if \(intent\.kind === "open-coven-memory"\) \{([\s\S]*?)\n\s*\}\n\s*if \(intent\.kind === "open-memory-file"\)/,
+  /if \(intent\.kind === "open-coven-memory"\) \{([\s\S]*?)\r?\n\s*\}\r?\n\s*if \(intent\.kind === "open-memory-file"\)/,
 );
 assert.ok(intentBranch, "Workspace handles canonical navigation separately from files");
 assert.match(

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -310,6 +310,17 @@ export function Workspace() {
     reload: reloadProjects,
     createProjectOrThrow,
   } = useProjects();
+  // The global registry answers "does a project exist?"; chat readiness is
+  // stricter and must be evaluated for the familiar that will run the turn.
+  // Keep the two reads separate so an inaccessible project never suppresses
+  // the recovery gate for this familiar.
+  const projectGateCandidateFamiliarId = activeId ?? visibleFamiliars[0]?.id ?? null;
+  const {
+    projects: accessibleGateProjects,
+    loading: accessibleGateProjectsLoading,
+    error: accessibleGateProjectsError,
+    loadedSuccessfully: accessibleGateProjectsLoadedSuccessfully,
+  } = useProjects({ familiarId: projectGateCandidateFamiliarId });
   const [familiarsError, setFamiliarsError] = useState<string | null>(null);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
   // false until the first /api/sessions/list fetch settles — lets the chat
@@ -2641,6 +2652,7 @@ export function Workspace() {
     activeFamiliarId: activeId,
     visibleFamiliars,
     registeredProjects,
+    accessibleProjects: accessibleGateProjects,
     pendingGrant: reconciledPendingFirstProjectGrant,
     onboardingResolved,
     onboardingOpen,
@@ -2648,6 +2660,8 @@ export function Workspace() {
     familiarsLoaded,
     familiarRosterLoadedSuccessfully,
     projectsInitiallyResolved,
+    accessibleProjectsInitiallyResolved:
+      !accessibleGateProjectsLoading && !accessibleGateProjectsError && accessibleGateProjectsLoadedSuccessfully,
   });
   const chatProjectBlockedRef = useRef(chatProjectBlocked);
   chatProjectBlockedRef.current = chatProjectBlocked;
@@ -3179,6 +3193,7 @@ export function Workspace() {
           onPendingGrantChange={setPendingFirstProjectGrant}
           loadingProjects={projectsLoading}
           projectsError={projectsError}
+          registeredProjects={registeredProjects}
           createProjectOrThrow={createProjectOrThrow}
           reloadProjects={reloadProjects}
         />

--- a/src/lib/app-update-daemon.test.ts
+++ b/src/lib/app-update-daemon.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import {
   compareCaveDaemonVersions,
-  updateDaemonForCaveUpdate,
+  updateCovenCli,
   waitForDaemonUpdateIdle,
 } from "./app-update-daemon.ts";
 
@@ -18,7 +18,7 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 
 {
   let releaseCheck: ((response: Response) => void) | undefined;
-  const operation = updateDaemonForCaveUpdate("0.1.3", {
+  const operation = updateCovenCli({
     fetch: () => new Promise<Response>((resolve) => { releaseCheck = resolve; }),
   });
   let idle = false;
@@ -28,7 +28,7 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
   releaseCheck!(json({
     ok: true,
     freshness: "fresh",
-    tools: [{ id: "coven-cli", installed: true, current: "0.1.3", compatible: true }],
+    tools: [{ id: "coven-cli", installed: true, current: "0.1.3", latest: "0.1.3", compatible: true }],
   }));
   await operation;
   await waiting;
@@ -37,13 +37,13 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 
 {
   const calls: string[] = [];
-  const result = await updateDaemonForCaveUpdate("0.1.3", {
+  const result = await updateCovenCli({
     fetch: async (input) => {
       calls.push(String(input));
       return json({
         ok: true,
         freshness: "fresh",
-        tools: [{ id: "coven-cli", installed: true, current: "0.1.3", outdated: false, compatible: true }],
+        tools: [{ id: "coven-cli", installed: true, current: "0.1.3", latest: "0.1.3", outdated: false, compatible: true }],
       });
     },
   });
@@ -56,7 +56,7 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
   let installBody: string | undefined;
   let polls = 0;
   let updateStarts = 0;
-  const result = await updateDaemonForCaveUpdate("0.1.3", {
+  const result = await updateCovenCli({
     fetch: async (input, init) => {
       const url = String(input);
       calls.push(url);
@@ -64,7 +64,7 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
         return json({
           ok: true,
           freshness: "fresh",
-          tools: [{ id: "coven-cli", installed: true, current: "0.1.2", outdated: true, compatible: true }],
+          tools: [{ id: "coven-cli", installed: true, current: "0.1.2", latest: "0.1.3", outdated: true, compatible: true }],
         });
       }
       if (url === "/api/onboarding/install") {
@@ -95,25 +95,25 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 
 {
   await assert.rejects(
-    updateDaemonForCaveUpdate("0.1.3", {
+    updateCovenCli({
       fetch: async (input) =>
         String(input) === "/api/onboarding/update"
-          ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: true, current: "0.1.2", compatible: true }] })
+          ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: true, current: "0.1.2", latest: "0.1.3", compatible: true }] })
           : String(input) === "/api/onboarding/install"
             ? json({ status: "running" })
             : json({ status: "done", ok: true, verification: { current: "0.1.2" } }),
       confirmInstall: true,
     }),
-    /could not verify version 0\.1\.3 or newer/,
-    "a successful npm job cannot install Cave while the resolved daemon remains older",
+    /could not verify version 0\.1\.3 or newer on PATH/,
+    "a successful npm job still requires a verified CLI version on PATH",
   );
 }
 
 {
-  const result = await updateDaemonForCaveUpdate("0.1.3", {
+  const result = await updateCovenCli({
     fetch: async (input) =>
       String(input) === "/api/onboarding/update"
-        ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: false, current: null }] })
+        ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: false, current: null, latest: "0.1.3" }] })
         : String(input) === "/api/onboarding/install"
           ? json({ status: "running" })
           : json({ status: "done", ok: true, verification: { current: "0.1.3" } }),
@@ -124,10 +124,10 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 
 {
   await assert.rejects(
-    updateDaemonForCaveUpdate("0.1.3", {
+    updateCovenCli({
       fetch: async (input) =>
         String(input) === "/api/onboarding/update"
-          ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: false, outdated: false }] })
+          ? json({ ok: true, freshness: "fresh", tools: [{ id: "coven-cli", installed: false, latest: "0.1.3", outdated: false }] })
           : String(input) === "/api/onboarding/install"
             ? json({ status: "running" })
             : json({ status: "done", ok: false, error: "daemon restart verification failed" }),
@@ -140,13 +140,13 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 
 {
   let installStarted = false;
-  const result = await updateDaemonForCaveUpdate("0.1.3", {
+  const result = await updateCovenCli({
     fetch: async (input) => {
       if (String(input) === "/api/onboarding/update") {
         return json({
           ok: true,
           freshness: "fresh",
-          tools: [{ id: "coven-cli", installed: true, current: "0.1.2", compatible: true }],
+          tools: [{ id: "coven-cli", installed: true, current: "0.1.2", latest: "0.1.3", compatible: true }],
         });
       }
       installStarted = true;
@@ -158,17 +158,36 @@ assert.equal(compareCaveDaemonVersions("invalid", "0.1.4"), null);
 }
 
 {
-  await assert.rejects(
-    updateDaemonForCaveUpdate("0.1.3", {
-      fetch: async () => json({
-        ok: true,
-        freshness: "stale",
-        tools: [{ id: "coven-cli", installed: true, current: "0.1.3", compatible: true }],
-      }),
+  const result = await updateCovenCli({
+    fetch: async () => json({
+      ok: true,
+      freshness: "stale",
+      tools: [{ id: "coven-cli", installed: true, current: "0.1.3", latest: "0.1.3", compatible: true }],
     }),
-    /fresh Coven CLI version/,
-    "a stale cached status cannot approve the Cave install",
-  );
+  });
+  assert.equal(result, "status-unavailable", "a stale cached status neither approves nor fails a background CLI check");
+}
+
+{
+  const result = await updateCovenCli({
+    fetch: async () => json({
+      ok: true,
+      freshness: "stale",
+      tools: [{ id: "coven-cli", installed: true, current: "0.1.6", compatible: true }],
+    }),
+  });
+  assert.equal(result, "status-unavailable");
+}
+
+{
+  const result = await updateCovenCli({
+    fetch: async () => json({
+      ok: true,
+      freshness: "fresh",
+      tools: [{ id: "coven-cli", installed: true, current: "0.1.6", latest: "0.1.6", outdated: false, compatible: true }],
+    }),
+  });
+  assert.equal(result, "current", "a fresh independently versioned CLI is current without matching Cave's version");
 }
 
 console.log("app-update-daemon.test.ts: ok");

--- a/src/lib/app-update-daemon.ts
+++ b/src/lib/app-update-daemon.ts
@@ -4,6 +4,7 @@ type ToolStatus = {
   outdated?: boolean;
   compatible?: boolean;
   current?: string | null;
+  latest?: string | null;
 };
 
 type InstallJob = {
@@ -89,48 +90,47 @@ export function compareCaveDaemonVersions(left: string, right: string): number |
   return 0;
 }
 
+export type CovenCliUpdateResult =
+  | "current"
+  | "updated"
+  | "confirmation-required"
+  | "status-unavailable";
+
 /**
- * Before Cave replaces and relaunches itself, bring the separately installed
- * Coven CLI up to date. The existing install route owns the safety-sensitive
- * daemon lifecycle: graceful stop, npm update, executable verification, and
- * restart only when the daemon was running before the update.
+ * Reconcile the separately installed Coven CLI on its own release channel.
+ * Cave, the CLI, and the daemon have independent version lifecycles: an app
+ * version must never be used as a required CLI version. The install route owns
+ * the safety-sensitive daemon lifecycle (graceful stop, npm update, verified
+ * executable, and conditional restart).
  */
-async function runDaemonUpdateForCaveUpdate(
-  caveVersion: string,
+async function runCovenCliUpdate(
   dependencies: Dependencies = {},
-): Promise<"current" | "updated" | "confirmation-required"> {
+): Promise<CovenCliUpdateResult> {
   const request = dependencies.fetch ?? fetch;
   const wait = dependencies.wait ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
   const pollIntervalMs = dependencies.pollIntervalMs ?? 1_000;
   const maxPollAttempts = dependencies.maxPollAttempts ?? 300;
-  if (!releaseSemver(caveVersion)) {
-    throw new Error("Cave could not verify the release version before updating the daemon.");
-  }
-
   const checkResponse = await request(UPDATE_ROUTE, {
     method: "POST",
     cache: "no-store",
   });
   const checkBody = await responseBody(checkResponse);
-  if (!checkResponse.ok || checkBody.ok === false) {
-    throw new Error(safeFailure(checkBody, "Cave could not check the Coven daemon version."));
-  }
+  if (!checkResponse.ok || checkBody.ok === false) return "status-unavailable";
   if (checkBody.freshness !== "fresh") {
-    throw new Error("Cave could not verify a fresh Coven CLI version before continuing.");
+    return "status-unavailable";
   }
 
   const tools = Array.isArray(checkBody.tools) ? (checkBody.tools as ToolStatus[]) : [];
   const cli = tools.find((tool) => tool.id === "coven-cli");
-  if (!cli) throw new Error("Cave could not find the Coven CLI update status.");
-  const currentComparison =
-    typeof cli.current === "string"
-      ? compareCaveDaemonVersions(cli.current, caveVersion)
-      : null;
+  if (!cli || typeof cli.latest !== "string" || !releaseSemver(cli.latest)) {
+    return "status-unavailable";
+  }
   if (
     cli.installed &&
     cli.compatible !== false &&
-    currentComparison !== null &&
-    currentComparison >= 0
+    cli.outdated === false &&
+    typeof cli.current === "string" &&
+    releaseSemver(cli.current)
   ) {
     return "current";
   }
@@ -161,11 +161,11 @@ async function runDaemonUpdateForCaveUpdate(
       if (job.ok) {
         const installedVersion = job.verification?.current;
         const comparison = typeof installedVersion === "string"
-          ? compareCaveDaemonVersions(installedVersion, caveVersion)
+          ? compareCaveDaemonVersions(installedVersion, cli.latest)
           : null;
         if (comparison !== null && comparison >= 0) return "updated";
         throw new Error(
-          `Cave updated the Coven CLI, but could not verify version ${caveVersion} or newer on PATH.`,
+          `Cave updated the Coven CLI, but could not verify version ${cli.latest} or newer on PATH.`,
         );
       }
       throw new Error(safeFailure(job as Record<string, unknown>, "The Coven daemon update failed."));
@@ -176,11 +176,10 @@ async function runDaemonUpdateForCaveUpdate(
   throw new Error("The Coven daemon update did not finish before the Cave update timed out.");
 }
 
-export function updateDaemonForCaveUpdate(
-  caveVersion: string,
+export function updateCovenCli(
   dependencies: Dependencies = {},
-): Promise<"current" | "updated" | "confirmation-required"> {
-  const operation = runDaemonUpdateForCaveUpdate(caveVersion, dependencies);
+): Promise<CovenCliUpdateResult> {
+  const operation = runCovenCliUpdate(dependencies);
   activeDaemonUpdates.add(operation);
   void operation.finally(() => activeDaemonUpdates.delete(operation)).catch(() => {});
   return operation;

--- a/src/lib/app-version.test.ts
+++ b/src/lib/app-version.test.ts
@@ -6,6 +6,8 @@ const packageJson = JSON.parse(await readFile(new URL("../../package.json", impo
 const tauriConfig = JSON.parse(await readFile(new URL("../../src-tauri/tauri.conf.json", import.meta.url), "utf8"));
 const cargoToml = await readFile(new URL("../../src-tauri/Cargo.toml", import.meta.url), "utf8");
 const appVersionSource = await readFile(new URL("./app-version.ts", import.meta.url), "utf8");
+const releaseWorkflow = await readFile(new URL("../../.github/workflows/release.yml", import.meta.url), "utf8");
+const buildInfoRoute = await readFile(new URL("../app/api/app/build-info/route.ts", import.meta.url), "utf8");
 
 const cargoVersion = cargoToml.match(/^version\s*=\s*"([^"]+)"/m)?.[1];
 const cargoDescription = cargoToml.match(/^description\s*=\s*"([^"]+)"/m)?.[1];
@@ -44,5 +46,19 @@ assert.match(
   /export const APP_VERSION/,
   "App version module must export APP_VERSION for UI reporting",
 );
+assert.match(
+  appVersionSource,
+  /NEXT_PUBLIC_COVEN_CAVE_BUILD_REVISION/,
+  "App build identity must be supplied from an explicit public release revision",
+);
+assert.match(appVersionSource, /export const APP_BUILD_REVISION/, "App build revision must be available to diagnostics");
+assert.match(appVersionSource, /export const APP_BUILD_IDENTITY/, "App build identity must combine version and revision");
+assert.match(
+  releaseWorkflow,
+  /NEXT_PUBLIC_COVEN_CAVE_BUILD_REVISION=\$\(git rev-parse --verify HEAD\)/,
+  "release builds must bake the checked-out source revision into the packaged app",
+);
+assert.match(buildInfoRoute, /APP_BUILD_IDENTITY/, "the packaged sidecar exposes a safe artifact identity endpoint");
+assert.match(buildInfoRoute, /APP_BUILD_REVISION/, "the artifact endpoint includes its revision fingerprint");
 
 console.log("app-version.test.ts: ok");

--- a/src/lib/app-version.ts
+++ b/src/lib/app-version.ts
@@ -1,3 +1,14 @@
 import packageJson from "../../package.json";
 
 export const APP_VERSION = packageJson.version;
+
+/**
+ * A release build bakes the exact source revision into both the web shell and
+ * its packaged sidecar. It is deliberately public: it identifies an artifact,
+ * not a person, path, token, or runtime configuration value.
+ */
+const requestedRevision = process.env.NEXT_PUBLIC_COVEN_CAVE_BUILD_REVISION?.trim() ?? "";
+export const APP_BUILD_REVISION = /^[0-9a-f]{7,64}$/i.test(requestedRevision)
+  ? requestedRevision.toLowerCase()
+  : "development";
+export const APP_BUILD_IDENTITY = `v${APP_VERSION}+${APP_BUILD_REVISION}`;

--- a/src/lib/chat-response-metadata.ts
+++ b/src/lib/chat-response-metadata.ts
@@ -13,7 +13,7 @@ export type ChatResponseMetadata = {
   modelApplicationState?: ModelApplicationState;
   modelApplicationReason?: string;
   openclawAgentId?: string;
-  openclawAgentSource?: "explicit" | "id-match" | "name-match" | "fallback";
+  openclawAgentSource?: "explicit" | "id-match" | "name-match" | "default" | "fallback";
   caveSessionId?: string;
   gatewaySessionId?: string;
   sessionKey?: string;

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -190,7 +190,11 @@ const {
     multiHost: { mode: "local", hubUrl: "", executorUrls: [] },
   });
   assert.equal(target.mode, "local");
-  assert.match(target.socketPath, /\.coven\/coven\.sock$/);
+  assert.match(
+    target.socketPath.replaceAll("\\", "/"),
+    /(?:\.coven\/coven\.sock|\/pipe\/coven-daemon-[a-f0-9]+\.sock)$/,
+    "the live local target may use the active Windows daemon pipe or the socket fallback",
+  );
   assert.equal(target.label, "Local daemon");
 }
 

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -64,13 +64,19 @@ const {
   else process.env.COVEN_SOCKET = before;
 }
 
-// socketPath() default has the expected suffix
+// The platform-neutral fallback has the expected Unix socket suffix. Do not
+// read the real host's daemon.json here: on Windows an active daemon resolves
+// to its named pipe, making a supposedly default-path assertion flaky.
 {
-  const before = process.env.COVEN_SOCKET;
-  delete process.env.COVEN_SOCKET;
-  const def = socketPath();
+  const def = resolveDaemonSocketPath({
+    platform: "linux",
+    env: {},
+    homeDir: "/home/cave-test",
+    readFileSync: () => {
+      throw new Error("no daemon status for default socket fixture");
+    },
+  });
   assert.match(def, /\.coven\/coven\.sock$/);
-  if (before !== undefined) process.env.COVEN_SOCKET = before;
 }
 
 // Windows daemon status stores the pipe name; Node HTTP needs the full pipe path

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -76,7 +76,10 @@ const {
       throw new Error("no daemon status for default socket fixture");
     },
   });
-  assert.match(def, /\.coven\/coven\.sock$/);
+  // `resolveDaemonSocketPath` deliberately uses the host's path module, so
+  // the simulated Linux policy still returns Windows separators in a Windows
+  // test process. The suffix contract itself is separator-independent.
+  assert.match(def.replaceAll("\\", "/"), /\.coven\/coven\.sock$/);
 }
 
 // Windows daemon status stores the pipe name; Node HTTP needs the full pipe path

--- a/src/lib/daemon-readiness.ts
+++ b/src/lib/daemon-readiness.ts
@@ -1,0 +1,42 @@
+export type DaemonReadinessResult = {
+  ready: boolean;
+  attempts: number;
+  elapsedMs: number;
+  runnerExited: boolean;
+};
+
+type ReadinessProbe = () => Promise<{ ok: boolean }>;
+
+/**
+ * A daemon launcher may intentionally remain foregrounded. Readiness therefore
+ * comes exclusively from the local health endpoint, not from the launcher
+ * closing. The injected seams keep foreground and timeout races testable.
+ */
+export async function waitForDaemonReadiness(input: {
+  probe: ReadinessProbe;
+  timeoutMs: number;
+  pollMs: number;
+  runnerExited: () => boolean;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}): Promise<DaemonReadinessResult> {
+  const now = input.now ?? Date.now;
+  const sleep = input.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const startedAt = now();
+  let attempts = 0;
+  while (true) {
+    attempts += 1;
+    if ((await input.probe()).ok) {
+      return { ready: true, attempts, elapsedMs: now() - startedAt, runnerExited: input.runnerExited() };
+    }
+    const elapsedMs = now() - startedAt;
+    if (input.runnerExited() || elapsedMs >= input.timeoutMs) {
+      // A final probe closes the race where a foreground runner publishes its
+      // socket just after the previous request, or exits after daemonizing.
+      attempts += 1;
+      const ready = (await input.probe()).ok;
+      return { ready, attempts, elapsedMs: now() - startedAt, runnerExited: input.runnerExited() };
+    }
+    await sleep(Math.min(input.pollMs, Math.max(1, input.timeoutMs - elapsedMs)));
+  }
+}

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -2,6 +2,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import { test } from "node:test";
+import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 
 const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
@@ -14,6 +15,17 @@ assert.match(daemonStart, /path: "\/api\/v1\/health"/);
 assert.match(daemonStart, /shell: launchMode === "shell"/);
 assert.match(readinessSource, /A final probe closes the race/);
 assert.doesNotMatch(daemonStart, /child\.kill\("SIGTERM"\)/, "a timeout must not kill an already-daemonized Windows descendant");
+assert.match(daemonStart, /sanitizeAboutDiagnosticText/, "daemon-start responses reuse the value-safe diagnostics sanitizer");
+assert.match(daemonStart, /sanitizeDaemonStartDiagnostic\(stdout\)/, "launcher stdout is redacted before it reaches a client");
+assert.match(daemonStart, /sanitizeDaemonStartDiagnostic\(stderr\)/, "launcher stderr is redacted before it reaches a client");
+
+{
+  const safe = sanitizeAboutDiagnosticText(
+    "failed at C:\\Users\\Example Person\\.npmrc token=ghp_1234567890abcdefghijklmnopqrstuv",
+  );
+  assert.doesNotMatch(safe, /Example Person|npmrc|ghp_/, "daemon start diagnostics redact local paths and credentials");
+  assert.match(safe, /\[local path omitted\]|\[redacted\]/, "redaction remains apparent to the user");
+}
 
 test("a foreground launcher is successful as soon as health becomes ready", async () => {
   let now = 0;

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -1,8 +1,14 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { readFile } from "node:fs/promises";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
 import { test } from "node:test";
+import { readFile } from "node:fs/promises";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
+import {
+  startLocalDaemon,
+  terminateDaemonLaunchTree,
+} from "./daemon-start.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 
 const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
@@ -12,12 +18,25 @@ const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url)
 assert.match(covenDaemon, /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/);
 assert.match(daemonStart, /waitForDaemonReadiness/);
 assert.match(daemonStart, /path: "\/api\/v1\/health"/);
-assert.match(daemonStart, /shell: launchMode === "shell"/);
+assert.match(daemonStart, /detached: launchMode === "direct"/, "POSIX launch owns a process group");
+assert.match(daemonStart, /taskkill/, "Windows timeout cleanup owns the shell process tree");
+assert.match(daemonStart, /const cleanup = await terminateLaunchTree\(child\)/, "timeout cleanup is executed, not merely declared");
 assert.match(readinessSource, /A final probe closes the race/);
-assert.doesNotMatch(daemonStart, /child\.kill\("SIGTERM"\)/, "a timeout must not kill an already-daemonized Windows descendant");
 assert.match(daemonStart, /sanitizeAboutDiagnosticText/, "daemon-start responses reuse the value-safe diagnostics sanitizer");
 assert.match(daemonStart, /sanitizeDaemonStartDiagnostic\(stdout\)/, "launcher stdout is redacted before it reaches a client");
 assert.match(daemonStart, /sanitizeDaemonStartDiagnostic\(stderr\)/, "launcher stderr is redacted before it reaches a client");
+
+function fakeChild(pid = 4321) {
+  const child = Object.assign(new EventEmitter(), {
+    pid,
+    exitCode: null,
+    signalCode: null,
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    kill: () => true,
+  });
+  return child;
+}
 
 {
   const safe = sanitizeAboutDiagnosticText(
@@ -66,6 +85,106 @@ test("an exited launcher reports not-ready only after its final probe", async ()
     sleep: async () => assert.fail("an exited launcher should not sleep"),
   });
   assert.deepEqual(result, { ready: true, attempts: 2, elapsedMs: 0, runnerExited: true });
+});
+
+test("a readiness timeout terminates the Windows launch tree", async () => {
+  const child = fakeChild();
+  let cleanupCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 0,
+    probe: async () => ({ ok: false }),
+    spawnImpl: () => child,
+    terminateLaunchTree: async (launched) => {
+      cleanupCalls += 1;
+      assert.equal(launched, child, "the exact spawned launcher is cleaned up");
+      return { attempted: true, completed: true, mode: "windows-tree" };
+    },
+    platform: "win32",
+  });
+  assert.equal(cleanupCalls, 1);
+  assert.deepEqual(result, {
+    ok: false,
+    code: "readiness_timeout",
+    error: "daemon readiness timed out",
+    stdout: "",
+    stderr: "",
+    status: 504,
+    readinessAttempts: 3,
+    elapsedMs: result.elapsedMs,
+    launchMode: "shell",
+    cleanup: { attempted: true, completed: true, mode: "windows-tree" },
+  });
+});
+
+test("the pre-cleanup health probe preserves a daemon that becomes healthy at the deadline", async () => {
+  const child = fakeChild();
+  let probes = 0;
+  let cleanupCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 0,
+    probe: async () => ({ ok: ++probes === 3 }),
+    spawnImpl: () => child,
+    terminateLaunchTree: async () => {
+      cleanupCalls += 1;
+      return { attempted: true, completed: true, mode: "windows-tree" };
+    },
+    platform: "win32",
+  });
+  assert.equal(cleanupCalls, 0, "a final healthy probe must never be cleaned up");
+  assert.equal(result.ok, true);
+  assert.equal(result.readinessAttempts, 3);
+});
+
+test("an exited but unhealthy launcher is cleaned up before it is reported", async () => {
+  const child = fakeChild();
+  let cleanupCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 1,
+    probe: async () => ({ ok: false }),
+    spawnImpl: () => {
+      queueMicrotask(() => child.emit("close", 1));
+      return child;
+    },
+    terminateLaunchTree: async () => {
+      cleanupCalls += 1;
+      return { attempted: true, completed: true, mode: "windows-tree" };
+    },
+    platform: "win32",
+  });
+  assert.equal(cleanupCalls, 1);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "runner_exited");
+  assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "windows-tree" });
+});
+
+test("Windows cleanup delegates the complete owned tree to taskkill", async () => {
+  const child = fakeChild(5199);
+  let taskkillPid = null;
+  const result = await terminateDaemonLaunchTree(child, {
+    platform: "win32",
+    terminateWindowsTree: async (pid) => {
+      taskkillPid = pid;
+      return true;
+    },
+  });
+  assert.equal(taskkillPid, 5199);
+  assert.deepEqual(result, { attempted: true, completed: true, mode: "windows-tree" });
+});
+
+test("POSIX cleanup escalates an owned process group when the launcher does not exit", async () => {
+  const child = fakeChild(5200);
+  const signals = [];
+  let waits = 0;
+  const result = await terminateDaemonLaunchTree(child, {
+    platform: "linux",
+    killProcessGroup: (pid, signal) => signals.push([pid, signal]),
+    waitForExit: async () => ++waits === 2,
+  });
+  assert.deepEqual(signals, [[5200, "SIGTERM"], [5200, "SIGKILL"]]);
+  assert.deepEqual(result, { attempted: true, completed: true, mode: "process-group" });
 });
 
 console.log("daemon-start.test.ts: ok");

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -1,44 +1,59 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 
 const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
+const readinessSource = await readFile(new URL("./daemon-readiness.ts", import.meta.url), "utf8");
 const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url), "utf8");
 
-assert.match(
-  covenDaemon,
-  /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/,
-  "coven-daemon should expose an explicit local target even when Cave is configured for a hub",
-);
+assert.match(covenDaemon, /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/);
+assert.match(daemonStart, /waitForDaemonReadiness/);
+assert.match(daemonStart, /path: "\/api\/v1\/health"/);
+assert.match(daemonStart, /shell: launchMode === "shell"/);
+assert.match(readinessSource, /A final probe closes the race/);
+assert.doesNotMatch(daemonStart, /child\.kill\("SIGTERM"\)/, "a timeout must not kill an already-daemonized Windows descendant");
 
-assert.match(
-  covenDaemon,
-  /export async function callDaemonTarget/,
-  "coven-daemon should let callers invoke a specific daemon target",
-);
+test("a foreground launcher is successful as soon as health becomes ready", async () => {
+  let now = 0;
+  let probes = 0;
+  const result = await waitForDaemonReadiness({
+    probe: async () => ({ ok: ++probes === 3 }),
+    timeoutMs: 1000,
+    pollMs: 100,
+    runnerExited: () => false,
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+  });
+  assert.deepEqual(result, { ready: true, attempts: 3, elapsedMs: 200, runnerExited: false });
+});
 
-assert.match(
-  daemonStart,
-  /callDaemonTarget\(localDaemonTarget\(\), \{ path: "\/api\/v1\/health", timeoutMs: healthTimeoutMs \}\)/,
-  "local daemon wake should check the laptop-local socket before spawning",
-);
+test("the deadline performs one final health probe before reporting timeout", async () => {
+  let now = 0;
+  let probes = 0;
+  const result = await waitForDaemonReadiness({
+    probe: async () => ({ ok: ++probes === 3 }),
+    timeoutMs: 100,
+    pollMs: 100,
+    runnerExited: () => false,
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+  });
+  assert.deepEqual(result, { ready: true, attempts: 3, elapsedMs: 100, runnerExited: false });
+});
 
-assert.match(
-  daemonStart,
-  /spawn\(covenBin\(\), \["daemon", "start"\]/,
-  "local daemon wake should start the Coven daemon through the existing CLI command",
-);
-
-assert.match(
-  daemonStart,
-  /shell: process\.platform === "win32"/,
-  "local daemon wake should preserve Windows npm shim support",
-);
-
-assert.match(
-  daemonStart,
-  /isMissingExecutableError\(err\)[\s\S]*covenCliMissingError\(\)/,
-  "local daemon wake should keep the missing-CLI error contract",
-);
+test("an exited launcher reports not-ready only after its final probe", async () => {
+  let probes = 0;
+  const result = await waitForDaemonReadiness({
+    probe: async () => ({ ok: ++probes === 2 }),
+    timeoutMs: 1000,
+    pollMs: 100,
+    runnerExited: () => true,
+    now: () => 0,
+    sleep: async () => assert.fail("an exited launcher should not sleep"),
+  });
+  assert.deepEqual(result, { ready: true, attempts: 2, elapsedMs: 0, runnerExited: true });
+});
 
 console.log("daemon-start.test.ts: ok");

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -117,6 +117,25 @@ test("a readiness timeout terminates the Windows launch tree", async () => {
   });
 });
 
+test("cleanup's own child close remains a readiness timeout", async () => {
+  const child = fakeChild();
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 0,
+    probe: async () => ({ ok: false }),
+    spawnImpl: () => child,
+    terminateLaunchTree: async () => {
+      child.emit("close", null);
+      return { attempted: true, completed: true, mode: "windows-tree" };
+    },
+    platform: "win32",
+  });
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "readiness_timeout");
+  assert.equal(result.status, 504);
+  assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "windows-tree" });
+});
+
 test("the pre-cleanup health probe preserves a daemon that becomes healthy at the deadline", async () => {
   const child = fakeChild();
   let probes = 0;

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -97,6 +97,10 @@ async function terminateChild(child: ChildProcess, waitForExit: (child: ChildPro
   return waitForExit(child, 2_000);
 }
 
+function isMissingProcess(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error && error.code === "ESRCH";
+}
+
 /**
  * Terminates only the process tree Cave started after readiness has failed a
  * final health check. Windows taskkill owns the shell and all descendants;
@@ -129,7 +133,7 @@ export async function terminateDaemonLaunchTree(
   } catch (error) {
     // A process that disappeared between readiness and cleanup is already
     // safe. Other failures are reported as incomplete cleanup diagnostics.
-    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+    if (isMissingProcess(error)) {
       return { attempted: true, completed: true, mode: "process-group" };
     }
     return { attempted: true, completed: false, mode: "process-group" };
@@ -140,7 +144,7 @@ export async function terminateDaemonLaunchTree(
   try {
     killProcessGroup(pid, "SIGKILL");
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+    if (!isMissingProcess(error)) {
       return { attempted: true, completed: false, mode: "process-group" };
     }
   }

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -4,6 +4,7 @@ import { covenBin } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
+import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
 
 export type DaemonStartResult =
   | { ok: true; alreadyRunning: true; readinessAttempts: number; elapsedMs: number; launchMode: "none" }
@@ -36,6 +37,15 @@ type StartLocalDaemonOptions = {
   startTimeoutMs?: number;
   readinessPollMs?: number;
 };
+
+/**
+ * Process output can contain local paths, npm configuration, and credentials.
+ * Keep the bounded, structured launch result useful without turning a failed
+ * start into a diagnostics exfiltration path.
+ */
+export function sanitizeDaemonStartDiagnostic(value: string): string {
+  return sanitizeAboutDiagnosticText(value);
+}
 
 export async function startLocalDaemon({
   restart = false,
@@ -82,26 +92,29 @@ export async function startLocalDaemon({
       elapsedMs: Date.now() - startedAt,
       launchMode,
       runner: readiness.runnerExited ? "exited" : "still-running",
-      stdout,
-      stderr,
+      stdout: sanitizeDaemonStartDiagnostic(stdout),
+      stderr: sanitizeDaemonStartDiagnostic(stderr),
     };
   }
   if (spawnError) {
     if (isMissingExecutableError(spawnError)) {
       const missing = covenCliMissingError();
       return {
-        ok: false, code: "spawn_failed", error: missing.error, stdout, stderr,
+        ok: false, code: "spawn_failed", error: sanitizeDaemonStartDiagnostic(missing.error),
+        stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
         status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
       };
     }
     return {
-      ok: false, code: "spawn_failed", error: spawnError.message, stdout, stderr,
+      ok: false, code: "spawn_failed", error: sanitizeDaemonStartDiagnostic(spawnError.message),
+      stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
       status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
     };
   }
   if (exitCode !== undefined) {
     return {
-      ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready", stdout, stderr,
+      ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready",
+      stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
       status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode, exitCode,
     };
   }
@@ -109,7 +122,8 @@ export async function startLocalDaemon({
   // handed the daemon to a descendant; the final health probe above is the
   // authority, and killing by shell pid can leave that healthy child orphaned.
   return {
-    ok: false, code: "readiness_timeout", error: "daemon readiness timed out", stdout, stderr,
+    ok: false, code: "readiness_timeout", error: "daemon readiness timed out",
+    stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
     status: 504, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
   };
 }

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -3,62 +3,113 @@ import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
 import { covenBin } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
+import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 
 export type DaemonStartResult =
-  | { ok: true; alreadyRunning: true }
-  | { ok: boolean; exitCode: number | null; restart: boolean; stdout: string; stderr: string }
-  | { ok: false; error: string; stdout?: string; stderr?: string; status?: number };
+  | { ok: true; alreadyRunning: true; readinessAttempts: number; elapsedMs: number; launchMode: "none" }
+  | {
+    ok: true;
+    alreadyRunning: false;
+    readinessAttempts: number;
+    elapsedMs: number;
+    launchMode: "shell" | "direct";
+    runner: "still-running" | "exited";
+    stdout: string;
+    stderr: string;
+  }
+  | {
+    ok: false;
+    code: "spawn_failed" | "runner_exited" | "readiness_timeout";
+    error: string;
+    stdout: string;
+    stderr: string;
+    status: 500 | 504;
+    readinessAttempts: number;
+    elapsedMs: number;
+    launchMode: "shell" | "direct";
+    exitCode?: number | null;
+  };
 
 type StartLocalDaemonOptions = {
   restart?: boolean;
   healthTimeoutMs?: number;
   startTimeoutMs?: number;
+  readinessPollMs?: number;
 };
 
 export async function startLocalDaemon({
   restart = false,
   healthTimeoutMs = 1500,
   startTimeoutMs = 8000,
+  readinessPollMs = 250,
 }: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
-  if (!restart) {
-    const health = await callDaemonTarget(localDaemonTarget(), { path: "/api/v1/health", timeoutMs: healthTimeoutMs });
-    if (health.ok) return { ok: true, alreadyRunning: true };
+  const probe = () => callDaemonTarget(localDaemonTarget(), { path: "/api/v1/health", timeoutMs: healthTimeoutMs });
+  const startedAt = Date.now();
+  if (!restart && (await probe()).ok) {
+    return { ok: true, alreadyRunning: true, readinessAttempts: 1, elapsedMs: Date.now() - startedAt, launchMode: "none" };
   }
 
-  return new Promise<DaemonStartResult>((resolve) => {
-    const child = spawn(covenBin(), ["daemon", "start"], {
-      stdio: ["ignore", "pipe", "pipe"],
-      detached: false,
-      // The daemon must never hold scoped vault secrets: daemon-launched
-      // sessions would inherit them wholesale. Scoped keys flow only through
-      // Cave's own per-familiar spawn path (cave-4nu6).
-      env: harnessSpawnEnv(),
-      shell: process.platform === "win32",
-    });
-
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (d) => (stdout += d.toString()));
-    child.stderr.on("data", (d) => (stderr += d.toString()));
-
-    const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve({ ok: false, error: "timeout", stdout, stderr, status: 504 });
-    }, startTimeoutMs);
-
-    child.on("error", (err) => {
-      clearTimeout(timer);
-      if (isMissingExecutableError(err)) {
-        const missing = covenCliMissingError();
-        resolve({ ...missing, ok: false, status: 500 });
-        return;
-      }
-      resolve({ ok: false, error: err.message, status: 500 });
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      resolve({ ok: code === 0, exitCode: code, restart, stdout, stderr });
-    });
+  const launchMode = process.platform === "win32" ? "shell" : "direct";
+  const child = spawn(covenBin(), ["daemon", "start"], {
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: false,
+    // The daemon must never hold scoped vault secrets: daemon-launched
+    // sessions would inherit them wholesale. Scoped keys flow only through
+    // Cave's own per-familiar spawn path (cave-4nu6).
+    env: harnessSpawnEnv(),
+    shell: launchMode === "shell",
   });
+  let stdout = "";
+  let stderr = "";
+  let exitCode: number | null | undefined;
+  let spawnError: Error | null = null;
+  child.stdout.on("data", (d) => (stdout += d.toString()));
+  child.stderr.on("data", (d) => (stderr += d.toString()));
+  child.on("close", (code) => { exitCode = code; });
+  child.on("error", (error) => { spawnError = error; });
+
+  const readiness = await waitForDaemonReadiness({
+    probe,
+    timeoutMs: startTimeoutMs,
+    pollMs: readinessPollMs,
+    runnerExited: () => spawnError !== null || exitCode !== undefined,
+  });
+  if (readiness.ready) {
+    return {
+      ok: true,
+      alreadyRunning: false,
+      readinessAttempts: readiness.attempts,
+      elapsedMs: Date.now() - startedAt,
+      launchMode,
+      runner: readiness.runnerExited ? "exited" : "still-running",
+      stdout,
+      stderr,
+    };
+  }
+  if (spawnError) {
+    if (isMissingExecutableError(spawnError)) {
+      const missing = covenCliMissingError();
+      return {
+        ok: false, code: "spawn_failed", error: missing.error, stdout, stderr,
+        status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
+      };
+    }
+    return {
+      ok: false, code: "spawn_failed", error: spawnError.message, stdout, stderr,
+      status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
+    };
+  }
+  if (exitCode !== undefined) {
+    return {
+      ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready", stdout, stderr,
+      status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode, exitCode,
+    };
+  }
+  // Do not kill a launcher on timeout. On Windows a shell can have already
+  // handed the daemon to a descendant; the final health probe above is the
+  // authority, and killing by shell pid can leave that healthy child orphaned.
+  return {
+    ok: false, code: "readiness_timeout", error: "daemon readiness timed out", stdout, stderr,
+    status: 504, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
+  };
 }

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process";
+import { execFile, spawn, type ChildProcess } from "node:child_process";
+import { promisify } from "node:util";
 import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
 import { covenBin } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
@@ -29,13 +30,133 @@ export type DaemonStartResult =
     elapsedMs: number;
     launchMode: "shell" | "direct";
     exitCode?: number | null;
+    /** Present only when Cave owned a launch that failed its readiness window. */
+    cleanup?: DaemonLaunchCleanup;
   };
+
+/**
+ * A failed daemon launch must not leave a retry-blocking process tree behind.
+ * Deliberately omit PIDs and command lines: this crosses the API boundary.
+ */
+export type DaemonLaunchCleanup = {
+  attempted: boolean;
+  completed: boolean;
+  mode: "windows-tree" | "process-group" | "child";
+};
+
+type DaemonLaunchCleanupDependencies = {
+  platform?: NodeJS.Platform;
+  terminateWindowsTree?: (pid: number) => Promise<boolean>;
+  killProcessGroup?: (pid: number, signal: NodeJS.Signals) => void;
+  waitForExit?: (child: ChildProcess, timeoutMs: number) => Promise<boolean>;
+};
+
+const execFileAsync = promisify(execFile);
+
+function childExited(child: ChildProcess): boolean {
+  return child.exitCode !== null || child.signalCode !== null;
+}
+
+async function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (childExited(child)) return true;
+  return new Promise((resolve) => {
+    let settled = false;
+    const settle = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.off("close", onClose);
+      child.off("error", onClose);
+      resolve(value);
+    };
+    const onClose = () => settle(true);
+    const timeout = setTimeout(() => settle(childExited(child)), timeoutMs);
+    child.once("close", onClose);
+    child.once("error", onClose);
+  });
+}
+
+async function terminateWindowsTree(pid: number): Promise<boolean> {
+  try {
+    await execFileAsync("taskkill", ["/pid", String(pid), "/t", "/f"], {
+      windowsHide: true,
+      timeout: 2_000,
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function terminateChild(child: ChildProcess, waitForExit: (child: ChildProcess, timeoutMs: number) => Promise<boolean>) {
+  try {
+    child.kill("SIGTERM");
+  } catch {
+    return false;
+  }
+  return waitForExit(child, 2_000);
+}
+
+/**
+ * Terminates only the process tree Cave started after readiness has failed a
+ * final health check. Windows taskkill owns the shell and all descendants;
+ * POSIX launches use an isolated process group so a foreground shell cannot
+ * strand its daemon child. This is intentionally not used for a healthy
+ * daemon, even if its launcher is still foregrounded.
+ */
+export async function terminateDaemonLaunchTree(
+  child: ChildProcess,
+  dependencies: DaemonLaunchCleanupDependencies = {},
+): Promise<DaemonLaunchCleanup> {
+  const platform = dependencies.platform ?? process.platform;
+  const waitForExit = dependencies.waitForExit ?? waitForChildExit;
+  const pid = child.pid;
+
+  if (platform === "win32") {
+    const completed = pid === undefined
+      ? await terminateChild(child, waitForExit)
+      : await (dependencies.terminateWindowsTree ?? terminateWindowsTree)(pid);
+    return { attempted: true, completed, mode: pid === undefined ? "child" : "windows-tree" };
+  }
+
+  if (pid === undefined) {
+    return { attempted: true, completed: await terminateChild(child, waitForExit), mode: "child" };
+  }
+
+  const killProcessGroup = dependencies.killProcessGroup ?? ((groupPid, signal) => process.kill(-groupPid, signal));
+  try {
+    killProcessGroup(pid, "SIGTERM");
+  } catch (error) {
+    // A process that disappeared between readiness and cleanup is already
+    // safe. Other failures are reported as incomplete cleanup diagnostics.
+    if ((error as NodeJS.ErrnoException).code === "ESRCH") {
+      return { attempted: true, completed: true, mode: "process-group" };
+    }
+    return { attempted: true, completed: false, mode: "process-group" };
+  }
+  if (await waitForExit(child, 500)) {
+    return { attempted: true, completed: true, mode: "process-group" };
+  }
+  try {
+    killProcessGroup(pid, "SIGKILL");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+      return { attempted: true, completed: false, mode: "process-group" };
+    }
+  }
+  return { attempted: true, completed: await waitForExit(child, 500), mode: "process-group" };
+}
 
 type StartLocalDaemonOptions = {
   restart?: boolean;
   healthTimeoutMs?: number;
   startTimeoutMs?: number;
   readinessPollMs?: number;
+  /** Test seams keep launch ownership and timeout cleanup executable. */
+  probe?: () => Promise<{ ok: boolean }>;
+  spawnImpl?: typeof spawn;
+  terminateLaunchTree?: (child: ChildProcess) => Promise<DaemonLaunchCleanup>;
+  platform?: NodeJS.Platform;
 };
 
 /**
@@ -52,17 +173,24 @@ export async function startLocalDaemon({
   healthTimeoutMs = 1500,
   startTimeoutMs = 8000,
   readinessPollMs = 250,
+  probe: probeOverride,
+  spawnImpl = spawn,
+  terminateLaunchTree = terminateDaemonLaunchTree,
+  platform = process.platform,
 }: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
-  const probe = () => callDaemonTarget(localDaemonTarget(), { path: "/api/v1/health", timeoutMs: healthTimeoutMs });
+  const probe = probeOverride ?? (() => callDaemonTarget(localDaemonTarget(), { path: "/api/v1/health", timeoutMs: healthTimeoutMs }));
   const startedAt = Date.now();
   if (!restart && (await probe()).ok) {
     return { ok: true, alreadyRunning: true, readinessAttempts: 1, elapsedMs: Date.now() - startedAt, launchMode: "none" };
   }
 
-  const launchMode = process.platform === "win32" ? "shell" : "direct";
-  const child = spawn(covenBin(), ["daemon", "start"], {
+  const launchMode = platform === "win32" ? "shell" : "direct";
+  const child = spawnImpl(covenBin(), ["daemon", "start"], {
     stdio: ["ignore", "pipe", "pipe"],
-    detached: false,
+    // POSIX uses an owned process group so timeout cleanup cannot strand a
+    // foreground shell's daemon descendant. Windows owns its shell tree via
+    // taskkill /T instead, where detached process groups do not provide this.
+    detached: launchMode === "direct",
     // The daemon must never hold scoped vault secrets: daemon-launched
     // sessions would inherit them wholesale. Scoped keys flow only through
     // Cave's own per-familiar spawn path (cave-4nu6).
@@ -73,8 +201,8 @@ export async function startLocalDaemon({
   let stderr = "";
   let exitCode: number | null | undefined;
   let spawnError: Error | null = null;
-  child.stdout.on("data", (d) => (stdout += d.toString()));
-  child.stderr.on("data", (d) => (stderr += d.toString()));
+  child.stdout?.on("data", (d) => (stdout += d.toString()));
+  child.stderr?.on("data", (d) => (stderr += d.toString()));
   child.on("close", (code) => { exitCode = code; });
   child.on("error", (error) => { spawnError = error; });
   // TypeScript's control-flow analysis cannot observe event-callback writes
@@ -116,19 +244,35 @@ export async function startLocalDaemon({
       status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
     };
   }
+  // waitForDaemonReadiness has already made its deadline probe. Recheck once
+  // immediately before cleanup so a just-published healthy daemon is never
+  // terminated merely because its foreground launcher has exited or remains
+  // attached. If this final probe is still unhealthy, clean up the owned tree
+  // even when the launcher reported an early exit: an escaped descendant is
+  // not allowed to survive an unsuccessful launch.
+  if ((await probe()).ok) {
+    return {
+      ok: true,
+      alreadyRunning: false,
+      readinessAttempts: readiness.attempts + 1,
+      elapsedMs: Date.now() - startedAt,
+      launchMode,
+      runner: exitCode === undefined ? "still-running" : "exited",
+      stdout: sanitizeDaemonStartDiagnostic(stdout),
+      stderr: sanitizeDaemonStartDiagnostic(stderr),
+    };
+  }
+  const cleanup = await terminateLaunchTree(child);
   if (exitCode !== undefined) {
     return {
       ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready",
       stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
-      status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode, exitCode,
+      status: 500, readinessAttempts: readiness.attempts + 1, elapsedMs: Date.now() - startedAt, launchMode, exitCode, cleanup,
     };
   }
-  // Do not kill a launcher on timeout. On Windows a shell can have already
-  // handed the daemon to a descendant; the final health probe above is the
-  // authority, and killing by shell pid can leave that healthy child orphaned.
   return {
     ok: false, code: "readiness_timeout", error: "daemon readiness timed out",
     stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
-    status: 504, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
+    status: 504, readinessAttempts: readiness.attempts + 1, elapsedMs: Date.now() - startedAt, launchMode, cleanup,
   };
 }

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -266,8 +266,13 @@ export async function startLocalDaemon({
       stderr: sanitizeDaemonStartDiagnostic(stderr),
     };
   }
+  // Capture this before cleanup. The owned-tree terminator deliberately
+  // causes the child to close (often with a null code after SIGTERM); that is
+  // evidence that cleanup worked, not that the launcher exited before its
+  // readiness deadline.
+  const runnerExitedBeforeCleanup = exitCode !== undefined;
   const cleanup = await terminateLaunchTree(child);
-  if (exitCode !== undefined) {
+  if (runnerExitedBeforeCleanup) {
     return {
       ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready",
       stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -77,6 +77,10 @@ export async function startLocalDaemon({
   child.stderr.on("data", (d) => (stderr += d.toString()));
   child.on("close", (code) => { exitCode = code; });
   child.on("error", (error) => { spawnError = error; });
+  // TypeScript's control-flow analysis cannot observe event-callback writes
+  // across an await. Read through a closure so the post-readiness state keeps
+  // its declared Error | null shape.
+  const launchError = () => spawnError;
 
   const readiness = await waitForDaemonReadiness({
     probe,
@@ -96,8 +100,9 @@ export async function startLocalDaemon({
       stderr: sanitizeDaemonStartDiagnostic(stderr),
     };
   }
-  if (spawnError) {
-    if (isMissingExecutableError(spawnError)) {
+  const error = launchError();
+  if (error) {
+    if (isMissingExecutableError(error)) {
       const missing = covenCliMissingError();
       return {
         ok: false, code: "spawn_failed", error: sanitizeDaemonStartDiagnostic(missing.error),
@@ -106,7 +111,7 @@ export async function startLocalDaemon({
       };
     }
     return {
-      ok: false, code: "spawn_failed", error: sanitizeDaemonStartDiagnostic(spawnError.message),
+      ok: false, code: "spawn_failed", error: sanitizeDaemonStartDiagnostic(error.message),
       stdout: sanitizeDaemonStartDiagnostic(stdout), stderr: sanitizeDaemonStartDiagnostic(stderr),
       status: 500, readinessAttempts: readiness.attempts, elapsedMs: Date.now() - startedAt, launchMode,
     };

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,8 +1,8 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
-import { callDaemonTarget, localDaemonTarget } from "@/lib/coven-daemon";
-import { covenBin } from "@/lib/coven-bin";
-import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
+import { callDaemonTarget, localDaemonTarget } from "./coven-daemon.ts";
+import { covenBin } from "./coven-bin.ts";
+import { covenCliMissingError, isMissingExecutableError } from "./coven-spawn-error.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";

--- a/src/lib/first-project-gate-policy.test.ts
+++ b/src/lib/first-project-gate-policy.test.ts
@@ -121,3 +121,37 @@ test("first-project gate policy keeps a pending retry bound to its original fami
     "the same pending retry hides on non-Home/Chat surfaces and can reopen later without losing its target",
   );
 });
+
+test("a globally registered project does not bypass the gate when the active familiar has no access", () => {
+  const denied = resolveFirstProjectGatePolicy({
+    activeFamiliarId: "ember",
+    visibleFamiliars,
+    registeredProjects: [project],
+    accessibleProjects: [],
+    accessibleProjectsInitiallyResolved: true,
+    pendingGrant: null,
+    onboardingResolved: true,
+    onboardingOpen: false,
+    mode: "chat",
+    familiarsLoaded: true,
+    familiarRosterLoadedSuccessfully: true,
+    projectsInitiallyResolved: true,
+  });
+  assert.deepEqual(denied, { open: true, familiarId: "ember", blockChatLaunch: true });
+
+  const granted = resolveFirstProjectGatePolicy({
+    activeFamiliarId: "ember",
+    visibleFamiliars,
+    registeredProjects: [project],
+    accessibleProjects: [project],
+    accessibleProjectsInitiallyResolved: true,
+    pendingGrant: null,
+    onboardingResolved: true,
+    onboardingOpen: false,
+    mode: "chat",
+    familiarsLoaded: true,
+    familiarRosterLoadedSuccessfully: true,
+    projectsInitiallyResolved: true,
+  });
+  assert.deepEqual(granted, { open: false, familiarId: "ember", blockChatLaunch: false });
+});

--- a/src/lib/first-project-gate-policy.ts
+++ b/src/lib/first-project-gate-policy.ts
@@ -7,6 +7,8 @@ export type FirstProjectGatePolicyInput = {
   activeFamiliarId: string | null;
   visibleFamiliars: readonly FamiliarLike[];
   registeredProjects: readonly CaveProject[];
+  /** Projects the target familiar can launch chat in, resolved server-side. */
+  accessibleProjects?: readonly CaveProject[];
   pendingGrant: PendingFirstProjectAccessSnapshot | null;
   onboardingResolved: boolean;
   onboardingOpen: boolean;
@@ -14,6 +16,7 @@ export type FirstProjectGatePolicyInput = {
   familiarsLoaded: boolean;
   familiarRosterLoadedSuccessfully: boolean;
   projectsInitiallyResolved: boolean;
+  accessibleProjectsInitiallyResolved?: boolean;
 };
 
 export type FirstProjectGatePolicy = {
@@ -34,13 +37,18 @@ export function resolveFirstProjectGatePolicy(
 ): FirstProjectGatePolicy {
   const familiarId = input.pendingGrant?.familiarId
     ?? preferredFirstProjectGateFamiliarId(input.activeFamiliarId, input.visibleFamiliars);
+  const accessibleProjects = input.accessibleProjects ?? input.registeredProjects;
+  const accessibleProjectsInitiallyResolved = input.accessibleProjectsInitiallyResolved ?? true;
   const blockChatLaunch = input.onboardingResolved
     && !input.onboardingOpen
     && input.familiarsLoaded
     && input.familiarRosterLoadedSuccessfully
     && input.projectsInitiallyResolved
+    && accessibleProjectsInitiallyResolved
     && familiarId !== null
-    && (input.registeredProjects.length === 0 || input.pendingGrant !== null);
+    // A project somewhere in the registry is not sufficient: the active
+    // familiar still needs an effective grant before a chat can be launched.
+    && (accessibleProjects.length === 0 || input.pendingGrant !== null);
 
   return {
     open: blockChatLaunch && (input.mode === "home" || input.mode === "chat"),

--- a/src/lib/openclaw-agents.test.ts
+++ b/src/lib/openclaw-agents.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { summarizeOpenClawAgent } from "./openclaw-agents.ts";
 
 assert.deepEqual(
@@ -27,3 +28,23 @@ assert.deepEqual(summarizeOpenClawAgent("coven-code", null, null), {
   role: "OpenClaw agent",
   workspacePath: null,
 });
+
+const route = readFileSync(
+  new URL("../app/api/openclaw-agents/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  route,
+  /listOpenClawAgents\(\)/,
+  "the summoning inventory should use OpenClaw's live registered agents",
+);
+assert.match(
+  route,
+  /agent\.workspace\?\.trim\(\) \|\| path\.join\(workspaceRoot, id\)/,
+  "registered agents should retain their authoritative workspace path",
+);
+assert.doesNotMatch(
+  route,
+  /readdir\(agentsRoot/,
+  "stale filesystem-only agent directories must not appear in the summoning inventory",
+);

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -10,6 +10,7 @@ import {
   openClawBridgeCapabilities,
   openClawAgentArgs,
   openClawSessionKey,
+  parseOpenClawAgentList,
   readTomlString,
   resolveOpenClawAgentBindingFromSources,
   resolveOpenClawAgentId,
@@ -24,6 +25,36 @@ assert.equal(readTomlString("id = \"nova\"", "openclaw_agent"), null);
 
 assert.equal(slugifyOpenClawAgentName("Cody Main"), "cody-main");
 assert.equal(slugifyOpenClawAgentName("  Nova / Release Review  "), "nova-release-review");
+assert.deepEqual(
+  parseOpenClawAgentList([
+    {
+      id: " main ",
+      name: null,
+      identityName: null,
+      isDefault: true,
+      workspace: "C:\\Users\\example\\.openclaw\\workspace",
+      futureField: "ignored",
+    },
+  ]),
+  [
+    {
+      id: "main",
+      isDefault: true,
+      workspace: "C:\\Users\\example\\.openclaw\\workspace",
+    },
+  ],
+  "the live registry parser should normalize the stable agent contract",
+);
+assert.deepEqual(
+  parseOpenClawAgentList([{ id: "main" }, { id: "main" }]),
+  [],
+  "duplicate live agent ids should fail closed",
+);
+assert.deepEqual(
+  parseOpenClawAgentList([{ id: "main", isDefault: "yes" }]),
+  [],
+  "malformed live registry fields should fail closed",
+);
 
 const candidateAgents = [
   { id: "fallback-match", name: "Nova", identityName: "Nova Identity" },

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -71,6 +71,29 @@ assert.deepEqual(
   },
   "slugified display or identity-name matches should report name-match source metadata",
 );
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("wren", null, [
+    { id: "main", isDefault: true },
+  ]),
+  {
+    caveFamiliarId: "wren",
+    openclawAgentId: "main",
+    source: "default",
+  },
+  "a unique OpenClaw default should bind a differently named Cave familiar",
+);
+assert.deepEqual(
+  resolveOpenClawAgentBindingFromSources("wren", null, [
+    { id: "main", isDefault: true },
+    { id: "research", isDefault: false },
+  ]),
+  {
+    caveFamiliarId: "wren",
+    openclawAgentId: "main",
+    source: "default",
+  },
+  "one declared default should remain deterministic when other agents exist",
+);
 assert.throws(
   () => resolveOpenClawAgentBindingFromSources("unknown", null, candidateAgents),
   (error) =>
@@ -89,6 +112,15 @@ assert.deepEqual(
     source: "fallback",
   },
   "fallback-to-familiar-id should be explicit and source-tagged",
+);
+assert.throws(
+  () =>
+    resolveOpenClawAgentBindingFromSources("unknown", null, [
+      { id: "main", isDefault: true },
+      { id: "other", isDefault: true },
+    ]),
+  (error) => error instanceof OpenClawAgentResolutionError,
+  "ambiguous default declarations should still fail closed",
 );
 
 assert.equal(

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -18,11 +18,18 @@ export type OpenClawAgentJson = {
 };
 
 export type OpenClawAgentSummary = {
-  id?: string;
-  name?: string;
-  identityName?: string;
+  id: string;
+  name?: string | null;
+  identityName?: string | null;
   isDefault?: boolean;
+  workspace?: string | null;
 };
+
+const OPENCLAW_AGENT_CACHE_TTL_MS = 5_000;
+let openClawAgentCache:
+  | { expiresAt: number; agents: OpenClawAgentSummary[] }
+  | null = null;
+let openClawAgentListInFlight: Promise<OpenClawAgentSummary[]> | null = null;
 
 type OpenClawBridgeRequest = {
   familiarId: string;
@@ -111,6 +118,33 @@ export function slugifyOpenClawAgentName(value: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
+export function parseOpenClawAgentList(value: unknown): OpenClawAgentSummary[] {
+  if (!Array.isArray(value)) return [];
+
+  const seen = new Set<string>();
+  const agents: OpenClawAgentSummary[] = [];
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== "object") return [];
+    const row = candidate as Record<string, unknown>;
+    const id = typeof row.id === "string" ? row.id.trim() : "";
+    if (!id || seen.has(id)) return [];
+    if (row.name != null && typeof row.name !== "string") return [];
+    if (row.identityName != null && typeof row.identityName !== "string") return [];
+    if (row.isDefault != null && typeof row.isDefault !== "boolean") return [];
+    if (row.workspace != null && typeof row.workspace !== "string") return [];
+
+    seen.add(id);
+    agents.push({
+      id,
+      ...(typeof row.name === "string" ? { name: row.name } : {}),
+      ...(typeof row.identityName === "string" ? { identityName: row.identityName } : {}),
+      ...(typeof row.isDefault === "boolean" ? { isDefault: row.isDefault } : {}),
+      ...(typeof row.workspace === "string" ? { workspace: row.workspace } : {}),
+    });
+  }
+  return agents;
+}
+
 export async function readOpenClawAgentBinding(familiarId: string): Promise<string | null> {
   try {
     const raw = await readFile(path.join(covenHome(), "familiars.toml"), "utf8");
@@ -125,7 +159,7 @@ export async function readOpenClawAgentBinding(familiarId: string): Promise<stri
   return null;
 }
 
-export async function listOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
+async function loadOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
   const {
     openClawBin,
     openClawNeedsShell,
@@ -139,19 +173,54 @@ export async function listOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
       shell: openClawNeedsShell(),
     });
     let stdout = "";
+    let settled = false;
+    const finish = (agents: OpenClawAgentSummary[]) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(agents);
+    };
+    const timeout = setTimeout(() => {
+      child.kill("SIGTERM");
+      finish([]);
+    }, 15_000);
     child.stdout.on("data", (data: Buffer) => {
       stdout += data.toString("utf8");
     });
-    child.on("error", () => resolve([]));
-    child.on("close", () => {
+    child.on("error", () => finish([]));
+    child.on("close", (code) => {
+      if (code !== 0) {
+        finish([]);
+        return;
+      }
       try {
-        const parsed = JSON.parse(stdout.trim()) as OpenClawAgentSummary[];
-        resolve(Array.isArray(parsed) ? parsed : []);
+        finish(parseOpenClawAgentList(JSON.parse(stdout.trim())));
       } catch {
-        resolve([]);
+        finish([]);
       }
     });
   });
+}
+
+export async function listOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
+  const now = Date.now();
+  if (openClawAgentCache && openClawAgentCache.expiresAt > now) {
+    return openClawAgentCache.agents;
+  }
+  if (openClawAgentListInFlight) return openClawAgentListInFlight;
+
+  openClawAgentListInFlight = loadOpenClawAgents()
+    .then((agents) => {
+      openClawAgentCache = {
+        expiresAt: Date.now() + OPENCLAW_AGENT_CACHE_TTL_MS,
+        agents,
+      };
+      return agents;
+    })
+    .finally(() => {
+      openClawAgentListInFlight = null;
+    });
+  return openClawAgentListInFlight;
 }
 
 export function resolveOpenClawAgentIdFromSources(
@@ -188,11 +257,11 @@ export function resolveOpenClawAgentBindingFromSources(
     return { caveFamiliarId: familiarId, openclawAgentId: named, source: "name-match" };
   }
 
-  const defaults = agents.filter((agent) => agent.isDefault === true && agent.id);
+  const defaults = agents.filter((agent) => agent.isDefault === true);
   if (defaults.length === 1) {
     return {
       caveFamiliarId: familiarId,
-      openclawAgentId: defaults[0].id!,
+      openclawAgentId: defaults[0].id,
       source: "default",
     };
   }

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -39,7 +39,7 @@ type OpenClawBridgeRequest = {
 export type OpenClawAgentBinding = {
   caveFamiliarId: string;
   openclawAgentId: string;
-  source: "explicit" | "id-match" | "name-match" | "fallback";
+  source: "explicit" | "id-match" | "name-match" | "default" | "fallback";
 };
 
 export type OpenClawBridgeCapabilities = {
@@ -186,6 +186,15 @@ export function resolveOpenClawAgentBindingFromSources(
   )?.id;
   if (named) {
     return { caveFamiliarId: familiarId, openclawAgentId: named, source: "name-match" };
+  }
+
+  const defaults = agents.filter((agent) => agent.isDefault === true && agent.id);
+  if (defaults.length === 1) {
+    return {
+      caveFamiliarId: familiarId,
+      openclawAgentId: defaults[0].id!,
+      source: "default",
+    };
   }
 
   if (options.allowFallback) {

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -24,6 +24,8 @@ try {
     filterProjectsForFamiliar,
     grantProjectToFamiliar,
     revokeAllGrantsForProject,
+    inspectProjectPermissionIntegrity,
+    repairOrphanProjectPermissions,
     listProjectGrants,
     listAccessibleProjects,
     loadHumanPermissionConfig,
@@ -414,6 +416,28 @@ try {
     afterCascade.some((grant) => grant.projectId === "docs" && grant.familiarId === "cascade-a"),
     "grants for other projects are untouched by the cascade",
   );
+
+  // ── Explicit orphan repair: legacy state is inspected first, then pruned
+  // only by an idempotent human-triggered repair that records what changed. ──
+  await grantProjectToFamiliar({ familiarId: "orphaned", projectId: "removed-project", source: "human" });
+  const beforeRepair = await inspectProjectPermissionIntegrity();
+  assert.deepEqual(beforeRepair, {
+    directGrants: 1,
+    groupGrants: 0,
+    proposals: 0,
+    orphanProjectIds: ["removed-project"],
+  }, "orphaned grants are visible without changing access");
+  const repaired = await repairOrphanProjectPermissions();
+  assert.deepEqual(repaired, beforeRepair, "repair reports the exact records it removed");
+  const afterRepair = await inspectProjectPermissionIntegrity();
+  assert.deepEqual(afterRepair, {
+    directGrants: 0,
+    groupGrants: 0,
+    proposals: 0,
+    orphanProjectIds: [],
+  }, "repair only removes unknown-project records and never broadens access");
+  assert.equal((await loadProjectPermissions()).repairAudit.at(-1)?.kind, "orphan-project-repair", "repair writes an auditable record");
+  assert.deepEqual(await repairOrphanProjectPermissions(), afterRepair, "a retry after interruption is idempotent");
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.test.ts
+++ b/src/lib/project-permissions.test.ts
@@ -427,6 +427,15 @@ try {
     proposals: 0,
     orphanProjectIds: ["removed-project"],
   }, "orphaned grants are visible without changing access");
+  const permissionSource = await readFile(new URL("./project-permissions.ts", import.meta.url), "utf8");
+  assert.match(permissionSource, /await writeJsonAtomic\(filePath, file\)/, "permission repairs persist through the atomic writer");
+  const interruptedWrite = `${process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE}.interrupted.tmp`;
+  await writeFile(interruptedWrite, '{"version":2,"projectGrants":[', "utf8");
+  assert.deepEqual(
+    await inspectProjectPermissionIntegrity(),
+    beforeRepair,
+    "an abandoned partial atomic-write temp file cannot replace the last valid permission state",
+  );
   const repaired = await repairOrphanProjectPermissions();
   assert.deepEqual(repaired, beforeRepair, "repair reports the exact records it removed");
   const afterRepair = await inspectProjectPermissionIntegrity();
@@ -437,7 +446,7 @@ try {
     orphanProjectIds: [],
   }, "repair only removes unknown-project records and never broadens access");
   assert.equal((await loadProjectPermissions()).repairAudit.at(-1)?.kind, "orphan-project-repair", "repair writes an auditable record");
-  assert.deepEqual(await repairOrphanProjectPermissions(), afterRepair, "a retry after interruption is idempotent");
+  assert.deepEqual(await repairOrphanProjectPermissions(), afterRepair, "a retry after an interrupted repair is idempotent");
 
   console.log("project-permissions.test.ts: ok");
 } finally {

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -3,6 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import { withCaveHomeReconciledStore } from "./server/cave-home-migration.ts";
+import { writeJsonAtomic } from "./server/atomic-write.ts";
 
 import { loadProjects, projectForRoot } from "./cave-projects.ts";
 import type { CaveProject } from "./cave-projects-types.ts";
@@ -406,7 +407,12 @@ export function materializeDueGrantProposals(
 }
 
 async function saveProjectPermissions(file: ProjectPermissionsFile): Promise<void> {
-  await writeJsonFile(permissionsFilePath(), file);
+  const filePath = permissionsFilePath();
+  await mkdir(path.dirname(filePath), { recursive: true });
+  // Repairs remove grants and append their audit record as one atomic state
+  // change. A crash before rename leaves the prior valid permission file
+  // authoritative; a later retry can safely inspect and repair it again.
+  await writeJsonAtomic(filePath, file);
 }
 
 function ensureProjectGrant(

--- a/src/lib/project-permissions.ts
+++ b/src/lib/project-permissions.ts
@@ -126,6 +126,22 @@ export type GrantChangeEntry = {
   groupId?: string;
 };
 
+export type ProjectPermissionRepairAudit = {
+  at: string;
+  kind: "orphan-project-repair";
+  directGrants: number;
+  groupGrants: number;
+  proposals: number;
+  orphanProjectIds: string[];
+};
+
+export type ProjectPermissionIntegrityReport = {
+  directGrants: number;
+  groupGrants: number;
+  proposals: number;
+  orphanProjectIds: string[];
+};
+
 type ProjectPermissionsFile = {
   version: 2;
   projectGrants: ProjectGrant[];
@@ -138,6 +154,7 @@ type ProjectPermissionsFile = {
    * would force every existing entry to be reinterpreted.
    */
   grantAudit: GrantChangeEntry[];
+  repairAudit: ProjectPermissionRepairAudit[];
 };
 
 type HumanPermissionConfigFile = {
@@ -193,6 +210,7 @@ function emptyFile(): ProjectPermissionsFile {
     grantProposals: [],
     permissionAudit: [],
     grantAudit: [],
+    repairAudit: [],
   };
 }
 
@@ -348,6 +366,7 @@ async function loadProjectPermissionsUnlocked(): Promise<ProjectPermissionsFile>
     // Absent on every store written before this log existed — an empty array
     // is the honest answer there, not a reconstruction.
     grantAudit: Array.isArray(parsed.grantAudit) ? parsed.grantAudit : [],
+    repairAudit: Array.isArray(parsed.repairAudit) ? parsed.repairAudit : [],
   };
   materializeDueGrantProposals(file, new Date());
   return file;
@@ -805,6 +824,62 @@ export async function revokeAllGrantsForProject(
 
     if (grants > 0 || groupGrants > 0 || proposals > 0) await saveProjectPermissions(file);
     return { grants, groupGrants, proposals };
+  }));
+}
+
+function orphanProjectIntegrity(
+  file: Pick<ProjectPermissionsFile, "projectGrants" | "accessGroups" | "grantProposals">,
+  knownProjectIds: ReadonlySet<string>,
+): ProjectPermissionIntegrityReport {
+  const orphanIds = new Set<string>();
+  let directGrants = 0;
+  let groupGrants = 0;
+  let proposals = 0;
+  for (const grant of file.projectGrants) {
+    if (knownProjectIds.has(grant.projectId)) continue;
+    directGrants += 1;
+    orphanIds.add(grant.projectId);
+  }
+  for (const group of file.accessGroups) for (const grant of group.projectGrants) {
+    if (knownProjectIds.has(grant.projectId)) continue;
+    groupGrants += 1;
+    orphanIds.add(grant.projectId);
+  }
+  for (const proposal of file.grantProposals) {
+    if (knownProjectIds.has(proposal.projectId)) continue;
+    proposals += 1;
+    orphanIds.add(proposal.projectId);
+  }
+  return { directGrants, groupGrants, proposals, orphanProjectIds: [...orphanIds].sort() };
+}
+
+/** Read-only integrity check. It deliberately does not grant or prune anything. */
+export async function inspectProjectPermissionIntegrity(): Promise<ProjectPermissionIntegrityReport> {
+  const [projects, permissions] = await Promise.all([loadProjects(), loadProjectPermissions()]);
+  return orphanProjectIntegrity(permissions, new Set(projects.map((project) => project.id)));
+}
+
+/**
+ * Explicit human-invoked repair for legacy orphan grants. Removing records for
+ * projects absent from the registry can only reduce access; an audit record is
+ * persisted atomically with the cleanup, making retries after interruption
+ * idempotent and reviewable.
+ */
+export async function repairOrphanProjectPermissions(): Promise<ProjectPermissionIntegrityReport> {
+  const projects = await loadProjects();
+  const knownProjectIds = new Set(projects.map((project) => project.id));
+  return withProjectPermissionsStore(() => withWriteMutex(async () => {
+    const file = await loadProjectPermissionsUnlocked();
+    const report = orphanProjectIntegrity(file, knownProjectIds);
+    if (report.directGrants + report.groupGrants + report.proposals === 0) return report;
+    file.projectGrants = file.projectGrants.filter((grant) => knownProjectIds.has(grant.projectId));
+    for (const group of file.accessGroups) {
+      group.projectGrants = group.projectGrants.filter((grant) => knownProjectIds.has(grant.projectId));
+    }
+    file.grantProposals = file.grantProposals.filter((proposal) => knownProjectIds.has(proposal.projectId));
+    file.repairAudit.push({ at: new Date().toISOString(), kind: "orphan-project-repair", ...report });
+    await saveProjectPermissions(file);
+    return report;
   }));
 }
 

--- a/src/lib/queue-project-readiness.test.ts
+++ b/src/lib/queue-project-readiness.test.ts
@@ -101,7 +101,15 @@ try {
   // an error here exactly like the mutation adapter's 422, never as ready.
   await rm(path.join(projectRoot, ".beads"), { recursive: true, force: true });
   await mkdir(path.join(projectRoot, "beads-elsewhere"));
-  await symlink(path.join(projectRoot, "beads-elsewhere"), path.join(projectRoot, ".beads"), "dir");
+  // Windows directory symlinks require Developer Mode/elevation. A junction
+  // is the equivalent reparse-point attack shape for this containment guard
+  // and is creatable by an ordinary Windows user, so retain this security
+  // regression test on every supported host.
+  await symlink(
+    path.join(projectRoot, "beads-elsewhere"),
+    path.join(projectRoot, ".beads"),
+    process.platform === "win32" ? "junction" : "dir",
+  );
   const swapped = await queueProjectReadiness({
     beadsProbe: async () => ({ ok: true, stdout: "[]", stderr: "" }),
   });

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -218,6 +218,12 @@ export function runtimeProcessFailure(runner: DirectRunnerId | CovenBackedRunner
   code: typeof RUNTIME_AVAILABILITY_ERROR_CODES.process_failed;
   message: string;
 } {
+  if (runner === "grok") {
+    return {
+      code: RUNTIME_AVAILABILITY_ERROR_CODES.process_failed,
+      message: "Grok Build exited before returning a response. Complete its interactive sign-in by running `grok` in a terminal, then retry.",
+    };
+  }
   const label = runner === "hermes" ? "Hermes" : RUNNER_LABELS[runner];
   return {
     code: RUNTIME_AVAILABILITY_ERROR_CODES.process_failed,

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -214,7 +214,7 @@ export function localRuntimeLaunchError(
 /** A process that did start but exited unsuccessfully is distinct from a
  * missing or unlaunchable CLI. Its copy is safe to surface without provider
  * output, executable paths, or scoped environment values. */
-export function runtimeProcessFailure(runner: DirectRunnerId): {
+export function runtimeProcessFailure(runner: DirectRunnerId | CovenBackedRunnerId): {
   code: typeof RUNTIME_AVAILABILITY_ERROR_CODES.process_failed;
   message: string;
 } {


### PR DESCRIPTION
Supersedes external PR #4006 solely because GitHub does not attach the required `CodeQL` check-run to the external-fork head, despite successful workflows. This branch is the exact audited current external head (`6adc3d9`).

## Included work
- project-gated chat/runtime launch hardening and bounded daemon readiness
- sanitized diagnostics, explicit failure states, and orphaned-permission repair
- the direct Node daemon-start import fix (`c7e183d`) verified in the focused regression

## Attribution
Preserve the original contributor credit for Timothy Wayne Gregg (`CompleteDotTech`, GitHub id 5861166) in the squash commit.

## Evidence
The external head already passed every CI job and CodeQL workflow; this internal transport exists only to obtain the protected CodeQL check context. Focused `daemon-start.test.ts` passes 9/9; `git diff --check` passes.