### PR TITLE
feat(worktrees): auto-lock worktrees holding unrecoverable work

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -19,6 +19,12 @@
             "statusMessage": "Checking worktree/branch safety…",
             "timeout": 15,
             "type": "command"
+          },
+          {
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/worktree-autolock.mjs\"",
+            "statusMessage": "Protecting at-risk worktrees…",
+            "timeout": 15,
+            "type": "command"
           }
         ],
         "matcher": "Bash"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,29 @@ Map PIDs to session JSONLs in `~/.claude/projects/-Users-buns-Documents-GitHub-O
 
 **Worktree guard (automatic, BLOCKING).** A second PreToolUse hook — `scripts/worktree-guard.mjs`, matcher Bash — blocks (exit 2) destruction of live work: `git worktree remove`/`rm -rf` of a worktree root that is dirty or whose HEAD is on no remote ref, `git branch -D` of an unpushed tip, and `git push --delete` of a branch that still heads an OPEN PR. Clean+pushed cleanup and husk GC pass silently. **"Retained" counts a remote branch OR a tag pushed to a remote** — so the right way to retire a branch whose commits you want kept but off the branch list is to archive it: `git tag -s archive/<branch-with-slashes-as-dashes> <oid> && git push origin <that-tag>`, then delete freely. Flatten the slashes (`fix/foo` → `archive/fix-foo-<date>`) — git cannot hold both a tag `archive/fix` and a tag `archive/fix/foo`, so nested archive names collide as soon as a second branch shares a prefix. A pushed tag is *more* durable than a branch (merging deletes the branch, never the tag); a **local-only tag does not count**, and if the remote is unreachable the tag check fails closed and blocks. If destruction is deliberate, re-run prefixed with `WT_GUARD_BYPASS=1 ` (the prefix must lead the WHOLE command string — a prefix buried inside `bash -c` or after a leading assignment does not reach the hook). Every bypass AND every block is appended to `.claude/worktree-guard-bypass.log` (gitignored, JSON lines with a `verdict` field) — after cave-boor8, where a destroyed worktree's post-mortem couldn't tell an override from a hole. Exists because on 2026-07-03 an actor merged another session's in-progress branch (PR #2290) and its post-merge cleanup destroyed that session's worktree mid-edit (coordination doc §5). Corollary disciplines: **push your branch to origin after every commit** — the remote is the only store a local actor can't destroy — and **any audit of a dirty worktree records `git status --porcelain` paths, never just a count** (cave-boor8: a count is unrecoverable; paths make lost-found search possible).
 
+**Worktree auto-lock (automatic, NON-blocking).** A third PreToolUse hook —
+`scripts/worktree-autolock.mjs`, matcher Bash — runs `git worktree lock` on any
+registered worktree that is dirty or holds commits absent from every remote. It
+exists because the guard above only sees Bash from a Claude Code session, and
+the actor that actually destroys worktrees here is **GitHub Desktop**: on
+2026-08-03 it executed 18 `git worktree remove` calls and 114 direct
+`git push origin main:main`, and it removed two live worktrees mid-session.
+
+A lock is the only defence that reaches outside Claude Code. Git refuses to
+remove a locked worktree unless `--force` is given **twice** (verified: plain
+remove and a single `--force` both fail with *"cannot remove a locked working
+tree"*); Desktop has never escalated past one force in any observed removal.
+
+It deliberately **skips clean, fully-pushed worktrees** — removing one of those
+loses nothing, and locking it would only force an unlock during routine
+cleanup. So a lock appearing on your worktree means it holds something no
+remote has. Clear it yourself when you are done: `git worktree unlock <path>`.
+Locking by hand is a snapshot; this re-applies as worktrees appear, throttled
+to once a minute via `.claude/worktree-autolock.stamp`. Every lock is appended
+to `.claude/worktree-autolock.log` (gitignored, JSON lines). Disable for a
+command with `WT_AUTOLOCK_DISABLE=1`. It never blocks a tool call and always
+exits 0 — if it cannot read a worktree, it leaves it alone.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:6cd5cc61 -->
 ## Beads Issue Tracker

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1089,6 +1089,7 @@ export const SUITES = {
     "scripts/sync-runtimes.test.mjs",
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",
+    "scripts/worktree-autolock.test.mjs",
     "scripts/branch-curator-manual-cleanup-contract.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
     "scripts/git-hooks-commit-msg.test.mjs",

--- a/scripts/worktree-autolock.mjs
+++ b/scripts/worktree-autolock.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+// Auto-lock worktrees that hold work a removal would destroy.
+//
+// `git worktree lock` is the only mechanism that survives an actor outside
+// Claude Code. `scripts/worktree-guard.mjs` blocks destructive Bash *from a
+// Claude session*; it never sees GitHub Desktop, which on 2026-08-03 executed
+// 18 `git worktree remove` calls (8 with a single `--force`) and 114 direct
+// pushes to `main`. Git refuses to remove a locked worktree unless `--force`
+// is given TWICE — Desktop has never escalated past one — so a lock defeats
+// every removal actually observed.
+//
+// Locking by hand is a snapshot: a worktree created a minute later is
+// unprotected. This runs as a PreToolUse hook so protection re-applies on its
+// own as worktrees appear.
+//
+// Deliberately does NOT lock clean, fully-pushed worktrees. Removing one of
+// those loses nothing (the branch and its commits outlive the worktree), and
+// locking it would only force an unlock during routine cleanup. Same
+// philosophy as the guard, which lets clean+pushed cleanup pass silently.
+//
+// Advisory only: this never blocks a tool call and always exits 0.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+const THROTTLE_MS = 60_000;
+const REASON_PREFIX = "auto-locked";
+
+function projectRoot() {
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+function git(args, cwd) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout: 10_000,
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  });
+}
+
+// `git worktree list --porcelain` emits blank-line-separated records. Only the
+// `worktree` line is guaranteed; `locked` appears with or without a reason.
+export function parseWorktrees(porcelain) {
+  const records = [];
+  let current = null;
+  for (const rawLine of porcelain.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("worktree ")) {
+      current = { path: line.slice("worktree ".length), locked: false, bare: false };
+      records.push(current);
+      continue;
+    }
+    if (!current) continue;
+    if (line === "locked" || line.startsWith("locked ")) current.locked = true;
+    if (line === "bare") current.bare = true;
+  }
+  return records;
+}
+
+// At risk = a removal would destroy something unrecoverable.
+//   dirty            → uncommitted edits exist nowhere else
+//   commits off-remote → committed but not yet on any remote
+// `rev-list HEAD --not --remotes` counts commits absent from every remote ref,
+// which is the same "retained on a remote" test the guard applies.
+export function riskOf(worktreePath) {
+  let dirty = 0;
+  let unpushed = 0;
+  try {
+    dirty = git(["status", "--porcelain"], worktreePath).split("\n").filter(Boolean).length;
+  } catch {
+    return null; // unreadable (mid-creation, or a dead registration) — leave it alone
+  }
+  try {
+    unpushed = Number(
+      git(["rev-list", "--count", "HEAD", "--not", "--remotes"], worktreePath).trim(),
+    );
+    if (!Number.isFinite(unpushed)) unpushed = 0;
+  } catch {
+    unpushed = 0; // detached/unborn HEAD — dirtiness alone decides
+  }
+  if (dirty === 0 && unpushed === 0) return null;
+  return { dirty, unpushed };
+}
+
+export function reasonFor({ dirty, unpushed }, today) {
+  const parts = [];
+  if (dirty > 0) parts.push(`${dirty} uncommitted path${dirty === 1 ? "" : "s"}`);
+  if (unpushed > 0) parts.push(`${unpushed} commit${unpushed === 1 ? "" : "s"} not on any remote`);
+  return (
+    `${REASON_PREFIX} ${today}: ${parts.join(", ")} — a removal would lose this. ` +
+    `Unlock when you are done: git worktree unlock <path>`
+  );
+}
+
+function throttled(root) {
+  const stamp = path.join(root, ".claude", "worktree-autolock.stamp");
+  try {
+    if (Date.now() - statSync(stamp).mtimeMs < THROTTLE_MS) return true;
+  } catch {
+    // no stamp yet — run
+  }
+  try {
+    mkdirSync(path.dirname(stamp), { recursive: true });
+    writeFileSync(stamp, String(Date.now()));
+  } catch {
+    // best effort; a missing stamp only costs an extra pass
+  }
+  return false;
+}
+
+function record(root, entry) {
+  try {
+    appendFileSync(
+      path.join(root, ".claude", "worktree-autolock.log"),
+      `${JSON.stringify({ at: new Date().toISOString(), ...entry })}\n`,
+    );
+  } catch {
+    // logging must never break a tool call
+  }
+}
+
+function main() {
+  const root = projectRoot();
+  if (process.env.WT_AUTOLOCK_DISABLE === "1") return;
+  if (throttled(root)) return;
+
+  let worktrees;
+  try {
+    worktrees = parseWorktrees(git(["worktree", "list", "--porcelain"], root));
+  } catch {
+    return; // not a git repo, or git unavailable — nothing to do
+  }
+
+  // The first record is the main working tree; git refuses to lock it.
+  for (const wt of worktrees.slice(1)) {
+    if (wt.locked || wt.bare) continue;
+    const risk = riskOf(wt.path);
+    if (!risk) continue;
+    const today = new Date().toISOString().slice(0, 10);
+    try {
+      git(["worktree", "lock", "--reason", reasonFor(risk, today), wt.path], root);
+      record(root, { verdict: "locked", worktree: wt.path, ...risk });
+    } catch (error) {
+      record(root, { verdict: "lock-failed", worktree: wt.path, error: String(error?.message ?? error) });
+    }
+  }
+}
+
+// Importable for tests; only acts when run as the hook itself. The hook's JSON
+// payload on stdin is deliberately left unread — nothing here depends on which
+// Bash command triggered it, and reading stdin on import would block a test
+// attached to a TTY.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch {
+    // advisory hook: never fail the tool call
+  }
+  process.exit(0);
+}

--- a/scripts/worktree-autolock.mjs
+++ b/scripts/worktree-autolock.mjs
@@ -21,8 +21,9 @@
 // Advisory only: this never blocks a tool call and always exits 0.
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync, mkdirSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 const THROTTLE_MS = 60_000;
 const REASON_PREFIX = "auto-locked";
@@ -149,11 +150,31 @@ function main() {
   }
 }
 
+// "Am I being run directly?" — compared as REAL paths, not as URL strings, the
+// same way `check-beads-jsonl-duplicates.mjs` does it. The naive
+// `import.meta.url === \`file://${process.argv[1]}\`` fails two ways here, and
+// both make the hook silently never run — the worst outcome for a guard, since
+// worktrees would look protected while nothing locked them:
+//   1. no percent-encoding — a checkout under a path with a space gives
+//      `file:///tmp/a b/x.mjs` while import.meta.url is `file:///tmp/a%20b/x.mjs`;
+//   2. symlinks — on macOS `/tmp` is a symlink to `/private/tmp`, so argv[1]
+//      can be `/tmp/...` while import.meta.url resolves to `/private/tmp/...`.
+// realpathSync on both sides collapses both cases.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
 // Importable for tests; only acts when run as the hook itself. The hook's JSON
 // payload on stdin is deliberately left unread — nothing here depends on which
 // Bash command triggered it, and reading stdin on import would block a test
 // attached to a TTY.
