### PR TITLE
feat(research): optimize desk workspace

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -73,6 +73,7 @@ export const SUITES = {
     "src/components/role-surfaces/research-evidence-ledger.test.ts",
     "src/components/role-surfaces/research-artifact-actions.test.ts",
     "src/components/role-surfaces/research-tab-prompt.test.ts",
+    "src/components/role-surfaces/research-desk-view.test.ts",
     "src/components/role-surfaces/research-tab-desk.test.ts",
     "src/components/ui/clamped-text.test.ts",
     "src/components/role-surfaces/research-tab-library.test.ts",

--- a/src/components/role-surfaces/research-desk-view.test.ts
+++ b/src/components/role-surfaces/research-desk-view.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ResearchMission } from "@/lib/research-missions";
+import {
+  filterResearchMissionsByText,
+  groupResearchMissions,
+  matchesResearchMissionScope,
+  researchMissionScopeCounts,
+} from "./research-desk-view.ts";
+
+const mission = (
+  id: string,
+  status: ResearchMission["status"],
+) => ({ id, status }) as ResearchMission;
+
+const missions = [
+  mission("checkpoint", "checkpoint"),
+  mission("running", "running"),
+  mission("failed", "failed"),
+  mission("completed", "completed"),
+  mission("archived", "archived"),
+];
+
+test("status scopes have explicit lifecycle membership", () => {
+  assert.equal(matchesResearchMissionScope(missions[0], "active"), true);
+  assert.equal(matchesResearchMissionScope(missions[2], "active"), false);
+  assert.equal(matchesResearchMissionScope(missions[2], "needs-review"), true);
+  assert.equal(matchesResearchMissionScope(missions[3], "finished"), true);
+  assert.equal(matchesResearchMissionScope(missions[4], "all"), true);
+});
+
+test("scope counts derive from the full mission set", () => {
+  assert.deepEqual(researchMissionScopeCounts(missions), {
+    all: 5,
+    active: 2,
+    "needs-review": 2,
+    finished: 1,
+  });
+});
+
+test("text filtering is case-insensitive across mission title and intent", () => {
+  const searchable = [
+    {
+      ...mission("memory", "running"),
+      title: "Agent memory survey",
+      intent: "Compare durable context systems.",
+    },
+    {
+      ...mission("vector", "checkpoint"),
+      title: "Vector database pricing",
+      intent: "Review vendor plans.",
+    },
+  ];
+
+  assert.deepEqual(
+    filterResearchMissionsByText(searchable, "DURABLE").map(({ id }) => id),
+    ["memory"],
+  );
+  assert.deepEqual(
+    filterResearchMissionsByText(searchable, " vector ").map(({ id }) => id),
+    ["vector"],
+  );
+  assert.equal(filterResearchMissionsByText(searchable, "").length, 2);
+});
+
+test("groups preserve source order inside the priority order", () => {
+  const groups = groupResearchMissions(missions);
+  assert.deepEqual(
+    groups.map((group) => [
+      group.id,
+      group.missions.map(({ id }) => id),
+    ]),
+    [
+      ["needs-review", ["checkpoint", "failed"]],
+      ["in-progress", ["running"]],
+      ["recent", ["completed"]],
+      ["archived", ["archived"]],
+    ],
+  );
+});

--- a/src/components/role-surfaces/research-desk-view.ts
+++ b/src/components/role-surfaces/research-desk-view.ts
@@ -1,0 +1,104 @@
+import type { ResearchMission } from "@/lib/research-missions";
+
+export type ResearchMissionScope =
+  | "all"
+  | "active"
+  | "needs-review"
+  | "finished";
+
+export type ResearchMissionGroupId =
+  | "needs-review"
+  | "in-progress"
+  | "recent"
+  | "archived";
+
+export type ResearchMissionGroup = {
+  id: ResearchMissionGroupId;
+  label: string;
+  missions: ResearchMission[];
+};
+
+const ACTIVE_STATUSES = new Set<ResearchMission["status"]>([
+  "queued",
+  "planning",
+  "running",
+  "checkpoint",
+  "paused",
+]);
+
+const NEEDS_REVIEW_STATUSES = new Set<ResearchMission["status"]>([
+  "checkpoint",
+  "paused",
+  "failed",
+]);
+
+const FINISHED_STATUSES = new Set<ResearchMission["status"]>([
+  "completed",
+  "cancelled",
+]);
+
+const IN_PROGRESS_STATUSES = new Set<ResearchMission["status"]>([
+  "queued",
+  "planning",
+  "running",
+]);
+
+export function filterResearchMissionsByText(
+  missions: ResearchMission[],
+  filter = "",
+): ResearchMission[] {
+  const query = filter.trim().toLowerCase();
+  if (!query) return missions;
+  return missions.filter((mission) =>
+    `${mission.title} ${mission.intent}`.toLowerCase().includes(query));
+}
+
+export function matchesResearchMissionScope(
+  mission: ResearchMission,
+  scope: ResearchMissionScope,
+): boolean {
+  if (scope === "active") return ACTIVE_STATUSES.has(mission.status);
+  if (scope === "needs-review") {
+    return NEEDS_REVIEW_STATUSES.has(mission.status);
+  }
+  if (scope === "finished") return FINISHED_STATUSES.has(mission.status);
+  return true;
+}
+
+export function researchMissionScopeCounts(
+  missions: ResearchMission[],
+): Record<ResearchMissionScope, number> {
+  return {
+    all: missions.length,
+    active: missions.filter((mission) =>
+      matchesResearchMissionScope(mission, "active")).length,
+    "needs-review": missions.filter((mission) =>
+      matchesResearchMissionScope(mission, "needs-review")).length,
+    finished: missions.filter((mission) =>
+      matchesResearchMissionScope(mission, "finished")).length,
+  };
+}
+
+export function groupResearchMissions(
+  missions: ResearchMission[],
+): ResearchMissionGroup[] {
+  const review = missions.filter((mission) =>
+    NEEDS_REVIEW_STATUSES.has(mission.status));
+  const progress = missions.filter((mission) =>
+    IN_PROGRESS_STATUSES.has(mission.status));
+  const archived = missions.filter((mission) =>
+    mission.status === "archived");
+  const assignedIds = new Set(
+    [...review, ...progress, ...archived].map(({ id }) => id),
+  );
+  const recent = missions.filter((mission) => !assignedIds.has(mission.id));
+
+  const groups: ResearchMissionGroup[] = [
+    { id: "needs-review", label: "Needs review", missions: review },
+    { id: "in-progress", label: "In progress", missions: progress },
+    { id: "recent", label: "Recent", missions: recent },
+    { id: "archived", label: "Archived", missions: archived },
+  ];
+
+  return groups.filter((group) => group.missions.length > 0);
+}

