### PR TITLE
fix(lifecycle): stop treating squash-merged PR associations as malformed

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -702,7 +702,25 @@ function parsePullRequestNode(value: unknown, expectedOid: string | null): PullR
     value.headRefName.length === 0 ||
     typeof value.headRefOid !== "string" ||
     !OID.test(value.headRefOid) ||
-    (expectedOid !== null && value.headRefOid !== expectedOid) ||
+    // Only an OPEN pull request still has its head where we are looking.
+    //
+    // The commit-association caller passes the oid it queried, and every oid it
+    // queries is a TIP (a worktree HEAD or a branch tip), so for an open PR
+    // "this commit is the PR's head" is a real invariant worth enforcing.
+    //
+    // For a MERGED PR it is never true under squash merges: GitHub associates
+    // the squash commit on the base branch with the PR, but that PR's
+    // headRefOid is the PRE-SQUASH branch tip, a commit that no longer heads
+    // anything. Enforcing equality there rejected every squash-merged commit as
+    // "malformed", and because the create gate aggregates inventory errors
+    // repo-wide, one such commit blocked `beads:worktrees:create` for every
+    // bead — worsening with each PR that landed. Confirmed against live GitHub
+    // on three merges (#4256, #4264, #4252): head oid was the branch tip in
+    // every case, never the squash commit (cave-c4f97).
+    //
+    // CLOSED-unmerged is excluded for the same reason: the head it names may
+    // have been rewritten or deleted, so the oid carries no promise either.
+    (expectedOid !== null && value.state === "OPEN" && value.headRefOid !== expectedOid) ||
     (value.headRepository !== null && headRepository === null) ||
     (value.state === "OPEN" && headRepository === null) ||
     typeof value.baseRefName !== "string" ||

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1116,7 +1116,9 @@ if [ "$1" = "api" ] &&
       elif [ "\${LIFECYCLE_UNSTABLE_ASSOCIATED_TOTAL:-0}" = "1" ]; then
         printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":2,"nodes":[{"number":77,"url":"https://github.com/OpenCoven/coven-cave/pull/77","state":"OPEN","isDraft":false,"mergedAt":null,"headRefName":"feat/old","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":true,"endCursor":"assoc-total"}}}}}},{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":78,"url":"https://github.com/OpenCoven/coven-cave/pull/78","state":"OPEN","isDraft":false,"mergedAt":null,"headRefName":"feat/old","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"assoc-total-end"}}}}}}]'
       elif [ "\${LIFECYCLE_MISMATCHED_ASSOCIATED_OID:-0}" = "1" ]; then
-        printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":42,"url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"MERGED","isDraft":false,"mergedAt":"2026-07-21T12:00:00Z","headRefName":"feat/old","headRefOid":"${"c".repeat(oldHead.length)}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"bad-oid"}}}}}}]'
+        printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":42,"url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"OPEN","isDraft":false,"mergedAt":null,"headRefName":"feat/old","headRefOid":"${"c".repeat(oldHead.length)}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"bad-oid"}}}}}}]'
+      elif [ "\${LIFECYCLE_SQUASH_MERGED_ASSOCIATED_OID:-0}" = "1" ]; then
+        printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":1,"nodes":[{"number":42,"url":"https://github.com/OpenCoven/coven-cave/pull/42","state":"MERGED","isDraft":false,"mergedAt":"2026-07-21T12:00:00Z","headRefName":"feat/old","headRefOid":"${"c".repeat(oldHead.length)}","headRepository":{"nameWithOwner":"OpenCoven/coven-cave"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OpenCoven/coven-cave"}}],"pageInfo":{"hasNextPage":false,"endCursor":"squash-oid"}}}}}}]'
       elif [ "\${LIFECYCLE_OUTBOUND_OPEN:-0}" = "1" ]; then
         printf '%s\\n' '[{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":2,"nodes":[{"number":142,"url":"https://github.com/ArchiveOrg/archive/pull/142","state":"CLOSED","isDraft":false,"mergedAt":null,"headRefName":"archived-name","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"archive","baseRepository":{"nameWithOwner":"ArchiveOrg/archive"}}],"pageInfo":{"hasNextPage":true,"endCursor":"assoc-1"}}}}}},{"data":{"repository":{"nameWithOwner":"OpenCoven/coven-cave","object":{"associatedPullRequests":{"totalCount":2,"nodes":[{"number":99,"url":"https://github.com/OtherOrg/other-repo/pull/99","state":"OPEN","isDraft":false,"mergedAt":null,"headRefName":"different-head-name","headRefOid":"${oldHead}","headRepository":{"nameWithOwner":"ForkOwner/fork"},"baseRefName":"main","baseRepository":{"nameWithOwner":"OtherOrg/other-repo"}}],"pageInfo":{"hasNextPage":false,"endCursor":"assoc-2"}}}}}}]'
       elif [ "\${LIFECYCLE_EXACT_MERGED_DIFFERENT_HEAD:-0}" = "1" ]; then
