### PR TITLE
feat(marketplace): gate Crafts UI behind flag

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -164,6 +164,9 @@ export default defineConfig({
     reuseExistingServer: false,
     env: {
       COVEN_CAVE_E2E: "1",
+      // Crafts stay hidden in production by default. Their dedicated E2E
+      // specs exercise the explicitly enabled surface through this fixture.
+      NEXT_PUBLIC_CAVE_CRAFTS: "1",
       // Keep app-owned preferences and backdrop bytes out of the developer's
       // real ~/.coven directory. A per-config UUID prevents concurrent runs or
       // later PID reuse from sharing stale state while remaining stable for

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -337,6 +337,7 @@ export const SUITES = {
     "src/lib/theme-token-hex.test.ts",
     "src/components/roles-tools-navigation.test.ts",
     "src/components/marketplace/crafts-marketplace.test.ts",
+    "src/components/marketplace/crafts-visibility.test.ts",
     "src/components/marketplace/craft-create-drawer.test.ts",
     "src/lib/craft-agent-prompt.test.ts",
     "src/components/marketplace/skill-builder.test.ts",

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -7,7 +7,8 @@ pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. Typed chat
-// follow-up and Copilot modules trace 5,796 files on Windows; preserve ten-file headroom.
+// follow-up, Copilot, Crafts, and live voice modules trace 5,796 files on
+// Windows; preserve ten-file headroom.
 pub(super) const MAX_FILE_COUNT: u64 = 5_806;
 
 #[derive(Debug, Deserialize)]

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -320,12 +320,16 @@ export function MarketplaceViewSurface({
     setQuery("");
   }, [setStoredSection, setKind]);
 
-  const categories = useMemo(() => categoriesFrom(plugins), [plugins]);
+  const visiblePlugins = useMemo(
+    () => plugins.filter((plugin) => craftsEnabled || plugin.kind !== "craft"),
+    [plugins, craftsEnabled],
+  );
+  const categories = useMemo(() => categoriesFrom(visiblePlugins), [visiblePlugins]);
   const categoryCounts = useMemo(() => {
     const counts = new Map<string, number>();
-    for (const p of plugins) counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
+    for (const p of visiblePlugins) counts.set(p.category, (counts.get(p.category) ?? 0) + 1);
     return counts;
-  }, [plugins]);
+  }, [visiblePlugins]);
 
   // The slim header's tab items — label plus a live count per section. Counts
   // appear once their loader settles so the header never flashes a stale 0;
@@ -337,13 +341,13 @@ export function MarketplaceViewSurface({
         label: s.label,
         icon: s.icon,
         count:
-          s.id === "browse" && loaded && skillsLoaded ? plugins.length + skills.length
-          : s.id === "browse" && loaded ? plugins.length
-          : s.id === "crafts" && loaded ? plugins.filter((plugin) => plugin.kind === "craft").length
+          s.id === "browse" && loaded && skillsLoaded ? visiblePlugins.length + skills.length
+          : s.id === "browse" && loaded ? visiblePlugins.length
+          : s.id === "crafts" && loaded ? visiblePlugins.filter((plugin) => plugin.kind === "craft").length
           : undefined,
         title: SECTION_HINT[s.id],
       })),
-    [loaded, plugins.length, skillsLoaded, skills.length],
+    [loaded, visiblePlugins, skillsLoaded, skills.length],
   );
 
   const activeCollection = useMemo(
@@ -360,8 +364,8 @@ export function MarketplaceViewSurface({
     if (normalized.collectionId !== collectionId) setCollectionId(normalized.collectionId);
   }, [loaded, categories, category, collectionId, setCategory, setCollectionId]);
   const collectionIds = useMemo(
-    () => (activeCollection ? resolveCollection(plugins, activeCollection).map((p) => p.id) : undefined),
-    [plugins, activeCollection],
+    () => (activeCollection ? resolveCollection(visiblePlugins, activeCollection).map((p) => p.id) : undefined),
+    [visiblePlugins, activeCollection],
   );
 
   // Registry-skill install state overlays optimistic local edits on top of the
@@ -403,14 +407,14 @@ export function MarketplaceViewSurface({
   // Plugin pool — connectors (mcp/api) plus plugin-kind skills, honoring the
   // rail's Type + Status + Category/Collection scope and the search box.
   const filteredPlugins = useMemo(() => {
-    const matched = filterPlugins(plugins.filter((plugin) => craftsEnabled || plugin.kind !== "craft"), {
+    const matched = filterPlugins(visiblePlugins, {
       query,
       category: activeCollection || kind === "skill" ? "All" : category,
       kind,
       ids: collectionIds,
     }).filter(statusOkPlugin);
     return sortPlugins(matched, sort);
-  }, [plugins, craftsEnabled, query, category, kind, sort, collectionIds, activeCollection, statusOkPlugin]);
+  }, [visiblePlugins, query, category, kind, sort, collectionIds, activeCollection, statusOkPlugin]);
 
   // Registry skills join the pool whenever Skills (or All) is the active type;
   // a picked plugin category or "needs-setup" status excludes them.
@@ -802,7 +806,7 @@ export function MarketplaceViewSurface({
                     <ExploreRailRow
                       key={cat}
                       label={cat}
-                      count={cat === "All" ? plugins.length : categoryCounts.get(cat) ?? 0}
+                      count={cat === "All" ? visiblePlugins.length : categoryCounts.get(cat) ?? 0}
                       active={!activeCollection && category === cat}
                       onClick={() => selectCategory(cat)}
                     />

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -63,6 +63,7 @@ import {
 import { useSurfacePreference } from "@/lib/surface-preferences";
 import { surfacePreferenceSpecs } from "@/lib/surface-preference-specs";
 import { invalidateSurfaceResources, readSurfaceResource } from "@/lib/surface-warmup-registry";
+import { caveCrafts } from "@/lib/feature-flags";
 
 export type { MarketplaceSection } from "@/components/marketplace/marketplace-view-model";
 
@@ -89,17 +90,22 @@ export function MarketplaceViewSurface({
   initialSection = "browse",
   familiars = [],
 }: Props = {}) {
+  const craftsEnabled = caveCrafts();
   // Roles and Capabilities are hidden: their deep links land on Browse.
   const [storedSection, setStoredSection] = useSurfacePreference(surfacePreferenceSpecs.marketplace.section);
   // Alias links are a one-visit destination, not a replacement for a normal
   // return preference.
-  const initialDestination = initialSection === "roles" || initialSection === "capabilities" ? "browse" : initialSection;
+  const initialDestination = initialSection === "roles" || initialSection === "capabilities"
+    ? "browse"
+    : initialSection === "crafts" ? craftsEnabled ? "crafts" : "browse" : initialSection;
   const [deepLinkSection, setDeepLinkSection] = useState<MarketplaceSection | null>(
     initialSection === "roles" || initialSection === "capabilities"
       ? "browse"
       : initialDestination === "browse" ? null : initialDestination,
   );
-  const section = deepLinkSection ?? storedSection;
+  const section = !craftsEnabled && (deepLinkSection ?? storedSection) === "crafts"
+    ? "browse"
+    : deepLinkSection ?? storedSection;
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement | null>(null);
 
@@ -109,6 +115,9 @@ export function MarketplaceViewSurface({
   const [error, setError] = useState<string | null>(null);
   const [category, setCategory] = useSurfacePreference(surfacePreferenceSpecs.marketplace.category);
   const [kind, setKind] = useSurfacePreference(surfacePreferenceSpecs.marketplace.kind);
+  useEffect(() => {
+    if (!craftsEnabled && kind === "craft") setKind("all");
+  }, [craftsEnabled, kind, setKind]);
   // Explore's rail "Status" segment and its skill "Topics" scope, plus the
   // card/list layout toggle — all durable so Explore reopens as you left it.
   const [status, setStatus] = useSurfacePreference(surfacePreferenceSpecs.marketplace.status);
@@ -394,14 +403,14 @@ export function MarketplaceViewSurface({
   // Plugin pool — connectors (mcp/api) plus plugin-kind skills, honoring the
   // rail's Type + Status + Category/Collection scope and the search box.
   const filteredPlugins = useMemo(() => {
-    const matched = filterPlugins(plugins, {
+    const matched = filterPlugins(plugins.filter((plugin) => craftsEnabled || plugin.kind !== "craft"), {
       query,
       category: activeCollection || kind === "skill" ? "All" : category,
       kind,
       ids: collectionIds,
     }).filter(statusOkPlugin);
     return sortPlugins(matched, sort);
-  }, [plugins, query, category, kind, sort, collectionIds, activeCollection, statusOkPlugin]);
+  }, [plugins, craftsEnabled, query, category, kind, sort, collectionIds, activeCollection, statusOkPlugin]);
 
   // Registry skills join the pool whenever Skills (or All) is the active type;
   // a picked plugin category or "needs-setup" status excludes them.
@@ -446,19 +455,21 @@ export function MarketplaceViewSurface({
   // Rail counts (mock parity): Type spans the whole catalog; Status is global.
   const typeCount = useCallback(
     (id: KindFilter) => {
-      if (id === "all") return plugins.length + skills.length;
-      if (id === "skill") return plugins.filter((p) => p.kind === "skill").length + skills.length;
-      return plugins.filter((p) => p.kind === id).length;
+      const visiblePlugins = plugins.filter((plugin) => craftsEnabled || plugin.kind !== "craft");
+      if (id === "all") return visiblePlugins.length + skills.length;
+      if (id === "skill") return visiblePlugins.filter((p) => p.kind === "skill").length + skills.length;
+      return visiblePlugins.filter((p) => p.kind === id).length;
     },
-    [plugins, skills],
+    [plugins, skills, craftsEnabled],
   );
   const statusCount = useCallback(
     (id: MarketplaceStatusFilter) => {
-      if (id === "installed") return plugins.filter((p) => pluginBadgeState(p) === "added").length + skills.filter(skillIsInstalled).length;
-      if (id === "needs-setup") return plugins.filter((p) => pluginBadgeState(p) === "needs-setup").length;
-      return plugins.length + skills.length;
+      const visiblePlugins = plugins.filter((plugin) => craftsEnabled || plugin.kind !== "craft");
+      if (id === "installed") return visiblePlugins.filter((p) => pluginBadgeState(p) === "added").length + skills.filter(skillIsInstalled).length;
+      if (id === "needs-setup") return visiblePlugins.filter((p) => pluginBadgeState(p) === "needs-setup").length;
+      return visiblePlugins.length + skills.length;
     },
-    [plugins, skills, skillIsInstalled],
+    [plugins, skills, skillIsInstalled, craftsEnabled],
   );
 
   const craftPlugins = useMemo(
@@ -971,7 +982,7 @@ export function MarketplaceViewSurface({
             )}
           </div>
         </div>
-      ) : section === "crafts" ? (
+      ) : craftsEnabled && section === "crafts" ? (
         <div
           role="tabpanel"
           id="marketplace-panel-crafts"
@@ -1159,7 +1170,7 @@ export function MarketplaceViewSurface({
         />
       ) : null}
 
-      <CraftCreateDrawer
+      {craftsEnabled ? <CraftCreateDrawer
         open={creatingCraft}
         seed={craftSeed}
         onClose={() => {
@@ -1173,7 +1184,7 @@ export function MarketplaceViewSurface({
           void load(true).then(() => setSelected(id));
           announce("Craft draft saved", "polite");
         }}
-      />
+      /> : null}
 
       <SkillExploreDrawer
         key={exploreSkill?.id ?? "none"}

--- a/src/components/marketplace/crafts-visibility.test.ts
+++ b/src/components/marketplace/crafts-visibility.test.ts
@@ -4,6 +4,7 @@ import { readFile } from "node:fs/promises";
 const flags = await readFile(new URL("../../lib/feature-flags.ts", import.meta.url), "utf8");
 const model = await readFile(new URL("./marketplace-view-model.ts", import.meta.url), "utf8");
 const view = await readFile(new URL("../marketplace-view.tsx", import.meta.url), "utf8");
+const playwrightConfig = await readFile(new URL("../../../playwright.config.ts", import.meta.url), "utf8");
 
 assert.match(flags, /export function caveCrafts\(\): boolean/, "Crafts has an explicit runtime flag");
 assert.match(flags, /NEXT_PUBLIC_CAVE_CRAFTS/, "Crafts defaults off unless explicitly enabled at runtime");
@@ -12,5 +13,6 @@ assert.match(model, /caveCrafts\(\) \? \[\{ id: "craft", label: "Crafts"/, "the 
 assert.match(view, /const craftsEnabled = caveCrafts\(\);/, "the Marketplace surface reads the flag");
 assert.match(view, /plugins\.filter\(\(plugin\) => craftsEnabled \|\| plugin\.kind !== "craft"\)/, "Craft cards stay out of Browse while the flag is off");
 assert.match(view, /initialSection === "crafts"[\s\S]*\? craftsEnabled \? "crafts" : "browse"/, "Craft deep links fall back to Browse while the flag is off");
+assert.match(playwrightConfig, /NEXT_PUBLIC_CAVE_CRAFTS: "1"/, "Craft E2E specs explicitly enable the hidden-by-default surface");
 
 console.log("crafts-visibility.test.ts: ok");

--- a/src/components/marketplace/crafts-visibility.test.ts
+++ b/src/components/marketplace/crafts-visibility.test.ts
@@ -1,0 +1,16 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const flags = await readFile(new URL("../../lib/feature-flags.ts", import.meta.url), "utf8");
+const model = await readFile(new URL("./marketplace-view-model.ts", import.meta.url), "utf8");
+const view = await readFile(new URL("../marketplace-view.tsx", import.meta.url), "utf8");
+
+assert.match(flags, /export function caveCrafts\(\): boolean/, "Crafts has an explicit runtime flag");
+assert.match(flags, /NEXT_PUBLIC_CAVE_CRAFTS/, "Crafts defaults off unless explicitly enabled at runtime");
+assert.match(model, /caveCrafts\(\) \? \[\{ id: "crafts", label: "Crafts"/, "the Crafts tab is flag-gated");
+assert.match(model, /caveCrafts\(\) \? \[\{ id: "craft", label: "Crafts"/, "the Browse Crafts filter is flag-gated");
+assert.match(view, /const craftsEnabled = caveCrafts\(\);/, "the Marketplace surface reads the flag");
+assert.match(view, /plugins\.filter\(\(plugin\) => craftsEnabled \|\| plugin\.kind !== "craft"\)/, "Craft cards stay out of Browse while the flag is off");
+assert.match(view, /initialSection === "crafts"[\s\S]*\? craftsEnabled \? "crafts" : "browse"/, "Craft deep links fall back to Browse while the flag is off");
+
+console.log("crafts-visibility.test.ts: ok");

--- a/src/components/marketplace/marketplace-view-model.ts
+++ b/src/components/marketplace/marketplace-view-model.ts
@@ -2,6 +2,7 @@ import type { IconName } from "@/lib/icon";
 import type { SkillBrowserEntry } from "@/lib/skill-directory";
 import type { SkillEntry as SkillDetailEntry } from "@/components/skill-detail-drawer";
 import type { KindFilter, SortKey } from "@/lib/marketplace-catalog";
+import { caveCrafts } from "@/lib/feature-flags";
 
 /** Sections retained by the marketplace router, including legacy deep links.
  *  "skills" is no longer a visible tab — the Skills directory merged into
@@ -12,7 +13,7 @@ export type MarketplaceSection = "browse" | "crafts" | "roles" | "skills" | "bui
 
 export const MARKETPLACE_SECTIONS: ReadonlyArray<{ id: MarketplaceSection; label: string; icon: IconName }> = [
   { id: "browse", label: "Explore", icon: "ph:compass" },
-  { id: "crafts", label: "Crafts", icon: "ph:package-bold" },
+  ...(caveCrafts() ? [{ id: "crafts", label: "Crafts", icon: "ph:package-bold" } satisfies { id: MarketplaceSection; label: string; icon: IconName }] : []),
   { id: "build", label: "Build", icon: "ph:flow-arrow" },
 ];
 
@@ -61,7 +62,7 @@ export const MARKETPLACE_KIND_TABS: ReadonlyArray<{ id: KindFilter; label: strin
   { id: "skill", label: "Skills" },
   { id: "prompt", label: "Prompts" },
   { id: "knowledge-pack", label: "Knowledge packs" },
-  { id: "craft", label: "Crafts" },
+  ...(caveCrafts() ? [{ id: "craft", label: "Crafts" } satisfies { id: KindFilter; label: string }] : []),
 ];
 
 export const MARKETPLACE_SORT_OPTIONS: ReadonlyArray<{ id: SortKey; label: string }> = [

--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -132,7 +132,7 @@ assert.doesNotMatch(marketplaceView, /\{ id: "roles", label: "Roles"/, "no Roles
 assert.doesNotMatch(marketplaceView, /\{ id: "capabilities", label: "Capabilities"/, "no Capabilities tab — the section is retired from the hub");
 assert.match(
   marketplaceView,
-  /initialSection === "roles" \|\| initialSection === "capabilities" \? "browse" : initialSection/,
+  /initialSection === "roles" \|\| initialSection === "capabilities"\s*\? "browse"/,
   "'roles' and 'capabilities' deep links land on Browse",
 );
 assert.match(marketplaceView, /import \{ type SkillBrowserEntry \} from "@\/lib\/skill-directory"/, "hub consumes the registry skill entry type for Explore");

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -6,3 +6,9 @@ function envFlag(value: string | undefined): boolean {
 export function caveChatoutCodex(): boolean {
   return envFlag(process.env.NEXT_PUBLIC_CAVE_CHATOUT_CODEX);
 }
+
+/** Crafts stay implemented but are hidden until an operator explicitly enables
+ * them for the running Cave instance. */
+export function caveCrafts(): boolean {
+  return envFlag(process.env.NEXT_PUBLIC_CAVE_CRAFTS);
+}


### PR DESCRIPTION
## Summary
- hide Crafts tabs, Browse filters/cards, draft drawer, and deep links by default
- retain Craft implementation and API routes behind `NEXT_PUBLIC_CAVE_CRAFTS=1`
- add wired visibility coverage

## Verification
- pnpm typecheck
- pnpm lint
- node src/components/marketplace/crafts-visibility.test.ts
- git diff --check