### PR TITLE
fix(tests): fail the drift gate fast under the CSS facade hook

### DIFF
--- a/src/lib/design-token-drift.test.ts
+++ b/src/lib/design-token-drift.test.ts
@@ -18,12 +18,37 @@
 // The codemod's px→token tables are pinned against the live definitions in
 // src/app/globals.css, so a token retune fails loudly instead of letting the
 // codemod silently rewrite to stale values.
+//
+// RUN THIS FILE WITHOUT THE CSS FACADE HOOK. This gate measures the PHYSICAL
+// CSS tree, so scripts/run-tests.mjs deliberately runs it without
+// `--require ./scripts/css-source-contract-hook.cjs` (RAW_SOURCE_SCANNER_TESTS).
+// Under the hook — the incantation every OTHER source-contract test wants —
+// fs.readFileSync inlines import facades and every imported sheet is counted
+// twice, inflating the ratchets ~1.6x into convincing but bogus "went UP"
+// failures. The guard below fails fast instead (cave-d1a0p).
 
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import cssContract from "../../scripts/css-source-contract.cjs";
+
+// Self-defense: compare a facade read through (possibly patched) fs against
+// the contract module's raw reader, which bound the original readFileSync
+// before any hook could patch it. A mismatch means the facade hook is active
+// and every number this gate would produce is wrong.
+{
+  const probe = new URL("../app/globals.css", import.meta.url);
+  // assert.ok, not assert.equal: on failure the message is the diagnosis —
+  // dumping two copies of the expanded stylesheet as a diff would bury it.
+  assert.ok(
+    readFileSync(probe, "utf8") === cssContract.readRawCssSync(probe, "utf8"),
+    "design-token-drift.test.ts must run WITHOUT --require ./scripts/css-source-contract-hook.cjs " +
+      "(see RAW_SOURCE_SCANNER_TESTS in scripts/run-tests.mjs). The facade hook inlines CSS imports, " +
+      "double-counting every imported sheet and inflating the ratchets with false drift. " +
+      "Run: node --experimental-strip-types --import ./scripts/test-alias-register.mjs --test src/lib/design-token-drift.test.ts",
+  );
+}
 
 import {
   tokenizeCss,


### PR DESCRIPTION
## Summary

Implements **cave-d1a0p**: run `design-token-drift.test.ts` with the css-source-contract hook — the incantation documented for TS tests generally, and the one a contributor reaches for when running a single file by hand — and the patched `readFileSync` inlines CSS import facades, counting every imported sheet twice. The ratchets inflate ~1.6x into convincing but entirely bogus "went UP" failures whose message actively coaches you to raise the baseline, which would silently bank ~1000 phantom violations and permanently defeat the ratchet. (This misled a real PR diagnosis once already, per the bead — and misled me during cave-8ppoa before I found the runner's `RAW_SOURCE_SCANNER_TESTS` carve-out.)

The gate now **self-defends instead of relying on the runner**: it compares a facade read through (possibly patched) `fs.readFileSync` against `cssContract.readRawCssSync` — which bound the original before any hook could patch it — and fails fast with the correct incantation in the message. This functional check defends against any patching, not just the current hook (no marker/env coordination needed). The file header documents the exception alongside the existing why-physical-tree rationale. `assert.ok` rather than `assert.equal`, so a failure prints the diagnosis, not a diff of two expanded stylesheets.

## Verification

- Correct incantation (no hook): passes at exact baseline.
- Hooked incantation: fails immediately with *"must run WITHOUT --require ./scripts/css-source-contract-hook.cjs (see RAW_SOURCE_SCANNER_TESTS…)"* instead of false drift numbers.
- CI is unaffected: `run-tests.mjs` already runs this file hook-free.

Closes cave-d1a0p (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)