### PR TITLE
feat(chat): match composer reference treatment

### DIFF
--- a/src/components/chat-composer-rec-autofill.test.ts
+++ b/src/components/chat-composer-rec-autofill.test.ts
@@ -6,6 +6,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const transcriptCss = readFileSync(new URL("../styles/cave-chat/transcript.css", import.meta.url), "utf8");
 
 // The recommendation derives from the ACTIVE branch path's last settled
 // assistant turn — but only a reply can be keyboard-filled.
@@ -35,12 +36,18 @@ assert.match(
   "accepting fills the draft (never sends)",
 );
 
-// Placeholder: the recommendation replaces the idle hint; streaming keeps
-// its own placeholder.
+// Placeholder: the recommendation replaces the idle hint; the input does not
+// carry keyboard-help copy because the send button is the visible affordance.
+assert.match(
+  transcriptCss,
+  /\.cave-chat-linear \.cave-composer-send \{[\s\S]*?border-radius: var\(--radius-control\);[\s\S]*?background: var\(--text-primary\);[\s\S]*?color: var\(--bg-panel\);/,
+  "the send button is the composer’s sole high-contrast square action",
+);
 assert.match(
   source,
-  /: recommendedNextPath\n\s*\? `\$\{recommendedNextPath\.prompt\}  ⇥ to fill`/,
-  "empty composer shows the recommendation as its placeholder with the ⇥ hint",
+  /: recommendedNextPath\n\s*\? recommendedNextPath\.prompt/,
+  "empty composer shows the recommendation without a key hint",
 );
+assert.doesNotMatch(source, /↵ to send|⇥ to fill/, "the composer renders no visible send or fill key tips");
 
 console.log("chat-composer-rec-autofill: all pins hold");

--- a/src/components/chat-session-chrome.test.ts
+++ b/src/components/chat-session-chrome.test.ts
@@ -91,14 +91,23 @@ test("2a — the title row and turn names wear the display serif", () => {
   );
 });
 
