### PR TITLE
test(e2e): stop the reader spec racing its own cold-start budget

### DIFF
--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -22,7 +22,15 @@ import { expect, test, type Page } from "@playwright/test";
 // navigation — which reads as "the reader is broken" when it is only cold.
 // Serial lets the first test pay the compile and the rest run warm. Same
 // posture as canonical-memory / code-surface / research-desk-tabs.
-test.describe.configure({ mode: "serial", timeout: 180_000 });
+// 240s, not 180s: openReader's own waits already budget 30s (chat surface) +
+// 30s (the answer) + 90s (the reader chunk) = 150s, and the FIRST test also
+// pays cold navigation and compile on top. At 180s the outer timeout fired
+// mid-wait and killed the very allowance the inner 90s exists to provide —
+// observed as `.cave-reader` "element(s) not found" with "Test timeout of
+// 180000ms exceeded" in the call log, on the first test only, passing on retry
+// (cave-n7wm5). Serial mode means only that first test is cold, so this buys
+// headroom for one test rather than lengthening the suite.
+test.describe.configure({ mode: "serial", timeout: 240_000 });
 
 const ISO = "2026-08-03T14:02:00.000Z";
 
@@ -142,6 +150,21 @@ async function openReader(page: Page, turn: TurnSpec) {
   // that passes only on Playwright's retry, and a test that needs a retry to
   // go green is a test that will eventually go red for no reason.
   await expect(page.locator(".cave-reader")).toBeVisible({ timeout: 90_000 });
+  // ...and then for the DOCUMENT, not just the shell that holds it. Every caller
+  // below asserts against `.cave-reader-doc .cave-md`, and those assertions get
+  // expect()'s default 5s window — not the 90s above. On a cold server, where
+  // the dynamic chunk is still settling, the shell turns visible while the prose
+  // and the citation-preview components that mount `a.cave-citation-chip` have
+  // not rendered yet, so the first assertion reads an empty document: the chip
+  // count came back 0 instead of 2, twice in one run, and passed on a clean
+  // re-run of the same commit (cave-n7wm5).
+  //
+  // Waiting on the answer's own text is the same rule the artifact wait above
+  // follows, and it is fixture-agnostic — both CITED_ANSWER and BARE_ANSWER open
+  // with prose, so this settles for every caller rather than only the cited one.
+  await expect(page.locator(".cave-reader-doc .cave-md")).toContainText(marker.slice(0, 24), {
+    timeout: 30_000,
+  });
 }
 
 test("cited sources render as chips, with no footnote plumbing left in the prose", async ({ page }) => {


### PR DESCRIPTION
Fixes `cave-n7wm5`. `cited sources render as chips` failed on CI (#4270's run) and passed on a clean re-run of the same commit — a flake, not a regression. I reproduced it locally against a cold `next dev` and found **two** cold-start races, at different layers.

## 1. The timeout arithmetic doesn't fit (what the local run proves)

`openReader`'s own waits already budget **30s** (chat surface) + **30s** (the answer) + **90s** (the reader chunk) = **150s**, and the *first* test also pays cold navigation and on-demand compilation on top — inside a **180s** describe timeout.

So the outer timeout fired mid-wait and killed the very allowance the inner 90s exists to provide:

```
Locator: locator('.cave-reader')
Expected: visible
Error: element(s) not found
Call log:
  - Expect "toBeVisible" with timeout 90000ms
  - Test timeout of 180000ms exceeded.
```

Raised to **240s**. Serial mode means only the first test is cold, so this buys headroom for one test rather than lengthening the suite.

## 2. The reader shell settles before its document (what CI hit)

`openReader` returned as soon as `.cave-reader` was visible. But every assertion after it targets `.cave-reader-doc .cave-md` on `expect()`'s **default 5s** window — not the 90s above. A shell that is visible while its prose and the citation-preview components that mount `a.cave-citation-chip` have not rendered reads as an empty document, which is exactly the CI symptom: chip count **0** instead of 2.

Now `openReader` waits for the answer's own text *inside the reader body* before returning — the same rule the artifact wait above already follows. It is fixture-agnostic: both `CITED_ANSWER` and `BARE_ANSWER` open with prose, so all seven callers settle, not just the cited one.

## Verification

Cold run with `.next` deleted:

| | result |
|---|---|
| before | 1 flaky (failed, passed on retry #1) |
| after | **7 passed, 0 retries, 0 flaky** (3.7m) |

## Notes

- I could not reproduce CI's exact symptom (chips = 0) locally — the local cold run failed at the earlier `.cave-reader` wait instead. Fix 1 is proven by local evidence; fix 2 targets the CI symptom and is a strict improvement regardless, since it removes the visible-shell/unrendered-document gap entirely.
- The spec's own comment already stated the principle: *"a test that needs a retry to go green is a test that will eventually go red for no reason."*
- Coordination: `feat/cave-xailn-reader-rewrite` is concurrently adding tests to this same file, but only appends at `@@ -269,3 +269,70 @@` and does not touch `openReader` or the describe config. Its new tests call `openReader`, so they inherit this hardening rather than conflicting with it.

Refs cave-n7wm5
