### PR TITLE
fix(voice): recover native microphone permission flow

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1197,6 +1197,7 @@ export const SUITES = {
     "src/lib/voice/local-tts.test.ts",
     "src/lib/voice/speak-message.test.ts",
     "src/lib/voice/speech-loop.test.ts",
+    "src/lib/voice/microphone-access.test.ts",
     "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",
     "src/lib/voice/elevenlabs.test.ts",

--- a/src-tauri/capabilities/loopback-microphone.json
+++ b/src-tauri/capabilities/loopback-microphone.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "loopback-microphone",
+  "description": "allows only the trusted main loopback webview to request and recover macOS microphone access",
+  "platforms": [
+    "macOS"
+  ],
+  "webviews": [
+    "main"
+  ],
+  "remote": {
+    "urls": [
+      "http://localhost:*/*",
+      "http://127.0.0.1:*/*",
+      "http://[\\:\\:1]:*/*"
+    ]
+  },
+  "permissions": [
+    "allow-microphone-permission-request",
+    "allow-microphone-settings-open"
+  ]
+}

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -21,15 +21,21 @@ const loopbackUpdaterCapability = JSON.parse(
 const loopbackSpeechCapability = JSON.parse(
   readFileSync(new URL("../capabilities/loopback-speech.json", import.meta.url), "utf8"),
 );
+const loopbackMicrophoneCapability = JSON.parse(
+  readFileSync(new URL("../capabilities/loopback-microphone.json", import.meta.url), "utf8"),
+);
 const defaultPermissions = readFileSync(new URL("./default.toml", import.meta.url), "utf8");
 const commandPermissions = readFileSync(new URL("./pty.toml", import.meta.url), "utf8");
 const speechPermissions = readFileSync(new URL("./speech.toml", import.meta.url), "utf8");
+const microphonePermissions = readFileSync(new URL("./microphone.toml", import.meta.url), "utf8");
 const reachabilityPermissions = readFileSync(new URL("./desktop-reachability.toml", import.meta.url), "utf8");
 const browserRust = readFileSync(new URL("../src/browser.rs", import.meta.url), "utf8");
 const browserCommandsRust = readFileSync(new URL("../src/browser_commands.rs", import.meta.url), "utf8");
 const ptyRust = readFileSync(new URL("../src/pty.rs", import.meta.url), "utf8");
 const tauriSetupRust = readFileSync(new URL("../src/tauri_setup.rs", import.meta.url), "utf8");
+const microphoneRust = readFileSync(new URL("../src/microphone.rs", import.meta.url), "utf8");
 const nativeSttTs = readFileSync(new URL("../../src/lib/voice/native-stt.ts", import.meta.url), "utf8");
+const microphoneAccessTs = readFileSync(new URL("../../src/lib/voice/microphone-access.ts", import.meta.url), "utf8");
 const browserPane = readFileSync(new URL("../../src/components/browser-pane.tsx", import.meta.url), "utf8");
 const bottomTerminal = readFileSync(new URL("../../src/components/bottom-terminal.tsx", import.meta.url), "utf8");
 const shellTsx = readFileSync(new URL("../../src/components/shell.tsx", import.meta.url), "utf8");
@@ -649,5 +655,50 @@ test("native speech recognition is scoped to the trusted main webview", () => {
     readFileSync(new URL("../src/speech.rs", import.meta.url), "utf8"),
     /options\.device|device_id|model_path/,
     "renderer must not choose capture devices or model files",
+  );
+});
+
+test("desktop calls can request and recover macOS microphone permission", () => {
+  const microphonePermissionIds = [
+    ["allow-microphone-permission-request", "microphone_permission_request"],
+    ["allow-microphone-settings-open", "microphone_settings_open"],
+  ];
+
+  for (const [permission, command] of microphonePermissionIds) {
+    assert.match(
+      microphonePermissions,
+      new RegExp(String.raw`identifier\s*=\s*"${permission}"[\s\S]{0,240}commands\.allow\s*=\s*\[[^\]]*"${command}"`),
+      `${permission} must map to ${command}`,
+    );
+    assert.match(
+      tauriSetupRust,
+      new RegExp(String.raw`microphone::${command}`),
+      `${command} must be registered in the desktop invoke handler`,
+    );
+    assert.match(
+      microphoneAccessTs,
+      new RegExp(String.raw`"${command}"`),
+      `the frontend microphone flow must drive ${command}`,
+    );
+    assert.ok(
+      loopbackMicrophoneCapability.permissions.includes(permission),
+      `loopback-microphone should grant ${permission}`,
+    );
+  }
+
+  assert.deepEqual(loopbackMicrophoneCapability.webviews, ["main"]);
+  assert.deepEqual(loopbackMicrophoneCapability.platforms, ["macOS"]);
+  assert.ok(capabilityAllowsOrigin(loopbackMicrophoneCapability, "http://127.0.0.1:3000/"));
+  assert.ok(capabilityAllowsOrigin(loopbackMicrophoneCapability, "http://localhost:64203/"));
+  assert.equal(capabilityAllowsOrigin(loopbackMicrophoneCapability, "http://example.com:64203/"), false);
+  assert.match(
+    microphoneRust,
+    /requestRecordPermissionWithCompletionHandler/,
+    "the native command must ask macOS for microphone access",
+  );
+  assert.match(
+    microphoneRust,
+    /x-apple\.systempreferences:com\.apple\.preference\.security\?Privacy_Microphone/,
+    "denied access must open the macOS microphone privacy pane directly",
   );
 });

