### PR TITLE
fix(composer): render the promote row from the composer's model chip

### DIFF
--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -329,6 +329,8 @@ export function ComposerContextChips(props: ComposerContextProps) {
         modelOptions={context.config.modelOptions}
         onPickRuntime={context.config.onPickRuntime}
         onPickModel={context.config.onPickModel}
+        promotableModel={context.config.promotableModel ?? null}
+        onPromoteModelToDefault={context.config.onPromoteModelToDefault}
       />
       {context.hasGit ? (
         <GitBranchMenuPopover

--- a/src/components/composer-model-promote.test.ts
+++ b/src/components/composer-model-promote.test.ts
@@ -72,9 +72,18 @@ test("the row is offered only when it would do something", () => {
 });
 
 test("the props are threaded, not dropped mid-way", () => {
-  // A prop typed but never passed is the quiet failure here: the row would
-  // never render and look like a feature that does not work.
-  assert.match(chips, /promotableModel=\{context\.config\.promotableModel \?\? null\}/, "chips pass it down");
-  assert.match(chips, /onPromoteModelToDefault=\{context\.config\.onPromoteModelToDefault\}/, "and the handler");
+  // cave-9f9nj: this test used to assert the FILE contained the prop-passing
+  // text. composer-context-pill has TWO <ComposerRuntimePopover> sites —
+  // ComposerContextPickers (the actions-menu path) and ComposerContextChips
+  // (the composer footer's model chip, which is what chat-view and
+  // home-composer actually render). Only the first forwarded the props, and a
+  // file-level match cannot tell them apart, so the row never rendered from
+  // the chip while this test stayed green. Check EVERY site instead.
+  const sites = chips.match(/<ComposerRuntimePopover[\s\S]*?\/>/g) ?? [];
+  assert.ok(sites.length >= 2, `expected every ComposerRuntimePopover site to be checked, found ${sites.length}`);
+  for (const [i, site] of sites.entries()) {
+    assert.match(site, /promotableModel=\{context\.config\.promotableModel \?\? null\}/, `site ${i} passes promotableModel`);
+    assert.match(site, /onPromoteModelToDefault=\{context\.config\.onPromoteModelToDefault\}/, `site ${i} passes the handler`);
+  }
   assert.match(chatView, /promotableModel=\{promotableModel\}/, "chat-view supplies it");
 });


### PR DESCRIPTION
Fixes **cave-9f9nj**. Follow-up to #4209 (cave-pkapw), which shipped the "Set as default for new chats" row but left it unreachable from the surface it was built for.

## The bug

`composer-context-pill.tsx` has **two** `<ComposerRuntimePopover>` render sites:

| site | reached via | forwarded the props? |
|---|---|---|
| `ComposerContextPickers` (~L194) | overflow actions menu | yes |
| `ComposerContextChips` (~L323) | **the composer footer's model chip** | **no** |

`chat-view.tsx:6663` renders `ComposerContextChips` and passes `promotableModel` correctly at line 6675 — so the prop arrived at the component and was dropped one level before the popover. `home-composer.tsx:1168` uses the same component. Neither live composer could render the row from its model chip.

## Verification

Same script and API mocks against both builds, driving a real session whose model (Claude Sonnet 5) diverges from the familiar default (GPT-5.6 Sol):

| build | menu height | rows matching "Set as default for new chats" |
|---|---|---|
| `main` @ 2f44d4fa6c | 997px | **0** |
| this branch | 1036px | **1** |

The 39px delta is the separator plus the row. Chip label, session, and mocks were identical.

## Why the suite missed it

The guarding test asserted that the **file** `composer-context-pill.tsx` contains the prop-passing text. Site A satisfies that match, and a file-level source-text assertion cannot distinguish two JSX sites in one file. The test's own comment described this failure mode — *"a prop typed but never passed is the quiet failure here: the row would never render and look like a feature that does not work"* — and it stayed green throughout.

It now extracts every `<ComposerRuntimePopover ... />` block and asserts each carries both props. Confirmed it **fails** against the unfixed file (site 1) and passes here, so it catches the regression rather than restating it.