### PR TITLE
fix(windows): recover transient sidecar cache activation

### DIFF
--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -24,7 +24,7 @@ mod sidecar_archive_preparation;
 
 use sidecar_archive_cache::{
     acquire_cache_lock, cleanup_staging_before_extraction, create_staging_directory,
-    remove_cache_path, required_free_space, try_acquire_cache_lock,
+    remove_cache_path, remove_cache_path_io, required_free_space, try_acquire_cache_lock,
 };
 pub(crate) use sidecar_archive_cleanup::cleanup_stale_sidecar_runtimes;
 use sidecar_archive_extraction::extract_archive;

--- a/src-tauri/src/sidecar_archive.rs
+++ b/src-tauri/src/sidecar_archive.rs
@@ -7,6 +7,7 @@ use std::path::{Path, PathBuf};
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tauri::Manager;
+use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_SHARING_VIOLATION};
 
 // `sidecar_archive` is itself a file module. Keep the extracted siblings at
 // `src/` so the native-host module layout stays flat on every target.
@@ -26,13 +27,19 @@ use sidecar_archive_cache::{
     remove_cache_path, required_free_space, try_acquire_cache_lock,
 };
 pub(crate) use sidecar_archive_cleanup::cleanup_stale_sidecar_runtimes;
-use sidecar_archive_extraction::{extract_archive, tree_metrics};
+use sidecar_archive_extraction::extract_archive;
+#[cfg(test)]
+use sidecar_archive_extraction::tree_metrics;
+#[cfg(test)]
+use sidecar_archive_manifest::ARCHIVE_FORMAT;
 use sidecar_archive_manifest::{
-    cache_key, is_sha256, read_manifest, SidecarArchiveManifest, ARCHIVE_FORMAT,
-    MANIFEST_SCHEMA_VERSION, MAX_ARCHIVE_BYTES, MAX_FILE_COUNT, MAX_UNPACKED_BYTES,
+    cache_key, is_sha256, read_manifest, SidecarArchiveManifest, MANIFEST_SCHEMA_VERSION,
+    MAX_FILE_COUNT, MAX_UNPACKED_BYTES,
 };
+use sidecar_archive_preparation::prepare_runtime_from_files;
+#[cfg(test)]
 use sidecar_archive_preparation::{
-    prepare_runtime_from_files, prepare_runtime_from_files_with_space,
+    activate_extracted_cache_with, prepare_runtime_from_files_with_space, ACTIVATION_RETRY_DELAYS,
 };
 
 const MIN_FREE_SPACE_RESERVE_BYTES: u64 = 64 * 1024 * 1024;

--- a/src-tauri/src/sidecar_archive_cache.rs
+++ b/src-tauri/src/sidecar_archive_cache.rs
@@ -83,28 +83,36 @@ pub(super) fn required_free_space(manifest: &SidecarArchiveManifest) -> Result<u
         .ok_or_else(|| "sidecar free-space requirement overflow".to_string())
 }
 
