### PR TITLE
feat(desktop): add Discord Rich Presence

### DIFF
--- a/docs/discord-rich-presence.md
+++ b/docs/discord-rich-presence.md
@@ -1,0 +1,42 @@
+# Discord Rich Presence
+
+CovenCave publishes a generic, privacy-safe activity to a locally running
+Discord desktop client. It does not require a bot, OAuth, a client secret, or
+any user content.
+
+## One-time Discord setup
+
+1. In the Discord Developer Portal, create an OpenCoven-managed application
+   named `CovenCave`.
+2. Use [`assets/brand/cave-icon.png`](../assets/brand/cave-icon.png) as both
+   its application icon and a Rich Presence Art Asset named `covencave`.
+   Discord lowercases asset keys; keep this key stable.
+3. Set the application website to `https://covencave.ai` and repository to
+   `https://github.com/OpenCoven/coven-cave`.
+4. Provide its public Application ID as `COVENCAVE_DISCORD_APPLICATION_ID` at
+   build time. The ID is not a secret. Never add a client secret, bot token,
+   OAuth credential, project name, repository path, prompt, memory, terminal
+   output, or conversation data to the presence payload.
+
+For a local desktop build, set the variable before launching the app:
+
+```bash
+COVENCAVE_DISCORD_APPLICATION_ID=<public-application-id> pnpm dev:app
+```
+
+Release builds must receive the same public variable. Without it, CovenCave
+continues normally and logs that Discord activity is disabled.
+
+## Verify
+
+1. Start the installed Discord desktop client and enable detected-activity
+   sharing in its Activity Privacy settings.
+2. Run `cargo check --manifest-path src-tauri/Cargo.toml`.
+3. Launch CovenCave with `pnpm dev:app` and inspect its Discord profile card.
+   It should show the Cave icon, generic status, and elapsed time.
+4. From a second Discord account, confirm the two public buttons point to
+   CovenCave and its GitHub repository. Discord does not show the publisher
+   its own Rich Presence buttons.
+
+The worker retries while Discord is closed and reconnects after Discord
+restarts. The native app icon and Discord art asset are managed separately.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -80,6 +80,7 @@ name = "app"
 version = "0.2.1"
 dependencies = [
  "block2",
+ "discord-rich-presence",
  "fs2",
  "libc",
  "log",
@@ -582,7 +583,7 @@ checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
 dependencies = [
  "byteorder",
  "fnv",
- "uuid",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -886,6 +887,21 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "discord-rich-presence"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90c55d69cab17c19677ce3a5f8face993a9e6eaf847fecac3547f3a3ff4a2494"
+dependencies = [
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "thiserror 2.0.18",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3413,7 +3429,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -3581,7 +3597,7 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
- "uuid",
+ "uuid 1.23.2",
 ]
 
 [[package]]
@@ -4311,7 +4327,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "url",
- "uuid",
+ "uuid 1.23.2",
  "walkdir",
 ]
 
@@ -4532,7 +4548,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "url",
  "urlpattern",
- "uuid",
+ "uuid 1.23.2",
  "walkdir",
 ]
 
@@ -5080,6 +5096,15 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "uuid"
@@ -6067,7 +6092,7 @@ dependencies = [
  "serde_repr",
  "tracing",
  "uds_windows",
- "uuid",
+ "uuid 1.23.2",
  "windows-sys 0.61.2",
  "winnow 1.0.3",
  "zbus_macros",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -54,6 +54,9 @@ portable-pty = "0.8"
 # desktop-only (mobile updates via the App Store / TestFlight).
 tauri-plugin-updater = "2"
 tauri-plugin-process = "2"
+# Direct desktop IPC to the locally running Discord client. This remains out
+# of mobile targets because Discord Rich Presence has no mobile client API.
+discord-rich-presence = "1.1.0"
 
 # Windows packages the large Next.js sidecar as one archive instead of one
 # WiX component per file. The launcher verifies and extracts it on first use.

--- a/src-tauri/src/discord_presence.rs
+++ b/src-tauri/src/discord_presence.rs
@@ -40,6 +40,27 @@ fn build_activity(started_at: i64) -> activity::Activity<'static> {
         ])
 }
 
+fn publish_activity(client: &mut impl DiscordIpc, started_at: i64) -> Result<(), String> {
+    client
+        .set_activity(build_activity(started_at))
+        .map_err(|error| error.to_string())?;
+    loop {
+        let (opcode, response) = client.recv().map_err(|error| error.to_string())?;
+        match opcode {
+            1 => {
+                if response.get("evt").is_some_and(|event| !event.is_null()) {
+                    return Err("Discord rejected the activity update".into());
+                }
+                return Ok(());
+            }
+            3 => client
+                .send(response, 4)
+                .map_err(|error| error.to_string())?,
+            _ => return Err(format!("unexpected Discord IPC opcode {opcode}")),
+        }
+    }
+}
+
 /// Starts one reconnecting IPC worker for the local Discord desktop client.
 ///
 /// The payload is intentionally generic: it never publishes local projects,
