### PR TITLE
docs: fix the managed worktree command in both agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,10 +6,27 @@
 - Use branches and worktrees only as short-lived PR transport for active implementation. Do not use branches as durable storage, coordination logs, or half-finished agent memory.
 - Keep durable coordination in tracked workflow artifacts: plans, specs, issues, PR descriptions/checklists, release notes, and handoff docs.
 - Before opening a PR, make the branch PR-shaped: scoped diff, relevant local verification, and a summary of what changed.
-- Create managed worktrees through `pnpm beads:worktrees:create -- --bead
-  cave-123 --branch fix/cave-123-example --owner kitty --purpose "Repair
-  example"` so the owning Bead records structured lifecycle metadata and
-  budget admission.
+- Create managed worktrees through `pnpm beads:worktrees:create --bead cave-123
+  --branch fix/cave-123-example --owner kitty --purpose "Repair example"` so the
+  owning Bead records structured lifecycle metadata and budget admission. Do
+  **not** insert `--` before the flags: pnpm forwards it to the script, and the
+  parser rejects every unrecognised option including a bare `--`
+  (`worktree-lifecycle-create: unknown option: --`). `--bead`, `--branch`,
+  `--owner` and `--purpose` are all required; `--start-point` defaults to
+  `origin/main` and the worktree is placed under `.worktrees/`.
+- That command refuses to create anything unless it can build a **complete**
+  lifecycle inventory, which means live GitHub queries. It therefore fails when
+  the GraphQL quota is exhausted (`API rate limit already exceeded`) and when any
+  commit's PR association comes back malformed (`pull request node returned
+  malformed fields or a mismatched head OID`) — a repo-state condition no amount
+  of waiting clears. When it will not run, fall back to `git worktree add -b
+  <branch> .worktrees/<branch> origin/main` and know the trade: that worktree
+  carries no lifecycle metadata, so `pnpm beads:worktrees` will class it
+  `uncertain` ("structured lifecycle metadata backfill required") forever and
+  `pnpm beads:worktrees:apply` can never retire it. Retire it by hand through the
+  archive-tag route in [`CLAUDE.md`](CLAUDE.md), and never hand-write the missing
+  metadata onto the Bead — that record is the evidence the retirement gate
+  checks.
 - After a PR merges, run `pnpm beads:worktrees`, record the merged unit's
   disposition, and use `pnpm beads:worktrees:apply` only when it reports a
   complete repository maintenance transaction. Local cleanup is bounded and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,9 +203,17 @@ Use `.worktrees/<branch-name>/` subdirectories inside the repo. Confirmed in use
 **Create:**
 
 ```bash
-pnpm beads:worktrees:create --bead <id> --branch <branch> --owner <you> --purpose "…"
-cd .worktrees/<branch> && pnpm install   # ~10s with pnpm's CAS store
+pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example --owner <you> --purpose "…"
+cd .worktrees/cave-123-example && pnpm install   # ~10s with pnpm's CAS store
 ```
+
+⚠️ **The directory is not `.worktrees/<branch>`.** The script slugifies the
+branch (`worktree-lifecycle-create.ts`): it strips one leading `feat/`, `fix/`,
+`docs/` or `chore/`, then replaces every remaining character outside
+`A-Za-z0-9._-` with `-`. So `fix/cave-123-example` lands at
+`.worktrees/cave-123-example`, and an unlisted prefix like `release/foo` lands at
+`.worktrees/release-foo`. `cd .worktrees/<branch>` works only for a branch with
+no prefix at all.
 
 This is the form [`AGENTS.md`](AGENTS.md) mandates, and it is the *only* one that
 produces a retirable worktree: it writes the `metadata.coven.worktree` record

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ gh api repos/OpenCoven/coven-cave/rulesets/19123333 \
 
 ```bash
 # work on a branch (in a worktree, per the convention below)
-git worktree add -b <branch> .worktrees/<branch> origin/main
+pnpm beads:worktrees:create --bead <id> --branch <branch> --owner <you> --purpose "…"
 # … commit (signed, per the global -S rule) …
 git push -u origin <branch>
 gh pr create --base main --head <branch> --title "…" --body "…"
@@ -203,9 +203,40 @@ Use `.worktrees/<branch-name>/` subdirectories inside the repo. Confirmed in use
 **Create:**
 
 ```bash
-git worktree add -b <branch> .worktrees/<branch> origin/main
+pnpm beads:worktrees:create --bead <id> --branch <branch> --owner <you> --purpose "…"
 cd .worktrees/<branch> && pnpm install   # ~10s with pnpm's CAS store
 ```
