### PR TITLE
fix(projects): serve one project-root form, and follow it in client stores (cave-2x1em)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -539,6 +539,7 @@ export const SUITES = {
     "src/lib/use-projects-normalize.test.ts",
     "src/lib/project-frecency.test.ts",
     "src/lib/project-root-normalizers.test.ts",
+    "src/lib/project-root-migration.test.ts",
     "src/lib/project-display-name-spaces.test.ts",
     "src/lib/use-projects-scope-transition.test.ts",
     "src/components/calendar-view-polish.test.ts",
@@ -1665,6 +1666,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/voice/familiar-brain.test.ts",
   "src/lib/voice/registry.test.ts",
   "src/lib/voice/elevenlabs.test.ts",
+  "src/lib/project-root-migration.test.ts",
 ]);
 
 // These gates inspect physical source files. The CSS facade expander would

--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -17,6 +17,19 @@ export type CaveProject = {
   access?: ProjectAccessLevel;
   /** Canonical GitHub repository link (https://github.com/owner/repo), when tied to one. */
   repoUrl?: string;
+  /**
+   * The root string as it was persisted, present ONLY when the server had to
+   * expand a leading `~` to return {@link CaveProject.root} (cave-2x1em).
+   *
+   * Roots are the KEYS of client-side stores — IDB projectAvatars,
+   * cave:chat:project-overrides, comux pins and order — so a record written
+   * before the server started expanding (`~/code/app`) keys differently from
+   * the same folder added today (`/Users/me/code/app`). Serving one consistent
+   * form fixes the split, but it also moves the key out from under whatever
+   * was already stored. This field carries the old key so the client can
+   * re-key its stores; it is response-only and never written back to disk.
+   */
+  legacyRoot?: string;
   createdAt: string;
   updatedAt: string;
 };

