### PR TITLE
fix(research): podcast drafter dogfood round 2 — sentence chunks, clean titles, spoken glyphs

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -664,7 +664,7 @@ test("podcast drafter clamps a long source mechanically at the local TTS limit",
   assert.ok(content.script.some((segment) => segment.text.includes("verbatim source claim")));
 });
 
-test("podcast drafter splits long units at sentence boundaries, never mid-sentence", () => {
+test("podcast drafter prefers sentence boundaries when splitting long units into turns", () => {
   // Dogfood round 2 (cave-2emgc): chunks become separate spoken turns, so a
   // continuation turn opening mid-sentence ("it can appear where you didn't…")
   // is a speech bug. Sentences short enough to pack many per chunk.

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -664,6 +664,82 @@ test("podcast drafter clamps a long source mechanically at the local TTS limit",
   assert.ok(content.script.some((segment) => segment.text.includes("verbatim source claim")));
 });
 
+test("podcast drafter splits long units at sentence boundaries, never mid-sentence", () => {
+  // Dogfood round 2 (cave-2emgc): chunks become separate spoken turns, so a
+  // continuation turn opening mid-sentence ("it can appear where you didn't…")
+  // is a speech bug. Sentences short enough to pack many per chunk.
+  const sentences = Array.from(
+    { length: 60 },
+    (_, i) => `Claim number ${i + 1} holds under repeated evaluation pressure.`,
+  ).join(" ");
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: `# Long findings\n\n## Detailed findings\n\n- ${sentences}`,
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const guestTurns = content.script.filter((segment) => segment.speaker === "guest");
+  assert.ok(guestTurns.length > 1, "long unit split into multiple turns");
+  for (const turn of guestTurns) {
+    assert.match(
+      turn.text,
+      /^[A-Z0-9(“"']/,
+      `turn never opens mid-sentence (${turn.text.slice(0, 40)}…)`,
+    );
+    assert.match(
+      turn.text,
+      /[.!?…]["'”’)\]]*$/,
+      `turn never ends mid-sentence (…${turn.text.slice(-40)})`,
+    );
+  }
+});
+
+test("podcast openings speak a cleaned mission title — no trailing '.…' garbage", () => {
+  const messyMission = {
+    ...mission,
+    title: "Research and compare: Identity Preservation for Agents during Self-Evolution.…",
+  };
+  for (const style of ["breakdown", "debate", "interview"] as const) {
+    const content = draftPodcastContent({
+      mission: messyMission,
+      artifact: { key: "findings", title: "Findings" },
+      markdown: "# Findings\n\n## Detailed findings\n\n- Gates bind proxies, not purposes.",
+    }, "standard", style);
+    assert.equal(content.kind, "podcast");
+    if (content.kind !== "podcast") return;
+    const opening = content.script[0]?.text ?? "";
+    assert.ok(
+      opening.includes("“Research and compare: Identity Preservation for Agents during Self-Evolution”"),
+      `${style} opening strips trailing title punctuation (${opening})`,
+    );
+    assert.ok(!opening.includes(".…"), `${style} opening never speaks '.…'`);
+  }
+});
+
+test("podcast drafter normalizes TTS-hostile glyphs into spoken words", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Open questions → next steps",
+      "",
+      "- Throughput improved 3× at ≥ 90% recall (≈ baseline cost).",
+    ].join("\n"),
+  }, "standard", "debate");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const narration = content.script.map((segment) => segment.text).join(" ");
+  assert.ok(narration.includes("Open questions to next steps"), `arrow spoken as 'to' (${narration})`);
+  assert.ok(narration.includes("3 times at at least 90%"), `× and ≥ spoken (${narration})`);
+  assert.ok(narration.includes("about baseline cost"), `≈ spoken as 'about' (${narration})`);
+  for (const glyph of ["→", "×", "≥", "≈"]) {
+    assert.ok(!narration.includes(glyph), `no raw ${glyph} reaches speech`);
+  }
+});
+
 test("video storyboard drafter maps headings, bullets, and narration without invention", () => {
   const content = draftVideoStoryboardContent({
     mission,

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -789,13 +789,26 @@ export function draftInfographicContent(source: GenerationDraftSource): Research
   return { kind: "infographic", stats };
 }
 
+/** Sentence terminator (with optional closing quotes/brackets) before a space. */
+const SENTENCE_BREAK_RE = /[.!?…]["'”’)\]]*(?=\s)/g;
+
 function splitMediaDraftText(text: string): string[] {
   const normalized = text.trim();
   if (!normalized) return [];
   const chunks: string[] = [];
   let remaining = normalized;
   while (remaining.length > MAX_MEDIA_DRAFT_CHARS) {
-    const boundary = remaining.lastIndexOf(" ", MAX_MEDIA_DRAFT_CHARS);
+    // Chunks become separate spoken turns, so prefer ending one at a sentence
+    // boundary; a continuation turn must never open mid-sentence.
+    const window = remaining.slice(0, MAX_MEDIA_DRAFT_CHARS);
+    let sentenceCut = -1;
+    for (const match of window.matchAll(SENTENCE_BREAK_RE)) {
+      sentenceCut = match.index + match[0].length;
+    }
+    const boundary =
+      sentenceCut > MAX_MEDIA_DRAFT_CHARS / 2
+        ? sentenceCut
+        : remaining.lastIndexOf(" ", MAX_MEDIA_DRAFT_CHARS);
     const cut = boundary > MAX_MEDIA_DRAFT_CHARS / 2 ? boundary : MAX_MEDIA_DRAFT_CHARS;
     chunks.push(remaining.slice(0, cut).trimEnd());
     remaining = remaining.slice(cut).trimStart();
@@ -807,11 +820,39 @@ function splitMediaDraftText(text: string): string[] {
 /** Fragment endings that already close a spoken clause — no "." appended. */
 const SPEAKABLE_TERMINAL_RE = /[.!?…;:)\]"'”’]$/;
 
+/**
+ * Glyphs TTS engines mangle or skip, mapped to spoken words. Scoped to
+ * symbols that carry meaning when read aloud ("Open questions → next steps").
+ */
+const SPOKEN_GLYPHS: [RegExp, string][] = [
+  [/\s*(?:→|->)\s*/g, " to "],
+  [/(?<=\d)\s*×\s*/g, " times "],
+  [/\s*≥\s*/g, " at least "],
+  [/\s*≤\s*/g, " at most "],
+  [/\s*≈\s*/g, " about "],
+];
+
+function normalizeSpokenGlyphs(text: string): string {
+  let spoken = text;
+  for (const [pattern, replacement] of SPOKEN_GLYPHS) {
+    spoken = spoken.replace(pattern, replacement);
+  }
+  return spoken.replace(/\s{2,}/g, " ").trim();
+}
+
 /** Terminates a fragment for speech without ever doubling punctuation. */
 function speakable(fragment: string): string {
-  const trimmed = fragment.trim();
+  const trimmed = normalizeSpokenGlyphs(fragment);
   if (!trimmed) return trimmed;
   return SPEAKABLE_TERMINAL_RE.test(trimmed) ? trimmed : `${trimmed}.`;
+}
+
+/**
+ * Mission titles arrive with trailing punctuation or truncation ellipses
+ * ("…Self-Evolution.…"); strip them so templated openings speak cleanly.
+ */
+function spokenTitle(missionTitle: string): string {
+  return normalizeSpokenGlyphs(missionTitle).replace(/[\s.…:;,–—-]+$/u, "");
 }
 
 type NarrationUnit = {
@@ -845,7 +886,9 @@ function mediaNarrationSectionUnits(source: GenerationDraftSource): NarrationUni
     const line = stripInlineMarkdown(
       rawLine.replace(/^\s*[-*+]\s+/, "").replace(/^\s*>\s?/, ""),
     );
-    if (line && !/^#{1,6}\s/.test(line)) lines.push({ title: null, text: line });
+    if (line && !/^#{1,6}\s/.test(line)) {
+      lines.push({ title: null, text: normalizeSpokenGlyphs(line) });
+    }
   }
   return lines;
 }
@@ -914,15 +957,15 @@ const PODCAST_DIALOGUE_TEMPLATES: Record<
   (missionTitle: string) => Omit<DialogueTemplate, "budget">
 > = {
   breakdown: (missionTitle) => ({
-    opening: `Welcome in — today we're breaking down “${missionTitle}”, finding by finding.`,
+    opening: `Welcome in — today we're breaking down “${spokenTitle(missionTitle)}”, finding by finding.`,
     framing: (title) => `Next up — ${speakable(title)}`,
   }),
   debate: (missionTitle) => ({
-    opening: `Welcome to the debate — today we're stress-testing “${missionTitle}”, starting where the findings are most contested.`,
+    opening: `Welcome to the debate — today we're stress-testing “${spokenTitle(missionTitle)}”, starting where the findings are most contested.`,
     framing: (title) => `Where do we actually stand on this one? ${speakable(title)}`,
   }),
   interview: (missionTitle) => ({
-    opening: `Today my guest walks us through “${missionTitle}”. Let's get into it.`,
+    opening: `Today my guest walks us through “${spokenTitle(missionTitle)}”. Let's get into it.`,
     framing: (title) => `Walk me through this part — ${speakable(title)}`,
   }),
 };

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -789,7 +789,7 @@ export function draftInfographicContent(source: GenerationDraftSource): Research
   return { kind: "infographic", stats };
 }
 
-/** Sentence terminator (with optional closing quotes/brackets) before a space. */
+/** Sentence terminator (with optional closing quotes/brackets) before whitespace. */
 const SENTENCE_BREAK_RE = /[.!?…]["'”’)\]]*(?=\s)/g;
 
 function splitMediaDraftText(text: string): string[] {


### PR DESCRIPTION
## What

Second dogfood round on the Studio podcast pipeline (bead `cave-2emgc`). Generated all four styles (breakdown / debate / interview / recap) from the identity-preservation mission via the live API and fixed the three speech-quality bugs it surfaced:

1. **Mid-sentence turn splits** — `splitMediaDraftText` cut at word boundaries only; continuation chunks become separate spoken turns, so turns opened mid-sentence ("it can appear where you didn't intend it"). Now prefers the last sentence terminator in the window (past half budget), word boundary as fallback.
2. **Raw title in openings** — the mission title ends `.…`, spoken verbatim in every opening. `spokenTitle()` strips trailing punctuation/ellipses.
3. **TTS-hostile glyphs** — "Open questions → next steps", "3×", "≥ 90%" reached speech raw. `normalizeSpokenGlyphs()` maps → × ≥ ≤ ≈ to words across speakable text, framed titles, and heading-less lines.

## Verification

- `node --test` drafter suite: 39/39 (3 new regression tests)
- Contract + pipeline + readiness + studio structural: 45/45
- `pnpm exec tsc --noEmit` clean

Evidence generations (familiar sage): debate 914c0936, breakdown ef2c5608, interview e5486017, recap afaf10a6.