### PR TITLE
fix(familiars): stop three surfaces picking a familiar the user never chose

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -790,6 +790,7 @@ export const SUITES = {
     "src/lib/gh-review-draft.test.ts",
     "src/components/skill-stage-card-wiring.test.ts",
     "src/lib/github-stage.test.ts",
+    "src/components/familiar-no-silent-default.test.ts",
     "src/components/github-view-polish.test.ts",
     "src/components/github-advanced.test.ts",
     "src/components/github-native-open.test.ts",

--- a/src/components/chat-list-panel.test.ts
+++ b/src/components/chat-list-panel.test.ts
@@ -69,8 +69,12 @@ assert.match(
   "Dossier identity row (avatar + name + role) renders only in all-familiars mode — the sidebar already names the selected familiar",
 );
 
+// Placement guard, not a familiar-selection one: what matters is that the CTA
+// sits inside the `{familiar && …}` branch. The argument is named only to
+// anchor the match — it was renamed fallbackFamiliarId → scopedFamiliarId when
+// the silent familiars[0] default was retired.
 assert.match(
   source,
-  /\{familiar && \(\s*<button[\s\S]*?onNewChat\(undefined, fallbackFamiliarId\)/,
+  /\{familiar && \(\s*<button[\s\S]*?onNewChat\(undefined, scopedFamiliarId\)/,
   "With the identity row hidden, the + Chat CTA moves into the search/filter row",
 );

--- a/src/components/chat-list.tsx
+++ b/src/components/chat-list.tsx
@@ -221,7 +221,15 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
     () => new Map(familiars.map((entry) => [entry.id, entry])),
     [familiars],
   );
-  const fallbackFamiliarId = familiar?.id ?? familiars[0]?.id ?? null;
+  // Scoped to one familiar? That is the user's own choice and it carries into a
+  // new chat. UNSCOPED there is no correct default: handing familiars[0]
+  // downstream starts the chat with whichever familiar happens to sort first
+  // AND makes it the active one, skipping the NewChatLaunch picker that exists
+  // precisely to ask (same defect as #4203/#4208).
+  const scopedFamiliarId = familiar?.id ?? null;
+  // The control stays live whenever a chat can start at all — the familiar is
+  // chosen downstream, not defaulted here.
+  const canStartChat = familiars.length > 0;
   const panelTitle = familiar?.display_name ?? "Familiars";
   const panelRole = familiar?.role ?? "All project conversations";
   const panelRuntime = familiar ? (familiar.harness ?? "codex") : "mixed";
@@ -426,7 +434,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         projectRoot: null,
         projectName: null,
         sessions: rows,
-        defaultFamiliarId: latest?.familiarId ?? fallbackFamiliarId,
+        defaultFamiliarId: latest?.familiarId ?? scopedFamiliarId,
         updatedAt: latest ? (latest.updated_at || latest.created_at) : null,
       }];
     }
@@ -439,7 +447,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
       return { ...group, sessions: ordered };
     });
     return changed ? next : scopedGroups;
-  }, [effectiveSelection, groupBy, scopedGroups, sessionOrder, pinnedIds, fallbackFamiliarId]);
+  }, [effectiveSelection, groupBy, scopedGroups, sessionOrder, pinnedIds, scopedFamiliarId]);
   // Calendar-day sections for the "Group by date" mode: header metadata keyed
   // by the first row index of each local day (Today / Yesterday / formatted).
   const daySectionsByIndex = useMemo(() => {
@@ -710,7 +718,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
         }}
         onNewChat={(root) => {
           const group = sidebarGroups.find((g) => g.projectRoot === root);
-          onNewChat(root ?? undefined, group?.defaultFamiliarId ?? fallbackFamiliarId);
+          onNewChat(root ?? undefined, group?.defaultFamiliarId ?? scopedFamiliarId);
         }}
       />
       )}
@@ -765,8 +773,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
             {/* + Session CTA */}
             <button
               type="button"
-              onClick={() => onNewChat(undefined, fallbackFamiliarId)}
-              disabled={!fallbackFamiliarId}
+              onClick={() => onNewChat(undefined, scopedFamiliarId)}
+              disabled={!canStartChat}
               className="chat-list-new-button mt-0.5 flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[length:var(--text-sm)] font-semibold text-[var(--accent-presence-foreground)] shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
