### PR TITLE
feat(daemon): opt-in unattended restart and Coven upgrade (cave-bqywj)

### DIFF
--- a/src/components/settings-daemon.tsx
+++ b/src/components/settings-daemon.tsx
@@ -20,6 +20,11 @@ import { TextInput } from "@/components/ui/text-input";
 import { copyText } from "@/lib/clipboard";
 import { Icon, type IconName } from "@/lib/icon";
 import { classifyTailscaleFailureKind } from "@/lib/tailscale-failure";
+import {
+  useDaemonAutomation,
+  writeDaemonAutomation,
+  type DaemonAutomationKey,
+} from "@/lib/daemon-automation-pref";
 import { parseExecutorUrls } from "./settings-multihost";
 
 type DaemonStatus = {
@@ -115,6 +120,73 @@ function SectionRule({ id, label, meta }: { id: string; label: string; meta?: Re
       <span className="settings-daemon-rule-line" aria-hidden="true" />
       {meta ? <span className="settings-daemon-rule-meta">{meta}</span> : null}
     </div>
+  );
+}
+
+/**
+ * Unattended lifecycle switches (cave-bqywj). Every one is opt-in and starts
+ * off: they restart processes and install binaries on this machine.
+ *
+ * There is no "auto-reconnect" switch on purpose — reconnection already
+ * happens unconditionally (the status poll re-probes every 5s and drops the
+ * offline banner the moment the daemon answers; the PTY bridge runs its own
+ * backoff loop). A toggle would either do nothing or, defaulting to off,
+ * remove recovery that works today.
+ *
+ * `.settings-switch` comes from dashboard.css, which settings-shell.tsx
+ * imports; DaemonSection only ever renders inside that shell.
+ */
+function AutomationSection() {
+  const automation = useDaemonAutomation();
+  const rows: {
+    key: DaemonAutomationKey;
+    label: string;
+    description: string;
+  }[] = [
+    {
+      key: "autoRestart",
+      label: "Restart the daemon",
+      description:
+        "Relaunch a local daemon that goes offline mid-session. Today it is only started once, at app launch.",
+    },
+    {
+      key: "autoUpgradeCli",
+      label: "Upgrade Coven",
+      description:
+        "Install Coven CLI updates unattended. This is also the daemon — they ship as one package — and it changes the version of the command you type at.",
+    },
+  ];
+
+  return (
+    <section
+      className="settings-daemon-section"
+      aria-labelledby="settings-daemon-automation-heading"
+    >
+      <SectionRule id="settings-daemon-automation-heading" label="AUTOMATION" />
+      <div className="settings-daemon-automation">
+        {rows.map((row) => {
+          const enabled = automation[row.key];
+          return (
+            <div className="settings-daemon-automation-row" key={row.key}>
+              <div className="settings-daemon-automation-copy">
+                <span className="settings-daemon-automation-label">{row.label}</span>
+                <span className="settings-daemon-automation-description">{row.description}</span>
+              </div>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                aria-label={row.label}
+                onClick={() => writeDaemonAutomation(row.key, !enabled)}
+                className={`settings-switch focus-ring${enabled ? " is-on" : ""}`}
+              >
+                <span className="settings-switch__knob" aria-hidden />
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
   );
 }
 
@@ -923,6 +995,8 @@ export function DaemonSection({
       </section>
 
       {omnigentSettings}
+
+      <AutomationSection />
 
       <section className="settings-daemon-section settings-daemon-info-section" aria-labelledby="settings-daemon-info-heading">
         <SectionRule id="settings-daemon-info-heading" label="INFO" />

--- a/src/components/settings-daemon.tsx
+++ b/src/components/settings-daemon.tsx
@@ -166,17 +166,24 @@ function AutomationSection() {
       <div className="settings-daemon-automation">
         {rows.map((row) => {
           const enabled = automation[row.key];
+          // The description is the consequence — a process restart or an
+          // unattended install. A screen reader must reach it from the switch
+          // itself, not only by having read the row on the way past.
+          const describedBy = `settings-daemon-automation-${row.key}-description`;
           return (
             <div className="settings-daemon-automation-row" key={row.key}>
               <div className="settings-daemon-automation-copy">
                 <span className="settings-daemon-automation-label">{row.label}</span>
-                <span className="settings-daemon-automation-description">{row.description}</span>
+                <span className="settings-daemon-automation-description" id={describedBy}>
+                  {row.description}
+                </span>
               </div>
               <button
                 type="button"
                 role="switch"
                 aria-checked={enabled}
                 aria-label={row.label}
+                aria-describedby={describedBy}
                 onClick={() => writeDaemonAutomation(row.key, !enabled)}
                 className={`settings-switch focus-ring${enabled ? " is-on" : ""}`}
               >

--- a/src/components/update-available.test.ts
+++ b/src/components/update-available.test.ts
@@ -67,13 +67,34 @@ assert.match(src, /resolveDownloadUrl\(combined\.status\)/, "fallback download U
 // Both surfaces are exported and resolve native-first.
 assert.match(src, /export function UpdateBannerTrigger/, "exports the banner trigger");
 assert.match(src, /export function DaemonReleaseAlignmentTrigger/, "reconciles the daemon after the new Cave version starts");
-assert.match(src, /updateCovenCli\(\)/, "startup reconciliation checks the independently versioned CLI");
+assert.match(src, /updateCovenCli\(/, "startup reconciliation checks the independently versioned CLI");
 assert.doesNotMatch(src, /APP_VERSION/, "the running Cave version is never treated as a CLI version requirement");
 assert.match(src, /process\.env\.NODE_ENV !== "production"/, "development launches never mutate the global CLI");
 assert.match(src, /const start = \(\) =>/, "startup reconciliation never silently confirms a global install");
-assert.match(src, /updateCovenCli\(\)\.then\(\(\) =>/, "startup reconciliation is a quiet status check only");
+
+// This call site used to be pinned as `updateCovenCli()` with no arguments —
+// the guarantee being that a background startup path can never install a
+// global package. cave-bqywj keeps that guarantee and makes it stricter rather
+// than relaxing it: the ONLY thing that may confirm the install is the user's
+// own opt-in preference, read at call time and off by default. A literal
+// `true`, or consent from any other source, must fail here.
+assert.match(
+  src,
+  /updateCovenCli\(\{ confirmInstall: readDaemonAutomation\(\)\.autoUpgradeCli \}\)/,
+  "startup reconciliation installs only on the user's explicit opt-in preference",
+);
+assert.doesNotMatch(
+  src,
+  /confirmInstall:\s*true/,
+  "install consent is never hardcoded — it comes from the preference or not at all",
+);
+assert.match(
+  src,
+  /import \{ readDaemonAutomation \} from "@\/lib\/daemon-automation-pref"/,
+  "the preference is read from its own module, not reconstructed locally",
+);
 assert.doesNotMatch(src, /Update Coven CLI/, "ordinary CLI update actions stay out of the chat header");
-assert.match(src, /updateCovenCli\(\)\.then\(\(\) => \{[\s\S]*dismissBanner\(DAEMON_ALIGNMENT_BANNER_ID\)/, "the quiet startup check clears any stale CLI banner");
+assert.match(src, /updateCovenCli\([\s\S]{0,120}?\)\.then\(\(\) => \{[\s\S]*dismissBanner\(DAEMON_ALIGNMENT_BANNER_ID\)/, "the quiet startup check clears any stale CLI banner");
 assert.match(
   layoutSrc,
   /<ShellBannersProvider>[\s\S]{0,100}<DaemonReleaseAlignmentTrigger \/>/,

--- a/src/components/update-available.tsx
+++ b/src/components/update-available.tsx
@@ -34,6 +34,7 @@ import {
   nativeUpdateCoordinator,
 } from "@/lib/native-update-coordinator";
 import { updateCovenCli } from "@/lib/app-update-daemon";
+import { readDaemonAutomation } from "@/lib/daemon-automation-pref";
 
 const BANNER_ID = "update-available";
 const DAEMON_ALIGNMENT_BANNER_ID = "daemon-release-alignment";
@@ -124,7 +125,13 @@ export function DaemonReleaseAlignmentTrigger() {
       if (!active || running) return;
       attempted.current = true;
       running = true;
-      void updateCovenCli().then(() => {
+      // `updateCovenCli` already refuses to install without explicit consent —
+      // it returns "confirmation-required" when confirmInstall is falsy, which
+      // is why this background check has always been a no-op that defers to
+      // Settings -> About. The opt-in preference is that consent (cave-bqywj):
+      // read at call time, default off, so nothing installs unattended unless
+      // the user asked for it.
+      void updateCovenCli({ confirmInstall: readDaemonAutomation().autoUpgradeCli }).then(() => {
         running = false;
         if (!active) return;
         // Ordinary CLI availability and update actions live in Settings →

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -74,6 +74,7 @@ import {
   createDaemonStatusRequestGate,
   runWorkspaceDaemonStart,
 } from "@/lib/daemon-desktop-auto-start";
+import { readDaemonAutomation } from "@/lib/daemon-automation-pref";
 import { waitForDaemonUpdateIdle } from "@/lib/app-update-daemon";
 import { useTauriPlatform } from "@/lib/tauri-platform";
 import type { BrowserPaneHandle } from "@/components/browser-pane";
@@ -556,9 +557,19 @@ export function Workspace() {
   const startDaemonRef = useRef<() => Promise<void>>(async () => {});
   const daemonAutoStartCoordinatorRef = useRef<ReturnType<typeof createDaemonDesktopAutoStartCoordinator> | null>(null);
   if (daemonAutoStartCoordinatorRef.current === null) {
-    daemonAutoStartCoordinatorRef.current = createDaemonDesktopAutoStartCoordinator(() => {
-      void startDaemonRef.current();
-    });
+    daemonAutoStartCoordinatorRef.current = createDaemonDesktopAutoStartCoordinator(
+      () => {
+        void startDaemonRef.current();
+      },
+      {
+        // Read per decision, not captured: Settings → Daemon → Automation can
+        // flip this mid-session and the next 5s poll must respect it
+        // (cave-bqywj). Off by default; boot auto-start is unaffected either
+        // way.
+        autoRestartEnabled: () => readDaemonAutomation().autoRestart,
+        now: () => Date.now(),
+      },
+    );
   }
   const browserPaneRef = useRef<BrowserPaneHandle>(null);
   const browserNavigationIdRef = useRef(Date.now() * 1024);

--- a/src/lib/daemon-automation-pref.ts
+++ b/src/lib/daemon-automation-pref.ts
@@ -3,13 +3,18 @@
 /**
  * Unattended daemon lifecycle preferences (cave-bqywj).
  *
- * Three opt-in switches, all default OFF: relaunch a local daemon that died,
- * upgrade the daemon, upgrade the Coven CLI. Cave already knows how to do all
- * three — what it does not do today is any of them without a person clicking.
+ * Two opt-in switches, both default OFF: relaunch a local daemon that died,
+ * and upgrade Coven. Cave already knows how to do both — what it does not do
+ * today is either of them without a person clicking.
+ *
+ * Two, not the three this module first described: there is no separate daemon
+ * artifact to upgrade. /api/onboarding/install's allowlist has one Coven entry,
+ * `coven-cli` -> `@opencoven/cli`, and the daemon is that binary run as a
+ * daemon.
  *
  * Default-off is the whole design. These restart processes and install
  * binaries on the user's machine, and the CLI is the thing they type at, so a
- * silent version change there is the most surprising of the three. The schema
+ * silent version change there is the more surprising of the two. The schema
  * normalizes with `=== true` rather than `!== false` so a corrupt or partial
  * preferences file fails closed instead of enabling automation nobody asked
  * for.
@@ -69,7 +74,7 @@ function subscribe(fn: () => void): () => void {
 }
 
 /**
- * Live view of the three switches. The server snapshot is the defaults —
+ * Live view of both switches. The server snapshot is the defaults —
  * every flag off — so SSR and a first paint before preferences load can never
  * render as though automation were already enabled.
  */

--- a/src/lib/daemon-automation-pref.ts
+++ b/src/lib/daemon-automation-pref.ts
@@ -1,0 +1,78 @@
+"use client";
+
+/**
+ * Unattended daemon lifecycle preferences (cave-bqywj).
+ *
+ * Three opt-in switches, all default OFF: relaunch a local daemon that died,
+ * upgrade the daemon, upgrade the Coven CLI. Cave already knows how to do all
+ * three — what it does not do today is any of them without a person clicking.
+ *
+ * Default-off is the whole design. These restart processes and install
+ * binaries on the user's machine, and the CLI is the thing they type at, so a
+ * silent version change there is the most surprising of the three. The schema
+ * normalizes with `=== true` rather than `!== false` so a corrupt or partial
+ * preferences file fails closed instead of enabling automation nobody asked
+ * for.
+ *
+ * There is deliberately NO auto-reconnect switch here. Reconnection is already
+ * unconditional — `useLocalDaemonReadiness` re-probes /api/daemon/status every
+ * 5s, workspace.tsx polls it on the same cadence and drops the offline banner
+ * as soon as the daemon answers, and the PTY bridge runs its own backoff
+ * reconnect loop. A toggle would either do nothing or, defaulting to off,
+ * REMOVE working recovery. See the note on cave-bqywj.
+ *
+ * Follows the celebrations-pref.ts shape: useSyncExternalStore keeps every
+ * subscriber live across same-tab writes and cross-tab storage events.
+ */
+
+import { useSyncExternalStore } from "react";
+import {
+  DEFAULT_DAEMON_AUTOMATION,
+  type CaveDaemonAutomationPreferences,
+} from "./preferences-schema.ts";
+import {
+  readAppPreferences,
+  subscribeAppPreferences,
+  updateAppPreferences,
+} from "./app-preferences.ts";
+
+export type DaemonAutomationKey = keyof CaveDaemonAutomationPreferences;
+
+let cached: CaveDaemonAutomationPreferences | null = null;
+const listeners = new Set<() => void>();
+
+function notify() {
+  for (const fn of listeners) fn();
+}
+
+export function readDaemonAutomation(): CaveDaemonAutomationPreferences {
+  if (cached === null) cached = readAppPreferences().daemon ?? DEFAULT_DAEMON_AUTOMATION;
+  return cached;
+}
+
+export function writeDaemonAutomation(key: DaemonAutomationKey, enabled: boolean): void {
+  cached = { ...readDaemonAutomation(), [key]: enabled };
+  updateAppPreferences({ daemon: { [key]: enabled } });
+  notify();
+}
+
+subscribeAppPreferences(() => {
+  cached = null;
+  notify();
+});
+
+function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => {
+    listeners.delete(fn);
+  };
+}
+
+/**
+ * Live view of the three switches. The server snapshot is the defaults —
+ * every flag off — so SSR and a first paint before preferences load can never
+ * render as though automation were already enabled.
+ */
+export function useDaemonAutomation(): CaveDaemonAutomationPreferences {
+  return useSyncExternalStore(subscribe, readDaemonAutomation, () => DEFAULT_DAEMON_AUTOMATION);
+}

--- a/src/lib/daemon-desktop-auto-start.test.ts
+++ b/src/lib/daemon-desktop-auto-start.test.ts
@@ -5,6 +5,7 @@ import {
   createDaemonStatusRequestGate,
   daemonDesktopAutoStartDecision,
   runWorkspaceDaemonStart,
+  DAEMON_RESTART_BACKOFF_MS,
 } from "./daemon-desktop-auto-start.ts";
 
 const localOffline = { kind: "offline", targetMode: "local" };
@@ -132,6 +133,133 @@ function response(ok, payload) {
   assert.equal(requests, 2);
   assert.deepEqual(errors, ["Coven CLI missing", "Coven CLI missing"]);
   assert.deepEqual(refreshes, [undefined, undefined], "failure keeps ordinary status authoritative");
+}
+
+
+// ── Opt-in auto-restart (cave-bqywj) ────────────────────────────────────────
+// Boot auto-start has always been one-shot: the coordinator consumes its
+// decision and never reconsiders, so a daemon that dies an hour into a session
+// stays dead. These pin the second half — and, just as importantly, pin that
+// it stays OFF unless the user asked for it.
+
+const OFFLINE = { kind: "offline", targetMode: "local" };
+const RUNNING = { kind: "running", targetMode: "local" };
+
+function restartHarness({ enabled = true, startClock = 0 } = {}) {
+  let clock = startClock;
+  const starts = [];
+  const coordinator = createDaemonDesktopAutoStartCoordinator(
+    () => starts.push(clock),
+    { autoRestartEnabled: () => enabled, now: () => clock },
+  );
+  return {
+    starts,
+    coordinator,
+    setEnabled(next) { enabled = next; },
+    advance(ms) { clock += ms; },
+  };
+}
+
+{
+  // The behaviour the bead exists for: offline mid-session gets relaunched.
+  const h = restartHarness();
+  h.coordinator.observePlatform("desktop");
+  h.coordinator.observeStatus(RUNNING);
+  assert.deepEqual(h.starts, [], "a healthy daemon is left alone");
+  h.advance(60_000);
+  h.coordinator.observeStatus(OFFLINE);
+  assert.equal(h.starts.length, 1, "a daemon that dies mid-session is restarted");
+}
+{
+  // Off by default is the entire safety story — a disabled preference must not
+  // restart anything, no matter how many polls report offline.
+  const h = restartHarness({ enabled: false });
+  h.coordinator.observePlatform("desktop");
+  h.coordinator.observeStatus(RUNNING);
+  for (let i = 0; i < 10; i += 1) {
+    h.advance(600_000);
+    h.coordinator.observeStatus(OFFLINE);
+  }
+  assert.deepEqual(h.starts, [], "opt-out means no unattended restarts at all");
+}
+{
+  // The preference is read at decision time, not captured — turning it off
+  // mid-session takes effect on the very next poll.
+  const h = restartHarness();
+  h.coordinator.observePlatform("desktop");
+  h.coordinator.observeStatus(RUNNING);
+  h.advance(60_000);
+  h.coordinator.observeStatus(OFFLINE);
+  assert.equal(h.starts.length, 1);
+  h.setEnabled(false);
+  h.advance(600_000);
+  h.coordinator.observeStatus(OFFLINE);
+  assert.equal(h.starts.length, 1, "turning the switch off stops the next restart");
+}
+{
+  // Backoff, and a real ceiling. A daemon that cannot start must not be
+  // relaunched every 5s forever — the poll cadence would otherwise make this
+  // an infinite loop against a broken install.
+  const h = restartHarness();
+  h.coordinator.observePlatform("desktop");
+  h.coordinator.observeStatus(RUNNING);
+  for (let i = 0; i < 400; i += 1) {
+    h.advance(5_000); // the real poll cadence
+    h.coordinator.observeStatus(OFFLINE);
+  }
+  assert.equal(
+    h.starts.length,
+    DAEMON_RESTART_BACKOFF_MS.length,
+    "attempts stop at the ceiling instead of looping forever",
+  );
+  const gaps = h.starts.slice(1).map((at, i) => at - h.starts[i]);
+  for (const [i, gap] of gaps.entries()) {
+    assert.ok(
+      gap >= DAEMON_RESTART_BACKOFF_MS[i + 1],
+      `attempt ${i + 2} waited at least its backoff (${gap} >= ${DAEMON_RESTART_BACKOFF_MS[i + 1]})`,
+    );
+  }
+}
+{
+  // Recovery resets the budget: a later, unrelated outage gets a full set of
+  // attempts rather than the exhausted tail of the previous one.
+  const h = restartHarness();
+  h.coordinator.observePlatform("desktop");
+  h.coordinator.observeStatus(RUNNING);
+  for (let i = 0; i < 400; i += 1) {
+    h.advance(5_000);
+    h.coordinator.observeStatus(OFFLINE);
+  }
+  const exhausted = h.starts.length;
+  h.advance(5_000);
+  h.coordinator.observeStatus(RUNNING);
+  h.advance(5_000);
+  h.coordinator.observeStatus(OFFLINE);
+  assert.equal(h.starts.length, exhausted + 1, "a recovered daemon restores the attempt budget");
+}
+{
+  // Scope guards: never on mobile, never for a hub target, and never a second
+  // start on the same observation that boot already acted on.
+  const mobile = restartHarness();
+  mobile.coordinator.observePlatform("mobile");
+  mobile.coordinator.observeStatus(OFFLINE);
+  mobile.advance(600_000);
+  mobile.coordinator.observeStatus(OFFLINE);
+  assert.deepEqual(mobile.starts, [], "mobile never auto-starts a local daemon");
+
+  const boot = restartHarness();
+  boot.coordinator.observePlatform("desktop");
+  boot.coordinator.observeStatus(OFFLINE);
+  assert.equal(boot.starts.length, 1, "boot start fires exactly once, not twice");
+}
+{
+  // No options → the old one-shot coordinator, byte for byte in behaviour.
+  const starts = [];
+  const coordinator = createDaemonDesktopAutoStartCoordinator(() => starts.push(1));
+  coordinator.observePlatform("desktop");
+  coordinator.observeStatus(RUNNING);
+  for (let i = 0; i < 5; i += 1) coordinator.observeStatus(OFFLINE);
+  assert.deepEqual(starts, [], "without opt-in wiring the coordinator stays one-shot");
 }
 
 console.log("daemon-desktop-auto-start.test.ts: ok");

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -30,19 +30,83 @@ export type DaemonDesktopAutoStartCoordinator = {
  * The decision is consumed synchronously before `start` is called, so even a
  * re-entrant status observation cannot issue a duplicate request.
  */
+/**
+ * Backoff for unattended restarts, in ms since the previous attempt. A daemon
+ * that cannot start must not be relaunched every 5 seconds forever: the list
+ * is finite, so after the last entry the coordinator gives up and leaves the
+ * offline banner to say so. A single observed `running` result resets it.
+ */
+export const DAEMON_RESTART_BACKOFF_MS = [0, 15_000, 60_000, 300_000] as const;
+
+export type DaemonAutoRestartOptions = {
+  /**
+   * Read at each decision, never captured: the user can turn the preference
+   * off mid-session and the very next poll must respect that.
+   */
+  autoRestartEnabled: () => boolean;
+  now: () => number;
+};
+
+/**
+ * Rendezvous the first accepted status decision with the resolved platform.
+ * The decision is consumed synchronously before `start` is called, so even a
+ * re-entrant status observation cannot issue a duplicate request.
+ *
+ * Boot behaviour is unchanged and unconditional — a daemon that is already
+ * offline when the app opens is still started once, with no preference
+ * involved. `options` adds the opt-in second half (cave-bqywj): after that
+ * first decision, keep watching, and relaunch a local daemon that goes offline
+ * mid-session. Without `options` the coordinator is exactly the one-shot it
+ * has always been.
+ */
 export function createDaemonDesktopAutoStartCoordinator(
   start: () => void,
+  options?: DaemonAutoRestartOptions,
 ): DaemonDesktopAutoStartCoordinator {
   let platform: TauriPlatform = "unknown";
   let firstStatus: DaemonStatusPollResult | null = null;
   let consumed = false;
+  let restartAttempts = 0;
+  let lastAttemptAt: number | null = null;
 
   const reconcile = () => {
     if (consumed) return;
     const decision = daemonDesktopAutoStartDecision({ platform, firstStatus });
     if (decision === "wait") return;
     consumed = true;
-    if (decision === "start") start();
+    if (decision === "start") {
+      lastAttemptAt = options ? options.now() : null;
+      restartAttempts = 1;
+      start();
+    }
+  };
+
+  /**
+   * Runs only after the boot decision is consumed. Deliberately re-reads the
+   * preference and re-checks the platform every time rather than trusting the
+   * state captured at boot.
+   */
+  const considerRestart = (status: DaemonStatusPollResult) => {
+    if (!options || !consumed) return;
+    if (status.kind === "running") {
+      // Proof the daemon is back: forget the attempt history so a later,
+      // unrelated outage gets a full budget rather than the tail of this one.
+      restartAttempts = 0;
+      lastAttemptAt = null;
+      return;
+    }
+    if (platform !== "desktop") return;
+    if (status.kind !== "offline" || status.targetMode !== "local") return;
+    if (!options.autoRestartEnabled()) return;
+    if (restartAttempts >= DAEMON_RESTART_BACKOFF_MS.length) return;
+
+    const wait = DAEMON_RESTART_BACKOFF_MS[restartAttempts];
+    const at = options.now();
+    if (lastAttemptAt !== null && at - lastAttemptAt < wait) return;
+
+    restartAttempts += 1;
+    lastAttemptAt = at;
+    start();
   };
 
   return {
@@ -53,6 +117,7 @@ export function createDaemonDesktopAutoStartCoordinator(
     observeStatus(status) {
       if (firstStatus === null) firstStatus = status;
       reconcile();
+      considerRestart(status);
     },
   };
 }

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -26,11 +26,6 @@ export type DaemonDesktopAutoStartCoordinator = {
 };
 
 /**
- * Rendezvous the first accepted status decision with the resolved platform.
- * The decision is consumed synchronously before `start` is called, so even a
- * re-entrant status observation cannot issue a duplicate request.
- */
-/**
  * Backoff for unattended restarts, in ms since the previous attempt. A daemon
  * that cannot start must not be relaunched every 5 seconds forever: the list
  * is finite, so after the last entry the coordinator gives up and leaves the

--- a/src/lib/preferences-schema.test.ts
+++ b/src/lib/preferences-schema.test.ts
@@ -446,7 +446,7 @@ assert.equal(defaults.appearance.backdrop.style, "image");
 }
 {
   // ── Daemon automation (cave-bqywj) ──────────────────────────────────────
-  // These three restart processes and install binaries on the user's machine.
+  // These two restart processes and install binaries on the user's machine.
   // Every assertion below exists because the failure mode is "the cave did
   // something unattended that the user never asked for", which no amount of
   // later UI polish undoes.

--- a/src/lib/preferences-schema.test.ts
+++ b/src/lib/preferences-schema.test.ts
@@ -444,3 +444,71 @@ assert.equal(defaults.appearance.backdrop.style, "image");
   const cleared = applyPreferencesPatch(scoped, { github: { orgScope: [] } });
   assert.deepEqual(cleared.github.orgScope, [], "empty patch clears back to all");
 }
+{
+  // ── Daemon automation (cave-bqywj) ──────────────────────────────────────
+  // These three restart processes and install binaries on the user's machine.
+  // Every assertion below exists because the failure mode is "the cave did
+  // something unattended that the user never asked for", which no amount of
+  // later UI polish undoes.
+  const daemon = createDefaultPreferences(false).daemon;
+  assert.equal(daemon.autoRestart, false, "auto-restart is opt-in");
+  assert.equal(daemon.autoUpgradeCli, false, "CLI auto-upgrade is opt-in");
+  assert.deepEqual(
+    Object.keys(daemon).sort(),
+    ["autoRestart", "autoUpgradeCli"],
+    "no daemon automation ships without a default asserted here",
+  );
+}
+{
+  // Absent section, and a file written by a build that never had one.
+  assert.equal(normalizeCavePreferences({}).daemon.autoUpgradeCli, false, "absent daemon → off");
+  assert.equal(
+    normalizeCavePreferences({ daemon: {} }).daemon.autoRestart,
+    false,
+    "empty daemon section → off",
+  );
+}
+{
+  // Fails CLOSED. The rest of the schema uses `!== false` for default-on
+  // booleans; a value that merely looks truthy must NOT switch these on.
+  for (const truthy of ["true", 1, "yes", {}, [], "on"]) {
+    const p = normalizeCavePreferences({
+      daemon: { autoRestart: truthy, autoUpgradeCli: truthy },
+    });
+    assert.equal(p.daemon.autoRestart, false, `truthy ${JSON.stringify(truthy)} is not consent`);
+    assert.equal(p.daemon.autoUpgradeCli, false, `truthy ${JSON.stringify(truthy)} is not consent`);
+  }
+  const on = normalizeCavePreferences({ daemon: { autoRestart: true } });
+  assert.equal(on.daemon.autoRestart, true, "an explicit true still turns it on");
+}
+{
+  // Patch validation: booleans only, known keys only.
+  const patch = validatePreferencesPatch({ daemon: { autoUpgradeCli: true } });
+  assert.equal(patch.daemon?.autoUpgradeCli, true);
+  assert.equal(
+    Object.hasOwn(patch.daemon ?? {}, "autoRestart"),
+    false,
+    "a patch touches only the keys it names",
+  );
+  for (const bad of ["true", 1, null]) {
+    assert.throws(
+      () => validatePreferencesPatch({ daemon: { autoRestart: bad } }),
+      PreferencesValidationError,
+      `daemon.autoRestart rejects ${JSON.stringify(bad)}`,
+    );
+  }
+  assert.throws(
+    () => validatePreferencesPatch({ daemon: { autoUpgradeEverything: true } }),
+    PreferencesValidationError,
+    "unknown daemon keys are rejected rather than silently stored",
+  );
+}
+{
+  // Toggling one flag leaves the others alone, and off is reachable again.
+  const base = createDefaultPreferences(true);
+  const on = applyPreferencesPatch(base, { daemon: { autoRestart: true } });
+  assert.equal(on.daemon.autoRestart, true);
+  assert.equal(on.daemon.autoUpgradeCli, false, "one toggle does not enable its neighbours");
+  const off = applyPreferencesPatch(on, { daemon: { autoRestart: false } });
+  assert.equal(off.daemon.autoRestart, false, "the user can always turn it back off");
+}

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -125,6 +125,30 @@ export type CavePreferences = {
      */
     orgScope: string[];
   };
+  /**
+   * Unattended daemon lifecycle. Every flag here defaults to FALSE and is
+   * normalized with `=== true`, not `!== false`: these actions restart
+   * processes and install binaries on the user's machine, so anything that is
+   * not an explicit `true` must read as off. A corrupt or partial preferences
+   * file therefore fails closed.
+   */
+  daemon: CaveDaemonAutomationPreferences;
+};
+
+export type CaveDaemonAutomationPreferences = {
+  /** Relaunch a local daemon that has gone offline mid-session. */
+  autoRestart: boolean;
+  /**
+   * Install Coven CLI updates without waiting for a banner click.
+   *
+   * There is no separate daemon flag because there is no separate daemon
+   * artifact: /api/onboarding/install's allowlist has one Coven entry,
+   * `coven-cli` -> `@opencoven/cli`, and the daemon is that same binary run as
+   * a daemon. daemon-update-lifecycle.ts exists precisely to update the CLI
+   * while its local daemon holds the executable open. Two switches would have
+   * been one action wearing two labels.
+   */
+  autoUpgradeCli: boolean;
 };
 
 export type CavePreferencesPatch = {
@@ -143,6 +167,7 @@ export type CavePreferencesPatch = {
   general?: Partial<CavePreferences["general"]>;
   phone?: Partial<CavePreferences["phone"]>;
   github?: Partial<CavePreferences["github"]>;
+  daemon?: Partial<CavePreferences["daemon"]>;
 };
 
 const DEFAULT_THEME: CaveThemePreferences = {
@@ -176,6 +201,35 @@ export function normalizeOrgScope(value: unknown): string[] {
     if (login) seen.add(login);
   }
   return [...seen];
+}
+
+/**
+ * Every daemon-automation key, in one place so the type, the defaults, the
+ * normalizer and the patch validator cannot drift apart. Adding a key here is
+ * the only edit needed to carry it through all four.
+ */
+export const DAEMON_AUTOMATION_KEYS = [
+  "autoRestart",
+  "autoUpgradeCli",
+] as const satisfies readonly (keyof CaveDaemonAutomationPreferences)[];
+
+/** Opt-in, every one of them. See the note on CavePreferences["daemon"]. */
+export const DEFAULT_DAEMON_AUTOMATION: CaveDaemonAutomationPreferences = {
+  autoRestart: false,
+  autoUpgradeCli: false,
+};
+
+/**
+ * `=== true` on purpose. The rest of this schema uses `!== false` for
+ * default-on booleans; these are default-OFF and they restart processes and
+ * install binaries, so a missing, malformed or truthy-but-not-true value has
+ * to normalize to off rather than on.
+ */
+function normalizeDaemonAutomation(source: Record<string, unknown>): CaveDaemonAutomationPreferences {
+  return {
+    autoRestart: source.autoRestart === true,
+    autoUpgradeCli: source.autoUpgradeCli === true,
+  };
 }
 
 function normalizeStopPhrase(value: unknown): string {
@@ -217,6 +271,7 @@ export function createDefaultPreferences(initialized = false): CavePreferences {
     general: { stopPhrase: DEFAULT_STOP_PHRASE, celebrations: true },
     phone: { mobileMode: true },
     github: { orgScope: [] },
+    daemon: DEFAULT_DAEMON_AUTOMATION,
   };
 }
 
@@ -380,6 +435,7 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
   const general = record(source.general);
   const phone = record(source.phone);
   const github = record(source.github);
+  const daemon = record(source.daemon);
 
   const modePreference = oneOf(theme.modePreference, MODE_PREFERENCES, "dark");
   const resolvedMode = oneOf(
@@ -461,6 +517,7 @@ export function normalizeCavePreferences(input: unknown): CavePreferences {
     },
     phone: { mobileMode: phone.mobileMode !== false },
     github: { orgScope: normalizeOrgScope(github.orgScope) },
+    daemon: normalizeDaemonAutomation(daemon),
   };
 }
 
@@ -554,7 +611,11 @@ function strictAccentSeed(value: unknown, path: string): CaveBackdropAccentSeed 
 
 export function validatePreferencesPatch(value: unknown): CavePreferencesPatch {
   const input = strictRecord(value, "preferences patch");
-  assertAllowedKeys(input, ["appearance", "general", "phone", "github"], "preferences patch");
+  assertAllowedKeys(
+    input,
+    ["appearance", "general", "phone", "github", "daemon"],
+    "preferences patch",
+  );
   const patch: CavePreferencesPatch = {};
 
   if (Object.hasOwn(input, "appearance")) {
@@ -724,6 +785,17 @@ export function validatePreferencesPatch(value: unknown): CavePreferencesPatch {
     }
     patch.github = githubPatch;
   }
+  if (Object.hasOwn(input, "daemon")) {
+    const daemon = strictRecord(input.daemon, "daemon");
+    assertAllowedKeys(daemon, DAEMON_AUTOMATION_KEYS, "daemon");
+    const daemonPatch: NonNullable<CavePreferencesPatch["daemon"]> = {};
+    for (const key of DAEMON_AUTOMATION_KEYS) {
+      if (Object.hasOwn(daemon, key)) {
+        daemonPatch[key] = strictBoolean(daemon[key], `daemon.${key}`);
+      }
+    }
+    patch.daemon = daemonPatch;
+  }
 
   return patch;
 }
@@ -802,6 +874,7 @@ export function applyPreferencesPatch(
     general: { ...current.general, ...(patch.general ?? {}) },
     phone: { ...current.phone, ...(patch.phone ?? {}) },
     github: { ...current.github, ...(patch.github ?? {}) },
+    daemon: { ...current.daemon, ...(patch.daemon ?? {}) },
   };
 
   const semanticCurrent = { ...current, initialized: true, revision: 0, updatedAt: "" };

--- a/src/lib/preferences-schema.ts
+++ b/src/lib/preferences-schema.ts
@@ -204,9 +204,11 @@ export function normalizeOrgScope(value: unknown): string[] {
 }
 
 /**
- * Every daemon-automation key, in one place so the type, the defaults, the
- * normalizer and the patch validator cannot drift apart. Adding a key here is
- * the only edit needed to carry it through all four.
+ * Every daemon-automation key, in one place. The defaults, the normalizer and
+ * the patch validator all derive from this list, so adding a key here really
+ * is the only edit needed to carry it through them — the type is the one thing
+ * that still has to be written by hand, and `satisfies` below fails the build
+ * if the two disagree.
  */
 export const DAEMON_AUTOMATION_KEYS = [
   "autoRestart",
@@ -214,10 +216,10 @@ export const DAEMON_AUTOMATION_KEYS = [
 ] as const satisfies readonly (keyof CaveDaemonAutomationPreferences)[];
 
 /** Opt-in, every one of them. See the note on CavePreferences["daemon"]. */
-export const DEFAULT_DAEMON_AUTOMATION: CaveDaemonAutomationPreferences = {
-  autoRestart: false,
-  autoUpgradeCli: false,
-};
+export const DEFAULT_DAEMON_AUTOMATION: CaveDaemonAutomationPreferences =
+  Object.freeze(
+    Object.fromEntries(DAEMON_AUTOMATION_KEYS.map((key) => [key, false])),
+  ) as CaveDaemonAutomationPreferences;
 
 /**
  * `=== true` on purpose. The rest of this schema uses `!== false` for
@@ -226,10 +228,9 @@ export const DEFAULT_DAEMON_AUTOMATION: CaveDaemonAutomationPreferences = {
  * to normalize to off rather than on.
  */
 function normalizeDaemonAutomation(source: Record<string, unknown>): CaveDaemonAutomationPreferences {
-  return {
-    autoRestart: source.autoRestart === true,
-    autoUpgradeCli: source.autoUpgradeCli === true,
-  };
+  return Object.fromEntries(
+    DAEMON_AUTOMATION_KEYS.map((key) => [key, source[key] === true]),
+  ) as CaveDaemonAutomationPreferences;
 }
 
 function normalizeStopPhrase(value: unknown): string {

--- a/src/styles/settings-daemon.css
+++ b/src/styles/settings-daemon.css
@@ -934,3 +934,38 @@
     transition: none;
   }
 }
+
+/* Unattended lifecycle switches (cave-bqywj). Same row rhythm as the info
+   list above it, with room for a second line of copy — each switch needs to
+   say what it will do without being clicked, because the consequence is a
+   process restart or a binary install. */
+.settings-daemon-automation {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.settings-daemon-automation-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-2) 0;
+}
+.settings-daemon-automation-row + .settings-daemon-automation-row {
+  border-top: 1px solid var(--border-hairline);
+}
+.settings-daemon-automation-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.settings-daemon-automation-label {
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+.settings-daemon-automation-description {
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  line-height: 1.4;
+}


### PR DESCRIPTION
Two switches in **Settings → Daemon → Automation**, both **default off**.

| switch | what it does |
|---|---|
| **Restart the daemon** | relaunches a local daemon that goes offline mid-session |
| **Upgrade Coven** | installs Coven CLI updates unattended — this is also the daemon |

They restart processes and install binaries on the user's machine, so the schema normalizes them with `=== true` rather than the `!== false` used for every other boolean here. A corrupt or partial preferences file fails closed instead of enabling automation nobody asked for.

## Restart — the genuinely new behaviour

Auto-start has always been one-shot. `createDaemonDesktopAutoStartCoordinator` rendezvouses the resolved platform with the **first** status result, consumes the decision, and never reconsiders — so a daemon that dies an hour into a session stays dead no matter how many later polls report it offline.

With the switch on, a later offline poll relaunches it, with backoff `[0, 15s, 60s, 5m]` and a **hard ceiling**. The status poll runs every 5 seconds, so without a ceiling a broken install would be relaunched forever. One observed `running` result resets the budget, so a later unrelated outage gets a full set of attempts rather than the exhausted tail of the previous one.

Boot behaviour is unchanged and still unconditional. Without the new options argument the coordinator is the one-shot it has always been.

## Upgrade — two lines, because the consent gate already existed

`updateCovenCli` returns `"confirmation-required"` unless `confirmInstall` is set, which is why the startup check has always been a deliberate no-op deferring to Settings → About. The preference simply **is** that consent, read at call time. No existing safety gate was weakened; one was fed.

## Two requested switches are deliberately absent

Verifying them showed both would have been placebos:

- **Auto-reconnect.** Reconnection is already unconditional — the status poll re-probes every 5s and drops the offline banner the moment the daemon answers, and the PTY bridge runs its own backoff loop. A toggle would do nothing, or worse: defaulting to off, it would *remove* recovery that works today.
- **Separate daemon vs CLI upgrade.** There is no separate daemon artifact. `/api/onboarding/install`'s allowlist has exactly one Coven entry — `coven-cli` → `@opencoven/cli` — and the daemon is that binary run as a daemon; `daemon-update-lifecycle.ts` exists precisely to update the CLI while its local daemon holds the executable open. Two switches would have been one action wearing two labels, and flipping the "daemon" one would silently upgrade the CLI.

## A safety pin was tightened, not relaxed

`update-available.test.ts` pinned that call site as `updateCovenCli()` with no arguments, asserting *"startup reconciliation never silently confirms a global install"*. My change walked through it, so the guard was rewritten to a stricter invariant rather than deleted:

- the call must source consent from the preference
- a literal `confirmInstall: true` anywhere in the file now **fails**
- the preference must come from its own module, not be reconstructed locally

The old regex would have permitted a hardcoded `true` the moment anyone added an argument. The old guarantee was "this path never installs"; the new one is "this path installs only on explicit, default-off, user-set consent."

## Verification

Every guard was negative-tested — each was broken and confirmed to fail with the assertion that names it:

- ignoring the preference → *opt-out means no unattended restarts at all*
- removing the restart ceiling → *attempts stop at the ceiling instead of looping forever*
- capturing the preference at construction → *turning the switch off stops the next restart*
- defaulting on, and lenient `!== false` coercion → both caught
- hardcoding consent, and dropping the gate entirely → both caught

Full `test:app`: one failure, `src/lib/server/research-media-jobs.test.ts` — the known open flake `cave-a1qys`. Reproduced 3 of 5 runs in isolation on this branch with a *different* assertion each time, and this diff touches nothing under `src/lib/server/`. `tsc --noEmit` clean; all 1406 test files wired.