### PR TITLE
fix(chat): present compatibility drift as notices

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -600,8 +600,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /const claudeDiagnostic =[\s\S]*?if \(claudeDiagnostic\) \{[\s\S]*?pushProgress\("claude-runtime-compatibility", claudeDiagnostic, "error"\)/,
-  "Claude compatibility diagnostics should be emitted before stdout so an immediately failing CLI still explains the text-only fallback",
+  /const claudeDiagnostic =[\s\S]*?if \(claudeDiagnostic\) \{[\s\S]*?pushProgress\("claude-runtime-compatibility", claudeDiagnostic, "notice"\)/,
+  "Claude compatibility diagnostics should be emitted as neutral notices before stdout so an immediately failing CLI still explains the text-only fallback",
 );
 
 assert.match(
@@ -618,7 +618,7 @@ assert.match(
 
 assert.match(
   streamEvents,
-  /\|\s*\{\s*kind: "progress";\s*id\?: string;\s*label: string;\s*detail\?: string;\s*status\?: "running" \| "done" \| "error";\s*durationMs\?: number;\s*\}/,
+  /\|\s*\{\s*kind: "progress";\s*id\?: string;\s*label: string;\s*detail\?: string;\s*status\?: "running" \| "done" \| "notice" \| "error";\s*durationMs\?: number;\s*\}/,
   "Native chat streams should expose progress SSE events for quiet phases",
 );
 

--- a/src/app/api/chat/send/harness-routing-opencode.test.ts
+++ b/src/app/api/chat/send/harness-routing-opencode.test.ts
@@ -164,7 +164,7 @@ assert.match(
 );
 assert.match(
   route,
-  /Couldn't verify OpenCode JSON events; continuing in plain chat without tool activity[\s\S]*?capability-probe-unavailable[\s\S]*?capability-probe-fallback[\s\S]*?\? "done"\s*:\s*"error"/,
+  /Couldn't verify OpenCode JSON events; continuing in plain chat without tool activity[\s\S]*?capability-probe-unavailable[\s\S]*?capability-probe-fallback[\s\S]*?pushProgress\([\s\S]*?"notice"/,
   "an unavailable capability probe is distinct from confirmed JSON incompatibility and does not create a false error issue",
 );
 assert.doesNotMatch(
@@ -236,6 +236,16 @@ assert.match(
   route,
   /opencode-compatibility[\s\S]*?unrecognized event[\s\S]*?redactedOpenCodeEventFingerprint\(rawEvent\)/,
   "unknown future event shapes surface a safe visible diagnostic",
+);
+assert.match(
+  route,
+  /quarantineOpenCodeProtocol[\s\S]*?pushProgress\("opencode-compatibility", label, "notice"/,
+  "OpenCode protocol quarantine is presented as a neutral notice",
+);
+assert.match(
+  route,
+  /const diagnostic = openCodeCompatibility\.diagnostic ===[\s\S]*?pushProgress\([\s\S]*?"opencode-compatibility"[\s\S]*?diagnostic,[\s\S]*?"notice"/,
+  "OpenCode compatibility fallback diagnostics are presented as neutral notices",
 );
 assert.match(
   route,

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -140,6 +140,17 @@ assert.match(
 
 assert.match(
   chatRoute,
+  /reportUnsupportedClaudeToolFrame = \(frame: unknown\) => \{[\s\S]*?pushProgress\([\s\S]*?"claude-runtime-compatibility"[\s\S]*?"notice"/,
+  "unsupported profiled tool blocks must be presented as neutral notices",
+);
+assert.match(
+  chatRoute,
+  /reportCopilotProtocolDiagnostic[\s\S]*?label: "Copilot tool activity needs an update"[\s\S]*?status: "notice"/,
+  "Copilot protocol drift must be presented as a neutral notice",
+);
+
+assert.match(
+  chatRoute,
   /Claude stream frame could not be decoded[\s\S]*?fingerprint: redactedEventFingerprint\(frame\)[\s\S]*?chat text will continue without unverified tool bubbles[\s\S]*?reportMalformedClaudeStreamFrame\(line\)/,
   "malformed Claude JSONL must be reduced to a fingerprint and diagnostic rather than falling through to payload-bearing stdout diagnostics",
 );

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -590,7 +590,7 @@ function openClawChatResponse(args: {
       const pushProgress = (
         id: string,
         label: string,
-        status: "running" | "done" | "error",
+        status: "running" | "done" | "notice" | "error",
         detail?: string,
         durationMs?: number,
       ) =>
@@ -2085,7 +2085,7 @@ export async function POST(req: Request) {
       const pushProgress = (
         id: string,
         label: string,
-        status: "running" | "done" | "error",
+        status: "running" | "done" | "notice" | "error",
         detail?: string,
         durationMs?: number,
       ) => {
@@ -2253,7 +2253,7 @@ export async function POST(req: Request) {
       if (claudeDiagnostic) {
         // Emit the fallback state before the child produces output: an absent
         // or immediately-failing CLI must not hide the only useful diagnostic.
-        pushProgress("claude-runtime-compatibility", claudeDiagnostic, "error");
+        pushProgress("claude-runtime-compatibility", claudeDiagnostic, "notice");
       }
       // A fallback reason is already a user-visible compatibility diagnostic.
       // Later malformed frames still get a redacted log fingerprint, but must
@@ -2276,7 +2276,7 @@ export async function POST(req: Request) {
         pushProgress(
           "claude-runtime-compatibility",
           "A Claude Code stream frame could not be decoded; chat text will continue without unverified tool bubbles.",
-          "error",
+          "notice",
         );
       };
       const reportUnsupportedClaudeToolFrame = (frame: unknown) => {
@@ -2294,7 +2294,7 @@ export async function POST(req: Request) {
         pushProgress(
           "claude-runtime-compatibility",
           "A Claude Code tool frame is not supported by the selected compatibility profile; chat text will continue without unverified tool bubbles.",
-          "error",
+          "notice",
         );
       };
       const settleUnfinishedTools = () => {
@@ -2360,7 +2360,7 @@ export async function POST(req: Request) {
         pushProgress(
           "grok-compatibility",
           "Grok Build sent an unrecognized event; future turns will use safe plain chat until a compatible schema is available",
-          "error",
+          "notice",
           detail,
         );
       };
@@ -2375,7 +2375,7 @@ export async function POST(req: Request) {
         quarantineOpenCodeSchema(openCodeCompatibility?.schema);
         if (openCodeProtocolQuarantineNoticeSent) return;
         openCodeProtocolQuarantineNoticeSent = true;
-        pushProgress("opencode-compatibility", label, "error", detail);
+        pushProgress("opencode-compatibility", label, "notice", detail);
       };
 
       // Model parity: the harness echoes its resolved model on the init/system
@@ -2402,7 +2402,7 @@ export async function POST(req: Request) {
           id: `copilot-protocol-${code}`,
           label: "Copilot tool activity needs an update",
           detail,
-          status: "error",
+          status: "notice",
         });
       };
 
@@ -2692,7 +2692,7 @@ export async function POST(req: Request) {
               : grokCompatibility.diagnostic === "no-compatible-schema"
                 ? "This Grok Build client has no verified tool-event schema; continuing without tool activity"
                 : "Grok Build's structured event protocol is unavailable; continuing without tool activity";
-          pushProgress("grok-compatibility", label, "error", grokCompatibility.diagnostic);
+          pushProgress("grok-compatibility", label, "notice", grokCompatibility.diagnostic);
         }
         if (grokCompatibility?.mode === "plain") {
           // Plain output is safe only while it is prose. A changed client can
@@ -2716,7 +2716,7 @@ export async function POST(req: Request) {
               pushProgress(
                 "grok-compatibility",
                 "Grok Build emitted unverified structured output; continuing without tool activity",
-                "error",
+                "notice",
                 "unverified-structured-output",
               );
             }
@@ -2824,7 +2824,7 @@ export async function POST(req: Request) {
                 pushProgress(
                   "grok-compatibility",
                   "Grok Build sent an unrecognized event; future turns will use safe plain chat until a compatible schema is available",
-                  "error",
+                  "notice",
                   `unknown-event:${redactedGrokEventFingerprint(raw)}`,
                 );
               }
@@ -2957,7 +2957,7 @@ export async function POST(req: Request) {
               pushProgress(
                 "opencode-compatibility",
                 "OpenCode sent an unrecognized event; future turns will use safe plain chat until a compatible schema is available",
-                "error",
+                "notice",
                 `${ev.diagnostic ?? "unknown-event"}:${redactedOpenCodeEventFingerprint(rawEvent)}`,
               );
             }
@@ -2999,9 +2999,7 @@ export async function POST(req: Request) {
           pushProgress(
             "opencode-compatibility",
             diagnostic,
-            openCodeCompatibility.diagnostic === "capability-probe-unavailable" || openCodeCompatibility.diagnostic === "capability-probe-fallback"
-              ? "done"
-              : "error",
+            "notice",
             openCodeCompatibility.diagnostic,
           );
         }
@@ -4002,9 +4000,7 @@ export async function POST(req: Request) {
         pushProgress(
           "opencode-compatibility",
           diagnostic,
-          openCodeCompatibility.diagnostic === "capability-probe-unavailable" || openCodeCompatibility.diagnostic === "capability-probe-fallback"
-            ? "done"
-            : "error",
+          "notice",
           openCodeCompatibility.diagnostic,
         );
       }
@@ -4020,7 +4016,7 @@ export async function POST(req: Request) {
             : openCodeSessionUnavailable
               ? "This OpenCode client cannot resume sessions; starting a fresh chat"
               : "This conversation has no resumable OpenCode session; starting a fresh chat",
-          "error",
+          "notice",
           "session-unavailable",
         );
       }

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -48,8 +48,19 @@ assert.match(
 
 assert.match(
   streamEvents,
-  /\{\s*kind: "progress";\s*id\?: string;\s*label: string;\s*detail\?: string;\s*status\?: "running" \| "done" \| "error";\s*durationMs\?: number;\s*\}/,
+  /\{\s*kind: "progress";\s*id\?: string;\s*label: string;\s*detail\?: string;\s*status\?: "running" \| "done" \| "notice" \| "error";\s*durationMs\?: number;\s*\}/,
   "Chat streams should expose non-token progress events for quiet phases",
+);
+
+assert.match(
+  source,
+  /event\.status === "notice"[\s\S]*?ph:info/,
+  "neutral progress notices use an informational icon instead of an error icon",
+);
+assert.match(
+  styles,
+  /\.cave-progress-row--notice\s*\{[\s\S]*?var\(--text-secondary\)/,
+  "neutral progress notices use secondary text styling rather than danger color",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -452,7 +452,7 @@ function upsertProgressEvent(
     id?: string;
     label: string;
     detail?: string;
-    status?: "running" | "done" | "error";
+    status?: "running" | "done" | "notice" | "error";
     durationMs?: number;
     createdAt?: string;
   },
@@ -518,7 +518,7 @@ function DurationText({ durationMs }: { durationMs?: number }) {
 }
 
 type ErrorStripTool = { id: string; name: string; input?: string; output?: string; status: "running" | "ok" | "error"; durationMs?: number };
-type ErrorStripStep = { id: string; label: string; detail?: string; status: "running" | "done" | "error" };
+type ErrorStripStep = { id: string; label: string; detail?: string; status: "running" | "done" | "notice" | "error" };
 type ErrorStripTurn = { tools?: ErrorStripTool[]; progress?: ErrorStripStep[]; lifecycle?: string };
 
 /** Inline error/debug strip between the transcript and the composer. Shows the
@@ -5426,7 +5426,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       id?: string;
       label: string;
       detail?: string;
-      status?: "running" | "done" | "error";
+      status?: "running" | "done" | "notice" | "error";
       durationMs?: number;
     },
     targetSessionId: string | null = currentSessionRef.current,
@@ -7561,8 +7561,9 @@ function ProgressGroup({
   pending: boolean;
 }) {
   const running = progress.filter((event) => event.status === "running").length;
+  const notices = progress.filter((event) => event.status === "notice").length;
   const errors = progress.filter((event) => event.status === "error").length;
-  const completed = progress.length - running - errors;
+  const completed = progress.filter((event) => event.status === "done").length;
   const current = currentProgress(progress);
 
   return (
@@ -7579,6 +7580,7 @@ function ProgressGroup({
         ) : null}
         <span className="ml-auto flex items-center gap-1.5 font-mono text-[length:var(--text-2xs)] normal-case tracking-normal text-[var(--text-muted)]">
           {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
+          {notices ? <span className="cave-tool-count cave-tool-count--notice">{notices} {notices === 1 ? "notice" : "notices"}</span> : null}
           {errors ? <span className="cave-tool-count cave-tool-count--error">{errors} {errors === 1 ? "issue" : "issues"}</span> : null}
           {completed ? <span className="cave-tool-count">{completed} done</span> : null}
         </span>
@@ -7601,6 +7603,8 @@ function ProgressRow({ event }: { event: ProgressEvent }) {
   const statusIcon =
     event.status === "error"
       ? "ph:warning-circle"
+      : event.status === "notice"
+        ? "ph:info"
       : event.status === "done"
         ? "ph:check-circle"
         : "ph:circle-dashed";
@@ -8108,6 +8112,7 @@ function RunActivityStrip({
   const issues =
     tools.filter((t) => t.status === "error").length +
     progress.filter((p) => p.status === "error").length;
+  const notices = progress.filter((p) => p.status === "notice").length;
   const done =
     tools.filter((t) => t.status === "ok").length +
     progress.filter((p) => p.status === "done").length;
@@ -8134,14 +8139,15 @@ function RunActivityStrip({
           aria-label={live ? "Agent activity (running)" : "Last run summary"}
         >
           <Icon
-            name={live ? "ph:circle-dashed" : issues ? "ph:warning-circle" : "ph:check-circle"}
+            name={live ? "ph:circle-dashed" : issues ? "ph:warning-circle" : notices ? "ph:info" : "ph:check-circle"}
             width={13}
-            className={`shrink-0 ${live ? "animate-spin text-[var(--accent-presence)]" : issues ? "text-[var(--color-warning)]" : "text-[var(--color-success)]"}`}
+            className={`shrink-0 ${live ? "animate-spin text-[var(--accent-presence)]" : issues ? "text-[var(--color-warning)]" : notices ? "text-[var(--text-secondary)]" : "text-[var(--color-success)]"}`}
             aria-hidden
           />
           <span className="min-w-0 flex-1 truncate text-[var(--text-secondary)]">{headline}</span>
           <span className="flex shrink-0 items-center gap-1.5 font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
             {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
+            {notices ? <span className="cave-tool-count cave-tool-count--notice">{notices} {notices === 1 ? "notice" : "notices"}</span> : null}
             {issues ? <span className="cave-tool-count cave-tool-count--error">{issues} {issues === 1 ? "issue" : "issues"}</span> : null}
             {done ? <span className="cave-tool-count">{done} done</span> : null}
           </span>

--- a/src/lib/cave-conversations.ts
+++ b/src/lib/cave-conversations.ts
@@ -45,7 +45,7 @@ export type ChatTurn = {
     id: string;
     label: string;
     detail?: string;
-    status: "running" | "done" | "error";
+    status: "running" | "done" | "notice" | "error";
     createdAt: string;
     durationMs?: number;
   }>;

--- a/src/lib/chat-turn-state.ts
+++ b/src/lib/chat-turn-state.ts
@@ -29,7 +29,7 @@ export type ProgressEvent = {
   id: string;
   label: string;
   detail?: string;
-  status: "running" | "done" | "error";
+  status: "running" | "done" | "notice" | "error";
   createdAt: string;
   durationMs?: number;
 };

--- a/src/lib/group-chat.ts
+++ b/src/lib/group-chat.ts
@@ -103,7 +103,7 @@ export type GroupStreamEvent =
   | { kind: "user"; text: string }
   | { kind: "assistant_chunk"; text: string }
   | { kind: "assistant_replace"; text: string }
-  | { kind: "progress"; label?: string; status?: "running" | "done" | "error" }
+  | { kind: "progress"; label?: string; status?: "running" | "done" | "notice" | "error" }
   | { kind: "tool_use"; name?: string; status?: "running" | "ok" | "error" }
   | { kind: "done"; durationMs?: number; isError?: boolean; sessionId?: string; costUsd?: number }
   | { kind: "error"; message: string; code?: string };

--- a/src/lib/session-debug.ts
+++ b/src/lib/session-debug.ts
@@ -38,7 +38,7 @@ export type DebugTurn = {
     id: string;
     label: string;
     detail?: string;
-    status: "running" | "done" | "error";
+    status: "running" | "done" | "notice" | "error";
     createdAt: string;
     durationMs?: number;
   }>;

--- a/src/lib/stream-events.ts
+++ b/src/lib/stream-events.ts
@@ -18,7 +18,7 @@ export type StreamEvent =
       id?: string;
       label: string;
       detail?: string;
-      status?: "running" | "done" | "error";
+      status?: "running" | "done" | "notice" | "error";
       durationMs?: number;
     }
   | {

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -281,6 +281,10 @@ details[open] > .cave-tool-summary::before {
   color: var(--color-danger);
 }
 
+.cave-tool-count--notice {
+  color: var(--text-secondary);
+}
+
 .cave-progress-list {
   display: grid;
   gap: 6px;
@@ -311,6 +315,10 @@ details[open] > .cave-tool-summary::before {
 
 .cave-progress-row--done {
   color: var(--text-muted);
+}
+
+.cave-progress-row--notice {
+  color: var(--text-secondary);
 }
 
 .cave-progress-row--error {


### PR DESCRIPTION
## Summary
- classify Claude, OpenCode, Grok, and Copilot compatibility drift as neutral notices
- render notices with info icons and secondary text instead of red issue styling
- preserve genuine runtime and authentication failures as errors

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` — all 975 test files passed
- `git diff --check