### PR TITLE
fix(release): accept v0.2.2 Windows runtime

### DIFF
--- a/scripts/windows-msi-budget.ps1
+++ b/scripts/windows-msi-budget.ps1
@@ -10,11 +10,12 @@ $ErrorActionPreference = "Stop"
 # Keep exact, independently reviewed baselines per table. Sharing the largest
 # value would leave silent slack in smaller tables; upper bounds would also hide
 # missing or incorrectly staged resources when a table unexpectedly shrinks.
+# These values are the measured v0.2.2 package after adding the Kokoro runtime.
 $rowBaselines = [ordered]@{
-    fileRows = 382
-    componentRows = 387
-    createFolderRows = 382
-    directoryRows = 50
+    fileRows = 741
+    componentRows = 746
+    createFolderRows = 741
+    directoryRows = 88
 }
 $rowInspectionLimit = 4096
 $byteBudget = 256MB

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -598,15 +598,15 @@ test("Windows release reports and enforces bounded MSI tables", async () => {
     assert.match(budget, new RegExp("FROM `" + table + "`"), `budget must inspect MSI ${table} rows`);
   }
   for (const [metric, limit] of Object.entries({
-    fileRows: 382,
-    componentRows: 387,
-    createFolderRows: 382,
-    directoryRows: 50,
+    fileRows: 741,
+    componentRows: 746,
+    createFolderRows: 741,
+    directoryRows: 88,
   })) {
     assert.match(
       budget,
       new RegExp(`${metric} = ${limit}`),
-      `${metric} must stay pinned to the independently measured post-placeholder baseline`,
+      `${metric} must stay pinned to the independently measured v0.2.2 Kokoro baseline`,
     );
   }
   assert.doesNotMatch(


### PR DESCRIPTION
## Summary
- pin the Windows MSI table gate to the measured v0.2.2 Kokoro package
- keep independent exact baselines for every inspected MSI table
- retain the 256 MiB byte cap and single-server-archive invariant

## Evidence
Release run `30732817598` measured:
- MSI: 105,293,493 bytes
- installed files: 227,782,694 bytes (below 268,435,456-byte cap)
- File/Component/CreateFolder/Directory rows: 741/746/741/88
- server archives: 1

The increase from v0.2.1 is the intentional packaged Kokoro/sherpa-onnx runtime shipped in #4079, including the offline TTS executable and its language-data tree.

## Verification
- `node --test src-tauri/release-runtime.test.mjs scripts/release-macos-signing.test.mjs`
- `git diff --check`