--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -47,6 +47,7 @@ import { ResearchEvidenceLedger, type ResearchOutputTab } from "./research-evide
 
 type Props = {
   mission: ResearchMission | null;
+  showEvidence: boolean;
   onOpenSession(sessionId: string): void;
   onOpenUrl(url: string): void;
   /** Quick link to the Resources tab (Saved resources). */
@@ -93,6 +94,7 @@ const LIVE_STATUSES = new Set<ResearchMission["status"]>(["queued", "planning", 
 
 export function ResearchMissionDetail({
   mission,
+  showEvidence,
   onOpenSession,
   onOpenUrl,
   onShowResources,
@@ -341,7 +343,10 @@ export function ResearchMissionDetail({
 
   return (
     <section className="research-mission-detail" aria-labelledby="research-mission-title">
-      <div className="research-mission-detail__body">
+      <div
+        className="research-mission-detail__body"
+        data-evidence-open={showEvidence}
+      >
         <div className="research-desk-center">
           <header className="research-mission-detail__header">
             <div>
@@ -668,56 +673,58 @@ export function ResearchMissionDetail({
               spans the rail, plus pinned quick links. The pane is the full
               evidence ledger — the rail no longer stacks a partial state panel
               above a collapsed copy of the same data. ── */}
-        <aside className="research-desk-rail" aria-label="Run evidence and links">
-          <Tabs<ResearchOutputTab>
-            className="research-desk-rail__toggle"
-            idPrefix="research-output"
-            ariaLabel="Rail contents"
-            variant="segment"
-            size="sm"
-            fill
-            value={railTab}
-            onChange={setRailTab}
-            items={[
-              { id: "artifacts", label: "Artifacts", count: mission.artifacts.length },
-              { id: "sources", label: "Sources", count: mission.sources.length },
-            ]}
-          />
-          <div className="research-desk-rail__pane">
-            <ResearchEvidenceLedger
-              mission={mission}
-              onAction={onAction}
-              onOpenUrl={onOpenUrl}
-              tab={railTab}
-              hint={railHint}
-              triage={isCheckpointLike}
-              highlightLatest={isLive}
+        {showEvidence ? (
+          <aside className="research-desk-rail" aria-label="Run evidence and links">
+            <Tabs<ResearchOutputTab>
+              className="research-desk-rail__toggle"
+              idPrefix="research-output"
+              ariaLabel="Rail contents"
+              variant="segment"
+              size="sm"
+              fill
+              value={railTab}
+              onChange={setRailTab}
+              items={[
+                { id: "artifacts", label: "Artifacts", count: mission.artifacts.length },
+                { id: "sources", label: "Sources", count: mission.sources.length },
+              ]}
             />
-          </div>
+            <div className="research-desk-rail__pane">
+              <ResearchEvidenceLedger
+                mission={mission}
+                onAction={onAction}
+                onOpenUrl={onOpenUrl}
+                tab={railTab}
+                hint={railHint}
+                triage={isCheckpointLike}
+                highlightLatest={isLive}
+              />
+            </div>
 
-          <div className="research-desk-rail__links">
-            {sessionId ? (
+            <div className="research-desk-rail__links">
+              {sessionId ? (
+                <button
+                  type="button"
+                  className="research-desk-rail__link focus-ring"
+                  onClick={() => onOpenSession(sessionId)}
+                >
+                  <Icon name="ph:chat-circle-dots" width={14} height={14} aria-hidden />
+                  <span>Discuss this run in chat</span>
+                  <span className="research-desk-rail__link-chevron" aria-hidden>›</span>
+                </button>
+              ) : null}
               <button
                 type="button"
                 className="research-desk-rail__link focus-ring"
-                onClick={() => onOpenSession(sessionId)}
+                onClick={onShowResources}
               >
-                <Icon name="ph:chat-circle-dots" width={14} height={14} aria-hidden />
-                <span>Discuss this run in chat</span>
+                <Icon name="ph:link" width={14} height={14} aria-hidden />
+                <span>Saved resources</span>
                 <span className="research-desk-rail__link-chevron" aria-hidden>›</span>
               </button>
-            ) : null}
-            <button
-              type="button"
-              className="research-desk-rail__link focus-ring"
-              onClick={onShowResources}
-            >
-              <Icon name="ph:link" width={14} height={14} aria-hidden />
-              <span>Saved resources</span>
-              <span className="research-desk-rail__link-chevron" aria-hidden>›</span>
-            </button>
-          </div>
-        </aside>
+            </div>
+          </aside>
+        ) : null}
       </div>
     </section>
   );

--- a/src/components/role-surfaces/research-mission-list.tsx
+++ b/src/components/role-surfaces/research-mission-list.tsx
@@ -1,10 +1,18 @@
 "use client";
 
 import { useEffect, useMemo, useRef, useState, type KeyboardEvent } from "react";
+import { Button } from "@/components/ui/button";
 import { Icon } from "@/lib/icon";
 import type { ResearchMission } from "@/lib/research-missions";
 import { relativeTime } from "@/lib/relative-time";
 import { nextRovingId, resolveRovingId, type RovingKey } from "@/lib/roving-list";
+import {
+  filterResearchMissionsByText,
+  groupResearchMissions,
+  matchesResearchMissionScope,
+  type ResearchMissionGroup,
+  type ResearchMissionScope,
+} from "./research-desk-view";
 
 type Props = {
   missions: ResearchMission[];
@@ -14,6 +22,8 @@ type Props = {
   /** Live query from the desk command bar (plain text or "/find …") — rows
    *  whose title/intent do not match are hidden; empty means no filtering. */
   filter?: string;
+  scope: ResearchMissionScope;
+  onClearFilters(): void;
 };
 
 const STATUS_TONE: Partial<Record<ResearchMission["status"], string>> = {
@@ -30,24 +40,33 @@ const STATUS_TONE: Partial<Record<ResearchMission["status"], string>> = {
 
 const ROVING_KEYS = new Set<string>(["ArrowDown", "ArrowUp", "Home", "End"]);
 
-export function ResearchMissionList({ missions, selectedId, loading, onSelect, filter }: Props) {
-  const query = (filter ?? "").trim().toLowerCase();
-  const filteredMissions = useMemo(() => {
-    if (!query) return missions;
-    return missions.filter((mission) =>
-      `${mission.title} ${mission.intent}`.toLowerCase().includes(query));
-  }, [missions, query]);
+export function ResearchMissionList({
+  missions,
+  selectedId,
+  loading,
+  onSelect,
+  filter,
+  scope,
+  onClearFilters,
+}: Props) {
+  const filteredMissions = useMemo(
+    () => filterResearchMissionsByText(missions, filter).filter((mission) =>
+      matchesResearchMissionScope(mission, scope)),
+    [missions, filter, scope],
+  );
 
-  // Archived missions leave the working ledger and collapse into a disclosure
-  // group at the bottom so finished noise never buries active work.
-  const { activeMissions, archivedMissions } = useMemo(() => {
-    const active: ResearchMission[] = [];
-    const archived: ResearchMission[] = [];
-    for (const mission of filteredMissions) {
-      (mission.status === "archived" ? archived : active).push(mission);
-    }
-    return { activeMissions: active, archivedMissions: archived };
-  }, [filteredMissions]);
+  const groups = useMemo(
+    () => groupResearchMissions(filteredMissions),
+    [filteredMissions],
+  );
+  const nonArchivedGroups = groups.filter((group) => group.id !== "archived");
+  const archivedMissions = groups.find(
+    (group) => group.id === "archived",
+  )?.missions ?? [];
+  const nonArchivedCount = nonArchivedGroups.reduce(
+    (count, group) => count + group.missions.length,
+    0,
+  );
   const [archivedOpen, setArchivedOpen] = useState(false);
 
   // The amber attention line derives from the full mission set — a rail
@@ -72,10 +91,13 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect, f
 
   // Keyboard roving covers exactly the rendered rows: active rows always,
   // archived rows only while the group is expanded.
-  const visibleIds = useMemo(() => [
-    ...activeMissions.map((mission) => mission.id),
-    ...(archivedOpen ? archivedMissions.map((mission) => mission.id) : []),
-  ], [activeMissions, archivedMissions, archivedOpen]);
+  const visibleIds = useMemo(
+    () => groups.flatMap((group) =>
+      group.id === "archived" && !archivedOpen
+        ? []
+        : group.missions.map((mission) => mission.id)),
+    [groups, archivedOpen],
+  );
   const [rovingId, setRovingId] = useState<string | null>(() => resolveRovingId(visibleIds, selectedId, selectedId));
   const buttonRefs = useRef(new Map<string, HTMLButtonElement>());
 
@@ -134,11 +156,30 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect, f
     );
   };
 
+  const renderGroup = (group: ResearchMissionGroup) => (
+    <section
+      key={group.id}
+      className="research-mission-nav__section"
+      aria-labelledby={`research-mission-group-${group.id}`}
+    >
+      <div
+        id={`research-mission-group-${group.id}`}
+        className="research-mission-nav__section-title"
+      >
+        <span>{group.label}</span>
+        <span>{group.missions.length}</span>
+      </div>
+      <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
+        {group.missions.map(renderRow)}
+      </ul>
+    </section>
+  );
+
   return (
     <nav className="research-mission-nav" aria-label="Research missions">
       <div className="research-mission-nav__head">
         <span>Runs</span>
-        <span>{activeMissions.length}</span>
+        <span>{nonArchivedCount}</span>
       </div>
       {checkpointMissions.length > 0 ? (
         <p className="research-mission-nav__waiting" role="status">
@@ -161,16 +202,19 @@ export function ResearchMissionList({ missions, selectedId, loading, onSelect, f
           <p>No research missions yet.</p>
           <span>Describe an investigation to start the first one.</span>
         </div>
-      ) : query && filteredMissions.length === 0 ? (
-        <p className="research-mission-nav__empty">No runs match “{filter?.trim()}”.</p>
+      ) : filteredMissions.length === 0 ? (
+        <div className="research-mission-nav__empty">
+          <p>No runs match the current filters.</p>
+          <Button size="xs" variant="ghost" onClick={onClearFilters}>
+            Clear filters
+          </Button>
+        </div>
       ) : (
         <>
-          {activeMissions.length === 0 ? (
+          {nonArchivedGroups.length === 0 ? (
             <p className="research-mission-nav__empty">No active missions.</p>
           ) : (
-            <ul className="research-mission-nav__list" onKeyDown={onListKeyDown}>
-              {activeMissions.map(renderRow)}
-            </ul>
+            nonArchivedGroups.map(renderGroup)
           )}
           {archivedMissions.length > 0 ? (
             <div className="research-mission-nav__group">

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -107,17 +107,58 @@ test("desk commands map to real destinations only", () => {
   assert.doesNotMatch(deskTab, /"\/task"/);
 });
 
-test("plain text filters the runs rail and is never dropped silently", () => {
+test("desk toolbar is truthful, scoped, and keyboard reachable", () => {
+  assert.match(deskTab, /<SearchInput/);
+  assert.match(deskTab, /placeholder="Filter runs…"/);
+  assert.match(deskTab, /aria-label="Filter research runs"/);
+  assert.match(deskTab, /aria-keyshortcuts="\/"/);
+  assert.match(deskTab, />\s*New research\s*<\/Button>/);
+  assert.match(deskTab, /ResearchMissionScope/);
+  assert.match(
+    deskTab,
+    /researchMissionScopeCounts\(\s*filterResearchMissionsByText\(research\.missions, listFilter\)/,
+  );
+  assert.match(
+    deskTab,
+    /aria-label=\{`\$\{item\.label\}, \$\{scopeCounts\[item\.id\]\} \$\{scopeCounts\[item\.id\] === 1 \? "run" : "runs"\}`\}/,
+  );
+  assert.match(deskTab, /window\.addEventListener\("keydown", onKeyDown\)/);
+  assert.match(
+    deskTab,
+    /target\?\.closest\("input, textarea, select, \[contenteditable='true'\]"\)/,
+  );
+  assert.match(
+    deskTab,
+    /document\.querySelector\('\[role="dialog"\]\[aria-modal="true"\]'\)/,
+  );
+});
+
+test("focus mode persists per familiar and announces both states", () => {
+  assert.match(
+    deskTab,
+    /useEffect\(\(\) => \{\s*setQuery\(""\);\s*setScope\("all"\);\s*setFocusMode\(readFocusMode\(familiarId\)\);/,
+  );
+  assert.match(deskTab, /FOCUS_STORAGE_PREFIX[\s\S]*familiarId/);
+  assert.match(deskTab, /window\.localStorage\.getItem/);
+  assert.match(deskTab, /window\.localStorage\.setItem/);
+  assert.match(
+    deskTab,
+    /announce\(next \? "Focus mode enabled\." : "Workspace rails restored\."\)/,
+  );
+  assert.match(deskTab, /focusMode \? "Show workspace" : "Focus run"/);
+});
+
+test("plain text filters the runs rail and creation stays one action away", () => {
   // "/find rest" and plain text both feed the list filter.
   assert.match(deskTab, /\/\^\\\/find\\s\+\(\.\*\)\$\/i/);
   assert.match(deskTab, /findMatch \? findMatch\[1\] : isCommandText \? "" : query/);
   assert.match(deskTab, /filter=\{listFilter\}/);
-  // The Prompt hand-off is explicit and honest — the tab contract carries a
-  // mode, not a draft, and the hint says so.
-  assert.match(deskTab, /Open in Prompt ↗/);
-  assert.match(deskTab, /isn’t carried over/);
+  // New research is an always-visible, honest destination; the filter no
+  // longer masquerades as a question composer or grows a hand-off hint.
+  assert.match(deskTab, /onNavigate\("prompt"\)/);
+  assert.doesNotMatch(deskTab, /Open in Prompt ↗|isn’t carried over/);
   assert.match(list, /filter\?: string/);
-  assert.match(list, /`\$\{mission\.title\} \$\{mission\.intent\}`\.toLowerCase\(\)\.includes\(query\)/);
+  assert.match(list, /filterResearchMissionsByText\(missions, filter\)/);
   // A filtered-empty rail says the filter is why.
   assert.match(list, /No runs match/);
 });
@@ -140,7 +181,28 @@ test("planning missions read as active work in the runs rail", () => {
   assert.match(list, /queued: "busy"/);
 });
 
+test("mission navigation composes text scope and priority groups", () => {
+  assert.match(list, /scope: ResearchMissionScope/);
+  assert.match(list, /matchesResearchMissionScope\(mission, scope\)/);
+  assert.match(list, /groupResearchMissions\(filteredMissions\)/);
+  assert.match(list, /research-mission-nav__section-title/);
+  assert.match(list, />\s*Clear filters\s*<\/Button>/);
+  assert.match(list, /groups\.flatMap/);
+});
+
 // ── Right rail: state switching + reachable ledger ──────────────────────────
+
+test("focus mode removes both rails without changing mission detail", () => {
+  assert.match(detail, /showEvidence: boolean/);
+  assert.match(detail, /\{showEvidence \? \(\s*<aside/);
+  assert.match(detail, /data-evidence-open=\{showEvidence\}/);
+  assert.match(deskTab, /showEvidence=\{!focusMode\}/);
+  assert.match(deskTab, /data-focus-mode=\{focusMode\}/);
+  assert.match(
+    css,
+    /\.research-desk-tab \.research-desk__workspace\[data-focus-mode="true"\]/,
+  );
+});
 
 test("the right rail is one Artifacts|Sources toggle over a full-height pane", () => {
   // No stacked state panels: a single segmented toggle drives one pane that
@@ -261,7 +323,25 @@ test("archived missions gate automation controls like the schedule button", () =
 test("desk-tab responsive collapses match the existing container breakpoints", () => {
   assert.match(css, /@container research-desk \(max-width: 900px\) \{[\s\S]*?\.research-desk-tab \.research-desk__workspace \{ grid-template-columns: 1fr; \}/);
   assert.match(css, /@container research-desk \(max-width: 760px\) \{[\s\S]*?\.research-desk-tab \.research-mission-detail__body \{ grid-template-columns: 1fr; \}/);
-  assert.match(css, /\.research-desk-rail \{ border-left: 0; border-top: 1px solid var\(--border\); \}/);
+  assert.match(
+    css,
+    /\.research-desk-rail \{[\s\S]*?border-left: 0;[\s\S]*?border-top: 1px solid var\(--border\);/,
+  );
+});
+
+test("narrow desks bound secondary rails while preserving the run surface", () => {
+  assert.match(
+    css,
+    /@container research-desk \(max-width: 900px\)[\s\S]*?max-height: calc\(var\(--space-10\) \* 4\)/,
+  );
+  assert.match(
+    css,
+    /@container research-desk \(max-width: 760px\)[\s\S]*?\.research-desk-rail \{[\s\S]*?max-height: 44vh/,
+  );
+  assert.match(
+    css,
+    /@container research-desk \(max-width: 560px\)[\s\S]*?\.research-desk-toolbar__main/,
+  );
 });
 
 // ── Artifact actions: shared component mounted on rail + saved summary ──────

--- a/src/components/role-surfaces/research-tab-desk.tsx
+++ b/src/components/role-surfaces/research-tab-desk.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 /**
- * Desk tab — the mission workspace (cave-dl74 B2): query/command bar, runs
+ * Desk tab — the mission workspace (cave-dl74 B2): command toolbar, runs
  * rail, mission detail (center column + evidence rail), and the load-error
  * banner.
  *
@@ -14,15 +14,25 @@
  *                         (offered only when that session actually exists)
  * There is no /task — no board-create destination is reachable from here.
  *
- * Plain text is kept as a live runs filter (the Prompt tab contract carries a
- * mode, not a draft, so navigating cannot take the text along). A hint row
- * offers "Open in Prompt" explicitly and says the question is not carried
- * over — user text is never dropped silently.
+ * Plain text is kept as a live runs filter. New research has one persistent
+ * destination in the toolbar, so filtering never masquerades as composing.
  */
 
-import { useState, type KeyboardEvent } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 import { Button } from "@/components/ui/button";
-import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { SearchInput } from "@/components/ui/search-input";
+import {
+  filterResearchMissionsByText,
+  researchMissionScopeCounts,
+  type ResearchMissionScope,
+} from "./research-desk-view";
 import { ResearchMissionDetail } from "./research-mission-detail";
 import { ResearchMissionList } from "./research-mission-list";
 import type { ResearchTabProps } from "./researcher-surface";
@@ -36,8 +46,34 @@ type DeskCommand = {
   keepsQuery?: boolean;
 };
 
+const FOCUS_STORAGE_PREFIX = "cave:research:desk-focus:";
+
+const SCOPES: Array<{ id: ResearchMissionScope; label: string }> = [
+  { id: "all", label: "All" },
+  { id: "active", label: "Active" },
+  { id: "needs-review", label: "Needs review" },
+  { id: "finished", label: "Finished" },
+];
+
+function readFocusMode(familiarId: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(
+      `${FOCUS_STORAGE_PREFIX}${familiarId}`,
+    ) === "true";
+  } catch {
+    return false;
+  }
+}
+
 export function ResearchTabDesk({ research, context, onNavigate }: ResearchTabProps) {
   const [query, setQuery] = useState("");
+  const [scope, setScope] = useState<ResearchMissionScope>("all");
+  const familiarId = context.activeFamiliar.id;
+  const [focusMode, setFocusMode] = useState(() =>
+    readFocusMode(familiarId));
+  const queryInputRef = useRef<HTMLInputElement>(null);
+  const { announce } = useAnnouncer();
 
   const selectedSessionId = research.selected?.iterations.at(-1)?.sessionId;
   const openMissionSession = (sessionId: string) => {
@@ -72,18 +108,56 @@ export function ResearchTabDesk({ research, context, onNavigate }: ResearchTabPr
   const isCommandText = query.startsWith("/");
   const findMatch = /^\/find\s+(.*)$/i.exec(query);
   const listFilter = findMatch ? findMatch[1] : isCommandText ? "" : query;
+  const scopeCounts = useMemo(
+    () => researchMissionScopeCounts(
+      filterResearchMissionsByText(research.missions, listFilter),
+    ),
+    [research.missions, listFilter],
+  );
   const commandsOpen = isCommandText && !findMatch;
   const commandToken = commandsOpen ? query.slice(1).split(/\s+/)[0].toLowerCase() : "";
   const visibleCommands = commandsOpen
     ? commands.filter((command) => command.cmd.slice(1).startsWith(commandToken))
     : [];
 
+  useEffect(() => {
+    setQuery("");
+    setScope("all");
+    setFocusMode(readFocusMode(familiarId));
+  }, [familiarId]);
+
+  useEffect(() => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
+      if (
+        event.key !== "/"
+        || event.metaKey
+        || event.ctrlKey
+        || event.altKey
+        || event.repeat
+      ) {
+        return;
+      }
+      if (document.querySelector('[role="dialog"][aria-modal="true"]')) {
+        return;
+      }
+      const target = event.target instanceof HTMLElement ? event.target : null;
+      if (target?.closest("input, textarea, select, [contenteditable='true']")) {
+        return;
+      }
+      event.preventDefault();
+      setQuery("/");
+      queryInputRef.current?.focus();
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+
   const runCommand = (command: DeskCommand) => {
     command.run();
     if (!command.keepsQuery) setQuery("");
   };
 
-  const onQueryKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+  const onQueryKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
     if (event.key === "Escape" && query) {
       event.preventDefault();
       setQuery("");
@@ -95,22 +169,56 @@ export function ResearchTabDesk({ research, context, onNavigate }: ResearchTabPr
     }
   };
 
+  const toggleFocusMode = () => {
+    const next = !focusMode;
+    setFocusMode(next);
+    try {
+      window.localStorage.setItem(
+        `${FOCUS_STORAGE_PREFIX}${familiarId}`,
+        String(next),
+      );
+    } catch {
+      // The workspace mode still applies for this visit.
+    }
+    announce(next ? "Focus mode enabled." : "Workspace rails restored.");
+  };
+
   return (
     <div className="research-desk-tab">
-      <div className="research-desk-querybar">
-        <div className="research-desk-querybar__field">
-          <Icon name="ph:magnifying-glass" width={13} height={13} aria-hidden />
-          <input
+      <div className="research-desk-toolbar">
+        <div className="research-desk-toolbar__main">
+          <SearchInput
+            ref={queryInputRef}
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
+            onValueChange={setQuery}
+            onClear={() => setQuery("")}
             onKeyDown={onQueryKeyDown}
-            placeholder="Ask a new research question — type / for commands"
-            aria-label="Search runs or type a desk command"
+            placeholder="Filter runs…"
+            aria-label="Filter research runs"
+            aria-keyshortcuts="/"
             aria-expanded={commandsOpen}
             aria-controls={commandsOpen ? "research-desk-commands" : undefined}
+            containerClassName="research-desk-toolbar__search"
             spellCheck={false}
           />
-          <span className="research-desk-querybar__affordance" aria-hidden>/ commands</span>
+          <span className="research-desk-toolbar__summary" role="status">
+            {scopeCounts.active} active · {scopeCounts["needs-review"]} need review
+          </span>
+          <Button
+            size="xs"
+            variant="ghost"
+            aria-pressed={focusMode}
+            onClick={toggleFocusMode}
+          >
+            {focusMode ? "Show workspace" : "Focus run"}
+          </Button>
+          <Button
+            size="xs"
+            variant="primary"
+            onClick={() => onNavigate("prompt")}
+          >
+            New research
+          </Button>
         </div>
         {commandsOpen ? (
           <div
@@ -138,24 +246,42 @@ export function ResearchTabDesk({ research, context, onNavigate }: ResearchTabPr
             )}
           </div>
         ) : null}
-        {listFilter.trim() && !isCommandText ? (
-          <p className="research-desk-querybar__filter-hint" role="status">
-            Filtering runs by “{listFilter.trim()}”.
-            <Button size="xs" variant="ghost" onClick={() => onNavigate("prompt")}>
-              Open in Prompt ↗
-            </Button>
-            <span>Your question isn’t carried over — the Prompt tab opens fresh.</span>
-          </p>
-        ) : null}
+        <div
+          className="research-desk-toolbar__scopes"
+          role="group"
+          aria-label="Filter runs by status"
+        >
+          {SCOPES.map((item) => (
+            <button
+              key={item.id}
+              type="button"
+              className="research-desk-scope focus-ring"
+              aria-pressed={scope === item.id}
+              aria-label={`${item.label}, ${scopeCounts[item.id]} ${scopeCounts[item.id] === 1 ? "run" : "runs"}`}
+              onClick={() => setScope(item.id)}
+            >
+              <span>{item.label}</span>
+              <span aria-hidden>{scopeCounts[item.id]}</span>
+            </button>
+          ))}
+        </div>
       </div>
 
-      <div className="research-desk__workspace">
+      <div
+        className="research-desk__workspace"
+        data-focus-mode={focusMode}
+      >
         <ResearchMissionList
           missions={research.missions}
           selectedId={research.selectedId}
           loading={research.loading}
           onSelect={research.select}
           filter={listFilter}
+          scope={scope}
+          onClearFilters={() => {
+            setQuery("");
+            setScope("all");
+          }}
         />
         <main className="research-desk__main">
           {research.error ? (
@@ -168,6 +294,7 @@ export function ResearchTabDesk({ research, context, onNavigate }: ResearchTabPr
           ) : null}
           <ResearchMissionDetail
             mission={research.selected}
+            showEvidence={!focusMode}
             onOpenSession={(sessionId) => {
               context.openSession(sessionId, context.activeFamiliar.id);
             }}

--- a/src/components/role-surfaces/researcher-surface.test.ts
+++ b/src/components/role-surfaces/researcher-surface.test.ts
@@ -233,11 +233,14 @@ test("mission list uses roving tabindex keyboard navigation", () => {
   assert.match(list, /research-mission-row focus-ring/);
 });
 
-test("archived missions collapse into a disclosure group below active work", () => {
-  // Partition: archived rows leave the working ledger…
-  assert.match(list, /mission\.status === "archived" \? archived : active/);
-  // …the header counts active missions only…
-  assert.match(list, /<span>\{activeMissions\.length\}<\/span>/);
+test("archived missions collapse below the priority groups", () => {
+  // The shared view model partitions filtered missions into review, progress,
+  // recent, and archived groups while the rail keeps archived rows separate.
+  assert.match(list, /groupResearchMissions\(filteredMissions\)/);
+  assert.match(list, /group\.id !== "archived"/);
+  assert.match(list, /group\.id === "archived"/);
+  // The header counts visible, non-archived missions only.
+  assert.match(list, /<span>\{nonArchivedCount\}<\/span>/);
   // …and the group is a real count-labeled disclosure.
   assert.match(list, /aria-expanded=\{archivedOpen\}/);
   assert.match(list, /research-mission-nav__group-toggle focus-ring/);

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -92,48 +92,71 @@
   flex-direction: column;
 }
 
-/* ── Query/command bar (design 51–72). ── */
-.research-desk-querybar {
+/* ── Control toolbar: one truthful filter, one primary action, compact view
+   controls, and the existing command menu behind "/". ── */
+.research-desk-toolbar {
   position: relative;
-  padding: var(--space-3) 22px var(--space-3);
-}
-.research-desk-querybar__field {
   display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+}
+.research-desk-toolbar__main {
+  display: flex;
+  min-width: 0;
   align-items: center;
-  gap: 10px;
-  min-height: 44px;
-  padding: 0 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius-control);
-  background: var(--bg-raised);
-  color: var(--text-muted);
+  gap: var(--space-2);
 }
-.research-desk-querybar__field:focus-within {
-  border-color: color-mix(in oklch, var(--research-accent) 45%, transparent);
-}
-.research-desk-querybar__field input {
+.research-desk-toolbar__search {
   flex: 1;
   min-width: 0;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  outline: none;
-  color: var(--text-primary);
-  font-size: var(--text-sm);
-  font-family: inherit;
 }
-.research-desk-querybar__field input::placeholder { color: var(--text-muted); }
-.research-desk-querybar__affordance {
+.research-desk-toolbar__summary {
   flex: none;
-  font-family: var(--font-mono, ui-monospace, monospace);
   font-size: var(--text-2xs);
   color: var(--text-muted);
 }
+.research-desk-toolbar__scopes {
+  display: flex;
+  gap: var(--space-1);
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.research-desk-toolbar__scopes::-webkit-scrollbar { display: none; }
+.research-desk-scope {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid transparent;
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  cursor: pointer;
+}
+.research-desk-scope:hover { color: var(--text-secondary); }
+.research-desk-scope[aria-pressed="true"] {
+  border-color: var(--border-hairline);
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+}
+.research-desk-scope > span:last-child {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  color: var(--text-muted);
+}
+.research-desk-tab .research-desk__workspace[data-focus-mode="true"] {
+  grid-template-columns: minmax(0, 1fr);
+}
+.research-desk-tab .research-desk__workspace[data-focus-mode="true"] > .research-mission-nav {
+  display: none;
+}
 .research-desk-querybar__popover {
   position: absolute;
-  top: calc(100% - 4px);
-  left: 22px;
-  right: 22px;
+  top: calc(100% - var(--space-1));
+  left: var(--space-5);
+  right: var(--space-5);
   z-index: 20;
   display: flex;
   flex-direction: column;
@@ -188,16 +211,6 @@
   font-size: var(--text-xs);
   color: var(--text-muted);
 }
-.research-desk-querybar__filter-hint {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 6px;
-  margin: 6px 2px 0;
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-}
-.research-desk-querybar__filter-hint span { color: var(--text-muted); }
 
 /* ── Runs rail: 264px per the design; base grid comes from
    .research-desk__workspace in surface-role-workspaces.css. ── */
@@ -215,6 +228,18 @@
   color: oklch(0.8 0.13 75); /* existing desk warn reading */
 }
 .research-mission-nav__waiting time { text-transform: none; }
+.research-mission-nav__section + .research-mission-nav__section {
+  border-top: 1px solid var(--border-hairline);
+}
+.research-mission-nav__section-title {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-2) var(--space-3) 0;
+  color: var(--text-muted);
+  font: 600 var(--text-2xs)/1.4 var(--font-mono, ui-monospace, monospace);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 
 /* ── Detail: center column + 312px evidence rail. ── */
 .research-desk-tab .research-mission-detail { padding: 0; }
@@ -222,6 +247,9 @@
   grid-template-columns: minmax(0, 1fr) minmax(280px, 320px);
   gap: 0;
   flex: 1;
+}
+.research-desk-tab .research-mission-detail__body[data-evidence-open="false"] {
+  grid-template-columns: minmax(0, 1fr);
 }
 .research-desk-center {
   display: flex;
@@ -543,21 +571,39 @@
    collapses are re-declared here for the desk tab. ── */
 @container research-desk (max-width: 900px) {
   .research-desk-tab .research-desk__workspace { grid-template-columns: 1fr; }
-  .research-desk-querybar { padding: 10px 14px; }
-  .research-desk-querybar__popover { left: 14px; right: 14px; }
+  .research-mission-nav { max-height: calc(var(--space-10) * 4); }
+  .research-desk-toolbar { padding: var(--space-3) var(--space-4); }
+  .research-desk-querybar__popover {
+    left: var(--space-4);
+    right: var(--space-4);
+  }
 }
 
 @container research-desk (max-width: 760px) {
   .research-desk__tabs { gap: var(--space-2); }
   .research-desk-tab .research-mission-detail__body { grid-template-columns: 1fr; }
-  .research-desk-rail { border-left: 0; border-top: 1px solid var(--border); }
+  .research-desk-rail {
+    max-height: 44vh;
+    overflow: hidden;
+    border-left: 0;
+    border-top: 1px solid var(--border);
+  }
 }
 
 @container research-desk (max-width: 560px) {
   .research-desk__tabs { padding: 0 12px; }
   .research-tab-placeholder { padding: var(--space-4) 12px; }
-  .research-desk-querybar { padding: 8px 12px; }
-  .research-desk-querybar__affordance { display: none; }
+  .research-desk-toolbar { padding: var(--space-2) var(--space-3); }
+  .research-desk-toolbar__main { flex-wrap: wrap; }
+  .research-desk-toolbar__search {
+    flex-basis: 100%;
+    min-width: 100%;
+  }
+  .research-desk-toolbar__summary { margin-right: auto; }
+  .research-desk-querybar__popover {
+    left: var(--space-3);
+    right: var(--space-3);
+  }
   .research-desk-center { padding: 14px 12px 0; }
   .research-desk-tab .research-mission-actions { margin: auto -12px 0; padding: 10px 12px; flex-wrap: wrap; }
   .research-desk-stepper__track { overflow-x: auto; padding-bottom: 4px; }

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -290,6 +290,23 @@ async function mockResearchApis(page: Page): Promise<BootHandles> {
   await page.route(/\/api\/research\/missions\?/, (route) =>
     route.fulfill({ json: { ok: true, missions: MISSIONS } }),
   );
+  await page.route(/\/api\/research\/missions\/[^/]+\/files\/[^/]+$/, (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        file: {
+          key: "draft-1",
+          kind: "findings",
+          title: "Working synthesis",
+          fileName: "draft.md",
+          relativePath: "artifacts/draft.md",
+          content: "# Working synthesis\n\nResearch findings with cited evidence.",
+          workspacePath: "/tmp/research-mission-1",
+          updatedAt: iso(5),
+        },
+      },
+    }),
+  );
   await page.route("**/api/research/links", (route) =>
     route.fulfill({ json: { ok: true, links: LINKS } }),
   );
@@ -404,6 +421,90 @@ test.describe("research desk tabs", () => {
       "The research session crashed before publishing.",
     );
     await expect(desk.locator(".research-mission-actions").getByRole("button", { name: /^Retry/ })).toBeVisible();
+  });
+
+  test("Desk toolbar scopes runs and preserves focus mode", async ({ page }) => {
+    await openResearchDesk(page);
+    const desk = page.locator(".research-desk");
+    const toolbar = desk.locator(".research-desk-toolbar");
+    const rail = desk.getByRole("navigation", { name: "Research missions" });
+    const filter = toolbar.getByRole("searchbox", {
+      name: "Filter research runs",
+    });
+
+    await expect(filter).toHaveAttribute("placeholder", "Filter runs…");
+    await page.keyboard.press("/");
+    await expect(filter).toBeFocused();
+    await expect(filter).toHaveValue("/");
+    await filter.press("Escape");
+    await expect(filter).toHaveValue("");
+
+    const railTabs = desk.getByRole("tablist", { name: "Rail contents" });
+    await railTabs.getByRole("tab", { name: /^Artifacts/ }).click();
+    await desk.getByRole("button", { name: "View Working synthesis" }).click();
+    const reader = page.getByRole("dialog", {
+      name: "Working synthesis — research reader",
+    });
+    await expect(reader).toBeVisible({ timeout: 15_000 });
+    await reader.getByRole("button", { name: "Close" }).focus();
+    await page.keyboard.press("/");
+    await expect(filter).not.toBeFocused();
+    await expect
+      .poll(() => reader.evaluate((node) => node.contains(document.activeElement)))
+      .toBe(true);
+    await reader.getByRole("button", { name: "Close" }).click();
+
+    const scopes = toolbar.getByRole("group", {
+      name: "Filter runs by status",
+    });
+    await expect(
+      scopes.getByRole("button", { name: "Active, 2 runs", exact: true }),
+    ).toBeVisible();
+    await scopes.getByRole("button", { name: "Needs review" }).click();
+    await expect(
+      scopes.getByRole("button", { name: "Needs review" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(rail.getByText("Needs review")).toBeVisible();
+    await expect(
+      rail.getByRole("button", { name: /Agent memory survey/ }),
+    ).toHaveCount(0);
+
+    await filter.fill("no matching research run");
+    await expect(
+      scopes.getByRole("button", { name: "Active, 0 runs", exact: true }),
+    ).toBeVisible();
+    await rail.getByRole("button", { name: "Clear filters" }).click();
+    await expect(filter).toHaveValue("");
+    await expect(
+      scopes.getByRole("button", { name: "All" }),
+    ).toHaveAttribute("aria-pressed", "true");
+    await expect(
+      rail.getByRole("button", { name: /Agent memory survey/ }),
+    ).toBeVisible();
+
+    await toolbar.getByRole("button", { name: "Focus run" }).click();
+    await expect(rail).toBeHidden();
+    await expect(desk.getByLabel("Run evidence and links")).toHaveCount(0);
+    await expect(
+      toolbar.getByRole("button", { name: "Show workspace" }),
+    ).toBeVisible();
+    const focusedMain = await desk.locator(".research-desk__main").boundingBox();
+    expect(focusedMain?.width ?? 0).toBeGreaterThan(900);
+
+    await page.reload();
+    await enterResearchDesk(page);
+    await expect(
+      desk.getByRole("button", { name: "Show workspace" }),
+    ).toBeVisible();
+    await desk.getByRole("button", { name: "Show workspace" }).click();
+    await expect(rail).toBeVisible();
+    await expect(desk.getByLabel("Run evidence and links")).toBeVisible();
+
+    await desk.getByRole("button", { name: "New research" }).click();
+    await expect(deskTab(page, /^Prompt/)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
   });
 
   test("Library shows the live ticker and artifact cards; the chosen tab survives a reload", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add a truthful Research Desk toolbar with query-aware lifecycle scopes and accessible counts
- group missions by review priority, persist per-familiar focus mode, and make the `/` shortcut modal-safe
- bound responsive rails while preserving mission selection, evidence, and existing five-tab workflows

## Test plan
- [x] `pnpm test:app` (981 test files)
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm check:tests-wired` (1350 files)
- [x] `pnpm exec playwright test tests/research-desk-tabs.spec.ts --project=desktop --no-deps --workers=1` (7 passed)
- [x] `pnpm build` (bundle and standalone budgets passed)

Bead: `cave-3x08i`