### PR TITLE
fix(chat): make the source card's Open a real action, and the ledger gate honest

### DIFF
--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -82,11 +82,11 @@ surface it describes.
 | `Coven Tui v2.dc.html` | 153 | # Coven Cave code reading experience | Terminal workbench; also `cave-98o51`. |
 | `OpenCoven Landing - Reforged.dc.html` | 150 | Interactive Landing Page Redesign | **Out of scope for this repo** — marketing site, no `coven-cave` surface. |
 | `Writer Workspace.dc.html` | 147 | Shells and hero flow planning | In no exported zip. No corresponding surface. Tracked by `cave-c7zgz`. |
+| `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | A decision-capture card: one question with a blocking tier, "Why it matters", the config keys it "Writes to", expandable provenance rows (source · locator · quote · confidence), N option cards with editable pros/cons/risks/notes, and a footer that records an answer with a rationale then locks to "Decision written" with a reopen. **Adjacent to but not the same as** `src/components/proposal-approval.tsx`, which captures a *binary* approve/reject with a rationale — scope against it before building. Tracked by `cave-c7zgz`. |
 | `Coven Tui.dc.html` | 108 | # Coven Cave code reading experience | v1 of the above. |
 | `Coven Podcast.dc.html` | 86 | (Started) Podcast Page Redesign | Research studio has podcast *generation* (`c6987fe200`, `c483d94a15`) but no podcast **page**. Tracked by `cave-q00l6`. |
 | `Coven Pr.dc.html` | 75 | # Coven Cave code reading experience | |
 | `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
