### PR TITLE
perf(projects): dedupe and sort once per fetch, not once per consumer (cave-k0gf)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -516,6 +516,7 @@ export const SUITES = {
     "src/lib/project-scope.test.ts",
     "src/lib/use-projects.test.ts",
     "src/lib/use-projects-race.test.ts",
+    "src/lib/use-projects-normalize.test.ts",
     "src/lib/use-projects-scope-transition.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/components/calendar-agenda-redesign.test.ts",

--- a/src/lib/use-projects-cache.ts
+++ b/src/lib/use-projects-cache.ts
@@ -1,4 +1,4 @@
-import type { CaveProject } from "./cave-projects-types.ts";
+import { sortProjectsAlphabetically, type CaveProject } from "./cave-projects-types.ts";
 import { createSwrCache } from "./swr-cache.ts";
 
 export type ProjectsPayload = { ok?: boolean; projects?: CaveProject[]; error?: string };
@@ -30,7 +30,28 @@ async function requestProjects(familiarId: string | null): Promise<ProjectsPaylo
   // Thrown (not returned) so HTTP failures are never cached — swr-cache only
   // stores resolutions — and every coalesced caller sees the same error.
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
-  return (await res.json()) as ProjectsPayload;
+  const payload = (await res.json()) as ProjectsPayload;
+  return normalizePayload(payload);
+}
+
+/**
+ * Dedupe + sort ONCE per fetch, here, rather than once per consumer.
+ *
+ * `useProjects()` has 20+ call sites and the cache already collapses their
+ * mount burst onto a single request — but each consumer was still running
+ * `sortProjectsAlphabetically` over the whole list when that one response
+ * resolved, so the O(n log n) ran once per consumer for identical input.
+ * Normalizing inside the cache also means every coalesced caller receives the
+ * SAME array instance, which keeps referential equality stable for memoized
+ * consumers instead of handing each one a fresh copy.
+ *
+ * Safe to share because nothing mutates the list in place: the only in-place
+ * sort over projects (comux-projects) builds its own objects from sessions.
+ */
+function normalizePayload(payload: ProjectsPayload): ProjectsPayload {
+  if (payload.ok === false) return payload;
+  const projects = Array.isArray(payload.projects) ? payload.projects : [];
+  return { ...payload, projects: sortProjectsAlphabetically(projects) };
 }
 
 function generationKey(familiarId: string | null): string {

--- a/src/lib/use-projects-normalize.test.ts
+++ b/src/lib/use-projects-normalize.test.ts
@@ -1,0 +1,167 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+
+import type { CaveProject } from "./cave-projects-types.ts";
+import { fetchProjectsForTests, resetProjectsCacheForTests } from "./use-projects-cache.ts";
+
+/**
+ * cave-k0gf: dedupe + sort belong to the cache, not to each consumer.
+ *
+ * The cache already collapses the mount burst onto one request, but every one
+ * of the 20+ useProjects() call sites used to re-run sortProjectsAlphabetically
+ * over that single response. These tests pin what the cache now guarantees —
+ * an already-normalized payload — plus a source pin that the hook no longer
+ * repeats the work on the fetch path.
+ */
+
+function project(over: Partial<CaveProject> & { id: string; root: string }): CaveProject {
+  return {
+    name: over.name ?? over.id,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as CaveProject;
+}
+
+/** Serve one canned payload, counting how many requests actually go out. */
+function stubFetch(payload: unknown): { restore: () => void; calls: () => number } {
+  const original = globalThis.fetch;
+  let calls = 0;
+  globalThis.fetch = (async () => {
+    calls += 1;
+    return { ok: true, status: 200, json: async () => payload } as unknown as Response;
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    calls: () => calls,
+  };
+}
+
+// Referential stability is a property of the SWR cache storing one resolution,
+// not of this change — pinned because moving normalization into the cache must
+// not accidentally hand each consumer a fresh copy.
+test("coalesced consumers share one payload instance", async () => {
+  resetProjectsCacheForTests();
+  const stub = stubFetch({
+    ok: true,
+    projects: [
+      project({ id: "zeta", root: "/z" }),
+      project({ id: "alpha", root: "/a" }),
+      project({ id: "mid", root: "/m" }),
+    ],
+  });
+  try {
+    // Stand in for a surface mount: many consumers asking at once.
+    const results = await Promise.all(
+      Array.from({ length: 12 }, () => fetchProjectsForTests("cody")),
+    );
+
+    assert.equal(stub.calls(), 1, "the burst still collapses onto one request");
+
+    const first = results[0].projects;
+    assert.ok(first, "the payload carries projects");
+    for (const [i, r] of results.entries()) {
+      assert.equal(
+        r.projects,
+        first,
+        `consumer ${i} got the very same array instance — nobody re-materialised it`,
+      );
+    }
+  } finally {
+    stub.restore();
+  }
+});
+
+test("the payload arrives already sorted and deduped", async () => {
+  resetProjectsCacheForTests();
+  const stub = stubFetch({
+    ok: true,
+    projects: [
+      project({ id: "zeta", name: "Zeta", root: "/z" }),
+      project({ id: "alpha", name: "Alpha", root: "/a" }),
+      // Same root as zeta but newer: dedupe keeps the newer record.
+      project({ id: "zeta-new", name: "Zeta", root: "/z", updatedAt: "2026-06-01T00:00:00.000Z" }),
+    ],
+  });
+  try {
+    const { projects } = await fetchProjectsForTests("cody");
+    assert.deepEqual(
+      projects?.map((p) => p.name),
+      ["Alpha", "Zeta"],
+      "sorted alphabetically with the duplicate root collapsed",
+    );
+    assert.equal(projects?.[1].id, "zeta-new", "dedupe kept the newer record for /z");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a non-array projects field normalizes to an empty list rather than throwing", async () => {
+  resetProjectsCacheForTests();
+  const stub = stubFetch({ ok: true });
+  try {
+    const { projects } = await fetchProjectsForTests("cody");
+    assert.deepEqual(projects, [], "missing projects becomes []");
+  } finally {
+    stub.restore();
+  }
+});
+
+// An error payload must pass through untouched: the hook reads `.error` from
+// it, and inventing an empty projects array would look like "no projects".
+test("an error payload is not rewritten", async () => {
+  resetProjectsCacheForTests();
+  const stub = stubFetch({ ok: false, error: "nope" });
+  try {
+    const payload = await fetchProjectsForTests("cody");
+    assert.equal(payload.ok, false);
+    assert.equal(payload.error, "nope");
+    assert.equal(payload.projects, undefined, "no fabricated empty list on the error path");
+  } finally {
+    stub.restore();
+  }
+});
+
+test("a fresh scope normalizes its own payload", async () => {
+  resetProjectsCacheForTests();
+  const stub = stubFetch({ ok: true, projects: [project({ id: "b", name: "B", root: "/b" }), project({ id: "a", name: "A", root: "/a" })] });
+  try {
+    const cody = await fetchProjectsForTests("cody");
+    const sage = await fetchProjectsForTests("sage");
+    assert.equal(stub.calls(), 2, "different scopes are different cache keys");
+    assert.deepEqual(cody.projects?.map((p) => p.name), ["A", "B"]);
+    assert.deepEqual(sage.projects?.map((p) => p.name), ["A", "B"]);
+    assert.notEqual(cody.projects, sage.projects, "each scope owns its own array");
+  } finally {
+    stub.restore();
+  }
+});
+
+// The behavioural tests above prove the CACHE normalizes. This proves the
+// consumer side no longer repeats it: the hook's fetch path must hand the
+// cached array straight to state. Source-pinned because "how many times did a
+// pure function run" is not observable from outside without instrumenting it.
+const hook = readFileSync(new URL("./use-projects.ts", import.meta.url), "utf8");
+const loadBody = hook.match(/const load = useCallback\([\s\S]*?\n  \}, \[/)?.[0] ?? "";
+assert.ok(loadBody, "found the hook's load() body");
+assert.match(
+  loadBody,
+  /setProjects\(Array\.isArray\(data\.projects\) \? data\.projects : \[\]\)/,
+  "the fetch path stores the cached array as-is",
+);
+assert.doesNotMatch(
+  loadBody,
+  /sortProjectsAlphabetically/,
+  "and does NOT re-sort it — that is the cache's job now (cave-k0gf)",
+);
+// The post-mutation re-sorts must survive: a locally inserted or edited
+// project has not been through the cache and still needs ordering.
+assert.ok(
+  (hook.match(/sortProjectsAlphabetically\(/g) ?? []).length >= 5,
+  "local create/update/delete paths still re-sort",
+);
+
+console.log("use-projects-normalize.test.ts: ok");

--- a/src/lib/use-projects.test.ts
+++ b/src/lib/use-projects.test.ts
@@ -126,9 +126,12 @@ assert.match(
   /const scopeKey = projectScopeKey\(familiarId\);[\s\S]*const \[loadedScopeKey, setLoadedScopeKey\] = useState<string \| null>\(null\);[\s\S]*const loadedSuccessfully = enabled && isCurrentProjectScope\(loadedScopeKey, familiarId\);/,
   "useProjects reports success only when the response belongs to the current familiar scope",
 );
+// The payload arrives already deduped + sorted from the cache (cave-k0gf), so
+// the success branch stores it as-is. What this pin guards is unchanged: only
+// a successful payload marks the scope loaded — an error must not.
 assert.match(
   source,
-  /if \(data\.ok === false\) \{[\s\S]*setError\(data\.error \?\? "Failed to load projects"\);[\s\S]*\} else \{[\s\S]*setProjects\(sortProjectsAlphabetically\(Array\.isArray\(data\.projects\) \? data\.projects : \[\]\)\);[\s\S]*setLoadedScopeKey\(scopeKey\);[\s\S]*\}/,
+  /if \(data\.ok === false\) \{[\s\S]*setError\(data\.error \?\? "Failed to load projects"\);[\s\S]*\} else \{[\s\S]*setProjects\(Array\.isArray\(data\.projects\) \? data\.projects : \[\]\);[\s\S]*setLoadedScopeKey\(scopeKey\);[\s\S]*\}/,
   "a scope becomes ready only after its own successful payload, not an error or another scope's payload",
 );
 assert.match(

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -89,7 +89,9 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
       if (data.ok === false) {
         setError(data.error ?? "Failed to load projects");
       } else {
-        setProjects(sortProjectsAlphabetically(Array.isArray(data.projects) ? data.projects : []));
+        // Already deduped + sorted by the cache (cave-k0gf), once per fetch
+        // rather than once per consumer — do not re-run it here.
+        setProjects(Array.isArray(data.projects) ? data.projects : []);
         setLoadedScopeKey(scopeKey);
       }
     } catch (err) {


### PR DESCRIPTION
Picked up from the sweep handoff another session left on `cave-k0gf`, which said to start from the four residual items rather than from "add a cache" — that part already landed.

## Re-verifying the residuals first was the valuable step

Two of the four no longer have a premise on `main`:

| item | state |
|---|---|
| dedupe/sort rerunning per consumer | **real** — fixed here |
| per-selection abort in `projects-view.tsx` (`boardAbortRef`) | **stale** — no `boardAbortRef`, and no abort logic at all in that file |
| virtualize picker + hub lists | still open, not addressed here |
| memoize `lastActiveByRootKey` | **stale** — the symbol does not exist anywhere in `src` |

All four findings are recorded on the bead so the next person doesn't re-derive them.

## The fix

The cache already collapses a mount burst onto one request, but each consumer then re-ran `sortProjectsAlphabetically` over that single response — **24 call sites across 22 files** doing the same dedupe and O(n log n) sort on identical input.

Normalization moves into `use-projects-cache.ts`: once per fetch, and the hook stores the cached array as-is. Coalesced callers now also share one array instance rather than each materialising a copy, which keeps referential equality stable for memoized consumers.

**Checked before relying on it:** sharing one array is only safe if nothing mutates it in place. The one in-place sort over projects (`comux-projects`) builds its own objects from sessions and never sees the hook's array.

Two things deliberately left alone:

- **The error path.** An `ok === false` payload passes through untouched — fabricating an empty `projects` array there would read as "no projects" rather than "the request failed".
- **The five post-mutation re-sorts** in the hook. A locally created or edited project hasn't been through the cache and still needs ordering.

## Verification

- `pnpm test:app` — 1010 files. `tsc --noEmit` clean.
- Five new behavioural tests on the cache: sorted+deduped payload, shared instance across a 12-consumer burst, non-array input, error passthrough, per-scope isolation. I confirmed they catch a regression by reverting the normalization — 3 of 5 fail.
- One of those tests originally claimed more than it proved (referential identity comes from the SWR cache, not from this change), so it's renamed to what it actually asserts, and a source pin covers the consumer side instead.
- One existing pin in `use-projects.test.ts` encoded the old line verbatim; updated, with its intent (only a successful payload marks a scope loaded) unchanged.

This unblocks `cave-ow9f` (frecency ranking in project pickers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)