-pub(super) fn remove_cache_path(path: &Path) -> Result<(), String> {
+fn remove_cache_path_raw(path: &Path) -> Result<(), (bool, io::Error)> {
     let metadata = match fs::symlink_metadata(path) {
         Ok(metadata) => metadata,
         Err(error) if error.kind() == io::ErrorKind::NotFound => return Ok(()),
-        Err(error) => {
-            return Err(format!(
-                "could not inspect sidecar cache path {}: {error}",
-                path.display()
-            ));
-        }
+        Err(error) => return Err((true, error)),
     };
     let removal = if metadata.is_dir() && !metadata.file_type().is_symlink() {
         fs::remove_dir_all(path)
     } else {
         fs::remove_file(path)
     };
-    removal.map_err(|error| {
+    removal.map_err(|error| (false, error))
+}
+
+pub(super) fn remove_cache_path(path: &Path) -> Result<(), String> {
+    remove_cache_path_raw(path).map_err(|(inspection_failed, error)| {
+        let operation = if inspection_failed {
+            "inspect"
+        } else {
+            "remove"
+        };
         format!(
-            "could not remove sidecar cache path {}: {error}",
+            "could not {operation} sidecar cache path {}: {error}",
             path.display()
         )
     })
+}
+
+pub(super) fn remove_cache_path_io(path: &Path) -> io::Result<()> {
+    remove_cache_path_raw(path).map_err(|(_, error)| error)
 }
 
 pub(super) fn cleanup_staging_before_extraction(

--- a/src-tauri/src/sidecar_archive_preparation.rs
+++ b/src-tauri/src/sidecar_archive_preparation.rs
@@ -50,16 +50,18 @@ pub(super) fn activate_extracted_cache_with(
         let destination_exists = destination.exists();
         let destination_ready = cache_is_ready(destination, manifest);
         if destination_ready {
-            match remove_cache_path(staging) {
+            match remove_cache_path_io(staging) {
                 Ok(()) => log::info!(
                     "[cave] sidecar cache activation reused concurrent destination attempt={attempt}/{maximum_attempts} elapsed_ms={} staging={}",
                     started.elapsed().as_millis(),
                     cache_path_label(staging)
                 ),
                 Err(cleanup_error) => log::warn!(
-                    "[cave] sidecar cache activation reused concurrent destination but staging cleanup failed attempt={attempt}/{maximum_attempts} elapsed_ms={} staging={} error={cleanup_error}",
+                    "[cave] sidecar cache activation reused concurrent destination but staging cleanup failed attempt={attempt}/{maximum_attempts} elapsed_ms={} staging={} cleanup_kind={:?} cleanup_raw_os_error={:?}",
                     started.elapsed().as_millis(),
-                    cache_path_label(staging)
+                    cache_path_label(staging),
+                    cleanup_error.kind(),
+                    cleanup_error.raw_os_error()
                 ),
             }
             return Ok(());
@@ -81,7 +83,7 @@ pub(super) fn activate_extracted_cache_with(
             }
         }
 
-        let cleanup_error = remove_cache_path(staging).err();
+        let cleanup_error = remove_cache_path_io(staging).err();
         log::warn!(
             "[cave] sidecar cache activation failed attempt={attempt}/{maximum_attempts} elapsed_ms={} kind={:?} raw_os_error={:?} staging={} destination={} source_exists={source_exists} destination_exists={destination_exists} destination_ready={destination_ready} cleanup={}",
             started.elapsed().as_millis(),
@@ -92,7 +94,13 @@ pub(super) fn activate_extracted_cache_with(
             if cleanup_error.is_some() { "failed" } else { "succeeded" }
         );
         let cleanup_detail = cleanup_error
-            .map(|cleanup_error| format!("; staging cleanup also failed: {cleanup_error}"))
+            .map(|cleanup_error| {
+                format!(
+                    "; staging cleanup also failed (kind: {:?}, raw OS error: {:?})",
+                    cleanup_error.kind(),
+                    cleanup_error.raw_os_error()
+                )
+            })
             .unwrap_or_default();
         return Err(format!(
             "could not activate extracted sidecar cache {} after {attempt} attempt(s): {error} (kind: {:?}, raw OS error: {:?}){cleanup_detail}",

--- a/src-tauri/src/sidecar_archive_preparation.rs
+++ b/src-tauri/src/sidecar_archive_preparation.rs
@@ -1,5 +1,110 @@
 use super::*;
 
+pub(super) const ACTIVATION_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_millis(50),
+    Duration::from_millis(100),
+    Duration::from_millis(200),
+    Duration::from_millis(400),
+    Duration::from_millis(800),
+];
+
+fn is_retryable_activation_error(error: &io::Error) -> bool {
+    matches!(
+        error.raw_os_error(),
+        Some(code)
+            if code == ERROR_ACCESS_DENIED as i32 || code == ERROR_SHARING_VIOLATION as i32
+    )
+}
+
+fn cache_path_label(path: &Path) -> String {
+    path.file_name()
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "<cache-root>".to_string())
+}
+
+pub(super) fn activate_extracted_cache_with(
+    staging: &Path,
+    destination: &Path,
+    manifest: &SidecarArchiveManifest,
+    mut rename: impl FnMut(&Path, &Path) -> io::Result<()>,
+    mut wait: impl FnMut(Duration),
+) -> Result<(), String> {
+    let started = Instant::now();
+    let maximum_attempts = ACTIVATION_RETRY_DELAYS.len() + 1;
+
+    for attempt in 1..=maximum_attempts {
+        let error = match rename(staging, destination) {
+            Ok(()) => {
+                if attempt > 1 {
+                    log::info!(
+                        "[cave] sidecar cache activation recovered attempt={attempt}/{maximum_attempts} elapsed_ms={}",
+                        started.elapsed().as_millis()
+                    );
+                }
+                return Ok(());
+            }
+            Err(error) => error,
+        };
+
+        let source_exists = staging.exists();
+        let destination_exists = destination.exists();
+        let destination_ready = cache_is_ready(destination, manifest);
+        if destination_ready {
+            match remove_cache_path(staging) {
+                Ok(()) => log::info!(
+                    "[cave] sidecar cache activation reused concurrent destination attempt={attempt}/{maximum_attempts} elapsed_ms={} staging={}",
+                    started.elapsed().as_millis(),
+                    cache_path_label(staging)
+                ),
+                Err(cleanup_error) => log::warn!(
+                    "[cave] sidecar cache activation reused concurrent destination but staging cleanup failed attempt={attempt}/{maximum_attempts} elapsed_ms={} staging={} error={cleanup_error}",
+                    started.elapsed().as_millis(),
+                    cache_path_label(staging)
+                ),
+            }
+            return Ok(());
+        }
+
+        if is_retryable_activation_error(&error) {
+            if let Some(delay) = ACTIVATION_RETRY_DELAYS.get(attempt - 1).copied() {
+                log::warn!(
+                    "[cave] sidecar cache activation retry attempt={attempt}/{maximum_attempts} delay_ms={} elapsed_ms={} kind={:?} raw_os_error={:?} staging={} destination={} source_exists={source_exists} destination_exists={destination_exists} destination_ready={destination_ready}",
+                    delay.as_millis(),
+                    started.elapsed().as_millis(),
+                    error.kind(),
+                    error.raw_os_error(),
+                    cache_path_label(staging),
+                    cache_path_label(destination)
+                );
+                wait(delay);
+                continue;
+            }
+        }
+
+        let cleanup_error = remove_cache_path(staging).err();
+        log::warn!(
+            "[cave] sidecar cache activation failed attempt={attempt}/{maximum_attempts} elapsed_ms={} kind={:?} raw_os_error={:?} staging={} destination={} source_exists={source_exists} destination_exists={destination_exists} destination_ready={destination_ready} cleanup={}",
+            started.elapsed().as_millis(),
+            error.kind(),
+            error.raw_os_error(),
+            cache_path_label(staging),
+            cache_path_label(destination),
+            if cleanup_error.is_some() { "failed" } else { "succeeded" }
+        );
+        let cleanup_detail = cleanup_error
+            .map(|cleanup_error| format!("; staging cleanup also failed: {cleanup_error}"))
+            .unwrap_or_default();
+        return Err(format!(
+            "could not activate extracted sidecar cache {} after {attempt} attempt(s): {error} (kind: {:?}, raw OS error: {:?}){cleanup_detail}",
+            destination.display(),
+            error.kind(),
+            error.raw_os_error()
+        ));
+    }
+
+    unreachable!("activation attempts are bounded by a non-empty delay schedule")
+}
+
 pub(super) fn prepare_runtime_from_files(
     archive_path: &Path,
     manifest_path: &Path,
@@ -97,18 +202,12 @@ pub(super) fn prepare_runtime_from_files_with_space(
         return Err(error);
     }
 
-    match fs::rename(&staging, &destination) {
-        Ok(()) => Ok(destination),
-        Err(_error) if cache_is_ready(&destination, &manifest) => {
-            let _ = remove_cache_path(&staging);
-            Ok(destination)
-        }
-        Err(error) => {
-            let _ = remove_cache_path(&staging);
-            Err(format!(
-                "could not activate extracted sidecar cache {}: {error}",
-                destination.display()
-            ))
-        }
-    }
+    activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |source, destination| fs::rename(source, destination),
+        thread::sleep,
+    )?;
+    Ok(destination)
 }

--- a/src-tauri/src/sidecar_archive_tests.rs
+++ b/src-tauri/src/sidecar_archive_tests.rs
@@ -408,6 +408,15 @@ fn activation_surfaces_staging_cleanup_failure() {
     .expect_err("permanent contention must fail");
 
     assert!(error.contains("staging cleanup also failed"));
+    assert!(error.contains("raw OS error: Some(5)"));
+    let cleanup_detail = error
+        .split("staging cleanup also failed")
+        .nth(1)
+        .expect("cleanup detail should be present");
+    assert!(
+        !cleanup_detail.contains(root.to_string_lossy().as_ref()),
+        "cleanup diagnostics must not include the full cache path"
+    );
     assert!(staging.exists(), "failed cleanup must not be hidden");
     drop(held_child);
     fs::remove_dir_all(root).expect("remove test root");

--- a/src-tauri/src/sidecar_archive_tests.rs
+++ b/src-tauri/src/sidecar_archive_tests.rs
@@ -1,4 +1,5 @@
 use super::*;
+use std::os::windows::fs::OpenOptionsExt;
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
     Arc, Barrier,
@@ -101,6 +102,31 @@ fn create_required_runtime(root: &Path) {
     }
 }
 
+fn create_ready_runtime(root: &Path, manifest: &SidecarArchiveManifest) {
+    create_required_runtime(root);
+    let marker = CompletionMarker {
+        schema_version: MANIFEST_SCHEMA_VERSION,
+        payload_sha256: manifest.payload_sha256.clone(),
+        tree_sha256: manifest.tree_sha256.clone(),
+    };
+    fs::write(
+        root.join(".complete.json"),
+        serde_json::to_vec(&marker).expect("serialize completion marker"),
+    )
+    .expect("write completion marker");
+}
+
+fn activation_fixture(name: &str) -> (PathBuf, PathBuf, PathBuf, SidecarArchiveManifest) {
+    let root = test_root(name);
+    let (_, _, manifest) = write_fixture(&root);
+    let cache = root.join("cache");
+    let staging = cache.join(".extract-test");
+    let destination = cache.join(cache_key(&manifest));
+    create_ready_runtime(&staging, &manifest);
+    fs::write(staging.join("extraction-id"), b"verified-once").expect("write extraction identity");
+    (root, staging, destination, manifest)
+}
+
 #[test]
 fn extracts_atomically_and_reuses_complete_cache() {
     let root = test_root("extract");
@@ -194,6 +220,231 @@ fn concurrent_preparations_extract_once_under_the_process_lock() {
             .count(),
         1
     );
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_retries_transient_access_denied_without_reextracting() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-retry-once");
+    let mut attempts = 0;
+    let mut waited = Vec::new();
+
+    activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |source, destination| {
+            attempts += 1;
+            if attempts == 1 {
+                Err(io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32))
+            } else {
+                fs::rename(source, destination)
+            }
+        },
+        |delay| waited.push(delay),
+    )
+    .expect("retry transient access denial");
+
+    assert_eq!(attempts, 2);
+    assert_eq!(waited, vec![ACTIVATION_RETRY_DELAYS[0]]);
+    assert_eq!(
+        fs::read(destination.join("extraction-id")).expect("read moved extraction identity"),
+        b"verified-once"
+    );
+    assert!(!staging.exists());
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_retries_multiple_sharing_violations_within_bound() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-retry-many");
+    let mut attempts = 0;
+    let mut waited = Vec::new();
+
+    activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |source, destination| {
+            attempts += 1;
+            if attempts <= 3 {
+                Err(io::Error::from_raw_os_error(ERROR_SHARING_VIOLATION as i32))
+            } else {
+                fs::rename(source, destination)
+            }
+        },
+        |delay| waited.push(delay),
+    )
+    .expect("retry bounded sharing violations");
+
+    assert_eq!(attempts, 4);
+    assert_eq!(waited.as_slice(), &ACTIVATION_RETRY_DELAYS[..3]);
+    assert!(cache_is_ready(&destination, &manifest));
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_exhausts_bounded_access_denied_retries() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-exhausted");
+    let mut attempts = 0;
+    let mut waited = Vec::new();
+
+    let error = activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |_, _| {
+            attempts += 1;
+            Err(io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32))
+        },
+        |delay| waited.push(delay),
+    )
+    .expect_err("permanent access denial must remain an error");
+
+    assert_eq!(attempts, ACTIVATION_RETRY_DELAYS.len() + 1);
+    assert_eq!(waited.as_slice(), &ACTIVATION_RETRY_DELAYS);
+    assert!(error.contains("after 6 attempt(s)"));
+    assert!(error.contains("raw OS error: Some(5)"));
+    assert!(!staging.exists(), "failed staging should be cleaned");
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_does_not_retry_unrelated_errors() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-unrelated");
+    let mut attempts = 0;
+    let mut waited = Vec::new();
+
+    let error = activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |_, _| {
+            attempts += 1;
+            Err(io::Error::from_raw_os_error(2))
+        },
+        |delay| waited.push(delay),
+    )
+    .expect_err("unrelated errors must fail immediately");
+
+    assert_eq!(attempts, 1);
+    assert!(waited.is_empty());
+    assert!(error.contains("raw OS error: Some(2)"));
+    assert!(!staging.exists(), "failed staging should be cleaned");
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_reuses_a_valid_concurrent_destination() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-concurrent");
+    let mut attempts = 0;
+    let mut waited = Vec::new();
+
+    activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |_, _| {
+            attempts += 1;
+            create_ready_runtime(&destination, &manifest);
+            Err(io::Error::from_raw_os_error(ERROR_SHARING_VIOLATION as i32))
+        },
+        |delay| waited.push(delay),
+    )
+    .expect("reuse a concurrently completed destination");
+
+    assert_eq!(attempts, 1);
+    assert!(waited.is_empty());
+    assert!(cache_is_ready(&destination, &manifest));
+    assert!(!staging.exists(), "redundant staging should be retired");
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_never_trusts_an_incomplete_concurrent_destination() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-incomplete");
+    let mut attempts = 0;
+
+    let error = activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |_, _| {
+            attempts += 1;
+            if attempts == 1 {
+                fs::create_dir(&destination).expect("create incomplete destination");
+                fs::write(destination.join("partial"), b"partial")
+                    .expect("write incomplete destination");
+            }
+            Err(io::Error::from_raw_os_error(ERROR_SHARING_VIOLATION as i32))
+        },
+        |_| {},
+    )
+    .expect_err("an incomplete destination must never be reused");
+
+    assert_eq!(attempts, ACTIVATION_RETRY_DELAYS.len() + 1);
+    assert!(error.contains("after 6 attempt(s)"));
+    assert!(!cache_is_ready(&destination, &manifest));
+    assert!(destination.join("partial").is_file());
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn activation_surfaces_staging_cleanup_failure() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-cleanup");
+    let held_child = OpenOptions::new()
+        .read(true)
+        .share_mode(0x0000_0001 | 0x0000_0002)
+        .open(staging.join("server.mjs"))
+        .expect("hold extracted child without delete sharing");
+
+    let error = activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |_, _| Err(io::Error::from_raw_os_error(ERROR_ACCESS_DENIED as i32)),
+        |_| {},
+    )
+    .expect_err("permanent contention must fail");
+
+    assert!(error.contains("staging cleanup also failed"));
+    assert!(staging.exists(), "failed cleanup must not be hidden");
+    drop(held_child);
+    fs::remove_dir_all(root).expect("remove test root");
+}
+
+#[test]
+fn native_activation_recovers_after_no_delete_share_handle_releases() {
+    let (root, staging, destination, manifest) = activation_fixture("activation-native-handle");
+    let held_child = OpenOptions::new()
+        .read(true)
+        .share_mode(0x0000_0001 | 0x0000_0002)
+        .open(staging.join("server.mjs"))
+        .expect("hold extracted child without delete sharing");
+    let mut held_child = Some(held_child);
+    let mut attempts = 0;
+    let mut raw_errors = Vec::new();
+
+    activate_extracted_cache_with(
+        &staging,
+        &destination,
+        &manifest,
+        |source, destination| {
+            attempts += 1;
+            let result = fs::rename(source, destination);
+            if let Err(error) = &result {
+                raw_errors.push(error.raw_os_error());
+            }
+            result
+        },
+        |_| drop(held_child.take()),
+    )
+    .expect("recover after the external handle is released");
+
+    assert_eq!(attempts, 2);
+    assert_eq!(raw_errors, vec![Some(ERROR_ACCESS_DENIED as i32)]);
+    assert!(cache_is_ready(&destination, &manifest));
+    assert!(!staging.exists());
     fs::remove_dir_all(root).expect("remove test root");
 }
 


