### PR TITLE
fix(chat): hold the Chat.dc.html session grammar under the typed follow-ups

### DIFF
--- a/src/components/chat-session-chrome.test.ts
+++ b/src/components/chat-session-chrome.test.ts
@@ -41,6 +41,13 @@ test("2a ③ — the context row renders under the header, from the same facts a
     /const \{ branch: sessionGitBranch \} = useChangesSummary\(/,
     "the branch rides the shared changes-summary gate rather than its own fetch",
   );
+  // 2b: a brand-new chat renders NO context band — the new-session dashboard
+  // already states the harness and model, so a lone model chip would repeat it.
+  assert.match(
+    chatView,
+    /\{sessionId !== null \|\| turns\.length > 0 \? \(\s*\n\s*<ChatSessionContextRow/,
+    "the band waits for a session or a first turn before it renders",
+  );
 });
 
 test("2a ③ — the row is presentation over a pure model and never renders empty chrome", () => {
@@ -84,14 +91,24 @@ test("2a — the title row and turn names wear the display serif", () => {
   );
 });
 
-test("2a ⑤ — follow-up pills spread the composer's width; in-turn chips don't", () => {
+test("2a ⑤ — follow-up suggestions spread the composer's width in ONE row", () => {
+  // The typed follow-up cards carry the design's geometry: equal shares of a
+  // single row (auto-flow column), never a count-blind grid that leaves a
+  // ragged 2+1 tail (#2672). next-paths caps the strip at 4.
   assert.match(
     styles,
-    /\.cave-chat-followups \.cave-next-path \{[\s\S]*?flex: 1 1 0;[\s\S]*?height: 40px;/,
-    "follow-ups take equal shares of one 40px row",
+    /\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: column;[\s\S]*?grid-auto-columns: minmax\(0, 1fr\);/,
+    "follow-up cards take equal shares of one row",
   );
-  // The shared in-turn chip grammar (intrinsic width, scrollable row) is
-  // untouched — the override only ever applies under .cave-chat-followups.
+  // The pill-era override is gone: nothing renders .cave-next-path inside the
+  // follow-up strip, so the orphaned selector must not linger in the cascade.
+  assert.doesNotMatch(
+    styles,
+    /\.cave-chat-followups \.cave-next-path\b/,
+    "the orphaned pill override does not survive the typed-card grammar",
+  );
+  // The shared in-turn chip grammar (intrinsic width, count-keyed row) is
+  // untouched.
   assert.doesNotMatch(
     styles.match(/^\.cave-next-path \{[\s\S]*?\n\}/m)?.[0] ?? "",
     /flex: 1 1 0/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5852,7 +5852,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       {/* Chat.dc.html 2a ③: the slim mono context band under the title —
           project · branch · model · cwd on the left, what the last run cost on
           the right. Everything here is machine-decided, so it reads in mono
-          and never invents a fact: a chip with no value doesn't render. */}
+          and never invents a fact: a chip with no value doesn't render. A
+          brand-new chat (no session yet) renders no band at all (2b): the
+          new-session dashboard already states the harness and model, so a lone
+          model chip here would say it twice. */}
+      {sessionId !== null || turns.length > 0 ? (
       <ChatSessionContextRow
         projectName={contextRowProject?.name ?? null}
         projectRoot={session?.project_root ?? projectRoot ?? null}
@@ -5867,6 +5871,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         onProjectChange={setProjectIdDraft}
         onAddProject={overflowAddProject.beginAddProject}
       />
+      ) : null}
       <RunActivityStrip activeTurn={activePendingTurn} lastTurn={lastSettledAssistantTurn} />
       <ToolProjectRootContext.Provider value={session?.project_root ?? projectRoot ?? null}>
       <FileLinkResolverContext.Provider value={fileLinkResolver}>

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -193,28 +193,11 @@
   }
 }
 
-/* ── ⑤ Suggestion pills spread the full width ──────────────────────────────
-   The design gives the follow-ups equal shares of the composer's measure —
-   one uniform row of up to four 40px pills — instead of intrinsic-width chips
-   that leave a ragged tail. Scoped to the follow-up row: the in-turn
-   .cave-next-paths chips keep their scrollable single-row grammar. */
-
-.cave-chat-followups .cave-next-paths {
-  flex-wrap: nowrap;
-  overflow: visible;
-}
-
-.cave-chat-followups .cave-next-path {
-  flex: 1 1 0;
-  min-width: 0;
-  justify-content: center;
-  height: 40px;
-  padding: 0 var(--space-4);
-  border-radius: var(--radius-panel);
-  background: color-mix(in oklch, var(--bg-raised) 45%, transparent);
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
+/* ── ⑤ Suggestions spread the full width ───────────────────────────────────
+   The design gives the follow-ups equal shares of ONE row of the composer's
+   measure. The typed follow-up cards that replaced the plain pills carry that
+   geometry in cave-chat/transcript.css (.cave-followup-cards__grid); the
+   in-turn .cave-next-paths chips keep their own count-keyed grammar. */
 
 /* ── Turn typography (④) ───────────────────────────────────────────────────
    The familiar's name is the second identity moment in the surface, so it

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -382,7 +382,10 @@
 
 .cave-followup-cards__grid {
   display: grid;
-  grid-template-columns: minmax(0, 1fr);
+  /* Chat.dc.html 2a ⑤ — suggestions take equal shares of ONE row (next-paths
+     caps the strip at 4), so the strip never renders a ragged 2+1 (#2672). */
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
   gap: var(--space-2);
 }
 
@@ -413,9 +416,12 @@
   color: var(--text-secondary);
 }
 
-@media (min-width: 40rem) {
+@media (max-width: 40rem) {
+  /* Narrow panes stack the cards instead of squeezing four abreast. */
   .cave-followup-cards__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-auto-flow: row;
+    grid-auto-columns: unset;
+    grid-template-columns: minmax(0, 1fr);
   }
 }
 

--- a/src/styles/globals/surface-compact-calendar.css
+++ b/src/styles/globals/surface-compact-calendar.css
@@ -656,6 +656,17 @@
   padding-block: 7px;
 }
 
+/* Chat.dc.html 2a ① — the chat chrome's tab row reads in the machine register:
+   mono, uppercase, letterspaced. Scoped to the chat surface's tab strip so the
+   shared Tabs primitive keeps its Inter register on every other surface. */
+.chat-scope-tabs [role="tab"] {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
 /* Dynamic viewport units for layout shell + modals — `100vh` on iOS
    includes the address bar height, so a `100vh` element would push
    content under the chrome. `100dvh` tracks the visible area, including


### PR DESCRIPTION
A live design-adherence review of the chat surface against the Chat.dc.html handoff (turn 2 "hybrid", project e13203e0) — driven in a prod build with real session data, including the very conversation the mock's transcript is based on — found four drifts from the merged redesign (#3983). This restores them without giving up anything the surface gained since.

## Fixes

- **Follow-up suggestions take equal shares of ONE row again (2a ⑤).** The typed intent cards (`87d27b3`) kept their Reply/Task/Action semantics but sat in a count-blind 2-column grid, so three suggestions rendered as a ragged 2+1 — the shape the uniform-rows rule (#2672) pins against. `grid-auto-flow: column` yields N equal columns at any count (next-paths caps the strip at 4); panes ≤40rem stack.
- **Orphaned ⑤ pill CSS removed.** Nothing renders `.cave-next-path` inside `.cave-chat-followups` since the typed cards landed; the block was dead cascade and its test pin asserted CSS the UI no longer used. The pin now guards the live contract and refuses the orphaned selector.
- **A brand-new chat renders no context band (2b).** The band's honest-chips rule let a lone `model` chip through on `sessionId === null`, repeating what the new-session dashboard's identity meta says directly above it.
- **The chat tab row wears the design's machine register** — mono, uppercase, letterspaced — scoped to `.chat-scope-tabs` so the shared Tabs primitive keeps its Inter register on every other surface.

## Verification

Prod build served against real data (session `fe292147`): new chat renders the dashboard with **no** context band; four suggestions render as **one row of equal-width cards**; tabs read in JetBrains Mono 10px/600/uppercase; the rest of the 2a chrome (serif title, 30px mono context row, honest chips, card user turns at the reading column's left edge, rail ticks/counts/⌘N) verified unchanged.

Gates: `pnpm test:app` (973 files) · `pnpm build` (first-load CSS 898/900 KB) · tsc · eslint · design-token-drift · css-module-order.

Bead: cave-hf7kt

🤖 Generated with [Claude Code](https://claude.com/claude-code)