### PR TITLE
fix(test): match the AppImage strip step by shape, not exact title (cave-ewnel)

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -193,9 +193,19 @@ test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-com
       releaseWorkflow.indexOf('gh release upload "$RELEASE_TAG" "${APPIMAGE}.sig" --clobber'),
     "the repacked AppImage itself must be uploaded before its regenerated signature",
   );
-  const stripStepStart = releaseWorkflow.indexOf("name: Strip bundled GLib from AppImage");
+  // Match the step by shape rather than by its exact title. What this guard is
+  // actually about is the SLICE — the lines below assert the strip step carries
+  // no GH_TOKEN and no signing key — and pinning the full name coupled that
+  // safety check to cosmetic wording. #2987 added libmount stripping, renamed
+  // the step to "Strip bundled GLib/libmount from AppImage", and turned main
+  // red on a required check (cave-ewnel).
+  const stripStepMatch = releaseWorkflow.match(/name: Strip bundled [^\n]*AppImage/);
+  const stripStepStart = stripStepMatch?.index ?? -1;
   const stripStepEnd = releaseWorkflow.indexOf("name: Upload and re-sign stripped AppImage");
-  assert.ok(stripStepStart !== -1, "strip step must exist under its exact name");
+  assert.ok(
+    stripStepStart !== -1,
+    "strip step must exist (a step named 'Strip bundled … AppImage')",
+  );
   assert.ok(stripStepEnd > stripStepStart, "upload/re-sign step must follow the strip step");
   const stripStep = releaseWorkflow.slice(stripStepStart, stripStepEnd);
   assert.ok(stripStep.length > 0, "strip-step slice must be non-empty for the secret-isolation guard to mean anything");


### PR DESCRIPTION
Closes `cave-ewnel`. **`main` is red on a required check and every PR is blocked behind it.**

## What broke

`ci.yml`'s **Frontend build** job runs `pnpm test:api`, which fails:

```
AssertionError: strip step must exist under its exact name
  scripts/release-macos-signing.test.mjs:198
```

#2987 (*"fix(release): strip libmount from linux appimage"*, `19afb1a3bc`) renamed the workflow step to **"Strip bundled GLib/libmount from AppImage"**. The test still looked for **"Strip bundled GLib from AppImage"**. Main went red at `131e763bc`.

## What the assertion is actually for

It is not a naming check. It locates the strip step so the next lines can prove that step carries **neither `GH_TOKEN` nor `TAURI_SIGNING_PRIVATE_KEY`** — a secret-isolation guard on a step that repacks a release artifact.

Failing closed on a missed match is therefore correct and stays: if `indexOf` returns `-1`, the slice becomes the **whole file**, and `doesNotMatch` against the entire workflow would be vacuously... well, actually false — but for the wrong reason, and a `-1` slice is nonsense either way.

What was wrong is coupling a security check to cosmetic wording. The step is now matched by shape:

```js
releaseWorkflow.match(/name: Strip bundled [^\n]*AppImage/)
```

## Verified the guard still bites

```
matched: "name: Strip bundled GLib/libmount from AppImage"
slice:   2,996 chars of 53,310   (a real step, not the whole file)
GH_TOKEN in slice: false | TAURI_SIGNING_PRIVATE_KEY in slice: false
```

Confirmed pre-existing: the failure reproduces on a pristine detached checkout of `origin/main`, so it is not from any open branch.

## Separately filed, not fixed here

Running the full `test:api` locally after this fix gets 57 tests further and then hits `scripts/sidecar-runtime-closure.test.mjs`, which is **macOS-only**: the allowed-root check compares an unresolved `/var/folders/…` path against a realpath'd `/private/var/folders/…` one, so a link is judged to escape a root it is actually inside. CI never reached that test (it stopped at 251; this one sorts at 308) and Linux does not symlink `/tmp`. Filed as its own bug — it means a Mac dev cannot complete the api suite, which hides anything later in it.
