### PR TITLE
Fix partial chat follow-up rows

### DIFF
--- a/src/components/chat-follow-up-layout.test.ts
+++ b/src/components/chat-follow-up-layout.test.ts
@@ -6,6 +6,8 @@ const styles = readFileSync(
   new URL("../styles/cave-chat/transcript.css", import.meta.url),
   "utf8",
 );
+const chatView = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const nextPaths = readFileSync(new URL("../lib/next-paths.ts", import.meta.url), "utf8");
 
 assert.match(
   styles,
@@ -14,8 +16,13 @@ assert.match(
 );
 assert.match(
   styles,
-  /\.cave-chat-followups \.cave-followup-cards__grid \{[\s\S]*?grid-template-columns: repeat\(3, minmax\(0, 1fr\)\);/,
-  "composer follow-ups fit exactly three equal options across the prompt width",
+  /\.cave-chat-followups \.cave-followup-cards__grid \{[\s\S]*?grid-auto-flow: column;[\s\S]*?grid-auto-columns: minmax\(0, 1fr\);[\s\S]*?grid-template-columns: none;/,
+  "composer follow-ups stretch one to three equal options across the prompt width",
+);
+assert.doesNotMatch(
+  styles,
+  /\.cave-chat-followups \.cave-followup-cards__grid \{[\s\S]*?grid-template-columns: repeat\(3,/,
+  "composer follow-ups do not reserve empty columns for malformed output",
 );
 assert.match(
   styles,
@@ -26,6 +33,16 @@ assert.match(
   styles,
   /@media \(max-width: 40rem\) \{[\s\S]*?\.cave-chat-followups \.cave-followup-card \{[\s\S]*?min-height: var\(--touch-target\);/,
   "narrow composer follow-ups preserve touch-safe targets",
+);
+assert.doesNotMatch(
+  chatView,
+  /extractNextPaths\([^;]+\.suggestions\.slice\(0,\s*4\)/,
+  "the parser owns the suggestion cap without a stale view-level limit",
+);
+assert.doesNotMatch(
+  nextPaths,
+  /At most 4 pills/,
+  "the parser comment stays aligned with the default cap",
 );
 
 console.log("chat-follow-up-layout.test.ts: ok");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3403,15 +3403,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // typed cards directly above the composer (aligned to the reading column) —
   // the most actionable element sits closest to the input. That turn's in-turn
   // card row is suppressed (followUp.turnId → TurnRow) so the suggestions
-  // never render twice; older turns keep their in-turn rows. Capped at 4 and
-  // laid out on the uniform-rows data-count grammar (never a 3+1 wrap).
+  // never render twice; older turns keep their in-turn rows. The parser owns
+  // the product cap so every renderer stays aligned.
   const followUp = useMemo(() => {
     const empty = { turnId: null as string | null, suggestions: [] as NextPath[] };
     const last = [...activePath]
       .reverse()
       .find((t) => t.role === "assistant" && !t.pending && !t.error);
     if (!last?.text) return empty;
-    const suggestions = extractNextPaths(splitReasoning(last.text).visible).suggestions.slice(0, 4);
+    const suggestions = extractNextPaths(splitReasoning(last.text).visible).suggestions;
     return suggestions.length ? { turnId: last.id, suggestions } : empty;
   }, [activePath]);
 

--- a/src/lib/next-paths.ts
+++ b/src/lib/next-paths.ts
@@ -185,8 +185,7 @@ export function extractNextPaths(text: string): { visible: string; suggestions: 
     .map((l) => l.replace(/^\s*[-*•]\s*/, "").trim())
     .map((line) => parseNextPath(line, closeAt === -1))
     .filter((suggestion): suggestion is NextPath => suggestion !== null)
-    // At most 4 pills ever render — the chip row's product cap (an over-eager
-    // agent that lists more gets trimmed, not a fifth row).
+    // Keep the parser as the single product cap so every renderer stays aligned.
     .slice(0, DEFAULT_NEXT_PATHS_COUNT);
   const visible = (markerSafeText.slice(0, open) + markerSafeText.slice(blockEnd)).trimEnd();
   return { visible, suggestions };

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -376,7 +376,9 @@
 }
 
 .cave-chat-followups .cave-followup-cards__grid {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-template-columns: none;
 }
 
 /* The dock is the one place next steps read as a compact prompt palette: the
@@ -425,8 +427,7 @@
 
 .cave-followup-cards__grid {
   display: grid;
-  /* Chat.dc.html 2a ⑤ — suggestions take equal shares of ONE row (next-paths
-     caps the strip at 3), so the strip never renders a ragged 2+1 (#2672). */
+  /* Suggestions take equal shares of one row up to the parser's product cap. */
   grid-auto-flow: column;
   grid-auto-columns: minmax(0, 1fr);
   gap: var(--space-2);
@@ -465,10 +466,6 @@
     grid-auto-flow: row;
     grid-auto-columns: unset;
     grid-template-columns: minmax(0, 1fr);
-  }
-
-  .cave-chat-followups .cave-followup-cards__grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 
   .cave-chat-followups .cave-followup-card {


### PR DESCRIPTION
## Summary
- stretch one or two parsed follow-up suggestions across the composer width instead of reserving empty tracks
- keep `extractNextPaths` as the single suggestion-cap authority
- remove stale four-option assumptions and extend focused regression coverage

## Verification
- `pnpm lint`
- `pnpm typecheck`
- focused next-path and follow-up regression tests
- `pnpm check:tests-wired`
- `pnpm build`
- Playwright computed-width checks for one, two, and three options

Follow-up to #4188.

Bead: `cave-8syxt`