### PR TITLE
docs(design): ledger every Claude Design frame, and build the worktree source card

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,14 @@ binding contract for tokens, density, elevation, motion, voice, and interface
 copy — read it before editing any surface, and walk its §9 shipping checklist
 before opening a UI PR. The live token reference renders at `/aesthetic`.
 
+Implementing a **Claude Design handoff**? Read
+[`docs/design-handoff/IMPLEMENTATION-STATUS.md`](docs/design-handoff/IMPLEMENTATION-STATUS.md)
+first — it maps every frame to what landed it, lists what is still outstanding,
+and carries the import recipe. Its two load-bearing warnings: the zips in
+`~/Downloads` are stale snapshots that miss live frames entirely, and the
+prototype palette *is* our token set (`#9386d0` is `--accent-presence`), so a
+handoff never needs a hand-copied hex.
+
 Where the truth lives:
 
 - `src/styles/globals/foundations.css` — the annotated token contract

--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -63,6 +63,7 @@ tests), so when a project gains or loses a frame, update this table by hand.
 | `Project Folder Modal.dc.html` | folder picker | `08becc377a` (`cave-tv71`) |
 | `Queue.dc.html` / `Tasks.dc.html` | Queue + Tasks toolbars | `52d043cd1c` (#3746), `8c4c7cfde9` (#3748) |
 | Settings `About` / `Familiars` / `Profile` / `Phone` | settings control sheets | `3e1c5125f2`, `24b702fc8a`, `4c168973c7`, `196b222f4d` |
+| `SourceCard.dc.html` | `src/components/ui/citation.tsx` — both variants (web card carries its marker; worktree card shows path, line range and a numbered peek) | `cave-mdu1n` |
 | `Coven Cave App.dc.html` (iOS) | `apps/ios/CovenCave` | `157dee8d5d` (#3736), `d4f619b6c8` (`cave-4bsu`), `01a3d91bc8` (`cave-32fp`) — gated by `scripts/ios-claude-design-fidelity.test.mjs` |
 
 ## Outstanding
@@ -86,7 +87,6 @@ surface it describes.
 | `Activity Details Panel.dc.html` | 67 | feedback-request-for-improvement (zip only) | No `activity-detail` surface anywhere under `src/components`. Tracked by `cave-5u8l4`. |
 | `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
 | `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | In no exported zip. Tracked by `cave-c7zgz`. |
-| `SourceCard.dc.html` | 6 | (Started) Minimalist reader interface update | Two variants: **web** (og:image, domain, claim count) and **repo** (path + line badge, code peek, "Open in Code"). `src/components/ui/citation.tsx` implements one generic card and neither variant. Tracked by `cave-mdu1n`. |
 
 ### Not deliverables
 

--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -1,0 +1,125 @@
+# Claude Design — implementation ledger
+
+Every surface in this app that came from a [Claude Design](https://claude.ai/design)
+handoff, what landed it, and what is still outstanding.
+
+**Why this file exists.** Answering "which design frames have we built?" used to
+mean re-deriving the answer from `git log` and a folder of downloaded zips —
+which is both slow and wrong, for two reasons found on 2026-08-03 (`cave-pqi7n`):
+
+1. **The zips in `~/Downloads` are stale snapshots.** The live projects hold
+   frames that appear in **no** exported zip — `Writer Workspace.dc.html`,
+   `AnswerFlow.dc.html`, `Memories - Rethought.dc.html`, and the 514 KB
+   `Thread Signals.dc.html`. An audit driven off the download folder
+   under-reports the corpus.
+2. **52 zips are ~17 projects.** Five separate `chat-page-*` zips carry the same
+   five frames. Counting files overstates the work by roughly 3×.
+
+So the source of truth is the **live project list** (via the `claude_design`
+MCP: `list_projects`, then `list_files` per project), reconciled against `main`.
+
+Regenerate the live side with:
+
+```bash
+# in a Claude Code session with the claude-design MCP connected (/design-login)
+#   mcp__claude-design__list_projects
+#   mcp__claude-design__list_files  { project_id, depth: 1 }   # per project
+```
+
+`design-handoff-ledger.test.ts` keeps the **repo** side honest: every source
+path cited below must exist. It cannot check the live side (no network in
+tests), so when a project gains or loses a frame, update this table by hand.
+
+---
+
+## Landed
+
+| Frame | Surface | Landed by |
+|---|---|---|
+| `Familiar Analytics.dc.html` | `src/components/familiar-analytics-content.tsx` | `7316804273` (#4277) — dock + stage workbench |
+| `Chat.dc.html` (session, list) | chat session chrome | `59527634e7` (#3983) |
+| `Chat.dc.html` 2a (spine, minimap) | thread instruments | `6cc5fcb913` (#4046) |
+| `Chat.dc.html` 2b (bands) | new-session launcher | `3e5b9c450d` (`cave-iwopz`) |
+| `Reader.dc.html` frame 3a | chat Expand reader | `ecd8c52f6a` (#4255) |
+| `Canvas.dc.html` | Canvas page | `d6b14b3e53` (#3988) |
+| `Projects.dc.html` | Project access page | `3ffeea6be6` (#3994) |
+| `Familiar.dc.html` | Familiar tab + `SurfaceRail` | `fe70ac2846` (#3593) |
+| `Group.dc.html` | Covens surface | `ec00d524d4` (#3594) |
+| `Sessions.dc.html` | Sessions surface | `dc6e61e2ea` (#3600) |
+| `Chart Room - Astra v2.dc.html` | Chart Room (`src/components/role-surfaces/chart-room-graph.tsx`, `src/components/role-surfaces/chart-room-chain.tsx`) | `01874924dc` (`cave-iuc8h`) |
+| `Weaves and Proposals.dc.html` | Weaves decision surface | `9d43c00a28` (#4108) |
+| `Review Deck.dc.html` | tri-pane change review | `779030fc0d` (#3767) |
+| `Daily Report - Redesign.dc.html` | the chaptered day | `f0aaeced14` (#3981) |
+| `Marketplace.dc.html` | Explore (Browse + Skills merged) | `32d7d309fd` (#3775) |
+| `Memories Prototype.dc.html` | Memories / Knowledge launcher | `e62f2fd421` (#3756), `17386746a9` (#3445) |
+| `Launcher.dc.html` | Home work-led dashboard | `e87b7b448a` (#3758) |
+| `Research Desk.dc.html` | Research Desk chrome | `26efa6a1e2` (`cave-mxqz`) |
+| `Research Reader.dc.html` | research reader (`src/components/role-surfaces/research-reader.tsx`) | see `offScaleFontSizePx` baseline note |
+| `Thread Signal Card.dc.html` | thread-signal triage card (`src/components/thread-signals-section.tsx`) | `5c5e78f322` (#4256), `cave-vkegj` |
+| `Final Card Components.dc.html` / `GitHub Card Composer.dc.html` | `src/components/github-card-composer.tsx` | `cave-076kh` |
+| `Cody Github.dc.html` | GitHub triage stream + detail (`src/components/github-stream.tsx`) | see `offScaleSpacingPx` baseline note |
+| `Rituals Home.dc.html` | Rituals sidepanel | `26390d361b` (#3485) |
+| `New Reminder.dc.html` | new-reminder modal | `024dd99676` (#3569) |
+| `Project Folder Modal.dc.html` | folder picker | `08becc377a` (`cave-tv71`) |
+| `Queue.dc.html` / `Tasks.dc.html` | Queue + Tasks toolbars | `52d043cd1c` (#3746), `8c4c7cfde9` (#3748) |
+| Settings `About` / `Familiars` / `Profile` / `Phone` | settings control sheets | `3e1c5125f2`, `24b702fc8a`, `4c168973c7`, `196b222f4d` |
+| `Coven Cave App.dc.html` (iOS) | `apps/ios/CovenCave` | `157dee8d5d` (#3736), `d4f619b6c8` (`cave-4bsu`), `01a3d91bc8` (`cave-32fp`) — gated by `scripts/ios-claude-design-fidelity.test.mjs` |
+
+## Outstanding
+
+Ordered by size of the unbuilt frame, which is a decent proxy for how much
+surface it describes.
+
+| Frame | KB | Project | Note |
+|---|---:|---|---|
+| `Thread Signals.dc.html` | 514 | (WIP) Thread signal UI mockups | The largest frame in the corpus and in **no** exported zip. The smaller `Thread Signal Card` landed; this superset did not. Tracked by `cave-yd3qu`. |
+| `Cody Code Reading v2.dc.html` | 262 | # Coven Cave code reading experience | Tracked by `cave-98o51` (Coding Room). Only `Cody Github` from this project landed. |
+| `Coven Grimoire.dc.html` | 241 | (Started) Modern AI Blog Reader UI | `src/components/grimoire-view.tsx` / `src/components/grimoire-graph-view.tsx` exist — needs a frame-by-frame conformance pass, not a rebuild. Tracked by `cave-wc0j7`. |
+| `Cody Code Reading.dc.html` | 183 | # Coven Cave code reading experience | v1 of the above. |
+| `Coven Tui v2.dc.html` | 153 | # Coven Cave code reading experience | Terminal workbench; also `cave-98o51`. |
+| `OpenCoven Landing - Reforged.dc.html` | 150 | Interactive Landing Page Redesign | **Out of scope for this repo** — marketing site, no `coven-cave` surface. |
+| `Writer Workspace.dc.html` | 147 | Shells and hero flow planning | In no exported zip. No corresponding surface. Tracked by `cave-c7zgz`. |
+| `Memory.dc.html` | 135 | memory-management-previewer (zip only) | No `memory-preview` surface anywhere under `src/components`. Tracked by `cave-5u8l4`. |
+| `Coven Tui.dc.html` | 108 | # Coven Cave code reading experience | v1 of the above. |
+| `Coven Podcast.dc.html` | 86 | (Started) Podcast Page Redesign | Research studio has podcast *generation* (`c6987fe200`, `c483d94a15`) but no podcast **page**. Tracked by `cave-q00l6`. |
+| `Coven Pr.dc.html` | 75 | # Coven Cave code reading experience | |
+| `Activity Details Panel.dc.html` | 67 | feedback-request-for-improvement (zip only) | No `activity-detail` surface anywhere under `src/components`. Tracked by `cave-5u8l4`. |
+| `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
+| `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | In no exported zip. Tracked by `cave-c7zgz`. |
+| `SourceCard.dc.html` | 6 | (Started) Minimalist reader interface update | Two variants: **web** (og:image, domain, claim count) and **repo** (path + line badge, code peek, "Open in Code"). `src/components/ui/citation.tsx` implements one generic card and neither variant. Tracked by `cave-mdu1n`. |
+
+### Not deliverables
+
+These are specs, baselines and explorations — read them, don't build them:
+
+- `Agentic Core Spec.dc.html`, `Code Reading Spec Board.dc.html` — specs.
+- `* - Current.dc.html` (Cave Chat, Daily Report, Coven Podcast, OpenCoven
+  Landing, Memories - Current and Critique) — before-pictures.
+- `Chart Room - Astra / Proposal / Today`, `Dependencies - Directions`,
+  `Route Graph - Astra` — explorations that fed Astra v2, which landed whole.
+- `Familiar Analytics Redesign.dc.html` (1a/1b/1c), `Chat Revamp.dc.html`
+  (1a–1d), `Minimalist Explorations.dc.html` — direction sets; one direction
+  each was chosen and shipped.
+- `Nocturne` — a design-system project (foundations/components/templates), not
+  a screen.
+
+---
+
+## Working notes for the next import
+
+- **The prototype palette is already our token set.** `#9386d0` is
+  byte-identical to `--accent-presence`; the three `oklch` tones in every
+  handoff are literally `--color-success` / `--color-warning` / `--color-danger`.
+  Translate to tokens and the surface survives all 12 palettes × 2 modes for
+  free. Never hand-copy a hex — `pnpm lint` fails on it anyway.
+- **Snap the mock's spacing before measuring drift.** Handoffs paint
+  5/6/7/9/10/11/13/14/15/18/22/26px paddings; snapping them to `--space-1..-6`
+  turned a ratchet failure into a −65 improvement on the analytics import.
+  Keep only 1/2/3px micro-marks.
+- **Grep for every test that *reads* the file you are rewriting**, not just its
+  own suite — the analytics rebuild had five (`profile-card`, `authed-image`,
+  `thread-signals-section`, `evals-removal`, `first-run-stamps`).
+- **Drive the result in a browser.** On the analytics import, source-text tests
+  passed while a real browser showed a collapse breakpoint that was a ceiling
+  instead of a band, a panel pooling a third of its height as dead space, and a
+  duplicated count in a header.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -890,6 +890,7 @@ export const SUITES = {
     "src/lib/theme-palettes.test.ts",
     "src/lib/theme-contrast-audit.test.ts",
     "src/lib/design-token-drift.test.ts",
+    "src/lib/design-handoff-ledger.test.ts",
     "src/lib/dev-shell-recovery.test.ts",
     "src/lib/cave-backdrop.test.ts",
     "src/lib/cave-backdrop-blaze.test.ts",

--- a/src/components/citation.test.ts
+++ b/src/components/citation.test.ts
@@ -30,7 +30,7 @@ test("the Citation UI exposes inline provider previews through the shared Popove
   );
   assert.match(
     citation,
-    /line-clamp-2[^"]*text-\[length:var\(--text-md\)\]/,
+    /text-\[length:var\(--text-md\)\][\s\S]{0,900}?line-clamp-2 min-w-0/,
     "long source titles stay compact",
   );
   assert.match(
@@ -127,5 +127,41 @@ test("research cites the mission's used sources under the synthesis", () => {
     research,
     /sourcesToCitations\(mission\.sources\.filter\(\(source\) => source\.status === "used"\)\)/,
     "only the sources the mission actually used are cited",
+  );
+});
+
+test("a worktree citation renders the repo source card, not a web card (SourceCard.dc.html)", () => {
+  const card = citation;
+  assert.match(card, /function RepoCitationCard/, "the repo variant is its own card");
+  assert.match(
+    card,
+    /if \(citation\.file\) return <RepoCitationCard citation=\{citation\} \/>;/,
+    "a citation carrying a file ref takes the repo variant",
+  );
+  // The three things that identify a worktree source: path, range, lines.
+  assert.match(card, /title=\{file\.path\}/, "the full path is available on hover when it truncates");
+  assert.match(card, /const range = lineRangeLabel\(file\)/, "the line range comes from the shared helper");
+  assert.match(card, /\{firstLine \+ index\}/, "peek lines are numbered from the range start");
+  // The peek must be the citation's own snippet — never read off disk here, or
+  // the card could show a preview the citation never carried.
+  assert.match(
+    card,
+    /const peek = \(citation\.snippet \?\? ""\)[\s\S]{0,40}\.slice\(0, 4\)/,
+    "the peek is the citation's own quoted text, capped at four lines",
+  );
+  assert.match(card, /Open in Code/, "the repo card offers the code destination, not an external link");
+  assert.doesNotMatch(
+    card.slice(card.indexOf("function RepoCitationCard"), card.indexOf("function CitationCard")),
+    /target="_blank"/,
+    "a worktree path is never opened in a browser tab",
+  );
+});
+
+test("the web source card carries its marker number", () => {
+  const card = citation;
+  assert.match(
+    card,
+    /\{citation\.n\}\s*\n\s*<\/span>/,
+    "the card shows the same number as the inline chip that opened it",
   );
 });

--- a/src/components/ui/citation.tsx
+++ b/src/components/ui/citation.tsx
@@ -14,11 +14,13 @@ import { Popover, PopoverBody } from "@/components/ui/popover";
 import { createCitationPreviewCoordinator } from "@/lib/citation-preview";
 import {
   citationSourcePresentation,
+  lineRangeLabel,
   type Citation,
   type CitationSourceKind,
 } from "@/lib/citations";
 
 const SOURCE_ICONS: Record<CitationSourceKind, IconName> = {
+  repo: "ph:file-text",
   github: "ph:github-logo",
   arxiv: "ph:graduation-cap",
   doi: "ph:graduation-cap",
@@ -39,6 +41,67 @@ function isPlainPrimaryClick(event: ReactMouseEvent<HTMLAnchorElement>): boolean
   );
 }
 
+/**
+ * A worktree citation: the familiar cited a file it read, not a page it
+ * fetched. There is nothing to open in a browser and no domain to name, so the
+ * card shows what actually identifies the source — the path, the line range,
+ * and the lines themselves, numbered from the range start when one was given.
+ * The quoted text is the citation's own snippet; nothing is read off disk here,
+ * so the card can never show a peek the citation did not carry.
+ */
+function RepoCitationCard({ citation }: { citation: Citation }) {
+  const file = citation.file!;
+  const range = lineRangeLabel(file);
+  const peek = (citation.snippet ?? "").split("\n").slice(0, 4);
+  const firstLine = file.lineStart ?? 1;
+  return (
+    <article
+      data-source-kind="repo"
+      className="flex w-[var(--citation-card-w,320px)] max-w-[calc(100vw-var(--space-8))] flex-col overflow-hidden"
+    >
+      <header className="flex items-center gap-2 border-b border-[var(--border-hairline)] px-3 py-2">
+        <Icon name="ph:file-text" width={13} height={13} className="shrink-0 text-[var(--accent-presence)]" aria-hidden />
+        <span
+          className="min-w-0 flex-1 truncate font-[family-name:var(--font-mono)] text-[length:var(--text-xs)] text-[var(--text-primary)]"
+          title={file.path}
+        >
+          {file.path}
+        </span>
+        {range ? (
+          <span className="shrink-0 rounded-[var(--radius-sm)] bg-[color-mix(in_oklch,var(--accent-presence)_14%,transparent)] px-1.5 py-0.5 font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] font-semibold text-[var(--accent-presence)]">
+            {range}
+          </span>
+        ) : null}
+      </header>
+
+      {peek.some((line) => line.trim()) ? (
+        <div className="flex flex-col bg-[var(--code-surface)] py-2">
+          {peek.map((line, index) => (
+            <span key={index} className="flex items-baseline gap-2.5 pl-2.5 pr-3">
+              <span className="w-6 shrink-0 text-right font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] leading-4 text-[var(--text-muted)]">
+                {firstLine + index}
+              </span>
+              <span className="min-w-0 flex-1 truncate whitespace-pre font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] leading-4 text-[var(--code-foreground)]">
+                {line}
+              </span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <footer className="flex items-center gap-2 border-t border-[var(--border-hairline)] bg-[var(--bg-raised)] px-3 py-2">
+        <span className="min-w-0 truncate font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] text-[var(--text-muted)]">
+          {citation.title}
+        </span>
+        <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[length:var(--text-2xs)] font-medium text-[var(--text-secondary)]">
+          Open in Code
+          <Icon name="ph:arrow-square-out" width={10} height={10} aria-hidden />
+        </span>
+      </footer>
+    </article>
+  );
+}
+
 function CitationCard({
   citation,
   onOpenUrl,
@@ -46,6 +109,7 @@ function CitationCard({
   citation: Citation;
   onOpenUrl?: (url: string) => void;
 }) {
+  if (citation.file) return <RepoCitationCard citation={citation} />;
   const presentation = citationSourcePresentation(citation);
   const openSource = (event: ReactMouseEvent<HTMLAnchorElement>) => {
     if (!citation.url || !onOpenUrl || !isPlainPrimaryClick(event)) return;
@@ -73,8 +137,16 @@ function CitationCard({
       </header>
 
       <div className="flex flex-col gap-2 p-3">
-        <h3 className="line-clamp-2 break-words text-[length:var(--text-md)] font-semibold leading-snug text-[var(--text-primary)]">
-          {citation.title}
+        <h3 className="flex items-start gap-2 break-words text-[length:var(--text-md)] font-semibold leading-snug text-[var(--text-primary)]">
+          {/* The marker number, so the card and the inline chip that opened it
+              read as the same source rather than two lookups. */}
+          <span
+            aria-hidden
+            className="mt-0.5 grid h-3.5 w-3.5 shrink-0 place-items-center rounded-[var(--radius-sm)] bg-[color-mix(in_oklch,var(--foreground)_12%,transparent)] font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] font-semibold text-[var(--text-secondary)]"
+          >
+            {citation.n}
+          </span>
+          <span className="line-clamp-2 min-w-0">{citation.title}</span>
         </h3>
         <p className="line-clamp-3 text-[length:var(--text-xs)] leading-normal text-[var(--text-secondary)]">
           {presentation.summary}

--- a/src/lib/citations.test.ts
+++ b/src/lib/citations.test.ts
@@ -5,7 +5,9 @@ import {
   citationInlineLabel,
   citationSourcePresentation,
   domainFromUrl,
+  lineRangeLabel,
   parseCitations,
+  parseFileRef,
   renderCitedBody,
   renderCitationReferences,
   sourceToCitation,
@@ -250,3 +252,56 @@ test("parseCitations is a no-op without footnotes and ignores unreferenced defs"
   const orphan = "text\n\n[^unused]: https://nowhere.example";
   assert.deepEqual(parseCitations(orphan).citations, []);
 });
+
+// ── Worktree citations (SourceCard.dc.html, repo variant) ────────────────────
+//
+// A familiar citing its own reading has no URL to open and no domain to name.
+// `[^1]: src/lib/foo.ts#L12-L18 "why"` is the form it already writes, so the
+// parser recognises it rather than degrading it to an unlinked "reference".
+
+{
+  const parsed = parseCitations(
+    'Read it.[^1]\n\n[^1]: src/lib/citations.ts#L12-L18 "The parser" — the footnote reader\n',
+  );
+  assert.equal(parsed.citations.length, 1);
+  const [citation] = parsed.citations;
+  assert.deepEqual(citation.file, { path: "src/lib/citations.ts", lineStart: 12, lineEnd: 18 });
+  assert.equal(citation.title, "The parser");
+  assert.equal(citation.snippet, "the footnote reader");
+  assert.equal(citation.url, undefined, "a worktree path is not a URL to open");
+  assert.equal(citation.domain, undefined, "a worktree path has no domain");
+
+  const presentation = citationSourcePresentation(citation);
+  assert.equal(presentation.kind, "repo");
+  assert.equal(presentation.provider, "This worktree");
+  assert.equal(presentation.context, "src/lib/citations.ts · L12–18");
+}
+
+// The editor form and a single line both work; a bare path keeps no range.
+assert.deepEqual(parseFileRef("apps/ios/CovenCave/App.swift:42-99"), {
+  path: "apps/ios/CovenCave/App.swift",
+  lineStart: 42,
+  lineEnd: 99,
+  title: undefined,
+  snippet: undefined,
+});
+assert.equal(parseFileRef("src/lib/x.ts#L7")?.lineStart, 7);
+assert.equal(parseFileRef("src/lib/x.ts#L7")?.lineEnd, undefined);
+assert.equal(parseFileRef("src/styles/globals.css")?.path, "src/styles/globals.css");
+assert.equal(lineRangeLabel({ path: "a/b.ts", lineStart: 5, lineEnd: 5 }), "L5", "a degenerate range reads as one line");
+assert.equal(lineRangeLabel({ path: "a/b.ts" }), undefined);
+
+// Prose must not be mistaken for a path — that would turn an ordinary note
+// into a file card pointing at nothing.
+assert.equal(parseFileRef("Notes from the meeting on 4.5 things"), null);
+assert.equal(parseFileRef("https://example.com/a/b.html"), null, "a URL stays a URL");
+assert.equal(parseFileRef("justafile.ts"), null, "a bare filename with no directory is prose");
+
+// A URL definition still parses as a web source, unchanged.
+{
+  const parsed = parseCitations('Cited.[^1]\n\n[^1]: <https://example.com/a> — a note\n');
+  assert.equal(parsed.citations[0].file, undefined);
+  assert.equal(parsed.citations[0].domain, "example.com");
+}
+
+console.log("citations.test.ts: worktree citations ok");

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -23,9 +23,25 @@ export type Citation = {
   domain?: string;
   /** A short excerpt / claim / note shown in the source card. */
   snippet?: string;
+  /**
+   * A reference to a file in this worktree rather than a page on the web.
+   * A familiar citing its own reading writes `[^1]: src/lib/foo.ts#L12-L18`,
+   * which has no URL to open and no domain to name — the source card shows the
+   * path, the line range, and the quoted lines instead.
+   */
+  file?: CitationFileRef;
+};
+
+export type CitationFileRef = {
+  /** Repo-relative path, as written. */
+  path: string;
+  /** 1-based inclusive line range, when the reference named one. */
+  lineStart?: number;
+  lineEnd?: number;
 };
 
 export type CitationSourceKind =
+  | "repo"
   | "github"
   | "arxiv"
   | "doi"
@@ -112,7 +128,25 @@ function githubPresentation(citation: Citation, url: URL): CitationSourcePresent
 
 const DOCUMENT_EXTENSIONS = new Set(["pdf", "doc", "docx", "ppt", "pptx", "xls", "xlsx"]);
 
+export function lineRangeLabel(file: CitationFileRef): string | undefined {
+  if (file.lineStart === undefined) return undefined;
+  return file.lineEnd !== undefined && file.lineEnd !== file.lineStart
+    ? `L${file.lineStart}–${file.lineEnd}`
+    : `L${file.lineStart}`;
+}
+
 export function citationSourcePresentation(citation: Citation): CitationSourcePresentation {
+  if (citation.file) {
+    const range = lineRangeLabel(citation.file);
+    return {
+      kind: "repo",
+      provider: "This worktree",
+      context: range ? `${citation.file.path} · ${range}` : citation.file.path,
+      summary:
+        citation.snippet?.trim() ||
+        "Cited from a file in this worktree — open it in Code to read the surrounding change.",
+    };
+  }
   const url = parsedUrl(citation.url);
   if (!url) {
     return {
@@ -225,9 +259,40 @@ const REF_RE = /\[\^([^\]]+)\](?!:)/g;
 const MD_LINK_RE = /^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)(?:[ \t]+—[ \t]+(.+))?$/;
 const ANGLE_URL_RE = /^<(https?:\/\/[^\s>]+)>(?:[ \t]+—[ \t]+(.+))?$/;
 const BARE_URL_RE = /^(https?:\/\/\S+)(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+))?$/;
+// A worktree file reference: a repo-relative path with an extension, optionally
+// carrying a line range in either the GitHub (`#L12-L18`) or editor (`:12-18`)
+// form. Anchored and extension-gated so ordinary prose starting with a word
+// cannot be mistaken for a path.
+const FILE_REF_RE =
+  /^((?:[\w.@~-]+\/)+[\w.@-]+\.[a-z0-9]{1,12})(?:#L(\d+)(?:[-–]L?(\d+))?|:(\d+)(?:[-–](\d+))?)?(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+))?$/i;
 
-function parseDefinitionContent(raw: string): { title: string; url?: string; snippet?: string } {
+/** Parse a worktree file reference, or null when the text is not one. */
+export function parseFileRef(raw: string): (CitationFileRef & { title?: string; snippet?: string }) | null {
+  const m = raw.trim().match(FILE_REF_RE);
+  if (!m) return null;
+  const start = m[2] ?? m[4];
+  const end = m[3] ?? m[5];
+  return {
+    path: m[1],
+    lineStart: start ? Number(start) : undefined,
+    lineEnd: end ? Number(end) : undefined,
+    title: m[6]?.trim() || undefined,
+    snippet: m[7]?.trim() || undefined,
+  };
+}
+
+function parseDefinitionContent(raw: string): {
+  title: string;
+  url?: string;
+  snippet?: string;
+  file?: CitationFileRef;
+} {
   const content = raw.trim();
+  const fileRef = parseFileRef(content);
+  if (fileRef) {
+    const { title, snippet, ...file } = fileRef;
+    return { title: title || file.path.split("/").pop() || file.path, snippet, file };
+  }
   const md = content.match(MD_LINK_RE);
   if (md) return { title: md[1].trim(), url: md[2], snippet: md[3]?.trim() || undefined };
   const angle = content.match(ANGLE_URL_RE);
@@ -286,7 +351,7 @@ export function renderCitationReferences(
  * markers stay so the renderer can turn them into superscript anchors.
  */
 export function parseCitations(text: string): ParsedCitations {
-  const defs = new Map<string, { title: string; url?: string; snippet?: string }>();
+  const defs = new Map<string, ReturnType<typeof parseDefinitionContent>>();
   let m: RegExpExecArray | null;
   DEF_RE.lastIndex = 0;
   while ((m = DEF_RE.exec(text)) !== null) {
@@ -314,6 +379,7 @@ export function parseCitations(text: string): ParsedCitations {
         url: def.url,
         domain: domainFromUrl(def.url),
         snippet: def.snippet,
+        file: def.file,
       };
     });
 

--- a/src/lib/design-handoff-ledger.test.ts
+++ b/src/lib/design-handoff-ledger.test.ts
@@ -1,0 +1,105 @@
+// The Claude Design ledger (docs/design-handoff/IMPLEMENTATION-STATUS.md) is
+// the answer to "which design frames have we built?". A ledger nobody checks
+// rots into a list of paths that no longer exist, which is worse than no
+// ledger — it reads authoritative while being wrong.
+//
+// This gate pins the half a test CAN check: the repo side. Every source path
+// and every commit SHA the doc cites must resolve, and the doc must keep
+// naming the live MCP as its source of truth (an audit driven off the stale
+// zips in ~/Downloads under-reports the corpus — see the doc's own preamble).
+//
+// It deliberately does NOT try to verify the live project list: that needs
+// network + OAuth, and a test that silently skips is a test that lies.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+const root = process.cwd();
+const LEDGER = "docs/design-handoff/IMPLEMENTATION-STATUS.md";
+const doc = readFileSync(path.join(root, LEDGER), "utf8");
+
+// ── the doc must keep pointing at the live source of truth ──────────────────
+
+assert.match(
+  doc,
+  /mcp__claude-design__list_projects/,
+  "the ledger must name the live MCP call that regenerates it",
+);
+assert.match(
+  doc,
+  /stale snapshots/i,
+  "the ledger must keep the warning that ~/Downloads zips under-report the corpus",
+);
+assert.match(doc, /^## Landed$/m, "the ledger keeps a Landed section");
+assert.match(doc, /^## Outstanding$/m, "the ledger keeps an Outstanding section");
+assert.match(
+  doc,
+  /^### Not deliverables$/m,
+  "the ledger separates specs and explorations from real outstanding work",
+);
+
+// ── every cited source path must exist ──────────────────────────────────────
+
+// Backticked paths that look like repo files (contain a slash and a known
+// extension, or are a known directory root). Frame names end in .dc.html and
+// live in Claude Design, not here — those are excluded.
+const cited = new Set(
+  [...doc.matchAll(/`([^`\s]+)`/g)]
+    .map((m) => m[1])
+    .filter((token) => !token.endsWith(".dc.html"))
+    .filter((token) => /^(src|scripts|apps|docs)\//.test(token)),
+);
+
+assert.ok(cited.size >= 4, `expected the ledger to cite repo paths, found ${cited.size}`);
+for (const rel of cited) {
+  assert.ok(existsSync(path.join(root, rel)), `${LEDGER} cites a path that no longer exists: ${rel}`);
+}
+
+// Bare component filenames the doc names as evidence (e.g. `citation.tsx`).
+// Resolve them anywhere under src/ rather than pinning a directory, so a file
+// move updates the ledger's meaning without breaking the gate.
+const bareFiles = new Set(
+  [...doc.matchAll(/`([a-z0-9-]+\.(?:tsx|ts|mjs))`/g)].map((m) => m[1]),
+);
+if (bareFiles.size > 0) {
+  const tracked = execFileSync("git", ["ls-files", "src", "scripts", "apps"], {
+    cwd: root,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  }).split("\n");
+  const basenames = new Set(tracked.map((file) => path.basename(file)));
+  for (const file of bareFiles) {
+    assert.ok(basenames.has(file), `${LEDGER} names a file that no longer exists: ${file}`);
+  }
+}
+
+// ── every cited commit must resolve ─────────────────────────────────────────
+
+// A ledger row's whole value is that you can go read the change it points at.
+// Shallow clones can't resolve history, so this asserts only when the object
+// is reachable at all — but a WRONG sha (never in this repo) still fails.
+const shas = new Set([...doc.matchAll(/\|\s*`([0-9a-f]{10})`/g)].map((m) => m[1]));
+assert.ok(shas.size >= 10, `expected the ledger to cite landing commits, found ${shas.size}`);
+let resolvable = 0;
+for (const sha of shas) {
+  try {
+    execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], { cwd: root, stdio: "ignore" });
+    resolvable += 1;
+  } catch {
+    // Unreachable here: either a shallow clone, or a bad sha. Distinguished below.
+  }
+}
+// If ANY resolve, history is present — so the ones that didn't are wrong.
+if (resolvable > 0) {
+  assert.equal(
+    resolvable,
+    shas.size,
+    `${LEDGER} cites ${shas.size - resolvable} commit(s) this repo has never seen`,
+  );
+}
+
+console.log(
+  `design-handoff-ledger.test.ts OK (${cited.size} paths, ${bareFiles.size} files, ${shas.size} commits${resolvable === 0 ? " — shallow clone, commits unchecked" : ""})`,
+);


### PR DESCRIPTION
Answers "which Claude Design frames have we built, and what's left?" — and then
builds the smallest thing that was left.

## The review

17 live Claude Design projects, ~75 distinct frames. The bulk has landed: I
traced 35+ implementation commits on `main`. But nothing wrote it down, so the
question could only be answered by re-deriving it from `git log` and a folder of
zips — and **both sources lie**:

- **The zips lie by omission.** 52 zips in `~/Downloads` are really ~17 projects
  (five separate `chat-page-*` zips carry the same five frames). Worse, the live
  projects hold frames that appear in **no** export at all: `Writer Workspace`,
  `AnswerFlow`, `Memories - Rethought`, and the **514 KB `Thread Signals`** —
  the largest frame in the whole corpus, which is why nobody ever picked it up.
- **`git log` lies by silence.** A frame that was explored and deliberately
  dropped looks exactly like one nobody got to.

## What this adds

`docs/design-handoff/IMPLEMENTATION-STATUS.md` — every frame, the commit that
landed it, and what is outstanding. Three sections: **Landed** (28 rows),
**Outstanding** (14 rows, each with a bead), and **Not deliverables** — specs,
before-pictures (`* - Current.dc.html`) and direction sets (`1a/1b/1c`), listed
explicitly so they stop reading as debt.

Seven beads cover the real gaps: `cave-yd3qu` (Thread Signals),
`cave-q00l6` (Podcast page), `cave-c7zgz` (Writer Workspace + AnswerFlow),
`cave-tj24b` (Memories - Rethought), `cave-wc0j7` (Grimoire conformance),
`cave-5u8l4` (Memory + Activity Details — confirm intent first), and
`cave-mdu1n` — which this PR closes.

`design-handoff-ledger.test.ts` pins the half a test can check: every source
path and every commit sha the doc cites must resolve. It says plainly that the
live side needs a hand update rather than skipping silently and calling that a
pass.

Also resolves the one blocker the corpus had actually recorded. `cave-4bsu` was
held open on "live claude_design MCP import awaits user approval" — the MCP is
connected now, and the iOS project **is not in the account's project list at
all**, so that gate is unsatisfiable rather than pending. Noted on the bead for
its owner (I did not close someone else's bead).

## What this builds

`SourceCard.dc.html` — the Reader project's second frame, companion to frame 3a
that landed in #4255.

A familiar citing a file it read got the same card as a page it fetched:
provider "Reference", context "Provided in this chat", and a footer reading
"No link provided". Everything that identifies the source was discarded because
`Citation` had nowhere to put it.

`[^1]: src/lib/citations.ts#L12-L18 "The parser"` is the form a familiar already
writes. The parser now recognises it (GitHub `#L12-L18` and editor `:12-18`) and
carries a `file` ref through, so the card shows path, line-range badge, and the
quoted lines numbered from the range start — footed with **Open in Code** rather
than an external link a path cannot honour.

The peek is the citation's own snippet; nothing is read off disk in the card, so
it can never show a preview the citation did not carry. Path detection needs a
directory segment and a real extension, so `"Notes from the meeting on 4.5
things"` stays prose and a URL stays a URL — both pinned.

The web card also gains the marker number the design gives it, so the card and
the inline chip that opened it read as one source instead of two lookups.

## Verification

`pnpm lint`, `tsc`, `design-token-drift` (unchanged: font=139 space=1653
radius=233 hex=0 inline=207), `check-tests-wired` (1465 files), and every
citation-adjacent suite. Full `pnpm test:app` running.