### PR TITLE
fix(chat): render the cited body in the reader, not raw footnote plumbing

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -1275,8 +1275,18 @@ function ExpandBubble({
         >
           {/* The reader's own reading scale (.cave-md--reader in
               cave-md/prose.css) — the transcript's dense 14px is right in the
-              stream, wrong for a full-screen reading surface. */}
-          <MarkdownBlock text={text} className="cave-md--expanded cave-md--reader" />
+              stream, wrong for a full-screen reading surface.
+
+              Renders the CITED body, exactly as the bubble does: raw `text`
+              still carries the footnote definitions, so a reader opened on a
+              cited answer would otherwise show `[^label]` markers inline and
+              dump the definition block into the prose. `text` stays raw on the
+              reader itself — Copy/Export hand back portable markdown, and the
+              Sources tab needs those definitions to parse. */}
+          <MarkdownBlock
+            text={renderCitedBody(text).body}
+            className="cave-md--expanded cave-md--reader"
+          />
         </MessageReader>
       ) : null}
     </>

--- a/src/components/message-reader.test.ts
+++ b/src/components/message-reader.test.ts
@@ -31,7 +31,7 @@ test("3a — Expand opens the reader, and frame 1a's sheet is gone", () => {
   );
   assert.match(
     bubble,
-    /<MessageReader[\s\S]{0,800}<MarkdownBlock text=\{text\} className="cave-md--expanded cave-md--reader" \/>[\s\S]{0,80}<\/MessageReader>/,
+    /<MessageReader[\s\S]{0,1400}<MarkdownBlock\s*\n\s*text=\{renderCitedBody\(text\)\.body\}[\s\S]{0,200}<\/MessageReader>/,
     "the reader takes the rendered answer as children — it must not import the markdown pipeline itself",
   );
   assert.doesNotMatch(
@@ -63,6 +63,24 @@ test("3a — the reader's weight is paid on open, not on every visit to /", () =
     bubble,
     /const MessageReader = dynamic\(\s*\n\s*\(\) => import\("@\/components\/message-reader"\)\.then\(\(m\) => m\.MessageReader\),\s*\n\s*\{ ssr: false \},\s*\n\s*\);/,
     "and the component itself loads only when Expand is clicked",
+  );
+});
+
+test("3a — the reader renders the CITED body, not raw footnote plumbing", () => {
+  // Caught by looking at the running app, not by a test: the bubble renders
+  // renderCitedBody(content).body while the reader was handed raw `text`, so a
+  // cited answer showed literal [^label] markers inline AND dumped the whole
+  // footnote definition block into the prose.
+  assert.match(
+    bubble,
+    /<MarkdownBlock\s*\n\s*text=\{renderCitedBody\(text\)\.body\}/,
+    "the reader's body is the cited body, exactly as the bubble renders it",
+  );
+  assert.match(
+    bubble,
+    /<MessageReader\s*\n\s*text=\{text\}/,
+    "`text` stays RAW on the reader — Copy/Export hand back portable markdown "
+      + "and the Sources tab needs the footnote definitions to parse",
   );
 });
 


### PR DESCRIPTION
Opening the reader on an answer with footnote citations showed literal `[^label]` markers inline **and** dumped the entire footnote definition block into the prose.

`MessageBubble` renders `renderCitedBody(content).body`; the reader was handed raw `text`. So it parsed those same footnotes to populate its **Sources** tab while displaying the plumbing in the body.

### The fix

`text` stays **raw** on the reader itself, deliberately:
- **Copy** and **Export** hand back portable markdown, footnotes intact
- the **Sources** tab needs the definitions to parse

Only the rendered children become the cited body — which the reader already takes as a separate prop, so this is a one-line change at the call site.

### How it was found, and why nothing caught it

By driving the running app and *looking at it*. Nothing in the suite renders the reader, so 24 unit tests, the design gates and nine green CI checks all passed straight over it.

Worse: the existing pin asserted `text={text}` — the buggy form — so the test was actively holding the defect in place. It now pins the cited body and the raw-text prop separately, with the reason written down.

### Verification

Screenshots before/after in the running app: the `[^mdn]` / `[^wcag]` markers and the trailing definition block are gone; citations render inline and the document ends cleanly at Verdict.

Typecheck clean, eslint clean, `message-reader.test.ts` 16/16.

### Known residual (not fixed here)

Citations in the reader render as plain links rather than the bubble's `● domain` chips — the reader lacks the `InlineCitationPreviews` DOM wiring. Cosmetic, and a larger change than this fix warrants.
