### PR TITLE
feat(ios): add biometric app lock and approvals

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -5,6 +5,10 @@ import UserNotifications
 struct CovenCaveApp: App {
     @State private var app: AppModel
     @State private var notificationDelegate: CaveNotificationDelegate
+    /// Owns the biometric app-unlock + approval state. Created alongside
+    /// `AppModel` so its cold-start lock decision is settled before the first
+    /// view mounts (see `LockScreenView`, substituted in for the whole root).
+    @State private var appLock: AppLock
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @Environment(\.scenePhase) private var scenePhase
 
@@ -18,6 +22,7 @@ struct CovenCaveApp: App {
         UNUserNotificationCenter.current().delegate = notificationDelegate
         _app = State(initialValue: app)
         _notificationDelegate = State(initialValue: notificationDelegate)
+        _appLock = State(initialValue: AppLock())
     }
 
     var body: some Scene {
@@ -33,9 +38,17 @@ struct CovenCaveApp: App {
             // columns behaves as regular — the same call Apple makes for Max
             // phones — which engages the existing balanced splits everywhere.
             WideSplitEnabler {
-                RootView()
+                // Full replacement, never a translucent overlay: while locked,
+                // RootView (and everything under it) simply isn't mounted, so
+                // a cold launch can never flash app content before auth.
+                if appLock.isLocked {
+                    LockScreenView(appLock: appLock)
+                } else {
+                    RootView()
+                }
             }
                 .environment(app)
+                .environment(appLock)
                 // Propagate the chrome palette to every view, tint app-wide
                 // controls with its accent, and apply the resolved light/dark mode.
                 .environment(\.chrome, resolved.chrome)
@@ -66,6 +79,18 @@ struct CovenCaveApp: App {
                         Task { await app.connectWithRetry() }
                     } else if app.connectionState == .connected {
                         Task { await app.validateConnectionOnForeground() }
+                    }
+                }
+                // Deliberately ignores `.inactive` — LocalAuthentication's own
+                // prompt (and the app switcher/control center) can bounce the
+                // scene through `.inactive` without a genuine background
+                // stint, which must never count toward the re-lock window.
+                .onChange(of: scenePhase) { _, phase in
+                    switch phase {
+                    case .background: appLock.sceneDidEnterBackground()
+                    case .active: appLock.sceneDidBecomeActive()
+                    case .inactive: break
+                    @unknown default: break
                     }
                 }
                 // Deep links from the home-screen widget (covencave://…) route to

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -9,6 +9,7 @@ struct CovenCaveApp: App {
     /// `AppModel` so its cold-start lock decision is settled before the first
     /// view mounts (see `LockScreenView`, substituted in for the whole root).
     @State private var appLock: AppLock
+    @State private var pairingApprovalFailed = false
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @Environment(\.scenePhase) private var scenePhase
 
@@ -111,7 +112,38 @@ struct CovenCaveApp: App {
                 // the matching destination/sheet. Handled even before connect — the destination is
                 // set so the right surface shows once the desktop is reached.
                 .onOpenURL { app.handleDeepLink($0) }
+                .task { await processPendingPairingIntent() }
+                .onChange(of: app.pendingPairingIntent) {
+                    Task { await processPendingPairingIntent() }
+                }
+                .onChange(of: appLock.isLocked) {
+                    Task { await processPendingPairingIntent() }
+                }
+                .alert("Couldn't confirm it's you", isPresented: $pairingApprovalFailed) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text("Authentication failed or was cancelled, so your desktop pairing was not changed.")
+                }
         }
+    }
+
+    @MainActor
+    private func processPendingPairingIntent() async {
+        guard let intent = app.takePendingPairingIntent(isLocked: appLock.isLocked) else { return }
+        let requiresApproval = PairingApprovalPolicy.requiresApproval(
+            hasExistingPairing: app.connection != nil
+        )
+        if !requiresApproval {
+            await app.configure(host: intent.host, token: intent.token)
+            return
+        }
+
+        let approved = await appLock.performApprovedAction(
+            reason: "Confirm it's you to replace your desktop pairing"
+        ) {
+            await app.configure(host: intent.host, token: intent.token)
+        }
+        if !approved { pairingApprovalFailed = true }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -10,6 +10,7 @@ struct CovenCaveApp: App {
     /// view mounts (see `LockScreenView`, substituted in for the whole root).
     @State private var appLock: AppLock
     @State private var pairingApprovalFailed = false
+    @State private var pairingAuthenticationUnavailable = false
     @State private var isProcessingPairingIntent = false
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @Environment(\.scenePhase) private var scenePhase
@@ -133,6 +134,11 @@ struct CovenCaveApp: App {
                 } message: {
                     Text("Authentication failed or was cancelled, so your desktop pairing was not changed.")
                 }
+                .alert("Device authentication unavailable", isPresented: $pairingAuthenticationUnavailable) {
+                    Button("OK", role: .cancel) {}
+                } message: {
+                    Text("Your pairing remains queued. Turn on a device passcode to approve it.")
+                }
         }
     }
 
@@ -162,17 +168,19 @@ struct CovenCaveApp: App {
             return
         }
 
-        let outcome = await appLock.requestApprovalOutcome(
+        let outcome = await appLock.requestApproval(
             reason: "Confirm it's you to replace your desktop pairing"
         )
         switch outcome {
-        case .approved:
+        case .authorized:
             await app.configure(host: intent.host, token: intent.token)
             app.consumePendingPairingIntent(matching: intent.id)
         case .denied:
             app.consumePendingPairingIntent(matching: intent.id)
             pairingApprovalFailed = true
-        case .unavailable, .busy:
+        case .unavailable:
+            pairingAuthenticationUnavailable = true
+        case .busy:
             break
         }
     }

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -105,7 +105,9 @@ struct CovenCaveApp: App {
                 .onChange(of: scenePhase) { _, phase in
                     switch phase {
                     case .background: appLock.sceneDidEnterBackground()
-                    case .active: appLock.sceneDidBecomeActive()
+                    case .active:
+                        appLock.sceneDidBecomeActive()
+                        Task { await processPendingPairingIntent() }
                     case .inactive: appLock.sceneDidBecomeInactive()
                     @unknown default: break
                     }
@@ -147,7 +149,8 @@ struct CovenCaveApp: App {
         guard PendingPairingProcessorPolicy.mayBegin(
             isLocked: appLock.isLocked,
             isAuthenticating: appLock.isAuthenticating,
-            isProcessing: isProcessingPairingIntent
+            isProcessing: isProcessingPairingIntent,
+            isActive: scenePhase == .active
         ), let intent = app.pendingPairingIntent else {
             return
         }
@@ -163,8 +166,10 @@ struct CovenCaveApp: App {
             hasExistingPairing: app.connection != nil
         )
         if !requiresApproval {
-            await app.configure(host: intent.host, token: intent.token)
-            app.consumePendingPairingIntent(matching: intent.id)
+            guard let reservedIntent = app.takePendingPairingIntent(matching: intent.id) else {
+                return
+            }
+            await app.configure(host: reservedIntent.host, token: reservedIntent.token)
             return
         }
 
@@ -173,11 +178,14 @@ struct CovenCaveApp: App {
         )
         switch outcome {
         case .authorized:
-            await app.configure(host: intent.host, token: intent.token)
-            app.consumePendingPairingIntent(matching: intent.id)
+            guard let reservedIntent = app.takePendingPairingIntent(matching: intent.id) else {
+                return
+            }
+            await app.configure(host: reservedIntent.host, token: reservedIntent.token)
         case .denied:
-            app.consumePendingPairingIntent(matching: intent.id)
-            pairingApprovalFailed = true
+            if app.consumePendingPairingIntent(matching: intent.id) {
+                pairingApprovalFailed = true
+            }
         case .unavailable:
             pairingAuthenticationUnavailable = true
         case .busy:

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -10,6 +10,7 @@ struct CovenCaveApp: App {
     /// view mounts (see `LockScreenView`, substituted in for the whole root).
     @State private var appLock: AppLock
     @State private var pairingApprovalFailed = false
+    @State private var isProcessingPairingIntent = false
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @Environment(\.scenePhase) private var scenePhase
 
@@ -119,6 +120,14 @@ struct CovenCaveApp: App {
                 .onChange(of: appLock.isLocked) {
                     Task { await processPendingPairingIntent() }
                 }
+                .onChange(of: appLock.isAuthenticating) { _, isAuthenticating in
+                    guard !isAuthenticating else { return }
+                    Task { await processPendingPairingIntent() }
+                }
+                .onChange(of: appLock.canUseDeviceAuthentication) { _, isAvailable in
+                    guard isAvailable else { return }
+                    Task { await processPendingPairingIntent() }
+                }
                 .alert("Couldn't confirm it's you", isPresented: $pairingApprovalFailed) {
                     Button("OK", role: .cancel) {}
                 } message: {
@@ -129,21 +138,43 @@ struct CovenCaveApp: App {
 
     @MainActor
     private func processPendingPairingIntent() async {
-        guard let intent = app.takePendingPairingIntent(isLocked: appLock.isLocked) else { return }
+        guard PendingPairingProcessorPolicy.mayBegin(
+            isLocked: appLock.isLocked,
+            isAuthenticating: appLock.isAuthenticating,
+            isProcessing: isProcessingPairingIntent
+        ), let intent = app.pendingPairingIntent else {
+            return
+        }
+        isProcessingPairingIntent = true
+        defer {
+            isProcessingPairingIntent = false
+            if let pending = app.pendingPairingIntent, pending.id != intent.id {
+                Task { await processPendingPairingIntent() }
+            }
+        }
+
         let requiresApproval = PairingApprovalPolicy.requiresApproval(
             hasExistingPairing: app.connection != nil
         )
         if !requiresApproval {
             await app.configure(host: intent.host, token: intent.token)
+            app.consumePendingPairingIntent(matching: intent.id)
             return
         }
 
-        let approved = await appLock.performApprovedAction(
+        let outcome = await appLock.requestApprovalOutcome(
             reason: "Confirm it's you to replace your desktop pairing"
-        ) {
+        )
+        switch outcome {
+        case .approved:
             await app.configure(host: intent.host, token: intent.token)
+            app.consumePendingPairingIntent(matching: intent.id)
+        case .denied:
+            app.consumePendingPairingIntent(matching: intent.id)
+            pairingApprovalFailed = true
+        case .unavailable, .busy:
+            break
         }
-        if !approved { pairingApprovalFailed = true }
     }
 }
 

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -40,12 +40,22 @@ struct CovenCaveApp: App {
             WideSplitEnabler {
                 // Full replacement, never a translucent overlay: while locked,
                 // RootView (and everything under it) simply isn't mounted, so
-                // a cold launch can never flash app content before auth.
-                if appLock.isLocked {
-                    LockScreenView(appLock: appLock)
-                } else {
-                    RootView()
+                // a cold launch can never flash app content before auth. The
+                // privacy shield is layered separately, above whichever of
+                // these is mounted, so a quick `.inactive`/`.background` blip
+                // shields snapshots without tearing down RootView's
+                // navigation state the way a full lock replacement would.
+                ZStack {
+                    if appLock.isLocked {
+                        LockScreenView(appLock: appLock)
+                    } else {
+                        RootView()
+                    }
+                    if appLock.isPrivacyShielded {
+                        PrivacyShieldView()
+                    }
                 }
+                .animation(nil, value: appLock.isPrivacyShielded)
             }
                 .environment(app)
                 .environment(appLock)
@@ -81,15 +91,19 @@ struct CovenCaveApp: App {
                         Task { await app.validateConnectionOnForeground() }
                     }
                 }
-                // Deliberately ignores `.inactive` — LocalAuthentication's own
-                // prompt (and the app switcher/control center) can bounce the
-                // scene through `.inactive` without a genuine background
-                // stint, which must never count toward the re-lock window.
+                // `.inactive` immediately raises the privacy shield (see
+                // `AppLock.sceneDidBecomeInactive`) so app-switcher/control-
+                // center snapshots never expose content, but deliberately
+                // does NOT count toward the 60s re-lock window or the
+                // auto-prompt cycle — LocalAuthentication's own prompt (and
+                // the app switcher/control center) can bounce the scene
+                // through `.inactive` without a genuine background stint,
+                // which must never force re-authentication on a quick return.
                 .onChange(of: scenePhase) { _, phase in
                     switch phase {
                     case .background: appLock.sceneDidEnterBackground()
                     case .active: appLock.sceneDidBecomeActive()
-                    case .inactive: break
+                    case .inactive: appLock.sceneDidBecomeInactive()
                     @unknown default: break
                     }
                 }

--- a/apps/ios/CovenCave/CovenCave/Info.plist
+++ b/apps/ios/CovenCave/CovenCave/Info.plist
@@ -52,6 +52,8 @@
 	<string>Coven Cave uses the microphone so you can dictate messages to your familiars.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>Coven Cave transcribes your speech into the message field when you dictate.</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Coven Cave uses Face ID to unlock the app and to confirm changes to your desktop connection.</string>
 	<key>NSBonjourServices</key>
 	<array>
 		<string>_tailscale._tcp</string>

--- a/apps/ios/CovenCave/CovenCave/Intents/CaveAppIntents.swift
+++ b/apps/ios/CovenCave/CovenCave/Intents/CaveAppIntents.swift
@@ -2,10 +2,11 @@ import AppIntents
 import Foundation
 
 /// Create a reminder by voice / Spotlight / Shortcuts — e.g. "New Coven reminder".
-/// Runs without opening the app: it reads the saved connection and POSTs directly.
+/// Requires local device authentication, then uses the saved connection directly.
 struct NewReminderIntent: AppIntent {
     static var title: LocalizedStringResource = "New Reminder"
     static var description = IntentDescription("Create a reminder in Coven Cave.")
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @Parameter(title: "Reminder", requestValueDialog: "What's the reminder?")
     var text: String
@@ -34,10 +35,11 @@ struct NewReminderIntent: AppIntent {
     }
 }
 
-/// Ask what's running — e.g. "What's running in Coven Cave". Read-only summary.
+/// Authenticated task summary — e.g. "What's running in Coven Cave".
 struct RunningTasksIntent: AppIntent {
     static var title: LocalizedStringResource = "Running Tasks"
     static var description = IntentDescription("Summarize the tasks currently running.")
+    static var authenticationPolicy: IntentAuthenticationPolicy = .requiresLocalDeviceAuthentication
 
     @MainActor
     func perform() async throws -> some IntentResult & ProvidesDialog {

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -26,11 +26,11 @@ enum AppLockPolicy {
     }
 }
 
-enum ApprovalRequestOutcome: Equatable {
-    case approved
+enum AuthenticationOutcome: Equatable {
+    case authorized
     case denied
-    case unavailable
     case busy
+    case unavailable
 }
 
 /// Pure decision logic for whether the lock screen should fire an automatic
@@ -135,18 +135,10 @@ final class AppLock {
     var biometricLabel: String { biometricKind.label }
     var biometricSystemImage: String { biometricKind.systemImage }
 
-    /// Whether a fresh authentication attempt may begin right now. `unlock`,
-    /// `requestApprovalOutcome`, `setLockEnabled`, and `setApprovalEnabled`
-    /// already no-op (returning `false`/`.busy`) when `isAuthenticating` is
-    /// `true`, but that `Bool`/no-prompt result is indistinguishable from a
-    /// real failure/cancellation to a caller that already committed to
-    /// showing a failure alert. Callers (Settings toggles, Connection's
-    /// direct save/disconnect/re-pair routes) should check this
-    /// synchronously — both to drive `.disabled` and to guard their action
-    /// handlers *before* spawning a `Task`, so a same-runloop double tap
-    /// can't race SwiftUI's disabled-state propagation into a second,
-    /// falsely-reported "authentication failed" alert when no second prompt
-    /// was ever attempted.
+    /// Whether a fresh authentication attempt may begin right now. Callers may
+    /// use this to disable controls synchronously, but correctness still comes
+    /// from the explicit `.busy` outcome returned by every authentication-gated
+    /// operation.
     var canBeginAuthentication: Bool { !isAuthenticating }
 
     // MARK: - Scene lifecycle
@@ -166,11 +158,16 @@ final class AppLock {
     /// Call when the scene reaches `.background`. Always ensures the privacy
     /// shield is up (belt-and-suspenders alongside `.inactive`, and the only
     /// shield trigger when a scene backgrounds without an observed
-    /// `.inactive` first), but only starts the re-lock clock when locking is
-    /// actually enabled.
+    /// `.inactive` first). A persisted lock request owns one continuous
+    /// background instant even while device authentication is temporarily
+    /// unavailable.
     func sceneDidEnterBackground() {
         isPrivacyShielded = true
-        guard lockEnabled else { return }
+        guard defaults.bool(forKey: Self.lockEnabledKey) else {
+            backgroundedAt = nil
+            return
+        }
+        guard backgroundedAt == nil else { return }
         backgroundedAt = continuousNow()
     }
 
@@ -184,15 +181,17 @@ final class AppLock {
     /// The privacy shield is cleared last, once the correct `isLocked` state
     /// is settled.
     func sceneDidBecomeActive() {
-        defer {
-            backgroundedAt = nil
-            isPrivacyShielded = false
-        }
+        defer { isPrivacyShielded = false }
         refreshAvailability()
-        guard lockEnabled else { return }
+        guard defaults.bool(forKey: Self.lockEnabledKey) else {
+            backgroundedAt = nil
+            return
+        }
+        guard canUseDeviceAuthentication else { return }
         let duration = backgroundedAt.map { start in
             start.duration(to: continuousNow())
         }
+        backgroundedAt = nil
         let wasLocked = isLocked
         if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
             isLocked = true
@@ -254,21 +253,15 @@ final class AppLock {
     /// Fresh authentication gate for approval-scoped actions (paired-desktop
     /// credential changes). Passes through immediately when approvals are
     /// disabled — never touches the authenticator in that case.
-    func requestApproval(reason: String) async -> Bool {
-        await requestApprovalOutcome(reason: reason) == .approved
-    }
-
-    /// Detailed approval result for callers that must distinguish a real
-    /// denial/cancellation from a request that never started.
-    func requestApprovalOutcome(reason: String) async -> ApprovalRequestOutcome {
-        guard approvalEnabled else { return .approved }
+    func requestApproval(reason: String) async -> AuthenticationOutcome {
+        guard !isAuthenticating else { return .busy }
+        guard approvalEnabled else { return .authorized }
         refreshAvailability()
         guard canUseDeviceAuthentication else { return .unavailable }
-        guard !isAuthenticating else { return .busy }
         isAuthenticating = true
         let success = await authenticator.authenticate(reason: reason)
         isAuthenticating = false
-        return success ? .approved : .denied
+        return success ? .authorized : .denied
     }
 
     /// Gates an arbitrary async action behind `requestApproval`, running it
@@ -276,13 +269,16 @@ final class AppLock {
     /// succeeded). Centralizes the "authenticate, then act, else leave
     /// everything alone" pattern so callers like Settings' credential-
     /// affecting operations (host change, disconnect) don't duplicate the
-    /// guard/return dance — they just branch on the returned `Bool` to show
-    /// their own failure alert.
+    /// guard/return dance.
     @discardableResult
-    func performApprovedAction(reason: String, action: () async -> Void) async -> Bool {
-        guard await requestApproval(reason: reason) else { return false }
+    func performApprovedAction(
+        reason: String,
+        action: () async -> Void
+    ) async -> AuthenticationOutcome {
+        let outcome = await requestApproval(reason: reason)
+        guard outcome == .authorized else { return outcome }
         await action()
-        return true
+        return .authorized
     }
 
     // MARK: - Settings toggles
@@ -291,41 +287,46 @@ final class AppLock {
     /// requires a successful fresh authentication first; on failure/cancel
     /// the preference is left completely unchanged.
     @discardableResult
-    func setLockEnabled(_ enabled: Bool) async -> Bool {
-        guard canUseDeviceAuthentication else { return false }
-        guard enabled != lockEnabled else { return true }
-        guard !isAuthenticating else { return false }
+    func setLockEnabled(_ enabled: Bool) async -> AuthenticationOutcome {
+        guard !isAuthenticating else { return .busy }
+        guard enabled != defaults.bool(forKey: Self.lockEnabledKey) else { return .authorized }
+        refreshAvailability()
+        guard canUseDeviceAuthentication else { return .unavailable }
         isAuthenticating = true
         let reason = enabled
             ? "Enable \(biometricLabel) to unlock Coven Cave"
             : "Disable \(biometricLabel) unlock"
         let success = await authenticator.authenticate(reason: reason)
         isAuthenticating = false
-        guard success else { return false }
+        guard success else { return .denied }
 
         lockEnabled = enabled
         defaults.set(enabled, forKey: Self.lockEnabledKey)
-        if !enabled { isLocked = false }
-        return true
+        if !enabled {
+            isLocked = false
+            backgroundedAt = nil
+        }
+        return .authorized
     }
 
     /// Enables/disables "require biometrics for approvals". Same
     /// authenticate-first-then-commit contract as `setLockEnabled`.
     @discardableResult
-    func setApprovalEnabled(_ enabled: Bool) async -> Bool {
-        guard canUseDeviceAuthentication else { return false }
-        guard enabled != approvalEnabled else { return true }
-        guard !isAuthenticating else { return false }
+    func setApprovalEnabled(_ enabled: Bool) async -> AuthenticationOutcome {
+        guard !isAuthenticating else { return .busy }
+        guard enabled != defaults.bool(forKey: Self.approvalEnabledKey) else { return .authorized }
+        refreshAvailability()
+        guard canUseDeviceAuthentication else { return .unavailable }
         isAuthenticating = true
         let reason = enabled
             ? "Enable \(biometricLabel) for approvals"
             : "Disable \(biometricLabel) approvals"
         let success = await authenticator.authenticate(reason: reason)
         isAuthenticating = false
-        guard success else { return false }
+        guard success else { return .denied }
 
         approvalEnabled = enabled
         defaults.set(enabled, forKey: Self.approvalEnabledKey)
-        return true
+        return .authorized
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -58,9 +58,8 @@ struct LockScreenAutoPromptCoordinator {
 /// ("require biometrics to unlock" and "…for approvals") and the transient
 /// `isLocked` state that gates the entire app's content at the root.
 ///
-/// Dependency-injected authenticator, `UserDefaults` suite, and clock keep
-/// this fully unit-testable without touching real biometrics or the wall
-/// clock.
+/// Dependency-injected authenticator, `UserDefaults` suite, and monotonic
+/// clock keep this fully unit-testable without touching real biometrics.
 @Observable
 @MainActor
 final class AppLock {
@@ -93,18 +92,18 @@ final class AppLock {
 
     private let authenticator: BiometricAuthenticating
     private let defaults: UserDefaults
-    private let now: () -> Date
-    private var backgroundedAt: Date?
+    private let monotonicNow: () -> TimeInterval
+    private var backgroundedAt: TimeInterval?
     private var autoPromptCoordinator = LockScreenAutoPromptCoordinator()
 
     init(
         authenticator: BiometricAuthenticating = LAContextBiometricAuthenticator(),
         defaults: UserDefaults = .standard,
-        now: @escaping () -> Date = Date.init
+        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
     ) {
         self.authenticator = authenticator
         self.defaults = defaults
-        self.now = now
+        self.monotonicNow = monotonicNow
 
         let availability = authenticator.availability()
         canUseDeviceAuthentication = availability.canEvaluate
@@ -144,7 +143,7 @@ final class AppLock {
     func sceneDidEnterBackground() {
         isPrivacyShielded = true
         guard lockEnabled else { return }
-        backgroundedAt = now()
+        backgroundedAt = monotonicNow()
     }
 
     /// Call when the scene reaches `.active`. Refreshes live authentication
@@ -163,7 +162,13 @@ final class AppLock {
         }
         refreshAvailability()
         guard lockEnabled else { return }
-        let duration = backgroundedAt.map { now().timeIntervalSince($0) }
+        let duration = backgroundedAt.map { start in
+            let end = monotonicNow()
+            guard start.isFinite, end.isFinite, end >= start else {
+                return AppLockPolicy.graceInterval
+            }
+            return end - start
+        }
         let wasLocked = isLocked
         if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
             isLocked = true

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -25,6 +25,35 @@ enum AppLockPolicy {
     }
 }
 
+/// Pure decision logic for whether the lock screen should fire an automatic
+/// authentication attempt on scene activation. Extracted from
+/// `LockScreenView` so the de-duplication rule is unit-testable without
+/// SwiftUI: a genuine lock presentation gets exactly one automatic prompt,
+/// and the `.inactive -> .active` bounce that presenting the
+/// LocalAuthentication sheet itself causes must never be mistaken for a
+/// second, fresh presentation.
+struct LockScreenAutoPromptCoordinator {
+    private var hasPromptedForCurrentPresentation = false
+
+    /// Call whenever a new genuine lock presentation begins (cold start
+    /// locked, or a real re-lock decision on `.active`) so the next
+    /// activation prompts again exactly once.
+    mutating func presentationBegan() {
+        hasPromptedForCurrentPresentation = false
+    }
+
+    /// Call on every scene activation while (potentially) locked. Returns
+    /// whether this activation should trigger an automatic authentication
+    /// attempt; consumes the "may auto-prompt" state for the current
+    /// presentation so repeat activations (including the bounce the prompt
+    /// itself causes) don't re-fire until `presentationBegan()` runs again.
+    mutating func shouldAutoPrompt(isLocked: Bool) -> Bool {
+        guard isLocked, !hasPromptedForCurrentPresentation else { return false }
+        hasPromptedForCurrentPresentation = true
+        return true
+    }
+}
+
 /// App-wide lock/approval controller. Owns two persisted preferences
 /// ("require biometrics to unlock" and "…for approvals") and the transient
 /// `isLocked` state that gates the entire app's content at the root.
@@ -58,6 +87,7 @@ final class AppLock {
     private let defaults: UserDefaults
     private let now: () -> Date
     private var backgroundedAt: Date?
+    private var autoPromptCoordinator = LockScreenAutoPromptCoordinator()
 
     init(
         authenticator: BiometricAuthenticating = LAContextBiometricAuthenticator(),
@@ -78,6 +108,7 @@ final class AppLock {
         lockEnabled = startLockEnabled
         approvalEnabled = availability.canEvaluate && defaults.bool(forKey: Self.approvalEnabledKey)
         isLocked = startLockEnabled
+        if startLockEnabled { autoPromptCoordinator.presentationBegan() }
     }
 
     var biometricLabel: String { biometricKind.label }
@@ -101,8 +132,14 @@ final class AppLock {
         defer { backgroundedAt = nil }
         guard lockEnabled else { return }
         let duration = backgroundedAt.map { now().timeIntervalSince($0) }
+        let wasLocked = isLocked
         if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
             isLocked = true
+            // Only a fresh false -> true transition is a new genuine lock
+            // presentation; re-affirming an already-locked state (the
+            // `alreadyLocked` branch above) must not grant another
+            // automatic prompt — the retry button stays the only retry.
+            if !wasLocked { autoPromptCoordinator.presentationBegan() }
         }
     }
 
@@ -120,6 +157,19 @@ final class AppLock {
         isAuthenticating = false
         if success { isLocked = false }
         return success
+    }
+
+    /// Called by `LockScreenView` on every scene activation. Fires at most
+    /// one automatic authentication attempt per genuine lock presentation:
+    /// the `.inactive -> .active` bounce a cancelled/failed LocalAuthentication
+    /// sheet itself causes is deliberately *not* treated as a new
+    /// presentation, so it never re-triggers a prompt — the explicit retry
+    /// button remains the only way to retry until the next genuine lock
+    /// cycle begins.
+    @discardableResult
+    func autoPromptOnActive() async -> Bool {
+        guard autoPromptCoordinator.shouldAutoPrompt(isLocked: isLocked) else { return false }
+        return await unlock()
     }
 
     // MARK: - Approval (credential-affecting actions)

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -6,7 +6,7 @@ import Observation
 enum AppLockPolicy {
     /// Quick app switches under this stay unlocked; anything at or beyond it
     /// re-locks on return to the foreground.
-    static let graceInterval: TimeInterval = 60
+    static let graceDuration: Duration = .seconds(60)
 
     /// Whether returning to the foreground should (re)lock the app.
     /// - Parameters:
@@ -14,15 +14,23 @@ enum AppLockPolicy {
     ///   - alreadyLocked: Whether the app is currently locked (e.g. cold start,
     ///     or a previous background stint already locked it and unlock hasn't
     ///     happened since).
-    ///   - backgroundDuration: Seconds spent backgrounded before returning, or
+    ///   - backgroundDuration: Time spent backgrounded before returning, or
     ///     `nil` if the app never left the foreground (only `.inactive`, which
     ///     callers must not report here — see `AppLock.sceneDidEnterBackground`).
-    static func shouldLock(enabled: Bool, alreadyLocked: Bool, backgroundDuration: TimeInterval?) -> Bool {
+    static func shouldLock(enabled: Bool, alreadyLocked: Bool, backgroundDuration: Duration?) -> Bool {
         guard enabled else { return false }
         if alreadyLocked { return true }
         guard let backgroundDuration else { return false }
-        return backgroundDuration >= graceInterval
+        guard backgroundDuration >= .zero else { return true }
+        return backgroundDuration >= graceDuration
     }
+}
+
+enum ApprovalRequestOutcome: Equatable {
+    case approved
+    case denied
+    case unavailable
+    case busy
 }
 
 /// Pure decision logic for whether the lock screen should fire an automatic
@@ -58,7 +66,7 @@ struct LockScreenAutoPromptCoordinator {
 /// ("require biometrics to unlock" and "…for approvals") and the transient
 /// `isLocked` state that gates the entire app's content at the root.
 ///
-/// Dependency-injected authenticator, `UserDefaults` suite, and monotonic
+/// Dependency-injected authenticator, `UserDefaults` suite, and continuous
 /// clock keep this fully unit-testable without touching real biometrics.
 @Observable
 @MainActor
@@ -78,7 +86,12 @@ final class AppLock {
     /// 60-second re-lock clock — a quick inactive/active blip must not
     /// destroy navigation state by unmounting the root.
     private(set) var isPrivacyShielded = false
+    /// Effective unlock preference. This is forced off while device-owner
+    /// authentication is unavailable so the user cannot be stranded.
     private(set) var lockEnabled: Bool
+    /// The user's persisted approval preference. Unlike `lockEnabled`, this
+    /// remains logically enabled while authentication is unavailable so
+    /// protected actions fail closed instead of silently passing through.
     private(set) var approvalEnabled: Bool
     private(set) var biometricKind: BiometricKind
     /// Whether `.deviceOwnerAuthentication` (biometric or device passcode) is
@@ -92,28 +105,29 @@ final class AppLock {
 
     private let authenticator: BiometricAuthenticating
     private let defaults: UserDefaults
-    private let monotonicNow: () -> TimeInterval
-    private var backgroundedAt: TimeInterval?
+    private let continuousNow: () -> ContinuousClock.Instant
+    private var backgroundedAt: ContinuousClock.Instant?
     private var autoPromptCoordinator = LockScreenAutoPromptCoordinator()
 
     init(
         authenticator: BiometricAuthenticating = LAContextBiometricAuthenticator(),
         defaults: UserDefaults = .standard,
-        monotonicNow: @escaping () -> TimeInterval = { ProcessInfo.processInfo.systemUptime }
+        continuousNow: @escaping () -> ContinuousClock.Instant = { ContinuousClock().now }
     ) {
         self.authenticator = authenticator
         self.defaults = defaults
-        self.monotonicNow = monotonicNow
+        self.continuousNow = continuousNow
 
         let availability = authenticator.availability()
         canUseDeviceAuthentication = availability.canEvaluate
         biometricKind = availability.kind
 
-        // Preferences are meaningless (and must not silently lock the user
-        // out) if device-owner authentication isn't available at all.
+        // Unlock is an effective preference because an unavailable
+        // authenticator must never strand the user. Approval remains the
+        // persisted logical preference so protected actions fail closed.
         let startLockEnabled = availability.canEvaluate && defaults.bool(forKey: Self.lockEnabledKey)
         lockEnabled = startLockEnabled
-        approvalEnabled = availability.canEvaluate && defaults.bool(forKey: Self.approvalEnabledKey)
+        approvalEnabled = defaults.bool(forKey: Self.approvalEnabledKey)
         isLocked = startLockEnabled
         if startLockEnabled { autoPromptCoordinator.presentationBegan() }
     }
@@ -143,7 +157,7 @@ final class AppLock {
     func sceneDidEnterBackground() {
         isPrivacyShielded = true
         guard lockEnabled else { return }
-        backgroundedAt = monotonicNow()
+        backgroundedAt = continuousNow()
     }
 
     /// Call when the scene reaches `.active`. Refreshes live authentication
@@ -163,11 +177,7 @@ final class AppLock {
         refreshAvailability()
         guard lockEnabled else { return }
         let duration = backgroundedAt.map { start in
-            let end = monotonicNow()
-            guard start.isFinite, end.isFinite, end >= start else {
-                return AppLockPolicy.graceInterval
-            }
-            return end - start
+            start.duration(to: continuousNow())
         }
         let wasLocked = isLocked
         if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
@@ -181,20 +191,16 @@ final class AppLock {
     }
 
     /// Re-checks `.deviceOwnerAuthentication` availability/kind and
-    /// reconciles the effective `lockEnabled`/`approvalEnabled` against the
-    /// *persisted* preferences so the UI stays truthful without losing the
-    /// user's actual choice. When device-owner authentication is
-    /// unavailable, effective toggles go false and any lock is cleared so
-    /// the user is never stranded with no way to authenticate; the
-    /// persisted preferences themselves are left untouched so they restore
-    /// automatically once availability returns.
+    /// reconciles effective `lockEnabled` against its persisted preference.
+    /// `approvalEnabled` remains the persisted logical choice even while
+    /// authentication is unavailable, causing protected actions to fail
+    /// closed. Any actual app lock is cleared so the user is never stranded.
     private func refreshAvailability() {
         let availability = authenticator.availability()
         canUseDeviceAuthentication = availability.canEvaluate
         biometricKind = availability.kind
 
         lockEnabled = canUseDeviceAuthentication && defaults.bool(forKey: Self.lockEnabledKey)
-        approvalEnabled = canUseDeviceAuthentication && defaults.bool(forKey: Self.approvalEnabledKey)
         if !canUseDeviceAuthentication {
             isLocked = false
         }
@@ -235,12 +241,20 @@ final class AppLock {
     /// credential changes). Passes through immediately when approvals are
     /// disabled — never touches the authenticator in that case.
     func requestApproval(reason: String) async -> Bool {
-        guard approvalEnabled else { return true }
-        guard !isAuthenticating else { return false }
+        await requestApprovalOutcome(reason: reason) == .approved
+    }
+
+    /// Detailed approval result for callers that must distinguish a real
+    /// denial/cancellation from a request that never started.
+    func requestApprovalOutcome(reason: String) async -> ApprovalRequestOutcome {
+        guard approvalEnabled else { return .approved }
+        refreshAvailability()
+        guard canUseDeviceAuthentication else { return .unavailable }
+        guard !isAuthenticating else { return .busy }
         isAuthenticating = true
         let success = await authenticator.authenticate(reason: reason)
         isAuthenticating = false
-        return success
+        return success ? .approved : .denied
     }
 
     /// Gates an arbitrary async action behind `requestApproval`, running it

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -71,6 +71,14 @@ final class AppLock {
     /// content. Never a translucent overlay — the caller (`CovenCaveApp`)
     /// substitutes this for the entire window content while `true`.
     private(set) var isLocked: Bool
+    /// Opaque privacy shield, independent of `isLocked`. Raised immediately on
+    /// `.inactive`/`.background` (app switcher, control center, an incoming
+    /// call, or a bounced LocalAuthentication sheet) so a snapshot never
+    /// exposes content, and cleared on a genuine `.active`. Unlike
+    /// `isLocked`, this never gates authentication and never affects the
+    /// 60-second re-lock clock — a quick inactive/active blip must not
+    /// destroy navigation state by unmounting the root.
+    private(set) var isPrivacyShielded = false
     private(set) var lockEnabled: Bool
     private(set) var approvalEnabled: Bool
     private(set) var biometricKind: BiometricKind
@@ -116,20 +124,44 @@ final class AppLock {
 
     // MARK: - Scene lifecycle
 
-    /// Call when the scene reaches `.background` — never for `.inactive`,
-    /// which LocalAuthentication prompts (and the app switcher/control
-    /// center) can trigger spuriously without the app actually backgrounding.
+    /// Call when the scene reaches `.inactive` (app switcher, control
+    /// center, an incoming call banner, or the `.inactive -> .active` bounce
+    /// a LocalAuthentication sheet itself causes). Immediately raises the
+    /// privacy shield so no content is visible in a snapshot, but —
+    /// deliberately unlike `.background` — never touches `isLocked`, never
+    /// starts/extends the 60s background clock, and never refreshes
+    /// availability or consumes an auto-prompt slot: a quick inactive/active
+    /// blip must not force re-authentication or restart the grace window.
+    func sceneDidBecomeInactive() {
+        isPrivacyShielded = true
+    }
+
+    /// Call when the scene reaches `.background`. Always ensures the privacy
+    /// shield is up (belt-and-suspenders alongside `.inactive`, and the only
+    /// shield trigger when a scene backgrounds without an observed
+    /// `.inactive` first), but only starts the re-lock clock when locking is
+    /// actually enabled.
     func sceneDidEnterBackground() {
+        isPrivacyShielded = true
         guard lockEnabled else { return }
         backgroundedAt = now()
     }
 
-    /// Call when the scene reaches `.active`. Re-locks only if a genuine
-    /// background stint (not a bare `.inactive` blip) reached the grace
-    /// window, or if the app was already locked (cold start / prior
-    /// re-lock not yet cleared by a successful unlock).
+    /// Call when the scene reaches `.active`. Refreshes live authentication
+    /// availability/kind first (enrollment or passcode can change while
+    /// backgrounded), reconciles the effective lock/approval preferences
+    /// against that availability, then runs the existing re-lock decision —
+    /// re-locking only if a genuine background stint (not a bare `.inactive`
+    /// blip) reached the grace window, or if the app was already locked
+    /// (cold start / prior re-lock not yet cleared by a successful unlock).
+    /// The privacy shield is cleared last, once the correct `isLocked` state
+    /// is settled.
     func sceneDidBecomeActive() {
-        defer { backgroundedAt = nil }
+        defer {
+            backgroundedAt = nil
+            isPrivacyShielded = false
+        }
+        refreshAvailability()
         guard lockEnabled else { return }
         let duration = backgroundedAt.map { now().timeIntervalSince($0) }
         let wasLocked = isLocked
@@ -140,6 +172,26 @@ final class AppLock {
             // `alreadyLocked` branch above) must not grant another
             // automatic prompt — the retry button stays the only retry.
             if !wasLocked { autoPromptCoordinator.presentationBegan() }
+        }
+    }
+
+    /// Re-checks `.deviceOwnerAuthentication` availability/kind and
+    /// reconciles the effective `lockEnabled`/`approvalEnabled` against the
+    /// *persisted* preferences so the UI stays truthful without losing the
+    /// user's actual choice. When device-owner authentication is
+    /// unavailable, effective toggles go false and any lock is cleared so
+    /// the user is never stranded with no way to authenticate; the
+    /// persisted preferences themselves are left untouched so they restore
+    /// automatically once availability returns.
+    private func refreshAvailability() {
+        let availability = authenticator.availability()
+        canUseDeviceAuthentication = availability.canEvaluate
+        biometricKind = availability.kind
+
+        lockEnabled = canUseDeviceAuthentication && defaults.bool(forKey: Self.lockEnabledKey)
+        approvalEnabled = canUseDeviceAuthentication && defaults.bool(forKey: Self.approvalEnabledKey)
+        if !canUseDeviceAuthentication {
+            isLocked = false
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -186,6 +186,20 @@ final class AppLock {
         return success
     }
 
+    /// Gates an arbitrary async action behind `requestApproval`, running it
+    /// only when approved (approvals disabled, or a fresh authentication
+    /// succeeded). Centralizes the "authenticate, then act, else leave
+    /// everything alone" pattern so callers like Settings' credential-
+    /// affecting operations (host change, disconnect) don't duplicate the
+    /// guard/return dance — they just branch on the returned `Bool` to show
+    /// their own failure alert.
+    @discardableResult
+    func performApprovedAction(reason: String, action: () async -> Void) async -> Bool {
+        guard await requestApproval(reason: reason) else { return false }
+        await action()
+        return true
+    }
+
     // MARK: - Settings toggles
 
     /// Enables/disables "require biometrics to unlock". Either direction

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -251,8 +251,9 @@ final class AppLock {
     // MARK: - Approval (credential-affecting actions)
 
     /// Fresh authentication gate for approval-scoped actions (paired-desktop
-    /// credential changes). Passes through immediately when approvals are
-    /// disabled — never touches the authenticator in that case.
+    /// credential changes). A concurrent authentication always returns
+    /// `.busy`; otherwise, disabled approvals pass through without touching
+    /// the authenticator.
     func requestApproval(reason: String) async -> AuthenticationOutcome {
         guard !isAuthenticating else { return .busy }
         guard approvalEnabled else { return .authorized }

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -14,15 +14,14 @@ enum AppLockPolicy {
     ///   - alreadyLocked: Whether the app is currently locked (e.g. cold start,
     ///     or a previous background stint already locked it and unlock hasn't
     ///     happened since).
-    ///   - backgroundDuration: Time spent backgrounded before returning, or
-    ///     `nil` if the app never left the foreground (only `.inactive`, which
-    ///     callers must not report here — see `AppLock.sceneDidEnterBackground`).
-    static func shouldLock(enabled: Bool, alreadyLocked: Bool, backgroundDuration: Duration?) -> Bool {
+    ///   - awayDuration: Time spent inactive or backgrounded before returning,
+    ///     or `nil` if the app never left the foreground.
+    static func shouldLock(enabled: Bool, alreadyLocked: Bool, awayDuration: Duration?) -> Bool {
         guard enabled else { return false }
         if alreadyLocked { return true }
-        guard let backgroundDuration else { return false }
-        guard backgroundDuration >= .zero else { return true }
-        return backgroundDuration >= graceDuration
+        guard let awayDuration else { return false }
+        guard awayDuration >= .zero else { return true }
+        return awayDuration >= graceDuration
     }
 }
 
@@ -106,7 +105,7 @@ final class AppLock {
     private let authenticator: BiometricAuthenticating
     private let defaults: UserDefaults
     private let continuousNow: () -> ContinuousClock.Instant
-    private var backgroundedAt: ContinuousClock.Instant?
+    private var becameInactiveAt: ContinuousClock.Instant?
     private var autoPromptCoordinator = LockScreenAutoPromptCoordinator()
 
     init(
@@ -146,13 +145,18 @@ final class AppLock {
     /// Call when the scene reaches `.inactive` (app switcher, control
     /// center, an incoming call banner, or the `.inactive -> .active` bounce
     /// a LocalAuthentication sheet itself causes). Immediately raises the
-    /// privacy shield so no content is visible in a snapshot, but —
-    /// deliberately unlike `.background` — never touches `isLocked`, never
-    /// starts/extends the 60s background clock, and never refreshes
-    /// availability or consumes an auto-prompt slot: a quick inactive/active
-    /// blip must not force re-authentication or restart the grace window.
+    /// privacy shield so no content is visible in a snapshot. Starts the
+    /// 60-second away clock unless a LocalAuthentication prompt is already in
+    /// flight; a quick inactive/active blip remains under the grace window,
+    /// while the prompt's own lifecycle bounce must not count as time away.
     func sceneDidBecomeInactive() {
         isPrivacyShielded = true
+        guard defaults.bool(forKey: Self.lockEnabledKey) else {
+            becameInactiveAt = nil
+            return
+        }
+        guard !isAuthenticating, becameInactiveAt == nil else { return }
+        becameInactiveAt = continuousNow()
     }
 
     /// Call when the scene reaches `.background`. Always ensures the privacy
@@ -164,36 +168,36 @@ final class AppLock {
     func sceneDidEnterBackground() {
         isPrivacyShielded = true
         guard defaults.bool(forKey: Self.lockEnabledKey) else {
-            backgroundedAt = nil
+            becameInactiveAt = nil
             return
         }
-        guard backgroundedAt == nil else { return }
-        backgroundedAt = continuousNow()
+        guard becameInactiveAt == nil else { return }
+        becameInactiveAt = continuousNow()
     }
 
     /// Call when the scene reaches `.active`. Refreshes live authentication
     /// availability/kind first (enrollment or passcode can change while
     /// backgrounded), reconciles the effective lock/approval preferences
     /// against that availability, then runs the existing re-lock decision —
-    /// re-locking only if a genuine background stint (not a bare `.inactive`
-    /// blip) reached the grace window, or if the app was already locked
-    /// (cold start / prior re-lock not yet cleared by a successful unlock).
+    /// re-locking only if an inactive/background stint reached the grace
+    /// window, or if the app was already locked (cold start / prior re-lock
+    /// not yet cleared by a successful unlock).
     /// The privacy shield is cleared last, once the correct `isLocked` state
     /// is settled.
     func sceneDidBecomeActive() {
         defer { isPrivacyShielded = false }
         refreshAvailability()
         guard defaults.bool(forKey: Self.lockEnabledKey) else {
-            backgroundedAt = nil
+            becameInactiveAt = nil
             return
         }
         guard canUseDeviceAuthentication else { return }
-        let duration = backgroundedAt.map { start in
+        let duration = becameInactiveAt.map { start in
             start.duration(to: continuousNow())
         }
-        backgroundedAt = nil
+        becameInactiveAt = nil
         let wasLocked = isLocked
-        if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
+        if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, awayDuration: duration) {
             isLocked = true
             // Only a fresh false -> true transition is a new genuine lock
             // presentation; re-affirming an already-locked state (the
@@ -305,7 +309,7 @@ final class AppLock {
         defaults.set(enabled, forKey: Self.lockEnabledKey)
         if !enabled {
             isLocked = false
-            backgroundedAt = nil
+            becameInactiveAt = nil
         }
         return .authorized
     }

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -135,6 +135,20 @@ final class AppLock {
     var biometricLabel: String { biometricKind.label }
     var biometricSystemImage: String { biometricKind.systemImage }
 
+    /// Whether a fresh authentication attempt may begin right now. `unlock`,
+    /// `requestApprovalOutcome`, `setLockEnabled`, and `setApprovalEnabled`
+    /// already no-op (returning `false`/`.busy`) when `isAuthenticating` is
+    /// `true`, but that `Bool`/no-prompt result is indistinguishable from a
+    /// real failure/cancellation to a caller that already committed to
+    /// showing a failure alert. Callers (Settings toggles, Connection's
+    /// direct save/disconnect/re-pair routes) should check this
+    /// synchronously — both to drive `.disabled` and to guard their action
+    /// handlers *before* spawning a `Task`, so a same-runloop double tap
+    /// can't race SwiftUI's disabled-state propagation into a second,
+    /// falsely-reported "authentication failed" alert when no second prompt
+    /// was ever attempted.
+    var canBeginAuthentication: Bool { !isAuthenticating }
+
     // MARK: - Scene lifecycle
 
     /// Call when the scene reaches `.inactive` (app switcher, control

--- a/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/AppLock.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Observation
+
+/// Pure, dependency-free lock/re-lock decision so the 60-second grace window
+/// is trivially testable without spinning up a whole `AppLock`.
+enum AppLockPolicy {
+    /// Quick app switches under this stay unlocked; anything at or beyond it
+    /// re-locks on return to the foreground.
+    static let graceInterval: TimeInterval = 60
+
+    /// Whether returning to the foreground should (re)lock the app.
+    /// - Parameters:
+    ///   - enabled: Whether the "require biometrics to unlock" preference is on.
+    ///   - alreadyLocked: Whether the app is currently locked (e.g. cold start,
+    ///     or a previous background stint already locked it and unlock hasn't
+    ///     happened since).
+    ///   - backgroundDuration: Seconds spent backgrounded before returning, or
+    ///     `nil` if the app never left the foreground (only `.inactive`, which
+    ///     callers must not report here — see `AppLock.sceneDidEnterBackground`).
+    static func shouldLock(enabled: Bool, alreadyLocked: Bool, backgroundDuration: TimeInterval?) -> Bool {
+        guard enabled else { return false }
+        if alreadyLocked { return true }
+        guard let backgroundDuration else { return false }
+        return backgroundDuration >= graceInterval
+    }
+}
+
+/// App-wide lock/approval controller. Owns two persisted preferences
+/// ("require biometrics to unlock" and "…for approvals") and the transient
+/// `isLocked` state that gates the entire app's content at the root.
+///
+/// Dependency-injected authenticator, `UserDefaults` suite, and clock keep
+/// this fully unit-testable without touching real biometrics or the wall
+/// clock.
+@Observable
+@MainActor
+final class AppLock {
+    static let lockEnabledKey = "cave.security.lockEnabled"
+    static let approvalEnabledKey = "cave.security.approvalEnabled"
+
+    /// Whether the app root should show the full-screen lock instead of app
+    /// content. Never a translucent overlay — the caller (`CovenCaveApp`)
+    /// substitutes this for the entire window content while `true`.
+    private(set) var isLocked: Bool
+    private(set) var lockEnabled: Bool
+    private(set) var approvalEnabled: Bool
+    private(set) var biometricKind: BiometricKind
+    /// Whether `.deviceOwnerAuthentication` (biometric or device passcode) is
+    /// possible at all on this device. Both toggles are disabled in Settings
+    /// when this is `false`.
+    private(set) var canUseDeviceAuthentication: Bool
+    /// Guards against stacked/duplicate LocalAuthentication prompts from
+    /// overlapping calls (e.g. the lock screen's auto-prompt racing a manual
+    /// retry tap).
+    private(set) var isAuthenticating = false
+
+    private let authenticator: BiometricAuthenticating
+    private let defaults: UserDefaults
+    private let now: () -> Date
+    private var backgroundedAt: Date?
+
+    init(
+        authenticator: BiometricAuthenticating = LAContextBiometricAuthenticator(),
+        defaults: UserDefaults = .standard,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.authenticator = authenticator
+        self.defaults = defaults
+        self.now = now
+
+        let availability = authenticator.availability()
+        canUseDeviceAuthentication = availability.canEvaluate
+        biometricKind = availability.kind
+
+        // Preferences are meaningless (and must not silently lock the user
+        // out) if device-owner authentication isn't available at all.
+        let startLockEnabled = availability.canEvaluate && defaults.bool(forKey: Self.lockEnabledKey)
+        lockEnabled = startLockEnabled
+        approvalEnabled = availability.canEvaluate && defaults.bool(forKey: Self.approvalEnabledKey)
+        isLocked = startLockEnabled
+    }
+
+    var biometricLabel: String { biometricKind.label }
+    var biometricSystemImage: String { biometricKind.systemImage }
+
+    // MARK: - Scene lifecycle
+
+    /// Call when the scene reaches `.background` — never for `.inactive`,
+    /// which LocalAuthentication prompts (and the app switcher/control
+    /// center) can trigger spuriously without the app actually backgrounding.
+    func sceneDidEnterBackground() {
+        guard lockEnabled else { return }
+        backgroundedAt = now()
+    }
+
+    /// Call when the scene reaches `.active`. Re-locks only if a genuine
+    /// background stint (not a bare `.inactive` blip) reached the grace
+    /// window, or if the app was already locked (cold start / prior
+    /// re-lock not yet cleared by a successful unlock).
+    func sceneDidBecomeActive() {
+        defer { backgroundedAt = nil }
+        guard lockEnabled else { return }
+        let duration = backgroundedAt.map { now().timeIntervalSince($0) }
+        if AppLockPolicy.shouldLock(enabled: lockEnabled, alreadyLocked: isLocked, backgroundDuration: duration) {
+            isLocked = true
+        }
+    }
+
+    // MARK: - Unlock
+
+    /// Attempts a fresh device-owner authentication to clear the lock.
+    /// No-ops (returns `true`) if not currently locked; returns `false`
+    /// without prompting if a prompt is already in flight.
+    @discardableResult
+    func unlock() async -> Bool {
+        guard isLocked else { return true }
+        guard !isAuthenticating else { return false }
+        isAuthenticating = true
+        let success = await authenticator.authenticate(reason: "Unlock Coven Cave with \(biometricLabel)")
+        isAuthenticating = false
+        if success { isLocked = false }
+        return success
+    }
+
+    // MARK: - Approval (credential-affecting actions)
+
+    /// Fresh authentication gate for approval-scoped actions (paired-desktop
+    /// credential changes). Passes through immediately when approvals are
+    /// disabled — never touches the authenticator in that case.
+    func requestApproval(reason: String) async -> Bool {
+        guard approvalEnabled else { return true }
+        guard !isAuthenticating else { return false }
+        isAuthenticating = true
+        let success = await authenticator.authenticate(reason: reason)
+        isAuthenticating = false
+        return success
+    }
+
+    // MARK: - Settings toggles
+
+    /// Enables/disables "require biometrics to unlock". Either direction
+    /// requires a successful fresh authentication first; on failure/cancel
+    /// the preference is left completely unchanged.
+    @discardableResult
+    func setLockEnabled(_ enabled: Bool) async -> Bool {
+        guard canUseDeviceAuthentication else { return false }
+        guard enabled != lockEnabled else { return true }
+        guard !isAuthenticating else { return false }
+        isAuthenticating = true
+        let reason = enabled
+            ? "Enable \(biometricLabel) to unlock Coven Cave"
+            : "Disable \(biometricLabel) unlock"
+        let success = await authenticator.authenticate(reason: reason)
+        isAuthenticating = false
+        guard success else { return false }
+
+        lockEnabled = enabled
+        defaults.set(enabled, forKey: Self.lockEnabledKey)
+        if !enabled { isLocked = false }
+        return true
+    }
+
+    /// Enables/disables "require biometrics for approvals". Same
+    /// authenticate-first-then-commit contract as `setLockEnabled`.
+    @discardableResult
+    func setApprovalEnabled(_ enabled: Bool) async -> Bool {
+        guard canUseDeviceAuthentication else { return false }
+        guard enabled != approvalEnabled else { return true }
+        guard !isAuthenticating else { return false }
+        isAuthenticating = true
+        let reason = enabled
+            ? "Enable \(biometricLabel) for approvals"
+            : "Disable \(biometricLabel) approvals"
+        let success = await authenticator.authenticate(reason: reason)
+        isAuthenticating = false
+        guard success else { return false }
+
+        approvalEnabled = enabled
+        defaults.set(enabled, forKey: Self.approvalEnabledKey)
+        return true
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Security/BiometricAuth.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/BiometricAuth.swift
@@ -32,6 +32,28 @@ enum BiometricKind: Equatable {
     }
 }
 
+/// Pure classification rule turning hardware/policy facts into a
+/// `BiometricKind`. Extracted from `LAContextBiometricAuthenticator` so it's
+/// testable without a real `LAContext`: `LAContext.biometryType` reflects the
+/// *hardware* present and stays populated even when nothing is
+/// enrolled/available, so it must never be trusted on its own. Only when
+/// `.deviceOwnerAuthenticationWithBiometrics` can currently evaluate (i.e.
+/// biometrics are enrolled and available) does the hardware type become a
+/// trustworthy label; otherwise device-owner auth can still succeed via the
+/// passcode fallback alone, and callers must report that instead of an
+/// incorrect biometric label.
+enum BiometricPolicyClassifier {
+    static func kind(biometryType: LABiometryType, canEvaluateBiometrics: Bool) -> BiometricKind {
+        guard canEvaluateBiometrics else { return .none }
+        switch biometryType {
+        case .faceID: return .faceID
+        case .touchID: return .touchID
+        case .opticID: return .opticID
+        default: return .none
+        }
+    }
+}
+
 /// Abstraction over LocalAuthentication so `AppLock` can be exercised with a
 /// fake in unit tests instead of driving real Face ID/Touch ID prompts.
 protocol BiometricAuthenticating {
@@ -55,7 +77,22 @@ struct LAContextBiometricAuthenticator: BiometricAuthenticating {
         let context = LAContext()
         var error: NSError?
         let canEvaluate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
-        return (canEvaluate, biometricKind(for: context))
+
+        // `.deviceOwnerAuthentication` alone succeeding (or failing) says
+        // nothing about biometrics specifically — device-owner auth can
+        // still succeed via the passcode fallback with biometric hardware
+        // present but nothing enrolled. Check the biometrics-only policy
+        // separately so the label doesn't lie about that.
+        var biometricsError: NSError?
+        let canEvaluateBiometrics = context.canEvaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            error: &biometricsError
+        )
+        let kind = BiometricPolicyClassifier.kind(
+            biometryType: context.biometryType,
+            canEvaluateBiometrics: canEvaluateBiometrics
+        )
+        return (canEvaluate, kind)
     }
 
     func authenticate(reason: String) async -> Bool {
@@ -68,15 +105,6 @@ struct LAContextBiometricAuthenticator: BiometricAuthenticating {
             context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
                 continuation.resume(returning: success)
             }
-        }
-    }
-
-    private func biometricKind(for context: LAContext) -> BiometricKind {
-        switch context.biometryType {
-        case .faceID: return .faceID
-        case .touchID: return .touchID
-        case .opticID: return .opticID
-        default: return .none
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Security/BiometricAuth.swift
+++ b/apps/ios/CovenCave/CovenCave/Security/BiometricAuth.swift
@@ -1,0 +1,82 @@
+import Foundation
+import LocalAuthentication
+
+/// Which biometric method (if any) `.deviceOwnerAuthentication` will present
+/// on this device. `.none` still means device-owner authentication can
+/// succeed via the passcode fallback alone (no enrolled biometry, or none
+/// available) — see `BiometricAuthenticating.availability()`.
+enum BiometricKind: Equatable {
+    case none
+    case touchID
+    case faceID
+    case opticID
+
+    /// Accurate, user-facing label for Settings rows and lock-screen copy.
+    var label: String {
+        switch self {
+        case .none: return "Device Passcode"
+        case .touchID: return "Touch ID"
+        case .faceID: return "Face ID"
+        case .opticID: return "Optic ID"
+        }
+    }
+
+    /// SF Symbol matching the label, for lock screen + Settings iconography.
+    var systemImage: String {
+        switch self {
+        case .none: return "lock.shield"
+        case .touchID: return "touchid"
+        case .faceID: return "faceid"
+        case .opticID: return "opticid"
+        }
+    }
+}
+
+/// Abstraction over LocalAuthentication so `AppLock` can be exercised with a
+/// fake in unit tests instead of driving real Face ID/Touch ID prompts.
+protocol BiometricAuthenticating {
+    /// Whether `.deviceOwnerAuthentication` (biometric + device-passcode
+    /// fallback) is currently possible, and which biometric kind would be
+    /// attempted first.
+    func availability() -> (canEvaluate: Bool, kind: BiometricKind)
+
+    /// Prompts a fresh device-owner authentication (Face ID/Touch ID/Optic ID
+    /// with passcode fallback) with the given reason. Returns whether it
+    /// succeeded.
+    func authenticate(reason: String) async -> Bool
+}
+
+/// Live `LocalAuthentication`-backed adapter. A new `LAContext` is created
+/// per call — LAContext can otherwise silently reuse a very recent successful
+/// evaluation instead of prompting again, which would undermine both the
+/// "fresh authentication" requirement for approvals and testability.
+struct LAContextBiometricAuthenticator: BiometricAuthenticating {
+    func availability() -> (canEvaluate: Bool, kind: BiometricKind) {
+        let context = LAContext()
+        var error: NSError?
+        let canEvaluate = context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error)
+        return (canEvaluate, biometricKind(for: context))
+    }
+
+    func authenticate(reason: String) async -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        guard context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &error) else {
+            return false
+        }
+        return await withCheckedContinuation { continuation in
+            context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: reason) { success, _ in
+                continuation.resume(returning: success)
+            }
+        }
+    }
+
+    private func biometricKind(for context: LAContext) -> BiometricKind {
+        switch context.biometryType {
+        case .faceID: return .faceID
+        case .touchID: return .touchID
+        case .opticID: return .opticID
+        default: return .none
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -12,6 +12,17 @@ extension AppTab {
     static let shortcutOrder: [AppTab] = drawerDestinations
 }
 
+struct PairingIntent: Equatable {
+    var host: String
+    var token: String?
+}
+
+enum PairingApprovalPolicy {
+    static func requiresApproval(hasExistingPairing: Bool) -> Bool {
+        hasExistingPairing
+    }
+}
+
 /// A transient confirmation banner shown over the chat after a command runs.
 struct ToastMessage: Identifiable, Equatable {
     enum Style { case success, info, warning, error }
@@ -683,15 +694,16 @@ final class AppModel {
     enum DeepLink: String { case tasks, reminders }
 
     var deepLink: DeepLink?
+    private(set) var pendingPairingIntent: PairingIntent?
 
     func handleDeepLink(_ url: URL) {
         guard url.scheme == "covencave" else { return }
         // covencave://connect?host=…&token=… — the desktop's pairing invite.
-        // Tapping it (or scanning its QR) configures host + credential in one
-        // step, replacing any previous pairing.
+        // Queue it for the app-level lock/approval processor rather than
+        // mutating credentials beneath a lock or authentication prompt.
         if url.host == "connect" {
             guard let invite = CaveInvite.parse(url.absoluteString) else { return }
-            Task { await configure(host: invite.host, token: invite.token) }
+            pendingPairingIntent = PairingIntent(host: invite.host, token: invite.token)
             return
         }
         // covencave://thread/<id> — a chat notification / Live Activity tap
@@ -705,6 +717,12 @@ final class AppModel {
         guard let target = DeepLink(rawValue: url.host ?? "") else { return }
         selectedTab = .tasks
         deepLink = target
+    }
+
+    func takePendingPairingIntent(isLocked: Bool) -> PairingIntent? {
+        guard !isLocked, let pendingPairingIntent else { return nil }
+        self.pendingPairingIntent = nil
+        return pendingPairingIntent
     }
 
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -13,13 +13,20 @@ extension AppTab {
 }
 
 struct PairingIntent: Equatable {
-    var host: String
-    var token: String?
+    let id = UUID()
+    let host: String
+    let token: String?
 }
 
 enum PairingApprovalPolicy {
     static func requiresApproval(hasExistingPairing: Bool) -> Bool {
         hasExistingPairing
+    }
+}
+
+enum PendingPairingProcessorPolicy {
+    static func mayBegin(isLocked: Bool, isAuthenticating: Bool, isProcessing: Bool) -> Bool {
+        !isLocked && !isAuthenticating && !isProcessing
     }
 }
 
@@ -719,10 +726,11 @@ final class AppModel {
         deepLink = target
     }
 
-    func takePendingPairingIntent(isLocked: Bool) -> PairingIntent? {
-        guard !isLocked, let pendingPairingIntent else { return nil }
+    @discardableResult
+    func consumePendingPairingIntent(matching id: UUID) -> Bool {
+        guard pendingPairingIntent?.id == id else { return false }
         self.pendingPairingIntent = nil
-        return pendingPairingIntent
+        return true
     }
 
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -25,8 +25,13 @@ enum PairingApprovalPolicy {
 }
 
 enum PendingPairingProcessorPolicy {
-    static func mayBegin(isLocked: Bool, isAuthenticating: Bool, isProcessing: Bool) -> Bool {
-        !isLocked && !isAuthenticating && !isProcessing
+    static func mayBegin(
+        isLocked: Bool,
+        isAuthenticating: Bool,
+        isProcessing: Bool,
+        isActive: Bool
+    ) -> Bool {
+        !isLocked && !isAuthenticating && !isProcessing && isActive
     }
 }
 
@@ -728,9 +733,13 @@ final class AppModel {
 
     @discardableResult
     func consumePendingPairingIntent(matching id: UUID) -> Bool {
-        guard pendingPairingIntent?.id == id else { return false }
-        self.pendingPairingIntent = nil
-        return true
+        takePendingPairingIntent(matching: id) != nil
+    }
+
+    func takePendingPairingIntent(matching id: UUID) -> PairingIntent? {
+        guard let intent = pendingPairingIntent, intent.id == id else { return nil }
+        pendingPairingIntent = nil
+        return intent
     }
 
 

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -234,7 +234,7 @@ struct ConnectionView: View {
         .controlSize(.large)
         .tint(.white)
         .foregroundStyle(Color(white: 0.08))
-        .disabled(busy)
+        .disabled(busy || appLock.isAuthenticating)
         .accessibilityHint("Opens the camera to scan the QR code shown in Cave on your desktop")
     }
 
@@ -322,7 +322,7 @@ struct ConnectionView: View {
             }
             .buttonStyle(.borderedProminent)
             .controlSize(.large)
-            .disabled(!hostPresent || busy)
+            .disabled(!hostPresent || busy || appLock.isAuthenticating)
             .shadow(color: chrome.accent.opacity(hostPresent && !busy ? 0.4 : 0), radius: 14, y: 5)
         }
         .padding(16)
@@ -436,6 +436,12 @@ struct ConnectionView: View {
     private func connect() {
         focused = false
         guard let invite = CaveInvite.parse(cleanHost(host)) else { return }
+        // Synchronous guard before spawning the Task: a same-runloop double
+        // tap can otherwise race the `.disabled` modifiers above into a
+        // second call that only fails because a prompt is already in
+        // flight, not because it was actually denied/cancelled — which
+        // would incorrectly show `approvalFailed`.
+        guard appLock.canBeginAuthentication else { return }
         host = invite.host
         busy = true
         liveCheck = .idle
@@ -464,6 +470,9 @@ struct ConnectionView: View {
         guard let invite = CaveInvite.parse(cleanHost(input)) else { return }
         host = invite.host
         if invite.token != nil {
+            // Same synchronous guard as `connect()` — QR scans route here
+            // too, and a busy no-op must not spawn a Task or show an alert.
+            guard appLock.canBeginAuthentication else { return }
             busy = true
             liveCheck = .idle
             Task {

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -9,6 +9,7 @@ import UIKit
 /// re-probe) is preserved; only the hierarchy changed.
 struct ConnectionView: View {
     @Environment(AppModel.self) private var app
+    @Environment(AppLock.self) private var appLock
     @Environment(\.chrome) private var chrome
     @Environment(\.scenePhase) private var scenePhase
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -27,6 +28,7 @@ struct ConnectionView: View {
     /// advisory: never auto-connects, never persists — Connect stays the
     /// explicit action.
     @State private var liveCheck: LiveCheckState = .idle
+    @State private var approvalFailed = false
     @FocusState private var focused: Bool
 
     enum LiveCheckState: Equatable {
@@ -126,6 +128,11 @@ struct ConnectionView: View {
                     guard !busy, case .unreachable = app.connectionState else { continue }
                     await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
                 }
+            }
+            .alert("Couldn't confirm it's you", isPresented: $approvalFailed) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Authentication failed or was cancelled, so your desktop pairing was not changed.")
             }
         }
     }
@@ -433,9 +440,13 @@ struct ConnectionView: View {
         busy = true
         liveCheck = .idle
         Task {
-            await app.configure(host: invite.host, token: invite.token)
+            let approved = await configurePairing(invite)
             busy = false
-            if app.connectionState == .connected { Haptics.success() }
+            if !approved {
+                approvalFailed = true
+            } else if app.connectionState == .connected {
+                Haptics.success()
+            }
         }
     }
 
@@ -456,13 +467,29 @@ struct ConnectionView: View {
             busy = true
             liveCheck = .idle
             Task {
-                await app.configure(host: invite.host, token: invite.token)
+                let approved = await configurePairing(invite)
                 busy = false
-                if app.connectionState == .connected { Haptics.success() }
+                if !approved {
+                    approvalFailed = true
+                } else if app.connectionState == .connected {
+                    Haptics.success()
+                }
             }
         } else {
             manualEntry = true
             focused = true
+        }
+    }
+
+    private func configurePairing(_ invite: CaveInvite) async -> Bool {
+        guard PairingApprovalPolicy.requiresApproval(hasExistingPairing: app.connection != nil) else {
+            await app.configure(host: invite.host, token: invite.token)
+            return true
+        }
+        return await appLock.performApprovedAction(
+            reason: "Confirm it's you to replace your desktop pairing"
+        ) {
+            await app.configure(host: invite.host, token: invite.token)
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -29,6 +29,7 @@ struct ConnectionView: View {
     /// explicit action.
     @State private var liveCheck: LiveCheckState = .idle
     @State private var approvalFailed = false
+    @State private var approvalUnavailable = false
     @FocusState private var focused: Bool
 
     enum LiveCheckState: Equatable {
@@ -133,6 +134,11 @@ struct ConnectionView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("Authentication failed or was cancelled, so your desktop pairing was not changed.")
+            }
+            .alert("Device authentication unavailable", isPresented: $approvalUnavailable) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Turn on a device passcode before replacing your desktop pairing.")
             }
         }
     }
@@ -436,21 +442,17 @@ struct ConnectionView: View {
     private func connect() {
         focused = false
         guard let invite = CaveInvite.parse(cleanHost(host)) else { return }
-        // Synchronous guard before spawning the Task: a same-runloop double
-        // tap can otherwise race the `.disabled` modifiers above into a
-        // second call that only fails because a prompt is already in
-        // flight, not because it was actually denied/cancelled — which
-        // would incorrectly show `approvalFailed`.
+        // Avoid redundant work before spawning the Task. The outcome switch
+        // remains authoritative if a same-runloop tap still races this guard.
         guard appLock.canBeginAuthentication else { return }
         host = invite.host
         busy = true
         liveCheck = .idle
         Task {
-            let approved = await configurePairing(invite)
+            let outcome = await configurePairing(invite)
             busy = false
-            if !approved {
-                approvalFailed = true
-            } else if app.connectionState == .connected {
+            handleApprovalOutcome(outcome)
+            if outcome == .authorized, app.connectionState == .connected {
                 Haptics.success()
             }
         }
@@ -470,17 +472,15 @@ struct ConnectionView: View {
         guard let invite = CaveInvite.parse(cleanHost(input)) else { return }
         host = invite.host
         if invite.token != nil {
-            // Same synchronous guard as `connect()` — QR scans route here
-            // too, and a busy no-op must not spawn a Task or show an alert.
+            // Same synchronous fast-path as `connect()`; QR scans route here too.
             guard appLock.canBeginAuthentication else { return }
             busy = true
             liveCheck = .idle
             Task {
-                let approved = await configurePairing(invite)
+                let outcome = await configurePairing(invite)
                 busy = false
-                if !approved {
-                    approvalFailed = true
-                } else if app.connectionState == .connected {
+                handleApprovalOutcome(outcome)
+                if outcome == .authorized, app.connectionState == .connected {
                     Haptics.success()
                 }
             }
@@ -490,15 +490,26 @@ struct ConnectionView: View {
         }
     }
 
-    private func configurePairing(_ invite: CaveInvite) async -> Bool {
+    private func configurePairing(_ invite: CaveInvite) async -> AuthenticationOutcome {
         guard PairingApprovalPolicy.requiresApproval(hasExistingPairing: app.connection != nil) else {
             await app.configure(host: invite.host, token: invite.token)
-            return true
+            return .authorized
         }
         return await appLock.performApprovedAction(
             reason: "Confirm it's you to replace your desktop pairing"
         ) {
             await app.configure(host: invite.host, token: invite.token)
+        }
+    }
+
+    private func handleApprovalOutcome(_ outcome: AuthenticationOutcome) {
+        switch outcome {
+        case .authorized, .busy:
+            break
+        case .denied:
+            approvalFailed = true
+        case .unavailable:
+            approvalUnavailable = true
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
@@ -87,9 +87,12 @@ struct PrivacyShieldView: View {
     @Environment(\.chrome) private var chrome
 
     var body: some View {
-        chrome.bgBase
-            .ignoresSafeArea()
-            .accessibilityHidden(true)
-            .transition(.identity)
+        ZStack {
+            Color(uiColor: .systemBackground)
+            chrome.bgBase
+        }
+        .ignoresSafeArea()
+        .accessibilityHidden(true)
+        .transition(.identity)
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+
+/// Full-screen replacement shown at the app root whenever `AppLock.isLocked`
+/// is `true`. Deliberately never a translucent overlay: a cold-launch or
+/// re-lock must guarantee zero app content is visible before authentication
+/// succeeds. `CovenCaveApp` swaps this in for the *entire* window content
+/// rather than layering it on top.
+struct LockScreenView: View {
+    var appLock: AppLock
+    @Environment(\.chrome) private var chrome
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(spacing: 28) {
+            Spacer()
+
+            ZStack {
+                RadialGradient(
+                    colors: [chrome.accent.opacity(0.18), .clear],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: 56
+                )
+                .frame(width: 112, height: 112)
+
+                Image(systemName: appLock.biometricSystemImage)
+                    .font(.system(size: 34, weight: .medium))
+                    .foregroundStyle(chrome.accent)
+            }
+            .accessibilityHidden(true)
+
+            VStack(spacing: 8) {
+                Text("Coven Cave is locked")
+                    .font(.title2.weight(.semibold))
+                    .foregroundStyle(chrome.textPrimary)
+                Text("Use \(appLock.biometricLabel) to continue.")
+                    .font(.subheadline)
+                    .foregroundStyle(chrome.textSecondary)
+            }
+            .multilineTextAlignment(.center)
+
+            Button {
+                Task { await appLock.unlock() }
+            } label: {
+                Label("Unlock", systemImage: appLock.biometricSystemImage)
+                    .font(.headline)
+                    .frame(maxWidth: 260)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(chrome.accent)
+            .disabled(appLock.isAuthenticating)
+            .accessibilityHint("Prompts \(appLock.biometricLabel) or your device passcode.")
+
+            Spacer()
+        }
+        .padding(.horizontal, 32)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(chrome.bgBase.ignoresSafeArea())
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Coven Cave is locked")
+        // Prompt automatically once the scene is genuinely active. Re-runs
+        // only when scenePhase itself changes (not on every re-render), and
+        // `AppLock.unlock()`'s own in-flight guard prevents this racing a
+        // manual tap on the button into a second stacked prompt.
+        .task(id: scenePhase) {
+            guard scenePhase == .active else { return }
+            await appLock.unlock()
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
@@ -9,7 +9,6 @@ struct LockScreenView: View {
     var appLock: AppLock
     @Environment(\.chrome) private var chrome
     @Environment(\.scenePhase) private var scenePhase
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(spacing: 28) {

--- a/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
@@ -59,13 +59,18 @@ struct LockScreenView: View {
         .background(chrome.bgBase.ignoresSafeArea())
         .accessibilityElement(children: .contain)
         .accessibilityLabel("Coven Cave is locked")
-        // Prompt automatically once the scene is genuinely active. Re-runs
-        // only when scenePhase itself changes (not on every re-render), and
-        // `AppLock.unlock()`'s own in-flight guard prevents this racing a
-        // manual tap on the button into a second stacked prompt.
+        // Prompt automatically once per genuine lock presentation while the
+        // scene is active. `AppLock.autoPromptOnActive()` de-duplicates
+        // against the `.inactive -> .active` bounce a cancelled/failed
+        // LocalAuthentication sheet itself causes — that bounce re-runs this
+        // `.task` but must not trigger a second automatic prompt; the retry
+        // button above remains the only retry until a new genuine lock
+        // cycle begins. `AppLock.unlock()`'s own in-flight guard additionally
+        // prevents this racing a manual tap on the button into a stacked
+        // prompt.
         .task(id: scenePhase) {
             guard scenePhase == .active else { return }
-            await appLock.unlock()
+            await appLock.autoPromptOnActive()
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LockScreenView.swift
@@ -74,3 +74,22 @@ struct LockScreenView: View {
         }
     }
 }
+
+/// Opaque, animation-free shield rendered ABOVE whatever content is
+/// currently mounted while `AppLock.isPrivacyShielded` is `true` (raised on
+/// `.inactive`/`.background`, cleared on `.active`). Unlike `LockScreenView`,
+/// this never replaces the view hierarchy — mounted content (and its
+/// navigation/scroll state) keeps living underneath — it only needs to keep
+/// app-switcher and Control Center snapshots from exposing anything. No
+/// translucency and no animated appearance/disappearance: either could leak
+/// a glimpse of content during the transition.
+struct PrivacyShieldView: View {
+    @Environment(\.chrome) private var chrome
+
+    var body: some View {
+        chrome.bgBase
+            .ignoresSafeArea()
+            .accessibilityHidden(true)
+            .transition(.identity)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -2,12 +2,14 @@ import SwiftUI
 
 struct SettingsView: View {
     @Environment(AppModel.self) private var app
+    @Environment(AppLock.self) private var appLock
     @Environment(\.chrome) private var chrome
     @AppStorage(AppearanceMode.storageKey) private var appearanceRaw = AppearanceMode.desktop.rawValue
     @AppStorage(ChatNotifications.enabledKey) private var chatNotificationsEnabled = true
     @State private var exportArchive: ExportArchive?
     @State private var exportFailed = false
     @State private var themeError = false
+    @State private var securityAuthFailed = false
     /// Light/Dark used both to preview the theme swatches and as the mode pushed
     /// to the desktop. Seeded from the desktop's published mode on appear.
     @State private var pushMode: ColorScheme = .dark
@@ -30,6 +32,7 @@ struct SettingsView: View {
                 heroSection
                 appearanceSection
                 wardsSection
+                securitySection
                 chatsSection
                 communitySection
                 legalSection
@@ -65,6 +68,11 @@ struct SettingsView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("Your desktop didn't confirm the change. Check the connection and try again.")
+            }
+            .alert("Couldn't confirm it's you", isPresented: $securityAuthFailed) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Authentication failed or was cancelled, so this setting wasn't changed.")
             }
         }
     }
@@ -217,6 +225,52 @@ struct SettingsView: View {
         }
     }
 
+    // MARK: - Security (biometric app lock + approvals)
+
+    /// Two persisted toggles gated behind `AppLock`: unlocking the app itself
+    /// and approving credential-affecting actions (desktop host changes,
+    /// disconnect). Both bind straight to `appLock`'s published state rather
+    /// than a locally mirrored `@State`, so a toggle only visibly moves once
+    /// the authentication it requires actually succeeds — a failed/cancelled
+    /// prompt just leaves the row where it was.
+    private var securitySection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { appLock.lockEnabled },
+                set: { newValue in
+                    Task {
+                        if await !appLock.setLockEnabled(newValue) { securityAuthFailed = true }
+                    }
+                }
+            )) {
+                Label("Require \(appLock.biometricLabel) to unlock", systemImage: appLock.biometricSystemImage)
+                    .foregroundStyle(.primary)
+            }
+            .disabled(!appLock.canUseDeviceAuthentication)
+
+            Toggle(isOn: Binding(
+                get: { appLock.approvalEnabled },
+                set: { newValue in
+                    Task {
+                        if await !appLock.setApprovalEnabled(newValue) { securityAuthFailed = true }
+                    }
+                }
+            )) {
+                Label("Require \(appLock.biometricLabel) for approvals", systemImage: "checkmark.shield")
+                    .foregroundStyle(.primary)
+            }
+            .disabled(!appLock.canUseDeviceAuthentication)
+        } header: {
+            Text("Security")
+        } footer: {
+            if appLock.canUseDeviceAuthentication {
+                Text("Unlock guards the app itself on cold start and after being away 60 seconds or more. Approvals re-confirm it's you before changing or disconnecting your paired desktop. Your device passcode always works as a fallback.")
+            } else {
+                Text("Turn on a passcode (Settings → Face ID & Passcode, or Touch ID & Passcode) to enable app lock and approvals.")
+            }
+        }
+    }
+
     // MARK: - Chats
 
     private var chatsSection: some View {
@@ -296,8 +350,10 @@ struct SettingsView: View {
 /// destructive disconnect.
 private struct ConnectionSettingsView: View {
     @Environment(AppModel.self) private var app
+    @Environment(AppLock.self) private var appLock
     @State private var editingHost: String = ""
     @State private var showDisconnectConfirm = false
+    @State private var approvalFailed = false
 
     var body: some View {
         Form {
@@ -317,7 +373,13 @@ private struct ConnectionSettingsView: View {
                     .keyboardType(.URL)
                     .font(.callout.monospaced())
                 Button("Save and reconnect") {
-                    Task { await app.configure(host: editingHost) }
+                    Task {
+                        guard await appLock.requestApproval(reason: "Confirm it's you to change your desktop connection") else {
+                            approvalFailed = true
+                            return
+                        }
+                        await app.configure(host: editingHost)
+                    }
                 }
                 .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
                           || editingHost == app.connection?.host)
@@ -341,10 +403,23 @@ private struct ConnectionSettingsView: View {
         .confirmationDialog("Disconnect from your desktop?",
                             isPresented: $showDisconnectConfirm,
                             titleVisibility: .visible) {
-            Button("Disconnect", role: .destructive) { app.disconnect() }
+            Button("Disconnect", role: .destructive) {
+                Task {
+                    guard await appLock.requestApproval(reason: "Confirm it's you to disconnect from your desktop") else {
+                        approvalFailed = true
+                        return
+                    }
+                    app.disconnect()
+                }
+            }
             Button("Cancel", role: .cancel) {}
         } message: {
             Text("You'll need to re-enter your desktop address to reconnect.")
+        }
+        .alert("Couldn't confirm it's you", isPresented: $approvalFailed) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Authentication failed or was cancelled, so nothing changed.")
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -10,6 +10,7 @@ struct SettingsView: View {
     @State private var exportFailed = false
     @State private var themeError = false
     @State private var securityAuthFailed = false
+    @State private var securityAuthUnavailable = false
     /// Light/Dark used both to preview the theme swatches and as the mode pushed
     /// to the desktop. Seeded from the desktop's published mode on appear.
     @State private var pushMode: ColorScheme = .dark
@@ -73,6 +74,11 @@ struct SettingsView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text("Authentication failed or was cancelled, so this setting wasn't changed.")
+            }
+            .alert("Device authentication unavailable", isPresented: $securityAuthUnavailable) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Turn on a device passcode before changing this security setting.")
             }
         }
     }
@@ -238,14 +244,11 @@ struct SettingsView: View {
             Toggle(isOn: Binding(
                 get: { appLock.lockEnabled },
                 set: { newValue in
-                    // Synchronous guard ahead of the `Task`: a same-runloop
-                    // double tap can otherwise race `.disabled` below into a
-                    // second call that only comes back `false` because a
-                    // prompt is already in flight, not because it failed —
-                    // which would incorrectly surface `securityAuthFailed`.
+                    // Avoid redundant work before spawning the Task. The
+                    // outcome switch still handles any same-runloop race.
                     guard appLock.canBeginAuthentication else { return }
                     Task {
-                        if await !appLock.setLockEnabled(newValue) { securityAuthFailed = true }
+                        handleSecurityOutcome(await appLock.setLockEnabled(newValue))
                     }
                 }
             )) {
@@ -259,7 +262,7 @@ struct SettingsView: View {
                 set: { newValue in
                     guard appLock.canBeginAuthentication else { return }
                     Task {
-                        if await !appLock.setApprovalEnabled(newValue) { securityAuthFailed = true }
+                        handleSecurityOutcome(await appLock.setApprovalEnabled(newValue))
                     }
                 }
             )) {
@@ -277,6 +280,17 @@ struct SettingsView: View {
             } else {
                 Text("Turn on a passcode (Settings → Face ID & Passcode, or Touch ID & Passcode) to enable app lock and approvals.")
             }
+        }
+    }
+
+    private func handleSecurityOutcome(_ outcome: AuthenticationOutcome) {
+        switch outcome {
+        case .authorized, .busy:
+            break
+        case .denied:
+            securityAuthFailed = true
+        case .unavailable:
+            securityAuthUnavailable = true
         }
     }
 
@@ -363,6 +377,7 @@ private struct ConnectionSettingsView: View {
     @State private var editingHost: String = ""
     @State private var showDisconnectConfirm = false
     @State private var approvalFailed = false
+    @State private var approvalUnavailable = false
 
     var body: some View {
         Form {
@@ -382,17 +397,16 @@ private struct ConnectionSettingsView: View {
                     .keyboardType(.URL)
                     .font(.callout.monospaced())
                 Button("Save and reconnect") {
-                    // Guard synchronously so a same-runloop double tap can't
-                    // race `.disabled` below into a second, indistinguishable
-                    // "busy" call that would show `approvalFailed`.
+                    // Avoid redundant work before spawning the Task; `.busy`
+                    // remains a no-op if a same-runloop tap races this guard.
                     guard appLock.canBeginAuthentication else { return }
                     Task {
-                        let approved = await appLock.performApprovedAction(
+                        let outcome = await appLock.performApprovedAction(
                             reason: "Confirm it's you to change your desktop connection"
                         ) {
                             await app.configure(host: editingHost)
                         }
-                        if !approved { approvalFailed = true }
+                        handleApprovalOutcome(outcome)
                     }
                 }
                 .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
@@ -419,17 +433,15 @@ private struct ConnectionSettingsView: View {
                             isPresented: $showDisconnectConfirm,
                             titleVisibility: .visible) {
             Button("Disconnect", role: .destructive) {
-                // Same synchronous guard as above: a busy no-op must not
-                // surface `approvalFailed` for a prompt that was never
-                // attempted.
+                // Same synchronous fast-path as above; `.busy` remains a no-op.
                 guard appLock.canBeginAuthentication else { return }
                 Task {
-                    let approved = await appLock.performApprovedAction(
+                    let outcome = await appLock.performApprovedAction(
                         reason: "Confirm it's you to disconnect from your desktop"
                     ) {
                         app.disconnect()
                     }
-                    if !approved { approvalFailed = true }
+                    handleApprovalOutcome(outcome)
                 }
             }
             Button("Cancel", role: .cancel) {}
@@ -440,6 +452,22 @@ private struct ConnectionSettingsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("Authentication failed or was cancelled, so nothing changed.")
+        }
+        .alert("Device authentication unavailable", isPresented: $approvalUnavailable) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Turn on a device passcode before changing your desktop connection.")
+        }
+    }
+
+    private func handleApprovalOutcome(_ outcome: AuthenticationOutcome) {
+        switch outcome {
+        case .authorized, .busy:
+            break
+        case .denied:
+            approvalFailed = true
+        case .unavailable:
+            approvalUnavailable = true
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -238,6 +238,12 @@ struct SettingsView: View {
             Toggle(isOn: Binding(
                 get: { appLock.lockEnabled },
                 set: { newValue in
+                    // Synchronous guard ahead of the `Task`: a same-runloop
+                    // double tap can otherwise race `.disabled` below into a
+                    // second call that only comes back `false` because a
+                    // prompt is already in flight, not because it failed —
+                    // which would incorrectly surface `securityAuthFailed`.
+                    guard appLock.canBeginAuthentication else { return }
                     Task {
                         if await !appLock.setLockEnabled(newValue) { securityAuthFailed = true }
                     }
@@ -246,11 +252,12 @@ struct SettingsView: View {
                 Label("Require \(appLock.biometricLabel) to unlock", systemImage: appLock.biometricSystemImage)
                     .foregroundStyle(.primary)
             }
-            .disabled(!appLock.canUseDeviceAuthentication)
+            .disabled(!appLock.canUseDeviceAuthentication || appLock.isAuthenticating)
 
             Toggle(isOn: Binding(
                 get: { appLock.approvalEnabled },
                 set: { newValue in
+                    guard appLock.canBeginAuthentication else { return }
                     Task {
                         if await !appLock.setApprovalEnabled(newValue) { securityAuthFailed = true }
                     }
@@ -259,7 +266,7 @@ struct SettingsView: View {
                 Label("Require \(appLock.biometricLabel) for approvals", systemImage: "checkmark.shield")
                     .foregroundStyle(.primary)
             }
-            .disabled(!appLock.canUseDeviceAuthentication)
+            .disabled(!appLock.canUseDeviceAuthentication || appLock.isAuthenticating)
         } header: {
             Text("Security")
         } footer: {
@@ -375,6 +382,10 @@ private struct ConnectionSettingsView: View {
                     .keyboardType(.URL)
                     .font(.callout.monospaced())
                 Button("Save and reconnect") {
+                    // Guard synchronously so a same-runloop double tap can't
+                    // race `.disabled` below into a second, indistinguishable
+                    // "busy" call that would show `approvalFailed`.
+                    guard appLock.canBeginAuthentication else { return }
                     Task {
                         let approved = await appLock.performApprovedAction(
                             reason: "Confirm it's you to change your desktop connection"
@@ -385,7 +396,8 @@ private struct ConnectionSettingsView: View {
                     }
                 }
                 .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
-                          || editingHost == app.connection?.host)
+                          || editingHost == app.connection?.host
+                          || appLock.isAuthenticating)
             } header: {
                 Text("Desktop address")
             } footer: {
@@ -407,6 +419,10 @@ private struct ConnectionSettingsView: View {
                             isPresented: $showDisconnectConfirm,
                             titleVisibility: .visible) {
             Button("Disconnect", role: .destructive) {
+                // Same synchronous guard as above: a busy no-op must not
+                // surface `approvalFailed` for a prompt that was never
+                // attempted.
+                guard appLock.canBeginAuthentication else { return }
                 Task {
                     let approved = await appLock.performApprovedAction(
                         reason: "Confirm it's you to disconnect from your desktop"

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -374,11 +374,12 @@ private struct ConnectionSettingsView: View {
                     .font(.callout.monospaced())
                 Button("Save and reconnect") {
                     Task {
-                        guard await appLock.requestApproval(reason: "Confirm it's you to change your desktop connection") else {
-                            approvalFailed = true
-                            return
+                        let approved = await appLock.performApprovedAction(
+                            reason: "Confirm it's you to change your desktop connection"
+                        ) {
+                            await app.configure(host: editingHost)
                         }
-                        await app.configure(host: editingHost)
+                        if !approved { approvalFailed = true }
                     }
                 }
                 .disabled(editingHost.trimmingCharacters(in: .whitespaces).isEmpty
@@ -405,11 +406,12 @@ private struct ConnectionSettingsView: View {
                             titleVisibility: .visible) {
             Button("Disconnect", role: .destructive) {
                 Task {
-                    guard await appLock.requestApproval(reason: "Confirm it's you to disconnect from your desktop") else {
-                        approvalFailed = true
-                        return
+                    let approved = await appLock.performApprovedAction(
+                        reason: "Confirm it's you to disconnect from your desktop"
+                    ) {
+                        app.disconnect()
                     }
-                    app.disconnect()
+                    if !approved { approvalFailed = true }
                 }
             }
             Button("Cancel", role: .cancel) {}

--- a/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/SettingsView.swift
@@ -265,6 +265,8 @@ struct SettingsView: View {
         } footer: {
             if appLock.canUseDeviceAuthentication {
                 Text("Unlock guards the app itself on cold start and after being away 60 seconds or more. Approvals re-confirm it's you before changing or disconnecting your paired desktop. Your device passcode always works as a fallback.")
+            } else if appLock.approvalEnabled {
+                Text("Approvals remain required, but device authentication is unavailable. Protected pairing changes are disabled until you turn on a device passcode.")
             } else {
                 Text("Turn on a passcode (Settings → Face ID & Passcode, or Touch ID & Passcode) to enable app lock and approvals.")
             }

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -261,6 +261,109 @@ final class AppLockTests: XCTestCase {
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
     }
 
+    // MARK: - Auto-prompt de-duplication (lock screen `.active` lifecycle)
+
+    /// Cold start locked: the first scene activation should trigger exactly
+    /// one automatic authentication attempt.
+    func testAutoPromptOnActiveFiresOnceOnColdStart() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        let result = await lock.autoPromptOnActive()
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    /// Reproduces the reported defect: LocalAuthentication sheets can bounce
+    /// the scene `.active -> .inactive -> .active`. After the user cancels
+    /// or fails, that bounce's resulting `.active` must NOT trigger a second
+    /// automatic prompt — only the explicit retry button may retry.
+    func testAutoPromptDoesNotRepeatAfterCancellationFromInactiveActiveBounce() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        let first = await lock.autoPromptOnActive()
+        XCTAssertFalse(first)
+        XCTAssertTrue(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+
+        // Simulates the `.inactive -> .active` bounce the cancelled/failed
+        // LocalAuthentication sheet itself causes: the view's `.task(id:
+        // scenePhase)` re-runs, calling this again with no genuine new lock
+        // cycle in between.
+        let second = await lock.autoPromptOnActive()
+        XCTAssertFalse(second)
+        XCTAssertTrue(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1, "must not stack/repeat an automatic prompt")
+    }
+
+    /// The explicit retry button (which calls `unlock()` directly, not the
+    /// auto-prompt path) must keep working after the auto-prompt has
+    /// declined to fire again.
+    func testExplicitRetryStillWorksAfterAutoPromptDeclines() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        _ = await lock.autoPromptOnActive()
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+
+        // A second bounce still must not auto-prompt.
+        _ = await lock.autoPromptOnActive()
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+
+        // But the user tapping the retry button directly always works.
+        authenticator.authenticateResult = true
+        let retried = await lock.unlock()
+
+        XCTAssertTrue(retried)
+        XCTAssertFalse(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 2)
+    }
+
+    /// A new genuine lock cycle (re-locking after the grace window elapses)
+    /// must get its own fresh automatic prompt.
+    func testAutoPromptFiresAgainForANewGenuineLockCycle() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+
+        _ = await lock.autoPromptOnActive()
+        XCTAssertFalse(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+        XCTAssertTrue(lock.isLocked)
+
+        let result = await lock.autoPromptOnActive()
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(lock.isLocked)
+        XCTAssertEqual(authenticator.authenticateCallCount, 2, "a new genuine lock cycle gets its own auto-prompt")
+    }
+
+    /// Two concurrent auto-prompt calls (e.g. a fast bounce racing the
+    /// initial `.task`) must never both reach the authenticator.
+    func testAutoPromptOnActiveNeverStacksConcurrentCalls() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        async let first = lock.autoPromptOnActive()
+        async let second = lock.autoPromptOnActive()
+        _ = await (first, second)
+
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+        XCTAssertFalse(lock.isLocked)
+    }
+
     // MARK: - Pure policy
 
     func testAppLockPolicyGraceBoundary() {

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -23,10 +23,10 @@ private final class FakeBiometricAuthenticator: BiometricAuthenticating {
 /// Controllable clock so background-duration boundaries (the 60s grace
 /// window) are deterministic instead of racing a real timer.
 private final class TestClock {
-    var current: Date
-    init(_ date: Date = Date(timeIntervalSinceReferenceDate: 0)) { current = date }
-    func now() -> Date { current }
-    func advance(by seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+    var current: TimeInterval
+    init(_ current: TimeInterval = 0) { self.current = current }
+    func now() -> TimeInterval { current }
+    func advance(by seconds: TimeInterval) { current += seconds }
 }
 
 @MainActor
@@ -51,7 +51,7 @@ final class AppLockTests: XCTestCase {
     ) -> AppLock {
         defaults.set(lockEnabled, forKey: AppLock.lockEnabledKey)
         defaults.set(approvalEnabled, forKey: AppLock.approvalEnabledKey)
-        return AppLock(authenticator: authenticator, defaults: defaults, now: clock.now)
+        return AppLock(authenticator: authenticator, defaults: defaults, monotonicNow: clock.now)
     }
 
     // MARK: - Cold start
@@ -102,6 +102,19 @@ final class AppLockTests: XCTestCase {
 
         lock.sceneDidEnterBackground()
         clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.isLocked)
+    }
+
+    func testMonotonicClockRollbackLocksConservatively() async {
+        let clock = TestClock(100)
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        clock.current = 50
         lock.sceneDidBecomeActive()
 
         XCTAssertTrue(lock.isLocked)

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -23,10 +23,17 @@ private final class FakeBiometricAuthenticator: BiometricAuthenticating {
 /// Controllable clock so background-duration boundaries (the 60s grace
 /// window) are deterministic instead of racing a real timer.
 private final class TestClock {
-    var current: TimeInterval
-    init(_ current: TimeInterval = 0) { self.current = current }
-    func now() -> TimeInterval { current }
-    func advance(by seconds: TimeInterval) { current += seconds }
+    var current: ContinuousClock.Instant
+
+    init(_ current: ContinuousClock.Instant = ContinuousClock().now) {
+        self.current = current
+    }
+
+    func now() -> ContinuousClock.Instant { current }
+
+    func advance(by seconds: TimeInterval) {
+        current = current.advanced(by: .seconds(seconds))
+    }
 }
 
 @MainActor
@@ -51,7 +58,7 @@ final class AppLockTests: XCTestCase {
     ) -> AppLock {
         defaults.set(lockEnabled, forKey: AppLock.lockEnabledKey)
         defaults.set(approvalEnabled, forKey: AppLock.approvalEnabledKey)
-        return AppLock(authenticator: authenticator, defaults: defaults, monotonicNow: clock.now)
+        return AppLock(authenticator: authenticator, defaults: defaults, continuousNow: clock.now)
     }
 
     // MARK: - Cold start
@@ -107,14 +114,14 @@ final class AppLockTests: XCTestCase {
         XCTAssertTrue(lock.isLocked)
     }
 
-    func testMonotonicClockRollbackLocksConservatively() async {
-        let clock = TestClock(100)
+    func testContinuousClockResetLocksConservatively() async {
+        let clock = TestClock()
         let authenticator = FakeBiometricAuthenticator()
         let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
         _ = await lock.unlock()
 
         lock.sceneDidEnterBackground()
-        clock.current = 50
+        clock.current = clock.current.advanced(by: .seconds(-50))
         lock.sceneDidBecomeActive()
 
         XCTAssertTrue(lock.isLocked)
@@ -220,6 +227,80 @@ final class AppLockTests: XCTestCase {
         XCTAssertTrue(approved)
         XCTAssertEqual(executionCount, 1)
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    func testEnabledApprovalFailsClosedWithoutExecutingWhenAuthenticationBecomesUnavailable() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        var executionCount = 0
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+
+        let approved = await lock.performApprovedAction(reason: "Replace pairing") {
+            executionCount += 1
+        }
+
+        XCTAssertFalse(approved)
+        XCTAssertTrue(lock.approvalEnabled, "the user's persisted approval choice remains logically enabled")
+        XCTAssertFalse(lock.canUseDeviceAuthentication)
+        XCTAssertEqual(executionCount, 0)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    func testRestoredAvailabilityStillRequiresApprovalAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        let unavailableApproval = await lock.requestApproval(reason: "Replace pairing")
+        XCTAssertFalse(unavailableApproval)
+
+        authenticator.canEvaluate = true
+        authenticator.kind = .faceID
+        authenticator.authenticateResult = false
+        let approved = await lock.requestApproval(reason: "Replace pairing")
+
+        XCTAssertFalse(approved)
+        XCTAssertTrue(lock.approvalEnabled)
+        XCTAssertTrue(lock.canUseDeviceAuthentication)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    func testDisabledPersistedApprovalPassesThroughWhenAuthenticationIsUnavailable() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
+        var executionCount = 0
+
+        let approved = await lock.performApprovedAction(reason: "Initial pairing") {
+            executionCount += 1
+        }
+
+        XCTAssertTrue(approved)
+        XCTAssertFalse(lock.approvalEnabled)
+        XCTAssertEqual(executionCount, 1)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    func testApprovalOutcomeDistinguishesUnavailableFromActualDenial() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+
+        let unavailable = await lock.requestApprovalOutcome(reason: "Replace pairing")
+
+        XCTAssertEqual(unavailable, .unavailable)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+
+        authenticator.canEvaluate = true
+        authenticator.authenticateResult = false
+        let denied = await lock.requestApprovalOutcome(reason: "Replace pairing")
+
+        XCTAssertEqual(denied, .denied)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
 
     // MARK: - Toggle gating
@@ -529,9 +610,9 @@ final class AppLockTests: XCTestCase {
         )
     }
 
-    /// Once availability returns, the effective preferences must be restored
-    /// from the untouched persisted values rather than staying forced off.
-    func testRestoredAvailabilityRestoresPersistedEffectivePreferences() async {
+    /// Once availability returns, effective lock must restore while the
+    /// logical approval preference remains enabled throughout.
+    func testRestoredAvailabilityRestoresEffectiveLockAndPreservesLogicalApproval() async {
         let authenticator = FakeBiometricAuthenticator()
         authenticator.authenticateResult = true
         let lock = makeLock(lockEnabled: true, approvalEnabled: true, authenticator: authenticator)
@@ -541,7 +622,7 @@ final class AppLockTests: XCTestCase {
         authenticator.kind = .none
         lock.sceneDidBecomeActive()
         XCTAssertFalse(lock.lockEnabled)
-        XCTAssertFalse(lock.approvalEnabled)
+        XCTAssertTrue(lock.approvalEnabled, "approvalEnabled is the persisted logical preference")
 
         authenticator.canEvaluate = true
         authenticator.kind = .faceID
@@ -572,10 +653,11 @@ final class AppLockTests: XCTestCase {
     // MARK: - Pure policy
 
     func testAppLockPolicyGraceBoundary() {
-        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: false, alreadyLocked: false, backgroundDuration: 600))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: false, alreadyLocked: false, backgroundDuration: .seconds(600)))
         XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: nil))
-        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: 59))
-        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: 60))
-        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: true, backgroundDuration: 1))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(59)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(60)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: true, backgroundDuration: .seconds(1)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(-1)))
     }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -185,9 +185,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = false
         let lock = makeLock(lockEnabled: false, approvalEnabled: false, authenticator: authenticator)
 
-        let approved = await lock.requestApproval(reason: "Change host")
+        let outcome = await lock.requestApproval(reason: "Change host")
 
-        XCTAssertTrue(approved)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
     }
 
@@ -196,9 +196,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = true
         let lock = makeLock(lockEnabled: false, approvalEnabled: true, authenticator: authenticator)
 
-        let approved = await lock.requestApproval(reason: "Disconnect")
+        let outcome = await lock.requestApproval(reason: "Disconnect")
 
-        XCTAssertTrue(approved)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
 
@@ -207,9 +207,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = false
         let lock = makeLock(lockEnabled: false, approvalEnabled: true, authenticator: authenticator)
 
-        let approved = await lock.requestApproval(reason: "Disconnect")
+        let outcome = await lock.requestApproval(reason: "Disconnect")
 
-        XCTAssertFalse(approved)
+        XCTAssertEqual(outcome, .denied)
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
 
@@ -221,9 +221,9 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
         var executionCount = 0
 
-        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+        let outcome = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
 
-        XCTAssertFalse(approved)
+        XCTAssertEqual(outcome, .denied)
         XCTAssertEqual(executionCount, 0)
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
@@ -234,9 +234,9 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
         var executionCount = 0
 
-        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+        let outcome = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
 
-        XCTAssertTrue(approved)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertEqual(executionCount, 1)
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
@@ -247,9 +247,9 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
         var executionCount = 0
 
-        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+        let outcome = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
 
-        XCTAssertTrue(approved)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertEqual(executionCount, 1)
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
     }
@@ -262,11 +262,11 @@ final class AppLockTests: XCTestCase {
         authenticator.canEvaluate = false
         authenticator.kind = .none
 
-        let approved = await lock.performApprovedAction(reason: "Replace pairing") {
+        let outcome = await lock.performApprovedAction(reason: "Replace pairing") {
             executionCount += 1
         }
 
-        XCTAssertFalse(approved)
+        XCTAssertEqual(outcome, .unavailable)
         XCTAssertTrue(lock.approvalEnabled, "the user's persisted approval choice remains logically enabled")
         XCTAssertFalse(lock.canUseDeviceAuthentication)
         XCTAssertEqual(executionCount, 0)
@@ -278,15 +278,15 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
         authenticator.canEvaluate = false
         authenticator.kind = .none
-        let unavailableApproval = await lock.requestApproval(reason: "Replace pairing")
-        XCTAssertFalse(unavailableApproval)
+        let unavailable = await lock.requestApproval(reason: "Replace pairing")
+        XCTAssertEqual(unavailable, .unavailable)
 
         authenticator.canEvaluate = true
         authenticator.kind = .faceID
         authenticator.authenticateResult = false
-        let approved = await lock.requestApproval(reason: "Replace pairing")
+        let denied = await lock.requestApproval(reason: "Replace pairing")
 
-        XCTAssertFalse(approved)
+        XCTAssertEqual(denied, .denied)
         XCTAssertTrue(lock.approvalEnabled)
         XCTAssertTrue(lock.canUseDeviceAuthentication)
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
@@ -299,33 +299,14 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
         var executionCount = 0
 
-        let approved = await lock.performApprovedAction(reason: "Initial pairing") {
+        let outcome = await lock.performApprovedAction(reason: "Initial pairing") {
             executionCount += 1
         }
 
-        XCTAssertTrue(approved)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertFalse(lock.approvalEnabled)
         XCTAssertEqual(executionCount, 1)
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
-    }
-
-    func testApprovalOutcomeDistinguishesUnavailableFromActualDenial() async {
-        let authenticator = FakeBiometricAuthenticator()
-        authenticator.canEvaluate = false
-        authenticator.kind = .none
-        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
-
-        let unavailable = await lock.requestApprovalOutcome(reason: "Replace pairing")
-
-        XCTAssertEqual(unavailable, .unavailable)
-        XCTAssertEqual(authenticator.authenticateCallCount, 0)
-
-        authenticator.canEvaluate = true
-        authenticator.authenticateResult = false
-        let denied = await lock.requestApprovalOutcome(reason: "Replace pairing")
-
-        XCTAssertEqual(denied, .denied)
-        XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
 
     // MARK: - Toggle gating
@@ -335,9 +316,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = true
         let lock = makeLock(lockEnabled: false, authenticator: authenticator)
 
-        let ok = await lock.setLockEnabled(true)
+        let outcome = await lock.setLockEnabled(true)
 
-        XCTAssertTrue(ok)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertTrue(lock.lockEnabled)
         XCTAssertTrue(defaults.bool(forKey: AppLock.lockEnabledKey))
     }
@@ -347,9 +328,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = false
         let lock = makeLock(lockEnabled: false, authenticator: authenticator)
 
-        let ok = await lock.setLockEnabled(true)
+        let outcome = await lock.setLockEnabled(true)
 
-        XCTAssertFalse(ok)
+        XCTAssertEqual(outcome, .denied)
         XCTAssertFalse(lock.lockEnabled)
         XCTAssertFalse(defaults.bool(forKey: AppLock.lockEnabledKey))
     }
@@ -359,9 +340,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = false
         let lock = makeLock(lockEnabled: true, authenticator: authenticator)
 
-        let ok = await lock.setLockEnabled(false)
+        let outcome = await lock.setLockEnabled(false)
 
-        XCTAssertFalse(ok)
+        XCTAssertEqual(outcome, .denied)
         XCTAssertTrue(lock.lockEnabled)
         XCTAssertTrue(defaults.bool(forKey: AppLock.lockEnabledKey))
     }
@@ -372,9 +353,9 @@ final class AppLockTests: XCTestCase {
         let lock = makeLock(lockEnabled: true, authenticator: authenticator)
         XCTAssertTrue(lock.isLocked)
 
-        let ok = await lock.setLockEnabled(false)
+        let outcome = await lock.setLockEnabled(false)
 
-        XCTAssertTrue(ok)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertFalse(lock.lockEnabled)
         XCTAssertFalse(lock.isLocked)
     }
@@ -384,9 +365,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = true
         let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
 
-        let ok = await lock.setApprovalEnabled(true)
+        let outcome = await lock.setApprovalEnabled(true)
 
-        XCTAssertTrue(ok)
+        XCTAssertEqual(outcome, .authorized)
         XCTAssertTrue(lock.approvalEnabled)
         XCTAssertTrue(defaults.bool(forKey: AppLock.approvalEnabledKey))
     }
@@ -396,9 +377,9 @@ final class AppLockTests: XCTestCase {
         authenticator.authenticateResult = false
         let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
 
-        let ok = await lock.setApprovalEnabled(false)
+        let outcome = await lock.setApprovalEnabled(false)
 
-        XCTAssertFalse(ok)
+        XCTAssertEqual(outcome, .denied)
         XCTAssertTrue(lock.approvalEnabled)
         XCTAssertTrue(defaults.bool(forKey: AppLock.approvalEnabledKey))
     }
@@ -414,9 +395,9 @@ final class AppLockTests: XCTestCase {
 
         XCTAssertFalse(lock.canUseDeviceAuthentication)
 
-        let ok = await lock.setLockEnabled(true)
+        let outcome = await lock.setLockEnabled(true)
 
-        XCTAssertFalse(ok)
+        XCTAssertEqual(outcome, .unavailable)
         XCTAssertFalse(lock.lockEnabled)
         XCTAssertEqual(authenticator.authenticateCallCount, 0)
     }
@@ -540,13 +521,13 @@ final class AppLockTests: XCTestCase {
         let started = expectation(description: "first prompt started")
         authenticator.onAuthenticateStart = { started.fulfill() }
 
-        let firstTask = Task { await lock.requestApprovalOutcome(reason: "First") }
+        let firstTask = Task { await lock.requestApproval(reason: "First") }
         await fulfillment(of: [started], timeout: 5)
         XCTAssertFalse(lock.canBeginAuthentication)
 
         authenticator.resumeSuspendedAuthenticate()
         let firstOutcome = await firstTask.value
-        XCTAssertEqual(firstOutcome, .approved)
+        XCTAssertEqual(firstOutcome, .authorized)
         XCTAssertTrue(lock.canBeginAuthentication)
     }
 
@@ -562,17 +543,17 @@ final class AppLockTests: XCTestCase {
         let started = expectation(description: "first prompt started")
         authenticator.onAuthenticateStart = { started.fulfill() }
 
-        let firstTask = Task { await lock.requestApprovalOutcome(reason: "First") }
+        let firstTask = Task { await lock.requestApproval(reason: "First") }
         await fulfillment(of: [started], timeout: 5)
 
-        let busyOutcome = await lock.requestApprovalOutcome(reason: "Second, concurrent")
+        let busyOutcome = await lock.requestApproval(reason: "Second, concurrent")
 
         XCTAssertEqual(busyOutcome, .busy)
         XCTAssertEqual(authenticator.authenticateCallCount, 1, "the concurrent request must not open a second prompt")
 
         authenticator.resumeSuspendedAuthenticate()
         let firstOutcome = await firstTask.value
-        XCTAssertEqual(firstOutcome, .approved, "the first, genuinely in-flight request must still succeed")
+        XCTAssertEqual(firstOutcome, .authorized, "the first, genuinely in-flight request must still succeed")
     }
 
     /// A concurrent toggle flip while another toggle/approval authentication
@@ -594,17 +575,110 @@ final class AppLockTests: XCTestCase {
         await fulfillment(of: [started], timeout: 5)
         XCTAssertFalse(lock.canBeginAuthentication)
 
-        let concurrentResult = await lock.setLockEnabled(true)
+        let concurrentOutcome = await lock.setLockEnabled(true)
 
-        XCTAssertFalse(concurrentResult)
+        XCTAssertEqual(concurrentOutcome, .busy)
         XCTAssertFalse(lock.lockEnabled, "the concurrent, busy call must not mutate the preference")
         XCTAssertFalse(defaults.bool(forKey: AppLock.lockEnabledKey))
         XCTAssertEqual(authenticator.authenticateCallCount, 1, "the concurrent call must not open a second prompt")
 
         authenticator.resumeSuspendedAuthenticate()
-        let firstResult = await firstTask.value
-        XCTAssertTrue(firstResult)
+        let firstOutcome = await firstTask.value
+        XCTAssertEqual(firstOutcome, .authorized)
         XCTAssertTrue(lock.lockEnabled, "the first, genuinely in-flight toggle must still take effect")
+    }
+
+    func testBusyApprovedActionReturnsBusyWithoutExecutingAndFirstRequestMaySucceed() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        var executionCount = 0
+
+        let started = expectation(description: "first approval started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+        let firstTask = Task { await lock.requestApproval(reason: "First") }
+        await fulfillment(of: [started], timeout: 5)
+
+        let busyOutcome = await lock.performApprovedAction(reason: "Second") {
+            executionCount += 1
+        }
+
+        XCTAssertEqual(busyOutcome, .busy)
+        XCTAssertEqual(executionCount, 0)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+
+        authenticator.resumeSuspendedAuthenticate()
+        let firstOutcome = await firstTask.value
+        XCTAssertEqual(firstOutcome, .authorized)
+    }
+
+    func testBusyApprovedActionDoesNotBypassBusyGuardWhenApprovalsAreDisabled() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        let lock = makeLock(lockEnabled: false, approvalEnabled: false, authenticator: authenticator)
+        var executionCount = 0
+
+        let started = expectation(description: "setting authentication started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+        let settingTask = Task { await lock.setLockEnabled(true) }
+        await fulfillment(of: [started], timeout: 5)
+
+        let outcome = await lock.performApprovedAction(reason: "Change host") {
+            executionCount += 1
+        }
+
+        XCTAssertEqual(outcome, .busy)
+        XCTAssertEqual(executionCount, 0)
+
+        authenticator.resumeSuspendedAuthenticate()
+        _ = await settingTask.value
+    }
+
+    func testBusyNoOpSettingRequestReturnsBusyBecauseInFlightRequestMayChangeIt() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+
+        let started = expectation(description: "enable authentication started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+        let enableTask = Task { await lock.setLockEnabled(true) }
+        await fulfillment(of: [started], timeout: 5)
+
+        let outcome = await lock.setLockEnabled(false)
+
+        XCTAssertEqual(outcome, .busy)
+        XCTAssertFalse(lock.lockEnabled)
+        XCTAssertFalse(defaults.bool(forKey: AppLock.lockEnabledKey))
+
+        authenticator.resumeSuspendedAuthenticate()
+        _ = await enableTask.value
+    }
+
+    func testNoOpSettingChangesAreAuthorizedWithoutAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.canEvaluate = false
+        let lock = makeLock(lockEnabled: false, approvalEnabled: true, authenticator: authenticator)
+
+        let lockOutcome = await lock.setLockEnabled(false)
+        let approvalOutcome = await lock.setApprovalEnabled(true)
+
+        XCTAssertEqual(lockOutcome, .authorized)
+        XCTAssertEqual(approvalOutcome, .authorized)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    func testApprovalSettingReportsUnavailableWithoutMutation() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.canEvaluate = false
+        let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
+
+        let outcome = await lock.setApprovalEnabled(true)
+
+        XCTAssertEqual(outcome, .unavailable)
+        XCTAssertFalse(lock.approvalEnabled)
+        XCTAssertFalse(defaults.bool(forKey: AppLock.approvalEnabledKey))
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
     }
 
     // MARK: - Privacy shield (separate from the authentication lock)
@@ -716,6 +790,127 @@ final class AppLockTests: XCTestCase {
             defaults.bool(forKey: AppLock.lockEnabledKey),
             "persisted preference must survive a transient unavailability"
         )
+    }
+
+    func testUnavailableActiveRetainsElapsedTimerAndRestoredAvailabilityLocksAtTotalSixtySeconds() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 30)
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked, "unavailable authentication must never strand the user")
+        XCTAssertFalse(lock.lockEnabled)
+
+        clock.advance(by: 30)
+        authenticator.canEvaluate = true
+        authenticator.kind = .faceID
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.lockEnabled)
+        XCTAssertTrue(lock.isLocked, "restored availability must apply the full retained elapsed interval")
+    }
+
+    func testRepeatedBackgroundEntryDoesNotReplaceRetainedEarlierInstant() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 30)
+        authenticator.canEvaluate = false
+        lock.sceneDidBecomeActive()
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 30)
+        authenticator.canEvaluate = true
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.isLocked, "the second background entry must not replace the earlier retained instant")
+    }
+
+    func testRestoredAvailabilityUnderTotalSixtySecondsPreservesGrace() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 20)
+        authenticator.canEvaluate = false
+        lock.sceneDidBecomeActive()
+        clock.advance(by: 39)
+        authenticator.canEvaluate = true
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.lockEnabled)
+        XCTAssertFalse(lock.isLocked)
+
+        clock.advance(by: 2)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked, "an available decision must consume the retained instant")
+    }
+
+    func testPersistedLockDisabledNeverAccumulatesBackgroundElapsedTime() {
+        let clock = TestClock()
+        let lock = makeLock(lockEnabled: false, clock: clock)
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 120)
+        defaults.set(true, forKey: AppLock.lockEnabledKey)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.lockEnabled)
+        XCTAssertFalse(lock.isLocked, "time before the persisted preference was enabled must not count")
+    }
+
+    func testPersistedLockTurningOffClearsAnEarlierRetainedInstant() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 10)
+        authenticator.canEvaluate = false
+        lock.sceneDidBecomeActive()
+
+        defaults.set(false, forKey: AppLock.lockEnabledKey)
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 100)
+        defaults.set(true, forKey: AppLock.lockEnabledKey)
+        authenticator.canEvaluate = true
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked, "elapsed time retained before the persisted preference turned off must be discarded")
+    }
+
+    func testSuccessfullyDisablingLockClearsRetainedBackgroundInstant() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 10)
+        authenticator.canEvaluate = false
+        lock.sceneDidBecomeActive()
+
+        authenticator.canEvaluate = true
+        let disableOutcome = await lock.setLockEnabled(false)
+        XCTAssertEqual(disableOutcome, .authorized)
+
+        defaults.set(true, forKey: AppLock.lockEnabledKey)
+        clock.advance(by: 100)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked, "a retained instant must not survive a successful disable")
     }
 
     /// Once availability returns, effective lock must restore while the

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -9,6 +9,18 @@ private final class FakeBiometricAuthenticator: BiometricAuthenticating {
     var kind: BiometricKind = .faceID
     var authenticateResult = true
     private(set) var authenticateCallCount = 0
+    /// When `true`, `authenticate` suspends (after recording the call) until
+    /// `resumeSuspendedAuthenticate()` is invoked — simulating a real,
+    /// still-on-screen LocalAuthentication prompt so busy-guard tests can
+    /// deterministically observe `isAuthenticating`/`canBeginAuthentication`
+    /// mid-flight.
+    var suspendsAuthenticate = false
+    /// Fired synchronously the instant `authenticate` is invoked (before
+    /// suspending), so a test can `await fulfillment(of:)` an expectation
+    /// instead of spin-polling `AppLock` state — a busy-poll loop on the
+    /// same `@MainActor` executor as the in-flight call risks starving it.
+    var onAuthenticateStart: (() -> Void)?
+    private var pendingContinuation: CheckedContinuation<Void, Never>?
 
     func availability() -> (canEvaluate: Bool, kind: BiometricKind) {
         (canEvaluate, kind)
@@ -16,7 +28,20 @@ private final class FakeBiometricAuthenticator: BiometricAuthenticating {
 
     func authenticate(reason: String) async -> Bool {
         authenticateCallCount += 1
+        onAuthenticateStart?()
+        if suspendsAuthenticate {
+            await withCheckedContinuation { continuation in
+                pendingContinuation = continuation
+            }
+        }
         return authenticateResult
+    }
+
+    /// Lets a suspended `authenticate` call complete, as if the user had
+    /// just finished (or the system delivered) the prompt.
+    func resumeSuspendedAuthenticate() {
+        pendingContinuation?.resume()
+        pendingContinuation = nil
     }
 }
 
@@ -497,6 +522,89 @@ final class AppLockTests: XCTestCase {
 
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
         XCTAssertFalse(lock.isLocked)
+    }
+
+    // MARK: - Busy guard (concurrent taps while a prompt is in flight)
+
+    /// `canBeginAuthentication` is the synchronous signal Settings/Connection
+    /// use to disable controls and guard action handlers before spawning a
+    /// `Task`. It must flip to `false` for the whole span `isAuthenticating`
+    /// is `true` and back to `true` once the in-flight prompt resolves.
+    func testCanBeginAuthenticationReflectsInFlightAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        XCTAssertTrue(lock.canBeginAuthentication)
+
+        let started = expectation(description: "first prompt started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+
+        let firstTask = Task { await lock.requestApprovalOutcome(reason: "First") }
+        await fulfillment(of: [started], timeout: 5)
+        XCTAssertFalse(lock.canBeginAuthentication)
+
+        authenticator.resumeSuspendedAuthenticate()
+        let firstOutcome = await firstTask.value
+        XCTAssertEqual(firstOutcome, .approved)
+        XCTAssertTrue(lock.canBeginAuthentication)
+    }
+
+    /// A second approval request arriving while the first is still on-screen
+    /// must come back `.busy` without ever prompting a second time and
+    /// without disturbing the first, in-flight attempt.
+    func testConcurrentApprovalRequestWhileAuthenticatingReturnsBusyWithoutSecondPrompt() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+
+        let started = expectation(description: "first prompt started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+
+        let firstTask = Task { await lock.requestApprovalOutcome(reason: "First") }
+        await fulfillment(of: [started], timeout: 5)
+
+        let busyOutcome = await lock.requestApprovalOutcome(reason: "Second, concurrent")
+
+        XCTAssertEqual(busyOutcome, .busy)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1, "the concurrent request must not open a second prompt")
+
+        authenticator.resumeSuspendedAuthenticate()
+        let firstOutcome = await firstTask.value
+        XCTAssertEqual(firstOutcome, .approved, "the first, genuinely in-flight request must still succeed")
+    }
+
+    /// A concurrent toggle flip while another toggle/approval authentication
+    /// is in flight must be rejected without mutating the persisted
+    /// preference or prompting again — this is what a Settings toggle's
+    /// caller-side guard (via `canBeginAuthentication`) relies on to avoid
+    /// showing a false "authentication failed" alert for a tap that was
+    /// never actually attempted.
+    func testConcurrentToggleWhileAuthenticatingDoesNotMutateSettingsOrPromptAgain() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.suspendsAuthenticate = true
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+
+        let started = expectation(description: "first toggle authentication started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+
+        let firstTask = Task { await lock.setLockEnabled(true) }
+        await fulfillment(of: [started], timeout: 5)
+        XCTAssertFalse(lock.canBeginAuthentication)
+
+        let concurrentResult = await lock.setLockEnabled(true)
+
+        XCTAssertFalse(concurrentResult)
+        XCTAssertFalse(lock.lockEnabled, "the concurrent, busy call must not mutate the preference")
+        XCTAssertFalse(defaults.bool(forKey: AppLock.lockEnabledKey))
+        XCTAssertEqual(authenticator.authenticateCallCount, 1, "the concurrent call must not open a second prompt")
+
+        authenticator.resumeSuspendedAuthenticate()
+        let firstResult = await firstTask.value
+        XCTAssertTrue(firstResult)
+        XCTAssertTrue(lock.lockEnabled, "the first, genuinely in-flight toggle must still take effect")
     }
 
     // MARK: - Privacy shield (separate from the authentication lock)

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -1,0 +1,273 @@
+import XCTest
+@testable import CovenCave
+
+/// A small controllable fake — never a test-only production hook. Records
+/// how many times authentication was actually invoked so tests can assert
+/// approval bypass and prompt de-duplication.
+private final class FakeBiometricAuthenticator: BiometricAuthenticating {
+    var canEvaluate = true
+    var kind: BiometricKind = .faceID
+    var authenticateResult = true
+    private(set) var authenticateCallCount = 0
+
+    func availability() -> (canEvaluate: Bool, kind: BiometricKind) {
+        (canEvaluate, kind)
+    }
+
+    func authenticate(reason: String) async -> Bool {
+        authenticateCallCount += 1
+        return authenticateResult
+    }
+}
+
+/// Controllable clock so background-duration boundaries (the 60s grace
+/// window) are deterministic instead of racing a real timer.
+private final class TestClock {
+    var current: Date
+    init(_ date: Date = Date(timeIntervalSinceReferenceDate: 0)) { current = date }
+    func now() -> Date { current }
+    func advance(by seconds: TimeInterval) { current = current.addingTimeInterval(seconds) }
+}
+
+@MainActor
+final class AppLockTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        suiteName = "AppLockTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func makeLock(
+        lockEnabled: Bool = false,
+        approvalEnabled: Bool = false,
+        authenticator: FakeBiometricAuthenticator = FakeBiometricAuthenticator(),
+        clock: TestClock = TestClock()
+    ) -> AppLock {
+        defaults.set(lockEnabled, forKey: AppLock.lockEnabledKey)
+        defaults.set(approvalEnabled, forKey: AppLock.approvalEnabledKey)
+        return AppLock(authenticator: authenticator, defaults: defaults, now: clock.now)
+    }
+
+    // MARK: - Cold start
+
+    func testDisabledPolicyDoesNotLockAtColdStart() {
+        let lock = makeLock(lockEnabled: false)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    func testEnabledColdStartLocks() {
+        let lock = makeLock(lockEnabled: true)
+        XCTAssertTrue(lock.isLocked)
+    }
+
+    func testDisabledPolicyStaysUnlockedAcrossBackgrounding() {
+        let clock = TestClock()
+        let lock = makeLock(lockEnabled: false, clock: clock)
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 600)
+        lock.sceneDidBecomeActive()
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    // MARK: - Grace boundary
+
+    func testQuickSwitchUnderSixtySecondsStaysUnlocked() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        // Cold start locks; unlock once so we can observe the re-lock decision
+        // in isolation from the initial cold-start lock.
+        _ = await lock.unlock()
+        XCTAssertFalse(lock.isLocked)
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 59)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    func testAtSixtySecondGraceBoundaryLocks() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+        XCTAssertFalse(lock.isLocked)
+
+        lock.sceneDidEnterBackground()
+        clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.isLocked)
+    }
+
+    // MARK: - Unlock
+
+    func testSuccessfulUnlockClearsTheLock() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+        XCTAssertTrue(lock.isLocked)
+
+        let result = await lock.unlock()
+
+        XCTAssertTrue(result)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    func testFailedUnlockLeavesTheLockInPlace() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+        XCTAssertTrue(lock.isLocked)
+
+        let result = await lock.unlock()
+
+        XCTAssertFalse(result)
+        XCTAssertTrue(lock.isLocked)
+    }
+
+    // MARK: - Approval
+
+    func testApprovalDisabledBypassesTheAuthenticatorEntirely() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: false, approvalEnabled: false, authenticator: authenticator)
+
+        let approved = await lock.requestApproval(reason: "Change host")
+
+        XCTAssertTrue(approved)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    func testApprovalEnabledReturnsAuthenticatorSuccess() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: false, approvalEnabled: true, authenticator: authenticator)
+
+        let approved = await lock.requestApproval(reason: "Disconnect")
+
+        XCTAssertTrue(approved)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    func testApprovalEnabledReturnsAuthenticatorFailure() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: false, approvalEnabled: true, authenticator: authenticator)
+
+        let approved = await lock.requestApproval(reason: "Disconnect")
+
+        XCTAssertFalse(approved)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    // MARK: - Toggle gating
+
+    func testEnablingLockOnlyTakesEffectAfterSuccessfulAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+
+        let ok = await lock.setLockEnabled(true)
+
+        XCTAssertTrue(ok)
+        XCTAssertTrue(lock.lockEnabled)
+        XCTAssertTrue(defaults.bool(forKey: AppLock.lockEnabledKey))
+    }
+
+    func testEnablingLockDoesNotChangeAnythingWhenAuthenticationFails() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+
+        let ok = await lock.setLockEnabled(true)
+
+        XCTAssertFalse(ok)
+        XCTAssertFalse(lock.lockEnabled)
+        XCTAssertFalse(defaults.bool(forKey: AppLock.lockEnabledKey))
+    }
+
+    func testDisablingLockAlsoRequiresSuccessfulAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        let ok = await lock.setLockEnabled(false)
+
+        XCTAssertFalse(ok)
+        XCTAssertTrue(lock.lockEnabled)
+        XCTAssertTrue(defaults.bool(forKey: AppLock.lockEnabledKey))
+    }
+
+    func testDisablingLockSucceedsAfterSuccessfulAuthenticationAndUnlocksImmediately() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+        XCTAssertTrue(lock.isLocked)
+
+        let ok = await lock.setLockEnabled(false)
+
+        XCTAssertTrue(ok)
+        XCTAssertFalse(lock.lockEnabled)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    func testEnablingApprovalOnlyTakesEffectAfterSuccessfulAuthentication() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
+
+        let ok = await lock.setApprovalEnabled(true)
+
+        XCTAssertTrue(ok)
+        XCTAssertTrue(lock.approvalEnabled)
+        XCTAssertTrue(defaults.bool(forKey: AppLock.approvalEnabledKey))
+    }
+
+    func testDisablingApprovalRequiresSuccessfulAuthenticationTooAndLeavesUnchangedOnFailure() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+
+        let ok = await lock.setApprovalEnabled(false)
+
+        XCTAssertFalse(ok)
+        XCTAssertTrue(lock.approvalEnabled)
+        XCTAssertTrue(defaults.bool(forKey: AppLock.approvalEnabledKey))
+    }
+
+    // MARK: - Unavailable device authentication
+
+    func testTogglesAreRejectedWhenDeviceOwnerAuthenticationIsUnavailable() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+
+        XCTAssertFalse(lock.canUseDeviceAuthentication)
+
+        let ok = await lock.setLockEnabled(true)
+
+        XCTAssertFalse(ok)
+        XCTAssertFalse(lock.lockEnabled)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
+    // MARK: - Pure policy
+
+    func testAppLockPolicyGraceBoundary() {
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: false, alreadyLocked: false, backgroundDuration: 600))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: nil))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: 59))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: 60))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: true, backgroundDuration: 1))
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -168,6 +168,47 @@ final class AppLockTests: XCTestCase {
         XCTAssertEqual(authenticator.authenticateCallCount, 1)
     }
 
+    // MARK: - Approved action (Settings' protected operations)
+
+    func testPerformApprovedActionDoesNotExecuteActionWhenEnabledApprovalFails() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        var executionCount = 0
+
+        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+
+        XCTAssertFalse(approved)
+        XCTAssertEqual(executionCount, 0)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    func testPerformApprovedActionExecutesActionExactlyOnceWhenEnabledApprovalSucceeds() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(approvalEnabled: true, authenticator: authenticator)
+        var executionCount = 0
+
+        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+
+        XCTAssertTrue(approved)
+        XCTAssertEqual(executionCount, 1)
+        XCTAssertEqual(authenticator.authenticateCallCount, 1)
+    }
+
+    func testPerformApprovedActionExecutesActionExactlyOnceWhenApprovalsDisabledWithoutTouchingAuthenticator() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = false
+        let lock = makeLock(approvalEnabled: false, authenticator: authenticator)
+        var executionCount = 0
+
+        let approved = await lock.performApprovedAction(reason: "Disconnect") { executionCount += 1 }
+
+        XCTAssertTrue(approved)
+        XCTAssertEqual(executionCount, 1)
+        XCTAssertEqual(authenticator.authenticateCallCount, 0)
+    }
+
     // MARK: - Toggle gating
 
     func testEnablingLockOnlyTakesEffectAfterSuccessfulAuthentication() async {

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -718,6 +718,49 @@ final class AppLockTests: XCTestCase {
         XCTAssertFalse(lock.isLocked)
     }
 
+    func testExtendedInactiveThenActiveRelocks() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidBecomeInactive()
+        clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.isLocked)
+        XCTAssertFalse(lock.isPrivacyShielded)
+    }
+
+    func testAuthenticationPromptInactiveBounceDoesNotRelock() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(
+            lockEnabled: true,
+            approvalEnabled: true,
+            authenticator: authenticator,
+            clock: clock
+        )
+        _ = await lock.unlock()
+
+        authenticator.suspendsAuthenticate = true
+        let started = expectation(description: "approval authentication started")
+        authenticator.onAuthenticateStart = { started.fulfill() }
+        let approvalTask = Task { await lock.requestApproval(reason: "Approve") }
+        await fulfillment(of: [started], timeout: 5)
+
+        lock.sceneDidBecomeInactive()
+        clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isLocked)
+        authenticator.resumeSuspendedAuthenticate()
+        let approvalOutcome = await approvalTask.value
+        XCTAssertEqual(approvalOutcome, .authorized)
+    }
+
     /// `.background` must raise the shield unconditionally, but only starts
     /// the re-lock clock when locking is actually enabled.
     func testBackgroundEnablesPrivacyShieldRegardlessOfLockEnabled() {
@@ -956,11 +999,11 @@ final class AppLockTests: XCTestCase {
     // MARK: - Pure policy
 
     func testAppLockPolicyGraceBoundary() {
-        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: false, alreadyLocked: false, backgroundDuration: .seconds(600)))
-        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: nil))
-        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(59)))
-        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(60)))
-        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: true, backgroundDuration: .seconds(1)))
-        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, backgroundDuration: .seconds(-1)))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: false, alreadyLocked: false, awayDuration: .seconds(600)))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, awayDuration: nil))
+        XCTAssertFalse(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, awayDuration: .seconds(59)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, awayDuration: .seconds(60)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: true, awayDuration: .seconds(1)))
+        XCTAssertTrue(AppLockPolicy.shouldLock(enabled: true, alreadyLocked: false, awayDuration: .seconds(-1)))
     }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AppLockTests.swift
@@ -405,6 +405,157 @@ final class AppLockTests: XCTestCase {
         XCTAssertFalse(lock.isLocked)
     }
 
+    // MARK: - Privacy shield (separate from the authentication lock)
+
+    /// `.inactive` (app switcher / control center / a bounced LocalAuthentication
+    /// sheet) must raise the privacy shield immediately, but must never mark
+    /// `isLocked`, start the background clock, or consume an auto-prompt slot.
+    func testInactiveEnablesPrivacyShieldWithoutLocking() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+        _ = await lock.unlock()
+        XCTAssertFalse(lock.isLocked)
+        XCTAssertFalse(lock.isPrivacyShielded)
+
+        lock.sceneDidBecomeInactive()
+
+        XCTAssertTrue(lock.isPrivacyShielded)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    /// A quick `.inactive -> .active` bounce with no genuine background stint
+    /// must clear the shield without ever re-locking.
+    func testQuickInactiveThenActiveClearsShieldWithoutLocking() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidBecomeInactive()
+        XCTAssertTrue(lock.isPrivacyShielded)
+
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.isPrivacyShielded)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    /// `.background` must raise the shield unconditionally, but only starts
+    /// the re-lock clock when locking is actually enabled.
+    func testBackgroundEnablesPrivacyShieldRegardlessOfLockEnabled() {
+        let lock = makeLock(lockEnabled: false)
+
+        lock.sceneDidEnterBackground()
+
+        XCTAssertTrue(lock.isPrivacyShielded)
+        XCTAssertFalse(lock.isLocked)
+    }
+
+    /// A background stint at/over the 60s grace window must clear the shield
+    /// on return to `.active` even though the app is (correctly) left locked.
+    func testGraceWindowExceededActiveClearsShieldButLeavesAppLocked() async {
+        let clock = TestClock()
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator, clock: clock)
+        _ = await lock.unlock()
+
+        lock.sceneDidEnterBackground()
+        XCTAssertTrue(lock.isPrivacyShielded)
+        clock.advance(by: 60)
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.isLocked)
+        XCTAssertFalse(lock.isPrivacyShielded)
+    }
+
+    // MARK: - Live authentication availability refresh
+
+    /// A genuine `.active` must re-check availability and refresh the
+    /// reported kind — e.g. biometrics got un-enrolled but the device
+    /// passcode fallback remains, so the label must become "Device Passcode".
+    func testActiveRefreshesBiometricKindWhenHardwareChanges() {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.kind = .faceID
+        let lock = makeLock(lockEnabled: false, authenticator: authenticator)
+        XCTAssertEqual(lock.biometricKind, .faceID)
+
+        authenticator.kind = .none
+        lock.sceneDidBecomeActive()
+
+        XCTAssertEqual(lock.biometricKind, .none)
+        XCTAssertEqual(lock.biometricLabel, "Device Passcode")
+    }
+
+    /// If device-owner authentication becomes entirely unavailable (no
+    /// biometrics enrolled and no passcode set) while the app is
+    /// backgrounded, the effective lock preference must go false and any
+    /// lock must clear on `.active` — the user must never be stranded with
+    /// no way to authenticate. The persisted preference itself must survive
+    /// untouched so it can be restored later.
+    func testUnavailableDeviceAuthenticationClearsEffectiveLockAndCannotStrandTheUser() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+        _ = await lock.unlock()
+        XCTAssertFalse(lock.isLocked)
+
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        lock.sceneDidEnterBackground()
+        lock.sceneDidBecomeActive()
+
+        XCTAssertFalse(lock.canUseDeviceAuthentication)
+        XCTAssertFalse(lock.lockEnabled, "effective lockEnabled must go false so the user isn't stranded")
+        XCTAssertFalse(lock.isLocked, "must never re-lock the user out with no way to authenticate")
+        XCTAssertTrue(
+            defaults.bool(forKey: AppLock.lockEnabledKey),
+            "persisted preference must survive a transient unavailability"
+        )
+    }
+
+    /// Once availability returns, the effective preferences must be restored
+    /// from the untouched persisted values rather than staying forced off.
+    func testRestoredAvailabilityRestoresPersistedEffectivePreferences() async {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.authenticateResult = true
+        let lock = makeLock(lockEnabled: true, approvalEnabled: true, authenticator: authenticator)
+        _ = await lock.unlock()
+
+        authenticator.canEvaluate = false
+        authenticator.kind = .none
+        lock.sceneDidBecomeActive()
+        XCTAssertFalse(lock.lockEnabled)
+        XCTAssertFalse(lock.approvalEnabled)
+
+        authenticator.canEvaluate = true
+        authenticator.kind = .faceID
+        lock.sceneDidBecomeActive()
+
+        XCTAssertTrue(lock.canUseDeviceAuthentication)
+        XCTAssertTrue(lock.lockEnabled, "restored availability should restore the persisted effective preference")
+        XCTAssertTrue(lock.approvalEnabled, "restored availability should restore the persisted effective preference")
+        XCTAssertFalse(lock.isLocked, "a quick active with no background stint must not re-lock")
+    }
+
+    /// `.inactive` must never trigger the availability/kind refresh — only a
+    /// genuine `.active` does.
+    func testInactiveDoesNotRefreshAvailabilityOrKind() {
+        let authenticator = FakeBiometricAuthenticator()
+        authenticator.kind = .faceID
+        let lock = makeLock(lockEnabled: true, authenticator: authenticator)
+
+        authenticator.kind = .touchID
+        authenticator.canEvaluate = false
+        lock.sceneDidBecomeInactive()
+
+        XCTAssertEqual(lock.biometricKind, .faceID, "inactive must not refresh availability")
+        XCTAssertTrue(lock.canUseDeviceAuthentication, "inactive must not refresh availability")
+        XCTAssertTrue(lock.isPrivacyShielded)
+    }
+
     // MARK: - Pure policy
 
     func testAppLockPolicyGraceBoundary() {

--- a/apps/ios/CovenCave/CovenCaveTests/BiometricKindTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/BiometricKindTests.swift
@@ -1,3 +1,4 @@
+import LocalAuthentication
 import XCTest
 @testable import CovenCave
 
@@ -24,5 +25,52 @@ final class BiometricKindTests: XCTestCase {
     func testNoneLabelAndSystemImageFallBackToPasscode() {
         XCTAssertEqual(BiometricKind.none.label, "Device Passcode")
         XCTAssertEqual(BiometricKind.none.systemImage, "lock.shield")
+    }
+}
+
+/// Tests for the pure runtime classification rule: hardware `biometryType`
+/// alone must never be trusted for the label — it stays populated even when
+/// no biometrics are enrolled/available, so `.deviceOwnerAuthenticationWithBiometrics`
+/// evaluability must gate whether the biometric-specific kind is reported.
+/// These exercise `BiometricPolicyClassifier.kind(...)` directly (no real
+/// `LAContext`) so the reviewer-flagged scenario — Face/Touch/Optic hardware
+/// present but nothing enrolled, device-owner auth still possible via
+/// passcode — is genuinely covered without needing physical hardware state.
+final class BiometricPolicyClassifierTests: XCTestCase {
+    func testEnrolledFaceIDReportsFaceIDKind() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .faceID, canEvaluateBiometrics: true)
+        XCTAssertEqual(kind, .faceID)
+    }
+
+    func testEnrolledTouchIDReportsTouchIDKind() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .touchID, canEvaluateBiometrics: true)
+        XCTAssertEqual(kind, .touchID)
+    }
+
+    func testEnrolledOpticIDReportsOpticIDKind() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .opticID, canEvaluateBiometrics: true)
+        XCTAssertEqual(kind, .opticID)
+    }
+
+    func testFaceIDHardwareWithoutEnrollmentReportsPasscode() {
+        // Face ID hardware present (biometryType == .faceID) but nothing
+        // enrolled/available: must report passcode, not Face ID.
+        let kind = BiometricPolicyClassifier.kind(biometryType: .faceID, canEvaluateBiometrics: false)
+        XCTAssertEqual(kind, .none)
+    }
+
+    func testTouchIDHardwareWithoutEnrollmentReportsPasscode() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .touchID, canEvaluateBiometrics: false)
+        XCTAssertEqual(kind, .none)
+    }
+
+    func testOpticIDHardwareWithoutEnrollmentReportsPasscode() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .opticID, canEvaluateBiometrics: false)
+        XCTAssertEqual(kind, .none)
+    }
+
+    func testNoBiometricHardwareReportsPasscode() {
+        let kind = BiometricPolicyClassifier.kind(biometryType: .none, canEvaluateBiometrics: false)
+        XCTAssertEqual(kind, .none)
     }
 }

--- a/apps/ios/CovenCave/CovenCaveTests/BiometricKindTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/BiometricKindTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import CovenCave
+
+/// Pure tests for `BiometricKind`'s user-visible copy. No `LAContext`
+/// involved — these assert the label/systemImage mapping directly so the
+/// lock screen and Settings iconography stays correct without driving real
+/// biometrics.
+final class BiometricKindTests: XCTestCase {
+    func testFaceIDLabelAndSystemImage() {
+        XCTAssertEqual(BiometricKind.faceID.label, "Face ID")
+        XCTAssertEqual(BiometricKind.faceID.systemImage, "faceid")
+    }
+
+    func testTouchIDLabelAndSystemImage() {
+        XCTAssertEqual(BiometricKind.touchID.label, "Touch ID")
+        XCTAssertEqual(BiometricKind.touchID.systemImage, "touchid")
+    }
+
+    func testOpticIDLabelAndSystemImage() {
+        XCTAssertEqual(BiometricKind.opticID.label, "Optic ID")
+        XCTAssertEqual(BiometricKind.opticID.systemImage, "opticid")
+    }
+
+    func testNoneLabelAndSystemImageFallBackToPasscode() {
+        XCTAssertEqual(BiometricKind.none.label, "Device Passcode")
+        XCTAssertEqual(BiometricKind.none.systemImage, "lock.shield")
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -72,6 +72,47 @@ final class PairingIntentTests: XCTestCase {
         XCTAssertEqual(app.pendingPairingIntent, newIntent)
     }
 
+    func testTakingMatchingPendingPairingIntentReturnsPayloadAndClearsIt() throws {
+        let app = AppModel()
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(url)
+        let intent = try XCTUnwrap(app.pendingPairingIntent)
+
+        XCTAssertEqual(app.takePendingPairingIntent(matching: intent.id), intent)
+        XCTAssertNil(app.pendingPairingIntent)
+    }
+
+    func testTakingNonmatchingPendingPairingIntentPreservesIt() throws {
+        let app = AppModel()
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(url)
+        let intent = try XCTUnwrap(app.pendingPairingIntent)
+
+        XCTAssertNil(app.takePendingPairingIntent(matching: UUID()))
+        XCTAssertEqual(app.pendingPairingIntent, intent)
+    }
+
+    func testTakingReplacedIntentCannotReturnStalePayload() throws {
+        let app = AppModel()
+        let oldURL = try XCTUnwrap(
+            URL(string: "covencave://connect?host=old-request.example.ts.net&token=old-secret")
+        )
+        let newURL = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-request.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(oldURL)
+        let oldIntent = try XCTUnwrap(app.pendingPairingIntent)
+        app.handleDeepLink(newURL)
+        let newIntent = try XCTUnwrap(app.pendingPairingIntent)
+
+        XCTAssertNil(app.takePendingPairingIntent(matching: oldIntent.id))
+        XCTAssertEqual(app.pendingPairingIntent, newIntent)
+    }
+
     func testPairingIntentIdentityIsUniqueEvenForIdenticalPayloads() {
         let first = PairingIntent(host: "desktop.example.ts.net", token: "secret")
         let second = PairingIntent(host: "desktop.example.ts.net", token: "secret")
@@ -84,22 +125,38 @@ final class PairingIntentTests: XCTestCase {
         XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
             isLocked: true,
             isAuthenticating: false,
-            isProcessing: false
+            isProcessing: false,
+            isActive: true
         ))
         XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
             isLocked: false,
             isAuthenticating: true,
-            isProcessing: false
+            isProcessing: false,
+            isActive: true
         ))
         XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
             isLocked: false,
             isAuthenticating: false,
-            isProcessing: true
+            isProcessing: true,
+            isActive: true
         ))
+    }
+
+    func testPendingPairingProcessorDefersWhileSceneIsInactiveOrBackgrounded() {
+        XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
+            isLocked: false,
+            isAuthenticating: false,
+            isProcessing: false,
+            isActive: false
+        ))
+    }
+
+    func testPendingPairingProcessorBeginsWhileUnlockedIdleAndActive() {
         XCTAssertTrue(PendingPairingProcessorPolicy.mayBegin(
             isLocked: false,
             isAuthenticating: false,
-            isProcessing: false
+            isProcessing: false,
+            isActive: true
         ))
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -13,10 +13,8 @@ final class PairingIntentTests: XCTestCase {
 
         app.handleDeepLink(url)
 
-        XCTAssertEqual(
-            app.pendingPairingIntent,
-            PairingIntent(host: "new-desktop.example.ts.net", token: "new-secret")
-        )
+        XCTAssertEqual(app.pendingPairingIntent?.host, "new-desktop.example.ts.net")
+        XCTAssertEqual(app.pendingPairingIntent?.token, "new-secret")
         XCTAssertEqual(app.connection, existing)
     }
 
@@ -32,20 +30,77 @@ final class PairingIntentTests: XCTestCase {
         XCTAssertNil(app.pendingPairingIntent)
     }
 
-    func testPendingPairingIntentRemainsWhileLockedAndConsumesOnceUnlocked() throws {
+    func testMatchingPendingPairingIntentIsConsumedConditionally() throws {
         let app = AppModel()
         let url = try XCTUnwrap(
             URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
         )
         app.handleDeepLink(url)
+        let intent = try XCTUnwrap(app.pendingPairingIntent)
 
-        XCTAssertNil(app.takePendingPairingIntent(isLocked: true))
-        XCTAssertNotNil(app.pendingPairingIntent)
-        XCTAssertEqual(
-            app.takePendingPairingIntent(isLocked: false),
-            PairingIntent(host: "new-desktop.example.ts.net", token: "new-secret")
-        )
+        XCTAssertTrue(app.consumePendingPairingIntent(matching: intent.id))
         XCTAssertNil(app.pendingPairingIntent)
+    }
+
+    func testNonmatchingPendingPairingIntentIsPreserved() throws {
+        let app = AppModel()
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(url)
+        let intent = try XCTUnwrap(app.pendingPairingIntent)
+
+        XCTAssertFalse(app.consumePendingPairingIntent(matching: UUID()))
+        XCTAssertEqual(app.pendingPairingIntent, intent)
+    }
+
+    func testNewIntentSurvivesCompletionOfOlderIntent() throws {
+        let app = AppModel()
+        let oldURL = try XCTUnwrap(
+            URL(string: "covencave://connect?host=old-request.example.ts.net&token=old-secret")
+        )
+        let newURL = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-request.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(oldURL)
+        let oldIntent = try XCTUnwrap(app.pendingPairingIntent)
+        app.handleDeepLink(newURL)
+        let newIntent = try XCTUnwrap(app.pendingPairingIntent)
+
+        XCTAssertNotEqual(oldIntent.id, newIntent.id)
+        XCTAssertFalse(app.consumePendingPairingIntent(matching: oldIntent.id))
+        XCTAssertEqual(app.pendingPairingIntent, newIntent)
+    }
+
+    func testPairingIntentIdentityIsUniqueEvenForIdenticalPayloads() {
+        let first = PairingIntent(host: "desktop.example.ts.net", token: "secret")
+        let second = PairingIntent(host: "desktop.example.ts.net", token: "secret")
+
+        XCTAssertNotEqual(first.id, second.id)
+        XCTAssertNotEqual(first, second)
+    }
+
+    func testPendingPairingProcessorDefersWhileLockedAuthenticatingOrAlreadyProcessing() {
+        XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
+            isLocked: true,
+            isAuthenticating: false,
+            isProcessing: false
+        ))
+        XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
+            isLocked: false,
+            isAuthenticating: true,
+            isProcessing: false
+        ))
+        XCTAssertFalse(PendingPairingProcessorPolicy.mayBegin(
+            isLocked: false,
+            isAuthenticating: false,
+            isProcessing: true
+        ))
+        XCTAssertTrue(PendingPairingProcessorPolicy.mayBegin(
+            isLocked: false,
+            isAuthenticating: false,
+            isProcessing: false
+        ))
     }
 
     func testInitialPairingDoesNotRequireApproval() {

--- a/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/PairingIntentTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class PairingIntentTests: XCTestCase {
+    func testConnectDeepLinkQueuesPairingIntentWithoutChangingConnection() throws {
+        let app = AppModel()
+        let existing = CaveConnection(host: "old-desktop.example.ts.net")
+        app.connection = existing
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
+        )
+
+        app.handleDeepLink(url)
+
+        XCTAssertEqual(
+            app.pendingPairingIntent,
+            PairingIntent(host: "new-desktop.example.ts.net", token: "new-secret")
+        )
+        XCTAssertEqual(app.connection, existing)
+    }
+
+    func testNonConnectDeepLinkStillRoutesWithoutCreatingPairingIntent() throws {
+        let app = AppModel()
+        app.selectedTab = .settings
+        let url = try XCTUnwrap(URL(string: "covencave://tasks"))
+
+        app.handleDeepLink(url)
+
+        XCTAssertEqual(app.selectedTab, .tasks)
+        XCTAssertEqual(app.deepLink, .tasks)
+        XCTAssertNil(app.pendingPairingIntent)
+    }
+
+    func testPendingPairingIntentRemainsWhileLockedAndConsumesOnceUnlocked() throws {
+        let app = AppModel()
+        let url = try XCTUnwrap(
+            URL(string: "covencave://connect?host=new-desktop.example.ts.net&token=new-secret")
+        )
+        app.handleDeepLink(url)
+
+        XCTAssertNil(app.takePendingPairingIntent(isLocked: true))
+        XCTAssertNotNil(app.pendingPairingIntent)
+        XCTAssertEqual(
+            app.takePendingPairingIntent(isLocked: false),
+            PairingIntent(host: "new-desktop.example.ts.net", token: "new-secret")
+        )
+        XCTAssertNil(app.pendingPairingIntent)
+    }
+
+    func testInitialPairingDoesNotRequireApproval() {
+        XCTAssertFalse(PairingApprovalPolicy.requiresApproval(hasExistingPairing: false))
+    }
+
+    func testReplacingExistingPairingRequiresApproval() {
+        XCTAssertTrue(PairingApprovalPolicy.requiresApproval(hasExistingPairing: true))
+    }
+}

--- a/scripts/ios-connect-paste.test.mjs
+++ b/scripts/ios-connect-paste.test.mjs
@@ -61,11 +61,12 @@ assert.match(
   "the stray-space nudge lives on as a classifier case, copy intact",
 );
 // The hint must NOT disable Connect — validation stays advisory (the connect flow
-// does the real probing); the button stays gated only on empty/busy.
+// does the real probing); the button stays gated only on empty/busy or an
+// in-flight device-authentication prompt, never on the advisory hint.
 assert.match(
   src,
-  /\.disabled\(!hostPresent \|\| busy\)/,
-  "Connect should stay enabled regardless of the advisory hint",
+  /\.disabled\(!hostPresent \|\| busy \|\| appLock\.isAuthenticating\)/,
+  "Connect should stay enabled regardless of the advisory hint, except while device authentication is in flight",
 );
 assert.match(
   src,

--- a/scripts/ios-connect-screen-ux.test.mjs
+++ b/scripts/ios-connect-screen-ux.test.mjs
@@ -112,8 +112,8 @@ assert.match(
 // --- Connected moment ----------------------------------------------------------
 assert.match(
   src,
-  /if app\.connectionState == \.connected \{ Haptics\.success\(\) \}/,
-  "a successful connect lands with success haptics",
+  /if outcome == \.authorized, app\.connectionState == \.connected \{\s*Haptics\.success\(\)\s*\}/,
+  "an approved successful connect lands with success haptics",
 );
 assert.match(
   src,

--- a/scripts/ios-ipad-split-chats.test.mjs
+++ b/scripts/ios-ipad-split-chats.test.mjs
@@ -59,6 +59,10 @@ assert.match(src, /\.navigationSplitViewStyle\(\.balanced\)/, "should use the ba
 const appRoot = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
 assert.match(appRoot, /struct WideSplitEnabler<Content: View>: View/, "the app root defines the wide-window size-class promoter");
 assert.match(appRoot, /geo\.size\.width >= 700 \? \.regular : inherited/, "≥700pt promotes to regular; narrower keeps the inherited class");
-assert.match(appRoot, /WideSplitEnabler \{\s*\n\s*RootView\(\)/, "RootView rides inside the promoter so every tab's split engages");
+assert.match(
+  appRoot,
+  /WideSplitEnabler \{[\s\S]*ZStack \{[\s\S]*RootView\(\)/,
+  "the lock/privacy root still keeps RootView inside the promoter so every tab's split engages",
+);
 
 console.log("ios-ipad-split-chats: OK");


### PR DESCRIPTION
## Summary
- add optional Face ID, Touch ID, Optic ID, or passcode app unlock with a 60-second background grace period
- require fresh device authentication for pairing replacements, host changes, disconnects, and sensitive App Intents
- protect app-switcher snapshots, serialize deep-link pairing intents, and fail closed when authentication is unavailable
- add comprehensive policy, lifecycle, concurrency, pairing, and biometric classification tests

## Test plan
- [x] `xcodegen generate`
- [x] Full `CovenCaveTests` unit-test bundle on iPhone 16 Pro simulator
- [x] `xcodebuild build` for iPhone 16 Pro simulator
- [x] Fresh spec-compliance and code-quality reviews

## Notes
The existing web-bundle prebuild reports the documented fallback warning because this isolated worktree does not contain `node_modules/@xterm`; unit tests and the native app build still complete successfully.