### PR TITLE
fix(ios): batch bulk reminder actions and stop reverting the whole batch

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -809,6 +809,41 @@ struct CaveClient {
 
     struct ReminderActionResponse: Decodable { var ok: Bool; var error: String?; var item: Reminder? }
 
+    /// What a bulk call actually did, per item (cave-ioswipe.2). The endpoint
+    /// echoes only what it changed, so an id requested but present in NEITHER
+    /// list did not take effect — that absence is the per-item failure signal,
+    /// and it is why a partial failure no longer has to revert the whole batch.
+    struct BulkInboxOutcome: Decodable {
+        var ok: Bool
+        var updated: [Reminder]
+        var deletedIds: [String]
+
+        enum CodingKeys: String, CodingKey { case ok, updated, deletedIds }
+
+        init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            ok = (try? c.decode(Bool.self, forKey: .ok)) ?? true
+            updated = (try? c.decode([Reminder].self, forKey: .updated)) ?? []
+            deletedIds = (try? c.decode([String].self, forKey: .deletedIds)) ?? []
+        }
+    }
+
+    /// `POST /api/inbox/bulk` — one round trip for read/unread/dismiss/done/
+    /// delete over many ids, replacing N sequential per-id calls.
+    ///
+    /// Snooze is deliberately NOT routed here: the endpoint has no `snooze`
+    /// action and no slot for its `minutes` argument. AppModel fans that one out
+    /// with bounded concurrency instead, which the bead's acceptance criteria
+    /// allow ("one round trip OR bounded concurrency"). Extending the server
+    /// action set is a separate, deliberate change — not something to slip in.
+    func bulkInboxAction(_ action: String, ids: [String]) async throws -> BulkInboxOutcome {
+        let body = try JSONSerialization.data(withJSONObject: ["action": action, "ids": ids])
+        let req = try request("api/inbox/bulk", method: "POST", body: body)
+        let (data, resp) = try await data(for: req)
+        try Self.check(resp)
+        return try JSONDecoder().decode(BulkInboxOutcome.self, from: data)
+    }
+
     /// `POST /api/inbox/{id}/{action}` — done / dismiss / snooze. Returns the
     /// server's updated item when present.
     @discardableResult

--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift
@@ -841,7 +841,11 @@ struct CaveClient {
         let req = try request("api/inbox/bulk", method: "POST", body: body)
         let (data, resp) = try await data(for: req)
         try Self.check(resp)
-        return try JSONDecoder().decode(BulkInboxOutcome.self, from: data)
+        do {
+            return try JSONDecoder().decode(BulkInboxOutcome.self, from: data)
+        } catch {
+            throw CaveError.decoding(String(describing: error))
+        }
     }
 
     /// `POST /api/inbox/{id}/{action}` — done / dismiss / snooze. Returns the

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -162,6 +162,19 @@ final class AppModel {
         Haptics.error()
     }
 
