### PR TITLE
fix(signals): clear thread signals the newest report no longer reports

### DIFF
--- a/src/components/thread-signals-section.test.ts
+++ b/src/components/thread-signals-section.test.ts
@@ -71,20 +71,21 @@ describe("aggregateThreadSignals", () => {
   it("marks blockers as crit when in >50% of reports", () => {
     const blocker = { id: "x", title: "X", category: "auth" as const, impact: "high" as const, detail: "" };
     const reports = [
-      report({ id: "r1", persistentBlockers: [blocker] }),
-      report({ id: "r2", persistentBlockers: [blocker] }),
-      report({ id: "r3", persistentBlockers: [] }),
+      report({ id: "r1", reportedAt: "2026-06-23T00:00:00.000Z", persistentBlockers: [blocker] }),
+      report({ id: "r2", reportedAt: "2026-06-24T00:00:00.000Z", persistentBlockers: [blocker] }),
+      report({ id: "r3", reportedAt: "2026-06-25T00:00:00.000Z", persistentBlockers: [blocker] }),
     ];
     const agg = aggregateThreadSignals(reports);
-    // x appears in 2/3 = 67% → crit
+    // x appears in 3/3 = 100% → crit
     assert.equal(agg.persistentBlockers[0].crit, true);
   });
 
   it("does not mark blockers as crit when in ≤50% of reports", () => {
     const blocker = { id: "y", title: "Y", category: "tooling" as const, impact: "medium" as const, detail: "" };
     const reports = [
-      report({ id: "r1", persistentBlockers: [blocker] }),
-      report({ id: "r2", persistentBlockers: [] }),
+      report({ id: "r1", reportedAt: "2026-06-23T00:00:00.000Z", persistentBlockers: [] }),
+      report({ id: "r2", reportedAt: "2026-06-24T00:00:00.000Z", persistentBlockers: [] }),
+      report({ id: "r3", reportedAt: "2026-06-25T00:00:00.000Z", persistentBlockers: [blocker] }),
     ];
     const agg = aggregateThreadSignals(reports);
     assert.equal(agg.persistentBlockers[0].crit, false);
@@ -104,16 +105,18 @@ describe("aggregateThreadSignals", () => {
     const reports = [
       report({
         id: "r1",
+        reportedAt: "2026-06-26T00:00:00.000Z",
         contextPressure: "critical",
         skillsNeedingAccess: [{ skillId: "github", reason: "token expired" }],
+        capabilitiesLacking: [{ name: "calendar search", importance: "blocking", detail: "cannot inspect conflicts" }],
         persistentBlockers: [
           { id: "auth", title: "Auth expired", category: "auth", impact: "blocking", detail: "GitHub auth failed" },
         ],
       }),
       report({
         id: "r2",
+        reportedAt: "2026-06-25T00:00:00.000Z",
         contextPressure: "tight",
-        capabilitiesLacking: [{ name: "calendar search", importance: "blocking", detail: "cannot inspect conflicts" }],
       }),
     ];
     const review = buildThreadSignalReviewQueue(aggregateThreadSignals(reports));
@@ -121,6 +124,12 @@ describe("aggregateThreadSignals", () => {
     assert.equal(review[0].severity, "critical");
     assert.match(review[0].title, /Auth expired/);
     assert.ok(review.some((item) => item.kind === "skill-access" && item.title === "github"));
+    assert.ok(
+      review.some(
+        (item) =>
+          item.kind === "capability" && item.sourceId === "calendar search" && item.title === "calendar search",
+      ),
+    );
     assert.ok(review.some((item) => item.kind === "context-pressure" && item.detail.includes("critical")));
   });
 

--- a/src/lib/thread-self-report.test.ts
+++ b/src/lib/thread-self-report.test.ts
@@ -284,3 +284,146 @@ describe("aggregateThreadSignals skill access gaps", () => {
     ]);
   });
 });
+
+describe("aggregateThreadSignals stale signal clearing", () => {
+  function reportAt(
+    id: string,
+    reportedAt: string,
+    overrides: Partial<ThreadSelfReport>,
+  ): ThreadSelfReport {
+    return {
+      ...fullReport(),
+      id,
+      sessionId: id,
+      reportedAt,
+      ...overrides,
+    };
+  }
+
+  it("clears stale capabilitiesLacking rows when newer reports no longer list them", () => {
+    const stale = reportAt("session-old", "2026-07-10T08:00:00.000Z", {
+      capabilitiesLacking: [
+        {
+          name: "Reliable granted-root write enforcement",
+          importance: "blocking",
+          detail: "Writes and repo-local commands were denied.",
+        },
+      ],
+    });
+    const recovered = reportAt("session-new", "2026-07-14T09:00:00.000Z", {
+      capabilitiesLacking: [],
+    });
+
+    for (const reports of [
+      [stale, recovered],
+      [recovered, stale],
+    ]) {
+      assert.deepEqual(aggregateThreadSignals(reports).capabilitiesLacking, []);
+    }
+  });
+
+  it("clears stale persistent blockers when newer reports resolve them", () => {
+    const stale = reportAt("session-old", "2026-07-10T08:00:00.000Z", {
+      persistentBlockers: [
+        {
+          id: "granted-root-write-denied",
+          title: "coven-cave grant not reflected in tool execution",
+          category: "permission",
+          impact: "blocking",
+          detail: "Writes and cwd changes were denied in the target repo.",
+        },
+      ],
+    });
+    const recovered = reportAt("session-new", "2026-07-14T09:00:00.000Z", {
+      persistentBlockers: [],
+    });
+
+    for (const reports of [
+      [stale, recovered],
+      [recovered, stale],
+    ]) {
+      assert.deepEqual(aggregateThreadSignals(reports).persistentBlockers, []);
+    }
+  });
+
+  it("uses descending report ID to break reportedAt ties regardless of input order", () => {
+    const stale = reportAt("report-a", "2026-07-14T09:00:00.000Z", {
+      capabilitiesLacking: [
+        {
+          name: "Shell access",
+          importance: "blocking",
+          detail: "Commands were denied.",
+        },
+      ],
+      persistentBlockers: [
+        {
+          id: "shell-denied",
+          title: "Shell denied",
+          category: "permission",
+          impact: "blocking",
+          detail: "Commands were denied.",
+        },
+      ],
+    });
+    const recovered = reportAt("report-z", stale.reportedAt, {
+      capabilitiesLacking: [],
+      persistentBlockers: [],
+    });
+
+    for (const reports of [
+      [stale, recovered],
+      [recovered, stale],
+    ]) {
+      const aggregate = aggregateThreadSignals(reports);
+      assert.deepEqual(aggregate.capabilitiesLacking, []);
+      assert.deepEqual(aggregate.persistentBlockers, []);
+    }
+  });
+
+  it("keeps historical frequency only for blockers still active in the newest report", () => {
+    const staleOnly = reportAt("session-oldest", "2026-07-08T08:00:00.000Z", {
+      persistentBlockers: [
+        {
+          id: "old-only",
+          title: "Old blocker",
+          category: "other",
+          impact: "high",
+          detail: "Only appears in old sessions.",
+        },
+        {
+          id: "still-active",
+          title: "Still active",
+          category: "infra",
+          impact: "medium",
+          detail: "Persists into newer sessions.",
+        },
+      ],
+    });
+    const older = reportAt("session-old", "2026-07-10T08:00:00.000Z", {
+      persistentBlockers: [
+        {
+          id: "still-active",
+          title: "Still active",
+          category: "infra",
+          impact: "medium",
+          detail: "Persists into newer sessions.",
+        },
+      ],
+    });
+    const newest = reportAt("session-new", "2026-07-14T09:00:00.000Z", {
+      persistentBlockers: [
+        {
+          id: "still-active",
+          title: "Still active",
+          category: "infra",
+          impact: "medium",
+          detail: "Persists into newer sessions.",
+        },
+      ],
+    });
+
+    const aggregate = aggregateThreadSignals([staleOnly, older, newest]);
+    assert.deepEqual(aggregate.persistentBlockers.map((item) => item.id), ["still-active"]);
+    assert.equal(aggregate.persistentBlockers[0].frequency, 3);
+  });
+});

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -215,8 +215,6 @@ export function buildThreadSignalResolutionPrompt(item: ThreadSignalReviewItem):
 
 export const THREAD_SIGNALS_EMPTY_STATE = "No thread reports yet. Use 'Reflect on this thread' to generate the first one.";
 
-const IMPORTANCE_WEIGHT: Record<CapabilityImportance, number> = { "nice-to-have": 1, important: 2, blocking: 3 };
-
 function libAvg(values: number[]): number {
   if (values.length === 0) return 0;
   return Math.round(values.reduce((s, v) => s + v, 0) / values.length);
@@ -236,7 +234,17 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
   const blockerFreq = new Map<string, number>();
   const blockerData = new Map<string, ThreadSelfReport["persistentBlockers"][number]>();
 
-  const sorted = [...reports].sort((a, b) => new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime());
+  const sorted = [...reports].sort(
+    (a, b) =>
+      new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime() ||
+      b.id.localeCompare(a.id),
+  );
+  const newest = sorted[0] ?? null;
+  // Stale-signal clearing: these lists are "current issues". If the newest
+  // report no longer carries an item, treat it as resolved and keep it out of
+  // the aggregate/queue even if older reports still mention it.
+  const activeCapabilityLacking = new Set((newest?.capabilitiesLacking ?? []).map((item) => item.name));
+  const activeBlockers = new Set((newest?.persistentBlockers ?? []).map((item) => item.id));
 
   for (const r of sorted) {
     contextCounts[r.contextPressure]++;
@@ -266,10 +274,13 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
       if (!capVital.has(c.name)) capVital.set(c.name, c);
     }
     for (const c of r.capabilitiesLacking) {
-      const prev = capLacking.get(c.name);
-      if (!prev || IMPORTANCE_WEIGHT[c.importance] > IMPORTANCE_WEIGHT[prev.importance]) capLacking.set(c.name, c);
+      if (!activeCapabilityLacking.has(c.name)) continue;
+      // Latest report wins per capability: once a capability is no longer in
+      // the newest "lacking" list, older complaints stay resolved.
+      if (!capLacking.has(c.name)) capLacking.set(c.name, c);
     }
     for (const b of r.persistentBlockers) {
+      if (!activeBlockers.has(b.id)) continue;
       libIncrement(blockerFreq, b.id);
       if (!blockerData.has(b.id)) blockerData.set(b.id, b);
     }


### PR DESCRIPTION
`capabilitiesLacking` and `persistentBlockers` are *current issues*, but `aggregateThreadSignals` treated them as history: one report naming a blocker kept it in the aggregate — and in the review queue, the attention count, and self-heal escalation — for the whole report window, however many later threads ran without it.

Closes `cave-vfk81`.

## This completes a rule the function already applies twice

`skillsNeedingAccess` and `capabilitiesVital` both carry a documented "latest report wins" rule citing **`cave-hdkx`**, where a stale *"not installed"* complaint pinned `status: blocked` long after later threads used the skill successfully. The two remaining lists never got the same treatment. Now they do — an item absent from the newest report is treated as resolved and kept out of the aggregate.

Two details worth calling out:

- **Frequency still counts every report** a blocker appeared in, so a long-running problem keeps its rank. It just has to *still be happening*.
- **The `reportedAt` sort gains an `id` tiebreak.** Reports sharing a timestamp previously ordered by input order, which silently decided which report counted as "newest" — the value the whole rule now hinges on.

## Downstream needed no changes — verified, not assumed

| consumer | behaviour under the new rule |
|---|---|
| `escalateBlockers` | stops raising heal requests for a cleared blocker |
| `blockingSignalCount` | stops counting it toward the attention badge |
| `thread-signals-section` | stops rendering its row |

## Provenance

These files were **uncommitted in the shared primary checkout** when it was cleared on 2026-07-29, and the session that wrote them had exited. Rather than take the intent on trust, I read the change against the file's own established rule and checked every consumer above.

The rescue also swept in an unrelated `.beads/ios-swipe-beads-import.jsonl`; dropped from this PR.

## Verification

The new tests **fail when the change is reverted** — I removed both clearing guards and confirmed `not ok 6 - aggregateThreadSignals stale signal clearing`, so they pin the behaviour rather than merely accompanying it.

| Gate | Result |
|---|---|
| `pnpm test:app` | 973 files pass |
| `typecheck` · `lint` · `check:tests-wired` | pass |

## Known follow-on (not in scope here)

A `SelfHealRequest` already raised for a blocker is **not** auto-resolved when that blocker clears — `escalateBlockers` only stops creating *new* ones. That's pre-existing heal-request lifecycle behaviour, but it's more visible now that blockers can clear, and worth a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)