### PR TITLE
feat(ios): add live voice transport foundation

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/Models.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Models.swift
@@ -17,6 +17,11 @@ struct Familiar: Identifiable, Codable, Hashable {
     var avatarUrl: String?
     var activeSessions: Int?
     var memoryFreshness: String?
+    /// Voice configuration published by Familiar Studio. All three remain
+    /// optional so phones can decode familiars created before voice support.
+    var voiceProvider: String? = nil
+    var voiceModel: String? = nil
+    var voiceName: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case id
@@ -25,6 +30,7 @@ struct Familiar: Identifiable, Codable, Hashable {
         case avatarUrl
         case activeSessions = "active_sessions"
         case memoryFreshness = "memory_freshness"
+        case voiceProvider, voiceModel, voiceName
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -16,6 +16,73 @@ protocol CaveBootstrapClient: Sendable {
 /// is required for the Tailscale app path because it exposes the full API.
 struct CaveClient {
     var connection: CaveConnection
+    private let injectedSession: URLSession?
+
+    init(connection: CaveConnection, session: URLSession? = nil) {
+        self.connection = connection
+        self.injectedSession = session
+    }
+
+    /// `POST /api/voice/session` request. The desktop resolves the familiar's
+    /// provider and mints any provider credential server-side.
+    struct VoiceSessionRequest: Codable, Sendable {
+        var familiarId: String
+        var sessionId: String
+    }
+
+    /// A prior conversation turn supplied by provider grants that need local
+    /// context to continue the call.
+    struct VoiceSessionSeedTurn: Codable, Sendable {
+        var role: String
+        var content: String
+    }
+
+    /// Provider-specific connection details. Known fields stay explicit while
+    /// optional metadata lets later transports select their own connection
+    /// path without teaching this client about provider secrets.
+    struct VoiceSessionConnection: Codable, Sendable {
+        var kind: String
+        var url: String?
+        var model: String?
+        var voice: String?
+        var familiarId: String?
+        var sessionId: String?
+        var voiceId: String?
+        var modelId: String?
+        var instructions: String?
+        var conversationSeed: [VoiceSessionSeedTurn]?
+    }
+
+    /// A short-lived server-minted grant. This contains an ephemeral client
+    /// secret when one is needed; it is never the desktop's OPENAI_API_KEY.
+    struct VoiceSessionGrant: Codable, Sendable {
+        var provider: String
+        var clientSecret: String
+        var expiresAt: String
+        var connection: VoiceSessionConnection
+    }
+
+    /// Wire response from `POST /api/voice/session`.
+    struct VoiceSessionResponse: Codable, Sendable {
+        var ok: Bool
+        var grant: VoiceSessionGrant?
+        var callId: String?
+        var error: String?
+    }
+
+    private struct VoiceSessionErrorEnvelope: Decodable {
+        var error: String?
+        var hint: String?
+        var missingKey: String?
+        var providerMessage: String?
+
+        var message: String? {
+            guard let error, !error.isEmpty else { return nil }
+            let detail = hint ?? providerMessage
+                ?? missingKey.map { "Missing \($0)." }
+            return detail.map { "\(error): \($0)" } ?? error
+        }
+    }
 
     private var base: URL {
         get throws {
@@ -57,6 +124,7 @@ struct CaveClient {
         let retryDelays: [Duration] = ["GET", "HEAD"].contains(method)
             ? [.milliseconds(350), .seconds(1)]
             : []
+        let session = injectedSession ?? self.session
         for attempt in 0...retryDelays.count {
             do {
                 return try await session.data(for: req)
@@ -163,6 +231,36 @@ struct CaveClient {
         guard let path = familiar.avatarUrl, let base = connection.baseURL else { return nil }
         if path.hasPrefix("http") { return URL(string: path) }
         return URL(string: path, relativeTo: base)?.absoluteURL
+    }
+
+    // MARK: - Voice
+
+    /// Mint a voice-call grant through Cave. The desktop keeps provider API
+    /// keys in its vault; iOS receives only the short-lived response grant.
+    func mintVoiceSession(familiarId: String, sessionId: String) async throws -> VoiceSessionResponse {
+        let payload = try JSONEncoder().encode(
+            VoiceSessionRequest(familiarId: familiarId, sessionId: sessionId)
+        )
+        let req = try request("api/voice/session", method: "POST", body: payload)
+        let (data, resp) = try await data(for: req)
+        if let http = resp as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
+            if let envelope = try? JSONDecoder().decode(VoiceSessionErrorEnvelope.self, from: data),
+               let message = envelope.message {
+                throw CaveError.transport(message)
+            }
+            try Self.check(resp)
+        }
+        let decoded: VoiceSessionResponse
+        do {
+            decoded = try JSONDecoder().decode(VoiceSessionResponse.self, from: data)
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
+        try Self.check(resp)
+        guard decoded.ok, decoded.grant != nil, decoded.callId != nil else {
+            throw CaveError.transport(decoded.error ?? "Voice session was not granted.")
+        }
+        return decoded
     }
 
     // MARK: - Marketplace

--- a/apps/ios/CovenCave/CovenCave/Voice/AppleVoiceTransport.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/AppleVoiceTransport.swift
@@ -1,0 +1,161 @@
+import AVFoundation
+import Speech
+
+/// The UI layer adapts its existing `ChatThread` stream to this small seam.
+/// Apple-native calls are intentionally turn-based: listen, recognize, send,
+/// then speak the completed response before listening again.
+@MainActor
+protocol VoiceTurnSending: AnyObject {
+    func sendRecognizedTurn(_ text: String, familiarId: String, sessionId: String) async throws -> VoiceTurnReply
+}
+
+struct VoiceTurnReply: Sendable {
+    let segmentID: String
+    let text: String
+}
+
+@MainActor
+final class AppleVoiceTransport: NSObject, VoiceCallTransport, AVSpeechSynthesizerDelegate {
+    var onEvent: (@MainActor (VoiceCallEvent) -> Void)?
+
+    private let recognizer: SFSpeechRecognizer?
+    private let audioEngine = AVAudioEngine()
+    private let synthesizer = AVSpeechSynthesizer()
+    private let turnSender: VoiceTurnSending
+    private var request: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private var responseTask: Task<Void, Never>?
+    private var context: VoiceCallTransportContext?
+    private var active = false
+    private var listening = false
+    private var muted = false
+    private var userRevision = 0
+    private var userSegmentID = ""
+
+    init(turnSender: VoiceTurnSending, recognizer: SFSpeechRecognizer? = SFSpeechRecognizer()) {
+        self.turnSender = turnSender
+        self.recognizer = recognizer
+        super.init()
+        synthesizer.delegate = self
+    }
+
+    func start(with context: VoiceCallTransportContext) async throws {
+        guard !active else { return }
+        self.context = context
+        active = true
+        onEvent?(.connected)
+        beginListening()
+    }
+
+    func setMuted(_ muted: Bool) {
+        self.muted = muted
+        if muted { stopRecognition() }
+        else if active, !synthesizer.isSpeaking { beginListening() }
+    }
+
+    func stop() {
+        guard active else { return }
+        active = false
+        responseTask?.cancel()
+        responseTask = nil
+        stopRecognition()
+        synthesizer.stopSpeaking(at: .immediate)
+        context = nil
+    }
+
+    private func beginListening() {
+        guard active, !muted, !listening, let recognizer, recognizer.isAvailable else {
+            if active, !muted { onEvent?(.failed("speech_recognizer_unavailable")) }
+            return
+        }
+        userRevision = 0
+        userSegmentID = UUID().uuidString
+        let request = SFSpeechAudioBufferRecognitionRequest()
+        request.shouldReportPartialResults = true
+        self.request = request
+        let node = audioEngine.inputNode
+        let format = node.outputFormat(forBus: 0)
+        node.installTap(onBus: 0, bufferSize: 1024, format: format) { [weak self] buffer, _ in
+            self?.request?.append(buffer)
+        }
+        audioEngine.prepare()
+        do {
+            try audioEngine.start()
+        } catch {
+            stopRecognition()
+            onEvent?(.failed("speech_audio_engine_failed"))
+            return
+        }
+        listening = true
+        onEvent?(.listening)
+        recognitionTask = recognizer.recognitionTask(with: request) { [weak self] result, error in
+            Task { @MainActor in self?.receiveRecognition(result: result, error: error) }
+        }
+    }
+
+    private func receiveRecognition(result: SFSpeechRecognitionResult?, error: Error?) {
+        guard active, listening else { return }
+        if let result {
+            let text = result.bestTranscription.formattedString
+            if !text.isEmpty {
+                userRevision += 1
+                onEvent?(.partial(role: .user, text: text, segmentID: userSegmentID, revision: userRevision))
+            }
+            if result.isFinal { completeRecognition(text) }
+        } else if error != nil {
+            stopRecognition()
+            onEvent?(.failed("speech_recognition_failed"))
+        }
+    }
+
+    private func completeRecognition(_ text: String) {
+        guard active else { return }
+        let prompt = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        stopRecognition()
+        guard !prompt.isEmpty, let context else {
+            if active { beginListening() }
+            return
+        }
+        onEvent?(.final(role: .user, text: prompt, segmentID: userSegmentID))
+        onEvent?(.processing)
+        responseTask = Task { [weak self, turnSender] in
+            do {
+                let reply = try await turnSender.sendRecognizedTurn(prompt, familiarId: context.familiarId, sessionId: context.sessionId)
+                guard !Task.isCancelled else { return }
+                self?.speak(reply)
+            } catch {
+                guard !Task.isCancelled else { return }
+                self?.reportSendFailure()
+            }
+        }
+    }
+
+    private func speak(_ reply: VoiceTurnReply) {
+        guard active, !reply.text.isEmpty else { return }
+        onEvent?(.final(role: .assistant, text: reply.text, segmentID: reply.segmentID))
+        onEvent?(.speaking)
+        synthesizer.speak(AVSpeechUtterance(string: reply.text))
+    }
+
+    private func reportSendFailure() {
+        guard active else { return }
+        onEvent?(.failed("voice_turn_send_failed"))
+    }
+
+    private func stopRecognition() {
+        guard listening || request != nil || recognitionTask != nil else { return }
+        audioEngine.stop()
+        audioEngine.inputNode.removeTap(onBus: 0)
+        request?.endAudio()
+        recognitionTask?.cancel()
+        request = nil
+        recognitionTask = nil
+        listening = false
+    }
+
+    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
+        Task { @MainActor [weak self] in self?.beginListening() }
+    }
+
+    nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didCancel utterance: AVSpeechUtterance) {}
+}

--- a/apps/ios/CovenCave/CovenCave/Voice/LiveVoiceCallState.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/LiveVoiceCallState.swift
@@ -1,0 +1,201 @@
+import Foundation
+
+/// The voice transport selected from a familiar's published voice metadata.
+enum VoiceCallMode: String, Equatable, Sendable {
+    case realtime
+    case native
+
+    static func forVoiceProvider(_ provider: String?) -> VoiceCallMode {
+        provider == "openai" ? .realtime : .native
+    }
+}
+
+/// Observable lifecycle for a live voice call. Terminal phases never accept
+/// transport callbacks again, so a stopped call cannot reactivate audio.
+enum VoiceCallPhase: Equatable, Sendable {
+    case idle
+    case requestingPermission
+    case connecting
+    case listening
+    case processing
+    case speaking
+    case error(String)
+    case ended
+
+    var isTerminal: Bool {
+        switch self {
+        case .error, .ended:
+            true
+        default:
+            false
+        }
+    }
+}
+
+enum VoiceTranscriptRole: String, Equatable, Sendable {
+    case user
+    case assistant
+}
+
+/// A stable transcript identity lets SwiftUI update a partial in place rather
+/// than replacing the surrounding reader content.
+struct VoiceTranscriptRow: Identifiable, Equatable, Sendable {
+    /// Stable UI identity derived from the transport's correlation key.
+    let id: String
+    /// Correlates retries and partial/final callbacks for one utterance.
+    let segmentID: String
+    let role: VoiceTranscriptRole
+    var text: String
+    var isFinal: Bool
+    /// Last accepted partial revision. Lower or equal revisions are stale.
+    var partialRevision: Int?
+
+    init(segmentID: String, role: VoiceTranscriptRole, text: String,
+         isFinal: Bool, partialRevision: Int? = nil) {
+        self.id = "\(role.rawValue)::\(segmentID)"
+        self.segmentID = segmentID
+        self.role = role
+        self.text = text
+        self.isFinal = isFinal
+        self.partialRevision = partialRevision
+    }
+}
+
+/// Intent originating from the call sheet. These commands remain independent
+/// from transport callbacks so either voice transport can use the same state.
+enum VoiceCallCommand: Equatable, Sendable {
+    case start
+    case setMuted(Bool)
+    case end
+    case setTranscriptExpanded(Bool)
+}
+
+/// Events emitted by a voice transport or permission coordinator.
+enum VoiceCallEvent: Equatable, Sendable {
+    case permissionGranted
+    case permissionDenied
+    case connected
+    case listening
+    case processing
+    case speaking
+    case partial(role: VoiceTranscriptRole, text: String, segmentID: String, revision: Int)
+    case final(role: VoiceTranscriptRole, text: String, segmentID: String)
+    case failed(String)
+}
+
+/// UI-independent call state shared by the Realtime and Apple-native paths.
+struct VoiceCallState: Equatable, Sendable {
+    let mode: VoiceCallMode
+    private(set) var phase: VoiceCallPhase = .idle
+    private(set) var isMuted = false
+    private(set) var isTranscriptExpanded = false
+    private(set) var transcript: [VoiceTranscriptRow] = []
+
+    init(mode: VoiceCallMode) {
+        self.mode = mode
+    }
+
+    var isAudioActive: Bool {
+        phase == .listening || phase == .speaking
+    }
+
+    var shouldCaptureAudio: Bool {
+        phase == .listening && !isMuted
+    }
+
+    var shouldPlayAudio: Bool {
+        phase == .speaking && !isMuted
+    }
+
+    mutating func send(_ command: VoiceCallCommand) {
+        switch command {
+        case .start where phase == .idle:
+            phase = .requestingPermission
+        case .setMuted(let muted) where !phase.isTerminal:
+            isMuted = muted
+        case .end where !phase.isTerminal:
+            isMuted = true
+            phase = .ended
+        case .setTranscriptExpanded(let expanded):
+            isTranscriptExpanded = expanded
+        default:
+            break
+        }
+    }
+
+    mutating func receive(_ event: VoiceCallEvent) {
+        guard !phase.isTerminal else { return }
+
+        switch event {
+        case .permissionGranted where phase == .requestingPermission:
+            phase = .connecting
+        case .permissionDenied where phase == .requestingPermission:
+            fail("microphone_denied")
+        case .connected where phase == .connecting:
+            phase = .listening
+        case .listening where phase == .connecting || phase == .processing || phase == .speaking:
+            phase = .listening
+        case .processing where phase == .listening:
+            phase = .processing
+        case .speaking where phase == .listening || phase == .processing:
+            phase = .speaking
+        case .partial(let role, let text, let segmentID, let revision) where acceptsTranscript:
+            upsertPartial(role: role, text: text, segmentID: segmentID, revision: revision)
+        case .final(let role, let text, let segmentID) where acceptsTranscript:
+            finalize(role: role, text: text, segmentID: segmentID)
+        case .failed(let message) where acceptsTransportFailure:
+            fail(message)
+        default:
+            break
+        }
+    }
+
+    private var acceptsTranscript: Bool {
+        phase == .listening || phase == .processing || phase == .speaking
+    }
+
+    private var acceptsTransportFailure: Bool {
+        phase == .requestingPermission || phase == .connecting || acceptsTranscript
+    }
+
+    private mutating func upsertPartial(role: VoiceTranscriptRole, text: String,
+                                        segmentID: String, revision: Int) {
+        guard !text.isEmpty, !segmentID.isEmpty else { return }
+
+        if let index = transcript.firstIndex(where: {
+            $0.role == role && $0.segmentID == segmentID
+        }) {
+            guard !transcript[index].isFinal else { return }
+            guard revision > (transcript[index].partialRevision ?? .min) else { return }
+            transcript[index].text = text
+            transcript[index].partialRevision = revision
+        } else {
+            transcript.append(VoiceTranscriptRow(
+                segmentID: segmentID, role: role, text: text, isFinal: false,
+                partialRevision: revision
+            ))
+        }
+    }
+
+    private mutating func finalize(role: VoiceTranscriptRole, text: String,
+                                   segmentID: String) {
+        guard !text.isEmpty, !segmentID.isEmpty else { return }
+
+        if let index = transcript.firstIndex(where: {
+            $0.role == role && $0.segmentID == segmentID
+        }) {
+            guard !transcript[index].isFinal else { return }
+            transcript[index].text = text
+            transcript[index].isFinal = true
+        } else {
+            transcript.append(VoiceTranscriptRow(
+                segmentID: segmentID, role: role, text: text, isFinal: true
+            ))
+        }
+    }
+
+    private mutating func fail(_ message: String) {
+        isMuted = true
+        phase = .error(message)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeEventDecoder.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeEventDecoder.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Decodes the transcript events currently sent over OpenAI Realtime's data
+/// channel. Revision is local, monotonic per provider item id, and is consumed
+/// by `VoiceCallState` to reject stale delivery after a reconnect.
+struct OpenAIRealtimeEventDecoder {
+    private var revisions: [String: Int] = [:]
+    private var partialTexts: [String: String] = [:]
+
+    mutating func decode(json: String) throws -> VoiceCallEvent? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try decode(data: data)
+    }
+
+    mutating func decode(data: Data) throws -> VoiceCallEvent? {
+        let event = try JSONDecoder().decode(Event.self, from: data)
+        guard let itemID = event.itemID, !itemID.isEmpty else { return nil }
+        switch event.type {
+        case "conversation.item.input_audio_transcription.delta":
+            return partial(role: .user, text: event.delta, itemID: itemID)
+        case "conversation.item.input_audio_transcription.completed":
+            return final(role: .user, text: event.transcript, itemID: itemID)
+        case "response.output_audio_transcript.delta":
+            return partial(role: .assistant, text: event.delta, itemID: itemID)
+        case "response.output_audio_transcript.done":
+            return final(role: .assistant, text: event.transcript, itemID: itemID)
+        default:
+            return nil
+        }
+    }
+
+    private mutating func partial(role: VoiceTranscriptRole, text: String?, itemID: String) -> VoiceCallEvent? {
+        guard let text, !text.isEmpty else { return nil }
+        let key = "\(role.rawValue)::\(itemID)"
+        let revision = (revisions[key] ?? 0) + 1
+        revisions[key] = revision
+        let accumulated = (partialTexts[key] ?? "") + text
+        partialTexts[key] = accumulated
+        return .partial(role: role, text: accumulated, segmentID: itemID, revision: revision)
+    }
+
+    private mutating func final(role: VoiceTranscriptRole, text: String?, itemID: String) -> VoiceCallEvent? {
+        guard let text, !text.isEmpty else { return nil }
+        let key = "\(role.rawValue)::\(itemID)"
+        partialTexts.removeValue(forKey: key)
+        revisions.removeValue(forKey: key)
+        return .final(role: role, text: text, segmentID: itemID)
+    }
+
+    private struct Event: Decodable {
+        let type: String
+        let itemID: String?
+        let delta: String?
+        let transcript: String?
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case itemID = "item_id"
+            case delta
+            case transcript
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
@@ -40,11 +40,11 @@ final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
 
     func start(with context: VoiceCallTransportContext) async throws {
         guard !stopped else { return }
-        guard let grant = context.grant,
-              grant.provider == "openai",
-              let endpoint = grant.connection.url,
-              let url = URL(string: endpoint) else {
+        guard let grant = context.grant, grant.provider == "openai" else {
             throw OpenAIRealtimeTransportError.missingGrant
+        }
+        guard let endpoint = grant.connection.url, let url = URL(string: endpoint) else {
+            throw OpenAIRealtimeTransportError.invalidConnectionURL
         }
 
         let configuration = RTCConfiguration()

--- a/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeTransport.swift
@@ -1,0 +1,170 @@
+import Foundation
+import WebRTC
+
+enum OpenAIRealtimeTransportError: LocalizedError {
+    case missingGrant
+    case invalidConnectionURL
+    case signalingFailed(Int)
+    case emptyAnswer
+
+    var errorDescription: String? {
+        switch self {
+        case .missingGrant: "realtime_grant_missing"
+        case .invalidConnectionURL: "realtime_connection_url_invalid"
+        case .signalingFailed(let status): "realtime_signaling_failed_\(status)"
+        case .emptyAnswer: "realtime_empty_sdp_answer"
+        }
+    }
+}
+
+/// Native OpenAI Realtime WebRTC transport. Signaling uses the provider URL
+/// and short-lived client secret returned by Cave's `/api/voice/session`; this
+/// class has no knowledge of, or path to, the desktop vault credential.
+@MainActor
+final class OpenAIRealtimeTransport: NSObject, VoiceCallTransport {
+    var onEvent: (@MainActor (VoiceCallEvent) -> Void)?
+
+    private let factory = RTCPeerConnectionFactory()
+    private let urlSession: URLSession
+    private var peerConnection: RTCPeerConnection?
+    private var dataChannel: RTCDataChannel?
+    private var localAudioSource: RTCAudioSource?
+    private var localAudioTrack: RTCAudioTrack?
+    private var decoder = OpenAIRealtimeEventDecoder()
+    private var stopped = false
+
+    init(urlSession: URLSession = .shared) {
+        self.urlSession = urlSession
+        super.init()
+    }
+
+    func start(with context: VoiceCallTransportContext) async throws {
+        guard !stopped else { return }
+        guard let grant = context.grant,
+              grant.provider == "openai",
+              let endpoint = grant.connection.url,
+              let url = URL(string: endpoint) else {
+            throw OpenAIRealtimeTransportError.missingGrant
+        }
+
+        let configuration = RTCConfiguration()
+        configuration.sdpSemantics = .unifiedPlan
+        let constraints = RTCMediaConstraints(mandatoryConstraints: nil,
+                                              optionalConstraints: ["DtlsSrtpKeyAgreement": "true"])
+        guard let connection = factory.peerConnection(with: configuration, constraints: constraints, delegate: self) else {
+            throw OpenAIRealtimeTransportError.emptyAnswer
+        }
+        peerConnection = connection
+
+        let source = factory.audioSource(with: constraints)
+        localAudioSource = source
+        let audioTrack = factory.audioTrack(with: source, trackId: "coven-microphone")
+        localAudioTrack = audioTrack
+        _ = connection.add(audioTrack, streamIds: ["coven-voice"])
+
+        let channel = connection.dataChannel(forLabel: "oai-events", configuration: RTCDataChannelConfiguration())
+        channel?.delegate = self
+        dataChannel = channel
+
+        let offer = try await createOffer(connection: connection, constraints: constraints)
+        try await setLocalDescription(offer, on: connection)
+        let answerSDP = try await sendOffer(offer.sdp, to: url, clientSecret: grant.clientSecret)
+        guard !answerSDP.isEmpty else { throw OpenAIRealtimeTransportError.emptyAnswer }
+        try await setRemoteDescription(RTCSessionDescription(type: .answer, sdp: answerSDP), on: connection)
+        guard !stopped else { return }
+        onEvent?(.connected)
+    }
+
+    func setMuted(_ muted: Bool) {
+        localAudioTrack?.isEnabled = !muted
+    }
+
+    func stop() {
+        guard !stopped else { return }
+        stopped = true
+        dataChannel?.delegate = nil
+        dataChannel?.close()
+        dataChannel = nil
+        localAudioTrack?.isEnabled = false
+        localAudioTrack = nil
+        localAudioSource = nil
+        peerConnection?.close()
+        peerConnection = nil
+    }
+
+    private func createOffer(connection: RTCPeerConnection, constraints: RTCMediaConstraints) async throws -> RTCSessionDescription {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.offer(for: constraints) { description, error in
+                if let error { continuation.resume(throwing: error) }
+                else if let description { continuation.resume(returning: description) }
+                else { continuation.resume(throwing: OpenAIRealtimeTransportError.emptyAnswer) }
+            }
+        }
+    }
+
+    private func setLocalDescription(_ description: RTCSessionDescription, on connection: RTCPeerConnection) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.setLocalDescription(description) { error in
+                error.map { continuation.resume(throwing: $0) } ?? continuation.resume()
+            }
+        }
+    }
+
+    private func setRemoteDescription(_ description: RTCSessionDescription, on connection: RTCPeerConnection) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            connection.setRemoteDescription(description) { error in
+                error.map { continuation.resume(throwing: $0) } ?? continuation.resume()
+            }
+        }
+    }
+
+    private func sendOffer(_ sdp: String, to url: URL, clientSecret: String) async throws -> String {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.httpBody = Data(sdp.utf8)
+        request.setValue("application/sdp", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/sdp", forHTTPHeaderField: "Accept")
+        request.setValue("Bearer \(clientSecret)", forHTTPHeaderField: "Authorization")
+        let (data, response) = try await urlSession.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw OpenAIRealtimeTransportError.signalingFailed((response as? HTTPURLResponse)?.statusCode ?? 0)
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+}
+
+extension OpenAIRealtimeTransport: RTCPeerConnectionDelegate {
+    nonisolated func peerConnectionShouldNegotiate(_ peerConnection: RTCPeerConnection) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didChange stateChanged: RTCSignalingState) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didAdd stream: RTCMediaStream) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didRemove stream: RTCMediaStream) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceConnectionState) {
+        guard newState == .failed || newState == .closed else { return }
+        Task { @MainActor [weak self] in self?.onEvent?(.failed("realtime_ice_\(newState.rawValue)")) }
+    }
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didChange newState: RTCIceGatheringState) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didGenerate candidate: RTCIceCandidate) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didRemove candidates: [RTCIceCandidate]) {}
+    nonisolated func peerConnection(_ peerConnection: RTCPeerConnection, didOpen dataChannel: RTCDataChannel) {
+        Task { @MainActor [weak self] in
+            guard let self, !self.stopped else { return }
+            dataChannel.delegate = self
+        }
+    }
+}
+
+extension OpenAIRealtimeTransport: RTCDataChannelDelegate {
+    nonisolated func dataChannelDidChangeState(_ dataChannel: RTCDataChannel) {}
+
+    nonisolated func dataChannel(_ dataChannel: RTCDataChannel, didReceiveMessageWith buffer: RTCDataBuffer) {
+        guard !buffer.isBinary else { return }
+        Task { @MainActor [weak self] in
+            guard let self, !self.stopped else { return }
+            do {
+                if let event = try self.decoder.decode(data: buffer.data) { self.onEvent?(event) }
+            } catch {
+                self.onEvent?(.failed("realtime_event_decode_failed"))
+            }
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
@@ -38,7 +38,7 @@ final class VoiceCallCoordinator {
 
     init(mode: VoiceCallMode, transport: VoiceCallTransport,
          mediaSession: VoiceMediaSessionManaging,
-         context: VoiceCallTransportContext = .init(familiarId: "", sessionId: "", grant: nil)) {
+         context: VoiceCallTransportContext) {
         state = VoiceCallState(mode: mode)
         self.transport = transport
         self.mediaSession = mediaSession

--- a/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// Context selected by the call sheet. Realtime receives only the short-lived
+/// grant minted by Cave; the desktop vault credential never reaches iOS.
+struct VoiceCallTransportContext: Sendable {
+    let familiarId: String
+    let sessionId: String
+    let grant: CaveClient.VoiceSessionGrant?
+}
+
+@MainActor
+protocol VoiceCallTransport: AnyObject {
+    var onEvent: (@MainActor (VoiceCallEvent) -> Void)? { get set }
+    func start(with context: VoiceCallTransportContext) async throws
+    func setMuted(_ muted: Bool)
+    func stop()
+}
+
+@MainActor
+protocol VoiceMediaSessionManaging: AnyObject {
+    var onInterruption: (@MainActor () -> Void)? { get set }
+    var onRouteChange: (@MainActor () -> Void)? { get set }
+    func prepare(mode: VoiceCallMode, needsSpeechRecognition: Bool) async throws
+    func stop()
+}
+
+/// Owns one call's permission, audio-session, and transport lifecycle. The
+/// state reducer remains the only owner of transcript revision/deduplication.
+@MainActor
+final class VoiceCallCoordinator {
+    private(set) var state: VoiceCallState
+    var onStateChange: (@MainActor (VoiceCallState) -> Void)?
+
+    private let transport: VoiceCallTransport
+    private let mediaSession: VoiceMediaSessionManaging
+    private let context: VoiceCallTransportContext
+    private var didCleanUp = false
+
+    init(mode: VoiceCallMode, transport: VoiceCallTransport,
+         mediaSession: VoiceMediaSessionManaging,
+         context: VoiceCallTransportContext = .init(familiarId: "", sessionId: "", grant: nil)) {
+        state = VoiceCallState(mode: mode)
+        self.transport = transport
+        self.mediaSession = mediaSession
+        self.context = context
+        transport.onEvent = { [weak self] event in self?.receive(event) }
+        mediaSession.onInterruption = { [weak self] in self?.receive(.failed("audio_interrupted")) }
+        mediaSession.onRouteChange = { [weak self] in self?.receive(.failed("audio_route_changed")) }
+    }
+
+    func start() async {
+        guard state.phase == .idle else { return }
+        state.send(.start)
+        publish()
+        do {
+            try await mediaSession.prepare(mode: state.mode, needsSpeechRecognition: state.mode == .native)
+            guard !state.phase.isTerminal else {
+                // `end()` may have run while permission was pending. A real
+                // media session can become active immediately before its async
+                // prepare returns, so deactivate it again after that late return.
+                mediaSession.stop()
+                return
+            }
+            state.receive(.permissionGranted)
+            publish()
+            try await transport.start(with: context)
+        } catch {
+            if state.phase.isTerminal {
+                mediaSession.stop()
+                return
+            }
+            receive(.failed(error.localizedDescription))
+        }
+    }
+
+    func setMuted(_ muted: Bool) {
+        guard !state.phase.isTerminal else { return }
+        state.send(.setMuted(muted))
+        transport.setMuted(muted)
+        publish()
+    }
+
+    func end() {
+        guard !state.phase.isTerminal else { return }
+        state.send(.end)
+        cleanUp()
+        publish()
+    }
+
+    private func receive(_ event: VoiceCallEvent) {
+        guard !state.phase.isTerminal else { return }
+        state.receive(event)
+        if state.phase.isTerminal { cleanUp() }
+        publish()
+    }
+
+    private func cleanUp() {
+        guard !didCleanUp else { return }
+        didCleanUp = true
+        transport.onEvent = nil
+        mediaSession.onInterruption = nil
+        mediaSession.onRouteChange = nil
+        transport.stop()
+        mediaSession.stop()
+    }
+
+    private func publish() {
+        onStateChange?(state)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Voice/VoiceMediaSession.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/VoiceMediaSession.swift
@@ -1,0 +1,78 @@
+import AVFoundation
+import Speech
+
+enum VoiceCallMediaError: LocalizedError {
+    case microphoneDenied
+    case speechRecognitionDenied
+
+    var errorDescription: String? {
+        switch self {
+        case .microphoneDenied: "microphone_denied"
+        case .speechRecognitionDenied: "speech_recognition_denied"
+        }
+    }
+}
+
+/// Process-wide audio session owner for one live call. Notifications are
+/// detached before deactivation, so an old route/interruption cannot revive a
+/// new or already-ended coordinator.
+@MainActor
+final class VoiceMediaSession: VoiceMediaSessionManaging {
+    var onInterruption: (@MainActor () -> Void)?
+    var onRouteChange: (@MainActor () -> Void)?
+
+    private let session: AVAudioSession
+    private var observers: [NSObjectProtocol] = []
+
+    init(session: AVAudioSession = .sharedInstance()) {
+        self.session = session
+    }
+
+    func prepare(mode: VoiceCallMode, needsSpeechRecognition: Bool) async throws {
+        guard await requestMicrophonePermission() else { throw VoiceCallMediaError.microphoneDenied }
+        if needsSpeechRecognition, !(await requestSpeechPermission()) {
+            throw VoiceCallMediaError.speechRecognitionDenied
+        }
+
+        try session.setCategory(.playAndRecord, mode: .voiceChat,
+                                options: [.allowBluetoothHFP, .defaultToSpeaker])
+        try session.setActive(true)
+        observeAudioChanges()
+    }
+
+    func stop() {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        observers.removeAll()
+        try? session.setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    private func requestMicrophonePermission() async -> Bool {
+        await withCheckedContinuation { continuation in
+            AVAudioApplication.requestRecordPermission { continuation.resume(returning: $0) }
+        }
+    }
+
+    private func requestSpeechPermission() async -> Bool {
+        let status = await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { continuation.resume(returning: $0) }
+        }
+        return status == .authorized
+    }
+
+    private func observeAudioChanges() {
+        observers.forEach(NotificationCenter.default.removeObserver)
+        let center = NotificationCenter.default
+        observers = [
+            center.addObserver(forName: AVAudioSession.interruptionNotification, object: session, queue: .main) { [weak self] note in
+                guard let type = note.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+                      type == AVAudioSession.InterruptionType.began.rawValue else { return }
+                Task { @MainActor in self?.onInterruption?() }
+            },
+            center.addObserver(forName: AVAudioSession.routeChangeNotification, object: session, queue: .main) { [weak self] note in
+                guard let reason = note.userInfo?[AVAudioSessionRouteChangeReasonKey] as? UInt,
+                      reason == AVAudioSession.RouteChangeReason.oldDeviceUnavailable.rawValue else { return }
+                Task { @MainActor in self?.onRouteChange?() }
+            }
+        ]
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/OpenAIRealtimeEventDecoderTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/OpenAIRealtimeEventDecoderTests.swift
@@ -1,0 +1,40 @@
+import XCTest
+@testable import CovenCave
+
+final class OpenAIRealtimeEventDecoderTests: XCTestCase {
+    func testDecoderAccumulatesIncrementalDeltasPerSegmentAndClearsAfterFinal() throws {
+        var decoder = OpenAIRealtimeEventDecoder()
+
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"conversation.item.input_audio_transcription.delta","item_id":"user-42","delta":"Hello"}"#),
+            .partial(role: .user, text: "Hello", segmentID: "user-42", revision: 1)
+        )
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"conversation.item.input_audio_transcription.delta","item_id":"user-42","delta":" world"}"#),
+            .partial(role: .user, text: "Hello world", segmentID: "user-42", revision: 2)
+        )
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"conversation.item.input_audio_transcription.completed","item_id":"user-42","transcript":"Hello Coven"}"#),
+            .final(role: .user, text: "Hello Coven", segmentID: "user-42")
+        )
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"response.output_audio_transcript.delta","item_id":"assistant-9","delta":"Hi"}"#),
+            .partial(role: .assistant, text: "Hi", segmentID: "assistant-9", revision: 1)
+        )
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"response.output_audio_transcript.done","item_id":"assistant-9","transcript":"Hi there"}"#),
+            .final(role: .assistant, text: "Hi there", segmentID: "assistant-9")
+        )
+        XCTAssertEqual(
+            try decoder.decode(json: #"{"type":"response.output_audio_transcript.delta","item_id":"assistant-9","delta":"Fresh"}"#),
+            .partial(role: .assistant, text: "Fresh", segmentID: "assistant-9", revision: 1)
+        )
+    }
+
+    func testDecoderIgnoresUnrelatedEventsAndRejectsMissingCorrelation() throws {
+        var decoder = OpenAIRealtimeEventDecoder()
+
+        XCTAssertNil(try decoder.decode(json: #"{"type":"response.audio.delta","delta":"..."}"#))
+        XCTAssertNil(try decoder.decode(json: #"{"type":"response.output_audio_transcript.delta","delta":"missing item"}"#))
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceCallCoordinatorTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceCallCoordinatorTests.swift
@@ -1,0 +1,141 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class VoiceCallCoordinatorTests: XCTestCase {
+    func testEndStopsMediaAndTransportOnceAndRejectsLateTransportCallbacks() async {
+        let media = FakeVoiceMediaSession()
+        let transport = FakeVoiceTransport()
+        let coordinator = VoiceCallCoordinator(
+            mode: .realtime, transport: transport, mediaSession: media
+        )
+
+        await coordinator.start()
+        XCTAssertEqual(media.prepareCalls.count, 1)
+        XCTAssertEqual(media.prepareCalls[0].0, .realtime)
+        XCTAssertFalse(media.prepareCalls[0].1)
+        XCTAssertEqual(transport.startCalls, 1)
+
+        transport.emit(.connected)
+        XCTAssertEqual(coordinator.state.phase, .listening)
+
+        coordinator.end()
+        coordinator.end()
+        transport.emit(.partial(role: .assistant, text: "late", segmentID: "a-1", revision: 1))
+
+        XCTAssertEqual(coordinator.state.phase, .ended)
+        XCTAssertTrue(coordinator.state.transcript.isEmpty)
+        XCTAssertEqual(transport.stopCalls, 1)
+        XCTAssertEqual(media.stopCalls, 1)
+    }
+
+    func testTransportFailureCleansUpOnceAndCannotBeRevivedByLaterCallbacks() async {
+        let media = FakeVoiceMediaSession()
+        let transport = FakeVoiceTransport()
+        let coordinator = VoiceCallCoordinator(
+            mode: .native, transport: transport, mediaSession: media
+        )
+
+        await coordinator.start()
+        transport.emit(.connected)
+        transport.emit(.failed("network unavailable"))
+        transport.emit(.listening)
+
+        XCTAssertEqual(coordinator.state.phase, .error("network unavailable"))
+        XCTAssertEqual(transport.stopCalls, 1)
+        XCTAssertEqual(media.stopCalls, 1)
+    }
+
+    func testSetupFailureBeforeConnectionIsTerminalAndCleansUp() async {
+        let media = FakeVoiceMediaSession()
+        media.prepareError = VoiceCallMediaError.speechRecognitionDenied
+        let transport = FakeVoiceTransport()
+        let coordinator = VoiceCallCoordinator(
+            mode: .native, transport: transport, mediaSession: media
+        )
+
+        await coordinator.start()
+
+        XCTAssertEqual(coordinator.state.phase, .error("speech_recognition_denied"))
+        XCTAssertEqual(transport.startCalls, 0)
+        XCTAssertEqual(transport.stopCalls, 1)
+        XCTAssertEqual(media.stopCalls, 1)
+    }
+
+    func testEndDuringPermissionWaitDeactivatesAudioPreparedAfterTheCallEnds() async {
+        let media = FakeVoiceMediaSession()
+        media.suspendsPreparation = true
+        let transport = FakeVoiceTransport()
+        let coordinator = VoiceCallCoordinator(
+            mode: .native, transport: transport, mediaSession: media
+        )
+        media.onPreparationWait = {
+            coordinator.end()
+            media.finishPreparationWithActiveAudio()
+        }
+
+        await coordinator.start()
+
+        XCTAssertEqual(coordinator.state.phase, .ended)
+        XCTAssertFalse(media.isAudioActive)
+        XCTAssertEqual(media.stopCalls, 2)
+        XCTAssertEqual(transport.startCalls, 0)
+    }
+}
+
+@MainActor
+private final class FakeVoiceTransport: VoiceCallTransport {
+    var onEvent: (@MainActor (VoiceCallEvent) -> Void)?
+    private(set) var startCalls = 0
+    private(set) var stopCalls = 0
+
+    func start(with context: VoiceCallTransportContext) async throws {
+        startCalls += 1
+    }
+
+    func setMuted(_ muted: Bool) {}
+
+    func stop() {
+        stopCalls += 1
+    }
+
+    func emit(_ event: VoiceCallEvent) {
+        onEvent?(event)
+    }
+}
+
+@MainActor
+private final class FakeVoiceMediaSession: VoiceMediaSessionManaging {
+    var onInterruption: (@MainActor () -> Void)?
+    var onRouteChange: (@MainActor () -> Void)?
+    private(set) var prepareCalls: [(VoiceCallMode, Bool)] = []
+    private(set) var stopCalls = 0
+    var prepareError: Error?
+    var suspendsPreparation = false
+    private var prepareContinuation: CheckedContinuation<Void, Never>?
+    private(set) var isAudioActive = false
+    var onPreparationWait: (() -> Void)?
+
+    func prepare(mode: VoiceCallMode, needsSpeechRecognition: Bool) async throws {
+        prepareCalls.append((mode, needsSpeechRecognition))
+        if let prepareError { throw prepareError }
+        if suspendsPreparation {
+            await withCheckedContinuation {
+                prepareContinuation = $0
+                onPreparationWait?()
+            }
+        }
+    }
+
+    func finishPreparationWithActiveAudio() {
+        isAudioActive = true
+        let continuation = prepareContinuation
+        prepareContinuation = nil
+        continuation?.resume()
+    }
+
+    func stop() {
+        stopCalls += 1
+        isAudioActive = false
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceCallCoordinatorTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceCallCoordinatorTests.swift
@@ -3,11 +3,12 @@ import XCTest
 
 @MainActor
 final class VoiceCallCoordinatorTests: XCTestCase {
+    private let context = VoiceCallTransportContext(familiarId: "familiar", sessionId: "session", grant: nil)
     func testEndStopsMediaAndTransportOnceAndRejectsLateTransportCallbacks() async {
         let media = FakeVoiceMediaSession()
         let transport = FakeVoiceTransport()
         let coordinator = VoiceCallCoordinator(
-            mode: .realtime, transport: transport, mediaSession: media
+            mode: .realtime, transport: transport, mediaSession: media, context: context
         )
 
         await coordinator.start()
@@ -33,7 +34,7 @@ final class VoiceCallCoordinatorTests: XCTestCase {
         let media = FakeVoiceMediaSession()
         let transport = FakeVoiceTransport()
         let coordinator = VoiceCallCoordinator(
-            mode: .native, transport: transport, mediaSession: media
+            mode: .native, transport: transport, mediaSession: media, context: context
         )
 
         await coordinator.start()
@@ -51,7 +52,7 @@ final class VoiceCallCoordinatorTests: XCTestCase {
         media.prepareError = VoiceCallMediaError.speechRecognitionDenied
         let transport = FakeVoiceTransport()
         let coordinator = VoiceCallCoordinator(
-            mode: .native, transport: transport, mediaSession: media
+            mode: .native, transport: transport, mediaSession: media, context: context
         )
 
         await coordinator.start()
@@ -67,7 +68,7 @@ final class VoiceCallCoordinatorTests: XCTestCase {
         media.suspendsPreparation = true
         let transport = FakeVoiceTransport()
         let coordinator = VoiceCallCoordinator(
-            mode: .native, transport: transport, mediaSession: media
+            mode: .native, transport: transport, mediaSession: media, context: context
         )
         media.onPreparationWait = {
             coordinator.end()

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift
@@ -1,0 +1,180 @@
+import XCTest
+@testable import CovenCave
+
+final class VoiceCallStateTests: XCTestCase {
+    private func connectedState(mode: VoiceCallMode = .native) -> VoiceCallState {
+        var state = VoiceCallState(mode: mode)
+        state.send(.start)
+        state.receive(.permissionGranted)
+        state.receive(.connected)
+        return state
+    }
+
+    func testProviderMetadataSelectsTheAppropriateCallMode() {
+        XCTAssertEqual(VoiceCallMode.forVoiceProvider("openai"), .realtime)
+        XCTAssertEqual(VoiceCallMode.forVoiceProvider("anthropic"), .native)
+        XCTAssertEqual(VoiceCallMode.forVoiceProvider("local"), .native)
+    }
+
+    func testLifecycleReachesListeningAndMuteDoesNotChangeThePhase() {
+        var state = VoiceCallState(mode: .native)
+
+        state.send(.start)
+        XCTAssertEqual(state.phase, .requestingPermission)
+        state.receive(.permissionGranted)
+        XCTAssertEqual(state.phase, .connecting)
+        state.receive(.connected)
+        XCTAssertEqual(state.phase, .listening)
+
+        state.send(.setMuted(true))
+        XCTAssertTrue(state.isMuted)
+        XCTAssertEqual(state.phase, .listening)
+        XCTAssertFalse(state.shouldCaptureAudio)
+    }
+
+    func testPartialTranscriptUpdatesOneInProgressRowAndFinalPromotesItOnce() {
+        var state = connectedState()
+
+        state.receive(.partial(role: .user, text: "Review", segmentID: "user-1", revision: 1))
+        let partialID = state.transcript[0].id
+        state.receive(.partial(role: .user, text: "Review this", segmentID: "user-1", revision: 2))
+        state.receive(.final(role: .user, text: "Review this", segmentID: "user-1"))
+        state.receive(.final(role: .user, text: "Review this branch", segmentID: "user-1"))
+
+        XCTAssertEqual(state.transcript.count, 1)
+        XCTAssertEqual(state.transcript[0].id, partialID)
+        XCTAssertEqual(state.transcript[0].role, .user)
+        XCTAssertEqual(state.transcript[0].text, "Review this")
+        XCTAssertTrue(state.transcript[0].isFinal)
+    }
+
+    func testFinalTranscriptRetriesDeduplicateBySegmentID() {
+        var state = connectedState(mode: .realtime)
+
+        state.receive(.final(role: .user, text: "Hello", segmentID: "user-1"))
+        state.receive(.final(role: .assistant, text: "Hi there", segmentID: "assistant-1"))
+        state.receive(.final(role: .user, text: "Hello", segmentID: "user-1"))
+        state.receive(.final(role: .assistant, text: "Hi there", segmentID: "assistant-1"))
+
+        XCTAssertEqual(state.transcript.map(\.role), [.user, .assistant])
+        XCTAssertEqual(state.transcript.map(\.text), ["Hello", "Hi there"])
+        XCTAssertTrue(state.transcript.allSatisfy(\.isFinal))
+    }
+
+    func testIdenticalFinalUtterancesWithDifferentSegmentIDsRemainSeparate() {
+        var state = connectedState()
+
+        state.receive(.final(role: .user, text: "Yes", segmentID: "user-1"))
+        state.receive(.final(role: .user, text: "Yes", segmentID: "user-2"))
+
+        XCTAssertEqual(state.transcript.map(\.text), ["Yes", "Yes"])
+        XCTAssertEqual(state.transcript.map(\.segmentID), ["user-1", "user-2"])
+    }
+
+    func testOlderPartialRevisionCannotOverwriteNewerPartial() {
+        var state = connectedState()
+
+        state.receive(.partial(role: .user, text: "Review", segmentID: "user-1", revision: 1))
+        state.receive(.partial(role: .user, text: "Review this", segmentID: "user-1", revision: 2))
+        state.receive(.partial(role: .user, text: "Review", segmentID: "user-1", revision: 1))
+
+        XCTAssertEqual(state.transcript[0].text, "Review this")
+        XCTAssertEqual(state.transcript[0].partialRevision, 2)
+    }
+
+    func testTranscriptRowIDsAreDeterministicForIdenticalEventStreams() {
+        var first = connectedState()
+        var second = connectedState()
+
+        first.receive(.partial(role: .assistant, text: "I can", segmentID: "assistant-1", revision: 1))
+        first.receive(.final(role: .assistant, text: "I can help.", segmentID: "assistant-1"))
+        second.receive(.partial(role: .assistant, text: "I can", segmentID: "assistant-1", revision: 1))
+        second.receive(.final(role: .assistant, text: "I can help.", segmentID: "assistant-1"))
+
+        XCTAssertEqual(first.transcript, second.transcript)
+        XCTAssertEqual(first.transcript[0].id, "assistant::assistant-1")
+    }
+
+    func testSameSegmentIDForDifferentRolesCreatesIndependentRows() {
+        var state = connectedState(mode: .realtime)
+
+        state.receive(.partial(role: .user, text: "Yes", segmentID: "0", revision: 1))
+        state.receive(.partial(role: .assistant, text: "Right", segmentID: "0", revision: 1))
+        state.receive(.final(role: .user, text: "Yes.", segmentID: "0"))
+        state.receive(.final(role: .assistant, text: "Right.", segmentID: "0"))
+
+        XCTAssertEqual(state.transcript.map(\.id), ["user::0", "assistant::0"])
+        XCTAssertEqual(state.transcript.map(\.text), ["Yes.", "Right."])
+        XCTAssertTrue(state.transcript.allSatisfy(\.isFinal))
+    }
+
+    func testTranscriptExpansionIsIndependentFromTheCallLifecycle() {
+        var state = connectedState()
+
+        state.send(.setTranscriptExpanded(true))
+        state.send(.end)
+
+        XCTAssertTrue(state.isTranscriptExpanded)
+        XCTAssertEqual(state.phase, .ended)
+
+        state.send(.setTranscriptExpanded(false))
+        XCTAssertFalse(state.isTranscriptExpanded)
+        XCTAssertEqual(state.phase, .ended)
+    }
+
+    func testLateCallbacksAfterEndCannotResurrectTheCallOrTranscript() {
+        var state = connectedState()
+        state.receive(.final(role: .user, text: "Keep this", segmentID: "user-1"))
+        state.send(.end)
+
+        state.receive(.connected)
+        state.receive(.partial(role: .assistant, text: "Ignore", segmentID: "assistant-1", revision: 1))
+        state.receive(.final(role: .assistant, text: "Ignore", segmentID: "assistant-1"))
+        state.receive(.failed("late failure"))
+
+        XCTAssertEqual(state.phase, .ended)
+        XCTAssertFalse(state.isAudioActive)
+        XCTAssertEqual(state.transcript.map(\.text), ["Keep this"])
+    }
+
+    func testFailureIsTerminalAndPreventsFurtherAudioTransitions() {
+        var state = connectedState()
+
+        state.receive(.failed("network unavailable"))
+        state.receive(.listening)
+        state.receive(.speaking)
+
+        XCTAssertEqual(state.phase, .error("network unavailable"))
+        XCTAssertFalse(state.isAudioActive)
+    }
+
+    func testPermissionDenialTerminatesWithoutStartingAudio() {
+        var state = VoiceCallState(mode: .native)
+        state.send(.start)
+
+        state.receive(.permissionDenied)
+        state.receive(.connected)
+
+        XCTAssertEqual(state.phase, .error("microphone_denied"))
+        XCTAssertFalse(state.isAudioActive)
+        XCTAssertFalse(state.shouldCaptureAudio)
+    }
+
+    func testStalePermissionDenialAfterConnectionIsIgnored() {
+        var state = connectedState()
+
+        state.receive(.permissionDenied)
+
+        XCTAssertEqual(state.phase, .listening)
+        XCTAssertTrue(state.shouldCaptureAudio)
+    }
+
+    func testStaleTransportFailureWhileIdleIsIgnored() {
+        var state = VoiceCallState(mode: .native)
+
+        state.receive(.failed("late failure"))
+
+        XCTAssertEqual(state.phase, .idle)
+        XCTAssertFalse(state.isAudioActive)
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceSessionContractTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceSessionContractTests.swift
@@ -24,6 +24,11 @@ private final class VoiceSessionURLProtocol: URLProtocol {
 }
 
 final class VoiceSessionContractTests: XCTestCase {
+    override func tearDown() {
+        VoiceSessionURLProtocol.handler = nil
+        super.tearDown()
+    }
+
     private func client(status: Int, body: String, contentType: String? = "application/json") -> CaveClient {
         VoiceSessionURLProtocol.handler = { request in
             XCTAssertEqual(request.url?.path, "/api/voice/session")

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceSessionContractTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceSessionContractTests.swift
@@ -1,0 +1,176 @@
+import Foundation
+import XCTest
+@testable import CovenCave
+
+private final class VoiceSessionURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class VoiceSessionContractTests: XCTestCase {
+    private func client(status: Int, body: String, contentType: String? = "application/json") -> CaveClient {
+        VoiceSessionURLProtocol.handler = { request in
+            XCTAssertEqual(request.url?.path, "/api/voice/session")
+            XCTAssertEqual(request.httpMethod, "POST")
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: status,
+                    httpVersion: nil,
+                    headerFields: contentType.map { ["Content-Type": $0] }
+                )
+            )
+            return (response, Data(body.utf8))
+        }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [VoiceSessionURLProtocol.self]
+        return CaveClient(
+            connection: CaveConnection(host: "http://cave.test:3000"),
+            session: URLSession(configuration: configuration)
+        )
+    }
+
+    func testFamiliarDecodesOptionalVoiceConfiguration() throws {
+        let configured = try JSONDecoder().decode(
+            Familiar.self,
+            from: """
+            {
+              "id": "milo",
+              "display_name": "Milo",
+              "voiceProvider": "openai",
+              "voiceModel": "gpt-realtime",
+              "voiceName": "alloy"
+            }
+            """.data(using: .utf8)!
+        )
+
+        XCTAssertEqual(configured.voiceProvider, "openai")
+        XCTAssertEqual(configured.voiceModel, "gpt-realtime")
+        XCTAssertEqual(configured.voiceName, "alloy")
+
+        let legacy = try JSONDecoder().decode(
+            Familiar.self,
+            from: #"{"id":"milo","display_name":"Milo"}"#.data(using: .utf8)!
+        )
+
+        XCTAssertNil(legacy.voiceProvider)
+        XCTAssertNil(legacy.voiceModel)
+        XCTAssertNil(legacy.voiceName)
+    }
+
+    func testVoiceSessionRequestAndResponseMatchDesktopContract() throws {
+        let request = CaveClient.VoiceSessionRequest(familiarId: "milo", sessionId: "sess-42")
+        let requestData = try JSONEncoder().encode(request)
+        let requestJSON = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: requestData) as? [String: String]
+        )
+
+        XCTAssertEqual(requestJSON, ["familiarId": "milo", "sessionId": "sess-42"])
+
+        let response = try JSONDecoder().decode(
+            CaveClient.VoiceSessionResponse.self,
+            from: """
+            {
+              "ok": true,
+              "callId": "01JVOICECALL00000000000000",
+              "grant": {
+                "provider": "openai",
+                "clientSecret": "ek_short_lived",
+                "expiresAt": "2026-07-29T18:00:00Z",
+                "connection": {
+                  "kind": "openai-realtime",
+                  "url": "https://api.openai.com/v1/realtime/calls",
+                  "model": "gpt-realtime",
+                  "voice": "alloy"
+                }
+              }
+            }
+            """.data(using: .utf8)!
+        )
+
+        XCTAssertTrue(response.ok)
+        XCTAssertEqual(response.callId, "01JVOICECALL00000000000000")
+        XCTAssertEqual(response.grant?.provider, "openai")
+        XCTAssertEqual(response.grant?.clientSecret, "ek_short_lived")
+        XCTAssertEqual(response.grant?.connection.kind, "openai-realtime")
+        XCTAssertEqual(response.grant?.connection.model, "gpt-realtime")
+    }
+
+    func testVoiceSessionResponsePreservesLocalLoopConnectionContext() throws {
+        let response = try JSONDecoder().decode(
+            CaveClient.VoiceSessionResponse.self,
+            from: """
+            {
+              "ok": true,
+              "callId": "01JLOCALLOOP00000000000000",
+              "grant": {
+                "provider": "local",
+                "clientSecret": "local",
+                "expiresAt": "2026-07-29T18:00:00Z",
+                "connection": {
+                  "kind": "local-loop",
+                  "model": "llama3.2",
+                  "voice": "",
+                  "instructions": "Be practical and kind.",
+                  "conversationSeed": [
+                    { "role": "user", "content": "Review this branch." },
+                    { "role": "assistant", "content": "I will inspect the diff." }
+                  ]
+                }
+              }
+            }
+            """.data(using: .utf8)!
+        )
+
+        XCTAssertEqual(response.grant?.connection.instructions, "Be practical and kind.")
+        XCTAssertEqual(response.grant?.connection.conversationSeed?.map(\.role), ["user", "assistant"])
+        XCTAssertEqual(response.grant?.connection.conversationSeed?.map(\.content), [
+            "Review this branch.", "I will inspect the diff.",
+        ])
+    }
+
+    func testMintVoiceSessionRetainsJSONRouteError() async {
+        let client = client(
+            status: 400,
+            body: #"{"ok":false,"error":"voice_not_configured","hint":"Choose a voice provider."}"#
+        )
+
+        do {
+            _ = try await client.mintVoiceSession(familiarId: "milo", sessionId: "sess-42")
+            XCTFail("expected voice session request to fail")
+        } catch let CaveError.transport(message) {
+            XCTAssertEqual(message, "voice_not_configured: Choose a voice provider.")
+        } catch {
+            XCTFail("expected actionable transport error, got \(error)")
+        }
+    }
+
+    func testMintVoiceSessionUsesBadResponseForNonJSONFailure() async {
+        let client = client(status: 502, body: "upstream unavailable", contentType: "text/plain")
+
+        do {
+            _ = try await client.mintVoiceSession(familiarId: "milo", sessionId: "sess-42")
+            XCTFail("expected voice session request to fail")
+        } catch let CaveError.badResponse(status) {
+            XCTAssertEqual(status, 502)
+        } catch {
+            XCTFail("expected bad response error, got \(error)")
+        }
+    }
+}

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -13,6 +13,10 @@ settings:
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic
     GENERATE_INFOPLIST_FILE: NO
+packages:
+  WebRTC:
+    url: https://github.com/stasel/WebRTC.git
+    revision: 6ed87f05368632f71dc95c89c14c051561710925 # 150.0.0
 targets:
   CovenCave:
     type: application
@@ -54,6 +58,8 @@ targets:
         IPHONEOS_DEPLOYMENT_TARGET: "18.0"
         CODE_SIGN_ENTITLEMENTS: CovenCave/CovenCave.entitlements
     dependencies:
+      - package: WebRTC
+        product: WebRTC
       - target: CovenCaveWidgets
 
   # Unit tests for the pure pairing logic (CaveInvite parsing, token-expiry


### PR DESCRIPTION
## Summary
- add server-minted iOS voice session contract and familiar voice metadata
- add deterministic call/transcript state plus native OpenAI WebRTC and Apple turn-based transport foundations
- add lifecycle, transcript, contract, and event-decoder coverage

## Verification
- xcodebuild focused voice tests on iPhone 16 Pro simulator
- pnpm test:mobile (74 files)
- git diff --check