### PR TITLE
fix(patrol): retry transient inventory drift instead of failing closed (cave-v59dk)

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -991,7 +991,22 @@ function fetchPullRequests(
     }
   }
   if (canonicalRepo === null) {
-    globalErrors.push("pull request inventory canonical repository is unavailable");
+    // Distinguish "GitHub did not answer" from "GitHub answered and the
+    // repository identity was wrong". Both used to surface as the latter, which
+    // sent the reader looking at repository configuration when the real cause
+    // was an exhausted GraphQL budget (its 5000/hr pool is separate from REST,
+    // so `gh api rate_limit` can look healthy while every graphql call fails).
+    // The per-OID errors already carry the true reason; this promotes it
+    // instead of overwriting it (cave-v59dk).
+    const attempted = new Set(heads).size;
+    const firstFailure = [...errorsByOid.values()][0] ?? null;
+    globalErrors.push(
+      attempted > 0 && errorsByOid.size === attempted && firstFailure !== null
+        ? `pull request inventory could not query GitHub — all ${attempted} commit association ${
+            attempted === 1 ? "query" : "queries"
+          } failed: ${firstFailure}`
+        : "pull request inventory canonical repository is unavailable",
+    );
   }
 
   if (
@@ -1178,21 +1193,74 @@ function fetchWorkflowSweep(
   };
 }
 
