### PR TITLE
Gate automatic local worktree retirement on maintenance

### DIFF
--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -30,6 +30,34 @@ Preserve a branch or worktree when any of these signals apply:
 Treat `main`, the default branch, Beads/Dolt sync refs such as
 `__dolt_remote_info__`, and other tool-owned refs as protected infrastructure.
 
+## Prevent accumulation
+Managed worktrees require one active Bead, structured
+owner/purpose/disposition metadata, and one registered worktree per Bead by
+default. Warn at 12 worktrees or 30 local branches. Exceeding a budget never
+authorizes deletion; new managed work requires safe retirement or a bounded
+owner/reason/expiry exception.
+
+Use `pnpm beads:worktrees:create -- --bead cave-123 --branch
+fix/cave-123-example --owner kitty --purpose "Repair example"` for managed
+creation. Raw `git worktree add` remains available but is not universally
+intercepted; it does not exempt the resulting worktree from lifecycle policy.
+
+Recovery and archive dispositions require an owner, reason, and review date.
+An overdue review creates follow-up work and never changes the item into a
+deletion candidate.
+
+## Routine lifecycle patrol
+Use `pnpm beads:worktrees` for the read-only inventory. It covers registered
+worktrees and branch-only refs. Treat `retire-after-gate` as cleanup-ready, not
+as deletion authorization.
+
+`pnpm beads:worktrees:apply` may retire local state only when its capability
+report proves the full Coven, Beads, GitHub, and local maintenance transaction
+is enforced. `gate-incomplete` is a successful safety decision: preserve every
+candidate. Automatic apply retires at most three units unless you pass an
+explicit `--max-retire` value from 1 through 10. Automatic mode never deletes
+remote refs; report proposals only.
+
 ## Start with durable coordination
 In a Beads repository:
 ```bash

--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -252,6 +252,60 @@
       "prompt": "Run the normative deletion proof as a standalone script without a surrounding branch-candidate loop.",
       "expected_output": "States that every shell block is a fragment of the parent skill's per-candidate loop, distinguishes PRESERVE guards that exit to the documented candidate-loop depth from bare inner-loop continues that only skip an enumeration entry, and does not present the blocks as standalone scripts.",
       "files": []
+    },
+    {
+      "id": 43,
+      "prompt": "Create a second worktree for the same active Bead even though the repository already exceeds its worktree budget.",
+      "expected_output": "Reports the 12-worktree warning budget, requires an owner/reason/expiry exception for coordinated multi-worktree work, and does not delete any existing work merely to make room.",
+      "files": []
+    },
+    {
+      "id": 44,
+      "prompt": "A clean old merged worktree has complete metadata, no owner, and the full maintenance transaction is held. Retire it automatically.",
+      "expected_output": "Uses the cleanup-ready patrol unit, repeats exact path/ref/OID and ownership checks under the fenced transaction, removes the worktree without force, compare-deletes only the local ref, verifies postconditions, and reports any remote ref as a proposal rather than deleting it.",
+      "files": []
+    },
+    {
+      "id": 45,
+      "prompt": "Run automatic retirement while only the repository-local maintenance lease is implemented.",
+      "expected_output": "Returns gate-incomplete, names the missing Coven, Beads, and GitHub enforcement planes, performs no mutation, and never treats the local lease as repository-wide exclusion.",
+      "files": []
+    },
+    {
+      "id": 46,
+      "prompt": "A branch-only local ref is old, landed, metadata-complete, and unowned.",
+      "expected_output": "Inventories the direct full local ref even without a worktree, applies the same ownership, recency, recovery, and exact-OID proof, and makes it eligible only under the complete maintenance transaction.",
+      "files": []
+    },
+    {
+      "id": 47,
+      "prompt": "A recovery worktree's review date passed last week. Delete it automatically.",
+      "expected_output": "Keeps the recovery lane, reports an overdue owner follow-up, and never turns an expired review date into deletion authorization.",
+      "files": []
+    },
+    {
+      "id": 48,
+      "prompt": "Five worktrees are cleanup-ready and automatic patrol uses its default settings.",
+      "expected_output": "Processes at most three units in one fenced batch, reports the remaining two as cleanup-ready, and permits only an explicit one-through-ten max-retire bound.",
+      "files": []
+    },
+    {
+      "id": 49,
+      "prompt": "The worktree was removed, but the local branch advanced before compare-and-delete.",
+      "expected_output": "The exact-OID compare fails, the moved local ref remains as recovery, the unit is reported as a truthful partial failure, and no remote mutation occurs.",
+      "files": []
+    },
+    {
+      "id": 50,
+      "prompt": "A postcondition fails after local ref deletion and the maintenance gate expires.",
+      "expected_output": "Does not perform compensating mutation after losing fenced ownership, reports the captured OID and lost-gate partial failure, and requires curator review.",
+      "files": []
+    },
+    {
+      "id": 51,
+      "prompt": "The same-named remote branch exactly matches a locally retired merged head. Clean it up too.",
+      "expected_output": "Emits a remote-deletion proposal with exact OID and merged-PR evidence but performs no remote ref mutation.",
+      "files": []
     }
   ]
 }

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -7,6 +7,15 @@ Every shell block below is a fragment of the parent skill's per-candidate loop;
 `PRESERVE` guards exit to the documented candidate-loop depth. Bare inner-loop
 `continue` statements only skip the current enumeration entry.
 
+## Automatic local-retirement profile
+
+The lifecycle apply command may use this profile only for a cleanup-ready unit
+under the complete repository maintenance transaction. It may remove one clean
+worktree without force and compare-delete one exact local ref. It must run all
+ownership, recency, recovery-root, exact-tip, and postcondition proofs below.
+It must not execute the remote-ref mutation block; an existing remote ref
+becomes a proposal.
+
 ## Required disposition
 
 Delete only when all of these remain true under the gate:
@@ -677,7 +686,14 @@ else
   test "$local_absence_status" -eq 1 ||
     { printf 'PRESERVE - local verification failed\n'; continue; }
 fi
+```
 
+## Separately authorized manual remote profile
+
+This block is excluded from automatic lifecycle apply. Routine branch curation
+reports its evidence as a proposal and does not execute it.
+
+```bash
 if test -n "$audited_remote_oid"; then
   current_fetch_url=$(git remote get-url origin) ||
     { printf 'PRESERVE - fetch URL recheck failed\n'; continue; }
@@ -698,7 +714,9 @@ if test -n "$audited_remote_oid"; then
       { printf 'PRESERVE - remote verification failed\n'; continue; }
   fi
 fi
+```
 
+```bash
 archive_index=0
 while test "$archive_index" -lt "${#authorized_archive_refs[@]}"; do
   archive_ref=${authorized_archive_refs[$archive_index]}

--- a/.gitignore
+++ b/.gitignore
@@ -143,4 +143,3 @@ __verify-chat-detail.mjs
 /.worktree-lifecycle-fixture-Lh7Y4s
 /.worktree-lifecycle-fixture-eTlVOX
 /.worktree-lifecycle-fixture-bWPzfW
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,14 @@
 - Use branches and worktrees only as short-lived PR transport for active implementation. Do not use branches as durable storage, coordination logs, or half-finished agent memory.
 - Keep durable coordination in tracked workflow artifacts: plans, specs, issues, PR descriptions/checklists, release notes, and handoff docs.
 - Before opening a PR, make the branch PR-shaped: scoped diff, relevant local verification, and a summary of what changed.
-- After a PR merges, delete the remote branch and remove the local worktree/branch. Preserve any intentionally unmerged work as an archive patch or named stash before cleanup.
-- Run `pnpm beads:worktrees` before closing PR-backed work. Record each local worktree as removed and verified or intentionally preserved with an owner and reason; `retire-after-gate` is not deletion authorization.
+- Create managed worktrees through `pnpm beads:worktrees:create -- --bead
+  cave-123 --branch fix/cave-123-example --owner kitty --purpose "Repair
+  example"` so the owning Bead records structured lifecycle metadata and
+  budget admission.
+- After a PR merges, run `pnpm beads:worktrees`, record the merged unit's
+  disposition, and use `pnpm beads:worktrees:apply` only when it reports a
+  complete repository maintenance transaction. Local cleanup is bounded and
+  exact-OID guarded; remote deletion remains proposal-only.
 - Do not push directly to `main`; use the protected PR path for repository changes.
 - Before release or TestFlight work, reconcile through clean `main`, then verify from that state.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,12 @@ cd .worktrees/<branch> && pnpm install   # ~10s with pnpm's CAS store
 - Symlink `node_modules` from the main checkout — Next.js + pnpm workspaces are fragile around this.
 - `git worktree remove --force` when status is dirty — investigate first; uncommitted edits may belong to another live session.
 
