### PR TITLE
test(e2e): point the chat landing spec at the Start-from bands

### DIFF
--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -6,7 +6,8 @@ import { expect, test, type Page } from "@playwright/test";
 // composer) without waiting for /api/sessions/list — the fetch that used to
 // gate the boot-compose effect and left users on the ChatList skeleton wall
 // for its full duration. Also pins the landing affordances: the live board's
-// open-work rows and the hidden-not-disabled pre-session Voice button.
+// work surfacing as a tile in the Start-from Tasks band (Chat.dc.html 2b) and
+// the hidden-not-disabled pre-session Voice button.
 //
 // Desktop only (compose-first boot is a desktop affordance — mobile keeps
 // the thread list as the chat home). /api/familiars, /api/sessions/list and
@@ -163,13 +164,19 @@ test.describe("chat boot landing", () => {
     const dash = page.getByTestId("chat-new-dashboard");
     await expect(dash).toBeVisible({ timeout: 45_000 });
 
-    // The live board's inbox card surfaces as an open-work row with the
-    // visual Resume CTA…
-    const workRow = dash.locator(".home-dash__work-row", { hasText: "Fix login flow" });
-    await expect(workRow).toBeVisible();
-    await expect(workRow).toContainText("Resume");
-    // …and the headline counts it.
-    await expect(dash.locator(".home-dash__headline")).toContainText("1 thread open.");
+    // Chat.dc.html 2b: the launcher is a band per SOURCE of work, and the
+    // live board's inbox card surfaces as a tile in the Tasks band…
+    const tasksBand = dash.locator('.cave-sf__band[data-kind="tasks"]');
+    await expect(tasksBand).toBeVisible();
+    const workTile = tasksBand.locator(".cave-sf__tile", { hasText: "Fix login flow" });
+    await expect(workTile).toBeVisible();
+    // …badged with its column, since a medium priority is too quiet to spend
+    // the tile's one badge on (taskTileBadge).
+    await expect(workTile.locator(".cave-sf__tile-badge")).toHaveText("inbox");
+    // The band head states how much of the source is on screen, so the hero
+    // no longer repeats a count that is already there.
+    await expect(tasksBand.locator(".cave-sf__band-count")).toHaveText("1");
+    await expect(dash.locator(".home-dash__headline")).toContainText("What should we begin?");
 
     // The context rail is retired: no quick-start rows, no rail project
     // picker — the composer owns those affordances.


### PR DESCRIPTION
Fixes the `E2E (Playwright)` failure my own change caused on `main`.

## What broke

The Chat.dc.html 2b launcher rebuild replaced the vertical `.home-dash__work-row` list with one band per source of work. `tests/chat-boot-landing.spec.ts` was keyed on that class, so its locator matched nothing and the required E2E check went red.

**This was my miss.** I ran `pnpm test:app` and treated it as *the* suite; `E2E (Playwright)` is a separate required check and I never ran it. The change then reached `main` without a PR — see #4177 for that half of the story — so nothing caught it before it landed.

## The fix

Repointed at the band markup, asserting the same facts the old locators did:

- the seeded board card is a **tile in the Tasks band**, not a full-width row
- its badge reads `inbox` — a `medium` priority is too quiet to spend the tile's one badge on, so `taskTileBadge` falls through to the column. Pinned rather than assumed, since it's the rule the design specifies (one token, never two).
- the **band head carries the count**, which is precisely why the hero stopped repeating it — so the headline assertion moves from `"1 thread open."` to the design's `"What should we begin?"`

I grepped the whole `tests/` tree: this was the only reference to any class the rebuild removed.

## Verification

Running the spec locally against `--project=desktop`. Two earlier attempts produced no result for reasons unrelated to the spec — the first used a project name that doesn't exist (`desktop-chromium`), and the second had its worktree force-deleted out from under the running dev server mid-run (the GitHub Desktop behaviour documented in #4177, which is what made it look like a wedged Next boot). This branch was pushed before running anything, so a third such deletion costs nothing.

The PR's own E2E run is the authoritative check either way.

## Expect unrelated red

`main` is currently red for two failures this PR cannot affect and does not fix:

- `Rust check` — unresolved `validate_x_oauth_url` / `open_x_oauth_url`
- `Frontend build` — four TypeScript errors in `scripts/worktree-lifecycle-inventory.ts`

Both come from other merges. `E2E (Playwright)` is the check to read here; it runs `next dev` and so is independent of the `tsc --noEmit` failure.