### PR TITLE
docs(worktrees): align workflow retirement cooldown

### DIFF
--- a/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
+++ b/docs/superpowers/plans/2026-08-01-eight-hour-worktree-retirement.md
@@ -20,6 +20,7 @@
 - `.agents/skills/branch-curator/evals/evals.json` — evaluation prompt and expected cutoff behavior.
 - `docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md` — current automatic-retirement architecture.
 - `docs/superpowers/specs/2026-08-01-eight-hour-worktree-retirement-design.md` — approved change design.
+- `docs/workflows/beads-familiars.md` — familiar patrol lifecycle lane documentation.
 
 ### Task 1: Pin the eight-hour classifier boundary
 
@@ -196,6 +197,7 @@ git commit -S -m "test(worktrees): use eight-hour landing cooldown"
 - Modify: `.agents/skills/branch-curator/references/deletion-proof.md`
 - Modify: `.agents/skills/branch-curator/evals/evals.json`
 - Modify: `docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md`
+- Modify: `docs/workflows/beads-familiars.md`
 
 - [ ] **Step 1: Update the curator rule**
 
@@ -236,7 +238,14 @@ rg -n "24 hours|24-hour|86400" \
 Replace only retirement-recency references with 8-hour wording. Do not change
 maintenance-gate lease limits or unrelated durations.
 
-- [ ] **Step 5: Verify no stale retirement policy remains**
+- [ ] **Step 5: Align the familiar workflow cooldown lane**
+
+In `docs/workflows/beads-familiars.md`, change only the lifecycle `cooldown`
+lane's retirement-recency statement from a mandatory 24-hour window to a
+mandatory 8-hour window. Preserve all maintenance/deletion gates and unrelated
+durations.
+
+- [ ] **Step 6: Verify no stale retirement policy remains**
 
 Run:
 
@@ -246,12 +255,13 @@ rg -n "last 24 hours|older than 24 hours|24-hour cooldown|now_epoch - 86400|nume
   src/lib/worktree-lifecycle.ts \
   src/lib/worktree-lifecycle.test.ts \
   scripts/worktree-lifecycle-patrol.test.mjs \
-  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md \
+  docs/workflows/beads-familiars.md
 ```
 
 Expected: no matches.
 
-- [ ] **Step 6: Commit policy alignment**
+- [ ] **Step 7: Commit policy alignment**
 
 Run:
 
@@ -260,7 +270,8 @@ git add \
   .agents/skills/branch-curator/SKILL.md \
   .agents/skills/branch-curator/references/deletion-proof.md \
   .agents/skills/branch-curator/evals/evals.json \
-  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md
+  docs/superpowers/specs/2026-07-31-automatic-local-branch-retirement-design.md \
+  docs/workflows/beads-familiars.md
 git commit -S -m "docs(worktrees): require eight-hour retirement recency"
 ```
 

--- a/docs/workflows/beads-familiars.md
+++ b/docs/workflows/beads-familiars.md
@@ -115,7 +115,7 @@ lanes are:
 
 - `active` — local changes or a live owner still needs the worktree.
 - `recovery` — detached, WIP, backup, or unlanded work still protects data.
-- `cooldown` — landed work is inside the mandatory 24-hour recency window.
+- `cooldown` — landed work is inside the mandatory 8-hour recency window.
 - `retire-after-gate` — old, clean, landed work is cleanup-ready. Automatic
   retirement still requires the full repository-wide maintenance gate; explicit
   maintainer authorization in the current task may instead activate Branch


### PR DESCRIPTION
## Summary

PR #4215 changed the runtime and binding retirement policy to a mandatory 8-hour cooldown, but final review found `docs/workflows/beads-familiars.md` still described the lifecycle cooldown as 24 hours.

This corrective PR:
- aligns the familiar workflow cooldown lane with the 8-hour policy
- expands the implementation plan stale-policy scan and staging instructions to include the workflow document

Maintenance and deletion gates, plus unrelated durations, are unchanged.

## Verification

- expanded stale 24-hour retirement-policy search, including `docs/workflows/beads-familiars.md` (no matches)
- JSON parse of `.agents/skills/branch-curator/evals/evals.json`
- `node --experimental-strip-types src/lib/worktree-lifecycle.test.ts`
- `node scripts/worktree-lifecycle-patrol.test.mjs`
- `git diff --check origin/main...HEAD`
