### PR TITLE
docs(agents): in_progress means actively worked right now (cave-1mxw4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,44 @@ bd prime                # Refresh Beads context
 - Close with `bd close <id>` only after merge or explicit completion criteria are satisfied.
 - Never put secrets in bead text, and never treat `.beads/issues.jsonl` as the sync source of truth.
 
+### `in_progress` means actively worked *right now* (cave-1mxw4)
+
+Set the status honestly **at creation and at handoff**. Everything that is not
+being worked at this moment is `open`, `blocked`, or `deferred` — `bd` supports
+all three, plus `--defer <date>` to hide an issue from `bd ready` until then.
+
+This exists because a triage sweep found `in_progress` at 47 against 16 `open`,
+and most of it was not work in flight — it was four different states wearing one
+status, each of which had to be re-derived by grepping `main`, checking branches
+and reading PRs. That re-derivation is most of the cost of a sweep, and it
+recurs every time:
+
+| Actually | Should be | Example |
+| --- | --- | --- |
+| waiting on a human at the machine | `blocked` | a live-mic pass no agent can perform |
+| waiting on a decision never made | `blocked` | "design approval is required before implementation" |
+| waiting on a maintainer action an agent must not take | `blocked` | provisioning signing keys; anything needing credentials |
+| lost — no code, no branch, no PR | `open` (or closed) | reads "approved design, in progress"; is at zero |
+
+Practical rules:
+
+- **Name what a `blocked` bead waits on**, in a comment and — for maintainer
+  actions — in the title, so it is actionable at a glance rather than merely
+  accurate.
+- **Close finished work with evidence.** Roughly 28 beads were closeable in one
+  sweep purely because nobody flipped them after their PR merged.
+- **Do not bulk re-status on weak evidence.** "No live worktree" is not proof
+  someone has stopped — work happens from the primary checkout too. Re-status
+  only when the specific blocker or the specific remaining gap is verified, and
+  say which in the comment.
+- **Durable trackers are a legitimate exception.** A tracker that follows live
+  external state (an open-PR patrol) never completes but is continuously
+  active, so `in_progress` fits it.
+
+Retrofitting this by audit does not work on its own: 17 corrections in a single
+session still left the count at 47, because other sessions kept adding. The
+status has to be right when the bead is written.
+
 ## Crediting Contributors
 
 When you re-land or build on someone else's work — a fork PR, an issue author's proposal, a co-author — **credit the human contributor with a working GitHub-linked trailer** so they show up in the contributors graph and on their profile:


### PR DESCRIPTION
## Why

A triage sweep found the `in_progress` bucket at **47 against 16 `open`** — and most of it was not work in flight. It was four distinct states wearing one status:

| Actually | Should be | Real example found |
| --- | --- | --- |
| waiting on a human at the machine | `blocked` | `cave-m0ex` — a live-mic pass no agent can perform |
| waiting on a decision never made | `blocked` | `cave-x6rw` — "design approval is required before implementation" |
| waiting on a maintainer action an agent must not take | `blocked` | `cave-qfsj7` — provision signing keys, set Actions secrets |
| genuinely lost | `open` or closed | `cave-21rp` — no code, no branch, no PR; reads "approved design, in progress", is at zero |

None of these is distinguishable from the status field, so each had to be re-derived by grepping `main`, checking branches and reading PRs. **That re-derivation is most of the cost of a sweep, and it recurs every time.**

## What this adds

The rule plus four practical points, each earned during the sweep:

- **Name what a `blocked` bead waits on** — in a comment, and in the title for maintainer actions — so the status is actionable, not merely accurate.
- **Close finished work with evidence.** ~28 beads were closeable in one sweep purely because nobody flipped them after their PR merged.
- **Never bulk re-status on weak evidence.** "No live worktree" is not proof someone stopped — work happens from the primary checkout too. Re-status only when the specific blocker or gap is verified, and say which.
- **Durable trackers are a legitimate exception.** An open-PR patrol never completes but is continuously active, so `in_progress` fits it.

It closes on the point that makes this a docs change rather than a cleanup task: retrofitting by audit does not work alone — **17 corrections in one session still left the count at 47**, because other sessions kept adding. The status has to be right when the bead is written.

## Placement

Added to **`## Coven Familiar Beads Protocol`**, deliberately *not* to either `## Beads Issue Tracker` section. Both of those are generated blocks — `<!-- BEGIN BEADS INTEGRATION v:1 ... -->` (lines 121–175) and `<!-- BEGIN BEADS CODEX SETUP: generated by bd setup codex -->` (177–199) — so an edit there would be silently overwritten by the next `bd setup` run. My section starts at line 210, outside both.

> Incidentally: `AGENTS.md` carries **two** `## Beads Issue Tracker` sections with near-identical Quick Reference blocks, one per generator. Not touched here, but worth knowing when reading the file.

## Verification

Docs-only, one file, +38/−0. Four tests read `AGENTS.md` and all pass — `beads-familiar-workflow`, `ui-consistency`, `grimoire-launcher-data`, `chat-assistant-filter`. `git diff --check` clean.

Bead: `cave-1mxw4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)