--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -694,7 +694,12 @@ test("desktop calls can request and recover macOS microphone permission", () => 
   assert.match(
     microphoneRust,
     /requestRecordPermissionWithCompletionHandler/,
-    "the native command must ask macOS for microphone access",
+    "the native command must use the Sonoma microphone permission API",
+  );
+  assert.match(
+    microphoneRust,
+    /AVCaptureDevice[\s\S]*respondsToSelector[\s\S]*requestAccessForMediaType/,
+    "the native command must safely fall back to AVFoundation permission prompting before macOS 14",
   );
   assert.match(
     microphoneRust,

--- a/src-tauri/permissions/microphone.toml
+++ b/src-tauri/permissions/microphone.toml
@@ -1,0 +1,9 @@
+[[permission]]
+identifier = "allow-microphone-permission-request"
+description = "Allows prompting for native macOS microphone access before a voice call."
+commands.allow = ["microphone_permission_request"]
+
+[[permission]]
+identifier = "allow-microphone-settings-open"
+description = "Allows opening the macOS microphone privacy settings pane."
+commands.allow = ["microphone_settings_open"]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -49,6 +49,8 @@ pub mod browser;
 mod desktop_reachability;
 #[cfg(desktop)]
 mod platform_lifecycle;
+#[cfg(all(desktop, target_os = "macos"))]
+mod microphone;
 #[cfg(desktop)]
 mod pty;
 #[cfg(desktop)]

--- a/src-tauri/src/microphone.rs
+++ b/src-tauri/src/microphone.rs
@@ -1,0 +1,85 @@
+use std::sync::mpsc;
+use std::time::Duration;
+
+use block2::RcBlock;
+use objc2::{
+    msg_send,
+    runtime::{AnyClass, Bool},
+};
+use serde::Serialize;
+
+const MICROPHONE_SETTINGS_URL: &str =
+    "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum MicrophonePermissionStatus {
+    Granted,
+    Denied,
+    Unavailable,
+}
+
+#[derive(Serialize)]
+pub struct MicrophonePermission {
+    status: MicrophonePermissionStatus,
+}
+
+fn request_native_permission() -> Result<MicrophonePermission, String> {
+    let Some(application) = AnyClass::get(c"AVAudioApplication") else {
+        return Ok(MicrophonePermission {
+            status: MicrophonePermissionStatus::Unavailable,
+        });
+    };
+
+    let (sender, receiver) = mpsc::channel();
+    let response = RcBlock::new(move |granted: Bool| {
+        let _ = sender.send(granted.as_bool());
+    });
+
+    unsafe {
+        let _: () = msg_send![
+            application,
+            requestRecordPermissionWithCompletionHandler: &*response
+        ];
+    }
+
+    let granted = receiver
+        .recv_timeout(Duration::from_secs(120))
+        .map_err(|error| format!("microphone permission request failed: {error}"))?;
+    Ok(MicrophonePermission {
+        status: if granted {
+            MicrophonePermissionStatus::Granted
+        } else {
+            MicrophonePermissionStatus::Denied
+        },
+    })
+}
+
+#[tauri::command]
+pub async fn microphone_permission_request() -> Result<MicrophonePermission, String> {
+    tauri::async_runtime::spawn_blocking(request_native_permission)
+        .await
+        .map_err(|error| format!("microphone permission task failed: {error}"))?
+}
+
+#[tauri::command]
+pub fn microphone_settings_open() -> Result<(), String> {
+    std::process::Command::new("open")
+        .arg(MICROPHONE_SETTINGS_URL)
+        .spawn()
+        .map_err(|error| format!("failed to open microphone settings: {error}"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MICROPHONE_SETTINGS_URL;
+
+    #[test]
+    fn settings_url_targets_microphone_privacy() {
+        assert_eq!(
+            MICROPHONE_SETTINGS_URL,
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+        );
+    }
+}

--- a/src-tauri/src/microphone.rs
+++ b/src-tauri/src/microphone.rs
@@ -4,9 +4,15 @@ use std::time::Duration;
 use block2::RcBlock;
 use objc2::{
     msg_send,
-    runtime::{AnyClass, Bool},
+    runtime::{AnyClass, AnyObject, Bool},
+    sel,
 };
 use serde::Serialize;
+
+#[link(name = "AVFoundation", kind = "framework")]
+unsafe extern "C" {
+    static AVMediaTypeAudio: *const AnyObject;
+}
 
 const MICROPHONE_SETTINGS_URL: &str =
     "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone";
@@ -25,12 +31,20 @@ pub struct MicrophonePermission {
 }
 
 fn request_native_permission() -> Result<MicrophonePermission, String> {
-    let Some(application) = AnyClass::get(c"AVAudioApplication") else {
-        return Ok(MicrophonePermission {
-            status: MicrophonePermissionStatus::Unavailable,
-        });
-    };
+    if let Some(application) = AnyClass::get(c"AVAudioApplication") {
+        return request_audio_application_permission(application);
+    }
+    if let Some(capture_device) = AnyClass::get(c"AVCaptureDevice") {
+        return request_capture_device_permission(capture_device);
+    }
+    Ok(MicrophonePermission {
+        status: MicrophonePermissionStatus::Unavailable,
+    })
+}
 
+fn request_audio_application_permission(
+    application: &AnyClass,
+) -> Result<MicrophonePermission, String> {
     let (sender, receiver) = mpsc::channel();
     let response = RcBlock::new(move |granted: Bool| {
         let _ = sender.send(granted.as_bool());
@@ -42,7 +56,43 @@ fn request_native_permission() -> Result<MicrophonePermission, String> {
             requestRecordPermissionWithCompletionHandler: &*response
         ];
     }
+    receive_permission(receiver)
+}
 
+fn request_capture_device_permission(
+    capture_device: &AnyClass,
+) -> Result<MicrophonePermission, String> {
+    let supported: Bool = unsafe {
+        msg_send![
+            capture_device,
+            respondsToSelector: sel!(requestAccessForMediaType:completionHandler:)
+        ]
+    };
+    if !supported.as_bool() {
+        return Ok(MicrophonePermission {
+            status: MicrophonePermissionStatus::Unavailable,
+        });
+    }
+
+    let (sender, receiver) = mpsc::channel();
+    let response = RcBlock::new(move |granted: Bool| {
+        let _ = sender.send(granted.as_bool());
+    });
+
+    unsafe {
+        if AVMediaTypeAudio.is_null() {
+            return Err("AVMediaTypeAudio is unavailable".into());
+        }
+        let _: () = msg_send![
+            capture_device,
+            requestAccessForMediaType: &*AVMediaTypeAudio,
+            completionHandler: &*response
+        ];
+    }
+    receive_permission(receiver)
+}
+
+fn receive_permission(receiver: mpsc::Receiver<bool>) -> Result<MicrophonePermission, String> {
     let granted = receiver
         .recv_timeout(Duration::from_secs(120))
         .map_err(|error| format!("microphone permission request failed: {error}"))?;
@@ -64,16 +114,28 @@ pub async fn microphone_permission_request() -> Result<MicrophonePermission, Str
 
 #[tauri::command]
 pub fn microphone_settings_open() -> Result<(), String> {
-    std::process::Command::new("open")
+    let status = std::process::Command::new("open")
         .arg(MICROPHONE_SETTINGS_URL)
-        .spawn()
+        .status()
         .map_err(|error| format!("failed to open microphone settings: {error}"))?;
-    Ok(())
+    settings_open_result(status)
+}
+
+fn settings_open_result(status: std::process::ExitStatus) -> Result<(), String> {
+    if status.success() {
+        Ok(())
+    } else {
+        Err(format!(
+            "failed to open microphone settings: open exited unsuccessfully ({status})"
+        ))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::MICROPHONE_SETTINGS_URL;
+    use std::os::unix::process::ExitStatusExt;
+
+    use super::{settings_open_result, MICROPHONE_SETTINGS_URL};
 
     #[test]
     fn settings_url_targets_microphone_privacy() {
@@ -81,5 +143,12 @@ mod tests {
             MICROPHONE_SETTINGS_URL,
             "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
         );
+    }
+
+    #[test]
+    fn settings_launcher_rejects_non_zero_exit() {
+        let error = settings_open_result(std::process::ExitStatus::from_raw(1 << 8))
+            .expect_err("a failed open command must reach the frontend");
+        assert!(error.contains("exited unsuccessfully"));
     }
 }

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -261,6 +261,10 @@ pub fn run() {
             shell_open_path,
             shell_pick_directory,
             set_traffic_lights_visible,
+            #[cfg(target_os = "macos")]
+            microphone::microphone_permission_request,
+            #[cfg(target_os = "macos")]
+            microphone::microphone_settings_open,
             speech::speech_stt_available,
             speech::speech_stt_start,
             speech::speech_stt_finish,

--- a/src/components/voice-call-overlay-state.test.ts
+++ b/src/components/voice-call-overlay-state.test.ts
@@ -14,11 +14,18 @@ test("requesting-mic → minting-session on MIC_READY", () => {
   assert.equal(next.state, "minting-session");
 });
 
-test("requesting-mic → error on MIC_DENIED", () => {
+test("requesting-mic → actionable error on MIC_FAILED", () => {
   const s = reduce(initialState, { type: "START" });
-  const next = reduce(s, { type: "MIC_DENIED" });
+  const next = reduce(s, {
+    type: "MIC_FAILED",
+    errorCode: "microphone_denied",
+    hint: "Allow Coven Cave in System Settings.",
+    canOpenSettings: true,
+  });
   assert.equal(next.state, "error");
   assert.equal(next.errorCode, "microphone_denied");
+  assert.equal(next.hint, "Allow Coven Cave in System Settings.");
+  assert.equal(next.canOpenSettings, true);
 });
 
 test("minting-session → connecting on SESSION_GRANTED", () => {
@@ -154,10 +161,14 @@ test("PROVIDER_ERROR clears a stale missingKey so unrelated errors don't offer a
 });
 
 test("error → requesting-mic on RETRY (clears errorCode)", () => {
-  const errored = reduce(reduce(initialState, { type: "START" }), { type: "MIC_DENIED" });
+  const errored = reduce(reduce(initialState, { type: "START" }), {
+    type: "MIC_FAILED",
+    errorCode: "microphone_denied",
+  });
   const next = reduce(errored, { type: "RETRY" });
   assert.equal(next.state, "requesting-mic");
   assert.equal(next.errorCode, undefined);
+  assert.equal(next.canOpenSettings, undefined);
 });
 
 test("muted is local-only state, toggled by MUTE_TOGGLE", () => {

--- a/src/components/voice-call-overlay-state.ts
+++ b/src/components/voice-call-overlay-state.ts
@@ -18,6 +18,7 @@ export type CallState = {
   errorCode?: string;
   missingKey?: string;
   hint?: string;
+  canOpenSettings?: boolean;
   /** How a live loop-based call hears (cave-vpe1); unset for realtime providers. */
   earsEngine?: VoiceEarsEngine;
   mouthEngine?: VoiceMouthEngine;
@@ -28,7 +29,7 @@ export const initialState: CallState = { state: "idle", muted: false };
 export type CallEvent =
   | { type: "START" }
   | { type: "MIC_READY" }
-  | { type: "MIC_DENIED" }
+  | { type: "MIC_FAILED"; errorCode: string; hint?: string; canOpenSettings?: boolean }
   | { type: "SESSION_GRANTED"; callId: string }
   | { type: "SESSION_FAILED"; errorCode: string; missingKey?: string; hint?: string }
   | { type: "CONNECTED"; startedAt: number; earsEngine?: VoiceEarsEngine; mouthEngine?: VoiceMouthEngine }
@@ -46,8 +47,14 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
     case "MIC_READY":
       if (s.state !== "requesting-mic") return s;
       return { ...s, state: "minting-session" };
-    case "MIC_DENIED":
-      return { ...s, state: "error", errorCode: "microphone_denied" };
+    case "MIC_FAILED":
+      return {
+        ...s,
+        state: "error",
+        errorCode: ev.errorCode,
+        hint: ev.hint,
+        canOpenSettings: ev.canOpenSettings,
+      };
     case "SESSION_GRANTED":
       if (s.state !== "minting-session") return s;
       return { ...s, state: "connecting", callId: ev.callId };
@@ -58,6 +65,7 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
         errorCode: ev.errorCode,
         missingKey: ev.missingKey,
         hint: ev.hint,
+        canOpenSettings: undefined,
       };
     case "CONNECTED":
       if (s.state !== "connecting") return s;
@@ -65,7 +73,14 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
     case "PROVIDER_ERROR":
       // Explicitly clear missingKey — a stale key name from an earlier mint
       // failure must not dress an unrelated connect error as key-fixable.
-      return { ...s, state: "error", errorCode: ev.errorCode, missingKey: undefined, hint: ev.hint };
+      return {
+        ...s,
+        state: "error",
+        errorCode: ev.errorCode,
+        missingKey: undefined,
+        hint: ev.hint,
+        canOpenSettings: undefined,
+      };
     case "CLOSE_REQUEST":
       if (s.state === "live") return { ...s, state: "ending" };
       return { ...s, state: "closed" };

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -93,11 +93,40 @@ assert.match(
 
 // ── Raw error codes map to actionable messages ───────────────────────────────
 assert.match(component, /function errorMessage\(code: string \| undefined\): string/, "errorMessage maps codes to readable text");
-assert.match(component, /case "microphone_denied":[\s\S]*?Microphone access was denied/, "microphone_denied becomes a friendly, actionable message");
+assert.match(component, /case "microphone_denied":[\s\S]*?Microphone access is blocked/, "microphone_denied becomes a native-safe headline");
+assert.match(component, /case "microphone_not_found":[\s\S]*?No microphone was found/, "missing hardware is not mislabeled as denied");
+assert.match(component, /case "microphone_unavailable":[\s\S]*?microphone isn't available/, "busy or unreadable hardware is not mislabeled as denied");
 assert.doesNotMatch(
   component,
   /<div>\{state\.errorCode\}<\/div>/,
   "the raw error code is no longer rendered as the headline",
+);
+
+// ── Desktop microphone permission is requested natively before capture ──────
+assert.match(
+  component,
+  /import\s+\{[^}]*requestMicrophoneStream[^}]*\}\s+from\s+["']@\/lib\/voice\/microphone-access["']/,
+  "voice calls use the shared native-aware microphone request",
+);
+assert.match(
+  component,
+  /await requestMicrophoneStream\(\)/,
+  "the overlay asks the native-aware flow for its stream",
+);
+assert.doesNotMatch(
+  component,
+  /navigator\.mediaDevices\.getUserMedia/,
+  "the overlay must not bypass the native permission preflight",
+);
+assert.match(
+  component,
+  /type:\s*"MIC_FAILED",[\s\S]{0,180}errorCode:\s*failure\.code,[\s\S]{0,180}hint:\s*failure\.hint,[\s\S]{0,180}canOpenSettings:\s*failure\.canOpenSettings/,
+  "capture failures preserve their real reason and recovery capability",
+);
+assert.match(
+  component,
+  /\{state\.canOpenSettings && \([\s\S]{0,600}>\s*Open settings\s*<\/button>/,
+  "denied desktop access offers a direct System Settings recovery action",
 );
 
 // ── True-voice providers own persistence — no transcript double-append ───────

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -125,6 +125,11 @@ assert.match(
 );
 assert.match(
   component,
+  /catch \(error\) \{[\s\S]*?if \(cancelled\) return;[\s\S]*?const failure = classifyMicrophoneCaptureError\(error\)/,
+  "cancelled microphone requests do not dispatch failure after cleanup",
+);
+assert.match(
+  component,
   /\{state\.canOpenSettings && \([\s\S]{0,600}>\s*Open settings\s*<\/button>/,
   "denied desktop access offers a direct System Settings recovery action",
 );

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -44,6 +44,7 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           micStreamRef.current = stream;
           dispatch({ type: "MIC_READY" });
         } catch (error) {
+          if (cancelled) return;
           const failure = classifyMicrophoneCaptureError(error);
           dispatch({
             type: "MIC_FAILED",

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -8,6 +8,11 @@ import { Icon } from "@iconify/react";
 import type { Familiar } from "@/lib/types";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 import { getVoiceProvider } from "@/lib/voice/registry";
+import {
+  classifyMicrophoneCaptureError,
+  openMicrophoneSettings,
+  requestMicrophoneStream,
+} from "@/lib/voice/microphone-access";
 import type { LiveSession, VoiceSessionGrant, VoiceEarsEngine, VoiceMouthEngine } from "@/lib/voice/types";
 import { voiceErrorHint } from "@/lib/voice/types";
 import { voiceRecoveryVaultKey } from "@/lib/voice/vault-key-recovery";
@@ -34,12 +39,18 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
     (async () => {
       if (state.state === "requesting-mic") {
         try {
-          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          const stream = await requestMicrophoneStream();
           if (cancelled) { stream.getTracks().forEach(t => t.stop()); return; }
           micStreamRef.current = stream;
           dispatch({ type: "MIC_READY" });
-        } catch {
-          dispatch({ type: "MIC_DENIED" });
+        } catch (error) {
+          const failure = classifyMicrophoneCaptureError(error);
+          dispatch({
+            type: "MIC_FAILED",
+            errorCode: failure.code,
+            hint: failure.hint,
+            canOpenSettings: failure.canOpenSettings,
+          });
         }
       } else if (state.state === "minting-session") {
         try {
@@ -148,10 +159,12 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
   const [keyDraft, setKeyDraft] = useState("");
   const [savingKey, setSavingKey] = useState(false);
   const [keySaveError, setKeySaveError] = useState<string | null>(null);
+  const [settingsOpenError, setSettingsOpenError] = useState<string | null>(null);
   useEffect(() => {
     if (state.state !== "error") {
       setKeyDraft("");
       setKeySaveError(null);
+      setSettingsOpenError(null);
     }
   }, [state.state]);
 
@@ -186,6 +199,15 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
       setKeySaveError("Couldn't save the key — is the daemon running?");
     } finally {
       setSavingKey(false);
+    }
+  };
+
+  const openPermissionSettings = async () => {
+    setSettingsOpenError(null);
+    try {
+      await openMicrophoneSettings();
+    } catch {
+      setSettingsOpenError("Couldn't open System Settings. Open Privacy & Security → Microphone manually.");
     }
   };
 
@@ -231,6 +253,18 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
             <div className="voice-call-overlay__error" role="alert">
               <div id="voice-call-overlay-error">{errorMessage(state.errorCode)}</div>
               {state.hint && <div className="voice-call-overlay__hint">{state.hint}</div>}
+              {state.canOpenSettings && (
+                <button
+                  type="button"
+                  className="voice-call-overlay__retry focus-ring"
+                  onClick={() => { void openPermissionSettings(); }}
+                >
+                  Open settings
+                </button>
+              )}
+              {settingsOpenError && (
+                <div className="voice-call-overlay__hint" role="alert">{settingsOpenError}</div>
+              )}
               {fixableKey && (
                 <form
                   className="voice-call-overlay__fix"
@@ -345,7 +379,15 @@ function errorMessage(code: string | undefined): string {
   }
   switch (code) {
     case "microphone_denied":
-      return "Microphone access was denied. Allow it in your browser settings to start a call.";
+      return "Microphone access is blocked.";
+    case "microphone_not_found":
+      return "No microphone was found.";
+    case "microphone_unavailable":
+      return "The microphone isn't available.";
+    case "microphone_unsupported":
+      return "Microphone capture isn't available in this window.";
+    case "microphone_permission_failed":
+      return "Coven Cave couldn't request microphone access.";
     case "network":
       return "Couldn't reach the voice service. Check your connection and try again.";
     case "internal":

--- a/src/lib/voice/microphone-access.test.ts
+++ b/src/lib/voice/microphone-access.test.ts
@@ -60,6 +60,41 @@ test("older macOS falls through to webview capture when native preflight is unav
   assert.equal(result, stream);
 });
 
+test("iOS Tauri skips macOS preflight even when its webview identifies as Mac", async () => {
+  const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      __TAURI_INTERNALS__: {},
+      __TAURI_OS_PLUGIN_INTERNALS__: { platform: "ios" },
+    },
+  });
+  Object.defineProperty(globalThis, "navigator", {
+    configurable: true,
+    value: { userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15)" },
+  });
+
+  try {
+    let invoked = false;
+    const result = await requestMicrophoneStream({
+      invoke: async () => {
+        invoked = true;
+        return { status: "denied" };
+      },
+      getUserMedia: async () => stream,
+    });
+
+    assert.equal(result, stream);
+    assert.equal(invoked, false);
+  } finally {
+    if (windowDescriptor) Object.defineProperty(globalThis, "window", windowDescriptor);
+    else delete globalThis.window;
+    if (navigatorDescriptor) Object.defineProperty(globalThis, "navigator", navigatorDescriptor);
+    else delete globalThis.navigator;
+  }
+});
+
 test("capture failures keep permission, hardware, and availability errors distinct", () => {
   const cases = [
     ["NotAllowedError", "microphone_denied"],

--- a/src/lib/voice/microphone-access.test.ts
+++ b/src/lib/voice/microphone-access.test.ts
@@ -60,6 +60,20 @@ test("older macOS falls through to webview capture when native preflight is unav
   assert.equal(result, stream);
 });
 
+test("missing native platform detection falls through to webview capture", async () => {
+  let detected = false;
+  const result = await requestMicrophoneStream({
+    detectNativeMac: async () => {
+      detected = true;
+      throw new Error("plugin-os unavailable");
+    },
+    getUserMedia: async () => stream,
+  });
+
+  assert.equal(detected, true);
+  assert.equal(result, stream);
+});
+
 test("iOS Tauri skips macOS preflight even when its webview identifies as Mac", async () => {
   const windowDescriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
   const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, "navigator");

--- a/src/lib/voice/microphone-access.test.ts
+++ b/src/lib/voice/microphone-access.test.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  MicrophoneAccessError,
+  classifyMicrophoneCaptureError,
+  openMicrophoneSettings,
+  requestMicrophoneStream,
+} from "./microphone-access.ts";
+
+const stream = { getTracks: () => [] } as unknown as MediaStream;
+
+test("macOS permission is requested before webview capture", async () => {
+  const events: string[] = [];
+  const result = await requestMicrophoneStream({
+    nativeMac: true,
+    invoke: async (command) => {
+      events.push(command);
+      return { status: "granted" };
+    },
+    getUserMedia: async () => {
+      events.push("getUserMedia");
+      return stream;
+    },
+  });
+
+  assert.equal(result, stream);
+  assert.deepEqual(events, ["microphone_permission_request", "getUserMedia"]);
+});
+
+test("native denial stops capture and enables System Settings recovery", async () => {
+  let captured = false;
+  await assert.rejects(
+    requestMicrophoneStream({
+      nativeMac: true,
+      invoke: async () => ({ status: "denied" }),
+      getUserMedia: async () => {
+        captured = true;
+        return stream;
+      },
+    }),
+    (error) => {
+      assert.ok(error instanceof MicrophoneAccessError);
+      assert.equal(error.code, "microphone_denied");
+      assert.equal(error.canOpenSettings, true);
+      assert.match(error.hint, /System Settings/);
+      return true;
+    },
+  );
+  assert.equal(captured, false);
+});
+
+test("older macOS falls through to webview capture when native preflight is unavailable", async () => {
+  const result = await requestMicrophoneStream({
+    nativeMac: true,
+    invoke: async () => ({ status: "unavailable" }),
+    getUserMedia: async () => stream,
+  });
+
+  assert.equal(result, stream);
+});
+
+test("capture failures keep permission, hardware, and availability errors distinct", () => {
+  const cases = [
+    ["NotAllowedError", "microphone_denied"],
+    ["NotFoundError", "microphone_not_found"],
+    ["DevicesNotFoundError", "microphone_not_found"],
+    ["NotReadableError", "microphone_unavailable"],
+    ["TrackStartError", "microphone_unavailable"],
+    ["AbortError", "microphone_unavailable"],
+    ["OverconstrainedError", "microphone_unavailable"],
+  ];
+
+  for (const [name, code] of cases) {
+    assert.equal(classifyMicrophoneCaptureError(new DOMException("capture failed", name)).code, code);
+  }
+});
+
+test("capture disabled by document policy does not offer permission settings recovery", () => {
+  const error = classifyMicrophoneCaptureError(
+    new DOMException("capture disabled", "SecurityError"),
+    true,
+  );
+
+  assert.equal(error.code, "microphone_unsupported");
+  assert.equal(error.canOpenSettings, false);
+  assert.doesNotMatch(error.hint, /System Settings/);
+});
+
+test("native prompt failures are not mislabeled as user denial", async () => {
+  await assert.rejects(
+    requestMicrophoneStream({
+      nativeMac: true,
+      invoke: async () => {
+        throw new Error("IPC unavailable");
+      },
+      getUserMedia: async () => stream,
+    }),
+    (error) => {
+      assert.ok(error instanceof MicrophoneAccessError);
+      assert.equal(error.code, "microphone_permission_failed");
+      assert.equal(error.canOpenSettings, false);
+      return true;
+    },
+  );
+});
+
+test("desktop recovery opens the macOS microphone privacy pane", async () => {
+  const commands: string[] = [];
+  await openMicrophoneSettings(async (command) => {
+    commands.push(command);
+  });
+  assert.deepEqual(commands, ["microphone_settings_open"]);
+});

--- a/src/lib/voice/microphone-access.ts
+++ b/src/lib/voice/microphone-access.ts
@@ -15,6 +15,7 @@ type InvokeCommand = (command: string) => Promise<unknown>;
 
 type MicrophoneAccessDependencies = {
   nativeMac?: boolean;
+  detectNativeMac?: () => Promise<boolean>;
   invoke?: InvokeCommand;
   getUserMedia?: () => Promise<MediaStream>;
 };
@@ -114,12 +115,9 @@ export async function requestMicrophoneStream(
 ): Promise<MediaStream> {
   let nativeMac: boolean;
   try {
-    nativeMac = dependencies.nativeMac ?? await isNativeMacPlatform();
+    nativeMac = dependencies.nativeMac ?? await (dependencies.detectNativeMac ?? isNativeMacPlatform)();
   } catch {
-    throw new MicrophoneAccessError(
-      "microphone_permission_failed",
-      "Restart Coven Cave and retry the call.",
-    );
+    nativeMac = false;
   }
   const invoke = dependencies.invoke ?? defaultInvoke;
 

--- a/src/lib/voice/microphone-access.ts
+++ b/src/lib/voice/microphone-access.ts
@@ -1,0 +1,149 @@
+import { isMacDesktopShell } from "../tauri-platform.ts";
+
+export type MicrophoneAccessErrorCode =
+  | "microphone_denied"
+  | "microphone_not_found"
+  | "microphone_unavailable"
+  | "microphone_unsupported"
+  | "microphone_permission_failed";
+
+type NativeMicrophonePermission = {
+  status: "granted" | "denied" | "unavailable";
+};
+
+type InvokeCommand = (command: string) => Promise<unknown>;
+
+type MicrophoneAccessDependencies = {
+  nativeMac?: boolean;
+  invoke?: InvokeCommand;
+  getUserMedia?: () => Promise<MediaStream>;
+};
+
+export class MicrophoneAccessError extends Error {
+  readonly code: MicrophoneAccessErrorCode;
+  readonly hint: string;
+  readonly canOpenSettings: boolean;
+
+  constructor(
+    code: MicrophoneAccessErrorCode,
+    hint: string,
+    canOpenSettings = false,
+  ) {
+    super(code);
+    this.name = "MicrophoneAccessError";
+    this.code = code;
+    this.hint = hint;
+    this.canOpenSettings = canOpenSettings;
+  }
+}
+
+function errorName(error: unknown): string {
+  if (typeof error === "object" && error !== null && "name" in error) {
+    const name = (error as { name?: unknown }).name;
+    return typeof name === "string" ? name : "";
+  }
+  return "";
+}
+
+export function classifyMicrophoneCaptureError(
+  error: unknown,
+  canOpenSettings = false,
+): MicrophoneAccessError {
+  if (error instanceof MicrophoneAccessError) return error;
+
+  switch (errorName(error)) {
+    case "NotAllowedError":
+      return new MicrophoneAccessError(
+        "microphone_denied",
+        canOpenSettings
+          ? "Allow Coven Cave under System Settings → Privacy & Security → Microphone, then retry."
+          : "Allow microphone access for this site in your browser settings, then retry.",
+        canOpenSettings,
+      );
+    case "SecurityError":
+      return new MicrophoneAccessError(
+        "microphone_unsupported",
+        "Microphone capture is disabled for this app window or browser.",
+      );
+    case "NotFoundError":
+    case "DevicesNotFoundError":
+      return new MicrophoneAccessError(
+        "microphone_not_found",
+        "Connect or enable a microphone, then retry.",
+      );
+    case "NotReadableError":
+    case "TrackStartError":
+    case "AbortError":
+    case "OverconstrainedError":
+    case "ConstraintNotSatisfiedError":
+      return new MicrophoneAccessError(
+        "microphone_unavailable",
+        "Close other apps using the microphone, check the selected input device, then retry.",
+      );
+    default:
+      return new MicrophoneAccessError(
+        "microphone_unavailable",
+        "Check the microphone connection and input settings, then retry.",
+      );
+  }
+}
+
+async function defaultInvoke(command: string): Promise<unknown> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  return invoke(command);
+}
+
+function defaultGetUserMedia(): Promise<MediaStream> {
+  if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+    throw new MicrophoneAccessError(
+      "microphone_unsupported",
+      "Use the Coven Cave desktop app or a browser window that supports microphone capture.",
+    );
+  }
+  return navigator.mediaDevices.getUserMedia({ audio: true });
+}
+
+export async function requestMicrophoneStream(
+  dependencies: MicrophoneAccessDependencies = {},
+): Promise<MediaStream> {
+  const nativeMac = dependencies.nativeMac ?? isMacDesktopShell();
+  const invoke = dependencies.invoke ?? defaultInvoke;
+
+  if (nativeMac) {
+    let permission: NativeMicrophonePermission;
+    try {
+      permission = await invoke("microphone_permission_request") as NativeMicrophonePermission;
+    } catch {
+      throw new MicrophoneAccessError(
+        "microphone_permission_failed",
+        "Restart Coven Cave and retry the call.",
+      );
+    }
+
+    if (permission.status === "denied") {
+      throw new MicrophoneAccessError(
+        "microphone_denied",
+        "Allow Coven Cave under System Settings → Privacy & Security → Microphone, then retry.",
+        true,
+      );
+    }
+    if (permission.status !== "granted" && permission.status !== "unavailable") {
+      throw new MicrophoneAccessError(
+        "microphone_permission_failed",
+        "Restart Coven Cave and retry the call.",
+      );
+    }
+  }
+
+  try {
+    return await (dependencies.getUserMedia ?? defaultGetUserMedia)();
+  } catch (error) {
+    throw classifyMicrophoneCaptureError(error, nativeMac);
+  }
+}
+
+export async function openMicrophoneSettings(
+  invoke: InvokeCommand = defaultInvoke,
+): Promise<void> {
+  await invoke("microphone_settings_open");
+}

--- a/src/lib/voice/microphone-access.ts
+++ b/src/lib/voice/microphone-access.ts
@@ -1,4 +1,4 @@
-import { isMacDesktopShell } from "../tauri-platform.ts";
+import { isTauri } from "../tauri-platform.ts";
 
 export type MicrophoneAccessErrorCode =
   | "microphone_denied"
@@ -103,10 +103,24 @@ function defaultGetUserMedia(): Promise<MediaStream> {
   return navigator.mediaDevices.getUserMedia({ audio: true });
 }
 
+async function isNativeMacPlatform(): Promise<boolean> {
+  if (!isTauri()) return false;
+  const { platform } = await import("@tauri-apps/plugin-os");
+  return platform() === "macos";
+}
+
 export async function requestMicrophoneStream(
   dependencies: MicrophoneAccessDependencies = {},
 ): Promise<MediaStream> {
-  const nativeMac = dependencies.nativeMac ?? isMacDesktopShell();
+  let nativeMac: boolean;
+  try {
+    nativeMac = dependencies.nativeMac ?? await isNativeMacPlatform();
+  } catch {
+    throw new MicrophoneAccessError(
+      "microphone_permission_failed",
+      "Restart Coven Cave and retry the call.",
+    );
+  }
   const invoke = dependencies.invoke ?? defaultInvoke;
 
   if (nativeMac) {


### PR DESCRIPTION
## Summary
- Request microphone permission through the native macOS/Tauri path instead of sending desktop users to browser settings.
- Classify capture failures precisely and provide an actionable Microphone privacy-settings recovery path.
- Add least-privilege loopback microphone ACL wiring and focused frontend/native regression coverage.

Tracks Bead cave-8yy3n.

## Verification
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired
- microphone helper/state/overlay/desktop-permissions regression tests
- rustfmt check for microphone.rs
- cargo check --no-default-features
- native microphone unit test