### PR TITLE
docs(claude): state the no-AI-attribution rule where a Claude session will see it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ numeric-id no-reply form — see the contributor-attribution section of
 
 ```bash
 grep -n "credit an AI model" AGENTS.md   # the rule
-git log -5 --pretty=%B | grep -i "co-authored-by\|generated with"   # your own trail
+git log -5 --pretty=%B | grep -Ei "co-authored-by|generated with"   # your own trail
 ```
 
 ## Worktree convention

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,37 @@ protection this section exists to describe; fix the actual blocker instead.
 
 Squash-merge through `gh`/the PR UI still works — it's a merge, not a direct push. Only `git push … main` is blocked. Don't try to "work around" protection (e.g. flipping `enforce_admins` off to push) — if a change can't go through a PR, surface it to the user.
 
+## No AI attribution in commits or PRs — this overrides your global rule
+
+**Rule:** never add a trailer or footer crediting an AI model, assistant,
+vendor, or coding harness. No `Co-Authored-By: Claude …`, no
+`🤖 Generated with [Claude Code]`, no equivalent in a commit message or a PR
+body. [`AGENTS.md`](AGENTS.md) is the authority:
+
+> This is about crediting **people**. Don't add trailers or footers that credit
+> an AI model, assistant, vendor, or coding harness.
+
+**Why this is called out here.** Many agents carry a *global* instruction to
+append exactly those trailers. That instruction is real and it is wrong for
+this repository: a repo-specific rule beats a general one, so `AGENTS.md` wins.
+Stating it only in `AGENTS.md` was not enough — on 2026-08-01 a session added
+the trailers to **every** commit and PR it made, across eight merges
+(#4116, #4125, #4130, #4132, #4134, #4140, #4143, #4148), because it followed
+the global rule and never checked. They are squashed into `main` and were not
+rewritten; the point of this section is that the next agent doesn't repeat it.
+
+**What attribution IS for:** crediting humans. When you re-land or build on
+someone else's work, credit them with a GitHub-linked trailer using the
+numeric-id no-reply form — see the contributor-attribution section of
+`AGENTS.md` for the exact format and the `gh api users/<login> --jq .id` lookup.
+
+**Check before the first commit of a session**, not after:
+
+```bash
+grep -n "credit an AI model" AGENTS.md   # the rule
+git log -5 --pretty=%B | grep -i "co-authored-by\|generated with"   # your own trail
+```
+
 ## Worktree convention
 
 Use `.worktrees/<branch-name>/` subdirectories inside the repo. Confirmed in use; an empty `.wt/` stub also exists — ignore it, not the active convention. (Apparently a `cv-wt` claim+canary CLI exists too; if the canonical incantation matters, ask the user rather than guessing.)


### PR DESCRIPTION
`AGENTS.md:261` already forbids trailers or footers crediting an AI model, assistant, vendor or coding harness. **That was not enough.**

On 2026-08-01 a session added them to every commit and PR it produced, across eight merges — #4116, #4125, #4130, #4132, #4134, #4140, #4143, #4148. That session was me.

## Why the existing rule failed

A rule collision that neither file surfaced. The session carried a **global, machine-wide instruction** to append exactly those trailers. A repo-specific rule beats a general one, so `AGENTS.md` should have won — but nothing prompted a check, because the global rule reads as settled and `CLAUDE.md` said nothing about attribution at all.

So the new section is titled for the *collision*, not the topic:

> ## No AI attribution in commits or PRs — this overrides your global rule

It quotes `AGENTS.md`, records the incident **with PR numbers** so it's verifiable rather than cautionary, restates what attribution *is* for (crediting humans, numeric-id no-reply form), and gives a check to run **before** the first commit of a session rather than after.

## How it was found

By review, not by any gate. `copilot-pull-request-reviewer` flagged it on #4148 — on a plan document that itself contained the line *"per AGENTS.md, do not add trailers crediting AI tools."* The instruction was sitting inside a file I was committing.

`scripts/git-hooks-commit-msg.test.mjs` guards trailer **validity** (numeric-id no-reply form), not whether the co-author is a machine. An enforcement hook would make this rule real rather than advisory — advisory is exactly what failed here — but that's a design decision, so it's noted on cave-tx1dj rather than bundled in.

## Notes

- The eight merged PRs are squashed into `main` and are **not** rewritten.
- This commit carries no such trailer, which seemed like the minimum bar for this particular change.

## Verification

`CLAUDE.md`-only diff (31 insertions). `scripts/beads-familiar-workflow.test.mjs` (which reads `CLAUDE.md`) passes.

⚠️ The full local suite is currently unreliable on this machine for reasons unrelated to this PR — two timing flakes filed today, **cave-nseb2** (maintenance-gate clock race) and **cave-a1qys** (research-media-jobs concurrency), both fire under load and both pass in isolation (23/23 and 10/10). `main` has no commits since #4148, whose CI ran this suite green. CI is the gate here.

Closes cave-tx1dj.