### PR TITLE
fix(research): bound short-video narration

### DIFF
--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -132,8 +132,11 @@ export const RESEARCH_MEDIA_LENGTH_LIMITS = {
     extended: { maxCharacters: 13_500 },
   },
   "short-video": {
-    brief: { maxDurationMs: 30_000, maxScenes: 6 },
-    standard: { maxDurationMs: 60_000, maxScenes: 12 },
+    // These conservative source budgets leave time for slow technical terms,
+    // citations, and provider-specific pacing. The renderer still measures the
+    // real audio and enforces the duration cap before publication.
+    brief: { maxDurationMs: 30_000, maxScenes: 6, maxCharacters: 300 },
+    standard: { maxDurationMs: 60_000, maxScenes: 12, maxCharacters: 600 },
   },
   "long-video": {
     brief: { maxDurationMs: 300_000, maxChapters: 4, maxScenes: 20 },

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -503,6 +503,76 @@ test("video storyboard drafter maps headings, bullets, and narration without inv
   assert.ok(content.storyboard.every((scene) => scene.id.startsWith("scene-")));
 });
 
+test("short-video drafts keep complete source bullets within each preset narration budget", () => {
+  const source = {
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Bounded video source",
+      "",
+      "## Executive summary",
+      "",
+      `- ${"First evidence-backed finding ".repeat(6).trim()}.`,
+      `- ${"Second evidence-backed finding ".repeat(6).trim()}.`,
+      `- ${"Third evidence-backed finding ".repeat(6).trim()}.`,
+      "",
+      "## Next steps",
+      "",
+      `- ${"Follow-up finding ".repeat(6).trim()}.`,
+    ].join("\n"),
+  };
+
+  const brief = draftVideoStoryboardContent(source, "brief");
+  const standard = draftVideoStoryboardContent(source, "standard");
+  assert.equal(brief.kind, "short-video");
+  assert.equal(standard.kind, "short-video");
+  if (brief.kind !== "short-video" || standard.kind !== "short-video") return;
+
+  const narrationLength = (content: typeof brief) =>
+    content.storyboard.reduce((total, scene) => total + scene.narration.length, 0);
+  assert.ok(narrationLength(brief) <= 300, "brief narration must fit its 30-second budget");
+  assert.ok(narrationLength(standard) <= 600, "standard narration must fit its 60-second budget");
+  assert.ok(brief.storyboard.length > 0, "brief keeps the leading fitting source bullet");
+  assert.ok(
+    narrationLength(standard) > narrationLength(brief),
+    "standard admits more source detail",
+  );
+  assert.ok(brief.storyboard.length <= standard.storyboard.length);
+  for (const content of [brief, standard]) {
+    for (const scene of content.storyboard) {
+      assert.equal(scene.narration, [scene.title, ...scene.bullets].join(". "));
+      assert.ok(source.markdown.includes(scene.title), "scene heading remains source-extractive");
+      assert.ok(
+        scene.bullets.every((bullet) => source.markdown.includes(bullet)),
+        "scene bullets remain source-extractive",
+      );
+    }
+  }
+});
+
+test("short-video drafts retain a fitting title when its source detail exceeds the remaining budget", () => {
+  const content = draftVideoStoryboardContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Bounded video source",
+      "",
+      "## Fitting heading",
+      "",
+      `- ${"Oversized source detail ".repeat(20).trim()}.`,
+    ].join("\n"),
+  }, "brief");
+
+  assert.equal(content.kind, "short-video");
+  if (content.kind !== "short-video") return;
+  assert.deepEqual(content.storyboard, [{
+    id: "scene-1",
+    title: "Fitting heading",
+    bullets: [],
+    narration: "Fitting heading",
+  }]);
+});
+
 // ── directions are forwarded, never interpreted ──────────────────────────────
 
 test("directions are stored verbatim but never steer the extracted content", async () => {

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -866,23 +866,65 @@ function storyboardSceneFromSection(
   };
 }
 
+function shortVideoStoryboardSceneFromSection(
+  section: MarkdownSection,
+  index: number,
+  maxNarrationCharacters: number,
+): ResearchGenerationStoryboardScene | null {
+  const availableBullets = (section.bullets.length > 0
+    ? section.bullets
+    : section.firstLine
+      ? [section.firstLine]
+      : []).slice(0, MAX_SLIDE_BULLETS);
+  const bullets: string[] = [];
+  for (const bullet of availableBullets) {
+    const narration = [section.title, ...bullets, bullet].join(". ");
+    if (narration.length > maxNarrationCharacters) break;
+    bullets.push(bullet);
+  }
+  if (bullets.length === 0 && section.title.length > maxNarrationCharacters) return null;
+  return {
+    id: `scene-${index}`,
+    title: section.title,
+    bullets,
+    narration: [section.title, ...bullets].join(". "),
+  };
+}
+
 /** Drafts the bounded storyboard consumed by the short-video path. */
 export function draftVideoStoryboardContent(
   source: GenerationDraftSource,
   length: "brief" | "standard",
 ): ResearchGenerationContent {
   const { documentTitle, sections } = extractMarkdownSections(source.markdown);
-  const maxScenes = RESEARCH_MEDIA_LENGTH_LIMITS["short-video"][length].maxScenes;
-  const scenes: ResearchGenerationStoryboardScene[] = sections.length > 0
-    ? sections
-        .slice(0, maxScenes)
-        .map((section, index) => storyboardSceneFromSection(section, index + 1))
-    : mediaNarrationUnits(source).slice(0, maxScenes).map((unit, index) => ({
-        id: `scene-${index + 1}`,
+  const limits = RESEARCH_MEDIA_LENGTH_LIMITS["short-video"][length];
+  const scenes: ResearchGenerationStoryboardScene[] = [];
+  let remainingCharacters = limits.maxCharacters;
+  if (sections.length > 0) {
+    for (const section of sections) {
+      if (scenes.length >= limits.maxScenes || remainingCharacters <= 0) break;
+      const scene = shortVideoStoryboardSceneFromSection(
+        section,
+        scenes.length + 1,
+        remainingCharacters,
+      );
+      if (!scene) continue;
+      scenes.push(scene);
+      remainingCharacters -= scene.narration.length;
+    }
+  } else {
+    for (const unit of mediaNarrationUnits(source)) {
+      if (scenes.length >= limits.maxScenes || remainingCharacters <= 0) break;
+      if (unit.length > remainingCharacters) continue;
+      scenes.push({
+        id: `scene-${scenes.length + 1}`,
         title: documentTitle ?? source.artifact.title,
-        bullets: [unit].slice(0, MAX_SLIDE_BULLETS),
+        bullets: [unit],
         narration: unit,
-      }));
+      });
+      remainingCharacters -= unit.length;
+    }
+  }
   return { kind: "short-video", storyboard: scenes };
 }
 

--- a/src/lib/server/research-short-video-pipeline.test.ts
+++ b/src/lib/server/research-short-video-pipeline.test.ts
@@ -178,6 +178,34 @@ test("short video rejects a stored storyboard beyond the selected scene budget",
   );
 });
 
