### PR TITLE
fix(guard): close worktree-guard evasion gaps and record bypasses

### DIFF
--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -26,13 +26,23 @@
  *   • `git push <remote> --delete <branch>` (or `push <remote> :<branch>`) is
  *     blocked when an OPEN PR still has that head (deleting the branch closes
  *     the PR — the #2286 failure). Needs `gh` + network; fails OPEN.
+ *   • `mv .worktrees/<name> <elsewhere>` is blocked on the same risk test:
+ *     git's admin file keeps pointing at the old path, so moving a live
+ *     worktree strands its work exactly like deleting it would.
+ *
+ * Paths are resolved against the SEGMENT's effective cwd, which both a leading
+ * `cd <dir> &&` and git's `-C <dir>` move. Resolving against the hook's cwd
+ * instead made those forms silently unguarded (cave-6d2dp).
  *
  * Deliberate destruction is allowed by prefixing the command with
  * `WT_GUARD_BYPASS=1 ` — the guard only ensures it can't happen by accident.
+ * Honoured bypasses are appended to `.claude/worktree-guard-bypass.log`
+ * (gitignored) so a later post-mortem can tell a deliberate override from a
+ * gap in the guard — the question cave-boor8 could not answer.
  * On any internal error the guard exits 0: a hook bug must never brick Bash.
  */
 
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { appendFileSync, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
@@ -62,6 +72,32 @@ function block(reason) {
   process.exit(2);
 }
 
+/**
+ * Record every honoured bypass.
+ *
+ * On 2026-07-29 a worktree holding 3 uncommitted files was destroyed and the
+ * post-mortem (cave-boor8) could not establish whether the guard had been
+ * bypassed or circumvented — the bypass path left no trace at all. An append
+ * here makes that question answerable. Best-effort by construction: any failure
+ * is swallowed, because refusing a command over a logging problem would be a
+ * worse bug than the missing record.
+ */
+function recordBypass(command, cwd, sessionId) {
+  try {
+    const root = process.env.CLAUDE_PROJECT_DIR || cwd;
+    const line = `${JSON.stringify({
+      at: new Date().toISOString(),
+      session: sessionId ?? null,
+      cwd,
+      command: command.length > 500 ? `${command.slice(0, 500)}…` : command,
+    })}\n`;
+    // .claude/* is gitignored (except settings.json), so this never enters the repo.
+    appendFileSync(path.join(root, ".claude", "worktree-guard-bypass.log"), line);
+  } catch {
+    /* logging must never block a command */
+  }
+}
+
 function git(args, cwd) {
   return execFileSync("git", args, { cwd, encoding: "utf8", timeout: 5000, stdio: ["ignore", "pipe", "ignore"] });
 }
@@ -80,6 +116,29 @@ function segments(command) {
 function resolveTarget(raw, cwd) {
   const clean = raw.replace(/\/+$/, "");
   return path.isAbsolute(clean) ? clean : path.resolve(cwd, clean);
+}
+
+/**
+ * The directory a segment's relative paths actually resolve against.
+ *
+ * Two things move it, and missing either let a real removal through: a leading
+ * `cd <dir> &&` in the same compound command, and git's own `-C <dir>`. Before
+ * this, `cd .worktrees && git worktree remove x` (or `git -C <repo> worktree
+ * remove x`) resolved `x` against the HOOK's cwd, so destructionRisk() stat'd a
+ * path that didn't exist, returned "safe", and the removal sailed through.
+ */
+function cdTargetOf(seg) {
+  const m = seg.match(/^cd\s+(?!-)(\S+|"[^"]*"|'[^']*')\s*$/);
+  return m ? m[1].replace(/^['"]|['"]$/g, "") : null;
+}
+
+/** `-C <dir>` (repeatable in git, applied left to right) for one segment. */
+function gitDashCDir(toks, cwd) {
+  let dir = cwd;
+  for (let i = 0; i < toks.length - 1; i++) {
+    if (toks[i] === "-C") dir = resolveTarget(toks[i + 1], dir);
+  }
+  return dir;
 }
 
 /**
@@ -117,10 +176,30 @@ function destructionRisk(wtPath) {
 function checkWorktreeRemove(seg, cwd) {
   const m = seg.match(/\bgit\b.*\bworktree\s+remove\s+(.*)$/);
   if (!m) return;
+  const base = gitDashCDir(tokens(seg), cwd);
   for (const tok of tokens(m[1])) {
     if (tok.startsWith("-")) continue;
-    const risk = destructionRisk(resolveTarget(tok, cwd));
+    const risk = destructionRisk(resolveTarget(tok, base));
     if (risk) block(`\`git worktree remove\` targets live work:\n${risk}`);
+  }
+}
+
+/**
+ * Moving a worktree root is as destructive as deleting it: git's admin file
+ * still points at the old path, so the worktree is broken and any uncommitted
+ * work is stranded somewhere the owning session will not look. `git worktree
+ * move` is the supported operation and is left alone.
+ */
+function checkMove(seg, cwd) {
+  const toks = tokens(seg);
+  if (toks[0] !== "mv") return;
+  const operands = toks.slice(1).filter((t) => !t.startsWith("-"));
+  if (operands.length < 2) return;
+  for (const tok of operands.slice(0, -1)) {
+    const hit = worktreeRoot(resolveTarget(tok, cwd));
+    if (!hit?.root) continue; // container or a path inside — not ours to police
+    const risk = destructionRisk(hit.root);
+    if (risk) block(`\`mv\` would strand a live worktree (git still points at the old path):\n${risk}`);
   }
 }
 
@@ -131,7 +210,9 @@ function checkRmRf(seg, cwd) {
   if (!(flags.includes("r") && flags.includes("f")) && !flags.includes("R")) return;
   for (const tok of toks.slice(1)) {
     if (tok.startsWith("-")) continue;
-    if (!tok.includes(".worktrees")) continue;
+    // Classify the RESOLVED path, never the raw token: after `cd .worktrees`
+    // the token is a bare name like `feature-x` and a substring test on it
+    // silently skips a real worktree root.
     const hit = worktreeRoot(resolveTarget(tok, cwd));
     if (!hit) continue; // a path INSIDE a worktree — its owner's business
     if (hit.root) {
@@ -218,15 +299,27 @@ function main() {
   }
   const command = input?.tool_input?.command;
   if (typeof command !== "string" || !INTEREST.test(command)) return allow();
-  if (command.includes(BYPASS)) return allow();
   const cwd =
     (typeof input.cwd === "string" && input.cwd) || process.env.CLAUDE_PROJECT_DIR || process.cwd();
+  if (command.includes(BYPASS)) {
+    recordBypass(command, cwd, input?.session_id);
+    return allow();
+  }
 
+  // Relative paths resolve against the segment's effective cwd, which a leading
+  // `cd` in the same compound command moves for everything after it.
+  let segCwd = cwd;
   for (const seg of segments(command)) {
-    checkWorktreeRemove(seg, cwd);
-    checkRmRf(seg, cwd);
-    checkBranchDelete(seg, cwd);
-    checkRemoteBranchDelete(seg, cwd);
+    const cdTo = cdTargetOf(seg);
+    if (cdTo) {
+      segCwd = resolveTarget(cdTo, segCwd);
+      continue;
+    }
+    checkWorktreeRemove(seg, segCwd);
+    checkRmRf(seg, segCwd);
+    checkMove(seg, segCwd);
+    checkBranchDelete(seg, segCwd);
+    checkRemoteBranchDelete(seg, segCwd);
   }
   return allow();
 }

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -197,9 +197,21 @@ function checkMove(seg, cwd) {
   if (operands.length < 2) return;
   for (const tok of operands.slice(0, -1)) {
     const hit = worktreeRoot(resolveTarget(tok, cwd));
-    if (!hit?.root) continue; // container or a path inside — not ours to police
-    const risk = destructionRisk(hit.root);
-    if (risk) block(`\`mv\` would strand a live worktree (git still points at the old path):\n${risk}`);
+    if (!hit) continue; // a path inside a worktree is the owner's business
+    if (hit.root) {
+      const risk = destructionRisk(hit.root);
+      if (risk) block(`\`mv\` would strand a live worktree (git still points at the old path):\n${risk}`);
+    } else if (hit.container && existsSync(hit.container)) {
+      // Moving the container strands every child just like removing it does.
+      try {
+        for (const child of readdirSync(hit.container)) {
+          const risk = destructionRisk(path.join(hit.container, child));
+          if (risk) block(`\`mv ${tok}\` wipes every worktree, including live work:\n${risk}`);
+        }
+      } catch {
+        /* unreadable container — allow */
+      }
+    }
   }
 }
 
@@ -301,7 +313,7 @@ function main() {
   if (typeof command !== "string" || !INTEREST.test(command)) return allow();
   const cwd =
     (typeof input.cwd === "string" && input.cwd) || process.env.CLAUDE_PROJECT_DIR || process.cwd();
-  if (command.includes(BYPASS)) {
+  if (/^\s*WT_GUARD_BYPASS=1(?:\s|$)/.test(command)) {
     recordBypass(command, cwd, input?.session_id);
     return allow();
   }

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -6,7 +6,7 @@
 // garbage input. A guard bug must never brick Bash.
 
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync, chmodSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -133,11 +133,75 @@ if (!isWin) {
   assert.equal(runHook("git push origin --delete feature-x", dir, env).status, 0, "no open PR → passes");
 }
 
-// ── 8. The bypass token allows deliberate destruction ──────────────────────────
+// ── 8. The bypass token allows deliberate destruction, and is RECORDED ────────
+// cave-boor8: a worktree with 3 uncommitted files was destroyed and the
+// post-mortem could not tell a deliberate override from a hole in the guard,
+// because the bypass path left no trace whatsoever.
 {
   const { dir, wt } = repoWithWorktree({ push: false, dirty: true });
+  mkdirSync(path.join(dir, ".claude"), { recursive: true });
   const res = runHook(`WT_GUARD_BYPASS=1 git worktree remove --force ${wt}`, dir);
   assert.equal(res.status, 0, "bypass token is honored");
+
+  const log = path.join(dir, ".claude", "worktree-guard-bypass.log");
+  assert.ok(existsSync(log), "an honored bypass is recorded");
+  const entry = JSON.parse(readFileSync(log, "utf8").trim().split("\n").pop());
+  assert.match(entry.command, /worktree remove/, "the record names the command that was let through");
+  assert.equal(entry.session, "test", "and the session that ran it");
+  assert.ok(Date.parse(entry.at) > 0, "and when");
+
+  // A second bypass appends rather than truncating — the log is a history.
+  runHook(`WT_GUARD_BYPASS=1 rm -rf ${wt}`, dir);
+  assert.equal(readFileSync(log, "utf8").trim().split("\n").length, 2, "bypasses accumulate");
+}
+
+// ── 8b. A missing .claude dir must not brick the command ──────────────────────
+{
+  const { dir, wt } = repoWithWorktree({ push: false, dirty: true });
+  // no .claude/ here — appendFileSync will throw and must be swallowed
+  assert.equal(
+    runHook(`WT_GUARD_BYPASS=1 git worktree remove --force ${wt}`, dir).status,
+    0,
+    "a logging failure never blocks a command",
+  );
+}
+
+// ── 8c. `cd` and `git -C` no longer hide a removal from the guard ─────────────
+// The gap that let cave-boor8 happen: relative targets were resolved against the
+// HOOK's cwd, so these forms stat'd a nonexistent path and were waved through.
+{
+  const { dir } = repoWithWorktree({ push: true, dirty: true });
+  const cases = [
+    ["cd .worktrees && git worktree remove feature-x", "cd moves the resolution base"],
+    [`git -C ${dir} worktree remove .worktrees/feature-x`, "-C moves the resolution base"],
+    ["cd .worktrees && rm -rf feature-x", "cd applies to rm too"],
+  ];
+  for (const [cmd, why] of cases) {
+    const res = runHook(cmd, dir);
+    assert.equal(res.status, 2, `blocks (${why}): ${cmd}`);
+    assert.match(res.stderr, /uncommitted change/, "and says why");
+  }
+  // A cd that walks somewhere unrelated must not create false positives.
+  assert.equal(
+    runHook("cd /tmp && rm -rf feature-x", dir).status,
+    0,
+    "an unrelated path outside .worktrees still passes",
+  );
+}
+
+// ── 8d. Moving a live worktree strands it just as badly as deleting it ────────
+{
+  const { dir, wt } = repoWithWorktree({ push: true, dirty: true });
+  const res = runHook(`mv ${wt} /tmp/parked-worktree`, dir);
+  assert.equal(res.status, 2, "moving a live worktree root is blocked");
+  assert.match(res.stderr, /strand a live worktree/, "explains that git still points at the old path");
+
+  // Moving something INSIDE a worktree, or a husk, is nobody else's business.
+  assert.equal(
+    runHook(`mv ${path.join(wt, "c.txt")} /tmp/c.txt`, dir).status,
+    0,
+    "moving a file inside a worktree passes",
+  );
 }
 
 // ── 9. Non-matching commands and garbage input never block ────────────────────

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -15,6 +15,7 @@ import { execFileSync, spawnSync } from "node:child_process";
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const script = path.join(root, "scripts", "worktree-guard.mjs");
 const isWin = process.platform === "win32";
+const BYPASS = "WT_GUARD_BYPASS=1";
 
 function runHook(command, cwd, extraEnv = {}) {
   const payload = JSON.stringify({ session_id: "test", cwd, tool_name: "Bash", tool_input: { command } });
@@ -202,6 +203,22 @@ if (!isWin) {
     0,
     "moving a file inside a worktree passes",
   );
+}
+
+// ── 8e. Moving the whole container must scan every child ─────────────────────
+{
+  const { dir } = repoWithWorktree({ push: true, dirty: true });
+  const res = runHook(`mv ${path.join(dir, ".worktrees")} /tmp/parked-worktrees`, dir);
+  assert.equal(res.status, 2, "moving every worktree is blocked while one is dirty");
+  assert.match(res.stderr, /wipes every worktree/);
+}
+
+// ── 8f. Only a leading bypass assignment is honoured ─────────────────────────
+{
+  const { dir, wt } = repoWithWorktree({ push: true, dirty: true });
+  const res = runHook(`echo ${BYPASS} && rm -rf ${wt}`, dir);
+  assert.equal(res.status, 2, "a bypass-looking argument cannot disable a later destructive command");
+  assert.match(res.stderr, /uncommitted change/);
 }
 
 // ── 9. Non-matching commands and garbage input never block ────────────────────


### PR DESCRIPTION
## Why

A worktree holding **3 uncommitted files was destroyed while the guard was active** (`cave-boor8`). The post-mortem could not establish whether the guard had been bypassed or simply circumvented — because the bypass path left no trace at all. That question turned out to be unanswerable, which is its own bug.

Three holes, all closed here.

## 1. Path resolution ignored `cd` and `git -C`

Targets resolved against the **hook's** cwd. So:

```bash
cd .worktrees && git worktree remove x
git -C <repo> worktree remove x
```

…resolved `x` against the wrong directory, `destructionRisk()` stat'd a path that didn't exist, returned "safe", and the removal was waved through. Each segment now carries an effective cwd that a leading `cd` moves, and `-C` is honoured per segment.

## 2. `mv` wasn't checked at all

Moving a worktree root strands it exactly like deleting it: git's admin file still points at the old path, so the worktree is broken and its uncommitted work sits somewhere the owning session will never look. Now blocked on the same risk test.

`git worktree move` (the supported operation) and moves *inside* a worktree are untouched.

## 3. Honoured bypasses left no trace

`WT_GUARD_BYPASS=1` now appends `{at, session, cwd, command}` to `.claude/worktree-guard-bypass.log` (gitignored via `.gitignore:55`). Logging is **best-effort by construction** — a failure there must never block a command, and there's a test for the missing-`.claude` case.

## A bug this surfaced in my own fix

The `rm`/`mv` checks filtered on the **raw token** containing `.worktrees`. After `cd .worktrees` the token is a bare `feature-x`, so the substring test skipped a real worktree root and `rm -rf` stayed unguarded. Both now classify the **resolved absolute path**.

That's the same class of mistake as the original gap, and it survived the first cut of the fix — caught only because the new test asserted the `cd … && rm -rf` case specifically.

## Residual gap this does NOT close

The hook's matcher is `Bash`. Destruction from a non-Bash tool or an external process evades it **by construction**, and no change inside this script can fix that. If `probe-timing` went that way, none of this would have stopped it — the new bypass log is precisely what lets us tell the two cases apart next time.

## Tests

`scripts/worktree-guard.test.mjs` gains cases for: bypass logging (contents, and that entries accumulate rather than truncate), logging failure not blocking, `cd`/`-C`/`cd + rm -rf` removals being blocked, an unrelated `cd /tmp && rm -rf feature-x` still passing (no false positives), `mv` of a live root blocked, and `mv` of a file inside a worktree passing.

Every pre-existing pass-silently case still exits 0: husk GC, clean+pushed cleanup, paths inside a worktree, garbage input.

## Verification

Exit codes captured unpiped:

- `node scripts/worktree-guard.test.mjs` — 0
- `pnpm typecheck` — 0
- `pnpm lint` — 0
- `pnpm check:tests-wired` — 0, 1333 files wired

Closes `cave-6d2dp`. Follows `cave-boor8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)