### PR TITLE
Gate worktree patrol apply behind maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ ds-bundle/
 /.cave-trash
 /.opencode
 /.copilot
+/.worktree-lifecycle-fixture-zTScru
+/.worktree-lifecycle-fixture-MVFCTP
+/.worktree-lifecycle-fixture-lbn9gq

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -57,6 +57,16 @@ const QUIESCE_POLL_MS = 100;
 const MUTATION_LOCK_POLL_MS = 10;
 const MUTATION_LOCK_WAIT_MS = 1_000;
 
+export function repositoryMaintenanceCapabilities() {
+  return {
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  };
+}
+
 /** Synchronous sleep without CPU spin (callers are sync CLI/hook processes). */
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -17,6 +17,7 @@ import {
   heartbeatMaintenanceGate,
   maintenanceGateRoot,
   maintenanceGateStatus,
+  repositoryMaintenanceCapabilities,
   registerWriterIntent,
   releaseMaintenanceGate,
   releaseWriterIntent,
@@ -739,4 +740,14 @@ test("every transition lands in the audit log with its generation", () => {
     "the audit trail records the full lifecycle in order",
   );
   rmSync(repo, { recursive: true, force: true });
+});
+
+test("repositoryMaintenanceCapabilities reports the current local-only maintenance contract", () => {
+  assert.deepEqual(repositoryMaintenanceCapabilities(), {
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  });
 });

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -10,7 +10,8 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { maintenanceGateRoot } from "./maintenance-gate.mjs";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -850,6 +851,53 @@ exit 0
       {
         env: {
           ...process.env,
+          NODE_NO_WARNINGS: "1",
+          PATH: `${needsGitFixture ? `${gitBin}${path.delimiter}` : ""}${bin}${path.delimiter}${process.env.PATH}`,
+          LIFECYCLE_TEST_INVOCATION: lastPatrolInvocation,
+          ...extraEnv,
+        },
+      },
+    );
+  };
+  const patrolResult = (extraArgs = [], extraEnv = {}) => {
+    lastPatrolInvocation = String(++patrolInvocation);
+    const needsGitFixture = [
+      "LIFECYCLE_DEFAULT_TRUNK",
+      "LIFECYCLE_STALE_DEFAULT",
+      "LIFECYCLE_MALFORMED_DEFAULT",
+      "LIFECYCLE_MISSING_DEFAULT_TRACKING",
+      "LIFECYCLE_MISMATCHED_DEFAULT_TARGET",
+      "LIFECYCLE_MALFORMED_DEFAULT_TRACKING",
+      "LIFECYCLE_MALFORMED_LIVE_MAIN_CASE",
+      "LIFECYCLE_DEFAULT_TRACKING_MUTATION",
+      "LIFECYCLE_DUPLICATE_REGISTERED_REF",
+      "LIFECYCLE_REQUIRE_SAFE_GIT",
+    ].some(
+      (name) =>
+        extraEnv[name] === "1" ||
+        (name === "LIFECYCLE_MALFORMED_LIVE_MAIN_CASE" &&
+          typeof extraEnv[name] === "string"),
+    );
+    return spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types",
+        script,
+        "--repo",
+        "OpenCoven/coven-cave",
+        "--root",
+        repo,
+        "--now",
+        "2026-08-10T22:00:00Z",
+        ...extraArgs,
+      ],
+      {
+        cwd: repo,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: "1",
           PATH: `${needsGitFixture ? `${gitBin}${path.delimiter}` : ""}${bin}${path.delimiter}${process.env.PATH}`,
           LIFECYCLE_TEST_INVOCATION: lastPatrolInvocation,
           ...extraEnv,
@@ -1665,6 +1713,67 @@ exit 0
       `${liveMainCase} live main does not run ancestry before default OID equality proof`,
     );
   }
