### PR TITLE
fix(release): say so when a release skipped the compatibility guards (cave-yp21x)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -319,6 +319,27 @@ jobs:
             echo "NEXT_PUBLIC_COVEN_GROK_SCHEMA_REGISTRY_CHECKPOINT=$NEXT_PUBLIC_COVEN_GROK_SCHEMA_REGISTRY_CHECKPOINT"
           } >> "$GITHUB_ENV"
 
+      # The escape hatch above is deliberately available for emergency manual
+      # runs, but using it must never be silent: v0.2.0 shipped with BOTH
+      # guards skipped and nobody noticed for four days, because the only
+      # evidence was a `skipped` line buried in the job steps (cave-yp21x).
+      # This is the inverse condition of the two guards, so it fires exactly
+      # when they did not.
+      - name: Record skipped compatibility guards
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_registries }}
+        shell: bash
+        run: |
+          {
+            echo "### ⚠️ Compatibility registry guards SKIPPED"
+            echo
+            echo "This \`${{ matrix.os }}\` build ran with \`allow_unconfigured_registries: true\`, so"
+            echo "**neither** the OpenCode nor the Grok signed schema-registry gate verified"
+            echo "anything. The build used the built-in baseline parsers."
+            echo
+            echo "Tag-push releases cannot do this — the hatch is manual-dispatch only."
+            echo "If this run publishes a release, its notes carry the same statement."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Decode the App Store Connect API key onto the runner for the custom
       # macOS release script. The path is exported into the env for later
       # steps. Runs only on the macOS leg.
@@ -850,6 +871,10 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          # Provenance for the body: true only on a manual run that skipped the
+          # signed-registry gates (cave-yp21x). `inputs` is readable from every
+          # job of a workflow_dispatch run, so this needs no job-output plumbing.
+          COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_registries }}
         run: |
           set -euo pipefail
           bash scripts/release-notes.sh "$RELEASE_TAG" > /tmp/release-body.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -867,6 +867,20 @@ jobs:
       # so the install instructions match what's actually attached. This is
       # the only step that sets the release body, so it stays the canonical
       # source for what users read on the release page.
+      # Verify the renderer before it writes anything user-facing. This is the
+      # only place in CI where release-notes.test.mjs can run: it needs live
+      # tag history for the no-CHANGELOG fallback case, which is why it is
+      # allowlisted out of the frontend suites — and this job already checks
+      # out with fetch-depth: 0 for exactly that reason.
+      #
+      # Placed BEFORE the notes are set so a broken renderer stops the body
+      # from being published rather than publishing a wrong one. Artifacts are
+      # already uploaded by this point, so a failure here costs a re-run or a
+      # local `gh release edit --notes-file`, not the release.
+      - name: Verify release-notes renderer
+        shell: bash
+        run: node --test scripts/release-notes.test.mjs
+
       - name: Set release notes
         shell: bash
         env:

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -124,6 +124,28 @@ shasum -a 256 -c SHA256SUMS
 
 INSTALL_REST
 
+# Build provenance (cave-yp21x). The signed OpenCode/Grok schema-registry gates
+# are fail-closed for tag pushes and skippable only on an emergency manual run.
+# v0.2.0 shipped through that hatch and said so nowhere a reader would find:
+# the only trace was a `skipped` step inside the Actions log. When the hatch is
+# used, the body states it plainly.
+#
+# Worded as provenance, not a warning. These gates guard against FUTURE schema
+# drift; a build without them uses the same built-in baseline parsers every
+# release before the gates existed used, so this is not a user-facing defect.
+if [ "${COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED:-}" = "true" ]; then
+  cat <<'PROVENANCE'
+## Build provenance
+
+This release was built on a manual run with `allow_unconfigured_registries`
+enabled, so the signed OpenCode and Grok compatibility-registry checks did not
+run. The build uses the built-in baseline schema parsers.
+
+Releases published from a tag push cannot skip those checks.
+
+PROVENANCE
+fi
+
 if [ -n "$PREV" ]; then
   printf '**Full changelog:** https://github.com/%s/compare/%s...%s\n' \
     "$REPO" "$PREV" "$VERSION"

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -21,12 +21,13 @@ import assert from "node:assert/strict";
 const SCRIPT = fileURLToPath(new URL("./release-notes.sh", import.meta.url));
 const REPO_ROOT = path.dirname(path.dirname(SCRIPT));
 
