### PR TITLE
fix(release): preserve cached Whisper runtime

### DIFF
--- a/scripts/whisper-runtime-bundle.sh
+++ b/scripts/whisper-runtime-bundle.sh
@@ -26,7 +26,9 @@ cleanup() {
     if [ ! -e "$LIVE_DEST" ]; then
       if ! mv "$PREVIOUS_DEST" "$LIVE_DEST"; then
         echo "ERROR: could not restore the previous bundled Whisper runtime" >&2
-        status=1
+        if [ "$status" -eq 0 ]; then
+          status=1
+        fi
       fi
     else
       if ! rm -rf "$PREVIOUS_DEST"; then

--- a/scripts/whisper-runtime-bundle.sh
+++ b/scripts/whisper-runtime-bundle.sh
@@ -13,17 +13,42 @@ WORK="$(mktemp -d "${TMPDIR:-/tmp}/coven-whisper-runtime.XXXXXX")"
 STAGE_ROOT="$(mktemp -d "$ROOT/src-tauri/resources/.whisper-staging.XXXXXX")"
 STAGE_DEST="$STAGE_ROOT/whisper"
 RUNTIME_ID="$VERSION:$(uname -s):$(uname -m):$MACOS_COMMIT"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) WHISPER_CLI_NAME="whisper-cli.exe" ;;
+  *) WHISPER_CLI_NAME="whisper-cli" ;;
+esac
+PREVIOUS_DEST=""
 
 cleanup() {
-  rm -rf "$WORK" "$STAGE_ROOT"
+  local status=$?
+  trap - EXIT INT TERM HUP
+  if [ -n "$PREVIOUS_DEST" ] && [ -d "$PREVIOUS_DEST" ]; then
+    if [ ! -e "$LIVE_DEST" ]; then
+      if ! mv "$PREVIOUS_DEST" "$LIVE_DEST"; then
+        echo "ERROR: could not restore the previous bundled Whisper runtime" >&2
+        status=1
+      fi
+    else
+      if ! rm -rf "$PREVIOUS_DEST"; then
+        echo "WARNING: could not remove the previous bundled Whisper runtime" >&2
+      fi
+    fi
+  fi
+  if ! rm -rf "$WORK" "$STAGE_ROOT"; then
+    echo "WARNING: could not remove temporary Whisper runtime files" >&2
+  fi
+  exit "$status"
 }
 trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 129' HUP
 
 runtime_is_current() {
-  [ -x "$LIVE_DEST/whisper-cli" ] || return 1
+  [ -x "$LIVE_DEST/$WHISPER_CLI_NAME" ] || return 1
   [ -f "$LIVE_DEST/.coven-whisper-runtime-id" ] || return 1
   [ "$(cat "$LIVE_DEST/.coven-whisper-runtime-id")" = "$RUNTIME_ID" ] || return 1
-  "$LIVE_DEST/whisper-cli" --version >/dev/null 2>&1
+  "$LIVE_DEST/$WHISPER_CLI_NAME" --version >/dev/null 2>&1
 }
 
 if [ "${COVEN_CAVE_REFRESH_WHISPER:-0}" != "1" ] && runtime_is_current; then
@@ -159,17 +184,14 @@ esac
 
 printf '%s\n' "$RUNTIME_ID" > "$DEST/.coven-whisper-runtime-id"
 
-previous=""
 if [ -d "$LIVE_DEST" ]; then
-  previous="$(mktemp -d "$ROOT/src-tauri/resources/.whisper-previous.XXXXXX")"
-  rmdir "$previous"
-  mv "$LIVE_DEST" "$previous"
+  PREVIOUS_DEST="$(mktemp -d "$ROOT/src-tauri/resources/.whisper-previous.XXXXXX")"
+  rmdir "$PREVIOUS_DEST"
+  mv "$LIVE_DEST" "$PREVIOUS_DEST"
 fi
 if ! mv "$STAGE_DEST" "$LIVE_DEST"; then
