### PR TITLE
test(ci): un-quarantine worktree-lifecycle-patrol

### DIFF
--- a/scripts/check-tests-wired.mjs
+++ b/scripts/check-tests-wired.mjs
@@ -23,24 +23,6 @@ const ALLOWLIST = new Map([
   // and passes COVEN_RELEASE_NOTES_ROOT, so it runs anywhere (cave-5yyj1).
   // Adding an entry means a test nothing runs — justify it here and expect the
   // justification to be read.
-  [
-    "scripts/worktree-lifecycle-patrol.test.mjs",
-    // QUARANTINED, not orphaned — cave-7ruzl. This test has NEVER executed:
-    // it failed to parse from the moment it landed (shell parameter expansions
-    // unescaped inside JS template literals), and the parse error was itself
-    // masked because worktree-lifecycle-retirement.test.mjs fails earlier in
-    // the suite. PR #4180 fixed the parse error and a fixture bug, at which
-    // point it reaches a further one: its stub `gh` never writes the
-    // workflow-calls-<n> marker the assertions read.
-    //
-    // Quarantining loses no coverage we currently have — the test has produced
-    // exactly zero signal to date — and it stops one never-run file holding
-    // the whole frontend gate red. It is NOT an invitation to keep it here:
-    // this file guards automated branch and worktree deletion, so it needs its
-    // author to say what it should assert, not another pass of fixture
-    // tweaking until the errors stop.
-    "never executed since landing; blocked on cave-7ruzl",
-  ],
 ]);
 
 function walk(dir, acc) {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -50,6 +50,7 @@ export const SUITES = {
     "scripts/test-alias-loader.test.mjs",
     "scripts/maintenance-gate.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
+    "scripts/worktree-lifecycle-patrol.test.mjs",
     "src/lib/board-cache-events.test.ts",
     "src/lib/surface-warmup-registry.test.ts",
     "src/components/workspace-surface-warmup.test.ts",


### PR DESCRIPTION
#4192 repaired the test and it now passes — a clean run against this base wrote `worktree-lifecycle-patrol.test.mjs: ok`. The quarantine I added in #4180 has outlived its cause, so it's removed and the test is wired back into the app suite.

That empties `ALLOWLIST` again, which is the state its own comment documents as correct.

## ⚠️ This PR is also a measurement

**Do not merge on a green `check:tests-wired` alone.** Read `Frontend build`'s duration.

| | |
|---|---|
| patrol runtime (loaded local machine) | **~19 min** |
| `Frontend build` `timeout-minutes` | **15** |
| `Frontend build` current duration | **8m33s** |
| headroom | **~6.5 min** |

If patrol isn't at least ~3× faster on a clean runner than it was locally, this job **times out and takes `main` red** — the opposite of what un-quarantining is for.

I'm deliberately learning that here rather than on `main`. The PR gate is exactly the safe place to find out, and it costs one CI run.

**If `Frontend build` goes red by timeout: don't merge.** The finding is that patrol needs to get faster, or move to its own job with its own budget, before it can rejoin this suite — and that belongs on **cave-7ruzl** rather than being forced through.

## Why a quarantine outliving its cause is worth chasing

Same argument as #4196, which removed the other one: the file sits on disk looking covered while nothing runs it, and `check:tests-wired` reports it as *deliberately excluded* rather than *broken*, so the signal that would prompt someone to look is gone.

## Not a conflict with #4181

That PR touches the patrol test body and `run-tests.mjs`, but only to drop the two stale `src/app/api/x/` entries already removed in #4180. It does not re-wire patrol, so this doesn't duplicate or race it.