### PR TITLE
fix(tests): restore the CSS sheet lists and correct their comments (cave-1d7zv)

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -229,21 +229,9 @@ const chatViewSource = readFileSync(new URL("./chat-view.tsx", import.meta.url),
 // The controls moved into the band, so the find-chrome pins read both files.
 const findChromeSource =
   chatViewSource + readFileSync(new URL("./chat-find-band.tsx", import.meta.url), "utf8");
-// Includes the cave-chat/* sheets: #3576 decomposed cave-chat.css and moved
-// rules like .cave-turn-found into them, but this list was not updated, so the
-// pins below were matching against files that no longer owned them.
-const chatCssSource = [
-  "cave-md",
-  "cave-composer",
-  "chat-list",
-  "calendar",
-  "cave-chat",
-  "cave-chat/activity",
-  "cave-chat/transcript",
-  "cave-chat/bubbles",
-  "cave-chat/session-chrome",
-  "cave-chat/auxiliary-surfaces",
-]
+// cave-chat.css is a facade of @imports; the runner's css-source-contract-hook
+// patches readFileSync so it yields the effective content of the split sheets.
+const chatCssSource = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 

--- a/src/components/chat-session-chrome.test.ts
+++ b/src/components/chat-session-chrome.test.ts
@@ -18,18 +18,11 @@ const contextRow = readFileSync(new URL("./chat-session-context-row.tsx", import
 const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 const emptyState = readFileSync(new URL("./chat-empty-state.tsx", import.meta.url), "utf8");
 const sidebar = readFileSync(new URL("./workspace-sidebar.tsx", import.meta.url), "utf8");
-// Includes the cave-chat/* sheets. #3576 decomposed cave-chat.css into them
-// and this list was never updated, so four pins here have been matching an
-// empty haystack ever since — green for the wrong reason.
-const styles = [
-  "cave-chat",
-  "chat-list",
-  "cave-chat/activity",
-  "cave-chat/transcript",
-  "cave-chat/bubbles",
-  "cave-chat/session-chrome",
-  "cave-chat/auxiliary-surfaces",
-]
+// Facade sheets resolve to their effective content: run-tests.mjs loads
+// scripts/css-source-contract-hook.cjs, which patches readFileSync so
+// cave-chat.css yields everything it @imports. Run these files through the
+// runner — invoking them bare skips the hook and fails for the wrong reason.
+const styles = ["cave-chat", "chat-list"]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 const shellNav = readFileSync(new URL("../styles/globals/shell-navigation.css", import.meta.url), "utf8");


### PR DESCRIPTION
Correcting a mistake I merged in #4131.

## What I got wrong

#4131 widened the CSS sheet lists in `chat-session-chrome.test.ts` and `chat-router-switching.test.ts`, with comments claiming #3576 had left them stale — that five pins were *"matching an empty haystack"* and *"green for the wrong reason"*.

That is false. The lists were correct all along.

`run-tests.mjs` loads `scripts/css-source-contract-hook.cjs` via `--require` for every test outside `RAW_SOURCE_SCANNER_TESTS`. The hook patches `fs.readFileSync` so that a **facade** stylesheet — `cave-chat.css` is nothing but `@import` lines — transparently yields the effective content of everything it imports. So `readFileSync("cave-chat.css")` already returns `activity.css`, `transcript.css` and the rest.

The failures I chased came from invoking the test files **bare**, which skips the hook.

## The proof

Run in a pristine detached worktree at `2e0d7426f`, so shared-checkout contamination is excluded:

```
node --experimental-strip-types <file>                        -> exit 1, 5 pass / 4 fail
node --require ...css-source-contract-hook.cjs ... <file>     -> exit 0, 9 pass / 0 fail
pnpm test:app in that worktree                                -> green, 1006 files
```

## What this PR does

Restores both lists to their originals and replaces the false comments with an accurate one: these assertions get their content through the facade hook, so run them through the runner — invoking them bare fails for the wrong reason.

**The find-band pins from #4131 are untouched** — the widened `</header> … <ChatSessionContextRow` window, the band-ordering assertion, and the find placement / count / aria / Esc-Enter updates all stay, because those *were* genuinely required by the new markup.

`pnpm test:app` is green at 1008 files with the lists restored, which is itself the proof the widening was never doing any work.

Root-cause investigation recorded in `cave-b0jof` (closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)