### PR TITLE
refactor(hooks): make .beads/hooks/pre-commit delegate instead of duplicating

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -43,8 +43,17 @@ if git diff --cached --name-only --diff-filter=ACMR -z \
    | tr '\0' '\n' | grep -qE '^\.beads/.*\.jsonl$'; then
   CHECKER="$REPO_ROOT/scripts/check-beads-jsonl-duplicates.mjs"
   if command -v node >/dev/null 2>&1 && [ -f "$CHECKER" ]; then
-    if ! node "$CHECKER" >/dev/null 2>&1; then
-      node "$CHECKER" >&2 || true
+    # Run FROM $REPO_ROOT. check-beads-jsonl-duplicates.mjs resolves .beads/
+    # relative to process.cwd(), so an inherited cwd elsewhere would make it
+    # scan the wrong directory — and finding no files reads exactly like
+    # finding no duplicates.
+    #
+    # Measured: git itself invokes pre-commit with cwd already at the worktree
+    # toplevel, even for `git commit` run from a subdirectory, so this is not
+    # reachable through git. It is cheap insurance against callers that do not
+    # replicate that guarantee — GUI clients drive this repo too.
+    if ! (cd "$REPO_ROOT" && node "$CHECKER") >/dev/null 2>&1; then
+      (cd "$REPO_ROOT" && node "$CHECKER") >&2 || true
       printf '\033[31m[pre-commit blocked]\033[0m %s\n' \
         "duplicate record ids in .beads/*.jsonl — see cave-1poit" >&2
       exit 1

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -1,164 +1,55 @@
 #!/usr/bin/env bash
-# coven-cave pre-commit hook
+# coven-cave pre-commit, beads hook path (cave-k9hom).
 #
-# Refuses commits that introduce:
-#   1. Files matching dangerous path patterns (env files, private keys,
-#      certificates, signing material, agent scratch state).
-#   2. Inline secret-shaped strings in staged diffs (AWS, Stripe, Slack,
-#      GitHub PAT, OpenRouter, OpenAI, Anthropic, Telegram bot tokens, generic
-#      Bearer tokens, password assignments, PEM private-key blocks).
+# A SHIM. The secret scanner used to exist twice — 128 duplicated lines shared
+# with scripts/git-hooks/pre-commit, kept in step by nothing. Only one hook
+# directory can ever run (core.hooksPath is a single directory), so the copy
+# that is not on the path silently does nothing: a fix applied to one side can
+# look installed while being dead. That is not theoretical — .beads/hooks had
+# no commit-msg at all, so the contributor-attribution guard never ran on this
+# clone until #4243 added a shim for it. This applies the same pattern to
+# pre-commit so the scanner has exactly one implementation.
 #
-# Bypass for genuine false positives:
-#     git commit --no-verify
-#
-# Install:
-#     scripts/install-git-hooks.sh
+# Layering, in order:
+#   1. scripts/git-hooks/pre-commit — the canonical secret scanner
+#   2. the .beads/*.jsonl duplicate-id guard (cave-1poit), which is specific to
+#      this hook path and has no business in the shared scanner
+#   3. the beads integration block, which bd manages between its own markers
 set -uo pipefail
 
-RED=$'\033[31m'; YELLOW=$'\033[33m'; CYAN=$'\033[36m'; RESET=$'\033[0m'
+REPO_ROOT=$(git rev-parse --show-toplevel)
+CANONICAL="$REPO_ROOT/scripts/git-hooks/pre-commit"
 
