### PR TITLE
fix(chat): boot-compose asks which familiar instead of picking one

### DIFF
--- a/src/components/chat-router-switching.test.ts
+++ b/src/components/chat-router-switching.test.ts
@@ -52,7 +52,7 @@ assert.match(
 
 // ── Chat-first IA (cave-hsa6): boot into a compose view, not the list ───────
 const bootComposeEffect =
-  source.match(/const bootComposeRef = useRef\(false\);[\s\S]*?\}, \[familiar\?\.id, fallbackFamiliar\?\.id\]\);/)?.[0] ?? "";
+  source.match(/const bootComposeRef = useRef\(false\);[\s\S]*?\}, \[familiar\?\.id, visibleFamiliars\.length\]\);/)?.[0] ?? "";
 assert.match(
   bootComposeEffect,
   /if \(bootComposeRef\.current\) return;/,
@@ -75,8 +75,22 @@ assert.match(
 );
 assert.match(
   bootComposeEffect,
-  /prev\.kind === "list" \? \{ kind: "chat", sessionId: null, familiarId: bootFamiliarId \} : prev/,
+  /prev\.kind === "list"\s*\?\s*\{ kind: "chat", sessionId: null, familiarId: familiar\?\.id \?\? null \}/,
   "booting into chat opens a zero-session compose view (ChatEmptyState + composer), no server session created",
+);
+// …and does NOT choose a familiar. An active one carries; absent one the view
+// opens unbound so NewChatLaunch asks, rather than binding the composer to
+// visibleFamiliars[0] and sending the user's first message to whichever
+// familiar sorted first.
+assert.doesNotMatch(
+  bootComposeEffect,
+  /fallbackFamiliar/,
+  "boot-compose does not adopt the first familiar in the roster",
+);
+assert.match(
+  bootComposeEffect,
+  /if \(visibleFamiliars\.length === 0\) return;/,
+  "boot still waits for the roster to load before leaving the list view",
 );
 
 // ── CHAT-D9-01: URL deep links (#chat-<sessionId>) ───────────────────────────

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -572,13 +572,21 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         return;
       }
     }
-    const bootFamiliarId = familiar?.id ?? fallbackFamiliar?.id ?? null;
-    if (!bootFamiliarId) return; // wait until a familiar is available
+    // Boot into chat rather than the list — but do not choose WHO for the user.
+    // An active familiar carries. Absent one this used to adopt
+    // visibleFamiliars[0], so a first run (or a cleared/deleted active familiar)
+    // landed on a composer silently bound to whichever familiar sorted first,
+    // and the user's FIRST message went to it. Open the compose view unbound
+    // instead: chatFamiliar stays null and NewChatLaunch asks, which keeps the
+    // chat-first landing without making the choice.
+    if (visibleFamiliars.length === 0) return; // wait until the roster has loaded
     bootComposeRef.current = true;
     setView((prev) =>
-      prev.kind === "list" ? { kind: "chat", sessionId: null, familiarId: bootFamiliarId } : prev,
+      prev.kind === "list"
+        ? { kind: "chat", sessionId: null, familiarId: familiar?.id ?? null }
+        : prev,
     );
-  }, [familiar?.id, fallbackFamiliar?.id]);
+  }, [familiar?.id, visibleFamiliars.length]);
 
   useImperativeHandle(
     ref,

--- a/src/components/familiar-no-silent-default.test.ts
+++ b/src/components/familiar-no-silent-default.test.ts
@@ -69,6 +69,20 @@ assert.doesNotMatch(
   "the retired fallback is not reachable from a new chat",
 );
 
+// Booting into chat is the same decision at startup: a first run, or a cleared
+// or deleted active familiar, used to land on a composer silently bound to
+// visibleFamiliars[0] — and the user's FIRST message went to it.
+assert.match(
+  chatRouter,
+  /familiarId: familiar\?\.id \?\? null \}/,
+  "boot-compose opens the composer unbound when no familiar is active",
+);
+assert.match(
+  chatRouter,
+  /if \(visibleFamiliars\.length === 0\) return;/,
+  "boot-compose waits for the roster instead of adopting its first entry",
+);
+
 // ── Running an LLM call ──────────────────────────────────────────────────────
 // Enhance runs through a familiar's model, so it takes the ACTIVE one and
 // tolerates null (usePromptEnhance has a hosted fallback for exactly this).

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -23,6 +23,16 @@ const FAMILIARS = {
   ],
 };
 
