### PR TITLE
fix(board): disclose capped and half-loaded GitHub work in the task picker

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1231,6 +1231,7 @@ export const SUITES = {
     "src/app/api/github/activity/route.test.ts",
     "src/app/api/github/pat/route.test.ts",
     "src/app/api/github/assigned/route.test.ts",
+    "src/lib/github-assigned-meta.test.ts",
     "src/app/api/github/commit/route.test.ts",
     "src/app/api/github/dispatch/route.test.ts",
     "src/app/api/github/merge/route.test.ts",

--- a/src/app/api/github/assigned/route.ts
+++ b/src/app/api/github/assigned/route.ts
@@ -1,9 +1,21 @@
 import { NextResponse } from "next/server";
 import type { GitHubItem } from "@/lib/github-tasks";
 import { resolveGitHubToken } from "@/lib/github-token";
+import {
+  failedSource,
+  isPartial,
+  isTruncated,
+  restSource,
+  searchSource,
+  type AssignedSourceMeta,
+  type AssignedSourcesMeta,
+} from "@/lib/github-assigned-meta";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
+
+const ASSIGNED_PER_PAGE = 50;
+const SEARCH_PER_PAGE = 30;
 
 function extractRepo(url: string): string {
   try {
@@ -30,9 +42,32 @@ type RawGitHubItem = {
 };
 
 type SearchResult = {
+  total_count?: number;
   items: RawGitHubItem[];
 };
 
+/**
+ * One capped source, fetched fault-isolated (cave-amx2m): a non-auth failure
+ * removes ONE source from the list instead of failing the whole response, and
+ * the returned meta says so — the picker must never dress a half-loaded list
+ * as a definitive empty. A 401 anywhere still aborts the aggregate via
+ * `unauthorized` (the stored PAT is dead for every source alike).
+ */
+async function fetchSource<T>(
+  url: string,
+  headers: Record<string, string>,
+  parse: (body: T, linkHeader: string | null) => { items: GitHubItem[]; meta: AssignedSourceMeta },
+): Promise<{ items: GitHubItem[]; meta: AssignedSourceMeta; unauthorized?: boolean }> {
+  try {
+    const res = await fetch(url, { headers });
+    if (res.status === 401) return { items: [], meta: failedSource("HTTP 401"), unauthorized: true };
+    if (!res.ok) return { items: [], meta: failedSource(`GitHub API error: HTTP ${res.status}`) };
+    const body = (await res.json()) as T;
+    return parse(body, res.headers.get("link"));
+  } catch (err) {
+    return { items: [], meta: failedSource(err instanceof Error ? err.message : "fetch failed") };
+  }
+}
 
 export async function GET() {
   const token = resolveGitHubToken();
@@ -47,93 +82,107 @@ export async function GET() {
     "X-GitHub-Api-Version": "2022-11-28",
   };
 
-  try {
-    const [assignedRes, reviewRes, createdRes] = await Promise.all([
-      fetch("https://api.github.com/issues?filter=assigned&state=open&per_page=50", { headers }),
-      fetch("https://api.github.com/search/issues?q=is:open+is:pr+review-requested:@me&per_page=30", { headers }),
-      fetch("https://api.github.com/search/issues?q=is:open+is:pr+author:@me&per_page=30", { headers }),
-    ]);
+  const [assigned, review, created] = await Promise.all([
+    fetchSource<RawGitHubItem[]>(
+      `https://api.github.com/issues?filter=assigned&state=open&per_page=${ASSIGNED_PER_PAGE}`,
+      headers,
+      (body, linkHeader) => {
+        const rows = Array.isArray(body) ? body : [];
+        const items: GitHubItem[] = rows.map((item) => ({
+          id: String(item.id),
+          kind: item.pull_request ? ("pr" as const) : ("issue" as const),
+          repo: item.repository?.full_name ?? "",
+          number: item.number,
+          title: item.title,
+          url: item.html_url,
+          state: item.state,
+          updatedAt: item.updated_at,
+          labels: item.labels?.map((l) => l.name) ?? [],
+          draft: item.draft ?? false,
+        }));
+        return { items, meta: restSource(items.length, ASSIGNED_PER_PAGE, linkHeader) };
+      },
+    ),
+    fetchSource<SearchResult>(
+      `https://api.github.com/search/issues?q=is:open+is:pr+review-requested:@me&per_page=${SEARCH_PER_PAGE}`,
+      headers,
+      (body) => {
+        const items: GitHubItem[] = (body?.items ?? []).map((item) => ({
+          id: String(item.id),
+          kind: "review_request" as const,
+          repo: extractRepo(item.html_url),
+          number: item.number,
+          title: item.title,
+          url: item.html_url,
+          state: item.state,
+          updatedAt: item.updated_at,
+          labels: item.labels?.map((l) => l.name) ?? [],
+        }));
+        return { items, meta: searchSource(items.length, body?.total_count) };
+      },
+    ),
+    fetchSource<SearchResult>(
+      `https://api.github.com/search/issues?q=is:open+is:pr+author:@me&per_page=${SEARCH_PER_PAGE}`,
+      headers,
+      (body) => {
+        const items: GitHubItem[] = (body?.items ?? []).map((item) => ({
+          id: String(item.id),
+          kind: "pr" as const,
+          repo: extractRepo(item.html_url),
+          number: item.number,
+          title: item.title,
+          url: item.html_url,
+          state: item.state,
+          updatedAt: item.updated_at,
+          labels: item.labels?.map((l) => l.name) ?? [],
+        }));
+        return { items, meta: searchSource(items.length, body?.total_count) };
+      },
+    ),
+  ]);
 
-    if (!assignedRes.ok || !reviewRes.ok || !createdRes.ok) {
-      const failedStatus = !assignedRes.ok
-        ? assignedRes.status
-        : !reviewRes.ok
-          ? reviewRes.status
-          : createdRes.status;
-      if (failedStatus === 401) {
-        // The stored PAT was rejected (revoked/expired) — flag it so the
-        // client reopens the connect form instead of pinning a raw 401
-        // against a form gated on configured===false (cave-cjgg/cave-d6zq).
-        return NextResponse.json(
-          { ok: false, error: "GitHub rejected the stored token (revoked or expired).", items: [], configured: true, patInvalid: true },
-          { status: 200 },
-        );
-      }
-      return NextResponse.json(
-        { ok: false, error: `GitHub API error: HTTP ${failedStatus}`, items: [] },
-        { status: 502 },
-      );
-    }
-
-    const [assignedData, reviewData, createdData] = await Promise.all([
-      assignedRes.json() as Promise<RawGitHubItem[]>,
-      reviewRes.json() as Promise<SearchResult>,
-      createdRes.json() as Promise<SearchResult>,
-    ]);
-
-    const assignedItems: GitHubItem[] = (Array.isArray(assignedData) ? assignedData : []).map(
-      (item) => ({
-        id: String(item.id),
-        kind: item.pull_request ? ("pr" as const) : ("issue" as const),
-        repo: item.repository?.full_name ?? "",
-        number: item.number,
-        title: item.title,
-        url: item.html_url,
-        state: item.state,
-        updatedAt: item.updated_at,
-        labels: item.labels?.map((l) => l.name) ?? [],
-        draft: item.draft ?? false,
-      }),
+  if (assigned.unauthorized || review.unauthorized || created.unauthorized) {
+    // The stored PAT was rejected (revoked/expired) — flag it so the
+    // client reopens the connect form instead of pinning a raw 401
+    // against a form gated on configured===false (cave-cjgg/cave-d6zq).
+    return NextResponse.json(
+      { ok: false, error: "GitHub rejected the stored token (revoked or expired).", items: [], configured: true, patInvalid: true },
+      { status: 200 },
     );
-
-    const reviewItems: GitHubItem[] = (reviewData?.items ?? []).map((item) => ({
-      id: String(item.id),
-      kind: "review_request" as const,
-      repo: extractRepo(item.html_url),
-      number: item.number,
-      title: item.title,
-      url: item.html_url,
-      state: item.state,
-      updatedAt: item.updated_at,
-      labels: item.labels?.map((l) => l.name) ?? [],
-    }));
-
-    const createdItems: GitHubItem[] = (createdData?.items ?? []).map((item) => ({
-      id: String(item.id),
-      kind: "pr" as const,
-      repo: extractRepo(item.html_url),
-      number: item.number,
-      title: item.title,
-      url: item.html_url,
-      state: item.state,
-      updatedAt: item.updated_at,
-      labels: item.labels?.map((l) => l.name) ?? [],
-    }));
-
-    // De-duplicate by url (keep first occurrence), then sort by updatedAt desc
-    const seen = new Set<string>();
-    const all: GitHubItem[] = [];
-    for (const item of [...assignedItems, ...reviewItems, ...createdItems]) {
-      if (!seen.has(item.url)) {
-        seen.add(item.url);
-        all.push(item);
-      }
-    }
-    all.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
-
-    return NextResponse.json({ ok: true, items: all, configured: true });
-  } catch (err) {
-    const message = err instanceof Error ? err.message : "Unknown error";
-    return NextResponse.json({ ok: false, error: message, items: [] }, { status: 502 });
   }
+
+  const sources: AssignedSourcesMeta = {
+    assigned: assigned.meta,
+    reviewRequested: review.meta,
+    authored: created.meta,
+  };
+
+  // Every source down = the old total-failure path: the caller gets an error,
+  // never a plausible-looking empty list.
+  if (!assigned.meta.ok && !review.meta.ok && !created.meta.ok) {
+    return NextResponse.json(
+      { ok: false, error: assigned.meta.error ?? "GitHub API error", items: [], sources },
+      { status: 502 },
+    );
+  }
+
+  // De-duplicate by url (keep first occurrence), then sort by updatedAt desc
+  const seen = new Set<string>();
+  const all: GitHubItem[] = [];
+  for (const item of [...assigned.items, ...review.items, ...created.items]) {
+    if (!seen.has(item.url)) {
+      seen.add(item.url);
+      all.push(item);
+    }
+  }
+  all.sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+
+  return NextResponse.json({
+    ok: true,
+    items: all,
+    configured: true,
+    sources,
+    partial: isPartial(sources),
+    truncated: isTruncated(sources),
+  });
 }

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -8,6 +8,7 @@ import { STATUSES, PRIORITIES } from "@/lib/cave-board-types";
 import type { CaveProject } from "@/lib/cave-projects";
 import { LifecycleBadge, formatTimeoutBadge } from "@/components/ui/lifecycle-badge";
 import { SkeletonRows } from "@/components/ui/skeleton";
+import { assignedDisclosure, isPartial, type AssignedSourcesMeta } from "@/lib/github-assigned-meta";
 import { usePausablePoll } from "@/lib/use-pausable-poll";
 import { publishBoardChanged } from "@/lib/board-cache-events";
 import { useFleetTokenEnabled } from "@/lib/omnigent/use-fleet-gate";
@@ -215,6 +216,11 @@ function GitHubAttachSection({
   const [err, setErr] = useState<string | null>(null);
   const [configured, setConfigured] = useState<boolean | null>(null);
   const [patRejected, setPatRejected] = useState(false);
+  // Completeness disclosure (cave-amx2m): the endpoint's per-source metadata,
+  // rendered as one quiet line so a capped or half-loaded list never wears a
+  // definitive "nothing assigned to you".
+  const [disclosure, setDisclosure] = useState<string | null>(null);
+  const [partial, setPartial] = useState(false);
   const [fetchKey, setFetchKey] = useState(0);
   const coarse = useIsCoarsePointer();
 
@@ -225,21 +231,27 @@ function GitHubAttachSection({
     setErr(null);
     fetch("/api/github/assigned", { cache: "no-store" })
       .then((r) => r.json())
-      .then((d: { ok: boolean; items?: GitHubItem[]; configured?: boolean; error?: string; patInvalid?: boolean }) => {
+      .then((d: { ok: boolean; items?: GitHubItem[]; configured?: boolean; error?: string; patInvalid?: boolean; sources?: AssignedSourcesMeta }) => {
         // Drop a superseded/post-close response (open toggled or PAT re-saved).
         if (cancelled) return;
         if (d.ok) {
           setItems(d.items ?? []);
           setConfigured(d.configured ?? true);
           setPatRejected(false);
+          setDisclosure(d.sources ? assignedDisclosure(d.sources, (d.items ?? []).length) : null);
+          setPartial(d.sources ? isPartial(d.sources) : false);
         } else if (d.patInvalid) {
           // Rejected token: reopen the connect form (it was gated on
           // configured===false, unreachable with a stored-but-dead PAT).
           setItems([]);
           setConfigured(false);
           setPatRejected(true);
+          setDisclosure(null);
+          setPartial(false);
         } else {
           setErr(d.error ?? "failed");
+          setDisclosure(null);
+          setPartial(false);
         }
       })
       .catch(() => { if (!cancelled) setErr("fetch failed"); })
@@ -367,13 +379,28 @@ function GitHubAttachSection({
                 <InlinePATSetup onSaved={() => { setItems([]); setConfigured(null); setPatRejected(false); setFetchKey((k) => k + 1); }} />
               </>
             )}
+            {/* cave-amx2m: the definitive empty claim is earned only by a
+                complete response — a half-loaded list says so instead. */}
             {!loading && !err && configured !== false && filtered.length === 0 && items.length === 0 && (
               <div className="[padding:var(--space-3)_10px]! [font-size:var(--text-xs)]! [color:var(--text-muted)]! [text-align:center]!">
-                No open issues, PRs, or review requests assigned to you.
+                {partial
+                  ? "Couldn’t load all GitHub sources — there may be work this list can’t see."
+                  : "No open issues, PRs, or review requests assigned to you."}
+                {partial && (
+                  <button
+                    type="button"
+                    className="board-toolbar-btn [font-size:var(--text-2xs)]! [padding:2px_var(--space-2)]! [margin-left:6px]!"
+                    onClick={() => setFetchKey((k) => k + 1)}
+                  >
+                    Retry
+                  </button>
+                )}
               </div>
             )}
             {!loading && !err && configured !== false && items.length > 0 && filtered.length === 0 && (
-              <div className="[padding:var(--space-3)_10px]! [font-size:var(--text-xs)]! [color:var(--text-muted)]! [text-align:center]!">No matches.</div>
+              <div className="[padding:var(--space-3)_10px]! [font-size:var(--text-xs)]! [color:var(--text-muted)]! [text-align:center]!">
+                {disclosure ? `No matches in what loaded — ${disclosure}` : "No matches."}
+              </div>
             )}
             {filtered.map((item) => {
               const attached = attachedUrls.has(item.url);
@@ -427,6 +454,27 @@ function GitHubAttachSection({
                 </div>
               );
             })}
+            {/* Completeness footer (cave-amx2m): rides under a non-empty list
+                whenever a source was capped or down, so partial never reads as
+                complete. */}
+            {!loading && !err && filtered.length > 0 && disclosure && (
+              <div
+                role="note"
+                className="[padding:6px_10px]! [font-size:var(--text-2xs)]! [color:var(--text-muted)]! [border-top:1px_solid_var(--border-hairline)]! [display:flex]! [align-items:center]! [gap:6px]!"
+              >
+                <Icon name={partial ? "ph:warning-circle" : "ph:info"} width={11} className="shrink-0" />
+                <span className="[flex:1]! [min-width:0]!">{disclosure}</span>
+                {partial && (
+                  <button
+                    type="button"
+                    className="board-toolbar-btn [font-size:var(--text-2xs)]! [padding:1px_6px]!"
+                    onClick={() => setFetchKey((k) => k + 1)}
+                  >
+                    Retry
+                  </button>
+                )}
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/src/lib/github-assigned-meta.test.ts
+++ b/src/lib/github-assigned-meta.test.ts
@@ -1,0 +1,115 @@
+// Contract tests for the assigned-work completeness model (cave-amx2m): caps,
+// partial failures, and the disclosure line the task picker renders. Plus
+// source pins for how the route and BoardInspector consume it.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+import {
+  assignedDisclosure,
+  failedSource,
+  isPartial,
+  isTruncated,
+  restSource,
+  searchSource,
+  type AssignedSourcesMeta,
+} from "./github-assigned-meta.ts";
+
+const full = (over: Partial<AssignedSourcesMeta> = {}): AssignedSourcesMeta => ({
+  assigned: { ok: true, truncated: false, count: 3 },
+  reviewRequested: { ok: true, truncated: false, count: 2, total: 2 },
+  authored: { ok: true, truncated: false, count: 1, total: 1 },
+  ...over,
+});
+
+test("REST caps: a rel=next Link header flags truncation, and so does a full page without one", () => {
+  assert.equal(restSource(12, 50, null).truncated, false, "under the cap, no next page — complete");
+  assert.equal(restSource(12, 50, '<https://api.github.com/issues?page=2>; rel="next"').truncated, true, "next page exists");
+  // A page exactly at the cap is indistinguishable from overflow — "maybe
+  // more" must never render as "that's everything".
+  assert.equal(restSource(50, 50, null).truncated, true, "full page counts as truncated even without the header");
+});
+
+test("search caps: total_count makes truncation exact and never undercounts", () => {
+  assert.deepEqual(searchSource(30, 84), { ok: true, truncated: true, count: 30, total: 84 });
+  assert.deepEqual(searchSource(7, 7), { ok: true, truncated: false, count: 7, total: 7 });
+  // A total below the returned count would be a lie — clamp up, never down.
+  assert.equal(searchSource(30, 4).total, 30);
+  assert.equal(searchSource(5, undefined).truncated, false, "no total → no truncation claim");
+});
+
+test("partial failures: one dead source marks the aggregate partial, not empty", () => {
+  const sources = full({ reviewRequested: failedSource("GitHub API error: HTTP 502") });
+  assert.equal(isPartial(sources), true);
+  assert.equal(isTruncated(sources), false);
+  assert.match(
+    assignedDisclosure(sources, 4) ?? "",
+    /1 GitHub source didn't load — this list may be incomplete\./,
+  );
+});
+
+test("failure outranks truncation in the disclosure line", () => {
+  const sources = full({
+    assigned: { ok: true, truncated: true, count: 50 },
+    authored: failedSource("boom"),
+  });
+  assert.match(assignedDisclosure(sources, 52) ?? "", /didn't load/);
+});
+
+test("pure truncation discloses the window; complete responses disclose nothing", () => {
+  const capped = full({
+    reviewRequested: { ok: true, truncated: true, count: 30, total: 84 },
+    authored: { ok: true, truncated: true, count: 30, total: 41 },
+  });
+  assert.equal(isTruncated(capped), true);
+  assert.match(assignedDisclosure(capped, 63) ?? "", /Showing the newest 63/);
+  // A REST cap has no total — the line stays honest about not knowing.
+  const restCapped = full({ assigned: { ok: true, truncated: true, count: 50 } });
+  assert.match(assignedDisclosure(restCapped, 53) ?? "", /more exists on GitHub than fits here/);
+  assert.equal(assignedDisclosure(full(), 6), null, "a complete list needs no caveat");
+});
+
+// ── Wiring pins ──────────────────────────────────────────────────────────────
+
+const route = readFileSync(new URL("../app/api/github/assigned/route.ts", import.meta.url), "utf8");
+const inspector = readFileSync(new URL("../components/board-inspector.tsx", import.meta.url), "utf8");
+
+test("the route fetches each capped source fault-isolated and returns the metadata", () => {
+  assert.match(route, /async function fetchSource</, "sources fetch through the fault-isolated helper");
+  assert.match(
+    route,
+    /if \(!assigned\.meta\.ok && !review\.meta\.ok && !created\.meta\.ok\)/,
+    "only ALL sources failing produces an error response",
+  );
+  assert.match(route, /sources,\s*\n\s*partial: isPartial\(sources\),\s*\n\s*truncated: isTruncated\(sources\),/, "the success payload carries per-source metadata");
+  assert.match(route, /restSource\(items\.length, ASSIGNED_PER_PAGE, linkHeader\)/, "the REST cap is measured");
+  assert.match(route, /searchSource\(items\.length, body\?\.total_count\)/, "search caps use GitHub's own totals");
+  assert.match(
+    route,
+    /assigned\.unauthorized \|\| review\.unauthorized \|\| created\.unauthorized/,
+    "a 401 anywhere still routes to the patInvalid response, not a partial list",
+  );
+});
+
+test("BoardInspector never renders a capped or half-loaded list as a trustworthy empty", () => {
+  assert.match(
+    inspector,
+    /partial\s*\n?\s*\? "Couldn’t load all GitHub sources — there may be work this list can’t see\."\s*\n?\s*: "No open issues, PRs, or review requests assigned to you\."/,
+    "the definitive empty claim is earned only by a complete response",
+  );
+  assert.match(
+    inspector,
+    /\{disclosure \? `No matches in what loaded — \$\{disclosure\}` : "No matches\."\}/,
+    "filtered emptiness discloses the window it searched",
+  );
+  assert.match(
+    inspector,
+    /filtered\.length > 0 && disclosure &&/,
+    "a non-empty but incomplete list carries the completeness footer",
+  );
+  assert.match(
+    inspector,
+    /assignedDisclosure\(d\.sources, \(d\.items \?\? \[\]\)\.length\)/,
+    "the disclosure line derives from the endpoint's own metadata",
+  );
+});

--- a/src/lib/github-assigned-meta.ts
+++ b/src/lib/github-assigned-meta.ts
@@ -1,0 +1,87 @@
+// Pure completeness model for /api/github/assigned (cave-amx2m).
+//
+// The endpoint stitches three capped GitHub sources into one list: assigned
+// issues (REST, per_page=50), review-requested PRs and authored PRs (search,
+// per_page=30). Before this, a cap was silent and ANY source failing failed
+// the whole response — so the task picker rendered "nothing assigned to you"
+// over lists that were truncated or half-missing. This module derives honest
+// per-source metadata the route returns and the picker discloses. Kept free
+// of fetch/Next so caps and partial failures are unit-testable with bare node.
+
+export type AssignedSourceMeta = {
+  ok: boolean;
+  /** True when GitHub has more than this source returned. */
+  truncated: boolean;
+  /** Items this source actually contributed. */
+  count: number;
+  /** GitHub's own total (search sources only — REST /issues reports none). */
+  total?: number;
+  /** Present only when ok=false: why the source is missing from the list. */
+  error?: string;
+};
+
+export type AssignedSourcesMeta = {
+  assigned: AssignedSourceMeta;
+  reviewRequested: AssignedSourceMeta;
+  authored: AssignedSourceMeta;
+};
+
+/** A failed source: contributes nothing, says so. */
+export function failedSource(error: string): AssignedSourceMeta {
+  return { ok: false, truncated: false, count: 0, error };
+}
+
+/**
+ * REST list sources (no total_count): truncation shows in the Link header's
+ * rel="next" page; a full page WITHOUT the header is still flagged, because a
+ * result exactly at the cap is indistinguishable from an overflowing one and
+ * "maybe more" must never render as "that's everything".
+ */
+export function restSource(count: number, perPage: number, linkHeader: string | null): AssignedSourceMeta {
+  const hasNext = typeof linkHeader === "string" && /rel="next"/.test(linkHeader);
+  return { ok: true, truncated: hasNext || count >= perPage, count };
+}
+
+/** Search sources report total_count — truncation is exact. */
+export function searchSource(count: number, totalCount: number | undefined): AssignedSourceMeta {
+  const total = Number.isFinite(totalCount) ? Math.max(totalCount as number, count) : undefined;
+  return {
+    ok: true,
+    truncated: total != null ? total > count : false,
+    count,
+    ...(total != null ? { total } : {}),
+  };
+}
+
+/** Any source failed → the aggregate list is PARTIAL, not empty-and-done. */
+export function isPartial(sources: AssignedSourcesMeta): boolean {
+  return Object.values(sources).some((s) => !s.ok);
+}
+
+/** Any source capped → the aggregate list is a newest-first WINDOW. */
+export function isTruncated(sources: AssignedSourcesMeta): boolean {
+  return Object.values(sources).some((s) => s.ok && s.truncated);
+}
+
+/**
+ * One quiet sentence for the picker's disclosure line. Failure outranks
+ * truncation: a missing source makes counts unreliable, so "may be
+ * incomplete" wins over the more precise "newest N" phrasing.
+ */
+export function assignedDisclosure(sources: AssignedSourcesMeta, shown: number): string | null {
+  if (isPartial(sources)) {
+    const failed = Object.values(sources).filter((s) => !s.ok).length;
+    return `${failed} GitHub source${failed === 1 ? "" : "s"} didn't load — this list may be incomplete.`;
+  }
+  if (isTruncated(sources)) {
+    const known = Object.values(sources).reduce(
+      (n, s) => (s.total != null ? n + s.total : n),
+      0,
+    );
+    const hasUnknownCap = Object.values(sources).some((s) => s.truncated && s.total == null);
+    return known > shown && !hasUnknownCap
+      ? `Showing the newest ${shown} of ${known} — search to narrow, or open GitHub for the rest.`
+      : `Showing the newest ${shown} — more exists on GitHub than fits here.`;
+  }
+  return null;
+}


### PR DESCRIPTION
`/api/github/assigned` stitches three capped sources (assigned issues at 50, review-requested and authored PR searches at 30) into one list, silently — a cap was invisible, and ANY source failing failed the whole response, so BoardInspector rendered definitive "nothing assigned to you" / "No matches" over lists that were truncated or half-missing. Closes **cave-amx2m** (from the cave-3zmnj completeness audit).

## What changes

- **Pure model** `src/lib/github-assigned-meta.ts`: per-source completeness — REST caps via `Link rel="next"` (a full page is flagged even without the header: exactly-at-cap is indistinguishable from overflow), search caps exact via `total_count` (clamped never below the returned count) — plus partial/truncated aggregation and the one-line disclosure the picker renders. Failure outranks truncation in the phrasing.
- **Fault-isolated route**: a non-auth failure removes one source and says so in `sources` metadata instead of failing the response; ALL sources down keeps the old 502; a 401 anywhere still routes to the `patInvalid` reconnect flow. Success payloads gain `sources` / `partial` / `truncated` — additive, so `use-review-requests` and `dashboard-analytics` are untouched.
- **BoardInspector earns its empty states**: definitive "nothing assigned" only on a complete response (partial → "Couldn't load all GitHub sources — there may be work this list can't see." + Retry); filtered no-match discloses the searched window; a non-empty but capped/partial list carries a quiet completeness footer.

## Acceptance criteria → coverage

| criterion | where |
| --- | --- |
| endpoint exposes truncation/failure metadata per capped source | `sources.{assigned,reviewRequested,authored}` w/ `truncated`/`count`/`total`/`error` |
| picker never renders failed/truncated as trustworthy empty | earned-empty ternary, disclosure footer, no-match window line |
| tests cover caps, partial failures, filtered emptiness | `github-assigned-meta.test.ts` (7 behavior tests + wiring pins) |

Gates: `pnpm test:app` (975 files) · `pnpm build` (budgets green) · tsc · eslint.

Bead: cave-amx2m

🤖 Generated with [Claude Code](https://claude.com/claude-code)