### PR TITLE
fix(desktop): prevent black Windows shell on hung dev origin

### DIFF
--- a/scripts/dev-app-origin-health.mjs
+++ b/scripts/dev-app-origin-health.mjs
@@ -1,0 +1,61 @@
+/**
+ * Bounded loopback-origin readiness probe for the Tauri development launcher.
+ * A listening TCP port is not sufficient: a wedged Next compiler can accept
+ * connections indefinitely while returning no HTTP response to the WebView.
+ */
+// Probe the same document the initial Tauri WebView loads. A lightweight API
+// route can answer before the root React tree is compiled, which would still
+// leave the desktop window black.
+const READY_PATH = "/?__devShellProbe=1";
+const DEFAULT_TIMEOUT_MS = 1_500;
+const MAX_TIMEOUT_MS = 300_000;
+
+export function parsePort(value) {
+  if (!/^\d+$/.test(value ?? "")) return null;
+  const port = Number(value);
+  return Number.isSafeInteger(port) && port >= 1 && port <= 65_535 ? port : null;
+}
+
+export function parseTimeout(value) {
+  if (value === undefined) return DEFAULT_TIMEOUT_MS;
+  if (!/^\d+$/.test(value)) return null;
+  const timeoutMs = Number(value);
+  return Number.isSafeInteger(timeoutMs) && timeoutMs >= 100 && timeoutMs <= MAX_TIMEOUT_MS
+    ? timeoutMs
+    : null;
+}
+
+export async function loopbackOriginResponds({
+  port,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetchImpl = fetch,
+} = {}) {
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) return false;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 100 || timeoutMs > MAX_TIMEOUT_MS) return false;
+  try {
+    const response = await fetchImpl(`http://127.0.0.1:${port}${READY_PATH}`, {
+      method: "GET",
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return response.status >= 200 && response.status < 400;
+  } catch {
+    return false;
+  }
+}
+
+function cliArgs(argv) {
+  let port = null;
+  let timeoutMs = DEFAULT_TIMEOUT_MS;
+  for (let index = 0; index < argv.length; index += 1) {
+    if (argv[index] === "--port") port = parsePort(argv[++index]);
+    else if (argv[index] === "--timeout-ms") timeoutMs = parseTimeout(argv[++index]);
+    else return null;
+  }
+  return port === null || timeoutMs === null ? null : { port, timeoutMs };
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  const options = cliArgs(process.argv.slice(2));
+  process.exitCode = options && await loopbackOriginResponds(options) ? 0 : 1;
+}

--- a/scripts/dev-app-origin-health.test.mjs
+++ b/scripts/dev-app-origin-health.test.mjs
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import net from "node:net";
+
+import {
+  loopbackOriginResponds,
+  parsePort,
+  parseTimeout,
+} from "./dev-app-origin-health.mjs";
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve(server.address().port));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+}
+
+assert.equal(parsePort("3000"), 3000);
+assert.equal(parsePort("0"), null);
+assert.equal(parsePort("3000;echo nope"), null);
+assert.equal(parseTimeout(undefined), 1_500);
+assert.equal(parseTimeout("99"), null);
+
+const ready = http.createServer((_, response) => {
+  response.writeHead(204);
+  response.end();
+});
+const readyPort = await listen(ready);
+try {
+  assert.equal(
+    await loopbackOriginResponds({ port: readyPort, timeoutMs: 500 }),
+    true,
+    "a 2xx loopback HTTP response is ready for the desktop WebView",
+  );
+} finally {
+  await close(ready);
+}
+
+const redirect = http.createServer((_, response) => {
+  response.writeHead(302, { location: "/" });
+  response.end();
+});
+const redirectPort = await listen(redirect);
+try {
+  assert.equal(
+    await loopbackOriginResponds({ port: redirectPort, timeoutMs: 500 }),
+    true,
+    "a bounded redirect is also a usable loopback origin",
+  );
+} finally {
+  await close(redirect);
+}
+
+const hungSockets = new Set();
+const hung = net.createServer((socket) => {
+  hungSockets.add(socket);
+  socket.on("close", () => hungSockets.delete(socket));
+  socket.on("error", () => {});
+});
+const hungPort = await listen(hung);
+try {
+  const started = Date.now();
+  assert.equal(
+    await loopbackOriginResponds({ port: hungPort, timeoutMs: 150 }),
+    false,
+    "a TCP-listening origin that never completes HTTP is not ready",
+  );
+  assert.ok(Date.now() - started < 1_500, "a hung origin must be bounded rather than blocking the launcher");
+} finally {
+  for (const socket of hungSockets) socket.destroy();
+  await close(hung);
+}
+
+const absent = net.createServer();
+const absentPort = await listen(absent);
+await close(absent);
+assert.equal(
+  await loopbackOriginResponds({ port: absentPort, timeoutMs: 150 }),
+  false,
+  "an unavailable loopback origin is not ready",
+);
+
+console.log("dev-app-origin-health: ok");

