### PR TITLE
fix(hooks): stop the installer disabling the hooks it does not own

### DIFF
--- a/.beads/hooks/commit-msg
+++ b/.beads/hooks/commit-msg
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# cave-7g7py: run the repository's commit-msg hook from the beads hook path.
+#
+# core.hooksPath is a single directory — git looks for every hook in exactly
+# one place. Clones point it at .beads/hooks (bd sets it), which had no
+# commit-msg, so scripts/git-hooks/commit-msg was NOT running: the guard that
+# requires Co-authored-by trailers to credit a person with GitHub's numeric
+# no-reply identity was silently inactive. That is the rule AGENTS.md and
+# CLAUDE.md exist to enforce, after a session added AI-attribution trailers
+# across eight merged PRs.
+#
+# A shim rather than a copy, deliberately. The two pre-commit hooks already
+# drifted into a 51-line difference by being maintained as separate copies;
+# duplicating commit-msg would set up the same failure. One implementation
+# lives in scripts/git-hooks/commit-msg and both hook paths reach it.
+set -euo pipefail
+
+REPO_ROOT=$(git rev-parse --show-toplevel)
+TARGET="$REPO_ROOT/scripts/git-hooks/commit-msg"
+
+# Missing implementation must FAIL, not pass silently: a commit-msg guard that
+# quietly no-ops is indistinguishable from one that approved the message.
+if [ ! -x "$TARGET" ]; then
+  if [ -f "$TARGET" ]; then
+    exec bash "$TARGET" "$@"
+  fi
+  printf '%s\n' "[commit-msg blocked] scripts/git-hooks/commit-msg is missing — cannot verify trailers" >&2
+  exit 1
+fi
+
+exec "$TARGET" "$@"

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,38 +1,76 @@
 #!/usr/bin/env bash
-# Point this clone's git hooks at scripts/git-hooks so the tracked
-# pre-commit secret scanner runs locally.
+# Install this clone's local git configuration: the hook path and the
+# .beads/*.jsonl merge driver. Neither can be committed — both live in
+# .git/config, which is per-clone.
 #
 # Idempotent. Run once per fresh clone:
 #     scripts/install-git-hooks.sh
+#
+# cave-7g7py: this script used to set core.hooksPath unconditionally. Clones
+# point it at .beads/hooks (bd sets it there), and .beads/hooks holds strictly
+# more than scripts/git-hooks — beads' post-checkout/post-merge/pre-push/
+# prepare-commit-msg, plus the duplicate-id guard from #4231 that
+# scripts/git-hooks/pre-commit does not carry. Overwriting the path therefore
+# DISABLED all of those. The script advertised as the way to activate the
+# duplicate-prevention merge driver was removing the duplicate-detection hook
+# in the same breath.
 set -euo pipefail
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
-HOOKS_DIR="$REPO_ROOT/scripts/git-hooks"
+FALLBACK_HOOKS="scripts/git-hooks"
 
-if [ ! -d "$HOOKS_DIR" ]; then
-  echo "scripts/git-hooks not found — run from a coven-cave clone" >&2
+if [ ! -d "$REPO_ROOT/$FALLBACK_HOOKS" ]; then
+  echo "$FALLBACK_HOOKS not found — run from a coven-cave clone" >&2
   exit 1
 fi
 
