### PR TITLE
feat(chat): put the brief composer under the hero on a new session (2b)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -461,6 +461,7 @@ export const SUITES = {
     "src/components/chat-queue-group.test.ts",
     "src/components/chat-reviews-group.test.ts",
     "src/components/chat-start-from-bands.test.ts",
+    "src/components/chat-inline-composer.test.ts",
     "src/components/chat-new-dashboard.test.ts",
     "src/components/user-chat-avatar.test.ts",
     "src/components/user-profile-invariants.test.ts",

--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -55,6 +55,17 @@ test("the dashboard never builds its own composer", () => {
   }
 });
 
+test("the inline composer stays selectable inside a select-none root", () => {
+  // ChatNewDashboard's root carries `select-none`; the composer is now nested
+  // inside it, so `user-select: none` inherits onto the textarea. Chromium
+  // still allows keyboard select-all, so a functional probe passes — what
+  // breaks is mouse drag-selection under WebKit, which is the desktop shell.
+  assert.match(dashboard, /home-dash__body home-dash--embed select-none/, "the root really is select-none");
+  const rule = css.match(/\.home-dash__composer \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.match(rule, /user-select: text/, "selection is handed back to the composer");
+  assert.match(rule, /-webkit-user-select: text/, "including the WebKit prefix — the desktop shell is WKWebView");
+});
+
 test("inline styling only undoes dock chrome", () => {
   const rule = css.match(/\.home-dash__composer \.cave-composer-dock \{[\s\S]*?\n\}/)?.[0] ?? "";
   assert.ok(rule, "the inline override exists");

--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+// Source pins for the new-session inline composer (Chat.dc.html 2b).
+//
+// The mock draws the brief directly under the hero and has no dock at all.
+// Cave's composer is permanently docked, so the temptation is to build a
+// SECOND composer in the page. That would fork the draft, the project / model
+// / branch selection and the enhance flow, and put two textareas on screen.
+// These pins exist so that shortcut stays closed: one composer element, two
+// positions, chosen by whether the chat has a session yet.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const dashboard = readFileSync(new URL("./chat-new-dashboard.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/home-dashboard.css", import.meta.url), "utf8");
+
+test("one composer element, rendered in exactly one of two positions", () => {
+  assert.match(chatView, /const composerNode = \(/, "the dock is extracted to a variable, not duplicated");
+  assert.match(chatView, /const inlineComposer = sessionId === null;/, "inline only on a brand-new chat");
+  assert.match(
+    chatView,
+    /\{inlineComposer \? null : composerNode\}/,
+    "the docked position yields when the composer goes inline",
+  );
+  assert.match(chatView, /composer=\{composerNode\}/, "the same node is handed to the dashboard");
+  // Exactly one <footer className="cave-composer-dock"> in the tree.
+  assert.equal(
+    (chatView.match(/className="cave-composer-dock"/g) ?? []).length,
+    1,
+    "a second dock element would mean two composers",
+  );
+});
+
+test("the dashboard places the composer between hero and bands", () => {
+  assert.match(dashboard, /composer\?: ReactNode;/, "the slot is typed");
+  assert.match(
+    dashboard,
+    /\{composer \? <div className="home-dash__composer">\{composer\}<\/div> : null\}/,
+    "the slot renders only when handed a composer",
+  );
+  const hero = dashboard.indexOf("home-dash__headline");
+  const slot = dashboard.indexOf("home-dash__composer");
+  const bands = dashboard.indexOf("<ChatStartFromBands");
+  assert.ok(hero > 0 && slot > 0 && bands > 0, "all three landmarks present");
+  assert.ok(hero < slot && slot < bands, "order is hero -> composer -> bands (2b)");
+});
+
+test("the dashboard never builds its own composer", () => {
+  for (const forbidden of ["<textarea", "usePromptEnhance", "ComposerContextChips", "EnhanceStrip"]) {
+    assert.ok(
+      !dashboard.includes(forbidden),
+      `the dashboard must not rebuild composer internals (${forbidden}) — it receives ChatView's`,
+    );
+  }
+});
+
+test("inline styling only undoes dock chrome", () => {
+  const rule = css.match(/\.home-dash__composer \.cave-composer-dock \{[\s\S]*?\n\}/)?.[0] ?? "";
+  assert.ok(rule, "the inline override exists");
+  for (const prop of ["padding: 0", "border-top: 0", "background: none"]) {
+    assert.ok(rule.includes(prop), `inline composer resets ${prop}`);
+  }
+  // The docked gradient/hairline read as a pinned band; nothing else should be
+  // restyled, or the two positions start drifting apart visually.
+  assert.doesNotMatch(rule, /position:|display:|width:/, "placement is layout's job, not this override's");
+});

--- a/src/components/chat-new-dashboard.tsx
+++ b/src/components/chat-new-dashboard.tsx
@@ -22,7 +22,7 @@ import "@/styles/home-dashboard.css";
 //   • cave:navigate-mode      (workspace switches surface: Tasks, Schedules)
 //   • cave:agents-open-session (ChatSurface routes into an existing session)
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { Familiar, SessionRow } from "@/lib/types";
 import type { InboxItem } from "@/lib/cave-inbox";
@@ -134,11 +134,17 @@ const markInboxItemRead = (id: string) => {
 export function ChatNewDashboard({
   familiar,
   sessions = [],
+  composer = null,
   modelId = null,
 }: {
   familiar: Familiar;
   /** Workspace-owned session list; powers Recent threads without a fetch. */
   sessions?: SessionRow[];
+  /** ChatView's own composer, rendered inline under the hero (Chat.dc.html 2b
+   *  puts the brief there and has no dock). Handed down rather than rebuilt so
+   *  there is exactly one draft, one project/model/branch selection and one
+   *  enhance flow — a second composer would fork all of them. */
+  composer?: ReactNode;
   /** Effective model for the board-head meta row (quiet text, not a badge). */
   modelId?: string | null;
 }) {
@@ -342,6 +348,11 @@ export function ChatNewDashboard({
               </p>
             </div>
           </div>
+
+          {/* Chat.dc.html 2b: the brief sits directly under the hero, above
+              the launcher — you state the work first, and the bands below are
+              the shortcut for when it already exists somewhere. */}
+          {composer ? <div className="home-dash__composer">{composer}</div> : null}
 
           {/* Chat.dc.html 2b: everything below is a launcher over work that
               already exists — one band per source, each a strip of tiles. */}

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5971,6 +5971,595 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     visibleModelId(familiar.model ?? undefined, familiar.harness ?? undefined);
   const contextRowBranch = sessionGitBranch;
 
+  // ── Composer placement (Chat.dc.html 2b) ────────────────────────────────
+  // One composer, two positions. On a brand-new chat the design puts the brief
+  // directly under the hero — its mock has no dock at all — so the SAME element
+  // renders inline there and docked everywhere else. Extracted to a variable
+  // rather than duplicated: a second composer would mean two textareas sharing
+  // nothing, with draft, project, model, branch and enhance state forked.
+  const inlineComposer = sessionId === null;
+  const composerNode = (
+        <footer
+          className="cave-composer-dock"
+          style={{ "--composer-kb-offset": `${keyboardOffset}px` } as React.CSSProperties}
+        >
+          {/* Chat-revamp 1b: the latest settled turn's follow-up suggestions sit
+              directly above the composer, aligned to the reading column. Same
+              data source (<coven:next-paths>) and typed-card treatment as the in-turn
+              rows; hidden while a response streams so a stale suggestion can't
+              be clicked mid-turn. */}
+          {followUp.suggestions.length > 0 && !busy ? (
+            <div className="cave-chat-followups">
+              <FollowUpCards paths={followUp.suggestions} onActivate={handleFollowUp} />
+            </div>
+          ) : null}
+          {setupCandidateRoot && !setupBannerDismissed ? (
+            <div
+              role="status"
+              className="mb-2 flex items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-secondary)]"
+            >
+              <Icon
+                name="ph:folder-plus"
+                width={14}
+                aria-hidden
+                className="shrink-0 text-[var(--text-muted)]"
+              />
+              <span className="min-w-0 flex-1 truncate" title={setupCandidateRoot}>
+                This chat runs in{" "}
+                <span className="font-medium text-[var(--text-primary)]">
+                  {projectNameForRoot(setupCandidateRoot)}
+                </span>
+                , which isn’t a registered project.
+              </span>
+              <Button variant="ghost" onClick={() => setProjectSetupRoot(setupCandidateRoot)}>
+                Set up as project…
+              </Button>
+              <button
+                type="button"
+                className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
+                aria-label="Dismiss project setup suggestion"
+                onClick={dismissSetupBanner}
+              >
+                <Icon name="ph:x" width={11} aria-hidden />
+              </button>
+            </div>
+          ) : null}
+          <div className="cave-composer-shell">
+            {mentionOpen ? (
+              <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+                <ul className="max-h-72 overflow-y-auto p-1.5" id={mentionListboxId} role="listbox" aria-label="Workspace files">
+                  {mentionMatches.map((file, i) => {
+                    const active = i === mentionActiveIdx;
+                    const base = file.split("/").pop() ?? file;
+                    return (
+                      <li
+                        key={file}
+                        role="option"
+                        id={`${mentionListboxId}-opt-${i}`}
+                        aria-selected={active}
+                      >
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeMentionOptionRef : null}
+                          onMouseEnter={() => setMentionIdx(i)}
+                          onClick={() => selectMention(file)}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <Icon name="ph:file-code" width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                          <span className="font-mono font-medium text-[var(--text-primary)]">{base}</span>
+                          <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">{file}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {keys.up}{keys.down} navigate · {keys.enter} insert · Tab insert · esc cancel
+                </div>
+              </div>
+            ) : null}
+            {modelMenuActive && modelOptions ? (
+              <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+                <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Models">
+                  {modelOptions.map((m, i) => {
+                    const active = i === slashIdx;
+                    return (
+                      <li key={m.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeSlashOptionRef : null}
+                          onMouseEnter={() => setSlashIdx(i)}
+                          onClick={() => {
+                            handleSelectModel(m.id);
+                            appendSystem(`Model set to ${m.id}.`);
+                            setInput("");
+                            inputRef.current?.focus();
+                          }}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <span className="font-medium text-[var(--text-primary)]">{m.label}</span>
+                          <span className="flex-1 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">{m.id}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {keys.up}{keys.down} navigate · {keys.enter} switch · esc cancel
+                </div>
+              </div>
+            ) : skillMenuActive && skillOptions ? (
+              <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+                <div className="flex">
+                <ul className="max-h-72 flex-1 min-w-0 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Skills">
+                  {skillOptions.map((s, i) => {
+                    const active = i === slashIdx;
+                    return (
+                      <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeSlashOptionRef : null}
+                          onMouseEnter={() => setSlashIdx(i)}
+                          onClick={() => invokeSkillOption(s)}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <Icon name="ph:sparkle" width={15} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+                          <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
+                          <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
+                            {s.description || s.id}
+                          </span>
+                          {s.argumentHint ? (
+                            <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                              {s.argumentHint}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <SkillDetailPreview skill={skillOptions[slashIdx] ?? skillOptions[0] ?? null} />
+                </div>
+                <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
+                </div>
+              </div>
+            ) : promptMenuActive && promptOptions ? (
+              <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+                <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Prompts">
+                  {promptOptions.map((p, i) => {
+                    const active = i === slashIdx;
+                    return (
+                      <li key={p.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeSlashOptionRef : null}
+                          onMouseEnter={() => setSlashIdx(i)}
+                          onClick={() => insertPrompt(p)}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <Icon name={promptIconName(p.icon)} width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                          <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
+                          <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
+                            {p.description || p.id}
+                          </span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {keys.up}{keys.down} navigate · {keys.enter} insert · Tab complete · esc cancel
+                </div>
+              </div>
+            ) : slashSuggestions.length > 0 || skillCommandRows.length > 0 ? (
+              <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
+                <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Slash commands">
+                  {slashSuggestions.length > 0 ? (
+                    <li role="presentation" className="px-3 pb-1 pt-1.5 text-[length:var(--text-sm)] font-medium text-[var(--text-muted)]">
+                      Commands
+                    </li>
+                  ) : null}
+                  {slashSuggestions.map((cmd, i) => {
+                    const active = i === slashIdx;
+                    return (
+                      <li
+                        key={cmd.name}
+                        role="option"
+                        id={`${slashListboxId}-opt-${i}`}
+                        aria-selected={active}
+                      >
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeSlashOptionRef : null}
+                          onMouseEnter={() => setSlashIdx(i)}
+                          onClick={() => {
+                            setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
+                            inputRef.current?.focus();
+                          }}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <Icon name="ph:terminal-window" width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                          <span className="font-mono font-medium text-[var(--text-primary)]">{cmd.name}</span>
+                          <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
+                            {cmd.description}
+                          </span>
+                          {cmd.argPlaceholder ? (
+                            <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                              {cmd.argPlaceholder}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                  {skillCommandRows.length > 0 ? (
+                    <li role="presentation" className="px-3 pb-1 pt-2.5 text-[length:var(--text-sm)] font-medium text-[var(--text-muted)]">
+                      Skills
+                    </li>
+                  ) : null}
+                  {skillCommandRows.map((s, i) => {
+                    const idx = slashSuggestions.length + i;
+                    const active = idx === slashIdx;
+                    return (
+                      <li key={`skill-${s.id}`} role="option" id={`${slashListboxId}-opt-${idx}`} aria-selected={active}>
+                        <button
+                          type="button"
+                          tabIndex={-1}
+                          ref={active ? activeSlashOptionRef : null}
+                          onMouseEnter={() => setSlashIdx(idx)}
+                          onClick={() => invokeSkillOption(s)}
+                          className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
+                            active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
+                          }`}
+                        >
+                          <Icon name="ph:sparkle" width={15} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+                          <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
+                          <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
+                            {s.description || s.id}
+                          </span>
+                          {s.argumentHint ? (
+                            <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                              {s.argumentHint}
+                            </span>
+                          ) : null}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+                <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+                  {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
+                </div>
+              </div>
+            ) : null}
+
+            <MobileChatActionStrip
+              busy={busy}
+              canRetry={Boolean(lastFailedSend)}
+              canAttach={attachments.length < 10}
+              hasSession={Boolean(sessionId)}
+              onRetry={retryLastSend}
+              onStop={cancelSend}
+              onSummarize={() => {
+                setInput((current) => current.trim() ? current : "Summarize this session and call out decisions, blockers, and next actions.");
+                inputRef.current?.focus();
+              }}
+              onAttach={() => fileInputRef.current?.click()}
+              onVoice={() => setVoiceCallOpen(true)}
+            />
+
+            <div className="cave-composer-panel">
+              {attachments.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5 border-b border-[var(--border-hairline)]/70 px-3 py-2">
+                  {attachments.map((attachment) => (
+                    <span
+                      key={attachment.id}
+                      className="inline-flex max-w-56 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/50 px-2 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)]"
+                    >
+                      {/* Staged images preview as themselves — a filename chip
+                          gave no way to tell which screenshot you picked. */}
+                      <AttachmentThumb attachment={attachment} />
+                      <span className="truncate">{attachment.name}</span>
+                      <span className="shrink-0 text-[var(--text-muted)]">{formatAttachmentBytes(attachment.size)}</span>
+                      <button
+                        type="button"
+                        onClick={() => removeAttachment(attachment.id)}
+                        className="focus-ring grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
+                        title={`Remove ${attachment.name}`}
+                        aria-label={`Remove ${attachment.name}`}
+                      >
+                        <Icon name="ph:x-bold" width={9} />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              ) : null}
+              {replyTarget ? (
+                <div className="cave-composer-reply flex items-center gap-2 border-b border-[var(--border-hairline)]/70 bg-[var(--bg-raised)] px-3 py-1.5">
+                  <Icon name="ph:arrow-bend-up-left" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
+                  <span className="flex min-w-0 flex-1 items-baseline gap-1.5 text-[length:var(--text-xs)]">
+                    <span className="shrink-0 font-medium text-[var(--text-secondary)]">Replying to {replyTarget.author}</span>
+                    <span className="truncate text-[var(--text-muted)]">{replyTarget.snippet}</span>
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setReplyTarget(null)}
+                    className="focus-ring grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]"
+                    title="Cancel reply"
+                    aria-label="Cancel reply"
+                  >
+                    <Icon name="ph:x-bold" width={9} aria-hidden />
+                  </button>
+                </div>
+              ) : null}
+              <div className="cave-composer-input-wrap">
+              <textarea
+                ref={inputRef}
+                value={input}
+                onChange={(e) => {
+                  setInput(e.target.value);
+                  syncComposerCaret(e);
+                }}
+                onKeyDown={onComposerKey}
+                onKeyUp={syncComposerCaret}
+                onClick={syncComposerCaret}
+                onSelect={syncComposerCaret}
+                onPaste={handlePaste}
+                placeholder={
+                  busy
+                    ? "Streaming… (send to queue · esc to cancel)"
+                    : recommendedNextPath
+                      ? recommendedNextPath.prompt
+                      : `Message ${familiar.display_name}…`
+                }
+                rows={1}
+                inputMode="text"
+                enterKeyHint="send"
+                className="cave-composer-input w-full resize-none bg-transparent px-4 pt-3 pb-2 leading-6 text-[var(--text-primary)] outline-none placeholder:text-[color-mix(in_oklch,var(--foreground)_45%,transparent)] md:text-sm"
+                aria-label="Message"
+                aria-autocomplete="list"
+                aria-haspopup="listbox"
+                aria-expanded={menuOpen}
+                aria-controls={menuOpen ? slashListboxId : undefined}
+                aria-activedescendant={
+                  menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
+                }
+                {...mentionAriaOverrides}
+              />
+              </div>
+              {/* Enhance status strip (shared): streaming preview, apply/dismiss
+                  for late arrivals, one-tap revert after an in-place apply. */}
+              <EnhanceStrip
+                state={promptEnhance.state}
+                onApply={promptEnhance.apply}
+                onDismiss={promptEnhance.dismiss}
+                onRevert={promptEnhance.revert}
+                onCancel={promptEnhance.cancel}
+              />
+              {queuedMessages.length > 0 ? (
+                <div className="cave-composer-queue" role="group" aria-label="Queued messages">
+                  {queuedMessages.map((message) => (
+                    <div key={message.id} className="cave-composer-queue__chip" title={message.text}>
+                      <button
+                        type="button"
+                        className="cave-composer-queue__steer focus-ring"
+                        onClick={() => steerQueuedMessage(message.id)}
+                        aria-label={busy ? "Send queued message next" : "Send queued message"}
+                        title={busy ? "Send this queued message next" : "Send queued message"}
+                      >
+                        <Icon name="ph:clock" width={12} aria-hidden />
+                        <span className="cave-composer-queue__text">
+                          {message.text.trim() || `${message.attachments.length} file${message.attachments.length === 1 ? "" : "s"}`}
+                        </span>
+                        {message.attachments.length > 0 && message.text.trim() ? (
+                          <span className="cave-composer-queue__count">📎{message.attachments.length}</span>
+                        ) : null}
+                      </button>
+                      <button
+                        type="button"
+                        className="cave-composer-queue__remove focus-ring"
+                        onClick={() => removeQueuedMessage(message.id)}
+                        aria-label="Remove queued message"
+                        title="Remove from queue"
+                      >
+                        <Icon name="ph:x" width={12} aria-hidden />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+              {dictation.listening ? (
+                <div className="hc-dictation-caption">
+                  {dictation.partial || "Listening…"}
+                </div>
+              ) : null}
+              <div className="cave-composer-controls">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept={CHAT_ATTACHMENT_ACCEPT}
+                  multiple
+                  className="hidden"
+                  onChange={(e) => {
+                    // Snapshot the files and clear the input synchronously so picking the
+                    // SAME file again still fires onChange (e.g. re-attach after the CSV
+                    // or 10-attachment-cap early returns in addFiles).
+                    const files = e.currentTarget.files ? Array.from(e.currentTarget.files) : null;
+                    e.currentTarget.value = "";
+                    void addFiles(files);
+                  }}
+                />
+                <div className="cave-composer-control-row">
+                  <div className="cave-composer-utility-row">
+                    <button
+                      type="button"
+                      className="cave-composer-footer-action focus-ring"
+                      onClick={() => void openVoiceCall()}
+                      disabled={!projectLaunchReady || voiceCallPending || (busy && !sessionId)}
+                      title="Voice call"
+                      aria-label="Voice call"
+                    >
+                      <Icon name="ph:phone" width="var(--icon-2xs)" aria-hidden />
+                    </button>
+                    <ComposerActionsMenu
+                      attach={{
+                        onSelect: () => fileInputRef.current?.click(),
+                        disabled: attachments.length >= 10,
+                        hint: keys.mod === "⌘" ? "⌘⇧A" : "Ctrl+Shift+A",
+                      }}
+                      skills={{
+                        onPickSkill: (skill) => {
+                          setInput(`/skill ${skill.id} `);
+                          inputRef.current?.focus();
+                        },
+                      }}
+                      context={{
+                        projects,
+                        projectValue: resolvedProjectId,
+                        onProjectChange: setProjectIdDraft,
+                        familiarId: familiar.id ?? null,
+                        createProject,
+                        runtime: modelHarness,
+                        modelValue: composerModelValue,
+                        modelOptions: composerModelOptions,
+                        onPickRuntime: handleSelectRuntime,
+                        onPickModel: handleSelectModel,
+                        modelDisabled: busy,
+                        projectRoot: activeProjectRoot,
+                        onOpenUrl,
+                      }}
+                      linkedWork={{
+                        linkedContext,
+                        onOpenTask,
+                        sessionId,
+                        onLinkedContextChange: setLinkedContext,
+                        handoff: { turns: activePath, familiarId: familiar.id ?? null, projectId: projectIdDraft },
+                        sessionSettled: !activePendingTurn && Boolean(lastSettledAssistantTurn) && !lastSettledAssistantTurn?.error,
+                      }}
+                      improve={{
+                        dictation: dictation.available
+                          ? {
+                              listening: dictation.listening,
+                              toggle: dictation.toggle,
+                              disabled: busy && !dictation.listening,
+                            }
+                          : undefined,
+                        promptSnippets: {
+                          onSelect: () => setPromptSnippetsOpen(true),
+                        },
+                        enhance: {
+                          onEnhance: promptEnhance.enhance,
+                          disabled: busy || !input.trim(),
+                          loading: promptEnhance.state.phase === "loading",
+                        },
+                      }}
+                      response={{
+                        hostValue: composerHostValue,
+                        onHostPick: setRuntimeHost,
+                        sections: composerResponseSections,
+                        onSaveAsTemplate: () => setSaveTemplateSeed(input),
+                        saveAsTemplateDisabled: !input.trim(),
+                        indicator:
+                          composerHostValue !== LOCAL_HOST_ID ||
+                          permissionMode !== DEFAULT_PERMISSION_MODE ||
+                          thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
+                          responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed,
+                      }}
+                    />
+                  </div>
+                  <div className="cave-composer-submit-row">
+                    {/* The compact send keeps its queue/cancel behavior in one
+                        stable action slot. */}
+                    {busy ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() => void send()}
+                          disabled={!projectLaunchReady || (!input.trim() && attachments.length === 0)}
+                          data-typing={input.trim() ? "true" : undefined}
+                          className="cave-composer-send cave-composer-send--queue focus-ring transition-colors"
+                          title="Queue message"
+                          aria-label="Queue message"
+                        >
+                          <Icon name="ph:arrow-up-bold" width="var(--icon-2xs)" aria-hidden />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={cancelSend}
+                          className="cave-composer-send cave-composer-send--busy focus-ring transition-colors"
+                          title="Cancel (esc)"
+                          aria-label="Cancel response"
+                        >
+                          <Icon name="ph:x-bold" width="var(--icon-2xs)" aria-hidden />
+                        </button>
+                      </>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => void send()}
+                        disabled={!projectLaunchReady || (!input.trim() && attachments.length === 0)}
+                        data-typing={input.trim() ? "true" : undefined}
+                        className="cave-composer-send focus-ring transition-colors"
+                        title={`Send message (${keys.enter})`}
+                        aria-label="Send message"
+                      >
+                        <Icon name="ph:arrow-up-bold" width="var(--icon-2xs)" aria-hidden />
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </div>
+              {/* Footer band — the darker strip attached to the panel's
+                  underside carries the context chips (project · model · branch
+                  as separate controls, cave-g21f; each opens its own picker) on
+                  the left and the linked-work strip (tasks · GitHub ·
+                  link/create) on the right. */}
+              <div className="cave-composer-footer-band">
+                <div className="cave-composer-footer-band__cluster">
+                  <ComposerContextChips
+                    projects={projects}
+                    projectValue={resolvedProjectId}
+                    onProjectChange={setProjectIdDraft}
+                    familiarId={familiar.id ?? null}
+                    createProject={createProject}
+                    runtime={modelHarness}
+                    modelValue={composerModelValue}
+                    modelOptions={composerModelOptions}
+                    onPickRuntime={handleSelectRuntime}
+                    onPickModel={handleSelectModel}
+                    modelDisabled={busy}
+                    projectRoot={activeProjectRoot}
+                    onOpenUrl={onOpenUrl}
+                    registerCurrentRoot={setupCandidateRoot ?? undefined}
+                    onRegisterCurrentRoot={
+                      setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
+                    }
+                  />
+                </div>
+                {linkedContextRow}
+              </div>
+            </div>
+          </div>
+        </footer>
+  );
+
+
   return (
     <section
       className="cave-chat-linear flex h-full flex-col bg-[var(--bg-base)] text-[var(--text-primary)]"
@@ -6240,15 +6829,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 onBack={onBack}
               />
             ) : sessionId === null ? (
-              // Brand-new chat (no session yet): the simplified work-led
-              // dashboard that used to be Home — a single no-scroll open-work
-              // board over ChatView's own composer (the composer owns project
-              // picking and prompt snippets). Existing zero-turn sessions
-              // (fresh task chats with linked context) keep the quieter
-              // ChatEmptyState below.
+              // Brand-new chat (no session yet): the 2b launcher — hero, the
+              // brief composer inline beneath it, then a band per source of
+              // work. The composer is ChatView's own, handed down rather than
+              // rebuilt, so project picking / model / branch / enhance all keep
+              // working and there is exactly one draft. Existing zero-turn
+              // sessions (fresh task chats with linked context) keep the
+              // quieter ChatEmptyState below.
               <ChatNewDashboard
                 familiar={familiar}
                 sessions={sessions}
+                composer={composerNode}
                 modelId={
                   modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
                     ? modelState.effectiveModel
@@ -6425,584 +7016,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         />
       ) : null}
 
-      <footer
-        className="cave-composer-dock"
-        style={{ "--composer-kb-offset": `${keyboardOffset}px` } as React.CSSProperties}
-      >
-        {/* Chat-revamp 1b: the latest settled turn's follow-up suggestions sit
-            directly above the composer, aligned to the reading column. Same
-            data source (<coven:next-paths>) and typed-card treatment as the in-turn
-            rows; hidden while a response streams so a stale suggestion can't
-            be clicked mid-turn. */}
-        {followUp.suggestions.length > 0 && !busy ? (
-          <div className="cave-chat-followups">
-            <FollowUpCards paths={followUp.suggestions} onActivate={handleFollowUp} />
-          </div>
-        ) : null}
-        {setupCandidateRoot && !setupBannerDismissed ? (
-          <div
-            role="status"
-            className="mb-2 flex items-center gap-2 rounded-[var(--radius-control)] border border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2 text-[length:var(--text-sm)] text-[var(--text-secondary)]"
-          >
-            <Icon
-              name="ph:folder-plus"
-              width={14}
-              aria-hidden
-              className="shrink-0 text-[var(--text-muted)]"
-            />
-            <span className="min-w-0 flex-1 truncate" title={setupCandidateRoot}>
-              This chat runs in{" "}
-              <span className="font-medium text-[var(--text-primary)]">
-                {projectNameForRoot(setupCandidateRoot)}
-              </span>
-              , which isn’t a registered project.
-            </span>
-            <Button variant="ghost" onClick={() => setProjectSetupRoot(setupCandidateRoot)}>
-              Set up as project…
-            </Button>
-            <button
-              type="button"
-              className="focus-ring grid h-5 w-5 shrink-0 place-items-center rounded text-[var(--text-muted)] transition-colors hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)]"
-              aria-label="Dismiss project setup suggestion"
-              onClick={dismissSetupBanner}
-            >
-              <Icon name="ph:x" width={11} aria-hidden />
-            </button>
-          </div>
-        ) : null}
-        <div className="cave-composer-shell">
-          {mentionOpen ? (
-            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
-              <ul className="max-h-72 overflow-y-auto p-1.5" id={mentionListboxId} role="listbox" aria-label="Workspace files">
-                {mentionMatches.map((file, i) => {
-                  const active = i === mentionActiveIdx;
-                  const base = file.split("/").pop() ?? file;
-                  return (
-                    <li
-                      key={file}
-                      role="option"
-                      id={`${mentionListboxId}-opt-${i}`}
-                      aria-selected={active}
-                    >
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeMentionOptionRef : null}
-                        onMouseEnter={() => setMentionIdx(i)}
-                        onClick={() => selectMention(file)}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <Icon name="ph:file-code" width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-                        <span className="font-mono font-medium text-[var(--text-primary)]">{base}</span>
-                        <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">{file}</span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                {keys.up}{keys.down} navigate · {keys.enter} insert · Tab insert · esc cancel
-              </div>
-            </div>
-          ) : null}
-          {modelMenuActive && modelOptions ? (
-            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
-              <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Models">
-                {modelOptions.map((m, i) => {
-                  const active = i === slashIdx;
-                  return (
-                    <li key={m.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeSlashOptionRef : null}
-                        onMouseEnter={() => setSlashIdx(i)}
-                        onClick={() => {
-                          handleSelectModel(m.id);
-                          appendSystem(`Model set to ${m.id}.`);
-                          setInput("");
-                          inputRef.current?.focus();
-                        }}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <span className="font-medium text-[var(--text-primary)]">{m.label}</span>
-                        <span className="flex-1 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">{m.id}</span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                {keys.up}{keys.down} navigate · {keys.enter} switch · esc cancel
-              </div>
-            </div>
-          ) : skillMenuActive && skillOptions ? (
-            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
-              <div className="flex">
-              <ul className="max-h-72 flex-1 min-w-0 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Skills">
-                {skillOptions.map((s, i) => {
-                  const active = i === slashIdx;
-                  return (
-                    <li key={s.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeSlashOptionRef : null}
-                        onMouseEnter={() => setSlashIdx(i)}
-                        onClick={() => invokeSkillOption(s)}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <Icon name="ph:sparkle" width={15} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
-                        <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
-                        <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
-                          {s.description || s.id}
-                        </span>
-                        {s.argumentHint ? (
-                          <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                            {s.argumentHint}
-                          </span>
-                        ) : null}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <SkillDetailPreview skill={skillOptions[slashIdx] ?? skillOptions[0] ?? null} />
-              </div>
-              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
-              </div>
-            </div>
-          ) : promptMenuActive && promptOptions ? (
-            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
-              <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Prompts">
-                {promptOptions.map((p, i) => {
-                  const active = i === slashIdx;
-                  return (
-                    <li key={p.id} role="option" id={`${slashListboxId}-opt-${i}`} aria-selected={active}>
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeSlashOptionRef : null}
-                        onMouseEnter={() => setSlashIdx(i)}
-                        onClick={() => insertPrompt(p)}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <Icon name={promptIconName(p.icon)} width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-                        <span className="font-medium text-[var(--text-primary)]">{p.name}</span>
-                        <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
-                          {p.description || p.id}
-                        </span>
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                {keys.up}{keys.down} navigate · {keys.enter} insert · Tab complete · esc cancel
-              </div>
-            </div>
-          ) : slashSuggestions.length > 0 || skillCommandRows.length > 0 ? (
-            <div className="cave-composer-popover absolute bottom-full left-0 right-0 mb-2 overflow-hidden rounded-2xl border border-[var(--border-hairline)] bg-[var(--bg-elevated)] shadow-2xl">
-              <ul className="max-h-72 overflow-y-auto p-1.5" id={slashListboxId} role="listbox" aria-label="Slash commands">
-                {slashSuggestions.length > 0 ? (
-                  <li role="presentation" className="px-3 pb-1 pt-1.5 text-[length:var(--text-sm)] font-medium text-[var(--text-muted)]">
-                    Commands
-                  </li>
-                ) : null}
-                {slashSuggestions.map((cmd, i) => {
-                  const active = i === slashIdx;
-                  return (
-                    <li
-                      key={cmd.name}
-                      role="option"
-                      id={`${slashListboxId}-opt-${i}`}
-                      aria-selected={active}
-                    >
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeSlashOptionRef : null}
-                        onMouseEnter={() => setSlashIdx(i)}
-                        onClick={() => {
-                          setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
-                          inputRef.current?.focus();
-                        }}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <Icon name="ph:terminal-window" width={15} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-                        <span className="font-mono font-medium text-[var(--text-primary)]">{cmd.name}</span>
-                        <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
-                          {cmd.description}
-                        </span>
-                        {cmd.argPlaceholder ? (
-                          <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                            {cmd.argPlaceholder}
-                          </span>
-                        ) : null}
-                      </button>
-                    </li>
-                  );
-                })}
-                {skillCommandRows.length > 0 ? (
-                  <li role="presentation" className="px-3 pb-1 pt-2.5 text-[length:var(--text-sm)] font-medium text-[var(--text-muted)]">
-                    Skills
-                  </li>
-                ) : null}
-                {skillCommandRows.map((s, i) => {
-                  const idx = slashSuggestions.length + i;
-                  const active = idx === slashIdx;
-                  return (
-                    <li key={`skill-${s.id}`} role="option" id={`${slashListboxId}-opt-${idx}`} aria-selected={active}>
-                      <button
-                        type="button"
-                        tabIndex={-1}
-                        ref={active ? activeSlashOptionRef : null}
-                        onMouseEnter={() => setSlashIdx(idx)}
-                        onClick={() => invokeSkillOption(s)}
-                        className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${
-                          active ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]/60"
-                        }`}
-                      >
-                        <Icon name="ph:sparkle" width={15} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
-                        <span className="font-medium text-[var(--text-primary)]">{s.name}</span>
-                        <span className="flex-1 truncate text-[length:var(--text-sm)] text-[var(--text-muted)]">
-                          {s.description || s.id}
-                        </span>
-                        {s.argumentHint ? (
-                          <span className="font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                            {s.argumentHint}
-                          </span>
-                        ) : null}
-                      </button>
-                    </li>
-                  );
-                })}
-              </ul>
-              <div className="border-t border-[var(--border-hairline)] px-3 py-1.5 text-[length:var(--text-2xs)] text-[var(--text-muted)]">
-                {keys.up}{keys.down} navigate · {keys.enter} run · Tab complete · esc cancel
-              </div>
-            </div>
-          ) : null}
-
-          <MobileChatActionStrip
-            busy={busy}
-            canRetry={Boolean(lastFailedSend)}
-            canAttach={attachments.length < 10}
-            hasSession={Boolean(sessionId)}
-            onRetry={retryLastSend}
-            onStop={cancelSend}
-            onSummarize={() => {
-              setInput((current) => current.trim() ? current : "Summarize this session and call out decisions, blockers, and next actions.");
-              inputRef.current?.focus();
-            }}
-            onAttach={() => fileInputRef.current?.click()}
-            onVoice={() => setVoiceCallOpen(true)}
-          />
-
-          <div className="cave-composer-panel">
-            {attachments.length > 0 ? (
-              <div className="flex flex-wrap gap-1.5 border-b border-[var(--border-hairline)]/70 px-3 py-2">
-                {attachments.map((attachment) => (
-                  <span
-                    key={attachment.id}
-                    className="inline-flex max-w-56 items-center gap-1.5 rounded-md border border-[var(--border-hairline)] bg-[var(--bg-base)]/50 px-2 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)]"
-                  >
-                    {/* Staged images preview as themselves — a filename chip
-                        gave no way to tell which screenshot you picked. */}
-                    <AttachmentThumb attachment={attachment} />
-                    <span className="truncate">{attachment.name}</span>
-                    <span className="shrink-0 text-[var(--text-muted)]">{formatAttachmentBytes(attachment.size)}</span>
-                    <button
-                      type="button"
-                      onClick={() => removeAttachment(attachment.id)}
-                      className="focus-ring grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)]"
-                      title={`Remove ${attachment.name}`}
-                      aria-label={`Remove ${attachment.name}`}
-                    >
-                      <Icon name="ph:x-bold" width={9} />
-                    </button>
-                  </span>
-                ))}
-              </div>
-            ) : null}
-            {replyTarget ? (
-              <div className="cave-composer-reply flex items-center gap-2 border-b border-[var(--border-hairline)]/70 bg-[var(--bg-raised)] px-3 py-1.5">
-                <Icon name="ph:arrow-bend-up-left" width={12} className="shrink-0 text-[var(--text-muted)]" aria-hidden />
-                <span className="flex min-w-0 flex-1 items-baseline gap-1.5 text-[length:var(--text-xs)]">
-                  <span className="shrink-0 font-medium text-[var(--text-secondary)]">Replying to {replyTarget.author}</span>
-                  <span className="truncate text-[var(--text-muted)]">{replyTarget.snippet}</span>
-                </span>
-                <button
-                  type="button"
-                  onClick={() => setReplyTarget(null)}
-                  className="focus-ring grid h-4 w-4 shrink-0 place-items-center rounded text-[var(--text-muted)] hover:bg-[var(--bg-base)] hover:text-[var(--text-primary)]"
-                  title="Cancel reply"
-                  aria-label="Cancel reply"
-                >
-                  <Icon name="ph:x-bold" width={9} aria-hidden />
-                </button>
-              </div>
-            ) : null}
-            <div className="cave-composer-input-wrap">
-            <textarea
-              ref={inputRef}
-              value={input}
-              onChange={(e) => {
-                setInput(e.target.value);
-                syncComposerCaret(e);
-              }}
-              onKeyDown={onComposerKey}
-              onKeyUp={syncComposerCaret}
-              onClick={syncComposerCaret}
-              onSelect={syncComposerCaret}
-              onPaste={handlePaste}
-              placeholder={
-                busy
-                  ? "Streaming… (send to queue · esc to cancel)"
-                  : recommendedNextPath
-                    ? recommendedNextPath.prompt
-                    : `Message ${familiar.display_name}…`
-              }
-              rows={1}
-              inputMode="text"
-              enterKeyHint="send"
-              className="cave-composer-input w-full resize-none bg-transparent px-4 pt-3 pb-2 leading-6 text-[var(--text-primary)] outline-none placeholder:text-[color-mix(in_oklch,var(--foreground)_45%,transparent)] md:text-sm"
-              aria-label="Message"
-              aria-autocomplete="list"
-              aria-haspopup="listbox"
-              aria-expanded={menuOpen}
-              aria-controls={menuOpen ? slashListboxId : undefined}
-              aria-activedescendant={
-                menuOpen ? `${slashListboxId}-opt-${slashIdx}` : undefined
-              }
-              {...mentionAriaOverrides}
-            />
-            </div>
-            {/* Enhance status strip (shared): streaming preview, apply/dismiss
-                for late arrivals, one-tap revert after an in-place apply. */}
-            <EnhanceStrip
-              state={promptEnhance.state}
-              onApply={promptEnhance.apply}
-              onDismiss={promptEnhance.dismiss}
-              onRevert={promptEnhance.revert}
-              onCancel={promptEnhance.cancel}
-            />
-            {queuedMessages.length > 0 ? (
-              <div className="cave-composer-queue" role="group" aria-label="Queued messages">
-                {queuedMessages.map((message) => (
-                  <div key={message.id} className="cave-composer-queue__chip" title={message.text}>
-                    <button
-                      type="button"
-                      className="cave-composer-queue__steer focus-ring"
-                      onClick={() => steerQueuedMessage(message.id)}
-                      aria-label={busy ? "Send queued message next" : "Send queued message"}
-                      title={busy ? "Send this queued message next" : "Send queued message"}
-                    >
-                      <Icon name="ph:clock" width={12} aria-hidden />
-                      <span className="cave-composer-queue__text">
-                        {message.text.trim() || `${message.attachments.length} file${message.attachments.length === 1 ? "" : "s"}`}
-                      </span>
-                      {message.attachments.length > 0 && message.text.trim() ? (
-                        <span className="cave-composer-queue__count">📎{message.attachments.length}</span>
-                      ) : null}
-                    </button>
-                    <button
-                      type="button"
-                      className="cave-composer-queue__remove focus-ring"
-                      onClick={() => removeQueuedMessage(message.id)}
-                      aria-label="Remove queued message"
-                      title="Remove from queue"
-                    >
-                      <Icon name="ph:x" width={12} aria-hidden />
-                    </button>
-                  </div>
-                ))}
-              </div>
-            ) : null}
-            {dictation.listening ? (
-              <div className="hc-dictation-caption">
-                {dictation.partial || "Listening…"}
-              </div>
-            ) : null}
-            <div className="cave-composer-controls">
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept={CHAT_ATTACHMENT_ACCEPT}
-                multiple
-                className="hidden"
-                onChange={(e) => {
-                  // Snapshot the files and clear the input synchronously so picking the
-                  // SAME file again still fires onChange (e.g. re-attach after the CSV
-                  // or 10-attachment-cap early returns in addFiles).
-                  const files = e.currentTarget.files ? Array.from(e.currentTarget.files) : null;
-                  e.currentTarget.value = "";
-                  void addFiles(files);
-                }}
-              />
-              <div className="cave-composer-control-row">
-                <div className="cave-composer-utility-row">
-                  <button
-                    type="button"
-                    className="cave-composer-footer-action focus-ring"
-                    onClick={() => void openVoiceCall()}
-                    disabled={!projectLaunchReady || voiceCallPending || (busy && !sessionId)}
-                    title="Voice call"
-                    aria-label="Voice call"
-                  >
-                    <Icon name="ph:phone" width="var(--icon-2xs)" aria-hidden />
-                  </button>
-                  <ComposerActionsMenu
-                    attach={{
-                      onSelect: () => fileInputRef.current?.click(),
-                      disabled: attachments.length >= 10,
-                      hint: keys.mod === "⌘" ? "⌘⇧A" : "Ctrl+Shift+A",
-                    }}
-                    skills={{
-                      onPickSkill: (skill) => {
-                        setInput(`/skill ${skill.id} `);
-                        inputRef.current?.focus();
-                      },
-                    }}
-                    context={{
-                      projects,
-                      projectValue: resolvedProjectId,
-                      onProjectChange: setProjectIdDraft,
-                      familiarId: familiar.id ?? null,
-                      createProject,
-                      runtime: modelHarness,
-                      modelValue: composerModelValue,
-                      modelOptions: composerModelOptions,
-                      onPickRuntime: handleSelectRuntime,
-                      onPickModel: handleSelectModel,
-                      modelDisabled: busy,
-                      projectRoot: activeProjectRoot,
-                      onOpenUrl,
-                    }}
-                    linkedWork={{
-                      linkedContext,
-                      onOpenTask,
-                      sessionId,
-                      onLinkedContextChange: setLinkedContext,
-                      handoff: { turns: activePath, familiarId: familiar.id ?? null, projectId: projectIdDraft },
-                      sessionSettled: !activePendingTurn && Boolean(lastSettledAssistantTurn) && !lastSettledAssistantTurn?.error,
-                    }}
-                    improve={{
-                      dictation: dictation.available
-                        ? {
-                            listening: dictation.listening,
-                            toggle: dictation.toggle,
-                            disabled: busy && !dictation.listening,
-                          }
-                        : undefined,
-                      promptSnippets: {
-                        onSelect: () => setPromptSnippetsOpen(true),
-                      },
-                      enhance: {
-                        onEnhance: promptEnhance.enhance,
-                        disabled: busy || !input.trim(),
-                        loading: promptEnhance.state.phase === "loading",
-                      },
-                    }}
-                    response={{
-                      hostValue: composerHostValue,
-                      onHostPick: setRuntimeHost,
-                      sections: composerResponseSections,
-                      onSaveAsTemplate: () => setSaveTemplateSeed(input),
-                      saveAsTemplateDisabled: !input.trim(),
-                      indicator:
-                        composerHostValue !== LOCAL_HOST_ID ||
-                        permissionMode !== DEFAULT_PERMISSION_MODE ||
-                        thinkingEffort !== COMMAND_CONTROL_DEFAULTS.thinkingEffort ||
-                        responseSpeed !== COMMAND_CONTROL_DEFAULTS.responseSpeed,
-                    }}
-                  />
-                </div>
-                <div className="cave-composer-submit-row">
-                  {/* The compact send keeps its queue/cancel behavior in one
-                      stable action slot. */}
-                  {busy ? (
-                    <>
-                      <button
-                        type="button"
-                        onClick={() => void send()}
-                        disabled={!projectLaunchReady || (!input.trim() && attachments.length === 0)}
-                        data-typing={input.trim() ? "true" : undefined}
-                        className="cave-composer-send cave-composer-send--queue focus-ring transition-colors"
-                        title="Queue message"
-                        aria-label="Queue message"
-                      >
-                        <Icon name="ph:arrow-up-bold" width="var(--icon-2xs)" aria-hidden />
-                      </button>
-                      <button
-                        type="button"
-                        onClick={cancelSend}
-                        className="cave-composer-send cave-composer-send--busy focus-ring transition-colors"
-                        title="Cancel (esc)"
-                        aria-label="Cancel response"
-                      >
-                        <Icon name="ph:x-bold" width="var(--icon-2xs)" aria-hidden />
-                      </button>
-                    </>
-                  ) : (
-                    <button
-                      type="button"
-                      onClick={() => void send()}
-                      disabled={!projectLaunchReady || (!input.trim() && attachments.length === 0)}
-                      data-typing={input.trim() ? "true" : undefined}
-                      className="cave-composer-send focus-ring transition-colors"
-                      title={`Send message (${keys.enter})`}
-                      aria-label="Send message"
-                    >
-                      <Icon name="ph:arrow-up-bold" width="var(--icon-2xs)" aria-hidden />
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
-            {/* Footer band — the darker strip attached to the panel's
-                underside carries the context chips (project · model · branch
-                as separate controls, cave-g21f; each opens its own picker) on
-                the left and the linked-work strip (tasks · GitHub ·
-                link/create) on the right. */}
-            <div className="cave-composer-footer-band">
-              <div className="cave-composer-footer-band__cluster">
-                <ComposerContextChips
-                  projects={projects}
-                  projectValue={resolvedProjectId}
-                  onProjectChange={setProjectIdDraft}
-                  familiarId={familiar.id ?? null}
-                  createProject={createProject}
-                  runtime={modelHarness}
-                  modelValue={composerModelValue}
-                  modelOptions={composerModelOptions}
-                  onPickRuntime={handleSelectRuntime}
-                  onPickModel={handleSelectModel}
-                  modelDisabled={busy}
-                  projectRoot={activeProjectRoot}
-                  onOpenUrl={onOpenUrl}
-                  registerCurrentRoot={setupCandidateRoot ?? undefined}
-                  onRegisterCurrentRoot={
-                    setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
-                  }
-                />
-              </div>
-              {linkedContextRow}
-            </div>
-          </div>
-        </div>
-      </footer>
+      {inlineComposer ? null : composerNode}
       {taskSuggestion && sessionId ? (
         <FollowUpTaskReview
           open

--- a/src/styles/home-dashboard.css
+++ b/src/styles/home-dashboard.css
@@ -189,6 +189,20 @@
   background: none;
 }
 
+/* The dashboard root carries `select-none` — the launcher is chrome, not prose,
+   and dragging across it should not paint a selection. The composer now lives
+   INSIDE that root, so selection has to be handed back explicitly or the brief
+   cannot be selected with the mouse. user-select inherits, so one declaration
+   on the wrapper covers the textarea and every label under it.
+   Not theoretical: `user-select: none` computes onto the textarea, and WebKit
+   honours it on form controls — the desktop shell is WKWebView. Chromium still
+   allows keyboard select-all, which is why this survives a shallow check.
+   Restores parity with the docked composer, which has no select-none ancestor. */
+.home-dash__composer {
+  user-select: text;
+  -webkit-user-select: text;
+}
+
 /* The board clips (no-scroll design) and is a size container. Neither reaches
    the pickers: ui/popover portals to document.body, so it is neither clipped
    by the overflow nor trapped by container-type the way a fixed-position

--- a/src/styles/home-dashboard.css
+++ b/src/styles/home-dashboard.css
@@ -178,6 +178,23 @@
   margin-right: var(--space-2);
 }
 
+/* ── Inline composer (Chat.dc.html 2b) ──────────────────────────────────── */
+/* The brief sits under the hero on a brand-new chat, where the mock puts it.
+   It is ChatView's OWN composer handed down, so this only undoes the dock
+   chrome — the docked element is a page-width band with a hairline top and a
+   gradient that only reads correctly pinned to the bottom of the pane. */
+.home-dash__composer .cave-composer-dock {
+  padding: 0;
+  border-top: 0;
+  background: none;
+}
+
+/* The board clips (no-scroll design) and is a size container. Neither reaches
+   the pickers: ui/popover portals to document.body, so it is neither clipped
+   by the overflow nor trapped by container-type the way a fixed-position
+   descendant would be. Nothing to undo here — noted because the reverse has
+   bitten this repo before. */
+
 /* Empty board — the one state with no band to show. */
 .home-dash__work-empty {
   padding: 22px 15px;


### PR DESCRIPTION
Chat.dc.html 2b draws the brief directly beneath the hero, with the runtime / model / project / branch row under it, and **no dock at all**. Cave's composer is permanently docked, so the new-session page matched the mock only from "Start from" down.

## Moved, not rebuilt

The composer element is extracted to a variable in `chat-view.tsx` and rendered in exactly one of two positions — inline when `sessionId === null`, docked otherwise. `ChatNewDashboard` takes it as a slot and places it between hero and bands.

**The alternative was a second composer in the page**, which is what "add the brief composer" sounds like and would have been wrong: two textareas on screen, with draft, project, model, branch and enhance state forked between them.

The config row needed **no work at all**. `ComposerContextChips` (cave-g21f) already renders project / model / branch as individually labelled chips with their own picker popovers, and `EnhanceStrip` already covers 2b's Enhance control. They were only ever in the wrong place.

## Two container hazards, checked rather than assumed

`.home-dash--embed` and `.home-dash__board` are both `overflow: hidden`, and the board is `container-type: size` — which creates a containing block for `position: fixed` descendants, a trap this repo has hit before.

Neither reaches the pickers: `ui/popover` uses `createPortal` to `document.body`, so the popover is not a DOM descendant of either container. Clipping and fixed-trapping both require ancestry. Noted in the CSS so the next person doesn't "fix" it by loosening the overflow.

## CSS

Undoes dock chrome and nothing else — the docked padding, hairline top and bottom-anchored gradient read as a pinned band and are wrong inline. Placement stays layout's job; a pin asserts this override never grows `position` / `display` / `width`.

## Verification

- full app suite — **0 failures** (every test run individually, not through the short-circuiting runner)
- `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired` — clean
- driven in the built app: **one** composer, **one** textarea, ordered hero (243) → composer (311) → bands (474), no dock at the bottom

## New pins

`chat-inline-composer.test.ts` keeps the second-composer shortcut closed:

- exactly one `cave-composer-dock` element in the tree
- the dashboard may not contain `<textarea`, `usePromptEnhance`, `ComposerContextChips` or `EnhanceStrip` — it receives ChatView's
- hero → composer → bands ordering
- the inline override resets only dock chrome

## Not included

Three 2b affordances Cave has no equivalent for: **"Save as default"**, the **`⌘⏎ start`** hint, and **project-as-required** gating Start with the amber warn tint. Each is a new behaviour rather than a relocation, so they belong in their own change — say the word.