### PR TITLE
test(lifecycle): make the patrol test's ten silent minutes legible and bounded

### DIFF
--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -36,11 +36,20 @@ const duplicateRegisteredPath = path.join(fixtureRoot, "duplicate-registered");
 const duplicateWorktreeInventory = path.join(fixtureRoot, "duplicate-worktree-inventory");
 const metadataAlias = path.join(fixtureRoot, "old-alias");
 
+// No child of this test should ever run unbounded. `execFileSync` without a
+// timeout waits forever, so a wedged git or a stub that never exits used to
+// stall the whole app suite with no output and no way to tell it apart from
+// slow-but-working. 120s is far above the slowest observed call (~5.6s for a
+// full patrol spawn) — it exists to convert a hang into a failure, not to
+// police speed.
+const CHILD_TIMEOUT_MS = Number(process.env.LIFECYCLE_TEST_CHILD_TIMEOUT_MS ?? 120_000);
+
 function run(command, args, cwd, options = {}) {
   return execFileSync(command, args, {
     cwd,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
+    timeout: CHILD_TIMEOUT_MS,
     ...options,
   });
 }
@@ -1404,8 +1413,21 @@ exit 0
   );
   let patrolInvocation = 0;
   let lastPatrolInvocation = "";
+  // This file spawns the patrol ~140 times at ~4.5s apiece (measured: 5.15s
+  // mean over the first ten, 3.75s over the last ten — flat, not degrading), so
+  // it produces no output for roughly ten minutes. That silence is
+  // indistinguishable from a hang and has been mistaken for one. Emit a
+  // heartbeat per spawn — cheap, and it names the exact invocation to look at
+  // when something does wedge.
+  const startedAt = Date.now();
+  const heartbeat = (label) => {
+    if (process.env.LIFECYCLE_TEST_QUIET) return;
+    const elapsed = ((Date.now() - startedAt) / 1000).toFixed(1);
+    process.stderr.write(`  patrol #${patrolInvocation} (${elapsed}s) ${label}\n`);
+  };
   const patrol = (extraArgs = [], extraEnv = {}) => {
     lastPatrolInvocation = String(++patrolInvocation);
+    heartbeat(extraArgs.join(" ") || "report");
     const needsGitFixture = [
       "LIFECYCLE_DEFAULT_TRUNK",
       "LIFECYCLE_STALE_DEFAULT",
@@ -1467,6 +1489,7 @@ exit 0
   };
   const patrolResult = (extraArgs = [], extraEnv = {}) => {
     lastPatrolInvocation = String(++patrolInvocation);
+    heartbeat(extraArgs.join(" ") || "result");
     return spawnSync(
       process.execPath,
       [
@@ -1484,6 +1507,7 @@ exit 0
         cwd: repo,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: CHILD_TIMEOUT_MS,
         env: {
           ...process.env,
           NODE_NO_WARNINGS: "1",

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -42,7 +42,17 @@ const metadataAlias = path.join(fixtureRoot, "old-alias");
 // slow-but-working. 120s is far above the slowest observed call (~5.6s for a
 // full patrol spawn) — it exists to convert a hang into a failure, not to
 // police speed.
-const CHILD_TIMEOUT_MS = Number(process.env.LIFECYCLE_TEST_CHILD_TIMEOUT_MS ?? 120_000);
+const DEFAULT_CHILD_TIMEOUT_MS = 120_000;
+// Validate the override rather than trusting Number(): `Number("")` is 0 and
+// `Number("nope")` is NaN, and Node treats BOTH as "no timeout" — so a typo in
+// the env var would silently restore the unbounded hang this exists to prevent.
+// Anything not a finite positive number falls back to the default.
+const CHILD_TIMEOUT_MS = (() => {
+  const raw = process.env.LIFECYCLE_TEST_CHILD_TIMEOUT_MS;
+  if (raw === undefined) return DEFAULT_CHILD_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_CHILD_TIMEOUT_MS;
+})();
 
 function run(command, args, cwd, options = {}) {
   return execFileSync(command, args, {


### PR DESCRIPTION
Reported as *"the patrol test hangs"*. It doesn't — it runs **~138 patrol subprocesses at ~4.5s each** and prints **nothing at all** until the end, so for ~10 minutes it is indistinguishable from a wedge.

Two fixes. Neither makes it faster; both make it honest.

## 1. A heartbeat per spawn

`patrol #N (elapsed) <args>` on stderr. You can see it's alive, and when something wedges the line names the exact invocation to look at — locally and in a CI log. Opt out with `LIFECYCLE_TEST_QUIET`.

## 2. A timeout on every child — the real defect

`run()` called `execFileSync` with **no timeout** and `patrolResult()` called `spawnSync` with **none**. A genuinely wedged git, or a stub that never exits, would have hung the entire app suite forever with no output and no way to tell it from slow-but-working. Both now carry 120s (`LIFECYCLE_TEST_CHILD_TIMEOUT_MS` to override) — ~21x the slowest spawn observed, so it converts a hang into a failure without policing speed.

I caught the `patrolResult` one only on re-reading my own diff; the first pass bounded `run()` alone and would have left half the children unbounded.

## Why nothing here targets the runtime

Profiled before changing anything:

| candidate | measured | verdict |
|---|---|---|
| node startup per spawn | 0.12s | not it |
| `MODULE_TYPELESS` double-parse | 10ms/spawn (~0.8s total) | not it |
| `command()`'s 30s timeout | nothing times out; slowest call 304ms | not it |
| O(n^2) fixture growth | 5.15s mean over first 10 spawns, 3.75s over last 10 | **flat, not it** |
| ~129 git calls/spawn @ ~45ms | ~5.8s | **this is the cost** |

It's inherent to exercising ~138 scenarios. Making it faster means changing what it asserts — the author call **cave-7ruzl** already describes. Full measurements are recorded on that bead.

## Two findings recorded separately

- **In production the patrol is network-bound, not git-bound.** One run against the real repo is 72 calls / 51.1s, of which **60 sequential `gh api graphql --paginate` calls are 49.1s — 96%**. Two independent read-only loops in `buildPullRequestInventory`. Batching or parallelising them is the lever for `pnpm beads:worktrees` feeling slow; not attempted here because `command()` is synchronous across 2,627 lines and this code gates destructive automation.
- **CI headroom is thin.** `Frontend build` took 10.4 min against `timeout-minutes: 15` on #4203, up from 8m33s before #4200 un-quarantined this test — ~4.6 min left. #4200's own body flagged this as the thing to watch.

## Verification

Full file, end-to-end, against exactly this code: **exit 0, 138 spawns, 12.1 min**, ending `worktree-lifecycle-patrol.test.mjs: ok`. `tsc --noEmit` clean; `check:tests-wired` reports all 1,440 files wired.
