### PR TITLE
test(chat): pin CODEX_BIN so the codex availability route test is host-proof

### DIFF
--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
 
@@ -16,6 +16,23 @@ await mkdir(familiarWorkspace, { recursive: true });
 
 const previousHome = process.env.COVEN_HOME;
 const previousCaveHome = process.env.COVEN_CAVE_HOME;
+// This route probes a launch-ready Codex CLI before falling back to the generic
+// Coven adapter path, so a developer machine with a real `codex` on PATH takes
+// the direct-Codex branch and never emits the `runtime_missing` event these
+// scenarios assert (cave-evrsr; same host dependency cave-g3qar fixed for the
+// sibling route-runtime-availability test, which this file was missed by).
+// Pin CODEX_BIN to an existing but UNLAUNCHABLE fixture — mode 0644 on POSIX,
+// an unconvertible .cmd on Windows — so the passive availability gate reports it
+// before any probe can spawn. A nonexistent path would not do: codexBin() falls
+// back to searching the launcher's effective PATH.
+const pinnedCodex = path.join(bin, process.platform === "win32" ? "codex-no-exec.cmd" : "codex-no-exec");
+await writeFile(pinnedCodex, process.platform === "win32" ? "@echo off\r\nexit /b 0\r\n" : "#!/bin/sh\nexit 0\n", {
+  mode: 0o644,
+});
+if (process.platform !== "win32") await chmod(pinnedCodex, 0o644);
+
+const previousCodexBin = process.env.CODEX_BIN;
+process.env.CODEX_BIN = pinnedCodex;
 const previousCovenBin = process.env.COVEN_BIN;
 const previousCovenTestLog = process.env.COVEN_TEST_LOG;
 const previousCovenTestMode = process.env.COVEN_TEST_MODE;
@@ -269,6 +286,8 @@ try {
   else process.env.COVEN_CAVE_HOME = previousCaveHome;
   if (previousCovenBin === undefined) delete process.env.COVEN_BIN;
   else process.env.COVEN_BIN = previousCovenBin;
+  if (previousCodexBin === undefined) delete process.env.CODEX_BIN;
+  else process.env.CODEX_BIN = previousCodexBin;
   if (previousCovenTestLog === undefined) delete process.env.COVEN_TEST_LOG;
   else process.env.COVEN_TEST_LOG = previousCovenTestLog;
   if (previousCovenTestMode === undefined) delete process.env.COVEN_TEST_MODE;


### PR DESCRIPTION
`route-codex-runtime-availability.integration.test.ts` fails deterministically on any machine with a real `codex` on `PATH`. The route probes for a launch-ready Codex CLI before falling back to the generic Coven adapter path, so a real binary sends it down the direct-Codex branch and it never emits the `runtime_missing` event every scenario here asserts:

```
AssertionError: the unavailable adapter produces a structured error event
  actual: undefined, expected: true
```

This is the **same host dependency `cave-g3qar` fixed for the sibling** `route-runtime-availability.integration.test.ts` in #4083 — this file was missed. Same remedy, same shape: pin `CODEX_BIN` to an existing but **unlaunchable** fixture (mode `0644` on POSIX, an unconvertible `.cmd` on Windows) so the passive availability gate reports it before any probe can spawn, restored in the `finally`. A nonexistent path would not work — `codexBin()` falls back to searching the launcher's effective PATH.

## Verification

A fix that only helps my machine would be worse than none, so all four corners:

| case | result |
|---|---|
| pin applied | PASS |
| pin neutralised (mutation) | **FAIL** |
| real `codex` on PATH (this machine) | PASS |
| PATH stripped of codex (**the CI shape**) | PASS |

`node scripts/run-tests.mjs api` → **298/298**, the first fully green api suite on macOS today. It previously stopped at file 123.

## Correcting the bead's own premise

I filed `cave-evrsr` claiming order-dependent suite pollution, because the test "passed in isolation". **Those isolation runs were contaminated** — they ran in a worktree immediately after a completed suite run, whose leftover state *masked* the failure. So I had the causality backwards: the suite didn't break the test, a finished suite hid the breakage.

From a clean environment it fails in both worktrees, in the fully-installed primary checkout, and at four separate commits (`d14b7d86c`, `ca1718cca`, `93f3673ce`, `4415dce13`).

Also ruled out, each of which looked plausible:
- **the css-source-contract hook** — fails identically with and without it
- **missing `node_modules`** — the fully-installed primary checkout fails too
- **Node patch level** — fails on both 24.13.0 and 24.18.1

One diagnostic note for the next person, since it cost me two false readings: bare `node --test <file>` cannot run these — it dies with `ERR_MODULE_NOT_FOUND: '@/lib'` because only `run-tests.mjs` installs the alias loader. Use `nodeArgsFor()` from the runner, or replicate `--require ./scripts/css-source-contract-hook.cjs --experimental-strip-types --import ./scripts/test-alias-register.mjs`.

Bead: `cave-evrsr`

🤖 Generated with [Claude Code](https://claude.com/claude-code)