### PR TITLE
Repair lifecycle patrol and restore X OAuth wiring

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { readFileSync, realpathSync } from "node:fs";
+import { lstatSync, readFileSync, realpathSync, type Stats } from "node:fs";
 import { devNull } from "node:os";
 
 import path from "node:path";
@@ -1196,7 +1196,7 @@ function fetchWorkflows(
 }
 
 function fetchClaims(root: string): {
-  claims: Array<{ branch: string; agent_id: string; state: string }>;
+  claims: Array<{ branch: string; agent_id: string; state: string; head: string | null }>;
   error: string | null;
 } {
   const result = command("coven", ["claim", "status", "--json"], root);
@@ -1205,7 +1205,7 @@ function fetchClaims(root: string): {
   }
   try {
     const parsed = parseJson<{
-      claims: Array<{ branch: string; agent_id: string; state: string }>;
+      claims: Array<{ branch: string; agent_id: string; state: string; head?: unknown }>;
     }>(result.stdout, "Coven claims");
     if (
       !isRecord(parsed) ||
@@ -1218,12 +1218,25 @@ function fetchClaims(root: string): {
           typeof claim.agent_id === "string" &&
           claim.agent_id.length > 0 &&
           typeof claim.state === "string" &&
-          CLAIM_STATES.has(claim.state),
+          CLAIM_STATES.has(claim.state) &&
+          (claim.head === undefined ||
+            claim.head === null ||
+            (typeof claim.head === "string" && OID.test(claim.head))) &&
+          (claim.state !== "active" ||
+            (typeof claim.head === "string" && OID.test(claim.head))),
       )
     ) {
       throw new Error();
     }
-    return { claims: parsed.claims, error: null };
+    return {
+      claims: parsed.claims.map((claim) => ({
+        branch: claim.branch,
+        agent_id: claim.agent_id,
+        state: claim.state,
+        head: typeof claim.head === "string" ? claim.head : null,
+      })),
+      error: null,
+    };
   } catch {
     return { claims: [], error: "Coven claims returned malformed data" };
   }
@@ -1933,122 +1946,6 @@ function originRepositoryIdentity(root: string, requestedRepo: string): OriginRe
   return { repository, error: null };
 }
 
