### PR TITLE
fix(omnigent): open session UI in system browser

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,13 @@ improvements.
 
 ## Community Contributors
 
+### Andrew Peltekci ([@appletechie](https://github.com/appletechie))
+
+Andrew contributed the per-host Omnigent workspace map and the follow-up that
+opens authenticated Omnigent sessions in the system browser so first-party
+session cookies work outside Cave's embedded Browser.
+(proposed in [#3247](https://github.com/OpenCoven/coven-cave/pull/3247))
+
 ### Timothy Wayne Gregg ([@CompleteDotTech](https://github.com/CompleteDotTech))
 
 Timothy contributed the Queue project readiness contract: a persisted

--- a/src/components/board-inspector-a11y.test.ts
+++ b/src/components/board-inspector-a11y.test.ts
@@ -41,7 +41,11 @@ assert.match(src, /transition: reducedMotion \? "none" : "width 0\.2s/, "the pro
 assert.match(src, /transition: reducedMotion \? "none" : "background 0\.15s"/, "the step checkbox drops its transition under reduced motion");
 assert.match(src, /@media \(prefers-reduced-motion: reduce\) \{ \.step-actions \{ transition: none; \} \}/, "the step-actions hover reveal honors reduced motion");
 
-assert.match(src, /import \{ openExternalUrl \} from "@\/lib\/open-external"/, "inline PAT setup imports the system-browser opener");
+assert.match(
+  src,
+  /import\s*\{[^}]*\bopenExternalUrl\b[^}]*\}\s*from "@\/lib\/open-external"/,
+  "inline PAT setup imports the shared URL opener",
+);
 assert.match(src, /onClick=\{\(\) => void openExternalUrl\(GITHUB_PAT_URL\)\}/, "inline PAT setup opens GitHub token creation outside the local app");
 assert.match(src, /read:user,read:org,repo,notifications/, "inline PAT setup requests organization-read access for the GitHub organization filter");
 assert.doesNotMatch(src, /href="https:\/\/github\.com\/settings\/tokens\/new/, "inline PAT setup no longer uses a plain localhost-bound anchor");

--- a/src/components/board-inspector.tsx
+++ b/src/components/board-inspector.tsx
@@ -38,7 +38,12 @@ import { HarnessFixActions } from "@/components/harness-fix-actions";
 import { parseHarnessFailure } from "@/lib/harness-failure";
 import { CHAT_OPEN_PROJECTS_EVENT, markProjectsTabPending } from "@/lib/chat-tab-events";
 import { useDateTimePrefs, formatDate, formatClock } from "@/lib/datetime-format";
-import { openExternalUrl } from "@/lib/open-external";
+import {
+  cancelSystemBrowserUrlWindow,
+  openExternalUrl,
+  openSystemBrowserUrl,
+  reserveSystemBrowserUrlWindow,
+} from "@/lib/open-external";
 import { InlineAsanaPATSetup } from "@/components/asana-connect-inline";
 import { attachmentIcon, fileToAttachment, hasDraggedFiles } from "@/lib/chat-attachments";
 import type { CardPatch } from "@/lib/board-card-ops";
@@ -1636,21 +1641,29 @@ export function BoardInspector({ card, familiars, sessions, projects, onClose, o
                       className="board-drawer-chat-cta"
                       title="Run on Omnigent fleet"
                       onClick={() => {
+                        const systemBrowserReservation = reserveSystemBrowserUrlWindow();
                         void (async () => {
-                          const { startOmnigentRunFromBrowser } = await import("@/lib/omnigent/browser-run");
-                          const { openExternalUrl } = await import("@/lib/open-external");
-                          const result = await startOmnigentRunFromBrowser({
-                            prompt: card.title,
-                            familiarId: card.familiarId ?? undefined,
-                            boardCardId: card.id,
-                            title: card.title,
-                            source: "cave-board",
-                          });
-                          if (!result.ok) {
-                            window.alert(result.error);
-                            return;
+                          let systemBrowserReservationConsumed = false;
+                          try {
+                            const { startOmnigentRunFromBrowser } = await import("@/lib/omnigent/browser-run");
+                            const result = await startOmnigentRunFromBrowser({
+                              prompt: card.title,
+                              familiarId: card.familiarId ?? undefined,
+                              boardCardId: card.id,
+                              title: card.title,
+                              source: "cave-board",
+                            });
+                            if (!result.ok) {
+                              window.alert(result.error);
+                              return;
+                            }
+                            systemBrowserReservationConsumed = true;
+                            void openSystemBrowserUrl(result.webUrl, { reservation: systemBrowserReservation });
+                          } finally {
+                            if (!systemBrowserReservationConsumed) {
+                              cancelSystemBrowserUrlWindow(systemBrowserReservation);
+                            }
                           }
-                          void openExternalUrl(result.webUrl);
                         })();
                       }}
                     >

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -118,7 +118,12 @@ import {
 } from "@/lib/chat-archive-nudge";
 import type { ChatLinkedContext } from "@/lib/chat-linked-context";
 import type { Card } from "@/lib/cave-board-types";
-import { openExternalUrl } from "@/lib/open-external";
+import {
+  cancelSystemBrowserUrlWindow,
+  openExternalUrl,
+  openSystemBrowserUrl,
+  reserveSystemBrowserUrlWindow,
+} from "@/lib/open-external";
 import { githubIcon, githubLabel, repoName } from "@/components/composer-linked-work-actions";
 import { LinkedContextRow } from "@/components/composer-linked-work-actions";
 import { ComposerContextChips } from "@/components/composer-context-pill";
@@ -4405,6 +4410,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         ? controlsOverride.queuedRuntimeHost
         : (controlsOverride?.runtimeHost ?? runtimeHost);
     if (isOmnigentHostOptionId(fleetHost) && submitPrompt) {
+      const systemBrowserReservation = reserveSystemBrowserUrlWindow();
+      let systemBrowserReservationConsumed = false;
       setBusy(true);
       setError(null);
       let started = false;
@@ -4424,12 +4431,16 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         appendSystem(
           `Started Omnigent session ${result.sessionId}. Open: ${result.webUrl}`,
         );
-        void openExternalUrl(result.webUrl);
+        systemBrowserReservationConsumed = true;
+        void openSystemBrowserUrl(result.webUrl, { reservation: systemBrowserReservation });
         announce("Omnigent session started");
         started = true;
       } catch (err) {
         setError(err instanceof Error ? err.message : "Omnigent run failed");
       } finally {
+        if (!systemBrowserReservationConsumed) {
+          cancelSystemBrowserUrlWindow(systemBrowserReservation);
+        }
         setBusy(false);
         if (started) drainNextQueuedMessage();
       }

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -79,6 +79,11 @@ import {
   shouldClearHomeComposerProjectSelection,
 } from "@/lib/home-composer-context";
 import { publishBoardChanged } from "@/lib/board-cache-events";
+import {
+  cancelSystemBrowserUrlWindow,
+  openSystemBrowserUrl,
+  reserveSystemBrowserUrlWindow,
+} from "@/lib/open-external";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -609,6 +614,8 @@ export function HomeComposer({
           requestSummonFamiliar();
           return;
         }
+        const systemBrowserReservation = reserveSystemBrowserUrlWindow();
+        let systemBrowserReservationConsumed = false;
         setSending(true);
         try {
           const { startOmnigentRunFromBrowser } = await import("@/lib/omnigent/browser-run");
@@ -628,9 +635,12 @@ export function HomeComposer({
           clearDraft();
           clearAttachments();
           onToast("Omnigent session started — opening…");
-          const { openExternalUrl } = await import("@/lib/open-external");
-          void openExternalUrl(result.webUrl);
+          systemBrowserReservationConsumed = true;
+          void openSystemBrowserUrl(result.webUrl, { reservation: systemBrowserReservation });
         } finally {
+          if (!systemBrowserReservationConsumed) {
+            cancelSystemBrowserUrlWindow(systemBrowserReservation);
+          }
           setSending(false);
         }
         return;

--- a/src/lib/open-external.test.ts
+++ b/src/lib/open-external.test.ts
@@ -4,6 +4,10 @@ import { readFile } from "node:fs/promises";
 
 const helper = await readFile(new URL("./open-external.ts", import.meta.url), "utf8");
 const about = await readFile(new URL("../components/settings-about.tsx", import.meta.url), "utf8");
+const boardInspector = await readFile(new URL("../components/board-inspector.tsx", import.meta.url), "utf8");
+const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
+const homeComposer = await readFile(new URL("../components/home-composer.tsx", import.meta.url), "utf8");
+const openExternalModule = await import("./open-external.ts");
 
 assert.match(
   helper,
@@ -35,11 +39,108 @@ assert.match(
   /window\.location\.assign\("\/#browser"\)/,
   "callers outside Workspace should route to the Workspace browser surface",
 );
-assert.doesNotMatch(
+assert.match(
   helper,
-  /shell_open|window\.open/,
-  "shared external URL helper should not open the system browser or a new tab",
+  /export function openExternalUrl\(url: string\): void \{\s*openInAppBrowserUrl\(url\);\s*\}/,
+  "legacy external URLs should remain an in-app browser handoff",
 );
+assert.equal(
+  typeof openExternalModule.openSystemBrowserUrl,
+  "function",
+  "cookie-sensitive destinations should have an explicit system-browser opener",
+);
+assert.equal(
+  typeof openExternalModule.reserveSystemBrowserUrlWindow,
+  "function",
+  "async session starts should be able to reserve a browser window during user activation",
+);
+
+if (typeof openExternalModule.openSystemBrowserUrl === "function") {
+  const desktopCalls: Array<[string, unknown]> = [];
+  const desktopOpened = await openExternalModule.openSystemBrowserUrl(
+    "https://fleet.omnigent.example/session/123",
+    {
+      tauri: true,
+      invoke: async (command, args) => {
+        desktopCalls.push([command, args]);
+      },
+    },
+  );
+  assert.equal(desktopOpened, true);
+  assert.deepEqual(desktopCalls, [[
+    "shell_open",
+    { url: "https://fleet.omnigent.example/session/123" },
+  ]]);
+
+  const navigated: string[] = [];
+  let popupClosed = false;
+  const popup = {
+    opener: {} as unknown,
+    closed: false,
+    location: { replace: (url: string) => navigated.push(url) },
+    close: () => { popupClosed = true; },
+  };
+  const reservation = openExternalModule.reserveSystemBrowserUrlWindow({
+    tauri: false,
+    openWindow: () => popup,
+  });
+  const browserOpened = await openExternalModule.openSystemBrowserUrl(
+    "https://fleet.omnigent.example/session/456",
+    { reservation },
+  );
+  assert.equal(browserOpened, true);
+  assert.equal(popup.opener, null);
+  assert.deepEqual(navigated, ["https://fleet.omnigent.example/session/456"]);
+  assert.equal(popupClosed, false);
+
+  const cancelledReservation = openExternalModule.reserveSystemBrowserUrlWindow({
+    tauri: false,
+    openWindow: () => popup,
+  });
+  openExternalModule.cancelSystemBrowserUrlWindow(cancelledReservation);
+  assert.equal(popupClosed, true);
+
+  const fallbacks: string[] = [];
+  const blocked = await openExternalModule.openSystemBrowserUrl(
+    "https://fleet.omnigent.example/session/789",
+    {
+      tauri: false,
+      openWindow: () => null,
+      fallback: (url) => fallbacks.push(url),
+    },
+  );
+  assert.equal(blocked, false);
+  assert.deepEqual(fallbacks, ["https://fleet.omnigent.example/session/789"]);
+
+  let unsafeOpened = false;
+  const unsafe = await openExternalModule.openSystemBrowserUrl(
+    "javascript:alert(1)",
+    {
+      tauri: true,
+      invoke: async () => { unsafeOpened = true; },
+      fallback: () => { unsafeOpened = true; },
+    },
+  );
+  assert.equal(unsafe, false);
+  assert.equal(unsafeOpened, false);
+}
+
+for (const [surface, source] of [
+  ["task inspector", boardInspector],
+  ["chat", chatView],
+  ["home composer", homeComposer],
+] as const) {
+  assert.match(
+    source,
+    /openSystemBrowserUrl\(result\.webUrl, \{ reservation: systemBrowserReservation \}\)/,
+    `${surface} should open Omnigent sessions in the system browser`,
+  );
+  assert.match(
+    source,
+    /const systemBrowserReservation = reserveSystemBrowserUrlWindow\(\);[\s\S]*?const result = await startOmnigentRunFromBrowser/,
+    `${surface} should reserve its browser window before awaiting the Omnigent start`,
+  );
+}
 
 assert.match(
   about,

--- a/src/lib/open-external.ts
+++ b/src/lib/open-external.ts
@@ -15,3 +15,107 @@ export function openInAppBrowserUrl(url: string): void {
 export function openExternalUrl(url: string): void {
   openInAppBrowserUrl(url);
 }
+
+type SystemBrowserPopup = {
+  opener: unknown;
+  readonly closed?: boolean;
+  location: { replace(url: string): void };
+  close?: () => void;
+};
+
+export type SystemBrowserUrlReservation =
+  | { kind: "desktop" }
+  | { kind: "browser"; popup: SystemBrowserPopup }
+  | { kind: "unavailable" };
+
+type OpenSystemBrowserUrlDependencies = {
+  tauri?: boolean;
+  invoke?: (command: string, args: { url: string }) => Promise<unknown>;
+  openWindow?: () => SystemBrowserPopup | null;
+  fallback?: (url: string) => void;
+  reservation?: SystemBrowserUrlReservation;
+};
+
+function safeHttpUrl(rawUrl: string): string | null {
+  try {
+    const url = new URL(rawUrl.trim());
+    return url.protocol === "http:" || url.protocol === "https:"
+      ? url.toString()
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Reserve a popup synchronously while the browser still has user activation. */
+export function reserveSystemBrowserUrlWindow(
+  dependencies: Pick<OpenSystemBrowserUrlDependencies, "tauri" | "openWindow"> = {},
+): SystemBrowserUrlReservation {
+  const tauri = dependencies.tauri
+    ?? (typeof window !== "undefined"
+      && (window as { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ !== undefined);
+  if (tauri) return { kind: "desktop" };
+
+  try {
+    const popup = (dependencies.openWindow
+      ?? (() => window.open("", "_blank") as SystemBrowserPopup | null))();
+    if (!popup) return { kind: "unavailable" };
+    // `noopener` window features discard the WindowProxy that this async handoff
+    // must navigate, so sever the opener synchronously while retaining the handle.
+    popup.opener = null;
+    return { kind: "browser", popup };
+  } catch {
+    return { kind: "unavailable" };
+  }
+}
+
+export function cancelSystemBrowserUrlWindow(
+  reservation: SystemBrowserUrlReservation,
+): void {
+  if (reservation.kind === "browser") reservation.popup.close?.();
+}
+
+/** Open auth-sensitive destinations outside Cave's embedded Browser surface. */
+export async function openSystemBrowserUrl(
+  rawUrl: string,
+  dependencies: OpenSystemBrowserUrlDependencies = {},
+): Promise<boolean> {
+  const reservation = dependencies.reservation
+    ?? reserveSystemBrowserUrlWindow(dependencies);
+  const url = safeHttpUrl(rawUrl);
+  if (!url) {
+    cancelSystemBrowserUrlWindow(reservation);
+    return false;
+  }
+
+  const fallback = dependencies.fallback ?? openInAppBrowserUrl;
+
+  if (reservation.kind === "desktop") {
+    try {
+      const invoke = dependencies.invoke ?? (await import("@tauri-apps/api/core")).invoke;
+      await invoke("shell_open", { url });
+      return true;
+    } catch {
+      fallback(url);
+      return false;
+    }
+  }
+
+  if (reservation.kind === "unavailable") {
+    fallback(url);
+    return false;
+  }
+
+  try {
+    if (reservation.popup.closed) {
+      fallback(url);
+      return false;
+    }
+    reservation.popup.location.replace(url);
+    return true;
+  } catch {
+    cancelSystemBrowserUrlWindow(reservation);
+    fallback(url);
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- open authenticated Omnigent session URLs through the system browser so first-party session cookies work
- reserve web popups synchronously before async session creation and close unused reservations
- fall back to the in-app Browser when a system launch is unavailable
- credit Andrew Peltekci for the original workspace map and follow-up patch

## Verification
- node --test src/lib/open-external.test.ts src/components/board-inspector-a11y.test.ts
- pnpm lint
- pnpm typecheck
- pnpm build, including bundle and standalone budgets
- git diff --check
- signed commit verified with git verify-commit HEAD
- initial implementation: pnpm test:app passed all 1053 files
- review revision: full app rerun reached an unrelated maintenance-gate timing failure while another live repo session held that gate; an isolated rerun failed a different timing case. No maintenance-gate code changed. Fresh protected CI is required before merge.

## Tracking
- Bead: cave-2e1pu
- Re-landed from appletechie/coven-cave:feature/omnigent-host-workspace-map commit 6a5d158308af after the original feature merged in #3247.