-test("2a ⑤ — follow-up suggestions spread the composer's width in ONE row", () => {
-  // The typed follow-up cards carry the design's geometry: equal shares of a
-  // single row (auto-flow column), never a count-blind grid that leaves a
-  // ragged 2+1 tail (#2672). next-paths caps the strip at 4.
+test("2a ⑤ — composer follow-ups are equal-width recommendation pills", () => {
+  // The typed follow-ups keep their equal-width one-row geometry, but their
+  // composer placement reads as quiet single-line recommendation pills.
   assert.match(
     styles,
     /\.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: column;[\s\S]*?grid-auto-columns: minmax\(0, 1fr\);/,
     "follow-up cards take equal shares of one row",
+  );
+  assert.match(
+    styles,
+    /\.cave-chat-followups \.cave-followup-card \{[\s\S]*?border-radius: var\(--radius-pill\);[\s\S]*?text-align: center;/,
+    "composer follow-ups use the shared pill radius and centered label",
+  );
+  assert.match(
+    styles,
+    /\.cave-chat-followups \.cave-followup-card__type,\s*\.cave-chat-followups \.cave-followup-card__outcome \{[\s\S]*?display: none;/,
+    "composer pills suppress visual metadata while preserving their accessible name",
   );
   // The pill-era override is gone: nothing renders .cave-next-path inside the
   // follow-up strip, so the orphaned selector must not linger in the cascade.

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -105,13 +105,17 @@ assert.doesNotMatch(
   "Composer dock model pill should be removed — header meta line carries the model",
 );
 
-// The steady-state hint survives behind the recommended-next-path ghost fill
-// (cave-h62k): with a recommendation the placeholder mirrors it (`⇥ to fill`),
-// without one the classic `Message <familiar>…  ↵ to send` remains.
+// The composer keeps the prompt-oriented ghost fill but leaves submission to
+// its high-contrast send button — no keyboard legend is rendered in the input.
 assert.match(
   source,
-  /: `Message \$\{familiar\.display_name\}…  ↵ to send`/,
-  "Composer placeholder should include ↵ to send hint in steady state",
+  /: `Message \$\{familiar\.display_name\}…`/,
+  "Composer placeholder should remain a concise familiar prompt in steady state",
+);
+assert.doesNotMatch(
+  source,
+  /↵ to send|⇥ to fill/,
+  "Composer should rely on its send button, without inline keyboard legends",
 );
 assert.match(
   source,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -6465,8 +6465,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 busy
                   ? "Streaming… (send to queue · esc to cancel)"
                   : recommendedNextPath
-                    ? `${recommendedNextPath.prompt}  ⇥ to fill`
-                    : `Message ${familiar.display_name}…  ↵ to send`
+                    ? recommendedNextPath.prompt
+                    : `Message ${familiar.display_name}…`
               }
               rows={1}
               inputMode="text"

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -375,6 +375,45 @@
   margin: 0 auto;
 }
 
+/* The dock is the one place next steps read as a compact prompt palette: the
+   full typed-action metadata remains available to assistive technology through
+   each button's aria-label, while the visual row stays as quiet as the input. */
+.cave-chat-followups .cave-followup-card {
+  display: block;
+  min-width: 0;
+  border-color: var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--bg-raised) 78%, transparent);
+  padding: var(--space-3) var(--space-4);
+  color: var(--text-secondary);
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.cave-chat-followups .cave-followup-card:hover {
+  border-color: color-mix(in oklch, var(--foreground) 52%, var(--border-strong));
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.cave-chat-followups .cave-followup-card__type,
+.cave-chat-followups .cave-followup-card__outcome {
+  display: none;
+}
+
+.cave-chat-followups .cave-followup-card__title {
+  display: block;
+  overflow: hidden;
+  font-size: var(--text-base);
+  font-weight: 500;
+  text-overflow: ellipsis;
+}
+
 /* Typed assistant suggestions keep their effect legible before activation.
    The card owns presentation only; ChatView owns routing and side effects. */
 .cave-followup-cards {
@@ -440,6 +479,42 @@
   box-shadow:
     0 14px 38px oklch(0 0 0 / 22%),
     inset 0 1px 0 color-mix(in oklch, var(--foreground) 8%, transparent);
+}
+
+/* Reference composer treatment: ChatView keeps the utility controls quiet and
+   makes one bright, square send control the clear end of the input row. */
+.cave-chat-linear .cave-composer-footer-action,
+.cave-chat-linear .cave-composer-plus {
+  width: var(--space-10);
+  height: var(--space-10);
+}
+
+.cave-chat-linear .cave-composer-control-row {
+  min-height: var(--space-10);
+}
+
+.cave-chat-linear .cave-composer-send {
+  width: var(--space-10);
+  height: var(--space-10);
+  border-color: transparent;
+  border-radius: var(--radius-control);
+  background: var(--text-primary);
+  color: var(--bg-panel);
+}
+
+.cave-chat-linear .cave-composer-send:hover:not(:disabled):not(.cave-composer-send--busy) {
+  background: color-mix(in oklch, var(--text-primary) 84%, var(--bg-hover));
+}
+
+.cave-chat-linear .cave-composer-send[data-typing="true"],
+.cave-chat-linear .cave-composer-send--queue {
+  background: var(--text-primary);
+}
+
+.cave-chat-linear .cave-composer-send--busy,
+.cave-chat-linear .cave-composer-send--busy:hover {
+  background: var(--color-danger);
+  color: var(--danger-text);
 }
 
 @media (max-width: 720px) {


### PR DESCRIPTION
## Summary

- Restyle the ChatView composer with a single high-contrast send action and compact utility controls.
- Render generated follow-ups as equal-width, centered recommendation pills.
- Remove visible inline keyboard legends and update the affected source contracts.

## Verification

- `pnpm test` (995 app test files)
- `pnpm lint`
- `pnpm check:tests-wired`
- Focused ChatView, follow-up, and composer source-contract tests

## Visual check

Native desktop validation could not launch because another CovenCave GUI instance owns desktop reachability; it was left untouched. The remaining manual check is a visual comparison in that active app.

Bead: `cave-68b7f`