### PR TITLE
fix(memory): fail trash moves closed on symlinked parents

### DIFF
--- a/src/lib/server/memory-trash.test.ts
+++ b/src/lib/server/memory-trash.test.ts
@@ -88,6 +88,66 @@ assert.equal(await readFile(victim, "utf8"), "do not delete me", "victim survive
 // also reject absolute and dot-dot ids
 assert.equal((await purgeMemoryTrash("/etc/hosts", home)).ok, false, "absolute trashId rejected");
 
+// ── Symlinked-parent escapes (cave-c51ij): the lexical classification is not
+// enough — the canonical location must stay inside the classified root. ────
+{
+  const { symlink, unlink } = await import("node:fs/promises");
+
+  // Archive escape: a familiar memory dir aliasing a location OUTSIDE the root.
+  const outside = path.join(home, "outside-storage");
+  await mkdir(outside, { recursive: true });
+  const escapee = path.join(outside, "loot.md");
+  await writeFile(escapee, "outside bytes", "utf8");
+  const aliasDir = path.join(home, ".coven", "workspaces", "familiars", "alias", "memory");
+  await mkdir(path.dirname(aliasDir), { recursive: true });
+  await symlink(outside, aliasDir);
+  const escapeArchive = await archiveMemoryFile(path.join(aliasDir, "loot.md"), home);
+  assert.deepEqual(
+    escapeArchive,
+    { ok: false, error: "path not allowed" },
+    "a symlinked memory parent aliasing outside storage cannot feed archive",
+  );
+  assert.equal(await readFile(escapee, "utf8"), "outside bytes", "aliased outside file was not moved");
+
+  // Archive alias: a familiar memory dir aliasing CANONICAL Coven storage.
+  await unlink(aliasDir);
+  await symlink(canonicalDir, aliasDir);
+  await writeFile(canonicalFile, "canonical", "utf8");
+  const aliasArchive = await archiveMemoryFile(path.join(aliasDir, "canonical.md"), home);
+  assert.deepEqual(
+    aliasArchive,
+    { ok: false, error: "path not allowed" },
+    "a symlinked memory parent aliasing canonical storage cannot feed archive",
+  );
+  assert.equal(await readFile(canonicalFile, "utf8"), "canonical", "canonical file survived the alias");
+  await unlink(aliasDir);
+
+  // Restore escape: archive legitimately, then swap the destination parent
+  // for a symlink pointing outside before restoring.
+  const swapDir = path.join(home, ".coven", "workspaces", "familiars", "swap", "memory");
+  await mkdir(swapDir, { recursive: true });
+  const swapFile = path.join(swapDir, "swapped.md");
+  await writeFile(swapFile, "legit", "utf8");
+  const swapArchive = await archiveMemoryFile(swapFile, home);
+  assert.equal(swapArchive.ok, true, "legitimate archive before the parent swap succeeds");
+  await rm(swapDir, { recursive: true, force: true });
+  await symlink(outside, swapDir);
+  const swapRestore = await restoreMemoryFile((swapArchive as { trashId: string }).trashId, home);
+  assert.deepEqual(
+    swapRestore,
+    { ok: false, error: "restore target not allowed" },
+    "a destination parent swapped for an outside symlink cannot receive a restore",
+  );
+  await assert.rejects(stat(path.join(outside, "swapped.md")), "nothing was written through the swapped parent");
+  await unlink(swapDir);
+
+  // The same trash entry restores cleanly once the real directory is back.
+  await mkdir(swapDir, { recursive: true });
+  const recovered = await restoreMemoryFile((swapArchive as { trashId: string }).trashId, home);
+  assert.equal(recovered.ok, true, "restore succeeds after the real parent returns");
+  assert.equal(await readFile(swapFile, "utf8"), "legit", "restored through the real parent");
+}
+
 await rm(home, { recursive: true, force: true });
 
 console.log("memory-trash.test: ok");

--- a/src/lib/server/memory-trash.ts
+++ b/src/lib/server/memory-trash.ts
@@ -53,9 +53,18 @@ async function realpathIfPresent(targetPath: string): Promise<string | null> {
  * a wholesale-symlinked ~/.coven) working.
  */
 async function canonicalContainedPath(candidate: string, rootPath: string): Promise<string | null> {
+  // Lexical pre-guard in the `path.relative` + `..` form a taint tracker
+  // recognizes as a sanitizer. Callers have already classified `candidate`
+  // inside `rootPath`; re-proving it adjacent to the fs sinks below keeps the
+  // guard legible to static analysis (same pattern as archiveMemoryFile's
+  // inline home barrier).
+  const resolvedCandidate = path.resolve(candidate);
+  const resolvedRoot = path.resolve(rootPath);
+  const rel = path.relative(resolvedRoot, resolvedCandidate);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   const [realCandidate, realRoot] = await Promise.all([
-    realpathIfPresent(candidate),
-    realpathIfPresent(rootPath),
+    realpathIfPresent(resolvedCandidate),
+    realpathIfPresent(resolvedRoot),
   ]);
   if (realCandidate === null || realRoot === null) return null;
   return isWithinRoot(realCandidate, realRoot) ? realCandidate : null;

--- a/src/lib/server/memory-trash.ts
+++ b/src/lib/server/memory-trash.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { homedir } from "node:os";
-import { mkdir, rename, writeFile, readFile, readdir, rm, access } from "node:fs/promises";
+import { mkdir, realpath, rename, writeFile, readFile, readdir, rm, access } from "node:fs/promises";
 import { classifyMemoryFilePath } from "./memory-file-sources.ts";
 import { isStructuralMemoryPath } from "../memory-management.ts";
 
@@ -30,9 +30,41 @@ function trashRoot(home: string): string {
   return path.join(home, ".coven", TRASH_DIRNAME, "memory");
 }
 
+function isWithinRoot(candidate: string, root: string): boolean {
+  return candidate === root || candidate.startsWith(root + path.sep);
+}
+
+async function realpathIfPresent(targetPath: string): Promise<string | null> {
+  try {
+    return await realpath(/* turbopackIgnore: true */ targetPath);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * classifyMemoryFilePath is lexical, so an allowed parent that is actually a
+ * symlink (a familiar workspace memory dir aliasing canonical storage, or a
+ * path outside the home) passes it while rename() follows the link. Trash
+ * moves therefore require the same realpath-vs-realpath containment the
+ * read/write paths enforce: canonicalize the candidate and its classified
+ * root and demand containment between the canonical forms. Comparing against
+ * the canonical root keeps legitimately symlinked roots (macOS /var,
+ * a wholesale-symlinked ~/.coven) working.
+ */
+async function canonicalContainedPath(candidate: string, rootPath: string): Promise<string | null> {
+  const [realCandidate, realRoot] = await Promise.all([
+    realpathIfPresent(candidate),
+    realpathIfPresent(rootPath),
+  ]);
+  if (realCandidate === null || realRoot === null) return null;
+  return isWithinRoot(realCandidate, realRoot) ? realCandidate : null;
+}
+
 export async function archiveMemoryFile(fullPath: string, home = homedir()): Promise<TrashResult> {
   const resolved = path.resolve(fullPath);
-  if (!classifyMemoryFilePath(resolved, home)) return { ok: false, error: "path not allowed" };
+  const classification = classifyMemoryFilePath(resolved, home);
+  if (!classification) return { ok: false, error: "path not allowed" };
   if (isStructuralMemoryPath(resolved)) return { ok: false, error: "protected: structural memory" };
   // Inline containment barrier against `home` (an untainted base):
   // classifyMemoryFilePath above already confines the path to the specific
@@ -43,11 +75,19 @@ export async function archiveMemoryFile(fullPath: string, home = homedir()): Pro
   if (homeRel.startsWith("..") || path.isAbsolute(homeRel)) {
     return { ok: false, error: "path not allowed" };
   }
+  // The existing target must still live inside its classified root after
+  // symlink resolution; a symlinked parent aliasing canonical storage or a
+  // location outside the root fails closed here (cave-c51ij).
+  const realTarget = await canonicalContainedPath(resolved, classification.rootPath);
+  if (realTarget === null) return { ok: false, error: "path not allowed" };
+  // A symlink could also alias a structural artifact under a deletable name.
+  if (isStructuralMemoryPath(realTarget)) return { ok: false, error: "protected: structural memory" };
   const dir = trashRoot(home);
   const trashId = `${Date.now()}-${path.basename(resolved)}`;
   try {
     await mkdir(dir, { recursive: true });
-    await rename(resolved, path.join(dir, trashId));
+    // Rename the canonical path: the checked value is the moved value.
+    await rename(realTarget, path.join(dir, trashId));
     const meta: Sidecar = { originalPath: resolved, deletedAt: new Date().toISOString() };
     await writeFile(path.join(dir, `${trashId}.json`), JSON.stringify(meta), { mode: 0o600 });
     return { ok: true, trashId };
@@ -81,12 +121,22 @@ export async function restoreMemoryFile(trashId: string, home = homedir()): Prom
   try {
     meta = JSON.parse(await readFile(path.join(dir, `${safeId}.json`), "utf8")) as Sidecar;
   } catch { return { ok: false, error: "not found" }; }
-  if (!classifyMemoryFilePath(meta.originalPath, home)) return { ok: false, error: "restore target not allowed" };
-  const occupied = await access(meta.originalPath).then(() => true).catch(() => false);
-  if (occupied) return { ok: false, error: "target already exists" };
+  const destination = path.resolve(meta.originalPath);
+  const classification = classifyMemoryFilePath(destination, home);
+  if (!classification) return { ok: false, error: "restore target not allowed" };
   try {
-    await mkdir(path.dirname(meta.originalPath), { recursive: true });
-    await rename(path.join(dir, safeId), meta.originalPath);
+    await mkdir(path.dirname(destination), { recursive: true });
+    // The classification above is lexical. Canonicalize the destination
+    // parent (which now exists) against the classified root so a symlinked
+    // parent cannot route the restored file into canonical storage or
+    // outside the root (cave-c51ij). Joining the canonical parent with the
+    // basename makes the checked parent the written parent.
+    const realParent = await canonicalContainedPath(path.dirname(destination), classification.rootPath);
+    if (realParent === null) return { ok: false, error: "restore target not allowed" };
+    const realDestination = path.join(realParent, path.basename(destination));
+    const occupied = await access(realDestination).then(() => true).catch(() => false);
+    if (occupied) return { ok: false, error: "target already exists" };
+    await rename(path.join(dir, safeId), realDestination);
     await rm(path.join(dir, `${safeId}.json`), { force: true });
     return { ok: true, trashId };
   } catch (err) {


### PR DESCRIPTION
## Summary

Implements **cave-c51ij** (security follow-up from the coven-code #170 review): memory-trash archive/restore relied on the lexical `classifyMemoryFilePath` containment before `rename`, so an allowed familiar-workspace memory parent that is actually a **symlink** could alias canonical Coven storage or a location outside the root — unlike the read/write paths, which already canonicalize with `realpath`.

- **Archive** canonicalizes the existing target against its classified root (realpath-vs-realpath, so legitimately symlinked roots — macOS `/var`, a wholesale-symlinked `~/.coven` — keep working), re-checks structural protection on the canonical path (a symlink could alias `MEMORY.md` under a deletable name), and renames the exact canonical value it checked.
- **Restore** canonicalizes the destination parent after `mkdir` and joins the basename onto that checked parent, so a parent swapped for a symlink cannot route the restored file into canonical storage or outside the root. The occupied check moved onto the canonical destination.

## Tests

Synthetic coverage for both escape directions in `memory-trash.test.ts`:
- archive through a memory parent aliasing **outside** storage → fails closed, file untouched
- archive through a memory parent aliasing **canonical** storage → fails closed, canonical file untouched
- restore through a destination parent swapped for an outside symlink → fails closed, nothing written through the link
- the same trash entry restores cleanly once the real parent returns

All prior pins unchanged (forged-sidecar restore, traversal purge/restore, structural protection, happy paths); wider memory test family (17 files) green; `tsc --noEmit` clean.

Closes cave-c51ij (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)