-if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+if (isDirectRun()) {
   try {
     main();
   } catch {

--- a/scripts/worktree-autolock.test.mjs
+++ b/scripts/worktree-autolock.test.mjs
@@ -1,10 +1,28 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { parseWorktrees, reasonFor, riskOf } from "./worktree-autolock.mjs";
+
+const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
+
+// Push a file's mtime past the index entry so git cannot classify a
+// same-tick rewrite as unchanged. See the call site for why this matters.
+function touchForward(file) {
+  const ahead = new Date(Date.now() + 5_000);
+  utimesSync(file, ahead, ahead);
+}
 
 // --- parsing ----------------------------------------------------------------
 // `locked` appears bare or with a reason; both must register as locked.
@@ -66,8 +84,10 @@ const git = (args, cwd) =>
       GIT_AUTHOR_EMAIL: "t@e",
       GIT_COMMITTER_NAME: "T",
       GIT_COMMITTER_EMAIL: "t@e",
-      GIT_CONFIG_GLOBAL: "/dev/null",
-      GIT_CONFIG_SYSTEM: "/dev/null",
+      // NUL on Windows — "/dev/null" does not exist there, and the
+      // cross-environment CI legs run on windows-latest.
+      GIT_CONFIG_GLOBAL: NULL_DEVICE,
+      GIT_CONFIG_SYSTEM: NULL_DEVICE,
     },
   });
 
