### PR TITLE
fix(ios): make destructive swipes recoverable and status writes cancellable

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -511,8 +511,16 @@ final class AppModel {
     /// row back to a status the user already moved off of.
     func requestTaskStatus(_ card: BoardCard, _ status: CardStatus) {
         statusWrites[card.id]?.cancel()
-        statusWrites[card.id] = Task { [weak self] in
+        let cardId = card.id
+        statusWrites[cardId] = Task { [weak self] in
             await self?.setTaskStatus(card, status)
+            // Drop the finished task so the map tracks only in-flight writes
+            // rather than accumulating one retained Task per card ever touched.
+            // Skip when cancelled: being cancelled means a newer write already
+            // replaced this entry, and clearing would lose the handle needed to
+            // cancel *that* one.
+            guard !Task.isCancelled else { return }
+            self?.statusWrites[cardId] = nil
         }
     }
 

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -500,18 +500,48 @@ final class AppModel {
 
     /// Optimistically set a task's status, then reconcile with the server's
     /// echoed card (it stamps lifecycle/updatedAt). Reverts on failure.
+    /// In-flight status writes, keyed by card id, so a newer intent can cancel
+    /// the one it supersedes (cave-ioswipe.4).
+    @ObservationIgnored private var statusWrites: [String: Task<Void, Never>] = [:]
+
+    /// Entry point for every status mutation. Views must call this rather than
+    /// wrapping `setTaskStatus` in their own `Task { }`: a detached task cannot
+    /// be cancelled, so a rapid done/reopen swipe sequence would leave two
+    /// writes racing and let the *older* server response land last, snapping the
+    /// row back to a status the user already moved off of.
+    func requestTaskStatus(_ card: BoardCard, _ status: CardStatus) {
+        statusWrites[card.id]?.cancel()
+        statusWrites[card.id] = Task { [weak self] in
+            await self?.setTaskStatus(card, status)
+        }
+    }
+
+    /// Restore a single card, mirroring `revert(_:to:)` for reminders. Assigning
+    /// the whole `tasks` array back would also roll back concurrent edits to
+    /// *other* cards that succeeded while this one was in flight.
+    private func revertTask(id: String, to previous: [BoardCard]) {
+        guard let old = previous.first(where: { $0.id == id }) else { return }
+        applyTask(id: id) { $0 = old }
+    }
+
     func setTaskStatus(_ card: BoardCard, _ status: CardStatus) async {
         guard let client, status != card.status else { return }
         let previous = tasks
         applyTask(id: card.id) { $0.statusRaw = status.rawValue }
         do {
             let updated = try await client.updateTask(cardId: card.id, status: status)
+            // A newer write for this card already applied its own optimistic
+            // state; landing this stale response would undo it.
+            guard !Task.isCancelled else { return }
             applyTask(id: card.id) { $0 = updated }
             Haptics.tap()
             await LiveActivityManager.shared.reconcile(tasks)
             publishWidgetSnapshot()
         } catch {
-            tasks = previous
+            // Cancellation surfaces here as a thrown CancellationError. Reverting
+            // on it would clobber the newer intent that did the cancelling.
+            guard !Task.isCancelled else { return }
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
             reportRevert("update the task")
         }

--- a/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift
@@ -39,7 +39,12 @@ struct LinkedTasksSheet: View {
                                 }
                             }
                             .buttonStyle(.plain)
-                            .swipeActions {
+                            // No full swipe on a destructive action that runs
+                            // immediately — unlinkTask has no confirmation and no
+                            // undo. Matches ChatsHomeView/FamiliarThreadsView;
+                            // TasksView may allow it because its trailing swipe
+                            // only opens a confirmation (cave-ioswipe.4).
+                            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                                 Button(role: .destructive) { app.unlinkTask(card) } label: {
                                     Label("Unlink", systemImage: "link.badge.minus")
                                 }

--- a/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift
@@ -76,7 +76,7 @@ struct TaskDetailView: View {
         Menu {
             Menu {
                 ForEach(CardStatus.allCases, id: \.self) { status in
-                    Button { Task { await app.setTaskStatus(live, status) } } label: {
+                    Button { app.requestTaskStatus(live, status) } label: {
                         Label(status.label, systemImage: live.status == status ? "checkmark" : status.systemImage)
                     }
                 }
@@ -199,7 +199,7 @@ struct TaskDetailView: View {
             cycleChip("Status", value: live.status.label, color: Theme.color(for: live.status)) {
                 guard let index = CardStatus.allCases.firstIndex(of: live.status) else { return }
                 let next = CardStatus.allCases[(index + 1) % CardStatus.allCases.count]
-                Task { await app.setTaskStatus(live, next) }
+                app.requestTaskStatus(live, next)
             }
             cycleChip("Priority", value: live.priority.label, color: Theme.color(for: live.priority)) {
                 guard let index = CardPriority.allCases.firstIndex(of: live.priority) else { return }
@@ -400,7 +400,7 @@ struct TaskDetailView: View {
             .buttonStyle(.borderedProminent)
 
             Button {
-                Task { await app.setTaskStatus(live, .done) }
+                app.requestTaskStatus(live, .done)
             } label: {
                 Label("Mark done", systemImage: "checkmark.circle")
                     .frame(maxWidth: .infinity)

--- a/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TasksView.swift
@@ -157,7 +157,7 @@ struct TasksView: View {
         Menu {
             ForEach(CardStatus.allCases, id: \.self) { status in
                 Button {
-                    Task { await app.setTaskStatus(card, status) }
+                    app.requestTaskStatus(card, status)
                 } label: {
                     Label(status.label, systemImage: card.status == status ? "checkmark" : status.systemImage)
                 }
@@ -355,7 +355,7 @@ struct TasksView: View {
                                 }
                             }
                             .swipeActions(edge: .leading, allowsFullSwipe: true) {
-                                Button { Task { await app.setTaskStatus(card, card.status == .done ? .running : .done) } } label: {
+                                Button { app.requestTaskStatus(card, card.status == .done ? .running : .done) } label: {
                                     Label(card.status == .done ? "Reopen" : "Done",
                                           systemImage: card.status == .done ? "arrow.uturn.backward" : "checkmark")
                                 }

--- a/scripts/ios-swipe-ux.test.mjs
+++ b/scripts/ios-swipe-ux.test.mjs
@@ -59,8 +59,22 @@ assert.match(
 // -- Status-write races ---------------------------------------------------
 assert.match(
   model,
-  /func requestTaskStatus\(_ card: BoardCard, _ status: CardStatus\) \{\s*\n\s*statusWrites\[card\.id\]\?\.cancel\(\)\s*\n\s*statusWrites\[card\.id\] = Task \{/,
+  /func requestTaskStatus\(_ card: BoardCard, _ status: CardStatus\) \{\s*\n\s*statusWrites\[card\.id\]\?\.cancel\(\)/,
   "a newer status write must cancel the one it supersedes, keyed by card id",
+);
+
+// The map must track only in-flight writes. Without the clear it grows one
+// retained Task per card ever mutated; without the cancellation guard on the
+// clear, a finishing task would delete the entry belonging to the newer write
+// that superseded it, losing the handle needed to cancel that one.
+const request = model.match(
+  /func requestTaskStatus\(_ card: BoardCard, _ status: CardStatus\) \{[\s\S]*?\n {4}\}/,
+);
+assert.ok(request, "requestTaskStatus must still exist");
+assert.match(
+  request[0],
+  /guard !Task\.isCancelled else \{ return \}\s*\n\s*self\?\.statusWrites\[cardId\] = nil/,
+  "a finished write must clear its entry, and only when it was not superseded",
 );
 
 // The two cancellation guards are the substance of the fix. Without the first,

--- a/scripts/ios-swipe-ux.test.mjs
+++ b/scripts/ios-swipe-ux.test.mjs
@@ -1,0 +1,116 @@
+// cave-ioswipe.4: swipe destructive-action semantics and status-write races.
+//
+// iOS Swift is NOT compiled by CI, so this source-text contract is the only
+// gate. Each assertion is checked to FAIL against its regression, not merely
+// to pass.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const linked = await read("apps/ios/CovenCave/CovenCave/Views/LinkedTasksSheet.swift");
+const tasksView = await read("apps/ios/CovenCave/CovenCave/Views/TasksView.swift");
+const detailView = await read("apps/ios/CovenCave/CovenCave/Views/TaskDetailView.swift");
+
+// -- Full-swipe semantics -------------------------------------------------
+// `unlinkTask` runs immediately with no confirmation and no undo, so an
+// accidental full swipe is unrecoverable. Chats and Threads already opt out
+// for the same reason; this sheet was the outlier.
+assert.match(
+  linked,
+  /\.swipeActions\(edge: \.trailing, allowsFullSwipe: false\) \{\s*\n\s*Button\(role: \.destructive\) \{ app\.unlinkTask\(card\) \}/,
+  "the destructive unlink swipe must opt out of full swipe — omitting allowsFullSwipe defaults it to TRUE",
+);
+
+// TasksView is allowed a full-swipe delete precisely because it does not
+// delete: it opens a confirmation. If that ever becomes a direct call, the
+// full swipe stops being safe.
+//
+// Extract the block by brace matching rather than a fixed character window —
+// a window can slide onto an identical-looking Button elsewhere in the file
+// (TasksView has one at the row context menu) and pass while the swipe itself
+// regressed.
+function blockAfter(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) return null;
+  let i = start + marker.length - 1; // marker ends at its opening brace
+  let depth = 0;
+  for (; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+const trailingSwipe = blockAfter(
+  tasksView,
+  ".swipeActions(edge: .trailing, allowsFullSwipe: true) {",
+);
+assert.ok(trailingSwipe, "TasksView must keep a trailing swipe action");
+assert.match(
+  trailingSwipe,
+  /Button\(role: \.destructive\) \{ pendingDelete = card \}/,
+  "TasksView's full-swipe delete must route through pendingDelete (a confirmation), not delete outright",
+);
+
+// -- Status-write races ---------------------------------------------------
+assert.match(
+  model,
+  /func requestTaskStatus\(_ card: BoardCard, _ status: CardStatus\) \{\s*\n\s*statusWrites\[card\.id\]\?\.cancel\(\)\s*\n\s*statusWrites\[card\.id\] = Task \{/,
+  "a newer status write must cancel the one it supersedes, keyed by card id",
+);
+
+// The two cancellation guards are the substance of the fix. Without the first,
+// a superseded response overwrites newer optimistic state; without the second,
+// the CancellationError thrown by the cancel itself triggers a revert that
+// clobbers the newer intent.
+const setStatus = model.match(
+  /func setTaskStatus\(_ card: BoardCard, _ status: CardStatus\) async \{[\s\S]*?\n {4}\}/,
+);
+assert.ok(setStatus, "setTaskStatus must still exist");
+const body = setStatus[0];
+assert.match(
+  body,
+  /let updated = try await client\.updateTask\(cardId: card\.id, status: status\)\s*\n(?:\s*\/\/[^\n]*\n)*\s*guard !Task\.isCancelled else \{ return \}\s*\n\s*applyTask/,
+  "a superseded response must not be applied — guard cancellation before applyTask",
+);
+assert.match(
+  body,
+  /\} catch \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*guard !Task\.isCancelled else \{ return \}/,
+  "cancellation arrives as a thrown error — reverting on it would undo the newer intent",
+);
+assert.doesNotMatch(
+  body,
+  /\n\s*tasks = previous\n/,
+  "restoring the whole array rolls back other cards' concurrent edits; revert only this card",
+);
+assert.match(
+  body,
+  /revertTask\(id: card\.id, to: previous\)/,
+  "failure must revert just the card that failed",
+);
+assert.match(
+  model,
+  /private func revertTask\(id: String, to previous: \[BoardCard\]\) \{/,
+  "the per-card revert helper must exist, mirroring revert(_:to:) for reminders",
+);
+
+// -- No view may re-introduce an uncancellable write ----------------------
+for (const [name, src] of [
+  ["TasksView", tasksView],
+  ["TaskDetailView", detailView],
+  ["LinkedTasksSheet", linked],
+]) {
+  assert.doesNotMatch(
+    src,
+    /Task \{ await app\.setTaskStatus\(/,
+    `${name} must call app.requestTaskStatus — a detached Task cannot be cancelled, which is the bug`,
+  );
+}
+assert.match(tasksView, /app\.requestTaskStatus\(/, "TasksView must use the managed entry point");
+assert.match(detailView, /app\.requestTaskStatus\(/, "TaskDetailView must use the managed entry point");
+
+console.log("ios-swipe-ux: ok");

--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -59,7 +59,10 @@ assert.match(
 );
 assert.match(
   list,
-  /await app\.setTaskStatus\(card, card\.status == \.done \? \.running : \.done\)/,
+  /app\.requestTaskStatus\(card, card\.status == \.done \? \.running : \.done\)/,
+  // Same intent as before; the call moved off a bare `Task { await ... }` onto
+  // the cancellable entry point so rapid toggles can't apply a stale response
+  // (cave-ioswipe.4).
   "swipe should toggle Done/Reopen",
 );
 assert.match(list, /confirmationDialog\("Delete this task\?"/, "list should confirm deletes");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1451,6 +1451,7 @@ export const SUITES = {
     "scripts/ios-connection-stability.test.mjs",
     "scripts/ios-bulk-reminders.test.mjs",
     "scripts/ios-session-refetch.test.mjs",
+    "scripts/ios-swipe-ux.test.mjs",
     "scripts/ios-reconnect-pill.test.mjs",
     "scripts/ios-port-discovery.test.mjs",
     "scripts/ios-legacy-token-migration.test.mjs",


### PR DESCRIPTION
Closes cave-ioswipe.4.

## Full-swipe semantics

`LinkedTasksSheet` omitted `allowsFullSwipe:` on its destructive unlink swipe. That parameter **defaults to `true`**, so a full swipe ran `unlinkTask` immediately — no confirmation, no undo, plus a fire-and-forget server patch. `ChatsHomeView` and `FamiliarThreadsView` already pass `false` for their destructive trailing swipes; this sheet was the only one that didn't.

`TasksView` keeps its full-swipe delete, and that's correct: the swipe sets `pendingDelete`, which opens a confirmation dialog. The test pins that relationship, so the full swipe can't silently become a direct delete.

## Status-write races

The five view call sites fired `Task { await app.setTaskStatus(...) }`. A detached task can't be cancelled, so a rapid done/reopen swipe sequence left two writes in flight and the **older** response could land last, snapping the row back to a status the user had already moved off.

All five now call `requestTaskStatus`, which cancels the write it supersedes. `setTaskStatus` guards cancellation in **both** places:

- before `applyTask` — a superseded response would overwrite newer optimistic state;
- in the `catch` — cancellation surfaces as a thrown `CancellationError`, and reverting on it would undo the very intent that did the cancelling.

Cancelling doesn't order the server's writes, and doesn't claim to. It stops a superseded *response* from being applied to the UI, which is the visible bug.

## Whole-array revert

`setTaskStatus` snapshotted all of `tasks` and restored it wholesale on failure, so one card's failed write rolled back every other card's concurrent successful edit. It now reverts just the failed card, mirroring the existing `revert(_:to:)` for reminders. Seven other sites in this file share the pattern; they aren't swipe-reachable and are left for a follow-up rather than widened into this change.

## Already satisfied

The bead also asked for pending-delete row feedback. That's covered: `pendingDelete` drives the confirmation dialog, and `deleteTask` is optimistic (the row disappears at once, reverting only on failure), so there's no pending window to indicate. The bead's Calendar/Reminders scope is moot — those views were purged.

## Verification

iOS Swift is not compiled by CI, so `scripts/ios-swipe-ux.test.mjs` is the only automated gate. Every assertion was checked to **fail** against its specific regression — all 7 caught:

| regression reintroduced | caught |
|---|---|
| full swipe re-enabled on unlink | ✓ |
| swipe deletes without confirming | ✓ |
| newer write no longer cancels the older | ✓ |
| stale response applied anyway | ✓ |
| cancellation reverts the newer intent | ✓ |
| whole-array revert restored | ✓ |
| view re-wraps in a detached `Task` | ✓ |

The TasksView assertion originally used a `{0,200}` character window and **passed while the swipe had regressed** — the window slid onto an identical `Button(role: .destructive) { pendingDelete = card }` at the row context menu. It now extracts the swipe block by brace matching. `swiftc -parse` clean on all four Swift files.