### PR DESCRIPTION
## Summary

- Recover Coven Cave first-launch sidecar cache publication when Windows briefly rejects the final directory rename with Win32 `ERROR_ACCESS_DENIED` (5) or `ERROR_SHARING_VIOLATION` (32).
- Retry only that already-verified staging-to-destination activation, under the existing cache lock, with five short delays (50, 100, 200, 400, and 800 ms).
- Leave successful first-attempt activation and warm-cache reuse unchanged.

Fixes #4182.

## User impact

On affected Windows first launches, users saw `could not activate extracted sidecar cache ... Access is denied. (os error 5)` on the native **Starting CovenCave** screen. Pressing **Retry** worked because a later startup worker attempted activation after the transient handle contention had cleared.

The screenshot's generation key exactly matches the published v0.2.1 x64 MSI manifest payload SHA-256, so the report is tied to the v0.2.1 Windows runtime payload rather than v0.2.2 or current main. The change is exercised on Windows 11 Pro build 26200, NTFS, with Microsoft Defender real-time protection enabled. The exact reporter machine build, install history, and process that held the handle remain unknown.

Thanks to @lmvdz for reporting the failure and confirming that Retry recovered it.

## Root cause

The failing operation is the one-shot `std::fs::rename(staging, destination)` in `prepare_runtime_from_files_with_space`, after archive, payload, tree, count, size, required-path, completion-marker, and flush checks have completed.