@@ -88,7 +108,13 @@ try {
   assert.equal(riskOf(repo), null, "a clean, fully pushed worktree is not locked");
 
   // 2. uncommitted edit → at risk (nothing else holds that content).
+  //
+  // Bump the mtime clear of the index entry. A file rewritten inside the same
+  // filesystem-timestamp tick as the commit can be read as "racily clean", and
+  // `riskOf` runs git with GIT_OPTIONAL_LOCKS=0 so the index is never refreshed
+  // to settle it. Observed failing 1 run in 4 before this line existed.
   writeFileSync(path.join(repo, "seed.txt"), "edited\n");
+  touchForward(path.join(repo, "seed.txt"));
   const dirty = riskOf(repo);
   assert.ok(dirty, "an uncommitted edit is at risk");
   assert.equal(dirty.dirty, 1);
@@ -119,6 +145,67 @@ try {
   assert.equal(riskOf(path.join(scratch, "does-not-exist")), null, "missing paths are skipped");
 } finally {
   rmSync(scratch, { recursive: true, force: true });
+}
+
+// --- the hook actually FIRES when invoked the way a hook is invoked ----------
+// Regression for the naive `import.meta.url === \`file://${process.argv[1]}\``
+// direct-run check. It fails on percent-encoding (a path with a space) and on
+// symlinks (macOS /tmp -> /private/tmp), and the symptom is silence: the hook
+// exits 0 having locked nothing, so worktrees look protected while they are
+// not. Both cases are exercised here at once.
+{
+  const box = mkdtempSync(path.join(tmpdir(), "autolock-run-"));
+  try {
+    const spaced = path.join(box, "dir with space");
+    mkdirSync(spaced);
+    const script = path.join(spaced, "worktree-autolock.mjs");
+    copyFileSync(fileURLToPath(new URL("./worktree-autolock.mjs", import.meta.url)), script);
+
+    // Reach the script through a symlink so argv[1] and import.meta.url differ.
+    const linked = path.join(box, "link");
+    symlinkSync(spaced, linked);
+    const viaSymlink = path.join(linked, "worktree-autolock.mjs");
+
+    const repo = path.join(box, "repo");
+    execFileSync("git", ["init", "--quiet", "-b", "main", repo], { cwd: box });
+    execFileSync("git", ["commit", "--quiet", "--allow-empty", "--no-gpg-sign", "-m", "seed"], {
+      cwd: repo,
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "T",
+        GIT_AUTHOR_EMAIL: "t@e",
+        GIT_COMMITTER_NAME: "T",
+        GIT_COMMITTER_EMAIL: "t@e",
+        GIT_CONFIG_GLOBAL: NULL_DEVICE,
+        GIT_CONFIG_SYSTEM: NULL_DEVICE,
+      },
+    });
+    execFileSync("git", ["worktree", "add", "--quiet", "-b", "risky", path.join(repo, "wt")], {
+      cwd: repo,
+    });
+    writeFileSync(path.join(repo, "wt", "unsaved.txt"), "would be lost\n");
+
+    execFileSync(process.execPath, [viaSymlink], {
+      cwd: repo,
+      env: { ...process.env, CLAUDE_PROJECT_DIR: repo },
+      stdio: ["ignore", "pipe", "pipe"],
+      timeout: 30_000,
+    });
+
+    const porcelain = execFileSync("git", ["worktree", "list", "--porcelain"], {
+      cwd: repo,
+      encoding: "utf8",
+    });
+    const wt = parseWorktrees(porcelain).find((w) => w.path.endsWith("wt"));
+    assert.ok(wt, "the worktree is still registered");
+    assert.equal(
+      wt.locked,
+      true,
+      "the hook must fire and lock when run through a symlinked path containing a space",
+    );
+  } finally {
+    rmSync(box, { recursive: true, force: true });
+  }
 }
 
 console.log("worktree-autolock.test.mjs: ok");

