### PR TITLE
fix(x): align component contract with partial landing

### DIFF
--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -116,6 +116,8 @@ export async function GET(req: Request) {
       autoSelfReport: configEntry.autoSelfReport ?? false,
       asanaEnabled: configEntry.asanaEnabled,
       asanaWorkspaceGid: configEntry.asanaWorkspaceGid,
+      xResearchEnabled: configEntry.xResearchEnabled === true,
+      xPublishEnabled: configEntry.xPublishEnabled === true,
       ...(binding.omnigent ? { omnigent: binding.omnigent } : {}),
       avatarUrl: avatar
         ? `/api/familiars/${encodeURIComponent(f.id)}/avatar?v=${Math.round(avatar.mtimeMs)}&format=png`

--- a/src/components/familiar-x-section.test.ts
+++ b/src/components/familiar-x-section.test.ts
@@ -11,7 +11,6 @@ const source = readFileSync(componentUrl, "utf8");
 const css = readFileSync(cssUrl, "utf8");
 const brain = readFileSync(new URL("./familiar-studio-brain-tab.tsx", import.meta.url), "utf8");
 const familiarRoute = readFileSync(new URL("../app/api/familiars/route.ts", import.meta.url), "utf8");
-const oauthStartRoute = readFileSync(new URL("../app/api/x/oauth/start/route.ts", import.meta.url), "utf8");
 const types = readFileSync(new URL("../lib/types.ts", import.meta.url), "utf8");
 
 assert.match(source, /import "@\/styles\/familiar-x-section\.css"/);
@@ -169,10 +168,6 @@ assert.match(
   /cancelXOAuthFlow\(pending\.flowId\)/,
   "post-start browser failures cancel only their server-side OAuth listener",
 );
-assert.match(oauthStartRoute, /export async function DELETE\(req: Request\)/);
-assert.match(oauthStartRoute, /readJsonBody<\{ flowId\?: unknown \}>\(req, MAX_BODY_BYTES\)/);
-assert.match(oauthStartRoute, /xOAuthService\.cancel\(flowId\)/);
-assert.doesNotMatch(oauthStartRoute, /xOAuthService\.cancel\(\)/);
 
 assert.match(brain, /import \{ FamiliarXSection \} from "@\/components\/familiar-x-section"/);
 assert.match(


### PR DESCRIPTION
## Summary
- stop the Familiar X source-contract test from reading the intentionally unlanded `/api/x/oauth/start` route
- restore the two X grant flags in the familiar roster response so the landed component can retain its configured state

## Root cause
The partial X integration restored the component, types, and source-contract test, while the X route tree and familiar roster grant mapping remained reverted. CI stopped first on the missing route read; removing that stale route contract exposed the missing grant mapping.

## Verification
- `node --experimental-strip-types src/components/familiar-x-section.test.ts`
- `pnpm typecheck`
- `pnpm test:app` advanced past the original failure; an unrelated timing-sensitive `research-media-jobs.test.ts` case failed later and also reproduced independently under local load.