### PR TITLE
fix(ios): show a tool call's argument instead of a bare "{"

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
@@ -29,6 +29,10 @@ struct ActivityStep: Codable, Hashable, Identifiable {
     var status: Status = .running
     /// Wall-clock duration the server reported when the step settled.
     var durationMs: Int?
+    /// Why a failed step failed — the tail of the tool's output, kept only for
+    /// `.error` steps. A successful call's output belongs on the desktop; a
+    /// failure with no reason is the one case a chip has to carry itself.
+    var errorOutput: String?
 }
 
 /// Folds raw stream events into a message's activity list. Pure functions so
@@ -41,13 +45,19 @@ enum ActivityFold {
     static let maxSteps = 120
     /// Detail strings are one-line chips, never payloads.
     static let detailCap = 140
+    /// A failure reason gets a few wrapped lines — enough to read the error,
+    /// far short of the payload the desktop shows.
+    static let errorOutputCap = 300
+    static let errorOutputLines = 4
+    /// What `capLiveToolPayload` appends when it head-caps a live payload.
+    private static let liveTruncationMarker = "[tool payload truncated]"
 
     /// Fold one event into `steps`. Returns the updated list, or nil when the
     /// event doesn't change the activity (callers skip the mutation + notify).
     static func fold(_ steps: [ActivityStep], event: StreamEvent) -> [ActivityStep]? {
         switch event {
-        case .toolUse(let id, let name, let input, _, let status, let durationMs):
-            return foldTool(steps, id: id, name: name, input: input,
+        case .toolUse(let id, let name, let input, let output, let status, let durationMs):
+            return foldTool(steps, id: id, name: name, input: input, output: output,
                             status: status, durationMs: durationMs)
         case .progress(let id, let label, let detail, let status, let durationMs):
             return foldProgress(steps, id: id, label: label, detail: detail,
@@ -77,15 +87,23 @@ enum ActivityFold {
     /// updates its step in place. Events with no id can never be re-keyed,
     /// so they simply append.
     private static func foldTool(_ steps: [ActivityStep], id: String?, name: String,
-                                 input: String?, status: String?,
+                                 input: String?, output: String?, status: String?,
                                  durationMs: Int?) -> [ActivityStep]? {
         let parsedStatus = ActivityStep.Status(rawValue: status ?? "") ?? .running
+        // Only a failure earns its output a place in the trail. Intermediate
+        // `running` frames carry partial output too, which would churn the
+        // snapshot for a call that is about to succeed anyway.
+        let failure = parsedStatus == .error ? capErrorOutput(output) : nil
         if let id, let idx = steps.lastIndex(where: { $0.kind == .tool && $0.id == id }) {
             var step = steps[idx]
             var changed = false
             if step.status != parsedStatus { step.status = parsedStatus; changed = true }
             if step.detail == nil, let detail = argSummary(name: name, input: input) {
                 step.detail = detail
+                changed = true
+            }
+            if let failure, step.errorOutput != failure {
+                step.errorOutput = failure
                 changed = true
             }
             if let durationMs, step.durationMs != durationMs {
@@ -99,7 +117,8 @@ enum ActivityFold {
         }
         let step = ActivityStep(id: id ?? UUID().uuidString, kind: .tool, title: name,
                                 detail: argSummary(name: name, input: input),
-                                status: parsedStatus, durationMs: durationMs)
+                                status: parsedStatus, durationMs: durationMs,
+                                errorOutput: failure)
         return append(step, to: steps)
     }
 
@@ -154,6 +173,28 @@ enum ActivityFold {
         return String(firstLine.prefix(detailCap))
     }
 
+    /// Why a failed call failed, trimmed to fit under a step row.
+    ///
+    /// Keeps the **tail**: a failing build prints its error last, which is the
+    /// same reason the server tail-caps persisted output. Live output is capped
+    /// the other way — head-first, with a `[tool payload truncated]` marker
+    /// glued on the end — so drop that marker before taking the tail, or every
+    /// long failure would report the marker instead of the error.
+    private static func capErrorOutput(_ text: String?) -> String? {
+        guard var trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        if trimmed.hasSuffix(liveTruncationMarker) {
+            trimmed = String(trimmed.dropLast(liveTruncationMarker.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let lines = trimmed.split(separator: "\n", omittingEmptySubsequences: false)
+        let tail = lines.suffix(errorOutputLines).joined(separator: "\n")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !tail.isEmpty else { return nil }
+        guard tail.count > errorOutputCap else { return tail }
+        return "…" + String(tail.suffix(errorOutputCap - 1))
+    }
+
     /// Tool inputs are pretty-printed JSON, whose first line is a bare `{`.
     /// Summarise the payload down to its most identifying argument instead —
     /// the same one-liner the web chat shows beside a tool name.
@@ -167,10 +208,12 @@ enum ActivityFold {
     static func steps(fromTools tools: [ToolCall]?) -> [ActivityStep]? {
         guard let tools, !tools.isEmpty else { return nil }
         return tools.suffix(maxSteps).map { tool in
-            ActivityStep(id: tool.id, kind: .tool, title: tool.name,
-                         detail: argSummary(name: tool.name, input: tool.input),
-                         status: tool.status == "error" ? .error : .ok,
-                         durationMs: tool.durationMs)
+            let failed = tool.status == "error"
+            return ActivityStep(id: tool.id, kind: .tool, title: tool.name,
+                                detail: argSummary(name: tool.name, input: tool.input),
+                                status: failed ? .error : .ok,
+                                durationMs: tool.durationMs,
+                                errorOutput: failed ? capErrorOutput(tool.output) : nil)
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift
@@ -10,9 +10,13 @@ struct ActivityStep: Codable, Hashable, Identifiable {
     }
 
     /// `running` animates; terminal states render a settled glyph. Raw values
-    /// mirror the server's `tool_use` statuses (`progress` "done" maps to `ok`).
+    /// mirror the server's statuses: `tool_use` sends running/ok/error, and
+    /// `progress` sends running/done/notice/error ("done" maps to `ok`).
+    /// `notice` is an informational line the harness reports — a compatibility
+    /// warning, a rate-limit note — and is terminal on arrival, so it must not
+    /// decode as `running` or it spins for the rest of the turn.
     enum Status: String, Codable {
-        case running, ok, error
+        case running, ok, error, notice
     }
 
     var id: String
@@ -80,7 +84,10 @@ enum ActivityFold {
             var step = steps[idx]
             var changed = false
             if step.status != parsedStatus { step.status = parsedStatus; changed = true }
-            if step.detail == nil, let detail = cap(input) { step.detail = detail; changed = true }
+            if step.detail == nil, let detail = argSummary(name: name, input: input) {
+                step.detail = detail
+                changed = true
+            }
             if let durationMs, step.durationMs != durationMs {
                 step.durationMs = durationMs
                 changed = true
@@ -91,8 +98,8 @@ enum ActivityFold {
             return updated
         }
         let step = ActivityStep(id: id ?? UUID().uuidString, kind: .tool, title: name,
-                                detail: cap(input), status: parsedStatus,
-                                durationMs: durationMs)
+                                detail: argSummary(name: name, input: input),
+                                status: parsedStatus, durationMs: durationMs)
         return append(step, to: steps)
     }
 
@@ -137,13 +144,21 @@ enum ActivityFold {
         return updated
     }
 
+    /// Progress details are already prose — one line, capped.
     private static func cap(_ text: String?) -> String? {
         guard let trimmed = text?.trimmingCharacters(in: .whitespacesAndNewlines),
               !trimmed.isEmpty else { return nil }
-        // One line only — a multi-line tool input reads as noise in a chip.
+        // One line only — a multi-line detail reads as noise in a chip.
         let firstLine = trimmed.split(separator: "\n", maxSplits: 1,
                                       omittingEmptySubsequences: false)[0]
         return String(firstLine.prefix(detailCap))
+    }
+
+    /// Tool inputs are pretty-printed JSON, whose first line is a bare `{`.
+    /// Summarise the payload down to its most identifying argument instead —
+    /// the same one-liner the web chat shows beside a tool name.
+    private static func argSummary(name: String, input: String?) -> String? {
+        ToolArgSummary.summary(name: name, input: input, max: detailCap)
     }
 
     /// Map a persisted conversation turn's tool calls into activity steps so
@@ -153,8 +168,9 @@ enum ActivityFold {
         guard let tools, !tools.isEmpty else { return nil }
         return tools.suffix(maxSteps).map { tool in
             ActivityStep(id: tool.id, kind: .tool, title: tool.name,
-                         detail: cap(tool.input),
-                         status: tool.status == "error" ? .error : .ok)
+                         detail: argSummary(name: tool.name, input: tool.input),
+                         status: tool.status == "error" ? .error : .ok,
+                         durationMs: tool.durationMs)
         }
     }
 }

--- a/apps/ios/CovenCave/CovenCave/Models/Models.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/Models.swift
@@ -118,6 +118,9 @@ struct ToolCall: Identifiable, Codable, Hashable {
     var input: String?
     var output: String?
     var status: String?
+    /// Wall-clock the server recorded when the call settled. Persisted with the
+    /// turn, so a reloaded transcript keeps the timings a live turn showed.
+    var durationMs: Int?
 }
 
 struct TurnUsage: Codable, Hashable {

--- a/apps/ios/CovenCave/CovenCave/Models/ToolArgSummary.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/ToolArgSummary.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+/// One-line argument summaries for tool activity chips — `ls -la src`,
+/// `src/lib/foo.ts` — derived from a tool call's input payload.
+///
+/// Tool inputs reach the app as *pretty-printed* JSON: the server stringifies
+/// them with two-space indentation (`formatToolInputValue`, see
+/// `src/lib/chat-tool-events.ts`), so the first line of a real payload is a
+/// bare `{`. Reading the first line — what the activity fold used to do — put
+/// a literal "{" under every tool call in the app.
+///
+/// Mirrors `src/lib/tool-arg-summary.ts` so a call reads the same on iOS as it
+/// does in the web chat. Keep the two in step: the preferred-key list and the
+/// command-first rule are the shared contract.
+enum ToolArgSummary {
+    /// Chips are a single line — long enough to identify a call, short enough
+    /// not to crowd the tool name beside it.
+    static let maxChars = 140
+
+    /// Well-known argument keys, most identifying first.
+    private static let preferredKeys = [
+        "file_path", "path", "command", "pattern", "url",
+        "query", "prompt", "description", "skill", "notebook_path",
+    ]
+
+    /// Shell-ish tools whose `command` key is the headline argument.
+    private static func isCommandFirst(_ name: String) -> Bool {
+        let lowered = name.lowercased()
+        return ["bash", "shell", "terminal", "exec"].contains { lowered.hasPrefix($0) }
+    }
+
+    private static func keyOrder(for name: String) -> [String] {
+        guard isCommandFirst(name) else { return preferredKeys }
+        return ["command"] + preferredKeys.filter { $0 != "command" }
+    }
+
+    /// Summarise a tool's input payload into one short line, or nil when the
+    /// payload carries nothing worth showing.
+    static func summary(name: String, input: String?, max: Int = maxChars) -> String? {
+        let raw = input?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !raw.isEmpty else { return nil }
+
+        if let parsed = parseJSON(raw) {
+            if let record = parsed as? [String: Any] {
+                return summarize(name: name, record: record, max: max)
+            }
+            if let list = parsed as? [Any] {
+                return ellipsize(list.compactMap(scalarString).joined(separator: " "), max)
+            }
+            if let scalar = scalarString(parsed) {
+                return ellipsize(scalar, max)
+            }
+            // JSON `null` and anything else unrepresentable fall through to the
+            // raw text below, which is what the web summariser does too.
+        }
+
+        // A payload that looks like an object but did not parse — a truncated
+        // `{ "file_path": "src/foo…` blob. Pull the first identifying token.
+        if raw.hasPrefix("{"), let token = firstIdentifyingToken(in: raw) {
+            return ellipsize(token, max)
+        }
+
+        // Plain payload (a bare shell command line, a search string) — as-is.
+        return ellipsize(raw, max)
+    }
+
+    // MARK: - Records
+
+    private static func summarize(name: String, record: [String: Any], max: Int) -> String? {
+        for key in keyOrder(for: name) {
+            if let value = record[key], let scalar = scalarString(value) {
+                return ellipsize(scalar, max)
+            }
+        }
+        // No well-known key — fall back to the first scalar value. Swift
+        // dictionaries are unordered where JS objects keep insertion order, so
+        // sort for a stable answer rather than an arbitrary one.
+        for key in record.keys.sorted() {
+            if let value = record[key], let scalar = scalarString(value) {
+                return ellipsize(scalar, max)
+            }
+        }
+        // Nothing but containers (a `todos` array, a nested config). The web
+        // summariser falls back to the JSON itself here; on a chip that is the
+        // very brace-noise this type exists to remove, so say nothing and let
+        // the tool name stand alone.
+        return nil
+    }
+
+    // MARK: - Value helpers
+
+    /// A JSON scalar rendered for display, or nil for blanks, containers and
+    /// `null` — the values that would summarise to noise.
+    private static func scalarString(_ value: Any) -> String? {
+        if let text = value as? String {
+            return text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? nil : text
+        }
+        guard let number = value as? NSNumber else { return nil }
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return number.boolValue ? "true" : "false" }
+        return number.stringValue
+    }
+
+    private static func parseJSON(_ raw: String) -> Any? {
+        guard let data = raw.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+
+    /// A quoted token, or something that looks like a file path.
+    private static let quotedToken = try? NSRegularExpression(
+        pattern: "\"([^\"\\n]{2,})\"|'([^'\\n]{2,})'")
+    private static let pathToken = try? NSRegularExpression(
+        pattern: "(?:~|\\.{1,2})?/?[\\w.@-]+(?:/[\\w.@-]+)+")
+
+    /// Pull the leading path-looking or quoted token out of an unparseable
+    /// object-ish blob, preferring whichever appears first.
+    ///
+    /// Quoted tokens that a `:` follows are *keys*, and a key is the one thing
+    /// the reader can already infer from the tool name — skip them so a
+    /// truncated `{"file_path": "src/foo.ts…` summarises to the path rather
+    /// than to the word "file_path".
+    private static func firstIdentifyingToken(in raw: String) -> String? {
+        let text = raw as NSString
+        let range = NSRange(location: 0, length: text.length)
+
+        var quoted: (value: String, location: Int)?
+        for match in quotedToken?.matches(in: raw, range: range) ?? [] {
+            guard !isKeyToken(match, in: text) else { continue }
+            for group in 1...2 where match.range(at: group).location != NSNotFound {
+                quoted = (text.substring(with: match.range(at: group)), match.range.location)
+                break
+            }
+            if quoted != nil { break }
+        }
+
+        var path: (value: String, location: Int)?
+        if let match = pathToken?.firstMatch(in: raw, range: range) {
+            path = (text.substring(with: match.range), match.range.location)
+        }
+
+        guard let path else { return quoted?.value }
+        guard let quoted else { return path.value }
+        return path.location < quoted.location ? path.value : quoted.value
+    }
+
+    /// True when the next non-space character after a quoted token is a colon.
+    private static func isKeyToken(_ match: NSTextCheckingResult, in text: NSString) -> Bool {
+        var index = match.range.location + match.range.length
+        while index < text.length {
+            let character = text.character(at: index)
+            if character == 32 || character == 9 { index += 1; continue } // space, tab
+            return character == 58 // ':'
+        }
+        return false
+    }
+
+    /// Collapse to a single line and cap with an ellipsis. Nil when nothing
+    /// survives the flattening.
+    private static func ellipsize(_ value: String, _ max: Int) -> String? {
+        let flat = value
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !flat.isEmpty, max > 0 else { return nil }
+        guard flat.count > max else { return flat }
+        return String(flat.prefix(max - 1)) + "…"
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Models/ToolArgSummary.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/ToolArgSummary.swift
@@ -55,9 +55,11 @@ enum ToolArgSummary {
         }
 
         // A payload that looks like an object but did not parse — a truncated
-        // `{ "file_path": "src/foo…` blob. Pull the first identifying token.
-        if raw.hasPrefix("{"), let token = firstIdentifyingToken(in: raw) {
-            return ellipsize(token, max)
+        // `{ "file_path": "src/foo…` blob. Pull the first identifying token,
+        // and stop there: with no token to find, falling through to the raw
+        // text would put the braces straight back on the chip.
+        if raw.hasPrefix("{") {
+            return firstIdentifyingToken(in: raw).flatMap { ellipsize($0, max) }
         }
 
         // Plain payload (a bare shell command line, a search string) — as-is.

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -370,6 +370,16 @@ final class AppModel {
             ChatTurnNotifier.shared.app = self
             return
         }
+
+        // Sibling fixture for the agent-activity trail — a settled turn whose
+        // steps cover every status a tool row can carry. Launch with
+        // `--ui-preview-tool-activity` and
+        // `CAVE_OPEN_THREAD=ui-preview-tool-activity`.
+        if ProcessInfo.processInfo.arguments.contains("--ui-preview-tool-activity") {
+            configureToolActivityPreview()
+            ChatTurnNotifier.shared.app = self
+            return
+        }
         #endif
         // Threads hydrate off-main via the store — no file I/O in init.
         Task { await self.hydrateThreads() }
@@ -468,6 +478,65 @@ final class AppModel {
                 id: "ui-preview-empty-chat",
                 title: "Chat with Nyx on Jul 26",
                 familiarIds: ["nyx"]
+            ),
+        ]
+        connectionState = .connected
+    }
+
+    /// Deterministic native screenshot fixture for the agent-activity trail.
+    /// One settled assistant turn whose steps cover every status a tool row can
+    /// carry: a succeeded call, a failed one with its reason, and an
+    /// informational notice. Release builds never carry fixture state.
+    private func configureToolActivityPreview() {
+        connection = nil
+        familiars = [
+            Familiar(
+                id: "nyx",
+                displayName: "Nyx",
+                role: "Code familiar",
+                description: "Keeps implementation work moving.",
+                pronouns: nil,
+                color: nil,
+                status: "active",
+                harness: "codex",
+                model: "gpt-5.6",
+                icon: "moon.stars.fill",
+                avatarUrl: nil,
+                activeSessions: 1,
+                memoryFreshness: "Fresh"
+            ),
+        ]
+        tasksLoaded = true
+        sessionsLoaded = true
+
+        var reply = DisplayMessage(
+            role: .assistant,
+            familiarId: "nyx",
+            text: "Fixed — the summary was reading the first line of a pretty-printed payload."
+        )
+        reply.activity = [
+            ActivityStep(id: "a", kind: .tool, title: "Read",
+                         detail: "src/lib/tool-arg-summary.ts", status: .ok, durationMs: 42),
+            ActivityStep(id: "b", kind: .tool, title: "Bash",
+                         detail: "pnpm test --filter tool-arg", status: .error,
+                         durationMs: 8_400,
+                         errorOutput: "error: cannot find module 'foo'\n  at Object.<anonymous> (tool-arg.test.ts:12:9)"),
+            ActivityStep(id: "c", kind: .progress, title: "Rate limited — retrying in 30s",
+                         status: .notice),
+            ActivityStep(id: "d", kind: .tool, title: "Edit",
+                         detail: "apps/ios/CovenCave/CovenCave/Models/AgentActivity.swift",
+                         status: .ok, durationMs: 1_200),
+        ]
+
+        threads = [
+            ChatThread(
+                id: "ui-preview-tool-activity",
+                title: "Chat with Nyx on Aug 3",
+                familiarIds: ["nyx"],
+                messages: [
+                    DisplayMessage(role: .user, text: "fix the ios tool calls"),
+                    reply,
+                ]
             ),
         ]
         connectionState = .connected

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -107,6 +107,15 @@ final class AppModel {
     /// matching hydrated thread can be opened, then is consumed exactly once.
     var launchThreadId: String?
 
+    /// Messages whose agent-activity trail the reader has opened.
+    ///
+    /// Deliberately not view-local `@State`: a transcript rebuild re-creates
+    /// the row, and state that lives on the row goes with it — silently
+    /// collapsing a trail the reader had just opened (cave-m5tao). Holding the
+    /// choice here means a re-created row re-reads it and stays open. In-memory
+    /// only; expansion is a reading position, not something to persist.
+    var expandedActivityMessages: Set<String> = []
+
     #if DEBUG
     /// Process-lifetime marker for the deterministic cold-connection preview.
     /// The app lifecycle uses it to skip only live connection work.

--- a/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
@@ -11,10 +11,17 @@ struct AgentActivityView: View {
     /// Whether the owning bubble is still streaming — the only state that may
     /// animate a spinner, so a persisted step can never spin after reload.
     let streaming: Bool
+    /// Identifies the owning message. The expanded/collapsed choice is keyed by
+    /// it in `AppModel` rather than held here, because a transcript rebuild
+    /// re-creates this view and view-local `@State` would go with it — the
+    /// trail collapsing itself moments after the reader opened it (cave-m5tao).
+    let messageId: String
 
-    @State private var expanded = false
+    @Environment(AppModel.self) private var app
     @Environment(\.chrome) private var chrome
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var expanded: Bool { app.expandedActivityMessages.contains(messageId) }
 
     /// Expanded list cap — the tail is where the action is, and a bubble
     /// shouldn't scroll for pages of settled steps.
@@ -35,7 +42,11 @@ struct AgentActivityView: View {
     private var chipButton: some View {
         Button {
             withAnimation(reduceMotion ? nil : .snappy(duration: 0.22)) {
-                expanded.toggle()
+                if expanded {
+                    app.expandedActivityMessages.remove(messageId)
+                } else {
+                    app.expandedActivityMessages.insert(messageId)
+                }
             }
             Haptics.tap()
         } label: {

--- a/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
@@ -118,6 +118,17 @@ struct AgentActivityView: View {
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
                 }
+                if let failure = step.errorOutput, !failure.isEmpty {
+                    // Why it failed. Wraps rather than truncating to one line —
+                    // a reason clipped mid-sentence is no reason at all.
+                    Text(failure)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(Color.red.opacity(0.85))
+                        .lineLimit(ActivityFold.errorOutputLines)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+                        .padding(.top, 2)
+                }
             }
             Spacer(minLength: 8)
             if let duration = Self.durationLabel(step.durationMs) {

--- a/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
@@ -142,6 +142,12 @@ struct AgentActivityView: View {
             Image(systemName: "checkmark.circle.fill")
                 .font(.caption2)
                 .foregroundStyle(.secondary)
+        case .notice:
+            // Informational, not an outcome — a harness note the run carried on
+            // past. Settled on arrival, so it never spins.
+            Image(systemName: "info.circle")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
         case .error:
             Image(systemName: "xmark.circle.fill")
                 .font(.caption2)

--- a/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/AgentActivityView.swift
@@ -54,6 +54,10 @@ struct AgentActivityView: View {
                     .font(.caption.weight(.medium))
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
+                    // "Bash — <argument>": keep the tool name and the end of
+                    // the argument, drop the middle. Same reasoning as the
+                    // detail line in an expanded row.
+                    .truncationMode(.middle)
                     // A ticking label shouldn't pop — crossfade between steps.
                     .contentTransition(reduceMotion ? .identity : .opacity)
                 Image(systemName: "chevron.down")
@@ -117,6 +121,11 @@ struct AgentActivityView: View {
                         .font(.caption2.monospaced())
                         .foregroundStyle(.tertiary)
                         .lineLimit(1)
+                        // Both ends identify the argument; the middle rarely
+                        // does. Clipping the tail cost a path its filename —
+                        // "apps/ios/CovenCave/CovenCave/Mod…" — and would cost
+                        // a long command its arguments.
+                        .truncationMode(.middle)
                 }
                 if let failure = step.errorOutput, !failure.isEmpty {
                     // Why it failed. Wraps rather than truncating to one line —

--- a/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/MessageBubble.swift
@@ -228,7 +228,8 @@ struct MessageBubble: View {
                 // while streaming, a collapsed summary once finished.
                 if !isUser, !message.activitySteps.isEmpty {
                     AgentActivityView(steps: message.activitySteps,
-                                      streaming: message.streaming)
+                                      streaming: message.streaming,
+                                      messageId: message.id)
                         .padding(.leading, 2)
                 }
                 // Hide the (empty) text bubble for image-only messages.

--- a/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
@@ -35,6 +35,14 @@ final class AgentActivityTests: XCTestCase {
         XCTAssertEqual(steps?[0].status, .running)
     }
 
+    func testToolDetailSummarisesThePrettyPrintedJsonTheServerSends() {
+        // The wire payload is JSON.stringify(input, null, 2) — reading its
+        // first line labelled every tool call in the app "{".
+        let input = "{\n  \"command\": \"pnpm test\",\n  \"description\": \"Run tests\"\n}"
+        let steps = ActivityFold.fold([], event: toolEvent(input: input))
+        XCTAssertEqual(steps?[0].detail, "pnpm test")
+    }
+
     func testToolSettleUpdatesItsStepInPlace() {
         let started = ActivityFold.fold([], event: toolEvent(input: "ls"))!
         let settled = ActivityFold.fold(started, event: toolEvent(status: "ok", durationMs: 420))
@@ -93,6 +101,25 @@ final class AgentActivityTests: XCTestCase {
         let first = ActivityFold.fold([], event: progressEvent(label: "Thinking"))!
         let second = ActivityFold.fold(first, event: progressEvent(label: "Writing"))!
         XCTAssertEqual(second.map(\.title), ["Thinking", "Writing"])
+    }
+
+    func testProgressNoticeIsTerminalNotRunning() {
+        // /api/chat/send emits "notice" for harness diagnostics (runtime
+        // compatibility, rate-limit warnings). Decoding those as .running left
+        // an informational line spinning for the rest of the turn.
+        let steps = ActivityFold.fold([], event: progressEvent(label: "Runtime mismatch",
+                                                               status: "notice"))
+        XCTAssertEqual(steps?[0].status, .notice)
+        XCTAssertNil(ActivityFold.settle(steps!, success: true),
+                     "a notice is already settled — nothing left to coerce")
+    }
+
+    func testANoticeDoesNotHijackTheRunningStep() {
+        var steps = ActivityFold.fold([], event: toolEvent(id: "t1", name: "Bash"))!
+        steps = ActivityFold.fold(steps, event: progressEvent(label: "Rate limited",
+                                                              status: "notice"))!
+        XCTAssertEqual(steps.currentStep?.title, "Bash",
+                       "the chip narrates the running tool, not the notice beside it")
     }
 
     func testProgressDoneStatusMapsToOk() {
@@ -189,6 +216,27 @@ final class AgentActivityTests: XCTestCase {
         XCTAssertEqual(steps?[0].detail, "pwd")
     }
 
+    func testPersistedToolsKeepTheirSummaryAndDuration() {
+        // History replays the same payload shape the stream sent, so a reloaded
+        // transcript must read identically to the live turn — argument summary
+        // included, and the duration the server recorded alongside it.
+        let tools = [ToolCall(id: "1", name: "Read",
+                              input: "{\n  \"file_path\": \"src/lib/foo.ts\"\n}",
+                              output: nil, status: "ok", durationMs: 42)]
+        let steps = ActivityFold.steps(fromTools: tools)
+        XCTAssertEqual(steps?[0].detail, "src/lib/foo.ts")
+        XCTAssertEqual(steps?[0].durationMs, 42)
+    }
+
+    func testPersistedToolsDecodeDurationFromTheServerPayload() throws {
+        let json = #"{"id":"t1","name":"Bash","input":"pwd","status":"ok","durationMs":900}"#
+        let tool = try JSONDecoder().decode(ToolCall.self, from: Data(json.utf8))
+        XCTAssertEqual(tool.durationMs, 900)
+        // Turns persisted before the field still decode.
+        let legacy = #"{"id":"t2","name":"Bash","status":"ok"}"#
+        XCTAssertNil(try JSONDecoder().decode(ToolCall.self, from: Data(legacy.utf8)).durationMs)
+    }
+
     func testStepsFromNilOrEmptyToolsIsNil() {
         XCTAssertNil(ActivityFold.steps(fromTools: nil))
         XCTAssertNil(ActivityFold.steps(fromTools: []))
@@ -231,6 +279,19 @@ final class AgentActivityTests: XCTestCase {
         XCTAssertEqual(input, "ls")
         XCTAssertEqual(status, "ok")
         XCTAssertEqual(durationMs, 123)
+    }
+
+    func testAToolFrameOffTheWireReadsAsItsArgument() throws {
+        // End to end over the real frame shape: the server JSON-encodes an
+        // already-pretty-printed input, so the escaped newlines survive decode
+        // and land in the fold. This is the label the chip shows.
+        let frame = #"{"kind":"tool_use","id":"t1","name":"Read","input":"{\n  \"file_path\": \"src/lib/foo.ts\"\n}","status":"running"}"#
+        guard let event = StreamEvent.decode(frame) else {
+            return XCTFail("expected a toolUse event")
+        }
+        let steps = ActivityFold.fold([], event: event)
+        XCTAssertEqual(steps?.currentStep?.title, "Read")
+        XCTAssertEqual(steps?.currentStep?.detail, "src/lib/foo.ts")
     }
 
     func testDecodeProgressCarriesIdAndStatus() throws {

--- a/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/AgentActivityTests.swift
@@ -58,6 +58,69 @@ final class AgentActivityTests: XCTestCase {
         XCTAssertEqual(settled?[0].status, .error)
     }
 
+    // MARK: - Failure reasons
+
+    func testAFailedToolCarriesItsReason() {
+        let started = ActivityFold.fold([], event: toolEvent(input: "cat missing.txt"))!
+        let failed = ActivityFold.fold(started, event: toolEvent(
+            output: "cat: missing.txt: No such file or directory", status: "error"))
+        XCTAssertEqual(failed?[0].errorOutput, "cat: missing.txt: No such file or directory")
+    }
+
+    func testASuccessfulToolDoesNotStoreItsOutput() {
+        // Only a failure has to explain itself; a successful call's payload
+        // belongs on the desktop, not in every persisted snapshot.
+        let steps = ActivityFold.fold([], event: toolEvent(output: "a\nb\nc", status: "ok"))
+        XCTAssertNil(steps?[0].errorOutput)
+    }
+
+    func testAnIntermediateRunningFrameDoesNotStoreOutput() {
+        let steps = ActivityFold.fold([], event: toolEvent(output: "partial…", status: "running"))
+        XCTAssertNil(steps?[0].errorOutput)
+    }
+
+    func testTheReasonKeepsTheTailWhereTheErrorIs() throws {
+        let log = (1...40).map { "build step \($0)" }.joined(separator: "\n")
+            + "\nerror: cannot find module 'foo'"
+        let steps = ActivityFold.fold([], event: toolEvent(output: log, status: "error"))!
+        let reason = try XCTUnwrap(steps[0].errorOutput)
+        XCTAssertTrue(reason.hasSuffix("error: cannot find module 'foo'"))
+        XCTAssertFalse(reason.contains("build step 1\n"), "the head of the log is not the reason")
+        XCTAssertLessThanOrEqual(reason.split(separator: "\n").count, ActivityFold.errorOutputLines)
+    }
+
+    func testTheLiveTruncationMarkerIsNotReportedAsTheReason() {
+        // capLiveToolPayload head-caps and glues a marker on the end, so the
+        // literal tail of a long live payload is the marker, not the failure.
+        let output = "error: the build failed\n[tool payload truncated]"
+        let steps = ActivityFold.fold([], event: toolEvent(output: output, status: "error"))!
+        XCTAssertEqual(steps[0].errorOutput, "error: the build failed")
+    }
+
+    func testALongReasonIsCappedFromTheEnd() throws {
+        let steps = ActivityFold.fold([], event: toolEvent(
+            output: String(repeating: "x", count: 900), status: "error"))!
+        let reason = try XCTUnwrap(steps[0].errorOutput)
+        XCTAssertEqual(reason.count, ActivityFold.errorOutputCap)
+        XCTAssertTrue(reason.hasPrefix("…"), "the cut end is marked")
+    }
+
+    func testPersistedFailuresKeepTheirReason() {
+        let tools = [
+            ToolCall(id: "1", name: "Bash", input: "pwd", output: "boom", status: "error"),
+            ToolCall(id: "2", name: "Read", input: nil, output: "file contents", status: "ok"),
+        ]
+        let steps = ActivityFold.steps(fromTools: tools)
+        XCTAssertEqual(steps?[0].errorOutput, "boom")
+        XCTAssertNil(steps?[1].errorOutput, "a successful call keeps its output off the trail")
+    }
+
+    func testStepsPersistedBeforeErrorOutputStillDecode() throws {
+        let legacy = #"{"id":"s1","kind":"tool","title":"Bash","status":"error"}"#
+        let step = try JSONDecoder().decode(ActivityStep.self, from: Data(legacy.utf8))
+        XCTAssertNil(step.errorOutput)
+    }
+
     func testReplayingAnAlreadyAppliedSettleIsANoOp() {
         // Mid-turn resume replays frames past the cursor — re-applying an
         // identical settle must report "no change" so the UI isn't re-notified.

--- a/apps/ios/CovenCave/CovenCaveTests/ToolArgSummaryTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ToolArgSummaryTests.swift
@@ -87,6 +87,13 @@ final class ToolArgSummaryTests: XCTestCase {
                        "the value, not the key — \"file_path\" tells the reader nothing")
     }
 
+    func testAnObjectBlobWithNoIdentifyingTokenSaysNothing() {
+        // Truncated past every quoted value, there is no argument left to show
+        // — and returning the raw text would put the brace straight back.
+        XCTAssertNil(ToolArgSummary.summary(name: "Edit", input: "{"))
+        XCTAssertNil(ToolArgSummary.summary(name: "Edit", input: "{\n  \"old_st"))
+    }
+
     func testArrayPayloadJoinsItsEntries() {
         XCTAssertEqual(ToolArgSummary.summary(name: "Glob", input: "[\"src\", \"docs\"]"),
                        "src docs")

--- a/apps/ios/CovenCave/CovenCaveTests/ToolArgSummaryTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ToolArgSummaryTests.swift
@@ -1,0 +1,108 @@
+import XCTest
+@testable import CovenCave
+
+/// ToolArgSummary turns a tool call's input payload into the one-line argument
+/// shown beside the tool name. The payloads here are the real wire shapes: the
+/// server pretty-prints tool inputs as JSON (`formatToolInputValue` in
+/// src/lib/chat-tool-events.ts), which is exactly the case the old first-line
+/// reader got wrong — every call summarised to a bare "{".
+final class ToolArgSummaryTests: XCTestCase {
+
+    /// The shape the server actually sends: `JSON.stringify(input, null, 2)`.
+    private func wire(_ object: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: object,
+                                               options: [.prettyPrinted, .sortedKeys])
+        return String(data: data, encoding: .utf8)!
+    }
+
+    // MARK: - The regression
+
+    func testPrettyPrintedJsonNeverSummarisesToABrace() {
+        let input = wire(["command": "ls -la src", "description": "List sources"])
+        XCTAssertTrue(input.hasPrefix("{\n"), "precondition: the wire payload is multi-line JSON")
+        let summary = ToolArgSummary.summary(name: "Bash", input: input)
+        XCTAssertEqual(summary, "ls -la src")
+        XCTAssertNotEqual(summary, "{")
+    }
+
+    func testShellToolsLeadWithTheirCommand() {
+        // `description` sorts ahead of `command` in the payload; the shell rule
+        // must still pick the command.
+        let input = wire(["description": "Run the tests", "command": "pnpm test"])
+        XCTAssertEqual(ToolArgSummary.summary(name: "Bash", input: input), "pnpm test")
+    }
+
+    func testFileToolsLeadWithTheirPath() {
+        let input = wire(["file_path": "src/lib/foo.ts", "limit": 100])
+        XCTAssertEqual(ToolArgSummary.summary(name: "Read", input: input), "src/lib/foo.ts")
+    }
+
+    func testNonShellToolDoesNotHoistCommand() {
+        // Only shell-ish tools promote `command`; for others the preferred-key
+        // order (path before command) decides.
+        let input = wire(["command": "ignored", "path": "docs/readme.md"])
+        XCTAssertEqual(ToolArgSummary.summary(name: "Write", input: input), "docs/readme.md")
+    }
+
+    // MARK: - Payload variants
+
+    func testUnknownKeysFallBackToTheFirstValue() {
+        let input = wire(["alpha": "first", "beta": "second"])
+        XCTAssertEqual(ToolArgSummary.summary(name: "Custom", input: input), "first",
+                       "keys sort for a stable answer — Swift dictionaries are unordered")
+    }
+
+    func testNumericAndBooleanValuesRenderWithoutJsonNoise() {
+        XCTAssertEqual(ToolArgSummary.summary(name: "Sleep", input: wire(["duration": 5])), "5")
+        XCTAssertEqual(ToolArgSummary.summary(name: "Toggle", input: wire(["enabled": true])),
+                       "true", "a JSON bool must not read as NSNumber's \"1\"")
+    }
+
+    func testPayloadsWithNothingToSaySayNothing() {
+        // Rather than falling back to the JSON itself: a chip full of braces is
+        // the thing this type exists to remove, so the tool name stands alone.
+        XCTAssertNil(ToolArgSummary.summary(name: "TodoWrite", input: "{}"))
+        XCTAssertNil(ToolArgSummary.summary(name: "TodoWrite",
+                                            input: wire(["todos": [["id": 1]]])),
+                     "a container-only payload has no one-line argument")
+    }
+
+    func testBarePayloadPassesThrough() {
+        // Not every runtime sends JSON — a raw command line stays as it is.
+        XCTAssertEqual(ToolArgSummary.summary(name: "Bash", input: "ls -la"), "ls -la")
+        XCTAssertNil(ToolArgSummary.summary(name: "Bash", input: "   "))
+        XCTAssertNil(ToolArgSummary.summary(name: "Bash", input: nil))
+    }
+
+    func testJsonStringPayloadUnwraps() {
+        XCTAssertEqual(ToolArgSummary.summary(name: "Bash", input: "\"pwd\""), "pwd")
+    }
+
+    func testTruncatedObjectYieldsItsFirstIdentifyingToken() {
+        // A payload capped mid-flight (LIVE_TOOL_INPUT_CAP) no longer parses;
+        // pull the path out rather than showing the broken blob.
+        let truncated = "{\n  \"file_path\": \"src/components/chat-view.tsx\",\n  \"old_str"
+        XCTAssertEqual(ToolArgSummary.summary(name: "Edit", input: truncated),
+                       "src/components/chat-view.tsx",
+                       "the value, not the key — \"file_path\" tells the reader nothing")
+    }
+
+    func testArrayPayloadJoinsItsEntries() {
+        XCTAssertEqual(ToolArgSummary.summary(name: "Glob", input: "[\"src\", \"docs\"]"),
+                       "src docs")
+    }
+
+    // MARK: - Shape
+
+    func testSummaryIsAlwaysOneLineAndCapped() {
+        let sprawling = wire(["prompt": "line one\nline two\n" + String(repeating: "x", count: 400)])
+        let summary = ToolArgSummary.summary(name: "Agent", input: sprawling, max: 40)
+        XCTAssertEqual(summary?.count, 40)
+        XCTAssertFalse(summary?.contains("\n") ?? true)
+        XCTAssertTrue(summary?.hasSuffix("…") ?? false, "truncation is visible")
+    }
+
+    func testShortSummaryIsNotPadded() {
+        XCTAssertEqual(ToolArgSummary.summary(name: "Bash", input: wire(["command": "pwd"])), "pwd")
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveUITests/AgentActivityUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/AgentActivityUITests.swift
@@ -29,17 +29,15 @@ final class AgentActivityUITests: XCTestCase {
         // one of these rows read "{".
         let firstArgument = app.staticTexts["src/lib/tool-arg-summary.ts"]
         chip.tap()
-
-        // Expansion is view-local `@State`, so a transcript rebuild arriving
-        // just after the tap re-creates the view and collapses the trail again
-        // — observed once in three runs, with the chevron back to its closed
-        // position. Re-open rather than fail the run on it; the underlying
-        // state-reset is tracked separately.
-        if !firstArgument.waitForExistence(timeout: 5) {
-            chip.tap()
-        }
         XCTAssertTrue(firstArgument.waitForExistence(timeout: 5),
                       "a tool row shows its argument, not a brace")
+
+        // One tap, and it stays open. The expansion used to be view-local
+        // @State, so a transcript rebuild landing just after the tap re-created
+        // the row and collapsed the trail under the reader (cave-m5tao).
+        Thread.sleep(forTimeInterval: 2)
+        XCTAssertTrue(firstArgument.exists,
+                      "the trail stays open — a re-created row re-reads the choice")
         XCTAssertTrue(app.staticTexts["pnpm test --filter tool-arg"].exists,
                       "a shell row leads with its command")
 

--- a/apps/ios/CovenCave/CovenCaveUITests/AgentActivityUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/AgentActivityUITests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// Drives the agent-activity trail on the `--ui-preview-tool-activity` fixture.
+///
+/// The fold rules are covered by unit tests; what only a running app can show
+/// is that the expanded rows actually render what the fold produced — the
+/// argument summary, and the reason under a failed call. Also writes the
+/// expanded state out as a PNG so the surface can be eyeballed.
+final class AgentActivityUITests: XCTestCase {
+
+    @MainActor
+    func testExpandedTrailShowsArgumentsAndTheFailureReason() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-tool-activity"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-tool-activity"
+        app.launch()
+
+        XCTAssertTrue(app.navigationBars["Chat with Nyx on Aug 3"].waitForExistence(timeout: 15),
+                      "the fixture thread opens on launch")
+
+        let chip = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Agent activity")
+        ).firstMatch
+        XCTAssertTrue(chip.waitForExistence(timeout: 10), "the settled turn carries an activity chip")
+        XCTAssertTrue(chip.label.contains("Ran 3 tools"), "chip summarises the turn: \(chip.label)")
+        XCTAssertTrue(chip.label.contains("1 failed"), "chip reports the failure: \(chip.label)")
+
+        // The argument summary — the whole point of the fix. Before it, every
+        // one of these rows read "{".
+        let firstArgument = app.staticTexts["src/lib/tool-arg-summary.ts"]
+        chip.tap()
+
+        // Expansion is view-local `@State`, so a transcript rebuild arriving
+        // just after the tap re-creates the view and collapses the trail again
+        // — observed once in three runs, with the chevron back to its closed
+        // position. Re-open rather than fail the run on it; the underlying
+        // state-reset is tracked separately.
+        if !firstArgument.waitForExistence(timeout: 5) {
+            chip.tap()
+        }
+        XCTAssertTrue(firstArgument.waitForExistence(timeout: 5),
+                      "a tool row shows its argument, not a brace")
+        XCTAssertTrue(app.staticTexts["pnpm test --filter tool-arg"].exists,
+                      "a shell row leads with its command")
+
+        // The reason under the failed call.
+        let reason = app.staticTexts.containing(
+            NSPredicate(format: "label CONTAINS %@", "cannot find module")
+        ).firstMatch
+        XCTAssertTrue(reason.waitForExistence(timeout: 5), "a failed row explains itself")
+
+        try attachScreenshot(named: "tool-rows-expanded")
+    }
+
+    /// Saves a full-screen PNG next to the test run and attaches it, so the
+    /// surface can be reviewed without re-running Xcode.
+    private func attachScreenshot(named name: String) throws {
+        let shot = XCUIScreen.main.screenshot()
+        let attachment = XCTAttachment(screenshot: shot)
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        let url = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("\(name).png")
+        try shot.pngRepresentation.write(to: url)
+        print("SCREENSHOT_PATH \(url.path)")
+    }
+}


### PR DESCRIPTION
Every tool call in the iOS chat rendered its detail as a single `{`.

## The bug

The chat stream sends `tool_use.input` as **pretty-printed** JSON — `formatToolInputValue` (`src/lib/chat-tool-events.ts`) stringifies with two-space indentation — so the first line of every real payload is an opening brace:

```
{
  "command": "ls -la src",
  "description": "List sources"
}
```

`ActivityFold.cap()` took exactly that first line, for live stream events and for tools replayed out of history alike. So the chip read `Bash — {`, and every row in the expanded step list read `{`.

Nothing caught it because the existing tests all passed bare strings (`"ls"`, `"pwd"`) — a shape the server never sends.

## The fix

Port the web chat's `toolArgSummary` (`src/lib/tool-arg-summary.ts`) to Swift and summarise the payload down to its most identifying argument, so the two surfaces read the same:

| payload | before | after |
| --- | --- | --- |
| `{"command": "pnpm test", …}` | `Bash — {` | `Bash — pnpm test` |
| `{"file_path": "src/lib/foo.ts"}` | `Read — {` | `Read — src/lib/foo.ts` |

Two deliberate divergences from the web version, both to keep braces off a one-line chip:

- a payload with nothing but containers (a `todos` array, a nested config) summarises to **nothing** rather than to its JSON, so the tool name stands alone;
- a truncated blob yields the quoted **value** rather than the key that precedes it — `"file_path"` tells the reader nothing the tool name didn't.

## Two smaller contract gaps in the same trail

- **`progress` status `notice` had no iOS case.** The harness emits it throughout `/api/chat/send` for compatibility diagnostics and rate-limit warnings. It decoded to `.running`, so an informational line spun until the turn ended — and took the chip's "currently running" slot away from the tool that actually was. It is terminal on arrival, and now renders as such.
- **`ToolCall` dropped `durationMs`.** The server persists it; iOS did not decode it, so a reloaded transcript silently lost the timings a live turn had shown.

## Verification

346 `CovenCaveTests` pass on an iPhone 16 Pro simulator (Swift is not built by CI, so this ran locally):

```
xcodebuild test -project CovenCave.xcodeproj -scheme CovenCave \
  -destination 'platform=iOS Simulator,name=iPhone 16 Pro' -only-testing:CovenCaveTests
** TEST SUCCEEDED **
```

New coverage: `ToolArgSummaryTests` (14 cases over the real wire shapes), plus fold-level regressions for the pretty-printed input, the `notice` status, the persisted duration, and one end-to-end case decoding an actual SSE frame.

The four `scripts/ios-*.test.mjs` source-text tests that read `Models.swift` also pass.

Closes cave-37ygo
