### PR TITLE
fix(codex): give the capability probe a realistic cold-start timeout

### DIFF
--- a/src/app/api/chat/send/harness-routing-codex-direct.test.ts
+++ b/src/app/api/chat/send/harness-routing-codex-direct.test.ts
@@ -146,6 +146,16 @@ try {
   }));
   const { events } = await readSse(response);
 
+  // Diagnose path selection before asserting bubbles: if the capability
+  // probe timed out or failed, the route silently serves the turn through
+  // the generic coven fallback and every tool assertion below would report
+  // an unhelpful empty list.
+  const directExecCalls = (await loggedCalls(codexLog)).filter((args) => args[0] === "exec");
+  assert.ok(
+    directExecCalls.length > 0,
+    `the verified CLI must serve this turn directly, not fall back (coven argv: ${JSON.stringify(await loggedCalls(covenLog))})`,
+  );
+
   const toolEvents = events.filter((event) => event.kind === "tool_use");
   assert.ok(
     toolEvents.some((event) => event.name === "Bash" && event.status === "running"),

--- a/src/lib/codex-compatibility.ts
+++ b/src/lib/codex-compatibility.ts
@@ -917,10 +917,21 @@ function codexProbeCacheKey(target: Required<CodexProbeTarget>, env: NodeJS.Proc
   });
 }
 
+/**
+ * The probe launches three concurrent cold `codex` processes; a loaded
+ * machine (or CI runner) routinely needs multiple seconds for cold Node CLI
+ * startups. A timeout here silently downgrades a working install to the
+ * generic fallback for the whole cached window, so it must be generous —
+ * discovery is TTL-cached and single-flight, and a genuinely missing binary
+ * still fails instantly via ENOENT rather than waiting this out. 1.5s
+ * reproducibly fell back on CI ubuntu runners.
+ */
+const CODEX_PROBE_TIMEOUT_MS = 5_000;
+
 /** Safe local discovery; failures become an explicit unavailable report. */
 export async function discoverCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = 1_500,
+  timeout = CODEX_PROBE_TIMEOUT_MS,
   env?: NodeJS.ProcessEnv,
 ): Promise<CodexRuntimeReport> {
   try {
@@ -966,7 +977,7 @@ export async function discoverCodexRuntime(
 /** Single-flight, bounded-cadence discovery for chat turns. */
 export async function discoverCachedCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = 1_500,
+  timeout = CODEX_PROBE_TIMEOUT_MS,
   env = codexProbeEnv(),
   now = Date.now(),
 ): Promise<CodexRuntimeReport> {
@@ -1012,7 +1023,7 @@ function startCodexRuntimeDiscovery(
  */
 export function peekCachedCodexRuntime(
   command: string | CodexProbeTarget = "codex",
-  timeout = 1_500,
+  timeout = CODEX_PROBE_TIMEOUT_MS,
   env = codexProbeEnv(),
   now = Date.now(),
 ): CodexRuntimeReport {


### PR DESCRIPTION
## Summary

`discoverCodexRuntime` launches three concurrent cold `codex` processes (`--version`, `exec --help`, `exec resume --help`) with a **1.5s** timeout each. On a contended runner the cold Node CLI startups exceed that, discovery reports unavailable, and the route silently downgrades a verified working install to the generic `coven run codex` fallback for the whole cached window.

This is not just a test problem — a real user on a loaded machine loses direct codex tool activity with no signal. But it did also reproduce twice back-to-back on CI ubuntu (PR #4079's `Frontend build`, 02:21Z and the 02:33Z rerun), failing `harness-routing-codex-direct.test.ts` with an unhelpful empty tool-event list while the same test passes 3/3 locally.

- Default probe timeout 1.5s → **5s** (one shared `CODEX_PROBE_TIMEOUT_MS` const across the three entry points). Discovery is TTL-cached (60s success / 10s failure) and single-flight, so the ceiling is not a steady-state cost; a genuinely missing binary still fails instantly via ENOENT.
- The integration test now asserts **path selection first**: if the route fell back, it fails with the coven argv it actually took, instead of `live tool activity starts a Bash bubble: []`.

## Verification

- `harness-routing-codex-direct.test.ts` + `codex-compatibility.test.ts` pass; `tsc --noEmit` clean.
- Root-cause chain from the CI logs: 115 tests passed before it, SSE stream completed 200 with assistant text but zero `tool_use` events — exactly the fallback signature, now made explicit by the new assertion.

Fixes the flake bead filed from the #4079 failure; unblocks #4079's Frontend build rerun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)