### PR TITLE
fix(patrol): scope inventory drift to the units it can affect (cave-63m12)

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1070,6 +1070,86 @@ function fetchPullRequests(
   };
 }
 
+/** Stable identity for a lifecycle unit within one patrol run. */
+function lifecycleUnitKey(unit: { kind: string; path: string | null; ref: string | null }): string {
+  return `${unit.kind}\0${unit.path ?? ""}\0${unit.ref ?? ""}`;
+}
+
+/**
+ * Which units — if any — had their own inputs move while the patrol ran.
+ *
+ * Returns a reason per affected unit; an empty map means nothing a verdict
+ * depends on changed. Throws only when a snapshot cannot be parsed, which the
+ * caller escalates to a whole-run failure.
+ */
+function unitScopedDrift({
+  units,
+  initialWorktreeRaw,
+  initialRefsRaw,
+  finalWorktreeRaw,
+  finalRefsRaw,
+}: {
+  units: Array<{ kind: string; path: string | null; ref: string | null; head: string }>;
+  initialWorktreeRaw: string;
+  initialRefsRaw: string;
+  finalWorktreeRaw: string;
+  finalRefsRaw: string;
+}): Map<string, string> {
+  const drift = new Map<string, string>();
+  if (finalWorktreeRaw === initialWorktreeRaw && finalRefsRaw === initialRefsRaw) {
+    return drift;
+  }
+
+  const finalEntries = parseWorktrees(finalWorktreeRaw);
+  const finalRefs = parseLocalBranchRefs(finalRefsRaw);
+  const finalOidByRef = new Map(finalRefs.map((localRef) => [localRef.ref, localRef.oid]));
+  const finalEntryByPath = new Map(finalEntries.map((entry) => [entry.path, entry]));
+  const pathsByRef = (entries: ReturnType<typeof parseWorktrees>) => {
+    const byRef = new Map<string, string[]>();
+    for (const entry of entries) {
+      if (entry.ref === null) continue;
+      byRef.set(entry.ref, [...(byRef.get(entry.ref) ?? []), entry.path].sort());
+    }
+    return byRef;
+  };
+  const initialPathsByRef = pathsByRef(parseWorktrees(initialWorktreeRaw));
+  const finalPathsByRef = pathsByRef(finalEntries);
+
+  for (const unit of units) {
+    const key = lifecycleUnitKey(unit);
+    if (unit.kind === "worktree" && unit.path !== null) {
+      const entry = finalEntryByPath.get(unit.path);
+      if (!entry) {
+        drift.set(key, "worktree was unregistered while the patrol was running");
+        continue;
+      }
+      if (entry.head !== unit.head || entry.ref !== unit.ref) {
+        drift.set(key, "worktree HEAD moved while the patrol was running");
+        continue;
+      }
+    }
+    if (unit.ref !== null) {
+      const oid = finalOidByRef.get(unit.ref);
+      if (oid === undefined) {
+        drift.set(key, "branch was deleted while the patrol was running");
+        continue;
+      }
+      if (oid !== unit.head) {
+        drift.set(key, "branch moved while the patrol was running");
+        continue;
+      }
+      // A ref gaining or losing a worktree changes what retiring it would mean,
+      // even when the OID held still.
+      const before = (initialPathsByRef.get(unit.ref) ?? []).join("\0");
+      const after = (finalPathsByRef.get(unit.ref) ?? []).join("\0");
+      if (before !== after) {
+        drift.set(key, "the worktrees holding this branch changed while the patrol was running");
+      }
+    }
+  }
+  return drift;
+}
+
 function fetchWorkflowSweep(
   repo: string,
   root: string,
@@ -2600,10 +2680,37 @@ export function collectWorktreeLifecycleInventory(
   ]);
   const finalGrafts = graftInventory(commonGitDir);
   const finalHistoryOverrides = historyOverrideProbe(root, commonGitDir);
