### PR TITLE
chore(tests): read owning CSS split modules instead of import facades

### DIFF
--- a/src/components/drag-to-split.test.ts
+++ b/src/components/drag-to-split.test.ts
@@ -91,7 +91,12 @@ test("the right companion (agent) panel is no longer mounted", () => {
 
 test("split tiles keep a usability floor (cave-hivd)", () => {
   const host = read("./detail-split-host.tsx");
-  const css = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+  // The pane-body rules' owning split module behind the globals.css facade
+  // (cave-xd2kg: source contracts read owning modules, not the facade).
+  const css = readFileSync(
+    new URL("../styles/globals/surface-chat-overlays.css", import.meta.url),
+    "utf8",
+  );
   // Multi-tile panels floor at 300px — a 12% min let dividers crush a tile to
   // ~110px letter soup on wide windows (tiles close via ✕, not drag-past-edge).
   assert.match(host, /id=\{`split-tile-\$\{tile\.id\}`\}[\s\S]{0,500}minSize="300px"/, "multi-tile panels have a pixel min");

--- a/src/components/home-composer-centering.test.ts
+++ b/src/components/home-composer-centering.test.ts
@@ -84,10 +84,28 @@ assert.match(
 );
 
 // ───── Home composer reads the variables and centers on viewport ─────
-const css = await readFile(
+// Source contracts read the owning split modules, not the import facade
+// (cave-xd2kg). The module list is derived from the facade's own @import
+// lines so the negative pins below keep facade-wide scope even when a new
+// module joins the surface.
+const homeComposerFacade = await readFile(
   new URL("../styles/home-composer.css", import.meta.url),
   "utf8",
 );
+const homeComposerModules = [
+  ...homeComposerFacade.matchAll(/@import\s+"\.\/home-composer\/([^"]+)"/g),
+].map((match) => match[1]);
+assert.ok(
+  homeComposerModules.includes("landing-composer.css"),
+  "the home-composer facade imports the landing-composer owning module",
+);
+const css = (
+  await Promise.all(
+    homeComposerModules.map((name) =>
+      readFile(new URL(`../styles/home-composer/${name}`, import.meta.url), "utf8"),
+    ),
+  )
+).join("\n");
 
 // With the right companion panel removed, the detail fills to the viewport
 // edge — there is no asymmetric right panel to re-center Home around, so the
@@ -198,15 +216,16 @@ assert.doesNotMatch(
   "old 760px max-width on .home-composer-suggestions removed",
 );
 
-// ───── globals.css lets the detail panel overflow when it's home mode ─────
-const globals = await readFile(
-  new URL("../app/globals.css", import.meta.url),
+// ── shell-navigation.css lets the detail panel overflow in home mode ──
+// (the owning split module behind the globals.css facade)
+const shellNavigation = await readFile(
+  new URL("../styles/globals/shell-navigation.css", import.meta.url),
   "utf8",
 );
 assert.match(
-  globals,
+  shellNavigation,
   /\.shell-detail-panel:has\(> \.shell-detail > \.cave-mode-fade > \.workspace-detail-content > \.home-composer-root\)\s*\{\s*overflow:\s*visible\s*!important/,
-  "globals.css opens .shell-detail-panel overflow when it contains the home composer through the inertable detail wrapper",
+  "shell-navigation.css opens .shell-detail-panel overflow when it contains the home composer through the inertable detail wrapper",
 );
 
 console.log("home-composer-centering.test.ts: ok");

--- a/src/components/shell-drawer-smoke.test.ts
+++ b/src/components/shell-drawer-smoke.test.ts
@@ -13,8 +13,10 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
+// The drawer rules' owning split module behind the globals.css facade
+// (cave-xd2kg: source contracts read owning modules, not the facade).
 const globals = readFileSync(
-  new URL("../app/globals.css", import.meta.url),
+  new URL("../styles/globals/shell-responsive.css", import.meta.url),
   "utf8",
 );
 const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");


### PR DESCRIPTION
## Summary

Implements **cave-xd2kg**: three source-contract assertions still read CSS import facades whose owning rules moved into split modules — they passed only through the facade-expansion shim (`css-source-contract-hook`), i.e. vacuously with respect to the file they claimed to inspect. Each assertion now reads its actual owning module:

| Test | Was reading | Now reads |
| --- | --- | --- |
| `home-composer-centering` (hc-* centering pins) | `styles/home-composer.css` facade | every module the facade imports (list derived from the facade's own `@import` lines, so **negative** pins keep facade-wide scope when a new module joins the surface) |
| `home-composer-centering` (detail-panel overflow pin) | `app/globals.css` facade | `styles/globals/shell-navigation.css` |
| `shell-drawer-smoke` (drawer transforms, breakpoint, fixed, overscroll) | `app/globals.css` facade | `styles/globals/shell-responsive.css` |
| `drag-to-split` (pane-body usability floor) | `app/globals.css` facade | `styles/globals/surface-chat-overlays.css` |

Every regex was verified against its owning module before repointing. No production CSS changes.

## Verification

All 11 assertions pass **both with and without** the facade-expansion hook (previously all three files failed without it); `check:tests-wired` green.

Closes cave-xd2kg (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)