+
+This is the form [`AGENTS.md`](AGENTS.md) mandates, and it is the *only* one that
+produces a retirable worktree: it writes the `metadata.coven.worktree` record
+onto the owning bead, which is exactly what the retirement gate reads
+(`src/lib/worktree-lifecycle.ts`). `--bead`, `--branch`, `--owner` and
+`--purpose` are all required; `--start-point` defaults to `origin/main`, and the
+worktree lands under `.worktrees/` (the script refuses any path escaping it).
+**No `--` before the flags** — pnpm forwards it and the parser rejects it
+outright with `unknown option: --`. That broken form was documented here and in
+`AGENTS.md` until 2026-08-03.
+
+⚠️ **The managed command can refuse to run, and the fallback has a cost.** It
+builds a *complete* lifecycle inventory first, which needs live GitHub queries,
+so it fails when the GraphQL quota is exhausted and when any commit's PR
+association returns `malformed fields or a mismatched head OID` — the latter is
+repo state, not a transient, so waiting does not clear it. Both were hit on
+2026-08-03. When it will not run:
+
+```bash
+git worktree add -b <branch> .worktrees/<branch> origin/main   # fallback only
+```
+
+A worktree made this way has **no lifecycle metadata**, so `pnpm beads:worktrees`
+reports it `uncertain` — *"structured lifecycle metadata backfill required
+before automated retirement can proceed"* — permanently, and
+`pnpm beads:worktrees:apply` can never retire it (`allowLegacyMissingMetadata`
+is hard-coded `false`; there is no flag to relax it). Retire it by hand with the
+archive-tag route in the worktree-guard section below. **Do not hand-write the
+missing metadata onto the bead** to make the patrol pass: that record is the
+evidence the gate exists to check, and forging it is the bypass the guard rules
+out. See `cave-l52dt`.
 
 **When to use a worktree:**
 


### PR DESCRIPTION
Fixes `cave-l52dt`. The two agent guides disagreed on how to create a worktree, and the one AGENTS.md recommended did not actually run.

## Two separate defects

**1. AGENTS.md's command was broken.** It documented:

```bash
pnpm beads:worktrees:create -- --bead cave-123 --branch fix/cave-123-example --owner kitty --purpose "Repair example"
```

pnpm forwards the literal `--` to the script, and `parseArgs` (`scripts/worktree-lifecycle-create.ts:260`) rejects every unrecognised option — including a bare `--`. The documented command dies immediately:

```
worktree-lifecycle-create: unknown option: --
```

Dropping the separator makes it parse. Verified against the real parser: `--bead`, `--branch`, `--owner`, `--purpose` are the four required flags, `--start-point` defaults to `origin/main`, and the worktree is placed under `.worktrees/` with any escaping path refused (`:420`, `:423`).

**2. CLAUDE.md contradicted AGENTS.md.** It documented plain `git worktree add -b <branch> .worktrees/<branch> origin/main` in two places (`:148`, `:206`) — one under the heading *"How to apply (the only path to `main`)"* — while CLAUDE.md itself names AGENTS.md the primary guide.

That form produces an **unretirable** worktree. With no `metadata.coven.worktree` record on the owning bead, `worktree-lifecycle.ts:354` classes the unit `uncertain` ("structured lifecycle metadata backfill required before automated retirement can proceed"), `allowLegacyMissingMetadata` is hard-coded `false` at `:488`, and there is no flag to relax it. `pnpm beads:worktrees:apply` can therefore never retire it. Two units created this way had to be retired by hand today via the archive-tag route.

## Why the managed command is documented with caveats rather than as an unconditional instruction

Because it refuses to run unless it can build a **complete** lifecycle inventory from live GitHub queries. Both failure modes were hit while making this change:

- exhausted GraphQL quota → `API rate limit already exceeded`
- `pull request node returned malformed fields or a mismatched head OID` — repo state, not a transient; it persisted after the quota reset

This branch's own worktree had to fall back to `git worktree add`. Documenting the managed command as the only path would have made the guide wrong in the opposite direction, so the fallback stays — labelled as such, with its cost stated and a pointer to the archive-tag retirement route.

Both guides now also state that the missing metadata must **not** be hand-written onto a bead to make the patrol pass: that record is the evidence the retirement gate reads, so forging it is precisely the bypass the worktree guard exists to prevent.

## Verification

Markdown only — no code paths touched.

- `ui-consistency`, `beads-familiar-workflow`, `branch-curator-manual-cleanup-contract` pass (these pin doc claims).
- `worktree-lifecycle-patrol.test.mjs` not run locally — it is the ~10-minute soak; CI covers it, and this change touches none of its assertions.
- Confirmed no `beads:worktrees:create -- ` form remains in either guide, and the only surviving `git worktree add` lines are the explicitly-labelled fallbacks.

Refs cave-l52dt