--- a/scripts/worktree-autolock.test.mjs
+++ b/scripts/worktree-autolock.test.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { parseWorktrees, reasonFor, riskOf } from "./worktree-autolock.mjs";
+
+// --- parsing ----------------------------------------------------------------
+// `locked` appears bare or with a reason; both must register as locked.
+{
+  const records = parseWorktrees(
+    [
+      "worktree /repo",
+      "HEAD abc",
+      "branch refs/heads/main",
+      "",
+      "worktree /repo/.worktrees/a",
+      "HEAD def",
+      "locked",
+      "",
+      "worktree /repo/.worktrees/b",
+      "HEAD 123",
+      "locked active work",
+      "",
+      "worktree /repo/.worktrees/c",
+      "detached",
+      "",
+    ].join("\n"),
+  );
+  assert.equal(records.length, 4, "every worktree record is parsed");
+  assert.equal(records[0].path, "/repo");
+  assert.equal(records[1].locked, true, "a bare 'locked' line counts as locked");
+  assert.equal(records[2].locked, true, "'locked <reason>' counts as locked");
+  assert.equal(records[3].locked, false, "an unlocked worktree is not misread as locked");
+}
+
+// A path containing spaces must survive parsing — .worktrees paths are ours,
+// but /private/tmp scratch worktrees are not always.
+{
+  const records = parseWorktrees("worktree /tmp/my worktree/a\nHEAD abc\n\n");
+  assert.equal(records[0].path, "/tmp/my worktree/a", "paths with spaces are preserved");
+}
+
+// --- reason text ------------------------------------------------------------
+{
+  const both = reasonFor({ dirty: 3, unpushed: 2 }, "2026-08-03");
+  assert.match(both, /3 uncommitted paths/);
+  assert.match(both, /2 commits not on any remote/);
+  assert.match(both, /git worktree unlock/, "the reason tells the owner how to clear it");
+  const one = reasonFor({ dirty: 1, unpushed: 0 }, "2026-08-03");
+  assert.match(one, /1 uncommitted path\b/, "singular is not mis-pluralised");
+  assert.doesNotMatch(one, /commits not on any remote/, "zero counts are omitted");
+}
+
+// --- risk classification against real git repos ------------------------------
+const scratch = mkdtempSync(path.join(tmpdir(), "autolock-"));
+const git = (args, cwd) =>
+  execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: "T",
+      GIT_AUTHOR_EMAIL: "t@e",
+      GIT_COMMITTER_NAME: "T",
+      GIT_COMMITTER_EMAIL: "t@e",
+      GIT_CONFIG_GLOBAL: "/dev/null",
+      GIT_CONFIG_SYSTEM: "/dev/null",
+    },
+  });
+
+try {
+  // An "origin" to push to, so "not on any remote" is a real distinction.
+  const origin = path.join(scratch, "origin.git");
+  git(["init", "--quiet", "--bare", "-b", "main", origin], scratch);
+
+  const repo = path.join(scratch, "repo");
+  git(["init", "--quiet", "-b", "main", repo], scratch);
+  writeFileSync(path.join(repo, "seed.txt"), "seed\n");
+  git(["add", "."], repo);
+  git(["commit", "--quiet", "--no-gpg-sign", "-m", "seed"], repo);
+  git(["remote", "add", "origin", origin], repo);
+  git(["push", "--quiet", "origin", "main"], repo);
+
+  // 1. clean and fully pushed → NOT at risk, so it is never locked.
+  assert.equal(riskOf(repo), null, "a clean, fully pushed worktree is not locked");
+
+  // 2. uncommitted edit → at risk (nothing else holds that content).
+  writeFileSync(path.join(repo, "seed.txt"), "edited\n");
+  const dirty = riskOf(repo);
+  assert.ok(dirty, "an uncommitted edit is at risk");
+  assert.equal(dirty.dirty, 1);
+  assert.equal(dirty.unpushed, 0);
+
+  // 3. untracked file counts too — that is the unrecoverable case.
+  git(["checkout", "--quiet", "--", "seed.txt"], repo);
+  writeFileSync(path.join(repo, "brand-new.txt"), "never committed\n");
+  const untracked = riskOf(repo);
+  assert.ok(untracked, "an untracked file is at risk");
+  assert.equal(untracked.dirty, 1);
+  rmSync(path.join(repo, "brand-new.txt"));
+
+  // 4. committed but unpushed → at risk until a remote holds it.
+  writeFileSync(path.join(repo, "seed.txt"), "committed locally\n");
+  git(["commit", "--quiet", "--no-gpg-sign", "-am", "local only"], repo);
+  const unpushed = riskOf(repo);
+  assert.ok(unpushed, "a commit absent from every remote is at risk");
+  assert.equal(unpushed.dirty, 0);
+  assert.equal(unpushed.unpushed, 1);
+
+  // 5. once pushed, the same worktree stops being at risk — the branch and its
+  //    commits outlive a removal, so locking it would be pure friction.
+  git(["push", "--quiet", "origin", "main"], repo);
+  assert.equal(riskOf(repo), null, "pushing clears the risk");
+
+  // 6. an unreadable path yields null rather than throwing into the hook.
+  assert.equal(riskOf(path.join(scratch, "does-not-exist")), null, "missing paths are skipped");
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}
+
+console.log("worktree-autolock.test.mjs: ok");