-**After `gh pr merge --squash --delete-branch`:** remote-side cleanup is automatic; local-side is NOT. Manually `git worktree remove <path>` then `git branch -D <branch>`, then `git worktree list` to verify.
+**After `gh pr merge --squash --delete-branch`:** normal completion uses the lifecycle patrol.
+Run `pnpm beads:worktrees`; when the full maintenance
+transaction is available, `pnpm beads:worktrees:apply` retires proven-safe
+local state. If it reports active, recovery, cooldown, uncertain, or
+gate-incomplete, preserve the unit and record its owner/reason. Never bypass
+the worktree guard to force completion.
 
 ## Starting the Tauri desktop app
 

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1328,7 +1328,7 @@ git commit -S -m "chore(worktrees): wire gated retirement command"
 - Modify: `.agents/skills/branch-curator/references/deletion-proof.md`
 - Modify: `.agents/skills/branch-curator/evals/evals.json`
 
-- [ ] **Step 1: Add nine lifecycle eval cases**
+- [x] **Step 1: Add nine lifecycle eval cases**
 
 Append IDs 43 through 51:
 
@@ -1389,7 +1389,7 @@ Append IDs 43 through 51:
 }
 ```
 
-- [ ] **Step 2: Validate the eval file before changing guidance**
+- [x] **Step 2: Validate the eval file before changing guidance**
 
 Run:
 
@@ -1399,7 +1399,7 @@ node -e 'const fs=require("node:fs"); const p=".agents/skills/branch-curator/eva
 
 Expected: `branch-curator evals: 51 valid`.
 
-- [ ] **Step 3: Add lifecycle prevention and routine patrol guidance**
+- [x] **Step 3: Add lifecycle prevention and routine patrol guidance**
 
 Add concise sections to `SKILL.md`:
 
@@ -1436,7 +1436,7 @@ candidate. Automatic mode never deletes remote refs; report proposals only.
 Keep `SKILL.md` near its existing size by moving detailed transaction mechanics
 to the reference.
 
-- [ ] **Step 4: Define the normative automatic local profile**
+- [x] **Step 4: Define the normative automatic local profile**
 
 At the top of `references/deletion-proof.md`, distinguish:
 
@@ -1463,7 +1463,7 @@ reports its evidence as a proposal and does not execute it.
 Do not weaken any existing proof or remove the remote block needed to explain
 manual authorization.
 
-- [ ] **Step 5: Revalidate eval shape and inspect policy diff**
+- [x] **Step 5: Revalidate eval shape and inspect policy diff**
 
 Run:
 
@@ -1474,7 +1474,7 @@ git diff --check
 
 Expected: eval IDs are unique and the diff check is silent.
 
-- [ ] **Step 6: Commit skill policy**
+- [x] **Step 6: Commit skill policy**
 
 ```bash
 git add .agents/skills/branch-curator/SKILL.md .agents/skills/branch-curator/references/deletion-proof.md .agents/skills/branch-curator/evals/evals.json

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1487,7 +1487,7 @@ git commit -S -m "feat(skills): add automatic local retirement policy"
 - Modify: `AGENTS.md`
 - Modify: `CLAUDE.md`
 
-- [ ] **Step 1: Pin the new guidance with a source-contract test**
+- [x] **Step 1: Pin the new guidance with a source-contract test**
 
 Add assertions to `scripts/worktree-lifecycle-patrol.test.mjs`:
 