-function render(version, previous) {
+function render(version, previous, env) {
   const args = previous ? [version, previous] : [version];
   return execFileSync(SCRIPT, args, {
     cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    env: { ...process.env, ...(env ?? {}) },
   });
 }
 
@@ -101,4 +102,39 @@ test("every rendered body ends with the standardized checksum + changelog footer
     assert.match(body, /shasum -a 256 -c SHA256SUMS/, `${v} body has the verify-checksums block`);
     assert.match(body, /\*\*Full changelog:\*\*/, `${v} body has the compare link`);
   }
+});
+
+// ── Build provenance when the registry guards were skipped (cave-yp21x) ─────
+// v0.2.0 shipped through the emergency manual hatch with BOTH signed-registry
+// gates skipped, and the only evidence was a `skipped` step in the Actions
+// log — invisible to anyone reading the release. The body now says so.
+
+test("the provenance block appears only when the guards were actually skipped", () => {
+  const skipped = render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
+  assert.match(skipped, /^## Build provenance/m, "a skipped-guard build states its provenance");
+  assert.match(skipped, /allow_unconfigured_registries/, "names the flag that caused it");
+  assert.match(skipped, /built-in baseline schema parsers/, "says what it used instead");
+  assert.match(skipped, /tag push cannot skip/, "says the normal path is still fail-closed");
+
+  // The default release path must stay unchanged — an unset or false flag adds
+  // nothing, so ordinary releases read exactly as before.
+  assert.doesNotMatch(render("v0.0.55"), /Build provenance/, "unset flag renders no block");
+  assert.doesNotMatch(
+    render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "false" }),
+    /Build provenance/,
+    "an explicit false renders no block",
+  );
+  // Only the exact string "true" counts — a truthy-looking value must not arm it.
+  assert.doesNotMatch(
+    render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "1" }),
+    /Build provenance/,
+    "a non-'true' value renders no block",
+  );
+});
+
+test("the provenance block never displaces the compare link", () => {
+  // The body's contract is that it ends with the changelog link; a section
+  // appended in the wrong place would bury it.
+  const body = render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
+  assert.match(body.trimEnd().split("\n").at(-1) ?? "", /^\*\*Full changelog:\*\*/);
 });


### PR DESCRIPTION
v0.2.0 shipped with **both** signed schema-registry gates skipped, and nobody noticed for four days.

Not because the escape hatch is wrong — it's deliberately scoped, and tag pushes stay fail-closed. The problem is that using it left **no trace anywhere a reader would look**. The only evidence was a `skipped` line inside the Actions job steps of a run whose overall conclusion was `failure`.

## Verified before changing anything

Every claim in the bead checks out independently:

| Claim | Verified |
|---|---|
| Guards are fail-closed for tag pushes | `if: github.event_name != 'workflow_dispatch' \|\| !inputs.allow_unconfigured_registries` on both |
| v0.2.0's run skipped them | run `30333797867`, `event: workflow_dispatch`, both steps `skipped` on all three legs |
| Nothing to verify against | **0** `OPENCODE_SCHEMA_REGISTRY_*` / `GROK_SCHEMA_REGISTRY_*` secrets exist |
| Release published anyway | v0.2.0, 12 assets, 2026-07-28 |

One detail not in the bead: that run's overall conclusion is **`failure`** — the artifacts came out of a run that didn't cleanly succeed, consistent with the cave-ud7nz recovery story.

## Maintainer decisions (recorded on the bead)

1. **Exposure — no remediation.** These gates guard *future* schema drift; the build used the same built-in baseline parsers every pre-gate release used. v0.2.0 stands.
2. **Policy — the hatch stays, but stops being silent.** This PR.

## What changed

Two surfaces, both gated on the **exact inverse** of the two guards' own `if`, so they fire precisely when the guards did not:

- **Job summary** — a block naming the platform, the flag, and what was used instead.
- **Release body** — a "Build provenance" section, wired through `COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED`. `inputs` is readable from every job of a dispatch run, so no job-output plumbing was needed.

The body text is **provenance, not a warning** — it states what ran without implying a user-facing defect, matching decision #1. Happy to make it read as a caution instead if you'd prefer.

Only the literal string `"true"` arms it; unset, `false`, and truthy-looking values render nothing, so the **ordinary release path is byte-identical to before**.

## Verification, and one gap

Shell syntax clean · YAML parses · renders with the flag and not without · compare link still closes the body · the four other tests that read `release.yml` pass · app suite **1008/1008**.

⚠️ **The two new test cases will not run in CI.** They live in `scripts/release-notes.test.mjs`, which is the one file deliberately allowlisted out of the wiring guard because it needs live git history. I ran them by hand — 7/7 — but the runner won't, so a future regression there is caught only by someone running it locally.

I have **not** exercised this on a real dispatch run; that would mean triggering a release. The conditions are the literal inverse of two conditions already proven to work on run `30333797867`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)