### PR TITLE
feat(openclaw): keychain-backed paired-device credential store

### DIFF
--- a/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
+++ b/docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md
@@ -91,13 +91,21 @@ package pair, negotiating wire protocol v4. It publishes `HelloOkSchema`,
 `sessions.messages.subscribe`. Cave validates that exact chat-only contract in
 its dispatcher, including the accepted `(sessionKey, agentId, runId)` tuple.
 
-Cave currently keeps the live route fail-closed **before client construction**:
-the reference client delegates device identity, challenge signing, and token
-lifecycle to host-owned `GatewayClientHostDeps`, and Cave does not yet have the
-required cross-platform OS-backed credential-store boundary. In particular,
-`OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_DEVICE_TOKEN` cannot activate a
-write-capable direct turn; the existing CLI/plain-chat bridge remains the
-fallback. This is intentional until real paired-device storage is shipped.
+The reference client delegates device identity, challenge signing, and token
+lifecycle to host-owned `GatewayClientHostDeps`. Cave backs those with an
+OS-backed paired-device credential store
+(`src/lib/server/openclaw-device-credentials.ts`, cave-cth7q): on macOS the
+Ed25519 device identity and Gateway-minted device tokens live in the login
+keychain (service `coven-cave.openclaw-gateway`, written through the
+`security` tool's stdin command mode so secrets never appear on argv), and
+every other platform fails closed **before client construction**. In
+particular, `OPENCLAW_GATEWAY_TOKEN` and `OPENCLAW_GATEWAY_DEVICE_TOKEN` still
+cannot activate a write-capable direct turn — the hostDeps drop the client's
+`env` bag — and dispatch stays opt-in behind `OPENCLAW_GATEWAY_DISPATCH` plus
+`OPENCLAW_GATEWAY_URL`; the existing CLI/plain-chat bridge remains the
+fallback everywhere the store (or the Gateway) is unavailable. An invalid
+persisted identity fails loudly and is never silently regenerated, because
+regeneration would silently unpair the device.
 
 The release also does **not** publish a `session.tool` event name, payload
 schema, or validator. Cave emits no Gateway tool card for this release and does
@@ -106,7 +114,7 @@ string is not a substitute for a versioned payload contract.
 
 | Package profile | Wire protocol | Runtime projection | Tool cards | Upgrade rule |
 | --- | --- | --- | --- | --- |
-| `2026.7.2-beta.4` | v4 only | None until Cave has OS-backed paired-device credentials; dispatcher tests validate only correlated `chat` frames | Disabled: no published schema | Add credential-store integration, then a fixture and explicit profile only when OpenClaw publishes a stable tool payload validator. |
+| `2026.7.2-beta.4` | v4 only | Correlated `chat` frames on macOS via the keychain-backed paired-device store; all other platforms fail closed | Disabled: no published schema (re-verified against `2026.7.2-beta.5`, whose `AgentEvent.data` is unchanged and whose typed `tool.*` events belong to the Talk surface only) | Add a fixture and explicit profile only when OpenClaw publishes a stable tool payload validator. |
 | Any other version/profile | Not assumed | None | Disabled | Keep CLI/plain chat with a visible compatibility diagnostic. |
 
 Before enabling tool cards, record the package release, exported validator,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1084,6 +1084,7 @@ export const SUITES = {
     "src/lib/openclaw-bin.test.ts",
     "src/lib/openclaw-bridge.test.ts",
     "src/lib/openclaw-gateway.test.ts",
+    "src/lib/server/openclaw-device-credentials.test.ts",
     "src/lib/coven-identity-canon.test.ts",
     "src/lib/familiar-runtime.test.ts",
     "src/lib/harness-adapters.test.ts",

--- a/src/lib/openclaw-gateway.test.ts
+++ b/src/lib/openclaw-gateway.test.ts
@@ -6,6 +6,7 @@ import {
   openClawGatewayPairedDeviceAuthStatus,
   textFromOpenClawGatewayMessage,
 } from "./openclaw-gateway.ts";
+import { createOpenClawDeviceCredentialStore } from "./server/openclaw-device-credentials.ts";
 
 const expected = {
   runId: "run-accepted",
@@ -64,12 +65,31 @@ assert.equal(
 );
 assert.equal(textFromOpenClawGatewayMessage({ raw: "not published" }), undefined);
 assert.deepEqual(
-  openClawGatewayPairedDeviceAuthStatus(),
+  openClawGatewayPairedDeviceAuthStatus(createOpenClawDeviceCredentialStore({ platform: "linux" })),
   {
     available: false,
-    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+    reason:
+      "OpenClaw Gateway dispatch requires the macOS Keychain credential store; linux has no supported OS credential store",
   },
-  "Cave must not activate the Gateway route before its host-owned paired-device credentials are secure",
+  "platforms without an OS credential store must not activate the Gateway route",
+);
+assert.deepEqual(
+  openClawGatewayPairedDeviceAuthStatus(
+    createOpenClawDeviceCredentialStore({ platform: "darwin", securityBinaryExists: () => false }),
+  ),
+  { available: false, reason: "The macOS security tool is unavailable for the OpenClaw credential store" },
+  "a macOS host without the security tool fails closed instead of degrading to env tokens",
+);
+assert.deepEqual(
+  openClawGatewayPairedDeviceAuthStatus(
+    createOpenClawDeviceCredentialStore({
+      platform: "darwin",
+      securityBinaryExists: () => true,
+      runSecurity: () => assert.fail("a status probe must not touch the keychain"),
+    }),
+  ),
+  { available: true },
+  "a macOS host with the security tool reports paired-device auth as available without keychain reads",
 );
 
 const missingRequestId = await dispatchOpenClawGatewayTurn({
@@ -101,12 +121,14 @@ const unpairedDispatch = await dispatchOpenClawGatewayTurn({
     OPENCLAW_GATEWAY_TOKEN: "must-not-activate-direct-dispatch",
   },
   onEvent: () => assert.fail("an unpaired Gateway must not emit events"),
+  credentialStore: createOpenClawDeviceCredentialStore({ platform: "linux" }),
 });
 assert.deepEqual(
   unpairedDispatch,
   {
     kind: "unavailable",
-    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+    reason:
+      "OpenClaw Gateway dispatch requires the macOS Keychain credential store; linux has no supported OS credential store",
   },
   "an environment token alone must never activate a write-capable Gateway dispatch",
 );
@@ -424,5 +446,126 @@ reconnectOptions.onEvent?.({
 if (reconnectDispatch.kind === "accepted") {
   assert.deepEqual(await reconnectDispatch.done, { state: "final" });
 }
+
+// --- paired-device credential wiring -------------------------------------
+
+// Opaque placeholders: nothing in the wiring path parses key material.
+const wiringIdentity = {
+  deviceId: "0".repeat(64),
+  privateKeyPem: "fake-device-private-key-pem",
+  publicKeyPem: "fake-device-public-key-pem",
+};
+const wiringCalls = [];
+const wiringStore = {
+  status: () => ({ available: true }),
+  loadOrCreateDeviceIdentity: () => wiringIdentity,
+  loadDeviceAuthToken: (params) => {
+    wiringCalls.push(["load", params]);
+    return { token: "keychain-token", scopes: ["operator.read", "operator.write"] };
+  },
+  storeDeviceAuthToken: (params) => {
+    wiringCalls.push(["store", params]);
+  },
+  clearDeviceAuthToken: (params) => {
+    wiringCalls.push(["clear", params]);
+  },
+};
+let wiringOptions;
+const wiredDispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  idempotencyKey: "cave-request-wired",
+  env: { OPENCLAW_GATEWAY_DISPATCH: "1", OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789" },
+  onEvent: () => {},
+  credentialStore: wiringStore,
+  clientFactory: (options) => {
+    wiringOptions = options;
+    return {
+      start() {
+        queueMicrotask(() => options.onHelloOk?.(helloOk()));
+      },
+      stop() {},
+      async request(method, _params, requestOptions) {
+        if (method === "chat.send") {
+          requestOptions?.onSent?.();
+          return { runId: expected.runId };
+        }
+        return {};
+      },
+    };
+  },
+});
+assert.equal(wiredDispatch.kind, "accepted", "an available credential store activates the Gateway dispatch path");
+assert.equal(
+  wiringOptions.deviceIdentity,
+  wiringIdentity,
+  "the client receives the store-resolved paired-device identity, not one it derives itself",
+);
+assert.deepEqual(
+  Object.keys(wiringOptions.env),
+  ["NODE_ENV"],
+  "wiring the credential store must not widen the client's environment beyond NODE_ENV",
+);
+assert.equal(typeof wiringOptions.hostDeps.signDevicePayload, "function");
+assert.equal(typeof wiringOptions.hostDeps.publicKeyRawBase64UrlFromPem, "function");
+assert.equal(
+  wiringOptions.hostDeps.loadOrCreateDeviceIdentity(),
+  wiringIdentity,
+  "hostDeps identity resolution returns the pre-resolved identity without another keychain round trip",
+);
+const loadedToken = wiringOptions.hostDeps.loadDeviceAuthToken({
+  deviceId: wiringIdentity.deviceId,
+  role: "operator",
+  env: { OPENCLAW_GATEWAY_DEVICE_TOKEN: "env-token-must-not-be-read" },
+});
+assert.deepEqual(
+  loadedToken,
+  { token: "keychain-token", scopes: ["operator.read", "operator.write"] },
+  "device tokens come from the credential store",
+);
+wiringOptions.hostDeps.storeDeviceAuthToken({
+  deviceId: wiringIdentity.deviceId,
+  role: "operator",
+  token: "minted-token",
+  scopes: ["operator.read"],
+  env: { HOME: "/nope" },
+});
+wiringOptions.hostDeps.clearDeviceAuthToken({
+  deviceId: wiringIdentity.deviceId,
+  role: "operator",
+  env: { HOME: "/nope" },
+});
+assert.deepEqual(
+  wiringCalls,
+  [
+    ["load", { deviceId: wiringIdentity.deviceId, role: "operator" }],
+    ["store", { deviceId: wiringIdentity.deviceId, role: "operator", token: "minted-token", scopes: ["operator.read"] }],
+    ["clear", { deviceId: wiringIdentity.deviceId, role: "operator" }],
+  ],
+  "hostDeps delegate to the credential store and drop the client's env bag so env auth can never revive",
+);
+if (wiredDispatch.kind === "accepted") wiredDispatch.close();
+
+const failingStoreDispatch = await dispatchOpenClawGatewayTurn({
+  sessionKey: expected.sessionKey,
+  agentId: expected.agentId,
+  message: "hello",
+  idempotencyKey: "cave-request-store-failure",
+  env: { OPENCLAW_GATEWAY_DISPATCH: "1", OPENCLAW_GATEWAY_URL: "ws://127.0.0.1:18789" },
+  onEvent: () => assert.fail("a failed credential store must not emit events"),
+  credentialStore: {
+    ...wiringStore,
+    loadOrCreateDeviceIdentity: () => {
+      throw new Error("The macOS Keychain holds an invalid OpenClaw device identity");
+    },
+  },
+  clientFactory: () => assert.fail("a failed credential store must not construct a Gateway client"),
+});
+assert.deepEqual(
+  failingStoreDispatch,
+  { kind: "unavailable", reason: "The macOS Keychain holds an invalid OpenClaw device identity" },
+  "an identity failure is a pre-dispatch compatibility failure that retains the CLI fallback",
+);
 
 console.log("openclaw Gateway run correlation tests passed");

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -12,7 +12,7 @@ import {
   signOpenClawDevicePayload,
   type OpenClawDeviceCredentialStore,
   type OpenClawDeviceIdentity,
-} from "@/lib/server/openclaw-device-credentials";
+} from "./server/openclaw-device-credentials.ts";
 
 /**
  * The direct Gateway transport is intentionally opt-in.  It owns a turn only

--- a/src/lib/openclaw-gateway.ts
+++ b/src/lib/openclaw-gateway.ts
@@ -1,4 +1,4 @@
-import { GatewayClient } from "@openclaw/gateway-client";
+import { GatewayClient, type GatewayClientHostDeps } from "@openclaw/gateway-client";
 import {
   ChatEventSchema,
   GATEWAY_SERVER_CAPS,
@@ -6,6 +6,13 @@ import {
 } from "@openclaw/gateway-protocol";
 import { PROTOCOL_VERSION } from "@openclaw/gateway-protocol/version";
 import { Value } from "typebox/value";
+import {
+  createOpenClawDeviceCredentialStore,
+  openClawPublicKeyRawBase64UrlFromPem,
+  signOpenClawDevicePayload,
+  type OpenClawDeviceCredentialStore,
+  type OpenClawDeviceIdentity,
+} from "@/lib/server/openclaw-device-credentials";
 
 /**
  * The direct Gateway transport is intentionally opt-in.  It owns a turn only
@@ -73,14 +80,35 @@ function gatewayDispatchEnabled(env: NodeJS.ProcessEnv): boolean {
 
 /**
  * The published client delegates device-identity creation, challenge signing,
- * and device-token lifecycle to hostDeps. Cave has not yet implemented the
- * required cross-platform OS credential-store boundary, so the route must not
- * activate a write-capable Gateway transport with process-environment tokens.
+ * and device-token lifecycle to hostDeps. Cave backs those with the OS
+ * credential store (macOS Keychain); platforms without a supported store fail
+ * closed so the route never activates a write-capable Gateway transport with
+ * process-environment tokens.
  */
-export function openClawGatewayPairedDeviceAuthStatus(): { available: boolean; reason?: string } {
+export function openClawGatewayPairedDeviceAuthStatus(
+  credentialStore?: OpenClawDeviceCredentialStore,
+): { available: boolean; reason?: string } {
+  return (credentialStore ?? createOpenClawDeviceCredentialStore()).status();
+}
+
+/**
+ * hostDeps ignore the `env` bag the client threads through its token hooks:
+ * device tokens live in the OS credential store only, and reviving env-token
+ * auth here would reopen the write-capable-transport-from-env hole this
+ * boundary exists to close.
+ */
+function hostDepsForCredentialStore(
+  store: OpenClawDeviceCredentialStore,
+  deviceIdentity: OpenClawDeviceIdentity,
+): GatewayClientHostDeps {
   return {
-    available: false,
-    reason: "Cave has no cross-platform OS-backed paired-device credential store for OpenClaw Gateway dispatch",
+    loadOrCreateDeviceIdentity: () => deviceIdentity,
+    signDevicePayload: signOpenClawDevicePayload,
+    publicKeyRawBase64UrlFromPem: openClawPublicKeyRawBase64UrlFromPem,
+    loadDeviceAuthToken: ({ deviceId, role }) => store.loadDeviceAuthToken({ deviceId, role }),
+    storeDeviceAuthToken: ({ deviceId, role, token, scopes }) =>
+      store.storeDeviceAuthToken({ deviceId, role, token, scopes }),
+    clearDeviceAuthToken: ({ deviceId, role }) => store.clearDeviceAuthToken({ deviceId, role }),
   };
 }
 
@@ -162,14 +190,22 @@ export async function dispatchOpenClawGatewayTurn(args: {
   env?: NodeJS.ProcessEnv;
   /** Injectable only so the official-client lifecycle can be tested without a live Gateway. */
   clientFactory?: GatewayClientFactory;
+  /** Injectable only so paired-device credential wiring can be tested without the OS keychain. */
+  credentialStore?: OpenClawDeviceCredentialStore;
 }): Promise<OpenClawGatewayDispatch> {
   const env = args.env ?? process.env;
   if (!gatewayDispatchEnabled(env)) return { kind: "unavailable", reason: "Gateway dispatch is disabled" };
-  const pairedDeviceAuth = openClawGatewayPairedDeviceAuthStatus();
+  // An injected test client without an injected store must never construct
+  // the real OS credential store: that path exists to exercise the client
+  // lifecycle hermetically and cannot create a real Gateway connection.
+  const credentialStore =
+    args.credentialStore ?? (args.clientFactory ? undefined : createOpenClawDeviceCredentialStore());
+  const pairedDeviceAuth: { available: boolean; reason?: string } = credentialStore
+    ? credentialStore.status()
+    : { available: false, reason: "Gateway paired-device authentication is unavailable" };
   // Keep this guard in the dispatcher as well as the route. A future caller
   // must not be able to turn an environment token into a write-capable
-  // Gateway session simply by bypassing the route-level fallback choice. The
-  // injectable port is test-only and cannot create a real Gateway connection.
+  // Gateway session simply by bypassing the route-level fallback choice.
   if (!pairedDeviceAuth.available && !args.clientFactory) {
     return { kind: "unavailable", reason: pairedDeviceAuth.reason ?? "Gateway paired-device authentication is unavailable" };
   }
@@ -178,6 +214,22 @@ export async function dispatchOpenClawGatewayTurn(args: {
   }
   const url = env[GATEWAY_URL_ENV];
   if (!nonEmptyString(url)) return { kind: "unavailable", reason: "Gateway URL is not configured" };
+  // Resolve the paired-device identity before any client is constructed. A
+  // keychain failure here is a pre-dispatch compatibility failure — the
+  // caller keeps the CLI fallback and no request can have reached the
+  // Gateway. When no store is in play (injected test client), the dispatcher
+  // proceeds without an identity exactly as before.
+  let deviceIdentity: OpenClawDeviceIdentity | undefined;
+  if (credentialStore && pairedDeviceAuth.available) {
+    try {
+      deviceIdentity = credentialStore.loadOrCreateDeviceIdentity();
+    } catch (error) {
+      return {
+        kind: "unavailable",
+        reason: error instanceof Error ? error.message : "The OpenClaw paired-device credential store failed",
+      };
+    }
+  }
 
   let client!: GatewayClientPort;
   let helloResolve: (() => void) | undefined;
@@ -283,11 +335,14 @@ export async function dispatchOpenClawGatewayTurn(args: {
 
   const clientOptions: ConstructorParameters<typeof GatewayClient>[0] = {
     url,
-    // Never let the Gateway client read Cave's process environment. The
-    // future paired-device boundary must provide identity and token lifecycle
-    // through hostDeps, rather than reviving token/device-token env auth.
+    // Never let the Gateway client read Cave's process environment. Identity
+    // and token lifecycle come only from the OS credential store via
+    // hostDeps, never from token/device-token env auth.
     // `GatewayClientOptions.env` requires NODE_ENV, which is non-secret.
     env: { NODE_ENV: process.env.NODE_ENV ?? "production" },
+    ...(deviceIdentity && credentialStore
+      ? { deviceIdentity, hostDeps: hostDepsForCredentialStore(credentialStore, deviceIdentity) }
+      : {}),
     clientName: "gateway-client",
     clientDisplayName: "Coven Cave",
     clientVersion: "2026.7.2-beta.4",

--- a/src/lib/server/openclaw-device-credentials.test.ts
+++ b/src/lib/server/openclaw-device-credentials.test.ts
@@ -1,0 +1,256 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import {
+  createOpenClawDeviceCredentialStore,
+  openClawDeviceCredentialStoreStatus,
+  openClawPublicKeyRawBase64UrlFromPem,
+  signOpenClawDevicePayload,
+} from "./openclaw-device-credentials.ts";
+
+const SERVICE = "coven-cave.openclaw-gateway";
+
+/**
+ * In-memory stand-in for the macOS keychain, speaking the exact `security`
+ * invocations the store issues. Every test in this file is hermetic: the real
+ * `/usr/bin/security` binary and keychain are never touched.
+ */
+function fakeKeychain() {
+  const items = new Map();
+  const invocations = [];
+  const runSecurity = (args, input) => {
+    invocations.push({ args, input });
+    if (args[0] === "find-generic-password") {
+      assert.deepEqual(args, ["find-generic-password", "-s", SERVICE, "-a", args[4], "-w"]);
+      const secret = items.get(args[4]);
+      if (secret === undefined) return { status: 44, stdout: "" };
+      return { status: 0, stdout: `${secret}\n` };
+    }
+    if (args[0] === "delete-generic-password") {
+      assert.deepEqual(args, ["delete-generic-password", "-s", SERVICE, "-a", args[4]]);
+      if (!items.has(args[4])) return { status: 44, stdout: "" };
+      items.delete(args[4]);
+      return { status: 0, stdout: "" };
+    }
+    // Writes must arrive in `-i` stdin command mode only: a secret on argv
+    // would be visible to every process on the machine.
+    assert.deepEqual(args, ["-i"], "keychain writes must use the security tool's stdin command mode");
+    const match = /^add-generic-password( -U)? -s "([^"]+)" -a "([^"]+)" -w "([^"]+)"\n$/.exec(input);
+    assert.ok(match, `unparseable security -i command: ${JSON.stringify(input)}`);
+    const [, update, service, account, secret] = match;
+    assert.equal(service, SERVICE);
+    if (!update && items.has(account)) return { status: 45, stdout: "" };
+    items.set(account, secret);
+    return { status: 0, stdout: "" };
+  };
+  return { items, invocations, runSecurity };
+}
+
+function darwinStore(keychain, overrides = {}) {
+  return createOpenClawDeviceCredentialStore({
+    platform: "darwin",
+    securityBinaryExists: () => true,
+    runSecurity: keychain.runSecurity,
+    ...overrides,
+  });
+}
+
+// --- availability ----------------------------------------------------------
+
+assert.deepEqual(
+  openClawDeviceCredentialStoreStatus({ platform: "linux" }),
+  {
+    available: false,
+    reason:
+      "OpenClaw Gateway dispatch requires the macOS Keychain credential store; linux has no supported OS credential store",
+  },
+  "non-macOS platforms fail closed",
+);
+assert.deepEqual(
+  openClawDeviceCredentialStoreStatus({ platform: "win32" }).available,
+  false,
+  "windows fails closed",
+);
+assert.deepEqual(
+  openClawDeviceCredentialStoreStatus({ platform: "darwin", securityBinaryExists: () => false }),
+  { available: false, reason: "The macOS security tool is unavailable for the OpenClaw credential store" },
+  "macOS without the security tool fails closed",
+);
+assert.deepEqual(
+  openClawDeviceCredentialStoreStatus({
+    platform: "darwin",
+    securityBinaryExists: () => true,
+    runSecurity: () => assert.fail("a status probe must not touch the keychain"),
+  }),
+  { available: true },
+  "the status probe is a platform/tool check only",
+);
+assert.throws(
+  () => createOpenClawDeviceCredentialStore({ platform: "linux" }).loadOrCreateDeviceIdentity(),
+  /no supported OS credential store/,
+  "identity resolution on an unsupported platform throws instead of inventing an unpaired identity",
+);
+
+// --- device identity lifecycle ---------------------------------------------
+
+const keychain = fakeKeychain();
+const store = darwinStore(keychain);
+const identity = store.loadOrCreateDeviceIdentity();
+assert.match(identity.deviceId, /^[0-9a-f]{64}$/, "deviceId is the sha256 fingerprint of the raw public key");
+// Functional PEM validation (stronger than shape-matching the markers): the
+// stored material must parse as an Ed25519 pair.
+assert.equal(crypto.createPublicKey(identity.publicKeyPem).asymmetricKeyType, "ed25519");
+assert.equal(crypto.createPrivateKey(identity.privateKeyPem).asymmetricKeyType, "ed25519");
+assert.equal(
+  identity.deviceId,
+  crypto
+    .createHash("sha256")
+    .update(Buffer.from(openClawPublicKeyRawBase64UrlFromPem(identity.publicKeyPem), "base64url"))
+    .digest("hex"),
+  "deviceId matches the reference fingerprint derivation (sha256 of the raw Ed25519 public key)",
+);
+
+const again = darwinStore(keychain).loadOrCreateDeviceIdentity();
+assert.deepEqual(again, identity, "a second resolution returns the persisted identity, never a fresh keypair");
+
+for (const invocation of keychain.invocations) {
+  const printable = invocation.args.join(" ");
+  assert.ok(
+    !printable.includes(identity.privateKeyPem) && !printable.includes("PRIVATE KEY"),
+    "no invocation may carry key material on argv",
+  );
+}
+
+// --- crypto contract ---------------------------------------------------------
+
+const raw = Buffer.from(openClawPublicKeyRawBase64UrlFromPem(identity.publicKeyPem), "base64url");
+assert.equal(raw.length, 32, "the Gateway contract sends the raw 32-byte Ed25519 public key");
+const signature = signOpenClawDevicePayload(identity.privateKeyPem, "challenge-payload");
+assert.ok(
+  crypto.verify(
+    null,
+    Buffer.from("challenge-payload", "utf8"),
+    crypto.createPublicKey(identity.publicKeyPem),
+    Buffer.from(signature, "base64url"),
+  ),
+  "signatures verify against the stored public key (base64url raw Ed25519)",
+);
+const rsa = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+assert.throws(
+  () => signOpenClawDevicePayload(rsa.privateKey.export({ type: "pkcs8", format: "pem" }).toString(), "x"),
+  /not an Ed25519 key/,
+  "non-Ed25519 key material is rejected instead of producing an unverifiable signature",
+);
+assert.throws(
+  () => openClawPublicKeyRawBase64UrlFromPem(rsa.publicKey.export({ type: "spki", format: "pem" }).toString()),
+  /not an Ed25519 key/,
+);
+
+// --- identity creation race ---------------------------------------------------
+
+const raceWinner = fakeKeychain();
+const winnerIdentity = darwinStore(raceWinner).loadOrCreateDeviceIdentity();
+let raceReads = 0;
+const racingStore = createOpenClawDeviceCredentialStore({
+  platform: "darwin",
+  securityBinaryExists: () => true,
+  runSecurity: (args, input) => {
+    if (args[0] === "find-generic-password") {
+      raceReads += 1;
+      // First read misses; by the time this process writes, another Cave
+      // process has already persisted the paired identity.
+      if (raceReads === 1) return { status: 44, stdout: "" };
+      return raceWinner.runSecurity(args, input);
+    }
+    if (args[0] === "-i") return { status: 45, stdout: "" };
+    return raceWinner.runSecurity(args, input);
+  },
+});
+assert.deepEqual(
+  racingStore.loadOrCreateDeviceIdentity(),
+  winnerIdentity,
+  "losing the identity-creation race adopts the winner's paired identity instead of clobbering it",
+);
+
+// --- invalid persisted identity ------------------------------------------------
+
+const corrupt = fakeKeychain();
+corrupt.items.set("device-identity", Buffer.from("not json").toString("base64"));
+assert.throws(
+  () => darwinStore(corrupt).loadOrCreateDeviceIdentity(),
+  /invalid OpenClaw device identity/,
+  "a corrupted identity fails loudly",
+);
+assert.equal(
+  corrupt.items.get("device-identity"),
+  Buffer.from("not json").toString("base64"),
+  "a corrupted paired identity is never silently replaced — replacement would unpair the device",
+);
+
+const mismatched = fakeKeychain();
+const otherIdentity = darwinStore(fakeKeychain()).loadOrCreateDeviceIdentity();
+mismatched.items.set(
+  "device-identity",
+  Buffer.from(
+    JSON.stringify({ version: 1, ...otherIdentity, deviceId: "f".repeat(64) }),
+    "utf8",
+  ).toString("base64"),
+);
+assert.throws(
+  () => darwinStore(mismatched).loadOrCreateDeviceIdentity(),
+  /invalid OpenClaw device identity/,
+  "an identity whose deviceId does not match its key material is rejected",
+);
+
+// --- device token lifecycle ------------------------------------------------------
+
+const tokenParams = { deviceId: identity.deviceId, role: "operator" };
+assert.equal(store.loadDeviceAuthToken(tokenParams), null, "no stored token yields null, not a fabricated record");
+store.storeDeviceAuthToken({ ...tokenParams, token: "minted-token", scopes: ["operator.read", "operator.write"] });
+assert.deepEqual(
+  store.loadDeviceAuthToken(tokenParams),
+  { token: "minted-token", scopes: ["operator.read", "operator.write"] },
+  "a minted device token round-trips through the keychain",
+);
+assert.equal(
+  store.loadDeviceAuthToken({ deviceId: identity.deviceId, role: "node" }),
+  null,
+  "tokens are scoped per role",
+);
+store.storeDeviceAuthToken({ ...tokenParams, token: "rotated-token", scopes: ["operator.read"] });
+assert.deepEqual(
+  store.loadDeviceAuthToken(tokenParams),
+  { token: "rotated-token", scopes: ["operator.read"] },
+  "storing again updates the existing item",
+);
+store.clearDeviceAuthToken(tokenParams);
+assert.equal(store.loadDeviceAuthToken(tokenParams), null, "cleared tokens stay cleared");
+store.clearDeviceAuthToken(tokenParams); // idempotent: a missing item is not an error
+
+// The token hooks swallow store errors by contract (a keychain hiccup on the
+// connect path degrades to fresh pairing); a hostile role must therefore be
+// rejected silently, and above all must never reach a keychain command line.
+store.storeDeviceAuthToken({ deviceId: identity.deviceId, role: 'operator" -w "x', token: "t", scopes: [] });
+assert.equal(
+  [...keychain.items.keys()].some((account) => account.includes('"')),
+  false,
+  "no keychain account may embed quoting metacharacters",
+);
+assert.equal(
+  store.loadDeviceAuthToken({ deviceId: identity.deviceId, role: 'operator" -w "x' }),
+  null,
+  "hostile role strings resolve to no stored token",
+);
+
+// A keychain failure while the connect path loads tokens degrades to
+// "no stored token" instead of throwing into the Gateway client.
+const failing = createOpenClawDeviceCredentialStore({
+  platform: "darwin",
+  securityBinaryExists: () => true,
+  runSecurity: () => ({ status: 51, stdout: "" }),
+});
+assert.equal(failing.loadDeviceAuthToken(tokenParams), null);
+failing.storeDeviceAuthToken({ ...tokenParams, token: "t", scopes: [] });
+failing.clearDeviceAuthToken(tokenParams);
+
+console.log("openclaw device credential store tests passed");

--- a/src/lib/server/openclaw-device-credentials.ts
+++ b/src/lib/server/openclaw-device-credentials.ts
@@ -1,0 +1,316 @@
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import fs from "node:fs";
+
+/**
+ * OS-backed paired-device credential store for OpenClaw Gateway dispatch.
+ *
+ * The published `@openclaw/gateway-client` delegates device-identity creation,
+ * challenge signing, and device-token lifecycle to host-owned dependencies.
+ * Cave backs those with the macOS Keychain through `/usr/bin/security` so a
+ * write-capable Gateway session can never be activated from process
+ * environment tokens: `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_DEVICE_TOKEN`
+ * are deliberately never read, and the `env` bag the client passes to the
+ * token hooks is deliberately ignored. Platforms without a supported OS
+ * credential store fail closed to the CLI/plain-chat fallback.
+ */
+
+const KEYCHAIN_SERVICE = "coven-cave.openclaw-gateway";
+const IDENTITY_ACCOUNT = "device-identity";
+const SECURITY_BIN = "/usr/bin/security";
+const IDENTITY_VERSION = 1;
+const TOKEN_VERSION = 1;
+const ED25519_RAW_KEY_LENGTH = 32;
+/** Exit statuses of the `security` tool for the two expected non-zero cases. */
+const SECURITY_ITEM_NOT_FOUND = 44;
+const SECURITY_DUPLICATE_ITEM = 45;
+/** Keychain command values are pinned to this alphabet before quoting. */
+const SAFE_VALUE_PATTERN = /^[A-Za-z0-9._+/=-]+$/;
+
+export type OpenClawDeviceIdentity = {
+  deviceId: string;
+  privateKeyPem: string;
+  publicKeyPem: string;
+};
+
+export type OpenClawDeviceTokenRecord = {
+  token?: string;
+  scopes?: string[];
+};
+
+export type OpenClawCredentialStoreStatus = { available: boolean; reason?: string };
+
+export class OpenClawCredentialStoreError extends Error {
+  constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+    this.name = "OpenClawCredentialStoreError";
+  }
+}
+
+type SecurityResult = { status: number; stdout: string };
+
+export type OpenClawCredentialStoreDeps = {
+  platform?: NodeJS.Platform;
+  securityBinaryExists?: () => boolean;
+  /**
+   * Runs the `security` tool. `input`, when present, is the tool's stdin in
+   * `-i` command mode — the only channel secrets may travel through; argv is
+   * visible to every process on the machine.
+   */
+  runSecurity?: (args: string[], input?: string) => SecurityResult;
+};
+
+export type OpenClawDeviceCredentialStore = {
+  status: () => OpenClawCredentialStoreStatus;
+  /** Throws {@link OpenClawCredentialStoreError}; never silently regenerates a paired identity. */
+  loadOrCreateDeviceIdentity: () => OpenClawDeviceIdentity;
+  loadDeviceAuthToken: (params: { deviceId: string; role: string }) => OpenClawDeviceTokenRecord | null;
+  storeDeviceAuthToken: (params: { deviceId: string; role: string; token: string; scopes: string[] }) => void;
+  clearDeviceAuthToken: (params: { deviceId: string; role: string }) => void;
+};
+
+function base64Url(bytes: Buffer): string {
+  return bytes.toString("base64url");
+}
+
+function ed25519RawPublicKey(publicKeyPem: string): Buffer {
+  const key = crypto.createPublicKey(publicKeyPem);
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new OpenClawCredentialStoreError("OpenClaw device public key is not an Ed25519 key");
+  }
+  const spki = key.export({ type: "spki", format: "der" });
+  return Buffer.from(spki.subarray(spki.length - ED25519_RAW_KEY_LENGTH));
+}
+
+/** Matches the Gateway contract: base64url of the raw Ed25519 signature over the UTF-8 payload. */
+export function signOpenClawDevicePayload(privateKeyPem: string, payload: string): string {
+  const key = crypto.createPrivateKey(privateKeyPem);
+  if (key.asymmetricKeyType !== "ed25519") {
+    throw new OpenClawCredentialStoreError("OpenClaw device private key is not an Ed25519 key");
+  }
+  return base64Url(crypto.sign(null, Buffer.from(payload, "utf8"), key));
+}
+
+/** Matches the Gateway contract: base64url of the raw 32-byte Ed25519 public key. */
+export function openClawPublicKeyRawBase64UrlFromPem(publicKeyPem: string): string {
+  return base64Url(ed25519RawPublicKey(publicKeyPem));
+}
+
+function deviceIdFromPublicKeyPem(publicKeyPem: string): string {
+  return crypto.createHash("sha256").update(ed25519RawPublicKey(publicKeyPem)).digest("hex");
+}
+
+function generateDeviceIdentity(): OpenClawDeviceIdentity {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
+  const publicKeyPem = publicKey.export({ type: "spki", format: "pem" }).toString();
+  const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" }).toString();
+  return { deviceId: deviceIdFromPublicKeyPem(publicKeyPem), publicKeyPem, privateKeyPem };
+}
+
+function safeValue(value: string, label: string): string {
+  if (!SAFE_VALUE_PATTERN.test(value)) {
+    throw new OpenClawCredentialStoreError(`OpenClaw credential ${label} contains unsupported characters`);
+  }
+  return value;
+}
+
+function tokenAccount(deviceId: string, role: string): string {
+  return `device-token.${safeValue(role, "role")}.${safeValue(deviceId, "device id")}`;
+}
+
+function encodePayload(record: unknown): string {
+  return Buffer.from(JSON.stringify(record), "utf8").toString("base64");
+}
+
+function decodePayload(secret: string): unknown {
+  return JSON.parse(Buffer.from(secret.trim(), "base64").toString("utf8"));
+}
+
+function defaultRunSecurity(args: string[], input?: string): SecurityResult {
+  try {
+    const stdout = execFileSync(SECURITY_BIN, args, {
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+      ...(input === undefined ? {} : { input }),
+    });
+    return { status: 0, stdout };
+  } catch (error) {
+    const status = (error as { status?: unknown }).status;
+    const stdout = (error as { stdout?: unknown }).stdout;
+    return {
+      status: typeof status === "number" ? status : 1,
+      stdout: typeof stdout === "string" ? stdout : "",
+    };
+  }
+}
+
+function parseStoredIdentity(secret: string): OpenClawDeviceIdentity {
+  let record: unknown;
+  try {
+    record = decodePayload(secret);
+  } catch (error) {
+    throw invalidIdentityError(error);
+  }
+  if (
+    !record ||
+    typeof record !== "object" ||
+    (record as { version?: unknown }).version !== IDENTITY_VERSION
+  ) {
+    throw invalidIdentityError();
+  }
+  const { deviceId, publicKeyPem, privateKeyPem } = record as Record<string, unknown>;
+  if (typeof deviceId !== "string" || typeof publicKeyPem !== "string" || typeof privateKeyPem !== "string") {
+    throw invalidIdentityError();
+  }
+  try {
+    if (deviceIdFromPublicKeyPem(publicKeyPem) !== deviceId) throw invalidIdentityError();
+    // Proves the private key parses and belongs to the stored public key.
+    const probe = signOpenClawDevicePayload(privateKeyPem, "coven-cave.identity-probe");
+    const valid = crypto.verify(
+      null,
+      Buffer.from("coven-cave.identity-probe", "utf8"),
+      crypto.createPublicKey(publicKeyPem),
+      Buffer.from(probe, "base64url"),
+    );
+    if (!valid) throw invalidIdentityError();
+  } catch (error) {
+    throw error instanceof OpenClawCredentialStoreError ? error : invalidIdentityError(error);
+  }
+  return { deviceId, publicKeyPem, privateKeyPem };
+}
+
+function invalidIdentityError(cause?: unknown): OpenClawCredentialStoreError {
+  return new OpenClawCredentialStoreError(
+    `The macOS Keychain holds an invalid OpenClaw device identity (service "${KEYCHAIN_SERVICE}"). ` +
+      "Cave will not silently replace a paired identity; delete the item in Keychain Access to re-pair.",
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+export function createOpenClawDeviceCredentialStore(
+  deps: OpenClawCredentialStoreDeps = {},
+): OpenClawDeviceCredentialStore {
+  const platform = deps.platform ?? process.platform;
+  const securityBinaryExists = deps.securityBinaryExists ?? (() => fs.existsSync(SECURITY_BIN));
+  const runSecurity = deps.runSecurity ?? defaultRunSecurity;
+
+  const status = (): OpenClawCredentialStoreStatus => {
+    if (platform !== "darwin") {
+      return {
+        available: false,
+        reason: `OpenClaw Gateway dispatch requires the macOS Keychain credential store; ${platform} has no supported OS credential store`,
+      };
+    }
+    if (!securityBinaryExists()) {
+      return { available: false, reason: "The macOS security tool is unavailable for the OpenClaw credential store" };
+    }
+    return { available: true };
+  };
+
+  const requireAvailable = () => {
+    const current = status();
+    if (!current.available) {
+      throw new OpenClawCredentialStoreError(current.reason ?? "The OpenClaw credential store is unavailable");
+    }
+  };
+
+  const readSecret = (account: string): string | null => {
+    const result = runSecurity(["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account, "-w"]);
+    if (result.status === 0) return result.stdout;
+    if (result.status === SECURITY_ITEM_NOT_FOUND) return null;
+    throw new OpenClawCredentialStoreError(
+      `The macOS Keychain rejected an OpenClaw credential read (security exited ${result.status})`,
+    );
+  };
+
+  // `-i` command mode keeps the secret on stdin; `add-generic-password -w <v>`
+  // on argv would expose it to every process on the machine.
+  const writeSecret = (account: string, secret: string, params: { update: boolean }): number => {
+    const command = [
+      "add-generic-password",
+      params.update ? "-U" : null,
+      `-s "${safeValue(KEYCHAIN_SERVICE, "service")}"`,
+      `-a "${safeValue(account, "account")}"`,
+      `-w "${safeValue(secret, "secret")}"`,
+    ]
+      .filter(Boolean)
+      .join(" ");
+    const result = runSecurity(["-i"], `${command}\n`);
+    return result.status;
+  };
+
+  const deleteSecret = (account: string): void => {
+    const result = runSecurity(["delete-generic-password", "-s", KEYCHAIN_SERVICE, "-a", account]);
+    if (result.status !== 0 && result.status !== SECURITY_ITEM_NOT_FOUND) {
+      throw new OpenClawCredentialStoreError(
+        `The macOS Keychain rejected an OpenClaw credential removal (security exited ${result.status})`,
+      );
+    }
+  };
+
+  return {
+    status,
+    loadOrCreateDeviceIdentity: () => {
+      requireAvailable();
+      const existing = readSecret(IDENTITY_ACCOUNT);
+      if (existing !== null) return parseStoredIdentity(existing);
+      const identity = generateDeviceIdentity();
+      const payload = encodePayload({ version: IDENTITY_VERSION, ...identity });
+      const written = writeSecret(IDENTITY_ACCOUNT, payload, { update: false });
+      if (written === 0) return identity;
+      if (written === SECURITY_DUPLICATE_ITEM) {
+        // Another Cave process created the identity between our read and
+        // write. The keychain copy is the paired one; ours is discarded.
+        const winner = readSecret(IDENTITY_ACCOUNT);
+        if (winner !== null) return parseStoredIdentity(winner);
+      }
+      throw new OpenClawCredentialStoreError(
+        `The macOS Keychain rejected the OpenClaw device identity write (security exited ${written})`,
+      );
+    },
+    // The token hooks run inside the Gateway client's connect path; a keychain
+    // hiccup there must degrade to "no stored token" (fresh challenge pairing),
+    // not tear down the transport with an exception it cannot attribute.
+    loadDeviceAuthToken: ({ deviceId, role }) => {
+      try {
+        const secret = readSecret(tokenAccount(deviceId, role));
+        if (secret === null) return null;
+        const record = decodePayload(secret);
+        if (!record || typeof record !== "object" || (record as { version?: unknown }).version !== TOKEN_VERSION) {
+          return null;
+        }
+        const { token, scopes } = record as Record<string, unknown>;
+        if (typeof token !== "string" || token.length === 0) return null;
+        return {
+          token,
+          scopes: Array.isArray(scopes) ? scopes.filter((scope): scope is string => typeof scope === "string") : [],
+        };
+      } catch {
+        return null;
+      }
+    },
+    storeDeviceAuthToken: ({ deviceId, role, token, scopes }) => {
+      try {
+        if (typeof token !== "string" || token.length === 0) return;
+        const payload = encodePayload({ version: TOKEN_VERSION, token, scopes });
+        writeSecret(tokenAccount(deviceId, role), payload, { update: true });
+      } catch {
+        // A token that fails to persist only costs a re-pair on the next
+        // connect; it must not break the in-flight authenticated session.
+      }
+    },
+    clearDeviceAuthToken: ({ deviceId, role }) => {
+      try {
+        deleteSecret(tokenAccount(deviceId, role));
+      } catch {
+        // Same degradation contract as storeDeviceAuthToken.
+      }
+    },
+  };
+}
+
+export function openClawDeviceCredentialStoreStatus(
+  deps: OpenClawCredentialStoreDeps = {},
+): OpenClawCredentialStoreStatus {
+  return createOpenClawDeviceCredentialStore(deps).status();
+}


### PR DESCRIPTION
## Summary

Implements **cave-cth7q** — the Cave-side blocker keeping the merged OpenClaw Gateway dispatch path (#3905) dormant. The published `@openclaw/gateway-client` delegates device identity, challenge signing, and device-token lifecycle to host-owned `GatewayClientHostDeps`; until now `openClawGatewayPairedDeviceAuthStatus()` hard-returned unavailable, so every OpenClaw turn rode the CLI fallback.

- **New `src/lib/server/openclaw-device-credentials.ts`** — macOS-Keychain-backed store (service `coven-cave.openclaw-gateway`) for the Ed25519 device identity (deviceId = sha256 of the raw public key, matching the reference derivation) and Gateway-minted device tokens keyed per `(deviceId, role)`. Writes go through the `security` tool's **stdin command mode** (`security -i`) so secrets never appear on argv; all command values are pinned to a safe alphabet first.
- **`openclaw-gateway.ts`** — the auth status now probes the store (platform + tool presence only, no keychain reads); the dispatcher resolves the paired identity **before client construction** and wires `deviceIdentity` + `hostDeps` into the published client. The hostDeps deliberately drop the `env` bag the client threads through its token hooks.
- Plan doc updated (`docs/specs/2026-07-25-openclaw-gateway-dispatch-plan.md`), including a re-verification note that `gateway-protocol@2026.7.2-beta.5` still publishes no tool-event contract for dispatched runs (tool cards stay disabled; cave-53iko.4 remains blocked upstream).

## Security invariants (all tested)

- `OPENCLAW_GATEWAY_TOKEN` / `OPENCLAW_GATEWAY_DEVICE_TOKEN` still cannot activate a write-capable direct turn; the client env stays `{NODE_ENV}` only.
- Non-macOS platforms (and macOS without `/usr/bin/security`) fail closed before any client is constructed; the CLI bridge remains the fallback.
- An invalid persisted identity fails loudly and is never silently regenerated (regeneration would silently unpair the device).
- Losing the identity-creation race against another Cave process adopts the winner's paired identity.
- Token-hook keychain failures degrade to fresh challenge pairing instead of throwing into the client's connect path.
- Injected test clients without an injected store never touch the real keychain.

**Default behavior is unchanged everywhere**: dispatch remains opt-in behind `OPENCLAW_GATEWAY_DISPATCH=1` + `OPENCLAW_GATEWAY_URL`.

## Tests

- New hermetic suite `src/lib/server/openclaw-device-credentials.test.ts` (fake keychain speaking the exact `security` invocations; identity round-trip/race/corruption, crypto contract incl. signature verify + raw-32-byte key, token lifecycle, hostile-role quoting, degradation).
- `openclaw-gateway.test.ts` extended with credential-wiring assertions (identity/hostDeps reach the client, env-bag dropped, store failure retains CLI fallback) and updated availability pins.
- `tsc --noEmit` clean; check-tests-wired green; all openclaw + route tool-event suites pass.

Closes cave-cth7q (bd). Unblocks the runtime half of cave-53iko.4; its tool-card half stays blocked on an upstream published tool payload validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)