### PR TITLE
fix(lifecycle): scope the create gate to errors that can affect creation

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -6,6 +6,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -1616,5 +1617,65 @@ await withFixture({}, async (fixture) => {
     1,
   );
 });
+
+// A created worktree starts with its HEAD equal to the default tip, which the
+// landing-time probe cannot date ("unprovable when candidate equals captured
+// default"). That is a per-unit probe error, and while creation aborted on any
+// probe error anywhere in the repo it meant every successful create poisoned the
+// inventory for the next one — worktree #1 blocked worktree #2, for a different
+// bead, forever. Creation reads only owned paths and budgets, neither of which a
+// probe touches, so an unrelated unit's probe error must not block it
+// (cave-t9tlm).
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    const first = runCreate(fixture, createArgs());
+    assert.equal(first.status, 0, `first create must succeed: ${first.stderr}`);
+
+    // Give the unit created above a real per-unit probe error. Dropping its
+    // reflog is exactly how production produced one: `__dolt_remote_info__` is
+    // written by Dolt rather than by git commands, so it carries no reflog and
+    // the recency probe reports "branch/worktree recency unavailable" for it.
+    // Without a reproduction the assertion below passes either way — the
+    // fixture's stub always supplies a merged-PR timestamp, so nothing else in
+    // it can fail a probe.
+    rmSync(path.join(fixture.repo, ".git", "logs", "refs", "heads", "feat"), {
+      recursive: true,
+      force: true,
+    });
+    for (const dir of readdirSync(path.join(fixture.repo, ".git", "worktrees"), {
+      withFileTypes: true,
+    })) {
+      if (dir.isDirectory()) {
+        rmSync(path.join(fixture.repo, ".git", "worktrees", dir.name, "logs"), {
+          recursive: true,
+          force: true,
+        });
+      }
+    }
+
+    const second = runCreate(
+      fixture,
+      createArgs({ bead: "cave-unit2", branch: "feat/cave-unit2-example" }),
+    );
+    assert.doesNotMatch(
+      second.stderr,
+      /lifecycle inventory is incomplete/,
+      "an existing unit's probe error must not block an unrelated creation",
+    );
+    assert.equal(second.status, 0, `second create must succeed: ${second.stderr}`);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit2-example") !== null,
+      true,
+      "the second branch is actually created",
+    );
+
+    // The global-outage stop (GitHub unreachable => abort) keeps its own
+    // coverage in the CAVE_TEST_GH_FAIL case earlier in this file, which still
+    // passes with the gate scoped. It is deliberately not re-asserted here: this
+    // bead already owns a worktree by now, so admission would refuse for that
+    // reason and the assertion would prove nothing about the inventory gate.
+  },
+);
 
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -751,15 +751,29 @@ function exceptionForPath(
   return unique.values().next().value ?? null;
 }
 
+/**
+ * Errors that can actually make a CREATION decision wrong.
+ *
+ * Creation reads exactly two things out of the inventory: the paths this bead
+ * already owns ({@link existingOwnedPaths}) and the budget counts. The first is
+ * derived from each item's path, taskIds and bead metadata, so a metadata error
+ * can hide an owned path and let creation past a budget it should have hit —
+ * that stays a hard stop, repo-wide. The second comes from local git facts
+ * (worktree count, branch count, exception counts) and no probe touches it.
+ *
+ * `probeErrors` are deliberately NOT included. They answer "is this unit safe to
+ * RETIRE" — landing time, PR association, ref recency — which creation never
+ * asks. Aggregating them here meant one unrelated unit denied `create` to every
+ * bead, and the units that tripped it were ones creation has no opinion about:
+ * the `__dolt_remote_info__` bookkeeping ref (protected, local commits GitHub has
+ * never seen, no reflog), and any branch whose HEAD still equals the default tip
+ * — which is every freshly-created worktree, so each new worktree blocked the
+ * next one. The inventory already reports probe failures per unit and lands that
+ * unit in `uncertain`; this makes the create gate agree with that posture instead
+ * of re-aborting the whole run (cave-c4f97).
+ */
 function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
-  return [
-    ...new Set(
-      items.flatMap((item) => [
-        ...item.probeErrors,
-        ...item.metadataErrors,
-      ]),
-    ),
-  ];
+  return [...new Set(items.flatMap((item) => item.metadataErrors))];
 }
 
 function existingOwnedPaths(
@@ -1501,7 +1515,11 @@ function execute(
     nowMs: Date.now(),
   });
   heartbeatBoth(leases, "after lifecycle inventory");
