### PR TITLE
feat(voice): package the Kokoro (sherpa-onnx) runtime into desktop builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ src-tauri/resources/whisper/*
 !src-tauri/resources/whisper/placeholder.txt
 src-tauri/resources/piper/*
 !src-tauri/resources/piper/placeholder.txt
+src-tauri/resources/kokoro/*
+!src-tauri/resources/kokoro/placeholder.txt
 
 # Notarized release artifacts
 release/

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -371,6 +371,11 @@ WHISPER_CLI="$APP_PATH/Contents/Resources/resources/whisper/whisper-cli"
 require_file "$WHISPER_CLI"
 "$WHISPER_CLI" --version >/dev/null
 echo "    bundled Whisper runtime present"
+KOKORO_CLI="$APP_PATH/Contents/Resources/resources/kokoro/sherpa-onnx-offline-tts"
+require_file "$KOKORO_CLI"
+"$KOKORO_CLI" --help >/dev/null
+require_file "$APP_PATH/Contents/Resources/resources/kokoro/espeak-ng-data/phontab"
+echo "    bundled Kokoro runtime present"
 
 echo "==> Signing every native binary inside the bundle"
 # Apple deprecated --deep; sign inner native binaries explicitly so each one

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -144,7 +144,13 @@ assert.doesNotMatch(
 // Tauri assembles the app.
 assert.deepEqual(
   windowsConfig.bundle.resources,
-  ["resources/server-archive/**/*", "resources/node/**/*", "resources/whisper/**/*", "resources/piper/**/*"],
+  [
+    "resources/server-archive/**/*",
+    "resources/node/**/*",
+    "resources/whisper/**/*",
+    "resources/piper/**/*",
+    "resources/kokoro/**/*",
+  ],
   "Windows resources must replace the expanded sidecar with its bounded archive while retaining bundled runtimes",
 );
 assert.ok(
@@ -157,6 +163,27 @@ assert.ok(
 );
 assert.match(src, /bundle_piper_runtime\(\)/, "release bundling must provision the pinned Piper runtime");
 assert.match(src, /Piper runtime checksum mismatch/, "Piper runtime downloads must be integrity-checked");
+assert.ok(
+  baseConfig.bundle.resources.includes("resources/kokoro/**/*"),
+  "desktop bundles must retain the local Kokoro (sherpa-onnx) runtime",
+);
+assert.match(src, /bundle_kokoro_runtime\(\)/, "release bundling must provision the pinned Kokoro runtime");
+assert.match(src, /Kokoro runtime checksum mismatch/, "Kokoro runtime downloads must be integrity-checked");
+assert.match(
+  src,
+  /Kokoro espeak-ng-data checksum mismatch/,
+  "the espeak-ng-data payload that rides with the Kokoro runtime must be integrity-checked",
+);
+assert.match(
+  src,
+  /tar -xjf "\$espeak_archive" -C "\$KOKORO_RUNTIME_DIR"/,
+  "espeak-ng-data must be staged beside the Kokoro executable, not inside the voice-model download",
+);
+assert.doesNotMatch(
+  sourceSection(src, "bundle_kokoro_runtime()", "fix_node_pty_spawn_helpers()", "Kokoro staging section"),
+  /placeholder\.txt/,
+  "the generated Kokoro payload must not spend an MSI row on the source-tree placeholder",
+);
 assert.match(
   src,
   /if \[ -f "\$PIPER_RUNTIME_DIR\/espeak-ng" \]; then[\s\S]*chmod \+x "\$PIPER_RUNTIME_DIR\/espeak-ng"/,

--- a/scripts/sidecar-bundle.sh
+++ b/scripts/sidecar-bundle.sh
@@ -19,6 +19,7 @@ WINDOWS_ARCHIVE_TEMP="$WINDOWS_ARCHIVE_DIR/.server.tar.zst.$$.tmp"
 WINDOWS_ARCHIVE_MANIFEST_TEMP="$WINDOWS_ARCHIVE_DIR/.manifest.json.$$.tmp"
 BUNDLED_NODE_DIR="$ROOT/src-tauri/resources/node"
 PIPER_RUNTIME_DIR="$ROOT/src-tauri/resources/piper"
+KOKORO_RUNTIME_DIR="$ROOT/src-tauri/resources/kokoro"
 # Use Node rather than shell-specific environment variables (such as OS) so
 # Git Bash and CI build the same Windows resource layout.
 BUILD_PLATFORM="$(node -p 'process.platform')"
@@ -90,6 +91,115 @@ bundle_piper_runtime() {
   chmod +x "$PIPER_RUNTIME_DIR/$executable" 2>/dev/null || true
   if [ -f "$PIPER_RUNTIME_DIR/espeak-ng" ]; then
     chmod +x "$PIPER_RUNTIME_DIR/espeak-ng"
+  fi
+}
+
+# Kokoro synthesis runs through the sherpa-onnx offline TTS CLI. The upstream
+# release archives ship dozens of demo binaries; stage only the offline-tts
+# CLI plus the onnxruntime library it links (rpath starts with
+# @loader_path/$ORIGIN, so a flat directory resolves). espeak-ng-data rides
+# with the runtime — NOT the voice-model download — because Kokoro
+# phonemization needs it wherever the executable lives (the Node runner passes
+# --kokoro-data-dir=<dir-of-executable>/espeak-ng-data).
+bundle_kokoro_runtime() {
+  local platform asset expected_sha archive extract_root executable bin_root runtime_root actual_sha
+  local espeak_asset espeak_sha espeak_archive
+  platform="$(node -p 'process.platform')"
+  case "$platform/$(node -p 'process.arch')" in
+    linux/x64)
+      asset="sherpa-onnx-v1.13.4-linux-x64-shared.tar.bz2"
+      expected_sha="18887dc13c7d313d0e0f6c164ed31715c27c1c2c4f71acd7c0147dc84cf02514"
+      executable="sherpa-onnx-offline-tts"
+      ;;
+    win32/x64)
+      asset="sherpa-onnx-v1.13.4-win-x64-shared-MD-Release.tar.bz2"
+      expected_sha="d4dacc8be5afe03f22ade4d50cfd587c03a625eaca8c41f2d99a24d3db463eab"
+      executable="sherpa-onnx-offline-tts.exe"
+      ;;
+    darwin/arm64)
+      asset="sherpa-onnx-v1.13.4-osx-arm64-shared.tar.bz2"
+      expected_sha="809ab5d0c77bd8f358364a244e6ab17f2afecf9779eb9fd436fa469c3ff5375c"
+      executable="sherpa-onnx-offline-tts"
+      ;;
+    darwin/x64)
+      # Upstream publishes no x86_64-only shared archive; universal2 covers it.
+      asset="sherpa-onnx-v1.13.4-osx-universal2-shared.tar.bz2"
+      expected_sha="02b9b0cf30819a18c6d5cf861aebf32336cb79958ab97a2b248227059678058b"
+      executable="sherpa-onnx-offline-tts"
+      ;;
+    *)
+      echo "ERROR: no managed Kokoro (sherpa-onnx) runtime for $platform/$(node -p 'process.arch')" >&2
+      exit 1
+      ;;
+  esac
+  espeak_asset="espeak-ng-data.tar.bz2"
+  espeak_sha="4135ccf82e1f40613491c0874d4945ae9e9c7840933d8e25a6f9e003d9ebf533"
+
+  archive="$PNPM_STAGE/$asset"
+  extract_root="$PNPM_STAGE/kokoro-runtime"
+  echo "==> downloading pinned Kokoro (sherpa-onnx) runtime $asset"
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/v1.13.4/$asset" \
+    --output "$archive"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha="$(sha256sum "$archive" | awk '{print $1}')"
+  else
+    actual_sha="$(shasum -a 256 "$archive" | awk '{print $1}')"
+  fi
+  if [ "$actual_sha" != "$expected_sha" ]; then
+    echo "ERROR: Kokoro runtime checksum mismatch for $asset" >&2
+    exit 1
+  fi
+
+  espeak_archive="$PNPM_STAGE/$espeak_asset"
+  echo "==> downloading pinned espeak-ng-data for the Kokoro runtime"
+  curl --fail --location --retry 3 --silent --show-error \
+    "https://github.com/k2-fsa/sherpa-onnx/releases/download/tts-models/$espeak_asset" \
+    --output "$espeak_archive"
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual_sha="$(sha256sum "$espeak_archive" | awk '{print $1}')"
+  else
+    actual_sha="$(shasum -a 256 "$espeak_archive" | awk '{print $1}')"
+  fi
+  if [ "$actual_sha" != "$espeak_sha" ]; then
+    echo "ERROR: Kokoro espeak-ng-data checksum mismatch for $espeak_asset" >&2
+    exit 1
+  fi
+
+  rm -rf "$extract_root" "$KOKORO_RUNTIME_DIR"
+  mkdir -p "$extract_root" "$KOKORO_RUNTIME_DIR"
+  tar -xjf "$archive" -C "$extract_root"
+  bin_root="$(dirname "$(find "$extract_root" -type f -name "$executable" -print -quit)")"
+  if [ -z "$bin_root" ] || [ ! -f "$bin_root/$executable" ]; then
+    echo "ERROR: Kokoro archive does not contain $executable" >&2
+    exit 1
+  fi
+  runtime_root="$(dirname "$bin_root")"
+  cp "$bin_root/$executable" "$KOKORO_RUNTIME_DIR/"
+  if [ "$platform" = "win32" ]; then
+    # Windows resolves DLLs beside the executable; upstream stages them in bin/.
+    cp "$bin_root"/*.dll "$KOKORO_RUNTIME_DIR/"
+  elif [ "$platform" = "darwin" ]; then
+    # The TTS CLI's only runtime link dependency is the versioned dylib
+    # (LC_LOAD_DYLIB @rpath/libonnxruntime.1.27.0.dylib); the unversioned
+    # sibling in the archive is a full 28MB duplicate, not a symlink.
+    cp "$runtime_root"/lib/libonnxruntime.*.dylib "$KOKORO_RUNTIME_DIR/"
+  else
+    # DT_NEEDED references the unversioned soname; it is the only .so needed.
+    cp "$runtime_root"/lib/libonnxruntime.so "$KOKORO_RUNTIME_DIR/"
+  fi
+  tar -xjf "$espeak_archive" -C "$KOKORO_RUNTIME_DIR"
+  if [ ! -d "$KOKORO_RUNTIME_DIR/espeak-ng-data" ]; then
+    echo "ERROR: espeak-ng-data did not extract beside the Kokoro executable" >&2
+    exit 1
+  fi
+  chmod +x "$KOKORO_RUNTIME_DIR/$executable" 2>/dev/null || true
+  if [ "$platform" = "darwin" ]; then
+    # Upstream's ad-hoc signatures do not survive staging: the copied pages
+    # fault with SIGKILL (Code Signature Invalid) on Apple silicon. Re-sign
+    # cleanly here; release builds re-sign again with the real identity when
+    # Tauri assembles the app.
+    codesign --force -s - "$KOKORO_RUNTIME_DIR"/libonnxruntime* "$KOKORO_RUNTIME_DIR/$executable"
   fi
 }
 
@@ -305,6 +415,7 @@ write_windows_sidecar_archive() {
 }
 
 bundle_piper_runtime
+bundle_kokoro_runtime
 
 echo "==> next build"
 (cd "$ROOT" && pnpm build) >&2

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -32,6 +32,13 @@ const bundledPiper = path.join(
   "piper",
   process.platform === "win32" ? "piper.exe" : "piper",
 );
+const bundledKokoro = path.join(
+  root,
+  "src-tauri",
+  "resources",
+  "kokoro",
+  process.platform === "win32" ? "sherpa-onnx-offline-tts.exe" : "sherpa-onnx-offline-tts",
+);
 const token = "sidecar-runtime-smoke-token";
 
 function reservePort() {
@@ -120,6 +127,7 @@ function launchSidecar({ sidecarServer, sidecarRoot, covenHome, port, environmen
       COVEN_CAVE_BUNDLE: "1",
       COVEN_WHISPER_CPP_BIN: bundledWhisper,
       COVEN_PIPER_BIN: bundledPiper,
+      COVEN_KOKORO_BIN: bundledKokoro,
       COVEN_CAVE_AUTH_TOKEN: token,
       COVEN_HOME: covenHome,
       NEXT_TELEMETRY_DISABLED: "1",
@@ -319,6 +327,18 @@ async function main() {
     `packaged Piper runtime must launch from resources: ${piperHelp.stderr || piperHelp.error}`,
   );
 
+  const kokoroHelp = spawnSync(bundledKokoro, ["--help"], {
+    encoding: "utf8",
+  });
+  assert.equal(
+    kokoroHelp.status,
+    0,
+    `packaged Kokoro (sherpa-onnx) runtime must launch from resources: ${kokoroHelp.stderr || kokoroHelp.error}`,
+  );
+  // espeak-ng-data must ride beside the Kokoro executable: the Node runner
+  // passes --kokoro-data-dir=<dir-of-executable>/espeak-ng-data.
+  await access(path.join(path.dirname(bundledKokoro), "espeak-ng-data", "phontab"));
+
   const nativeModules = spawnSync(
     bundledNode,
     ["-e", "require('sharp'); require('node-pty')"],
@@ -454,6 +474,11 @@ async function main() {
       engines.runtimes?.piper?.available,
       true,
       "the sidecar must execute the managed Piper resource, not fall back to PATH",
+    );
+    assert.equal(
+      engines.runtimes?.kokoro?.available,
+      true,
+      "the sidecar must execute the managed Kokoro (sherpa-onnx) resource, not fall back to PATH",
     );
 
     const marketplaceResponse = await fetch(`${baseUrl}/api/marketplace`, {

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -246,6 +246,11 @@ test("macOS reachability daemon uses the managed Piper runtime", async () => {
     /\.env\("COVEN_PIPER_BIN", &piper\)/,
     "the background sidecar must pass its managed Piper path to local TTS",
   );
+  assert.match(
+    daemon,
+    /\.env\("COVEN_KOKORO_BIN", &kokoro\)/,
+    "the background sidecar must pass its managed Kokoro path to local TTS",
+  );
 });
 
 test("clean release runners have resource glob placeholders", async () => {
@@ -257,6 +262,7 @@ test("clean release runners have resource glob placeholders", async () => {
     access(new URL("./resources/node/placeholder.txt", import.meta.url)),
     access(new URL("./resources/whisper/placeholder.txt", import.meta.url)),
     access(new URL("./resources/piper/placeholder.txt", import.meta.url)),
+    access(new URL("./resources/kokoro/placeholder.txt", import.meta.url)),
   ]);
 
   assert.match(
@@ -287,6 +293,13 @@ test("clean release runners have resource glob placeholders", async () => {
     /!src-tauri\/resources\/piper\/placeholder\.txt/,
     "Piper placeholder must be tracked so resources/piper/**/* matches in clean CI",
   );
