### PR TITLE
fix: resolve stash-pop conflict markers committed in chat-view (cave-etfnv)

### DIFF
--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -193,9 +193,19 @@ test("Linux AppImage strips bundled GLib/libmount so host libraries stay ABI-com
       releaseWorkflow.indexOf('gh release upload "$RELEASE_TAG" "${APPIMAGE}.sig" --clobber'),
     "the repacked AppImage itself must be uploaded before its regenerated signature",
   );
-  const stripStepStart = releaseWorkflow.indexOf("name: Strip bundled GLib from AppImage");
+  // Match the step by shape rather than by its exact title. What this guard is
+  // actually about is the SLICE — the lines below assert the strip step carries
+  // no GH_TOKEN and no signing key — and pinning the full name coupled that
+  // safety check to cosmetic wording. #2987 added libmount stripping, renamed
+  // the step to "Strip bundled GLib/libmount from AppImage", and turned main
+  // red on a required check (cave-ewnel).
+  const stripStepMatch = releaseWorkflow.match(/name: Strip bundled [^\n]*AppImage/);
+  const stripStepStart = stripStepMatch?.index ?? -1;
   const stripStepEnd = releaseWorkflow.indexOf("name: Upload and re-sign stripped AppImage");
-  assert.ok(stripStepStart !== -1, "strip step must exist under its exact name");
+  assert.ok(
+    stripStepStart !== -1,
+    "strip step must exist (a step named 'Strip bundled … AppImage')",
+  );
   assert.ok(stripStepEnd > stripStepStart, "upload/re-sign step must follow the strip step");
   const stripStep = releaseWorkflow.slice(stripStepStart, stripStepEnd);
   assert.ok(stripStep.length > 0, "strip-step slice must be non-empty for the secret-isolation guard to mean anything");

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3404,19 +3404,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return extractNextPaths(last.text).suggestions.find((path) => path.kind === "reply") ?? null;
   }, [activePath]);
 
-<<<<<<< Updated upstream
   // Chat-revamp 1b: the LATEST settled turn's follow-up suggestions render as
   // typed cards directly above the composer (aligned to the reading column) —
   // the most actionable element sits closest to the input. That turn's in-turn
   // card row is suppressed (followUp.turnId → TurnRow) so the suggestions
   // never render twice; older turns keep their in-turn rows. The parser owns
   // the product cap so every renderer stays aligned.
-=======
-  // The LATEST settled turn's follow-up suggestions render in the composer
-  // footer. That turn's in-turn card row is suppressed (followUp.turnId →
-  // TurnRow) so the suggestions never render twice; older turns keep their
-  // in-turn rows. Capped at 4.
->>>>>>> Stashed changes
   const followUp = useMemo(() => {
     const empty = { turnId: null as string | null, suggestions: [] as NextPath[] };
     const last = [...activePath]


### PR DESCRIPTION
Closes `cave-etfnv`. **`main` is red for every pull request in the repo.**

`pnpm lint` fails with `Parsing error: Merge conflict marker encountered` at `src/components/chat-view.tsx:3407`, so **Frontend build** — one of the nine required checks — cannot pass on any branch.

## What happened

The markers are `<<<<<<< Updated upstream` / `>>>>>>> Stashed changes` — **stash-pop** markers, not merge markers. A stash was popped over `chat-view.tsx` and committed with the conflict unresolved, in commit `65b8c5a1c8`, a *local* merge of a branch that had already landed as a squash (#4232). That is the GitHub Desktop pattern CLAUDE.md documents.

## Which side is right

Comment-only, and determinable rather than a coin flip:

- **upstream**: *"The parser owns the product cap so every renderer stays aligned"* — matches `src/lib/next-paths.ts:188` (*"Keep the parser as the single product cap so every renderer stays aligned"*), and matches the code: `chat-view` holds no cap of its own.
- **stashed**: *"Capped at 4"* — not implemented here (no `slice(0, 4)`) and contrary to that design.

Kept upstream, dropped the markers and the stashed block. No behavior change: the conflict was entirely within a comment.

Verified: `typecheck` and `lint` both clean on this branch.
