### PR TITLE
refactor(chat): extract the composer's four accordion sections

### DIFF
--- a/src/components/github-card-composer.tsx
+++ b/src/components/github-card-composer.tsx
@@ -27,6 +27,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Icon, type IconName } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { FamiliarSection } from "@/components/github-card/familiar-section";
+import { GateSection } from "@/components/github-card/gate-section";
+import { MergeSection } from "@/components/github-card/merge-section";
+import { MetaSection } from "@/components/github-card/meta-section";
+import { METHOD_LABEL, seg, segTight, type Method } from "@/components/github-card/shared";
 import {
   buildCommandTree,
   parseCommand,
@@ -75,7 +80,6 @@ export type GhComposerThread = {
 type Phase = "rest" | "open" | "sending" | "error" | "merged";
 type Section = "" | "gate" | "merge" | "meta" | "fam";
 type Mode = "comment" | "approve" | "request" | "merge";
-type Method = "squash" | "merge" | "rebase";
 
 type Reaction = { content: string; count: number; mine: number | null };
 
@@ -97,8 +101,6 @@ const VERB: Record<Mode, string> = {
   request: "Request changes",
   merge: "Merge",
 };
-
-const METHOD_LABEL: Record<Method, string> = { squash: "squash", merge: "merge commit", rebase: "rebase" };
 
 /** Markdown toolbar: three clusters — emphasis · blocks · refs. */
 type Tool = {
@@ -746,6 +748,7 @@ export function GitHubCardComposer({
     unresolved.length === 0
       ? "all threads resolved"
       : `${unresolved.length} unresolved thread${unresolved.length === 1 ? "" : "s"}`;
+  const threadNote = unresolved[0]?.path ? `1 unresolved in ${unresolved[0].path}` : threadLabel;
 
   const baseRef = item.pull?.baseRef ?? "the base branch";
   const commits = item.pull?.commits ?? null;
@@ -759,12 +762,26 @@ export function GitHubCardComposer({
         : commits
           ? `${commits} commits replayed`
           : "commits replayed";
+  const commitTitle =
+    method === "merge"
+      ? `Merge pull request #${number}${item.pull?.headRef ? ` from ${item.pull.headRef}` : ""}`
+      : `${item.title} (#${number})`;
+
+  const peopleSummary = people.length ? people.join(", ") : "unassigned";
+  const labelSummary = labels.length ? labels.join(" · ") : "no labels";
+  const labelPalette = palette.length ? palette : item.labels;
+  const labelColor = (name: string) =>
+    (palette.find((p) => p.name === name) ?? item.labels.find((l) => l.name === name))?.color;
+
+  const scopeChoices: [keyof GhDraftScopes, string][] = [
+    ["files", item.isPull ? "changed files" : "description"],
+    ["threads", `${unresolved.length} open thread${unresolved.length === 1 ? "" : "s"}`],
+    ["checks", "failing checks"],
+  ];
+  const famSummary = drafting ? "drafting…" : famDraft ? "draft ready · review before sending" : "reads what you allow";
 
   const draftStateLabel = restored ? "draft restored" : body.length ? "draft saved" : "no draft";
   const draftStateCls = restored ? " ghc-draftstate--restored" : body.length ? " ghc-draftstate--saved" : "";
-
-  const seg = (on: boolean) => `ghc-seg__item focus-ring${on ? " ghc-seg__item--on" : ""}`;
-  const segTight = (on: boolean) => `ghc-seg__item ghc-seg__item--tight focus-ring${on ? " ghc-seg__item--on" : ""}`;
 
   // ── phases that replace the sheet entirely ────────────────────────────────
 
@@ -1064,420 +1081,92 @@ export function GitHubCardComposer({
 
         {/* ── Gate ── */}
         {mergeable ? (
-          <>
-            <button
-              type="button"
-              className="ghc-sec focus-ring"
-              aria-expanded={sec === "gate"}
-              aria-label="Gate — checks, reviews and threads"
-              onClick={() => toggleSec("gate")}
-            >
-              <span aria-hidden className={`ghc-sec__caret${sec === "gate" ? " ghc-sec__caret--open" : ""}`}>
-                <Icon name="ph:caret-right" width={11} />
-              </span>
-              <span aria-hidden className={`ghc-sec__icon ${gateOk ? "ghc-sec__ok" : "ghc-sec__warn"}`}>
-                <Icon name={gateOk ? "ph:check-circle" : "ph:warning-circle"} width={13} />
-              </span>
-              <span className="ghc-sec__title">Gate</span>
-              <span className="ghc-sec__summary">
-                <span className="ghc-sec__mono">{checksLabel}</span>
-                {reviewLabel ? <span>{reviewLabel}</span> : null}
-                <span className={unresolved.length ? "ghc-sec__warn" : "ghc-sec__ok"}>{threadLabel}</span>
-              </span>
-            </button>
-            {sec === "gate" ? (
-              <div className="ghc-body">
-                <div className="ghc-gate-row">
-                  <span aria-hidden className={`ghc-gate-row__icon ${checks?.counts.failed ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
-                    <Icon name={checks?.counts.failed ? "ph:x-circle-fill" : "ph:check-circle"} width={12} />
-                  </span>
-                  Checks
-                  <span className="ghc-gate-row__tail">
-                    <span className="ghc-gate-row__note">{checksLabel}</span>
-                    {checks && checks.counts.total > 0 ? (
-                      <button
-                        type="button"
-                        className="ghc-mini focus-ring"
-                        onClick={() => void rerunChecks(true)}
-                        disabled={busy === "checks"}
-                      >
-                        {busy === "checks" ? "…" : "Re-run"}
-                      </button>
-                    ) : null}
-                  </span>
-                </div>
-                {reviewLabel ? (
-                  <div className="ghc-gate-row">
-                    <span aria-hidden className={`ghc-gate-row__icon ${reviews?.changesRequested ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
-                      <Icon name={reviews?.changesRequested ? "ph:warning-circle" : "ph:check-circle"} width={12} />
-                    </span>
-                    Reviews
-                    <span className="ghc-gate-row__tail">
-                      <span className="ghc-gate-row__note">{reviewLabel}</span>
-                    </span>
-                  </div>
-                ) : null}
-                <div className="ghc-gate-row">
-                  <span aria-hidden className={`ghc-gate-row__icon ${unresolved.length ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
-                    <Icon name={unresolved.length ? "ph:warning-circle" : "ph:check-circle"} width={12} />
-                  </span>
-                  Threads
-                  <span className="ghc-gate-row__tail">
-                    <span className="ghc-gate-row__note">
-                      {unresolved[0]?.path ? `1 unresolved in ${unresolved[0].path}` : threadLabel}
-                    </span>
-                    {unresolved[0] ? (
-                      <button
-                        type="button"
-                        className="ghc-mini focus-ring"
-                        onClick={() => void resolveThread(unresolved[0].id)}
-                        disabled={busy === unresolved[0].id}
-                      >
-                        {busy === unresolved[0].id ? "…" : "Resolve"}
-                      </button>
-                    ) : null}
-                  </span>
-                </div>
-              </div>
-            ) : null}
-          </>
+          <GateSection
+            expanded={sec === "gate"}
+            onToggle={() => toggleSec("gate")}
+            gateOk={gateOk}
+            checksLabel={checksLabel}
+            reviewLabel={reviewLabel}
+            threadLabel={threadLabel}
+            threadNote={threadNote}
+            unresolvedCount={unresolved.length}
+            failedChecks={checks?.counts.failed ?? 0}
+            changesRequested={reviews?.changesRequested ?? 0}
+            canRerunChecks={Boolean(checks && checks.counts.total > 0)}
+            checksBusy={busy === "checks"}
+            threadBusy={Boolean(unresolved[0]) && busy === unresolved[0]?.id}
+            onRerunFailedChecks={() => void rerunChecks(true)}
+            onResolveFirstThread={() => void resolveThread(unresolved[0].id)}
+          />
         ) : null}
 
         {/* ── Merge ── */}
         {mergeable ? (
-          <>
-            <button
-              type="button"
-              className="ghc-sec focus-ring"
-              aria-expanded={sec === "merge"}
-              aria-label="Merge — method, commit and branch"
-              onClick={() => toggleSec("merge")}
-            >
-              <span aria-hidden className={`ghc-sec__caret${sec === "merge" ? " ghc-sec__caret--open" : ""}`}>
-                <Icon name="ph:caret-right" width={11} />
-              </span>
-              <span aria-hidden className="ghc-sec__icon">
-                <Icon name="ph:git-merge" width={13} />
-              </span>
-              <span className="ghc-sec__title">Merge</span>
-              <span className="ghc-sec__summary">
-                <span>
-                  {METHOD_LABEL[method]} → {baseRef}
-                </span>
-                <span>{commitSummary}</span>
-                <span>{delBranch ? "delete branch" : "keep branch"}</span>
-              </span>
-            </button>
-            {sec === "merge" ? (
-              <div className="ghc-body ghc-body--roomy">
-                <div className="ghc-row">
-                  <div className="ghc-seg ghc-seg--sunken">
-                    {(["squash", "merge", "rebase"] as Method[]).map((m) => (
-                      <button
-                        key={m}
-                        type="button"
-                        className={segTight(method === m)}
-                        onClick={() => setMethod(m)}
-                        aria-pressed={method === m}
-                      >
-                        {m === "squash" ? "Squash" : m === "merge" ? "Merge commit" : "Rebase"}
-                      </button>
-                    ))}
-                  </div>
-                  {item.pull?.headRef ? (
-                    <button
-                      type="button"
-                      className="ghc-switch focus-ring"
-                      aria-pressed={delBranch}
-                      aria-label={`Delete ${item.pull.headRef} after merging`}
-                      onClick={() => setDelBranch((v) => !v)}
-                    >
-                      <span aria-hidden className={`ghc-switch__track${delBranch ? " ghc-switch__track--on" : ""}`}>
-                        <span className="ghc-switch__knob" />
-                      </span>
-                      delete <span className="ghc-switch__branch">{item.pull.headRef}</span>
-                    </button>
-                  ) : null}
-                </div>
-                <div className="ghc-commit">
-                  <div className="ghc-commit__head">
-                    <span className="ghc-commit__eyebrow">COMMIT</span>
-                    <span className="ghc-commit__method">{METHOD_LABEL[method]}</span>
-                  </div>
-                  <div className="ghc-commit__title">
-                    {method === "merge"
-                      ? `Merge pull request #${number}${item.pull?.headRef ? ` from ${item.pull.headRef}` : ""}`
-                      : `${item.title} (#${number})`}
-                  </div>
-                </div>
-                <div className={`ghc-arm${nudge === "arm" ? " ghc-arm--nudged" : ""}`}>
-                  <span className="ghc-arm__label">type</span>
-                  <span className="ghc-arm__word">merge</span>
-                  <span className="ghc-arm__label">to arm</span>
-                  <input
-                    ref={armRef}
-                    className="ghc-arm__input focus-ring"
-                    value={arm}
-                    onChange={(e) => {
-                      setArm(e.target.value);
-                      setNudge("");
-                    }}
-                    placeholder="…"
-                    aria-label="Type merge to arm the merge button"
-                  />
-                  {armed ? (
-                    <span aria-hidden className="ghc-arm__ok">
-                      <Icon name="ph:check" width={12} />
-                    </span>
-                  ) : null}
-                </div>
-              </div>
-            ) : null}
-          </>
+          <MergeSection
+            expanded={sec === "merge"}
+            onToggle={() => toggleSec("merge")}
+            method={method}
+            onSelectMethod={(m) => setMethod(m)}
+            baseRef={baseRef}
+            commitSummary={commitSummary}
+            headRef={item.pull?.headRef ?? null}
+            deleteBranch={delBranch}
+            onToggleDeleteBranch={() => setDelBranch((v) => !v)}
+            commitTitle={commitTitle}
+            arm={arm}
+            onArmChange={(value) => {
+              setArm(value);
+              setNudge("");
+            }}
+            armed={armed}
+            nudged={nudge === "arm"}
+            armRef={armRef}
+          />
         ) : null}
 
         {/* ── Assignees & labels ── */}
-        <button
-          type="button"
-          className="ghc-sec focus-ring"
-          aria-expanded={sec === "meta"}
-          aria-label="Assignees and labels"
-          onClick={() => toggleSec("meta")}
-        >
-          <span aria-hidden className={`ghc-sec__caret${sec === "meta" ? " ghc-sec__caret--open" : ""}`}>
-            <Icon name="ph:caret-right" width={11} />
-          </span>
-          <span aria-hidden className="ghc-sec__icon">
-            <Icon name="ph:tag" width={13} />
-          </span>
-          <span className="ghc-sec__title">Assignees &amp; labels</span>
-          <span className="ghc-sec__summary">
-            <span>{people.length ? people.join(", ") : "unassigned"}</span>
-            <span>{labels.length ? labels.join(" · ") : "no labels"}</span>
-          </span>
-        </button>
-        {sec === "meta" ? (
-          <div className="ghc-body ghc-body--roomy">
-            <div className="ghc-field">
-              <span className="ghc-field__label">assignees</span>
-              <div className="ghc-field__body">
-                {people.map((p) => (
-                  <span key={p} className="ghc-chip">
-                    <span aria-hidden className="ghc-avatar">
-                      {p.slice(0, 1).toUpperCase()}
-                    </span>
-                    {p}
-                    <button
-                      type="button"
-                      className="ghc-chip__x focus-ring"
-                      onClick={() => togglePerson(p)}
-                      aria-label={`Unassign ${p}`}
-                    >
-                      <Icon name="ph:x" width={8} aria-hidden />
-                    </button>
-                  </span>
-                ))}
-                <button
-                  type="button"
-                  className="ghc-add focus-ring"
-                  aria-expanded={pick === "people"}
-                  onClick={() => setPick((v) => (v === "people" ? "" : "people"))}
-                >
-                  <Icon name="ph:plus" width={9} aria-hidden />
-                  add
-                </button>
-                {pick === "people" ? (
-                  <div className="ghc-picker">
-                    <div className="ghc-pal__label">PEOPLE</div>
-                    <div className="ghc-pal__rows">
-                      {mentionRoster.map((p) => (
-                        <button
-                          key={p.login}
-                          type="button"
-                          className={`ghc-pal__row ghc-pal__row--person focus-ring${people.includes(p.login) ? " ghc-pal__row--active" : ""}`}
-                          onClick={() => togglePerson(p.login)}
-                        >
-                          <span aria-hidden className="ghc-avatar">
-                            {p.login.slice(0, 1).toUpperCase()}
-                          </span>
-                          <span className="ghc-pal__name">{p.login}</span>
-                          <span className="ghc-pal__role">{p.role}</span>
-                          <span className="ghc-pal__state">{people.includes(p.login) ? "assigned" : ""}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-            <div className="ghc-field">
-              <span className="ghc-field__label">labels</span>
-              <div className="ghc-field__body">
-                {labels.map((name) => {
-                  const hex = (palette.find((p) => p.name === name) ?? item.labels.find((l) => l.name === name))?.color;
-                  return (
-                    <span key={name} className="ghc-chip ghc-chip--label">
-                      <span
-                        aria-hidden
-                        className="ghc-chip__dot"
-                        style={hex ? { background: `#${hex}` } : undefined}
-                      />
-                      {name}
-                      <button
-                        type="button"
-                        className="ghc-chip__x focus-ring"
-                        onClick={() => toggleLabel(name)}
-                        aria-label={`Remove label ${name}`}
-                      >
-                        <Icon name="ph:x" width={8} aria-hidden />
-                      </button>
-                    </span>
-                  );
-                })}
-                <button
-                  type="button"
-                  className="ghc-add ghc-add--label focus-ring"
-                  aria-expanded={pick === "labels"}
-                  onClick={() => setPick((v) => (v === "labels" ? "" : "labels"))}
-                >
-                  <Icon name="ph:plus" width={9} aria-hidden />
-                  add
-                </button>
-                {pick === "labels" ? (
-                  <div className="ghc-picker">
-                    <div className="ghc-pal__label">REPO LABELS</div>
-                    <div className="ghc-pal__rows">
-                      {(palette.length ? palette : item.labels).map((l) => (
-                        <button
-                          key={l.name}
-                          type="button"
-                          className={`ghc-pal__row ghc-pal__row--person focus-ring${labels.includes(l.name) ? " ghc-pal__row--active" : ""}`}
-                          onClick={() => toggleLabel(l.name)}
-                        >
-                          <span
-                            aria-hidden
-                            className="ghc-chip__dot"
-                            style={l.color ? { background: `#${l.color}` } : undefined}
-                          />
-                          <span className="ghc-pal__name">{l.name}</span>
-                          <span className="ghc-pal__state">{labels.includes(l.name) ? "applied" : ""}</span>
-                        </button>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            </div>
-          </div>
-        ) : null}
+        <MetaSection
+          expanded={sec === "meta"}
+          onToggle={() => toggleSec("meta")}
+          people={people}
+          labels={labels}
+          peopleSummary={peopleSummary}
+          labelSummary={labelSummary}
+          pick={pick}
+          onTogglePick={(which) => setPick((v) => (v === which ? "" : which))}
+          roster={mentionRoster}
+          labelPalette={labelPalette}
+          labelColor={labelColor}
+          onTogglePerson={togglePerson}
+          onToggleLabel={toggleLabel}
+        />
 
         {/* ── Draft with <familiar> ── */}
         {familiar ? (
-          <>
-            <button
-              type="button"
-              className="ghc-sec focus-ring"
-              aria-expanded={sec === "fam"}
-              aria-label={`Draft with the ${familiar.name} familiar`}
-              onClick={() => toggleSec("fam")}
-            >
-              <span aria-hidden className={`ghc-sec__caret${sec === "fam" ? " ghc-sec__caret--open" : ""}`}>
-                <Icon name="ph:caret-right" width={11} />
-              </span>
-              <span aria-hidden className="ghc-sec__icon ghc-sec__accent">
-                <Icon name="ph:brain" width={13} />
-              </span>
-              <span className="ghc-sec__title">
-                Draft with <span className="ghc-sec__accent">{familiar.name}</span>
-              </span>
-              <span className="ghc-sec__summary">
-                <span className={famDraft ? "ghc-sec__accent" : undefined}>
-                  {drafting ? "drafting…" : famDraft ? "draft ready · review before sending" : "reads what you allow"}
-                </span>
-              </span>
-            </button>
-            {sec === "fam" ? (
-              <div className="ghc-body ghc-body--roomy ghc-body--familiar">
-                {famDraft == null ? (
-                  <div className="ghc-scopes">
-                    <span className="ghc-field__label">scope</span>
-                    {(
-                      [
-                        ["files", item.isPull ? "changed files" : "description"],
-                        ["threads", `${unresolved.length} open thread${unresolved.length === 1 ? "" : "s"}`],
-                        ["checks", "failing checks"],
-                      ] as [keyof GhDraftScopes, string][]
-                    ).map(([key, label]) => (
-                      <button
-                        key={key}
-                        type="button"
-                        className={`ghc-scope focus-ring${scopes[key] ? " ghc-scope--on" : ""}`}
-                        aria-pressed={scopes[key]}
-                        onClick={() => setScopes((s) => ({ ...s, [key]: !s[key] }))}
-                      >
-                        {label}
-                      </button>
-                    ))}
-                    <button
-                      type="button"
-                      className="ghc-draft-cta focus-ring"
-                      onClick={() => void draftWithFamiliar()}
-                      disabled={drafting}
-                    >
-                      <Icon name="ph:sparkle" width={12} aria-hidden />
-                      {drafting ? "Drafting…" : "Draft the review"}
-                    </button>
-                  </div>
-                ) : (
-                  <>
-                    <div className="ghc-draft-box">{famDraft || "…"}</div>
-                    <div className="ghc-draft-foot">
-                      <span className="ghc-draft-note">never auto-sent</span>
-                      <button
-                        type="button"
-                        className="ghc-draft-use focus-ring"
-                        onClick={() => {
-                          commitText(famDraft);
-                          setTab("write");
-                          setSec("");
-                          requestAnimationFrame(focusInput);
-                        }}
-                        disabled={drafting || !famDraft}
-                      >
-                        Use as my reply
-                      </button>
-                      <button
-                        type="button"
-                        className="ghc-draft-alt focus-ring"
-                        onClick={() => void draftWithFamiliar()}
-                        disabled={drafting}
-                      >
-                        <Icon name="ph:arrows-clockwise" width={10} aria-hidden />
-                        Re-roll
-                      </button>
-                      <button
-                        type="button"
-                        className="ghc-draft-drop focus-ring"
-                        aria-label="Discard the draft"
-                        onClick={() => {
-                          draftAbort.current?.abort();
-                          setFamDraft(null);
-                          setDrafting(false);
-                        }}
-                      >
-                        <Icon name="ph:x" width={10} aria-hidden />
-                      </button>
-                    </div>
-                  </>
-                )}
-                {famError ? (
-                  <span className="ghc-nudge" role="alert">
-                    {famError}
-                  </span>
-                ) : null}
-              </div>
-            ) : null}
-          </>
+          <FamiliarSection
+            expanded={sec === "fam"}
+            onToggle={() => toggleSec("fam")}
+            familiarName={familiar.name}
+            summary={famSummary}
+            drafting={drafting}
+            draft={famDraft}
+            error={famError}
+            scopes={scopes}
+            scopeChoices={scopeChoices}
+            onToggleScope={(key) => setScopes((s) => ({ ...s, [key]: !s[key] }))}
+            onDraft={() => void draftWithFamiliar()}
+            onUseDraft={() => {
+              commitText(famDraft ?? "");
+              setTab("write");
+              setSec("");
+              requestAnimationFrame(focusInput);
+            }}
+            onDiscardDraft={() => {
+              draftAbort.current?.abort();
+              setFamDraft(null);
+              setDrafting(false);
+            }}
+          />
         ) : null}
 
         {/* ── footer ── */}

--- a/src/components/github-card-composer.tsx
+++ b/src/components/github-card-composer.tsx
@@ -748,7 +748,16 @@ export function GitHubCardComposer({
     unresolved.length === 0
       ? "all threads resolved"
       : `${unresolved.length} unresolved thread${unresolved.length === 1 ? "" : "s"}`;
-  const threadNote = unresolved[0]?.path ? `1 unresolved in ${unresolved[0].path}` : threadLabel;
+  // Name the file only when there is exactly one thread to name. The old form
+  // read `1 unresolved in <first path>` for ANY count, so three open threads
+  // reported one — understating the gate the user is about to merge past.
+  const firstPath = unresolved[0]?.path;
+  const threadNote =
+    !firstPath
+      ? threadLabel
+      : unresolved.length === 1
+        ? `1 unresolved in ${firstPath}`
+        : `${threadLabel}, first in ${firstPath}`;
 
   const baseRef = item.pull?.baseRef ?? "the base branch";
   const commits = item.pull?.commits ?? null;

--- a/src/components/github-card-wiring.test.ts
+++ b/src/components/github-card-wiring.test.ts
@@ -86,6 +86,10 @@ assert.match(card, /Workflow run failed/, "hydrated run glyph reflects a fail co
 // composer cockpit ("Final Card Components.dc.html" §01). The write routes are
 // unchanged — only where they are called from moved.
 const composer = readFileSync(new URL("./github-card-composer.tsx", import.meta.url), "utf8");
+// The composer's four accordion sections are presentation-only child files
+// (src/components/github-card/*.tsx) statically imported into the same chunk —
+// all state, fetches and mutation handlers stay in the composer above.
+const familiarSection = readFileSync(new URL("./github-card/familiar-section.tsx", import.meta.url), "utf8");
 // The composer MUST stay lazy. chat-view sits in the `/` startup graph, so a
 // static import drags gh-card-composer.css into the home first load for every
 // session — that is 8 KB over the CSS budget and fails `Frontend build`.
@@ -154,7 +158,7 @@ assert.match(
 );
 
 // The familiar drafts, the human sends.
-assert.match(composer, /never auto-sent/, "the draft strip says out loud that it is not sent");
+assert.match(familiarSection, /never auto-sent/, "the draft strip says out loud that it is not sent");
 
 // navigator.clipboard is undefined in the packaged Tauri webview, which is the
 // whole reason @/lib/clipboard exists. A direct call there no-ops while the

--- a/src/components/github-card/familiar-section.tsx
+++ b/src/components/github-card/familiar-section.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * Draft with <familiar> — scope chips, the draft CTA, and the draft itself with
+ * use / re-roll / discard, as one accordion section of the composer sheet.
+ *
+ * Presentation only, and that is load-bearing here: the draft has nowhere to go
+ * but the textarea. `onUseDraft` hands it to the parent's own draft state, and
+ * the write routes live in `github-card-composer.tsx`, so no callback on this
+ * component can post a familiar's words to GitHub.
+ */
+
+import { Icon } from "@/lib/icon";
+import { type GhDraftScopes } from "@/lib/gh-review-draft";
+
+export type FamiliarSectionProps = {
+  /** True when this section owns the sheet's single open slot. */
+  expanded: boolean;
+  onToggle: () => void;
+  familiarName: string;
+  /** Header line: drafting / ready / what it may read. */
+  summary: string;
+  drafting: boolean;
+  /** null → the scope picker; a string (even empty, mid-stream) → the draft. */
+  draft: string | null;
+  error: string | null;
+  scopes: GhDraftScopes;
+  /** Which scopes to offer, already labelled for this item. */
+  scopeChoices: [keyof GhDraftScopes, string][];
+  onToggleScope: (key: keyof GhDraftScopes) => void;
+  onDraft: () => void;
+  onUseDraft: () => void;
+  onDiscardDraft: () => void;
+};
+
+export function FamiliarSection({
+  expanded,
+  onToggle,
+  familiarName,
+  summary,
+  drafting,
+  draft,
+  error,
+  scopes,
+  scopeChoices,
+  onToggleScope,
+  onDraft,
+  onUseDraft,
+  onDiscardDraft,
+}: FamiliarSectionProps) {
+  return (
+    <>
+      <button
+        type="button"
+        className="ghc-sec focus-ring"
+        aria-expanded={expanded}
+        aria-label={`Draft with the ${familiarName} familiar`}
+        onClick={onToggle}
+      >
+        <span aria-hidden className={`ghc-sec__caret${expanded ? " ghc-sec__caret--open" : ""}`}>
+          <Icon name="ph:caret-right" width={11} />
+        </span>
+        <span aria-hidden className="ghc-sec__icon ghc-sec__accent">
+          <Icon name="ph:brain" width={13} />
+        </span>
+        <span className="ghc-sec__title">
+          Draft with <span className="ghc-sec__accent">{familiarName}</span>
+        </span>
+        <span className="ghc-sec__summary">
+          <span className={draft ? "ghc-sec__accent" : undefined}>{summary}</span>
+        </span>
+      </button>
+      {expanded ? (
+        <div className="ghc-body ghc-body--roomy ghc-body--familiar">
+          {draft == null ? (
+            <div className="ghc-scopes">
+              <span className="ghc-field__label">scope</span>
+              {scopeChoices.map(([key, label]) => (
+                <button
+                  key={key}
+                  type="button"
+                  className={`ghc-scope focus-ring${scopes[key] ? " ghc-scope--on" : ""}`}
+                  aria-pressed={scopes[key]}
+                  onClick={() => onToggleScope(key)}
+                >
+                  {label}
+                </button>
+              ))}
+              <button type="button" className="ghc-draft-cta focus-ring" onClick={onDraft} disabled={drafting}>
+                <Icon name="ph:sparkle" width={12} aria-hidden />
+                {drafting ? "Drafting…" : "Draft the review"}
+              </button>
+            </div>
+          ) : (
+            <>
+              <div className="ghc-draft-box">{draft || "…"}</div>
+              <div className="ghc-draft-foot">
+                <span className="ghc-draft-note">never auto-sent</span>
+                <button
+                  type="button"
+                  className="ghc-draft-use focus-ring"
+                  onClick={onUseDraft}
+                  disabled={drafting || !draft}
+                >
+                  Use as my reply
+                </button>
+                <button type="button" className="ghc-draft-alt focus-ring" onClick={onDraft} disabled={drafting}>
+                  <Icon name="ph:arrows-clockwise" width={10} aria-hidden />
+                  Re-roll
+                </button>
+                <button
+                  type="button"
+                  className="ghc-draft-drop focus-ring"
+                  aria-label="Discard the draft"
+                  onClick={onDiscardDraft}
+                >
+                  <Icon name="ph:x" width={10} aria-hidden />
+                </button>
+              </div>
+            </>
+          )}
+          {error ? (
+            <span className="ghc-nudge" role="alert">
+              {error}
+            </span>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/github-card/gate-section.tsx
+++ b/src/components/github-card/gate-section.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+/**
+ * Gate — the merge preconditions (checks, reviews, unresolved threads) as one
+ * accordion section of the composer sheet.
+ *
+ * Presentation only. Every label arrives already derived and every verb is a
+ * callback, so the header summary and the expanded rows can never disagree
+ * about what the gate says, and `/api/github/rerun` +
+ * `/api/github/resolve-thread` stay in `github-card-composer.tsx`.
+ */
+
+import { Icon } from "@/lib/icon";
+
+export type GateSectionProps = {
+  /** True when this section owns the sheet's single open slot. */
+  expanded: boolean;
+  onToggle: () => void;
+  /** Whether the gate is clear — drives the header glyph. */
+  gateOk: boolean;
+  checksLabel: string;
+  /** Empty when the item has no review data — the row is then omitted. */
+  reviewLabel: string;
+  threadLabel: string;
+  /** The Threads row's note: names the file when exactly one thread is open. */
+  threadNote: string;
+  unresolvedCount: number;
+  failedChecks: number;
+  changesRequested: number;
+  /** There is at least one check run to re-run. */
+  canRerunChecks: boolean;
+  checksBusy: boolean;
+  threadBusy: boolean;
+  onRerunFailedChecks: () => void;
+  onResolveFirstThread: () => void;
+};
+
+export function GateSection({
+  expanded,
+  onToggle,
+  gateOk,
+  checksLabel,
+  reviewLabel,
+  threadLabel,
+  threadNote,
+  unresolvedCount,
+  failedChecks,
+  changesRequested,
+  canRerunChecks,
+  checksBusy,
+  threadBusy,
+  onRerunFailedChecks,
+  onResolveFirstThread,
+}: GateSectionProps) {
+  return (
+    <>
+      <button
+        type="button"
+        className="ghc-sec focus-ring"
+        aria-expanded={expanded}
+        aria-label="Gate — checks, reviews and threads"
+        onClick={onToggle}
+      >
+        <span aria-hidden className={`ghc-sec__caret${expanded ? " ghc-sec__caret--open" : ""}`}>
+          <Icon name="ph:caret-right" width={11} />
+        </span>
+        <span aria-hidden className={`ghc-sec__icon ${gateOk ? "ghc-sec__ok" : "ghc-sec__warn"}`}>
+          <Icon name={gateOk ? "ph:check-circle" : "ph:warning-circle"} width={13} />
+        </span>
+        <span className="ghc-sec__title">Gate</span>
+        <span className="ghc-sec__summary">
+          <span className="ghc-sec__mono">{checksLabel}</span>
+          {reviewLabel ? <span>{reviewLabel}</span> : null}
+          <span className={unresolvedCount ? "ghc-sec__warn" : "ghc-sec__ok"}>{threadLabel}</span>
+        </span>
+      </button>
+      {expanded ? (
+        <div className="ghc-body">
+          <div className="ghc-gate-row">
+            <span aria-hidden className={`ghc-gate-row__icon ${failedChecks ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
+              <Icon name={failedChecks ? "ph:x-circle-fill" : "ph:check-circle"} width={12} />
+            </span>
+            Checks
+            <span className="ghc-gate-row__tail">
+              <span className="ghc-gate-row__note">{checksLabel}</span>
+              {canRerunChecks ? (
+                <button type="button" className="ghc-mini focus-ring" onClick={onRerunFailedChecks} disabled={checksBusy}>
+                  {checksBusy ? "…" : "Re-run"}
+                </button>
+              ) : null}
+            </span>
+          </div>
+          {reviewLabel ? (
+            <div className="ghc-gate-row">
+              <span aria-hidden className={`ghc-gate-row__icon ${changesRequested ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
+                <Icon name={changesRequested ? "ph:warning-circle" : "ph:check-circle"} width={12} />
+              </span>
+              Reviews
+              <span className="ghc-gate-row__tail">
+                <span className="ghc-gate-row__note">{reviewLabel}</span>
+              </span>
+            </div>
+          ) : null}
+          <div className="ghc-gate-row">
+            <span aria-hidden className={`ghc-gate-row__icon ${unresolvedCount ? "ghc-sec__warn" : "ghc-sec__ok"}`}>
+              <Icon name={unresolvedCount ? "ph:warning-circle" : "ph:check-circle"} width={12} />
+            </span>
+            Threads
+            <span className="ghc-gate-row__tail">
+              <span className="ghc-gate-row__note">{threadNote}</span>
+              {unresolvedCount ? (
+                <button type="button" className="ghc-mini focus-ring" onClick={onResolveFirstThread} disabled={threadBusy}>
+                  {threadBusy ? "…" : "Resolve"}
+                </button>
+              ) : null}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/github-card/gate-section.tsx
+++ b/src/components/github-card/gate-section.tsx
@@ -22,7 +22,8 @@ export type GateSectionProps = {
   /** Empty when the item has no review data — the row is then omitted. */
   reviewLabel: string;
   threadLabel: string;
-  /** The Threads row's note: names the file when exactly one thread is open. */
+  /** The Threads row's note, already derived by the parent: names the file when
+   *  exactly one thread is open, otherwise counts them and names the first. */
   threadNote: string;
   unresolvedCount: number;
   failedChecks: number;

--- a/src/components/github-card/merge-section.tsx
+++ b/src/components/github-card/merge-section.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+/**
+ * Merge — method, branch tidy, commit preview and the arm field, as one
+ * accordion section of the composer sheet.
+ *
+ * Presentation only. The arm field reports its keystrokes upward and nothing
+ * else: the "does this literally read merge" decision and the `/api/github/merge`
+ * call both stay in `github-card-composer.tsx`, so the one irreversible verb has
+ * exactly one gate.
+ */
+
+import { Icon } from "@/lib/icon";
+import { METHOD_LABEL, segTight, type Method } from "@/components/github-card/shared";
+
+export type MergeSectionProps = {
+  /** True when this section owns the sheet's single open slot. */
+  expanded: boolean;
+  onToggle: () => void;
+  method: Method;
+  onSelectMethod: (method: Method) => void;
+  baseRef: string;
+  /** What the chosen method does to the history, in words. */
+  commitSummary: string;
+  /** Absent → no branch to tidy, so the switch is omitted. */
+  headRef: string | null;
+  deleteBranch: boolean;
+  onToggleDeleteBranch: () => void;
+  /** The commit subject GitHub will write, previewed. */
+  commitTitle: string;
+  arm: string;
+  onArmChange: (value: string) => void;
+  /** The arm field agrees — the footer CTA is live. */
+  armed: boolean;
+  /** The user tried to merge unarmed; flash the field. */
+  nudged: boolean;
+  armRef: React.RefObject<HTMLInputElement | null>;
+};
+
+export function MergeSection({
+  expanded,
+  onToggle,
+  method,
+  onSelectMethod,
+  baseRef,
+  commitSummary,
+  headRef,
+  deleteBranch,
+  onToggleDeleteBranch,
+  commitTitle,
+  arm,
+  onArmChange,
+  armed,
+  nudged,
+  armRef,
+}: MergeSectionProps) {
+  return (
+    <>
+      <button
+        type="button"
+        className="ghc-sec focus-ring"
+        aria-expanded={expanded}
+        aria-label="Merge — method, commit and branch"
+        onClick={onToggle}
+      >
+        <span aria-hidden className={`ghc-sec__caret${expanded ? " ghc-sec__caret--open" : ""}`}>
+          <Icon name="ph:caret-right" width={11} />
+        </span>
+        <span aria-hidden className="ghc-sec__icon">
+          <Icon name="ph:git-merge" width={13} />
+        </span>
+        <span className="ghc-sec__title">Merge</span>
+        <span className="ghc-sec__summary">
+          <span>
+            {METHOD_LABEL[method]} → {baseRef}
+          </span>
+          <span>{commitSummary}</span>
+          <span>{deleteBranch ? "delete branch" : "keep branch"}</span>
+        </span>
+      </button>
+      {expanded ? (
+        <div className="ghc-body ghc-body--roomy">
+          <div className="ghc-row">
+            <div className="ghc-seg ghc-seg--sunken">
+              {(["squash", "merge", "rebase"] as Method[]).map((m) => (
+                <button
+                  key={m}
+                  type="button"
+                  className={segTight(method === m)}
+                  onClick={() => onSelectMethod(m)}
+                  aria-pressed={method === m}
+                >
+                  {m === "squash" ? "Squash" : m === "merge" ? "Merge commit" : "Rebase"}
+                </button>
+              ))}
+            </div>
+            {headRef ? (
+              <button
+                type="button"
+                className="ghc-switch focus-ring"
+                aria-pressed={deleteBranch}
+                aria-label={`Delete ${headRef} after merging`}
+                onClick={onToggleDeleteBranch}
+              >
+                <span aria-hidden className={`ghc-switch__track${deleteBranch ? " ghc-switch__track--on" : ""}`}>
+                  <span className="ghc-switch__knob" />
+                </span>
+                delete <span className="ghc-switch__branch">{headRef}</span>
+              </button>
+            ) : null}
+          </div>
+          <div className="ghc-commit">
+            <div className="ghc-commit__head">
+              <span className="ghc-commit__eyebrow">COMMIT</span>
+              <span className="ghc-commit__method">{METHOD_LABEL[method]}</span>
+            </div>
+            <div className="ghc-commit__title">{commitTitle}</div>
+          </div>
+          <div className={`ghc-arm${nudged ? " ghc-arm--nudged" : ""}`}>
+            <span className="ghc-arm__label">type</span>
+            <span className="ghc-arm__word">merge</span>
+            <span className="ghc-arm__label">to arm</span>
+            <input
+              ref={armRef}
+              className="ghc-arm__input focus-ring"
+              value={arm}
+              onChange={(e) => onArmChange(e.target.value)}
+              placeholder="…"
+              aria-label="Type merge to arm the merge button"
+            />
+            {armed ? (
+              <span aria-hidden className="ghc-arm__ok">
+                <Icon name="ph:check" width={12} />
+              </span>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/github-card/meta-section.tsx
+++ b/src/components/github-card/meta-section.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+/**
+ * Assignees & labels — the chips, their add buttons and both pickers, as one
+ * accordion section of the composer sheet.
+ *
+ * Presentation only. Chips are rendered from the parent's optimistic arrays and
+ * every tap is a callback, so `PATCH /api/github/issue` and the
+ * "server truth wins unless a picker is open" rule stay in
+ * `github-card-composer.tsx`.
+ */
+
+import { Icon } from "@/lib/icon";
+
+export type MetaSectionProps = {
+  /** True when this section owns the sheet's single open slot. */
+  expanded: boolean;
+  onToggle: () => void;
+  /** The optimistic assignee logins. */
+  people: string[];
+  /** The optimistic label names. */
+  labels: string[];
+  peopleSummary: string;
+  labelSummary: string;
+  /** Which picker is open, if either. */
+  pick: "" | "people" | "labels";
+  onTogglePick: (which: "people" | "labels") => void;
+  /** Who can be assigned — author plus current assignees. */
+  roster: { login: string; role: string }[];
+  /** The repo's labels when they arrived, else the item's own. */
+  labelPalette: { name: string; color: string }[];
+  /** Hex (no `#`) for an applied label, from whichever source knows it. */
+  labelColor: (name: string) => string | undefined;
+  onTogglePerson: (login: string) => void;
+  onToggleLabel: (name: string) => void;
+};
+
+export function MetaSection({
+  expanded,
+  onToggle,
+  people,
+  labels,
+  peopleSummary,
+  labelSummary,
+  pick,
+  onTogglePick,
+  roster,
+  labelPalette,
+  labelColor,
+  onTogglePerson,
+  onToggleLabel,
+}: MetaSectionProps) {
+  return (
+    <>
+      <button
+        type="button"
+        className="ghc-sec focus-ring"
+        aria-expanded={expanded}
+        aria-label="Assignees and labels"
+        onClick={onToggle}
+      >
+        <span aria-hidden className={`ghc-sec__caret${expanded ? " ghc-sec__caret--open" : ""}`}>
+          <Icon name="ph:caret-right" width={11} />
+        </span>
+        <span aria-hidden className="ghc-sec__icon">
+          <Icon name="ph:tag" width={13} />
+        </span>
+        <span className="ghc-sec__title">Assignees &amp; labels</span>
+        <span className="ghc-sec__summary">
+          <span>{peopleSummary}</span>
+          <span>{labelSummary}</span>
+        </span>
+      </button>
+      {expanded ? (
+        <div className="ghc-body ghc-body--roomy">
+          <div className="ghc-field">
+            <span className="ghc-field__label">assignees</span>
+            <div className="ghc-field__body">
+              {people.map((p) => (
+                <span key={p} className="ghc-chip">
+                  <span aria-hidden className="ghc-avatar">
+                    {p.slice(0, 1).toUpperCase()}
+                  </span>
+                  {p}
+                  <button
+                    type="button"
+                    className="ghc-chip__x focus-ring"
+                    onClick={() => onTogglePerson(p)}
+                    aria-label={`Unassign ${p}`}
+                  >
+                    <Icon name="ph:x" width={8} aria-hidden />
+                  </button>
+                </span>
+              ))}
+              <button
+                type="button"
+                className="ghc-add focus-ring"
+                aria-expanded={pick === "people"}
+                onClick={() => onTogglePick("people")}
+              >
+                <Icon name="ph:plus" width={9} aria-hidden />
+                add
+              </button>
+              {pick === "people" ? (
+                <div className="ghc-picker">
+                  <div className="ghc-pal__label">PEOPLE</div>
+                  <div className="ghc-pal__rows">
+                    {roster.map((p) => (
+                      <button
+                        key={p.login}
+                        type="button"
+                        className={`ghc-pal__row ghc-pal__row--person focus-ring${people.includes(p.login) ? " ghc-pal__row--active" : ""}`}
+                        onClick={() => onTogglePerson(p.login)}
+                      >
+                        <span aria-hidden className="ghc-avatar">
+                          {p.login.slice(0, 1).toUpperCase()}
+                        </span>
+                        <span className="ghc-pal__name">{p.login}</span>
+                        <span className="ghc-pal__role">{p.role}</span>
+                        <span className="ghc-pal__state">{people.includes(p.login) ? "assigned" : ""}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+          <div className="ghc-field">
+            <span className="ghc-field__label">labels</span>
+            <div className="ghc-field__body">
+              {labels.map((name) => {
+                const hex = labelColor(name);
+                return (
+                  <span key={name} className="ghc-chip ghc-chip--label">
+                    <span aria-hidden className="ghc-chip__dot" style={hex ? { background: `#${hex}` } : undefined} />
+                    {name}
+                    <button
+                      type="button"
+                      className="ghc-chip__x focus-ring"
+                      onClick={() => onToggleLabel(name)}
+                      aria-label={`Remove label ${name}`}
+                    >
+                      <Icon name="ph:x" width={8} aria-hidden />
+                    </button>
+                  </span>
+                );
+              })}
+              <button
+                type="button"
+                className="ghc-add ghc-add--label focus-ring"
+                aria-expanded={pick === "labels"}
+                onClick={() => onTogglePick("labels")}
+              >
+                <Icon name="ph:plus" width={9} aria-hidden />
+                add
+              </button>
+              {pick === "labels" ? (
+                <div className="ghc-picker">
+                  <div className="ghc-pal__label">REPO LABELS</div>
+                  <div className="ghc-pal__rows">
+                    {labelPalette.map((l) => (
+                      <button
+                        key={l.name}
+                        type="button"
+                        className={`ghc-pal__row ghc-pal__row--person focus-ring${labels.includes(l.name) ? " ghc-pal__row--active" : ""}`}
+                        onClick={() => onToggleLabel(l.name)}
+                      >
+                        <span
+                          aria-hidden
+                          className="ghc-chip__dot"
+                          style={l.color ? { background: `#${l.color}` } : undefined}
+                        />
+                        <span className="ghc-pal__name">{l.name}</span>
+                        <span className="ghc-pal__state">{labels.includes(l.name) ? "applied" : ""}</span>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/github-card/shared.ts
+++ b/src/components/github-card/shared.ts
@@ -1,0 +1,14 @@
+/**
+ * The handful of pieces `github-card-composer.tsx` shares with its section
+ * files. Nothing here holds state or knows a route — the composer stays the one
+ * owner of both, so a section file can be read end-to-end as presentation.
+ */
+
+export type Method = "squash" | "merge" | "rebase";
+
+export const METHOD_LABEL: Record<Method, string> = { squash: "squash", merge: "merge commit", rebase: "rebase" };
+
+/** Segment-control item classNames — `--tight` is the footer/inline density. */
+export const seg = (on: boolean) => `ghc-seg__item focus-ring${on ? " ghc-seg__item--on" : ""}`;
+export const segTight = (on: boolean) =>
+  `ghc-seg__item ghc-seg__item--tight focus-ring${on ? " ghc-seg__item--on" : ""}`;


### PR DESCRIPTION
Follow-up to #4068, where `github-card-composer.tsx` shipped at 1517 lines.

Splits the Gate, Merge, Assignees-and-labels and Draft-with-familiar sections into `src/components/github-card/*-section.tsx`.

| file | lines |
|---|---|
| `github-card-composer.tsx` | 1517 → **1214** |
| `gate-section.tsx` | 122 |
| `merge-section.tsx` | 141 |
| `meta-section.tsx` | 186 |
| `familiar-section.tsx` | 131 |
| `shared.ts` | 14 |

## The split rule is the point, not the line count

**All state, fetches and mutation handlers stay in the parent.** The children are presentation-only — props in, callbacks out. Verified mechanically rather than by eye: zero `useState`, zero `useEffect`, zero `fetch`/`postJson` across all four files. Derivations stay in the parent too and are passed down as finished display values, so there's exactly one source of truth for every string on screen.

That boundary was chosen because it keeps the write-path invariants where the tests already pin them.

## Pins repointed, not weakened

17 of the 18 source pins still describe parent code — all six route strings, the single-slot accordion guarantee, the arm-field gate, the `deleteBranch` spread, the empty-body rule, both clipboard pins, and the draft-never-auto-sends `doesNotMatch`. Exactly one moved (`never auto-sent`, now in `familiar-section.tsx`) and it was repointed with its assertion message intact. **None were weakened or deleted.**

## The CSS budget trap, avoided deliberately

Imports are **static**, so the sections join the composer's existing chunk. `github-card.tsx` is untouched, the composer is still behind `next/dynamic`, and `gh-card-composer.css` is still imported exactly once.

I confirmed this by diffing `github-card.tsx` against `main` (empty) rather than assuming, because a stray lazy boundary or a static import of the composer is precisely what put the route 8 KB over the home CSS budget during #4068 — and that failure surfaces as three red required checks, not one.

## Gates

`tsc` 0 · `pnpm lint` clean · drift unchanged (`font=146 space=1691 radius=230 hex=0 inline=190`) · `test:app` 980 files · wiring + reward pins hold.

No behaviour change intended or made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)