### PR TITLE
fix(ci): align sidecar budget with Familiar settings

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_811/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_814/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
@@ -215,7 +215,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_811;/,
+  /const MAX_FILE_COUNT: u64 = 5_814;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -145,7 +145,10 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // 2026-07-29 (Node 24 LTS dependency refresh): the Windows runtime measured
   // 5,801 files. Retain the same ten-file headroom without relaxing the byte
   // ceiling.
-  fileCount: 5_811,
+  // 2026-07-29 (Chat Familiar settings): the nested Familiar settings
+  // writers trace 5,804 files on Windows. Retain the established ten files
+  // of cross-platform headroom without relaxing the byte ceiling.
+  fileCount: 5_814,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -97,10 +97,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_811);
+  assert.ok(metrics.fileCount <= 5_814);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_811,
+    fileCount: 5_814,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -248,7 +248,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_811);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_814);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -8,7 +8,7 @@ pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. The Node 24 LTS
 // dependency refresh traces 5,801 files on Windows; preserve ten-file headroom.
-pub(super) const MAX_FILE_COUNT: u64 = 5_811;
+pub(super) const MAX_FILE_COUNT: u64 = 5_814;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -43,5 +43,13 @@ assert.match(
   /\.familiar-tab__settings-body\s*\{[^}]*flex:\s*1;[^}]*min-width:\s*0;[^}]*min-height:\s*0;/,
   "the nested settings body owns the remaining scrollable height",
 );
+assert.match(settings, /ChatSettingsView/);
+assert.match(settings, /type FamiliarSettingsTab = "chat" \|/);
+assert.match(settings, /\{ id: "chat", label: "Chat" \}/);
+assert.match(settings, /tab === "chat" \? <ChatSettingsView \/>/);
+assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
+assert.match(settings, /familiar\.id/);
+assert.match(settings, /localDaemonReady/);
+assert.match(settings, /allFamiliars/);
 
 console.log("familiar-tab-settings.test.ts: ok");


### PR DESCRIPTION
The Familiar settings nesting is already landed in #4041. This follow-up lands the coupled sidecar file-count budget and archive cap updates measured for that feature, plus the focused Familiar-settings contract assertions.

Verification: local typecheck, lint, wired-test check, app suite, focused sidecar tests, and required GitHub CI/CodeQL checks on the preceding implementation commit were green; this PR will rerun them against the rebased delta.