### PR TITLE
feat(research): podcast template tuning from Charm's editorial review

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -595,6 +595,9 @@ test("podcast drafter strips citation apparatus from speech, keeps prose verbati
       "- Benchmarks preserve scores, not intent (the DGM lesson).",
       "- External outcomes should decide promotion [S01](../sources.json) [S06].",
       "- Robust goal-guarding traces to training choices (S20 2025-06; high confidence).",
+      "- The date alone was flagged as unverified (2025-11).",
+      "- Anti-faking mitigations were characterized (verified).",
+      "- The Gödel machine (2003) proposed proof-gated self-modification, and (I) doubt it scales.",
     ].join("\n"),
   }, "standard");
   assert.equal(content.kind, "podcast");
@@ -615,6 +618,15 @@ test("podcast drafter strips citation apparatus from speech, keeps prose verbati
   assert.ok(
     narration.includes("Robust goal-guarding traces to training choices."),
     `dated confidence parentheticals never reach speech (${narration})`,
+  );
+  assert.ok(
+    narration.includes("The date alone was flagged as unverified.") &&
+      narration.includes("Anti-faking mitigations were characterized."),
+    `lone date and lone label parentheticals never reach speech (${narration})`,
+  );
+  assert.ok(
+    narration.includes("The Gödel machine (2003) proposed proof-gated self-modification, and (I) doubt it scales."),
+    `bare publication years and lone pronouns stay verbatim (${narration})`,
   );
   assert.ok(!/\bS\d{1,3}\b/.test(narration), `no bare ledger ids in speech (${narration})`);
 });

