### PR TITLE
ci: attest release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,10 @@ jobs:
   build:
     name: Build ${{ matrix.label }}
     needs: daemon-package
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     strategy:
       fail-fast: false
       matrix:
@@ -731,9 +735,38 @@ jobs:
           fi
           gh release upload "$RELEASE_TAG" "${UPLOAD_FILES[@]}" --clobber
 
+      - name: Attest Linux AppImage
+        if: >-
+          matrix.family == 'linux' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'linux')
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
+        with:
+          subject-path: src-tauri/target/release/bundle/**/*.AppImage
+
+      - name: Attest Windows MSI
+        if: >-
+          matrix.family == 'windows' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'windows') &&
+          (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only)
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
+        with:
+          subject-path: src-tauri/target/release/bundle/**/*.msi
+
+      - name: Attest macOS DMG
+        if: >-
+          matrix.family == 'macos' &&
+          (github.event_name != 'workflow_dispatch' || inputs.platform == 'all' || inputs.platform == 'macos')
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
+        with:
+          subject-path: release/CovenCave-v${{ env.RELEASE_VERSION }}-${{ matrix.arch_suffix }}.dmg
+
   checksums:
     name: Publish SHA256SUMS
     needs: build
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     runs-on: ubuntu-24.04
     if: ${{ success() && (github.event_name != 'workflow_dispatch' || !inputs.windows_diagnostics_only) }}
     steps:
@@ -801,6 +834,11 @@ jobs:
         run: |
           set -euo pipefail
           gh release upload "$RELEASE_TAG" _release/SHA256SUMS --clobber
+
+      - name: Attest SHA256SUMS
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4
+        with:
+          subject-path: _release/SHA256SUMS
 
       # Render the standardized release body — CHANGELOG.md section for
       # the version, plus arch-aware install instructions, checksum verify

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -20,6 +20,22 @@ const sidecarTargetModule = readFileSync(
   "utf8",
 );
 
+function getWorkflowJob(name) {
+  const lines = releaseWorkflow.split(/\r?\n/);
+  const marker = `  ${name}:`;
+  const start = lines.findIndex((line) => line === marker);
+  assert.notEqual(start, -1, `release workflow must define the ${name} job`);
+
+  let end = lines.length;
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[index])) {
+      end = index;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
 test("macOS release signing includes native files without executable mode", () => {
   assert.match(
     releaseScript,
@@ -219,6 +235,53 @@ test("manual release retries build from the release tag before publishing", () =
     releaseWorkflow,
     /scripts\/release\.sh[\s\S]*scripts\/sidecar-bundle\.sh[\s\S]*scripts\/windows-msi-budget\.ps1/,
     "the allowlist must cover only the three packaging scripts needed by v0.2.0 recovery",
+  );
+});
+
+test("release packages and checksum manifest receive GitHub artifact attestations", () => {
+  const buildJob = getWorkflowJob("build");
+  const checksumsJob = getWorkflowJob("checksums");
+
+  for (const job of [buildJob, checksumsJob]) {
+    assert.match(job, /^\s{4}permissions:\n\s{6}contents: write\n\s{6}id-token: write\n\s{6}attestations: write$/m);
+  }
+
+  assert.match(
+    buildJob,
+    /name: Attest Linux AppImage[\s\S]*uses: actions\/attest@[0-9a-f]{40} # v4[\s\S]*subject-path: src-tauri\/target\/release\/bundle\/\*\*\/\*\.AppImage/,
+  );
+  assert.match(
+    buildJob,
+    /name: Attest Windows MSI[\s\S]*uses: actions\/attest@[0-9a-f]{40} # v4[\s\S]*subject-path: src-tauri\/target\/release\/bundle\/\*\*\/\*\.msi/,
+  );
+  assert.match(
+    buildJob,
+    /name: Attest macOS DMG[\s\S]*uses: actions\/attest@[0-9a-f]{40} # v4[\s\S]*subject-path: release\/CovenCave-v\$\{\{ env\.RELEASE_VERSION \}\}-\$\{\{ matrix\.arch_suffix \}\}\.dmg/,
+  );
+  assert.match(
+    checksumsJob,
+    /name: Attest SHA256SUMS[\s\S]*uses: actions\/attest@[0-9a-f]{40} # v4[\s\S]*subject-path: _release\/SHA256SUMS/,
+  );
+
+  assert(
+    buildJob.indexOf("name: Upload and re-sign stripped AppImage") <
+      buildJob.indexOf("name: Attest Linux AppImage"),
+    "the final repacked AppImage must be uploaded and re-signed before it is attested",
+  );
+  assert(
+    buildJob.indexOf("name: Publish validated Windows MSI") <
+      buildJob.indexOf("name: Attest Windows MSI"),
+    "the budget-approved MSI must be final before it is attested",
+  );
+  assert(
+    buildJob.indexOf("name: Verify macOS DMG is notarized") <
+      buildJob.indexOf("name: Attest macOS DMG"),
+    "the DMG must pass notarization verification before it is attested",
+  );
+  assert(
+    checksumsJob.indexOf("name: Compute SHA256SUMS") <
+      checksumsJob.indexOf("name: Attest SHA256SUMS"),
+    "the checksum manifest must be complete before it is attested",
   );
 });
 


### PR DESCRIPTION
## Summary
- generate GitHub artifact attestations for final macOS DMGs, Linux AppImages, and Windows MSIs
- attest the published `SHA256SUMS` manifest with job-scoped OIDC permissions
- add release workflow contract coverage for permissions, artifact paths, and final-byte ordering

## Verification
- `node --test scripts/release-macos-signing.test.mjs src-tauri/release-runtime.test.mjs`
- parsed `.github/workflows/release.yml` with the repository's `yaml` dependency
- `node scripts/secret-preflight.mjs --label "release attestation diff" .github/workflows/release.yml scripts/release-macos-signing.test.mjs`
- `git diff --check origin/main...HEAD`

## Tracking
- Bead: `cave-f8bx0`
