### PR TITLE
fix(git): retain squash PR heads without global scans

### DIFF
--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -389,6 +389,18 @@ esac
 An open matching PR or active workflow makes the branch live. Query failure
 makes it uncertain.
 
+When GitHub has squash-merged the exact candidate and auto-deleted its source
+branch, do not turn a full remote namespace scan into deletion evidence. The
+manual profile may select one exact merged-PR retention source only after the
+fresh PR inventory identifies the candidate head, the PR detail endpoint
+confirms `closed` + merged state on the repository default branch, and
+`refs/pull/<number>/head` advertises the audited OID. Pass that repository,
+remote, PR number, and base to the strict guard. The guard independently
+reauthenticates all of them, fetches only that one source ref, and rechecks it
+for drift. Any missing, open, mismatched, malformed, or moving PR proof is
+uncertainty. Generic branch/tag retention keeps its existing bounded scan; a
+large unrelated ref namespace is never a reason to raise or bypass that bound.
+
 For other candidates, inspect unique work using fully qualified refs:
 ```bash
 local_ref="refs/heads/$branch"

--- a/.agents/skills/branch-curator/references/deletion-proof.md
+++ b/.agents/skills/branch-curator/references/deletion-proof.md
@@ -783,6 +783,19 @@ of stdout, and exactly the documented four-key allow object. After the final
 allow-object validation, nothing except the worktree removal itself may
 intervene:
 
+If the exact source branch still exists or `HEAD` is an ancestor of an
+advertised branch/tag, leave `strict_guard_retention_args` empty and use the
+ordinary bounded proof. If GitHub squash-merged the exact candidate and
+auto-deleted its source branch, populate the array only after a fresh exact PR
+detail query has proved: one numeric PR, `state == closed`, `merged == true`, a
+valid `merged_at`, `head.sha == audited_worktree_head_oid`,
+`base.ref == audited_remote_main_branch`, and
+`base.repo.full_name == audited_gh_repo`.
+The strict guard reauthenticates those facts and queries/fetches only the exact
+`refs/pull/<number>/head`; it never enumerates unrelated heads/tags in this
+mode. Any ambiguity leaves the array unset and preserves the candidate rather
+than trying both paths or bypassing the source bound.
+
 ```bash
 if test -n "$worktree_path"; then
   current_worktree_head_oid=$(git_exact -C "$worktree_path" rev-parse \
@@ -803,7 +816,15 @@ if test -n "$worktree_path"; then
     { rm -f -- "$strict_guard_output_file";
       printf 'PRESERVE - default ref changed before worktree removal\n';
       continue; }
-  if env -u WT_GUARD_BYPASS -u WT_GUARD_TEST_MODE -u WT_GUARD_TEST_LSOF_BIN node scripts/worktree-guard.mjs --strict-worktree-remove "$canonical_worktree_path" --expected-head "$audited_worktree_head_oid" >"$strict_guard_output_file"; then
+  strict_guard_retention_args=()
+  if test -n "${audited_merged_pr_number:-}"; then
+    strict_guard_retention_args=(
+      --retained-by-github-pr origin "$audited_gh_repo"
+      "$audited_merged_pr_number"
+      --expected-base "$audited_remote_main_branch"
+    )
+  fi
+  if env -u WT_GUARD_BYPASS -u WT_GUARD_TEST_MODE -u WT_GUARD_TEST_LSOF_BIN node scripts/worktree-guard.mjs --strict-worktree-remove "$canonical_worktree_path" --expected-head "$audited_worktree_head_oid" "${strict_guard_retention_args[@]}" >"$strict_guard_output_file"; then
     :
   else
     strict_guard_status=$?

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -262,9 +262,13 @@ test("normative proof scopes remote deletion and uses exact expected OIDs", () =
   );
   assert.ok(
     worktreeTransaction.includes(
-      `env -u WT_GUARD_BYPASS -u WT_GUARD_TEST_MODE -u WT_GUARD_TEST_LSOF_BIN node scripts/worktree-guard.mjs --strict-worktree-remove "$canonical_worktree_path" --expected-head "$audited_worktree_head_oid"`,
+      `env -u WT_GUARD_BYPASS -u WT_GUARD_TEST_MODE -u WT_GUARD_TEST_LSOF_BIN node scripts/worktree-guard.mjs --strict-worktree-remove "$canonical_worktree_path" --expected-head "$audited_worktree_head_oid" "\${strict_guard_retention_args[@]}"`,
     ),
   );
+  assert.match(worktreeTransaction, /--retained-by-github-pr origin "\$audited_gh_repo"/);
+  assert.match(worktreeTransaction, /"\$audited_merged_pr_number"/);
+  assert.match(worktreeTransaction, /--expected-base "\$audited_remote_main_branch"/);
+  assert.match(worktreeTransaction, /queries\/fetches only the exact|queries\/fetches only|queries\/fetches/);
   assert.match(
     worktreeTransaction,
     /if env -u WT_GUARD_BYPASS -u WT_GUARD_TEST_MODE -u WT_GUARD_TEST_LSOF_BIN node scripts\/worktree-guard\.mjs --strict-worktree-remove[\s\S]*else[\s\S]*PRESERVE - strict worktree guard failed/,

--- a/scripts/worktree-guard.mjs
+++ b/scripts/worktree-guard.mjs
@@ -30,8 +30,12 @@
  *     git's admin file keeps pointing at the old path, so moving a live
  *     worktree strands its work exactly like deleting it would.
  *
- * "Retained" means a remote BRANCH or a TAG that is present on a remote. Tags
- * count because archiving a branch as a signed, pushed tag preserves its OIDs
+ * "Retained" normally means a remote BRANCH or a TAG that is present on a
+ * remote. The strict direct guard also accepts one explicitly named merged
+ * GitHub PR whose exact `refs/pull/<number>/head` is freshly authenticated,
+ * fetched, and rechecked; this bounded path handles squash-source auto-delete
+ * without enumerating a large unrelated ref namespace. Tags count because
+ * archiving a branch as a signed, pushed tag preserves its OIDs
  * more durably than a branch does — merging deletes the branch, never the tag.
  * Requiring a branch made the guard block six provably-archived cleanups during
  * one sweep (2026-07-29), and six bypasses to delete preserved work is how the
@@ -63,9 +67,10 @@ import { execFileSync, spawnSync } from "node:child_process";
 import path from "node:path";
 
 const FULL_OID = /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/;
-// Strict retention proof has a deterministic network/work ceiling. Normal
-// repositories are far below these limits; exceeding any one is uncertainty,
-// not permission to turn an unbounded ref inventory into deletion evidence.
+// Generic branch/tag retention proof has a deterministic network/work ceiling.
+// Exceeding any one is uncertainty, not permission to turn an unbounded ref
+// inventory into deletion evidence. Exact merged-PR proof has its own smaller
+// ceiling: one PR API record and one exact PR ref, each checked twice.
 // With incremental 16-ref fetch batches this permits at most 16 initial
 // advertisements, 31 source-only fetches, and 31 rechecks: 78 remote round
 // trips total.
@@ -134,6 +139,43 @@ function strictGit(args, cwd) {
   const probe = strictGitProbe(args, cwd);
   if (probe.status !== 0) throw new Error(`git probe exited ${probe.status}`);
   return probe.stdout;
+}
+
+function strictGithubApi(endpoint, cwd) {
+  const env = strictGitEnv();
+  delete env.GH_HOST;
+  delete env.GH_REPO;
+  env.GH_PAGER = "cat";
+  env.GH_PROMPT_DISABLED = "1";
+  const probe = spawnSync(
+    "gh",
+    ["api", "--hostname", "github.com", "--method", "GET", endpoint],
+    {
+      cwd,
+      env,
+      encoding: "utf8",
+      timeout: 10000,
+      maxBuffer: 1024 * 1024,
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (probe.error) throw new Error(`GitHub API failed: ${probe.error.message}`);
+  if (probe.signal) throw new Error(`GitHub API ended on signal ${probe.signal}`);
+  if (probe.status !== 0) throw new Error(`GitHub API exited ${probe.status}`);
+  if (probe.stderr !== "") throw new Error("GitHub API returned unexpected diagnostics");
+  if (typeof probe.stdout !== "string" || !probe.stdout) {
+    throw new Error("GitHub API returned empty output");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(probe.stdout);
+  } catch {
+    throw new Error("GitHub API returned malformed JSON");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("GitHub API returned malformed PR data");
+  }
+  return parsed;
 }
 
 function strictSingleOid(output, label) {
@@ -231,7 +273,7 @@ function strictFetchAdvertisedRefs(target, remote, sourceRefs) {
   }
   strictGit([
     "-C", target,
-    "fetch", "--quiet", "--refetch", "--no-write-fetch-head", "--no-tags", "--no-recurse-submodules", "--refmap=",
+    "fetch", "--quiet", "--refetch", "--no-auto-maintenance", "--no-write-fetch-head", "--no-tags", "--no-recurse-submodules", "--refmap=",
     "--", remote, ...sourceRefs.map((sourceRef) => `${sourceRef}:`),
   ], target);
 }
@@ -287,6 +329,102 @@ function strictResolveAdvertisedCommit(target, remote, entry, peeled) {
     throw new Error(`remote ${remote} advertised ${entry.ref} as an ambiguous commit target`);
   }
   return advertisedCommit;
+}
+
+function strictGithubRepoFromRemoteUrl(output) {
+  const remoteUrl = strictSingleLine(output, "git remote get-url");
+  const match =
+    /^https:\/\/github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(remoteUrl) ??
+    /^git@github\.com:([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(remoteUrl) ??
+    /^ssh:\/\/git@github\.com\/([A-Za-z0-9_.-]+)\/([A-Za-z0-9_.-]+?)(?:\.git)?$/.exec(remoteUrl);
+  if (!match) throw new Error("configured remote URL is not a canonical github.com repository URL");
+  return `${match[1]}/${match[2]}`;
+}
+
+function strictSingleExactRef(output, remote, expectedRef, expectedOidWidth) {
+  const lines = output.split("\n");
+  if (lines.length !== 2 || lines[1] !== "") {
+    throw new Error(`remote ${remote} returned malformed exact-ref output`);
+  }
+  const match = /^([0-9a-f]+)\t(refs\/pull\/([1-9][0-9]*)\/head)$/.exec(lines[0]);
+  if (
+    !match ||
+    !FULL_OID.test(match[1]) ||
+    match[1].length !== expectedOidWidth ||
+    match[2] !== expectedRef ||
+    Buffer.byteLength(match[2], "utf8") > STRICT_MAX_REF_BYTES
+  ) {
+    throw new Error(`remote ${remote} returned a malformed exact PR head`);
+  }
+  return { oid: match[1], ref: match[2], kind: "pull", name: match[3], peeled: false };
+}
+
+function strictValidateMergedGithubPr(pr, proof, head) {
+  if (pr.number !== proof.number) throw new Error("GitHub PR number does not match requested proof");
+  if (pr.state !== "closed" || pr.merged !== true || typeof pr.merged_at !== "string" || !Number.isFinite(Date.parse(pr.merged_at))) {
+    throw new Error("GitHub PR is not merged");
+  }
+  if (!FULL_OID.test(pr.merge_commit_sha) || pr.merge_commit_sha.length !== head.length) {
+    throw new Error("GitHub PR returned a malformed merge commit");
+  }
+  if (pr.head?.sha !== head) throw new Error("GitHub PR head does not match expected HEAD");
+  if (pr.base?.ref !== proof.base) throw new Error("GitHub PR base does not match expected base");
+  if (pr.base?.repo?.full_name?.toLowerCase() !== proof.repo.toLowerCase()) {
+    throw new Error("GitHub PR repository does not match requested proof");
+  }
+  return {
+    number: pr.number,
+    state: pr.state,
+    merged: pr.merged,
+    mergedAt: pr.merged_at,
+    mergeCommit: pr.merge_commit_sha,
+    head: pr.head.sha,
+    base: pr.base.ref,
+    repo: pr.base.repo.full_name.toLowerCase(),
+  };
+}
+
+function strictRetainedByMergedGithubPr(target, head, proof) {
+  const remotes = strictRemoteNames(target);
+  if (!remotes.includes(proof.remote)) throw new Error("GitHub PR proof remote is not configured");
+  strictGit(["-C", target, "check-ref-format", `refs/heads/${proof.base}`]);
+
+  const remoteRepo = strictGithubRepoFromRemoteUrl(
+    strictGit(["-C", target, "remote", "get-url", "--", proof.remote]),
+  );
+  if (remoteRepo.toLowerCase() !== proof.repo.toLowerCase()) {
+    throw new Error("configured remote URL does not match GitHub PR proof repository");
+  }
+
+  const endpoint = `repos/${proof.repo}/pulls/${proof.number}`;
+  const initialPr = strictValidateMergedGithubPr(strictGithubApi(endpoint, target), proof, head);
+
+  const prRef = `refs/pull/${proof.number}/head`;
+  strictGit(["-C", target, "check-ref-format", prRef]);
+  const advertised = strictSingleExactRef(
+    strictGit(["-C", target, "ls-remote", "--", proof.remote, prRef]),
+    proof.remote,
+    prRef,
+    head.length,
+  );
+  if (advertised.oid !== head) throw new Error("advertised GitHub PR head does not match expected HEAD");
+
+  strictFetchAdvertisedRefs(target, proof.remote, [prRef]);
+  const refreshed = strictSingleExactRef(
+    strictGit(["-C", target, "ls-remote", "--", proof.remote, prRef]),
+    proof.remote,
+    prRef,
+    head.length,
+  );
+  if (refreshed.oid !== advertised.oid) {
+    throw new Error(`remote ${proof.remote} changed ${prRef} during retention proof`);
+  }
+  const refreshedPr = strictValidateMergedGithubPr(strictGithubApi(endpoint, target), proof, head);
+  if (JSON.stringify(refreshedPr) !== JSON.stringify(initialPr)) {
+    throw new Error("GitHub PR changed during retention proof");
+  }
+  const advertisedCommit = strictResolveAdvertisedCommit(target, proof.remote, advertised, null);
+  if (advertisedCommit !== head) throw new Error("fetched GitHub PR head does not match expected HEAD");
 }
 
 function strictRetainedOnRemote(target, head) {
@@ -358,6 +496,25 @@ function strictRetainedOnRemote(target, head) {
   throw new Error("HEAD is not retained by any configured remote");
 }
 
+function strictCanonicalCwd(cwd) {
+  const missingSegments = [];
+  let cursor = cwd;
+  for (;;) {
+    try {
+      return {
+        path: path.join(realpathSync(cursor), ...missingSegments),
+        missing: missingSegments.length > 0,
+      };
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw new Error(`lsof cwd cannot be resolved: ${error.message}`);
+      const parent = path.dirname(cursor);
+      if (parent === cursor) throw new Error(`lsof cwd cannot be resolved: ${error.message}`);
+      missingSegments.unshift(path.basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
 function strictLiveProcesses(target) {
   const testLsof =
     process.env.WT_GUARD_TEST_MODE === "1" && process.env.WT_GUARD_TEST_LSOF_BIN
@@ -399,14 +556,10 @@ function strictLiveProcesses(target) {
       if (!line.startsWith("n") || !cwd || !path.isAbsolute(cwd)) {
         throw new Error("lsof probe returned a malformed cwd name");
       }
-      let canonicalCwd;
-      try {
-        canonicalCwd = realpathSync(cwd);
-      } catch (error) {
-        throw new Error(`lsof cwd cannot be resolved: ${error.message}`);
-      }
+      const canonicalCwd = strictCanonicalCwd(cwd);
       recordCount += 1;
-      if (canonicalCwd === target || canonicalCwd.startsWith(prefix)) {
+      if (canonicalCwd.path === target || canonicalCwd.path.startsWith(prefix)) {
+        if (canonicalCwd.missing) throw new Error("lsof cwd inside target cannot be resolved");
         throw new Error(`process ${processRecord.pid} has cwd inside target`);
       }
       processRecord = null;
@@ -420,17 +573,46 @@ function strictLiveProcesses(target) {
 }
 
 function runStrictWorktreeRemove(args) {
-  if (
-    args.length !== 4 ||
-    args[0] !== "--strict-worktree-remove" ||
-    args[2] !== "--expected-head"
-  ) {
-    throw new Error("expected --strict-worktree-remove <absolute-path> --expected-head <full-oid>");
+  const basicArgs =
+    args.length === 4 &&
+    args[0] === "--strict-worktree-remove" &&
+    args[2] === "--expected-head";
+  const githubPrArgs =
+    args.length === 10 &&
+    args[0] === "--strict-worktree-remove" &&
+    args[2] === "--expected-head" &&
+    args[4] === "--retained-by-github-pr" &&
+    args[8] === "--expected-base";
+  if (!basicArgs && !githubPrArgs) {
+    throw new Error(
+      "expected --strict-worktree-remove <absolute-path> --expected-head <full-oid> " +
+        "[--retained-by-github-pr <remote> <owner/repo> <number> --expected-base <branch>]",
+    );
   }
   const requestedPath = args[1];
   const expectedHead = args[3];
   if (!path.isAbsolute(requestedPath)) throw new Error("target path must be absolute");
   if (!FULL_OID.test(expectedHead)) throw new Error("expected HEAD must be a full OID");
+  let githubProof = null;
+  if (githubPrArgs) {
+    const remote = args[5];
+    const repo = args[6];
+    const numberText = args[7];
+    const base = args[9];
+    if (!remote || /\s/.test(remote)) throw new Error("GitHub PR proof remote is malformed");
+    if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repo) || repo.endsWith(".git")) {
+      throw new Error("GitHub PR proof repository is malformed");
+    }
+    if (!/^[1-9][0-9]*$/.test(numberText) || numberText.length > 10) {
+      throw new Error("GitHub PR proof number is malformed");
+    }
+    if (!base || base.length > STRICT_MAX_REF_BYTES || strictSingleLine(`${base}\n`, "expected base") !== base) {
+      throw new Error("GitHub PR proof base is malformed");
+    }
+    const number = Number(numberText);
+    if (!Number.isSafeInteger(number)) throw new Error("GitHub PR proof number is out of range");
+    githubProof = { remote, repo, number, base };
+  }
 
   let target;
   try {
@@ -462,7 +644,8 @@ function runStrictWorktreeRemove(args) {
   ]);
   if (status !== "") throw new Error("target worktree is not clean");
 
-  strictRetainedOnRemote(target, actualHead);
+  if (githubProof) strictRetainedByMergedGithubPr(target, actualHead, githubProof);
+  else strictRetainedOnRemote(target, actualHead);
   strictLiveProcesses(target);
   process.stdout.write(`${JSON.stringify({
     ok: true,

--- a/scripts/worktree-guard.test.mjs
+++ b/scripts/worktree-guard.test.mjs
@@ -83,6 +83,18 @@ function strictArgs(wt, head) {
   return ["--strict-worktree-remove", wt, "--expected-head", head];
 }
 
+function strictGithubPrArgs(wt, head, number = "4214") {
+  return [
+    ...strictArgs(wt, head),
+    "--retained-by-github-pr",
+    "origin",
+    "OpenCoven/coven-cave",
+    number,
+    "--expected-base",
+    "main",
+  ];
+}
+
 function strictEnv(executable = lsofStub()) {
   return { WT_GUARD_TEST_MODE: "1", WT_GUARD_TEST_LSOF_BIN: executable };
 }
@@ -100,8 +112,15 @@ const options = ${JSON.stringify(options)};
 const args = process.argv.slice(2);
 const isLsRemote = args.includes("ls-remote");
 const isFetch = args.includes("fetch");
+if (options.callLog) {
+  appendFileSync(options.callLog, JSON.stringify(args) + "\\n");
+}
 if (isFetch && options.fetchLog) {
   appendFileSync(options.fetchLog, JSON.stringify(args) + "\\n");
+}
+if (options.remoteUrl && args.includes("remote") && args.includes("get-url")) {
+  process.stdout.write(options.remoteUrl + "\\n");
+  process.exit(0);
 }
 if (isLsRemote && options.lsRemoteOutput !== undefined) {
   process.stdout.write(options.lsRemoteOutput);
@@ -129,6 +148,32 @@ process.exit(Number.isInteger(result.status) ? result.status : 127);
   );
   chmodSync(executable, 0o755);
   return `${bin}${path.delimiter}${process.env.PATH}`;
+}
+
+function ghWrapper(payload, { status = 0, stderr = "", tailPath = process.env.PATH } = {}) {
+  const bin = mkdtempSync(path.join(tmpdir(), "wt-guard-gh-"));
+  const executable = path.join(bin, "gh");
+  const stateFile = path.join(bin, "state");
+  const payloads = Array.isArray(payload) ? payload : [payload];
+  writeFileSync(
+    executable,
+    `#!/usr/bin/env node\nconst { existsSync, readFileSync, writeFileSync } = require("node:fs");\nconst payloads = ${JSON.stringify(payloads)};\nconst stateFile = ${JSON.stringify(stateFile)};\nconst count = existsSync(stateFile) ? Number(readFileSync(stateFile, "utf8")) : 0;\nwriteFileSync(stateFile, String(count + 1));\nprocess.stdout.write(payloads[Math.min(count, payloads.length - 1)]);\nprocess.stderr.write(${JSON.stringify(stderr)});\nprocess.exit(${status});\n`,
+  );
+  chmodSync(executable, 0o755);
+  return `${bin}${path.delimiter}${tailPath}`;
+}
+
+function mergedPrPayload(head, overrides = {}) {
+  return JSON.stringify({
+    number: 4214,
+    state: "closed",
+    merged: true,
+    merged_at: "2026-08-02T04:40:45Z",
+    merge_commit_sha: "a".repeat(head.length),
+    head: { sha: head },
+    base: { ref: "main", repo: { full_name: "OpenCoven/coven-cave" } },
+    ...overrides,
+  });
 }
 
 function fetchCalls(fetchLog) {
@@ -587,6 +632,7 @@ await test("strict exact branch tips fetch only the exact advertised source", ()
   assert.equal(result.status, 0, `an exact advertised branch tip is retained: ${result.stderr}`);
   const calls = fetchCalls(fetchLog);
   assert.equal(calls.length, 1, "exact retention uses one source-only fetch");
+  assert.equal(calls[0].includes("--no-auto-maintenance"), true, "strict fetch cannot create its own live CWD");
   const separator = calls[0].indexOf("--");
   assert.deepEqual(
     calls[0].slice(separator + 2),
@@ -673,6 +719,131 @@ await test("strict retention has a hard aggregate candidate bound", () => {
   assert.equal(result.status, 2, "more than 256 advertised candidate sources is refused before fetch");
   assert.equal(result.stdout, "");
   assert.deepEqual(gitMetadataSnapshot(excessive.dir), metadataBefore, "candidate overflow changes no refs or FETCH_HEAD");
+});
+
+await test("strict merged PR proof bypasses no limits and avoids a large remote namespace", () => {
+  const fixture = repoWithWorktree({ push: false });
+  const head = sh("git", ["-C", fixture.wt, "rev-parse", "HEAD"], fixture.dir).trim();
+  const remoteMain = sh("git", ["-C", fixture.dir, "rev-parse", "main"], fixture.dir).trim();
+  for (let index = 0; index < 257; index += 1) {
+    sh(
+      "git",
+      ["--git-dir", fixture.bare, "update-ref", `refs/heads/generated-${String(index).padStart(3, "0")}`, remoteMain],
+      fixture.dir,
+    );
+  }
+  sh("git", ["-C", fixture.wt, "push", "-q", "origin", "HEAD:refs/pull/4214/head"], fixture.dir);
+
+  const logs = mkdtempSync(path.join(tmpdir(), "wt-guard-pr-proof-"));
+  const callLog = path.join(logs, "git.jsonl");
+  const fetchLog = path.join(logs, "fetch.jsonl");
+  writeFileSync(callLog, "");
+  writeFileSync(fetchLog, "");
+  const metadataBefore = gitMetadataSnapshot(fixture.dir);
+  const gitPath = gitWrapper({
+    callLog,
+    fetchLog,
+    remoteUrl: "https://github.com/OpenCoven/coven-cave.git",
+  });
+  const result = runStrict(strictGithubPrArgs(fixture.wt, head), fixture.dir, {
+    ...strictEnv(),
+    PATH: ghWrapper(mergedPrPayload(head), { tailPath: gitPath }),
+  });
+
+  assert.equal(result.status, 0, `exact merged PR retention succeeds without scanning 257 refs: ${result.stderr}`);
+  const calls = readFileSync(callLog, "utf8").trimEnd().split("\n").map((line) => JSON.parse(line));
+  const lsRemoteCalls = calls.filter((args) => args.includes("ls-remote"));
+  assert.equal(lsRemoteCalls.length, 2, "the exact PR ref is advertised and rechecked once");
+  for (const args of lsRemoteCalls) {
+    assert.equal(args.includes("--heads"), false, "merged PR proof never enumerates remote branches");
+    assert.equal(args.includes("--tags"), false, "merged PR proof never enumerates remote tags");
+    assert.deepEqual(args.slice(-3), ["--", "origin", "refs/pull/4214/head"], "only the exact PR head is queried");
+  }
+  const fetches = fetchCalls(fetchLog);
+  assert.equal(fetches.length, 1, "merged PR proof performs one source-only fetch");
+  assert.deepEqual(fetches[0].slice(-3), ["--", "origin", "refs/pull/4214/head:"], "only the PR head is fetched");
+  assert.deepEqual(gitMetadataSnapshot(fixture.dir), metadataBefore, "merged PR proof changes no refs or FETCH_HEAD");
+});
+
+await test("strict merged PR proof refuses state, scope, identity, API, and drift failures", () => {
+  const fixture = repoWithWorktree({ push: false });
+  const head = sh("git", ["-C", fixture.wt, "rev-parse", "HEAD"], fixture.dir).trim();
+  const other = sh("git", ["-C", fixture.dir, "rev-parse", "main"], fixture.dir).trim();
+  sh("git", ["-C", fixture.wt, "push", "-q", "origin", "HEAD:refs/pull/4214/head"], fixture.dir);
+  const metadataBefore = gitMetadataSnapshot(fixture.dir);
+
+  const cases = [
+    ["open PR", mergedPrPayload(head, { state: "open", merged_at: null }), {}, /not merged/],
+    ["head mismatch", mergedPrPayload(other), {}, /head does not match/],
+    ["base mismatch", mergedPrPayload(head, { base: { ref: "develop", repo: { full_name: "OpenCoven/coven-cave" } } }), {}, /base does not match/],
+    ["repo mismatch", mergedPrPayload(head, { base: { ref: "main", repo: { full_name: "Other/repo" } } }), {}, /repository does not match/],
+    ["API failure", "", { status: 1, stderr: "offline" }, /GitHub API/],
+  ];
+  for (const [label, payload, ghOptions, pattern] of cases) {
+    const gitPath = gitWrapper({ remoteUrl: "https://github.com/OpenCoven/coven-cave.git" });
+    const result = runStrict(strictGithubPrArgs(fixture.wt, head), fixture.dir, {
+      ...strictEnv(),
+      PATH: ghWrapper(payload, { ...ghOptions, tailPath: gitPath }),
+    });
+    assert.equal(result.status, 2, `${label} is refused`);
+    assert.match(result.stderr, pattern, `${label} explains the failed proof`);
+  }
+
+  const wrongRemotePath = gitWrapper({ remoteUrl: "https://github.com/Other/repo.git" });
+  const wrongRemote = runStrict(strictGithubPrArgs(fixture.wt, head), fixture.dir, {
+    ...strictEnv(),
+    PATH: ghWrapper(mergedPrPayload(head), { tailPath: wrongRemotePath }),
+  });
+  assert.equal(wrongRemote.status, 2, "configured remote/repository mismatch is refused");
+  assert.match(wrongRemote.stderr, /remote URL does not match/);
+
+  const driftPath = gitWrapper({
+    remoteUrl: "https://github.com/OpenCoven/coven-cave.git",
+    driftRef: "refs/pull/4214/head",
+    driftOid: other,
+  });
+  const drift = runStrict(strictGithubPrArgs(fixture.wt, head), fixture.dir, {
+    ...strictEnv(),
+    PATH: ghWrapper(mergedPrPayload(head), { tailPath: driftPath }),
+  });
+  assert.equal(drift.status, 2, "PR head drift after fetch is refused");
+  assert.match(drift.stderr, /changed refs\/pull\/4214\/head/);
+
+  const apiDriftPath = gitWrapper({ remoteUrl: "https://github.com/OpenCoven/coven-cave.git" });
+  const apiDrift = runStrict(strictGithubPrArgs(fixture.wt, head), fixture.dir, {
+    ...strictEnv(),
+    PATH: ghWrapper(
+      [
+        mergedPrPayload(head),
+        mergedPrPayload(head, { merge_commit_sha: "b".repeat(head.length) }),
+      ],
+      { tailPath: apiDriftPath },
+    ),
+  });
+  assert.equal(apiDrift.status, 2, "PR API drift after fetch is refused");
+  assert.match(apiDrift.stderr, /GitHub PR changed during retention proof/);
+  assert.deepEqual(gitMetadataSnapshot(fixture.dir), metadataBefore, "all PR proof refusals change no refs or FETCH_HEAD");
+});
+
+await test("strict lsof proof ignores only unresolved cwd paths outside the target", () => {
+  const fixture = repoWithWorktree({ push: true });
+  const head = sh("git", ["-C", fixture.wt, "rev-parse", "HEAD"], fixture.dir).trim();
+  const unrelatedDeleted = path.join(fixture.dir, ".worktrees", "already-deleted");
+  const unrelated = runStrict(strictArgs(fixture.wt, head), fixture.dir, strictEnv(lsofStub(
+    `p4242\ncstale\nfcwd\nn${unrelatedDeleted}\n`,
+  )));
+  assert.equal(
+    unrelated.status,
+    0,
+    `an unresolved cwd outside the exact target is not target ownership: ${unrelated.stderr}`,
+  );
+
+  const deletedInsideTarget = path.join(fixture.wt, "removed-child");
+  const inside = runStrict(strictArgs(fixture.wt, head), fixture.dir, strictEnv(lsofStub(
+    `p4242\ncstale\nfcwd\nn${deletedInsideTarget}\n`,
+  )));
+  assert.equal(inside.status, 2, "an unresolved cwd lexically inside the target remains uncertain");
+  assert.match(inside.stderr, /cwd inside target cannot be resolved/);
 });
 
 await test("strict advertisements use one repository OID width", () => {


### PR DESCRIPTION
## Summary

- authenticate one exact merged GitHub PR head without enumerating unrelated remote refs
- preserve the generic 256-source bound and refuse PR state, scope, identity, API, or ref drift
- ignore only unresolved process CWDs outside the target and disable guard-induced Git auto-maintenance

## Verification

- worktree-guard: 10/10
- maintenance-gate: 24/24
- branch-curator contract: 4/4
- all 1,443 test files wired into CI
- pnpm lint
- pnpm beads:worktrees (report-only)
- git diff --check and signed pre-commit gate
- live exact proof against merged PRs #4204 and #4214

Bead: cave-nycsf