### PR TITLE
fix(chat): legible cancel glyph + attached images render and survive reload (cave-xrvns, cave-cysu4)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -37,9 +37,19 @@ const nextConfig: NextConfig = {
   // inputs; packaged assets are copied explicitly by sidecar-bundle.sh.
   outputFileTracingExcludes: {
     "/*": [
+      "./.agents/**/*",
       "./.beads/**/*",
       "./.claude/**/*",
       "./.codex/**/*",
+      "./.design-sync/**/*",
+      // A route whose module graph reaches a `caveHome()`-derived path makes
+      // the tracer glob the checkout root, which pulls in every dot-entry it
+      // is not told to skip. `./.git/**/*` below covers a normal clone, where
+      // `.git` is a directory; in a git WORKTREE `.git` is a plain file, and
+      // only this bare entry excludes it.
+      "./.git",
+      "./.github/**/*",
+      "./.gitignore",
       "./.next/cache/**/*",
       "./.next/dev/**/*",
       "./src-tauri/**/*",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -272,6 +272,7 @@ export const SUITES = {
     "src/lib/server/process-intent-lock.test.ts",
     "src/lib/server/research-generations.test.ts",
     "src/lib/server/research-media-store.test.ts",
+    "src/lib/server/chat-attachment-store.test.ts",
     "src/lib/server/research-podcast-pipeline.test.ts",
     "src/lib/server/research-video-renderer.test.ts",
     "src/lib/server/research-short-video-pipeline.test.ts",
@@ -1174,6 +1175,8 @@ export const SUITES = {
     "src/app/api/research/generations/route.test.ts",
     "src/app/api/research/generations/cancel/route.test.ts",
     "src/app/api/research/generations/media/route.test.ts",
+    "src/app/api/chat/attachment/route.test.ts",
+    "src/app/api/chat/send/chat-send-image-persistence.test.ts",
     "src/app/api/research/generations/readiness/route.test.ts",
     "src/app/api/research/generations/render/route.test.ts",
     "src/app/api/research/autoloop/routes.test.ts",
@@ -1574,6 +1577,9 @@ const ALIAS_LOADER = new Set([
   "src/lib/server/run-history-guards.test.ts",
   // conversation-write-guards imports ChatTurn via "@/lib/…" alias
   "src/lib/server/conversation-write-guards.test.ts",
+  // the attachment route imports the local-origin gate and the store via "@/…"
+  "src/app/api/chat/attachment/route.test.ts",
+  "src/app/api/chat/send/chat-send-image-persistence.test.ts",
   "src/components/thread-signal-card.test.ts",
   "src/components/thread-signals-section.test.ts",
   "src/components/chat-view.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -40,6 +40,7 @@ const contracts: RouteContract[] = [
   { route: "/capabilities", methods: ["GET"], kind: "json" },
   { route: "/cave-home-migration", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/changes", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", pathGuard: true },
+  { route: "/chat/attachment", methods: ["GET"], kind: "stream", localOriginGuard: true, pathGuard: true },
   { route: "/chat/conversation", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/conversation/[id]", methods: ["GET", "POST", "PUT", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/chat/model-state", methods: ["GET", "PATCH"], kind: "json", readsJson: true, invalidJson: "guarded" },

--- a/src/app/api/chat/attachment/route.test.ts
+++ b/src/app/api/chat/attachment/route.test.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+// Behavioral tests for GET /api/chat/attachment — the durable half of
+// "attached images survive a reload" (cave-cysu4). The store root is read at
+// call time from COVEN_CAVE_CHAT_ATTACHMENTS_DIR, but route.ts pulls in the
+// api-security gate at module load, so the env is set before the dynamic
+// import to keep every path inside the temp dir.
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, writeFileSync, symlinkSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ROOT = mkdtempSync(join(tmpdir(), "chat-attachment-route-"));
+const OUTSIDE = mkdtempSync(join(tmpdir(), "chat-attachment-route-outside-"));
+process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = ROOT;
+
+const { GET } = await import("./route.ts");
+const { saveChatImageAttachment } = await import("@/lib/server/chat-attachment-store");
+
+after(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+  rmSync(OUTSIDE, { recursive: true, force: true });
+});
+
+const PIXEL = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+/** A loopback request, which is what the local-origin gate expects. */
+function localRequest(query: string): Request {
+  return new Request(`http://127.0.0.1:3000/api/chat/attachment?${query}`, {
+    headers: { host: "127.0.0.1:3000" },
+  });
+}
+
+test("a stored image is served with its own bytes and mime type", async () => {
+  const storedId = await saveChatImageAttachment(
+    `data:image/png;base64,${PIXEL.toString("base64")}`,
+    "image/png",
+  );
+  assert.ok(storedId, "the store minted an id");
+
+  const res = await GET(localRequest(`id=${encodeURIComponent(storedId)}`));
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "image/png");
+  assert.equal(res.headers.get("x-content-type-options"), "nosniff");
+  assert.equal(res.headers.get("content-length"), String(PIXEL.byteLength));
+  assert.match(res.headers.get("cache-control") ?? "", /private/);
+  // User-supplied bytes must not be able to pull subresources if the URL is
+  // ever opened directly (an SVG attachment is still markup).
+  assert.match(res.headers.get("content-security-policy") ?? "", /default-src 'none'/);
+
+  const body = Buffer.from(await res.arrayBuffer());
+  assert.deepEqual(body, PIXEL, "the served bytes are the stored bytes");
+});
+
+test("a non-local request is refused before the store is touched", async () => {
+  const res = await GET(
+    new Request("http://cave.example.com/api/chat/attachment?id=x", {
+      headers: { host: "cave.example.com", origin: "http://evil.example.com" },
+    }),
+  );
+  assert.equal(res.status, 403);
+});
+
+test("ids the store could not have minted are a path-deny", async () => {
+  for (const bad of ["", "..%2F..%2Fetc%2Fpasswd", "not-a-uuid.png", "x".repeat(200)]) {
+    const res = await GET(localRequest(`id=${bad}`));
+    assert.equal(res.status, 403, `rejects ${JSON.stringify(bad)}`);
+    assert.match((await res.json()).error, /path not allowed/);
+  }
+});
+
+test("a well-formed id with nothing behind it is a 404", async () => {
+  const res = await GET(localRequest("id=11111111-2222-4333-8444-555555555555.png"));
+  assert.equal(res.status, 404);
+});
+
+test("a symlink planted in the store is not served", async () => {
+  const secret = join(OUTSIDE, "secret.png");
+  writeFileSync(secret, "not yours");
+  const linkId = "5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.png";
+  symlinkSync(secret, join(ROOT, linkId));
+  const res = await GET(localRequest(`id=${linkId}`));
+  assert.equal(res.status, 404, "a symlinked entry is refused, not dereferenced");
+  const body = await res.text();
+  assert.ok(!body.includes("not yours"), "the linked file's contents never leave the store");
+});
+
+console.log("chat/attachment route.test.ts: ok");

--- a/src/app/api/chat/attachment/route.ts
+++ b/src/app/api/chat/attachment/route.ts
@@ -1,0 +1,63 @@
+// The explicit .js extension (matching the sibling conversation route) lets
+// route.test.ts import this module directly under plain Node ESM resolution:
+// `next` ships no "exports" map, so the extensionless "next/server" specifier
+// 404s outside Next's own resolver.
+import { NextResponse } from "next/server.js";
+
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import {
+  ChatAttachmentStoreError,
+  isValidChatAttachmentId,
+  readChatImageAttachment,
+} from "@/lib/server/chat-attachment-store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Serve a chat image attachment the send route stored durably, so a reopened
+ * transcript can render the picture instead of a filename chip.
+ *
+ * Fetch this through `AuthedImage` / the patched `window.fetch`, never a bare
+ * `<img src="/api/...">`: in the packaged app the sidecar gates `/api/*` on a
+ * header only the patched fetch carries, and a native image load 401s into
+ * WebKit's broken-image glyph (cave-wgc2).
+ */
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  // An id is a filename inside the store, so anything but the exact shape the
+  // store mints is a path-deny — same 403 wording as the other byte-serving
+  // routes (see /api/research/generations/media).
+  const id = new URL(req.url).searchParams.get("id")?.trim() ?? "";
+  if (!isValidChatAttachmentId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+
+  try {
+    const { data, mimeType } = await readChatImageAttachment(id);
+    return new Response(new Uint8Array(data), {
+      status: 200,
+      headers: {
+        "content-type": mimeType,
+        "content-length": String(data.byteLength),
+        // The bytes are user content: forbid sniffing, forbid any subresource
+        // an SVG might try to pull if it is ever opened directly, and keep it
+        // out of shared caches.
+        "x-content-type-options": "nosniff",
+        "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'; sandbox",
+        "content-disposition": "inline",
+        "cache-control": "private, max-age=3600",
+      },
+    });
+  } catch (error) {
+    if (error instanceof ChatAttachmentStoreError) {
+      if (error.code === "invalid-id") {
+        return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+      }
+      return NextResponse.json({ ok: false, error: "attachment not found" }, { status: 404 });
+    }
+    return NextResponse.json({ ok: false, error: "failed to read attachment" }, { status: 500 });
+  }
+}

--- a/src/app/api/chat/send/chat-send-attachments.ts
+++ b/src/app/api/chat/send/chat-send-attachments.ts
@@ -5,6 +5,10 @@ import {
   MAX_ATTACHMENT_IMAGE_BYTES,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
+import {
+  saveChatImageAttachment,
+  sweepChatImageAttachments,
+} from "@/lib/server/chat-attachment-store";
 
 const ATTACHMENT_TMP_DIR = path.join(tmpdir(), "coven-cave-attachments");
 const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
@@ -42,6 +46,35 @@ export async function writeImageAttachmentsToTemp(
     }
   }
   return filePaths;
+}
+
+/**
+ * Give each image attachment a durable copy and stamp its id onto the record
+ * the transcript will keep. `persisted` is the metadata-only shape (payloads
+ * already stripped); `source` still holds the pixels.
+ *
+ * Best effort by design: a store failure leaves that attachment exactly as it
+ * was before — metadata only — rather than failing the send.
+ */
+export async function persistImageAttachments(
+  persisted: ChatAttachment[],
+  source: ChatAttachment[],
+): Promise<ChatAttachment[]> {
+  const anyImages = source.some(
+    (attachment) => attachment.dataUrl && attachment.mimeType?.startsWith("image/"),
+  );
+  if (!anyImages) return persisted;
+  const stored = await Promise.all(
+    persisted.map(async (attachment, index) => {
+      const origin = source[index];
+      if (!origin?.dataUrl || !origin.mimeType?.startsWith("image/")) return attachment;
+      const storedId = await saveChatImageAttachment(origin.dataUrl, origin.mimeType);
+      return storedId ? { ...attachment, storedId } : attachment;
+    }),
+  );
+  // Retention runs off the write path so a send never waits on a directory scan.
+  void sweepChatImageAttachments().catch(() => undefined);
+  return stored;
 }
 
 export function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {

--- a/src/app/api/chat/send/chat-send-image-persistence.test.ts
+++ b/src/app/api/chat/send/chat-send-image-persistence.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+// The send route's half of "attached images survive a reload" (cave-cysu4):
+// the payload still gets stripped from the transcript, but an image now leaves
+// behind a durable copy whose id the transcript keeps.
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ROOT = mkdtempSync(join(tmpdir(), "chat-send-image-persistence-"));
+process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = ROOT;
+
+const { persistImageAttachments } = await import("./chat-send-attachments.ts");
+const { normalizeChatAttachments, stripPreviewOnlyAttachmentFields, chatAttachmentSrc } =
+  await import("@/lib/chat-attachments");
+
+after(() => rmSync(ROOT, { recursive: true, force: true }));
+
+const PIXEL_B64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+const IMAGE = {
+  name: "shot.png",
+  type: "image/png",
+  mimeType: "image/png",
+  size: 95,
+  dataUrl: `data:image/png;base64,${PIXEL_B64}`,
+};
+const TEXT_FILE = { name: "notes.txt", type: "text/plain", size: 12, text: "hello there" };
+
+test("an image gains a storedId while its payload stays out of the transcript", async () => {
+  const attachments = normalizeChatAttachments([IMAGE, TEXT_FILE]);
+  const persisted = await persistImageAttachments(
+    stripPreviewOnlyAttachmentFields(attachments),
+    attachments,
+  );
+
+  const [image, text] = persisted;
+  assert.ok(image.storedId, "the image records where its durable copy lives");
+  assert.equal(image.dataUrl, undefined, "the base64 payload never reaches the transcript");
+  assert.equal(text.storedId, undefined, "a text attachment stores nothing");
+
+  // The bytes are really on disk, and the client can point an <img> at them.
+  const files = readdirSync(ROOT);
+  assert.ok(files.includes(image.storedId), "the file is in the store");
+  assert.deepEqual(
+    readFileSync(join(ROOT, image.storedId)),
+    Buffer.from(PIXEL_B64, "base64"),
+    "the stored bytes are the attached bytes",
+  );
+  assert.equal(
+    chatAttachmentSrc(image),
+    `/api/chat/attachment?id=${encodeURIComponent(image.storedId)}`,
+    "a reopened transcript resolves the image to the serving route",
+  );
+});
+
+test("a storedId survives the round trip through normalization", async () => {
+  const attachments = normalizeChatAttachments([IMAGE]);
+  const [persisted] = await persistImageAttachments(
+    stripPreviewOnlyAttachmentFields(attachments),
+    attachments,
+  );
+  // This is the shape the conversation route hands back to the client.
+  const [reloaded] = normalizeChatAttachments([persisted]);
+  assert.equal(reloaded.storedId, persisted.storedId, "the id is not dropped on the way back");
+  assert.ok(chatAttachmentSrc(reloaded), "the reloaded attachment still has a source");
+});
+
+test("a forged storedId is discarded rather than fetched", () => {
+  const [forged] = normalizeChatAttachments([
+    { ...IMAGE, dataUrl: undefined, storedId: "../../etc/passwd" },
+  ]);
+  assert.equal(forged.storedId, undefined, "only store-minted ids survive normalization");
+  assert.equal(chatAttachmentSrc(forged), null, "and nothing is fetched for them");
+});
+
+test("a turn with no images does no store work", async () => {
+  const attachments = normalizeChatAttachments([TEXT_FILE]);
+  const before = readdirSync(ROOT).length;
+  const persisted = await persistImageAttachments(
+    stripPreviewOnlyAttachmentFields(attachments),
+    attachments,
+  );
+  assert.deepEqual(persisted, stripPreviewOnlyAttachmentFields(attachments));
+  assert.equal(readdirSync(ROOT).length, before, "nothing was written");
+});
+
+console.log("chat-send-image-persistence.test.ts: ok");

--- a/src/app/api/chat/send/harness-routing-attachments.test.ts
+++ b/src/app/api/chat/send/harness-routing-attachments.test.ts
@@ -92,10 +92,19 @@ assert.match(
   "Image temp files should be best-effort deleted after the harness child has exited",
 );
 
+// The transcript still never receives a base64 payload. Since cave-cysu4 the
+// stripped record additionally carries a `storedId` pointing at the durable
+// copy, so a reopened thread can render the image — but the strip stays the
+// inner call, i.e. nothing reaches persistence that the strip did not pass.
 assert.match(
   chatRoute,
-  /const persistedAttachments = stripPreviewOnlyAttachmentFields\(attachments\);/,
+  /const persistedAttachments = await persistImageAttachments\(\s*stripPreviewOnlyAttachmentFields\(attachments\),\s*attachments,\s*\);/,
   "Persisted transcripts should keep attachment metadata only, not base64 image payloads",
+);
+assert.match(
+  chatRoute,
+  /import \{[\s\S]*?persistImageAttachments,[\s\S]*?\} from "\.\/chat-send-attachments";/,
+  "The durable-copy step lives with the other attachment helpers",
 );
 
 // Behavioral coverage: normalization keeps bounded image payloads and rejects

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -241,6 +241,7 @@ import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 import {
   appendMentionedFilesBlock,
   cleanupImageTempFiles,
+  persistImageAttachments,
   resolveMentionedFiles,
   writeImageAttachmentsToTemp,
 } from "./chat-send-attachments";
@@ -1213,8 +1214,14 @@ export async function POST(req: Request) {
     );
   }
   // Persisted transcripts keep attachment metadata only — base64 image
-  // payloads stay out of the conversation store.
-  const persistedAttachments = stripPreviewOnlyAttachmentFields(attachments);
+  // payloads stay out of the conversation store. Images additionally get a
+  // durable copy in the attachment store, and the transcript records its id,
+  // so reopening the thread can show the picture again instead of degrading
+  // to a filename chip (cave-cysu4).
+  const persistedAttachments = await persistImageAttachments(
+    stripPreviewOnlyAttachmentFields(attachments),
+    attachments,
+  );
 
   const config = await loadConfig();
   const binding = bindingFor(config, body.familiarId);

--- a/src/components/chat-attachment-cards.test.ts
+++ b/src/components/chat-attachment-cards.test.ts
@@ -42,13 +42,42 @@ assert.match(
 );
 assert.match(
   cards,
-  /export function AttachmentThumb[\s\S]*?if \(!isInlineImageAttachment\(attachment\)\) \{[\s\S]*?<Icon name=\{attachmentIcon\(attachment\)\}/,
+  /export function AttachmentThumb[\s\S]*?const glyph = <Icon name=\{attachmentIcon\(attachment\)\}[\s\S]*?if \(!isInlineImageAttachment\(attachment\)\) return glyph;/,
   "attachments with no pixels fall back to the mime glyph",
 );
 assert.match(
   cards,
-  /export function AttachmentThumb[\s\S]*?<img\s*src=\{attachment\.dataUrl\}/,
+  /<AuthedImage[\s\S]*?fallback=\{glyph\}/,
+  "the glyph also stands in while the authenticated fetch is in flight or fails",
+);
+assert.match(
+  cards,
+  /export function AttachmentThumb[\s\S]*?<AuthedImage\s*src=\{chatAttachmentSrc\(attachment\)\}/,
   "an image we hold pixels for previews as the picture itself",
+);
+
+// Durable images (cave-cysu4). A reopened transcript has no dataUrl — the
+// payload is stripped at persistence — so every image render resolves its
+// source through chatAttachmentSrc, which falls back to the stored copy.
+assert.doesNotMatch(
+  cards,
+  /<img\s+src=\{attachment\.dataUrl\}/,
+  "no render site reads dataUrl directly; a stored-only image would show nothing",
+);
+assert.equal(
+  (cards.match(/<AuthedImage/g) ?? []).length,
+  3,
+  "thumb, inline image, and lightbox all render through AuthedImage",
+);
+assert.doesNotMatch(
+  cards,
+  /<img src="\/api\//,
+  "an API-served image must never be a native <img> load — the packaged sidecar 401s it (cave-wgc2)",
+);
+assert.match(
+  cards,
+  /isInlineImageAttachment[\s\S]*?startsWith\("image\/"\) &&\s*chatAttachmentSrc\(attachment\)/,
+  "an image counts as inline-able when EITHER the payload or the stored copy can supply it",
 );
 
 console.log("chat-attachment-cards.test.ts: ok");

--- a/src/components/chat-attachment-cards.test.ts
+++ b/src/components/chat-attachment-cards.test.ts
@@ -13,13 +13,42 @@ assert.match(cards, /useFocusTrap\(true, dialogRef, \{ onEscape: onClose \}\)/, 
 assert.match(cards, /aria-modal="true"/, "attachment preview remains a modal dialog");
 assert.match(cards, /export function AttachmentList/, "attachment chips have a dedicated presentation component");
 assert.match(cards, /export function InlineImageAttachments/, "familiar-produced images have an inline presentation component");
-assert.match(chatView, /import \{ AttachmentList, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment \} from "\.\/chat-attachment-cards"/, "ChatView consumes the attachment presentation boundary");
-assert.match(chatView, /<AttachmentList attachments=\{turn\.attachments\} \/>/, "transcript rows continue to render attachment chips");
-assert.match(chatView, /<InlineImageAttachments attachments=\{turn\.attachments\} \/>/, "assistant image attachments render inline (e.g. /image generations)");
+assert.match(cards, /export function AttachmentThumb/, "staged attachments have a chip-sized preview component");
+assert.match(chatView, /import \{ AttachmentList, AttachmentThumb, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment \} from "\.\/chat-attachment-cards"/, "ChatView consumes the attachment presentation boundary");
+
+// Both transcript paths — the turn you sent and the turn a familiar produced —
+// render images as images and keep the chip list for everything that has no
+// pixels to show. A user-attached screenshot used to appear only as a filename
+// (cave-xrvns follow-up), which is indistinguishable from a text file.
+const inlineSplits = chatView.match(
+  /<InlineImageAttachments attachments=\{turn\.attachments\} \/>\s*\{turn\.attachments\.some\(\(a\) => !isInlineImageAttachment\(a\)\) \? \(\s*<AttachmentList attachments=\{turn\.attachments\.filter\(\(a\) => !isInlineImageAttachment\(a\)\)\} \/>/g,
+) ?? [];
+assert.equal(
+  inlineSplits.length,
+  2,
+  "both the user/system turn and the assistant turn split inline images from chips",
+);
+assert.doesNotMatch(
+  chatView,
+  /<AttachmentList attachments=\{turn\.attachments\} \/>/,
+  "no transcript path sends images through the chip list unfiltered",
+);
+
+// Composer staging: the picked image previews in its chip.
 assert.match(
   chatView,
-  /<AttachmentList attachments=\{turn\.attachments\.filter\(\(a\) => !isInlineImageAttachment\(a\)\)\} \/>/,
-  "inlined images are excluded from the assistant chip list (no double display)",
+  /<AttachmentThumb attachment=\{attachment\} \/>\s*<span className="truncate">\{attachment\.name\}<\/span>/,
+  "the composer chip leads with the staged attachment's own preview",
+);
+assert.match(
+  cards,
+  /export function AttachmentThumb[\s\S]*?if \(!isInlineImageAttachment\(attachment\)\) \{[\s\S]*?<Icon name=\{attachmentIcon\(attachment\)\}/,
+  "attachments with no pixels fall back to the mime glyph",
+);
+assert.match(
+  cards,
+  /export function AttachmentThumb[\s\S]*?<img\s*src=\{attachment\.dataUrl\}/,
+  "an image we hold pixels for previews as the picture itself",
 );
 
 console.log("chat-attachment-cards.test.ts: ok");

--- a/src/components/chat-attachment-cards.tsx
+++ b/src/components/chat-attachment-cards.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import { attachmentIcon, type ChatAttachment } from "@/lib/chat-attachments";
+import { AuthedImage } from "@/components/ui/authed-image";
+import { attachmentIcon, chatAttachmentSrc, type ChatAttachment } from "@/lib/chat-attachments";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 
@@ -18,6 +19,7 @@ export function formatAttachmentBytes(size?: number): string {
 
 function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachment; onClose: () => void }) {
   const isImage = (attachment.mimeType ?? attachment.type)?.startsWith("image/");
+  const imageSrc = chatAttachmentSrc(attachment);
   const dialogRef = useRef<HTMLDivElement | null>(null);
   // This component only mounts while open: trap Tab/Shift+Tab and restore the
   // chip trigger on dismissal, including Escape.
@@ -53,9 +55,9 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
             <Icon name="ph:x-bold" width={11} />
           </button>
         </div>
-        {isImage && attachment.dataUrl ? (
+        {isImage && imageSrc ? (
           <div className="flex items-center justify-center overflow-hidden p-4">
-            <img src={attachment.dataUrl} alt={attachment.name} className="rounded-lg object-contain block [max-height:75vh]! [max-width:min(85vw,_100%)]! [width:auto]! [height:auto]!" />
+            <AuthedImage src={imageSrc} alt={attachment.name} className="rounded-lg object-contain block [max-height:75vh]! [max-width:min(85vw,_100%)]! [width:auto]! [height:auto]!" />
           </div>
         ) : attachment.text ? (
           <pre className="max-h-[70vh] overflow-auto p-4 font-mono text-[length:var(--text-sm)] leading-relaxed text-[var(--text-secondary)] whitespace-pre-wrap">{attachment.text}</pre>
@@ -96,10 +98,15 @@ export function AttachmentList({ attachments }: { attachments: ChatAttachment[] 
   );
 }
 
-/** True when the attachment is an image that can render inline (has a data URL). */
+/**
+ * True when the attachment is an image we can actually show — either we still
+ * hold the payload (the turn you just sent) or the server kept a durable copy
+ * (a reopened transcript). An image with neither stays a chip.
+ */
 export function isInlineImageAttachment(attachment: ChatAttachment): boolean {
   return Boolean(
-    (attachment.mimeType ?? attachment.type)?.startsWith("image/") && attachment.dataUrl,
+    (attachment.mimeType ?? attachment.type)?.startsWith("image/") &&
+      chatAttachmentSrc(attachment),
   );
 }
 
@@ -109,14 +116,14 @@ export function isInlineImageAttachment(attachment: ChatAttachment): boolean {
  * attached image is recognizable before it is sent, rather than a filename.
  */
 export function AttachmentThumb({ attachment }: { attachment: ChatAttachment }) {
-  if (!isInlineImageAttachment(attachment)) {
-    return <Icon name={attachmentIcon(attachment)} width={12} className="shrink-0" />;
-  }
+  const glyph = <Icon name={attachmentIcon(attachment)} width={12} className="shrink-0" />;
+  if (!isInlineImageAttachment(attachment)) return glyph;
   return (
-    <img
-      src={attachment.dataUrl}
+    <AuthedImage
+      src={chatAttachmentSrc(attachment)}
       alt=""
       aria-hidden
+      fallback={glyph}
       className="h-5 w-5 shrink-0 rounded-sm border border-[var(--border-hairline)] object-cover"
     />
   );
@@ -142,8 +149,8 @@ export function InlineImageAttachments({ attachments }: { attachments: ChatAttac
             title={`View ${attachment.name}`}
             onClick={() => setSelected(attachment)}
           >
-            <img
-              src={attachment.dataUrl}
+            <AuthedImage
+              src={chatAttachmentSrc(attachment)}
               alt={attachment.name}
               loading="lazy"
               className="block max-h-80 max-w-full object-contain"

--- a/src/components/chat-attachment-cards.tsx
+++ b/src/components/chat-attachment-cards.tsx
@@ -104,6 +104,25 @@ export function isInlineImageAttachment(attachment: ChatAttachment): boolean {
 }
 
 /**
+ * Chip-sized preview of a staged attachment: the picture itself for an image
+ * we hold pixels for, the mime glyph otherwise. Used by the composer so an
+ * attached image is recognizable before it is sent, rather than a filename.
+ */
+export function AttachmentThumb({ attachment }: { attachment: ChatAttachment }) {
+  if (!isInlineImageAttachment(attachment)) {
+    return <Icon name={attachmentIcon(attachment)} width={12} className="shrink-0" />;
+  }
+  return (
+    <img
+      src={attachment.dataUrl}
+      alt=""
+      aria-hidden
+      className="h-5 w-5 shrink-0 rounded-sm border border-[var(--border-hairline)] object-cover"
+    />
+  );
+}
+
+/**
  * Full-bleed inline rendering for image attachments a familiar produced
  * (e.g. /image generations) — a bounded picture in the transcript instead of
  * a filename chip. Click opens the same lightbox as the chip list.

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -184,6 +184,29 @@ assert.match(
   "typing should still add the accent tint fill to the send button",
 );
 
+// The busy/cancel circle paints its glyph ON the danger fill, so the only
+// legible foreground is the on-danger token. `--danger-text` resolves to
+// `var(--color-danger)` — red type meant for neutral surfaces — and painting
+// the ✕ with it left a solid red square with no visible icon (cave-xrvns).
+for (const [sheet, label] of [
+  [css, "cave-composer.css"],
+  [transcriptCss, "transcript.css"],
+] as const) {
+  const busy = sheet.match(/\.cave-composer-send--busy[^{]*\{[^}]*\}/g) ?? [];
+  assert.ok(busy.length > 0, `${label} should style the busy send button`);
+  for (const rule of busy) {
+    assert.doesNotMatch(
+      rule,
+      /color:\s*var\(--danger-text\)/,
+      `${label}: the busy glyph must not reuse --danger-text (same value as the danger fill)`,
+    );
+  }
+  assert.ok(
+    busy.some((rule) => /color:\s*var\(--color-danger-foreground\)/.test(rule)),
+    `${label}: the busy glyph should use the on-danger foreground token`,
+  );
+}
+
 // The "↵ send · ⇧↵ newline" typing hint is gone from the chat composer
 // (2026-07-21): the tinted send button already signals sendability. The
 // home composer dropped its hint in the same day's parity pass, so the

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -76,7 +76,6 @@ import { githubIcon, githubLabel, repoName } from "@/components/composer-linked-
 import { LinkedContextRow } from "@/components/composer-linked-work-actions";
 import { ComposerContextChips } from "@/components/composer-context-pill";
 import {
-  attachmentIcon,
   cleanImageDataUrl,
   extractAgentAttachmentMarkers,
   stripPreviewOnlyAttachmentFieldsKeepingImages,
@@ -207,7 +206,7 @@ import {
 import { streamFamiliarText } from "@/lib/familiar-stream";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
-import { AttachmentList, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment } from "./chat-attachment-cards";
+import { AttachmentList, AttachmentThumb, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment } from "./chat-attachment-cards";
 import { preloadMarkdownPreview } from "@/lib/markdown-preview";
 
 // Chat history commonly arrives before syntax highlighting is needed. Warm the
@@ -6415,7 +6414,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     key={attachment.id}
                     className="inline-flex max-w-56 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/50 px-2 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)]"
                   >
-                    <Icon name={attachmentIcon(attachment)} width={12} />
+                    {/* Staged images preview as themselves — a filename chip
+                        gave no way to tell which screenshot you picked. */}
+                    <AttachmentThumb attachment={attachment} />
                     <span className="truncate">{attachment.name}</span>
                     <span className="shrink-0 text-[var(--text-muted)]">{formatAttachmentBytes(attachment.size)}</span>
                     <button
@@ -7185,7 +7186,17 @@ function TurnRowImpl({
                 onOpenUrl={onOpenUrl}
                 branchNav={branchNav}
               />
-              {turn.attachments?.length ? <AttachmentList attachments={turn.attachments} /> : null}
+              {/* An image you attached renders as the image, matching the
+                  assistant path — the chip list only carries what has no
+                  pixels to show (text files, oversize/undelivered images). */}
+              {turn.attachments?.length ? (
+                <>
+                  <InlineImageAttachments attachments={turn.attachments} />
+                  {turn.attachments.some((a) => !isInlineImageAttachment(a)) ? (
+                    <AttachmentList attachments={turn.attachments.filter((a) => !isInlineImageAttachment(a))} />
+                  ) : null}
+                </>
+              ) : null}
               {/* Bare-line GitHub URLs in a user message unfurl into cards
                   beneath the bubble (attachment idiom) — the headline "paste a
                   PR link" gesture (design §1). User turns only, never system. */}

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -25,7 +25,33 @@ export type ChatAttachment = {
   truncated?: boolean;
   /** Base64 data URL for images, set when the file is attached locally */
   dataUrl?: string;
+  /**
+   * Id of the image in the durable attachment store, set by the server when
+   * the turn is persisted. This is what lets a reopened transcript show the
+   * picture again: `dataUrl` is stripped at persistence, `storedId` is not.
+   */
+  storedId?: string;
 };
+
+/** `<uuid>.<ext>` as minted by the server's attachment store. Validated on the
+ * client too so a hand-edited transcript cannot steer the fetch. */
+const STORED_ATTACHMENT_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.[a-z0-9]{1,8}$/;
+
+function cleanStoredId(value: unknown): string | undefined {
+  return typeof value === "string" && STORED_ATTACHMENT_ID_RE.test(value) ? value : undefined;
+}
+
+/**
+ * Where to point an `<img>` for this attachment: the in-memory payload when we
+ * still hold it (the turn you just sent), otherwise the stored copy served by
+ * `/api/chat/attachment`. Null when there are no pixels to show.
+ */
+export function chatAttachmentSrc(attachment: ChatAttachment): string | null {
+  if (attachment.dataUrl) return attachment.dataUrl;
+  const storedId = cleanStoredId(attachment.storedId);
+  return storedId ? `/api/chat/attachment?id=${encodeURIComponent(storedId)}` : null;
+}
 
 /** Fenced marker a familiar emits to attach a file it produced, e.g.
  *   ```coven:attachment
@@ -113,6 +139,7 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
       // server can hand them to the harness. Everything else stays metadata-only.
       const image = cleanImageDataUrl(raw.dataUrl);
       const mimeType = cleanType(raw.mimeType);
+      const storedId = cleanStoredId(raw.storedId);
       return {
         name: cleanName(raw.name),
         type: cleanType(raw.type),
@@ -121,6 +148,7 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
         ...(text != null ? { text } : {}),
         ...(rawText != null && rawText.length > MAX_ATTACHMENT_TEXT_CHARS ? { truncated: true } : {}),
         ...(image ? { mimeType: image.mimeType, dataUrl: image.dataUrl } : {}),
+        ...(storedId ? { storedId } : {}),
       };
     });
 }

--- a/src/lib/server/chat-attachment-store.test.ts
+++ b/src/lib/server/chat-attachment-store.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readdir, rm, stat, symlink, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+
+const root = await mkdtemp(path.join(tmpdir(), "cave-chat-attachments-"));
+const outside = await mkdtemp(path.join(tmpdir(), "cave-chat-attachments-outside-"));
+const originalRoot = process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR;
+process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = root;
+
+const {
+  CHAT_ATTACHMENT_MAX_AGE_MS,
+  ChatAttachmentStoreError,
+  chatAttachmentMimeType,
+  isValidChatAttachmentId,
+  readChatImageAttachment,
+  saveChatImageAttachment,
+  sweepChatImageAttachments,
+} = await import("./chat-attachment-store.ts");
+
+after(async () => {
+  if (originalRoot === undefined) delete process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR;
+  else process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = originalRoot;
+  await rm(root, { recursive: true, force: true });
+  await rm(outside, { recursive: true, force: true });
+});
+
+const PIXEL = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+  "base64",
+);
+const PIXEL_DATA_URL = `data:image/png;base64,${PIXEL.toString("base64")}`;
+
+test("an image round-trips through the store", async () => {
+  const storedId = await saveChatImageAttachment(PIXEL_DATA_URL, "image/png");
+  assert.ok(storedId, "saving a valid png returns an id");
+  assert.ok(isValidChatAttachmentId(storedId), "the minted id matches the safe shape");
+  assert.match(storedId, /\.png$/, "the extension comes from the mime type");
+
+  const read = await readChatImageAttachment(storedId);
+  assert.equal(read.mimeType, "image/png");
+  assert.deepEqual(read.data, PIXEL, "the bytes come back unchanged");
+});
+
+test("stored files are owner-only", async () => {
+  const storedId = await saveChatImageAttachment(PIXEL_DATA_URL, "image/jpeg");
+  assert.ok(storedId);
+  assert.match(storedId, /\.jpg$/, "jpeg normalizes to the jpg extension");
+  const meta = await stat(path.join(root, storedId));
+  assert.equal(meta.mode & 0o777, 0o600, "attachments are not group- or world-readable");
+});
+
+test("non-images and unusable payloads are refused", async () => {
+  assert.equal(await saveChatImageAttachment(PIXEL_DATA_URL, "text/plain"), null);
+  assert.equal(await saveChatImageAttachment("not-a-data-url", "image/png"), null);
+  assert.equal(await saveChatImageAttachment("data:image/png;base64,", "image/png"), null);
+});
+
+test("only ids the store could have minted are accepted", async () => {
+  for (const bad of [
+    "",
+    "../escape.png",
+    "not-a-uuid.png",
+    "5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b",
+    "5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.png/../../etc/passwd",
+    "5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.PNG",
+    "5B1F0E64-6B0E-4B6B-9F3A-0D1C2E3F4A5B.png",
+  ]) {
+    assert.equal(isValidChatAttachmentId(bad), false, `rejects ${JSON.stringify(bad)}`);
+    await assert.rejects(
+      () => readChatImageAttachment(bad),
+      (error: unknown) =>
+        error instanceof ChatAttachmentStoreError && error.code === "invalid-id",
+      `reading ${JSON.stringify(bad)} is refused`,
+    );
+  }
+});
+
+test("an id with an extension the store does not serve is refused", async () => {
+  await assert.rejects(
+    () => readChatImageAttachment("5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.exe"),
+    (error: unknown) => error instanceof ChatAttachmentStoreError && error.code === "invalid-id",
+  );
+  assert.equal(chatAttachmentMimeType("5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.exe"), null);
+  assert.equal(chatAttachmentMimeType("5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.webp"), "image/webp");
+});
+
+test("a symlink planted in the store is not followed", async () => {
+  const secret = path.join(outside, "secret.png");
+  await writeFile(secret, "not yours");
+  const linkId = "5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.png";
+  await symlink(secret, path.join(root, linkId));
+  await assert.rejects(
+    () => readChatImageAttachment(linkId),
+    (error: unknown) => error instanceof ChatAttachmentStoreError && error.code === "symlink",
+    "a symlinked entry is refused rather than dereferenced",
+  );
+  await rm(path.join(root, linkId), { force: true });
+});
+
+test("a missing attachment reports missing, not a crash", async () => {
+  await assert.rejects(
+    () => readChatImageAttachment("11111111-2222-4333-8444-555555555555.png"),
+    (error: unknown) => error instanceof ChatAttachmentStoreError && error.code === "missing",
+  );
+});
+
+test("the sweep drops only entries past the retention window", async () => {
+  const keep = await saveChatImageAttachment(PIXEL_DATA_URL, "image/png");
+  const drop = await saveChatImageAttachment(PIXEL_DATA_URL, "image/png");
+  assert.ok(keep && drop);
+  const stale = new Date(Date.now() - CHAT_ATTACHMENT_MAX_AGE_MS - 60_000);
+  await utimes(path.join(root, drop), stale, stale);
+
+  const removed = await sweepChatImageAttachments();
+  assert.ok(removed >= 1, "the stale entry is swept");
+  const names = await readdir(root);
+  assert.ok(names.includes(keep), "a fresh entry survives the sweep");
+  assert.ok(!names.includes(drop), "the stale entry is gone");
+});
+
+console.log("chat-attachment-store.test.ts: ok");

--- a/src/lib/server/chat-attachment-store.ts
+++ b/src/lib/server/chat-attachment-store.ts
@@ -1,0 +1,219 @@
+import { lstat, mkdir, open, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { MAX_ATTACHMENT_IMAGE_BYTES } from "../chat-attachments.ts";
+import { caveHome } from "../coven-paths.ts";
+
+/**
+ * Durable home for chat image attachments.
+ *
+ * The conversation store deliberately keeps base64 payloads out of its JSON
+ * (a 5 MB screenshot would be ~6.7 MB of transcript), and the temp copy handed
+ * to local harnesses is deleted as soon as the turn ends. Without a third
+ * place to put the bytes, an image you sent survives only as long as the
+ * optimistic turn lives in React state — reopen the thread and it degrades to
+ * a filename chip (cave-cysu4).
+ *
+ * Files are flat and content-addressed by a random id: the transcript records
+ * `storedId` and nothing else, so nothing here needs to know about sessions,
+ * and no caller can steer a path with attacker-shaped input.
+ */
+
+/** `<uuid>.<ext>` — the whole of what a caller may ask for. */
+const SAFE_STORED_ID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.[a-z0-9]{1,8}$/;
+const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = { jpeg: "jpg", "svg+xml": "svg" };
+const MIME_BY_EXT: Record<string, string> = {
+  apng: "image/apng",
+  avif: "image/avif",
+  bmp: "image/bmp",
+  gif: "image/gif",
+  heic: "image/heic",
+  heif: "image/heif",
+  ico: "image/x-icon",
+  jpg: "image/jpeg",
+  png: "image/png",
+  svg: "image/svg+xml",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  webp: "image/webp",
+};
+/** Files older than this are swept opportunistically on write. */
+export const CHAT_ATTACHMENT_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000;
+/** Upper bound on a single sweep so a huge directory never stalls a send. */
+const SWEEP_SCAN_LIMIT = 2_000;
+
+export class ChatAttachmentStoreError extends Error {
+  readonly code: "invalid-id" | "missing" | "symlink" | "too-large";
+
+  constructor(code: ChatAttachmentStoreError["code"], message: string) {
+    super(message);
+    this.name = "ChatAttachmentStoreError";
+    this.code = code;
+  }
+}
+
+export function chatAttachmentRoot(): string {
+  return (
+    process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR?.trim() ||
+    path.join(/* turbopackIgnore: true */ caveHome(), "chat-attachments")
+  );
+}
+
+function extensionFor(mimeType: string): string {
+  const subtype = mimeType.split("/")[1]?.toLowerCase() ?? "";
+  const mapped = IMAGE_EXT_BY_SUBTYPE[subtype] ?? subtype;
+  return /^[a-z0-9]{1,8}$/.test(mapped) ? mapped : "img";
+}
+
+/** Canonical mime for a stored id, derived from the id itself — never from a
+ * caller-supplied header. Unknown extensions are refused rather than guessed. */
+export function chatAttachmentMimeType(storedId: string): string | null {
+  const ext = storedId.slice(storedId.lastIndexOf(".") + 1).toLowerCase();
+  return MIME_BY_EXT[ext] ?? null;
+}
+
+export function isValidChatAttachmentId(value: unknown): value is string {
+  return typeof value === "string" && SAFE_STORED_ID.test(value);
+}
+
+function isContained(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative !== "" &&
+    relative !== ".." &&
+    !relative.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(relative)
+  );
+}
+
+/** Resolve the store root, refusing a symlinked root outright. */
+async function resolvedRoot(create: boolean): Promise<string> {
+  const root = chatAttachmentRoot();
+  if (create) await mkdir(root, { recursive: true, mode: 0o700 });
+  let meta;
+  try {
+    meta = await lstat(root);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ChatAttachmentStoreError("missing", "attachment store not found");
+    }
+    throw error;
+  }
+  if (meta.isSymbolicLink()) {
+    throw new ChatAttachmentStoreError("symlink", "attachment store root is a symlink");
+  }
+  if (!meta.isDirectory()) {
+    throw new ChatAttachmentStoreError("symlink", "attachment store root is not a directory");
+  }
+  return realpath(root);
+}
+
+/**
+ * Persist one validated image payload. Returns the stored id to record on the
+ * transcript, or null when the payload is unusable — callers fall back to the
+ * existing metadata-only behavior rather than failing the send.
+ */
+export async function saveChatImageAttachment(
+  dataUrl: string,
+  mimeType: string,
+): Promise<string | null> {
+  if (!mimeType.startsWith("image/")) return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma === -1) return null;
+  const payload = Buffer.from(dataUrl.slice(comma + 1), "base64");
+  if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_IMAGE_BYTES) return null;
+  try {
+    const root = await resolvedRoot(true);
+    const storedId = `${randomUUID()}.${extensionFor(mimeType)}`;
+    if (!SAFE_STORED_ID.test(storedId)) return null;
+    const target = path.join(root, storedId);
+    if (!isContained(root, target)) return null;
+    // `wx` refuses to follow an existing symlink planted at the target.
+    await writeFile(target, payload, { mode: 0o600, flag: "wx" });
+    return storedId;
+  } catch {
+    // Best effort: the turn still sends, the transcript just keeps metadata.
+    return null;
+  }
+}
+
+/** Read a stored attachment's bytes. Throws rather than serving anything the
+ * id did not literally name. */
+export async function readChatImageAttachment(
+  storedId: string,
+): Promise<{ data: Buffer; mimeType: string }> {
+  if (!isValidChatAttachmentId(storedId)) {
+    throw new ChatAttachmentStoreError("invalid-id", "invalid attachment id");
+  }
+  const mimeType = chatAttachmentMimeType(storedId);
+  if (!mimeType) {
+    throw new ChatAttachmentStoreError("invalid-id", "unsupported attachment type");
+  }
+  const root = await resolvedRoot(false);
+  const target = path.join(root, storedId);
+  if (!isContained(root, target)) {
+    throw new ChatAttachmentStoreError("invalid-id", "attachment escapes the store root");
+  }
+  let meta;
+  try {
+    meta = await lstat(target);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      throw new ChatAttachmentStoreError("missing", "attachment not found");
+    }
+    throw error;
+  }
+  if (meta.isSymbolicLink()) {
+    throw new ChatAttachmentStoreError("symlink", "attachment is a symlink");
+  }
+  if (!meta.isFile()) {
+    throw new ChatAttachmentStoreError("missing", "attachment not found");
+  }
+  if (meta.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+    throw new ChatAttachmentStoreError("too-large", "attachment exceeds the size limit");
+  }
+  const handle = await open(target, "r");
+  try {
+    // Re-check through the open descriptor: the path could have been swapped
+    // between lstat and open.
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+      throw new ChatAttachmentStoreError("missing", "attachment not found");
+    }
+    const data = Buffer.alloc(stat.size);
+    await handle.read(data, 0, stat.size, 0);
+    return { data, mimeType };
+  } finally {
+    await handle.close().catch(() => {});
+  }
+}
+
+/**
+ * Drop attachments older than the retention window. Opportunistic and bounded:
+ * a failure here must never surface to a send.
+ */
+export async function sweepChatImageAttachments(now = Date.now()): Promise<number> {
+  let removed = 0;
+  try {
+    const root = await resolvedRoot(false);
+    const entries = await readdir(root, { withFileTypes: true });
+    for (const entry of entries.slice(0, SWEEP_SCAN_LIMIT)) {
+      if (!entry.isFile() || !isValidChatAttachmentId(entry.name)) continue;
+      const target = path.join(root, entry.name);
+      if (!isContained(root, target)) continue;
+      try {
+        const meta = await lstat(target);
+        if (meta.isSymbolicLink()) continue;
+        if (now - meta.mtimeMs <= CHAT_ATTACHMENT_MAX_AGE_MS) continue;
+        await rm(target, { force: true });
+        removed += 1;
+      } catch {
+        // Skip anything that races us.
+      }
+    }
+  } catch {
+    // No store yet, or an unreadable root — nothing to sweep.
+  }
+  return removed;
+}

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -511,10 +511,13 @@
   background: var(--text-primary);
 }
 
+/* The glyph rides ON the danger fill, so it needs the on-danger foreground —
+   --danger-text is `var(--color-danger)` (red type for neutral surfaces) and
+   painted the cancel ✕ the same color as the button, leaving a blank square. */
 .cave-chat-linear .cave-composer-send--busy,
 .cave-chat-linear .cave-composer-send--busy:hover {
   background: var(--color-danger);
-  color: var(--danger-text);
+  color: var(--color-danger-foreground);
 }
 
 @media (max-width: 720px) {

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -1111,7 +1111,7 @@
 .cave-composer-send--busy {
   border-color: transparent;
   background: color-mix(in oklch, var(--color-danger) 90%, transparent);
-  color: white;
+  color: var(--color-danger-foreground);
 }
 
 .cave-composer-send--busy:hover {


### PR DESCRIPTION
Three composer bugs, all reported from one screenshot of the chat input.

## 1. The stop button was a blank red square (cave-xrvns)

The busy state set `color: var(--danger-text)` over a `var(--color-danger)` fill. `--danger-text` is defined as `var(--color-danger)` — red type meant for *neutral* surfaces — so the cancel ✕ was painted the same color as the button it sits on. The base (non-linear) rule used `color: white`, visible but only ~2:1 against the salmon in dark mode.

Both rules now use `--color-danger-foreground` (`#111111` dark / `#ffffff` light). Pinned in `chat-composer-footer-band.test.ts` for both sheets; verified the pin fails when the old value is restored.

## 2. Attached images never rendered as images

The composer staged a picked image behind a generic camera glyph, and the user turn sent every attachment — images included — through `AttachmentList`. Only the *assistant* path rendered images inline, so a screenshot you attached looked exactly like a text file until you clicked the chip open.

- New `AttachmentThumb`: chip-sized preview, the picture when we hold pixels for it, the mime glyph otherwise.
- The user/system turn now uses the same inline-images-plus-chips split the assistant turn already used.

## 3. …and they vanished on reload (cave-cysu4)

`/api/chat/send` strips base64 payloads before persisting, and the temp copy written for local harnesses is deleted with the turn. So an image survived only as long as the optimistic turn lived in React state — reopening the thread degraded it back to a chip. Images now get a durable copy whose id the transcript keeps:

- **`src/lib/server/chat-attachment-store.ts`** — flat, content-addressed store under `caveHome()/chat-attachments`. Ids are `<uuid>.<ext>` **minted by the store**, so no caller-supplied string steers a path. Files are `0600` in a `0700` root, written with `wx` so a symlink planted at the target isn't followed. Reads validate the id, refuse extensions the store doesn't serve, reject symlinks, re-check through the open descriptor, and cap size. Entries past 180 days are swept off the write path.
- **`GET /api/chat/attachment`** — local-origin gated, `nosniff`, `default-src 'none'` CSP so an SVG attachment can't pull subresources if opened directly, private cache. A malformed id is `403 path not allowed`, matching the other byte-serving routes.
- **`persistImageAttachments`** stamps `storedId` onto the already-stripped record. The payload still never reaches the transcript — the strip stays the inner call, pinned in `harness-routing-attachments.test.ts`.
- **`chatAttachmentSrc()`** resolves `dataUrl ?? the serving route`, and all three render sites go through **`AuthedImage`** — bytes arrive via the patched fetch as a `blob:` URL rather than a native `<img>` load the packaged sidecar would 401 (cave-wgc2).

### A build-gate fix that came with it

The first build after the new route failed: `forbidden root leaked into Next standalone output: .git`. I built pristine `origin/main` in an identical worktree to check whether it was pre-existing — it built clean, so this branch caused it. A route whose graph reaches a `caveHome()`-derived path makes Next's tracer glob the checkout root, and every dot-entry not on the exclude list rides into the standalone sidecar. Extended the existing dot-root list (`.agents`, `.design-sync`, `.github`, `.gitignore`) and added a bare **`./.git`** — `./.git/**/*` covers a normal clone, but in a git **worktree** `.git` is a plain file, so only the bare entry excludes it. That closes a latent hole for anyone building in a worktree.

## Verification

- `pnpm test:app` — 998 files. `pnpm test:api` — 305 files. `tsc --noEmit` and `pnpm build` clean.
- New behavioral tests: 8 store cases (round trip, `0600` mode, traversal/case/shape rejection, unserved extension, symlink refusal, retention sweep), 5 route cases (bytes + headers, non-local 403, path-deny, 404, symlink not served), 4 persistence cases.
- Live, isolated temp home: a transcript record holding **only** `storedId` and zero `data:` URLs renders the image, with `200 /api/chat/attachment` in the network log. Served bytes are byte-identical to the stored file; `?id=../../../etc/passwd` is refused.
- Live, real composer: staged chip renders a thumbnail, the sent turn renders the image at natural size, and the cancel button shows a dark ✕ on salmon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)