### PR TITLE
refactor(projects): four project-root normalizers become two (cave-zz12)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -519,6 +519,7 @@ export const SUITES = {
     "src/lib/use-projects-race.test.ts",
     "src/lib/use-projects-normalize.test.ts",
     "src/lib/project-frecency.test.ts",
+    "src/lib/project-root-normalizers.test.ts",
     "src/lib/use-projects-scope-transition.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/components/calendar-agenda-redesign.test.ts",

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -26,7 +26,21 @@ function projectsFilePath(): string {
   );
 }
 
-function normalizeRoot(root: string): string {
+/**
+ * Server-side project root: {@link normalizeProjectRoot} PLUS `~` expansion.
+ *
+ * Deliberately NOT merged into the display normalizer (cave-zz12). Expanding
+ * `~` changes what a root normalizes to, and roots are the keys of persisted
+ * stores — IDB projectAvatars, cave:chat:project-overrides, comux pins and
+ * order — so folding this into the shared normalizer silently re-keys them and
+ * avatars and pins vanish for existing users. Unifying the two needs a
+ * migration pass, tracked separately; until then the divergence is explicit
+ * and named rather than an anonymous private duplicate.
+ *
+ * Not a security boundary either: resolveAllowedProjectPath / trustedProjectCwd
+ * do their own validation and must not be routed through any display path.
+ */
+function normalizeRootExpandingHome(root: string): string {
   let trimmed = root.trim();
   // Expand a leading ~ — a manually-typed ~/code/app was stored literally and
   // never matched the daemon's absolute project_root, so Sessions/Git/Tasks
@@ -89,7 +103,7 @@ async function loadProjectsUnlocked(): Promise<CaveProject[]> {
     // trustedProjectCwd, permission filtering) while the UI hid them via
     // dedupeProjectsByRoot — a client/server divergence. Newest record wins;
     // the next mutation persists the deduped list, self-healing the file.
-    return dedupeByRoot(parsed.projects, normalizeRoot);
+    return dedupeByRoot(parsed.projects, normalizeRootExpandingHome);
   } catch {
     return [];
   }
@@ -128,13 +142,13 @@ export function createProject(input: {
 }): Promise<CaveProject> {
   return withProjectsStore(() => withWriteMutex(async () => {
     const projects = await loadProjectsUnlocked();
-    const root = normalizeRoot(input.root);
+    const root = normalizeRootExpandingHome(input.root);
     // One project per root. Creating at an already-registered root would persist
     // a duplicate on disk that the UI hides via dedupeProjectsByRoot but the
     // server (projectById / trustedProjectCwd) can still resolve to — a
     // client/server divergence. Return the existing project idempotently instead
     // ("this folder is already a project → here it is").
-    const existing = projects.find((entry) => normalizeRoot(entry.root) === root);
+    const existing = projects.find((entry) => normalizeRootExpandingHome(entry.root) === root);
     if (existing) return existing;
     const now = new Date().toISOString();
     const project: CaveProject = {
@@ -169,9 +183,9 @@ export function patchProject(
     // for one path. Name/color still apply.
     let nextRoot = current.root;
     if (patch.root !== undefined) {
-      const candidate = normalizeRoot(patch.root);
+      const candidate = normalizeRootExpandingHome(patch.root);
       const collides = projects.some(
-        (entry) => entry.id !== id && normalizeRoot(entry.root) === candidate,
+        (entry) => entry.id !== id && normalizeRootExpandingHome(entry.root) === candidate,
       );
       if (!collides) nextRoot = candidate;
     }
@@ -216,8 +230,8 @@ export function projectForRoot(
   projects: CaveProject[],
 ): CaveProject | null {
   if (!root?.trim()) return null;
-  const normalized = normalizeRoot(root);
-  return projects.find((project) => normalizeRoot(project.root) === normalized) ?? null;
+  const normalized = normalizeRootExpandingHome(root);
+  return projects.find((project) => normalizeRootExpandingHome(project.root) === normalized) ?? null;
 }
 
 export function projectById(

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -1,6 +1,6 @@
 import type { SessionRow } from "./types.ts";
 import type { CaveProject } from "./cave-projects.ts";
-import { compareProjectsAlphabetically } from "./cave-projects-types.ts";
+import { compareProjectsAlphabetically, normalizeProjectRoot } from "./cave-projects-types.ts";
 
 export type ChatProject = CaveProject;
 export type { CaveProject };
@@ -16,9 +16,18 @@ export type ChatProjectGroup = {
   updatedAt: string | null;
 };
 
+/**
+ * Canonical project-root form for chat.
+ *
+ * This was a character-for-character reimplementation of normalizeProjectRoot
+ * (cave-zz12) — same trim, same backslash flip, same trailing-slash strip,
+ * same "/" fallback. Two identical normalizers are one silent divergence
+ * waiting to happen, so this is now a re-export that keeps the chat-side name
+ * at its ~30 call sites. The signature stays string -> string: chat callers
+ * always have a root in hand, and widening it would hide a missing one.
+ */
 export function normalizeChatProjectRoot(root: string): string {
-  const normalized = root.trim().replace(/\\/g, "/").replace(/\/+$/, "");
-  return normalized || "/";
+  return normalizeProjectRoot(root);
 }
 
 export function chatProjectById(

--- a/src/lib/comux-projects.ts
+++ b/src/lib/comux-projects.ts
@@ -1,4 +1,13 @@
 import type { SessionRow } from "@/lib/types";
+// One display normalizer for the whole app (cave-zz12). comux used to carry a
+// private copy that differed only by not trimming; its keying call site below
+// already passes a trimmed value, so this is the same result — and one fewer
+// place for project identity to quietly diverge.
+// Relative, not "@/": the existing `@/lib/types` import above is TYPE-ONLY and
+// erased at runtime, but this is a value import — via the alias it would need
+// the test alias loader, and any test whose graph reaches this file without it
+// would fail to resolve.
+import { normalizeProjectRoot } from "./cave-projects-types.ts";
 
 export type ComuxProject = {
   name: string;
@@ -57,11 +66,7 @@ export function projectMonogram(name: string): string {
   return (first + last).toUpperCase();
 }
 
-/** Strip trailing slashes so `/x/app` and `/x/app/` bucket as one project. */
-function normalizeRoot(root: string): string {
-  const stripped = root.replace(/\\/g, "/").replace(/\/+$/, "");
-  return stripped || "/";
-}
+
 
 /** `parent/name` for disambiguating projects that share a basename. */
 function projectNameWithParent(root: string): string {
@@ -85,7 +90,7 @@ export function deriveComuxProjects(
   for (const session of sessions) {
     const raw = session.project_root?.trim();
     if (!raw) continue;
-    const root = normalizeRoot(raw);
+    const root = normalizeProjectRoot(raw);
     const bucket = byRoot.get(root) ?? { sessions: [], familiarIds: new Set<string>() };
     bucket.sessions.push(session);
     if (session.familiarId) bucket.familiarIds.add(session.familiarId);
@@ -131,7 +136,7 @@ export function deriveComuxProjects(
     return [
       {
         name: projectName(fallbackRoot),
-        root: normalizeRoot(fallbackRoot),
+        root: normalizeProjectRoot(fallbackRoot),
         sessionCount: 0,
         runningCount: 0,
         familiarCount: 0,

--- a/src/lib/project-root-normalizers.test.ts
+++ b/src/lib/project-root-normalizers.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { normalizeProjectRoot } from "./cave-projects-types.ts";
+import { normalizeChatProjectRoot } from "./chat-projects.ts";
+import { deriveComuxProjects } from "./comux-projects.ts";
+import type { SessionRow } from "./types.ts";
+
+/**
+ * cave-zz12: four competing project-root normalizers collapse to two.
+ *
+ * The safety claim of that change is behavioural, so it is tested behaviourally:
+ * the two that were folded in produced identical output for the inputs their
+ * call sites actually pass, which is why no persisted key moves. Roots are the
+ * keys of IDB projectAvatars, cave:chat:project-overrides, and comux pins and
+ * order — if normalization shifted, those would silently empty out.
+ */
+
+// Every shape a project root arrives in, plus the awkward ones.
+const CASES = [
+  "/w/app",
+  "/w/app/",
+  "/w/app///",
+  "C:\\code\\app",
+  "C:\\code\\app\\",
+  "/w/app with spaces",
+  "~/code/app",
+  "~",
+  "/",
+  "//",
+  "",
+  "   ",
+  "  /w/app  ",
+  "/w/app/.worktrees/feature",
+];
+
+test("the chat normalizer is exactly the shared one", () => {
+  for (const input of CASES) {
+    assert.equal(
+      normalizeChatProjectRoot(input),
+      normalizeProjectRoot(input),
+      `diverged on ${JSON.stringify(input)}`,
+    );
+  }
+});
+
+// The chat normalizer was a character-for-character copy, so this is not a
+// refactor that "should" preserve behaviour — it provably does. Pinned because
+// re-introducing a second implementation is exactly how the two drift apart.
+test("chat-projects no longer carries its own implementation", () => {
+  const src = readFileSync(new URL("./chat-projects.ts", import.meta.url), "utf8");
+  assert.match(
+    src,
+    /export function normalizeChatProjectRoot\(root: string\): string \{\s*return normalizeProjectRoot\(root\);\s*\}/,
+    "it delegates rather than re-implementing trim/backslash/trailing-slash",
+  );
+  // Narrowly the normalizer idiom — chat-projects legitimately flips
+  // backslashes elsewhere when splitting a root into path segments, so
+  // matching that would be a false positive.
+  assert.doesNotMatch(
+    src,
+    /replace\(\/\\\/\+\$\/, ""\)/,
+    "no second trailing-slash-stripping normalizer",
+  );
+});
+
+test("comux no longer carries its own implementation", () => {
+  const src = readFileSync(new URL("./comux-projects.ts", import.meta.url), "utf8");
+  assert.doesNotMatch(src, /function normalizeRoot\(/, "the private copy is gone");
+  assert.match(src, /normalizeProjectRoot\(raw\)/, "bucketing keys through the shared normalizer");
+});
+
+function session(over: Partial<SessionRow> & { id: string }): SessionRow {
+  return {
+    familiarId: "cody",
+    status: "idle",
+    created_at: "2026-01-01T00:00:00.000Z",
+    updated_at: "2026-01-01T00:00:00.000Z",
+    ...over,
+  } as SessionRow;
+}
+
+// comux's normalizer differed from the shared one ONLY by not trimming, and
+// its keying call site already trims (`session.project_root?.trim()`). So the
+// bucket keys — which back comux pins and ordering — cannot move.
+test("comux buckets trailing-slash variants together, exactly as before", () => {
+  const projects = deriveComuxProjects(
+    [
+      session({ id: "a", project_root: "/w/app" }),
+      session({ id: "b", project_root: "/w/app/" }),
+      session({ id: "c", project_root: "/w/app///" }),
+      session({ id: "d", project_root: "/w/other" }),
+    ],
+  );
+  const roots = projects.map((p) => p.root).sort();
+  assert.deepEqual(roots, ["/w/app", "/w/other"], "one bucket per real project");
+  const app = projects.find((p) => p.root === "/w/app");
+  assert.equal(app?.sessionCount, 3, "all three spellings landed in the same bucket");
+});
+
+test("comux still buckets a windows root to forward slashes", () => {
+  const projects = deriveComuxProjects([session({ id: "a", project_root: "C:\\code\\app\\" })], undefined);
+  assert.equal(projects[0]?.root, "C:/code/app");
+});
+
+// The surrounding-whitespace case is the one place comux's missing trim could
+// ever have mattered. Its call site strips first, so the outcome is unchanged —
+// and now it would be right even if that stripping went away.
+test("a root arriving with whitespace still buckets with its clean twin", () => {
+  const projects = deriveComuxProjects(
+    [session({ id: "a", project_root: "/w/app" }), session({ id: "b", project_root: "  /w/app  " })],
+  );
+  assert.equal(projects.length, 1, "one project, not two");
+  assert.equal(projects[0].sessionCount, 2);
+});
+
+// The ~-expanding server normalizer is deliberately NOT folded in: expanding ~
+// changes what a root normalizes to, which would re-key the persisted stores.
+test("the shared normalizer still does not expand ~", () => {
+  assert.equal(normalizeProjectRoot("~/code/app"), "~/code/app");
+  assert.equal(normalizeProjectRoot("~"), "~");
+});
+
+test("the server normalizer is named for what it does, not left anonymous", () => {
+  const src = readFileSync(new URL("./cave-projects.ts", import.meta.url), "utf8");
+  assert.match(src, /function normalizeRootExpandingHome\(/, "the ~ expander says so in its name");
+  assert.doesNotMatch(src, /\bfunction normalizeRoot\(/, "no anonymous third normalizer");
+  assert.match(
+    src,
+    /migration pass/,
+    "and it documents why it is not merged — the re-key risk",
+  );
+});
+
+console.log("project-root-normalizers.test.ts: ok");

--- a/src/lib/project-root-normalizers.test.ts
+++ b/src/lib/project-root-normalizers.test.ts
@@ -52,7 +52,8 @@ test("chat-projects no longer carries its own implementation", () => {
   const src = readFileSync(new URL("./chat-projects.ts", import.meta.url), "utf8");
   assert.match(
     src,
-    /export function normalizeChatProjectRoot\(root: string\): string \{\s*return normalizeProjectRoot\(root\);\s*\}/,
+    // Whitespace-tolerant: a reformat should not fail a test about delegation.
+    /export function normalizeChatProjectRoot\s*\(\s*root:\s*string\s*\)\s*:\s*string\s*\{\s*return normalizeProjectRoot\(root\);\s*\}/,
     "it delegates rather than re-implementing trim/backslash/trailing-slash",
   );
   // Narrowly the normalizer idiom — chat-projects legitimately flips
@@ -71,14 +72,22 @@ test("comux no longer carries its own implementation", () => {
   assert.match(src, /normalizeProjectRoot\(raw\)/, "bucketing keys through the shared normalizer");
 });
 
+// No `as SessionRow`: every required field is supplied, so the compiler checks
+// the shape. A cast here would let a future edit build an invalid session and
+// silently change what deriveComuxProjects sees, with no type error.
 function session(over: Partial<SessionRow> & { id: string }): SessionRow {
   return {
-    familiarId: "cody",
+    project_root: "/w/app",
+    harness: "copilot",
+    title: "session",
     status: "idle",
+    exit_code: null,
+    archived_at: null,
     created_at: "2026-01-01T00:00:00.000Z",
     updated_at: "2026-01-01T00:00:00.000Z",
+    familiarId: "cody",
     ...over,
-  } as SessionRow;
+  };
 }
 
 // comux's normalizer differed from the shared one ONLY by not trimming, and


### PR DESCRIPTION
Project identity was computed four different ways. Reading them showed two weren't different *ideas* at all:

| normalizer | verdict |
|---|---|
| `normalizeProjectRoot` (cave-projects-types) | the canonical one — unchanged |
| `normalizeChatProjectRoot` (chat-projects) | **character-for-character duplicate** → delegates |
| private `normalizeRoot` (comux-projects) | differs only by the trim → uses the shared one |
| private `normalizeRoot` (cave-projects) | genuinely different (expands `~`) → kept, and *named* |

## Why this is a zero-migration change

The bead's design field flags the real hazard: roots are the **keys** of persisted stores — IDB `projectAvatars`, `cave:chat:project-overrides`, comux pins and order — so changing what a root normalizes to silently re-keys them and avatars and pins vanish.

Nothing here changes `normalizeProjectRoot`'s behaviour, so no key moves:

- The chat normalizer was provably identical, not merely similar. A test asserts the two agree across every root shape — windows paths, `~`, bare `/`, `//`, empty, whitespace-only, trailing slashes.
- comux's differed only by the trim, and its keying call site already trims (`session.project_root?.trim()` at line 88). Tests cover the bucketing directly: trailing-slash variants collapse to one project, a windows root flips to forward slashes, and a whitespace-wrapped root still buckets with its clean twin.

**Deliberately not done here:** making `normalizeProjectRoot` expand `~`. That's the half that carries the re-key risk, and it's filed as `cave-2x1em` with the migration spelled out, rather than smuggled in behind a refactor. The `~`-expanding normalizer keeps its behaviour and now says in its own doc why merging it isn't free.

Security validators `resolveAllowedProjectPath` / `trustedProjectCwd` are untouched.

## A trap worth recording

comux's existing `@/lib/types` import is **type-only** and erased at runtime, so that file never needed the test alias loader. Adding a **value** import through `@/` passed in isolation but broke `comux-projects.test.ts` inside the suite. The shared normalizer is imported relatively instead.

## Verification

- `pnpm test:app` — 1014 files. `tsc --noEmit` clean.
- Two of the three tests the bead pinned pass unchanged (`chat-projects`, `comux-projects`). The third, `project-paths.test.ts`, does not exist on main — noted on the bead.
- 8 new tests, including the cross-normalizer equivalence sweep and a pin that the shared normalizer still does *not* expand `~`.

Unblocks `cave-4wbi` and `cave-1vpy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)