On Rust 1.97.1 for Windows, this reaches `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` (with the standard library's access-denied fallback). A native deterministic reproduction opened a child of the extracted staging tree with read/write sharing but without delete sharing:

1. Renaming the parent staging directory returned `io::ErrorKind::PermissionDenied`, raw OS error 5.
2. The source still existed and the destination did not.
3. Releasing that exact handle made the same rename succeed immediately, without re-extraction.

A held directory handle produced raw OS error 32 and likewise succeeded after release. This establishes the transient Windows handle-contention failure class and explains why a later visible Retry can work. It does **not** identify the reporter's external actor; no reporter ProcMon trace is available, so this PR does not claim Defender, another AV/EDR, SearchIndexer, or the installer was responsible.

The interprocess cache lock serializes Cave instances, but it cannot prevent an external process from opening newly extracted content without delete sharing. Existing tests covered Cave concurrency, damaged/incomplete generations, low space, and stale staging, but had no injectable activation seam or transient Win32 rename failure coverage.

Confidence is high in the failing operation, recoverable handle-contention class, and safety of the bounded remedy; confidence in the reporter-specific external actor is intentionally unspecified pending a ProcMon trace.

## Implementation

- `src-tauri/src/sidecar_archive_preparation.rs`
  - Adds an injectable activation helper used by production and deterministic tests.
  - Retries only raw Win32 errors 5 and 32.
  - Makes at most six rename attempts with 1.55 seconds maximum cumulative delay.
  - Keeps the existing cache lock and already-verified staging tree; extraction is not repeated.
  - Rechecks after every failure whether another actor has published a valid destination.
  - Cleans redundant staging when a valid destination appears.
  - On exhaustion or an unrelated error, attempts cleanup and returns the final activation error, including `ErrorKind`, raw OS code, attempt count, and any cleanup failure.
  - Emits structured activation context with cache basenames rather than user-profile paths.
- `src-tauri/src/sidecar_archive.rs`\n  - Imports the Windows error constants and exposes the activation seam only to the module's tests.\n- `src-tauri/src/sidecar_archive_cache.rs`
  - Preserves existing path-bearing String errors for established callers while exposing raw `io::Error` details only to activation diagnostics, allowing cleanup kind/raw-code redaction.\n- `src-tauri/src/sidecar_archive_tests.rs`
  - Covers one and multiple transient failures, bound exhaustion, unrelated errors, concurrent valid/incomplete destinations, visible cleanup failure, no re-extraction, and a real native no-delete-share handle that releases between attempts.

The delay bound is deliberately shorter than a user-visible Retry cycle and adds no sleep to a successful first attempt. A durable ACL or policy denial therefore still fails with its diagnostic after a bounded 1.55-second wait.

## Preserved invariants

The change preserves:

- archive SHA-256 verification;
- payload and extracted-tree verification;
- file, directory, byte, and path-safety limits;
- content-addressed destination identity;
- interprocess locking;
- unique staging directories;
- completion-marker creation and flush before publication;
- atomic staging-to-destination publication;
- rejection of partial or mismatched caches;
- safe reuse of concurrently published valid generations;
- safe concurrent-version behavior.

It does not extract into the destination, copy over a partial destination, broaden accepted cache content, or swallow a final permission failure.

## Reproduction

### Original report

1. Install/open the v0.2.1 Windows build for the first time.
2. Runtime extraction and verification complete.
3. Atomic cache activation fails with raw Windows error 5 on the native startup page.
4. Pressing **Retry** starts a new worker and succeeds.

The screenshot generation key is `v3-07320b…b5886`; its full payload hash matches the manifest extracted from the official v0.2.1 x64 MSI. The downloaded MSI SHA-256 also matched the release `SHA256SUMS` file.

### Controlled reproduction

- Environment: Windows 11 Pro build 26200, NTFS, Defender real-time protection enabled, native Rust 1.97.1.
- Before recovery behavior: 1/1 injected no-delete-share child-handle cases failed with raw OS error 5.
- After recovery behavior: 1/1 identical cases succeeded on attempt 2 after the controlled handle release, using the same verified staging tree.
- Natural runs: 0/8 activation failures across published v0.2.1 and v0.2.2 archive extractions plus three single-launch and three simultaneous-launch current packaged-payload cycles. Natural success is supporting validation, not proof of the original external actor.

## Validation

### Source/local checks

Passed:

- `pnpm install --frozen-lockfile`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,443 test files wired)
- `pnpm build`
- `pnpm test:mobile` (77 files)
- `pnpm test:conformance` (3 files; one documented Tailscale CLI skip)
- `pnpm test:sidecar-runtime` (native win32/x64)
- `node src-tauri/release-runtime.test.mjs` (24/24)
- targeted `rustfmt --edition 2021 --check` on all three changed Rust files
- `git diff --check`
- repository staged privacy/secret hook (3/3 changed files)

