### PR TITLE
fix(cli): recover OpenClaw/runtime parity

### DIFF
--- a/src/app/api/capabilities/route.test.ts
+++ b/src/app/api/capabilities/route.test.ts
@@ -40,6 +40,12 @@ assert.match(
 
 assert.match(
   source,
+  /const rawHarness = url\.searchParams\.get\("harness"\);[\s\S]*const harness = rawHarness \? canonicalHarnessId\(rawHarness\) : null;/,
+  "Per-harness capability requests should canonicalize legacy CLI aliases before daemon lookup",
+);
+
+assert.match(
+  source,
   /bridge_capabilities: openClawBridgeCapabilities\(\)/,
   "The synthetic OpenClaw manifest should include structured bridge capability flags",
 );

--- a/src/app/api/capabilities/route.ts
+++ b/src/app/api/capabilities/route.ts
@@ -196,7 +196,8 @@ async function ensureAdapterCoverage(
 export async function GET(req: Request) {
   const url = new URL(req.url);
   const refresh = url.searchParams.get("refresh") === "1" ? "?refresh=1" : "";
-  const harness = url.searchParams.get("harness");
+  const rawHarness = url.searchParams.get("harness");
+  const harness = rawHarness ? canonicalHarnessId(rawHarness) : null;
 
   if (harness) {
     if (harness === "openclaw") {

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -220,6 +220,16 @@ assert.match(
   /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*requiredFiles:\s*openclawLaunch\.requiredFiles,[\s\S]*openclawAvailability\.state !== "ready"/,
   "OpenClaw chat should fail closed when the launch plan is not ready",
 );
+assert.match(
+  chatRoute,
+  /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*unresolvedWindowsShim: openclawLaunch\.unresolvedWindowsShim === true/,
+  "OpenClaw chat should classify an unresolved Windows npm shim through the shared availability contract",
+);
+assert.match(
+  chatRoute,
+  /const openclawAvailability = evaluateRuntimeAvailability\(\{[\s\S]*runner: "openclaw"[\s\S]*command: openclawLaunch\.command[\s\S]*requiredFiles: openclawLaunch\.requiredFiles[\s\S]*\}\);[\s\S]*if \(openclawAvailability\.state !== "ready"\)[\s\S]*return;[\s\S]*spawn\(openclawLaunch\.command/,
+  "OpenClaw chat should use the shared passive availability gate before spawning",
+);
 
 assert.match(
   openclawBridge,

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -217,8 +217,8 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*if \(openclawLaunch\.unresolvedWindowsShim\)[\s\S]*openclaw_unsafe_shell/,
-  "OpenClaw chat should fail closed when it cannot resolve a Windows npm shim's JavaScript target",
+  /const openclawLaunch = openClawLaunchCommand\(\);[\s\S]*requiredFiles:\s*openclawLaunch\.requiredFiles,[\s\S]*openclawAvailability\.state !== "ready"/,
+  "OpenClaw chat should fail closed when the launch plan is not ready",
 );
 
 assert.match(
@@ -266,7 +266,7 @@ assert.doesNotMatch(
 
 assert.match(
   chatRoute,
-  /const spawnChild = \(mode: "gateway" \| "local"\) => \{[\s\S]*openClawAgentArgs\(args\.harnessPrompt, agentId, conversationId, mode\)[\s\S]*spawn\(openclawLaunch\.command, \[\.\.\.openclawLaunch\.fixedArgs, \.\.\.argv\],[\s\S]*env: openClawSpawnEnv\(\),[\s\S]*shell: false/,
+  /const spawnChild = \(mode: "gateway" \| "local"\) => \{[\s\S]*openClawAgentArgs\(args\.harnessPrompt, agentId, conversationId, mode\)[\s\S]*spawn\(openclawLaunch\.command, \[\.\.\.openclawLaunch\.fixedArgs, \.\.\.argv\],[\s\S]*env: openclawEnv,[\s\S]*shell: false/,
   "OpenClaw chat should invoke resolved npm shims through Node without shell parsing untrusted prompts",
 );
 

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -894,18 +894,26 @@ function openClawChatResponse(args: {
         return;
       }
       const openclawLaunch = openClawLaunchCommand();
-      if (openclawLaunch.unresolvedWindowsShim) {
+      const openclawEnv = openClawSpawnEnv();
+      const openclawAvailability = evaluateRuntimeAvailability({
+        runner: "openclaw",
+        command: openclawLaunch.command,
+        env: openclawEnv,
+        requiredFiles: openclawLaunch.requiredFiles,
+        unresolvedWindowsShim: openclawLaunch.unresolvedWindowsShim === true,
+        cwd,
+      });
+      if (openclawAvailability.state !== "ready") {
         pushProgress(
           "openclaw-start",
-          "OpenClaw bridge cannot start safely",
+          "OpenClaw bridge not started",
           "error",
-          "The resolved OpenClaw Windows npm shim could not be mapped to its JavaScript entry point. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
+          openclawAvailability.message,
         );
         push({
           kind: "error",
-          code: "openclaw_unsafe_shell",
-          message:
-            "OpenClaw chat is unavailable because its Windows npm shim could not be launched without shell parsing. Reinstall OpenClaw or configure a native executable with OPENCLAW_BIN.",
+          code: openclawAvailability.code,
+          message: openclawAvailability.message,
         });
         push({
           kind: "done",
@@ -926,7 +934,7 @@ function openClawChatResponse(args: {
         return spawn(openclawLaunch.command, [...openclawLaunch.fixedArgs, ...argv], {
           cwd,
           stdio: ["ignore", "pipe", "pipe"],
-          env: openClawSpawnEnv(),
+          env: openclawEnv,
           shell: false,
         });
       };
@@ -994,12 +1002,9 @@ function openClawChatResponse(args: {
       const failChild = (err: NodeJS.ErrnoException) => {
         if (terminal) return;
         terminal = true;
-        const message =
-          err.code === "ENOENT"
-            ? "openclaw CLI not found on PATH. Open Setup to install it, then try again."
-            : err.message;
-        pushProgress("openclaw-response", "OpenClaw bridge failed", "error", message);
-        push({ kind: "error", code: err.code, message });
+        const failure = localRuntimeLaunchError("openclaw", err.code);
+        pushProgress("openclaw-response", "OpenClaw bridge failed", "error", failure.message);
+        push({ kind: "error", code: failure.code, message: failure.message });
         push({
           kind: "done",
           durationMs: Date.now() - startedAt,

--- a/src/components/chat-familiar-capabilities.test.ts
+++ b/src/components/chat-familiar-capabilities.test.ts
@@ -9,6 +9,12 @@ const source = readFileSync(
 
 assert.match(
   source,
+  /const harnessId = canonicalHarnessId\(familiar\.harness \?\? "codex"\);[\s\S]*canonicalHarnessId\(item\.harness_id\) === harnessId[\s\S]*canonicalHarnessId\(item\.id\) === harnessId/,
+  "Familiar capability summaries should match legacy harness aliases to canonical manifests and reports",
+);
+
+assert.match(
+  source,
   /const availability = h\.availability;[\s\S]{0,100}if \(availability && availability\.state !== "ready"\)[\s\S]{0,240}label: `\$\{h\.label\}\$\{availability\.state === "missing" \? " \(not installed\)" : " \(unavailable\)"\}`,[\s\S]{0,100}detail: availability\.message/,
   "the Familiar capability runtime picker must distinguish an unlaunchable runtime and show the shared remediation",
 );

--- a/src/components/chat-familiar-capabilities.tsx
+++ b/src/components/chat-familiar-capabilities.tsx
@@ -30,7 +30,11 @@ import { deriveFamiliarSectionData } from "@/lib/familiar-tab-section-model";
 import type { HarnessCapabilityManifest } from "@/app/api/capabilities/route";
 import type { RoleEntry } from "@/app/api/roles/route";
 import type { LocalSkillEntry } from "@/app/api/skills/local/route";
-import { isBindableRuntimeChoice, type AdapterReport } from "@/lib/harness-adapters";
+import {
+  canonicalHarnessId,
+  isBindableRuntimeChoice,
+  type AdapterReport,
+} from "@/lib/harness-adapters";
 import { consumeFamiliarSettingsPending, type FamiliarSettingsTab } from "@/lib/chat-tab-events";
 import { openFamiliarStudioSettingsTab } from "@/lib/familiar-studio-context";
 import { listVoiceProviders } from "@/lib/voice/registry";
@@ -96,8 +100,8 @@ function FamiliarIdentityHero({
 
   // Runtime select: "" inherits the cave default; anything else is a
   // per-familiar override (binding key: harness).
-  const defaultHarnessId = familiar.defaultHarness ?? familiar.harness ?? "";
-  const defaultHarness = harnesses.find((h) => h.id === defaultHarnessId);
+  const defaultHarnessId = canonicalHarnessId(familiar.defaultHarness ?? familiar.harness ?? "");
+  const defaultHarness = harnesses.find((h) => canonicalHarnessId(h.id) === defaultHarnessId);
   const runtimeValue = familiar.harnessOverride ?? "";
   const runtimeOptions: StandardSelectOption<string>[] = [
     { value: "", label: `Default${defaultHarness ? ` · ${defaultHarness.label}` : ""}`, detail: "Inherit the cave runtime" },
@@ -333,7 +337,7 @@ function FamiliarRosterWarning({ message, onRetry }: { message: string; onRetry?
 }
 
 function familiarCapabilitySummary(familiar: ResolvedFamiliar, snapshot: CapabilitySnapshot) {
-  const harnessId = familiar.harness ?? "codex";
+  const harnessId = canonicalHarnessId(familiar.harness ?? "codex");
   const roles = snapshot.roles.filter(
     (role) => role.active && (role.familiar === familiar.id || role.familiar === "all" || role.familiar === "global"),
   );
@@ -341,14 +345,18 @@ function familiarCapabilitySummary(familiar: ResolvedFamiliar, snapshot: Capabil
   const localSkills = snapshot.localSkills.filter(
     (skill) => skill.familiar === "global" || (skill.familiar as string) === familiar.id,
   );
-  const manifest = snapshot.harnessCapabilities.find((item) => item.harness_id === harnessId);
+  const manifest = snapshot.harnessCapabilities.find(
+    (item) => canonicalHarnessId(item.harness_id) === harnessId,
+  );
   const skillIds = new Set([
     ...roleSkills,
     ...localSkills.map((skill) => skill.id),
     ...(manifest?.skills ?? []).map((skill) => skill.id),
   ]);
   const enabledPlugins = (manifest?.plugins ?? []).filter((plugin) => plugin.enabled).length;
-  const harness = snapshot.harnesses.find((item) => item.id === harnessId);
+  const harness = snapshot.harnesses.find(
+    (item) => canonicalHarnessId(item.id) === harnessId,
+  );
   return {
     roleCount: roles.length,
     skillCount: skillIds.size,

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -20,6 +20,16 @@ assert.match(
 );
 assert.match(
   source,
+  /const harnessId = canonicalHarnessId\(draftHarness \|\| defaultHarnessId\);/,
+  "Brain tab should canonicalize legacy harness aliases before model and availability lookup",
+);
+assert.match(
+  source,
+  /harnesses\.find\([\s\S]{0,100}canonicalHarnessId\(item\.id\) === harnessId/,
+  "Brain tab should match canonical harness reports after alias normalization",
+);
+assert.match(
+  source,
   /h\.availability && h\.availability\.state !== "ready"[\s\S]*?h\.availability\.message/,
   "Runtime picker should reuse server-provided launchability remediation instead of treating an installed but unlaunchable CLI as ready",
 );
@@ -484,7 +494,7 @@ assert.match(
 );
 assert.match(
   source,
-  /const selectedHarnessAvailability = harnesses\.find\(\(item\) => item\.id === harnessId\)\?\.availability;[\s\S]*?selectedHarnessAvailability\.state !== "ready"[\s\S]*?selectedHarnessAvailability\.message/,
+  /const selectedHarnessAvailability = harnesses\.find\([\s\S]{0,120}canonicalHarnessId\(item\.id\) === harnessId,[\s\S]{0,40}\)\?\.availability;[\s\S]*?selectedHarnessAvailability\.state !== "ready"[\s\S]*?selectedHarnessAvailability\.message/,
   "the selected runtime shows truthful launch remediation rather than only an install bit",
 );
 assert.match(

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/lib/daemon-sync-status";
 import type { HarnessCapabilityManifest } from "@/components/capability-card";
 import { StandardSelect, type StandardSelectGroup } from "@/components/ui/select";
-import { isBindableRuntimeChoice } from "@/lib/harness-adapters";
+import { canonicalHarnessId, isBindableRuntimeChoice } from "@/lib/harness-adapters";
 import type { RuntimeAvailabilitySummary } from "@/lib/runtime-availability";
 import { catalogForRuntime } from "@/lib/runtime-models";
 import type { RuntimeModelOption } from "@/lib/grok-build";
@@ -272,10 +272,12 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
     return () => { cancelled = true; };
   }, []);
 
-  const defaultHarnessId = familiar.defaultHarness ?? familiar.harness ?? "";
+  const defaultHarnessId = canonicalHarnessId(familiar.defaultHarness ?? familiar.harness ?? "");
   const defaultHarnessLabel = runtimeLabel(defaultHarnessId, harnesses);
-  const harnessId = draftHarness || defaultHarnessId;
-  const selectedHarnessAvailability = harnesses.find((item) => item.id === harnessId)?.availability;
+  const harnessId = canonicalHarnessId(draftHarness || defaultHarnessId);
+  const selectedHarnessAvailability = harnesses.find(
+    (item) => canonicalHarnessId(item.id) === harnessId,
+  )?.availability;
 
   // Model parity: source the per-familiar model menu from the same runtime →
   // provider catalog the chat picker uses. allowCustom keeps the free-text

--- a/src/lib/chat-model-state.test.ts
+++ b/src/lib/chat-model-state.test.ts
@@ -19,6 +19,11 @@ const base = {
 
 assert.equal(cleanModelId("  anthropic/claude-opus-4-7  "), "anthropic/claude-opus-4-7");
 assert.equal(cleanModelId("openai/gpt-5.5"), "openai/gpt-5.5");
+assert.equal(
+  cleanModelId("openrouter/~anthropic/claude-opus-latest"),
+  "openrouter/~anthropic/claude-opus-latest",
+  "OpenCode provider aliases with a tilde-prefixed path segment remain selectable",
+);
 assert.equal(cleanModelId(""), null);
 assert.equal(cleanModelId("bad model with spaces"), null);
 assert.equal(cleanModelId("../escape"), null);

--- a/src/lib/chat-model-state.ts
+++ b/src/lib/chat-model-state.ts
@@ -1,4 +1,4 @@
-import { runtimeOwnsModelDefault } from "./runtime-models.ts";
+import { isSafeRuntimeModelId, runtimeOwnsModelDefault } from "./runtime-models.ts";
 
 export type ModelScope =
   | "runtime-default"
@@ -60,15 +60,13 @@ const SYNTHETIC_LOCAL_MODELS = new Set([
   "openclaw-local",
 ]);
 
-const MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$/;
-
 export function cleanModelId(value: unknown): string | null {
   if (typeof value !== "string") return null;
 
   const trimmed = value.trim();
   if (!trimmed) return null;
   if (trimmed.includes(" ") || trimmed.includes("..")) return null;
-  if (!MODEL_ID_RE.test(trimmed)) return null;
+  if (!isSafeRuntimeModelId(trimmed)) return null;
 
   return trimmed;
 }

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -37,7 +37,7 @@ assert.match(
 );
 assert.match(
   src,
-  /export function openClawLaunchCommandForBinary\(binary: string\): CovenLaunchCommand[\s\S]*covenLaunchCommandForBinary\(binary, shimPlatform\)/,
+  /export function openClawLaunchCommandForBinary\(binary: string\): OpenClawLaunchCommand[\s\S]*requiredFiles:\s*\[launch\.fixedArgs\.at\(-1\)!\]/,
   "OpenClaw Windows npm shims should launch their JavaScript target with Node instead of cmd.exe",
 );
 assert.match(

--- a/src/lib/openclaw-bin.test.ts
+++ b/src/lib/openclaw-bin.test.ts
@@ -37,8 +37,13 @@ assert.match(
 );
 assert.match(
   src,
-  /export function openClawLaunchCommandForBinary\(binary: string\): OpenClawLaunchCommand[\s\S]*requiredFiles:\s*\[launch\.fixedArgs\.at\(-1\)!\]/,
+  /export function openClawLaunchCommandForBinary\(binary: string\): OpenClawLaunchCommand[\s\S]*covenLaunchCommandForBinary\(binary, shimPlatform\)/,
   "OpenClaw Windows npm shims should launch their JavaScript target with Node instead of cmd.exe",
+);
+assert.match(
+  src,
+  /requiredFiles: \[launch\.fixedArgs\.at\(-1\)!\]/,
+  "OpenClaw Windows shim preflight should retain the resolved package target as a required artifact",
 );
 assert.match(
   src,

--- a/src/lib/openclaw-bin.ts
+++ b/src/lib/openclaw-bin.ts
@@ -21,6 +21,10 @@ import { isVaultKeyGrantedTo, loadVaultMap } from "./vault";
 
 let cachedBin: string | null = null;
 
+export type OpenClawLaunchCommand = CovenLaunchCommand & {
+  requiredFiles?: string[];
+};
+
 const FORBIDDEN_SPAWN_ENV_KEYS = new Set(["GITHUB_PAT"]);
 // The Gateway dispatcher reads these only in Cave's server process. They must
 // never cross the fallback boundary, even if a broad harness allow-list was
@@ -122,13 +126,17 @@ export function openClawSupportsUntrustedArgs(bin = openClawBin()): boolean {
  * shims are batch files, but their final target is a JavaScript entry point;
  * resolve that target and execute it with the running Node binary instead.
  */
-export function openClawLaunchCommandForBinary(binary: string): CovenLaunchCommand {
+export function openClawLaunchCommandForBinary(binary: string): OpenClawLaunchCommand {
   const shimPlatform = /\.(cmd|bat)$/i.test(binary) ? "win32" : process.platform;
-  return covenLaunchCommandForBinary(binary, shimPlatform);
+  const launch = covenLaunchCommandForBinary(binary, shimPlatform);
+  return {
+    ...launch,
+    ...(launch.fixedArgs.length > 0 ? { requiredFiles: [launch.fixedArgs.at(-1)!] } : {}),
+  };
 }
 
 /** A spawn-safe OpenClaw command for either a native executable or npm shim. */
-export function openClawLaunchCommand(): CovenLaunchCommand {
+export function openClawLaunchCommand(): OpenClawLaunchCommand {
   return openClawLaunchCommandForBinary(openClawBin());
 }
 

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -78,6 +78,19 @@ assert.deepEqual(openClawBridgeCapabilities(), {
   nativeMessaging: true,
 });
 
+assert.equal(
+  extractOpenClawText({ result: { payloads: [{ content: "scalar reply" }] } }),
+  "scalar reply",
+  "OpenClaw scalar payload content should not be discarded",
+);
+assert.equal(
+  extractOpenClawText({
+    result: { payloads: [{ content: { text: "object reply" } }] },
+  }),
+  "object reply",
+  "OpenClaw object payload content with a text field should not be discarded",
+);
+
 assert.deepEqual(
   resolveOpenClawAgentBindingFromSources("nova", "explicit-nova", candidateAgents),
   {

--- a/src/lib/openclaw-bridge.test.ts
+++ b/src/lib/openclaw-bridge.test.ts
@@ -211,6 +211,18 @@ try {
 }
 
 assert.equal(openClawSessionKey("ABC_123:Weird"), "cave-abc-123-weird");
+assert.equal(
+  extractOpenClawText({ result: { payloads: [{ content: "scalar reply" }] } }),
+  "scalar reply",
+  "OpenClaw scalar payload content should not be discarded",
+);
+assert.equal(
+  extractOpenClawText({
+    result: { payloads: [{ content: { text: "object reply" } }] },
+  }),
+  "object reply",
+  "OpenClaw object payload content with a text field should not be discarded",
+);
 assert.deepEqual(openClawAgentArgs("hi", "nova", "ABC_123"), [
   "agent",
   "--agent",

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -326,6 +326,7 @@ export function extractOpenClawText(json: OpenClawAgentJson): string {
   const text = payloads
     .map((payload) => {
       if (typeof payload.text === "string") return payload.text;
+      if (typeof payload.content === "string") return payload.content;
       if (Array.isArray(payload.content)) {
         return payload.content
           .map((part) =>
@@ -337,6 +338,14 @@ export function extractOpenClawText(json: OpenClawAgentJson): string {
               : "",
           )
           .join("");
+      }
+      if (
+        payload.content &&
+        typeof payload.content === "object" &&
+        "text" in payload.content &&
+        typeof payload.content.text === "string"
+      ) {
+        return payload.content.text;
       }
       return "";
     })

--- a/src/lib/openclaw-conversation-tools.test.ts
+++ b/src/lib/openclaw-conversation-tools.test.ts
@@ -20,8 +20,8 @@ assert.match(
 
 assert.match(
   source,
-  /function extractToolEvent[\s\S]*role: "tool"[\s\S]*status: msg\.status === "error" \? "error" : "ok"/,
-  "OpenClaw JSONL fallback should convert tool-role messages into tool events",
+  /function openClawToolStatus[\s\S]*return !normalized[\s\S]*: "error";[\s\S]*function extractToolEvent[\s\S]*status: openClawToolStatus\(msg\.status\)/,
+  "OpenClaw JSONL fallback should preserve non-success tool terminal states as errors",
 );
 
 assert.match(

--- a/src/lib/openclaw-conversation.test.ts
+++ b/src/lib/openclaw-conversation.test.ts
@@ -43,7 +43,7 @@ try {
         id: "tool1",
         parentId: "a1",
         timestamp: "2026-06-08T06:00:03.000Z",
-        message: { role: "tool", content: "internal tool output" },
+        message: { role: "tool", status: "failed", content: "internal tool output" },
       }),
     ].join("\n"),
     "utf8",
@@ -55,10 +55,22 @@ try {
   assert.equal(conv?.harness, "openclaw");
   assert.equal(conv?.title, "New chat");
   assert.deepEqual(
-    conv?.turns.map((turn) => [turn.role, turn.text]),
+    conv?.turns.map((turn) => [turn.id, turn.parentId, turn.role, turn.text]),
     [
-      ["user", "Show me the recent sessions"],
-      ["assistant", "Here are the recent sessions."],
+      ["u1", null, "user", "Show me the recent sessions"],
+      ["a1", "u1", "assistant", "Here are the recent sessions."],
+    ],
+  );
+  assert.equal(conv?.activeLeafId, "a1");
+  assert.deepEqual(
+    conv?.turns[1]?.tools,
+    [
+      {
+        id: "tool1",
+        name: "tool",
+        output: "internal tool output",
+        status: "error",
+      },
     ],
   );
 

--- a/src/lib/openclaw-conversation.test.ts
+++ b/src/lib/openclaw-conversation.test.ts
@@ -43,7 +43,12 @@ try {
         id: "tool1",
         parentId: "a1",
         timestamp: "2026-06-08T06:00:03.000Z",
-        message: { role: "tool", status: "failed", content: "internal tool output" },
+        message: {
+          role: "tool",
+          name: "session_lookup",
+          status: "failed",
+          content: "internal tool output",
+        },
       }),
     ].join("\n"),
     "utf8",
@@ -61,17 +66,18 @@ try {
       ["a1", "u1", "assistant", "Here are the recent sessions."],
     ],
   );
-  assert.equal(conv?.activeLeafId, "a1");
+  assert.equal(conv?.activeLeafId, "a1", "the imported active path should end at the latest visible turn");
   assert.deepEqual(
     conv?.turns[1]?.tools,
     [
       {
         id: "tool1",
-        name: "tool",
+        name: "session_lookup",
         output: "internal tool output",
         status: "error",
       },
     ],
+    "non-success OpenClaw tool statuses should remain failures after import",
   );
 
   assert.equal(

--- a/src/lib/openclaw-conversation.ts
+++ b/src/lib/openclaw-conversation.ts
@@ -51,6 +51,13 @@ function stringifyUnknown(value: unknown): string | undefined {
   }
 }
 
+function openClawToolStatus(status: string | undefined): "ok" | "error" {
+  const normalized = status?.trim().toLowerCase();
+  return !normalized || ["ok", "success", "completed", "done"].includes(normalized)
+    ? "ok"
+    : "error";
+}
+
 function extractToolEvent(
   id: string,
   msg: OpenclawMessage & { role: "tool" },
@@ -68,7 +75,7 @@ function extractToolEvent(
     id: msg.tool_call_id ?? id,
     name,
     output,
-    status: msg.status === "error" ? "error" : "ok",
+    status: openClawToolStatus(msg.status),
   };
 }
 
@@ -126,6 +133,7 @@ export async function loadConversationFromJsonl(
     const msgRecord = record as {
       type: "message";
       id: string;
+      parentId: string | null;
       timestamp: string;
       message: OpenclawMessage;
     };
@@ -154,6 +162,7 @@ export async function loadConversationFromJsonl(
 
     const turn: ChatTurn = {
       id: msgRecord.id,
+      parentId: msgRecord.parentId,
       role: msg.role as "user" | "assistant",
       text,
       createdAt: iso,
@@ -177,5 +186,6 @@ export async function loadConversationFromJsonl(
     createdAt: createdAt ?? now,
     updatedAt: updatedAt ?? now,
     turns,
+    activeLeafId: turns.at(-1)?.id,
   };
 }

--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -239,7 +239,7 @@ try {
 
   // Verification matrix: binary absent from every discovery location →
   // missing, with per-runner install/PATH remediation.
-  for (const runner of ["coven", "codex", "copilot", "grok", "hermes", "opencode"] as const) {
+  for (const runner of ["coven", "codex", "copilot", "grok", "hermes", "opencode", "openclaw"] as const) {
     const missing = evaluateRuntimeAvailability({
       runner,
       command: runner === "coven" ? "coven" : runner,
@@ -270,6 +270,11 @@ try {
     missingRunnerMessage("coven"),
     /Coven CLI not found on PATH/,
     "Coven missing copy stays pinned to the client recovery matcher",
+  );
+  assert.equal(
+    runtimeLaunchFailedMessage("openclaw"),
+    "OpenClaw CLI failed to start. Check its installation and try again.",
+    "OpenClaw spawn races should use the shared value-free launch-failure contract",
   );
 
   const emptyPath = evaluateRuntimeAvailability({

--- a/src/lib/runtime-availability.test.ts
+++ b/src/lib/runtime-availability.test.ts
@@ -264,6 +264,12 @@ try {
     );
   }
 
+  assert.equal(
+    runtimeLaunchFailedMessage("openclaw"),
+    "OpenClaw CLI failed to start. Check its installation and try again.",
+    "OpenClaw spawn races should use the shared value-free launch-failure contract",
+  );
+
   // The chat client's "Open Setup" recovery matches this exact phrase
   // (src/components/chat-view.test.ts); the availability gate must keep it.
   assert.match(

--- a/src/lib/runtime-availability.ts
+++ b/src/lib/runtime-availability.ts
@@ -19,7 +19,14 @@ import { harnessSpawnEnv } from "./harness-spawn-env.ts";
  * real output.
  */
 
-export type DirectRunnerId = "coven" | "codex" | "copilot" | "grok" | "hermes" | "opencode";
+export type DirectRunnerId =
+  | "coven"
+  | "codex"
+  | "copilot"
+  | "grok"
+  | "hermes"
+  | "opencode"
+  | "openclaw";
 /** A runtime launched by Coven rather than handed directly to Node's spawn. */
 export type CovenBackedRunnerId = "claude";
 export type RuntimeRunnerId = DirectRunnerId | CovenBackedRunnerId;
@@ -167,6 +174,8 @@ const MISSING_RUNNER_MESSAGES: Record<RuntimeRunnerId, string> = {
   hermes: "Hermes CLI not found on PATH. Install Hermes, then try again.",
   opencode:
     "OpenCode CLI not found on PATH. Install it with `npm install -g opencode-ai`, then try again.",
+  openclaw:
+    "OpenClaw CLI not found on PATH. Open Setup to install it, then try again.",
 };
 
 const RUNTIME_LAUNCH_FAILED_MESSAGES: Record<DirectRunnerId, string> = {
@@ -176,6 +185,7 @@ const RUNTIME_LAUNCH_FAILED_MESSAGES: Record<DirectRunnerId, string> = {
   grok: "Grok Build CLI failed to start. Check its installation and try again.",
   hermes: "Hermes CLI failed to start. Check its installation and try again.",
   opencode: "OpenCode CLI failed to start. Check its installation and try again.",
+  openclaw: "OpenClaw CLI failed to start. Check its installation and try again.",
 };
 
 const RUNNER_LABELS: Record<RuntimeRunnerId, string> = {
@@ -186,6 +196,7 @@ const RUNNER_LABELS: Record<RuntimeRunnerId, string> = {
   grok: "Grok Build CLI",
   hermes: "Hermes CLI",
   opencode: "OpenCode CLI",
+  openclaw: "OpenClaw CLI",
 };
 
 export function missingRunnerMessage(runner: RuntimeRunnerId): string {

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -22,6 +22,26 @@ for (const runtime of ["codex", "claude", "copilot", "hermes", "opencode", "open
   assert.ok(Array.isArray(catalog.models));
 }
 
+for (const [alias, canonical] of [
+  ["claude-code", "claude"],
+  ["openai-codex", "codex"],
+  ["github-copilot", "copilot"],
+  ["copilot-cli", "copilot"],
+  ["hermes-agent", "hermes"],
+  ["opencode-ai", "opencode"],
+]) {
+  assert.deepEqual(
+    catalogForRuntime(alias),
+    catalogForRuntime(canonical),
+    `${alias} should resolve the canonical ${canonical} model catalog`,
+  );
+  assert.equal(
+    defaultModelForRuntime(alias),
+    defaultModelForRuntime(canonical),
+    `${alias} should inherit the canonical ${canonical} default model`,
+  );
+}
+
 // Provider-backed runtimes expose a menu sourced from their provider.
 assert.equal(catalogForRuntime("codex").provider, "openai");
 assert.equal(catalogForRuntime("claude").provider, "anthropic");

--- a/src/lib/runtime-models.test.ts
+++ b/src/lib/runtime-models.test.ts
@@ -287,6 +287,11 @@ assert.equal(
 // Revalidate the transformed argv value so stripping cannot expose a CLI flag;
 // nested ids remain valid after their first provider segment is removed.
 assert.equal(runtimeModelIdForLaunch("copilot", "provider/team/model"), "team/model");
+assert.equal(
+  runtimeModelIdForLaunch("opencode", "openrouter/~anthropic/claude-opus-latest"),
+  "openrouter/~anthropic/claude-opus-latest",
+  "OpenCode launch validation should preserve authenticated tilde-prefixed provider aliases",
+);
 assert.equal(runtimeModelIdForLaunch("copilot", "provider/--allow-all-tools"), null);
 assert.equal(runtimeModelIdForLaunch("copilot", "provider/../escape"), null);
 assert.equal(runtimeModelIdForLaunch("copilot", null), null);

--- a/src/lib/runtime-models.ts
+++ b/src/lib/runtime-models.ts
@@ -29,6 +29,16 @@ type RuntimeModelTransformMetadata = {
   modelIdTransform?: unknown;
 };
 
+const MODEL_PROVIDER_RE = /^[A-Za-z0-9][A-Za-z0-9._:@+-]*$/;
+const MODEL_PATH_SEGMENT_RE = /^~?[A-Za-z0-9][A-Za-z0-9._:@+-]*$/;
+
+export function isSafeRuntimeModelId(value: string): boolean {
+  if (!value || value.includes("..")) return false;
+  const [provider, ...modelPath] = value.split("/");
+  if (!MODEL_PROVIDER_RE.test(provider ?? "")) return false;
+  return modelPath.every((segment) => MODEL_PATH_SEGMENT_RE.test(segment));
+}
+
 /**
  * Apply the adapter registry's model-id transform using the same semantics as
  * Coven's Rust authority layer. Unknown or missing metadata defaults to
@@ -40,7 +50,8 @@ export function transformModelIdForRuntime(
   modelId: string,
   runtimes: readonly RuntimeModelTransformMetadata[] = REGISTRY_RUNTIMES,
 ): string {
-  const transform = runtimes.find((runtime) => runtime.id === runtimeId)?.modelIdTransform;
+  const canonicalRuntime = canonicalHarnessId(runtimeId);
+  const transform = runtimes.find((runtime) => runtime.id === canonicalRuntime)?.modelIdTransform;
   if (transform === "preserve") return modelId;
 
   const slash = modelId.indexOf("/");
@@ -55,9 +66,7 @@ export function transformModelIdForRuntime(
 export function runtimeModelIdForLaunch(runtimeId: string, modelId: string | null): string | null {
   if (!modelId) return null;
   const transformed = transformModelIdForRuntime(runtimeId, modelId);
-  return !transformed.includes("..") && /^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$/.test(transformed)
-    ? transformed
-    : null;
+  return isSafeRuntimeModelId(transformed) ? transformed : null;
 }
 
 export type RuntimeModelCatalog = {
@@ -184,13 +193,14 @@ export const RUNTIME_MODEL_CATALOG: Record<string, RuntimeModelCatalog> = {
 const GLOBAL_DEFAULT_MODEL = "openai/gpt-5.6-sol";
 
 export function catalogForRuntime(runtime: string): RuntimeModelCatalog | null {
-  const curated = RUNTIME_MODEL_CATALOG[runtime];
+  const canonicalRuntime = canonicalHarnessId(runtime);
+  const curated = RUNTIME_MODEL_CATALOG[canonicalRuntime];
   if (curated) return curated;
   // Registry-synced runtimes without a curated list get the runtime-managed
   // treatment: no menu, free-text only (same branch as openclaw above).
-  if (REGISTRY_RUNTIMES.some((entry) => entry.id === runtime)) {
+  if (REGISTRY_RUNTIMES.some((entry) => entry.id === canonicalRuntime)) {
     return {
-      runtime,
+      runtime: canonicalRuntime,
       provider: null,
       models: [],
       allowCustom: true,
@@ -233,10 +243,8 @@ export function isModelInCatalog(runtime: string, modelId: string): boolean {
 
 /** Translate a stable Cave model id only at the native runtime boundary. */
 export function modelForRuntimeLaunch(runtime: string, modelId: string): string {
-  if (
-    (runtime === "claude" || runtime === "claude-code") &&
-    modelId === CLAUDE_OPUS_5_CAVE_ID
-  ) {
+  const canonicalRuntime = canonicalHarnessId(runtime);
+  if (canonicalRuntime === "claude" && modelId === CLAUDE_OPUS_5_CAVE_ID) {
     return CLAUDE_OPUS_5_NATIVE_MODEL;
   }
   return modelId;

--- a/src/lib/slash-model.test.ts
+++ b/src/lib/slash-model.test.ts
@@ -41,6 +41,11 @@ assert.equal(resolveModelArg("Claude Sonnet 4.6", "claude"), "anthropic/claude-s
 assert.equal(resolveModelArg("anthropic/claude-haiku-4-5", "claude"), "anthropic/claude-haiku-4-5", "matches by exact id");
 assert.equal(resolveModelArg("sonnet", "claude"), "anthropic/claude-sonnet-5", "substring matches the newest Sonnet first");
 assert.equal(resolveModelArg("openai/gpt-6", "claude"), "openai/gpt-6", "accepts a valid custom id");
+assert.equal(
+  resolveModelArg("openrouter/~anthropic/claude-opus-latest", "opencode"),
+  "openrouter/~anthropic/claude-opus-latest",
+  "OpenCode provider aliases with a tilde-prefixed path segment remain selectable",
+);
 assert.equal(resolveModelArg("  ", "claude"), null, "empty arg → null");
 assert.equal(resolveModelArg("not a model!!", "claude"), null, "malformed custom id → null");
 assert.equal(

--- a/src/lib/slash-model.ts
+++ b/src/lib/slash-model.ts
@@ -3,16 +3,16 @@
 // Pure + client-safe (only depends on the runtime-models catalog); the model-id
 // shape is validated inline so this never pulls server code into the bundle.
 
-import { catalogForRuntime, type RuntimeModelOption } from "@/lib/runtime-models";
+import {
+  catalogForRuntime,
+  isSafeRuntimeModelId,
+  type RuntimeModelOption,
+} from "@/lib/runtime-models";
 
 // Composer text while in the argument position of /model (or /m): the user has
 // typed "/model " (with a space) and is now typing the model id/name. Group 1 is
 // the partial argument (possibly empty right after the space).
 const MODEL_ARG_RE = /^\/(?:model|m)\s+(.*)$/i;
-
-// Cave model ids follow `provider/model` with a conservative charset (mirrors
-// cleanModelId in chat-model-state.ts, inlined to keep this client-safe).
-const MODEL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._:/@+-]*$/;
 
 function modelsFor(
   harness: string | null | undefined,
@@ -59,7 +59,7 @@ export function resolveModelArg(
     (m) => m.id.toLowerCase().includes(lower) || m.label.toLowerCase().includes(lower),
   );
   if (partial) return partial.id;
-  return MODEL_ID_RE.test(a) ? a : null;
+  return isSafeRuntimeModelId(a) ? a : null;
 }
 
 /** One-line-per-model list for the `/model` (no-arg) system message. */

--- a/src/lib/slash-model.ts
+++ b/src/lib/slash-model.ts
@@ -1,7 +1,7 @@
 // Helpers for the `/model` slash command — resolving a typed model argument to
 // a concrete id, and the inline autocomplete options shown while typing it.
-// Pure + client-safe (only depends on the runtime-models catalog); the model-id
-// shape is validated inline so this never pulls server code into the bundle.
+// Pure + client-safe: both dependencies are data/string helpers with no server
+// imports, so every composer surface shares the same model-id contract.
 
 import {
   catalogForRuntime,


### PR DESCRIPTION
## Summary
- Recover the CLI parity changes for runtime model ids, OpenClaw bridge/conversation parsing, runtime availability, and chat send preflight.
- Keep the current send-route architecture intact while adding safer OpenClaw launch validation.
- Update focused tests for the changed runtime/OpenClaw surfaces.

## Verification
- pnpm check:tests-wired
- pnpm typecheck
- pnpm lint
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/runtime-models.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/chat-model-state.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/openclaw-bridge.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/openclaw-conversation.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/runtime-availability.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/slash-model.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/lib/openclaw-bin.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/app/api/capabilities/route.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/app/api/chat/send/harness-routing-host-session.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/chat-familiar-capabilities.test.ts
- node --experimental-strip-types --import ./scripts/test-alias-register.mjs src/components/familiar-studio-brain-tab.test.ts

## Notes
- Full pnpm test:app was attempted; it hit unrelated maintenance-gate test failures in scripts/maintenance-gate.test.mjs (existing flake outside this change).