### PR TITLE
fix(x): hide the X surfaces until their routes land (cave-lsj8u)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -118,6 +118,7 @@ export const SUITES = {
     "src/lib/open-system-browser.test.ts",
     "src/components/familiar-x-section.test.ts",
     "src/components/familiar-x-section-behavior.test.tsx",
+    "src/components/x-surface-gating.test.ts",
     "src/lib/mcp-doctor.test.ts",
     "src/lib/settings-profile-form.test.ts",
     "src/lib/user-profile-shared.test.ts",

--- a/src/components/familiar-studio-brain-tab.test.ts
+++ b/src/components/familiar-studio-brain-tab.test.ts
@@ -133,7 +133,10 @@ assert.match(
 );
 assert.match(
   source,
-  /<FamiliarAsanaSection familiar=\{familiar\} \/>\s*<FamiliarXSection familiar=\{familiar\} \/>/,
+  // Still beside Asana, but now behind the cave-lsj8u capability gate: the X
+  // routes never landed, so the section stays hidden until they do. Ordering is
+  // what this pins; the gate itself is pinned in x-surface-gating.test.ts.
+  /<FamiliarAsanaSection familiar=\{familiar\} \/>[\s\S]{0,700}?<FamiliarXSection familiar=\{familiar\} \/>/,
   "X account and grants should render beside the existing Asana integration",
 );
 assert.match(

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -1518,15 +1518,15 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
           </section>
 
           <FamiliarAsanaSection familiar={familiar} />
-          {/* cave-lsj8u: the X connection routes (/api/x/connection,
-            /api/x/oauth/start) exist only on tag
-            archive/cave-8i8q5-wip-2026-07-29, so this section 404s and shows a
-            permanent ErrorState. Gated on EITHER capability, since the
-            connection serves both: whichever half lands first re-exposes it.
-            Delete this condition when the routes land. */}
-        {familiar.xResearchEnabled || familiar.xPublishEnabled ? (
-          <FamiliarXSection familiar={familiar} />
-        ) : null}
+            {/* cave-lsj8u: the X connection routes (/api/x/connection,
+              /api/x/oauth/start) exist only on tag
+              archive/cave-8i8q5-wip-2026-07-29, so this section 404s and shows a
+              permanent ErrorState. Gated on EITHER capability, since the
+              connection serves both: whichever half lands first re-exposes it.
+              Delete this condition when the routes land. */}
+          {familiar.xResearchEnabled || familiar.xPublishEnabled ? (
+            <FamiliarXSection familiar={familiar} />
+          ) : null}
 
           {harnessId ? (
             <details

--- a/src/components/familiar-studio-brain-tab.tsx
+++ b/src/components/familiar-studio-brain-tab.tsx
@@ -1518,7 +1518,15 @@ export function FamiliarStudioBrainTab({ familiar }: Props) {
           </section>
 
           <FamiliarAsanaSection familiar={familiar} />
+          {/* cave-lsj8u: the X connection routes (/api/x/connection,
+            /api/x/oauth/start) exist only on tag
+            archive/cave-8i8q5-wip-2026-07-29, so this section 404s and shows a
+            permanent ErrorState. Gated on EITHER capability, since the
+            connection serves both: whichever half lands first re-exposes it.
+            Delete this condition when the routes land. */}
+        {familiar.xResearchEnabled || familiar.xPublishEnabled ? (
           <FamiliarXSection familiar={familiar} />
+        ) : null}
 
           {harnessId ? (
             <details

--- a/src/components/familiar-x-section.test.ts
+++ b/src/components/familiar-x-section.test.ts
@@ -172,7 +172,10 @@ assert.match(
 assert.match(brain, /import \{ FamiliarXSection \} from "@\/components\/familiar-x-section"/);
 assert.match(
   brain,
-  /<FamiliarAsanaSection familiar=\{familiar\} \/>\s*<FamiliarXSection familiar=\{familiar\} \/>/,
+  // Still beside Asana, but now behind the cave-lsj8u capability gate: the X
+  // routes never landed, so the section stays hidden until they do. Ordering is
+  // what this pins; the gate itself is pinned in x-surface-gating.test.ts.
+  /<FamiliarAsanaSection familiar=\{familiar\} \/>[\s\S]{0,700}?<FamiliarXSection familiar=\{familiar\} \/>/,
   "X settings render beside Asana",
 );
 assert.match(types, /xResearchEnabled\?: boolean/);

--- a/src/components/role-surfaces/research-tab-resources.tsx
+++ b/src/components/role-surfaces/research-tab-resources.tsx
@@ -307,11 +307,19 @@ export function ResearchTabResources({ research, context, onNavigate }: Research
         </span>
       </header>
 
-      <ResearchXSources
-        familiar={context.activeFamiliar}
-        selectedMissionId={selectedMission?.id ?? null}
-        onMissionAttached={research.applyMission}
-      />
+      {/* cave-lsj8u: src/app/api/x/ never landed, so this section's every
+          fetch (/api/x/sources, /posts/search, /posts/lookup) 404s and it
+          renders a permanent ErrorState. Gate it on the capability flag the
+          familiars API already returns — off by default, so the surface stays
+          hidden until the routes exist. Delete this condition when they land;
+          the component itself needs no change. */}
+      {context.activeFamiliar?.xResearchEnabled ? (
+        <ResearchXSources
+          familiar={context.activeFamiliar}
+          selectedMissionId={selectedMission?.id ?? null}
+          onMissionAttached={research.applyMission}
+        />
+      ) : null}
 
       <form className="research-res__intake" onSubmit={onSave}>
         <div className="research-res__intake-head">

--- a/src/components/x-surface-gating.test.ts
+++ b/src/components/x-surface-gating.test.ts
@@ -1,0 +1,61 @@
+// @ts-nocheck
+// The X surfaces stay hidden until their routes exist (cave-lsj8u).
+//
+// The X work landed its lib/ and components/ half on main and left
+// src/app/api/x/ behind entirely. Both surfaces rendered unconditionally, so
+// every fetch 404'd and each showed a permanent ErrorState — a section that
+// can only ever fail, offered to every user.
+//
+// These pins hold the gate in place. They are deliberately cheap to satisfy
+// and cheap to DELETE: when the routes land, removing the conditions makes
+// these fail, which is the prompt to remove the pins too.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { existsSync } from "node:fs";
+import { readFileSync } from "node:fs";
+
+const studio = readFileSync(new URL("./familiar-studio-brain-tab.tsx", import.meta.url), "utf8");
+const research = readFileSync(
+  new URL("./role-surfaces/research-tab-resources.tsx", import.meta.url),
+  "utf8",
+);
+const types = readFileSync(new URL("../lib/types.ts", import.meta.url), "utf8");
+const familiarsRoute = readFileSync(new URL("../app/api/familiars/route.ts", import.meta.url), "utf8");
+
+test("the gate reads flags that actually reach the client", () => {
+  // A gate on a field the API never sends would hide the surface forever and
+  // look like a bug rather than a decision.
+  for (const flag of ["xResearchEnabled", "xPublishEnabled"]) {
+    assert.match(types, new RegExp(`${flag}\\?: boolean`), `Familiar carries ${flag}`);
+    assert.match(familiarsRoute, new RegExp(`${flag}: configEntry\\.${flag} === true`),
+      `/api/familiars emits ${flag}`);
+  }
+});
+
+test("the research surface is gated on the research capability", () => {
+  assert.match(
+    research,
+    /\{context\.activeFamiliar\?\.xResearchEnabled \? \(\s*<ResearchXSources/,
+    "ResearchXSources renders only when the familiar has X research enabled",
+  );
+});
+
+test("the studio connection section is gated on EITHER capability", () => {
+  // The connection serves both halves, so whichever lands first re-exposes it.
+  assert.match(
+    studio,
+    /\{familiar\.xResearchEnabled \|\| familiar\.xPublishEnabled \? \(\s*<FamiliarXSection/,
+    "FamiliarXSection renders when either X capability is enabled",
+  );
+});
+
+test("the gate exists because the routes do not", () => {
+  // The moment this stops being true, the gate is obsolete: delete the
+  // conditions and this file together.
+  assert.equal(
+    existsSync(new URL("../app/api/x/", import.meta.url)),
+    false,
+    "src/app/api/x/ has landed — remove the gates in familiar-studio-brain-tab " +
+      "and research-tab-resources, and delete this test (cave-lsj8u)",
+  );
+});

--- a/src/components/x-surface-gating.test.ts
+++ b/src/components/x-surface-gating.test.ts
@@ -11,8 +11,7 @@
 // these fail, which is the prompt to remove the pins too.
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { existsSync } from "node:fs";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 
 const studio = readFileSync(new URL("./familiar-studio-brain-tab.tsx", import.meta.url), "utf8");
 const research = readFileSync(


### PR DESCRIPTION
> ⚠️ **This hides another team's in-flight feature.** Reversible in two lines. Flagging it up top so the X owner hears it from the PR rather than discovering it.

## The problem

Two X surfaces ship on `main` and render **unconditionally**, and every endpoint they call 404s:

| Surface | Reached via | Calls |
|---|---|---|
| `FamiliarXSection` | Familiar studio → brain tab | `/api/x/connection`, `/api/x/oauth/start` |
| `ResearchXSources` | Research tab → resources | `/api/x/posts/lookup`, `/api/x/posts/search`, `/api/x/sources` |

`src/app/api/x/` never landed — the X work put its `lib/` and `components/` half on `main` and left the handlers behind.

**Not a crash.** Both components check `response.ok` and render `ErrorState`, so users see "Couldn't load the X connection". But it's a section that can *only ever fail*, offered to everyone.

## The fix

Gated on the capability flags `/api/familiars` **already returns**. No new plumbing — `xResearchEnabled` and `xPublishEnabled` are on the `Familiar` type and emitted by the route (#4192); they were simply never consulted at either render site.

The studio connection section is gated on **either** capability, because the connection serves both halves. Gating it on one would leave it hidden after a half-restore, which reads as a bug rather than a decision.

## The test retires itself

```js
assert.equal(existsSync(".../app/api/x/"), false,
  "src/app/api/x/ has landed — remove the gates and delete this test")
```

Landing the routes makes this fail **on purpose**, and the failure names what to delete. A gate with no expiry becomes permanent by neglect; this one has a tripwire.

It also verifies the flags genuinely reach the client — a gate reading a field the API never sends would hide the surface forever and look like a bug rather than a choice.

## Two existing pins widened, not weakened

`familiar-x-section` and `familiar-studio-brain-tab` both asserted `<FamiliarAsanaSection/>` *immediately* followed by `<FamiliarXSection/>`. The section is still beside Asana, just behind a condition — so the regexes now tolerate the gate between them and carry a note pointing at where the gate itself is pinned.

Placement and gating stay **separate guarantees**; collapsing them would have quietly lost the placement check.

## Recovery status (full forensics on cave-lsj8u)

I searched every branch, remote, tag, stash and dangling blob:

- ✅ `/connection` + `/oauth/start` — **recoverable** from tag `archive/cave-8i8q5-wip-2026-07-29`
- ❌ `/posts/lookup`, `/posts/search`, `/sources` — on **no ref, no stash, no dangling blob**. They were staged in the primary checkout earlier today and have since left the index, working tree and object graph. **Plan to rewrite, not hunt** — that's the expensive default this saves.

## Verification

Full app suite run per-test — **0 failures**. Typecheck, lint, `check:tests-wired` clean.

The first sweep caught two real failures from this change (the adjacency pins above); they're fixed here rather than worked around.