+// Two familiars, so "whichever sorts first" is an actual choice being made —
+// with one, adopting it is indistinguishable from asking.
+const FAMILIARS_TWO = {
+  ok: true,
+  familiars: [
+    { id: "aster", display_name: "Aster", role: "Builder", status: "active", icon: "ph:sparkle-fill" },
+    { id: "nova", display_name: "Nova", role: "Orchestrator", status: "active", icon: "ph:sparkle-fill" },
+  ],
+};
+
 const SESSION_S1 = {
   id: "s1",
   title: "Refactor auth flow",
@@ -54,6 +64,15 @@ const BOARD = {
     },
   ],
 };
+
+async function seedWithoutActiveFamiliar(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+  });
+  await page.route("**/api/familiars**", (route) => route.fulfill({ json: FAMILIARS_TWO }));
+  await page.route("**/api/board**", (route) => route.fulfill({ json: BOARD }));
+  await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: [] } }));
+}
 
 async function seed(page: Page) {
   await page.addInitScript(() => {
@@ -204,4 +223,25 @@ test.describe("chat boot landing", () => {
     await expect(page.getByRole("menuitem", { name: "Enhance prompt" })).toBeVisible();
     await page.keyboard.press("Escape");
   });
+});
+
+// Boot with NO active familiar — a first run, or after clearing storage or
+// deleting the active familiar. This used to open a composer silently bound to
+// whichever familiar sorted first, so the user's FIRST message went to it.
+// It must ask instead.
+test("booting with no active familiar asks which one instead of picking", async ({ page }) => {
+  await seedWithoutActiveFamiliar(page);
+  await page.goto("/?mode=chat", { waitUntil: "domcontentloaded" });
+
+  // The chat-first landing still happens — we did not fall back to the list.
+  const launch = page.locator(".cave-launch");
+  await expect(launch).toBeVisible({ timeout: 45_000 });
+  await expect(page.getByRole("heading", { name: "Start a new chat" })).toBeVisible();
+
+  // Both familiars are offered; neither has been chosen for the user.
+  await expect(launch.getByText("Aster")).toBeVisible();
+  await expect(launch.getByText("Nova")).toBeVisible();
+
+  // And no composer is sitting there already bound to one of them.
+  await expect(page.getByTestId("chat-new-dashboard")).toHaveCount(0);
 });


### PR DESCRIPTION
Last of the silent-familiar defaults, after #4203, #4208 and #4228.

## The bug

Booting into chat used `familiar?.id ?? fallbackFamiliar?.id`. So a first run — or a cleared `localStorage`, or a deleted active familiar — landed you on a composer **silently bound to `visibleFamiliars[0]`**, and your *first message* went to whichever familiar happened to sort first.

## The fix

Open the compose view **unbound** when nothing is active: `chatFamiliar` stays null, `NewChatLaunch` renders, and you pick.

The chat-first landing is preserved — this does **not** fall back to the session list. It just stops making the choice for you. It still waits for the roster to load before leaving the list, so the picker never paints empty.

I'd earlier flagged that changing this "risks an empty startup screen". That was wrong: a null id simply returned and left you on the list. Opening unbound is better than either option.

## Verified behaviourally, not by source text

This is the part that matters here. The existing `chat-boot-landing` spec seeds `cave:active-familiar`, so **every case exercised the path where a familiar carries** — the fallback branch this bug lived in was never tested. Source pins can't answer "does removing the default leave the user somewhere sensible?"

The new case seeds **no** active familiar and **two** familiars (with one, adopting it is indistinguishable from asking), then asserts:
- the launcher appears, offering both familiars
- no composer is sitting there pre-bound

It passed on the first attempt. The three flaky results in that run are pre-existing cases (lines 93/102/152) that hit a 60s `page.goto` under machine load and passed on retry; suite exit was 0.

## Guards

- `chat-router-switching.test.ts` extracts the boot effect by matching its dependency array, which changed — so its regex moves with it, and gains two assertions: no `fallbackFamiliar`, and the roster wait is still present.
- `familiar-no-silent-default.test.ts` now covers boot-compose too, so the whole class is pinned in one place.

`fallbackFamiliar` itself survives for the one flow that still resolves a familiar — resuming a session that recorded none — where `chat-router-hide-archived`'s archive-aware assertion remains load-bearing.

## Verification

`pnpm test:app` — 1,052 files ✓ · `tsc --noEmit` ✓ · e2e `chat-boot-landing` ✓ (new case passed first try).
