### PR TITLE
fix: make macOS pnpm test:api green (codex probe pin + version-proof mirror guard)

### DIFF
--- a/src/app/api/chat/send/route-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-runtime-availability.integration.test.ts
@@ -34,6 +34,26 @@ const pinnedGrok = path.join(
 await writeFile(pinnedGrok, "#!/bin/sh\nexit 0\n", { mode: 0o755 });
 if (process.platform !== "win32") await chmod(pinnedGrok, 0o755);
 
+// Codex direct routing probes a launch-ready CLI with three capability
+// spawns before choosing the generic Coven path, so a developer machine with
+// a real Codex on PATH would turn scenario 0's zero-spawn assertion into a
+// host-dependent failure (cave-g3qar). Pin CODEX_BIN to an existing but
+// unlaunchable fixture — the same shape as scenario 0's blocked Coven: a
+// mode-0644 file on POSIX, an intentionally unconvertible .cmd on Windows —
+// so the passive availability gate reports it before any probe can spawn.
+// (A nonexistent override would not do: codexBin() falls back to searching
+// the launcher's effective PATH.)
+const pinnedCodex = path.join(
+  bin,
+  process.platform === "win32" ? "codex-no-exec.cmd" : "codex-no-exec",
+);
+await writeFile(
+  pinnedCodex,
+  process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+  { mode: 0o644 },
+);
+if (process.platform !== "win32") await chmod(pinnedCodex, 0o644);
+
 const previousHome = process.env.COVEN_HOME;
 const previousCaveHome = process.env.COVEN_CAVE_HOME;
 const previousCovenBin = process.env.COVEN_BIN;
@@ -42,6 +62,8 @@ const previousPath = process.env.PATH;
 process.env.COVEN_HOME = home;
 process.env.COVEN_CAVE_HOME = path.join(home, "cave");
 process.env.GROK_BIN = pinnedGrok;
+const previousCodexBin = process.env.CODEX_BIN;
+process.env.CODEX_BIN = pinnedCodex;
 
 async function readSse(response) {
   assert.equal(response.status, 200, await response.clone().text());
@@ -345,6 +367,8 @@ try {
   else process.env.COVEN_BIN = previousCovenBin;
   if (previousGrokBin === undefined) delete process.env.GROK_BIN;
   else process.env.GROK_BIN = previousGrokBin;
+  if (previousCodexBin === undefined) delete process.env.CODEX_BIN;
+  else process.env.CODEX_BIN = previousCodexBin;
   if (previousPath === undefined) delete process.env.PATH;
   else process.env.PATH = previousPath;
   const { refreshCovenSpawnEnv } = await import("@/lib/coven-bin");

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -1281,6 +1281,15 @@ async function ensureCompatibility(
       if ((await statPath(legacyPath)).kind === "symlink") {
         await rm(legacyPath, { recursive: true, force: true });
       }
+      // The legacy path was retired above, so anything present here now was
+      // recreated by a concurrent writer (an older tool still running). The
+      // mirror fallback must fail closed rather than merge canonical bytes
+      // into that foreign directory. fs.cp's errorOnExist only enforces this
+      // on newer Node releases (older 24.x silently merges directories), so
+      // the invariant is checked explicitly instead of delegated to cp.
+      if ((await statPath(legacyPath)).kind !== "missing") {
+        throw new Error("legacy path was recreated before the compatibility mirror could be installed");
+      }
       const fallbackCanonical = await pathInfo(canonicalPath);
       await validateCanonical(entry, canonicalPath, fallbackCanonical);
       if (fallbackCanonical.kind !== canonicalInfo.kind || fallbackCanonical.hash !== canonicalInfo.hash) {


### PR DESCRIPTION
## Summary

Two independent host-dependent failures made `pnpm test:api` red on macOS developer machines while CI stayed green — the "trains people to ignore local failures" failure mode. Both are fixed at the level that removes the host dependence, not by loosening assertions.

**cave-g3qar — runtime-availability scenario 0 vs installed Codex.** The scenario asserts zero spawned processes for a blocked generic runner, but any machine with a real Codex on PATH now triggers direct routing's three capability probes first. `CODEX_BIN` is pinned to an existing-but-unlaunchable fixture (mode-0644 file on POSIX, intentionally unconvertible `.cmd` on Windows — the exact `blockedCoven` shape already used by the scenario) so the passive availability gate reports it before any probe can spawn. A nonexistent override wouldn't work: `codexBin()` falls back to searching the launcher's effective PATH.

**cave-kox4t — Windows migration mirror-race red on macOS.** The `windows-directory-mirror-race` cases assert the compatibility fallback fails closed when a concurrent old tool recreates the retired legacy directory. That invariant was implicitly delegated to `fs.cp`'s `errorOnExist`, which older Node 24.x (e.g. 24.13, common locally) **silently ignores for existing destination directories** — merging canonical bytes into the foreign directory — while newer Node (24.18, CI) throws. `ensureCompatibility` now checks the invariant explicitly, so the fail-closed behavior no longer depends on the Node patch level. (Verified the divergence directly: `fs.cp` with `errorOnExist: true` merges on 24.13.)

Also verified during this sweep (no code change): cave-9zavn's Hermes missing-preflight regression is already fixed on main — reproduced at its baseline `25d817c0b` and at `dffdc7bce`, passing from `eadfde259` onward; closed with the bisect bracket.

## Verification

- Both suites pass on macOS / Node 24.13 with real `codex` and `hermes` installed (the exact conditions that were failing).
- Full migration-family tests (8 files) green; `tsc --noEmit` clean.

Closes cave-g3qar and cave-kox4t (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)