### PR TITLE
docs(heal): record that SelfHealRequest.resolved is honoured but never set

### DIFF
--- a/src/lib/familiar-heal-requests.ts
+++ b/src/lib/familiar-heal-requests.ts
@@ -15,6 +15,24 @@ export type SelfHealRequest = {
   suggestedAction: string;
   actionKind: HealActionKind;
   createdAt: string;
+  /** Consumers honour this; no producer sets it yet.
+   *
+   *  Every request in this file is DERIVED — from contract violations, growth
+   *  signals, or the thread-signal aggregate — and none is persisted, so
+   *  nothing has anywhere to record a resolution and all four construction
+   *  sites below set `false`. A request stops existing when the condition that
+   *  derived it stops holding, which is why the system works without ever
+   *  flipping this.
+   *
+   *  It is still load-bearing on the read side: familiar-card-insights gates
+   *  its "Review heal requests" action on `!resolved` and excludes resolved
+   *  requests from the `openHeals` count, with a test pinning that a resolved
+   *  request is not counted. So the filter reads as vacuous today but is the
+   *  correct behaviour the moment persisted, resolvable requests exist.
+   *
+   *  Do not "clean this up" as a dead field (cave-7zbup): deleting it changes
+   *  tested insight behaviour. Delete it only together with those consumers,
+   *  or leave it until resolution is actually implemented. */
   resolved: boolean;
 };
 


### PR DESCRIPTION
**This PR does the opposite of what its branch name says, and that's the point.**

I filed `cave-7zbup` claiming `SelfHealRequest.resolved` was dead — *always false, never set, never read* — and opened this branch to delete it. It isn't dead. Deleting it would have silently changed tested behaviour.

## What I got wrong

`familiar-card-insights.ts` reads it in two places, and a test pins the semantics:

| location | use |
|---|---|
| `familiar-card-insights.ts:96` | gates the *"Review heal requests"* action on `healRequests.some((r) => !r.resolved)` |
| `familiar-card-insights.ts:110` | `openHeals = healRequests.filter((r) => !r.resolved).length` |
| `familiar-card-insights.test.ts:112` | passes a `resolved: true` request and asserts `"1 self-heal request"` — *resolved heals not counted* |

My original search scoped "who consumes `SelfHealRequest`" to files importing that type by name. `familiar-card-insights` takes a structurally-typed model, so it never appeared.

## What's actually true

Consumers honour the flag; **no producer sets it**. Every request is derived — contract violations, growth signals, the thread-signal aggregate — and none is persisted, so there's nowhere to record a resolution and all four construction sites set `false`. A request stops existing when the condition that derived it stops holding, which is why the system works without ever flipping it.

So the filter is vacuous *today* and becomes correct the moment persisted, resolvable requests exist. That's a half-implemented lifecycle, not dead code.

## The change

A comment at the field, recording the asymmetry and that it must not be deleted without its consumers. **No behaviour change** — one file, +18 lines of documentation.

The asymmetry is invisible at the definition, which is precisely what led me to nearly delete it. Now the next person reads it before reaching for the same fix.

| Gate | Result |
|---|---|
| `pnpm test:app` | 973 files pass |
| `typecheck` · `lint` | pass |

`cave-7zbup` has had its title and description corrected to match reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)