-fail() { printf "%s[pre-commit blocked]%s %s\n" "$RED" "$RESET" "$1" >&2; }
-warn() { printf "%s[pre-commit warn]%s %s\n" "$YELLOW" "$RESET" "$1" >&2; }
-info() { printf "%s[pre-commit]%s %s\n" "$CYAN" "$RESET" "$1" >&2; }
-
-# Capture staged file list to a temp file (NUL-separated). Avoids bash
-# command-substitution stripping NULs, which would collapse all paths
-# into one blob.
-TMPDIR_RUN=$(mktemp -d)
-trap 'rm -rf "$TMPDIR_RUN"' EXIT
-STAGED_FILE="$TMPDIR_RUN/staged"
-git diff --cached --name-only --diff-filter=ACMR -z > "$STAGED_FILE"
-[ -s "$STAGED_FILE" ] || exit 0
-
-BLOCKED=0
-
-# ---- 1. Path-based blocks --------------------------------------------------
-BLOCK_PATH_RE='(^|/)\.env(\.[^/]*)?$|\.(pem|key|p12|pfx|p8|cer|crt|der|jks|keystore|mobileprovision|provisionprofile)$|(^|/)id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$|(^|/)\.netrc$|(^|/)(secrets|credentials)/|(^|/)\.aws/credentials$|(^|/)\.ssh/(id_|authorized_keys|known_hosts)|(^|/)\.pypirc$|(^|/)\.claude/scheduled_tasks\.lock$|(^|/)\.claude/session|(^|/)\.cursor/|(^|/)\.aider'
-
-# Allow tracked *.example / *.sample / *.dist even with key extensions.
-ALLOW_PATH_RE='\.example$|\.sample$|\.dist$'
-
-STAGED_FILES=()
-while IFS= read -r -d '' f; do
-  STAGED_FILES+=("$f")
-done < "$STAGED_FILE"
-
-for f in "${STAGED_FILES[@]}"; do
-  if [[ "$f" =~ $BLOCK_PATH_RE ]] && ! [[ "$f" =~ $ALLOW_PATH_RE ]]; then
-    if [ "$f" = ".npmrc" ]; then
-      if git diff --cached -- "$f" | grep -qE '_authToken|//.*:_password|//.*:_auth='; then
-        fail ".npmrc change contains a registry auth token: $f"
-        BLOCKED=1
-      else
-        warn ".npmrc modified — confirm no auth tokens were added"
-      fi
-      continue
-    fi
-    fail "refusing to commit private/credential file: $f"
-    BLOCKED=1
-  fi
-done
-
-# ---- 2. Inline secret scan over the staged diff ----------------------------
-DIFF_FILE="$TMPDIR_RUN/diff"
-git diff --cached --no-color --unified=0 > "$DIFF_FILE"
-
-ADDED_FILE="$TMPDIR_RUN/added"
-awk '/^\+\+\+ /{next} /^\+/{sub(/^\+/,""); print}' "$DIFF_FILE" > "$ADDED_FILE"
-
-# Values that are self-evidently not credentials. Deliberately narrow, and
-# applied ONLY to the two generic shape heuristics below (Bearer / password
-# assignment) — never to a vendor pattern, because a real sk-ant-… or ghp_…
-# does not become safe by containing the word "test".
-#
-# The marker has to appear INSIDE the matched value, not merely somewhere on
-# the line, so a real key cannot slip through by sharing a line with the word
-# "example". The filter is still line-granular like the Tailscale check below,
-# so a line carrying BOTH a synthetic and a real token would be skipped; keep
-# fixtures on their own lines.
-SYNTHETIC='(synthetic|placeholder|example|dummy|fake|sample|redacted|changeme|not-a-real|your[_-]?(token|key|secret))'
-
-scan() {
-  local label="$1" pattern="$2" allow="${3:-}"
-  local hits
-  if [ -n "$allow" ]; then
-    # Filter per MATCH, not per line. A line-granular `grep -v` would drop the
-    # whole line when any part of it looked synthetic, so
-    #     const a = "Bearer synthetic-token", b = "Bearer <a real one>"
-    # would suppress the real secret too. Extract each match with -o and keep
-    # only those that do NOT carry a synthetic marker.
-    hits=$(grep -IonE -e "$pattern" "$ADDED_FILE" 2>/dev/null | while IFS= read -r entry; do
-      [ -n "$entry" ] || continue
-      match=${entry#*:}
-      printf '%s' "$match" | grep -qE -e "$allow" || printf '%s\n' "$entry"
-    done)
-  else
-    hits=$(grep -InE -e "$pattern" "$ADDED_FILE" || true)
-  fi
-  if [ -n "$hits" ]; then
-    fail "possible $label in staged diff:"
-    printf '%s\n' "$hits" | head -5 | sed 's/^/    /' >&2
-    BLOCKED=1
-  fi
-}
-
-# Patterns intentionally aligned with src/lib/redact.ts so contributors get
-# the same coverage at commit time as users get at render time.
-scan "OpenRouter API key"    'sk-or-v1-[A-Za-z0-9_-]{32,}'
-scan "AWS access key"        'AKIA[0-9A-Z]{16}'
-scan "AWS secret access key" 'aws_secret_access_key[[:space:]]*[:=][[:space:]]*["'\'']?[A-Za-z0-9/+=]{30,}'
-scan "GitHub PAT"            'gh[pousr]_[A-Za-z0-9]{30,}'
-scan "Slack token"           'xox[abprs]-[A-Za-z0-9-]{10,}'
-scan "Stripe secret"         'sk_(live|test)_[A-Za-z0-9]{20,}'
-scan "OpenAI key"            'sk-[A-Za-z0-9]{32,}'
-scan "Anthropic key"         'sk-ant-[A-Za-z0-9_-]{20,}'
-scan "Google API key"        'AIza[0-9A-Za-z_-]{30,}'
-scan "Telegram bot token"    '(^|[^0-9])[0-9]{8,11}:[A-Za-z0-9_-]{30,}'
-scan "Bearer token"          'Bearer[[:space:]]+[A-Za-z0-9_.-]{16,}' \
-     "Bearer[[:space:]]+[A-Za-z0-9_.-]*$SYNTHETIC[A-Za-z0-9_.-]*"
-scan "PEM private key"       'BEGIN ((RSA|EC|OPENSSH|DSA|PGP|ENCRYPTED) )?PRIVATE KEY'
-scan "password assignment"   '(password|passwd|secret|api[_-]?key|access[_-]?token)[[:space:]]*[:=][[:space:]]*["'\''][^"'\''[:space:]]{8,}["'\'']' \
-     "(password|passwd|secret|api[_-]?key|access[_-]?token)[[:space:]]*[:=][[:space:]]*[\"']*[^\"'[:space:]]*$SYNTHETIC[^\"'[:space:]]*[\"']*"
-
-# Tailscale Serve hostnames are not credentials, but real MagicDNS hostnames
-# can identify Val's private tailnet/machine. Allow examples and placeholders.
-tailscale_hits=$(grep -InE '[A-Za-z0-9-]+\.[A-Za-z0-9-]+\.ts\.net(:[0-9]+)?' "$ADDED_FILE" \
-  | grep -vE '(^|[.])example\.ts\.net|<[^>]+>\.ts\.net|\*\.ts\.net' || true)
-if [ -n "$tailscale_hits" ]; then
-  fail "possible private Tailscale Serve host in staged diff:"
-  printf '%s\n' "$tailscale_hits" | head -5 | sed 's/^/    /' >&2
-  BLOCKED=1
-fi
-
-if [ "$BLOCKED" -ne 0 ]; then
-  cat >&2 <<EOF
-
-${RED}commit refused.${RESET} If a hit is a false positive (e.g. a regex literal
-in a redaction module, a test fixture, or documentation), bypass once with:
-
-    git commit --no-verify
-
-Prefer fixing the diff first.
-EOF
+# ---- 1. Delegate to the canonical scanner ----------------------------------
+# A missing implementation must BLOCK. A secret scanner that quietly no-ops is
+# indistinguishable from one that found nothing, which is the whole failure
+# mode this file exists to remove.
+if [ ! -f "$CANONICAL" ]; then
+  printf '[pre-commit blocked] %s is missing — cannot scan for secrets\n' \
+    "scripts/git-hooks/pre-commit" >&2
   exit 1
 fi
+bash "$CANONICAL" "$@" || exit $?
 
-info "ok (${#STAGED_FILES[@]} files scanned)"
-
-# ---- 3. Duplicate record ids in .beads/*.jsonl (cave-1poit) ---------------
-# These are append-only audit logs; a repeated id means the log reports one
-# event twice. Fast local feedback only — `git merge` does NOT run pre-commit,
-# and the duplicates that prompted this were born in a merge commit, so the
-# authoritative gate is the wired test in CI (pnpm check:beads-jsonl).
-if grep -qz '^\.beads/.*\.jsonl$' "$STAGED_FILE" 2>/dev/null; then
-  if command -v node >/dev/null 2>&1 && [ -f scripts/check-beads-jsonl-duplicates.mjs ]; then
-    if ! node scripts/check-beads-jsonl-duplicates.mjs >/dev/null 2>&1; then
-      node scripts/check-beads-jsonl-duplicates.mjs >&2 || true
-      fail "duplicate record ids in .beads/*.jsonl — see cave-1poit"
-      BLOCKED=1
-    else
-      info "beads jsonl: no duplicate record ids"
+# ---- 2. Duplicate record ids in .beads/*.jsonl (cave-1poit) ----------------
+# Self-contained: it no longer shares the scanner's helpers or its staged-file
+# list, because those now live in another process.
+#
+# Fast local feedback only — `git merge` does NOT run pre-commit, and the
+# duplicates that prompted this were born in a merge commit, so the
+# authoritative gates are the wired test in CI (pnpm check:beads-jsonl) and the
+# merge driver (cave-1poit).
+if git diff --cached --name-only --diff-filter=ACMR -z \
+   | tr '\0' '\n' | grep -qE '^\.beads/.*\.jsonl$'; then
+  CHECKER="$REPO_ROOT/scripts/check-beads-jsonl-duplicates.mjs"
+  if command -v node >/dev/null 2>&1 && [ -f "$CHECKER" ]; then
+    if ! node "$CHECKER" >/dev/null 2>&1; then
+      node "$CHECKER" >&2 || true
+      printf '\033[31m[pre-commit blocked]\033[0m %s\n' \
+        "duplicate record ids in .beads/*.jsonl — see cave-1poit" >&2
+      exit 1
     fi
+    printf '\033[36m[pre-commit]\033[0m %s\n' "beads jsonl: no duplicate record ids" >&2
   fi
 fi
 
@@ -194,5 +85,4 @@ if command -v bd >/dev/null 2>&1; then
   if [ $_bd_exit -ne 0 ]; then exit $_bd_exit; fi
 fi
 # --- END BEADS INTEGRATION v1.0.5 ---
-
 exit 0

--- a/scripts/beads-pre-commit-shim.test.mjs
+++ b/scripts/beads-pre-commit-shim.test.mjs
@@ -112,6 +112,35 @@ test("the duplicate-id guard still blocks, and names the bead", () => {
   } finally { rmSync(dir, { recursive: true, force: true }); }
 });
 
