### PR TITLE
Research Studio: podcast drafter polish — punctuation-aware joins, host/guest dialogue, style options

### DIFF
--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -44,6 +44,7 @@ import {
   type ResearchGenerationReadiness,
   type ResearchMediaLength,
   type ResearchMediaProvider,
+  type ResearchPodcastStyle,
 } from "@/lib/research-generations";
 import type { ResearchMission } from "@/lib/research-missions";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -473,6 +474,12 @@ export function GenerationReviewModal({
                 <dd>{generation.renderConfig.voices.guest}</dd>
               </div>
             ) : null}
+            {generation.renderConfig.style ? (
+              <div>
+                <dt>Style</dt>
+                <dd>{generation.renderConfig.style}</dd>
+              </div>
+            ) : null}
             <div>
               <dt>Length</dt>
               <dd>{generation.renderConfig.length}</dd>
@@ -532,6 +539,8 @@ export function GenerationConfigModal({
   onMediaVoiceChange,
   mediaGuestVoice,
   onMediaGuestVoiceChange,
+  mediaStyle,
+  onMediaStyleChange,
   mediaLength,
   onMediaLengthChange,
   error,
@@ -553,6 +562,9 @@ export function GenerationConfigModal({
   /** Podcast-only guest voice; empty string means one voice for both speakers. */
   mediaGuestVoice: string;
   onMediaGuestVoiceChange: (voice: string) => void;
+  /** Podcast-only drafting style; ignored for video kinds. */
+  mediaStyle: ResearchPodcastStyle;
+  onMediaStyleChange: (style: ResearchPodcastStyle) => void;
   mediaLength: ResearchMediaLength;
   onMediaLengthChange: (length: ResearchMediaLength) => void;
   /** Server-side create failure — e.g. the 409 "no markdown artifact" message. */
@@ -583,6 +595,7 @@ export function GenerationConfigModal({
       }
       if (
         kind === "podcast" &&
+        mediaStyle !== "recap" &&
         mediaGuestVoice &&
         !readiness.providers.local.voices.some(
           (voice) => voice.id === mediaGuestVoice,
@@ -784,6 +797,43 @@ export function GenerationConfigModal({
             )}
 
             {kind === "podcast" ? (
+              <div className="research-studio-config__field">
+                <label
+                  className="research-studio-config__label"
+                  htmlFor="research-studio-config-style"
+                >
+                  Style
+                </label>
+                <select
+                  id="research-studio-config-style"
+                  className="research-studio__select focus-ring"
+                  value={mediaStyle}
+                  aria-describedby="research-studio-config-style-help"
+                  onChange={(event) =>
+                    onMediaStyleChange(event.target.value as ResearchPodcastStyle)
+                  }
+                >
+                  <option value="breakdown">Breakdown</option>
+                  <option value="debate">Debate</option>
+                  <option value="interview">Interview</option>
+                  <option value="recap">Recap</option>
+                </select>
+                <span
+                  id="research-studio-config-style-help"
+                  className="research-studio-config__hint"
+                >
+                  {mediaStyle === "breakdown"
+                    ? "A host and guest walk the findings section by section."
+                    : mediaStyle === "debate"
+                      ? "Contested findings lead; the host pushes, the guest defends."
+                      : mediaStyle === "interview"
+                        ? "The host asks; the guest answers with the findings."
+                        : "One narrator reads the findings straight through."}
+                </span>
+              </div>
+            ) : null}
+
+            {kind === "podcast" && mediaStyle !== "recap" ? (
               <div className="research-studio-config__field">
                 <label
                   className="research-studio-config__label"

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -469,10 +469,16 @@ export function GenerationReviewModal({
               <dd>{generation.renderConfig.voice}</dd>
             </div>
             {generation.renderConfig.voices ? (
-              <div>
-                <dt>Guest voice</dt>
-                <dd>{generation.renderConfig.voices.guest}</dd>
-              </div>
+              <>
+                <div>
+                  <dt>Host voice</dt>
+                  <dd>{generation.renderConfig.voices.host}</dd>
+                </div>
+                <div>
+                  <dt>Guest voice</dt>
+                  <dd>{generation.renderConfig.voices.guest}</dd>
+                </div>
+              </>
             ) : null}
             {generation.renderConfig.style ? (
               <div>

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -252,7 +252,11 @@ export function generationContentToMarkdown(generation: ResearchGeneration): str
       return `${content.stats.map((stat) => `- **${stat.value}** — ${stat.context}`).join("\n")}\n`;
     case "podcast":
       return `# ${generationTitle(generation)}\n\n${content.script
-        .map((segment) => segment.text)
+        .map((segment) =>
+          segment.speaker
+            ? `**${segment.speaker === "host" ? "Host" : "Guest"}:** ${segment.text}`
+            : segment.text,
+        )
         .join("\n\n")}\n`;
     case "short-video":
       return `# ${generationTitle(generation)}\n\n${content.storyboard
@@ -463,6 +467,12 @@ export function GenerationReviewModal({
               <dt>Voice</dt>
               <dd>{generation.renderConfig.voice}</dd>
             </div>
+            {generation.renderConfig.voices ? (
+              <div>
+                <dt>Guest voice</dt>
+                <dd>{generation.renderConfig.voices.guest}</dd>
+              </div>
+            ) : null}
             <div>
               <dt>Length</dt>
               <dd>{generation.renderConfig.length}</dd>
@@ -471,7 +481,14 @@ export function GenerationReviewModal({
         ) : null}
         {content?.kind === "podcast" ? (
           <ol className="research-studio-review__list">
-            {content.script.map((segment) => <li key={segment.id}>{segment.text}</li>)}
+            {content.script.map((segment) => (
+              <li key={segment.id}>
+                {segment.speaker ? (
+                  <strong>{segment.speaker === "host" ? "Host" : "Guest"}</strong>
+                ) : null}
+                <span>{segment.text}</span>
+              </li>
+            ))}
           </ol>
         ) : content?.kind === "short-video" ? (
           <ol className="research-studio-review__list">
@@ -513,6 +530,8 @@ export function GenerationConfigModal({
   onMediaProviderChange,
   mediaVoice,
   onMediaVoiceChange,
+  mediaGuestVoice,
+  onMediaGuestVoiceChange,
   mediaLength,
   onMediaLengthChange,
   error,
@@ -531,6 +550,9 @@ export function GenerationConfigModal({
   onMediaProviderChange: (provider: ResearchMediaProvider) => void;
   mediaVoice: string;
   onMediaVoiceChange: (voice: string) => void;
+  /** Podcast-only guest voice; empty string means one voice for both speakers. */
+  mediaGuestVoice: string;
+  onMediaGuestVoiceChange: (voice: string) => void;
   mediaLength: ResearchMediaLength;
   onMediaLengthChange: (length: ResearchMediaLength) => void;
   /** Server-side create failure — e.g. the 409 "no markdown artifact" message. */
@@ -558,6 +580,15 @@ export function GenerationConfigModal({
         )
       ) {
         return "Choose a ready local voice.";
+      }
+      if (
+        kind === "podcast" &&
+        mediaGuestVoice &&
+        !readiness.providers.local.voices.some(
+          (voice) => voice.id === mediaGuestVoice,
+        )
+      ) {
+        return "Choose a ready local voice for the guest.";
       }
     } else {
       if (!readiness.providers.elevenlabs.ready) {
@@ -751,6 +782,64 @@ export function GenerationConfigModal({
                 </span>
               </div>
             )}
+
+            {kind === "podcast" ? (
+              <div className="research-studio-config__field">
+                <label
+                  className="research-studio-config__label"
+                  htmlFor="research-studio-config-guest-voice"
+                >
+                  Guest voice (optional)
+                </label>
+                {mediaProvider === "local" ? (
+                  <select
+                    id="research-studio-config-guest-voice"
+                    className="research-studio__select focus-ring"
+                    value={mediaGuestVoice}
+                    aria-describedby="research-studio-config-guest-voice-help"
+                    aria-invalid={mediaConfigurationError ? true : undefined}
+                    aria-errormessage={
+                      mediaConfigurationError
+                        ? "research-studio-config-media-error"
+                        : undefined
+                    }
+                    onChange={(event) =>
+                      onMediaGuestVoiceChange(event.target.value)
+                    }
+                  >
+                    <option value="">Same as host voice</option>
+                    {readiness?.providers.local.voices.map((voice) => (
+                      <option key={voice.id} value={voice.id}>
+                        {voice.name} · {voice.engine}
+                      </option>
+                    ))}
+                  </select>
+                ) : (
+                  <input
+                    id="research-studio-config-guest-voice"
+                    className="research-studio-config__input focus-ring"
+                    value={mediaGuestVoice}
+                    placeholder="Same as host voice"
+                    aria-describedby="research-studio-config-guest-voice-help"
+                    aria-invalid={mediaConfigurationError ? true : undefined}
+                    aria-errormessage={
+                      mediaConfigurationError
+                        ? "research-studio-config-media-error"
+                        : undefined
+                    }
+                    onChange={(event) =>
+                      onMediaGuestVoiceChange(event.target.value)
+                    }
+                  />
+                )}
+                <span
+                  id="research-studio-config-guest-voice-help"
+                  className="research-studio-config__hint"
+                >
+                  A second voice makes the podcast a host/guest dialogue.
+                </span>
+              </div>
+            ) : null}
 
             <div className="research-studio-config__field">
               <label

--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -34,6 +34,7 @@ import {
   type ResearchGenerationReadiness,
   type ResearchMediaLength,
   type ResearchMediaProvider,
+  type ResearchPodcastStyle,
 } from "@/lib/research-generations";
 import type { ResearchTabProps } from "./researcher-surface";
 import {
@@ -69,6 +70,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     useState<ResearchMediaProvider>("local");
   const [mediaVoice, setMediaVoice] = useState("");
   const [mediaGuestVoice, setMediaGuestVoice] = useState("");
+  const [mediaStyle, setMediaStyle] = useState<ResearchPodcastStyle>("breakdown");
   const [mediaLength, setMediaLength] =
     useState<ResearchMediaLength>("standard");
   const [createError, setCreateError] = useState<string | null>(null);
@@ -304,7 +306,9 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
               provider: mediaProvider,
               voice: mediaVoice,
               length: mediaLength,
-              ...(configKind === "podcast" && mediaGuestVoice.trim().length > 0
+              ...(configKind === "podcast" &&
+              mediaStyle !== "recap" &&
+              mediaGuestVoice.trim().length > 0
                 ? {
                     voices: {
                       host: mediaVoice,
@@ -312,6 +316,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
                     },
                   }
                 : {}),
+              ...(configKind === "podcast" ? { style: mediaStyle } : {}),
             },
           }
         : {}),
@@ -347,6 +352,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     mediaGuestVoice,
     mediaLength,
     mediaProvider,
+    mediaStyle,
     mediaVoice,
   ]);
 
@@ -795,6 +801,8 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
           onMediaVoiceChange={setMediaVoice}
           mediaGuestVoice={mediaGuestVoice}
           onMediaGuestVoiceChange={setMediaGuestVoice}
+          mediaStyle={mediaStyle}
+          onMediaStyleChange={setMediaStyle}
           mediaLength={mediaLength}
           onMediaLengthChange={setMediaLength}
           error={createError}

--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -68,6 +68,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
   const [mediaProvider, setMediaProvider] =
     useState<ResearchMediaProvider>("local");
   const [mediaVoice, setMediaVoice] = useState("");
+  const [mediaGuestVoice, setMediaGuestVoice] = useState("");
   const [mediaLength, setMediaLength] =
     useState<ResearchMediaLength>("standard");
   const [createError, setCreateError] = useState<string | null>(null);
@@ -303,6 +304,14 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
               provider: mediaProvider,
               voice: mediaVoice,
               length: mediaLength,
+              ...(configKind === "podcast" && mediaGuestVoice.trim().length > 0
+                ? {
+                    voices: {
+                      host: mediaVoice,
+                      guest: mediaGuestVoice.trim(),
+                    },
+                  }
+                : {}),
             },
           }
         : {}),
@@ -335,6 +344,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     directions,
     effectiveSourceId,
     familiarId,
+    mediaGuestVoice,
     mediaLength,
     mediaProvider,
     mediaVoice,
@@ -775,9 +785,16 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
           onDirectionsChange={setDirections}
           readiness={readiness}
           mediaProvider={mediaProvider}
-          onMediaProviderChange={setMediaProvider}
+          onMediaProviderChange={(provider) => {
+            setMediaProvider(provider);
+            // Guest voices are provider-specific; a stale one must not leak
+            // into the other provider's render config.
+            setMediaGuestVoice("");
+          }}
           mediaVoice={mediaVoice}
           onMediaVoiceChange={setMediaVoice}
+          mediaGuestVoice={mediaGuestVoice}
+          onMediaGuestVoiceChange={setMediaGuestVoice}
           mediaLength={mediaLength}
           onMediaLengthChange={setMediaLength}
           error={createError}

--- a/src/lib/research-generations.test.ts
+++ b/src/lib/research-generations.test.ts
@@ -165,6 +165,50 @@ test("per-speaker podcast voices are podcast-only, trimmed, and bounded", () => 
   );
 });
 
+test("podcast style is podcast-only with an explicit vocabulary", () => {
+  const styled = validateResearchMediaRenderConfig("podcast", {
+    provider: "local",
+    voice: "piper-lessac-medium",
+    length: "standard",
+    style: "debate",
+  });
+  assert.deepEqual(styled, {
+    ok: true,
+    value: {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      style: "debate",
+    },
+  });
+  // Absent style stays absent — old stored configs revalidate byte-identical.
+  const unstyled = validateResearchMediaRenderConfig("podcast", {
+    provider: "local",
+    voice: "piper-lessac-medium",
+    length: "standard",
+  });
+  assert.ok(unstyled.ok);
+  if (unstyled.ok) assert.equal("style" in unstyled.value, false);
+  assert.equal(
+    validateResearchMediaRenderConfig("short-video", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "brief",
+      style: "breakdown",
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateResearchMediaRenderConfig("podcast", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      style: "freestyle",
+    }).ok,
+    false,
+  );
+});
+
 test("chapter progress accepts bounded real units and rejects invented ranges", () => {
   assert.equal(
     isResearchGenerationProgress({

--- a/src/lib/research-generations.test.ts
+++ b/src/lib/research-generations.test.ts
@@ -110,6 +110,61 @@ test("media render configuration is kind-aware, trimmed, and bounded", () => {
   );
 });
 
+test("per-speaker podcast voices are podcast-only, trimmed, and bounded", () => {
+  assert.deepEqual(
+    validateResearchMediaRenderConfig("podcast", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      voices: { host: " piper-lessac-medium ", guest: " piper-amy " },
+    }),
+    {
+      ok: true,
+      value: {
+        provider: "local",
+        voice: "piper-lessac-medium",
+        length: "standard",
+        voices: { host: "piper-lessac-medium", guest: "piper-amy" },
+      },
+    },
+  );
+  // Single-voice configs stay exactly as before — no voices key appears.
+  const single = validateResearchMediaRenderConfig("podcast", {
+    provider: "local",
+    voice: "piper-lessac-medium",
+    length: "standard",
+  });
+  assert.ok(single.ok);
+  if (single.ok) assert.equal("voices" in single.value, false);
+  assert.equal(
+    validateResearchMediaRenderConfig("short-video", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "brief",
+      voices: { host: "piper-lessac-medium", guest: "piper-amy" },
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateResearchMediaRenderConfig("podcast", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      voices: { host: "piper-lessac-medium", guest: "  " },
+    }).ok,
+    false,
+  );
+  assert.equal(
+    validateResearchMediaRenderConfig("podcast", {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      voices: { host: "x".repeat(129), guest: "piper-amy" },
+    }).ok,
+    false,
+  );
+});
+
 test("chapter progress accepts bounded real units and rejects invented ranges", () => {
   assert.equal(
     isResearchGenerationProgress({
@@ -267,6 +322,22 @@ test("content guard enforces the per-kind discriminated union", () => {
       kind: "podcast",
       script: [{ id: "segment-1", text: "A source-grounded narration." }],
     }),
+  );
+  assert.ok(
+    isResearchGenerationContent({
+      kind: "podcast",
+      script: [
+        { id: "segment-1", text: "Welcome in.", speaker: "host" },
+        { id: "segment-2", text: "A source-grounded finding.", speaker: "guest" },
+      ],
+    }),
+  );
+  assert.equal(
+    isResearchGenerationContent({
+      kind: "podcast",
+      script: [{ id: "segment-1", text: "Narration.", speaker: "narrator" }],
+    }),
+    false,
   );
   assert.ok(
     isResearchGenerationContent({

--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -111,11 +111,18 @@ export const RESEARCH_GENERATION_CREATABLE_KINDS = [
 
 export type ResearchMediaProvider = "local" | "elevenlabs";
 export type ResearchMediaLength = "brief" | "standard" | "extended";
+export type ResearchPodcastSpeaker = "host" | "guest";
 
 export type ResearchMediaRenderConfig = {
   provider: ResearchMediaProvider;
+  /** Primary voice; also the fallback for any segment without a speaker map. */
   voice: string;
   length: ResearchMediaLength;
+  /**
+   * Podcast only: per-speaker voices for dialogue scripts. Absent means every
+   * segment renders with `voice`, which keeps single-voice configs unchanged.
+   */
+  voices?: { host: string; guest: string };
 };
 
 export type ResearchGenerationProgress = {
@@ -174,12 +181,32 @@ export function validateResearchMediaRenderConfig(
   if (kind === "short-video" && value.length === "extended") {
     return { ok: false, error: "short video length must be brief or standard" };
   }
+  let voices: { host: string; guest: string } | undefined;
+  if (value.voices !== undefined) {
+    if (kind !== "podcast") {
+      return { ok: false, error: "per-speaker voices are only valid for podcasts" };
+    }
+    if (!value.voices || typeof value.voices !== "object" || Array.isArray(value.voices)) {
+      return { ok: false, error: "media voices must map host and guest voices" };
+    }
+    const pair = value.voices as Record<string, unknown>;
+    const host = typeof pair.host === "string" ? pair.host.trim() : "";
+    const guest = typeof pair.guest === "string" ? pair.guest.trim() : "";
+    if (!host || host.length > 128 || !guest || guest.length > 128) {
+      return {
+        ok: false,
+        error: "host and guest voices must be between 1 and 128 characters",
+      };
+    }
+    voices = { host, guest };
+  }
   return {
     ok: true,
     value: {
       provider: value.provider,
       voice,
       length: value.length,
+      ...(voices ? { voices } : {}),
     },
   };
 }
@@ -241,6 +268,11 @@ export type ResearchGenerationScriptSegment = {
   id: string;
   /** Extracted narration text, never generated from directions. */
   text: string;
+  /**
+   * Dialogue speaker for two-voice podcasts. Absent on single-narrator
+   * scripts, which render entirely with the config's primary voice.
+   */
+  speaker?: ResearchPodcastSpeaker;
 };
 
 export type ResearchGenerationStoryboardScene = {
@@ -363,7 +395,10 @@ export function isResearchGenerationContent(
         typeof segment === "object" &&
         typeof (segment as ResearchGenerationScriptSegment).id === "string" &&
         (segment as ResearchGenerationScriptSegment).id.length > 0 &&
-        typeof (segment as ResearchGenerationScriptSegment).text === "string",
+        typeof (segment as ResearchGenerationScriptSegment).text === "string" &&
+        ((segment as ResearchGenerationScriptSegment).speaker === undefined ||
+          (segment as ResearchGenerationScriptSegment).speaker === "host" ||
+          (segment as ResearchGenerationScriptSegment).speaker === "guest"),
     );
   const isStoryboard = (candidate: unknown): candidate is ResearchGenerationStoryboardScene[] =>
     Array.isArray(candidate) &&

--- a/src/lib/research-generations.ts
+++ b/src/lib/research-generations.ts
@@ -113,6 +113,20 @@ export type ResearchMediaProvider = "local" | "elevenlabs";
 export type ResearchMediaLength = "brief" | "standard" | "extended";
 export type ResearchPodcastSpeaker = "host" | "guest";
 
+export const RESEARCH_PODCAST_STYLES = [
+  "breakdown",
+  "debate",
+  "interview",
+  "recap",
+] as const;
+export type ResearchPodcastStyle = (typeof RESEARCH_PODCAST_STYLES)[number];
+
+export function isResearchPodcastStyle(
+  value: unknown,
+): value is ResearchPodcastStyle {
+  return RESEARCH_PODCAST_STYLES.includes(value as ResearchPodcastStyle);
+}
+
 export type ResearchMediaRenderConfig = {
   provider: ResearchMediaProvider;
   /** Primary voice; also the fallback for any segment without a speaker map. */
@@ -123,6 +137,11 @@ export type ResearchMediaRenderConfig = {
    * segment renders with `voice`, which keeps single-voice configs unchanged.
    */
   voices?: { host: string; guest: string };
+  /**
+   * Podcast only: drafting style. Absent means "breakdown" — old stored
+   * configs keep validating and re-draft exactly as the default style.
+   */
+  style?: ResearchPodcastStyle;
 };
 
 export type ResearchGenerationProgress = {
@@ -200,6 +219,19 @@ export function validateResearchMediaRenderConfig(
     }
     voices = { host, guest };
   }
+  let style: ResearchPodcastStyle | undefined;
+  if (value.style !== undefined) {
+    if (kind !== "podcast") {
+      return { ok: false, error: "podcast style is only valid for podcasts" };
+    }
+    if (!isResearchPodcastStyle(value.style)) {
+      return {
+        ok: false,
+        error: "podcast style must be breakdown, debate, interview, or recap",
+      };
+    }
+    style = value.style;
+  }
   return {
     ok: true,
     value: {
@@ -207,6 +239,7 @@ export function validateResearchMediaRenderConfig(
       voice,
       length: value.length,
       ...(voices ? { voices } : {}),
+      ...(style ? { style } : {}),
     },
   };
 }

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -525,6 +525,64 @@ test("podcast drafter drafts a host/guest dialogue with templated framing only",
   assert.notEqual(last.text.startsWith("Next up — "), true);
 });
 
+test("podcast styles branch the drafter without inventing findings", () => {
+  const source = {
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Key claims",
+      "",
+      "- Gates bind proxies, not purposes.",
+      "",
+      "## Open questions",
+      "",
+      "- Does goal-guarding generalize?",
+    ].join("\n"),
+  };
+  const recap = draftPodcastContent(source, "standard", "recap");
+  assert.equal(recap.kind, "podcast");
+  if (recap.kind !== "podcast") return;
+  assert.ok(
+    recap.script.every((segment) => segment.speaker === undefined),
+    "recap is a single-narrator read-through with no dialogue turns",
+  );
+  assert.ok(
+    recap.script[0].text.includes("Gates bind proxies, not purposes."),
+    "recap starts straight into the findings, no templated opening",
+  );
+
+  const debate = draftPodcastContent(source, "standard", "debate");
+  assert.equal(debate.kind, "podcast");
+  if (debate.kind !== "podcast") return;
+  assert.ok(debate.script[0].text.includes("stress-testing"));
+  const debateFraming = debate.script.filter((segment) =>
+    segment.text.includes("Where do we actually stand"),
+  );
+  assert.ok(
+    debateFraming[0]?.text.includes("Open questions"),
+    "debate leads with the contested section",
+  );
+
+  const interview = draftPodcastContent(source, "standard", "interview");
+  assert.equal(interview.kind, "podcast");
+  if (interview.kind !== "podcast") return;
+  assert.ok(interview.script[0].text.includes("my guest walks us through"));
+  assert.ok(
+    interview.script.some((segment) =>
+      segment.text.startsWith("Walk me through this part — Key claims"),
+    ),
+  );
+
+  // The default is breakdown — an unstyled call and an explicit breakdown
+  // call draft the identical script.
+  assert.deepEqual(
+    draftPodcastContent(source, "standard"),
+    draftPodcastContent(source, "standard", "breakdown"),
+  );
+});
+
 test("podcast drafter joins are punctuation-aware — never a double period", () => {
   const content = draftPodcastContent({
     mission,

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -462,10 +462,67 @@ test("podcast drafter creates bounded extractive narration segments", () => {
   }, "standard");
   assert.equal(content.kind, "podcast");
   if (content.kind !== "podcast") return;
-  assert.ok(content.script.length >= 1, "heading-less artifacts still produce a draft");
+  assert.ok(content.script.length >= 2, "heading-less artifacts still produce a draft");
   assert.ok(content.script.every((segment) => segment.text.length > 0));
   assert.ok(content.script.every((segment) => segment.text.length <= 4_000));
-  assert.ok(content.script[0].text.includes("A standalone paragraph with a claim."));
+  assert.equal(content.script[0].speaker, "host", "a host opening frames the episode");
+  assert.ok(content.script[1].text.includes("A standalone paragraph with a claim."));
+  assert.ok(
+    content.script.every(
+      (segment) => segment.speaker === "host" || segment.speaker === "guest",
+    ),
+    "every drafted segment carries a dialogue speaker",
+  );
+});
+
+test("podcast drafter drafts a host/guest dialogue with templated framing only", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Key claims",
+      "",
+      "- Gates bind proxies, not purposes.",
+      "",
+      "## Open questions",
+      "",
+      "- Does goal-guarding generalize?",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const script = content.script;
+  assert.equal(script[0].speaker, "host");
+  assert.ok(
+    script[0].text.includes(mission.title),
+    "the opening names the mission title, nothing invented",
+  );
+  const framing = script.filter((segment) => segment.text.startsWith("Next up — "));
+  assert.deepEqual(
+    framing.map((segment) => segment.speaker),
+    ["host", "host"],
+    "each titled section gets one host framing line",
+  );
+  assert.ok(
+    framing.every((segment) => !segment.text.includes("..")),
+    "framing reuses punctuation-aware headings",
+  );
+  const guests = script.filter((segment) => segment.speaker === "guest");
+  assert.ok(
+    guests.some((segment) => segment.text.includes("Gates bind proxies, not purposes.")),
+    "findings are delivered verbatim by the guest",
+  );
+  assert.deepEqual(
+    script.map((segment) => segment.id),
+    script.map((_, index) => `segment-${index + 1}`),
+    "segment ids stay sequential",
+  );
+  // A host framing line is never the last thing in the script — framing only
+  // enters alongside the findings it introduces.
+  const last = script[script.length - 1];
+  assert.notEqual(last.text.startsWith("Next up — "), true);
 });
 
 test("podcast drafter joins are punctuation-aware — never a double period", () => {

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -468,6 +468,73 @@ test("podcast drafter creates bounded extractive narration segments", () => {
   assert.ok(content.script[0].text.includes("A standalone paragraph with a claim."));
 });
 
+test("podcast drafter joins are punctuation-aware — never a double period", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Punctuated findings",
+      "",
+      "## Key claims (with confidence)",
+      "",
+      "- Formal proofs are blocked (high confidence).",
+      "- Does goal-guarding generalize?",
+      "- Benchmarks bind proxies (the DGM lesson)",
+      "- an unterminated bullet",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const narration = content.script.map((segment) => segment.text).join(" ");
+  assert.ok(!narration.includes(".."), `no double periods (${narration})`);
+  assert.ok(!narration.includes("?."), `no punctuation stacking after ? (${narration})`);
+  assert.ok(
+    narration.includes("(the DGM lesson) an unterminated bullet."),
+    "paren-terminated fragments are not re-punctuated",
+  );
+  assert.ok(
+    narration.includes("Key claims (with confidence)"),
+    "the heading still frames its details",
+  );
+});
+
+test("podcast drafter skips table-only sections instead of speaking bare headings", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Mechanism comparison",
+      "",
+      "| Mechanism | Guarantee |",
+      "|---|---|",
+      "| Proof-gated | formal |",
+      "",
+      "## Empty section",
+      "",
+      "## Detailed findings",
+      "",
+      "- Gates bind proxies, not purposes.",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const texts = content.script.map((segment) => segment.text);
+  assert.ok(
+    texts.every((text) => text !== "Mechanism comparison" && text !== "Mechanism comparison."),
+    "table-only sections never become orphan spoken headings",
+  );
+  assert.ok(
+    texts.every((text) => !text.startsWith("Empty section")),
+    "empty sections are skipped",
+  );
+  assert.ok(
+    texts.some((text) => text.includes("Gates bind proxies, not purposes.")),
+    "sections with speakable details survive",
+  );
+});
+
 test("podcast drafter clamps a long source mechanically at the local TTS limit", () => {
   const longLine = `A ${"verbatim source claim ".repeat(300)}`;
   const content = draftPodcastContent({

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -57,6 +57,7 @@ import {
   type ResearchMediaLength,
   type ResearchMediaRenderConfig,
   type ResearchPodcastSpeaker,
+  type ResearchPodcastStyle,
 } from "../research-generations.ts";
 import { LOCAL_TTS_MAX_CHARS } from "../voice/local-tts.ts";
 import type { ResearchArtifactRef, ResearchMission } from "../research-missions.ts";
@@ -859,17 +860,72 @@ function mediaNarrationUnits(source: GenerationDraftSource): string[] {
 export function draftPodcastContent(
   source: GenerationDraftSource,
   length: ResearchMediaLength,
+  style: ResearchPodcastStyle = "breakdown",
 ): ResearchGenerationContent {
   const budget = RESEARCH_MEDIA_LENGTH_LIMITS.podcast[length].maxCharacters;
+  const units = mediaNarrationSectionUnits(source);
+  if (style === "recap") {
+    // Recap is the original single-narrator read-through: one voice, no
+    // dialogue turns, findings in source order.
+    const candidates = units
+      .map((unit) =>
+        unit.title !== null ? `${speakable(unit.title)} ${unit.text}` : unit.text,
+      )
+      .flatMap(splitMediaDraftText);
+    const script: ResearchGenerationScriptSegment[] = [];
+    let used = 0;
+    for (const [index, text] of candidates.entries()) {
+      if (used + text.length > budget) break;
+      script.push({ id: `segment-${index + 1}`, text });
+      used += text.length;
+    }
+    return { kind: "podcast", script };
+  }
   return {
     kind: "podcast",
-    script: draftDialogueScript(mediaNarrationSectionUnits(source), {
-      budget,
-      opening: `Welcome in — today we're breaking down “${source.mission.title}”, finding by finding.`,
-      framing: (title) => `Next up — ${speakable(title)}`,
-    }),
+    script: draftDialogueScript(
+      style === "debate" ? contestedSectionsFirst(units) : units,
+      { budget, ...PODCAST_DIALOGUE_TEMPLATES[style](source.mission.title) },
+    ),
   };
 }
+
+/**
+ * Section titles that signal disagreement or open ground. Debate episodes
+ * lead with these so the contested findings get the airtime.
+ */
+const CONTESTED_TITLE_RE =
+  /conflict|contradiction|open question|unresolved|challenge|risk|limitation/i;
+
+function contestedSectionsFirst(units: NarrationUnit[]): NarrationUnit[] {
+  const contested = units.filter(
+    (unit) => unit.title !== null && CONTESTED_TITLE_RE.test(unit.title),
+  );
+  if (contested.length === 0) return units;
+  return [...contested, ...units.filter((unit) => !contested.includes(unit))];
+}
+
+/**
+ * Per-style templated copy — episode structure only. Every findings turn the
+ * templates introduce stays verbatim artifact text.
+ */
+const PODCAST_DIALOGUE_TEMPLATES: Record<
+  Exclude<ResearchPodcastStyle, "recap">,
+  (missionTitle: string) => Omit<DialogueTemplate, "budget">
+> = {
+  breakdown: (missionTitle) => ({
+    opening: `Welcome in — today we're breaking down “${missionTitle}”, finding by finding.`,
+    framing: (title) => `Next up — ${speakable(title)}`,
+  }),
+  debate: (missionTitle) => ({
+    opening: `Welcome to the debate — today we're stress-testing “${missionTitle}”, starting where the findings are most contested.`,
+    framing: (title) => `Where do we actually stand on this one? ${speakable(title)}`,
+  }),
+  interview: (missionTitle) => ({
+    opening: `Today my guest walks us through “${missionTitle}”. Let's get into it.`,
+    framing: (title) => `Walk me through this part — ${speakable(title)}`,
+  }),
+};
 
 type DialogueTemplate = {
   budget: number;
@@ -1197,7 +1253,7 @@ export async function createResearchMediaGenerationFromMission(
   let content: ResearchGenerationContent;
   switch (input.kind) {
     case "podcast":
-      content = draftPodcastContent(draftSource, renderConfig.length);
+      content = draftPodcastContent(draftSource, renderConfig.length, renderConfig.style);
       break;
     case "short-video":
       if (renderConfig.length === "extended") {

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -56,6 +56,7 @@ import {
   type ResearchGenerationVideoChapter,
   type ResearchMediaLength,
   type ResearchMediaRenderConfig,
+  type ResearchPodcastSpeaker,
 } from "../research-generations.ts";
 import { LOCAL_TTS_MAX_CHARS } from "../voice/local-tts.ts";
 import type { ResearchArtifactRef, ResearchMission } from "../research-missions.ts";
@@ -860,17 +861,72 @@ export function draftPodcastContent(
   length: ResearchMediaLength,
 ): ResearchGenerationContent {
   const budget = RESEARCH_MEDIA_LENGTH_LIMITS.podcast[length].maxCharacters;
-  const candidates: ResearchGenerationScriptSegment[] = mediaNarrationUnits(source)
-    .flatMap(splitMediaDraftText)
-    .map((text, index) => ({ id: `segment-${index + 1}`, text }));
-  const script: ResearchGenerationScriptSegment[] = [];
-  let usedCharacters = 0;
-  for (const segment of candidates) {
-    if (usedCharacters + segment.text.length > budget) break;
-    script.push(segment);
-    usedCharacters += segment.text.length;
+  return {
+    kind: "podcast",
+    script: draftDialogueScript(mediaNarrationSectionUnits(source), {
+      budget,
+      opening: `Welcome in — today we're breaking down “${source.mission.title}”, finding by finding.`,
+      framing: (title) => `Next up — ${speakable(title)}`,
+    }),
+  };
+}
+
+type DialogueTemplate = {
+  budget: number;
+  /** Templated host opener; counts against the character budget. */
+  opening: string;
+  /** Templated host bridge into a titled section; structure, never findings. */
+  framing: (title: string) => string;
+};
+
+/**
+ * Turns narration units into alternating host/guest turns. Framing lines are
+ * templated structure; every findings turn stays verbatim artifact text.
+ */
+function draftDialogueScript(
+  units: NarrationUnit[],
+  template: DialogueTemplate,
+): ResearchGenerationScriptSegment[] {
+  const turns: { text: string; speaker: ResearchPodcastSpeaker }[] = [];
+  let used = 0;
+  const push = (text: string, speaker: ResearchPodcastSpeaker) => {
+    turns.push({ text, speaker });
+    used += text.length;
+  };
+  if (units.length === 0 || template.opening.length > template.budget) {
+    return [];
   }
-  return { kind: "podcast", script };
+  push(template.opening, "host");
+  // Heading-less lines have no title to frame, so delivery alternates.
+  let alternate: ResearchPodcastSpeaker = "guest";
+  outer: for (const unit of units) {
+    const chunks = splitMediaDraftText(unit.text);
+    if (chunks.length === 0) continue;
+    if (unit.title !== null) {
+      const framing = template.framing(unit.title);
+      // Never leave an orphan host question: the framing line only enters
+      // when at least its first findings chunk also fits the budget.
+      if (used + framing.length + chunks[0].length > template.budget) break;
+      push(framing, "host");
+      for (const chunk of chunks) {
+        if (used + chunk.length > template.budget) break outer;
+        push(chunk, "guest");
+      }
+    } else {
+      for (const chunk of chunks) {
+        if (used + chunk.length > template.budget) break outer;
+        push(chunk, alternate);
+        alternate = alternate === "guest" ? "host" : "guest";
+      }
+    }
+  }
+  // An opening with nothing to deliver is not a podcast.
+  if (turns.length < 2) return [];
+  return turns.map((turn, index) => ({
+    id: `segment-${index + 1}`,
+    text: turn.text,
+    speaker: turn.speaker,
+  }));
 }
 
 function storyboardSceneFromSection(

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -802,19 +802,37 @@ function splitMediaDraftText(text: string): string[] {
   return chunks.filter((chunk) => chunk.length <= LOCAL_TTS_MAX_CHARS);
 }
 
-function mediaNarrationUnits(source: GenerationDraftSource): string[] {
+/** Fragment endings that already close a spoken clause — no "." appended. */
+const SPEAKABLE_TERMINAL_RE = /[.!?…;:)\]"'”’]$/;
+
+/** Terminates a fragment for speech without ever doubling punctuation. */
+function speakable(fragment: string): string {
+  const trimmed = fragment.trim();
+  if (!trimmed) return trimmed;
+  return SPEAKABLE_TERMINAL_RE.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+type NarrationUnit = {
+  /** Section heading, or null on the heading-less fallback path. */
+  title: string | null;
+  /** Speakable detail text, punctuation-safe joined. */
+  text: string;
+};
+
+function mediaNarrationSectionUnits(source: GenerationDraftSource): NarrationUnit[] {
   const { sections } = extractMarkdownSections(source.markdown);
   if (sections.length > 0) {
-    return sections.flatMap((section) => {
+    return sections.flatMap((section): NarrationUnit[] => {
       const details = section.bullets.length > 0 ? section.bullets : section.firstLine ? [section.firstLine] : [];
-      return details.length > 0
-        ? [`${section.title}. ${details.join(". ")}`]
-        : [section.title];
+      // Sections whose body is only a table (or nothing) have no speakable
+      // details; a bare spoken heading is worse than silence, so skip them.
+      if (details.length === 0) return [];
+      return [{ title: section.title, text: details.map(speakable).join(" ") }];
     });
   }
   // A heading-less artifact still has useful source lines. Ignore markdown
   // fences and structural blank lines, but retain the artifact's wording.
-  const lines: string[] = [];
+  const lines: NarrationUnit[] = [];
   let inFence = false;
   for (const rawLine of source.markdown.split("\n")) {
     if (/^\s*(```|~~~)/.test(rawLine)) {
@@ -825,9 +843,15 @@ function mediaNarrationUnits(source: GenerationDraftSource): string[] {
     const line = stripInlineMarkdown(
       rawLine.replace(/^\s*[-*+]\s+/, "").replace(/^\s*>\s?/, ""),
     );
-    if (line && !/^#{1,6}\s/.test(line)) lines.push(line);
+    if (line && !/^#{1,6}\s/.test(line)) lines.push({ title: null, text: line });
   }
   return lines;
+}
+
+function mediaNarrationUnits(source: GenerationDraftSource): string[] {
+  return mediaNarrationSectionUnits(source).map((unit) =>
+    unit.title === null ? unit.text : `${speakable(unit.title)} ${unit.text}`,
+  );
 }
 
 /** Drafts a reviewable, extractive host script before any audio is rendered. */

--- a/src/lib/server/research-media-readiness.test.ts
+++ b/src/lib/server/research-media-readiness.test.ts
@@ -132,6 +132,47 @@ test("selection validation freezes exact voices and video prerequisites", async 
   assert.equal(invalidElevenLabs.ok, false);
   if (!invalidElevenLabs.ok) assert.match(invalidElevenLabs.error, /voice id/i);
 
+  assert.deepEqual(
+    validateResearchMediaSelection(
+      "podcast",
+      {
+        provider: "local",
+        voice: "piper-lessac-medium",
+        length: "standard",
+        voices: {
+          host: "piper-lessac-medium",
+          guest: "piper-lessac-medium",
+        },
+      },
+      ready,
+    ),
+    { ok: true },
+  );
+  const missingGuest = validateResearchMediaSelection(
+    "podcast",
+    {
+      provider: "local",
+      voice: "piper-lessac-medium",
+      length: "standard",
+      voices: { host: "piper-lessac-medium", guest: "piper-not-installed" },
+    },
+    ready,
+  );
+  assert.equal(missingGuest.ok, false);
+  if (!missingGuest.ok) assert.match(missingGuest.error, /host and guest/i);
+  const invalidGuestId = validateResearchMediaSelection(
+    "podcast",
+    {
+      provider: "elevenlabs",
+      voice: DEFAULT_ELEVENLABS_VOICE_ID,
+      length: "brief",
+      voices: { host: DEFAULT_ELEVENLABS_VOICE_ID, guest: "bad id" },
+    },
+    ready,
+  );
+  assert.equal(invalidGuestId.ok, false);
+  if (!invalidGuestId.ok) assert.match(invalidGuestId.error, /host and guest/i);
+
   const noFfprobe = await getResearchMediaReadiness({
     speechReadiness: async () => ({ tts: [readyLocalVoice] }),
     elevenLabsKey: () => undefined,

--- a/src/lib/server/research-media-readiness.ts
+++ b/src/lib/server/research-media-readiness.ts
@@ -118,15 +118,22 @@ export function validateResearchMediaSelection(
   config: ResearchMediaRenderConfig,
   readiness: ResearchMediaReadiness,
 ): ResearchMediaSelectionValidation {
+  const configuredVoices = config.voices
+    ? [config.voice, config.voices.host, config.voices.guest]
+    : [config.voice];
   if (config.provider === "local") {
+    const readyIds = new Set(
+      readiness.providers.local.voices.map((voice) => voice.id),
+    );
     if (
       !readiness.providers.local.ready ||
-      !readiness.providers.local.voices.some((voice) => voice.id === config.voice)
+      !configuredVoices.every((voice) => readyIds.has(voice))
     ) {
       return {
         ok: false,
-        error:
-          "The selected local voice is not ready. Download it in Settings → Voice or choose another ready voice.",
+        error: config.voices
+          ? "Host and guest voices must both be ready local voices. Download another voice in Settings → Voice or use one voice for both speakers."
+          : "The selected local voice is not ready. Download it in Settings → Voice or choose another ready voice.",
       };
     }
   } else {
@@ -136,10 +143,12 @@ export function validateResearchMediaSelection(
         error: "Set ELEVENLABS_API_KEY in Vault settings before rendering.",
       };
     }
-    if (!isValidElevenLabsVoiceId(config.voice)) {
+    if (!configuredVoices.every((voice) => isValidElevenLabsVoiceId(voice))) {
       return {
         ok: false,
-        error: "Enter a valid ElevenLabs voice id.",
+        error: config.voices
+          ? "Enter valid ElevenLabs voice ids for the host and guest voices."
+          : "Enter a valid ElevenLabs voice id.",
       };
     }
   }

--- a/src/lib/server/research-podcast-pipeline.test.ts
+++ b/src/lib/server/research-podcast-pipeline.test.ts
@@ -156,6 +156,39 @@ test("podcast uses the exact frozen provider and voice and stores measured metad
   }
 });
 
+test("dialogue segments synthesize with their speaker's frozen voice", async () => {
+  const config = renderConfig({
+    voices: { host: "piper-amy", guest: "piper-lessac-medium" },
+  });
+  const calls: Array<{ text: string; voice: string }> = [];
+  const definition = createPodcastMediaJobDefinition(
+    {
+      familiarId: "nova",
+      generationId: "podcast-dialogue-voices",
+      script: [
+        { id: "segment-1", text: "Welcome in.", speaker: "host" },
+        { id: "segment-2", text: "A verbatim finding.", speaker: "guest" },
+        { id: "segment-3", text: "Legacy narration." },
+      ],
+      renderConfig: config,
+    },
+    {
+      synthesize: async (text, _provider, voice) => {
+        calls.push({ text, voice });
+        return { bytes: wav([1]), voice };
+      },
+    },
+  );
+  const result = await definition.run(jobContext());
+  assert.deepEqual(calls, [
+    { text: "Welcome in.", voice: "piper-amy" },
+    { text: "A verbatim finding.", voice: "piper-lessac-medium" },
+    // Speaker-less segments keep the primary voice — old drafts render unchanged.
+    { text: "Legacy narration.", voice: "piper-amy" },
+  ]);
+  assert.equal(result.content.kind, "podcast");
+});
+
 test("a segment failure is honest and names the failing index", async () => {
   const definition = createPodcastMediaJobDefinition(
     {

--- a/src/lib/server/research-podcast-pipeline.ts
+++ b/src/lib/server/research-podcast-pipeline.ts
@@ -271,9 +271,15 @@ export function createPodcastMediaJobDefinition(
   input: PodcastMediaJobInput,
   dependencies: PodcastPipelineDependencies = {},
 ): ResearchMediaJobDefinition {
-  const { provider, voice, length } = input.renderConfig;
+  const { provider, voice, voices, length } = input.renderConfig;
   const synthesize =
     dependencies.synthesize ?? synthesizeResearchPodcastSegment;
+  const voiceForSegment = (segment: ResearchGenerationScriptSegment): string =>
+    segment.speaker === "guest"
+      ? (voices?.guest ?? voice)
+      : segment.speaker === "host"
+        ? (voices?.host ?? voice)
+        : voice;
   return {
     familiarId: input.familiarId,
     generationId: input.generationId,
@@ -314,14 +320,15 @@ export function createPodcastMediaJobDefinition(
             throw new Error("podcast render cancelled");
           }
           await context.reportStage("synthesizing");
+          const segmentVoice = voiceForSegment(segment);
           try {
             const synthesized = await synthesize(
               segment.text,
               provider,
-              voice,
+              segmentVoice,
               context.signal,
             );
-            if (synthesized.voice !== voice) {
+            if (synthesized.voice !== segmentVoice) {
               throw new Error(
                 `selected ${provider} voice changed during synthesis`,
               );

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -55,6 +55,8 @@ type RenderConfig = {
   provider: "local" | "elevenlabs";
   voice: string;
   length: "brief" | "standard" | "extended";
+  voices?: { host: string; guest: string };
+  style?: "breakdown" | "debate" | "interview" | "recap";
 };
 
 function generation(
@@ -339,11 +341,7 @@ async function boot(
       if (method === "POST") {
         const body = route.request().postDataJSON() as {
           kind: MediaKind;
-          renderConfig: {
-            provider: "local" | "elevenlabs";
-            voice: string;
-            length: "brief" | "standard" | "extended";
-          };
+          renderConfig: RenderConfig;
         };
         createBodies.push(body as unknown as Record<string, unknown>);
         sequence += 1;
@@ -417,15 +415,30 @@ test.describe("Research Studio media honesty and playback", () => {
       "eleven-default",
     );
     await expect(config.getByLabel("Length").locator("option")).toHaveCount(3);
+    await expect(config.getByLabel("Style").locator("option")).toHaveText([
+      "Breakdown",
+      "Debate",
+      "Interview",
+      "Recap",
+    ]);
+    // Recap is single-narrator, so the guest voice field leaves with it.
+    await expect(config.getByLabel("Guest voice (optional)")).toBeVisible();
+    await config.getByLabel("Style").selectOption("recap");
+    await expect(config.getByLabel("Guest voice (optional)")).toHaveCount(0);
+    await config.getByLabel("Style").selectOption("breakdown");
     await page.keyboard.press("Escape");
     await expect(podcastCard).toBeFocused();
 
     await podcastCard.click();
+    await config.getByLabel("Style").selectOption("debate");
+    await config.getByLabel("Guest voice (optional)").fill("eleven-guest");
     await config.getByRole("button", { name: /Draft for review Podcast/ }).click();
     expect(controls.createBodies.at(-1)?.renderConfig).toEqual({
       provider: "elevenlabs",
       voice: "eleven-default",
       length: "standard",
+      voices: { host: "eleven-default", guest: "eleven-guest" },
+      style: "debate",
     });
     let review = page.getByRole("dialog", {
       name: "Review before rendering",
@@ -434,6 +447,8 @@ test.describe("Research Studio media honesty and playback", () => {
       "An extracted finding for the podcast.",
     );
     await expect(review).toContainText("ElevenLabs");
+    await expect(review).toContainText("eleven-guest");
+    await expect(review).toContainText("debate");
     await review.getByRole("button", { name: "Keep draft" }).click();
     const row = studio.locator(".research-studio-row").first();
     await row.getByRole("button", { name: "Review draft" }).click();


### PR DESCRIPTION
## What

Three chained polish beads from dogfooding the first real podcast render (generation d8e8a2f0):

### cave-xfu10 — drafter fixes (54ab7b890)
- Punctuation-aware narration joins via `speakable()` — no more `…confidence)..` double periods.
- Table-only/empty sections are skipped instead of spoken as orphan headings ("Key claims (with confidence)." — then nothing).

### cave-7sbpm — two-speaker dialogue (d7d0d6ff7)
- `speaker: host|guest` on script segments; `voices: {host, guest}` on the podcast render config.
- Drafter is dialogue-by-default: templated host opening + per-section host framing, findings delivered verbatim by the guest. Framing is structure only — never invented findings — and never enters without the findings it introduces.
- Pipeline synthesizes each segment with its speaker's frozen voice; readiness validates both voices; Studio gains a guest voice field, review speaker labels, and copy-export prefixes.

### cave-8cgce — style options (03aba55f9)
- `style: breakdown|debate|interview|recap` (podcast-only). Breakdown = default dialogue; debate leads with contested sections; interview frames sections as questions; recap = the original single-narrator read-through.
- Studio Style picker with per-style hint copy; guest voice hides for recap; review modal shows style.

## Backward compat
Speaker-less segments and configs without `voices`/`style` validate and render exactly as before — old stored drafts are untouched.

## Verification
- 79/79 targeted unit + structural tests (`research-generations` contract + server, podcast pipeline, media readiness, studio structural)
- `tests/research-studio-media.spec.ts` e2e green (incl. new style/guest-voice coverage)
- `pnpm typecheck` clean, eslint clean on changed files

Beads: cave-xfu10, cave-7sbpm, cave-8cgce