### PR TITLE
fix(hooks): block invalid co-author trailers

### DIFF
--- a/scripts/git-hooks-commit-msg.test.mjs
+++ b/scripts/git-hooks-commit-msg.test.mjs
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const hookSource = path.join(root, "scripts", "git-hooks", "commit-msg");
+const gitBash = "C:\\Program Files\\Git\\bin\\bash.exe";
+const bashCommand = process.platform === "win32" && existsSync(gitBash) ? gitBash : "bash";
+
+function runHook(message) {
+  const dir = mkdtempSync(path.join(tmpdir(), "coven-cave-commit-msg-test-"));
+  const hooksDir = path.join(dir, "scripts", "git-hooks");
+  mkdirSync(hooksDir, { recursive: true });
+  const hook = path.join(hooksDir, "commit-msg");
+  cpSync(hookSource, hook);
+  chmodSync(hook, 0o755);
+  const messageFile = path.join(dir, "message");
+  writeFileSync(messageFile, message);
+  return spawnSync(bashCommand, [hook, messageFile], { cwd: dir, encoding: "utf8" });
+}
+
+{
+  const result = runHook("fix: preserve human credit\n\nCo-authored-by: Val Alexander <68980965+BunsDev@users.noreply.github.com>\n");
+  assert.equal(result.status, 0, result.stderr);
+}
+
+{
+  const result = runHook("fix: reject vendor attribution\n\nCo-authored-by: Claude Fable 5 <noreply@anthropic.com>\n");
+  assert.notEqual(result.status, 0, "AI/vendor co-author trailers must be blocked");
+  assert.match(result.stderr, /numeric no-reply identity/i);
+}
+
+{
+  const result = runHook("fix: reject machine address\n\nCo-authored-by: Jane Doe <jane@Someones-Mac.local>\n");
+  assert.notEqual(result.status, 0, "machine-local co-author trailers must be blocked");
+  assert.match(result.stderr, /users\.noreply\.github\.com/i);
+}
+
+console.log("git-hooks-commit-msg.test.mjs: ok");

--- a/scripts/git-hooks/commit-msg
+++ b/scripts/git-hooks/commit-msg
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# coven-cave commit-msg hook
+#
+# Co-authored-by trailers are contributor credit. The repository requires a
+# GitHub-linked numeric no-reply identity so credit reaches the person rather
+# than a local machine, AI model, vendor, or coding harness address.
+set -euo pipefail
+
+message_file=${1:-}
+if [ -z "$message_file" ] || [ ! -f "$message_file" ]; then
+  printf '%s\n' "[commit-msg blocked] expected a commit-message file" >&2
+  exit 1
+fi
+
+trailer_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:'
+human_identity_re='^[[:space:]]*[Cc][Oo]-[Aa][Uu][Tt][Hh][Oo][Rr][Ee][Dd]-[Bb][Yy]:[[:space:]]+.+[[:space:]]+<[0-9]+\+[A-Za-z0-9-]+@users\.noreply\.github\.com>[[:space:]]*$'
+
+while IFS= read -r line || [ -n "$line" ]; do
+  if [[ "$line" =~ $trailer_re ]] && ! [[ "$line" =~ $human_identity_re ]]; then
+    printf '%s\n' "[commit-msg blocked] Co-authored-by trailers must credit a person with GitHub's numeric no-reply identity: Full Name <ID+username@users.noreply.github.com>." >&2
+    exit 1
+  fi
+done < "$message_file"

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1035,6 +1035,7 @@ export const SUITES = {
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
+    "scripts/git-hooks-commit-msg.test.mjs",
     "scripts/secret-preflight.test.mjs",
     "scripts/uninstall-app.test.mjs",
     "scripts/desktop-reachability.test.mjs",


### PR DESCRIPTION
## Summary

Adds a tracked `commit-msg` hook that requires every `Co-authored-by:` trailer to use the repository's numeric GitHub no-reply identity. This prevents AI/vendor and machine-local attribution such as the Anthropic trailer identified during review of #4090.

## Validation

- `node scripts/git-hooks-commit-msg.test.mjs`
- `node scripts/check-tests-wired.mjs`
- `bash -n scripts/git-hooks/commit-msg`
- `git diff --check`

## Local host note

`pnpm lint` could not complete because a clean locked install cannot compile `node-pty` in this WSL host: `gyp ERR! stack Error: not found: make`. GitHub CI remains the authoritative full-suite validation.

Bead: cave-4cb