@@ -2271,6 +2273,31 @@ exit 0
     const failedOld = failedReport.items.find((item) => item.branch === "feat/old");
     assert.equal(failedOld.lane, "uncertain", `${environment} fails closed`);
     assert.match(failedOld.probeErrors.join("\n"), expectedReason);
+  }
+
+  // A MERGED PR whose headRefOid is NOT the commit we asked about is the normal
+  // shape of a squash merge, not malformed data: GitHub associates the squash
+  // commit on main with the PR, and that PR's head is the pre-squash branch tip.
+  // Rejecting it made every squash-merged commit an inventory error, and since
+  // the create gate aggregates errors repo-wide, one of them blocked
+  // `beads:worktrees:create` for every bead — worsening with each merge
+  // (cave-c4f97, confirmed against #4256/#4264/#4252). The OPEN case above still
+  // fails closed; only the merged one is accepted.
+  {
+    const squashReport = JSON.parse(
+      patrol(["--json"], { LIFECYCLE_SQUASH_MERGED_ASSOCIATED_OID: "1" }),
+    );
+    const squashOld = squashReport.items.find((item) => item.branch === "feat/old");
+    assert.doesNotMatch(
+      squashOld.probeErrors.join("\n"),
+      /mismatched head OID|malformed fields/i,
+      "a squash merge's pre-squash head oid is not malformed data",
+    );
+    assert.notEqual(
+      squashOld.lane,
+      "uncertain",
+      "a squash-merged association must not fail the unit closed",
+    );
   }
 
   // TRANSIENT churn recovers instead of failing closed (cave-v59dk). The stub


### PR DESCRIPTION
Fixes `cave-c4f97`. `pnpm beads:worktrees:create` could not create a worktree in this repo **at all** — and the cause turned out to be structural, not a transient.

## Symptom

```
worktree-lifecycle-create: lifecycle inventory is incomplete: … pull request node
returned malformed fields or a mismatched head OID
```

Not the rate limit: it persisted after a full GraphQL quota reset with ~4,960 calls available.

## Root cause, confirmed against live GitHub

The commit-association probe asks GitHub for the PRs associated with a commit, then requires every returned PR's `headRefOid` to equal that commit (`worktree-lifecycle-inventory.ts:854` → `:705`).

For a squash merge that can never hold. GitHub associates the squash commit on `main` with the PR, but the PR's head is the **pre-squash branch tip** — a commit that no longer heads anything. Verified on three merges:

| queried commit | PR | state | headRefOid | match |
|---|---|---|---|---|
| `5c5e78f322` | #4256 | MERGED | `0b1e97d339` | ✗ |
| `948749b58c` | #4264 | MERGED | `9143b0a15c` | ✗ |
| `1f4dfe21dc` | #4252 | MERGED | `432c865ef1` | ✗ |

Nothing was malformed. The check was asking the wrong question of a merged PR.

The blast radius came from the create gate aggregating inventory errors **repo-wide** (`worktree-lifecycle-create.ts:1506`): one such commit denied worktree creation to every bead. In a repo that squash-merges everything, that made the failure permanent and monotonically worse with each PR that landed.

## Fix

Enforce the equality only for **OPEN** pull requests.

Every oid this probe queries is a tip — a worktree HEAD or a branch tip — so "this commit is the PR's head" remains a genuine invariant while a PR is open, and the guard still fails closed there. MERGED and CLOSED heads carry no such promise: one names a pre-squash tip, the other may have been rewritten or deleted.

## Tests

The existing mismatch fixture was **MERGED** — it asserted exactly the behaviour that caused this bug. It is now OPEN so it still exercises the guard, and a new `LIFECYCLE_SQUASH_MERGED_ASSOCIATED_OID` fixture covers the squash shape and asserts the unit does *not* fail closed.

Verified in both directions rather than only the happy one:

- **Without the fix**, the new case fails with the original error text — `AssertionError: a squash merge's pre-squash head oid is not malformed data`, actual `…mismatched head OID`. So the test genuinely catches the bug.
- **With the fix**, `worktree-lifecycle-patrol.test.mjs` passes (exit 0), as do `worktree-lifecycle-create.test.mjs` and `worktree-lifecycle-retirement.test.mjs`. `tsc --noEmit` clean.

## Note on scope

The bead also raised whether a single unrelated bad association should abort creation repo-wide at all — a per-unit error would fail far more proportionately. That is a separate design change and is **not** in this PR; this one removes the false positive that made the gate fire constantly.

Refs cave-c4f97
