### PR TITLE
fix(github): safe merge asks which familiar instead of taking the first (cave-26sg4)

### DIFF
--- a/src/components/github-view-polish.test.ts
+++ b/src/components/github-view-polish.test.ts
@@ -239,6 +239,36 @@ for (const [name, src] of [["stream", stream], ["stage", stage]]) {
   assert.doesNotMatch(src, /\bCody\b/i, `${name} names no specific familiar`);
 }
 
+// …and the HOST does not quietly pick one either (cave-26sg4). The guard above
+// covered the stream and the stage, which is where the slot was introduced —
+// but the violation it was written against lived in github-view.tsx, where
+// SafeMergeAction fell back to `familiars[0]`. Roster order is not a choice the
+// user made, and safe merge creates a worktree and drives a merge, so the
+// familiar it lands on has to be asked for.
+assert.doesNotMatch(
+  source,
+  /familiars\[0\]/,
+  "the host never falls back to whichever familiar sorts first",
+);
+// Safe merge asks when the work is not already attached to a familiar.
+assert.match(
+  source,
+  /const linkedFamiliarId = linkedCard\?\.familiarId \?\? null;/,
+  "safe merge derives its familiar from the linked card only",
+);
+assert.match(
+  source,
+  /if \(linkedFamiliarId\) \{\s*void startSafeMerge\(linkedFamiliarId\);[\s\S]{0,80}?setPickerOpen\(\(v\) => !v\);/,
+  "safe merge runs straight through when a linked card names a familiar, and opens the picker otherwise",
+);
+// An empty roster and a failed load are different claims — cave-59cv's rule,
+// applied here because safe merge now surfaces the roster itself.
+assert.match(
+  source,
+  /familiarsFailed \? "Could not load your familiars\." : "No familiars yet\."/,
+  "safe merge distinguishes a failed familiars load from an empty roster",
+);
+
 // The row keeps exactly ONE accented verb. Moving the hand-off to a slot took
 // the accent off it (the slot renders a plain secondary button), which left
 // .gh-stream-verb--accent as dead CSS and the row with no primary-action

--- a/src/components/github-view.tsx
+++ b/src/components/github-view.tsx
@@ -536,21 +536,61 @@ function SafeMergeAction({
   item,
   linkedCards,
   familiars,
+  familiarsFailed = false,
 }: {
   item: GitHubItem;
   linkedCards: Card[];
   familiars: Familiar[];
+  /** The familiars load FAILED — an empty list then means "couldn't load",
+   *  not "none exist" (cave-59cv). */
+  familiarsFailed?: boolean;
 }) {
   const [busy, setBusy] = useState(false);
   const { announce } = useAnnouncer();
   const [error, setError] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const pickerRef = useRef<HTMLDivElement>(null);
+
+  // Close the familiar picker on outside click / Escape (same posture as
+  // OpenChatAction's card picker).
+  useEffect(() => {
+    if (!pickerOpen) return;
+    function onDoc(ev: MouseEvent) {
+      if (pickerRef.current && !pickerRef.current.contains(ev.target as Node)) setPickerOpen(false);
+    }
+    function onKey(ev: KeyboardEvent) {
+      if (ev.key === "Escape") setPickerOpen(false);
+    }
+    const id = window.setTimeout(() => document.addEventListener("mousedown", onDoc), 30);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      window.clearTimeout(id);
+      document.removeEventListener("mousedown", onDoc);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [pickerOpen]);
+
   if (item.kind !== "pr" && item.kind !== "review_request") return null;
 
   const linkedCard = linkedCards.find((card) => card.cwd) ?? linkedCards[0] ?? null;
-  const familiarId = linkedCard?.familiarId ?? familiars[0]?.id ?? null;
+  // A linked card carries a familiar the user already chose for this work.
+  // Absent that there is no correct default — safe merge creates a worktree and
+  // drives a merge, so the familiar it lands on is the user's call, not
+  // whichever one happens to sort first (cave-26sg4).
+  const linkedFamiliarId = linkedCard?.familiarId ?? null;
 
-  async function startSafeMerge(e: React.MouseEvent) {
+  function handleClick(e: React.MouseEvent) {
     e.stopPropagation();
+    setError(null);
+    if (linkedFamiliarId) {
+      void startSafeMerge(linkedFamiliarId);
+      return;
+    }
+    setPickerOpen((v) => !v);
+  }
+
+  async function startSafeMerge(familiarId: string) {
+    setPickerOpen(false);
     setBusy(true);
     setError(null);
     let safeMergeRoot: string | null = linkedCard?.cwd ?? null;
@@ -613,13 +653,42 @@ function SafeMergeAction({
         size="xs"
         variant="secondary"
         leadingIcon="ph:git-merge"
-        onClick={startSafeMerge}
+        onClick={handleClick}
         disabled={busy}
-        title="Safely merge from a worktree"
+        aria-expanded={pickerOpen}
+        title={linkedFamiliarId ? "Safely merge from a worktree" : "Safely merge — choose a familiar"}
       >
         {busy ? "Prep…" : "Merge"}
       </Button>
       {error && <span className="gh-action-error" role="img" aria-label={`Error: ${error}`} title={error}>!</span>}
+
+      {pickerOpen && (
+        <div ref={pickerRef} className="gh-action-popover" onClick={(e) => e.stopPropagation()}>
+          <p className="gh-action-popover-title">Merge with…</p>
+          {familiars.length === 0 ? (
+            // An empty roster and a failed load are different claims: one says
+            // "you have none", the other says "we could not tell".
+            <p className="gh-action-popover-title">
+              {familiarsFailed ? "Could not load your familiars." : "No familiars yet."}
+            </p>
+          ) : (
+            <ul className="gh-action-popover-list">
+              {familiars.map((f) => (
+                <li key={f.id}>
+                  <button
+                    type="button"
+                    onClick={() => void startSafeMerge(f.id)}
+                    disabled={busy}
+                    className="gh-action-popover-item"
+                  >
+                    <span className="gh-action-popover-item-title">{f.display_name}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -2630,7 +2699,7 @@ function GitHubItemGlassPanel({
                 cardsFailed={cardsFailed}
                 onAfterLink={onAfterLink}
               />
-              <SafeMergeAction item={item} linkedCards={linkedCards} familiars={familiars} />
+              <SafeMergeAction item={item} linkedCards={linkedCards} familiars={familiars} familiarsFailed={familiarsFailed} />
             </div>
 
             <dl className="gh-next-wire">
@@ -3644,7 +3713,7 @@ export function GitHubView({
                           cardsFailed={cardsFailed}
                           onAfterLink={refreshLinkedWork}
                         />
-                        <SafeMergeAction item={item} linkedCards={linked} familiars={familiars} />
+                        <SafeMergeAction item={item} linkedCards={linked} familiars={familiars} familiarsFailed={familiarsFailed} />
                         <IconButton
                           icon="ph:arrow-square-out"
                           size="xs"


### PR DESCRIPTION
Closes `cave-26sg4`, filed while reviewing #4203.

## The problem

`SafeMergeAction` fell back to `familiars[0]?.id` when a PR had no linked board card:

```ts
const familiarId = linkedCard?.familiarId ?? familiars[0]?.id ?? null;
```

That `familiarId` is what the dispatched `cave:agents-new-chat` carries — it decides **which familiar receives the merge conversation**. Roster order is not a choice the user made, and this is not a small action: it creates a worktree and drives a merge. On this machine `familiars[0]` is Nova, out of nine.

#4203 established the rule for the row hand-off — *"there is no correct default: familiars are the user's own, and the one in the design mock is the designer's"* — and fixed that one call site. This applies it to the one that still broke it.

## The fix

Mirrors `OpenChatAction`, which already had the right shape:

- **Linked card** → it carries a familiar the user chose for this work; the merge runs straight through, unchanged.
- **No linked card** → the button opens a picker over the real roster and does nothing until you choose.

Passing `null` instead would not have fixed it. `chat-surface.tsx`'s `onNewChat` reads `d?.familiarId` and, absent one, opens the chat with whatever familiar is currently active — a different guess, not an absence of one.

I did **not** reuse `GitHubActionPopover mode="chat"`: it composes its own generic prompt and dispatches the event itself, so it would have silently dropped safe merge's worktree creation and its merge-specific prompt. The picker here is the same `.gh-action-popover` markup `OpenChatAction` already renders inline for its multi-card case.

The picker distinguishes a failed familiars load from an empty roster (cave-59cv), since safe merge now surfaces the roster itself — hence `familiarsFailed` threaded through both call sites.

## Guard

#4203's pin covered `github-stream.tsx` and `lib/github-stage.ts` — but the violation lived in `github-view.tsx`, which was unguarded, so it would not have caught this or a third call site. The guard now covers the host and asserts the **branch shape**, not just the absence of a string.

## Verification

`typecheck` · `lint` · `test:app` (1049 files) · `build` + bundle budget — all green.

**Not verified by a live drive.** I tried three times; the GitHub room sits behind familiar-role gating my harness could not satisfy, so I stopped rather than keep burning time on the harness. The change is synchronous branch logic covered by the pins above, but the picker's *rendering* has not been seen on screen — worth a glance when someone next has the surface open with a PAT attached.
