### PR TITLE
style(shell): float the sidebar edge

### DIFF
--- a/docs/superpowers/plans/2026-07-31-dia-sidebar-edge.md
+++ b/docs/superpowers/plans/2026-07-31-dia-sidebar-edge.md
@@ -1,0 +1,70 @@
+# Dia-Style Sidebar Edge Implementation Plan
+
+**Goal:** Give the expanded desktop sidebar and hover-peek one inset, rounded,
+token-driven floating silhouette while preserving the compact rail, vertical
+scrolling, mobile drawer, and shell behavior.
+
+**Architecture:** Keep navigation components and state unchanged. Implement the
+desktop treatment in the owning shell stylesheet, share it across non-rail
+states, and pin the resulting state matrix with one wired source-contract test.
+
+## Task 1: Pin the state contract
+
+**Files:**
+
+- Create `src/components/sidebar-floating-edge.test.ts`.
+- Modify `scripts/run-tests.mjs`.
+
+- [x] Add a failing source contract for the shared desktop silhouette.
+- [x] Require the same inset for expanded and hover-peek states.
+- [x] Require `overflow-x: hidden` and `overflow-y: auto` so rounded clipping
+  cannot disable long-list scrolling.
+- [x] Require the collapsed rail to remain outside the floating selector.
+- [x] Require the detail canvas to lose its competing rounded gutter.
+- [x] Require the responsive stylesheet to remain unchanged for this feature.
+- [x] Wire the test into the app suite and verify the initial red result.
+
+## Task 2: Implement the minimal CSS
+
+**File:** `src/styles/globals/shell-navigation.css`
+
+- [x] Remove the detail pane's leading radius and inset margin.
+- [x] Return `.shell-detail-panel` to `--bg-base`.
+- [x] Keep hover-peek absolute positioning in its existing base rule.
+- [x] Add a desktop-only shared selector for every non-rail `.shell-nav` direct
+  child of `.shell-nav-panel`.
+- [x] Apply the token border, panel radius, derived shadow, horizontal clipping,
+  vertical scrolling, and shared grid-aligned margin in that selector.
+- [x] Keep expanded navigation in flex layout with width reduced by the shared
+  inline margins; rely on existing flex stretch for height.
+- [x] Avoid a mobile override because the new rule is desktop-only.
+
+## Task 3: Resolve review feedback
+
+- [x] Replace the initial `overflow: hidden` shorthand with axis-specific
+  overflow declarations.
+- [x] Update the contract so it protects vertical scrolling rather than pinning
+  the buggy shorthand.
+- [x] Reply to both review threads with the fix and verification evidence.
+- [x] Resolve only the addressed threads.
+
+## Task 4: Verify and deliver
+
+- [x] Run the focused sidebar contract.
+- [x] Run `pnpm lint`.
+- [x] Run `pnpm typecheck`.
+- [x] Run `pnpm check:tests-wired`.
+- [x] Run the complete `pnpm test:app` suite.
+- [x] Run `pnpm build` and enforce bundle/standalone budgets.
+- [x] Run `git diff --check`.
+- [x] Commit the scoped implementation and documentation.
+- [ ] Push the exact verified head and require CI to pass.
+- [ ] Re-audit review conversations, squash-merge the protected PR, close the
+  Bead, and remove the short-lived branch/worktree.
+
+## Expected shipped diff
+
+- `src/styles/globals/shell-navigation.css`
+- `src/components/sidebar-floating-edge.test.ts`
+- `scripts/run-tests.mjs`
+- this implementation plan and its matching design spec