--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -70,15 +70,20 @@ mkdirSync(fakeScripts, { recursive: true });
 mkdirSync(fakeBin, { recursive: true });
 
 copyFileSync(path.join(scriptsDir, "dev-app.sh"), path.join(fakeScripts, "dev-app.sh"));
+copyFileSync(path.join(scriptsDir, "dev-app-origin-health.mjs"), path.join(fakeScripts, "dev-app-origin-health.mjs"));
 chmodSync(path.join(fakeScripts, "dev-app.sh"), 0o755);
 writeFileSync(path.join(fakeScripts, "whisper-runtime-dev-env.sh"), "# stub for tests\n");
 
 const fakePnpm = (port, pidFile) => `#!/usr/bin/env bash
-echo "tauri $$" >>"${pidFile}"
+if [ "$1" = "dev" ]; then
+echo "server $$" >>"${pidFile}"
 node -e '
-  const net = require("net");
+  const http = require("http");
   const fs = require("fs");
-  const server = net.createServer(() => {});
+  const server = http.createServer((request, response) => {
+    response.writeHead(204);
+    response.end();
+  });
   server.listen(${port}, "127.0.0.1", () => {
     fs.appendFileSync("${pidFile}", "server " + process.pid + "\\n");
   });
@@ -86,6 +91,32 @@ node -e '
 ' &
 child=$!
 wait "$child"
+else
+echo "tauri $$" >>"${pidFile}"
+node -e "setInterval(() => {}, 1000)" &
+child=$!
+wait "$child"
+fi
+`;
+
+const fakeHungPnpm = (port, pidFile) => `#!/usr/bin/env bash
+echo "server_command $$" >>"${pidFile}"
+node -e '
+  const net = require("net");
+  const fs = require("fs");
+  const server = net.createServer(() => {});
+  server.listen(${port}, "127.0.0.1", () => {
+    fs.appendFileSync("${pidFile}", "origin " + process.pid + "\\n");
+  });
+  setInterval(() => {}, 1000);
+' &
+child=$!
+wait "$child"
+`;
+
+const fakeUnavailablePnpm = (pidFile) => `#!/usr/bin/env bash
+echo "server_command $$" >>"${pidFile}"
+exit 0
 `;
 
 const readPids = (pidFile) =>
@@ -115,7 +146,7 @@ async function assertTeardown(signal) {
       PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
       PORT: String(port),
       COVEN_CAVE_AUTH_TOKEN: "",
-      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "0",
+      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "2",
     },
   });
   wrapper.unref();
@@ -125,7 +156,12 @@ async function assertTeardown(signal) {
     await waitFor(() => probePort(port), {
       label: `the fake dev server to bind port ${port}`,
     });
-    pids = readPids(pidFile);
+    await waitFor(() => {
+      pids = readPids(pidFile);
+      return Boolean(pids.tauri && pids.server);
+    }, {
+      label: "the launcher to complete HTTP readiness and start the Tauri child",
+    });
     assert.ok(pids.tauri, "the launcher must actually start the Tauri child");
     assert.ok(pids.server, "the Tauri child must own the dev server process");
 
@@ -159,9 +195,97 @@ async function assertTeardown(signal) {
   }
 }
 
