### PR TITLE
feat(github): fold reaction counts into the item response

### DIFF
--- a/src/app/api/github/item/route.ts
+++ b/src/app/api/github/item/route.ts
@@ -67,7 +67,29 @@ type ItemDetail = {
   updatedAt: string | null;
   htmlUrl: string | null;
   comments: number;
+  /**
+   * Per-content reaction counts, straight from the issue payload GitHub
+   * already returns — no extra request. Deliberately counts-only: the issue
+   * payload has no viewer-reaction ids, so "mine" state and removal still
+   * require the reactions route, which the card fetches lazily on first
+   * interaction (cave-6p628).
+   */
+  reactionCounts: Record<string, number>;
 };
+
+/** GitHub's eight reaction contents, in the order its own UI shows them. */
+const REACTION_CONTENTS = ["+1", "-1", "laugh", "hooray", "confused", "heart", "rocket", "eyes"] as const;
+
+function reactionCounts(raw: unknown): Record<string, number> {
+  if (!raw || typeof raw !== "object") return {};
+  const source = raw as Record<string, unknown>;
+  const counts: Record<string, number> = {};
+  for (const content of REACTION_CONTENTS) {
+    const count = source[content];
+    if (typeof count === "number" && Number.isFinite(count) && count > 0) counts[content] = count;
+  }
+  return counts;
+}
 
 function person(raw: unknown): Person | null {
   if (!raw || typeof raw !== "object") return null;
@@ -212,6 +234,7 @@ export async function GET(req: Request) {
       updatedAt: typeof d.updated_at === "string" ? d.updated_at : null,
       htmlUrl: typeof d.html_url === "string" ? d.html_url : null,
       comments: Number(d.comments ?? 0),
+      reactionCounts: reactionCounts(d.reactions),
     };
 
     // Absent `pull=1` the payload stays byte-identical to what every existing

--- a/src/components/github-card-composer.tsx
+++ b/src/components/github-card-composer.tsx
@@ -54,6 +54,8 @@ export type GhComposerItem = {
   author: string | null;
   assignees: string[];
   labels: { name: string; color: string }[];
+  /** Per-content counts the item response carries for free (cave-6p628). */
+  reactionCounts?: Record<string, number>;
   pull: {
     headRef: string | null;
     baseRef: string | null;
@@ -179,7 +181,16 @@ export function GitHubCardComposer({
   const [merged, setMerged] = useState<{ sha: string | null; branchDeleted: boolean } | null>(null);
   const [restored, setRestored] = useState(false);
   const [busy, setBusy] = useState<string | null>(null);
-  const [reactions, setReactions] = useState<Reaction[]>([]);
+  // Seeded from the counts the item response already carries — zero extra
+  // requests at rest. `mine` stays null until the full list is hydrated
+  // lazily on first interaction with the chip row, because only the
+  // reactions endpoint knows the viewer's own reaction ids (cave-6p628).
+  const [reactions, setReactions] = useState<Reaction[]>(() =>
+    Object.keys(REACTION_EMOJI)
+      .filter((content) => (item.reactionCounts?.[content] ?? 0) > 0)
+      .map((content) => ({ content, count: item.reactionCounts?.[content] ?? 0, mine: null })),
+  );
+  const reactionsHydratedRef = useRef(false);
   const [palette, setPalette] = useState<{ name: string; color: string }[]>([]);
   const [scopes, setScopes] = useState<GhDraftScopes>({ files: true, threads: true, checks: false });
   const [drafting, setDrafting] = useState(false);
@@ -295,26 +306,9 @@ export function GitHubCardComposer({
     if (pick === "") setLabels(item.labels.map((l) => l.name));
   }, [item.labels, pick]);
 
-  // ── reactions + label palette, fetched once the composer is reachable ─────
-
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(
-          `/api/github/reactions?repo=${encodeURIComponent(repo)}&number=${number}`,
-          { cache: "no-store" },
-        );
-        const data = (await res.json().catch(() => null)) as { ok?: boolean; reactions?: Reaction[] } | null;
-        if (!cancelled && res.ok && data?.ok && Array.isArray(data.reactions)) setReactions(data.reactions);
-      } catch {
-        /* reactions are decoration — a failure leaves the row empty */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [repo, number]);
+  // ── reactions: no mount fetch — counts ride in on the item response, and
+  // the full list (which carries the viewer's own reaction ids) hydrates
+  // lazily on first pointer/keyboard contact with a chip (cave-6p628). ──────
 
   // The label palette is only needed once the user opens the picker.
   useEffect(() => {
@@ -472,20 +466,51 @@ export function GitHubCardComposer({
     onRefreshThreads?.();
   };
 
-  const rereadReactions = async () => {
+  const rereadReactions = async (): Promise<Reaction[] | null> => {
     try {
       const r = await fetch(`/api/github/reactions?repo=${encodeURIComponent(repo)}&number=${number}`, {
         cache: "no-store",
       });
       const data = (await r.json().catch(() => null)) as { ok?: boolean; reactions?: Reaction[] } | null;
-      if (data?.ok && Array.isArray(data.reactions)) setReactions(data.reactions);
+      if (data?.ok && Array.isArray(data.reactions)) {
+        reactionsHydratedRef.current = true;
+        setReactions(data.reactions);
+        return data.reactions;
+      }
+      return null;
     } catch {
-      /* leave the optimistic state; the next mount corrects it */
+      /* leave the seeded/optimistic state; a later interaction retries */
+      return null;
     }
   };
 
+  // First pointer/keyboard contact with a chip fetches the full list so the
+  // viewer's own reactions highlight and become removable. One-shot: after
+  // hydration (or any toggle) the state is authoritative.
+  const hydrateReactionsOnce = () => {
+    if (reactionsHydratedRef.current) return;
+    reactionsHydratedRef.current = true;
+    void rereadReactions().then((list) => {
+      if (list === null) reactionsHydratedRef.current = false;
+    });
+  };
+
   const toggleReaction = async (content: string) => {
-    const existing = reactions.find((r) => r.content === content);
+    // A tap that beats hover hydration (touch, keyboard) must not guess:
+    // without the viewer's reaction ids a second 👍 on an already-reacted
+    // item would double-add. Hydrate first, then decide add vs remove.
+    let current = reactions;
+    if (!reactionsHydratedRef.current) {
+      reactionsHydratedRef.current = true;
+      const hydrated = await rereadReactions();
+      if (hydrated === null) {
+        reactionsHydratedRef.current = false;
+        announce("That reaction did not stick.");
+        return;
+      }
+      current = hydrated;
+    }
+    const existing = current.find((r) => r.content === content);
     const removing = existing?.mine != null;
     // Optimistic: the chip is a toggle and a round-trip would make it feel dead.
     setReactions((prev) =>
@@ -916,6 +941,8 @@ export function GitHubCardComposer({
                 type="button"
                 className={`ghc-reaction focus-ring${r.mine ? " ghc-reaction--mine" : ""}`}
                 onClick={() => void toggleReaction(r.content)}
+                onPointerEnter={hydrateReactionsOnce}
+                onFocus={hydrateReactionsOnce}
                 aria-pressed={Boolean(r.mine)}
                 aria-label={`${r.content} reaction, ${r.count}`}
               >

--- a/src/components/github-card-wiring.test.ts
+++ b/src/components/github-card-wiring.test.ts
@@ -193,4 +193,35 @@ assert.match(actionCard, /agents propose, humans dispose/i, "proposal cards docu
 assert.doesNotMatch(actionCard, /useEffect\([^)]*fireGitHubAction/s, "no effect ever auto-fires a proposal — taps only");
 assert.match(chatView, /<GitHubActionCard action=\{p\.action\} \/>/, "assistant turns render proposal cards from action pieces");
 
+// ── reaction counts ride the item response; the list hydrates lazily ──────
+// (cave-6p628: one fewer GitHub request per mounted card)
+const itemRoute = readFileSync(new URL("../app/api/github/item/route.ts", import.meta.url), "utf8");
+assert.match(
+  itemRoute,
+  /reactionCounts: reactionCounts\(d\.reactions\)/,
+  "the item route folds per-content reaction counts from the payload GitHub already returns",
+);
+assert.match(card, /reactionCounts: item\.reactionCounts \?\? \{\}/, "the card threads counts into the composer");
+const composerSrc = readFileSync(new URL("./github-card-composer.tsx", import.meta.url), "utf8");
+assert.match(
+  composerSrc,
+  /useState<Reaction\[\]>\(\(\) =>\s*Object\.keys\(REACTION_EMOJI\)/,
+  "the composer seeds chips from the item's counts, not a fetch",
+);
+assert.doesNotMatch(
+  composerSrc,
+  /useEffect\([^}]*\/api\/github\/reactions/s,
+  "no mount-time reactions request — the list is only fetched on interaction",
+);
+assert.match(
+  composerSrc,
+  /onPointerEnter=\{hydrateReactionsOnce\}/,
+  "first pointer contact with a chip hydrates the viewer's own-reaction state",
+);
+assert.match(
+  composerSrc,
+  /if \(!reactionsHydratedRef\.current\) \{[\s\S]{0,400}await rereadReactions\(\)/,
+  "a toggle that beats hydration fetches the list first — never guesses add-vs-remove",
+);
+
 console.log("github chat-card wiring: ok");

--- a/src/components/github-card.tsx
+++ b/src/components/github-card.tsx
@@ -57,6 +57,9 @@ type ItemDetail = {
   updatedAt: string | null;
   htmlUrl: string | null;
   comments: number;
+  /** Per-content counts folded into the item response (cave-6p628); absent on
+   *  older payloads, in which case the composer starts with an empty row. */
+  reactionCounts?: Record<string, number>;
   pull: PullDetail | null;
 };
 
@@ -717,6 +720,7 @@ export function GitHubCard({
               author: item.author?.login ?? null,
               assignees: item.assignees.map((a) => a.login),
               labels: item.labels,
+              reactionCounts: item.reactionCounts ?? {},
               // Absent whenever the response predates `pull=1` (or the item is
               // an issue) — the composer treats null as "no PR facts yet".
               pull: item.pull ?? null,


### PR DESCRIPTION
## Summary

Implements **cave-6p628**: each open-PR card in a chat transcript fired four GitHub requests on mount (item, checks, threads, reactions); the reactions GET was pure waste at rest, because `GET /repos/{repo}/issues/{n}` already carries per-content reaction counts.

- **/api/github/item** now surfaces `reactionCounts` (nonzero contents only, GitHub's own display order) parsed from the payload it already receives — no extra upstream request.
- **github-card** threads the counts into the composer prop.
- **github-card-composer** seeds its chip row from the counts and drops the mount-time reactions fetch entirely.

The bead's embedded product call is resolved the way its own analysis leans: the issue payload carries no viewer-reaction ids (needed for the "mine" highlight and DELETE), so the full list hydrates **lazily on first pointer/keyboard contact** with a chip. A toggle that beats hydration — touch has no hover — fetches the list before deciding add-vs-remove, because guessing would double-add on an already-reacted item. Until hydration, chips show counts un-highlighted.

Net: rest-state cards cost 3 requests instead of 4 (open PRs; issues drop from 2 to 1), and the reactions route is only hit by users who actually approach the chip row.

## Tests

Wiring pins added in `github-card-wiring.test.ts` for all four legs: the route folds counts, the card threads them, the composer seeds without a mount fetch (`doesNotMatch` on any reactions-fetching effect), and the toggle hydrates before deciding. `api-contracts`, `github-view-polish` green; `tsc --noEmit` clean.

Closes cave-6p628 (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)