### PR TITLE
docs(chat): align Familiar tab stylesheet contract

### DIFF
--- a/src/styles/familiar-tab.css
+++ b/src/styles/familiar-tab.css
@@ -2,7 +2,8 @@
    Chat · Familiar tab — identity detail for the ACTIVE familiar
    (design-handoff redesign, scoped by cave-k8b0a: the sidebar's global scope
    dropdown is the only familiar switcher, so the tab hosts no roster rail —
-   just the identity header + Roles/Skills/Runtime/Capabilities cards. The
+   just the identity header + Identity/Skills/MCP/Analytics/Memory/Settings
+   sections spanning the full-width capability panel. The
    `.familiar-tab` root class is load-bearing for backdrop glass — see
    backdrop.css.)
    ──────────────────────────────────────────────── */


### PR DESCRIPTION
Follow-up to #4049.

Updates the Familiar tab stylesheet header to describe the current full-width Identity, Skills, MCP, Analytics, Memory, and Settings sections instead of the removed roster/card layout. This resolves the valid Copilot review comment on #4049.

Verification: pre-commit, focused contract test 6/6, typecheck, lint/design drift, tests-wired, and diff check.