+async function assertHungOriginStopsOwnedTree() {
+  const port = await freePort();
+  const pidFile = path.join(root, "pids-hung-origin.txt");
+  writeFileSync(path.join(fakeBin, "pnpm"), fakeHungPnpm(port, pidFile));
+  chmodSync(path.join(fakeBin, "pnpm"), 0o755);
+
+  const wrapper = spawn("bash", [path.join(fakeScripts, "dev-app.sh")], {
+    cwd: root,
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      PORT: String(port),
+      COVEN_CAVE_AUTH_TOKEN: "",
+      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "2",
+    },
+  });
+  wrapper.unref();
+
+  let pids = {};
+  try {
+    await waitFor(() => probePort(port), {
+      label: `the HTTP-hung fake origin to bind port ${port}`,
+    });
+    pids = readPids(pidFile);
+    assert.ok(pids.server_command, "the launcher must start the owned HTTP-hung origin before judging it");
+    assert.ok(pids.origin, "the owned dev-server command must own the HTTP-hung origin process");
+
+    await waitFor(() => !isAlive(wrapper.pid), {
+      timeoutMs: 12_000,
+      label: "the launcher to exit after its bounded HTTP readiness grace period",
+    });
+    await waitFor(async () => !(await probePort(port)), {
+      label: `port ${port} to be released when the HTTP-hung origin is rejected`,
+    });
+
+    assert.equal(isAlive(Number(pids.server_command)), false, "preflight failure must stop the owned dev-server command");
+    assert.equal(isAlive(Number(pids.origin)), false, "preflight failure must not leave the rejected origin process alive");
+  } finally {
+    for (const pid of [wrapper.pid, Number(pids.server_command), Number(pids.origin)]) {
+      if (Number.isFinite(pid) && pid > 0) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {}
+      }
+    }
+  }
+}
+
+async function assertUnavailableOriginNeverOpensTauri() {
+  const port = await freePort();
+  const pidFile = path.join(root, "pids-unavailable-origin.txt");
+  writeFileSync(path.join(fakeBin, "pnpm"), fakeUnavailablePnpm(pidFile));
+  chmodSync(path.join(fakeBin, "pnpm"), 0o755);
+
+  const wrapper = spawn("bash", [path.join(fakeScripts, "dev-app.sh")], {
+    cwd: root,
+    detached: true,
+    stdio: "ignore",
+    env: {
+      ...process.env,
+      PATH: `${fakeBin}${path.delimiter}${process.env.PATH ?? ""}`,
+      PORT: String(port),
+      COVEN_CAVE_AUTH_TOKEN: "",
+      COVEN_CAVE_DEV_SERVER_GRACE_SECONDS: "2",
+    },
+  });
+  wrapper.unref();
+
+  try {
+    await waitFor(() => !isAlive(wrapper.pid), {
+      timeoutMs: 12_000,
+      label: "the launcher to exit when its selected loopback origin never becomes available",
+    });
+    const records = readFileSync(pidFile, "utf8");
+    assert.match(records, /server_command/, "the launcher must attempt to start its selected dev server");
+    assert.doesNotMatch(records, /tauri/, "an unavailable origin must fail before Tauri can open a black window");
+    assert.equal(await probePort(port), false, "an unavailable selected port must remain unavailable after preflight failure");
+  } finally {
+    try {
+      process.kill(wrapper.pid, "SIGKILL");
+    } catch {}
+  }
+}
+
 try {
   await assertTeardown("SIGTERM");
   await assertTeardown("SIGINT");
+  await assertHungOriginStopsOwnedTree();
+  await assertUnavailableOriginNeverOpensTauri();
 } finally {
   rmSync(root, { recursive: true, force: true });
 }

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -21,6 +21,13 @@ port_is_listening() {
   node -e "const net=require('net');const s=net.connect({host:'127.0.0.1',port:Number(process.argv[1])});s.setTimeout(300);s.on('connect',()=>process.exit(0));s.on('timeout',()=>process.exit(1));s.on('error',()=>process.exit(1));" "$1"
 }
 
+# A socket accept only proves that some process owns the port. The desktop
+# WebView needs an actual HTTP response; a wedged compiler otherwise leaves a
+# responsive but permanently black Tauri window.
+origin_is_ready() {
+  node scripts/dev-app-origin-health.mjs --port "$1" --timeout-ms "${2:-1500}" >/dev/null 2>&1
+}
+
 # If PORT is explicitly set, use that; otherwise auto-discover
 if [ -n "${PORT:-}" ]; then
   dev_port="$PORT"
@@ -56,11 +63,11 @@ fi
 TAURI_OVERRIDE_CONFIG="$(mktemp)"
 WATCHDOG_VERDICT="$(mktemp)"
 tauri_pid=""
+server_pid=""
 watchdog_pid=""
 