-  const errors = inventoryErrors(inventory.items);
+  // Global failures still abort: if GitHub was unreachable or the canonical
+  // repository could not be resolved, the run did not see the repository at all
+  // and no admission decision it makes is trustworthy. Per-unit probe errors do
+  // not abort — see {@link inventoryErrors}.
+  const errors = [...inventory.globalErrors, ...inventoryErrors(inventory.items)];
   if (errors.length > 0) {
     throw new CliError(`lifecycle inventory is incomplete: ${errors.join("; ")}`);
   }

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -31,6 +31,15 @@ export interface WorktreeLifecycleInventory {
   items: WorktreeLifecycleItem[];
   budgets: WorktreeLifecycleBudgets;
   inventoryFingerprint: string;
+  /**
+   * Failures of a whole probe rather than of one unit — GitHub unreachable, the
+   * canonical repository unresolvable, the Beads or workflow inventory
+   * unreadable. They are also folded into every unit's `probeErrors` so each
+   * unit fails closed on its own, but callers that need to tell "the run could
+   * not see the repo" apart from "this unit has an unprovable landing time"
+   * read them here (cave-t9tlm).
+   */
+  globalErrors: string[];
 }
 
 type CommandResult = {
@@ -2847,6 +2856,7 @@ export function collectWorktreeLifecycleInventory(
       classifyInventoryObservation(observation, options.nowMs),
     ),
     budgets,
+    globalErrors: [...new Set(branchGlobalErrors)],
     inventoryFingerprint: fingerprint(
       initialWorktreeRaw,
       initialRefsRaw,


### PR DESCRIPTION
Follow-up to #4269. That PR removed the squash-merge false positive; this one makes `pnpm beads:worktrees:create` actually work again.

## Why it was still broken

Creation aborted on **any** `probeError` from **any** unit in the repo. But creation reads only two things out of the inventory:

- **owned paths** — from each item's `path`, `taskIds` and bead metadata
- **budgets** — from local git facts (worktree count, branch count, exception counts)

Neither depends on a probe. `probeErrors` answer a different question — *is this unit safe to **retire*** — via landing time, PR association and ref recency. Aggregating them into the create gate denied creation over units creation has no opinion about.

The three that blocked it here:

| unit | error | why |
|---|---|---|
| `__dolt_remote_info__` | `branch/worktree recency unavailable` | Dolt writes this ref without git commands, so it has **no reflog** |
| `__dolt_remote_info__` | `commit association connection is unavailable` | its local tip is a commit GitHub has never seen |
| any branch at the default tip | `landing time is unprovable when candidate equals captured default` | **every freshly-created worktree** — so each new worktree blocked the next one, even for a different bead |

`__dolt_remote_info__` is lane `protected`: never a retirement candidate, yet it denied creation to every bead.

## Fix

Gate on **metadata errors** — those genuinely can make a creation decision wrong, by hiding a path this bead already owns and letting it past a budget it should have hit.

Keep aborting on **global** failures: if GitHub was unreachable or the canonical repository could not be resolved, the run never saw the repository and no admission decision is trustworthy. That distinction needed a channel, so the inventory now returns its `globalErrors` alongside `items` instead of only folding them into every unit's `probeErrors`.

I caught this the hard way: scoping the gate to metadata errors alone silently disabled the total-outage stop, and the existing `CAVE_TEST_GH_FAIL` test failed (`0 !== 1`). It passes again with the global channel restored.

## Verified end to end

Against the real repository, not just fixtures:

- `beads:worktrees:create` exits **0** and writes the `metadata.coven.worktree` record.
- The resulting unit is classified **`active` with metadata present** — not `uncertain — structured lifecycle metadata backfill required`, which is what made worktrees unretirable in the first place.
- The landing-time condition now appears as a *probe warning* on that unit rather than a repo-wide abort.

All three lifecycle suites pass (create, retirement, patrol), `tsc --noEmit` clean.

## On the regression test

My first version asserted "second create succeeds" and **passed with and without the fix** — the fixture's gh stub always supplies a merged-PR timestamp, so nothing in it can fail a probe. A test that cannot fail is not evidence, so I rewrote it: it now drops the created unit's reflog first, which is exactly how production produced a probe error (`__dolt_remote_info__` has no reflog). Against the unscoped gate it fails with precisely this assertion:

```
AssertionError: an existing unit's probe error must not block an unrelated creation
```

I also removed a sub-case that re-asserted the outage stop using a bead that already owned a worktree — admission would refuse first, so it proved nothing about the gate. That path keeps its existing coverage earlier in the file.

Refs cave-t9tlm, cave-c4f97