-  if (
-    finalWorktreeRaw !== initialWorktreeRaw ||
-    finalRefsRaw !== initialRefsRaw
-  ) {
+  // Local git state moving during the patrol used to abort the entire run. On a
+  // checkout shared by several agents that fires constantly — one session
+  // committing on its own branch discarded a multi-minute inventory of every
+  // other unit — so the patrol could not be run to completion at all
+  // (cave-63m12).
+  //
+  // Drift is now scoped to the units it can actually affect. What each unit's
+  // verdict rests on is its OWN ref OID, its OWN worktree registration, and the
+  // set of worktrees holding its ref. Nothing else in `refs/heads` can change a
+  // conclusion about it: default-branch ancestry is measured against the
+  // REMOTE-tracking ref, which this snapshot does not even cover.
+  //
+  // Two asymmetries make this safe rather than merely convenient:
+  //   - A unit that gained drift is marked `uncertain`, never retired. Losing a
+  //     verdict is free; acting on a stale one is not.
+  //   - Refs and worktrees that APPEAR mid-run are simply absent from this
+  //     report. A unit that is not reported is never retired, so an incomplete
+  //     snapshot is conservative by construction.
+  //
+  // A snapshot that cannot be parsed is still a global failure: that is an
+  // integrity problem rather than ordinary churn.
+  let driftReasonByUnitKey: Map<string, string>;
+  try {
+    driftReasonByUnitKey = unitScopedDrift({
+      units,
+      initialWorktreeRaw,
+      initialRefsRaw,
+      finalWorktreeRaw,
+      finalRefsRaw,
+    });
+  } catch {
     throw new Error("worktree or branch inventory changed during patrol");
   }
   if (
@@ -2684,8 +2791,18 @@ export function collectWorktreeLifecycleInventory(
     ).length,
   });
 