+  assert.match(
+    gitignore,
+    /!src-tauri\/resources\/kokoro\/placeholder\.txt/,
+    "Kokoro placeholder must be tracked so resources/kokoro/**/* matches in clean CI",
+  );
+  assert.match(releaseScript, /KOKORO_CLI=.*resources\/kokoro\/sherpa-onnx-offline-tts/, "macOS release must resolve the bundled Kokoro runtime before signing");
+  assert.match(releaseScript, /"\$KOKORO_CLI" --help/, "macOS release must smoke-test the copied Kokoro runtime");
 });
 
 test("native updater cleanup stops the sidecar before Windows exits", async () => {

--- a/src-tauri/resources/kokoro/placeholder.txt
+++ b/src-tauri/resources/kokoro/placeholder.txt
@@ -1,0 +1,1 @@
+generated at release build time

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -1554,6 +1554,13 @@ fn run_sidecar_daemon() -> Result<i32, String> {
             piper.display()
         ));
     }
+    let kokoro = bundled_kokoro_path(&resource_dir);
+    if !kokoro.is_file() {
+        return Err(format!(
+            "bundled Kokoro runtime is unavailable at {}",
+            kokoro.display()
+        ));
+    }
     let port = daemon_port()?;
     let auth_token = sidecar_auth_token();
     let mobile_access_token =