+/**
+ * Errors that mean "the repository moved while we were reading it", as opposed
+ * to "the data is wrong". Runs start, finish and change state continuously, so
+ * a paginated read on a busy repo routinely lands mid-flight: pages disagree on
+ * total_count, the collected rows fall short of the total, or two verification
+ * sweeps see different sets. None of these indicate a problem with the
+ * inventory — they indicate CI is running — and every one of them is expected
+ * to resolve on a re-read.
+ */
+const RETRYABLE_SWEEP_ERROR =
+  /(returned partial data|returned inconsistent totals|changed between verification sweeps)/;
+
+/**
+ * Pairs of sweeps to attempt before giving up.
+ *
+ * Deliberately no backoff between attempts. Each sweep is itself several
+ * round-trips to GitHub, so a re-read is already far enough after the last one
+ * to see a settled state; adding a sleep would only lengthen the window during
+ * which the repository can change again. It would also be the one blocking
+ * primitive in an otherwise spawn-bound script, which is a poor thing to
+ * introduce into a path that runs while a maintenance gate is held.
+ */
+const WORKFLOW_SWEEP_ATTEMPTS = 4;
+
+/**
+ * A stable snapshot of the active workflow runs.
+ *
+ * The safety requirement is unchanged: two consecutive sweeps must agree before
+ * the result is trusted, because a partial inventory could miss a run that is
+ * live against a worktree and let it be retired. What changed is that ordinary
+ * churn no longer *ends* the attempt — a disagreement is retried rather than
+ * reported. On a repo with runs in flight the first pair almost never agrees,
+ * which is why this previously reported "partial data" whenever CI was busy and
+ * left every unit `uncertain` (cave-v59dk).
+ *
+ * Genuine inconsistencies — a duplicate run ID, conflicting statuses, malformed
+ * JSON, the 1000-run cap, a failed `gh` call — are NOT retried. Those do not
+ * settle on a second read, and retrying them would only delay a real report.
+ */
 function fetchWorkflows(
   repo: string,
   root: string,
 ): { runs: WorkflowRun[]; error: string | null } {
-  const first = fetchWorkflowSweep(repo, root);
-  if (first.error) return first;
-  const second = fetchWorkflowSweep(repo, root);
-  if (second.error) return second;
-  if (JSON.stringify(first.runs) !== JSON.stringify(second.runs)) {
-    return {
-      runs: [],
-      error: "workflow inventory changed between verification sweeps",
-    };
+  let lastError = "workflow inventory did not stabilize";
+  for (let attempt = 1; attempt <= WORKFLOW_SWEEP_ATTEMPTS; attempt += 1) {
+    const first = fetchWorkflowSweep(repo, root);
+    if (first.error) {
+      if (!RETRYABLE_SWEEP_ERROR.test(first.error)) return first;
+      lastError = first.error;
+    } else {
+      const second = fetchWorkflowSweep(repo, root);
+      if (second.error) {
+        if (!RETRYABLE_SWEEP_ERROR.test(second.error)) return second;
+        lastError = second.error;
+      } else if (JSON.stringify(first.runs) === JSON.stringify(second.runs)) {
+        return first;
+      } else {
+        lastError = "workflow inventory changed between verification sweeps";
+      }
+    }
   }
-  return first;
+  // Still moving after every attempt. Report the last reason AND the fact that
+  // it was retried, so the reader knows this is sustained churn rather than a
+  // one-off — otherwise the message invites exactly the wrong diagnosis.
+  return {
+    runs: [],
+    error: `${lastError} (unstable across ${WORKFLOW_SWEEP_ATTEMPTS} verification attempts — CI is likely busy)`,
+  };
 }
 
 function fetchClaims(root: string): {

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1206,7 +1206,11 @@ const RETRYABLE_SWEEP_ERROR =
   /(returned partial data|returned inconsistent totals|changed between verification sweeps)/;
 
 /**
- * Pairs of sweeps to attempt before giving up.
+ * How many times to attempt a stable read before giving up.
+ *
+ * An attempt is one sweep, plus a second confirming sweep only if the first
+ * succeeded — a first sweep that fails with retryable drift ends the attempt
+ * immediately, since there is nothing to confirm against.
  *
  * Deliberately no backoff between attempts. Each sweep is itself several
  * round-trips to GitHub, so a re-read is already far enough after the last one

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1088,6 +1088,14 @@ if [ "$1" = "api" ] &&
       fail "associated PR query repeated for duplicate OID $OID_ARG"
     : > "$ASSOCIATION_MARKER"
 
+    # Every association query fails the way an exhausted GraphQL budget fails:
+    # nonzero exit with the real cause on stderr. The inventory must surface
+    # THAT, not "canonical repository is unavailable" (cave-v59dk).
+    if [ "\${LIFECYCLE_GRAPHQL_BUDGET_EXHAUSTED:-0}" = "1" ]; then
+      printf '%s\\n' 'API rate limit already exceeded for user ID 68980965.' >&2
+      exit 1
+    fi
+
     REPOSITORY="OpenCoven/coven-cave"
     if [ "\${LIFECYCLE_BAD_CANONICAL_REPO:-0}" = "1" ] &&
        [ "$OID_ARG" = "${oldHead}" ]; then
@@ -1229,6 +1237,21 @@ case "$*" in
       else
         : > "$WORKFLOW_MARKER"
         printf '%s\n' '[{"total_count":0,"workflow_runs":[]}]'
+      fi
+    elif [ "\${LIFECYCLE_ALWAYS_UNSTABLE_WORKFLOW:-0}" = "1" ] &&
+         [ "$WORKFLOW_STATUS" = "queued" ]; then
+      # Never settles: every single sweep disagrees with the one before it, so
+      # no pair of verification sweeps can ever match. Models a repo where CI
+      # churns continuously for the whole patrol run (cave-v59dk).
+      WORKFLOW_TICK=${JSON.stringify(
+        path.join(fixtureRoot, "workflow-tick-"),
+      )}"\${LIFECYCLE_TEST_INVOCATION:-unknown}"
+      printf 'x' >> "$WORKFLOW_TICK"
+      WORKFLOW_TICKS=\$(wc -c < "$WORKFLOW_TICK" | tr -d ' ')
+      if [ \$(( WORKFLOW_TICKS % 2 )) -eq 1 ]; then
+        printf '%s\n' '[{"total_count":0,"workflow_runs":[]}]'
+      else
+        printf '%s\n' '[{"total_count":1,"workflow_runs":[{"id":9005,"status":"queued","head_branch":"feat/old","head_sha":"${oldHead}","html_url":"https://example.test/run/9005"}]}]'
       fi
     elif [ "$WORKFLOW_STATUS" = "queued" ]; then
       printf '%s\n' '[{"total_count":1,"workflow_runs":[{"id":9000,"status":"queued","head_branch":"feat/live","head_sha":"${workflowHead}","html_url":"https://example.test/run/9000"}]}]'
@@ -2193,7 +2216,20 @@ exit 0
     ["LIFECYCLE_MALFORMED_WORKFLOW_ID", /workflow inventory returned malformed data/i],
     ["LIFECYCLE_MISMATCHED_WORKFLOW_STATUS", /workflow inventory returned malformed data/i],
     ["LIFECYCLE_CONFLICTING_WORKFLOW_STATUS", /workflow inventory.*conflicting.*status/i],
-    ["LIFECYCLE_UNSTABLE_WORKFLOW", /workflow inventory changed between verification sweeps/i],
+    // Sustained churn still fails closed — and says it was retried, so the
+    // reader knows this is a busy repo rather than corrupt data (cave-v59dk).
+    [
+      "LIFECYCLE_ALWAYS_UNSTABLE_WORKFLOW",
+      /workflow inventory changed between verification sweeps \(unstable across \d+ verification attempts/i,
+    ],
+    // A dead GraphQL budget names itself rather than blaming the repository.
+    // Its 5000/hr pool is separate from REST, so `gh api rate_limit` can look
+    // healthy while every graphql call fails — the old message sent readers to
+    // check repository configuration instead (cave-v59dk).
+    [
+      "LIFECYCLE_GRAPHQL_BUDGET_EXHAUSTED",
+      /could not query GitHub — all \d+ commit association quer(?:y|ies) failed:[\s\S]*rate limit/i,
+    ],
     ["LIFECYCLE_BAD_TASKS", /Beads inventory returned malformed data/],
     ["LIFECYCLE_BEADS_STDERR", /Beads inventory omitted records/],
     ["LIFECYCLE_PR_CAP", /exact-head PR search.*(?:cap|1000)/i],
@@ -2228,6 +2264,28 @@ exit 0
     const failedOld = failedReport.items.find((item) => item.branch === "feat/old");
     assert.equal(failedOld.lane, "uncertain", `${environment} fails closed`);
     assert.match(failedOld.probeErrors.join("\n"), expectedReason);
+  }
+
+  // TRANSIENT churn recovers instead of failing closed (cave-v59dk). The stub
+  // disagrees with itself once and is then stable, which is what an ordinary
+  // busy repo looks like: a run started or finished between two sweeps. Before
+  // the retry, this single disagreement ended the attempt and left every unit
+  // `uncertain`, so the patrol was unusable whenever CI was running.
+  {
+    const recoveredReport = JSON.parse(
+      patrol(["--json"], { LIFECYCLE_UNSTABLE_WORKFLOW: "1" }),
+    );
+    const recoveredOld = recoveredReport.items.find((item) => item.branch === "feat/old");
+    assert.doesNotMatch(
+      recoveredOld.probeErrors.join("\n"),
+      /workflow inventory/i,
+      "a one-off sweep disagreement is retried, not reported",
+    );
+    assert.notEqual(
+      recoveredOld.lane,
+      "uncertain",
+      "transient workflow churn no longer forces a unit into uncertain",
+    );
   }
 
   const activeSessionReport = JSON.parse(


### PR DESCRIPTION
Closes `cave-v59dk`.

## The symptom

The worktree lifecycle patrol was unusable on a busy repo. Identical local state produced three different verdicts inside ten minutes:

```
run 1:  2 cleanup-ready |  8 uncertain
run 2:  0 cleanup-ready | 11 uncertain   → "workflow inventory returned partial data for in_progress"
earlier: every unit uncertain            → "pull request inventory canonical repository is unavailable"
```

Both messages are *global* probe errors, and `classifyLifecycleUnit` checks `probeErrors` **before** metadata — so one API hiccup sends every unit to `uncertain` regardless of how well-formed its lifecycle record is. Anyone running this during active CI concludes their metadata is broken when it is fine.

## Workflow inventory — retry, don't relax

`fetchWorkflows` already demanded **two consecutive identical sweeps**. That posture is correct and is preserved: a partial inventory could miss a run that is live against a worktree and let it be retired.

The bug was that a single disagreement *ended* the attempt. With runs in flight, two sweeps essentially never agree — the repo had 3 in progress and 11 queued while this was diagnosed. Drift is now retried up to four times, and a result is still only trusted when a pair agrees.

Not retried, because they never settle on a re-read: duplicate run ID, conflicting statuses, malformed JSON, the 1000-run cap, a failed `gh` invocation.

**No backoff, deliberately.** My first attempt used a synchronous sleep, and it hung `--apply` past the harness's 120s child timeout. That is a good argument against introducing the only blocking primitive into a spawn-bound script — one that runs while a maintenance gate is held. Each sweep is already several round-trips, so a re-read is far enough after the last.

## Canonical repository — say what actually failed

An exhausted GraphQL budget surfaced as *"canonical repository is unavailable"*, which sends the reader to check repository configuration. GraphQL's 5000/hr pool is **separate from REST**, so `gh api rate_limit` can look perfectly healthy while every `graphql` call fails.

When every association query failed, the message now says that and quotes the real error — which the per-OID failures were already carrying, just never promoted.

## Coverage

Three cases in `worktree-lifecycle-patrol.test.mjs`:

- transient churn now **recovers** (previously forced `uncertain`)
- sustained churn still **fails closed**, and says it was retried so the reader knows it is a busy repo rather than corrupt data
- an exhausted GraphQL budget **names itself**

Verified against a **pristine-main baseline run** so the harness is known to pass both before and after: baseline 138 patrols green, branch 140 patrols green.

## Known, not fixed here

There is a third instance of this same fail-on-drift pattern, filed separately rather than scope-crept into this PR: `collectWorktreeLifecycleInventory` throws *"worktree or branch inventory changed during patrol"* if any branch OID moves mid-run. On a machine with ~10 concurrent sessions that fires often — I caught it live and identified the exact cause (another session removed the `fix/familiar-defaults` worktree and branch during the run). The check is *correct*; it is the recovery that is missing. It is a larger change (the whole collection would need to be retryable) and a different mechanism.

Gates: `typecheck` · `lint` · `check:tests-wired` · `worktree-lifecycle-patrol.test.mjs` all green.
