### PR TITLE
feat(beads): guard against duplicate record ids in .beads/*.jsonl

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -145,6 +145,23 @@ fi
 
 info "ok (${#STAGED_FILES[@]} files scanned)"
 
+# ---- 3. Duplicate record ids in .beads/*.jsonl (cave-1poit) ---------------
+# These are append-only audit logs; a repeated id means the log reports one
+# event twice. Fast local feedback only — `git merge` does NOT run pre-commit,
+# and the duplicates that prompted this were born in a merge commit, so the
+# authoritative gate is the wired test in CI (pnpm check:beads-jsonl).
+if grep -qz '^\.beads/.*\.jsonl$' "$STAGED_FILE" 2>/dev/null; then
+  if command -v node >/dev/null 2>&1 && [ -f scripts/check-beads-jsonl-duplicates.mjs ]; then
+    if ! node scripts/check-beads-jsonl-duplicates.mjs >/dev/null 2>&1; then
+      node scripts/check-beads-jsonl-duplicates.mjs >&2 || true
+      fail "duplicate record ids in .beads/*.jsonl — see cave-1poit"
+      BLOCKED=1
+    else
+      info "beads jsonl: no duplicate record ids"
+    fi
+  fi
+fi
+
 # --- BEGIN BEADS INTEGRATION v1.0.5 ---
 # This section is managed by beads. Do not remove these markers.
 if command -v bd >/dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "lint:design": "eslint \"src/components/**/*.tsx\" --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",
+    "check:beads-jsonl": "node scripts/check-beads-jsonl-duplicates.mjs",
     "test": "node scripts/run-tests.mjs app",
     "test:app": "node scripts/run-tests.mjs app",
     "test:api": "node scripts/run-tests.mjs api",

--- a/scripts/check-beads-jsonl-duplicates.mjs
+++ b/scripts/check-beads-jsonl-duplicates.mjs
@@ -20,8 +20,9 @@
 // arrives via a PR, and the wired test calls this. The pre-commit hook is fast
 // local feedback, not the guarantee.
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
  * Scan JSONL text for repeated `id` values and unparseable lines.
@@ -55,7 +56,11 @@ export function findDuplicateIds(text) {
     if (typeof id !== "string" || id === "") continue;
     const entry = byId.get(id) ?? { lines: [], texts: new Set() };
     entry.lines.push(i + 1);
-    entry.texts.add(trimmed);
+    // Record the RAW line, not the trimmed one. `identical` is the signal that
+    // a copy is safe to drop, and it claims byte-identity — comparing trimmed
+    // text would call two lines identical when they differ by leading or
+    // trailing whitespace, which is precisely the claim it must not overstate.
+    entry.texts.add(raw);
     byId.set(id, entry);
   }
 
@@ -153,6 +158,28 @@ function main(argv) {
   return 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+// "Am I being run directly?" — compared as REAL paths, not as URL strings.
+//
+// Two ways the naive `import.meta.url === \`file://${process.argv[1]}\`` goes
+// wrong, and both make main() silently never run, which is the worst failure
+// mode for a checker:
+//   1. no percent-encoding — a checkout under a path containing a space gives
+//      `file:///tmp/a b/x.mjs` where import.meta.url is `file:///tmp/a%20b/x.mjs`;
+//   2. symlinks — on macOS `/var` is a symlink to `/private/var`, so argv[1]
+//      can be `/var/folders/...` while import.meta.url resolves to
+//      `/private/var/folders/...`. pathToFileURL alone does NOT fix this.
+// realpathSync on both sides collapses both cases. Verified by an executable
+// test that runs this file from a temp directory whose name contains a space.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
   process.exit(main(process.argv.slice(2)));
 }

