### PR TITLE
test(release): wire release-notes.test.mjs into CI on a seeded fixture (cave-5yyj1)

### DIFF
--- a/scripts/check-tests-wired.mjs
+++ b/scripts/check-tests-wired.mjs
@@ -18,10 +18,11 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 // path, value = the reason (printed in the "allowlisted" summary). Keep this
 // short and justified — the whole point of the guard is that orphaning is loud.
 const ALLOWLIST = new Map([
-  [
-    "scripts/release-notes.test.mjs",
-    "needs live git history/tags; absent in CI's shallow checkout (runs in the release workflow)",
-  ],
+  // Empty by design. scripts/release-notes.test.mjs used to live here because
+  // it read this checkout's own tags and CHANGELOG; it now seeds a throwaway
+  // fixture repo and passes COVEN_RELEASE_NOTES_ROOT, so it runs anywhere
+  // (cave-5yyj1). Adding an entry back means a test nothing runs — justify it
+  // here and expect the justification to be read.
 ]);
 
 function walk(dir, acc) {

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -29,7 +29,12 @@ VERSION="$1"
 VER_NUM="${VERSION#v}"
 PREV="${2:-}"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# The repository this renders from. Defaults to the script's own checkout — the
+# only thing that makes sense in CI and for local backfills — but is overridable
+# so the test suite can point it at a seeded fixture repo instead of depending
+# on this checkout's live tags and CHANGELOG (cave-5yyj1). Same spirit as
+# COVEN_REPO_SLUG below, which already exists for exactly that reason.
+ROOT="${COVEN_RELEASE_NOTES_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
 CHANGELOG="$ROOT/CHANGELOG.md"
 REPO="${COVEN_REPO_SLUG:-OpenCoven/coven-cave}"
 

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -1,106 +1,167 @@
-// Sanity test for scripts/release-notes.sh. Run with:
-//   npx --yes tsx --test scripts/release-notes.test.mjs
+// Tests for scripts/release-notes.sh — the renderer that writes every
+// user-facing GitHub release body.
+//
+// These used to read this checkout's own tags and CHANGELOG, which meant they
+// could not run against CI's shallow clone and were allowlisted out of the
+// wiring guard (cave-5yyj1). They now build a throwaway git repo per run and
+// point the script at it with COVEN_RELEASE_NOTES_ROOT, so they depend on
+// nothing outside this file and are wired into the normal suite.
 //
 // Asserts the script:
 //   1. Picks up the CHANGELOG.md section when one exists for the version.
-//   2. Renders the arch-split install block for v0.0.54+.
-//   3. Falls back to the legacy single-DMG install block for pre-v0.0.54.
+//   2. Renders the arch-split install block above the cutoff.
+//   3. Falls back to the legacy single-DMG block below the cutoff.
 //   4. Falls back to a git-log commit list when no CHANGELOG entry exists.
 //   5. Always ends with a `**Full changelog:**` compare link.
-//
-// Live git history is needed for the fallback case, so this test is
-// expected to run inside the repo's working tree (CI does not execute it
-// — see CLAUDE.md / auto-memory reference_test_runner).
+//   6. Emits the cave-yp21x build-provenance block only when guards were skipped.
 
 import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
+import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import assert from "node:assert/strict";
 
 const SCRIPT = fileURLToPath(new URL("./release-notes.sh", import.meta.url));
-const REPO_ROOT = path.dirname(path.dirname(SCRIPT));
+const SLUG = "ExampleOrg/example-repo";
+
+/**
+ * A throwaway repository carrying the tag history and CHANGELOG the cases need.
+ *
+ * Commits use a fixed identity and signing is disabled explicitly: a machine
+ * with `commit.gpgsign = true` (this repo requires signed commits) would
+ * otherwise fail to build the fixture.
+ */
+function seedRepo() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "release-notes-fixture-"));
+  const git = (...args) =>
+    execFileSync("git", ["-C", dir, ...args], { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "fixture@example.invalid");
+  git("config", "user.name", "Fixture");
+  git("config", "commit.gpgsign", "false");
+  git("config", "tag.gpgsign", "false");
+
+  const commitTag = (tag, subject) => {
+    writeFileSync(path.join(dir, `${tag}.txt`), `${tag}\n`);
+    git("add", "-A");
+    git("commit", "-q", "-m", subject);
+    git("tag", tag);
+  };
+
+  // Deliberately a major version that does NOT exist in this repository. If
+  // COVEN_RELEASE_NOTES_ROOT ever stops taking effect, tag auto-detection finds
+  // no v7.* tags and these cases fail loudly instead of quietly passing against
+  // the real checkout's history.
+  // Pre-CHANGELOG history, below the arch-split cutoff (patch < 54, minor 0).
+  commitTag("v7.0.41", "fix: earliest fixture commit");
+  commitTag("v7.0.42", "fix: teach the widget to widget");
+  // Straddle the cutoff, then the versions that DO have CHANGELOG sections.
+  commitTag("v7.0.50", "feat: fixture midpoint");
+  commitTag("v7.0.54", "feat: arch-split DMGs");
+  commitTag("v7.0.55", "feat: fixture head");
+
+  // Only 7.0.55 and 7.0.50 get sections, so 7.0.42 must hit the git-log
+  // fallback — the branch that needed live history in the first place.
+  writeFileSync(
+    path.join(dir, "CHANGELOG.md"),
+    [
+      "# Changelog",
+      "",
+      "## [7.0.55]",
+      "",
+      "- Loopback-tolerant referer check",
+      "- A second bullet so the section is unambiguous",
+      "",
+      "## [7.0.50]",
+      "",
+      "- The midpoint entry",
+      "",
+    ].join("\n"),
+  );
+  return dir;
+}
+
+const REPO_DIR = seedRepo();
+test.after(() => rmSync(REPO_DIR, { recursive: true, force: true }));
 
 function render(version, previous, env) {
   const args = previous ? [version, previous] : [version];
   return execFileSync(SCRIPT, args, {
-    cwd: REPO_ROOT,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
-    env: { ...process.env, ...(env ?? {}) },
+    env: {
+      ...process.env,
+      COVEN_RELEASE_NOTES_ROOT: REPO_DIR,
+      COVEN_REPO_SLUG: SLUG,
+      ...(env ?? {}),
+    },
   });
 }
 
