### PR TITLE
fix(chat): surface silent Codex process failures safely

### DIFF
--- a/src/app/api/chat/send/harness-routing-model-capabilities.test.ts
+++ b/src/app/api/chat/send/harness-routing-model-capabilities.test.ts
@@ -226,8 +226,26 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /modelApplicationForHarness\(\{ supported: true, confirmed: true \}\)/,
-  "Confirming an echoed model should promote the application state to applied",
+  /else if \(confirmedModel\) \{[\s\S]*?modelApplicationFromRun\(\{[\s\S]*?confirmedModel,/,
+  "a direct runtime echo is evaluated as confirmation only in the native-runtime branch",
+);
+
+const covenModelMetadataStart = chatRoute.indexOf('else if (localRuntimePlan?.runner === "coven" && forwardModel) {');
+const nativeModelMetadataStart = chatRoute.indexOf("else if (confirmedModel) {", covenModelMetadataStart);
+assert.ok(
+  covenModelMetadataStart >= 0 && nativeModelMetadataStart > covenModelMetadataStart,
+  "Coven-forwarded model metadata must be handled before generic harness echoes",
+);
+const covenModelMetadataBlock = chatRoute.slice(covenModelMetadataStart, nativeModelMetadataStart);
+assert.match(
+  covenModelMetadataBlock,
+  /Coven forwarded the selected model; downstream acceptance was not confirmed\./,
+  "forwarding a model through Coven must not be described as downstream acceptance",
+);
+assert.doesNotMatch(
+  covenModelMetadataBlock,
+  /responseMetadata\.confirmedModel = confirmedModel/,
+  "a Coven system-init model echo must not be persisted as a confirmed model",
 );
 
 console.log("model parity routing tests passed");

--- a/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
+++ b/src/app/api/chat/send/route-codex-runtime-availability.integration.test.ts
@@ -51,11 +51,16 @@ const shim = [
   "const { appendFileSync } = require('node:fs');",
   "appendFileSync(process.env.COVEN_TEST_LOG, `${JSON.stringify(process.argv.slice(2))}\\n`);",
   "if (process.argv[2] === 'adapter' && process.argv[3] === 'list' && process.argv[4] === '--json') {",
-  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit', 'assistant-envelope', 'assistant-envelope-exit-1', 'cancel'].includes(process.env.COVEN_TEST_MODE) }]));",
+  "  process.stdout.write(JSON.stringify([{ id: 'codex', executable: 'codex', available: ['post-start', 'silent-exit', 'silent-stderr', 'assistant-envelope', 'assistant-envelope-exit-1', 'cancel'].includes(process.env.COVEN_TEST_MODE) }]));",
+  "  process.exit(0);",
+  "}",
+  "if (process.argv[2] === 'run' && process.argv[3] === '--help') {",
+  "  process.stdout.write('  --model <model>  Forward a provider model id\\n');",
   "  process.exit(0);",
   "}",
   "if (process.argv[2] === 'run' && process.argv[3] === 'codex') {",
   "  if (process.env.COVEN_TEST_MODE === 'silent-exit') process.exit(1);",
+  "  if (process.env.COVEN_TEST_MODE === 'silent-stderr') { console.error('model gpt-5.6-sol is unsupported at /private/fixture/secret ghp_1234567890abcdefghijklmnopqrstuv'); process.exit(1); }",
   "  if (process.env.COVEN_TEST_MODE === 'cancel') {",
   "    appendFileSync(process.env.COVEN_TEST_CANCEL_READY, 'started');",
   "    setInterval(() => {}, 1000);",
@@ -229,20 +234,74 @@ try {
   // Codex is signed out. It must remain a structured runtime-process error
   // instead of fabricating the completed-but-empty authentication hint.
   process.env.COVEN_TEST_MODE = "silent-exit";
+  const silentExitSessionId = "silent-codex-session";
   const silentExitResponse = await POST(new Request("http://localhost/api/chat/send", {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({ familiarId: "opal", prompt: "silent child", projectRoot: familiarWorkspace }),
+    body: JSON.stringify({
+      familiarId: "opal",
+      prompt: "silent child",
+      modelOverride: "openai/gpt-5.6-sol",
+      projectRoot: familiarWorkspace,
+      sessionId: silentExitSessionId,
+    }),
   }));
   const { body: silentExitBody, events: silentExitEvents } = await readSse(silentExitResponse);
   const silentExitError = silentExitEvents.find((event) => event.kind === "error");
   assert.ok(silentExitError, "a silent non-zero Codex exit produces a structured error event");
   assert.equal(silentExitError.code, "runtime_process_failed");
-  assert.match(silentExitError.message, /Codex CLI exited with an error/);
+  assert.match(silentExitError.message, /Codex CLI exited with an error \(exit code 1\)/);
+  assert.match(silentExitError.message, /did not emit an error message/);
   assert.doesNotMatch(silentExitBody, /installed but not authenticated|produced no output/i);
   assert.ok(!silentExitEvents.some((event) => event.kind === "assistant_chunk"));
+  assert.deepEqual(
+    silentExitEvents.find((event) => event.kind === "progress" && event.id === "runtime-process"),
+    {
+      kind: "progress",
+      id: "runtime-process",
+      label: "codex process failure",
+      status: "error",
+      detail: "Exit code 1; the runtime did not emit an error message.",
+    },
+    "silent exits retain a safe, concrete diagnostic without guessing at authentication",
+  );
   const silentDone = silentExitEvents.findLast((event) => event.kind === "done");
   assert.equal(silentDone?.isError, true);
+  assert.equal(silentDone?.responseMetadata?.confirmedModel, undefined);
+  assert.equal(silentDone?.responseMetadata?.modelApplicationState, "pending");
+  const silentConversation = await loadConversation(silentExitSessionId);
+  const silentTurn = silentConversation?.turns.at(-1);
+  assert.equal(silentTurn?.isError, true, "an existing conversation retains the failed run");
+  assert.match(silentTurn?.text ?? "", /exit code 1/);
+  assert.deepEqual(silentTurn?.progress?.find((step) => step.id === "runtime-process"), {
+    id: "runtime-process",
+    label: "codex process failure",
+    status: "error",
+    detail: "Exit code 1; the runtime did not emit an error message.",
+    createdAt: silentTurn?.progress?.find((step) => step.id === "runtime-process")?.createdAt,
+  });
+
+  // Stderr may name a rejected model or contain local credentials and paths.
+  // Cave persists only the fixed diagnostic shape rather than copying the
+  // provider payload into chat, and treats the forwarded model as unverified.
+  process.env.COVEN_TEST_MODE = "silent-stderr";
+  const stderrExitResponse = await POST(new Request("http://localhost/api/chat/send", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      familiarId: "opal",
+      prompt: "silent stderr",
+      modelOverride: "openai/gpt-5.6-sol",
+      projectRoot: familiarWorkspace,
+    }),
+  }));
+  const { body: stderrExitBody, events: stderrExitEvents } = await readSse(stderrExitResponse);
+  const stderrExitError = stderrExitEvents.find((event) => event.kind === "error");
+  assert.match(stderrExitError?.message ?? "", /exit code 1/);
+  assert.match(stderrExitError?.message ?? "", /diagnostic output, which Cave withheld/);
+  assert.doesNotMatch(stderrExitBody, /ghp_|\/private\/fixture|unsupported at/i);
+  assert.equal(stderrExitEvents.findLast((event) => event.kind === "done")?.responseMetadata?.confirmedModel, undefined);
+  assert.equal(stderrExitEvents.findLast((event) => event.kind === "done")?.responseMetadata?.modelApplicationState, "pending");
 
   // Stop is an expected interruption, not evidence that Coven or Codex
   // failed. Its child commonly closes with a null exit code after SIGTERM;

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2258,7 +2258,11 @@ export async function POST(req: Request) {
         detail?: string,
         durationMs?: number,
       ) => {
-        if (id === "opencode-compatibility" || id === "grok-compatibility" || id === "codex-compatibility") {
+        if (
+          (id === "opencode-compatibility" || id === "grok-compatibility") ||
+          id === "codex-compatibility" ||
+          id === "runtime-process"
+        ) {
           persistedCompatibilityDiagnostics.push({
             id,
             label,
@@ -2382,6 +2386,7 @@ export async function POST(req: Request) {
       // stream frame. Defer classifying that condition until all buffered
       // stdout has passed through the more-specific adapter failure parser.
       let covenBackedProcessFailed = false;
+      let covenBackedExitCode: number | null = null;
       // Coven is the outer launch vehicle. Its cleanup can fail after the
       // adapter has already supplied a successful structured result; that
       // completed assistant response remains authoritative for this attempt.
@@ -4219,6 +4224,9 @@ export async function POST(req: Request) {
               !covenCompletedSuccessfulResult &&
               typeof code === "number" &&
               code !== 0;
+            if (covenBackedProcessFailed && typeof code === "number" && code !== 0) {
+              covenBackedExitCode = code;
+            }
             if (covenBackedProcessFailed) {
               result = { ...result, is_error: true };
             }
@@ -4368,6 +4376,7 @@ export async function POST(req: Request) {
         stdoutErrTail.length = 0;
         codexAdapterFailure = null;
         covenBackedProcessFailed = false;
+        covenBackedExitCode = null;
         covenCompletedSuccessfulResult = false;
         resumeFailed = false;
         adapterConflict = null;
@@ -4427,6 +4436,7 @@ export async function POST(req: Request) {
         stdoutErrTail.length = 0;
         codexAdapterFailure = null;
         covenBackedProcessFailed = false;
+        covenBackedExitCode = null;
         covenCompletedSuccessfulResult = false;
         resumeFailed = false;
         // Settle the retry step BEFORE the fresh attempt runs, not after it
@@ -4484,10 +4494,22 @@ export async function POST(req: Request) {
           : binding.harness === "claude"
             ? "claude"
             : "coven";
-        const failure = runtimeProcessFailure(failedRunner);
+        const emittedDiagnostic = stderrTail.length > 0 || stdoutErrTail.length > 0;
+        const detail = covenBackedExitCode == null
+          ? emittedDiagnostic
+            ? "Runtime diagnostic output was withheld to protect local data."
+            : "The runtime did not emit an error message."
+          : emittedDiagnostic
+            ? `Exit code ${covenBackedExitCode}; runtime diagnostic output was withheld to protect local data.`
+            : `Exit code ${covenBackedExitCode}; the runtime did not emit an error message.`;
+        const failure = runtimeProcessFailure(failedRunner, {
+          exitCode: covenBackedExitCode,
+          emittedDiagnostic,
+        });
         launchFailure = failure;
         result.is_error = true;
         pushProgress("harness-start", `${binding.harness} exited with an error`, "error", failure.message);
+        pushProgress("runtime-process", `${binding.harness} process failure`, "error", detail);
         push({ kind: "error", code: failure.code, message: failure.message });
       }
 
@@ -4649,12 +4671,37 @@ export async function POST(req: Request) {
         modelState.applicationState = application.state;
         modelState.reason = application.reason;
       }
-      // Model parity: if the harness echoed its resolved model, promote the
-      // application state from `pending` to `applied` and record what actually
-      // ran. No echo ⇒ leave the honest `pending`/`unsupported` state untouched.
+      // `coven run` can echo the forwarded model in system.init before it has
+      // started the downstream harness. That establishes argv forwarding, not
+      // downstream acceptance, so keep the model pending unless the error
+      // itself safely identifies a rejected model. In particular, do not mark
+      // a successful wrapper response as proof that Codex accepted `--model`.
+      else if (localRuntimePlan?.runner === "coven" && forwardModel) {
+        const rejected = result.is_error === true && modelRejectionInError(
+          [...stderrTail, ...stdoutErrTail].join("\n"),
+        );
+        const application = modelApplicationForHarness(
+          rejected ? { failed: true } : { supported: true },
+        );
+        responseMetadata.modelApplicationState = application.state;
+        responseMetadata.modelApplicationReason = rejected
+          ? application.reason
+          : "Coven forwarded the selected model; downstream acceptance was not confirmed.";
+        modelState.applicationState = application.state;
+        modelState.reason = responseMetadata.modelApplicationReason;
+      }
+      // Direct/native runtime echoes can identify the resolved model. A
+      // successful run confirms it; a model rejection becomes failed rather
+      // than incorrectly reporting the selected model as applied.
       else if (confirmedModel) {
-        const application = modelApplicationForHarness({ supported: true, confirmed: true });
-        responseMetadata.confirmedModel = confirmedModel;
+        const application = modelApplicationForHarness(
+          modelApplicationFromRun({
+            confirmedModel,
+            isError: result.is_error === true,
+            errorText: [...stderrTail, ...stdoutErrTail].join("\n"),
+          }),
+        );
+        if (!result.is_error) responseMetadata.confirmedModel = confirmedModel;
         responseMetadata.modelApplicationState = application.state;
         responseMetadata.modelApplicationReason = application.reason;
         modelState.applicationState = application.state;
@@ -4689,11 +4736,15 @@ export async function POST(req: Request) {
       // early-exiting harness never supplied a session id and therefore has
       // no conversation file to persist.
       settleUnfinishedTools();
-      // Launch failures never produced a real assistant response: the client
-      // already received the structured error above, so persist nothing
-      // (matching the OpenClaw no-spawn precedent) instead of writing a
-      // fabricated turn the user would rediscover on reload.
-      if (finalSessionId && !launchFailure) {
+      // Preflight/spawn failures never produced a real assistant response, so
+      // preserve the established no-transcript behavior for them. A Coven
+      // child that did start and then exited non-zero is different: persist a
+      // clearly marked failure when the conversation already has an id, so a
+      // reload retains the safe exit diagnostics instead of looking complete.
+      const persistCovenProcessFailure = Boolean(
+        finalSessionId && launchFailure && covenBackedProcessFailed,
+      );
+      if (finalSessionId && (!launchFailure || persistCovenProcessFailure)) {
         pushProgress("save-transcript", "Saving transcript", "running");
         await recordSessionFamiliar(finalSessionId, body.familiarId);
         // Settle any in-flight stub write first so it can never race (and
@@ -4738,10 +4789,13 @@ export async function POST(req: Request) {
           const persistedTools = toPersistedTools([...priorAttemptTools, ...toolTracker.snapshot()],
             assistantText.length - assistantText.trimStart().length,
           );
+          const persistedAssistantText = persistCovenProcessFailure && !cleanedAssistantText
+            ? launchFailure!.message
+            : cleanedAssistantText;
           const assistantTurn: ChatTurn = {
             id: assistantTurnId,
             role: "assistant",
-            text: cleanedAssistantText,
+            text: persistedAssistantText,
             ...(agentAttachments.length ? { attachments: agentAttachments } : {}),
             createdAt: new Date().toISOString(),
             durationMs: result.duration_ms,
@@ -4783,7 +4837,7 @@ export async function POST(req: Request) {
           if (workBranch) conv.branch = workBranch;
           // Transcript PR snapshot: the reply's last reported PR URL (fallback
           // attribution for chats whose work happens in agent worktrees).
-          const reportedPrUrl = latestPrUrlFromText(cleanedAssistantText);
+          const reportedPrUrl = latestPrUrlFromText(persistedAssistantText);
           if (reportedPrUrl) conv.prUrl = reportedPrUrl;
           if (harnessSessionId) conv.harnessSessionId = harnessSessionId;
           else if (openCodeDirect && existingConversation && !openCodeNativeResumeUsed) {

--- a/src/components/chat-error-redaction.test.ts
+++ b/src/components/chat-error-redaction.test.ts
@@ -13,6 +13,16 @@ assert.match(source, /onClick=\{\(\) => copy\(detailText\)\}/, "copy only receiv
 assert.match(source, /parseHarnessFailure\(recoveryText\)/, "recovery can classify raw failures without rendering them");
 assert.match(source, /input and output are withheld to protect project data/, "tool I/O is explicitly withheld in the UI");
 assert.match(source, /detail is withheld to protect project data/, "step detail is explicitly withheld in the UI");
+assert.match(
+  source,
+  /function safeRuntimeProcessDetail[\s\S]*?runtime diagnostic output was withheld to protect local data/,
+  "only the fixed runtime-process exit-code diagnostic may be disclosed",
+);
+assert.match(
+  source,
+  /safeRuntimeProcessDetail\(p\) \?\? "A runtime step failed\. Its detail is withheld to protect project data\."/,
+  "the diagnostics view falls back to withholding every unrecognized step detail",
+);
 
 const errorStrip = source.slice(source.indexOf("function ChatErrorStrip"), source.indexOf("function AuthFixRow"));
 assert.doesNotMatch(errorStrip, /<pre className=\{pre\}>\{t\.(?:input|output)\}<\/pre>/, "raw tool I/O is not rendered");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -522,6 +522,15 @@ type ErrorStripTool = { id: string; name: string; input?: string; output?: strin
 type ErrorStripStep = { id: string; label: string; detail?: string; status: "running" | "done" | "notice" | "error" };
 type ErrorStripTurn = { tools?: ErrorStripTool[]; progress?: ErrorStripStep[]; lifecycle?: string };
 
+/** Only display the fixed, server-produced runtime-process diagnostic shape.
+ * Progress detail normally can contain project output, so every other value
+ * remains withheld in the error strip. */
+function safeRuntimeProcessDetail(step: ErrorStripStep): string | null {
+  if (step.id !== "runtime-process" || !step.detail) return null;
+  const match = /^Exit code (\d+); (runtime diagnostic output was withheld to protect local data|the runtime did not emit an error message)\.$/.exec(step.detail);
+  return match ? `Exit code ${match[1]}. ${match[2]}.` : null;
+}
+
 /** Inline error/debug strip between the transcript and the composer. Shows the
  *  latest chat error message + code plus metadata-only failure diagnostics.
  *  Tool input/output and step detail can contain project content, paths, or
@@ -795,7 +804,7 @@ function ChatErrorStrip({
             {erroredSteps.map((p) => (
               <div key={p.id}>
                 <div className={kicker}>step failure</div>
-                <pre className={pre}>A runtime step failed. Its detail is withheld to protect project data.</pre>
+                <pre className={pre}>{safeRuntimeProcessDetail(p) ?? "A runtime step failed. Its detail is withheld to protect project data."}</pre>
               </div>
             ))}
             {erroredTools.length === 0 && erroredSteps.length === 0 ? (

--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -484,6 +484,16 @@ try {
     RUNTIME_AVAILABILITY_ERROR_CODES.process_failed,
     "a started Hermes process has a structured error distinct from availability",
   );
+  assert.match(
+    runtimeProcessFailure("codex", { exitCode: 1, emittedDiagnostic: false }).message,
+    /Codex CLI exited with an error \(exit code 1\).*did not emit an error message.*local runtime configuration/i,
+    "a silent Codex/Coven exit names its safe exit code without guessing at authentication",
+  );
+  assert.doesNotMatch(
+    runtimeProcessFailure("codex", { exitCode: 1, emittedDiagnostic: true }).message,
+    /stderr|token|path/i,
+    "runtime process diagnostics report only that output was withheld, never its contents",
+  );
 
   // A resolved npm shim may produce a direct Node + script launch. Both the
   // executable and its fixed package target are part of the exact plan.

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -214,7 +214,10 @@ export function localRuntimeLaunchError(
 /** A process that did start but exited unsuccessfully is distinct from a
  * missing or unlaunchable CLI. Its copy is safe to surface without provider
  * output, executable paths, or scoped environment values. */
-export function runtimeProcessFailure(runner: DirectRunnerId | CovenBackedRunnerId): {
+export function runtimeProcessFailure(
+  runner: DirectRunnerId | CovenBackedRunnerId,
+  options: { exitCode?: number | null; emittedDiagnostic?: boolean } = {},
+): {
   code: typeof RUNTIME_AVAILABILITY_ERROR_CODES.process_failed;
   message: string;
 } {
@@ -225,9 +228,16 @@ export function runtimeProcessFailure(runner: DirectRunnerId | CovenBackedRunner
     };
   }
   const label = runner === "hermes" ? "Hermes" : RUNNER_LABELS[runner];
+  const exitCode =
+    typeof options.exitCode === "number" && Number.isInteger(options.exitCode)
+      ? ` (exit code ${options.exitCode})`
+      : "";
+  const diagnostic = options.emittedDiagnostic
+    ? " The runtime emitted diagnostic output, which Cave withheld to protect local data."
+    : " The runtime did not emit an error message.";
   return {
     code: RUNTIME_AVAILABILITY_ERROR_CODES.process_failed,
-    message: `${label} exited with an error before returning a response. Check ${label} sign-in and configuration, then try again.`,
+    message: `${label} exited with an error${exitCode} before returning a response.${diagnostic} Check the local runtime configuration, then try again.`,
   };
 }
 


### PR DESCRIPTION
## Summary
- classify a Coven-backed Codex process that starts and exits nonzero as an explicit failed chat run
- surface only safe, fixed diagnostics: exit code plus whether runtime output was withheld or absent
- persist an existing conversation's failed turn and progress record so reload cannot present the attempt as a completed empty response
- keep model selection pending when `coven run` merely forwards a model; promote it only after downstream acceptance is established
- add integration, redaction, runtime-availability, and model-routing regression coverage

## User impact
A silent Codex code-1 exit no longer produces the fabricated "CLI is installed but not authenticated" explanation or looks like a completed blank response. Cave reports a structured `runtime_process_failed` result, names the exit code when available, and directs the user to local runtime configuration without revealing stderr, paths, project contents, or credentials.

## Privacy boundary
Runtime output is never copied into chat. The server emits and persists only one of two allowlisted detail shapes: `Exit code N; the runtime did not emit an error message.` or `Exit code N; runtime diagnostic output was withheld to protect local data.` The UI displays only that validated form and withholds every other step detail.

## Validation
- `node --experimental-strip-types src/lib/runtime-availability.test.ts`
- `node --experimental-strip-types src/components/chat-error-redaction.test.ts`
- `node --experimental-strip-types src/app/api/chat/send/harness-routing-model-capabilities.test.ts`
- alias-aware `route-codex-runtime-availability.integration.test.ts`
- `pnpm run typecheck`
- `pnpm lint`
- `node scripts/check-tests-wired.mjs` (1370 files wired)
- `git diff --check`

## Scope
This changes generic Coven-backed process-failure handling, with focused Codex coverage. It does not change provider authentication or the Grok Build transport.