Repository-wide pre-existing failures, all outside this diff:

- `cargo fmt --manifest-path src-tauri/Cargo.toml --check` reports existing formatting drift in `build.rs`, `lib.rs`, `pty.rs`, `speech.rs`, and other untouched files; the three changed files pass direct rustfmt.
- `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets -- -D warnings` reports existing unused/dead-code and clippy errors in `browser.rs`, `browser_commands.rs`, `browser_state.rs`, `desktop_reachability.rs`, `pty.rs`, `shell_open_commands.rs`, `sidecar_lifecycle.rs`, and `speech.rs`; it reports no error in the changed activation code.
- Native-Windows `pnpm test:app` / `pnpm test:api` hit existing Windows harness assumptions around extensionless `git` and linked-worktree path identity. CI runs those suites on Ubuntu.

### Deterministic Rust tests

`cargo test --manifest-path src-tauri/Cargo.toml --locked sidecar_archive -- --nocapture`

- 23 passed, 0 failed.
- Includes the real native handle-contention recovery test and the built Windows archive test.
- Covers transient success, bounded permanent failure, unrelated-error fail-fast behavior, valid/incomplete destination races, cleanup diagnostics, existing concurrency, corruption, recovery, and space checks.

### GitHub CI

[CI run 30747594378](https://github.com/OpenCoven/coven-cave/actions/runs/30747594378) completed successfully on exact head `cf681fbd9f920e447bdbb741d91e78051106b9c8`. All 9 rollup checks passed, including Windows sidecar archive extraction and lifecycle tests.

### Native Windows packaged-payload proof

- Built an unsigned x64 MSI from this head with a temporary, code-identical validation product name and app identifier so no real Coven Cave cache or installation was touched.
- MSI SHA-256: `6381478e9574862b46433696e4b4aa8456e1dc1f68efffb25eadbb2bb81beb68`.
- Administratively extracted that MSI and launched its packaged `app.exe` and resources under the disposable identifier with Defender enabled.
- Three single cold launches published a valid marker in 10.07–11.11 s and reached sidecar readiness in 11.39–13.59 s.
- Three warm launches reached sidecar readiness in 1.93–2.41 s.
- Three two-process simultaneous-launch cycles published one valid generation in 9.30–11.42 s, retained every required path, left zero staging remnants, and left zero validation processes after shutdown.
- Published v0.2.1 and v0.2.2 archives independently passed native extraction and verification (37.11 s and 37.15 s).
- The disposable identifier cache, extracted app, app data, and processes were removed afterward; `%LOCALAPPDATA%\ai.opencoven.cave` was not modified.

A full MSI installation transaction was attempted but Windows Installer rejected this all-users package without elevation (`Error 1925`, exit 1603) before registering or installing the product. No elevation bypass was attempted. Therefore this is packaged-MSI-payload launch proof, not a completed installer-transaction proof. A clean elevated VM install and reporter ProcMon capture remain follow-up validation gaps.

## Performance

- Successful first-attempt activation: no retry and no added sleep.
- Maximum transient-contention delay: 1.55 s across five waits and six attempts.
- Extraction is never repeated inside the retry loop.
- Current packaged-payload single cold activation: 10.07–11.11 s to marker (three runs).
- Current packaged-payload warm launch: 1.93–2.41 s to sidecar readiness (three runs).
- No comparable patched/unpatched natural-contention timing exists because the spontaneous condition did not occur in the clean runs; deterministic tests establish the retry delta.

## Risk and rollback

- **Error classification:** Win32 error 5 can also represent a durable ACL/policy denial. The strict attempt/time bound prevents an unbounded wait and still surfaces that denial; only errors 5 and 32 are retried.
- **External actor uncertainty:** the causal handle behavior is proven, but the reporter-specific process is unknown. Structured raw-code/attempt/state logging is retained for future diagnosis without logging the user-profile prefix.
- **Bound exhaustion:** the final rename error remains the primary error, with cleanup failure appended rather than hidden.
- **Security/integrity:** no verification, extraction limit, lock, marker, path, or atomic-publication behavior is weakened.
- **Rollback:** revert the PR (or both commits `cf681fbd9f920e447bdbb741d91e78051106b9c8` and `1d7834b67538c62cb6963b36ec5540f22ff7783d`); existing cache formats and completed generations require no migration.

## Readiness packet

- **Scope:** Windows sidecar archive activation only; four Rust files, no UI/API/schema/migration changes.
- **Affected platform:** packaged Windows desktop builds. Other platforms do not compile this module.
- **Issue evidence:** v0.2.1 payload identity confirmed; failing operation isolated; native Win32 handle-contention class reproduced; exact reporter actor remains unknown.
- **Test evidence:** focused Rust 23/23, JS runtime/archive checks green, three cold/warm/concurrent packaged-payload cycles green, staged privacy scan green.
- **CI:** pending on this exact draft head.
- **Known limitations:** no reporter ProcMon trace and no completed elevated MSI install in a clean VM; these are explicitly not claimed as complete.
- **Review focus:** retryable raw-code classification, 1.55-second bound, destination recheck, final cleanup/error behavior, and native handle test.
- **Commit:** DCO-signed conventional commit; no reporter co-author trailer was added because the report did not contribute code.
