### PR TITLE
fix(ios): make CavePerformance's default key limit nonisolated

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Performance/CavePerformance.swift
+++ b/apps/ios/CovenCave/CovenCave/Performance/CavePerformance.swift
@@ -46,7 +46,11 @@ final class CavePerformanceRecorder {
     #else
     private static let sharedEnabledByDefault = false
     #endif
-    private static let defaultDistinctKeyLimit = 128
+    // nonisolated: referenced from `init` default arguments, which Swift 6
+    // evaluates in a nonisolated context. An immutable Int is safe to read
+    // from anywhere; without this the references become errors in the
+    // Swift 6 language mode.
+    private nonisolated static let defaultDistinctKeyLimit = 128
 
     static let shared = CavePerformanceRecorder(enabled: sharedEnabledByDefault)
 


### PR DESCRIPTION
## Summary

Implements **cave-ae48w**: `CavePerformanceRecorder` is `@MainActor`, so its `static defaultDistinctKeyLimit` was main-actor-isolated — but Swift 6 evaluates `init` default arguments in a nonisolated context, so both references (`sampleKeyLimit:`/`counterKeyLimit:` defaults) warned *"main actor-isolated static property 'defaultDistinctKeyLimit' can not be referenced from a nonisolated context; this is an error in the Swift 6 language mode."* One-line fix: the immutable `Int` is safe to read from anywhere, so it's now `nonisolated`.

## Verification (local — iOS Swift is not compiled by CI)

- Baseline on clean main reproduced exactly the two warnings at the default-argument sites (lines 126/127).
- After the change: `xcodebuild build` emits **zero** actor-isolation warnings, BUILD SUCCEEDED.
- `xcodebuild test -only-testing:CovenCaveTests/CavePerformanceTests`: **10 tests, 0 failures** on the iPhone 16 Pro simulator (Xcode 26.6).
- No web-side source-text tests pin this file (checked — that trap has bitten before).

Closes cave-ae48w (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)