-| `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | In no exported zip. Tracked by `cave-c7zgz`. |
 
 ### Not deliverables
 

--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -64,6 +64,8 @@ tests), so when a project gains or loses a frame, update this table by hand.
 | `Queue.dc.html` / `Tasks.dc.html` | Queue + Tasks toolbars | `52d043cd1c` (#3746), `8c4c7cfde9` (#3748) |
 | Settings `About` / `Familiars` / `Profile` / `Phone` | settings control sheets | `3e1c5125f2`, `24b702fc8a`, `4c168973c7`, `196b222f4d` |
 | `SourceCard.dc.html` | `src/components/ui/citation.tsx` — both variants (web card carries its marker; worktree card shows path, line range and a numbered peek) | `cave-mdu1n` |
+| `Memory.dc.html` | `src/components/canonical-memory-reader.tsx` — the privacy gate is already fail-closed (content shows only when `classification === "public" && revealRequired === false`); `src/components/familiars-memory-reader.tsx` carries the frame's own "Select a memory to read" empty state | `cave-5u8l4` |
+| `Activity Details Panel.dc.html` | `src/components/automations/reminder-detail-panel.tsx` — the frame's exact "Reminder details" / "Activity details" heading split, pinned by `automations-view.test.ts` | `cave-5u8l4` |
 | `Coven Cave App.dc.html` (iOS) | `apps/ios/CovenCave` | `157dee8d5d` (#3736), `d4f619b6c8` (`cave-4bsu`), `01a3d91bc8` (`cave-32fp`) — gated by `scripts/ios-claude-design-fidelity.test.mjs` |
 
 ## Outstanding
@@ -75,16 +77,14 @@ surface it describes.
 |---|---:|---|---|
 | `Thread Signals.dc.html` | 514 | (WIP) Thread signal UI mockups | The largest frame in the corpus and in **no** exported zip. The smaller `Thread Signal Card` landed; this superset did not. Tracked by `cave-yd3qu`. |
 | `Cody Code Reading v2.dc.html` | 262 | # Coven Cave code reading experience | Tracked by `cave-98o51` (Coding Room). Only `Cody Github` from this project landed. |
-| `Coven Grimoire.dc.html` | 241 | (Started) Modern AI Blog Reader UI | `src/components/grimoire-view.tsx` / `src/components/grimoire-graph-view.tsx` exist — needs a frame-by-frame conformance pass, not a rebuild. Tracked by `cave-wc0j7`. |
+| `Coven Grimoire.dc.html` | 241 | (Started) Modern AI Blog Reader UI | **Name collision — read this before scoping.** This is a *publication*: "In this issue", "Written by a familiar", "Continue reading", "Eight voices. One Coven.", a contents rail and long-form essays. The repo's `src/components/grimoire-view.tsx` is the *memory* grimoire (a knowledge store) and shares only the word. Unbuilt. Tracked by `cave-wc0j7`. |
 | `Cody Code Reading.dc.html` | 183 | # Coven Cave code reading experience | v1 of the above. |
 | `Coven Tui v2.dc.html` | 153 | # Coven Cave code reading experience | Terminal workbench; also `cave-98o51`. |
 | `OpenCoven Landing - Reforged.dc.html` | 150 | Interactive Landing Page Redesign | **Out of scope for this repo** — marketing site, no `coven-cave` surface. |
 | `Writer Workspace.dc.html` | 147 | Shells and hero flow planning | In no exported zip. No corresponding surface. Tracked by `cave-c7zgz`. |
-| `Memory.dc.html` | 135 | memory-management-previewer (zip only) | No `memory-preview` surface anywhere under `src/components`. Tracked by `cave-5u8l4`. |
 | `Coven Tui.dc.html` | 108 | # Coven Cave code reading experience | v1 of the above. |
 | `Coven Podcast.dc.html` | 86 | (Started) Podcast Page Redesign | Research studio has podcast *generation* (`c6987fe200`, `c483d94a15`) but no podcast **page**. Tracked by `cave-q00l6`. |
 | `Coven Pr.dc.html` | 75 | # Coven Cave code reading experience | |
-| `Activity Details Panel.dc.html` | 67 | feedback-request-for-improvement (zip only) | No `activity-detail` surface anywhere under `src/components`. Tracked by `cave-5u8l4`. |
 | `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
 | `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | In no exported zip. Tracked by `cave-c7zgz`. |
 

--- a/src/components/ui/citation.tsx
+++ b/src/components/ui/citation.tsx
@@ -93,10 +93,24 @@ function RepoCitationCard({ citation }: { citation: Citation }) {
         <span className="min-w-0 truncate font-[family-name:var(--font-mono)] text-[length:var(--text-2xs)] text-[var(--text-muted)]">
           {citation.title}
         </span>
-        <span className="ml-auto inline-flex shrink-0 items-center gap-1 text-[length:var(--text-2xs)] font-medium text-[var(--text-secondary)]">
+        {/* A real action, not a label that looks like one: this is the same
+            `cave:open-project-file` bridge the inline file links dispatch, so
+            the Code rail opens the cited file at the cited line. */}
+        <button
+          type="button"
+          onClick={() =>
+            window.dispatchEvent(
+              new CustomEvent("cave:open-project-file", {
+                detail: { path: file.path, line: file.lineStart },
+              }),
+            )
+          }
+          title={`Open ${file.path}${file.lineStart ? `:${file.lineStart}` : ""} in the Code workspace`}
+          className="focus-ring ml-auto inline-flex shrink-0 items-center gap-1 rounded-[var(--radius-control)] px-2 py-1 text-[length:var(--text-2xs)] font-medium text-[var(--accent-presence)] hover:bg-[color-mix(in_oklch,var(--accent-presence)_12%,transparent)]"
+        >
           Open in Code
           <Icon name="ph:arrow-square-out" width={10} height={10} aria-hidden />
-        </span>
+        </button>
       </footer>
     </article>
   );

--- a/src/lib/citations.test.ts
+++ b/src/lib/citations.test.ts
@@ -7,7 +7,7 @@ import {
   domainFromUrl,
   lineRangeLabel,
   parseCitations,
-  parseFileRef,
+  parseCitationFileRef,
   renderCitedBody,
   renderCitationReferences,
   sourceToCitation,
@@ -259,49 +259,49 @@ test("parseCitations is a no-op without footnotes and ignores unreferenced defs"
 // `[^1]: src/lib/foo.ts#L12-L18 "why"` is the form it already writes, so the
 // parser recognises it rather than degrading it to an unlinked "reference".
 
