### PR TITLE
fix(guard): block worktree removal while a process is still working in it

### DIFF
--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -42,7 +42,7 @@
  * On any internal error the guard exits 0: a hook bug must never brick Bash.
  */
 
-import { appendFileSync, existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { appendFileSync, existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { execFileSync } from "node:child_process";
 import path from "node:path";
 
@@ -154,6 +154,80 @@ function worktreeRoot(abs) {
 }
 
 /** "" = safe to destroy; otherwise a human reason it is not. */
+/** PIDs from this process up to init — a hook that blocked on its OWN shell's
+ *  cwd would make every in-worktree cleanup impossible. */
+function ownAncestry() {
+  const mine = new Set();
+  let pid = process.pid;
+  for (let hops = 0; hops < 32 && pid > 1; hops += 1) {
+    mine.add(String(pid));
+    try {
+      const out = execFileSync("ps", ["-o", "ppid=", "-p", String(pid)], { encoding: "utf8", timeout: 2000 });
+      const parent = Number.parseInt(out.trim(), 10);
+      if (!Number.isFinite(parent) || parent <= 1) break;
+      pid = parent;
+    } catch {
+      break;
+    }
+  }
+  return mine;
+}
+
+/** Processes whose cwd sits inside `wtPath`.
+ *
+ *  `git status` only sees a session that has SAVED edits. A session driving the
+ *  worktree by absolute path — editing files in it while its own cwd is the
+ *  primary checkout, or running `pnpm test:app` in it — leaves a clean, pushed
+ *  worktree that this guard used to wave through. That is the husk case named
+ *  at the top of this file (a worktree gutted while a dev server or tsc still
+ *  ran inside it), and it is the one shape the earlier checks cannot see.
+ *
+ *  One `lsof` over cwd descriptors only: no directory walk, so node_modules
+ *  costs nothing. Fails open like every other probe here — a guard that bricks
+ *  Bash when lsof is missing or slow is worse than one that misses a case. */
+function liveProcesses(wtPath) {
+  let out = "";
+  try {
+    out = execFileSync("lsof", ["-d", "cwd", "-F", "pcn"], {
+      encoding: "utf8",
+      timeout: 5000,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch (err) {
+    // lsof exits non-zero when some processes are unreadable; keep partial output.
+    out = typeof err?.stdout === "string" ? err.stdout : "";
+  }
+  if (!out) return [];
+  const mine = ownAncestry();
+  // The kernel hands lsof the CANONICAL path, so `/var/...` on macOS comes back
+  // as `/private/var/...`. Comparing the caller's spelling against it silently
+  // matches nothing — the check would look installed and catch zero cases.
+  let root = wtPath;
+  try {
+    root = realpathSync(wtPath);
+  } catch {
+    /* unreadable — fall back to the literal path */
+  }
+  const prefix = root.endsWith(path.sep) ? root : `${root}${path.sep}`;
+  const hits = [];
+  let pid = "";
+  let cmd = "";
+  for (const line of out.split("\n")) {
+    if (line.startsWith("p")) {
+      pid = line.slice(1);
+      cmd = "";
+    } else if (line.startsWith("c")) {
+      cmd = line.slice(1);
+    } else if (line.startsWith("n")) {
+      const dir = line.slice(1);
+      if (dir !== root && !dir.startsWith(prefix)) continue;
+      if (mine.has(pid)) continue;
+      if (!hits.some((h) => h.pid === pid)) hits.push({ pid, cmd });
+    }
+  }
+  return hits;
+}
+
 function destructionRisk(wtPath) {
   if (!existsSync(wtPath)) return "";
   if (!existsSync(path.join(wtPath, ".git"))) return ""; // husk — GC freely
@@ -167,6 +241,12 @@ function destructionRisk(wtPath) {
     const head = git(["-C", wtPath, "rev-parse", "HEAD"], undefined).trim();
     const onRemote = git(["-C", wtPath, "branch", "-r", "--contains", head], undefined).trim();
     if (!onRemote) return `\`${wtPath}\` HEAD (${head.slice(0, 8)}) exists on NO remote ref — removing it orphans unpushed commits.`;
+    const live = liveProcesses(wtPath);
+    if (live.length) {
+      const who = live.slice(0, 3).map((h) => `pid ${h.pid} (${h.cmd || "?"})`).join(", ");
+      const more = live.length > 3 ? ` and ${live.length - 3} more` : "";
+      return `\`${wtPath}\` is clean and pushed, but ${live.length} process(es) are still working in it: ${who}${more}.`;
+    }
     return "";
   } catch {
     return ""; // can't assess (mid-teardown, permissions) — don't brick cleanup

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -82,6 +82,32 @@ function repoWithWorktree({ push = false, dirty = false } = {}) {
   assert.equal(res.stdout.trim(), "", "and silent");
 }
 
+// ── 3b. Clean + pushed, but a process is still working IN it → blocked ────────
+// The husk case named in the guard's own header: a session driving a worktree by
+// absolute path (or running its test suite there) leaves `git status` clean and
+// the branch pushed, so every earlier check waves the removal through while the
+// work is still live.
+if (!isWin) {
+  const { dir, wt } = repoWithWorktree({ push: true });
+  const child = execFileSync("node", ["-e", `
+    const { spawn } = require("node:child_process");
+    const p = spawn(process.execPath, ["-e", "setTimeout(()=>{},60000)"], { cwd: ${JSON.stringify(wt)}, detached: true, stdio: "ignore" });
+    p.unref(); console.log(p.pid);
+  `], { encoding: "utf8" }).trim();
+  try {
+    // Give the child a moment to land its cwd.
+    execFileSync("node", ["-e", "setTimeout(()=>{}, 400)"]);
+    const res = runHook(`git worktree remove ${wt}`, dir);
+    assert.equal(res.status, 2, "blocks removal while a process is working inside the worktree");
+    assert.match(res.stderr, /still working in it/, "names the live processes");
+    // The bypass still wins — the guard advises, it does not imprison.
+    const forced = runHook(`${BYPASS} git worktree remove ${wt}`, dir);
+    assert.equal(forced.status, 0, "explicit bypass overrides the live-process block");
+  } finally {
+    try { process.kill(Number(child)); } catch { /* already gone */ }
+  }
+}
+
 // ── 4. Husk dirs (no .git link) and paths INSIDE a worktree pass ───────────────
 {
   const { dir } = repoWithWorktree({ push: true });


### PR DESCRIPTION
`worktree-guard.mjs` opens by naming this incident class — *"a worktree gutted while a dev server / tsc still ran inside it"* — and then never checks for it. `destructionRisk` blocked on **uncommitted changes** or **unpushed commits**; a session driving a worktree *by absolute path* produces neither.

## Found for real, today

A session on ttys016 had its cwd in the **primary checkout** while editing `.worktrees/fix-remove-settings-familiars` by absolute path and running `pnpm test:app` inside it — a 15-file refactor in flight.

Every cwd-based ownership check reported that worktree **unowned**, including the sweep I had just run and reported as complete. `git status` was clean at the moment I looked, and the branch was pushed, so the guard would have allowed the removal.

## The fix

`destructionRisk` now also asks whether any process has its cwd inside the worktree, and names them:

```
`…/.worktrees/wt` is clean and pushed, but 2 process(es) are still
working in it: pid 51069 (node), pid 51070 (pnpm).
```

One `lsof -d cwd` over cwd descriptors — **no directory walk**, so `node_modules` costs nothing. It fails open like every other probe in this file, and `WT_GUARD_BYPASS=1` still wins: this advises, it does not imprison.

## Two details that decide whether it works at all

**Path canonicalisation.** The kernel hands `lsof` the real path, so a macOS worktree under `/var/…` comes back as `/private/var/…`. Without `realpathSync` the prefix match finds nothing — the check looks installed while catching **zero** cases. My first version had exactly this bug; the test caught it, which is the only reason this PR isn't a no-op.

**Self-exclusion.** The hook's own process ancestry is skipped, or a cleanup run from inside the worktree would block itself.

## Verification

Mutation-tested: with the check disabled, the new test fails with `blocks removal while a process is working inside the worktree`. It pins the behaviour rather than accompanying it.

| Gate | Result |
|---|---|
| `worktree-guard.test.mjs` | pass (11s) |
| `pnpm test:app` | 975 files pass |
| `lint` | pass |

The new test is POSIX-only (`isWin` guard), matching the existing convention in that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)