### PR TITLE
test(mobile): lock Coven Memory response contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,11 @@ pnpm mobile:tailscale:app      # pair the native iOS app to a daemon over Tailsc
 pnpm mobile:ios:sim            # build & run the native iOS app in the simulator
 ```
 
+The standalone Coven Memory iOS client uses the same **Open on phone**
+bearer/Tailscale boundary and Cave's read-only canonical-memory routes. See
+[`docs/mobile-memory.md`](docs/mobile-memory.md) for enablement, pairing,
+global credential rotation, recovery, and privacy constraints.
+
 The native SwiftUI app has its own notes in
 [`apps/ios/CovenCave/README.md`](apps/ios/CovenCave/README.md).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,16 +69,18 @@ The following properties are design goals of OpenCoven. If you find a way to vio
 
 ### Coven Memory mobile boundary
 
-The standalone iOS memory client reaches only Cave's bearer-protected
-`/api/mobile/coven-memory` GET routes over the existing Tailscale Serve flow.
-Tailscale membership alone is not authorization. Cave validates the mobile
-marker before configuration or daemon access, keeps responses private and
-uncacheable, strips daemon paths, and exposes no mutation route.
+The standalone iOS memory client reaches Cave's bearer-protected
+`/api/mobile/coven-memory` GET routes and `POST /api/mobile-token/refresh` over
+the existing Tailscale Serve flow. Tailscale membership alone is not
+authorization. Cave validates the mobile marker before configuration or daemon
+access, keeps responses private and uncacheable, strips daemon paths, and
+exposes no memory mutation route.
 
 Pairing URLs and the persisted mobile access secret are credentials. Never put
 them in logs, screenshots, fixtures, issues, PR text, or support transcripts.
-The current credential is shared across paired mobile clients; a lost device
-requires global secret rotation and re-pairing, as documented in
+The invite remains usable until its shared credential is rotated. The current
+credential is shared across paired mobile clients; a lost device requires
+global secret rotation and re-pairing, as documented in
 [`docs/mobile-memory.md`](docs/mobile-memory.md). Screen capture by a device
 owner remains outside the app's control, so review and beta evidence must use
 synthetic status-only data.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,6 +67,22 @@ The following properties are design goals of OpenCoven. If you find a way to vio
 3. **Agent identity integrity** — a familiar's identity must not be forgeable by another agent or external caller
 4. **Execution boundaries** — agent tool calls must not escape their intended scope
 
+### Coven Memory mobile boundary
+
+The standalone iOS memory client reaches only Cave's bearer-protected
+`/api/mobile/coven-memory` GET routes over the existing Tailscale Serve flow.
+Tailscale membership alone is not authorization. Cave validates the mobile
+marker before configuration or daemon access, keeps responses private and
+uncacheable, strips daemon paths, and exposes no mutation route.
+
+Pairing URLs and the persisted mobile access secret are credentials. Never put
+them in logs, screenshots, fixtures, issues, PR text, or support transcripts.
+The current credential is shared across paired mobile clients; a lost device
+requires global secret rotation and re-pairing, as documented in
+[`docs/mobile-memory.md`](docs/mobile-memory.md). Screen capture by a device
+owner remains outside the app's control, so review and beta evidence must use
+synthetic status-only data.
+
 ---
 
 *Last updated: 2026-07-04*

--- a/docs/mobile-memory.md
+++ b/docs/mobile-memory.md
@@ -1,0 +1,83 @@
+# Coven Memory mobile access
+
+Coven Memory for iOS is a read-only client of Cave's canonical-memory API. It
+uses the existing **Open on phone** bearer/Tailscale boundary; there is no
+second Coven listener, cloud relay, device-signature protocol, or direct phone
+connection to the Coven daemon.
+
+## Enable and pair
+
+Mobile access is disabled until an operator starts the native-app flow. The
+host needs a running local Coven daemon, Node and pnpm, Tailscale signed into
+the same tailnet as the phone, and Tailscale Serve permission.
+
+```bash
+pnpm mobile:tailscale:app
+```
+
+The command keeps Next.js on loopback, publishes that backend with Tailscale
+Serve, and prints a credential-bearing HTTPS pairing URL and QR code. In Coven
+Memory, scan the QR or paste the URL. Do not send the URL through chat, paste it
+into an issue, or capture it in a screenshot or terminal recording.
+
+The app then reads only:
+
+- `GET /api/mobile/coven-memory`
+- `GET /api/mobile/coven-memory/overview`
+- `GET /api/mobile/coven-memory/{id}`
+
+Every request needs a currently valid mobile bearer credential. Cave validates
+that boundary before reading configuration or contacting the loopback Coven
+socket. The routes are read-only, force dynamic responses, return
+`private, no-store`, omit daemon paths, and fail closed when Coven is missing,
+incompatible, or returns an invalid payload.
+
+## Status, stop, and recovery
+
+```bash
+pnpm mobile:tailscale:status
+pnpm mobile:tailscale:stop
+```
+
+Status output redacts the credential. Stop terminates tracked mobile servers
+and resets Tailscale Serve. It does not rotate the persisted shared access
+secret, so starting again lets already-paired clients reconnect.
+
+Current Cave mobile access has no per-device registry or per-device host-side
+revoke command. For a lost device or suspected invite disclosure, revoke all
+paired clients by stopping the service, deleting the exact `access-token` file
+inside the state directory printed by `pnpm mobile:tailscale:status`, and then
+starting `pnpm mobile:tailscale:app` again. Confirm the path is the printed
+per-port mobile state directory before deletion. Re-pair each trusted device.
+On the phone, **Pair again** deletes only that phone's Keychain connection.
+
+If pairing or refresh fails:
+
+1. Confirm `tailscale status --self` succeeds on the host and phone.
+2. Confirm `pnpm mobile:tailscale:status` reports the tracked loopback server.
+3. Stop the service and verify stale Serve state is gone.
+4. Start the native-app flow again and use the newly printed invite.
+5. Update Cave when the app reports an unsupported protocol or invalid host
+   response.
+
+## Threat boundary
+
+- Tailscale membership is private routing, not authorization; the bearer is
+  still required.
+- The Cave server remains loopback-bound. Never substitute `0.0.0.0` or a LAN
+  bind for Tailscale Serve.
+- Cave injects access to the local Coven socket; the phone never receives a
+  socket path or transport credential.
+- The iOS client stores only its Cave URL and bearer in the device-only
+  Keychain. Memory data is retained in memory only and is purged on lock,
+  background, reader dismissal, reset, or auth failure.
+- A device owner can still screenshot, screen-record, or photograph visible
+  content. Operational evidence must use synthetic fixtures and status-only
+  results.
+- Do not log request authorization, invite URLs, private endpoints, memory
+  bodies, excerpts, or device identifiers.
+
+The cross-repository fixture contract lives at
+`tests/fixtures/mobile-canonical-memory-v1` in Cave and
+`apps/ios/CovenMemory/Tests/Fixtures/cave-mobile-memory-v1` in coven-memory.
+Both copies are deterministic and synthetic.

--- a/docs/mobile-memory.md
+++ b/docs/mobile-memory.md
@@ -16,21 +16,25 @@ pnpm mobile:tailscale:app
 ```
 
 The command keeps Next.js on loopback, publishes that backend with Tailscale
