### PR TITLE
fix(projects): preserve the create-new project selection

### DIFF
--- a/src/components/first-project-gate.test.ts
+++ b/src/components/first-project-gate.test.ts
@@ -54,6 +54,25 @@ test("the gate stays prop-driven and focuses the correct first control on first 
   assert.doesNotMatch(src, /autoFocus/, "initial focus no longer depends on DOM-order-sensitive autoFocus");
 });
 
+test("the registered-project default never overwrites an explicit create-new selection", () => {
+  const src = read("./first-project-gate.tsx");
+  assert.match(
+    src,
+    /const existingProjectSelectionInitializedRef = useRef\(false\);/,
+    "tracks whether the automatic existing-project default has already run",
+  );
+  assert.match(
+    src,
+    /if \(registeredProject \|\| availableProjects\.length === 0 \|\| existingProjectSelectionInitializedRef\.current\) return;\s*existingProjectSelectionInitializedRef\.current = true;\s*setSelectedExistingProjectId\(availableProjects\[0\]!\.id\);/,
+    "defaults once when projects arrive, then preserves the explicit empty create-new option",
+  );
+  assert.doesNotMatch(
+    src,
+    /registeredProject \|\| selectedExistingProjectId \|\| availableProjects\.length === 0/,
+    "does not mistake the intentional empty select value for an uninitialized selection",
+  );
+});
+
 test("workspace wires the first-project gate through pending-aware policy and renders it inside the detail area", () => {
   const src = read("./workspace.tsx");
   assert.match(src, /import \{ FirstProjectGate \} from "@\/components\/first-project-gate";/, "workspace eagerly imports the first-project gate");

--- a/src/components/first-project-gate.tsx
+++ b/src/components/first-project-gate.tsx
@@ -67,6 +67,9 @@ export function FirstProjectGate({
   const nameInputRef = useRef<HTMLInputElement | null>(null);
   const submitButtonRef = useRef<HTMLButtonElement | null>(null);
   const wasVisibleRef = useRef(false);
+  // An empty select value is the explicit "Add a different project…" path,
+  // not an uninitialized choice. Only apply the convenient default once.
+  const existingProjectSelectionInitializedRef = useRef(false);
   const titleId = useId();
   const copyId = useId();
   const rootHintId = useId();
@@ -81,9 +84,10 @@ export function FirstProjectGate({
   const canSubmit = lockedProject ? true : Boolean(nameDraft.trim() && rootDraft.trim() && isAbsolutePath(rootDraft));
 
   useEffect(() => {
-    if (registeredProject || selectedExistingProjectId || availableProjects.length === 0) return;
+    if (registeredProject || availableProjects.length === 0 || existingProjectSelectionInitializedRef.current) return;
+    existingProjectSelectionInitializedRef.current = true;
     setSelectedExistingProjectId(availableProjects[0]!.id);
-  }, [availableProjects, registeredProject, selectedExistingProjectId]);
+  }, [availableProjects, registeredProject]);
 
   useEffect(() => {
     if (!open) {


### PR DESCRIPTION
Follow-up for late Copilot finding from #4025.

## Fix
- default to the first registered project only once after project data arrives
- preserve the explicit empty “Add a different project…” selection so users can create a project even when existing projects are present
- add a regression source contract

## Verification
- red/green focused `first-project-gate.test.ts` (8/8)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `git diff --check`