### PR TITLE
fix(tests): pin CODEX_BIN so the coven-transport codex test cannot go direct

### DIFF
--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -20,9 +20,31 @@ const previousCovenBin = process.env.COVEN_BIN;
 const previousCovenTestLog = process.env.COVEN_TEST_LOG;
 const previousCovenTestMode = process.env.COVEN_TEST_MODE;
 const previousCovenCancelReady = process.env.COVEN_TEST_CANCEL_READY;
+const previousCodexBin = process.env.CODEX_BIN;
 process.env.COVEN_HOME = home;
 process.env.COVEN_CAVE_HOME = path.join(home, "cave");
 process.env.COVEN_TEST_LOG = log;
+
+// Every scenario in this file exercises the GENERIC `coven run codex`
+// transport through the shim above. On a machine with a real Codex CLI on
+// the discovered spawn PATH, direct codex routing can engage instead —
+// bypassing the adapter gate entirely and spawning the real CLI on the test
+// prompt (cave-evrsr: order/timing-dependent, since the capability probes
+// race their timeout). Pin CODEX_BIN to an existing but unlaunchable fixture
+// (mode-0644 file on POSIX, unconvertible .cmd on Windows — the same shape
+// as cave-g3qar's fix in the sibling route-runtime-availability test) so the
+// passive availability gate keeps the direct path off deterministically. A
+// nonexistent override would not do: codexBin() falls back to PATH search.
+const pinnedCodex = path.join(
+  bin,
+  process.platform === "win32" ? "codex-no-exec.cmd" : "codex-no-exec",
+);
+await writeFile(
+  pinnedCodex,
+  process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n",
+  { mode: 0o644 },
+);
+process.env.CODEX_BIN = pinnedCodex;
 
 const shimScript = path.join(bin, "coven.js");
 const shim = [
@@ -275,6 +297,8 @@ try {
   else process.env.COVEN_TEST_MODE = previousCovenTestMode;
   if (previousCovenCancelReady === undefined) delete process.env.COVEN_TEST_CANCEL_READY;
   else process.env.COVEN_TEST_CANCEL_READY = previousCovenCancelReady;
+  if (previousCodexBin === undefined) delete process.env.CODEX_BIN;
+  else process.env.CODEX_BIN = previousCodexBin;
   await rm(home, { recursive: true, force: true });
 }
 


### PR DESCRIPTION
## Summary

Implements **cave-evrsr**: `route-codex-runtime-availability.integration.test.ts` failed only inside the full api suite (deterministically at file 123, passing in isolation) with no `runtime_missing` error event.

Root cause is not filesystem pollution but a **timing race the suite context reliably wins**: the test exercises the generic `coven run codex` transport through a shimmed coven CLI but never pinned `CODEX_BIN`. On a machine with a real Codex 0.145.0 (inside the bootstrap schema range) on the discovered spawn PATH, direct codex routing can engage — bypassing the adapter gate the test exists to verify, and **spawning the real codex CLI on the test prompt**. Whether the capability probes complete within their timeout decides which path runs, which is why isolation (cold caches) passed and the warmed suite failed — and why this surfaced right after #4082 made the probe timeout more generous.

The fix mirrors cave-g3qar/#4083's sibling pattern: `CODEX_BIN` pinned to an existing-but-unlaunchable fixture (mode-0644 on POSIX, intentionally unconvertible `.cmd` on Windows) so the passive availability gate keeps the direct path off deterministically for every scenario in the file. A nonexistent override wouldn't work — `codexBin()` falls back to PATH search.

`codex-routing.test.ts` (the other codex-harness test without a pin) was checked and is not exposed: it injects its probe and never reaches real discovery.

## Verification

- Baseline reproduced: full `node scripts/run-tests.mjs api` failed at file 123 on clean main in this worktree.
- With the pin: the isolated test passes and the **full api suite is green (298 files, exit 0)**.

Closes cave-evrsr (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)