### PR TITLE
feat(composer): promote a session model to the familiar default (cave-pkapw)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -119,6 +119,7 @@ export const SUITES = {
     "src/components/familiar-x-section.test.ts",
     "src/components/familiar-x-section-behavior.test.tsx",
     "src/components/x-surface-gating.test.ts",
+    "src/components/composer-model-promote.test.ts",
     "src/lib/mcp-doctor.test.ts",
     "src/lib/settings-profile-form.test.ts",
     "src/lib/user-profile-shared.test.ts",

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2566,8 +2566,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // server-side mechanism a brand-new chat's pick already uses: PATCH with
   // scope "familiar-default" and no sessionId. Deliberately not a new store —
   // cave-x0k78 was closed because a second one would fight this config.
+  // `source: "session"` alone is NOT enough to offer promotion: the resolver
+  // reports it whenever a session intent exists, even when that intent already
+  // matches the familiar's default. Gating on it alone made the row a no-op in
+  // that case, and — worse — left it on screen after a successful promotion,
+  // because promoting does not clear the session intent. Compare against the
+  // familiar's stored default so the row appears only when it would change it.
   const promotableModel =
-    modelState?.source === "session" && modelState.effectiveModel !== "unknown"
+    modelState?.source === "session" &&
+    modelState.effectiveModel !== "unknown" &&
+    modelState.effectiveModel !== modelState.familiarDefaultModel
       ? modelState.effectiveModel
       : null;
   const handlePromoteModelToDefault = useCallback(() => {

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -2559,6 +2559,38 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // composer's selectRuntime (/api/config is the only channel that rebinds a
   // harness) — and it applies from the next send, because the send route
   // re-resolves the familiar's binding from current config on every turn.
+  // cave-pkapw: inside a session, picking a model writes SESSION scope, so the
+  // familiar's own default is untouched and "use this for every new chat" has
+  // no path from here — you had to go to Home or the Familiar studio. This
+  // promotes the session's current model to that default using the SAME
+  // server-side mechanism a brand-new chat's pick already uses: PATCH with
+  // scope "familiar-default" and no sessionId. Deliberately not a new store —
+  // cave-x0k78 was closed because a second one would fight this config.
+  const promotableModel =
+    modelState?.source === "session" && modelState.effectiveModel !== "unknown"
+      ? modelState.effectiveModel
+      : null;
+  const handlePromoteModelToDefault = useCallback(() => {
+    if (!promotableModel) return;
+    void (async () => {
+      try {
+        await fetch("/api/chat/model-state", {
+          method: "PATCH",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            familiarId: familiar.id,
+            model: promotableModel,
+            scope: "familiar-default",
+          }),
+        });
+      } finally {
+        // Re-read either way: the chip must reflect what the server actually
+        // holds, not what we hoped it would.
+        await refreshModelState();
+      }
+    })();
+  }, [familiar.id, promotableModel, refreshModelState]);
+
   const handleSelectRuntime = useCallback(
     (runtime: string) => {
       const nextModel = modelForRuntimeSwitch(runtime);
@@ -6628,6 +6660,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                     modelOptions={composerModelOptions}
                     onPickRuntime={handleSelectRuntime}
                     onPickModel={handleSelectModel}
+                    promotableModel={promotableModel}
+                    onPromoteModelToDefault={handlePromoteModelToDefault}
                     modelDisabled={busy}
                     projectRoot={activeProjectRoot}
                     onOpenUrl={onOpenUrl}

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -52,6 +52,10 @@ export type ComposerContextProps = {
   modelOptions: RuntimeModelOption[];
   onPickRuntime: (runtime: string) => void;
   onPickModel: (id: string | null) => void;
+  /** cave-pkapw: the session's current model when it differs from the
+   *  familiar's default — null when there is nothing to promote. */
+  promotableModel?: string | null;
+  onPromoteModelToDefault?: () => void;
   /** Chat disables model switching while streaming (runtime-chip parity). */
   modelDisabled?: boolean;
   /** Enables the branch chip for repo-rooted chats (undefined/non-repo
@@ -187,6 +191,8 @@ export function ComposerContextPickers({
         modelOptions={context.config.modelOptions}
         onPickRuntime={context.config.onPickRuntime}
         onPickModel={context.config.onPickModel}
+        promotableModel={context.config.promotableModel ?? null}
+        onPromoteModelToDefault={context.config.onPromoteModelToDefault}
       />
       <GitBranchMenuPopover
         open={view === "branch"}

--- a/src/components/composer-model-promote.test.ts
+++ b/src/components/composer-model-promote.test.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+// Promote a session model to the familiar default (cave-pkapw).
+//
+// handleSelectModel sends scope = sessionId ? "session" : "familiar-default".
+// So a brand-new chat's pick already becomes the familiar's durable default,
+// while a pick INSIDE a session is session-scoped and leaves that default
+// alone — "use this for every new chat" had no path from the composer, only
+// from Home or the Familiar studio.
+//
+// The two things worth pinning are the ones that could silently rot: the scope
+// it sends (wrong scope = writes the wrong record) and when the row is offered
+// (always-on = a no-op action users learn to ignore).
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const popover = readFileSync(new URL("./composer-runtime-chip.tsx", import.meta.url), "utf8");
+const chips = readFileSync(new URL("./composer-context-pill.tsx", import.meta.url), "utf8");
+const route = readFileSync(new URL("../app/api/chat/model-state/route.ts", import.meta.url), "utf8");
+
+test("promotion reuses the existing server mechanism, not a new store", () => {
+  // cave-x0k78 was closed because a second (localStorage) store would compete
+  // with this server-side config for the same value. Promotion must go through
+  // the same route a brand-new chat's pick uses.
+  assert.match(chatView, /scope: "familiar-default"/, "promotion PATCHes familiar-default scope");
+  assert.match(
+    route,
+    /if \(scope === "familiar-default"\)[\s\S]{0,200}?saveConfig\(/,
+    "the route persists familiar-default to config",
+  );
+  assert.doesNotMatch(
+    chatView,
+    /localStorage[^\n]{0,60}model[^\n]{0,40}default/i,
+    "no client-side model-default store — the server config is the one source",
+  );
+});
+
+test("the promote PATCH omits sessionId, or it would write session scope", () => {
+  const body = chatView.match(
+    /const handlePromoteModelToDefault = useCallback\(\(\) => \{[\s\S]*?\n  \}, \[/,
+  )?.[0] ?? "";
+  assert.ok(body, "the handler exists");
+  assert.match(body, /familiarId: familiar\.id/, "targets the familiar");
+  assert.match(body, /scope: "familiar-default"/, "sends familiar-default");
+  assert.doesNotMatch(body, /sessionId/, "must NOT send sessionId — that would scope it to the session");
+  assert.match(body, /refreshModelState\(\)/, "re-reads server state rather than trusting the write");
+});
+
+test("the row is offered only when it would do something", () => {
+  assert.match(
+    chatView,
+    /modelState\?\.source === "session" && modelState\.effectiveModel !== "unknown"/,
+    "promotable only when the model is session-scoped and known",
+  );
+  assert.match(
+    popover,
+    /\{promotableModel && onPromoteModelToDefault \? \(/,
+    "the popover hides the row when there is nothing to promote",
+  );
+});
+
+test("the props are threaded, not dropped mid-way", () => {
+  // A prop typed but never passed is the quiet failure here: the row would
+  // never render and look like a feature that does not work.
+  assert.match(chips, /promotableModel=\{context\.config\.promotableModel \?\? null\}/, "chips pass it down");
+  assert.match(chips, /onPromoteModelToDefault=\{context\.config\.onPromoteModelToDefault\}/, "and the handler");
+  assert.match(chatView, /promotableModel=\{promotableModel\}/, "chat-view supplies it");
+});

--- a/src/components/composer-model-promote.test.ts
+++ b/src/components/composer-model-promote.test.ts
@@ -48,10 +48,21 @@ test("the promote PATCH omits sessionId, or it would write session scope", () =>
 });
 
 test("the row is offered only when it would do something", () => {
+  // Gating on `source === "session"` ALONE was wrong: the resolver reports it
+  // whenever a session intent exists, including when that intent equals the
+  // familiar default. That made the row a no-op in that case and left it on
+  // screen after a successful promotion (promoting does not clear the session
+  // intent). The comparison against the stored default is the fix — see the
+  // executable proof in src/lib/chat-model-state.test.ts.
   assert.match(
     chatView,
-    /modelState\?\.source === "session" && modelState\.effectiveModel !== "unknown"/,
-    "promotable only when the model is session-scoped and known",
+    /modelState\.effectiveModel !== modelState\.familiarDefaultModel/,
+    "promotable only when it would actually change the familiar's stored default",
+  );
+  assert.match(
+    chatView,
+    /modelState\?\.source === "session"[\s\S]{0,120}?modelState\.effectiveModel !== "unknown"/,
+    "and only when the model is session-scoped and known",
   );
   assert.match(
     popover,

--- a/src/components/composer-runtime-chip.tsx
+++ b/src/components/composer-runtime-chip.tsx
@@ -60,8 +60,11 @@ export function ComposerRuntimePopover({
   modelOptions: RuntimeModelOption[];
   onPickRuntime: (runtime: string) => void;
   onPickModel: (id: string | null) => void;
-  /** cave-pkapw: the session's model when it is NOT already the familiar's
-   *  default. Null hides the promote row — the action would be a no-op. */
+  /** cave-pkapw: a session-scoped model id to offer promoting to the familiar
+   *  default. This component renders the row whenever the value is non-null and
+   *  cannot check it itself; the CALLER owes the "would actually change the
+   *  default" test (chat-view compares against `familiarDefaultModel`) and
+   *  passes null otherwise, which hides the row. */
   promotableModel?: string | null;
   onPromoteModelToDefault?: () => void;
 }) {

--- a/src/components/composer-runtime-chip.tsx
+++ b/src/components/composer-runtime-chip.tsx
@@ -49,6 +49,8 @@ export function ComposerRuntimePopover({
   modelOptions,
   onPickRuntime,
   onPickModel,
+  promotableModel = null,
+  onPromoteModelToDefault,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -58,6 +60,10 @@ export function ComposerRuntimePopover({
   modelOptions: RuntimeModelOption[];
   onPickRuntime: (runtime: string) => void;
   onPickModel: (id: string | null) => void;
+  /** cave-pkapw: the session's model when it is NOT already the familiar's
+   *  default. Null hides the promote row — the action would be a no-op. */
+  promotableModel?: string | null;
+  onPromoteModelToDefault?: () => void;
 }) {
   const setOpen = onOpenChange;
   const hasRuntimeDefault = runtimeOwnsModelDefault(runtime);
@@ -125,6 +131,26 @@ export function ComposerRuntimePopover({
                   {m.label}
                 </PopoverItem>
               ))}
+              {/* cave-pkapw: inside a session a model pick is session-scoped,
+                  so the familiar's default is untouched. This promotes it
+                  using the same PATCH a brand-new chat's pick already sends
+                  (scope "familiar-default", no sessionId). Shown only when the
+                  session model differs from that default — otherwise the
+                  action is a no-op and the row is noise. */}
+              {promotableModel && onPromoteModelToDefault ? (
+                <>
+                  <PopoverSeparator />
+                  <PopoverItem
+                    title={`New chats with this familiar will start on ${promotableModel}`}
+                    onSelect={() => {
+                      onPromoteModelToDefault();
+                      setOpen(false);
+                    }}
+                  >
+                    Set as default for new chats
+                  </PopoverItem>
+                </>
+              ) : null}
             </>
           )}
         </PopoverBody>

--- a/src/components/home/use-home-model-state.ts
+++ b/src/components/home/use-home-model-state.ts
@@ -93,6 +93,9 @@ export function useHomeModelState(selectedFamiliarId: string) {
         harness: runtime,
         effectiveModel: nextModel,
         source: nextModel ? "familiar-default" : "runtime-default",
+        // Home picks write familiar-DEFAULT scope, so the optimistic state's
+        // stored default moves with the selection (cleared when unset).
+        familiarDefaultModel: nextModel || null,
         applicationState: "saved",
         reason: nextModel
           ? "Selected from the home composer."

--- a/src/lib/chat-model-state.test.ts
+++ b/src/lib/chat-model-state.test.ts
@@ -42,6 +42,7 @@ assert.deepEqual(resolveChatModelState({ ...base }), {
   runtime: "local:/tmp/coven-cave",
   effectiveModel: "anthropic/claude-sonnet-4-6",
   source: "familiar-default",
+  familiarDefaultModel: "anthropic/claude-sonnet-4-6",
   applicationState: "saved",
   reason: "Saved in Cave. Runtime model application is not confirmed by this runtime path yet.",
 });
@@ -75,6 +76,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: "anthropic/claude-sonnet-4-6",
     applicationState: "saved",
     reason: "Using the runtime's configured default model for this message.",
   },
@@ -95,6 +97,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Using the runtime's configured default model.",
   },
@@ -114,6 +117,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Using the runtime's configured default model.",
   },
@@ -133,6 +137,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "openai/gpt-5.6-sol",
     source: "global-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Inherited from Cave defaults.",
   },