-# Every descendant of a pid, children before parents. Tauri's `beforeDevCommand`
-# runs as its child, so walking the tree from the Tauri pid reaches the Next dev
-# server without ever guessing at unrelated processes that merely hold the port.
+# Every descendant of a pid, children before parents. The launcher only ever
+# walks PIDs it started, never a process guessed from a loopback port.
 list_process_tree() {
   local pid="$1" child
   if command -v pgrep >/dev/null 2>&1; then
@@ -106,6 +113,7 @@ cleanup() {
     watchdog_pid=""
   fi
   terminate_process_tree "$tauri_pid"
+  terminate_process_tree "$server_pid"
   if [ "${should_start_server:-false}" = true ] && port_is_listening "$dev_port" >/dev/null 2>&1; then
     echo "[dev:app] warning: 127.0.0.1:${dev_port} is still listening after teardown" >&2
   fi
@@ -115,10 +123,10 @@ trap cleanup EXIT
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM HUP
 
-# A Tauri dev process and its `beforeDevCommand` inherit this secret together.
-# The server therefore requires the browser-side bridge token too; carry it in
-# the URL fragment so it never participates in Next's module URL resolution or
-# reaches the HTTP server. The bridge stores it in sessionStorage, strips it,
+# The launcher starts both the Tauri dev process and its owned server with this
+# secret. Carry it into the browser-side bridge through the URL fragment so it
+# never participates in Next's module URL resolution or reaches the HTTP server.
+# The bridge stores it in sessionStorage, strips it,
 # and attaches the header to same-origin `/api/` calls.
 dev_url="http://127.0.0.1:${dev_port}"
 if [ -n "${COVEN_CAVE_AUTH_TOKEN:-}" ]; then
@@ -126,31 +134,10 @@ if [ -n "${COVEN_CAVE_AUTH_TOKEN:-}" ]; then
   dev_url+="#covenCaveToken=${sidecar_token_fragment}"
 fi
 
-if [ "$should_start_server" = true ]; then
-  # The desktop shell always uses a loopback devUrl. A host-provided HOSTNAME
-  # (for example Docker/WSL's machine name) would bind the server elsewhere
-  # and leave Tauri waiting forever. Tauri invokes beforeDevCommand through
-  # cmd.exe on Windows, so use cmd's `set` form under Git Bash/MSYS.
-  before_dev_command="HOSTNAME=127.0.0.1 PORT=${dev_port} pnpm dev"
-  case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*) before_dev_command="set HOSTNAME=127.0.0.1&& set PORT=${dev_port}&& pnpm dev" ;;
-  esac
-  # Use beforeDevCommand but set PORT so it uses our free port.
-  cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
-{"build":{"beforeDevCommand":"${before_dev_command}","devUrl":"${dev_url}"}}
-CONF
-else
-  # Skip beforeDevCommand since the server is already running
-  cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
-{"build":{"beforeDevCommand":null,"devUrl":"${dev_url}"}}
-CONF
-fi
-
-# The desktop shell must not stay attached to a loopback origin that is never
-# coming back. The in-app recovery overlay covers restarts, so the watchdog only
-# fires after a long silence: past that, the dev server is gone for good and a
-# surviving window would just show stale Turbopack chunks.
-DEV_SERVER_GRACE_SECONDS="${COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-30}"
+# The desktop shell must not be opened until the actual root document answers.
+# The first Windows compile can be slow, so a long one-shot request avoids
+# multiplying concurrent compiles while still bounding a genuinely hung origin.
+DEV_SERVER_GRACE_SECONDS="${COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-180}"
 case "$DEV_SERVER_GRACE_SECONDS" in
   ''|*[!0-9]*)
     echo "[dev:app] ERROR: COVEN_CAVE_DEV_SERVER_GRACE_SECONDS must be a whole number of seconds" >&2
@@ -158,21 +145,39 @@ case "$DEV_SERVER_GRACE_SECONDS" in
     ;;
 esac
 