--- a/scripts/check-beads-jsonl-duplicates.mjs
+++ b/scripts/check-beads-jsonl-duplicates.mjs
@@ -1,0 +1,158 @@
+#!/usr/bin/env node
+// cave-1poit: refuse a `.beads/*.jsonl` file that carries the same record `id`
+// twice.
+//
+// These files are append-only audit logs, not regenerable exports. Duplicates
+// do not lose data, but a log that reports the same event twice cannot be used
+// as evidence of what happened — and the obvious way to land pending records
+// ("append the local file") silently propagates them.
+//
+// They arise from git TEXTUALLY merging an append-only JSONL: two sides append
+// overlapping blocks and the merge keeps both. On main they were born at
+// 4f3cb37c11, a plain "Merge branch main" (6 duplicates), and reached 20 via
+// PR #4227, which appended records the base had regained through a different
+// merge. Repaired in #4229; this exists so the condition cannot come back
+// unnoticed.
+//
+// IMPORTANT — where this must run. `git merge` does NOT invoke the pre-commit
+// hook, so a commit-time check alone would have missed the exact event that
+// caused this. The authoritative gate is CI: main is protected, everything
+// arrives via a PR, and the wired test calls this. The pre-commit hook is fast
+// local feedback, not the guarantee.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Scan JSONL text for repeated `id` values and unparseable lines.
+ * Pure so it can be tested without touching the repo's real logs.
+ *
+ * @param {string} text
+ * @returns {{duplicates: Array<{id: string, lines: number[], identical: boolean}>, malformed: Array<{line: number, error: string}>, records: number}}
+ */
+export function findDuplicateIds(text) {
+  /** @type {Map<string, {lines: number[], texts: Set<string>}>} */
+  const byId = new Map();
+  const malformed = [];
+  let records = 0;
+
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i += 1) {
+    const raw = lines[i];
+    const trimmed = raw.trim();
+    if (!trimmed) continue;
+    let parsed;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (error) {
+      malformed.push({ line: i + 1, error: String(error?.message ?? error) });
+      continue;
+    }
+    records += 1;
+    // A record without an id cannot be deduplicated by id; that is a different
+    // defect, so leave it alone rather than inventing a key for it.
+    const id = parsed?.id;
+    if (typeof id !== "string" || id === "") continue;
+    const entry = byId.get(id) ?? { lines: [], texts: new Set() };
+    entry.lines.push(i + 1);
+    entry.texts.add(trimmed);
+    byId.set(id, entry);
+  }
+
+  const duplicates = [];
+  for (const [id, entry] of byId) {
+    if (entry.lines.length < 2) continue;
+    // Worth distinguishing: byte-identical copies are safe to drop
+    // (first-occurrence-wins). Differing copies sharing an id mean the log
+    // disagrees with itself about one event, which a script must not resolve
+    // on its own.
+    duplicates.push({ id, lines: entry.lines, identical: entry.texts.size === 1 });
+  }
+  duplicates.sort((a, b) => a.lines[0] - b.lines[0]);
+  return { duplicates, malformed, records };
+}
+
+/** Every tracked `.beads/*.jsonl` under `root`. */
+export function beadsJsonlFiles(root) {
+  const dir = join(root, ".beads");
+  let names;
+  try {
+    names = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return names
+    .filter((name) => name.endsWith(".jsonl"))
+    .map((name) => join(dir, name))
+    .filter((path) => {
+      try {
+        return statSync(path).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+/**
+ * @param {string[]} files
+ * @returns {{path: string, duplicates: any[], malformed: any[], records: number}[]}
+ */
+export function checkFiles(files) {
+  return files.map((path) => ({
+    path,
+    ...findDuplicateIds(readFileSync(path, "utf8")),
+  }));
+}
+
+function main(argv) {
+  const root = process.cwd();
+  const explicit = argv.filter((a) => !a.startsWith("-"));
+  const files = explicit.length > 0 ? explicit : beadsJsonlFiles(root);
+  if (files.length === 0) {
+    console.log("check-beads-jsonl-duplicates: no .beads/*.jsonl files — nothing to check");
+    return 0;
+  }
+
+  let failed = false;
+  for (const result of checkFiles(files)) {
+    const rel = result.path.startsWith(root) ? result.path.slice(root.length + 1) : result.path;
+    if (result.malformed.length > 0) {
+      failed = true;
+      console.error(`✗ ${rel}: ${result.malformed.length} unparseable line(s)`);
+      for (const m of result.malformed.slice(0, 5)) {
+        console.error(`    line ${m.line}: ${m.error}`);
+      }
+    }
+    if (result.duplicates.length > 0) {
+      failed = true;
+      const dupLines = result.duplicates.reduce((n, d) => n + d.lines.length - 1, 0);
+      console.error(
+        `✗ ${rel}: ${result.duplicates.length} duplicated id(s) across ${dupLines} extra line(s)`,
+      );
+      for (const d of result.duplicates.slice(0, 10)) {
+        const how = d.identical ? "identical copies" : "DIFFERING copies — resolve by hand";
+        console.error(`    ${d.id} at lines ${d.lines.join(", ")} (${how})`);
+      }
+      if (result.duplicates.length > 10) {
+        console.error(`    … and ${result.duplicates.length - 10} more`);
+      }
+    }
+    if (result.malformed.length === 0 && result.duplicates.length === 0) {
+      console.log(`✓ ${rel}: ${result.records} records, no duplicate ids`);
+    }
+  }
+
+  if (failed) {
+    console.error("");
+    console.error("These files are append-only audit logs. Duplicates usually mean a git merge");
+    console.error("concatenated two divergent tails — see cave-1poit. Drop the later copy of each");
+    console.error("id (first occurrence wins) ONLY when the copies are byte-identical.");
+    return 1;
+  }
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exit(main(process.argv.slice(2)));
+}

--- a/scripts/check-beads-jsonl-duplicates.test.mjs
+++ b/scripts/check-beads-jsonl-duplicates.test.mjs
@@ -12,7 +12,9 @@
 // check alone would have missed the causing event entirely.
 import assert from "node:assert/strict";
 import { test } from "node:test";
-import { readFileSync } from "node:fs";
+import { copyFileSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -60,6 +62,16 @@ test("copies that share an id but differ are flagged as NOT identical", () => {
   assert.equal(dup.identical, false, "differing copies must not look safe to auto-drop");
 });
 
+test("copies differing only by whitespace are NOT called identical", () => {
+  // `identical` claims byte-identity and is the signal that a copy is safe to
+  // drop. Comparing trimmed text would overstate that: these two lines encode
+  // the same record but are not the same bytes, so a human should look.
+  const text = [rec("a"), "  " + rec("a")].join("\n");
+  const [dup] = findDuplicateIds(text).duplicates;
+  assert.equal(dup.id, "a");
+  assert.equal(dup.identical, false, "whitespace-only differences must not read as byte-identical");
+});
+
 test("unparseable lines are reported rather than silently skipped", () => {
   const text = [rec("a"), "{not json", rec("b")].join("\n");
   const { malformed, records } = findDuplicateIds(text);
@@ -95,15 +107,61 @@ test("the repository's own .beads/*.jsonl have no duplicate ids", () => {
   }
 });
 
-test("the guard is reachable as a CLI, not only as a module", () => {
-  // A checker nothing invokes is not a guard. Keep the package script and the
-  // executable entry point pinned together.
+test("the guard actually RUNS as a CLI and exits non-zero on duplicates", () => {
+  // Deliberately executes the script instead of matching its source. A
+  // source-text pin cannot tell a working CLI entry from a broken one: the
+  // original spelling (`file://${process.argv[1]}`) matched the pattern and
+  // worked on a plain POSIX path, yet would silently no-op under a checkout
+  // path containing a space, because it does not percent-encode. A checker
+  // that quietly does nothing is the worst failure mode here, so prove it
+  // runs.
+  const script = join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs");
+
+  const dir = mkdtempSync(join(tmpdir(), "beads-dup-guard-"));
+  const clean = join(dir, "clean.jsonl");
+  const dirty = join(dir, "dirty.jsonl");
+  writeFileSync(clean, [rec("a"), rec("b")].join("\n") + "\n");
+  writeFileSync(dirty, [rec("a"), rec("b"), rec("a")].join("\n") + "\n");
+
+  const run = (file) => spawnSync(process.execPath, [script, file], { encoding: "utf8" });
+
+  const ok = run(clean);
+  assert.equal(ok.status, 0, `clean file should exit 0, got ${ok.status}\n${ok.stderr}`);
+  assert.match(ok.stdout, /no duplicate ids/, "and say so on stdout");
+
+  const bad = run(dirty);
+  assert.equal(bad.status, 1, "a duplicated id must exit non-zero or nothing gates on it");
+  assert.match(bad.stderr, /1 duplicated id/, "and name the problem on stderr");
+  assert.match(bad.stderr, /cave-1poit/, "pointing at the bead that explains the cause");
+
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("a checkout path containing a space still runs the CLI", () => {
+  // The concrete regression the percent-encoding fix addresses: copy the
+  // script under a directory with a space and confirm it still executes.
+  const dir = mkdtempSync(join(tmpdir(), "beads dup guard "));
+  const script = join(dir, "check.mjs");
+  copyFileSync(join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs"), script);
+  const dirty = join(dir, "dirty.jsonl");
+  writeFileSync(dirty, [rec("a"), rec("a")].join("\n") + "\n");
+
+  const res = spawnSync(process.execPath, [script, dirty], { encoding: "utf8" });
+  assert.equal(
+    res.status,
+    1,
+    `CLI must still run from a path with a space (got ${res.status}); ` +
+      "a naive file:// concatenation silently no-ops here",
+  );
+  rmSync(dir, { recursive: true, force: true });
+});
+
+test("the guard is exposed as a package script", () => {
+  // A checker nothing invokes is not a guard.
   const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
   assert.equal(
     pkg.scripts["check:beads-jsonl"],
     "node scripts/check-beads-jsonl-duplicates.mjs",
     "package.json must expose the guard as a runnable script",
   );
-  const source = readFileSync(join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs"), "utf8");
-  assert.match(source, /import\.meta\.url === `file:\/\/\$\{process\.argv\[1\]\}`/, "has a CLI entry");
 });

--- a/scripts/check-beads-jsonl-duplicates.test.mjs
+++ b/scripts/check-beads-jsonl-duplicates.test.mjs
@@ -1,0 +1,109 @@
+// cave-1poit: the duplicate-id guard for .beads/*.jsonl.
+//
+// Two jobs here, and the second is the one that matters operationally:
+//   1. the detector behaves (fixtures below);
+//   2. the repository's REAL .beads/*.jsonl carry no duplicate ids.
+//
+// (2) is the actual gate. It runs inside `pnpm test:app`, which `Frontend
+// build` runs on every PR, and main is protected — so a duplicate cannot reach
+// main without a required check going red. That placement is deliberate:
+// `git merge` does not invoke the pre-commit hook, and the duplicates this
+// guards against were BORN in a merge commit (4f3cb37c11), so a commit-time
+// check alone would have missed the causing event entirely.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+import {
+  beadsJsonlFiles,
+  checkFiles,
+  findDuplicateIds,
+} from "./check-beads-jsonl-duplicates.mjs";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const rec = (id, extra = "x") => JSON.stringify({ id, kind: "field_change", extra });
+
+test("a clean log reports no duplicates", () => {
+  const text = [rec("a"), rec("b"), rec("c")].join("\n") + "\n";
+  const { duplicates, malformed, records } = findDuplicateIds(text);
+  assert.deepEqual(duplicates, []);
+  assert.deepEqual(malformed, []);
+  assert.equal(records, 3);
+});
+
+test("repeated ids are reported with every line they occupy", () => {
+  // The real shape: a block appended twice, non-adjacently — which is what a
+  // textual merge of two divergent tails produces.
+  const text = [rec("a"), rec("dup1"), rec("dup2"), rec("b"), rec("dup1"), rec("dup2")].join("\n");
+  const { duplicates } = findDuplicateIds(text);
+  assert.equal(duplicates.length, 2);
+  assert.deepEqual(
+    duplicates.map((d) => [d.id, d.lines]),
+    [
+      ["dup1", [2, 5]],
+      ["dup2", [3, 6]],
+    ],
+  );
+  assert.ok(duplicates.every((d) => d.identical), "byte-identical copies are flagged as such");
+});
+
+test("copies that share an id but differ are flagged as NOT identical", () => {
+  // This is the case a script must never resolve on its own: the log
+  // disagrees with itself about one event, so first-occurrence-wins would be
+  // choosing between two versions of history.
+  const text = [rec("a"), rec("a", "DIFFERENT")].join("\n");
+  const [dup] = findDuplicateIds(text).duplicates;
+  assert.equal(dup.id, "a");
+  assert.equal(dup.identical, false, "differing copies must not look safe to auto-drop");
+});
+
+test("unparseable lines are reported rather than silently skipped", () => {
+  const text = [rec("a"), "{not json", rec("b")].join("\n");
+  const { malformed, records } = findDuplicateIds(text);
+  assert.equal(malformed.length, 1);
+  assert.equal(malformed[0].line, 2);
+  assert.equal(records, 2, "the bad line is not counted as a record");
+});
+
+test("blank lines and records without an id do not trip the check", () => {
+  // A trailing newline is normal, and at least one real record in this repo's
+  // log has no `id` field — neither is a duplicate.
+  const text = [rec("a"), "", JSON.stringify({ kind: "rfc", summary: "no id" }), ""].join("\n");
+  const { duplicates, malformed } = findDuplicateIds(text);
+  assert.deepEqual(duplicates, []);
+  assert.deepEqual(malformed, []);
+});
+
+test("the repository's own .beads/*.jsonl have no duplicate ids", () => {
+  const files = beadsJsonlFiles(repoRoot);
+  assert.ok(files.length > 0, "expected at least one .beads/*.jsonl to check");
+  for (const result of checkFiles(files)) {
+    const rel = result.path.slice(repoRoot.length + 1);
+    assert.deepEqual(
+      result.malformed,
+      [],
+      `${rel} has unparseable lines: ${JSON.stringify(result.malformed.slice(0, 3))}`,
+    );
+    assert.deepEqual(
+      result.duplicates.map((d) => `${d.id} @ ${d.lines.join(",")}`),
+      [],
+      `${rel} carries duplicate record ids — see cave-1poit`,
+    );
+  }
+});
+
+test("the guard is reachable as a CLI, not only as a module", () => {
+  // A checker nothing invokes is not a guard. Keep the package script and the
+  // executable entry point pinned together.
+  const pkg = JSON.parse(readFileSync(join(repoRoot, "package.json"), "utf8"));
+  assert.equal(
+    pkg.scripts["check:beads-jsonl"],
+    "node scripts/check-beads-jsonl-duplicates.mjs",
+    "package.json must expose the guard as a runnable script",
+  );
+  const source = readFileSync(join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs"), "utf8");
+  assert.match(source, /import\.meta\.url === `file:\/\/\$\{process\.argv\[1\]\}`/, "has a CLI entry");
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -49,6 +49,7 @@ export const SUITES = {
     "scripts/canonical-memory-smoke-lifecycle.test.mjs",
     "scripts/test-alias-loader.test.mjs",
     "scripts/maintenance-gate.test.mjs",
+    "scripts/check-beads-jsonl-duplicates.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
     "src/lib/board-cache-events.test.ts",


### PR DESCRIPTION
Part of **cave-1poit**. `.beads/*.jsonl` are append-only audit logs. A repeated record `id` doesn't lose data, but it makes the log report one event twice — and the obvious way to land pending records ("append the local file") then propagates it. #4229 removed 20 such records; this stops them coming back unnoticed.

## Where the gate has to be

**`git merge` does not invoke the pre-commit hook**, and these duplicates were *born* in a merge commit — `4f3cb37c11`, a plain `Merge branch main` whose two sides had appended overlapping blocks. A commit-time check alone would have missed the causing event entirely.

So the authoritative gate is a **wired test**: it runs in `pnpm test:app`, which `Frontend build` runs on every PR, and `main` is protected — a duplicate cannot reach `main` without a required check going red. The pre-commit hook is fast local feedback, not the guarantee, and it's inserted *ahead of* the beads-managed block so `bd` regenerating that block can't silently drop it.

## Verified against real history

It catches the actual regressions rather than restating them:

| commit | result |
|---|---|
| `4f3cb37c11` — where they were born | **exit 1**, 6 duplicated ids |
| `b9097e90ad` — PR #4227, which compounded them | **exit 1**, 20 duplicated ids |
| `17550f544f` — current `main` | exit 0, 1014 records clean |

## Design note

The checker distinguishes **byte-identical** copies from copies that share an id but **differ**. Only the former are safe to resolve first-occurrence-wins; the latter mean the log disagrees with itself about one event and must be settled by hand, so the tool refuses to imply otherwise.

## What this does not do

It doesn't stop a merge from *creating* duplicates — it makes them impossible to land silently. A merge driver for `.beads/*.jsonl` remains open on cave-1poit. Note a naive `merge=union` in `.gitattributes` would make this **worse**: union concatenates both sides, which is exactly how the duplicates appear.

Added: `scripts/check-beads-jsonl-duplicates.mjs` (module + CLI, `pnpm check:beads-jsonl`), its wired test, and the hook section.
