### PR TITLE
fix(chat): give the reader real citation chips, not bare links

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -756,9 +756,13 @@ type MarkdownContentProps = {
   pending?: boolean;
   onOpenUrl?: (url: string) => void;
   citations?: readonly Citation[];
+  /** Extra classes on the markdown container — the Expand reader uses this to
+   *  set its own reading scale (.cave-md--reader). Omitted in the transcript,
+   *  which reads at the stream's density. */
+  className?: string;
 };
 
-function MarkdownContent({ text, pending, onOpenUrl, citations = [] }: MarkdownContentProps) {
+function MarkdownContent({ text, pending, onOpenUrl, citations = [], className }: MarkdownContentProps) {
   const [html, setHtml] = useState<string | null>(
     () => pending ? null : renderCacheGet(text) ?? null,
   );
@@ -860,7 +864,7 @@ function MarkdownContent({ text, pending, onOpenUrl, citations = [] }: MarkdownC
 
   if (!html) {
     return (
-      <span className="whitespace-pre-wrap break-words text-[length:var(--text-md)] leading-relaxed">
+      <span className={`whitespace-pre-wrap break-words text-[length:var(--text-md)] leading-relaxed${className ? ` ${className}` : ""}`}>
         {text}
         {pending && text ? (
           <span aria-hidden className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
@@ -873,7 +877,7 @@ function MarkdownContent({ text, pending, onOpenUrl, citations = [] }: MarkdownC
     <>
       <div
         ref={containerRef}
-        className="cave-md"
+        className={`cave-md${className ? ` ${className}` : ""}`}
         // Markdown output is sanitized in mdToHtml before DOM insertion.
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}
@@ -1253,6 +1257,7 @@ function ExpandBubble({
   onAskAbout?: (quote: string) => void;
 }) {
   const [open, setOpen] = useState(false);
+  const readerCited = useMemo(() => renderCitedBody(text), [text]);
   return (
     <>
       <button
@@ -1273,18 +1278,24 @@ function ExpandBubble({
           onAsk={onAskAbout}
           onClose={() => setOpen(false)}
         >
-          {/* The reader's own reading scale (.cave-md--reader in
-              cave-md/prose.css) — the transcript's dense 14px is right in the
-              stream, wrong for a full-screen reading surface.
+          {/* MarkdownContent, not MarkdownBlock: it is the renderer that wires
+              InlineCitationPreviews, so a cited answer gets the same interactive
+              source chips the transcript shows instead of bare links. It also
+              carries the file-link and code-reading wiring — the portal keeps
+              those contexts, so they behave as they do in the stream.
 
-              Renders the CITED body, exactly as the bubble does: raw `text`
-              still carries the footnote definitions, so a reader opened on a
-              cited answer would otherwise show `[^label]` markers inline and
-              dump the definition block into the prose. `text` stays raw on the
-              reader itself — Copy/Export hand back portable markdown, and the
-              Sources tab needs those definitions to parse. */}
-          <MarkdownBlock
-            text={renderCitedBody(text).body}
+              Renders the CITED body: raw `text` still carries the footnote
+              definitions, so the reader would otherwise show `[^label]` markers
+              inline and dump the definition block into the prose. `text` stays
+              raw on the reader itself — Copy/Export hand back portable
+              markdown, and the Sources tab needs those definitions to parse.
+
+              The reader's own reading scale (.cave-md--reader in
+              cave-md/prose.css): the transcript's dense 14px is right in the
+              stream, wrong for a full-screen reading surface. */}
+          <MarkdownContent
+            text={readerCited.body}
+            citations={readerCited.citations}
             className="cave-md--expanded cave-md--reader"
           />
         </MessageReader>

--- a/src/components/message-reader.test.ts
+++ b/src/components/message-reader.test.ts
@@ -31,7 +31,7 @@ test("3a — Expand opens the reader, and frame 1a's sheet is gone", () => {
   );
   assert.match(
     bubble,
-    /<MessageReader[\s\S]{0,1400}<MarkdownBlock\s*\n\s*text=\{renderCitedBody\(text\)\.body\}[\s\S]{0,200}<\/MessageReader>/,
+    /<MessageReader[\s\S]{0,2000}<MarkdownContent\s*\n\s*text=\{readerCited\.body\}[\s\S]{0,300}<\/MessageReader>/,
     "the reader takes the rendered answer as children — it must not import the markdown pipeline itself",
   );
   assert.doesNotMatch(
@@ -73,14 +73,37 @@ test("3a — the reader renders the CITED body, not raw footnote plumbing", () =
   // footnote definition block into the prose.
   assert.match(
     bubble,
-    /<MarkdownBlock\s*\n\s*text=\{renderCitedBody\(text\)\.body\}/,
+    /const readerCited = useMemo\(\(\) => renderCitedBody\(text\), \[text\]\);/,
     "the reader's body is the cited body, exactly as the bubble renders it",
+  );
+  assert.match(
+    bubble,
+    /text=\{readerCited\.body\}/,
+    "and that cited body is what gets rendered",
   );
   assert.match(
     bubble,
     /<MessageReader\s*\n\s*text=\{text\}/,
     "`text` stays RAW on the reader — Copy/Export hand back portable markdown "
       + "and the Sources tab needs the footnote definitions to parse",
+  );
+});
+
+test("3a — cited sources are interactive chips, not bare links", () => {
+  // MarkdownBlock renders markdown; MarkdownContent is the renderer that also
+  // mounts InlineCitationPreviews against its container ref. The reader used
+  // the former, so citations degraded to plain underlined links while the
+  // transcript showed real source chips.
+  assert.match(
+    bubble,
+    /<MarkdownContent\s*\n\s*text=\{readerCited\.body\}\s*\n\s*citations=\{readerCited\.citations\}/,
+    "the reader passes citations to the renderer that wires the previews",
+  );
+  assert.match(
+    bubble,
+    /className=\{`cave-md\$\{className \? ` \$\{className\}` : ""\}`\}/,
+    "MarkdownContent takes an optional className so a surface sets its own "
+      + "reading scale instead of forking the component",
   );
 });
 


### PR DESCRIPTION
The reader rendered its body through `MarkdownBlock`, which renders markdown and nothing else. `MarkdownContent` is the renderer that *also* mounts `InlineCitationPreviews` against its container ref — that is what turns a citation into an interactive source chip.

So a cited answer showed real chips in the transcript and plain underlined links in the reader.

### The change

- the reader renders `MarkdownContent` instead of `MarkdownBlock`
- `MarkdownContent` hardcoded `className="cave-md"`, so it gains an **optional** `className` rather than being forked — the reader passes its own reading scale (`.cave-md--reader`), the transcript is unaffected
- the cited body and its `citations` are computed once via `useMemo`

### Side effect worth having

`MarkdownContent` also carries the file-link and code-reading wiring, and React context survives `createPortal` — so `src/foo.ts:42` references and code-block Read/Compare now behave in the reader the way they do in the stream.

### Verification

Built and driven in the running app, which is the only place this class of defect shows:
- **2 citation chips** rendered inside `.cave-reader-doc .cave-md` (`developer.mozilla.org`, `w3.org`)
- **no** `[^label]` markers remaining
- reader reading scale intact

Typecheck clean, eslint clean, `message-reader.test.ts` 17/17.

### Note on the pins

Three source pins were updated, one of which I wrote in #4264 and which asserted the now-superseded `MarkdownBlock` form. That is the second time in this sequence a pin I authored locked in the shape I was about to change — worth stating plainly, because source-text pins verify that code *matches a shape*, never that it *renders correctly*.