-test("v0.0.55 pulls its CHANGELOG section and renders the arch-split install block", () => {
-  const body = render("v0.0.55");
-  assert.match(body, /^## What's new in v0\.0\.55/m, "starts with the standard heading");
-  assert.match(
-    body,
-    /Loopback-tolerant referer check/,
-    "includes the CHANGELOG bullet for the loopback-tolerant fix",
-  );
-  assert.match(
-    body,
-    /CovenCave-v0\.0\.55-aarch64\.dmg/,
-    "arch-split install block lists the aarch64 DMG",
-  );
-  assert.match(
-    body,
-    /CovenCave-v0\.0\.55-x86_64\.dmg/,
-    "arch-split install block lists the x86_64 DMG",
-  );
+test("a version with a CHANGELOG section renders it under the standard heading", () => {
+  const body = render("v7.0.55");
+  assert.match(body, /^## What's new in v7\.0\.55/m, "starts with the standard heading");
+  assert.match(body, /Loopback-tolerant referer check/, "includes the section's bullet");
+});
+
+test("v7.0.54+ renders the arch-split install block and not the legacy DMG", () => {
+  const body = render("v7.0.55");
+  assert.match(body, /CovenCave-v7\.0\.55-aarch64\.dmg/, "lists the aarch64 DMG");
+  assert.match(body, /CovenCave-v7\.0\.55-x86_64\.dmg/, "lists the x86_64 DMG");
   assert.doesNotMatch(
     body,
-    /CovenCave-v0\.0\.55\.dmg(?!-)/,
-    "arch-split block must not also list the legacy un-suffixed DMG",
-  );
-  assert.match(
-    body,
-    /\*\*Full changelog:\*\* https:\/\/github\.com\/OpenCoven\/coven-cave\/compare\/v0\.0\.54\.\.\.v0\.0\.55/,
-    "trailing compare link uses the auto-detected previous tag",
+    /CovenCave-v7\.0\.55\.dmg(?!-)/,
+    "must not also list the legacy un-suffixed DMG",
   );
 });
 
-test("pre-v0.0.54 versions render the legacy single-DMG install block", () => {
-  const body = render("v0.0.42");
+test("pre-v7.0.54 versions render the legacy single-DMG install block", () => {
+  const body = render("v7.0.42");
   assert.match(
     body,
-    /download \[`CovenCave-v0\.0\.42\.dmg`\]\(https:\/\/github\.com\/OpenCoven\/coven-cave\/releases\/download\/v0\.0\.42\/CovenCave-v0\.0\.42\.dmg\)/,
+    new RegExp(
+      `download \\[\`CovenCave-v7\\.0\\.42\\.dmg\`\\]\\(https://github\\.com/${SLUG}/releases/download/v7\\.0\\.42/CovenCave-v7\\.0\\.42\\.dmg\\)`,
+    ),
     "legacy install block lists the un-suffixed DMG",
   );
-  assert.doesNotMatch(
-    body,
-    /aarch64\.dmg|x86_64\.dmg/,
-    "legacy block must not mention arch-suffixed DMGs",
-  );
+  assert.doesNotMatch(body, /aarch64\.dmg|x86_64\.dmg/, "legacy block mentions no arch DMGs");
 });
 
 test("versions without a CHANGELOG entry fall back to a git-log bullet list", () => {
-  // v0.0.42 is below the CHANGELOG cutoff (which starts at 0.0.50) so it
-  // must hit the fallback branch.
-  const body = render("v0.0.42", "v0.0.41");
+  // 7.0.42 has no CHANGELOG section in the fixture, so this takes the fallback
+  // branch — the one that reads real commits between two tags.
+  const body = render("v7.0.42", "v7.0.41");
+  assert.match(body, /Commits since \[`v7\.0\.41`\]/, "fallback cites the previous tag");
+  assert.match(body, /^- /m, "fallback emits at least one bullet");
+  assert.match(body, /teach the widget to widget/, "the bullet is a real commit subject");
+});
+
+test("the compare link uses the auto-detected previous tag", () => {
   assert.match(
-    body,
-    /Commits since \[`v0\.0\.41`\]/,
-    "fallback bullet list cites the previous tag",
+    render("v7.0.55"),
+    new RegExp(
+      `\\*\\*Full changelog:\\*\\* https://github\\.com/${SLUG}/compare/v7\\.0\\.54\\.\\.\\.v7\\.0\\.55`,
+    ),
+    "auto-detection picks the immediately preceding tag",
   );
-  assert.match(body, /^- /m, "fallback emits at least one `- ` bullet");
 });
 
 test("an explicit previous-tag argument overrides auto-detection", () => {
-  const body = render("v0.0.55", "v0.0.50");
-  assert.match(
-    body,
-    /compare\/v0\.0\.50\.\.\.v0\.0\.55/,
-    "compare link respects the explicit previous tag",
-  );
+  assert.match(render("v7.0.55", "v7.0.50"), /compare\/v7\.0\.50\.\.\.v7\.0\.55/);
 });
 
-test("every rendered body ends with the standardized checksum + changelog footer", () => {
-  for (const v of ["v0.0.55", "v0.0.42"]) {
+test("every rendered body ends with the checksum block and the compare link", () => {
+  for (const v of ["v7.0.55", "v7.0.42"]) {
     const body = render(v);
-    assert.match(body, /shasum -a 256 -c SHA256SUMS/, `${v} body has the verify-checksums block`);
-    assert.match(body, /\*\*Full changelog:\*\*/, `${v} body has the compare link`);
+    assert.match(body, /shasum -a 256 -c SHA256SUMS/, `${v} has the verify-checksums block`);
+    assert.match(
+      body.trimEnd().split("\n").at(-1) ?? "",
+      /^\*\*Full changelog:\*\*/,
+      `${v} ends with the compare link`,
+    );
   }
 });
 
@@ -110,31 +171,36 @@ test("every rendered body ends with the standardized checksum + changelog footer
 // log — invisible to anyone reading the release. The body now says so.
 
 test("the provenance block appears only when the guards were actually skipped", () => {
-  const skipped = render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
+  const skipped = render("v7.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
   assert.match(skipped, /^## Build provenance/m, "a skipped-guard build states its provenance");
   assert.match(skipped, /allow_unconfigured_registries/, "names the flag that caused it");
   assert.match(skipped, /built-in baseline schema parsers/, "says what it used instead");
   assert.match(skipped, /tag push cannot skip/, "says the normal path is still fail-closed");
 
-  // The default release path must stay unchanged — an unset or false flag adds
-  // nothing, so ordinary releases read exactly as before.
-  assert.doesNotMatch(render("v0.0.55"), /Build provenance/, "unset flag renders no block");
+  assert.doesNotMatch(render("v7.0.55"), /Build provenance/, "unset flag renders no block");
   assert.doesNotMatch(
-    render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "false" }),
+    render("v7.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "false" }),
     /Build provenance/,
     "an explicit false renders no block",
   );
   // Only the exact string "true" counts — a truthy-looking value must not arm it.
   assert.doesNotMatch(
-    render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "1" }),
+    render("v7.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "1" }),
     /Build provenance/,
     "a non-'true' value renders no block",
   );
 });
 
 test("the provenance block never displaces the compare link", () => {
-  // The body's contract is that it ends with the changelog link; a section
-  // appended in the wrong place would bury it.
-  const body = render("v0.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
+  const body = render("v7.0.55", undefined, { COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: "true" });
   assert.match(body.trimEnd().split("\n").at(-1) ?? "", /^\*\*Full changelog:\*\*/);
+});
+
+test("the fixture is genuinely self-contained", () => {
+  // The point of cave-5yyj1: no assertion above may depend on this checkout's
+  // own tags, CHANGELOG, or slug. If the real slug leaks through, the script is
+  // reading something other than the fixture and the wiring is a lie.
+  const body = render("v7.0.55");
+  assert.doesNotMatch(body, /OpenCoven\/coven-cave/, "renders against the fixture, not this repo");
+  assert.match(body, new RegExp(SLUG.replace("/", "\\/")), "uses the fixture slug");
 });

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1276,6 +1276,7 @@ export const SUITES = {
     "src/server-heap-monitor.test.ts",
     "src/lib/pty-ws-bridge.test.ts",
     "scripts/release-macos-signing.test.mjs",
+    "scripts/release-notes.test.mjs",
     "scripts/generate-latest-json.test.mjs",
     "scripts/stamp-release.test.mjs",
     "src/app/api/daemon/start/route.test.ts",


### PR DESCRIPTION
`scripts/release-notes.sh` renders every user-facing GitHub release body, and until now **nothing verified it on any runner**. Its test was the single file allowlisted out of `check-tests-wired`, because it read this checkout's own tags and CHANGELOG and couldn't survive a shallow clone.

## The blocker

`ROOT` derives from the *script's own location*, not cwd — so no amount of `chdir` could point it at a fixture. Added `COVEN_RELEASE_NOTES_ROOT`, following the precedent `COVEN_REPO_SLUG` already set for exactly this purpose. **The default is unchanged**, so CI and local backfills behave identically to before.

The test now seeds a throwaway repo per run: five tagged commits straddling the `patch >= 54` arch-split cutoff, and a CHANGELOG with sections for only two of them so the git-log fallback still exercises real commit history. Signing is disabled in the fixture — a machine with `commit.gpgsign = true` (which this repo requires) would otherwise fail to build it.

## ⚠️ The first version passed 10/10 and verified almost nothing

It reused tag names like `v0.0.55` that **also exist in this repo**. If the override silently stopped working, every assertion would still have passed against the real checkout — a green test measuring nothing.

The fixture now uses `v7.0.x`, which cannot exist upstream. And I proved it rather than assuming:

| Override | Result |
|---|---|
| Disabled | **4 fail** / 6 pass |
| Restored | **10 pass** / 0 fail |

## Result

```
✓ all 1394 test files wired into CI
```

No "(1 allowlisted)" suffix — the map is kept but **empty**, with a comment noting that re-adding an entry means a test nothing runs, so the next person has to justify it.

The release workflow's `Verify release-notes renderer` step stays. It's now duplicative of the wired suite, but it guards the actual moment of use, seconds before the body is written.

## Verification

10/10 on the file · negative-tested for vacuity · app suite **1010/1010** (up from 1008 — this file plus its own wiring).

Closes cave-5yyj1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)