### PR TITLE
fix(ios): pin the reconnect re-probe by behaviour, unbreaking main

### DIFF
--- a/scripts/ios-reconnect-pill.test.mjs
+++ b/scripts/ios-reconnect-pill.test.mjs
@@ -59,9 +59,23 @@ assert.match(
 // The Connect screen's own 10s ticker no longer runs for unreachable-with-
 // surfaces (that screen isn't mounted), so RootView carries its own quiet
 // re-probe, mutually exclusive via the hasLoadedSurfaces guard.
+// Pinned as BEHAVIOUR, not control-flow spelling. This previously required a
+// literal `guard app.hasLoadedSurfaces, case .unreachable = …` block;
+// 3e54ecdbe4 ("fix(ios): sustain chat connectivity") refactored the same logic
+// into a `switch` with a `where` clause and the assertion broke on `main`
+// while the behaviour was intact. What matters is that the scene-phase task
+// re-probes ONLY when the desktop is unreachable AND surfaces are already
+// loaded (so it cannot fight the Connect screen's own ticker), and that the
+// probe is the quiet, surface-reloading one.
+const scenePhaseTask = root.slice(root.indexOf(".task(id: scenePhase)"));
 assert.match(
-  root,
-  /\.task\(id: scenePhase\) \{[\s\S]*?guard app\.hasLoadedSurfaces,\s*\n\s*case \.unreachable = app\.connectionState else \{ continue \}[\s\S]*?await app\.refreshConnection\(reloadLoadedSurfaces: true, quiet: true\)/,
+  scenePhaseTask,
+  /case \.unreachable where app\.hasLoadedSurfaces|guard app\.hasLoadedSurfaces,\s*\n\s*case \.unreachable = app\.connectionState/,
+  "RootView re-probes only when unreachable AND surfaces are loaded",
+);
+assert.match(
+  scenePhaseTask,
+  /await app\.refreshConnection\(reloadLoadedSurfaces: true, quiet: true\)/,
   "RootView quietly re-probes while the pill covers an unreachable desktop",
 );
 

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_841/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_887/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 for (const runtimeFile of [
   "dist/compiled/webpack/webpack-lib.js",
@@ -253,7 +253,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_841;/,
+  /const MAX_FILE_COUNT: u64 = 5_887;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -163,6 +163,15 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // and 5,831 on Windows after maps, declarations, nested dependencies, and
   // non-runtime roots are excluded. Preserve the established ten-file
   // cross-platform headroom.
+  // 2026-08-03 (src/app/api/x/ route handlers, #4235): CI measures 5,874 on
+  // Ubuntu and 5,877 on Windows. Set from the HIGHER figure plus the same
+  // ten-file headroom.
+  //
+  // This number was reverted to 5_841 once already, by a local merge of a
+  // superseded branch citing the stale 5,831 line above (#4249). The routes
+  // needing this headroom are still present, so it must not move DOWN while
+  // they exist — and any bump belongs here, beside the measurement that
+  // justifies it, or the next reader reverts it again.
   fileCount: 5_887,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -163,7 +163,7 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // and 5,831 on Windows after maps, declarations, nested dependencies, and
   // non-runtime roots are excluded. Preserve the established ten-file
   // cross-platform headroom.
-  fileCount: 5_841,
+  fileCount: 5_887,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -102,10 +102,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_841);
+  assert.ok(metrics.fileCount <= 5_887);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_841,
+    fileCount: 5_887,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -256,7 +256,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_841);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_887);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -7,7 +7,10 @@ pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. The current
-// cross-platform closure peaks at 5,831 files; preserve ten-file headroom.
+// cross-platform closure peaks at 5,877 files (Windows, 2026-08-03, after the
+// src/app/api/x/ route handlers landed in #4235); preserve ten-file headroom.
+// Reverted to 5_841 once by a local merge citing the older 5,831 peak — see
+// #4249. It must not move DOWN while those routes exist.
 pub(super) const MAX_FILE_COUNT: u64 = 5_887;
 
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -8,7 +8,7 @@ pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. The current
 // cross-platform closure peaks at 5,831 files; preserve ten-file headroom.
-pub(super) const MAX_FILE_COUNT: u64 = 5_841;
+pub(super) const MAX_FILE_COUNT: u64 = 5_887;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]


### PR DESCRIPTION
**`main` is red** on `scripts/ios-reconnect-pill.test.mjs` and every branch inherits it. #4249 failed `Frontend build` on this while changing nothing but sidecar budget constants.

## Not a behaviour regression

The assertion pinned a literal control-flow spelling:

```swift
guard app.hasLoadedSurfaces,
  case .unreachable = app.connectionState else { continue }
```

`3e54ecdbe4` (*"fix(ios): sustain chat connectivity"*) refactored the same logic into a `switch`:

```swift
case .unreachable where app.hasLoadedSurfaces:
    connectedTicks = 0
    await app.refreshConnection(reloadLoadedSurfaces: true, quiet: true)
```

Same guard, same call, different syntax — the test broke while the behaviour it protects stayed intact.

**Third instance of this shape today**, after the release strip-step name (#4240) and the composer popover literal (#4240). A pin on one spelling of an implementation cannot survive a refactor that preserves the behaviour.

## The fix

Two behavioural assertions scoped to the scene-phase task:

1. it re-probes **only** when unreachable **and** surfaces are already loaded — so it cannot fight the Connect screen's own ticker
2. the probe is the **quiet, surface-reloading** one

Tolerates either spelling.

## Verified it still catches real regressions

A pin that cannot fail is what got us here, so I checked both directions:

| mutation | result |
|---|---|
| remove the `hasLoadedSurfaces` condition | **fails** ✓ |
| downgrade to plain `refreshConnection()` | **fails** ✓ |
| unmodified | passes ✓ |