+    /// A batch that partly landed (cave-ioswipe.2). Says how many of how many
+    /// failed, because the old wholesale "reverted" message was actively
+    /// misleading here: most of the batch DID take effect server-side, and only
+    /// the named few came back.
+    private func reportPartial(_ failed: Int, of total: Int, verb: String) {
+        showToast(
+            "Couldn’t \(verb) \(failed) of \(total) — those were restored",
+            systemImage: "exclamationmark.triangle.fill",
+            style: .error,
+        )
+        Haptics.error()
+    }
+
     /// Ask the chat list to open a thread (switches to Chats first).
     func requestOpen(_ thread: ChatThread) {
         selectedTab = .chats
@@ -743,14 +756,24 @@ final class AppModel {
     }
 
 
-    /// Optimistically remove reminders, then DELETE each; reverts on failure.
+    /// Optimistically remove reminders, then delete them in ONE round trip
+    /// (cave-ioswipe.2). Previously this was N sequential DELETEs that reverted
+    /// the whole batch on any failure — so item 20 failing silently undid the
+    /// optimistic removal of items 1-19 whose server-side deletes had already
+    /// succeeded, leaving the UI disagreeing with the server. Now only the ids
+    /// the server did NOT confirm come back.
     func deleteReminders(_ ids: Set<String>) async {
         guard let client, !ids.isEmpty else { return }
         let previous = reminders
         reminders.removeAll { ids.contains($0.id) }
         do {
-            for id in ids { try await client.deleteReminder(id: id) }
-            Haptics.success()
+            let outcome = try await client.bulkInboxAction("delete", ids: Array(ids))
+            let deleted = Set(outcome.deletedIds)
+            let missed = ids.subtracting(deleted)
+            guard !missed.isEmpty else { Haptics.success(); return }
+            // Restore only what did not take effect, preserving list order.
+            reminders = previous.filter { !deleted.contains($0.id) }
+            reportPartial(missed.count, of: ids.count, verb: "delete")
         } catch {
             reminders = previous
             remindersError = error.localizedDescription
@@ -788,32 +811,105 @@ final class AppModel {
     // MARK: - Bulk reminder actions
 
     func markRemindersDone(_ ids: Set<String>) async {
-        await bulkReminderAction(ids, optimistic: "done") { try await $0.markReminderDone(id: $1) }
+        await bulkServerAction(ids, optimistic: "done", action: "done")
     }
     func dismissReminders(_ ids: Set<String>) async {
-        await bulkReminderAction(ids, optimistic: "dismissed") { try await $0.dismissReminder(id: $1) }
-    }
-    func snoozeReminders(_ ids: Set<String>, minutes: Int) async {
-        await bulkReminderAction(ids, optimistic: "snoozed") { try await $0.snoozeReminder(id: $1, minutes: minutes) }
+        await bulkServerAction(ids, optimistic: "dismissed", action: "dismiss")
     }
 
-    /// Apply an action to every selected reminder: optimistic status for all,
-    /// then run each server call reconciling its echoed item; revert all on any
-    /// failure.
-    private func bulkReminderAction(_ ids: Set<String>, optimistic: String,
-                                    _ call: @escaping (CaveClient, String) async throws -> Reminder?) async {
+    /// Snooze is the one bulk action WITHOUT a server counterpart: the bulk
+    /// endpoint has no `snooze` action and no slot for its `minutes` argument.
+    /// The bead's acceptance criteria allow "one round trip OR bounded
+    /// concurrency", so this fans out with a small in-flight cap rather than
+    /// extending a request-guarded API surface as a side effect of a client fix.
+    func snoozeReminders(_ ids: Set<String>, minutes: Int) async {
+        await boundedReminderFanOut(ids, optimistic: "snoozed", verb: "snooze") {
+            try await $0.snoozeReminder(id: $1, minutes: minutes)
+        }
+    }
+
+    /// One round trip for the actions the bulk endpoint supports. Items echoed
+    /// in `updated` succeeded; ids absent from it did not take effect and are
+    /// the only ones reverted — the old all-or-nothing revert made the UI
+    /// disagree with a server that had already applied most of the batch.
+    private func bulkServerAction(_ ids: Set<String>, optimistic: String, action: String) async {
         guard let client, !ids.isEmpty else { return }
         let previous = reminders
         for id in ids { applyReminder(id: id) { $0.status = optimistic } }
         do {
-            for id in ids {
-                if let updated = try await call(client, id) { applyReminder(id: id) { $0 = updated } }
+            let outcome = try await client.bulkInboxAction(action, ids: Array(ids))
+            var confirmed = Set<String>()
+            for item in outcome.updated {
+                applyReminder(id: item.id) { $0 = item }
+                confirmed.insert(item.id)
             }
-            Haptics.success()
+            for id in outcome.deletedIds { confirmed.insert(id) }
+            let missed = ids.subtracting(confirmed)
+            guard !missed.isEmpty else { Haptics.success(); return }
+            revert(missed, to: previous)
+            reportPartial(missed.count, of: ids.count, verb: "update")
         } catch {
             reminders = previous
             remindersError = error.localizedDescription
             reportRevert("update the reminders")
+        }
+    }
+
+    /// Bounded concurrent fan-out for actions with no bulk endpoint. Caps
+    /// in-flight requests so a large selection cannot open one socket per item,
+    /// and reverts only the items that actually failed.
+    private static let reminderFanOutWidth = 4
+
+    private func boundedReminderFanOut(
+        _ ids: Set<String>,
+        optimistic: String,
+        verb: String,
+        _ call: @escaping @Sendable (CaveClient, String) async throws -> Reminder?,
+    ) async {
+        guard let client, !ids.isEmpty else { return }
+        let previous = reminders
+        for id in ids { applyReminder(id: id) { $0.status = optimistic } }
+
+        let ordered = Array(ids)
+        let width = min(Self.reminderFanOutWidth, ordered.count)
+        let results = await withTaskGroup(of: (String, Reminder?, Bool).self) { group -> [(String, Reminder?, Bool)] in
+            var next = 0
+            func addTask() {
+                guard next < ordered.count else { return }
+                let id = ordered[next]
+                next += 1
+                group.addTask {
+                    do { return (id, try await call(client, id), true) }
+                    catch { return (id, nil, false) }
+                }
+            }
+            for _ in 0..<width { addTask() }
+            var out: [(String, Reminder?, Bool)] = []
+            while let finished = await group.next() {
+                out.append(finished)
+                addTask()   // keep exactly `width` in flight
+            }
+            return out
+        }
+
+        var failed = Set<String>()
+        for (id, updated, ok) in results {
+            if ok { if let updated { applyReminder(id: id) { $0 = updated } } } else { failed.insert(id) }
+        }
+        guard !failed.isEmpty else { Haptics.success(); return }
+        revert(failed, to: previous)
+        reportPartial(failed.count, of: ids.count, verb: verb)
+    }
+
+    /// Put back only the named ids, leaving successful siblings applied.
+    private func revert(_ ids: Set<String>, to previous: [Reminder]) {
+        for id in ids {
+            guard let old = previous.first(where: { $0.id == id }) else { continue }
+            if let idx = reminders.firstIndex(where: { $0.id == id }) {
+                reminders[idx] = old
+            } else {
+                reminders.append(old)
+            }
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -811,10 +811,10 @@ final class AppModel {
     // MARK: - Bulk reminder actions
 
     func markRemindersDone(_ ids: Set<String>) async {
-        await bulkServerAction(ids, optimistic: "done", action: "done")
+        await bulkServerAction(ids, optimistic: "done", action: "done", verb: "mark done")
     }
     func dismissReminders(_ ids: Set<String>) async {
-        await bulkServerAction(ids, optimistic: "dismissed", action: "dismiss")
+        await bulkServerAction(ids, optimistic: "dismissed", action: "dismiss", verb: "dismiss")
     }
 
     /// Snooze is the one bulk action WITHOUT a server counterpart: the bulk
@@ -832,7 +832,10 @@ final class AppModel {
     /// in `updated` succeeded; ids absent from it did not take effect and are
     /// the only ones reverted — the old all-or-nothing revert made the UI
     /// disagree with a server that had already applied most of the batch.
-    private func bulkServerAction(_ ids: Set<String>, optimistic: String, action: String) async {
+    /// `verb` is what the user is told, and it is passed rather than derived
+    /// from `action` because the two are not the same vocabulary: the wire
+    /// action is "done", the sentence needs "mark done".
+    private func bulkServerAction(_ ids: Set<String>, optimistic: String, action: String, verb: String) async {
         guard let client, !ids.isEmpty else { return }
         let previous = reminders
         for id in ids { applyReminder(id: id) { $0.status = optimistic } }
@@ -847,7 +850,7 @@ final class AppModel {
             let missed = ids.subtracting(confirmed)
             guard !missed.isEmpty else { Haptics.success(); return }
             revert(missed, to: previous)
-            reportPartial(missed.count, of: ids.count, verb: "update")
+            reportPartial(missed.count, of: ids.count, verb: verb)
         } catch {
             reminders = previous
             remindersError = error.localizedDescription

--- a/scripts/ios-bulk-reminders.test.mjs
+++ b/scripts/ios-bulk-reminders.test.mjs
@@ -1,0 +1,88 @@
+// cave-ioswipe.2: bulk reminder actions must not be N sequential round trips,
+// and a partial failure must not revert the whole batch.
+//
+// iOS Swift is NOT compiled by CI, so this source-text contract is the only
+// gate these properties have. Each assertion below is checked to FAIL against
+// its specific regression, not merely to pass.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const client = await read("apps/ios/CovenCave/CovenCave/Networking/CaveClient.swift");
+
+// --- One round trip, not N -------------------------------------------------
+assert.match(
+  client,
+  /func bulkInboxAction\(_ action: String, ids: \[String\]\) async throws -> BulkInboxOutcome/,
+  "the client needs a bulk entry point or AppModel has nothing to batch against",
+);
+assert.match(
+  client,
+  /request\("api\/inbox\/bulk", method: "POST"/,
+  "bulk actions must hit the existing /api/inbox/bulk endpoint",
+);
+assert.match(
+  model,
+  /client\.bulkInboxAction\("delete", ids: Array\(ids\)\)/,
+  "deleteReminders must delete in one round trip",
+);
+assert.match(
+  model,
+  /private func bulkServerAction\([\s\S]*?client\.bulkInboxAction\(action, ids: Array\(ids\)\)/,
+  "done/dismiss must go through the bulk endpoint",
+);
+
+// The old shape: a per-id loop awaiting inside. Its return would silently
+// reinstate N round trips while every other assertion here still passed.
+assert.doesNotMatch(
+  model,
+  /for id in ids \{\s*\n\s*try await client\.deleteReminder\(id: id\)/,
+  "no per-id delete loop may come back",
+);
+
+// --- Partial failure must not revert the whole batch -----------------------
+// This is the more serious half: the old code reverted `previous` wholesale, so
+// one late failure undid the optimistic state of items the server HAD already
+// changed, leaving the UI disagreeing with the server.
+assert.match(
+  model,
+  /private func revert\(_ ids: Set<String>, to previous: \[Reminder\]\)/,
+  "there must be a targeted revert that restores only the named ids",
+);
+assert.match(
+  model,
+  /let missed = ids\.subtracting\(confirmed\)[\s\S]*?revert\(missed, to: previous\)/,
+  "only ids the server did not confirm may be reverted",
+);
+assert.match(
+  model,
+  /func reportPartial\(_ failed: Int, of total: Int, verb: String\)/,
+  "a partly-applied batch needs its own message — 'reverted' alone is misleading",
+);
+
+// --- Snooze: bounded concurrency, and NOT smuggled into the bulk endpoint ---
+// The endpoint has no `snooze` action and no slot for `minutes`; routing it
+// there would 400 at best and silently no-op at worst.
+assert.doesNotMatch(
+  model,
+  /bulkInboxAction\("snooze"/,
+  "snooze has no bulk action server-side — it must not be routed there",
+);
+assert.match(
+  model,
+  /private static let reminderFanOutWidth = \d+/,
+  "the fan-out must be bounded, or a large selection opens one socket per item",
+);
+assert.match(
+  model,
+  /for _ in 0\.\.<width \{ addTask\(\) \}[\s\S]*?while let finished = await group\.next\(\)[\s\S]*?addTask\(\)/,
+  "the fan-out must refill to keep exactly `width` in flight, not launch all at once",
+);
+assert.match(
+  model,
+  /func snoozeReminders\(_ ids: Set<String>, minutes: Int\) async \{\s*\n\s*await boundedReminderFanOut/,
+  "snoozeReminders must use the bounded fan-out",
+);
+
+console.log("ios-bulk-reminders: OK");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1445,6 +1445,7 @@ export const SUITES = {
     "scripts/ios-ats-protections.test.mjs",
     "scripts/ios-self-healing-sync.test.mjs",
     "scripts/ios-connection-stability.test.mjs",
+    "scripts/ios-bulk-reminders.test.mjs",
     "scripts/ios-reconnect-pill.test.mjs",
     "scripts/ios-port-discovery.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",


### PR DESCRIPTION
Implements **cave-ioswipe.2**.

Two loops in `AppModel` issued **N sequential round trips** — `deleteReminders` (per-id `DELETE`) and `bulkReminderAction` (per-id `POST`) — and both were all-or-nothing: any single throw restored `previous` wholesale.

## The latency was the visible half; divergence was the worse half

On a 20-item sweep, item 20 failing reverted the optimistic state of items 1–19 **whose server-side writes had already succeeded**. The UI rolled back, the server did not, and nothing said so.

## Uses the bulk endpoint that already existed

`src/app/api/inbox/bulk` (`POST {action, ids}` → `{updated, deletedIds}`). **No server change.** Its response *is* the per-item outcome signal the acceptance criteria ask for: echoed in `updated` or `deletedIds` = applied; requested but in neither = did not take effect.

| action | before | after |
|---|---|---|
| done / dismiss / delete | N round trips | **one** |
| snooze | N round trips | bounded fan-out, width 4 |

## Snooze is deliberately not bulked

The endpoint has no `snooze` action and no slot for its `minutes` argument, so routing it there would 400 at best. The acceptance criteria allow *"one round trip **or** bounded concurrency"*, so snooze fans out with a small in-flight cap rather than extending a request-guarded API surface as a side effect of a client fix.

Extending `BulkAction` server-side stays open as a deliberate choice — not something to slip in here.

## Partial failures

Only ids the server did not confirm are reverted, and `reportPartial` names how many of how many failed. The old blanket *"reverted"* message was actively misleading when most of the batch had landed.

## Verification

- `swiftc -parse` clean on both Swift files — **iOS Swift is not compiled by CI**, so that check is manual and the `.mjs` contract is the only automated gate
- each contract assertion **fails** against its specific regression, not merely passes:

| mutation | result |
|---|---|
| revert whole batch instead of missed-only | **fails** ✓ |
| route snooze through the bulk endpoint | **fails** ✓ |
| unbounded fan-out (launch all at once) | **fails** ✓ |
| restore the per-id delete loop | **fails** ✓ |
| unmodified | passes ✓ |

## Credit

Built on read-only design notes another session left on this bead (2026-08-01) after `bd` refused their claim. Their collision check against #4135 and their identification of the existing bulk endpoint saved re-deriving both.
