### PR TITLE
test(worktrees): land the retirement fixtures so their branches are provably behind main

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -124,6 +124,7 @@ function createFixture({ issues = [defaultIssue()] } = {}) {
   git(["commit", "-q", "-m", "initial"], repo);
   git(["remote", "add", "origin", origin], repo);
   git(["push", "-q", "-u", "origin", "main"], repo);
+  const initialOid = git(["rev-parse", "HEAD"], repo).trim();
   const tree = git(["rev-parse", "HEAD^{tree}"], repo).trim();
   const alternateOid = git(["commit-tree", tree, "-m", "alternate identity"], repo, {
     env: {
@@ -213,7 +214,17 @@ case "$1 $2" in
 esac
 case "$*" in
   *"graphql"*"associatedPullRequests"*)
-    printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+    OID_ARG=
+    for arg in "$@"; do
+      case "$arg" in
+        oid=*) OID_ARG=\${arg#oid=} ;;
+      esac
+    done
+    if [ "$OID_ARG" = "${initialOid}" ]; then
+      printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":1,"url":"https://github.com/OpenCoven/coven-cave/pull/1","state":"MERGED","isDraft":false,"mergedAt":"2026-07-31T12:00:00Z","headRefName":"fixture-main","headRefOid":"${initialOid}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+    else
+      printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}]'
+    fi
     ;;
   *"graphql"*)
     printf '%s\\n' '[{"data":{"search":{"issueCount":0,"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}]'

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -1116,6 +1116,14 @@ test("adapter reprobe rejects a candidate that is no longer cleanup-ready", () =
     };
     git(["branch", branch, "HEAD"], fixture.repo, { env: agedEnv });
     git(["push", "-q", "-u", "origin", branch], fixture.repo);
+    // Land the branch for real: advance main past it and push, so the branch
+    // is strictly behind the default tip. cave-ox3ky's ae16550d6 fails closed
+    // when the candidate oid EQUALS the captured default — with no ref move
+    // there is no evidence of WHEN it landed, so the age window is unprovable.
+    // A fixture that leaves the branch at the default tip is asserting on a
+    // case the engine now (correctly) refuses to judge.
+    git(["commit", "-q", "--allow-empty", "-m", "land fix/reprobe-dirty"], fixture.repo, { env: agedEnv });
+    git(["push", "-q", "origin", "main"], fixture.repo);
     git(["worktree", "add", worktreePath, branch], fixture.repo, { env: agedEnv });
     executable(
       path.join(fixture.bin, "bd"),
@@ -1294,6 +1302,14 @@ test("real git adapter retires a landed managed worktree under a held maintenanc
     };
     git(["branch", branch, "HEAD"], fixture.repo, { env: agedEnv });
     git(["push", "-q", "-u", "origin", branch], fixture.repo);
+    // Land the branch for real: advance main past it and push, so the branch
+    // is strictly behind the default tip. cave-ox3ky's ae16550d6 fails closed
+    // when the candidate oid EQUALS the captured default — with no ref move
+    // there is no evidence of WHEN it landed, so the age window is unprovable.
+    // A fixture that leaves the branch at the default tip is asserting on a
+    // case the engine now (correctly) refuses to judge.
+    git(["commit", "-q", "--allow-empty", "-m", "land fix/retire-me"], fixture.repo, { env: agedEnv });
+    git(["push", "-q", "origin", "main"], fixture.repo);
     git(["worktree", "add", worktreePath, branch], fixture.repo, { env: agedEnv });
     mkdirSync(path.join(worktreePath, ".next"), { recursive: true });
     writeFileSync(path.join(worktreePath, ".next", "cache.txt"), "cache\n");


### PR DESCRIPTION
`main` is red on `scripts/worktree-lifecycle-retirement.test.mjs`. **The engine is right and the fixtures were wrong.**

Both failing tests created the candidate branch **at HEAD**, pushed it, then asserted the lane is `retire-after-gate`. `cave-ox3ky`'s `ae16550d6` ("fail closed on ambiguous branch evidence") added exactly the rule that refuses this:

```
default branch landing time is unprovable when candidate equals captured default:
remote ref-move time is unavailable without an exact merged PR timestamp
```

That is correct behaviour. A branch pointing at the same commit as the default tip has produced no ref movement, so there is no evidence of *when* it landed and the age-based retirement window cannot be computed. Returning `uncertain` instead of guessing is the whole point of that commit.

So the fixtures now land the branch for real — an empty commit advances `main` past it and is pushed, leaving the branch strictly behind the default tip with provable landing evidence. **No engine or policy change; the safety rule is untouched.**

## Why it appeared suddenly

`00f18d8f0` (the retirement engine and these tests) and `ae16550d6` (the evidence hardening) were developed on divergent bases. Git merged them cleanly at `1fe100273` and their *semantics* conflicted — the engine got stricter about landing evidence while its own fixtures kept the old shape.

Bisected: `3d8cb731d` PASS → `00f18d8f0` PASS → `1fe100273` **FAIL**.

Two corrections to my own earlier reading, since I reported both:

- **Not Linux-only.** It reproduces on macOS. My "passes locally" came from a worktree pinned to a pre-merge base.
- **Not a flake.** Two CI runs and three local runs are deterministic.

The test was also invisible until `4a4ca7c46` wired it into CI, so the conflict reached `main` unobserved.

## Verification

- 3/3 local runs pass with both fixtures landed
- Negative-tested: reverting either fixture to the unlanded shape fails again with the same assertion
- One file changed, tests only