### PR TITLE
fix(notify): keep the OS banner when the notification sound is Silent

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -23,6 +23,7 @@ import { fileURLToPath } from "node:url";
 export const SUITES = {
   app: [
     "src/lib/array-content-equal.test.ts",
+    "src/lib/native-notify.test.ts",
     "src/lib/session-list-equal.test.ts",
     "src/lib/familiar-workspace-sessions.test.ts",
     "src/lib/session-list-deletes.test.ts",

--- a/src/lib/native-notify.test.ts
+++ b/src/lib/native-notify.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+import { notificationPayload } from "./native-notify.ts";
+
+// Regression: the bell's "Sound → Silent" preference used to suppress the OS
+// notification entirely, not just its sound. `sound()` in workspace.tsx maps
+// silent mode to `null`, and native-notify returned early on `null` before it
+// ever called `sendNotification`. The only surviving surface was then the
+// in-app toast, which renders inside the Cave window — i.e. behind whatever
+// app is frontmost. Users on Silent saw nothing at all while working
+// elsewhere. Silence must mean "no ding", never "no banner".
+
+test("silent mode still produces a notification, just without a sound", () => {
+  const payload = notificationPayload("Reminder", "Stand up", null);
+  assert.equal(payload.title, "Reminder");
+  assert.equal(payload.body, "Stand up");
+  assert.equal(
+    "sound" in payload,
+    false,
+    "silent omits the sound field — the plugin only attaches a sound when one is supplied",
+  );
+});
+
+test("platform default omits the sound field too", () => {
+  const payload = notificationPayload("Reminder", "Stand up", undefined);
+  assert.equal("sound" in payload, false);
+});
+
+test("a named sound is passed through verbatim", () => {
+  assert.equal(notificationPayload("Reminder", "Stand up", "Glass").sound, "Glass");
+  assert.equal(notificationPayload("Reminder", undefined, "Funk").sound, "Funk");
+});
+
+test("a missing body stays absent rather than becoming a string", () => {
+  assert.equal(notificationPayload("Reminder").body, undefined);
+});
+
+// Source contract: guard the specific line that caused the bug, so a future
+// "skip the notification when muted" shortcut cannot quietly reintroduce it.
+// The mute path is handled upstream in workspace.tsx (`isMuted`), which never
+// calls nativeNotify at all — this wrapper must not add a second kill switch.
+const src = readFileSync(new URL("./native-notify.ts", import.meta.url), "utf8");
+
+test("native-notify never returns early on a null sound", () => {
+  assert.doesNotMatch(
+    src,
+    /sound\s*===\s*null\)\s*return/,
+    "a null sound means silent, not suppressed — do not early-return before sendNotification",
+  );
+});
+
+test("sendNotification is reached on every granted path", () => {
+  assert.match(src, /await mod\.sendNotification\(notificationPayload\(title, body, sound\)\)/);
+});

--- a/src/lib/native-notify.ts
+++ b/src/lib/native-notify.ts
@@ -3,11 +3,40 @@
  * No-ops outside Tauri (e.g. `next dev` in a browser) so the toast path
  * still works without an unhandled dynamic-import error.
  *
- * `sound` semantics:
- *   undefined  → platform default sound
- *   null       → silent (skip the notification entirely so macOS doesn't ding)
+ * `sound` semantics — silence is about the *ding*, never about the banner:
+ *   undefined  → platform default
+ *   null       → silent (send the notification with no sound attached)
  *   string     → named macOS sound (e.g. "Glass", "Funk", "Pop")
+ *
+ * `null` used to return early and skip `sendNotification` entirely. That made
+ * the bell's "Sound → Silent" preference suppress the OS banner as well, which
+ * left the in-app toast (`InboxToastStack`, rendered inside the Cave window at
+ * z-50) as the only surface — and that toast is behind whatever app is
+ * frontmost whenever Cave is not. Users on Silent therefore lost every
+ * notification while working in another window. Omitting the `sound` field is
+ * what actually produces a soundless banner: the plugin only calls
+ * `notification.sound_name(...)` when a sound is supplied, so an absent field
+ * means no sound rather than a default one.
  */
+
+export type NotificationPayload = { title: string; body?: string; sound?: string };
+
+/**
+ * Build the plugin payload. Pure and exported so the silent-vs-suppressed
+ * contract is testable without mocking the Tauri dynamic import.
+ */
+export function notificationPayload(
+  title: string,
+  body?: string,
+  sound?: string | null,
+): NotificationPayload {
+  const payload: NotificationPayload = { title, body };
+  // Only a named sound sets the field. `undefined` (platform default) and
+  // `null` (silent) both omit it — neither one suppresses the notification.
+  if (typeof sound === "string") payload.sound = sound;
+  return payload;
+}
+
 export async function nativeNotify(
   title: string,
   body?: string,
@@ -16,18 +45,12 @@ export async function nativeNotify(
   if (typeof window === "undefined") return;
   // @ts-expect-error Tauri injects this at runtime
   if (!window.__TAURI_INTERNALS__) return;
-  if (sound === null) return; // silent mode: suppress entirely
   try {
     const mod = await import("@tauri-apps/plugin-notification");
     let granted = await mod.isPermissionGranted();
     if (!granted) granted = (await mod.requestPermission()) === "granted";
     if (!granted) return;
-    const payload: { title: string; body?: string; sound?: string } = {
-      title,
-      body,
-    };
-    if (typeof sound === "string") payload.sound = sound;
-    await mod.sendNotification(payload);
+    await mod.sendNotification(notificationPayload(title, body, sound));
   } catch {
     /* native notify failure shouldn't break the app */
   }


### PR DESCRIPTION
## The symptom

Cave notifications appear *behind* whatever window you're actually working in, so you never see them.

## Root cause

The notification bell's settings panel has a section headed **Sound** offering Default / **Silent** / Glass / Pop / Funk (`src/components/notification-bell.tsx:388-397`).

Picking **Silent** sets `sound.mode = "silent"`. That flows into `workspace.tsx:1394`:

```ts
const sound = () => {
  const s = inboxPrefsRef.current.sound;
  if (s.mode === "silent") return null;
  ...
};
```

…and lands in `src/lib/native-notify.ts:19`:

```ts
if (sound === null) return; // silent mode: suppress entirely
```

So a **sound** preference was suppressing the entire OS notification, not just the ding.

That matters because Cave fires two surfaces per inbox alert:

| surface | where it renders | visible when Cave isn't frontmost? |
|---|---|---|
| `InboxToastStack` | `fixed top-4 right-4 z-50`, **inside the Cave window** (`inbox-toast.tsx:90`) | ❌ — behind the active window by construction |
| OS banner via `nativeNotify` | system-composited | ✅ |

With Silent selected, the only surface left is the in-app toast — which is behind the active window whenever Cave isn't frontmost. Hence the report.

## The fix

Silence is about the ding, not the banner. Drop the early return; `null` and `undefined` both simply omit the `sound` field.

Omitting the field is the intended way to get a *soundless* notification: the plugin only calls `notification.sound_name(...)` when a sound is supplied. (`silent: true` in the plugin's `Options` is documented as iOS-only, so it isn't the right lever here.)

**Verified against the dependency chain** (no Rust toolchain here to build with, so this is source-level, not audible):

| layer | behaviour with no sound supplied |
|---|---|
| `tauri-plugin-notification` `desktop.rs` | `if let Some(sound) = self.sound { notification.sound_name(&sound) }` — `sound_name` stays `None` |
| `notify-rust` `macos/*.rs` | `.maybe_sound(n.sound_name.as_deref())` — passes the `Option` straight through |
| `mac-notification-sys` `notification.rs:209` | `maybe_sound` → `self.sound = sound.map(Into::into)` — stays `None` |
| `mac-notification-sys` `Sound::Default` | `NSUserNotificationDefaultSoundName` is only reachable via the explicit `default_sound()` opt-in |

So an absent `sound` field yields a genuinely **silent** banner. macOS does not substitute its own default. "Silent" stays silent.

## Verification

`src/lib/native-notify.test.ts` (new, wired into the `app` suite in `scripts/run-tests.mjs`).

**Negative control** — the behaviour, replayed against a spy:

```
clean main has the suppressing early-return: true
fixed source has it: false
OLD, silent mode -> sendNotification calls: 0
NEW, silent mode -> sendNotification calls: 1  [{"title":"t","body":"b"}]
```

The test itself fails on clean `main` (the `notificationPayload` export doesn't exist) and passes here — 6/6.

Also green locally: `pnpm typecheck`, `node scripts/check-tests-wired.mjs` (1462 files wired).

## Notes for the reviewer

- **Scope.** This fixes the surface I could prove from the code. If the report was actually about the **notch** pill rather than the toast, that's a different cause — see below.
- **Follow-up worth filing:** neither floating window (`notch`, `quick-chat` in `src-tauri/src/window_geometry.rs:213,560`) sets `set_visible_on_all_workspaces` / macOS `NSWindowCollectionBehavior` (`fullScreenAuxiliary | canJoinAllSpaces`). They both set `always_on_top(true)`, so they don't go behind a normal window — but they *do* vanish over a fullscreen app and don't follow Spaces. Separate symptom, separate PR.
- **Pre-existing bug this uncovers, deliberately not fixed here:** the same chain means Cave's "Default" sound mode is *also* silent on macOS — it passes `undefined`, which omits the field, so it never plays the platform default the code comment promises. Making Default actually ding is a real behaviour change and belongs in its own PR.
- This branch comes from a fork — the authoring account has read-only access to this repo. Commits are unsigned (no signing key in that checkout); the squash-merge commit will be signed by GitHub.

