### PR TITLE
feat(chat): add Familiar settings panel

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -737,6 +737,7 @@ export const SUITES = {
     "src/components/familiar-tab-hero.test.ts",
     "src/components/familiar-tab-sections.test.ts",
     "src/components/familiar-tab-bridges.test.ts",
+    "src/components/familiar-tab-settings.test.ts",
     "src/components/familiar-tab-scope.test.ts",
     "src/components/familiar-tab-skills.test.ts",
     "src/components/familiar-tab-identity.test.ts",

--- a/src/components/chat-canvas-tab.test.ts
+++ b/src/components/chat-canvas-tab.test.ts
@@ -24,8 +24,8 @@ assert.match(
 );
 assert.match(
   surface,
-  /\{ id: "projects", label: "Projects" \},\s*\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Skills" \}/,
-  "Canvas is a first-class scope tab between Projects and Skills (familiar scope)",
+  /\{ id: "projects", label: "Projects" \},\s*\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \}/,
+  "Canvas is a first-class scope tab between Projects and Familiar",
 );
 assert.match(
   surface,

--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -6,8 +6,8 @@
  * Skills-page design handoff (cave-moig): a shared SurfaceRail roster on the
  * left (search, collapse, resize — local selection only, never the app-wide
  * scope) and, on the right, an identity hero (avatar, serif name, presence,
- * live Runtime/Model/Voice selects, Edit in Studio, New chat) over a five-tab
- * band: Identity · Skills · MCP · Analytics · Memory. Capability data still
+ * live Runtime/Model/Voice selects, Edit in Studio, New chat) over a six-tab
+ * band: Identity · Skills · MCP · Analytics · Memory · Settings. Capability data still
  * flows through useCapabilitySnapshot (/api/roles, /api/skills/local,
  * /api/capabilities?harness=, /api/harnesses) and is derived once into a
  * shared section model; the lifecycle/scope state machine
@@ -40,6 +40,7 @@ import { FamiliarIdentitySection } from "@/components/familiar-tab-identity";
 import { FamiliarMcpSection } from "@/components/familiar-tab-mcp";
 import { FamiliarAnalyticsSection } from "@/components/familiar-tab-analytics";
 import { FamiliarMemorySection } from "@/components/familiar-tab-memory";
+import { FamiliarSettingsSection } from "@/components/familiar-tab-settings";
 import "@/styles/familiar-tab.css";
 
 // ── Identity hero ────────────────────────────────────────────────────────────