-  if [ -n "$previous" ]; then mv "$previous" "$LIVE_DEST"; fi
   echo "ERROR: could not install bundled Whisper runtime" >&2
   exit 1
 fi
-if [ -n "$previous" ]; then rm -rf "$previous"; fi
 
 echo "==> bundled whisper.cpp $VERSION ($(find "$LIVE_DEST" -maxdepth 1 -type f | wc -l | tr -d ' ') files)"

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -203,8 +203,33 @@ test("release bundle includes and prefers bundled Node and Whisper runtimes", as
   );
   assert.match(
     whisperBundleScript,
+    /MINGW\*\|MSYS\*\|CYGWIN\*\) WHISPER_CLI_NAME="whisper-cli\.exe"/,
+    "Windows cache validation must use the staged whisper-cli.exe name",
+  );
+  assert.match(
+    whisperBundleScript,
+    /\[ -x "\$LIVE_DEST\/\$WHISPER_CLI_NAME" \][\s\S]*?"\$LIVE_DEST\/\$WHISPER_CLI_NAME" --version/,
+    "cache validation must probe the platform-specific Whisper executable",
+  );
+  assert.match(
+    whisperBundleScript,
     /STAGE_ROOT=.*\.whisper-staging[\s\S]*?mv "\$STAGE_DEST" "\$LIVE_DEST"/,
     "Whisper must stage in a sibling directory before replacing the live runtime",
+  );
+  assert.match(
+    whisperBundleScript,
+    /PREVIOUS_DEST=""[\s\S]*?cleanup\(\)[\s\S]*?\[ -n "\$PREVIOUS_DEST" \][\s\S]*?\[ ! -e "\$LIVE_DEST" \][\s\S]*?mv "\$PREVIOUS_DEST" "\$LIVE_DEST"/,
+    "cleanup must restore the previous runtime when an interrupted swap leaves the live path absent",
+  );
+  assert.match(
+    whisperBundleScript,
+    /trap 'exit 130' INT[\s\S]*?trap 'exit 143' TERM[\s\S]*?trap 'exit 129' HUP/,
+    "signals must flow through EXIT rollback cleanup with their conventional statuses",
+  );
+  assert.match(
+    whisperBundleScript,
+    /local status=\$\?[\s\S]*?if ! rm -rf "\$PREVIOUS_DEST"[\s\S]*?if ! rm -rf "\$WORK" "\$STAGE_ROOT"[\s\S]*?exit "\$status"/,
+    "non-restoration cleanup failures must be reported without replacing the original exit status",
   );
   assert.doesNotMatch(
     whisperBundleScript,

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -231,6 +231,11 @@ test("release bundle includes and prefers bundled Node and Whisper runtimes", as
     /local status=\$\?[\s\S]*?if ! rm -rf "\$PREVIOUS_DEST"[\s\S]*?if ! rm -rf "\$WORK" "\$STAGE_ROOT"[\s\S]*?exit "\$status"/,
     "non-restoration cleanup failures must be reported without replacing the original exit status",
   );
+  assert.match(
+    whisperBundleScript,
+    /could not restore the previous bundled Whisper runtime[\s\S]*?if \[ "\$status" -eq 0 \]; then[\s\S]*?status=1/,
+    "rollback failure must preserve an existing failure or signal status while making a successful exit fail",
+  );
   assert.doesNotMatch(
     whisperBundleScript,
     /rm -rf "\$DEST"/,


### PR DESCRIPTION
## Summary
- validate the cached Windows Whisper runtime through `whisper-cli.exe`
- restore the previous runtime if staging is interrupted after the live directory moves aside
- preserve signal and failure exit statuses while reporting cleanup failures

## Test plan
- [x] `node src-tauri/release-runtime.test.mjs`
- [x] `bash -n scripts/whisper-runtime-bundle.sh`
- [x] `pnpm test:app`
- [x] `pnpm build`

Bead: cave-qcpy7