### PR TITLE
perf(weaves): share one ward.audit read per weave, retire the dead map builder (cave-3lklx)

### DIFF
--- a/src/components/strand-inspector.test.ts
+++ b/src/components/strand-inspector.test.ts
@@ -38,6 +38,22 @@ assert.match(inspector, /strandsState\.message/, "blocked strand read shows why"
 assert.match(inspector, /auditState\.message/, "blocked audit read shows why");
 assert.match(inspector, /cache: "no-store"/, "reads are never cached");
 
+// The weave reads ward.audit ONCE per weave and passes each thread its own
+// slice; the inspector must not re-fetch what the parent already has (cave-3lklx).
+assert.doesNotMatch(
+  inspector,
+  /\/audit`/,
+  "the inspector takes audit as a prop — re-fetching duplicated one request per opened thread",
+);
+assert.match(inspector, /auditState: SurfaceState<AuditEntryView\[\]>/, "audit arrives as a SurfaceState prop");
+assert.match(
+  view,
+  /useState<Map<string, SurfaceState<AuditEntryView\[\]>>>/,
+  "the view keeps audit per thread, so a blocked read cannot borrow a neighbour's verified-empty",
+);
+assert.match(view, /auditByThread=\{weaveAudit\}/, "the per-thread audit map reaches the pane");
+assert.match(pane, /auditByThread\.get\(thread\.id\)/, "each thread gets its own audit slice");
+
 // the evidence lives inside the thread it explains, not a scroll away
 assert.match(pane, /<StrandInspector/, "the opened thread carries its own strand evidence");
 assert.match(pane, /knownProposalIds=\{knownProposalIds\}/, "the pane supplies known proposal ids for R7 annotation");

--- a/src/components/strand-inspector.tsx
+++ b/src/components/strand-inspector.tsx
@@ -60,27 +60,29 @@ function DiffBlock({ strand }: { strand: StrandView }) {
 export function StrandInspector({
   thread,
   knownProposalIds,
+  auditState,
   onTraceThread,
 }: {
   thread: ThreadView;
   knownProposalIds: ReadonlySet<string>;
+  /**
+   * ward.audit for THIS thread, read once per weave by the view and passed
+   * down. Re-reading it here duplicated a request the parent had already made
+   * for every thread in the weave. It stays a SurfaceState so a thread whose
+   * audit read was blocked still says so in its own lineage rather than
+   * borrowing a neighbour's verified-empty.
+   */
+  auditState: SurfaceState<AuditEntryView[]>;
   onTraceThread: () => void;
 }) {
   const [strandsState, setStrandsState] = useState<SurfaceState<StrandView[]>>({ kind: "loading" });
-  const [auditState, setAuditState] = useState<SurfaceState<AuditEntryView[]>>({ kind: "loading" });
 
   useEffect(() => {
     let cancelled = false;
     setStrandsState({ kind: "loading" });
-    setAuditState({ kind: "loading" });
     void fetchSurface<StrandView[]>(`/api/threads/${encodeURIComponent(thread.id)}/strands`).then(
       (state) => {
         if (!cancelled) setStrandsState(state);
-      },
-    );
-    void fetchSurface<AuditEntryView[]>(`/api/threads/${encodeURIComponent(thread.id)}/audit`).then(
-      (state) => {
-        if (!cancelled) setAuditState(state);
       },
     );
     return () => {

--- a/src/components/thread-pane.tsx
+++ b/src/components/thread-pane.tsx
@@ -12,7 +12,8 @@ import { Icon } from "@/lib/icon";
 import { StatusPill } from "@/components/weave-rail";
 import { StrandInspector } from "@/components/strand-inspector";
 import { channelLabel, paneModel, pillForTension } from "@/lib/weave-rail";
-import type { ThreadView, WeaveDetail } from "@/lib/threads-read";
+import type { AuditEntryView, ThreadView, WeaveDetail } from "@/lib/threads-read";
+import type { SurfaceState } from "@/lib/weave-rail";
 
 function ChannelChips({ thread }: { thread: ThreadView }) {
   if (thread.holdsUnder.length === 0) {
@@ -77,6 +78,7 @@ export function ThreadPane({
   openThreadId,
   stagedThreadIds,
   knownProposalIds,
+  auditByThread,
   onToggleThread,
   onTraceThread,
   onOpenProposal,
@@ -86,6 +88,8 @@ export function ThreadPane({
   /** Threads with a staged write awaiting a decision, from /api/proposals. */
   stagedThreadIds: ReadonlySet<string>;
   knownProposalIds: ReadonlySet<string>;
+  /** ward.audit read once per weave by the view, keyed by thread id. */
+  auditByThread: ReadonlyMap<string, SurfaceState<AuditEntryView[]>>;
   onToggleThread: (id: string) => void;
   onTraceThread: (thread: ThreadView) => void;
   onOpenProposal: (threadId: string) => void;
@@ -157,6 +161,7 @@ export function ThreadPane({
                 <StrandInspector
                   thread={thread}
                   knownProposalIds={knownProposalIds}
+                  auditState={auditByThread.get(thread.id) ?? { kind: "loading" }}
                   onTraceThread={() => onTraceThread(thread)}
                 />
               ) : null}

--- a/src/components/weave-rail.test.ts
+++ b/src/components/weave-rail.test.ts
@@ -66,8 +66,14 @@ assert.match(view, /traceForWeave|traceForTension|traceForDegradedFamiliar/, "tr
 assert.match(view, /weaveSummaryLine\(paneState\.data\)/, "the detail verdict comes from the view-model");
 assert.match(view, /weaveTallies\(entries, pendingCount \?\? 0\)/, "the overview counts come from the view-model");
 // a blocked proposals read must not make a thread claim a decision is pending
-assert.match(view, /if \(proposalsState\.kind !== "ready"\) return map/, "staged threads need a verified queue");
-assert.match(view, /pendingCount =\s*\n?\s*proposalsState\.kind === "ready"/, "the pending badge needs a verified queue");
+assert.match(
+  view,
+  /if \(proposalsState\.kind !== "ready"\)\s*\n?\s*return \{ stagedByThread: map, pendingCount: null \}/,
+  "an unverifiable queue yields neither a staged-thread claim nor a badge count",
+);
+// One pass over the queue feeds both consumers — they cannot disagree about
+// what is pending.
+assert.match(view, /const \{ stagedByThread, pendingCount \} = useMemo/, "queue derivation is memoised once");
 // empty selection guidance keeps the referent binding
 assert.match(view, /binds one protected surface to one\s+writer/, "thread referent stated in empty state");
 

--- a/src/components/weaves-view.tsx
+++ b/src/components/weaves-view.tsx
@@ -133,20 +133,19 @@ export function WeavesView() {
     );
   }, [proposalsState]);
 
-  // Threads with a staged write, and the proposal each one is waiting on. A
-  // blocked read contributes nothing: no thread claims a decision is pending
-  // unless the queue said so.
-  const stagedByThread = useMemo(() => {
+  // Threads with a staged write, the proposal each one is waiting on, and the
+  // count for the header badge — all one pass over the queue. A blocked read
+  // contributes nothing: no thread claims a decision is pending unless the
+  // queue said so, and the badge is omitted rather than shown as zero.
+  const { stagedByThread, pendingCount } = useMemo(() => {
     const map = new Map<string, string>();
-    if (proposalsState.kind !== "ready") return map;
-    for (const proposal of proposalListModel(proposalsState.data).ok) {
+    if (proposalsState.kind !== "ready") return { stagedByThread: map, pendingCount: null };
+    const ok = proposalListModel(proposalsState.data).ok;
+    for (const proposal of ok) {
       if (proposal.payload) map.set(proposal.payload.threadId, proposal.payload.id);
     }
-    return map;
+    return { stagedByThread: map, pendingCount: ok.length };
   }, [proposalsState]);
-
-  const pendingCount =
-    proposalsState.kind === "ready" ? proposalListModel(proposalsState.data).ok.length : null;
 
   useEffect(() => {
     if (!selectedWeaveId) {
@@ -165,29 +164,48 @@ export function WeavesView() {
     };
   }, [selectedWeaveId, paneAttempt]);
 
-  // Audit rows for the weave map's List view — one lazy fetch per thread of the
-  // open weave. A blocked read contributes nothing (a row simply claims less
-  // evidence), never an invented edge.
-  const [weaveAudit, setWeaveAudit] = useState<AuditEntryView[]>([]);
+  // ward.audit rows for the open weave, read once per weave and keyed by thread.
+  // Both consumers share this: the map's List view (which threads carry audited
+  // touches) and the opened thread's lineage. Fetching per thread in each place
+  // meant opening a six-thread weave cost six requests and then a seventh
+  // duplicate the moment you expanded a row.
+  //
+  // Per-thread SurfaceState, not flattened rows: a thread whose audit read is
+  // blocked has to say so in its own lineage rather than borrow a neighbour's
+  // verified-empty. A blocked read still contributes no map edge — it claims
+  // less evidence, never invents any.
+  const [weaveAudit, setWeaveAudit] = useState<Map<string, SurfaceState<AuditEntryView[]>>>(
+    new Map(),
+  );
   useEffect(() => {
     if (paneState?.kind !== "ready") {
-      setWeaveAudit([]);
+      setWeaveAudit(new Map());
       return;
     }
     let cancelled = false;
+    const threads = paneState.data.threads;
     void Promise.all(
-      paneState.data.threads.map((thread) =>
-        fetchSurface<AuditEntryView[]>(`/api/threads/${encodeURIComponent(thread.id)}/audit`).then(
-          (state) => (state.kind === "ready" ? state.data : []),
-        ),
+      threads.map((thread) =>
+        fetchSurface<AuditEntryView[]>(`/api/threads/${encodeURIComponent(thread.id)}/audit`),
       ),
-    ).then((batches) => {
-      if (!cancelled) setWeaveAudit(batches.flat());
+    ).then((states) => {
+      if (cancelled) return;
+      setWeaveAudit(new Map(threads.map((thread, i) => [thread.id, states[i]])));
     });
     return () => {
       cancelled = true;
     };
   }, [paneState]);
+
+  // The map only asks "which threads have audited touches"; flatten for it.
+  const auditRows = useMemo(
+    () => [...weaveAudit.values()].flatMap((state) => (state.kind === "ready" ? state.data : [])),
+    [weaveAudit],
+  );
+
+  // Rebuilt only when the queue changes — a fresh Set every render would give
+  // ThreadPane a new prop identity on each parent render.
+  const stagedThreadIds = useMemo(() => new Set(stagedByThread.keys()), [stagedByThread]);
 
   const rail = railState.kind === "ready" ? railModel(railState.data) : null;
 
@@ -394,7 +412,7 @@ export function WeavesView() {
 
                 <WeaveMapCanvas
                   threads={paneState.data.threads}
-                  audit={weaveAudit}
+                  audit={auditRows}
                   proposals={proposalsState.kind === "ready" ? proposalsState.data : []}
                   asList={mapAsList}
                   onPresentation={setMapAsList}
@@ -432,8 +450,9 @@ export function WeavesView() {
                   <ThreadPane
                     weave={paneState.data}
                     openThreadId={openThreadId}
-                    stagedThreadIds={new Set(stagedByThread.keys())}
+                    stagedThreadIds={stagedThreadIds}
                     knownProposalIds={knownProposalIds}
+                    auditByThread={weaveAudit}
                     onToggleThread={(id) => setOpenThreadId(id === openThreadId ? null : id)}
                     onTraceThread={onTraceThread}
                     onOpenProposal={openProposal}

--- a/src/lib/weave-map.test.ts
+++ b/src/lib/weave-map.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { buildWeaveMap, surfaceNodeId, threadNodeId, toneForTension } from "./weave-map.ts";
+import { buildBipartiteWeaveMap, toneForTension, weaveMapRows } from "./weave-map.ts";
 import type { AuditEntryView, ProposalView, ThreadView } from "./threads-read.ts";
 
 function thread(id: string, surface: string, writer = "familiar:sage", state: "holds" | "frayed" | "snapped" | "unknown" = "holds"): ThreadView {
@@ -74,61 +74,84 @@ describe("toneForTension", () => {
   });
 });
 
-describe("buildWeaveMap", () => {
-  it("builds authority edges from the thread contract", () => {
-    const map = buildWeaveMap({ threads: [thread("t1", "SOUL.md")], audit: [], proposals: [] });
-    assert.equal(map.nodes.length, 2);
-    const threadNode = map.nodes.find((n) => n.kind === "thread");
-    assert.equal(threadNode?.label, "sage", "familiar: prefix stripped for display");
+describe("buildBipartiteWeaveMap", () => {
+  it("deduplicates the writer lane but keeps one surface row per thread", () => {
+    const map = buildBipartiteWeaveMap({
+      threads: [
+        thread("t1", "SOUL.md", "familiar:sage"),
+        thread("t2", "IDENTITY.md", "familiar:sage"),
+        thread("t3", "ward.toml", "daemon:ward"),
+      ],
+      proposals: [],
+    });
+    assert.deepEqual(map.writers, ["familiar:sage", "daemon:ward"]);
+    assert.equal(map.surfaces.length, 3, "one right-lane row per thread, never deduped");
     assert.deepEqual(
-      map.edges.map((e) => [e.from, e.to, e.style, e.count]),
-      [[threadNodeId("t1"), surfaceNodeId("SOUL.md"), "authority", 1]],
+      map.links.map((l) => l.writerIndex),
+      [0, 0, 1],
+      "both sage threads point at the same writer node",
     );
+    assert.deepEqual(map.links.map((l) => l.surfaceIndex), [0, 1, 2]);
   });
 
-  it("aggregates audited touches per (thread, file) with counts", () => {
-    const map = buildWeaveMap({
+  it("marks only threads the queue actually staged a write for", () => {
+    const map = buildBipartiteWeaveMap({
+      threads: [thread("t1", "SOUL.md"), thread("t2", "IDENTITY.md")],
+      proposals: [proposal("t1", ["SOUL.md"])],
+    });
+    assert.deepEqual(map.links.map((l) => l.pending), [true, false]);
+  });
+
+  it("ignores a corrupt staged file — it can never claim a pending edge", () => {
+    const map = buildBipartiteWeaveMap({
       threads: [thread("t1", "SOUL.md")],
-      audit: [auditRow("t1", ["MEMORY.md"], 1), auditRow("t1", ["MEMORY.md", "SOUL.md"], 2)],
+      proposals: [proposal("t1", ["SOUL.md"], "corrupt")],
+    });
+    assert.equal(map.links[0].pending, false);
+  });
+
+  it("carries the thread tension through to both the edge and its surface", () => {
+    const map = buildBipartiteWeaveMap({
+      threads: [thread("t1", "SOUL.md", "familiar:sage", "snapped")],
       proposals: [],
     });
-    const touched = map.edges.filter((e) => e.style === "touched");
-    const memoryEdge = touched.find((e) => e.to === surfaceNodeId("MEMORY.md"));
-    assert.equal(memoryEdge?.count, 2);
-    assert.match(memoryEdge?.detail ?? "", /2 audited decisions/);
-    assert.ok(map.nodes.some((n) => n.kind === "surface" && n.surface === "MEMORY.md"));
+    assert.equal(map.links[0].tone, "snapped");
+    assert.equal(map.surfaces[0].tone, "snapped");
   });
+});
 
-  it("skips unattributable audit rows — no thread id, no edge", () => {
-    const map = buildWeaveMap({
-      threads: [thread("t1", "SOUL.md")],
-      audit: [auditRow(null, ["MEMORY.md"]), auditRow("t-foreign", ["MEMORY.md"])],
+describe("weaveMapRows", () => {
+  it("claims audited only for a thread the audit rows attribute", () => {
+    const rows = weaveMapRows({
+      threads: [thread("t1", "SOUL.md"), thread("t2", "IDENTITY.md")],
+      audit: [auditRow("t1", ["SOUL.md"])],
       proposals: [],
     });
-    assert.equal(map.edges.filter((e) => e.style === "touched").length, 0);
-    assert.ok(!map.nodes.some((n) => n.kind === "surface" && n.surface === "MEMORY.md"));
+    assert.match(rows[0].evidence, /audited/);
+    assert.doesNotMatch(rows[1].evidence, /audited/);
   });
 
-  it("staged proposals ride as pending edges; corrupt proposals are ignored", () => {
-    const map = buildWeaveMap({
+  it("does not attribute an audit row that carries no thread id", () => {
+    const rows = weaveMapRows({
       threads: [thread("t1", "SOUL.md")],
+      audit: [auditRow(null, ["SOUL.md"])],
+      proposals: [],
+    });
+    assert.doesNotMatch(rows[0].evidence, /audited/, "unattributable rows are skipped, never guessed");
+  });
+
+  it("names the staged proposal and keeps the surface → writer referent", () => {
+    const rows = weaveMapRows({
+      threads: [thread("t1", "SOUL.md", "familiar:sage")],
       audit: [],
-      proposals: [proposal("t1", ["IDENTITY.md", "IDENTITY.md"]), proposal("t1", ["x"], "corrupt")],
+      proposals: [proposal("t1", ["SOUL.md"])],
     });
-    const pending = map.edges.filter((e) => e.style === "pending");
-    assert.equal(pending.length, 1);
-    assert.equal(pending[0].count, 2);
-    assert.match(pending[0].detail, /2 staged edits/);
+    assert.equal(rows[0].label, "SOUL.md → familiar:sage");
+    assert.match(rows[0].evidence, /1 staged proposal/);
   });
 
-  it("thread tone follows tension, failing closed", () => {
-    const map = buildWeaveMap({
-      threads: [thread("t1", "a", "familiar:sage", "frayed"), thread("t2", "b", "familiar:echo", "unknown")],
-      audit: [],
-      proposals: [],
-    });
-    const tones = new Map(map.nodes.filter((n) => n.kind === "thread").map((n) => [n.threadId, n.tone]));
-    assert.equal(tones.get("t1"), "frayed");
-    assert.equal(tones.get("t2"), "blocked");
+  it("emits one row per thread so the List view is never a reduced set", () => {
+    const threads = [thread("t1", "a"), thread("t2", "b"), thread("t3", "c")];
+    assert.equal(weaveMapRows({ threads, audit: [], proposals: [] }).length, threads.length);
   });
 });

--- a/src/lib/weave-map.ts
+++ b/src/lib/weave-map.ts
@@ -1,18 +1,17 @@
 // The weave map — coven-threads memory made visible (cave-kgts).
 //
-// Pure builder: authority threads + their memory surfaces as a small graph,
-// every edge a VERIFIED fact. Three edge styles, three provenances:
+// Pure builders for the surface's two readings of the same verified edges:
+// a bipartite diagram (writers ⇄ protected surfaces, one edge per thread) and
+// the List view that carries the identical rows as text.
 //
-//   authority — the thread's own contract (ThreadView.surface): this writer
-//               may propose writes to this surface. Always present.
-//   touched   — ward_audit rows: files a decision actually touched, keyed by
-//               thread_id. Aggregated per (thread, file) with a count.
-//   pending   — staged proposals awaiting decision: dashed, the invitation.
+// Fail-closed (Phase-4 §4): audit rows without a thread_id can't be attributed
+// and are skipped, never guessed; unknown/stale tension renders as the blocked
+// tone. Memory READS are not audited yet (Phase 5), so no "recalled" edge is
+// drawn — none can be verified.
 //
-// Fail-closed (Phase-4 §4): audit rows without a thread_id can't be
-// attributed and are skipped, never guessed; unknown/stale tension renders
-// as the blocked tone. Memory READS are not audited yet (Phase 5) — this map
-// deliberately shows no "recalled" edges, because none can be verified.
+// The original force-directed graph builder (buildWeaveMap + its node/edge
+// model) was retired in cave-3lklx: the redesign replaced the force layout,
+// which left it with no caller outside its own test.
 
 import type {
   AuditEntryView,
@@ -22,39 +21,6 @@ import type {
 } from "./threads-read.ts";
 
 export type WeaveMapTone = "holds" | "frayed" | "snapped" | "blocked";
-
-export type WeaveMapNode =
-  | {
-      id: string;
-      kind: "thread";
-      threadId: string;
-      /** Writer identity with the `familiar:` prefix stripped for display. */
-      label: string;
-      tone: WeaveMapTone;
-    }
-  | {
-      id: string;
-      kind: "surface";
-      surface: string;
-      label: string;
-    };
-
-export type WeaveMapEdgeStyle = "authority" | "touched" | "pending";
-
-export type WeaveMapEdge = {
-  from: string;
-  to: string;
-  style: WeaveMapEdgeStyle;
-  /** Aggregated evidence count (audit rows / staged edits behind the edge). */
-  count: number;
-  /** One-line evidence copy for the hover/selection detail. */
-  detail: string;
-};
-
-export type WeaveMap = {
-  nodes: WeaveMapNode[];
-  edges: WeaveMapEdge[];
-};
 
 /** §2.1 tension → node tone; the two UI-only states fail closed to blocked. */
 export function toneForTension(tension: TensionView): WeaveMapTone {
@@ -70,90 +36,11 @@ export function toneForTension(tension: TensionView): WeaveMapTone {
   }
 }
 
-export function threadNodeId(threadId: string): string {
-  return `thread:${threadId}`;
-}
-
-export function surfaceNodeId(surface: string): string {
-  return `surface:${surface}`;
-}
-
-function writerLabel(writer: string): string {
-  return writer.startsWith("familiar:") ? writer.slice("familiar:".length) : writer;
-}
-
-export function buildWeaveMap(args: {
-  threads: ThreadView[];
-  audit: AuditEntryView[];
-  proposals: ProposalView[];
-}): WeaveMap {
-  const threadIds = new Set(args.threads.map((t) => t.id));
-  const nodes = new Map<string, WeaveMapNode>();
-  const edgeAgg = new Map<string, WeaveMapEdge>();
-
-  const ensureSurface = (surface: string) => {
-    const id = surfaceNodeId(surface);
-    if (!nodes.has(id)) nodes.set(id, { id, kind: "surface", surface, label: surface });
-    return id;
-  };
-  const addEdge = (from: string, to: string, style: WeaveMapEdgeStyle) => {
-    const key = `${style}|${from}|${to}`;
-    const existing = edgeAgg.get(key);
-    if (existing) {
-      existing.count += 1;
-    } else {
-      edgeAgg.set(key, { from, to, style, count: 1, detail: "" });
-    }
-  };
-
-  for (const thread of args.threads) {
-    const id = threadNodeId(thread.id);
-    nodes.set(id, {
-      id,
-      kind: "thread",
-      threadId: thread.id,
-      label: writerLabel(thread.writer),
-      tone: toneForTension(thread.tension),
-    });
-    addEdge(id, ensureSurface(thread.surface), "authority");
-  }
-
-  for (const entry of args.audit) {
-    // No thread id → no attribution; skipping is the honest treatment.
-    if (!entry.threadId || !threadIds.has(entry.threadId)) continue;
-    for (const file of entry.filesTouched) {
-      addEdge(threadNodeId(entry.threadId), ensureSurface(file), "touched");
-    }
-  }
-
-  for (const proposal of args.proposals) {
-    const payload = proposal.payload;
-    if (proposal.parse !== "ok" || !payload) continue;
-    if (!threadIds.has(payload.threadId)) continue;
-    for (const edit of payload.edits) {
-      addEdge(threadNodeId(payload.threadId), ensureSurface(edit.surface), "pending");
-    }
-  }
-
-  const edges = [...edgeAgg.values()].map((edge) => ({
-    ...edge,
-    detail:
-      edge.style === "authority"
-        ? "authority contract — this writer may propose writes here"
-        : edge.style === "touched"
-          ? `${edge.count} audited decision${edge.count === 1 ? "" : "s"} touched this file`
-          : `${edge.count} staged edit${edge.count === 1 ? "" : "s"} awaiting decision`,
-  }));
-
-  return { nodes: [...nodes.values()], edges };
-}
-
 // ---------------------------------------------------------------------------
 // Bipartite presentation (cave-f8rdi): writers on the left, protected surfaces
 // on the right, one edge per thread. A force layout made every weave look like
 // a different shape; two fixed lanes make "who may write where" readable at a
-// glance and comparable between familiars. The graph model above is unchanged
-// — this is a second reading of the same verified edges, plus a text List view
+// glance and comparable between familiars. Paired with a text List view
 // that carries the identical rows for anyone the diagram does not serve.
 
 export type WeaveMapLink = {


### PR DESCRIPTION
An optimality pass over the merged Weaves/Proposals redesign (#4108). It found one dead module and one request amplification that redesign had introduced.

## Audit was being read twice

`weaves-view` fetched `/api/threads/<id>/audit` for **every** thread of the selected weave — it needs to know which threads carry audited touches for the map's List view. Then `strand-inspector` fetched **the same endpoint again** for whichever thread you expanded.

Opening a six-thread weave cost six requests, then a seventh duplicate on the first expand. The weave now reads it once and passes each thread its own slice.

**The slice stays a `SurfaceState`, not a flattened row list.** Flattening is simpler and was tempting, but it would let a thread whose audit read was *blocked* render its neighbour's verified-empty lineage — the healthy-by-default failure this whole surface exists to prevent. A blocked read still contributes no map edge: it claims less evidence, never invents any.

Also folded a duplicated `proposalListModel` pass into one memo, so the header's pending badge and the threads' staged-write CTAs cannot disagree about what is waiting on you.

## Dead code

`buildWeaveMap` and its node/edge model had no caller once the bipartite map replaced the force layout — 125 lines removed. `toneForTension` **stays**; it backs both live builders.

## Coverage that would otherwise have gone backwards

The retired builder had 57 lines of unit tests. Its two replacements — `buildBipartiteWeaveMap` and `weaveMapRows` — shipped in #4108 with **no lib coverage at all**, so deleting the old tests without replacing them would have quietly reduced coverage. Nine cases added:

- writer-lane dedup, and one surface row per thread (never deduped)
- staged-write marking, and that a **corrupt** staged file can never claim a pending edge
- tension passthrough to both the edge and its surface
- that an audit row with **no `thread_id`** is never attributed — skipped, not guessed
- that the List view emits one row per thread, so it is never a reduced set

## Validation

- `pnpm exec tsc --noEmit` — clean
- `pnpm lint` — clean
- `pnpm test:app` — 995 files pass
- New source pins keep the duplicate fetch from returning (`assert.doesNotMatch(inspector, /\/audit`/)`)

Net −42 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)