### PR TITLE
docs: replace a hard-coded home directory with the placeholder the README already uses

### DIFF
--- a/.agents/skills/run-cave-app/SKILL.md
+++ b/.agents/skills/run-cave-app/SKILL.md
@@ -20,7 +20,7 @@ The primary checkout often has another live session's uncommitted work and concu
 - **`cd` ONLY into the path `add` just created**, and sanity-check `HEAD`.
 
 ```bash
-MAIN=/Users/buns/Documents/GitHub/OpenCoven/coven-cave
+MAIN=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git -C "$MAIN" worktree prune                        # drop stale entries from crashed runs
 # Pick a name that is neither an existing dir nor a registered worktree.
 WT=""; for _ in 1 2 3 4 5; do

--- a/.claude/skills/run-cave-app/SKILL.md
+++ b/.claude/skills/run-cave-app/SKILL.md
@@ -20,7 +20,7 @@ The primary checkout often has another live session's uncommitted work and concu
 - **`cd` ONLY into the path `add` just created**, and sanity-check `HEAD`.
 
 ```bash
-MAIN=/Users/buns/Documents/GitHub/OpenCoven/coven-cave
+MAIN=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git -C "$MAIN" worktree prune                        # drop stale entries from crashed runs
 # Pick a name that is neither an existing dir nor a registered worktree.
 WT=""; for _ in 1 2 3 4 5; do

--- a/docs/plans/2026-07-29-ios-new-chat-project-contract.md
+++ b/docs/plans/2026-07-29-ios-new-chat-project-contract.md
@@ -665,7 +665,7 @@ On an iPhone simulator verify:
 git diff --check
 git diff --stat origin/main...
 git status --short --branch
-git -C /Users/buns/Documents/GitHub/OpenCoven/coven-cave status --short --branch
+git -C /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave status --short --branch
 ```
 
 Expected: the feature worktree contains only this task; the canonical

--- a/docs/specs/2026-06-30-codex-code-surface-plan.md
+++ b/docs/specs/2026-06-30-codex-code-surface-plan.md
@@ -1017,7 +1017,7 @@ gh pr checks --watch && gh pr merge --squash --delete-branch
 ```
 Local cleanup (per CLAUDE.md):
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/codex-code-surface
 git branch -D kitty/codex-code-surface
 git worktree list

--- a/docs/specs/2026-07-03-shell-left-panels-px-widths-plan.md
+++ b/docs/specs/2026-07-03-shell-left-panels-px-widths-plan.md
@@ -10,7 +10,7 @@
 
 **Spec:** `docs/specs/2026-07-03-shell-left-panels-px-widths-design.md`
 
-**Where to work:** worktree `.worktrees/shell-left-panels-px-widths`, branch `shell-left-panels-px-widths`. ⚠️ Use ONLY paths under the worktree for every Edit/Write — absolute paths into the primary checkout (`/Users/buns/Documents/GitHub/OpenCoven/coven-cave/src/...`) silently land edits in the primary tree, and 7 other Claude sessions are live on this machine. ⚠️ Every commit must be signed: `git commit -S`.
+**Where to work:** worktree `.worktrees/shell-left-panels-px-widths`, branch `shell-left-panels-px-widths`. ⚠️ Use ONLY paths under the worktree for every Edit/Write — absolute paths into the primary checkout (`/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/src/...`) silently land edits in the primary tree, and 7 other Claude sessions are live on this machine. ⚠️ Every commit must be signed: `git commit -S`.
 
 ---
 
@@ -323,7 +323,7 @@ Expected: `MERGED`. ⚠️ Do NOT chain branch-deletion cleanup onto the merge c
 - [ ] **Step 5: Local cleanup (only after MERGED is confirmed)**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/shell-left-panels-px-widths
 git branch -D shell-left-panels-px-widths
 git worktree list