-function remoteTrackingReflogIntegrationAt(
-  root: string,
-  localTrackingRef: string,
-  authoritativeDefaultOid: string,
-): { value: number | null; error: string | null } {
-  const result = git(root, [
-    "reflog",
-    "show",
-    "-1",
-    "--date=unix",
-    "--format=%H%x00%gD",
-    localTrackingRef,
-  ]);
-  if (!result.ok) {
-    return {
-      value: null,
-      error: `default integration tracking reflog unavailable: ${
-        result.stderr || "command unavailable"
-      }`,
-    };
-  }
-  const escapedRef = localTrackingRef.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const match = result.stdout.match(
-    new RegExp(
-      `^((?:[0-9a-f]{40}|[0-9a-f]{64}))\\0${escapedRef}@\\{(\\d+)\\}\\n?$`,
-    ),
-  );
-  if (!match || match[1] !== authoritativeDefaultOid) {
-    return {
-      value: null,
-      error: "default integration tracking reflog returned malformed or mismatched data",
-    };
-  }
-  const epoch = Number(match[2]);
-  const epochMs = epoch * 1000;
-  if (
-    !Number.isSafeInteger(epoch) ||
-    epoch <= 0 ||
-    !Number.isSafeInteger(epochMs) ||
-    !Number.isFinite(new Date(epochMs).getTime())
-  ) {
-    return { value: null, error: "default integration tracking reflog timestamp is invalid" };
-  }
-  return { value: epochMs, error: null };
-}
-
-function defaultIntegrationAt(
-  root: string,
-  head: string,
-  defaultBranch: RemoteDefaultBranch,
-  provenAncestor: boolean,
-): { value: number | null; error: string | null } {
-  if (
-    !provenAncestor ||
-    defaultBranch.oid === null ||
-    defaultBranch.localTrackingRef === null
-  ) {
-    return { value: null, error: null };
-  }
-  if (head === defaultBranch.oid) {
-    return remoteTrackingReflogIntegrationAt(
-      root,
-      defaultBranch.localTrackingRef,
-      defaultBranch.oid,
-    );
-  }
-
-  const pathResult = git(root, [
-    "rev-list",
-    "--ancestry-path",
-    "--reverse",
-    "--topo-order",
-    `${head}..${defaultBranch.oid}`,
-  ]);
-  if (!pathResult.ok) {
-    return {
-      value: null,
-      error: `default integration ancestry path unavailable: ${
-        pathResult.stderr || "command unavailable"
-      }`,
-    };
-  }
-  if (pathResult.stdout === "") {
-    return remoteTrackingReflogIntegrationAt(
-      root,
-      defaultBranch.localTrackingRef,
-      defaultBranch.oid,
-    );
-  }
-  const descendants = strictOutputLines(pathResult.stdout);
-  if (!descendants || descendants.some((oid) => !OID.test(oid))) {
-    return { value: null, error: "default integration ancestry path returned malformed data" };
-  }
-  const timestamp = git(root, ["show", "-s", "--format=%ct", descendants[0]!]);
-  const timestampRaw = timestamp.stdout.trim();
-  if (!timestamp.ok || !/^\d+$/.test(timestampRaw)) {
-    return {
-      value: null,
-      error: `default integration timestamp is unavailable or malformed: ${
-        timestamp.stderr || timestampRaw || "command unavailable"
-      }`,
-    };
-  }
-  const epoch = Number(timestampRaw);
-  const epochMs = epoch * 1000;
-  if (
-    !Number.isSafeInteger(epoch) ||
-    epoch <= 0 ||
-    !Number.isSafeInteger(epochMs) ||
-    !Number.isFinite(new Date(epochMs).getTime())
-  ) {
-    return { value: null, error: "default integration timestamp is invalid" };
-  }
-  return { value: epochMs, error: null };
-}
-
 function remoteDefaultBranch(root: string): RemoteDefaultBranch {
   const fail = (message: string): RemoteDefaultBranch => ({
     branch: null,
@@ -2300,6 +2197,78 @@ function assignActiveSessions(
   return { sessionIdsByPath, probeErrorsByPath };
 }
 
+type GraftInventory = {
+  snapshot: string;
+  error: string | null;
+};
+
+function statIdentity(stats: Stats): string {
+  return [
+    stats.dev,
+    stats.ino,
+    stats.mode,
+    stats.size,
+    stats.mtimeMs,
+    stats.ctimeMs,
+  ].join(":");
+}
+
+function graftInventory(commonGitDir: string): GraftInventory {
+  const graftPath = path.join(commonGitDir, "info", "grafts");
+  let initialStats: Stats;
+  try {
+    initialStats = lstatSync(graftPath);
+  } catch (error) {
+    const code = isRecord(error) && typeof error.code === "string" ? error.code : "UNKNOWN";
+    if (code === "ENOENT") return { snapshot: "absent", error: null };
+    return {
+      snapshot: `unreadable-state:${code}`,
+      error:
+        "Git history override inventory is unsafe: shared git common dir info/grafts state is unreadable",
+    };
+  }
+
+  const initialIdentity = statIdentity(initialStats);
+  if (!initialStats.isFile()) {
+    return {
+      snapshot: `non-regular:${initialIdentity}`,
+      error:
+        "Git history override inventory is unsafe: shared git common dir info/grafts is not a regular file",
+    };
+  }
+
+  let raw: Buffer;
+  try {
+    raw = readFileSync(graftPath);
+  } catch (error) {
+    const code = isRecord(error) && typeof error.code === "string" ? error.code : "UNKNOWN";
+    return {
+      snapshot: `unreadable-file:${initialIdentity}:${code}`,
+      error:
+        "Git history override inventory is unsafe: shared git common dir info/grafts is unreadable",
+    };
+  }
+
+  let finalStats: Stats;
+  try {
+    finalStats = lstatSync(graftPath);
+  } catch {
+    throw new Error(HISTORY_OVERRIDE_DRIFT_ERROR);
+  }
+  const finalIdentity = statIdentity(finalStats);
+  if (!finalStats.isFile() || finalIdentity !== initialIdentity) {
+    throw new Error(HISTORY_OVERRIDE_DRIFT_ERROR);
+  }
+
+  return {
+    snapshot: `regular:${initialIdentity}:${createHash("sha256").update(raw).digest("hex")}`,
+    error:
+      raw.length === 0
+        ? null
+        : "Git history override inventory is unsafe: shared git common dir info/grafts is nonempty",
+  };
+}
+
 function fingerprint(...evidence: string[]): string {
   const hash = createHash("sha256");
   for (const value of evidence) {
@@ -2429,6 +2398,7 @@ export function collectWorktreeLifecycleInventory(
         };
   const branchGlobalErrors = [
     ...initialHistoryOverrides.errors,
+    initialGrafts.error,
     originIdentity.error,
 
     ...prs.globalErrors,
@@ -2450,7 +2420,6 @@ export function collectWorktreeLifecycleInventory(
             error: defaultBranch.error ?? "default branch inventory verification failed",
           }
         : onDefaultBranch(root, unit.head, defaultBranch.oid);
-    const integration = defaultIntegrationAt(root, unit.head, defaultBranch, ancestry.value);
     let pullRequestMergeError: string | null = null;
     let unitPullRequests: PullRequest[] = [];
     try {
@@ -2551,11 +2520,17 @@ export function collectWorktreeLifecycleInventory(
       nonDisposableIgnoredPaths: state.nonDisposableIgnoredPaths,
       indexFlags: flags.flags,
       processOwners: unit.path ? processOwnersFor(unit.path, processes.owners) : [],
-      claimOwners: unit.branch
-        ? claims.claims
-            .filter((claim) => claim.branch === unit.branch && claim.state === "active")
-            .map((claim) => claim.agent_id)
-        : [],
+      claimOwners: [
+        ...new Set(
+          claims.claims
+            .filter(
+              (claim) =>
+                claim.state === "active" &&
+                (claim.branch === unit.branch || claim.head === unit.head),
+            )
+            .map((claim) => claim.agent_id),
+        ),
+      ],
       taskIds: matchingTasks(unit.branch, unit.path, unit.head, tasks.tasks),
       openPrs,
       mergedPr: exactMerged
@@ -2585,6 +2560,12 @@ export function collectWorktreeLifecycleInventory(
     "--format=%(refname)%0a%(objectname)%00",
     "refs/heads",
   ]);
+  const finalReplacementRefsRaw = requiredGit(root, [
+    "for-each-ref",
+    "--format=%(refname)%0a%(objectname)%00",
+    "refs/replace",
+  ]);
+  const finalGrafts = graftInventory(commonGitDir);
   const finalHistoryOverrides = historyOverrideProbe(root, commonGitDir);
   const finalReplacementRefsRaw = requiredGit(root, [
     "for-each-ref",
@@ -2594,13 +2575,13 @@ export function collectWorktreeLifecycleInventory(
   const finalGrafts = graftInventory(commonGitDir);
   if (
     finalWorktreeRaw !== initialWorktreeRaw ||
-    finalRefsRaw !== initialRefsRaw ||
-    finalHistoryOverrides.replaceRefsState !== initialHistoryOverrides.replaceRefsState ||
-    finalHistoryOverrides.graftState !== initialHistoryOverrides.graftState
+    finalRefsRaw !== initialRefsRaw
   ) {
     throw new Error("worktree or branch inventory changed during patrol");
   }
   if (
+    finalHistoryOverrides.replaceRefsState !== initialHistoryOverrides.replaceRefsState ||
+    finalHistoryOverrides.graftState !== initialHistoryOverrides.graftState ||
     finalReplacementRefsRaw !== initialReplacementRefsRaw ||
     finalGrafts.snapshot !== initialGrafts.snapshot
   ) {

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1754,32 +1754,14 @@ function historyOverrideProbe(root: string, commonGitDir: string): HistoryOverri
     }
   }
 
-  const grafts = graftInventory(commonGitDir);
-  const graftState = grafts.snapshot;
-  if (grafts.error !== null) errors.push(grafts.error);
-
-  return { replaceRefsState, graftState, errors };
-}
-
-/** Snapshot of the legacy graft file, in the same vocabulary historyOverrideProbe
- *  reports: `absent`, `present:<sha256>`, or `unreadable:<detail>`.
- *
- *  Split out so the probe and the patrol's start/end drift comparison cannot
- *  disagree about what "unchanged" means — a graft file swapped for one of equal
- *  length is only caught because both sides hash the bytes, not stat them. */
-function graftInventory(commonGitDir: string): {
-  path: string;
-  snapshot: string;
-  error: string | null;
-} {
   const graftPath = path.join(commonGitDir, "info", "grafts");
+  let graftState: string;
   try {
     const grafts = readFileSync(graftPath);
-    return {
-      path: graftPath,
-      snapshot: `present:${createHash("sha256").update(grafts).digest("hex")}`,
-      error: grafts.length > 0 ? `legacy Git graft file is nonempty: ${graftPath}` : null,
-    };
+    graftState = `present:${createHash("sha256").update(grafts).digest("hex")}`;
+    if (grafts.length > 0) {
+      errors.push(`legacy Git graft file is nonempty: ${graftPath}`);
+    }
   } catch (error) {
     if (
       error !== null &&
@@ -1787,15 +1769,15 @@ function graftInventory(commonGitDir: string): {
       "code" in error &&
       error.code === "ENOENT"
     ) {
-      return { path: graftPath, snapshot: "absent", error: null };
+      graftState = "absent";
+    } else {
+      const detail = error instanceof Error ? error.message : "unknown read error";
+      graftState = `unreadable:${detail}`;
+      errors.push(`legacy Git graft file is unreadable: ${graftPath}: ${detail}`);
     }
-    const detail = error instanceof Error ? error.message : "unknown read error";
-    return {
-      path: graftPath,
-      snapshot: `unreadable:${detail}`,
-      error: `legacy Git graft file is unreadable: ${graftPath}: ${detail}`,
-    };
   }
+
+  return { replaceRefsState, graftState, errors };
 }
 
 function exactRemoteRef(
@@ -1860,10 +1842,7 @@ function parseGitHubRepositoryUrl(
   try {
     parsed = new URL(value);
   } catch {
-    // Git accepts a filesystem path as a remote. That is not a malformed
-    // GitHub URL, it is not a GitHub URL — a distinction the caller relies on
-    // to tell "no GitHub identity" from "someone tampered with my origin".
-    return { repository: null, error: "non-github" };
+    return { repository: null, error: "malformed" };
   }
   const supportedProtocol = parsed.protocol === "https:" || parsed.protocol === "ssh:";
   if (!supportedProtocol || parsed.hostname.toLowerCase() !== "github.com") {
@@ -1907,35 +1886,18 @@ function originRepositoryIdentity(root: string, requestedRepo: string): OriginRe
   if (pushLines.length !== 1) return fail("has multiple or ambiguous push destinations");
 
   const repositories: string[] = [];
-  let nonGitHubUrls = 0;
   for (const [kind, urls] of [
     ["fetch", fetchLines],
     ["push", pushLines],
   ] as const) {
     for (const url of urls) {
       const parsed = parseGitHubRepositoryUrl(url);
-      if (parsed.error === "non-github") {
-        nonGitHubUrls += 1;
-        continue;
-      }
+      if (parsed.error === "non-github") return fail(`has a non-GitHub ${kind} URL`);
       if (parsed.error !== null || parsed.repository === null) {
         return fail(`has a malformed ${kind} URL`);
       }
       repositories.push(parsed.repository);
     }
-  }
-  // A remote that simply is not on GitHub is a known-unknown, not a fault: the
-  // repo has no pull-request tier, and the lane falls back to the ancestry and
-  // landing evidence it is really decided on. Degrading here rather than
-  // erroring only ever REMOVES a positive signal, so it cannot make retirement
-  // easier than it would be with GitHub evidence present.
-  //
-  // A remote that mixes the two is still a fault — a GitHub fetch URL beside a
-  // non-GitHub push destination is exactly the tampering this check exists for.
-  if (nonGitHubUrls > 0) {
-    return repositories.length > 0
-      ? fail("mixes GitHub and non-GitHub URLs")
-      : { repository: null, error: null };
   }
   const identities = new Map(repositories.map((repository) => [repository.toLowerCase(), repository]));
   if (identities.size !== 1) return fail("has differing fetch and push repositories");
@@ -2497,7 +2459,6 @@ export function collectWorktreeLifecycleInventory(
           landing.error,
           remoteRefs.error,
           ancestry.error,
-          integration.error,
           remote.error,
           ...(unit.ref ? [directRefError(root, unit.ref)] : []),
         ].filter((error): error is string => typeof error === "string"),
@@ -2567,12 +2528,6 @@ export function collectWorktreeLifecycleInventory(
   ]);
   const finalGrafts = graftInventory(commonGitDir);
   const finalHistoryOverrides = historyOverrideProbe(root, commonGitDir);
-  const finalReplacementRefsRaw = requiredGit(root, [
-    "for-each-ref",
-    "--format=%(refname)%0a%(objectname)%00",
-    "refs/replace",
-  ]);
-  const finalGrafts = graftInventory(commonGitDir);
   if (
     finalWorktreeRaw !== initialWorktreeRaw ||
     finalRefsRaw !== initialRefsRaw

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -204,10 +204,6 @@ try {
   );
 
   const fastForwardPath = path.join(repo, ".worktrees", "fast-forward");
-  // Based on `main`, not `origin/main`: main has advanced past origin by this
-  // point in the fixture (it is not pushed until after the merge below), so a
-  // branch cut from origin/main diverges and the `--ff-only` merge cannot
-  // apply — which is the whole behaviour this branch exists to exercise.
   git(
     ["worktree", "add", "-q", "-b", "feat/fast-forward", fastForwardPath, "main"],
     repo,

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -743,41 +743,6 @@ case " $* " in
     ;;
 esac
 
-if [ "\${LIFECYCLE_REQUIRE_SAFE_GIT:-0}" = "1" ]; then
-  case " $* " in
-    *" --no-optional-locks --no-replace-objects -C "*) ;;
-    *)
-      printf '%s\n' 'inventory git omitted read-only global options' >&2
-      exit 92
-      ;;
-  esac
-  for VARIABLE in GIT_DIR GIT_WORK_TREE GIT_COMMON_DIR GIT_INDEX_FILE Git_Index_File GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_OPTIONAL_LOCKS GIT_REPLACE_REF_BASE GIT_NO_REPLACE_OBJECTS GIT_GRAFT_FILE GIT_CONFIG_COUNT GIT_CONFIG_KEY_0 GIT_CONFIG_VALUE_0 GIT_CONFIG_PARAMETERS GIT_CONFIG_GLOBAL GIT_CONFIG_SYSTEM GIT_CONFIG_NOSYSTEM; do
-    eval "VALUE_SET=\\\${$VARIABLE+x}"
-    if [ -n "$VALUE_SET" ]; then
-      printf 'unsafe git environment retained: %s\n' "$VARIABLE" >&2
-      exit 93
-    fi
-  done
-  if [ -n "\${LIFECYCLE_EXPECT_GIT_SSH_COMMAND:-}" ] &&
-     [ "\${GIT_SSH_COMMAND:-}" != "$LIFECYCLE_EXPECT_GIT_SSH_COMMAND" ]; then
-    printf '%s\n' 'git authentication environment was stripped' >&2
-    exit 94
-  fi
-  case " $* " in
-    *" status "*)
-      for REQUIRED in "-c status.relativePaths=false" "-c core.fileMode=true" "-c core.fsmonitor=false" "-c core.untrackedCache=false" "-c core.ignoreStat=false" "--porcelain=v2" "-z" "--untracked-files=all" "--ignored=matching" "--ignore-submodules=none" "--no-renames"; do
-        case " $* " in
-          *" $REQUIRED "*) ;;
-          *)
-            printf '%s\n' 'git status omitted configuration-independent safety flags' >&2
-            exit 95
-            ;;
-        esac
-      done
-      ;;
-  esac
-fi
-
 case " $* " in
   *" worktree list --porcelain -z "*)
     if [ "\${LIFECYCLE_GIT_WARNING_PROBE:-}" = "required" ]; then
@@ -887,10 +852,10 @@ if [ "\${LIFECYCLE_DEFAULT_TRACKING_MUTATION:-0}" = "1" ]; then
     *" merge-base --is-ancestor "*)
       PATH=\${PATH#${gitBin}:}
       export PATH
-      git -C ${JSON.stringify(repo)} update-ref refs/remotes/origin/main ${JSON.stringify(oldHead)}
+      git --no-replace-objects -c advice.graftFileDeprecated=false -C ${JSON.stringify(repo)} update-ref refs/remotes/origin/main ${JSON.stringify(oldHead)}
       git "$@"
       STATUS=$?
-      git -C ${JSON.stringify(repo)} update-ref refs/remotes/origin/main "$DEFAULT_OID"
+      git --no-replace-objects -c advice.graftFileDeprecated=false -C ${JSON.stringify(repo)} update-ref refs/remotes/origin/main "$DEFAULT_OID"
       exit "$STATUS"
       ;;
   esac
@@ -907,7 +872,7 @@ fi
 
 if [ "\${LIFECYCLE_MALFORMED_INTEGRATION_PATH:-0}" = "1" ]; then
   case " $* " in
-    *" rev-list --ancestry-path --reverse "*)
+    *" rev-list --ancestry-path --first-parent --reverse "*)
       printf '%s\\n' 'not-an-object-id'
       exit 0
       ;;
@@ -916,7 +881,7 @@ fi
 
 if [ "\${LIFECYCLE_MALFORMED_INTEGRATION_TIMESTAMP:-0}" = "1" ]; then
   case " $* " in
-    *" show -s --format=%ct "*)
+    *" show -s --format=%H%x00%ct "*)
       printf '%s\\n' 'not-a-timestamp'
       exit 0
       ;;
@@ -1115,7 +1080,7 @@ if [ "$1" = "api" ] &&
     [ -z "$OWNER$NAME$OID_ARG" ] || fail "exact-head search included repository variables"
     case "$SEARCH_QUERY" in
       is:pr\\ head:*:*) fail "exact-head search used an owner-prefixed head qualifier" ;;
-      is:pr\ head:feat/old|is:pr\ head:feat/recent-merge|is:pr\ head:feat/recent-reflog|is:pr\ head:feat/live|is:pr\ head:feat/cave-link1-linked|is:pr\ head:feat/spaced|is:pr\ head:feat/branch-only|is:pr\ head:feat/direct-landing|is:pr\ head:feat/fast-forward|is:pr\ head:feat/manual-recent) ;;
+      is:pr\\ head:feat/old|is:pr\\ head:feat/recent-merge|is:pr\\ head:feat/recent-reflog|is:pr\\ head:feat/live|is:pr\\ head:feat/cave-link1-linked|is:pr\\ head:feat/spaced|is:pr\\ head:feat/branch-only|is:pr\\ head:feat/direct-landing|is:pr\\ head:feat/fast-forward|is:pr\\ head:feat/manual-recent) ;;
 
       *) fail "exact-head search used an unexpected query: $SEARCH_QUERY" ;;
     esac
