### PR TITLE
fix(browser): stop hidden Linux webviews stealing half the window (cave-vb79)

### DIFF
--- a/src-tauri/src/browser_native.rs
+++ b/src-tauri/src/browser_native.rs
@@ -1,4 +1,4 @@
-#[cfg(not(target_os = "windows"))]
+#[cfg(not(any(target_os = "windows", target_os = "linux")))]
 use super::offscreen_browser_position;
 use super::{browser_bounds_within_client, BrowserBounds};
 use tauri::{PhysicalPosition, PhysicalSize, Rect};
@@ -12,13 +12,23 @@ pub(super) fn hide_webview(webview: &tauri::Webview) -> Result<(), String> {
     // Offscreen parking is not a visibility guarantee on Windows: WebView2
     // can retain a stale native input surface and invisibly capture Cave
     // clicks. Hide the child layer through the platform API instead.
-    #[cfg(target_os = "windows")]
+    //
+    // Linux joins Windows here for a different reason: parking cannot work at
+    // all. tauri-runtime-wry packs child webviews into the window's vertical
+    // GtkBox (`build_gtk(window.default_vbox())`, expand=true), so every
+    // set_position is a silent no-op and GTK allocates the child half the
+    // window regardless — a "hidden" browser still steals that space
+    // (cave-vb79). Hiding the widget is the only way to give it zero
+    // allocation. The upstream fix chain (tao#1232 -> wry#1745 ->
+    // tauri#15463) was still unmerged as of 2026-07-31; when it lands, Linux
+    // can move back to parking with the rest.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     webview.hide().map_err(|e| e.to_string())?;
 
-    // WKWebView may drop its backing surface when hidden, so other platforms
-    // retain the realized layer at its current size and move it entirely
-    // outside the physical client area.
-    #[cfg(not(target_os = "windows"))]
+    // WKWebView may drop its backing surface when hidden, so the remaining
+    // platforms retain the realized layer at its current size and move it
+    // entirely outside the physical client area.
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
     let offscreen_position = {
         let window = webview.window();
         let client = window.inner_size().map_err(|e| e.to_string())?;
@@ -31,7 +41,7 @@ pub(super) fn hide_webview(webview: &tauri::Webview) -> Result<(), String> {
         )?;
         PhysicalPosition::new(x, y)
     };
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(not(any(target_os = "windows", target_os = "linux")))]
     webview
         .set_position(offscreen_position)
         .map_err(|e| e.to_string())?;
@@ -73,7 +83,9 @@ pub(super) fn show_webview_at(
             size: PhysicalSize::new(w, h).into(),
         })
         .map_err(|e| e.to_string())?;
-    #[cfg(target_os = "windows")]
+    // Paired with the hide above: any platform that hides the widget must show
+    // it again here, or the browser never comes back from a hidden state.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     webview.show().map_err(|e| e.to_string())?;
     Ok(())
 }

--- a/src/components/browser-polish.test.ts
+++ b/src/components/browser-polish.test.ts
@@ -314,17 +314,44 @@ const hideWebviewFn = rustBrowser.match(
   /fn hide_webview\(webview: &tauri::Webview\) -> Result<\(\), String> \{[\s\S]*?\n\}/,
 )?.[0];
 assert.ok(hideWebviewFn, "hide_webview() exists in src-tauri/src/browser.rs");
