### PR TITLE
fix(ios): serialize thread snapshot writes and make the lifecycle flush durable (cave-2cpo)

### DIFF
--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import UserNotifications
 
 @main
@@ -83,9 +84,22 @@ struct CovenCaveApp: App {
                 // so it gets one cheap validation probe instead of blind trust.
                 .onChange(of: scenePhase) { _, phase in
                     // Leaving the foreground: flush any debounced thread
-                    // persistence synchronously so an in-flight write isn't
-                    // lost if the app is suspended or terminated.
-                    if phase != .active { app.flushThreads() }
+                    // persistence and WAIT for it, holding a background-task
+                    // assertion so the system grants time to finish (cave-2cpo).
+                    // The previous call was fire-and-forget: it returned the
+                    // instant the write task was spawned, so suspension could
+                    // freeze the process before the bytes landed — the comment
+                    // here claimed a durability the code never provided.
+                    if phase != .active {
+                        Task {
+                            let assertion = UIApplication.shared
+                                .beginBackgroundTask(withName: "cave.flushThreads")
+                            await app.flushThreadsAndWait()
+                            if assertion != .invalid {
+                                UIApplication.shared.endBackgroundTask(assertion)
+                            }
+                        }
+                    }
                     guard phase == .active, app.connection != nil else { return }
                     if app.connectionState != .connected,
                        app.connectionState != .checking {

--- a/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
+++ b/apps/ios/CovenCave/CovenCave/CovenCaveApp.swift
@@ -91,13 +91,23 @@ struct CovenCaveApp: App {
                     // freeze the process before the bytes landed — the comment
                     // here claimed a durability the code never provided.
                     if phase != .active {
-                        Task {
-                            let assertion = UIApplication.shared
-                                .beginBackgroundTask(withName: "cave.flushThreads")
-                            await app.flushThreadsAndWait()
-                            if assertion != .invalid {
+                        Task { @MainActor in
+                            // The assertion MUST be released on every path. If
+                            // background time runs out first the system kills
+                            // the app for over-holding it, so an expiration
+                            // handler releases it early; `defer` covers the
+                            // normal and cancelled paths. `release()` is
+                            // idempotent because both can fire.
+                            var assertion: UIBackgroundTaskIdentifier = .invalid
+                            func release() {
+                                guard assertion != .invalid else { return }
                                 UIApplication.shared.endBackgroundTask(assertion)
+                                assertion = .invalid
                             }
+                            assertion = UIApplication.shared
+                                .beginBackgroundTask(withName: "cave.flushThreads") { release() }
+                            defer { release() }
+                            await app.flushThreadsAndWait()
                         }
                     }
                     guard phase == .active, app.connection != nil else { return }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1850,6 +1850,15 @@ final class AppModel {
     /// Pending debounced thread-persist flush. Not observable state.
     @ObservationIgnored private var persistThreadsTask: Task<Void, Never>?
 
+    /// The in-flight snapshot write, kept separate from the debounce timer
+    /// above (cave-2cpo). Two things need it: a newer flush must be able to
+    /// supersede a stale write rather than race it, and a lifecycle caller must
+    /// be able to await durability. `ThreadSnapshotStore` is an actor, so two
+    /// saves can never interleave — but actors make no FIFO promise, so without
+    /// this the OLDER snapshot could still resume last and overwrite newer
+    /// state on disk.
+    @ObservationIgnored private var threadWriteTask: Task<Void, Never>?
+
     /// Guards against saving before the async `hydrateThreads()` restore has
     /// settled. Without it, a background/flush that fires before hydration
     /// publishes would snapshot the not-yet-hydrated (possibly empty) `threads`
@@ -1881,10 +1890,27 @@ final class AppModel {
         persistThreadsTask?.cancel()
         persistThreadsTask = nil
         let snapshots = threads.map(\.snapshot)
-        Task.detached(priority: .utility) { [threadStore] in
+        // Supersede, then chain (cave-2cpo). Cancelling lets `save`'s entry
+        // `checkCancellation` drop a write that has not started, and awaiting
+        // the superseded task before saving means writes land in CALL order —
+        // the actor alone only guarantees they do not overlap, not which one
+        // wins. Without both, a burst could leave the older snapshot on disk.
+        let previous = threadWriteTask
+        previous?.cancel()
+        threadWriteTask = Task.detached(priority: .utility) { [threadStore] in
+            _ = await previous?.value
             // Non-fatal: persistence is best-effort.
             try? await threadStore.save(snapshots)
         }
+    }
+
+    /// Flush and await the write. The scene-phase handler uses this when the
+    /// app leaves the foreground: `flushThreads()` alone returns the instant
+    /// the task is spawned, so the process could be suspended before the bytes
+    /// reach disk — which is exactly the durability the caller believed it had.
+    func flushThreadsAndWait() async {
+        flushThreads()
+        _ = await threadWriteTask?.value
     }
 
     /// One-shot restore at launch: load off-main via the store and publish the

--- a/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
+++ b/apps/ios/CovenCave/CovenCave/State/ChatThread.swift
@@ -65,6 +65,21 @@ extension DisplayMessage {
     /// that retry depends on.
     static func restored(from turn: ChatTurn, familiarId: String?) -> DisplayMessage {
         let role = Role(rawValue: turn.role) ?? .assistant
+        // Sub-expressions are hoisted out of the initializer call deliberately:
+        // inline, the two ternaries plus the nested flatMap/map closure pushed
+        // this literal past the type checker's time limit and the whole target
+        // failed to compile. Keep them as typed locals.
+        let metadata = turn.responseMetadata
+        let resolvedModel = metadata?.retryModel ?? turn.modelOverride
+        let overridesByFamiliar: [String: String]? = resolvedModel.flatMap { model in
+            familiarId.map { [$0: model] }
+        }
+        let activity: [ActivityStep]? = role == .assistant
+            ? ActivityFold.steps(fromTools: turn.tools)
+            : nil
+        // Argument order follows DisplayMessage's stored-property order —
+        // appliedControls is declared before requestedControls, and the
+        // memberwise initializer requires that order.
         return DisplayMessage(
             role: role,
             familiarId: role == .assistant ? familiarId : nil,
@@ -73,16 +88,13 @@ extension DisplayMessage {
             reasoningEffort: turn.reasoningEffort,
             responseSpeed: turn.responseSpeed,
             modelControls: turn.modelControls,
-            requestedControls: turn.responseMetadata?.requestedControls,
-            promptGuidanceControls: turn.responseMetadata?.promptGuidanceControls,
-            appliedControls: turn.responseMetadata?.appliedControls,
-            rejectedControlFamilies: turn.responseMetadata?.rejectedControlFamilies,
-            modelOverride: turn.responseMetadata?.retryModel ?? turn.modelOverride,
-            modelOverridesByFamiliar: (turn.responseMetadata?.retryModel ?? turn.modelOverride).flatMap { model in
-                familiarId.map { [$0: model] }
-            },
-            activity: role == .assistant
-                ? ActivityFold.steps(fromTools: turn.tools) : nil
+            appliedControls: metadata?.appliedControls,
+            requestedControls: metadata?.requestedControls,
+            promptGuidanceControls: metadata?.promptGuidanceControls,
+            rejectedControlFamilies: metadata?.rejectedControlFamilies,
+            modelOverride: resolvedModel,
+            modelOverridesByFamiliar: overridesByFamiliar,
+            activity: activity
         )
     }
 
@@ -112,9 +124,9 @@ extension DisplayMessage {
             reasoningEffort: message.reasoningEffort,
             responseSpeed: message.responseSpeed,
             modelControls: message.modelControls,
+            appliedControls: message.appliedControls,
             requestedControls: message.requestedControls,
             promptGuidanceControls: message.promptGuidanceControls,
-            appliedControls: message.appliedControls,
             rejectedControlFamilies: message.rejectedControlFamilies,
             modelOverride: message.modelOverride,
             modelOverridesByFamiliar: message.modelOverridesByFamiliar,

--- a/scripts/ios-thread-persist-durability.test.mjs
+++ b/scripts/ios-thread-persist-durability.test.mjs
@@ -92,6 +92,31 @@ assert.match(
   /endBackgroundTask/,
   "the assertion must be released or the app is killed for over-holding it",
 );
+// Review finding on PR #4135: releasing it on the happy path alone is not
+// enough. If background time expires first the system kills the app for
+// over-holding, and an early return or cancellation leaks it the same way — so
+// an expiration handler AND a defer are both required, with an idempotent
+// release because either can fire first.
+assert.match(
+  scenePhaseBlock,
+  /beginBackgroundTask\(withName: "[^"]+"\) \{ release\(\) \}/,
+  "an expiration handler must release the assertion when background time runs out",
+);
+assert.match(
+  scenePhaseBlock,
+  /defer \{ release\(\) \}/,
+  "a defer must release the assertion on the cancelled/early-return paths",
+);
+assert.match(
+  scenePhaseBlock,
+  /guard assertion != \.invalid else \{ return \}/,
+  "release() must be idempotent — the expiration handler and the defer can both fire",
+);
+assert.match(
+  scenePhaseBlock,
+  /Task \{ @MainActor in/,
+  "UIApplication calls must be explicitly main-actor isolated, not inherited by accident",
+);
 assert.ok(
   !/if phase != \.active \{ app\.flushThreads\(\) \}/.test(appEntry),
   "the old fire-and-forget lifecycle flush must not come back",

--- a/scripts/ios-thread-persist-durability.test.mjs
+++ b/scripts/ios-thread-persist-durability.test.mjs
@@ -1,0 +1,116 @@
+// Source pins for cave-2cpo — thread-snapshot write durability on iOS.
+//
+// PR #3456 shipped the debounced persistence but merged with both review
+// threads unresolved, leaving two defects that are invisible to CI because
+// apps/ios is not compiled by any required check:
+//
+//   1. flushThreads() spawned an UNTRACKED Task.detached, so a newer flush
+//      could not supersede a stale in-flight write. ThreadSnapshotStore is an
+//      actor — writes never interleave — but actors make no FIFO promise, so
+//      the OLDER snapshot could resume last and overwrite newer state.
+//   2. flushThreads() was documented and used as a SYNCHRONOUS lifecycle flush
+//      from the scenePhase handler, but returned the instant the task was
+//      spawned, so suspension could freeze the process before the bytes landed.
+//
+// These pin the contract rather than the implementation: a tracked write, a
+// chained (ordered) write, an awaitable flush, and a lifecycle caller that
+// actually waits while holding background time.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const appModel = fs.readFileSync(
+  path.join(root, "apps/ios/CovenCave/CovenCave/State/AppModel.swift"),
+  "utf8",
+);
+const appEntry = fs.readFileSync(
+  path.join(root, "apps/ios/CovenCave/CovenCave/CovenCaveApp.swift"),
+  "utf8",
+);
+const store = fs.readFileSync(
+  path.join(root, "apps/ios/CovenCave/CovenCave/State/ThreadSnapshotStore.swift"),
+  "utf8",
+);
+
+// ── 1. The write is tracked, not fire-and-forget ─────────────────────────────
+assert.match(
+  appModel,
+  /private var threadWriteTask: Task<Void, Never>\?/,
+  "the in-flight snapshot write must be held so a newer flush can supersede it",
+);
+const flushBody = appModel.slice(
+  appModel.indexOf("func flushThreads()"),
+  appModel.indexOf("func flushThreadsAndWait()"),
+);
+assert.ok(flushBody.length > 0, "flushThreads and flushThreadsAndWait both exist");
+assert.match(
+  flushBody,
+  /threadWriteTask = Task\.detached/,
+  "the detached write must be assigned to threadWriteTask, not discarded",
+);
+
+// ── 2. Writes apply in call order ────────────────────────────────────────────
+// Cancelling alone is not enough: save() only checks cancellation on entry, so
+// a write that already started still lands. Awaiting the superseded task is
+// what forces call-order.
+assert.match(flushBody, /previous\?\.cancel\(\)/, "a superseded write is cancelled");
+assert.match(
+  flushBody,
+  /_ = await previous\?\.value/,
+  "the new write awaits the superseded one so the newest snapshot lands last",
+);
+
+// ── 3. Lifecycle durability is actually awaitable ────────────────────────────
+assert.match(
+  appModel,
+  /func flushThreadsAndWait\(\) async \{[\s\S]*?_ = await threadWriteTask\?\.value/,
+  "flushThreadsAndWait must await the write, not just spawn it",
+);
+
+// ── 4. The scene-phase caller waits, and holds background time ───────────────
+// Awaiting without an assertion buys nothing — the process can still be
+// suspended mid-write, which is the exact failure this bead describes.
+const scenePhaseBlock = appEntry.slice(
+  appEntry.indexOf("if phase != .active"),
+  appEntry.indexOf("guard phase == .active"),
+);
+assert.ok(scenePhaseBlock.length > 0, "the leaving-foreground branch is present");
+assert.match(
+  scenePhaseBlock,
+  /await app\.flushThreadsAndWait\(\)/,
+  "leaving the foreground must AWAIT the flush",
+);
+assert.match(
+  scenePhaseBlock,
+  /beginBackgroundTask/,
+  "the flush must hold a background-task assertion so the system grants time",
+);
+assert.match(
+  scenePhaseBlock,
+  /endBackgroundTask/,
+  "the assertion must be released or the app is killed for over-holding it",
+);
+assert.ok(
+  !/if phase != \.active \{ app\.flushThreads\(\) \}/.test(appEntry),
+  "the old fire-and-forget lifecycle flush must not come back",
+);
+
+// ── 5. The store's own guarantees, which the above relies on ─────────────────
+assert.match(store, /actor ThreadSnapshotStore/, "the store serializes writes as an actor");
+assert.match(
+  store,
+  /func save\([\s\S]*?try Task\.checkCancellation\(\)/,
+  "save() checks cancellation on entry so a superseded write can be dropped",
+);
+
+// ── 6. Wired into CI ─────────────────────────────────────────────────────────
+const runner = fs.readFileSync(path.join(root, "scripts/run-tests.mjs"), "utf8");
+assert.match(
+  runner,
+  /"scripts\/ios-thread-persist-durability\.test\.mjs"/,
+  "this pin must run in CI — apps/ios is not compiled, so source pins are the only gate",
+);
+
+console.log("ios-thread-persist-durability: all pins hold");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1364,6 +1364,7 @@ export const SUITES = {
     "scripts/ios-ipad-split-tasks.test.mjs",
     "scripts/ios-ipad-split-chats.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",
+    "scripts/ios-thread-persist-durability.test.mjs",
     "scripts/ios-thread-rename.test.mjs",
     "scripts/ios-archive-threads.test.mjs",
     "scripts/ios-pin-threads.test.mjs",


### PR DESCRIPTION
## Summary

PR #3456 merged **with both of its review threads unresolved**, leaving two real defects in iOS thread persistence. `apps/ios` is compiled by no required check, so nothing has caught them since 2026-07-19.

### 1. Lost-write race

`flushThreads()` spawned an **untracked** `Task.detached`, so a newer flush could not supersede a stale in-flight write. `ThreadSnapshotStore` is an `actor`, so writes never interleave — but actors make **no FIFO promise**, so the *older* snapshot could resume last and overwrite newer state on disk. Silent user-visible data loss, not a perf nit.

The write is now held in `threadWriteTask`; a new flush cancels the previous one **and awaits it** before saving. Cancelling alone is insufficient — `save()` only checks cancellation on entry, so a write that already started still lands. Awaiting the superseded task is what forces call-order.

### 2. The flush was not synchronous

`flushThreads()` was documented and used as a durability flush from the `scenePhase` handler, but returned the instant the task was spawned. Added `flushThreadsAndWait()`, and the scene-phase caller now awaits it while holding a `beginBackgroundTask` assertion — awaiting *without* one buys nothing, because the process can still be suspended mid-write.

## Also: this repairs `main`'s iOS build

`main` did not compile. Verified on a clean baseline worktree with zero changes from me — `BUILD FAILED`, same two errors. Both came from **PR #4097**, merged the same day:

- `DisplayMessage`'s memberwise init was called with `requestedControls` before `appliedControls` at **both** call sites, while the properties are declared `appliedControls` first
- one oversized init literal — two ternaries plus a nested `flatMap`/`map` closure inline — exceeded the type checker's time limit

Argument order corrected at both sites; sub-expressions hoisted into typed locals. **This unblocks iOS compilation for everyone**, so merging has a side effect beyond the `cave-2cpo` fix. Flagging because it touches another session's just-merged code.

## Verification

```
xcodebuild -scheme CovenCave -destination 'iOS Simulator,iPhone 16 Pro'
  this branch  → BUILD SUCCEEDED
  origin/main  → BUILD FAILED (the two errors above)
```

New pin `scripts/ios-thread-persist-durability.test.mjs`, wired into CI (1392 files). It pins the *contract* — tracked write, chained write, awaitable flush, and a lifecycle caller that waits while holding background time — not the implementation. **Proven non-vacuous**: reverting both halves of the fix fails with *"the detached write must be assigned to threadWriteTask, not discarded"*.

Gates: `test:app` **1008 files** (byte-identical to the `origin/main` baseline), `typecheck`, `check:tests-wired` 1392, `git diff --check`.

> A local suite failure on `workspace-canonical-memory-navigation-behavior.test.tsx` turned out to be my own environment — I had not run `pnpm install` in this worktree, so `vitest` was absent. Not a regression; the corrected run matches the baseline exactly.

Bead: `cave-2cpo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)