### PR TITLE
fix(daily-report): collapse redundant PR notices

### DIFF
--- a/src/lib/daily-report-day.test.ts
+++ b/src/lib/daily-report-day.test.ts
@@ -40,6 +40,21 @@ function reminder(id, hour, title = "Sync the registry") {
   };
 }
 
+function agentNotice(id, hour, minute, auto, title = "PR opened") {
+  return {
+    id,
+    kind: "agent",
+    title,
+    status: "fired",
+    createdAt: at(hour, minute),
+    updatedAt: at(hour, minute),
+    firedAt: at(hour, minute),
+    recurrence: "none",
+    source: "agent",
+    auto,
+  };
+}
+
 // ── clockLabel ──────────────────────────────────────────────────────────────
 {
   assert.equal(clockLabel(at(8, 14)), "08:14");
@@ -347,6 +362,46 @@ function reminder(id, hour, title = "Sync the registry") {
   assert.deepEqual(spine.map((e) => e.count), [1, 1]);
 
   assert.deepEqual(deriveSpine([]), [], "no chapters, no spine");
+}
+
+{
+  const events = dayEvents(
+    {
+      prsMerged: [
+        { repo: "OpenCoven/coven", number: 1, title: "merged one", url: "", mergedAt: at(14, 0) },
+        { repo: "OpenCoven/cave", number: 2, title: "merged two", url: "", mergedAt: at(14, 1) },
+        { repo: "OpenCoven/docs", number: 3, title: "merged three", url: "", mergedAt: at(14, 2) },
+      ],
+      factsHash: "h",
+      refreshedAt: at(23),
+    },
+    emptyBreakdown({
+      familiars: [
+        agentNotice("merged-notice-1", 14, 5, "github-sub:pr-opened:OpenCoven/coven#1"),
+        agentNotice("merged-notice-2", 14, 6, "github-sub:pr-opened:opencoven/CAVE#2"),
+        agentNotice("open-notice-1", 14, 10, "github-sub:pr-opened:OpenCoven/runtime#10"),
+        agentNotice("open-notice-1-repeat", 14, 11, "github-sub:pr-opened:OpenCoven/runtime#10"),
+        agentNotice("open-notice-2", 14, 12, "github-sub:pr-opened:OpenCoven/landing#11"),
+        agentNotice("ordinary-agent", 14, 20, "session-finished:s1", "Sage finished the release audit"),
+        agentNotice("open-notice-1-later", 18, 0, "github-sub:pr-opened:OpenCoven/runtime#10"),
+      ],
+    }),
+    DAY,
+  );
+
+  const chapters = deriveChapters(events, 0);
+  assert.equal(chapters.length, 2, "the later duplicate opens a second chapter");
+  const spine = deriveSpine(chapters);
+  assert.equal(spine.length, 3, "merged notices disappear, duplicate openings dedupe, and the rest collapse");
+  assert.deepEqual(
+    spine.map(({ label, count }) => ({ label, count })),
+    [
+      { label: "3 merges across 3 repos", count: 3 },
+      { label: "2 PRs opened across 2 repos", count: 2 },
+      { label: "Sage finished the release audit", count: 1 },
+    ],
+  );
+  assert.equal(spine[1].detail, "runtime · landing");
 }
 
 // ── the trailing week ───────────────────────────────────────────────────────

--- a/src/lib/daily-report-day.ts
+++ b/src/lib/daily-report-day.ts
@@ -13,6 +13,7 @@ import type { InboxItem } from "./cave-inbox";
 import type { DailyReportBreakdown, DailyReportStats, RecentReport } from "./daily-report";
 import { dateSlug, isSameLocalDay } from "./daily-report.ts";
 import type { DailyReportPayload, MergedPr, SessionGroup } from "./daily-report-facts";
+import { repoFromGithubSubTag } from "./github-sub-tags.ts";
 
 // ── shapes ──────────────────────────────────────────────────────────────────
 
@@ -36,6 +37,9 @@ export type DayEvent = {
   tone: DayTone;
   href?: string;
   familiarId?: string | null;
+  /** Machine discriminator retained from inbox-backed events so derived
+   *  surfaces can group them without matching visible copy. */
+  auto?: string | null;
   /** Set on merge events — lets a surface open the rich GitHub card for it
    *  instead of sending the reader out to github.com. */
   pr?: { repo: string; number: number };
@@ -279,6 +283,7 @@ export function dayEvents(
       at: item.firedAt as string,
       label: item.title,
       familiarId: item.familiarId ?? null,
+      auto: item.auto ?? null,
     });
   }
 