--- a/docs/superpowers/specs/2026-07-31-dia-sidebar-edge-design.md
+++ b/docs/superpowers/specs/2026-07-31-dia-sidebar-edge-design.md
@@ -1,0 +1,88 @@
+# Dia-Style Sidebar Edge Design
+
+**Bead:** `cave-9q0v`
+
+## Objective
+
+Make Coven Cave's expanded desktop sidebar and collapsed hover-peek read as one
+inset floating surface, following the supplied Dia-style reference, without
+changing navigation state, routing, widths, resize persistence, or mobile
+behavior.
+
+## Owning seam
+
+The behavior belongs in `src/styles/globals/shell-navigation.css`. Both the
+expanded sidebar and hover-peek already render as direct `.shell-nav` children
+of `.shell-nav-panel`; their distinction is layout geometry, not component
+ownership. A focused source-contract test pins the shared silhouette and state
+differences, and `scripts/run-tests.mjs` wires that contract into `test:app`.
+
+No React component or responsive stylesheet needs to change.
+
+## Selected design
+
+At desktop widths (`min-width: 1024px`), every non-rail sidebar surface owns
+the same visual treatment:
+
+- one token-driven hairline border;
+- `--radius-panel` corners;
+- restrained elevation derived from `--shadow-color`;
+- horizontal clipping at the rounded edge;
+- preserved `overflow-y: auto` for long navigation content;
+- the same grid-aligned inset around expanded and hover-peek states.
+
+The expanded sidebar remains in normal flex layout and consumes its existing
+resizable allocation. Its width is reduced by the shared inline margins; flex
+stretch continues to provide full available height. The hover-peek remains
+absolutely positioned over content and gets the same inset through that shared
+margin rule.
+
+The collapsed `.shell-nav--rail` is deliberately excluded. It stays flush and
+square so its icon hit areas and persistent-column reading do not change.
+
+The detail canvas loses its competing rounded leading gutter. The sidebar is
+the sole elevated object; the main canvas returns to `--bg-base`.
+
+## State matrix
+
+| State | Layout | Surface treatment |
+| --- | --- | --- |
+| Expanded desktop | Existing flex allocation | Inset, rounded, bordered, elevated |
+| Hover-peek desktop | Existing absolute overlay | Same inset and silhouette |
+| Collapsed rail | Existing compact allocation | Flush, square, no elevation |
+| Mobile drawer | Existing responsive rules | Unchanged; desktop rule does not apply |
+
+## Accessibility and compatibility
+
+- Vertical scrolling remains available through explicit `overflow-y: auto`.
+- Existing focus order, landmarks, keyboard controls, and focus rings are
+  unchanged.
+- No new motion is introduced; existing reduced-motion behavior remains
+  authoritative.
+- All colors, radius, spacing, and shadow inputs use existing design tokens and
+  therefore inherit all theme/mode combinations.
+- Mobile behavior is protected structurally by the desktop-only media query,
+  avoiding a second responsive override to maintain.
+
+## Verification contract
+
+`src/components/sidebar-floating-edge.test.ts` pins:
+
+1. the shared desktop selector and token-driven border/radius/shadow;
+2. horizontal clipping plus preserved vertical scrolling;
+3. the common grid-aligned inset;
+4. expanded flex geometry and unchanged absolute hover-peek positioning;
+5. exclusion of the collapsed rail;
+6. removal of the detail-pane gutter;
+7. absence of floating-surface changes from the mobile stylesheet.
+
+The focused contract, complete app suite, lint, typecheck, test wiring, build,
+bundle budgets, and CI must pass before merge.
+
+## Non-goals
+
+- Replacing `react-resizable-panels` or changing remembered widths.
+- Making the expanded sidebar cover the main content.
+- Redesigning rows, labels, familiar scope, badges, or footer actions.
+- Changing collapsed-rail or mobile-drawer interaction.
+- Adding colors, typography, icons, or animation.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -476,6 +476,7 @@ export const SUITES = {
     "src/components/sidepanel-badges.test.ts",
     "src/components/sidepanel-badge-dots.test.ts",
     "src/components/sidepanel-nav-peek.test.ts",
+    "src/components/sidebar-floating-edge.test.ts",
     "src/components/sidepanel-peel-reveal.test.ts",
     "src/components/sidepanel-keyboard-nav.test.ts",
     "src/components/recent-activity-rollup.test.ts",

--- a/src/components/sidebar-floating-edge.test.ts
+++ b/src/components/sidebar-floating-edge.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const navigation = readFileSync(new URL("../styles/globals/shell-navigation.css", import.meta.url), "utf8");
+
+assert.match(
+  navigation,
+  /\/\* Dia-style floating sidebar edge[\s\S]*?@media \(min-width: 1024px\) \{[\s\S]*?\.shell-nav-panel > \.shell-nav:not\(\.shell-nav--rail\) \{[\s\S]*?border: 1px solid var\(--border-hairline\);[\s\S]*?border-radius: var\(--radius-panel\);[\s\S]*?box-shadow:[\s\S]*?var\(--shadow-color\);[\s\S]*?overflow-x: hidden;[\s\S]*?margin: var\(--space-2\);/,
+  "expanded and peek sidebars share one token-driven inset silhouette on desktop",
+);
+
+assert.match(
+  navigation,
+  /\.shell-nav \{[\s\S]*?overflow-y: auto;/,
+  "the shared sidebar remains vertically scrollable",
+);
+
+assert.match(
+  navigation,
+  /\.shell-nav-panel > \.shell-nav:not\(\.shell-nav--rail, \.shell-nav--peek\) \{[\s\S]*?flex: 0 0 auto;[\s\S]*?width: calc\(100% - var\(--space-4\)\);/,
+  "expanded desktop navigation is inset inside its existing panel allocation",
+);
+
+const detailRule = navigation.match(/\.shell-detail \{([\s\S]*?)\n\}/)?.[1] ?? "";
+assert.doesNotMatch(
+  detailRule,
+  /border-(?:start-start|end-start)-radius|margin-inline-start/,
+  "detail canvas no longer competes with the sidebar silhouette",
+);
+assert.match(
+  navigation,
+  /\.shell-detail-panel \{\s*background: var\(--bg-base\);\s*\}/,
+  "detail wrapper returns to the base canvas after the recessed gutter is removed",
+);
+
+assert.doesNotMatch(
+  navigation,
+  /\.shell-nav--rail \{[^}]*?(?:margin|border-radius|box-shadow):/,
+  "collapsed icon rail does not become a second floating card",
+);
+
+console.log("sidebar-floating-edge.test.ts: ok");

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -43,10 +43,8 @@
   overflow: visible !important;
 }
 
-/* Inner panel border — the recessed gutter and rounded leading edge of
-   .shell-detail now carry the separation, so the side panes drop the hard
-   divider that used to double it. (`list` is undefined at every call site
-   today; if that pane ever returns, its seam is a fresh call to make.) */
+/* The sidebar owns the desktop shell elevation; this wrapper only establishes
+   the positioning context for the hover-peek overlay. */
 .shell-nav-panel { position: relative; }
 
 .shell-nav-panel > .shell-nav,
@@ -138,9 +136,25 @@
      @supports / reduced-transparency blocks below. */
   background: var(--glass-raised);
   backdrop-filter: blur(var(--glass-blur)) saturate(var(--glass-saturate));
-  border-right: 1px solid var(--border-hairline);
-  box-shadow: 0 12px 40px rgb(0 0 0 / 0.35);
   animation: shellNavPeekIn 0.13s ease;
+}
+
+/* Dia-style floating sidebar edge: expanded navigation stays in the panel's
+   resizable allocation while its painted surface floats inside the shell.
+   Hover-peek shares the same silhouette, so both states read as one object. */
+@media (min-width: 1024px) {
+  .shell-nav-panel > .shell-nav:not(.shell-nav--rail) {
+    border: 1px solid var(--border-hairline);
+    border-radius: var(--radius-panel);
+    box-shadow: 0 14px 36px -24px var(--shadow-color);
+    overflow-x: hidden;
+    margin: var(--space-2);
+  }
+
+  .shell-nav-panel > .shell-nav:not(.shell-nav--rail, .shell-nav--peek) {
+    flex: 0 0 auto;
+    width: calc(100% - var(--space-4));
+  }
 }
 @keyframes shellNavPeekIn {
   from { opacity: 0; transform: translateX(-8px); }
@@ -1041,26 +1055,11 @@
   height: 100%;
   display: flex;
   flex-direction: column;
-  /* Rounded leading edge: the content pane reads as a surface raised off the
-     shell rather than a third column butted against the rail. Logical corners,
-     so RTL rounds the trailing edge instead. The recess behind the arc is
-     painted by .shell-detail-panel below — .shell-root cannot supply it,
-     because backdrop mode makes root transparent. */
-  border-start-start-radius: var(--radius-panel);
-  border-end-start-radius: var(--radius-panel);
-  /* A hair of inset so the recess reads down the whole edge rather than only
-     inside the corner arcs — flush panes make the rounding almost invisible. */
-  margin-inline-start: var(--space-2);
 }
 
-/* The arc needs a surface behind it. The panel wrapper paints the gutter in
-   the nav's own rendered colour — .shell-nav is `--bg-raised` at 88% over
-   `--bg-base`, so this is that mix flattened — which makes the content read as
-   a card floating on the rail's plane. Deriving it instead of picking a token
-   keeps the relationship right in light themes too, where a recess token like
-   --bg-panel is *lighter* than the base and would invert the effect. */
+/* The detail wrapper is the quiet canvas behind the elevated navigation. */
 .shell-detail-panel {
-  background: color-mix(in oklch, var(--bg-raised) 88%, var(--bg-base));
+  background: var(--bg-base);
 }
 
 .shell-detail-header {


### PR DESCRIPTION
## Summary

- float the expanded desktop sidebar inside its existing panel allocation with a token-driven border, radius, and shadow
- give hover peek the same silhouette while keeping the collapsed rail flush and the mobile drawer full-height
- remove the competing rounded detail gutter and add a wired regression contract for the shell states

## Why

The existing detail-pane arc made the sidebar read as a recessed column. This moves the visual ownership to the navigation surface itself, matching the modern Dia-style overlay edge while preserving Cave routing, panel sizing, responsive behavior, and interaction state.

## Verification

- pnpm test:app — 1,011 test files passed
- pnpm build — production build and bundle/standalone budgets passed
- pnpm lint
- pnpm typecheck
- pnpm check:tests-wired — all 1,395 test files wired
- focused expanded, hover-peek, rail, contextual Chat, and mobile shell contracts
- rendered Chromium verification at 1440x900 and 390x844 across dark, light, and tide themes with no horizontal overflow

Closes cave-9q0v.
