### PR TITLE
fix(sidecar): compare link targets and allowed roots in the same namespace

### DIFF
--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -182,6 +182,49 @@ function isInside(root, candidate) {
   return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
 }
 
+/**
+ * Containment check that survives symlinks (cave-awj6q).
+ *
+ * isInside only path.resolve()s — that normalises `..` and makes a path
+ * absolute, but does NOT follow links. Comparing a realpath'd link target
+ * against roots that were never resolved compares two different namespaces, so
+ * a legitimate link is rejected purely because its spelling changed. On macOS
+ * every temp path hits this, since /var is a symlink to /private/var:
+ *
+ *   /var/folders/.../locked-production/node_modules/next
+ *   -> /private/var/folders/.../project/node_modules/unrelated-next
+ *
+ * Both are inside the same directory; nothing escaped. Not macOS-specific —
+ * any checkout reached through a symlinked component (home, volume mount,
+ * linked worktree) produces the same false rejection in a real build.
+ *
+ * Raw comparison first: it costs no syscall and answers the overwhelmingly
+ * common case where nothing is linked. Only when that fails do we pay for
+ * realpath, which is precisely the case resolution exists for.
+ */
+async function isInsideAllowedRoots(roots, candidate) {
+  if (roots.some((root) => isInside(root, candidate))) return true;
+
+  let resolvedCandidate;
+  try {
+    resolvedCandidate = await realpath(candidate);
+  } catch {
+    return false;
+  }
+  for (const root of roots) {
+    let resolvedRoot;
+    try {
+      resolvedRoot = await realpath(root);
+    } catch {
+      // A root that does not exist yet cannot contain anything, and the raw
+      // comparison above already had its chance.
+      continue;
+    }
+    if (isInside(resolvedRoot, resolvedCandidate)) return true;
+  }
+  return false;
+}
+
 function packageParts(relativePath) {
   const parts = relativePath.split(path.sep);
   if (parts[0] !== "node_modules") return null;
@@ -214,7 +257,7 @@ function shouldSkipPackageEntry(relativePath, entryName, _isDirectory) {
 }
 
 async function copyResolvedEntry(source, destination, options, relativePath = "") {
-  if (!options.allowedLinkRoots.some((root) => isInside(root, source))) {
+  if (!(await isInsideAllowedRoots(options.allowedLinkRoots, source))) {
     throw new Error(`sidecar runtime input escapes its allowed roots: ${source}`);
   }
   const metadata = await lstat(source);
@@ -226,7 +269,7 @@ async function copyResolvedEntry(source, destination, options, relativePath = ""
       throw new Error(`sidecar runtime input must not contain links: ${source}`);
     }
     resolvedSource = await realpath(source);
-    if (!options.allowedLinkRoots.some((root) => isInside(root, resolvedSource))) {
+    if (!(await isInsideAllowedRoots(options.allowedLinkRoots, resolvedSource))) {
       throw new Error(`sidecar dependency link escapes its allowed roots: ${source} -> ${resolvedSource}`);
     }
     resolvedMetadata = await stat(resolvedSource);

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -208,16 +208,22 @@ async function isInsideAllowedRoots(roots, candidate) {
   let resolvedCandidate;
   try {
     resolvedCandidate = await realpath(candidate);
-  } catch {
+  } catch (error) {
+    // ENOENT only. Anything else — EACCES, ELOOP, ENOTDIR — is a real fault,
+    // and swallowing it here would surface as "escapes its allowed roots",
+    // pointing whoever debugs it at a containment problem that does not exist.
+    if (error?.code !== "ENOENT") throw error;
     return false;
   }
   for (const root of roots) {
     let resolvedRoot;
     try {
       resolvedRoot = await realpath(root);
-    } catch {
+    } catch (error) {
       // A root that does not exist yet cannot contain anything, and the raw
-      // comparison above already had its chance.
+      // comparison above already had its chance. Same narrowing: only a
+      // missing root is benign.
+      if (error?.code !== "ENOENT") throw error;
       continue;
     }
     if (isInside(resolvedRoot, resolvedCandidate)) return true;


### PR DESCRIPTION
Closes **cave-awj6q**.

`copyResolvedEntry` resolved a symlink's **target** with `realpath` but compared it against `allowedLinkRoots` that were **never resolved** — two different namespaces — so a legitimate link was rejected purely because its spelling changed:

```
sidecar dependency link escapes its allowed roots:
  /var/folders/…/locked-production/node_modules/next
  -> /private/var/folders/…/project/node_modules/unrelated-next
```

Both paths are inside the same temp directory. Nothing escaped. `isInside` only `path.resolve()`s — that normalises `..` and absolutises, but does not follow links.

## Not macOS-only

macOS is just where it reproduces on demand (`/var` is a symlink to `/private/var`, so every temp path trips it). **Any real build whose checkout is reached through a symlinked component** — a linked home, a volume mount, a linked worktree — gets the same false rejection. CI runs Linux, which is why this never went red there.

## The fix

At the **comparison**, not the six construction sites that feed `allowedLinkRoots`, so they can't drift apart.

Raw comparison runs first and costs no syscall, answering the overwhelmingly common unlinked case; only when that fails does it resolve both sides. A root that doesn't exist yet is skipped rather than throwing — it can't contain anything.

## The check is not weakened

It gains a second, resolved-namespace way to say **yes**; it never stops saying **no**. The suite's three escape assertions still reject genuine escapes.

Worth noting: one of those assertions sits **after** the one that used to abort the file, so on macOS that negative test **had not been running at all**. The fix restores coverage as well as the check.

## Verification

- `scripts/sidecar-runtime-closure.test.mjs` now exits 0 on macOS — previously failed at *"an allowed-root link must still resolve to the actual Next package"*, masking the more specific check it exists to exercise
- `sidecar-bundle-deps` and `sidecar-runtime-smoke` unchanged

Third `/var` symlink bug of this shape found in one session — the others were the CLI entry check (#4231) and the beads merge driver (#4238). Same lesson each time: **if one side of a path comparison is realpath'd, the other must be too.**