@@ -429,14 +434,46 @@ function chapterKicker(events: DayEvent[]): string {
  *  coven-runtimes") and the shipped table carries the detail. */
 const SPINE_MERGE_DETAIL_LIMIT = 2;
 
+function prOpenedFromAuto(auto: string | null | undefined): { repo: string; number: number } | null {
+  if (!auto?.startsWith("github-sub:pr-opened:")) return null;
+  const repo = repoFromGithubSubTag(auto);
+  const hash = auto.lastIndexOf("#");
+  const rawNumber = hash === -1 ? "" : auto.slice(hash + 1);
+  if (!repo || !/^[1-9]\d*$/.test(rawNumber)) return null;
+  return { repo, number: Number(rawNumber) };
+}
+
+function repoListDetail(repos: string[]): string | undefined {
+  if (repos.length === 0) return undefined;
+  if (repos.length <= 3) return repos.join(" · ");
+  return `${repos.slice(0, 3).join(" · ")} +${repos.length - 3}`;
+}
+
 export function deriveSpine(chapters: Chapter[]): SpineEntry[] {
   const out: SpineEntry[] = [];
+  const mergedPrKeys = new Set(
+    chapters.flatMap((chapter) =>
+      chapter.events
+        .filter((event) => event.kind === "merge" && event.pr)
+        .map((event) => prKey(event.pr?.repo, event.pr?.number)),
+    ),
+  );
+  const seenOpenedPrKeys = new Set<string>();
 
   for (const chapter of chapters) {
     const merges = chapter.events.filter((e) => e.kind === "merge");
     const others = chapter.events.filter((e) => e.kind !== "merge");
+    const openedPrs: { event: DayEvent; repo: string; number: number }[] = [];
 
     for (const e of others) {
+      const openedPr = prOpenedFromAuto(e.auto);
+      if (openedPr) {
+        const key = prKey(openedPr.repo, openedPr.number);
+        if (mergedPrKeys.has(key) || seenOpenedPrKeys.has(key)) continue;
+        seenOpenedPrKeys.add(key);
+        openedPrs.push({ event: e, ...openedPr });
+        continue;
+      }
       out.push({
         id: e.id,
         at: e.at,
@@ -445,6 +482,30 @@ export function deriveSpine(chapters: Chapter[]): SpineEntry[] {
         detail: e.detail,
         chapterIndex: chapter.index,
         count: 1,
+      });
+    }
+
+    if (openedPrs.length === 1) {
+      const [opened] = openedPrs;
+      out.push({
+        id: opened.event.id,
+        at: opened.event.at,
+        tone: opened.event.tone,
+        label: opened.event.label,
+        detail: opened.event.detail,
+        chapterIndex: chapter.index,
+        count: 1,
+      });
+    } else if (openedPrs.length > 1) {
+      const repos = [...new Set(openedPrs.map(({ repo }) => repoBasename(repo)))];
+      out.push({
+        id: `chapter-pr-opened:${chapter.index}`,
+        at: openedPrs[0].event.at,
+        tone: openedPrs[0].event.tone,
+        label: `${openedPrs.length} PRs opened${repos.length ? ` across ${repos.length} ${repos.length === 1 ? "repo" : "repos"}` : ""}`,
+        detail: repoListDetail(repos),
+        chapterIndex: chapter.index,
+        count: openedPrs.length,
       });
     }
 
@@ -467,18 +528,13 @@ export function deriveSpine(chapters: Chapter[]): SpineEntry[] {
     }
 
     const repos = [...new Set(merges.map((m) => (m.detail ?? "").split("#")[0]).filter(Boolean))];
-    const where =
-      repos.length === 0
-        ? ""
-        : repos.length <= 3
-          ? repos.join(" · ")
-          : `${repos.slice(0, 3).join(" · ")} +${repos.length - 3}`;
+    const where = repoListDetail(repos);
     out.push({
       id: `chapter-merges:${chapter.index}`,
       at: merges[0].at,
       tone: "success",
       label: `${merges.length} merges${repos.length ? ` across ${repos.length} ${repos.length === 1 ? "repo" : "repos"}` : ""}`,
-      detail: where || undefined,
+      detail: where,
       chapterIndex: chapter.index,
       count: merges.length,
     });


### PR DESCRIPTION
## Summary

- retain the inbox auto discriminator on daily-report familiar events
- suppress PR-opened subscription notices when the same PR merged that day
- deduplicate repeated stable PR-opened tags across chapters
- collapse remaining PR-opened notices per chapter while preserving ordinary familiar notices

## Evidence

On the real 2026-07-29 local report: 98 raw PR-opened notices, 95 unique notices, and 87 matched same-day merges. The resulting spine contains 6 entries, 4 of them collapsed.

## Verification

- node --experimental-strip-types src/lib/daily-report-day.test.ts
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired
- git diff --check
- pnpm build

The full pnpm test:app suite was attempted twice before publish but did not complete because of unrelated tracked flakes: canonical-memory SIGINT cleanup exceeded its 2500 ms timing bound once and passed isolated; research-media transient terminal reconciliation failed once and passed isolated 10/10. Exact-head GitHub checks are required before merge.

Bead: cave-ys0ev