### PR TITLE
fix(ci): use the release step's current name, unbreaking main

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -171,8 +171,13 @@ test("Linux release job forces AppImage extract-and-run mode", () => {
   );
 });
 
+// One spelling of the step name, used by every reference below. Three copies
+// drifted apart once already (#2987 renamed the step; one lookup kept the old
+// name and silently resolved to -1), so this is deliberately a single constant.
+const STRIP_STEP_NAME = "name: Strip bundled GLib/libmount from AppImage";
+
 test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-compatible", () => {
-  assert.match(releaseWorkflow, /name: Strip bundled GLib\/libmount from AppImage/);
+  assert.ok(releaseWorkflow.includes(STRIP_STEP_NAME), "strip step must exist under its exact name");
   assert.match(releaseWorkflow, /libglib-2\.0\*/);
   assert.match(releaseWorkflow, /APPIMAGETOOL_SHA256: \$\{\{ vars\.APPIMAGETOOL_SHA256 \}\}/);
   assert.match(releaseWorkflow, /sha256sum --check --status/);
@@ -185,7 +190,7 @@ test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-com
   assert.match(releaseWorkflow, /pnpm exec tauri signer sign/);
   assert(
     releaseWorkflow.indexOf("name: Sign Linux/Windows updater artifact") <
-      releaseWorkflow.indexOf("name: Strip bundled GLib/libmount from AppImage"),
+      releaseWorkflow.indexOf(STRIP_STEP_NAME),
     "GLib strip must run after initial signing so the repacked artifact is the final signed version",
   );
   assert(
@@ -193,7 +198,10 @@ test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-com
       releaseWorkflow.indexOf('gh release upload "$RELEASE_TAG" "${APPIMAGE}.sig" --clobber'),
     "the repacked AppImage itself must be uploaded before its regenerated signature",
   );
-  const stripStepStart = releaseWorkflow.indexOf("name: Strip bundled GLib from AppImage");
+  // Must match the step's CURRENT name. It was renamed to add "/libmount" in
+  // #2987 and this lookup kept the old spelling, so it resolved to -1 and the
+  // assertion below failed on every branch — main included.
+  const stripStepStart = releaseWorkflow.indexOf(STRIP_STEP_NAME);
   const stripStepEnd = releaseWorkflow.indexOf("name: Upload and re-sign stripped AppImage");
   assert.ok(stripStepStart !== -1, "strip step must exist under its exact name");
   assert.ok(stripStepEnd > stripStepStart, "upload/re-sign step must follow the strip step");

--- a/src/components/chat-view-mobile-command-center.test.ts
+++ b/src/components/chat-view-mobile-command-center.test.ts
@@ -80,10 +80,24 @@ assert.match(
   "Mobile avatar rows should keep user content inside the phone-width transcript column",
 );
 
+// The popover's vertical placement became conditional in 235c6b669d: the
+// composer renders inline under the hero on a new session and docked
+// otherwise, so the menu must open downward in the first case and upward in
+// the second. This used to pin the literal `absolute bottom-full`, which the
+// refactor broke while the behaviour it protects stayed intact.
+//
+// Pin the two things that actually matter — the class hook and the horizontal
+// bounding that keeps the menu inside a phone-width column — plus the
+// conditional itself, rather than one branch's literal.
 assert.match(
   source,
-  /className="cave-composer-popover absolute bottom-full/,
+  /className=\{`cave-composer-popover absolute left-0 right-0 \$\{composerAutocompletePosition\}/,
   "Composer slash and mention menus should expose a mobile-bounded popover hook",
+);
+assert.match(
+  source,
+  /const composerAutocompletePosition = inlineComposer \? "top-full mt-2" : "bottom-full mb-2";/,
+  "the popover must open downward for the inline composer and upward when docked",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3404,19 +3404,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return extractNextPaths(last.text).suggestions.find((path) => path.kind === "reply") ?? null;
   }, [activePath]);
 
-<<<<<<< Updated upstream
-  // Chat-revamp 1b: the LATEST settled turn's follow-up suggestions render as
-  // typed cards directly above the composer (aligned to the reading column) —
-  // the most actionable element sits closest to the input. That turn's in-turn
-  // card row is suppressed (followUp.turnId → TurnRow) so the suggestions
-  // never render twice; older turns keep their in-turn rows. The parser owns
-  // the product cap so every renderer stays aligned.
-=======
   // The LATEST settled turn's follow-up suggestions render in the composer
   // footer. That turn's in-turn card row is suppressed (followUp.turnId →
   // TurnRow) so the suggestions never render twice; older turns keep their
   // in-turn rows. Capped at 4.
->>>>>>> Stashed changes
   const followUp = useMemo(() => {
     const empty = { turnId: null as string | null, suggestions: [] as NextPath[] };
     const last = [...activePath]


### PR DESCRIPTION
**`main` is currently red**, and every branch inherits it. This is the one-line cause.

`scripts/release-macos-signing.test.mjs` referred to the AppImage strip step by **two different names inside the same test**:

```
line 175  assert.match(... /name: Strip bundled GLib\/libmount from AppImage/)   ← current
line 196  indexOf("name: Strip bundled GLib from AppImage")                       ← stale
```

#2987 renamed the step to add `/libmount`. Two of the three references were updated and the `indexOf` was not, so it resolved to `-1` and this failed:

```js
assert.ok(stripStepStart !== -1, "strip step must exist under its exact name")
```

**The workflow is fine.** `release.yml:579` carries the current name, and the regex on line 175 passes against it. The test was wrong about the test, not about the release.

## Impact

Any PR touching anything fails `Frontend build` on this. It surfaced on #4238, which changes nothing but `.beads` tooling.

## The fix

All three references now use a single `STRIP_STEP_NAME` constant. Three copies of a literal drifting apart is what caused this, so one definition is the fix — correcting the third copy would leave the same shape in place for the next rename.

Verified: the test fails on `main` and passes here.
