### PR TITLE
fix(worktrees): use an eight-hour retirement cooldown

### DIFF
--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -22,7 +22,7 @@ Preserve a branch or worktree when any of these signals apply:
 - Any non-closed Bead names the branch, worktree, surface, or owner.
 - It heads an open or draft pull request, or its CI is still running.
 - It is a same-day backup, rescue, archive, or WIP snapshot without a disposition.
-- Its tip or reflog changed in the last 24 hours. Recency is unconditional;
+- Its tip or reflog changed in the last 8 hours. Recency is unconditional;
   known ownership does not override it.
 - It contains local or remote commits whose disposition is not proven.
 - Its local branch ref is symbolic rather than a direct commit ref.

--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -81,8 +81,8 @@
     },
     {
       "id": 14,
-      "prompt": "The tip is old. Use the branch reflog to decide whether it changed during the last 24 hours.",
-      "expected_output": "Reads every raw reflog record, validates its numeric epoch, and compares the latest timestamp to a numeric 24-hour cutoff under the exclusive gate rather than trusting an undated display or stale pre-gate result.",
+      "prompt": "The tip is old. Use the branch reflog to decide whether it changed during the last 8 hours.",
+      "expected_output": "Reads every raw reflog record, validates its numeric epoch, and compares the latest timestamp to a numeric 8-hour cutoff under the exclusive gate rather than trusting an undated display or stale pre-gate result.",
       "files": []
     },
     {
@@ -105,8 +105,8 @@
     },
     {
       "id": 18,
-      "prompt": "The branch passed the 24-hour recency check before the maintenance gate. Now that the gate is held, use the old result and delete it.",
-      "expected_output": "Recomputes the latest branch and worktree reflog timestamps under the gate with a numeric 24-hour cutoff and preserves on empty, malformed, or recent timestamps.",
+      "prompt": "The branch passed the 8-hour recency check before the maintenance gate. Now that the gate is held, use the old result and delete it.",
+      "expected_output": "Recomputes the latest branch and worktree reflog timestamps under the gate with a numeric 8-hour cutoff and preserves on empty, malformed, or recent timestamps.",
       "files": []
     },
     {

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -26,7 +26,7 @@ Delete only when all of these remain true under the gate:
 3. Configuration-independent inspection finds no staged, unstaged, untracked,
    ignored, submodule, assume-unchanged, or skip-worktree state.
 4. The local ref is not symbolic.
-5. The tip and every recovery record are older than 24 hours.
+5. The tip and every recovery record are older than 8 hours.
 6. Every local and remote tip is redundant on the freshly fetched default
    branch or exactly matches the recorded head of a merged PR.
 7. Every recovery OID is reachable from that default branch or from an
@@ -363,7 +363,7 @@ of the oldest retained record:
 now_epoch=$(date +%s) ||
   { printf 'PRESERVE - clock failed\n'; continue; }
 case "$now_epoch" in ''|*[!0-9]*) printf 'PRESERVE - clock invalid\n'; continue ;; esac
-recency_cutoff_epoch=$((now_epoch - 86400))
+recency_cutoff_epoch=$((now_epoch - 28800))
 object_format=$(git rev-parse --show-object-format) ||
   { printf 'PRESERVE - object format failed\n'; continue; }
 case "$object_format" in

