### PR TITLE
fix(release): allow explicit hidden-X recovery

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,11 @@ on:
         required: false
         default: false
         type: boolean
+      allow_unconfigured_x_app:
+        description: "RECOVERY ONLY: ship with X integration disabled when its public client ID is unavailable. Tag pushes always stay fail-closed."
+        required: false
+        default: false
+        type: boolean
       use_current_release_tooling:
         description: "RECOVERY ONLY: build tag source with the audited release.sh and sidecar-bundle.sh from this workflow commit. Tag pushes always use tag tooling."
         required: false
@@ -276,6 +281,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Require OpenCoven X app configuration
+        env:
+          COVEN_CAVE_X_RELEASE_DISABLED: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app && '1' || '' }}
         run: node scripts/check-x-app-release.mjs
 
       - name: Require signed OpenCode compatibility registry
@@ -894,6 +901,7 @@ jobs:
           # signed-registry gates (cave-yp21x). `inputs` is readable from every
           # job of a workflow_dispatch run, so this needs no job-output plumbing.
           COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_registries }}
+          COVEN_RELEASE_X_GUARD_SKIPPED: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
         run: |
           set -euo pipefail
           bash scripts/release-notes.sh "$RELEASE_TAG" > /tmp/release-body.md

--- a/scripts/check-x-app-release.mjs
+++ b/scripts/check-x-app-release.mjs
@@ -2,8 +2,11 @@
 // ship without its configured native app registration.
 const clientId = process.env.COVEN_CAVE_X_PRODUCTION_CLIENT_ID?.trim() ?? "";
 const validPublicClientId = /^[A-Za-z0-9][A-Za-z0-9_-]{7,127}$/.test(clientId);
+const xReleaseDisabled = process.env.COVEN_CAVE_X_RELEASE_DISABLED === "1";
 
