### PR TITLE
fix(redaction): stop treating a session identifier as a credential (cave-3ww55)

### DIFF
--- a/src/lib/secret-redaction.test.ts
+++ b/src/lib/secret-redaction.test.ts
@@ -469,3 +469,41 @@ assert.equal(
 );
 
 console.log("secret-redaction.test.ts: ok");
+
+// ── Session identifiers are foreign keys, not credentials (cave-3ww55) ──────
+// "session" used to be a terminal secret word, so `sessionId` redacted. That
+// was not a cosmetic over-match: findSelfReport compared a redacted value and
+// could never match any session, and appendSelfReport redacted BEFORE writing,
+// so self-reports were persisted with the link to their session destroyed.
+{
+  const keys = {
+    sessionId: "session-two",
+    sessionSlug: "s-two",
+    sessionDuration: 30,
+  };
+  const kept = redactSecretsDeep(keys);
+  assert.deepEqual(kept, keys, "session identifiers survive redaction intact");
+}
+{
+  // Everything that actually carries a credential still redacts. This is the
+  // half that stops the narrowing from being widened into a hole.
+  const secrets = {
+    session: "abc123",
+    sessionToken: "abc123",
+    sessionKey: "abc123",
+    session_secret: "abc123",
+    sessionCookie: "abc123",
+  };
+  const out = redactSecretsDeep(secrets) as Record<string, string>;
+  for (const key of Object.keys(secrets)) {
+    assert.equal(out[key], REDACTED_SECRET, `${key} is still redacted`);
+  }
+}
+{
+  // The text path shares isSecretKey, so it moves in lockstep.
+  assert.equal(
+    redactSecretText("sessionId=session-two sessionToken=abc123 session=abc123"),
+    `sessionId=session-two sessionToken=${REDACTED_SECRET} session=${REDACTED_SECRET}`,
+    "log lines keep the identifier and mask the credential",
+  );
+}

--- a/src/lib/secret-redaction.ts
+++ b/src/lib/secret-redaction.ts
@@ -12,10 +12,16 @@ const SECRET_TERMINAL_WORDS = new Set([
   "pass",
   "password",
   "secret",
-  "session",
   "token",
 ]);
 
+// "session" is deliberately NOT a terminal word (cave-3ww55). A session
+// IDENTIFIER is a foreign key, not a credential, and treating it as one made
+// `sessionId` unreadable: findSelfReport compared a redacted value and could
+// never match, and appendSelfReport redacted before writing, so reports were
+// persisted with the link to their session destroyed. A session TOKEN is still
+// a credential — these pairs and the terminal words below keep every
+// secret-bearing form covered.
 const SECRET_TERMINAL_PAIRS = new Set([
   "api:key",
   "auth:token",
@@ -23,9 +29,15 @@ const SECRET_TERMINAL_PAIRS = new Set([
   "private:key",
   "refresh:token",
   "secret:key",
+  "session:cookie",
+  "session:credential",
+  "session:credentials",
+  "session:key",
+  "session:secret",
+  "session:token",
 ]);
 
-const SECRET_KEY_MARKERS = new Set(["api", "auth", "client", "private", "secret"]);
+const SECRET_KEY_MARKERS = new Set(["api", "auth", "client", "private", "secret", "session"]);
 
 const AUTHORIZATION_SCHEMES = new Set([
   "basic",
@@ -338,6 +350,12 @@ function consumeStringBytes(value: string, budget: RedactionBudget): boolean {
 function isSecretKey(key: string): boolean {
   const words = normalizeKeyWords(key).map(normalizeSecretWord);
   if (words.length === 0) return false;
+
+  // A key that is exactly `session` still redacts. Dropping "session" from the
+  // terminal words (cave-3ww55) was about qualified identifiers like sessionId;
+  // a bare `session=…` in a log line is as likely to be the token itself as
+  // anything, and nothing else in this file would catch it.
+  if (words.length === 1 && words[0] === "session") return true;
 
   for (let index = 1; index < words.length; index += 1) {
     if (SECRET_TERMINAL_PAIRS.has(`${words[index - 1]}:${words[index]}`)) return true;


### PR DESCRIPTION
`secret-redaction.ts` listed `"session"` as a terminal secret word, so `redactSecretsDeep` rewrote **every** key containing it — including `sessionId`, which is a foreign key, not a credential.

## Two consequences, and the second is worse than the failing test

1. `findSelfReport` redacts on read, then compares `report.sessionId` to the requested id. The stored value was already `"[redacted]"`, so the comparison could **never** match — the function returned null for every session that exists.
2. `appendSelfReport` **also redacts before writing**, so self-reports were being *persisted* with `sessionId: "[redacted]"`. Not a display-time mask — data loss at rest, with the link from a report back to its session unrecoverable from the file.

`main` has been red on `familiar-self-reports.test.ts` since this landed. It passes now.

## What changed

| key | before | after |
|---|---|---|
| `sessionId`, `sessionSlug` | redacted | **kept** |
| `session` | redacted | redacted |
| `sessionToken`, `sessionKey`, `sessionCookie` | redacted | redacted |
| `session_secret` | redacted | redacted |
| `tokenId`, `apiKeyId` | redacted | redacted |

`"session"` is no longer a terminal word; it joins `SECRET_KEY_MARKERS` so `sessionKey` still matches the key branch, and explicit `session:*` pairs cover the rest.

## One deviation, called out because it is a security decision

Dropping the word also stopped a **bare** `session=…` redacting — in the object walker *and* in free-text log redaction, since both share `isSecretKey` — and an existing test asserted that behaviour.

A lone `session` value is as likely to be the token itself as anything, and nothing else in the file would catch it. So a key that normalizes to exactly `session` still redacts. Qualified identifiers are the only thing this loosens.

## Verification

Both halves negative-tested:

- restoring `"session"` as a terminal word → fails with *"session identifiers survive redaction intact"*
- removing the bare-session rule → fails the **pre-existing** *"common terminal credential terms are classified"* assertion, so the suite was already guarding that half

Full `test:app` is otherwise clean. The only remaining failure is `research-media-jobs.test.ts` — the known flake `cave-a1qys`, which failed 1 of 3 runs here with a different assertion each time, on a diff that touches one library file.

This should also unblock #4171 and #4169, both of which are currently failing `Frontend build` on this same test rather than on anything of their own.