### PR TITLE
feat(chat): read a reply aloud from the assistant hover actions

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1191,6 +1191,7 @@ export const SUITES = {
     "src/lib/voice/local-loop.test.ts",
     "src/lib/voice/local-tts-server.test.ts",
     "src/lib/voice/local-tts.test.ts",
+    "src/lib/voice/speak-message.test.ts",
     "src/lib/voice/speech-loop.test.ts",
     "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -43,6 +43,7 @@ import { renderCitedBody } from "@/lib/citations";
 import { CitationSources } from "@/components/ui/citation";
 import { classifyDiffLines, parseFenceInfo, type DiffLine } from "@/lib/message-code-fences";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
+import { SpeakBubble } from "@/components/speak-bubble";
 import { copyText } from "@/lib/clipboard";
 import { sanitizeHtml } from "@/lib/html-sanitize";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -1081,6 +1082,9 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
           ) : null}
           <ExpandBubble text={content} label={label ?? "Familiar response"} />
           <CopyBubble text={content} />
+          {role === "assistant" ? (
+            <SpeakBubble text={content} familiarId={feedbackContext?.familiarId} />
+          ) : null}
           {messageId ? (
             <>
               <button

--- a/src/components/speak-bubble.tsx
+++ b/src/components/speak-bubble.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  resolveSpeechPlan,
+  speechRequestFor,
+  speechTextFor,
+  type FamiliarVoice,
+} from "@/lib/voice/speak-message";
+
+/**
+ * "Read this reply aloud" for the assistant bubble's hover action row.
+ *
+ * Speaks in the RESPONDING familiar's voice: voiceProvider/voiceName/voiceModel
+ * are per-familiar config, so a reply should sound like whoever wrote it. The
+ * familiar id rides in `feedbackContext`, which every MessageBubble call site
+ * already threads, so this needs no new prop plumbing.
+ */
+
+// Same shape as familiar-inline-card's cache and the same failure rule: a
+// FAILED load must not be cached for the app's lifetime, or one transient
+// error silently mutes every message until a reload.
+let voicesCache: Promise<Record<string, FamiliarVoice> | null> | null = null;
+function loadFamiliarVoices(): Promise<Record<string, FamiliarVoice> | null> {
+  if (!voicesCache) {
+    voicesCache = fetch("/api/familiars", { cache: "no-store" })
+      .then((r) => r.json())
+      .then((j) => {
+        if (!j?.ok || !Array.isArray(j.familiars)) throw new Error("familiars load failed");
+        const map: Record<string, FamiliarVoice> = {};
+        for (const f of j.familiars) {
+          map[f.id] = { provider: f.voiceProvider, name: f.voiceName, model: f.voiceModel };
+        }
+        return map;
+      })
+      .catch(() => {
+        voicesCache = null;
+        return null;
+      });
+  }
+  return voicesCache;
+}
+
+/**
+ * Only one message speaks at a time. Starting playback anywhere calls the
+ * previous message's stopper first, so clicking a second speaker doesn't leave
+ * two replies talking over each other.
+ */
+let activeStop: (() => void) | null = null;
+
+type SpeakState = "idle" | "loading" | "playing";
+
+export function SpeakBubble({ text, familiarId }: { text: string; familiarId?: string }) {
+  const [state, setState] = useState<SpeakState>("idle");
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlRef = useRef<string | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+  // Bumped on every stop so an in-flight synthesis that lands late can tell it
+  // has been superseded and must not start playing.
+  const genRef = useRef(0);
+
+  const teardown = () => {
+    genRef.current += 1;
+    abortRef.current?.abort();
+    abortRef.current = null;
+    if (audioRef.current) {
+      audioRef.current.pause();
+      audioRef.current = null;
+    }
+    if (urlRef.current) {
+      URL.revokeObjectURL(urlRef.current);
+      urlRef.current = null;
+    }
+    if (typeof window !== "undefined" && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
+  };
+
+  const stop = () => {
+    teardown();
+    if (activeStop === stop) activeStop = null;
+    setState("idle");
+  };
+
+  // Stop on unmount — a bubble scrolled out of a virtualized list should not
+  // keep talking.
+  useEffect(() => () => { teardown(); if (activeStop === stop) activeStop = null; }, []);
+
+  const speak = async () => {
+    activeStop?.();
+    activeStop = stop;
+    const gen = ++genRef.current;
+    setState("loading");
+
+    const spoken = speechTextFor(text);
+    if (!spoken) { stop(); return; }
+
+    const voices = familiarId ? await loadFamiliarVoices() : null;
+    if (gen !== genRef.current) return;
+    const plan = resolveSpeechPlan((familiarId && voices?.[familiarId]) || {});
+    const request = speechRequestFor(plan, spoken);
+
+    // No arbitrary-text route for this provider — the platform synthesizer
+    // speaks it locally instead.
+    if (!request) {
+      if (typeof window === "undefined" || !window.speechSynthesis) { stop(); return; }
+      const utterance = new SpeechSynthesisUtterance(spoken);
+      if (plan.engine === "system" && plan.voiceName) {
+        const match = window.speechSynthesis
+          .getVoices()
+          .find((v) => v.name.toLowerCase() === plan.voiceName!.toLowerCase());
+        if (match) utterance.voice = match;
+      }
+      utterance.onend = () => { if (gen === genRef.current) stop(); };
+      utterance.onerror = () => { if (gen === genRef.current) stop(); };
+      window.speechSynthesis.cancel();
+      window.speechSynthesis.speak(utterance);
+      setState("playing");
+      return;
+    }
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+    try {
+      // fetch (not a bare <audio src>) because the request carries the sidecar
+      // auth token.
+      const res = await fetch(request.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(request.body),
+        signal: controller.signal,
+      });
+      if (gen !== genRef.current) return;
+      if (!res.ok || !(res.headers.get("content-type") ?? "").includes("audio/")) {
+        stop();
+        return;
+      }
+      const blob = await res.blob();
+      if (gen !== genRef.current) return;
+      const url = URL.createObjectURL(blob);
+      urlRef.current = url;
+      const audio = new Audio(url);
+      audioRef.current = audio;
+      audio.onended = () => { if (gen === genRef.current) stop(); };
+      audio.onerror = () => { if (gen === genRef.current) stop(); };
+      await audio.play();
+      if (gen !== genRef.current) return;
+      setState("playing");
+    } catch {
+      // Aborts land here too; a superseded generation must not clear the new one.
+      if (gen === genRef.current) stop();
+    }
+  };
+
+  const busy = state !== "idle";
+  return (
+    <button
+      type="button"
+      aria-label={busy ? "Stop reading response" : "Read response aloud"}
+      title={busy ? "Stop" : "Read aloud"}
+      aria-pressed={busy}
+      onClick={() => (busy ? stop() : void speak())}
+      className="cave-copy-btn cave-copy-btn-bubble cave-copy-btn--icon"
+    >
+      {/* Names come from the curated ICON_NAMES union — `ph:speaker-high-fill`
+          is the only speaker glyph carried in the subset, so the idle state
+          uses the fill variant rather than growing the catalogue. */}
+      <Icon
+        name={
+          state === "playing"
+            ? "ph:stop-fill"
+            : state === "loading"
+              ? "ph:circle-notch-bold"
+              : "ph:speaker-high-fill"
+        }
+        width={13}
+        aria-hidden
+      />
+    </button>
+  );
+}

--- a/src/lib/voice/speak-message.test.ts
+++ b/src/lib/voice/speak-message.test.ts
@@ -1,0 +1,138 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  resolveSpeechPlan,
+  speechRequestFor,
+  speechTextFor,
+  stripMarkdownForSpeech,
+  SPEAK_MAX_CHARS,
+} from "./speak-message.ts";
+
+// ── Engine selection ────────────────────────────────────────────────────────
+// Only /api/voice/local/tts and /api/voice/elevenlabs/tts accept arbitrary
+// text; /api/voice/preview returns a canned sample, so it can never voice a
+// reply. Everything else must land on the platform synthesizer.
+
+assert.deepEqual(
+  resolveSpeechPlan({ provider: "local", name: "piper-amy-medium-en-us" }),
+  { engine: "local", voiceName: "piper-amy-medium-en-us" },
+  "a local provider with a known Piper voice uses the local neural route",
+);
+assert.deepEqual(
+  resolveSpeechPlan({ provider: "familiar", name: "piper-amy-medium-en-us" }),
+  { engine: "local", voiceName: "piper-amy-medium-en-us" },
+  "'familiar' is the studio's other spelling of the local provider",
+);
+assert.equal(
+  resolveSpeechPlan({ provider: "local", name: "Samantha" }).engine,
+  "system",
+  "a local provider pointed at a system voice is NOT a neural voice",
+);
+assert.deepEqual(
+  resolveSpeechPlan({ provider: "elevenlabs", name: "voice-1", model: "model-1" }),
+  { engine: "elevenlabs", voiceId: "voice-1", modelId: "model-1" },
+  "elevenlabs carries both the voice and the model",
+);
+assert.deepEqual(
+  resolveSpeechPlan({ provider: "elevenlabs", name: "voice-1" }),
+  { engine: "elevenlabs", voiceId: "voice-1" },
+  "an absent model is omitted rather than sent empty",
+);
+assert.equal(
+  resolveSpeechPlan({ provider: "openai", name: "alloy" }).engine,
+  "system",
+  "openai has no arbitrary-text route, so a reply falls back to the platform voice",
+);
+assert.deepEqual(resolveSpeechPlan({}), { engine: "system" }, "no config at all still speaks");
+assert.equal(
+  resolveSpeechPlan({ provider: "elevenlabs" }).engine,
+  "system",
+  "elevenlabs without a voice id cannot be called — fall back rather than POST a broken body",
+);
+assert.equal(
+  resolveSpeechPlan({ provider: "  LOCAL  ", name: "piper-amy-medium-en-us" }).engine,
+  "local",
+  "provider matching is case- and whitespace-insensitive",
+);
+
+// ── Request shape ───────────────────────────────────────────────────────────
+assert.deepEqual(
+  speechRequestFor({ engine: "local", voiceName: "piper-amy-medium-en-us" }, "hi"),
+  { url: "/api/voice/local/tts", body: { text: "hi", voiceName: "piper-amy-medium-en-us" } },
+  "the local route takes text + voiceName",
+);
+assert.deepEqual(
+  speechRequestFor({ engine: "elevenlabs", voiceId: "v", modelId: "m" }, "hi"),
+  { url: "/api/voice/elevenlabs/tts", body: { text: "hi", voiceId: "v", modelId: "m" } },
+  "the elevenlabs route takes text + voiceId + modelId",
+);
+assert.equal(
+  speechRequestFor({ engine: "system" }, "hi"),
+  null,
+  "the system engine has no request — null tells the caller to use speechSynthesis",
+);
+
+// ── Markdown is unlistenable ────────────────────────────────────────────────
+assert.equal(
+  stripMarkdownForSpeech("Here is `code` and **bold** and _soft_ text."),
+  "Here is code and bold and soft text.",
+  "inline markers are dropped but their words survive",
+);
+assert.match(
+  stripMarkdownForSpeech("Before\n```js\nconst a = 1;\n```\nAfter"),
+  /Before\n\(code block\)\nAfter/,
+  "a fenced block is announced, not read out line by line, with no stranded spaces",
+);
+assert.equal(
+  stripMarkdownForSpeech("See [the docs](https://example.com) now"),
+  "See the docs now",
+  "link text is spoken and the URL is not",
+);
+assert.equal(
+  stripMarkdownForSpeech("![alt text](img.png)Hello"),
+  "Hello",
+  "images contribute nothing spoken",
+);
+assert.equal(
+  stripMarkdownForSpeech("## Heading\n\n> quoted\n\n- one\n- two"),
+  "Heading\n\nquoted\n\none\ntwo",
+  "headings, quotes and bullets lose their punctuation",
+);
+assert.equal(
+  stripMarkdownForSpeech("A claim[^1]\n\n[^1]: https://example.com \"Title\""),
+  "A claim",
+  "citation markers and their definitions are not read aloud",
+);
+
+// ── Length cap ──────────────────────────────────────────────────────────────
+const long = `${"word ".repeat(2000)}. tail`;
+const capped = speechTextFor(long);
+assert.ok(capped.length <= SPEAK_MAX_CHARS, "output respects the cap");
+assert.equal(speechTextFor("short"), "short", "short replies pass through untouched");
+assert.equal(speechTextFor("   "), "", "whitespace-only yields nothing to speak");
+const sentences = `${"Sentence here. ".repeat(400)}`;
+assert.ok(
+  speechTextFor(sentences).endsWith("."),
+  "when a sentence boundary is near the cap, playback stops on it rather than mid-word",
+);
+
+// ── Wiring: the control is in the assistant hover row ───────────────────────
+const bubble = await readFile(new URL("../../components/message-bubble.tsx", import.meta.url), "utf8");
+const speak = await readFile(new URL("../../components/speak-bubble.tsx", import.meta.url), "utf8");
+
+assert.match(
+  bubble,
+  /role === "assistant" \? \(\s*<SpeakBubble text=\{content\} familiarId=\{feedbackContext\?\.familiarId\}/,
+  "only assistant replies get a speaker, and it reads the familiar from feedbackContext",
+);
+assert.match(speak, /aria-label=\{busy \? "Stop reading response" : "Read response aloud"\}/, "the control names both of its states");
+assert.match(speak, /state === "playing"\s*\?\s*"ph:stop-fill"/, "playing shows a stop affordance");
+assert.match(speak, /"ph:speaker-high-fill"/, "idle shows the audio icon");
+assert.match(speak, /let activeStop: \(\(\) => void\) \| null = null;/, "only one message speaks at a time");
+assert.match(speak, /activeStop\?\.\(\);/, "starting playback stops whatever was already speaking");
+assert.match(speak, /useEffect\(\(\) => \(\) => \{ teardown\(\);/, "unmounting a bubble stops its audio");
+assert.match(speak, /URL\.revokeObjectURL/, "blob urls are revoked rather than leaked");
+assert.match(speak, /voicesCache = null;/, "a failed familiars load is not cached for the app's lifetime");
+assert.match(speak, /gen !== genRef\.current/, "a superseded synthesis never starts playing");
+
+console.log("speak-message guard passed");

--- a/src/lib/voice/speak-message.ts
+++ b/src/lib/voice/speak-message.ts
@@ -1,0 +1,128 @@
+import { isLocalTtsVoiceName } from "./local-tts.ts";
+
+/**
+ * Speaking a chat reply out loud.
+ *
+ * The familiar studio's voice preview (familiar-studio-brain-tab) already picks
+ * an engine and plays a blob, but it only ever synthesizes ONE fixed sample
+ * sentence. Reading a real reply has a constraint that preview doesn't: the
+ * engine has to accept arbitrary text. Only two of our routes do —
+ * `/api/voice/local/tts` and `/api/voice/elevenlabs/tts`. `/api/voice/preview`
+ * returns a canned sample and cannot voice a message, so every other provider
+ * (openai, or nothing configured) falls back to the browser's own synthesizer,
+ * which speaks arbitrary text with no network and no key.
+ */
+
+/** Longest reply we'll synthesize in one go. */
+export const SPEAK_MAX_CHARS = 4_000;
+
+export type FamiliarVoice = {
+  provider?: string | null;
+  name?: string | null;
+  model?: string | null;
+};
+
+export type SpeechPlan =
+  | { engine: "local"; voiceName: string }
+  | { engine: "elevenlabs"; voiceId: string; modelId?: string }
+  | { engine: "system"; voiceName?: string };
+
+/**
+ * `local` and `familiar` both mean "this machine's neural voice" — the studio
+ * treats them interchangeably, so we match that rather than inventing a third
+ * spelling. A local provider whose voice name isn't a known Piper voice means
+ * the familiar is pointed at a system voice, not a neural one.
+ */
+export function resolveSpeechPlan(voice: FamiliarVoice): SpeechPlan {
+  const provider = (voice.provider ?? "").trim().toLowerCase();
+  const name = (voice.name ?? "").trim();
+  const model = (voice.model ?? "").trim();
+
+  if ((provider === "local" || provider === "familiar") && isLocalTtsVoiceName(name)) {
+    return { engine: "local", voiceName: name };
+  }
+  if (provider === "elevenlabs" && name) {
+    return model ? { engine: "elevenlabs", voiceId: name, modelId: model } : { engine: "elevenlabs", voiceId: name };
+  }
+  // openai has no arbitrary-text route, and an unset provider has nothing to
+  // call — both land on the platform synthesizer.
+  return name && provider !== "elevenlabs" ? { engine: "system", voiceName: name } : { engine: "system" };
+}
+
+/** The POST a plan turns into, or null for the system synthesizer. */
+export function speechRequestFor(
+  plan: SpeechPlan,
+  text: string,
+): { url: string; body: Record<string, string> } | null {
+  if (plan.engine === "local") {
+    return { url: "/api/voice/local/tts", body: { text, voiceName: plan.voiceName } };
+  }
+  if (plan.engine === "elevenlabs") {
+    return {
+      url: "/api/voice/elevenlabs/tts",
+      body: plan.modelId
+        ? { text, voiceId: plan.voiceId, modelId: plan.modelId }
+        : { text, voiceId: plan.voiceId },
+    };
+  }
+  return null;
+}
+
+/**
+ * Markdown read aloud is unlistenable — fences become "backtick backtick
+ * backtick", link syntax becomes punctuation soup. Strip to prose and drop the
+ * parts that carry no spoken meaning. Code blocks are announced rather than
+ * read: hearing a whole function is worse than hearing that one is there.
+ */
+export function stripMarkdownForSpeech(raw: string): string {
+  let text = raw;
+
+  // Fenced code → a short spoken placeholder.
+  text = text.replace(/```[\s\S]*?```/g, " (code block) ");
+  text = text.replace(/~~~[\s\S]*?~~~/g, " (code block) ");
+
+  // Citation footnote definitions and markers (see renderCitedBody).
+  text = text.replace(/^\[\^[^\]]+\]:.*$/gm, "");
+  text = text.replace(/\[\^([^\]]+)\]/g, "");
+
+  // Images before links, so alt text doesn't survive as a bare word.
+  text = text.replace(/!\[[^\]]*\]\([^)]*\)/g, " ");
+  text = text.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Inline code, emphasis, strikethrough — keep the words, drop the markers.
+  text = text.replace(/`([^`]+)`/g, "$1");
+  text = text.replace(/(\*\*|__)(.*?)\1/g, "$2");
+  text = text.replace(/(\*|_)(.*?)\1/g, "$2");
+  text = text.replace(/~~(.*?)~~/g, "$1");
+
+  // Headings, quotes, list bullets, horizontal rules, table pipes. These use
+  // [ \t] rather than \s for the indent and trailing gap: \s matches newlines,
+  // so `\s{0,3}` at a line start would reach back over a preceding blank line
+  // and delete it, silently welding two paragraphs together.
+  text = text.replace(/^[ \t]{0,3}#{1,6}[ \t]+/gm, "");
+  text = text.replace(/^[ \t]{0,3}>[ \t]?/gm, "");
+  text = text.replace(/^[ \t]{0,3}[-*+][ \t]+/gm, "");
+  text = text.replace(/^[ \t]{0,3}\d+\.[ \t]+/gm, "");
+  text = text.replace(/^[ \t]{0,3}([-*_][ \t]*){3,}$/gm, " ");
+  text = text.replace(/\|/g, " ");
+
+  // Collapse the whitespace all of the above leaves behind, including the
+  // spaces stranded at line edges when a block was replaced or a marker cut.
+  text = text.replace(/[ \t]+/g, " ");
+  text = text.replace(/[ \t]+\n/g, "\n");
+  text = text.replace(/\n[ \t]+/g, "\n");
+  text = text.replace(/\n{3,}/g, "\n\n");
+
+  return text.trim();
+}
+
+/** Prepare a reply for synthesis: strip markdown, then cap the length. */
+export function speechTextFor(raw: string, maxChars = SPEAK_MAX_CHARS): string {
+  const stripped = stripMarkdownForSpeech(raw);
+  if (stripped.length <= maxChars) return stripped;
+  // Cut on a sentence boundary when one is near the cap, so playback doesn't
+  // stop mid-word.
+  const head = stripped.slice(0, maxChars);
+  const lastStop = Math.max(head.lastIndexOf(". "), head.lastIndexOf("\n"));
+  return (lastStop > maxChars * 0.6 ? head.slice(0, lastStop + 1) : head).trim();
+}


### PR DESCRIPTION
## What

Assistant bubbles now carry a speaker icon in the hover action row, beside Reply / Regenerate / Copy. Clicking reads the reply aloud; clicking again stops.

Chat had **no** TTS affordance before this — the voice stack (`/api/voice/local/tts`, `/api/voice/elevenlabs/tts`, `src/lib/voice/*`) was only reachable from the familiar studio's voice preview and the live-call overlay.

## It speaks in the responding familiar's voice

`voiceProvider` / `voiceName` / `voiceModel` are **per-familiar** config, so a reply should sound like whoever wrote it. The familiar id already rides in `feedbackContext`, which every `MessageBubble` call site threads, so this needed no new prop plumbing.

## Engine selection is narrower than the studio's

Only `/api/voice/local/tts` and `/api/voice/elevenlabs/tts` accept **arbitrary text**. `/api/voice/preview` returns a canned sample and can never voice a message — so the studio's preview logic doesn't transfer directly. `resolveSpeechPlan` therefore routes:

| familiar voice | engine |
|---|---|
| `local`/`familiar` + a Piper/Kokoro voice id | `/api/voice/local/tts` |
| `elevenlabs` + a voice id | `/api/voice/elevenlabs/tts` |
| `openai`, or nothing configured | browser `speechSynthesis` |

That fallback is deliberate: it speaks arbitrary text with no network and no key, so the control is useful for everyone rather than dark for anyone who hasn't set a voice up.

## Markdown is stripped before synthesis

Read literally, markdown is unlistenable. Fenced blocks become a spoken `(code block)` rather than being read line by line; links keep their text and drop the URL; citations, headings, quotes and bullets lose their punctuation.

**Two bugs surfaced while testing that**, both fixed here:
- `^\s{0,3}` line-prefix rules — `\s` matches newlines, so a bullet after a blank line reached back and deleted that blank line, welding two paragraphs together. Now `[ \t]`.
- Block replacement stranded spaces at line edges (`"Before\n (code block) \nAfter"`).

## Robustness

Only one message speaks at a time (starting playback stops whatever was speaking); playback stops on unmount so a bubble scrolled out of a virtualized list doesn't keep talking; blob URLs are revoked; a superseded synthesis that lands late never starts playing; a failed familiars load isn't cached for the app's lifetime (the `cave-2ex2` rule from `familiar-inline-card`).

## Icons

From the curated `ICON_NAMES` union. `ph:speaker-high-fill` is the only speaker glyph in the subset, so idle uses the fill variant rather than growing the catalogue — `icon.tsx` calls adding a name "a deliberate review point". Happy to add `ph:speaker-high` (non-fill) if you'd rather the idle state matched the row's outline icons.

## Verification

Exit codes captured unpiped:

- `pnpm typecheck` — 0
- `pnpm lint` (codemod drift-check + eslint) — 0, 0 files with drift
- `pnpm check:tests-wired` — 0, 1330 files wired
- `pnpm test:app` — 0, **970 test files passed**

`src/lib/voice/speak-message.test.ts` (new, wired into `run-tests.mjs`) covers engine selection, request shape, markdown stripping, the length cap, and source-pins the wiring.

**Not yet driven in the real app** — the audio path (blob playback, stop-on-second-click, one-at-a-time) is only covered by source pins so far. Worth a listen before merge.

Closes `cave-eju5k`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)