--- a/src/lib/cave-projects-types.ts
+++ b/src/lib/cave-projects-types.ts
@@ -18,8 +18,12 @@ export type CaveProject = {
   /** Canonical GitHub repository link (https://github.com/owner/repo), when tied to one. */
   repoUrl?: string;
   /**
-   * The root string as it was persisted, present ONLY when the server had to
-   * expand a leading `~` to return {@link CaveProject.root} (cave-2x1em).
+   * The root string as it was persisted, present whenever the server had to
+   * re-normalize it to return {@link CaveProject.root} (cave-2x1em).
+   *
+   * Usually that is a leading `~` being expanded, but the server normalizer
+   * also trims, converts backslashes and drops trailing slashes — any of which
+   * moves the key. The field is attached for all of them, not just `~`.
    *
    * Roots are the KEYS of client-side stores — IDB projectAvatars,
    * cave:chat:project-overrides, comux pins and order — so a record written
@@ -27,7 +31,13 @@ export type CaveProject = {
    * the same folder added today (`/Users/me/code/app`). Serving one consistent
    * form fixes the split, but it also moves the key out from under whatever
    * was already stored. This field carries the old key so the client can
-   * re-key its stores; it is response-only and never written back to disk.
+   * re-key its stores.
+   *
+   * Response-only: `saveProjects` strips it before writing, so it never reaches
+   * projects.json. That strip is the enforcement — every mutation path persists
+   * the array `loadProjectsUnlocked` returned, so documenting the intent here
+   * without stripping there would have written the marker to disk on the first
+   * create/patch/delete after an upgrade.
    */
   legacyRoot?: string;
   createdAt: string;

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -103,7 +103,22 @@ async function loadProjectsUnlocked(): Promise<CaveProject[]> {
     // trustedProjectCwd, permission filtering) while the UI hid them via
     // dedupeProjectsByRoot — a client/server divergence. Newest record wins;
     // the next mutation persists the deduped list, self-healing the file.
-    return dedupeByRoot(parsed.projects, normalizeRootExpandingHome);
+    // Serve ONE root form (cave-2x1em). createProject has persisted the
+    // expanded root since cave-psp8, but records written before that still
+    // hold a literal `~/...`, so the same folder reaches clients as two
+    // different strings depending on when it was added — and roots are the
+    // keys of the client's avatar, chat-override and comux stores.
+    //
+    // The display normalizer deliberately does NOT expand `~`: it runs in the
+    // browser, which has no home directory. So the split is closed here, on
+    // the side that knows the homedir, rather than by shipping one to the
+    // client. `legacyRoot` carries the old key so the client can re-key what
+    // it already stored; it is response-only and never written back.
+    return dedupeByRoot(parsed.projects, normalizeRootExpandingHome).map((project) => {
+      const expanded = normalizeRootExpandingHome(project.root);
+      if (expanded === project.root) return project;
+      return { ...project, root: expanded, legacyRoot: project.root };
+    });
   } catch {
     return [];
   }

--- a/src/lib/cave-projects.ts
+++ b/src/lib/cave-projects.ts
@@ -144,7 +144,17 @@ export function withProjectRegistryLock<T>(
 }
 
 async function saveProjects(projects: CaveProject[]): Promise<void> {
-  const file: ProjectsFile = { version: 1, projects };
+  // Strip legacyRoot before it reaches disk. loadProjectsUnlocked attaches it
+  // in memory so the client can follow a moved root, and every mutation path
+  // (create/patch/delete) writes back the array that load returned — so without
+  // this the transitional marker would be persisted, and then re-attached on
+  // the next read of a record that no longer needs it. A response-only field
+  // has to be stripped at the boundary that writes, not merely documented as
+  // response-only.
+  const file: ProjectsFile = {
+    version: 1,
+    projects: projects.map(({ legacyRoot: _legacyRoot, ...project }) => project),
+  };
   await writeProjectsFile(projectsFilePath(), JSON.stringify(file, null, 2));
 }
 

--- a/src/lib/project-root-migration.test.ts
+++ b/src/lib/project-root-migration.test.ts
@@ -18,6 +18,7 @@
  *     against nothing.
  */
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 
 const store = new Map();
 globalThis.window = {
@@ -148,6 +149,48 @@ const PROJECTS = [
   store.set(CHAT_PROJECT_OVERRIDES_KEY, "{not json");
   await migrateProjectRootKeys(PROJECTS);
   assert.ok(true, "absent and corrupt override stores are survivable");
+}
+
+
+// ── legacyRoot must never reach disk (review on #4185) ─────────────────────
+// loadProjectsUnlocked attaches legacyRoot in memory, and every mutation path
+// persists the array it returned — so a marker documented as "response-only"
+// was being written to projects.json on the first create/patch/delete after an
+// upgrade, and then re-attached forever. Documenting the intent is not the
+// same as enforcing it; saveProjects strips the field, and this asserts the
+// strip rather than the comment.
+{
+  const src = readFileSync(new URL("./cave-projects.ts", import.meta.url), "utf8");
+  const save = src.match(/async function saveProjects\([\s\S]*?\n\}/)?.[0] ?? "";
+  assert.ok(save, "saveProjects is findable");
+  assert.match(
+    save,
+    /legacyRoot: _legacyRoot, \.\.\.project/,
+    "saveProjects strips legacyRoot before writing",
+  );
+  assert.doesNotMatch(
+    save,
+    /projects: projects,?\n/,
+    "the raw array is never handed to the writer",
+  );
+}
+
+// The image store keys by normalizeProjectRoot(root), so the snapshot probe has
+// to normalize too. A root carrying a trailing slash or backslashes normalizes
+// to something else entirely, and comparing the raw string would skip it.
+{
+  const src = readFileSync(new URL("./project-root-migration.ts", import.meta.url), "utf8");
+  assert.match(src, /const fromKey = normalizeProjectRoot\(from\)/, "probe uses the store's key");
+  assert.match(
+    src,
+    /await whenProjectImagesHydrated\(\)/,
+    "hydration is awaited before the snapshot is read",
+  );
+  assert.doesNotMatch(
+    src,
+    /readProjectImagesSnapshot\(\), from\)/,
+    "no raw-string snapshot lookups remain",
+  );
 }
 
 console.log("project-root-migration.test.ts: ok");

--- a/src/lib/project-root-migration.test.ts
+++ b/src/lib/project-root-migration.test.ts
@@ -1,0 +1,153 @@
+// @ts-nocheck
+/**
+ * cave-2x1em: when the server starts serving one root form, the client's
+ * root-keyed data must come with it.
+ *
+ * createProject has persisted an expanded root since cave-psp8, so the same
+ * folder reaches the client as `~/code/app` or `/home/dev/code/app` depending
+ * on when it was added. Serving one form fixes that split — and moves the key
+ * out from under whatever the client already stored. `legacyRoot` carries the
+ * old key so this migration can follow it.
+ *
+ * SCOPE, corrected against the code rather than the bead:
+ *   - IDB projectAvatars    keyed BY root      -> re-key
+ *   - cave:chat:project-overrides  root is the VALUE -> rewrite values
+ *   - comux pins + order    DOES NOT EXIST — the comux surface was deleted
+ *     (cave-c3yt), so there is nothing to migrate and no test for it here.
+ *     A migration for a store that has not existed for months would pass
+ *     against nothing.
+ */
+import assert from "node:assert/strict";
+
+const store = new Map();
+globalThis.window = {
+  localStorage: {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+  },
+  addEventListener: () => {},
+  removeEventListener: () => {},
+  dispatchEvent: () => {},
+};
+
+const idb = { projectAvatars: new Map(), familiarImages: new Map() };
+let denyWrites = false;
+const fakeDriver = {
+  async getAll(s) {
+    return Object.fromEntries(idb[s]);
+  },
+  async put(s, key, value) {
+    if (denyWrites) throw new DOMException("The quota has been exceeded.", "QuotaExceededError");
+    idb[s].set(key, value);
+  },
+  async delete(s, key) {
+    idb[s].delete(key);
+  },
+};
+
+const { setAvatarStorageForTests } = await import("./avatar-idb.ts");
+setAvatarStorageForTests(fakeDriver);
+
+const images = await import("./cave-project-images.ts");
+await images.whenProjectImagesHydrated();
+
+const { CHAT_PROJECT_OVERRIDES_KEY, readProjectOverrides } = await import(
+  "./chat-project-overrides.ts"
+);
+const { migrateProjectRootKeys } = await import("./project-root-migration.ts");
+
+const LEGACY = "~/code/app";
+const EXPANDED = "/home/dev/code/app";
+const IMAGE = { dataUrl: "data:image/png;base64,AAAA", mime: "image/png" };
+
+// Seed through the PUBLIC api, not by writing into the fake driver. The image
+// store hydrates once at import and keeps an in-memory snapshot; poking the map
+// behind it leaves that snapshot stale, so moveProjectImage would find nothing
+// and the test would fail for a reason that has nothing to do with the
+// migration. Going through setProjectImage is also how the app gets here.
+async function seed() {
+  for (const key of [...idb.projectAvatars.keys()]) await images.clearProjectImage(key);
+  await images.setProjectImage(LEGACY, IMAGE);
+  store.set(
+    CHAT_PROJECT_OVERRIDES_KEY,
+    JSON.stringify({ "session-a": LEGACY, "session-b": "/untouched/root" }),
+  );
+}
+
+// The projects the server now serves: one that moved, one that never had a ~.
+const PROJECTS = [
+  { id: "p1", root: EXPANDED, legacyRoot: LEGACY },
+  { id: "p2", root: "/already/absolute" },
+];
+
+{
+  // The acceptance criterion, demonstrated rather than assumed: an existing
+  // profile keeps its avatar and its override across the upgrade.
+  await seed();
+  const moved = await migrateProjectRootKeys(PROJECTS);
+
+  assert.equal(idb.projectAvatars.has(EXPANDED), true, "avatar follows the root");
+  assert.equal(idb.projectAvatars.has(LEGACY), false, "the stale key is cleaned up");
+  assert.equal(
+    idb.projectAvatars.get(EXPANDED)?.dataUrl,
+    IMAGE.dataUrl,
+    "the image survives byte-for-byte, not just its key",
+  );
+
+  const overrides = readProjectOverrides();
+  assert.equal(overrides["session-a"], EXPANDED, "override VALUE is rewritten");
+  assert.equal(
+    overrides["session-b"],
+    "/untouched/root",
+    "an unrelated override is left exactly alone",
+  );
+  assert.equal(moved, 1, "reports how many roots it followed");
+}
+
+{
+  // Two windows can start at once, so this runs twice. The second pass must be
+  // a no-op — not merely non-crashing.
+  const after = JSON.stringify([...idb.projectAvatars], null, 0);
+  const overridesAfter = store.get(CHAT_PROJECT_OVERRIDES_KEY);
+  const moved = await migrateProjectRootKeys(PROJECTS);
+  assert.equal(moved, 0, "a second pass finds nothing to move");
+  assert.equal(JSON.stringify([...idb.projectAvatars], null, 0), after, "avatars unchanged");
+  assert.equal(store.get(CHAT_PROJECT_OVERRIDES_KEY), overridesAfter, "overrides unchanged");
+}
+
+{
+  // No legacyRoot means the server never moved anything — touching a store
+  // here would be a re-key with no cause.
+  await seed();
+  const moved = await migrateProjectRootKeys([{ id: "p2", root: "/already/absolute" }]);
+  assert.equal(moved, 0, "nothing to do without legacyRoot");
+  assert.equal(idb.projectAvatars.has(LEGACY), true, "an untouched profile is left as it was");
+}
+
+{
+  // A write failure must not destroy the old record. moveProjectImage writes
+  // the new key first and deletes the old only on success; the migration has
+  // to preserve that ordering rather than delete-then-write.
+  await seed();
+  denyWrites = true;
+  await migrateProjectRootKeys(PROJECTS);
+  denyWrites = false;
+  assert.equal(
+    idb.projectAvatars.has(LEGACY),
+    true,
+    "a failed write leaves the avatar under its old key rather than losing it",
+  );
+}
+
+{
+  // The override map can legitimately be absent or corrupt; a migration that
+  // throws on first run is worse than one that does nothing.
+  store.delete(CHAT_PROJECT_OVERRIDES_KEY);
+  await migrateProjectRootKeys(PROJECTS);
+  store.set(CHAT_PROJECT_OVERRIDES_KEY, "{not json");
+  await migrateProjectRootKeys(PROJECTS);
+  assert.ok(true, "absent and corrupt override stores are survivable");
+}
+
+console.log("project-root-migration.test.ts: ok");

--- a/src/lib/project-root-migration.ts
+++ b/src/lib/project-root-migration.ts
@@ -24,8 +24,12 @@
  *     pins or order, so there is no store to move.
  */
 
-import type { CaveProject } from "./cave-projects-types.ts";
-import { moveProjectImage, readProjectImagesSnapshot } from "./cave-project-images.ts";
+import { normalizeProjectRoot, type CaveProject } from "./cave-projects-types.ts";
+import {
+  moveProjectImage,
+  readProjectImagesSnapshot,
+  whenProjectImagesHydrated,
+} from "./cave-project-images.ts";
 import { readProjectOverrides, writeProjectOverrides } from "./chat-project-overrides.ts";
 
 /**
@@ -56,14 +60,25 @@ export async function migrateProjectRootKeys(
   // which is what a caller logs and what makes a second pass observably 0.
   const followed = new Set<string>();
 
+  // Wait for the image store before reading its snapshot. It hydrates
+  // asynchronously on import, so an early read returns {} and every avatar
+  // looks absent — the migration would skip a real one and report 0, which is
+  // indistinguishable from "nothing to do".
+  await whenProjectImagesHydrated();
+
   for (const { from, to } of moves) {
-    const hadImage = Object.hasOwn(readProjectImagesSnapshot(), from);
+    // Look up by the store's OWN key. It is keyed by normalizeProjectRoot(root),
+    // which is identity for a plain `~/code/app` but not for a root carrying
+    // backslashes or a trailing slash — comparing the raw string would miss
+    // exactly those.
+    const fromKey = normalizeProjectRoot(from);
+    const hadImage = Object.hasOwn(readProjectImagesSnapshot(), fromKey);
     if (hadImage) {
       // Failures are swallowed inside moveProjectImage — it writes the new key
       // first and deletes the old only on success, so a denied write leaves the
       // record under its old key rather than losing it.
       await moveProjectImage(from, to);
-      if (!Object.hasOwn(readProjectImagesSnapshot(), from)) followed.add(from);
+      if (!Object.hasOwn(readProjectImagesSnapshot(), fromKey)) followed.add(from);
     }
   }
 

--- a/src/lib/project-root-migration.ts
+++ b/src/lib/project-root-migration.ts
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * Follow a project root that the server re-normalized (cave-2x1em).
+ *
+ * `createProject` has persisted an expanded root since cave-psp8, but records
+ * written before that still hold a literal `~/code/app`. The same folder
+ * therefore reached the client as two different strings depending on when it
+ * was added, and roots are the KEYS of client-side stores — so an old project's
+ * avatar and chat overrides were filed under a key nothing else produced.
+ *
+ * `loadProjectsUnlocked` now serves one expanded form and attaches `legacyRoot`
+ * when it had to move one. This pass follows that move in the client's stores.
+ * It cannot compute the mapping itself: expanding `~` needs a home directory,
+ * and the browser has none — which is also why `normalizeProjectRoot` stays
+ * deliberately non-expanding.
+ *
+ * WHAT IS AND IS NOT MIGRATED, checked against the code rather than the
+ * original issue text:
+ *   - IDB projectAvatars           keyed BY root      -> re-keyed
+ *   - cave:chat:project-overrides  root is the VALUE  -> values rewritten
+ *   - comux pins + order           does not exist. The comux surface was
+ *     deleted (cave-c3yt); `deriveComuxProjects` survives but nothing persists
+ *     pins or order, so there is no store to move.
+ */
+
+import type { CaveProject } from "./cave-projects-types.ts";
+import { moveProjectImage, readProjectImagesSnapshot } from "./cave-project-images.ts";
+import { readProjectOverrides, writeProjectOverrides } from "./chat-project-overrides.ts";
+
+/**
+ * Re-key what the server moved. Returns how many roots were followed, which is
+ * what makes idempotence observable: a second window running this immediately
+ * after the first gets 0.
+ *
+ * Safe to run concurrently. Avatars go through `moveProjectImage`, which writes
+ * the new key before deleting the old one, so a denied write (quota, private
+ * mode) leaves the record under its old key rather than losing it. Overrides
+ * are read-modify-written whole; the last writer wins with identical content.
+ */
+export async function migrateProjectRootKeys(
+  projects: readonly CaveProject[],
+): Promise<number> {
+  const moves = projects
+    .filter((project) => project.legacyRoot && project.legacyRoot !== project.root)
+    .map((project) => ({ from: project.legacyRoot as string, to: project.root }));
+  if (moves.length === 0) return 0;
+
+  // Count what was actually FOLLOWED, not what was offered. The server keeps
+  // attaching legacyRoot on every load until the projects file self-heals on
+  // its next mutation, so a second window would otherwise report the same
+  // migration again and idempotence would be unobservable — the count is the
+  // only externally visible signal that this pass did nothing.
+  // Per ROOT, not per store: a root that had both an avatar and an override
+  // counts once. The number answers "how many roots did this pass follow",
+  // which is what a caller logs and what makes a second pass observably 0.
+  const followed = new Set<string>();
+
+  for (const { from, to } of moves) {
+    const hadImage = Object.hasOwn(readProjectImagesSnapshot(), from);
+    if (hadImage) {
+      // Failures are swallowed inside moveProjectImage — it writes the new key
+      // first and deletes the old only on success, so a denied write leaves the
+      // record under its old key rather than losing it.
+      await moveProjectImage(from, to);
+      if (!Object.hasOwn(readProjectImagesSnapshot(), from)) followed.add(from);
+    }
+  }
+
+  // One read-modify-write for every move, so a corrupt or absent map costs one
+  // recovery rather than one per project. readProjectOverrides already returns
+  // {} for both cases, so this cannot throw on a first run.
+  const overrides = readProjectOverrides();
+  let rewrote = false;
+  const next = { ...overrides };
+  for (const { from, to } of moves) {
+    for (const [sessionId, root] of Object.entries(overrides)) {
+      if (root !== from) continue;
+      next[sessionId] = to;
+      rewrote = true;
+      followed.add(from);
+    }
+  }
+  if (rewrote) writeProjectOverrides(next);
+
+  return followed.size;
+}

--- a/src/lib/use-projects-cache.ts
+++ b/src/lib/use-projects-cache.ts
@@ -51,7 +51,34 @@ async function requestProjects(familiarId: string | null): Promise<ProjectsPaylo
 function normalizePayload(payload: ProjectsPayload): ProjectsPayload {
   if (payload.ok === false) return payload;
   const projects = Array.isArray(payload.projects) ? payload.projects : [];
+  followRootMoves(projects);
   return { ...payload, projects: sortProjectsAlphabetically(projects) };
+}
+
+/**
+ * Follow any root the server re-normalized, once (cave-2x1em).
+ *
+ * This is the single choke point every project consumer funnels through, which
+ * is why the migration hangs here rather than in a component: 20+ call sites
+ * would otherwise each need to remember to run it.
+ *
+ * Deliberately NOT awaited. The payload is already correct — the server serves
+ * the expanded root — so nothing on screen waits for a re-key of local avatar
+ * and override records. A failure leaves the old keys in place and the next
+ * load retries; the migration is idempotent and reports 0 when there is
+ * nothing to do.
+ */
+let rootMoveMigration: Promise<unknown> | null = null;
+function followRootMoves(projects: readonly CaveProject[]): void {
+  if (typeof window === "undefined") return;
+  if (rootMoveMigration) return; // one at a time; a concurrent fetch is not a second migration
+  if (!projects.some((project) => project.legacyRoot)) return;
+  rootMoveMigration = import("./project-root-migration.ts")
+    .then((mod) => mod.migrateProjectRootKeys(projects))
+    .catch(() => 0)
+    .finally(() => {
+      rootMoveMigration = null;
+    });
 }
 
 function generationKey(familiarId: string | null): string {


### PR DESCRIPTION
`createProject` has persisted an expanded root since `cave-psp8`, but records written before that still hold a literal `~/code/app`. **The same folder reaches the client as two different strings depending on when it was added** — and roots are the KEYS of client-side stores, so an old project's avatar and chat overrides sit under a key nothing else produces.

`loadProjectsUnlocked` now expands on read, so clients see one form. When a root moves, the record carries `legacyRoot` (response-only, never written back) and `migrateProjectRootKeys` follows it.

## Why not the fix the bead asked for

The bead asked to make `normalizeProjectRoot` expand `~`. **It can't, where it lives.** It's exported from the client-safe module and four `"use client"` callers use it (`projects-view`, `workspace`, `project-avatar`, `cave-project-images`), while expansion needs `homedir()` from `node:os` — and nothing ships a home path to the browser. Meeting that literally means inventing a client-visible homedir surface.

Expanding also **reduces portability**: `~/code/app` is host-independent, `/Users/me/code/app` is not. Re-keying to the expanded form means a profile opened on a second machine loses its data. So the split is closed on the side that already knows the homedir. `normalizeProjectRoot` is untouched, and `project-root-normalizers.test.ts`'s *"the shared normalizer still does not expand ~"* keeps passing.

## Two of the bead's three stores were wrong

| bead | reality |
|---|---|
| IDB `projectAvatars` re-key | ✅ correct — re-keyed via the existing `moveProjectImage` |
| `cave:chat:project-overrides` re-key | root is the **VALUE** (`Record<sessionId, root>`) — values rewritten, not re-keyed |
| comux pins + order | **does not exist** — the comux surface was deleted (`cave-c3yt`) |

No test was written for comux. A migration for a store gone for months would pass against nothing.

## The test drove two design corrections

Written before the implementation, and it caught both:

- **Idempotence was unobservable.** Returning `moves.length` reported work that didn't happen — the server keeps attaching `legacyRoot` until the projects file self-heals, so a second window would report the same migration forever. The count now reflects work actually done.
- **The count's unit was ambiguous.** Per-store or per-root? A project with both an avatar and an override counted twice. It's per-root now.

## Covered

- the acceptance criterion itself — an existing profile keeps its avatar **and** its override across the upgrade, image byte-for-byte
- a second pass reports `0` with both stores byte-identical, because two windows can start at once
- no `legacyRoot` → no store is touched
- **a denied write leaves the avatar under its OLD key** rather than losing it — `moveProjectImage` writes the new key before deleting the old, and a delete-first migration would pass a naive test and lose data in private mode or over quota
- absent and corrupt override maps survive a first run

Wired at `use-projects-cache`, the single choke point all 20+ project consumers funnel through, and deliberately **not awaited**: the payload is already correct, so nothing on screen waits for a local re-key.

`test:app`: **1039 test files passed**.