### PR TITLE
refactor(memory): one search policy for every familiar-memory surface

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -883,6 +883,7 @@ export const SUITES = {
     "src/components/chat-surface-projects-tab.test.ts",
     "src/components/composer-density.test.ts",
     "src/lib/memory-rows.test.ts",
+    "src/lib/memory-search-policy.test.ts",
     "src/lib/memory-feed-request-gate.test.ts",
     "src/lib/local-daemon-readiness.test.ts",
     "src/lib/memory-file-scope.test.ts",

--- a/src/components/familiars-memory-utils.ts
+++ b/src/components/familiars-memory-utils.ts
@@ -1,4 +1,5 @@
 import type { CanonicalMemorySummary } from "@/lib/canonical-memory";
+import { canonicalMemoryMatches, fileMemoryMatches } from "@/lib/memory-search-policy";
 
 export type FileMemoryEntry = {
   root: string;
@@ -50,27 +51,10 @@ export function memoryMatches(
   entry: CanonicalMemorySummary | FileMemoryEntry,
   query: string,
 ): boolean {
-  if (!query) return true;
-  const values = "verification" in entry
-    ? [
-        entry.title,
-        entry.excerpt,
-        entry.familiarId,
-        entry.source.kind,
-        entry.source.label,
-        entry.privacy.classification ?? "",
-        entry.verification.state,
-      ]
-    : [
-        entry.rootLabel,
-        entry.sourceKindLabel,
-        entry.harnessId ?? "",
-        entry.runtimeId ?? "",
-        entry.origin ?? "",
-        entry.familiarId ?? "",
-        entry.relPath,
-        entry.fullPath,
-        entry.sourceContext ?? "",
-      ];
-  return values.some((value) => value.toLowerCase().includes(query));
+  // One policy for every memory surface (cave-she6o.1): canonical summaries
+  // search only the safe field allowlist; files search the unified field
+  // union. See src/lib/memory-search-policy.ts for the rationale.
+  return "verification" in entry
+    ? canonicalMemoryMatches(entry, query)
+    : fileMemoryMatches(entry, query);
 }

--- a/src/lib/memory-rows.ts
+++ b/src/lib/memory-rows.ts
@@ -1,4 +1,5 @@
 import type { CanonicalMemorySummary } from "./canonical-memory.ts";
+import { canonicalMemoryMatches, fileMemoryMatches } from "./memory-search-policy.ts";
 import {
   classifyProtection,
   detectStale,
@@ -138,45 +139,13 @@ function baseName(path: string): string {
   return segments[segments.length - 1] ?? path;
 }
 
-function canonicalMatches(entry: CanonicalMemorySummary, query: string): boolean {
-  if (!query) return true;
-  return [
-    entry.title,
-    entry.excerpt,
-    entry.familiarId,
-    entry.source.kind,
-    entry.source.label,
-    entry.privacy.classification ?? "",
-    entry.verification.state,
-  ]
-    .join(" ")
-    .toLowerCase()
-    .includes(query);
-}
-
-function fileMatches(entry: RawFileEntry, query: string): boolean {
-  if (!query) return true;
-  return [
-    entry.title ?? "",
-    entry.relPath,
-    entry.fullPath,
-    entry.sourceKind,
-    entry.sourceKindLabel,
-    entry.rootLabel,
-    entry.familiarId ?? "",
-    entry.excerpt ?? "",
-  ]
-    .join(" ")
-    .toLowerCase()
-    .includes(query);
-}
 
 export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
   const query = args.query.trim().toLowerCase();
 
   const canonicalRows: CanonicalMemoryRow[] = args.canonical
     .filter((entry) => entry.familiarId === args.familiarFilter)
-    .filter((entry) => canonicalMatches(entry, query))
+    .filter((entry) => canonicalMemoryMatches(entry, query))
     .map((entry) => ({
       kind: "canonical",
       rowId: `coven:${entry.id}`,
@@ -198,7 +167,7 @@ export function buildMemoryRows(args: BuildArgs): MemoryRow[] {
         args.sourceFilter === "all" || entry.sourceKind === args.sourceFilter,
     )
     .filter((entry) => entry.familiarId === args.familiarFilter)
-    .filter((entry) => fileMatches(entry, query))
+    .filter((entry) => fileMemoryMatches(entry, query))
     .map((entry) => {
       const managed = normalizeFileEntry(entry);
       return {

--- a/src/lib/memory-search-policy.test.ts
+++ b/src/lib/memory-search-policy.test.ts
@@ -1,0 +1,105 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  canonicalMemoryMatches,
+  canonicalSearchFields,
+  fileMemoryMatches,
+  fileSearchFields,
+} from "./memory-search-policy.ts";
+
+const canonicalEntry = {
+  id: "mem-1",
+  title: "Release ritual",
+  excerpt: "Bump eight files before tagging",
+  familiarId: "sage",
+  source: { kind: "conversation", label: "Chat with Sage" },
+  privacy: { classification: "internal" },
+  verification: { state: "verified" },
+  updatedAt: "2026-07-31T00:00:00Z",
+  // Fields a canonical summary may carry but search must NEVER see:
+  fullPath: "/Users/someone/.coven/memory/secret-location.md",
+  raw: "unredacted body text",
+  privateDetail: "do not leak",
+};
+
+// ── canonical: the safe-field allowlist is the whole story ──────────────────
+
+assert.deepEqual(
+  canonicalSearchFields(canonicalEntry),
+  ["Release ritual", "Bump eight files before tagging", "sage", "conversation", "Chat with Sage", "internal", "verified"],
+  "canonical search sees exactly the seven safe fields",
+);
+
+// The strongest guard: a proxy records every property canonical search READS.
+// If a future edit sneaks a path/raw/private field into the policy, this
+// fails even if the value happens not to match the query.
+{
+  const accessed = new Set();
+  const record = (target, prefix = "") =>
+    new Proxy(target, {
+      get(t, key) {
+        if (typeof key === "string") accessed.add(`${prefix}${key}`);
+        const value = t[key];
+        return value && typeof value === "object" ? record(value, `${prefix}${String(key)}.`) : value;
+      },
+    });
+  canonicalMemoryMatches(record(canonicalEntry), "anything");
+  const allowed = new Set([
+    "title", "excerpt", "familiarId",
+    "source", "source.kind", "source.label",
+    "privacy", "privacy.classification",
+    "verification", "verification.state",
+  ]);
+  const leaked = [...accessed].filter((key) => !allowed.has(key));
+  assert.deepEqual(leaked, [], `canonical search read fields outside the allowlist: ${leaked.join(", ")}`);
+}
+
+assert.equal(canonicalMemoryMatches(canonicalEntry, "ritual"), true);
+assert.equal(canonicalMemoryMatches(canonicalEntry, "secret-location"), false, "paths are not searchable on canonical entries");
+assert.equal(canonicalMemoryMatches(canonicalEntry, "unredacted"), false, "raw bodies are not searchable on canonical entries");
+assert.equal(canonicalMemoryMatches(canonicalEntry, ""), true, "empty query matches everything");
+
+// Per-field semantics: a query spanning two adjacent fields must NOT match.
+// (The old master-detail matcher joined fields with spaces, so
+// "tagging sage" — excerpt end + familiarId — matched with no single field
+// justifying it. That drift is retired.)
+assert.equal(
+  canonicalMemoryMatches(canonicalEntry, "tagging sage"),
+  false,
+  "queries cannot span field boundaries",
+);
+
+// ── files: the unified union keeps every historically-findable entry ────────
+
+const fileEntry = {
+  relPath: "memory/notes.md",
+  fullPath: "/home/x/.coven/workspaces/familiars/opal/memory/notes.md",
+  sourceKind: "coven-origin",
+  sourceKindLabel: "Coven workspace files",
+  rootLabel: "Opal workspace",
+  title: "Standup notes",
+  excerpt: "Discussed the release",
+  familiarId: "opal",
+  harnessId: "openclaw",
+  runtimeId: "codex",
+  origin: "coven",
+  sourceContext: "workspace scan",
+};
+
+assert.equal(fileSearchFields(fileEntry).length, 12, "file search unions both views' historical field sets");
+// Master-detail historically matched these; the compact view must too now:
+assert.equal(fileMemoryMatches(fileEntry, "standup"), true, "title stays searchable");
+assert.equal(fileMemoryMatches(fileEntry, "discussed"), true, "excerpt stays searchable");
+assert.equal(fileMemoryMatches(fileEntry, "coven-origin"), true, "sourceKind stays searchable");
+// The compact view historically matched these; master-detail must too now:
+assert.equal(fileMemoryMatches(fileEntry, "openclaw"), true, "harnessId stays searchable");
+assert.equal(fileMemoryMatches(fileEntry, "workspace scan"), true, "sourceContext stays searchable");
+// Paths are fair game for local files (unlike canonical summaries).
+assert.equal(fileMemoryMatches(fileEntry, "familiars/opal"), true, "file paths stay searchable");
+// Optional fields absent → no crash, no phantom match.
+assert.equal(
+  fileMemoryMatches({ ...fileEntry, title: undefined, excerpt: undefined, harnessId: undefined }, "standup"),
+  false,
+);
+
+console.log("memory-search-policy.test.ts: ok");

--- a/src/lib/memory-search-policy.ts
+++ b/src/lib/memory-search-policy.ts
@@ -1,0 +1,90 @@
+import type { CanonicalMemorySummary } from "./canonical-memory.ts";
+
+/**
+ * One familiar-memory search policy for every surface (cave-she6o.1).
+ *
+ * The compact view (familiars-memory-utils' memoryMatches) and the
+ * master-detail view (memory-rows' canonicalMatches/fileMatches) each grew
+ * their own copy of this logic; the canonical field lists agreed but the
+ * match semantics and file field sets had drifted. Both now consume this
+ * module, so a field added or removed here changes every surface together.
+ */
+
+/**
+ * The ONLY fields canonical search may see. Storage paths, raw bodies, and
+ * private detail fields are deliberately absent: canonical summaries reach
+ * surfaces that must never leak where a memory lives or what its unredacted
+ * content says. Widening this list is a privacy decision, not a convenience —
+ * memory-search-policy.test.ts proxies an entry to prove no other property
+ * is even read.
+ */
+export function canonicalSearchFields(entry: CanonicalMemorySummary): string[] {
+  return [
+    entry.title,
+    entry.excerpt,
+    entry.familiarId,
+    entry.source.kind,
+    entry.source.label,
+    entry.privacy.classification ?? "",
+    entry.verification.state,
+  ];
+}
+
+/**
+ * Per-field substring match. Deliberately NOT a joined-string match: joining
+ * with spaces let a query span two adjacent fields ("excerpt-end familiarId")
+ * and match rows no single field justified — one of the drifts this module
+ * retires.
+ */
+export function canonicalMemoryMatches(entry: CanonicalMemorySummary, query: string): boolean {
+  if (!query) return true;
+  return canonicalSearchFields(entry).some((value) => value.toLowerCase().includes(query));
+}
+
+/**
+ * Structural view of a searchable file entry: covers memory-rows'
+ * RawFileEntry and the components' FileMemoryEntry without importing either.
+ */
+export type FileSearchableEntry = {
+  relPath: string;
+  fullPath: string;
+  sourceKind: string;
+  sourceKindLabel: string;
+  rootLabel: string;
+  title?: string | null;
+  excerpt?: string | null;
+  familiarId?: string | null;
+  harnessId?: string | null;
+  runtimeId?: string | null;
+  origin?: string | null;
+  sourceContext?: string | null;
+};
+
+/**
+ * File search fields: the union of what the two views historically matched
+ * (the master-detail view knew title/excerpt/sourceKind; the compact view
+ * knew harnessId/runtimeId/origin/sourceContext), so no previously-findable
+ * file becomes unfindable in either view. Files are local artifacts the user
+ * already owns — paths are searchable here, unlike canonical summaries.
+ */
+export function fileSearchFields(entry: FileSearchableEntry): string[] {
+  return [
+    entry.title ?? "",
+    entry.excerpt ?? "",
+    entry.relPath,
+    entry.fullPath,
+    entry.sourceKind,
+    entry.sourceKindLabel,
+    entry.rootLabel,
+    entry.familiarId ?? "",
+    entry.harnessId ?? "",
+    entry.runtimeId ?? "",
+    entry.origin ?? "",
+    entry.sourceContext ?? "",
+  ];
+}
+
+export function fileMemoryMatches(entry: FileSearchableEntry, query: string): boolean {
+  if (!query) return true;
+  return fileSearchFields(entry).some((value) => value.toLowerCase().includes(query));
+}


### PR DESCRIPTION
## Summary

Implements **cave-she6o.1**: the compact and master-detail familiar-memory views each carried their own filtering logic. The canonical field lists agreed but the semantics had drifted (the master-detail matcher joined fields with spaces, so a query could span two adjacent fields and match rows no single field justified), and the **file** field sets had diverged entirely — `title`/`excerpt`/`sourceKind` searchable in one view, `harnessId`/`runtimeId`/`origin`/`sourceContext` in the other.

Both views now consume one policy module, `src/lib/memory-search-policy.ts`:

- **`canonicalSearchFields` is the safe allowlist** — exactly the seven path-free, raw-free fields both views already used. The test **proxies an entry and records every property search reads**, failing if anything outside the allowlist is even touched — so canonical search cannot silently gain path/raw/private fields, per the bead's acceptance criteria, even when the leaked value doesn't match the query.
- **Per-field matching everywhere**; the cross-field span behavior is retired (pinned by a test).
- **`fileSearchFields` is the union** of both views' historical sets, so no previously-findable file becomes unfindable in either view. Paths stay searchable for files (local artifacts the user owns) and never for canonical summaries.

File filter/sort/staleness behavior is untouched — both views already shared `detectStale`/`normalizeFileEntry`; the drift was confined to search.

## Verification

New `memory-search-policy.test.ts` (allowlist pin, proxy leak guard, span-query retirement, union coverage in both directions, optional-field safety) plus the existing memory family (`memory-rows`, filter-paginate, sources, master-detail, canonical) — 14 test files green with no expectation changes. `check:tests-wired` green; `tsc --noEmit` clean.

Closes cave-she6o.1 (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)