### PR TITLE
test(maintenance-gate): expire the lease deterministically instead of racing it (cave-j54fz)

### DIFF
--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -648,6 +648,8 @@ test("acquisition does not return success after its final audit outlives the lea
   // Shift acquiredAt with it: validateGate requires heartbeatAt >= acquiredAt,
   // so moving the heartbeat alone makes the gate malformed instead of expired,
   // and the cleanup on the rejection path then fails with gate-cleanup-failed.
+  // This is what expireGate() above does; it has to be inlined here because the
+  // shim runs inside the spawned child, which shares no scope with this file.
   const TTL_MS = 60_000;
   const worker = `
     import fs from "node:fs";

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -631,13 +631,39 @@ test("a gate is active when acquisition returns after a slow drain", async () =>
 
 test("acquisition does not return success after its final audit outlives the lease", async () => {
   const repo = makeRepo();
+  // The lease must be alive at the promotion checkpoint (which reports a plain
+  // "expired") and dead at the final ownership audit (the only checkpoint that
+  // reports "expired-before-return"). Expiring it by sleeping made that a race
+  // the test could not win: acquisition's own file I/O between gate creation
+  // and the audit append measured 1.3s-4.4s on a loaded machine, so a short
+  // ttlMs died at promotion instead and the test failed ~1 run in 6. Raising
+  // ttlMs only moves the boundary, because the sleep has to outlast it.
+  //
+  // So stop racing the clock. Give the lease a ttl no setup delay can exhaust,
+  // and expire it exactly where this test means to — backdate heartbeatAt as
+  // the gate-acquired audit line is written, which is after promotion and
+  // before the final audit. gateExpired() is a plain heartbeatAt + ttlMs
+  // comparison and clockRegressed() only fires on FUTURE heartbeats, so a
+  // backdated one reads as unambiguously expired rather than merely late.
+  // Shift acquiredAt with it: validateGate requires heartbeatAt >= acquiredAt,
+  // so moving the heartbeat alone makes the gate malformed instead of expired,
+  // and the cleanup on the rejection path then fails with gate-cleanup-failed.
+  const TTL_MS = 60_000;
   const worker = `
     import fs from "node:fs";
+    import path from "node:path";
     import { syncBuiltinESMExports } from "node:module";
     const originalAppend = fs.appendFileSync;
     fs.appendFileSync = (target, content, options) => {
       if (String(content).includes('"event":"gate-acquired"')) {
-        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 200);
+        fs.appendFileSync = originalAppend;
+        // audit.jsonl and gate.json share the gate root directory.
+        const gateFile = path.join(path.dirname(String(target)), "gate.json");
+        const gate = JSON.parse(fs.readFileSync(gateFile, "utf8"));
+        const shiftMs = gate.ttlMs + 1000;
+        gate.acquiredAt = new Date(Date.parse(gate.acquiredAt) - shiftMs).toISOString();
+        gate.heartbeatAt = new Date(Date.parse(gate.heartbeatAt) - shiftMs).toISOString();
+        fs.writeFileSync(gateFile, JSON.stringify(gate, null, 2));
       }
       return originalAppend(target, content, options);
     };
@@ -646,7 +672,7 @@ test("acquisition does not return success after its final audit outlives the lea
     const result = gate.acquireMaintenanceGate({
       ownerId: "curator",
       repoDir: process.argv[1],
-      ttlMs: 100,
+      ttlMs: ${TTL_MS},
     });
     console.log(JSON.stringify(result));
   `;


### PR DESCRIPTION
Closes cave-j54fz — `acquisition does not return success after its final audit outlives the lease`, failing ~1 run in 6.

## Why the bead's suggested fix doesn't work

The test needs the lease **alive at the promotion checkpoint** (which reports a plain `expired`) and **dead at the final ownership audit** (the only checkpoint that reports `expired-before-return`). It arranged that with `ttlMs: 100` plus a 200ms sleep injected into the `gate-acquired` audit append — so both sides depended on winning a wall-clock race.

The bead suggested raising `ttlMs`. I tried it: **1000 still failed 1 in 8**, with the identical `'expired'`.

The measurement explains why. Failed runs leave their tmpdir behind, so their `audit.jsonl` gives the real timeline — the gap between gate creation (`gate-draining`) and the promotion checkpoint (`acquire-rejected`):

```
1289 ms   1501 ms   2937 ms   4421 ms
```

Acquisition's own file I/O is what varies, by more than 3×. Any fixed `ttlMs` only relocates the boundary, because the sleep then has to outlast the larger ttl as well — the two constraints chase each other, and the test gets slower at every step.

## What this does instead

Stop racing the clock. Give the lease a 60s ttl no setup delay can plausibly exhaust, and expire it *exactly where this test means to*: backdate the gate timestamps as the `gate-acquired` line is written — after promotion, before the final audit.

That's sound because `gateExpired()` is a plain `heartbeatAt + ttlMs` comparison and `clockRegressed()` only fires on **future** heartbeats, so a backdated gate reads as unambiguously expired rather than merely late.

`acquiredAt` shifts with `heartbeatAt`: `validateGate` requires `heartbeatAt >= acquiredAt`, so moving the heartbeat alone makes the gate *malformed* instead of expired and the rejection path's cleanup then fails with `gate-cleanup-failed` — observed **10/10** before the timestamps were shifted together. This mirrors the file's existing `expireGate()` helper, which can't be called directly because the shim runs inside the spawned child.

## Verification

- **12/12 runs green** (was ~1 in 6 failing).
- The test drops from **~3–7s to ~0.8s**, since nothing sleeps any more.
- **Mutation-checked that it still discriminates**: removing the `expired → expired-before-return` remap in `maintenance-gate.mjs` makes it fail with `actual: 'expired'`, exactly as it should. So the race was removed without hollowing out the assertion.
- Full file: 22/23. The one remaining failure is a **different, pre-existing** test — `concurrent multi-process acquisition: exactly one winner`. I measured it on an unmodified `origin/main` copy of the file (1/6 failures) versus this branch (2/6), so it is not caused by this change; filed as **cave-uadm8**.

`scripts/maintenance-gate.mjs` is untouched — this is a test-only change.

### Note on a neighbouring bead

cave-nseb2 tracks a *different* race in this same file, and a fix for it is sitting uncommitted in the primary checkout as another session's live work. I left that alone; this PR touches only the one test function, so the two shouldn't conflict beyond a trivial rebase.