### PR TITLE
fix(settings): one search-index entry per destination

### DIFF
--- a/src/components/settings-search.test.ts
+++ b/src/components/settings-search.test.ts
@@ -62,13 +62,18 @@ assert.doesNotMatch(shell, /params\.get\("familiarTab"\)/, "Settings no longer a
 
 // One index entry per destination. `section` + `group` is the entire address
 // `open-setting` can navigate to, and BOTH consumers key their rendered rows off
-// exactly that pair — the palette as `setting:${section}:${group}` and the
-// settings shell as `${section}:${group}`. A second entry for the same pair is
-// therefore not extra search coverage: it is a duplicate React key plus a second
-// row that opens the identical panel. Profile › Identity was split across a
-// name/pronouns entry and an avatar entry, so any query matching both (e.g.
-// "profile") tripped React's duplicate-key error (cave-x7v6b). Put new keywords
-// on the existing entry for that destination instead of adding a sibling.
+// exactly that pair — the palette as `setting:${section}:${group ?? "overview"}`
+// (command-palette.tsx) and the settings shell as `${section}:${group ?? ""}`
+// (settings-shell.tsx). The two differ only in what they substitute for a
+// missing group, which is why the check below normalizes to one of them: a pair
+// that collides under either spelling collides under both.
+//
+// A second entry for the same pair is therefore not extra search coverage: it is
+// a duplicate React key plus a second row that opens the identical panel.
+// Profile › Identity was split across a name/pronouns entry and an avatar entry,
+// so any query matching both (e.g. "profile") tripped React's duplicate-key
+// error (cave-x7v6b). Put new keywords on the existing entry for that
+// destination instead of adding a sibling.
 {
   const seen = new Map();
   for (const entry of SETTINGS_INDEX) {

--- a/src/components/settings-search.test.ts
+++ b/src/components/settings-search.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { SETTINGS_INDEX } from "./settings-sections.ts";
 
 const shell = readFileSync(new URL("./settings-shell.tsx", import.meta.url), "utf8");
 const sections = readFileSync(new URL("./settings-sections.ts", import.meta.url), "utf8");
@@ -58,5 +59,28 @@ assert.match(
 );
 assert.match(shell, /params\.get\("group"\)/, "Settings accepts a group deep-link target");
 assert.doesNotMatch(shell, /params\.get\("familiarTab"\)/, "Settings no longer accepts a retired familiar studio-tab target");
+
+// One index entry per destination. `section` + `group` is the entire address
+// `open-setting` can navigate to, and BOTH consumers key their rendered rows off
+// exactly that pair — the palette as `setting:${section}:${group}` and the
+// settings shell as `${section}:${group}`. A second entry for the same pair is
+// therefore not extra search coverage: it is a duplicate React key plus a second
+// row that opens the identical panel. Profile › Identity was split across a
+// name/pronouns entry and an avatar entry, so any query matching both (e.g.
+// "profile") tripped React's duplicate-key error (cave-x7v6b). Put new keywords
+// on the existing entry for that destination instead of adding a sibling.
+{
+  const seen = new Map();
+  for (const entry of SETTINGS_INDEX) {
+    const address = `${entry.section}:${entry.group ?? "overview"}`;
+    assert.equal(
+      seen.has(address),
+      false,
+      `SETTINGS_INDEX has two entries for ${address} — merge their keywords into one entry instead:\n` +
+        `  kept:      ${seen.get(address)}\n  duplicate: ${entry.keywords}`,
+    );
+    seen.set(address, entry.keywords);
+  }
+}
 
 console.log("settings-search.test.ts OK");

--- a/src/components/settings-sections.ts
+++ b/src/components/settings-sections.ts
@@ -38,8 +38,12 @@ export const SECTION_HIGHLIGHTS: Record<Section, string[]> = {
 };
 
 export const SETTINGS_INDEX: SettingsIndexEntry[] = [
-  { section: "profile", group: "Identity", keywords: "profile name display pronouns identity operator user you" },
-  { section: "profile", group: "Identity", keywords: "avatar image photo picture upload face profile" },
+  // One entry per destination, never one per control: `section` + `group` is the
+  // full address `open-setting` can navigate to, and both the palette and the
+  // settings search key their rows off exactly that pair. Identity was split
+  // across two entries (name/pronouns, avatar) so a query matching both rendered
+  // duplicate React keys and two rows opening the same panel (cave-x7v6b).
+  { section: "profile", group: "Identity", keywords: "profile name display pronouns identity operator user you avatar image photo picture upload face" },
   { section: "profile", group: "Context", keywords: "bio about timezone time zone familiar draft" },
   { section: "profile", group: "Personality", keywords: "personality mbti type axes tone familiar" },
   { section: "profile", group: "Links", keywords: "links github socials url website portfolio" },


### PR DESCRIPTION
Fixes the `Encountered two children with the same key, \`setting:profile:Identity\`` console error in the command palette.

## Root cause

`SETTINGS_INDEX` carried **two** entries for Profile › Identity — one for name/pronouns, one for the avatar:

```ts
{ section: "profile", group: "Identity", keywords: "profile name display pronouns identity operator user you" },
{ section: "profile", group: "Identity", keywords: "avatar image photo picture upload face profile" },
```

`section` + `group` is the entire address `open-setting` can navigate to, and **both** consumers key their rendered rows off exactly that pair — the palette as `setting:${section}:${group}` (`command-palette.tsx:494`), the settings shell as `${section}:${group}` (`settings-shell.tsx:255`).

So the split was never extra search coverage. Any query matching both entries — `"profile"` matches each — rendered two rows carrying the same React key. The two rows were also visually identical (both titled "Profile › Identity") and dispatched the identical intent, so the second one opened the same panel and bought the reader nothing.

The palette is where it was reported, but the settings-page search has the same collision on the same data. It was the only colliding pair in the index (29 entries, checked exhaustively).

## Fix

Merge the keywords onto the single Identity entry, and add a guard to `settings-search.test.ts` that fails if any two index entries share `section` + `group`. Fixing the data means both consumers are correct without either growing its own dedupe pass, and the guard keeps it that way — a future contributor adding keywords is told to put them on the existing entry for that destination.

## Verification

- Guard checked **both ways**: it fails on the old data with the offending address named, and passes on the new.
- `settings-search`, `settings-profile`, `settings-overview`, `command-palette` tests green. The existing profile tests still pass unchanged — they join keywords across profile entries and dedupe groups through a `Set`, so the merge is invisible to them, and every term they assert (`name`, `pronouns`, `avatar`, ...) still matches.
- `tsc --noEmit` and `lint:design` clean.

Refs cave-x7v6b
