### PR TITLE
fix(ios): sustain chat connectivity

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/ChatProjectSelection.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/ChatProjectSelection.swift
@@ -38,6 +38,19 @@ enum ChatProjectSelection {
         return sorted(projects).first?.root
     }
 
+    static func loadProjectsWithRecovery(
+        load: () async throws -> [ProjectInfo],
+        recover: (Error) async -> Bool
+    ) async throws -> [ProjectInfo] {
+        do {
+            return try await load()
+        } catch {
+            if error is CancellationError { throw error }
+            guard await recover(error) else { throw error }
+            return try await load()
+        }
+    }
+
     /// A New Chat import's explicit familiar selection is the permission scope
     /// used to choose its project. Transcript authors remain attributed in the
     /// restored messages, but cannot silently widen the next-send fan-out.

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -951,12 +951,22 @@ final class AppModel {
     /// retry/discovery path. A successful probe also gives the rolling token
     /// renewal a chance to run for long-foregrounded devices.
     func validateConnectionOnForeground() async {
+        await validateCurrentConnection(refreshProfile: true)
+    }
+
+    /// Keep a long-lived foreground session honest even when the network path
+    /// itself never changes. This prevents the next chat send from being the
+    /// first operation to discover that the desktop restarted or moved.
+    func maintainConnectionWhileActive() async {
+        await validateCurrentConnection(refreshProfile: false)
+    }
+
+    private func validateCurrentConnection(refreshProfile: Bool) async {
         guard connection != nil, connectionState == .connected else { return }
         if let client, await client.ping() {
-            // Profile first (the just-succeeded ping proves the current token is
-            // valid), then the rolling token renewal + queue flush stay adjacent
-            // — the offline-compose flush invariant pins that pair.
-            await loadOperatorProfile()
+            if refreshProfile {
+                await loadOperatorProfile()
+            }
             await refreshAccessTokenIfNeeded()
             flushQueuedMessages()
             return

--- a/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
@@ -155,7 +155,7 @@ struct ChatProjectPicker: View {
             return
         }
 
-        guard let client = app.client else {
+        guard app.client != nil else {
             projects = []
             isResolved = false
             errorMessage = "Connect to your Cave to load projects."
@@ -167,7 +167,18 @@ struct ChatProjectPicker: View {
         isResolved = false
         errorMessage = nil
         do {
-            let loaded = try await client.projects(familiarIds: familiarKey)
+            let loaded = try await ChatProjectSelection.loadProjectsWithRecovery(
+                load: {
+                    guard let currentClient = app.client else {
+                        throw CaveError.notConfigured
+                    }
+                    return try await currentClient.projects(familiarIds: familiarKey)
+                },
+                recover: { _ in
+                    await app.recoverConnectionInBackground()
+                    return app.connectionState == .connected
+                }
+            )
             try Task.checkCancellation()
             projects = loaded
             selectedRoot = requiresExplicitSelection

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -378,21 +378,24 @@ struct ChatView: View {
         .shadow(color: .black.opacity(0.16), radius: 18, y: 8)
     }
 
+    @ViewBuilder
     private var projectContext: some View {
-        ChatProjectPicker(
-            familiarIds: thread.familiarIds,
-            recentRoots: app.recentProjectRoots,
-            selectedRoot: $thread.projectRoot,
-            isResolved: $projectResolved,
-            locked: !thread.canChangeProject,
-            requiresExplicitSelection: thread.needsProjectSelection
-        ) {
-            thread.needsProjectSelection = false
-            app.touch(thread)
+        if thread.needsProjectSelection || !thread.canSendMessages {
+            ChatProjectPicker(
+                familiarIds: thread.familiarIds,
+                recentRoots: app.recentProjectRoots,
+                selectedRoot: $thread.projectRoot,
+                isResolved: $projectResolved,
+                locked: !thread.canChangeProject,
+                requiresExplicitSelection: thread.needsProjectSelection
+            ) {
+                thread.needsProjectSelection = false
+                app.touch(thread)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(chrome.bgRaised)
         }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 8)
-        .background(chrome.bgRaised)
     }
 
     private func sessionControlRow<Control: View>(

--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -41,19 +41,28 @@ struct RootView: View {
         .overlay {
             ConnectedMomentOverlay()
         }
-        // While the pill is up over the shell, quietly re-probe so a desktop
-        // that comes back (restarted, woke from sleep) reconnects on its own.
-        // The Connect screen has its own ticker for the pre-surfaces case;
-        // the hasLoadedSurfaces guard keeps the two from double-probing.
-        // Keyed on scenePhase so backgrounding stops the timer.
+        // Keep the active app connected for long sessions. Unreachable Cave
+        // instances retry every tick; a nominally connected instance gets a
+        // cheap heartbeat once a minute so a same-path desktop restart is
+        // discovered before the user's next send.
         .task(id: scenePhase) {
             guard scenePhase == .active else { return }
+            var connectedTicks = 0
             while !Task.isCancelled {
                 try? await Task.sleep(for: .seconds(10))
                 if Task.isCancelled { return }
-                guard app.hasLoadedSurfaces,
-                      case .unreachable = app.connectionState else { continue }
-                await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
+                switch app.connectionState {
+                case .connected:
+                    connectedTicks += 1
+                    guard connectedTicks >= 6 else { continue }
+                    connectedTicks = 0
+                    await app.maintainConnectionWhileActive()
+                case .unreachable where app.hasLoadedSurfaces:
+                    connectedTicks = 0
+                    await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
+                default:
+                    connectedTicks = 0
+                }
             }
         }
         .background(chrome.bgBase.ignoresSafeArea())

--- a/apps/ios/CovenCave/CovenCaveTests/ChatProjectSelectionTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatProjectSelectionTests.swift
@@ -149,4 +149,44 @@ final class ChatProjectSelectionTests: XCTestCase {
             ["sage", "nova"]
         )
     }
+
+    func testProjectLoadRetriesOnceAfterConnectionRecovery() async throws {
+        var attempts = 0
+        var recoveryErrors: [String] = []
+
+        let loaded = try await ChatProjectSelection.loadProjectsWithRecovery(
+            load: {
+                attempts += 1
+                if attempts == 1 { throw URLError(.networkConnectionLost) }
+                return [self.project("cave", "Cave", .write)]
+            },
+            recover: { error in
+                recoveryErrors.append(error.localizedDescription)
+                return true
+            }
+        )
+
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(recoveryErrors.count, 1)
+        XCTAssertEqual(loaded.map(\.id), ["cave"])
+    }
+
+    func testProjectLoadPreservesOriginalErrorWhenRecoveryFails() async {
+        var attempts = 0
+
+        do {
+            _ = try await ChatProjectSelection.loadProjectsWithRecovery(
+                load: {
+                    attempts += 1
+                    throw URLError(.cannotConnectToHost)
+                },
+                recover: { _ in false }
+            )
+            XCTFail("Expected project loading to fail")
+        } catch {
+            XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost)
+        }
+
+        XCTAssertEqual(attempts, 1)
+    }
 }

--- a/scripts/ios-chat-project-contract.test.mjs
+++ b/scripts/ios-chat-project-contract.test.mjs
@@ -80,8 +80,18 @@ assert.match(
 );
 assert.match(
   picker,
-  /client\.projects\(familiarIds: familiarKey\)/,
+  /currentClient\.projects\(familiarIds: familiarKey\)/,
   "the picker must request projects scoped to every selected familiar",
+);
+assert.match(
+  picker,
+  /loadProjectsWithRecovery\([\s\S]*recoverConnectionInBackground\(\)[\s\S]*connectionState == \.connected/,
+  "new-chat project discovery must recover a stale connection before surfacing failure",
+);
+assert.match(
+  nativeSelectionTests,
+  /testProjectLoadRetriesOnceAfterConnectionRecovery[\s\S]*testProjectLoadPreservesOriginalErrorWhenRecoveryFails/,
+  "native tests must bound new-chat project recovery to one retry",
 );
 assert.match(
   picker,

--- a/scripts/ios-chat-project-contract.test.mjs
+++ b/scripts/ios-chat-project-contract.test.mjs
@@ -147,6 +147,11 @@ assert.match(
 );
 assert.match(
   chat,
+  /if thread\.needsProjectSelection \|\| !thread\.canSendMessages \{[\s\S]*?ChatProjectPicker\(/,
+  "resolved chats must not keep a persistent Project control above the composer",
+);
+assert.match(
+  chat,
   /startFreshThread\(familiarIds: thread\.familiarIds,[\s\S]*projectRoot: thread\.projectRoot\)/,
   "/new must preserve the current project context",
 );

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -14,6 +14,7 @@ const terminal = await read("apps/ios/CovenCave/CovenCave/Networking/PtyTerminal
 const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
 const thread = await read("apps/ios/CovenCave/CovenCave/State/ChatThread.swift");
 const app = await read("apps/ios/CovenCave/CovenCave/CovenCaveApp.swift");
+const rootView = await read("apps/ios/CovenCave/CovenCave/Views/RootView.swift");
 const connectView = await read("apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift");
 
 // --- Shared URLSessions: sessions are never deallocated, so per-request
@@ -123,6 +124,16 @@ assert.match(
   app,
   /else if app\.connectionState == \.connected \{\s*\n\s*Task \{ await app\.validateConnectionOnForeground\(\) \}/,
   "the app should validate a stale connected state on foreground",
+);
+assert.match(
+  rootView,
+  /case \.connected:[\s\S]*?connectedTicks >= 6[\s\S]*?maintainConnectionWhileActive\(\)/,
+  "a long-lived active app should validate a nominally connected desktop once a minute",
+);
+assert.match(
+  model,
+  /func maintainConnectionWhileActive\(\) async[\s\S]*?validateCurrentConnection\(refreshProfile: false\)/,
+  "the active heartbeat should use the shared connection validation path without reloading profile data",
 );
 
 // --- Quiet retry: the unreachable screen re-probes without UI bouncing ------


### PR DESCRIPTION
## Summary
- heartbeat connected foreground sessions once per minute through the existing single-flight recovery path
- hide the Project picker after chat provenance is resolved, while preserving recovery for blocked or stale threads
- extend iOS contract coverage for both behaviors

## Test plan
- [x] `node scripts/ios-chat-project-contract.test.mjs`
- [x] `node scripts/ios-connection-stability.test.mjs`
- [x] `xcodebuild -project apps/ios/CovenCave/CovenCave.xcodeproj -scheme CovenCave -destination "generic/platform=iOS Simulator" -derivedDataPath /tmp/cave-kw434-derived CODE_SIGNING_ALLOWED=NO build`