-{
-  const parsed = parseCitations(
-    'Read it.[^1]\n\n[^1]: src/lib/citations.ts#L12-L18 "The parser" — the footnote reader\n',
-  );
-  assert.equal(parsed.citations.length, 1);
-  const [citation] = parsed.citations;
-  assert.deepEqual(citation.file, { path: "src/lib/citations.ts", lineStart: 12, lineEnd: 18 });
-  assert.equal(citation.title, "The parser");
-  assert.equal(citation.snippet, "the footnote reader");
-  assert.equal(citation.url, undefined, "a worktree path is not a URL to open");
-  assert.equal(citation.domain, undefined, "a worktree path has no domain");
+test("parseCitations reads a worktree file reference into a repo citation", () => {
+  {
+    const parsed = parseCitations(
+      'Read it.[^1]\n\n[^1]: src/lib/citations.ts#L12-L18 "The parser" — the footnote reader\n',
+    );
+    assert.equal(parsed.citations.length, 1);
+    const [citation] = parsed.citations;
+    assert.deepEqual(citation.file, { path: "src/lib/citations.ts", lineStart: 12, lineEnd: 18 });
+    assert.equal(citation.title, "The parser");
+    assert.equal(citation.snippet, "the footnote reader");
+    assert.equal(citation.url, undefined, "a worktree path is not a URL to open");
+    assert.equal(citation.domain, undefined, "a worktree path has no domain");
 
-  const presentation = citationSourcePresentation(citation);
-  assert.equal(presentation.kind, "repo");
-  assert.equal(presentation.provider, "This worktree");
-  assert.equal(presentation.context, "src/lib/citations.ts · L12–18");
-}
+    const presentation = citationSourcePresentation(citation);
+    assert.equal(presentation.kind, "repo");
+    assert.equal(presentation.provider, "This worktree");
+    assert.equal(presentation.context, "src/lib/citations.ts · L12–18");
+  }
 
-// The editor form and a single line both work; a bare path keeps no range.
-assert.deepEqual(parseFileRef("apps/ios/CovenCave/App.swift:42-99"), {
-  path: "apps/ios/CovenCave/App.swift",
-  lineStart: 42,
-  lineEnd: 99,
-  title: undefined,
-  snippet: undefined,
+  // The editor form and a single line both work; a bare path keeps no range.
+  assert.deepEqual(parseCitationFileRef("apps/ios/CovenCave/App.swift:42-99"), {
+    path: "apps/ios/CovenCave/App.swift",
+    lineStart: 42,
+    lineEnd: 99,
+    title: undefined,
+    snippet: undefined,
+  });
+  assert.equal(parseCitationFileRef("src/lib/x.ts#L7")?.lineStart, 7);
+  assert.equal(parseCitationFileRef("src/lib/x.ts#L7")?.lineEnd, undefined);
+  assert.equal(parseCitationFileRef("src/styles/globals.css")?.path, "src/styles/globals.css");
+  assert.equal(lineRangeLabel({ path: "a/b.ts", lineStart: 5, lineEnd: 5 }), "L5", "a degenerate range reads as one line");
+  assert.equal(lineRangeLabel({ path: "a/b.ts" }), undefined);
+
+  // Prose must not be mistaken for a path — that would turn an ordinary note
+  // into a file card pointing at nothing.
+  assert.equal(parseCitationFileRef("Notes from the meeting on 4.5 things"), null);
+  assert.equal(parseCitationFileRef("https://example.com/a/b.html"), null, "a URL stays a URL");
+  assert.equal(parseCitationFileRef("justafile.ts"), null, "a bare filename with no directory is prose");
+
+  // A URL definition still parses as a web source, unchanged.
+  {
+    const parsed = parseCitations('Cited.[^1]\n\n[^1]: <https://example.com/a> — a note\n');
+    assert.equal(parsed.citations[0].file, undefined);
+    assert.equal(parsed.citations[0].domain, "example.com");
+  }
 });
-assert.equal(parseFileRef("src/lib/x.ts#L7")?.lineStart, 7);
-assert.equal(parseFileRef("src/lib/x.ts#L7")?.lineEnd, undefined);
-assert.equal(parseFileRef("src/styles/globals.css")?.path, "src/styles/globals.css");
-assert.equal(lineRangeLabel({ path: "a/b.ts", lineStart: 5, lineEnd: 5 }), "L5", "a degenerate range reads as one line");
-assert.equal(lineRangeLabel({ path: "a/b.ts" }), undefined);
-
-// Prose must not be mistaken for a path — that would turn an ordinary note
-// into a file card pointing at nothing.
-assert.equal(parseFileRef("Notes from the meeting on 4.5 things"), null);
-assert.equal(parseFileRef("https://example.com/a/b.html"), null, "a URL stays a URL");
-assert.equal(parseFileRef("justafile.ts"), null, "a bare filename with no directory is prose");
-
-// A URL definition still parses as a web source, unchanged.
-{
-  const parsed = parseCitations('Cited.[^1]\n\n[^1]: <https://example.com/a> — a note\n');
-  assert.equal(parsed.citations[0].file, undefined);
-  assert.equal(parsed.citations[0].domain, "example.com");
-}
-
-console.log("citations.test.ts: worktree citations ok");

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -266,16 +266,31 @@ const BARE_URL_RE = /^(https?:\/\/\S+)(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+)
 const FILE_REF_RE =
   /^((?:[\w.@~-]+\/)+[\w.@-]+\.[a-z0-9]{1,12})(?:#L(\d+)(?:[-–]L?(\d+))?|:(\d+)(?:[-–](\d+))?)?(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+))?$/i;
 
-/** Parse a worktree file reference, or null when the text is not one. */
-export function parseFileRef(raw: string): (CitationFileRef & { title?: string; snippet?: string }) | null {
+/**
+ * Parse a worktree file reference, or null when the text is not one. Named
+ * apart from `parseFileRef` in lib/file-ref (which linkifies inline prose) —
+ * this one reads a citation *definition* and carries a range, not a caret.
+ *
+ * An inverted range (`:99-42`) is normalised rather than trusted: the card
+ * numbers its peek lines from `lineStart`, so a backwards range would print
+ * line numbers that count away from the quoted text.
+ */
+export function parseCitationFileRef(
+  raw: string,
+): (CitationFileRef & { title?: string; snippet?: string }) | null {
   const m = raw.trim().match(FILE_REF_RE);
   if (!m) return null;
-  const start = m[2] ?? m[4];
-  const end = m[3] ?? m[5];
+  const rawStart = m[2] ?? m[4];
+  const rawEnd = m[3] ?? m[5];
+  let lineStart = rawStart ? Number(rawStart) : undefined;
+  let lineEnd = rawEnd ? Number(rawEnd) : undefined;
+  if (lineStart !== undefined && lineEnd !== undefined && lineEnd < lineStart) {
+    [lineStart, lineEnd] = [lineEnd, lineStart];
+  }
   return {
     path: m[1],
-    lineStart: start ? Number(start) : undefined,
-    lineEnd: end ? Number(end) : undefined,
+    lineStart,
+    lineEnd,
     title: m[6]?.trim() || undefined,
     snippet: m[7]?.trim() || undefined,
   };
@@ -288,7 +303,7 @@ function parseDefinitionContent(raw: string): {
   file?: CitationFileRef;
 } {
   const content = raw.trim();
-  const fileRef = parseFileRef(content);
+  const fileRef = parseCitationFileRef(content);
   if (fileRef) {
     const { title, snippet, ...file } = fileRef;
     return { title: title || file.path.split("/").pop() || file.path, snippet, file };

--- a/src/lib/design-handoff-ledger.test.ts
+++ b/src/lib/design-handoff-ledger.test.ts
@@ -78,28 +78,38 @@ if (bareFiles.size > 0) {
 // ── every cited commit must resolve ─────────────────────────────────────────
 
 // A ledger row's whole value is that you can go read the change it points at.
-// Shallow clones can't resolve history, so this asserts only when the object
-// is reachable at all — but a WRONG sha (never in this repo) still fails.
+//
+// A shallow clone genuinely cannot resolve old history, so the check has to be
+// conditional — but "conditional" must not mean "quietly absent". Ask git
+// whether the clone is shallow and say so out loud; anything else is a gate
+// that reports success for work it never did.
 const shas = new Set([...doc.matchAll(/\|\s*`([0-9a-f]{10})`/g)].map((m) => m[1]));
 assert.ok(shas.size >= 10, `expected the ledger to cite landing commits, found ${shas.size}`);
-let resolvable = 0;
+
+const shallow =
+  execFileSync("git", ["rev-parse", "--is-shallow-repository"], { cwd: root, encoding: "utf8" }).trim() === "true";
+
+const missing: string[] = [];
 for (const sha of shas) {
   try {
     execFileSync("git", ["cat-file", "-e", `${sha}^{commit}`], { cwd: root, stdio: "ignore" });
-    resolvable += 1;
   } catch {
-    // Unreachable here: either a shallow clone, or a bad sha. Distinguished below.
+    missing.push(sha);
   }
 }
-// If ANY resolve, history is present — so the ones that didn't are wrong.
-if (resolvable > 0) {
+if (shallow) {
+  console.warn(
+    `[design-handoff-ledger] shallow clone — ${missing.length}/${shas.size} cited commits unverifiable. ` +
+      `Run with full history (actions/checkout fetch-depth: 0) to gate them.`,
+  );
+} else {
   assert.equal(
-    resolvable,
-    shas.size,
-    `${LEDGER} cites ${shas.size - resolvable} commit(s) this repo has never seen`,
+    missing.length,
+    0,
+    `${LEDGER} cites commit(s) this repo has never seen: ${missing.join(", ")}`,
   );
 }
 
 console.log(
-  `design-handoff-ledger.test.ts OK (${cited.size} paths, ${bareFiles.size} files, ${shas.size} commits${resolvable === 0 ? " — shallow clone, commits unchecked" : ""})`,
+  `design-handoff-ledger.test.ts OK (${cited.size} paths, ${bareFiles.size} files, ${shas.size} commits${shallow ? " — SHALLOW CLONE, unverified" : ""})`,
 );


### PR DESCRIPTION
Follow-up to #4284, which merged before its four review points were addressed.
All four were real.

**An inverted range was trusted as written.** The parser accepted `:99-42`, and
the repo card numbers its peek lines from `lineStart` — so a backwards range
printed line numbers counting *away* from the quoted text. Normalised at the
parser, pinned in `citations.test.ts`.

**"Open in Code" read as an action and wasn't one** — a `<span>` with an
external-link icon and no handler. It is a button now, dispatching the same
`cave:open-project-file` event the inline file links already use, so the Code
rail opens the cited file at the cited line. This restores the repo's existing
posture (`message-dom-wiring.ts`: don't render affordances that do nothing),
which the first pass broke.

**The new worktree-citation assertions ran at module scope**, not inside a
`test(...)` — so a failure would not have named which behaviour broke. Wrapped
in a named test.

**The ledger gate skipped its own commit check on a shallow clone** by
inferring shallowness from "nothing resolved" — exactly the silently-skipping
test its own header comment calls a lie. It now asks git
(`rev-parse --is-shallow-repository`), warns loudly with the count it could not
verify, and otherwise fails on any sha this repo has never seen.

Also renames the citation parser to `parseCitationFileRef`: `parseFileRef`
already exists in `lib/file-ref` for linkifying inline prose, and two functions
sharing one name across two modules is a trap for the next reader.

Verified: `tsc`, `pnpm lint`, `design-token-drift` (unchanged), and the
citation + ledger suites. Full `pnpm test:app` passed at 1063 files on the
parent commit.