### PR TITLE
feat(git-hygiene): repository maintenance-gate lease core

### DIFF
--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -1,0 +1,399 @@
+// Repository maintenance gate — local fail-closed core (cave-wqa0b.1).
+//
+// Branch/worktree deletion proofs need repository-wide exclusion: while a
+// curator audits final ownership, no other writer may mutate the repository,
+// and while any writer is mid-work, the curator must not start. The existing
+// guards are advisory (claims, PID snapshots); this module is the first
+// NON-advisory layer: an atomic exclusive gate plus writer-intent leases,
+// with generation fencing, bounded lifetimes, an append-only audit log, and
+// owner revalidation for postcondition checks.
+//
+// Scope: repository-LOCAL only. Coven-session enforcement (wqa0b.2), the
+// Beads pre-write hook (wqa0b.3), and the GitHub-side transaction (wqa0b.4)
+// build on this; until they land, full cross-system exclusion must not be
+// claimed.
+//
+// Storage lives under the shared Git COMMON directory so every linked
+// worktree sees one gate:
+//   <git-common-dir>/coven-maintenance-gate/
+//     gate.json          exclusive ownership (O_EXCL-created, rename-replaced)
+//     generation         monotonic high-water mark across takeovers
+//     intents/<id>.json  writer-intent leases
+//     audit.jsonl        append-only acquisition/release/reject trail
+//
+// Fail-closed rules:
+//   - A malformed gate or intent file is never silently reclaimed: gate
+//     acquisition and writer intents both refuse until a human (or an
+//     explicit stale-takeover for EXPIRED-but-well-formed gates) resolves it.
+//   - Only the owner holding the exact (generation, token) pair can
+//     heartbeat, verify, or release.
+//   - There is no bypass parameter. Consumers that skip this module entirely
+//     are out of scope here and closed off by wqa0b.2–.4.
+
+import {
+  appendFileSync,
+  realpathSync,
+  closeSync,
+  mkdirSync,
+  openSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+  constants as fsConstants,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+export const DEFAULT_GATE_TTL_MS = 10 * 60_000;
+export const DEFAULT_INTENT_TTL_MS = 2 * 60_000;
+export const DEFAULT_QUIESCE_TIMEOUT_MS = 30_000;
+const QUIESCE_POLL_MS = 100;
+
+/** Synchronous sleep without CPU spin (callers are sync CLI/hook processes). */
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+export function maintenanceGateRoot(repoDir = process.cwd()) {
+  const commonDir = execFileSync("git", ["rev-parse", "--git-common-dir"], {
+    cwd: repoDir,
+    encoding: "utf8",
+  }).trim();
+  // realpath: a linked worktree's gitdir stores the canonical absolute path
+  // while the main checkout may reach the same directory through a symlink
+  // alias (macOS /var → /private/var). One gate requires one canonical root.
+  return path.join(realpathSync(path.resolve(repoDir, commonDir)), "coven-maintenance-gate");
+}
+
+const gatePath = (root) => path.join(root, "gate.json");
+const generationPath = (root) => path.join(root, "generation");
+const intentsDir = (root) => path.join(root, "intents");
+const auditPath = (root) => path.join(root, "audit.jsonl");
+
+function audit(root, event, detail) {
+  mkdirSync(root, { recursive: true });
+  appendFileSync(
+    auditPath(root),
+    JSON.stringify({ at: new Date().toISOString(), pid: process.pid, event, ...detail }) + "\n",
+  );
+}
+
+/** Parse a state file strictly. Returns {ok,value} | {ok:false,malformed:true} | {ok:false,missing:true}. */
+function readJsonState(filePath, requiredKeys) {
+  let raw;
+  try {
+    raw = readFileSync(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") return { ok: false, missing: true };
+    return { ok: false, malformed: true };
+  }
+  try {
+    const value = JSON.parse(raw);
+    if (!value || typeof value !== "object") return { ok: false, malformed: true };
+    for (const key of requiredKeys) {
+      if (!(key in value)) return { ok: false, malformed: true };
+    }
+    return { ok: true, value };
+  } catch {
+    return { ok: false, malformed: true };
+  }
+}
+
+const GATE_KEYS = ["generation", "ownerId", "token", "phase", "acquiredAt", "heartbeatAt", "ttlMs", "purpose"];
+const INTENT_KEYS = ["writerId", "token", "registeredAt", "ttlMs", "purpose"];
+
+function gateExpired(gate, now) {
+  return now > Date.parse(gate.heartbeatAt) + gate.ttlMs;
+}
+
+function intentExpired(intent, now) {
+  return now > Date.parse(intent.registeredAt) + intent.ttlMs;
+}
+
+function writeExclusive(filePath, value) {
+  const fd = openSync(filePath, fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_WRONLY);
+  try {
+    writeFileSync(fd, JSON.stringify(value, null, 2));
+  } finally {
+    closeSync(fd);
+  }
+}
+
+function replaceAtomically(filePath, value) {
+  const temp = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(temp, JSON.stringify(value, null, 2));
+  renameSync(temp, filePath);
+}
+
+function nextGeneration(root, observed) {
+  let highWater = 0;
+  try {
+    highWater = Number.parseInt(readFileSync(generationPath(root), "utf8"), 10) || 0;
+  } catch {
+    /* first acquisition */
+  }
+  const generation = Math.max(highWater, observed) + 1;
+  writeFileSync(generationPath(root), String(generation));
+  return generation;
+}
+
+function listIntents(root, now) {
+  let names;
+  try {
+    names = readdirSync(intentsDir(root));
+  } catch {
+    return { live: [], malformed: [] };
+  }
+  const live = [];
+  const malformed = [];
+  for (const name of names) {
+    if (!name.endsWith(".json")) continue;
+    const filePath = path.join(intentsDir(root), name);
+    const parsed = readJsonState(filePath, INTENT_KEYS);
+    if (!parsed.ok) {
+      if (parsed.malformed) malformed.push(name);
+      continue; // vanished mid-scan = released
+    }
+    if (intentExpired(parsed.value, now)) {
+      // An expired lease no longer blocks the gate; leave the file for the
+      // audit trail — the owner's release removes it, and a fresh intent
+      // from the same writer id replaces it atomically below.
+      continue;
+    }
+    live.push(parsed.value);
+  }
+  return { live, malformed };
+}
+
+/**
+ * Register a writer-intent lease. Writers call this BEFORE mutating the
+ * repository; the lease is what maintenance acquisition drains against.
+ * Rejected whenever a gate exists — held, draining, expired, or malformed —
+ * because a writer must never start under (or race the cleanup of) an
+ * exclusion it cannot see the end of.
+ */
+export function registerWriterIntent({
+  writerId,
+  purpose,
+  repoDir = process.cwd(),
+  ttlMs = DEFAULT_INTENT_TTL_MS,
+  now = Date.now(),
+} = {}) {
+  if (!writerId || /[/\\]/.test(writerId)) return { ok: false, reason: "invalid-writer-id" };
+  const root = maintenanceGateRoot(repoDir);
+  mkdirSync(intentsDir(root), { recursive: true });
+
+  const intent = {
+    writerId,
+    token: randomBytes(8).toString("hex"),
+    registeredAt: new Date(now).toISOString(),
+    ttlMs,
+    purpose: purpose ?? "",
+    pid: process.pid,
+  };
+  const filePath = path.join(intentsDir(root), `${writerId}.json`);
+  // Create-then-check ordering closes the race against a concurrent gate
+  // acquisition: whichever of {intent file, gate file} lands second, the
+  // writer self-revokes on seeing a gate, and the acquirer's drain sees any
+  // intent that beat it.
+  try {
+    writeExclusive(filePath, intent);
+  } catch (error) {
+    if (error?.code !== "EEXIST") throw error;
+    const existing = readJsonState(filePath, INTENT_KEYS);
+    if (existing.ok && !intentExpired(existing.value, now)) {
+      return { ok: false, reason: "writer-already-active" };
+    }
+    if (!existing.ok && existing.malformed) {
+      audit(root, "intent-rejected", { writerId, reason: "malformed-existing-intent" });
+      return { ok: false, reason: "malformed-existing-intent" };
+    }
+    replaceAtomically(filePath, intent); // own expired lease → renew
+  }
+
+  const gate = readJsonState(gatePath(root), GATE_KEYS);
+  if (!gate.missing) {
+    // Gate present in ANY state (or unreadable): fail closed and revoke.
+    try {
+      rmSync(filePath, { force: true });
+    } catch {
+      /* the drain treats a malformed leftover as blocking; owner retries */
+    }
+    const reason = gate.ok ? "maintenance-gate-held" : "maintenance-gate-unreadable";
+    audit(root, "intent-rejected", { writerId, reason });
+    return { ok: false, reason };
+  }
+
+  audit(root, "intent-registered", { writerId, token: intent.token, ttlMs });
+  return {
+    ok: true,
+    lease: { writerId, token: intent.token, root },
+  };
+}
+
+/** Release a writer-intent lease. Only the matching token releases. */
+export function releaseWriterIntent(lease) {
+  if (!lease?.root || !lease.writerId) return { ok: false, reason: "invalid-lease" };
+  const filePath = path.join(intentsDir(lease.root), `${lease.writerId}.json`);
+  const existing = readJsonState(filePath, INTENT_KEYS);
+  if (!existing.ok) return { ok: false, reason: existing.missing ? "not-held" : "malformed" };
+  if (existing.value.token !== lease.token) return { ok: false, reason: "not-owner" };
+  rmSync(filePath, { force: true });
+  audit(lease.root, "intent-released", { writerId: lease.writerId });
+  return { ok: true };
+}
+
+/**
+ * Acquire the exclusive maintenance gate.
+ *
+ * Sequence: atomically create gate.json in phase "draining" (new writers now
+ * fail closed), wait for pre-existing live intents to release or expire
+ * (writer-before-gate drains), then promote to phase "held". On drain
+ * timeout the gate is released and acquisition fails, naming the blockers.
+ *
+ * A well-formed EXPIRED gate can be taken over only with takeoverStale:true;
+ * the takeover bumps the fenced generation so the previous owner's token can
+ * never release or verify again. A MALFORMED gate always fails closed.
+ */
+export function acquireMaintenanceGate({
+  ownerId,
+  purpose,
+  repoDir = process.cwd(),
+  ttlMs = DEFAULT_GATE_TTL_MS,
+  quiesceTimeoutMs = DEFAULT_QUIESCE_TIMEOUT_MS,
+  takeoverStale = false,
+  now = Date.now(),
+} = {}) {
+  if (!ownerId) return { ok: false, reason: "invalid-owner-id" };
+  const root = maintenanceGateRoot(repoDir);
+  mkdirSync(intentsDir(root), { recursive: true });
+
+  const gateFile = gatePath(root);
+  const existing = readJsonState(gateFile, GATE_KEYS);
+  if (existing.ok && !gateExpired(existing.value, now)) {
+    return { ok: false, reason: "gate-held", holder: existing.value.ownerId };
+  }
+  if (!existing.ok && existing.malformed) {
+    audit(root, "acquire-rejected", { ownerId, reason: "malformed-gate" });
+    return { ok: false, reason: "malformed-gate" };
+  }
+  if (existing.ok) {
+    // Expired but well-formed.
+    if (!takeoverStale) return { ok: false, reason: "gate-stale", holder: existing.value.ownerId };
+    const staleName = `${gateFile}.stale-${existing.value.generation}-${Date.now().toString(36)}`;
+    try {
+      renameSync(gateFile, staleName); // atomic: exactly one taker wins
+    } catch {
+      return { ok: false, reason: "takeover-lost" };
+    }
+    audit(root, "gate-taken-over", { ownerId, from: existing.value.ownerId, generation: existing.value.generation });
+  }
+
+  const generation = nextGeneration(root, existing.ok ? existing.value.generation : 0);
+  const gate = {
+    generation,
+    ownerId,
+    token: randomBytes(12).toString("hex"),
+    phase: "draining",
+    acquiredAt: new Date(now).toISOString(),
+    heartbeatAt: new Date(now).toISOString(),
+    ttlMs,
+    purpose: purpose ?? "",
+    pid: process.pid,
+  };
+  try {
+    writeExclusive(gateFile, gate);
+  } catch (error) {
+    if (error?.code === "EEXIST") return { ok: false, reason: "gate-held" };
+    throw error;
+  }
+  audit(root, "gate-draining", { ownerId, generation });
+
+  // Drain: pre-existing live intents must release or expire.
+  const deadline = now + quiesceTimeoutMs;
+  for (;;) {
+    const current = Date.now();
+    const { live, malformed } = listIntents(root, current);
+    if (malformed.length > 0) {
+      rmSync(gateFile, { force: true });
+      audit(root, "acquire-rejected", { ownerId, generation, reason: "malformed-intent", files: malformed });
+      return { ok: false, reason: "malformed-intent", files: malformed };
+    }
+    if (live.length === 0) break;
+    if (current > deadline) {
+      rmSync(gateFile, { force: true });
+      const blockers = live.map((intent) => intent.writerId);
+      audit(root, "acquire-rejected", { ownerId, generation, reason: "quiesce-timeout", blockers });
+      return { ok: false, reason: "quiesce-timeout", blockers };
+    }
+    sleepSync(QUIESCE_POLL_MS);
+  }
+
+  replaceAtomically(gateFile, { ...gate, phase: "held" });
+  audit(root, "gate-acquired", { ownerId, generation });
+  return {
+    ok: true,
+    handle: { root, ownerId, generation, token: gate.token },
+  };
+}
+
+function readOwnedGate(handle) {
+  if (!handle?.root || !handle.token) return { ok: false, reason: "invalid-handle" };
+  const gate = readJsonState(gatePath(handle.root), GATE_KEYS);
+  if (!gate.ok) return { ok: false, reason: gate.missing ? "gate-missing" : "malformed-gate" };
+  if (gate.value.generation !== handle.generation || gate.value.token !== handle.token || gate.value.ownerId !== handle.ownerId) {
+    return { ok: false, reason: "not-owner" };
+  }
+  return { ok: true, gate: gate.value };
+}
+
+/**
+ * Owner-capability check for postconditions: true only while the exact
+ * fenced (generation, token) pair still owns an unexpired, held gate.
+ * Destructive completions call this immediately before and after their
+ * final verification so a takeover or expiry mid-audit invalidates the run.
+ */
+export function verifyMaintenanceGateOwnership(handle, now = Date.now()) {
+  const owned = readOwnedGate(handle);
+  if (!owned.ok) return { ok: false, reason: owned.reason };
+  if (owned.gate.phase !== "held") return { ok: false, reason: "not-held" };
+  if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
+  return { ok: true };
+}
+
+/** Extend the gate's lifetime. Only the matching fenced owner can heartbeat. */
+export function heartbeatMaintenanceGate(handle, now = Date.now()) {
+  const owned = readOwnedGate(handle);
+  if (!owned.ok) return { ok: false, reason: owned.reason };
+  if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
+  replaceAtomically(gatePath(handle.root), { ...owned.gate, heartbeatAt: new Date(now).toISOString() });
+  return { ok: true };
+}
+
+/** Release the gate. Only the matching fenced owner releases. */
+export function releaseMaintenanceGate(handle) {
+  const owned = readOwnedGate(handle);
+  if (!owned.ok) return { ok: false, reason: owned.reason };
+  rmSync(gatePath(handle.root), { force: true });
+  audit(handle.root, "gate-released", { ownerId: handle.ownerId, generation: handle.generation });
+  return { ok: true };
+}
+
+/** Read-only status for tooling and the guards built in wqa0b.2–.4. */
+export function maintenanceGateStatus(repoDir = process.cwd(), now = Date.now()) {
+  const root = maintenanceGateRoot(repoDir);
+  const gate = readJsonState(gatePath(root), GATE_KEYS);
+  const { live, malformed } = listIntents(root, now);
+  return {
+    gate: gate.ok
+      ? { ...gate.value, expired: gateExpired(gate.value, now) }
+      : gate.missing
+        ? null
+        : { malformed: true },
+    liveIntents: live.map((intent) => intent.writerId),
+    malformedIntents: malformed,
+  };
+}

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -18,6 +18,7 @@
 //   <git-common-dir>/coven-maintenance-gate/
 //     gate.json          exclusive ownership (O_EXCL-created, rename-replaced)
 //     generation         monotonic high-water mark across takeovers
+//     mutation.lock      non-reclaiming mutex for fenced state transitions
 //     intents/<id>.json  writer-intent leases
 //     audit.jsonl        append-only acquisition/release/reject trail
 //
@@ -34,6 +35,7 @@ import {
   appendFileSync,
   realpathSync,
   closeSync,
+  linkSync,
   mkdirSync,
   openSync,
   readdirSync,
@@ -43,14 +45,17 @@ import {
   writeFileSync,
   constants as fsConstants,
 } from "node:fs";
-import { randomBytes } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 
 export const DEFAULT_GATE_TTL_MS = 10 * 60_000;
 export const DEFAULT_INTENT_TTL_MS = 2 * 60_000;
 export const DEFAULT_QUIESCE_TIMEOUT_MS = 30_000;
+export const MAX_LEASE_TTL_MS = 24 * 60 * 60_000;
 const QUIESCE_POLL_MS = 100;
+const MUTATION_LOCK_POLL_MS = 10;
+const MUTATION_LOCK_WAIT_MS = 1_000;
 
 /** Synchronous sleep without CPU spin (callers are sync CLI/hook processes). */
 function sleepSync(ms) {
@@ -72,6 +77,11 @@ const gatePath = (root) => path.join(root, "gate.json");
 const generationPath = (root) => path.join(root, "generation");
 const intentsDir = (root) => path.join(root, "intents");
 const auditPath = (root) => path.join(root, "audit.jsonl");
+const mutationLockPath = (root) => path.join(root, "mutation.lock");
+const intentPath = (root, writerId) => {
+  const encodedId = createHash("sha256").update(writerId).digest("hex");
+  return path.join(intentsDir(root), `${encodedId}.json`);
+};
 
 function audit(root, event, detail) {
   mkdirSync(root, { recursive: true });
@@ -81,8 +91,8 @@ function audit(root, event, detail) {
   );
 }
 
-/** Parse a state file strictly. Returns {ok,value} | {ok:false,malformed:true} | {ok:false,missing:true}. */
-function readJsonState(filePath, requiredKeys) {
+/** Parse and schema-check state. Invalid values remain blocking until explicitly repaired. */
+function readJsonState(filePath, validate) {
   let raw;
   try {
     raw = readFileSync(filePath, "utf8");
@@ -92,25 +102,88 @@ function readJsonState(filePath, requiredKeys) {
   }
   try {
     const value = JSON.parse(raw);
-    if (!value || typeof value !== "object") return { ok: false, malformed: true };
-    for (const key of requiredKeys) {
-      if (!(key in value)) return { ok: false, malformed: true };
-    }
+    if (!validate(value)) return { ok: false, malformed: true };
     return { ok: true, value };
   } catch {
     return { ok: false, malformed: true };
   }
 }
 
-const GATE_KEYS = ["generation", "ownerId", "token", "phase", "acquiredAt", "heartbeatAt", "ttlMs", "purpose"];
-const INTENT_KEYS = ["writerId", "token", "registeredAt", "ttlMs", "purpose"];
+function isRecord(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function validTimestamp(value) {
+  if (typeof value !== "string") return false;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) && new Date(parsed).toISOString() === value;
+}
+
+function validTtl(value) {
+  return Number.isSafeInteger(value) && value > 0 && value <= MAX_LEASE_TTL_MS;
+}
+
+function validIdentity(value) {
+  return typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9._:@-]{0,127}$/.test(value);
+}
+
+function validPurpose(value) {
+  return typeof value === "string" && Buffer.byteLength(value, "utf8") <= 4_096;
+}
+
+function validToken(value, bytes) {
+  return typeof value === "string" && new RegExp(`^[a-f0-9]{${bytes * 2}}$`).test(value);
+}
+
+function validateGate(value) {
+  return (
+    isRecord(value) &&
+    Number.isSafeInteger(value.generation) &&
+    value.generation > 0 &&
+    validIdentity(value.ownerId) &&
+    validToken(value.token, 12) &&
+    (value.phase === "draining" || value.phase === "held") &&
+    validTimestamp(value.acquiredAt) &&
+    validTimestamp(value.heartbeatAt) &&
+    Date.parse(value.heartbeatAt) >= Date.parse(value.acquiredAt) &&
+    validTtl(value.ttlMs) &&
+    validPurpose(value.purpose) &&
+    Number.isSafeInteger(value.pid) &&
+    value.pid > 0
+  );
+}
+
+function validateIntent(value) {
+  return (
+    isRecord(value) &&
+    validIdentity(value.writerId) &&
+    validToken(value.token, 8) &&
+    validTimestamp(value.registeredAt) &&
+    validTimestamp(value.heartbeatAt) &&
+    Date.parse(value.heartbeatAt) >= Date.parse(value.registeredAt) &&
+    validTtl(value.ttlMs) &&
+    validPurpose(value.purpose) &&
+    Number.isSafeInteger(value.pid) &&
+    value.pid > 0
+  );
+}
+
+function validateMutationLock(value) {
+  return (
+    isRecord(value) &&
+    validToken(value.token, 12) &&
+    validTimestamp(value.acquiredAt) &&
+    Number.isSafeInteger(value.pid) &&
+    value.pid > 0
+  );
+}
 
 function gateExpired(gate, now) {
   return now > Date.parse(gate.heartbeatAt) + gate.ttlMs;
 }
 
 function intentExpired(intent, now) {
-  return now > Date.parse(intent.registeredAt) + intent.ttlMs;
+  return now > Date.parse(intent.heartbeatAt) + intent.ttlMs;
 }
 
 function writeExclusive(filePath, value) {
@@ -128,31 +201,114 @@ function replaceAtomically(filePath, value) {
   renameSync(temp, filePath);
 }
 
+function replaceTextAtomically(filePath, value) {
+  const temp = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(temp, value);
+  renameSync(temp, filePath);
+}
+
+function publishExclusiveJson(filePath, value) {
+  const candidate = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.candidate`;
+  writeExclusive(candidate, value);
+  try {
+    linkSync(candidate, filePath);
+  } finally {
+    rmSync(candidate, { force: true });
+  }
+}
+
+/**
+ * Serialize every pathname mutation. The lock is intentionally never
+ * auto-reclaimed: a crashed or malformed lock fails closed until an operator
+ * proves that its owner is gone and repairs it.
+ */
+function mutateState(root, operation) {
+  mkdirSync(root, { recursive: true });
+  const filePath = mutationLockPath(root);
+  const lock = {
+    token: randomBytes(12).toString("hex"),
+    acquiredAt: new Date().toISOString(),
+    pid: process.pid,
+  };
+  const deadline = Date.now() + MUTATION_LOCK_WAIT_MS;
+  for (;;) {
+    try {
+      publishExclusiveJson(filePath, lock);
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      const existing = readJsonState(filePath, validateMutationLock);
+      if (existing.missing) continue;
+      if (!existing.ok && existing.malformed) {
+        if (Date.now() >= deadline) {
+          return { ok: false, reason: "malformed-mutation-lock" };
+        }
+        sleepSync(MUTATION_LOCK_POLL_MS);
+        continue;
+      }
+      if (Date.now() >= deadline) {
+        return {
+          ok: false,
+          reason: "state-busy",
+          holderPid: existing.ok ? existing.value.pid : undefined,
+        };
+      }
+      sleepSync(MUTATION_LOCK_POLL_MS);
+    }
+  }
+
+  let result;
+  let thrown;
+  try {
+    result = operation();
+  } catch (error) {
+    thrown = error;
+  }
+  const current = readJsonState(filePath, validateMutationLock);
+  if (!current.ok || current.value.token !== lock.token) {
+    if (thrown) throw thrown;
+    return { ok: false, reason: "mutation-lock-lost" };
+  }
+  rmSync(filePath);
+  if (thrown) throw thrown;
+  return result;
+}
+
 function nextGeneration(root, observed) {
   let highWater = 0;
   try {
-    highWater = Number.parseInt(readFileSync(generationPath(root), "utf8"), 10) || 0;
-  } catch {
-    /* first acquisition */
+    const raw = readFileSync(generationPath(root), "utf8");
+    if (!/^(?:0|[1-9]\d*)$/.test(raw) || !Number.isSafeInteger(Number(raw))) {
+      return { ok: false, reason: "malformed-generation" };
+    }
+    highWater = Number(raw);
+  } catch (error) {
+    if (error?.code !== "ENOENT") return { ok: false, reason: "malformed-generation" };
   }
   const generation = Math.max(highWater, observed) + 1;
-  writeFileSync(generationPath(root), String(generation));
-  return generation;
+  if (!Number.isSafeInteger(generation)) return { ok: false, reason: "generation-exhausted" };
+  replaceTextAtomically(generationPath(root), String(generation));
+  return { ok: true, generation };
 }
 
 function listIntents(root, now) {
   let names;
   try {
     names = readdirSync(intentsDir(root));
-  } catch {
-    return { live: [], malformed: [] };
+  } catch (error) {
+    if (error?.code === "ENOENT") return { live: [], malformed: [], unreadable: null };
+    return {
+      live: [],
+      malformed: [],
+      unreadable: error?.code ?? "unknown",
+    };
   }
   const live = [];
   const malformed = [];
   for (const name of names) {
     if (!name.endsWith(".json")) continue;
     const filePath = path.join(intentsDir(root), name);
-    const parsed = readJsonState(filePath, INTENT_KEYS);
+    const parsed = readJsonState(filePath, validateIntent);
     if (!parsed.ok) {
       if (parsed.malformed) malformed.push(name);
       continue; // vanished mid-scan = released
@@ -165,7 +321,7 @@ function listIntents(root, now) {
     }
     live.push(parsed.value);
   }
-  return { live, malformed };
+  return { live, malformed, unreadable: null };
 }
 
 /**
@@ -180,30 +336,24 @@ export function registerWriterIntent({
   purpose,
   repoDir = process.cwd(),
   ttlMs = DEFAULT_INTENT_TTL_MS,
-  now = Date.now(),
 } = {}) {
-  if (!writerId || /[/\\]/.test(writerId)) return { ok: false, reason: "invalid-writer-id" };
+  if (!validIdentity(writerId)) return { ok: false, reason: "invalid-writer-id" };
+  if (!validPurpose(purpose ?? "")) return { ok: false, reason: "invalid-purpose" };
+  if (!validTtl(ttlMs)) return { ok: false, reason: "invalid-lease-options" };
   const root = maintenanceGateRoot(repoDir);
   mkdirSync(intentsDir(root), { recursive: true });
 
-  const intent = {
-    writerId,
-    token: randomBytes(8).toString("hex"),
-    registeredAt: new Date(now).toISOString(),
-    ttlMs,
-    purpose: purpose ?? "",
-    pid: process.pid,
-  };
-  const filePath = path.join(intentsDir(root), `${writerId}.json`);
-  // Create-then-check ordering closes the race against a concurrent gate
-  // acquisition: whichever of {intent file, gate file} lands second, the
-  // writer self-revokes on seeing a gate, and the acquirer's drain sees any
-  // intent that beat it.
-  try {
-    writeExclusive(filePath, intent);
-  } catch (error) {
-    if (error?.code !== "EEXIST") throw error;
-    const existing = readJsonState(filePath, INTENT_KEYS);
+  const filePath = intentPath(root, writerId);
+  return mutateState(root, () => {
+    const now = Date.now();
+    const gate = readJsonState(gatePath(root), validateGate);
+    if (!gate.missing) {
+      const reason = gate.ok ? "maintenance-gate-held" : "maintenance-gate-unreadable";
+      audit(root, "intent-rejected", { writerId, reason });
+      return { ok: false, reason };
+    }
+
+    const existing = readJsonState(filePath, validateIntent);
     if (existing.ok && !intentExpired(existing.value, now)) {
       return { ok: false, reason: "writer-already-active" };
     }
@@ -211,39 +361,91 @@ export function registerWriterIntent({
       audit(root, "intent-rejected", { writerId, reason: "malformed-existing-intent" });
       return { ok: false, reason: "malformed-existing-intent" };
     }
-    replaceAtomically(filePath, intent); // own expired lease → renew
-  }
-
-  const gate = readJsonState(gatePath(root), GATE_KEYS);
-  if (!gate.missing) {
-    // Gate present in ANY state (or unreadable): fail closed and revoke.
-    try {
-      rmSync(filePath, { force: true });
-    } catch {
-      /* the drain treats a malformed leftover as blocking; owner retries */
+    const publishedAt = new Date(Date.now()).toISOString();
+    const intent = {
+      writerId,
+      token: randomBytes(8).toString("hex"),
+      registeredAt: publishedAt,
+      heartbeatAt: publishedAt,
+      ttlMs,
+      purpose: purpose ?? "",
+      pid: process.pid,
+    };
+    if (existing.missing) {
+      writeExclusive(filePath, intent);
+    } else {
+      replaceAtomically(filePath, intent);
     }
-    const reason = gate.ok ? "maintenance-gate-held" : "maintenance-gate-unreadable";
-    audit(root, "intent-rejected", { writerId, reason });
-    return { ok: false, reason };
-  }
 
-  audit(root, "intent-registered", { writerId, token: intent.token, ttlMs });
-  return {
-    ok: true,
-    lease: { writerId, token: intent.token, root },
-  };
+    audit(root, "intent-registered", { writerId, token: intent.token, ttlMs });
+    if (intentExpired(intent, Date.now())) {
+      rmSync(filePath);
+      audit(root, "intent-registration-expired", { writerId, token: intent.token });
+      return { ok: false, reason: "expired-before-return" };
+    }
+    return {
+      ok: true,
+      lease: { writerId, token: intent.token, root },
+    };
+  });
+}
+
+/** Extend an active writer lease while its repository mutation is in flight. */
+export function heartbeatWriterIntent(lease) {
+  if (
+    !lease?.root ||
+    !validIdentity(lease.writerId) ||
+    !validToken(lease.token, 8)
+  ) {
+    return { ok: false, reason: "invalid-lease" };
+  }
+  const filePath = intentPath(lease.root, lease.writerId);
+  return mutateState(lease.root, () => {
+    const existing = readJsonState(filePath, validateIntent);
+    if (!existing.ok) return { ok: false, reason: existing.missing ? "not-held" : "malformed" };
+    if (existing.value.token !== lease.token) return { ok: false, reason: "not-owner" };
+    const now = Date.now();
+    if (intentExpired(existing.value, now)) return { ok: false, reason: "expired" };
+    if (now < Date.parse(existing.value.heartbeatAt)) {
+      return { ok: false, reason: "heartbeat-regressed" };
+    }
+
+    const gate = readJsonState(gatePath(lease.root), validateGate);
+    if (!gate.missing && (!gate.ok || gate.value.phase !== "draining")) {
+      return {
+        ok: false,
+        reason: gate.ok ? "maintenance-gate-held" : "maintenance-gate-unreadable",
+      };
+    }
+    const updated = {
+      ...existing.value,
+      heartbeatAt: new Date(now).toISOString(),
+    };
+    replaceAtomically(filePath, updated);
+    audit(lease.root, "intent-heartbeat", { writerId: lease.writerId });
+    if (intentExpired(updated, Date.now())) {
+      rmSync(filePath);
+      audit(lease.root, "intent-heartbeat-expired", { writerId: lease.writerId });
+      return { ok: false, reason: "expired-before-return" };
+    }
+    return { ok: true };
+  });
 }
 
 /** Release a writer-intent lease. Only the matching token releases. */
 export function releaseWriterIntent(lease) {
-  if (!lease?.root || !lease.writerId) return { ok: false, reason: "invalid-lease" };
-  const filePath = path.join(intentsDir(lease.root), `${lease.writerId}.json`);
-  const existing = readJsonState(filePath, INTENT_KEYS);
-  if (!existing.ok) return { ok: false, reason: existing.missing ? "not-held" : "malformed" };
-  if (existing.value.token !== lease.token) return { ok: false, reason: "not-owner" };
-  rmSync(filePath, { force: true });
-  audit(lease.root, "intent-released", { writerId: lease.writerId });
-  return { ok: true };
+  if (!lease?.root || !validIdentity(lease.writerId) || !validToken(lease.token, 8)) {
+    return { ok: false, reason: "invalid-lease" };
+  }
+  const filePath = intentPath(lease.root, lease.writerId);
+  return mutateState(lease.root, () => {
+    const existing = readJsonState(filePath, validateIntent);
+    if (!existing.ok) return { ok: false, reason: existing.missing ? "not-held" : "malformed" };
+    if (existing.value.token !== lease.token) return { ok: false, reason: "not-owner" };
+    rmSync(filePath);
+    audit(lease.root, "intent-released", { writerId: lease.writerId });
+    return { ok: true };
+  });
 }
 
 /**
@@ -265,89 +467,227 @@ export function acquireMaintenanceGate({
   ttlMs = DEFAULT_GATE_TTL_MS,
   quiesceTimeoutMs = DEFAULT_QUIESCE_TIMEOUT_MS,
   takeoverStale = false,
-  now = Date.now(),
 } = {}) {
-  if (!ownerId) return { ok: false, reason: "invalid-owner-id" };
+  if (!validIdentity(ownerId)) return { ok: false, reason: "invalid-owner-id" };
+  if (!validPurpose(purpose ?? "")) return { ok: false, reason: "invalid-purpose" };
+  if (
+    !validTtl(ttlMs) ||
+    !Number.isSafeInteger(quiesceTimeoutMs) ||
+    quiesceTimeoutMs < 0 ||
+    typeof takeoverStale !== "boolean"
+  ) {
+    return { ok: false, reason: "invalid-gate-options" };
+  }
   const root = maintenanceGateRoot(repoDir);
   mkdirSync(intentsDir(root), { recursive: true });
 
   const gateFile = gatePath(root);
-  const existing = readJsonState(gateFile, GATE_KEYS);
-  if (existing.ok && !gateExpired(existing.value, now)) {
-    return { ok: false, reason: "gate-held", holder: existing.value.ownerId };
-  }
-  if (!existing.ok && existing.malformed) {
-    audit(root, "acquire-rejected", { ownerId, reason: "malformed-gate" });
-    return { ok: false, reason: "malformed-gate" };
-  }
-  if (existing.ok) {
-    // Expired but well-formed.
-    if (!takeoverStale) return { ok: false, reason: "gate-stale", holder: existing.value.ownerId };
-    const staleName = `${gateFile}.stale-${existing.value.generation}-${Date.now().toString(36)}`;
-    try {
-      renameSync(gateFile, staleName); // atomic: exactly one taker wins
-    } catch {
-      return { ok: false, reason: "takeover-lost" };
+  const started = mutateState(root, () => {
+    const now = Date.now();
+    const existing = readJsonState(gateFile, validateGate);
+    if (existing.ok && !gateExpired(existing.value, now)) {
+      return { ok: false, reason: "gate-held", holder: existing.value.ownerId };
     }
-    audit(root, "gate-taken-over", { ownerId, from: existing.value.ownerId, generation: existing.value.generation });
-  }
+    if (!existing.ok && existing.malformed) {
+      audit(root, "acquire-rejected", { ownerId, reason: "malformed-gate" });
+      return { ok: false, reason: "malformed-gate" };
+    }
+    if (existing.ok && !takeoverStale) {
+      return { ok: false, reason: "gate-stale", holder: existing.value.ownerId };
+    }
 
-  const generation = nextGeneration(root, existing.ok ? existing.value.generation : 0);
-  const gate = {
-    generation,
-    ownerId,
-    token: randomBytes(12).toString("hex"),
-    phase: "draining",
-    acquiredAt: new Date(now).toISOString(),
-    heartbeatAt: new Date(now).toISOString(),
-    ttlMs,
-    purpose: purpose ?? "",
-    pid: process.pid,
-  };
-  try {
-    writeExclusive(gateFile, gate);
-  } catch (error) {
-    if (error?.code === "EEXIST") return { ok: false, reason: "gate-held" };
-    throw error;
+    const advanced = nextGeneration(root, existing.ok ? existing.value.generation : 0);
+    if (!advanced.ok) return advanced;
+    const gate = {
+      generation: advanced.generation,
+      ownerId,
+      token: randomBytes(12).toString("hex"),
+      phase: "draining",
+      acquiredAt: new Date(now).toISOString(),
+      heartbeatAt: new Date(now).toISOString(),
+      ttlMs,
+      purpose: purpose ?? "",
+      pid: process.pid,
+    };
+    if (existing.ok) {
+      const staleName = `${gateFile}.stale-${existing.value.generation}-${randomBytes(4).toString("hex")}`;
+      writeExclusive(staleName, existing.value);
+      replaceAtomically(gateFile, gate);
+    } else {
+      writeExclusive(gateFile, gate);
+    }
+    return {
+      ok: true,
+      gate,
+      previous: existing.ok ? existing.value : null,
+    };
+  });
+  if (!started.ok) return started;
+  const { gate } = started;
+  const generation = gate.generation;
+  const handle = { root, ownerId, generation, token: gate.token };
+  if (started.previous) {
+    audit(root, "gate-taken-over", {
+      ownerId,
+      from: started.previous.ownerId,
+      generation: started.previous.generation,
+    });
   }
   audit(root, "gate-draining", { ownerId, generation });
 
   // Drain: pre-existing live intents must release or expire.
-  const deadline = now + quiesceTimeoutMs;
+  const deadline = Date.now() + quiesceTimeoutMs;
+  const drainPollMs = Math.max(1, Math.min(QUIESCE_POLL_MS, Math.floor(ttlMs / 3)));
   for (;;) {
+    const refreshed = refreshDrainingGate(handle);
+    if (!refreshed.ok) {
+      if (refreshed.reason === "state-busy" && Date.now() <= deadline) {
+        sleepSync(drainPollMs);
+        continue;
+      }
+      return refreshed;
+    }
     const current = Date.now();
-    const { live, malformed } = listIntents(root, current);
+    const { live, malformed, unreadable } = listIntents(root, current);
+    if (unreadable) {
+      const released = removeOwnedGate(handle);
+      if (!released.ok) return { ok: false, reason: "gate-cleanup-failed", detail: released.reason };
+      audit(root, "acquire-rejected", {
+        ownerId,
+        generation,
+        reason: "intent-scan-failed",
+        code: unreadable,
+      });
+      return { ok: false, reason: "intent-scan-failed", code: unreadable };
+    }
     if (malformed.length > 0) {
-      rmSync(gateFile, { force: true });
+      const released = removeOwnedGate(handle);
+      if (!released.ok) return { ok: false, reason: "gate-cleanup-failed", detail: released.reason };
       audit(root, "acquire-rejected", { ownerId, generation, reason: "malformed-intent", files: malformed });
       return { ok: false, reason: "malformed-intent", files: malformed };
     }
-    if (live.length === 0) break;
-    if (current > deadline) {
-      rmSync(gateFile, { force: true });
+    if (live.length > 0) {
+      if (current <= deadline) {
+        sleepSync(drainPollMs);
+        continue;
+      }
+      const released = removeOwnedGate(handle);
+      if (!released.ok) return { ok: false, reason: "gate-cleanup-failed", detail: released.reason };
       const blockers = live.map((intent) => intent.writerId);
       audit(root, "acquire-rejected", { ownerId, generation, reason: "quiesce-timeout", blockers });
       return { ok: false, reason: "quiesce-timeout", blockers };
     }
-    sleepSync(QUIESCE_POLL_MS);
+
+    const promoted = mutateState(root, () => {
+      const owned = readOwnedGate(handle);
+      if (!owned.ok) return { ok: false, reason: owned.reason };
+      if (owned.gate.phase !== "draining") return { ok: false, reason: "not-draining" };
+
+      const finalScanAt = Date.now();
+      if (gateExpired(owned.gate, finalScanAt)) {
+        return { ok: false, reason: "expired" };
+      }
+      const finalScan = listIntents(root, finalScanAt);
+      if (finalScan.unreadable) {
+        return { ok: false, reason: "intent-scan-failed", code: finalScan.unreadable };
+      }
+      if (finalScan.malformed.length > 0) {
+        return { ok: false, reason: "malformed-intent", files: finalScan.malformed };
+      }
+      if (finalScan.live.length > 0) {
+        return {
+          ok: false,
+          reason: "writers-active",
+          blockers: finalScan.live.map((intent) => intent.writerId),
+        };
+      }
+
+      const heartbeatAt = new Date(
+        Math.max(finalScanAt, Date.parse(owned.gate.heartbeatAt)),
+      ).toISOString();
+      replaceAtomically(gateFile, {
+        ...owned.gate,
+        phase: "held",
+        heartbeatAt,
+      });
+      return { ok: true };
+    });
+    if (promoted.ok) break;
+    if (promoted.reason === "writers-active" || promoted.reason === "state-busy") {
+      if (Date.now() <= deadline) {
+        sleepSync(drainPollMs);
+        continue;
+      }
+      const released = removeOwnedGate(handle);
+      if (!released.ok) return { ok: false, reason: "gate-cleanup-failed", detail: released.reason };
+      const blockers = promoted.blockers ?? [];
+      audit(root, "acquire-rejected", { ownerId, generation, reason: "quiesce-timeout", blockers });
+      return { ok: false, reason: "quiesce-timeout", blockers };
+    }
+    if (promoted.reason === "malformed-intent" || promoted.reason === "intent-scan-failed") {
+      const released = removeOwnedGate(handle);
+      if (!released.ok) return { ok: false, reason: "gate-cleanup-failed", detail: released.reason };
+      audit(root, "acquire-rejected", { ownerId, generation, ...promoted });
+      return promoted;
+    }
+    return promoted;
   }
 
-  replaceAtomically(gateFile, { ...gate, phase: "held" });
   audit(root, "gate-acquired", { ownerId, generation });
+  const finalOwnership = verifyMaintenanceGateOwnership(handle);
+  if (!finalOwnership.ok) {
+    return {
+      ok: false,
+      reason: finalOwnership.reason === "expired" ? "expired-before-return" : finalOwnership.reason,
+    };
+  }
   return {
     ok: true,
-    handle: { root, ownerId, generation, token: gate.token },
+    handle,
   };
 }
 
 function readOwnedGate(handle) {
-  if (!handle?.root || !handle.token) return { ok: false, reason: "invalid-handle" };
-  const gate = readJsonState(gatePath(handle.root), GATE_KEYS);
+  if (
+    !handle?.root ||
+    !validIdentity(handle.ownerId) ||
+    !Number.isSafeInteger(handle.generation) ||
+    handle.generation <= 0 ||
+    !validToken(handle.token, 12)
+  ) {
+    return { ok: false, reason: "invalid-handle" };
+  }
+  const gate = readJsonState(gatePath(handle.root), validateGate);
   if (!gate.ok) return { ok: false, reason: gate.missing ? "gate-missing" : "malformed-gate" };
   if (gate.value.generation !== handle.generation || gate.value.token !== handle.token || gate.value.ownerId !== handle.ownerId) {
     return { ok: false, reason: "not-owner" };
   }
   return { ok: true, gate: gate.value };
+}
+
+function removeOwnedGate(handle) {
+  return mutateState(handle.root, () => {
+    const owned = readOwnedGate(handle);
+    if (!owned.ok) return { ok: false, reason: owned.reason };
+    rmSync(gatePath(handle.root));
+    return { ok: true };
+  });
+}
+
+function refreshDrainingGate(handle) {
+  return mutateState(handle.root, () => {
+    const owned = readOwnedGate(handle);
+    if (!owned.ok) return { ok: false, reason: owned.reason };
+    if (owned.gate.phase !== "draining") return { ok: false, reason: "not-draining" };
+    const now = Date.now();
+    if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
+    if (now <= Date.parse(owned.gate.heartbeatAt)) return { ok: true };
+    replaceAtomically(gatePath(handle.root), {
+      ...owned.gate,
+      heartbeatAt: new Date(now).toISOString(),
+    });
+    return { ok: true };
+  });
 }
 
 /**
@@ -356,37 +696,52 @@ function readOwnedGate(handle) {
  * Destructive completions call this immediately before and after their
  * final verification so a takeover or expiry mid-audit invalidates the run.
  */
-export function verifyMaintenanceGateOwnership(handle, now = Date.now()) {
+export function verifyMaintenanceGateOwnership(handle) {
   const owned = readOwnedGate(handle);
   if (!owned.ok) return { ok: false, reason: owned.reason };
   if (owned.gate.phase !== "held") return { ok: false, reason: "not-held" };
-  if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
+  if (gateExpired(owned.gate, Date.now())) return { ok: false, reason: "expired" };
   return { ok: true };
 }
 
 /** Extend the gate's lifetime. Only the matching fenced owner can heartbeat. */
-export function heartbeatMaintenanceGate(handle, now = Date.now()) {
-  const owned = readOwnedGate(handle);
-  if (!owned.ok) return { ok: false, reason: owned.reason };
-  if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
-  replaceAtomically(gatePath(handle.root), { ...owned.gate, heartbeatAt: new Date(now).toISOString() });
-  return { ok: true };
+export function heartbeatMaintenanceGate(handle) {
+  if (!handle?.root) return { ok: false, reason: "invalid-handle" };
+  return mutateState(handle.root, () => {
+    const owned = readOwnedGate(handle);
+    if (!owned.ok) return { ok: false, reason: owned.reason };
+    const now = Date.now();
+    if (gateExpired(owned.gate, now)) return { ok: false, reason: "expired" };
+    if (now < Date.parse(owned.gate.heartbeatAt)) {
+      return { ok: false, reason: "heartbeat-regressed" };
+    }
+    const updated = {
+      ...owned.gate,
+      heartbeatAt: new Date(now).toISOString(),
+    };
+    replaceAtomically(gatePath(handle.root), updated);
+    if (gateExpired(updated, Date.now())) {
+      return { ok: false, reason: "expired-before-return" };
+    }
+    return { ok: true };
+  });
 }
 
 /** Release the gate. Only the matching fenced owner releases. */
 export function releaseMaintenanceGate(handle) {
-  const owned = readOwnedGate(handle);
-  if (!owned.ok) return { ok: false, reason: owned.reason };
-  rmSync(gatePath(handle.root), { force: true });
+  if (!handle?.root) return { ok: false, reason: "invalid-handle" };
+  const released = removeOwnedGate(handle);
+  if (!released.ok) return released;
   audit(handle.root, "gate-released", { ownerId: handle.ownerId, generation: handle.generation });
   return { ok: true };
 }
 
 /** Read-only status for tooling and the guards built in wqa0b.2–.4. */
-export function maintenanceGateStatus(repoDir = process.cwd(), now = Date.now()) {
+export function maintenanceGateStatus(repoDir = process.cwd()) {
+  const now = Date.now();
   const root = maintenanceGateRoot(repoDir);
-  const gate = readJsonState(gatePath(root), GATE_KEYS);
-  const { live, malformed } = listIntents(root, now);
+  const gate = readJsonState(gatePath(root), validateGate);
+  const { live, malformed, unreadable } = listIntents(root, now);
   return {
     gate: gate.ok
       ? { ...gate.value, expired: gateExpired(gate.value, now) }
@@ -395,5 +750,6 @@ export function maintenanceGateStatus(repoDir = process.cwd(), now = Date.now())
         : { malformed: true },
     liveIntents: live.map((intent) => intent.writerId),
     malformedIntents: malformed,
+    intentScanError: unreadable,
   };
 }

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -106,11 +106,17 @@ const GATE_KEYS = ["generation", "ownerId", "token", "phase", "acquiredAt", "hea
 const INTENT_KEYS = ["writerId", "token", "registeredAt", "ttlMs", "purpose"];
 
 function gateExpired(gate, now) {
-  return now > Date.parse(gate.heartbeatAt) + gate.ttlMs;
+  const heartbeatAt = Date.parse(gate.heartbeatAt);
+  const ttlMs = Number(gate.ttlMs);
+  if (!Number.isFinite(heartbeatAt) || !Number.isFinite(ttlMs) || ttlMs <= 0) return true;
+  return now > heartbeatAt + ttlMs;
 }
 
 function intentExpired(intent, now) {
-  return now > Date.parse(intent.registeredAt) + intent.ttlMs;
+  const registeredAt = Date.parse(intent.registeredAt);
+  const ttlMs = Number(intent.ttlMs);
+  if (!Number.isFinite(registeredAt) || !Number.isFinite(ttlMs) || ttlMs <= 0) return true;
+  return now > registeredAt + ttlMs;
 }
 
 function writeExclusive(filePath, value) {

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -157,7 +157,7 @@ test("the gate lives in the shared git common dir: linked worktrees see one gate
   rmSync(repo, { recursive: true, force: true });
 });
 
-test("concurrent multi-process acquisition: exactly one winner", () => {
+test("concurrent multi-process acquisition: exactly one winner", async () => {
   const repo = makeRepo();
   const contenders = 6;
   const worker = `

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,9 +1,8 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import {
   acquireMaintenanceGate,

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
-import { execFileSync, spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { execFileSync, spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { test } from "node:test";
 import {
   acquireMaintenanceGate,
@@ -17,12 +24,131 @@ import {
 } from "./maintenance-gate.mjs";
 
 const moduleUrl = new URL("./maintenance-gate.mjs", import.meta.url);
-const modulePath = fileURLToPath(moduleUrl);
+const MAX_SAFE_TEST_OFFSET = 60 * 60_000;
 
 function makeRepo() {
   const repo = mkdtempSync(path.join(tmpdir(), "cave-gate-"));
   execFileSync("git", ["init", "-q", repo]);
   return repo;
+}
+
+function intentFileForLease(lease) {
+  const directory = path.join(lease.root, "intents");
+  for (const name of readdirSync(directory)) {
+    if (!name.endsWith(".json")) continue;
+    const filePath = path.join(directory, name);
+    const state = JSON.parse(readFileSync(filePath, "utf8"));
+    if (state.token === lease.token) return filePath;
+  }
+  assert.fail(`intent file not found for ${lease.writerId}`);
+}
+
+function expireGate(repo) {
+  const filePath = path.join(maintenanceGateRoot(repo), "gate.json");
+  const original = JSON.parse(readFileSync(filePath, "utf8"));
+  const heartbeat = Date.now() - original.ttlMs - 1_000;
+  writeFileSync(
+    filePath,
+    JSON.stringify({
+      ...original,
+      acquiredAt: new Date(heartbeat - 1).toISOString(),
+      heartbeatAt: new Date(heartbeat).toISOString(),
+    }),
+  );
+  return { filePath, original };
+}
+
+function expireIntent(lease) {
+  const filePath = intentFileForLease(lease);
+  const original = JSON.parse(readFileSync(filePath, "utf8"));
+  const heartbeat = Date.now() - original.ttlMs - 1_000;
+  writeFileSync(
+    filePath,
+    JSON.stringify({
+      ...original,
+      registeredAt: new Date(heartbeat - 1).toISOString(),
+      heartbeatAt: new Date(heartbeat).toISOString(),
+    }),
+  );
+  return { filePath, original };
+}
+
+async function waitUntil(predicate, message, timeoutMs = 5000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) assert.fail(message);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+function collectChild(child) {
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    stdout += chunk;
+  });
+  child.stderr.on("data", (chunk) => {
+    stderr += chunk;
+  });
+  return new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (status) => {
+      if (status !== 0) {
+        reject(new Error(`child exited ${status}: ${stderr}`));
+        return;
+      }
+      resolve(JSON.parse(stdout.trim().split("\n").pop()));
+    });
+  });
+}
+
+function spawnPausedMutation({ mode, ready, proceed, payload }) {
+  const worker = `
+    import fs from "node:fs";
+    import { syncBuiltinESMExports } from "node:module";
+    import path from "node:path";
+    const config = JSON.parse(process.env.CAVE_GATE_RACE_CONFIG);
+    const pause = () => {
+      fs.writeFileSync(config.ready, "ready");
+      while (!fs.existsSync(config.proceed)) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      }
+    };
+    const originalRename = fs.renameSync;
+    const originalRemove = fs.rmSync;
+    fs.renameSync = (source, target) => {
+      const targetIsGate = path.basename(target) === "gate.json";
+      const targetIsIntent = path.basename(path.dirname(target)) === "intents";
+      if (config.mode === "gate-heartbeat" && targetIsGate && source.endsWith(".tmp")) pause();
+      if (config.mode === "intent-heartbeat" && targetIsIntent && source.endsWith(".tmp")) pause();
+      return originalRename(source, target);
+    };
+    fs.rmSync = (target, options) => {
+      if (config.mode === "intent-release" && path.basename(path.dirname(target)) === "intents") pause();
+      return originalRemove(target, options);
+    };
+    syncBuiltinESMExports();
+    const gate = await import(config.moduleUrl);
+    const result = config.mode === "gate-heartbeat"
+      ? gate.heartbeatMaintenanceGate(config.payload.handle)
+      : config.mode === "intent-heartbeat"
+        ? gate.heartbeatWriterIntent(config.payload.lease)
+        : gate.releaseWriterIntent(config.payload.lease);
+    console.log(JSON.stringify(result));
+  `;
+  return spawn(process.execPath, ["--input-type=module", "-e", worker], {
+    env: {
+      ...process.env,
+      CAVE_GATE_RACE_CONFIG: JSON.stringify({
+        mode,
+        ready,
+        proceed,
+        payload,
+        moduleUrl: moduleUrl.href,
+      }),
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
 }
 
 test("writer-before-gate drains: acquisition waits for the live intent to release", () => {
@@ -82,16 +208,149 @@ test("malformed ownership fails closed everywhere — never silently reclaimed",
   rmSync(repo, { recursive: true, force: true });
 });
 
+test("semantically malformed gate state fails closed", () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo });
+  assert.equal(acquired.ok, true);
+  const gateFile = path.join(root, "gate.json");
+  const onDisk = JSON.parse(readFileSync(gateFile, "utf8"));
+  writeFileSync(gateFile, JSON.stringify({ ...onDisk, heartbeatAt: "not-a-date", ttlMs: "nan" }));
+
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "malformed-gate");
+  assert.equal(acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason, "malformed-gate");
+  assert.equal(registerWriterIntent({ writerId: "w", repoDir: repo }).reason, "maintenance-gate-unreadable");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("semantically malformed writer intent blocks acquisition", () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  mkdirSync(path.join(root, "intents"), { recursive: true });
+  writeFileSync(
+    path.join(root, "intents", "broken.json"),
+    JSON.stringify({
+      writerId: "broken",
+      token: "0123456789abcdef",
+      registeredAt: new Date().toISOString(),
+      heartbeatAt: "not-a-date",
+      ttlMs: "nan",
+      purpose: "",
+      pid: process.pid,
+    }),
+  );
+
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo, quiesceTimeoutMs: 100 });
+  assert.equal(acquired.reason, "malformed-intent");
+  assert.deepEqual(acquired.files, ["broken.json"]);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("an unreadable intent scan fails closed and releases the draining gate", async () => {
+  const repo = makeRepo();
+  const worker = `
+    import fs from "node:fs";
+    import path from "node:path";
+    import { syncBuiltinESMExports } from "node:module";
+    const originalReadDir = fs.readdirSync;
+    fs.readdirSync = (target, options) => {
+      if (path.basename(target) === "intents") {
+        const error = new Error("injected unreadable intent directory");
+        error.code = "EACCES";
+        throw error;
+      }
+      return originalReadDir(target, options);
+    };
+    syncBuiltinESMExports();
+    const gate = await import(${JSON.stringify(moduleUrl.href)});
+    const result = gate.acquireMaintenanceGate({ ownerId: "curator", repoDir: process.argv[1] });
+    console.log(JSON.stringify(result));
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", worker, repo], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const acquired = await collectChild(child);
+  assert.equal(acquired.reason, "intent-scan-failed");
+  assert.equal(maintenanceGateStatus(repo).gate, null);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("a transiently incomplete mutation lock is treated as contention, not malformed state", async () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  mkdirSync(root, { recursive: true });
+  const lockFile = path.join(root, "mutation.lock");
+  writeFileSync(lockFile, "");
+  const readyFile = path.join(repo, "lock-contender-ready");
+
+  const worker = `
+    import { writeFileSync } from "node:fs";
+    import { registerWriterIntent } from ${JSON.stringify(moduleUrl.href)};
+    writeFileSync(process.argv[2], "ready");
+    const result = registerWriterIntent({ writerId: "waiting-writer", repoDir: process.argv[1] });
+    console.log(JSON.stringify(result));
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", worker, repo, readyFile], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const result = collectChild(child);
+  await waitUntil(() => existsSync(readyFile), "lock contender never started");
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  writeFileSync(
+    lockFile,
+    JSON.stringify({
+      token: "0123456789abcdef01234567",
+      acquiredAt: new Date().toISOString(),
+      pid: process.pid,
+    }),
+  );
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  rmSync(lockFile);
+
+  const registered = await result;
+  assert.equal(registered.ok, true);
+  assert.equal(releaseWriterIntent(registered.lease).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("caller-controlled time cannot force takeover or publish a future lease", () => {
+  const repo = makeRepo();
+  const acquired = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(acquired.ok, true);
+  const forced = acquireMaintenanceGate({
+    ownerId: "second",
+    repoDir: repo,
+    takeoverStale: true,
+    now: Date.now() + MAX_SAFE_TEST_OFFSET,
+  });
+  assert.equal(forced.reason, "gate-held");
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+
+  const intent = registerWriterIntent({
+    writerId: "writer",
+    repoDir: repo,
+    now: Date.now() + MAX_SAFE_TEST_OFFSET,
+  });
+  assert.equal(intent.ok, true);
+  const intentState = JSON.parse(
+    readFileSync(intentFileForLease(intent.lease), "utf8"),
+  );
+  assert.ok(Date.parse(intentState.heartbeatAt) <= Date.now());
+  assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
 test("stale takeover fences out the previous owner's every capability", () => {
   const repo = makeRepo();
-  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo, ttlMs: 1 });
+  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
   assert.equal(first.ok, true);
+  expireGate(repo);
 
   // Expired but well-formed: plain acquisition reports staleness...
-  const stale = acquireMaintenanceGate({ ownerId: "second", repoDir: repo, now: Date.now() + 50 });
+  const stale = acquireMaintenanceGate({ ownerId: "second", repoDir: repo });
   assert.equal(stale.reason, "gate-stale");
   // ...and only an explicit takeover proceeds, bumping the generation.
-  const second = acquireMaintenanceGate({ ownerId: "second", repoDir: repo, takeoverStale: true, now: Date.now() + 50 });
+  const second = acquireMaintenanceGate({ ownerId: "second", repoDir: repo, takeoverStale: true });
   assert.equal(second.ok, true);
   assert.ok(second.handle.generation > first.handle.generation, "takeover advances the fenced generation");
 
@@ -110,26 +369,199 @@ test("owner capability holds through postconditions and dies on tampering, expir
   assert.equal(acquired.ok, true);
   assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
 
-  // Heartbeat extends the lease into the future.
-  const nearExpiry = Date.now() + 59_000;
-  assert.equal(heartbeatMaintenanceGate(acquired.handle, nearExpiry).ok, true);
-  assert.equal(verifyMaintenanceGateOwnership(acquired.handle, nearExpiry + 30_000).ok, true, "heartbeat extended ownership");
+  assert.equal(heartbeatMaintenanceGate(acquired.handle).ok, true);
+  const gateFile = path.join(root, "gate.json");
+  const heartbeated = JSON.parse(readFileSync(gateFile, "utf8"));
+  writeFileSync(
+    gateFile,
+    JSON.stringify({
+      ...heartbeated,
+      heartbeatAt: new Date(Date.now() + MAX_SAFE_TEST_OFFSET).toISOString(),
+    }),
+  );
+  assert.equal(
+    heartbeatMaintenanceGate(acquired.handle).reason,
+    "heartbeat-regressed",
+  );
+  writeFileSync(gateFile, JSON.stringify(heartbeated));
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
 
   // External tampering with the token invalidates the capability.
-  const gateFile = path.join(root, "gate.json");
-  const onDisk = JSON.parse(readFileSync(gateFile, "utf8"));
-  writeFileSync(gateFile, JSON.stringify({ ...onDisk, token: "forged" }));
-  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "not-owner");
+  writeFileSync(gateFile, JSON.stringify({ ...heartbeated, token: "forged" }));
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "malformed-gate");
 
-  writeFileSync(gateFile, JSON.stringify(onDisk));
+  writeFileSync(gateFile, JSON.stringify(heartbeated));
   assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
-  assert.equal(
-    verifyMaintenanceGateOwnership(acquired.handle, Date.now() + 10 * 60_000).reason,
-    "expired",
-    "an expired gate is no capability even for its owner",
-  );
+  expireGate(repo);
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "expired");
+
+  writeFileSync(gateFile, JSON.stringify(heartbeated));
   assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
   assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "gate-missing");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("a fenced owner cannot overwrite a successful stale takeover", async () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(first.ok, true);
+
+  const ready = path.join(repo, "heartbeat-ready");
+  const proceed = path.join(repo, "heartbeat-proceed");
+  const child = spawnPausedMutation({
+    mode: "gate-heartbeat",
+    ready,
+    proceed,
+    payload: { handle: first.handle },
+  });
+  const childResult = collectChild(child);
+  await waitUntil(() => existsSync(ready), "old owner never reached its final heartbeat mutation");
+  expireGate(repo);
+
+  const second = acquireMaintenanceGate({
+    ownerId: "second",
+    repoDir: repo,
+    takeoverStale: true,
+  });
+  writeFileSync(proceed, "proceed");
+  const heartbeat = await childResult;
+
+  assert.equal(
+    second.ok && heartbeat.ok,
+    false,
+    "takeover and the fenced owner's later pathname mutation must not both succeed",
+  );
+  const status = maintenanceGateStatus(repo);
+  if (second.ok) {
+    assert.equal(status.gate.ownerId, "second");
+  } else if (heartbeat.ok) {
+    assert.equal(status.gate.ownerId, "first");
+  }
+  rmSync(root, { recursive: true, force: true });
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("promotion rechecks intents after a concurrent writer heartbeat", async () => {
+  const repo = makeRepo();
+  const intent = registerWriterIntent({
+    writerId: "promotion-writer",
+    repoDir: repo,
+  });
+  assert.equal(intent.ok, true);
+
+  const acquireWorker = `
+    import { acquireMaintenanceGate } from ${JSON.stringify(moduleUrl.href)};
+    const result = acquireMaintenanceGate({
+      ownerId: "curator",
+      repoDir: process.argv[1],
+      quiesceTimeoutMs: 5000,
+    });
+    console.log(JSON.stringify(result));
+  `;
+  const acquireChild = spawn(
+    process.execPath,
+    ["--input-type=module", "-e", acquireWorker, repo],
+    { stdio: ["ignore", "pipe", "pipe"] },
+  );
+  const acquiredResult = collectChild(acquireChild);
+  await waitUntil(
+    () => maintenanceGateStatus(repo).gate?.phase === "draining",
+    "gate never entered draining phase",
+    30_000,
+  );
+
+  const ready = path.join(repo, "intent-heartbeat-ready");
+  const proceed = path.join(repo, "intent-heartbeat-proceed");
+  const heartbeatChild = spawnPausedMutation({
+    mode: "intent-heartbeat",
+    ready,
+    proceed,
+    payload: { lease: intent.lease },
+  });
+  const heartbeatResult = collectChild(heartbeatChild);
+  await waitUntil(() => existsSync(ready), "writer heartbeat never reached its final mutation");
+  expireIntent(intent.lease);
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  writeFileSync(proceed, "proceed");
+  assert.equal((await heartbeatResult).ok, true);
+  await new Promise((resolve) => setTimeout(resolve, 150));
+
+  const duringRenewedWrite = maintenanceGateStatus(repo);
+  assert.equal(duringRenewedWrite.gate?.phase, "draining");
+  assert.deepEqual(duringRenewedWrite.liveIntents, ["promotion-writer"]);
+
+  assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  const acquired = await acquiredResult;
+  assert.equal(acquired.ok, true);
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("a gate is active when acquisition returns after a slow drain", async () => {
+  const repo = makeRepo();
+  const intent = registerWriterIntent({ writerId: "slow-writer", repoDir: repo });
+  assert.equal(intent.ok, true);
+  const worker = `
+    import { acquireMaintenanceGate } from ${JSON.stringify(moduleUrl.href)};
+    const result = acquireMaintenanceGate({
+      ownerId: "curator",
+      repoDir: process.argv[1],
+      ttlMs: 500,
+      quiesceTimeoutMs: 5000,
+    });
+    console.log(JSON.stringify(result));
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", worker, repo], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const acquiredResult = collectChild(child);
+  await waitUntil(
+    () => maintenanceGateStatus(repo).gate?.phase === "draining",
+    "gate never entered draining phase",
+    30_000,
+  );
+  await new Promise((resolve) => setTimeout(resolve, 600));
+  assert.equal(
+    maintenanceGateStatus(repo).gate?.expired,
+    false,
+    "the active acquirer keeps its draining lease alive",
+  );
+  assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  const acquired = await acquiredResult;
+  assert.equal(acquired.ok, true);
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("acquisition does not return success after its final audit outlives the lease", async () => {
+  const repo = makeRepo();
+  const worker = `
+    import fs from "node:fs";
+    import { syncBuiltinESMExports } from "node:module";
+    const originalAppend = fs.appendFileSync;
+    fs.appendFileSync = (target, content, options) => {
+      if (String(content).includes('"event":"gate-acquired"')) {
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+      }
+      return originalAppend(target, content, options);
+    };
+    syncBuiltinESMExports();
+    const gate = await import(${JSON.stringify(moduleUrl.href)});
+    const result = gate.acquireMaintenanceGate({
+      ownerId: "curator",
+      repoDir: process.argv[1],
+      ttlMs: 100,
+    });
+    console.log(JSON.stringify(result));
+  `;
+  const child = spawn(process.execPath, ["--input-type=module", "-e", worker, repo], {
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const acquired = await collectChild(child);
+  assert.equal(acquired.ok, false);
+  assert.equal(acquired.reason, "expired-before-return");
   rmSync(repo, { recursive: true, force: true });
 });
 
@@ -157,33 +589,111 @@ test("the gate lives in the shared git common dir: linked worktrees see one gate
   rmSync(repo, { recursive: true, force: true });
 });
 
-test("concurrent multi-process acquisition: exactly one winner", () => {
+test("concurrent multi-process acquisition: exactly one winner", async () => {
   const repo = makeRepo();
   const contenders = 6;
+  const barrier = path.join(repo, "barrier");
+  mkdirSync(barrier);
   const worker = `
+    import { existsSync, writeFileSync } from "node:fs";
+    import path from "node:path";
     import { acquireMaintenanceGate } from ${JSON.stringify(moduleUrl.href)};
-    const result = acquireMaintenanceGate({ ownerId: process.argv[1], repoDir: process.argv[2], quiesceTimeoutMs: 2000 });
+    const [ownerId, repoDir, barrier] = process.argv.slice(1);
+    writeFileSync(path.join(barrier, ownerId + ".ready"), "ready");
+    while (!existsSync(path.join(barrier, "start"))) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+    }
+    const result = acquireMaintenanceGate({ ownerId, repoDir, quiesceTimeoutMs: 2000 });
     console.log(JSON.stringify({ ok: result.ok, reason: result.reason ?? null }));
   `;
   const results = [];
-  const children = [];
   for (let i = 0; i < contenders; i += 1) {
-    children.push(
-      spawnSync(process.execPath, ["--input-type=module", "-e", worker, `owner-${i}`, repo], {
-        encoding: "utf8",
-      }),
+    const child = spawn(
+      process.execPath,
+      ["--input-type=module", "-e", worker, `owner-${i}`, repo, barrier],
+      { stdio: ["ignore", "pipe", "pipe"] },
     );
+    results.push(collectChild(child));
   }
-  for (const child of children) {
-    assert.equal(child.status, 0, child.stderr);
-    results.push(JSON.parse(child.stdout.trim().split("\n").pop()));
-  }
-  const winners = results.filter((result) => result.ok);
-  assert.equal(winners.length, 1, `exactly one of ${contenders} concurrent acquirers wins: ${JSON.stringify(results)}`);
+  await waitUntil(
+    () => readdirSync(barrier).filter((name) => name.endsWith(".ready")).length === contenders,
+    "not every acquisition contender reached the start barrier",
+  );
+  writeFileSync(path.join(barrier, "start"), "start");
+  const settled = await Promise.all(results);
+  const winners = settled.filter((result) => result.ok);
+  assert.equal(winners.length, 1, `exactly one of ${contenders} concurrent acquirers wins: ${JSON.stringify(settled)}`);
   assert.ok(
-    results.filter((result) => !result.ok).every((result) => result.reason === "gate-held"),
+    settled.filter((result) => !result.ok).every((result) => result.reason === "gate-held"),
     "every loser sees gate-held",
   );
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("writer lease heartbeat keeps a long-running mutation live", async () => {
+  const gate = await import("./maintenance-gate.mjs");
+  assert.equal(typeof gate.heartbeatWriterIntent, "function", "writer leases need a token-fenced heartbeat");
+
+  const repo = makeRepo();
+  const intent = registerWriterIntent({ writerId: "long-writer", repoDir: repo });
+  assert.equal(intent.ok, true);
+  assert.equal(gate.heartbeatWriterIntent(intent.lease).ok, true);
+  const intentFile = intentFileForLease(intent.lease);
+  const heartbeated = JSON.parse(readFileSync(intentFile, "utf8"));
+  writeFileSync(
+    intentFile,
+    JSON.stringify({
+      ...heartbeated,
+      heartbeatAt: new Date(Date.now() + MAX_SAFE_TEST_OFFSET).toISOString(),
+    }),
+  );
+  assert.equal(
+    gate.heartbeatWriterIntent(intent.lease).reason,
+    "heartbeat-regressed",
+  );
+  writeFileSync(intentFile, JSON.stringify(heartbeated));
+  assert.deepEqual(maintenanceGateStatus(repo).liveIntents, ["long-writer"]);
+  assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("a stale writer cannot delete a successfully renewed lease", async () => {
+  const repo = makeRepo();
+  const first = registerWriterIntent({
+    writerId: "writer-race",
+    repoDir: repo,
+  });
+  assert.equal(first.ok, true);
+
+  const ready = path.join(repo, "release-ready");
+  const proceed = path.join(repo, "release-proceed");
+  const child = spawnPausedMutation({
+    mode: "intent-release",
+    ready,
+    proceed,
+    payload: { lease: first.lease },
+  });
+  const childResult = collectChild(child);
+  await waitUntil(() => existsSync(ready), "stale writer never reached its final release mutation");
+  expireIntent(first.lease);
+
+  const renewed = registerWriterIntent({
+    writerId: "writer-race",
+    repoDir: repo,
+  });
+  writeFileSync(proceed, "proceed");
+  const released = await childResult;
+
+  assert.equal(
+    renewed.ok && released.ok,
+    false,
+    "renewal and the stale writer's later pathname removal must not both succeed",
+  );
+  if (renewed.ok) {
+    assert.deepEqual(maintenanceGateStatus(repo).liveIntents, ["writer-race"]);
+  } else {
+    assert.equal(released.ok, true);
+  }
   rmSync(repo, { recursive: true, force: true });
 });
 
@@ -192,14 +702,20 @@ test("writer lease lifecycle: duplicate ids rejected, expiry renews, wrong token
   const first = registerWriterIntent({ writerId: "w1", repoDir: repo, ttlMs: 60_000 });
   assert.equal(first.ok, true);
   assert.equal(registerWriterIntent({ writerId: "w1", repoDir: repo }).reason, "writer-already-active");
-  assert.equal(releaseWriterIntent({ ...first.lease, token: "wrong" }).reason, "not-owner");
+  assert.equal(releaseWriterIntent({ ...first.lease, token: "0000000000000000" }).reason, "not-owner");
 
   // An expired lease renews in place for the same writer id.
-  const expired = registerWriterIntent({ writerId: "w2", repoDir: repo, ttlMs: 1 });
+  const expired = registerWriterIntent({ writerId: "w2", repoDir: repo });
   assert.equal(expired.ok, true);
-  const renewed = registerWriterIntent({ writerId: "w2", repoDir: repo, now: Date.now() + 50 });
+  expireIntent(expired.lease);
+  const renewed = registerWriterIntent({ writerId: "w2", repoDir: repo });
   assert.equal(renewed.ok, true);
   assert.notEqual(renewed.lease.token, expired.lease.token);
+
+  const portable = registerWriterIntent({ writerId: "writer:CON", repoDir: repo });
+  assert.equal(portable.ok, true);
+  assert.ok(maintenanceGateStatus(repo).liveIntents.includes("writer:CON"));
+  assert.equal(releaseWriterIntent(portable.lease).ok, true);
 
   assert.equal(registerWriterIntent({ writerId: "../escape", repoDir: repo }).reason, "invalid-writer-id");
   rmSync(repo, { recursive: true, force: true });

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,0 +1,226 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import {
+  acquireMaintenanceGate,
+  heartbeatMaintenanceGate,
+  maintenanceGateRoot,
+  maintenanceGateStatus,
+  registerWriterIntent,
+  releaseMaintenanceGate,
+  releaseWriterIntent,
+  verifyMaintenanceGateOwnership,
+} from "./maintenance-gate.mjs";
+
+const moduleUrl = new URL("./maintenance-gate.mjs", import.meta.url);
+const modulePath = fileURLToPath(moduleUrl);
+
+function makeRepo() {
+  const repo = mkdtempSync(path.join(tmpdir(), "cave-gate-"));
+  execFileSync("git", ["init", "-q", repo]);
+  return repo;
+}
+
+test("writer-before-gate drains: acquisition waits for the live intent to release", () => {
+  const repo = makeRepo();
+  const intent = registerWriterIntent({ writerId: "writer-a", repoDir: repo, purpose: "commit" });
+  assert.equal(intent.ok, true);
+
+  // A short quiesce window with the intent still live must time out and name it.
+  const blocked = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo, quiesceTimeoutMs: 350 });
+  assert.equal(blocked.ok, false);
+  assert.equal(blocked.reason, "quiesce-timeout");
+  assert.deepEqual(blocked.blockers, ["writer-a"]);
+  // The failed drain must not leave a gate behind.
+  assert.equal(maintenanceGateStatus(repo).gate, null, "a timed-out drain releases the gate file");
+
+  assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo, quiesceTimeoutMs: 1000 });
+  assert.equal(acquired.ok, true, "acquisition succeeds once the writer released");
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("gate-before-writer rejects: no new intent may start under a gate, in any phase", () => {
+  const repo = makeRepo();
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo });
+  assert.equal(acquired.ok, true);
+
+  const rejected = registerWriterIntent({ writerId: "late-writer", repoDir: repo });
+  assert.equal(rejected.ok, false);
+  assert.equal(rejected.reason, "maintenance-gate-held");
+  assert.deepEqual(maintenanceGateStatus(repo).liveIntents, [], "the rejected writer self-revoked its lease file");
+
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  assert.equal(registerWriterIntent({ writerId: "late-writer", repoDir: repo }).ok, true, "writers flow again after release");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("malformed ownership fails closed everywhere — never silently reclaimed", () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo });
+  assert.equal(acquired.ok, true);
+  writeFileSync(path.join(root, "gate.json"), "{not json");
+
+  assert.equal(acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason, "malformed-gate");
+  assert.equal(acquireMaintenanceGate({ ownerId: "second", repoDir: repo, takeoverStale: true }).reason, "malformed-gate", "takeover never applies to malformed state");
+  assert.equal(registerWriterIntent({ writerId: "w", repoDir: repo }).reason, "maintenance-gate-unreadable");
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "malformed-gate");
+  assert.equal(releaseMaintenanceGate(acquired.handle).reason, "malformed-gate");
+
+  // A malformed INTENT blocks acquisition the same way.
+  rmSync(path.join(root, "gate.json"), { force: true });
+  writeFileSync(path.join(root, "intents", "broken.json"), "{not json");
+  const blockedByIntent = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo, quiesceTimeoutMs: 300 });
+  assert.equal(blockedByIntent.reason, "malformed-intent");
+  assert.deepEqual(blockedByIntent.files, ["broken.json"]);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("stale takeover fences out the previous owner's every capability", () => {
+  const repo = makeRepo();
+  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo, ttlMs: 1 });
+  assert.equal(first.ok, true);
+
+  // Expired but well-formed: plain acquisition reports staleness...
+  const stale = acquireMaintenanceGate({ ownerId: "second", repoDir: repo, now: Date.now() + 50 });
+  assert.equal(stale.reason, "gate-stale");
+  // ...and only an explicit takeover proceeds, bumping the generation.
+  const second = acquireMaintenanceGate({ ownerId: "second", repoDir: repo, takeoverStale: true, now: Date.now() + 50 });
+  assert.equal(second.ok, true);
+  assert.ok(second.handle.generation > first.handle.generation, "takeover advances the fenced generation");
+
+  assert.equal(verifyMaintenanceGateOwnership(first.handle).reason, "not-owner", "old owner cannot verify");
+  assert.equal(heartbeatMaintenanceGate(first.handle).reason, "not-owner", "old owner cannot heartbeat");
+  assert.equal(releaseMaintenanceGate(first.handle).reason, "not-owner", "old owner cannot release");
+  assert.equal(verifyMaintenanceGateOwnership(second.handle).ok, true);
+  assert.equal(releaseMaintenanceGate(second.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("owner capability holds through postconditions and dies on tampering, expiry, and release", () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo, ttlMs: 60_000 });
+  assert.equal(acquired.ok, true);
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
+
+  // Heartbeat extends the lease into the future.
+  const nearExpiry = Date.now() + 59_000;
+  assert.equal(heartbeatMaintenanceGate(acquired.handle, nearExpiry).ok, true);
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle, nearExpiry + 30_000).ok, true, "heartbeat extended ownership");
+
+  // External tampering with the token invalidates the capability.
+  const gateFile = path.join(root, "gate.json");
+  const onDisk = JSON.parse(readFileSync(gateFile, "utf8"));
+  writeFileSync(gateFile, JSON.stringify({ ...onDisk, token: "forged" }));
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "not-owner");
+
+  writeFileSync(gateFile, JSON.stringify(onDisk));
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).ok, true);
+  assert.equal(
+    verifyMaintenanceGateOwnership(acquired.handle, Date.now() + 10 * 60_000).reason,
+    "expired",
+    "an expired gate is no capability even for its owner",
+  );
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  assert.equal(verifyMaintenanceGateOwnership(acquired.handle).reason, "gate-missing");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("the gate lives in the shared git common dir: linked worktrees see one gate", () => {
+  const repo = makeRepo();
+  writeFileSync(path.join(repo, "seed.txt"), "seed");
+  execFileSync("git", ["-C", repo, "add", "seed.txt"]);
+  execFileSync("git", ["-C", repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-q", "-m", "seed"]);
+  const linked = path.join(repo, ".worktrees", "linked");
+  execFileSync("git", ["-C", repo, "worktree", "add", "-q", "-b", "linked", linked]);
+
+  assert.equal(
+    maintenanceGateRoot(linked),
+    maintenanceGateRoot(repo),
+    "both checkouts resolve the same gate root",
+  );
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo });
+  assert.equal(acquired.ok, true);
+  assert.equal(
+    registerWriterIntent({ writerId: "linked-writer", repoDir: linked }).reason,
+    "maintenance-gate-held",
+    "a writer in a linked worktree is rejected by the main checkout's gate",
+  );
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("concurrent multi-process acquisition: exactly one winner", () => {
+  const repo = makeRepo();
+  const contenders = 6;
+  const worker = `
+    import { acquireMaintenanceGate } from ${JSON.stringify(moduleUrl.href)};
+    const result = acquireMaintenanceGate({ ownerId: process.argv[1], repoDir: process.argv[2], quiesceTimeoutMs: 2000 });
+    console.log(JSON.stringify({ ok: result.ok, reason: result.reason ?? null }));
+  `;
+  const results = [];
+  const children = [];
+  for (let i = 0; i < contenders; i += 1) {
+    children.push(
+      spawnSync(process.execPath, ["--input-type=module", "-e", worker, `owner-${i}`, repo], {
+        encoding: "utf8",
+      }),
+    );
+  }
+  for (const child of children) {
+    assert.equal(child.status, 0, child.stderr);
+    results.push(JSON.parse(child.stdout.trim().split("\n").pop()));
+  }
+  const winners = results.filter((result) => result.ok);
+  assert.equal(winners.length, 1, `exactly one of ${contenders} concurrent acquirers wins: ${JSON.stringify(results)}`);
+  assert.ok(
+    results.filter((result) => !result.ok).every((result) => result.reason === "gate-held"),
+    "every loser sees gate-held",
+  );
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("writer lease lifecycle: duplicate ids rejected, expiry renews, wrong token cannot release", () => {
+  const repo = makeRepo();
+  const first = registerWriterIntent({ writerId: "w1", repoDir: repo, ttlMs: 60_000 });
+  assert.equal(first.ok, true);
+  assert.equal(registerWriterIntent({ writerId: "w1", repoDir: repo }).reason, "writer-already-active");
+  assert.equal(releaseWriterIntent({ ...first.lease, token: "wrong" }).reason, "not-owner");
+
+  // An expired lease renews in place for the same writer id.
+  const expired = registerWriterIntent({ writerId: "w2", repoDir: repo, ttlMs: 1 });
+  assert.equal(expired.ok, true);
+  const renewed = registerWriterIntent({ writerId: "w2", repoDir: repo, now: Date.now() + 50 });
+  assert.equal(renewed.ok, true);
+  assert.notEqual(renewed.lease.token, expired.lease.token);
+
+  assert.equal(registerWriterIntent({ writerId: "../escape", repoDir: repo }).reason, "invalid-writer-id");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("every transition lands in the audit log with its generation", () => {
+  const repo = makeRepo();
+  const root = maintenanceGateRoot(repo);
+  const intent = registerWriterIntent({ writerId: "w", repoDir: repo });
+  releaseWriterIntent(intent.lease);
+  const acquired = acquireMaintenanceGate({ ownerId: "curator", repoDir: repo });
+  releaseMaintenanceGate(acquired.handle);
+
+  const events = readFileSync(path.join(root, "audit.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line).event);
+  assert.deepEqual(
+    events,
+    ["intent-registered", "intent-released", "gate-draining", "gate-acquired", "gate-released"],
+    "the audit trail records the full lifecycle in order",
+  );
+  rmSync(repo, { recursive: true, force: true });
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -46,6 +46,7 @@ export const SUITES = {
     "scripts/canonical-memory-smoke-helpers.test.mjs",
     "scripts/canonical-memory-smoke-lifecycle.test.mjs",
     "scripts/test-alias-loader.test.mjs",
+    "scripts/maintenance-gate.test.mjs",
     "src/lib/board-cache-events.test.ts",
     "src/lib/surface-warmup-registry.test.ts",
     "src/components/workspace-surface-warmup.test.ts",


### PR DESCRIPTION
## Summary

Implements **cave-wqa0b.1** — the repository-local, fail-closed foundation of the maintenance gate (`scripts/maintenance-gate.mjs`): an atomic exclusive gate plus writer-intent leases stored under the **shared Git common directory**, so every linked worktree sees one gate. This is the first non-advisory exclusion layer for branch/worktree curation; wqa0b.2–.4 (Coven session enforcement, Beads pre-write hook, GitHub transaction) build on it before cross-system exclusion can be claimed.

**Mechanics.** Ownership is won by `O_EXCL` creation and mutated only by temp+rename replacement. Writer intents use create-then-check ordering, closing the race against concurrent gate acquisition in every interleaving (the writer self-revokes on seeing any gate; the acquirer's drain sees any intent that beat it). Acquisition enters a `draining` phase — new writers already fail closed — waits for pre-existing live intents to release or expire, names its blockers and leaves no gate behind on timeout, then promotes to `held`. Takeover of an *expired, well-formed* gate is explicit-only (`takeoverStale`) and bumps a persistent high-water **generation**, after which the previous owner's `(generation, token)` pair can neither heartbeat, verify, nor release. Malformed gate or intent state fails closed everywhere — nothing is silently reclaimed, and **no bypass parameter exists**. `verifyMaintenanceGateOwnership` is the owner-capability postcondition check the curator calls around final verification. Every transition lands in an append-only `audit.jsonl` with its generation.

One subtlety worth noting: the gate root realpaths the common dir — a linked worktree's gitdir stores the canonical absolute path while the main checkout may arrive through a symlink alias (macOS `/var` → `/private/var`), and one gate requires one canonical root.

## Acceptance criteria → tests (9, all in `scripts/maintenance-gate.test.mjs`)

- **Writer-before-gate drains** — live intent blocks with `quiesce-timeout` naming the blocker; acquisition succeeds after release; failed drains leave no gate.
- **Gate-before-writer rejects** — in every phase, with the rejected writer's lease self-revoked.
- **Malformed/stale fails closed** — malformed gate blocks acquire/takeover/verify/release and writer intents; malformed intents block acquisition; stale well-formed gates need explicit takeover.
- **Only the matching fenced owner releases** — post-takeover, every old-owner capability returns `not-owner`; wrong intent tokens can't release leases.
- **Owner capability through postconditions** — survives heartbeat extension; dies on external token tampering, expiry, and release.
- **Common-dir storage across linked worktrees** — both checkouts resolve one root; a linked-worktree writer is rejected by the main checkout's gate.
- **Multi-process race** — six concurrent acquirers, exactly one winner, every loser sees `gate-held`.

`check:tests-wired` green (test wired into the runner).

Closes cave-wqa0b.1 (bd) after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)