### PR TITLE
test(chat): align follow-up grid contract

### DIFF
--- a/src/components/chat-view-polish-edit-review.test.ts
+++ b/src/components/chat-view-polish-edit-review.test.ts
@@ -27,8 +27,13 @@ assert.match(
 );
 assert.match(
   styles,
-  /\.cave-followup-cards__grid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/,
-  "cards use the responsive two-column card grid",
+  /\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: column;[\s\S]*?grid-auto-columns: minmax\(0, 1fr\)/,
+  "cards use equal shares in one row",
+);
+assert.match(
+  styles,
+  /@media \(max-width: 40rem\) \{[\s\S]*?\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: row;[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/,
+  "cards stack in a single column in narrow panes",
 );
 assert.match(
   styles,


### PR DESCRIPTION
Follow-up to #4036. Updates the legacy ChatView polish contract to match the landed one-row typed follow-up grid and pins the narrow-pane single-column fallback. Verified with the CSS source-contract hook, both focused tests, and git diff check.