-if (!validPublicClientId) {
+if (xReleaseDisabled) {
+  console.warn("::warning::Shipping with X integration disabled by an explicit manual release override.");
+} else if (!validPublicClientId) {
   console.error("::error::COVEN_CAVE_X_PRODUCTION_CLIENT_ID must be configured with a valid OpenCoven X public client ID before creating a release.");
   process.exitCode = 1;
 }

--- a/scripts/check-x-app-release.test.mjs
+++ b/scripts/check-x-app-release.test.mjs
@@ -41,4 +41,20 @@ const configured = spawnSync(process.execPath, [script], {
 assert.equal(configured.status, 0);
 assert.doesNotMatch(configured.stdout + configured.stderr, /test-client-id-123/);
 
+const explicitlyDisabled = spawnSync(process.execPath, [script], {
+  cwd,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    COVEN_CAVE_X_PRODUCTION_CLIENT_ID: "",
+    COVEN_CAVE_X_RELEASE_DISABLED: "1",
+  },
+});
+assert.equal(explicitlyDisabled.status, 0);
+assert.equal(explicitlyDisabled.stdout, "");
+assert.equal(
+  explicitlyDisabled.stderr,
+  "::warning::Shipping with X integration disabled by an explicit manual release override.\n",
+);
+
 console.log("check-x-app-release.test.mjs: ok");

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -155,8 +155,8 @@ fi
 if [ "$x_guard_skipped" = "true" ]; then
   cat <<'PROVENANCE'
 This release was built on a manual run with `allow_unconfigured_x_app` enabled.
-The incomplete X integration remains disabled in this build because no
-production public client ID was configured.
+The X app configuration check was explicitly bypassed. The incomplete X
+integration remains disabled in this build.
 
 Releases published from a tag push cannot skip the X app configuration check.
 

--- a/scripts/release-notes.sh
+++ b/scripts/release-notes.sh
@@ -129,24 +129,36 @@ shasum -a 256 -c SHA256SUMS
 
 INSTALL_REST
 
-# Build provenance (cave-yp21x). The signed OpenCode/Grok schema-registry gates
-# are fail-closed for tag pushes and skippable only on an emergency manual run.
-# v0.2.0 shipped through that hatch and said so nowhere a reader would find:
-# the only trace was a `skipped` step inside the Actions log. When the hatch is
-# used, the body states it plainly.
-#
-# Worded as provenance, not a warning. These gates guard against FUTURE schema
-# drift; a build without them uses the same built-in baseline parsers every
-# release before the gates existed used, so this is not a user-facing defect.
-if [ "${COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED:-}" = "true" ]; then
+# Build provenance for explicit manual-release recovery hatches. Tag pushes
+# remain fail-closed; when a maintainer uses a manual override, the permanent
+# release body records it instead of leaving the only evidence in an Actions log.
+registry_guards_skipped="${COVEN_RELEASE_REGISTRY_GUARDS_SKIPPED:-}"
+x_guard_skipped="${COVEN_RELEASE_X_GUARD_SKIPPED:-}"
+if [ "$registry_guards_skipped" = "true" ] || [ "$x_guard_skipped" = "true" ]; then
   cat <<'PROVENANCE'
 ## Build provenance
 
+PROVENANCE
+fi
+
+if [ "$registry_guards_skipped" = "true" ]; then
+  cat <<'PROVENANCE'
 This release was built on a manual run with `allow_unconfigured_registries`
 enabled, so the signed OpenCode and Grok compatibility-registry checks did not
 run. The build uses the built-in baseline schema parsers.
 
 Releases published from a tag push cannot skip those checks.
+
+PROVENANCE
+fi
+
+if [ "$x_guard_skipped" = "true" ]; then
+  cat <<'PROVENANCE'
+This release was built on a manual run with `allow_unconfigured_x_app` enabled.
+The incomplete X integration remains disabled in this build because no
+production public client ID was configured.
+
+Releases published from a tag push cannot skip the X app configuration check.
 
 PROVENANCE
 fi

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -204,6 +204,18 @@ test("the provenance block never displaces the compare link", () => {
   assert.match(body.trimEnd().split("\n").at(-1) ?? "", /^\*\*Full changelog:\*\*/);
 });
 
+test("the X recovery override is permanently disclosed in release provenance", () => {
+  const skipped = render("v7.0.55", undefined, { COVEN_RELEASE_X_GUARD_SKIPPED: "true" });
+  assert.match(skipped, /^## Build provenance/m);
+  assert.match(skipped, /allow_unconfigured_x_app/);
+  assert.match(skipped, /X integration remains disabled/);
+  assert.match(skipped, /tag push cannot skip the X app configuration check/);
+  assert.doesNotMatch(
+    render("v7.0.55", undefined, { COVEN_RELEASE_X_GUARD_SKIPPED: "1" }),
+    /allow_unconfigured_x_app/,
+  );
+});
+
 test("the fixture is genuinely self-contained", () => {
   // The point of cave-5yyj1: no assertion above may depend on this checkout's
   // own tags, CHANGELOG, or slug. If the real slug leaks through, the script is

--- a/scripts/release-notes.test.mjs
+++ b/scripts/release-notes.test.mjs
@@ -208,7 +208,9 @@ test("the X recovery override is permanently disclosed in release provenance", (
   const skipped = render("v7.0.55", undefined, { COVEN_RELEASE_X_GUARD_SKIPPED: "true" });
   assert.match(skipped, /^## Build provenance/m);
   assert.match(skipped, /allow_unconfigured_x_app/);
-  assert.match(skipped, /X integration remains disabled/);
+  assert.match(skipped, /configuration check was explicitly bypassed/);
+  assert.match(skipped, /incomplete X\s+integration remains disabled/);
+  assert.doesNotMatch(skipped, /because no production public client ID was configured/);
   assert.match(skipped, /tag push cannot skip the X app configuration check/);
   assert.doesNotMatch(
     render("v7.0.55", undefined, { COVEN_RELEASE_X_GUARD_SKIPPED: "1" }),


### PR DESCRIPTION
## Summary

- keep tag-push releases fail-closed when the production X client ID is absent
- add a manual-dispatch-only `allow_unconfigured_x_app` recovery input for builds where the incomplete X surface is intentionally disabled
- permanently disclose use of that recovery input in the GitHub Release body

## Context

The v0.2.2 tag run failed before packaging because no `COVEN_CAVE_X_PRODUCTION_CLIENT_ID` repository variable exists. The shipped X UI is intentionally hidden, so this provides an explicit, auditable recovery path without inventing a client ID or weakening normal tag releases.

## Validation

- `node scripts/check-x-app-release.test.mjs`
- `node scripts/release-notes.test.mjs`
- `node src-tauri/release-runtime.test.mjs`
- `pnpm typecheck`
- `git diff --check`

Bead: `cave-dstji`
Release run: `30730867456`