### PR TITLE
fix(github): row hand-off goes through the user's own familiar picker

### DIFF
--- a/src/components/github-stream.tsx
+++ b/src/components/github-stream.tsx
@@ -211,6 +211,14 @@ function StreamRow({
   const meta = metaFor(entry);
   const numberSuffix = row.number != null ? ` #${row.number}` : "";
 
+  // The row is a click target AND a double-click target, so anything
+  // interactive nested inside it has to swallow both. Stopping only `click`
+  // leaves `dblclick` bubbling — an impatient double-click on the hand-off
+  // picker or the Peek verb would open the focused read out from under you.
+  const stopRowActivation = useCallback((e: React.SyntheticEvent) => {
+    e.stopPropagation();
+  }, []);
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
       if (e.key !== "Enter" && e.key !== " ") return;
@@ -250,22 +258,31 @@ function StreamRow({
             ))}
           </span>
           <RelativeTime iso={row.updatedAt} className="gh-stream-row-age" />
-          <span className="gh-stream-row-verbs reveal-on-hover">
+          <span
+            className="gh-stream-row-verbs reveal-on-hover"
+            onClick={stopRowActivation}
+            onDoubleClick={stopRowActivation}
+          >
             <button
               type="button"
               className="gh-stream-verb focus-ring"
               aria-expanded={peekOpen}
               title={peekOpen ? "Hide the peek" : "Peek without leaving the list"}
               onClick={(e) => { e.stopPropagation(); onTogglePeek(row.id); }}
+              onDoubleClick={stopRowActivation}
             >
               <Icon name={peekOpen ? "ph:caret-up" : "ph:caret-down"} width={9} aria-hidden />
               Peek
             </button>
             {renderHandOff ? (
               // The wrapper is not the affordance — the picker inside it is.
-              // It only stops the row's own click from firing (and re-selecting)
-              // while you are choosing a familiar, so it needs no key handler.
-              <span className="gh-stream-handoff" onClick={(e) => e.stopPropagation()}>
+              // It only keeps the row's own click/double-click from firing while
+              // you are choosing a familiar, so it needs no key handler.
+              <span
+                className="gh-stream-handoff"
+                onClick={stopRowActivation}
+                onDoubleClick={stopRowActivation}
+              >
                 {renderHandOff(row)}
               </span>
             ) : null}
@@ -317,11 +334,16 @@ function StreamRow({
                 type="button"
                 className="gh-stream-peek-primary focus-ring"
                 onClick={(e) => { e.stopPropagation(); onOpen(row.id); }}
+                onDoubleClick={stopRowActivation}
               >
                 Open detail
               </button>
               {renderRowActions ? (
-                <span className="gh-stream-peek-verbs" onClick={(e) => e.stopPropagation()}>
+                <span
+                  className="gh-stream-peek-verbs"
+                  onClick={stopRowActivation}
+                  onDoubleClick={stopRowActivation}
+                >
                   {renderRowActions(row)}
                 </span>
               ) : null}

--- a/src/components/github-stream.tsx
+++ b/src/components/github-stream.tsx
@@ -76,9 +76,13 @@ export type GitHubStreamProps = {
   onSelect: (id: string) => void;
   /** Select and raise the focused detail view. */
   onOpen: (id: string) => void;
-  /** Hand the row to a familiar — the stream's one accented row verb. */
-  onHandOff?: (item: GitHubItem) => void;
-  handOffLabel?: string;
+  /**
+   * The row's hand-off verb. A slot rather than a callback because handing work
+   * to a familiar means choosing WHICH familiar — that picker is the host's
+   * (it reads the user's own roster), and this component must never assume a
+   * name or a default.
+   */
+  renderHandOff?: (item: GitHubItem) => ReactNode;
   /** The existing chat / board / merge verbs, rendered into the peek footer. */
   renderRowActions?: (item: GitHubItem) => ReactNode;
 };
@@ -92,8 +96,7 @@ export function GitHubStream({
   onTogglePeek,
   onSelect,
   onOpen,
-  onHandOff,
-  handOffLabel = "Hand to a familiar",
+  renderHandOff,
   renderRowActions,
 }: GitHubStreamProps) {
   const listRef = useRef<HTMLDivElement | null>(null);
@@ -172,8 +175,7 @@ export function GitHubStream({
                     onTogglePeek={onTogglePeek}
                     onSelect={onSelect}
                     onOpen={onOpen}
-                    onHandOff={onHandOff}
-                    handOffLabel={handOffLabel}
+                    renderHandOff={renderHandOff}
                     renderRowActions={renderRowActions}
                   />
                 ))}
@@ -191,8 +193,7 @@ function StreamRow({
   onTogglePeek,
   onSelect,
   onOpen,
-  onHandOff,
-  handOffLabel,
+  renderHandOff,
   renderRowActions,
 }: {
   entry: GhStreamEntry<GitHubItem>;
@@ -201,8 +202,7 @@ function StreamRow({
   onTogglePeek: (id: string) => void;
   onSelect: (id: string) => void;
   onOpen: (id: string) => void;
-  onHandOff?: (item: GitHubItem) => void;
-  handOffLabel: string;
+  renderHandOff?: (item: GitHubItem) => ReactNode;
   renderRowActions?: (item: GitHubItem) => ReactNode;
 }) {
   const { row, stage } = entry;
@@ -261,16 +261,13 @@ function StreamRow({
               <Icon name={peekOpen ? "ph:caret-up" : "ph:caret-down"} width={9} aria-hidden />
               Peek
             </button>
-            {onHandOff ? (
-              <button
-                type="button"
-                className="gh-stream-verb gh-stream-verb--accent focus-ring"
-                title={handOffLabel}
-                onClick={(e) => { e.stopPropagation(); onHandOff(row); }}
-              >
-                <Icon name="ph:sparkle" width={9} aria-hidden />
-                Hand off
-              </button>
+            {renderHandOff ? (
+              // The wrapper is not the affordance — the picker inside it is.
+              // It only stops the row's own click from firing (and re-selecting)
+              // while you are choosing a familiar, so it needs no key handler.
+              <span className="gh-stream-handoff" onClick={(e) => e.stopPropagation()}>
+                {renderHandOff(row)}
+              </span>
             ) : null}
           </span>
         </span>

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -238,6 +238,21 @@ assert.match(
 for (const [name, src] of [["stream", stream], ["stage", stage]]) {
   assert.doesNotMatch(src, /\bCody\b/i, `${name} names no specific familiar`);
 }
+
+// The row is both a click and a double-click target, so every interactive
+// island nested inside it must swallow BOTH. Stopping only `click` leaves
+// `dblclick` bubbling, and an impatient double-click on the hand-off picker or
+// the Peek verb opens the focused read out from under the interaction.
+assert.match(stream, /const stopRowActivation = useCallback\(/, "one helper swallows row activation for nested islands");
+{
+  const islands = stream.match(/onDoubleClick=\{stopRowActivation\}/g) ?? [];
+  assert.ok(islands.length >= 5, `every nested island stops dblclick (found ${islands.length}, expected >= 5)`);
+}
+assert.match(
+  stream,
+  /className="gh-stream-handoff"\s*\n\s*onClick=\{stopRowActivation\}\s*\n\s*onDoubleClick=\{stopRowActivation\}/,
+  "the hand-off slot swallows both activations",
+);
 assert.match(boardCss, /\.gh-tone--ok\s+\{ --gh-tone:var\(--color-success\); \}/, "one custom property carries a row's tone to every part that paints it");
 
 // ── Landing gates ─────────────────────────────────────────────────────────────

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -222,6 +222,22 @@ assert.match(source, /allSections\.filter\(\(s\) => pickedFacets\.includes\(s\.k
 assert.match(source, /const live = picked\.filter\(\(key\) => allSections\.some\(\(s\) => s\.key === key\)\)/, "a facet whose section disappeared is dropped rather than silently emptying the list");
 assert.match(stage, /return defs[\s\S]{0,200}?\.filter\(\(s\) => s\.entries\.length > 0\)/, "empty sections are dropped, not rendered as bare headings");
 assert.match(stream, /GH_NEXT_STEP\[stage\.key\]/, "peek names the next step for the row's stage");
+
+// ── The stream never names or defaults a familiar ────────────────────────────
+// Handing work off means choosing WHICH familiar, from the user's own roster.
+// The stream takes a slot; the host fills it with the picker. A callback here
+// would have invited a hardcoded default, and the earlier `onHandOff` prop was
+// never wired at all, so the row verb silently did not render.
+assert.doesNotMatch(stream, /onHandOff|handOffLabel/, "the dead hand-off callback is gone");
+assert.match(stream, /renderHandOff\?: \(item: GitHubItem\) => ReactNode;/, "hand-off is a host-rendered slot");
+assert.match(
+  source,
+  /renderHandOff=\{\(item\) => \(\s*<OpenChatAction/,
+  "the host fills the hand-off slot with the familiar picker",
+);
+for (const [name, src] of [["stream", stream], ["stage", stage]]) {
+  assert.doesNotMatch(src, /\bCody\b/i, `${name} names no specific familiar`);
+}
 assert.match(boardCss, /\.gh-tone--ok\s+\{ --gh-tone:var\(--color-success\); \}/, "one custom property carries a row's tone to every part that paints it");
 
 // ── Landing gates ─────────────────────────────────────────────────────────────

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -3616,20 +3616,26 @@ export function GitHubView({
                   onTogglePeek={togglePeek}
                   onSelect={selectRow}
                   onOpen={openDetail}
+                  // The row's hand-off. OpenChatAction opens the familiar
+                  // picker (GitHubActionPopover reads /api/familiars), so the
+                  // work always goes to a familiar the user chose from their
+                  // own roster — the stream never names or defaults one.
+                  renderHandOff={(item) => (
+                    <OpenChatAction
+                      item={item}
+                      linkedCards={linkedMap.get(item.id) ?? []}
+                      familiars={familiars}
+                      cards={cards}
+                      familiarsFailed={familiarsFailed}
+                      cardsFailed={cardsFailed}
+                      onJumpToSession={onJumpToSession}
+                      onAfterLink={refreshLinkedWork}
+                    />
+                  )}
                   renderRowActions={(item) => {
                     const linked = linkedMap.get(item.id) ?? [];
                     return (
                       <>
-                        <OpenChatAction
-                          item={item}
-                          linkedCards={linked}
-                          familiars={familiars}
-                          cards={cards}
-                          familiarsFailed={familiarsFailed}
-                          cardsFailed={cardsFailed}
-                          onJumpToSession={onJumpToSession}
-                          onAfterLink={refreshLinkedWork}
-                        />
                         <AddToBoardAction
                           item={item}
                           familiars={familiars}

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -710,3 +710,9 @@
   overflow:hidden;
 }
 .gh-budget-fill { display:block; height:100%; background:currentColor; border-radius:2px; }
+
+/* The row's hand-off slot. The host renders the familiar picker into it, so
+   the sizing lives here rather than in the stream — the row only guarantees
+   the space and the hover reveal. */
+.gh-stream-handoff { display:inline-flex; align-items:center; }
+.gh-stream-handoff .gh-action-wrap { display:inline-flex; }


### PR DESCRIPTION
Follow-up to #4198.

## The bug

`GitHubStream` declared an `onHandOff` callback and rendered a
"Hand to a familiar" button from it — and `github-view.tsx` **never passed
it**. The design's row-hover hand-off silently did not render at all. Tests
passed because nothing asserted it was wired.

## Why it's a slot now, not a callback

A bare `onHandOff(item)` has to decide *which* familiar somewhere, and the
obvious place to put that decision is a default. There is no correct default:
familiars are the user's own, and the one in the design mock is the designer's.

So the row takes a slot:

```ts
renderHandOff?: (item: GitHubItem) => ReactNode
```

and the host fills it with the existing `OpenChatAction`, whose picker reads
`/api/familiars` and lists whatever roster this user has. **The stream cannot
name a familiar because it never sees one.**

The peek footer drops its now-duplicate chat verb; the row's label comes from
the picker itself (`Start` / `Open` / `Open (n)`), which already reflects
whether linked work exists.

## Guards

`github-view-polish.test.ts` now pins:

- the dead `onHandOff` / `handOffLabel` props stay gone
- hand-off is a host-rendered slot
- the host fills it with the familiar picker
- **neither `github-stream.tsx` nor `github-stage.ts` contains a familiar
  name** — a `/\bCody\b/i` assertion over both files, so the mock's name can't
  drift back in from a future copy-paste

## Verification

- `pnpm test:app` 1044 files ✓ · `pnpm lint` ✓ · `tsc --noEmit` ✓ ·
  `pnpm build` ✓ (budgets unchanged)
- Driven in the running Code Workshop: row verbs are now `["Peek", "Start"]`
  (previously just `["Peek"]` — the hand-off was absent), and opening it shows
  **"Start a chat with… Nova"**, the mocked roster's familiar, resolved from
  data rather than hardcoded.

No design-token ratchet movement — the one new rule is a layout wrapper for
the slot.