### PR TITLE
Remove retired Settings Familiars tab

### DIFF
--- a/src/components/access-groups-section.test.ts
+++ b/src/components/access-groups-section.test.ts
@@ -7,7 +7,7 @@ const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "ut
 const inline = readFileSync(new URL("./familiar-studio-inline.tsx", import.meta.url), "utf8");
 const sections = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
 
-// ── Access groups management lives in Settings → Familiars ───────────────────
+// ── Access groups management lives in Chat → Familiar → Settings ─────────────
 assert.match(section, /export function AccessGroupsSection/, "exports the access groups section");
 assert.doesNotMatch(shell, /<AccessGroupsSection/, "the shell does not duplicate access groups below the control sheet");
 assert.match(
@@ -15,7 +15,7 @@ assert.match(
   /<AccessGroupsSection familiars=\{resolved\} \/>/,
   "the Projects tab mounts the access groups manager",
 );
-assert.match(sections, /group: "Access groups"/, "settings search indexes the access groups group");
+assert.doesNotMatch(sections, /group: "Access groups"/, "retired Settings search does not index the access groups group");
 
 // ── Speaks the access-groups API, human-confirmed ─────────────────────────────
 assert.match(section, /fetch\("\/api\/access-groups"/, "loads groups from the list route");

--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -31,6 +31,7 @@ import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
 import { isBindableRuntimeChoice, type AdapterReport } from "@/lib/harness-adapters";
+import { consumeFamiliarSettingsPending, type FamiliarSettingsTab } from "@/lib/chat-tab-events";
 import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { listVoiceProviders } from "@/lib/voice/registry";
 import { useRuntimeModelOptions } from "@/lib/use-runtime-model-options";
@@ -471,6 +472,14 @@ function FamiliarCapabilityPanel({
   const snapshot = useCapabilitySnapshot(harnessId);
   // Skills is the section this handoff is named for — it opens first.
   const [section, setSection] = useState<FamiliarSectionId>("skills");
+  const [settingsTab, setSettingsTab] = useState<FamiliarSettingsTab | undefined>();
+
+  useEffect(() => {
+    const target = consumeFamiliarSettingsPending();
+    if (!target) return;
+    setSection("settings");
+    setSettingsTab(target.tab);
+  }, []);
 
   const data = useMemo(
     () =>
@@ -551,6 +560,7 @@ function FamiliarCapabilityPanel({
             familiars={familiars}
             allFamiliars={allFamiliars}
             localDaemonReady={localDaemonReady}
+            initialTab={settingsTab}
             onRosterChanged={onRosterChanged}
           />
         ) : null}

--- a/src/components/command-palette.tsx
+++ b/src/components/command-palette.tsx
@@ -69,7 +69,6 @@ type PaletteIntent =
       kind: "open-setting";
       section: SettingsIndexEntry["section"];
       group?: string;
-      familiarTab?: SettingsIndexEntry["familiarTab"];
     };
 
 type Card = {
@@ -492,7 +491,7 @@ export function CommandPalette({
         )
           .slice(0, RESULT_LIMITS.setting)
           .map((entry) => ({
-            id: `setting:${entry.section}:${entry.group ?? "overview"}:${entry.familiarTab ?? "root"}`,
+            id: `setting:${entry.section}:${entry.group ?? "overview"}`,
             kind: "setting" as const,
             entry,
           }));
@@ -777,7 +776,6 @@ export function CommandPalette({
         kind: "open-setting",
         section: row.entry.section,
         ...(row.entry.group ? { group: row.entry.group } : {}),
-        ...(row.entry.familiarTab ? { familiarTab: row.entry.familiarTab } : {}),
       });
     } else {
       onIntent(row.intent);
@@ -1166,7 +1164,7 @@ export function CommandPalette({
                           {row.entry.group ? ` › ${row.entry.group}` : ""}
                         </span>
                         <span className="truncate text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                          {row.entry.familiarTab ? `Familiars · ${row.entry.familiarTab}` : row.entry.keywords}
+                          {row.entry.keywords}
                         </span>
                       </span>
                       {active ? <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">open</span> : null}

--- a/src/components/familiar-studio-inline.test.ts
+++ b/src/components/familiar-studio-inline.test.ts
@@ -8,6 +8,7 @@ const styles = readFileSync(new URL("../styles/settings-familiars.css", import.m
 const identityTab = readFileSync(new URL("./familiar-studio-identity-tab.tsx", import.meta.url), "utf8");
 const memoryTab = readFileSync(new URL("./familiar-studio-memory-tab.tsx", import.meta.url), "utf8");
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
+const chatCapabilities = readFileSync(new URL("./chat-familiar-capabilities.tsx", import.meta.url), "utf8");
 
 assert.match(source, /export function FamiliarStudioInlinePanel/, "Exports the inline control sheet");
 assert.match(source, /SettingsFamiliarPicker/, "Renders the persistent familiar roster");
@@ -43,10 +44,11 @@ assert.match(
 assert.match(picker, /data-archived=\{familiar\.archived \|\| undefined\}/, "Archived rows expose a visual state");
 assert.match(picker, /reveal-scope/, "Row actions follow shared progressive disclosure");
 assert.match(
-  shell,
-  /useResolvedFamiliars\(rawFamiliars,\s*\{\s*includeArchived:\s*true\s*\}\)/,
-  "Settings keeps archived familiars in the lifecycle control sheet",
+  chatCapabilities,
+  /useResolvedFamiliars\(familiars,\s*\{\s*includeArchived:\s*true\s*\}\)/,
+  "Chat keeps archived familiars in the lifecycle control sheet",
 );
+assert.doesNotMatch(shell, /useResolvedFamiliars\(/, "the retired Settings shell no longer owns familiar lifecycle state");
 assert.match(
   styles,
   /\.settings-familiar-roster__list\s*\{[\s\S]*?min-height:\s*0[\s\S]*?overflow-y:\s*auto/,

--- a/src/components/familiar-summoning-circle.test.ts
+++ b/src/components/familiar-summoning-circle.test.ts
@@ -284,18 +284,10 @@ assert.match(
 // ── The circle is the only creation path (dialog fully replaced) ────────────
 const familiarsView = await readFile(new URL("./familiars-view.tsx", import.meta.url), "utf8");
 const settingsShell = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
-for (const [name, consumer] of [["familiars-view", familiarsView], ["settings-shell", settingsShell]]) {
-  assert.match(
-    consumer,
-    /FamiliarSummoningCircle/,
-    `${name} opens the summoning circle`,
-  );
-  assert.doesNotMatch(
-    consumer,
-    /CreateFamiliarDialog/,
-    `${name} no longer references the retired CreateFamiliarDialog`,
-  );
-}
+assert.match(familiarsView, /FamiliarSummoningCircle/, "the Chat familiars view opens the summoning circle");
+assert.doesNotMatch(familiarsView, /CreateFamiliarDialog/, "the Chat familiars view no longer references the retired CreateFamiliarDialog");
+assert.doesNotMatch(settingsShell, /FamiliarSummoningCircle/, "the retired Settings Familiars section no longer opens the summoning circle");
+assert.doesNotMatch(settingsShell, /CreateFamiliarDialog/, "Settings no longer references the retired CreateFamiliarDialog");
 assert.match(
   familiarsView,
   /onEnhance=\{\(\) => setEnhanceTarget\(selectedFamiliar\)\}/,

--- a/src/components/familiar-tab-settings.test.ts
+++ b/src/components/familiar-tab-settings.test.ts
@@ -11,6 +11,9 @@ assert.match(surface, /type FamiliarSectionId = "identity" \| "skills" \| "mcp" 
 assert.match(surface, /\{ id: "settings", label: "Settings" \}/);
 assert.match(surface, /section === "settings" \? \([\s\S]{0,120}?<FamiliarSettingsSection/);
 assert.match(surface, /<FamiliarSettingsSection[\s\S]{0,500}?familiar=\{familiar\}/);
+assert.match(surface, /consumeFamiliarSettingsPending/);
+assert.match(surface, /setSection\("settings"\)/);
+assert.match(surface, /initialTab=\{settingsTab\}/);
 
 assert.match(settings, /export function FamiliarSettingsSection\(/);
 assert.match(settings, /FamiliarStudioIdentityTab/);
@@ -24,7 +27,7 @@ assert.doesNotMatch(
   /from "@\/components\/lazy-surfaces"/,
   "Familiar settings should not pull the all-surfaces lazy registry into Chat's client graph",
 );
-assert.match(settings, /type FamiliarSettingsTab = "chat" \|/);
+assert.match(settings, /import type \{ FamiliarSettingsTab \} from "@\/lib\/chat-tab-events"/);
 assert.match(settings, /\{ id: "chat", label: "Chat" \}/);
 assert.match(settings, /tab === "chat" \? <ChatSettingsView \/>/);
 assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
@@ -33,6 +36,8 @@ assert.match(settings, /familiar\.id/);
 assert.match(settings, /localDaemonReady/);
 assert.match(settings, /allFamiliars/);
 assert.match(settings, /<Tabs<FamiliarSettingsTab>/);
+assert.match(settings, /initialTab\?: FamiliarSettingsTab/);
+assert.match(settings, /useState<FamiliarSettingsTab>\(initialTab \?\? "identity"\)/);
 assert.match(
   styles,
   /\.familiar-tab__settings\s*\{[^}]*min-height:\s*0;[^}]*flex:\s*1;/,
@@ -43,13 +48,4 @@ assert.match(
   /\.familiar-tab__settings-body\s*\{[^}]*flex:\s*1;[^}]*min-width:\s*0;[^}]*min-height:\s*0;/,
   "the nested settings body owns the remaining scrollable height",
 );
-assert.match(settings, /ChatSettingsView/);
-assert.match(settings, /type FamiliarSettingsTab = "chat" \|/);
-assert.match(settings, /\{ id: "chat", label: "Chat" \}/);
-assert.match(settings, /tab === "chat" \? <ChatSettingsView \/>/);
-assert.match(settings, /<VaultPanel[\s\S]{0,100}familiarId=\{familiar\.id\}/);
-assert.match(settings, /familiar\.id/);
-assert.match(settings, /localDaemonReady/);
-assert.match(settings, /allFamiliars/);
-
 console.log("familiar-tab-settings.test.ts: ok");

--- a/src/components/familiar-tab-settings.tsx
+++ b/src/components/familiar-tab-settings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { AccessGroupsSection } from "@/components/access-groups-section";
 import dynamic from "next/dynamic";
 import { FamiliarStudioBrainTab } from "@/components/familiar-studio-brain-tab";
@@ -10,10 +10,11 @@ import { FamiliarStudioProjectsTab } from "@/components/familiar-studio-projects
 import { SkeletonRows } from "@/components/ui/skeleton";
 import { VaultPanel } from "@/components/vault-panel";
 import { Tabs } from "@/components/ui/tabs";
+import type { FamiliarSettingsTab } from "@/lib/chat-tab-events";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { Familiar } from "@/lib/types";
 
-type FamiliarSettingsTab = "chat" | "identity" | "brain" | "memory" | "projects" | "vault";
+export type { FamiliarSettingsTab } from "@/lib/chat-tab-events";
 
 const SETTINGS_TABS: Array<{ id: FamiliarSettingsTab; label: string }> = [
   { id: "chat", label: "Chat" },
@@ -42,22 +43,28 @@ const ChatSettingsView = dynamic(
 /**
  * The selected familiar's editable Studio controls, embedded in Chat's
  * Familiar tab. The Chat roster owns selection; these bodies remain the
- * canonical settings writers used by Settings → Familiars.
+ * canonical settings writers shared with the retired Settings → Familiars
+ * surface.
  */
 export function FamiliarSettingsSection({
   familiar,
   familiars,
   allFamiliars,
   localDaemonReady,
+  initialTab,
   onRosterChanged,
 }: {
   familiar: ResolvedFamiliar;
   familiars: Familiar[];
   allFamiliars: ResolvedFamiliar[];
   localDaemonReady: boolean;
+  initialTab?: FamiliarSettingsTab;
   onRosterChanged?: () => void;
 }) {
-  const [tab, setTab] = useState<FamiliarSettingsTab>("identity");
+  const [tab, setTab] = useState<FamiliarSettingsTab>(initialTab ?? "identity");
+  useEffect(() => {
+    if (initialTab) setTab(initialTab);
+  }, [initialTab]);
   const raw = useMemo(
     () => familiars.find((item) => item.id === familiar.id),
     [familiars, familiar.id],

--- a/src/components/familiars-memory-canonical.test.ts
+++ b/src/components/familiars-memory-canonical.test.ts
@@ -26,12 +26,12 @@ const workspace = readFileSync(
   new URL("./workspace.tsx", import.meta.url),
   "utf8",
 );
-const settings = readFileSync(
+const settingsShell = readFileSync(
   new URL("./settings-shell.tsx", import.meta.url),
   "utf8",
 );
-const settingsReadiness = readFileSync(
-  new URL("../lib/use-local-daemon-readiness.ts", import.meta.url),
+const familiarSettings = readFileSync(
+  new URL("./familiar-tab-settings.tsx", import.meta.url),
   "utf8",
 );
 const studio = readFileSync(
@@ -175,39 +175,20 @@ test("local daemon readiness reaches every mounted canonical reader", () => {
     (sections.match(/localDaemonReady=\{localDaemonReady\}/g) ?? []).length >= 2,
     "overlay and detail tab pass readiness to FamiliarsMemoryView",
   );
-  assert.match(
-    settings,
-    /\{\s*acceptedLocalDaemonHealthy,\s*refreshLocalDaemonReadiness,\s*\} = useLocalDaemonReadiness\(\)/,
-    "Settings consumes one live readiness checker for initial, poll, and post-Start reads",
+  assert.doesNotMatch(
+    settingsShell,
+    /useLocalDaemonReadiness/,
+    "the retired Settings Familiars host no longer owns canonical readiness",
   );
   assert.match(
-    settingsReadiness,
-    /payload\.running === true && payload\.target\.mode === "local"/,
-    "Settings accepts only a healthy local daemon target",
+    familiarSettings,
+    /localDaemonReady: boolean/,
+    "Chat Familiar Settings receives the workspace-owned local readiness state",
   );
   assert.match(
-    settingsReadiness,
-    /createDaemonStatusRequestGate\(\)[\s\S]*!mounted \|\| !requestGate\.isLatest\(requestId\)/,
-    "Settings readiness rejects out-of-order and post-unmount publications",
-  );
-  assert.match(
-    settingsReadiness,
-    /usePausablePoll\(\s*\(\) => void refreshLocalDaemonReadiness\(\),\s*5_000,\s*\{ pauseWhileInputActive: true \}/,
-    "Settings keeps accepted-local readiness live through the visible/focus poll",
-  );
-  assert.match(
-    settings,
-    /Promise\.all\(\[load\(\), refreshLocalDaemonReadiness\(\)\]\)/,
-    "post-Start readiness uses the same latest-safe checker",
-  );
-  assert.match(
-    settings,
-    /const localDaemonReady = acceptedLocalDaemonHealthy &&\s*canonicalMemoryLocalAccessEligible\(\{[\s\S]{0,240}platform: tauriPlatform,[\s\S]{0,240}hostname:/,
-    "Settings reuses the same local platform/host eligibility gate as Workspace",
-  );
-  assert.match(
-    settings,
-    /<FamiliarStudioInlinePanel[\s\S]*localDaemonReady=\{localDaemonReady\}/,
+    familiarSettings,
+    /<FamiliarStudioMemoryTab[\s\S]*localDaemonReady=\{localDaemonReady\}/,
+    "Chat Familiar Settings passes exact local readiness to its memory tab",
   );
   assert.match(
     studio,
@@ -227,7 +208,7 @@ test("local daemon readiness reaches every mounted canonical reader", () => {
     "all three production memory mounts carry local readiness",
   );
   assert.doesNotMatch(
-    settings,
+    familiarSettings,
     /json\?\.ok[\s\S]{0,200}setAcceptedLocalDaemonHealthy\(true\)/,
     "a successful familiar roster response never implies canonical readiness",
   );

--- a/src/components/settings-familiars-control-sheet.test.ts
+++ b/src/components/settings-familiars-control-sheet.test.ts
@@ -11,13 +11,9 @@ const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "ut
 const stylesUrl = new URL("../styles/settings-familiars.css", import.meta.url);
 const styles = existsSync(stylesUrl) ? readFileSync(stylesUrl, "utf8") : "";
 
-// Familiars owns the content viewport. The app settings rail remains the first
-// pane; this surface supplies the always-visible roster and detail panes.
-assert.match(
-  shell,
-  /section === "familiars" \? "settings-shell__content--familiars" : ""/,
-  "Settings removes generic page padding/scroll only for the Familiars control sheet",
-);
+// The legacy Settings host is retired; the shared inline primitives remain
+// contract-tested for any remaining non-settings reuse.
+assert.doesNotMatch(shell, /section === "familiars"|FamiliarsSection/, "Settings no longer hosts the retired Familiars control sheet");
 assert.match(
   globals,
   /@import "\.\.\/styles\/settings-familiars\.css";/,

--- a/src/components/settings-familiars-section.test.ts
+++ b/src/components/settings-familiars-section.test.ts
@@ -2,40 +2,13 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// Settings → Familiars section (cave-i7y): the daemon-offline 503 must never
-// masquerade as "no familiars", and familiars are creatable from Settings.
+// Familiar management migrated to Chat → Familiar → Settings. Keep the
+// retired Settings route out of both the shell and the section catalog.
 const shell = await readFile(new URL("./settings-shell.tsx", import.meta.url), "utf8");
-const section = shell.slice(shell.indexOf("function FamiliarsSection"));
+const sections = await readFile(new URL("./settings-sections.ts", import.meta.url), "utf8");
 
-assert.match(
-  section,
-  /res\.status === 503[\s\S]{0,80}setDaemonDown\(true\)/,
-  "a 503 roster response must flip the daemon-down state, not render an empty roster",
-);
-assert.match(
-  section,
-  /if \(daemonDown\)[\s\S]{0,1500}Start daemon/,
-  "the daemon-down state must offer a Start-daemon action",
-);
-assert.match(
-  section,
-  /familiars\.length === 0[\s\S]{0,1500}Summon familiar/,
-  "the genuinely-empty state must offer a Summon-familiar action",
-);
-assert.match(
-  section,
-  /FamiliarSummoningCircle/,
-  "Settings should reuse the shared FamiliarSummoningCircle",
-);
-assert.match(
-  section,
-  /onCreated=\{[\s\S]{0,300}openFamiliarStudio\(id\)/,
-  "a created familiar must be selected in the studio, not left on the first roster entry",
-);
-assert.match(
-  section,
-  /onCreated=\{[\s\S]{0,300}void load\(\)/,
-  "creation must refresh the roster via the extracted load()",
-);
+assert.doesNotMatch(shell, /FamiliarsSection|section === "familiars"/, "Settings no longer renders the retired Familiars section");
+assert.doesNotMatch(sections, /id: "familiars"|section: "familiars"/, "Settings no longer catalogs the retired Familiars section");
+assert.doesNotMatch(shell, /FamiliarStudioProvider/, "Settings no longer mounts the retired Familiar Studio provider");
 
 console.log("settings-familiars-section.test.ts: ok");

--- a/src/components/settings-overview.test.ts
+++ b/src/components/settings-overview.test.ts
@@ -12,7 +12,7 @@ import {
 // ── settings-sections catalog (pure) ─────────────────────────────────────────
 
 test("every section has full overview metadata + a highlight strip", () => {
-  const ids = ["profile", "general", "daemon", "familiars", "mobile", "appearance", "about"];
+  const ids = ["profile", "general", "daemon", "mobile", "appearance", "about"];
   assert.deepEqual(SECTIONS.map((s) => s.id), ids, "the section set matches the shell nav");
   for (const s of SECTIONS) {
     assert.ok(s.label && s.icon.startsWith("ph:") && s.description.length > 0, `${s.id} has label/icon/description`);

--- a/src/components/settings-search.test.ts
+++ b/src/components/settings-search.test.ts
@@ -45,32 +45,11 @@ assert.match(
   "global foundations style the search highlight",
 );
 
-// ── Search reaches inside the Familiars studio panel (2026-07-06) ────────────
-// Each studio tab is indexed with a familiarTab target, so "voice" or
-// "archive" lands on the right tab instead of just the section.
-assert.match(
-  sections,
-  /familiarTab\?: FamiliarStudioTab/,
-  "index entries can target a Familiars studio tab",
-);
-for (const tab of ["identity", "brain", "memory", "projects", "vault"]) {
-  assert.match(
-    sections,
-    new RegExp(`familiarTab: "${tab}"`),
-    `the ${tab} studio tab is indexed for search`,
-  );
-}
-// Look/Lifecycle/Journal merged or moved out — no rows target retired tabs.
-for (const gone of ["look", "lifecycle", "journal"]) {
-  assert.doesNotMatch(
-    sections,
-    new RegExp(`familiarTab: "${gone}"`),
-    `no search row targets the retired ${gone} tab`,
-  );
-}
-// Picking a familiars entry activates the studio tab below the provider
-// instead of scrolling to a SettingsGroup (the panel has none).
-assert.match(shell, /if \(entry\.familiarTab\) \{[\s\S]*?setFamiliarsTabTarget\(entry\.familiarTab\)/, "goToSetting branches familiars entries to the tab target");
+// Familiar controls moved to Chat → Familiar → Settings. Settings search must
+// not keep exposing the retired section or its nested studio tabs.
+assert.doesNotMatch(sections, /section: "familiars"/, "Settings search omits the retired Familiars section");
+assert.doesNotMatch(sections, /familiarTab/, "Settings search has no retired studio-tab targets");
+assert.doesNotMatch(shell, /FamiliarsSection|familiarsTabTarget|familiarTab/, "Settings shell has no retired Familiars routing");
 
 assert.match(
   shell,
@@ -78,9 +57,6 @@ assert.match(
   "Settings reads exact group/tab targets passed by the global palette",
 );
 assert.match(shell, /params\.get\("group"\)/, "Settings accepts a group deep-link target");
-assert.match(shell, /params\.get\("familiarTab"\)/, "Settings accepts a familiar studio-tab deep-link target");
-assert.match(shell, /setActiveTab\(tabTarget\)/, "FamiliarsSection activates the targeted studio tab");
-assert.match(shell, /familiar-studio-inline-tab-\$\{tabTarget\}/, "the targeted tab button receives focus");
-assert.match(shell, /onTabTargetConsumed\?\.\(\)/, "the one-shot tab target is handed back to the shell");
+assert.doesNotMatch(shell, /params\.get\("familiarTab"\)/, "Settings no longer accepts a retired familiar studio-tab target");
 
 console.log("settings-search.test.ts OK");

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -3,33 +3,26 @@
 // "what's in here" highlight strip). Kept in its own module so the shell nav and
 // the SettingsOverview header share one source of truth.
 //
-import type { FamiliarStudioTab } from "@/lib/familiar-studio-context";
-
 export type Section =
   | "profile"
   | "general"
   | "daemon"
-  | "familiars"
   | "mobile"
   | "appearance"
   | "about";
 
 export type SectionMeta = { id: Section; label: string; icon: string; description: string; accent: string };
 
-// `familiarTab` marks an entry that lives inside the Familiars studio panel —
-// picking it activates that studio tab instead of scrolling to a SettingsGroup.
 export type SettingsIndexEntry = {
   section: Section;
   group?: string;
   keywords: string;
-  familiarTab?: FamiliarStudioTab;
 };
 
 export const SECTIONS: SectionMeta[] = [
   { id: "profile", label: "Profile", icon: "ph:user-circle", description: "Your name, image, and details familiars know you by.", accent: "#f0c987" },
   { id: "general", label: "General", icon: "ph:sliders-horizontal", description: "Workspace, startup, and app-wide defaults.", accent: "#9386d0" },
   { id: "daemon", label: "Daemon", icon: "ph:terminal-window", description: "Local runtime status and process controls.", accent: "#69d6a6" },
-  { id: "familiars", label: "Familiars", icon: "ph:users-three", description: "Roster, identity, permissions, and pin order.", accent: "#d8a9ff" },
   { id: "mobile", label: "Phone", icon: "ph:device-mobile", description: "Native iOS handoff over your Tailscale network.", accent: "#73d9d0" },
   { id: "appearance", label: "Appearance", icon: "ph:paint-brush", description: "Theme, typography, and reading controls.", accent: "#ff9fb5" },
   { id: "about", label: "About", icon: "ph:info", description: "Version, updates, and project links.", accent: "#b8d8ff" },
@@ -39,7 +32,6 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
   profile: ["Identity & pronouns", "Context & personality", "Portrait & links"],
   general: ["Workspace path", "Encrypted backup", "Launch behavior"],
   daemon: ["Runtime health", "Local/hub routing", "Socket & version"],
-  familiars: ["Roster & identity", "Per-familiar permissions", "Pinned strip order"],
   mobile: ["Mobile mode", "Tailscale handoff", "Native iOS guide"],
   appearance: ["Theme & colors", "Typography", "Reading comfort"],
   about: ["App version", "Tool updates", "Project links"],
@@ -60,13 +52,6 @@ export const SETTINGS_INDEX: SettingsIndexEntry[] = [
   { section: "daemon", group: "Status", keywords: "daemon status running start stop restart hub server executor private network tailscale" },
   { section: "daemon", group: "Connection", keywords: "daemon hub server executor private network tailscale remote multihost multi host" },
   { section: "daemon", group: "Info", keywords: "daemon info version socket pid api" },
-  { section: "familiars", keywords: "familiars agents personas roster" },
-  { section: "familiars", group: "Identity", familiarTab: "identity", keywords: "identity name role pronouns description rename look avatar image photo upload icon glyph color accent swatch palette backdrop lifecycle archive unarchive remove delete restore recently removed" },
-  { section: "familiars", group: "Brain", familiarTab: "brain", keywords: "brain runtime harness model voice system prompt note capabilities" },
-  { section: "familiars", group: "Memory", familiarTab: "memory", keywords: "memory memories daily notes recall" },
-  { section: "familiars", group: "Projects", familiarTab: "projects", keywords: "projects access grants allow deny tool policy guard security audit requests permissions read write level" },
-  { section: "familiars", group: "Access groups", keywords: "access groups group grants base projects read write level team role shared membership permissions" },
-  { section: "familiars", group: "Vault", familiarTab: "vault", keywords: "vault secrets env environment keys tokens credentials 1password" },
   { section: "mobile", group: "Pair", keywords: "phone mobile connect qr pair tailscale" },
   { section: "mobile", group: "Why there’s no password", keywords: "password security auth login" },
   { section: "mobile", group: "Get the app", keywords: "app download ios testflight install" },

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -15,14 +15,9 @@ import { SettingControlRow, Segmented } from "@/components/ui/settings-controls"
 import { SearchInput } from "@/components/ui/search-input";
 import { prefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 import { SkeletonRows } from "@/components/ui/skeleton";
-import { FamiliarStudioInlinePanel } from "@/components/familiar-studio-inline";
-import { useResolvedFamiliars } from "@/lib/familiar-resolve";
-import type { Familiar } from "@/lib/types";
 import { THEME_IDS, THEME_META, getSwatches, type ThemeId } from "@/lib/theme-palettes";
 import type { Mode, ModePref } from "@/lib/theme-storage";
 import { ModeToggle } from "@/components/mode-toggle";
-import { FamiliarStudioProvider, useFamiliarStudio, type FamiliarStudioTab } from "@/lib/familiar-studio-context";
-import { FamiliarSummoningCircle } from "@/components/familiar-summoning-circle";
 import { useIsMobile } from "@/lib/use-viewport";
 import { useIsTauriDesktop } from "@/lib/tauri-platform";
 import { useCelebrationsEnabled, writeCelebrationsEnabled } from "@/lib/celebrations-pref";
@@ -63,9 +58,6 @@ import {
 import { readableTextColor } from "@/lib/readable-text-color";
 import { openExternalUrl } from "@/lib/open-external";
 import { getBackupPassphraseGuidance } from "@/lib/backup-passphrase-strength";
-import { canonicalMemoryLocalAccessEligible } from "@/lib/canonical-memory-local-access";
-import { useTauriPlatform } from "@/lib/tauri-platform";
-import { useLocalDaemonReadiness } from "@/lib/use-local-daemon-readiness";
 import { BackdropSettings } from "@/components/backdrop-settings";
 import { VoiceEngineSettings } from "@/components/voice-engine-settings";
 import {
@@ -96,8 +88,7 @@ export function SettingsShell() {
   const [suggestedHubUrl, setSuggestedHubUrl] = useState<string | null>(null);
   // Mobile drill-down: when true, render the section list full-screen
   // (no section content) — iOS-Settings-style. Tap a section → false,
-  // render that section. Hash-deep-link (`/settings#familiars`) skips the
-  // picker so the user lands directly on the target.
+  // render that section.
   const [pickerView, setPickerView] = useState(false);
   const activeSection = SECTIONS.find((s) => s.id === section);
   const showPicker = isMobile && pickerView;
@@ -105,9 +96,6 @@ export function SettingsShell() {
   // ── Search across settings ────────────────────────────────────────────────
   const [query, setQuery] = useState("");
   const [scrollTarget, setScrollTarget] = useState<string | null>(null);
-  // One-shot studio-tab target for search results that point inside the
-  // Familiars panel (see SettingsIndexEntry.familiarTab).
-  const [familiarsTabTarget, setFamiliarsTabTarget] = useState<FamiliarStudioTab | null>(null);
   const results = useMemo(() => {
     const q = query.trim().toLowerCase();
     if (!q) return [];
@@ -118,14 +106,6 @@ export function SettingsShell() {
   function goToSetting(entry: SettingsIndexEntry) {
     openSection(entry.section);
     setQuery("");
-    if (entry.familiarTab) {
-      // The Familiars panel isn't a SettingsGroup — the entry targets one of
-      // its studio tabs instead, activated below the provider by
-      // FamiliarsSection once the roster has loaded.
-      setFamiliarsTabTarget(entry.familiarTab);
-      setScrollTarget(null);
-      return;
-    }
     setScrollTarget(entry.group ? settingsGroupId(entry.group) : null);
   }
 
@@ -166,24 +146,17 @@ export function SettingsShell() {
     }
   }
 
-  // Support hash-based deep-linking, e.g. /settings#familiars. Read it after
-  // hydration so SSR and the first client render both start on General.
+  // Support hash-based deep-linking. Read it after hydration so SSR and the
+  // first client render both start on General.
   useEffect(() => {
     const applyHashSection = () => {
       const hash = window.location.hash.replace("#", "") as Section;
       if (SECTIONS.some((s) => s.id === hash)) {
         const params = new URLSearchParams(window.location.search);
         const group = params.get("group")?.trim();
-        const familiarTab = params.get("familiarTab")?.trim() as FamiliarStudioTab | undefined;
         setSection(hash);
         setPickerView(false);
-        if (familiarTab && SETTINGS_INDEX.some((entry) => entry.familiarTab === familiarTab)) {
-          setFamiliarsTabTarget(familiarTab);
-          setScrollTarget(null);
-        } else {
-          setFamiliarsTabTarget(null);
-          setScrollTarget(group ? settingsGroupId(group) : null);
-        }
+        setScrollTarget(group ? settingsGroupId(group) : null);
         return;
       }
       setPickerView(true);
@@ -217,7 +190,6 @@ export function SettingsShell() {
   }, [router, section]);
 
   return (
-    <FamiliarStudioProvider>
     <div className="settings-shell flex h-[100dvh] w-full flex-col overflow-hidden bg-[var(--bg-base)] text-[var(--text-primary)]">
       {/* Header. On mobile the back button has two roles: from a section
           page it drops back to the picker; from the picker it pops the
@@ -328,13 +300,7 @@ export function SettingsShell() {
         {/* Content */}
         <main
           hidden={showPicker}
-          className={`settings-shell__content min-h-0 flex-1 ${
-            section === "familiars" ? "settings-shell__content--familiars" : ""
-          } ${
-            section === "familiars"
-              ? "overflow-hidden"
-              : "overflow-y-auto px-4 py-6 md:px-8 [padding-bottom:calc(1.5rem_+_var(--sai-bottom))]!"
-          }`}
+          className="settings-shell__content min-h-0 flex-1 overflow-y-auto px-4 py-6 md:px-8 [padding-bottom:calc(1.5rem_+_var(--sai-bottom))]!"
         >
           {section === "profile" && <ProfileSection />}
           {section === "general" && <GeneralSection />}
@@ -343,12 +309,6 @@ export function SettingsShell() {
               suggestedHubUrl={suggestedHubUrl}
               onSuggestionConsumed={() => setSuggestedHubUrl(null)}
               omnigentSettings={<OmnigentSettingsGroup />}
-            />
-          )}
-          {section === "familiars" && (
-            <FamiliarsSection
-              tabTarget={familiarsTabTarget}
-              onTabTargetConsumed={() => setFamiliarsTabTarget(null)}
             />
           )}
           {section === "mobile"   && <PhoneSection onUseAsHub={(url) => { setSuggestedHubUrl(url); openSection("daemon"); }} />}
@@ -360,7 +320,6 @@ export function SettingsShell() {
         {isMobile ? (pickerView ? "Tap a section to open" : "Back returns to Settings") : "Esc back · ↑↓ navigate sections"}
       </footer>
     </div>
-    </FamiliarStudioProvider>
   );
 }
 
@@ -1276,192 +1235,6 @@ function OmnigentSettingsGroup() {
         </>
       ) : null}
     </SettingsGroup>
-  );
-}
-
-// ─── Section: Familiars ───────────────────────────────────────────────────────
-
-function FamiliarsSection({
-  tabTarget,
-  onTabTargetConsumed,
-}: {
-  /** Studio tab a search result asked to open; consumed once activated. */
-  tabTarget?: FamiliarStudioTab | null;
-  onTabTargetConsumed?: () => void;
-}) {
-  // Settings is a standalone route with no workspace context, so this panel
-  // sources its own familiar roster and resolves cave overrides locally.
-  const [rawFamiliars, setRawFamiliars] = useState<Familiar[]>([]);
-  const [loaded, setLoaded] = useState(false);
-  // The roster endpoint 503s when the daemon is down — that means "unknown",
-  // not "no familiars"; the two must never share an empty state.
-  const [daemonDown, setDaemonDown] = useState(false);
-  const [createOpen, setCreateOpen] = useState(false);
-  const [starting, setStarting] = useState(false);
-  const [startError, setStartError] = useState<string | null>(null);
-  const {
-    acceptedLocalDaemonHealthy,
-    refreshLocalDaemonReadiness,
-  } = useLocalDaemonReadiness();
-  const tauriPlatform = useTauriPlatform();
-  const localDaemonReady = acceptedLocalDaemonHealthy &&
-    canonicalMemoryLocalAccessEligible({
-      platform: tauriPlatform,
-      hostname: typeof window === "undefined" ? null : window.location.hostname,
-    });
-  const familiars = useResolvedFamiliars(rawFamiliars, { includeArchived: true });
-  // This renders below FamiliarStudioProvider (the shell mounts it), so the
-  // studio tab state is reachable here even though the shell body can't.
-  const { setActiveTab, openFamiliarStudio } = useFamiliarStudio();
-
-  // A search result can target a specific studio tab (e.g. "voice" → Brain).
-  // Activate it once the roster has settled so the tab strip exists, move
-  // focus to the tab button (the panel has no SettingsGroup to flash), and
-  // hand the one-shot target back to the shell.
-  useEffect(() => {
-    if (!tabTarget || !loaded) return;
-    setActiveTab(tabTarget);
-    const raf = requestAnimationFrame(() => {
-      const el = document.getElementById(`familiar-studio-inline-tab-${tabTarget}`);
-      if (el) {
-        el.scrollIntoView({ block: "nearest", behavior: prefersReducedMotion() ? "auto" : "smooth" });
-        el.focus({ preventScroll: true });
-      }
-      onTabTargetConsumed?.();
-    });
-    return () => cancelAnimationFrame(raf);
-  }, [tabTarget, loaded, setActiveTab, onTabTargetConsumed]);
-
-  const load = useCallback(async (signal?: AbortSignal) => {
-    try {
-      const res = await fetch("/api/familiars", { cache: "no-store", signal });
-      const json = await res.json().catch(() => null);
-      if (signal?.aborted) return;
-      if (json?.ok) {
-        setRawFamiliars((json.familiars ?? []) as Familiar[]);
-        setDaemonDown(false);
-      } else if (res.status === 503) {
-        setDaemonDown(true);
-      }
-    } catch {
-      /* transient (or aborted) — keep last good list */
-    } finally {
-      if (!signal?.aborted) setLoaded(true);
-    }
-  }, []);
-
-  useEffect(() => {
-    const ctrl = new AbortController();
-    void load(ctrl.signal);
-    return () => ctrl.abort();
-  }, [load]);
-
-  const startDaemon = useCallback(async () => {
-    setStarting(true);
-    setStartError(null);
-    try {
-      const res = await fetch("/api/daemon/start", { method: "POST" });
-      const json = await res.json().catch(() => ({}));
-      if (!res.ok || json?.ok === false) {
-        throw new Error(json?.error || json?.stderr || "daemon did not start");
-      }
-      await Promise.all([load(), refreshLocalDaemonReadiness()]);
-    } catch (err) {
-      setStartError(err instanceof Error ? err.message : "daemon did not start");
-    } finally {
-      setStarting(false);
-    }
-  }, [load, refreshLocalDaemonReadiness]);
-
-  // Hold the panel until the first fetch settles so the "No familiars
-  // configured" empty state never flashes before the roster loads.
-  if (!loaded) {
-    return (
-      <div className="settings-familiars-panel" role="status" aria-busy="true" aria-label="Loading familiars">
-        <SkeletonRows count={4} />
-      </div>
-    );
-  }
-
-  const createDialog = (
-    <FamiliarSummoningCircle
-      open={createOpen}
-      onClose={() => setCreateOpen(false)}
-      existingIds={rawFamiliars.map((f) => f.id)}
-      defaultHarness={rawFamiliars.find((f) => f.defaultHarness)?.defaultHarness}
-      daemonRunning={!daemonDown}
-      onCreated={(id) => {
-        // Select the freshly created familiar (not the first in the roster);
-        // the shared studio context drives the inline panel's detail pane.
-        openFamiliarStudio(id);
-        void load();
-      }}
-    />
-  );
-
-  if (daemonDown) {
-    return (
-      <div className="settings-familiars-panel">
-        <div className="flex flex-col items-start gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-4">
-          <p className="text-[length:var(--text-base)] text-[var(--text-secondary)]">
-            <Icon name="ph:warning-circle" width={13} aria-hidden className="mr-1.5 inline-block align-[-2px]" />
-            The daemon is offline, so the familiar roster can&apos;t be read. Start it to manage
-            familiars.
-          </p>
-          <div className="flex flex-wrap items-center gap-2">
-            <Button
-              variant="primary"
-              size="sm"
-              onClick={() => void startDaemon()}
-              disabled={starting}
-              leadingIcon="ph:rocket-launch-bold"
-              title="coven daemon start"
-            >
-              {starting ? "Starting..." : "Start daemon"}
-            </Button>
-            {startError ? (
-              <span role="alert" className="text-[length:var(--text-xs)] text-[var(--color-danger)]">
-                {startError}
-              </span>
-            ) : null}
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  if (familiars.length === 0) {
-    return (
-      <div className="settings-familiars-panel">
-        <div className="flex flex-col items-start gap-3 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-4 py-4">
-          <p className="text-[length:var(--text-base)] text-[var(--text-secondary)]">
-            No familiars configured yet. The circle awaits your first summoning.
-          </p>
-          <Button
-            variant="primary"
-            size="sm"
-            onClick={() => setCreateOpen(true)}
-            leadingIcon="ph:magic-wand-fill"
-          >
-            Summon familiar
-          </Button>
-        </div>
-        {createDialog}
-      </div>
-    );
-  }
-
-  return (
-    <>
-      <FamiliarStudioInlinePanel
-        familiars={rawFamiliars}
-        resolved={familiars}
-        localDaemonReady={localDaemonReady}
-        onSummon={() => setCreateOpen(true)}
-        onRosterChanged={() => void load()}
-      />
-      {createDialog}
-    </>
   );
 }
 

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -27,8 +27,8 @@ import {
   restoreWorkspaceNavigation,
 } from "@/lib/workspace-navigation-history";
 import type { PaletteIntent } from "@/components/command-palette";
-// Journal retired as an in-shell surface (redirects to Settings → Familiars),
-// so JournalView is gone; Grimoire is a new in-shell surface from main.
+// Journal retired as an in-shell surface, so JournalView is gone; Grimoire is
+// a new in-shell surface from main.
 import type { CalendarDeadline } from "@/components/calendar-view";
 import { CaveBackdropLayer } from "@/components/cave-backdrop-layer";
 import { readMobileModeEnabled, writeMobileModeEnabled } from "@/lib/mobile-mode-pref";
@@ -2476,7 +2476,6 @@ export function Workspace() {
     if (intent.kind === "open-setting") {
       const params = new URLSearchParams();
       if (intent.group) params.set("group", intent.group);
-      if (intent.familiarTab) params.set("familiarTab", intent.familiarTab);
       const search = params.size > 0 ? `?${params.toString()}` : "";
       nextRouter.push(`/settings${search}#${intent.section}`);
       return;
@@ -3252,11 +3251,11 @@ export function Workspace() {
       inboxBadgeCount={inboxBadgeCount}
     />
   );
-  // The standalone "Manage familiars" drawer is gone — Settings → Familiars is
-  // the single source of truth. `redirectToSettings` routes every
+  // The standalone "Manage familiars" drawer is gone — Chat → Familiar →
+  // Settings is the single source of truth. `redirectToChat` routes every
   // openFamiliarStudio(...) trigger (cards, switcher, onboarding) there.
   return (
-    <FamiliarStudioProvider redirectToSettings>
+    <FamiliarStudioProvider redirectToChat>
       {/* Backdrop vibe: the user's image behind Home + Chat, painted under
           the shell; the derived accent applies document-wide from the same
           store (cave-backdrop.ts). In chat, a single-familiar scope with its

--- a/src/lib/chat-tab-events.ts
+++ b/src/lib/chat-tab-events.ts
@@ -15,6 +15,48 @@ export const CHAT_OPEN_COVEN_EVENT = "cave:chat-open-coven";
  * the ordinary Chat destination without unmounting the surface. */
 export const CHAT_OPEN_CONVERSATION_EVENT = "cave:chat-open-conversation";
 
+/** Nested tab in Chat → Familiar → Settings for a studio handoff. */
+export type FamiliarSettingsTab =
+  | "chat"
+  | "identity"
+  | "brain"
+  | "memory"
+  | "projects"
+  | "vault";
+
+export type FamiliarSettingsTarget = {
+  tab?: FamiliarSettingsTab;
+};
+
+const FAMILIAR_SETTINGS_TARGET_KEY = "cave:familiar-settings-target:v1";
+
+/** Persist a one-shot nested Settings target before Chat mounts. */
+export function markFamiliarSettingsPending(tab?: FamiliarSettingsTab): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(
+      FAMILIAR_SETTINGS_TARGET_KEY,
+      JSON.stringify(tab ? { tab } satisfies FamiliarSettingsTarget : {}),
+    );
+  } catch {
+    /* storage may be unavailable */
+  }
+}
+
+/** Consume the pending nested Settings target exactly once. */
+export function consumeFamiliarSettingsPending(): FamiliarSettingsTarget | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(FAMILIAR_SETTINGS_TARGET_KEY);
+    if (!raw) return null;
+    window.localStorage.removeItem(FAMILIAR_SETTINGS_TARGET_KEY);
+    const parsed = JSON.parse(raw) as FamiliarSettingsTarget;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return null;
+  }
+}
+
 // A retained latch backing CHAT_OPEN_COVEN_EVENT. When the legacy `groupchat`
 // mode is requested from a DIFFERENT surface, ChatSurface mounts fresh — and a
 // fire-and-forget event can race its listener subscription. The Workspace sets

--- a/src/lib/familiar-studio-context.test.ts
+++ b/src/lib/familiar-studio-context.test.ts
@@ -11,5 +11,9 @@ assert.match(source, /closeFamiliarStudio/, "Hook returns closeFamiliarStudio");
 assert.match(source, /activeFamiliarId/, "State exposes activeFamiliarId");
 assert.match(source, /activeTab/, "State exposes activeTab");
 assert.match(source, /createContext/, "Uses React context");
+assert.match(source, /markFamiliarSettingsPending\(chatSettingsTabFor\(tab\)\)/, "studio handoffs target Chat Familiar Settings");
+assert.match(source, /setFamiliarScope\(\[familiarId\]\)/, "studio handoffs preserve the selected familiar");
+assert.match(source, /window\.location\.assign\("\/\?mode=chat"\)/, "studio handoffs navigate to Chat");
+assert.doesNotMatch(source, /window\.location\.assign\("\/settings#familiars"\)/, "studio handoffs no longer target retired Settings Familiars");
 
 console.log("familiar-studio-context.test.ts: ok");

--- a/src/lib/familiar-studio-context.tsx
+++ b/src/lib/familiar-studio-context.tsx
@@ -9,6 +9,11 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import {
+  markFamiliarSettingsPending,
+  type FamiliarSettingsTab,
+} from "@/lib/chat-tab-events";
+import { setFamiliarScope } from "@/lib/familiar-memory";
 
 export type FamiliarStudioTab =
   | "identity" | "brain" | "memory" | "projects" | "contract" | "vault";
@@ -23,17 +28,15 @@ const DEFAULT_TAB: FamiliarStudioTab = "identity";
 /**
  * One-shot handoff for "Open Brain Studio": the right-side drawer (Workspace
  * provider) writes the familiar id here before a full navigation to
- * `/settings#familiars`, and the Settings inline panel (a separate, isolated
- * provider — so `activeFamiliarId` does not carry over) reads it once to select
- * the same familiar, then clears it.
+ * Chat → Familiar → Settings consumes the familiar/tab handoff after the
+ * workspace boots the selected scope.
  */
 export const BRAIN_STUDIO_FAMILIAR_KEY = "cave:brain-studio-familiar:v1";
 
 /**
- * Hard-navigate to Settings → Familiars with an optional studio tab and
- * familiar preselected. This is the single redirect path shared by the
- * workspace-level provider (`redirectToSettings`) and workspace surfaces that
- * retired their own page in favor of the studio.
+ * Hard-navigate to Chat → Familiar → Settings with an optional studio tab and
+ * familiar preselected. This is the single handoff path shared by workspace
+ * surfaces that retired their own Familiar editor in favor of Chat.
  */
 export function openFamiliarStudioSettingsTab(tab?: FamiliarStudioTab, familiarId?: string): void {
   if (typeof window === "undefined") return;
@@ -43,7 +46,27 @@ export function openFamiliarStudioSettingsTab(tab?: FamiliarStudioTab, familiarI
   } catch {
     /* storage may be unavailable */
   }
-  window.location.assign("/settings#familiars");
+  if (familiarId) setFamiliarScope([familiarId]);
+  markFamiliarSettingsPending(chatSettingsTabFor(tab));
+  window.location.assign("/?mode=chat");
+}
+
+function chatSettingsTabFor(tab?: FamiliarStudioTab): FamiliarSettingsTab | undefined {
+  switch (tab) {
+    case "brain":
+      return "brain";
+    case "memory":
+      return "memory";
+    case "projects":
+      return "projects";
+    case "vault":
+      return "vault";
+    case "identity":
+    case "contract":
+      return "identity";
+    default:
+      return undefined;
+  }
 }
 
 type Ctx = {
@@ -51,7 +74,7 @@ type Ctx = {
   activeFamiliarId: string | null;
   activeTab: FamiliarStudioTab;
   openFamiliarStudio: (id: string, tab?: FamiliarStudioTab) => void;
-  /** Opens the familiars manager (Settings → Familiars) without forcing a tab. */
+  /** Opens Chat → Familiar → Settings without forcing a nested tab. */
   openFamiliarStudioListView: () => void;
   closeFamiliarStudio: () => void;
   setActiveTab: (tab: FamiliarStudioTab) => void;
@@ -61,18 +84,15 @@ const StudioContext = createContext<Ctx | null>(null);
 
 export function FamiliarStudioProvider({
   children,
-  redirectToSettings = false,
+  redirectToChat = false,
 }: {
   children: ReactNode;
   /**
-   * When true (the workspace-level provider), opening a familiar no longer
-   * pops a drawer — there is no drawer. Instead it hands the familiar/tab off
-   * to Settings → Familiars (the single source of truth) and navigates there,
-   * reusing the same `BRAIN_STUDIO_FAMILIAR_KEY` / tab handoff the Settings
-   * inline panel already reads. The Settings provider leaves this false so the
-   * inline panel keeps its in-place tab/familiar navigation.
+   * When true, opening a familiar hands the familiar/tab off to Chat →
+   * Familiar → Settings. The Chat surface consumes the one-shot target after
+   * the workspace switches to the active familiar.
    */
-  redirectToSettings?: boolean;
+  redirectToChat?: boolean;
 }) {
   const [activeFamiliarId, setActiveFamiliarId] = useState<string | null>(null);
   const [activeTab, setActiveTabState] = useState<FamiliarStudioTab>(DEFAULT_TAB);
@@ -95,26 +115,24 @@ export function FamiliarStudioProvider({
 
   const openFamiliarStudio = useCallback(
     (id: string, tab?: FamiliarStudioTab) => {
-      if (redirectToSettings) {
+      if (redirectToChat) {
         openFamiliarStudioSettingsTab(tab, id);
         return;
       }
       setActiveFamiliarId(id);
       if (tab) setActiveTab(tab);
     },
-    [setActiveTab, redirectToSettings],
+    [setActiveTab, redirectToChat],
   );
 
-  // "Manage familiars" entry point: with the roster manager retired, this just
-  // opens Settings → Familiars (keeping the last-used tab); the inline panel
-  // auto-selects a familiar.
+  // "Manage familiars" entry point: open the Chat Familiar settings surface.
   const openFamiliarStudioListView = useCallback(() => {
-    if (redirectToSettings) {
+    if (redirectToChat) {
       openFamiliarStudioSettingsTab();
       return;
     }
     setActiveFamiliarId(null);
-  }, [redirectToSettings]);
+  }, [redirectToChat]);
 
   const closeFamiliarStudio = useCallback(() => {
     setActiveFamiliarId(null);

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -15,10 +15,29 @@ async function gotoChatFamiliarSettings(page: Page) {
     window.localStorage.setItem("cave:familiar-scope", JSON.stringify(["familiar-01"]));
     window.localStorage.setItem("cave:active-familiar", "familiar-01");
   });
-  await page.route("**/api/familiars", (route) =>
+  await page.route("**/api/familiars**", (route) =>
     route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
   );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [] } }),
+  );
   await page.goto("/?mode=chat");
+  await page.waitForSelector(".shell-frame", { timeout: 30_000 });
+  const surface = page.locator(".chat-surface");
+  try {
+    await surface.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    const chatDestination = page
+      .locator('aside[aria-label="Sidebar"]')
+      .getByRole("button", { name: /^Chat\b/ })
+      .first();
+    if (!(await chatDestination.isVisible().catch(() => false))) {
+      const openNav = page.getByRole("button", { name: "Open navigation (⌘B)" });
+      if (await openNav.isVisible().catch(() => false)) await openNav.click();
+    }
+    await chatDestination.click();
+    await surface.waitFor({ state: "visible", timeout: 30_000 });
+  }
   const chatSections = page.getByRole("tablist", { name: "Chat sections" });
   await expect(chatSections).toBeVisible({ timeout: 60_000 });
   await chatSections.getByRole("tab", { name: "Familiar", exact: true }).click();

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Locator, type Page } from "@playwright/test";
+import { expect, test, type Page } from "@playwright/test";
 
 const FAMILIARS = Array.from({ length: 60 }, (_, index) => ({
   id: `familiar-${String(index + 1).padStart(2, "0")}`,
@@ -9,19 +9,23 @@ const FAMILIARS = Array.from({ length: 60 }, (_, index) => ({
   status: "active",
 }));
 
-async function gotoFamiliarSettings(page: Page) {
+async function gotoChatFamiliarSettings(page: Page) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:familiar-scope", JSON.stringify(["familiar-01"]));
+    window.localStorage.setItem("cave:active-familiar", "familiar-01");
   });
   await page.route("**/api/familiars", (route) =>
     route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
   );
-  await page.goto("/settings#familiars");
+  await page.goto("/?mode=chat");
+  await page.getByRole("tab", { name: "Familiar", exact: true }).click();
+  const settingsTab = page.getByRole("tab", { name: "Settings", exact: true });
+  await expect(settingsTab).toBeVisible({ timeout: 30_000 });
+  await settingsTab.click();
   await expect(
-    page.getByRole("complementary", { name: "Familiar roster" }),
-  ).toBeVisible({
-    timeout: 30_000,
-  });
+    page.getByRole("region", { name: "Settings for Familiar 01" }),
+  ).toBeVisible({ timeout: 30_000 });
 }
 
 async function emulateVisualViewport(page: Page, width: number, height: number) {
@@ -45,100 +49,48 @@ async function emulateVisualViewport(page: Page, width: number, height: number) 
   );
 }
 
-async function expectContained(inner: Locator, outer: Locator) {
-  const [innerBox, outerBox] = await Promise.all([
-    inner.boundingBox(),
-    outer.boundingBox(),
-  ]);
-  expect(innerBox, "inner control has layout bounds").not.toBeNull();
-  expect(outerBox, "container has layout bounds").not.toBeNull();
-  expect(innerBox!.y, "control top stays inside the container").toBeGreaterThanOrEqual(
-    outerBox!.y - 1,
-  );
-  expect(
-    innerBox!.y + innerBox!.height,
-    "control bottom stays inside the container",
-  ).toBeLessThanOrEqual(outerBox!.y + outerBox!.height + 1);
-}
-
-test("a keyboard-shrunk visual viewport keeps roster controls and one full result", async ({ page }) => {
-  // Mobile keyboards can shrink visualViewport without changing the CSS layout
-  // viewport. The persistent roster must keep its controls fixed while only
-  // the familiar list scrolls.
+test("Chat Familiar Settings remains reachable in a keyboard-shrunk viewport", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 720 });
   await emulateVisualViewport(page, 390, 270);
-  await gotoFamiliarSettings(page);
+  await gotoChatFamiliarSettings(page);
 
-  const roster = page.getByRole("complementary", { name: "Familiar roster" });
-  const search = page.getByRole("searchbox", { name: "Find a familiar" });
-  const summon = page.getByRole("button", { name: "Summon familiar" });
-  const results = page.getByRole("list", { name: "Familiars" });
-  const options = results.locator(".settings-familiar-roster__option");
-  const first = options.first();
-  const last = options.last();
+  const settings = page.getByRole("region", { name: "Settings for Familiar 01" });
+  await expect(settings.getByRole("tablist", { name: "Familiar settings" })).toBeVisible();
+  await expect(settings.getByRole("tab", { name: "Identity", exact: true })).toBeVisible();
+  await expect(settings.getByRole("tab", { name: "Memory", exact: true })).toBeVisible();
+  await expect(settings.getByText("Tune Familiar 01 without leaving Chat.")).toBeVisible();
 
-  await expect(options).toHaveCount(60);
-  await expectContained(search, roster);
-  await expectContained(summon, roster);
-
-  // Wrapping from the first result to the last must scroll only the roster list
-  // and leave the search and summon controls in place.
-  await first.focus();
-  await first.press("ArrowUp");
-  await expect(last).toBeFocused();
-  await expect(last).toContainText("Familiar 60");
-  await expectContained(search, roster);
-  await expectContained(summon, roster);
-  const resultsBox = await results.boundingBox();
-  expect(resultsBox, "the result scroller has layout bounds").not.toBeNull();
-  expect(resultsBox!.height, "the roster preserves a full touch target").toBeGreaterThanOrEqual(44);
-  await expectContained(last, results);
-
-  const scrollState = await roster.evaluate((element) => ({
-    scrollTop: element.scrollTop,
-    scrollHeight: element.scrollHeight,
-    clientHeight: element.clientHeight,
-  }));
-  expect(scrollState.scrollTop, "the roster shell must stay fixed").toBe(0);
-  expect(
-    scrollState.scrollHeight - scrollState.clientHeight,
-    "the roster shell itself must not be the scrolling region",
-  ).toBeLessThanOrEqual(1);
+  await settings.getByRole("tab", { name: "Memory", exact: true }).click();
+  await expect(settings.getByRole("tab", { name: "Memory", exact: true })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
 });
 
-test("a 60-familiar roster stays compact, searchable, and keyboard-selectable", async ({ page }) => {
+test("the migrated Familiar Settings surface keeps its nested controls", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 720 });
-  await gotoFamiliarSettings(page);
+  await gotoChatFamiliarSettings(page);
 
-  const roster = page.getByRole("complementary", { name: "Familiar roster" });
-  const summary = roster.locator(".settings-familiar-roster__summary");
-  const results = page.getByRole("list", { name: "Familiars" });
-  const options = results.locator(".settings-familiar-roster__option");
-  await expect(summary).toHaveText("60 familiars");
-  await expect(options).toHaveCount(60);
-  const rosterBox = await roster.boundingBox();
-  expect(rosterBox, "the familiar roster has layout bounds").not.toBeNull();
-  expect(rosterBox!.width, "the persistent roster stays compact").toBeLessThanOrEqual(260);
-  const resultsScroll = await results.evaluate((element) => ({
-    clientHeight: element.clientHeight,
-    scrollHeight: element.scrollHeight,
-  }));
-  expect(resultsScroll.scrollHeight, "large rosters scroll inside the roster").toBeGreaterThan(
-    resultsScroll.clientHeight,
+  const settings = page.getByRole("region", { name: "Settings for Familiar 01" });
+  await expect(settings.getByRole("tab", { name: "Chat", exact: true })).toBeVisible();
+  await expect(settings.getByRole("tab", { name: "Brain", exact: true })).toBeVisible();
+  await expect(settings.getByRole("tab", { name: "Projects", exact: true })).toBeVisible();
+  await expect(settings.getByRole("tab", { name: "Vault", exact: true })).toBeVisible();
+
+  await settings.getByRole("tab", { name: "Projects", exact: true }).click();
+  await expect(settings.getByRole("tab", { name: "Projects", exact: true })).toHaveAttribute(
+    "aria-selected",
+    "true",
   );
+});
 
-  await options.first().focus();
-  await options.first().press("ArrowDown");
-  await expect(options.nth(1)).toBeFocused();
-
-  const search = page.getByRole("searchbox", { name: "Find a familiar" });
-  await search.fill("Researcher familiar-60");
-  const match = results.locator(".settings-familiar-roster__option");
-  await expect(match).toHaveCount(1);
-  await expect(match).toContainText("Familiar 60");
-  await expect(match).toContainText("Researcher");
-
-  await match.press("Enter");
-  await expect(match).toHaveAttribute("aria-current", "page");
-  await expect(page.getByRole("heading", { name: "Familiar 60" })).toBeVisible();
+test("the retired Settings route no longer exposes the familiar roster", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars", (route) =>
+    route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
+  );
+  await page.goto("/settings#familiars");
+  await expect(page.getByRole("complementary", { name: "Familiar roster" })).toHaveCount(0);
 });

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -19,9 +19,13 @@ async function gotoChatFamiliarSettings(page: Page) {
     route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
   );
   await page.goto("/?mode=chat");
-  await page.getByRole("tab", { name: "Familiar", exact: true }).click();
-  const settingsTab = page.getByRole("tab", { name: "Settings", exact: true });
-  await expect(settingsTab).toBeVisible({ timeout: 30_000 });
+  const chatSections = page.getByRole("tablist", { name: "Chat sections" });
+  await expect(chatSections).toBeVisible({ timeout: 60_000 });
+  await chatSections.getByRole("tab", { name: "Familiar", exact: true }).click();
+  const familiarSections = page.getByRole("tablist", { name: "Familiar sections" });
+  await expect(familiarSections).toBeVisible({ timeout: 60_000 });
+  const settingsTab = familiarSections.getByRole("tab", { name: "Settings", exact: true });
+  await expect(settingsTab).toBeVisible({ timeout: 60_000 });
   await settingsTab.click();
   await expect(
     page.getByRole("region", { name: "Settings for Familiar 01" }),

--- a/tests/settings-familiar-picker.spec.ts
+++ b/tests/settings-familiar-picker.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+test.describe.configure({ mode: "serial" });
+
 const FAMILIARS = Array.from({ length: 60 }, (_, index) => ({
   id: `familiar-${String(index + 1).padStart(2, "0")}`,
   display_name: `Familiar ${String(index + 1).padStart(2, "0")}`,
@@ -15,6 +17,10 @@ async function gotoChatFamiliarSettings(page: Page) {
     window.localStorage.setItem("cave:familiar-scope", JSON.stringify(["familiar-01"]));
     window.localStorage.setItem("cave:active-familiar", "familiar-01");
   });
+  // This migration path only needs the roster and session shape below. Abort
+  // unrelated daemon-backed API reads so Cave-home reconciliation cannot hold
+  // the Chat shell behind a live runtime lock in the full CI suite.
+  await page.route("**/api/**", (route) => route.abort());
   await page.route("**/api/familiars**", (route) =>
     route.fulfill({ json: { ok: true, familiars: FAMILIARS } }),
   );


### PR DESCRIPTION
## Summary

- Remove the obsolete Settings → Familiars navigation, search index entries, and deep-link host.
- Route existing Familiar Studio handoffs into Chat → Familiar → Settings, preserving familiar scope and nested targets.
- Keep the migrated Chat Familiar Settings surface and shared Studio primitives contract-tested.

## Validation

- `pnpm test:app` — 975/975 test files passed
- `pnpm typecheck`
- `pnpm lint` — 0 design drift
- `pnpm check:tests-wired`
- `git diff --check`