### PR TITLE
fix(test): repoint the growth view test at the sheet that owns its rules

### DIFF
--- a/src/components/familiar-growth-view.test.ts
+++ b/src/components/familiar-growth-view.test.ts
@@ -5,7 +5,16 @@ import { describe, it } from "node:test";
 
 const view = readFileSync(new URL("./familiar-growth-view.tsx", import.meta.url), "utf8");
 const report = readFileSync(new URL("./familiar-growth-report.tsx", import.meta.url), "utf8");
-const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
+// The growth surface's CSS left the globals.css facade in cave-ii7xi — it is
+// component-imported by familiar-growth-view.tsx now, so it code-splits with
+// the /dashboard routes instead of riding every route's first load. The
+// css-source-contract hook resolves the facade's @imports, so reading globals
+// here used to reach these rules transitively; after the split it no longer
+// does. Read the sheet that owns them.
+const globals = readFileSync(
+  new URL("../styles/globals/surface-reporting.css", import.meta.url),
+  "utf8",
+);
 
 describe("Familiar growth view", () => {
   it("sorts the roster attention-first (stalled → quiet → steady → active)", () => {


### PR DESCRIPTION
**My regression, from `cave-ii7xi` / #4165.** `main` has been red on it since that merge.

Moving `surface-reporting.css` out of the `globals.css` facade took the `growth-*` rules with it. `familiar-growth-view.test.ts` reads `../app/globals.css` and asserts on eight of them — the `css-source-contract` hook resolves the facade's `@import`s, so those assertions used to reach the rules transitively. After the split they can't.

The test now reads `src/styles/globals/surface-reporting.css`. Each of the eight asserted rules was checked individually against both the resolved facade and the sheet rather than assumed:

| assertion | in resolved facade | in surface-reporting.css |
|---|---|---|
| `.growth-triage__chip--stalled` / `--active` | no | yes |
| `.growth-picker {` | no | yes |
| `.growth-hero__updated` | no | yes |
| `container-name: growth` | no | yes |
| `@container growth (max-width: 920px)` | no | yes |
| `.growth-signal--crit` | no | yes |
| `.growth-signal__action {` | no | yes |

## Why I missed it

Before splitting I grepped for tests naming `surface-reporting` and found only `design-token-drift`. **This test names the facade, not the sheet**, so that grep could never have found it. Moving CSS out of a facade needs both searches — the sheet by name, *and* every test that reads `globals.css`. That is the actual lesson and it is now in the commit message.

## The suite still does not fully pass, and this is not that

`src/lib/server/familiar-self-reports.test.ts` fails **identically on pristine `main` (`1cd3d940d`) and on this branch** — *"findSelfReport returns null for missing sessions and the matching report for existing ones"* gets `undefined` instead of `'r2'`. It has nothing to do with CSS, and this diff touches one test file.

It was invisible until now because the runner stops at the first failure and the growth test came first. Both were red; this PR fixes the one I caused. I did not fold in a fix for the other — after closing #4168 as a duplicate of work someone had already claimed, opening a speculative fix for an unowned failure is exactly the move to avoid.

## Verification

- `familiar-growth-view.test.ts` passes under the runner's real invocation (`--require ./scripts/css-source-contract-hook.cjs --experimental-strip-types`)
- Confirmed failing on pristine `main` before the change, passing after
- Full `test:app` now advances past it and stops on the unrelated failure above