### PR TITLE
feat(chat): batch the turn's tool calls and name the skills it used (cave-81wtu)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -190,6 +190,7 @@ export const SUITES = {
     "src/lib/chat-session-context.test.ts",
     "src/lib/chat-start-from.test.ts",
     "src/lib/chat-thread-instruments.test.ts",
+    "src/lib/chat-tool-batches.test.ts",
     "src/lib/chat-queue-followups.test.ts",
     "src/lib/chat-review-requests.test.ts",
     "src/lib/chat-starter-suggestions.test.ts",
@@ -434,6 +435,7 @@ export const SUITES = {
     "src/components/chat-siderail-hide-archived.test.ts",
     "src/components/chat-empty-state.test.ts",
     "src/components/chat-session-chrome.test.ts",
+    "src/components/chat-tool-batches-ui.test.ts",
     "src/components/chat-queue-group.test.ts",
     "src/components/chat-reviews-group.test.ts",
     "src/components/chat-new-dashboard.test.ts",
@@ -1420,6 +1422,8 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  // resolves "@/lib/tool-visual" for the batch band's tint
+  "src/lib/chat-tool-batches.test.ts",
   // reaches @/lib/next-paths and @/lib/familiar-stream through the draft module
   "src/lib/gh-review-draft.test.ts",
   // Imports the module under test, which resolves "@/lib/github-repo-link".

--- a/src/components/chat-tool-batches-ui.test.ts
+++ b/src/components/chat-tool-batches-ui.test.ts
@@ -1,0 +1,109 @@
+// @ts-nocheck
+// Source pins for the tool-activity card the Chat.dc.html hybrid draws
+// (2a ④, "Tool use, skills and capabilities as components"):
+//
+//   • the work line carries a quiet "N batches · M ok" rollup, and still
+//     hands running/failed calls their own tinted counters;
+//   • each block of calls gets one tinted band above its first row, and a
+//     turn with only one block gets no bands at all;
+//   • the SKILLS eyebrow sits above the card and is absent when the turn
+//     reached for no capability.
+//
+// The derivation itself is unit-tested in lib/chat-tool-batches.test.ts —
+// these pin that the surface actually renders it, and renders it once.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const activityCss = readFileSync(new URL("../styles/cave-chat/activity.css", import.meta.url), "utf8");
+
+test("2a ④ — the work line states batches and settled calls, trouble stays tinted", () => {
+  assert.match(
+    chatView,
+    /const rollup = toolBatchSummary\(tools, toolBatches\(tools\)\);/,
+    "the rollup comes from the pure model, not a second count in the component",
+  );
+  assert.match(
+    chatView,
+    /\{rollup \? <span className="cave-tool-rollup">\{rollup\}<\/span> : null\}[\s\S]{0,400}cave-tool-count--running[\s\S]{0,300}cave-tool-count--error/,
+    "the neutral rollup precedes the tinted running and error counters",
+  );
+});
+
+test("2a ④ — one band per block of calls, and none when a band would say nothing", () => {
+  const toolRuns = chatView.match(/function ToolRuns\([\s\S]*?\n\}/)?.[0] ?? "";
+  assert.ok(toolRuns, "expected ToolRuns in ChatView");
+  assert.match(
+    toolRuns,
+    /const bandedBatches =\s*\n\s*batches\.length > 1 && batches\.some\(\(batch\) => batch\.toolIds\.length > 1\) \? batches : \[\];/,
+    "bands only where they chunk something: never over a lone block, never one per single call",
+  );
+  assert.match(
+    toolRuns,
+    /headerByToolId\.get\(run\.tools\[0\]!\.id\)[\s\S]*?\{header \? <ToolBatchHeader batch=\{header\} \/> : null\}/,
+    "the band renders above the batch's first row, exactly once",
+  );
+  // The pre-existing run grammar has to survive: adjacent repeats still roll
+  // into a run, one-offs still render as blocks.
+  assert.match(
+    toolRuns,
+    /groupConsecutiveTools\(tools\)[\s\S]*<ToolRunGroup[\s\S]*<ToolBlock/,
+    "banding is layered over the existing run/block grammar, not instead of it",
+  );
+});
+
+test("2a ④ — the band states which move, what ran, how, and how long", () => {
+  const header = chatView.match(/function ToolBatchHeader\([\s\S]*?\n\}/)?.[0] ?? "";
+  assert.ok(header, "expected ToolBatchHeader in ChatView");
+  assert.match(header, /data-tool-category=\{batch\.category\}/, "the band takes the block's own tint");
+  for (const [field, why] of [
+    ["cave-tool-batch__index", "which move this is"],
+    ["cave-tool-batch__label", "what ran"],
+    ["cave-tool-batch__mode", "how it ran"],
+    ["cave-tool-batch__duration", "how long it took"],
+  ]) {
+    assert.match(header, new RegExp(field), `the band states ${why}`);
+  }
+});
+
+test("2a ④ — the skills eyebrow is derived, counted, and absent when empty", () => {
+  assert.match(
+    chatView,
+    /const skills = useMemo\(\(\) => turnSkills\(tools\), \[tools\]\);/,
+    "the chips come from the pure model over the turn's own tool events",
+  );
+  assert.match(
+    chatView,
+    /\{skills\.length > 0 \? \([\s\S]{0,200}className="cave-tool-skills"[\s\S]*?cave-tool-skills__label">Skills</,
+    "no capability, no eyebrow — the surface never labels an empty row",
+  );
+  assert.match(
+    chatView,
+    /className="cave-tool-skills__count">\s*\{skill\.calls\} \{skill\.calls === 1 \? "call" : "calls"\}/,
+    "each chip carries how many calls went through it",
+  );
+  assert.match(
+    chatView,
+    /name=\{skill\.source === "mcp" \? "ph:plug" : "ph:flask"\}/,
+    "a skill and an MCP server are told apart at a glance",
+  );
+});
+
+test("2a ④ — the band reuses the card's category tints instead of a second palette", () => {
+  assert.match(
+    activityCss,
+    /:is\(\.cave-tool-block, \.cave-tool-run, \.cave-tool-batch\)\[data-tool-category="shell"\]/,
+    "one tint set serves the row, the run and the band",
+  );
+  assert.doesNotMatch(
+    activityCss,
+    /\.cave-tool-batch\[data-tool-category="shell"\]\s*\{/,
+    "no standalone per-category rules for the band",
+  );
+  assert.match(
+    activityCss,
+    /\.cave-tool-batch \{[\s\S]*?--tool-accent: var\(--text-muted\);/,
+    "an unclassified block still gets a readable band rather than an unset colour",
+  );
+});

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -21,7 +21,7 @@ import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib
 import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { SETTLE_MIN_RUN_MS, shouldFlare } from "@/lib/flare-cooldown";
 import { groupConsecutiveTools, segmentTurn } from "@/lib/turn-segments";
-import { toolBatchSummary, toolBatches, turnSkills, type ToolBatch } from "@/lib/chat-tool-batches";
+import { formatBatchDuration, toolBatchSummary, toolBatches, turnSkills, type ToolBatch } from "@/lib/chat-tool-batches";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { invalidateConversation, readCachedConversation, storeConversation } from "@/lib/conversation-cache";
@@ -7772,7 +7772,7 @@ function ToolRuns({ tools }: { tools: ToolEvent[] }) {
  *  what ran, how it ran, and how long it took — tinted by the block's dominant
  *  tool category, the same palette the rows beneath it use. */
 function ToolBatchHeader({ batch }: { batch: ToolBatch }) {
-  const duration = fmtDuration(batch.durationMs);
+  const duration = formatBatchDuration(batch.durationMs);
   return (
     <div className="cave-tool-batch" data-tool-category={batch.category}>
       <span className="cave-tool-batch__dot" aria-hidden />

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -21,6 +21,7 @@ import { buildSketchPrompt, extractArtifactBlocks, titleFromPrompt } from "@/lib
 import { readCelebrationsEnabled } from "@/lib/celebrations-pref";
 import { SETTLE_MIN_RUN_MS, shouldFlare } from "@/lib/flare-cooldown";
 import { groupConsecutiveTools, segmentTurn } from "@/lib/turn-segments";
+import { toolBatchSummary, toolBatches, turnSkills, type ToolBatch } from "@/lib/chat-tool-batches";
 import { CHAT_OPEN_PROJECTS_EVENT } from "@/lib/chat-tab-events";
 import { isLiveSnapshotActive } from "@/lib/live-chat-snapshot";
 import { invalidateConversation, readCachedConversation, storeConversation } from "@/lib/conversation-cache";
@@ -7665,50 +7666,124 @@ function ToolGroup({ tools, durationMs }: { tools: ToolEvent[]; durationMs?: num
     .reverse()
     .find((t) => /bash|shell|terminal|command|exec/i.test(t.name));
   const lastCommand = lastShellTool ? toolArgSummary(lastShellTool.name, lastShellTool.input) : "";
+  // Chat.dc.html 2a ④: the quiet rollup on the right of the work line —
+  // "4 batches · 6 ok". Running and failed calls keep their tinted counters
+  // beside it so trouble never reads as neutral mono.
+  const rollup = toolBatchSummary(tools, toolBatches(tools));
+  // The capabilities this turn actually reached for, as the design's SKILLS
+  // eyebrow above the card. Absent when the turn used none — this surface
+  // never shows a label with nothing under it.
+  const skills = useMemo(() => turnSkills(tools), [tools]);
 
   return (
-    <details
-      className="cave-tool-group cave-work-line mt-3"
-      data-default-collapsed="true"
-      onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
-    >
-      <summary className="cave-tool-summary" aria-expanded={open} aria-label="Tool activity">
-        <span className="cave-work-line__label">
-          {duration ? `Worked for ${duration} · ` : ""}
-          {tools.length} {tools.length === 1 ? "step" : "steps"}
-        </span>
-        {lastCommand ? (
-          <span className="cave-work-line__ran">
-            {"· ran "}
-            <code className="cave-work-line__cmd">{lastCommand}</code>
+    <>
+      {skills.length > 0 ? (
+        <div className="cave-tool-skills" role="group" aria-label="Skills and capabilities used">
+          <span className="cave-tool-skills__label">Skills</span>
+          {skills.map((skill) => (
+            <span
+              key={skill.id}
+              className="cave-tool-skills__chip"
+              data-source={skill.source}
+              title={
+                skill.source === "mcp"
+                  ? `${skill.name} — MCP server, ${skill.calls} ${skill.calls === 1 ? "call" : "calls"} this turn`
+                  : `${skill.name} — skill, ${skill.calls} ${skill.calls === 1 ? "call" : "calls"} this turn`
+              }
+            >
+              <Icon
+                name={skill.source === "mcp" ? "ph:plug" : "ph:flask"}
+                width={11}
+                className="cave-tool-skills__icon"
+                aria-hidden
+              />
+              {skill.name}
+              <span className="cave-tool-skills__count">
+                {skill.calls} {skill.calls === 1 ? "call" : "calls"}
+              </span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <details
+        className="cave-tool-group cave-work-line mt-3"
+        data-default-collapsed="true"
+        onToggle={(e) => setOpen((e.target as HTMLDetailsElement).open)}
+      >
+        <summary className="cave-tool-summary" aria-expanded={open} aria-label="Tool activity">
+          <span className="cave-work-line__label">
+            {duration ? `Worked for ${duration} · ` : ""}
+            {tools.length} {tools.length === 1 ? "step" : "steps"}
           </span>
-        ) : null}
-        <span className="ml-auto flex items-center gap-1.5 font-mono text-[length:var(--text-2xs)] normal-case tracking-normal text-[var(--text-muted)]">
-          {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
-          {errors ? <span className="cave-tool-count cave-tool-count--error">{errors} {errors === 1 ? "error" : "errors"}</span> : null}
-        </span>
-      </summary>
-      <div className="mt-2 space-y-2 border-t border-[var(--border-hairline)]/70 pt-2">
-        <ToolRuns tools={tools} />
-      </div>
-    </details>
+          {lastCommand ? (
+            <span className="cave-work-line__ran">
+              {"· ran "}
+              <code className="cave-work-line__cmd">{lastCommand}</code>
+            </span>
+          ) : null}
+          <span className="ml-auto flex items-center gap-1.5 font-mono text-[length:var(--text-2xs)] normal-case tracking-normal text-[var(--text-muted)]">
+            {rollup ? <span className="cave-tool-rollup">{rollup}</span> : null}
+            {running ? <span className="cave-tool-count cave-tool-count--running">{running} running</span> : null}
+            {errors ? <span className="cave-tool-count cave-tool-count--error">{errors} {errors === 1 ? "error" : "errors"}</span> : null}
+          </span>
+        </summary>
+        <div className="mt-2 space-y-2 border-t border-[var(--border-hairline)]/70 pt-2">
+          <ToolRuns tools={tools} />
+        </div>
+      </details>
+    </>
   );
 }
 
 function ToolRuns({ tools }: { tools: ToolEvent[] }) {
+  // Chat.dc.html 2a ④: a real agent fires a block of calls, writes some prose,
+  // then fires again. Each block gets its own tinted band so a 30-step turn
+  // reads as four moves instead of one wall. Bands earn their place only when
+  // they chunk something: one block (including every transcript persisted
+  // before textOffset existed) needs no header, and a turn whose every call
+  // stands alone already reads one-move-per-row — a band over each would
+  // repeat the row beneath it.
+  const batches = toolBatches(tools);
+  const bandedBatches =
+    batches.length > 1 && batches.some((batch) => batch.toolIds.length > 1) ? batches : [];
+  const headerByToolId = new Map(bandedBatches.map((batch) => [batch.headToolId, batch]));
   return groupConsecutiveTools(tools).map((run) => {
+    const key = run.tools.map((tool) => tool.id).join(":");
+    const header = headerByToolId.get(run.tools[0]!.id);
     // File-mutation cards carry review/undo affordances. Keeping each one
     // standalone means a repeated edit never hides an actionable change.
     const containsEdit = run.tools.some((tool) => toolInputAsDiff(tool.name, tool.input) != null);
-    if (run.tools.length > 1 && !containsEdit) {
-      return <ToolRunGroup key={run.tools.map((tool) => tool.id).join(":")} name={run.name} tools={run.tools} />;
-    }
+    const body =
+      run.tools.length > 1 && !containsEdit ? (
+        <ToolRunGroup name={run.name} tools={run.tools} />
+      ) : (
+        run.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)
+      );
     return (
-      <Fragment key={run.tools.map((tool) => tool.id).join(":")}>
-        {run.tools.map((tool) => <ToolBlock key={tool.id} tool={tool} />)}
+      <Fragment key={key}>
+        {header ? <ToolBatchHeader batch={header} /> : null}
+        {body}
       </Fragment>
     );
   });
+}
+
+/** The band above a batch of calls (Chat.dc.html 2a ④): which move this is,
+ *  what ran, how it ran, and how long it took — tinted by the block's dominant
+ *  tool category, the same palette the rows beneath it use. */
+function ToolBatchHeader({ batch }: { batch: ToolBatch }) {
+  const duration = fmtDuration(batch.durationMs);
+  return (
+    <div className="cave-tool-batch" data-tool-category={batch.category}>
+      <span className="cave-tool-batch__dot" aria-hidden />
+      <span className="cave-tool-batch__index">batch {batch.index}</span>
+      <span className="cave-tool-batch__label" title={batch.label}>
+        {batch.label}
+      </span>
+      <span className="cave-tool-batch__mode">{batch.mode}</span>
+      <span className="cave-tool-batch__duration">{duration}</span>
+    </div>
+  );
 }
 
 function ToolRunGroup({ name, tools }: { name: string; tools: ToolEvent[] }) {

--- a/src/lib/chat-tool-batches.test.ts
+++ b/src/lib/chat-tool-batches.test.ts
@@ -6,6 +6,7 @@ import test from "node:test";
 
 import {
   LONG_RUNNING_BATCH_MS,
+  formatBatchDuration,
   toolBatchSummary,
   toolBatches,
   turnSkills,
@@ -125,6 +126,15 @@ test("the rollup counts batches and settled calls, leaving trouble to the tinted
 
   const running = [tool({ id: "a", name: "Bash", textOffset: 0, status: "running" })];
   assert.equal(toolBatchSummary(running, toolBatches(running)), "", "nothing has settled yet");
+});
+
+test("a band's duration keeps the precision the number deserves", () => {
+  assert.equal(formatBatchDuration(400), "0.4s", "a fast batch never reads as taking no time");
+  assert.equal(formatBatchDuration(20), "0.1s", "work that happened is never rounded away to zero");
+  assert.equal(formatBatchDuration(1600), "2s");
+  assert.equal(formatBatchDuration(19 * 60_000 + 4000), "19m 4s");
+  assert.equal(formatBatchDuration(2 * 3_600_000), "2h");
+  assert.equal(formatBatchDuration(undefined), "", "no reported time renders no time");
 });
 
 test("skills are the capabilities the turn actually reached for", () => {

--- a/src/lib/chat-tool-batches.test.ts
+++ b/src/lib/chat-tool-batches.test.ts
@@ -1,0 +1,174 @@
+// @ts-nocheck
+// The tool-activity card's pure model (Chat.dc.html 2a ④): batches derived
+// from the transcript's own textOffset, and the skill/MCP chips above them.
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  LONG_RUNNING_BATCH_MS,
+  toolBatchSummary,
+  toolBatches,
+  turnSkills,
+} from "./chat-tool-batches.ts";
+
+const tool = (over) => ({
+  id: over.id,
+  name: over.name,
+  status: over.status ?? "ok",
+  ...over,
+});
+
+test("consecutive calls sharing a text offset are one batch", () => {
+  const batches = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0, durationMs: 400 }),
+    tool({ id: "b", name: "Grep", textOffset: 0, durationMs: 200 }),
+    tool({ id: "c", name: "Read", textOffset: 180, durationMs: 100 }),
+    tool({ id: "d", name: "Edit", textOffset: 180, durationMs: 300 }),
+  ]);
+
+  assert.equal(batches.length, 2, "the offset moves once, so there are two blocks");
+  assert.deepEqual(batches[0].toolIds, ["a", "b"]);
+  assert.deepEqual(batches[1].toolIds, ["c", "d"]);
+  assert.equal(batches[0].index, 1);
+  assert.equal(batches[1].index, 2);
+  assert.equal(batches[0].headToolId, "a", "the header renders above the batch's first row");
+});
+
+test("a batch names the distinct tools it ran, in first-use order", () => {
+  const [batch] = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0 }),
+    tool({ id: "b", name: "Grep", textOffset: 0 }),
+    tool({ id: "c", name: "Bash", textOffset: 0 }),
+  ]);
+  assert.equal(batch.label, "Bash · Grep", "a repeated tool is named once");
+});
+
+test("a wide fan-out rolls its label up rather than wrapping", () => {
+  const [batch] = toolBatches(
+    ["Bash", "Grep", "Read", "Edit", "WebFetch"].map((name, i) =>
+      tool({ id: `t${i}`, name, textOffset: 0 }),
+    ),
+  );
+  assert.equal(batch.label, "Bash · Grep · Read +2");
+});
+
+test("mode reports the shape the transcript can actually see", () => {
+  const single = toolBatches([tool({ id: "a", name: "Bash", textOffset: 0, durationMs: 400 })]);
+  assert.equal(single[0].mode, "single call");
+
+  const several = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0, durationMs: 400 }),
+    tool({ id: "b", name: "Grep", textOffset: 0, durationMs: 200 }),
+  ]);
+  assert.equal(several[0].mode, "2 calls", "no start times means no parallelism claim");
+
+  const slow = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0, durationMs: LONG_RUNNING_BATCH_MS }),
+  ]);
+  assert.equal(slow[0].mode, "long-running", "a long wait is the headline, not the count");
+});
+
+test("a batch sums its calls' wall time, and stays silent without one", () => {
+  const [timed] = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0, durationMs: 400 }),
+    tool({ id: "b", name: "Grep", textOffset: 0, durationMs: 250 }),
+  ]);
+  assert.equal(timed.durationMs, 650);
+
+  const [untimed] = toolBatches([tool({ id: "a", name: "Bash", textOffset: 0 })]);
+  assert.equal(untimed.durationMs, undefined, "no reported duration invents no number");
+});
+
+test("the batch tint follows the block's dominant register", () => {
+  const [batch] = toolBatches([
+    tool({ id: "a", name: "Read", textOffset: 0 }),
+    tool({ id: "b", name: "Read", textOffset: 0 }),
+    tool({ id: "c", name: "Edit", textOffset: 0 }),
+  ]);
+  assert.equal(batch.category, "read", "the majority wins, not the last call");
+});
+
+test("a legacy turn with no offsets is one batch, not one per call", () => {
+  const batches = toolBatches([
+    tool({ id: "a", name: "Bash" }),
+    tool({ id: "b", name: "Grep" }),
+    tool({ id: "c", name: "Read" }),
+  ]);
+  assert.equal(batches.length, 1, "transcripts persisted before textOffset render unbanded");
+  assert.deepEqual(batches[0].toolIds, ["a", "b", "c"]);
+});
+
+test("an offsetless call joins the batch in progress", () => {
+  const batches = toolBatches([
+    tool({ id: "a", name: "Bash", textOffset: 0 }),
+    tool({ id: "b", name: "Grep" }),
+    tool({ id: "c", name: "Read", textOffset: 120 }),
+  ]);
+  assert.equal(batches.length, 2);
+  assert.deepEqual(batches[0].toolIds, ["a", "b"]);
+});
+
+test("the rollup counts batches and settled calls, leaving trouble to the tinted counters", () => {
+  const tools = [
+    tool({ id: "a", name: "Bash", textOffset: 0 }),
+    tool({ id: "b", name: "Grep", textOffset: 0 }),
+    tool({ id: "c", name: "Read", textOffset: 90, status: "error" }),
+  ];
+  assert.equal(
+    toolBatchSummary(tools, toolBatches(tools)),
+    "2 batches · 2 ok",
+    "the failure keeps its own tinted counter rather than reading as neutral mono",
+  );
+
+  const clean = [tool({ id: "a", name: "Bash", textOffset: 0 })];
+  assert.equal(toolBatchSummary(clean, toolBatches(clean)), "1 ok", "a single batch is not worth saying");
+
+  const running = [tool({ id: "a", name: "Bash", textOffset: 0, status: "running" })];
+  assert.equal(toolBatchSummary(running, toolBatches(running)), "", "nothing has settled yet");
+});
+
+test("skills are the capabilities the turn actually reached for", () => {
+  const skills = turnSkills([
+    tool({ id: "a", name: "Skill", input: '{"skill":"release-audit"}' }),
+    tool({ id: "b", name: "Bash" }),
+    tool({ id: "c", name: "Skill", input: '{"skill":"release-audit"}' }),
+    tool({ id: "d", name: "mcp__github__list_runs" }),
+    tool({ id: "e", name: "mcp__github__get_release" }),
+  ]);
+
+  assert.deepEqual(
+    skills.map((s) => [s.id, s.name, s.source, s.calls]),
+    [
+      ["skill:release-audit", "release-audit", "skill", 2],
+      ["mcp:github", "github", "mcp", 2],
+    ],
+    "first-use order, one chip per capability, counted",
+  );
+});
+
+test("a skill names itself from whichever key the harness used", () => {
+  const skills = turnSkills([
+    tool({ id: "a", name: "Skill", input: '{"command":"/branch-to-merge extra args"}' }),
+    tool({ id: "b", name: "Skill", input: "deep-research" }),
+  ]);
+  assert.deepEqual(
+    skills.map((s) => s.name),
+    ["branch-to-merge", "deep-research"],
+  );
+});
+
+test("an unnamed skill yields no chip", () => {
+  assert.deepEqual(
+    turnSkills([
+      tool({ id: "a", name: "Skill" }),
+      tool({ id: "b", name: "Skill", input: "{not json" }),
+      tool({ id: "c", name: "Skill", input: '{"args":"nothing useful"}' }),
+    ]),
+    [],
+    "a capability the payload cannot name is worse than none",
+  );
+});
+
+test("ordinary tools are not mistaken for capabilities", () => {
+  assert.deepEqual(turnSkills([tool({ id: "a", name: "Bash" }), tool({ id: "b", name: "Read" })]), []);
+});