--- a/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
+++ b/docs/specs/2026-07-22-chat-footer-split-context-chips-plan.md
@@ -1015,7 +1015,7 @@ Expected: no other open PR touching the composer footer. If one exists, reconcil
 ```bash
 gh pr checks <PR#> --watch
 gh pr merge <PR#> --squash --delete-branch
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/feat-chat-footer-split-chips
 git branch -D feat/chat-footer-split-chips
 git worktree list

--- a/docs/specs/2026-07-26-ios-drawer-quiet-portal-plan.md
+++ b/docs/specs/2026-07-26-ios-drawer-quiet-portal-plan.md
@@ -584,7 +584,7 @@ xcodebuild -quiet build \
   -destination 'platform=iOS Simulator,id=8E08D33E-D46E-40D6-921C-6B8475046CFC' \
   CODE_SIGNING_ALLOWED=NO
 xcrun simctl install booted \
-  /Users/buns/Library/Developer/Xcode/DerivedData/CovenCave-dzmowrhvcyskqggugzwiftgejwqr/Build/Products/Debug-iphonesimulator/CovenCave.app
+  /Users/<someone>/Library/Developer/Xcode/DerivedData/CovenCave-dzmowrhvcyskqggugzwiftgejwqr/Build/Products/Debug-iphonesimulator/CovenCave.app
 xcrun simctl launch --terminate-running-process booted \
   ai.opencoven.cave --ui-preview-connecting
 xcrun simctl io booted screenshot /tmp/coven-cave-ios-quiet-portal.png

--- a/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
+++ b/docs/superpowers/plans/2026-06-30-home-chat-code-command-center.md
@@ -1079,7 +1079,7 @@ If the port is already occupied, inspect the listener first:
 lsof -nP -iTCP:3000 -sTCP:LISTEN
 ```
 
-Use the existing server only if its `cwd` is `/Users/buns/Documents/GitHub/OpenCoven/coven-cave`.
+Use the existing server only if its `cwd` is `/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave`.
 
 - [ ] **Step 4: Render-check Home, Chat, Code, and Quick Chat**
 

--- a/docs/superpowers/plans/2026-07-06-journal-to-familiar-studio.md
+++ b/docs/superpowers/plans/2026-07-06-journal-to-familiar-studio.md
@@ -25,7 +25,7 @@
 - [ ] **Step 1: Create the archive feature branch on origin from current main (canvas surface intact)**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git fetch origin
 git push origin origin/main:refs/heads/feature/journal-canvas-surface
 ```
@@ -737,7 +737,7 @@ gh pr merge <#> --squash --delete-branch
 - [ ] **Step 4: Local cleanup (worktree guard rules apply — branch must be merged first)**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/journal-studio-move
 git branch -D journal-studio-move
 git worktree list

--- a/docs/superpowers/plans/2026-07-09-ui-consistency-phase-0.md
+++ b/docs/superpowers/plans/2026-07-09-ui-consistency-phase-0.md
@@ -1578,9 +1578,9 @@ Expected:
 Run:
 
 ```bash
-MAIN=/Users/buns/Documents/GitHub/OpenCoven/coven-cave
-FEATURE=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-ui-consistency-program
-VERIFY=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/run-ui-xd1b1-019f4a47
+MAIN=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
+FEATURE=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-ui-consistency-program
+VERIFY=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/run-ui-xd1b1-019f4a47
 git -C "$MAIN" worktree prune
 test ! -e "$VERIFY"
 SHA=$(git -C "$FEATURE" rev-parse HEAD)
@@ -1725,8 +1725,8 @@ and repeat this runtime step.
 Delete `__verify-aesthetic.mjs` with `apply_patch`, then run:
 
 ```bash
-MAIN=/Users/buns/Documents/GitHub/OpenCoven/coven-cave
-VERIFY=/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/run-ui-xd1b1-019f4a47
+MAIN=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
+VERIFY=/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/run-ui-xd1b1-019f4a47
 git -C "$MAIN" worktree remove --force "$VERIFY"
 git -C "$MAIN" worktree prune
 git -C "$MAIN" worktree list
@@ -1873,10 +1873,10 @@ After verified merge:
 ```bash
 bd close cave-xd1b.1 --reason "Phase 0 merged and verified on origin/main"
 bd update cave-xd1b --append-notes "Phase 0 cave-xd1b.1 merged: copy contract, field primitives, aesthetic reference, and conformance baseline. Umbrella remains open for React migrations, iOS, Tauri, and closure audit." --json