@@ -1582,6 +1589,7 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         .env("NODE_ENV", "production")
         .env("COVEN_CAVE_BUNDLE", "1")
         .env("COVEN_PIPER_BIN", &piper)
+        .env("COVEN_KOKORO_BIN", &kokoro)
         .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
         .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token)
         .stdin(Stdio::null());

--- a/src-tauri/src/sidecar_discovery.rs
+++ b/src-tauri/src/sidecar_discovery.rs
@@ -59,6 +59,22 @@ pub(super) fn bundled_piper_path(resource_dir: &Path) -> PathBuf {
         .join("piper")
 }
 
+#[cfg(all(desktop, target_os = "windows"))]
+pub(super) fn bundled_kokoro_path(resource_dir: &Path) -> PathBuf {
+    resource_dir
+        .join("resources")
+        .join("kokoro")
+        .join("sherpa-onnx-offline-tts.exe")
+}
+
+#[cfg(all(desktop, not(target_os = "windows")))]
+pub(super) fn bundled_kokoro_path(resource_dir: &Path) -> PathBuf {
+    resource_dir
+        .join("resources")
+        .join("kokoro")
+        .join("sherpa-onnx-offline-tts")
+}
+
 /// Find a usable `node` binary. Release builds include a Node runtime under
 /// bundled resources so clean user machines can boot the sidecar. Development
 /// builds can still fall back to common local Node installs.

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -154,6 +154,20 @@ pub(super) fn start_sidecar_runtime(
             "[cave] bundled Piper is unavailable in development; local voices will use an explicit COVEN_PIPER_BIN or PATH fallback"
         );
     }