--- a/src/lib/chat-tool-batches.ts
+++ b/src/lib/chat-tool-batches.ts
@@ -1,0 +1,230 @@
+// Pure model for the tool-activity card the Chat.dc.html hybrid draws (2a ④,
+// "Tool use, skills and capabilities as components"):
+//
+//   • BATCHES — a real agent fires a block of calls, writes some prose, then
+//     fires again. The design bands each block with its own tinted header
+//     (batch index · what ran · how it ran · how long).
+//   • SKILLS — the eyebrow row above the card, one chip per skill or MCP
+//     server the turn actually reached for, with its call count.
+//
+// Everything here is derived from the transcript's own ToolEvent[] — no new
+// plumbing, no fetch, no invented facts. `textOffset` (the length of the turn
+// text when a tool's first event arrived) is the honest batch signal: calls
+// issued in one block share an offset, and the offset only moves once the
+// model has streamed more prose. Legacy turns persisted before the field land
+// in a single batch, which the card renders without any batch chrome at all.
+//
+// Deliberately dependency-free apart from the shared tool-category map, so it
+// is unit-testable with bare node and can never disagree with the rows it
+// annotates.
+
+import { toolCategory, type ToolCategory } from "@/lib/tool-visual";
+
+/** Minimal structural slice of chat-turn-state's ToolEvent the model reads. */
+export type BatchTool = {
+  id: string;
+  name: string;
+  input?: string;
+  status: "running" | "ok" | "error";
+  durationMs?: number;
+  textOffset?: number;
+};
+
+export type ToolBatch = {
+  /** 1-based position of this batch within the turn. */
+  index: number;
+  /** Id of the batch's first tool — the row the header is rendered above. */
+  headToolId: string;
+  /** Every tool in the batch, in order. */
+  toolIds: string[];
+  /** Dominant category; drives the band's tint through data-tool-category. */
+  category: ToolCategory;
+  /** What ran — the distinct tool names, in first-use order. */
+  label: string;
+  /** How it ran, in the design's short mono register. */
+  mode: string;
+  /** Summed wall time; absent when no tool in the batch reported one. */
+  durationMs?: number;
+};
+
+/** A batch whose calls together took at least this long reads as long-running
+ *  rather than as a count — the interesting fact about a 19-minute CI watch is
+ *  the wait, not that it was one call. */
+export const LONG_RUNNING_BATCH_MS = 60_000;
+
+/** Distinct tool names shown in a batch label before it rolls up to "+N". */
+const LABEL_NAME_CAP = 3;
+
+/** Consecutive tools that share a `textOffset` were issued in one block.
+ *  A tool with no offset joins the batch in progress rather than starting a
+ *  new one, so a legacy turn (no offsets at all) is a single batch. */
+export function toolBatches(tools: readonly BatchTool[]): ToolBatch[] {
+  const groups: BatchTool[][] = [];
+  let currentOffset: number | undefined;
+  for (const tool of tools) {
+    const offset = Number.isFinite(tool.textOffset) ? tool.textOffset : undefined;
+    const startsBatch =
+      groups.length === 0 ||
+      (offset !== undefined && currentOffset !== undefined && offset !== currentOffset);
+    if (startsBatch) {
+      groups.push([tool]);
+      currentOffset = offset;
+    } else {
+      groups[groups.length - 1]!.push(tool);
+      if (currentOffset === undefined) currentOffset = offset;
+    }
+  }
+  return groups.map((group, i) => {
+    const durationMs = batchDuration(group);
+    return {
+      index: i + 1,
+      headToolId: group[0]!.id,
+      toolIds: group.map((t) => t.id),
+      category: dominantCategory(group),
+      label: batchLabel(group),
+      mode: batchMode(group, durationMs),
+      ...(durationMs !== undefined ? { durationMs } : {}),
+    };
+  });
+}
+
+/** The batch's own register: the most-used category, first-use order breaking
+ *  ties, so a read+read+edit block reads as "read" and not as its last call. */
+function dominantCategory(group: readonly BatchTool[]): ToolCategory {
+  const counts = new Map<ToolCategory, number>();
+  for (const tool of group) {
+    const category = toolCategory(tool.name);
+    counts.set(category, (counts.get(category) ?? 0) + 1);
+  }
+  let best: ToolCategory = toolCategory(group[0]!.name);
+  let bestCount = 0;
+  for (const tool of group) {
+    const category = toolCategory(tool.name);
+    const count = counts.get(category) ?? 0;
+    if (count > bestCount) {
+      best = category;
+      bestCount = count;
+    }
+  }
+  return best;
+}
+
+/** What ran, named honestly: the distinct tool names in the order the batch
+ *  used them, rolled up past three so a wide fan-out stays one line. */
+function batchLabel(group: readonly BatchTool[]): string {
+  const names: string[] = [];
+  for (const tool of group) {
+    const name = tool.name.trim();
+    if (name && !names.includes(name)) names.push(name);
+  }
+  if (names.length === 0) return "";
+  if (names.length <= LABEL_NAME_CAP) return names.join(" · ");
+  return `${names.slice(0, LABEL_NAME_CAP).join(" · ")} +${names.length - LABEL_NAME_CAP}`;
+}
+
+/** How it ran. The transcript records no start times, so this never claims
+ *  parallelism it cannot see — it reports the shape it can: one call, N calls,
+ *  or a batch whose wall time makes the wait the headline. */
+function batchMode(group: readonly BatchTool[], duration: number | undefined): string {
+  if (duration !== undefined && duration >= LONG_RUNNING_BATCH_MS) return "long-running";
+  if (group.length === 1) return "single call";
+  return `${group.length} calls`;
+}
+
+function batchDuration(group: readonly BatchTool[]): number | undefined {
+  let total: number | undefined;
+  for (const tool of group) {
+    if (!Number.isFinite(tool.durationMs)) continue;
+    total = (total ?? 0) + (tool.durationMs as number);
+  }
+  return total;
+}
+
+/** The work line's quiet right-hand rollup — "4 batches · 6 ok". Only the
+ *  settled good news lives here; running and failed calls keep their own
+ *  tinted counters beside it, so a problem never reads as neutral mono. A
+ *  lone batch is not worth saying, and neither is a zero. */
+export function toolBatchSummary(
+  tools: readonly BatchTool[],
+  batches: readonly ToolBatch[],
+): string {
+  const parts: string[] = [];
+  if (batches.length > 1) parts.push(`${batches.length} batches`);
+  const ok = tools.filter((t) => t.status === "ok").length;
+  if (ok) parts.push(`${ok} ok`);
+  return parts.join(" · ");
+}
+
+export type TurnSkill = {
+  /** Stable chip key — `skill:<name>` or `mcp:<server>`. */
+  id: string;
+  /** What to show: the skill's own name, or the MCP server's. */
+  name: string;
+  source: "skill" | "mcp";
+  /** How many calls in this turn went through it. */
+  calls: number;
+};
+
+/** The capabilities the turn actually reached for, in first-use order: skills
+ *  invoked through the harness's Skill tool, then MCP servers named by their
+ *  `mcp__<server>__<tool>` calls. A skill whose name cannot be read off its
+ *  input yields no chip — an unnamed capability is worse than none. */
+export function turnSkills(tools: readonly BatchTool[]): TurnSkill[] {
+  const found = new Map<string, TurnSkill>();
+  const bump = (id: string, name: string, source: TurnSkill["source"]) => {
+    const existing = found.get(id);
+    if (existing) existing.calls += 1;
+    else found.set(id, { id, name, source, calls: 1 });
+  };
+  for (const tool of tools) {
+    const raw = tool.name.trim();
+    const lower = raw.toLowerCase();
+    if (lower === "skill" || lower === "skills") {
+      const name = skillNameFromInput(tool.input);
+      if (name) bump(`skill:${name}`, name, "skill");
+      continue;
+    }
+    const server = mcpServer(raw);
+    if (server) bump(`mcp:${server}`, server, "mcp");
+  }
+  return [...found.values()];
+}
+
+/** `mcp__github__list_runs` → `github`. Null for anything not MCP-namespaced. */
+function mcpServer(name: string): string | null {
+  const match = /^mcp_{1,2}(.+)$/i.exec(name);
+  if (!match) return null;
+  const rest = match[1] ?? "";
+  const server = rest.split("__")[0] ?? "";
+  return server.trim() || null;
+}
+
+/** The skill's name as the harness passed it — `{"skill":"release-audit"}`,
+ *  `{"command":"/release-audit"}`, or a bare name. Null when the payload does
+ *  not say, so the chip row never guesses. */
+function skillNameFromInput(input: string | undefined): string | null {
+  const text = (input ?? "").trim();
+  if (!text) return null;
+  if (!text.startsWith("{")) return cleanSkillName(text);
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!parsed || typeof parsed !== "object") return null;
+  const record = parsed as Record<string, unknown>;
+  for (const key of ["skill", "name", "command", "skill_name", "skillName"]) {
+    const value = record[key];
+    if (typeof value === "string") {
+      const name = cleanSkillName(value);
+      if (name) return name;
+    }
+  }
+  return null;
+}
+
+function cleanSkillName(value: string): string | null {
+  const name = value.trim().replace(/^\/+/, "").split(/\s+/)[0] ?? "";
+  return name || null;
+}