-WT_GUARD_BYPASS=1 git -C /Users/buns/Documents/GitHub/OpenCoven/coven-cave worktree remove /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-ui-consistency-program
-git -C /Users/buns/Documents/GitHub/OpenCoven/coven-cave worktree prune
-git -C /Users/buns/Documents/GitHub/OpenCoven/coven-cave branch -D feat/ui-consistency-program
-git -C /Users/buns/Documents/GitHub/OpenCoven/coven-cave status --short --branch
+WT_GUARD_BYPASS=1 git -C /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave worktree remove /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-ui-consistency-program
+git -C /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave worktree prune
+git -C /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave branch -D feat/ui-consistency-program
+git -C /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave status --short --branch
 ```
 
 Expected: the Phase 0 child is closed, `cave-xd1b` remains open/unassigned,

--- a/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
+++ b/docs/superpowers/plans/2026-07-21-canvas-fullscreen.md
@@ -10,12 +10,12 @@
 
 **Spec:** `docs/superpowers/specs/2026-07-21-canvas-fullscreen-design.md` · **Bead:** cave-i0qt
 
-**Working directory for ALL tasks:** `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen` (branch `feat/canvas-fullscreen`, local-only until Task 5 pushes). All commits are signed (`-S`).
+**Working directory for ALL tasks:** `/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen` (branch `feat/canvas-fullscreen`, local-only until Task 5 pushes). All commits are signed (`-S`).
 
 **One-time setup (before Task 1):**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-canvas-fullscreen
 pnpm install
 ```
 
@@ -675,7 +675,7 @@ bd update cave-i0qt --notes "Implemented on feat/canvas-fullscreen (worktree .wo
 
 ```bash
 gh pr merge <n> --squash --delete-branch
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/feat-canvas-fullscreen
 git branch -D feat/canvas-fullscreen
 git worktree list

--- a/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
+++ b/docs/superpowers/plans/2026-07-23-blaze-backdrop.md
@@ -10,7 +10,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-07-23-blaze-backdrop-design.md` (versioned in this repo since cave-8zjr5). **Bead:** cave-99s9. **Worktree:** `.worktrees/blaze-backdrop` (branch `blaze-backdrop`, already pushed? No — branch exists locally with no commits yet beyond origin/main).
 
-**Working directory for ALL tasks:** `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop`
+**Working directory for ALL tasks:** `/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop`
 
 **Conventions:** signed commits (`git commit -S`), Co-authored-by trailer:
 `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
@@ -44,7 +44,7 @@
 - [ ] **Step 1: Fetch the registry payload and write the file**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
 curl -sL "https://canvasui.dev/r/blaze-react.json" -o /tmp/blaze-react.json
 node -e "
 const j = require('/tmp/blaze-react.json');
@@ -945,7 +945,7 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
 - [ ] **Step 1: Full local gates**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/blaze-backdrop
 pnpm lint && pnpm typecheck && node scripts/check-tests-wired.mjs
 ```
 Expected: all clean.
@@ -1005,7 +1005,7 @@ All four required checks (Frontend build, Rust check, CodeQL, E2E (Playwright)) 
 - [ ] **Step 8: Local cleanup (worktree + branch)**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/blaze-backdrop
 git branch -D blaze-backdrop
 git worktree list
@@ -1014,7 +1014,7 @@ git worktree list
 - [ ] **Step 9: Discard the staged shadcn experiment in the primary checkout (user-approved)** — ONLY these paths; `src-tauri/src/sidecar_discovery.rs` and `.beads/*` belong to other work and stay:
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git restore --staged --worktree components.json __shoot2.mjs src/app/globals.css src/app/layout.tsx src/lib/utils.ts package.json pnpm-lock.yaml src/components/canvasui/Blaze.tsx 2>/dev/null || true
 rm -f components.json __shoot2.mjs
 git status --short   # confirm only unrelated files remain

--- a/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
+++ b/docs/superpowers/plans/2026-07-24-analytics-contract-review.md
@@ -12,7 +12,7 @@
 
 **One deliberate deviation from the spec:** the spec listed a `familiarName` prop on `ContractCompliance`. It is not needed — the button copy is static and the brief is built in the parent, which already derives `familiarName`. YAGNI: only `onReview` is added.
 