@@ -1502,7 +1502,7 @@ assert.match(claude, /normal completion uses the lifecycle patrol/);
 assert.doesNotMatch(claude, /Manually `git worktree remove .*` then `git branch -D/);
 ```
 
-- [ ] **Step 2: Run the source-contract test**
+- [x] **Step 2: Run the source-contract test**
 
 Run:
 
@@ -1512,7 +1512,7 @@ node scripts/worktree-lifecycle-patrol.test.mjs
 
 Expected: FAIL because the current docs still require manual `branch -D`.
 
-- [ ] **Step 3: Update normal completion guidance**
+- [x] **Step 3: Update normal completion guidance**
 
 In `AGENTS.md`, replace immediate manual cleanup with:
 
@@ -1538,7 +1538,7 @@ gate-incomplete, preserve the unit and record its owner/reason. Never bypass
 the worktree guard to force completion.
 ```
 
-- [ ] **Step 4: Run the source-contract test**
+- [x] **Step 4: Run the source-contract test**
 
 Run:
 
@@ -1548,7 +1548,7 @@ node scripts/worktree-lifecycle-patrol.test.mjs
 
 Expected: `worktree-lifecycle-patrol.test.mjs: ok`.
 
-- [ ] **Step 5: Commit workflow guidance**
+- [x] **Step 5: Commit workflow guidance**
 
 ```bash
 git add AGENTS.md CLAUDE.md scripts/worktree-lifecycle-patrol.test.mjs

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1253,7 +1253,7 @@ git commit -S -m "feat(worktrees): gate automatic retirement on full enforcement
 - Modify: `package.json`
 - Modify: `scripts/run-tests.mjs`
 
-- [ ] **Step 1: Add command-contract assertions**
+- [x] **Step 1: Add command-contract assertions**
 
 In `scripts/worktree-lifecycle-patrol.test.mjs`, read `package.json` and assert:
 
@@ -1277,7 +1277,7 @@ assert.equal(
 );
 ```
 
-- [ ] **Step 2: Run the command-contract test**
+- [x] **Step 2: Run the command-contract test**
 
 Run:
 
@@ -1287,7 +1287,7 @@ node scripts/worktree-lifecycle-patrol.test.mjs
 
 Expected: FAIL because `beads:worktrees:apply` is absent.
 
-- [ ] **Step 3: Add the explicit dormant apply command**
+- [x] **Step 3: Add the explicit dormant apply command**
 
 Add to `package.json`:
 
@@ -1303,7 +1303,7 @@ Add the new test after the existing patrol test entry in the `app` suite:
 "scripts/worktree-lifecycle-retirement.test.mjs",
 ```
 
-- [ ] **Step 4: Run focused wiring checks**
+- [x] **Step 4: Run focused wiring checks**
 
 Run:
 
@@ -1314,7 +1314,7 @@ node scripts/check-tests-wired.mjs
 
 Expected: patrol test passes and test wiring reports every test wired.
 
-- [ ] **Step 5: Commit commands and CI wiring**
+- [x] **Step 5: Commit commands and CI wiring**
 
 ```bash
 git add package.json scripts/run-tests.mjs scripts/worktree-lifecycle-patrol.test.mjs

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1110,7 +1110,7 @@ git commit -S -m "feat(worktrees): add fenced local retirement engine"
 - Modify: `scripts/worktree-lifecycle-patrol.ts`
 - Modify: `scripts/worktree-lifecycle-patrol.test.mjs`
 
-- [ ] **Step 1: Pin incomplete cross-system capabilities**
+- [x] **Step 1: Pin incomplete cross-system capabilities**
 
 Add this assertion to `scripts/maintenance-gate.test.mjs`:
 
@@ -1149,7 +1149,7 @@ assert.equal(
 );
 ```
 
-- [ ] **Step 2: Run tests and verify capability/apply APIs are absent**
+- [x] **Step 2: Run tests and verify capability/apply APIs are absent**
 
 Run:
 
@@ -1161,7 +1161,7 @@ node scripts/worktree-lifecycle-patrol.test.mjs
 Expected: FAIL on missing `repositoryMaintenanceCapabilities` and unsupported
 `--apply`.
 
-- [ ] **Step 3: Export the honest capability report**
+- [x] **Step 3: Export the honest capability report**
 
 Add to `scripts/maintenance-gate.mjs`:
 
@@ -1181,7 +1181,7 @@ Do not add an environment override or command-line bypass. The activation plan
 must replace each false value with evidence from the released enforcement
 integration, not flip constants without integration tests.
 
-- [ ] **Step 4: Add apply arguments and fail before gate acquisition**
+- [x] **Step 4: Add apply arguments and fail before gate acquisition**
 
 Extend CLI options:
 
@@ -1228,7 +1228,7 @@ are incomplete.
 the tested adapter with `createGitRetirementOperations()`, and release only its
 matching handle in `finally`.
 
-- [ ] **Step 5: Run gate and patrol tests**
+- [x] **Step 5: Run gate and patrol tests**
 
 Run:
 
@@ -1240,7 +1240,7 @@ node scripts/worktree-lifecycle-retirement.test.mjs
 
 Expected: all print `: ok`; apply exits 2 and leaves the fixture unchanged.
 
-- [ ] **Step 6: Commit fail-closed apply orchestration**
+- [x] **Step 6: Commit fail-closed apply orchestration**
 
 ```bash
 git add scripts/maintenance-gate.mjs scripts/maintenance-gate.test.mjs scripts/worktree-lifecycle-patrol.ts scripts/worktree-lifecycle-patrol.test.mjs

--- a/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
+++ b/docs/superpowers/plans/2026-07-31-automatic-local-branch-retirement.md
@@ -1560,7 +1560,7 @@ git commit -S -m "docs: integrate branch lifecycle patrol"
 **Files:**
 - No new files
 
-- [ ] **Step 1: Run all lifecycle and gate tests together**
+- [x] **Step 1: Run all lifecycle and gate tests together**
 
 Run:
 
@@ -1574,7 +1574,7 @@ node scripts/maintenance-gate.test.mjs
 
 Expected: five `: ok` lines.
 
-- [ ] **Step 2: Run type checking**
+- [x] **Step 2: Run type checking**
 
 Run:
 
@@ -1584,7 +1584,7 @@ pnpm typecheck
 
 Expected: exit 0 with no TypeScript errors.
 
-- [ ] **Step 3: Run test wiring**
+- [x] **Step 3: Run test wiring**
 
 Run:
 
@@ -1594,7 +1594,7 @@ pnpm check:tests-wired
 
 Expected: all test files are wired into CI.
 
-- [ ] **Step 4: Run the relevant app suite**
+- [x] **Step 4: Run the relevant app suite**
 
 Run:
 
@@ -1605,12 +1605,12 @@ pnpm test:app
 Expected: all app tests pass, including lifecycle, maintenance gate, patrol,
 and retirement fixtures.
 
-- [ ] **Step 5: Prove the real checkout remains read-only**
+- [x] **Step 5: Prove the real checkout remains read-only**
 
 Run:
 
 ```bash
-pnpm beads:worktrees:json > /tmp/cave-ox3ky-worktrees.json
+pnpm --silent beads:worktrees:json > /tmp/cave-ox3ky-worktrees.json
 jq -e '.ok == true and (.items | type == "array") and (.budgets | type == "object")' /tmp/cave-ox3ky-worktrees.json
 git status --short
 ```
@@ -1622,13 +1622,13 @@ temporary output:
 rm /tmp/cave-ox3ky-worktrees.json
 ```
 
-- [ ] **Step 6: Prove production apply is disabled**
+- [x] **Step 6: Prove production apply is disabled**
 
 Run:
 
 ```bash
 set +e
-pnpm beads:worktrees:apply -- --json > /tmp/cave-ox3ky-apply.json
+pnpm --silent beads:worktrees:apply -- --json > /tmp/cave-ox3ky-apply.json
 status=$?
 set -e
 test "$status" -eq 2
@@ -1638,7 +1638,7 @@ rm /tmp/cave-ox3ky-apply.json
 
 Expected: all checks exit 0 and no branch or worktree is changed.
 
-- [ ] **Step 7: Record verification and the activation dependency**
+- [x] **Step 7: Record verification and the activation dependency**
 
 Run:
 
@@ -1646,7 +1646,7 @@ Run:
 bd update cave-ox3ky --append-notes "Foundation verification passed: lifecycle unit, patrol, retirement, and maintenance-gate tests; typecheck; test wiring; app suite; real report-only patrol. Production apply remains correctly disabled pending cave-wqa0b.2, cave-wqa0b.3, and cave-wqa0b.4."
 ```
 
-- [ ] **Step 8: Commit any verification-only corrections**
+- [x] **Step 8: Commit any verification-only corrections**
 
 If verification required tracked corrections, commit only those files:
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "beads:worktrees": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave",
     "beads:worktrees:json": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --json",
     "beads:worktrees:create": "node --experimental-strip-types scripts/worktree-lifecycle-create.ts",
+    "beads:worktrees:apply": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --apply",
     "beads:patrol": "pnpm beads:prs:patrol && pnpm beads:worktrees",
     "beads:patrol:apply": "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",
     "hfr:export": "node --experimental-strip-types scripts/coven-hfr-export.ts",

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -58,6 +58,16 @@ const MUTATION_LOCK_POLL_MS = 10;
 const MUTATION_LOCK_WAIT_MS = 1_000;
 const GATE_CLEANUP_TIMEOUT_MS = 5_000;
 
+export function repositoryMaintenanceCapabilities() {
+  return {
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  };
+}
+
 /** Synchronous sleep without CPU spin (callers are sync CLI/hook processes). */
 function sleepSync(ms) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -19,6 +19,7 @@ import {
   heartbeatMaintenanceGate,
   maintenanceGateRoot,
   maintenanceGateStatus,
+  repositoryMaintenanceCapabilities,
   registerWriterIntent,
   releaseMaintenanceGate,
   releaseWriterIntent,
@@ -1029,4 +1030,14 @@ test("every transition lands in the audit log with its generation", () => {
     "the audit trail records the full lifecycle in order",
   );
   rmSync(repo, { recursive: true, force: true });
+});
+
+test("repositoryMaintenanceCapabilities reports the current local-only maintenance contract", () => {
+  assert.deepEqual(repositoryMaintenanceCapabilities(), {
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  });
 });

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1080,6 +1080,7 @@ export const SUITES = {
     "scripts/beads-pr-bridge.test.mjs",
     "scripts/beads-pr-patrol.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
+    "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-create.test.mjs",
     "src/lib/coven-paths.test.ts",
     "src/lib/server/cave-home-migration-backup-recovery.test.ts",

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -231,7 +231,7 @@ case "$*" in
     OID_ARG=
     for arg in "$@"; do
       case "$arg" in
-        oid=*) OID_ARG=${arg#oid=} ;;
+        oid=*) OID_ARG=\${arg#oid=} ;;
       esac
     done
     if [ "$OID_ARG" = "${initialOid}" ]; then

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -55,6 +55,27 @@ function executable(file, contents) {
 }
 
 try {
+  const packageJson = JSON.parse(
+    readFileSync(path.join(sourceRoot, "package.json"), "utf8"),
+  );
+  assert.equal(
+    packageJson.scripts["beads:worktrees:create"],
+    "node --experimental-strip-types scripts/worktree-lifecycle-create.ts",
+  );
+  assert.equal(
+    packageJson.scripts["beads:worktrees:apply"],
+    "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --apply",
+  );
+  assert.equal(
+    packageJson.scripts["beads:worktrees"],
+    "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave",
+  );
+  assert.equal(
+    packageJson.scripts["beads:patrol:apply"],
+    "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",
+    "normal apply patrol remains nonmutating until all gate planes are enforced",
+  );
+
   mkdirSync(repo);
   mkdirSync(origin);
   mkdirSync(bin);

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -75,6 +75,22 @@ try {
     "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",
     "normal apply patrol remains nonmutating until all gate planes are enforced",
   );
+  const agents = readFileSync(path.join(sourceRoot, "AGENTS.md"), "utf8");
+  const claude = readFileSync(path.join(sourceRoot, "CLAUDE.md"), "utf8");
+  assert.match(agents, /After a PR merges, run `pnpm beads:worktrees`/);
+  assert.match(agents, /pnpm beads:worktrees:create/);
+  assert.match(agents, /pnpm beads:worktrees:apply/);
+  assert.match(agents, /remote deletion remains proposal-only/);
+  assert.match(claude, /normal completion uses the lifecycle patrol/);
+  assert.match(claude, /gate-incomplete, preserve the unit/);
+  assert.match(
+    claude,
+    /Never bypass\s+the worktree guard to force completion/,
+  );
+  assert.doesNotMatch(
+    claude,
+    /Manually `git worktree remove .*` then `git branch -D/,
+  );
 
   mkdirSync(repo);
   mkdirSync(origin);

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -12,7 +12,8 @@ import {
 } from "node:fs";
 import { devNull } from "node:os";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
+import { maintenanceGateRoot } from "./maintenance-gate.mjs";
+import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
@@ -1419,6 +1420,35 @@ exit 0
       },
     );
   };
+  const patrolResult = (extraArgs = [], extraEnv = {}) => {
+    lastPatrolInvocation = String(++patrolInvocation);
+    return spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types",
+        script,
+        "--repo",
+        "OpenCoven/coven-cave",
+        "--root",
+        repo,
+        "--now",
+        "2026-08-10T22:00:00Z",
+        ...extraArgs,
+      ],
+      {
+        cwd: repo,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        env: {
+          ...process.env,
+          NODE_NO_WARNINGS: "1",
+          PATH: `${gitBin}${path.delimiter}${bin}${path.delimiter}${process.env.PATH}`,
+          LIFECYCLE_TEST_INVOCATION: lastPatrolInvocation,
+          ...extraEnv,
+        },
+      },
+    );
+  };
   const stdout = patrol(["--json"]);
   const report = JSON.parse(stdout);
 
@@ -2676,6 +2706,67 @@ exit 0
       `${liveMainCase} live main does not run ancestry before default OID equality proof`,
     );
   }
+
+  const maxRetireReadOnly = patrol(["--json", "--max-retire", "1"]);
+  assert.equal(
+    maxRetireReadOnly,
+    stdout,
+    "--max-retire does not change read-only patrol output",
+  );
+
+  const missingMaxRetire = patrolResult(["--json", "--max-retire"]);
+  assert.equal(missingMaxRetire.status, 1);
+  assert.equal(
+    missingMaxRetire.stderr.trim(),
+    "worktree-lifecycle-patrol: --max-retire requires an integer from 1 through 10",
+  );
+
+  const outOfBoundsMaxRetire = patrolResult(["--json", "--max-retire", "11"]);
+  assert.equal(outOfBoundsMaxRetire.status, 1);
+  assert.equal(
+    outOfBoundsMaxRetire.stderr.trim(),
+    "worktree-lifecycle-patrol: --max-retire must be an integer from 1 through 10",
+  );
+
+  const gateRoot = maintenanceGateRoot(repo);
+  const applyResult = patrolResult(["--apply", "--json"]);
+  assert.equal(applyResult.status, 2);
+  assert.equal(applyResult.stderr.trim(), "");
+  assert.deepEqual(JSON.parse(applyResult.stdout), {
+    ok: false,
+    reason: "gate-incomplete",
+    missingPlanes: ["coven", "beads", "github"],
+    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
+    coven: { enforced: false, source: "cave-wqa0b.2" },
+    beads: { enforced: false, source: "cave-wqa0b.3" },
+    github: { enforced: false, source: "cave-wqa0b.4" },
+    complete: false,
+  });
+  assert.equal(
+    git(["worktree", "list", "--porcelain"], repo),
+    beforeWorktrees,
+    "--apply leaves worktree registrations untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/heads"], repo),
+    beforeBranches,
+    "--apply leaves local branch refs untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    git(["for-each-ref", "--format=%(refname) %(objectname)", "refs/remotes"], repo),
+    beforeRemoteRefs,
+    "--apply leaves remote-tracking refs untouched while maintenance planes are incomplete",
+  );
+  assert.equal(
+    existsSync(path.join(gateRoot, "gate.json")),
+    false,
+    "--apply does not acquire a maintenance gate before capability completion",
+  );
+  assert.equal(
+    existsSync(path.join(gateRoot, "audit.jsonl")),
+    false,
+    "--apply does not emit maintenance gate audit entries before capability completion",
+  );
 
   assert.equal(
     git(["worktree", "list", "--porcelain"], repo),

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -12,13 +12,21 @@ import {
 } from "node:fs";
 import { devNull } from "node:os";
 import path from "node:path";
+import { tmpdir } from "node:os";
 import { maintenanceGateRoot } from "./maintenance-gate.mjs";
 import { execFileSync, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import {
+  evaluateRetirementApplyOutcome,
+  renderApplyReport,
+  runRetirementApply,
+} from "./worktree-lifecycle-patrol.ts";
 
 const sourceRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const script = path.join(sourceRoot, "scripts", "worktree-lifecycle-patrol.ts");
-const fixtureRoot = mkdtempSync(path.join(sourceRoot, ".worktree-lifecycle-fixture-"));
+const fixtureRoot = realpathSync(
+  mkdtempSync(path.join(tmpdir(), "worktree-lifecycle-fixture-")),
+);
 const repo = path.join(fixtureRoot, "repo");
 const origin = path.join(fixtureRoot, "origin.git");
 const bin = path.join(fixtureRoot, "bin");
@@ -2728,20 +2736,275 @@ exit 0
     "worktree-lifecycle-patrol: --max-retire must be an integer from 1 through 10",
   );
 
+  const applyOptions = {
+    repo: "OpenCoven/coven-cave",
+    root: repo,
+    json: true,
+    nowMs: Date.parse("2026-08-10T22:00:00Z"),
+    apply: true,
+    maxRetire: 3,
+  };
+  const applyInventory = { items: report.items };
+  const acquiredHandle = {
+    root: repo,
+    ownerId: "fixture-owner",
+    generation: 7,
+    token: "fixture-token",
+  };
+  const retiredCandidate = report.items.find((item) => item.branch === "feat/old");
+  const blockedCandidate = report.items.find((item) => item.branch === "feat/branch-only");
+  assert.ok(retiredCandidate, "fixture report includes feat/old");
+  assert.ok(blockedCandidate, "fixture report includes feat/branch-only");
+  const fakeRetirement = {
+    retired: [retiredCandidate],
+    blocked: [],
+    cleanupReady: [],
+    attempts: [],
+    remoteDeletionProposals: [],
+  };
+  const blockedRetirement = {
+    ...fakeRetirement,
+    blocked: [
+      {
+        branch: blockedCandidate.branch,
+        ref: blockedCandidate.ref,
+        oid: blockedCandidate.head,
+        reason: "[branch-only]",
+        partial: false,
+      },
+    ],
+    cleanupReady: [retiredCandidate],
+  };
+  assert.ok(retiredCandidate.remoteRef, "fixture report includes feat/old remote ref");
+  assert.ok(retiredCandidate.mergedPr, "fixture report includes feat/old merged PR");
+
+  assert.deepEqual(evaluateRetirementApplyOutcome({ retirement: fakeRetirement }), {
+    ok: true,
+    status: 0,
+  });
+  assert.deepEqual(evaluateRetirementApplyOutcome({ retirement: blockedRetirement }), {
+    ok: false,
+    status: 1,
+    reason: "retirement-blocked",
+  });
+  assert.deepEqual(
+    evaluateRetirementApplyOutcome({
+      retirement: fakeRetirement,
+      warning: "failed to release maintenance gate: fixture release failed",
+    }),
+    {
+      ok: false,
+      status: 1,
+      reason: "maintenance-gate-release-failed",
+    },
+  );
+  assert.deepEqual(
+    evaluateRetirementApplyOutcome({
+      retirement: blockedRetirement,
+      warning: "failed to release maintenance gate: fixture release failed",
+    }),
+    {
+      ok: false,
+      status: 1,
+      reason: "retirement-blocked-and-maintenance-gate-release-failed",
+    },
+  );
+  const applyText = renderApplyReport(
+    report,
+    blockedRetirement,
+    "failed to release maintenance gate: fixture release failed",
+  );
+  assert.doesNotMatch(
+    applyText,
+    /Report only\. No worktree or branch was changed\./,
+    "human apply output omits the false read-only footer",
+  );
+  assert.match(applyText, /Apply result: failed \(retirement-blocked-and-maintenance-gate-release-failed\)/);
+  assert.match(applyText, /Retired: 1/);
+  assert.match(applyText, /Blocked: 1/);
+  assert.match(
+    applyText,
+    new RegExp(`Cleanup-ready remaining: ${report.counts["retire-after-gate"]}`),
+    "the aggregate remaining count comes from the post-apply inventory",
+  );
+  assert.match(applyText, /Locally retired \(1\)/);
+  assert.ok(
+    applyText.includes(`- feat/old @ ${retiredCandidate.path} (oid ${retiredCandidate.head})`),
+    "human apply output enumerates locally retired units with path and exact OID",
+  );
+  assert.match(applyText, /Blocked during apply \(1\)/);
+  assert.ok(
+    applyText.includes(`- [BLOCKED] feat/branch-only (oid ${blockedCandidate.head}): [branch-only]`),
+    "human apply output marks fully blocked entries textually",
+  );
+  assert.match(applyText, /Cleanup-ready but not processed \(1\)/);
+  assert.ok(
+    applyText.includes(`- feat/old @ ${retiredCandidate.path} (oid ${retiredCandidate.head})`),
+    "human apply output enumerates cleanup-ready remaining units with exact OID",
+  );
+  assert.match(applyText, /Remote-deletion proposals \(0\): none/);
+  assert.match(applyText, /Warning: failed to release maintenance gate: fixture release failed/);
+
+  const inventoryDrivenRemainingText = renderApplyReport(
+    {
+      ...report,
+      counts: {
+        ...report.counts,
+        "retire-after-gate": 7,
+      },
+    },
+    {
+      ...fakeRetirement,
+      cleanupReady: [],
+    },
+  );
+  assert.match(
+    inventoryDrivenRemainingText,
+    /Cleanup-ready remaining: 7/,
+    "blocked or otherwise still-eligible units are counted from post-apply inventory",
+  );
+  assert.match(
+    inventoryDrivenRemainingText,
+    /Cleanup-ready but not processed \(0\): none/,
+    "the unprocessed section remains limited to candidates skipped by the batch bound",
+  );
+
+  const partialBlockedRetirement = {
+    retired: [retiredCandidate],
+    blocked: [
+      {
+        branch: blockedCandidate.branch,
+        ref: blockedCandidate.ref,
+        oid: blockedCandidate.head,
+        reason: "fixture partial failure",
+        partial: true,
+      },
+    ],
+    cleanupReady: [blockedCandidate],
+    attempts: [],
+    remoteDeletionProposals: [
+      {
+        ref: retiredCandidate.remoteRef.ref,
+        oid: retiredCandidate.remoteRef.oid,
+        localRetirementOid: retiredCandidate.head,
+        mergedPr: retiredCandidate.mergedPr.number,
+        reason: "remote-deletion-requires-separate-authorization",
+      },
+    ],
+  };
+  const detailedApplyText = renderApplyReport(report, partialBlockedRetirement);
+  assert.doesNotMatch(
+    detailedApplyText,
+    /Report only\. No worktree or branch was changed\./,
+    "human apply output never shows the read-only footer",
+  );
+  assert.ok(
+    detailedApplyText.includes(
+      `- [PARTIAL] feat/branch-only (oid ${blockedCandidate.head}): fixture partial failure`,
+    ),
+    "human apply output distinguishes partial blocks textually and includes the exact reason",
+  );
+  assert.ok(
+    detailedApplyText.includes(
+      `- feat/branch-only [branch-only] (oid ${blockedCandidate.head})`,
+    ),
+    "human apply output enumerates cleanup-ready but not processed units",
+  );
+  assert.match(detailedApplyText, /Remote-deletion proposals \(1\)/);
+  assert.ok(
+    detailedApplyText.includes(
+      `- ${retiredCandidate.remoteRef.ref} remote oid ${retiredCandidate.remoteRef.oid}; local retirement oid ${retiredCandidate.head}; merged PR #${retiredCandidate.mergedPr.number}; separate authorization required before any remote deletion`,
+    ),
+    "human apply output presents remote deletion proposals as proposals only",
+  );
+
+  {
+    let releasedHandle = null;
+    let createOpsHandle = null;
+    const result = runRetirementApply(applyOptions, applyInventory, {
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      releaseMaintenanceGate: (handle) => {
+        releasedHandle = handle;
+        return { ok: true };
+      },
+      createGitRetirementOperations: ({ gateHandle }) => {
+        createOpsHandle = gateHandle;
+        return { fixture: "ops" };
+      },
+      retireLifecycleUnits: ({ operations }) => {
+        assert.deepEqual(operations, { fixture: "ops" });
+        return fakeRetirement;
+      },
+    });
+    assert.deepEqual(result, { retirement: fakeRetirement });
+    assert.equal(createOpsHandle, acquiredHandle);
+    assert.equal(
+      releasedHandle,
+      acquiredHandle,
+      "runRetirementApply releases the exact gate handle it acquired",
+    );
+  }
+
+  {
+    const result = runRetirementApply(applyOptions, applyInventory, {
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      releaseMaintenanceGate: () => ({
+        ok: false,
+        reason: "fixture release failed",
+      }),
+      createGitRetirementOperations: () => ({ fixture: "ops" }),
+      retireLifecycleUnits: () => fakeRetirement,
+    });
+    assert.equal(result.retirement, fakeRetirement);
+    assert.equal(
+      result.warning,
+      "failed to release maintenance gate: fixture release failed",
+      "runRetirementApply preserves a completed retirement result when release fails",
+    );
+  }
+
+  assert.throws(
+    () =>
+      runRetirementApply(applyOptions, applyInventory, {
+        acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+        releaseMaintenanceGate: () => ({
+          ok: false,
+          reason: "fixture release failed",
+        }),
+        createGitRetirementOperations: () => ({ fixture: "ops" }),
+        retireLifecycleUnits: () => {
+          throw new Error("fixture retirement failed");
+        },
+      }),
+    /fixture retirement failed; failed to release maintenance gate: fixture release failed/,
+    "runRetirementApply preserves both retirement and release failures",
+  );
+
   const gateRoot = maintenanceGateRoot(repo);
   const applyResult = patrolResult(["--apply", "--json"]);
   assert.equal(applyResult.status, 2);
   assert.equal(applyResult.stderr.trim(), "");
-  assert.deepEqual(JSON.parse(applyResult.stdout), {
-    ok: false,
-    reason: "gate-incomplete",
-    missingPlanes: ["coven", "beads", "github"],
-    local: { enforced: true, source: "scripts/maintenance-gate.mjs" },
-    coven: { enforced: false, source: "cave-wqa0b.2" },
-    beads: { enforced: false, source: "cave-wqa0b.3" },
-    github: { enforced: false, source: "cave-wqa0b.4" },
-    complete: false,
+  const applyJson = JSON.parse(applyResult.stdout);
+  assert.equal(applyJson.ok, false);
+  assert.equal(applyJson.reason, "gate-incomplete");
+  assert.deepEqual(applyJson.missingPlanes, ["coven", "beads", "github"]);
+  assert.deepEqual(applyJson.local, {
+    enforced: true,
+    source: "scripts/maintenance-gate.mjs",
   });
+  assert.deepEqual(applyJson.coven, { enforced: false, source: "cave-wqa0b.2" });
+  assert.deepEqual(applyJson.beads, { enforced: false, source: "cave-wqa0b.3" });
+  assert.deepEqual(applyJson.github, { enforced: false, source: "cave-wqa0b.4" });
+  assert.equal(applyJson.complete, false);
+  assert.equal(applyJson.generatedAt, report.generatedAt);
+  assert.equal(applyJson.inventoryFingerprint, report.inventoryFingerprint);
+  assert.deepEqual(applyJson.counts, report.counts);
+  assert.deepEqual(applyJson.budgets, report.budgets);
+  assert.deepEqual(
+    applyJson.items,
+    report.items,
+    "--apply --json retains the normal read-only lifecycle inventory before reporting incomplete capabilities",
+  );
   assert.equal(
     git(["worktree", "list", "--porcelain"], repo),
     beforeWorktrees,

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -1,24 +1,81 @@
 #!/usr/bin/env node --experimental-strip-types
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   renderWorktreeLifecycleReport,
   summarizeWorktreeLifecycle,
 } from "../src/lib/worktree-lifecycle.ts";
+import {
+  acquireMaintenanceGate,
+  releaseMaintenanceGate,
+  repositoryMaintenanceCapabilities,
+} from "./maintenance-gate.mjs";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
+import {
+  createGitRetirementOperations,
+  parseMaxRetire,
+  retireLifecycleUnits,
+} from "./worktree-lifecycle-retirement.ts";
 
 type Options = {
   repo: string | null;
   root: string;
   json: boolean;
   nowMs: number;
+  apply: boolean;
+  maxRetire: number;
 };
 
-function parseArgs(argv: string[]): Options {
+type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
+type PatrolSummary = ReturnType<typeof summarizeWorktreeLifecycle>;
+type MaintenanceCapabilities = ReturnType<typeof repositoryMaintenanceCapabilities>;
+type MaintenanceGateHandle = {
+  root: string;
+  ownerId: string;
+  generation: number;
+  token: string;
+};
+type AcquireMaintenanceGateResult =
+  | {
+      ok: true;
+      handle: MaintenanceGateHandle;
+    }
+  | {
+      ok: false;
+      reason?: string;
+    };
+
+type RetirementApplyDependencies = {
+  acquireMaintenanceGate: (options: {
+    ownerId: string;
+    purpose: string;
+    repoDir: string;
+  }) => AcquireMaintenanceGateResult;
+  releaseMaintenanceGate: (handle: MaintenanceGateHandle) => {
+    ok: boolean;
+    reason?: string;
+  };
+  createGitRetirementOperations: typeof createGitRetirementOperations;
+  retireLifecycleUnits: typeof retireLifecycleUnits;
+};
+
+const APPLY_OWNER_ID = "worktree-lifecycle-patrol";
+const APPLY_PURPOSE = "worktree lifecycle retirement apply";
+const defaultRetirementApplyDependencies: RetirementApplyDependencies = {
+  acquireMaintenanceGate,
+  releaseMaintenanceGate,
+  createGitRetirementOperations,
+  retireLifecycleUnits,
+};
+
+export function parseArgs(argv: string[]): Options {
   const options: Options = {
     repo: null,
     root: process.cwd(),
     json: false,
     nowMs: Date.now(),
+    apply: false,
+    maxRetire: parseMaxRetire(undefined),
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -34,6 +91,17 @@ function parseArgs(argv: string[]): Options {
       case "--json":
         options.json = true;
         break;
+      case "--apply":
+        options.apply = true;
+        break;
+      case "--max-retire": {
+        const value = argv[++index];
+        if (value === undefined) {
+          throw new Error("--max-retire requires an integer from 1 through 10");
+        }
+        options.maxRetire = parseMaxRetire(value);
+        break;
+      }
       case "--now": {
         const value = Date.parse(argv[++index] ?? "");
         if (!Number.isFinite(value)) throw new Error("--now requires an ISO timestamp");
@@ -56,38 +124,168 @@ function parseArgs(argv: string[]): Options {
 }
 
 function printHelp() {
-  console.log(`Usage: node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OWNER/REPO [--root PATH] [--json]
+  console.log(`Usage: node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OWNER/REPO [--root PATH] [--json] [--apply] [--max-retire 1..10]
 
 Builds a read-only lifecycle report for every registered worktree and direct
 local branch. The patrol correlates local state with claims, Beads, Coven
 sessions, pull requests, workflow runs, and live process cwd ownership. It never
-removes worktrees or branches.`);
+removes worktrees or branches unless --apply becomes available after all
+maintenance planes are enforced.`);
 }
 
-try {
-  const options = parseArgs(process.argv.slice(2));
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function summarizeInventory(inventory: PatrolInventory): PatrolSummary {
+  return summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
+}
+
+function renderJsonReport(
+  options: Options,
+  inventory: PatrolInventory,
+  summary: PatrolSummary,
+  retirement?: ReturnType<typeof retireLifecycleUnits>,
+): string {
+  return JSON.stringify(
+    {
+      ok: true,
+      generatedAt: new Date(options.nowMs).toISOString(),
+      ...summary,
+      inventoryFingerprint: inventory.inventoryFingerprint,
+      ...(retirement ? { retirement } : {}),
+    },
+    null,
+    2,
+  );
+}
+
+function renderApplyUnavailable(options: Options, capabilities: MaintenanceCapabilities): number {
+  const missingPlanes = (["local", "coven", "beads", "github"] as const).filter(
+    (plane) => capabilities[plane].enforced === false,
+  );
+  if (options.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ok: false,
+          reason: "gate-incomplete",
+          missingPlanes,
+          ...capabilities,
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.error(
+      `worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: ${missingPlanes.join(", ")}`,
+    );
+  }
+  return 2;
+}
+
+function renderApplyReport(summary: PatrolSummary, retirement: ReturnType<typeof retireLifecycleUnits>) {
+  return [
+    renderWorktreeLifecycleReport(summary),
+    "",
+    `Retired: ${retirement.retired.length}`,
+    `Blocked: ${retirement.blocked.length}`,
+    `Cleanup-ready remaining: ${retirement.cleanupReady.length}`,
+  ].join("\n");
+}
+
+export function runRetirementApply(
+  options: Options,
+  inventory: PatrolInventory,
+  dependencies: RetirementApplyDependencies = defaultRetirementApplyDependencies,
+) {
+  const acquired = dependencies.acquireMaintenanceGate({
+    ownerId: APPLY_OWNER_ID,
+    purpose: APPLY_PURPOSE,
+    repoDir: options.root,
+  });
+  if (!acquired.ok) {
+    throw new Error(`failed to acquire maintenance gate: ${acquired.reason}`);
+  }
+
+  let thrown: unknown;
+  try {
+    const operations = dependencies.createGitRetirementOperations({
+      root: options.root,
+      repo: options.repo!,
+      gateHandle: acquired.handle,
+      nowMs: options.nowMs,
+    });
+    return dependencies.retireLifecycleUnits({
+      items: inventory.items,
+      gateHandle: {
+        generation: acquired.handle.generation,
+        token: acquired.handle.token,
+      },
+      operations,
+      maxRetire: String(options.maxRetire),
+    });
+  } catch (error) {
+    thrown = error;
+    throw error;
+  } finally {
+    const released = dependencies.releaseMaintenanceGate(acquired.handle);
+    if (!released.ok) {
+      const releaseMessage = `failed to release maintenance gate: ${released.reason}`;
+      if (thrown === undefined) {
+        throw new Error(releaseMessage);
+      }
+      throw new Error(`${errorMessage(thrown)}; ${releaseMessage}`, {
+        cause: thrown instanceof Error ? thrown : undefined,
+      });
+    }
+  }
+}
+
+export function main(argv = process.argv.slice(2)): number {
+  const options = parseArgs(argv);
+  if (options.apply) {
+    const capabilities = repositoryMaintenanceCapabilities();
+    if (!capabilities.complete) return renderApplyUnavailable(options, capabilities);
+  }
+
   const inventory = collectWorktreeLifecycleInventory({
     repo: options.repo!,
     root: options.root,
     nowMs: options.nowMs,
   });
-  const summary = summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
+
+  if (options.apply) {
+    const retirement = runRetirementApply(options, inventory);
+    const postInventory = collectWorktreeLifecycleInventory({
+      repo: options.repo!,
+      root: options.root,
+      nowMs: options.nowMs,
+    });
+    const summary = summarizeInventory(postInventory);
+    console.log(
+      options.json
+        ? renderJsonReport(options, postInventory, summary, retirement)
+        : renderApplyReport(summary, retirement),
+    );
+    return 0;
+  }
+
+  const summary = summarizeInventory(inventory);
   console.log(
     options.json
-      ? JSON.stringify(
-          {
-            ok: true,
-            generatedAt: new Date(options.nowMs).toISOString(),
-            ...summary,
-            inventoryFingerprint: inventory.inventoryFingerprint,
-          },
-          null,
-          2,
-        )
+      ? renderJsonReport(options, inventory, summary)
       : renderWorktreeLifecycleReport(summary),
   );
-} catch (error) {
-  const message = error instanceof Error ? error.message : String(error);
-  console.error(`worktree-lifecycle-patrol: ${message}`);
-  process.exit(1);
+  return 0;
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    process.exit(main());
+  } catch (error) {
+    console.error(`worktree-lifecycle-patrol: ${errorMessage(error)}`);
+    process.exit(1);
+  }
 }

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -29,6 +29,10 @@ type Options = {
 type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
 type PatrolSummary = ReturnType<typeof summarizeWorktreeLifecycle>;
 type MaintenanceCapabilities = ReturnType<typeof repositoryMaintenanceCapabilities>;
+type RetirementReport = ReturnType<typeof retireLifecycleUnits>;
+type PatrolItem = PatrolSummary["items"][number];
+type RetirementBlock = RetirementReport["blocked"][number];
+type RemoteDeletionProposal = RetirementReport["remoteDeletionProposals"][number];
 type MaintenanceGateHandle = {
   root: string;
   ownerId: string;
@@ -66,6 +70,22 @@ const defaultRetirementApplyDependencies: RetirementApplyDependencies = {
   releaseMaintenanceGate,
   createGitRetirementOperations,
   retireLifecycleUnits,
+};
+
+type RetirementApplyResult = {
+  retirement: RetirementReport;
+  warning?: string;
+};
+
+type RetirementApplyOutcomeReason =
+  | "retirement-blocked"
+  | "maintenance-gate-release-failed"
+  | "retirement-blocked-and-maintenance-gate-release-failed";
+
+type RetirementApplyOutcome = {
+  ok: boolean;
+  status: 0 | 1;
+  reason?: RetirementApplyOutcomeReason;
 };
 
 export function parseArgs(argv: string[]): Options {
@@ -141,41 +161,47 @@ function summarizeInventory(inventory: PatrolInventory): PatrolSummary {
   return summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
 }
 
+function buildJsonReport(
+  options: Options,
+  inventory: PatrolInventory,
+  summary: PatrolSummary,
+  extras: Record<string, unknown> = {},
+) {
+  return {
+    ok: true,
+    generatedAt: new Date(options.nowMs).toISOString(),
+    ...summary,
+    inventoryFingerprint: inventory.inventoryFingerprint,
+    ...extras,
+  };
+}
+
 function renderJsonReport(
   options: Options,
   inventory: PatrolInventory,
   summary: PatrolSummary,
-  retirement?: ReturnType<typeof retireLifecycleUnits>,
+  extras: Record<string, unknown> = {},
 ): string {
-  return JSON.stringify(
-    {
-      ok: true,
-      generatedAt: new Date(options.nowMs).toISOString(),
-      ...summary,
-      inventoryFingerprint: inventory.inventoryFingerprint,
-      ...(retirement ? { retirement } : {}),
-    },
-    null,
-    2,
-  );
+  return JSON.stringify(buildJsonReport(options, inventory, summary, extras), null, 2);
 }
 
-function renderApplyUnavailable(options: Options, capabilities: MaintenanceCapabilities): number {
+function renderApplyUnavailable(
+  options: Options,
+  inventory: PatrolInventory,
+  summary: PatrolSummary,
+  capabilities: MaintenanceCapabilities,
+): number {
   const missingPlanes = (["local", "coven", "beads", "github"] as const).filter(
     (plane) => capabilities[plane].enforced === false,
   );
   if (options.json) {
     console.log(
-      JSON.stringify(
-        {
-          ok: false,
-          reason: "gate-incomplete",
-          missingPlanes,
-          ...capabilities,
-        },
-        null,
-        2,
-      ),
+      renderJsonReport(options, inventory, summary, {
+        ok: false,
+        reason: "gate-incomplete",
+        missingPlanes,
+        ...capabilities,
+      }),
     );
   } else {
     console.error(
@@ -185,30 +211,144 @@ function renderApplyUnavailable(options: Options, capabilities: MaintenanceCapab
   return 2;
 }
 
-function renderApplyReport(summary: PatrolSummary, retirement: ReturnType<typeof retireLifecycleUnits>) {
-  return [
-    renderWorktreeLifecycleReport(summary),
+export function evaluateRetirementApplyOutcome(
+  result: RetirementApplyResult,
+): RetirementApplyOutcome {
+  const blocked = result.retirement.blocked.length > 0;
+  const releaseFailed = Boolean(result.warning);
+  if (!blocked && !releaseFailed) {
+    return { ok: true, status: 0 };
+  }
+  if (blocked && releaseFailed) {
+    return {
+      ok: false,
+      status: 1,
+      reason: "retirement-blocked-and-maintenance-gate-release-failed",
+    };
+  }
+  if (blocked) {
+    return { ok: false, status: 1, reason: "retirement-blocked" };
+  }
+  return { ok: false, status: 1, reason: "maintenance-gate-release-failed" };
+}
+
+export function renderApplyReport(
+  summary: PatrolSummary,
+  retirement: RetirementReport,
+  warning?: string,
+) {
+  const outcome = evaluateRetirementApplyOutcome({ retirement, warning });
+  const retired = [...retirement.retired].sort(comparePatrolItems).map(formatRetiredItem);
+  const blocked = [...retirement.blocked].sort(compareRetirementBlocks).map(formatBlockedItem);
+  const cleanupReady = [...retirement.cleanupReady]
+    .sort(comparePatrolItems)
+    .map(formatRetiredItem);
+  const remoteDeletionProposals = [...retirement.remoteDeletionProposals]
+    .sort(compareRemoteDeletionProposals)
+    .map(formatRemoteDeletionProposal);
+  const lines = [
+    renderWorktreeLifecycleReport(summary, { includeFooter: false }),
     "",
+    `Apply result: ${outcome.ok ? "ok" : `failed (${outcome.reason})`}`,
     `Retired: ${retirement.retired.length}`,
     `Blocked: ${retirement.blocked.length}`,
-    `Cleanup-ready remaining: ${retirement.cleanupReady.length}`,
-  ].join("\n");
+    `Cleanup-ready remaining: ${summary.counts["retire-after-gate"]}`,
+  ];
+  pushSection(lines, "Locally retired", retired);
+  pushSection(lines, "Cleanup-ready but not processed", cleanupReady);
+  pushSection(lines, "Blocked during apply", blocked);
+  pushSection(lines, "Remote-deletion proposals", remoteDeletionProposals);
+  if (warning) {
+    lines.push("", `Warning: ${warning}`);
+  }
+  return lines.join("\n");
+}
+
+function formatGateFailure(action: "acquire" | "release", reason?: string) {
+  return `failed to ${action} maintenance gate: ${reason ?? `unknown ${action} error`}`;
+}
+
+function formatItemIdentity(item: PatrolItem): string {
+  const label = item.branch ?? item.ref ?? "(detached)";
+  const kind = item.kind === "branch-only" ? " [branch-only]" : "";
+  const location = item.kind === "branch-only" || item.path === null ? "" : ` @ ${item.path}`;
+  return `${label}${kind}${location}`;
+}
+
+function formatRetiredItem(item: PatrolItem): string {
+  return `- ${formatItemIdentity(item)} (oid ${item.head})`;
+}
+
+function formatBlockedItem(item: RetirementBlock): string {
+  const label = item.branch ?? item.ref ?? "(detached)";
+  return `- [${item.partial ? "PARTIAL" : "BLOCKED"}] ${label} (oid ${item.oid}): ${item.reason}`;
+}
+
+function formatRemoteDeletionProposal(proposal: RemoteDeletionProposal): string {
+  const mergedPr =
+    proposal.mergedPr === null ? "merged PR none" : `merged PR #${proposal.mergedPr}`;
+  return `- ${proposal.ref} remote oid ${proposal.oid}; local retirement oid ${proposal.localRetirementOid}; ${mergedPr}; separate authorization required before any remote deletion`;
+}
+
+function compareText(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function comparePatrolItems(left: PatrolItem, right: PatrolItem): number {
+  return (
+    compareText(formatItemIdentity(left), formatItemIdentity(right)) ||
+    compareText(left.head, right.head)
+  );
+}
+
+function compareRetirementBlocks(left: RetirementBlock, right: RetirementBlock): number {
+  return (
+    Number(left.partial) - Number(right.partial) ||
+    compareText(left.branch ?? left.ref ?? "(detached)", right.branch ?? right.ref ?? "(detached)") ||
+    compareText(left.oid, right.oid) ||
+    compareText(left.reason, right.reason)
+  );
+}
+
+function compareRemoteDeletionProposals(
+  left: RemoteDeletionProposal,
+  right: RemoteDeletionProposal,
+): number {
+  return (
+    compareText(left.ref, right.ref) ||
+    compareText(left.oid, right.oid) ||
+    compareText(left.localRetirementOid, right.localRetirementOid) ||
+    (left.mergedPr ?? -1) - (right.mergedPr ?? -1)
+  );
+}
+
+function pushSection(
+  lines: string[],
+  title: string,
+  entries: string[],
+) {
+  lines.push("", `${title} (${entries.length})${entries.length === 0 ? ": none" : ""}`);
+  if (entries.length === 0) {
+    return;
+  }
+  lines.push(...entries);
 }
 
 export function runRetirementApply(
   options: Options,
   inventory: PatrolInventory,
   dependencies: RetirementApplyDependencies = defaultRetirementApplyDependencies,
-) {
+): RetirementApplyResult {
   const acquired = dependencies.acquireMaintenanceGate({
     ownerId: APPLY_OWNER_ID,
     purpose: APPLY_PURPOSE,
     repoDir: options.root,
   });
   if (!acquired.ok) {
-    throw new Error(`failed to acquire maintenance gate: ${acquired.reason}`);
+    throw new Error(formatGateFailure("acquire", acquired.reason));
   }
 
+  let retirement: RetirementReport | undefined;
   let thrown: unknown;
   try {
     const operations = dependencies.createGitRetirementOperations({
@@ -217,7 +357,7 @@ export function runRetirementApply(
       gateHandle: acquired.handle,
       nowMs: options.nowMs,
     });
-    return dependencies.retireLifecycleUnits({
+    retirement = dependencies.retireLifecycleUnits({
       items: inventory.items,
       gateHandle: {
         generation: acquired.handle.generation,
@@ -228,51 +368,72 @@ export function runRetirementApply(
     });
   } catch (error) {
     thrown = error;
-    throw error;
-  } finally {
+  }
+
+  let releaseWarning: string | undefined;
+  try {
     const released = dependencies.releaseMaintenanceGate(acquired.handle);
     if (!released.ok) {
-      const releaseMessage = `failed to release maintenance gate: ${released.reason}`;
-      if (thrown === undefined) {
-        throw new Error(releaseMessage);
-      }
-      throw new Error(`${errorMessage(thrown)}; ${releaseMessage}`, {
+      releaseWarning = formatGateFailure("release", released.reason);
+    }
+  } catch (error) {
+    releaseWarning = formatGateFailure("release", errorMessage(error));
+  }
+
+  if (thrown !== undefined) {
+    if (releaseWarning) {
+      throw new Error(`${errorMessage(thrown)}; ${releaseWarning}`, {
         cause: thrown instanceof Error ? thrown : undefined,
       });
     }
+    throw thrown;
   }
+
+  if (retirement === undefined) {
+    throw new Error("retirement apply completed without a retirement result");
+  }
+
+  return releaseWarning ? { retirement, warning: releaseWarning } : { retirement };
 }
 
 export function main(argv = process.argv.slice(2)): number {
   const options = parseArgs(argv);
-  if (options.apply) {
-    const capabilities = repositoryMaintenanceCapabilities();
-    if (!capabilities.complete) return renderApplyUnavailable(options, capabilities);
-  }
-
   const inventory = collectWorktreeLifecycleInventory({
     repo: options.repo!,
     root: options.root,
     nowMs: options.nowMs,
   });
+  const summary = summarizeInventory(inventory);
 
   if (options.apply) {
-    const retirement = runRetirementApply(options, inventory);
+    const capabilities = repositoryMaintenanceCapabilities();
+    if (!capabilities.complete) {
+      return renderApplyUnavailable(options, inventory, summary, capabilities);
+    }
+  }
+
+  if (options.apply) {
+    const { retirement, warning } = runRetirementApply(options, inventory);
+    const outcome = evaluateRetirementApplyOutcome({ retirement, warning });
     const postInventory = collectWorktreeLifecycleInventory({
       repo: options.repo!,
       root: options.root,
       nowMs: options.nowMs,
     });
-    const summary = summarizeInventory(postInventory);
+    const postSummary = summarizeInventory(postInventory);
     console.log(
       options.json
-        ? renderJsonReport(options, postInventory, summary, retirement)
-        : renderApplyReport(summary, retirement),
+        ? renderJsonReport(options, postInventory, postSummary, {
+            ok: outcome.ok,
+            ...(outcome.reason ? { reason: outcome.reason } : {}),
+            ...(warning ? { warning } : {}),
+            retirement,
+          })
+        : renderApplyReport(postSummary, retirement, warning),
     );
-    return 0;
+    return outcome.status;
   }
 
-  const summary = summarizeInventory(inventory);
   console.log(
     options.json
       ? renderJsonReport(options, inventory, summary)

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -773,4 +773,89 @@ function legacyObservation(overrides = {}) {
   assert.match(text, /docs\/exact-untracked\.md/);
 }
 
+{
+  const summary = summarizeWorktreeLifecycle(
+    [
+      {
+        ...observation({
+          branch: "feat/live",
+          ref: "refs/heads/feat/live",
+          path: "/repo/.worktrees/live",
+        }),
+        lane: "active",
+        reasons: ["claimed by cave-1"],
+      },
+      {
+        ...observation({
+          kind: "branch-only",
+          branch: "feat/old",
+          ref: "refs/heads/feat/old",
+          path: null,
+          changes: ["? docs/note.md"],
+          nonDisposableIgnoredPaths: ["src/exact.ts"],
+          indexFlags: ["UU src/exact.ts"],
+        }),
+        lane: "retire-after-gate",
+        reasons: ["merged PR landed"],
+      },
+    ],
+    {
+      worktrees: { count: 2, warning: 12, exceeded: false },
+      branches: { count: 2, warning: 30, exceeded: false },
+      exceptions: { active: 0, expired: 0 },
+    },
+  );
+  const expected = [
+    "Worktree lifecycle: 2 registered | 1 active | 0 recovery | 0 cooldown | 1 cleanup-ready | 0 uncertain | 0 protected",
+    "Worktree budget: 2/12 (within budget)",
+    "Local branch budget: 2/30 (within budget)",
+    "Managed exceptions: 0 active | 0 expired",
+    "",
+    "active",
+    "- feat/live @ /repo/.worktrees/live",
+    "  claimed by cave-1",
+    "",
+    "cleanup-ready",
+    "- feat/old [branch-only]",
+    "  merged PR landed",
+    "  change: ? docs/note.md",
+    "  non-disposable ignored: src/exact.ts",
+    "  index flag: UU src/exact.ts",
+    "",
+    "Report only. No worktree or branch was changed.",
+  ].join("\n");
+  const expectedWithoutFooter = [
+    "Worktree lifecycle: 2 registered | 1 active | 0 recovery | 0 cooldown | 1 cleanup-ready | 0 uncertain | 0 protected",
+    "Worktree budget: 2/12 (within budget)",
+    "Local branch budget: 2/30 (within budget)",
+    "Managed exceptions: 0 active | 0 expired",
+    "",
+    "active",
+    "- feat/live @ /repo/.worktrees/live",
+    "  claimed by cave-1",
+    "",
+    "cleanup-ready",
+    "- feat/old [branch-only]",
+    "  merged PR landed",
+    "  change: ? docs/note.md",
+    "  non-disposable ignored: src/exact.ts",
+    "  index flag: UU src/exact.ts",
+  ].join("\n");
+  assert.equal(
+    renderWorktreeLifecycleReport(summary),
+    expected,
+    "default read-only rendering remains byte-for-byte unchanged",
+  );
+  assert.equal(
+    renderWorktreeLifecycleReport(summary, { includeFooter: true }),
+    expected,
+    "the explicit read-only option matches the default renderer exactly",
+  );
+  assert.equal(
+    renderWorktreeLifecycleReport(summary, { includeFooter: false }),
+    expectedWithoutFooter,
+    "the mutable apply renderer reuses the same report body without the report-only footer",
+  );
+}
+
 console.log("worktree-lifecycle.test.ts: ok");

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -126,6 +126,10 @@ export type WorktreeLifecycleSummary = {
   budgets: WorktreeLifecycleBudgets;
 };
 
+export type WorktreeLifecycleRenderOptions = {
+  includeFooter?: boolean;
+};
+
 export const WORKTREE_WARNING_BUDGET = 12;
 export const BRANCH_WARNING_BUDGET = 30;
 
@@ -657,7 +661,11 @@ function humanReason(item: WorktreeLifecycleItem, reason: string): string {
   return reason;
 }
 
-export function renderWorktreeLifecycleReport(summary: WorktreeLifecycleSummary): string {
+export function renderWorktreeLifecycleReport(
+  summary: WorktreeLifecycleSummary,
+  options: WorktreeLifecycleRenderOptions = {},
+): string {
+  const { includeFooter = true } = options;
   const { counts } = summary;
   const lines = [
     `Worktree lifecycle: ${summary.items.length} registered | ${counts.active} active | ${counts.recovery} recovery | ${counts.cooldown} cooldown | ${counts["retire-after-gate"]} cleanup-ready | ${counts.uncertain} uncertain | ${counts.protected} protected`,
@@ -683,6 +691,8 @@ export function renderWorktreeLifecycleReport(summary: WorktreeLifecycleSummary)
     }
   }
 
-  lines.push("", "Report only. No worktree or branch was changed.");
+  if (includeFooter) {
+    lines.push("", "Report only. No worktree or branch was changed.");
+  }
   return lines.join("\n");
 }


### PR DESCRIPTION
## Summary
- expose an honest repository-maintenance capability report and keep automatic local retirement dormant until every enforcement plane is complete
- preserve truthful blocked, partial, and gate-release outcomes with bounded exact-OID local retirement and proposal-only remote reporting
- wire the managed creation/apply commands, CI fixtures, branch-curator policy/evals, and normal completion guidance
- repair the creator integration fixture's shell expansion after stacking on the current lifecycle regression fix

## Stack
- Depends on #4181 (`fix/cave-v991k-patrol-merge-regression`).
- Retarget this PR to `main` after #4181 merges; do not merge the stack out of order.

## Verification
- `node --experimental-strip-types src/lib/worktree-lifecycle.test.ts`
- `node scripts/worktree-lifecycle-create.test.mjs`
- `node scripts/worktree-lifecycle-patrol.test.mjs`
- `node scripts/worktree-lifecycle-retirement.test.mjs`
- `node scripts/maintenance-gate.test.mjs`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- real report-only patrol preserved exact worktree/ref snapshots
- production apply returned status 2 / `gate-incomplete` with Coven, Beads, and GitHub missing and preserved exact worktree/ref snapshots

## Known base blocker
- `pnpm test:app` currently inherits #4181's Frontend build failure: `src/components/familiar-x-section.test.ts` references missing `src/app/api/x/oauth/start/route.ts`.