--- a/src/lib/chat-tool-batches.ts
+++ b/src/lib/chat-tool-batches.ts
@@ -155,6 +155,23 @@ export function toolBatchSummary(
   return parts.join(" · ");
 }
 
+/** The band's own duration, to the precision the number deserves: a batch of
+ *  fast calls reads "0.4s" rather than the shared formatter's "0s", which
+ *  claims the work took no time at all. Absent when nothing was reported. */
+export function formatBatchDuration(durationMs: number | undefined): string {
+  if (!Number.isFinite(durationMs) || (durationMs as number) < 0) return "";
+  const ms = durationMs as number;
+  if (ms < 1000) return `${Math.max(0.1, Math.round(ms / 100) / 10)}s`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  const rest = seconds % 60;
+  if (minutes < 60) return rest ? `${minutes}m ${rest}s` : `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const restMinutes = minutes % 60;
+  return restMinutes ? `${hours}h ${restMinutes}m` : `${hours}h`;
+}
+
 export type TurnSkill = {
   /** Stable chip key — `skill:<name>` or `mcp:<server>`. */
   id: string;

--- a/src/lib/chat-tool-batches.ts
+++ b/src/lib/chat-tool-batches.ts
@@ -11,8 +11,8 @@
 // plumbing, no fetch, no invented facts. `textOffset` (the length of the turn
 // text when a tool's first event arrived) is the honest batch signal: calls
 // issued in one block share an offset, and the offset only moves once the
-// model has streamed more prose. Legacy turns persisted before the field land
-// in a single batch, which the card renders without any batch chrome at all.
+// model has streamed more prose. Turns persisted before that field existed all
+// land in one batch, which the card renders without any batch chrome at all.
 //
 // Deliberately dependency-free apart from the shared tool-category map, so it
 // is unit-testable with bare node and can never disagree with the rows it

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -378,15 +378,111 @@ details[open] > .cave-tool-summary::before {
 .cave-tool-icon { color: var(--tool-accent); }
 .cave-tool-name { color: color-mix(in oklch, var(--tool-accent) 80%, var(--text-secondary)); }
 
-.cave-tool-block[data-tool-category="shell"], .cave-tool-run[data-tool-category="shell"]  { --tool-accent: oklch(0.80 0.15 150); } /* green */
-.cave-tool-block[data-tool-category="read"], .cave-tool-run[data-tool-category="read"]   { --tool-accent: oklch(0.74 0.13 235); } /* blue */
-.cave-tool-block[data-tool-category="search"], .cave-tool-run[data-tool-category="search"] { --tool-accent: oklch(0.74 0.16 295); } /* violet */
-.cave-tool-block[data-tool-category="edit"], .cave-tool-run[data-tool-category="edit"]   { --tool-accent: oklch(0.82 0.14 75); }  /* amber */
-.cave-tool-block[data-tool-category="agent"], .cave-tool-run[data-tool-category="agent"]  { --tool-accent: oklch(0.74 0.18 350); } /* magenta */
-.cave-tool-block[data-tool-category="web"], .cave-tool-run[data-tool-category="web"]    { --tool-accent: oklch(0.78 0.12 200); } /* teal */
-.cave-tool-block[data-tool-category="task"], .cave-tool-run[data-tool-category="task"]   { --tool-accent: oklch(0.80 0.13 95); }  /* lime */
-.cave-tool-block[data-tool-category="mcp"], .cave-tool-run[data-tool-category="mcp"]    { --tool-accent: oklch(0.72 0.14 270); } /* indigo */
-.cave-tool-block[data-tool-category="other"], .cave-tool-run[data-tool-category="other"]  { --tool-accent: var(--text-muted); }
+/* One tint set for every category-coded surface in the card — the row, the
+   run, and the batch band above them. Grouping with :is() keeps a fourth
+   consumer from costing a fourth selector list. */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="shell"]  { --tool-accent: oklch(0.80 0.15 150); } /* green */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="read"]   { --tool-accent: oklch(0.74 0.13 235); } /* blue */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="search"] { --tool-accent: oklch(0.74 0.16 295); } /* violet */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="edit"]   { --tool-accent: oklch(0.82 0.14 75); }  /* amber */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="agent"]  { --tool-accent: oklch(0.74 0.18 350); } /* magenta */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="web"]    { --tool-accent: oklch(0.78 0.12 200); } /* teal */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="task"]   { --tool-accent: oklch(0.80 0.13 95); }  /* lime */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="mcp"]    { --tool-accent: oklch(0.72 0.14 270); } /* indigo */
+:is(.cave-tool-block, .cave-tool-run, .cave-tool-batch)[data-tool-category="other"]  { --tool-accent: var(--text-muted); }
+
+/* ── Batch band (Chat.dc.html 2a ④) ────────────────────────────────────────
+   A turn's calls arrive in blocks: the agent fires several, writes prose,
+   fires again. Each block gets one thin tinted band — which move this is,
+   what ran, how it ran, how long — so a thirty-step turn reads as four moves
+   instead of one wall. Only rendered when a turn has more than one block. */
+.cave-tool-batch {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  --tool-accent: var(--text-muted);
+  border: 1px solid color-mix(in oklch, var(--tool-accent) 22%, transparent);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--tool-accent) 7%, transparent);
+  padding: 0 var(--space-3);
+  min-height: 25px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.cave-tool-batch__dot {
+  flex: none;
+  width: 5px;
+  height: 5px;
+  border-radius: var(--radius-pill);
+  background: var(--tool-accent);
+}
+.cave-tool-batch__index {
+  flex: none;
+  color: var(--tool-accent);
+}
+/* What ran is the one human phrase in the band, so it drops the mono/caps
+   register the machine-readable parts keep. */
+.cave-tool-batch__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: var(--text-xs);
+  letter-spacing: 0.02em;
+  text-overflow: ellipsis;
+  text-transform: none;
+  white-space: nowrap;
+}
+.cave-tool-batch__mode,
+.cave-tool-batch__duration {
+  flex: none;
+  color: var(--text-muted);
+}
+.cave-tool-batch__duration {
+  min-width: 44px;
+  text-align: right;
+}
+
+/* ── Skills eyebrow (Chat.dc.html 2a ④) ────────────────────────────────────
+   The capabilities the turn actually reached for — skills invoked through the
+   harness's Skill tool, and MCP servers named by their own calls — above the
+   card, with how many calls each took. Absent when the turn used none. */
+.cave-tool-skills {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+}
+.cave-tool-skills__label {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+.cave-tool-skills__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  height: 22px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  padding: 0 var(--space-2);
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+}
+.cave-tool-skills__icon { color: var(--accent-presence); }
+.cave-tool-skills__count { color: var(--text-muted); }
+
+/* The work line's quiet rollup — "4 batches · 6 ok". One phrase, never wrapped
+   away from the tinted running/error counters beside it. */
+.cave-tool-rollup { white-space: nowrap; }
 
 /* CHAT-D4-07: expanded tool I/O is secondary context — clamp it tighter than
    prose code blocks (which cap at min(60vh, 520px), CHAT-D7-03). 360px sits


### PR DESCRIPTION
Implements the tool-activity component the `Chat.dc.html` hybrid draws — turn 2, option **2a ④**, *"Tool use, skills and capabilities as components"* — from the [Chat page interface overhaul](https://claude.ai/design/p/e13203e0-f296-4381-bd47-f3d645b10636?file=Chat.dc.html) handoff. It is the piece the handoff's own close-up calls out, and the last unbuilt part of that turn's assistant-turn anatomy.

## What the design asks for

A real agent does not emit one flat list of calls. It fires a block, writes some prose, then fires again. The design bands each block with its own tinted header — which move this is, what ran, how it ran, how long it took — and puts a **SKILLS** eyebrow above the card naming the capabilities the turn reached for, each with its call count. The work line's right side carries a quiet `4 batches · 6 ok`.

## What this ships

- **Batch bands.** One thin tinted band per block of calls, tinted by the block's dominant tool category — the *same* `data-tool-category` palette the rows beneath it already use, not a second one.
- **Skills eyebrow.** One chip per skill or MCP server the turn used, with how many calls went through it. Skills carry `ph:flask`, MCP servers `ph:plug`, so the two are told apart at a glance.
- **Work-line rollup.** `N batches · M ok`, with running and failed calls keeping their existing tinted counters beside it so trouble never reads as neutral mono.

## Derived, not plumbed

Everything comes from the transcript's own `ToolEvent[]`. No new fields, no fetch, no daemon dependency:

- `textOffset` — the length of the turn text when a call's first event arrived — is the honest block boundary. Calls issued together share one; it only moves once the model has streamed more prose.
- Skill invocations name themselves in the `Skill` tool's own input; MCP calls name their server in `mcp__<server>__<tool>`.

`src/lib/chat-tool-batches.ts` is the whole derivation — pure, dependency-light, and unit-tested with bare node.

## Where it refuses to overclaim

The design's mock says *"2 in parallel"* and *"2 sequential"*. The transcript records no start times, so this cannot know which — and does not pretend to. It reports only the shape it can see: `single call`, `N calls`, or `long-running` when a block's wall time makes the wait the headline. Likewise a batch with no reported durations shows no number, and a skill whose payload does not name it yields no chip: an unnamed capability is worse than none.

## Where bands stay out of the way

Bands earn their place only when they chunk something.

- One block → no bands. That includes **every transcript persisted before `textOffset` existed**, which lands in a single batch by construction.
- Every call standing alone → no bands either, since a header over each would only repeat the row beneath it.

The existing run/block grammar is untouched: adjacent repeats still roll into an expandable run, and file mutations still keep their edit card with Review/Undo.

## Cost

Regrouping the nine category-tint rules with `:is()` pays for the band as a third consumer and then some. First-load CSS lands at **913 064 B against the 921 600 B budget**. Every new spacing and radius value sits on the scale, so `offScaleSpacingPx` and `offScaleRadiusPx` both hold at their baselines — no ratchet was raised.

## Verification

- `pnpm test:app` green · `pnpm test:api` green · `pnpm build` green (bundle budget within) · `pnpm lint` clean · `tsc --noEmit` clean.
- 19 new assertions: `src/lib/chat-tool-batches.test.ts` (the derivation) and `src/components/chat-tool-batches-ui.test.ts` (that the surface renders it, once).
- **Driven in the real app** against a rendered transcript, which is how the duration bug in the second commit was found: the band was printing `0s` over a block that plainly took time. The bands now read `0.6s`, `0.9s`, `0.4s`, and `long-running 19m 5s`.

Closes cave-81wtu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)