+
+  const maxRetireReadOnly = patrol(["--json", "--max-retire", "1"]);
+  assert.equal(
+    maxRetireReadOnly,
+    stdout,
+    "--max-retire does not change read-only patrol output",
+  );
+
+  const missingMaxRetire = patrolResult(["--json", "--max-retire"]);
+  assert.equal(missingMaxRetire.status, 1);
+  assert.equal(
+    missingMaxRetire.stderr.trim(),
+    "worktree-lifecycle-patrol: --max-retire requires an integer from 1 through 10",
+  );
+
+  const outOfBoundsMaxRetire = patrolResult(["--json", "--max-retire", "11"]);
+  assert.equal(outOfBoundsMaxRetire.status, 1);
+  assert.equal(
+    outOfBoundsMaxRetire.stderr.trim(),
+    "worktree-lifecycle-patrol: --max-retire must be an integer from 1 through 10",
+  );
+
+  const gateRoot = maintenanceGateRoot(repo);
+  const applyResult = patrolResult(["--apply", "--json"]);
+  assert.equal(applyResult.status, 2);
+  assert.equal(applyResult.stderr.trim(), "");
+  assert.deepEqual(JSON.parse(applyResult.stdout), {
+    ok: false,
+    reason: "gate-incomplete",
+    missingPlanes: ["coven", "beads", "github"],
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  });
+  assert.equal(
+    git(["worktree", "list", "--porcelain"], repo),
+    beforeWorktrees,
+    "--apply leaves worktree registrations untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/heads"], repo),
+    beforeBranches,
+    "--apply leaves local branch refs untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], repo),
+    beforeRemoteRefs,
+    "--apply leaves remote-tracking refs untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    existsSync(path.join(gateRoot, "gate.json")),
+    false,
+    "--apply does not acquire a maintenance gate before capability completion",
+  );
+  assert.equal(
+    existsSync(path.join(gateRoot, "audit.jsonl")),
+    false,
+    "--apply does not emit maintenance gate audit entries before capability completion",
+  );
 
   assert.equal(
     git(["worktree", "list", "--porcelain"], repo),

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -1,24 +1,81 @@
 #!/usr/bin/env node --experimental-strip-types
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   renderWorktreeLifecycleReport,
   summarizeWorktreeLifecycle,
 } from "../src/lib/worktree-lifecycle.ts";
+import {
+  acquireMaintenanceGate,
+  releaseMaintenanceGate,
+  repositoryMaintenanceCapabilities,
+} from "./maintenance-gate.mjs";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
+import {
+  createGitRetirementOperations,
+  parseMaxRetire,
+  retireLifecycleUnits,
+} from "./worktree-lifecycle-retirement.ts";
 
 type Options = {
   repo: string | null;
   root: string;
   json: boolean;
   nowMs: number;
+  apply: boolean;
+  maxRetire: number;
 };
 