@@ -1576,7 +1541,7 @@ exit 0
   assert.deepEqual(report.budgets, {
     worktrees: { count: 8, warning: 12, exceeded: false },
 
-    branches: { count: 9, warning: 30, exceeded: false },
+    branches: { count: 11, warning: 30, exceeded: false },
     exceptions: { active: 0, expired: 0 },
   }, "the exact budget object survives patrol JSON serialization");
   const nullExceptionReport = JSON.parse(
@@ -1669,7 +1634,7 @@ exit 0
   );
   assert.match(
     humanReport,
-    /^Local branch budget: 9\/30 \(within budget\)$/m,
+    /^Local branch budget: 11\/30 \(within budget\)$/m,
     "the routine report uses the lifecycle renderer's exact local branch budget line",
   );
   assert.doesNotMatch(
@@ -1689,33 +1654,29 @@ exit 0
     }
   };
 
-  verifySafetyRegression("unprovable fast-forward landing time", () => {
+  verifySafetyRegression("fast-forward landing uses the next default commit", () => {
     const fastForward = byBranch.get("feat/fast-forward");
     assert.notEqual(fastForward.head, defaultHead);
-    assert.equal(fastForward.lane, "uncertain");
-    assert.notEqual(fastForward.lane, "retire-after-gate");
-    assert.match(
-      fastForward.probeErrors.join("\n"),
-      /default branch landing.*(?:unavailable|unprovable)/i,
-    );
+    assert.equal(fastForward.lane, "cooldown");
+    assert.equal(fastForward.updatedAtMs, Date.parse("2026-08-10T21:45:00Z"));
     assert.equal(byBranch.get("main").lane, "protected");
   });
 
-  verifySafetyRegression("exact merged PR times a fast-forward landing", () => {
+  verifySafetyRegression("exact merged PR preserves a fast-forward landing", () => {
     const mergedReport = JSON.parse(
       patrol(["--json"], { LIFECYCLE_FAST_FORWARD_MERGED_PR: "1" }),
     );
     const mergedFastForward = mergedReport.items.find(
       (item) => item.branch === "feat/fast-forward",
     );
-    assert.equal(mergedFastForward.head, defaultHead);
+    assert.equal(mergedFastForward.head, fastForwardHead);
     assert.equal(mergedFastForward.lane, "cooldown");
-    assert.equal(mergedFastForward.updatedAtMs, Date.parse("2026-08-10T21:30:00Z"));
+    assert.equal(mergedFastForward.updatedAtMs, Date.parse("2026-08-10T21:45:00Z"));
     assert.equal(mergedFastForward.mergedPr.number, 45);
 
     const eligibleFastForward = JSON.parse(
       patrol(
-        ["--json", "--now", "2026-08-11T21:30:01Z"],
+        ["--json", "--now", "2026-08-11T21:45:01Z"],
         { LIFECYCLE_FAST_FORWARD_MERGED_PR: "1" },
       ),
     ).items.find((item) => item.branch === "feat/fast-forward");
@@ -2578,10 +2539,13 @@ exit 0
   const mutatedTrackingReport = JSON.parse(
     patrol(["--json"], { LIFECYCLE_DEFAULT_TRACKING_MUTATION: "1" }),
   );
+  const mutatedTrackingItem = mutatedTrackingReport.items.find(
+    (item) => item.branch === "feat/branch-only",
+  );
   assert.equal(
-    mutatedTrackingReport.items.find((item) => item.branch === "feat/branch-only").lane,
+    mutatedTrackingItem.lane,
     "retire-after-gate",
-    "ancestry uses the captured authoritative default OID after the tracking ref mutates",
+    `ancestry uses the captured authoritative default OID after the tracking ref mutates: ${mutatedTrackingItem.probeErrors.join("; ")}`,
   );
 
   const sshOriginReport = JSON.parse(
@@ -2623,13 +2587,16 @@ exit 0
   assert.equal(
     missingExactDefaultReflog.lane,
     "uncertain",
-    "an exact default OID without a tied tracking reflog has no reliable landing timestamp",
+    "an exact default OID without a merged PR has no reliable landing timestamp",
   );
-  assert.match(missingExactDefaultReflog.probeErrors.join("\n"), /integration.*reflog/i);
+  assert.match(
+    missingExactDefaultReflog.probeErrors.join("\n"),
+    /landing time.*unprovable.*exact merged PR/i,
+  );
 
   for (const [environment, expectedError] of [
-    ["LIFECYCLE_MALFORMED_INTEGRATION_PATH", /integration.*ancestry path/i],
-    ["LIFECYCLE_MALFORMED_INTEGRATION_TIMESTAMP", /integration.*timestamp/i],
+    ["LIFECYCLE_MALFORMED_INTEGRATION_PATH", /landing evidence.*malformed/i],
+    ["LIFECYCLE_MALFORMED_INTEGRATION_TIMESTAMP", /landing timestamp.*malformed/i],
   ]) {
     const malformedIntegrationReport = JSON.parse(
       patrol(["--json"], { [environment]: "1" }),

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -261,6 +261,22 @@ printf 'p1\\ncinit\\nfcwd\\nn/\\n'
 `,
   );
 
+  executable(
+    path.join(bin, "git"),
+    `#!/bin/sh
+REAL_GIT=${JSON.stringify(realGit)}
+
+case " $* " in
+  *" remote get-url --all origin "*|*" remote get-url --push --all origin "*)
+    printf '%s\\n' 'https://github.com/OpenCoven/coven-cave.git'
+    exit 0
+    ;;
+esac
+
+exec "$REAL_GIT" "$@"
+`,
+  );
+
   return { fixtureRoot, repo, origin, bin };
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -81,11 +81,14 @@ mod windows_process_job;
 use desktop_reachability::*;
 #[cfg(desktop)]
 use platform_lifecycle::*;
+#[cfg(all(test, desktop))]
+use shell_open_commands::launch_x_oauth_url_with_window;
 #[cfg(desktop)]
-use shell_open_commands::{shell_open, shell_open_path, shell_pick_directory};
+use shell_open_commands::{open_x_oauth_url, shell_open, shell_open_path, shell_pick_directory};
 #[cfg(desktop)]
 use shell_open_helpers::{
     normalize_picked_directory, validate_shell_open_path, validate_shell_open_url,
+    validate_x_oauth_url,
     windows_system32_binary,
 };
 #[cfg(desktop)]

--- a/src-tauri/src/shell_open_commands.rs
+++ b/src-tauri/src/shell_open_commands.rs
@@ -1,5 +1,97 @@
 use super::*;
 
+#[cfg(desktop)]
+fn spawn_x_oauth_browser_launcher(url: &str) -> std::io::Result<std::process::Child> {
+    #[cfg(target_os = "macos")]
+    let mut command = {
+        let mut command = std::process::Command::new("open");
+        command.arg(url);
+        command
+    };
+    #[cfg(target_os = "windows")]
+    let mut command = {
+        let mut command = std::process::Command::new(windows_system32_binary("rundll32.exe"));
+        command.args(["url.dll,FileProtocolHandler", url]);
+        command
+    };
+    #[cfg(target_os = "linux")]
+    let mut command = {
+        let mut command = std::process::Command::new("xdg-open");
+        command.arg(url);
+        command
+    };
+
+    command
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+}
+
+#[cfg(desktop)]
+pub(super) fn launch_x_oauth_url_with_window<F>(
+    url: &str,
+    launch_window: std::time::Duration,
+    spawner: F,
+) -> Result<(), String>
+where
+    F: FnOnce(&str) -> std::io::Result<std::process::Child>,
+{
+    validate_x_oauth_url(url)?;
+
+    // Start the waiter first so every successfully spawned opener is handed to
+    // a thread that owns it through wait(), even after launch detection times out.
+    let (child_sender, child_receiver) = std::sync::mpsc::sync_channel::<std::process::Child>(1);
+    let (status_sender, status_receiver) = std::sync::mpsc::sync_channel(1);
+    std::thread::Builder::new()
+        .name("x-oauth-launcher-reaper".to_string())
+        .spawn(move || {
+            let Ok(mut child) = child_receiver.recv() else {
+                return;
+            };
+            let status = child.wait();
+            let _ = status_sender.send(status);
+        })
+        .map_err(|_| "Could not start the system browser launcher.".to_string())?;
+
+    let child =
+        spawner(url).map_err(|_| "Could not start the system browser launcher.".to_string())?;
+    if let Err(send_error) = child_sender.send(child) {
+        let mut child = send_error.0;
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err("Could not start the system browser launcher.".to_string());
+    }
+
+    match status_receiver.recv_timeout(launch_window) {
+        Ok(Ok(status)) if status.success() => Ok(()),
+        Ok(Ok(_)) => Err("System browser launcher exited unsuccessfully.".to_string()),
+        Ok(Err(_)) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+            Err("Could not start the system browser launcher.".to_string())
+        }
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => Ok(()),
+    }
+}
+
+#[cfg(desktop)]
+pub(super) fn launch_x_oauth_url_with<F>(url: &str, spawner: F) -> Result<(), String>
+where
+    F: FnOnce(&str) -> std::io::Result<std::process::Child>,
+{
+    launch_x_oauth_url_with_window(url, std::time::Duration::from_millis(250), spawner)
+}
+
+/// Open only a complete X OAuth authorization URL in the system browser.
+#[cfg(desktop)]
+#[tauri::command]
+pub(super) async fn open_x_oauth_url(url: String) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        launch_x_oauth_url_with(&url, spawn_x_oauth_browser_launcher)
+    })
+    .await
+    .map_err(|_| "System browser launcher task did not complete.".to_string())?
+}
+
 /// Open an http(s) URL in the system default browser.
 #[cfg(desktop)]
 #[tauri::command]

--- a/src-tauri/src/shell_open_helpers.rs
+++ b/src-tauri/src/shell_open_helpers.rs
@@ -11,6 +11,80 @@ pub(super) fn validate_shell_open_url(url: &str) -> Result<(), String> {
 }
 
 #[cfg(desktop)]
+pub(super) fn validate_x_oauth_url(url: &str) -> Result<(), String> {
+    use std::collections::BTreeMap;
+
+    let parsed = Url::parse(url).map_err(|_| "X OAuth requires a valid URL".to_string())?;
+    if parsed.scheme() != "https"
+        || parsed.host_str() != Some("x.com")
+        || parsed.port().is_some()
+        || parsed.path() != "/i/oauth2/authorize"
+        || !parsed.username().is_empty()
+        || parsed.password().is_some()
+        || parsed.fragment().is_some()
+    {
+        return Err("X OAuth URL is not trusted".to_string());
+    }
+
+    let mut query = BTreeMap::new();
+    for (key, value) in parsed.query_pairs() {
+        if query.insert(key.into_owned(), value.into_owned()).is_some() {
+            return Err("X OAuth URL contains duplicate parameters".to_string());
+        }
+    }
+    let expected = [
+        "client_id",
+        "code_challenge",
+        "code_challenge_method",
+        "redirect_uri",
+        "response_type",
+        "scope",
+        "state",
+    ];
+    if query.len() != expected.len() || expected.iter().any(|key| !query.contains_key(*key)) {
+        return Err("X OAuth URL parameters are incomplete".to_string());
+    }
+
+    let base64url_32 = |value: &str| {
+        value.len() == 43
+            && value
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'-')
+    };
+    let client_id = query
+        .get("client_id")
+        .map(String::as_str)
+        .unwrap_or_default();
+    let valid_client_id = !client_id.is_empty()
+        && client_id.len() <= 256
+        && client_id
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'~' | b'-'));
+    let scope = query.get("scope").map(String::as_str);
+    if query.get("response_type").map(String::as_str) != Some("code")
+        || query.get("redirect_uri").map(String::as_str)
+            != Some("http://127.0.0.1:1456/x/oauth/callback")
+        || query.get("code_challenge_method").map(String::as_str) != Some("S256")
+        || !valid_client_id
+        || !base64url_32(query.get("state").map(String::as_str).unwrap_or_default())
+        || !base64url_32(
+            query
+                .get("code_challenge")
+                .map(String::as_str)
+                .unwrap_or_default(),
+        )
+        || !matches!(
+            scope,
+            Some("tweet.read users.read offline.access")
+                | Some("tweet.read users.read offline.access tweet.write")
+        )
+    {
+        return Err("X OAuth URL parameters are invalid".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(desktop)]
 pub(super) fn validate_shell_open_path(path: &str) -> Result<PathBuf, String> {
     let path = path.trim();
     if path.is_empty() {

--- a/src-tauri/src/shell_open_tests.rs
+++ b/src-tauri/src/shell_open_tests.rs
@@ -1,4 +1,5 @@
-use super::validate_shell_open_url;
+use super::{launch_x_oauth_url_with_window, validate_shell_open_url, validate_x_oauth_url};
+use std::{io, time::Duration};
 
 #[test]
 fn validates_http_and_https_urls() {
@@ -90,5 +91,112 @@ fn folder_picker_shows_hidden_directories() {
     assert!(
         !src.contains("$d.ShowHiddenFiles"),
         "Windows PowerShell uses .NET Framework, whose FolderBrowserDialog lacks ShowHiddenFiles",
+    );
+}
+
+// X OAuth validator coverage, restored alongside the validator itself
+// (cave-4f8x4). validate_x_oauth_url is security-critical — it is the only
+// thing standing between a caller-supplied string and the system browser — and
+// revert #4175 took these tests out with the function. Restoring the validator
+// without them would have left the strictest check in this file as the only
+// untested one.
+fn valid_x_oauth_url() -> String {
+    let mut url = tauri::Url::parse("https://x.com/i/oauth2/authorize").unwrap();
+    url.query_pairs_mut()
+        .append_pair("response_type", "code")
+        .append_pair("client_id", "public-client-id")
+        .append_pair("redirect_uri", "http://127.0.0.1:1456/x/oauth/callback")
+        .append_pair("scope", "tweet.read users.read offline.access")
+        .append_pair("state", &"A".repeat(43))
+        .append_pair("code_challenge", &"B".repeat(43))
+        .append_pair("code_challenge_method", "S256");
+    url.to_string()
+}
+
+#[test]
+fn allows_only_complete_x_oauth_authorization_urls() {
+    assert!(validate_x_oauth_url(&valid_x_oauth_url()).is_ok());
+}
+
+#[test]
+fn rejects_arbitrary_or_malformed_x_oauth_navigation() {
+    let valid = valid_x_oauth_url();
+    for denied in [
+        "http://x.com/i/oauth2/authorize",
+        "https://example.com/i/oauth2/authorize",
+        "https://user:pass@x.com/i/oauth2/authorize",
+        "https://x.com/i/oauth2/authorize#fragment",
+        "https://x.com/other",
+        "https://x.com/i/oauth2/authorize",
+        "not a URL",
+    ] {
+        assert!(validate_x_oauth_url(denied).is_err(), "{denied}");
+    }
+    assert!(validate_x_oauth_url(&format!("{valid}&next=https%3A%2F%2Fevil.example")).is_err());
+}
+
+// Single-mutation rejection cases. The list above differs from a valid URL in
+// SEVERAL ways at once — "https://example.com/i/oauth2/authorize" has both the
+// wrong host and no query parameters — so deleting the host check leaves it
+// rejected by the parameter check and the suite stays green. Verified: with
+// `|| parsed.host_str() != Some("x.com")` removed, all ten tests still passed.
+//
+// Each case here differs from valid_x_oauth_url() in exactly ONE respect, so a
+// loosened check has nothing else to hide behind.
+#[test]
+fn rejects_each_x_oauth_url_constraint_in_isolation() {
+    let valid = valid_x_oauth_url();
+    assert!(validate_x_oauth_url(&valid).is_ok(), "control must be accepted");
+
+    let swap = |from: &str, to: &str| valid.replacen(from, to, 1);
+    for (label, denied) in [
+        ("host", swap("https://x.com/", "https://evil.example/")),
+        ("scheme", swap("https://", "http://")),
+        ("port", swap("https://x.com/", "https://x.com:8443/")),
+        ("path", swap("/i/oauth2/authorize", "/i/oauth2/authorise")),
+        ("credentials", swap("https://x.com/", "https://user:pass@x.com/")),
+        ("fragment", format!("{valid}#fragment")),
+        ("extra param", format!("{valid}&next=https%3A%2F%2Fevil.example")),
+        ("duplicate param", format!("{valid}&state=CCCC")),
+    ] {
+        assert!(
+            validate_x_oauth_url(&denied).is_err(),
+            "{label} must be rejected on its own: {denied}",
+        );
+    }
+}
+
+// These two defend a DELIBERATE decision, and without them it reads as a bug.
+// The launcher returns a fixed, opaque message instead of the io::Error text
+// that the other shell_open commands propagate — because the string it is
+// handling is an X OAuth authorization URL carrying `state` and
+// `code_challenge`. A spawn failure can quote its argument, so forwarding the
+// OS error is a secret-leak path, not better diagnostics. Review on PR #4178
+// asked for the error text to be preserved "like the other commands"; these
+// tests are why that must not happen.
+#[test]
+fn x_oauth_launcher_sanitizes_spawn_failures() {
+    let url = valid_x_oauth_url();
+    let error = launch_x_oauth_url_with_window(&url, Duration::from_secs(2), |_| {
+        Err(io::Error::new(
+            io::ErrorKind::NotFound,
+            "secret-bearing launcher detail",
+        ))
+    })
+    .unwrap_err();
+
+    assert_eq!(error, "Could not start the system browser launcher.");
+    assert!(!error.contains("secret-bearing"));
+    assert!(!error.contains(&url));
+}
+
+#[test]
+fn native_x_oauth_launcher_suppresses_secret_bearing_process_output() {
+    let src = include_str!("shell_open_commands.rs");
+
+    assert!(
+        src.contains(".stdout(std::process::Stdio::null())")
+            && src.contains(".stderr(std::process::Stdio::null())"),
+        "the native launcher must not forward output that could contain the authorization URL",
     );
 }

--- a/src-tauri/src/shell_open_tests.rs
+++ b/src-tauri/src/shell_open_tests.rs
@@ -124,7 +124,6 @@ fn rejects_arbitrary_or_malformed_x_oauth_navigation() {
     for denied in [
         "http://x.com/i/oauth2/authorize",
         "https://example.com/i/oauth2/authorize",
-        "https://user:pass@x.com/i/oauth2/authorize",
         "https://x.com/i/oauth2/authorize#fragment",
         "https://x.com/other",
         "https://x.com/i/oauth2/authorize",
@@ -149,12 +148,15 @@ fn rejects_each_x_oauth_url_constraint_in_isolation() {
     assert!(validate_x_oauth_url(&valid).is_ok(), "control must be accepted");
 
     let swap = |from: &str, to: &str| valid.replacen(from, to, 1);
+    let mut credentialed = tauri::Url::parse(&valid).unwrap();
+    credentialed.set_username("fixture-user").unwrap();
+    credentialed.set_password(Some("fixture-password")).unwrap();
     for (label, denied) in [
         ("host", swap("https://x.com/", "https://evil.example/")),
         ("scheme", swap("https://", "http://")),
         ("port", swap("https://x.com/", "https://x.com:8443/")),
         ("path", swap("/i/oauth2/authorize", "/i/oauth2/authorise")),
-        ("credentials", swap("https://x.com/", "https://user:pass@x.com/")),
+        ("credentials", credentialed.to_string()),
         ("fragment", format!("{valid}#fragment")),
         ("extra param", format!("{valid}&next=https%3A%2F%2Fevil.example")),
         ("duplicate param", format!("{valid}&state=CCCC")),

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -258,6 +258,7 @@ pub fn run() {
             browser::browser_commands::browser_report_title,
             browser::browser_commands::browser_report_scroll,
             shell_open,
+            open_x_oauth_url,
             shell_open_path,
             shell_pick_directory,
             set_traffic_lights_visible,

--- a/src/app/api/familiars/route.ts
+++ b/src/app/api/familiars/route.ts
@@ -116,6 +116,8 @@ export async function GET(req: Request) {
       autoSelfReport: configEntry.autoSelfReport ?? false,
       asanaEnabled: configEntry.asanaEnabled,
       asanaWorkspaceGid: configEntry.asanaWorkspaceGid,
+      xResearchEnabled: configEntry.xResearchEnabled === true,
+      xPublishEnabled: configEntry.xPublishEnabled === true,
       ...(binding.omnigent ? { omnigent: binding.omnigent } : {}),
       avatarUrl: avatar
         ? `/api/familiars/${encodeURIComponent(f.id)}/avatar?v=${Math.round(avatar.mtimeMs)}&format=png`

--- a/src/components/familiar-x-section.test.ts
+++ b/src/components/familiar-x-section.test.ts
@@ -11,7 +11,6 @@ const source = readFileSync(componentUrl, "utf8");
 const css = readFileSync(cssUrl, "utf8");
 const brain = readFileSync(new URL("./familiar-studio-brain-tab.tsx", import.meta.url), "utf8");
 const familiarRoute = readFileSync(new URL("../app/api/familiars/route.ts", import.meta.url), "utf8");
-const oauthStartRoute = readFileSync(new URL("../app/api/x/oauth/start/route.ts", import.meta.url), "utf8");
 const types = readFileSync(new URL("../lib/types.ts", import.meta.url), "utf8");
 
 assert.match(source, /import "@\/styles\/familiar-x-section\.css"/);
@@ -169,10 +168,6 @@ assert.match(
   /cancelXOAuthFlow\(pending\.flowId\)/,
   "post-start browser failures cancel only their server-side OAuth listener",
 );
-assert.match(oauthStartRoute, /export async function DELETE\(req: Request\)/);
-assert.match(oauthStartRoute, /readJsonBody<\{ flowId\?: unknown \}>\(req, MAX_BODY_BYTES\)/);
-assert.match(oauthStartRoute, /xOAuthService\.cancel\(flowId\)/);
-assert.doesNotMatch(oauthStartRoute, /xOAuthService\.cancel\(\)/);
 
 assert.match(brain, /import \{ FamiliarXSection \} from "@\/components\/familiar-x-section"/);
 assert.match(


### PR DESCRIPTION
## Summary
- re-land the reviewed lifecycle patrol regression repair on current `main`, preserving exact-head claim attribution and fail-closed graft/replacement-ref evidence
- restore the X OAuth launcher, strict URL validation, security tests, and the Tauri command registration used by `open-system-browser`
- align the landed Familiar X component contract with the intentionally unlanded X route tree while restoring familiar grant-state exposure
- retain current-main E2E and sidecar fixes instead of replaying stale/conflicting copies from #4181

## Integration
This supersedes conflicted PR #4181 and patch PR #4191. Current `main` already contained part of #4181 through #4180, so merging the old branch directly would have replayed stale fixture and sidecar changes.

## Verification
- lifecycle patrol and retirement integration tests
- Familiar X source contract
- sidecar bundle and runtime closure contracts
- Rust `shell_open` security tests (13 passed)
- `cargo check --locked`
- mobile access token lifecycle tests
- `pnpm typecheck`
- `pnpm check:tests-wired` (1434 wired)
- independent code review: no significant issues

The full local frontend sequence reaches `scripts/dev-app-teardown.test.mjs`, which times out waiting for a fake port on this macOS host and reproduces unchanged on current `main`; protected Linux CI is the merge gate.