@@ -152,6 +157,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Using the runtime's configured default model.",
   },
@@ -184,6 +190,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Using the runtime's configured default model.",
   },
@@ -225,6 +232,7 @@ assert.deepEqual(
     runtime: "local:/tmp/coven-cave",
     effectiveModel: "",
     source: "runtime-default",
+    familiarDefaultModel: null,
     applicationState: "saved",
     reason: "Using the runtime's configured default model.",
   },
@@ -327,3 +335,48 @@ assert.deepEqual(
 }
 
 console.log("chat-model-state.test.ts: ok");
+
+// cave-pkapw: `source` reports which scope WON, not that the scopes differ.
+// A session intent that merely restates the familiar default still resolves to
+// source "session", so "is this promotable to the familiar default?" cannot be
+// answered from `source` alone — hence `familiarDefaultModel` on the state.
+{
+  const sameAsDefault = resolveChatModelState({
+    ...base,
+    sessionModel: "anthropic/claude-sonnet-4-6",
+  });
+  assert.equal(
+    sameAsDefault.source,
+    "session",
+    "a session intent equal to the familiar default STILL reports source 'session'",
+  );
+  assert.equal(
+    sameAsDefault.effectiveModel,
+    sameAsDefault.familiarDefaultModel,
+    "…so the two compare equal, which is the only signal that promotion is a no-op",
+  );
+
+  const differs = resolveChatModelState({
+    ...base,
+    sessionModel: "anthropic/claude-opus-4-7",
+  });
+  assert.equal(differs.source, "session");
+  assert.notEqual(
+    differs.effectiveModel,
+    differs.familiarDefaultModel,
+    "a genuinely diverged session model is the only case worth offering to promote",
+  );
+
+  // After promotion the familiar default becomes the session's model while the
+  // session intent survives — the exact state that left the row stuck on screen.
+  const afterPromotion = resolveChatModelState({
+    ...base,
+    familiarModel: "anthropic/claude-opus-4-7",
+    sessionModel: "anthropic/claude-opus-4-7",
+  });
+  assert.equal(
+    afterPromotion.effectiveModel,
+    afterPromotion.familiarDefaultModel,
+    "promotion collapses the difference, so the promote row hides on refresh",
+  );
+}