@@ -66,7 +87,7 @@ pub fn start() {
 
                 let mut first_publish = true;
                 loop {
-                    match client.set_activity(build_activity(started_at)) {
+                    match publish_activity(&mut client, started_at) {
                         Ok(()) => {
                             if first_publish {
                                 log::info!("[discord-presence] CovenCave presence published");
@@ -92,7 +113,79 @@ pub fn start() {
 
 #[cfg(test)]
 mod tests {
-    use super::{build_activity, ASSET_KEY};
+    use super::{build_activity, publish_activity, ASSET_KEY};
+    use discord_rich_presence::{activity, error::Error, DiscordIpc};
+    use serde_json::{json, Value};
+    use std::collections::VecDeque;
+
+    struct RecordingClient {
+        activity_published: bool,
+        responses_read: usize,
+        responses: VecDeque<(u32, Value)>,
+        sent_frames: Vec<(u8, Value)>,
+    }
+
+    impl RecordingClient {
+        fn new() -> Self {
+            Self {
+                activity_published: false,
+                responses_read: 0,
+                responses: VecDeque::from([(1, json!({ "evt": null }))]),
+                sent_frames: Vec::new(),
+            }
+        }
+
+        fn with_response(opcode: u32, response: Value) -> Self {
+            Self::with_responses([(opcode, response)])
+        }
+
+        fn with_responses(responses: impl IntoIterator<Item = (u32, Value)>) -> Self {
+            Self {
+                responses: responses.into_iter().collect(),
+                ..Self::new()
+            }
+        }
+    }
+
+    impl DiscordIpc for RecordingClient {
+        fn get_client_id(&self) -> &str {
+            "test-client"
+        }
+
+        fn connect_ipc(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn write(&mut self, _data: &[u8]) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn read(&mut self, _buffer: &mut [u8]) -> Result<(), Error> {
+            Ok(())
+        }
+
+        fn send(&mut self, data: Value, opcode: u8) -> Result<(), Error> {
+            self.sent_frames.push((opcode, data));
+            Ok(())
+        }
+
+        fn set_activity(&mut self, _activity_payload: activity::Activity<'_>) -> Result<(), Error> {
+            self.activity_published = true;
+            Ok(())
+        }
+
+        fn recv(&mut self) -> Result<(u32, Value), Error> {
+            self.responses_read += 1;
+            Ok(self
+                .responses
+                .pop_front()
+                .expect("test client needs a queued response"))
+        }
+
+        fn close(&mut self) -> Result<(), Error> {
+            Ok(())
+        }
+    }
 
     #[test]
     fn activity_is_generic_and_uses_the_stable_cave_asset_key() {
@@ -108,5 +201,53 @@ mod tests {
             serialized["buttons"][1]["url"],
             "https://github.com/OpenCoven/coven-cave"
         );
+    }
+
+    #[test]
+    fn publishing_consumes_the_activity_response() {
+        let mut client = RecordingClient::new();
+
+        publish_activity(&mut client, 1_700_000_000).expect("activity should publish");
+
+        assert!(client.activity_published);
+        assert_eq!(client.responses_read, 1);
+    }
+
+    #[test]
+    fn publishing_rejects_non_frame_responses() {
+        let mut client = RecordingClient::with_response(2, json!({ "code": 4000 }));
+
+        let result = publish_activity(&mut client, 1_700_000_000);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn publishing_rejects_discord_error_events() {
+        let mut client = RecordingClient::with_response(
+            1,
+            json!({
+                "evt": "ERROR",
+                "data": { "code": 4000, "message": "invalid activity" }
+            }),
+        );
+
+        let result = publish_activity(&mut client, 1_700_000_000);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn publishing_answers_ping_before_reading_activity_response() {
+        let ping_payload = json!({ "nonce": "ping-1" });
+        let mut client = RecordingClient::with_responses([
+            (3, ping_payload.clone()),
+            (1, json!({ "evt": null })),
+        ]);
+
+        publish_activity(&mut client, 1_700_000_000).expect("activity should publish");
+
+        assert_eq!(client.responses_read, 2);
+        assert_eq!(client.sent_frames, [(4, ping_payload)]);
     }
 }

--- a/src-tauri/src/discord_presence.rs
+++ b/src-tauri/src/discord_presence.rs
@@ -1,0 +1,112 @@
+//! Privacy-safe Discord Rich Presence for the desktop shell.
+//!
+//! `COVENCAVE_DISCORD_APPLICATION_ID` is a public Discord application ID,
+//! supplied at build time after the OpenCoven-managed Discord application has
+//! been created. It is deliberately optional until that application exists:
+//! an unconfigured build must remain fully functional when Discord is absent.
+
+use discord_rich_presence::{activity, DiscordIpc, DiscordIpcClient};
+use std::{
+    thread,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+const DISCORD_APPLICATION_ID: Option<&str> = option_env!("COVENCAVE_DISCORD_APPLICATION_ID");
+const ASSET_KEY: &str = "covencave";
+const RETRY_DELAY: Duration = Duration::from_secs(15);
+const REFRESH_DELAY: Duration = Duration::from_secs(60);
+
+fn unix_now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64
+}
+
+fn build_activity(started_at: i64) -> activity::Activity<'static> {
+    activity::Activity::new()
+        .details("Desktop control room for OpenCoven")
+        .state("Working with familiars")
+        .timestamps(activity::Timestamps::new().start(started_at))
+        .assets(
+            activity::Assets::new()
+                .large_image(ASSET_KEY)
+                .large_text("CovenCave")
+                .large_url("https://covencave.ai"),
+        )
+        .buttons(vec![
+            activity::Button::new("Open CovenCave", "https://covencave.ai"),
+            activity::Button::new("View on GitHub", "https://github.com/OpenCoven/coven-cave"),
+        ])
+}
+
+/// Starts one reconnecting IPC worker for the local Discord desktop client.
+///
+/// The payload is intentionally generic: it never publishes local projects,
+/// repositories, prompts, terminal output, memory, or conversation content.
+pub fn start() {
+    let Some(application_id) = DISCORD_APPLICATION_ID else {
+        log::warn!(
+            "[discord-presence] COVENCAVE_DISCORD_APPLICATION_ID is not configured; Discord activity is disabled"
+        );
+        return;
+    };
+
+    if let Err(error) = thread::Builder::new()
+        .name("discord-rich-presence".into())
+        .spawn(move || {
+            let started_at = unix_now();
+            loop {
+                let mut client = DiscordIpcClient::new(application_id);
+                if let Err(error) = client.connect() {
+                    log::debug!("[discord-presence] Discord unavailable: {error}");
+                    thread::sleep(RETRY_DELAY);
+                    continue;
+                }
+
+                let mut first_publish = true;
+                loop {
+                    match client.set_activity(build_activity(started_at)) {
+                        Ok(()) => {
+                            if first_publish {
+                                log::info!("[discord-presence] CovenCave presence published");
+                                first_publish = false;
+                            }
+                        }
+                        Err(error) => {
+                            log::debug!("[discord-presence] connection lost: {error}");
+                            break;
+                        }
+                    }
+                    thread::sleep(REFRESH_DELAY);
+                }
+
+                let _ = client.close();
+                thread::sleep(RETRY_DELAY);
+            }
+        })
+    {
+        log::warn!("[discord-presence] could not start worker: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{build_activity, ASSET_KEY};
+
+    #[test]
+    fn activity_is_generic_and_uses_the_stable_cave_asset_key() {
+        let activity = build_activity(1_700_000_000);
+        let serialized = serde_json::to_value(activity).expect("activity should serialize");
+
+        assert_eq!(serialized["details"], "Desktop control room for OpenCoven");
+        assert_eq!(serialized["state"], "Working with familiars");
+        assert_eq!(serialized["assets"]["large_image"], ASSET_KEY);
+        assert_eq!(serialized["timestamps"]["start"], 1_700_000_000);
+        assert_eq!(serialized["buttons"][0]["url"], "https://covencave.ai");
+        assert_eq!(
+            serialized["buttons"][1]["url"],
+            "https://github.com/OpenCoven/coven-cave"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -46,6 +46,8 @@ mod app_lifecycle_tests;
 #[cfg(desktop)]
 pub mod browser;
 #[cfg(desktop)]
+mod discord_presence;
+#[cfg(desktop)]
 mod desktop_reachability;
 #[cfg(desktop)]
 mod platform_lifecycle;

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -307,6 +307,7 @@ pub fn run() {
 
             app.handle().plugin(tauri_plugin_notification::init())?;
             prepare_gui_reachability(app.handle())?;
+            discord_presence::start();
 
             // Desktop auto-update: updater checks/downloads/installs signed
             // release artifacts; process provides relaunch() after install.


### PR DESCRIPTION
## Summary
- reland Timothy Wayne Gregg's Discord Rich Presence contribution from #4093 through a trusted internal branch so the required CodeQL upload can run
- publish only a generic, privacy-safe desktop activity with CovenCave and GitHub links
- reconnect after Discord starts or restarts, consume each IPC acknowledgement, and answer interleaved PING frames
- document the one-time Discord application and asset setup

## Privacy
The presence never exposes local projects, repository paths, prompts, terminal output, memory, conversations, secrets, or user data. It remains disabled when `COVENCAVE_DISCORD_APPLICATION_ID` is absent.

## Verification
- `rustfmt --check src-tauri/src/discord_presence.rs`
- `git diff --check`
- `cargo test --manifest-path src-tauri/Cargo.toml discord_presence::tests`
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- independent pre-merge review approved

## Attribution
Relands #4093 by @CompleteDotTech. The squash commit must retain Timothy's numeric no-reply `Co-authored-by` trailer.