### PR TITLE
feat(shell): round the content pane's leading edge against the rail

### DIFF
--- a/src/styles/backdrop.css
+++ b/src/styles/backdrop.css
@@ -105,6 +105,7 @@ html[data-backdrop] .cave-backdrop-layer::after {
    backgrounds, so the image shows through the content area only. The shared
    glass tokens (PR 2790) give floating chrome above the image a real blur. */
 html[data-backdrop-on] .shell-root,
+html[data-backdrop-on] .shell-detail-panel,
 html[data-backdrop-on] .shell-detail {
   background: transparent;
 }

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -43,9 +43,11 @@
   overflow: visible !important;
 }
 
-/* Inner panel border — subtle dividing line on the right edge of side panels */
-.shell-nav-panel { border-right: 1px solid var(--border-hairline); position: relative; }
-.shell-list-panel { border-right: 1px solid var(--border-hairline); }
+/* Inner panel border — the recessed gutter and rounded leading edge of
+   .shell-detail now carry the separation, so the side panes drop the hard
+   divider that used to double it. (`list` is undefined at every call site
+   today; if that pane ever returns, its seam is a fresh call to make.) */
+.shell-nav-panel { position: relative; }
 
 .shell-nav-panel > .shell-nav,
 .shell-list-panel > .shell-list,
@@ -1037,6 +1039,26 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  /* Rounded leading edge: the content pane reads as a surface raised off the
+     shell rather than a third column butted against the rail. Logical corners,
+     so RTL rounds the trailing edge instead. The recess behind the arc is
+     painted by .shell-detail-panel below — .shell-root cannot supply it,
+     because backdrop mode makes root transparent. */
+  border-start-start-radius: var(--radius-panel);
+  border-end-start-radius: var(--radius-panel);
+  /* A hair of inset so the recess reads down the whole edge rather than only
+     inside the corner arcs — flush panes make the rounding almost invisible. */
+  margin-inline-start: var(--space-2);
+}
+
+/* The arc needs a surface behind it. The panel wrapper paints the gutter in
+   the nav's own rendered colour — .shell-nav is `--bg-raised` at 88% over
+   `--bg-base`, so this is that mix flattened — which makes the content read as
+   a card floating on the rail's plane. Deriving it instead of picking a token
+   keeps the relationship right in light themes too, where a recess token like
+   --bg-panel is *lighter* than the base and would invert the effect. */
+.shell-detail-panel {
+  background: color-mix(in oklch, var(--bg-raised) 88%, var(--bg-base));
 }
 
 .shell-detail-header {

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -1071,6 +1071,11 @@
 
   .shell-detail {
     padding-bottom: 0;
+    /* The side panes are overlay drawers at this width — nothing sits beside
+       the content pane for a rounded edge to meet, so it goes full-bleed. */
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+    margin-inline-start: 0;
   }
 
   /* Drawer panels: fixed-position overlays that slide in from the side.


### PR DESCRIPTION
The content pane butted flush against the nav rail, separated only by a hairline divider — three columns of equal weight rather than a content surface sitting on shell chrome.

## What changed

`.shell-detail` takes a logical leading radius (`--radius-panel`, so it tracks the theme and flips under RTL) plus an 8px inset.

The inset is what makes it read. With the panes flush, the recess is only visible *inside* the corner arcs, and the rounding is nearly invisible at a glance — I shipped that version first and had to look at the render to see it wasn't working.

The gutter behind the arc is painted on `.shell-detail-panel`, **derived** as the nav's own rendered colour (`--bg-raised` at 88% over `--bg-base`, flattened) rather than picked from a token. That's deliberate: a nominally recessed token like `--bg-panel` is *lighter* than the base in light themes and would invert the effect. Deriving from the rail keeps "content is a card floating on the rail's plane" true in every theme.

Measured in both modes with the backdrop isolated:

| mode | gutter | content |
|---|---|---|
| dark | `oklch(0.199)` | `rgb(13,13,13)` |
| light | `oklch(0.984)` | `#ffffff` |

With the gutter carrying the separation, the side panes drop the hard divider that used to double it.

## Where it deliberately does nothing

- **Mobile** — the side panes are overlay drawers below the breakpoint, so nothing sits beside the content for a rounded edge to meet. Radius and inset both zero out.
- **Backdrop mode** — `.shell-detail-panel` joins the existing `html[data-backdrop-on]` transparent list, so an opaque strip never lands over the image. The shell stays full-bleed there, as designed.

## Verification

- `pnpm build` green; `tokenize-css` a no-op; `design-token-drift` passes **unchanged** — the radius, inset and colour are all tokens or token-derived, so there is nothing to bank.
- `pnpm test:app` — 448 suites, 0 failures. `pnpm lint` clean.
- Rendered and inspected at 1500×950 in dark and light. No test pins the divider rule that was removed.

Bead: `cave-r2f5j`

🤖 Generated with [Claude Code](https://claude.com/claude-code)