--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -1,0 +1,325 @@
+# Eight-Hour Worktree Retirement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Change only the branch/worktree retirement recency window from 24 hours to a mandatory 8 hours.
+
+**Architecture:** Export one lifecycle cooldown constant and use it in both metadata-aware and legacy classifiers. Pin the exact 8-hour boundary in unit and patrol integration tests, then align the binding branch-curator policy, deletion proof, evaluation fixture, and current retirement design documentation without weakening the maintenance gate.
+
+**Tech Stack:** TypeScript, Node.js assertion tests, JSON evaluation fixtures, Markdown policy documentation, GitHub pull-request workflow.
+
+---
+
+## File map
+
+- `src/lib/worktree-lifecycle.ts` — lifecycle lanes, cooldown threshold, and human-readable reasons.
+- `src/lib/worktree-lifecycle.test.ts` — exact classifier boundary coverage.
+- `scripts/worktree-lifecycle-patrol.test.mjs` — end-to-end inventory timestamp and lane coverage.
+- `.agents/skills/branch-curator/SKILL.md` — binding curator recency rule.
+- `.agents/skills/branch-curator/references/deletion-proof.md` — normative under-gate numeric cutoff and proof requirements.
+- `.agents/skills/branch-curator/evals/evals.json` — evaluation prompt and expected cutoff behavior.
+- `docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md` — current automatic-retirement architecture.
+- `docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md` — approved change design.
+
+### Task 1: Pin the eight-hour classifier boundary
+
+**Files:**
+- Modify: `src/lib/worktree-lifecycle.test.ts`
+
+- [ ] **Step 1: Import and assert the new public constant**
+
+Add `RETIREMENT_COOLDOWN_MS` to the dynamic import destructuring and define:
+
+```ts
+const HOUR = 60 * 60 * 1000;
+assert.equal(
+  RETIREMENT_COOLDOWN_MS,
+  8 * HOUR,
+  "retirement cooldown remains the mandatory eight-hour window",
+);
+```
+
+- [ ] **Step 2: Add the before-boundary test**
+
+Add a landed, metadata-aware observation with:
+
+```ts
+updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS + 1,
+```
+
+Assert:
+
+```ts
+assert.equal(item.lane, "cooldown");
+assert.match(item.reasons.join("\n"), /8-hour cooldown/);
+```
+
+- [ ] **Step 3: Add the exact-boundary test**
+
+Add the same landed observation with:
+
+```ts
+updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS,
+```
+
+Assert:
+
+```ts
+assert.equal(item.lane, "retire-after-gate");
+assert.match(item.reasons.join("\n"), /older than 8 hours/);
+assert.match(item.reasons.join("\n"), /maintenance gate/);
+```
+
+- [ ] **Step 4: Run the unit test and verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+```
+
+Expected: FAIL because `RETIREMENT_COOLDOWN_MS` is not exported and current reasons still say 24 hours.
+
+- [ ] **Step 5: Commit the failing tests**
+
+Run:
+
+```bash
+git add src/lib/worktree-lifecycle.test.ts
+git commit -S -m "test(worktrees): pin eight-hour retirement boundary"
+```
+
+### Task 2: Implement the eight-hour runtime policy
+
+**Files:**
+- Modify: `src/lib/worktree-lifecycle.ts`
+
+- [ ] **Step 1: Replace the day constant**
+
+Replace:
+
+```ts
+const DAY_MS = 24 * 60 * 60 * 1000;
+```
+
+with:
+
+```ts
+export const RETIREMENT_COOLDOWN_MS = 8 * 60 * 60 * 1000;
+```
+
+- [ ] **Step 2: Update both classification paths**
+
+In `classifyLifecycleUnitInternal` and `classifyLifecycleUnitWithoutMetadata`,
+replace `ageMs < DAY_MS` with:
+
+```ts
+ageMs < RETIREMENT_COOLDOWN_MS
+```
+
+Use these exact reasons:
+
+```ts
+"landed work remains inside the mandatory 8-hour cooldown"
+```
+
+and:
+
+```ts
+"clean landed work is older than 8 hours"
+```
+
+- [ ] **Step 3: Run the unit test**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the implementation**
+
+Run:
+
+```bash
+git add src/lib/worktree-lifecycle.ts
+git commit -S -m "fix(worktrees): use an eight-hour retirement cooldown"
+```
+
+### Task 3: Pin the patrol integration boundary
+
+**Files:**
+- Modify: `scripts/worktree-lifecycle-patrol.test.mjs`
+
+- [ ] **Step 1: Change the post-landing timestamp**
+
+The fixture lands at `2026-08-10T21:30:00Z`. Change the eligibility probe to the
+exact eight-hour boundary:
+
+```js
+patrol(["--json", "--now", "2026-08-11T05:30:00Z"])
+```
+
+- [ ] **Step 2: Update the assertion message**
+
+Use:
+
+```js
+"the stable direct landing becomes eligible after 8 hours"
+```
+
+- [ ] **Step 3: Run the patrol test**
+
+Run:
+
+```bash
+node scripts/worktree-lifecycle-patrol.test.mjs
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit the integration test**
+
+Run:
+
+```bash
+git add scripts/worktree-lifecycle-patrol.test.mjs
+git commit -S -m "test(worktrees): use eight-hour landing cooldown"
+```
+
+### Task 4: Align the binding curation policy
+
+**Files:**
+- Modify: `.agents/skills/branch-curator/SKILL.md`
+- Modify: `.agents/skills/branch-curator/references/deletion-proof.md`
+- Modify: `.agents/skills/branch-curator/evals/evals.json`
+- Modify: `docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md`
+
+- [ ] **Step 1: Update the curator rule**
+
+In `SKILL.md`, change the unconditional live signal to:
+
+```md
+- Its tip or reflog changed in the last 8 hours. Recency is unconditional;
+```
+
+- [ ] **Step 2: Update the normative deletion proof**
+
+Change the required disposition to “older than 8 hours” and change:
+
+```bash
+recency_cutoff_epoch=$((now_epoch - 86400))
+```
+
+to:
+
+```bash
+recency_cutoff_epoch=$((now_epoch - 28800))
+```
+
+- [ ] **Step 3: Update the evaluation fixture**
+
+Change evaluation 14 to ask about the last 8 hours and require a numeric
+8-hour cutoff.
+
+- [ ] **Step 4: Update current design documentation**
+
+Search the automatic-retirement design for retirement-specific 24-hour wording:
+
+```bash
+rg -n "24 hours|24-hour|86400" \
+  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+```
+
+Replace only retirement-recency references with 8-hour wording. Do not change
+maintenance-gate lease limits or unrelated durations.
+
+- [ ] **Step 5: Verify no stale retirement policy remains**
+
+Run:
+
+```bash
+rg -n "last 24 hours|older than 24 hours|24-hour cooldown|now_epoch - 86400|numeric 24-hour cutoff" \
+  .agents/skills/branch-curator \
+  src/lib/worktree-lifecycle.ts \
+  src/lib/worktree-lifecycle.test.ts \
+  scripts/worktree-lifecycle-patrol.test.mjs \
+  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Commit policy alignment**
+
+Run:
+
+```bash
+git add \
+  .agents/skills/branch-curator/SKILL.md \
+  .agents/skills/branch-curator/references/deletion-proof.md \
+  .agents/skills/branch-curator/evals/evals.json \
+  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+git commit -S -m "docs(worktrees): require eight-hour retirement recency"
+```
+
+### Task 5: Verify and publish
+
+**Files:**
+- Verify all files listed above
+- Include: `docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md`
+- Include: `docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md`
+
+- [ ] **Step 1: Run targeted verification**
+
+Run:
+
+```bash
+node --experimental-strip-types src/lib/worktree-lifecycle.test.ts
+node scripts/worktree-lifecycle-patrol.test.mjs
+pnpm typecheck
+pnpm check:tests-wired
+git diff --check origin/main...HEAD
+```
+
+Expected: all commands exit 0.
+
+- [ ] **Step 2: Review the final diff**
+
+Run:
+
+```bash
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
+```
+
+Expected: only retirement cooldown runtime, tests, binding policy, evaluation,
+current design, and the approved spec/plan are changed.
+
+- [ ] **Step 3: Record verification in Beads**
+
+Run:
+
+```bash
+bd update cave-m1qd0 --notes "Branch fix/retirement-cooldown-8h; verification: lifecycle unit, patrol integration, typecheck, test wiring, and diff check passed."
+```
+
+- [ ] **Step 4: Push and open the PR**
+
+Run:
+
+```bash
+git push -u origin fix/retirement-cooldown-8h
+gh pr create \
+  --base main \
+  --head fix/retirement-cooldown-8h \
+  --title "fix(worktrees): use an eight-hour retirement cooldown" \
+  --body "Changes only branch/worktree retirement recency from 24 hours to a mandatory 8 hours. Keeps the repository-wide maintenance gate, deletion proof, and unrelated 24-hour policies unchanged."
+```
+
+- [ ] **Step 5: Merge through protected main**
+
+Read all review comments, fix any valid findings, wait for all nine required
+checks, then squash-merge the exact checked head. Close `cave-m1qd0` only after
+the merge is confirmed on `origin/main`.

--- a/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+++ b/docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
@@ -184,7 +184,7 @@ maintenance transaction:
    request, or active workflow owns the path, branch, or exact OID.
 6. Every liveness query is complete and schema-valid.
 7. The latest commit, branch reflog, worktree HEAD reflog, and exact merge are
-   outside the mandatory 24-hour cooldown.
+   outside the mandatory 8-hour cooldown.
 8. The exact local OID is on the freshly fetched default branch or exactly
    matches the recorded head of a pull request merged into that default branch.
 9. Structured lifecycle metadata exists and no unexpired exception or recovery
@@ -378,4 +378,4 @@ lifecycle cases. Existing safety cases must not regress.
 - No age-only or name-only stale inference.
 - No automatic cleanup of unstructured legacy state before metadata backfill.
 - No claim that raw Git worktree creation is universally blocked.
-- No weakening of the 24-hour cooldown or existing recovery guarantees.
+- No weakening of the 8-hour cooldown or existing recovery guarantees.

--- a/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
+++ b/docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md
@@ -1,0 +1,56 @@
+# Eight-Hour Worktree Retirement Design
+
+## Goal
+
+Reduce the mandatory branch/worktree retirement recency window from 24 hours to
+8 hours while preserving every other deletion safeguard.
+
+## Scope
+
+This change applies only to local branch and worktree retirement eligibility.
+It does not alter unrelated 24-hour limits such as API caches, stale PR
+defaults, attachment retention, session resources, or maintenance-gate lease
+limits.
+
+## Policy
+
+A clean, landed lifecycle unit remains in `cooldown` until its authoritative
+recency timestamp is at least 8 hours old. At exactly 8 hours it may enter
+`retire-after-gate`.
+
+`retire-after-gate` is not deletion authorization. Removal still requires:
+
+- complete ownership, PR, workflow, task, reflog, and recovery evidence;
+- the repository-wide maintenance transaction;
+- the normative final deletion proof; and
+- successful post-action verification.
+
+Recovery, WIP, dirty, active, protected, unlanded, divergent, or uncertain
+units remain preserved regardless of age.
+
+## Implementation
+
+Replace the lifecycle classifier's day-based threshold with one named
+`RETIREMENT_COOLDOWN_MS` constant set to 8 hours. Use that constant in both
+metadata-aware and legacy classification paths and update their human-readable
+reasons.
+
+Align the binding policy surfaces:
+
+- lifecycle unit tests and patrol integration tests;
+- branch-curator guidance and deletion proof;
+- branch-curator evaluation fixtures; and
+- the current automatic-retirement design documentation.
+
+Historical or unrelated documents that happen to mention 24 hours remain
+unchanged unless they define this retirement policy.
+
+## Verification
+
+Tests must pin both sides of the boundary:
+
+- 7 hours, 59 minutes, 59.999 seconds remains `cooldown`;
+- exactly 8 hours becomes `retire-after-gate`.
+
+Run the lifecycle unit test, patrol integration test, branch-curator skill
+validation if available, typecheck, and test-wiring checks.

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1602,12 +1602,12 @@ exit 0
   assert.equal(directLanding.updatedAtMs, Date.parse("2026-08-10T21:30:00Z"));
   assert.equal(directLanding.mergedPr, null);
   const postLandingCooldown = JSON.parse(
-    patrol(["--json", "--now", "2026-08-11T21:30:01Z"]),
+    patrol(["--json", "--now", "2026-08-11T05:30:00Z"]),
   ).items.find((item) => item.branch === "feat/direct-landing");
   assert.equal(
     postLandingCooldown.lane,
     "retire-after-gate",
-    "the stable direct landing becomes eligible after 24 hours",
+    "the stable direct landing becomes eligible after 8 hours",
   );
   assert.deepEqual(report.budgets, {
     worktrees: { count: 8, warning: 12, exceeded: false },

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 
 const {
   BRANCH_WARNING_BUDGET,
+  RETIREMENT_COOLDOWN_MS,
   WORKTREE_WARNING_BUDGET,
   assessManagedWorktreeCreation,
   calculateLifecycleBudgets,
@@ -15,7 +16,14 @@ const {
 } = await import("./worktree-lifecycle.ts");
 
 const NOW = Date.parse("2026-07-29T22:00:00Z");
+const HOUR = 60 * 60 * 1000;
 const DAY = 24 * 60 * 60 * 1000;
+
+assert.equal(
+  RETIREMENT_COOLDOWN_MS,
+  8 * HOUR,
+  "retirement cooldown remains the mandatory eight-hour window",
+);
 
 {
   for (const equivalent of [
@@ -277,22 +285,25 @@ function legacyObservation(overrides = {}) {
     observation({
       metadata: metadata({ disposition: "pr" }),
       mergedPr: { number: 46, headOid: "a".repeat(40), url: "https://example.test/46" },
-      updatedAtMs: NOW - 2 * 60 * 60 * 1000,
+      updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS + 1,
     }),
     NOW,
   );
-  assert.equal(item.lane, "cooldown", "same-day merged work stays visible during the recency window");
-  assert.match(item.reasons.join("\n"), /24-hour cooldown/);
+  assert.equal(item.lane, "cooldown");
+  assert.match(item.reasons.join("\n"), /8-hour cooldown/);
 }
 
 {
-  const item = classifyWorktree(
-    legacyObservation({
+  const item = classifyLifecycleUnit(
+    observation({
+      metadata: metadata({ disposition: "pr" }),
       mergedPr: { number: 47, headOid: "a".repeat(40), url: "https://example.test/47" },
+      updatedAtMs: NOW - RETIREMENT_COOLDOWN_MS,
     }),
     NOW,
   );
   assert.equal(item.lane, "retire-after-gate", "old exact merged heads become owner-actionable");
+  assert.match(item.reasons.join("\n"), /older than 8 hours/);
   assert.match(item.reasons.join("\n"), /maintenance gate/);
 }
 

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -150,7 +150,7 @@ export type WorktreeLifecycleBudgets = {
   };
 };
 
-const DAY_MS = 24 * 60 * 60 * 1000;
+export const RETIREMENT_COOLDOWN_MS = 8 * 60 * 60 * 1000;
 const RECOVERY_BRANCH = /^(?:backup|archive|rescue)\//i;
 const WIP_BRANCH = /(?:^|[/-])wip(?:$|[/-])/i;
 const DISPOSABLE_IGNORED_ROOTS = [
@@ -418,15 +418,15 @@ function classifyLifecycleUnitInternal(
   }
 
   const ageMs = nowMs - observation.updatedAtMs;
-  if (ageMs < DAY_MS) {
+  if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 24-hour cooldown",
+      "landed work remains inside the mandatory 8-hour cooldown",
       ...reviewAfterReasons(observation.metadata, nowMs),
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 24 hours",
+    "clean landed work is older than 8 hours",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
     ...reviewAfterReasons(observation.metadata, nowMs),
   ]);
@@ -468,14 +468,14 @@ function classifyLifecycleUnitWithoutMetadata(
   }
 
   const ageMs = nowMs - observation.updatedAtMs;
-  if (ageMs < DAY_MS) {
+  if (ageMs < RETIREMENT_COOLDOWN_MS) {
     return withReasons(observation, "cooldown", [
-      "landed work remains inside the mandatory 24-hour cooldown",
+      "landed work remains inside the mandatory 8-hour cooldown",
     ]);
   }
 
   return withReasons(observation, "retire-after-gate", [
-    "clean landed work is older than 24 hours",
+    "clean landed work is older than 8 hours",
     "removal still requires the repository-wide maintenance gate and final deletion proof",
   ]);
 }


### PR DESCRIPTION
## Summary

Changes only branch/worktree retirement recency from 24 hours to a mandatory 8 hours. Repository-wide maintenance and deletion gates, final deletion proof requirements, and unrelated 24-hour policies remain unchanged.

## Verification

All commands exited 0:

- `node --experimental-strip-types src/lib/worktree-lifecycle.test.ts` — passed (`worktree-lifecycle.test.ts: ok`)
- `node scripts/worktree-lifecycle-patrol.test.mjs` — passed (`worktree-lifecycle-patrol.test.mjs: ok`)
- `pnpm typecheck` — passed
- `pnpm check:tests-wired` — passed (`all 1436 test files wired into CI`)
- `git diff --check origin/main...HEAD` — passed with no output