-Serve, and prints a credential-bearing HTTPS pairing URL and QR code. In Coven
-Memory, scan the QR or paste the URL. Do not send the URL through chat, paste it
-into an issue, or capture it in a screenshot or terminal recording.
+Serve, and prints a credential-bearing HTTPS pairing URL and QR code. The URL
+carries the current shared mobile access secret and remains valid until that
+secret is rotated. In Coven Memory, scan the QR or paste the URL. Do not send
+the URL through chat, paste it into an issue, or capture it in a screenshot or
+terminal recording.
 
-The app then reads only:
+The app uses these bearer-protected routes:
 
 - `GET /api/mobile/coven-memory`
 - `GET /api/mobile/coven-memory/overview`
 - `GET /api/mobile/coven-memory/{id}`
+- `POST /api/mobile-token/refresh`
 
 Every request needs a currently valid mobile bearer credential. Cave validates
 that boundary before reading configuration or contacting the loopback Coven
 socket. The routes are read-only, force dynamic responses, return
 `private, no-store`, omit daemon paths, and fail closed when Coven is missing,
-incompatible, or returns an invalid payload.
+incompatible, or returns an invalid payload. Token refresh renews the active
+credential but does not mutate memory.
 
 ## Status, stop, and recovery
 

--- a/scripts/mobile-tailscale.sh
+++ b/scripts/mobile-tailscale.sh
@@ -500,28 +500,6 @@ const [backendUrl, input] = process.argv.slice(2);
 NODE
 }
 