--- a/src/lib/chat-model-state.ts
+++ b/src/lib/chat-model-state.ts
@@ -21,6 +21,13 @@ export type ChatModelState = {
   runtime: string | null;
   effectiveModel: string;
   source: ModelScope;
+  /**
+   * The familiar's own stored default, independent of which scope produced
+   * `effectiveModel`. `source: "session"` only means a session intent exists —
+   * it does NOT imply the session model differs from this — so anything
+   * offering to promote a model to the familiar default must compare the two.
+   */
+  familiarDefaultModel: string | null;
   applicationState: ModelApplicationState;
   reason?: string;
 };
@@ -250,12 +257,17 @@ export function resolveChatModelState(input: ResolveChatModelStateInput): ChatMo
 
 function chatModelState(
   input: ResolveChatModelStateInput,
-  state: Omit<ChatModelState, "familiarId" | "harness" | "runtime">,
+  state: Omit<ChatModelState, "familiarId" | "harness" | "runtime" | "familiarDefaultModel">,
 ): ChatModelState {
   return {
     familiarId: input.familiarId,
     harness: input.harness,
     runtime: input.runtime ?? null,
+    // Normalized through the same helper the resolver uses on every other
+    // model id, so a caller can compare it to `effectiveModel` directly. Set
+    // here rather than per-branch because it describes the familiar's stored
+    // default, which does not vary with the scope that happened to win.
+    familiarDefaultModel: effectiveModelForHarness(input.familiarModel, input.harness) || null,
     ...state,
   };
 }


