### PR TITLE
feat: expose canonical memory to verified mobile clients

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -55,9 +55,9 @@ const contracts: RouteContract[] = [
   { route: "/codex-automations/[id]/runs/[runId]/log", methods: ["GET"], kind: "json" },
   { route: "/codex-automations", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/config", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },
-  { route: "/coven-memory", methods: ["GET"], kind: "json", localOriginGuard: true },
-  { route: "/coven-memory/[id]", methods: ["GET"], kind: "json", localOriginGuard: true },
-  { route: "/coven-memory/overview", methods: ["GET"], kind: "json", localOriginGuard: true },
+  { route: "/coven-memory", methods: ["GET", "POST"], kind: "json", localOriginGuard: true },
+  { route: "/coven-memory/[id]", methods: ["GET", "POST"], kind: "json", localOriginGuard: true },
+  { route: "/coven-memory/overview", methods: ["GET", "POST"], kind: "json", localOriginGuard: true },
   { route: "/coven/exec", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/daemon/capabilities", methods: ["GET"], kind: "json" },
   { route: "/daemon/probe", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
@@ -135,6 +135,9 @@ const contracts: RouteContract[] = [
   { route: "/launch", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/mobile-handoff", methods: ["GET", "POST"], kind: "json", readsJson: true },
   { route: "/mobile-token/refresh", methods: ["POST"], kind: "json" },
+  { route: "/mobile/coven-memory", methods: ["GET", "POST", "HEAD", "OPTIONS"], kind: "json" },
+  { route: "/mobile/coven-memory/[id]", methods: ["GET", "POST", "HEAD", "OPTIONS"], kind: "json" },
+  { route: "/mobile/coven-memory/overview", methods: ["GET", "POST", "HEAD", "OPTIONS"], kind: "json" },
   { route: "/mcp", methods: ["GET"], kind: "json" },
   { route: "/mcp/health", methods: ["GET"], kind: "json" },
   { route: "/marketplace", methods: ["GET"], kind: "json" },
@@ -283,13 +286,18 @@ function routeFromFile(file: string): string {
 }
 
 function exportedMethods(source: string): string[] {
-  const direct = [...source.matchAll(/export async function (GET|POST|PUT|PATCH|DELETE)\b/g)].map((match) => match[1]);
-  const aliases = [...source.matchAll(/^\s*[A-Za-z_$][\w$]*\s+as (GET|POST|PUT|PATCH|DELETE)\b/gm)].map((match) => match[1]);
-  return [...direct, ...aliases];
+  const method = "GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS";
+  const functions = [...source.matchAll(new RegExp(`export (?:async )?function (${method})\\b`, "g"))]
+    .map((match) => match[1]);
+  const constants = [...source.matchAll(new RegExp(`export const (${method})\\b`, "g"))]
+    .map((match) => match[1]);
+  const aliases = [...source.matchAll(new RegExp(`^\\s*[A-Za-z_$][\\w$]*\\s+as (${method})\\b`, "gm"))]
+    .map((match) => match[1]);
+  return [...functions, ...constants, ...aliases];
 }
 
 function usesJsonResponse(source: string): boolean {
-  return /NextResponse\.json|Response\.json|new Response\(|canonicalMemoryJson/.test(source);
+  return /NextResponse\.json|Response\.json|new Response\(|canonicalMemory(?:Json|ListResponse|OverviewResponse|DetailResponse)\s*\(/.test(source);
 }
 
 function effectiveRouteSource(file: string, source: string): string {

--- a/src/app/api/coven-memory/route.test.ts
+++ b/src/app/api/coven-memory/route.test.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import { after, test } from "node:test";
 
 const MEMORY_ID = "11111111-1111-5111-8111-111111111111";
+const MOBILE_ACCESS_HEADER = "x-coven-cave-mobile-access";
 const TEST_ROOT = mkdtempSync(path.join(tmpdir(), "coven-memory-routes-"));
 const COVEN_HOME = path.join(TEST_ROOT, "coven");
 const CAVE_HOME = path.join(TEST_ROOT, "cave");
@@ -218,12 +219,119 @@ async function expectSuccess(
   return body;
 }
 
+test("mobile canonical-memory routes require a verified mobile request before daemon access", async () => {
+  const [listModule, overviewModule, detailModule] = await Promise.all([
+    import("../mobile/coven-memory/route.ts"),
+    import("../mobile/coven-memory/overview/route.ts"),
+    import("../mobile/coven-memory/[id]/route.ts"),
+  ]);
+  const httpMethods = [
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "HEAD",
+    "OPTIONS",
+  ];
+  for (const routeModule of [listModule, overviewModule, detailModule]) {
+    assert.equal(routeModule.dynamic, "force-dynamic");
+    assert.equal(routeModule.runtime, "nodejs");
+    assert.deepEqual(
+      Object.keys(routeModule)
+        .filter((name) => httpMethods.includes(name))
+        .sort(),
+      ["GET", "HEAD", "OPTIONS", "POST"],
+    );
+  }
+
+  const routes: Route[] = [
+    {
+      name: "mobile list",
+      pathname: "/api/mobile/coven-memory",
+      call: (req) => listModule.GET(req),
+    },
+    {
+      name: "mobile overview",
+      pathname: "/api/mobile/coven-memory/overview",
+      call: (req) => overviewModule.GET(req),
+    },
+    {
+      name: "mobile detail",
+      pathname: `/api/mobile/coven-memory/${MEMORY_ID}`,
+      call: (req, id = MEMORY_ID) =>
+        detailModule.GET(req, { params: Promise.resolve({ id }) }),
+    },
+  ];
+
+  let before = socketPaths.length;
+  for (const route of routes) {
+    const response = await route.call(request(route.pathname));
+    assert.equal(
+      response.status,
+      401,
+      `${route.name} must require verified mobile access`,
+    );
+    assert.deepEqual(await responseJson(response), {
+      ok: false,
+      code: "mobile_access_required",
+    });
+  }
+  assert.equal(
+    socketPaths.length,
+    before,
+    "unstamped mobile requests must perform zero daemon reads",
+  );
+
+  before = socketPaths.length;
+  // Direct route tests run below `proxy.ts`, so they intentionally set its
+  // trusted marker. `project-permission-routes.test.ts` pins spoof resistance.
+  const [listBody, overviewBody, detailBody] = await Promise.all(
+    routes.map((route) =>
+      expectSuccess(route, { [MOBILE_ACCESS_HEADER]: "1" }),
+    ),
+  );
+  assert.deepEqual(socketPaths.slice(before).sort(), [
+    "/api/v1/memory",
+    `/api/v1/memory/${MEMORY_ID}`,
+    "/api/v1/memory/overview",
+  ].sort());
+  assert.deepEqual(listBody.entries[0].source, {
+    kind: "coven-origin",
+    label: "Coven origin",
+  });
+  assert.equal(overviewBody.overview.totals.entries, 1);
+  assert.equal(detailBody.entry.id, MEMORY_ID);
+
+  before = socketPaths.length;
+  for (const [routeModule, pathname] of [
+    [listModule, "/api/mobile/coven-memory"],
+    [overviewModule, "/api/mobile/coven-memory/overview"],
+    [detailModule, `/api/mobile/coven-memory/${MEMORY_ID}`],
+  ] as const) {
+    for (const method of ["POST", "HEAD", "OPTIONS"] as const) {
+      const response = await routeModule[method](request(pathname));
+      assert.equal(response.status, 405, `${method} ${pathname} must be rejected`);
+      assert.equal(response.headers.get("allow"), "GET");
+      assert.deepEqual(await responseJson(response), {
+        ok: false,
+        code: "method_not_allowed",
+      });
+    }
+  }
+  assert.equal(
+    socketPaths.length,
+    before,
+    "mobile read-only route rejection must perform zero daemon reads",
+  );
+});
+
 test("all canonical-memory routes enforce the local boundary before config or transport", async () => {
   const listModule = await import("./route.ts");
   const firstSocketCount = socketPaths.length;
   const firstDenied = await listModule.GET(
     request("/api/coven-memory", {
-      "x-coven-cave-mobile-access": "1",
+      [MOBILE_ACCESS_HEADER]: "1",
     }),
   );
   assert.equal(firstDenied.status, 403);
@@ -294,11 +402,11 @@ test("all canonical-memory routes enforce the local boundary before config or tr
   ];
 
   for (const route of routes) {
-    await expectDenied(route, { "x-coven-cave-mobile-access": "1" });
+    await expectDenied(route, { [MOBILE_ACCESS_HEADER]: "1" });
   }
   await expectDenied(
     routes[2],
-    { "x-coven-cave-mobile-access": "1" },
+    { [MOBILE_ACCESS_HEADER]: "1" },
     "../fixture-note.md",
   );
 

--- a/src/app/api/mobile/coven-memory/[id]/route.ts
+++ b/src/app/api/mobile/coven-memory/[id]/route.ts
@@ -1,0 +1,25 @@
+import {
+  canonicalMemoryDetailResponse,
+  canonicalMemoryMethodNotAllowed,
+} from "@/lib/server/canonical-memory-gateway";
+import { rejectUnverifiedMobileCanonicalMemoryRequest } from "@/lib/server/mobile-canonical-memory-request";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  context: { params: Promise<{ id: string }> },
+) {
+  const denied = rejectUnverifiedMobileCanonicalMemoryRequest(req);
+  if (denied) return denied;
+  const { id } = await context.params;
+  return canonicalMemoryDetailResponse(id);
+}
+
+export function POST() {
+  return canonicalMemoryMethodNotAllowed();
+}
+
+export const HEAD = POST;
+export const OPTIONS = POST;

--- a/src/app/api/mobile/coven-memory/overview/route.ts
+++ b/src/app/api/mobile/coven-memory/overview/route.ts
@@ -1,0 +1,21 @@
+import {
+  canonicalMemoryMethodNotAllowed,
+  canonicalMemoryOverviewResponse,
+} from "@/lib/server/canonical-memory-gateway";
+import { rejectUnverifiedMobileCanonicalMemoryRequest } from "@/lib/server/mobile-canonical-memory-request";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const denied = rejectUnverifiedMobileCanonicalMemoryRequest(req);
+  if (denied) return denied;
+  return canonicalMemoryOverviewResponse();
+}
+
+export function POST() {
+  return canonicalMemoryMethodNotAllowed();
+}
+
+export const HEAD = POST;
+export const OPTIONS = POST;

--- a/src/app/api/mobile/coven-memory/route.ts
+++ b/src/app/api/mobile/coven-memory/route.ts
@@ -1,0 +1,21 @@
+import {
+  canonicalMemoryListResponse,
+  canonicalMemoryMethodNotAllowed,
+} from "@/lib/server/canonical-memory-gateway";
+import { rejectUnverifiedMobileCanonicalMemoryRequest } from "@/lib/server/mobile-canonical-memory-request";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const denied = rejectUnverifiedMobileCanonicalMemoryRequest(req);
+  if (denied) return denied;
+  return canonicalMemoryListResponse();
+}
+
+export function POST() {
+  return canonicalMemoryMethodNotAllowed();
+}
+
+export const HEAD = POST;
+export const OPTIONS = POST;

--- a/src/lib/server/mobile-canonical-memory-request.ts
+++ b/src/lib/server/mobile-canonical-memory-request.ts
@@ -1,0 +1,21 @@
+import { MOBILE_ACCESS_HEADER } from "../../proxy-helpers.ts";
+
+function hasProxyIssuedMobileMarker(req: Request): boolean {
+  return req.headers.get(MOBILE_ACCESS_HEADER) === "1";
+}
+
+/**
+ * `proxy.ts` removes every client-supplied `x-coven-cave-mobile-access` value
+ * and re-adds `1` only after validating the Cave mobile credential. Route
+ * handlers call this guard downstream of that trust boundary; the invariant is
+ * pinned by `src/app/api/project-permission-routes.test.ts`.
+ */
+export function rejectUnverifiedMobileCanonicalMemoryRequest(
+  req: Request,
+): Response | null {
+  if (hasProxyIssuedMobileMarker(req)) return null;
+  return Response.json(
+    { ok: false, code: "mobile_access_required" },
+    { status: 401, headers: { "Cache-Control": "private, no-store" } },
+  );
+}

--- a/tests/mobile/canonical-memory-boundary.spec.ts
+++ b/tests/mobile/canonical-memory-boundary.spec.ts
@@ -41,6 +41,10 @@ function syntheticDefault(pathname: string): unknown {
   return { ok: true };
 }
 
+function isRouteFamily(pathname: string, base: string): boolean {
+  return pathname === base || pathname.startsWith(`${base}/`);
+}
+
 async function routeSyntheticMobile(
   route: Route,
   state: BoundaryState,
@@ -60,7 +64,10 @@ async function routeSyntheticMobile(
     await route.fallback();
     return;
   }
-  if (pathname.startsWith("/api/coven-memory")) {
+  if (
+    isRouteFamily(pathname, "/api/coven-memory") ||
+    isRouteFamily(pathname, "/api/mobile/coven-memory")
+  ) {
     state.outboundCanonicalMarkers.push(
       request.headers()["x-coven-cave-mobile-access"],
     );
@@ -125,7 +132,12 @@ async function openMobileMemory(page: Page, state: BoundaryState) {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
   });
   page.on("response", async (response) => {
-    if (new URL(response.url()).pathname.startsWith("/api/coven-memory")) {
+    if (
+      isRouteFamily(
+        new URL(response.url()).pathname,
+        "/api/coven-memory",
+      )
+    ) {
       state.canonicalStatuses.push(response.status());
       const body = await response.json().catch(() => null);
       if (
@@ -206,4 +218,38 @@ test("paired mobile is denied canonical reads while synthetic file memory remain
     dialog.getByRole("button", { name: "Edit memory file" }),
   ).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Copy path" })).toBeVisible();
+});
+
+test("mobile canonical route trusts only the proxy-authenticated marker", async ({
+  request,
+}) => {
+  const untrustedLocalPeer = {
+    "x-coven-cave-local-peer": "mobile-untrusted",
+  };
+  const spoofed = await request.get("/api/mobile/coven-memory/overview", {
+    headers: {
+      "x-coven-cave-mobile-access": "1",
+    },
+  });
+  expect(spoofed.status()).toBe(401);
+  expect(await spoofed.json()).toEqual({
+    ok: false,
+    code: "mobile_access_required",
+  });
+
+  const authenticated = await request.get(
+    "/api/mobile/coven-memory/overview",
+    {
+      headers: {
+        ...untrustedLocalPeer,
+        authorization: "Bearer test-fixture",
+        "x-coven-cave-mobile-access": "forged",
+      },
+    },
+  );
+  expect(authenticated.status()).toBe(503);
+  expect(await authenticated.json()).toEqual({
+    ok: false,
+    code: "canonical_memory_unavailable",
+  });
 });


### PR DESCRIPTION
## Summary
- add dedicated proxy-authenticated, read-only mobile canonical-memory list, overview, and detail routes
- reuse the bounded, path-free canonical gateway without changing desktop-only routes
- explicitly reject `POST`, `HEAD`, and `OPTIONS` with `405` and zero daemon access

## Why
Coven Memory can now reuse Cave's **Open on phone** pairing without treating a Cave mobile credential as local desktop authority.

Tracked by `cave-n71fa`.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired` — 1,349 files wired
- API suite with Codex discovery disabled via a non-executable fixture — 298 test files passed
- focused canonical-memory route tests — 2 passed after the final rebase
- `pnpm exec playwright test tests/mobile/canonical-memory-boundary.spec.ts --project=pixel-5` — 5 passed after the final rebase
- `git diff --check`

## Known local baseline
The unmodified `pnpm test:api` command fails on machines with a real Codex CLI because an upstream integration test counts the three new Codex discovery subprocesses before its old zero-process assertion. The feature does not touch that seam; the hermetic-test fix is tracked separately as `cave-g3qar`.