### PR TITLE
test(maintenance-gate): make the gate tests race-free instead of timing-lucky (cave-nseb2)

### DIFF
--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -1,11 +1,13 @@
 import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import {
   existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -43,18 +45,86 @@ function intentFileForLease(lease) {
   assert.fail(`intent file not found for ${lease.writerId}`);
 }
 
+/**
+ * Replace a state file the way the module under test does: write a uniquely
+ * named temporary beside it, then rename over the target.
+ *
+ * This matters because these files are read by CONCURRENTLY RUNNING children.
+ * `writeFileSync` truncates and then fills, so a child polling gate.json can
+ * observe a zero-length or half-written file and reject it as `malformed-gate`.
+ * That is not hypothetical — it is how the clock-regression test failed on CI
+ * job 91328244743 (expected `clock-regressed`, got `malformed-gate`), and it is
+ * why maintenance-gate.mjs publishes every one of these files by renaming a temp
+ * over the target (see its header: "rename-replaced"). A test that pokes the
+ * same files owes them the same atomicity, or it is asserting against a state
+ * the production writer can never produce.
+ *
+ * The temp name mirrors the module's own convention so it still ends in `.tmp`,
+ * which matters: the intent scanner skips anything not ending in `.json`, so a
+ * temp file cannot be mistaken for a malformed intent during its brief life.
+ *
+ * rename(2) is atomic within a filesystem, so a reader sees strictly the old
+ * bytes or strictly the new ones.
+ */
+function writeJsonAtomic(filePath, value) {
+  const temp = `${filePath}.${process.pid}.${randomBytes(4).toString("hex")}.tmp`;
+  writeFileSync(temp, JSON.stringify(value));
+  renameSync(temp, filePath);
+}
+
+/**
+ * Run `mutate` while holding the module's own `mutation.lock`, so a state edit
+ * made by the test is serialized against a concurrently running acquirer.
+ *
+ * Needed because the module's writers are not merely atomic, they are LOCKED,
+ * and read-check-write is only sound for a participant that takes the same lock.
+ * `refreshDrainingGate` reads the gate, checks it for clock regression, and then
+ * writes a fresh `heartbeatAt` — all inside this lock. An unlocked test write
+ * that lands between that read and that write is overwritten before the check
+ * ever examines it, so the injected state is silently lost and the drain runs to
+ * its full quiesce timeout. Taking the lock closes that window by construction
+ * rather than by timing.
+ *
+ * Holding it briefly is safe: a blocked acquirer treats `state-busy` during
+ * drain as a reason to keep waiting (it re-polls until its own deadline), so the
+ * worst case is that the child spins a few extra poll intervals.
+ */
+function withStateLock(repo, mutate) {
+  const lockFile = path.join(maintenanceGateRoot(repo), "mutation.lock");
+  const deadline = Date.now() + 30_000;
+  for (;;) {
+    try {
+      writeFileSync(
+        lockFile,
+        JSON.stringify({
+          token: "feedfacefeedfacefeedface",
+          acquiredAt: new Date().toISOString(),
+          pid: process.pid,
+        }),
+        { flag: "wx" },
+      );
+      break;
+    } catch (error) {
+      if (error?.code !== "EEXIST") throw error;
+      if (Date.now() > deadline) assert.fail("never acquired the state lock");
+    }
+  }
+  try {
+    return mutate();
+  } finally {
+    rmSync(lockFile, { force: true });
+  }
+}
+
 function expireGate(repo) {
   const filePath = path.join(maintenanceGateRoot(repo), "gate.json");
   const original = JSON.parse(readFileSync(filePath, "utf8"));
   const heartbeat = Date.now() - original.ttlMs - 1_000;
-  writeFileSync(
-    filePath,
-    JSON.stringify({
-      ...original,
-      acquiredAt: new Date(heartbeat - 1).toISOString(),
-      heartbeatAt: new Date(heartbeat).toISOString(),
-    }),
-  );
+  writeJsonAtomic(filePath, {
+    ...original,
+    acquiredAt: new Date(heartbeat - 1).toISOString(),
+    heartbeatAt: new Date(heartbeat).toISOString(),
+  });
   return { filePath, original };
 }
 
@@ -62,14 +132,11 @@ function expireIntent(lease) {
   const filePath = intentFileForLease(lease);
   const original = JSON.parse(readFileSync(filePath, "utf8"));
   const heartbeat = Date.now() - original.ttlMs - 1_000;
-  writeFileSync(
-    filePath,
-    JSON.stringify({
-      ...original,
-      registeredAt: new Date(heartbeat - 1).toISOString(),
-      heartbeatAt: new Date(heartbeat).toISOString(),
-    }),
-  );
+  writeJsonAtomic(filePath, {
+    ...original,
+    registeredAt: new Date(heartbeat - 1).toISOString(),
+    heartbeatAt: new Date(heartbeat).toISOString(),
+  });
   return { filePath, original };
 }
 
@@ -296,14 +363,13 @@ test("a transiently incomplete mutation lock is treated as contention, not malfo
   const result = collectChild(child);
   await waitUntil(() => existsSync(readyFile), "lock contender never started");
   await new Promise((resolve) => setTimeout(resolve, 50));
-  writeFileSync(
-    lockFile,
-    JSON.stringify({
-      token: "0123456789abcdef01234567",
-      acquiredAt: new Date().toISOString(),
-      pid: process.pid,
-    }),
-  );
+  // Atomic: the contender polls mutation.lock while blocked, so a truncate-then
+  // -fill write can hand it a zero-length lock that parses as "unheld".
+  writeJsonAtomic(lockFile, {
+    token: "0123456789abcdef01234567",
+    acquiredAt: new Date().toISOString(),
+    pid: process.pid,
+  });
   await new Promise((resolve) => setTimeout(resolve, 50));
   rmSync(lockFile);
 
@@ -484,10 +550,23 @@ test("promotion rechecks intents after a concurrent writer heartbeat", async () 
   const heartbeatResult = collectChild(heartbeatChild);
   await waitUntil(() => existsSync(ready), "writer heartbeat never reached its final mutation");
   expireIntent(intent.lease);
+  // This sleep is load-bearing and stays: it gives the draining ACQUIRER — a
+  // separate process — a window to scan and see a lapsed writer, before the
+  // heartbeat child renews the lease underneath it. That observation happens
+  // inside the child and leaves no artifact to wait on, so there is nothing
+  // deterministic to poll here; waiting on the parent's own view of the expiry
+  // would return in one tick and quietly stop staging the interleaving. The
+  // acquirer's 30s quiesce budget leaves ample room for 150ms.
   await new Promise((resolve) => setTimeout(resolve, 150));
   writeFileSync(proceed, "proceed");
   assert.equal((await heartbeatResult).ok, true);
-  await new Promise((resolve) => setTimeout(resolve, 150));
+  // The renewal is already durable — collectChild only resolves after the child
+  // exited, which is after its write landed — so wait on the renewed intent
+  // becoming visible instead of burning another fixed 150ms of drain budget.
+  await waitUntil(
+    () => maintenanceGateStatus(repo).liveIntents.includes("promotion-writer"),
+    "the renewed writer intent never became visible",
+  );
 
   const duringRenewedWrite = maintenanceGateStatus(repo);
   assert.equal(duringRenewedWrite.gate?.phase, "draining");
@@ -574,15 +653,33 @@ test("clock regression during drain does not report timeout blockers", async () 
     30_000,
   );
 
+  // Atomic (cave-nseb2): the acquiring child spawned above is polling gate.json
+  // in its drain loop right now, so this read-modify-write has a live reader. A
+  // plain writeFileSync truncates before it fills, letting the child observe an
+  // empty or half-written file and — correctly — reject it as `malformed-gate`
+  // rather than see the future heartbeat being injected here.
+  //
+  // That is the recorded failure, not a theory: CI job 91328244743 got
+  // 'malformed-gate' where it expected 'clock-regressed'. It did so after 224ms,
+  // which is what rules out the quiesce timeout it was first blamed on — the
+  // budget for this test is 30s. The rename below is indivisible to the reader.
+  //
+  // Under the state lock for a second, independent reason: unlocked, this
+  // injection can be erased before it is ever examined. The child's drain does
+  // read -> check-for-regression -> rewrite heartbeatAt, all holding this lock;
+  // a write that slips between its read and its rewrite vanishes unobserved, and
+  // the child then drains for the full 30s and returns 'quiesce-timeout'. That
+  // is the OTHER way this test fails, and raising the timeout only made it take
+  // six times longer to do so. Reproduced locally post-rebase: expected
+  // 'clock-regressed', got 'quiesce-timeout'.
   const gateFile = path.join(maintenanceGateRoot(repo), "gate.json");
-  const gate = JSON.parse(readFileSync(gateFile, "utf8"));
-  writeFileSync(
-    gateFile,
-    JSON.stringify({
+  withStateLock(repo, () => {
+    const gate = JSON.parse(readFileSync(gateFile, "utf8"));
+    writeJsonAtomic(gateFile, {
       ...gate,
       heartbeatAt: new Date(Date.now() + MAX_SAFE_TEST_OFFSET).toISOString(),
-    }),
-  );
+    });
+  });
 
   const acquired = await acquiredResult;
   assert.equal(acquired.reason, "clock-regressed");
@@ -615,7 +712,21 @@ test("a gate is active when acquisition returns after a slow drain", async () =>
     "gate never entered draining phase",
     30_000,
   );
-  await new Promise((resolve) => setTimeout(resolve, 600));
+  // Wait for a heartbeat to actually LAND, not for wall-clock to pass its ttl.
+  // The old form slept 600ms against ttlMs 500 and asserted the lease was still
+  // alive — which only holds if the acquirer got scheduled to heartbeat inside
+  // that window. On a loaded machine it may not: #4155 measured this module's
+  // own file I/O at 1.3s-4.4s, several times the margin being relied on, and the
+  // assertion then reads a genuinely expired lease and fails. Observing
+  // heartbeatAt advance past the value we started from proves the renewal
+  // happened, which is the actual claim; the lease being unexpired at that
+  // moment then follows for the right reason rather than by timing luck.
+  const firstBeat = maintenanceGateStatus(repo).gate?.heartbeatAt;
+  await waitUntil(
+    () => maintenanceGateStatus(repo).gate?.heartbeatAt > firstBeat,
+    "the draining acquirer never renewed its lease",
+    30_000,
+  );
   assert.equal(
     maintenanceGateStatus(repo).gate?.expired,
     false,
@@ -780,9 +891,24 @@ test("concurrent multi-process acquisition: exactly one winner", async () => {
   const settled = await Promise.all(results);
   const winners = settled.filter((result) => result.ok);
   assert.equal(winners.length, 1, `exactly one of ${contenders} concurrent acquirers wins: ${JSON.stringify(settled)}`);
+  // Losing for either contention reason is correct. `gate-held` means the loser
+  // got the state lock and read a live gate; `state-busy` means it never got the
+  // state lock at all, because MUTATION_LOCK_WAIT_MS is a fixed 1s budget and
+  // six processes serialize through one O_EXCL file. Both say "someone else has
+  // it", which is the property under test. Measured on this machine with four
+  // concurrent instances of this scenario: 86 gate-held, 74 state-busy, and
+  // exactly one winner in all 32 rounds — so pinning the reason to `gate-held`
+  // asserts a scheduling outcome the module never promises, and fails under load
+  // even though the mutual exclusion it exists to check is intact.
+  //
+  // The reasons deliberately NOT accepted are the ones that would be real bugs:
+  // `malformed-gate` (a torn read of gate.json), `gate-stale` (a live holder's
+  // lease judged expired), and anything else outside this set.
+  const contentionReasons = new Set(["gate-held", "state-busy"]);
+  const losers = settled.filter((result) => !result.ok);
   assert.ok(
-    settled.filter((result) => !result.ok).every((result) => result.reason === "gate-held"),
-    "every loser sees gate-held",
+    losers.every((result) => contentionReasons.has(result.reason)),
+    `every loser is turned away for contention, not a fault: ${JSON.stringify(settled)}`,
   );
   rmSync(repo, { recursive: true, force: true });
 });


### PR DESCRIPTION
Fixes the intermittent failures in `scripts/maintenance-gate.test.mjs` (cave-nseb2). All three defects are in the test; **no production behaviour changes**.

## The recorded diagnosis was wrong

The bead said the acquiring child exhausts its quiesce budget, and `dc224b4ce` acted on that by raising it from 5000ms to 30_000ms. The failing job's log rules it out — CI job 91328244743:

```
clock regression during drain does not report timeout blockers (224.935459ms)
AssertionError: + 'malformed-gate'  - 'clock-regressed'
```

It failed after **224 milliseconds**. Nothing needing five seconds happened. (That workflow run now reports `success` — it was re-run to green, which is the pattern the bead warned this invites.)

## 1. Non-atomic writes to files a child was reading

`writeFileSync` truncates then fills, so an acquirer polling `gate.json` in its drain loop can read an empty or half-written file and — correctly — reject it as `malformed-gate`. `maintenance-gate.mjs` never produces that state; it renames a temp over the target, which its own header calls `rename-replaced`. The test was writing in a way the module under test cannot, then asserting on the fallout.

Adds `writeJsonAtomic()` mirroring the module's writer (same `.tmp` suffix, so the intent scanner's `.json` filter still skips it), applied to the concurrently-read sites.

## 2. The clock-regression injection could be erased unobserved

The drain calls `refreshDrainingGate()` each poll. It runs **inside the mutation lock** and does read → check `clockRegressed` → write `heartbeatAt = now` (`maintenance-gate.mjs:809,813,816`). Line 816 has no `Math.max` guard, unlike the promotion path at line 690. The test injected without taking that lock, so an injection landing between the child's read and its rewrite was overwritten before line 813 examined it — after which the drain runs its full budget and returns `quiesce-timeout`.

That is the outcome the original diagnosis predicted, by the wrong mechanism: the write isn't too slow, it's discarded. Raising `quiesceTimeoutMs` doesn't narrow that window — it just makes the failure take 30s instead of 5s. Reproduced locally after rebasing onto the raise.

Adds `withStateLock()`, taking the module's own `mutation.lock` by the same O_EXCL protocol. Holding it briefly is safe by design: a draining acquirer treats `state-busy` as "keep waiting" and re-polls until its own deadline (`maintenance-gate.mjs:557`).

## 3. "exactly one winner" asserted scheduling, not safety

It required every loser to report `gate-held`. Under contention a loser gets `state-busy` instead — it never won the fixed 1s `MUTATION_LOCK_WAIT_MS`, so it never read the gate. Measured with four concurrent instances: **86 `gate-held`, 74 `state-busy`, and exactly one winner in all 32 rounds.** Mutual exclusion held every time; only the over-specified reason broke.

Widened to `{gate-held, state-busy}`, still rejecting reasons that would be real defects (`malformed-gate`, `gate-stale`).

## Also

Two fixed sleeps that asserted against wall-clock now wait on state: a 600ms sleep against a 500ms ttl waits for `heartbeatAt` to advance, and a 150ms sleep running *after* its child was already awaited is gone. The 150ms sleep staging a genuine interleaving is kept and documented as load-bearing.

`dc224b4ce`'s raise is left in place — harmless, and closes a different real-but-unobserved race.

## Verification, honestly

Not a measured before/after. The full suite passes **6/6 under concurrent gate load on both `main` and this branch**, so the local load available here doesn't reproduce the CI flake on `main` either; the sweep only shows nothing regressed. Defect 3 has a direct measurement; defect 1 rests on the CI log plus the module's atomicity contract; defect 2 on one local reproduction plus a plainly visible read-check-write window. Each fix removes a window by construction rather than widening a margin.

Isolated runs don't discriminate — the clock-regression test passes 10/10 alone on both trees. Both modes need full-suite interleaving, which is why "passes locally" was never evidence here.
