### PR TITLE
fix(budget): report headroom on every build, warn before a budget is fatal

### DIFF
--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -95,6 +95,30 @@ if (!existsSync(chunksDir)) {
 }
 
 const kb = (n) => (n / 1024).toFixed(0).padStart(6) + " KB";
+
+// Warn while there is still room to act. Every budget below used to print only
+// its total and its cap, so accretion was invisible until a PR crossed the line
+// and ate the failure — the home CSS set drifted to 0.04% of margin over a
+// single day of small merges before anyone noticed (cave-7fd41). Reporting the
+// remaining headroom on every build turns that into a visible slope.
+//
+// Deliberately does NOT fail: this is signal, not a new gate. A thin budget is
+// information for the next author, not a reason to block the current one.
+const THIN_HEADROOM_PCT = 2;
+let thin = [];
+
+function headroom(label, bytes, budget) {
+  const left = budget - bytes;
+  if (left < 0) return; // the caller's failure branch reports the overage
+  const pct = (left / budget) * 100;
+  const line = `  ${(left / 1024).toFixed(1).padStart(6)} KB headroom  (${pct.toFixed(1)}%)`;
+  if (pct < THIN_HEADROOM_PCT) {
+    thin.push(label);
+    console.log(`${line}  \u26a0 THIN — the next change of any size may fail this gate`);
+  } else {
+    console.log(line);
+  }
+}
 const sizeOf = (relToNext) => {
   try {
     return statSync(path.join(nextDir, relToNext)).size;
@@ -149,10 +173,12 @@ const shellBytes = shellFiles.reduce((a, f) => a + sizeOf(f), 0);
 
 console.log(`\nbundle-budget — initial / route JavaScript:`);
 console.log(`  ${kb(homeBytes)}  TOTAL first-load JS across ${homeFiles.length} chunks  (budget: ${kb(MAX_HOME_BYTES)})`);
+headroom("first-load JS", homeBytes, MAX_HOME_BYTES);
 
 console.log(`\nbundle-budget — always-loaded shell (rootMainFiles):`);
 for (const f of shellFiles) console.log(`  ${kb(sizeOf(f))}  ${f.replace("static/chunks/", "")}`);
 console.log(`  ${kb(shellBytes)}  TOTAL shell  (budget: ${kb(MAX_SHELL_BYTES)})`);
+headroom("always-loaded shell", shellBytes, MAX_SHELL_BYTES);
 
 console.log(`\nbundle-budget — largest client chunks:`);
 for (const c of chunks.slice(0, 8)) console.log(`  ${kb(c.bytes)}  ${c.file}`);
@@ -265,10 +291,12 @@ try {
   console.log(`bundle-budget — root-layout CSS (every route pays this):`);
   for (const f of rootCss.files) console.log(`  ${kb(f.bytes)}  ${f.file}`);
   console.log(`  ${kb(rootCss.bytes)}  TOTAL root CSS  (budget: ${kb(MAX_ROOT_CSS_BYTES)})`);
+  headroom("root-layout CSS", rootCss.bytes, MAX_ROOT_CSS_BYTES);
   console.log(`\nbundle-budget — initial / route CSS:`);
   console.log(
     `  ${kb(homeCss.bytes)}  TOTAL first-load CSS across ${homeCss.files.length} stylesheets  (budget: ${kb(MAX_HOME_CSS_BYTES)})`,
   );
+  headroom("initial / route CSS", homeCss.bytes, MAX_HOME_CSS_BYTES);
 
   if (rootCss.bytes > MAX_ROOT_CSS_BYTES) {
     failed = true;
@@ -297,4 +325,11 @@ try {
 }
 
 if (failed) process.exit(1);
+if (thin.length > 0) {
+  console.log(
+    `\n\u26a0 bundle-budget: within budget, but thin on ${thin.join(", ")}.\n` +
+      `  Reclaim room (move surface CSS to component imports, #3264) or raise the\n` +
+      `  cap deliberately with a justification — before it lands on someone else.`,
+  );
+}
 console.log(`\n✓ bundle-budget: within budget.\n`);

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -105,7 +105,7 @@ const kb = (n) => (n / 1024).toFixed(0).padStart(6) + " KB";
 // Deliberately does NOT fail: this is signal, not a new gate. A thin budget is
 // information for the next author, not a reason to block the current one.
 const THIN_HEADROOM_PCT = 2;
-let thin = [];
+const thin = [];
 
 function headroom(label, bytes, budget) {
   const left = budget - bytes;

--- a/scripts/bundle-budget.test.mjs
+++ b/scripts/bundle-budget.test.mjs
@@ -115,4 +115,3 @@ assert.doesNotMatch(
   /function headroom\([\s\S]{0,400}?failed = true/,
   "headroom() reports without failing the build",
 );
-

--- a/scripts/bundle-budget.test.mjs
+++ b/scripts/bundle-budget.test.mjs
@@ -59,3 +59,60 @@ assert.match(
 );
 
 console.log("bundle-budget.test.mjs: ok");
+
+// ── Headroom reporting (cave-7fd41) ─────────────────────────────────────────
+// The budgets used to print only a total and a cap, so accretion was invisible
+// until a PR crossed the line and ate the failure — the home CSS set reached
+// 0.04% of margin over a single day before anyone noticed. These pin the
+// reporting itself, because a silent regression here restores that blindness
+// without failing anything.
+
+assert.match(
+  source,
+  /const THIN_HEADROOM_PCT = \d+;/,
+  "the thin-budget threshold is an explicit named constant, not a magic number",
+);
+assert.match(
+  source,
+  /function headroom\(label, bytes, budget\)/,
+  "one shared helper reports headroom, so every budget reports it the same way",
+);
+assert.match(
+  source,
+  /if \(left < 0\) return;/,
+  "headroom() defers to the caller's failure branch when a budget is already blown",
+);
+assert.match(
+  source,
+  /THIN — the next change of any size may fail this gate/,
+  "a thin budget warns in the words the next author needs",
+);
+assert.match(
+  source,
+  /within budget, but thin on \$\{thin\.join\(", "\)\}/,
+  "the summary names which budgets are thin",
+);
+
+// Every budget reports headroom — a budget that reports a total but no margin
+// is exactly the blind spot this change exists to close.
+for (const [label, bytes, budget] of [
+  ["first-load JS", "homeBytes", "MAX_HOME_BYTES"],
+  ["always-loaded shell", "shellBytes", "MAX_SHELL_BYTES"],
+  ["root-layout CSS", "rootCss.bytes", "MAX_ROOT_CSS_BYTES"],
+  ["initial / route CSS", "homeCss.bytes", "MAX_HOME_CSS_BYTES"],
+]) {
+  assert.match(
+    source,
+    new RegExp(`headroom\\("${label.replace(/[/]/g, "\\/")}", ${bytes.replace(".", "\\.")}, ${budget}\\)`),
+    `${label} reports its remaining headroom`,
+  );
+}
+
+// Reporting must not become a gate: this is signal for the next author, not a
+// new failure mode for the current one.
+assert.doesNotMatch(
+  source,
+  /function headroom\([\s\S]{0,400}?failed = true/,
+  "headroom() reports without failing the build",
+);
+


### PR DESCRIPTION
The home CSS set drifted from ~8 KB of margin to **0.04%** over a single day of small merges, and nobody saw it until a 157-byte rule failed CI (cave-7fd41).

**The report was the reason.** It printed a total and a cap and nothing else, so a budget one rule from failing looked identical to one comfortably under. `kb()` rounds to whole kilobytes, so 899.94 KB even rendered as `900 KB`.

## What this does

All four budgets now print remaining headroom to one decimal, flag `⚠ THIN` below 2%, and the summary names which budgets are thin with the two legitimate remedies.

**Deliberately non-failing** — signal for the next author, not a new gate on the current one. Changing CI pass/fail semantics wasn't asked for and isn't mine to decide unilaterally.

## It earns its keep on the first run

```
    2158 KB  TOTAL first-load JS across 23 chunks   (budget: 2800 KB)
   641.9 KB headroom  (22.9%)
     447 KB  TOTAL shell                            (budget:  650 KB)
   203.3 KB headroom  (31.3%)
     638 KB  TOTAL root CSS                         (budget:  660 KB)
    22.2 KB headroom   (3.4%)
     902 KB  TOTAL first-load CSS across 13 sheets  (budget:  910 KB)
     8.5 KB headroom   (0.9%)  ⚠ THIN — the next change of any size may fail this gate
```

## The finding that matters more than the change

PR #4144 raised the home cap **900 → 910** to restore working headroom. The set is **already at 902 KB** — so **8.5 KB of that 10 KB bump is already spent.** The raise bought roughly a day.

Every other budget is comfortable (22.9%, 31.3%, 3.4%). Only home CSS is starving, and it was the one nobody could see.

That's the argument for **option (a)** in the bead — audit the 13 home stylesheets and code-split what is surface-specific. This PR does **not** do that, and it remains open. Raising the cap again would be the third bump in two days.

## Scope note

The bead's premise is partly stale: it describes ~0 headroom at a 900 KB cap, but **option (b) was already taken** by #4144 before I started. What was never addressed is the invisibility, which is what this fixes.

## Verification

Verified by grepping the build log for `✓ bundle-budget: within budget` — **not** by exit code. The bead itself warns that `pnpm build | tail -N` reports 0 when the budget fails, because the pipeline's status belongs to `tail`.