### PR TITLE
fix(sidebar): show Dashboard above Settings

### DIFF
--- a/src/components/shell-chrome-revamp.test.ts
+++ b/src/components/shell-chrome-revamp.test.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 // Chat-revamp phase D — app chrome contracts:
 //   1. 56px icon rail: brand mark on top, primary-surface icon buttons,
-//      Settings + account avatar at the bottom; quiet surfaces demoted to the
-//      expanded panel (still reachable via ⌘B / hover-peek / ⌘K).
+//      Dashboard + Settings + account avatar at the bottom; quiet surfaces
+//      remain reachable as icons.
 //   2. 52px-band command bar: "Search or ask <familiar>…" + ⌘K keycap,
 //      right cluster = compact running status + notification bell.
 //   3. Bottom status bar: session context chips (project/model/branch/cwd) +
@@ -51,12 +51,12 @@ assert.match(
   /\.shell-nav--rail \.sidebar-folder-row,\n\.shell-nav--rail \.sidebar-action-row,\n\.shell-nav--rail \.sidebar-foot-btn,\n\.shell-nav--rail \.sidebar-foot-icon-btn \{[\s\S]{0,220}?width: 36px;\s*\n\s*height: 36px;/,
   "rail controls are 36px squares",
 );
-// Every visible workspace destination earns a rail icon; Dashboard remains an
-// expanded-panel link because it leaves the workspace route context.
-assert.match(
+// Dashboard stays reachable in the rail and follows the footer's DOM order, so
+// its icon sits directly above Settings in the rail's vertical footer stack.
+assert.doesNotMatch(
   sidebarCss,
   /\.shell-nav--rail a\.sidebar-foot-btn\[href="\/dashboard"\] \{\s*\n\s*display: none;/,
-  "Dashboard stays out of the rail because it leaves the workspace route context",
+  "Dashboard remains visible above Settings in the rail footer",
 );
 assert.doesNotMatch(
   sidebarCss,

--- a/src/components/sidebar-footer.test.ts
+++ b/src/components/sidebar-footer.test.ts
@@ -15,6 +15,11 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 assert.match(footer, /export function SidebarFooter\(\{ onOpenSettings \}/, "SidebarFooter is a shared component taking onOpenSettings");
 assert.match(footer, /href="\/dashboard"/, "footer links to the Dashboard route");
 assert.match(footer, /onClick=\{onOpenSettings\}[\s\S]*?aria-label="Settings"/, "footer Settings button calls onOpenSettings");
+assert.match(
+  footer,
+  /aria-label="Dashboard"[\s\S]*?aria-label="Settings"/,
+  "Dashboard precedes Settings in the footer",
+);
 assert.match(footer, /className="sidebar-version"[\s\S]*?v\{APP_VERSION\}/, "footer shows the app version line");
 // The version line is the shortest path to what it's about: Settings → About
 // carries the version, updates and project links, and the settings shell

--- a/src/styles/sidebar-minimal/activity-rail.css
+++ b/src/styles/sidebar-minimal/activity-rail.css
@@ -99,14 +99,6 @@
   color: var(--text-primary);
 }
 
-/* The collapsed rail keeps every visible sidebar destination reachable by
-   icon, including the quiet cluster (Memories, Marketplace, and GitHub).
-   Dashboard remains an expanded-panel destination; its route context is
-   distinct from workspace mode navigation. */
-.shell-nav--rail a.sidebar-foot-btn[href="/dashboard"] {
-  display: none;
-}
-
 /* The header familiar switcher survives the rail as the avatar-only trigger:
    the trigger label drops, the 28px avatar stays reachable. */
 .shell-nav--rail .sidebar-familiar-switch .familiar-switcher__trigger-label {

--- a/tests/sidebar-footer.spec.ts
+++ b/tests/sidebar-footer.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from "@playwright/test";
+
+test("collapsed rail places Dashboard directly above Settings", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:shell:nav-open", "0");
+  });
+
+  await page.goto("/?demo=1");
+
+  const footer = page.locator(".shell-nav--rail .sidebar-foot");
+  const dashboard = footer.getByRole("link", { name: "Dashboard" });
+  const settings = footer.getByRole("button", { name: "Settings", exact: true });
+
+  await expect(footer).toBeVisible();
+  await expect(dashboard).toBeVisible();
+  await expect(settings).toBeVisible();
+
+  const dashboardBox = await dashboard.boundingBox();
+  const settingsBox = await settings.boundingBox();
+  expect(dashboardBox).not.toBeNull();
+  expect(settingsBox).not.toBeNull();
+  expect(dashboardBox!.y).toBeLessThan(settingsBox!.y);
+});


### PR DESCRIPTION
## Summary
- keep Dashboard visible in the collapsed 56px sidebar rail
- preserve the shared footer DOM order so Dashboard sits directly above Settings
- add source contracts and a rendered Playwright layout regression

## Verification
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidebar-footer.test.ts`
- `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/shell-chrome-revamp.test.ts`
- `PORT=3488 pnpm exec playwright test tests/sidebar-footer.spec.ts --project=desktop --no-deps --reporter=line`
- `pnpm build`

## Tracking
- Bead: `cave-suj64`