-function parseArgs(argv: string[]): Options {
+type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
+type PatrolSummary = ReturnType<typeof summarizeWorktreeLifecycle>;
+type MaintenanceCapabilities = ReturnType<typeof repositoryMaintenanceCapabilities>;
+type MaintenanceGateHandle = {
+  root: string;
+  ownerId: string;
+  generation: number;
+  token: string;
+};
+type AcquireMaintenanceGateResult =
+  | {
+      ok: true;
+      handle: MaintenanceGateHandle;
+    }
+  | {
+      ok: false;
+      reason?: string;
+    };
+
+type RetirementApplyDependencies = {
+  acquireMaintenanceGate: (options: {
+    ownerId: string;
+    purpose: string;
+    repoDir: string;
+  }) => AcquireMaintenanceGateResult;
+  releaseMaintenanceGate: (handle: MaintenanceGateHandle) => {
+    ok: boolean;
+    reason?: string;
+  };
+  createGitRetirementOperations: typeof createGitRetirementOperations;
+  retireLifecycleUnits: typeof retireLifecycleUnits;
+};
+
+const APPLY_OWNER_ID = "worktree-lifecycle-patrol";
+const APPLY_PURPOSE = "worktree lifecycle retirement apply";
+const defaultRetirementApplyDependencies: RetirementApplyDependencies = {
+  acquireMaintenanceGate,
+  releaseMaintenanceGate,
+  createGitRetirementOperations,
+  retireLifecycleUnits,
+};
+
+export function parseArgs(argv: string[]): Options {
   const options: Options = {
     repo: null,
     root: process.cwd(),
     json: false,
     nowMs: Date.now(),
+    apply: false,
+    maxRetire: parseMaxRetire(undefined),
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -34,6 +91,17 @@ function parseArgs(argv: string[]): Options {
       case "--json":
         options.json = true;
         break;
+      case "--apply":
+        options.apply = true;
+        break;
+      case "--max-retire": {
+        const value = argv[++index];
+        if (value === undefined) {
+          throw new Error("--max-retire requires an integer from 1 through 10");
+        }
+        options.maxRetire = parseMaxRetire(value);
+        break;
+      }
       case "--now": {
         const value = Date.parse(argv[++index] ?? "");
         if (!Number.isFinite(value)) throw new Error("--now requires an ISO timestamp");
@@ -56,38 +124,168 @@ function parseArgs(argv: string[]): Options {
 }
 
 function printHelp() {
-  console.log(`Usage: node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OWNER/REPO [--root PATH] [--json]
+  console.log(`Usage: node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OWNER/REPO [--root PATH] [--json] [--apply] [--max-retire 1..10]
 
 Builds a read-only lifecycle report for every registered worktree and direct
 local branch. The patrol correlates local state with claims, Beads, Coven
 sessions, pull requests, workflow runs, and live process cwd ownership. It never
-removes worktrees or branches.`);
+removes worktrees or branches unless --apply becomes available after all
+maintenance planes are enforced.`);
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function summarizeInventory(inventory: PatrolInventory): PatrolSummary {
+  return summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
+}
+
+function renderJsonReport(
+  options: Options,
+  inventory: PatrolInventory,
+  summary: PatrolSummary,
+  retirement?: ReturnType<typeof retireLifecycleUnits>,
+): string {
+  return JSON.stringify(
+    {
+      ok: true,
+      generatedAt: new Date(options.nowMs).toISOString(),
+      ...summary,
+      inventoryFingerprint: inventory.inventoryFingerprint,
+      ...(retirement ? { retirement } : {}),
+    },
+    null,
+    2,
+  );
+}
+
+function renderApplyUnavailable(options: Options, capabilities: MaintenanceCapabilities): number {
+  const missingPlanes = (["local", "coven", "beads", "github"] as const).filter(
+    (plane) => capabilities[plane].enforced === false,
+  );
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: false,
+          reason: "gate-incomplete",
+          missingPlanes,
+          ...capabilities,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.error(
+      `worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: ${missingPlanes.join(", ")}`,
+    );
+  }
+  return 2;
+}
+
+function renderApplyReport(summary: PatrolSummary, retirement: ReturnType<typeof retireLifecycleUnits>) {
+  return [
+    renderWorktreeLifecycleReport(summary),
+    "",
+    `Retired: ${retirement.retired.length}`,
+    `Blocked: ${retirement.blocked.length}`,
+    `Cleanup-ready remaining: ${retirement.cleanupReady.length}`,
+  ].join("\n");
+}
+
+export function runRetirementApply(
+  options: Options,
+  inventory: PatrolInventory,
+  dependencies: RetirementApplyDependencies = defaultRetirementApplyDependencies,
+) {
+  const acquired = dependencies.acquireMaintenanceGate({
+    ownerId: APPLY_OWNER_ID,
+    purpose: APPLY_PURPOSE,
+    repoDir: options.root,
+  });
+  if (!acquired.ok) {
+    throw new Error(`failed to acquire maintenance gate: ${acquired.reason}`);
+  }
+
+  let thrown: unknown;
+  try {
+    const operations = dependencies.createGitRetirementOperations({
+      root: options.root,
+      repo: options.repo!,
+      gateHandle: acquired.handle,
+      nowMs: options.nowMs,
+    });
+    return dependencies.retireLifecycleUnits({
+      items: inventory.items,
+      gateHandle: {
+        generation: acquired.handle.generation,
+        token: acquired.handle.token,
+      },
+      operations,
+      maxRetire: String(options.maxRetire),
+    });
+  } catch (error) {
+    thrown = error;
+    throw error;
+  } finally {
+    const released = dependencies.releaseMaintenanceGate(acquired.handle);
+    if (!released.ok) {
+      const releaseMessage = `failed to release maintenance gate: ${released.reason}`;
+      if (thrown === undefined) {
+        throw new Error(releaseMessage);
+      }
+      throw new Error(`${errorMessage(thrown)}; ${releaseMessage}`, {
+        cause: thrown instanceof Error ? thrown : undefined,
+      });
+    }
+  }
+}
+
+export function main(argv = process.argv.slice(2)): number {
+  const options = parseArgs(argv);
+  if (options.apply) {
+    const capabilities = repositoryMaintenanceCapabilities();
+    if (!capabilities.complete) return renderApplyUnavailable(options, capabilities);
+  }
+
   const inventory = collectWorktreeLifecycleInventory({
     repo: options.repo!,
     root: options.root,
     nowMs: options.nowMs,
   });
-  const summary = summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
+
+  if (options.apply) {
+    const retirement = runRetirementApply(options, inventory);
+    const postInventory = collectWorktreeLifecycleInventory({
+      repo: options.repo!,
+      root: options.root,
+      nowMs: options.nowMs,
+    });
+    const summary = summarizeInventory(postInventory);
+    console.log(
+      options.json
+        ? renderJsonReport(options, postInventory, summary, retirement)
+        : renderApplyReport(summary, retirement),
+    );
+    return 0;
+  }
+
+  const summary = summarizeInventory(inventory);
   console.log(
     options.json
-      ? JSON.stringify(
-          {
-            ok: true,
-            generatedAt: new Date(options.nowMs).toISOString(),
-            ...summary,
-            inventoryFingerprint: inventory.inventoryFingerprint,
-          },
-          null,
-          2,
-        )
+      ? renderJsonReport(options, inventory, summary)
       : renderWorktreeLifecycleReport(summary),
   );
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`worktree-lifecycle-patrol: ${message}`);
-  process.exit(1);
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error(`worktree-lifecycle-patrol: ${errorMessage(error)}`);
+    process.exit(1);
+  }
 }


### PR DESCRIPTION
Expose the repository maintenance capability contract and use it to block `worktree-lifecycle-patrol --apply` until the non-local maintenance planes are enforced. This also adds `--apply`/`--max-retire` CLI plumbing, exports the patrol entry points for testing, and extends the test suite to cover argument validation and the no-mutation behavior when apply is unavailable.

<!--
Thanks for contributing to Coven Cave. A few tips before you fill this out:

  - Keep the PR focused on one concern.
  - Sign off your commits (`git commit -s`) per the DCO in CONTRIBUTING.md.
  - Make sure CI is green before requesting review.

  See CONTRIBUTING.md for the full contribution flow.
-->

## Summary

<!-- What does this change do, in one or two sentences? -->

## Why

<!-- Why is this change needed? Link the issue, plan, or release notes if any. -->

## Changes

<!-- Bullet list of the meaningful changes in this PR. -->

-

## Verification

<!--
What did you run locally to convince yourself this works?
Tests, builds, manual repro steps, screenshots, anything that matters.
-->

## Risk + rollout notes

<!--
Anything reviewers should look at carefully?
Anything that needs a release-note line, migration, or follow-up issue?
-->
