### PR TITLE
fix(chat): harden quick-chat protocol rendering

### DIFF
--- a/src/lib/github-blocks.ts
+++ b/src/lib/github-blocks.ts
@@ -288,11 +288,47 @@ function hasUnquotedGt(s: string, from: number): boolean {
   return false;
 }
 
+function mergeRanges(ranges: Array<[number, number]>): Array<[number, number]> {
+  const merged: Array<[number, number]> = [];
+  for (const range of ranges.sort(([a], [b]) => a - b)) {
+    const previous = merged[merged.length - 1];
+    if (previous && range[0] <= previous[1]) {
+      previous[1] = Math.max(previous[1], range[1]);
+    } else {
+      merged.push([...range]);
+    }
+  }
+  return merged;
+}
+
+function rendererFenceRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+  let offset = 0;
+  let start = -1;
+  let character = "";
+  for (const line of text.split("\n")) {
+    const fence = /^\s*(`{3,}|~{3,})(\w*)?\s*$/.exec(line);
+    if (start === -1) {
+      if (fence) {
+        start = offset;
+        character = fence[1][0];
+      }
+    } else if (fence && fence[1][0] === character) {
+      ranges.push([start, offset + line.length]);
+      start = -1;
+      character = "";
+    }
+    offset += line.length + 1;
+  }
+  if (start !== -1) ranges.push([start, text.length]);
+  return ranges;
+}
+
 /** Character ranges covered by ```/~~~ fences (delimiters included). Fenced
  *  marker syntax is example text, never live cards (review finding,
  *  cave-m0r6); an unclosed trailing fence protects through the text end. */
 export function fencedRanges(text: string): Array<[number, number]> {
-  const ranges: Array<[number, number]> = [];
+  const containerRanges: Array<[number, number]> = [];
   let offset = 0;
   let fenceStart = -1;
   let fenceCharacter = "";
@@ -339,7 +375,7 @@ export function fencedRanges(text: string): Array<[number, number]> {
         && closing[2][0] === fenceCharacter
         && closing[2].length >= fenceLength
       ) {
-        ranges.push([fenceStart, offset + line.length]);
+        containerRanges.push([fenceStart, offset + line.length]);
         fenceStart = -1;
         fenceCharacter = "";
         fenceLength = 0;
@@ -349,42 +385,13 @@ export function fencedRanges(text: string): Array<[number, number]> {
     }
     offset += line.length + 1;
   }
-  if (fenceStart !== -1) ranges.push([fenceStart, text.length]);
+  if (fenceStart !== -1) containerRanges.push([fenceStart, text.length]);
 
   // The shipped parser also recognizes any whitespace-indented raw fence line
   // and closes it with the next same-character fence, regardless of run
   // length. Union that state machine with the container-aware ranges above so
   // parser quirks can never leave rendered code executable as protocol.
-  const rendererRanges: Array<[number, number]> = [];
-  let rendererOffset = 0;
-  let rendererStart = -1;
-  let rendererCharacter = "";
-  for (const line of text.split("\n")) {
-    const fence = /^\s*(`{3,}|~{3,})(\w*)?\s*$/.exec(line);
-    if (rendererStart === -1) {
-      if (fence) {
-        rendererStart = rendererOffset;
-        rendererCharacter = fence[1][0];
-      }
-    } else if (fence && fence[1][0] === rendererCharacter) {
-      rendererRanges.push([rendererStart, rendererOffset + line.length]);
-      rendererStart = -1;
-      rendererCharacter = "";
-    }
-    rendererOffset += line.length + 1;
-  }
-  if (rendererStart !== -1) rendererRanges.push([rendererStart, text.length]);
-
-  const merged: Array<[number, number]> = [];
-  for (const range of [...ranges, ...rendererRanges].sort(([a], [b]) => a - b)) {
-    const previous = merged[merged.length - 1];
-    if (previous && range[0] <= previous[1]) {
-      previous[1] = Math.max(previous[1], range[1]);
-    } else {
-      merged.push([...range]);
-    }
-  }
-  return merged;
+  return mergeRanges([...containerRanges, ...rendererFenceRanges(text)]);
 }
 
 function inRanges(ranges: Array<[number, number]>, index: number): boolean {
@@ -396,10 +403,23 @@ function inRanges(ranges: Array<[number, number]>, index: number): boolean {
  * briefly activate protocol controls before their closing delimiter arrives. */
 export function markdownCodeRanges(text: string): Array<[number, number]> {
   const fences = fencedRanges(text);
+  const rendererFences = rendererFenceRanges(text);
   const inline: Array<[number, number]> = [];
   let cursor = 0;
+  let rendererFenceIndex = 0;
 
   while (cursor < text.length) {
+    while (
+      rendererFenceIndex < rendererFences.length
+      && cursor >= rendererFences[rendererFenceIndex][1]
+    ) {
+      rendererFenceIndex += 1;
+    }
+    const rendererFence = rendererFences[rendererFenceIndex];
+    if (rendererFence && cursor >= rendererFence[0]) {
+      cursor = rendererFence[1];
+      continue;
+    }
     if (text[cursor] !== "`") {
       cursor += 1;
       continue;
@@ -410,8 +430,20 @@ export function markdownCodeRanges(text: string): Array<[number, number]> {
     const delimiterLength = cursor - start;
     let closingEnd = -1;
     let search = cursor;
+    let searchFenceIndex = rendererFenceIndex;
 
     while (search < text.length) {
+      while (
+        searchFenceIndex < rendererFences.length
+        && search >= rendererFences[searchFenceIndex][1]
+      ) {
+        searchFenceIndex += 1;
+      }
+      const searchFence = rendererFences[searchFenceIndex];
+      if (searchFence && search >= searchFence[0]) {
+        search = searchFence[1];
+        continue;
+      }
       if (text[search] !== "`") {
         search += 1;
         continue;
@@ -428,16 +460,7 @@ export function markdownCodeRanges(text: string): Array<[number, number]> {
     cursor = closingEnd === -1 ? text.length : closingEnd;
   }
 
-  const merged: Array<[number, number]> = [];
-  for (const range of [...fences, ...inline].sort(([a], [b]) => a - b)) {
-    const previous = merged[merged.length - 1];
-    if (previous && range[0] <= previous[1]) {
-      previous[1] = Math.max(previous[1], range[1]);
-    } else {
-      merged.push([...range]);
-    }
-  }
-  return merged;
+  return mergeRanges([...fences, ...inline]);
 }
 
 /**

--- a/src/lib/github-blocks.ts
+++ b/src/lib/github-blocks.ts
@@ -295,22 +295,149 @@ export function fencedRanges(text: string): Array<[number, number]> {
   const ranges: Array<[number, number]> = [];
   let offset = 0;
   let fenceStart = -1;
+  let fenceCharacter = "";
+  let fenceLength = 0;
+  let fenceQuoteDepth = 0;
+  let closingIndent = 3;
   for (const line of text.split("\n")) {
-    if (/^\s*(```|~~~)/.test(line)) {
-      if (fenceStart === -1) fenceStart = offset;
-      else {
+    let contentOffset = 0;
+    let quoteDepth = 0;
+    while (true) {
+      const quote = /^ {0,3}>[ \t]?/.exec(line.slice(contentOffset));
+      if (!quote) break;
+      contentOffset += quote[0].length;
+      quoteDepth += 1;
+    }
+    const containerContent = line.slice(contentOffset);
+
+    if (fenceStart === -1) {
+      const list = /^ {0,3}(?:[-+*]|\d{1,9}[.)])[ \t]+/.exec(containerContent);
+      const content = list
+        ? containerContent.slice(list[0].length)
+        : containerContent;
+      const opening = /^([ \t]*)(`{3,}|~{3,})(.*)$/.exec(content);
+      if (opening) {
+        const indent = (list?.[0].length ?? 0) + opening[1].length;
+        const fence = opening[2];
+        const info = opening[3];
+        if (fence[0] === "`" && info.includes("`")) {
+          offset += line.length + 1;
+          continue;
+        }
+        fenceStart = offset;
+        fenceCharacter = fence[0];
+        fenceLength = fence.length;
+        fenceQuoteDepth = quoteDepth;
+        closingIndent = indent + 3;
+      }
+    } else {
+      const closing = /^([ \t]*)(`{3,}|~{3,})\s*$/.exec(containerContent);
+      if (
+        closing
+        && quoteDepth === fenceQuoteDepth
+        && closing[1].length <= closingIndent
+        && closing[2][0] === fenceCharacter
+        && closing[2].length >= fenceLength
+      ) {
         ranges.push([fenceStart, offset + line.length]);
         fenceStart = -1;
+        fenceCharacter = "";
+        fenceLength = 0;
+        fenceQuoteDepth = 0;
+        closingIndent = 3;
       }
     }
     offset += line.length + 1;
   }
   if (fenceStart !== -1) ranges.push([fenceStart, text.length]);
-  return ranges;
+
+  // The shipped parser also recognizes any whitespace-indented raw fence line
+  // and closes it with the next same-character fence, regardless of run
+  // length. Union that state machine with the container-aware ranges above so
+  // parser quirks can never leave rendered code executable as protocol.
+  const rendererRanges: Array<[number, number]> = [];
+  let rendererOffset = 0;
+  let rendererStart = -1;
+  let rendererCharacter = "";
+  for (const line of text.split("\n")) {
+    const fence = /^\s*(`{3,}|~{3,})(\w*)?\s*$/.exec(line);
+    if (rendererStart === -1) {
+      if (fence) {
+        rendererStart = rendererOffset;
+        rendererCharacter = fence[1][0];
+      }
+    } else if (fence && fence[1][0] === rendererCharacter) {
+      rendererRanges.push([rendererStart, rendererOffset + line.length]);
+      rendererStart = -1;
+      rendererCharacter = "";
+    }
+    rendererOffset += line.length + 1;
+  }
+  if (rendererStart !== -1) rendererRanges.push([rendererStart, text.length]);
+
+  const merged: Array<[number, number]> = [];
+  for (const range of [...ranges, ...rendererRanges].sort(([a], [b]) => a - b)) {
+    const previous = merged[merged.length - 1];
+    if (previous && range[0] <= previous[1]) {
+      previous[1] = Math.max(previous[1], range[1]);
+    } else {
+      merged.push([...range]);
+    }
+  }
+  return merged;
 }
 
 function inRanges(ranges: Array<[number, number]>, index: number): boolean {
   return ranges.some(([start, end]) => index >= start && index < end);
+}
+
+/** Markdown code ranges, including fenced blocks and inline backtick spans.
+ * Unterminated spans protect through the text end so streamed examples cannot
+ * briefly activate protocol controls before their closing delimiter arrives. */
+export function markdownCodeRanges(text: string): Array<[number, number]> {
+  const fences = fencedRanges(text);
+  const inline: Array<[number, number]> = [];
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    if (text[cursor] !== "`") {
+      cursor += 1;
+      continue;
+    }
+
+    const start = cursor;
+    while (cursor < text.length && text[cursor] === "`") cursor += 1;
+    const delimiterLength = cursor - start;
+    let closingEnd = -1;
+    let search = cursor;
+
+    while (search < text.length) {
+      if (text[search] !== "`") {
+        search += 1;
+        continue;
+      }
+      const closingStart = search;
+      while (search < text.length && text[search] === "`") search += 1;
+      if (search - closingStart === delimiterLength) {
+        closingEnd = search;
+        break;
+      }
+    }
+
+    inline.push([start, closingEnd === -1 ? text.length : closingEnd]);
+    cursor = closingEnd === -1 ? text.length : closingEnd;
+  }
+
+  const merged: Array<[number, number]> = [];
+  for (const range of [...fences, ...inline].sort(([a], [b]) => a - b)) {
+    const previous = merged[merged.length - 1];
+    if (previous && range[0] <= previous[1]) {
+      previous[1] = Math.max(previous[1], range[1]);
+    } else {
+      merged.push([...range]);
+    }
+  }
+  return merged;
 }
 
 /**
@@ -322,10 +449,10 @@ function inRanges(ranges: Array<[number, number]>, index: number): boolean {
  */
 export function stripGitHubMarkers(text: string): string {
   if (!text || !text.includes("<coven:g")) return text;
-  const fences = fencedRanges(text);
+  const codeRanges = markdownCodeRanges(text);
   MARKER_RE.lastIndex = 0;
   const out = text.replace(MARKER_RE, (m, _action, _attrs, index: number) =>
-    inRanges(fences, index) ? m : "",
+    inRanges(codeRanges, index) ? m : "",
   );
   return stripIncompleteGitHubMarker(out);
 }
@@ -338,7 +465,7 @@ export function stripIncompleteGitHubMarker(text: string): string {
   // name) with no UNQUOTED closing `>` after it hides from the visible
   // stream — unless it sits inside a fence, where it's example text.
   const tail = text.lastIndexOf("<coven:g");
-  if (tail !== -1 && !hasUnquotedGt(text, tail) && !inRanges(fencedRanges(text), tail)) {
+  if (tail !== -1 && !hasUnquotedGt(text, tail) && !inRanges(markdownCodeRanges(text), tail)) {
     const frag = text.slice(tail);
     if ("<coven:github-action".startsWith(frag.slice(0, "<coven:github-action".length)) || frag.startsWith("<coven:github")) {
       return text.slice(0, tail);
@@ -363,7 +490,10 @@ function bareLineDescriptor(line: string): GitHubBlockDescriptor | null {
  * Inline URL mentions stay plain text. Returns [{kind:"text", text}] unchanged
  * when there is nothing to extract, so callers can cheaply detect "no cards".
  */
-export function sliceGitHubBlocks(text: string): GitHubTextPiece[] {
+export function sliceGitHubBlocks(
+  text: string,
+  { unfurlBareUrls = true }: { unfurlBareUrls?: boolean } = {},
+): GitHubTextPiece[] {
   if (!text) return [{ kind: "text", text }];
   const pieces: GitHubTextPiece[] = [];
   let cursor = 0;
@@ -375,11 +505,11 @@ export function sliceGitHubBlocks(text: string): GitHubTextPiece[] {
     // Fenced markers are example text — leave them literal instead of
     // splitting the fence and mounting a live (possibly armed action) card
     // (review finding, cave-m0r6).
-    const fences = fencedRanges(text);
+    const codeRanges = markdownCodeRanges(text);
     MARKER_RE.lastIndex = 0;
     let m: RegExpExecArray | null;
     while ((m = MARKER_RE.exec(text)) !== null) {
-      if (inRanges(fences, m.index)) continue;
+      if (inRanges(codeRanges, m.index)) continue;
       pushText(text.slice(cursor, m.index));
       cursor = m.index + m[0].length;
       const isAction = Boolean(m[1]);
@@ -398,6 +528,10 @@ export function sliceGitHubBlocks(text: string): GitHubTextPiece[] {
     pushText(text);
   }
 
+  if (!unfurlBareUrls) {
+    return pieces.length ? pieces : [{ kind: "text", text }];
+  }
+
   // Second pass: unfurl bare-line URLs inside the text pieces.
   const out: GitHubTextPiece[] = [];
   for (const piece of pieces) {
@@ -406,27 +540,22 @@ export function sliceGitHubBlocks(text: string): GitHubTextPiece[] {
       continue;
     }
     const lines = piece.text.split("\n");
+    const codeRanges = markdownCodeRanges(piece.text);
     let buf: string[] = [];
-    let inFence = false;
+    let offset = 0;
     const flush = () => {
       if (buf.length) out.push({ kind: "text", text: buf.join("\n") });
       buf = [];
     };
     for (const line of lines) {
-      // Fence tracking: never unfurl inside ```/~~~ blocks — consuming a line
-      // there would split the fence and break the markdown render.
-      if (/^\s*(```|~~~)/.test(line)) {
-        inFence = !inFence;
-        buf.push(line);
-        continue;
-      }
-      const d = inFence ? null : bareLineDescriptor(line);
+      const d = inRanges(codeRanges, offset) ? null : bareLineDescriptor(line);
       if (d) {
         flush();
         out.push({ kind: "card", descriptor: d });
       } else {
         buf.push(line);
       }
+      offset += line.length + 1;
     }
     flush();
   }

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -6,10 +6,16 @@
  * suggestions ride along on the normal turn.
  */
 
+import { markdownCodeRanges } from "./github-blocks.ts";
+
 export const DEFAULT_NEXT_PATHS_COUNT = 4;
 
 const OPEN = "<coven:next-paths>";
 const CLOSE = "</coven:next-paths>";
+const MARKER_PREFIXES = [
+  { prefix: "<coven:", marker: OPEN },
+  { prefix: "</coven:", marker: CLOSE },
+] as const;
 const NEXT_PATH_EXAMPLES = [
   { control: "[reply]", label: "Draft the follow-up message" },
   { control: "[task]", label: "Create a task for the follow-up" },
@@ -41,6 +47,73 @@ function replyFor(title: string): NextPath | null {
   return normalized && !isTemplateSuggestion(normalized)
     ? { kind: "reply", label: normalized, prompt: normalized }
     : null;
+}
+
+function inFencedRange(ranges: Array<[number, number]>, index: number): boolean {
+  return ranges.some(([start, end]) => index >= start && index < end);
+}
+
+function isIncompleteMarkerAt(
+  text: string,
+  index: number,
+  prefix: string,
+  marker: string,
+): boolean {
+  if (text.startsWith(marker, index)) return false;
+  let matched = 0;
+  while (
+    matched < marker.length
+    && index + matched < text.length
+    && text[index + matched] === marker[matched]
+  ) {
+    matched += 1;
+  }
+  if (matched < prefix.length) return false;
+  const mismatch = text[index + matched];
+  return matched > prefix.length || mismatch === undefined || /\s/.test(mismatch);
+}
+
+function stripIncompleteNextPathsMarker(text: string): string {
+  const codeRanges = markdownCodeRanges(text);
+  let cutAt = text.length;
+  for (const { prefix, marker } of MARKER_PREFIXES) {
+    let markerStart = text.indexOf(prefix);
+    while (markerStart !== -1) {
+      if (
+        !inFencedRange(codeRanges, markerStart)
+        && isIncompleteMarkerAt(text, markerStart, prefix, marker)
+      ) {
+        cutAt = Math.min(cutAt, markerStart);
+      }
+      markerStart = text.indexOf(prefix, markerStart + prefix.length);
+    }
+  }
+  return cutAt === text.length ? text : text.slice(0, cutAt);
+}
+
+function lastIndexOutsideFences(
+  text: string,
+  token: string,
+  ranges: Array<[number, number]>,
+): number {
+  let index = text.lastIndexOf(token);
+  while (index !== -1 && inFencedRange(ranges, index)) {
+    index = text.lastIndexOf(token, index - 1);
+  }
+  return index;
+}
+
+function nextIndexOutsideFences(
+  text: string,
+  token: string,
+  from: number,
+  ranges: Array<[number, number]>,
+): number {
+  let index = text.indexOf(token, from);
+  while (index !== -1 && inFencedRange(ranges, index)) {
+    index = text.indexOf(token, index + token.length);
+  }
+  return index;
 }
 
 /**
@@ -104,12 +177,14 @@ export function buildNextPathsDirective(count: number = DEFAULT_NEXT_PATHS_COUNT
  */
 export function extractNextPaths(text: string): { visible: string; suggestions: NextPath[] } {
   if (!text) return { visible: text, suggestions: [] };
-  const open = text.lastIndexOf(OPEN);
-  if (open === -1) return { visible: text, suggestions: [] };
-  const closeAt = text.indexOf(CLOSE, open);
-  const innerEnd = closeAt === -1 ? text.length : closeAt;
-  const blockEnd = closeAt === -1 ? text.length : closeAt + CLOSE.length;
-  const inner = text.slice(open + OPEN.length, innerEnd);
+  const markerSafeText = stripIncompleteNextPathsMarker(text);
+  const codeRanges = markdownCodeRanges(markerSafeText);
+  const open = lastIndexOutsideFences(markerSafeText, OPEN, codeRanges);
+  if (open === -1) return { visible: markerSafeText, suggestions: [] };
+  const closeAt = nextIndexOutsideFences(markerSafeText, CLOSE, open, codeRanges);
+  const innerEnd = closeAt === -1 ? markerSafeText.length : closeAt;
+  const blockEnd = closeAt === -1 ? markerSafeText.length : closeAt + CLOSE.length;
+  const inner = markerSafeText.slice(open + OPEN.length, innerEnd);
   const suggestions = inner
     .split(/\r?\n/)
     .map((l) => l.replace(/^\s*[-*•]\s*/, "").trim())
@@ -118,6 +193,6 @@ export function extractNextPaths(text: string): { visible: string; suggestions: 
     // At most 4 pills ever render — the chip row's product cap (an over-eager
     // agent that lists more gets trimmed, not a fifth row).
     .slice(0, DEFAULT_NEXT_PATHS_COUNT);
-  const visible = (text.slice(0, open) + text.slice(blockEnd)).trimEnd();
+  const visible = (markerSafeText.slice(0, open) + markerSafeText.slice(blockEnd)).trimEnd();
   return { visible, suggestions };
 }

--- a/src/lib/quick-chat-message-format.test.ts
+++ b/src/lib/quick-chat-message-format.test.ts
@@ -278,6 +278,21 @@ test("overlapping quoted fence and inline code ranges stay non-executable", () =
   assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
 });
 
+test("inline delimiters inside block fences cannot suppress later controls", () => {
+  const marker = '<coven:github kind="pr" repo="OpenCoven/coven-cave" number="3982" />';
+  const text = [
+    "~~~text",
+    "unmatched ` example",
+    "~~~",
+    marker,
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.doesNotMatch(formatted.copyText, /coven:github/);
+  assert.ok(formatted.pieces.some((piece) => piece.kind === "card"));
+});
+
 test("a list delimiter that opens renderer code protects following controls", () => {
   const text = [
     "- ```xml",

--- a/src/lib/quick-chat-message-format.test.ts
+++ b/src/lib/quick-chat-message-format.test.ts
@@ -70,6 +70,69 @@ test("settled quick-chat text hides an interrupted GitHub marker tail", () => {
   assert.deepEqual(formatted.pieces, [{ kind: "text", text: "Checks finished." }]);
 });
 
+test("quick-chat text hides an interrupted next-path marker tail", () => {
+  for (const streaming of [true, false]) {
+    const formatted = formatQuickChatAssistantMessage(
+      "Checks finished.\n<coven:next-paths",
+      streaming,
+    );
+
+    assert.equal(formatted.copyText, "Checks finished.");
+    assert.deepEqual(formatted.pieces, [{ kind: "text", text: "Checks finished." }]);
+    assert.deepEqual(formatted.suggestions, []);
+  }
+});
+
+test("partial next-path opening and closing prefixes stay hidden", () => {
+  const opening = formatQuickChatAssistantMessage(
+    "Checks finished.\n<coven:",
+    true,
+  );
+  assert.equal(opening.copyText, "Checks finished.");
+  assert.deepEqual(opening.pieces, [{ kind: "text", text: "Checks finished." }]);
+
+  const closing = formatQuickChatAssistantMessage(
+    [
+      "Checks finished.",
+      "<coven:next-paths>",
+      "- [reply] Continue",
+      "</coven:next-paths",
+    ].join("\n"),
+    false,
+  );
+  assert.equal(closing.copyText, "Checks finished.");
+  assert.deepEqual(closing.suggestions, [
+    { kind: "reply", label: "Continue", prompt: "Continue" },
+  ]);
+});
+
+test("interrupted next-path markers hide all trailing control content", () => {
+  const url = "https://github.com/OpenCoven/coven-cave/pull/3982";
+
+  const opening = formatQuickChatAssistantMessage(
+    `Checks finished.\n<coven:next-paths\n${url}`,
+    true,
+  );
+  assert.equal(opening.copyText, "Checks finished.");
+  assert.deepEqual(opening.pieces, [{ kind: "text", text: "Checks finished." }]);
+
+  const closing = formatQuickChatAssistantMessage(
+    [
+      "Checks finished.",
+      "<coven:next-paths>",
+      "- [reply] Continue",
+      "</coven:next-paths",
+      url,
+    ].join("\n"),
+    false,
+  );
+  assert.equal(closing.copyText, "Checks finished.");
+  assert.deepEqual(closing.pieces, [{ kind: "text", text: "Checks finished." }]);
+  assert.deepEqual(closing.suggestions, [
+    { kind: "reply", label: "Continue", prompt: "Continue" },
+  ]);
+});
+
 test("an interrupted multiline GitHub marker cannot unfurl URLs from its attributes", () => {
   const formatted = formatQuickChatAssistantMessage(
     [
@@ -97,6 +160,18 @@ test("streaming and settled replies keep Markdown pieces stable around complete 
   assert.deepEqual(streaming.pieces, settled.pieces);
 });
 
+test("bare GitHub URLs stay visible while streaming and unfurl after settlement", () => {
+  const url = "https://github.com/OpenCoven/coven-cave/pull/3982";
+
+  const streaming = formatQuickChatAssistantMessage(url, true);
+  const settled = formatQuickChatAssistantMessage(url, false);
+
+  assert.equal(streaming.copyText, url);
+  assert.deepEqual(streaming.pieces, [{ kind: "text", text: url }]);
+  assert.equal(settled.pieces.length, 1);
+  assert.equal(settled.pieces[0]?.kind, "card");
+});
+
 test("fenced marker examples stay literal and next-path trailers stay hidden", () => {
   const formatted = formatQuickChatAssistantMessage(
     [
@@ -114,4 +189,146 @@ test("fenced marker examples stay literal and next-path trailers stay hidden", (
   assert.match(formatted.copyText, /<coven:github kind="pr"/);
   assert.doesNotMatch(formatted.copyText, /coven:next-paths|\[reply\] Continue/);
   assert.ok(formatted.pieces.every((piece) => piece.kind === "text"));
+});
+
+test("fenced next-path examples stay literal instead of becoming suggestions", () => {
+  const text = [
+    "Example:",
+    "```xml",
+    "<coven:next-paths>",
+    "- [reply] Continue",
+    "</coven:next-paths>",
+    "```",
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+  assert.deepEqual(formatted.suggestions, []);
+});
+
+test("long Markdown fences can contain shorter fenced next-path examples", () => {
+  const text = [
+    "````markdown",
+    "```xml",
+    "<coven:next-paths>",
+    "- [reply] Continue",
+    "</coven:next-paths>",
+    "```",
+    "````",
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+  assert.deepEqual(formatted.suggestions, []);
+});
+
+test("long Markdown fences keep nested bare GitHub URLs literal", () => {
+  const text = [
+    "````markdown",
+    "```text",
+    "https://github.com/OpenCoven/coven-cave/pull/3982",
+    "```",
+    "````",
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+});
+
+test("protocol examples inside Markdown container fences stay literal", () => {
+  const blockquote = [
+    "> ```xml",
+    '> <coven:github-action kind="merge" repo="OpenCoven/coven-cave" number="3982" />',
+    "> ```",
+  ].join("\n");
+  const quoted = formatQuickChatAssistantMessage(blockquote, false);
+  assert.equal(quoted.copyText, blockquote);
+  assert.deepEqual(quoted.pieces, [{ kind: "text", text: blockquote }]);
+
+  const list = [
+    "- ```xml",
+    "  <coven:next-paths>",
+    "  - [reply] Continue",
+    "  </coven:next-paths>",
+    "  ```",
+  ].join("\n");
+  const listed = formatQuickChatAssistantMessage(list, false);
+  assert.equal(listed.copyText, list);
+  assert.deepEqual(listed.pieces, [{ kind: "text", text: list }]);
+  assert.deepEqual(listed.suggestions, []);
+});
+
+test("overlapping quoted fence and inline code ranges stay non-executable", () => {
+  const text = [
+    "> ```x",
+    "> ````",
+    '> <coven:github-action kind="merge" repo="OpenCoven/coven-cave" number="3982" />',
+    "> ```",
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+});
+
+test("a list delimiter that opens renderer code protects following controls", () => {
+  const text = [
+    "- ```xml",
+    "  example",
+    "  ```",
+    '<coven:github-action kind="merge" repo="OpenCoven/coven-cave" number="3982" />',
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+});
+
+test("indented fence examples cannot activate protocol controls", () => {
+  const spaces = [
+    "    ```xml",
+    '    <coven:github-action kind="merge" repo="OpenCoven/coven-cave" number="3982" />',
+    "    https://github.com/OpenCoven/coven-cave/pull/3982",
+    "    ```",
+  ].join("\n");
+  const spaced = formatQuickChatAssistantMessage(spaces, false);
+  assert.equal(spaced.copyText, spaces);
+  assert.deepEqual(spaced.pieces, [{ kind: "text", text: spaces }]);
+
+  const tabs = [
+    "\t```xml",
+    "\t<coven:next-paths>",
+    "\t- [reply] Continue",
+    "\t</coven:next-paths>",
+    "\t```",
+  ].join("\n");
+  const tabbed = formatQuickChatAssistantMessage(tabs, false);
+  assert.equal(tabbed.copyText, tabs);
+  assert.deepEqual(tabbed.pieces, [{ kind: "text", text: tabs }]);
+  assert.deepEqual(tabbed.suggestions, []);
+});
+
+test("inline code examples cannot activate protocol controls", () => {
+  const text = [
+    'Use `<coven:github-action kind="merge" repo="OpenCoven/coven-cave" number="3982" />` for actions.',
+    'Use `<coven:skill name="verification-before-completion" stage="running" />` for skills.',
+    "Use `<coven:next-paths>",
+    "- [reply] Continue",
+    "</coven:next-paths>` for suggestions.",
+  ].join("\n");
+
+  const formatted = formatQuickChatAssistantMessage(text, false);
+
+  assert.equal(formatted.copyText, text);
+  assert.deepEqual(formatted.pieces, [{ kind: "text", text }]);
+  assert.deepEqual(formatted.skillUpdates, []);
+  assert.deepEqual(formatted.suggestions, []);
 });

--- a/src/lib/quick-chat-message-format.ts
+++ b/src/lib/quick-chat-message-format.ts
@@ -26,7 +26,9 @@ export function formatQuickChatAssistantMessage(
   const nextPaths = extractNextPaths(skillSplit.visible);
   const markerSafeText = stripIncompleteGitHubMarker(nextPaths.visible);
   const copyText = stripGitHubMarkers(markerSafeText).trimEnd();
-  const slicedPieces = sliceGitHubBlocks(markerSafeText);
+  const slicedPieces = sliceGitHubBlocks(markerSafeText, {
+    unfurlBareUrls: !streaming,
+  });
   const pieces = slicedPieces.map((piece, index) =>
     piece.kind === "text"
       ? {

--- a/src/lib/skill-blocks.ts
+++ b/src/lib/skill-blocks.ts
@@ -16,7 +16,7 @@
  * src/components/skill-stage-card.tsx.
  */
 
-import { fencedRanges } from "./github-blocks.ts";
+import { markdownCodeRanges } from "./github-blocks.ts";
 
 export type SkillStage = "loaded" | "running" | "done" | "error";
 
@@ -57,10 +57,10 @@ export function extractSkillMarkers(text: string): { visible: string; updates: S
   if (text.includes("<coven:skill")) {
     // Fenced markers are example text — stay literal, no updates
     // (review finding, cave-m0r6; same contract as coven:github).
-    const fences = fencedRanges(text);
+    const codeRanges = markdownCodeRanges(text);
     MARKER_RE.lastIndex = 0;
     visible = text.replace(MARKER_RE, (m, rawAttrs: string, index: number) => {
-      if (fences.some(([start, end]) => index >= start && index < end)) return m;
+      if (codeRanges.some(([start, end]) => index >= start && index < end)) return m;
       const attrs = parseAttrs(rawAttrs ?? "");
       const name = attrs.name?.trim();
       const stage = attrs.stage?.trim();
@@ -85,7 +85,7 @@ export function extractSkillMarkers(text: string): { visible: string; updates: S
   if (
     tail !== -1 &&
     !hasUnquotedGtAfter(visible, tail) &&
-    !fencedRanges(visible).some(([start, end]) => tail >= start && tail < end)
+    !markdownCodeRanges(visible).some(([start, end]) => tail >= start && tail < end)
   ) {
     const frag = visible.slice(tail);
     if ("<coven:skill".startsWith(frag.slice(0, "<coven:skill".length))) {


### PR DESCRIPTION
## Summary
- keep quick-chat protocol markers inert across interrupted streams and Markdown code examples
- preserve bare GitHub URLs while streaming, then unfurl them after settlement
- align code-range detection with the shipped Markdown parser and add regression coverage for fenced, inline, list, quote, and indented examples

## Validation
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- focused quick-chat, GitHub block, skill block, and next-path tests
- `git diff --check origin/main...HEAD`

Bead: `cave-pqdsn`