### PR TITLE
test(projects): pin spaced display names through registration, selection and chat (cave-8e7q)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -522,6 +522,7 @@ export const SUITES = {
     "src/lib/use-projects-normalize.test.ts",
     "src/lib/project-frecency.test.ts",
     "src/lib/project-root-normalizers.test.ts",
+    "src/lib/project-display-name-spaces.test.ts",
     "src/lib/use-projects-scope-transition.test.ts",
     "src/components/calendar-view-polish.test.ts",
     "src/components/calendar-agenda-redesign.test.ts",

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -50,7 +50,7 @@ assert.match(listRoute, /name and root are required/, "POST /api/projects should
 // intact. A slugify/tokenize step added here is what originally mangled it.
 assert.match(
   listRoute,
-  /const name = String\(body\.name \?\? ""\)\.trim\(\);/,
+  /const\s+name\s*=\s*String\(body\.name\s*\?\?\s*""\)\.trim\(\);/,
   "POST /api/projects should store the display name with only its ends trimmed",
 );
 assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects should validate roots before persisting them");

--- a/src/app/api/projects/route.test.ts
+++ b/src/app/api/projects/route.test.ts
@@ -44,6 +44,15 @@ assert.doesNotMatch(
 );
 assert.match(listRoute, /export async function POST\(req: Request\)/, "projects route should expose POST");
 assert.match(listRoute, /name and root are required/, "POST /api/projects should validate required fields");
+// cave-8e7q: the display name is presentation text, never a connection
+// identifier — identity is id + root. Trimming the ends is the ONLY normalizing
+// allowed, so interior spaces in a name like `My Project Two` reach the store
+// intact. A slugify/tokenize step added here is what originally mangled it.
+assert.match(
+  listRoute,
+  /const name = String\(body\.name \?\? ""\)\.trim\(\);/,
+  "POST /api/projects should store the display name with only its ends trimmed",
+);
 assert.match(listRoute, /isAllowedNewProjectRoot\(root\)/, "POST /api/projects should validate roots before persisting them");
 assert.equal(
   PROJECT_ROOT_OUTSIDE_ALLOWED_WORKSPACE_CODE,

--- a/src/components/project-picker.test.ts
+++ b/src/components/project-picker.test.ts
@@ -142,4 +142,11 @@ assert.match(src, /onRegisterCurrentRoot\?: \(\) => void;/, "and the setup-open 
 assert.match(src, /Register this folder as a project…/, "in-place registration row");
 assert.match(src, /ph:folder-plus/, "register row carries the folder-plus icon");
 
+// cave-8e7q: selection travels as the project's generated id, never its display
+// name. Emitting the name would make presentation text a connection identifier,
+// which is what mangled names containing spaces. The behaviour of the id the
+// caller then resolves is pinned in lib/project-display-name-spaces.test.ts.
+assert.match(src, /onChange: \(id: string\) => void;/, "the picker's selection callback takes an id");
+assert.match(src, /onChange\(project\.id\);/, "picking a project emits its id, not its display name");
+
 console.log("project-picker.test.ts OK");

--- a/src/lib/project-display-name-spaces.test.ts
+++ b/src/lib/project-display-name-spaces.test.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+// Regression coverage for cave-8e7q: a project display name containing spaces
+// must survive registration, picker selection, and chat root resolution.
+//
+// Nothing here is a new guarantee — spaces already survive, but only because no
+// code along the path happens to transform the name. Identity is id + root and
+// the name is presentation text, so a future slugify/tokenize/encode step could
+// silently turn `My Project Two` into an identifier again and every existing
+// test would still pass. These pins make that regression fail loudly instead.
+//
+// Deliberately a spaced NAME over an ordinary ROOT: spaced paths are a separate
+// concern already covered by project-root-normalizers.test.ts ("/w/app with
+// spaces"), and mixing the two would hide which one broke.
+import assert from "node:assert/strict";
+
+import { addChatProject, projectNameForRoot } from "./chat-add-project.ts";
+import { chatProjectById, projectIdForRoot, resolveChatProjectSelection } from "./chat-projects.ts";
+import { resetProjectRegistryListenersForTests } from "./project-registry-events.ts";
+
+const SPACED_NAME = "My Project Two";
+const ROOT = "/w/app";
+
+// Registration: the name reaches createProject exactly as typed.
+{
+  resetProjectRegistryListenersForTests();
+  const calls = [];
+  const createProject = async (name, root, options) => {
+    calls.push(["create", name, root, options]);
+    return { id: "p-spaced", name, root };
+  };
+  const fetchImpl = async (url, init) => {
+    calls.push(["fetch", url, JSON.parse(init.body)]);
+    return { ok: true, json: async () => ({ ok: true }) };
+  };
+
+  const result = await addChatProject({
+    root: ROOT,
+    name: SPACED_NAME,
+    familiarId: "sage",
+    createProject,
+    fetchImpl,
+  });
+
+  assert.deepEqual(result, { ok: true, projectId: "p-spaced" });
+  assert.deepEqual(
+    calls[0],
+    ["create", SPACED_NAME, ROOT, { emitMutation: false }],
+    "the spaced display name is registered verbatim — not split, slugified, or encoded",
+  );
+  // The grant travels by id. A display name appearing in this payload would
+  // make it a de-facto connection identifier, which is the bug this bead is about.
+  assert.deepEqual(calls[1][2], { targetFamiliarId: "sage", projectId: "p-spaced" });
+  assert.doesNotMatch(
+    JSON.stringify(calls[1][2]),
+    /My Project Two/,
+    "the grant identifies the project by id, never by display name",
+  );
+}
+
+// A root whose leaf folder contains spaces keeps them in the derived name.
+assert.equal(projectNameForRoot("/w/My App With Spaces"), "My App With Spaces");
+
+// Picker selection and chat root resolution both key off id, and hand back the
+// unchanged root for a project whose name has spaces.
+{
+  const projects = [
+    { id: "p-spaced", name: SPACED_NAME, root: ROOT },
+    { id: "p-other", name: "Other", root: "/w/other" },
+  ];
+
+  assert.equal(chatProjectById("p-spaced", projects)?.root, ROOT);
+  assert.equal(chatProjectById("p-spaced", projects)?.name, SPACED_NAME);
+  assert.equal(projectIdForRoot(ROOT, projects), "p-spaced");
+
+  // The picker emits an id; chat resolves that id back to the canonical root.
+  const selection = resolveChatProjectSelection({
+    draftId: "p-spaced",
+    hasSession: false,
+    sessionProjectRoot: null,
+    fallbackProjectRoot: null,
+    projects,
+  });
+  assert.equal(selection.projectId, "p-spaced");
+  assert.equal(selection.project?.root, ROOT, "chat resolves the selection to the unchanged root");
+  assert.equal(selection.project?.name, SPACED_NAME);
+}
+
+// A failed registration surfaces the API's own error and issues no grant.
+{
+  resetProjectRegistryListenersForTests();
+  let granted = false;
+  const createProject = async () => {
+    throw new Error("project root is outside the allowed workspace");
+  };
+  const fetchImpl = async () => {
+    granted = true;
+    return { ok: true, json: async () => ({ ok: true }) };
+  };
+
+  const result = await addChatProject({
+    root: ROOT,
+    name: SPACED_NAME,
+    familiarId: "sage",
+    createProject,
+    fetchImpl,
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(
+    result.error,
+    "project root is outside the allowed workspace",
+    "the specific API error reaches the caller instead of a generic 'could not register project'",
+  );
+  assert.equal(granted, false, "registration failure must not go on to attempt a grant");
+}

--- a/src/lib/project-display-name-spaces.test.ts
+++ b/src/lib/project-display-name-spaces.test.ts
@@ -8,9 +8,9 @@
 // silently turn `My Project Two` into an identifier again and every existing
 // test would still pass. These pins make that regression fail loudly instead.
 //
-// Deliberately a spaced NAME over an ordinary ROOT: spaced paths are a separate
-// concern already covered by project-root-normalizers.test.ts ("/w/app with
-// spaces"), and mixing the two would hide which one broke.
+// The end-to-end regression fixture deliberately pairs a spaced NAME with an
+// ordinary ROOT so a failure identifies the name path. A separate assertion
+// below preserves the already-supported spaced-root name derivation.
 import assert from "node:assert/strict";
 
 import { addChatProject, projectNameForRoot } from "./chat-add-project.ts";


### PR DESCRIPTION
Closes cave-8e7q.

## What was actually left

Earlier sweeps on this bead had already narrowed it, and I re-verified against `main` before writing anything:

- **Shipped** — "propagate precise `/api/projects` failures": the route returns specific errors, and `useProjects` exposes them via `requestCreateProject` / `createProjectOrThrow`.
- **Holds, but only by construction** — spaces survive because *nothing along the path transforms the name*. Identity is `id` + `root`; the name is presentation text.
- **Missing** — any test asserting that. Which is the problem: a future slugify/tokenize/encode step would reintroduce the original bug and the entire suite would still be green.

So this PR is coverage only. No production code changes.

Two notes for anyone re-reading the bead: its cited spec (`docs/superpowers/specs/2026-07-18-…`) is **unrecoverable** — `docs/superpowers` was gitignored when it was written (see cave-8zjr5) — so the bead description was treated as the spec. And the worktree its notes call "implementation complete" no longer exists, with no local branch, no remote ref and no PR.

## The pins

`src/lib/project-display-name-spaces.test.ts` drives the **real functions** rather than pinning source text, covering the three paths the bead names:

| path | pinned |
|---|---|
| registration | `addChatProject` passes `My Project Two` to `createProject` verbatim — not split, slugified, or encoded |
| identity | the `/api/project-grants` payload carries only `projectId`; a display name appearing there would make it a de-facto connection identifier, which *is* the bug |
| selection + chat | `chatProjectById`, `projectIdForRoot` and `resolveChatProjectSelection` key off the id and return the **unchanged** root |
| failure | a thrown registration error reaches the caller intact **and** no grant is attempted afterwards |

Plus one server-side pin in `route.test.ts`: `POST /api/projects` must only trim the name's *ends*, since that is where a slugify would most plausibly be added.

Deliberately a spaced **name** over an ordinary **root** — spaced *paths* are a separate concern already covered by `project-root-normalizers.test.ts` (`/w/app with spaces`), and mixing the two would obscure which one broke.

## Verification

- **Mutation-checked, not merely green**: making `addChatProject` slugify the name fails the new test with *"the spaced display name is registered verbatim — not split, slugified, or encoded"*. Reverted immediately; no production file is modified by this PR.
- `pnpm check:tests-wired` — all **1401** test files wired.
- `tsc --noEmit` — clean.
- Full `pnpm test:app` re-run after rebasing onto `b06ded291`; the branch was originally cut before that commit, whose gate-flake fix the suite needs.

### Acceptance criteria

1. `My Project` registers and is selected without being split/encoded/rewritten — pinned.
2. Chat still resolves by root, unaffected by spaces in the name — pinned.
3. A failed registration surfaces the underlying error — pinned.
4. Names without spaces behave as before — covered by the existing suite.