### PR DESCRIPTION
Closes cave-8aiy8.

`scripts/worktree-guard.mjs` blocks destructive Bash **from a Claude Code session**. It never sees the actor that actually destroys worktrees here.

## What happened today

GitHub Desktop, on 2026-08-03:

| operation | count |
|---|---|
| `git push origin main:main` (direct to main) | **114** |
| `git worktree remove` | **18** (8 with a single `--force`) |
| `git push origin :<branch>` | 7 (three of them `:main`, all rejected) |

It removed two live worktrees mid-session, and a third — holding another session's uncommitted work — while that session was still running.

## Why locking

`git worktree lock` is the only defence that reaches outside Claude Code. Git refuses to remove a locked worktree unless `--force` is given **twice**. Verified directly:

```
plain remove:    fatal: cannot remove a locked working tree, lock reason: test
single --force:  fatal: cannot remove a locked working tree, lock reason: test
double --force:  removed
```

Desktop has never escalated past a single force in any of the 18 observed removals, so a lock defeats every removal actually performed.

Locking by hand is a snapshot — a worktree created a minute later is unprotected, which is exactly what happened while auditing this. The hook re-applies as worktrees appear, throttled to once a minute via a stamp file.

## What it deliberately does not do

**It skips clean, fully-pushed worktrees.** Removing one loses nothing — the branch and its commits outlive the worktree — and locking it would only force an unlock during routine cleanup. This mirrors the guard, which lets clean+pushed cleanup pass silently. A lock therefore *means something*: the worktree holds work no remote has.

It also never blocks a tool call (always exits 0), leaves unreadable worktrees alone, and opts out via `WT_AUTOLOCK_DISABLE=1`. The lock reason names the state and the unlock command, so an owner hitting one can clear it deliberately.

## Verification

- `scripts/worktree-autolock.test.mjs` (new, wired into the `app` suite) — parsing, reason text, and risk classification against **real** throwaway repos with a real remote: clean+pushed is not locked, uncommitted edits are, untracked files are, unpushed commits are, and pushing clears the risk.
- End-to-end against a scratch repo: the at-risk worktree is locked, the clean+pushed one is untouched.
- `worktree-guard`, `surface-claim-guard`, `worktree-lifecycle-create`, `beads-familiar-workflow`, `ui-consistency` — all pass.
- `pnpm check:tests-wired` — 1,454 files wired (the new test would otherwise have failed CI on that guard).

`worktree-lifecycle-patrol.test.mjs` is a long-running soak test; I stopped it at 900s mid-loop (patrol #129) rather than run it to completion. It shares no imports with this change and hooks are not invoked from it.