+    let kokoro = bundled_kokoro_path(&resource_dir);
+    if !cfg!(debug_assertions) && !kokoro.is_file() {
+        return Err(SidecarStartError::Failed(format!(
+            "bundled Kokoro runtime not found at {}",
+            kokoro.display()
+        )));
+    }
+    if kokoro.is_file() {
+        log::info!("[cave] using bundled Kokoro at {}", kokoro.display());
+    } else {
+        log::warn!(
+            "[cave] bundled Kokoro is unavailable in development; Kokoro voices will use an explicit COVEN_KOKORO_BIN or PATH fallback"
+        );
+    }
     let whisper_cli = find_bundled_whisper_cli(&resource_dir).ok_or_else(|| {
         SidecarStartError::Failed(
             "Could not find the bundled local Whisper runtime. Reinstall CovenCave or contact support."
@@ -273,6 +287,9 @@ pub(super) fn start_sidecar_runtime(
     }
     if piper.is_file() {
         command.env("COVEN_PIPER_BIN", node_arg_path(&piper));
+    }
+    if kokoro.is_file() {
+        command.env("COVEN_KOKORO_BIN", node_arg_path(&kokoro));
     }
 
     // Ubuntu's pinned whisper.cpp archive keeps its shared objects next to the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,8 @@
       "resources/server/**/*",
       "resources/node/**/*",
       "resources/whisper/**/*",
-      "resources/piper/**/*"
+      "resources/piper/**/*",
+      "resources/kokoro/**/*"
     ],
     "icon": [
       "icons/32x32.png",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -5,7 +5,8 @@
       "resources/server-archive/**/*",
       "resources/node/**/*",
       "resources/whisper/**/*",
-      "resources/piper/**/*"
+      "resources/piper/**/*",
+      "resources/kokoro/**/*"
     ],
     "windows": {
       "webviewInstallMode": {


### PR DESCRIPTION
## Summary

Implements **cave-2svvx**: packaged desktop builds reported the Kokoro TTS runtime unavailable because nothing bundled it — the cave-tr09i wiring (registry entry, sherpa-onnx runner, route dispatch, UI gating) was dev-runtime-only. This mirrors the Piper packaging pattern end to end.

- **`bundle_kokoro_runtime()`** in `sidecar-bundle.sh`: downloads the sha256-pinned sherpa-onnx **v1.13.4** per-platform archive (linux-x64 / win-x64 MD-Release / osx-arm64 / osx-universal2 for darwin-x64, which upstream doesn't publish standalone) plus the pinned `espeak-ng-data` payload from the tts-models release, and stages a **flat `resources/kokoro/`** containing only the offline-tts CLI + the single onnxruntime library it links. Verified rpaths (`@loader_path` / `$ORIGIN` first) make the flat layout resolve on all three platforms; upstream's unversioned macOS dylib is a full 28MB byte-duplicate and is dropped.
- **espeak-ng-data rides with the runtime, not the voice-model download** — the Node runner passes `--kokoro-data-dir=<dir-of-executable>/espeak-ng-data` (pinned by the runner contract from cave-tr09i).
- **macOS ad-hoc re-sign after staging**: upstream's signatures don't survive staging — reproduced `SIGKILL (Code Signature Invalid)` from the crash report, and a clean `codesign --force -s -` fixes it deterministically. Release builds re-sign with the real identity during the existing generic dylib/executable sweep in `release.sh`.
- **Fail-closed release startup**: `sidecar_startup.rs` (GUI) and `desktop_reachability.rs` (daemon relaunch) error if the bundled runtime is missing and inject `COVEN_KOKORO_BIN` beside `COVEN_PIPER_BIN`. `kokoroExecutable()` already honors it (no server change, as the bead predicted).
- **CI**: the Sidecar runtime smoke now probes the bundled CLI (`--help` exit 0), asserts `espeak-ng-data/phontab` rides beside it, and requires `engines.runtimes.kokoro.available` via the managed resource on ubuntu + windows.
- **macOS release gate**: `release.sh` requires the runtime + data in the DMG and smoke-runs it, matching the Whisper guard; `release-runtime.test.mjs` pins all of the above.

## Size delta (bead criterion 4)

Measured darwin/arm64: **47MB unpacked → ~17MB compressed** (2MB CLI + 28MB libonnxruntime + 19MB espeak-ng-data). Linux ships one 16MB `.so` instead; Windows two DLLs. Within budget — no download-on-demand needed.

## Verification

- The exact shipped function was executed end-to-end on darwin/arm64 (fresh staging → `--help` exit 0 → size probe).
- `sidecar-bundle-deps.test.mjs` (updated pins incl. the Windows resources list) and `release-runtime.test.mjs` (23 tests) pass; `cargo check` clean; `bash -n` + `node --check` clean.
- The Sidecar runtime required check exercises the real download → stage → smoke path on both CI platforms in this PR.

Closes cave-2svvx (bd) after merge. Unblocks cave-xopgb (named Kokoro speakers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)