-**Worktree:** All work happens in `/Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-analytics-contract-review` (branch `feat/analytics-contract-review`, already created from `origin/main`, already has `node_modules` via pnpm — if not, run `pnpm install` there first, ~10s). All commands below run from that directory. Commits MUST be signed (`git commit -S`).
+**Worktree:** All work happens in `/Users/<someone>/Documents/GitHub/OpenCoven/coven-cave/.worktrees/feat-analytics-contract-review` (branch `feat/analytics-contract-review`, already created from `origin/main`, already has `node_modules` via pnpm — if not, run `pnpm install` there first, ~10s). All commands below run from that directory. Commits MUST be signed (`git commit -S`).
 
 **Key existing code you'll touch or reuse (read these before editing):**
 
@@ -366,7 +366,7 @@ gh pr merge feat/analytics-contract-review --squash --delete-branch
 - [ ] **Step 5: Local cleanup (squash orphans the tip — bypass is sanctioned after verifying content landed)**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git fetch origin --quiet
 # verify the squash landed the same content before destroying the branch:
 git diff feat/analytics-contract-review origin/main -- src/components/familiar-analytics-content.tsx src/components/familiar-analytics-view.test.ts src/styles/familiar-analytics.css

--- a/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
+++ b/docs/superpowers/plans/2026-07-24-research-final-artifacts.md
@@ -49,7 +49,7 @@
 - [ ] **Step 0.1: Create the worktree**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree add -b research-final-artifacts .worktrees/research-final-artifacts origin/main
 cp docs/specs/2026-07-24-research-final-artifacts-design.md .worktrees/research-final-artifacts/docs/specs/
 mkdir -p .worktrees/research-final-artifacts/docs/superpowers/plans

--- a/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
+++ b/docs/superpowers/plans/2026-07-24-sidepanel-peel-reveal.md
@@ -673,7 +673,7 @@ gh pr merge --squash --delete-branch \
 - [ ] **Step 5: Local cleanup + bead close**
 
 ```bash
-cd /Users/buns/Documents/GitHub/OpenCoven/coven-cave
+cd /Users/<someone>/Documents/GitHub/OpenCoven/coven-cave
 git worktree remove .worktrees/peel-sidepanel-reveal
 git branch -D peel-sidepanel-reveal
 git worktree list


### PR DESCRIPTION
## Summary

`coven-cave` is a **public** repo, and **33 occurrences of a contributor's literal home path** (`/Users/buns/…`) were tracked across **15 documentation files** — publishing a username and local directory layout for no benefit.

Replaced with `/Users/<someone>` — the exact placeholder `docs/superpowers/README.md` already uses when it warns that these paths *"were the author's paths, not portable instructions"*. So the docs now match their own stated convention.

## Wider than it first looked

#4148 surfaced this by committing 12 such paths in newly-versioned superpowers plans. But the same paths were **already public** in `docs/specs`, `docs/plans`, and both `run-cave-app/SKILL.md` copies — those trees were never ignored. Fixing only the new ones would have left most of the exposure in place.

| Tree | Files | Occurrences |
|---|---|---|
| `docs/superpowers/plans` | 8 | 25 |
| `docs/specs` | 4 | 5 |
| `docs/plans` | 1 | 1 |
| `.claude/skills` + `.agents/skills` | 2 | 2 |

> The two `SKILL.md` copies live under gitignored directories but were **already tracked** — the same tracked-before-ignored situation that caused cave-8zjr5. `git add` warns about the ignored parent while committing the tracked file's change normally.

## Deliberately not included

**The code-side occurrences.** Four test files hard-code the same path as fixtures — `familiar-workspace-sessions`, `knowledge-pack-ui`, `projects/access-page`, `adapter-conflict-heal` (12 occurrences). Those are machine-specific fixtures that arguably should be repo-relative or `tmpdir`-based, but editing assertions to fix a privacy nit risks breaking real coverage. That deserves its own change with its own verification.

Also noticed in passing: `scripts/__pycache__/split-cave-chat-css.cpython-314.pyc` is a **tracked build artifact** that should probably be ignored.

## Verification

Docs-only — no assertion, no code path touched. The two tests that read the changed files both pass: `design-token-drift` and `ui-consistency`. `git diff --check` clean. 32 lines changed, all of them the same substitution.

Follow-up to #4148.

🤖 Generated with [Claude Code](https://claude.com/claude-code)