### PR TITLE
fix(ios): one-probe reconnect via last-good URL, short-circuit the sweep

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -83,8 +83,15 @@ struct CaveConnection: Codable, Equatable {
             add("https://\(hostname)")        // bare 443
         } else {
             // The desktop falls back through 3000-3010 when ports are taken
-            // (scripts/dev-app.sh / server.ts PORT), so probe the whole range —
-            // discovery is concurrent, so the extra candidates cost no wall time.
+            // (scripts/dev-app.sh / server.ts PORT), so probe the whole range.
+            //
+            // These extra candidates are NOT free: the paired path probes
+            // sequentially on purpose (see AppModel.discoverBaseURL — fanning
+            // the Bearer token across ports concurrently would widen credential
+            // exposure), so 16 candidates x a 6s timeout is a 96s worst case
+            // when packets are silently dropped. `lastGoodBaseURL` is what keeps
+            // the common case at a single probe; do not add candidates on the
+            // assumption that they cost nothing (cave-ioswipe.3).
             for port in 3000...3010 { add("http://\(hostname):\(port)") }
             for port in ["4500", "4555", "8443"] { add("http://\(hostname):\(port)") }
             add("https://\(hostname):8443")
@@ -107,7 +114,48 @@ struct CaveConnection: Codable, Equatable {
 
     static func clear() {
         UserDefaults.standard.removeObject(forKey: storageKey)
+        UserDefaults.standard.removeObject(forKey: lastGoodKey)
         KeychainStore.remove(tokenKey)
+    }
+
+    /// The base URL that last answered a successful probe, per host
+    /// (cave-ioswipe.3). Discovery tries this first, which turns the common
+    /// reconnect — same desktop, same port — into ONE probe instead of walking
+    /// the candidate list. Keyed by host so a remembered port for one desktop
+    /// is never tried against a different one.
+    ///
+    /// Not a secret (the host string beside it is already plain UserDefaults),
+    /// so it does not belong in the Keychain.
+    static let lastGoodKey = "cave.connection.last-good"
+
+    private static func lastGoodMap() -> [String: String] {
+        UserDefaults.standard.dictionary(forKey: lastGoodKey) as? [String: String] ?? [:]
+    }
+
+    static func lastGoodBaseURL(forHost host: String) -> URL? {
+        let key = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !key.isEmpty, let raw = lastGoodMap()[key] else { return nil }
+        return URL(string: raw)
+    }
+
+    static func saveLastGoodBaseURL(_ url: URL, forHost host: String) {
+        let key = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !key.isEmpty else { return }
+        var map = lastGoodMap()
+        map[key] = url.absoluteString
+        UserDefaults.standard.set(map, forKey: lastGoodKey)
+    }
+
+    /// Candidates with the last-good URL hoisted to the front. Kept separate
+    /// from `candidateBaseURLs` so that property stays pure and testable; only
+    /// this one reads persisted state.
+    var prioritizedCandidateBaseURLs: [URL] {
+        let candidates = candidateBaseURLs
+        guard let remembered = Self.lastGoodBaseURL(forHost: host),
+              candidates.contains(remembered),
+              candidates.first != remembered
+        else { return candidates }
+        return [remembered] + candidates.filter { $0 != remembered }
     }
 
     /// The mobile access credential, when this desktop's API is token-gated

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1023,7 +1023,9 @@ final class AppModel {
         // (state + loads must run once, not per caller). A joiner's
         // surface-reload intent is OR-merged onto the probe so the launcher
         // applies it — the joiner returning early must not drop it.
-        let candidates = connection.candidateBaseURLs
+        // Last-good first (cave-ioswipe.3): the ordinary reconnect then costs a
+        // single probe instead of walking the candidate list.
+        let candidates = connection.prioritizedCandidateBaseURLs
         // Identity of the endpoint this probe describes. `configure()` cancels
         // the in-flight probe, but a launcher that already passed its
         // `Task.isCancelled` check races that cancel — without this capture it
@@ -1057,6 +1059,13 @@ final class AppModel {
             // refresh owns the state.
             return
         case .found(let working):
+            // Remember what answered, keyed by the host we probed, so the next
+            // reconnect starts here (cave-ioswipe.3). Recorded even when the URL
+            // is unchanged: a first success is exactly what makes the fast path
+            // available on the following launch.
+            if let host = self.connection?.host {
+                CaveConnection.saveLastGoodBaseURL(working, forHost: host)
+            }
             if working != self.connection?.baseURL {
                 // Relocate: persist the working endpoint so future launches
                 // connect directly. Stored as bare `host:port` when the
@@ -1185,24 +1194,56 @@ final class AppModel {
     /// already succeeded or rejected it. Unpaired probes carry no secret, so they
     /// may still run concurrently for the cold-launch wall-clock win.
     static func discoverBaseURL(_ candidates: [URL]) async -> DiscoveryOutcome {
-        guard !candidates.isEmpty else { return .unreachable(nil) }
+        guard let preferred = candidates.first else { return .unreachable(nil) }
+
+        // Fast path (cave-ioswipe.3): probe the preferred endpoint ALONE first.
+        // Callers put the last-good URL at the head, so the ordinary reconnect —
+        // same desktop, same port — costs exactly one probe instead of walking
+        // up to 16 candidates. This is also what keeps the preferred endpoint
+        // authoritative: racing the whole list could relocate to a different
+        // working port purely on timing, persisting an endpoint the user never
+        // chose.
+        var strongest: ProbeFailure?
+        switch await Self.probe(preferred) {
+        case .ok: return .found(preferred)
+        case .unauthorized: return .unauthorized
+        case .failed(let failure): strongest = failure
+        }
+
+        let rest = Array(candidates.dropFirst())
+        guard !rest.isEmpty else { return .unreachable(strongest) }
+
+        // The paired path stays SEQUENTIAL by design: every candidate carries
+        // the Bearer token, and fanning it across ports concurrently would widen
+        // credential exposure. Only the unpaired sweep races.
         if CaveConnection.accessToken != nil {
-            return await discoverBaseURLSequentially(candidates)
+            return await discoverBaseURLSequentially(rest, seededWith: strongest)
         }
 
         let results = await withTaskGroup(of: (Int, ProbeResult).self) { group in
-            for (index, base) in candidates.enumerated() {
+            for (index, base) in rest.enumerated() {
                 group.addTask { (index, await Self.probe(base)) }
             }
-            var collected = [ProbeResult?](repeating: nil, count: candidates.count)
-            for await (index, result) in group { collected[index] = result }
+            var collected = [ProbeResult?](repeating: nil, count: rest.count)
+            for await (index, result) in group {
+                collected[index] = result
+                // Short-circuit: a reachable endpoint is enough, so stop paying
+                // for the slowest probe in the list.
+                if case .ok = result {
+                    group.cancelAll()
+                    break
+                }
+            }
             return collected
         }
-        return adjudicateDiscoveryResults(results, candidates: candidates)
+        return adjudicateDiscoveryResults(results, candidates: rest, seededWith: strongest)
     }
 
-    private static func discoverBaseURLSequentially(_ candidates: [URL]) async -> DiscoveryOutcome {
-        var strongest: ProbeFailure?
+    private static func discoverBaseURLSequentially(
+        _ candidates: [URL],
+        seededWith seed: ProbeFailure? = nil,
+    ) async -> DiscoveryOutcome {
+        var strongest: ProbeFailure? = seed
         for base in candidates {
             switch await Self.probe(base) {
             case .ok: return .found(base)
@@ -1213,8 +1254,15 @@ final class AppModel {
         return .unreachable(strongest)
     }
 
-    private static func adjudicateDiscoveryResults(_ results: [ProbeResult?], candidates: [URL]) -> DiscoveryOutcome {
-        var strongest: ProbeFailure?
+    private static func adjudicateDiscoveryResults(
+        _ results: [ProbeResult?],
+        candidates: [URL],
+        seededWith seed: ProbeFailure? = nil,
+    ) -> DiscoveryOutcome {
+        // Seeded with the preferred endpoint's failure so the diagnosis the user
+        // sees still reflects the endpoint they configured, not only the
+        // alternates.
+        var strongest: ProbeFailure? = seed
         for (index, result) in results.enumerated() {
             switch result {
             case .ok: return .found(candidates[index])

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -1225,11 +1225,21 @@ final class AppModel {
                 group.addTask { (index, await Self.probe(base)) }
             }
             var collected = [ProbeResult?](repeating: nil, count: rest.count)
+            // Short-circuit WITHOUT breaking ordered adjudication. Candidate
+            // order is a preference ranking, so cancelling on the first .ok to
+            // *arrive* would let a later port win purely on timing and get
+            // persisted over an earlier one that also worked. Instead, stop only
+            // once some candidate has succeeded AND every candidate ranked above
+            // it has already reported — at which point no earlier winner is
+            // still possible and the remaining probes cannot change the answer.
+            var earliestSuccess: Int?
             for await (index, result) in group {
                 collected[index] = result
-                // Short-circuit: a reachable endpoint is enough, so stop paying
-                // for the slowest probe in the list.
-                if case .ok = result {
+                if case .ok = result, index < earliestSuccess ?? Int.max {
+                    earliestSuccess = index
+                }
+                if let winner = earliestSuccess,
+                   (0..<winner).allSatisfy({ collected[$0] != nil }) {
                     group.cancelAll()
                     break
                 }

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -204,10 +204,20 @@ assert.match(
 );
 
 // The unpaired sweep stops paying for the slowest probe once one answers.
+// Short-circuit, but not at the cost of ordered adjudication: candidate order
+// is a preference ranking, so cancelling on the first .ok to ARRIVE would let a
+// later port win on timing and be persisted over an earlier one that also
+// worked. The sweep may only stop once every candidate ranked above the winner
+// has reported.
 assert.match(
   model,
-  /if case \.ok = result \{\s*\n\s*group\.cancelAll\(\)/,
-  "the concurrent sweep must cancel remaining probes on first success",
+  /group\.cancelAll\(\)/,
+  "the concurrent sweep must cancel remaining probes once the answer is settled",
+);
+assert.match(
+  model,
+  /\(0\.\.<winner\)\.allSatisfy\(\{ collected\[\$0\] != nil \}\)/,
+  "it may only stop once no higher-ranked candidate can still win — order is preference, not timing",
 );
 
 // Persisting the winner is what makes the fast path available next launch.

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -73,7 +73,7 @@ assert.match(
 // --- Discovery: credential-safe probes, ordered adjudication, 401 terminal -
 assert.match(
   model,
-  /if CaveConnection\.accessToken != nil \{\s*\n\s*return await discoverBaseURLSequentially\(candidates\)/,
+  /if CaveConnection\.accessToken != nil \{\s*\n\s*return await discoverBaseURLSequentially\(rest, seededWith: strongest\)/,
   "paired discovery must probe sequentially so Bearer tokens are not sent to speculative sibling ports",
 );
 assert.match(
@@ -180,6 +180,56 @@ assert.match(
   terminal,
   /guard let ws = self\?\.task else \{ return \}[\s\S]*?self\.task === ws/,
   "the receive loop must pin its socket — a replaced socket's stale error must not clobber the live connection",
+);
+
+// --- Host discovery: one probe on the common path, and the paired sweep stays
+// --- sequential (cave-ioswipe.3) --------------------------------------------
+// The paired path probes candidates ONE AT A TIME on purpose: every candidate
+// carries the Bearer token, so racing them would fan the credential across
+// ports. That is the property most likely to be "optimised" away by someone
+// speeding up discovery, so it is pinned first and loudest.
+
+// One probe on the ordinary reconnect: preferred endpoint alone, before any
+// fan-out. Without this, a paired user walks up to 16 candidates at a 6s
+// timeout each.
+assert.match(
+  model,
+  /switch await Self\.probe\(preferred\) \{[\s\S]*?case \.ok: return \.found\(preferred\)/,
+  "discovery must probe the preferred endpoint alone first",
+);
+assert.match(
+  model,
+  /let candidates = connection\.prioritizedCandidateBaseURLs/,
+  "discovery must use the last-good-first ordering, or the fast path probes the wrong endpoint",
+);
+
+// The unpaired sweep stops paying for the slowest probe once one answers.
+assert.match(
+  model,
+  /if case \.ok = result \{\s*\n\s*group\.cancelAll\(\)/,
+  "the concurrent sweep must cancel remaining probes on first success",
+);
+
+// Persisting the winner is what makes the fast path available next launch.
+assert.match(
+  model,
+  /CaveConnection\.saveLastGoodBaseURL\(working, forHost: host\)/,
+  "a successful probe must record the working URL for the next reconnect",
+);
+assert.match(
+  connection,
+  /var prioritizedCandidateBaseURLs: \[URL\] \{[\s\S]*?candidates\.contains\(remembered\)/,
+  "a remembered URL is only honoured when it is still a candidate for this host",
+);
+assert.match(
+  connection,
+  /static func lastGoodBaseURL\(forHost host: String\)/,
+  "the last-good URL is keyed by host so one desktop's port is never tried against another",
+);
+assert.match(
+  connection,
+  /static func clear\(\) \{[\s\S]*?removeObject\(forKey: lastGoodKey\)/,
+  "disconnecting must drop remembered endpoints too",
 );
 
 console.log("ios-connection-stability: OK");


### PR DESCRIPTION
Implements **cave-ioswipe.3** — *"Short-circuit probing after first success, cancel remaining probes, persist last-good URL."*

## The problem, measured

Discovery walked up to **16 candidates** (configured URL, ports 3000–3010, 4500/4555/8443, https:8443) at `timeoutInterval = 6` each. For a **paired** user that walk is *sequential*, so a silently-dropping network cost up to **~96s** of probing while swipe actions queued behind it.

The comment justifying those 16 candidates said *"discovery is concurrent, so the extra candidates cost no wall time."* That's true only for the **unpaired** sweep. The paired path — the one a real user is on — has always been sequential. I corrected the comment, since it's what invites more candidates.

## What did NOT change, deliberately

**The paired sweep stays sequential.** Every candidate carries the Bearer token, so racing them fans the credential across sibling ports.

`scripts/ios-connection-stability.test.mjs` already pinned this — *"paired discovery must probe sequentially so Bearer tokens are not sent to speculative sibling ports"* — and my first draft **tripped it**. The guard worked. Only its call signature is updated here.

## Three changes

1. **Last-good base URL persisted per host, tried first.** The ordinary reconnect — same desktop, same port — becomes **one probe**. Keyed by host so a remembered port never leaks to a different desktop, honoured only while still a candidate for that host, and dropped by `clear()` on disconnect.

2. **Probe the preferred endpoint alone before any fan-out.** This also keeps that endpoint authoritative: racing the whole list could relocate to a different working port purely on timing, persisting an endpoint the user never chose.

3. **The unpaired sweep cancels remaining probes on first success** instead of waiting for the slowest.

Failures from the preferred probe are seeded into the fallback's adjudication, so the diagnosis still reflects the endpoint the user configured rather than only the alternates.

## Verified the assertions actually catch regressions

Not just that they pass:

| mutation | result |
|---|---|
| make the paired path concurrent (credential regression) | **fails** ✓ |
| drop `group.cancelAll()` | **fails** ✓ |
| revert to unprioritized candidates | **fails** ✓ |
| unmodified | passes ✓ |

## Notes

- iOS Swift isn't compiled by CI, so the `.mjs` source-text contract is the real gate — that's where the guards live.
- The bead is assigned to **Cody** but was untouched since 2026-07-27 (status `open`, no branch, no worktree). Taken at the owner's direction; attribution left as is.
