### PR TITLE
feat(chat): scope the Familiar tab to the active familiar only

### DIFF
--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -3,9 +3,11 @@
 /**
  * ChatFamiliarView — the chat surface's Familiar tab.
  *
- * Skills-page design handoff (cave-moig): a shared SurfaceRail roster on the
- * left (search, collapse, resize — local selection only, never the app-wide
- * scope) and, on the right, an identity hero (avatar, serif name, presence,
+ * Skills-page design handoff (cave-moig), scoped to the ACTIVE familiar
+ * (cave-k8b0a): the tab describes who you're chatting with — the app-wide
+ * scope dropdown at the top-left of the sidebar is the ONLY place a familiar
+ * is switched, so the tab hosts no roster of its own. An identity hero
+ * (avatar, serif name, presence,
  * live Runtime/Model/Voice selects, Edit in Studio, New chat) over a six-tab
  * band: Identity · Skills · MCP · Analytics · Memory · Settings. Capability data still
  * flows through useCapabilitySnapshot (/api/roles, /api/skills/local,
@@ -19,8 +21,6 @@ import type { Familiar } from "@/lib/types";
 import { Icon } from "@/lib/icon";
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
-import { SurfaceRail } from "@/components/ui/surface-rail";
-import { SearchInput } from "@/components/ui/search-input";
 import { Tabs } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
@@ -559,81 +559,6 @@ function FamiliarCapabilityPanel({
   );
 }
 
-// ── Roster rail ──────────────────────────────────────────────────────────────
-
-/**
- * The left-hand roster: a SurfaceRail listing every selectable familiar.
- * Selection here switches the DETAIL only (local state in the surface) — it
- * never mutates the app-wide familiar scope.
- */
-function FamiliarRosterRail({
-  familiars,
-  selectedId,
-  query,
-  onQueryChange,
-  onSelect,
-}: {
-  familiars: ResolvedFamiliar[];
-  selectedId: string;
-  query: string;
-  onQueryChange: (next: string) => void;
-  onSelect: (id: string) => void;
-}) {
-  const needle = query.trim().toLowerCase();
-  const filtered = needle
-    ? familiars.filter(
-        (item) =>
-          item.display_name.toLowerCase().includes(needle) ||
-          (item.role ?? "").toLowerCase().includes(needle),
-      )
-    : familiars;
-  return (
-    <SurfaceRail
-      storageKey="cave:familiar-tab:rail"
-      title="Familiars"
-      ariaLabel="Familiars"
-      search={
-        <SearchInput
-          value={query}
-          onValueChange={onQueryChange}
-          onClear={() => onQueryChange("")}
-          placeholder="Search familiars…"
-          aria-label="Search familiars"
-        />
-      }
-    >
-      {(open) => (
-        <>
-          {filtered.length === 0 ? (
-            <p className="px-2 py-1.5 text-[length:var(--text-sm)] text-[var(--text-muted)]">
-              No familiars match &ldquo;{query.trim()}&rdquo;.
-            </p>
-          ) : null}
-          {filtered.map((item) => (
-            <button
-              key={item.id}
-              type="button"
-              className="familiar-tab__rail-row focus-ring"
-              aria-current={item.id === selectedId ? "true" : undefined}
-              title={open ? undefined : item.display_name}
-              aria-label={open ? undefined : item.display_name}
-              onClick={() => onSelect(item.id)}
-            >
-              <FamiliarAvatar familiar={item} size="md" />
-              {open ? (
-                <span className="familiar-tab__rail-text">
-                  <span className="familiar-tab__rail-name">{item.display_name}</span>
-                  <span className="familiar-tab__rail-role">{item.role || "No role"}</span>
-                </span>
-              ) : null}
-            </button>
-          ))}
-        </>
-      )}
-    </SurfaceRail>
-  );
-}
-
 // ── Surface ──────────────────────────────────────────────────────────────────
 
 /**
@@ -675,16 +600,6 @@ export function ChatFamiliarCapabilities({
   const selectedFamiliar = familiar
     ? resolvedFamiliars.find((item) => item.id === familiar.id) ?? null
     : null;
-
-  // Rail-local detail selection: browsing the roster switches the detail pane
-  // only; the app-wide active familiar (and saved scope) never changes from
-  // here. A new app-wide selection re-anchors the detail.
-  const [detailId, setDetailId] = useState<string | null>(null);
-  const [railQuery, setRailQuery] = useState("");
-  const activeFamiliarId = familiar?.id ?? null;
-  useEffect(() => {
-    setDetailId(null);
-  }, [activeFamiliarId]);
 
   const state = deriveFamiliarTabState({
     familiars: selectableFamiliars,
@@ -784,21 +699,16 @@ export function ChatFamiliarCapabilities({
     );
   }
 
-  const detailFamiliar =
-    (detailId ? selectableFamiliars.find((item) => item.id === detailId) : null) ?? state.familiar;
+  // The tab always describes the app-wide ACTIVE familiar (cave-k8b0a) — the
+  // sidebar's scope dropdown is the only switching surface, so no local
+  // detail selection exists to diverge from it.
+  const detailFamiliar = state.familiar;
 
   return (
     <section
       className="chat-familiar-view familiar-tab flex h-full min-h-0 flex-row"
       aria-label="Familiar profile"
     >
-      <FamiliarRosterRail
-        familiars={selectableFamiliars}
-        selectedId={detailFamiliar.id}
-        query={railQuery}
-        onQueryChange={setRailQuery}
-        onSelect={setDetailId}
-      />
       <div className="flex min-h-0 min-w-0 flex-1 flex-col">
         {state.rosterWarning ? <FamiliarRosterWarning message={state.rosterWarning} onRetry={onRetryFamiliars} /> : null}
         <FamiliarCapabilityPanel

--- a/src/components/familiar-tab-scope.test.ts
+++ b/src/components/familiar-tab-scope.test.ts
@@ -28,35 +28,22 @@ test("the view renders explicit lifecycle, scope, and unavailable states", () =>
   assert.match(view, /state\.kind === "all" \|\| state\.kind === "subset"/, "all and subset share the overview");
   assert.match(
     view,
-    /const detailFamiliar =\s*\(detailId \? selectableFamiliars\.find\(\(item\) => item\.id === detailId\) : null\) \?\? state\.familiar;/,
-    "the detail defaults to the app-wide active familiar",
+    /const detailFamiliar = state\.familiar;/,
+    "the detail IS the app-wide active familiar — nothing local to diverge",
   );
   assert.match(view, /<FamiliarCapabilityPanel[\s\S]*?familiar=\{detailFamiliar\}/, "single state retains the capability panel");
   assert.doesNotMatch(view, /No familiar selected/, "nullable single-familiar copy is gone");
 });
 
-test("the roster rail browses locally — it never mutates the app-wide scope", () => {
-  assert.match(view, /<FamiliarRosterRail/, "single state hosts the roster rail");
-  assert.match(view, /storageKey="cave:familiar-tab:rail"/, "rail persists under its own key");
-  assert.match(view, /placeholder="Search familiars…"/, "rail search follows placeholder grammar");
-  assert.match(
-    view,
-    /item\.display_name\.toLowerCase\(\)\.includes\(needle\) \|\|\s*\(item\.role \?\? ""\)\.toLowerCase\(\)\.includes\(needle\)/,
-    "search filters by name and role",
-  );
-  assert.match(view, /aria-current=\{item\.id === selectedId \? "true" : undefined\}/, "selected row announced with aria-current");
-  assert.match(view, /onSelect=\{setDetailId\}/, "row activation only moves the local detail selection");
-  const rail = view.slice(view.indexOf("function FamiliarRosterRail"), view.indexOf("// ── Surface"));
-  assert.ok(rail.length > 0, "rail component located");
-  assert.doesNotMatch(rail, /onFamiliarScopeChange/, "the rail cannot reach the scope mutation path");
-  // A new app-wide selection re-anchors the local detail.
-  assert.match(
-    view,
-    /useEffect\(\(\) => \{\s*setDetailId\(null\);\s*\}, \[activeFamiliarId\]\)/,
-    "active familiar changes reset the local browse selection",
-  );
-  // Collapsed rail rows fall back to avatar-only buttons with tooltip names.
-  assert.match(view, /title=\{open \? undefined : item\.display_name\}/, "collapsed rows keep tooltip names");
+test("the tab hosts NO familiar switching — the sidebar scope dropdown is the only one (cave-k8b0a)", () => {
+  // Val's directive (2026-07-29): the Familiar tab shows only the selected
+  // familiar; switching lives solely in the global dropdown at the top-left
+  // of the sidebar. The old roster rail and its local detail selection are
+  // gone — reintroducing either needs the directive revisited first.
+  assert.doesNotMatch(view, /FamiliarRosterRail/, "the roster rail does not return");
+  assert.doesNotMatch(view, /cave:familiar-tab:rail/, "no rail persistence key lingers");
+  assert.doesNotMatch(view, /setDetailId|detailId/, "no rail-local detail selection exists");
+  assert.doesNotMatch(view, /SurfaceRail/, "the tab mounts no roster rail primitive");
 });
 
 test("overview activation is the only action that narrows scope", () => {

--- a/src/components/familiar-tab-scope.test.ts
+++ b/src/components/familiar-tab-scope.test.ts
@@ -6,7 +6,7 @@ import { readFileSync } from "node:fs";
 const view = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
 const surface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/globals/shell-responsive.css", import.meta.url), "utf8");
 
 test("Workspace threads the explicit scope and canonical mutation path to the Familiar tab", () => {
   assert.match(workspace, /selectedFamiliarIds=\{scopeIds\}/, "full scope reaches ChatSurface");

--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -1,65 +1,11 @@
 /* ────────────────────────────────────────────────
-   Chat · Familiar tab — roster rail + identity detail
-   (design-handoff redesign: SurfaceRail roster on the left, identity header
-   + Roles/Skills/Runtime/Capabilities cards on the right. The `.familiar-tab`
-   root class is load-bearing for backdrop glass — see backdrop.css.)
+   Chat · Familiar tab — identity detail for the ACTIVE familiar
+   (design-handoff redesign, scoped by cave-k8b0a: the sidebar's global scope
+   dropdown is the only familiar switcher, so the tab hosts no roster rail —
+   just the identity header + Roles/Skills/Runtime/Capabilities cards. The
+   `.familiar-tab` root class is load-bearing for backdrop glass — see
+   backdrop.css.)
    ──────────────────────────────────────────────── */
