### PR TITLE
feat(chat): add inline source previews

### DIFF
--- a/src/components/citation.test.ts
+++ b/src/components/citation.test.ts
@@ -4,116 +4,120 @@ import test from "node:test";
 
 const citation = readFileSync(new URL("./ui/citation.tsx", import.meta.url), "utf8");
 const bubble = readFileSync(new URL("./message-bubble.tsx", import.meta.url), "utf8");
+const domWiring = readFileSync(new URL("./message-dom-wiring.ts", import.meta.url), "utf8");
 const research = readFileSync(new URL("./role-surfaces/research-mission-detail.tsx", import.meta.url), "utf8");
+const markdownInteractions = readFileSync(new URL("../styles/cave-md/interactions.css", import.meta.url), "utf8");
 
-test("the Citation UI uses the shared Popover and Cave's accent hue", () => {
-  assert.match(citation, /export function CitationMarker/, "exports the inline marker");
-  assert.match(citation, /export function CitationSources/, "exports the sources list");
-  assert.match(citation, /import \{ Popover, PopoverBody \} from "@\/components\/ui\/popover"/, "the marker opens the shared Popover");
+test("the Citation UI exposes inline provider previews through the shared Popover", () => {
+  assert.match(citation, /export function InlineCitationPreviews/, "exports inline citation previews");
+  assert.match(citation, /export function CitationSources/, "keeps the research sources list");
+  assert.match(
+    citation,
+    /import \{ Popover, PopoverBody \} from "@\/components\/ui\/popover"/,
+    "source previews use the shared Popover",
+  );
   assert.match(
     citation,
     /createCitationPreviewCoordinator/,
-    "source previews coordinate hover and focus across the row and portaled card",
+    "previews coordinate hover and focus across the inline chip and portaled card",
   );
+  assert.match(citation, /citationSourcePresentation/, "preview content derives from the shared source classifier");
   assert.match(citation, /var\(--accent-presence\)/, "citations use the accent-presence hue");
   assert.match(
     citation,
-    /max-w-\[var\(--citation-card-w,272px\)\][^"]*gap-1[^"]*p-0/,
-    "preview cards use the compact desktop density contract",
+    /data-source-kind=\{presentation\.kind\}/,
+    "preview cards expose provider kind for distinct treatments",
   );
   assert.match(
     citation,
-    /line-clamp-2[^"]*leading-snug/,
+    /line-clamp-2[^"]*text-\[length:var\(--text-md\)\]/,
     "long source titles stay compact",
   );
   assert.match(
     citation,
     /line-clamp-3[^"]*leading-normal/,
-    "source excerpts preserve context without dominating the preview",
+    "source summaries preserve context without dominating the preview",
+  );
+  assert.match(citation, /presentation\.context/, "provider-specific context is visible in the preview");
+  assert.match(
+    citation,
+    /querySelectorAll<HTMLAnchorElement>\('a\[href\^="#cite-"\]'\)/,
+    "only citation anchors in rendered markdown are enhanced",
   );
   assert.match(
     citation,
-    /className="bg-\[var\(--bg-elevated\)\]"[\s\S]*?ariaLabel=\{`Source \$\{citation\.n\} preview`\}[\s\S]*?minWidth=\{272\}/,
-    "chat previews use the dense opaque evidence-card treatment",
-  );
-  assert.match(citation, /showHoverPreview = false/, "sources can opt into hover preview cards");
-  assert.match(
-    citation,
-    /onMouseEnter=\{showHoverPreview \? \(\) => preview\.enter\("row-hover"\) : undefined\}/,
-    "rows without previews do not wire hidden hover-open state",
+    /renderedHtml: string[\s\S]*?\[activate, citationsById, containerRef, onOpenUrl, preview, renderedHtml\]/,
+    "preview wiring reruns when the markdown renderer replaces its injected DOM",
   );
   assert.match(
     citation,
-    /onMouseLeave=\{showHoverPreview \? \(\) => preview\.leave\("row-hover"\) : undefined\}/,
-    "rows without previews do not wire hidden hover-close state",
+    /classList\.add\("cave-citation-chip"\)/,
+    "inline source anchors receive the evidence-chip treatment",
   );
   assert.match(
     citation,
-    /onFocusCapture=\{showHoverPreview \? \(\) => preview\.enter\("row-focus"\) : undefined\}/,
-    "rows without previews do not wire hidden focus-open state",
+    /dataset\.sourceKind = presentation\.kind/,
+    "inline chips expose their provider type",
   );
   assert.match(
     citation,
-    /onBlurCapture=\{showHoverPreview \? leaveRowFocus : undefined\}/,
-    "rows without previews do not wire hidden focus-close state",
+    /matchMedia\("\(hover: none\)"\)/,
+    "touch-only devices tap to preview rather than losing the hover content",
   );
-  assert.match(citation, /preview\.enter\("row-hover"\)/, "row hover opens a source preview");
-  assert.match(citation, /preview\.leave\("row-hover"\)/, "row hover departure participates in coordinated closing");
-  assert.match(citation, /preview\.enter\("row-focus"\)/, "row focus opens a source preview");
-  assert.match(citation, /preview\.leave\("row-focus"\)/, "row focus departure participates in coordinated closing");
+  assert.match(
+    citation,
+    /event\.stopImmediatePropagation\(\)/,
+    "citation clicks do not leak into generic markdown link routing",
+  );
+  assert.match(citation, /activate\(link, citation, "row-hover"\)/, "chip hover opens a source preview");
+  assert.match(citation, /preview\.leave\("row-hover"\)/, "chip hover departure participates in coordinated closing");
+  assert.match(citation, /activate\(link, citation, "row-focus"\)/, "chip focus opens a source preview");
+  assert.match(citation, /preview\.leave\("row-focus"\)/, "chip focus departure participates in coordinated closing");
   assert.match(citation, /preview\.enter\("preview-hover"\)/, "the portaled card can retain the preview across its gap");
   assert.match(citation, /preview\.leave\("preview-hover"\)/, "the portaled card releases hover ownership");
   assert.match(citation, /preview\.enter\("preview-focus"\)/, "focus within the portaled card retains the preview");
   assert.match(citation, /preview\.leave\("preview-focus"\)/, "the portaled card releases focus ownership");
+  assert.match(citation, /onOpenUrl\(citation\.url\)/, "link activation can route through the existing chat URL handler");
+  assert.match(citation, /target="_blank"/, "source cards retain a browser fallback without a URL handler");
   assert.match(
     citation,
-    /const previewTitleIsButton = showHoverPreview && !citation\.url/,
-    "URL-less preview rows get a conditional keyboard target",
+    /ariaLabel=\{`\$\{presentation\.provider\} source preview`\}/,
+    "hover previews are announced accessibly",
   );
-  assert.match(
-    citation,
-    /previewTitleIsButton \? \(\s*<button[\s\S]*?type="button"[\s\S]*?aria-haspopup="dialog"/,
-    "the URL-less title is a semantic preview button without changing linked rows",
-  );
-  assert.doesNotMatch(
-    citation,
-    /<li[\s\S]*?ref=\{anchorRef\}/,
-    "the preview anchor is never the non-focusable source row",
-  );
-  assert.match(
-    citation,
-    /citation\.url \? \(\s*<a[\s\S]*?ref=\{setAnchorRef\}/,
-    "linked previews anchor to the source link so Popover can return focus",
-  );
-  assert.match(
-    citation,
-    /previewTitleIsButton \? \(\s*<button[\s\S]*?ref=\{setAnchorRef\}/,
-    "URL-less previews anchor to their keyboard target so Popover can return focus",
-  );
-  assert.match(
-    citation,
-    /onClick=\{\(\) => \(open \? preview\.dismiss\(\) : preview\.enter\("row-focus"\)\)\}/,
-    "the URL-less preview control toggles its aria-expanded dialog",
-  );
-  assert.match(citation, /ariaLabel=\{`Source \$\{citation\.n\} preview`\}/, "hover previews are announced accessibly");
-  // The sources list rows are anchor targets so inline markers can jump to them.
-  assert.match(citation, /id=\{citation\.id\}/, "each source row is an anchor target");
-  assert.match(citation, /aria-label=\{`Source \$\{citation\.n\}: \$\{citation\.title\}`\}/, "markers are named for screen readers");
+  assert.match(citation, /Open source:/, "inline source chips are named for screen readers");
   assert.match(citation, /rel="noreferrer"/, "external source links are safe");
+  assert.match(
+    markdownInteractions,
+    /\.cave-md a\.cave-citation-chip \{[\s\S]*?border-radius: var\(--radius-pill\);/,
+    "inline sources use the shared pill shape",
+  );
+  assert.match(
+    markdownInteractions,
+    /\.cave-md a\.cave-citation-chip:focus-visible \{[\s\S]*?var\(--ring-focus\)/,
+    "inline sources retain the shared keyboard focus treatment",
+  );
+  assert.match(
+    domWiring,
+    /link\.getAttribute\("href"\)\?\.startsWith\("#cite-"\)/,
+    "generic markdown link wiring leaves citation links to the preview component",
+  );
 });
 
-test("chat renders citations as a footer below the message, not inside the sanitized HTML", () => {
-  assert.match(bubble, /import \{ renderCitedBody \} from "@\/lib\/citations"/, "the bubble lifts footnote citations from the body");
-  assert.match(bubble, /import \{ CitationSources \} from "@\/components\/ui\/citation"/, "renders the shared sources footer");
+test("chat renders inline source previews without a numbered Sources footer", () => {
+  assert.match(bubble, /renderCitedBody,[\s\S]*?from "@\/lib\/citations"/, "the bubble lifts footnote citations from the body");
+  assert.match(bubble, /import \{ InlineCitationPreviews \} from "@\/components\/ui\/citation"/, "renders inline source previews");
   assert.match(bubble, /const cited = useMemo\(\(\) => renderCitedBody\(content\), \[content\]\)/, "citations are parsed once per body");
-  // The parsed body (defs stripped, refs rewritten to anchors) feeds the renderer…
-  assert.match(bubble, /<MarkdownContent text=\{cited\.body\}/, "the def-stripped body feeds the markdown renderer");
-  // …and the sources render as a sibling footer, never inside the HTML string.
   assert.match(
     bubble,
-    /cited\.citations\.length > 0 \? <CitationSources citations=\{cited\.citations\} showHoverPreview \/>/,
-    "chat opts into hover-preview citation sources",
+    /<MarkdownContent[\s\S]{0,120}?text=\{cited\.body\}/,
+    "the definition-free body feeds the markdown renderer",
   );
+  assert.match(
+    bubble,
+    /<InlineCitationPreviews[\s\S]*citations=\{citations\}[\s\S]*containerRef=\{containerRef\}[\s\S]*renderedHtml=\{html\}/,
+    "the rendered markdown container is enhanced with inline previews",
+  );
+  assert.doesNotMatch(bubble, /<CitationSources citations=\{cited\.citations\}/, "chat no longer renders a Sources footer");
 });
 
 test("research cites the mission's used sources under the synthesis", () => {

--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -314,6 +314,11 @@ assert.match(
 );
 assert.match(
   domWiring,
+  /link\.classList\.contains\("cave-citation-chip"\)/,
+  "The generic markdown linker should never claim an enhanced citation chip",
+);
+assert.match(
+  domWiring,
   /event\.preventDefault\(\)[\s\S]*onOpenUrl\(href\)/,
   "Markdown link clicks should prevent normal navigation and open in the provided browser target",
 );

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -39,8 +39,13 @@ import type { Block } from "@create-markdown/core";
 import type { PreviewPlugin } from "@create-markdown/preview";
 import { getShikiHighlighter } from "@/lib/shiki-highlighter";
 import { Icon } from "@/lib/icon";
-import { renderCitedBody } from "@/lib/citations";
-import { CitationSources } from "@/components/ui/citation";
+import {
+  parseCitations,
+  renderCitedBody,
+  renderCitationReferences,
+  type Citation,
+} from "@/lib/citations";
+import { InlineCitationPreviews } from "@/components/ui/citation";
 import { classifyDiffLines, parseFenceInfo, type DiffLine } from "@/lib/message-code-fences";
 import { getFeedback, setFeedback, recordFeedbackAnalytics, type Feedback, type FeedbackContext } from "@/lib/message-feedback";
 import { SpeakBubble } from "@/components/speak-bubble";
@@ -691,7 +696,14 @@ async function mdToHtml(
 // plain fallback only until the first render lands
 // ---------------------------------------------------------------------------
 
-function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?: boolean; onOpenUrl?: (url: string) => void }) {
+type MarkdownContentProps = {
+  text: string;
+  pending?: boolean;
+  onOpenUrl?: (url: string) => void;
+  citations?: readonly Citation[];
+};
+
+function MarkdownContent({ text, pending, onOpenUrl, citations = [] }: MarkdownContentProps) {
   const [html, setHtml] = useState<string | null>(
     () => pending ? null : renderCacheGet(text) ?? null,
   );
@@ -813,6 +825,12 @@ function MarkdownContent({ text, pending, onOpenUrl }: { text: string; pending?:
       {pending ? (
         <span aria-hidden="true" className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
       ) : null}
+      <InlineCitationPreviews
+        citations={citations}
+        containerRef={containerRef}
+        onOpenUrl={onOpenUrl}
+        renderedHtml={html}
+      />
     </>
   );
 }
@@ -941,6 +959,10 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
   // pipeline). Bodies without footnotes pass through unchanged. Mid-stream the
   // definition block hasn't arrived, so this is a no-op until the turn settles.
   const cited = useMemo(() => renderCitedBody(content), [content]);
+  const segmentedCitations = useMemo(
+    () => (segments?.length ? parseCitations(content) : null),
+    [content, segments],
+  );
 
   if (role === "system") {
     return (
@@ -1027,17 +1049,31 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
     >
       <div className={isError ? "text-[var(--color-warning)]" : ""}>
         {segments?.length ? (
-          segments.map((seg, i) =>
-            seg.kind === "text" ? (
-              <MarkdownContent key={`span-${i}`} text={seg.text} pending={pending && i === lastTextIdx} onOpenUrl={onOpenUrl} />
-            ) : (
-              <div key={seg.key} className="my-2">{seg.node}</div>
-            ),
-          )
+          segments.map((seg, i) => {
+            if (seg.kind === "block") {
+              return <div key={seg.key} className="my-2">{seg.node}</div>;
+            }
+            const text = segmentedCitations
+              ? renderCitationReferences(seg.text, segmentedCitations)
+              : seg.text;
+            return (
+              <MarkdownContent
+                key={`span-${i}`}
+                text={text}
+                pending={pending && i === lastTextIdx}
+                onOpenUrl={onOpenUrl}
+                citations={cited.citations}
+              />
+            );
+          })
         ) : (
-          <MarkdownContent text={cited.body} pending={pending} onOpenUrl={onOpenUrl} />
+          <MarkdownContent
+            text={cited.body}
+            pending={pending}
+            onOpenUrl={onOpenUrl}
+            citations={cited.citations}
+          />
         )}
-        {cited.citations.length > 0 ? <CitationSources citations={cited.citations} showHoverPreview /> : null}
       </div>
       {/* Always in the DOM (CHAT-D6-04) — visibility is CSS-gated so the
           actions are reachable by keyboard (Tab), screen readers, and touch. */}

--- a/src/components/message-dom-wiring.ts
+++ b/src/components/message-dom-wiring.ts
@@ -72,6 +72,10 @@ function wireCopyButtons(container: HTMLElement) {
 function wireMarkdownLinks(container: HTMLElement, onOpenUrl?: (url: string) => void) {
   if (!onOpenUrl) return;
   for (const link of Array.from(container.querySelectorAll<HTMLAnchorElement>("a[href]"))) {
+    if (
+      link.getAttribute("href")?.startsWith("#cite-") ||
+      link.classList.contains("cave-citation-chip")
+    ) continue;
     if ((link as HTMLAnchorElement & { _caveLinkWired?: boolean })._caveLinkWired) continue;
     const href = link.href;
     let parsed: URL;

--- a/src/components/ui/citation.tsx
+++ b/src/components/ui/citation.tsx
@@ -1,128 +1,261 @@
 "use client";
 
-/**
- * Citation UI — shared across chat responses and research artifacts.
- *
- * `CitationMarker` is an inline superscript chip (¹) that opens a source card in
- * the shared Popover. `CitationSources` is the numbered "Sources" list rendered
- * below a body; its rows are anchor targets (`id="cite-N"`) so inline markers
- * can jump to them. Both take the shared `Citation` shape and lean on Cave's
- * tokens (accent-presence for the citation hue, the type scale for sizing).
- */
-
-import { useCallback, useEffect, useMemo, useRef, useState, type FocusEvent } from "react";
-import { Icon } from "@/lib/icon";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type MouseEvent as ReactMouseEvent,
+  type RefObject,
+} from "react";
+import { Icon, type IconName } from "@/lib/icon";
 import { Popover, PopoverBody } from "@/components/ui/popover";
 import { createCitationPreviewCoordinator } from "@/lib/citation-preview";
-import type { Citation } from "@/lib/citations";
+import {
+  citationSourcePresentation,
+  type Citation,
+  type CitationSourceKind,
+} from "@/lib/citations";
 
-function CitationCard({ citation }: { citation: Citation }) {
+const SOURCE_ICONS: Record<CitationSourceKind, IconName> = {
+  github: "ph:github-logo",
+  arxiv: "ph:graduation-cap",
+  doi: "ph:graduation-cap",
+  wikipedia: "ph:book-open",
+  video: "ph:video",
+  document: "ph:file-text",
+  web: "ph:globe",
+  reference: "ph:link",
+};
+
+function isPlainPrimaryClick(event: ReactMouseEvent<HTMLAnchorElement>): boolean {
   return (
-    <div className="flex max-w-[var(--citation-card-w,272px)] flex-col gap-1 p-0">
-      <div className="flex items-center gap-1">
-        <span className="flex h-4 min-w-4 items-center justify-center rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_16%,transparent)] px-1 text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]">
-          {citation.n}
-        </span>
-        {citation.domain ? (
-          <span className="truncate text-[length:var(--text-2xs)] uppercase tracking-widest text-[var(--text-muted)]">
-            {citation.domain}
-          </span>
-        ) : null}
-      </div>
-      {citation.url ? (
-        <a
-          href={citation.url}
-          target="_blank"
-          rel="noreferrer"
-          className="focus-ring inline-flex w-full items-start gap-1 text-[length:var(--text-sm)] font-medium leading-snug text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
-        >
-          <span className="min-w-0 line-clamp-2 break-words">{citation.title}</span>
-          <Icon name="ph:arrow-square-out" width={12} height={12} className="mt-0.5 shrink-0" aria-hidden />
-        </a>
-      ) : (
-        <span className="line-clamp-2 break-words text-[length:var(--text-sm)] font-medium leading-snug text-[var(--text-primary)]">
-          {citation.title}
-        </span>
-      )}
-      {citation.snippet ? (
-        <p className="line-clamp-3 text-[length:var(--text-xs)] leading-normal text-[var(--text-secondary)]">
-          {citation.snippet}
-        </p>
-      ) : null}
-    </div>
+    event.button === 0 &&
+    !event.metaKey &&
+    !event.ctrlKey &&
+    !event.shiftKey &&
+    !event.altKey
   );
 }
 
-/** Inline superscript citation marker that opens its source card on click. */
-export function CitationMarker({ citation }: { citation: Citation }) {
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
-  const [open, setOpen] = useState(false);
-  return (
-    <>
-      <button
-        ref={anchorRef}
-        type="button"
-        aria-label={`Source ${citation.n}: ${citation.title}`}
-        aria-expanded={open}
-        onClick={() => setOpen((o) => !o)}
-        className="focus-ring relative -top-[0.35em] mx-px inline-flex min-w-[1.1em] items-center justify-center rounded-[3px] bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)] px-1 align-baseline text-[0.66em] font-semibold text-[var(--accent-presence)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_22%,transparent)]"
-      >
-        {citation.n}
-      </button>
-      <Popover
-        open={open}
-        onOpenChange={setOpen}
-        anchorRef={anchorRef}
-        placement="top-start"
-        ariaLabel={`Source ${citation.n}`}
-        minWidth={240}
-      >
-        <PopoverBody>
-          <CitationCard citation={citation} />
-        </PopoverBody>
-      </Popover>
-    </>
-  );
-}
-
-/** The "Sources" list rendered under a cited body. Anchor targets for markers. */
-function CitationSourceRow({
+function CitationCard({
   citation,
-  showHoverPreview,
+  onOpenUrl,
 }: {
   citation: Citation;
-  showHoverPreview: boolean;
+  onOpenUrl?: (url: string) => void;
 }) {
-  const anchorRef = useRef<HTMLElement | null>(null);
-  const [open, setOpen] = useState(false);
-  const preview = useMemo(() => createCitationPreviewCoordinator(setOpen), [setOpen]);
-  const previewTitleIsButton = showHoverPreview && !citation.url;
-  const setAnchorRef = useCallback((element: HTMLElement | null) => {
-    anchorRef.current = element;
-  }, []);
-
-  useEffect(() => () => preview.dispose(), [preview]);
-
-  const leaveRowFocus = (event: FocusEvent<HTMLLIElement>) => {
-    const next = event.relatedTarget;
-    if (next instanceof Node && event.currentTarget.contains(next)) return;
-    preview.leave("row-focus");
-  };
-  const leavePreviewFocus = (event: FocusEvent<HTMLDivElement>) => {
-    const next = event.relatedTarget;
-    if (next instanceof Node && event.currentTarget.contains(next)) return;
-    preview.leave("preview-focus");
+  const presentation = citationSourcePresentation(citation);
+  const openSource = (event: ReactMouseEvent<HTMLAnchorElement>) => {
+    if (!citation.url || !onOpenUrl || !isPlainPrimaryClick(event)) return;
+    event.preventDefault();
+    onOpenUrl(citation.url);
   };
 
   return (
-    <li
-      id={citation.id}
-      className="flex scroll-mt-4 items-start gap-2"
-      onMouseEnter={showHoverPreview ? () => preview.enter("row-hover") : undefined}
-      onMouseLeave={showHoverPreview ? () => preview.leave("row-hover") : undefined}
-      onFocusCapture={showHoverPreview ? () => preview.enter("row-focus") : undefined}
-      onBlurCapture={showHoverPreview ? leaveRowFocus : undefined}
+    <article
+      data-source-kind={presentation.kind}
+      className="flex w-[var(--citation-card-w,320px)] max-w-[calc(100vw-var(--space-8))] flex-col overflow-hidden"
     >
+      <header className="flex items-start gap-3 border-b border-[var(--border-hairline)] bg-[color-mix(in_oklch,var(--accent-presence)_6%,transparent)] p-3">
+        <span className="flex h-[var(--space-8)] w-[var(--space-8)] shrink-0 items-center justify-center rounded-[var(--radius-control)] border border-[color-mix(in_oklch,var(--accent-presence)_36%,var(--border-hairline))] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] text-[var(--accent-presence)]">
+          <Icon name={SOURCE_ICONS[presentation.kind]} width={16} height={16} aria-hidden />
+        </span>
+        <span className="min-w-0">
+          <span className="block text-[length:var(--text-2xs)] font-semibold uppercase tracking-widest text-[var(--accent-presence)]">
+            {presentation.provider}
+          </span>
+          <span className="mt-0.5 block truncate font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+            {presentation.context}
+          </span>
+        </span>
+      </header>
+
+      <div className="flex flex-col gap-2 p-3">
+        <h3 className="line-clamp-2 break-words text-[length:var(--text-md)] font-semibold leading-snug text-[var(--text-primary)]">
+          {citation.title}
+        </h3>
+        <p className="line-clamp-3 text-[length:var(--text-xs)] leading-normal text-[var(--text-secondary)]">
+          {presentation.summary}
+        </p>
+      </div>
+
+      <footer className="flex items-center justify-between gap-2 border-t border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2">
+        <span className="min-w-0 truncate text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+          {citation.domain || (citation.url ? "External source" : "Local reference")}
+        </span>
+        {citation.url ? (
+          <a
+            href={citation.url}
+            target="_blank"
+            rel="noreferrer"
+            onClick={openSource}
+            className="focus-ring inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-control)] px-2 py-1 text-[length:var(--text-xs)] font-medium text-[var(--accent-presence)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)]"
+          >
+            Open source
+            <Icon name="ph:arrow-square-out" width={12} height={12} aria-hidden />
+          </a>
+        ) : (
+          <span className="text-[length:var(--text-2xs)] text-[var(--text-muted)]">No link provided</span>
+        )}
+      </footer>
+    </article>
+  );
+}
+
+export function InlineCitationPreviews({
+  citations,
+  containerRef,
+  onOpenUrl,
+  renderedHtml,
+}: {
+  citations: readonly Citation[];
+  containerRef: RefObject<HTMLElement | null>;
+  onOpenUrl?: (url: string) => void;
+  renderedHtml: string;
+}) {
+  const anchorRef = useRef<HTMLElement | null>(null);
+  const [activeCitation, setActiveCitation] = useState<Citation | null>(null);
+  const [open, setOpen] = useState(false);
+  const preview = useMemo(() => createCitationPreviewCoordinator(setOpen), []);
+  const citationsById = useMemo(
+    () => new Map(citations.map((citation) => [citation.id, citation])),
+    [citations],
+  );
+  const presentation = activeCitation
+    ? citationSourcePresentation(activeCitation)
+    : null;
+
+  useEffect(() => () => preview.dispose(), [preview]);
+  useEffect(() => {
+    anchorRef.current?.setAttribute("aria-expanded", open ? "true" : "false");
+  }, [open]);
+
+  const activate = useCallback(
+    (
+      link: HTMLAnchorElement,
+      citation: Citation,
+      interaction: "row-hover" | "row-focus",
+    ) => {
+      if (anchorRef.current !== link) {
+        anchorRef.current?.setAttribute("aria-expanded", "false");
+        anchorRef.current = link;
+      }
+      setActiveCitation(citation);
+      link.setAttribute("aria-expanded", "true");
+      preview.enter(interaction);
+    },
+    [preview],
+  );
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || citationsById.size === 0) return;
+    anchorRef.current = null;
+    setActiveCitation(null);
+    preview.dismiss();
+
+    const cleanups: Array<() => void> = [];
+    for (const link of container.querySelectorAll<HTMLAnchorElement>('a[href^="#cite-"]')) {
+      const href = link.getAttribute("href");
+      const citation = href ? citationsById.get(href.slice(1)) : undefined;
+      if (!citation) continue;
+      const presentation = citationSourcePresentation(citation);
+
+      link.classList.add("cave-citation-chip");
+      link.dataset.sourceKind = presentation.kind;
+      link.setAttribute("aria-label", `Open source: ${citation.title}. ${presentation.provider}.`);
+      link.setAttribute("aria-haspopup", "dialog");
+      link.setAttribute("aria-expanded", "false");
+
+      const onMouseEnter = () => activate(link, citation, "row-hover");
+      const onMouseLeave = () => preview.leave("row-hover");
+      const onFocus = () => activate(link, citation, "row-focus");
+      const onBlur = () => preview.leave("row-focus");
+      const onClick = (event: MouseEvent) => {
+        event.stopImmediatePropagation();
+        if (!citation.url || window.matchMedia("(hover: none)").matches) {
+          event.preventDefault();
+          activate(link, citation, "row-focus");
+          return;
+        }
+        if (
+          onOpenUrl &&
+          event.button === 0 &&
+          !event.metaKey &&
+          !event.ctrlKey &&
+          !event.shiftKey &&
+          !event.altKey
+        ) {
+          event.preventDefault();
+          onOpenUrl(citation.url);
+        }
+      };
+
+      if (citation.url) {
+        link.href = citation.url;
+        link.target = "_blank";
+        link.rel = "noreferrer";
+      }
+      link.addEventListener("mouseenter", onMouseEnter);
+      link.addEventListener("mouseleave", onMouseLeave);
+      link.addEventListener("focus", onFocus);
+      link.addEventListener("blur", onBlur);
+      link.addEventListener("click", onClick);
+
+      cleanups.push(() => {
+        link.removeEventListener("mouseenter", onMouseEnter);
+        link.removeEventListener("mouseleave", onMouseLeave);
+        link.removeEventListener("focus", onFocus);
+        link.removeEventListener("blur", onBlur);
+        link.removeEventListener("click", onClick);
+        link.classList.remove("cave-citation-chip");
+        delete link.dataset.sourceKind;
+        link.removeAttribute("aria-label");
+        link.removeAttribute("aria-haspopup");
+        link.removeAttribute("aria-expanded");
+        link.removeAttribute("target");
+        link.removeAttribute("rel");
+        if (href) link.setAttribute("href", href);
+      });
+    }
+
+    return () => {
+      for (const cleanup of cleanups) cleanup();
+    };
+  }, [activate, citationsById, containerRef, onOpenUrl, preview, renderedHtml]);
+
+  if (!activeCitation || !presentation) return null;
+  return (
+    <Popover
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (nextOpen) setOpen(true);
+        else preview.dismiss();
+      }}
+      anchorRef={anchorRef}
+      placement="top-start"
+      className="bg-[var(--bg-elevated)]"
+      ariaLabel={`${presentation.provider} source preview`}
+    >
+      <PopoverBody className="p-0">
+        <div
+          onMouseEnter={() => preview.enter("preview-hover")}
+          onMouseLeave={() => preview.leave("preview-hover")}
+          onFocusCapture={() => preview.enter("preview-focus")}
+          onBlurCapture={() => preview.leave("preview-focus")}
+        >
+          <CitationCard citation={activeCitation} onOpenUrl={onOpenUrl} />
+        </div>
+      </PopoverBody>
+    </Popover>
+  );
+}
+
+function CitationSourceRow({ citation }: { citation: Citation }) {
+  return (
+    <li id={citation.id} className="flex scroll-mt-4 items-start gap-2">
       <span
         aria-hidden
         className="mt-0.5 flex h-4 min-w-4 shrink-0 items-center justify-center rounded-[var(--radius-control)] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] px-1 text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]"
@@ -133,7 +266,6 @@ function CitationSourceRow({
         <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
           {citation.url ? (
             <a
-              ref={setAnchorRef}
               href={citation.url}
               target="_blank"
               rel="noreferrer"
@@ -142,17 +274,6 @@ function CitationSourceRow({
               {citation.title}
               <Icon name="ph:arrow-square-out" width={11} height={11} className="shrink-0" aria-hidden />
             </a>
-          ) : previewTitleIsButton ? (
-            <button
-              ref={setAnchorRef}
-              type="button"
-              aria-haspopup="dialog"
-              aria-expanded={open}
-              onClick={() => (open ? preview.dismiss() : preview.enter("row-focus"))}
-              className="focus-ring text-left text-[length:var(--text-sm)] font-medium text-[var(--text-primary)] hover:text-[var(--accent-presence)]"
-            >
-              {citation.title}
-            </button>
           ) : (
             <span className="text-[length:var(--text-sm)] font-medium text-[var(--text-primary)]">
               {citation.title}
@@ -168,31 +289,6 @@ function CitationSourceRow({
           </p>
         ) : null}
       </div>
-      {showHoverPreview ? (
-        <Popover
-          open={open}
-          onOpenChange={(nextOpen) => {
-            if (nextOpen) setOpen(true);
-            else preview.dismiss();
-          }}
-          anchorRef={anchorRef}
-          placement="top-start"
-          className="bg-[var(--bg-elevated)]"
-          ariaLabel={`Source ${citation.n} preview`}
-          minWidth={272}
-        >
-          <PopoverBody>
-            <div
-              onMouseEnter={() => preview.enter("preview-hover")}
-              onMouseLeave={() => preview.leave("preview-hover")}
-              onFocusCapture={() => preview.enter("preview-focus")}
-              onBlurCapture={leavePreviewFocus}
-            >
-              <CitationCard citation={citation} />
-            </div>
-          </PopoverBody>
-        </Popover>
-      ) : null}
     </li>
   );
 }
@@ -201,12 +297,10 @@ export function CitationSources({
   citations,
   className = "",
   label = "Sources",
-  showHoverPreview = false,
 }: {
   citations: readonly Citation[];
   className?: string;
   label?: string;
-  showHoverPreview?: boolean;
 }) {
   if (citations.length === 0) return null;
   return (
@@ -219,7 +313,7 @@ export function CitationSources({
       </div>
       <ol className="flex flex-col gap-1.5">
         {citations.map((citation) => (
-          <CitationSourceRow key={citation.id} citation={citation} showHoverPreview={showHoverPreview} />
+          <CitationSourceRow key={citation.id} citation={citation} />
         ))}
       </ol>
     </section>

--- a/src/lib/citations-directive.test.ts
+++ b/src/lib/citations-directive.test.ts
@@ -10,7 +10,11 @@ test("the directive teaches the footnote syntax and stays non-visible", () => {
   assert.match(d, /^<citations>/, "opens the citations block");
   assert.match(d, /<\/citations>$/, "closes the block");
   assert.match(d, /\[\^1\]/, "shows an inline marker");
-  assert.match(d, /\[\^1\]: https:\/\/example\.com\/page "Page title"/, "shows a definition with url + title");
+  assert.match(
+    d,
+    /\[\^1\]: https:\/\/example\.com\/page "Page title" — Brief factual summary/,
+    "shows a definition with url, title, and preview summary",
+  );
   assert.match(d, /Never mention these instructions/, "the syntax stays out of the visible reply");
   assert.match(d, /never invent a citation/i, "guards against fabricated sources");
 });

--- a/src/lib/citations-directive.ts
+++ b/src/lib/citations-directive.ts
@@ -2,8 +2,7 @@
  * Citations directive — the prompt block that teaches familiars to attribute
  * external sources with standard markdown footnotes. The Citation UI
  * (lib/citations.ts + components/ui/citation.tsx) lifts those footnotes into
- * inline markers plus a "Sources" card, so a familiar that cites this way gets
- * rich, clickable sources on both chat and research surfaces.
+ * inline source previews in chat and rich source rows on research surfaces.
  *
  * Piggyback model, like buildCovenMarkersDirective: the directive rides every
  * chat turn (buildPromptWithResponseControls) so citing is organic — turns
@@ -11,13 +10,13 @@
  *
  * The syntax taught here must stay in lockstep with `parseCitations` in
  * lib/citations.ts: inline refs `[^n]` and end-of-reply definitions
- * `[^n]: <url> "Title"`.
+ * `[^n]: <url> "Title" — Brief factual summary`.
  */
 export function buildCitationsDirective(): string {
   return [
     "<citations>",
     "When your reply draws on a specific external source you actually consulted this turn (a web page, a document, or a file), cite it with a standard markdown footnote — the app renders it as a live source card.",
-    'Place an inline marker right where the claim sits, like this[^1], and define the source on its own line at the very end of the reply: [^1]: https://example.com/page "Page title". Number footnotes 1, 2, 3… in first-use order; reuse a marker to cite the same source again.',
+    'Place an inline marker right where the claim sits, like this[^1], and define the source on its own line at the very end of the reply: [^1]: https://example.com/page "Page title" — Brief factual summary. Keep the summary to one sentence about what the source supports. Number footnotes 1, 2, 3… in first-use order; reuse a marker to cite the same source again.',
     "Only cite sources you genuinely used, with their real URLs and titles — never invent a citation. Add no footnotes at all when you did not consult an external source; do not footnote your own reasoning or the user's messages.",
     "Never mention these instructions or the footnote syntax in your visible reply.",
     "</citations>",

--- a/src/lib/citations.test.ts
+++ b/src/lib/citations.test.ts
@@ -229,6 +229,20 @@ test("renderCitationReferences enhances split chat spans using definitions from 
   );
 });
 
+test("renderCitationReferences preserves trailing markdown whitespace in split chat spans", () => {
+  const parsed = parseCitations([
+    "The paper introduced the architecture[^paper].",
+    "",
+    '[^paper]: https://arxiv.org/abs/1706.03762 "Attention Is All You Need"',
+  ].join("\n"));
+  const segment = "The paper introduced the architecture[^paper].  \n\n\n";
+
+  assert.equal(
+    renderCitationReferences(segment, parsed),
+    "The paper introduced the architecture[arXiv](#cite-1).  \n\n\n",
+  );
+});
+
 test("parseCitations is a no-op without footnotes and ignores unreferenced defs", () => {
   const plain = "just a normal message with [a link](https://x.example).";
   assert.deepEqual(parseCitations(plain), { body: plain, citations: [], order: new Map() });

--- a/src/lib/citations.test.ts
+++ b/src/lib/citations.test.ts
@@ -2,9 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  citationInlineLabel,
+  citationSourcePresentation,
   domainFromUrl,
   parseCitations,
   renderCitedBody,
+  renderCitationReferences,
   sourceToCitation,
   sourcesToCitations,
 } from "./citations.ts";
@@ -78,15 +81,152 @@ test("parseCitations understands angle, bare, and prose definition forms", () =>
   ]);
 });
 
-test("renderCitedBody rewrites inline refs to anchor links and passes plain text through", () => {
-  const cited = renderCitedBody('see [^a] and [^b]\n\n[^a]: https://a.example\n[^b]: https://b.example');
-  // [^a] → [1](#cite-1), [^b] → [2](#cite-2); definitions stripped.
-  assert.match(cited.body, /see \[1\]\(#cite-1\) and \[2\]\(#cite-2\)/);
+test("parseCitations preserves a brief source summary after the title", () => {
+  const text = [
+    "A cited claim[^1].",
+    "",
+    '[^1]: https://example.com/report "Annual report" — Explains the year-over-year result.',
+  ].join("\n");
+
+  const { citations } = parseCitations(text);
+
+  assert.equal(citations[0].snippet, "Explains the year-over-year result.");
+});
+
+test("citationSourcePresentation identifies GitHub resources", () => {
+  const pullRequest = citationSourcePresentation({
+    n: 1,
+    id: "cite-1",
+    title: "Inline source previews",
+    url: "https://github.com/OpenCoven/coven-cave/pull/4102",
+    domain: "github.com",
+  });
+  const commit = citationSourcePresentation({
+    n: 2,
+    id: "cite-2",
+    title: "Fix citation rendering",
+    url: "https://github.com/OpenCoven/coven-cave/commit/1234567890abcdef",
+    domain: "github.com",
+  });
+
+  assert.equal(pullRequest.kind, "github");
+  assert.equal(pullRequest.provider, "GitHub");
+  assert.equal(pullRequest.context, "OpenCoven/coven-cave · Pull request #4102");
+  assert.match(pullRequest.summary, /Preview text wasn't provided/);
+  assert.equal(commit.context, "OpenCoven/coven-cave · Commit 1234567");
+});
+
+test("citationSourcePresentation identifies research publications", () => {
+  const arxiv = citationSourcePresentation({
+    n: 1,
+    id: "cite-1",
+    title: "Attention Is All You Need",
+    url: "https://arxiv.org/pdf/1706.03762",
+    domain: "arxiv.org",
+  });
+  const doi = citationSourcePresentation({
+    n: 2,
+    id: "cite-2",
+    title: "A journal article",
+    url: "https://doi.org/10.1000/example",
+    domain: "doi.org",
+  });
+
+  assert.deepEqual(
+    [arxiv.kind, arxiv.provider, arxiv.context],
+    ["arxiv", "arXiv", "Research paper · 1706.03762"],
+  );
+  assert.deepEqual(
+    [doi.kind, doi.provider, doi.context],
+    ["doi", "DOI", "Publication · 10.1000/example"],
+  );
+});
+
+test("citationSourcePresentation tolerates malformed URL escapes", () => {
+  const doi = citationSourcePresentation({
+    n: 1,
+    id: "cite-1",
+    title: "Malformed DOI",
+    url: "https://doi.org/10.1000/%E0%A4%A",
+    domain: "doi.org",
+  });
+  const wikipedia = citationSourcePresentation({
+    n: 2,
+    id: "cite-2",
+    title: "Malformed article",
+    url: "https://en.wikipedia.org/wiki/%E0%A4%A",
+    domain: "en.wikipedia.org",
+  });
+
+  assert.match(doi.context, /10\.1000\/%E0%A4%A/);
+  assert.match(wikipedia.context, /%E0%A4%A/);
+});
+
+test("citationSourcePresentation provides distinct media and web fallbacks", () => {
+  const cases = [
+    ["https://en.wikipedia.org/wiki/Accessible_Rich_Internet_Applications", "wikipedia", "Wikipedia"],
+    ["https://youtu.be/dQw4w9WgXcQ", "video", "YouTube"],
+    ["https://example.com/report.pdf", "document", "PDF"],
+    ["https://example.com/guide", "web", "example.com"],
+  ] as const;
+
+  for (const [url, kind, provider] of cases) {
+    const presentation = citationSourcePresentation({
+      n: 1,
+      id: "cite-1",
+      title: "Source title",
+      url,
+      domain: domainFromUrl(url),
+    });
+    assert.equal(presentation.kind, kind);
+    assert.equal(presentation.provider, provider);
+    assert.ok(presentation.summary.length > 0);
+  }
+
+  const local = citationSourcePresentation({
+    n: 1,
+    id: "cite-1",
+    title: "Local design notes",
+    snippet: "A project-local reference.",
+  });
+  assert.deepEqual(
+    [local.kind, local.provider, local.context, local.summary],
+    ["reference", "Reference", "Provided in this chat", "A project-local reference."],
+  );
+});
+
+test("renderCitedBody rewrites inline refs to provider labels and passes plain text through", () => {
+  const cited = renderCitedBody([
+    "see [^a], [^b], and [^c]",
+    "",
+    '[^a]: https://github.com/OpenCoven/coven-cave/pull/4102 "Inline source previews"',
+    '[^b]: https://arxiv.org/abs/1706.03762 "Attention Is All You Need"',
+    '[^c]: https://example.com/guide "A web guide"',
+  ].join("\n"));
+  assert.match(cited.body, /see \[GitHub\]\(#cite-1\), \[arXiv\]\(#cite-2\), and \[example\.com\]\(#cite-3\)/);
   assert.doesNotMatch(cited.body, /\[\^a\]:/);
-  assert.equal(cited.citations.length, 2);
+  assert.equal(cited.citations.length, 3);
+  assert.equal(citationInlineLabel(cited.citations[0]), "GitHub");
   // Plain text (no footnotes) is returned verbatim.
   const plain = renderCitedBody("nothing to cite here");
   assert.deepEqual(plain, { body: "nothing to cite here", citations: [] });
+});
+
+test("renderCitationReferences enhances split chat spans using definitions from the full turn", () => {
+  const parsed = parseCitations([
+    "The paper introduced the architecture[^paper].",
+    "",
+    '[^paper]: https://arxiv.org/abs/1706.03762 "Attention Is All You Need"',
+  ].join("\n"));
+
+  assert.equal(
+    renderCitationReferences("The paper introduced the architecture[^paper].", parsed),
+    "The paper introduced the architecture[arXiv](#cite-1).",
+  );
+  assert.equal(
+    renderCitationReferences('[^paper]: https://arxiv.org/abs/1706.03762 "Attention Is All You Need"', parsed),
+    "",
+  );
 });
 
 test("parseCitations is a no-op without footnotes and ignores unreferenced defs", () => {

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -1,15 +1,14 @@
 /**
  * citations — shared parsing + shaping for the Citation UI (chat + research).
  *
- * A "citation" is a numbered source: an inline marker (`[^1]`) that points at a
- * source card (title · domain · snippet · link). This module is JSX-free so the
- * rules are unit-testable under plain `node --experimental-strip-types`.
+ * A "citation" is a source reference: chat renders it as an inline provider
+ * chip with a preview card, while research surfaces can render a numbered
+ * source list. This module is JSX-free so shaping stays unit-testable.
  *
  * Two producers feed the same `Citation` shape:
  *  - Chat/markdown bodies that carry standard footnote citations
  *    (`[^1]` refs + `[^1]: <url> "Title"` definitions). `parseCitations` pulls
- *    the definitions out so a Sources footer can render them richly while the
- *    body keeps its inline markers.
+ *    the definitions out so chat can replace numeric refs with provider chips.
  *  - Research missions, whose `ResearchSourceRef` rows map straight across.
  */
 
@@ -26,6 +25,23 @@ export type Citation = {
   snippet?: string;
 };
 
+export type CitationSourceKind =
+  | "github"
+  | "arxiv"
+  | "doi"
+  | "wikipedia"
+  | "video"
+  | "document"
+  | "web"
+  | "reference";
+
+export type CitationSourcePresentation = {
+  kind: CitationSourceKind;
+  provider: string;
+  context: string;
+  summary: string;
+};
+
 /** The bare host of a URL, dropping a leading `www.`. Null for non-URLs. */
 export function domainFromUrl(url: string | undefined | null): string | undefined {
   if (!url) return undefined;
@@ -35,6 +51,141 @@ export function domainFromUrl(url: string | undefined | null): string | undefine
   } catch {
     return undefined;
   }
+}
+
+function parsedUrl(url: string | undefined): URL | undefined {
+  if (!url) return undefined;
+  try {
+    return new URL(url);
+  } catch {
+    return undefined;
+  }
+}
+
+function decodeUrlPart(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+function sourceSummary(citation: Citation, fallback: string): string {
+  return citation.snippet?.trim() || `Preview text wasn't provided. ${fallback}`;
+}
+
+function githubPresentation(citation: Citation, url: URL): CitationSourcePresentation {
+  const parts = url.pathname.split("/").filter(Boolean);
+  const repository = parts.length >= 2 ? `${parts[0]}/${parts[1]}` : "GitHub";
+  const resource = parts[2];
+  const value = parts[3];
+  let detail = "Repository";
+  let fallback = "Open the repository to review the cited context.";
+
+  if (resource === "pull" && value) {
+    detail = `Pull request #${value}`;
+    fallback = "Open the pull request to inspect its discussion and changes.";
+  } else if (resource === "issues" && value) {
+    detail = `Issue #${value}`;
+    fallback = "Open the issue to inspect its discussion and status.";
+  } else if (resource === "commit" && value) {
+    detail = `Commit ${value.slice(0, 7)}`;
+    fallback = "Open the commit to inspect its patch and surrounding history.";
+  } else if (resource === "discussions" && value) {
+    detail = `Discussion #${value}`;
+    fallback = "Open the discussion to inspect the full thread.";
+  } else if (resource === "actions" && parts[3] === "runs" && parts[4]) {
+    detail = `Workflow run ${parts[4]}`;
+    fallback = "Open the workflow run to inspect its jobs and logs.";
+  } else if (resource === "releases" && value === "tag" && parts[4]) {
+    detail = `Release ${decodeUrlPart(parts[4])}`;
+    fallback = "Open the release to inspect its notes and assets.";
+  }
+
+  return {
+    kind: "github",
+    provider: "GitHub",
+    context: `${repository} · ${detail}`,
+    summary: sourceSummary(citation, fallback),
+  };
+}
+
+const DOCUMENT_EXTENSIONS = new Set(["pdf", "doc", "docx", "ppt", "pptx", "xls", "xlsx"]);
+
+export function citationSourcePresentation(citation: Citation): CitationSourcePresentation {
+  const url = parsedUrl(citation.url);
+  if (!url) {
+    return {
+      kind: "reference",
+      provider: citation.domain?.trim() || "Reference",
+      context: "Provided in this chat",
+      summary: citation.snippet?.trim() || "No preview text or external link was provided for this reference.",
+    };
+  }
+
+  const host = url.hostname.replace(/^www\./, "").toLowerCase();
+  if (host === "github.com") return githubPresentation(citation, url);
+
+  if (host === "arxiv.org" || host === "export.arxiv.org") {
+    const identifier = url.pathname.replace(/^\/(?:abs|pdf)\//, "").replace(/\.pdf$/i, "") || "Unspecified";
+    return {
+      kind: "arxiv",
+      provider: "arXiv",
+      context: `Research paper · ${identifier}`,
+      summary: sourceSummary(citation, "Open the paper to read its abstract and full text."),
+    };
+  }
+
+  if (host === "doi.org" || host === "dx.doi.org") {
+    const identifier = decodeUrlPart(url.pathname.replace(/^\/+/, "")) || "Unspecified";
+    return {
+      kind: "doi",
+      provider: "DOI",
+      context: `Publication · ${identifier}`,
+      summary: sourceSummary(citation, "Open the publication record to review the cited work."),
+    };
+  }
+
+  if (host.endsWith(".wikipedia.org") || host === "wikipedia.org") {
+    const article = decodeUrlPart(url.pathname.replace(/^\/wiki\//, "")).replaceAll("_", " ");
+    return {
+      kind: "wikipedia",
+      provider: "Wikipedia",
+      context: article && article !== url.pathname ? `Encyclopedia article · ${article}` : "Encyclopedia article",
+      summary: sourceSummary(citation, "Open the article to review its references and full context."),
+    };
+  }
+
+  if (host === "youtube.com" || host === "m.youtube.com" || host === "youtu.be" || host === "vimeo.com") {
+    const provider = host === "vimeo.com" ? "Vimeo" : "YouTube";
+    return {
+      kind: "video",
+      provider,
+      context: "Video",
+      summary: sourceSummary(citation, "Open the video to review the cited segment and description."),
+    };
+  }
+
+  const extension = url.pathname.match(/\.([a-z0-9]+)$/i)?.[1]?.toLowerCase();
+  if (extension && DOCUMENT_EXTENSIONS.has(extension)) {
+    return {
+      kind: "document",
+      provider: extension === "pdf" ? "PDF" : extension.toUpperCase(),
+      context: `Document · ${citation.domain || host}`,
+      summary: sourceSummary(citation, "Open the document to review the cited material."),
+    };
+  }
+
+  return {
+    kind: "web",
+    provider: citation.domain || host || "Web",
+    context: "Web page",
+    summary: sourceSummary(citation, "Open the page to review the full context."),
+  };
+}
+
+export function citationInlineLabel(citation: Citation): string {
+  return citationSourcePresentation(citation).provider;
 }
 
 /** Minimal shape of a research source row (see ResearchSourceRef). */
@@ -71,18 +222,30 @@ export function sourcesToCitations(sources: readonly SourceLike[]): Citation[] {
 const DEF_RE = /^\[\^([^\]]+)\]:[ \t]+(.+?)[ \t]*$/gm;
 // An inline reference: `[^label]` NOT immediately followed by `:` (that's a def).
 const REF_RE = /\[\^([^\]]+)\](?!:)/g;
-const MD_LINK_RE = /^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)$/;
-const ANGLE_URL_RE = /^<(https?:\/\/[^\s>]+)>$/;
-const BARE_URL_RE = /^(https?:\/\/\S+)(?:[ \t]+"([^"]+)")?$/;
+const MD_LINK_RE = /^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)(?:[ \t]+—[ \t]+(.+))?$/;
+const ANGLE_URL_RE = /^<(https?:\/\/[^\s>]+)>(?:[ \t]+—[ \t]+(.+))?$/;
+const BARE_URL_RE = /^(https?:\/\/\S+)(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+))?$/;
 
 function parseDefinitionContent(raw: string): { title: string; url?: string; snippet?: string } {
   const content = raw.trim();
   const md = content.match(MD_LINK_RE);
-  if (md) return { title: md[1].trim(), url: md[2] };
+  if (md) return { title: md[1].trim(), url: md[2], snippet: md[3]?.trim() || undefined };
   const angle = content.match(ANGLE_URL_RE);
-  if (angle) return { title: domainFromUrl(angle[1]) ?? angle[1], url: angle[1] };
+  if (angle) {
+    return {
+      title: domainFromUrl(angle[1]) ?? angle[1],
+      url: angle[1],
+      snippet: angle[2]?.trim() || undefined,
+    };
+  }
   const bare = content.match(BARE_URL_RE);
-  if (bare) return { title: bare[2]?.trim() || domainFromUrl(bare[1]) || bare[1], url: bare[1] };
+  if (bare) {
+    return {
+      title: bare[2]?.trim() || domainFromUrl(bare[1]) || bare[1],
+      url: bare[1],
+      snippet: bare[3]?.trim() || undefined,
+    };
+  }
   // Plain prose: a leading `"Title"` becomes the title, the rest the snippet.
   const quoted = content.match(/^"([^"]+)"[ \t]*(.*)$/);
   if (quoted) return { title: quoted[1].trim(), snippet: quoted[2].trim() || undefined };
@@ -97,6 +260,23 @@ export type ParsedCitations = {
   /** Original footnote label → assigned 1-based number, for marker rewriting. */
   order: Map<string, number>;
 };
+
+export function renderCitationReferences(
+  text: string,
+  parsed: Pick<ParsedCitations, "citations" | "order">,
+): string {
+  if (parsed.citations.length === 0) return text;
+  const byNumber = new Map(parsed.citations.map((citation) => [citation.n, citation]));
+  return text
+    .replace(DEF_RE, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd()
+    .replace(REF_RE, (whole, label: string) => {
+      const n = parsed.order.get(label);
+      const citation = n ? byNumber.get(n) : undefined;
+      return citation ? `[${citationInlineLabel(citation)}](#cite-${n})` : whole;
+    });
+}
 
 /**
  * Pull standard markdown footnote citations out of a body. Only definitions
@@ -144,17 +324,15 @@ export function parseCitations(text: string): ParsedCitations {
 
 /**
  * Prepare a cited body for markdown rendering: strip the footnote definitions
- * and rewrite each inline `[^label]` reference to a plain markdown link
- * `[N](#cite-N)` pointing at its Sources-list anchor. Standard markdown that
- * survives the sanitizing renderer — no raw HTML, no pipeline changes. Bodies
- * without citations pass through untouched (identical to before).
+ * and rewrite each inline `[^label]` reference to a provider-labelled anchor.
+ * The fragment is an enhancement hook; chat turns it into an interactive source
+ * chip after sanitization, while no-JavaScript output stays understandable.
  */
 export function renderCitedBody(text: string): { body: string; citations: Citation[] } {
-  const { body, citations, order } = parseCitations(text);
-  if (citations.length === 0) return { body: text, citations: [] };
-  const rewritten = body.replace(REF_RE, (whole, label: string) => {
-    const n = order.get(label);
-    return n ? `[${n}](#cite-${n})` : whole;
-  });
-  return { body: rewritten, citations };
+  const parsed = parseCitations(text);
+  if (parsed.citations.length === 0) return { body: text, citations: [] };
+  return {
+    body: renderCitationReferences(parsed.body, parsed),
+    citations: parsed.citations,
+  };
 }

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -267,15 +267,15 @@ export function renderCitationReferences(
 ): string {
   if (parsed.citations.length === 0) return text;
   const byNumber = new Map(parsed.citations.map((citation) => [citation.n, citation]));
-  return text
-    .replace(DEF_RE, "")
-    .replace(/\n{3,}/g, "\n\n")
-    .trimEnd()
-    .replace(REF_RE, (whole, label: string) => {
-      const n = parsed.order.get(label);
-      const citation = n ? byNumber.get(n) : undefined;
-      return citation ? `[${citationInlineLabel(citation)}](#cite-${n})` : whole;
-    });
+  const withoutDefinitions = text.replace(DEF_RE, "");
+  const body = withoutDefinitions === text
+    ? text
+    : withoutDefinitions.replace(/\n{3,}/g, "\n\n").trimEnd();
+  return body.replace(REF_RE, (whole, label: string) => {
+    const n = parsed.order.get(label);
+    const citation = n ? byNumber.get(n) : undefined;
+    return citation ? `[${citationInlineLabel(citation)}](#cite-${n})` : whole;
+  });
 }
 
 /**

--- a/src/styles/cave-md/interactions.css
+++ b/src/styles/cave-md/interactions.css
@@ -133,6 +133,53 @@
   outline-offset: 1px;
 }
 
+/* Citation footnotes become compact evidence chips after the sanitized
+   markdown mounts. Provider text keeps the source legible without relying on
+   the accent dot, while the full provenance stays one hover or focus away. */
+.cave-md a.cave-citation-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-height: 1.4em;
+  margin-inline: 0.12em;
+  padding-inline: var(--space-1);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, var(--border-hairline));
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--accent-presence) 10%, transparent);
+  color: var(--accent-presence);
+  font-size: 0.78em;
+  font-weight: 600;
+  line-height: 1.4;
+  text-decoration: none;
+  white-space: nowrap;
+  vertical-align: 0.08em;
+  transition:
+    background-color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.cave-md a.cave-citation-chip::before {
+  width: var(--space-1);
+  height: var(--space-1);
+  border-radius: var(--radius-pill);
+  background: currentColor;
+  content: "";
+  opacity: 0.72;
+}
+
+.cave-md a.cave-citation-chip:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--accent-presence);
+  text-decoration: none;
+}
+
+.cave-md a.cave-citation-chip:focus-visible {
+  outline: var(--ring-width) solid var(--ring-focus);
+  outline-offset: var(--ring-offset);
+  text-decoration: none;
+}
+
 /* Task list */
 .cave-md li.task-list-item {
   list-style: none;


### PR DESCRIPTION
## Summary
- replace numbered chat citation footers with inline provider-labelled source chips
- add accessible hover, focus, touch, and URL-handler-backed source previews
- preserve research source lists and extend citation parsing/classification with summary fallbacks

## Verification
- `node --experimental-strip-types --test src/lib/citations.test.ts src/lib/citations-directive.test.ts src/lib/citation-preview.test.ts src/components/citation.test.ts src/components/message-bubble-markdown.test.ts` (21/21)
- `pnpm typecheck`
- `pnpm lint`
- `node --experimental-strip-types --test src/lib/design-token-drift.test.ts`
- `node scripts/ui-consistency.test.mjs`
- `pnpm build` (bundle and standalone budgets pass)

## Tracking
- Bead: `cave-wisp-eew`
- Reproduced from the preserved dirty source worktree with per-file hash fidelity.