### PR TITLE
docs(sidecar): record current closure headroom

### DIFF
--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -167,9 +167,11 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // connection supervisor and its routes, the X API lib/component half, the
   // chat Start-from bands, the shell inset layout and the research-mission
   // surfaces. Retain the established ten-file cross-platform headroom over the
-  // highest platform (5,831) without relaxing the byte ceiling — measured
+  // then-highest platform (5,831) without relaxing the byte ceiling — measured
   // bytes are 104 MB against a 200 MB cap, so size is not the pressure here,
   // file count is.
+  // 2026-08-03 (X API route handlers): CI measured 5,874 files on Ubuntu and
+  // 5,877 on Windows. Retain the established ten-file cross-platform headroom.
   fileCount: 5_887,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -6,8 +6,8 @@ pub(super) const MANIFEST_SCHEMA_VERSION: u32 = 3;
 pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
-// Keep this in sync with scripts/sidecar-runtime-closure.mjs. The shared Memory
-// document reader traces 5,817 files on Windows; preserve ten-file headroom.
+// Keep this in sync with scripts/sidecar-runtime-closure.mjs. On 2026-08-03,
+// the cross-platform closure peaked at 5,877 files; preserve ten-file headroom.
 pub(super) const MAX_FILE_COUNT: u64 = 5_887;
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
## Summary

- record the 5,874-file Ubuntu and 5,877-file Windows measurements behind the current 5,887 sidecar ceiling
- keep the JavaScript and Rust provenance comments aligned
- leave all enforcement values unchanged

Tracked by `cave-v991k`. This intentionally excludes the review-gated orchestration spec and unrelated dirty-main artifacts from the rejected direct push.

## Verification

- `node scripts/sidecar-runtime-closure.test.mjs`
- `node scripts/sidecar-bundle-deps.test.mjs`
- `pnpm check:tests-wired` (1,450 test files)
- `pnpm typecheck`
- `pnpm lint`
- `rustfmt --check src-tauri/src/sidecar_archive_manifest.rs`
- `git diff --check origin/main...HEAD`