-assert.match(hideWebviewFn, /#\[cfg\(target_os = "windows"\)\][\s\S]*webview\.hide\(\)/, "Windows hides WebView2 so it cannot capture clicks");
 assert.match(
   hideWebviewFn,
-  /#\[cfg\(not\(target_os = "windows"\)\)\][\s\S]*offscreen_browser_position\([\s\S]*PhysicalPosition::new\(x, y\)[\s\S]*set_position\(offscreen_position\)/,
-  "non-Windows parks the retained child fully outside its physical client area",
+  /#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\][\s\S]*webview\.hide\(\)/,
+  "Windows hides WebView2 so it cannot capture clicks; Linux hides because parking is a no-op there (cave-vb79)",
 );
 assert.match(
-  rustBrowser,
-  /fn show_webview_at[\s\S]*inner_size\(\)[\s\S]*PhysicalPosition::new\(x, y\)[\s\S]*PhysicalSize::new\(w, h\)[\s\S]*#\[cfg\(target_os = "windows"\)\][\s\S]*webview\.show\(\)/,
-  "Windows atomically applies clamped bounds before revealing WebView2",
+  hideWebviewFn,
+  /#\[cfg\(not\(any\(target_os = "windows", target_os = "linux"\)\)\)\][\s\S]*offscreen_browser_position\([\s\S]*PhysicalPosition::new\(x, y\)[\s\S]*set_position\(offscreen_position\)/,
+  "the remaining platforms park the retained child fully outside its physical client area",
 );
+const showWebviewFn = rustBrowser.match(
+  /fn show_webview_at\([\s\S]*?\n\}/,
+)?.[0];
+assert.ok(showWebviewFn, "show_webview_at() exists in src-tauri/src/browser.rs");
+assert.match(
+  rustBrowser,
+  /fn show_webview_at[\s\S]*inner_size\(\)[\s\S]*PhysicalPosition::new\(x, y\)[\s\S]*PhysicalSize::new\(w, h\)[\s\S]*#\[cfg\(any\(target_os = "windows", target_os = "linux"\)\)\][\s\S]*webview\.show\(\)/,
+  "hiding platforms atomically apply clamped bounds before revealing the child",
+);
+
+// Hide and show must cover the SAME platform set. A platform that hides the
+// widget but never shows it again strands the browser invisible forever —
+// which is how extending the Linux hide (cave-vb79) could have gone wrong.
+{
+  // The first `cfg(any(...))` in each function is its hide/show guard.
+  const guardOf = (fn: string) =>
+    (fn.match(/#\[cfg\(any\(([^)]*)\)\)\]/)?.[1] ?? "").replace(/\s+/g, "");
+  const hideGuard = guardOf(hideWebviewFn);
+  assert.equal(
+    hideGuard,
+    guardOf(showWebviewFn),
+    "every platform that hides the child webview must also show it again in show_webview_at",
+  );
+  assert.ok(
+    hideGuard.includes('target_os="windows"') && hideGuard.includes('target_os="linux"'),
+    "the hiding platforms are Windows and Linux",
+  );
+}
 assert.match(rustBrowser, /fn browser_bounds_within_client[\s\S]{0,900}!x\.is_finite\(\)[\s\S]{0,500}browser bounds must be finite/, "invalid browser bounds fail closed");
 assert.match(rustBrowser, /fn ensure_browser[\s\S]{0,1200}offscreen_browser_creation_bounds[\s\S]*main\.add_child/, "first-created WebViews use the same bounded geometry policy");
 assert.match(rustBrowser, /fn offscreen_browser_creation_bounds[\s\S]{0,600}browser_bounds_within_client/, "offscreen creation bounds are derived from the bounded geometry policy");


### PR DESCRIPTION
**Damage containment, not a fix.** The visible mispositioning in cave-vb79 stays upstream-blocked; this stops the *hidden* case from stealing half the window.

## Why hiding, when everything else parks offscreen

On Linux, `tauri-runtime-wry` packs child webviews into the window's vertical GtkBox (`build_gtk(window.default_vbox())`, `expand=true`), so **every `set_position` is a silent no-op** and GTK allocates the child half the window regardless. `hide_webview` parks the layer offscreen on all platforms except Windows — which on Linux does nothing at all. A *hidden* browser still occupies half the window.

Hiding the widget is the only way to give it zero allocation there.

The offscreen-parking rationale doesn't apply to Linux. It exists because **WKWebView** may drop its backing surface when hidden and re-seat as an unpainted black layer — a macOS concern. macOS keeps parking; the `cfg` boundary just moves.

## The trap this could have fallen into

`hide_webview` and `show_webview_at` are a **pair** — the latter re-shows under the same `cfg`. Extending the hide without the show would have stranded every Linux browser invisible forever, which is worse than the bug being contained.

So `browser-polish.test.ts` now asserts the two guards cover the *same platform set*. I negative-tested it: reverting the show guard alone makes it fail, and restoring makes it pass. The pair can't drift apart silently now.

## Upstream status (the bead's prescribed first step)

Re-checked today — **all three still unmerged**, so a version bump still won't help:

| PR | State |
|---|---|
| `tauri-apps/tao#1232` — `content_fixed` overlay layer | OPEN |
| `tauri-apps/wry#1745` — position `gtk::Fixed` children via `move_` | OPEN |
| `tauri-apps/tauri#15463` — position multi-webview children | **still draft** |

When that chain lands, Linux can move back to parking with everyone else and this `cfg` reverts.

## Verification, and its limits

- `cargo check` clean on macOS
- app suite **1006/1006**
- the symmetry guard negative-tested

**What I could not verify:** the Linux branch itself. There's no desktop-Linux Rust target installed and webkitgtk won't cross-build from macOS, so `Rust check` and `Cross-environment (ubuntu-latest)` are the verifiers here. **Nobody has reproduced this on a Linux box as part of this change** — it follows the 2026-07-26 desk audit's root-cause analysis, which was itself thorough but also desk-only.

The audit's **Windows** claim remains unconfirmed and is untouched by this PR.