+test("short video rejects a stored storyboard beyond the selected narration budget before rendering", async () => {
+  const definition = createShortVideoMediaJobDefinition(
+    {
+      familiarId: "nova",
+      generationId: "short-over-narration-budget",
+      storyboard: [
+        {
+          id: "scene-1",
+          title: "Finding one",
+          bullets: [],
+          narration: "n".repeat(301),
+        },
+      ],
+      renderConfig: renderConfig({ length: "brief" }),
+    },
+    {
+      renderVideoSequence: async () => {
+        assert.fail("an over-budget storyboard must not reach the renderer");
+      },
+    },
+  );
+
+  await assert.rejects(
+    () => definition.run(context()),
+    /brief short-video narration budget \(300\) exceeded/,
+  );
+});
+
 test("short-video source never buffers the rendered MP4 with readFile", async () => {
   const source = await readFile(
     new URL("./research-short-video-pipeline.ts", import.meta.url),

--- a/src/lib/server/research-short-video-pipeline.ts
+++ b/src/lib/server/research-short-video-pipeline.ts
@@ -53,9 +53,21 @@ export function createShortVideoMediaJobDefinition(
       const maxScenes =
         RESEARCH_MEDIA_LENGTH_LIMITS["short-video"][input.renderConfig.length]
           .maxScenes;
+      const maxCharacters =
+        RESEARCH_MEDIA_LENGTH_LIMITS["short-video"][input.renderConfig.length]
+          .maxCharacters;
       if (input.storyboard.length > maxScenes) {
         throw new Error(
           `${input.renderConfig.length} short-video scene budget (${maxScenes}) exceeded`,
+        );
+      }
+      const narrationCharacters = input.storyboard.reduce(
+        (total, scene) => total + scene.narration.length,
+        0,
+      );
+      if (narrationCharacters > maxCharacters) {
+        throw new Error(
+          `${input.renderConfig.length} short-video narration budget (${maxCharacters}) exceeded`,
         );
       }
       const temporary = await mkdtemp(path.join(tmpdir(), "cave-short-video-"));


### PR DESCRIPTION
## Summary
- bound short-video drafts to conservative Brief (300) and Standard (600) extractive narration budgets
- retain only complete source bullets that fit, keeping slides and narration aligned
- reject legacy over-budget drafts before TTS; Retry creates a fresh bounded draft

## Root cause
The drafter capped scene count but not narration length. The supplied 2,287-character storyboard exceeded both the 30-second and 60-second renderer caps after synthesis.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- focused generation, short-video pipeline, and renderer suites
- `node scripts/check-tests-wired.mjs ...`
- `git diff --check`