--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -482,11 +482,11 @@ test("podcast drafter drafts a host/guest dialogue with templated framing only",
     markdown: [
       "# Findings",
       "",
-      "## Key claims",
+      "## Gating mechanisms",
       "",
       "- Gates bind proxies, not purposes.",
       "",
-      "## Open questions",
+      "## Consolidation levers",
       "",
       "- Does goal-guarding generalize?",
     ].join("\n"),
@@ -499,7 +499,10 @@ test("podcast drafter drafts a host/guest dialogue with templated framing only",
     script[0].text.includes(mission.title),
     "the opening names the mission title, nothing invented",
   );
-  const framing = script.filter((segment) => segment.text.startsWith("Next up — "));
+  const framing = script.filter(
+    (segment) =>
+      segment.text.includes("Gating mechanisms") || segment.text.includes("Consolidation levers"),
+  );
   assert.deepEqual(
     framing.map((segment) => segment.speaker),
     ["host", "host"],
@@ -508,6 +511,13 @@ test("podcast drafter drafts a host/guest dialogue with templated framing only",
   assert.ok(
     framing.every((segment) => !segment.text.includes("..")),
     "framing reuses punctuation-aware headings",
+  );
+  // Charm review #2: host bridges rotate through distinct jobs rather than
+  // repeating one generic line per style.
+  assert.notEqual(
+    framing[0].text.replace("Gating mechanisms", "§"),
+    framing[1].text.replace("Consolidation levers", "§"),
+    "consecutive sections get different bridge copy",
   );
   const guests = script.filter((segment) => segment.speaker === "guest");
   assert.ok(
@@ -519,10 +529,94 @@ test("podcast drafter drafts a host/guest dialogue with templated framing only",
     script.map((_, index) => `segment-${index + 1}`),
     "segment ids stay sequential",
   );
-  // A host framing line is never the last thing in the script — framing only
-  // enters alongside the findings it introduces.
+  // Charm review #5: a section ends on the host's synthesis turn, never on
+  // the guest's last list item.
   const last = script[script.length - 1];
-  assert.notEqual(last.text.startsWith("Next up — "), true);
+  assert.equal(last.speaker, "host", "the episode closes on a host synthesis turn");
+  assert.ok(
+    !last.text.includes("Consolidation levers"),
+    "the closing host turn is a synthesis, not an orphan framing line",
+  );
+});
+
+test("podcast drafter translates document furniture into listener questions", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Executive summary",
+      "",
+      "- Gates bind proxies, not purposes.",
+      "",
+      "## Open questions",
+      "",
+      "- Does goal-guarding generalize?",
+      "",
+      "## Recommended next steps",
+      "",
+      "- Re-run the sweep in a quarter.",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const texts = content.script.map((segment) => segment.text);
+  for (const furniture of ["Executive summary", "Open questions", "Recommended next steps"]) {
+    assert.ok(
+      texts.every((text) => !text.includes(furniture)),
+      `"${furniture}" is never spoken aloud`,
+    );
+  }
+  const questions = content.script.filter((segment) =>
+    [
+      "what's the headline here?",
+      "What's still unsettled after all of this?",
+      "So where does this go from here?",
+    ].some((question) => segment.text.includes(question)),
+  );
+  assert.equal(questions.length, 3, "each furniture heading becomes a listener question");
+  assert.ok(
+    questions.every((segment) => segment.speaker === "host"),
+    "furniture questions are host turns",
+  );
+});
+
+test("podcast drafter strips citation apparatus from speech, keeps prose verbatim", () => {
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Gating mechanisms",
+      "",
+      "- Formal proofs are blocked (S8, S16; high).",
+      "- Benchmarks preserve scores, not intent (the DGM lesson).",
+      "- External outcomes should decide promotion [S01](../sources.json) [S06].",
+      "- Robust goal-guarding traces to training choices (S20 2025-06; high confidence).",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const narration = content.script.map((segment) => segment.text).join(" ");
+  assert.ok(
+    narration.includes("Formal proofs are blocked."),
+    `ledger-id parentheticals never reach speech (${narration})`,
+  );
+  assert.ok(
+    narration.includes("(the DGM lesson)"),
+    "prose parentheticals stay verbatim",
+  );
+  assert.ok(
+    narration.includes("External outcomes should decide promotion."),
+    `bracketed and link-form ledger ids never reach speech (${narration})`,
+  );
+  assert.ok(
+    narration.includes("Robust goal-guarding traces to training choices."),
+    `dated confidence parentheticals never reach speech (${narration})`,
+  );
+  assert.ok(!/\bS\d{1,3}\b/.test(narration), `no bare ledger ids in speech (${narration})`);
 });
 
 test("podcast styles branch the drafter without inventing findings", () => {
@@ -532,7 +626,7 @@ test("podcast styles branch the drafter without inventing findings", () => {
     markdown: [
       "# Findings",
       "",
-      "## Key claims",
+      "## Gating mechanisms",
       "",
       "- Gates bind proxies, not purposes.",
       "",
@@ -557,11 +651,14 @@ test("podcast styles branch the drafter without inventing findings", () => {
   assert.equal(debate.kind, "podcast");
   if (debate.kind !== "podcast") return;
   assert.ok(debate.script[0].text.includes("stress-testing"));
-  const debateFraming = debate.script.filter((segment) =>
-    segment.text.includes("Where do we actually stand"),
+  const debateUnsettled = debate.script.findIndex((segment) =>
+    segment.text.includes("What's still unsettled"),
+  );
+  const debateGates = debate.script.findIndex((segment) =>
+    segment.text.includes("Gating mechanisms"),
   );
   assert.ok(
-    debateFraming[0]?.text.includes("Open questions"),
+    debateUnsettled !== -1 && debateGates !== -1 && debateUnsettled < debateGates,
     "debate leads with the contested section",
   );
 
@@ -571,7 +668,7 @@ test("podcast styles branch the drafter without inventing findings", () => {
   assert.ok(interview.script[0].text.includes("my guest walks us through"));
   assert.ok(
     interview.script.some((segment) =>
-      segment.text.startsWith("Walk me through this part — Key claims"),
+      segment.text.startsWith("Walk me through this part — Gating mechanisms"),
     ),
   );
 
@@ -590,9 +687,9 @@ test("podcast drafter joins are punctuation-aware — never a double period", ()
     markdown: [
       "# Punctuated findings",
       "",
-      "## Key claims (with confidence)",
+      "## Claim ledger (with caveats)",
       "",
-      "- Formal proofs are blocked (high confidence).",
+      "- Formal proofs are blocked (by Löb's theorem).",
       "- Does goal-guarding generalize?",
       "- Benchmarks bind proxies (the DGM lesson)",
       "- an unterminated bullet",
@@ -608,7 +705,7 @@ test("podcast drafter joins are punctuation-aware — never a double period", ()
     "paren-terminated fragments are not re-punctuated",
   );
   assert.ok(
-    narration.includes("Key claims (with confidence)"),
+    narration.includes("Claim ledger (with caveats)"),
     "the heading still frames its details",
   );
 });
@@ -710,8 +807,12 @@ test("podcast openings speak a cleaned mission title — no trailing '.…' garb
     if (content.kind !== "podcast") return;
     const opening = content.script[0]?.text ?? "";
     assert.ok(
-      opening.includes("“Research and compare: Identity Preservation for Agents during Self-Evolution”"),
-      `${style} opening strips trailing title punctuation (${opening})`,
+      opening.includes("“Identity Preservation for Agents during Self-Evolution”"),
+      `${style} opening speaks the framed question, cleanly terminated (${opening})`,
+    );
+    assert.ok(
+      !opening.includes("Research and compare:"),
+      `${style} opening never reads the research-prompt prefix aloud (${opening})`,
     );
     assert.ok(!opening.includes(".…"), `${style} opening never speaks '.…'`);
   }
@@ -724,7 +825,7 @@ test("podcast drafter normalizes TTS-hostile glyphs into spoken words", () => {
     markdown: [
       "# Findings",
       "",
-      "## Open questions → next steps",
+      "## Throughput → cost curve",
       "",
       "- Throughput improved 3× at ≥ 90% recall (≈ baseline cost).",
     ].join("\n"),
@@ -732,7 +833,7 @@ test("podcast drafter normalizes TTS-hostile glyphs into spoken words", () => {
   assert.equal(content.kind, "podcast");
   if (content.kind !== "podcast") return;
   const narration = content.script.map((segment) => segment.text).join(" ");
-  assert.ok(narration.includes("Open questions to next steps"), `arrow spoken as 'to' (${narration})`);
+  assert.ok(narration.includes("Throughput to cost curve"), `arrow spoken as 'to' (${narration})`);
   assert.ok(narration.includes("3 times at at least 90%"), `× and ≥ spoken (${narration})`);
   assert.ok(narration.includes("about baseline cost"), `≈ spoken as 'about' (${narration})`);
   for (const glyph of ["→", "×", "≥", "≈"]) {

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -852,6 +852,21 @@ const CITATION_ID_RE =
 /** Confidence labels that only annotate a citation. */
 const CITATION_LABEL_RE =
   /^(?:high|medium|low|inference|fact|theory|confidence|verified|\[?[IVH]\]?|\d{4}(?:-\d{2}){0,2})$/i;
+/**
+ * Tokens that anchor a parenthetical as citation metadata on their own.
+ * Deliberately narrower than `CITATION_LABEL_RE`: single grade letters would
+ * strip prose like "(I)", and bare years would strip publication years like
+ * "(2003)" that still read as meaningful speech.
+ */
+const CITATION_ANCHOR_RE =
+  /^(?:high|medium|low|inference|fact|theory|verified|confidence|\d{4}(?:-\d{2}){1,2})$/i;
+/**
+ * Ids allowed to anchor a parenthetical. Narrower than the bracket form:
+ * bare numbers ("(2003)") and hyphenated prose ("(state-of-the-art)") are
+ * not citations there, so kebab ids must carry a digit.
+ */
+const PAREN_ID_RE =
+  /^(?:SS|[A-Z]{1,2}\d{1,3}(?:\.\w+)?[a-z]?|(?:src|link)-[\w.…-]+|arXiv:[\w./-]+|[a-z][\w.…]*(?:-[\w.…]+)*-[\w.…]*\d[\w.…-]*)$/;
 
 function citationTokens(inner: string): string[] {
   return inner.split(/[\s,;·+&]+/).filter(Boolean);
@@ -870,10 +885,10 @@ function stripSpokenCitations(text: string): string {
     .replace(/\(([^()]+)\)/g, (match, inner: string) => {
       const tokens = citationTokens(inner);
       const allCitation = tokens.every(
-        (token) => CITATION_ID_RE.test(token) || CITATION_LABEL_RE.test(token),
+        (token) => PAREN_ID_RE.test(token) || CITATION_LABEL_RE.test(token),
       );
       const anchored = tokens.some(
-        (token) => CITATION_ID_RE.test(token) || /^(?:high|medium|low|inference)$/i.test(token),
+        (token) => PAREN_ID_RE.test(token) || CITATION_ANCHOR_RE.test(token),
       );
       return allCitation && anchored ? "" : match;
     })

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -840,19 +840,81 @@ function normalizeSpokenGlyphs(text: string): string {
   return spoken.replace(/\s{2,}/g, " ").trim();
 }
 
+// ── spoken citation handling (cave-jckyz, Charm review #4) ──────────────────
+// Citation apparatus belongs in show notes, not speech: "(S5, S6; high)" read
+// aloud is noise. Removal is strictly mechanical — a group goes only when
+// every token in it is recognizably citation metadata; anything containing
+// plain prose stays verbatim.
+
+/** Source-ledger ids: "S20", "C2", "F1.1", "src-kiro-specs", "knuth-lp-1992", "[^1]". */
+const CITATION_ID_RE =
+  /^(?:\^?\d+|SS|[A-Z]{1,2}\d{1,3}(?:\.\w+)?[a-z]?|(?:src|link)-[\w.…-]+|arXiv:[\w./-]+|[a-z][\w]*(?:-[\w…]+)+)$/;
+/** Confidence labels that only annotate a citation. */
+const CITATION_LABEL_RE =
+  /^(?:high|medium|low|inference|fact|theory|confidence|verified|\[?[IVH]\]?|\d{4}(?:-\d{2}){0,2})$/i;
+
+function citationTokens(inner: string): string[] {
+  return inner.split(/[\s,;·+&]+/).filter(Boolean);
+}
+
+function stripSpokenCitations(text: string): string {
+  return text
+    // Bracket groups made only of ledger ids: "[S01]", "[knuth-lp-1992]".
+    .replace(/\[([^\][]+)\]/g, (match, inner: string) => {
+      const tokens = citationTokens(inner);
+      return tokens.every((token) => CITATION_ID_RE.test(token)) ? "" : match;
+    })
+    // Parentheticals of ids + dates + confidence labels: "(S20 2025-06; high)",
+    // "(high confidence)". At least one id or label keeps "(the DGM lesson)"
+    // and other prose parentheticals intact.
+    .replace(/\(([^()]+)\)/g, (match, inner: string) => {
+      const tokens = citationTokens(inner);
+      const allCitation = tokens.every(
+        (token) => CITATION_ID_RE.test(token) || CITATION_LABEL_RE.test(token),
+      );
+      const anchored = tokens.some(
+        (token) => CITATION_ID_RE.test(token) || /^(?:high|medium|low|inference)$/i.test(token),
+      );
+      return allCitation && anchored ? "" : match;
+    })
+    // Bare ledger ids left behind by markdown-link stripping ("S01 S06").
+    .replace(/(^|\s)[SCR]\d{1,3}[a-z]?(?=[\s,.;:!?]|$)/g, "$1")
+    // Tidy the seams the removals leave behind.
+    .replace(/\s+([,.;:!?])/g, "$1")
+    .replace(/([,;:])\s*(?=[,.;:])/g, "")
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+/** Full spoken-text normalization: citations out, glyphs to words. */
+function spokenText(text: string): string {
+  return normalizeSpokenGlyphs(stripSpokenCitations(text));
+}
+
 /** Terminates a fragment for speech without ever doubling punctuation. */
 function speakable(fragment: string): string {
-  const trimmed = normalizeSpokenGlyphs(fragment);
+  const trimmed = spokenText(fragment);
   if (!trimmed) return trimmed;
   return SPEAKABLE_TERMINAL_RE.test(trimmed) ? trimmed : `${trimmed}.`;
 }
 
 /**
- * Mission titles arrive with trailing punctuation or truncation ellipses
- * ("…Self-Evolution.…"); strip them so templated openings speak cleanly.
+ * Mission titles are often raw research prompts ("Research and compare: X.
+ * Primary questions: …"). The episode should frame the intellectual question,
+ * not read the query furniture aloud (Charm review #1) — so strip prompt
+ * prefixes, cut instruction tails, and drop trailing punctuation/ellipses.
  */
 function spokenTitle(missionTitle: string): string {
-  return normalizeSpokenGlyphs(missionTitle).replace(/[\s.…:;,–—-]+$/u, "");
+  let title = normalizeSpokenGlyphs(missionTitle);
+  title = title.replace(
+    /^research(?:\s+(?:and\s+compare|prompt|brief|mission|task))?\s*[:\-–—]\s*/i,
+    "",
+  );
+  const instructionTail = title.search(
+    /[.!?]\s+(?:primary\s+questions?|questions?|task|recommend|compare|focus)\b/i,
+  );
+  if (instructionTail !== -1) title = title.slice(0, instructionTail);
+  return title.replace(/[\s.…:;,–—-]+$/u, "");
 }
 
 type NarrationUnit = {
@@ -887,7 +949,7 @@ function mediaNarrationSectionUnits(source: GenerationDraftSource): NarrationUni
       rawLine.replace(/^\s*[-*+]\s+/, "").replace(/^\s*>\s?/, ""),
     );
     if (line && !/^#{1,6}\s/.test(line)) {
-      lines.push({ title: null, text: normalizeSpokenGlyphs(line) });
+      lines.push({ title: null, text: spokenText(line) });
     }
   }
   return lines;
@@ -950,32 +1012,128 @@ function contestedSectionsFirst(units: NarrationUnit[]): NarrationUnit[] {
 
 /**
  * Per-style templated copy — episode structure only. Every findings turn the
- * templates introduce stays verbatim artifact text.
+ * templates introduce stays verbatim artifact text. Host bridges rotate
+ * through distinct editorial jobs (orient / define / challenge / connect /
+ * turn-to-practice) instead of repeating one generic line, and every section
+ * ends on a short host synthesis turn rather than the guest's last list item
+ * (cave-jckyz, Charm review #2/#5). Style guidance for dense research:
+ * breakdown (default) > interview (host as listener proxy) > recap > debate
+ * (only when the source has genuinely competing interpretations).
  */
+const rotated = (variants: readonly string[], index: number): string =>
+  variants[index % variants.length];
+
 const PODCAST_DIALOGUE_TEMPLATES: Record<
   Exclude<ResearchPodcastStyle, "recap">,
   (missionTitle: string) => Omit<DialogueTemplate, "budget">
 > = {
   breakdown: (missionTitle) => ({
-    opening: `Welcome in — today we're breaking down “${spokenTitle(missionTitle)}”, finding by finding.`,
-    framing: (title) => `Next up — ${speakable(title)}`,
+    opening: `Welcome in — today we're breaking down what we actually know about “${spokenTitle(missionTitle)}”, finding by finding.`,
+    framing: (title, section) =>
+      rotated(
+        [
+          `Next up — ${speakable(title)}`,
+          `Let's get precise about this one. ${speakable(title)}`,
+          `Here's the part worth slowing down for. ${speakable(title)}`,
+          `And notice how this connects to what we just heard. ${speakable(title)}`,
+          `So what would you actually do with this? ${speakable(title)}`,
+        ],
+        section,
+      ),
+    closer: (section) =>
+      rotated(
+        [
+          "Okay — that one's on the board.",
+          "Good. Let's keep moving.",
+          "That's the takeaway there.",
+          "Noted — that piece matters.",
+        ],
+        section,
+      ),
   }),
   debate: (missionTitle) => ({
     opening: `Welcome to the debate — today we're stress-testing “${spokenTitle(missionTitle)}”, starting where the findings are most contested.`,
-    framing: (title) => `Where do we actually stand on this one? ${speakable(title)}`,
+    framing: (title, section) =>
+      rotated(
+        [
+          `Where do we actually stand on this one? ${speakable(title)}`,
+          `Steelman it for me. ${speakable(title)}`,
+          `I'm not convinced yet — make the case. ${speakable(title)}`,
+          `What would it take to change your mind here? ${speakable(title)}`,
+        ],
+        section,
+      ),
+    closer: (section) =>
+      rotated(
+        [
+          "So the jury's still out on that one.",
+          "Fair — I'll grant that point.",
+          "We'll have to leave that one contested.",
+          "That lands. Next round.",
+        ],
+        section,
+      ),
   }),
   interview: (missionTitle) => ({
     opening: `Today my guest walks us through “${spokenTitle(missionTitle)}”. Let's get into it.`,
-    framing: (title) => `Walk me through this part — ${speakable(title)}`,
+    framing: (title, section) =>
+      rotated(
+        [
+          `Walk me through this part — ${speakable(title)}`,
+          `For listeners just joining us, what does this actually mean? ${speakable(title)}`,
+          `Push back on me for a second here. ${speakable(title)}`,
+          `How does that square with what you said earlier? ${speakable(title)}`,
+          `And for someone who wants to apply this tomorrow? ${speakable(title)}`,
+        ],
+        section,
+      ),
+    closer: (section) =>
+      rotated(
+        [
+          "Got it — that's much clearer now.",
+          "That's a really useful way to put it.",
+          "Right — I hadn't thought of it that way.",
+          "Okay, that helps. Let's go on.",
+        ],
+        section,
+      ),
   }),
 };
+
+/**
+ * Document furniture headings translated into listener questions — the host
+ * never reads "Executive summary" or "Open questions" aloud (cave-jckyz,
+ * Charm review #3). Matching is prefix-based after list numbering is dropped;
+ * unmatched headings flow to the style's own bridges.
+ */
+const FURNITURE_HEADING_QUESTIONS: [RegExp, string][] = [
+  [/^executive summary/i, "Let's start with the big picture — what's the headline here?"],
+  [/^key claims/i, "What are the claims we can actually stand behind?"],
+  [/^(?:key |detailed |main )?findings/i, "So what did the research actually find?"],
+  [/^(?:open|unresolved) questions/i, "What's still unsettled after all of this?"],
+  [/^(?:recommended )?next steps/i, "So where does this go from here?"],
+  [/^(?:comparison|decision) criteria/i, "If someone has to choose, how should they actually decide?"],
+  [/^\S+ comparison\b/i, "How do the options stack up against each other?"],
+  [/^(?:conclusion|bottom line|summary\b)/i, "So what's the bottom line?"],
+  [/^(?:sources?\b|source ledger|research log)/i, "And what is all of this based on?"],
+];
+
+function furnitureQuestion(title: string): string | null {
+  const bare = title.replace(/^\d+[.)]\s*/, "").trim();
+  for (const [pattern, question] of FURNITURE_HEADING_QUESTIONS) {
+    if (pattern.test(bare)) return question;
+  }
+  return null;
+}
 
 type DialogueTemplate = {
   budget: number;
   /** Templated host opener; counts against the character budget. */
   opening: string;
   /** Templated host bridge into a titled section; structure, never findings. */
-  framing: (title: string) => string;
+  framing: (title: string, section: number) => string;
+  /** Templated host synthesis turn closing a titled section. */
+  closer: (section: number) => string;
 };
 
 /**
@@ -998,11 +1156,15 @@ function draftDialogueScript(
   push(template.opening, "host");
   // Heading-less lines have no title to frame, so delivery alternates.
   let alternate: ResearchPodcastSpeaker = "guest";
+  let section = 0;
   outer: for (const unit of units) {
     const chunks = splitMediaDraftText(unit.text);
     if (chunks.length === 0) continue;
     if (unit.title !== null) {
-      const framing = template.framing(unit.title);
+      // Document furniture becomes a listener question; real headings get the
+      // style's rotating bridge (list numbering never gets spoken).
+      const heading = unit.title.replace(/^\d+[.)]\s*/, "");
+      const framing = furnitureQuestion(heading) ?? template.framing(heading, section);
       // Never leave an orphan host question: the framing line only enters
       // when at least its first findings chunk also fits the budget.
       if (used + framing.length + chunks[0].length > template.budget) break;
@@ -1011,6 +1173,13 @@ function draftDialogueScript(
         if (used + chunk.length > template.budget) break outer;
         push(chunk, "guest");
       }
+      // Host synthesis bookend — a section ends on the host's turn, not the
+      // guest's last list item. Skipped only when the budget is spent.
+      const closer = template.closer(section);
+      if (used + closer.length <= template.budget) {
+        push(closer, "host");
+      }
+      section += 1;
     } else {
       for (const chunk of chunks) {
         if (used + chunk.length > template.budget) break outer;


### PR DESCRIPTION
Implements Charm's editorial review of the four podcast styles (bead `cave-jckyz`, follow-up to #4189).

## What changed (all in `src/lib/server/research-generations.ts`)

1. **Mission-aware openings** — `spokenTitle` now strips research-prompt prefixes (`Research and compare:`) and instruction tails (`. Primary questions: …`), so episodes frame the intellectual question instead of reading the raw query aloud.
2. **Rotating host bridges with distinct jobs** — each style's `framing` now rotates per section through orient / define / challenge / connect / turn-to-practice variants instead of one repeated generic line.
3. **Furniture headings → listener questions** — `Executive summary`, `Open questions`, `Recommended next steps`, comparison tables, sources, etc. are translated to host questions and never spoken verbatim.
4. **Spoken citation stripping** — mechanical removal only: bracketed ledger ids (`[S01]`, `[knuth-lp-1992]`), parentheticals composed solely of ids/dates/confidence labels (`(S5, S6; high)`, `(S20 2025-06; high confidence)`), and bare ids left by link-stripping. Prose parentheticals like `(the DGM lesson)` stay verbatim — the extractive constraint holds.
5. **Host synthesis bookends** — every titled section now ends on a short templated host turn, not the guest's last list item, nudging host/guest word balance toward Charm's 20–30% / 70–80% target.

Charm's ranking guidance (breakdown > interview > recap > debate for dense research) is recorded in the template doc comment; breakdown remains the default.

## Verification

- `research-generations.test.ts`: 41/41 pass, including 2 new tests (furniture translation, citation stripping) and updated dialogue/style/rotation assertions.
- Adjacent media contract/job tests: 28/28 pass.
- `pnpm typecheck` clean.
- Manual dogfood against real identity-preservation findings content: openings, questions, bridges, closers, and citation-free speech all render as reviewed.