-
-/* Roster rail rows (rendered inside SurfaceRail's content slot). */
-.familiar-tab__rail-row {
-  display: flex;
-  flex: none;
-  align-items: center;
-  gap: var(--space-2);
-  width: 100%;
-  padding: var(--space-1);
-  border: none;
-  border-radius: var(--radius-md);
-  background: transparent;
-  color: var(--text-primary);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-
-.familiar-tab__rail-row:hover {
-  background: color-mix(in oklch, var(--text-primary) 6%, transparent);
-}
-
-/* Selected row = surface bg. */
-.familiar-tab__rail-row[aria-current="true"] {
-  background: var(--bg-raised);
-}
-
-/* Collapsed rail: avatar-only square buttons. */
-.surface-rail[data-open="false"] .familiar-tab__rail-row {
-  width: auto;
-  justify-content: center;
-}
-
-.familiar-tab__rail-text {
-  display: flex;
-  flex: 1;
-  flex-direction: column;
-  min-width: 0;
-}
-
-.familiar-tab__rail-name {
-  font-size: var(--text-base);
-  font-weight: 500;
-  color: var(--text-primary);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.familiar-tab__rail-role {
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
 /* Detail pane: the main column measures its own inline size so the card grid
    goes two-column when the pane (not the viewport) is wide enough. */


### PR DESCRIPTION
Val's directive (bead cave-k8b0a): the Familiar tab describes who you're chatting with — the app-wide scope dropdown at the top-left of the sidebar is the **only** place a familiar is switched.

## What changes

- The tab's SurfaceRail roster (search, browse, per-row selection) is **removed**; the capability panel spans the tab full-width.
- The rail-local `detailId` selection is removed with it — the detail **is** the active familiar, so the tab can never diverge from the scope the sidebar shows.
- The orphaned `.familiar-tab__rail-*` styles leave `familiar-tab.css` (net −183 lines).
- `familiar-tab-scope.test.ts` now pins the **absence** of the rail (`doesNotMatch FamiliarRosterRail / detailId / SurfaceRail`) instead of the old local-browse contract, so reintroducing in-tab switching fails loudly.

The scope overview (the landing when "All familiars" is selected globally) stays: with no single selection there's nothing to scope the tab to, and its cards route through the same canonical `onFamiliarScopeChange` the dropdown uses.

## Verification

Prod build: with Kitty selected via the global dropdown, the FAMILIAR tab renders her identity hero + Identity/Skills/MCP/Analytics/Memory/Settings sections full-width with **no rail**; switching exists only in the sidebar dropdown. (Capability sections load slowly in the local env — the outdated installed Coven CLI makes `/api/harnesses` crawl — unrelated to this diff.)

Gates: `pnpm test:app` (975 files) · `pnpm build` (budgets green) · tsc · eslint.

Bead: cave-k8b0a

🤖 Generated with [Claude Code](https://claude.com/claude-code)