### PR TITLE
test(ci): un-quarantine familiar-x-section — it passes again

### DIFF
--- a/scripts/check-tests-wired.mjs
+++ b/scripts/check-tests-wired.mjs
@@ -41,22 +41,6 @@ const ALLOWLIST = new Map([
     // tweaking until the errors stop.
     "never executed since landing; blocked on cave-7ruzl",
   ],
-  [
-    "src/components/familiar-x-section.test.ts",
-    // QUARANTINED — cave-lsj8u. This test asserts against a feature that is
-    // only half on main: the X API work landed its lib/ and components/ side
-    // and left src/app/api/x/ behind entirely, so the test dies reading
-    // app/api/x/oauth/start/route.ts, and app/api/familiars/route.ts carries
-    // ZERO of the X fields it checks for.
-    //
-    // Guarding the missing reads one at a time was tried and abandoned: with
-    // the subject substantially absent, that path ends at a test whittled down
-    // until it passes, which is worse than one that is honestly switched off.
-    // The other four X tests (x-api, x-oauth, familiar-x-section-behavior,
-    // research-x-sources) all pass and stay wired — this is the only one whose
-    // subject did not land.
-    "subject half-landed; blocked on cave-lsj8u",
-  ],
 ]);
 
 function walk(dir, acc) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -115,6 +115,7 @@ export const SUITES = {
     "src/lib/server/x-access.test.ts",
     "src/lib/server/x-sources.test.ts",
     "src/lib/open-system-browser.test.ts",
+    "src/components/familiar-x-section.test.ts",
     "src/components/familiar-x-section-behavior.test.tsx",
     "src/lib/mcp-doctor.test.ts",
     "src/lib/settings-profile-form.test.ts",


### PR DESCRIPTION
I quarantined this test earlier today (#4180) because it read `src/app/api/x/oauth/start/route.ts`, which never landed, and died with ENOENT at module scope — taking all 66 of its assertions with it.

**#4192 removed those four route-dependent assertions**, so the test no longer depends on the missing file. Verified passing against current `main` before touching the wiring.

Re-wired into the app suite, dropped from `ALLOWLIST`.

## Why this matters more than the diff suggests

A quarantine that outlives its cause is worse than the failure it hid. The file sits on disk looking covered while nothing runs it, and `check:tests-wired` reports it as *deliberately excluded* rather than *broken* — so the signal that would prompt someone to look is gone. Mine was two commits from becoming permanent, and I only caught it because I went back to check whether #4192 had resolved the beads I'd filed.

## What the fix cost, recorded

The allowlist entry was the only place this was written down, so putting it here instead:

The DELETE-handler assertions are **gone, not satisfied**. The X route directory still does not exist on `main`:

```
$ git ls-tree -r --name-only origin/main -- src/app/api/x/
(empty)
```

#4192 restored the Rust OAuth side (`shell_open_commands.rs`, `shell_open_helpers.rs`) and the familiars route — not the handlers. That's its author's call to make, and the file's other 62 assertions run again either way. Recorded on **cave-lsj8u**.

## Patrol stays quarantined

`worktree-lifecycle-patrol` (**cave-7ruzl**) keeps its allowlist entry. #4192 repaired it, but I have not re-verified it here — it runs past ten minutes locally without producing output, so re-wiring on the strength of a PR title would be the same mistake in the other direction.