-chmod +x "$HOOKS_DIR"/* 2>/dev/null || true
-git -C "$REPO_ROOT" config core.hooksPath scripts/git-hooks
+chmod +x "$REPO_ROOT/$FALLBACK_HOOKS"/* 2>/dev/null || true
+chmod +x "$REPO_ROOT/.beads/hooks"/* 2>/dev/null || true
 
-echo "OK core.hooksPath -> scripts/git-hooks"
-echo "  installed hooks: $(ls "$HOOKS_DIR" | xargs)"
+current=$(git -C "$REPO_ROOT" config --get core.hooksPath || true)
+
+# Compare resolved paths: bd writes an ABSOLUTE hooksPath, so a string compare
+# against ".beads/hooks" would miss it and clobber the very thing this guard
+# exists to protect.
+resolved_current=""
+if [ -n "$current" ]; then
+  case "$current" in
+    /*) resolved_current="$current" ;;
+    *)  resolved_current="$REPO_ROOT/$current" ;;
+  esac
+fi
+
+if [ -n "$resolved_current" ] && [ -d "$resolved_current" ] \
+   && [ "$resolved_current" != "$REPO_ROOT/$FALLBACK_HOOKS" ]; then
+  echo "KEEP core.hooksPath -> $current"
+  echo "  left alone: it already points at a hook directory, and replacing it"
+  echo "  would silently disable every hook living there (cave-7g7py)."
+  echo "  hooks present: $(ls "$resolved_current" 2>/dev/null | xargs)"
+  missing=""
+  for hook in pre-commit commit-msg; do
+    [ -e "$resolved_current/$hook" ] || missing="$missing $hook"
+  done
+  if [ -n "$missing" ]; then
+    echo "  WARNING missing hook(s):$missing — those guards are NOT running." >&2
+    echo "  Add a shim in that directory that execs $FALLBACK_HOOKS/<hook>." >&2
+  fi
+else
+  git -C "$REPO_ROOT" config core.hooksPath "$FALLBACK_HOOKS"
+  echo "OK core.hooksPath -> $FALLBACK_HOOKS"
+  echo "  installed hooks: $(ls "$REPO_ROOT/$FALLBACK_HOOKS" | xargs)"
+fi
 
 # cave-1poit: register the .beads/interactions.jsonl merge driver named in
-# .gitattributes. A merge driver's implementation lives in git config, which is
-# per-clone and cannot be committed, so this has to be installed rather than
-# checked in. Until it is, git falls back to the default text merge — a
-# divergent append conflicts loudly instead of silently duplicating records,
+# .gitattributes. Runs unconditionally — it is independent of the hook path,
+# and the hook decision above must never determine whether the driver gets
+# installed. Until it is registered git falls back to the default text merge:
+# a divergent append conflicts loudly instead of silently duplicating records,
 # which is the correct direction to fail.
 git -C "$REPO_ROOT" config merge.beads-jsonl.name \
   "union .beads/interactions.jsonl by record id (cave-1poit)"
-# %O/%A/%B are QUOTED: git substitutes paths into this command and runs it
-# through a shell, so an unquoted placeholder is word-split when a path
-# contains a space — which happens on any clone under a home directory with a
-# space in it. The driver would then receive broken arguments and silently do
-# the wrong thing.
+# %O/%A/%B are quoted as defence in depth. Measured behaviour is that git
+# substitutes relative, space-free temp names, so this is not load-bearing —
+# see the note in scripts/beads-jsonl-merge-driver.mjs before "fixing" it.
 git -C "$REPO_ROOT" config merge.beads-jsonl.driver \
   'node scripts/beads-jsonl-merge-driver.mjs "%O" "%A" "%B"'
 

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -46,13 +46,25 @@ if [ -n "$resolved_current" ] && [ -d "$resolved_current" ] \
   echo "  left alone: it already points at a hook directory, and replacing it"
   echo "  would silently disable every hook living there (cave-7g7py)."
   echo "  hooks present: $(ls "$resolved_current" 2>/dev/null | xargs)"
+  # -x, not -e: git only runs a hook that is EXECUTABLE. A present but
+  # non-executable file is exactly the silent no-op this script exists to
+  # surface, so treat it as a distinct, louder case rather than "fine".
   missing=""
+  not_exec=""
   for hook in pre-commit commit-msg; do
-    [ -e "$resolved_current/$hook" ] || missing="$missing $hook"
+    if [ ! -e "$resolved_current/$hook" ]; then
+      missing="$missing $hook"
+    elif [ ! -x "$resolved_current/$hook" ]; then
+      not_exec="$not_exec $hook"
+    fi
   done
   if [ -n "$missing" ]; then
     echo "  WARNING missing hook(s):$missing — those guards are NOT running." >&2
     echo "  Add a shim in that directory that execs $FALLBACK_HOOKS/<hook>." >&2
+  fi
+  if [ -n "$not_exec" ]; then
+    echo "  WARNING non-executable hook(s):$not_exec — present but git will NOT run them." >&2
+    echo "  Fix with: chmod +x $resolved_current/<hook>" >&2
   fi
 else
   git -C "$REPO_ROOT" config core.hooksPath "$FALLBACK_HOOKS"

--- a/scripts/install-git-hooks.test.mjs
+++ b/scripts/install-git-hooks.test.mjs
@@ -1,0 +1,153 @@
+// cave-7g7py: the hook installer must not disable hooks it does not own.
+//
+// The failure it guards against: core.hooksPath is a SINGLE directory, so
+// pointing it somewhere new silently disables every hook in the old place.
+// Clones point it at .beads/hooks, which holds strictly more than
+// scripts/git-hooks — beads' lifecycle hooks plus the duplicate-id guard from
+// #4231. The installer overwrote it unconditionally, so the script documented
+// as the way to activate the duplicate-prevention merge driver removed the
+// duplicate-detection hook at the same time.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const installer = join(repoRoot, "scripts", "install-git-hooks.sh");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/** A throwaway clone carrying just the files the installer touches. */
+function scaffold() {
+  const dir = mkdtempSync(join(tmpdir(), "hook-install-"));
+  git(dir, "init", "-q", "-b", "main");
+  mkdirSync(join(dir, "scripts", "git-hooks"), { recursive: true });
+  mkdirSync(join(dir, ".beads", "hooks"), { recursive: true });
+  cpSync(installer, join(dir, "scripts", "install-git-hooks.sh"));
+  for (const hook of ["pre-commit", "commit-msg"]) {
+    writeFileSync(join(dir, "scripts", "git-hooks", hook), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+  }
+  return dir;
+}
+
+function runInstaller(dir) {
+  return execFileSync("bash", [join(dir, "scripts", "install-git-hooks.sh")], {
+    cwd: dir,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+test("an existing hooksPath is PRESERVED, not overwritten", () => {
+  const dir = scaffold();
+  try {
+    // Mirror the real clone: bd points hooksPath at .beads/hooks and puts its
+    // own hooks there, including ones scripts/git-hooks has no copy of.
+    for (const hook of ["pre-commit", "commit-msg", "post-merge", "pre-push"]) {
+      writeFileSync(join(dir, ".beads", "hooks", hook), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    }
+    git(dir, "config", "core.hooksPath", ".beads/hooks");
+
+    const out = runInstaller(dir);
+    assert.equal(
+      git(dir, "config", "--get", "core.hooksPath"),
+      ".beads/hooks",
+      "the installer must not hijack a hooksPath that already points somewhere",
+    );
+    assert.match(out, /KEEP core\.hooksPath/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("bd's ABSOLUTE hooksPath is recognised, not clobbered", () => {
+  // The real clone stores an absolute path. A naive string compare against
+  // ".beads/hooks" would miss it and overwrite the very thing being protected.
+  const dir = scaffold();
+  try {
+    for (const hook of ["pre-commit", "commit-msg"]) {
+      writeFileSync(join(dir, ".beads", "hooks", hook), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    }
+    const absolute = join(dir, ".beads", "hooks");
+    git(dir, "config", "core.hooksPath", absolute);
+
+    runInstaller(dir);
+    assert.equal(
+      git(dir, "config", "--get", "core.hooksPath"),
+      absolute,
+      "an absolute hooksPath must be preserved too",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an unset hooksPath is still installed", () => {
+  const dir = scaffold();
+  try {
+    const out = runInstaller(dir);
+    assert.equal(git(dir, "config", "--get", "core.hooksPath"), "scripts/git-hooks");
+    assert.match(out, /OK core\.hooksPath/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a preserved hook directory missing a guard WARNS rather than passing silently", () => {
+  // The live gap this bead found: .beads/hooks had no commit-msg, so the
+  // contributor-attribution guard was not running and nothing said so.
+  const dir = scaffold();
+  try {
+    writeFileSync(join(dir, ".beads", "hooks", "pre-commit"), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+    git(dir, "config", "core.hooksPath", ".beads/hooks");
+    const proc = execFileSync("bash", [join(dir, "scripts", "install-git-hooks.sh")], {
+      cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+    });
+    // stderr is merged into the thrown output only on failure; capture both by
+    // re-running with 2>&1 semantics via the shell.
+    const combined = execFileSync("bash", ["-c", `bash "${dir}/scripts/install-git-hooks.sh" 2>&1`], {
+      cwd: dir, encoding: "utf8",
+    });
+    assert.match(combined, /WARNING missing hook\(s\): commit-msg/, "a missing guard must be reported");
+    assert.ok(proc.length >= 0);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the merge driver is registered regardless of the hook decision", () => {
+  // The driver must never be collateral damage of the hooks branch — that
+  // coupling is what made the original script unsafe to run at all.
+  for (const preset of ["unset", "preserved"]) {
+    const dir = scaffold();
+    try {
+      if (preset === "preserved") {
+        for (const hook of ["pre-commit", "commit-msg"]) {
+          writeFileSync(join(dir, ".beads", "hooks", hook), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o755 });
+        }
+        git(dir, "config", "core.hooksPath", ".beads/hooks");
+      }
+      runInstaller(dir);
+      assert.equal(
+        git(dir, "config", "--get", "merge.beads-jsonl.driver"),
+        'node scripts/beads-jsonl-merge-driver.mjs "%O" "%A" "%B"',
+        `driver must be registered when hooksPath is ${preset}`,
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+test(".beads/hooks carries a commit-msg shim so the attribution guard runs", () => {
+  // core.hooksPath is one directory: without this file, scripts/git-hooks/
+  // commit-msg never executes on a clone using the beads hook path.
+  const shim = readFileSync(join(repoRoot, ".beads", "hooks", "commit-msg"), "utf8");
+  assert.match(shim, /scripts\/git-hooks\/commit-msg/, "the shim must delegate rather than duplicate");
+  assert.match(shim, /exit 1/, "a missing implementation must fail, not pass silently");
+});

--- a/scripts/install-git-hooks.test.mjs
+++ b/scripts/install-git-hooks.test.mjs
@@ -120,6 +120,33 @@ test("a preserved hook directory missing a guard WARNS rather than passing silen
   }
 });
 
+test("a PRESENT but NON-EXECUTABLE hook warns — git will not run it", () => {
+  // git only runs a hook that is executable, so an `-e` existence check would
+  // call this fine while the guard stays dead — the same silent no-op this
+  // script exists to surface.
+  //
+  // Uses a THIRD directory on purpose. The installer chmod +x's both
+  // scripts/git-hooks and .beads/hooks, so neither of those can reach the
+  // check non-executable; the gap only exists for a hooksPath the installer
+  // does not own, which is exactly where it must not guess and must warn.
+  const dir = scaffold();
+  try {
+    mkdirSync(join(dir, "custom-hooks"), { recursive: true });
+    for (const hook of ["pre-commit", "commit-msg"]) {
+      writeFileSync(join(dir, "custom-hooks", hook), "#!/usr/bin/env bash\nexit 0\n", { mode: 0o644 });
+    }
+    git(dir, "config", "core.hooksPath", "custom-hooks");
+    const combined = execFileSync("bash", ["-c", `bash "${dir}/scripts/install-git-hooks.sh" 2>&1`], {
+      cwd: dir, encoding: "utf8",
+    });
+    assert.match(combined, /WARNING non-executable hook\(s\):/, "a non-executable hook must be reported");
+    assert.doesNotMatch(combined, /WARNING missing hook/, "it is present — not missing");
+    assert.equal(git(dir, "config", "--get", "core.hooksPath"), "custom-hooks", "and still preserved");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("the merge driver is registered regardless of the hook decision", () => {
   // The driver must never be collateral damage of the hooks branch — that
   // coupling is what made the original script unsafe to run at all.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -51,6 +51,7 @@ export const SUITES = {
     "scripts/maintenance-gate.test.mjs",
     "scripts/check-beads-jsonl-duplicates.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",
+    "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
     "src/lib/board-cache-events.test.ts",


### PR DESCRIPTION
Fixes **cave-7g7py**. `core.hooksPath` is a **single directory**, so pointing it somewhere new silently disables every hook in the old place. `scripts/install-git-hooks.sh` set it unconditionally — but clones point it at `.beads/hooks`, which holds strictly more:

| | hooks |
|---|---|
| `.beads/hooks` (active) | `post-checkout`, `post-merge`, `pre-commit`, `pre-push`, `prepare-commit-msg` — **plus `commit-msg`, added here** |
| `scripts/git-hooks` (installer target) | `commit-msg`, `pre-commit` |

Their `pre-commit` hooks differ by **51 lines, all additions on the `.beads` side**: same secret scanner, plus the duplicate-id guard from #4231 and the beads integration block.

So running the installer disabled beads' four lifecycle hooks **and removed the duplicate-id guard** — the script documented as the way to activate the duplicate-**prevention** merge driver was deleting the duplicate-**detection** hook in the same breath. That's my defect from #4238: I added the driver registration to this script without checking what `hooksPath` was actually set to.

## Three changes

**1. Preserve an existing `hooksPath`.** If it points at a real directory, leave it and report what lives there. Compares **resolved** paths, not strings — `bd` writes an *absolute* `hooksPath`, so a compare against `".beads/hooks"` would miss it and clobber the thing being protected. If the preserved directory lacks `pre-commit` or `commit-msg`, it warns and names them rather than leaving a guard quietly not running.

**2. Register the merge driver unconditionally.** It's independent of the hook path and must never be collateral damage of that branch — coupling them is what made the script unsafe to run at all.

**3. `.beads/hooks/commit-msg` shim.** ⚠️ **A live gap, not hypothetical:** the beads hook path had no `commit-msg`, so the guard requiring `Co-authored-by` trailers to credit a person with GitHub's numeric no-reply identity **was not running on this clone at all** — the rule `AGENTS.md` exists to enforce after a session added AI-attribution trailers across eight merged PRs.

A shim that `exec`s `scripts/git-hooks/commit-msg` rather than a copy, because the two `pre-commit` hooks already drifted 51 lines apart by being maintained as separate copies. A missing implementation exits 1: a `commit-msg` guard that no-ops is indistinguishable from one that approved the message.

## Verification

End to end through the **beads** hook path:

```
AI-attribution trailer   -> [commit-msg blocked] ...must credit a person...
human numeric no-reply   -> allowed, commit created
```

Six wired tests: preserve / absolute-path / unset / warn-on-missing / driver-always-registered / shim-delegates.