+test("the duplicate-id guard works when invoked with a FOREIGN cwd", () => {
+  // The checker resolves .beads/ from process.cwd(), so a hook inherited with
+  // a different cwd would scan the wrong directory — and finding no files
+  // looks identical to finding no duplicates.
+  //
+  // git itself always hands pre-commit the worktree toplevel (measured), so
+  // this is not reachable via `git commit`. It IS reachable by any other
+  // caller that invokes the hook directly, which is why the hook pins its own
+  // cwd rather than trusting the one it is given.
+  const dir = scaffold();
+  try {
+    mkdirSync(join(dir, "sub", "deeper"), { recursive: true });
+    writeFileSync(join(dir, ".beads/interactions.jsonl"), '{"id":"a"}\n{"id":"a"}\n');
+    git(dir, "add", "-A");
+    let blocked = false;
+    let output = "";
+    try {
+      output = execFileSync("bash", [join(dir, ".beads/hooks/pre-commit")], {
+        cwd: join(dir, "sub", "deeper"), encoding: "utf8", stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      blocked = true;
+      output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+    }
+    assert.equal(blocked, true, "duplicates must still be caught from a foreign cwd");
+    assert.match(output, /cave-1poit/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
 test("a missing canonical scanner BLOCKS rather than passing silently", () => {
   const dir = scaffold();
   try {

--- a/scripts/beads-pre-commit-shim.test.mjs
+++ b/scripts/beads-pre-commit-shim.test.mjs
@@ -1,0 +1,125 @@
+// cave-k9hom: .beads/hooks/pre-commit delegates instead of duplicating.
+//
+// The secret scanner used to exist twice — 128 duplicated lines shared with
+// scripts/git-hooks/pre-commit, kept in step by nothing. Only one hook
+// directory runs (core.hooksPath is a single directory), so the copy not on
+// the path silently does nothing and a fix applied to it looks installed while
+// being dead. The same shape already produced a live gap: .beads/hooks had no
+// commit-msg, so the attribution guard never ran until #4243.
+//
+// These drive a real repository and real commits, because the only property
+// that matters is whether git actually blocks.
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { execFileSync } from "node:child_process";
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/** Returns {ok, output} for a commit attempt — never throws. */
+function commit(dir, message) {
+  try {
+    const out = execFileSync("git", ["-c", "user.email=t@e", "-c", "user.name=t", "commit", "-q", "-m", message],
+      { cwd: dir, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] });
+    return { ok: true, output: out };
+  } catch (error) {
+    return { ok: false, output: `${error.stdout ?? ""}${error.stderr ?? ""}` };
+  }
+}
+
+function scaffold() {
+  const dir = mkdtempSync(join(tmpdir(), "beads-shim-"));
+  git(dir, "init", "-q", "-b", "main");
+  git(dir, "config", "commit.gpgsign", "false");
+  mkdirSync(join(dir, ".beads", "hooks"), { recursive: true });
+  mkdirSync(join(dir, "scripts", "git-hooks"), { recursive: true });
+  // NB: cpSync's `mode` option is copy FLAGS (0-7), not file permissions —
+  // passing 0o755 there throws ERR_OUT_OF_RANGE. chmod after copying instead,
+  // and it must be 0o755: git silently skips a hook that is not executable.
+  cpSync(join(repoRoot, ".beads/hooks/pre-commit"), join(dir, ".beads/hooks/pre-commit"));
+  cpSync(join(repoRoot, "scripts/git-hooks/pre-commit"), join(dir, "scripts/git-hooks/pre-commit"));
+  chmodSync(join(dir, ".beads/hooks/pre-commit"), 0o755);
+  chmodSync(join(dir, "scripts/git-hooks/pre-commit"), 0o755);
+  cpSync(join(repoRoot, "scripts/check-beads-jsonl-duplicates.mjs"),
+         join(dir, "scripts/check-beads-jsonl-duplicates.mjs"));
+  git(dir, "config", "core.hooksPath", ".beads/hooks");
+  return dir;
+}
+
+test("the shim does not duplicate the scanner — it delegates", () => {
+  const shim = readFileSync(join(repoRoot, ".beads/hooks/pre-commit"), "utf8");
+  const canonical = readFileSync(join(repoRoot, "scripts/git-hooks/pre-commit"), "utf8");
+  assert.match(shim, /scripts\/git-hooks\/pre-commit/, "must reference the canonical scanner");
+  // The scanner's own machinery must NOT be copied back in.
+  for (const marker of ["BLOCK_PATH_RE", "Inline secret scan over the staged diff"]) {
+    assert.ok(canonical.includes(marker), `sanity: canonical owns ${marker}`);
+    assert.ok(!shim.includes(marker), `${marker} must live in ONE place, not be duplicated`);
+  }
+});
+
+test("the bd-managed block survives untouched", () => {
+  // bd regenerates between its markers; anything hand-added must sit outside.
+  const shim = readFileSync(join(repoRoot, ".beads/hooks/pre-commit"), "utf8");
+  assert.match(shim, /# --- BEGIN BEADS INTEGRATION/, "bd's markers must remain");
+  assert.match(shim, /# --- END BEADS INTEGRATION/);
+  const guardAt = shim.indexOf("cave-1poit");
+  const beadsAt = shim.indexOf("BEGIN BEADS INTEGRATION");
+  assert.ok(guardAt >= 0 && guardAt < beadsAt,
+    "the duplicate-id guard must sit BEFORE bd's block, or a bd regen can drop it");
+});
+
+test("a clean commit is allowed", () => {
+  const dir = scaffold();
+  try {
+    writeFileSync(join(dir, "ok.txt"), "hello\n");
+    git(dir, "add", "-A");
+    assert.equal(commit(dir, "clean").ok, true);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("delegation is real: secret-shaped content is still blocked", () => {
+  // If the shim stopped reaching the canonical scanner this passes silently,
+  // which is exactly the failure being designed out.
+  const dir = scaffold();
+  try {
+    // Assembled at RUNTIME, never written as a literal here: the repo's own
+    // pre-commit scanner refuses a staged diff containing a secret-shaped
+    // string, so spelling it out would make this very file uncommittable. It
+    // blocked exactly that on the first attempt.
+    const shaped = ["aws_secret_access_key = \"wJalrXUtnFEMI",
+                    "K7MDENG", "bPxRfiCYEXAMPLEKEY\""].join("/");
+    writeFileSync(join(dir, "leak.txt"), `${shaped}\n`);
+    git(dir, "add", "-A");
+    assert.equal(commit(dir, "leak").ok, false, "the secret scanner must still run through the shim");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("the duplicate-id guard still blocks, and names the bead", () => {
+  const dir = scaffold();
+  try {
+    writeFileSync(join(dir, ".beads/interactions.jsonl"), '{"id":"a"}\n{"id":"a"}\n');
+    git(dir, "add", "-A");
+    const res = commit(dir, "dupes");
+    assert.equal(res.ok, false, "duplicate ids must block");
+    assert.match(res.output, /cave-1poit/, "and point at the bead explaining why");
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});
+
+test("a missing canonical scanner BLOCKS rather than passing silently", () => {
+  const dir = scaffold();
+  try {
+    rmSync(join(dir, "scripts/git-hooks/pre-commit"));
+    writeFileSync(join(dir, "y.txt"), "x\n");
+    git(dir, "add", "-A");
+    const res = commit(dir, "no scanner");
+    assert.equal(res.ok, false, "a scanner that cannot run must not be treated as finding nothing");
+    assert.match(res.output, /missing/);
+  } finally { rmSync(dir, { recursive: true, force: true }); }
+});

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -52,6 +52,7 @@ export const SUITES = {
     "scripts/check-beads-jsonl-duplicates.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",
     "scripts/install-git-hooks.test.mjs",
+    "scripts/beads-pre-commit-shim.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
     "src/lib/board-cache-events.test.ts",


### PR DESCRIPTION
Closes **cave-k9hom**. The secret scanner existed **twice**:

| file | lines |
|---|---|
| `.beads/hooks/pre-commit` | 198 |
| `scripts/git-hooks/pre-commit` | 147 |
| **shared, duplicated body** | **128** |
| only on the `.beads` side | 51 (duplicate-id guard + bd block) |
| only on the `scripts` side | **0** — a strict superset |

## Why duplication is particularly bad here

`core.hooksPath` is a **single directory**, so whichever copy isn't on the path doesn't run *at all*. A fix applied to the wrong one looks installed while being dead.

That already happened: `.beads/hooks` had no `commit-msg`, so the contributor-attribution guard never ran on this clone until #4243 shimmed it. These 128 lines were the same trap still standing.

## What changed

`.beads/hooks/pre-commit` is now **88 lines**, layering in order:

1. **delegate** to `scripts/git-hooks/pre-commit` — one scanner implementation
2. the `.beads/*.jsonl` duplicate-id guard (cave-1poit), made self-contained since it no longer shares the scanner's helpers or staged-file list
3. the beads integration block, preserved **byte-for-byte**

The bd block is regenerated by `bd` between its own markers, so the duplicate-id guard stays **before** it — a test pins that ordering, because a regen would otherwise silently drop anything placed inside.

**A missing canonical scanner BLOCKS.** A secret scanner that quietly no-ops is indistinguishable from one that found nothing — that's the failure being designed out, so it must not return as the error path.

## Verification — real commits, not source-text pins

The only property that matters is whether git actually blocks:

- clean commit → allowed
- secret-shaped content → **blocked** (proves delegation is live, not merely referenced)
- duplicate ids in `.beads/*.jsonl` → **blocked**, naming cave-1poit
- missing scanner → **blocked**

## Two traps recorded in the test

Both would have made it pass for the wrong reason:

- `cpSync`'s `mode` option is **copy flags (0–7)**, not permissions — `0o755` throws `ERR_OUT_OF_RANGE`. It chmods after copying, and `0o755` matters because git silently skips a non-executable hook.
- the secret-shaped fixture is assembled **at runtime**. Written as a literal it makes the test file itself uncommittable — this repo's scanner refused exactly that on the first attempt at this commit, *through the new shim*.
