### PR TITLE
fix(sidecar): compare allowed roots and candidates in the same namespace (cave-24dps)

### DIFF
--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -182,6 +182,45 @@ function isInside(root, candidate) {
   return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
 }
 
+/**
+ * Containment against a set of allowed roots, tolerant of path aliases.
+ *
+ * `isInside` is lexical, so it only answers correctly when both sides are
+ * spelled the same way. The roots here are built with `path.resolve`, which
+ * normalizes but does NOT resolve symlinks, while a candidate that has been
+ * through `realpath` is fully canonical. On macOS that difference is routine
+ * rather than exotic — `/var` is a symlink to `/private/var` and `/tmp` to
+ * `/private/tmp`, so every temp-dir path has two spellings — and comparing one
+ * against the other rejected links that were plainly inside an allowed root.
+ *
+ * The lexical check runs first and answers almost every call. Only when it says
+ * "outside" do we canonicalize the roots and ask again, so the extra syscalls
+ * land on the path that was about to throw anyway. This narrows what is
+ * rejected, never widens it: containment is still required, just measured
+ * between two spellings of the same filesystem location.
+ */
+export async function isInsideAllowedRoots(roots, candidate) {
+  if (roots.some((root) => isInside(root, candidate))) return true;
+  // Canonicalize BOTH sides before the second opinion. Canonicalizing only one
+  // of them just moves the mismatch: an aliased root against a canonical
+  // candidate fails exactly as an aliased candidate against a canonical root
+  // does. A path that cannot be resolved keeps its lexical spelling, which is
+  // the best available answer for something that does not exist yet.
+  const canonicalCandidate = await canonicalize(candidate);
+  for (const root of roots) {
+    if (isInside(await canonicalize(root), canonicalCandidate)) return true;
+  }
+  return false;
+}
+
+async function canonicalize(target) {
+  try {
+    return await realpath(target);
+  } catch {
+    return path.resolve(target);
+  }
+}
+
 function packageParts(relativePath) {
   const parts = relativePath.split(path.sep);
   if (parts[0] !== "node_modules") return null;
@@ -214,7 +253,7 @@ function shouldSkipPackageEntry(relativePath, entryName, _isDirectory) {
 }
 
 async function copyResolvedEntry(source, destination, options, relativePath = "") {
-  if (!options.allowedLinkRoots.some((root) => isInside(root, source))) {
+  if (!(await isInsideAllowedRoots(options.allowedLinkRoots, source))) {
     throw new Error(`sidecar runtime input escapes its allowed roots: ${source}`);
   }
   const metadata = await lstat(source);
@@ -226,7 +265,7 @@ async function copyResolvedEntry(source, destination, options, relativePath = ""
       throw new Error(`sidecar runtime input must not contain links: ${source}`);
     }
     resolvedSource = await realpath(source);
-    if (!options.allowedLinkRoots.some((root) => isInside(root, resolvedSource))) {
+    if (!(await isInsideAllowedRoots(options.allowedLinkRoots, resolvedSource))) {
       throw new Error(`sidecar dependency link escapes its allowed roots: ${source} -> ${resolvedSource}`);
     }
     resolvedMetadata = await stat(resolvedSource);
@@ -429,7 +468,7 @@ async function copyNextRuntimeFiles(projectRoot, standaloneRoot, dependencyRoot,
       const candidate = path.join(root, relativePath);
       try {
         const resolvedNextRoot = await realpath(root);
-        if (!resolvedPackageRoots.some((allowedRoot) => isInside(allowedRoot, resolvedNextRoot))) {
+        if (!(await isInsideAllowedRoots(resolvedPackageRoots, resolvedNextRoot))) {
           throw new Error(`sidecar dependency link escapes its allowed roots: ${root} -> ${resolvedNextRoot}`);
         }
         const nextPackage = JSON.parse(await readFile(path.join(resolvedNextRoot, "package.json"), "utf8"));

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 import {
   assembleSidecarRuntime,
   collectTracedDependencies,
+  isInsideAllowedRoots,
   SIDECAR_FORBIDDEN_ROOTS,
   SIDECAR_NEXT_RUNTIME_FILES,
   SIDECAR_RUNTIME_BUDGETS,
@@ -530,3 +531,52 @@ try {
 }
 
 console.log("sidecar-runtime-closure.test.mjs: ok");
+
+// ── Allowed-root containment survives path aliases (cave-24dps) ─────────────
+// The roots are built with path.resolve, which normalizes but does not resolve
+// symlinks; a candidate that has been through realpath is fully canonical.
+// Comparing one spelling against the other rejected links that were plainly
+// inside an allowed root. On macOS this is the default state of every temp dir
+// (/var -> /private/var), which made the api suite unrunnable there. Built here
+// with an explicit symlink so it pins the behaviour on any platform.
+{
+  const aliasFixture = await mkdtemp(path.join(os.tmpdir(), "coven-sidecar-alias-"));
+  try {
+    const realRoot = path.join(aliasFixture, "real-root");
+    const inside = path.join(realRoot, "pkg");
+    const outside = path.join(aliasFixture, "outside");
+    await mkdir(inside, { recursive: true });
+    await mkdir(outside, { recursive: true });
+    const aliasRoot = path.join(aliasFixture, "alias-root");
+    let linked = true;
+    try {
+      await symlink(realRoot, aliasRoot, process.platform === "win32" ? "junction" : "dir");
+    } catch (error) {
+      if (!["EPERM", "EACCES", "ENOSYS"].includes(error.code)) throw error;
+      linked = false;
+      console.warn(`sidecar-runtime-closure.test: alias containment skipped (${error.code})`);
+    }
+    if (linked) {
+      // The root is spelled through the symlink; the candidate is canonical.
+      assert.equal(
+        await isInsideAllowedRoots([aliasRoot], inside),
+        true,
+        "a canonical candidate is inside a root spelled through a symlink",
+      );
+      // The guard still refuses what is genuinely outside, under either spelling.
+      assert.equal(
+        await isInsideAllowedRoots([aliasRoot], outside),
+        false,
+        "canonicalizing roots must not admit paths outside them",
+      );
+    }
+    // A root that cannot be resolved contains nothing, and does not throw.
+    assert.equal(
+      await isInsideAllowedRoots([path.join(aliasFixture, "missing")], inside),
+      false,
+      "an unresolvable root contains nothing",
+    );
+  } finally {
+    await rm(aliasFixture, { recursive: true, force: true });
+  }
+}


### PR DESCRIPTION
Closes `cave-24dps`.

## The problem

`pnpm test:api` could not complete on macOS. `sidecar-runtime-closure` rejected a dependency link that was plainly **inside** an allowed root:

```
sidecar dependency link escapes its allowed roots:
  /var/folders/.../locked-production/node_modules/next ->
  /private/var/folders/.../project/node_modules/unrelated-next
```

Those are the same location. The roots are built with `path.resolve`, which normalizes but does **not** resolve symlinks; the candidate has been through `realpath` and is fully canonical. macOS symlinks `/var` → `/private/var` and `/tmp` → `/private/tmp`, so every temp-dir path has two spellings and the lexical comparison was between different ones.

Traced to the exact site rather than guessed — a stack trace put it at `copyResolvedEntry` (the `resolvedSource` check), not the `nextRoots` check that already canonicalizes its roots.

## The fix

Containment gets a second opinion with **both sides canonicalized**. The lexical check still runs first and answers almost every call, so the extra syscalls land only on the path that was about to throw anyway.

This **narrows** what is accepted rather than widening it: containment is still required, just measured between two spellings of one filesystem location. A path that cannot be resolved keeps its lexical spelling — the best available answer for something that does not exist yet.

## What the new test caught

Canonicalizing only the *roots* would have moved the mismatch rather than fixed it: an aliased root against a canonical candidate fails exactly as an aliased candidate against a canonical root does. My first cut did only the roots, and the test I added failed until both sides were resolved. It builds the alias with an explicit `symlink`, so it pins the behaviour on platforms that do not symlink `/var`, and it also asserts:

- a path genuinely outside is still refused under either spelling
- an unresolvable root contains nothing, and does not throw

## The guard is intact

The three existing tests asserting that genuine escapes **are** rejected still pass. What changed is that a link inside an allowed root now reaches the `sidecar Next package root is not the Next package` check it was always meant to hit — which is what the failing test was asserting all along.

## Verification

`pnpm test:api` completes on macOS for the first time: **324 files passed**. Plus `typecheck` and `lint` clean.

Impact beyond the one test: this was hiding every api-suite failure after it from anyone developing on a Mac.
