### PR TITLE
fix(github): keep the row's accent on the hand-off slot

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -244,15 +244,18 @@ for (const [name, src] of [["stream", stream], ["stage", stage]]) {
 // .gh-stream-verb--accent as dead CSS and the row with no primary-action
 // signal at all. The accent now reaches the slot by selector, so this pins
 // both halves: the declarations stay live, and the slot is what wears them.
+// Whitespace-tolerant on purpose: these pin the SELECTOR PAIRING, not the
+// formatting. A regex that demands a literal newline fails on a reflow that
+// changed nothing, which trains people to edit the test instead of reading it.
 assert.match(
   boardCss,
-  /\.gh-stream-verb--accent,\s*\n\.gh-stream-handoff \.ui-btn \{/,
+  /\.gh-stream-verb--accent,\s*\.gh-stream-handoff \.ui-btn\s*\{/,
   "the row's accent reaches the hand-off slot rather than becoming dead CSS",
 );
 // The slot's wrapper does not restate what .gh-action-wrap already sets.
 assert.doesNotMatch(
   boardCss,
-  /\.gh-stream-handoff \.gh-action-wrap \{ display:inline-flex; \}/,
+  /\.gh-stream-handoff\s+\.gh-action-wrap\s*\{\s*display:\s*inline-flex/,
   "the hand-off wrapper does not restate .gh-action-wrap's own display",
 );
 

--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -239,6 +239,23 @@ for (const [name, src] of [["stream", stream], ["stage", stage]]) {
   assert.doesNotMatch(src, /\bCody\b/i, `${name} names no specific familiar`);
 }
 
+// The row keeps exactly ONE accented verb. Moving the hand-off to a slot took
+// the accent off it (the slot renders a plain secondary button), which left
+// .gh-stream-verb--accent as dead CSS and the row with no primary-action
+// signal at all. The accent now reaches the slot by selector, so this pins
+// both halves: the declarations stay live, and the slot is what wears them.
+assert.match(
+  boardCss,
+  /\.gh-stream-verb--accent,\s*\n\.gh-stream-handoff \.ui-btn \{/,
+  "the row's accent reaches the hand-off slot rather than becoming dead CSS",
+);
+// The slot's wrapper does not restate what .gh-action-wrap already sets.
+assert.doesNotMatch(
+  boardCss,
+  /\.gh-stream-handoff \.gh-action-wrap \{ display:inline-flex; \}/,
+  "the hand-off wrapper does not restate .gh-action-wrap's own display",
+);
+
 // The row is both a click and a double-click target, so every interactive
 // island nested inside it must swallow BOTH. Stopping only `click` leaves
 // `dblclick` bubbling, and an impatient double-click on the hand-off picker or

--- a/src/styles/board/github-list.css
+++ b/src/styles/board/github-list.css
@@ -512,12 +512,19 @@
   cursor:pointer;
 }
 .gh-stream-verb:hover { background:var(--bg-hover); color:var(--text-primary); }
-.gh-stream-verb--accent {
+/* The row's ONE accented verb. The hand-off is now a host-rendered slot rather
+   than a button this component styles, so the accent reaches it by selector —
+   the alternative was a second copy of these declarations living next to the
+   slot, which is how two "accents" drift apart. Whatever the host renders into
+   the slot inherits the row's accent, and there is still exactly one. */
+.gh-stream-verb--accent,
+.gh-stream-handoff .ui-btn {
   border-color:color-mix(in oklch,var(--accent-presence) 40%,transparent);
   background:color-mix(in oklch,var(--accent-presence) 15%,transparent);
   color:var(--accent-presence);
 }
-.gh-stream-verb--accent:hover {
+.gh-stream-verb--accent:hover,
+.gh-stream-handoff .ui-btn:hover {
   background:color-mix(in oklch,var(--accent-presence) 26%,transparent);
   color:var(--text-primary);
 }
@@ -713,6 +720,6 @@
 
 /* The row's hand-off slot. The host renders the familiar picker into it, so
    the sizing lives here rather than in the stream — the row only guarantees
-   the space and the hover reveal. */
+   the space and the hover reveal. (.gh-action-wrap is already inline-flex; it
+   does not need restating here.) */
 .gh-stream-handoff { display:inline-flex; align-items:center; }
-.gh-stream-handoff .gh-action-wrap { display:inline-flex; }


### PR DESCRIPTION
Review follow-ups on #4203, which merged while the review was in flight — so these land as their own PR rather than as commits on that branch.

## 1. The row lost its one accented verb

#4203 moved the hand-off from a button `GitHubStream` styled to a host-rendered slot. The slot renders `<Button variant="secondary">`, so the accent went with it: `.gh-stream-verb--accent` was left with **zero** call sites, and the row with no primary-action signal at all.

The prop comment #4203 deleted said it plainly:

> `/** Hand the row to a familiar — the stream's one accented row verb. */`

The accent now reaches the slot by selector instead of being restated next to it:

```css
.gh-stream-verb--accent,
.gh-stream-handoff .ui-btn { … }
```

One set of declarations, still exactly one accented verb per row, and whatever the host renders into the slot wears it. Checked for leakage: `github-action-popover.tsx` renders no `.ui-btn` (the picker's rows are `.gh-action-popover-item`), so the selector cannot reach past the trigger.

## 2. A no-op rule

`.gh-stream-handoff .gh-action-wrap { display:inline-flex; }` restated what `.gh-action-wrap` already declares one file over. Dropped.

## Guards

Both pinned in `github-view-polish.test.ts` — the accent dying was silent the first time, which is the whole reason it survived review.

## Not in scope

Two other findings from the same review, left alone deliberately:

- **Height/typography mismatch.** `.gh-stream-verb` is `19px`/mono/`--text-2xs`; `.ui-btn--xs` is `22px`/sans/`--text-xs`. They sit adjacent in a `gap:3px` cluster. `align-items:center` keeps it from breaking, but Peek and the hand-off now read as two different families of control. That's a call for whoever owns the row's visual language.
- **`SafeMergeAction` still defaults to `familiars[0]`** (`github-view.tsx:550`) — the exact thing #4203 argues is never correct. Filed as `cave-26sg4`.

Verified: `github-view-polish.test.ts` · `typecheck` · `lint` all green; compiled CSS confirms the accent declarations reach `.gh-stream-handoff .ui-btn` and the no-op is gone.