+  // A unit whose own inputs moved carries that as a probe error, which lands it
+  // in `uncertain` — the same posture the whole-run abort had, applied only
+  // where it is warranted.
+  const driftedObservations = observations.map((observation) => {
+    const reason = driftReasonByUnitKey.get(lifecycleUnitKey(observation));
+    return reason === undefined
+      ? observation
+      : { ...observation, probeErrors: [...observation.probeErrors, reason] };
+  });
+
   return {
-    items: observations.map((observation) =>
+    items: driftedObservations.map((observation) =>
       classifyInventoryObservation(observation, options.nowMs),
     ),
     budgets,

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -1100,9 +1100,21 @@ function unitScopedDrift({
     return drift;
   }
 
+  // Drift is measured INITIAL → FINAL, never against the unit's own fields. A
+  // unit can start out inconsistent — a registered worktree whose ref is absent
+  // from the branch inventory, or whose HEAD differs from that ref, both of
+  // which `initialErrors` already reports — and comparing the final snapshot to
+  // those fields would blame the patrol window for a discrepancy that predates
+  // it. Only a real change between the two reads is drift.
+  const initialEntries = parseWorktrees(initialWorktreeRaw);
   const finalEntries = parseWorktrees(finalWorktreeRaw);
-  const finalRefs = parseLocalBranchRefs(finalRefsRaw);
-  const finalOidByRef = new Map(finalRefs.map((localRef) => [localRef.ref, localRef.oid]));
+  const initialOidByRef = new Map(
+    parseLocalBranchRefs(initialRefsRaw).map((localRef) => [localRef.ref, localRef.oid]),
+  );
+  const finalOidByRef = new Map(
+    parseLocalBranchRefs(finalRefsRaw).map((localRef) => [localRef.ref, localRef.oid]),
+  );
+  const initialEntryByPath = new Map(initialEntries.map((entry) => [entry.path, entry]));
   const finalEntryByPath = new Map(finalEntries.map((entry) => [entry.path, entry]));
   const pathsByRef = (entries: ReturnType<typeof parseWorktrees>) => {
     const byRef = new Map<string, string[]>();
@@ -1112,37 +1124,45 @@ function unitScopedDrift({
     }
     return byRef;
   };
-  const initialPathsByRef = pathsByRef(parseWorktrees(initialWorktreeRaw));
+  const initialPathsByRef = pathsByRef(initialEntries);
   const finalPathsByRef = pathsByRef(finalEntries);
 
   for (const unit of units) {
     const key = lifecycleUnitKey(unit);
     if (unit.kind === "worktree" && unit.path !== null) {
-      const entry = finalEntryByPath.get(unit.path);
-      if (!entry) {
-        drift.set(key, "worktree was unregistered while the patrol was running");
-        continue;
-      }
-      if (entry.head !== unit.head || entry.ref !== unit.ref) {
-        drift.set(key, "worktree HEAD moved while the patrol was running");
-        continue;
+      const before = initialEntryByPath.get(unit.path);
+      const after = finalEntryByPath.get(unit.path);
+      if (before !== undefined) {
+        if (after === undefined) {
+          drift.set(key, "worktree was unregistered while the patrol was running");
+          continue;
+        }
+        if (after.head !== before.head || after.ref !== before.ref) {
+          drift.set(key, "worktree HEAD moved while the patrol was running");
+          continue;
+        }
       }
     }
     if (unit.ref !== null) {
-      const oid = finalOidByRef.get(unit.ref);
-      if (oid === undefined) {
-        drift.set(key, "branch was deleted while the patrol was running");
-        continue;
-      }
-      if (oid !== unit.head) {
-        drift.set(key, "branch moved while the patrol was running");
-        continue;
+      const oidBefore = initialOidByRef.get(unit.ref);
+      const oidAfter = finalOidByRef.get(unit.ref);
+      // A ref the initial snapshot never had is not something this window
+      // changed; `initialErrors` already covers that inconsistency.
+      if (oidBefore !== undefined) {
+        if (oidAfter === undefined) {
+          drift.set(key, "branch was deleted while the patrol was running");
+          continue;
+        }
+        if (oidAfter !== oidBefore) {
+          drift.set(key, "branch moved while the patrol was running");
+          continue;
+        }
       }
       // A ref gaining or losing a worktree changes what retiring it would mean,
       // even when the OID held still.
-      const before = (initialPathsByRef.get(unit.ref) ?? []).join("\0");
-      const after = (finalPathsByRef.get(unit.ref) ?? []).join("\0");
-      if (before !== after) {
+      const pathsBefore = (initialPathsByRef.get(unit.ref) ?? []).join("\0");
+      const pathsAfter = (finalPathsByRef.get(unit.ref) ?? []).join("\0");
+      if (pathsBefore !== pathsAfter) {
         drift.set(key, "the worktrees holding this branch changed while the patrol was running");
       }
     }
@@ -2710,8 +2730,11 @@ export function collectWorktreeLifecycleInventory(
       finalWorktreeRaw,
       finalRefsRaw,
     });
-  } catch {
-    throw new Error("worktree or branch inventory changed during patrol");
+  } catch (error) {
+    // Keep the parse failure attached: this is now the ONLY whole-run abort, so
+    // "changed during patrol" with no detail would be the least diagnosable
+    // message in the script.
+    throw new Error("worktree or branch inventory changed during patrol", { cause: error });
   }
   if (
     finalHistoryOverrides.replaceRefsState !== initialHistoryOverrides.replaceRefsState ||

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1283,6 +1283,13 @@ if [ "\${LIFECYCLE_DRIFT:-0}" = "1" ] && [ ! -e "${path.join(fixtureRoot, "drift
   touch "${path.join(fixtureRoot, "drift-once")}"
   git -C "${repo}" branch feat/drift origin/main
 fi
+# Moves an EXISTING unit's ref rather than adding a new one. feat/branch-only
+# has no worktree, so this is exactly "another session committed on its branch"
+# — the case that must invalidate that one unit and nothing else (cave-63m12).
+if [ "\${LIFECYCLE_UNIT_DRIFT:-0}" = "1" ] && [ ! -e "${path.join(fixtureRoot, "unit-drift-once")}" ]; then
+  touch "${path.join(fixtureRoot, "unit-drift-once")}"
+  git -C "${repo}" update-ref refs/heads/feat/branch-only ${JSON.stringify(defaultHead)}
+fi
 if [ "\${LIFECYCLE_GRAFT_DRIFT:-0}" = "1" ]; then
   printf '%s %s\n' ${JSON.stringify(defaultHead)} ${JSON.stringify(oldHead)} > ${JSON.stringify(path.join(repo, ".git", "info", "grafts"))}
 fi
@@ -3314,11 +3321,45 @@ exit 0
   );
   assert.equal(readFileSync(path.join(live, "uncommitted.txt"), "utf8"), "live\n");
 
-  assert.throws(
-    () => patrol(["--json"], { LIFECYCLE_DRIFT: "1" }),
-    /worktree or branch inventory changed during patrol/,
-    "a concurrent branch change aborts instead of returning an incomplete success",
-  );
+  // A branch APPEARING mid-run no longer discards the whole inventory
+  // (cave-63m12). The new ref is simply absent from this report, and a unit that
+  // is not reported is never retired — so an incomplete snapshot is
+  // conservative rather than dangerous. Every unit that did not move keeps the
+  // verdict the patrol spent minutes computing.
+  {
+    const addedReport = JSON.parse(patrol(["--json"], { LIFECYCLE_DRIFT: "1" }));
+    const addedOld = addedReport.items.find((item) => item.branch === "feat/old");
+    assert.ok(addedOld, "a concurrent branch addition still returns a report");
+    assert.doesNotMatch(
+      addedOld.probeErrors.join("\n"),
+      /during the patrol|during patrol/i,
+      "an unrelated branch appearing does not taint other units",
+    );
+    assert.equal(
+      addedReport.items.some((item) => item.branch === "feat/drift"),
+      false,
+      "a ref that appeared mid-run is out of scope for this report",
+    );
+  }
+
+  // A unit whose OWN ref moved is the case that must still fail closed — but
+  // only for that unit.
+  {
+    const movedReport = JSON.parse(patrol(["--json"], { LIFECYCLE_UNIT_DRIFT: "1" }));
+    const movedUnit = movedReport.items.find((item) => item.branch === "feat/branch-only");
+    assert.equal(movedUnit.lane, "uncertain", "a unit whose branch moved fails closed");
+    assert.match(
+      movedUnit.probeErrors.join("\n"),
+      /branch moved while the patrol was running/,
+      "the drifted unit says what moved",
+    );
+    const untouched = movedReport.items.find((item) => item.branch === "feat/old");
+    assert.doesNotMatch(
+      untouched.probeErrors.join("\n"),
+      /while the patrol was running/,
+      "one unit's drift does not invalidate its neighbours",
+    );
+  }
 
   let graftDriftError;
   try {
@@ -3347,17 +3388,27 @@ exit 0
     "worktree-lifecycle-patrol: history override inventory changed during patrol",
   );
 
-  let registrationDriftError;
-  try {
-    patrol(["--json"], { LIFECYCLE_WORKTREE_DRIFT: "1", NODE_NO_WARNINGS: "1" });
-  } catch (error) {
-    registrationDriftError = error;
+  // A worktree REGISTERED mid-run is detached — no ref, and a path no existing
+  // unit owns — so it cannot change any verdict already computed. Like a new
+  // branch, it is out of scope for this report rather than a reason to discard
+  // it (cave-63m12).
+  {
+    const registeredReport = JSON.parse(
+      patrol(["--json"], { LIFECYCLE_WORKTREE_DRIFT: "1", NODE_NO_WARNINGS: "1" }),
+    );
+    const registeredOld = registeredReport.items.find((item) => item.branch === "feat/old");
+    assert.ok(registeredOld, "a concurrent worktree registration still returns a report");
+    assert.doesNotMatch(
+      registeredOld.probeErrors.join("\n"),
+      /while the patrol was running/,
+      "a worktree registered elsewhere does not taint unrelated units",
+    );
+    assert.equal(
+      registeredReport.items.some((item) => item.path === registeredDrift),
+      false,
+      "a worktree registered mid-run is out of scope for this report",
+    );
   }
-  assert.ok(registrationDriftError, "a concurrent worktree registration must abort patrol");
-  assert.equal(
-    registrationDriftError.stderr.trim(),
-    "worktree-lifecycle-patrol: worktree or branch inventory changed during patrol",
-  );
 } finally {
   if (existsSync(registeredDrift)) {
     git(["worktree", "remove", registeredDrift], repo);

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -3347,6 +3347,7 @@ exit 0
   {
     const movedReport = JSON.parse(patrol(["--json"], { LIFECYCLE_UNIT_DRIFT: "1" }));
     const movedUnit = movedReport.items.find((item) => item.branch === "feat/branch-only");
+    assert.ok(movedUnit, "the drifted unit is still reported");
     assert.equal(movedUnit.lane, "uncertain", "a unit whose branch moved fails closed");
     assert.match(
       movedUnit.probeErrors.join("\n"),
@@ -3354,6 +3355,7 @@ exit 0
       "the drifted unit says what moved",
     );
     const untouched = movedReport.items.find((item) => item.branch === "feat/old");
+    assert.ok(untouched, "its neighbours are still reported");
     assert.doesNotMatch(
       untouched.probeErrors.join("\n"),
       /while the patrol was running/,


### PR DESCRIPTION
Closes `cave-63m12`. Third and last of the fail-on-drift instances behind `cave-v59dk` (#4232).

## The problem

`collectWorktreeLifecycleInventory` snapshots `git worktree list` and `for-each-ref refs/heads` at the start, re-reads them at the end, and throws **"worktree or branch inventory changed during patrol"** if either moved.

The check is *correct* — the classification would otherwise describe a snapshot that no longer exists. What was missing is recovery. A patrol run takes minutes, this checkout is shared by ~10 agents, and **any** branch OID moving anywhere discarded the entire inventory. It could not be run to completion here.

Diagnosed live rather than guessed: diffing the inventory across a run showed another session had removed the `fix/familiar-defaults` worktree and branch mid-patrol.

## The fix

Drift is scoped to the units it can actually affect. A unit's verdict rests on:

- its own ref OID
- its own worktree registration
- the set of worktrees holding its ref (a ref gaining or losing a worktree changes what retiring it would mean, even when the OID held still)

Nothing else in `refs/heads` can change a conclusion about it. Default-branch ancestry is measured against the **remote-tracking** ref, which this snapshot does not cover — so a local `main` moving cannot silently alter landedness either.

## Why this is safe, not just convenient

Two asymmetries carry it:

- A unit that gained drift is marked **`uncertain`**, never retired. Losing a verdict is free; acting on a stale one is not.
- Refs and worktrees that **appear** mid-run are simply absent from the report. A unit that is not reported is never retired, so an incomplete snapshot is conservative by construction.

A snapshot that cannot be **parsed** is still a whole-run failure — that is an integrity problem rather than ordinary churn.

## Coverage

Three cases, replacing two that asserted the global abort:

- a branch appearing mid-run → report still returned, other units untainted, the new ref out of scope
- a worktree registered mid-run (detached, so no ref and a path no unit owns) → same
- **a unit's own branch moving** → that unit is `uncertain` and says what moved, while its neighbours keep their verdicts

## Verification

Live on the shared checkout — three consecutive runs, all exit 0, **identical lane counts**:

```
run 1: 38 registered | 21 active | 1 recovery | 2 cooldown | 2 cleanup-ready | 10 uncertain | 2 protected
run 2: 38 registered | 21 active | 1 recovery | 2 cooldown | 2 cleanup-ready | 10 uncertain | 2 protected
run 3: 39 registered | 22 active | 1 recovery | 2 cooldown | 2 cleanup-ready | 10 uncertain | 2 protected
```

Run 3 absorbed a worktree another session created mid-run instead of aborting. Before #4232 and this change, identical local state produced three *different* verdicts in ten minutes.

Gates: `typecheck` · `lint` · `worktree-lifecycle-patrol.test.mjs` (141 patrols) all green.
