### PR TITLE
test(models): wait for the kill escalation instead of sleeping past it

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1016,6 +1016,7 @@ export const SUITES = {
     "src/lib/server/cave-home-migration-status.test.ts",
     "src/lib/server/cave-home-migration-discard-guard.test.ts",
     "src/lib/server/cave-home-migration-fast-path.test.ts",
+    "src/lib/testing/wait-for.test.ts",
     "src/lib/server/claude-models.test.ts",
     "src/lib/server/copilot-models.test.ts",
     "src/lib/server/runtime-model-options.test.ts",

--- a/src/lib/server/claude-models.test.ts
+++ b/src/lib/server/claude-models.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "../testing/wait-for.ts";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
@@ -191,7 +192,14 @@ const timedOut = await listClaudeModels("sage", {
   forceKillGraceMs: 5,
 });
 assert.ok(!timedOut.some((model) => model.id === "anthropic/claude-opus-5"));
-await new Promise((resolve) => setTimeout(resolve, 15));
+// The escalation is what's under test — SIGTERM, then SIGKILL once the grace
+// timer expires — not how promptly this host's event loop delivers two 5ms
+// timers. Sleeping a fixed 15ms here left ~2ms of headroom at p99 on an IDLE
+// machine (measured: p50 11.4ms, p99 13.0ms, max 15.5ms), so it failed
+// outright under load. Wait for the signals themselves (cave-2nhfe).
+await waitFor(() => timeoutSignals.length >= 2, {
+  describe: "the probe timeout to escalate SIGTERM to SIGKILL",
+});
 assert.deepEqual(timeoutSignals, ["SIGTERM", "SIGKILL"]);
 
 clearClaudeModelCache();

--- a/src/lib/server/copilot-models.test.ts
+++ b/src/lib/server/copilot-models.test.ts
@@ -1,3 +1,4 @@
+import { waitFor } from "../testing/wait-for.ts";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { PassThrough } from "node:stream";
@@ -313,7 +314,14 @@ const timedOut = await listCopilotModels("sage", {
   forceKillGraceMs: 5,
 });
 assert.deepEqual(timedOut, []);
-await new Promise((resolve) => setTimeout(resolve, 15));
+// The escalation is what's under test — SIGTERM, then SIGKILL once the grace
+// timer expires — not how promptly this host's event loop delivers two 5ms
+// timers. Sleeping a fixed 15ms here left ~2ms of headroom at p99 on an IDLE
+// machine (measured: p50 11.4ms, p99 13.0ms, max 15.5ms), so it failed
+// outright under load. Wait for the signals themselves (cave-2nhfe).
+await waitFor(() => timeoutSignals.length >= 2, {
+  describe: "the probe timeout to escalate SIGTERM to SIGKILL",
+});
 assert.deepEqual(timeoutSignals, ["SIGTERM", "SIGKILL"]);
 
 clearCopilotModelCache();

--- a/src/lib/testing/wait-for.test.ts
+++ b/src/lib/testing/wait-for.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+// The point of waitFor is that it removes a race WITHOUT removing the
+// assertion: it must still fail when the awaited thing never happens.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { waitFor } from "./wait-for.ts";
+
+test("returns immediately when the condition already holds", async () => {
+  const started = Date.now();
+  await waitFor(() => true, { timeoutMs: 1000 });
+  assert.ok(Date.now() - started < 50, "an already-satisfied wait costs no wall clock");
+});
+
+test("resolves once the condition becomes true", async () => {
+  let ready = false;
+  setTimeout(() => {
+    ready = true;
+  }, 30);
+  await waitFor(() => ready, { timeoutMs: 2000, intervalMs: 2 });
+  assert.equal(ready, true);
+});
+
+test("still fails when the condition never holds — the assertion is not weakened", async () => {
+  await assert.rejects(
+    () => waitFor(() => false, { timeoutMs: 30, intervalMs: 5, describe: "a thing that never happens" }),
+    /timed out after 30ms waiting for a thing that never happens/,
+  );
+});
+
+test("accepts an async condition", async () => {
+  let hits = 0;
+  await waitFor(async () => ++hits >= 3, { timeoutMs: 1000, intervalMs: 1 });
+  assert.equal(hits, 3);
+});
+
+test("a slow condition does not fail early — the ceiling is wall clock, not attempts", async () => {
+  const started = Date.now();
+  let ready = false;
+  setTimeout(() => {
+    ready = true;
+  }, 60);
+  await waitFor(() => ready, { timeoutMs: 2000, intervalMs: 10 });
+  assert.ok(Date.now() - started >= 55, "waited for the real event rather than a guess");
+});

--- a/src/lib/testing/wait-for.ts
+++ b/src/lib/testing/wait-for.ts
@@ -1,0 +1,40 @@
+// Test-side wait: poll for a condition instead of sleeping a guessed interval.
+//
+// A `await new Promise(r => setTimeout(r, 15))` before an assertion says "the
+// work should be done by now" — which is a bet on the host's event loop, not a
+// statement about the code. It fails on a busy machine and reads as a bare
+// value mismatch, with nothing pointing at the deadline that actually lost.
+// (See PR #4015: a launcher test inherited a 2.5s UI budget as a correctness
+// assertion and failed intermittently for months' worth of runs.)
+//
+// Polling flips the trade: a fast machine proceeds the moment the condition
+// holds, a slow one gets as long as it needs, and a genuine regression still
+// fails — at the ceiling, with a message naming what was awaited.
+
+export type WaitForOptions = {
+  /** Upper bound before giving up. Generous by design: it exists to fail a
+   *  real regression, not to police latency. */
+  timeoutMs?: number;
+  /** Gap between checks. Small enough to keep fast paths fast. */
+  intervalMs?: number;
+  /** What we were waiting for, quoted in the timeout error. */
+  describe?: string;
+};
+
+/** Resolve once `condition()` returns truthy; reject at the ceiling.
+ *
+ *  The condition is checked immediately, so an already-satisfied wait costs
+ *  nothing and the common case adds no wall-clock time to the suite. */
+export async function waitFor(
+  condition: () => boolean | Promise<boolean>,
+  { timeoutMs = 2000, intervalMs = 5, describe = "condition" }: WaitForOptions = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (await condition()) return;
+    if (Date.now() >= deadline) {
+      throw new Error(`waitFor: timed out after ${timeoutMs}ms waiting for ${describe}`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}


### PR DESCRIPTION
Follow-up to #4015, fixing the same *class* of hazard found by scanning for it. Closes `cave-2nhfe`.

`claude-models.test.ts` and `copilot-models.test.ts` both configured a probe with `timeoutMs: 5` + `forceKillGraceMs: 5`, slept a fixed **15 ms**, then asserted the signal log equalled `[SIGTERM, SIGKILL]`. That's a bet on the host's event loop, not a statement about the code.

## The margin, measured

That exact 5 ms + 5 ms chain, 400 samples, **idle** machine:

```
p50 11.42ms   p95 11.93ms   p99 12.97ms   max 15.49ms
0.3% of samples already exceed the 15ms budget — ~2ms headroom at p99
```

Under a build or a second session that stops being rare, and it fails the way the launcher flake did: a bare `deepEqual` mismatch with nothing indicating a *deadline* rather than the logic lost.

Neither reproduced in 20 idle runs or 24 8-way-concurrent runs — which is exactly what a ~0.3% base rate looks like. **The absence of a repro was sample size, not health**; the measurement is the evidence.

## The fix

Both now poll for the signals with a 2 s ceiling, via a new shared helper `src/lib/testing/wait-for.ts`. A fast machine proceeds the moment the escalation lands; a slow one gets the time it needs.

**This removes a race, not an assertion** — verified by mutation. With `child.kill("SIGKILL")` removed from `claude-models.ts`:

```
Error: waitFor: timed out after 2000ms waiting for
       the probe timeout to escalate SIGTERM to SIGKILL
```

The regression is still caught, and the failure now names what it was waiting for. The helper carries its own tests, including one pinning that a never-satisfied condition still rejects.

| Gate | Result |
|---|---|
| `pnpm test:app` | 970 files pass |
| `typecheck` · `lint` · `check:tests-wired` | pass |

Also surveyed and found **clean**: all 12 tests touching `$HOME` override it to a temp dir; zero `networkidle` in Playwright specs; "network" and "port" grep hits were string fixtures. Left as watch-only: `chunk-coalescer.test.ts` (same shape, 5× headroom) and `hermes-shim.test.ts` (real `bash`, generous 5 s budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)