### PR TITLE
feat(chat): merge settings into familiar scope

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_811/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_814/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -215,7 +215,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_811;/,
+  /const MAX_FILE_COUNT: u64 = 5_814;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -145,7 +145,10 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // 2026-07-29 (Node 24 LTS dependency refresh): the Windows runtime measured
   // 5,801 files. Retain the same ten-file headroom without relaxing the byte
   // ceiling.
-  fileCount: 5_811,
+  // 2026-07-29 (Chat Familiar settings): the nested Familiar settings
+  // writers trace 5,804 files on Windows. Retain the established ten files
+  // of cross-platform headroom without relaxing the byte ceiling.
+  fileCount: 5_814,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_811);
+  assert.ok(metrics.fileCount <= 5_814);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_811,
+    fileCount: 5_814,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -248,7 +248,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_811);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_814);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -8,7 +8,7 @@ pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. The Node 24 LTS
 // dependency refresh traces 5,801 files on Windows; preserve ten-file headroom.
-pub(super) const MAX_FILE_COUNT: u64 = 5_811;
+pub(super) const MAX_FILE_COUNT: u64 = 5_814;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/chat-canvas-tab.test.ts
+++ b/src/components/chat-canvas-tab.test.ts
@@ -19,7 +19,7 @@ const css = readFileSync(new URL("../styles/chat-canvas.css", import.meta.url), 
 // ── Tab wiring in the chat surface ──────────────────────────────────────────
 assert.match(
   surface,
-  /"conversation" \| "projects" \| "coven" \| "familiar" \| "settings" \| "canvas"/,
+  /"conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
   "FamiliarsScope includes the canvas scope",
 );
 assert.match(

--- a/src/components/chat-settings-view.test.ts
+++ b/src/components/chat-settings-view.test.ts
@@ -12,27 +12,27 @@ const settingsView = readFileSync(new URL("./chat-settings-view.tsx", import.met
 const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
-// --- chat-surface: Settings is a first-class chat scope tab -------------------
+// --- chat-surface: Settings is merged into the Familiar scope -----------------
 
 assert.match(
   surface,
-  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "settings"/,
-  "chat surface must know the settings scope",
+  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
+  "chat surface keeps the Familiar scope and Canvas scope",
 );
-assert.match(
+assert.doesNotMatch(
   surface,
   /\{\s*id:\s*"settings",\s*label:\s*"Settings"\s*\}/,
-  "chat exposes Settings as a dedicated tab beside Sessions/Projects",
+  "chat does not expose Settings as a fifth top-level tab",
 );
-assert.match(
+assert.doesNotMatch(
   surface,
   /scope === "settings" \? \([\s\S]*?<ChatSettingsView \/>/,
-  "the settings scope renders the consolidated ChatSettingsView",
+  "the ChatSurface no longer owns the consolidated ChatSettingsView branch",
 );
 assert.match(
   surface,
-  /import \{[\s\S]*ChatSettingsView[\s\S]*\} from "@\/components\/lazy-surfaces"/,
-  "chat-surface lazy-loads ChatSettingsView",
+  /<ChatFamiliarView[\s\S]*localDaemonReady=\{localDaemonReady\}/,
+  "the Familiar scope receives the daemon readiness needed by merged settings",
 );
 
 // --- chat-settings-view: reads and writes the policy through /api/config ------

--- a/src/components/chat-surface.test.ts
+++ b/src/components/chat-surface.test.ts
@@ -61,11 +61,16 @@ assert.doesNotMatch(
 // The chat surface no longer hosts a memory scope — familiar memory lives in
 // the Familiars surface and the Grimoire editor (cave-liut). The "familiar"
 // scope is the capability panel promoted out of the retired inspector
-// sidepanel, sitting immediately left of Settings.
+// sidepanel; chat settings now live inside the Familiar surface.
 assert.match(
   chatSurface,
-  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "settings"/,
-  "ChatSurface scope union should carry the promoted familiar tab (and no dead memory scope)",
+  /type FamiliarsScope = "conversation" \| "projects" \| "coven" \| "familiar" \| "canvas"/,
+  "ChatSurface scope union should carry the promoted familiar tab and canvas",
+);
+assert.doesNotMatch(
+  chatSurface,
+  /\{\s*id:\s*"settings",\s*label:\s*"Settings"\s*\}/,
+  "ChatSurface should merge chat Settings into the Familiar tab instead of keeping a fifth top-level tab",
 );
 assert.doesNotMatch(
   chatSurface,
@@ -226,13 +231,18 @@ assert.doesNotMatch(
 );
 
 // The inspector sidepanel is retired: its Familiar section is a first-class
-// chat scope tab (left of Settings), Analytics/Automations are gone from chat,
+// chat scope tab, Analytics/Automations are gone from chat,
 // and the code rail is the only right sidepanel. Canvas (saved sketches) sits
-// between Projects and Familiar.
+// between Projects and Familiar; chat settings live inside Familiar.
 assert.match(
   chatSurface,
-  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \},\s*\{ id: "settings", label: "Settings" \},/,
-  "the Familiar tab sits immediately left of Settings (after Canvas)",
+  /\{ id: "canvas", label: "Canvas" \},\s*\{ id: "familiar", label: "Familiar" \},/,
+  "the Familiar tab is the final primary scope after Canvas",
+);
+assert.doesNotMatch(
+  chatSurface,
+  /scope === "settings"|<ChatSettingsView\s*\/>/,
+  "ChatSurface should no longer own a standalone chat-settings branch",
 );
 // The skills-tab latch must be consumed on the LIVE event path too: "Manage
 // skills" from an already-mounted chat doesn't remount this surface, so a

--- a/src/components/chat-surface.tsx
+++ b/src/components/chat-surface.tsx
@@ -10,7 +10,6 @@ import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import {
   ChatCanvasView,
   ChatFamiliarView,
-  ChatSettingsView,
   GroupChatView,
   ProjectsView,
   WorkspaceRail,
@@ -59,10 +58,9 @@ const chatStorage = {
 // surface and the Grimoire editor, not as a chat scope (cave-liut).
 // "familiar" is the active familiar's capability panel, promoted from the
 // retired inspector sidepanel to a first-class chat tab.
-// "settings" is the consolidated chat-settings tab (auto-archive policy et al).
 // "canvas" is the gallery of sketches saved from chat artifacts — saves landed
 // in the canvas store with no surface after the standalone Canvas page retired.
-type FamiliarsScope = "conversation" | "projects" | "coven" | "familiar" | "settings" | "canvas";
+type FamiliarsScope = "conversation" | "projects" | "coven" | "familiar" | "canvas";
 
 type Props = {
   familiars: Familiar[];
@@ -373,7 +371,6 @@ export function ChatSurface({
               { id: "projects", label: "Projects" },
               { id: "canvas", label: "Canvas" },
               { id: "familiar", label: "Familiar" },
-              { id: "settings", label: "Settings" },
             ]}
           />
           <div className="flex shrink-0 items-center gap-1.5">
@@ -445,13 +442,6 @@ export function ChatSurface({
                 onRosterChanged={onRetryFamiliars}
               />
             </div>
-          </div>
-        ) : scope === "settings" ? (
-          // Consolidated chat settings (cave-wide auto-archive policy, incl.
-          // archive-on-reflection) as a first-class chat tab — the knobs govern
-          // chat behavior, so they live where chats live.
-          <div className="flex min-h-0 min-w-0 flex-1">
-            <ChatSettingsView />
           </div>
         ) : scope === "coven" ? (
           // Group Chat ("coven") lives here as a first-class chat tab instead of

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -29,5 +29,13 @@ assert.match(
   /\.familiar-tab__settings-tabs\s*\{[^}]*position:\s*sticky;[^}]*top:\s*0;[^}]*z-index:\s*1;[^}]*background:\s*var\(--bg-raised\);/,
   "the nested settings tabs stay reachable while the familiar section scrolls",
 );
+assert.match(settings, /ChatSettingsView/);
+assert.match(settings, /type FamiliarSettingsTab = "chat" \|/);
+assert.match(settings, /\{ id: "chat", label: "Chat" \}/);
+assert.match(settings, /tab === "chat" \? <ChatSettingsView \/>/);
+assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
+assert.match(settings, /familiar\.id/);
+assert.match(settings, /localDaemonReady/);
+assert.match(settings, /allFamiliars/);
 
 console.log("familiar-tab-settings.test.ts: ok");

--- a/src/components/familiar-tab-settings.tsx
+++ b/src/components/familiar-tab-settings.tsx
@@ -6,14 +6,16 @@ import { FamiliarStudioBrainTab } from "@/components/familiar-studio-brain-tab";
 import { FamiliarStudioIdentityTab } from "@/components/familiar-studio-identity-tab";
 import { FamiliarStudioMemoryTab } from "@/components/familiar-studio-memory-tab";
 import { FamiliarStudioProjectsTab } from "@/components/familiar-studio-projects-tab";
+import { ChatSettingsView } from "@/components/lazy-surfaces";
 import { VaultPanel } from "@/components/vault-panel";
 import { Tabs } from "@/components/ui/tabs";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
 
-type FamiliarSettingsTab = "identity" | "brain" | "memory" | "projects" | "vault";
+type FamiliarSettingsTab = "chat" | "identity" | "brain" | "memory" | "projects" | "vault";
 
 const SETTINGS_TABS: Array<{ id: FamiliarSettingsTab; label: string }> = [
+  { id: "chat", label: "Chat" },
   { id: "identity", label: "Identity" },
   { id: "brain", label: "Brain" },
   { id: "memory", label: "Memory" },
@@ -74,6 +76,7 @@ export function FamiliarSettingsSection({
         aria-labelledby={`familiar-settings-tab-${tab}`}
         className="familiar-tab__settings-body familiar-studio__body"
       >
+        {tab === "chat" ? <ChatSettingsView /> : null}
         {tab === "identity" ? (
           <FamiliarStudioIdentityTab
             key={`${familiar.id}:identity`}


### PR DESCRIPTION
## Summary

- Merge the chat Settings scope into the Familiar scope.
- Add Familiar settings tabs for Chat, Identity, Brain, Memory, Projects, and Vault while reusing the existing settings bodies.
- Propagate daemon readiness, update scope contracts, and wire the new regression test into the app suite.

## Verification

- Node 24.18.0 `pnpm typecheck`
- Node 24.18.0 `pnpm lint`
- Node 24.18.0 `pnpm check:tests-wired` (1335 wired)
- Focused Familiar/chat/canvas source contracts
- Node 24.18.0 `pnpm test:app` (974/974)
