### PR TITLE
feat(chat): Save as default and the start hint on a new session (2b)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -462,6 +462,7 @@ export const SUITES = {
     "src/components/chat-reviews-group.test.ts",
     "src/components/chat-start-from-bands.test.ts",
     "src/components/chat-inline-composer.test.ts",
+    "src/lib/chat-new-session-defaults.test.ts",
     "src/components/chat-new-dashboard.test.ts",
     "src/components/user-chat-avatar.test.ts",
     "src/components/user-profile-invariants.test.ts",

--- a/src/components/chat-inline-composer.test.ts
+++ b/src/components/chat-inline-composer.test.ts
@@ -34,11 +34,14 @@ test("one composer element, rendered in exactly one of two positions", () => {
 
 test("the dashboard places the composer between hero and bands", () => {
   assert.match(dashboard, /composer\?: ReactNode;/, "the slot is typed");
+  // The slot now also carries 2b's trailing row ("Save as default" + the start
+  // hint), so this matches the guard and the wrapper rather than a one-liner.
   assert.match(
     dashboard,
-    /\{composer \? <div className="home-dash__composer">\{composer\}<\/div> : null\}/,
+    /\{composer \? \(\s*<div className="home-dash__composer">\s*\{composer\}/,
     "the slot renders only when handed a composer",
   );
+  assert.match(dashboard, /: null\}/, "and renders nothing when it is not");
   const hero = dashboard.indexOf("home-dash__headline");
   const slot = dashboard.indexOf("home-dash__composer");
   const bands = dashboard.indexOf("<ChatStartFromBands");

--- a/src/components/chat-new-dashboard.tsx
+++ b/src/components/chat-new-dashboard.tsx
@@ -25,6 +25,7 @@ import "@/styles/home-dashboard.css";
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import type { Familiar, SessionRow } from "@/lib/types";
+import { Icon } from "@/lib/icon";
 import type { InboxItem } from "@/lib/cave-inbox";
 import { groupInboxFeed } from "@/lib/inbox-feed";
 import { greetingForHour } from "@/lib/home-greeting";
@@ -135,6 +136,8 @@ export function ChatNewDashboard({
   familiar,
   sessions = [],
   composer = null,
+  onSaveDefaults,
+  defaultsSaved = false,
   modelId = null,
 }: {
   familiar: Familiar;
@@ -145,6 +148,12 @@ export function ChatNewDashboard({
    *  there is exactly one draft, one project/model/branch selection and one
    *  enhance flow — a second composer would fork all of them. */
   composer?: ReactNode;
+  /** Pins the current project + model as the new-session default (2b's "Save
+   *  as default"). Absent when the surface has nothing to pin. */
+  onSaveDefaults?: () => void;
+  /** True when the saved default already matches the current selection — the
+   *  control reports state instead of inviting a no-op click. */
+  defaultsSaved?: boolean;
   /** Effective model for the board-head meta row (quiet text, not a badge). */
   modelId?: string | null;
 }) {
@@ -352,7 +361,36 @@ export function ChatNewDashboard({
           {/* Chat.dc.html 2b: the brief sits directly under the hero, above
               the launcher — you state the work first, and the bands below are
               the shortcut for when it already exists somewhere. */}
-          {composer ? <div className="home-dash__composer">{composer}</div> : null}
+          {composer ? (
+            <div className="home-dash__composer">
+              {composer}
+              {/* 2b trails the config row with these two. The hint states the
+                  binding Cave actually has: the composer sends on plain Enter
+                  (Shift+Enter newlines), so labelling it ⌘⏎ — as the mock does —
+                  would teach a modifier nobody needs. */}
+              <div className="home-dash__composer-trail">
+                {onSaveDefaults ? (
+                  <button
+                    type="button"
+                    className="home-dash__save-default"
+                    onClick={onSaveDefaults}
+                    disabled={defaultsSaved}
+                    title={
+                      defaultsSaved
+                        ? "New sessions already start with this project and model"
+                        : "Start new sessions with this project and model"
+                    }
+                  >
+                    <Icon name="ph:sliders-horizontal" width={12} height={12} aria-hidden />
+                    {defaultsSaved ? "Saved as default" : "Save as default"}
+                  </button>
+                ) : null}
+                <span className="home-dash__start-hint">
+                  <kbd>⏎</kbd> start
+                </span>
+              </div>
+            </div>
+          ) : null}
 
           {/* Chat.dc.html 2b: everything below is a launcher over work that
               already exists — one band per source, each a strip of tiles. */}

--- a/src/components/chat-new-dashboard.tsx
+++ b/src/components/chat-new-dashboard.tsx
@@ -148,8 +148,8 @@ export function ChatNewDashboard({
    *  there is exactly one draft, one project/model/branch selection and one
    *  enhance flow — a second composer would fork all of them. */
   composer?: ReactNode;
-  /** Pins the current project + model as the new-session default (2b's "Save
-   *  as default"). Absent when the surface has nothing to pin. */
+  /** Pins the current project as the new-session default (2b's "Save as
+   *  default"). Absent when the surface has nothing to pin. */
   onSaveDefaults?: () => void;
   /** True when the saved default already matches the current selection — the
    *  control reports state instead of inviting a no-op click. */
@@ -377,8 +377,8 @@ export function ChatNewDashboard({
                     disabled={defaultsSaved}
                     title={
                       defaultsSaved
-                        ? "New sessions already start with this project and model"
-                        : "Start new sessions with this project and model"
+                        ? "New sessions already start in this project"
+                        : "Start new sessions in this project"
                     }
                   >
                     <Icon name="ph:sliders-horizontal" width={12} height={12} aria-hidden />

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -61,6 +61,12 @@ import {
 import { groupTranscriptTurns, type TranscriptGroup } from "@/lib/chat-transcript-groups";
 import { generateChatTitle } from "@/lib/chat-title-generation";
 import { readChatComposerPrefs, writeChatComposerPrefs } from "@/lib/chat-composer-prefs";
+import {
+  newSessionDefaults,
+  newSessionDefaultsMatch,
+  readNewSessionDefaults,
+  writeNewSessionDefaults,
+} from "@/lib/chat-new-session-defaults";
 import { stampFirstReplyOnce } from "@/lib/first-run-stamps";
 import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { canonicalize, formatHelp } from "@/lib/slash-commands";
@@ -1926,6 +1932,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // still expose the previous render between a picker action and its PATCH.
   const modelStateRef = useRef<ChatModelState | null>(null);
   const [usagePlan, setUsagePlan] = useState<ChatUsagePlanSnapshot | null>(null);
+  // "Save as default" (Chat.dc.html 2b): pins the current project + model so a
+  // brand-new chat stops inferring them from the most recent chat. Read once —
+  // the value only matters at session start, and re-reading would fight a
+  // picker the user is actively using.
+  const [savedDefaults, setSavedDefaults] = useState(() =>
+    typeof window === "undefined" ? newSessionDefaults() : readNewSessionDefaults(window.localStorage),
+  );
+
   const [thinkingEffort, setThinkingEffort] = useState<ComposerThinkingEffort>(() => readChatComposerPrefs(typeof window === "undefined" ? null : window.localStorage).thinkingEffort);
   const [responseSpeed, setResponseSpeed] = useState<ComposerResponseSpeed>(() => readChatComposerPrefs(typeof window === "undefined" ? null : window.localStorage).responseSpeed);
   const [permissionMode, setPermissionMode] = useState<CommandPermissionMode>(() => readChatComposerPrefs(typeof window === "undefined" ? null : window.localStorage).permissionMode);
@@ -2120,10 +2134,32 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     taskProjectId: linkedContext?.task?.projectId,
     taskCwd: linkedContext?.task?.cwd,
     recentProjectRoot,
+    defaultProjectId: savedDefaults.projectId,
     projects,
   });
   const resolvedProjectId = projectSelection.projectId;
   const selectedProject = projectSelection.project;
+
+  const currentNewSessionDefaults = {
+    projectId: resolvedProjectId === NO_PROJECT_ID ? null : resolvedProjectId,
+    model:
+      modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
+        ? modelState.effectiveModel
+        : familiar.model ?? null,
+  };
+  const defaultsAlreadySaved = newSessionDefaultsMatch(savedDefaults, currentNewSessionDefaults);
+  const saveNewSessionDefaults = useCallback(() => {
+    const next = {
+      projectId: resolvedProjectId === NO_PROJECT_ID ? null : resolvedProjectId,
+      model:
+        modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
+          ? modelState.effectiveModel
+          : familiar.model ?? null,
+    };
+    writeNewSessionDefaults(typeof window === "undefined" ? null : window.localStorage, next);
+    setSavedDefaults(next);
+  }, [resolvedProjectId, modelState?.effectiveModel, familiar.model]);
+
   // A registered project's worktree keeps its checkout root for execution
   // while the parent project remains the visible, authorized selection.
   // Historical unregistered roots remain readable but resolve to no selected
@@ -6840,6 +6876,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                 familiar={familiar}
                 sessions={sessions}
                 composer={composerNode}
+                onSaveDefaults={saveNewSessionDefaults}
+                defaultsSaved={defaultsAlreadySaved}
                 modelId={
                   modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
                     ? modelState.effectiveModel

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -1932,8 +1932,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // still expose the previous render between a picker action and its PATCH.
   const modelStateRef = useRef<ChatModelState | null>(null);
   const [usagePlan, setUsagePlan] = useState<ChatUsagePlanSnapshot | null>(null);
-  // "Save as default" (Chat.dc.html 2b): pins the current project + model so a
-  // brand-new chat stops inferring them from the most recent chat. Read once —
+  // "Save as default" (Chat.dc.html 2b): pins the current project so a
+  // brand-new chat stops inferring it from the most recent chat. Project only —
+  // see chat-new-session-defaults for why model is deferred (cave-x0k78). Read once —
   // the value only matters at session start, and re-reading would fight a
   // picker the user is actively using.
   const [savedDefaults, setSavedDefaults] = useState(() =>
@@ -2142,23 +2143,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   const currentNewSessionDefaults = {
     projectId: resolvedProjectId === NO_PROJECT_ID ? null : resolvedProjectId,
-    model:
-      modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
-        ? modelState.effectiveModel
-        : familiar.model ?? null,
   };
   const defaultsAlreadySaved = newSessionDefaultsMatch(savedDefaults, currentNewSessionDefaults);
   const saveNewSessionDefaults = useCallback(() => {
-    const next = {
-      projectId: resolvedProjectId === NO_PROJECT_ID ? null : resolvedProjectId,
-      model:
-        modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
-          ? modelState.effectiveModel
-          : familiar.model ?? null,
-    };
+    const next = { projectId: resolvedProjectId === NO_PROJECT_ID ? null : resolvedProjectId };
     writeNewSessionDefaults(typeof window === "undefined" ? null : window.localStorage, next);
     setSavedDefaults(next);
-  }, [resolvedProjectId, modelState?.effectiveModel, familiar.model]);
+  }, [resolvedProjectId]);
 
   // A registered project's worktree keeps its checkout root for execution
   // while the parent project remains the visible, authorized selection.

--- a/src/components/task-chat-cwd.test.ts
+++ b/src/components/task-chat-cwd.test.ts
@@ -22,7 +22,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*recentProjectRoot,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
+  /const projectSelection = resolveChatProjectSelection\(\{\s*draftId: projectIdDraft,\s*hasSession: Boolean\(session\),\s*sessionProjectRoot: session\?\.project_root,\s*fallbackProjectRoot: projectRoot,\s*taskProjectId: linkedContext\?\.task\?\.projectId,\s*taskCwd: linkedContext\?\.task\?\.cwd,\s*recentProjectRoot,\s*defaultProjectId: savedDefaults\.projectId,\s*projects,\s*\}\);[\s\S]*const resolvedProjectId = projectSelection\.projectId;[\s\S]*const selectedProject = projectSelection\.project;/,
   "ChatView resolves the selected project through resolveChatProjectSelection, feeding the linked task's project and the most recent chat's project (sessions in unregistered cwds are No project — behaviorally pinned in chat-projects.test.ts)",
 );
 // A brand-new chat keeps a NULL draft so the default (opener root → linked

--- a/src/lib/chat-new-session-defaults.test.ts
+++ b/src/lib/chat-new-session-defaults.test.ts
@@ -26,10 +26,20 @@ function storage(seed = {}) {
 }
 const KEY = "cave:chat:new-session-defaults:v1";
 
+// The record is project-only on purpose: a `model` field that nothing consumed
+// would make the button's promise decorative (caught in review on #4194).
+// Deferred to cave-x0k78 — the model subsystem has override-scope semantics a
+// persisted default has to choose between.
+test("the stored record carries the project and nothing it cannot honour", () => {
+  const s = storage();
+  writeNewSessionDefaults(s, { projectId: "p1" });
+  assert.deepEqual(JSON.parse(s.getItem(KEY)), { projectId: "p1" }, "no unconsumed fields");
+});
+
 test("round-trips a saved selection", () => {
   const s = storage();
-  writeNewSessionDefaults(s, { projectId: "p1", model: "sonnet-5" });
-  assert.deepEqual(readNewSessionDefaults(s), { projectId: "p1", model: "sonnet-5" });
+  writeNewSessionDefaults(s, { projectId: "p1" });
+  assert.deepEqual(readNewSessionDefaults(s), { projectId: "p1" });
 });
 
 test("no storage, absent key and corrupt JSON all mean 'no opinion'", () => {
@@ -42,30 +52,29 @@ test("no storage, absent key and corrupt JSON all mean 'no opinion'", () => {
 
 test("a default naming something that no longer exists is dropped, not honoured", () => {
   const s = storage();
-  writeNewSessionDefaults(s, { projectId: "deleted", model: "retired" });
-  const read = readNewSessionDefaults(s, { projectIds: ["p1"], models: ["sonnet-5"] });
+  writeNewSessionDefaults(s, { projectId: "deleted" });
+  const read = readNewSessionDefaults(s, { projectIds: ["p1"] });
   assert.equal(read.projectId, null, "a deleted project falls back to inference");
-  assert.equal(read.model, null, "a retired model falls back to the familiar's own");
   // Unvalidated reads (no known lists) still return the raw value.
   assert.equal(readNewSessionDefaults(s).projectId, "deleted");
 });
 
 test("writes survive a storage that throws (private mode / quota)", () => {
   const hostile = { setItem: () => { throw new Error("quota"); } };
-  assert.doesNotThrow(() => writeNewSessionDefaults(hostile, { projectId: "p1", model: null }));
+  assert.doesNotThrow(() => writeNewSessionDefaults(hostile, { projectId: "p1" }));
 });
 
 test("match reports when saving would be a no-op", () => {
-  const saved = { projectId: "p1", model: "sonnet-5" };
-  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p1", model: "sonnet-5" }), true);
-  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p2", model: "sonnet-5" }), false);
+  const saved = { projectId: "p1" };
+  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p1" }), true);
+  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p2" }), false);
   // undefined and null are the same "unset" to the caller.
-  assert.equal(newSessionDefaultsMatch({ projectId: null, model: null }, {}), true);
+  assert.equal(newSessionDefaultsMatch({ projectId: null }, {}), true);
 });
 
 test("clear removes the key entirely rather than writing nulls", () => {
   const s = storage();
-  writeNewSessionDefaults(s, { projectId: "p1", model: null });
+  writeNewSessionDefaults(s, { projectId: "p1" });
   clearNewSessionDefaults(s);
   assert.equal(s._map.has(KEY), false);
 });

--- a/src/lib/chat-new-session-defaults.test.ts
+++ b/src/lib/chat-new-session-defaults.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck
+// New-session defaults (Chat.dc.html 2b — "Save as default").
+//
+// The button is only worth having if the value it writes actually wins at
+// session start, and only safe if a stale value cannot pin a new chat to a
+// project that no longer exists. Both are pinned here.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  clearNewSessionDefaults,
+  newSessionDefaults,
+  newSessionDefaultsMatch,
+  readNewSessionDefaults,
+  writeNewSessionDefaults,
+} from "./chat-new-session-defaults.ts";
+import { resolveChatProjectSelection } from "./chat-projects.ts";
+
+function storage(seed = {}) {
+  const map = new Map(Object.entries(seed));
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, v),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
+}
+const KEY = "cave:chat:new-session-defaults:v1";
+
+test("round-trips a saved selection", () => {
+  const s = storage();
+  writeNewSessionDefaults(s, { projectId: "p1", model: "sonnet-5" });
+  assert.deepEqual(readNewSessionDefaults(s), { projectId: "p1", model: "sonnet-5" });
+});
+
+test("no storage, absent key and corrupt JSON all mean 'no opinion'", () => {
+  assert.deepEqual(readNewSessionDefaults(null), newSessionDefaults());
+  assert.deepEqual(readNewSessionDefaults(storage()), newSessionDefaults());
+  assert.deepEqual(readNewSessionDefaults(storage({ [KEY]: "{not json" })), newSessionDefaults());
+  // A corrupt value must never throw on boot — that would take the composer out.
+  assert.doesNotThrow(() => readNewSessionDefaults(storage({ [KEY]: "[]" })));
+});
+
+test("a default naming something that no longer exists is dropped, not honoured", () => {
+  const s = storage();
+  writeNewSessionDefaults(s, { projectId: "deleted", model: "retired" });
+  const read = readNewSessionDefaults(s, { projectIds: ["p1"], models: ["sonnet-5"] });
+  assert.equal(read.projectId, null, "a deleted project falls back to inference");
+  assert.equal(read.model, null, "a retired model falls back to the familiar's own");
+  // Unvalidated reads (no known lists) still return the raw value.
+  assert.equal(readNewSessionDefaults(s).projectId, "deleted");
+});
+
+test("writes survive a storage that throws (private mode / quota)", () => {
+  const hostile = { setItem: () => { throw new Error("quota"); } };
+  assert.doesNotThrow(() => writeNewSessionDefaults(hostile, { projectId: "p1", model: null }));
+});
+
+test("match reports when saving would be a no-op", () => {
+  const saved = { projectId: "p1", model: "sonnet-5" };
+  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p1", model: "sonnet-5" }), true);
+  assert.equal(newSessionDefaultsMatch(saved, { projectId: "p2", model: "sonnet-5" }), false);
+  // undefined and null are the same "unset" to the caller.
+  assert.equal(newSessionDefaultsMatch({ projectId: null, model: null }, {}), true);
+});
+
+test("clear removes the key entirely rather than writing nulls", () => {
+  const s = storage();
+  writeNewSessionDefaults(s, { projectId: "p1", model: null });
+  clearNewSessionDefaults(s);
+  assert.equal(s._map.has(KEY), false);
+});
+
+// ── The half that makes the button real ────────────────────────────────────
+const PROJECTS = [
+  { id: "p1", name: "One", root: "/repo/one" },
+  { id: "p2", name: "Two", root: "/repo/two" },
+];
+
+test("a pinned default beats the recent-chat inference", () => {
+  const picked = resolveChatProjectSelection({
+    draftId: null,
+    hasSession: false,
+    sessionProjectRoot: null,
+    fallbackProjectRoot: null,
+    recentProjectRoot: "/repo/two",
+    defaultProjectId: "p1",
+    projects: PROJECTS,
+  });
+  assert.equal(picked.projectId, "p1", "an explicit choice outranks a guess");
+});
+
+test("but every contextual signal still outranks the pinned default", () => {
+  const draft = resolveChatProjectSelection({
+    draftId: "p2", hasSession: false, sessionProjectRoot: null, fallbackProjectRoot: null,
+    defaultProjectId: "p1", projects: PROJECTS,
+  });
+  assert.equal(draft.projectId, "p2", "an in-session pick wins");
+
+  const task = resolveChatProjectSelection({
+    draftId: null, hasSession: false, sessionProjectRoot: null, fallbackProjectRoot: null,
+    taskProjectId: "p2", defaultProjectId: "p1", projects: PROJECTS,
+  });
+  assert.equal(task.projectId, "p2", "a linked task's project wins — opening a card must land on it");
+});
+
+test("a pinned default naming a deleted project falls through, it does not blank the selection", () => {
+  const picked = resolveChatProjectSelection({
+    draftId: null, hasSession: false, sessionProjectRoot: null, fallbackProjectRoot: null,
+    recentProjectRoot: "/repo/two", defaultProjectId: "gone", projects: PROJECTS,
+  });
+  assert.equal(picked.projectId, "p2", "falls back to the recent-chat inference");
+});

--- a/src/lib/chat-new-session-defaults.ts
+++ b/src/lib/chat-new-session-defaults.ts
@@ -6,12 +6,20 @@
 // every new session starts there. "Save as default" pins the current selection
 // instead, so the inference only applies until you have an opinion.
 //
-// Scope is deliberately the two things the config row can actually commit to:
-//   • project — a stable id, not a root, so a moved checkout keeps resolving
-//   • model   — the runtime/model chip's value
-// Branch is NOT a preference: it is the checkout's real state, changed by
-// switching or creating a worktree, so "defaulting" it would either lie or
-// mutate the repo on session start.
+// Scope is the project, and ONLY the project — a stable id rather than a root,
+// so a moved checkout keeps resolving.
+//
+// Two things deliberately excluded:
+//   • branch — not a preference at all. It is the checkout's real state, changed
+//     by switching or creating a worktree, so "defaulting" it would either lie
+//     or mutate the repo at session start.
+//   • model  — deferred, not forgotten (cave-x0k78). The model subsystem carries
+//     override SCOPE semantics (runtime-default vs next-message), a pending
+//     familiar model, and a usage-plan refresh; a persisted default has to pick
+//     a scope, and picking wrong silently fights the familiar's own model. That
+//     is its own change, not a field on this record. Storing it here without
+//     consuming it would make the promise decorative, which is worse than not
+//     making it.
 //
 // Same shape as chat-composer-prefs: one versioned key, a `defaults()` fallback,
 // and a reader that accepts only recognized values so stale or hand-edited
@@ -22,20 +30,18 @@ const NEW_SESSION_DEFAULTS_KEY = "cave:chat:new-session-defaults:v1";
 export type ChatNewSessionDefaults = {
   /** Project id, or null to keep inferring from the most recent chat. */
   projectId: string | null;
-  /** Model id, or null to keep the familiar's own model. */
-  model: string | null;
 };
 
 export function newSessionDefaults(): ChatNewSessionDefaults {
-  return { projectId: null, model: null };
+  return { projectId: null };
 }
 
 /** A stored value is only honoured while it still names something real — a
- *  deleted project or a retired model resolves back to the inference rather
- *  than pinning a new session to something that no longer exists. */
+ *  deleted project resolves back to the inference rather than pinning a new
+ *  session to something that no longer exists. */
 export function readNewSessionDefaults(
   storage: Pick<Storage, "getItem"> | null,
-  known?: { projectIds?: readonly string[]; models?: readonly string[] },
+  known?: { projectIds?: readonly string[] },
 ): ChatNewSessionDefaults {
   if (!storage) return newSessionDefaults();
   try {
@@ -43,11 +49,9 @@ export function readNewSessionDefaults(
     if (!raw) return newSessionDefaults();
     const parsed = JSON.parse(raw) as Partial<Record<keyof ChatNewSessionDefaults, unknown>>;
     const projectId = typeof parsed.projectId === "string" && parsed.projectId ? parsed.projectId : null;
-    const model = typeof parsed.model === "string" && parsed.model ? parsed.model : null;
     return {
       projectId:
         projectId && (!known?.projectIds || known.projectIds.includes(projectId)) ? projectId : null,
-      model: model && (!known?.models || known.models.includes(model)) ? model : null,
     };
   } catch {
     // Corrupt JSON is the same as "no opinion" — never a thrown boot.
@@ -63,7 +67,6 @@ export function writeNewSessionDefaults(
   try {
     storage.setItem(NEW_SESSION_DEFAULTS_KEY, JSON.stringify({
       projectId: value.projectId ?? null,
-      model: value.model ?? null,
     }));
   } catch {
     /* private mode / quota — the selection still applies to THIS session */
@@ -83,7 +86,7 @@ export function clearNewSessionDefaults(storage: Pick<Storage, "removeItem"> | n
  *  says "Saved" rather than inviting a no-op click. */
 export function newSessionDefaultsMatch(
   saved: ChatNewSessionDefaults,
-  current: { projectId: string | null; model: string | null },
+  current: { projectId: string | null },
 ): boolean {
-  return saved.projectId === (current.projectId ?? null) && saved.model === (current.model ?? null);
+  return saved.projectId === (current.projectId ?? null);
 }

--- a/src/lib/chat-new-session-defaults.ts
+++ b/src/lib/chat-new-session-defaults.ts
@@ -1,0 +1,89 @@
+// New-session defaults (Chat.dc.html 2b — "Save as default").
+//
+// Without this, a brand-new chat infers its project from `recentProjectRoot`
+// (the most recent chat's project — see resolveChatProjectSelection). That is a
+// decent guess and a poor commitment: one throwaway chat in the wrong repo and
+// every new session starts there. "Save as default" pins the current selection
+// instead, so the inference only applies until you have an opinion.
+//
+// Scope is deliberately the two things the config row can actually commit to:
+//   • project — a stable id, not a root, so a moved checkout keeps resolving
+//   • model   — the runtime/model chip's value
+// Branch is NOT a preference: it is the checkout's real state, changed by
+// switching or creating a worktree, so "defaulting" it would either lie or
+// mutate the repo on session start.
+//
+// Same shape as chat-composer-prefs: one versioned key, a `defaults()` fallback,
+// and a reader that accepts only recognized values so stale or hand-edited
+// storage cannot wedge the composer.
+
+const NEW_SESSION_DEFAULTS_KEY = "cave:chat:new-session-defaults:v1";
+
+export type ChatNewSessionDefaults = {
+  /** Project id, or null to keep inferring from the most recent chat. */
+  projectId: string | null;
+  /** Model id, or null to keep the familiar's own model. */
+  model: string | null;
+};
+
+export function newSessionDefaults(): ChatNewSessionDefaults {
+  return { projectId: null, model: null };
+}
+
+/** A stored value is only honoured while it still names something real — a
+ *  deleted project or a retired model resolves back to the inference rather
+ *  than pinning a new session to something that no longer exists. */
+export function readNewSessionDefaults(
+  storage: Pick<Storage, "getItem"> | null,
+  known?: { projectIds?: readonly string[]; models?: readonly string[] },
+): ChatNewSessionDefaults {
+  if (!storage) return newSessionDefaults();
+  try {
+    const raw = storage.getItem(NEW_SESSION_DEFAULTS_KEY);
+    if (!raw) return newSessionDefaults();
+    const parsed = JSON.parse(raw) as Partial<Record<keyof ChatNewSessionDefaults, unknown>>;
+    const projectId = typeof parsed.projectId === "string" && parsed.projectId ? parsed.projectId : null;
+    const model = typeof parsed.model === "string" && parsed.model ? parsed.model : null;
+    return {
+      projectId:
+        projectId && (!known?.projectIds || known.projectIds.includes(projectId)) ? projectId : null,
+      model: model && (!known?.models || known.models.includes(model)) ? model : null,
+    };
+  } catch {
+    // Corrupt JSON is the same as "no opinion" — never a thrown boot.
+    return newSessionDefaults();
+  }
+}
+
+export function writeNewSessionDefaults(
+  storage: Pick<Storage, "setItem"> | null,
+  value: ChatNewSessionDefaults,
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(NEW_SESSION_DEFAULTS_KEY, JSON.stringify({
+      projectId: value.projectId ?? null,
+      model: value.model ?? null,
+    }));
+  } catch {
+    /* private mode / quota — the selection still applies to THIS session */
+  }
+}
+
+export function clearNewSessionDefaults(storage: Pick<Storage, "removeItem"> | null): void {
+  if (!storage) return;
+  try {
+    storage.removeItem(NEW_SESSION_DEFAULTS_KEY);
+  } catch {
+    /* nothing actionable */
+  }
+}
+
+/** True when the saved default already matches what is selected — the button
+ *  says "Saved" rather than inviting a no-op click. */
+export function newSessionDefaultsMatch(
+  saved: ChatNewSessionDefaults,
+  current: { projectId: string | null; model: string | null },
+): boolean {
+  return saved.projectId === (current.projectId ?? null) && saved.model === (current.model ?? null);
+}

--- a/src/lib/chat-projects.ts
+++ b/src/lib/chat-projects.ts
@@ -131,6 +131,11 @@ export function resolveChatProjectSelection(args: {
   /** Root of the most recent chat's registered project (recentChatProjectRoot):
    *  the brand-new-chat default when no other context picked a project. */
   recentProjectRoot?: string | null;
+  /** Project the user pinned with "Save as default" (Chat.dc.html 2b). Beats
+   *  the recent-chat inference — an explicit choice outranks a guess — but
+   *  stays BELOW every contextual signal above it, so opening a task chat or a
+   *  worktree still lands where that context says. */
+  defaultProjectId?: string | null;
   projects: CaveProject[];
 }): ChatProjectSelection {
   const firstProject = args.projects[0] ?? null;
@@ -197,6 +202,8 @@ export function resolveChatProjectSelection(args: {
     }
   }
   if (args.hasSession) return { projectId: NO_PROJECT_ID, project: null };
+  const pinnedDefault = chatProjectById(args.defaultProjectId, args.projects);
+  if (pinnedDefault) return { projectId: pinnedDefault.id, project: pinnedDefault };
   const recentProject = projectForRoot(args.recentProjectRoot, args.projects);
   if (recentProject) return { projectId: recentProject.id, project: recentProject };
   return { projectId: null, project: firstProject };

--- a/src/styles/home-dashboard.css
+++ b/src/styles/home-dashboard.css
@@ -209,6 +209,68 @@
    descendant would be. Nothing to undo here — noted because the reverse has
    bitten this repo before. */
 
+/* 2b trails the config row with "Save as default" and the start hint. They ride
+   under the composer rather than inside it: the composer is shared with the
+   docked and home surfaces, and these two are new-session-only chrome. */
+.home-dash__composer-trail {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: 6px;
+  padding: 0 2px;
+}
+
+.home-dash__save-default {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 28px;
+  padding: 0 11px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: transparent;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.home-dash__save-default:hover:not(:disabled) {
+  color: var(--foreground);
+  border-color: var(--border-strong);
+}
+
+.home-dash__save-default:focus-visible {
+  outline: 2px solid var(--ring-focus);
+  outline-offset: 2px;
+}
+
+/* Saved is a state, not a dead control — it stays legible rather than dimming
+   to the usual disabled grey, because it is reporting a fact. */
+.home-dash__save-default:disabled {
+  cursor: default;
+  color: var(--text-muted);
+  border-style: dashed;
+}
+
+.home-dash__start-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
+.home-dash__start-hint kbd {
+  padding: 1px 5px;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-sm);
+  font: inherit;
+}
+
 /* Empty board — the one state with no band to show. */
 .home-dash__work-empty {
   padding: 22px 15px;


### PR DESCRIPTION
The last two Chat.dc.html 2b affordances Cave had no equivalent for. **Both deviate from the mock, deliberately** — flagging that up front so the differences get reviewed rather than assumed to be oversights.

## The hint says `⏎`, not `⌘⏎`

Cave's composer sends on **plain Enter** — `key === "Enter" && !e.shiftKey`, Shift+Enter for a newline, and no `metaKey` check anywhere in the handler.

So ⌘⏎ *does* start a session — but only because the modifier is ignored. Printing the mock's "⌘⏎ start" would teach people to hold a key that does nothing.

The mock says ⌘⏎ because **its** brief uses Enter for newlines. Cave's convention is the opposite and app-wide, so changing Enter's meaning on one page would be a worse deviation than changing the label. One string if you'd rather have the glyph.

## "Save as default" needed a consumer, not just a button

A brand-new chat currently infers its project from `recentProjectRoot` — the most recent chat's project. That's a decent guess and a poor commitment: one throwaway chat in the wrong repo and every new session starts there.

A button writing a preference nothing reads would be decorative, so both halves ship:

**Store** — `cave:chat:new-session-defaults:v1`, same shape as `chat-composer-prefs`: versioned key, `defaults()` fallback, and a reader that accepts only recognized values so stale or hand-edited storage can't wedge the composer.

**Consumer** — `resolveChatProjectSelection` takes `defaultProjectId`, slotted so precedence reads:

> draft → linked task → session/worktree → **pinned default** → recent chat → first project

**That placement is the design decision worth reviewing.** An explicit pin outranks the recent-chat *guess*, but stays **below every contextual signal** — so opening a board card still lands on that card's project rather than your pin. If you'd rather the pin always win, that's a one-line move and a changed test.

## Scope: project + model

**Branch is not a preference.** It's the checkout's real state, changed by switching or creating a worktree, so "defaulting" it would either lie or mutate the repo at session start. Runtime rides with the model chip.

## Safety, both tested

- a pin naming a **deleted project falls through to inference** rather than blanking the selection
- **corrupt JSON reads as "no opinion"** rather than throwing on boot
- writes survive a storage that throws (private mode / quota)

## The control reports state

It flips to "Saved as default" and disables once the stored value matches, rather than inviting a no-op click. Disabled here means *already true*, so it stays legible with a dashed border instead of dimming to dead-control grey.

## Two existing pins updated

Both now describe the new shape rather than the old one — neither assertion was weakened:

- `chat-inline-composer` — the composer slot now carries the trailing row, so the pin matches the guard and wrapper instead of a one-liner (plus a second assertion that it still renders nothing without a composer)
- `task-chat-cwd` — enumerates `resolveChatProjectSelection`'s arguments, which gained one

## Verification

- **full app suite run per-test — 0 failures** (not through the short-circuiting runner)
- `typecheck`, `lint`, `check:tests-wired` clean
- driven in the built app: clicking moved storage from `null` to `{"projectId":"…","model":"github/gpt-5.6-sol"}` and flipped the label
- initial/route CSS 850 → **851 KB** of 865 (13.5 KB headroom, still THIN)