### PR TITLE
fix(release): overlay hidden-X recovery tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -229,6 +229,27 @@ jobs:
           git diff --check
           echo "Using release tooling from reviewed workflow commit $RECOVERY_TOOLING_SHA against tag source."
 
+      - name: Overlay audited X release recovery guard
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
+        shell: bash
+        env:
+          RECOVERY_TOOLING_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tooling_path="scripts/check-x-app-release.mjs"
+          git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
+          git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
+          mv "${tooling_path}.recovery" "$tooling_path"
+          expected_blob="$(git rev-parse "${RECOVERY_TOOLING_SHA}:${tooling_path}")"
+          actual_blob="$(git hash-object "$tooling_path")"
+          if [ "$actual_blob" != "$expected_blob" ]; then
+            echo "::error::Recovery tooling blob mismatch for $tooling_path"
+            exit 1
+          fi
+          echo "$actual_blob  $tooling_path"
+          git diff --check
+          echo "Using the reviewed X release guard from workflow commit $RECOVERY_TOOLING_SHA against tag source."
+
       - name: Set release metadata
         shell: bash
         env:
@@ -813,6 +834,31 @@ jobs:
           # the full tag history (shallow defaults would only have HEAD).
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Overlay audited X release provenance renderer
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
+        shell: bash
+        env:
+          RECOVERY_TOOLING_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
+          for tooling_path in scripts/release-notes.sh scripts/release-notes.test.mjs; do
+            git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
+            mv "${tooling_path}.recovery" "$tooling_path"
+            if [[ "$tooling_path" == *.sh ]]; then
+              chmod +x "$tooling_path"
+            fi
+            expected_blob="$(git rev-parse "${RECOVERY_TOOLING_SHA}:${tooling_path}")"
+            actual_blob="$(git hash-object "$tooling_path")"
+            if [ "$actual_blob" != "$expected_blob" ]; then
+              echo "::error::Recovery tooling blob mismatch for $tooling_path"
+              exit 1
+            fi
+            echo "$actual_blob  $tooling_path"
+          done
+          git diff --check
+          echo "Using the reviewed X provenance renderer from workflow commit $RECOVERY_TOOLING_SHA against tag source."
 
       - name: Resolve release tag
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -233,9 +233,15 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
         shell: bash
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RECOVERY_TOOLING_REF: ${{ github.ref }}
           RECOVERY_TOOLING_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          if [ "$RECOVERY_TOOLING_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "::error::X release recovery must be dispatched from the repository default branch."
+            exit 1
+          fi
           tooling_path="scripts/check-x-app-release.mjs"
           git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
           git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
@@ -839,9 +845,15 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.allow_unconfigured_x_app }}
         shell: bash
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RECOVERY_TOOLING_REF: ${{ github.ref }}
           RECOVERY_TOOLING_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
+          if [ "$RECOVERY_TOOLING_REF" != "refs/heads/$DEFAULT_BRANCH" ]; then
+            echo "::error::X release recovery must be dispatched from the repository default branch."
+            exit 1
+          fi
           git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
           for tooling_path in scripts/release-notes.sh scripts/release-notes.test.mjs; do
             git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"

--- a/scripts/check-x-app-release.test.mjs
+++ b/scripts/check-x-app-release.test.mjs
@@ -61,12 +61,12 @@ assert.equal(
 const workflow = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
 assert.match(
   workflow,
-  /name: Overlay audited X release recovery guard[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?tooling_path="scripts\/check-x-app-release\.mjs"/,
+  /name: Overlay audited X release recovery guard[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?RECOVERY_TOOLING_REF: \$\{\{ github\.ref \}\}[\s\S]*?refs\/heads\/\$DEFAULT_BRANCH[\s\S]*?tooling_path="scripts\/check-x-app-release\.mjs"/,
   "manual recovery overlays the reviewed guard after checking out the release tag",
 );
 assert.match(
   workflow,
-  /name: Overlay audited X release provenance renderer[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?for tooling_path in scripts\/release-notes\.sh scripts\/release-notes\.test\.mjs/,
+  /name: Overlay audited X release provenance renderer[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?RECOVERY_TOOLING_REF: \$\{\{ github\.ref \}\}[\s\S]*?refs\/heads\/\$DEFAULT_BRANCH[\s\S]*?for tooling_path in scripts\/release-notes\.sh scripts\/release-notes\.test\.mjs/,
   "manual recovery overlays the reviewed provenance renderer after checking out the release tag",
 );
 

--- a/scripts/check-x-app-release.test.mjs
+++ b/scripts/check-x-app-release.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
 
 const script = "scripts/check-x-app-release.mjs";
 const cwd = new URL("..", import.meta.url);
@@ -55,6 +56,18 @@ assert.equal(explicitlyDisabled.stdout, "");
 assert.equal(
   explicitlyDisabled.stderr,
   "::warning::Shipping with X integration disabled by an explicit manual release override.\n",
+);
+
+const workflow = await readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
+assert.match(
+  workflow,
+  /name: Overlay audited X release recovery guard[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?tooling_path="scripts\/check-x-app-release\.mjs"/,
+  "manual recovery overlays the reviewed guard after checking out the release tag",
+);
+assert.match(
+  workflow,
+  /name: Overlay audited X release provenance renderer[\s\S]*?inputs\.allow_unconfigured_x_app[\s\S]*?for tooling_path in scripts\/release-notes\.sh scripts\/release-notes\.test\.mjs/,
+  "manual recovery overlays the reviewed provenance renderer after checking out the release tag",
 );
 
 console.log("check-x-app-release.test.mjs: ok");


### PR DESCRIPTION
## Summary
- overlay the reviewed X release guard after manual recovery jobs check out the tagged source
- overlay the reviewed release-note renderer and tests before checksum provenance is published
- pin both post-checkout overlays in the X release guard contract test

## Why
PR #4211 added the explicit recovery input, but manual release jobs intentionally check out `v0.2.2`. Without these overlays, the tagged guard still rejects the recovery input and the tagged renderer cannot disclose it in the permanent release body.

## Verification
- `node --test scripts/check-x-app-release.test.mjs scripts/release-notes.test.mjs`
- `git diff --check`