### PR TITLE
feat(chat): echo the prompt that produced the answer, with edit & rerun

### DIFF
--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -367,9 +367,20 @@ assert.match(
   "Regenerate is hidden while busy and on pending turns (CHAT-D6-02)",
 );
 
+// The backwards walk for the preceding user turn moved into a named helper
+// when the reader's "You asked" card needed the same turn (cave-r8gfl). The
+// guarantee is unchanged and split across two assertions: the helper finds the
+// nearest USER turn, and regenerate still reuses that turn's controls plus the
+// assistant's authoritative retry model.
 assert.match(
   source,
-  /function regenerateFor\(turn: Turn\)[\s\S]*?role === "user"[\s\S]*?if \(!prevUser\) return undefined;[\s\S]*?retryTurnModelRequest\(prevUser, turn\)[\s\S]*?modelControls: prevUser\.modelControls \?\? \{\}/,
+  /function precedingUserTurn\(turn: Turn\): Turn \| undefined \{[\s\S]*?candidate\.role === "user"/,
+  "The preceding-user-turn walk is a single named helper, not copied per caller (CHAT-D6-02)",
+);
+
+assert.match(
+  source,
+  /function regenerateFor\(turn: Turn\)[\s\S]*?const prevUser = precedingUserTurn\(turn\);[\s\S]*?if \(!prevUser\) return undefined;[\s\S]*?retryTurnModelRequest\(prevUser, turn\)[\s\S]*?modelControls: prevUser\.modelControls \?\? \{\}/,
   "Regenerate reuses the preceding user turn's controls and the assistant's authoritative retry model (CHAT-D6-02)",
 );
 

--- a/src/components/chat-view-transcript-memo.test.ts
+++ b/src/components/chat-view-transcript-memo.test.ts
@@ -37,7 +37,7 @@ assert.match(
 // ── 3. Latest-ref pattern: reassigned every render, all typed actions ───────
 assert.match(
   src,
-  /transcriptHandlersRef\.current = \{\s*siblingsFor,\s*switchBranch,\s*editTurnInComposer,\s*regenerateFor,\s*replyFor,\s*askAboutFor,\s*send,\s*activateFollowUp: handleFollowUp,\s*\};/,
+  /transcriptHandlersRef\.current = \{\s*siblingsFor,\s*switchBranch,\s*editTurnInComposer,\s*regenerateFor,\s*replyFor,\s*askAboutFor,\s*readerPromptFor,\s*rerunWithFor,\s*send,\s*activateFollowUp: handleFollowUp,\s*\};/,
   "the handlers ref must be reassigned in the render body so closures never go stale",
 );
 

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -5292,16 +5292,64 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // assistant turns with no preceding user turn (e.g. system-injected), and
   // on assistant turns that are NOT the last on the active path (only the tip
   // gets a regenerate button so earlier branches keep their settled answers).
+  /** The user turn that produced this answer: the nearest `user` turn before it
+   *  on the active path. Both the Regenerate action and the reader's "You asked"
+   *  card key off this, so it lives in one place — a second copy of the walk is
+   *  a second thing to get wrong when branching changes. */
+  function precedingUserTurn(turn: Turn): Turn | undefined {
+    const idx = activePath.findIndex((t) => t.id === turn.id);
+    if (idx < 0) return undefined;
+    for (let j = idx - 1; j >= 0; j -= 1) {
+      const candidate = activePath[j];
+      if (candidate && candidate.role === "user") return candidate;
+    }
+    return undefined;
+  }
+
+  /** What the reader echoes above the answer. Display only, so it is NOT gated
+   *  on being the tip or on `busy` the way rerunning is — every settled answer
+   *  had a prompt, and showing it is always honest. */
+  function readerPromptFor(turn: Turn): { text: string; createdAt?: string } | undefined {
+    if (turn.role !== "assistant" || turn.pending) return undefined;
+    const prevUser = precedingUserTurn(turn);
+    const text = prevUser?.text?.trim();
+    return text ? { text, createdAt: prevUser?.createdAt } : undefined;
+  }
+
+  /** Rerun this turn from an EDITED prompt. Same send path, attachments, model
+   *  request and controls as Regenerate — only the text differs — and the same
+   *  `parentTurnId`, so the new answer lands as a sibling rather than appending.
+   *  That is what the design means by "replaces the answer below".
+   *  Gated exactly as regenerateFor is: a rerun mutates the thread. */
+  function rerunWithFor(turn: Turn): ((prompt: string) => void) | undefined {
+    if (busy || turn.role !== "assistant" || turn.pending) return undefined;
+    if (activePath[activePath.length - 1]?.id !== turn.id) return undefined;
+    const prevUser = precedingUserTurn(turn);
+    if (!prevUser) return undefined;
+    const { attachments: prevAttachments, parentId } = prevUser;
+    return (prompt: string) => {
+      const next = prompt.trim();
+      if (!next) return;
+      void sendRaw(
+        next,
+        prevAttachments ?? [],
+        [],
+        { parentTurnId: parentId ?? null, ...retryTurnModelRequest(prevUser, turn) },
+        {
+          thinkingEffort,
+          responseSpeed,
+          modelControls: prevUser.modelControls ?? {},
+          permissionMode,
+          runtimeHost: runtimeHost ?? undefined,
+        },
+      );
+    };
+  }
+
   function regenerateFor(turn: Turn): (() => void) | undefined {
     if (busy || turn.role !== "assistant" || turn.pending) return undefined;
     if (activePath[activePath.length - 1]?.id !== turn.id) return undefined;
-    const idx = activePath.findIndex((t) => t.id === turn.id);
-    if (idx < 0) return undefined;
-    let prevUser: Turn | undefined;
-    for (let j = idx - 1; j >= 0; j -= 1) {
-      const candidate = activePath[j];
-      if (candidate && candidate.role === "user") { prevUser = candidate; break; }
-    }
+    const prevUser = precedingUserTurn(turn);
     if (!prevUser) return undefined;
     const { text, attachments: prevAttachments, parentId } = prevUser;
     if (!text.trim() && !prevAttachments?.length) return undefined;
@@ -5472,6 +5520,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     regenerateFor,
     replyFor,
     askAboutFor,
+    readerPromptFor,
+    rerunWithFor,
     send,
     activateFollowUp: handleFollowUp,
   };
@@ -7577,6 +7627,8 @@ type TranscriptHandlers = {
   regenerateFor: (turn: Turn) => (() => void) | undefined;
   replyFor: (turn: Turn) => (() => void) | undefined;
   askAboutFor: (turn: Turn) => ((quote: string) => void) | undefined;
+  readerPromptFor: (turn: Turn) => { text: string; createdAt?: string } | undefined;
+  rerunWithFor: (turn: Turn) => ((prompt: string) => void) | undefined;
   send: (override?: string) => Promise<void>;
   activateFollowUp: (path: NextPath) => void;
 };
@@ -7673,6 +7725,8 @@ const TranscriptRows = memo(function TranscriptRows({
           onRegenerate={handlers().regenerateFor(t)}
           onReply={handlers().replyFor(t)}
           onAskAbout={handlers().askAboutFor(t)}
+          readerPrompt={handlers().readerPromptFor(t)}
+          onRerunWith={handlers().rerunWithFor(t)}
           onOpenUrl={onOpenUrl}
           onSuggestion={(path) => handlers().activateFollowUp(path)}
           onRequest={(prompt) => void handlers().send(prompt)}
@@ -7724,6 +7778,8 @@ const TranscriptRows = memo(function TranscriptRows({
               onRegenerate={handlers().regenerateFor(t)}
               onReply={handlers().replyFor(t)}
               onAskAbout={handlers().askAboutFor(t)}
+              readerPrompt={handlers().readerPromptFor(t)}
+              onRerunWith={handlers().rerunWithFor(t)}
               onOpenUrl={onOpenUrl}
               onSuggestion={(path) => handlers().activateFollowUp(path)}
               onRequest={(prompt) => void handlers().send(prompt)}
@@ -7753,6 +7809,8 @@ function TurnRowImpl({
   onRegenerate,
   onReply,
   onAskAbout,
+  readerPrompt,
+  onRerunWith,
   onOpenUrl,
   expanded = false,
   onToggleAvatar,
@@ -7784,6 +7842,11 @@ function TurnRowImpl({
   /** Ask about a passage selected in the Expand reader — stages the selection
    *  as the composer's quoted reply target. Assistant turns only. */
   onAskAbout?: (quote: string) => void;
+  /** The prompt that produced this answer, echoed above it in the reader. */
+  readerPrompt?: { text: string; createdAt?: string };
+  /** Rerun the turn from an edited prompt. Absent while busy or off the tip,
+   *  which is what hides the reader's Edit affordance. */
+  onRerunWith?: (prompt: string) => void;
   onOpenUrl?: (url: string) => void;
   expanded?: boolean;
   onToggleAvatar?: () => void;
@@ -8128,6 +8191,8 @@ function TurnRowImpl({
                   readerTools={settledTools}
                   readerDurationMs={turn.durationMs}
                   onAskAbout={onAskAbout}
+                  readerPrompt={readerPrompt}
+                  onRerunWith={onRerunWith}
                   branchNav={branchNav}
                 />
                 <ResponseModelStatus metadata={turn.responseMetadata} />

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -990,6 +990,10 @@ export type MessageBubbleProps = {
   /** Ask a follow-up about a passage selected inside the reader. Without it
    *  the reader's selection ask-bar is not rendered. */
   onAskAbout?: (quote: string) => void;
+  /** The prompt that produced this answer, echoed above it in the reader. */
+  readerPrompt?: { text: string; createdAt?: string };
+  /** Rerun this turn from an edited prompt. Absent while busy or off the tip. */
+  onRerunWith?: (prompt: string) => void;
   /** Branching: when a turn has siblings, render a compact ‹ index/total ›
    *  switcher. Omitted (or total <= 1) hides it. */
   branchNav?: {
@@ -1000,7 +1004,7 @@ export type MessageBubbleProps = {
   };
 };
 
-export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, feedbackContext, segments, readerTools, readerDurationMs, onAskAbout, branchNav }: MessageBubbleProps) {
+export function MessageBubble({ role, content, timestamp, showTimestamp = true, pending, isError, label, onEdit, onRegenerate, onReply, onOpenUrl, messageId, feedbackContext, segments, readerTools, readerDurationMs, onAskAbout, readerPrompt, onRerunWith, branchNav }: MessageBubbleProps) {
   const [tsVisible, setTsVisible] = useState(false);
   const [vote, setVote] = useState<Feedback | null>(() => (messageId ? getFeedback(messageId) : null));
   const applyVote = (v: Feedback) => {
@@ -1203,6 +1207,8 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
             tools={readerTools}
             durationMs={readerDurationMs}
             onAskAbout={onAskAbout}
+            prompt={readerPrompt}
+            onRerunWith={onRerunWith}
           />
           <CopyBubble text={content} />
           {role === "assistant" ? (
@@ -1249,12 +1255,16 @@ function ExpandBubble({
   tools,
   durationMs,
   onAskAbout,
+  prompt,
+  onRerunWith,
 }: {
   text: string;
   label: string;
   tools?: readonly BatchTool[];
   durationMs?: number;
   onAskAbout?: (quote: string) => void;
+  prompt?: { text: string; createdAt?: string };
+  onRerunWith?: (prompt: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const readerCited = useMemo(() => renderCitedBody(text), [text]);
@@ -1276,6 +1286,8 @@ function ExpandBubble({
           tools={tools}
           durationMs={durationMs}
           onAsk={onAskAbout}
+          prompt={prompt}
+          onRerunWith={onRerunWith}
           onClose={() => setOpen(false)}
         >
           {/* MarkdownContent, not MarkdownBlock: it is the renderer that wires

--- a/src/components/message-reader.tsx
+++ b/src/components/message-reader.tsx
@@ -85,6 +85,14 @@ export type MessageReaderProps = {
   /** Ask a follow-up about the selected passage. Without it, selecting text in
    *  the reader does nothing special — the ask-bar is not rendered. */
   onAsk?: (quote: string) => void;
+  /** The prompt that produced this answer. Absent — a root turn, or a turn
+   *  whose prompt is empty — renders no card at all rather than an empty one. */
+  prompt?: { text: string; createdAt?: string };
+  /** Rerun from an edited prompt. Absent while the thread is busy or this turn
+   *  is not the tip, which is exactly when a rerun would be a lie: the answer
+   *  it replaces is not the one on screen. Display of the prompt is NOT gated
+   *  on this — reading what you asked is always safe. */
+  onRerunWith?: (prompt: string) => void;
 };
 
 type FootTab = "sources" | "tools" | "skills";
@@ -103,6 +111,15 @@ const VIEW_LABELS: Record<ToolsView | SkillsView, string> = {
 };
 const viewLabel = (view: ToolsView | SkillsView) => VIEW_LABELS[view];
 
+/** The prompt's clock time, in the reader's locale. Falls back to nothing
+ *  rather than an invalid-date string when the turn carries no usable stamp. */
+function fmtAskTime(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime())
+    ? ""
+    : d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}
+
 /** A filename the OS will accept, derived from the familiar's name. */
 function exportFilename(label: string): string {
   const slug = label.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
@@ -117,6 +134,8 @@ export function MessageReader({
   tools,
   durationMs,
   onAsk,
+  prompt,
+  onRerunWith,
 }: MessageReaderProps) {
   const dialogRef = useRef<HTMLDivElement | null>(null);
   const docRef = useRef<HTMLDivElement | null>(null);
@@ -157,6 +176,8 @@ export function MessageReader({
   const [footTab, setFootTab] = useState<FootTab>("sources");
   const [toolsView, setToolsView] = useState<ToolsView>("batches");
   const [skillsView, setSkillsView] = useState<SkillsView>("cards");
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(prompt?.text ?? "");
   const [selection, setSelection] = useState<string | null>(null);
   const [viewer, setViewer] = useState<Citation | null>(null);
 
@@ -426,6 +447,71 @@ export function MessageReader({
               onTouchEnd={onSelect}
             >
               <div className="cave-reader-measure">
+                {prompt ? (
+                  <div className="cave-reader-ask">
+                    <div className="cave-reader-ask__head">
+                      <span className="cave-reader-eyebrow">You asked</span>
+                      {prompt.createdAt ? (
+                        <span className="cave-reader-ask__when">{fmtAskTime(prompt.createdAt)}</span>
+                      ) : null}
+                      {onRerunWith && !editing ? (
+                        <button
+                          type="button"
+                          className="ui-btn ui-btn--ghost ui-btn--xs focus-ring cave-reader-ask__edit"
+                          onClick={() => {
+                            setDraft(prompt.text);
+                            setEditing(true);
+                          }}
+                        >
+                          <Icon name="ph:note-pencil" width={10} aria-hidden />
+                          Edit &amp; rerun
+                        </button>
+                      ) : null}
+                    </div>
+
+                    {editing ? (
+                      <div className="cave-reader-ask__edit-body">
+                        <textarea
+                          className="cave-reader-ask__input"
+                          value={draft}
+                          onChange={(e) => setDraft(e.target.value)}
+                          aria-label="Edit the prompt"
+                          rows={3}
+                        />
+                        <div className="cave-reader-ask__actions">
+                          <button
+                            type="button"
+                            className="ui-btn ui-btn--primary ui-btn--sm focus-ring"
+                            disabled={!draft.trim()}
+                            onClick={() => {
+                              const next = draft.trim();
+                              if (!next) return;
+                              onRerunWith?.(next);
+                              // Close: the answer behind this card is the one
+                              // being replaced, so leaving the reader open on it
+                              // would show a result the rerun has superseded.
+                              setEditing(false);
+                              onClose();
+                            }}
+                          >
+                            Rerun this turn
+                          </button>
+                          <button
+                            type="button"
+                            className="ui-btn ui-btn--ghost ui-btn--sm focus-ring"
+                            onClick={() => setEditing(false)}
+                          >
+                            Cancel
+                          </button>
+                          <span className="cave-reader-ask__note">replaces the answer below</span>
+                        </div>
+                      </div>
+                    ) : (
+                      <p className="cave-reader-ask__text">{prompt.text}</p>
+                    )}
+                  </div>
+                ) : null}
+
                 {skills.length ? (
                   <div className="cave-reader-turnmeta">
                     <span className="cave-reader-eyebrow">Skills</span>

--- a/src/styles/cave-chat/reader.css
+++ b/src/styles/cave-chat/reader.css
@@ -364,6 +364,65 @@
    clear of the head rather than flush against it. */
 .cave-reader-doc :is(h1, h2, h3, h4, h5, h6) { scroll-margin-top: var(--space-6); }
 
+/* "You asked" — the prompt that produced the answer, echoed above it so the
+   reader is a record of the exchange rather than half of one. */
+.cave-reader-ask {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-6);
+  padding: var(--space-3);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--foreground) 3%, transparent);
+}
+.cave-reader-ask__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.cave-reader-ask__when {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+.cave-reader-ask__edit { margin-left: auto; }
+.cave-reader-ask__text {
+  margin: 0;
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+  color: var(--text-secondary);
+}
+.cave-reader-ask__edit-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.cave-reader-ask__input {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence-soft) 45%, transparent);
+  border-radius: var(--radius-control);
+  background: var(--bg-base);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: var(--text-base);
+  line-height: var(--leading-relaxed);
+  outline: none;
+}
+.cave-reader-ask__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+.cave-reader-ask__note {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+
 /* The turn's own eyebrow row — skills the answer reached for, and the
    collapsed agent-work line. Both are real turn data or they are absent. */
 .cave-reader-turnmeta {

--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -26,6 +26,9 @@ test.describe.configure({ mode: "serial", timeout: 180_000 });
 
 const ISO = "2026-08-03T14:02:00.000Z";
 
+/** The prompt the reader echoes back above the answer. */
+const USER_PROMPT = "Review PR #4188 for correctness and regressions.";
+
 /** An answer with headings (rail), footnote citations (chips + Sources) and
  *  enough prose that the document scrolls. */
 const CITED_ANSWER = `Reviewing PR #4188 for correctness and regressions.
@@ -112,7 +115,7 @@ async function openReader(page: Page, turn: TurnSpec) {
         ok: true,
         conversation: {
           turns: [
-            { id: "u1", role: "user", text: "Review PR #4188.", createdAt: ISO },
+            { id: "u1", role: "user", text: USER_PROMPT, createdAt: ISO },
             { id: "a1", role: "assistant", text: turn.text, createdAt: ISO, durationMs: 134_000, tools: turn.tools ?? [] },
           ],
         },
@@ -232,4 +235,37 @@ test("Escape unwinds one layer at a time: source viewer, then menu, then reader"
   // Only now does Escape close the reader itself.
   await page.keyboard.press("Escape");
   await expect(page.locator(".cave-reader")).toHaveCount(0);
+});
+
+test("the reader echoes the prompt that produced the answer", async ({ page }) => {
+  await openReader(page, { text: CITED_ANSWER, tools: TOOLS });
+
+  const ask = page.locator(".cave-reader-ask");
+  await expect(ask).toBeVisible();
+  await expect(ask).toContainText("You asked");
+  await expect(ask.locator(".cave-reader-ask__text")).toHaveText(USER_PROMPT);
+
+  // The card sits ABOVE the answer — it frames what follows, it is not a footnote.
+  const askBox = await ask.boundingBox();
+  const firstHeading = await page.locator(".cave-reader-doc h2").first().boundingBox();
+  expect(askBox!.y).toBeLessThan(firstHeading!.y);
+});
+
+test("Edit opens the prompt for editing and Cancel puts it back", async ({ page }) => {
+  await openReader(page, { text: CITED_ANSWER, tools: TOOLS });
+  const ask = page.locator(".cave-reader-ask");
+
+  await ask.getByRole("button", { name: /Edit & rerun/i }).click();
+  const input = ask.locator(".cave-reader-ask__input");
+  await expect(input).toHaveValue(USER_PROMPT);
+  // The prose form is replaced while editing, not duplicated beside it.
+  await expect(ask.locator(".cave-reader-ask__text")).toHaveCount(0);
+
+  await input.fill("");
+  // An empty prompt cannot be rerun — there is nothing to send.
+  await expect(ask.getByRole("button", { name: "Rerun this turn" })).toBeDisabled();
+
+  await ask.getByRole("button", { name: "Cancel" }).click();
+  await expect(ask.locator(".cave-reader-ask__input")).toHaveCount(0);
+  await expect(ask.locator(".cave-reader-ask__text")).toHaveText(USER_PROMPT);
 });


### PR DESCRIPTION
`Reader.dc.html` frame 3a opens with a **"You asked"** card above the answer: the prompt, its time, and an **Edit & rerun** affordance. Deferred from #4255 because the reader was handed only the assistant turn — but the data was already there.

### How it works

`chat-view`'s `regenerateFor` already walked `activePath` backwards for the preceding user turn. That walk is now `precedingUserTurn`, used by both — one place to get branching wrong instead of two.

Rerunning from an **edited** prompt is `regenerateFor`'s own `sendRaw` call with the text substituted: same attachments, same model request, same controls, same `parentTurnId`. That last one is what makes the new answer a *sibling branch* rather than an append — which is exactly what the design's "replaces the answer below" means.

### Two gates, encoded rather than implied

- **Display is not gated.** Every settled answer had a prompt, and showing it is always honest — tip or not, busy or not.
- **Rerun is gated exactly as Regenerate is** (not busy, settled, tip of the active path). Off the tip, a rerun would replace an answer that isn't the one on screen.

A turn with no preceding prompt renders **no card at all**, not an empty shell.

### The spec earned its keep before this shipped

I wired the new props into **only one of the two `TurnRow` call sites**. `tests/reader.spec.ts` caught it immediately as `.cave-reader-ask` never rendering.

That is the *same class of miss* that reached `main` twice earlier in this series (#4264, #4265) — both times because nothing in the suite rendered. This time it never left the branch.

### Coverage added

By rendering, not by source pins:
- the card shows the real prompt and sits **above** the answer (asserted by bounding box, not by DOM order)
- Edit swaps prose for the input without duplicating it
- an emptied prompt **disables** Rerun — there is nothing to send
- Cancel restores the prose form

**7/7 green, no flake.** Typecheck clean, eslint clean, drift ratchet unchanged.

### Note on the worktree

`pnpm beads:worktrees:create` refused — *"creating a worktree would exceed the 12-worktree warning budget"*. It suggests `apply`, but the patrol reported **0 cleanup-ready**, so `apply` would free nothing; the budget is occupied by other sessions' active worktrees, and I would not mass-retire their work. Used the documented `git worktree add` fallback, which means this one retires by hand via the archive-tag route.