+if [ "$should_start_server" = true ]; then
+  # Bind explicitly to loopback. Git Bash exports HOSTNAME from the host (often
+  # a non-loopback machine name), so relying on server.ts's default is unsafe.
+  HOSTNAME=127.0.0.1 PORT="$dev_port" pnpm dev &
+  server_pid=$!
+fi
+
+initial_timeout_ms=$((DEV_SERVER_GRACE_SECONDS * 1000))
+if [ "$initial_timeout_ms" -lt 100 ]; then
+  initial_timeout_ms=100
+fi
+if ! origin_is_ready "$dev_port" "$initial_timeout_ms"; then
+  echo "[dev:app] loopback origin on 127.0.0.1:${dev_port} did not return the root document within ${DEV_SERVER_GRACE_SECONDS}s; desktop shell was not opened" >&2
+  exit 1
+fi
+
+# The server is already owned by this wrapper (or was pre-existing), so Tauri
+# must never start another one. This makes initial startup fail in the terminal
+# rather than presenting a black native window.
+cat >"$TAURI_OVERRIDE_CONFIG" <<CONF
+{"build":{"beforeDevCommand":null,"devUrl":"${dev_url}"}}
+CONF
+
 watch_dev_server() {
   local down_for=0
-  # Only start judging once the server has actually come up.
-  until port_is_listening "$dev_port" >/dev/null 2>&1; do
-    kill -0 "$tauri_pid" 2>/dev/null || return 0
-    sleep 2
-  done
   while kill -0 "$tauri_pid" 2>/dev/null; do
-    if port_is_listening "$dev_port" >/dev/null 2>&1; then
+    if origin_is_ready "$dev_port"; then
       down_for=0
     else
       down_for=$((down_for + 2))
       if [ "$down_for" -ge "$DEV_SERVER_GRACE_SECONDS" ]; then
-        echo "[dev:app] dev server on 127.0.0.1:${dev_port} has been unreachable for ${down_for}s; shutting the desktop shell down" >&2
-        printf 'dev-server-lost\n' >"$WATCHDOG_VERDICT"
+        echo "[dev:app] loopback origin on 127.0.0.1:${dev_port} did not return HTTP within ${down_for}s; shutting the desktop shell down" >&2
+        printf 'dev-origin-unhealthy\n' >"$WATCHDOG_VERDICT"
         terminate_process_tree "$tauri_pid"
         return 0
       fi

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -12,21 +12,26 @@ assert.match(
   /source scripts\/whisper-runtime-dev-env\.sh/,
   "the development launcher must stage and export Whisper before starting Tauri",
 );
+assert.match(
+  source,
+  /if \[ -n "\$\{PORT:-\}" \]; then[\s\S]*?dev_port="\$PORT"[\s\S]*?for candidate in \$\(seq 3000 3010\)/,
+  "explicit PORT and automatic 3000-3010 discovery must remain part of the launcher contract",
+);
+assert.match(
+  source,
+  /dev_url="http:\/\/127\.0\.0\.1:\$\{dev_port\}"[\s\S]*?origin_is_ready "\$dev_port" "\$initial_timeout_ms"/,
+  "the configured loopback devUrl and initial readiness probe must always target the same selected port",
+);
 
 assert.match(
   source,
-  /MINGW\*\|MSYS\*\|CYGWIN\*\) before_dev_command="set HOSTNAME=127\.0\.0\.1&& set PORT=\$\{dev_port\}&& pnpm dev"/,
-  "Windows Tauri launches must bind loopback and use cmd.exe's set syntax",
+  /HOSTNAME=127\.0\.0\.1 PORT="\$dev_port" pnpm dev &/,
+  "the launcher must bind its owned dev server to the Tauri loopback devUrl on Windows and POSIX",
 );
 assert.match(
   source,
-  /before_dev_command="HOSTNAME=127\.0\.0\.1 PORT=\$\{dev_port\} pnpm dev"/,
-  "POSIX launches must bind the dev server to the desktop shell's loopback devUrl",
-);
-assert.match(
-  source,
-  /beforeDevCommand":"\$\{before_dev_command\}"/,
-  "the generated Tauri override must use the platform-correct command",
+  /"beforeDevCommand":null,"devUrl":"\$\{dev_url\}"/,
+  "Tauri must not launch a second server after the launcher has verified the first root document",
 );
 
 assert.match(
@@ -57,18 +62,28 @@ assert.match(
 );
 assert.match(
   source,
-  /cleanup\(\) \{[\s\S]*?terminate_process_tree "\$tauri_pid"[\s\S]*?rm -f "\$TAURI_OVERRIDE_CONFIG"/,
-  "cleanup must reap the Tauri tree and remove the generated override config",
+  /cleanup\(\) \{[\s\S]*?terminate_process_tree "\$tauri_pid"[\s\S]*?terminate_process_tree "\$server_pid"[\s\S]*?rm -f "\$TAURI_OVERRIDE_CONFIG"/,
+  "cleanup must reap only its Tauri and owned server trees before removing the generated override config",
 );
 assert.match(
   source,
-  /DEV_SERVER_GRACE_SECONDS="\$\{COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-30\}"/,
+  /DEV_SERVER_GRACE_SECONDS="\$\{COVEN_CAVE_DEV_SERVER_GRACE_SECONDS:-180\}"/,
   "the dev-server watchdog must have a documented, overridable grace window",
 );
 assert.match(
   source,
-  /watch_dev_server\(\) \{[\s\S]*?down_for=\$\(\(down_for \+ 2\)\)[\s\S]*?terminate_process_tree "\$tauri_pid"/,
-  "the shell must not outlive a loopback dev server that is never coming back",
+  /origin_is_ready\(\) \{[\s\S]*?node scripts\/dev-app-origin-health\.mjs --port "\$1" --timeout-ms "\$\{2:-1500\}"/,
+  "the launcher must require a bounded HTTP response rather than only a TCP socket",
+);
+assert.match(
+  source,
+  /initial_timeout_ms=\$\(\(DEV_SERVER_GRACE_SECONDS \* 1000\)\)[\s\S]*?origin_is_ready "\$dev_port" "\$initial_timeout_ms"[\s\S]*?desktop shell was not opened[\s\S]*?beforeDevCommand":null[\s\S]*?pnpm exec tauri dev/,
+  "the launcher must validate the root document before opening Tauri, avoiding an initial black window",
+);
+assert.match(
+  source,
+  /watch_dev_server\(\) \{[\s\S]*?if origin_is_ready "\$dev_port"; then[\s\S]*?down_for=\$\(\(down_for \+ 2\)\)[\s\S]*?terminate_process_tree "\$tauri_pid"/,
+  "the running shell must still tear down its owned Tauri tree when the loopback origin later becomes unavailable or HTTP-hung",
 );
 
 console.log("dev-app: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1030,6 +1030,7 @@ export const SUITES = {
     "scripts/dependency-policy.test.mjs",
     "scripts/build-sandbox-runtime.test.mjs",
     "scripts/dev-app.test.mjs",
+    "scripts/dev-app-origin-health.test.mjs",
     "scripts/dev-app-teardown.test.mjs",
     "scripts/sync-runtimes.test.mjs",
     "scripts/surface-claim-guard.test.mjs",


### PR DESCRIPTION
## Summary
- require a successful bounded HTTP request to the exact loopback root URL before launching the native Tauri shell
- keep TCP port selection separate from application readiness, so a listening but hung Next server cannot open a blank desktop window
- make the wrapper own and clean up its dev server and Tauri process tree on failure, SIGINT, SIGTERM, and normal exit
- add a reusable, dependency-free origin-health probe and regression coverage for healthy, redirecting, hung, and unavailable origins
- extend launcher contract and teardown coverage, and wire the new test into the repository test runner

## Root cause
The Windows launcher treated a successful TCP connect as proof that the Next origin was usable. Next could accept the socket while the initial document request was still blocked or had failed, so Tauri opened WebView2 against a non-responsive route and presented a black shell. The new preflight waits for an actual 2xx/3xx response from `/?__devShellProbe=1`; Tauri is not started unless that route is usable.

## Implementation notes
- `scripts/dev-app.sh` still preserves explicit `PORT` and the `3000..3010` loopback selection range.
- The wrapper explicitly starts the owned dev server with `HOSTNAME=127.0.0.1`, passes the selected `devUrl` through a temporary Tauri config, and disables Tauri's duplicate `beforeDevCommand`.
- The readiness watchdog continues after launch and closes the desktop process if the origin remains unavailable past the configurable grace period (default 180 seconds).
- No global Next/Turbopack configuration change is included. A Windows-only worker-thread experiment failed in this app with `ERR_SOCKET_BAD_PORT`; forcing webpack made the observed startup behavior worse. The PR fixes the user-visible blank-window failure at the launcher boundary without broadening runtime risk.

## Validation
- `bash -n scripts/dev-app.sh`
- `node scripts/dev-app-origin-health.test.mjs`
- `node scripts/dev-app.test.mjs`
- `node scripts/dev-app-teardown.test.mjs` (native Windows skips POSIX signal assertions by design)
- `node scripts/check-tests-wired.mjs` (1373 test files wired)
- `pnpm run typecheck`
- `pnpm codemod:design:check`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- Native Windows smoke: the root probe returned HTTP 200 before Tauri launched; the rendered `CovenCave` main window was captured; a normal `WM_CLOSE` left no app, Next, WebView, or loopback-port process behind.

## Scope
This is limited to the desktop development launcher and its tests. Grok Build/harness compatibility is not changed by this PR.