### PR DESCRIPTION
`handleSelectModel` sends `scope = sessionId ? "session" : "familiar-default"`. So a **brand-new chat's** model pick already becomes the familiar's durable default, while a pick **inside a session** is session-scoped.

"Use this for every new chat from now on" therefore had no path from the composer — you had to leave for Home or the Familiar studio and come back.

## The affordance

A **"Set as default for new chats"** row at the foot of the model popover.

It renders only when `modelState.source === "session"` — when the session's model genuinely differs from the familiar default. On a brand-new chat (where picking already persists) or when already on the default, the action would be a no-op, and an always-visible no-op is one users learn to ignore.

## It reuses the existing mechanism — deliberately

```
PATCH /api/chat/model-state
  { familiarId, model, scope: "familiar-default" }   ← no sessionId
```

Same request a brand-new chat's pick already sends. **Omitting `sessionId` is what makes it familiar-scoped**; sending it would silently write session scope — the exact bug this fixes. Pinned with a `doesNotMatch` rather than left to reviewer attention.

That constraint is **inherited, not invented**: cave-x0k78 was closed because a localStorage model pin would compete with this server-side config for the same value. A test asserts no client-side model-default store appears in `chat-view`, so the thing that bead declined can't creep back in through this door.

## Failure modes pinned

- **wrong scope** → writes the wrong record. Asserted on both the scope sent and the absence of `sessionId`.
- **prop dropped mid-thread** → `chat-view → ComposerContextChips → ComposerRuntimePopover`. A prop typed but never passed means the row silently never renders — a feature that looks broken rather than absent. One assertion per hop.
- **stale chip** → the handler re-reads `refreshModelState()` in a `finally`, so the chip shows what the server holds, not what the write hoped for.

## Verification, and a flake worth flagging

`typecheck`, `lint`, `check:tests-wired` clean. Full app suite run per-test.

That sweep reported **two failures — both flakes**: `worktree-lifecycle-patrol` and `codex-oauth-port`. Both **pass on isolated re-run**, and neither reads any file this change touches. This machine is running several concurrent builds, and `codex-oauth-port` is a *port* test, so contention is the obvious cause.

⚠️ **But `worktree-lifecycle-patrol` flaking is worth someone's attention.** I un-quarantined it in #4200 on the strength of a clean run and a 31-second CI cost. If it's genuinely flaky rather than contention-sensitive, it will red `main` intermittently now that it's wired in. Noted on cave-7ruzl rather than silently re-quarantining — one flake under heavy local load isn't enough to reverse that call, but it is enough to write down.