-tailscale_ip_host() {
-  local self_json
-  if ! self_json="$(tailscale_capture status --self --json 2>/dev/null)"; then
-    return 1
-  fi
-
-  node - "$self_json" <<'NODE'
-const input = process.argv[2] || "";
-let status;
-try {
-  status = JSON.parse(input);
-} catch {
-  process.exit(1);
-}
-const rawIps = status?.Self?.TailscaleIPs ?? status?.TailscaleIPs;
-const ips = Array.isArray(rawIps) ? rawIps.filter((ip) => typeof ip === "string") : [];
-const ipv4 = ips.find((ip) => /^100\.\d+\.\d+\.\d+$/.test(ip));
-if (!ipv4) process.exit(1);
-console.log(ipv4);
-NODE
-}
-
 create_invite() {
   need node
   load_or_create_token
@@ -642,9 +620,9 @@ app_command() {
     APP_URL="$(serve_url_from_status "$TAILSCALE_BACKEND" "$status_json" 2>/dev/null || true)"
   fi
   if [ -z "$APP_URL" ]; then
-    APP_IP_HOST="$(tailscale_ip_host)"
-    tailscale_cmd serve --bg --http="$PORT" "$TAILSCALE_BACKEND" >/dev/null
-    APP_URL="http://${APP_IP_HOST}:${PORT}/"
+    echo "Could not determine an HTTPS Tailscale Serve URL for the native app." >&2
+    echo "Confirm MagicDNS and HTTPS are enabled, run 'pnpm mobile:tailscale:stop', then retry." >&2
+    exit 1
   fi
 
   APP_PAIRING_URL="$(node -e "const url = new URL(process.argv[1]); url.searchParams.set('coven_access_token', process.argv[2]); process.stdout.write(url.toString())" "$APP_URL" "$ACCESS_TOKEN")"

--- a/scripts/mobile-tailscale.test.mjs
+++ b/scripts/mobile-tailscale.test.mjs
@@ -44,12 +44,10 @@ test("mobile tailscale runner can use an explicit Tailscale binary", () => {
   assert.match(script, /command -v "\$TAILSCALE_BIN"/);
 });
 
-test("mobile tailscale app mode falls back to Tailscale IP HTTP when MagicDNS is missing", () => {
-  assert.match(script, /tailscale_ip_host\(\)/);
-  assert.match(script, /Array\.isArray\(rawIps\)/);
-  assert.match(script, /typeof ip === "string"/);
-  assert.match(script, /tailscale_cmd serve --bg --http="\$PORT" "\$TAILSCALE_BACKEND"/);
-  assert.match(script, /APP_URL="http:\/\/\$\{APP_IP_HOST\}:\$\{PORT\}\/"/);
+test("mobile tailscale app mode fails closed when HTTPS Serve is unavailable", () => {
+  assert.match(script, /Could not determine an HTTPS Tailscale Serve URL/);
+  assert.doesNotMatch(script, /tailscale_cmd serve --bg --http=/);
+  assert.doesNotMatch(script, /APP_URL="http:\/\//);
 });
 
 test("mobile tailscale app mode records ownership separately from sidecar tokens", () => {

--- a/src/app/api/coven-memory/route.test.ts
+++ b/src/app/api/coven-memory/route.test.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -24,6 +25,19 @@ const ORIGINAL_ENV = {
   COVEN_SOCKET: process.env.COVEN_SOCKET,
   COVEN_CAVE_AUTH_TOKEN: process.env.COVEN_CAVE_AUTH_TOKEN,
 };
+
+function readFixture(name: string): unknown {
+  const fixturePath = path.resolve(
+    import.meta.dirname,
+    "../../../../tests/fixtures/mobile-canonical-memory-v1",
+    name,
+  );
+  return JSON.parse(readFileSync(fixturePath, "utf8"));
+}
+
+const listSuccessFixture = readFixture("cave-list-success.json");
+const overviewSuccessFixture = readFixture("cave-overview-success.json");
+const detailSuccessFixture = readFixture("cave-detail-success.json");
 
 mkdirSync(COVEN_HOME, { recursive: true });
 mkdirSync(CAVE_HOME, { recursive: true });
@@ -302,6 +316,9 @@ test("mobile canonical-memory routes require a verified mobile request before da
   });
   assert.equal(overviewBody.overview.totals.entries, 1);
   assert.equal(detailBody.entry.id, MEMORY_ID);
+  assert.deepEqual(listBody, listSuccessFixture);
+  assert.deepEqual(overviewBody, overviewSuccessFixture);
+  assert.deepEqual(detailBody, detailSuccessFixture);
 
   before = socketPaths.length;
   for (const [routeModule, pathname] of [

--- a/src/app/api/mobile-token/refresh/route.ts
+++ b/src/app/api/mobile-token/refresh/route.ts
@@ -5,6 +5,10 @@ import { ACCESS_TOKEN_COOKIE, ACCESS_TOKEN_QUERY_PARAM } from "@/proxy-helpers";
 
 export const dynamic = "force-dynamic";
 
+const PRIVATE_NO_STORE_HEADERS = {
+  "Cache-Control": "private, no-store",
+};
+
 /** The credential the caller actually presented — same sources, same order,
  *  as the proxy's mobileAccessGate (Bearer header, cookie, query param). */
 function suppliedCredential(req: NextRequest): string | null {
@@ -33,15 +37,24 @@ export async function POST(req: NextRequest) {
     secret: process.env.COVEN_CAVE_ACCESS_TOKEN?.trim() || null,
   });
   if (!result.ok) {
-    return NextResponse.json({ ok: false, error: result.error }, { status: result.status });
+    return NextResponse.json(
+      { ok: false, error: result.error },
+      {
+        status: result.status,
+        headers: PRIVATE_NO_STORE_HEADERS,
+      },
+    );
   }
   // Paired-signal beat (cave-i74f): a successful refresh IS the proof a paired
   // device is alive — record it so the desktop's Settings card can say so.
   await recordMobileSeen();
-  return NextResponse.json({
-    ok: true,
-    token: result.token,
-    expiresAt: result.expiresAt,
-    expiresAtIso: new Date(result.expiresAt).toISOString(),
-  });
+  return NextResponse.json(
+    {
+      ok: true,
+      token: result.token,
+      expiresAt: result.expiresAt,
+      expiresAtIso: new Date(result.expiresAt).toISOString(),
+    },
+    { headers: PRIVATE_NO_STORE_HEADERS },
+  );
 }

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -256,6 +256,16 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
 
   const refresh = read("../app/api/mobile-token/refresh/route.ts");
   assert.match(refresh, /await recordMobileSeen\(\);/, "a successful token refresh records the paired-device beat");
+  assert.match(
+    refresh,
+    /const PRIVATE_NO_STORE_HEADERS = \{\s*"Cache-Control": "private, no-store",?\s*\}/,
+    "token refresh declares the private no-store response boundary",
+  );
+  assert.equal(
+    refresh.match(/headers: PRIVATE_NO_STORE_HEADERS/g)?.length,
+    2,
+    "token refresh applies private no-store headers to success and failure responses",
+  );
 
   const modal = read("../components/mobile-handoff-modal.tsx");
   assert.match(modal, /chatId \? \{ action: "app-start", chatId \} : \{ action: "app-start" \}/, "the modal forwards its chatId to app-start");

--- a/tests/fixtures/mobile-canonical-memory-v1/cave-detail-success.json
+++ b/tests/fixtures/mobile-canonical-memory-v1/cave-detail-success.json
@@ -1,0 +1,29 @@
+{
+  "ok": true,
+  "entry": {
+    "id": "11111111-1111-5111-8111-111111111111",
+    "familiarId": "fixture-familiar",
+    "title": "fixture-note",
+    "updatedAt": "2026-07-26T09:56:00Z",
+    "source": {
+      "kind": "coven-origin",
+      "label": "Coven origin"
+    },
+    "content": "Synthetic detail.",
+    "contentFormat": "markdown",
+    "privacy": {
+      "classification": null,
+      "revealRequired": null,
+      "reason": "privacy taxonomy unavailable"
+    },
+    "verification": {
+      "state": "unknown",
+      "reason": "verification metadata unavailable"
+    },
+    "attestationMetadata": null,
+    "supersession": {
+      "supersedes": null,
+      "supersededBy": null
+    }
+  }
+}

--- a/tests/fixtures/mobile-canonical-memory-v1/cave-error-cases.json
+++ b/tests/fixtures/mobile-canonical-memory-v1/cave-error-cases.json
@@ -1,0 +1,30 @@
+[
+  {
+    "ok": false,
+    "code": "mobile_access_required"
+  },
+  {
+    "ok": false,
+    "code": "local_daemon_required"
+  },
+  {
+    "ok": false,
+    "code": "canonical_memory_unavailable"
+  },
+  {
+    "ok": false,
+    "code": "capability_unavailable"
+  },
+  {
+    "ok": false,
+    "code": "daemon_update_required"
+  },
+  {
+    "ok": false,
+    "code": "invalid_daemon_payload"
+  },
+  {
+    "ok": false,
+    "code": "memory_not_found"
+  }
+]

--- a/tests/fixtures/mobile-canonical-memory-v1/cave-list-success.json
+++ b/tests/fixtures/mobile-canonical-memory-v1/cave-list-success.json
@@ -1,0 +1,24 @@
+{
+  "ok": true,
+  "entries": [
+    {
+      "id": "11111111-1111-5111-8111-111111111111",
+      "familiarId": "fixture-familiar",
+      "title": "fixture-note",
+      "updatedAt": "2026-07-26T09:56:00Z",
+      "relativeUpdatedAt": "4m ago",
+      "excerpt": "Synthetic summary.",
+      "source": {
+        "kind": "coven-origin",
+        "label": "Coven origin"
+      },
+      "privacy": {
+        "classification": null,
+        "revealRequired": null
+      },
+      "verification": {
+        "state": "unknown"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/mobile-canonical-memory-v1/cave-overview-success.json
+++ b/tests/fixtures/mobile-canonical-memory-v1/cave-overview-success.json
@@ -1,0 +1,28 @@
+{
+  "ok": true,
+  "overview": {
+    "generatedAt": "2026-07-26T10:00:00Z",
+    "totals": {
+      "entries": 1,
+      "familiars": 1,
+      "verified": 0,
+      "needsReview": 0,
+      "unknown": 1
+    },
+    "lastUpdatedAt": "2026-07-26T09:56:00Z",
+    "capabilities": {
+      "detail": true,
+      "verification": false,
+      "attestationMetadata": false,
+      "supersessionHistory": false,
+      "mutations": false
+    },
+    "verification": {
+      "state": "unavailable",
+      "checkedAt": "2026-07-26T10:00:00Z",
+      "manifest": null,
+      "index": null,
+      "issues": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add shared canonical-memory response fixtures for the iOS client contract
- assert Cave routes serialize the exact successful fixture payloads
- document the mobile token-refresh route and shared-secret lifetime
- fail closed when the native-app flow cannot obtain an HTTPS Tailscale Serve URL
- mark refresh success and failure responses private, no-store

## Why

Coven Memory needs a stable upstream contract and an honest pairing boundary before its iOS beta-readiness branch can rely on these payloads in CI.

## Impact

No canonical-memory API behavior changes. The mobile operator script no longer emits an HTTP fallback that the native client rejects, and token-refresh responses now explicitly prohibit caching.

## Verification

- pnpm typecheck
- pnpm lint
- pnpm test:mobile (77 files)
- mobile-tailscale tests (14/14) and bash syntax
- refresh success/error no-store route assertion
- all 325 API test files on the rebased branch baseline
- changed-file secret preflight
- exact fixture parity with the coven-memory iOS test bundle
- independent security re-review: no Critical, Important, or Minor findings