@@ -447,15 +448,23 @@ function FamiliarScopeOverview({
 
 // ── Section tabs ─────────────────────────────────────────────────────────────
 
-type FamiliarSectionId = "identity" | "skills" | "mcp" | "analytics" | "memory";
+type FamiliarSectionId = "identity" | "skills" | "mcp" | "analytics" | "memory" | "settings";
 
 function FamiliarCapabilityPanel({
   familiar,
+  familiars,
+  allFamiliars,
   daemonRunning,
+  localDaemonReady,
+  onRosterChanged,
   onStartChat,
 }: {
-  familiar: Familiar;
+  familiar: ResolvedFamiliar;
+  familiars: Familiar[];
+  allFamiliars: ResolvedFamiliar[];
   daemonRunning?: boolean;
+  localDaemonReady: boolean;
+  onRosterChanged?: () => void;
   onStartChat?: (familiarId: string) => void;
 }) {
   const harnessId = familiar.harness ?? "codex";
@@ -512,6 +521,7 @@ function FamiliarCapabilityPanel({
             { id: "mcp", label: "MCP" },
             { id: "analytics", label: "Analytics" },
             { id: "memory", label: "Memory" },
+            { id: "settings", label: "Settings" },
           ]}
           value={section}
           onChange={setSection}
@@ -535,6 +545,15 @@ function FamiliarCapabilityPanel({
         )}
         {section === "analytics" ? <FamiliarAnalyticsSection familiar={familiar} /> : null}
         {section === "memory" ? <FamiliarMemorySection familiar={familiar} /> : null}
+        {section === "settings" ? (
+          <FamiliarSettingsSection
+            familiar={familiar}
+            familiars={familiars}
+            allFamiliars={allFamiliars}
+            localDaemonReady={localDaemonReady}
+            onRosterChanged={onRosterChanged}
+          />
+        ) : null}
       </div>
     </div>
   );
@@ -626,6 +645,7 @@ export function ChatFamiliarCapabilities({
   familiar,
   familiars,
   selectedFamiliarIds,
+  localDaemonReady,
   familiarsLoaded = true,
   familiarsError,
   daemonRunning,
@@ -634,10 +654,12 @@ export function ChatFamiliarCapabilities({
   onOpenOnboarding,
   onFamiliarScopeChange,
   onStartChat,
+  onRosterChanged,
 }: {
   familiar: Familiar | null;
   familiars: Familiar[];
   selectedFamiliarIds: ReadonlySet<string>;
+  localDaemonReady: boolean;
   familiarsLoaded?: boolean;
   familiarsError?: string | null;
   daemonRunning?: boolean;
@@ -646,6 +668,7 @@ export function ChatFamiliarCapabilities({
   onOpenOnboarding?: () => void;
   onFamiliarScopeChange: (id: string | null, opts?: { preserveSurface?: boolean }) => void;
   onStartChat?: (familiarId: string) => void;
+  onRosterChanged?: () => void;
 }) {
   const resolvedFamiliars = useResolvedFamiliars(familiars, { includeArchived: true });
   const selectableFamiliars = resolvedFamiliars.filter((item) => !item.archived);
@@ -781,7 +804,11 @@ export function ChatFamiliarCapabilities({
         <FamiliarCapabilityPanel
           key={detailFamiliar.id}
           familiar={detailFamiliar}
+          familiars={familiars}
+          allFamiliars={resolvedFamiliars}
           daemonRunning={daemonRunning}
+          localDaemonReady={localDaemonReady}
+          onRosterChanged={onRosterChanged}
           onStartChat={onStartChat}
         />
       </div>

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -119,6 +119,17 @@ assert.match(
 
 assert.match(
   chatSurface,
+  /\{\s*id:\s*"familiar",\s*label:\s*"Familiar"\s*\}/,
+  "ChatSurface should name the familiar-focused scope Familiar",
+);
+assert.doesNotMatch(
+  chatSurface,
+  /\{\s*id:\s*"familiar",\s*label:\s*"Skills"\s*\}/,
+  "ChatSurface should not leave the merged familiar scope labeled Skills",
+);
+
+assert.match(
+  chatSurface,
   /useState<FamiliarsScope>\("conversation"\)/,
   "ChatSurface should default the scope to conversation so the ChatList shows when Chat is selected",
 );
@@ -220,8 +231,8 @@ assert.doesNotMatch(
 // between Projects and Familiar.
 assert.match(
   chatSurface,
-  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Skills" \},\s*\{ id: "settings", label: "Settings" \},/,
-  "the Skills tab (familiar scope) sits immediately left of Settings (after Canvas)",
+  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \},\s*\{ id: "settings", label: "Settings" \},/,
+  "the Familiar tab sits immediately left of Settings (after Canvas)",
 );
 // The skills-tab latch must be consumed on the LIVE event path too: "Manage
 // skills" from an already-mounted chat doesn't remount this surface, so a

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -71,6 +71,7 @@ type Props = {
   activeFamiliarId: string | null;
   selectedFamiliarIds: ReadonlySet<string>;
   daemonRunning: boolean;
+  localDaemonReady: boolean;
   routerRef: RefObject<ChatRouterHandle | null>;
   sessionsLoaded?: boolean;
   /** Last session-list load failed — chat list shows a can't-load state (cave-x6k5). */
@@ -111,6 +112,7 @@ export function ChatSurface({
   activeFamiliarId,
   selectedFamiliarIds,
   daemonRunning,
+  localDaemonReady,
   routerRef,
   sessionsLoaded,
   sessionsError,
@@ -331,13 +333,13 @@ export function ChatSurface({
     return () => window.removeEventListener(CHAT_OPEN_COVEN_EVENT, open);
   }, []);
 
-  // Composer "+" menu → "Manage skills" lands on the Skills tab (familiar
-  // scope), including from Home where this surface mounts fresh (latch).
+  // Composer "+" menu → "Manage skills" lands on the Familiar scope (Skills
+  // section), including from Home where this surface mounts fresh (latch).
   useEffect(() => {
     if (consumeSkillsTabPending()) setScope("familiar");
     // Consume in the live path too: when chat is already mounted the
     // navigate-mode hop doesn't remount this surface, so a latch left set
-    // here would hijack a LATER fresh mount onto the Skills tab.
+    // here would hijack a LATER fresh mount onto the Familiar scope.
     const open = () => {
       consumeSkillsTabPending();
       setScope("familiar");
@@ -370,7 +372,7 @@ export function ChatSurface({
               { id: "conversation", label: "Sessions" },
               { id: "projects", label: "Projects" },
               { id: "canvas", label: "Canvas" },
-              { id: "familiar", label: "Skills" },
+              { id: "familiar", label: "Familiar" },
               { id: "settings", label: "Settings" },
             ]}
           />
@@ -434,11 +436,13 @@ export function ChatSurface({
                 familiarsLoaded={familiarsLoaded}
                 familiarsError={familiarsError}
                 daemonRunning={daemonRunning}
+                localDaemonReady={localDaemonReady}
                 onRetryFamiliars={onRetryFamiliars}
                 onCreateFamiliar={requestSummonFamiliar}
                 onOpenOnboarding={onOpenOnboarding}
                 onFamiliarScopeChange={onFamiliarScopeChange}
                 onStartChat={startFamiliarHeroChat}
+                onRosterChanged={onRetryFamiliars}
               />
             </div>
           </div>

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -1,0 +1,27 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const surface = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
+const settings = readFileSync(new URL("./familiar-tab-settings.tsx", import.meta.url), "utf8");
+
+assert.match(surface, /import \{ FamiliarSettingsSection \} from "@\/components\/familiar-tab-settings"/);
+assert.match(surface, /type FamiliarSectionId = "identity" \| "skills" \| "mcp" \| "analytics" \| "memory" \| "settings"/);
+assert.match(surface, /\{ id: "settings", label: "Settings" \}/);
+assert.match(surface, /section === "settings" \? \([\s\S]{0,120}?<FamiliarSettingsSection/);
+assert.match(surface, /<FamiliarSettingsSection[\s\S]{0,500}?familiar=\{familiar\}/);
+
+assert.match(settings, /export function FamiliarSettingsSection\(/);
+assert.match(settings, /FamiliarStudioIdentityTab/);
+assert.match(settings, /FamiliarStudioBrainTab/);
+assert.match(settings, /FamiliarStudioMemoryTab/);
+assert.match(settings, /FamiliarStudioProjectsTab/);
+assert.match(settings, /import \{ AccessGroupsSection \} from "@\/components\/access-groups-section"/);
+assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
+assert.match(settings, /<AccessGroupsSection[\s\S]{0,100}familiars=\{allFamiliars\}/);
+assert.match(settings, /familiar\.id/);
+assert.match(settings, /localDaemonReady/);
+assert.match(settings, /allFamiliars/);
+assert.match(settings, /<Tabs[\s\S]{0,240}bordered=\{false\}/);
+
+console.log("familiar-tab-settings.test.ts: ok");

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 
 const surface = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
 const settings = readFileSync(new URL("./familiar-tab-settings.tsx", import.meta.url), "utf8");
+const styles = readFileSync(new URL("../styles/familiar-tab.css", import.meta.url), "utf8");
 
 assert.match(surface, /import \{ FamiliarSettingsSection \} from "@\/components\/familiar-tab-settings"/);
 assert.match(surface, /type FamiliarSectionId = "identity" \| "skills" \| "mcp" \| "analytics" \| "memory" \| "settings"/);
@@ -23,5 +24,10 @@ assert.match(settings, /familiar\.id/);
 assert.match(settings, /localDaemonReady/);
 assert.match(settings, /allFamiliars/);
 assert.match(settings, /<Tabs[\s\S]{0,240}bordered=\{false\}/);
+assert.match(
+  styles,
+  /\.familiar-tab__settings-tabs\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*z-index:\s*1;[^}]*background:\s*var\(--bg-raised\);/,
+  "the nested settings tabs stay reachable while the familiar section scrolls",
+);
 
 console.log("familiar-tab-settings.test.ts: ok");

--- a/src/components/familiar-tab-settings.tsx
+++ b/src/components/familiar-tab-settings.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { AccessGroupsSection } from "@/components/access-groups-section";
+import { FamiliarStudioBrainTab } from "@/components/familiar-studio-brain-tab";
+import { FamiliarStudioIdentityTab } from "@/components/familiar-studio-identity-tab";
+import { FamiliarStudioMemoryTab } from "@/components/familiar-studio-memory-tab";
+import { FamiliarStudioProjectsTab } from "@/components/familiar-studio-projects-tab";
+import { VaultPanel } from "@/components/vault-panel";
+import { Tabs } from "@/components/ui/tabs";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
+import type { Familiar } from "@/lib/types";
+
+type FamiliarSettingsTab = "identity" | "brain" | "memory" | "projects" | "vault";
+
+const SETTINGS_TABS: Array<{ id: FamiliarSettingsTab; label: string }> = [
+  { id: "identity", label: "Identity" },
+  { id: "brain", label: "Brain" },
+  { id: "memory", label: "Memory" },
+  { id: "projects", label: "Projects" },
+  { id: "vault", label: "Vault" },
+];
+
+/**
+ * The selected familiar's editable Studio controls, embedded in Chat's
+ * Familiar tab. The Chat roster owns selection; these bodies remain the
+ * canonical settings writers used by Settings → Familiars.
+ */
+export function FamiliarSettingsSection({
+  familiar,
+  familiars,
+  allFamiliars,
+  localDaemonReady,
+  onRosterChanged,
+}: {
+  familiar: ResolvedFamiliar;
+  familiars: Familiar[];
+  allFamiliars: ResolvedFamiliar[];
+  localDaemonReady: boolean;
+  onRosterChanged?: () => void;
+}) {
+  const [tab, setTab] = useState<FamiliarSettingsTab>("identity");
+  const raw = useMemo(
+    () => familiars.find((item) => item.id === familiar.id),
+    [familiars, familiar.id],
+  );
+
+  return (
+    <section className="familiar-tab__settings" aria-label={`Settings for ${familiar.display_name}`}>
+      <div className="familiar-tab__settings-heading">
+        <div>
+          <h3 className="familiar-tab__card-title">Settings</h3>
+          <p className="familiar-tab__settings-copy">
+            Tune {familiar.display_name} without leaving Chat.
+          </p>
+        </div>
+      </div>
+
+      <div className="familiar-tab__settings-tabs">
+        <Tabs<FamiliarSettingsTab>
+          variant="underline"
+          idPrefix="familiar-settings"
+          ariaLabel="Familiar settings"
+          value={tab}
+          onChange={setTab}
+          items={SETTINGS_TABS}
+          bordered={false}
+        />
+      </div>
+
+      <div
+        role="tabpanel"
+        id={`familiar-settings-panel-${tab}`}
+        aria-labelledby={`familiar-settings-tab-${tab}`}
+        className="familiar-tab__settings-body familiar-studio__body"
+      >
+        {tab === "identity" ? (
+          <FamiliarStudioIdentityTab
+            key={`${familiar.id}:identity`}
+            familiar={familiar}
+            rawDaemonValues={{
+              display_name: raw?.display_name,
+              role: raw?.role,
+              pronouns: raw?.pronouns,
+              description: raw?.description,
+            }}
+            allFamiliars={allFamiliars}
+            onRosterChanged={onRosterChanged}
+          />
+        ) : null}
+        {tab === "brain" ? <FamiliarStudioBrainTab key={`${familiar.id}:brain`} familiar={familiar} /> : null}
+        {tab === "memory" ? (
+          <FamiliarStudioMemoryTab
+            key={`${familiar.id}:memory`}
+            familiar={familiar}
+            allFamiliars={familiars}
+            localDaemonReady={localDaemonReady}
+          />
+        ) : null}
+        {tab === "projects" ? (
+          <div className="familiar-studio-control__projects">
+            <FamiliarStudioProjectsTab key={`${familiar.id}:projects`} familiar={familiar} />
+            <AccessGroupsSection familiars={allFamiliars} />
+          </div>
+        ) : null}
+        {tab === "vault" ? <VaultPanel key={`${familiar.id}:vault`} familiarId={familiar.id} /> : null}
+      </div>
+    </section>
+  );
+}

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2996,6 +2996,7 @@ export function Workspace() {
         activeFamiliarId={activeId}
         selectedFamiliarIds={scopeIds}
         daemonRunning={daemonRunning}
+        localDaemonReady={localDaemonReady}
         routerRef={routerRef}
         hideThreadRail
         sessionsLoaded={sessionsLoaded}

--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -387,6 +387,38 @@
   overscroll-behavior: contain;
 }
 
+/* Settings keeps the same familiar detail column while reusing the canonical
+   Studio bodies. The nested tab strip stays visible as its body scrolls. */
+.familiar-tab__settings {
+  display: flex;
+  min-height: 100%;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-bottom: var(--space-6);
+}
+
+.familiar-tab__settings-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.familiar-tab__settings-copy {
+  margin-top: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--text-muted);
+}
+
+.familiar-tab__settings-tabs {
+  flex: none;
+  border-bottom: 1px solid var(--border-hairline);
+}
+
+.familiar-tab__settings-body {
+  min-width: 0;
+}
+
 /* Coarse pointers: the group toggles and CTAs are compact targets tuned for a
    cursor — grow their hit areas on touch. */
 @media (pointer: coarse) {

--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -412,7 +412,11 @@
 
 .familiar-tab__settings-tabs {
   flex: none;
+  position: sticky;
+  top: 0;
+  z-index: 1;
   border-bottom: 1px solid var(--border-hairline);
+  background: var(--bg-raised);
 }
 
 .familiar-tab__settings-body {


### PR DESCRIPTION
## Summary
- add the canonical Identity, Brain, Memory, Projects, and Vault settings bodies to Chat > Familiar > Settings
- pass roster refresh and local daemon readiness through the Chat surface
- rename the outer scope from Skills to Familiar and add focused contract coverage

## Verification
- `node scripts/run-tests.mjs app`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `git diff --check`
- live Playwright smoke: Chat > Familiar > Nova > Settings; all five nested tabs rendered, with no console errors