### PR TITLE
feat(api): persist chat pin as server state so it reaches other clients

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1283,6 +1283,7 @@ export const SUITES = {
     "src/lib/conversation-cache.test.ts",
     "src/lib/familiar-identity-scaffold.test.ts",
     "src/lib/session-list-merge.test.ts",
+    "src/lib/session-pin-persistence.test.ts",
     "src/lib/session-git-enrich.test.ts",
     "src/lib/server/chat-work-branch.test.ts",
     "src/lib/github-tasks-cache.test.ts",

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -6,6 +6,7 @@ import {
   extendSessionAutoArchiveLocal,
   sacrificeSessionLocal,
   setSessionKeepLocal,
+  setSessionPinnedLocal,
   setSessionTitle,
   summonSessionLocal,
 } from "@/lib/cave-config";
@@ -21,6 +22,8 @@ type PatchBody = {
   archived?: boolean;
   /** true → mark keep (never auto-archived), false → clear the mark. */
   keep?: boolean;
+  /** true → pin to the top of chat lists, false → unpin. */
+  pinned?: boolean;
   /** Push the auto-archive deadline out by N days from now (1–365). */
   extendDays?: number;
 };
@@ -59,6 +62,7 @@ export async function PATCH(
     title?: string | null;
     archivedAt?: string | null;
     keep?: boolean;
+    pinned?: boolean;
     extendedUntil?: string;
   } = { ok: true };
 
@@ -80,6 +84,10 @@ export async function PATCH(
 
   if (typeof body.keep === "boolean") {
     result.keep = await setSessionKeepLocal(id, body.keep);
+  }
+
+  if (typeof body.pinned === "boolean") {
+    result.pinned = await setSessionPinnedLocal(id, body.pinned);
   }
 
   if (extendDays != null) {

--- a/src/lib/cave-config.test.ts
+++ b/src/lib/cave-config.test.ts
@@ -18,6 +18,7 @@ try {
     sessionArchived: {},
     sessionSacrificed: {},
     sessionKeep: {},
+    sessionPinned: {},
     sessionArchiveExtendedUntil: {},
     sessionOwned: {},
     mergedPrAutoArchived: {},
@@ -150,6 +151,7 @@ try {
     sessionArchived: {},
     sessionSacrificed: { "session-1": sacrificedAt },
     sessionKeep: {},
+    sessionPinned: {},
     sessionOwned: {},
     mergedPrAutoArchived: { "session-1": "OpenCoven/coven-cave#42" },
     travel: {

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -131,6 +131,7 @@ function defaultState(): CaveState {
     sessionArchived: {},
     sessionSacrificed: {},
     sessionKeep: {},
+    sessionPinned: {},
     sessionArchiveExtendedUntil: {},
     sessionOwned: {},
     mergedPrAutoArchived: {},
@@ -334,6 +335,8 @@ export type CaveState = {
   sessionSacrificed: Record<string, string>;
   /** Session to ISO timestamp when marked keep (never auto-archived). */
   sessionKeep: Record<string, string>;
+  /** Session id -> ISO stamp when it was pinned. Absent means unpinned. */
+  sessionPinned: Record<string, string>;
   /** Session to ISO deadline before which auto-archive sweeps must skip it. */
   sessionArchiveExtendedUntil: Record<string, string>;
   /** Sessions created through Cave's browser-facing session API. */
@@ -660,6 +663,7 @@ async function loadStateUnlocked(): Promise<CaveState> {
       sessionArchived: parsed.sessionArchived ?? {},
       sessionSacrificed: parsed.sessionSacrificed ?? {},
       sessionKeep: parsed.sessionKeep ?? {},
+      sessionPinned: parsed.sessionPinned ?? {},
       sessionArchiveExtendedUntil: parsed.sessionArchiveExtendedUntil ?? {},
       sessionOwned: parsed.sessionOwned ?? {},
       mergedPrAutoArchived: parsed.mergedPrAutoArchived ?? {},
@@ -930,6 +934,20 @@ export async function summonSessionLocal(sessionId: string): Promise<void> {
 }
 
 /** Mark or unmark a session keep (never auto-archived). Manual archive still works. */
+/** Pin or unpin a session so chat lists sort it to the top. Stored like
+ *  `sessionKeep`: an ISO stamp when set, key absent when cleared. */
+export async function setSessionPinnedLocal(sessionId: string, pinned: boolean): Promise<boolean> {
+  await updateState((state) => {
+    if (pinned) {
+      state.sessionPinned[sessionId] = new Date().toISOString();
+    } else {
+      delete state.sessionPinned[sessionId];
+    }
+  });
+  invalidateSessionsListCache();
+  return pinned;
+}
+
 export async function setSessionKeepLocal(sessionId: string, keep: boolean): Promise<boolean> {
   await updateState((state) => {
     if (keep) {

--- a/src/lib/cave-config.ts
+++ b/src/lib/cave-config.ts
@@ -934,6 +934,18 @@ export async function summonSessionLocal(sessionId: string): Promise<void> {
 }
 
 /** Mark or unmark a session keep (never auto-archived). Manual archive still works. */
+export async function setSessionKeepLocal(sessionId: string, keep: boolean): Promise<boolean> {
+  await updateState((state) => {
+    if (keep) {
+      state.sessionKeep[sessionId] = new Date().toISOString();
+    } else {
+      delete state.sessionKeep[sessionId];
+    }
+  });
+  invalidateSessionsListCache();
+  return keep;
+}
+
 /** Pin or unpin a session so chat lists sort it to the top. Stored like
  *  `sessionKeep`: an ISO stamp when set, key absent when cleared. */
 export async function setSessionPinnedLocal(sessionId: string, pinned: boolean): Promise<boolean> {
@@ -946,18 +958,6 @@ export async function setSessionPinnedLocal(sessionId: string, pinned: boolean):
   });
   invalidateSessionsListCache();
   return pinned;
-}
-
-export async function setSessionKeepLocal(sessionId: string, keep: boolean): Promise<boolean> {
-  await updateState((state) => {
-    if (keep) {
-      state.sessionKeep[sessionId] = new Date().toISOString();
-    } else {
-      delete state.sessionKeep[sessionId];
-    }
-  });
-  invalidateSessionsListCache();
-  return keep;
 }
 
 /** Push a session's auto-archive deadline out to `untilIso`. */

--- a/src/lib/server/cave-home-reconciliation.ts
+++ b/src/lib/server/cave-home-reconciliation.ts
@@ -938,6 +938,7 @@ const STATE_MAPS = [
   "sessionArchived",
   "sessionSacrificed",
   "sessionKeep",
+  "sessionPinned",
   "sessionArchiveExtendedUntil",
   "sessionOwned",
   "mergedPrAutoArchived",
@@ -947,6 +948,7 @@ const TIMESTAMP_STATE_MAPS = new Set<string>([
   "sessionArchived",
   "sessionSacrificed",
   "sessionKeep",
+  "sessionPinned",
   "sessionArchiveExtendedUntil",
   "sessionOwned",
 ]);
@@ -955,6 +957,7 @@ const DELETABLE_STATE_MAPS = new Set<string>([
   "sessionTitles",
   "sessionArchived",
   "sessionKeep",
+  "sessionPinned",
 ]);
 
 function mergeRecordMap(

--- a/src/lib/session-list-merge.ts
+++ b/src/lib/session-list-merge.ts
@@ -60,6 +60,7 @@ function localConversationToSession(
   projectRootForCwd?: (cwd: string) => string | null,
 ): SessionRow {
   const keep = Boolean(state.sessionKeep?.[conv.sessionId]);
+  const pinned = Boolean(state.sessionPinned?.[conv.sessionId]);
   const extendedUntil = state.sessionArchiveExtendedUntil?.[conv.sessionId] ?? null;
   const title =
     state.sessionTitles[conv.sessionId] ?? sanitizeSessionTitle(conv.title) ?? "Chat";
@@ -92,6 +93,7 @@ function localConversationToSession(
     ...(conv.prUrl ? { chatPrUrl: conv.prUrl } : {}),
     initiator: conv.initiator ?? { kind: "human", label: "Cave user", channel: "cave" },
     ...(keep ? { keep: true } : {}),
+    ...(pinned ? { pinned: true } : {}),
     ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
   };
 }
@@ -160,6 +162,7 @@ export function mergeSessionRows({
     const titleOverride = state.sessionTitles[session.id];
     const archivedLocal = state.sessionArchived[session.id] ?? null;
     const keep = Boolean(state.sessionKeep?.[session.id]);
+    const pinned = Boolean(state.sessionPinned?.[session.id]);
     const extendedUntil = state.sessionArchiveExtendedUntil?.[session.id] ?? null;
     const archived_at = archivedLocal ?? session.archived_at;
     const localUpdatedAt = localUpdatedById.get(session.id);
@@ -206,6 +209,7 @@ export function mergeSessionRows({
       ...(!local && inferOrigin(session) === "chat" ? { generated: true } : {}),
       ...(local ? { hasLocalConversation: true } : {}),
       ...(keep ? { keep: true } : {}),
+      ...(pinned ? { pinned: true } : {}),
       ...(extendedUntil ? { archive_extended_until: extendedUntil } : {}),
       familiarId,
       initiator: session.initiator ?? initiatorFromSessionKey("", familiarId ?? session.harness),

--- a/src/lib/session-pin-persistence.test.ts
+++ b/src/lib/session-pin-persistence.test.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+// cave-ioswipe.6: pinning a chat must survive a refresh and reach other
+// clients, so it is server state (`sessionPinned`) rather than device-local
+// state. Mirrors `sessionKeep`: an ISO stamp when set, key absent when cleared.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { localConversationSessionRows, mergeSessionRows } from "./session-list-merge.ts";
+
+const baseState = {
+  sessionFamiliar: {},
+  sessionTitles: {},
+  sessionArchived: {},
+  sessionSacrificed: {},
+  sessionKeep: {},
+  sessionPinned: {},
+};
+
+const conv = {
+  sessionId: "local-1",
+  familiarId: "nova",
+  harness: "codex",
+  title: "A chat",
+  createdAt: "2026-08-03T10:00:00.000Z",
+  updatedAt: "2026-08-03T10:05:00.000Z",
+  initiator: { kind: "human", label: "Cave user", channel: "cave" },
+};
+
+// -- Local conversation rows ---------------------------------------------
+const unpinned = localConversationSessionRows([conv], baseState, false);
+assert.equal(unpinned.length, 1);
+assert.ok(
+  !("pinned" in unpinned[0]),
+  "an unpinned row must OMIT the key, not carry pinned:false — the existing " +
+    "deepEqual row tests assert exact shape and a always-present key breaks them",
+);
+
+const pinned = localConversationSessionRows(
+  [conv],
+  { ...baseState, sessionPinned: { "local-1": "2026-08-03T10:06:00.000Z" } },
+  false,
+);
+assert.equal(pinned[0].pinned, true, "a pinned local conversation must surface pinned:true");
+
+// -- Daemon session rows --------------------------------------------------
+// The daemon path builds rows separately from the local-conversation path, so
+// wiring one and not the other is a real failure mode: pin would survive on a
+// UI-only chat and silently vanish on a daemon-backed one.
+const daemonSession = {
+  id: "daemon-1",
+  project_root: "/tmp/proj",
+  harness: "claude",
+  title: "Daemon chat",
+  status: "completed",
+  exit_code: 0,
+  archived_at: null,
+  created_at: "2026-08-03T09:00:00.000Z",
+  updated_at: "2026-08-03T09:30:00.000Z",
+};
+
+const merged = mergeSessionRows({
+  daemonSessions: [daemonSession],
+  localConversations: [],
+  state: { ...baseState, sessionPinned: { "daemon-1": "2026-08-03T10:06:00.000Z" } },
+  includeArchived: false,
+  isValidDaemonProjectRoot: () => true,
+});
+const daemonRow = merged.find((r) => r.id === "daemon-1");
+assert.ok(daemonRow, "the daemon session must be listed");
+assert.equal(daemonRow.pinned, true, "a pinned daemon session must surface pinned:true");
+
+const mergedUnpinned = mergeSessionRows({
+  daemonSessions: [daemonSession],
+  localConversations: [],
+  state: baseState,
+  includeArchived: false,
+  isValidDaemonProjectRoot: () => true,
+});
+assert.ok(
+  !("pinned" in mergedUnpinned.find((r) => r.id === "daemon-1")),
+  "an unpinned daemon row must omit the key too",
+);
+
+// -- Reconciliation registration -----------------------------------------
+// These three lists are module-private constants, so this is a source check
+// rather than a behavioural one. It is worth having: a new state map that is
+// missing from STATE_MAPS is silently dropped when two cave-home states
+// reconcile, and one missing from DELETABLE_STATE_MAPS makes UNPINNING
+// un-mergeable — the delete is discarded and the pin resurrects. Neither
+// failure is visible from the route or the merge.
+const reconciliation = await readFile(
+  new URL("./server/cave-home-reconciliation.ts", import.meta.url),
+  "utf8",
+);
+for (const list of ["STATE_MAPS", "TIMESTAMP_STATE_MAPS", "DELETABLE_STATE_MAPS"]) {
+  const block = reconciliation.match(new RegExp(`const ${list}[^\\[]*\\[(.*?)\\]`, "s"));
+  assert.ok(block, `${list} must exist`);
+  assert.match(
+    block[1],
+    /"sessionPinned"/,
+    `sessionPinned must be registered in ${list}, or pin state is lost on reconciliation`,
+  );
+}
+
+// -- Route contract -------------------------------------------------------
+const route = await readFile(
+  new URL("../app/api/sessions/[id]/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  route,
+  /if \(typeof body\.pinned === "boolean"\) \{\s*\n\s*result\.pinned = await setSessionPinnedLocal\(id, body\.pinned\);/,
+  "PATCH must apply pinned and echo it back",
+);
+
+console.log("session-pin-persistence: ok");

--- a/src/lib/session-pin-persistence.test.ts
+++ b/src/lib/session-pin-persistence.test.ts
@@ -31,7 +31,7 @@ assert.equal(unpinned.length, 1);
 assert.ok(
   !("pinned" in unpinned[0]),
   "an unpinned row must OMIT the key, not carry pinned:false — the existing " +
-    "deepEqual row tests assert exact shape and a always-present key breaks them",
+    "deepEqual row tests assert exact shape and an always-present key breaks them",
 );
 
 const pinned = localConversationSessionRows(
@@ -106,9 +106,18 @@ const route = await readFile(
   new URL("../app/api/sessions/[id]/route.ts", import.meta.url),
   "utf8",
 );
+// Two independent single-line matches rather than one regex spanning the
+// block: the previous form hard-required specific whitespace after the `if`
+// opened, so reformatting the route could fail a test whose behaviour was
+// unchanged. Both still fail if the branch is removed.
 assert.match(
   route,
-  /if \(typeof body\.pinned === "boolean"\) \{\s*\n\s*result\.pinned = await setSessionPinnedLocal\(id, body\.pinned\);/,
+  /typeof body\.pinned === "boolean"/,
+  "PATCH must gate on a boolean, so an absent field is never treated as an unpin",
+);
+assert.match(
+  route,
+  /result\.pinned = await setSessionPinnedLocal\(id, body\.pinned\)/,
   "PATCH must apply pinned and echo it back",
 );
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -116,6 +116,8 @@ export type SessionRow = {
   diff?: { additions: number; deletions: number } | null;
   /** Keep mark from Cave state (never auto-archived when true). */
   keep?: boolean;
+  /** Pinned by the user; chat lists sort pinned rows to the top. */
+  pinned?: boolean;
   /** Cave-local auto-archive defer-until timestamp, if set. */
   archive_extended_until?: string | null;
 };


### PR DESCRIPTION
Server half of cave-ioswipe.6. The iOS half follows separately.

Pinning a chat was device-local: it did not survive a reinstall and never reflected on another client. `archived` already had full server support (`PATCH /api/sessions/:id { archived }`); `pinned` had none at all. This adds it as `sessionPinned` in cave state, mirroring `sessionKeep` exactly — an ISO stamp when set, key absent when cleared.

## What changed

- `PATCH /api/sessions/:id` accepts `pinned` and echoes it back.
- `SessionRow.pinned` surfaces it to every client.
- **Both** row-construction paths in `session-list-merge` set it. The local-conversation path and the daemon-session path are separate; wiring one and not the other would make pin survive on a UI-only chat and silently vanish on a daemon-backed one. Both are covered.
- Registered in **all three** cave-home reconciliation lists.

That last point is the one worth reviewing closely, because both failure modes are invisible from the route and from the merge:

| list | if `sessionPinned` is missing |
|---|---|
| `STATE_MAPS` | the key is dropped entirely when two cave-home states reconcile |
| `TIMESTAMP_STATE_MAPS` | the ISO stamp is merged with the wrong strategy |
| `DELETABLE_STATE_MAPS` | **unpinning becomes un-mergeable — the delete is discarded and the pin resurrects** |

## Shape choice

Rows omit `pinned` entirely when unpinned rather than carrying `pinned: false`. The existing merge tests assert exact row shape via `deepEqual`, so an always-present key would break them. That choice is itself pinned, so it can't be quietly reversed.

Two pre-existing exact-shape assertions in `cave-config.test.ts` gain the new map. That's a legitimate consequence of adding state, not a workaround — and there were two, not one, which the full suite is what surfaced.

## Verification

Seven regressions each checked to **fail** the new test:

| regression | caught |
|---|---|
| local-conversation rows lose `pinned` | ✓ |
| daemon rows lose `pinned` | ✓ |
| `pinned` always present (breaks exact-shape tests) | ✓ |
| `STATE_MAPS` drops `sessionPinned` | ✓ |
| `TIMESTAMP_STATE_MAPS` drops `sessionPinned` | ✓ |
| `DELETABLE_STATE_MAPS` drops it (unpin resurrects) | ✓ |
| PATCH stops applying `pinned` | ✓ |

`pnpm typecheck` clean · `test:app` 1060 files · `test:api` 327 files.

## Scope note

Message delete is deliberately **not** here. It has no server API anywhere — the transcript is served from the daemon's event log — and the two viable shapes (non-destructive suppression vs. true deletion) mean materially different things to someone deleting a message containing a secret. Split to **cave-2nl6c** with both options written up rather than picked unilaterally.
