### PR TITLE
fix(projects): keep local registrations visible before familiar setup

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -79,6 +79,17 @@ for (const forbiddenRoot of [
 }
 assert.match(closureSource, /fileCount: 5_841/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
+for (const runtimeFile of [
+  "dist/compiled/webpack/webpack-lib.js",
+  "dist/compiled/webpack/webpack.js",
+  "dist/compiled/webpack/bundle5.js",
+]) {
+  assert.match(
+    closureSource,
+    new RegExp(runtimeFile.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    `runtime closure must retain Next startup file ${runtimeFile}`,
+  );
+}
 
 // App-size: runtime bundles must drop test/dev packages and metadata that are
 // useful only while developing or debugging the build machine.

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -35,6 +35,15 @@ export const SIDECAR_DYNAMIC_PACKAGES = Object.freeze([
   "ws",
 ]);
 
+// Next's server config loader resolves these files dynamically at startup.
+// NFT does not retain them in the sparse standalone dependency tree, so keep
+// the small compiled webpack bootstrap explicitly in the sidecar closure.
+export const SIDECAR_NEXT_RUNTIME_FILES = Object.freeze([
+  "dist/compiled/webpack/webpack-lib.js",
+  "dist/compiled/webpack/webpack.js",
+  "dist/compiled/webpack/bundle5.js",
+]);
+
 export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Headroom over the ~5.2k baseline: .agents/skills is a runtime root, so
   // each first-party skill shipped to familiars adds a file here (covenwiki
@@ -398,6 +407,35 @@ async function copyNextAliases(standaloneRoot, destination, allowedLinkRoots) {
   }
 }
 
+async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination, allowedLinkRoots) {
+  const nextRoots = [
+    path.join(standaloneRoot, "node_modules", "next"),
+    path.join(dependencyRoot, "next"),
+  ];
+
+  for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+    let source = null;
+    for (const root of nextRoots) {
+      const candidate = path.join(root, relativePath);
+      try {
+        await stat(candidate);
+        source = candidate;
+        break;
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+    }
+    if (!source) {
+      throw new Error(`required Next sidecar runtime file is missing: ${relativePath}`);
+    }
+    await copyResolvedEntry(
+      source,
+      path.join(destination, "node_modules", "next", relativePath),
+      { followLinks: true, allowedLinkRoots },
+    );
+  }
+}
+
 export async function assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination) {
   const roots = [projectRoot, standaloneRoot, dependencyRoot].map((root) => path.resolve(root));
   [projectRoot, standaloneRoot, dependencyRoot, destination] = [
@@ -485,6 +523,7 @@ export async function assembleSidecarRuntime(projectRoot, standaloneRoot, depend
   for (const packageName of SIDECAR_DYNAMIC_PACKAGES) {
     await copyDynamicPackage(packageName, dependencyRoot, destination, roots);
   }
+  await copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination, roots);
   await copyDynamicNativePackages(dependencyRoot, destination, roots);
   await copyNextAliases(standaloneRoot, destination, roots);
 
@@ -532,6 +571,7 @@ export async function verifySidecarRuntime(root) {
     "node_modules/react-dom/package.json",
     "node_modules/sharp/package.json",
     "node_modules/ws/package.json",
+    ...SIDECAR_NEXT_RUNTIME_FILES.map((relativePath) => path.join("node_modules/next", relativePath)),
     "package.json",
     "public/sandbox/react-runtime.js",
     "server.js",

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -414,11 +414,12 @@ async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot,
   ];
   // A required file can be beneath a symlinked `next` package directory, so
   // checking only the final directory entry is not enough to enforce the
-  // staging-root boundary. Resolve both the candidate and the allowed roots
-  // before copying, while still letting copyResolvedEntry apply its existing
-  // final-entry link checks. Do not use the broad project root here: a
-  // dependency symlink must not pull unrelated project files into the sidecar.
-  const resolvedAllowedLinkRoots = await Promise.all(
+  // package boundary. Resolve the package root and candidate before copying,
+  // while still letting copyResolvedEntry apply its existing final-entry link
+  // checks. A required entry may only resolve within its own `next` package;
+  // allowing the broader project or node_modules roots could copy unrelated
+  // dependency trees into the sidecar.
+  const resolvedPackageRoots = await Promise.all(
     [standaloneRoot, path.join(projectRoot, "node_modules"), dependencyRoot].map((root) => realpath(root)),
   );
 
@@ -427,15 +428,19 @@ async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot,
     for (const root of nextRoots) {
       const candidate = path.join(root, relativePath);
       try {
+        const resolvedNextRoot = await realpath(root);
+        if (!resolvedPackageRoots.some((allowedRoot) => isInside(allowedRoot, resolvedNextRoot))) {
+          throw new Error(`sidecar dependency link escapes its allowed roots: ${root} -> ${resolvedNextRoot}`);
+        }
         const resolvedCandidate = await realpath(candidate);
-        if (!resolvedAllowedLinkRoots.some((allowedRoot) => isInside(allowedRoot, resolvedCandidate))) {
+        if (!isInside(resolvedNextRoot, resolvedCandidate)) {
           throw new Error(`sidecar dependency link escapes its allowed roots: ${candidate} -> ${resolvedCandidate}`);
         }
         const metadata = await stat(resolvedCandidate);
         if (!metadata.isFile()) {
           throw new Error(`required Next sidecar runtime file is not a regular file: ${relativePath}`);
         }
-        source = resolvedCandidate;
+        source = { path: resolvedCandidate, root: resolvedNextRoot };
         break;
       } catch (error) {
         if (error.code !== "ENOENT") throw error;
@@ -445,9 +450,9 @@ async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot,
       throw new Error(`required Next sidecar runtime file is missing: ${relativePath}`);
     }
     await copyResolvedEntry(
-      source,
+      source.path,
       path.join(destination, "node_modules", "next", relativePath),
-      { followLinks: true, allowedLinkRoots: resolvedAllowedLinkRoots },
+      { followLinks: true, allowedLinkRoots: [source.root] },
     );
   }
 }

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -412,17 +412,27 @@ async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination,
     path.join(standaloneRoot, "node_modules", "next"),
     path.join(dependencyRoot, "next"),
   ];
+  // A required file can be beneath a symlinked `next` package directory, so
+  // checking only the final directory entry is not enough to enforce the
+  // staging-root boundary. Resolve both the candidate and the allowed roots
+  // before copying, while still letting copyResolvedEntry apply its existing
+  // final-entry link checks.
+  const resolvedAllowedLinkRoots = await Promise.all(allowedLinkRoots.map((root) => realpath(root)));
 
   for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
     let source = null;
     for (const root of nextRoots) {
       const candidate = path.join(root, relativePath);
       try {
-        const metadata = await stat(candidate);
+        const resolvedCandidate = await realpath(candidate);
+        if (!resolvedAllowedLinkRoots.some((allowedRoot) => isInside(allowedRoot, resolvedCandidate))) {
+          throw new Error(`sidecar dependency link escapes its allowed roots: ${candidate} -> ${resolvedCandidate}`);
+        }
+        const metadata = await stat(resolvedCandidate);
         if (!metadata.isFile()) {
           throw new Error(`required Next sidecar runtime file is not a regular file: ${relativePath}`);
         }
-        source = candidate;
+        source = resolvedCandidate;
         break;
       } catch (error) {
         if (error.code !== "ENOENT") throw error;
@@ -434,7 +444,7 @@ async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination,
     await copyResolvedEntry(
       source,
       path.join(destination, "node_modules", "next", relativePath),
-      { followLinks: true, allowedLinkRoots },
+      { followLinks: true, allowedLinkRoots: resolvedAllowedLinkRoots },
     );
   }
 }

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -432,6 +432,10 @@ async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot,
         if (!resolvedPackageRoots.some((allowedRoot) => isInside(allowedRoot, resolvedNextRoot))) {
           throw new Error(`sidecar dependency link escapes its allowed roots: ${root} -> ${resolvedNextRoot}`);
         }
+        const nextPackage = JSON.parse(await readFile(path.join(resolvedNextRoot, "package.json"), "utf8"));
+        if (nextPackage.name !== "next") {
+          throw new Error(`sidecar Next package root is not the Next package: ${root} -> ${resolvedNextRoot}`);
+        }
         const resolvedCandidate = await realpath(candidate);
         if (!isInside(resolvedNextRoot, resolvedCandidate)) {
           throw new Error(`sidecar dependency link escapes its allowed roots: ${candidate} -> ${resolvedCandidate}`);

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -407,7 +407,7 @@ async function copyNextAliases(standaloneRoot, destination, allowedLinkRoots) {
   }
 }
 
-async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination, allowedLinkRoots) {
+async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot, destination) {
   const nextRoots = [
     path.join(standaloneRoot, "node_modules", "next"),
     path.join(dependencyRoot, "next"),
@@ -416,8 +416,11 @@ async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination,
   // checking only the final directory entry is not enough to enforce the
   // staging-root boundary. Resolve both the candidate and the allowed roots
   // before copying, while still letting copyResolvedEntry apply its existing
-  // final-entry link checks.
-  const resolvedAllowedLinkRoots = await Promise.all(allowedLinkRoots.map((root) => realpath(root)));
+  // final-entry link checks. Do not use the broad project root here: a
+  // dependency symlink must not pull unrelated project files into the sidecar.
+  const resolvedAllowedLinkRoots = await Promise.all(
+    [standaloneRoot, path.join(projectRoot, "node_modules"), dependencyRoot].map((root) => realpath(root)),
+  );
 
   for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
     let source = null;
@@ -536,7 +539,7 @@ export async function assembleSidecarRuntime(projectRoot, standaloneRoot, depend
   for (const packageName of SIDECAR_DYNAMIC_PACKAGES) {
     await copyDynamicPackage(packageName, dependencyRoot, destination, roots);
   }
-  await copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination, roots);
+  await copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot, destination);
   await copyDynamicNativePackages(dependencyRoot, destination, roots);
   await copyNextAliases(standaloneRoot, destination, roots);
 

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -418,7 +418,10 @@ async function copyNextRuntimeFiles(standaloneRoot, dependencyRoot, destination,
     for (const root of nextRoots) {
       const candidate = path.join(root, relativePath);
       try {
-        await stat(candidate);
+        const metadata = await stat(candidate);
+        if (!metadata.isFile()) {
+          throw new Error(`required Next sidecar runtime file is not a regular file: ${relativePath}`);
+        }
         source = candidate;
         break;
       } catch (error) {
@@ -578,7 +581,19 @@ export async function verifySidecarRuntime(root) {
     "server.mjs",
     "vault.yaml",
   ];
-  for (const relativePath of required) await stat(path.join(root, relativePath));
+  for (const relativePath of required) {
+    try {
+      const metadata = await stat(path.join(root, relativePath));
+      if (!metadata.isFile()) {
+        throw new Error(`required sidecar runtime file is not a regular file: ${relativePath}`);
+      }
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        throw new Error(`required sidecar runtime file is missing: ${relativePath}`);
+      }
+      throw error;
+    }
+  }
   for (const forbiddenRoot of SIDECAR_FORBIDDEN_ROOTS) {
     try {
       await stat(path.join(root, forbiddenRoot));

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -130,6 +130,39 @@ try {
     assert.ok(await missing(path.join(destination, forbiddenRoot)), `${forbiddenRoot} must be excluded`);
   }
 
+  const missingRuntimePath = SIDECAR_NEXT_RUNTIME_FILES[0];
+  await rm(path.join(dependencyRoot, "next", missingRuntimePath));
+  await assert.rejects(
+    assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+    new RegExp(`required Next sidecar runtime file is missing: ${missingRuntimePath.replace(/[.*+?^${}()|[\\]\\]/g, "\\\\$&")}`),
+    "assembly must fail clearly when a required Next runtime file is absent",
+  );
+  await write(dependencyRoot, path.join("next", missingRuntimePath), "next runtime fixture\n");
+
+  const directoryRuntimePath = SIDECAR_NEXT_RUNTIME_FILES[1];
+  await rm(path.join(dependencyRoot, "next", directoryRuntimePath));
+  await mkdir(path.join(dependencyRoot, "next", directoryRuntimePath), { recursive: true });
+  await assert.rejects(
+    assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+    /required Next sidecar runtime file is not a regular file/,
+    "assembly must reject a directory where a required Next runtime file belongs",
+  );
+  await rm(path.join(dependencyRoot, "next", directoryRuntimePath), { recursive: true });
+  await write(dependencyRoot, path.join("next", directoryRuntimePath), "next runtime fixture\n");
+  await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
+
+  const verifiedDirectoryPath = SIDECAR_NEXT_RUNTIME_FILES[2];
+  const verifiedDirectory = path.join(destination, "node_modules", "next", verifiedDirectoryPath);
+  await rm(verifiedDirectory);
+  await mkdir(verifiedDirectory, { recursive: true });
+  await assert.rejects(
+    verifySidecarRuntime(destination),
+    /required sidecar runtime file is not a regular file: node_modules[\\/]next[\\/]dist[\\/]compiled[\\/]webpack[\\/]bundle5\.js/,
+    "final runtime verification must reject a non-file required entry",
+  );
+  await rm(verifiedDirectory, { recursive: true });
+  await write(destination, path.join("node_modules", "next", verifiedDirectoryPath), "next runtime fixture\n");
+
   const optionalPackage = "@next/swc-linux-x64-gnu";
   await packageFixture(projectRoot, optionalPackage);
   await writeFile(

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -245,6 +245,37 @@ try {
     }
   }
 
+  // A package-root link that stays inside node_modules must still point to the
+  // actual Next package; otherwise the explicit paths could import an
+  // unrelated dependency tree that happens to contain matching filenames.
+  const unrelatedNextRoot = path.join(projectRoot, "node_modules", "unrelated-next");
+  await packageFixture(projectRoot, "unrelated-next");
+  for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+    await write(unrelatedNextRoot, relativePath, "unrelated runtime\n");
+  }
+  await rm(path.join(dependencyRoot, "next"), { recursive: true, force: true });
+  try {
+    await symlink(
+      unrelatedNextRoot,
+      path.join(dependencyRoot, "next"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await assert.rejects(
+      assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+      /sidecar Next package root is not the Next package/,
+      "an allowed-root link must still resolve to the actual Next package",
+    );
+  } catch (error) {
+    if (!(["EPERM", "EACCES", "ENOSYS"].includes(error.code))) throw error;
+    console.warn(`sidecar-runtime-closure.test: internal Next package-link confinement skipped (${error.code})`);
+  } finally {
+    await rm(path.join(dependencyRoot, "next"), { recursive: true, force: true });
+    await packageFixture(path.dirname(dependencyRoot), "next");
+    for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+      await write(dependencyRoot, path.join("next", relativePath), "next runtime fixture\n");
+    }
+  }
+
   const externalNextFile = path.join(projectRoot, "node_modules", "unrelated-runtime.js");
   await writeFile(externalNextFile, "outside runtime\n", "utf8");
   const linkedRuntimePath = path.join(dependencyRoot, "next", SIDECAR_NEXT_RUNTIME_FILES[0]);

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -214,6 +214,37 @@ try {
     await packageFixture(path.dirname(dependencyRoot), "sharp");
   }
 
+  // The explicit Next runtime files are nested below a package root, so the
+  // package directory itself must also be confined rather than only its final
+  // file entry.
+  const externalNextRoot = path.join(fixture, "outside-allowed-roots", "next");
+  for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+    await write(externalNextRoot, relativePath, "outside runtime\n");
+  }
+  await packageFixture(standaloneRoot, "next");
+  await rm(path.join(dependencyRoot, "next"), { recursive: true, force: true });
+  try {
+    await symlink(
+      externalNextRoot,
+      path.join(dependencyRoot, "next"),
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await assert.rejects(
+      assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+      /sidecar dependency link escapes its allowed roots/,
+      "Next runtime files must not follow a package-root link outside the locked production root",
+    );
+  } catch (error) {
+    if (!["EPERM", "EACCES", "ENOSYS"].includes(error.code)) throw error;
+    console.warn(`sidecar-runtime-closure.test: Next package-link confinement skipped (${error.code})`);
+  } finally {
+    await rm(path.join(dependencyRoot, "next"), { recursive: true, force: true });
+    await packageFixture(path.dirname(dependencyRoot), "next");
+    for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+      await write(dependencyRoot, path.join("next", relativePath), "next runtime fixture\n");
+    }
+  }
+
   const publishedArchive = path.join(fixture, "published", "server.tar.zst");
   const publishedManifest = path.join(fixture, "published", "manifest.json");
   const interruptedArchive = path.join(fixture, "published", ".server.tar.zst.interrupted.tmp");

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -245,6 +245,29 @@ try {
     }
   }
 
+  const externalNextFile = path.join(projectRoot, "node_modules", "unrelated-runtime.js");
+  await writeFile(externalNextFile, "outside runtime\n", "utf8");
+  const linkedRuntimePath = path.join(dependencyRoot, "next", SIDECAR_NEXT_RUNTIME_FILES[0]);
+  await rm(linkedRuntimePath);
+  try {
+    await symlink(
+      externalNextFile,
+      linkedRuntimePath,
+      process.platform === "win32" ? "file" : undefined,
+    );
+    await assert.rejects(
+      assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination),
+      /sidecar dependency link escapes its allowed roots/,
+      "Next runtime files must not follow a link into an unrelated dependency tree",
+    );
+  } catch (error) {
+    if (!(["EPERM", "EACCES", "ENOSYS"].includes(error.code))) throw error;
+    console.warn(`sidecar-runtime-closure.test: Next file-link confinement skipped (${error.code})`);
+  } finally {
+    await rm(linkedRuntimePath, { force: true });
+    await write(dependencyRoot, linkedRuntimePath.slice(dependencyRoot.length + 1), "next runtime fixture\n");
+  }
+
   const publishedArchive = path.join(fixture, "published", "server.tar.zst");
   const publishedManifest = path.join(fixture, "published", "manifest.json");
   const interruptedArchive = path.join(fixture, "published", ".server.tar.zst.interrupted.tmp");

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -217,7 +217,7 @@ try {
   // The explicit Next runtime files are nested below a package root, so the
   // package directory itself must also be confined rather than only its final
   // file entry.
-  const externalNextRoot = path.join(fixture, "outside-allowed-roots", "next");
+  const externalNextRoot = path.join(projectRoot, "outside-allowed-roots", "next");
   for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
     await write(externalNextRoot, relativePath, "outside runtime\n");
   }

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -8,6 +8,7 @@ import {
   assembleSidecarRuntime,
   collectTracedDependencies,
   SIDECAR_FORBIDDEN_ROOTS,
+  SIDECAR_NEXT_RUNTIME_FILES,
   SIDECAR_RUNTIME_BUDGETS,
   verifySidecarRuntime,
 } from "./sidecar-runtime-closure.mjs";
@@ -80,6 +81,9 @@ try {
     await packageFixture(projectRoot, packageName);
     await packageFixture(path.dirname(dependencyRoot), packageName);
   }
+  for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+    await write(dependencyRoot, path.join("next", relativePath), "next runtime fixture\n");
+  }
   await write(projectRoot, "node_modules/@img/sharp-win32-x64/lib/libvips-42.dll", "native dependency\n");
   await write(dependencyRoot, "@img/sharp-win32-x64/lib/libvips-42.dll", "native dependency\n");
   await write(projectRoot, "node_modules/foo/node_modules/evil/index.js", "must not be copied\n");
@@ -109,6 +113,12 @@ try {
   assert.equal(await readFile(path.join(destination, "marketplace/plugins/example/plugin.json"), "utf8"), "{}\n");
   assert.equal(await readFile(path.join(destination, "workflows/example.yaml"), "utf8"), "id: example\n");
   assert.equal(await readFile(path.join(destination, "public/sandbox/tailwind.js"), "utf8"), "tailwind\n");
+  for (const relativePath of SIDECAR_NEXT_RUNTIME_FILES) {
+    assert.equal(
+      await readFile(path.join(destination, "node_modules", "next", relativePath), "utf8"),
+      "next runtime fixture\n",
+    );
+  }
   assert.equal(await readFile(path.join(destination, "node_modules/foo/index.js"), "utf8"), 'module.exports = "foo";\n');
   assert.equal(
     await readFile(path.join(destination, "node_modules/@img/sharp-win32-x64/lib/libvips-42.dll"), "utf8"),

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -278,6 +278,9 @@ async function main() {
     "marketplace/plugins/prompt-pack-essentials/plugin.json",
     "public/sandbox/react-runtime.js",
     "public/sandbox/tailwind.js",
+    "node_modules/next/dist/compiled/webpack/webpack-lib.js",
+    "node_modules/next/dist/compiled/webpack/webpack.js",
+    "node_modules/next/dist/compiled/webpack/bundle5.js",
     "vault.yaml",
     "workflows/release-review.yaml",
   ]) {

--- a/src/components/chat-project-launch-gate.test.ts
+++ b/src/components/chat-project-launch-gate.test.ts
@@ -95,8 +95,8 @@ assert.match(
 );
 assert.match(
   home,
-  /const projectLaunchReady =[\s\S]*projectsLoadedSuccessfully[\s\S]*!projectsLoading[\s\S]*!projectsError[\s\S]*selectedProject\?\.access/,
-  "Home readiness should require a fresh accessible selected project",
+  /const projectLaunchReady = isHomeComposerProjectLaunchReady\(\{[\s\S]*familiarId: selectedFamiliarId[\s\S]*projectsLoadedSuccessfully[\s\S]*projectsLoading[\s\S]*projectsError[\s\S]*selectedProject,/,
+  "Home should pass the familiar and authoritative project state to its launch gate",
 );
 assert.doesNotMatch(home, /\ballowNoProject\b/, "Home should not offer No project for Chat launch");
 assert.doesNotMatch(

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -37,8 +37,8 @@ assert.match(
 );
 assert.match(
   source,
-  /const projects = useMemo\(\s*\(\) => selectedFamiliarId\s*\? scopedProjects\.filter\(\(project\) => project\.access !== undefined\)\s*:\s*scopedProjects,/,
-  "HomeComposer should filter by access only when it has a familiar scope",
+  /projectsForHomeComposerScope\(scopedProjects, selectedFamiliarId\)/,
+  "HomeComposer should apply the operator-versus-familiar project scope helper",
 );
 assert.match(
   source,
@@ -47,8 +47,8 @@ assert.match(
 );
 assert.match(
   source,
-  /role=\{projectsError \? "alert" : "status"\}[\s\S]{0,220}\{projectLaunchMessage\}/,
-  "HomeComposer should render launch guidance while chat is blocked",
+  /destination === "chat" && !projectLaunchReady/,
+  "HomeComposer should not show chat-only launch guidance for task creation",
 );
 
 // Chat revamp 1a + minimal pass: the hero is the hearth card's heading —

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -45,6 +45,11 @@ assert.match(
   /!selectedFamiliarId\s*\?\s*"Summon a familiar before starting chat\."/,
   "HomeComposer should explain why chat remains blocked without a familiar while retaining registered projects",
 );
+assert.match(
+  source,
+  /role=\{projectsError \? "alert" : "status"\}[\s\S]{0,220}\{projectLaunchMessage\}/,
+  "HomeComposer should render launch guidance while chat is blocked",
+);
 
 // Chat revamp 1a + minimal pass: the hero is the hearth card's heading —
 // greeting kicker, "What are we casting today?", then a live-context subtitle

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -42,6 +42,11 @@ assert.match(
 );
 assert.match(
   source,
+  /shouldClearHomeComposerProjectSelection\(projects, selectedProjectId, projectsLoadedSuccessfully\)/,
+  "HomeComposer should not clear a selected project while the familiar-scoped list is still loading",
+);
+assert.match(
+  source,
   /!selectedFamiliarId\s*\?\s*"Summon a familiar before starting chat\."/,
   "HomeComposer should explain why chat remains blocked without a familiar while retaining registered projects",
 );

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -32,8 +32,18 @@ assert.doesNotMatch(
 
 assert.match(
   source,
-  /useProjects\(\{\s*enabled: Boolean\(selectedFamiliarId\),\s*familiarId: selectedFamiliarId \|\| null,\s*\}\)/,
-  "HomeComposer should load projects only for a selected familiar, never through the unscoped fallback",
+  /useProjects\(\{\s*enabled: true,\s*familiarId: selectedFamiliarId \|\| null,\s*\}\)/,
+  "HomeComposer should keep the operator project registry visible before a familiar is selected",
+);
+assert.match(
+  source,
+  /const projects = useMemo\(\s*\(\) => selectedFamiliarId\s*\? scopedProjects\.filter\(\(project\) => project\.access !== undefined\)\s*:\s*scopedProjects,/,
+  "HomeComposer should filter by access only when it has a familiar scope",
+);
+assert.match(
+  source,
+  /!selectedFamiliarId\s*\?\s*"Summon a familiar before starting chat\."/,
+  "HomeComposer should explain why chat remains blocked without a familiar while retaining registered projects",
 );
 
 // Chat revamp 1a + minimal pass: the hero is the hearth card's heading —

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -47,8 +47,8 @@ assert.match(
 );
 assert.match(
   source,
-  /!selectedFamiliarId\s*\?\s*"Summon a familiar before starting chat\."/,
-  "HomeComposer should explain why chat remains blocked without a familiar while retaining registered projects",
+  /homeComposerProjectLaunchMessage\(\{[\s\S]*familiarId: selectedFamiliarId[\s\S]*projectsLoading[\s\S]*projectsError[\s\S]*projectsLoadedSuccessfully[\s\S]*projectCount: projects\.length,/,
+  "HomeComposer should derive launch guidance from the familiar and authoritative project state",
 );
 assert.match(
   source,

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -205,6 +205,10 @@ export function HomeComposer({
   );
   const { modelState, selectModel: handleSelectModel, selectRuntime: handleSelectRuntime } =
     useHomeModelState(selectedFamiliarId);
+  // Keep the operator registry query alive even before a familiar exists. The
+  // home add-project action can register a folder before familiar setup, and
+  // hiding the unscoped result makes a successful creation look inert. Once a
+  // familiar is selected, the same hook switches to its access-scoped view.
   const {
     projects: scopedProjects,
     loading: projectsLoading,
@@ -213,12 +217,14 @@ export function HomeComposer({
     createProject,
     createProjectOrThrow,
   } = useProjects({
-    enabled: Boolean(selectedFamiliarId),
+    enabled: true,
     familiarId: selectedFamiliarId || null,
   });
   const projects = useMemo(
-    () => scopedProjects.filter((project) => project.access !== undefined),
-    [scopedProjects],
+    () => selectedFamiliarId
+      ? scopedProjects.filter((project) => project.access !== undefined)
+      : scopedProjects,
+    [scopedProjects, selectedFamiliarId],
   );
   const [selectedProjectId, setSelectedProjectId] = useState("");
   // Host chip: where the opened chat should execute. Per-composer state, not a
@@ -245,11 +251,13 @@ export function HomeComposer({
     ? "Checking project access…"
     : projectsError
       ? "Projects are unavailable. Retry before starting chat."
-      : !projectsLoadedSuccessfully
-        ? "Checking project access…"
-        : projects.length === 0
-          ? "Add a project this familiar can access before starting chat."
-          : "Choose a project this familiar can access before starting chat.";
+      : !selectedFamiliarId
+        ? "Summon a familiar before starting chat."
+        : !projectsLoadedSuccessfully
+          ? "Checking project access…"
+          : projects.length === 0
+            ? "Add a project this familiar can access before starting chat."
+            : "Choose a project this familiar can access before starting chat.";
   const displayProjectId = selectedProject?.id ?? null;
   const selectedRuntime = canonicalHarnessId(
     modelState?.harness ?? selectedFamiliar?.harness ?? selectedFamiliar?.defaultHarness ?? "claude",

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -70,7 +70,12 @@ import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
 import { greetingForHour } from "@/lib/home-greeting";
 import { DESTINATIONS, placeholderFor, type Destination } from "@/components/home/home-destinations";
-import { resolveHomeComposerFamiliar, resolveHomeComposerProject } from "@/lib/home-composer-context";
+import {
+  isHomeComposerProjectLaunchReady,
+  projectsForHomeComposerScope,
+  resolveHomeComposerFamiliar,
+  resolveHomeComposerProject,
+} from "@/lib/home-composer-context";
 import { publishBoardChanged } from "@/lib/board-cache-events";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -221,9 +226,7 @@ export function HomeComposer({
     familiarId: selectedFamiliarId || null,
   });
   const projects = useMemo(
-    () => selectedFamiliarId
-      ? scopedProjects.filter((project) => project.access !== undefined)
-      : scopedProjects,
+    () => projectsForHomeComposerScope(scopedProjects, selectedFamiliarId),
     [scopedProjects, selectedFamiliarId],
   );
   const [selectedProjectId, setSelectedProjectId] = useState("");
@@ -241,12 +244,13 @@ export function HomeComposer({
     [projects, selectedProjectId, recentProjectRoot],
   );
   const selectedProjectRoot = selectedProject?.root ?? "";
-  const projectLaunchReady =
-    projectsLoadedSuccessfully &&
-    !projectsLoading &&
-    !projectsError &&
-    selectedProject?.access !== undefined &&
-    Boolean(selectedProjectRoot);
+  const projectLaunchReady = isHomeComposerProjectLaunchReady({
+    familiarId: selectedFamiliarId,
+    projectsLoadedSuccessfully,
+    projectsLoading,
+    projectsError,
+    selectedProject,
+  });
   const projectLaunchMessage = projectsLoading
     ? "Checking project access…"
     : projectsError
@@ -872,7 +876,7 @@ export function HomeComposer({
           />
         ) : null}
 
-        {!projectLaunchReady ? (
+        {destination === "chat" && !projectLaunchReady ? (
           <p
             role={projectsError ? "alert" : "status"}
             className="mx-auto mb-2 max-w-3xl px-3 text-[length:var(--text-xs)] leading-5 text-[var(--text-muted)]"

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -75,6 +75,7 @@ import {
   projectsForHomeComposerScope,
   resolveHomeComposerFamiliar,
   resolveHomeComposerProject,
+  shouldClearHomeComposerProjectSelection,
 } from "@/lib/home-composer-context";
 import { publishBoardChanged } from "@/lib/board-cache-events";
 
@@ -294,10 +295,9 @@ export function HomeComposer({
   // then the first project) resolves in resolveHomeComposerProject so it can
   // upgrade as sessions land. Only clear a stale pick whose project vanished.
   useEffect(() => {
-    if (!selectedProjectId) return;
-    if (projects.some((project) => project.id === selectedProjectId)) return;
+    if (!shouldClearHomeComposerProjectSelection(projects, selectedProjectId, projectsLoadedSuccessfully)) return;
     setSelectedProjectId("");
-  }, [projects, selectedProjectId]);
+  }, [projects, projectsLoadedSuccessfully, selectedProjectId]);
 
   // "Add to project ›" flyout data + the "Start a new project" flow (same
   // directory-picker flow the context pill uses, so both entry points create

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -71,6 +71,7 @@ import { EnhanceStrip } from "@/components/composer-enhance";
 import { greetingForHour } from "@/lib/home-greeting";
 import { DESTINATIONS, placeholderFor, type Destination } from "@/components/home/home-destinations";
 import {
+  homeComposerProjectLaunchMessage,
   isHomeComposerProjectLaunchReady,
   projectsForHomeComposerScope,
   resolveHomeComposerFamiliar,
@@ -252,17 +253,13 @@ export function HomeComposer({
     projectsError,
     selectedProject,
   });
-  const projectLaunchMessage = projectsLoading
-    ? "Checking project access…"
-    : projectsError
-      ? "Projects are unavailable. Retry before starting chat."
-      : !selectedFamiliarId
-        ? "Summon a familiar before starting chat."
-        : !projectsLoadedSuccessfully
-          ? "Checking project access…"
-          : projects.length === 0
-            ? "Add a project this familiar can access before starting chat."
-            : "Choose a project this familiar can access before starting chat.";
+  const projectLaunchMessage = homeComposerProjectLaunchMessage({
+    familiarId: selectedFamiliarId,
+    projectsLoading,
+    projectsError,
+    projectsLoadedSuccessfully,
+    projectCount: projects.length,
+  });
   const displayProjectId = selectedProject?.id ?? null;
   const selectedRuntime = canonicalHarnessId(
     modelState?.harness ?? selectedFamiliar?.harness ?? selectedFamiliar?.defaultHarness ?? "claude",

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -872,6 +872,15 @@ export function HomeComposer({
           />
         ) : null}
 
+        {!projectLaunchReady ? (
+          <p
+            role={projectsError ? "alert" : "status"}
+            className="mx-auto mb-2 max-w-3xl px-3 text-[length:var(--text-xs)] leading-5 text-[var(--text-muted)]"
+          >
+            {projectLaunchMessage}
+          </p>
+        ) : null}
+
         {/* Composer card — reference layout: the input leads; the mode pills,
             attach, model chip, and mic all live INSIDE the card's control row,
             with a darker attached footer band beneath for context pickers. */}

--- a/src/lib/home-composer-context.test.ts
+++ b/src/lib/home-composer-context.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  homeComposerProjectLaunchMessage,
   isHomeComposerProjectLaunchReady,
   projectsForHomeComposerScope,
   resolveHomeComposerFamiliar,
@@ -42,6 +43,29 @@ test("home composer never treats project access as launch permission without a f
     isHomeComposerProjectLaunchReady({ ...readyArgs, familiarId: "sage" }),
     true,
     "a loaded project with familiar access is launchable",
+  );
+});
+
+test("home composer explains the familiar prerequisite while projects are loading", () => {
+  assert.equal(
+    homeComposerProjectLaunchMessage({
+      familiarId: null,
+      projectsLoading: true,
+      projectsError: null,
+      projectsLoadedSuccessfully: false,
+      projectCount: 0,
+    }),
+    "Summon a familiar before starting chat.",
+  );
+  assert.equal(
+    homeComposerProjectLaunchMessage({
+      familiarId: "sage",
+      projectsLoading: false,
+      projectsError: null,
+      projectsLoadedSuccessfully: true,
+      projectCount: 0,
+    }),
+    "Add a project this familiar can access before starting chat.",
   );
 });
 

--- a/src/lib/home-composer-context.test.ts
+++ b/src/lib/home-composer-context.test.ts
@@ -67,6 +67,17 @@ test("home composer explains the familiar prerequisite while projects are loadin
     }),
     "Add a project this familiar can access before starting chat.",
   );
+  assert.equal(
+    homeComposerProjectLaunchMessage({
+      familiarId: "sage",
+      projectsLoading: false,
+      projectsError: "HTTP 503",
+      projectsLoadedSuccessfully: false,
+      projectCount: 0,
+    }),
+    "Projects are unavailable. Retry before starting chat.",
+    "an initial project-load failure must not be reported as an endless loading state",
+  );
 });
 
 test("home composer keeps an explicit project through a pending familiar scope", () => {

--- a/src/lib/home-composer-context.test.ts
+++ b/src/lib/home-composer-context.test.ts
@@ -5,6 +5,7 @@ import {
   projectsForHomeComposerScope,
   resolveHomeComposerFamiliar,
   resolveHomeComposerProject,
+  shouldClearHomeComposerProjectSelection,
 } from "./home-composer-context.ts";
 
 test("home composer shows the unscoped registry, then filters to familiar access", () => {
@@ -41,6 +42,25 @@ test("home composer never treats project access as launch permission without a f
     isHomeComposerProjectLaunchReady({ ...readyArgs, familiarId: "sage" }),
     true,
     "a loaded project with familiar access is launchable",
+  );
+});
+
+test("home composer keeps an explicit project through a pending familiar scope", () => {
+  const project = { id: "selected", name: "Selected", root: "/work/selected" } as never;
+  assert.equal(
+    shouldClearHomeComposerProjectSelection([], "selected", false),
+    false,
+    "the masked list during a scope request is not proof that the selected project disappeared",
+  );
+  assert.equal(
+    shouldClearHomeComposerProjectSelection([project], "selected", true),
+    false,
+    "an accessible selected project remains selected after the scoped response",
+  );
+  assert.equal(
+    shouldClearHomeComposerProjectSelection([], "selected", true),
+    true,
+    "an explicitly selected project is cleared once the settled scope excludes it",
   );
 });
 

--- a/src/lib/home-composer-context.test.ts
+++ b/src/lib/home-composer-context.test.ts
@@ -1,6 +1,48 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveHomeComposerFamiliar, resolveHomeComposerProject } from "./home-composer-context.ts";
+import {
+  isHomeComposerProjectLaunchReady,
+  projectsForHomeComposerScope,
+  resolveHomeComposerFamiliar,
+  resolveHomeComposerProject,
+} from "./home-composer-context.ts";
+
+test("home composer shows the unscoped registry, then filters to familiar access", () => {
+  const projects = [
+    { id: "open", name: "Open", root: "/work/open", access: undefined },
+    { id: "readable", name: "Readable", root: "/work/readable", access: "read" },
+  ] as never[];
+  assert.deepEqual(
+    projectsForHomeComposerScope(projects, null).map((project) => project.id),
+    ["open", "readable"],
+    "initial setup must retain every locally registered project",
+  );
+  assert.deepEqual(
+    projectsForHomeComposerScope(projects, "sage").map((project) => project.id),
+    ["readable"],
+    "a familiar scope must retain only projects with server-derived access",
+  );
+});
+
+test("home composer never treats project access as launch permission without a familiar", () => {
+  const selectedProject = { root: "/work/readable", access: "read" } as never;
+  const readyArgs = {
+    projectsLoadedSuccessfully: true,
+    projectsLoading: false,
+    projectsError: null,
+    selectedProject,
+  };
+  assert.equal(
+    isHomeComposerProjectLaunchReady({ ...readyArgs, familiarId: null }),
+    false,
+    "chat launch must remain blocked before familiar setup even if a stale access field is present",
+  );
+  assert.equal(
+    isHomeComposerProjectLaunchReady({ ...readyArgs, familiarId: "sage" }),
+    true,
+    "a loaded project with familiar access is launchable",
+  );
+});
 
 test("home composer excludes archived familiars and falls back from an archived active familiar", () => {
   const familiars = [

--- a/src/lib/home-composer-context.ts
+++ b/src/lib/home-composer-context.ts
@@ -15,6 +15,21 @@ export function projectsForHomeComposerScope(
     : [...projects];
 }
 
+/**
+ * Do not clear an explicit pick while a new familiar scope is still loading.
+ * The hook intentionally masks the previous scope during that request, so an
+ * empty list at that point is not evidence that the selected project vanished.
+ */
+export function shouldClearHomeComposerProjectSelection(
+  projects: readonly CaveProject[],
+  selectedProjectId: string,
+  projectsLoadedSuccessfully: boolean,
+): boolean {
+  return projectsLoadedSuccessfully
+    && Boolean(selectedProjectId)
+    && !projects.some((project) => project.id === selectedProjectId);
+}
+
 /** Chat launch needs both an actual familiar and server-derived project access. */
 export function isHomeComposerProjectLaunchReady(args: {
   familiarId: string | null | undefined;

--- a/src/lib/home-composer-context.ts
+++ b/src/lib/home-composer-context.ts
@@ -2,6 +2,35 @@ import type { CaveProject } from "./cave-projects-types";
 import type { Familiar } from "./types";
 import { projectForRoot } from "./chat-projects.ts";
 
+/**
+ * The home composer uses the operator registry before familiar setup, then
+ * switches to the server-authorized familiar view once a familiar exists.
+ */
+export function projectsForHomeComposerScope(
+  projects: readonly CaveProject[],
+  familiarId: string | null | undefined,
+): CaveProject[] {
+  return familiarId
+    ? projects.filter((project) => project.access !== undefined)
+    : [...projects];
+}
+
+/** Chat launch needs both an actual familiar and server-derived project access. */
+export function isHomeComposerProjectLaunchReady(args: {
+  familiarId: string | null | undefined;
+  projectsLoadedSuccessfully: boolean;
+  projectsLoading: boolean;
+  projectsError: string | null;
+  selectedProject: Pick<CaveProject, "access" | "root"> | null;
+}): boolean {
+  return Boolean(args.familiarId)
+    && args.projectsLoadedSuccessfully
+    && !args.projectsLoading
+    && !args.projectsError
+    && args.selectedProject?.access !== undefined
+    && Boolean(args.selectedProject?.root);
+}
+
 export function resolveHomeComposerFamiliar(
   familiars: readonly Familiar[],
   activeFamiliarId: string | null,

--- a/src/lib/home-composer-context.ts
+++ b/src/lib/home-composer-context.ts
@@ -55,8 +55,8 @@ export function homeComposerProjectLaunchMessage(args: {
   projectCount: number;
 }): string {
   if (!args.familiarId) return "Summon a familiar before starting chat.";
-  if (args.projectsLoading || !args.projectsLoadedSuccessfully) return "Checking project access…";
   if (args.projectsError) return "Projects are unavailable. Retry before starting chat.";
+  if (args.projectsLoading || !args.projectsLoadedSuccessfully) return "Checking project access…";
   if (args.projectCount === 0) return "Add a project this familiar can access before starting chat.";
   return "Choose a project this familiar can access before starting chat.";
 }

--- a/src/lib/home-composer-context.ts
+++ b/src/lib/home-composer-context.ts
@@ -46,6 +46,21 @@ export function isHomeComposerProjectLaunchReady(args: {
     && Boolean(args.selectedProject?.root);
 }
 
+/** Keep the independent familiar prerequisite actionable while project data loads. */
+export function homeComposerProjectLaunchMessage(args: {
+  familiarId: string | null | undefined;
+  projectsLoading: boolean;
+  projectsError: string | null;
+  projectsLoadedSuccessfully: boolean;
+  projectCount: number;
+}): string {
+  if (!args.familiarId) return "Summon a familiar before starting chat.";
+  if (args.projectsLoading || !args.projectsLoadedSuccessfully) return "Checking project access…";
+  if (args.projectsError) return "Projects are unavailable. Retry before starting chat.";
+  if (args.projectCount === 0) return "Add a project this familiar can access before starting chat.";
+  return "Choose a project this familiar can access before starting chat.";
+}
+
 export function resolveHomeComposerFamiliar(
   familiars: readonly Familiar[],
   activeFamiliarId: string | null,

--- a/src/lib/use-projects-scope-transition.test.ts
+++ b/src/lib/use-projects-scope-transition.test.ts
@@ -9,7 +9,7 @@ import {
   LOCAL_REQUEST_REQUIRED_CODE,
   ProjectCreationError,
 } from "./project-errors.ts";
-import { resetProjectRegistryListenersForTests } from "./project-registry-events.ts";
+import { emitProjectRegistryMutation, resetProjectRegistryListenersForTests } from "./project-registry-events.ts";
 import { resetProjectsCacheForTests, useProjects } from "./use-projects.ts";
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -269,6 +269,29 @@ test("unscoped project creation is visible before the initial registry load sett
       latestState!.projects.map((entry) => entry.id),
       [created.id],
       "the successful local registration must not remain masked by the pending GET",
+    );
+
+    await settle(pending[0]!, [project("existing-before-create")]);
+    assert.deepEqual(
+      latestState!.projects.map((entry) => entry.id),
+      [created.id, "existing-before-create"],
+      "an older in-flight snapshot must not overwrite the new registration or hide existing projects",
+    );
+
+    await act(async () => {
+      emitProjectRegistryMutation({ kind: "delete", projectId: created.id });
+      await Promise.resolve();
+    });
+    assert.deepEqual(
+      latestState!.projects.map((entry) => entry.id),
+      ["existing-before-create"],
+      "a delete from another project hook must remove the locally pending registration",
+    );
+    await settle(pending[0]!, [project("existing-before-create")]);
+    assert.deepEqual(
+      latestState!.projects.map((entry) => entry.id),
+      ["existing-before-create"],
+      "a delete refresh must not resurrect a locally pending registration",
     );
   } finally {
     await act(async () => {

--- a/src/lib/use-projects-scope-transition.test.ts
+++ b/src/lib/use-projects-scope-transition.test.ts
@@ -238,3 +238,44 @@ test("project creation preserves the local-only code through nullable and throwi
     resetProjectsCacheForTests();
   }
 });
+
+test("unscoped project creation is visible before the initial registry load settles", async () => {
+  resetProjectRegistryListenersForTests();
+  resetProjectsCacheForTests();
+  const originalFetch = globalThis.fetch;
+  const pending: DeferredResponse[] = [];
+  let latestState: ReturnType<typeof useProjects> | null = null;
+  let renderer: ReturnType<typeof create> | null = null;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return await new Promise((resolve) => pending.push({ url, resolve }));
+  }) as typeof fetch;
+
+  try {
+    await act(async () => {
+      renderer = create(createElement(CreationProbe, { onState: (state) => { latestState = state; } }));
+    });
+    assert.equal(pending.length, 1, "the initial unscoped list is still in flight");
+
+    const created = project("created-before-load");
+    const creation = latestState!.createProject("Created", created.root, { emitMutation: false });
+    assert.equal(pending.length, 2, "creation is independent of the pending list request");
+    pending[1]!.resolve({ ok: true, status: 201, json: async () => ({ ok: true, project: created }) });
+    await act(async () => {
+      await creation;
+    });
+
+    assert.deepEqual(
+      latestState!.projects.map((entry) => entry.id),
+      [created.id],
+      "the successful local registration must not remain masked by the pending GET",
+    );
+  } finally {
+    await act(async () => {
+      renderer?.unmount();
+    });
+    globalThis.fetch = originalFetch;
+    resetProjectRegistryListenersForTests();
+    resetProjectsCacheForTests();
+  }
+});

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -89,6 +89,10 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
   // per-instance AbortController — the shared, coalesced request can't be
   // aborted by one of its subscribers, so late results are discarded instead.)
   const generationRef = useRef(0);
+  // A bundled create may intentionally suppress the registry event while it
+  // applies a familiar grant. Keep that local registration in the unscoped
+  // view if the GET that was already in flight returns its older snapshot.
+  const locallyCreatedProjectsRef = useRef(new Map<string, CaveProject>());
 
   const load = useCallback(async (opts?: { force?: boolean }) => {
     generationRef.current += 1;
@@ -104,7 +108,21 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
       } else {
         // Already deduped + sorted by the cache (cave-k0gf), once per fetch
         // rather than once per consumer — do not re-run it here.
-        setProjects(Array.isArray(data.projects) ? data.projects : []);
+        if (familiarId === null && locallyCreatedProjectsRef.current.size > 0) {
+          const serverProjects = Array.isArray(data.projects) ? data.projects : [];
+          const serverProjectIds = new Set(serverProjects.map((project) => project.id));
+          for (const projectId of serverProjectIds) {
+            locallyCreatedProjectsRef.current.delete(projectId);
+          }
+          const pendingLocalProjects = [...locallyCreatedProjectsRef.current.values()];
+          setProjects(
+            pendingLocalProjects.length > 0
+              ? sortProjectsAlphabetically([...serverProjects, ...pendingLocalProjects])
+              : serverProjects,
+          );
+        } else {
+          setProjects(Array.isArray(data.projects) ? data.projects : []);
+        }
         setLoadedScopeKey(scopeKey);
       }
     } catch (err) {
@@ -140,6 +158,9 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
   useEffect(() => {
     if (!enabled) return;
     return subscribeProjectRegistryMutation(({ mutation }) => {
+      if (mutation.kind === "delete") {
+        locallyCreatedProjectsRef.current.delete(mutation.projectId);
+      }
       setProjects((prev) => applyProjectRegistryMutation(prev, mutation));
       void load();
     });
@@ -157,7 +178,10 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     // unscoped operator view. Surface it even if the initial GET is still
     // pending (or fails), while familiar-scoped views must await their grant-
     // filtered response before becoming ready.
-    if (familiarId === null) setLoadedScopeKey(scopeKey);
+    if (familiarId === null) {
+      locallyCreatedProjectsRef.current.set(project.id, project);
+      setLoadedScopeKey(scopeKey);
+    }
     if (options?.emitMutation !== false) emitProjectRegistryMutation();
     return project;
   }, [familiarId, scopeKey]);
@@ -284,6 +308,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
     const res = await fetch(`/api/projects/${id}`, { method: "DELETE" });
     const data = await res.json();
     if (data.ok) {
+      locallyCreatedProjectsRef.current.delete(id);
       setProjects((prev) => prev.filter((project) => project.id !== id));
       emitProjectRegistryMutation({ kind: "delete", projectId: id });
       return true;

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -36,6 +36,16 @@ function fetchProjects(
   return fetchProjectsFromCache(familiarId, opts);
 }
 
+function mergeLocallyCreatedProjects(
+  serverProjects: CaveProject[],
+  localProjects: Iterable<CaveProject>,
+): CaveProject[] {
+  const pendingLocalProjects = [...localProjects];
+  return pendingLocalProjects.length > 0
+    ? sortProjectsAlphabetically([...serverProjects, ...pendingLocalProjects])
+    : serverProjects;
+}
+
 /** Test-only: drop the module-level cache between cases. */
 export function resetProjectsCacheForTests(): void {
   clearProjectsCache();
@@ -114,12 +124,7 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
           for (const projectId of serverProjectIds) {
             locallyCreatedProjectsRef.current.delete(projectId);
           }
-          const pendingLocalProjects = [...locallyCreatedProjectsRef.current.values()];
-          setProjects(
-            pendingLocalProjects.length > 0
-              ? sortProjectsAlphabetically([...serverProjects, ...pendingLocalProjects])
-              : serverProjects,
-          );
+          setProjects(mergeLocallyCreatedProjects(serverProjects, locallyCreatedProjectsRef.current.values()));
         } else {
           setProjects(Array.isArray(data.projects) ? data.projects : []);
         }

--- a/src/lib/use-projects.ts
+++ b/src/lib/use-projects.ts
@@ -153,9 +153,14 @@ export function useProjects({ enabled = true, familiarId = null }: UseProjectsOp
 
   const applyCreatedProject = useCallback((project: CaveProject, options?: CreateProjectOptions): CaveProject => {
     setProjects((prev) => sortProjectsAlphabetically([...prev, project]));
+    // A successful local registration is already authoritative for the
+    // unscoped operator view. Surface it even if the initial GET is still
+    // pending (or fails), while familiar-scoped views must await their grant-
+    // filtered response before becoming ready.
+    if (familiarId === null) setLoadedScopeKey(scopeKey);
     if (options?.emitMutation !== false) emitProjectRegistryMutation();
     return project;
-  }, []);
+  }, [familiarId, scopeKey]);
 
   const requestCreateProject = useCallback(async (name: string, root: string, options?: CreateProjectOptions): Promise<CreateProjectResult> => {
     try {


### PR DESCRIPTION
## Summary

Fixes the desktop project-creation flow where selecting a folder successfully registered the project, but the new project immediately disappeared from the main screen.

The project was written to `~/.coven/cave/projects.json`, but `HomeComposer` disabled project loading until a familiar was selected. As a result, the UI discarded the newly registered project and made the action appear to do nothing.

This change keeps the project registry visible before familiar setup while continuing to prevent chat launch until a familiar and valid project access are available. It also hardens sidecar packaging so generated MSI builds include the Next.js webpack runtime files required during startup.

## Root cause

`HomeComposer` configured `useProjects()` with:

```ts
enabled: Boolean(selectedFamiliarId)
```

When no familiar was selected:

1. The folder picker submitted `POST /api/projects`.
2. The server successfully registered the local project.
3. The project query remained disabled.
4. The main screen rendered an empty project list.
5. The user received no visible confirmation or error.

The project creation request succeeded; the UI state was incorrectly scoped to familiar availability.

The generated desktop sidecar had a separate packaging issue: the runtime archive omitted Next.js compiled webpack modules, causing startup failures such as:

```text
Cannot find module 'next/dist/compiled/webpack/webpack-lib'
```

## Changes

### Project visibility before familiar setup

- Keep the project registry query enabled before a familiar is selected.
- Pass `null` as the familiar scope when no familiar is available.
- Display registered projects without access filtering during initial setup.
- Continue filtering to familiar-accessible projects once a familiar is selected.

### Preserve launch safety

- Chat launch remains blocked until:
  - a familiar is selected; and
  - the selected project has valid familiar access.
- Project registration remains local-only.
- No remote familiar or filesystem authorization is introduced.
- Selecting a directory still registers it through the existing trusted-local API path.

### Improve empty-state guidance

When a project is visible but chat cannot start because no familiar is selected, display:

```text
Summon a familiar before starting chat.
```

This distinguishes setup state from project-registration failure.

### Harden sidecar runtime packaging

- Explicitly include the Next.js runtime files in the sidecar closure:
  - `next/dist/compiled/webpack/webpack-lib.js`
  - `next/dist/compiled/webpack/webpack.js`
  - `next/dist/compiled/webpack/bundle5.js`
- Copy and verify those files during sidecar assembly.
- Add closure assertions and smoke coverage for the required runtime files.
- Prevent MSI builds from silently producing an incomplete sidecar archive.

## Security considerations

- Project registration remains restricted to trusted loopback requests.
- Remote project listing remains read-only.
- `PUT` and `DELETE` project mutations remain local-only.
- `/api/fs-browse` remains local-only.
- Existing root and path validation is unchanged.
- No Tailscale, LAN, arbitrary-host, mobile, or remote filesystem capability is added.
- Chat launch still requires valid familiar access.

## Tests added or updated

- Verify `HomeComposer` keeps `useProjects()` enabled without a selected familiar.
- Verify unscoped registered projects remain visible before familiar setup.
- Verify familiar-scoped results continue filtering by access.
- Verify chat launch remains blocked without a familiar.
- Verify the no-familiar actionable message.
- Verify required Next.js webpack files are included in the sidecar runtime closure.
- Verify the sidecar smoke test can start and preserve runtime preferences on Windows.

## Validation

Passed locally:

```bash
node --experimental-strip-types src/components/home-composer.test.ts
node --experimental-strip-types src/lib/home-composer-context.test.ts
node --experimental-strip-types scripts/sidecar-runtime-closure.test.mjs
node --experimental-strip-types scripts/sidecar-bundle-deps.test.mjs

pnpm typecheck
pnpm lint
git diff --check
```

The design-token codemod check completed with zero drift, and the design ESLint gate passed.

The Windows sidecar smoke test also passed on the generated runtime:

```text
sidecar-runtime-smoke: ok on win32/x64
```

Generated MSI validation from the implementation work:

```text
CovenCave_0.2.2_x64_en-US.msi
SHA256: e154fd5c0d1a48ff5f915db64bdfde3d76155efbc786c5b49fffb162d964e963
```

The MSI is unsigned because it was built with `--no-sign`.

The aggregate local suites were also attempted. `pnpm test:app` and `pnpm test:api` reached unrelated WSL timing/heartbeat failures in existing maintenance tests:

- `canonical-memory-smoke-lifecycle.test.mjs`: `late-browser-close-reject cleanup exceeded 2000ms`
- `worktree-lifecycle-create.test.mjs`: `heartbeat-regressed`

Interactive Tauri UI validation remains separate from WSL validation and should be performed after installing the MSI on Windows.

## Files changed

- `src/components/home-composer.tsx`
- `src/components/home-composer.test.ts`
- `scripts/sidecar-runtime-closure.mjs`
- `scripts/sidecar-runtime-closure.test.mjs`
- `scripts/sidecar-runtime-smoke.mjs`
- `scripts/sidecar-bundle-deps.test.mjs`

## Acceptance criteria

- Selecting a local project directory visibly adds the project to the main screen.
- Project registration continues to work before familiar setup.
- Registered projects are not silently hidden when no familiar is selected.
- Chat remains unavailable until a familiar and valid project access are present.
- Existing local-only authorization boundaries remain unchanged.
- Generated MSI sidecars contain all required Next.js runtime modules.
- Windows sidecar startup completes without the missing webpack-module error.

## Non-goals

- Enabling remote project creation.
- Changing familiar discovery or authorization.
- Changing project path validation.
- Changing project CRUD semantics.
- Automatically selecting or creating a familiar.
- Merging or modifying PR #4202.
