### PR TITLE
fix(research): make missing primary artifacts retryable

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -22,6 +22,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { Modal } from "@/components/ui/modal";
 import { CitationSources } from "@/components/ui/citation";
 import { ClampedText } from "@/components/ui/clamped-text";
 import { Tabs } from "@/components/ui/tabs";
@@ -109,6 +110,7 @@ export function ResearchMissionDetail({
   const [busy, setBusy] = useState(false);
   const [direction, setDirection] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   // null = untouched; the retry payload then adapts to the failure instead.
   const [retryRoot, setRetryRoot] = useState<string | null>(null);
   // Toggles the "Saved" summary's copy-workspace-path button label; reverted
@@ -147,6 +149,13 @@ export function ResearchMissionDetail({
     setRetryRoot(null);
     setActionError(null);
     setDirection("");
+  }, [missionId]);
+
+  // A diagnostics dialog belongs to the selected run. Close it when the user
+  // moves to another mission so its details cannot be mistaken for the new
+  // selection.
+  useEffect(() => {
+    setDiagnosticsOpen(false);
   }, [missionId]);
 
   // The copied-path confirmation is per-mission UI state too. Its cleanup
@@ -191,6 +200,24 @@ export function ResearchMissionDetail({
   const draftArtifact = mission.artifacts.find(
     (artifact) => artifact.relativePath === "artifacts/primary.md" && artifact.state === "working",
   );
+  const primaryArtifact = mission.artifacts.find(
+    (artifact) => artifact.relativePath === "artifacts/primary.md",
+  );
+  const diagnostics = [
+    ["Error", mission.lastError ?? "No current error"],
+    ["Status", mission.status],
+    ["Pass", iteration ? `${iteration.number} of ${mission.bounds.maxIterations}` : "No pass recorded"],
+    ["Control", iteration?.decisionReason ?? "No control decision recorded"],
+    ["Flow run", iteration?.flowRunId ?? "No flow run recorded"],
+    ["Session", sessionId ?? "No session recorded"],
+    [
+      "Primary artifact",
+      primaryArtifact
+        ? `${primaryArtifact.relativePath} · ${primaryArtifact.state}`
+        : "No primary artifact reference",
+    ],
+    ["Sources", `${mission.sources.length} recorded · ${sourceCounts.used} used`],
+  ] as const;
   const isCheckpointLike = mission.status === "checkpoint" || mission.status === "paused";
   const isLive = LIVE_STATUSES.has(mission.status);
   // One line of run context above the open pane — the state the two stacked
@@ -424,6 +451,15 @@ export function ResearchMissionDetail({
             <div className="research-mission-stop" role="status">
               <Icon name="ph:warning" width={14} height={14} aria-hidden />
               <span>{mission.lastError}</span>
+              <Button
+                className="research-mission-stop__diagnostics"
+                size="xs"
+                variant="ghost"
+                leadingIcon="ph:terminal-window"
+                onClick={() => setDiagnosticsOpen(true)}
+              >
+                View diagnostics
+              </Button>
             </div>
           ) : iteration?.decisionReason ? (
             <div className="research-mission-decision" role="status">
@@ -431,6 +467,29 @@ export function ResearchMissionDetail({
               <p>{iteration.decisionReason}</p>
             </div>
           ) : null}
+
+          <Modal
+            open={diagnosticsOpen}
+            onClose={() => setDiagnosticsOpen(false)}
+            breadcrumb={["Research", "Diagnostics"]}
+            footerActions={(
+              <Button variant="secondary" onClick={() => setDiagnosticsOpen(false)}>
+                Close
+              </Button>
+            )}
+          >
+            <div className="research-mission-diagnostics">
+              <p>Run details are local to this research mission.</p>
+              <dl>
+                {diagnostics.map(([label, value]) => (
+                  <div key={label}>
+                    <dt>{label}</dt>
+                    <dd>{value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </Modal>
 
           {/* ── Checkpoint / paused: what changed + refine box.
                 Tiles derive from real data only — a tile whose datum is

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -74,6 +74,18 @@ test("running and completed blocks stay honest about their data", () => {
   assert.doesNotMatch(detail, /Finding 1|compFindings/);
 });
 
+test("run failures disclose persisted diagnostics without fabricating a cause", () => {
+  assert.match(detail, /View diagnostics/);
+  assert.match(detail, /<Modal[\s\S]*?breadcrumb=\{\["Research", "Diagnostics"\]\}/);
+  assert.match(detail, /\["Error", mission\.lastError \?\? "No current error"\]/);
+  assert.match(detail, /\["Flow run", iteration\?\.flowRunId \?\? "No flow run recorded"\]/);
+  assert.match(detail, /\["Session", sessionId \?\? "No session recorded"\]/);
+  assert.match(detail, /primaryArtifact\.relativePath/);
+  assert.match(detail, /\["Sources", `\$\{mission\.sources\.length\} recorded/);
+  assert.match(css, /\.research-mission-diagnostics/);
+  assert.match(css, /var\(--bg-sunken\)/);
+});
+
 // ── Evidence triage: exact ledger source-update mechanism ──────────────────
 // Triage lives in the ledger now — the rail's Sources pane IS the ledger, so
 // the checkpoint verdicts ride the same source cards as the full list.

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -247,6 +247,59 @@ test("running reconciliation carries real Flow phase progress", async () => {
   ]);
 });
 
+test("a finished run without its primary artifact fails instead of masquerading as a checkpoint", async () => {
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    // This reproduces a direct session that was reported finished but never
+    // persisted its transcript or wrote the mission workspace.
+    loadConversation: async () => null,
+    readMissionFile: async () => null,
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations[0].status, "failed");
+  assert.equal(result.iterations[0].decision, undefined);
+  assert.match(result.lastError ?? "", /artifacts\/primary\.md/);
+  assert.ok(allowedResearchActions(result).includes("retry"));
+  assert.ok(!allowedResearchActions(result).includes("continue"));
+});
+
+test("a reviewable primary artifact still creates a checkpoint", async () => {
+  const conversation = {
+    sessionId: "session-1",
+    familiarId: "sage",
+    harness: "codex",
+    createdAt: NOW.toISOString(),
+    updatedAt: NOW.toISOString(),
+    turns: [{
+      id: "turn-1",
+      role: "assistant",
+      text: [
+        "@@research-control",
+        '{"decision":"checkpoint","reason":"Review the evidence","confidence":0.7}',
+        "@@research-artifacts-written",
+      ].join("\n"),
+      createdAt: NOW.toISOString(),
+    }],
+  } satisfies ConversationFile;
+  const runner = makeResearchMissionRunner(deps({
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    loadConversation: async () => conversation,
+    readMissionFile: async (_id, relativePath) => (
+      relativePath === "artifacts/primary.md" ? "# Evidence-backed draft\n" : null
+    ),
+  }));
+  const started = await runner.createAndStart(INPUT);
+  const result = await runner.reconcile(started);
+
+  assert.equal(result.status, "checkpoint");
+  assert.equal(result.iterations[0].status, "checkpoint");
+  assert.equal(result.lastError, undefined);
+  assert.ok(allowedResearchActions(result).includes("continue"));
+});
+
 test("successful evidence reconciliation publishes every provenance-rich artifact", async () => {
   const published: string[] = [];
   const conversation = {
@@ -801,12 +854,30 @@ test("finish surfaces publish failures without blocking completion", async () =>
   assert.equal(primary?.state, "published");
 });
 
-test("finish degrades an unreadable primary instead of 500ing after pauseAutomation (cave-v73d)", async () => {
+test("finish makes a missing primary retryable instead of completing a partial artifact set", async () => {
+  let stored = checkpointMission();
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async () => null,
+  }));
+  const result = await runner.act(stored.id, { action: "finish" });
+
+  assert.equal(result.status, "failed");
+  assert.equal(result.iterations.at(-1)?.status, "failed");
+  assert.equal(result.iterations.at(-1)?.decision, undefined);
+  assert.match(result.lastError ?? "", /artifacts\/primary\.md/);
+  assert.ok(allowedResearchActions(result).includes("retry"));
+  assert.ok(!allowedResearchActions(result).includes("continue"));
+  for (const artifact of result.artifacts) assert.equal(artifact.state, "working");
+});
+
+test("finish makes an unreadable primary retryable instead of 500ing after pauseAutomation (cave-v73d)", async () => {
   // A symlinked/oversized/escaping primary makes the store throw. Because finish
   // has already run pauseAutomation, a raw throw would 500 the whole action and
-  // leave automation paused while the mission never settles. The read is now
-  // defensive: the primary degrades to a named publish failure and finish still
-  // completes — no throw escapes act().
+  // leave automation paused while the mission never settles. The read remains
+  // defensive: it settles to a retryable failure without publishing a partial
+  // artifact set.
   let stored = checkpointMission({
     artifacts: [
       { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
@@ -824,12 +895,13 @@ test("finish degrades an unreadable primary instead of 500ing after pauseAutomat
     },
   }));
   const result = await runner.act(stored.id, { action: "finish" });
-  assert.equal(result.status, "completed", "finish still settles despite the unreadable primary");
+  assert.equal(result.status, "failed", "finish settles despite the unreadable primary");
+  assert.ok(allowedResearchActions(result).includes("retry"));
   const primary = result.artifacts.find((artifact) => artifact.key === "primary");
   assert.notEqual(primary?.state, "published", "the unreadable primary is not published");
   const findings = result.artifacts.find((artifact) => artifact.key === "findings");
-  assert.equal(findings?.state, "published", "the readable refs still publish");
-  assert.match(result.lastError ?? "", /primary/, "the failed primary is named in the banner");
+  assert.equal(findings?.state, "working", "a partial artifact set is not published");
+  assert.match(result.lastError ?? "", /symlinks/, "the integrity failure is retained");
 });
 
 test("reject-artifact clears the stale publish-failure banner for the rejected ref (cave-o780)", async () => {

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -404,23 +404,44 @@ async function reconcileCompletedRun(
     summary: control.reason,
     ...(costUsd === undefined ? {} : { costUsd }),
   };
+  // A missing or unreadable primary artifact is an execution failure, not a
+  // review checkpoint. A checkpoint means the agent completed a bounded pass
+  // and left a reviewable draft behind. Without that draft (often alongside a
+  // missing terminal control record), rendering it as a checkpoint falsely
+  // turns every stale phase green and offers Continue instead of Retry.
+  const failedIteration = {
+    ...iteration,
+    status: "failed" as const,
+    finishedAt: timestamp,
+    summary: "Research output unavailable",
+    ...(costUsd === undefined ? {} : { costUsd }),
+  };
   let markdown: string | null;
+  try {
+    markdown = await deps.readMissionFile(mission.id, "artifacts/primary.md");
+  } catch (error) {
+    return {
+      ...mission,
+      status: "failed",
+      updatedAt: timestamp,
+      lastError: error instanceof Error ? error.message : "Research evidence could not be read",
+      iterations: mission.iterations.map((item, index) => index === iterationIndex ? failedIteration : item),
+    };
+  }
+
   let fileSources: ResearchSourceRef[];
   try {
-    [markdown, fileSources] = await Promise.all([
-      deps.readMissionFile(mission.id, "artifacts/primary.md"),
-      deps.readSources(mission.id),
-    ]);
+    fileSources = await deps.readSources(mission.id);
   } catch (error) {
+    // A primary draft exists but its ledger needs repair. Keep this as a
+    // checkpoint: the user can inspect the draft and correct/reject evidence
+    // instead of discarding a useful pass as an execution failure.
     return {
       ...mission,
       status: "checkpoint",
       updatedAt: timestamp,
-      lastError: error instanceof Error ? error.message : "Research evidence could not be read",
-      iterations: mission.iterations.map((item, index) => index === iterationIndex ? {
-        ...nextIteration,
-        status: "checkpoint",
-      } : item),
+      lastError: error instanceof Error ? error.message : "Research sources could not be read",
+      iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
     };
   }
   const sources = mergeFileSources(mission.sources, fileSources);
@@ -428,11 +449,11 @@ async function reconcileCompletedRun(
   if (!markdown) {
     return {
       ...mission,
-      status: "checkpoint",
+      status: "failed",
       updatedAt: timestamp,
       lastError: "Research run completed without artifacts/primary.md",
       sources,
-      iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
+      iterations: mission.iterations.map((item, index) => index === iterationIndex ? failedIteration : item),
     };
   }
   // Primary lookup by path, not index — backfilled legacy arrays and the
@@ -811,33 +832,50 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       }
       if (input.action === "finish") {
         mission = await pauseAutomation(mission, "Mission finished");
-        // Read the primary defensively — like the `complete` path does. A
-        // symlinked/oversized/escaping primary must NOT throw here: pauseAutomation
-        // has already flipped the automation store, so a raw throw would 500 the
-        // whole finish and leave automation paused while the mission never
-        // settles (status divergence, cave-v73d). An unreadable primary degrades:
-        // publishFinalArtifacts isolates it as a named publish failure and the
-        // mission still finishes.
+        const finishedMission = mission;
+        // Read the primary defensively. A symlinked/oversized/escaping primary
+        // must NOT throw after pauseAutomation has changed the schedule state,
+        // but it also cannot be treated as a completed research result. A
+        // primary artifact is the deliverable that makes a Finish finalization
+        // meaningful; without it, leave every ref un-published and offer Retry.
         let primaryMarkdown: string | null = null;
+        let primaryError: string | null = null;
         try {
-          primaryMarkdown = await deps.readMissionFile(mission.id, "artifacts/primary.md");
-        } catch {
-          primaryMarkdown = null;
+          primaryMarkdown = await deps.readMissionFile(finishedMission.id, "artifacts/primary.md");
+        } catch (error) {
+          primaryError = error instanceof Error ? error.message : "Research evidence could not be read";
+        }
+        if (!primaryMarkdown) {
+          return saveUpdated({
+            ...finishedMission,
+            status: "failed",
+            lastError: primaryError ?? "Research run completed without artifacts/primary.md",
+            iterations: finishedMission.iterations.map((iteration, index) => {
+              if (index !== finishedMission.iterations.length - 1) return iteration;
+              const { decision: _decision, decisionReason: _decisionReason, ...failedIteration } = iteration;
+              return {
+                ...failedIteration,
+                status: "failed" as const,
+                finishedAt: timestamp,
+                summary: "Research output unavailable",
+              };
+            }),
+          });
         }
         // Finishing by hand saves the same final artifacts a `complete`
         // decision would — the checkpointed files are the deliverables.
         const outcome = await publishFinalArtifacts({
-          mission,
-          artifacts: mission.artifacts.map((artifact) => (
+          mission: finishedMission,
+          artifacts: finishedMission.artifacts.map((artifact) => (
             artifact.state === "rejected" ? artifact : { ...artifact, updatedAt: timestamp }
           )),
-          sources: mission.sources,
+          sources: finishedMission.sources,
           primaryMarkdown,
-          provenance: latestIterationProvenance(mission, timestamp),
+          provenance: latestIterationProvenance(finishedMission, timestamp),
           deps,
         });
         return saveUpdated({
-          ...mission,
+          ...finishedMission,
           status: "completed",
           finishedAt: timestamp,
           artifacts: outcome.artifacts,

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -413,6 +413,19 @@
 }
 .research-desk-block__abstract { color: var(--text-primary); }
 .research-desk-block__empty { margin: 0; font-size: var(--text-2xs); color: var(--text-muted); }
+
+/* Failure details stay out of the main run narrative until explicitly opened.
+   The modal uses the shared focus trap; these rows only establish the compact,
+   token-driven evidence hierarchy inside it. */
+.research-mission-stop { align-items: center; }
+.research-mission-stop > span { min-width: 0; }
+.research-mission-stop__diagnostics { flex: none; margin-left: auto; }
+.research-mission-diagnostics { display: grid; gap: var(--space-4); }
+.research-mission-diagnostics > p { margin: 0; color: var(--text-secondary); font-size: var(--text-xs); }
+.research-mission-diagnostics dl { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: var(--space-2); margin: 0; }
+.research-mission-diagnostics dl > div { display: grid; gap: var(--space-1); min-width: 0; padding: var(--space-3); border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: var(--bg-sunken); }
+.research-mission-diagnostics dt { color: var(--text-muted); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+.research-mission-diagnostics dd { margin: 0; color: var(--text-primary); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-xs); overflow-wrap: anywhere; }
 .research-desk-activity {
   display: flex;
   flex-direction: column;

--- a/tests/research-desk-tabs.spec.ts
+++ b/tests/research-desk-tabs.spec.ts
@@ -457,6 +457,14 @@ test.describe("research desk tabs", () => {
       "The research session crashed before publishing.",
     );
     await expect(desk.locator(".research-mission-actions").getByRole("button", { name: /^Retry/ })).toBeVisible();
+
+    await desk.getByRole("button", { name: "View diagnostics" }).click();
+    const diagnostics = page.getByRole("dialog", { name: /Research.*Diagnostics/ });
+    await expect(diagnostics).toContainText("The research session crashed before publishing.");
+    await expect(diagnostics).toContainText("sess-fail-1");
+    await expect(diagnostics).toContainText("No flow run recorded");
+    await diagnostics.getByText("Close", { exact: true }).click();
+    await expect(diagnostics).toBeHidden();
   });
 
   test("Desk toolbar scopes runs and preserves focus mode", async ({ page }) => {


### PR DESCRIPTION
## Summary
- classify a completed research pass with a missing or unreadable `artifacts/primary.md` as a failed mission and failed iteration, rather than a misleading checkpoint
- preserve real checkpoints when the primary draft exists but the source ledger cannot be read
- make manual Finish leave an absent or unreadable primary retryable and prevent publishing a partial artifact set
- add the requested **View diagnostics** action to failure copy, using the shared focus-trapped Modal with only bounded mission metadata
- add lifecycle, UI-contract, and Playwright coverage for the changed behavior

## User impact
The reported `Iteration limit reached` / `Research run completed without artifacts/primary.md` state now stays visibly failed instead of looking reviewable or complete. The user gets Retry and can open a local diagnostics dialog containing the error, status, iteration/control identifiers, session/flow identifiers, primary-artifact state, and source counts. It never invents a cause or prints unbounded process output.

## Safety and UI details
- The missing-primary path marks the latest iteration as `failed` with the stable summary `Research output unavailable`.
- The diagnostics modal resets when the selected mission changes, reuses the existing Modal accessibility behavior, and stays within the shared token/design system.
- A source-ledger read failure remains a checkpoint when a real primary draft exists, preserving a reviewable result.

## Validation
- `research-tab-desk.test.ts`: 26 passing UI-contract tests
- `research-mission-runner-lifecycle-actions.test.ts`: 33 passing lifecycle tests
- `pnpm run typecheck`
- `pnpm lint` (design codemod clean, ESLint clean)
- `node scripts/check-tests-wired.mjs` (1370 files wired)
- `git diff --check`
- Browser spec was invoked with `pnpm exec playwright test tests/research-desk-tabs.spec.ts --project=desktop`, but this machine does not have Playwright Chromium installed. It failed before the app started; no browser dependency was downloaded or machine configuration changed.

## Scope
This PR covers research-run lifecycle truthfulness and the diagnostics button requested for that failure state. It does not change chat harnesses or desktop startup.