### PR TITLE
fix(chat): resolve thread instrument review gaps

### DIFF
--- a/src/components/chat-thread-instruments.tsx
+++ b/src/components/chat-thread-instruments.tsx
@@ -23,6 +23,7 @@ import { Icon } from "@/lib/icon";
 import { useUserProfile, userDisplayName } from "@/lib/user-profile";
 import type { Turn } from "@/lib/chat-turn-state";
 import {
+  spineSegmentHeights,
   spineNodes,
   spineStackHeight,
   threadMapEvents,
@@ -137,10 +138,11 @@ function SpineNodeButton({
   onJump: () => void;
 }) {
   const stackH = spineStackHeight(node.total);
+  const segmentHeights = spineSegmentHeights(node.cats);
   return (
     <button
       type="button"
-      className={`cave-thread-spine__node is-${node.role}${node.error ? " is-error" : ""}${node.running ? " is-running" : ""}`}
+      className={`cave-thread-spine__node focus-ring is-${node.role}${node.error ? " is-error" : ""}`}
       style={{ top }}
       title={`${node.name}${node.time ? ` · ${node.time}` : ""} — click to jump`}
       aria-label={`Jump to ${node.name}'s turn${node.time ? ` at ${node.time}` : ""}`}
@@ -156,11 +158,11 @@ function SpineNodeButton({
       ) : null}
       {node.total > 0 ? (
         <span className="cave-thread-spine__stack" style={{ height: stackH }} aria-hidden>
-          {node.cats.map((c) => (
+          {node.cats.map((c, index) => (
             <span
               key={c.cat}
               className={`cave-thread-spine__seg is-${c.cat}`}
-              style={{ height: `${Math.max(8, (c.count / node.total) * 100)}%` }}
+              style={{ height: `${segmentHeights[index] ?? 0}%` }}
               title={`${c.cat} · ${c.count}`}
             />
           ))}
@@ -380,7 +382,7 @@ function MapRow({
   return (
     <button
       type="button"
-      className={`cave-thread-map__row is-${event.kind}${event.error ? " is-error" : ""}`}
+      className={`cave-thread-map__row focus-ring is-${event.kind}${event.error ? " is-error" : ""}`}
       title={`${event.label} — click to jump`}
       aria-label={`Jump to ${event.label}`}
       onClick={onJump}

--- a/src/lib/chat-thread-instruments.test.ts
+++ b/src/lib/chat-thread-instruments.test.ts
@@ -9,6 +9,7 @@ import {
   formatTookLabel,
   instrumentSummary,
   instrumentTime,
+  spineSegmentHeights,
   spineNodes,
   spineStackHeight,
   threadMapEvents,
@@ -78,6 +79,16 @@ test("spine stack height follows the design's curve and stays bounded", () => {
   assert.equal(spineStackHeight(500), 96); // cap — a 100-step turn can't own the gutter
 });
 
+test("spine segment heights stay within one stack even with a dominant category", () => {
+  const heights = spineSegmentHeights([
+    { count: 99 },
+    { count: 1 },
+  ]);
+  assert.equal(heights.length, 2);
+  assert.ok(heights.every((height) => height > 0));
+  assert.ok(heights.reduce((sum, height) => sum + height, 0) <= 100.0001);
+});
+
 test("threadMapEvents orders prompt → tools → answer and attributes owners", () => {
   const events = threadMapEvents(
     [
@@ -136,6 +147,21 @@ const instruments = readFileSync(
   new URL("../components/chat-thread-instruments.tsx", import.meta.url),
   "utf8",
 );
+const instrumentStyles = readFileSync(
+  new URL("../styles/cave-chat/thread-instruments.css", import.meta.url),
+  "utf8",
+);
+
+test("instrument controls use the shared focus ring and no dead running class", () => {
+  assert.match(instruments, /className=\{`cave-thread-spine__node focus-ring/);
+  assert.match(instruments, /className=\{`cave-thread-map__row focus-ring/);
+  assert.doesNotMatch(instruments, /is-running/);
+});
+
+test("instrument tint mappings use theme-aware semantic tokens", () => {
+  assert.doesNotMatch(instrumentStyles, /--tim-[^:]+:\s*oklch\(/);
+  assert.match(instrumentStyles, /\.cave-thread-map \.is-read \{ --tim: var\(--color-info\); \}/);
+});
 
 test("chat-view mounts both instruments over the SAME activePath the transcript renders", () => {
   assert.match(

--- a/src/lib/chat-thread-instruments.test.ts
+++ b/src/lib/chat-thread-instruments.test.ts
@@ -85,7 +85,7 @@ test("spine segment heights stay within one stack even with a dominant category"
     { count: 1 },
   ]);
   assert.equal(heights.length, 2);
-  assert.ok(heights.every((height) => height > 0));
+  assert.ok(heights.every((height) => height >= Math.min(8, 100 / heights.length)));
   assert.ok(heights.reduce((sum, height) => sum + height, 0) <= 100.0001);
 });
 

--- a/src/lib/chat-thread-instruments.ts
+++ b/src/lib/chat-thread-instruments.ts
@@ -94,7 +94,6 @@ export type SpineNode = {
   name: string;
   summary: string;
   error: boolean;
-  running: boolean;
   /** Aggregated tool calls, in THREAD_TOOL_CATEGORIES order, zero-counts dropped. */
   cats: { cat: ThreadToolCategory; count: number }[];
   total: number;
@@ -123,7 +122,6 @@ export function spineNodes(
       name: turn.role === "user" ? names.operatorName : names.familiarName,
       summary: instrumentSummary(turn.text),
       error: Boolean(turn.error),
-      running: Boolean(turn.pending),
       cats,
       total: cats.reduce((n, c) => n + c.count, 0),
     });
@@ -136,6 +134,20 @@ export function spineNodes(
 export function spineStackHeight(total: number): number {
   if (total <= 0) return 0;
   return Math.min(96, Math.max(28, Math.round(total * 2.4)));
+}
+
+/** Convert category counts into bounded percentages for the vertical stack.
+ * Small categories stay legible, then the complete stack is renormalized so
+ * those minimums can never push the segments past 100%. */
+export function spineSegmentHeights(cats: readonly { count: number }[]): number[] {
+  if (cats.length === 0) return [];
+  const counts = cats.map(({ count }) => Math.max(0, count));
+  const total = counts.reduce((sum, count) => sum + count, 0);
+  if (total <= 0) return counts.map(() => 0);
+  const minimum = Math.min(8, 100 / counts.length);
+  const heights = counts.map((count) => Math.max(minimum, (count / total) * 100));
+  const sum = heights.reduce((totalHeight, height) => totalHeight + height, 0);
+  return sum > 100 ? heights.map((height) => (height / sum) * 100) : heights;
 }
 
 export type ThreadMapEvent = {

--- a/src/lib/chat-thread-instruments.ts
+++ b/src/lib/chat-thread-instruments.ts
@@ -137,17 +137,16 @@ export function spineStackHeight(total: number): number {
 }
 
 /** Convert category counts into bounded percentages for the vertical stack.
- * Small categories stay legible, then the complete stack is renormalized so
- * those minimums can never push the segments past 100%. */
+ * Reserve a readable minimum for every category, then distribute only the
+ * remaining height by count so the minimum can never be renormalized away. */
 export function spineSegmentHeights(cats: readonly { count: number }[]): number[] {
   if (cats.length === 0) return [];
   const counts = cats.map(({ count }) => Math.max(0, count));
   const total = counts.reduce((sum, count) => sum + count, 0);
   if (total <= 0) return counts.map(() => 0);
   const minimum = Math.min(8, 100 / counts.length);
-  const heights = counts.map((count) => Math.max(minimum, (count / total) * 100));
-  const sum = heights.reduce((totalHeight, height) => totalHeight + height, 0);
-  return sum > 100 ? heights.map((height) => (height / sum) * 100) : heights;
+  const remaining = 100 - minimum * counts.length;
+  return counts.map((count) => minimum + (count / total) * remaining);
 }
 
 export type ThreadMapEvent = {

--- a/src/styles/cave-chat/thread-instruments.css
+++ b/src/styles/cave-chat/thread-instruments.css
@@ -5,39 +5,25 @@
    the reading column's existing side gutters — overlays, never layout — and
    both stay home on narrow panes (gated in the components).
 
-   One tint per tool category, set once here and read by spine segments, card
-   swatches and map bars alike — the design's NODE_TINT palette. */
-
-.cave-thread-spine,
-.cave-thread-map {
-  --tim-turn: var(--text-primary);
-  --tim-answer: var(--color-success);
-  --tim-read: oklch(0.74 0.13 235);
-  --tim-shell: oklch(0.8 0.15 150);
-  --tim-edit: oklch(0.82 0.14 75);
-  --tim-search: oklch(0.74 0.16 295);
-  --tim-wait: var(--color-warning);
-  --tim-web: oklch(0.78 0.12 200);
-  --tim-agent: oklch(0.74 0.18 350);
-  --tim-other: var(--text-muted);
-}
+   Category colors deliberately come from the global semantic token contract so
+   every palette and mode can retune them without a component-local palette. */
 
 .cave-thread-spine .is-shell,
-.cave-thread-map .is-shell { --tim: var(--tim-shell); }
+.cave-thread-map .is-shell { --tim: var(--color-success); }
 .cave-thread-spine .is-edit,
-.cave-thread-map .is-edit { --tim: var(--tim-edit); }
+.cave-thread-map .is-edit { --tim: var(--color-warning); }
 .cave-thread-spine .is-search,
-.cave-thread-map .is-search { --tim: var(--tim-search); }
+.cave-thread-map .is-search { --tim: var(--accent-presence); }
 .cave-thread-spine .is-wait,
-.cave-thread-map .is-wait { --tim: var(--tim-wait); }
+.cave-thread-map .is-wait { --tim: var(--color-warning); }
 .cave-thread-spine .is-web,
-.cave-thread-map .is-web { --tim: var(--tim-web); }
+.cave-thread-map .is-web { --tim: var(--color-info); }
 .cave-thread-spine .is-agent,
-.cave-thread-map .is-agent { --tim: var(--tim-agent); }
+.cave-thread-map .is-agent { --tim: var(--accent-presence); }
 .cave-thread-spine .is-other,
-.cave-thread-map .is-other { --tim: var(--tim-other); }
+.cave-thread-map .is-other { --tim: var(--text-muted); }
 .cave-thread-spine .is-read,
-.cave-thread-map .is-read { --tim: var(--tim-read); }
+.cave-thread-map .is-read { --tim: var(--color-info); }
 
 /* ── Spine — left gutter, scrolls with the content ───────────────────────── */
 
@@ -312,8 +298,8 @@
   background: color-mix(in oklch, var(--foreground) 8%, transparent);
 }
 
-.cave-thread-map .is-turn { --tim: var(--tim-turn); }
-.cave-thread-map .is-answer { --tim: var(--tim-answer); }
+.cave-thread-map .is-turn { --tim: var(--text-primary); }
+.cave-thread-map .is-answer { --tim: var(--color-success); }
 .cave-thread-map .is-error { --tim: var(--color-danger); }
 
 .cave-thread-map__bar {


### PR DESCRIPTION
Follow-up for merged #4046.

- add shared focus rings to spine/minimap jump controls
- bound proportional spine segments so minimum legibility cannot overflow the stack
- remove the dead running class state
- replace component-local hard-coded tint palette values with global semantic theme tokens

Verification: focused chat-thread-instruments contract (11/11), pnpm typecheck, pnpm lint (design drift 0), pnpm check:tests-wired, git diff --check.