### PR TITLE
docs(permissions): Node 24 does have URLPattern — say why we still hand-roll

### DIFF
--- a/src-tauri/permissions/desktop-permissions.test.mjs
+++ b/src-tauri/permissions/desktop-permissions.test.mjs
@@ -92,9 +92,13 @@ const requiredCommands = [
   "desktop_reachability_configure",
 ];
 
-// Node 24 (CI's runtime) has no global URLPattern, so match capability
-// remote URL patterns component-wise the way Tauri's urlpattern crate does
-// for the simple `scheme://host:port/path` + `*` shapes this repo uses.
+// Match capability remote URL patterns component-wise, the way Tauri's
+// urlpattern crate does for the simple `scheme://host:port/path` + `*` shapes
+// this repo uses. Node 24 DOES expose a global URLPattern (verified on 24.13
+// and 24.18), but it implements the WHATWG spec rather than Tauri's matcher,
+// and what this test asserts is what Tauri will accept — so the hand-rolled
+// comparison stays. The previous wording claimed the global was absent: true
+// on Node 22, carried forward unchecked when CI moved to 24 in #4033.
 // Backslash escapes in patterns (e.g. the IPv6 colons in
 // "http://[\:\:1]:*/*") are URLPattern literal escapes — strip them first.
 function originMatchesPattern(pattern, origin) {


### PR DESCRIPTION
Fallout from reviewing `agent/theme-roster-node24-lts`, which merged as **#4033** while the review was in progress. Two of the three findings died with the squash-merge; this one landed on `main` and is worth correcting.

## The claim on main is false

`src-tauri/permissions/desktop-permissions.test.mjs:95` currently reads:

> `// Node 24 (CI's runtime) has no global URLPattern, so match capability remote URL patterns component-wise…`

#4033 bumped the version number in that sentence from 22 to 24 without rechecking whether the claim survived the bump. It didn't:

```
node v24.13.0 → typeof URLPattern = function
node v24.18.0 → typeof URLPattern = function
```

Both are the versions `.nvmrc` and the workflows pin.

## The code is still right — for a different reason

The hand-rolled component-wise comparison should stay. Node's `URLPattern` implements the **WHATWG spec**; this test asserts what **Tauri's `urlpattern` crate** will accept. Matching against the spec implementation would be testing the wrong matcher.

So the comment now states that, rather than a runtime fact that stopped being true. The risk otherwise is a reasonable future reader deleting ~30 lines of hand-rolled matching in favour of the global that "wasn't available" — and silently changing what this test guarantees.

**Comment only, no behaviour change.** The test passes on Node 22 and Node 24.18 either way.

| Gate | Result |
|---|---|
| `pnpm test:app` | 973 files pass |
| target test on Node 24.18 | pass |
| target test on Node 22 | pass |
| `lint` | pass |

## The other two findings, for the record

- **Empty commit** `290733a96 "ci: rerun PR checks"` (zero diff, CI re-trigger) — moot, the squash-merge collapsed it.
- **Bundling** — theme trimming and a Node LTS bump have different blast radii and ideally ship separately. Moot once merged; noted for next time.

Otherwise #4033 reviewed well: the ten removed themes migrate to `coven` on every read path I traced (schema, pre-hydration paint bootstrap, and the server boundary, which has a new test), and the sidecar budget bump to 5,811 fixes a pre-existing mismatch on main between the closure (5,799) and the Rust const (5,806).

🤖 Generated with [Claude Code](https://claude.com/claude-code)