### PR TITLE
test(chat): align follow-up grid contract

### DIFF
--- a/src/components/chat-view-polish-edit-review.test.ts
+++ b/src/components/chat-view-polish-edit-review.test.ts
@@ -27,8 +27,13 @@ assert.match(
 );
 assert.match(
   styles,
-  /\.cave-followup-cards__grid \{[\s\S]*?grid-template-columns: repeat\(2, minmax\(0, 1fr\)\)/,
-  "cards use the responsive two-column card grid",
+  /\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: column;[\s\S]*?grid-auto-columns: minmax\(0, 1fr\)/,
+  "cards use equal shares in one row",
+);
+assert.match(
+  styles,
+  /@media \(max-width: 40rem\) \{[\s\S]*?\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: row;[\s\S]*?grid-template-columns: minmax\(0, 1fr\)/,
+  "cards stack in a single column in narrow panes",
 );
 assert.match(
   styles,


### PR DESCRIPTION
Rescues a commit stranded on the primary checkout's local `main` (direct push rejected by branch protection, GH013). Cherry-picked with original authorship onto a branch off `origin/main`.

Tightens the follow-up card pin in `chat-view-polish-edit-review.test.ts` to the single-row contract that landed in #4036: the old pin's lazy `[\s\S]*?` regex could skip from `.cave-followup-cards__grid {` to an unrelated `repeat(2, minmax(0, 1fr))` later in the concatenated CSS, so it kept passing after the geometry changed. The pin now asserts `grid-auto-flow: column` + equal auto-columns, and adds the narrow-pane single-column stack assertion.

Verified against merged main with the css-source-contract hook: `chat-view-polish-edit-review.test.ts` and `chat-session-chrome.test.ts` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)