### PR TITLE
fix(docs): stop silently discarding approved specs and plans (cave-8zjr5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,7 +104,12 @@ package-lock.json
 /.playwright-cli
 /graphify-out
 /artifacts
-/docs/superpowers
+# NOT ignored: /docs/superpowers. Beads cite specs and plans there as the
+# authoritative approved design, so ignoring it meant `git add` silently
+# dropped them and the design died with the authoring machine — four approved
+# designs were lost that way before anyone noticed (cave-8zjr5). The directory
+# is 100% markdown; `/.superpowers` above is the tool's scratch dir and stays
+# ignored.
 
 # Generated Canvas Sketch sandbox runtime (built in prebuild)
 /public/sandbox/

--- a/docs/superpowers/README.md
+++ b/docs/superpowers/README.md
@@ -1,0 +1,51 @@
+# Approved specs and plans
+
+Beads cite files here as the authoritative approved design for a piece of work.
+`specs/` holds the design; `plans/` holds the implementation plan derived from
+it.
+
+## These are point-in-time records
+
+Each document describes the repository **as it was on the date in its
+filename**. Read the design and the requirements as authoritative; read the
+operational details as history.
+
+In particular, do not follow these as live runbooks:
+
+- **Required-check lists.** Several plans list `CodeQL` among the required
+  status checks. That was true when they were written; CodeQL was retired on
+  2026-07-31 (cave-yp21x). `CLAUDE.md` carries the current list.
+- **Absolute paths.** Some plans hard-code a machine-local checkout or worktree
+  path such as `/Users/<someone>/…/coven-cave/.worktrees/<branch>`. Those were
+  the author's paths, not portable instructions. Everything is repo-relative
+  from your own checkout root.
+- **Branch and worktree names.** Named branches and worktrees in these plans are
+  long since merged, renamed, or deleted.
+
+They have deliberately not been rewritten. A plan is a record of what was
+approved and how it was carried out; editing it later to match today's
+repository would make it a worse record, not a better one.
+
+## Why this directory is versioned
+
+It was previously listed in `.gitignore`, so `git add` dropped new files here
+silently — no error, no untracked-file noise. Beads went on citing paths under
+it as durable while the files existed only on the authoring machine.
+
+**Four approved designs were lost that way** before anyone noticed, and one of
+them (cave-21rp) lost its implementation branch too, leaving a bead that read
+"approved design and plan, in progress" while sitting at zero.
+
+What made it easy to miss: 27 files here were already tracked because they
+predate the ignore rule, and tracked files stay tracked regardless. The
+directory looked versioned while every new file was discarded.
+
+Fixed in cave-8zjr5. `/.superpowers` — the tool's scratch directory, a
+different thing — remains ignored.
+
+## Durability
+
+Committing a design here makes it survive the authoring machine, which is what
+this directory is for. It does not make it survive a checkout that is never
+pushed. If a design matters, get it onto `origin`, and consider also pasting it
+into the bead's `DESIGN` field, which syncs through Dolt independently of git.

--- a/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
+++ b/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
@@ -1,0 +1,685 @@
+# Canvas Editor Full Screen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an in-app Expand toggle and a native Full screen button to the Canvas sketch editor so a sketch can fill the editor body or the whole monitor.
+
+**Architecture:** A pure Escape-precedence resolver lives in `src/lib/canvas-editor-escape.ts` (importable by tests; the component module can't be imported because it imports CSS). `CanvasEditor` gains `expanded` / `nativeFullscreen` / `fullscreenAvailable` state, two header icon buttons before the mode group, a `canvas-editor--expanded` root modifier class driven purely by CSS, and `requestFullscreen()` on the frame shell with `webkit`-prefixed fallbacks for WKWebView/Tauri.
+
+**Tech Stack:** React 19 client component, plain CSS (semantic tokens), Phosphor icons via `src/lib/icon.tsx`, `node --test` with source-regex pins per repo convention.
+
+**Spec:** `docs/superpowers/specs/2026-07-21-canvas-fullscreen-design.md` · **Bead:** cave-i0qt
+
+**Working directory for ALL tasks:** `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen` (branch `feat/canvas-fullscreen`, local-only until Task 5 pushes). All commits are signed (`-S`).
+
+**One-time setup (before Task 1):**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen
+pnpm install
+```
+
+Expected: completes in ~10s (pnpm CAS store). Needed for `pnpm typecheck` in Task 5.
+
+---
+
+## File Structure
+
+- **Create** `src/lib/canvas-editor-escape.ts` — pure Escape-precedence resolver (one responsibility: the deterministic rule; no DOM).
+- **Modify** `src/components/canvas-editor.tsx` — state, callbacks, header buttons, root class, frame-shell ref, rewritten Escape handler that delegates to the resolver.
+- **Modify** `src/styles/canvas-editor.css` — view-controls button styles, `--expanded` overrides, `:fullscreen` chrome strip.
+- **Modify** `src/lib/icon.tsx` — register `ph:frame-corners` in `ICON_NAMES`.
+- **Modify (test)** `src/components/canvas-editor.test.ts` — behavioral tests for the resolver, updated Escape pin, new fullscreen wiring + CSS pins. Already registered in `scripts/run-tests.mjs` (line ~373), so no suite wiring needed.
+
+---
+
+### Task 1: Escape-precedence resolver (`src/lib/canvas-editor-escape.ts`)
+
+**Files:**
+- Create: `src/lib/canvas-editor-escape.ts`
+- Test: `src/components/canvas-editor.test.ts` (append to existing file)
+
+- [ ] **Step 1: Write the failing behavioral tests**
+
+In `src/components/canvas-editor.test.ts`, add below the existing import block (after `import * as inspector from "../lib/canvas-inspector.ts";`):
+
+```js
+import { resolveEscapeAction } from "../lib/canvas-editor-escape.ts";
+```
+
+And append this section at the end of the file, just above the final `console.log("canvas editor wiring: ok");` line:
+
+```js
+// ── Escape precedence: field → selection → in-app expand ────────────────────
+assert.equal(
+  resolveEscapeAction({ fieldHasContent: true, hasSelection: true, expanded: true }),
+  "none",
+  "a non-empty field owns Escape outright",
+);
+assert.equal(
+  resolveEscapeAction({ fieldHasContent: false, hasSelection: true, expanded: true }),
+  "clear-selection",
+  "selection clears before expand exits",
+);
+assert.equal(
+  resolveEscapeAction({ fieldHasContent: false, hasSelection: false, expanded: true }),
+  "exit-expand",
+  "with nothing selected, Escape exits the expanded sketch",
+);
+assert.equal(
+  resolveEscapeAction({ fieldHasContent: false, hasSelection: false, expanded: false }),
+  "none",
+  "Escape is a no-op when there is nothing to dismiss",
+);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: FAIL — `Cannot find module '../lib/canvas-editor-escape.ts'`.
+
+- [ ] **Step 3: Implement the resolver**
+
+Create `src/lib/canvas-editor-escape.ts`:
+
+```ts
+// Escape-key precedence for the canvas sketch editor: fields own Escape while
+// they hold content, then a component selection clears, then in-app expand
+// exits. One deterministic resolver so the editor and its tests share the
+// rule (the component module imports CSS, so tests import this instead).
+
+export type CanvasEscapeAction = "none" | "clear-selection" | "exit-expand";
+
+export function resolveEscapeAction(state: {
+  fieldHasContent: boolean;
+  hasSelection: boolean;
+  expanded: boolean;
+}): CanvasEscapeAction {
+  if (state.fieldHasContent) return "none";
+  if (state.hasSelection) return "clear-selection";
+  if (state.expanded) return "exit-expand";
+  return "none";
+}
+```
+
+- [ ] **Step 4: Run the test to verify the new asserts pass**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: PASS (`canvas editor wiring: ok` printed; `pass 1`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/canvas-editor-escape.ts src/components/canvas-editor.test.ts
+git commit -S -m "feat(canvas): add Escape-precedence resolver for sketch editor (cave-i0qt)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: Register the `ph:frame-corners` icon
+
+**Files:**
+- Modify: `src/lib/icon.tsx` (ICON_NAMES array, ~line 177)
+
+- [ ] **Step 1: Add the icon name**
+
+In `src/lib/icon.tsx`, find the entries:
+
+```tsx
+  "ph:flag",
+  "ph:flag-fill",
+```
+
+and add the new name after them:
+
+```tsx
+  "ph:flag",
+  "ph:flag-fill",
+  "ph:frame-corners",
+```
+
+(Icon exists in Phosphor — verified in `node_modules/@iconify-json/ph/icons.json`.)
+
+- [ ] **Step 2: Regenerate the bundled icon subset**
+
+`ICON_NAMES` is backed by the generated `src/lib/ph-icons-subset.json` (the only collection registered with Iconify; `src/lib/icon-subset.test.ts` enforces sync):
+
+```bash
+node scripts/generate-icon-subset.mjs
+node --experimental-strip-types --no-warnings --test src/lib/icon-subset.test.ts
+```
+
+Expected: test passes; `git status` shows only `src/lib/ph-icons-subset.json` changed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/icon.tsx src/lib/ph-icons-subset.json
+git commit -S -m "feat(icons): register ph:frame-corners for canvas full screen (cave-i0qt)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: Component wiring (state, Escape rewrite, header buttons)
+
+**Files:**
+- Modify: `src/components/canvas-editor.tsx`
+- Test: `src/components/canvas-editor.test.ts`
+
+- [ ] **Step 1: Update the stale Escape pin and add failing wiring pins**
+
+In `src/components/canvas-editor.test.ts`, **replace** the existing Escape pin (the block under the comment `// Escape deselects, but never swallows Escape from a non-empty field.`):
+
+```js
+// Escape deselects, but never swallows Escape from a non-empty field.
+assert.match(
+  editor,
+  /event\.key !== "Escape" \|\| !selectionRef\.current\) return;[\s\S]{0,400}?active\.value\.trim\(\)[\s\S]{0,120}?return;[\s\S]{0,200}?setSelection\(null\)/,
+  "Escape clears the selection unless a field still holds content",
+);
+```
+
+with:
+
+```js
+// Escape routes through the shared resolver: field → selection → expand.
+assert.match(
+  editor,
+  /import \{ resolveEscapeAction \} from "@\/lib\/canvas-editor-escape";/,
+  "the editor delegates Escape precedence to the shared resolver",
+);
+assert.match(
+  editor,
+  /event\.key !== "Escape"\) return;[\s\S]{0,500}?resolveEscapeAction\(\{/,
+  "the keydown handler asks the resolver what Escape should do",
+);
+assert.match(
+  editor,
+  /action === "clear-selection"[\s\S]{0,300}?setSelection\(null\)[\s\S]{0,400}?action === "exit-expand"[\s\S]{0,200}?setExpanded\(false\)/,
+  "selection clears before expand exits, matching the resolver order",
+);
+```
+
+Then add a new pin section just above the `// ── Escape precedence` section added in Task 1:
+
+```js
+// ── Full screen: in-app expand + native fullscreen ──────────────────────────
+assert.match(
+  editor,
+  /className=\{`canvas-editor\$\{expanded \? " canvas-editor--expanded" : ""\}`\}/,
+  "the expanded state drives the root modifier class",
+);
+assert.match(editor, /aria-pressed=\{expanded\}/, "the expand toggle exposes pressed state");
+assert.match(
+  editor,
+  /doc\.fullscreenEnabled \|\| doc\.webkitFullscreenEnabled/,
+  "availability covers standard and WebKit-prefixed Fullscreen APIs",
+);
+assert.match(
+  editor,
+  /\{fullscreenAvailable \? \(/,
+  "the native full screen button renders only when the API is available",
+);
+assert.match(
+  editor,
+  /addEventListener\("fullscreenchange", onFullscreenChange\);[\s\S]{0,120}?addEventListener\("webkitfullscreenchange", onFullscreenChange\)/,
+  "fullscreenchange (incl. webkit) keeps the button state in sync",
+);
+assert.match(
+  editor,
+  /ref=\{frameShellRef\}/,
+  "the frame shell (iframe + error overlay) is the fullscreen element",
+);
+```
+
+- [ ] **Step 2: Run the test to verify the new pins fail**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: FAIL — first failing assert: "the editor delegates Escape precedence to the shared resolver".
+
+- [ ] **Step 3: Implement the component changes**
+
+All edits in `src/components/canvas-editor.tsx`.
+
+**3a — import the resolver.** After the line `import { buildCanvasCommentsRequest } from "@/lib/canvas-comments";` add:
+
+```tsx
+import { resolveEscapeAction } from "@/lib/canvas-editor-escape";
+```
+
+**3b — fullscreen DOM typings.** After the `type StyleKey = ...` line (module scope, near the other type aliases), add:
+
+```tsx
+// WKWebView (Tauri shell) still exposes only the webkit-prefixed Fullscreen
+// API surface; these widen the DOM types for feature-detected fallbacks.
+type FullscreenDocument = Document & {
+  webkitFullscreenEnabled?: boolean;
+  webkitFullscreenElement?: Element | null;
+  webkitExitFullscreen?: () => void;
+};
+type FullscreenElement = HTMLElement & {
+  webkitRequestFullscreen?: () => void;
+};
+```
+
+**3c — state + refs.** After the line `const [announcement, setAnnouncement] = useState("");` add:
+
+```tsx
+  const [expanded, setExpanded] = useState(false);
+  const [nativeFullscreen, setNativeFullscreen] = useState(false);
+  const [fullscreenAvailable, setFullscreenAvailable] = useState(false);
+```
+
+After the line `const frameRef = useRef<HTMLIFrameElement | null>(null);` add:
+
+```tsx
+  const frameShellRef = useRef<HTMLDivElement | null>(null);
+```
+
+**3d — rewrite the Escape handler.** Replace the whole existing effect (comment included):
+
+```tsx
+  // Escape clears the selection — unless focus sits in a field that still has
+  // content (conventional: Escape there belongs to the field/draft).
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape" || !selectionRef.current) return;
+      const active = document.activeElement;
+      if (
+        (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)
+        && active.value.trim()
+      ) {
+        return;
+      }
+      selectionRef.current = null;
+      setSelection(null);
+      setAnnouncement("Selection cleared.");
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+```
+
+with:
+
+```tsx
+  // Escape precedence (shared resolver): a non-empty field owns Escape, then
+  // the selection clears, then the in-app expanded sketch restores.
+  const expandedRef = useRef(expanded);
+  expandedRef.current = expanded;
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== "Escape") return;
+      const active = document.activeElement;
+      const fieldHasContent =
+        (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)
+        && Boolean(active.value.trim());
+      const action = resolveEscapeAction({
+        fieldHasContent,
+        hasSelection: selectionRef.current !== null,
+        expanded: expandedRef.current,
+      });
+      if (action === "clear-selection") {
+        selectionRef.current = null;
+        setSelection(null);
+        setAnnouncement("Selection cleared.");
+      } else if (action === "exit-expand") {
+        setExpanded(false);
+        setAnnouncement("Sketch restored.");
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, []);
+```
+
+(Note: the `expandedRef` declaration + render-sync assignment sit immediately before the effect, mirroring how `modeRef`/`selectionRef` are render-synced at the top of the component.)
+
+**3e — availability + change sync effect.** Directly after the rewritten Escape effect, add:
+
+```tsx
+  // Native fullscreen: detect availability once, and mirror fullscreenchange
+  // (incl. the WebKit-prefixed event WKWebView fires) into button state.
+  useEffect(() => {
+    const doc = document as FullscreenDocument;
+    setFullscreenAvailable(Boolean(doc.fullscreenEnabled || doc.webkitFullscreenEnabled));
+    function onFullscreenChange() {
+      const active = Boolean(doc.fullscreenElement ?? doc.webkitFullscreenElement);
+      setNativeFullscreen(active);
+      setAnnouncement(active ? "Entered full screen." : "Exited full screen.");
+    }
+    document.addEventListener("fullscreenchange", onFullscreenChange);
+    document.addEventListener("webkitfullscreenchange", onFullscreenChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onFullscreenChange);
+      document.removeEventListener("webkitfullscreenchange", onFullscreenChange);
+    };
+  }, []);
+```
+
+**3f — toggle callbacks.** Directly after the effect from 3e, add:
+
+```tsx
+  const toggleExpanded = useCallback(() => {
+    setExpanded(!expanded);
+    setAnnouncement(!expanded ? "Sketch expanded." : "Sketch restored.");
+  }, [expanded]);
+
+  const toggleNativeFullscreen = useCallback(() => {
+    const doc = document as FullscreenDocument;
+    if (doc.fullscreenElement ?? doc.webkitFullscreenElement) {
+      if (doc.exitFullscreen) void doc.exitFullscreen().catch(() => {});
+      else doc.webkitExitFullscreen?.();
+      return;
+    }
+    const shell = frameShellRef.current as FullscreenElement | null;
+    if (!shell) return;
+    if (shell.requestFullscreen) {
+      void shell.requestFullscreen().catch(() => {
+        setAnnouncement("Full screen was blocked.");
+      });
+    } else {
+      shell.webkitRequestFullscreen?.();
+    }
+  }, []);
+```
+
+**3g — root modifier class.** Change:
+
+```tsx
+    <div className="canvas-editor">
+```
+
+to:
+
+```tsx
+    <div className={`canvas-editor${expanded ? " canvas-editor--expanded" : ""}`}>
+```
+
+**3h — header view controls.** In the header JSX, between `</span>` closing `canvas-editor__title` and the `canvas-editor__modes` span — i.e. change:
+
+```tsx
+        <span className="canvas-editor__title" title={artifact.title}>{artifact.title}</span>
+        <span className="canvas-editor__modes" role="group" aria-label="Editor mode">
+```
+
+to:
+
+```tsx
+        <span className="canvas-editor__title" title={artifact.title}>{artifact.title}</span>
+        <span className="canvas-editor__view-controls" role="group" aria-label="Sketch view">
+          <button
+            type="button"
+            className={`canvas-editor__view focus-ring-inset${expanded ? " is-active" : ""}`}
+            title={expanded ? "Exit expanded sketch" : "Expand sketch"}
+            aria-label={expanded ? "Exit expanded sketch" : "Expand sketch"}
+            aria-pressed={expanded}
+            onClick={toggleExpanded}
+          >
+            <Icon name={expanded ? "ph:arrows-in-simple" : "ph:arrows-out-simple"} width={15} aria-hidden />
+          </button>
+          {fullscreenAvailable ? (
+            <button
+              type="button"
+              className="canvas-editor__view focus-ring-inset"
+              title={nativeFullscreen ? "Exit full screen" : "Enter full screen"}
+              aria-label={nativeFullscreen ? "Exit full screen" : "Enter full screen"}
+              onClick={toggleNativeFullscreen}
+            >
+              <Icon name="ph:frame-corners" width={15} aria-hidden />
+            </button>
+          ) : null}
+        </span>
+        <span className="canvas-editor__modes" role="group" aria-label="Editor mode">
+```
+
+**3i — frame-shell ref.** Change:
+
+```tsx
+          <div className="canvas-editor__frame-shell">
+```
+
+to:
+
+```tsx
+          <div className="canvas-editor__frame-shell" ref={frameShellRef}>
+```
+
+- [ ] **Step 4: Run the test to verify the pins pass**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/canvas-editor.tsx src/components/canvas-editor.test.ts
+git commit -S -m "feat(canvas): in-app expand + native full screen for the sketch editor (cave-i0qt)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: CSS (view controls, expanded layout, :fullscreen chrome)
+
+**Files:**
+- Modify: `src/styles/canvas-editor.css`
+- Test: `src/components/canvas-editor.test.ts`
+
+- [ ] **Step 1: Add failing CSS pins**
+
+In `src/components/canvas-editor.test.ts`, at the end of the `// ── Full screen` pin section from Task 3, add:
+
+```js
+const editorCss = readFileSync(new URL("../styles/canvas-editor.css", import.meta.url), "utf8");
+assert.match(
+  editorCss,
+  /\.canvas-editor--expanded \.canvas-editor__aside \{\s*display: none;/,
+  "expanding hides the inspector/design-chat aside",
+);
+assert.match(
+  editorCss,
+  /\.canvas-editor--expanded \.canvas-editor__frame-shell \{[^}]*width: 100%;/,
+  "expanding removes the 900px frame cap",
+);
+assert.match(
+  editorCss,
+  /\.canvas-editor__frame-shell:fullscreen \{/,
+  "native fullscreen strips the frame chrome",
+);
+```
+
+- [ ] **Step 2: Run the test to verify the pins fail**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: FAIL — "expanding hides the inspector/design-chat aside".
+
+- [ ] **Step 3: Add the CSS**
+
+In `src/styles/canvas-editor.css`:
+
+**4a** — after the `.canvas-editor__done:hover` rule (end of the Header section), add:
+
+```css
+/* View controls: in-app expand toggle + native full screen. */
+.canvas-editor__view-controls {
+  display: inline-flex;
+  height: 30px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  overflow: hidden;
+  flex: none;
+}
+.canvas-editor__view {
+  display: inline-flex;
+  align-items: center;
+  padding: 0 var(--space-2);
+  border: 0;
+  cursor: pointer;
+  color: var(--text-muted);
+  background: transparent;
+  transition: color 0.12s ease, background 0.12s ease;
+}
+.canvas-editor__view:hover {
+  color: var(--text-primary);
+}
+.canvas-editor__view.is-active {
+  color: var(--accent-presence);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  box-shadow: inset 0 0 0 1px var(--accent-presence);
+}
+```
+
+**4b** — after the `.canvas-editor__error` rule (end of the Body section, before the Aside section), add:
+
+```css
+/* Expanded: the sketch fills the editor body; the aside and stage chrome go.
+   Pure CSS off the root modifier so editor state survives the toggle. */
+.canvas-editor--expanded .canvas-editor__aside {
+  display: none;
+}
+.canvas-editor--expanded .canvas-editor__stage {
+  padding: 0;
+}
+.canvas-editor--expanded .canvas-editor__frame-shell {
+  width: 100%;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+/* Native fullscreen: the frame shell itself is the fullscreen element.
+   Separate rules — an unsupported selector would invalidate a shared list. */
+.canvas-editor__frame-shell:fullscreen {
+  border: 0;
+  border-radius: 0;
+}
+.canvas-editor__frame-shell:-webkit-full-screen {
+  border: 0;
+  border-radius: 0;
+}
+```
+
+**4c** — extend the reduced-motion block at the bottom of the file. Change:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .canvas-editor__mode {
+    transition: none;
+  }
+}
+```
+
+to:
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  .canvas-editor__mode,
+  .canvas-editor__view {
+    transition: none;
+  }
+}
+```
+
+- [ ] **Step 4: Run the test to verify everything passes**
+
+```bash
+node --experimental-strip-types --no-warnings --test src/components/canvas-editor.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/styles/canvas-editor.css src/components/canvas-editor.test.ts
+git commit -S -m "feat(canvas): expanded + fullscreen styles for the sketch stage (cave-i0qt)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: Validation, push, PR
+
+**Files:** none (verification + delivery)
+
+- [ ] **Step 1: Typecheck**
+
+```bash
+pnpm typecheck
+```
+
+Expected: exits 0, no output errors.
+
+- [ ] **Step 2: Run the app test suite**
+
+```bash
+pnpm test:app
+```
+
+Expected: all suites pass (this catches cross-file regressions and the check-tests-wired gate).
+
+- [ ] **Step 3 (optional, manual): Visual check**
+
+If a visual check is wanted, use the `run-cave-app` skill from the worktree to open Canvas → a sketch → verify: Expand fills the body and hides the rail, Esc restores (selection clears first), the frame-corners button enters/exits native fullscreen, and the button hides if the API is unavailable.
+
+- [ ] **Step 4: Race check, push, open PR**
+
+```bash
+gh pr list --limit 15 --search "canvas fullscreen" --json number,title
+git push -u origin feat/canvas-fullscreen
+gh pr create --base main --head feat/canvas-fullscreen \
+  --title "feat(canvas): in-app expand + native full screen for the sketch editor (cave-i0qt)" \
+  --body "Adds two view controls to the Canvas sketch editor header, per the approved spec (docs/superpowers/specs/2026-07-21-canvas-fullscreen-design.md, untracked):
+
+- **Expand** — in-app toggle: hides the 320px aside and the 900px frame cap so the sketch fills the editor body. Esc exits (selection-clear keeps Esc priority via a shared resolver). State (selection, drafts, comments, chat) survives the toggle.
+- **Full screen** — native \`requestFullscreen()\` on the frame shell, with webkit-prefixed fallbacks for WKWebView/Tauri; hidden when the Fullscreen API is unavailable; \`fullscreenchange\` keeps the control in sync.
+
+A11y: \`aria-pressed\` on the toggle, labelled icon buttons, announcements through the editor's existing live region.
+
+Tests: behavioral coverage for \`resolveEscapeAction\` + source-regex pins for the wiring and CSS in \`canvas-editor.test.ts\`.
+
+Bead: cave-i0qt"
+```
+
+Expected: PR opens; required checks `Frontend build`, `Rust check`, `CodeQL`, `E2E (Playwright)` start.
+
+- [ ] **Step 5: Record evidence on the bead**
+
+```bash
+bd update cave-i0qt --notes "Implemented on feat/canvas-fullscreen (worktree .worktrees/feat-canvas-fullscreen). PR #<n>. Verified: canvas-editor.test.ts targeted run, pnpm typecheck, pnpm test:app. Awaiting required checks + merge."
+```
+
+- [ ] **Step 6: After checks go green — merge and clean up**
+
+```bash
+gh pr merge <n> --squash --delete-branch
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git worktree remove .worktrees/feat-canvas-fullscreen
+git branch -D feat/canvas-fullscreen
+git worktree list
+bd close cave-i0qt
+```
+
+Expected: squash lands on `main`; worktree/branch gone; bead closed after merge.

--- a/docs/superpowers/plans/2026-07-21-shipped-data-table.md
+++ b/docs/superpowers/plans/2026-07-21-shipped-data-table.md
@@ -1,0 +1,58 @@
+# Shipped Data Table — /daily-report Merged PRs (cave-zo7f)
+
+Spec: `docs/superpowers/specs/2026-07-09-shipped-data-table-design.md` (retargeted 2026-07-21).
+Branch `feat/shipped-data-table`, worktree `.worktrees/feat-shipped-data-table`, base `origin/main` 4fbd6f060.
+
+**Goal:** Replace the unbounded `dr-list` of merged-PR rows on `/daily-report/[date]` with a bounded (300px, internal scroll, sticky header), filterable (title / repo full+short / #number), sortable (3-state cycle, aria-sort) semantic table. Section `SectionHead` (icon/title/total count) stays.
+
+**Data:** `MergedPr` = `{ repo /* "owner/name" */, number, title, url, mergedAt }` from `src/lib/daily-report-facts.ts`. `relativeTime(iso, nowMs)` from `src/lib/relative-time.ts` accepts epoch ms.
+
+## Task 1 — Pure helpers: `src/lib/shipped-table.ts` (TDD)
+
+New module, client-safe (no `node:` imports). Exports:
+
+- `type ShippedSortKey = "pr" | "repo" | "merged"`, `type ShippedSortDir = "asc" | "desc"`, `type ShippedSort = { key: ShippedSortKey; dir: ShippedSortDir } | null`
+- `filterShippedRows(rows: readonly MergedPr[], query: string): MergedPr[]` — trim+lowercase query; empty query → all rows (same array or copy). Match: title substring; full repo (`owner/name`) substring; short repo (`name` after last `/`) substring; PR number — `#123` or bare `123` matches `String(number)` substring.
+- `sortShippedRows(rows: readonly MergedPr[], sort: ShippedSort): MergedPr[]` — never mutates input. `null` sort → default merged-newest: valid `mergedAt` timestamps descending; invalid timestamps (NaN from `Date.parse`) sort AFTER all valid; input index is the final stable tie-breaker. `pr` → `title.localeCompare` (dir); `repo` → full repo `localeCompare`, then `number` ascending numeric (dir applies to both); `merged` → timestamp (dir), invalid always last regardless of dir, index tie-break.
+- `nextShippedSort(current: ShippedSort, key: ShippedSortKey): ShippedSort` — 3-state cycle. First activation: `merged` starts `desc`, `pr`/`repo` start `asc`. Second: flips dir. Third: `null` (default order). Clicking a different key starts that key's first state.
+
+Tests (same file as Task 2 pins): `src/components/shipped-table.test.ts` — top-level assertion script (`// @ts-nocheck`, `node:assert/strict`, imports helpers from `../lib/shipped-table.ts`). Behavioral coverage: filter by title / full repo / short repo / `#number` / bare number, case-insensitive, empty query; sort default newest-first, invalid-date-last, stable ties; each key's cycle incl. cross-key switch; non-mutation.
+
+TDD: write failing asserts first (module missing), then implement until green:
+`node --experimental-strip-types --no-warnings --test src/components/shipped-table.test.ts`
+
+Commit: `feat(daily-report): shipped-table filter/sort helpers (cave-zo7f)` (signed `-S`, Copilot co-author trailer).
+
+## Task 2 — Component, page wiring, CSS, pins
+
+**`src/components/shipped-table.tsx`** — `"use client"`. Props `{ rows: readonly MergedPr[]; nowMs: number }`. State `query` (""), `sort` (null). Derived `useMemo`: `sortShippedRows(filterShippedRows(rows, query), sort)`.
+
+Structure (all `dr-shipped*` classes, `dr-*` conventions):
+- Toolbar: labeled search input (`placeholder="Filter shipped work…"`, `aria-label` naming titles/repositories/PR numbers, `type="search"`) + `<span role="status">` count `visible / total` (e.g. `3 / 12`).
+- One bordered shell wrapping toolbar + scroll viewport. Viewport div: `tabIndex={0}`, `aria-label="Merged pull requests table"`, class `dr-shipped__viewport`.
+- `<table>` with `<thead>`/`<tbody>`, `<th scope="col">` × 3 (Pull request / Repository / Merged), each header a real `<button type="button">` calling `setSort(nextShippedSort(sort, key))`. `aria-sort` on the `<th>`: `ascending`/`descending` when active, `none` otherwise. Caret `Icon` (`ph:caret-up`/`ph:caret-down`) when active, `aria-hidden`.
+- Rows: title cell = `<a href={pr.url} target="_blank" rel="noreferrer">{pr.title}</a>`; repo cell `owner/repo#number`; merged cell `relativeTime(pr.mergedAt, nowMs)`. Key `${repo}#${number}`.
+- Empty-filter state: single `<td colSpan={3}>` row — `No shipped work matches this filter.`
+
+**Page wiring** (`src/app/daily-report/[date]/page.tsx`): inside the existing `Merged pull requests` section, keep `SectionHead`, replace the `dr-list` map with `<ShippedTable rows={report.prsMerged} nowMs={Date.now()} />`. Remove now-unused imports only if actually unused elsewhere (relativeTime is used by other sections — check).
+
+**CSS** (`src/styles/globals/surface-reporting.css`, after the `.dr-row` block): `.dr-shipped` shell (hairline border, `var(--bg-raised)`, `var(--radius-card)`, overflow hidden); `.dr-shipped__toolbar` (flex, gap, padding, hairline bottom border); `.dr-shipped__viewport { max-height: 300px; overflow: auto; overscroll-behavior: contain; scrollbar-width: thin; }`; `table { width: 100%; min-width: 520px; border-collapse: collapse; }` (min-width gives horizontal scroll in narrow panes); sticky `thead th { position: sticky; top: 0; background: var(--bg-raised); z-index: 1; }`; hairline row separators (`border-top` on `tbody td`); header buttons quiet, active sort + links use `var(--color-info)`; focus via existing `.focus-ring`/`:focus-visible` conventions (match neighboring dr-* controls).
+
+**Pins** (append to `src/components/shipped-table.test.ts`, `readFileSync` + `assert.match`):
+- component: `"use client"`, `role="status"`, `aria-sort`, `scope="col"`, `nextShippedSort`, `rel="noreferrer"`, `tabIndex={0}` on viewport, empty-state string;
+- page: `<ShippedTable` + `rows={report.prsMerged}` present, old `dr-list` PR map gone from that section;
+- CSS: `.dr-shipped__viewport` block contains `max-height: 300px` + `overflow: auto`; `position: sticky` in the shipped thead rule.
+
+**Registration:** add `"src/components/shipped-table.test.ts"` to the app-suite list in `scripts/run-tests.mjs` (alphabetical/nearby grouping as the file list shows). `pnpm check:tests-wired` must pass.
+
+Guards: existing `src/app/daily-report-page.test.ts` pins `Merged pull requests` heading — keep that string in the page.
+
+Commit: `feat(daily-report): bounded interactive shipped table (cave-zo7f)`.
+
+## Task 3 — Validation + PR
+
+1. `node --experimental-strip-types --no-warnings --test src/components/shipped-table.test.ts src/app/daily-report-page.test.ts`
+2. `pnpm check:tests-wired && pnpm typecheck && pnpm test:app`
+3. Browser pass (run-cave-app skill or `pnpm dev`): open a daily report with merged PRs — verify 300px cap, internal+horizontal scroll, sticky header, filter, 3-state sort with aria-sort, links open, focus visible, narrow width. Screenshot.
+4. Race-check `gh pr list`; push; `gh pr create --base main --head feat/shipped-data-table --title "feat(daily-report): bounded interactive merged-PRs table (cave-zo7f)"` — body: problem (unbounded list), what changed (helpers/component/CSS/pins), verification evidence, spec path, bead id.
+5. `bd update cave-zo7f --notes` (PR #, evidence); checks green → `gh pr merge --squash --delete-branch`; worktree+branch cleanup; `bd close cave-zo7f`.

--- a/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
+++ b/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Next.js 16 / React 19, node source-contract tests (`scripts/run-tests.mjs`), design gates (`pnpm lint` = codemod check + design ESLint), pnpm.
 
-**Spec:** `docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md` (local, gitignored). **Bead:** cave-99s9. **Worktree:** `.worktrees/blaze-backdrop` (branch `blaze-backdrop`, already pushed? No — branch exists locally with no commits yet beyond origin/main).
+**Spec:** `docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md` (versioned in this repo since cave-8zjr5). **Bead:** cave-99s9. **Worktree:** `.worktrees/blaze-backdrop` (branch `blaze-backdrop`, already pushed? No — branch exists locally with no commits yet beyond origin/main).
 
 **Working directory for ALL tasks:** `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop`
 

--- a/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
+++ b/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
@@ -1,0 +1,1038 @@
+# Blaze Animated Backdrop Style Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Blaze" (Canvas UI fire/sparks/smoke WebGL effect) as a second backdrop style alongside the image backdrop, selectable in Settings → Appearance → Backdrop, with colors derived from the live theme accent.
+
+**Architecture:** The vendored zero-dependency `Blaze.tsx` renders inside the existing fixed z-0 backdrop layer when a new `style: "image" | "blaze"` preference selects it. All existing machinery (enablement, intensity → layer opacity, scrim, glass translucency, per-familiar image override) is reused unchanged. A small pure module derives `sparkColor`/`smokeColor` from `--accent-presence`.
+
+**Tech Stack:** Next.js 16 / React 19, node source-contract tests (`scripts/run-tests.mjs`), design gates (`pnpm lint` = codemod check + design ESLint), pnpm.
+
+**Spec:** `docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md` (local, gitignored). **Bead:** cave-99s9. **Worktree:** `.worktrees/blaze-backdrop` (branch `blaze-backdrop`, already pushed? No — branch exists locally with no commits yet beyond origin/main).
+
+**Working directory for ALL tasks:** `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop`
+
+**Conventions:** signed commits (`git commit -S`), Co-authored-by trailer:
+`Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
+
+---
+
+## File structure
+
+| File | Responsibility |
+| --- | --- |
+| `src/components/canvasui/Blaze.tsx` (create) | Vendored Canvas UI component, verbatim + design-codemod pass |
+| `src/lib/preferences-schema.ts` (modify) | `BACKDROP_STYLES` option set, `style` field: type, default, normalize, strict patch, legacy mirror/import |
+| `src/lib/preferences-schema.test.ts` (modify) | Schema tests for `style` |
+| `src/lib/cave-backdrop.ts` (modify) | Client `BackdropPrefs.style` plumbing |
+| `src/lib/cave-backdrop.test.ts` (modify) | Source pins for the client plumbing |
+| `src/lib/cave-backdrop-blaze-colors.ts` (create) | Pure accent→colors derivation + playground option constants |
+| `src/components/cave-backdrop-blaze.tsx` (create) | Client component: lazy Blaze, reduced-motion skip, live accent tracking |
+| `src/lib/cave-backdrop-blaze.test.ts` (create) | Unit tests (derivation) + source pins (component, layer, CSS, settings) |
+| `src/components/cave-backdrop-layer.tsx` (modify) | Render Blaze when selected; suppress image accent; skip image fetch |
+| `src/styles/backdrop.css` (modify) | Blaze fill classes + reduced-motion hide rule |
+| `src/components/backdrop-settings.tsx` (modify) | Style segmented picker; image rows conditional |
+| `scripts/run-tests.mjs` (modify) | Register the new test file in the app suite |
+
+---
+
+### Task 1: Vendor the Blaze component
+
+**Files:**
+- Create: `src/components/canvasui/Blaze.tsx`
+
+- [ ] **Step 1: Fetch the registry payload and write the file**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
+curl -sL "https://canvasui.dev/r/blaze-react.json" -o /tmp/blaze-react.json
+node -e "
+const j = require('/tmp/blaze-react.json');
+if (j.name !== 'blaze-react' || j.files[0].path !== 'components/canvasui/Blaze.tsx') throw new Error('unexpected registry payload');
+require('fs').mkdirSync('src/components/canvasui', { recursive: true });
+require('fs').writeFileSync('src/components/canvasui/Blaze.tsx', j.files[0].content);
+console.log('wrote', j.files[0].content.length, 'chars');
+"
+```
+Expected: `wrote 22363 chars` (length may drift slightly if upstream updates; that is fine).
+
+- [ ] **Step 2: Add a provenance header**
+
+Prepend above the `"use client";` line (comments before the directive are valid):
+
+```tsx
+// Vendored from Canvas UI — https://canvasui.dev/docs/components/blaze
+// Registry: https://canvasui.dev/r/blaze-react.json (item "blaze-react"), fetched 2026-07-23.
+// Zero runtime dependencies. Local delta: static JSX styles rewritten by
+// scripts/codemods/tokenize-tsx-design.mjs (design gate) — re-run it after re-vendoring.
+```
+
+- [ ] **Step 3: Run the design codemod (sanctioned auto-fixer)**
+
+```bash
+node scripts/codemods/tokenize-tsx-design.mjs src/components/canvasui/Blaze.tsx
+```
+Expected: `[tokenize-tsx-design] rewrote src/components/canvasui/Blaze.tsx` — it converts the three static `style={{...}}` objects to arbitrary-property utility classes. The `style={{ position: "relative", ...style }}` wrapper stays (runtime-derived, allowed).
+
+- [ ] **Step 4: Verify the gates and types**
+
+```bash
+node scripts/codemods/tokenize-tsx-design.mjs --check src/components/canvasui/Blaze.tsx \
+  && pnpm exec eslint src/components/canvasui/Blaze.tsx --max-warnings=0 \
+  && pnpm typecheck
+```
+Expected: `checked — 0 file(s) with drift`, no ESLint output, tsc exits 0. (If `pnpm typecheck` fails inside the vendored file, fix minimally with a `// @ts-expect-error` + comment rather than restructuring upstream code — but this was pre-verified to pass ESLint/codemod; typecheck is expected clean.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/canvasui/Blaze.tsx
+git commit -S -m "Vendor Canvas UI Blaze component (cave-99s9)
+
+Exact blaze-react registry payload + provenance header + the repo's design
+codemod pass (static inline styles → utility classes). Zero dependencies;
+WebGL2 with built-in reduced-motion, offscreen pause, and DPR capping.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: `style` field in the preferences schema (TDD)
+
+**Files:**
+- Modify: `src/lib/preferences-schema.ts`
+- Test: `src/lib/preferences-schema.test.ts`
+
+- [ ] **Step 1: Write the failing tests** — append at the end of `src/lib/preferences-schema.test.ts`:
+
+```ts
+// ── Backdrop style option set (cave-99s9) ────────────────────────────────────
+// "image" is the compatible default; unknown styles normalize back to it, the
+// strict patch path rejects them, and the legacy mirror round-trips the choice.
+assert.equal(defaults.appearance.backdrop.style, "image");
+{
+  const normalized = normalizeCavePreferences({ appearance: { backdrop: { style: "blaze" } } });
+  assert.equal(normalized.appearance.backdrop.style, "blaze");
+  const coerced = normalizeCavePreferences({ appearance: { backdrop: { style: "confetti" } } });
+  assert.equal(coerced.appearance.backdrop.style, "image", "unknown styles fall back to image");
+}
+{
+  const patch = validatePreferencesPatch({ appearance: { backdrop: { style: "blaze" } } });
+  assert.equal(patch.appearance?.backdrop?.style, "blaze");
+  assert.throws(
+    () => validatePreferencesPatch({ appearance: { backdrop: { style: "confetti" } } }),
+    PreferencesValidationError,
+    "unknown backdrop styles are rejected",
+  );
+}
+{
+  const prefs = createDefaultPreferences(true);
+  prefs.appearance.backdrop.style = "blaze";
+  const mirrored = preferencesToLegacyStorage(prefs);
+  assert.equal(JSON.parse(mirrored["cave:backdrop:v1"]).style, "blaze", "legacy mirror carries the style");
+  const imported = legacyStorageToPreferencesPatch(mirrored);
+  assert.equal(imported.appearance?.backdrop?.style, "blaze", "legacy import restores the style");
+}
+```
+
+(`defaults`, `normalizeCavePreferences`, `validatePreferencesPatch`, `PreferencesValidationError`, `createDefaultPreferences`, `preferencesToLegacyStorage`, `legacyStorageToPreferencesPatch` are already imported/defined at the top of that file.)
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/preferences-schema.test.ts
+```
+Expected: FAIL — `defaults.appearance.backdrop.style` is `undefined`.
+
+- [ ] **Step 3: Implement in `src/lib/preferences-schema.ts`** — six anchored edits:
+
+3a. Below the `CaveBackdropImageMetadata` type (near line 67), add the option set, and add `style` to `CaveBackdropPreferences`:
+
+```ts
+/** Backdrop style option set — grows as animated styles land (cave-99s9). */
+export const BACKDROP_STYLES = ["image", "blaze"] as const;
+export type CaveBackdropStyle = (typeof BACKDROP_STYLES)[number];
+```
+
+```ts
+export type CaveBackdropPreferences = {
+  enabled: boolean;
+  intensity: number;
+  matchAccent: boolean;
+  accentSeed: CaveBackdropAccentSeed | null;
+  /** Which visual fills the layer: the stored image or the Blaze effect. */
+  style: CaveBackdropStyle;
+  /** Explicit per-familiar enablement (cave-kf8p); absent id = image-presence default. */
+  familiars: Record<string, boolean>;
+  image: CaveBackdropImageMetadata;
+};
+```
+
+3b. In `createDefaultPreferences` (backdrop block near line 175), add `style: "image",` after `accentSeed: null,`.
+
+3c. In `normalizeCavePreferences` (backdrop block near line 396), add after the `accentSeed` line:
+
+```ts
+        style: oneOf(backdrop.style, BACKDROP_STYLES, "image"),
+```
+
+3d. In `validatePreferencesPatch` (near line 596): extend the allowed-keys list and add the strict branch after the `accentSeed` branch:
+
+```ts
+      assertAllowedKeys(backdrop, ["enabled", "intensity", "matchAccent", "accentSeed", "style", "familiars", "image"], "appearance.backdrop");
+```
+```ts
+      if (Object.hasOwn(backdrop, "style")) {
+        backdropPatch.style = strictChoice(backdrop.style, BACKDROP_STYLES, "appearance.backdrop.style");
+      }
+```
+
+3e. In `preferencesToLegacyStorage` (near line 809), add `style: appearance.backdrop.style,` inside the `"cave:backdrop:v1": JSON.stringify({...})` object.
+
+3f. In `legacyStorageToPreferencesPatch` (near line 907, inside `if (isRecord(backdropRaw))`), add before the `if (Object.keys(backdrop).length > 0)` line:
+
+```ts
+    if (typeof backdropRaw.style === "string" && BACKDROP_STYLES.includes(backdropRaw.style as never)) {
+      backdrop.style = backdropRaw.style as CaveBackdropStyle;
+    }
+```
+
+(The `CavePreferencesPatch` backdrop type is `Partial<Omit<CaveBackdropPreferences, "image">>` — `style` joins it automatically.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+node --experimental-strip-types src/lib/preferences-schema.test.ts && node --experimental-strip-types src/lib/server/preferences-store.test.ts
+```
+Expected: both PASS (the store test guards patch/merge behavior downstream of the schema).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/preferences-schema.ts src/lib/preferences-schema.test.ts
+git commit -S -m "Preferences: backdrop style option set (image | blaze) (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 3: Client store plumbing in `cave-backdrop.ts` (TDD)
+
+**Files:**
+- Modify: `src/lib/cave-backdrop.ts`
+- Test: `src/lib/cave-backdrop.test.ts`
+
+- [ ] **Step 1: Write the failing source pins** — append at the end of `src/lib/cave-backdrop.test.ts` (it already imports `readFile` from `node:fs/promises`):
+
+```ts
+// ── Backdrop style plumbing (cave-99s9) ──────────────────────────────────────
+// The client store mirrors the central style choice; the default stays the
+// image so existing setups don't change visuals on upgrade.
+{
+  const src = await readFile(new URL("./cave-backdrop.ts", import.meta.url), "utf8");
+  assert.match(src, /style: CaveBackdropStyle;/, "BackdropPrefs carries the style choice");
+  assert.match(src, /style: "image",\n  familiars: \{\},/, "the default style is the image");
+  assert.match(src, /style: central\.style,/, "readBackdropPrefs mirrors the central style");
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop.test.ts
+```
+Expected: FAIL on `BackdropPrefs carries the style choice`.
+
+- [ ] **Step 3: Implement in `src/lib/cave-backdrop.ts`**
+
+3a. Extend the type import (near line 30):
+
+```ts
+import {
+  MAX_FAMILIAR_BACKDROPS,
+  type CaveBackdropStyle,
+  type CaveMode,
+} from "@/lib/preferences-schema";
+```
+
+3b. In `BackdropPrefs` (after the `accentSeed` member):
+
+```ts
+  /** Which visual fills the layer: the stored image or the Blaze effect. */
+  style: CaveBackdropStyle;
+```
+
+3c. In `DEFAULT_PREFS`, add `style: "image",` before `familiars: {},`.
+
+3d. In `readBackdropPrefs`, add `style: central.style,` before `familiars: { ...central.familiars },`.
+
+(`writeBackdropPrefs` spreads patches and posts the whole object to `updateAppPreferences` — no change needed. `applyBackdropToDocument` stays style-agnostic; the layer owns style behavior.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop.test.ts
+```
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/cave-backdrop.ts src/lib/cave-backdrop.test.ts
+git commit -S -m "Backdrop client store: style plumbing (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: Accent-derived colors module + Blaze layer component (TDD)
+
+**Files:**
+- Create: `src/lib/cave-backdrop-blaze-colors.ts`
+- Create: `src/components/cave-backdrop-blaze.tsx`
+- Test: create `src/lib/cave-backdrop-blaze.test.ts`
+- Modify: `scripts/run-tests.mjs` (register the test)
+
+- [ ] **Step 1: Write the failing test** — create `src/lib/cave-backdrop-blaze.test.ts`:
+
+```ts
+// @ts-nocheck
+// Blaze backdrop style (cave-99s9): unit tests for the accent → fire-color
+// derivation, plus source pins for the component contract (reduced motion,
+// lazy chunk, live theme tracking).
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  blazeColorsFromAccent,
+  BLAZE_FALLBACK_SMOKE,
+  BLAZE_FALLBACK_SPARK,
+  BLAZE_OPTIONS,
+} from "./cave-backdrop-blaze-colors.ts";
+
+// ── Smoke IS the accent; sparks sit 70% toward neutral grey ──────────────────
+{
+  const { sparkColor, smokeColor } = blazeColorsFromAccent("rgb(255, 0, 0)");
+  assert.deepEqual(smokeColor, [1, 0, 0], "smoke takes the accent directly");
+  const expected = [1 * 0.3 + 0.66 * 0.7, 0.66 * 0.7, 0.66 * 0.7];
+  for (let i = 0; i < 3; i++) {
+    assert.ok(Math.abs(sparkColor[i] - expected[i]) < 1e-6, "sparks mix 70% toward 0.66 grey");
+  }
+}
+
+// ── The oklch syntax the theme tokens actually use parses in range ───────────
+{
+  const { sparkColor, smokeColor } = blazeColorsFromAccent("oklch(0.72 0.16 293)");
+  assert.ok(smokeColor.every((c) => c >= 0 && c <= 1), "oklch accents land in 0–1 channels");
+  assert.ok(sparkColor.every((c) => c >= 0 && c <= 1), "spark channels stay clamped");
+}
+
+// ── Unparseable accent → the exact Canvas UI playground values ───────────────
+{
+  const { sparkColor, smokeColor } = blazeColorsFromAccent("");
+  assert.deepEqual(sparkColor, BLAZE_FALLBACK_SPARK);
+  assert.deepEqual(smokeColor, BLAZE_FALLBACK_SMOKE);
+}
+
+// ── The exact playground option values (user-configured) ─────────────────────
+assert.deepEqual(BLAZE_OPTIONS, {
+  height: 0.75,
+  distortion: 0.5,
+  distortionScale: 1,
+  speed: 0.5,
+  sparks: 0.75,
+  sparkDensity: 0.75,
+  sparkSize: 0.75,
+  layers: 5,
+  smoke: 1,
+  glow: 0.5,
+});
+
+// ── Component contract pins ──────────────────────────────────────────────────
+const component = readFileSync(new URL("../components/cave-backdrop-blaze.tsx", import.meta.url), "utf8");
+assert.match(
+  component,
+  /if \(reducedMotion \|\| accentCss === null\) return null;/,
+  "reduced motion skips mounting the GPU loop entirely",
+);
+assert.match(
+  component,
+  /dynamic\(\(\) => import\("@\/components\/canvasui\/Blaze"\), \{ ssr: false \}\)/,
+  "the vendored WebGL file stays out of the main bundle",
+);
+assert.match(
+  component,
+  /attributeFilter: \["data-theme", "data-mode", "style"\]/,
+  "colors re-derive live on theme/mode/custom-accent changes",
+);
+
+console.log("cave-backdrop-blaze.test.ts: ok");
+```
+
+- [ ] **Step 2: Register the test** — in `scripts/run-tests.mjs`, in the `app` suite, directly after the line `"src/lib/cave-backdrop.test.ts",` (near line 736), insert:
+
+```js
+    "src/lib/cave-backdrop-blaze.test.ts",
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts
+```
+Expected: FAIL — `Cannot find module … cave-backdrop-blaze-colors.ts`.
+
+- [ ] **Step 4: Create `src/lib/cave-backdrop-blaze-colors.ts`**
+
+```ts
+/**
+ * Blaze backdrop colors — derived from ONE theme token (cave-99s9).
+ *
+ * The smoke takes `--accent-presence` directly; the sparks sit 70% toward a
+ * neutral grey so they read as pale embers over any of the 21 palettes × 2
+ * modes (the same single-token philosophy as the app's state tints). When the
+ * accent can't be parsed, the exact Canvas UI playground values apply.
+ */
+
+import { parseThemeColor } from "@/lib/theme-contrast";
+
+export type BlazeRgb = [number, number, number];
+
+/** Canvas UI playground values — fallback colors. */
+export const BLAZE_FALLBACK_SPARK: BlazeRgb = [0.6314, 0.6314, 0.6902];
+export const BLAZE_FALLBACK_SMOKE: BlazeRgb = [0.5451, 0.3608, 0.9647];
+
+/** Exact effect options from the Canvas UI playground — do not tune casually;
+ *  these are the user-approved look (spec 2026-07-23-blaze-backdrop-design). */
+export const BLAZE_OPTIONS = {
+  height: 0.75,
+  distortion: 0.5,
+  distortionScale: 1,
+  speed: 0.5,
+  sparks: 0.75,
+  sparkDensity: 0.75,
+  sparkSize: 0.75,
+  layers: 5,
+  smoke: 1,
+  glow: 0.5,
+} as const;
+
+const SPARK_GREY = 0.66;
+const SPARK_MIX = 0.7;
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+/** Derive the fire palette from the accent CSS color (any theme syntax). */
+export function blazeColorsFromAccent(accentCss: string): {
+  sparkColor: BlazeRgb;
+  smokeColor: BlazeRgb;
+} {
+  const accent = parseThemeColor(accentCss);
+  if (!accent) return { sparkColor: BLAZE_FALLBACK_SPARK, smokeColor: BLAZE_FALLBACK_SMOKE };
+  const ember = (channel: number) => clamp01(channel * (1 - SPARK_MIX) + SPARK_GREY * SPARK_MIX);
+  return {
+    smokeColor: [clamp01(accent.r), clamp01(accent.g), clamp01(accent.b)],
+    sparkColor: [ember(accent.r), ember(accent.g), ember(accent.b)],
+  };
+}
+```
+
+- [ ] **Step 5: Create `src/components/cave-backdrop-blaze.tsx`**
+
+```tsx
+"use client";
+
+import dynamic from "next/dynamic";
+import { useEffect, useState } from "react";
+import { blazeColorsFromAccent, BLAZE_OPTIONS } from "@/lib/cave-backdrop-blaze-colors";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+
+// The ~22 KB vendored WebGL file loads only when the Blaze style is shown.
+const Blaze = dynamic(() => import("@/components/canvasui/Blaze"), { ssr: false });
+
+function readAccentCss(): string {
+  return getComputedStyle(document.documentElement).getPropertyValue("--accent-presence").trim();
+}
+
+/**
+ * The animated backdrop visual (cave-99s9): Canvas UI Blaze rendered with no
+ * wrapped content, so the output canvas carries pure fire/sparks/smoke behind
+ * the app. Colors derive live from `--accent-presence` — theme and mode swaps
+ * retint the fire without a remount (the vendored wrapper forwards prop
+ * changes to the running instance). Reduced motion mounts nothing: no frozen
+ * fire frame, no GPU spend (backdrop.css hides the layer as the CSS belt to
+ * this suspender). No WebGL2 → the vendored component quietly renders nothing.
+ */
+export function CaveBackdropBlaze() {
+  const reducedMotion = usePrefersReducedMotion();
+  const [accentCss, setAccentCss] = useState<string | null>(null);
+
+  // One observer covers every accent source: preset swaps rewrite
+  // data-theme/data-mode; custom themes carry the accent as an inline style
+  // property on <html>.
+  useEffect(() => {
+    const root = document.documentElement;
+    const sync = () => setAccentCss(readAccentCss());
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(root, {
+      attributes: true,
+      attributeFilter: ["data-theme", "data-mode", "style"],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  if (reducedMotion || accentCss === null) return null;
+  const { sparkColor, smokeColor } = blazeColorsFromAccent(accentCss);
+  return (
+    <div className="cave-backdrop-blaze" aria-hidden>
+      <Blaze
+        {...BLAZE_OPTIONS}
+        sparkColor={sparkColor}
+        smokeColor={smokeColor}
+        className="cave-backdrop-blaze__fill"
+      >
+        {null}
+      </Blaze>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts && node scripts/check-tests-wired.mjs
+```
+Expected: `cave-backdrop-blaze.test.ts: ok` and the wired-guard passes.
+
+- [ ] **Step 7: Lint the new component**
+
+```bash
+pnpm exec eslint src/components/cave-backdrop-blaze.tsx --max-warnings=0 \
+  && node scripts/codemods/tokenize-tsx-design.mjs --check src/components/cave-backdrop-blaze.tsx
+```
+Expected: clean (the component has no static inline styles — layout lives in `backdrop.css`, Task 5).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/lib/cave-backdrop-blaze-colors.ts src/components/cave-backdrop-blaze.tsx src/lib/cave-backdrop-blaze.test.ts scripts/run-tests.mjs
+git commit -S -m "Blaze backdrop visual: accent-derived colors + layer component (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: Layer integration (TDD)
+
+**Files:**
+- Modify: `src/components/cave-backdrop-layer.tsx`
+- Test: `src/lib/cave-backdrop-blaze.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing pins** — append to `src/lib/cave-backdrop-blaze.test.ts` (before the final `console.log`):
+
+```ts
+// ── Layer integration ────────────────────────────────────────────────────────
+const layer = readFileSync(new URL("../components/cave-backdrop-layer.tsx", import.meta.url), "utf8");
+assert.match(
+  layer,
+  /prefs\.style === "blaze" && !familiarImageShowing/,
+  "a familiar's own image still overrides the Blaze style while active",
+);
+assert.match(
+  layer,
+  /\{blazeShowing && active \? <CaveBackdropBlaze \/> : null\}/,
+  "the GPU loop unmounts whenever no backdrop surface is frontmost",
+);
+assert.match(
+  layer,
+  /data-backdrop-style=\{blazeShowing \? "blaze" : "image"\}/,
+  "CSS can target the active backdrop style",
+);
+assert.match(
+  layer,
+  /prefs\.style === "image" &&\n\s*\(prefs\.enabled \|\|/,
+  "image bytes are not fetched while the Blaze style is selected",
+);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts
+```
+Expected: FAIL on the first layer pin.
+
+- [ ] **Step 3: Implement in `src/components/cave-backdrop-layer.tsx`**
+
+3a. Add the import after the existing `@/lib/cave-backdrop` import block:
+
+```tsx
+import { CaveBackdropBlaze } from "@/components/cave-backdrop-blaze";
+```
+
+3b. Replace the `wantsAppImage` assignment (keep the existing comment above it, and append one clause note):
+
+```tsx
+  // The app image is wanted when the app backdrop is on, or for any familiar
+  // explicitly switched on — even one whose own image is showing, so the
+  // fallback stays warm. Deliberately keyed on prefs alone (not the async
+  // familiarUrl): gating on image absence would churn the fetch on every
+  // mount and blank-flash when a familiar image is removed. With the Blaze
+  // style selected the layer never paints the app image, so its bytes are
+  // not fetched at all (cave-99s9).
+  const wantsAppImage =
+    prefs.style === "image" &&
+    (prefs.enabled || (familiarId ? prefs.familiars[familiarId] === true : false));
+```
+
+3c. After the `effectiveEnabled` line, add:
+
+```tsx
+  // Blaze fills the layer app-wide; a familiar's own image (an explicit
+  // per-familiar opt-in) still takes the layer over while it is showing.
+  const blazeShowing =
+    effectiveEnabled && prefs.style === "blaze" && !familiarImageShowing;
+```
+
+3d. Update the apply effect — Blaze joins the familiar-image branch in suppressing the sampled image accent (the theme accent must *drive* the fire, not be driven), and clears the image custom property:
+
+```tsx
+  useEffect(() => {
+    const effectivePrefs =
+      familiarImageShowing || blazeShowing
+        ? { ...prefs, enabled: true, matchAccent: false, accentSeed: null }
+        : { ...prefs, enabled: effectiveEnabled };
+    applyBackdropToDocument(effectivePrefs, blazeShowing ? null : effectiveUrl);
+    const observer = new MutationObserver(() => applyBackdropToDocument(effectivePrefs, undefined));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-mode", "data-theme"] });
+    return () => observer.disconnect();
+  }, [prefs, familiarImageShowing, blazeShowing, effectiveUrl, effectiveEnabled]);
+```
+
+3e. Replace the final return:
+
+```tsx
+  if (!effectiveEnabled) return null;
+  return (
+    <div
+      className="cave-backdrop-layer"
+      data-on={active ? "true" : "false"}
+      data-backdrop-style={blazeShowing ? "blaze" : "image"}
+      aria-hidden
+    >
+      {blazeShowing && active ? <CaveBackdropBlaze /> : null}
+    </div>
+  );
+```
+
+- [ ] **Step 4: Run tests to verify pass** — the new pins plus the pre-existing layer pins in `backdrop-scrim.test.ts` (which pin `effectiveUrl`, `effectiveEnabled`, and the `matchAccent: false, accentSeed: null` suppression — all still present):
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts \
+  && node --experimental-strip-types src/components/backdrop-scrim.test.ts \
+  && pnpm exec eslint src/components/cave-backdrop-layer.tsx --max-warnings=0
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/cave-backdrop-layer.tsx src/lib/cave-backdrop-blaze.test.ts
+git commit -S -m "Backdrop layer: render Blaze style behind Home/Chat (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 6: Backdrop CSS for the Blaze style (TDD)
+
+**Files:**
+- Modify: `src/styles/backdrop.css`
+- Test: `src/lib/cave-backdrop-blaze.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing pins** — append to `src/lib/cave-backdrop-blaze.test.ts` (before the final `console.log`):
+
+```ts
+// ── CSS: fill + reduced-motion hide ──────────────────────────────────────────
+const css = readFileSync(new URL("../styles/backdrop.css", import.meta.url), "utf8");
+assert.match(
+  css,
+  /\.cave-backdrop-blaze \{\n  position: absolute;\n  inset: 0;\n\}/,
+  "the Blaze visual fills the fixed layer",
+);
+assert.match(
+  css,
+  /@media \(prefers-reduced-motion: reduce\) \{\n  html\[data-backdrop\] \.cave-backdrop-layer\[data-backdrop-style="blaze"\] \{\n    display: none;\n  \}\n\}/,
+  "reduced motion hides the animated style entirely (no frozen fire frame)",
+);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts
+```
+Expected: FAIL on the first CSS pin.
+
+- [ ] **Step 3: Implement** — in `src/styles/backdrop.css`, insert after the readability-floor `::after` block (after line ~40, before the `html[data-backdrop-on] .shell-root` section):
+
+```css
+/* ── Blaze style (cave-99s9) ─────────────────────────────────────────────────
+   The animated option: the vendored Canvas UI Blaze renders inside the same
+   fixed layer the image uses, so enablement, the intensity opacity, the
+   scrim above, and the glass contracts below all apply unchanged. The canvas
+   is decorative and inert (aria-hidden; the layer already ignores pointers). */
+.cave-backdrop-blaze {
+  position: absolute;
+  inset: 0;
+}
+
+.cave-backdrop-blaze__fill {
+  width: 100%;
+  height: 100%;
+}
+
+/* No frozen fire frame: reduced motion drops the animated style entirely
+   (the component also skips mounting — this rule is the CSS belt to that
+   suspender). The static image style is unaffected. */
+@media (prefers-reduced-motion: reduce) {
+  html[data-backdrop] .cave-backdrop-layer[data-backdrop-style="blaze"] {
+    display: none;
+  }
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass** (plus the CSS codemod stays a no-op — the drift ratchet requires it):
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts \
+  && node --experimental-strip-types src/components/backdrop-scrim.test.ts \
+  && node --experimental-strip-types src/lib/design-token-drift.test.ts
+```
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/styles/backdrop.css src/lib/cave-backdrop-blaze.test.ts
+git commit -S -m "Backdrop CSS: Blaze fill + reduced-motion hide rule (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 7: Settings — backdrop style picker (TDD)
+
+**Files:**
+- Modify: `src/components/backdrop-settings.tsx`
+- Test: `src/lib/cave-backdrop-blaze.test.ts` (extend)
+
+- [ ] **Step 1: Write the failing pins** — append to `src/lib/cave-backdrop-blaze.test.ts` (before the final `console.log`):
+
+```ts
+// ── Settings: the style picker and its enablement rules ──────────────────────
+const settings = readFileSync(new URL("../components/backdrop-settings.tsx", import.meta.url), "utf8");
+assert.match(settings, /ariaLabel="Backdrop style"/, "the style picker is a labeled segmented control");
+assert.match(
+  settings,
+  /writeBackdropPrefs\(\{ style, enabled: true \}\);/,
+  "choosing Blaze turns the backdrop on without needing an image",
+);
+assert.match(
+  settings,
+  /writeBackdropPrefs\(\{ style, enabled: previewUrl !== null \}\);/,
+  "switching to Image stays on only when a stored image exists",
+);
+assert.match(
+  settings,
+  /\{prefs\.style === "image" \? \(/,
+  "the image chooser and accent-match rows are image-style-only",
+);
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts
+```
+Expected: FAIL on `ariaLabel="Backdrop style"`.
+
+- [ ] **Step 3: Implement in `src/components/backdrop-settings.tsx`**
+
+3a. Add imports:
+
+```tsx
+import { Segmented } from "@/components/ui/settings-controls";
+import { BACKDROP_STYLES, type CaveBackdropStyle } from "@/lib/preferences-schema";
+```
+
+3b. Add module-level label maps (below the imports, above the component):
+
+```tsx
+const STYLE_LABELS: Record<CaveBackdropStyle, string> = { image: "Image", blaze: "Blaze" };
+const STYLE_TITLES: Record<CaveBackdropStyle, string> = {
+  image: "A picture you choose shows behind Home and Chat",
+  blaze: "Animated embers and smoke, tinted to your theme accent",
+};
+```
+
+3c. Add the handler inside `BackdropSettings` (after `clearBackdrop`):
+
+```tsx
+  function setStyle(style: CaveBackdropStyle) {
+    if (style === prefs.style) return;
+    if (style === "blaze") {
+      writeBackdropPrefs({ style, enabled: true });
+      announce("Backdrop set to Blaze — embers and smoke follow your theme accent.");
+      return;
+    }
+    writeBackdropPrefs({ style, enabled: previewUrl !== null });
+    announce(
+      previewUrl
+        ? "Backdrop set to your image."
+        : "Backdrop style set to Image — choose an image to turn it on.",
+    );
+  }
+```
+
+3d. Restructure the JSX. The returned card becomes: a header row (title + description + segmented picker), then the image row *only* for the image style, then the enabled block with Intensity always and Match-accent image-only. Full replacement of the `return (...)` body:
+
+```tsx
+  return (
+    <div className="flex flex-col gap-3 px-4 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-[length:var(--text-base)] font-medium text-[var(--text-primary)]">Backdrop</p>
+          <p className="text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
+            Shows behind Home and Chat — a picture of yours, or animated Blaze embers tinted to
+            your theme.
+          </p>
+        </div>
+        <Segmented
+          ariaLabel="Backdrop style"
+          options={BACKDROP_STYLES}
+          value={prefs.style}
+          onChange={setStyle}
+          getLabel={(option) => STYLE_LABELS[option]}
+          getTitle={(option) => STYLE_TITLES[option]}
+        />
+      </div>
+
+      {prefs.style === "image" ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            disabled={busy}
+            aria-label={previewUrl ? "Replace backdrop image" : "Choose backdrop image"}
+            className="focus-ring grid h-20 w-32 shrink-0 place-items-center overflow-hidden rounded-[var(--radius-card)] border border-dashed border-[var(--border-strong)] bg-[var(--bg-base)]/40 text-[length:var(--text-xs)] text-[var(--text-muted)] hover:border-[var(--accent-presence)]/60"
+          >
+            {previewUrl ? (
+              <img src={previewUrl} alt="" className="h-full w-full object-cover" />
+            ) : (
+              <span>{busy ? "Reading…" : "Choose image"}</span>
+            )}
+          </button>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/avif,image/heic,image/heif"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0] ?? null;
+              if (file) void pickImage(file);
+              e.target.value = "";
+            }}
+          />
+          <p className="min-w-0 flex-1 text-[length:var(--text-xs)] leading-relaxed text-[var(--text-muted)]">
+            The accent tints to the image’s dominant color, kept readable against your theme.
+          </p>
+          <div className="flex items-center gap-2">
+            {previewUrl ? (
+              <Button
+                size="xs"
+                variant="ghost"
+                leadingIcon="ph:x"
+                onClick={() => clearConfirm.trigger(() => void clearBackdrop())}
+                disabled={busy}
+              >
+                {clearConfirm.armed ? "Really clear?" : "Clear"}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+
+      {prefs.enabled ? (
+        <div className="flex flex-col gap-3 border-l border-[var(--border-hairline)] pl-3">
+          <label className="flex items-center gap-3 text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+            <span className="w-16 shrink-0">Intensity</span>
+            <input
+              type="range"
+              min={10}
+              max={80}
+              value={prefs.intensity}
+              onChange={(e) => writeBackdropPrefs({ intensity: Number(e.target.value) })}
+              className="cave-backdrop-intensity min-w-0 flex-1"
+              aria-label="Backdrop intensity"
+            />
+            <span className="w-8 text-right font-mono text-[length:var(--text-xs)] text-[var(--text-muted)]">
+              {prefs.intensity}
+            </span>
+          </label>
+          {prefs.style === "image" ? (
+            <label className="flex items-center justify-between gap-3 text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+              <span>Match accent to the image</span>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={prefs.matchAccent}
+                aria-label="Match accent to the image"
+                onClick={() => writeBackdropPrefs({ matchAccent: !prefs.matchAccent })}
+                className={`focus-ring rounded-[var(--radius-control)] border px-3 py-1 text-[length:var(--text-sm)] transition-colors ${
+                  prefs.matchAccent
+                    ? "border-[var(--accent-presence)] bg-[var(--accent-presence)]/15 text-[var(--text-primary)]"
+                    : "border-[var(--border-hairline)] text-[var(--text-secondary)]"
+                }`}
+              >
+                {prefs.matchAccent ? "On" : "Off"}
+              </button>
+            </label>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+```
+
+(The `Backdrop`/description copy moves into the header row; the accent hint moves next to the chooser. The matchAccent switch markup is byte-identical to today's — the existing a11y pin in `a11y-audit-fixes.test.ts` keeps passing.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```bash
+node --experimental-strip-types src/lib/cave-backdrop-blaze.test.ts \
+  && node --experimental-strip-types src/components/a11y-audit-fixes.test.ts \
+  && node --experimental-strip-types src/components/settings-appearance.test.ts \
+  && pnpm exec eslint src/components/backdrop-settings.tsx --max-warnings=0 \
+  && node scripts/codemods/tokenize-tsx-design.mjs --check src/components/backdrop-settings.tsx
+```
+Expected: all PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/backdrop-settings.tsx src/lib/cave-backdrop-blaze.test.ts
+git commit -S -m "Settings: backdrop style picker (Image | Blaze) (cave-99s9)
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: Full gates, PR, merge, cleanup
+
+**Files:** none new (verification, delivery)
+
+- [ ] **Step 1: Full local gates**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
+pnpm lint && pnpm typecheck && node scripts/check-tests-wired.mjs
+```
+Expected: all clean.
+
+- [ ] **Step 2: Targeted test sweep** (every touched suite file):
+
+```bash
+for t in src/lib/preferences-schema.test.ts src/lib/server/preferences-store.test.ts \
+         src/lib/cave-backdrop.test.ts src/lib/cave-backdrop-blaze.test.ts \
+         src/components/backdrop-scrim.test.ts src/components/a11y-audit-fixes.test.ts \
+         src/components/settings-appearance.test.ts src/lib/design-token-drift.test.ts \
+         src/lib/app-preferences.test.ts src/components/theme-script.test.ts; do
+  node --experimental-strip-types "$t" || exit 1
+done
+```
+Expected: every file passes. (`app-preferences.test.ts` and `theme-script.test.ts` cover the legacy-mirror consumers of `cave:backdrop:v1`.)
+
+- [ ] **Step 3: Production build (CI parity — Frontend build is a required check)**
+
+```bash
+pnpm build
+```
+Expected: build + bundle budgets pass; the Blaze chunk is lazy so no page budget grows.
+
+- [ ] **Step 4: Optional visual QA** — for a human-in-the-loop look, run `bash scripts/dev-app.sh` from the worktree in a foreground terminal, open Settings → Appearance → Backdrop, pick **Blaze**, visit Home and a Chat, flip a few themes and dark/light, check the fire retints; verify Reduce Motion (macOS setting) hides it.
+
+- [ ] **Step 5: Push and open the PR**
+
+```bash
+git push -u origin blaze-backdrop
+gh pr create --base main --head blaze-backdrop \
+  --title "Backdrop: Blaze animated style (Canvas UI) behind Home/Chat" \
+  --body "Adds a style picker to Settings → Appearance → Backdrop: **Image** (existing) or **Blaze** — the vendored zero-dependency Canvas UI fire/sparks/smoke WebGL effect (https://canvasui.dev/docs/components/blaze), rendered in the existing fixed backdrop layer.
+
+- New \`appearance.backdrop.style\` preference (\"image\" | \"blaze\"), strict-validated, legacy-mirrored
+- Colors derive from the live \`--accent-presence\` (smoke = accent, sparks 70% toward neutral) with the Canvas UI playground values as fallback; retints live across all 21 themes × 2 modes
+- Exact playground options: height .75, distortion .5, distortionScale 1, speed .5, sparks .75, sparkDensity .75, sparkSize .75, layers 5, smoke 1, glow .5
+- Reduced motion: layer hidden AND component unmounted (no frozen frame, no GPU); no WebGL2 → quietly empty
+- Existing intensity/scrim/glass/per-familiar-override machinery reused unchanged; vendored file passes the design gates via the repo codemod
+- Bead: cave-99s9 · Spec: docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md (local)"
+```
+
+- [ ] **Step 6: Record evidence on the bead**
+
+```bash
+bd update cave-99s9 --notes "PR #<n> open; branch blaze-backdrop; local gates: lint/typecheck/targeted tests/build green. Awaiting required checks."
+```
+
+- [ ] **Step 7: Wait for required checks, then squash-merge**
+
+```bash
+gh pr checks <n> --watch
+gh pr merge <n> --squash --delete-branch
+```
+All four required checks (Frontend build, Rust check, CodeQL, E2E (Playwright)) must be green. Squash message: keep the PR title + `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+
+- [ ] **Step 8: Local cleanup (worktree + branch)**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git worktree remove .worktrees/blaze-backdrop
+git branch -D blaze-backdrop
+git worktree list
+```
+
+- [ ] **Step 9: Discard the staged shadcn experiment in the primary checkout (user-approved)** — ONLY these paths; `src-tauri/src/sidecar_discovery.rs` and `.beads/*` belong to other work and stay:
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git restore --staged --worktree components.json __shoot2.mjs src/app/globals.css src/app/layout.tsx src/lib/utils.ts package.json pnpm-lock.yaml src/components/canvasui/Blaze.tsx 2>/dev/null || true
+rm -f components.json __shoot2.mjs
+git status --short   # confirm only unrelated files remain
+pnpm install         # prune the experiment's packages per the restored lockfile
+```
+Note: `git restore` of an added-then-restored path may leave the untracked file behind — hence the explicit `rm -f` for the two new files. If `src/components/canvasui/Blaze.tsx` reports a conflict with the merged version, `git checkout origin/main -- src/components/canvasui/Blaze.tsx` after `git pull`.
+
+- [ ] **Step 10: Sync and close the bead**
+
+```bash
+git pull --rebase
+bd close cave-99s9
+bd dolt push || echo "report blocked sync"
+```
+
+---
+
+## Self-review notes (spec coverage)
+
+- Spec §1 vendored component → Task 1. §2 schema → Task 2. §3 client store → Task 3. §4 layer + colors + component → Tasks 4–5. §5 CSS → Task 6. §6 settings → Task 7. Error handling (WebGL null, parse fallback, reduced motion, offscreen, strict validation) → Tasks 4–6 code + Task 2 tests. Testing section → each task's test steps + Task 8 sweep. Delivery §1/§2 → Task 8. Out-of-scope items: no tasks (correct).
+- Type names consistent: `CaveBackdropStyle` (schema, store, settings), `BLAZE_OPTIONS` / `blazeColorsFromAccent` / `BLAZE_FALLBACK_*` (colors module, component, tests), `blazeShowing` (layer + pins), `CaveBackdropBlaze` (component + layer).

--- a/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
+++ b/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Next.js/React (TSX), plain CSS (component-imported sheet), node:test source-contract tests run with `--experimental-strip-types`.
 
-**Spec:** `docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md` (in the primary checkout at `/Users/buns/Documents/GitHub/OpenCoven/coven-cave`; `docs/superpowers` is gitignored — local-only, do not try to commit it).
+**Spec:** `docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md` (versioned in this repo since cave-8zjr5).
 
 **One deliberate deviation from the spec:** the spec listed a `familiarName` prop on `ContractCompliance`. It is not needed — the button copy is static and the brief is built in the parent, which already derives `familiarName`. YAGNI: only `onReview` is added.
 
@@ -338,7 +338,7 @@ Expected: clean (no rewrites proposed).
 gh pr create --base main --head feat/analytics-contract-review \
   --title "feat(analytics): contract review launch + empty-results grid layout" \
   --body "$(cat <<'EOF'
-Two fixes for the Familiar Analytics surface (design spec: docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md, local-only):
+Two fixes for the Familiar Analytics surface (design spec: docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md):
 
 **1. Empty results no longer leave holes in the grid.** `.fa-grid` had `align-items: start`, so a short empty-state card sharing a row with a tall neighbor (empty confidence card next to a full Recent sessions list) floated over a large blank gap. Rows now stretch (grid default) and empty-state notices center vertically inside their cards (`.fa-section > .ui-empty-state`, `.fa-section > .fa-thread-empty`). No JSX/order changes; the "empty thread-signals doesn't go wide" pin is untouched.
 

--- a/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
+++ b/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
@@ -1,0 +1,379 @@
+# Analytics Contract Review Button + Empty-Results Layout Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On the Familiar Analytics page, stop empty-state cards from leaving blank holes in the two-column grid, and give failing Contract compliance reports a "Review and resolve" button that direct-launches a chat seeded with the rehabilitation brief.
+
+**Architecture:** Two surgical changes to one surface. (1) CSS-only layout fix: let `.fa-grid` rows stretch (grid default) and vertically center empty states inside their cards. (2) The `ContractCompliance` component gains an `onReview` callback prop and renders a primary Button when the report fails; the parent (`FamiliarAnalyticsContent`) owns the launch via the existing `requestAgentsNewChat` bridge + `buildRehabilitationBrief` — the exact flow the Studio Contract tab already uses.
+
+**Tech Stack:** Next.js/React (TSX), plain CSS (component-imported sheet), node:test source-contract tests run with `--experimental-strip-types`.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md` (in the primary checkout at `/Users/buns/Documents/GitHub/OpenCoven/coven-cave`; `docs/superpowers` is gitignored — local-only, do not try to commit it).
+
+**One deliberate deviation from the spec:** the spec listed a `familiarName` prop on `ContractCompliance`. It is not needed — the button copy is static and the brief is built in the parent, which already derives `familiarName`. YAGNI: only `onReview` is added.
+
+**Worktree:** All work happens in `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-analytics-contract-review` (branch `feat/analytics-contract-review`, already created from `origin/main`, already has `node_modules` via pnpm — if not, run `pnpm install` there first, ~10s). All commands below run from that directory. Commits MUST be signed (`git commit -S`).
+
+**Key existing code you'll touch or reuse (read these before editing):**
+
+- `src/components/familiar-analytics-content.tsx`
+  - `FaSection` shell (~line 37): renders `<section className="fa-section…">` with a head div, then `{children}` as direct children.
+  - `ContractCompliance` (~line 886): memoized, currently takes only `{ report }`.
+  - Parent `FamiliarAnalyticsContent` (~line 1320): `familiarName` derived at ~1332, `useAnnouncer()` at ~1367, `confirmAction` at ~1377 (the launch pattern to mirror), callsite `<ContractCompliance report={model.contractReport} />` at ~1555.
+- `src/styles/familiar-analytics.css`: `.fa-grid` at ~376 (has `align-items: start` — the bug), `.fa-section` at ~383, `.fa-thread-empty { min-width: 0; }` at ~869, single-column collapse `@container fa (max-width: 880px)` at ~1712.
+- `src/lib/familiar-rehabilitation.ts`: `buildRehabilitationBrief(familiarName, report)` — pure, unit-tested brief generator.
+- `src/lib/agents-new-chat.ts`: `requestAgentsNewChat({ familiarId, initialPrompt, origin })` — already imported in the content file (line ~29).
+- `src/components/familiar-studio-contract-tab.tsx` (~line 129–148): the Studio precedent — `<Button variant="primary" size="sm" className="self-start" leadingIcon="ph:sparkle">` launching a rehabilitation chat when `!report.pass`. (`self-start` is a Tailwind 4 utility; Tailwind is in this repo.)
+- `src/components/familiar-analytics-view.test.ts`: the source-contract test for this surface (node:test `describe`/`it`; reads the content TSX into `source` at top, reads `faCss` per-test). Already registered in `scripts/run-tests.mjs` — extending it needs NO registration change.
+
+**Test command used throughout (run from the worktree root):**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+```
+
+---
+
+### Task 1: Empty-results layout — stretch grid rows, center empty states
+
+**Files:**
+- Modify: `src/components/familiar-analytics-view.test.ts` (add one `it` block after the `it("leads the grid with the full-width self-heal queue and closes with wide contract compliance", …)` block, which ends around line 502)
+- Modify: `src/styles/familiar-analytics.css:375-393`
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/components/familiar-analytics-view.test.ts`, directly after the closing `});` of the `it("leads the grid with the full-width self-heal queue and closes with wide contract compliance", …)` block (~line 502), insert:
+
+```ts
+  it("stretches grid rows and centers empty states so short empty cards don't leave holes", () => {
+    const faCss = readFileSync(new URL("../styles/familiar-analytics.css", import.meta.url), "utf8");
+    const grid = faCss.match(/\.fa-grid\s*\{[^}]*\}/);
+    assert.ok(grid, ".fa-grid rule should exist");
+    assert.doesNotMatch(
+      grid![0],
+      /align-items:\s*start/,
+      "grid rows stretch (the default), so an empty card fills its row instead of floating over a blank gap",
+    );
+    assert.match(
+      faCss,
+      /\.fa-section > \.ui-empty-state,\s*\.fa-section > \.fa-thread-empty\s*\{[^}]*margin-block:\s*auto/,
+      "empty states center vertically inside a stretched card",
+    );
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+```
+
+Expected: FAIL — the new `it` reports `grid rows stretch (the default)…` (the `align-items: start` doesNotMatch assertion trips first). All previously existing tests still pass.
+
+- [ ] **Step 3: Make the CSS change**
+
+In `src/styles/familiar-analytics.css`, replace the `.fa-grid` block (lines ~375–381):
+
+```css
+/* Sections flow in two columns on wide panes; `--wide` spans both. */
+.fa-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+  align-items: start;
+}
+```
+
+with (drop `align-items: start` — stretch is the grid default — and extend the comment):
+
+```css
+/* Sections flow in two columns on wide panes; `--wide` spans both. Rows
+   stretch (grid default) so a short card sharing a row with a tall neighbor
+   fills the cell instead of floating over a blank gap. */
+.fa-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 18px;
+}
+```
+
+Then, immediately after the `.fa-section { … }` block (ends ~line 393, right before the `/* Arriving via a drill-through flashes… */` comment), insert:
+
+```css
+/* Inside a stretched card, an empty-state notice centers in the leftover
+   space instead of hugging the top. Covers both shapes that occur as direct
+   section children: the shared EmptyState and thread-signals' wrapper. */
+.fa-section > .ui-empty-state,
+.fa-section > .fa-thread-empty { margin-block: auto; }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+```
+
+Expected: PASS (all tests, including the new one).
+
+- [ ] **Step 5: Run the neighboring behavior pins (unchanged files, must stay green)**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/thread-signals-section.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/design-token-drift.test.ts
+```
+
+Expected: both PASS. (`thread-signals-section.test.ts` pins that an empty Thread signals section does NOT go wide — we didn't touch that. `design-token-drift.test.ts` confirms the CSS codemod stays a no-op; `margin-block: auto` has no px literal so nothing to tokenize.)
+
+- [ ] **Step 6: Commit (signed)**
+
+```bash
+git add src/styles/familiar-analytics.css src/components/familiar-analytics-view.test.ts
+git commit -S -m "fix(analytics): stretch fa-grid rows and center empty states
+
+A short empty-state card sharing a grid row with a tall neighbor (e.g.
+empty thread-analysis confidence next to a full Recent sessions list)
+floated at the top of the row and left a large blank hole beneath it.
+Drop align-items:start so rows stretch, and center empty-state notices
+inside the stretched cards.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin feat/analytics-contract-review
+```
+
+---
+
+### Task 2: "Review and resolve" button on failing contract reports
+
+**Files:**
+- Modify: `src/components/familiar-analytics-view.test.ts` (add one `it` block right after the one added in Task 1)
+- Modify: `src/components/familiar-analytics-content.tsx` (import at ~line 29, `ContractCompliance` at ~886, parent callback at ~1387, callsite at ~1555)
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/components/familiar-analytics-view.test.ts`, directly after the `it("stretches grid rows and centers empty states…")` block added in Task 1, insert:
+
+```ts
+  it("offers a direct review launch when the contract fails", () => {
+    // Same flow as the Studio Contract tab: seed a chat with the shared,
+    // deterministic rehabilitation brief. No confirm modal — direct launch.
+    assert.match(
+      source,
+      /import \{ buildRehabilitationBrief \} from "@\/lib\/familiar-rehabilitation";/,
+      "content reuses the shared rehabilitation brief builder",
+    );
+    assert.match(
+      source,
+      /buildRehabilitationBrief\(familiarName, model\.contractReport\)/,
+      "the review thread is seeded with the brief for this familiar's failing report",
+    );
+    assert.match(
+      source,
+      /\{!report\.pass \? \([\s\S]*?Review and resolve[\s\S]*?\) : null\}/,
+      "the Review and resolve button renders only for failing reports",
+    );
+    assert.match(
+      source,
+      /onReview=\{reviewContract\}/,
+      "the contract section is wired to the parent-owned launch callback",
+    );
+    assert.match(
+      source,
+      /const reviewContract = useCallback\(\(\) => \{[\s\S]*?requestAgentsNewChat\(\{[\s\S]*?familiarId: model\.familiarId,[\s\S]*?origin: "chat"/,
+      "review launches a familiar-scoped working thread via the agents-new-chat bridge",
+    );
+    assert.match(
+      source,
+      /announce\(`Opening a review thread to repair \$\{familiarName\}'s contract\.`\)/,
+      "the launch is announced to assistive tech",
+    );
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+```
+
+Expected: FAIL — the new `it` reports `content reuses the shared rehabilitation brief builder`.
+
+- [ ] **Step 3: Implement in `familiar-analytics-content.tsx`**
+
+**(a)** After the existing import at ~line 29 (`import { requestAgentsNewChat } from "@/lib/agents-new-chat";`), add:
+
+```ts
+import { buildRehabilitationBrief } from "@/lib/familiar-rehabilitation";
+```
+
+**(b)** Change the `ContractCompliance` signature (~line 886) from:
+
+```tsx
+const ContractCompliance = memo(function ContractCompliance({ report }: { report: ContractReport | null }) {
+```
+
+to:
+
+```tsx
+const ContractCompliance = memo(function ContractCompliance({
+  report,
+  onReview,
+}: {
+  report: ContractReport | null;
+  /** Direct-launch a review thread for a failing report (parent owns the launch). */
+  onReview: () => void;
+}) {
+```
+
+**(c)** Inside the same component, directly after the detail-panel expression (`{detail ? ( … ) : null}`, ends ~line 938) and before the closing `</>`, add:
+
+```tsx
+          {/* Failing contract = operating as an agent. Mirror the Studio
+              Contract tab: direct-launch a chat seeded with the rehabilitation
+              brief so investigation and resolution start in one click. */}
+          {!report.pass ? (
+            <Button
+              variant="primary"
+              size="sm"
+              className="self-start"
+              leadingIcon="ph:sparkle"
+              onClick={onReview}
+            >
+              Review and resolve
+            </Button>
+          ) : null}
+```
+
+(This sits inside the `{report ? (…) : (…)}` truthy branch, so `report` is non-null there. `Button` is already imported; `ph:sparkle` is already in `ICON_NAMES` — no icon-subset regeneration.)
+
+**(d)** In `FamiliarAnalyticsContent`, directly after the `confirmAction` callback (ends ~line 1387), add:
+
+```tsx
+  // Contract review: direct-launch a thread seeded with the rehabilitation
+  // brief — the same "Rite of Binding" flow as the Studio Contract tab.
+  const reviewContract = useCallback(() => {
+    if (!model.contractReport) return;
+    requestAgentsNewChat({
+      familiarId: model.familiarId,
+      initialPrompt: `${buildRehabilitationBrief(familiarName, model.contractReport)}\n\nAnalytics source: /dashboard/familiars/${encodeURIComponent(model.familiarId)}/analytics`,
+      origin: "chat" as const,
+    });
+    announce(`Opening a review thread to repair ${familiarName}'s contract.`);
+  }, [announce, familiarName, model.contractReport, model.familiarId]);
+```
+
+**(e)** Update the callsite (~line 1555) from:
+
+```tsx
+        <ContractCompliance report={model.contractReport} />
+```
+
+to:
+
+```tsx
+        <ContractCompliance report={model.contractReport} onReview={reviewContract} />
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+```
+
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Type-check and lint the changed files**
+
+```bash
+pnpm exec tsc --noEmit
+pnpm exec eslint src/components/familiar-analytics-content.tsx src/components/familiar-analytics-view.test.ts
+```
+
+Expected: both clean (tsc may take ~1–2 min; the eslint run includes the design-gate rules).
+
+- [ ] **Step 6: Commit (signed) and push**
+
+```bash
+git add src/components/familiar-analytics-content.tsx src/components/familiar-analytics-view.test.ts
+git commit -S -m "feat(analytics): review-and-resolve launch for failing contract reports
+
+The Contract compliance section showed violations but offered no action.
+When the report fails, render a section-level 'Review and resolve' button
+that direct-launches a working thread seeded with the shared rehabilitation
+brief (buildRehabilitationBrief) — the same flow as the Studio Contract
+tab — plus an analytics-source provenance line, with an a11y announcement.
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push
+```
+
+---
+
+### Task 3: Full verification, PR, merge
+
+**Files:** none created/modified (verification + workflow only)
+
+- [ ] **Step 1: Run the full neighboring test set**
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-analytics-view.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/thread-signals-section.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/familiar-rehabilitation.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/familiar-studio-contract-tab.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/lib/design-token-drift.test.ts
+```
+
+Expected: all five print ok / pass with exit code 0.
+
+- [ ] **Step 2: Design codemod no-op check**
+
+```bash
+pnpm codemod:design:check
+```
+
+Expected: clean (no rewrites proposed).
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base main --head feat/analytics-contract-review \
+  --title "feat(analytics): contract review launch + empty-results grid layout" \
+  --body "$(cat <<'EOF'
+Two fixes for the Familiar Analytics surface (design spec: docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md, local-only):
+
+**1. Empty results no longer leave holes in the grid.** `.fa-grid` had `align-items: start`, so a short empty-state card sharing a row with a tall neighbor (empty confidence card next to a full Recent sessions list) floated over a large blank gap. Rows now stretch (grid default) and empty-state notices center vertically inside their cards (`.fa-section > .ui-empty-state`, `.fa-section > .fa-thread-empty`). No JSX/order changes; the "empty thread-signals doesn't go wide" pin is untouched.
+
+**2. Contract compliance violations are actionable.** When the contract report fails, the section renders a "Review and resolve" primary button that direct-launches a working thread seeded with `buildRehabilitationBrief` (the Studio Contract tab's exact flow) plus an analytics-source provenance line, announced via the live region.
+
+**Testing:** extended `familiar-analytics-view.test.ts` (already registered) with pins for both behaviors; ran thread-signals, rehabilitation, studio-contract-tab, and design-token-drift suites; `tsc --noEmit` and design-gate eslint clean.
+EOF
+)"
+```
+
+- [ ] **Step 4: Wait for required checks, then squash-merge**
+
+```bash
+gh pr checks feat/analytics-contract-review --watch
+```
+
+Expected: `Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment required`, `Sidecar runtime required`, `CodeQL` all pass. Then:
+
+```bash
+gh pr merge feat/analytics-contract-review --squash --delete-branch
+```
+
+(If the merge commit message is editable, keep the `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer.)
+
+- [ ] **Step 5: Local cleanup (squash orphans the tip — bypass is sanctioned after verifying content landed)**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git fetch origin --quiet
+# verify the squash landed the same content before destroying the branch:
+git diff feat/analytics-contract-review origin/main -- src/components/familiar-analytics-content.tsx src/components/familiar-analytics-view.test.ts src/styles/familiar-analytics.css
+# expected: empty diff. Then:
+WT_GUARD_BYPASS=1 git worktree remove .worktrees/feat-analytics-contract-review
+WT_GUARD_BYPASS=1 git branch -D feat/analytics-contract-review
+git worktree list
+```
+
+Expected: worktree gone, branch gone, `git worktree list` no longer shows it.

--- a/docs/superpowers/plans/2026-07-24-project-setup-from-chat.md
+++ b/docs/superpowers/plans/2026-07-24-project-setup-from-chat.md
@@ -1,0 +1,1384 @@
+# Project Setup From a Chat's Unregistered Folder — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a chat runs in an ad-hoc folder that maps to no registered Cave project, offer an in-place "Set up as project" flow (picker row + dismissible banner) that explains what registering entails and lets the human pick access for the chat's familiar and the familiar's access groups.
+
+**Architecture:** A pure eligibility helper (`project-setup-offer.ts`) decides when the offer applies (chat resolved to `NO_PROJECT_ID` with an `unregisteredRoot` that is neither a registered project nor a project worktree). Two chat-view entry points open one new `ProjectSetupModal`, which registers via the existing `useProjects().createProject` (extended to carry `color`/`repoUrl`), grants the familiar via `POST /api/project-grants`, and patches group grants via `PATCH /api/access-groups/[id]` — all from the direct human click the grant routes require. A tiny `remote=1` mode on the existing `/api/changes` GET prefills the GitHub field.
+
+**Tech Stack:** Next.js app router, React client components, node:test-style `*.test.ts` files run by `node scripts/run-tests.mjs`, design-token CSS utility classes, Phosphor icon subset.
+
+**Spec:** `docs/superpowers/specs/2026-07-24-project-setup-from-chat-design.md` (approved).
+
+**Worktree:** `.worktrees/feat-project-setup-from-chat` (branch `feat/project-setup-from-chat`, already created from `origin/main`). Run `pnpm install` there once before starting.
+
+**Repo conventions that bind every task:**
+- Tests are plain script files (`// @ts-nocheck`, `node:assert/strict`, `console.log("<name> OK")` at the end). Run one with `node --experimental-strip-types <path>`. Every new `*.test.ts` MUST also be appended to the right suite array in `scripts/run-tests.mjs` or `pnpm check:tests-wired` fails CI.
+- Design gates: tokens only (no raw hex/px in render code), `.focus-ring` on interactive elements, reuse `src/components/ui/` primitives.
+- Commits: signed (`git -c commit.gpgsign=true commit -S …` or rely on repo config), include the trailer `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+- Push the branch to origin after every commit (`git push origin feat/project-setup-from-chat`).
+
+---
+
+### Task 1: Pure eligibility helper — `project-setup-offer.ts`
+
+**Files:**
+- Create: `src/lib/project-setup-offer.ts`
+- Create: `src/lib/project-setup-offer.test.ts`
+- Modify: `scripts/run-tests.mjs` (register the test)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/project-setup-offer.test.ts`:
+
+```ts
+// @ts-nocheck
+// The in-place "Set up as project" offer (spec 2026-07-24) applies ONLY to a
+// chat actively running in an ad-hoc unregistered folder. Registered projects,
+// bare No-project chats (familiar workspaces carry no unregisteredRoot), and
+// `.worktrees/` checkouts (they authorize against their parent project) are
+// all excluded — this matrix is the contract.
+import assert from "node:assert/strict";
+import {
+  PROJECT_SETUP_COLOR_CHOICES,
+  projectSetupCandidateRoot,
+  projectSetupDismissKey,
+} from "./project-setup-offer.ts";
+import { NO_PROJECT_ID } from "./chat-projects.ts";
+
+const projects = [{ id: "p1", name: "cave", root: "/code/cave" }];
+
+// Ad-hoc unregistered root → offered, normalized (trailing slash stripped).
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "/code/other/" },
+    projects,
+  ),
+  "/code/other",
+);
+
+// Backslashes normalize like every other root comparison in chat-projects.
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "C:\\code\\thing" },
+    projects,
+  ),
+  "C:/code/thing",
+);
+
+// A registered-project selection → no offer.
+assert.equal(
+  projectSetupCandidateRoot({ projectId: "p1", project: projects[0] }, projects),
+  null,
+);
+
+// Bare No-project (no unregisteredRoot — e.g. the familiar's own workspace,
+// whose cwd is never surfaced) → no offer.
+assert.equal(
+  projectSetupCandidateRoot({ projectId: NO_PROJECT_ID, project: null }, projects),
+  null,
+);
+
+// A root that IS a registered project (stale selection) → no offer.
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "/code/cave/" },
+    projects,
+  ),
+  null,
+);
+
+// Worktree child of a registered project → no offer (parent-project auth).
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "/code/cave/.worktrees/feat-x" },
+    projects,
+  ),
+  null,
+);
+
+// The `.worktrees` directory itself → no offer either.
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "/code/cave/.worktrees" },
+    projects,
+  ),
+  null,
+);
+
+// A sibling that merely shares a path prefix is NOT a worktree child.
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "/code/cave-evil" },
+    projects,
+  ),
+  "/code/cave-evil",
+);
+
+// Blank/whitespace unregisteredRoot → no offer.
+assert.equal(
+  projectSetupCandidateRoot(
+    { projectId: NO_PROJECT_ID, project: null, unregisteredRoot: "   " },
+    projects,
+  ),
+  null,
+);
+
+// Dismissal key is per NORMALIZED root, so `/x/` and `/x` share one dismissal.
+assert.equal(projectSetupDismissKey("/code/other/"), "cave:project-setup-dismissed:/code/other");
+
+// Fixed identity palette for the modal's swatch row: the projectTint recipe
+// (same lightness/chroma, spread hues) so explicit colors match auto tints.
+assert.equal(PROJECT_SETUP_COLOR_CHOICES.length, 6);
+for (const color of PROJECT_SETUP_COLOR_CHOICES) {
+  assert.match(color, /^oklch\(0\.74 0\.12 \d+\)$/);
+}
+
+console.log("project-setup-offer.test.ts OK");
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --experimental-strip-types src/lib/project-setup-offer.test.ts`
+Expected: FAIL — `Cannot find module ... project-setup-offer.ts`
+
+- [ ] **Step 3: Write the implementation**
+
+Create `src/lib/project-setup-offer.ts`:
+
+```ts
+/**
+ * project-setup-offer.ts
+ *
+ * Pure eligibility for the in-place "Set up as project" flow (spec
+ * 2026-07-24): a chat actively running in an ad-hoc unregistered folder can be
+ * promoted to a registered project without re-browsing to it. Deliberately
+ * narrow — mirrors the containment discipline in chat-project-access.ts:
+ *
+ *   - Registered-project chats: nothing to offer.
+ *   - Bare No-project chats (no unregisteredRoot): the recorded cwd is the
+ *     familiar's own workspace or another dir the UI never re-asserts.
+ *   - `.worktrees/<branch>` checkouts under a registered project: they
+ *     authorize against the PARENT project by design, never become projects.
+ */
+
+import {
+  NO_PROJECT_ID,
+  normalizeChatProjectRoot,
+  projectForRoot,
+  type CaveProject,
+  type ChatProjectSelection,
+} from "./chat-projects.ts";
+
+export function projectSetupCandidateRoot(
+  selection: ChatProjectSelection,
+  projects: CaveProject[],
+): string | null {
+  if (selection.projectId !== NO_PROJECT_ID) return null;
+  const raw = selection.unregisteredRoot?.trim();
+  if (!raw) return null;
+  const root = normalizeChatProjectRoot(raw);
+  if (projectForRoot(root, projects)) return null;
+  const inProjectWorktrees = projects.some((project) => {
+    const worktrees = `${normalizeChatProjectRoot(project.root)}/.worktrees`;
+    return root === worktrees || root.startsWith(`${worktrees}/`);
+  });
+  if (inProjectWorktrees) return null;
+  return root;
+}
+
+/** localStorage key for the banner's per-folder dismissal — normalized, so
+ *  `/x` and `/x/` share one dismissal and the same folder never re-nags. */
+export function projectSetupDismissKey(root: string): string {
+  return `cave:project-setup-dismissed:${normalizeChatProjectRoot(root)}`;
+}
+
+/**
+ * Fixed identity palette for the setup modal's color swatches. Same recipe as
+ * comux-projects' projectTint (`oklch(0.74 0.12 <hue>)`) so explicit picks sit
+ * in the same perceptual family as the auto root-hash tint; hues spread evenly
+ * so adjacent swatches read as distinct on both themes. Data values (stored as
+ * the project's color), not render-time CSS literals.
+ */
+export const PROJECT_SETUP_COLOR_CHOICES: readonly string[] = [
+  25, 85, 145, 205, 265, 325,
+].map((hue) => `oklch(0.74 0.12 ${hue})`);
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --experimental-strip-types src/lib/project-setup-offer.test.ts`
+Expected: `project-setup-offer.test.ts OK`
+
+- [ ] **Step 5: Register the test in the runner**
+
+In `scripts/run-tests.mjs`, in the `app` suite array, add directly after the line `"src/lib/chat-add-project.test.ts",`:
+
+```js
+    "src/lib/project-setup-offer.test.ts",
+```
+
+Run: `pnpm check:tests-wired`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/project-setup-offer.ts src/lib/project-setup-offer.test.ts scripts/run-tests.mjs
+git commit -m "feat(chat): pure eligibility helper for in-place project setup
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 2: Thread `color`/`repoUrl` through `CreateProjectOptions`
+
+**Files:**
+- Modify: `src/lib/chat-add-project.ts:8` (the `CreateProjectOptions` type)
+- Modify: `src/lib/use-projects.ts:131-152` (`requestCreateProject` POST body)
+- Modify: `src/lib/use-projects.test.ts` (append source-shape asserts)
+
+`POST /api/projects` already accepts `color` and `repoUrl` (`src/app/api/projects/route.ts:66-82`); only the client hook drops them today.
+
+- [ ] **Step 1: Write the failing test**
+
+Insert above the file's final line (`console.log("use-projects.test.ts: ok");`) in `src/lib/use-projects.test.ts` (the file already reads `use-projects.ts` into `const source`):
+
+```ts
+// The setup modal registers with an explicit color and GitHub link in the
+// same request — createProject must carry optional color/repoUrl through to
+// the POST body the projects route already accepts.
+assert.match(
+  source,
+  /body: JSON\.stringify\(\{\s*name,\s*root,\s*\.\.\.\(options\?\.color \? \{ color: options\.color \} : \{\}\),\s*\.\.\.\(options\?\.repoUrl \? \{ repoUrl: options\.repoUrl \} : \{\}\),\s*\}\)/,
+  "createProject threads optional color/repoUrl into the POST body",
+);
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --experimental-strip-types src/lib/use-projects.test.ts`
+Expected: FAIL — "createProject threads optional color/repoUrl into the POST body"
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/chat-add-project.ts`, replace:
+
+```ts
+export type CreateProjectOptions = { emitMutation?: boolean };
+```
+
+with:
+
+```ts
+export type CreateProjectOptions = {
+  emitMutation?: boolean;
+  /** Explicit identity tint persisted on the project (absent → auto root-hash tint). */
+  color?: string;
+  /** Canonical GitHub link — callers must pre-normalize via normalizeGitHubRepoUrl. */
+  repoUrl?: string;
+};
+```
+
+In `src/lib/use-projects.ts`, inside `requestCreateProject`, replace:
+
+```ts
+        body: JSON.stringify({ name, root }),
+```
+
+with:
+
+```ts
+        body: JSON.stringify({
+          name,
+          root,
+          ...(options?.color ? { color: options.color } : {}),
+          ...(options?.repoUrl ? { repoUrl: options.repoUrl } : {}),
+        }),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `node --experimental-strip-types src/lib/use-projects.test.ts && node --experimental-strip-types src/lib/chat-add-project.test.ts`
+Expected: both print `... OK` (chat-add-project's existing assertions still hold — the options object it checks, `{ emitMutation: false }`, is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/chat-add-project.ts src/lib/use-projects.ts src/lib/use-projects.test.ts
+git commit -m "feat(projects): createProject carries optional color/repoUrl to the API
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 3: Add the `ph:folder-plus` icon
+
+**Files:**
+- Modify: `src/lib/icon.tsx:144` (the `ICON_NAMES` union — alphabetical `folder` cluster)
+- Regenerate: the icon subset via `node scripts/generate-icon-subset.mjs` (commit whatever files it rewrites — `icon-subset.test.ts` fails CI otherwise)
+
+- [ ] **Step 1: Add the name**
+
+In `src/lib/icon.tsx`, in the `ICON_NAMES` list, after the line `"ph:folder-open-bold",` add:
+
+```ts
+  "ph:folder-plus",
+```
+
+- [ ] **Step 2: Regenerate the subset**
+
+Run: `node scripts/generate-icon-subset.mjs`
+Expected: exits 0 and rewrites the generated subset file(s). Run `git status --porcelain` to see exactly which files changed.
+
+- [ ] **Step 3: Run the subset guard test**
+
+Run: `node --experimental-strip-types src/lib/icon-subset.test.ts`
+Expected: exit 0 (this is the guard that fails CI when the committed subset doesn't match `ICON_NAMES`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A src/lib
+git commit -m "feat(icons): add ph:folder-plus for the project-setup affordances
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 4: `remote=1` probe on the changes API
+
+**Files:**
+- Modify: `src/app/api/changes/route.ts:422-473` (GET) + new helper below it
+- Modify: `src/app/api/changes/route.test.ts` (append asserts)
+
+- [ ] **Step 1: Write the failing test**
+
+Insert above the file's final line (`console.log("changes route.test.ts: ok");`) in `src/app/api/changes/route.test.ts`:
+
+```ts
+// remote=1 — read-only origin probe powering the project-setup modal's GitHub
+// prefill. Must ride the same resolveRepoRoot containment as every other GET
+// mode and go through execFile argv (no shell); an absent origin is a normal
+// state (null), never an error.
+assert.match(
+  source,
+  /if \(wantRemote !== null\) return await originRemoteUrl\(root\.repoRoot\);/,
+  "remote=1 resolves through the shared resolveRepoRoot containment",
+);
+assert.match(
+  source,
+  /\["config", "--get", "remote\.origin\.url"\]/,
+  "the origin probe reads git config through argv, not a shell",
+);
+assert.match(
+  source,
+  /NextResponse\.json\(\{ ok: true, remoteUrl: remoteUrl \|\| null \}\)/,
+  "absent origin remotes resolve to remoteUrl: null, not an error",
+);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --experimental-strip-types src/app/api/changes/route.test.ts`
+Expected: FAIL — "remote=1 resolves through the shared resolveRepoRoot containment"
+
+- [ ] **Step 3: Implement**
+
+In `src/app/api/changes/route.ts`, in `GET`, after the line
+`const wantBranches = req.nextUrl.searchParams.get("branches");` add:
+
+```ts
+  const wantRemote = req.nextUrl.searchParams.get("remote");
+```
+
+Inside the `try` block, after `if (wantPr !== null) return await branchPr(root.repoRoot);` add:
+
+```ts
+    if (wantRemote !== null) return await originRemoteUrl(root.repoRoot);
+```
+
+After the `GET` function's closing brace, add the helper:
+
+```ts
+/** Origin remote URL for the repo, or null when no origin is configured —
+ *  read-only probe behind the project-setup modal's GitHub prefill. */
+async function originRemoteUrl(repoRoot: string): Promise<NextResponse> {
+  try {
+    const { stdout } = await git(repoRoot, ["config", "--get", "remote.origin.url"]);
+    const remoteUrl = stdout.trim();
+    return NextResponse.json({ ok: true, remoteUrl: remoteUrl || null });
+  } catch {
+    // `git config --get` exits 1 when the key is absent — a repo with no
+    // origin remote is a normal state, not an error.
+    return NextResponse.json({ ok: true, remoteUrl: null });
+  }
+}
+```
+
+(`git(...)` is the route's existing execFile wrapper — do not add imports.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --experimental-strip-types src/app/api/changes/route.test.ts`
+Expected: `... OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/app/api/changes/route.ts src/app/api/changes/route.test.ts
+git commit -m "feat(changes): remote=1 probe returns the origin URL for repo prefill
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 5: `ProjectSetupModal`
+
+**Files:**
+- Create: `src/components/project-setup-modal.tsx`
+- Create: `src/components/project-setup-modal.test.ts`
+- Modify: `scripts/run-tests.mjs` (register the test)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/project-setup-modal.test.ts`:
+
+```ts
+// @ts-nocheck
+// ProjectSetupModal — the in-place "register this ad-hoc folder" flow (spec
+// 2026-07-24). It must explain what registering entails, default the chat's
+// familiar to write (the chat needs to keep running here) and groups to no
+// access, honor Supreme's all-access status, and sequence create → familiar
+// grant → group patches with a single registry emit — retrying after a
+// partial failure without duplicating the project.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("./project-setup-modal.tsx", import.meta.url), "utf8");
+
+// ── Explains what registering entails ──────────────────────────────────────
+assert.match(src, /Registering makes this folder a project across the Cave/, "explainer copy present");
+assert.match(src, /Familiars can only work in a project after you grant access/, "grant model explained");
+assert.match(src, /changed later in Projects and Permissions/, "reversibility called out");
+
+// ── Preference defaults ─────────────────────────────────────────────────────
+assert.match(src, /useState<AccessChoice>\("write"\)/, "familiar access defaults to write");
+assert.match(src, /groupLevels\[group\.id\] \?\? "none"/, "groups default to no access");
+assert.match(src, /familiar\.id === supremeFamiliarId/, "Supreme is detected and grant-skipped");
+assert.match(src, /has access to every project/, "Supreme renders as all-access, not a select");
+
+// ── Submit sequence ─────────────────────────────────────────────────────────
+assert.match(src, /emitMutation: false/, "creation suppresses its own emit (single fan-out)");
+assert.match(src, /"\/api\/project-grants"/, "familiar grant goes to the grants route");
+assert.match(src, /targetFamiliarId: familiar\.id/, "grant sends targetFamiliarId (never familiarId)");
+assert.match(src, /`\/api\/access-groups\/\$\{group\.id\}`/, "group grants PATCH each group");
+assert.match(
+  src,
+  /\.filter\(\(grant\) => grant\.projectId !== project\.id\)/,
+  "group patch replaces any same-project grant instead of duplicating",
+);
+assert.match(src, /emitProjectRegistryMutation\(\)/, "registry listeners get refreshed");
+assert.match(src, /setCreatedProject\(project\)/, "retry after partial failure skips re-creation");
+
+// ── Prefill + validation ────────────────────────────────────────────────────
+assert.match(src, /&remote=1/, "GitHub prefill probes the changes remote endpoint");
+assert.match(src, /normalizeGitHubRepoUrl/, "repo input validates through the shared normalizer");
+assert.match(src, /current\.trim\(\) \? current : /, "prefill never clobbers what the user typed");
+
+// ── Primitives + a11y ───────────────────────────────────────────────────────
+assert.match(src, /<Modal\b/, "built on the shared Modal (focus trap + return)");
+assert.match(src, /useAnnouncer\(\)/, "completion is announced");
+assert.match(src, /StandardSelect/, "access levels use the shared select primitive");
+assert.match(src, /aria-pressed=/, "color swatches expose pressed state");
+assert.match(src, /PROJECT_SETUP_COLOR_CHOICES/, "swatch palette comes from the lib, not render literals");
+
+console.log("project-setup-modal.test.ts OK");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --experimental-strip-types src/components/project-setup-modal.test.ts`
+Expected: FAIL — cannot read `project-setup-modal.tsx`
+
+- [ ] **Step 3: Write the component**
+
+Create `src/components/project-setup-modal.tsx`:
+
+```tsx
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { Icon } from "@/lib/icon";
+import type { CaveProject } from "@/lib/cave-projects-types";
+import { projectNameForRoot, type CreateProjectOptions } from "@/lib/chat-add-project";
+import { projectTint } from "@/lib/comux-projects";
+import { normalizeGitHubRepoUrl } from "@/lib/github-repo-link";
+import type { ProjectAccessLevel } from "@/lib/project-access-levels";
+import { emitProjectRegistryMutation } from "@/lib/project-registry-events";
+import { PROJECT_SETUP_COLOR_CHOICES } from "@/lib/project-setup-offer";
+import { Button } from "@/components/ui/button";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { Modal } from "@/components/ui/modal";
+import { StandardSelect, type StandardSelectOption } from "@/components/ui/select";
+
+type AccessChoice = "none" | ProjectAccessLevel;
+
+type SetupAccessGroup = {
+  id: string;
+  name: string;
+  memberFamiliarIds: string[];
+  projectGrants: { projectId: string; access?: ProjectAccessLevel }[];
+};
+
+const ACCESS_OPTIONS: StandardSelectOption<AccessChoice>[] = [
+  { value: "none", label: "No access" },
+  { value: "read", label: "Read" },
+  { value: "write", label: "Write" },
+];
+
+/**
+ * "Set up as project" — registers an ad-hoc chat folder as a Cave project in
+ * place (spec 2026-07-24). One human-confirmed submit sequences: create the
+ * project (with optional color + GitHub link) → grant the chat's familiar →
+ * patch each chosen access group — every request fired from the direct click
+ * the grant routes require (they reject relayed approvals). A partial failure
+ * keeps the modal open naming the failed step; retry reuses the already
+ * created project instead of duplicating it (addChatProject's two-step
+ * semantics, including the partial-mutation registry emit).
+ */
+export function ProjectSetupModal({
+  root,
+  familiar,
+  createProject,
+  onClose,
+  onCreated,
+}: {
+  /** Normalized ad-hoc folder being registered; null keeps the modal closed. */
+  root: string | null;
+  familiar: { id: string | null; name: string };
+  /** From the caller's useProjects() so its local list updates in place. */
+  createProject: (
+    name: string,
+    root: string,
+    options?: CreateProjectOptions,
+  ) => Promise<CaveProject | null>;
+  onClose: () => void;
+  onCreated: (projectId: string) => void;
+}) {
+  const { announce } = useAnnouncer();
+  const [name, setName] = useState("");
+  const [color, setColor] = useState<string | null>(null);
+  const [repoDraft, setRepoDraft] = useState("");
+  const [familiarAccess, setFamiliarAccess] = useState<AccessChoice>("write");
+  const [groupLevels, setGroupLevels] = useState<Record<string, AccessChoice>>({});
+  const [groups, setGroups] = useState<SetupAccessGroup[]>([]);
+  const [supremeFamiliarId, setSupremeFamiliarId] = useState<string | null>(null);
+  const [createdProject, setCreatedProject] = useState<CaveProject | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Re-seed per folder: prefill the name from the leaf, probe groups +
+  // supreme (one grants fetch) and the git origin (GitHub prefill). Both
+  // probes are best-effort — a failure leaves its section blank/hidden and
+  // never blocks setup.
+  useEffect(() => {
+    if (!root) return;
+    setName(projectNameForRoot(root));
+    setColor(null);
+    setRepoDraft("");
+    setFamiliarAccess("write");
+    setGroupLevels({});
+    setCreatedProject(null);
+    setBusy(false);
+    setError(null);
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await fetch("/api/project-grants", { cache: "no-store" });
+        const data = (await res.json()) as {
+          accessGroups?: SetupAccessGroup[];
+          supremeFamiliarId?: string;
+        };
+        if (cancelled) return;
+        setGroups(Array.isArray(data?.accessGroups) ? data.accessGroups : []);
+        setSupremeFamiliarId(
+          typeof data?.supremeFamiliarId === "string" ? data.supremeFamiliarId : null,
+        );
+      } catch {
+        /* group section stays hidden; direct grant + creation still work */
+      }
+    })();
+    void (async () => {
+      try {
+        const res = await fetch(
+          `/api/changes?projectRoot=${encodeURIComponent(root)}&remote=1`,
+          { cache: "no-store" },
+        );
+        const data = (await res.json()) as { remoteUrl?: string | null };
+        if (cancelled) return;
+        const normalized =
+          typeof data?.remoteUrl === "string" ? normalizeGitHubRepoUrl(data.remoteUrl) : null;
+        if (normalized) setRepoDraft((current) => (current.trim() ? current : normalized));
+      } catch {
+        /* prefill only — never blocks */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [root]);
+
+  if (!root) return null;
+
+  const isSupremeFamiliar = Boolean(familiar.id) && familiar.id === supremeFamiliarId;
+  const memberGroups = familiar.id
+    ? groups.filter((group) => group.memberFamiliarIds.includes(familiar.id as string))
+    : [];
+
+  const submit = async () => {
+    if (busy) return;
+    const trimmedName = name.trim() || projectNameForRoot(root);
+    const trimmedRepo = repoDraft.trim();
+    const normalizedRepo = trimmedRepo ? normalizeGitHubRepoUrl(trimmedRepo) : null;
+    if (trimmedRepo && !normalizedRepo) {
+      setError(
+        "That doesn’t look like a GitHub repository. Try owner/repo or a https://github.com/owner/repo link.",
+      );
+      return;
+    }
+    setBusy(true);
+    setError(null);
+    // Creation succeeded but a later grant failed → the project exists, so
+    // fan the partial registry mutation out before surfacing the error
+    // (mirrors addChatProject).
+    const failAfterCreate = (message: string) => {
+      emitProjectRegistryMutation();
+      setError(message);
+    };
+    try {
+      let project = createdProject;
+      if (!project) {
+        project = await createProject(trimmedName, root, {
+          emitMutation: false,
+          ...(color ? { color } : {}),
+          ...(normalizedRepo ? { repoUrl: normalizedRepo } : {}),
+        });
+        if (!project) {
+          setError("Couldn’t register the project. Is the desktop reachable?");
+          return;
+        }
+        setCreatedProject(project);
+      }
+      if (familiar.id && familiarAccess !== "none" && !isSupremeFamiliar) {
+        const res = await fetch("/api/project-grants", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            targetFamiliarId: familiar.id,
+            projectId: project.id,
+            access: familiarAccess,
+          }),
+        });
+        if (!res.ok) {
+          failAfterCreate(`Project registered, but granting ${familiar.name} failed — retry, or grant it from Permissions.`);
+          return;
+        }
+      }
+      for (const group of memberGroups) {
+        const level = groupLevels[group.id] ?? "none";
+        if (level === "none") continue;
+        const projectGrants = group.projectGrants
+          .filter((grant) => grant.projectId !== project.id)
+          .map((grant) => ({ projectId: grant.projectId, access: grant.access ?? "write" }));
+        projectGrants.push({ projectId: project.id, access: level });
+        const res = await fetch(`/api/access-groups/${group.id}`, {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ projectGrants }),
+        });
+        if (!res.ok) {
+          failAfterCreate(`Project registered, but granting the ${group.name} group failed — retry, or grant it from Permissions.`);
+          return;
+        }
+      }
+      emitProjectRegistryMutation();
+      announce("Project created.");
+      onCreated(project.id);
+      onClose();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal
+      open
+      onClose={onClose}
+      breadcrumb={["Projects", "Set up project"]}
+      footerActions={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={busy}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={() => void submit()} loading={busy}>
+            {busy ? "Creating…" : "Create project"}
+          </Button>
+        </>
+      }
+    >
+      <div className="mb-3 flex items-center gap-2 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+        <Icon name="ph:folder-plus" width={13} aria-hidden />
+        <span className="truncate" title={root}>
+          {root}
+        </span>
+      </div>
+
+      <p className="mb-4 text-[length:var(--text-sm)] leading-relaxed text-[var(--text-secondary)]">
+        Registering makes this folder a project across the Cave — it shows up in project
+        pickers, the Board, and chat rails. Familiars can only work in a project after you
+        grant access; choose who starts with access below. Everything here can be changed
+        later in Projects and Permissions.
+      </p>
+
+      <label className="block">
+        <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+          Project name
+        </div>
+        <input
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          aria-label="Project name"
+          spellCheck={false}
+          className="focus-ring w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none"
+        />
+      </label>
+
+      <div className="mt-4">
+        <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+          Color
+        </div>
+        <div className="flex flex-wrap items-center gap-1.5" role="group" aria-label="Project color">
+          <button
+            type="button"
+            onClick={() => setColor(null)}
+            aria-pressed={color === null}
+            aria-label="Automatic color from the folder path"
+            title="Auto"
+            className={`focus-ring h-6 w-6 rounded-md transition-transform hover:scale-110 ${
+              color === null ? "ring-2 ring-[var(--accent-presence)]" : "ring-1 ring-[var(--border-strong)]"
+            }`}
+            style={{ background: projectTint(root) }}
+          />
+          {PROJECT_SETUP_COLOR_CHOICES.map((choice) => (
+            <button
+              key={choice}
+              type="button"
+              onClick={() => setColor(choice)}
+              aria-pressed={color === choice}
+              aria-label={`Use ${choice}`}
+              title={choice}
+              className={`focus-ring h-6 w-6 rounded-md transition-transform hover:scale-110 ${
+                color === choice ? "ring-2 ring-[var(--accent-presence)]" : "ring-1 ring-[var(--border-strong)]"
+              }`}
+              style={{ background: choice }}
+            />
+          ))}
+        </div>
+        <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+          Auto derives a stable tint from the folder path.
+        </p>
+      </div>
+
+      <label className="mt-4 block">
+        <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+          GitHub repository
+        </div>
+        <input
+          value={repoDraft}
+          onChange={(e) => {
+            setRepoDraft(e.target.value);
+            setError(null);
+          }}
+          placeholder="owner/repo or https://github.com/owner/repo"
+          aria-label="GitHub repository"
+          spellCheck={false}
+          autoCapitalize="off"
+          autoCorrect="off"
+          className="focus-ring w-full rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-base)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-primary)] outline-none placeholder:text-[var(--text-muted)]"
+        />
+      </label>
+      <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+        Optional — ties the project to a repository. Leave empty to skip.
+      </p>
+
+      <div className="mt-4">
+        <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+          {familiar.name}’s access
+        </div>
+        {isSupremeFamiliar ? (
+          <p className="text-[length:var(--text-sm)] text-[var(--text-secondary)]">
+            {familiar.name} has access to every project.
+          </p>
+        ) : familiar.id ? (
+          <>
+            <StandardSelect
+              label={`${familiar.name}'s access`}
+              value={familiarAccess}
+              onChange={setFamiliarAccess}
+              options={ACCESS_OPTIONS}
+            />
+            <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+              Write lets {familiar.name} run chats and edit files here; Read is read-only.
+            </p>
+          </>
+        ) : (
+          <p className="text-[length:var(--text-sm)] text-[var(--text-muted)]">
+            No familiar in this chat — grant access from Permissions later.
+          </p>
+        )}
+      </div>
+
+      {memberGroups.length > 0 ? (
+        <div className="mt-4">
+          <div className="mb-1.5 text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
+            {familiar.name}’s groups
+          </div>
+          <div className="flex flex-col gap-2">
+            {memberGroups.map((group) => (
+              <div key={group.id} className="flex items-center justify-between gap-3">
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-[length:var(--text-sm)] text-[var(--text-primary)]">
+                    {group.name}
+                  </span>
+                  <span className="block text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                    {group.memberFamiliarIds.length}{" "}
+                    {group.memberFamiliarIds.length === 1 ? "member" : "members"}
+                  </span>
+                </span>
+                <StandardSelect
+                  label={`${group.name} group access`}
+                  value={groupLevels[group.id] ?? "none"}
+                  onChange={(level) =>
+                    setGroupLevels((prev) => ({ ...prev, [group.id]: level }))
+                  }
+                  options={ACCESS_OPTIONS}
+                />
+              </div>
+            ))}
+          </div>
+          <p className="mt-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+            Applies to every member of the group.
+          </p>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p
+          className="mt-4 rounded-[var(--radius-control)] border border-[var(--danger-border)] bg-[var(--danger-bg)] px-3 py-1.5 text-[length:var(--text-xs)] text-[var(--danger-text)]"
+          role="alert"
+        >
+          {error}
+        </p>
+      ) : null}
+    </Modal>
+  );
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --experimental-strip-types src/components/project-setup-modal.test.ts`
+Expected: `project-setup-modal.test.ts OK`
+
+- [ ] **Step 5: Register the test in the runner**
+
+In `scripts/run-tests.mjs`, `app` suite, add directly after `"src/components/project-picker.test.ts",` (line ~650):
+
+```js
+    "src/components/project-setup-modal.test.ts",
+```
+
+Run: `pnpm check:tests-wired`
+Expected: exit 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/project-setup-modal.tsx src/components/project-setup-modal.test.ts scripts/run-tests.mjs
+git commit -m "feat(chat): ProjectSetupModal — register an ad-hoc folder with access prefs
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 6: "Register this folder" row in `ProjectPickerPopover`
+
+**Files:**
+- Modify: `src/components/project-picker.tsx:112-240` (`ProjectPickerPopover`)
+- Modify: `src/components/project-picker.test.ts` (append asserts)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `src/components/project-picker.test.ts`, above the final `console.log(...)`:
+
+```ts
+// ── In-place registration row (spec 2026-07-24) ─────────────────────────────
+// A chat running in an ad-hoc unregistered folder offers to register THAT
+// folder — no directory re-browse — above the generic Add-project row.
+assert.match(src, /registerCurrentRoot\?: string;/, "picker takes the candidate root");
+assert.match(src, /onRegisterCurrentRoot\?: \(\) => void;/, "and the setup-open callback");
+assert.match(src, /Register this folder as a project…/, "in-place registration row");
+assert.match(src, /ph:folder-plus/, "register row carries the folder-plus icon");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --experimental-strip-types src/components/project-picker.test.ts`
+Expected: FAIL — "picker takes the candidate root"
+
+- [ ] **Step 3: Implement**
+
+In `src/components/project-picker.tsx`, `ProjectPickerPopover`:
+
+Add to the destructured props (after `onAddProject,`):
+
+```tsx
+  registerCurrentRoot,
+  onRegisterCurrentRoot,
+```
+
+Add to the props type (after the `onAddProject?: () => void;` line and its comment):
+
+```tsx
+  /** Ad-hoc root the current chat runs in (spec 2026-07-24) — presence with
+   *  onRegisterCurrentRoot enables the in-place "Register this folder" row. */
+  registerCurrentRoot?: string;
+  onRegisterCurrentRoot?: () => void;
+```
+
+Replace the footer block:
+
+```tsx
+        {onAddProject ? (
+          <>
+            <PopoverSeparator />
+            <PopoverItem
+              icon="ph:plus"
+              disabled={addingProject}
+              onSelect={() => {
+                close();
+                onAddProject();
+              }}
+            >
+              {addingProject ? "Adding project…" : "Add project…"}
+            </PopoverItem>
+          </>
+        ) : null}
+```
+
+with:
+
+```tsx
+        {(onRegisterCurrentRoot && registerCurrentRoot) || onAddProject ? (
+          <PopoverSeparator />
+        ) : null}
+        {onRegisterCurrentRoot && registerCurrentRoot ? (
+          <PopoverItem
+            icon="ph:folder-plus"
+            onSelect={() => {
+              close();
+              onRegisterCurrentRoot();
+            }}
+          >
+            <span className="cave-project-picker__option">
+              <span className="cave-project-picker__option-name">
+                Register this folder as a project…
+              </span>
+              <span className="cave-project-picker__option-root">{registerCurrentRoot}</span>
+            </span>
+          </PopoverItem>
+        ) : null}
+        {onAddProject ? (
+          <PopoverItem
+            icon="ph:plus"
+            disabled={addingProject}
+            onSelect={() => {
+              close();
+              onAddProject();
+            }}
+          >
+            {addingProject ? "Adding project…" : "Add project…"}
+          </PopoverItem>
+        ) : null}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `node --experimental-strip-types src/components/project-picker.test.ts`
+Expected: `project-picker.test.ts OK`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/project-picker.tsx src/components/project-picker.test.ts
+git commit -m "feat(chat): in-place 'Register this folder' row in the project picker
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 7: Pass-through props on the composer chips and session kebab
+
+**Files:**
+- Modify: `src/components/composer-context-pill.tsx:33-59` (props type) and both `<ProjectPickerPopover …>` instances (lines ~148 and ~266)
+- Modify: `src/components/chat-session-header.tsx:18-155` (`SessionOverflowMenu`)
+
+No new test file — Task 8's chat-view assertions cover the wiring end-to-end.
+
+- [ ] **Step 1: Extend `ComposerContextProps`**
+
+In `src/components/composer-context-pill.tsx`, add to `ComposerContextProps` (after the `createProject?:` member):
+
+```tsx
+  /** Ad-hoc root the chat runs in — enables the picker's in-place
+   *  "Register this folder" row (spec 2026-07-24). */
+  registerCurrentRoot?: string;
+  onRegisterCurrentRoot?: () => void;
+```
+
+Add to **both** `<ProjectPickerPopover …>` usages in this file (one in `ComposerContextPickers`, one in `ComposerContextChips`), alongside `onAddProject={…}`:
+
+```tsx
+        registerCurrentRoot={context.config.registerCurrentRoot}
+        onRegisterCurrentRoot={context.config.onRegisterCurrentRoot}
+```
+
+- [ ] **Step 2: Extend `SessionOverflowMenu`**
+
+In `src/components/chat-session-header.tsx`, add to `SessionOverflowMenu`'s destructured props (after `onAddProject,`) and its props type (after the `onAddProject?: () => void;` member):
+
+```tsx
+  registerCurrentRoot,
+  onRegisterCurrentRoot,
+```
+
+```tsx
+  /** Ad-hoc root the chat runs in — enables the picker's in-place
+   *  "Register this folder" row (spec 2026-07-24). */
+  registerCurrentRoot?: string;
+  onRegisterCurrentRoot?: () => void;
+```
+
+Add to its `<ProjectPickerPopover …>` (after `onAddProject={onAddProject}`):
+
+```tsx
+        registerCurrentRoot={registerCurrentRoot}
+        onRegisterCurrentRoot={onRegisterCurrentRoot}
+```
+
+- [ ] **Step 3: Verify nothing broke**
+
+Run: `node --experimental-strip-types src/components/project-picker.test.ts && node --experimental-strip-types src/components/composer-actions-menu.test.ts && node --experimental-strip-types src/components/composer-add-menu.test.ts`
+Expected: all `... OK` (props are optional; existing call sites unchanged).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/composer-context-pill.tsx src/components/chat-session-header.tsx
+git commit -m "feat(chat): thread register-current-folder affordance to picker hosts
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 8: Wire the offer into `chat-view` (candidate memo, banner, modal)
+
+**Files:**
+- Modify: `src/components/chat-view.tsx` — imports (~line 147/172), state after the `overflowAddProject` block (~line 2126), banner before `<div className="cave-composer-shell">` (~line 5843), kebab props (~line 5579), modal mount after `{overflowAddProject.addProjectModal}` (~line 5592), `ComposerContextChips` props (~line 6351)
+- Modify: `src/components/chat-view.test.ts` (append asserts; the file reads chat-view.tsx into `source`)
+
+- [ ] **Step 1: Write the failing test**
+
+Append at the very end of `src/components/chat-view.test.ts` (the file ends with an `assert.match(...)`, not a `console.log`):
+
+```ts
+// ── In-place project setup for ad-hoc chat homes (spec 2026-07-24) ──────────
+// Eligibility comes from the pure helper on the RESOLVED selection — so
+// registered projects, familiar workspaces (no unregisteredRoot), and
+// project worktrees never see the offer.
+assert.match(
+  source,
+  /projectSetupCandidateRoot\(projectSelection, projects\)/,
+  "the setup offer derives from the resolved selection via the pure helper",
+);
+// Banner dismissal persists per normalized root, so one folder never re-nags.
+assert.match(
+  source,
+  /projectSetupDismissKey\(setupCandidateRoot\)/,
+  "banner dismissal keys on the shared per-root helper",
+);
+assert.match(
+  source,
+  /Set up as project…/,
+  "the banner offers setup in one click",
+);
+// Success rescopes the chat to the new project — same contract as the shared
+// add flow (draft set + registry reload).
+assert.match(
+  source,
+  /<ProjectSetupModal[\s\S]*?onCreated=\{\(newProjectId\) => \{\s*setProjectIdDraft\(newProjectId\);\s*reloadProjects\(\);/,
+  "a created project becomes the chat's next-send selection",
+);
+// Both picker hosts (composer chips + session kebab) surface the register row.
+assert.match(
+  source,
+  /<ComposerContextChips[\s\S]*?registerCurrentRoot=\{setupCandidateRoot \?\? undefined\}/,
+  "composer chips carry the register-current-folder affordance",
+);
+assert.match(
+  source,
+  /<SessionOverflowMenu[\s\S]*?registerCurrentRoot=\{setupCandidateRoot \?\? undefined\}/,
+  "the session kebab picker carries it too",
+);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --experimental-strip-types src/components/chat-view.test.ts`
+Expected: FAIL — "the setup offer derives from the resolved selection via the pure helper"
+
+- [ ] **Step 3: Add imports**
+
+In `src/components/chat-view.tsx` add (near the existing `@/lib/chat-projects` import at ~line 147 and the `useAddProjectFlow` import at ~line 172):
+
+```tsx
+import { projectNameForRoot } from "@/lib/chat-add-project";
+import { projectSetupCandidateRoot, projectSetupDismissKey } from "@/lib/project-setup-offer";
+import { ProjectSetupModal } from "@/components/project-setup-modal";
+```
+
+(`Button`, `Icon`, `useState`, `useEffect` are already imported.)
+
+- [ ] **Step 4: Add state**
+
+Directly after the `overflowAddProject` `useAddProjectFlow({...});` block (~line 2126), add (plain const, not `useMemo` — `projectSelection` is a fresh object each render, so memoizing on it buys nothing):
+
+```tsx
+  // In-place registration for ad-hoc chat homes (spec 2026-07-24): a chat
+  // running in an unregistered folder — not a project worktree, not a
+  // familiar workspace — can be promoted to a registered project without
+  // re-browsing to it. Pure eligibility lives in project-setup-offer.ts.
+  const setupCandidateRoot = projectSetupCandidateRoot(projectSelection, projects);
+  const [projectSetupRoot, setProjectSetupRoot] = useState<string | null>(null);
+  // Default dismissed until the per-root localStorage read says otherwise, so
+  // the banner never flashes for an already-dismissed folder.
+  const [setupBannerDismissed, setSetupBannerDismissed] = useState(true);
+  useEffect(() => {
+    if (!setupCandidateRoot) {
+      setSetupBannerDismissed(true);
+      return;
+    }
+    try {
+      setSetupBannerDismissed(
+        localStorage.getItem(projectSetupDismissKey(setupCandidateRoot)) === "1",
+      );
+    } catch {
+      setSetupBannerDismissed(true);
+    }
+  }, [setupCandidateRoot]);
+  const dismissSetupBanner = () => {
+    if (setupCandidateRoot) {
+      try {
+        localStorage.setItem(projectSetupDismissKey(setupCandidateRoot), "1");
+      } catch {
+        /* banner-only state — session dismissal still applies */
+      }
+    }
+    setSetupBannerDismissed(true);
+  };
+```
+
+- [ ] **Step 5: Render the banner**
+
+Immediately before `<div className="cave-composer-shell">` (~line 5843), add:
+
+```tsx
+        {setupCandidateRoot && !setupBannerDismissed ? (
+          <div
+            role="status"
+            className="mb-2 flex items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-secondary)]"
+          >
+            <Icon
+              name="ph:folder-plus"
+              width={14}
+              aria-hidden
+              className="shrink-0 text-[var(--text-muted)]"
+            />
+            <span className="min-w-0 flex-1 truncate" title={setupCandidateRoot}>
+              This chat runs in{" "}
+              <span className="font-medium text-[var(--text-primary)]">
+                {projectNameForRoot(setupCandidateRoot)}
+              </span>
+              , which isn’t a registered project.
+            </span>
+            <Button variant="ghost" onClick={() => setProjectSetupRoot(setupCandidateRoot)}>
+              Set up as project…
+            </Button>
+            <button
+              type="button"
+              className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+              aria-label="Dismiss project setup suggestion"
+              onClick={dismissSetupBanner}
+            >
+              <Icon name="ph:x" width={11} aria-hidden />
+            </button>
+          </div>
+        ) : null}
+```
+
+- [ ] **Step 6: Mount the modal and thread the pickers**
+
+After `{overflowAddProject.addProjectModal}` (~line 5592), add:
+
+```tsx
+            <ProjectSetupModal
+              root={projectSetupRoot}
+              familiar={{ id: familiar.id ?? null, name: familiar.display_name }}
+              createProject={createProject}
+              onClose={() => setProjectSetupRoot(null)}
+              onCreated={(newProjectId) => {
+                setProjectIdDraft(newProjectId);
+                reloadProjects();
+              }}
+            />
+```
+
+Add to the `<SessionOverflowMenu …>` props (~line 5579, after `onAddProject={…}`):
+
+```tsx
+                registerCurrentRoot={setupCandidateRoot ?? undefined}
+                onRegisterCurrentRoot={
+                  setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
+                }
+```
+
+Add the same two props to `<ComposerContextChips …>` (~line 6351, after `createProject={createProject}`):
+
+```tsx
+                  registerCurrentRoot={setupCandidateRoot ?? undefined}
+                  onRegisterCurrentRoot={
+                    setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
+                  }
+```
+
+- [ ] **Step 7: Run to verify it passes**
+
+Run: `node --experimental-strip-types src/components/chat-view.test.ts`
+Expected: `... OK` (all pre-existing assertions too).
+
+If `reloadProjects` is not in scope at the modal mount, check what the `useProjects()` destructure in chat-view names it (`grep -n "reloadProjects\|reload" src/components/chat-view.tsx | head`) and use that binding — it is already used by `overflowAddProject`'s `onAdded`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/chat-view.tsx src/components/chat-view.test.ts
+git commit -m "feat(chat): offer in-place project setup when a chat runs in an ad-hoc folder
+
+Banner + picker rows gated on the pure eligibility helper; setup modal
+registers the folder, grants the chat's familiar, and patches its access
+groups, then rescopes the chat to the new project (spec 2026-07-24).
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push origin feat/project-setup-from-chat
+```
+
+---
+
+### Task 9: Full gates + PR
+
+**Files:** none new — verification only.
+
+- [ ] **Step 1: Design + lint gates**
+
+Run: `pnpm lint && pnpm codemod:design:check`
+Expected: exit 0. If the design ESLint gate flags the swatch `style={{ background: … }}`: these are dynamic values (allowed by `no-static-inline-style`); a static-literal flag means a swatch got hardcoded — move the value back to `PROJECT_SETUP_COLOR_CHOICES`.
+
+- [ ] **Step 2: Targeted test sweep**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/project-setup-offer.test.ts \
+&& node --experimental-strip-types src/lib/use-projects.test.ts \
+&& node --experimental-strip-types src/lib/chat-add-project.test.ts \
+&& node --experimental-strip-types src/app/api/changes/route.test.ts \
+&& node --experimental-strip-types src/components/project-setup-modal.test.ts \
+&& node --experimental-strip-types src/components/project-picker.test.ts \
+&& node --experimental-strip-types src/components/chat-view.test.ts \
+&& node --experimental-strip-types src/components/composer-actions-menu.test.ts \
+&& node --experimental-strip-types src/components/composer-add-menu.test.ts \
+&& node --experimental-strip-types src/components/chat-view-polish-attachments-mentions.test.ts \
+&& node --experimental-strip-types src/components/task-chat-cwd.test.ts \
+&& pnpm check:tests-wired
+```
+
+Expected: every file prints `... OK`, wired-check exits 0.
+
+- [ ] **Step 3: Full app suite + build**
+
+Run: `node scripts/run-tests.mjs app` (long — expect several minutes) and `pnpm build` if the repo's PR checklist expects a local build (`Frontend build` is a required PR check either way).
+Expected: exit 0.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --base main --head feat/project-setup-from-chat \
+  --title "feat(chat): set up an ad-hoc chat folder as a project, with familiar + group access" \
+  --body "$(cat <<'EOF'
+When a conversation opens in a folder that isn't a registered project (ad-hoc
+opener cwd), the chat now offers to register it in place:
+
+- **Eligibility** (`project-setup-offer.ts`, pure): resolved No-project selection
+  with an `unregisteredRoot` that isn't a registered project or a project
+  `.worktrees/` checkout. Familiar workspaces are never offered.
+- **Entry points:** "Register this folder as a project…" row in the chat's
+  project pickers (composer chip + session kebab), plus a per-folder
+  dismissible banner above the composer.
+- **Setup modal:** explains what registering entails; name (prefilled from the
+  leaf), color (auto tint or fixed oklch palette), GitHub repo (prefilled from
+  the new `/api/changes?remote=1` origin probe), access level for the chat's
+  familiar (default write; Supreme shown as all-access), and per-group grants
+  for the familiar's access groups (default none).
+- **Submit:** create → familiar grant → group patches → single registry emit;
+  partial failure keeps the modal open and retries without duplicating the
+  project. All mutations ride the direct human click the grant routes require.
+- Chat rescopes to the new project on success.
+
+Spec: docs/superpowers/specs/2026-07-24-project-setup-from-chat-design.md (local).
+EOF
+)"
+```
+
+Wait for the required checks (`Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment required`, `Sidecar runtime required`, `CodeQL`), then:
+
+```bash
+gh pr merge <#> --squash --delete-branch
+git worktree remove .worktrees/feat-project-setup-from-chat
+git branch -D feat/project-setup-from-chat
+```

--- a/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
@@ -1,0 +1,1919 @@
+# Research Final Artifacts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Research missions durably save all four final artifacts (primary deliverable, findings, source ledger, research log) — auto-published to the Grimoire Vault on completion, manually publishable when settled, and viewable/downloadable from the Desk and Library.
+
+**Architecture:** Every mission carries four `ResearchArtifactRef`s (legacy missions backfilled at store-read time). The runner's complete path publishes each unpublished ref with per-artifact failure isolation; a new `publish-artifact` action retries individual refs; a new read-only files API serves ref-backed file bytes to a shared View/Download/Publish UI component.
+
+**Tech Stack:** Next.js App Router (API routes), TypeScript, node:test (`--experimental-strip-types`), React 19 client components, CSS tokens per `docs/coven-design-language.md`.
+
+**Spec:** `docs/specs/2026-07-24-research-final-artifacts-design.md` (approved — read it first).
+
+---
+
+## Orientation (read before Task 1)
+
+- **Run one test file:** `node --experimental-strip-types --import ./scripts/test-alias-register.mjs <file>` (the alias register resolves `@/` imports).
+- **Suites:** `node scripts/run-tests.mjs app` and `node scripts/run-tests.mjs api`. Both use **explicit file manifests** inside `scripts/run-tests.mjs` — a new test file that isn't appended to a manifest array never runs. App-suite lib/component files are listed near lines 40–70; server files near line 226; API route files near lines 1018–1022.
+- **Gates:** `pnpm typecheck` (tsc --noEmit), `pnpm lint` (design ESLint + `pnpm codemod:design:check`).
+- **Commits:** signed (`git commit -S`), each ending with the trailer `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`.
+- **Test styles in this repo:** server/lib code gets behavioral node:test tests with fake `ResearchMissionRunnerDeps`; **API routes and JSX components get source-scan tests** (`readFileSync(new URL("./route.ts", import.meta.url), "utf8")` + regex asserts) because JSX can't import under node:test.
+- **Mission workspace layout:** `<root>/<missionId>/` contains `mission.json`, `research-state.yaml`, `findings.md`, `research-log.md`, `sources.json`, `artifacts/primary.md`. Root is `caveHome()/research-missions`, overridable via `COVEN_RESEARCH_MISSIONS_DIR` (store line ~30).
+
+### File map
+
+| File | Role in this plan |
+| --- | --- |
+| `src/lib/research-artifact-contract.ts` | + `renderSourceLedgerMarkdown` (Task 1) |
+| `src/lib/research-missions.ts` | + `researchArtifactKindForMode`, `STANDARD_RESEARCH_ARTIFACTS`, `ensureStandardArtifactRefs`, `publish-artifact` action type (Tasks 2, 5) |
+| `src/lib/server/research-mission-lifecycle.ts` | `createMissionRecord` registers 4 refs (Task 3) |
+| `src/lib/server/research-mission-store.ts` | read-time backfill in `loadResearchMission` (Task 3) |
+| `src/lib/server/research-mission-runner.ts` | multi-publish on complete, `finish` publishes, `publish-artifact` branch (Tasks 4, 5) |
+| `src/app/api/research/missions/[id]/actions/route.ts` | ACTIONS + VALIDATION_ERRORS + 409 (Task 5) |
+| `src/app/api/research/missions/[id]/files/[key]/route.ts` | **new** read-only files endpoint (Task 6) |
+| `src/lib/research-mission-client.ts` | + `getResearchMissionFile` (Task 6) |
+| `src/components/role-surfaces/research-artifact-actions.tsx` | **new** shared View/Download/Grimoire/Publish component (Task 7) |
+| `src/styles/globals/surface-research-desk.css` | actions-row + viewer styles (Task 7) |
+| `src/components/role-surfaces/research-mission-detail.tsx` | rail actions, saved summary (Task 8) |
+| `src/components/role-surfaces/research-evidence-ledger.tsx` | checkpoint-surface actions (Task 8) |
+| `src/components/role-surfaces/research-tab-library.tsx` | unpublished-card actions, stale comment (Task 9) |
+| `scripts/run-tests.mjs` | register the 3 new test files (Tasks 3, 6, 7) |
+
+---
+
+### Task 0: Worktree + commit the spec
+
+`main` is protected — all work happens on a branch in a worktree.
+
+- [ ] **Step 0.1: Create the worktree**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git worktree add -b research-final-artifacts .worktrees/research-final-artifacts origin/main
+cp docs/specs/2026-07-24-research-final-artifacts-design.md .worktrees/research-final-artifacts/docs/specs/
+mkdir -p .worktrees/research-final-artifacts/docs/superpowers/plans
+cp docs/superpowers/plans/2026-07-24-research-final-artifacts.md .worktrees/research-final-artifacts/docs/superpowers/plans/
+cd .worktrees/research-final-artifacts && pnpm install
+```
+
+(The spec + plan were authored in the primary checkout while uncommitted; the `cp` carries them onto the branch.)
+
+- [ ] **Step 0.2: Commit spec + plan**
+
+```bash
+git add docs/specs/2026-07-24-research-final-artifacts-design.md docs/superpowers/plans/2026-07-24-research-final-artifacts.md
+git commit -S -m "docs: research final-artifacts design spec and implementation plan
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git push -u origin research-final-artifacts
+```
+
+All later tasks run inside `.worktrees/research-final-artifacts/`.
+
+---
+
+### Task 1: `renderSourceLedgerMarkdown`
+
+The Vault can't ingest raw `sources.json`; this pure function renders the mission's merged `ResearchSourceRef[]` as a markdown ledger (list format, not tables — spec §2).
+
+**Files:**
+- Modify: `src/lib/research-artifact-contract.ts` (append near `researchKnowledgeEntry`, end of file)
+- Test: `src/lib/research-artifact-contract.test.ts` (exists; already in the app manifest)
+
+- [ ] **Step 1.1: Write the failing tests** — append to `src/lib/research-artifact-contract.test.ts` (add `renderSourceLedgerMarkdown` to its existing import from `./research-artifact-contract.ts`):
+
+```ts
+test("renderSourceLedgerMarkdown renders an empty ledger honestly", () => {
+  const markdown = renderSourceLedgerMarkdown([]);
+  assert.match(markdown, /^# Source ledger\n/);
+  assert.match(markdown, /No sources were recorded for this mission\./);
+});
+
+test("renderSourceLedgerMarkdown renders every source with status and evidence fields", () => {
+  const markdown = renderSourceLedgerMarkdown([
+    {
+      id: "s1",
+      title: "SQLite WAL docs",
+      url: "https://sqlite.org/wal.html",
+      publisher: "SQLite",
+      publishedAt: "2025-01-01",
+      sourceType: "web",
+      claim: "WAL allows concurrent readers",
+      note: "verified locally",
+      confidence: 0.9,
+      status: "used",
+    },
+    { id: "s2", title: "Old blog post", sourceType: "web", status: "rejected" },
+  ]);
+  assert.match(markdown, /2 sources recorded for this mission\./);
+  assert.match(markdown, /1\. \*\*SQLite WAL docs\*\* — used · web/);
+  assert.match(markdown, /- URL: https:\/\/sqlite\.org\/wal\.html/);
+  assert.match(markdown, /- Publisher: SQLite \(2025-01-01\)/);
+  assert.match(markdown, /- Claim: WAL allows concurrent readers/);
+  assert.match(markdown, /- Note: verified locally/);
+  assert.match(markdown, /- Confidence: 0\.9/);
+  assert.match(markdown, /2\. \*\*Old blog post\*\* — rejected · web/);
+  assert.ok(markdown.endsWith("\n"));
+});
+```
+
+- [ ] **Step 1.2: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/research-artifact-contract.test.ts`
+Expected: FAIL — `renderSourceLedgerMarkdown` is not exported.
+
+- [ ] **Step 1.3: Implement** — append to `src/lib/research-artifact-contract.ts` (it already imports the `ResearchSourceRef` type? — it imports from `./research-missions.ts` at line 3; add `type ResearchSourceRef` to that import list):
+
+```ts
+/** Render the mission's merged sources as a markdown ledger for Vault
+ *  publication — sources.json itself is machine-shaped, not readable. */
+export function renderSourceLedgerMarkdown(sources: ResearchSourceRef[]): string {
+  const lines = ["# Source ledger", ""];
+  if (sources.length === 0) {
+    lines.push("No sources were recorded for this mission.");
+    return `${lines.join("\n")}\n`;
+  }
+  lines.push(`${sources.length} source${sources.length === 1 ? "" : "s"} recorded for this mission.`, "");
+  sources.forEach((source, index) => {
+    lines.push(`${index + 1}. **${source.title}** — ${source.status} · ${source.sourceType}`);
+    if (source.url) lines.push(`   - URL: ${source.url}`);
+    if (source.localPath) lines.push(`   - Local path: ${source.localPath}`);
+    if (source.publisher) {
+      lines.push(`   - Publisher: ${source.publisher}${source.publishedAt ? ` (${source.publishedAt})` : ""}`);
+    } else if (source.publishedAt) {
+      lines.push(`   - Published: ${source.publishedAt}`);
+    }
+    if (source.claim) lines.push(`   - Claim: ${source.claim}`);
+    if (source.note) lines.push(`   - Note: ${source.note}`);
+    if (source.confidence !== undefined) lines.push(`   - Confidence: ${source.confidence}`);
+  });
+  return `${lines.join("\n")}\n`;
+}
+```
+
+- [ ] **Step 1.4: Run to verify pass**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/research-artifact-contract.test.ts`
+Expected: PASS (all tests in the file).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/lib/research-artifact-contract.ts src/lib/research-artifact-contract.test.ts
+git commit -S -m "feat(research): render source ledger markdown for vault publishing
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 2: Standard artifact table + `ensureStandardArtifactRefs`
+
+Client-safe domain additions in `src/lib/research-missions.ts`: the mode→kind mapping (currently duplicated privately in lifecycle and runner), the standard-artifact table, and the additive backfill helper.
+
+**Files:**
+- Modify: `src/lib/research-missions.ts` (after the `ResearchArtifactRef` type, ~line 92)
+- Test: `src/lib/research-missions.test.ts` (exists; already in the app manifest)
+
+- [ ] **Step 2.1: Write the failing tests** — append to `src/lib/research-missions.test.ts` (extend its existing import from `./research-missions.ts` with `ensureStandardArtifactRefs`, `researchArtifactKindForMode`, `STANDARD_RESEARCH_ARTIFACTS`, and `type ResearchMission` if not present; reuse the file's existing mission-builder helper if one exists, otherwise this inline builder):
+
+```ts
+function missionWithArtifacts(
+  artifacts: ResearchMission["artifacts"],
+  iterations: ResearchMission["iterations"] = [{ number: 2, status: "checkpoint" }],
+): ResearchMission {
+  return {
+    version: 1,
+    id: "mission-refs",
+    familiarId: "sage",
+    title: "Storage decision",
+    intent: "Compare SQLite and Postgres",
+    mode: "brief",
+    modeSource: "user",
+    deliverable: "brief",
+    constraints: [],
+    bounds: {
+      wallClockMinutes: 20,
+      maxIterations: 3,
+      sourceTarget: 6,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+    },
+    status: "checkpoint",
+    createdAt: "2026-07-24T00:00:00.000Z",
+    updatedAt: "2026-07-24T01:00:00.000Z",
+    iterations,
+    artifacts,
+    sources: [],
+  };
+}
+
+test("researchArtifactKindForMode maps every mode to its deliverable kind", () => {
+  assert.equal(researchArtifactKindForMode("sweep"), "report");
+  assert.equal(researchArtifactKindForMode("paper"), "paper");
+  assert.equal(researchArtifactKindForMode("autoresearch"), "findings");
+  assert.equal(researchArtifactKindForMode("brief"), "brief");
+});
+
+test("ensureStandardArtifactRefs appends missing standard refs after existing ones", () => {
+  const primary = {
+    key: "primary",
+    kind: "brief" as const,
+    title: "Storage decision",
+    relativePath: "artifacts/primary.md",
+    iteration: 2,
+    state: "working" as const,
+    updatedAt: "2026-07-24T00:30:00.000Z",
+  };
+  const result = ensureStandardArtifactRefs(missionWithArtifacts([primary]));
+  assert.equal(result.artifacts.length, 4);
+  assert.equal(result.artifacts[0], primary, "primary stays first and untouched");
+  assert.deepEqual(
+    result.artifacts.slice(1).map((artifact) => [artifact.key, artifact.kind, artifact.relativePath]),
+    [
+      ["findings", "findings", "findings.md"],
+      ["source-ledger", "source-ledger", "sources.json"],
+      ["research-log", "research-log", "research-log.md"],
+    ],
+  );
+  for (const artifact of result.artifacts.slice(1)) {
+    assert.equal(artifact.state, "working");
+    assert.equal(artifact.iteration, 2, "backfilled refs adopt the latest iteration number");
+    assert.equal(artifact.updatedAt, "2026-07-24T01:00:00.000Z");
+  }
+});
+
+test("ensureStandardArtifactRefs is identity when nothing is missing and never overwrites", () => {
+  const complete = ensureStandardArtifactRefs(missionWithArtifacts([{
+    key: "primary",
+    kind: "brief",
+    title: "Storage decision",
+    relativePath: "artifacts/primary.md",
+    iteration: 1,
+    state: "working",
+    updatedAt: "2026-07-24T00:30:00.000Z",
+  }]));
+  assert.equal(ensureStandardArtifactRefs(complete), complete, "same object when complete");
+
+  const customFindings = {
+    key: "findings",
+    kind: "findings" as const,
+    title: "Custom findings title",
+    relativePath: "findings.md",
+    knowledgeId: "research-mission-refs-findings",
+    iteration: 1,
+    state: "published" as const,
+    updatedAt: "2026-07-24T00:10:00.000Z",
+  };
+  const result = ensureStandardArtifactRefs(missionWithArtifacts([customFindings]));
+  assert.equal(
+    result.artifacts.find((artifact) => artifact.key === "findings"),
+    customFindings,
+    "existing refs are never overwritten",
+  );
+  assert.equal(result.artifacts.length, 3);
+});
+```
+
+- [ ] **Step 2.2: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/research-missions.test.ts`
+Expected: FAIL — the three names are not exported.
+
+- [ ] **Step 2.3: Implement** — insert into `src/lib/research-missions.ts` directly after the `ResearchArtifactRef` type (~line 92):
+
+```ts
+/** Mode → primary-deliverable kind. Single source of truth — the lifecycle
+ *  and runner previously duplicated this mapping privately. */
+export function researchArtifactKindForMode(mode: ResearchMissionMode): ResearchArtifactKind {
+  if (mode === "sweep") return "report";
+  if (mode === "paper") return "paper";
+  if (mode === "autoresearch") return "findings";
+  return "brief";
+}
+
+/** The always-produced workspace files every mission must track and save,
+ *  beyond the mode-specific primary deliverable. */
+export const STANDARD_RESEARCH_ARTIFACTS: ReadonlyArray<
+  Pick<ResearchArtifactRef, "key" | "kind" | "title" | "relativePath">
+> = [
+  { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md" },
+  { key: "source-ledger", kind: "source-ledger", title: "Source ledger", relativePath: "sources.json" },
+  { key: "research-log", kind: "research-log", title: "Research log", relativePath: "research-log.md" },
+];
+
+/** Additive backfill for missions created before the standard refs existed:
+ *  appends any standard ref whose key is absent. Never overwrites, never
+ *  reorders (the primary working copy must stay first), identity when
+ *  nothing is missing. */
+export function ensureStandardArtifactRefs(mission: ResearchMission): ResearchMission {
+  const missing = STANDARD_RESEARCH_ARTIFACTS.filter(
+    (standard) => !mission.artifacts.some((artifact) => artifact.key === standard.key),
+  );
+  if (missing.length === 0) return mission;
+  const iteration = mission.iterations.at(-1)?.number ?? 1;
+  return {
+    ...mission,
+    artifacts: [
+      ...mission.artifacts,
+      ...missing.map((standard) => ({
+        ...standard,
+        iteration,
+        state: "working" as const,
+        updatedAt: mission.updatedAt,
+      })),
+    ],
+  };
+}
+```
+
+Check the file's existing type names: `ResearchMissionMode` and `ResearchArtifactKind` are both defined/exported in this same file (kinds at line ~70) — no new imports needed.
+
+- [ ] **Step 2.4: Run to verify pass**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/research-missions.test.ts`
+Expected: PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/lib/research-missions.ts src/lib/research-missions.test.ts
+git commit -S -m "feat(research): standard artifact table and additive ref backfill
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+<!-- PLAN-CONTINUES-1 -->
+
+---
+
+### Task 3: Register refs at creation + backfill at store read
+
+**Files:**
+- Modify: `src/lib/server/research-mission-lifecycle.ts` (createMissionRecord, lines 18–68)
+- Modify: `src/lib/server/research-mission-store.ts` (loadResearchMission, lines 149–162)
+- Test (new): `src/lib/server/research-mission-lifecycle.test.ts`
+- Test: `src/lib/server/research-mission-store.test.ts` (exists)
+- Modify: `scripts/run-tests.mjs` (register the new lifecycle test)
+
+- [ ] **Step 3.1: Write the failing lifecycle test** — create `src/lib/server/research-mission-lifecycle.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createMissionRecord } from "./research-mission-lifecycle.ts";
+
+const INPUT = {
+  familiarId: "sage",
+  title: "Storage decision",
+  intent: "Compare SQLite and Postgres",
+  mode: "sweep" as const,
+  modeSource: "user" as const,
+  deliverable: "report",
+  constraints: [],
+  bounds: {
+    wallClockMinutes: 20,
+    maxIterations: 1,
+    sourceTarget: 6,
+    checkpointEvery: 1,
+    stopWhenCostUnavailable: false,
+  },
+};
+
+test("createMissionRecord registers the primary and all standard artifact refs", () => {
+  const mission = createMissionRecord(INPUT, "mission-1", new Date("2026-07-24T00:00:00.000Z"));
+  assert.deepEqual(
+    mission.artifacts.map((artifact) => [artifact.key, artifact.kind, artifact.relativePath]),
+    [
+      ["primary", "report", "artifacts/primary.md"],
+      ["findings", "findings", "findings.md"],
+      ["source-ledger", "source-ledger", "sources.json"],
+      ["research-log", "research-log", "research-log.md"],
+    ],
+  );
+  for (const artifact of mission.artifacts) {
+    assert.equal(artifact.state, "working");
+    assert.equal(artifact.iteration, 1);
+    assert.equal(artifact.updatedAt, "2026-07-24T00:00:00.000Z");
+    assert.equal(artifact.knowledgeId, undefined);
+  }
+});
+```
+
+- [ ] **Step 3.2: Register the new test file** — in `scripts/run-tests.mjs`, add to the manifest array that already contains `"src/lib/server/research-mission-store.test.ts"` (~line 226), directly after that entry:
+
+```js
+    "src/lib/server/research-mission-lifecycle.test.ts",
+```
+
+- [ ] **Step 3.3: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-lifecycle.test.ts`
+Expected: FAIL — artifacts array has length 1 (only primary).
+
+- [ ] **Step 3.4: Implement lifecycle** — in `src/lib/server/research-mission-lifecycle.ts`:
+
+Replace the import block's research-missions line and delete the private mapper:
+
+```ts
+import {
+  researchArtifactKindForMode,
+  STANDARD_RESEARCH_ARTIFACTS,
+  type CreateResearchMissionInput,
+  type ResearchMission,
+} from "../research-missions.ts";
+```
+
+Delete the whole `function artifactKindForMode(...)` (lines 18–23) and its now-unused `ResearchArtifactKind` import. In `createMissionRecord`, change `const kind = artifactKindForMode(input.mode);` to `const kind = researchArtifactKindForMode(input.mode);` and replace the `artifacts:` property with:
+
+```ts
+    artifacts: [
+      {
+        key: "primary",
+        kind,
+        title: missionTitle(input),
+        relativePath: "artifacts/primary.md",
+        iteration: 1,
+        state: "working",
+        updatedAt: timestamp,
+      },
+      ...STANDARD_RESEARCH_ARTIFACTS.map((standard) => ({
+        ...standard,
+        iteration: 1,
+        state: "working" as const,
+        updatedAt: timestamp,
+      })),
+    ],
+```
+
+- [ ] **Step 3.5: Write the failing store-backfill test** — append to `src/lib/server/research-mission-store.test.ts`. **First view the top of that file** and reuse its existing temp-root setup helper if it has one; otherwise use this self-contained pattern (the store reads `COVEN_RESEARCH_MISSIONS_DIR` at call time, line ~30):
+
+```ts
+test("loadResearchMission backfills standard artifact refs on legacy missions", async (t) => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "research-store-backfill-"));
+  const previousRoot = process.env.COVEN_RESEARCH_MISSIONS_DIR;
+  process.env.COVEN_RESEARCH_MISSIONS_DIR = root;
+  t.after(async () => {
+    if (previousRoot === undefined) delete process.env.COVEN_RESEARCH_MISSIONS_DIR;
+    else process.env.COVEN_RESEARCH_MISSIONS_DIR = previousRoot;
+    await rm(root, { recursive: true, force: true });
+  });
+  const legacy = {
+    version: 1,
+    id: "legacy-mission",
+    familiarId: "sage",
+    title: "Legacy",
+    intent: "Legacy mission from before standard refs",
+    mode: "brief",
+    modeSource: "user",
+    deliverable: "brief",
+    constraints: [],
+    bounds: {
+      wallClockMinutes: 20,
+      maxIterations: 1,
+      sourceTarget: 6,
+      checkpointEvery: 1,
+      stopWhenCostUnavailable: false,
+    },
+    status: "completed",
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-01T01:00:00.000Z",
+    iterations: [{ number: 1, status: "completed" }],
+    artifacts: [{
+      key: "primary",
+      kind: "brief",
+      title: "Legacy",
+      relativePath: "artifacts/primary.md",
+      iteration: 1,
+      state: "working",
+      updatedAt: "2026-07-01T01:00:00.000Z",
+    }],
+    sources: [],
+  };
+  await mkdir(path.join(root, "legacy-mission"), { recursive: true });
+  await writeFile(path.join(root, "legacy-mission", "mission.json"), JSON.stringify(legacy));
+  const loaded = await loadResearchMission("legacy-mission");
+  assert.ok(loaded);
+  assert.deepEqual(
+    loaded.artifacts.map((artifact) => artifact.key),
+    ["primary", "findings", "source-ledger", "research-log"],
+  );
+});
+```
+
+Add whichever of `mkdtemp`, `mkdir`, `writeFile`, `rm` (from `node:fs/promises`), `os` (`node:os`), `path` (`node:path`), and `loadResearchMission` the file doesn't already import.
+
+- [ ] **Step 3.6: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-store.test.ts`
+Expected: the new test FAILS (only `primary` present); pre-existing tests still pass.
+
+- [ ] **Step 3.7: Implement the store backfill** — in `src/lib/server/research-mission-store.ts`, add `ensureStandardArtifactRefs` to the existing import from `../research-missions.ts`, then in `loadResearchMission` change:
+
+```ts
+    if (!isResearchMission(parsed) || parsed.id !== id) return null;
+    return parsed;
+```
+
+to:
+
+```ts
+    if (!isResearchMission(parsed) || parsed.id !== id) return null;
+    // Additive read-time backfill: missions created before the standard refs
+    // existed gain them on load; the refs persist on the next save.
+    return ensureStandardArtifactRefs(parsed);
+```
+
+- [ ] **Step 3.8: Run to verify pass**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-lifecycle.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-store.test.ts
+```
+Expected: PASS both. Also run the four runner test files (they consume `createMissionRecord` missions indirectly):
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-automation-scheduling.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+```
+If any assert an exact `artifacts.length` after mission creation, update that expectation to 4 (test fixtures built literally — like `checkpointMission()` — are unaffected).
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add src/lib/server/research-mission-lifecycle.ts src/lib/server/research-mission-lifecycle.test.ts src/lib/server/research-mission-store.ts src/lib/server/research-mission-store.test.ts scripts/run-tests.mjs
+git commit -S -m "feat(research): register standard artifact refs at creation and backfill on load
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 4: Runner — publish every final artifact on complete
+
+`reconcileCompletedRun` (runner lines 281–393) currently bumps/publishes only `artifacts[0]`. Now: every non-rejected ref is bumped each pass; on a `complete` decision every unpublished, non-rejected ref publishes with per-artifact failure isolation.
+
+**Files:**
+- Modify: `src/lib/server/research-mission-runner.ts`
+- Test: `src/lib/server/research-mission-runner-reconciliation-evidence.test.ts` (exists; builders `deps(overrides)` / `checkpointMission(overrides)` at lines 45–131)
+
+- [ ] **Step 4.1: Write the failing tests** — append to the reconciliation test file. It reconciles via `runner.act` with a succeeded flow run (copy the stub shape from its first test, lines 132–169). Helper + tests to add:
+
+```ts
+const FOUR_REFS: ResearchMission["artifacts"] = [
+  { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+  { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+  { key: "source-ledger", kind: "source-ledger", title: "Source ledger", relativePath: "sources.json", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+  { key: "research-log", kind: "research-log", title: "Research log", relativePath: "research-log.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+];
+
+function completingRunDeps(
+  stored: { mission: ResearchMission },
+  overrides: Partial<ResearchMissionRunnerDeps> = {},
+): ResearchMissionRunnerDeps {
+  return deps({
+    loadMission: async () => structuredClone(stored.mission),
+    saveMission: async (mission) => { stored.mission = structuredClone(mission); },
+    loadFlowRun: async () => ({ ...RUN, status: "succeeded", finishedAt: NOW.toISOString() }),
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: [
+          "@@research-control",
+          '{"decision":"complete","reason":"Done","confidence":0.9}',
+          "@@research-artifacts-written",
+        ].join("\n"),
+        createdAt: NOW.toISOString(),
+      }],
+    }),
+    readMissionFile: async (_id, relativePath) => `# Content of ${relativePath}\n`,
+    ...overrides,
+  });
+}
+
+test("complete publishes all four final artifacts to the vault", async () => {
+  const stored = {
+    mission: checkpointMission({
+      status: "running",
+      artifacts: structuredClone(FOUR_REFS),
+      sources: [{ id: "s1", title: "SQLite docs", url: "https://sqlite.org", sourceType: "web", status: "used" }],
+      iterations: [{ ...checkpointMission().iterations[0], status: "running", finishedAt: undefined }],
+    }),
+  };
+  const published: Array<{ id: string; body: string }> = [];
+  const runner = makeResearchMissionRunner(completingRunDeps(stored, {
+    publishKnowledge: async (entry) => { published.push({ id: entry.id, body: entry.body }); return entry; },
+  }));
+  const result = await runner.act(stored.mission.id, { action: "resume" });
+  assert.equal(result.status, "completed");
+  assert.equal(result.lastError, undefined);
+  assert.deepEqual(
+    published.map((entry) => entry.id).sort(),
+    [
+      "research-mission-actions-findings",
+      "research-mission-actions-primary",
+      "research-mission-actions-research-log",
+      "research-mission-actions-source-ledger",
+    ],
+  );
+  const ledger = published.find((entry) => entry.id.endsWith("source-ledger"));
+  assert.match(ledger?.body ?? "", /SQLite docs/, "ledger publishes rendered markdown, not raw JSON");
+  for (const artifact of result.artifacts) {
+    assert.equal(artifact.state, "published");
+    assert.ok(artifact.knowledgeId);
+  }
+});
+
+test("checkpoint publishes nothing but bumps every working ref", async () => {
+  const stored = {
+    mission: checkpointMission({
+      status: "running",
+      artifacts: structuredClone(FOUR_REFS),
+      iterations: [{ ...checkpointMission().iterations[0], number: 2, status: "running", finishedAt: undefined }],
+    }),
+  };
+  let published = 0;
+  const runner = makeResearchMissionRunner(completingRunDeps(stored, {
+    loadConversation: async () => ({
+      sessionId: "session-1",
+      familiarId: "sage",
+      harness: "codex",
+      createdAt: NOW.toISOString(),
+      updatedAt: NOW.toISOString(),
+      turns: [{
+        id: "turn-1",
+        role: "assistant",
+        text: [
+          "@@research-control",
+          '{"decision":"checkpoint","reason":"Review","confidence":0.8}',
+          "@@research-artifacts-written",
+        ].join("\n"),
+        createdAt: NOW.toISOString(),
+      }],
+    }),
+    publishKnowledge: async (entry) => { published += 1; return entry; },
+  }));
+  const result = await runner.act(stored.mission.id, { action: "resume" });
+  assert.equal(result.status, "checkpoint");
+  assert.equal(published, 0);
+  for (const artifact of result.artifacts) {
+    assert.equal(artifact.state, "working");
+    assert.equal(artifact.iteration, 2, "every ref adopts the finished pass number");
+  }
+});
+
+test("a single publish failure is isolated: mission completes, ref stays working, lastError names it", async () => {
+  const stored = {
+    mission: checkpointMission({
+      status: "running",
+      artifacts: structuredClone(FOUR_REFS),
+      iterations: [{ ...checkpointMission().iterations[0], status: "running", finishedAt: undefined }],
+    }),
+  };
+  const runner = makeResearchMissionRunner(completingRunDeps(stored, {
+    publishKnowledge: async (entry) => {
+      if (entry.id.endsWith("-findings")) throw new Error("vault write failed");
+      return entry;
+    },
+  }));
+  const result = await runner.act(stored.mission.id, { action: "resume" });
+  assert.equal(result.status, "completed", "publish failure never blocks the terminal state");
+  assert.match(result.lastError ?? "", /findings: vault write failed/);
+  const findings = result.artifacts.find((artifact) => artifact.key === "findings");
+  assert.equal(findings?.state, "working");
+  assert.equal(findings?.knowledgeId, undefined);
+  assert.equal(
+    result.artifacts.filter((artifact) => artifact.state === "published").length,
+    3,
+    "the other refs still publish",
+  );
+});
+
+test("a missing standard file fails only that artifact", async () => {
+  const stored = {
+    mission: checkpointMission({
+      status: "running",
+      artifacts: structuredClone(FOUR_REFS),
+      iterations: [{ ...checkpointMission().iterations[0], status: "running", finishedAt: undefined }],
+    }),
+  };
+  const runner = makeResearchMissionRunner(completingRunDeps(stored, {
+    readMissionFile: async (_id, relativePath) => (
+      relativePath === "research-log.md" ? null : `# Content of ${relativePath}\n`
+    ),
+  }));
+  const result = await runner.act(stored.mission.id, { action: "resume" });
+  assert.equal(result.status, "completed");
+  assert.match(result.lastError ?? "", /research-log: file missing/);
+  assert.equal(result.artifacts.filter((artifact) => artifact.state === "published").length, 3);
+});
+```
+
+Note: `{ action: "resume" }` on a mission whose flow run has succeeded triggers `reconcileFlowUnlocked` → `reconcileCompletedRun` before the resume branch, exactly like the existing "actions reconcile a completed Flow" test — after reconciliation to a terminal status, resume is not in `allowedResearchActions`, so the reconciled mission is returned as-is.
+
+- [ ] **Step 4.2: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-reconciliation-evidence.test.ts`
+Expected: new tests FAIL (only 1 publish happens; standard refs never bumped).
+
+- [ ] **Step 4.3: Implement** — in `src/lib/server/research-mission-runner.ts`:
+
+**(a)** Extend imports: add `renderSourceLedgerMarkdown` and `type ResearchProvenance` to the existing import from `../research-artifact-contract.ts`; add `researchArtifactKindForMode` to the existing import from `../research-missions.ts`. Delete the private `defaultArtifactKindForMode` (line ~209) and replace its two call sites with `researchArtifactKindForMode`.
+
+**(b)** Add the shared publisher directly above `reconcileCompletedRun`:
+
+```ts
+type PublishFinalArtifactsArgs = {
+  mission: ResearchMission;
+  artifacts: ResearchArtifactRef[];
+  sources: ResearchSourceRef[];
+  /** Pre-read artifacts/primary.md content; null when unavailable. */
+  primaryMarkdown: string | null;
+  provenance: ResearchProvenance;
+  deps: Pick<ResearchMissionRunnerDeps, "readMissionFile" | "publishKnowledge">;
+};
+
+/** Publish every unpublished, non-rejected ref. Per-artifact isolation: one
+ *  failed vault write or missing file never blocks the others or the
+ *  mission's terminal state — the failed ref stays `working` (retryable via
+ *  publish-artifact) and is named in the returned failures. */
+async function publishFinalArtifacts(
+  args: PublishFinalArtifactsArgs,
+): Promise<{ artifacts: ResearchArtifactRef[]; failures: string[] }> {
+  const artifacts: ResearchArtifactRef[] = [];
+  const failures: string[] = [];
+  for (const artifact of args.artifacts) {
+    if (artifact.state === "rejected" || artifact.knowledgeId) {
+      artifacts.push(artifact);
+      continue;
+    }
+    try {
+      const markdown = artifact.relativePath === "artifacts/primary.md"
+        ? args.primaryMarkdown
+        : artifact.kind === "source-ledger"
+          ? renderSourceLedgerMarkdown(args.sources)
+          : await args.deps.readMissionFile(args.mission.id, artifact.relativePath);
+      if (markdown === null) throw new Error("file missing");
+      const content = validateResearchArtifactContent(artifact.kind, markdown);
+      if (!content.ok) throw new Error(content.reason);
+      const entry = await args.deps.publishKnowledge(researchKnowledgeEntry({
+        mission: args.mission,
+        artifact,
+        provenance: args.provenance,
+        markdown: content.value,
+      }));
+      artifacts.push({ ...artifact, knowledgeId: entry.id, state: "published" });
+    } catch (error) {
+      failures.push(`${artifact.key}: ${error instanceof Error ? error.message : "publish failed"}`);
+      artifacts.push(artifact);
+    }
+  }
+  return { artifacts, failures };
+}
+
+function publishFailureError(failures: string[]): string | undefined {
+  return failures.length ? `Artifact publish failed — ${failures.join("; ")}` : undefined;
+}
+```
+
+If `ResearchArtifactRef` / `ResearchSourceRef` aren't already imported as types in the runner, add them to the `../research-missions.ts` type import (ResearchArtifactRef is already used at line ~341).
+
+**(c)** In `reconcileCompletedRun`, replace everything from `const primaryArtifact: ResearchArtifactRef | undefined = mission.artifacts[0];` (line ~341) through the final `return` (line ~392) with:
+
+```ts
+  // Primary lookup by path, not index — backfilled legacy arrays and the
+  // reject flow's prepended working copies both keep this stable.
+  const primaryArtifact = mission.artifacts.find(
+    (artifact) => artifact.relativePath === "artifacts/primary.md" && artifact.state !== "rejected",
+  );
+  const content = validateResearchArtifactContent(
+    primaryArtifact?.kind ?? researchArtifactKindForMode(mission.mode),
+    markdown,
+  );
+  if (!content.ok) {
+    return {
+      ...mission,
+      status: "checkpoint",
+      updatedAt: timestamp,
+      lastError: content.reason,
+      sources,
+      iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
+    };
+  }
+
+  // Every pass through the normal evidence path bumps every live ref — the
+  // standard files are rewritten by each run just like the primary.
+  let artifacts = mission.artifacts.map((artifact) => (
+    artifact.state === "rejected" ? artifact : {
+      ...artifact,
+      iteration: iteration.number,
+      updatedAt: timestamp,
+    }
+  ));
+  let publishFailures: string[] = [];
+  if (control.decision === "complete") {
+    const outcome = await publishFinalArtifacts({
+      mission,
+      artifacts,
+      sources,
+      primaryMarkdown: content.value,
+      provenance: {
+        missionId: mission.id,
+        iteration: iteration.number,
+        flowRunId: iteration.flowRunId,
+        sessionId: iteration.sessionId,
+        automationRunId: iteration.automationRunId,
+        generatedAt: timestamp,
+      },
+      deps,
+    });
+    artifacts = outcome.artifacts;
+    publishFailures = outcome.failures;
+  }
+
+  return {
+    ...mission,
+    status: control.decision === "complete" ? "completed" : "checkpoint",
+    updatedAt: timestamp,
+    ...(control.decision === "complete" ? { finishedAt: timestamp } : {}),
+    lastError: publishFailureError(publishFailures),
+    sources,
+    artifacts,
+    iterations: mission.iterations.map((item, index) => index === iterationIndex ? nextIteration : item),
+  };
+```
+
+The three early returns above this block (evidence read failure, missing `primary.md`, validation failure) are unchanged — they keep checkpoint + `lastError` and never touch refs.
+
+- [ ] **Step 4.4: Run to verify pass**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-automation-scheduling.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+```
+Expected: PASS. If a pre-existing test completes a single-ref mission and asserts on `result.artifacts[0]` only, it still passes (single-ref missions behave as before). Fix any test asserting `lastError === undefined` after a complete whose fixture makes standard-file reads fail — give its deps a `readMissionFile` override that returns content for every path (like `completingRunDeps` does).
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/lib/server/research-mission-runner.ts src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+git commit -S -m "feat(research): publish all final artifacts on complete with failure isolation
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 5: `publish-artifact` action + `finish` publishes
+
+Manual per-artifact publish for settled missions, and the user-driven `finish` action now saves artifacts exactly like an agent `complete` decision (spec §2–§3).
+
+**Files:**
+- Modify: `src/lib/research-missions.ts` (action input union, lines 170–183)
+- Modify: `src/lib/server/research-mission-runner.ts` (`act`, lines 564–667)
+- Modify: `src/app/api/research/missions/[id]/actions/route.ts` (ACTIONS ~line 26, VALIDATION_ERRORS ~line 33, `actionErrorStatus` ~line 44)
+- Tests: `src/lib/server/research-mission-runner-lifecycle-actions.test.ts`, `src/app/api/research/missions/[id]/actions/route.test.ts` (both exist)
+
+- [ ] **Step 5.1: Extend the action input type** — in `src/lib/research-missions.ts`, add a final variant to `ResearchMissionActionInput`:
+
+```ts
+  | { action: "reject-artifact"; artifactKey: string; reason: string }
+  | { action: "publish-artifact"; artifactKey: string };
+```
+
+- [ ] **Step 5.2: Write the failing runner tests** — append to `src/lib/server/research-mission-runner-lifecycle-actions.test.ts` (reuse its local `deps`/mission builders — it has the same `deps(overrides)` + `checkpointMission(overrides)` pattern as the reconciliation file; if the builder names differ, view the file top first and adapt these tests to its builders, keeping assertions identical):
+
+```ts
+test("publish-artifact publishes one working ref on a settled mission", async () => {
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+    lastError: "Artifact publish failed — findings: vault write failed",
+  });
+  const published: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async (_id, relativePath) => `# Content of ${relativePath}\n`,
+    publishKnowledge: async (entry) => { published.push(entry.id); return entry; },
+  }));
+  const result = await runner.act(stored.id, { action: "publish-artifact", artifactKey: "findings" });
+  assert.deepEqual(published, ["research-mission-actions-findings"]);
+  const findings = result.artifacts.find((artifact) => artifact.key === "findings");
+  assert.equal(findings?.state, "published");
+  assert.equal(findings?.knowledgeId, "research-mission-actions-findings");
+  assert.equal(result.status, "checkpoint", "manual publish never changes mission status");
+  assert.equal(
+    result.lastError,
+    "Artifact publish failed — findings: vault write failed",
+    "publish-failure lastError stays until no unpublished working refs remain",
+  );
+});
+
+test("publish-artifact clears the publish-failure lastError once nothing is left unpublished", async () => {
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString(), knowledgeId: "research-mission-actions-primary" },
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+    lastError: "Artifact publish failed — findings: vault write failed",
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async () => "# Findings\n",
+  }));
+  const result = await runner.act(stored.id, { action: "publish-artifact", artifactKey: "findings" });
+  assert.equal(result.lastError, undefined);
+});
+
+test("publish-artifact rejects running missions, published refs, rejected refs, and unknown keys", async () => {
+  const base = checkpointMission({
+    artifacts: [
+      { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+      { key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "published", knowledgeId: "research-mission-actions-findings", updatedAt: NOW.toISOString() },
+      { key: "research-log", kind: "research-log", title: "Research log", relativePath: "research-log.md", iteration: 1, state: "rejected", rejectionReason: "sparse", updatedAt: NOW.toISOString() },
+    ],
+  });
+  const cases: Array<[Partial<ResearchMission>, string, string]> = [
+    [{ status: "running" }, "primary", "research mission is still running"],
+    [{}, "findings", "research artifact already published"],
+    [{}, "research-log", "rejected artifacts need a new working version before publishing"],
+    [{}, "nope", "research artifact not found"],
+  ];
+  for (const [overrides, artifactKey, message] of cases) {
+    let stored = { ...structuredClone(base), ...overrides };
+    const runner = makeResearchMissionRunner(deps({
+      loadMission: async () => structuredClone(stored),
+      saveMission: async (mission) => { stored = structuredClone(mission); },
+      readMissionFile: async () => "# Content\n",
+    }));
+    await assert.rejects(
+      () => runner.act(stored.id, { action: "publish-artifact", artifactKey }),
+      new Error(message),
+      message,
+    );
+  }
+});
+
+test("publish-artifact surfaces a missing file as a clear validation error", async () => {
+  let stored = checkpointMission({
+    artifacts: [{ key: "findings", kind: "findings", title: "Findings", relativePath: "findings.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() }],
+  });
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async () => null,
+  }));
+  await assert.rejects(
+    () => runner.act(stored.id, { action: "publish-artifact", artifactKey: "findings" }),
+    new Error("research artifact file missing"),
+  );
+});
+
+test("finish publishes the mission's working refs like a complete decision", async () => {
+  let stored = checkpointMission({
+    artifacts: [
+      { key: "primary", kind: "findings", title: "Iterative research", relativePath: "artifacts/primary.md", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+      { key: "source-ledger", kind: "source-ledger", title: "Source ledger", relativePath: "sources.json", iteration: 1, state: "working", updatedAt: NOW.toISOString() },
+    ],
+    sources: [{ id: "s1", title: "SQLite docs", url: "https://sqlite.org", sourceType: "web", status: "used" }],
+  });
+  const published: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    loadMission: async () => structuredClone(stored),
+    saveMission: async (mission) => { stored = structuredClone(mission); },
+    readMissionFile: async (_id, relativePath) => `# Content of ${relativePath}\n`,
+    publishKnowledge: async (entry) => { published.push(entry.id); return entry; },
+  }));
+  const result = await runner.act(stored.id, { action: "finish" });
+  assert.equal(result.status, "completed");
+  assert.deepEqual(published.sort(), [
+    "research-mission-actions-primary",
+    "research-mission-actions-source-ledger",
+  ]);
+  assert.equal(result.lastError, undefined);
+  for (const artifact of result.artifacts) assert.equal(artifact.state, "published");
+});
+```
+
+Add `type ResearchMission` to the test file's imports if missing.
+
+- [ ] **Step 5.3: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-lifecycle-actions.test.ts`
+Expected: new tests FAIL (`publish-artifact` falls through to the allowed-actions gate and returns the mission unchanged; `finish` publishes nothing).
+
+- [ ] **Step 5.4: Implement the runner branches** — in `act()`:
+
+**(a)** Insert after the `reject-artifact` branch (ends line ~598) and **before** the `allowedResearchActions` gate (line ~600) — input-specific actions run before that gate by existing convention:
+
+```ts
+      if (input.action === "publish-artifact") {
+        if (!["checkpoint", "completed", "failed"].includes(mission.status)) {
+          throw new Error("research mission is still running");
+        }
+        const artifact = mission.artifacts.find((item) => item.key === input.artifactKey);
+        if (!artifact) throw new Error("research artifact not found");
+        if (artifact.knowledgeId || artifact.state === "published") {
+          throw new Error("research artifact already published");
+        }
+        if (artifact.state === "rejected") {
+          throw new Error("rejected artifacts need a new working version before publishing");
+        }
+        const markdown = artifact.kind === "source-ledger"
+          ? renderSourceLedgerMarkdown(mission.sources)
+          : await deps.readMissionFile(mission.id, artifact.relativePath);
+        if (markdown === null) throw new Error("research artifact file missing");
+        const content = validateResearchArtifactContent(artifact.kind, markdown);
+        if (!content.ok) throw new Error(content.reason);
+        const lastIteration = mission.iterations.at(-1);
+        const entry = await deps.publishKnowledge(researchKnowledgeEntry({
+          mission,
+          artifact,
+          provenance: {
+            missionId: mission.id,
+            iteration: lastIteration?.number ?? mission.iterations.length,
+            flowRunId: lastIteration?.flowRunId,
+            sessionId: lastIteration?.sessionId,
+            automationRunId: lastIteration?.automationRunId,
+            generatedAt: timestamp,
+          },
+          markdown: content.value,
+        }));
+        const artifacts = mission.artifacts.map((item) => (
+          item.key === artifact.key
+            ? { ...item, knowledgeId: entry.id, state: "published" as const, updatedAt: timestamp }
+            : item
+        ));
+        // The publish-failure lastError clears once nothing publishable is
+        // left unpublished; any other lastError is not ours to clear.
+        const publishPending = artifacts.some((item) => item.state === "working" && !item.knowledgeId);
+        const lastError = mission.lastError?.startsWith("Artifact publish failed") && !publishPending
+          ? undefined
+          : mission.lastError;
+        return saveUpdated({ ...mission, artifacts, lastError });
+      }
+```
+
+**(b)** Replace the `finish` branch (lines ~649–657) with:
+
+```ts
+      if (input.action === "finish") {
+        mission = await pauseAutomation(mission, "Mission finished");
+        // Finishing by hand saves the same final artifacts a `complete`
+        // decision would — the checkpointed files are the deliverables.
+        const lastIteration = mission.iterations.at(-1);
+        const outcome = await publishFinalArtifacts({
+          mission,
+          artifacts: mission.artifacts.map((artifact) => (
+            artifact.state === "rejected" ? artifact : { ...artifact, updatedAt: timestamp }
+          )),
+          sources: mission.sources,
+          primaryMarkdown: await deps.readMissionFile(mission.id, "artifacts/primary.md"),
+          provenance: {
+            missionId: mission.id,
+            iteration: lastIteration?.number ?? mission.iterations.length,
+            flowRunId: lastIteration?.flowRunId,
+            sessionId: lastIteration?.sessionId,
+            automationRunId: lastIteration?.automationRunId,
+            generatedAt: timestamp,
+          },
+          deps,
+        });
+        return saveUpdated({
+          ...mission,
+          status: "completed",
+          finishedAt: timestamp,
+          artifacts: outcome.artifacts,
+          lastError: publishFailureError(outcome.failures),
+        });
+      }
+```
+
+- [ ] **Step 5.5: Run runner suites; reconcile existing `finish` expectations**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-automation-scheduling.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+```
+
+Known interaction: `finish` now attempts publishes, and the default `deps()` stub returns `readMissionFile: async () => null` — a fixture mission with a working primary ref finishes with `lastError: "Artifact publish failed — primary: file missing"`. The two automation tests that run `finish` ("terminal mission actions pause a linked active Automation", line ~290; "terminal actions pause Automation truth even when mission metadata is stale", line ~396) only assert automation status and are expected to keep passing. If any test fails on an unexpected `lastError` after `finish`, add `readMissionFile: async () => "# Complete\n",` to that test's `deps({...})` overrides rather than weakening the assertion.
+
+- [ ] **Step 5.6: Write the failing route test** — append to `src/app/api/research/missions/[id]/actions/route.test.ts` (source-scan style; it reads `./route.ts` at the top):
+
+```ts
+test("publish-artifact is routable with its validation and conflict mappings", () => {
+  assert.match(source, /"attach-source", "update-source", "reject-artifact", "publish-artifact"/);
+  assert.match(source, /"research mission is still running"/);
+  assert.match(source, /"rejected artifacts need a new working version before publishing"/);
+  assert.match(source, /"research artifact file missing"/);
+  assert.match(source, /"Research artifact is too large"/);
+  assert.match(source, /research artifact already published.*return 409|return 409.*research artifact already published/s);
+});
+```
+
+- [ ] **Step 5.7: Implement the route additions** — in `src/app/api/research/missions/[id]/actions/route.ts`:
+
+Line ~26, extend the input-specific list:
+
+```ts
+  "attach-source", "update-source", "reject-artifact", "publish-artifact",
+```
+
+In `VALIDATION_ERRORS` (~line 33), add:
+
+```ts
+  "research mission is still running",
+  "rejected artifacts need a new working version before publishing",
+  "research artifact file missing",
+  "Research artifact is too large",
+  "Unsupported research artifact kind",
+```
+
+In `actionErrorStatus` (~line 44), after the automation-conflict 409 line, add:
+
+```ts
+  // Re-publishing an already-vaulted artifact is a state conflict, not a bad
+  // request — the UI resolves it by refreshing the mission.
+  if (message === "research artifact already published") return 409;
+```
+
+- [ ] **Step 5.8: Run to verify pass**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs "src/app/api/research/missions/[id]/actions/route.test.ts"
+```
+Expected: PASS.
+
+- [ ] **Step 5.9: Commit**
+
+```bash
+git add src/lib/research-missions.ts src/lib/server/research-mission-runner.ts src/lib/server/research-mission-runner-lifecycle-actions.test.ts "src/app/api/research/missions/[id]/actions/route.ts" "src/app/api/research/missions/[id]/actions/route.test.ts"
+git commit -S -m "feat(research): manual publish-artifact action and publishing finish
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+<!-- PLAN-CONTINUES-2 -->
+
+---
+
+### Task 6: Files API + client accessor
+
+Read-only endpoint serving ref-backed file content (path-validated, symlink-safe, 2 MiB cap via the existing `readValidatedMissionFile`), plus the typed client accessor the UI uses.
+
+**Files:**
+- Create: `src/app/api/research/missions/[id]/files/[key]/route.ts`
+- Create: `src/app/api/research/missions/[id]/files/[key]/route.test.ts`
+- Modify: `src/lib/research-mission-client.ts` (types near the top, function after `getResearchMission` ~line 61)
+- Test: `src/lib/research-mission-client.test.ts` (exists)
+- Modify: `scripts/run-tests.mjs` (register the new route test)
+
+- [ ] **Step 6.1: Write the failing route source-scan test** — create `src/app/api/research/missions/[id]/files/[key]/route.test.ts` (mirror the sibling `[id]/route.test.ts` style):
+
+```ts
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
+
+test("research mission file route is dynamic, node-only, and local-only", () => {
+  assert.match(source, /export const dynamic = "force-dynamic"/);
+  assert.match(source, /export const runtime = "nodejs"/);
+  assert.match(source, /rejectNonLocalRequest/);
+});
+
+test("route validates the mission id and resolves the artifact by key", () => {
+  assert.match(source, /isValidResearchMissionId/);
+  assert.match(source, /"path not allowed"/);
+  assert.match(source, /"research mission not found"/);
+  assert.match(source, /"research artifact not found"/);
+});
+
+test("route reads through the validated store reader and tolerates missing files", () => {
+  assert.match(source, /readValidatedMissionFile/);
+  assert.match(source, /ENOENT/);
+  assert.match(source, /content: string \| null/);
+  assert.match(source, /workspacePath/);
+});
+```
+
+- [ ] **Step 6.2: Register it** — in `scripts/run-tests.mjs`, add to the API route manifest next to the existing `"src/app/api/research/missions/[id]/route.test.ts"` entry (~line 1021):
+
+```js
+  "src/app/api/research/missions/[id]/files/[key]/route.test.ts",
+```
+
+- [ ] **Step 6.3: Run to verify failure**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs "src/app/api/research/missions/[id]/files/[key]/route.test.ts"`
+Expected: FAIL — `./route.ts` does not exist (ENOENT).
+
+- [ ] **Step 6.4: Implement the route** — create `src/app/api/research/missions/[id]/files/[key]/route.ts`. **First view the sibling** `src/app/api/research/missions/[id]/route.ts` and copy its exact import paths and `rejectNonLocalRequest` usage. Shape:
+
+```ts
+import path from "node:path";
+import { NextResponse } from "next/server";
+import { rejectNonLocalRequest } from "@/lib/server/local-request";
+import {
+  isValidResearchMissionId,
+  loadResearchMission,
+  readValidatedMissionFile,
+  researchMissionWorkspacePath,
+} from "@/lib/server/research-mission-store";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type MissionFilePayload = {
+  key: string;
+  kind: string;
+  title: string;
+  fileName: string;
+  relativePath: string;
+  /** File body, or null when the run has not written it yet. */
+  content: string | null;
+  workspacePath: string;
+  updatedAt: string;
+};
+
+export async function GET(
+  request: Request,
+  context: { params: Promise<{ id: string; key: string }> },
+) {
+  const rejected = rejectNonLocalRequest(request);
+  if (rejected) return rejected;
+  const { id, key } = await context.params;
+  if (!isValidResearchMissionId(id)) {
+    return NextResponse.json({ ok: false, error: "path not allowed" }, { status: 403 });
+  }
+  const mission = await loadResearchMission(id);
+  if (!mission) {
+    return NextResponse.json({ ok: false, error: "research mission not found" }, { status: 404 });
+  }
+  const artifact = mission.artifacts.find((item) => item.key === key);
+  if (!artifact) {
+    return NextResponse.json({ ok: false, error: "research artifact not found" }, { status: 404 });
+  }
+  let content: string | null = null;
+  try {
+    content = await readValidatedMissionFile(id, artifact.relativePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      const message = error instanceof Error ? error.message : "failed to read research artifact";
+      return NextResponse.json({ ok: false, error: message }, { status: 500 });
+    }
+  }
+  const file: MissionFilePayload = {
+    key: artifact.key,
+    kind: artifact.kind,
+    title: artifact.title,
+    fileName: path.posix.basename(artifact.relativePath),
+    relativePath: artifact.relativePath,
+    content,
+    workspacePath: researchMissionWorkspacePath(id),
+    updatedAt: artifact.updatedAt,
+  };
+  return NextResponse.json({ ok: true, file });
+}
+```
+
+Adjust to reality while implementing: check the actual exported names in `research-mission-store.ts` (`readValidatedMissionFile` may return null for missing files instead of throwing ENOENT — view lines 182–200 and keep whichever contract holds, updating the try/catch accordingly) and whether `researchMissionWorkspacePath(id)` is the store's actual workspace-path helper name. Keep the route response shape exactly as typed.
+
+- [ ] **Step 6.5: Run to verify pass**
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs "src/app/api/research/missions/[id]/files/[key]/route.test.ts"`
+Expected: PASS.
+
+- [ ] **Step 6.6: Write the failing client test** — append to `src/lib/research-mission-client.test.ts`, following its existing fetch-stub pattern (lines 19–34: stash `globalThis.fetch`, restore in `finally`):
+
+```ts
+test("getResearchMissionFile fetches the file payload with encoded segments", async () => {
+  const originalFetch = globalThis.fetch;
+  const calls: string[] = [];
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    calls.push(String(input));
+    return new Response(JSON.stringify({
+      ok: true,
+      file: {
+        key: "source-ledger",
+        kind: "source-ledger",
+        title: "Source ledger",
+        fileName: "sources.json",
+        relativePath: "sources.json",
+        content: "[]",
+        workspacePath: "/tmp/research-missions/mission-1",
+        updatedAt: "2026-07-24T00:00:00.000Z",
+      },
+    }), { status: 200, headers: { "content-type": "application/json" } });
+  }) as typeof fetch;
+  try {
+    const file = await getResearchMissionFile("mission 1", "source-ledger");
+    assert.deepEqual(calls, ["/api/research/missions/mission%201/files/source-ledger"]);
+    assert.equal(file.content, "[]");
+    assert.equal(file.workspacePath, "/tmp/research-missions/mission-1");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getResearchMissionFile surfaces API errors", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () => new Response(
+    JSON.stringify({ ok: false, error: "research artifact not found" }),
+    { status: 404, headers: { "content-type": "application/json" } },
+  )) as typeof fetch;
+  try {
+    await assert.rejects(
+      () => getResearchMissionFile("mission-1", "nope"),
+      /research artifact not found/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+```
+
+Match the error-message assertion to the client's existing error convention (view how `getResearchMission` throws — reuse the same helper).
+
+- [ ] **Step 6.7: Run to verify failure, implement, verify pass** — add to `src/lib/research-mission-client.ts`, mirroring `getResearchMission` (~lines 52–61) exactly (same fetch options, same response-unwrapping helper):
+
+```ts
+export type ResearchMissionFile = {
+  key: string;
+  kind: string;
+  title: string;
+  fileName: string;
+  relativePath: string;
+  content: string | null;
+  workspacePath: string;
+  updatedAt: string;
+};
+
+type ResearchMissionFileResponse = { ok: true; file: ResearchMissionFile };
+
+export async function getResearchMissionFile(
+  missionId: string,
+  artifactKey: string,
+  signal?: AbortSignal,
+): Promise<ResearchMissionFile> {
+  const response = await fetch(
+    `/api/research/missions/${encodeURIComponent(missionId)}/files/${encodeURIComponent(artifactKey)}`,
+    { cache: "no-store", signal },
+  );
+  const payload = await parseResponse<ResearchMissionFileResponse>(response);
+  return payload.file;
+}
+```
+
+(`parseResponse` = whatever unwrap helper the file's other functions use; keep the real name.)
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/research-mission-client.test.ts`
+Expected: PASS.
+
+- [ ] **Step 6.8: Commit**
+
+```bash
+git add "src/app/api/research/missions/[id]/files" src/lib/research-mission-client.ts src/lib/research-mission-client.test.ts scripts/run-tests.mjs
+git commit -S -m "feat(research): mission artifact file API and client accessor
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 7: Shared `ResearchArtifactActions` component + styles
+
+One client component rendering the per-artifact action row: **View** (modal), **Download**, **Grimoire** (when published), **Publish** (when offered). Reused by the Desk rail, evidence ledger, and Library.
+
+**Files:**
+- Create: `src/components/role-surfaces/research-artifact-actions.tsx`
+- Create: `src/components/role-surfaces/research-artifact-actions.test.ts` (source-scan)
+- Modify: `src/styles/globals/surface-research-desk.css` (append)
+- Modify: `scripts/run-tests.mjs` (app manifest, next to the other role-surface component tests ~line 53)
+
+- [ ] **Step 7.1: Write the failing source-scan test** — create `src/components/role-surfaces/research-artifact-actions.test.ts`:
+
+```ts
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(new URL("./research-artifact-actions.tsx", import.meta.url), "utf8");
+
+test("artifact actions is a client component with view, download, grimoire, publish", () => {
+  assert.match(source, /^"use client";/);
+  assert.match(source, /getResearchMissionFile/);
+  assert.match(source, /aria-label=\{`View \$\{artifact\.title\}`\}/);
+  assert.match(source, /aria-label=\{`Download \$\{artifact\.title\}`\}/);
+  assert.match(source, /openGrimoireDoc\("knowledge", artifact\.knowledgeId\)/);
+  assert.match(source, /artifact\.state === "working" && !artifact\.knowledgeId/);
+});
+
+test("viewer uses the ui Modal with focus management and honest empty copy", () => {
+  assert.match(source, /from "@\/components\/ui\/modal"/);
+  assert.match(source, /This file has not been written yet\./);
+  assert.match(source, /role="alert"/);
+  assert.match(source, /focus-ring/);
+});
+
+test("download builds a Blob and revokes the object URL", () => {
+  assert.match(source, /URL\.createObjectURL/);
+  assert.match(source, /URL\.revokeObjectURL/);
+});
+
+test("exports the workspace-path fetcher for the desk summary", () => {
+  assert.match(source, /export async function fetchResearchWorkspacePath/);
+});
+```
+
+Register in `scripts/run-tests.mjs` app manifest next to `"src/components/role-surfaces/research-evidence-ledger.test.ts"`:
+
+```js
+    "src/components/role-surfaces/research-artifact-actions.test.ts",
+```
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-artifact-actions.test.ts`
+Expected: FAIL (file missing).
+
+- [ ] **Step 7.2: Implement the component** — create `src/components/role-surfaces/research-artifact-actions.tsx`. Before writing, view `research-evidence-ledger.tsx` lines 1–40 for the exact import paths of `Modal`, `Icon`, `useAnnouncer`, `openGrimoireDoc`, and the `ResearchMission` types used in role surfaces, and reuse them:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { Modal } from "@/components/ui/modal";
+import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/lib/announcer";
+import { openGrimoireDoc } from "@/lib/grimoire-doc";
+import { getResearchMissionFile, type ResearchMissionFile } from "@/lib/research-mission-client";
+import type { ResearchArtifactRef, ResearchMission } from "@/lib/research-missions";
+
+type ResearchArtifactActionsProps = {
+  mission: ResearchMission;
+  artifact: ResearchArtifactRef;
+  busy?: boolean;
+  /** When provided and the ref is an unpublished working copy, renders the
+   *  Publish action. Surfaces that must not offer publishing omit it. */
+  onPublish?: (artifactKey: string) => void;
+};
+
+function downloadTextFile(fileName: string, content: string) {
+  const type = fileName.endsWith(".json") ? "application/json" : "text/markdown";
+  const url = URL.createObjectURL(new Blob([content], { type }));
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = fileName;
+  document.body.append(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Resolve the mission workspace path for "Copy workspace path" affordances. */
+export async function fetchResearchWorkspacePath(missionId: string): Promise<string | null> {
+  try {
+    const file = await getResearchMissionFile(missionId, "primary");
+    return file.workspacePath;
+  } catch {
+    return null;
+  }
+}
+
+export function ResearchArtifactActions({ mission, artifact, busy, onPublish }: ResearchArtifactActionsProps) {
+  const announce = useAnnouncer();
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [viewing, setViewing] = useState<ResearchMissionFile | null>(null);
+  const [viewerOpen, setViewerOpen] = useState(false);
+
+  const loadFile = async (): Promise<ResearchMissionFile | null> => {
+    setPending(true);
+    setError(null);
+    try {
+      return await getResearchMissionFile(mission.id, artifact.key);
+    } catch (cause) {
+      const message = cause instanceof Error ? cause.message : "Research file could not be read.";
+      setError(message);
+      announce(message);
+      return null;
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const view = async () => {
+    const file = await loadFile();
+    if (!file) return;
+    setViewing(file);
+    setViewerOpen(true);
+  };
+
+  const download = async () => {
+    const file = await loadFile();
+    if (!file) return;
+    if (file.content === null) {
+      const message = `${artifact.title} has not been written yet.`;
+      setError(message);
+      announce(message);
+      return;
+    }
+    downloadTextFile(file.fileName, file.content);
+    announce(`${artifact.title} downloaded.`);
+  };
+
+  const disabled = Boolean(busy) || pending;
+  const showPublish = Boolean(onPublish) && artifact.state === "working" && !artifact.knowledgeId;
+
+  return (
+    <>
+      <div className="research-desk-artifact__actions">
+        <button
+          type="button"
+          className="research-desk-artifact__open focus-ring"
+          onClick={view}
+          disabled={disabled}
+          aria-label={`View ${artifact.title}`}
+        >
+          <Icon name="ph:file-text" size={14} />
+          View
+        </button>
+        <button
+          type="button"
+          className="research-desk-artifact__open focus-ring"
+          onClick={download}
+          disabled={disabled}
+          aria-label={`Download ${artifact.title}`}
+        >
+          <Icon name="ph:download-simple" size={14} />
+          Download
+        </button>
+        {artifact.knowledgeId ? (
+          <button
+            type="button"
+            className="research-desk-artifact__open focus-ring"
+            onClick={() => openGrimoireDoc("knowledge", artifact.knowledgeId)}
+            aria-label={`Open ${artifact.title} in the Grimoire`}
+          >
+            <Icon name="ph:arrow-square-out" size={14} />
+            Grimoire
+          </button>
+        ) : null}
+        {showPublish ? (
+          <button
+            type="button"
+            className="research-desk-artifact__open focus-ring"
+            onClick={() => onPublish?.(artifact.key)}
+            disabled={disabled}
+            aria-label={`Publish ${artifact.title} to the Grimoire`}
+          >
+            <Icon name="ph:book-bookmark" size={14} />
+            Publish
+          </button>
+        ) : null}
+      </div>
+      {error ? (
+        <p role="alert" className="research-desk-artifact__error">{error}</p>
+      ) : null}
+      <Modal
+        open={viewerOpen}
+        onClose={() => setViewerOpen(false)}
+        breadcrumb={["Research", viewing?.fileName ?? artifact.title]}
+        ariaLabel={`${artifact.title} file contents`}
+        wide
+      >
+        {viewing?.content === null || viewing?.content === undefined ? (
+          <p className="research-artifact-viewer__empty">This file has not been written yet.</p>
+        ) : (
+          <pre className="research-artifact-viewer__content">{viewing.content}</pre>
+        )}
+      </Modal>
+    </>
+  );
+}
+```
+
+While implementing, verify against the real `Modal` props (`src/components/ui/modal.tsx`: `open`, `onClose`, `breadcrumb?: ReactNode[]`, `wide?`, `ariaLabel?` — it owns focus trapping and portalling internally) and the real announcer/grimoire import paths; adjust imports, not behavior. All four icons (`ph:file-text`, `ph:download-simple`, `ph:arrow-square-out`, `ph:book-bookmark`) are already in `ICON_NAMES` — no subset regeneration.
+
+- [ ] **Step 7.3: Append styles** — to `src/styles/globals/surface-research-desk.css` (tokens only; `.research-desk-artifact__open` already carries the shared chip look at lines 600–612):
+
+```css
+.research-desk-artifact__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  align-items: center;
+}
+
+.research-desk-artifact__error {
+  margin: 0;
+  font-size: var(--text-2xs);
+  color: var(--danger-text);
+}
+
+.research-artifact-viewer__content {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 60vh;
+  overflow: auto;
+  font-size: var(--text-2xs);
+}
+
+.research-artifact-viewer__empty {
+  margin: 0;
+  font-size: var(--text-2xs);
+  color: var(--text-tertiary);
+}
+```
+
+- [ ] **Step 7.4: Run to verify pass + gates**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-artifact-actions.test.ts
+pnpm typecheck
+pnpm lint
+```
+Expected: PASS / clean. (Typecheck is the real safety net for a source-scanned component.)
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/components/role-surfaces/research-artifact-actions.tsx src/components/role-surfaces/research-artifact-actions.test.ts src/styles/globals/surface-research-desk.css scripts/run-tests.mjs
+git commit -S -m "feat(research): shared artifact view/download/publish actions component
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 8: Desk integration — rail actions, saved summary, ledger actions
+
+**Files:**
+- Modify: `src/components/role-surfaces/research-mission-detail.tsx` (rail cards ~667–703, completed block ends ~464, `runMissionAction` 177–204)
+- Modify: `src/components/role-surfaces/research-evidence-ledger.tsx` (artifact cards ~144–189, `act()` 67–90)
+- Tests: `src/components/role-surfaces/research-tab-desk.test.ts` (source-scans the detail file via `new URL("./research-mission-detail.tsx", import.meta.url)`), `src/components/role-surfaces/research-evidence-ledger.test.ts` (both exist)
+
+- [ ] **Step 8.1: Write the failing source-scan assertions**
+
+Append to `research-tab-desk.test.ts` (reuse its existing detail-source variable name):
+
+```ts
+test("desk rail renders shared artifact actions with publish on settled missions", () => {
+  assert.match(detailSource, /ResearchArtifactActions/);
+  assert.match(detailSource, /onPublish=\{settled \? publishArtifact : undefined\}/);
+  assert.match(detailSource, /action: "publish-artifact"/);
+  assert.match(detailSource, /Artifact published to the Grimoire\./);
+});
+
+test("desk shows a saved-artifacts summary with a copy-workspace-path affordance", () => {
+  assert.match(detailSource, /fetchResearchWorkspacePath/);
+  assert.match(detailSource, /artifacts published to the Grimoire\./);
+  assert.match(detailSource, /working files saved in the mission workspace\./);
+  assert.match(detailSource, /Copy workspace path/);
+  assert.match(detailSource, /Workspace path copied/);
+});
+```
+
+Append to `research-evidence-ledger.test.ts` (it scans its own component source):
+
+```ts
+test("ledger artifact cards mount the shared actions with publish wiring", () => {
+  assert.match(source, /ResearchArtifactActions/);
+  assert.match(source, /action: "publish-artifact"/);
+  assert.match(source, /Artifact published to the Grimoire\./);
+});
+```
+
+Run both; expected: FAIL.
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-tab-desk.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-evidence-ledger.test.ts
+```
+
+- [ ] **Step 8.2: Implement in `research-mission-detail.tsx`**
+
+> **Review carry-over (Tasks 2–3):** the desk tile's `draftArtifact = artifacts.filter(state === "working").at(-1)` (~line 147) resolves to the appended `research-log` ref now that every mission carries 4 working refs. While in this file, change the selection to the working primary only — `mission.artifacts.find((a) => a.relativePath === "artifacts/primary.md" && a.state === "working")` — with NO fallback to standard refs: when the primary is rejected the tile must disappear, as it did before the standard refs existed.
+
+**(a)** Import the component: `import { ResearchArtifactActions, fetchResearchWorkspacePath } from "./research-artifact-actions";`
+
+**(b)** Near the existing action callbacks (after `runMissionAction`, ~line 204), add:
+
+```tsx
+  const settled = ["checkpoint", "completed", "failed"].includes(mission.status);
+  const publishArtifact = (artifactKey: string) => {
+    void runMissionAction(
+      "Artifact could not be published",
+      () => onAction({ action: "publish-artifact", artifactKey }),
+      () => announce("Artifact published to the Grimoire."),
+    );
+  };
+```
+
+(Match `runMissionAction`'s real signature — view lines 177–204 first; if it takes `(errorLabel, action, onSuccess)` in a different order or shape, adapt the call, not the helper.)
+
+**(c)** In the artifact rail cards (~667–703), replace the lone Grimoire-open button block with:
+
+```tsx
+              <ResearchArtifactActions
+                mission={mission}
+                artifact={artifact}
+                busy={busy}
+                onPublish={settled ? publishArtifact : undefined}
+              />
+```
+
+Keep the surrounding card markup (title, state chip, iteration) untouched.
+
+**(d)** Saved summary — insert a section directly after the completed Findings block (ends ~line 464), rendered when `mission.status === "completed" || mission.status === "checkpoint"`:
+
+```tsx
+        {mission.status === "completed" || mission.status === "checkpoint" ? (
+          <section className="research-desk-section">
+            <p className="research-desk-section__kicker">Saved</p>
+            <p className="research-desk-section__line">
+              {mission.status === "completed"
+                ? `${mission.artifacts.filter((artifact) => artifact.knowledgeId).length} of ${mission.artifacts.filter((artifact) => artifact.state !== "rejected").length} artifacts published to the Grimoire.`
+                : `${mission.artifacts.filter((artifact) => artifact.state === "working").length} working files saved in the mission workspace.`}
+            </p>
+            <button
+              type="button"
+              className="research-desk-artifact__open focus-ring"
+              onClick={copyWorkspacePath}
+              aria-label="Copy the mission workspace path"
+            >
+              <Icon name="ph:copy" size={14} />
+              {workspaceCopied ? "Workspace path copied" : "Copy workspace path"}
+            </button>
+          </section>
+        ) : null}
+```
+
+with state + handler near the other component state:
+
+```tsx
+  const [workspaceCopied, setWorkspaceCopied] = useState(false);
+  const copyWorkspacePath = async () => {
+    const workspacePath = await fetchResearchWorkspacePath(mission.id);
+    if (!workspacePath) {
+      announce("Workspace path could not be resolved.");
+      return;
+    }
+    await navigator.clipboard.writeText(workspacePath);
+    setWorkspaceCopied(true);
+    announce("Workspace path copied.");
+    setTimeout(() => setWorkspaceCopied(false), 2000);
+  };
+```
+
+Reuse the section/kicker class names actually present in the completed Findings block you're inserting after (view ~430–464 and copy its exact classes; the names above are indicative). `ph:copy` is already in `ICON_NAMES`.
+
+- [ ] **Step 8.3: Implement in `research-evidence-ledger.tsx`** — import `ResearchArtifactActions`, then inside the artifact card (~153–161, after the state/meta line) add:
+
+```tsx
+            <ResearchArtifactActions
+              mission={mission}
+              artifact={artifact}
+              busy={busy}
+              onPublish={async (artifactKey) => {
+                const ok = await act({ action: "publish-artifact", artifactKey });
+                if (ok) announce("Artifact published to the Grimoire.");
+              }}
+            />
+```
+
+The ledger's local `act()` (lines 67–90) already returns `Promise<boolean>` and handles error surfacing. Match the card's real local variable names (`mission`, `artifact`, `busy`) while editing. This is the checkpoint surface — the desk rail is hidden at checkpoint (`showArtifactRail = !isCheckpointLike && !isLive`), so the ledger must offer the full action set.
+
+- [ ] **Step 8.4: Run to verify pass + gates**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-tab-desk.test.ts
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-evidence-ledger.test.ts
+pnpm typecheck
+```
+Expected: PASS / clean.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/components/role-surfaces/research-mission-detail.tsx src/components/role-surfaces/research-evidence-ledger.tsx src/components/role-surfaces/research-tab-desk.test.ts src/components/role-surfaces/research-evidence-ledger.test.ts
+git commit -S -m "feat(research): desk and ledger artifact actions with saved summary
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 9: Library integration
+
+Unpublished artifacts on Library mission cards get View/Download (no Publish — the Library stays a browsing surface); published ones keep their existing Grimoire open button. Also fix the stale header comment claiming artifacts have no real file bytes.
+
+**Files:**
+- Modify: `src/components/role-surfaces/research-tab-library.tsx` (card actions ~416–434, header comment ~line 16)
+- Test: `src/components/role-surfaces/research-tab-library.test.ts` (exists)
+
+- [ ] **Step 9.1: Write the failing source-scan assertions** — append to `research-tab-library.test.ts`:
+
+```ts
+test("library offers view/download for unpublished artifacts without publish", () => {
+  assert.match(source, /ResearchArtifactActions/);
+  assert.doesNotMatch(source, /onPublish=/, "library never offers publishing");
+});
+```
+
+Run: `node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-tab-library.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 9.2: Implement** — in `research-tab-library.tsx`:
+
+**(a)** Import: `import { ResearchArtifactActions } from "./research-artifact-actions";`
+
+**(b)** In the card actions block (~416–434), where unpublished artifacts currently render nothing (or a disabled hint), render for each artifact without `knowledgeId`:
+
+```tsx
+                <ResearchArtifactActions mission={mission} artifact={artifact} />
+```
+
+keeping the existing published-artifact Open `Button` untouched. Match the real loop variable names at the site.
+
+**(c)** Update the stale header comment (~line 16) that says artifacts expose no real file bytes — replace that sentence with: `Artifacts are backed by real mission workspace files served via /api/research/missions/[id]/files/[key].`
+
+- [ ] **Step 9.3: Run to verify pass**
+
+```bash
+node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/role-surfaces/research-tab-library.test.ts
+pnpm typecheck
+```
+Expected: PASS / clean.
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add src/components/role-surfaces/research-tab-library.tsx src/components/role-surfaces/research-tab-library.test.ts
+git commit -S -m "feat(research): library view/download for unpublished artifacts
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+```
+
+---
+
+### Task 10: Full gates + PR
+
+- [ ] **Step 10.1: Run every gate**
+
+```bash
+pnpm typecheck
+pnpm lint
+node scripts/run-tests.mjs app
+node scripts/run-tests.mjs api
+node scripts/run-tests.mjs server 2>/dev/null || true
+```
+
+(Check `scripts/run-tests.mjs` for the actual suite name covering `src/lib/server/**` — it may be part of `app` or its own suite; run whichever suite contains the runner/store/lifecycle test files.)
+
+Expected: all green. Fix regressions before proceeding — common suspects are listed in Steps 3.8, 4.4, and 5.5.
+
+- [ ] **Step 10.2: Push and open the PR**
+
+```bash
+git push origin research-final-artifacts
+gh pr create --base main --head research-final-artifacts \
+  --title "Research Desk: produce and save final research artifacts" \
+  --body "$(cat <<'BODY'
+## Summary
+- Every research mission now tracks all four final artifacts (primary deliverable, findings, source ledger, research log) as first-class refs, backfilled for legacy missions at load time.
+- Agent `complete` decisions and the user `finish` action publish every non-rejected artifact to the Grimoire Vault with per-artifact failure isolation; failures land in `lastError` and are retryable via the new `publish-artifact` action.
+- `sources.json` publishes as a rendered markdown source ledger.
+- New read-only files API + shared `ResearchArtifactActions` component give View / Download / Grimoire / Publish across the Desk rail, evidence ledger, and Library, plus a saved-artifacts summary with copy-workspace-path.
+
+Spec: `docs/specs/2026-07-24-research-final-artifacts-design.md`
+Plan: `docs/superpowers/plans/2026-07-24-research-final-artifacts.md`
+
+## Testing
+- `pnpm typecheck`, `pnpm lint`
+- `node scripts/run-tests.mjs app`, `node scripts/run-tests.mjs api` (new: contract ledger rendering, ref backfill, multi-publish reconciliation, publish-artifact/finish lifecycle, files route, component/desk/ledger/library source scans)
+BODY
+)"
+```
+
+Wait for the required checks (`Frontend build`, `Rust check`, `CodeQL`, `E2E (Playwright)`), then squash-merge and clean up the worktree per repo convention.
+
+

--- a/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
+++ b/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
@@ -1,0 +1,684 @@
+# Sidepanel Peel-Reveal Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the desktop nav is collapsed to its 56px rail, moving the cursor toward the left edge of the detail pane peels the page back (WebGL page-curl) revealing the sidebar beneath — on HTML-in-canvas browsers only; everywhere else stays byte-identical.
+
+**Architecture:** Vendor the Canvas UI `Peel` registry component (exact Blaze precedent: transient shadcn scaffolding, provenance header, design-codemod pass). A new `ShellPeelReveal` wrapper gates on a local HTML-in-canvas probe + `usePrefersReducedMotion`; non-enhanced browsers render a `display: contents` pass-through, enhanced browsers keep `<Peel>` permanently mounted and toggle its geometry options (`reveal`/`zone` → 0) on `active` so the detail tree never re-parents. `shell.tsx` wraps the detail children with `active={navPeekEnabled} under={nav}`; the existing interactive frosted hover-peek is untouched.
+
+**Tech Stack:** Next.js 15 / React 19.2.7 (`inert` boolean prop), vendored zero-dep React+WebGL2 file, repo node source-contract tests (`scripts/run-tests.mjs`), design gates (`pnpm lint`, `pnpm codemod:design`).
+
+**Spec:** `docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md` (local-only; `/docs/superpowers` is gitignored). **Bead:** cave-3vgd. **Worktree:** `.worktrees/peel-sidepanel-reveal` (branch `peel-sidepanel-reveal`). All commands below run from the worktree root unless stated. Push after every commit (worktree-guard discipline). Commits are signed via the global git config; per `AGENTS.md`, do not add trailers crediting AI tools.
+
+---
+
+## File Structure
+
+- **Create** `src/components/canvasui/Peel.tsx` — vendored registry payload + provenance header + codemod pass. Never hand-edited otherwise.
+- **Create** `src/components/shell-peel-reveal.tsx` — the only file that knows about probing, reduced motion, option-zeroing, and context-loss recovery.
+- **Create** `src/components/sidepanel-peel-reveal.test.ts` — source-contract test for CSS + wrapper + vendored file + shell wiring.
+- **Modify** `src/styles/globals/shell-navigation.css` — one new block after the existing peek styles (~line 146).
+- **Modify** `src/components/shell.tsx:880-895` — wrap the detail children.
+- **Modify** `scripts/run-tests.mjs` (~line 408) — wire the new test into the `app` suite.
+
+---
+
+### Task 1: Vendor `Peel.tsx`
+
+**Files:**
+- Create: `src/components/canvasui/Peel.tsx`
+- Transient (never committed): `components.json`
+
+- [ ] **Step 1: Confirm clean worktree state**
+
+Run: `git status --porcelain`
+Expected: empty (only the untracked gitignored `docs/superpowers/` spec may appear under `git status --ignored`; that is fine).
+
+- [ ] **Step 2: Write the transient shadcn config**
+
+Create `components.json` at the worktree root (the registry item pins its own target `components/canvasui/Peel.tsx`; the aliases only let the CLI resolve `src/`):
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "new-york",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "neutral",
+    "cssVariables": true
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib",
+    "ui": "@/components/ui"
+  }
+}
+```
+
+- [ ] **Step 3: Install the registry component**
+
+Run: `npx -y shadcn@latest add @canvas-ui/peel-react --yes`
+Expected output ends with:
+
+```text
+✔ Created 1 file:
+  - src/components/canvasui/Peel.tsx
+```
+
+- [ ] **Step 4: Delete the transient config**
+
+Run: `rm components.json && git status --porcelain`
+Expected: only `?? src/components/canvasui/Peel.tsx`.
+
+- [ ] **Step 5: Add the provenance header**
+
+Prepend to `src/components/canvasui/Peel.tsx`, above the existing `"use client";` line (mirrors `Blaze.tsx`):
+
+```tsx
+// Vendored from Canvas UI — https://canvasui.dev/docs/components/peel
+// Registry: https://canvasui.dev/r/peel-react.json (item "peel-react", shadcn
+// namespace @canvas-ui/peel-react), fetched 2026-07-24.
+// License: MIT + Commons Clause v1.0, Copyright (c) 2026 David Haz —
+// https://github.com/DavidHDev/canvas-ui/blob/main/LICENSE.md (permits use in
+// applications/products; forbids selling or redistributing the components themselves).
+// Zero runtime dependencies. Local delta: static JSX styles rewritten by
+// scripts/codemods/tokenize-tsx-design.mjs (design gate) — re-run it after re-vendoring.
+```
+
+- [ ] **Step 6: Run the design auto-fixer**
+
+Run: `pnpm codemod:design`
+Expected: it reports rewriting `src/components/canvasui/Peel.tsx` (4 static JSX style objects — under layer, native content wrapper, fallback content wrapper, output canvas — become arbitrary-property utility classes, the same shape as `Blaze.tsx`'s `[position:relative]! [width:100%]!…`). No other files change.
+
+- [ ] **Step 7: Verify the design gates pass**
+
+Run: `pnpm lint`
+Expected: `codemod:design:check` reports no drift; ESLint reports 0 problems. (Before the codemod this file failed with 4 × `coven-design/no-static-inline-style` — verified against the raw payload.)
+
+- [ ] **Step 8: Commit and push**
+
+```bash
+git add src/components/canvasui/Peel.tsx
+git commit -m "feat(shell): vendor Canvas UI Peel registry component (cave-3vgd)
+
+Exact @canvas-ui/peel-react payload plus provenance header and the repo
+design codemod pass (static JSX styles -> utility classes), matching the
+Blaze vendoring precedent. Transient components.json used for the shadcn
+CLI install and deleted; no scaffolding or dependencies adopted."
+git push -u origin peel-sidepanel-reveal
+```
+
+---
+
+### Task 2: CSS contract (test-first)
+
+**Files:**
+- Create: `src/components/sidepanel-peel-reveal.test.ts`
+- Modify: `src/styles/globals/shell-navigation.css` (insert after the `@keyframes shellNavPeekIn` block that closes at line 146)
+
+- [ ] **Step 1: Write the failing CSS contract test**
+
+Create `src/components/sidepanel-peel-reveal.test.ts`:
+
+```ts
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const css = readFileSync(
+  new URL("../styles/globals/shell-navigation.css", import.meta.url),
+  "utf8",
+);
+
+// Plain mode (no HTML-in-canvas, or reduced motion) must be layout-invisible.
+assert.match(
+  css,
+  /\.shell-peel-reveal--plain,\s*\.shell-peel-reveal--plain > \.shell-peel-scroll \{\s*display: contents;/,
+  "plain peel wrappers are display: contents",
+);
+
+// Live mode reproduces .shell-detail's scroll contract (the vendored content
+// wrapper is overflow: hidden, so scrolling moves inside the sheet).
+assert.match(
+  css,
+  /\.shell-peel-reveal--live \{[\s\S]*?flex: 1;[\s\S]*?min-height: 0;[\s\S]*?position: relative;/,
+  "live peel wrapper is a positioned flex child",
+);
+assert.match(
+  css,
+  /\.shell-peel-reveal--live \.shell-peel-scroll \{[\s\S]*?height: 100%;[\s\S]*?overflow-y: auto;[\s\S]*?flex-direction: column;/,
+  "live peel scroll host reproduces the detail scroll contract",
+);
+
+// The revealed under-layer backing uses tokens and matches the 232px peek.
+assert.match(
+  css,
+  /\.shell-peel-under \{[\s\S]*?width: 232px;[\s\S]*?background: var\(--bg-raised\);[\s\S]*?border-right: 1px solid var\(--border-hairline\);/,
+  "under layer is an opaque token-backed 232px sheet",
+);
+
+console.log("sidepanel-peel-reveal.test.ts: ok");
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: FAIL — `AssertionError` "plain peel wrappers are display: contents".
+
+- [ ] **Step 3: Add the CSS block**
+
+In `src/styles/globals/shell-navigation.css`, directly after the `@keyframes shellNavPeekIn { … }` block (line 146), insert:
+
+```css
+/* Peel-reveal (cave-3vgd): progressive-enhancement page-curl around the
+   detail pane, revealing the sidebar when the collapsed rail is armed.
+   Plain mode (every browser without experimental HTML-in-canvas, and any
+   reduced-motion user) is layout-invisible via display: contents. Live mode
+   becomes the box the vendored Peel canvases fill; .shell-peel-scroll
+   reproduces .shell-detail's scroll contract because the vendor's content
+   wrapper is overflow: hidden. The under sheet is opaque (--bg-raised) and
+   232px wide to hand off seamlessly into the .shell-nav--peek overlay. */
+.shell-peel-reveal--plain,
+.shell-peel-reveal--plain > .shell-peel-scroll {
+  display: contents;
+}
+.shell-peel-reveal--live {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+}
+.shell-peel-reveal--live .shell-peel-fill {
+  height: 100%;
+}
+.shell-peel-reveal--live .shell-peel-scroll {
+  height: 100%;
+  min-height: 0;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+.shell-peel-under {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 232px;
+  background: var(--bg-raised);
+  border-right: 1px solid var(--border-hairline);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: `sidepanel-peel-reveal.test.ts: ok`
+
+- [ ] **Step 5: Verify the CSS codemod stays a no-op**
+
+Run: `node scripts/codemods/tokenize-css.mjs --check 2>/dev/null || node scripts/codemods/tokenize-css.mjs`
+Expected: no rewrite of `shell-navigation.css` (232px is intentionally off-scale — it matches the existing peek overlay width literal at line 132, which the codemod already tolerates; if the check flags it, mirror however line 132's `width: 232px` is annotated).
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add src/components/sidepanel-peel-reveal.test.ts src/styles/globals/shell-navigation.css
+git commit -m "feat(shell): peel-reveal CSS contract (cave-3vgd)"
+git push
+```
+
+---
+
+### Task 3: `ShellPeelReveal` wrapper (test-first)
+
+**Files:**
+- Modify: `src/components/sidepanel-peel-reveal.test.ts` (append)
+- Create: `src/components/shell-peel-reveal.tsx`
+
+- [ ] **Step 1: Extend the contract test (failing)**
+
+Append to `src/components/sidepanel-peel-reveal.test.ts`, above the final `console.log` line:
+
+```ts
+const wrapper = readFileSync(
+  new URL("./shell-peel-reveal.tsx", import.meta.url),
+  "utf8",
+);
+const vendored = readFileSync(
+  new URL("./canvasui/Peel.tsx", import.meta.url),
+  "utf8",
+);
+
+// The ~22 KB vendored WebGL file loads lazily and never renders on the server.
+assert.match(
+  wrapper,
+  /const Peel = dynamic\(\(\) => import\("@\/components\/canvasui\/Peel"\), \{ ssr: false \}\)/,
+  "vendored Peel is dynamically imported with ssr: false",
+);
+
+// Enhancement gates: local capability probe (false on the server) + reduced motion.
+assert.match(
+  wrapper,
+  /useSyncExternalStore\(emptySubscribe, probeHtmlInCanvas, \(\) => false\)/,
+  "capability probe returns false as the server snapshot",
+);
+assert.match(
+  wrapper,
+  /const enhanced = supported && !reducedMotion;/,
+  "reduced motion disables the enhancement entirely",
+);
+
+// Permanent mount: `active` swaps geometry options, never mounts/unmounts Peel,
+// so toggling the nav can't re-parent (and remount) the detail tree.
+assert.match(
+  wrapper,
+  /OFF_OPTIONS = \{ reveal: 0, zone: 0 \}/,
+  "inactive geometry collapses to zero via options",
+);
+assert.match(
+  wrapper,
+  /\{\.\.\.\(active \? LIVE_OPTIONS : OFF_OPTIONS\)\}/,
+  "active drives options, not mounting",
+);
+
+// The revealed sidebar clone is decorative: hidden from AT and uninteractive.
+assert.match(
+  wrapper,
+  /<div className="shell-peel-under" aria-hidden inert>/,
+  "under layer is aria-hidden and inert",
+);
+
+// WebGL context loss re-mounts the vendored component, capped (cave-kbh1).
+assert.match(wrapper, /key=\{glEpoch\}/, "epoch key re-mounts on context loss");
+assert.match(
+  wrapper,
+  /MAX_CONTEXT_RESTARTS = 3/,
+  "context-loss restarts are capped",
+);
+
+// Plain path renders the stable display:contents wrappers.
+assert.match(
+  wrapper,
+  /className="shell-peel-reveal shell-peel-reveal--plain"/,
+  "plain path renders the contents wrapper",
+);
+
+// Vendored file keeps its provenance and stays the module the wrapper imports.
+assert.match(
+  vendored,
+  /Vendored from Canvas UI — https:\/\/canvasui\.dev\/docs\/components\/peel/,
+  "vendored Peel carries the provenance header",
+);
+assert.match(vendored, /peel-react\.json/, "provenance cites the registry item");
+assert.match(vendored, /export default Peel;/, "vendored Peel default-exports");
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: FAIL — `ENOENT … shell-peel-reveal.tsx`.
+
+- [ ] **Step 3: Create the wrapper**
+
+Create `src/components/shell-peel-reveal.tsx`:
+
+```tsx
+"use client";
+
+import dynamic from "next/dynamic";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+
+// The ~22 KB vendored WebGL file loads only on HTML-in-canvas browsers.
+const Peel = dynamic(() => import("@/components/canvasui/Peel"), { ssr: false });
+
+/** Peel geometry while the collapsed rail arms the reveal: 232px of exposed
+ *  under-layer matches the hover-peek overlay width; a 120px trigger strip
+ *  (vs the vendor's 200 default) keeps casual mouse travel from curling. */
+const LIVE_OPTIONS = { reveal: 232, zone: 120 } as const;
+/** Nav open: geometry collapses to nothing via the vendor's live setOptions.
+ *  The component stays mounted so toggling ⌘B never re-parents (and thereby
+ *  remounts) the detail tree. */
+const OFF_OPTIONS = { reveal: 0, zone: 0 } as const;
+
+/** How many times a lost WebGL context earns a fresh mount before giving up —
+ *  a crashing GPU/driver loop should not thrash remounts forever (mirrors
+ *  cave-backdrop-blaze.tsx, cave-kbh1). */
+const MAX_CONTEXT_RESTARTS = 3;
+
+type ProbeCanvas = HTMLCanvasElement & { requestPaint?: () => void };
+type ProbeContext = CanvasRenderingContext2D & {
+  drawElementImage?: (element: Element, x: number, y: number) => void;
+};
+
+let htmlInCanvasProbe: boolean | null = null;
+/** Local copy of the vendored supportsHtmlInCanvas() so the probe never pulls
+ *  the 22 KB module into the bundle. Cached: capability is static per env. */
+function probeHtmlInCanvas(): boolean {
+  if (htmlInCanvasProbe !== null) return htmlInCanvasProbe;
+  if (typeof document === "undefined") return false;
+  const canvas = document.createElement("canvas") as ProbeCanvas;
+  const ctx = canvas.getContext("2d") as ProbeContext | null;
+  htmlInCanvasProbe = Boolean(
+    ctx &&
+      typeof ctx.drawElementImage === "function" &&
+      typeof canvas.requestPaint === "function",
+  );
+  return htmlInCanvasProbe;
+}
+
+const emptySubscribe = () => () => {};
+
+/**
+ * Progressive peel-reveal around the shell's detail children (cave-3vgd).
+ * When the desktop nav is collapsed to its rail (`active`), browsers with the
+ * experimental HTML-in-canvas API peel the page back from the left edge as
+ * the cursor approaches, revealing the sidebar (`under`) beneath — a
+ * decorative tease that hands off to the interactive .shell-nav--peek
+ * overlay. Everywhere else (Tauri WKWebView, Safari, Firefox, stock Chrome,
+ * reduced-motion users) this renders display:contents wrappers: zero layout
+ * impact, zero GPU or network cost, and the children are never re-parented
+ * by `active` changes within a mode.
+ */
+export function ShellPeelReveal({
+  active,
+  under,
+  children,
+}: {
+  active: boolean;
+  under: ReactNode;
+  children: ReactNode;
+}) {
+  const supported = useSyncExternalStore(emptySubscribe, probeHtmlInCanvas, () => false);
+  const reducedMotion = usePrefersReducedMotion();
+  const enhanced = supported && !reducedMotion;
+
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const [glEpoch, setGlEpoch] = useState(0);
+
+  // webglcontextlost fires on the vendor's output canvas and does not bubble,
+  // but a capture-phase listener on the wrapper still sees it.
+  useEffect(() => {
+    if (!enhanced) return;
+    const node = wrapRef.current;
+    if (!node) return;
+    const onContextLost = () => {
+      setGlEpoch((epoch) => (epoch < MAX_CONTEXT_RESTARTS ? epoch + 1 : epoch));
+    };
+    node.addEventListener("webglcontextlost", onContextLost, true);
+    return () => node.removeEventListener("webglcontextlost", onContextLost, true);
+  }, [enhanced]);
+
+  if (!enhanced) {
+    return (
+      <div className="shell-peel-reveal shell-peel-reveal--plain">
+        <div className="shell-peel-scroll">{children}</div>
+      </div>
+    );
+  }
+  return (
+    <div ref={wrapRef} className="shell-peel-reveal shell-peel-reveal--live">
+      <Peel
+        key={glEpoch}
+        className="shell-peel-fill"
+        side="left"
+        mode="cursor"
+        under={
+          active ? (
+            <div className="shell-peel-under" aria-hidden inert>
+              {under}
+            </div>
+          ) : undefined
+        }
+        {...(active ? LIVE_OPTIONS : OFF_OPTIONS)}
+      >
+        <div className="shell-peel-scroll">{children}</div>
+      </Peel>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the contract test to verify it passes**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: `sidepanel-peel-reveal.test.ts: ok`
+
+- [ ] **Step 5: Run the design gates**
+
+Run: `pnpm lint`
+Expected: pass (no inline styles, no raw px text — the 232/120 are numeric props, not px literals).
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add src/components/shell-peel-reveal.tsx src/components/sidepanel-peel-reveal.test.ts
+git commit -m "feat(shell): ShellPeelReveal progressive-enhancement wrapper (cave-3vgd)"
+git push
+```
+
+---
+
+### Task 4: Shell wiring (test-first)
+
+**Files:**
+- Modify: `src/components/sidepanel-peel-reveal.test.ts` (append)
+- Modify: `src/components/shell.tsx:880-895` (+ one import)
+
+- [ ] **Step 1: Extend the contract test (failing)**
+
+Append above the final `console.log` line:
+
+```ts
+const shell = readFileSync(new URL("./shell.tsx", import.meta.url), "utf8");
+
+// The peel arms exactly when the interactive hover-peek is armed, and the
+// under layer is the same nav node the sidebar aside renders.
+assert.match(
+  shell,
+  /<ShellPeelReveal active=\{navPeekEnabled\} under=\{nav\}>/,
+  "shell arms the peel with navPeekEnabled and feeds it the nav",
+);
+assert.match(
+  shell,
+  /import \{ ShellPeelReveal \} from "@\/components\/shell-peel-reveal";/,
+  "shell imports the wrapper",
+);
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: FAIL — "shell arms the peel with navPeekEnabled and feeds it the nav".
+
+- [ ] **Step 3: Wire the shell**
+
+In `src/components/shell.tsx`, add the import alongside the other `@/components/...` imports near the top of the file:
+
+```tsx
+import { ShellPeelReveal } from "@/components/shell-peel-reveal";
+```
+
+Then wrap the detail children (currently lines 880–895). Before:
+
+```tsx
+        <main className="shell-detail" id="shell-main-content" tabIndex={-1} ref={detailElRef}>
+          <UpdateBannerTrigger />
+          <OpenCovenToolsBannerTrigger />
+          <CaveHomeMigrationBannerTrigger />
+          <ShellBannerStrip />
+          <DetailSplitHost
+            primary={detail}
+            secondaryTiles={splitTiles}
+            secondarySide={splitSide}
+            onClose={() => onCloseSplit?.()}
+            onCloseTile={(id) => onCloseSplitTile?.(id)}
+            onPromoteTile={(id) => onPromoteSplitTile?.(id)}
+            onDropPage={(mode, side) => onDropSplitPage?.(mode, side)}
+            enableDrop={!isMobile}
+          />
+        </main>
+```
+
+After:
+
+```tsx
+        <main className="shell-detail" id="shell-main-content" tabIndex={-1} ref={detailElRef}>
+          {/* Peel-reveal (cave-3vgd): decorative page-curl toward the collapsed
+              rail on HTML-in-canvas browsers; display:contents pass-through
+              everywhere else. The interactive reveal remains the hover-peek. */}
+          <ShellPeelReveal active={navPeekEnabled} under={nav}>
+            <UpdateBannerTrigger />
+            <OpenCovenToolsBannerTrigger />
+            <CaveHomeMigrationBannerTrigger />
+            <ShellBannerStrip />
+            <DetailSplitHost
+              primary={detail}
+              secondaryTiles={splitTiles}
+              secondarySide={splitSide}
+              onClose={() => onCloseSplit?.()}
+              onCloseTile={(id) => onCloseSplitTile?.(id)}
+              onPromoteTile={(id) => onPromoteSplitTile?.(id)}
+              onDropPage={(mode, side) => onDropSplitPage?.(mode, side)}
+              enableDrop={!isMobile}
+            />
+          </ShellPeelReveal>
+        </main>
+```
+
+(There is exactly one `navPeekEnabled` in scope — the existing derivation at line 388: `navPolicy === "remembered" && !isMobile && !navOpen`. Do not touch the peek state, handlers, or classes.)
+
+- [ ] **Step 4: Run the contract test to verify it passes**
+
+Run: `node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-peel-reveal.test.ts`
+Expected: `sidepanel-peel-reveal.test.ts: ok`
+
+- [ ] **Step 5: Verify the neighboring shell contracts still hold**
+
+Run:
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/sidepanel-nav-peek.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/shell-left-panels-fit.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/shell-edge-rails.test.ts
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/shell-nav-memory.test.ts
+```
+
+Expected: each prints `…: ok`. If one asserts on the exact `<main className="shell-detail">…` children shape, read its assertion and adjust only that regex expectation — the peek/nav behavior itself must not change.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add src/components/shell.tsx src/components/sidepanel-peel-reveal.test.ts
+git commit -m "feat(shell): peel detail pane toward the collapsed rail on hover (cave-3vgd)"
+git push
+```
+
+---
+
+### Task 5: Wire into CI suites and run the full gates
+
+**Files:**
+- Modify: `scripts/run-tests.mjs` (~line 408)
+
+- [ ] **Step 1: Register the test in the app suite**
+
+In `scripts/run-tests.mjs`, directly after the line `"src/components/sidepanel-nav-peek.test.ts",` (~line 408), add:
+
+```js
+    "src/components/sidepanel-peel-reveal.test.ts",
+```
+
+- [ ] **Step 2: Verify the wiring guard**
+
+Run: `pnpm check:tests-wired`
+Expected: pass (an unlisted `*.test.ts` fails this in CI).
+
+- [ ] **Step 3: Full design + lint gate**
+
+Run: `pnpm lint`
+Expected: pass.
+
+- [ ] **Step 4: App test suite (includes the drift ratchet)**
+
+Run: `node scripts/run-tests.mjs app`
+Expected: all tests pass, including `src/lib/design-token-drift.test.ts` (the new CSS block is token-only apart from the peek-matching 232px) and the new contract test.
+
+- [ ] **Step 5: Production build + bundle budget**
+
+Run: `pnpm build && pnpm test:bundle`
+Expected: build succeeds (React 19 accepts the `inert` boolean; the dynamic import splits the vendored file into a lazy chunk) and the bundle budget passes — the main bundle gains only the small wrapper; the 22 KB Peel chunk is lazy and never fetched on non-enhanced browsers.
+
+- [ ] **Step 6: Commit and push**
+
+```bash
+git add scripts/run-tests.mjs
+git commit -m "test(shell): wire sidepanel-peel-reveal contract into the app suite (cave-3vgd)"
+git push
+```
+
+---
+
+### Task 6: Manual native-path QA (optional), PR, merge, cleanup
+
+- [ ] **Step 1 (optional, needs a flag-enabled Chromium): native path smoke**
+
+```bash
+pnpm dev  # note the port
+# In a Chromium build with experimental web platform features enabled:
+#   open http://127.0.0.1:<port>, collapse the nav (⌘B) on a desktop viewport
+```
+
+Verify: cursor approaching the detail pane's left edge curls the page revealing the sidebar beneath; reaching the rail floats the frosted peek over it continuously; opening the nav shows zero residual curl (`reveal/zone` 0); theme swap re-tints the shine; reduced-motion (OS setting) drops the effect entirely. If option-zeroing leaks visually, the spec's named fallback is hiding the output canvas via a `.shell-peel-reveal--live[data-peel-off]` class — implement only if observed.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create --base main --head peel-sidepanel-reveal \
+  --title "Shell: peel-reveal the sidebar when the collapsed rail is hovered (cave-3vgd)" \
+  --body "$(cat <<'EOF'
+## Summary
+Progressive enhancement: with the desktop nav collapsed to its 56px rail, moving the cursor toward the detail pane's left edge peels the page back (Canvas UI Peel, WebGL page-curl) revealing the sidebar beneath, handing off into the existing interactive frosted hover-peek. Renders only on browsers with Chromium's experimental HTML-in-canvas API; everywhere else — Tauri WKWebView, Safari, Firefox, stock Chrome, and all reduced-motion users — the DOM is a display:contents pass-through with zero layout/GPU/network cost.
+
+- Vendors `@canvas-ui/peel-react` (exact registry payload + provenance header + design-codemod pass; transient `components.json`, no scaffolding adopted — Blaze precedent)
+- `ShellPeelReveal` keeps `<Peel>` permanently mounted when enhanced and zeroes `reveal`/`zone` while the nav is open, so ⌘B never re-parents the detail tree; WebGL context loss re-mounts with a capped epoch (cave-kbh1 pattern)
+- Revealed under-layer is `aria-hidden` + `inert` (decorative); the hover-peek remains the only interactive reveal
+- Contract test `sidepanel-peel-reveal.test.ts` wired into the app suite
+
+Design spec (local, gitignored path): docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md
+Bead: cave-3vgd
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for required checks**
+
+Run: `gh pr checks --watch`
+Expected: `Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment required`, `Sidecar runtime required`, `CodeQL` all pass (E2E runs headless Chromium without the experimental flag → plain path, unaffected).
+
+- [ ] **Step 4: Squash-merge with an explicit message**
+
+```bash
+gh pr merge --squash --delete-branch \
+  --subject "Shell: peel-reveal the sidebar when the collapsed rail is hovered (cave-3vgd) (#<PR>)" \
+  --body "Vendored Canvas UI Peel as a progressive enhancement around the detail pane: HTML-in-canvas browsers curl the page toward the collapsed rail revealing the sidebar; all other environments render a display:contents pass-through. Interactive reveal remains the frosted hover-peek."
+```
+
+- [ ] **Step 5: Local cleanup + bead close**
+
+```bash
+cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+git worktree remove .worktrees/peel-sidepanel-reveal
+git branch -D peel-sidepanel-reveal
+git worktree list
+bd update cave-3vgd --notes "Merged via PR #<PR> (squash). Verification: contract test in app suite, pnpm lint, build+bundle, required checks green. Native path manually smoke-tested where a flag-enabled Chromium was available."
+bd close cave-3vgd
+```
+
+(The worktree guard allows removal once the branch is clean and pushed/merged; if it blocks, resolve the cited state rather than bypassing.)

--- a/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
+++ b/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
@@ -8,7 +8,7 @@
 
 **Tech Stack:** Next.js 15 / React 19.2.7 (`inert` boolean prop), vendored zero-dep React+WebGL2 file, repo node source-contract tests (`scripts/run-tests.mjs`), design gates (`pnpm lint`, `pnpm codemod:design`).
 
-**Spec:** `docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md` (local-only; `/docs/superpowers` is gitignored). **Bead:** cave-3vgd. **Worktree:** `.worktrees/peel-sidepanel-reveal` (branch `peel-sidepanel-reveal`). All commands below run from the worktree root unless stated. Push after every commit (worktree-guard discipline). Commits are signed via the global git config; per `AGENTS.md`, do not add trailers crediting AI tools.
+**Spec:** `docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md` (versioned in this repo since cave-8zjr5). **Bead:** cave-3vgd. **Worktree:** `.worktrees/peel-sidepanel-reveal` (branch `peel-sidepanel-reveal`). All commands below run from the worktree root unless stated. Push after every commit (worktree-guard discipline). Commits are signed via the global git config; per `AGENTS.md`, do not add trailers crediting AI tools.
 
 ---
 
@@ -32,7 +32,7 @@
 - [ ] **Step 1: Confirm clean worktree state**
 
 Run: `git status --porcelain`
-Expected: empty (only the untracked gitignored `docs/superpowers/` spec may appear under `git status --ignored`; that is fine).
+Expected: empty (`docs/superpowers/` is versioned since cave-8zjr5, so specs appear as ordinary tracked files).
 
 - [ ] **Step 2: Write the transient shadcn config**
 
@@ -651,7 +651,7 @@ Progressive enhancement: with the desktop nav collapsed to its 56px rail, moving
 - Revealed under-layer is `aria-hidden` + `inert` (decorative); the hover-peek remains the only interactive reveal
 - Contract test `sidepanel-peel-reveal.test.ts` wired into the app suite
 
-Design spec (local, gitignored path): docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md
+Design spec: docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md
 Bead: cave-3vgd
 EOF
 )"

--- a/docs/superpowers/plans/2026-07-27-memories-sidebar-collapse.md
+++ b/docs/superpowers/plans/2026-07-27-memories-sidebar-collapse.md
@@ -1,0 +1,106 @@
+# Memories Sidebar Collapse Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Memories navigator a locally persisted, explicitly collapsible icon rail while preserving the expanded experience by default.
+
+**Architecture:** `GrimoireView` owns a new boolean rail preference independently of its existing per-section collapse record. The navigator’s root `aside` switches from its full-width container-query class to a narrow rail class; its source controls retain accessible labels, focus behavior, and existing selection/search behavior.
+
+**Tech Stack:** React, TypeScript, Tailwind utility classes, Phosphor icon subset, Node source-pinned component tests.
+
+---
+
+### Task 1: Pin the whole-rail contract
+
+**Files:**
+- Modify: `src/components/grimoire-view.test.ts`
+- Test: `src/components/grimoire-view.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Add assertions that pin a distinct persisted whole-rail key, a focusable toggle labelled `Collapse Memories sidebar` / `Expand Memories sidebar`, and a collapsed `aside` branch that keeps the navigator rendered as a narrow rail rather than hiding it.
+
+```ts
+assert.match(view, /"cave:grimoire:navigator-collapsed:v1"/, "whole navigator collapse persists locally");
+assert.match(view, /aria-label=\{navigatorCollapsed \? "Expand Memories sidebar" : "Collapse Memories sidebar"\}/, "navigator toggle exposes its action");
+assert.match(view, /navigatorCollapsed \? "@min-\[880px\]\/grimoire:w-\[44px\]" : "@min-\[880px\]\/grimoire:w-\[300px\]"/, "collapsed navigator becomes a compact rail");
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --experimental-strip-types src/components/grimoire-view.test.ts`
+
+Expected: assertion failure because the whole-navigator preference and controls do not exist.
+
+### Task 2: Add the persisted collapse behavior
+
+**Files:**
+- Modify: `src/components/grimoire-view.tsx:394-435, 724-753, 1450-1490`
+- Test: `src/components/grimoire-view.test.ts`
+
+- [ ] **Step 1: Add a storage key and safe reader**
+
+Add a versioned `NAVIGATOR_COLLAPSED_STORAGE_KEY` and `readNavigatorCollapsed()` near the existing navigator preference helpers. It returns `false` during SSR, storage failures, or malformed values.
+
+```ts
+const NAVIGATOR_COLLAPSED_STORAGE_KEY = "cave:grimoire:navigator-collapsed:v1";
+
+function readNavigatorCollapsed(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(NAVIGATOR_COLLAPSED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+```
+
+- [ ] **Step 2: Add a toggle to `GrimoireView`**
+
+Initialize `navigatorCollapsed` with the reader, invert it only on the explicit button action, and write `String(next)` to local storage inside a `try/catch`. Announce the resulting state through the already-mounted `useAnnouncer()`.
+
+```ts
+const [navigatorCollapsed, setNavigatorCollapsed] = useState(readNavigatorCollapsed);
+const toggleNavigator = useCallback(() => {
+  setNavigatorCollapsed((previous) => {
+    const next = !previous;
+    try { window.localStorage.setItem(NAVIGATOR_COLLAPSED_STORAGE_KEY, String(next)); } catch {}
+    announce(next ? "Memories sidebar collapsed" : "Memories sidebar expanded", "polite");
+    return next;
+  });
+}, [announce]);
+```
+
+- [ ] **Step 3: Render the compact rail**
+
+Keep the existing `aside` in the DOM. Add the toggle as its first interactive control, switch its wide width between `44px` and `300px`, and hide text-only navigator detail with the collapsed state while retaining labels, selected state, and explicit `aria-label`s on icon controls. Reuse `ph:sidebar-simple`, `focus-ring-inset`, and existing tokens; do not add CSS literals or alter the section-collapse data model.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --experimental-strip-types src/components/grimoire-view.test.ts`
+
+Expected: `grimoire-view.test.ts: ok`.
+
+### Task 3: Verify the surface stays safe
+
+**Files:**
+- Modify: `src/components/grimoire-view.tsx`
+- Test: `src/components/grimoire-view.test.ts`
+
+- [ ] **Step 1: Run focused tests**
+
+Run: `node --experimental-strip-types src/components/grimoire-view.test.ts && node --experimental-strip-types src/components/grimoire-launcher.test.ts`
+
+Expected: both tests print `ok` and exit 0.
+
+- [ ] **Step 2: Run lint**
+
+Run: `pnpm lint`
+
+Expected: exit 0, including the design-token and static-style gates.
+
+- [ ] **Step 3: Inspect scope**
+
+Run: `git diff -- src/components/grimoire-view.tsx src/components/grimoire-view.test.ts docs/superpowers/specs/2026-07-27-memories-sidebar-collapse-design.md docs/superpowers/plans/2026-07-27-memories-sidebar-collapse.md`
+
+Expected: only the navigator collapse feature, its source-pinned test, and its approved design/plan artifacts appear.

--- a/docs/superpowers/plans/2026-07-28-streamed-chat-activity.md
+++ b/docs/superpowers/plans/2026-07-28-streamed-chat-activity.md
@@ -1,0 +1,129 @@
+# Streamed Chat Activity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stream inline reasoning and collapse adjacent repeated tool calls into an expandable, counted run without changing chat stream data.
+
+**Architecture:** Add a pure run-partition helper alongside `segmentTurn`, then use it in the shared tool rendering path. Move the existing reasoning disclosure ahead of assistant prose and make its default-open state depend on pending status. Keep all ToolEvent data and existing ToolBlock behavior intact.
+
+**Tech Stack:** React, TypeScript, Node assertion tests, tokenized CSS.
+
+---
+
+## Files
+
+- Modify: `src/lib/turn-segments.ts` — export a pure consecutive-run partitioner.
+- Test: `src/lib/turn-segments.test.ts` — prove grouping boundaries.
+- Modify: `src/components/chat-view.tsx` — render streamed reasoning first and grouped tool runs.
+- Modify: `src/components/chat-view-polish-tools-activity.test.ts` — assert the new transcript contracts.
+- Modify: `src/styles/cave-chat/activity.css` and `src/styles/cave-chat/transcript.css` — compact tokenized nested-run layout.
+
+### Task 1: Define consecutive tool-run semantics
+
+**Files:**
+- Modify: `src/lib/turn-segments.ts`
+- Test: `src/lib/turn-segments.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+```ts
+assert.deepEqual(
+  groupConsecutiveTools([
+    { id: "1", name: "Read" },
+    { id: "2", name: "read" },
+    { id: "3", name: "Grep" },
+    { id: "4", name: "Read" },
+  ]).map((run) => run.tools.map((tool) => tool.id)),
+  [["1", "2"], ["3"], ["4"]],
+);
+```
+
+- [ ] **Step 2: Verify the test fails**
+
+Run: `pnpm exec tsx src/lib/turn-segments.test.ts`
+
+Expected: a failure because `groupConsecutiveTools` is not exported.
+
+- [ ] **Step 3: Implement the smallest pure helper**
+
+```ts
+export function groupConsecutiveTools<T extends { name: string }>(tools: T[]): { name: string; tools: T[] }[] {
+  return tools.reduce<{ name: string; tools: T[] }[]>((runs, tool) => {
+    const key = tool.name.trim().toLowerCase();
+    const previous = runs.at(-1);
+    if (previous && previous.name.trim().toLowerCase() === key) previous.tools.push(tool);
+    else runs.push({ name: tool.name, tools: [tool] });
+    return runs;
+  }, []);
+}
+```
+
+- [ ] **Step 4: Verify the helper passes**
+
+Run: `pnpm exec tsx src/lib/turn-segments.test.ts`
+
+Expected: PASS.
+
+### Task 2: Render grouped tool runs and live reasoning
+
+**Files:**
+- Modify: `src/components/chat-view.tsx`
+- Test: `src/components/chat-view-polish-tools-activity.test.ts`
+
+- [ ] **Step 1: Write failing source-contract assertions**
+
+Assert that `ReasoningBlock` receives `pending`, derives `open` from
+`pending || showThinking`, and appears before `MessageBubble`; assert that
+`ToolRunGroup` uses `groupConsecutiveTools(tools)` and renders every child via
+`ToolBlock`.
+
+- [ ] **Step 2: Verify the assertions fail**
+
+Run: `pnpm exec tsx src/components/chat-view-polish-tools-activity.test.ts`
+
+Expected: FAIL because neither `pending` nor `ToolRunGroup` exists.
+
+- [ ] **Step 3: Implement the render path**
+
+```tsx
+function ToolRuns({ tools }: { tools: ToolEvent[] }) {
+  return groupConsecutiveTools(tools).map((run) =>
+    run.tools.length === 1 ? <ToolBlock key={run.tools[0].id} tool={run.tools[0]} /> :
+      <ToolRunGroup key={run.tools.map((tool) => tool.id).join(":")} name={run.name} tools={run.tools} />,
+  );
+}
+```
+
+Use `ToolRuns` in both chronological streaming segments and the expanded
+`ToolGroup`, and render `<ReasoningBlock reasoning={reasoning} pending={!!turn.pending} ... />`
+before the assistant message body.
+
+- [ ] **Step 4: Verify the focused UI test passes**
+
+Run: `pnpm exec tsx src/components/chat-view-polish-tools-activity.test.ts`
+
+Expected: PASS.
+
+### Task 3: Add compact disclosure styling and run integration checks
+
+**Files:**
+- Modify: `src/styles/cave-chat/activity.css`
+- Modify: `src/styles/cave-chat/transcript.css`
+
+- [ ] **Step 1: Add tokenized nested-run styles**
+
+Add a `.cave-tool-run` disclosure style using existing `--border-hairline`,
+`--bg-subtle`, `--radius-control`, and spacing tokens. Reuse the parent
+disclosure rules rather than adding colors or a new animation.
+
+- [ ] **Step 2: Run focused checks**
+
+Run: `pnpm exec tsx src/lib/turn-segments.test.ts && pnpm exec tsx src/components/chat-view-polish-tools-activity.test.ts`
+
+Expected: both PASS.
+
+- [ ] **Step 3: Run integration checks**
+
+Run: `pnpm lint && pnpm test -- --runInBand`
+
+Expected: PASS, or record the exact unrelated blocker before handoff.

--- a/docs/superpowers/plans/2026-07-29-chat-follow-up-intents.md
+++ b/docs/superpowers/plans/2026-07-29-chat-follow-up-intents.md
@@ -1,0 +1,334 @@
+# Chat Follow-up Intents Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make assistant-recommended chat follow-ups visibly and behaviorally distinct as editable replies, review-first tasks, or safe registered actions.
+
+**Architecture:** Extend the pure next-path parser from `string[]` to typed `NextPath[]` while retaining legacy line compatibility. Render one shared card component in the current transcript and composer placements; `chat-view` routes the typed activation to its composer, a review-first task dialog, or a narrow navigation allowlist. The existing board draft builder remains the only source for chat-to-task data.
+
+**Tech Stack:** TypeScript, React 19, Next.js, existing Cave UI primitives/tokens, Node source-contract tests.
+
+---
+
+## File map
+
+- `src/lib/next-paths.ts` — typed model, parser, prompt directive, and safe action-id vocabulary.
+- `src/lib/next-paths.test.ts` — pure parser/directive regressions.
+- `src/lib/chat-task-autofill.ts` — split draft submission from draft construction so the dialog can show a draft before POSTing it.
+- `src/lib/chat-task-autofill.test.ts` — pin that an explicit draft, rather than an implicit one-click handoff, is submitted.
+- `src/components/chat-follow-up-cards.tsx` — focused, shared presentation component for reply/task/action cards.
+- `src/components/chat-follow-up-cards.test.ts` — source contract for labels, outcomes, keyboard-safe buttons, and no direct send handler.
+- `src/components/chat-follow-up-task-review.tsx` — focus-trapped task review dialog using `Modal`, draft fields, explicit create/cancel semantics.
+- `src/components/chat-follow-up-task-review.test.ts` — source contract for review-first mutation, focus-return, and announcer copy.
+- `src/components/chat-view.tsx` — consumes `NextPath[]`, owns activation router and renders both existing follow-up placements through the shared component.
+- `src/components/chat-follow-up-intents-wiring.test.ts` — pins the two placements, active-row suppression, and the exact safe action route.
+- `src/styles/cave-chat/transcript.css` — token-only card layout and narrow-pane/reduced-motion behavior.
+- `package.json` — add every new source test to `test:app` if `check:tests-wired` requires it.
+
+### Task 1: Define the typed, backward-compatible trailer protocol
+
+**Files:**
+- Modify: `src/lib/next-paths.ts`
+- Modify: `src/lib/next-paths.test.ts`
+
+- [ ] **Step 1: Write failing parser tests for each public behavior.**
+
+  Add type-aware expectations before modifying the parser:
+
+  ```ts
+  const typed = extractNextPaths(`Answer.\n<coven:next-paths>\n- [reply] Ask for the rollout plan\n- [task] Create accessibility task\n- [action:open-tasks] Review open tasks\n</coven:next-paths>`);
+  assert.deepEqual(typed.suggestions, [
+    { kind: "reply", label: "Ask for the rollout plan", prompt: "Ask for the rollout plan" },
+    { kind: "task", label: "Create accessibility task", prompt: "Create accessibility task" },
+    { kind: "action", actionId: "open-tasks", label: "Review open tasks", prompt: "Review open tasks" },
+  ]);
+  assert.equal(extractNextPaths("<coven:next-paths>\n- Legacy line\n</coven:next-paths>").suggestions[0].kind, "reply");
+  assert.equal(extractNextPaths("<coven:next-paths>\n- [action:erase-disk] Nope\n</coven:next-paths>").suggestions[0].kind, "reply");
+  ```
+
+- [ ] **Step 2: Run the parser test and verify it fails for the missing typed model.**
+
+  Run: `node --experimental-strip-types src/lib/next-paths.test.ts`  
+  Expected: FAIL because `suggestions` are still raw strings and no `kind` exists.
+
+- [ ] **Step 3: Add the minimal typed parser and directive.**
+
+  In `next-paths.ts`, export a discriminated union and keep lines without a valid prefix as replies:
+
+  ```ts
+  export type NextPath =
+    | { kind: "reply"; label: string; prompt: string }
+    | { kind: "task"; label: string; prompt: string }
+    | { kind: "action"; actionId: "open-tasks"; label: string; prompt: string };
+
+  function nextPathFromLine(raw: string): NextPath | null {
+    const prompt = raw.replace(/^\s*[-*•]\s*/, "").trim();
+    const typed = /^\[(reply|task|action:open-tasks)\]\s+(.+)$/i.exec(prompt);
+    if (!typed) return prompt ? { kind: "reply", label: prompt, prompt } : null;
+    const label = typed[2].trim();
+    if (typed[1].toLowerCase() === "task") return { kind: "task", label, prompt: label };
+    if (typed[1].toLowerCase() === "reply") return { kind: "reply", label, prompt: label };
+    return { kind: "action", actionId: "open-tasks", label, prompt: label };
+  }
+  ```
+
+  Change the directive examples/rules to request only `[reply]`, `[task]`, or `[action:open-tasks]`; explicitly say that an action id must be drawn from the listed allowlist. Preserve streaming stripping, the four-item cap, and the `visible` result.
+
+- [ ] **Step 4: Re-run the parser test and verify it passes.**
+
+  Run: `node --experimental-strip-types src/lib/next-paths.test.ts`  
+  Expected: `next-paths.test.ts: ok`.
+
+### Task 2: Make chat-task creation review-first without replacing its data model
+
+**Files:**
+- Modify: `src/lib/chat-task-autofill.ts`
+- Modify: `src/lib/chat-task-autofill.test.ts`
+
+- [ ] **Step 1: Write a failing test for explicit draft submission.**
+
+  Add a test that builds a `ChatTaskDraft`, calls the extracted submit helper, and proves exactly one `POST /api/board` contains that same title, `sessionId`, `familiarId`, `projectId`, and `labels`—without calling the draft builder a second time.
+
+- [ ] **Step 2: Run the focused autofill test and verify the new helper is absent.**
+
+  Run: `node --experimental-strip-types src/lib/chat-task-autofill.test.ts`  
+  Expected: FAIL because `createTaskFromDraft` is not exported.
+
+- [ ] **Step 3: Extract submission with no behavior change for existing callers.**
+
+  ```ts
+  export async function createTaskFromDraft(
+    draft: ChatTaskDraft,
+  ): Promise<{ ok: boolean; card?: Card; error?: string }> {
+    const res = await fetch("/api/board", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(draft),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok || !data?.ok) return { ok: false, error: data?.error ?? `HTTP ${res.status}` };
+    publishBoardChanged();
+    return { ok: true, card: data.card as Card };
+  }
+
+  export async function createSmartTaskFromChat({
+    sessionId, context, title, now,
+  }: {
+    sessionId: string;
+    context: ChatHandoffContext;
+    title?: string;
+    now?: Date;
+  }) {
+    return createTaskFromDraft(buildTaskDraftFromChat({ sessionId, context, title, now }));
+  }
+  ```
+
+- [ ] **Step 4: Re-run autofill and existing chat-create wiring tests.**
+
+  Run: `node --experimental-strip-types src/lib/chat-task-autofill.test.ts && node --experimental-strip-types src/components/chat-task-create-button-wiring.test.ts`  
+  Expected: both pass; the existing quick-create path remains intact.
+
+### Task 3: Build the reusable typed card and review dialog
+
+**Files:**
+- Create: `src/components/chat-follow-up-cards.tsx`
+- Create: `src/components/chat-follow-up-cards.test.ts`
+- Create: `src/components/chat-follow-up-task-review.tsx`
+- Create: `src/components/chat-follow-up-task-review.test.ts`
+- Modify: `src/styles/cave-chat/transcript.css`
+
+- [ ] **Step 1: Write failing source-contract tests before either component exists.**
+
+  The card test must assert a labelled `role="group"`, native buttons using
+  `.focus-ring`, visible `Reply`/`Task`/`Action` labels, outcome cues, and an
+  `onActivate(path)` callback rather than `send(path.prompt)`. The dialog test
+  must assert `Modal`, an editable title field, `createTaskFromDraft(draft)`,
+  Cancel, `dismissOnEscape={!creating}`, and `announce('Task "…" created from this chat.')`.
+
+- [ ] **Step 2: Run the two new tests and verify both fail because the files do not exist.**
+
+  Run: `node --experimental-strip-types src/components/chat-follow-up-cards.test.ts && node --experimental-strip-types src/components/chat-follow-up-task-review.test.ts`  
+  Expected: FAIL with missing-file errors.
+
+- [ ] **Step 3: Implement `FollowUpCards` as a pure controlled component.**
+
+  ```tsx
+  type FollowUpCardsProps = {
+    paths: NextPath[];
+    onActivate: (path: NextPath) => void;
+    recommended?: boolean;
+  };
+  const FOLLOW_UP_META = {
+    reply: { icon: "ph:chat-circle-dots", label: "Reply", outcome: "Drafts a reply below" },
+    task: { icon: "ph:check-square", label: "Task", outcome: "Opens a linked task review" },
+    action: { icon: "ph:arrow-square-out", label: "Action", outcome: "Opens Tasks" },
+  } satisfies Record<NextPath["kind"], { icon: IconName; label: string; outcome: string }>;
+
+  export function FollowUpCards({ paths, onActivate, recommended = true }: FollowUpCardsProps) {
+    return <section className="cave-followup-cards" role="group" aria-label="Suggested next steps">
+      <span className="cave-followup-cards__label">Suggested next steps</span>
+      <div className="cave-followup-cards__grid" data-count={paths.length}>
+        {paths.map((path, index) => <button key={`${path.kind}:${path.label}:${index}`}
+          type="button" className="cave-followup-card focus-ring" onClick={() => onActivate(path)}
+          aria-label={`${FOLLOW_UP_META[path.kind].label}: ${path.label}. ${FOLLOW_UP_META[path.kind].outcome}`}>
+          <Icon name={FOLLOW_UP_META[path.kind].icon} width={14} aria-hidden />
+          <span className="cave-followup-card__type">{FOLLOW_UP_META[path.kind].label}</span>
+          {recommended && index === 0 ? <span className="cave-followup-card__recommended">Recommended</span> : null}
+          <strong className="cave-followup-card__title">{path.label}</strong>
+          <span className="cave-followup-card__outcome">{FOLLOW_UP_META[path.kind].outcome}</span>
+        </button>)}
+      </div>
+    </section>;
+  }
+  ```
+
+  Map only existing icons: `ph:chat-circle-dots` for reply, `ph:check-square`
+  for task, and `ph:arrow-square-out` for action. Derive type styling from one
+  solid semantic token with `color-mix`; do not add hardcoded colours, font
+  sizes, or a second status hue.
+
+- [ ] **Step 4: Implement the task dialog as a controlled review, not a creation shortcut.**
+
+  Accept `open`, `sessionId`, `context`, `suggestion`, `onCreated`, and
+  `onClose`. Initialize the draft with `buildTaskDraftFromChat({ sessionId,
+  context, title: suggestion.prompt })`, let the title remain editable, and
+  call `createTaskFromDraft(draft)` only from the explicit **Create task**
+  footer button. Disable backdrop/Escape only while creating; surface an inline
+  `role="alert"` failure and restore focus through `Modal` on cancellation.
+
+  ```tsx
+  const initialDraft = useMemo(
+    () => buildTaskDraftFromChat({ sessionId, context, title: suggestion.prompt }),
+    [sessionId, context, suggestion.prompt],
+  );
+  const [draft, setDraft] = useState(initialDraft);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const create = async () => {
+    setCreating(true); setError(null);
+    const result = await createTaskFromDraft(draft);
+    setCreating(false);
+    if (!result.ok || !result.card) { setError(result.error ?? "Couldn't create task"); return; }
+    announce(`Task "${result.card.title}" created from this chat.`);
+    onCreated(result.card);
+  };
+  ```
+
+- [ ] **Step 5: Add token-only layout CSS and run the component tests.**
+
+  Use a 1-column narrow-pane layout and 2-column grid when the composer
+  container permits it. Reuse `--bg-raised`, `--border-hairline`,
+  `--radius-control`, `--space-*`, text tiers, and the existing
+  `prefers-reduced-motion` recommendation treatment. Run: `node --experimental-strip-types src/components/chat-follow-up-cards.test.ts && node --experimental-strip-types src/components/chat-follow-up-task-review.test.ts`  
+  Expected: both pass.
+
+### Task 4: Route typed follow-ups through ChatView without duplicate or unsafe behavior
+
+**Files:**
+- Modify: `src/components/chat-view.tsx`
+- Create: `src/components/chat-follow-up-intents-wiring.test.ts`
+- Modify: `src/components/chat-view-polish-attachments-mentions.test.ts`
+
+- [ ] **Step 1: Write failing wiring assertions.**
+
+  Pin all of the following:
+
+  ```ts
+  assert.match(source, /<FollowUpCards[\s\S]*?paths=\{followUp\.suggestions\}/);
+  assert.match(source, /case "reply":[\s\S]*?setInput\(path\.prompt\)[\s\S]*?inputRef\.current\?\.focus\(\)/);
+  assert.match(source, /case "task":[\s\S]*?setFollowUpTask\(path\)/);
+  assert.match(source, /case "action":[\s\S]*?path\.actionId === "open-tasks"[\s\S]*?"cave:navigate-mode"[\s\S]*?mode: "board"/);
+  assert.doesNotMatch(source, /onClick=\{\(\) => void send\(s\)\}/);
+  ```
+
+  Also assert that the historical `TurnRowImpl` receives `NextPath[]` and the
+  active latest turn remains suppressed there, so one recommendation is never
+  rendered twice.
+
+- [ ] **Step 2: Run the new wiring test and verify it fails.**
+
+  Run: `node --experimental-strip-types src/components/chat-follow-up-intents-wiring.test.ts`  
+  Expected: FAIL because ChatView still maps raw strings to `send(s)`.
+
+- [ ] **Step 3: Integrate the shared component and a single activation router.**
+
+  Import `FollowUpCards`, `FollowUpTaskReview`, and `type NextPath`. Keep
+  `followUp` and `TurnRowImpl` typed as `NextPath[]`. Add a callback with this
+  policy:
+
+  ```ts
+  const activateFollowUp = useCallback((path: NextPath) => {
+    if (path.kind === "reply") { setInput(path.prompt); inputRef.current?.focus(); return; }
+    if (path.kind === "task") { setFollowUpTask(path); return; }
+    if (path.actionId === "open-tasks") {
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "board" } }));
+    }
+  }, []);
+  ```
+
+  Mount one review dialog at `ChatView` scope with the existing `activePath`,
+  familiar id, `projectIdDraft`, and session id. On creation, clear the pending
+  suggestion, update linked context using the existing card assignment shape,
+  and announce success. Do not broaden the action allowlist in this task.
+
+- [ ] **Step 4: Update legacy source pins and run all focused chat tests.**
+
+  Replace assertions that expect `cave-next-path--recommended` pills and direct
+  `send(s)` with the typed-card contract. Run:
+
+  ```bash
+  node --experimental-strip-types src/lib/next-paths.test.ts
+  node --experimental-strip-types src/lib/chat-task-autofill.test.ts
+  node --experimental-strip-types src/components/chat-follow-up-cards.test.ts
+  node --experimental-strip-types src/components/chat-follow-up-task-review.test.ts
+  node --experimental-strip-types src/components/chat-follow-up-intents-wiring.test.ts
+  node --experimental-strip-types src/components/chat-view-polish-attachments-mentions.test.ts
+  node --experimental-strip-types src/components/chat-task-create-button-wiring.test.ts
+  node --experimental-strip-types src/components/chat-task-handoff-wiring.test.ts
+  ```
+
+  Expected: every test prints `ok` (Node's existing module-type warning is
+  baseline noise, not a new failure).
+
+### Task 5: Wire, validate, and visually audit the completed surface
+
+**Files:**
+- Modify: `package.json` only if `pnpm check:tests-wired` reports an unwired new test.
+- Modify: `docs/superpowers/specs/2026-07-29-chat-follow-up-intent-design.md` only to record an implementation decision that differs from the approved spec.
+
+- [ ] **Step 1: Verify test-script wiring before broad checks.**
+
+  Run: `pnpm check:tests-wired`  
+  Expected: PASS. If it names a new test file, add precisely that file to the
+  existing `test:app` script and rerun until it passes.
+
+- [ ] **Step 2: Run static/design gates.**
+
+  Run:
+
+  ```bash
+  pnpm typecheck
+  pnpm lint
+  pnpm codemod:design:check
+  git diff --check
+  ```
+
+  Expected: PASS. Do not hide a newly introduced design-drift category; fix the
+  source so the codemod stays a no-op.
+
+- [ ] **Step 3: Perform the native desktop interaction audit.**
+
+  Run `bash scripts/dev-app.sh` from this worktree in the foreground. In the
+  Tauri window, verify a typed reply fills and focuses the composer without
+  sending; a task opens an editable linked review, Cancel returns focus, and
+  Create produces one task; `action:open-tasks` routes to Tasks. Repeat the
+  visual check in dark, light, and one non-default palette; narrow the pane to
+  confirm a single-column card layout; enable reduced motion to confirm no
+  recommendation motion remains necessary to identify the card.
+
+- [ ] **Step 4: Record verification in the claimed bead and hand off without committing.**
+
+  Run `bd update cave-mqdhl --notes='Worktree: ...; changed files: ...; verification: ...'`.
+  The repository is in the conservative Beads profile, so leave the branch
+  uncommitted and report the exact diff and successful commands for explicit
+  commit/PR authorization.

--- a/docs/superpowers/plans/2026-07-29-mobile-live-voice.md
+++ b/docs/superpowers/plans/2026-07-29-mobile-live-voice.md
@@ -1,0 +1,333 @@
+# Mobile live voice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a direct-chat iOS voice-call sheet with OpenAI Realtime full-duplex audio and an explicit Apple-native turn-taking mode, while retaining composer dictation.
+
+**Architecture:** `VoiceCallCoordinator` is the single audio/session lifecycle owner. It delegates OpenAI calls to a pinned WebRTC adapter that consumes the existing server-minted ephemeral grant, and delegates Native voice to Speech recognition plus AVSpeechSynthesizer and ChatThread streaming. `VoiceCallSheet` and its expanded transcript reader render the same coordinator state.
+
+**Tech Stack:** SwiftUI, Observation, AVFoundation, Speech, URLSession, `WebRTC` SPM package from `https://github.com/stasel/WebRTC.git` pinned at `150.0.0` (`6ed87f05368632f71dc95c89c14c051561710925`), existing Next.js `/api/voice/session` grant route, XCTest, node:test.
+
+---
+
+## File structure
+
+- `apps/ios/CovenCave/project.yml` — pin the WebRTC binary package for app and test builds.
+- `apps/ios/CovenCave/CovenCave/Models/Models.swift` — decode published familiar voice metadata.
+- `apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift` — typed call-grant request with no key material.
+- `apps/ios/CovenCave/CovenCave/Voice/VoiceCallState.swift` — pure call mode, phases, rows, and reducer-like transitions.
+- `apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift` — observable lifecycle owner and audio cleanup boundary.
+- `apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeCall.swift` — WebRTC SDP/session adapter.
+- `apps/ios/CovenCave/CovenCave/Voice/NativeVoiceCall.swift` — Speech/AVSpeech turn-taking adapter.
+- `apps/ios/CovenCave/CovenCave/Views/VoiceCallSheet.swift` — compact and expanded transcript call UI.
+- `apps/ios/CovenCave/CovenCave/Views/ChatView.swift` — direct-chat phone entry point; preserve dictation.
+- `apps/ios/CovenCave/CovenCave/Info.plist` — call-specific microphone/speech privacy purpose strings.
+- `apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift` — pure lifecycle/transcript regression tests.
+- `apps/ios/CovenCave/CovenCaveTests/CaveClientVoiceTests.swift` — grant decoding/request contract tests.
+- `src/app/api/voice/session/route.test.ts` — assert that a mobile-shaped request does not expose a vault key.
+
+### Task 1: Expose the safe call-eligibility and grant contracts
+
+**Files:**
+- Modify: `apps/ios/CovenCave/CovenCave/Models/Models.swift:6-30`
+- Modify: `apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift:1-110, 440-520`
+- Create: `apps/ios/CovenCave/CovenCaveTests/CaveClientVoiceTests.swift`
+- Test: `src/app/api/voice/session/route.test.ts`
+
+- [ ] **Step 1: Write the failing Swift and route tests.**
+
+```swift
+func testFamiliarDecodesPublishedVoiceMetadata() throws {
+    let data = #"{"id":"aria","display_name":"Aria","voiceProvider":"openai","voiceModel":"gpt-realtime","voiceName":"marin"}"#.data(using: .utf8)!
+    let familiar = try JSONDecoder().decode(Familiar.self, from: data)
+    XCTAssertEqual(familiar.voiceProvider, "openai")
+    XCTAssertEqual(familiar.voiceName, "marin")
+}
+
+func testVoiceGrantNeverContainsProviderKey() throws {
+    let grant = try JSONDecoder().decode(CaveClient.VoiceSessionResponse.self, from: fixture)
+    XCTAssertEqual(grant.grant.provider, "openai")
+    XCTAssertFalse(String(data: fixture, encoding: .utf8)!.contains("OPENAI_API_KEY"))
+}
+```
+
+- [ ] **Step 2: Run the tests and verify red.**
+
+Run: `xcodegen generate && xcodebuild test -project CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:CovenCaveTests/CaveClientVoiceTests`
+
+Expected: compile failure for missing `voiceProvider` and `VoiceSessionResponse`.
+
+- [ ] **Step 3: Add the minimal typed model and request.**
+
+```swift
+// Familiar
+var voiceProvider: String?
+var voiceModel: String?
+var voiceName: String?
+
+// CaveClient
+struct VoiceSessionResponse: Decodable {
+    let ok: Bool; let grant: VoiceSessionGrant?; let callId: String?
+    let error: String?; let hint: String?
+}
+func voiceSession(familiarId: String, sessionId: String) async throws -> VoiceSessionResponse {
+    let data = try JSONEncoder().encode(["familiarId": familiarId, "sessionId": sessionId])
+    let request = try request("api/voice/session", method: "POST", body: data)
+    let (body, _) = try await data(for: request)
+    return try JSONDecoder().decode(VoiceSessionResponse.self, from: body)
+}
+```
+
+- [ ] **Step 4: Prove green.**
+
+Run the Step 2 command and `node --experimental-strip-types src/app/api/voice/session/route.test.ts`.
+
+Expected: both pass; response fixture contains an ephemeral `clientSecret` only, never the provider key.
+
+### Task 2: Establish the testable call state machine before audio code
+
+**Files:**
+- Create: `apps/ios/CovenCave/CovenCave/Voice/VoiceCallState.swift`
+- Create: `apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift`
+
+- [ ] **Step 1: Write failing state tests.**
+
+```swift
+func testPartialTranscriptIsReplacedByFinalTranscript() {
+    var state = VoiceCallState(mode: .native)
+    state.apply(.partial(role: .assistant, text: "I can"))
+    state.apply(.final(role: .assistant, text: "I can help."))
+    XCTAssertEqual(state.transcript.map(\.text), ["I can help."])
+}
+
+func testEndClearsAudioPhaseButKeepsTranscript() {
+    var state = VoiceCallState(mode: .realtime)
+    state.apply(.connected)
+    state.apply(.final(role: .user, text: "Hello"))
+    state.apply(.ended)
+    XCTAssertEqual(state.phase, .ended)
+    XCTAssertEqual(state.transcript.count, 1)
+}
+```
+
+- [ ] **Step 2: Run red.**
+
+Run: `xcodebuild test -project CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:CovenCaveTests/VoiceCallStateTests`
+
+Expected: compile failure because `VoiceCallState` does not exist.
+
+- [ ] **Step 3: Implement pure state.**
+
+```swift
+enum VoiceCallMode: String, CaseIterable { case realtime, native }
+enum VoiceCallPhase: Equatable { case idle, connecting, listening, speaking, ended, failed(String) }
+struct VoiceTranscriptRow: Identifiable, Equatable { let id: UUID; let role: DisplayMessage.Role; var text: String; var partial: Bool }
+enum VoiceCallEvent { case connected, partial(role: DisplayMessage.Role, text: String), final(role: DisplayMessage.Role, text: String), ended }
+struct VoiceCallState {
+    var mode: VoiceCallMode; var phase: VoiceCallPhase = .idle; var transcript: [VoiceTranscriptRow] = []
+    mutating func apply(_ event: VoiceCallEvent) { /* replace last matching partial; append finals; preserve finals on end */ }
+}
+```
+
+- [ ] **Step 4: Run green.**
+
+Run the Step 2 command.
+
+Expected: partial rows are display-only, finals are ordered, and end never erases the reader.
+
+### Task 3: Add and isolate the two audio transports
+
+**Files:**
+- Modify: `apps/ios/CovenCave/project.yml:1-95`
+- Create: `apps/ios/CovenCave/CovenCave/Voice/OpenAIRealtimeCall.swift`
+- Create: `apps/ios/CovenCave/CovenCave/Voice/NativeVoiceCall.swift`
+- Create: `apps/ios/CovenCave/CovenCave/Voice/VoiceCallCoordinator.swift`
+- Modify: `apps/ios/CovenCave/CovenCave/SpeechDictation.swift:1-105`
+- Test: `apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift`
+
+- [ ] **Step 1: Add failing coordinator tests for permission failure, interruption, and native turn handoff.**
+
+```swift
+func testPermissionDenialEndsWithoutStartingTransport() async {
+    let coordinator = VoiceCallCoordinator(permission: .denied, transport: FakeTransport())
+    await coordinator.start(mode: .native, familiarId: "aria", sessionId: "s1")
+    XCTAssertEqual(coordinator.state.phase, .failed("microphone_denied"))
+}
+
+func testNativeFinalUserTurnUsesThreadSendOnce() async {
+    let sink = RecordingTurnSink()
+    let coordinator = VoiceCallCoordinator(permission: .granted, transport: FakeTransport(), turnSink: sink)
+    await coordinator.didRecognizeFinal("Review this PR")
+    XCTAssertEqual(await sink.prompts, ["Review this PR"])
+}
+```
+
+- [ ] **Step 2: Run red.**
+
+Run the `VoiceCallStateTests` command from Task 2.
+
+Expected: missing coordinator and fakeable transport protocol errors.
+
+- [ ] **Step 3: Pin the package and implement the transport boundary.**
+
+```yaml
+packages:
+  WebRTC:
+    url: https://github.com/stasel/WebRTC.git
+    revision: 6ed87f05368632f71dc95c89c14c051561710925
+targets:
+  CovenCave:
+    dependencies:
+      - package: WebRTC
+```
+
+```swift
+protocol VoiceCallTransport: Sendable {
+    func start(grant: CaveClient.VoiceSessionGrant, callbacks: VoiceCallCallbacks) async throws
+    func setMuted(_ muted: Bool)
+    func stop() async
+}
+struct VoiceCallCallbacks: Sendable {
+    let partial: @Sendable (DisplayMessage.Role, String) -> Void
+    let final: @Sendable (DisplayMessage.Role, String) -> Void
+    let failed: @Sendable (String) -> Void
+}
+```
+
+`OpenAIRealtimeCall` creates one `RTCPeerConnection`, adds the microphone
+track, opens the data channel, exchanges SDP against `grant.connection.url`,
+routes `conversation.item.input_audio_transcription.*` and
+`response.output_audio_transcript.*` into callbacks, and closes every track
+on stop. `NativeVoiceCall` reuses the recognizer mechanics only after extracting
+them from `SpeechDictation`; it stops listening before `ChatThread.send`, speaks
+the completed assistant reply through `AVSpeechSynthesizer`, then resumes.
+
+- [ ] **Step 4: Implement coordinator cleanup exactly once.**
+
+```swift
+func finish() async {
+    await transport?.stop()
+    transport = nil
+    audioEngine.stop()
+    AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    state.apply(.ended)
+}
+```
+
+Wire AVAudioSession interruption and route-change notifications to `finish()`;
+never let `SpeechDictation` and a call own an input-node tap concurrently.
+
+- [ ] **Step 5: Run green.**
+
+Run the Task 2 test command and `xcodebuild -project CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=iPhone 16 Pro' CODE_SIGNING_ALLOWED=NO build`.
+
+Expected: coordinator tests pass and the package resolves reproducibly from its pinned revision.
+
+### Task 4: Render the call sheet without replacing dictation
+
+**Files:**
+- Create: `apps/ios/CovenCave/CovenCave/Views/VoiceCallSheet.swift`
+- Modify: `apps/ios/CovenCave/CovenCave/Views/ChatView.swift:30-65, 170-310, 835-1110`
+- Modify: `apps/ios/CovenCave/CovenCave/Info.plist`
+- Test: `apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift`
+
+- [ ] **Step 1: Add failing eligibility and presentation tests.**
+
+```swift
+func testRealtimeIsAvailableOnlyForOpenAIFamiliar() {
+    XCTAssertTrue(VoiceCallMode.realtime.isAvailable(for: familiar(provider: "openai")))
+    XCTAssertFalse(VoiceCallMode.realtime.isAvailable(for: familiar(provider: "familiar")))
+}
+
+func testNativeVoiceIsAvailableForAnyDirectChat() {
+    XCTAssertTrue(VoiceCallEligibility(thread: .directFixture, provider: nil).nativeEnabled)
+    XCTAssertFalse(VoiceCallEligibility(thread: .groupFixture, provider: "openai").nativeEnabled)
+}
+```
+
+Add this test helper in the same XCTest file so the eligibility test has no
+implicit fixture dependency:
+
+```swift
+private func familiar(provider: String?) -> Familiar {
+    let value = provider.map { "\"$0\"" } ?? "null"
+    let data = "{\"id\":\"aria\",\"display_name\":\"Aria\",\"voiceProvider\":\(value)}".data(using: .utf8)!
+    return try! JSONDecoder().decode(Familiar.self, from: data)
+}
+```
+
+- [ ] **Step 2: Run red.**
+
+Run the Task 2 test command.
+
+Expected: missing eligibility model and view-coordinator presentation wiring.
+
+- [ ] **Step 3: Add UI with explicit mode selection.**
+
+```swift
+.sheet(isPresented: $showVoiceCall) {
+    VoiceCallSheet(coordinator: voiceCall, familiar: familiar)
+        .presentationDetents([.medium, .large])
+        .interactiveDismissDisabled(voiceCall.isActive)
+}
+
+ToolbarItem(placement: .topBarTrailing) {
+    Button { showVoiceCall = true } label: { Image(systemName: "phone.fill") }
+        .accessibilityLabel("Start voice call")
+        .disabled(thread.isGroup || app.client == nil)
+}
+```
+
+The sheet uses a mode picker before connecting, transcript rows with role text
+(`You` / familiar name), a mute control, an end-call control, and an expand
+action. Native mode copy says `Turn-based with Apple Speech`; Realtime says
+`Live OpenAI Realtime`. Add `.onDisappear { Task { await voiceCall.finish() } }`
+only when the call has ended; do not tear down a live call during expansion.
+
+Update the two iOS privacy strings to state that microphone/speech access is
+used for both dictation and voice calls.
+
+- [ ] **Step 4: Run green.**
+
+Run the Task 2 test command and build command from Task 3.
+
+Expected: dictation remains in `composerActions`; phone action is direct-chat-only; sheet presentation does not reconnect on expansion.
+
+### Task 5: Verify end-to-end contracts and hand off safely
+
+**Files:**
+- Modify: `src/app/api/voice/session/route.test.ts`
+- Modify: `apps/ios/CovenCave/CovenCaveTests/VoiceCallStateTests.swift`
+- Modify: `docs/superpowers/specs/2026-07-29-mobile-live-voice-design.md` only if implementation uncovers a deliberate contract change.
+
+- [ ] **Step 1: Add final regression tests.**
+
+```ts
+test("mobile voice grant exposes no vault secret", async () => {
+  writeFamiliar({ voiceProvider: "openai", voiceModel: "gpt-realtime" });
+  process.env.OPENAI_API_KEY = "sk-test-only";
+  nextFetchResponse = new Response(JSON.stringify({ value: "ek-short-lived" }), { status: 200 });
+  const json = await (await POST(req({ familiarId: FAMILIAR_ID, sessionId: SESSION_ID }))).json();
+  assert.equal(JSON.stringify(json).includes("sk-test-only"), false);
+});
+```
+
+- [ ] **Step 2: Run the focused regression suite.**
+
+Run:
+`node --experimental-strip-types src/app/api/voice/session/route.test.ts`
+
+`xcodebuild test -project apps/ios/CovenCave/CovenCave.xcodeproj -scheme CovenCave -destination 'platform=iOS Simulator,name=iPhone 16 Pro'`
+
+Expected: route test passes; all iOS tests pass with no audio permission prompt required by unit tests.
+
+- [ ] **Step 3: Run repository gates and inspect the diff.**
+
+Run:
+`pnpm test:mobile && pnpm typecheck && pnpm lint && git diff --check && git status --short`
+
+Expected: all applicable gates pass; only the planned mobile, API-test, spec, and plan files changed; report any pre-existing dirty files separately.
+
+- [ ] **Step 4: Update Beads and request commit authority.**
+
+Record test commands/results, the WebRTC pin, branch/worktree, and iOS simulator used in `cave-6p87m`. Do not commit or push until the maintainer explicitly authorizes it.

--- a/docs/superpowers/plans/2026-07-29-tasks-multi-familiar-grouping.md
+++ b/docs/superpowers/plans/2026-07-29-tasks-multi-familiar-grouping.md
@@ -1,0 +1,157 @@
+# Tasks Multi-Familiar Grouping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the Tasks page's Familiar grouping option only when the shell scope contains more than one selected familiar.
+
+**Architecture:** `BoardView` already receives `scopeFamiliarIds`, so derive one local `showFamiliarGrouping` boolean from that set and reuse it for the Kanban/Table control, Gantt control, and persisted-preference fallbacks. Keep filtering and task assignment unchanged.
+
+**Tech Stack:** React, TypeScript, Node source-contract tests, pnpm
+
+---
+
+### Task 1: Pin multi-familiar grouping visibility
+
+**Files:**
+- Test: `src/components/board-view-familiar-scope.test.ts`
+
+- [ ] **Step 1: Replace the single-familiar fallback pin and add visibility pins**
+
+Add these assertions after the existing multiselect filtering assertion:
+
+```ts
+assert.match(
+  source,
+  /const showFamiliarGrouping = \(scopeFamiliarIds\?\.size \?\? 0\) > 1;/,
+  "BoardView exposes familiar grouping only for a true multi-familiar scope",
+);
+
+assert.equal(
+  (source.match(/\{showFamiliarGrouping \? \(/g) ?? []).length,
+  2,
+  "Kanban/Table and Gantt both gate their Familiar grouping control on multi-selection",
+);
+```
+
+Replace the existing `effectiveGroupBy` assertion with:
+
+```ts
+assert.match(
+  source,
+  /const effectiveGroupBy: GroupBy = !showFamiliarGrouping && groupBy === "familiar" \? "status" : groupBy;/,
+  "Tasks falls back to status when a saved Familiar grouping is unavailable",
+);
+
+assert.match(
+  source,
+  /const effectiveGanttGroup = ganttGroup === "familiar" && !showFamiliarGrouping \? "project" : ganttGroup;/,
+  "Gantt falls back to project when a saved Familiar grouping is unavailable",
+);
+```
+
+- [ ] **Step 2: Run the focused test and verify the expected failure**
+
+Run:
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/board-view-familiar-scope.test.ts
+```
+
+Expected: FAIL because `showFamiliarGrouping` does not exist yet.
+
+### Task 2: Gate Familiar grouping on the selected set
+
+**Files:**
+- Modify: `src/components/board-view.tsx:402-410`
+- Modify: `src/components/board-view.tsx:1060-1090`
+- Test: `src/components/board-view-familiar-scope.test.ts`
+
+- [ ] **Step 1: Derive the shared visibility condition and update fallbacks**
+
+Replace the current familiar-grouping comment and derived values with:
+
+```ts
+// The shell already owns familiar scope. Re-expose Familiar grouping only
+// when the selected set contains multiple familiars and grouping that union
+// adds information; hide it for All and single-familiar scopes.
+const showFamiliarGrouping = (scopeFamiliarIds?.size ?? 0) > 1;
+const effectiveGroupBy: GroupBy = !showFamiliarGrouping && groupBy === "familiar" ? "status" : groupBy;
+const effectiveGanttGroup = ganttGroup === "familiar" && !showFamiliarGrouping ? "project" : ganttGroup;
+```
+
+- [ ] **Step 2: Gate both Familiar controls**
+
+In the Gantt grouping control and the Kanban/Table grouping control, replace:
+
+```tsx
+{activeFamiliarId === null ? (
+```
+
+with:
+
+```tsx
+{showFamiliarGrouping ? (
+```
+
+- [ ] **Step 3: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+node --require ./scripts/css-source-contract-hook.cjs --experimental-strip-types src/components/board-view-familiar-scope.test.ts
+```
+
+Expected: `board-view-familiar-scope.test.ts: ok`
+
+### Task 3: Verify and hand off
+
+**Files:**
+- Verify: `src/components/board-view.tsx`
+- Verify: `src/components/board-view-familiar-scope.test.ts`
+- Update tracker: Bead `cave-znoi1`
+
+- [ ] **Step 1: Run type and design checks**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm lint
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 2: Run the full app suite**
+
+Run:
+
+```bash
+pnpm test:app
+```
+
+Expected: all app test files pass.
+
+- [ ] **Step 3: Inspect the final scope**
+
+Run:
+
+```bash
+git diff --check
+git diff -- src/components/board-view.tsx src/components/board-view-familiar-scope.test.ts
+git status --short
+```
+
+Expected: no whitespace errors; only the two scoped implementation files plus
+the pre-existing unrelated work and Beads interaction log are modified.
+
+- [ ] **Step 4: Record verification without closing prematurely**
+
+Update `cave-znoi1` with the branch/worktree, session, familiar owner, changed
+files, and exact verification results. Leave it `in_progress` because this
+repository closes implementation beads only after merge or explicit completion
+criteria.
+
+- [ ] **Step 5: Stop before commit or push**
+
+The active conservative profile does not authorize commit or push. Report the
+verified diff and wait for explicit authority.

--- a/docs/superpowers/specs/2026-07-21-canvas-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-07-21-canvas-fullscreen-design.md
@@ -1,0 +1,96 @@
+# Canvas editor full screen — design
+
+**Date:** 2026-07-21 · **Bead:** cave-i0qt · **Status:** approved
+
+## Problem
+
+In the Canvas sketch editor (`src/components/canvas-editor.tsx`), the sketch
+preview is capped at `min(900px, 100%)` wide inside a padded stage, and the
+320px inspector/design-chat aside is always visible. There is no way to view a
+sketch at full size — neither filling the editor area nor taking over the
+screen.
+
+## Goals
+
+- Let the sketch fill the whole editor body (in-app expand).
+- Let the sketch take over the monitor (native fullscreen), where supported.
+- Preserve the Select / Comment / Edit workflow and all editor state
+  (selection, style drafts, comments, chat) across both.
+
+## Non-goals
+
+- No fullscreen for the gallery thumbnails or the inline chat artifact viewer.
+- No layout redesign of the aside; it simply hides while expanded.
+- No persistence of the expanded state across editor sessions.
+
+## Approved approach (A)
+
+Two icon buttons in the editor header, grouped immediately before the
+Select/Comment/Edit mode group:
+
+1. **Expand** (in-app toggle) — icon `ph:arrows-out-simple`, switching to
+   `ph:arrows-in-simple` while active; `aria-pressed` reflects state with a
+   steady accessible name ("Expand sketch"), per the ARIA toggle-button
+   pattern.
+2. **Full screen** (native) — icon `ph:frame-corners` (new `ICON_NAMES`
+   entry + regenerated `ph-icons-subset.json`); rendered only when the
+   Fullscreen API is available.
+
+Rejected: floating overlay cluster on the sketch corner (overlaps sketch
+content, weak on touch); single button with modifier for native
+(undiscoverable).
+
+## Behavior
+
+### In-app expand
+
+- `expanded` state on the editor root: class `canvas-editor--expanded`.
+- CSS only: hide `.canvas-editor__aside`, drop stage padding, let
+  `.canvas-editor__frame-shell` fill the stage (no 900px cap, no radius/border
+  chrome). Header stays visible so modes, Done, and both toggles remain
+  reachable.
+- `Esc` exits. Precedence, encoded in a small exported pure helper
+  (`resolveEscapeAction`) so it is testable: (1) if the sketch is in native
+  fullscreen, the browser owns `Esc` (it exits fullscreen itself; one press
+  peels exactly one layer); (2) if focus is in a non-empty input/textarea,
+  `Esc` belongs to the field — do nothing (this now also covers expand, a
+  deliberate extension of the existing selection-only guard); (3) else if a
+  selection exists, clear it; (4) else if expanded, exit expand; (5) else
+  nothing.
+- Editor state (selection, drafts, annotations, chat) is untouched by
+  toggling.
+
+### Native fullscreen
+
+- `requestFullscreen()` on `.canvas-editor__frame-shell` (the div wrapping the
+  iframe and the runtime-error overlay), with `webkit`-prefixed fallbacks for
+  WKWebView/Tauri.
+- Button hidden unless `document.fullscreenEnabled` (or
+  `webkitFullscreenEnabled`) is true.
+- A `fullscreenchange` (+`webkitfullscreenchange`) listener syncs a
+  `nativeFullscreen` state so the button label flips to "Exit full screen" and
+  exit-by-`Esc` (handled natively by the browser) keeps the UI in sync.
+- `:fullscreen` CSS on the frame shell removes the border/radius.
+
+### Accessibility
+
+- Both buttons use `focus-ring-inset`/`focus-ring` per the global convention,
+  have `title` + `aria-label`s, and the expand toggle sets `aria-pressed`.
+- State changes announce through the editor's existing `aria-live` region:
+  "Sketch expanded." / "Sketch restored." / "Entered full screen." /
+  "Exited full screen."
+
+## Testing
+
+Per repo convention (behavioral tests for pure logic, source-regex pins for
+React wiring), in `src/components/canvas-editor.test.ts` (already wired in
+`scripts/run-tests.mjs`):
+
+- Behavioral: `resolveEscapeAction` — field-with-content guard, selection
+  precedence, exit-expand, no-op when neither.
+- Source pins: `canvas-editor--expanded` class toggle, fullscreen-availability
+  gate, `aria-pressed` wiring, `fullscreenchange` listener, and the
+  `:fullscreen` / `--expanded` CSS rules in `src/styles/canvas-editor.css`.
+
+Validation: targeted test run + `pnpm typecheck`; PR through the protected
+`main` path with the required checks.

--- a/docs/superpowers/specs/2026-07-21-ios-canvas-scroll-header-design.md
+++ b/docs/superpowers/specs/2026-07-21-ios-canvas-scroll-header-design.md
@@ -1,0 +1,75 @@
+# iOS Canvas Scroll Header Design
+
+## Goal
+
+Give the native iOS Canvas gallery more vertical space while browsing without
+making creation controls hard to recover.
+
+## Interaction
+
+- Keep the `Canvas` title row pinned at the top.
+- Show the prompt composer and starter chips in their current layout at rest.
+- After a deliberate upward gallery scroll, slide and fade the composer and
+  starter chips away together.
+- Reveal those controls as soon as the user deliberately scrolls downward.
+- Always reveal the controls when the gallery returns near the top.
+- Ignore small offset changes so finger jitter and layout updates do not flicker
+  the controls.
+- When Reduce Motion is enabled, change visibility without translational
+  animation.
+
+## Architecture
+
+`CanvasView` will split its current header into:
+
+1. A permanent title row.
+2. A collapsible controls region containing `composer` and `starterBar`.
+
+The gallery `ScrollView` will use `onScrollGeometryChange` to report a
+normalized vertical offset. Normalization must account for the current top
+content inset so changing the collapsible region's height does not look like a
+user scroll and immediately reverse the state.
+
+A small value-type scroll-state reducer will own:
+
+- the previous normalized offset;
+- accumulated movement since the last direction change;
+- whether the controls are visible;
+- upward and downward hysteresis thresholds;
+- the near-top reset.
+
+The view will apply reducer output to the collapsible region with a short
+ease-out opacity-and-offset transition. Existing composer focus, generation,
+refresh, and gallery behavior remain unchanged.
+
+## State Rules
+
+- Initial state: controls visible.
+- Near top: controls visible and movement accumulation reset.
+- Upward movement beyond the hide threshold: controls hidden.
+- Downward movement beyond the reveal threshold: controls visible.
+- Movement below the jitter threshold: no visibility change.
+- Layout-driven inset changes: no direction reversal because decisions use the
+  normalized offset.
+
+## Accessibility
+
+- Respect `accessibilityReduceMotion`.
+- Do not remove or rename controls, labels, focus behavior, or VoiceOver order.
+- If the prompt is focused, scrolling may dismiss the keyboard interactively;
+  hiding the controls must not leave an active hidden text field.
+
+## Testing
+
+- Add native unit coverage for initial visibility, upward hide, downward reveal,
+  near-top reset, jitter tolerance, and inset-normalized offsets.
+- Extend `scripts/ios-canvas-tab.test.mjs` to pin the scroll geometry wiring,
+  permanent title row, collapsible controls region, and Reduce Motion handling.
+- Run the focused Node contract test and the iOS Canvas unit tests or simulator
+  test target available in the repository.
+
+## Scope
+
+This change affects only the native iOS Canvas gallery header. It does not alter
+the desktop/web Canvas composer, artifact generation, persistence, detail view,
+or component annotation behavior.

--- a/docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md
+++ b/docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md
@@ -1,0 +1,174 @@
+# Blaze animated backdrop style — design
+
+- **Date:** 2026-07-23
+- **Bead:** cave-99s9
+- **Branch:** `blaze-backdrop` (worktree `.worktrees/blaze-backdrop`)
+
+## Summary
+
+Add an animated backdrop option to Settings → Appearance → Backdrop: the
+Canvas UI **Blaze** effect (fire sparks, smoke, and glow rising from the
+bottom of the page), rendered behind Home and Chat in the same fixed layer
+the image backdrop uses today. `style` becomes a small extensible option set
+(`"image" | "blaze"`) so future animated effects slot in without another
+schema shape change.
+
+Source component: <https://canvasui.dev/docs/components/blaze>, shadcn
+registry item `https://canvasui.dev/r/blaze-react.json` (`blaze-react`).
+It is a single self-contained React + WebGL2 file with **zero dependencies**.
+The repo does not adopt shadcn scaffolding (no `components.json`, no base
+theme, no new packages) — only the one component file is vendored.
+
+## Decisions (user-confirmed)
+
+1. **Placement:** extend the existing Backdrop system as a *style picker*
+   (Image | Blaze) sharing enablement, intensity, and surfaces — not a
+   separate setting, not tied to specific themes.
+2. **Colors:** derive `smokeColor`/`sparkColor` from the active theme accent
+   so the effect stays coherent across all 21 palettes × 2 modes; the
+   user's playground values are the fallback when the accent cannot be
+   parsed.
+3. **Layering:** under content — same fixed `z-0` layer as the image
+   backdrop; the existing scrim and glass readability floors stay in force.
+4. **Scaffolding:** vendor `Blaze.tsx` only. The shadcn init experiment
+   staged in the primary checkout is discarded after this PR lands.
+
+## Components
+
+### 1. Vendored component — `src/components/canvasui/Blaze.tsx`
+
+- Exact registry payload, then the repo's own design auto-fixer
+  (`pnpm codemod:design`) applied so the design gates pass (verified: it
+  rewrites three static inline style objects to arbitrary-property utility
+  classes; ESLint `coven-design/*` and `codemod:design:check` both green).
+- A short provenance header comment records the source URL and fetch date
+  so future updates can re-diff against upstream.
+- No other edits; the component keeps its own reduced-motion handling,
+  `IntersectionObserver` pause, `ResizeObserver`, and DPR cap (2).
+
+### 2. Preferences — `src/lib/preferences-schema.ts`
+
+- `BACKDROP_STYLES = ["image", "blaze"] as const`;
+  `CaveBackdropPreferences.style: BackdropStyle`, default `"image"`.
+- `normalizeCavePreferences`: `oneOf(backdrop.style, BACKDROP_STYLES, "image")`.
+- Strict patch path: `"style"` added to the backdrop `assertAllowedKeys`
+  list; value validated via the strict-choice helper (unknown values 400).
+- Legacy mirror: `cave:backdrop:v1` JSON gains `style`; the legacy import
+  path reads it back when valid.
+
+### 3. Client store — `src/lib/cave-backdrop.ts`
+
+- `BackdropPrefs.style: BackdropStyle`, `DEFAULT_PREFS.style = "image"`,
+  read/write plumbed through `readAppPreferences`/`updateAppPreferences`
+  like the existing fields.
+
+### 4. Layer — `src/components/cave-backdrop-layer.tsx` + new `src/components/cave-backdrop-blaze.tsx`
+
+- When the effective visual is Blaze (`style === "blaze"`, enabled, and no
+  familiar image override showing), the layer div renders
+  `<CaveBackdropBlaze />` instead of the CSS `background-image`, and the
+  app-image byte fetch is skipped.
+- A familiar's own backdrop image (explicit per-familiar opt-in) still
+  takes over the layer while that familiar is active; per-familiar
+  backdrops remain image-only.
+- While Blaze is the effective visual, the image `accentSeed` is
+  suppressed (`matchAccent: false, accentSeed: null` passed to
+  `applyBackdropToDocument`) — the theme accent *drives* Blaze rather than
+  the backdrop driving the accent.
+- `CaveBackdropBlaze` (client component, loaded via `next/dynamic` with
+  `ssr: false` so the ~22 KB WebGL file stays out of the main bundle):
+  - Skips mounting under `usePrefersReducedMotion()`.
+  - Reads computed `--accent-presence` from `document.documentElement`,
+    parses it with the existing `parseThemeColor` (`theme-contrast.ts`),
+    converts to `[r, g, b]` in 0–1.
+  - **Color recipe (single-token derivation, per the design language):**
+    `smokeColor = accent`;
+    `sparkColor = accent × 0.3 + [0.66, 0.66, 0.66] × 0.7` (per channel,
+    i.e. 70% toward neutral grey) — reproducing the playground's
+    smoke↔spark relationship (vivid smoke, desaturated pale sparks).
+  - **Fallback:** parse failure → the exact playground colors
+    `sparkColor [0.6314, 0.6314, 0.6902]`, `smokeColor [0.5451, 0.3608, 0.9647]`.
+  - All other options exactly as configured in the playground:
+    `height 0.75, distortion 0.5, distortionScale 1, speed 0.5, sparks 0.75,
+    sparkDensity 0.75, sparkSize 0.75, layers 5, smoke 1, glow 0.5`.
+  - Owns a `MutationObserver` on `data-theme`/`data-mode` and re-derives
+    colors live via the instance's `setOptions` (no re-mount) — the effect
+    must look intentional in all 42 theme × mode combinations.
+  - Renders `<Blaze>` with no children: in normal browsers the
+    experimental HTML-in-canvas capture is unsupported, the source canvas
+    stays empty, and the output canvas shows pure fire/smoke/glow — which
+    is exactly the backdrop visual. No content is ever routed through the
+    component.
+
+### 5. CSS — `src/styles/backdrop.css`
+
+- The layer div gains `data-backdrop-style` so CSS can target styles.
+- `.cave-backdrop-blaze` fills the layer (absolute inset 0); the canvas is
+  `aria-hidden` and `pointer-events: none` (from the vendored component),
+  and the layer itself is already `pointer-events: none`.
+- Existing intensity (`--cave-backdrop-opacity` on the layer), the
+  bg-base scrim `::after`, the `data-backdrop-on` glass/translucency
+  contract, and the `prefers-reduced-transparency` hide-rule all apply
+  unchanged — they are style-agnostic.
+- New rule: `@media (prefers-reduced-motion: reduce)` hides the layer when
+  `data-backdrop-style="blaze"` (belt to the component-level skip's
+  suspenders; no frozen fire frame, no GPU spend).
+
+### 6. Settings — `src/components/backdrop-settings.tsx`
+
+- A labeled `Segmented` style picker (Image | Blaze) at the top of the
+  Backdrop card.
+- Choosing **Blaze**: `writeBackdropPrefs({ style: "blaze", enabled: true })`
+  — works with no stored image; announce via `useAnnouncer`.
+- Choosing **Image**: `enabled` becomes `true` iff a stored image exists
+  (otherwise the card shows the chooser and stays off until one is picked).
+- Image chooser, Clear, and "Match accent to the image" rows render only
+  for the Image style; Intensity renders for both styles whenever enabled.
+- Card hint copy updated to cover both styles, following the §10 copy
+  contract (vocabulary, placeholder grammar not applicable here).
+
+## Error handling
+
+- **No WebGL2 / context lost:** `createBlaze` returns `null`; the layer
+  stays quietly empty. No error surface — the backdrop is decorative.
+- **Accent parse failure:** exact playground colors (above).
+- **Reduced motion:** layer hidden + component not mounted.
+- **Offscreen / backgrounded:** the component's own `IntersectionObserver`
+  stops the RAF loop.
+- **Server-side validation:** unknown `style` values rejected by the
+  strict patch path; normalization coerces bad stored values to `"image"`.
+
+## Testing
+
+Repo's node source-contract style, extending existing suites:
+
+- `preferences-schema.test.ts` — style default + normalization, strict
+  patch accepts `"blaze"` / rejects unknown, legacy mirror round-trip.
+- `cave-backdrop.test.ts` — `DEFAULT_PREFS.style`, write plumbing.
+- New contract test (blaze layer) — reduced-motion guard, lazy
+  `next/dynamic` import, playground fallback constants, exact option
+  values, `backdrop.css` reduced-motion rule for the blaze layer.
+- Settings a11y contract — labeled segmented control, announcements.
+- Gates: `pnpm lint` (design ESLint + codemod check),
+  `design-token-drift.test.ts`, app test suite, `pnpm build`.
+
+## Delivery
+
+1. Branch `blaze-backdrop` in `.worktrees/blaze-backdrop`, signed commits,
+   PR to `main`; required checks (Frontend build, Rust check, CodeQL,
+   E2E (Playwright)) green, then squash-merge and delete the branch;
+   remove the worktree; close bead cave-99s9.
+2. **Post-merge cleanup of the primary checkout** (user-approved): discard
+   the staged shadcn experiment — `components.json`, the `globals.css`
+   shadcn theme dump, the `layout.tsx` Inter font change, the
+   `package.json`/`pnpm-lock.yaml` dependency additions, `__shoot2.mjs`,
+   and the staged registry copy of `Blaze.tsx` — then `pnpm install` to
+   prune. `src-tauri/src/sidecar_discovery.rs` and `.beads/*` are left
+   untouched (other sessions' work).
+
+## Out of scope
+
+- Per-familiar Blaze overrides (per-familiar backdrops stay image-only).
+- Additional animated styles (the option set makes room; none ship here).
+- Content heat-distortion via the experimental HTML-in-canvas API (never
+  routed; the backdrop renders fire only).

--- a/docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md
+++ b/docs/superpowers/specs/2026-07-24-analytics-contract-review-design.md
@@ -1,0 +1,99 @@
+# Familiar Analytics: contract review button + empty-results layout
+
+Date: 2026-07-24
+Status: approved (design conversation, this session)
+Surface: `/dashboard/familiars/<id>/analytics`
+
+## Problem
+
+1. **Contract compliance is a dead end.** The analytics "Contract compliance"
+   section (`ContractCompliance` in `src/components/familiar-analytics-content.tsx`)
+   shows the five familiar properties and, for a failing property, the violation
+   messages behind it — but offers no action. The Studio Contract tab already
+   launches a rehabilitation chat from the same failing state; analytics should
+   too instead of stranding the reader.
+2. **Empty results leave holes in the grid.** `.fa-grid`
+   (`src/styles/familiar-analytics.css`) is a two-column grid with
+   `align-items: start`. When one cell in a row is a short empty-state card and
+   its neighbor is tall (e.g. empty "Confidence from thread analysis" next to a
+   full "Recent sessions"), the short card floats at the top of the row leaving
+   a large blank gap beneath it.
+
+## Decisions (from design conversation)
+
+- **Granularity:** one **section-level** review button, shown only when the
+  contract report fails (`report.pass === false`). No per-property buttons —
+  the rehabilitation brief always covers the whole contract, so per-violation
+  buttons would differ only in emphasis.
+- **Launch behavior:** **direct launch** (no confirm modal), matching the
+  Studio Contract tab precedent, not the heal-queue's `ActionModal` flow.
+- **Prompt source:** reuse `buildRehabilitationBrief(familiarName, report)`
+  from `src/lib/familiar-rehabilitation.ts` — the deterministic, unit-tested
+  "Rite of Binding" brief the Studio Contract tab already sends
+  (`familiar-studio-contract-tab.tsx:139`). No new prompt synthesis.
+
+## Design
+
+### 1. Review button in `ContractCompliance`
+
+- `ContractCompliance` gains two props: `familiarName: string` and
+  `onReview: () => void`. It stays presentation-only; the parent owns the
+  launch.
+- When `report && !report.pass`, render after the property grid / detail
+  panel:
+  `<Button variant="primary" size="sm" leadingIcon="ph:sparkle" onClick={onReview}>Review and resolve</Button>`
+  (verb-first action copy, no ampersand — codebase button copy uses none).
+  (`ph:sparkle` is the icon the Studio tab's rehabilitation button uses for
+  this same action; already in `ICON_NAMES`, no icon-subset regeneration).
+  Button is aligned to the start of the column flow (`self-start`-style
+  placement per the section's flex column).
+- Passing reports and `report === null` render exactly as today — no button.
+- Parent (`FamiliarAnalyticsContent`) wires `onReview` to:
+  1. `requestAgentsNewChat({ familiarId: model.familiarId, initialPrompt, origin: "chat" })`
+     where `initialPrompt` is the rehabilitation brief plus the same
+     provenance line the heal-queue's `confirmAction` appends:
+     `\n\nAnalytics source: /dashboard/familiars/<id>/analytics`.
+  2. `announce(...)` via `useAnnouncer` (mutation announcement, per a11y
+     contract), mirroring `confirmAction`'s announce.
+- `familiarName` comes from the existing derivation at
+  `familiar-analytics-content.tsx:1332`
+  (`model.familiar?.display_name ?? model.familiarId`);
+  `buildRehabilitationBrief` already falls back safely for blank names.
+
+### 2. Empty-results layout in `.fa-grid`
+
+- Remove `align-items: start` from `.fa-grid` so cards in the same grid row
+  stretch to equal height (grid default). Bordered cards filling their cells
+  read as intentional; a short card floating over a blank gap does not.
+- Center empty states vertically inside their (now taller) cards with
+  `margin-block: auto` on the two shapes that occur as direct section
+  children:
+  - `.fa-section > .ui-empty-state` (thread-analysis, recent-sessions,
+    contract "no report" — all render `EmptyState` directly)
+  - `.fa-section > .fa-thread-empty` (thread-signals wraps its `EmptyState`)
+- No JSX/order changes. The thread-signals rule "empty state shouldn't claim
+  both columns" (pinned by `src/components/thread-signals-section.test.ts`)
+  is untouched.
+
+## Testing
+
+- Extend the analytics content source-contract test (same style as
+  `familiar-studio-contract-tab.test.ts`): failing report renders the
+  review button wired to `buildRehabilitationBrief` +
+  `requestAgentsNewChat`; passing/null report paths render no button.
+- Pin the two CSS invariants in the analytics CSS contract test surface if
+  one exists; otherwise assert via the source-contract test that `.fa-grid`
+  no longer declares `align-items: start` and the centering selectors exist.
+- Run `src/lib/familiar-rehabilitation.test.ts` and
+  `src/components/thread-signals-section.test.ts` unchanged (behavior pins).
+- Any new test file must be registered in `scripts/run-tests.mjs` SUITES
+  (`check:tests-wired` gate).
+
+## Out of scope
+
+- Per-violation heal-request changes (`familiar-heal-requests.ts` already
+  models contract violations; unchanged).
+- Studio Contract tab (already has the launch; unchanged).
+- The pre-existing off-grid `gap: 18px` in `.fa-grid` (design-gate baseline
+  concern, not this fix).
+- Responsive single-column behavior for `.fa-grid` (none exists today).

--- a/docs/superpowers/specs/2026-07-24-project-setup-from-chat-design.md
+++ b/docs/superpowers/specs/2026-07-24-project-setup-from-chat-design.md
@@ -1,0 +1,166 @@
+# Set up a project from a chat's unregistered folder — design
+
+Date: 2026-07-24
+Status: approved (brainstorm with @BunsDev)
+
+## Problem
+
+A chat can open in a folder that is not a registered Cave project — an
+opener-provided ad-hoc cwd (Code surface hand-offs, launch flows, GitHub
+kick-offs). Today that chat just shows "No project": the folder never groups
+in rails or the Board, and the only path to register it is the generic
+"Add project…" flow, which makes the user re-browse to a directory the chat
+already knows. There is also no in-context way to decide, at registration
+time, which familiar — or which of the familiar's access groups — gets
+access to the new project.
+
+## Goal
+
+When a conversation is opened in a non-registered project location:
+
+1. Offer to create/register that folder as a project, in place.
+2. Explain what registering entails before the user commits.
+3. Let the user pick access preferences for the chat's familiar and for the
+   access groups that familiar belongs to.
+
+## Non-goals
+
+- Registering a familiar's own workspace as a project (bare "No project"
+  chats). Policy: those cwds are never surfaced or re-asserted.
+- Promoting `.worktrees/<branch>` checkouts to standalone projects — they
+  deliberately authorize against their parent project.
+- Any change to grant-mutation security (`requireTrustedHumanGrantMutation`,
+  relayed-approval rejection stays as is).
+- Group membership editing; only project grants on existing groups.
+
+## Eligibility
+
+New pure helper `src/lib/project-setup-offer.ts`:
+
+```ts
+projectSetupCandidateRoot(args: {
+  selection: ChatProjectSelection;   // from resolveChatProjectSelection
+  projects: CaveProject[];
+}): string | null
+```
+
+Returns the normalized root only when ALL hold:
+
+- `selection.projectId === NO_PROJECT_ID` and `selection.unregisteredRoot`
+  is present (the chat actively runs in a known unregistered folder);
+- the root does not map to a registered project (`projectForRoot` misses);
+- the root is not at or below any registered project's `.worktrees/`
+  directory (separator-exact, normalized comparison — same containment
+  discipline as `chat-project-access.ts`).
+
+Consequences: registered-project chats, bare No-project chats (familiar
+workspaces carry no `unregisteredRoot`), and worktree checkouts are all
+excluded. Pure and unit-testable, in the style of `chat-projects.ts`.
+
+## Entry points (chat view)
+
+Both entry points call one `beginProjectSetup(root)`.
+
+1. **Picker row.** `ProjectPickerPopover` gains optional props
+   `registerCurrentRoot?: string` and `onRegisterCurrentRoot?: () => void`.
+   When provided, a row "Register this folder as a project…" (leading
+   `ph:folder-plus`, root as secondary text) renders above the existing
+   "Add project…" row. Wired from the chat composer's project chip and the
+   session-header kebab picker whenever the candidate root is non-null.
+
+2. **Dismissible banner.** An inline notice above the composer when the
+   candidate root is non-null and not dismissed: "This chat runs in
+   `<leaf>`, which isn't a registered project." with a **Set up as
+   project…** button and a dismiss ✕. Dismissal persists in
+   `localStorage` under `cave:project-setup-dismissed:<normalized-root>` —
+   per folder, so the same folder never re-nags across chats; the picker
+   row remains the persistent affordance. Banner uses design-language
+   tokens only, `.focus-ring` on both controls, color never the only
+   channel.
+
+## Setup modal
+
+New `ProjectSetupModal`, built on `components/ui` `Modal` (focus trap +
+focus return come with it), `useAnnouncer()` for completion.
+
+- **Header:** "Set up project"; folder path as subtitle.
+- **Explainer:** "Registering makes this folder a project across the
+  Cave — it shows up in project pickers, the Board, and chat rails.
+  Familiars can only work in a project after you grant access; choose who
+  starts with access below. Everything here can be changed later in
+  Projects and Permissions."
+- **Fields:**
+  1. **Name** — text, prefilled `projectNameForRoot(root)`.
+  2. **Color** — the swatch row from `project-settings-modal`, extracted
+     into a shared piece (not duplicated).
+  3. **GitHub repository** — optional; prefilled when the folder's git
+     `origin` remote normalizes to a GitHub URL (see server addition);
+     server-side validation stays `normalizeGitHubRepoUrl`.
+  4. **Familiar access** — "`<Familiar name>`'s access": No access / Read /
+     Write; default **Write** (the chat needs to keep running here). If the
+     familiar is Supreme: static "has access to every project", no grant
+     call.
+  5. **Group access** — one row per access group whose
+     `memberFamiliarIds` contains the chat's familiar: group name, member
+     count, No access / Read / Write (default **No access**), helper
+     "Applies to every member." Section hidden when the familiar belongs
+     to no groups. Groups come from the existing `GET /api/project-grants`
+     payload (`accessGroups`).
+- **Footer:** Cancel / **Create project** (busy label "Creating…").
+
+## Submit sequence
+
+All requests fire from the direct human click (satisfies
+`requireTrustedHumanGrantMutation` / relayed-approval rejection):
+
+1. `createProject(name, root, { emitMutation: false, color, repoUrl })` —
+   `CreateProjectOptions` in `chat-add-project.ts` extends with optional
+   `color` and `repoUrl`; `use-projects` threads them into the
+   `POST /api/projects` body (the API already accepts both).
+2. If familiar access ≠ none and familiar is not Supreme:
+   `POST /api/project-grants { targetFamiliarId, projectId, access }`.
+3. For each group with level ≠ none:
+   `PATCH /api/access-groups/<id>` with `projectGrants` = the group's
+   existing grants ∪ `{ projectId, access }` (replace an existing entry for
+   the same projectId rather than duplicating).
+4. `emitProjectRegistryMutation()` exactly once, then `onAdded(projectId)`
+   → the chat's `projectIdDraft` rescopes to the new project,
+   `reloadProjects()`, announce "Project created."
+
+**Partial failure:** if creation succeeded but a later step failed, the
+modal stays open with an inline error naming the failed step; retry passes
+`existingProjectId` so no duplicate project is created (mirrors
+`addChatProject`'s two-step semantics and its partial-mutation emit).
+
+## Server addition: git-remote probe
+
+`GET /api/changes?projectRoot=<abs>&remote=1` →
+`{ ok: true, remoteUrl: string | null }`, implemented with the route's
+existing `execFile` discipline (`git config --get remote.origin.url`, no
+shell). Containment is unchanged: an eligible ad-hoc root is by definition
+a daemon session root (the chat runs there), so the route's existing
+`resolveWithinSessionRoots` fallback already admits it. Missing remote or
+non-repo → `remoteUrl: null`. The modal probes once on open; a failed
+probe leaves the field blank and never blocks.
+
+## Testing
+
+1. `src/lib/project-setup-offer.test.ts` — eligibility matrix: ad-hoc root
+   ✓; registered root ✗; `.worktrees/` child ✗; bare No-project ✗;
+   normalization (trailing slash, backslashes).
+2. `src/components/project-setup-modal.test.ts` — source-shape: explainer
+   copy, defaults (familiar write, groups none), Supreme skip, submit
+   ordering (create → grant → group patches → single emit),
+   `existingProjectId` retry, focus/announcer wiring.
+3. `chat-view.test.ts` / `project-picker.test.ts` additions — banner gated
+   on candidate root + localStorage dismissal; picker row only when
+   `registerCurrentRoot` is provided.
+4. `chat-add-project.test.ts` / `use-projects` coverage — `color`/`repoUrl`
+   ride the create POST body.
+5. `src/app/api/changes` route test — `remote=1` returns the origin URL,
+   absent remote → null, containment intact.
+
+Gates: `pnpm lint` (design ESLint suite) plus targeted `node --test` on the
+touched suites. `ph:folder-plus` is not yet in `ICON_NAMES` (verified): add
+it and regenerate the icon subset (`node scripts/generate-icon-subset.mjs`),
+committing the regenerated subset in the same PR.

--- a/docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md
+++ b/docs/superpowers/specs/2026-07-24-sidepanel-peel-reveal-design.md
@@ -1,0 +1,230 @@
+# Sidepanel peel-reveal (collapsed nav) — design
+
+- **Date:** 2026-07-24
+- **Bead:** cave-3vgd
+- **Branch:** `peel-sidepanel-reveal` (worktree `.worktrees/peel-sidepanel-reveal`)
+
+## Summary
+
+Progressive enhancement for the collapsed left sidepanel: when the desktop
+nav sits at its 56px icon rail, moving the cursor toward the left edge of
+the detail pane **peels the page back like paper** (WebGL page-curl),
+revealing the sidebar underneath; reaching the rail hands off to the
+existing interactive frosted hover-peek at the same 232px, so the revealed
+sidebar "becomes real". The effect renders only on browsers with Chromium's
+experimental **HTML-in-canvas** API (`drawElementImage` + `requestPaint` +
+`layoutsubtree`); everywhere else — the Tauri desktop shell (WKWebView),
+Safari, Firefox, stock Chrome — behavior and DOM cost are unchanged.
+
+Source component: Canvas UI **Peel**, shadcn registry item
+`@canvas-ui/peel-react` (`components/canvasui/Peel.tsx`, single
+self-contained React + WebGL2 file, zero dependencies, same author and
+license as the already-vendored `Blaze.tsx`). Per the Blaze precedent the
+repo does **not** adopt shadcn scaffolding — the install uses a transient
+`components.json` that is deleted before commit; only the component file is
+vendored.
+
+## Decisions (user-confirmed)
+
+1. **Strategy: progressive enhancement.** The existing rail hover-peek
+   (`navPeeking` / `shell-nav--peek`) remains the functional, interactive
+   reveal path everywhere. The peel is a purely decorative additive layer.
+2. **Approach A:** cursor-driven peel on the detail pane with the sidebar
+   as the `under` layer — not a replacement for the peek (rejected: `under`
+   is never clickable), not install-only.
+3. **Install via `npx shadcn@latest add @canvas-ui/peel-react`** (verified
+   working against a minimal non-Tailwind `components.json`; the registry
+   item pins its target to `components/canvasui/Peel.tsx`). The
+   `components.json` is transient and removed before commit.
+4. **Options:** `side="left"`, `mode="cursor"` (progressive curl as the
+   pointer nears the edge), `reveal: 232` (matches the peek overlay width),
+   `zone: 120` (narrower than the 200 default so casual mouse travel does
+   not trigger it), `shineColor: "auto"` (follows theme — must look
+   intentional across all 21 palettes × 2 modes), remaining options at
+   vendor defaults.
+
+## Components
+
+### 1. Vendored component — `src/components/canvasui/Peel.tsx`
+
+- Exact registry payload, then the repo's design auto-fixer
+  (`pnpm codemod:design`) applied once. Verified against the payload: it
+  reports exactly 4 static inline style objects (under layer, native
+  content wrapper, fallback content wrapper, output canvas) which the
+  codemod rewrites to arbitrary-property utility classes — the same
+  mechanical treatment `Blaze.tsx` received. ESLint `coven-design/*` and
+  `codemod:design:check` both green afterward; the container's
+  `style={{ position: "relative", ...style }}` spread is runtime-derived
+  and allowed.
+- A short provenance header comment records the source registry URL and
+  fetch date so future updates can re-diff against upstream.
+- No other edits (vendor-verbatim, per cave-kbh1 precedent). The existing
+  `src/components/canvasui/UPSTREAM_LICENSE.txt` (MIT + Commons Clause,
+  same upstream author) already covers the directory; no license change.
+- Component facts the design relies on: `supported` is probed via
+  `useSyncExternalStore` with a `false` server snapshot (SSR-safe); when
+  not native it renders children in a plain fallback wrapper with no
+  canvases active; `under` is rendered only in native mode; the output
+  canvas is `aria-hidden` + `pointer-events: none`; a `ResizeObserver`
+  keeps geometry current; `setOptions` applies live option changes without
+  re-mount.
+
+### 2. Wrapper — `src/components/shell-peel-reveal.tsx` (new)
+
+Client component modeled on `cave-backdrop-blaze.tsx`:
+
+- `const Peel = dynamic(() => import("@/components/canvasui/Peel"), { ssr: false })`
+  — the ~22 KB WebGL file stays out of the main bundle and off the network
+  for every non-enhanced environment.
+- **Local support probe** (3-line `drawElementImage`/`requestPaint` check
+  behind `useSyncExternalStore`, server snapshot `false`) duplicated in the
+  wrapper so the probe itself never imports the vendored module.
+- `usePrefersReducedMotion()` — reduced motion is **never enhanced**: no
+  peel, no WebGL, no vendored download.
+- Props: `{ active: boolean; under: ReactNode; children: ReactNode }`.
+- **Non-enhanced path** (`!supported || reducedMotion` — every current
+  production environment): children render inside
+  `<div className="shell-peel-reveal shell-peel-reveal--plain">` with
+  `display: contents`, contributing zero layout impact. The wrapper element
+  is structurally stable; children are never re-parented by `active`
+  toggling. (A mid-session reduced-motion change re-parents once — rare,
+  accepted; Blaze unmounts similarly.)
+- **Enhanced path** (`supported && !reducedMotion`): `<Peel>` is mounted
+  **permanently** (not gated on `active`) so ⌘B / rail toggles never
+  re-parent the detail tree. `active` switches the option set instead:
+  `{ reveal: 232, zone: 120 }` when the rail is collapsed vs
+  `{ reveal: 0, zone: 0 }` when the nav is open — geometry collapses to
+  nothing via the vendor's live `setOptions`. Zero-value behavior is
+  asserted during implementation on a flag-enabled Chromium (see Testing);
+  if zeroing proves visually leaky, fall back to CSS
+  `visibility: hidden` on the output canvas via a wrapper class — vendor
+  file still untouched.
+- **`under` layer:** rendered only while `active`; wrapped in
+  `<div className="shell-peel-under" aria-hidden inert>` so the duplicate
+  nav render is invisible to AT, unfocusable, and non-interactive. Backed
+  by opaque `var(--bg-raised)` with a `var(--border-hairline)` right edge,
+  232px wide — visually congruent with the peek overlay that takes over.
+- **Scroll contract:** in enhanced mode the vendor's native content wrapper
+  is `overflow: hidden`, so the wrapper adds its own inner
+  `<div className="shell-peel-scroll">` reproducing `.shell-detail`'s
+  scroll behavior (`height: 100%; overflow-y: auto; display: flex;
+  flex-direction: column; min-height: 0`) around children. In the plain
+  path this div also renders (stable tree) but as `display: contents`, so
+  today's scroll behavior is byte-identical.
+- **WebGL context-loss recovery:** capture-phase `webglcontextlost`
+  listener on the wrapper bumps a `key` epoch to re-mount the vendored
+  component, capped at `MAX_CONTEXT_RESTARTS = 3` — copied from
+  `cave-backdrop-blaze.tsx` (cave-kbh1).
+
+### 3. Shell wiring — `src/components/shell.tsx`
+
+Inside `<main className="shell-detail">`, wrap the existing children
+(banner triggers, `ShellBannerStrip`, `DetailSplitHost`):
+
+```tsx
+<ShellPeelReveal active={navPeekEnabled} under={nav}>
+  …existing children…
+</ShellPeelReveal>
+```
+
+- `navPeekEnabled` is the existing derivation
+  (`navPolicy === "remembered" && !isMobile && !navOpen`) — the peel arms
+  exactly when the interactive hover-peek is armed. No new state, no
+  changes to the peek's handlers, classes, or CSS.
+- `nav` is the same node the nav `<aside>` renders; the duplicate render
+  exists only in enhanced+active mode and sits inert. Any `id` collisions
+  from the duplicate are mitigated by `inert` + `aria-hidden` (decorative
+  clone); audited during implementation for observable breakage (e.g.
+  `aria-labelledby` targets resolving to the clone).
+
+### 4. CSS — `src/styles/globals/shell-navigation.css`
+
+Tokens only; no new colors, no off-grid values:
+
+```css
+.shell-peel-reveal--plain,
+.shell-peel-reveal--plain > .shell-peel-scroll { display: contents; }
+.shell-peel-reveal--live { flex: 1; min-height: 0; position: relative; }
+.shell-peel-reveal--live .shell-peel-scroll { height: 100%; overflow-y: auto;
+  display: flex; flex-direction: column; min-height: 0; }
+.shell-peel-under { position: absolute; inset: 0 auto 0 0; width: 232px;
+  background: var(--bg-raised); border-right: 1px solid var(--border-hairline); }
+```
+
+(Exact selectors settle during implementation; the contract is: plain mode
+is layout-invisible, live mode reproduces `.shell-detail`'s scroll, the
+under backing is opaque `--bg-raised` + hairline, width matches the 232px
+peek overlay.)
+
+## Interaction & accessibility
+
+- The peel is **decorative only**: output canvas `pointer-events: none`,
+  under layer `inert` + `aria-hidden`. Keyboard, screen-reader, and click
+  behavior are identical in all modes; opening the sidebar remains rail
+  hover-peek / rail click / ⌘B.
+- `prefers-reduced-motion: reduce` → non-enhanced path entirely (the
+  motion story is "no motion").
+- `prefers-reduced-transparency` is unaffected: the under backing is
+  already opaque; the peek overlay's existing opaque fallbacks stay in
+  force.
+- Color is never the only channel for anything (nothing is communicated by
+  the peel that the peek doesn't also communicate interactively).
+
+## Error handling
+
+- **Probe false / SSR:** plain path; server HTML never contains canvases.
+- **`createPeel` returns null** (no WebGL2 despite probe): vendor sets
+  `failed`, renders the children fallback; wrapper stays live-classed —
+  content still visible and scrollable via `.shell-peel-scroll`; one-time
+  re-parent accepted on this exotic path.
+- **Context lost:** epoch re-mount, ≤ 3 attempts, then quietly plain
+  (matches Blaze).
+- **Split/secondary tiles, banners:** all live inside `children` and peel
+  together as one sheet — no per-surface special cases.
+
+## Testing
+
+Repo's node source-contract style:
+
+- New `src/components/sidepanel-peel-reveal.test.ts`:
+  - `shell.tsx` wires `<ShellPeelReveal active={navPeekEnabled} under={nav}>`
+    inside `shell-detail`, and the existing peek regexes
+    (`sidepanel-nav-peek.test.ts`) remain untouched/green.
+  - Wrapper contract: `dynamic(..., { ssr: false })`, local probe with
+    `false` server snapshot, `usePrefersReducedMotion` gate, permanent
+    mount + option-zeroing on `active` (never conditional-mount on
+    `active`), `inert` + `aria-hidden` under layer, context-loss epoch cap.
+  - Vendored file: provenance header present; codemod-clean (the 4
+    rewritten style objects stay as utility classes).
+  - CSS contract: plain mode `display: contents`; live scroll rule;
+    under-layer tokens.
+- Gates: `pnpm lint` (codemod check + design ESLint), app test suite
+  (includes `design-token-drift.test.ts`), `pnpm test:bundle`,
+  `pnpm build`; PR required checks (Frontend build, Rust check,
+  E2E (Playwright), Cross-environment required, Sidecar runtime required,
+  CodeQL).
+- **Manual native-path verification:** Chromium with
+  `--enable-experimental-web-platform-features` (HTML-in-canvas): peel
+  renders and follows the cursor at the left edge when collapsed; nav-open
+  zeroing shows no residual effect; hand-off into the frosted peek reads
+  continuous; theme swap re-tints the shine; no Playwright automation of
+  the flag path in CI (out of scope).
+
+## Delivery
+
+1. Transient `components.json` → `npx shadcn@latest add
+   @canvas-ui/peel-react` → delete `components.json` → provenance header →
+   `pnpm codemod:design` → commit vendored file.
+2. Wrapper, shell wiring, CSS, and contract test; signed commits; PR to
+   `main`; required checks green; squash-merge; delete branch; remove
+   worktree; close bead cave-3vgd.
+
+## Out of scope
+
+- Replacing or restyling the frosted hover-peek (it remains the only
+  interactive reveal).
+- `mode="hover"` full-snap variant (rejected as approach B).
+- Peeling the list pane or any other edge/surface.
+- Enabling the effect in the Tauri shell (WKWebView lacks the API).
+- Committed shadcn scaffolding or new runtime dependencies.
+- CI automation of the experimental-flag browser path.

--- a/docs/superpowers/specs/2026-07-27-memories-sidebar-collapse-design.md
+++ b/docs/superpowers/specs/2026-07-27-memories-sidebar-collapse-design.md
@@ -1,0 +1,36 @@
+# Memories sidebar collapse
+
+## Goal
+
+Let people reclaim width in the Memories (`GrimoireView`) workspace without
+making its navigator unavailable.
+
+## Interaction
+
+- The navigator remains expanded by default, exactly as it is today.
+- A labelled, keyboard-accessible toggle at the top of the navigator collapses
+  it only after an explicit click.
+- Collapsed state reduces the navigator to a narrow icon rail. The existing
+  source groups remain reachable through their icons; each control retains an
+  accessible name and a tooltip.
+- Expanding restores the full navigator. The preference is stored locally and
+  safely falls back to expanded if storage is unavailable or malformed.
+- Narrow-container behavior remains unchanged: the existing detail/graph rules
+  continue to own the available width.
+
+## Implementation boundary
+
+Keep the change within `src/components/grimoire-view.tsx` and its existing
+source-pinned test. Use the existing `ph:sidebar-simple` icon, design tokens,
+focus-ring utility, roving navigation convention, and container-query layout.
+Do not change document loading, selection, search, or the current per-section
+collapse preferences.
+
+## Verification
+
+- Add a failing source-pinned test for the whole-rail preference, accessible
+  toggle, collapsed rail semantics, and the preserved responsive rule.
+- Run that focused test red, implement the smallest behavior, then rerun it
+  green.
+- Run the relevant component test group and `pnpm lint` if the touched
+  Tailwind/design rules require it.

--- a/docs/superpowers/specs/2026-07-28-streamed-chat-activity-design.md
+++ b/docs/superpowers/specs/2026-07-28-streamed-chat-activity-design.md
@@ -1,0 +1,64 @@
+# Streamed chat activity design
+
+## Goal
+
+Make an assistant turn explain its live work without interrupting the answer:
+thinking streams in a compact inline disclosure, and adjacent repeated tool
+calls become one expandable run with an honest call count.
+
+## Existing contracts retained
+
+- `/api/chat/send` and persisted `ToolEvent` data stay unchanged.
+- `splitReasoning()` continues to strip complete and partial `<thinking>` /
+  `<reasoning>` tags from visible prose while a turn streams.
+- `segmentTurn()` remains the chronology boundary. A tool run can only be
+  grouped within one tool segment; it never crosses an assistant text span.
+- Structured edit cards remain individual, actionable items and are excluded
+  from rollups.
+
+## Interaction
+
+### Streamed thinking
+
+When a pending assistant turn contains reasoning, render the reasoning
+disclosure before the visible answer. It is open while pending, identifies the
+activity as “Thinking”, and updates as chunks arrive. Once the turn settles it
+returns to the normal collapsed state, except when the existing global “Show
+thinking” preference is enabled. The body remains formatted with `RichText`.
+
+### Consecutive tool runs
+
+Partition each chronological tool segment into maximal consecutive runs of the
+same normalized tool name. A run of one call keeps the existing `ToolBlock`.
+A run of two or more calls renders one `ToolRunGroup` disclosure whose summary
+uses the exact display name and the count, for example `Read · 3 calls`.
+Opening it renders every existing `ToolBlock`, preserving all inputs, output,
+status, duration, file actions, and error treatment.
+
+The group boundary is intentionally strict: prose, a progress event, a
+different tool name, a structured edit, or a non-adjacent segment ends the
+run. This avoids claiming unrelated activity was one action.
+
+### Completed turns
+
+The existing completed-turn work line continues to summarize all non-edit
+activity. Its expanded content uses the same run presentation, so users see
+the same grouping whether they open a completed work line or watch the turn
+stream.
+
+## Visual and accessibility contract
+
+- Reuse `cave-tool-summary`, `cave-tool-block`, semantic tokens, existing
+  disclosure chevron, and `.focus-ring` behavior; add only tokenized layout
+  rules required for a nested run.
+- The group summary has a clear accessible name containing its tool and call
+  count. Native `<details>/<summary>` supplies keyboard interaction and
+  expanded/collapsed semantics.
+- Existing reduced-motion behavior remains unchanged; no new animation is
+  required.
+
+## Verification
+
+Focused source tests must prove the run partitioning and each render path,
+including the live-thinking open state and settled collapse behavior. The
+chat-polish suite and the project lint/type checks then validate integration.

--- a/docs/superpowers/specs/2026-07-29-chat-follow-up-intent-design.md
+++ b/docs/superpowers/specs/2026-07-29-chat-follow-up-intent-design.md
@@ -1,0 +1,134 @@
+# Chat follow-up intent design
+
+**Status:** approved for implementation review  
+**Date:** 2026-07-29  
+**Surface:** chat transcript and composer
+
+## Problem
+
+Chat follow-ups currently arrive as bare lines in a `<coven:next-paths>` trailer.
+The renderer turns every line into an indistinguishable pill whose click sends
+text immediately. That collapses very different user intents—continuing a
+conversation, creating a task, or opening a review surface—into one surprising
+chat-send action.
+
+## Decision
+
+Replace bare next-path pills with typed follow-up cards. The assistant declares
+the intent in the existing trailer; Cave owns the interpretation, visible
+affordance, and side-effect boundary.
+
+### Structured trailer
+
+The directive asks for one of these forms:
+
+```text
+<coven:next-paths>
+- [reply] Ask Jules to verify the rollout plan
+- [task] Create a task for the accessibility fixes
+- [action:open-changes] Review the edited files
+</coven:next-paths>
+```
+
+The supported intent set is deliberately small:
+
+| Intent | Meaning | Result on activation |
+| --- | --- | --- |
+| `reply` | A conversational next message. | Put the recommendation into the composer for editing; never send it directly. |
+| `task` | Captured work that belongs in Tasks. | Open a prefilled, conversation-linked task review. The user explicitly creates the task from that review. |
+| `action:<id>` | A named, non-arbitrary in-app destination or action. | Resolve only a registered client-side action. Mutating actions require their existing confirmation or review step. |
+
+Plain legacy lines remain valid and parse as `reply`. An unknown intent,
+malformed bracket prefix, unknown action identifier, or incomplete streaming
+line is harmless: it becomes an editable reply or remains hidden until safe to
+render. No model-produced string can choose an arbitrary command, route, or
+side effect.
+
+### Shared card surface
+
+`FollowUpCards` will render the same semantic item in both existing locations:
+
+1. The latest settled assistant turn's row directly above the composer.
+2. Historical assistant-turn rows, where they are not suppressed as the active
+   composer row.
+
+The group has the persistent label **Suggested next steps**. Each card has an
+icon, visible type label (**Reply**, **Task**, or **Action**), imperative title,
+and one-line outcome cue:
+
+- Reply: “Drafts a reply below”
+- Task: “Opens a linked task review”
+- Action: names its actual destination, such as “Opens Changes”
+
+The assistant's first item is marked **Recommended** separately from its type.
+That marker combines text with the existing success-derived treatment; color is
+never the only signal. Cards use the existing semantic tokens, `--space-*`
+grid, card/control radii, `.focus-ring`, and a 1–2 column container-query
+layout. The compact card form must stay readable in narrow panes and mobile.
+
+### Interaction boundaries
+
+- Reply activation updates the composer draft and focuses it, preserving the
+  existing edit-before-send expectation.
+- Task activation opens a review built from the existing chat-to-task handoff
+  context: current session, familiar, project, source turns, and assistant
+  suggestion. Creating is a separate explicit control in that review.
+- Action activation only routes through a static allowlist owned by the chat
+  surface. A registered navigation action may open its target directly;
+  state-changing actions retain their owning flow's confirmation.
+- Success and failure states use the existing announcer and exact action copy.
+  Focus returns to the activating card when a review closes without creating.
+
+## Architecture
+
+`src/lib/next-paths.ts` becomes the source of truth for a typed `NextPath`
+model, parser, and revised assistant directive. The model has a display label,
+intent, optional registered action id, and the source prompt/title. It remains
+pure and streaming-safe.
+
+`chat-view.tsx` consumes that model instead of raw strings and sends activation
+through one intent router. The router delegates task review/creation to the
+existing chat-task handoff helpers rather than inventing a second board write.
+The component owns its rendering and accessibility; its CSS belongs beside the
+current chat next-path rules and uses only the design-token contract.
+
+Other consumers that only strip trailers continue to use `extractNextPaths(...)
+.visible`; their behavior is unchanged. Consumers that render suggestions (for
+example group chat and compact quick chat) are audited explicitly: they must
+either adopt typed cards with safe routing or intentionally render reply-only
+suggestions. No consumer may continue to treat a task/action item as text to
+send.
+
+## Error handling and accessibility
+
+- Partial trailer control text never appears in assistant prose.
+- Unsupported cards explain that the action is unavailable and offer the safe
+  reply route; they do not silently trigger an unrelated operation.
+- Cards are native buttons with type-and-result accessible names. The group is
+  labelled; the recommended state is spoken; keyboard focus is visible.
+- The task review is focus-trapped and restores focus on cancellation. Task
+  creation and failures announce their outcome.
+- Any recommendation motion honors `prefers-reduced-motion`; no new movement
+  is required to understand the state.
+
+## Verification
+
+1. Pure parser tests cover legacy lines, every typed intent, unknown/malformed
+   input, action-id allowlist boundaries, over-limit input, and partial streams.
+2. Component tests prove type labels, outcome cues, accessible names, duplicate
+   suppression, and each activation route.
+3. Task tests prove the review receives the chat handoff context and no board
+   write happens before explicit creation.
+4. Design gates cover token-only styling, lint/codemod drift, typecheck, and
+   the relevant app suite wiring.
+5. A real desktop and narrow-pane/Tauri smoke verifies reply drafting, task
+   review/cancel/create, action routing, dark/light plus a non-default theme,
+   keyboard focus, and reduced-motion behavior.
+
+## Non-goals
+
+- Letting assistants define arbitrary executable actions.
+- Replacing existing board task storage or chat-to-task audit fields.
+- Adding a user-facing mode selector for every follow-up.
+- Changing non-chat consumers beyond the audit needed to keep their semantics
+  safe.

--- a/docs/superpowers/specs/2026-07-29-mobile-live-voice-design.md
+++ b/docs/superpowers/specs/2026-07-29-mobile-live-voice-design.md
@@ -1,0 +1,112 @@
+# Mobile live voice calls
+
+## Goal
+
+Add a live voice-call action to a direct iOS chat without changing the existing
+composer dictation action. A call opens in a compact bottom sheet and can expand
+into a transcript-first full-screen view.
+
+## Scope
+
+- Direct chats only in this increment.
+- OpenAI Realtime is the full-duplex path for familiars configured with the
+  `openai` voice provider.
+- Apple-native voice is a separate, clearly labeled, turn-based call mode using
+  `Speech` recognition, `AVAudioSession`, and `AVSpeechSynthesizer`.
+- The sheet displays final and partial user/assistant transcript rows. It
+  expands when the user asks for focused reading; it returns to the existing
+  chat when dismissed.
+- Dictation remains the composer microphone and only edits the unsent draft.
+
+## Non-goals
+
+- Do not describe Apple-native voice as full-duplex or Realtime.
+- Do not add group-call fan-out, background calling, CallKit integration, call
+  recording, or voice settings editing.
+- Do not send provider API keys or long-lived credentials to iOS.
+- Do not make local, familiar, Gemini, or ElevenLabs voice loops part of this
+  first implementation.
+
+## Architecture
+
+`VoiceCallCoordinator` owns one call lifecycle and exposes a small observable
+state model: `idle`, `requestingPermission`, `connecting`, `listening`,
+`speaking`, `muted`, `ended`, and `failed`. It owns the audio session and is
+the only code allowed to start or stop a call microphone.
+
+`VoiceCallSheet` renders the compact call controls and transcript. Its expand
+control presents `VoiceCallTranscriptView` full-screen using the same
+coordinator, so a call never reconnects merely because the operator changes
+presentation.
+
+The chat toolbar gets a phone action only for direct chats. Tapping it presents
+the call sheet in a pre-connect state with explicit modes: `Realtime` is
+enabled only when the familiar reports the `openai` voice provider, while
+`Native voice` is available for every connected direct chat. The selected mode
+starts only after the operator taps its explicit call action; a Realtime error
+never silently falls back to Native voice. The composer keeps its existing
+dictation action and continues to operate independently when no call is active.
+
+The iOS `Familiar` model decodes the already-published `voiceProvider`,
+`voiceModel`, and `voiceName` roster fields solely to determine mode
+availability and accessible labels. It does not receive provider credentials.
+
+### OpenAI Realtime path
+
+1. iOS creates or resolves the direct-chat server session using existing chat
+   ownership rules.
+2. iOS posts only `familiarId` and `sessionId` to `/api/voice/session` using
+   the paired mobile credential.
+3. The desktop resolves the vault key, hydrates familiar instructions and
+   conversation seed, and returns a short-lived OpenAI Realtime grant.
+4. An iOS WebRTC adapter exchanges SDP with the grant URL, sends microphone
+   audio, plays inbound audio, and maps provider events into transcript rows.
+5. Ending the call closes the peer connection, stops audio, and leaves the
+   ordinary chat thread intact. Final transcript persistence must use one
+   explicit path so it never duplicates a provider-persisted turn.
+
+SwiftUI does not provide `RTCPeerConnection`; the implementation therefore
+adds a vetted iOS WebRTC package rather than attempting to emulate Realtime
+over the deprecated WebSocket protocol.
+
+### Apple-native path
+
+Apple-native voice uses the app's existing `Speech` permission pattern, an
+exclusive call audio session, and `AVSpeechSynthesizer` output. It is a
+turn-taking loop:
+
+1. Listen for a final spoken user turn.
+2. Append that turn through `ChatThread.send` so ordinary chat persistence and
+   streaming remain authoritative.
+3. Render the assistant stream in the call transcript.
+4. Speak only completed assistant text, then return to listening.
+
+The sheet labels this mode `Native voice` and describes its turn-based behavior
+in accessible status text. It never claims to be a live Realtime conversation.
+
+## Safety and failure handling
+
+- Request microphone and speech permissions before starting either path; deny
+  cleanly with a retryable explanation.
+- Use an audio session appropriate for two-way audio, deactivate it on every
+  terminal state, and stop promptly for interruptions, route changes, and
+  app-background transition.
+- Map `/api/voice/session` errors to the route's existing actionable hints;
+  do not surface vault values or ephemeral secrets in UI, logs, or tests.
+- Disable Realtime, with an explanatory label, when the familiar's provider is
+  not OpenAI; Native voice remains an explicit available mode.
+- Finalize or discard partial transcript rows explicitly on disconnect so a
+  partial string is never persisted as a user or assistant chat message.
+
+## Verification
+
+- Pure Swift tests cover state transitions, permission denial, mute/end,
+  transcript ordering, partial-final replacement, audio interruption cleanup,
+  and native turn handoff.
+- API tests prove the mobile call request carries only familiar/session IDs and
+  the returned grant never contains the provider key.
+- UI tests prove dictation and phone-call controls remain distinct, the sheet
+  expands without reconnecting, and unsupported/group chats cannot start a
+  call.
+- Generate the Xcode project from `project.yml`, run focused iOS tests, then
+  run the relevant JavaScript API/app gates and a diff check.

--- a/docs/superpowers/specs/2026-07-29-tasks-multi-familiar-grouping-design.md
+++ b/docs/superpowers/specs/2026-07-29-tasks-multi-familiar-grouping-design.md
@@ -1,0 +1,31 @@
+# Tasks multi-familiar grouping
+
+## Problem
+
+The Tasks header currently shows its **Familiar** grouping option whenever
+`activeFamiliarId` is `null`. That state represents both **All familiars** and a
+multi-familiar shell selection, so the page exposes redundant familiar chrome
+while the shell is already providing the only scope the user selected.
+
+## Design
+
+Treat the shell's selected-familiar set as the source of truth. The Tasks and
+Gantt grouping controls show **Familiar** only when
+`scopeFamiliarIds.size > 1`. They hide it for the unscoped **All familiars**
+state and for a single selected familiar.
+
+If a persisted grouping preference is `familiar` while the control is hidden,
+Tasks renders the existing safe fallback:
+
+- status grouping for Kanban and Table
+- project grouping for Gantt
+
+Task filtering, task assignment controls, and the shell familiar switcher do
+not change.
+
+## Verification
+
+Extend the existing Tasks familiar-scope source-contract test to pin the shared
+multi-selection predicate, both conditional controls, and both persisted-value
+fallbacks. Run that focused test first, then the relevant app, type, and design
+gates.


### PR DESCRIPTION
Beads cite `docs/superpowers/` as the authoritative approved design for a piece of work. **That path was gitignored**, so `git add` dropped those files with no error and no untracked-file noise. The design died with the authoring machine while the bead kept pointing at it as if it were durable.

## Four approved designs are already lost

I searched before changing anything, and they're unrecoverable:

| Where I looked | Result |
|---|---|
| Filesystem, all 17 worktrees | absent |
| `git log --all` for each path | **0 commits** |
| All reachable objects | **0 matches** |
| Every stash | absent |

`cave-21rp` is the compounding case — its branch was never pushed either, so **both the design and the implementation are gone**, while the bead still reads *"approved design and plan, in progress"*. That bead is at zero; someone should correct its status before a fresh owner picks it up expecting a foundation.

## Why it was easy to miss

**27 files under that path were already tracked.** They predate the ignore rule, and tracked files stay tracked regardless — so the directory looked versioned while every *new* file was dropped. Just over half tracked, the rest silently discarded, no error either way.

## Why no split was needed

The bead flagged checking whether the rule protects scratch or bulk agent output. It doesn't: the directory is **100% markdown** — 50 files, 884K, `specs/` and `plans/` only, largest file 84K. Negligible beside a repo shipping a 377MB standalone bundle.

The separate `/.superpowers` rule (the tool's actual scratch dir) **stays ignored**. The two were likely added as a pair without distinguishing documents from scratch.

## Verified both directions

Not assumed:

- a probe under `docs/superpowers` now reports as **untracked** where it previously vanished
- a probe under `.superpowers` is still caught by `.gitignore` line 101

Commits the **23 files** the rule had been dropping (8,429 lines). App suite **1013/1013**.

## What this does not do

It stops the bleeding; it doesn't recover what's gone. The bead's **option 3** — copying approved designs into the bead's Dolt-synced `DESIGN` field — is still worth doing, since a design living only in one laptop's git checkout is one lost machine away from gone. Left for a follow-up rather than bundled here.

Closes cave-8zjr5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)