### PR TITLE
fix(research): spoken-text normalization for ~N and word+word, per-segment dead-air trim

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -840,6 +840,7 @@ test("podcast drafter normalizes TTS-hostile glyphs into spoken words", () => {
       "## Throughput → cost curve",
       "",
       "- Throughput improved 3× at ≥ 90% recall (≈ baseline cost).",
+      "- Latency held near ~5 s once the spec+regression checks ran 2+2 times.",
     ].join("\n"),
   }, "standard", "debate");
   assert.equal(content.kind, "podcast");
@@ -848,7 +849,10 @@ test("podcast drafter normalizes TTS-hostile glyphs into spoken words", () => {
   assert.ok(narration.includes("Throughput to cost curve"), `arrow spoken as 'to' (${narration})`);
   assert.ok(narration.includes("3 times at at least 90%"), `× and ≥ spoken (${narration})`);
   assert.ok(narration.includes("about baseline cost"), `≈ spoken as 'about' (${narration})`);
-  for (const glyph of ["→", "×", "≥", "≈"]) {
+  assert.ok(narration.includes("about 5 s"), `~5 spoken as 'about 5' (${narration})`);
+  assert.ok(narration.includes("spec and regression"), `word+word spoken as 'and' (${narration})`);
+  assert.ok(narration.includes("2 plus 2 times"), `digit+digit spoken as 'plus' (${narration})`);
+  for (const glyph of ["→", "×", "≥", "≈", "~", "+"]) {
     assert.ok(!narration.includes(glyph), `no raw ${glyph} reaches speech`);
   }
 });

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -830,6 +830,16 @@ const SPOKEN_GLYPHS: [RegExp, string][] = [
   [/\s*≥\s*/g, " at least "],
   [/\s*≤\s*/g, " at most "],
   [/\s*≈\s*/g, " about "],
+  // "~5" gets spoken as "five-five" or a stray glyph (cave-8nndo, Charm
+  // re-review); only the numeric-approximation use is rewritten, so paths
+  // like "~/.config" stay untouched.
+  [/~\s*(?=\d)/g, "about "],
+  // "spec+regression" gets ASR-mangled ("specs or aggression"); digits keep
+  // arithmetic sense ("2+2" → "2 plus 2"), words read as a pairing. "C++"
+  // stays intact: its second "+" is not followed by a letter, so neither
+  // pattern matches the token.
+  [/(?<=\d)\s*\+\s*(?=\d)/g, " plus "],
+  [/(?<=[A-Za-z])\+(?=[A-Za-z])/g, " and "],
 ];
 
 function normalizeSpokenGlyphs(text: string): string {

--- a/src/lib/server/research-podcast-pipeline.test.ts
+++ b/src/lib/server/research-podcast-pipeline.test.ts
@@ -18,6 +18,7 @@ const {
   concatPcmWav,
   createPodcastMediaJobDefinition,
   readBoundedElevenLabsAudio,
+  trimPcmWavSilence,
 } = await import("./research-podcast-pipeline.ts");
 const {
   openResearchGenerationMedia,
@@ -94,6 +95,27 @@ test("PCM WAV concatenation preserves one valid header and all samples", () => {
     [0, 1, 2, 3].map((index) => view.getInt16(44 + index * 2, true)),
     [1, 2, 3, 4],
   );
+});
+
+test("segment silence trimming caps dead air while preserving every audible sample", () => {
+  // 5s of silence on each side of 100 loud frames at the 8kHz test rate.
+  const silence = (seconds: number) => new Array<number>(seconds * 8_000).fill(0);
+  const speech = new Array<number>(100).fill(1_000);
+  const trimmed = trimPcmWavSilence(wav([...silence(5), ...speech, ...silence(5)]));
+  const view = new DataView(trimmed.buffer);
+  // Kept: 250ms lead (2000 frames) + speech (100) + 450ms tail (3600 frames).
+  assert.equal(view.getUint32(40, true), (2_000 + 100 + 3_600) * 2, "silence capped on both sides");
+  assert.equal(view.getInt16(44 + 2_000 * 2, true), 1_000, "first audible sample survives");
+  assert.equal(view.getInt16(44 + (2_000 + 99) * 2, true), 1_000, "last audible sample survives");
+});
+
+test("segment silence trimming leaves natural pauses and silent segments alone", () => {
+  const shortPause = new Array<number>(800).fill(0); // 100ms at 8kHz
+  const speech = new Array<number>(50).fill(2_000);
+  const natural = wav([...shortPause, ...speech, ...shortPause]);
+  assert.equal(trimPcmWavSilence(natural), natural, "sub-cap silence is untouched");
+  const silent = wav(new Array<number>(1_600).fill(0));
+  assert.equal(trimPcmWavSilence(silent), silent, "an all-silent segment passes through unmasked");
 });
 
 test("podcast uses the exact frozen provider and voice and stores measured metadata", async () => {

--- a/src/lib/server/research-podcast-pipeline.ts
+++ b/src/lib/server/research-podcast-pipeline.ts
@@ -120,6 +120,72 @@ export function pcmWavDurationMs(bytes: Uint8Array): number {
   return Math.round((parsed.dataLength / parsed.byteRate) * 1_000);
 }
 
+// ── per-segment silence trimming (cave-8nndo) ────────────────────────────────
+// TTS engines pad segments with long stretches of near-silence (Charm's
+// re-review caught ~4.9s of dead air mid-episode). Each segment is trimmed
+// before concatenation, keeping a short natural breath on both sides so turns
+// don't slam into each other.
+
+/** 16-bit amplitude below which a sample counts as silence (~ -44 dBFS). */
+const SILENCE_AMPLITUDE_THRESHOLD = 200;
+/** Silence kept before a segment's first audible frame. */
+const MAX_LEADING_SILENCE_MS = 250;
+/** Silence kept after a segment's last audible frame. */
+const MAX_TRAILING_SILENCE_MS = 450;
+
+/**
+ * Trims leading/trailing silence from a 16-bit PCM WAV segment down to the
+ * caps above. Non-16-bit audio and fully silent segments pass through
+ * unchanged — a wholly silent segment is a synthesis symptom this function
+ * must surface, not mask.
+ */
+export function trimPcmWavSilence(bytes: Uint8Array): Uint8Array {
+  const parsed = parsePcmWav(bytes);
+  if (parsed.bitsPerSample !== 16 || parsed.blockAlign < parsed.channels * 2) return bytes;
+  const view = new DataView(parsed.bytes.buffer, parsed.bytes.byteOffset, parsed.bytes.byteLength);
+  const frameBytes = parsed.blockAlign;
+  const frameCount = Math.floor(parsed.dataLength / frameBytes);
+  const audible = (frame: number): boolean => {
+    const base = parsed.dataOffset + frame * frameBytes;
+    for (let channel = 0; channel < parsed.channels; channel += 1) {
+      if (Math.abs(view.getInt16(base + channel * 2, true)) > SILENCE_AMPLITUDE_THRESHOLD) {
+        return true;
+      }
+    }
+    return false;
+  };
+  let first = 0;
+  while (first < frameCount && !audible(first)) first += 1;
+  if (first === frameCount) return bytes;
+  let last = frameCount - 1;
+  while (last > first && !audible(last)) last -= 1;
+  const framesPerMs = parsed.sampleRate / 1_000;
+  const start = Math.max(0, first - Math.round(MAX_LEADING_SILENCE_MS * framesPerMs));
+  const end = Math.min(frameCount, last + 1 + Math.round(MAX_TRAILING_SILENCE_MS * framesPerMs));
+  if (start === 0 && end === frameCount) return bytes;
+  const dataStart = parsed.dataOffset + start * frameBytes;
+  const dataLength = (end - start) * frameBytes;
+  const output = new Uint8Array(44 + dataLength);
+  const headerView = new DataView(output.buffer);
+  const text = (offset: number, value: string) =>
+    [...value].forEach((char, index) => (output[offset + index] = char.charCodeAt(0)));
+  text(0, "RIFF");
+  headerView.setUint32(4, output.length - 8, true);
+  text(8, "WAVE");
+  text(12, "fmt ");
+  headerView.setUint32(16, 16, true);
+  headerView.setUint16(20, 1, true);
+  headerView.setUint16(22, parsed.channels, true);
+  headerView.setUint32(24, parsed.sampleRate, true);
+  headerView.setUint32(28, parsed.byteRate, true);
+  headerView.setUint16(32, parsed.blockAlign, true);
+  headerView.setUint16(34, parsed.bitsPerSample, true);
+  text(36, "data");
+  headerView.setUint32(40, dataLength, true);
+  output.set(parsed.bytes.subarray(dataStart, dataStart + dataLength), 44);
+  return output;
+}
+
 function readyVoice(voices: SpeechModelReadiness[], requestedVoice?: string): SpeechModelReadiness {
   const voice = requestedVoice
     ? voices.find((candidate) => candidate.id === requestedVoice && candidate.ready)
@@ -333,11 +399,12 @@ export function createPodcastMediaJobDefinition(
                 `selected ${provider} voice changed during synthesis`,
               );
             }
-            cumulativeAudioBytes += synthesized.bytes.byteLength;
+            const trimmed = trimPcmWavSilence(synthesized.bytes);
+            cumulativeAudioBytes += trimmed.byteLength;
             if (cumulativeAudioBytes > RESEARCH_AUDIO_MAX_BYTES) {
               throw new Error("podcast audio exceeds the size limit");
             }
-            segments.push(synthesized.bytes);
+            segments.push(trimmed);
           } catch (error) {
             if (
               context.signal.aborted ||


### PR DESCRIPTION
Fixes the three audio bugs from Charm's re-review (bead cave-8nndo, notes in cave-jckyz):

- **'~5' spoken as 'five-five'** → `~` before a digit now normalizes to *about*; paths (`~/.config`) untouched.
- **'spec+regression' mangled into 'specs or aggression'** → `+` between letters reads *and*, between digits *plus*; `C++` unaffected by construction.
- **~4.9s dead air at 2:26 of the breakdown render** → new `trimPcmWavSilence` caps each synthesized segment at 250ms leading / 450ms trailing silence before `concatPcmWav`. All-silent segments pass through unchanged so synthesis failures stay audible/visible rather than masked.

## Verification
- `node --test research-podcast-pipeline.test.ts` — 12/12 (3 new: trim caps, sample preservation, natural-pause + silent pass-through)
- `node --test research-generations.test.ts` — 41/41 (glyph test extended: ~5, spec+regression, 2+2)
- `pnpm typecheck` clean