### PR TITLE
feat(chat): name a chat from its transcript with the title-row sparkle (cave-quiva)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -823,6 +823,8 @@ export const SUITES = {
     "src/lib/chat-archive-nudge.test.ts",
     "src/lib/chat-auto-archive.test.ts",
     "src/lib/chat-auto-rename.test.ts",
+    "src/lib/chat-title-generation.test.ts",
+    "src/components/chat-title-sparkle.test.ts",
     "src/components/chat-archive-nudge.test.ts",
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",

--- a/src/components/chat-session-header.tsx
+++ b/src/components/chat-session-header.tsx
@@ -321,13 +321,19 @@ export function ChatTitleEditable({
 
   const display = baseTitle || session.id;
 
+  // A resolved fetch is not a successful one: the local-origin gate answers 403
+  // and a rejected patch answers { ok: false }. Refreshing on those would paint
+  // the rename as applied when the server refused it, so the refresh is gated
+  // on a genuine success and anything else falls through to the sessions poll.
   const patchTitle = async (title: string) => {
     try {
-      await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
+      const res = await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ title }),
       });
+      const json = await res.json().catch(() => ({ ok: res.ok }));
+      if (!res.ok || json?.ok === false) return;
       onSessionsChanged?.();
     } catch {
       /* transient — next sessions poll will reconcile */
@@ -408,7 +414,11 @@ export function ChatTitleEditable({
     <span className={headline ? "cave-chat-title flex w-full min-w-0 items-center gap-1.5" : "cave-chat-title flex min-w-0 flex-1 items-center gap-1"}>
       {/* cave-quiva: name-this-chat leads the title row. The glyph stays hidden
           until hover/focus so a settled header reads title-first; the control
-          is only rendered when a transcript is actually in scope. */}
+          is only rendered when a transcript is actually in scope.
+          aria-disabled rather than disabled: a disabled button loses focus the
+          instant it flips, dropping a keyboard user who pressed Enter back to
+          the body. Re-entry is already blocked in the handler, so the native
+          disable buys nothing and costs the focus ring. */}
       {generateTitle ? (
         <button
           type="button"
@@ -417,7 +427,7 @@ export function ChatTitleEditable({
           title={generating ? "Generating name" : "Generate name"}
           aria-label={generating ? "Generating name" : "Generate name"}
           aria-busy={generating || undefined}
-          disabled={generating}
+          aria-disabled={generating || undefined}
           onClick={(e) => {
             e.stopPropagation();
             void generate();

--- a/src/components/chat-session-header.tsx
+++ b/src/components/chat-session-header.tsx
@@ -278,6 +278,7 @@ export function ChatTitleEditable({
   displayTitleOverride,
   onSessionsChanged,
   headline = false,
+  generateTitle,
 }: {
   session: SessionRow;
   /** When set, displayed in place of session.title (e.g. to hide a raw
@@ -289,8 +290,14 @@ export function ChatTitleEditable({
   /** Render as a full-width all-caps headline row above the context chips
    *  instead of an inline title inside the session chip. */
   headline?: boolean;
+  /** Derives a fresh title from the live transcript (cave-quiva). Supplied by
+   *  the surface that actually holds the turns; when omitted the sparkle is
+   *  not rendered, so title rows without a transcript in scope degrade to the
+   *  manual pencil rather than shipping a control that can only no-op. */
+  generateTitle?: () => string | null;
 }) {
   const [editing, setEditing] = useState(false);
+  const [generating, setGenerating] = useState(false);
   const baseTitle = displayTitleOverride ?? session.title ?? "";
   const [value, setValue] = useState(baseTitle);
   const inputRef = useRef<HTMLInputElement | null>(null);
@@ -314,21 +321,42 @@ export function ChatTitleEditable({
 
   const display = baseTitle || session.id;
 
+  const patchTitle = async (title: string) => {
+    try {
+      await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
+        method: "PATCH",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ title }),
+      });
+      onSessionsChanged?.();
+    } catch {
+      /* transient — next sessions poll will reconcile */
+    }
+  };
+
   const submit = async () => {
     if (submittedRef.current) return;
     submittedRef.current = true;
     const trimmed = value.trim();
     setEditing(false);
     if (trimmed === (session.title ?? "").trim()) return;
+    await patchTitle(trimmed);
+  };
+
+  // Regenerate the name from the transcript. The derivation is pure and
+  // synchronous (chat-title-generation.ts) — the visible "generating" state
+  // covers the PATCH, not the naming. A null derivation means the thread has
+  // nothing to name itself after yet, so the current title is left alone
+  // rather than blanked.
+  const generate = async () => {
+    if (generating) return;
+    const next = generateTitle?.()?.trim();
+    if (!next) return;
+    setGenerating(true);
     try {
-      await fetch(`/api/sessions/${encodeURIComponent(session.id)}`, {
-        method: "PATCH",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({ title: trimmed }),
-      });
-      onSessionsChanged?.();
-    } catch {
-      /* transient — next sessions poll will reconcile */
+      if (next !== (session.title ?? "").trim()) await patchTitle(next);
+    } finally {
+      setGenerating(false);
     }
   };
 
@@ -378,9 +406,30 @@ export function ChatTitleEditable({
 
   return (
     <span className={headline ? "cave-chat-title flex w-full min-w-0 items-center gap-1.5" : "cave-chat-title flex min-w-0 flex-1 items-center gap-1"}>
+      {/* cave-quiva: name-this-chat leads the title row. The glyph stays hidden
+          until hover/focus so a settled header reads title-first; the control
+          is only rendered when a transcript is actually in scope. */}
+      {generateTitle ? (
+        <button
+          type="button"
+          className="cave-chat-title-spark focus-ring"
+          data-generating={generating ? "true" : undefined}
+          title={generating ? "Generating name" : "Generate name"}
+          aria-label={generating ? "Generating name" : "Generate name"}
+          aria-busy={generating || undefined}
+          disabled={generating}
+          onClick={(e) => {
+            e.stopPropagation();
+            void generate();
+          }}
+        >
+          <Icon name="ph:sparkle" width={11} aria-hidden />
+        </button>
+      ) : null}
       <button
         type="button"
         className={buttonClassName}
+        data-generating={generating ? "true" : undefined}
         title={`${display} — click to rename`}
         onClick={(e) => {
           e.stopPropagation();

--- a/src/components/chat-title-sparkle.test.ts
+++ b/src/components/chat-title-sparkle.test.ts
@@ -32,7 +32,11 @@ test("the sparkle only renders when a transcript is actually in scope", () => {
 
 test("generation state is exposed to assistive tech, not just as opacity", () => {
   assert.match(header, /aria-busy=\{generating \|\| undefined\}/, "aria-busy carries the run state");
-  assert.match(header, /disabled=\{generating\}/, "the control cannot be re-entered mid-run");
+  // aria-disabled, not the native disabled: a disabled button loses focus the
+  // instant it flips, dropping a keyboard user back to the body mid-run.
+  assert.match(header, /aria-disabled=\{generating \|\| undefined\}/, "state without stealing focus");
+  assert.ok(!/\sdisabled=\{generating\}/.test(header), "the native disable would strand keyboard focus");
+  assert.match(header, /if \(generating\) return;/, "re-entry is blocked in the handler instead");
   for (const label of ["Generate name", "Generating name"]) {
     assert.ok(
       header.includes(`"${label}"`),
@@ -92,7 +96,30 @@ test("the sparkle is hover-revealed and the title dims while it runs", () => {
     "keyboard focus reveals it too — hover alone would strand keyboard users",
   );
 
-  const dim = css.match(/\.cave-chat-title button\[data-generating="true"\] \{[^}]*\}/);
+  const dim = css.match(/\.cave-chat-title button\[data-generating="true"\][^{]*\{[^}]*\}/);
   assert.ok(dim, "the title dims while the rename is in flight");
   assert.match(dim[0], /opacity:\s*0\.35;/, "the design's 0.35 dim");
+  // Regression (PR #4121 review): the sparkle is itself a button inside
+  // .cave-chat-title carrying the same flag, and the dim selector (0,2,1)
+  // outranks the spark's own reveal (0,2,0) — so without this exclusion the
+  // control dims ITSELF the moment it starts working. Hover masks the bug,
+  // which is why only a keyboard run surfaces it.
+  assert.match(
+    dim[0],
+    /:not\(\.cave-chat-title-spark\)/,
+    "the dim must exclude the sparkle or the control fades itself out mid-run",
+  );
+});
+
+test("a refused PATCH does not paint the rename as applied", () => {
+  // Regression (PR #4121 review): a resolved fetch is not a successful one —
+  // the local-origin gate answers 403 and a rejected patch answers
+  // { ok: false }. Refreshing on either would show the new title even though
+  // the server kept the old one.
+  assert.match(header, /if \(!res\.ok \|\| json\?\.ok === false\) return;/, "failure short-circuits");
+  assert.match(
+    header,
+    /if \(!res\.ok \|\| json\?\.ok === false\) return;\s*\n\s*onSessionsChanged\?\.\(\);/,
+    "the refresh happens only after a genuine success",
+  );
 });

--- a/src/components/chat-title-sparkle.test.ts
+++ b/src/components/chat-title-sparkle.test.ts
@@ -1,0 +1,98 @@
+// @ts-nocheck
+// Source pins for cave-quiva — the title row's "name this chat" sparkle
+// (Chat.dc.html 2a ②). These pin the contracts the control depends on:
+// that it is conditional on a transcript being in scope, that its state is
+// carried for assistive tech and not only in opacity, and that the naming
+// itself stays on the pure offline heuristic rather than a titling round-trip.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+const header = readFileSync(new URL("./chat-session-header.tsx", import.meta.url), "utf8");
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const css = readFileSync(
+  new URL("../styles/cave-chat/session-chrome.css", import.meta.url),
+  "utf8",
+);
+
+test("the sparkle only renders when a transcript is actually in scope", () => {
+  // A title row with no turns behind it (a rail row, a session chip) must fall
+  // back to the manual pencil rather than ship a control that can only no-op.
+  assert.match(
+    header,
+    /\{generateTitle \? \(\s*<button/,
+    "the sparkle button is gated on the generateTitle prop",
+  );
+  assert.match(
+    header,
+    /generateTitle\?: \(\) => string \| null/,
+    "generateTitle is an optional pure derivation, not a required async fetch",
+  );
+});
+
+test("generation state is exposed to assistive tech, not just as opacity", () => {
+  assert.match(header, /aria-busy=\{generating \|\| undefined\}/, "aria-busy carries the run state");
+  assert.match(header, /disabled=\{generating\}/, "the control cannot be re-entered mid-run");
+  for (const label of ["Generate name", "Generating name"]) {
+    assert.ok(
+      header.includes(`"${label}"`),
+      `the ${label} label is present for the tooltip and the accessible name`,
+    );
+  }
+  // The accessible name must track the state, so both labels feed aria-label.
+  assert.match(
+    header,
+    /aria-label=\{generating \? "Generating name" : "Generate name"\}/,
+    "the accessible name flips with the state",
+  );
+});
+
+test("a null derivation leaves the existing title alone", () => {
+  // Blanking a chat's name because the heuristic had nothing to say would be a
+  // destructive no-op; the guard is what makes the control safe to mash.
+  assert.match(
+    header,
+    /const next = generateTitle\?\.\(\)\?\.trim\(\);\s*\n\s*if \(!next\) return;/,
+    "an empty derivation returns before any PATCH",
+  );
+});
+
+test("the chat view supplies the title from the transcript it already holds", () => {
+  assert.match(
+    chatView,
+    /import \{ generateChatTitle \} from "@\/lib\/chat-title-generation";/,
+    "the pure heuristic is the naming engine",
+  );
+  assert.match(
+    chatView,
+    /useCallback\(\(\) => generateChatTitle\(turns\), \[turns\]\)/,
+    "the derivation reads the live turns",
+  );
+  assert.match(chatView, /generateTitle=\{generateTitleFromTranscript\}/, "MetaLine receives it");
+  // No titling route: the control must keep working with the daemon down.
+  assert.ok(
+    !/api\/sessions\/[^"']*\/title/.test(chatView + header),
+    "naming does not depend on a titling round-trip",
+  );
+});
+
+test("the sparkle is hover-revealed and the title dims while it runs", () => {
+  // Pin the declarations individually — a lazy [\s\S]*? across the whole sheet
+  // would pass on unrelated rules and prove nothing.
+  const spark = css.match(/\.cave-chat-title-spark \{[^}]*\}/);
+  assert.ok(spark, ".cave-chat-title-spark is declared");
+  assert.match(spark[0], /opacity:\s*0;/, "the glyph starts hidden so the header reads title-first");
+
+  const reveal = css.match(/\.cave-chat-title:hover \.cave-chat-title-spark[^{]*\{[^}]*\}/);
+  assert.ok(reveal, "hover/focus reveals the glyph");
+  assert.match(reveal[0], /opacity:\s*1;/, "the reveal sets full opacity");
+  assert.match(
+    reveal[0],
+    /focus-visible/,
+    "keyboard focus reveals it too — hover alone would strand keyboard users",
+  );
+
+  const dim = css.match(/\.cave-chat-title button\[data-generating="true"\] \{[^}]*\}/);
+  assert.ok(dim, "the title dims while the rename is in flight");
+  assert.match(dim[0], /opacity:\s*0\.35;/, "the design's 0.35 dim");
+});

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -44,6 +44,7 @@ import {
   type Turn,
 } from "@/lib/chat-turn-state";
 import { groupTranscriptTurns, type TranscriptGroup } from "@/lib/chat-transcript-groups";
+import { generateChatTitle } from "@/lib/chat-title-generation";
 import { readChatComposerPrefs, writeChatComposerPrefs } from "@/lib/chat-composer-prefs";
 import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
@@ -1417,6 +1418,7 @@ function MetaLine({
   familiar,
   projectRoot,
   onSessionsChanged,
+  generateTitle,
   children,
 }: {
   session: SessionRow | null;
@@ -1435,6 +1437,8 @@ function MetaLine({
   familiar: Familiar;
   projectRoot?: string;
   onSessionsChanged?: () => void;
+  /** Derives a title from the live transcript for the title row's sparkle. */
+  generateTitle?: () => string | null;
   children?: React.ReactNode;
 }) {
   const state = metaLineState({ busy, lifecycle, error, daemonRunning });
@@ -1509,6 +1513,7 @@ function MetaLine({
           session={session}
           displayTitleOverride={titleOverride}
           onSessionsChanged={onSessionsChanged}
+          generateTitle={generateTitle}
         />
       ) : null}
       <span className="cave-chat-meta-line__meta" title={metaModel ?? undefined}>
@@ -3193,6 +3198,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         ),
     [turns],
   );
+
+  // cave-quiva: the title row's sparkle names the chat from the transcript this
+  // view already holds — no titling round-trip, and it works with the daemon
+  // down. Null when the thread has nothing nameable yet; the control then
+  // leaves the current title alone.
+  const generateTitleFromTranscript = useCallback(() => generateChatTitle(turns), [turns]);
 
   // Active branch path: when activeLeafId is set (branched conversation), only
   // the turns on the path from the root to that leaf are rendered. For linear
@@ -5781,6 +5792,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
           familiar={familiar}
           projectRoot={projectRoot}
           onSessionsChanged={onSessionsChanged}
+          generateTitle={generateTitleFromTranscript}
         >
           <div className="cave-chat-session-actions">
             {/* cave-zolo: lifecycle + call verbs are direct icons (the kebab

--- a/src/lib/chat-title-generation.test.ts
+++ b/src/lib/chat-title-generation.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { generateChatTitle, latestExchangeForTitle } from "./chat-title-generation.ts";
+
+const turn = (role, text, extra = {}) => ({
+  id: `${role}-${text.slice(0, 8)}-${Math.abs(text.length)}`,
+  role,
+  text,
+  createdAt: "2026-07-31T00:00:00.000Z",
+  ...extra,
+});
+
+// ── Empty / meaningless threads yield nothing ────────────────────────────────
+// Callers keep the existing title on null rather than blanking it, so "no
+// signal" must be null and never an empty string.
+assert.equal(latestExchangeForTitle([]), null);
+assert.equal(generateChatTitle([]), null);
+assert.equal(latestExchangeForTitle([turn("user", "   ")]), null);
+assert.equal(generateChatTitle([turn("user", "   ")]), null);
+
+// ── The freshest settled exchange wins ───────────────────────────────────────
+// A long thread should be named after where it *is*, not where it opened.
+const thread = [
+  turn("user", "How do I set up the vault?"),
+  turn("assistant", "Run the init command."),
+  turn("user", "Now rotate the signing key"),
+  turn("assistant", "Use the rotate subcommand."),
+];
+assert.deepEqual(latestExchangeForTitle(thread), {
+  userText: "Now rotate the signing key",
+  assistantText: "Use the rotate subcommand.",
+});
+
+// ── Pending assistant turns are skipped ──────────────────────────────────────
+// Naming a chat after a reply that is still streaming captures a half-formed
+// thought, so the newest SETTLED assistant turn is the anchor.
+const streaming = [...thread, turn("user", "And the audit log?"), turn("assistant", "Partial…", { pending: true })];
+const streamingExchange = latestExchangeForTitle(streaming);
+assert.equal(streamingExchange.assistantText, "Use the rotate subcommand.");
+assert.equal(streamingExchange.userText, "Now rotate the signing key");
+
+// ── Errored assistant turns are skipped too ──────────────────────────────────
+const errored = [...thread, turn("user", "And the audit log?"), turn("assistant", "boom", { error: true })];
+assert.equal(latestExchangeForTitle(errored).assistantText, "Use the rotate subcommand.");
+
+// ── Before any assistant reply, the last user turn stands alone ──────────────
+// This is exactly what the first-exchange auto-name already does.
+const openingOnly = [turn("user", "Draft the release notes")];
+assert.deepEqual(latestExchangeForTitle(openingOnly), {
+  userText: "Draft the release notes",
+  assistantText: null,
+});
+assert.equal(typeof generateChatTitle(openingOnly), "string");
+
+// ── An assistant turn with no preceding user turn still names the chat ───────
+const assistantFirst = [turn("assistant", "Here is the summary of the incident.")];
+const assistantOnly = latestExchangeForTitle(assistantFirst);
+assert.equal(assistantOnly.userText, null);
+assert.equal(assistantOnly.assistantText, "Here is the summary of the incident.");
+
+// ── System turns never supply the title ──────────────────────────────────────
+assert.equal(latestExchangeForTitle([turn("system", "You are a helpful familiar.")]), null);
+
+// ── Whitespace-only turns are treated as absent ──────────────────────────────
+const blankReply = [turn("user", "Rotate the key"), turn("assistant", "   ")];
+assert.deepEqual(latestExchangeForTitle(blankReply), {
+  userText: "Rotate the key",
+  assistantText: null,
+});
+
+// ── Generation is pure: same input, same output, no I/O ──────────────────────
+assert.equal(generateChatTitle(thread), generateChatTitle(thread));
+assert.equal(typeof generateChatTitle(thread), "string");
+assert.ok(generateChatTitle(thread).length > 0);

--- a/src/lib/chat-title-generation.ts
+++ b/src/lib/chat-title-generation.ts
@@ -1,0 +1,74 @@
+// On-demand chat title generation — the engine behind the title row's sparkle
+// control (cave-quiva). Periodic auto-rename (chat-auto-rename.ts) already
+// re-derives a title from the latest exchange on a cadence; this module is the
+// user-triggered path for the same idea: "name this chat from what it is
+// actually about, now".
+//
+// It deliberately reuses `chatSummaryTitle` rather than adding a titling model
+// call. The heuristic is pure, synchronous and offline, so the control works
+// with no daemon and no network — the same reason the auto-rename decision
+// logic stays pure. Everything here is unit-tested with no I/O.
+
+import { chatSummaryTitle } from "./cave-chat-titles.ts";
+import type { Turn } from "./chat-turn-state.ts";
+
+/** The pair the title heuristic reads: a prompt and the reply it produced. */
+export type TitleExchange = {
+  userText: string | null;
+  assistantText: string | null;
+};
+
+function turnText(turn: Turn | undefined): string | null {
+  const text = turn?.text?.trim();
+  return text ? text : null;
+}
+
+/**
+ * The freshest *settled* exchange in the thread — the newest non-pending,
+ * non-error assistant turn plus the most recent user turn before it.
+ *
+ * Pending and errored assistant turns are skipped: naming a chat after a reply
+ * that is still streaming (or that failed) would capture a half-formed thought.
+ * When no assistant turn has settled yet the last user turn stands alone, which
+ * is what the first-exchange auto-name already does.
+ */
+export function latestExchangeForTitle(turns: readonly Turn[]): TitleExchange | null {
+  if (turns.length === 0) return null;
+
+  let assistantIndex = -1;
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (turn.role === "assistant" && !turn.pending && !turn.error && turnText(turn)) {
+      assistantIndex = i;
+      break;
+    }
+  }
+
+  const searchUserFrom = assistantIndex >= 0 ? assistantIndex - 1 : turns.length - 1;
+  let userText: string | null = null;
+  for (let i = searchUserFrom; i >= 0; i -= 1) {
+    const turn = turns[i];
+    if (turn.role === "user" && turnText(turn)) {
+      userText = turnText(turn);
+      break;
+    }
+  }
+
+  const assistantText = assistantIndex >= 0 ? turnText(turns[assistantIndex]) : null;
+  if (!userText && !assistantText) return null;
+  return { userText, assistantText };
+}
+
+/**
+ * Derive a title for the thread, or null when there is nothing meaningful to
+ * name it after (an empty chat, or one whose only content is whitespace).
+ * Callers keep the current title on null rather than blanking it.
+ */
+export function generateChatTitle(turns: readonly Turn[]): string | null {
+  const exchange = latestExchangeForTitle(turns);
+  if (!exchange) return null;
+  return chatSummaryTitle({
+    userText: exchange.userText,
+    assistantText: exchange.assistantText,
+  });
+}

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -61,7 +61,7 @@
   cursor: progress;
 }
 
-.cave-chat-title button[data-generating="true"] {
+.cave-chat-title button[data-generating="true"]:not(.cave-chat-title-spark) {
   opacity: 0.35;
 }
 

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -27,6 +27,44 @@
   line-height: 1.15;
 }
 
+/* cave-quiva: name-this-chat. A presence-tinted chip leads the title row; its
+   glyph stays transparent until hover/focus so a settled header reads
+   title-first, and the title itself dims while the rename is in flight so the
+   feedback lands on the thing being changed. Disabled + aria-busy carry the
+   state for assistive tech, which never sees the opacity at all. */
+.cave-chat-title-spark {
+  display: grid;
+  place-items: center;
+  flex: none;
+  width: var(--space-5);
+  height: var(--space-5);
+  border-radius: var(--radius-control);
+  background: linear-gradient(
+    135deg,
+    color-mix(in oklch, var(--accent-presence) 24%, transparent),
+    transparent
+  );
+  color: var(--accent-presence);
+  opacity: 0;
+  transition:
+    opacity var(--duration-fast) var(--ease-standard),
+    background-color var(--duration-fast) var(--ease-standard);
+}
+
+.cave-chat-title:hover .cave-chat-title-spark,
+.cave-chat-title-spark:focus-visible,
+.cave-chat-title-spark[data-generating="true"] {
+  opacity: 1;
+}
+
+.cave-chat-title-spark[data-generating="true"] {
+  cursor: progress;
+}
+
+.cave-chat-title button[data-generating="true"] {
+  opacity: 0.35;
+}
+
 /* ── ③ Slim context row ─────────────────────────────────────────────────────
    Machine-readable facts only, in mono, on a 30px band closed by hairlines
    top and bottom — the design's "everything the machine decided" register. */

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -46,9 +46,7 @@
   );
   color: var(--accent-presence);
   opacity: 0;
-  transition:
-    opacity var(--duration-fast) var(--ease-standard),
-    background-color var(--duration-fast) var(--ease-standard);
+  transition: opacity var(--duration-fast) var(--ease-standard);
 }
 
 .cave-chat-title:hover .cave-chat-title-spark,
@@ -61,7 +59,13 @@
   cursor: progress;
 }
 
-.cave-chat-title button[data-generating="true"] {
+/* The sparkle is itself a button inside .cave-chat-title and carries the same
+   data-generating flag, and `.cave-chat-title button[data-generating]` (0,2,1)
+   outranks the spark's own reveal (0,2,0) — so without this exclusion the
+   control dims itself the moment it starts working. Hover masks it
+   (`.cave-chat-title:hover .cave-chat-title-spark` is (0,3,0)), which is
+   exactly why a pointer-driven check misses it and a keyboard run does not. */
+.cave-chat-title button[data-generating="true"]:not(.cave-chat-title-spark) {
   opacity: 0.35;
 }
 


### PR DESCRIPTION
## Summary

Chat.dc.html 2a ② draws a small gradient sparkle left of the session title: hover reveals the glyph, click regenerates the name from the conversation, and the title dims while it runs. The repo had **no title-generation affordance at all** — renaming was the pencil (manual) only.

**The naming engine already existed.** Periodic auto-rename (`chat-auto-rename.ts`) derives a title from the latest exchange via the pure `chatSummaryTitle` heuristic. This adds the *user-triggered* path to the same idea rather than a titling model call, so the control is synchronous, offline, and works with the daemon down — which also keeps it clear of the daemon-less `E2E (Playwright)` job. The bead guessed this would need a titling route; it does not.

## Changes

- **`src/lib/chat-title-generation.ts`** (new) — `latestExchangeForTitle` / `generateChatTitle`. Anchors on the newest **settled** assistant turn: pending and errored turns are skipped so a chat is never named after a half-streamed or failed reply. A null derivation leaves the current title alone rather than blanking it.
- **`ChatTitleEditable`** — optional `generateTitle` prop. The sparkle only renders when a transcript is actually in scope, so title rows without one (rail rows, session chips) keep the manual pencil instead of showing a control that can only no-op. Run state rides `disabled` + `aria-busy` + a label that flips to "Generating name", so assistive tech never depends on the opacity.
- **`ChatView`** — supplies the derivation from the turns it already holds.
- **`session-chrome.css`** — presence-tinted chip, hidden at rest, revealed on hover *and* `:focus-visible` (hover alone would strand keyboard users); title dims to the design's 0.35 while in flight.

## Verification

Driven in the real app against a **mocked** session — no writes to the real conversation store (1,593 live conversations there):

| State | Result |
|---|---|
| Rest | sparkle `opacity: 0`, label "Generate name" |
| Hover | `opacity: 1`, seated left of the title (x 314 vs 338) |
| Click | PATCHes `{"title":"Now rotate the signing key"}` — the **latest** exchange, not the opening prompt |
| Mid-flight | label "Generating name", title `opacity: 0.35` |
| Settled | returns to rest |

Gates: `test:app` (999 files), `test:api`, `typecheck`, `lint` (0 design drift), `check:tests-wired` (1374), `build`. First-load CSS **893 KB / 900 KB** budget.

## Note

The tooltip is the native `title` attribute, matching the pencil beside it, rather than the comp's styled mono tooltip. Introducing a one-off tooltip for a single control seemed worse than matching its sibling; happy to revisit.

Bead: `cave-quiva`

🤖 Generated with [Claude Code](https://claude.com/claude-code)