### PR TITLE
fix(chat): report Hermes' missing tool activity as a notice, not an error (cave-fig9w)

### DIFF
--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -251,6 +251,37 @@ assert.match(
   "the CLI fallback must disclose that structured tool activity is unavailable and how to enable it — as an informational notice, not an error: the turn itself runs fine and only its tool bubbles are missing",
 );
 
+/**
+ * Exact source of the call that starts at `needle`, located by paren-depth
+ * scan rather than a length bound. A magic `{0,N}` window silently truncates
+ * once a call grows past it, which would drop the very status argument these
+ * assertions exist to read. An unbalanced scan returns null and fails the
+ * assertion loudly instead.
+ */
+function callSource(source: string, start: number): string | null {
+  let depth = 0;
+  for (let i = source.indexOf("(", start); i >= 0 && i < source.length; i++) {
+    if (source[i] === "(") depth += 1;
+    else if (source[i] === ")") {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+/** Every `pushProgress` call carrying one diagnostic id. A runtime may emit
+ *  the same id from more than one branch, and checking only the first would
+ *  leave the rest free to drift back to an error. */
+function progressCalls(source: string, id: string): (string | null)[] {
+  const calls: (string | null)[] = [];
+  const re = new RegExp(`pushProgress\\(\\s*"${id}",`, "g");
+  for (let match = re.exec(source); match; match = re.exec(source)) {
+    calls.push(callSource(source, match.index));
+  }
+  return calls;
+}
+
 // Every runtime that degrades to text-only chat reports the same fact, so they
 // must report it at the same severity. A degradation row styled as an error
 // paints a red step and an "N issues" count onto a turn that never failed.
@@ -261,15 +292,34 @@ for (const [id, label] of [
   ["grok-compatibility", "Grok Build"],
   ["codex-compatibility", "Codex"],
 ] as const) {
-  const call = new RegExp(`pushProgress\\(\\s*"${id}",[\\s\\S]{0,400}?\\)\\;`);
-  const match = call.exec(chatRoute);
-  assert.ok(match, `${label}'s tool-activity diagnostic must still be emitted`);
-  assert.equal(
-    /"error"/.test(match[0]),
-    false,
-    `${label}'s tool-activity degradation must be informational, not an error`,
-  );
+  const calls = progressCalls(chatRoute, id);
+  assert.ok(calls.length > 0, `${label}'s tool-activity diagnostic must still be emitted`);
+  for (const call of calls) {
+    assert.ok(call, `${label}'s tool-activity diagnostic must be a balanced call expression`);
+    assert.equal(
+      /"error"/.test(call),
+      false,
+      `${label}'s tool-activity degradation must be informational, not an error`,
+    );
+  }
 }
+
+// Copilot's protocol diagnostic is the one member of that family emitted
+// through `push({ kind: "progress" })` rather than pushProgress, so the loop
+// above cannot see it. Pin it on its own shape.
+const copilotDiagnostic =
+  /reportCopilotProtocolDiagnostic = [\s\S]*?push\(\{([\s\S]*?)\}\);/.exec(chatRoute);
+assert.ok(copilotDiagnostic, "Copilot's protocol diagnostic must still be emitted");
+assert.match(
+  copilotDiagnostic[1],
+  /status: "notice"/,
+  "Copilot protocol drift must be presented as a neutral notice",
+);
+assert.doesNotMatch(
+  copilotDiagnostic[1],
+  /status: "error"/,
+  "Copilot protocol drift must not regress to an error",
+);
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/harness-routing-tool-events.test.ts
+++ b/src/app/api/chat/send/harness-routing-tool-events.test.ts
@@ -247,9 +247,29 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /hermesDirect && !hermesApi[\s\S]*?Hermes tool activity unavailable[\s\S]*?HERMES_API_URL/,
-  "the CLI fallback must disclose that structured tool activity is unavailable and how to enable it",
+  /hermesDirect && !hermesApi[\s\S]*?"Hermes tool activity unavailable[^"]*",\s*"notice",\s*"Configure valid HERMES_API_URL/,
+  "the CLI fallback must disclose that structured tool activity is unavailable and how to enable it — as an informational notice, not an error: the turn itself runs fine and only its tool bubbles are missing",
 );
+
+// Every runtime that degrades to text-only chat reports the same fact, so they
+// must report it at the same severity. A degradation row styled as an error
+// paints a red step and an "N issues" count onto a turn that never failed.
+for (const [id, label] of [
+  ["hermes-tool-activity", "Hermes"],
+  ["claude-runtime-compatibility", "Claude"],
+  ["opencode-compatibility", "OpenCode"],
+  ["grok-compatibility", "Grok Build"],
+  ["codex-compatibility", "Codex"],
+] as const) {
+  const call = new RegExp(`pushProgress\\(\\s*"${id}",[\\s\\S]{0,400}?\\)\\;`);
+  const match = call.exec(chatRoute);
+  assert.ok(match, `${label}'s tool-activity diagnostic must still be emitted`);
+  assert.equal(
+    /"error"/.test(match[0]),
+    false,
+    `${label}'s tool-activity degradation must be informational, not an error`,
+  );
+}
 
 assert.match(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -2338,10 +2338,18 @@ export async function POST(req: Request) {
         // Do not fabricate tool bubbles from the CLI's presentation layer.
         // This gives the operator an actionable, privacy-safe degradation
         // notice while preserving normal CLI chat output.
+        //
+        // `notice`, not `error`: nothing failed here. The turn runs normally
+        // and only its tool bubbles are missing, which is exactly what every
+        // peer runtime's "continuing without tool activity" row reports
+        // (claude-runtime-compatibility, opencode-compatibility,
+        // grok-compatibility, codex-compatibility, copilot-protocol-*). Hermes
+        // was the lone one styled as a failure, so every CLI-mode Hermes turn
+        // opened with a red row and a "1 issue" count against a healthy run.
         pushProgress(
           "hermes-tool-activity",
-          "Hermes tool activity unavailable",
-          "error",
+          "Hermes tool activity unavailable; chat text will continue without tool bubbles",
+          "notice",
           "Configure valid HERMES_API_URL and HERMES_API_KEY values for the versioned structured event transport.",
         );
       }


### PR DESCRIPTION
## What

Every CLI-mode Hermes turn opened with a **red** progress row — *"Hermes tool activity unavailable"* — and an **"N issues"** count, on a turn where nothing had failed.

The Hermes CLI does not expose a versioned tool-event protocol, so Cave deliberately declines to fabricate tool bubbles from its presentation layer and discloses that instead. That is a degradation notice, not a failure.

## Why it was the odd one out

Every peer runtime already reports the same fact at the same severity:

| diagnostic | status |
| --- | --- |
| `claude-runtime-compatibility` | `notice` |
| `opencode-compatibility` | `notice` |
| `grok-compatibility` | `notice` |
| `codex-compatibility` | `notice` |
| `copilot-protocol-*` | `notice` |
| **`hermes-tool-activity`** | **`error`** ← |

`notice` already has its own rendering — `ph:info` glyph, `--text-secondary`, an "N notices" counter — so the row stays visible and keeps its actionable detail; it just stops claiming the run broke.

## Changes

- `hermes-tool-activity` → `"notice"`, label extended with the peers' phrasing (`…; chat text will continue without tool bubbles`). The `HERMES_API_URL` / `HERMES_API_KEY` remediation detail is unchanged.
- The existing source pin matched on label text alone, so it would have stayed green either way — it now requires the `"notice"` status.
- New assertion loop over the whole "continuing without tool activity" family, so the next runtime added cannot drift back to `error`.

## Verification

`harness-routing-tool-events.test.ts` and `route-hermes-availability.integration.test.ts` both pass. Confirmed the new loop actually bites (it reads each `pushProgress` call body and rejects `"error"`), rather than passing vacuously.

Closes cave-fig9w

🤖 Generated with [Claude Code](https://claude.com/claude-code)