@@ -922,8 +930,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
           {familiar && (
             <button
               type="button"
-              onClick={() => onNewChat(undefined, fallbackFamiliarId)}
-              disabled={!fallbackFamiliarId}
+              onClick={() => onNewChat(undefined, scopedFamiliarId)}
+              disabled={!canStartChat}
               className="chat-list-new-button flex h-8 shrink-0 items-center gap-1.5 rounded-lg bg-[var(--accent-presence)] px-3 text-[length:var(--text-sm)] font-semibold text-[var(--accent-presence-foreground)] shadow-[0_1px_8px_color-mix(in_oklch,var(--accent-presence)_35%,transparent)] transition-all hover:opacity-90 hover:shadow-[0_2px_12px_color-mix(in_oklch,var(--accent-presence)_50%,transparent)] active:scale-95"
             >
               <Icon name="ph:plus-bold" width={11} />
@@ -1013,8 +1021,8 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                   variant="primary"
                   size="sm"
                   leadingIcon="ph:plus-bold"
-                  onClick={() => onNewChat(undefined, fallbackFamiliarId)}
-                  disabled={!fallbackFamiliarId}
+                  onClick={() => onNewChat(undefined, scopedFamiliarId)}
+                  disabled={!canStartChat}
                 >
                   Start with context
                 </Button>
@@ -1118,7 +1126,7 @@ export function ChatList({ familiar, familiars = [], sessions, daemonRunning, on
                       className="chat-list-group-new touch-always-visible flex h-5 w-5 shrink-0 items-center justify-center rounded text-[var(--text-muted)] opacity-0 transition-opacity hover:bg-[var(--bg-raised)] hover:text-[var(--text-primary)] focus-visible:opacity-100 group-hover:opacity-100"
                       onClick={(e) => {
                         e.stopPropagation();
-                        onNewChat(projectRoot ?? undefined, defaultFamiliarId ?? fallbackFamiliarId);
+                        onNewChat(projectRoot ?? undefined, defaultFamiliarId ?? scopedFamiliarId);
                       }}
                       title={`New session in ${projectRoot ? repoName(projectRoot) : "no project"}`}
                       aria-label={`New session in ${projectRoot ? repoName(projectRoot) : "no project"}`}

--- a/src/components/chat-router-hide-archived.test.ts
+++ b/src/components/chat-router-hide-archived.test.ts
@@ -56,17 +56,30 @@ assert.match(
   "chat-router should default fallbackFamiliar to the first non-archived familiar",
 );
 
-// 5. fallbackFamiliarId same story.
+// 5. The new-chat paths now satisfy this guard by a STRONGER route: they do not
+// substitute a familiar at all. `fallbackFamiliarId` existed to be the
+// archive-aware default for "Start a new chat"; that default is gone, so the
+// user cannot be dropped onto an archived familiar there because they are not
+// dropped onto ANY familiar — the NewChatLaunch picker asks instead. Not
+// dropping the guard, restating it at the strength the code now holds.
 assert.doesNotMatch(
   source,
-  /fallbackFamiliarId\s*=\s*familiar\?\.id\s*\?\?\s*familiars\[0\]\?\.id/,
-  "chat-router should not derive fallbackFamiliarId from raw familiars[0] (could be archived)",
+  /fallbackFamiliarId/,
+  "the new-chat default is retired entirely — no fallback to be archived or otherwise",
 );
-
 assert.match(
   source,
-  /fallbackFamiliarId\s*=\s*familiar\?\.id\s*\?\?\s*visibleFamiliars\[0\]\?\.id/,
-  "chat-router should derive fallbackFamiliarId from the first non-archived familiar",
+  /const next = familiarId \? selectFamiliarForChat\(familiarId\) : null;/,
+  "an unspecified familiar stays unspecified, so no archived familiar can be adopted",
 );
+assert.match(
+  source,
+  /const nextFamiliarId = group\?\.defaultFamiliarId \?\? familiar\?\.id \?\? null;/,
+  "the project-grouped new chat asks rather than defaulting",
+);
+
+// `fallbackFamiliar` (no Id) survives for the OTHER flows that still resolve a
+// familiar — resuming a session that recorded none, and boot-compose — so the
+// archive-aware derivation asserted in (4) above is still load-bearing there.
 
 console.log("chat-router-hide-archived.test.ts: ok");

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -252,7 +252,6 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     ? familiars.find((entry) => entry.id === activeSession.familiarId) ?? null
     : null;
   const chatFamiliar = selectedViewFamiliar ?? sessionFamiliar ?? familiar ?? null;
-  const fallbackFamiliarId = familiar?.id ?? visibleFamiliars[0]?.id ?? null;
   const { projects } = useProjects();
   const projectOverrides = useProjectOverrides();
 
@@ -723,7 +722,10 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           if (fq) setPendingFind({ query: fq, nonce: Date.now() });
         }}
         onNewChat={(projectRoot, familiarId) => {
-          const next = selectFamiliarForChat(familiarId);
+          // No familiar supplied means the user has not chosen one. Leave it
+          // null so NewChatLaunch renders and asks, rather than adopting
+          // visibleFamiliars[0] and silently making it the active familiar.
+          const next = familiarId ? selectFamiliarForChat(familiarId) : null;
           setView({ kind: "chat", sessionId: null, projectRoot, familiarId: next?.id ?? familiarId ?? null });
         }}
       />
@@ -880,8 +882,10 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         onOpenSessionInSplit={enableSplit ? handleOpenSessionInSplit : undefined}
         onNewChat={(root) => {
           const group = sidebarGroups.find((g) => g.projectRoot === root);
-          const nextFamiliarId = group?.defaultFamiliarId ?? fallbackFamiliarId;
-          const next = selectFamiliarForChat(nextFamiliarId);
+          // The group's own latest familiar is a real signal. Absent it, ask
+          // rather than fall back to whichever familiar sorts first.
+          const nextFamiliarId = group?.defaultFamiliarId ?? familiar?.id ?? null;
+          const next = nextFamiliarId ? selectFamiliarForChat(nextFamiliarId) : null;
           setView({
             kind: "chat",
             sessionId: null,

--- a/src/components/familiar-no-silent-default.test.ts
+++ b/src/components/familiar-no-silent-default.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+// Guards the rule that #4203, #4208 and this change all land on: a surface may
+// not pick WHICH familiar does the work. Familiars are the user's own roster —
+// `familiars[0]` is whichever one happens to sort first, so defaulting to it
+// silently assigns work, spends the wrong model's tokens, or (worst) changes
+// the active familiar out from under the user.
+//
+// A default IS fine when it seeds a control the user can see and change. What
+// this file pins is the consequential paths, where the answer must come from
+// the user's own choice or from an explicit picker.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const read = (p) => readFileSync(new URL(p, import.meta.url), "utf8");
+// Assert against CODE, not prose: these files explain the rule in comments that
+// necessarily quote the anti-pattern, and a blunt source match would trip on
+// its own documentation.
+const code = (p) =>
+  read(p)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .split("\n")
+    .filter((line) => !line.trim().startsWith("//"))
+    .join("\n");
+const chatList = code("./chat-list.tsx");
+const chatListSource = read("./chat-list.tsx");
+const chatRouter = code("./chat-router.tsx");
+const skillBuilder = code("./marketplace/skill-builder.tsx");
+const marketplace = read("./marketplace-view.tsx");
+const drawer = code("./skill-detail-drawer.tsx");
+const drawerSource = read("./skill-detail-drawer.tsx");
+
+// ── Starting a chat ──────────────────────────────────────────────────────────
+// Scoped to one familiar, that choice carries. Unscoped, hand null down so
+// chat-router falls through to NewChatLaunch instead of adopting a default.
+assert.match(
+  chatListSource,
+  /const scopedFamiliarId = familiar\?\.id \?\? null;/,
+  "chat-list does not invent a familiar when unscoped",
+);
+assert.doesNotMatch(
+  chatList,
+  /familiar\?\.id \?\? familiars\[0\]/,
+  "chat-list's new-chat default is not familiars[0]",
+);
+// The control must stay usable — the fix is "ask downstream", not "disable".
+assert.match(
+  chatList,
+  /const canStartChat = familiars\.length > 0;/,
+  "New chat stays enabled whenever any chat can start",
+);
+assert.doesNotMatch(chatList, /disabled=\{!fallbackFamiliarId\}/, "the button no longer gates on a guessed familiar");
+
+// chat-router must not substitute one either — selectFamiliarForChat(null)
+// falls back to visibleFamiliars[0] AND calls onSetActiveFamiliar, so calling
+// it with nothing is what changed the active familiar as a side effect.
+assert.match(
+  chatRouter,
+  /const next = familiarId \? selectFamiliarForChat\(familiarId\) : null;/,
+  "the sidebar new-chat path leaves the familiar unset when none was chosen",
+);
+assert.match(
+  chatRouter,
+  /const nextFamiliarId = group\?\.defaultFamiliarId \?\? familiar\?\.id \?\? null;/,
+  "the project-grouped new-chat path asks rather than defaulting",
+);
+assert.doesNotMatch(
+  chatRouter,
+  /group\?\.defaultFamiliarId \?\? fallbackFamiliarId/,
+  "the retired fallback is not reachable from a new chat",
+);
+
+// ── Running an LLM call ──────────────────────────────────────────────────────
+// Enhance runs through a familiar's model, so it takes the ACTIVE one and
+// tolerates null (usePromptEnhance has a hosted fallback for exactly this).
+assert.match(skillBuilder, /familiarId: activeFamiliarId,/, "Enhance uses the active familiar");
+assert.doesNotMatch(skillBuilder, /familiars\[0\]/, "Enhance does not borrow the first familiar");
+assert.match(marketplace, /activeFamiliarId=\{activeFamiliarId\}/, "the surface threads the active familiar through");
+
+// ── Reporting state ──────────────────────────────────────────────────────────
+// The eval loop is per-familiar. Rendering familiars[0]'s status unlabelled, in
+// a panel whose own copy says every familiar can load the skill, was showing
+// one arbitrary familiar's state as if it were the skill's.
+assert.doesNotMatch(drawer, /familiars\[0\]/, "the skill drawer does not query an arbitrary familiar");
+assert.doesNotMatch(drawer, /Eval loop:/, "the unattributed eval-loop readout is gone");
+assert.match(drawerSource, /Every familiar can load this skill/, "the panel still states the skill is not familiar-owned");
+
+console.log("familiar-no-silent-default.test.ts OK");

--- a/src/components/marketplace-view.tsx
+++ b/src/components/marketplace-view.tsx
@@ -33,7 +33,6 @@ import { MarketplaceConfigure } from "@/components/marketplace/marketplace-confi
 import { SkillBuilder } from "@/components/marketplace/skill-builder";
 import { SkillsComingSoon } from "@/components/marketplace/skills-coming-soon";
 import { type SkillBrowserEntry } from "@/lib/skill-directory";
-import { type FamiliarForSkill } from "@/components/skill-detail-drawer";
 import { SkillExploreCard } from "@/components/marketplace/skill-explore-card";
 import { SkillExploreDrawer } from "@/components/marketplace/skill-explore-drawer";
 import {
@@ -75,8 +74,10 @@ export type { MarketplaceSection } from "@/components/marketplace/marketplace-vi
 type Props = {
   /** Which section to land on — deep links from the roles/capabilities modes. */
   initialSection?: MarketplaceSection;
-  /** Familiars offered by the skill detail drawer's "try it" affordances. */
-  familiars?: FamiliarForSkill[];
+  /** The familiar the user is working as. Threaded to the Skill Builder's
+   *  Enhance, which runs an LLM call through it — that is the user's choice to
+   *  make, not the roster's sort order. */
+  activeFamiliarId?: string | null;
   /** Opens a chat with the familiar that owns a role. Unused while the Roles
    *  section is hidden; kept so re-enabling Roles is a UI-only change. */
   onOpenChat?: (familiarId: string) => void;
@@ -84,7 +85,7 @@ type Props = {
 
 export function MarketplaceViewSurface({
   initialSection = "browse",
-  familiars = [],
+  activeFamiliarId = null,
 }: Props = {}) {
   const craftsEnabled = caveCrafts();
   // Roles and Capabilities are hidden: their deep links land on Browse.
@@ -954,7 +955,7 @@ export function MarketplaceViewSurface({
           className="flex min-h-0 flex-1 flex-col"
         >
           <SkillBuilder
-            familiars={familiars}
+            activeFamiliarId={activeFamiliarId}
             onSaved={() => {
               invalidateSurfaceResources("marketplace:skills");
               void loadSkills(true);

--- a/src/components/marketplace/skill-builder.tsx
+++ b/src/components/marketplace/skill-builder.tsx
@@ -67,7 +67,6 @@ type Props = {
   onSaved?: () => void;
   /** Jumps to the Skills tab (the success panel's "View in Skills"). */
   onViewSkills?: () => void;
-  /** Familiars roster — powers the model-backed Enhance (offline fallback otherwise). */
   /** The familiar the user is actually working as. Enhance runs an LLM call
    *  through it, so it must not be guessed — null falls back to the hosted
    *  path rather than borrowing whichever familiar sorts first. */

--- a/src/components/marketplace/skill-builder.tsx
+++ b/src/components/marketplace/skill-builder.tsx
@@ -25,7 +25,6 @@ import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { StandardSelect } from "@/components/ui/select";
 import { useAnnouncer } from "@/components/ui/live-region";
-import type { FamiliarForSkill } from "@/components/skill-detail-drawer";
 import { handlePlaceholderTab, placeholderSpans } from "@/lib/prompt-placeholders";
 import { buildSkillAgentPrompt } from "@/lib/skill-agent-prompt";
 import {
@@ -69,10 +68,13 @@ type Props = {
   /** Jumps to the Skills tab (the success panel's "View in Skills"). */
   onViewSkills?: () => void;
   /** Familiars roster — powers the model-backed Enhance (offline fallback otherwise). */
-  familiars?: FamiliarForSkill[];
+  /** The familiar the user is actually working as. Enhance runs an LLM call
+   *  through it, so it must not be guessed — null falls back to the hosted
+   *  path rather than borrowing whichever familiar sorts first. */
+  activeFamiliarId?: string | null;
 };
 
-export function SkillBuilder({ onSaved, onViewSkills, familiars = [] }: Props) {
+export function SkillBuilder({ onSaved, onViewSkills, activeFamiliarId = null }: Props) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [tagsText, setTagsText] = useState("");
@@ -122,7 +124,7 @@ export function SkillBuilder({ onSaved, onViewSkills, familiars = [] }: Props) {
   const enhancer = usePromptEnhance({
     draft: instructions,
     setDraft: setInstructions,
-    familiarId: familiars[0]?.id ?? null,
+    familiarId: activeFamiliarId,
     mode: "task",
     disabled: saving,
   });

--- a/src/components/skill-detail-drawer.tsx
+++ b/src/components/skill-detail-drawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef } from "react";
 import { Icon } from "@/lib/icon";
 import { SkillDryRunTester } from "@/components/marketplace/skill-builder";
 import { useFocusTrap } from "@/lib/use-focus-trap";
@@ -52,24 +52,14 @@ export function SkillDetailDrawer({
   // behind the backdrop).
   useFocusTrap(Boolean(skill), panelRef, { onEscape: onClose });
 
-  // Daemon eval-loop state, when the loop is active for a familiar
-  // (docs/authoring-assist.md §3.3, cave-cyfc): authored skills and evaluated
-  // skills stop being different worlds. Quiet when the daemon is offline.
-  const [evalStatus, setEvalStatus] = useState<string | null>(null);
-  const familiarId = familiars[0]?.id;
-  useEffect(() => {
-    setEvalStatus(null);
-    if (!skill || !familiarId) return;
-    const ctl = new AbortController();
-    fetch(`/api/skills/eval-loop/${encodeURIComponent(familiarId)}`, { cache: "no-store", signal: ctl.signal })
-      .then((res) => res.json())
-      .then((json: { ok?: boolean; state?: { status?: unknown } | null }) => {
-        if (ctl.signal.aborted || !json.ok || !json.state) return;
-        if (typeof json.state.status === "string" && json.state.status) setEvalStatus(json.state.status);
-      })
-      .catch(() => {});
-    return () => ctl.abort();
-  }, [skill, familiarId]);
+  // The daemon's eval loop is per-FAMILIAR, not per-skill. This drawer used to
+  // query familiars[0] and render the answer as "Eval loop: <status>" with no
+  // attribution — so with more than one familiar it showed whichever one sorted
+  // first, labelled as if it described the skill. This panel's own copy says
+  // "Every familiar can load this skill while it works", so there is no single
+  // familiar for it to report on. Removed rather than re-pointed: showing one
+  // arbitrary familiar's loop here cannot be made correct (cave-cyfc's
+  // authored/evaluated link belongs on a familiar-scoped surface).
 
   if (!skill) return null;
 
@@ -170,13 +160,6 @@ export function SkillDetailDrawer({
               </div>
             </div>
           )}
-
-          {evalStatus ? (
-            <p className="flex items-center gap-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
-              <Icon name="ph:arrows-clockwise" width={11} aria-hidden />
-              Eval loop: {evalStatus}
-            </p>
-          ) : null}
 
           {/* Dry-run: would a familiar pick this skill up? (cave-cyfc) */}
           {skill.description ? (

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3205,7 +3205,7 @@ export function Workspace() {
       <MarketplaceView
         key={mode}
         initialSection={mode === "roles" ? "roles" : mode === "capabilities" ? "capabilities" : "browse"}
-        familiars={resolvedFamiliars}
+        activeFamiliarId={activeId}
         onOpenChat={(familiarId) => startFamiliarChat(familiarId)}
       />
     ) : mode === "submissions" ? (


### PR DESCRIPTION
Audit follow-up to #4203 and #4208. Familiars are the user's own roster, so `familiars[0]` means *"whichever one sorts first"* — fine for seeding a control you can see and change, wrong for anything consequential.

## 1. Starting a chat — the worst of the three

`chat-list` handed `familiars[0]` downstream whenever you weren't scoped to a familiar. `chat-router` then opened the chat with it **and**, via `selectFamiliarForChat` → `onSetActiveFamiliar`, **changed your active familiar as a side effect** — skipping `NewChatLaunch`, the picker that exists precisely to ask.

It now passes the scoped familiar or `null`, and both new-chat paths leave an unspecified familiar unspecified so the picker renders. The button stays enabled on its own `canStartChat`: the fix is "ask downstream", not "disable".

## 2. Enhance

`SkillBuilder` ran an LLM call through `familiars[0]`'s model. It now takes the active familiar (threaded `workspace → marketplace-view → SkillBuilder`) and tolerates `null` — `usePromptEnhance` already has a hosted fallback for exactly that.

With the guess gone, `SkillBuilder`'s entire `familiars` prop was unused: supplying that default had been its only purpose. It goes, and with it the dead pass-through in `marketplace-view` and `workspace`. **Net −2 lines.**

## 3. Skill drawer

It fetched `familiars[0]`'s eval-loop state and rendered `Eval loop: <status>` with **no attribution**, in a panel whose own copy reads *"Every familiar can load this skill while it works."*

Removed rather than re-pointed: the eval loop is per-familiar, so there is no familiar this panel can correctly report on. Worth noting separately — the component is currently **orphaned**; nothing imports it, only its types.

## Two existing guards restated, not deleted

- **`chat-router-hide-archived`** pinned `fallbackFamiliarId` to protect a *different* invariant: never drop the user onto an **archived** familiar. Retiring the default satisfies that more strongly — you land on no familiar unasked — so the assertion now pins the stronger property. The archive-aware `fallbackFamiliar` assertion stays load-bearing for the flows that still resolve one.
- **`chat-list-panel`**'s CTA assertion is a **layout** guard that merely anchored on the variable name. Renamed the anchor, kept the invariant, noted the coupling so the next rename doesn't look like a licence to drop it.

## Guard

New `familiar-no-silent-default.test.ts` pins all three. It asserts against source **with comments stripped** — the first version tripped on its own comment quoting the anti-pattern.

## Deliberately left

Two silent picks that want their own decision, not this PR's:
- `chat-router`'s boot-compose default (changing it risks an empty startup screen)
- `selectFamiliarForChat`'s null branch when resuming a session that recorded no familiar

## Verification

`pnpm test:app` — 1,051 files ✓ · `tsc --noEmit` ✓ · `pnpm lint` ✓ (0 design drift) · `check:tests-wired` — all 1,444 wired.

Also worth recording: my first audit pass was **case-sensitive** and missed six `visibleFamiliars[0]` sites, including `chat-router:247` — which would have silently defeated fix #1.
