### PR TITLE
test(research): wait for media runner start events

### DIFF
--- a/src/lib/server/research-media-jobs.test.ts
+++ b/src/lib/server/research-media-jobs.test.ts
@@ -435,7 +435,8 @@ test("startup fails old rendering rows, preserves FIFO queue, and is idempotent"
   await waitForStarts(starts, 1);
   const afterFirstStart = await listResearchGenerations(familiarId);
   const interrupted = afterFirstStart.find((row) => row.id === "interrupted");
-  assert.equal(interrupted?.status, "failed");
+  assert.ok(interrupted);
+  assert.equal(interrupted.status, "failed");
   assert.equal(interrupted.error, "interrupted by runner ownership loss");
   assert.equal(interrupted.stage, undefined);
   assert.equal(

--- a/src/lib/server/research-media-jobs.test.ts
+++ b/src/lib/server/research-media-jobs.test.ts
@@ -432,22 +432,30 @@ test("startup fails old rendering rows, preserves FIFO queue, and is idempotent"
 
   await startResearchMediaJobs(factory);
   await startResearchMediaJobs(factory);
-  const interrupted = await waitForStatus(familiarId, "interrupted", "failed");
+  await waitForStarts(starts, 1);
+  const afterFirstStart = await listResearchGenerations(familiarId);
+  const interrupted = afterFirstStart.find((row) => row.id === "interrupted");
+  assert.equal(interrupted?.status, "failed");
   assert.equal(interrupted.error, "interrupted by runner ownership loss");
   assert.equal(interrupted.stage, undefined);
-  await waitForStatus(familiarId, "resume-first", "rendering");
-  await waitForStarts(starts, 1);
   assert.equal(
-    (await listResearchGenerations(familiarId)).find(
-      (row) => row.id === "resume-second",
-    )?.status,
+    afterFirstStart.find((row) => row.id === "resume-first")?.status,
+    "rendering",
+  );
+  assert.equal(
+    afterFirstStart.find((row) => row.id === "resume-second")?.status,
     "queued",
   );
   assert.deepEqual(starts, ["resume-first"]);
 
   releases.get("resume-first")?.();
-  await waitForStatus(familiarId, "resume-second", "rendering");
   await waitForStarts(starts, 2);
+  assert.equal(
+    (await listResearchGenerations(familiarId)).find(
+      (row) => row.id === "resume-second",
+    )?.status,
+    "rendering",
+  );
   releases.get("resume-second")?.();
   await waitForStatus(familiarId, "resume-second", "ready");
   assert.deepEqual(starts, ["resume-first", "resume-second"]);


### PR DESCRIPTION
## Summary
- replace the startup recovery test’s spin-polling status reads with the existing runner-start event
- retain durable recovery and FIFO state assertions after the event proves the transition

## Verification
- `research-media-jobs.test.ts` (10/10)
- three full lifecycle-suite runs under controlled CPU contention
- `pnpm typecheck`
- `pnpm lint`
- `node scripts/check-tests-wired.mjs src/lib/server/research-media-jobs.test.ts`
- `git diff --check`