### PR TITLE
feat(chat): merge settings into Familiar scope

### DIFF
--- a/src/components/chat-canvas-tab.test.ts
+++ b/src/components/chat-canvas-tab.test.ts
@@ -19,7 +19,7 @@ const css = readFileSync(new URL("../styles/chat-canvas.css", import.meta.url), 
 // ── Tab wiring in the chat surface ──────────────────────────────────────────
 assert.match(
   surface,
-  /"conversation" \| "projects" \| "coven" \| "familiar" \| "settings" \| "canvas"/,
+  /"conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
   "FamiliarsScope includes the canvas scope",
 );
 assert.match(

--- a/src/components/chat-settings-view.test.ts
+++ b/src/components/chat-settings-view.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-// Consolidated chat settings (the chat page's Settings tab) + auto-archive on
+// Consolidated chat settings (the Familiar page's Chat tab) + auto-archive on
 // thread reflections. Source-contract tests in the repo's house style: the tab
 // must exist on the chat surface, the settings view must round-trip the
 // `chatAutoArchive` policy through /api/config, and the reflect flows must
@@ -12,27 +12,27 @@ const settingsView = readFileSync(new URL("./chat-settings-view.tsx", import.met
 const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
-// --- chat-surface: Settings is a first-class chat scope tab -------------------
+// --- chat-surface: Settings is merged into the Familiar scope -----------------
 
 assert.match(
   surface,
-  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "settings"/,
-  "chat surface must know the settings scope",
+  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
+  "chat surface keeps the Familiar scope and Canvas scope",
 );
-assert.match(
+assert.doesNotMatch(
   surface,
   /\{\s*id:\s*"settings",\s*label:\s*"Settings"\s*\}/,
-  "chat exposes Settings as a dedicated tab beside Sessions/Projects",
+  "chat does not expose Settings as a fifth top-level tab",
 );
-assert.match(
+assert.doesNotMatch(
   surface,
   /scope === "settings" \? \([\s\S]*?<ChatSettingsView \/>/,
-  "the settings scope renders the consolidated ChatSettingsView",
+  "the ChatSurface no longer owns the consolidated ChatSettingsView branch",
 );
 assert.match(
   surface,
-  /import \{[\s\S]*ChatSettingsView[\s\S]*\} from "@\/components\/lazy-surfaces"/,
-  "chat-surface lazy-loads ChatSettingsView",
+  /<ChatFamiliarView[\s\S]*localDaemonReady=\{localDaemonReady\}/,
+  "the Familiar scope receives the daemon readiness needed by merged settings",
 );
 
 // --- chat-settings-view: reads and writes the policy through /api/config ------

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -61,11 +61,16 @@ assert.doesNotMatch(
 // The chat surface no longer hosts a memory scope — familiar memory lives in
 // the Familiars surface and the Grimoire editor (cave-liut). The "familiar"
 // scope is the capability panel promoted out of the retired inspector
-// sidepanel, sitting immediately left of Settings.
+// sidepanel; chat settings now live inside the Familiar surface.
 assert.match(
   chatSurface,
-  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "settings"/,
-  "ChatSurface scope union should carry the promoted familiar tab (and no dead memory scope)",
+  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
+  "ChatSurface scope union should carry the promoted familiar tab and canvas",
+);
+assert.doesNotMatch(
+  chatSurface,
+  /\{\s*id:\s*"settings",\s*label:\s*"Settings"\s*\}/,
+  "ChatSurface should merge chat Settings into the Familiar tab instead of keeping a fifth top-level tab",
 );
 assert.doesNotMatch(
   chatSurface,
@@ -226,13 +231,18 @@ assert.doesNotMatch(
 );
 
 // The inspector sidepanel is retired: its Familiar section is a first-class
-// chat scope tab (left of Settings), Analytics/Automations are gone from chat,
+// chat scope tab, Analytics/Automations are gone from chat,
 // and the code rail is the only right sidepanel. Canvas (saved sketches) sits
-// between Projects and Familiar.
+// between Projects and Familiar; chat settings live inside Familiar.
 assert.match(
   chatSurface,
-  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \},\s*\{ id: "settings", label: "Settings" \},/,
-  "the Familiar tab sits immediately left of Settings (after Canvas)",
+  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \},/,
+  "the Familiar tab is the final primary scope after Canvas",
+);
+assert.doesNotMatch(
+  chatSurface,
+  /scope === "settings"|<ChatSettingsView\s*\/>/,
+  "ChatSurface should no longer own a standalone chat-settings branch",
 );
 // The skills-tab latch must be consumed on the LIVE event path too: "Manage
 // skills" from an already-mounted chat doesn't remount this surface, so a

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -10,7 +10,6 @@ import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import {
   ChatCanvasView,
   ChatFamiliarView,
-  ChatSettingsView,
   GroupChatView,
   ProjectsView,
   WorkspaceRail,
@@ -59,10 +58,9 @@ const chatStorage = {
 // surface and the Grimoire editor, not as a chat scope (cave-liut).
 // "familiar" is the active familiar's capability panel, promoted from the
 // retired inspector sidepanel to a first-class chat tab.
-// "settings" is the consolidated chat-settings tab (auto-archive policy et al).
 // "canvas" is the gallery of sketches saved from chat artifacts — saves landed
 // in the canvas store with no surface after the standalone Canvas page retired.
-type FamiliarsScope = "conversation" | "projects" | "coven" | "familiar" | "settings" | "canvas";
+type FamiliarsScope = "conversation" | "projects" | "coven" | "familiar" | "canvas";
 
 type Props = {
   familiars: Familiar[];
@@ -373,7 +371,6 @@ export function ChatSurface({
               { id: "projects", label: "Projects" },
               { id: "canvas", label: "Canvas" },
               { id: "familiar", label: "Familiar" },
-              { id: "settings", label: "Settings" },
             ]}
           />
           <div className="flex shrink-0 items-center gap-1.5">
@@ -445,13 +442,6 @@ export function ChatSurface({
                 onRosterChanged={onRetryFamiliars}
               />
             </div>
-          </div>
-        ) : scope === "settings" ? (
-          // Consolidated chat settings (cave-wide auto-archive policy, incl.
-          // archive-on-reflection) as a first-class chat tab — the knobs govern
-          // chat behavior, so they live where chats live.
-          <div className="flex min-h-0 min-w-0 flex-1">
-            <ChatSettingsView />
           </div>
         ) : scope === "coven" ? (
           // Group Chat ("coven") lives here as a first-class chat tab instead of

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -18,16 +18,30 @@ assert.match(settings, /FamiliarStudioBrainTab/);
 assert.match(settings, /FamiliarStudioMemoryTab/);
 assert.match(settings, /FamiliarStudioProjectsTab/);
 assert.match(settings, /import \{ AccessGroupsSection \} from "@\/components\/access-groups-section"/);
+assert.match(settings, /ChatSettingsView/);
+assert.doesNotMatch(
+  settings,
+  /from "@\/components\/lazy-surfaces"/,
+  "Familiar settings should not pull the all-surfaces lazy registry into Chat's client graph",
+);
+assert.match(settings, /type FamiliarSettingsTab = "chat" \|/);
+assert.match(settings, /\{ id: "chat", label: "Chat" \}/);
+assert.match(settings, /tab === "chat" \? <ChatSettingsView \/>/);
 assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
 assert.match(settings, /<AccessGroupsSection[\s\S]{0,100}familiars=\{allFamiliars\}/);
 assert.match(settings, /familiar\.id/);
 assert.match(settings, /localDaemonReady/);
 assert.match(settings, /allFamiliars/);
-assert.match(settings, /<Tabs[\s\S]{0,240}bordered=\{false\}/);
+assert.match(settings, /<Tabs<FamiliarSettingsTab>/);
 assert.match(
   styles,
-  /\.familiar-tab__settings-tabs\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*z-index:\s*1;[^}]*background:\s*var\(--bg-raised\);/,
-  "the nested settings tabs stay reachable while the familiar section scrolls",
+  /\.familiar-tab__settings\s*\{[^}]*min-height:\s*0;[^}]*flex:\s*1;/,
+  "the nested settings section fills the Familiar panel",
+);
+assert.match(
+  styles,
+  /\.familiar-tab__settings-body\s*\{[^}]*flex:\s*1;[^}]*min-width:\s*0;[^}]*min-height:\s*0;/,
+  "the nested settings body owns the remaining scrollable height",
 );
 
 console.log("familiar-tab-settings.test.ts: ok");

--- a/src/components/familiar-tab-settings.tsx
+++ b/src/components/familiar-tab-settings.tsx
@@ -2,24 +2,42 @@
 
 import { useMemo, useState } from "react";
 import { AccessGroupsSection } from "@/components/access-groups-section";
+import dynamic from "next/dynamic";
 import { FamiliarStudioBrainTab } from "@/components/familiar-studio-brain-tab";
 import { FamiliarStudioIdentityTab } from "@/components/familiar-studio-identity-tab";
 import { FamiliarStudioMemoryTab } from "@/components/familiar-studio-memory-tab";
 import { FamiliarStudioProjectsTab } from "@/components/familiar-studio-projects-tab";
+import { SkeletonRows } from "@/components/ui/skeleton";
 import { VaultPanel } from "@/components/vault-panel";
 import { Tabs } from "@/components/ui/tabs";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
 
-type FamiliarSettingsTab = "identity" | "brain" | "memory" | "projects" | "vault";
+type FamiliarSettingsTab = "chat" | "identity" | "brain" | "memory" | "projects" | "vault";
 
 const SETTINGS_TABS: Array<{ id: FamiliarSettingsTab; label: string }> = [
+  { id: "chat", label: "Chat" },
   { id: "identity", label: "Identity" },
   { id: "brain", label: "Brain" },
   { id: "memory", label: "Memory" },
   { id: "projects", label: "Projects" },
   { id: "vault", label: "Vault" },
 ];
+
+const ChatSettingsView = dynamic(
+  () =>
+    import("@/components/chat-settings-view").then(
+      (module) => module.ChatSettingsView,
+    ),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex min-h-0 flex-col gap-3 p-6" aria-hidden>
+        <SkeletonRows count={6} />
+      </div>
+    ),
+  },
+);
 
 /**
  * The selected familiar's editable Studio controls, embedded in Chat's
@@ -64,7 +82,6 @@ export function FamiliarSettingsSection({
           value={tab}
           onChange={setTab}
           items={SETTINGS_TABS}
-          bordered={false}
         />
       </div>
 
@@ -74,6 +91,7 @@ export function FamiliarSettingsSection({
         aria-labelledby={`familiar-settings-tab-${tab}`}
         className="familiar-tab__settings-body familiar-studio__body"
       >
+        {tab === "chat" ? <ChatSettingsView /> : null}
         {tab === "identity" ? (
           <FamiliarStudioIdentityTab
             key={`${familiar.id}:identity`}

--- a/src/components/settings-about.test.ts
+++ b/src/components/settings-about.test.ts
@@ -60,6 +60,13 @@ test("About gives OpenCoven Tools a full-width desktop row", () => {
   );
 });
 
+test("About gives the build details a full-width desktop row", () => {
+  assert.match(
+    component,
+    /id=\{settingsGroupId\("CovenCave"\)\}\s+data-settings-group\s+className="settings-about-control settings-about-control--wide"/,
+  );
+});
+
 test("About preserves truthful live status and safe diagnostic behavior", () => {
   assert.match(component, /classifyAboutDaemonStatus/);
   assert.match(component, /fetch\("\/api\/daemon\/status"/);

--- a/src/components/settings-about.tsx
+++ b/src/components/settings-about.tsx
@@ -426,7 +426,7 @@ export function AboutSection() {
         <div
           id={settingsGroupId("CovenCave")}
           data-settings-group
-          className="settings-about-control"
+          className="settings-about-control settings-about-control--wide"
         >
           <SectionRule aside="This build">CovenCave</SectionRule>
           <div className="settings-about-sheet">

--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -391,7 +391,8 @@
    Studio bodies. The nested tab strip stays visible as its body scrolls. */
 .familiar-tab__settings {
   display: flex;
-  min-height: 100%;
+  min-height: 0;
+  flex: 1;
   flex-direction: column;
   gap: var(--space-4);
   padding-bottom: var(--space-6);
@@ -412,15 +413,13 @@
 
 .familiar-tab__settings-tabs {
   flex: none;
-  position: sticky;
-  top: 0;
-  z-index: 1;
   border-bottom: 1px solid var(--border-hairline);
-  background: var(--bg-raised);
 }
 
 .familiar-tab__settings-body {
+  flex: 1;
   min-width: 0;
+  min-height: 0;
 }
 
 /* Coarse pointers: the group toggles and CTAs are compact targets tuned for a


### PR DESCRIPTION
## Summary
- move Chat Settings into the Familiar scope as a nested settings tab
- keep Familiar capabilities, identity, brain, memory, projects, and vault in one surface
- make the About build-details section span the full desktop settings pane

## Test plan
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (974/974)
- focused About contract test (11/11)