### PR TITLE
fix(chat): stop the composer eating left arrow to accept a suggestion (cave-i66c)

### DIFF
--- a/src/components/chat-composer-rec-autofill.test.ts
+++ b/src/components/chat-composer-rec-autofill.test.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 // Pins for the recommended-next-path composer ghost fill (cave-h62k): the
 // empty composer mirrors the last settled turn's top suggestion as its
-// placeholder, and ⇥ / ← accept it as an editable draft — fill, never send.
+// placeholder, and ⇥ accepts it as an editable draft — fill, never send.
+// ← was removed as an accept key in cave-i66c; see the regression pin below.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -24,12 +25,24 @@ assert.match(
 // Key handling: empty-draft-only, not while busy, Shift+Tab untouched, and
 // ordered AFTER the menu/token handlers so they keep owning Tab while open.
 const keyBranch = source.match(
-  /\(\(e\.key === "Tab" && !e\.shiftKey\) \|\| e\.key === "ArrowLeft"\) &&\n\s*input === "" &&\n\s*!busy &&\n\s*recommendedNextPath/,
+  /e\.key === "Tab" &&\n\s*!e\.shiftKey &&\n\s*input === "" &&\n\s*!busy &&\n\s*recommendedNextPath/,
 );
-assert.ok(keyBranch, "⇥/← fill is gated on empty draft, not-busy, and a live recommendation");
+assert.ok(keyBranch, "⇥ fill is gated on empty draft, not-busy, and a live recommendation");
 const menuKeyIdx = source.indexOf("if (handleMenuKey(e)) return;");
-const fillIdx = source.indexOf('e.key === "ArrowLeft"');
+const fillIdx = source.indexOf('e.key === "Tab" &&\n      !e.shiftKey &&');
 assert.ok(menuKeyIdx !== -1 && fillIdx > menuKeyIdx, "menus keep owning Tab — fill branch comes after handleMenuKey");
+
+// Regression (cave-i66c): ← must never be an accept key. It was briefly one on
+// the reasoning that an empty textarea makes it inert, but that is only true of
+// the text buffer — ArrowLeft stays a live navigation key for screen readers and
+// IME candidate lists, and it is the one key a person presses expecting nothing
+// to happen. Assert on the ACCEPT BRANCH rather than the whole file, so the
+// unrelated ↑↓ history handler (handleArrowKey) stays free to use arrow keys.
+const acceptBranch = source.slice(fillIdx, source.indexOf("}", source.indexOf("setInput(recommendedNextPath.prompt);")));
+assert.ok(
+  !acceptBranch.includes("ArrowLeft"),
+  "left arrow must not be intercepted for recommendation autofill",
+);
 assert.match(
   source,
   /setInput\(recommendedNextPath\.prompt\);\n\s*return;/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5661,13 +5661,21 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     // CHAT-D11-04: Input history navigation (↑↓), matching HomeComposer
     if (handleArrowKey(e, input, setInput)) return;
     // Recommended-next-path ghost fill: an EMPTY composer showing the
-    // recommendation as its placeholder accepts it with ⇥ or ← (both inert
-    // in an empty textarea, so no editing behaviour is lost). Ordered after
-    // the menus and token branches — they keep owning Tab while open — and
-    // gated on the empty draft so native Tab focus-move survives the moment
-    // there's real text (a11y). Fill, never send: the draft stays editable.
+    // recommendation as its placeholder accepts it with ⇥. Ordered after the
+    // menus and token branches — they keep owning Tab while open — and gated
+    // on the empty draft so native Tab focus-move survives the moment there's
+    // real text (a11y). Fill, never send: the draft stays editable.
+    //
+    // ← is deliberately NOT an accept key (cave-i66c). It was added on the
+    // reasoning that an empty textarea makes it inert, but "inert" is only true
+    // of the text buffer: ArrowLeft stays a live navigation key for screen
+    // readers and IME candidate lists, and preventDefault here eats it for
+    // them. It is also the one key a person presses expecting nothing to
+    // happen, so spending it to paste an assistant suggestion into their draft
+    // is a surprise with no undo affordance. Tab is the only accept.
     if (
-      ((e.key === "Tab" && !e.shiftKey) || e.key === "ArrowLeft") &&
+      e.key === "Tab" &&
+      !e.shiftKey &&
       input === "" &&
       !busy &&
       recommendedNextPath


### PR DESCRIPTION
## Summary

An empty chat composer showing a recommended next path accepted it on **⇥ or ←**. The `←` binding was added in cave-h62k on the reasoning that an empty textarea makes the key inert, so nothing is lost by claiming it.

That holds only for the *text buffer*. `ArrowLeft` stays a live navigation key for screen readers and IME candidate lists, and `preventDefault` here eats it for them. It's also the one key a person presses expecting **nothing** to happen — spending it to paste an assistant suggestion into their draft is a surprise with no undo affordance.

**Tab is now the sole accept.** Everything else about the branch is unchanged: empty-draft-only, not-while-busy, still ordered after the menu and placeholder-token handlers so they keep owning Tab while open, still *fill and never send*. The ↑↓ input-history handler (`handleArrowKey`) is untouched and keeps its arrow keys.

## The test was protecting the bug

`chat-composer-rec-autofill.test.ts` asserted the `((e.key === "Tab" && !e.shiftKey) || e.key === "ArrowLeft")` branch shape — so the defect was pinned in place and any fix would have failed CI. It now pins Tab-only, plus a regression assertion that `←` is never intercepted for autofill.

That assertion is scoped to the **accept branch**, not the whole file, so the unrelated arrow-key history handler stays free to use arrow keys.

## Verification

A pin that can't fail is worthless, so I reintroduced the bug two ways and confirmed each is caught:

| Simulated regression | Caught by |
|---|---|
| re-added `\|\| e.key === "ArrowLeft"` | branch-shape pin |
| subtler second accept clause inside the branch | the new `left arrow` assertion |

Gates: `test:app` **1004 files**, `typecheck`, `lint` (0 design drift), `check:tests-wired` **1387**, `git diff --check`.

> One local aside: `chat-session-chrome.test.ts` fails under a bare `node --test`, but a clean throwaway worktree at `origin/main` reproduces the identical failure, and it passes in the full suite — a standalone-invocation artifact, not a regression here.

## Notes

**On the bead's wording.** It asks to preserve "the visible Tab-to-fill shortcut", but PR #4114 removed that placeholder hint earlier today per the design comp, and a test now pins its absence. I'm not re-adding it — the keystroke still works, only the printed hint is gone by design. Flagging rather than silently reverting this morning's decision.

**Concurrency.** `chat-view.tsx` is also being edited by the live `feat/cave-9xadi-chat-participants` worktree (title-row participants). My change is one condition plus a comment in the composer keydown handler, far from the title row, so conflict risk is low — but worth knowing if both land close together.

Bead: `cave-i66c`

🤖 Generated with [Claude Code](https://claude.com/claude-code)