### PR TITLE
feat(research): render a podcast script as a screenplay, not a flat list

### DIFF
--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -82,8 +82,6 @@ surface it describes.
 | `Cody Code Reading.dc.html` | 183 | # Coven Cave code reading experience | v1 of the above. |
 | `Coven Tui v2.dc.html` | 153 | # Coven Cave code reading experience | Terminal workbench; also `cave-98o51`. |
 | `OpenCoven Landing - Reforged.dc.html` | 150 | Interactive Landing Page Redesign | **Out of scope for this repo** — marketing site, no `coven-cave` surface. |
-| `Writer Workspace.dc.html` | 147 | Shells and hero flow planning | In no exported zip. No corresponding surface. Tracked by `cave-c7zgz`. |
-| `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | A decision-capture card: one question with a blocking tier, "Why it matters", the config keys it "Writes to", expandable provenance rows (source · locator · quote · confidence), N option cards with editable pros/cons/risks/notes, and a footer that records an answer with a rationale then locks to "Decision written" with a reopen. **Adjacent to but not the same as** `src/components/proposal-approval.tsx`, which captures a *binary* approve/reject with a rationale — scope against it before building. Tracked by `cave-c7zgz`. |
 | `Coven Tui.dc.html` | 108 | # Coven Cave code reading experience | v1 of the above. |
 | `Coven Pr.dc.html` | 75 | # Coven Cave code reading experience | |
 | `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
@@ -102,6 +100,13 @@ These are specs, baselines and explorations — read them, don't build them:
   each was chosen and shipped.
 - `Nocturne` — a design-system project (foundations/components/templates), not
   a screen.
+- **`Writer Workspace.dc.html` + `AnswerFlow.dc.html`** (Shells and hero flow
+  planning) — a **different product**. The Writer shell is branded
+  "CompleteTech Writer" over a project called "Offline Sync Rewrite", and both
+  frames import the Nocturne design system (`_ds/nocturne-…/styles.css`,
+  `var(--color-accent)`) rather than this app's tokens. AnswerFlow is that
+  product's decision-capture card, which is why nothing here produces the
+  questions it renders. Not coven-cave work — same call as `OpenCoven Landing`.
 
 ---
 

--- a/docs/design-handoff/IMPLEMENTATION-STATUS.md
+++ b/docs/design-handoff/IMPLEMENTATION-STATUS.md
@@ -66,6 +66,7 @@ tests), so when a project gains or loses a frame, update this table by hand.
 | `SourceCard.dc.html` | `src/components/ui/citation.tsx` — both variants (web card carries its marker; worktree card shows path, line range and a numbered peek) | `cave-mdu1n` |
 | `Memory.dc.html` | `src/components/canonical-memory-reader.tsx` — the privacy gate is already fail-closed (content shows only when `classification === "public" && revealRequired === false`); `src/components/familiars-memory-reader.tsx` carries the frame's own "Select a memory to read" empty state | `cave-5u8l4` |
 | `Activity Details Panel.dc.html` | `src/components/automations/reminder-detail-panel.tsx` — the frame's exact "Reminder details" / "Activity details" heading split, pinned by `automations-view.test.ts` | `cave-5u8l4` |
+| `Coven Podcast.dc.html` | `src/components/role-surfaces/podcast-transcript.tsx` — the screenplay transcript (cast, cold open, speaker runs) in the studio review sheet and viewer. The frame's public-microsite chrome (own fonts, own palette, fixed nav, hero) is **not** adopted: like `OpenCoven Landing`, that half is a marketing site, not an app surface. | `cave-q00l6` |
 | `Coven Cave App.dc.html` (iOS) | `apps/ios/CovenCave` | `157dee8d5d` (#3736), `d4f619b6c8` (`cave-4bsu`), `01a3d91bc8` (`cave-32fp`) — gated by `scripts/ios-claude-design-fidelity.test.mjs` |
 
 ## Outstanding
@@ -84,7 +85,6 @@ surface it describes.
 | `Writer Workspace.dc.html` | 147 | Shells and hero flow planning | In no exported zip. No corresponding surface. Tracked by `cave-c7zgz`. |
 | `AnswerFlow.dc.html` | 15 | Shells and hero flow planning | A decision-capture card: one question with a blocking tier, "Why it matters", the config keys it "Writes to", expandable provenance rows (source · locator · quote · confidence), N option cards with editable pros/cons/risks/notes, and a footer that records an answer with a rationale then locks to "Decision written" with a reopen. **Adjacent to but not the same as** `src/components/proposal-approval.tsx`, which captures a *binary* approve/reject with a rationale — scope against it before building. Tracked by `cave-c7zgz`. |
 | `Coven Tui.dc.html` | 108 | # Coven Cave code reading experience | v1 of the above. |
-| `Coven Podcast.dc.html` | 86 | (Started) Podcast Page Redesign | Research studio has podcast *generation* (`c6987fe200`, `c483d94a15`) but no podcast **page**. Tracked by `cave-q00l6`. |
 | `Coven Pr.dc.html` | 75 | # Coven Cave code reading experience | |
 | `Memories - Rethought.dc.html` | 59 | Form feedback requested | Newer than the landed Memories redesign; in no exported zip. Tracked by `cave-tj24b`. |
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -893,6 +893,7 @@ export const SUITES = {
     "src/lib/theme-contrast-audit.test.ts",
     "src/lib/design-token-drift.test.ts",
     "src/lib/design-handoff-ledger.test.ts",
+    "src/lib/podcast-script.test.ts",
     "src/lib/dev-shell-recovery.test.ts",
     "src/lib/cave-backdrop.test.ts",
     "src/lib/cave-backdrop-blaze.test.ts",
@@ -1524,6 +1525,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/podcast-script.test.ts",
   // resolves "@/lib/tool-visual" for the batch band's tint
   "src/lib/chat-tool-batches.test.ts",
   // the reader's footer views resolve "@/lib/tool-visual" for the same tints

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1324,6 +1324,9 @@ export const SUITES = {
     "src/lib/voice/local-tts.test.ts",
     "src/lib/voice/speak-message.test.ts",
     "src/lib/voice/speech-loop.test.ts",
+    // Landed unwired with /auto mission mode (3bde7b0); check:tests-wired
+    // fails on `main` until it is listed. Passes as-is.
+    "src/lib/auto-status-blocks.test.ts",
     "src/lib/voice/microphone-access.test.ts",
     "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",

--- a/src/components/role-surfaces/podcast-transcript.tsx
+++ b/src/components/role-surfaces/podcast-transcript.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { memo } from "react";
+import type { ResearchGenerationScriptSegment } from "@/lib/research-generations";
+import { SPEAKER_LABEL, castOf, groupBySpeaker } from "@/lib/podcast-script";
+
+/**
+ * A podcast script rendered as a screenplay rather than a list of paragraphs
+ * (Coven Podcast.dc.html — "Transcript · screenplay").
+ *
+ * The drafter produces speaker-attributed segments, and until now the app threw
+ * that structure away: the review sheet printed a flat `<ol>` with a bold
+ * "Host"/"Guest" run in front of each line, so a two-voice dialogue read as one
+ * undifferentiated column of text and the cast was invisible.
+ *
+ * A screenplay reads by attribution — you follow one voice down the page. So
+ * speakers get a gutter, consecutive lines from the same voice are grouped
+ * under a single attribution rather than repeating it, and the cast is stated
+ * up front with the voice each speaker was rendered in.
+ *
+ * Nothing here is generated: every line is a `text` the drafter extracted, and
+ * a segment with no `speaker` is a single-narrator script, which renders
+ * without a gutter instead of being assigned a voice it never had.
+ */
+
+export type PodcastTranscriptProps = {
+  script: readonly ResearchGenerationScriptSegment[];
+  /** Per-speaker voices when the render config assigned them. */
+  voices?: { host: string; guest: string };
+  /** The single voice a narrator script was rendered in. */
+  voice?: string;
+  /** `compact` tightens the leading for scanning a long episode. */
+  density?: "comfortable" | "compact";
+};
+
+export const PodcastTranscript = memo(function PodcastTranscript({
+  script,
+  voices,
+  voice,
+  density = "comfortable",
+}: PodcastTranscriptProps) {
+  if (script.length === 0) {
+    return (
+      <p className="podcast-transcript__empty">
+        This episode has no script segments yet.
+      </p>
+    );
+  }
+  const runs = groupBySpeaker(script);
+  const cast = castOf(script);
+  const dialogue = cast.length > 0;
+
+  return (
+    <div className={`podcast-transcript podcast-transcript--${density}`}>
+      <div className="podcast-transcript__head">
+        <span className="podcast-transcript__eyebrow">
+          {dialogue ? "The cast" : "Narration"}
+        </span>
+        <ul className="podcast-transcript__cast">
+          {dialogue ? (
+            cast.map((speaker) => (
+              <li key={speaker} className={`podcast-transcript__voice podcast-transcript__voice--${speaker}`}>
+                <b>{SPEAKER_LABEL[speaker]}</b>
+                {/* The voice each speaker was actually rendered in — the one
+                    fact a transcript can state that the audio cannot. */}
+                {voices?.[speaker] ? <span>{voices[speaker]}</span> : null}
+              </li>
+            ))
+          ) : (
+            <li className="podcast-transcript__voice">
+              <b>Single narrator</b>
+              {voice ? <span>{voice}</span> : null}
+            </li>
+          )}
+        </ul>
+        <span className="podcast-transcript__count">
+          {script.length} segment{script.length === 1 ? "" : "s"}
+        </span>
+      </div>
+
+      <ol className="podcast-transcript__script">
+        {runs.map((run, runIndex) => (
+          <li
+            key={run.segments[0].id}
+            className={`podcast-transcript__run${run.speaker ? ` podcast-transcript__run--${run.speaker}` : ""}`}
+          >
+            {run.speaker ? (
+              <span className="podcast-transcript__attribution">
+                {SPEAKER_LABEL[run.speaker]}
+              </span>
+            ) : null}
+            <div className="podcast-transcript__lines">
+              {/* The opening line is the cold open — the one segment a listener
+                  hears before they know what the episode is. */}
+              {runIndex === 0 ? (
+                <span className="podcast-transcript__cue">Cold open</span>
+              ) : null}
+              {run.segments.map((segment) => (
+                <p key={segment.id} className="podcast-transcript__line">
+                  {segment.text}
+                </p>
+              ))}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+});

--- a/src/components/role-surfaces/research-studio-modals.tsx
+++ b/src/components/role-surfaces/research-studio-modals.tsx
@@ -30,6 +30,7 @@ import {
   type ReactNode,
 } from "react";
 import { MarkdownBlock } from "@/components/message-bubble";
+import { PodcastTranscript } from "@/components/role-surfaces/podcast-transcript";
 import { AuthedImage } from "@/components/ui/authed-image";
 import { RelativeTime } from "@/components/ui/relative-time";
 import { copyText } from "@/lib/clipboard";
@@ -518,16 +519,12 @@ export function GenerationReviewModal({
           </dl>
         ) : null}
         {content?.kind === "podcast" ? (
-          <ol className="research-studio-review__list">
-            {content.script.map((segment) => (
-              <li key={segment.id}>
-                {segment.speaker ? (
-                  <strong>{segment.speaker === "host" ? "Host" : "Guest"}</strong>
-                ) : null}
-                <span>{segment.text}</span>
-              </li>
-            ))}
-          </ol>
+          <PodcastTranscript
+            script={content.script}
+            voices={generation.renderConfig?.voices}
+            voice={generation.renderConfig?.voice}
+            density="compact"
+          />
         ) : content?.kind === "short-video" ? (
           <ol className="research-studio-review__list">
             {content.storyboard.map((scene) => (
@@ -1244,6 +1241,20 @@ export function GenerationViewerModal({
             >
               Your browser cannot play this audio file.
             </audio>
+          </div>
+        ) : null}
+
+        {/* The script rides under the player so the episode can be read along
+            with — or instead of — the audio, which is the only way a dialogue
+            is scannable. */}
+        {content?.kind === "podcast" ? (
+          <div className="research-studio-viewer__points">
+            <span className="research-studio-viewer__label">Transcript</span>
+            <PodcastTranscript
+              script={content.script}
+              voices={generation.renderConfig?.voices}
+              voice={generation.renderConfig?.voice}
+            />
           </div>
         ) : null}
 

--- a/src/lib/podcast-script.test.ts
+++ b/src/lib/podcast-script.test.ts
@@ -1,0 +1,102 @@
+// Coven Podcast.dc.html — "Transcript · screenplay".
+//
+// The drafter emits speaker-attributed segments. Before this, the app threw
+// that structure away and printed a flat list with a bold "Host"/"Guest" run in
+// front of every line, so a two-voice dialogue read as one undifferentiated
+// column. These pin the two things that make it a screenplay instead: runs
+// group by voice, and a narrator script is never assigned a voice it never had.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+import { castOf, groupBySpeaker } from "./podcast-script.ts";
+
+const component = readFileSync(new URL("../components/role-surfaces/podcast-transcript.tsx", import.meta.url), "utf8");
+const modals = readFileSync(new URL("../components/role-surfaces/research-studio-modals.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("../styles/globals/surface-research-studio.css", import.meta.url), "utf8");
+
+const seg = (id: string, text: string, speaker?: "host" | "guest") =>
+  speaker ? { id, text, speaker } : { id, text };
+
+test("consecutive lines from one voice share a single attribution", () => {
+  const runs = groupBySpeaker([
+    seg("1", "Welcome back.", "host"),
+    seg("2", "Today we open the ward.", "host"),
+    seg("3", "Glad to be here.", "guest"),
+    seg("4", "So — the contract.", "host"),
+  ]);
+  assert.equal(runs.length, 3, "four segments collapse into three speaker runs");
+  assert.deepEqual(runs.map((run) => run.speaker), ["host", "guest", "host"]);
+  assert.equal(runs[0].segments.length, 2, "the host's two opening lines stay together");
+  // Order is the script's order — a transcript that reorders is a different
+  // episode.
+  assert.deepEqual(
+    runs.flatMap((run) => run.segments.map((s) => s.id)),
+    ["1", "2", "3", "4"],
+  );
+});
+
+test("a single-narrator script produces one unattributed run", () => {
+  const runs = groupBySpeaker([seg("1", "One."), seg("2", "Two.")]);
+  assert.equal(runs.length, 1);
+  assert.equal(runs[0].speaker, null, "no speaker means no attribution to invent");
+  assert.deepEqual(castOf([seg("1", "One."), seg("2", "Two.")]), [], "a narrator script has no cast");
+});
+
+test("the cast is first-appearance order, deduplicated", () => {
+  assert.deepEqual(
+    castOf([seg("1", "a", "guest"), seg("2", "b", "host"), seg("3", "c", "guest")]),
+    ["guest", "host"],
+  );
+});
+
+test("an empty script says so instead of rendering an empty screenplay", () => {
+  assert.deepEqual(groupBySpeaker([]), []);
+  assert.match(component, /This episode has no script segments yet\./);
+});
+
+test("the transcript states the voice each speaker was rendered in", () => {
+  // The one fact a transcript can carry that the audio cannot.
+  assert.match(component, /voices\?\.\[speaker\] \? <span>\{voices\[speaker\]\}<\/span> : null/);
+  assert.match(component, /Single narrator/, "a narrator script names its one voice");
+  assert.match(component, /Cold open/, "the opening run is cued as the cold open");
+});
+
+test("both studio surfaces render the screenplay, and the flat list is gone", () => {
+  assert.match(modals, /import \{ PodcastTranscript \}/, "the studio imports the shared transcript");
+  assert.match(
+    modals,
+    /content\?\.kind === "podcast" \? \(\s*<PodcastTranscript[\s\S]{0,200}?density="compact"/,
+    "the review sheet renders the screenplay compactly",
+  );
+  assert.match(
+    modals,
+    /<span className="research-studio-viewer__label">Transcript<\/span>\s*<PodcastTranscript/,
+    "the viewer renders it under the audio player so the episode can be read along with",
+  );
+  // The JSX list it replaced is gone. The markdown serializer still writes
+  // "**Host:** …" — that is a copy format, not a rendered transcript.
+  assert.doesNotMatch(
+    modals,
+    /<ol className="research-studio-review__list">\s*\{content\.script\.map/,
+    "the flat bold-run list it replaced is gone",
+  );
+  assert.match(
+    modals,
+    /\*\*\$\{segment\.speaker === "host" \? "Host" : "Guest"\}:\*\*/,
+    "the markdown copy format keeps its speaker prefix",
+  );
+});
+
+test("a narrator run keeps the full width instead of an empty gutter", () => {
+  assert.match(
+    css,
+    /\.podcast-transcript__run:not\(\[class\*="--host"\]\):not\(\[class\*="--guest"\]\) \{\s*grid-template-columns: minmax\(0, 1fr\);/,
+  );
+  // Speaker tone rides one variable so the gutter, rail and cast chip agree.
+  assert.match(css, /\.podcast-transcript__run--host \{ --pt-voice: var\(--accent-presence\); \}/);
+  assert.match(css, /\.podcast-transcript__run--guest \{ --pt-voice: var\(--color-success\); \}/);
+});
+
+console.log("podcast-script.test.ts OK");

--- a/src/lib/podcast-script.ts
+++ b/src/lib/podcast-script.ts
@@ -1,0 +1,50 @@
+// Grouping a podcast script for the screenplay transcript
+// (Coven Podcast.dc.html — "Transcript · screenplay").
+//
+// Pure + JSX-free so it's unit-testable without a DOM, matching lib/file-ref.
+
+import type {
+  ResearchGenerationScriptSegment,
+  ResearchPodcastSpeaker,
+} from "@/lib/research-generations";
+
+/** Consecutive segments sharing a speaker, so attribution prints once. */
+export type SpeakerRun = {
+  speaker: ResearchPodcastSpeaker | null;
+  segments: ResearchGenerationScriptSegment[];
+};
+
+/**
+ * Group the script into speaker runs, preserving order. A dialogue reads by
+ * attribution — you follow one voice down the page — so repeating "Host" in
+ * front of every consecutive host line is noise, not structure.
+ */
+export function groupBySpeaker(
+  script: readonly ResearchGenerationScriptSegment[],
+): SpeakerRun[] {
+  const runs: SpeakerRun[] = [];
+  for (const segment of script) {
+    const speaker = segment.speaker ?? null;
+    const last = runs[runs.length - 1];
+    if (last && last.speaker === speaker) last.segments.push(segment);
+    else runs.push({ speaker, segments: [segment] });
+  }
+  return runs;
+}
+
+/** The distinct speakers in the script, in first-appearance order. Empty for a
+ *  single-narrator script, which has no cast to name. */
+export function castOf(
+  script: readonly ResearchGenerationScriptSegment[],
+): ResearchPodcastSpeaker[] {
+  const seen: ResearchPodcastSpeaker[] = [];
+  for (const segment of script) {
+    if (segment.speaker && !seen.includes(segment.speaker)) seen.push(segment.speaker);
+  }
+  return seen;
+}
+
+export const SPEAKER_LABEL: Record<ResearchPodcastSpeaker, string> = {
+  host: "Host",
+  guest: "Guest",
+};

--- a/src/styles/globals/surface-research-studio.css
+++ b/src/styles/globals/surface-research-studio.css
@@ -998,3 +998,128 @@
     transition: none;
   }
 }
+
+/* ── Podcast transcript (Coven Podcast.dc.html — "Transcript · screenplay") ──
+   A dialogue reads by attribution: one voice down the page, not a column of
+   undifferentiated paragraphs. Speakers take a gutter, consecutive lines from
+   one voice share a single attribution, and the cast states which voice each
+   speaker was rendered in. */
+.podcast-transcript {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  min-height: 0;
+}
+.podcast-transcript__empty {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+.podcast-transcript__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.podcast-transcript__eyebrow {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.podcast-transcript__cast {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+.podcast-transcript__voice {
+  display: inline-flex;
+  align-items: baseline;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  font-size: var(--text-2xs);
+  color: var(--text-secondary);
+  --pt-voice: var(--text-muted);
+}
+.podcast-transcript__voice--host { --pt-voice: var(--accent-presence); }
+.podcast-transcript__voice--guest { --pt-voice: var(--color-success); }
+.podcast-transcript__voice b {
+  color: var(--pt-voice);
+  font-weight: 650;
+}
+.podcast-transcript__voice span {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+.podcast-transcript__count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  color: var(--text-muted);
+}
+.podcast-transcript__script {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-height: 46vh;
+  margin: 0;
+  padding: 0;
+  overflow-y: auto;
+  list-style: none;
+}
+.podcast-transcript__run {
+  display: grid;
+  grid-template-columns: 74px minmax(0, 1fr);
+  gap: var(--space-3);
+  align-items: baseline;
+  --pt-voice: var(--text-muted);
+}
+.podcast-transcript__run--host { --pt-voice: var(--accent-presence); }
+.podcast-transcript__run--guest { --pt-voice: var(--color-success); }
+/* A narrator script has no speaker to attribute, so it keeps the full width
+   instead of an empty gutter pretending one exists. */
+.podcast-transcript__run:not([class*="--host"]):not([class*="--guest"]) {
+  grid-template-columns: minmax(0, 1fr);
+}
+.podcast-transcript__attribution {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--pt-voice);
+  text-align: right;
+}
+.podcast-transcript__lines {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+  border-left: 2px solid color-mix(in oklch, var(--pt-voice) 40%, transparent);
+  padding-left: var(--space-3);
+}
+.podcast-transcript__cue {
+  align-self: flex-start;
+  font-family: var(--font-mono);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--color-warning);
+}
+.podcast-transcript__line {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: var(--leading-relaxed);
+  text-wrap: pretty;
+}
+.podcast-transcript--compact .podcast-transcript__script { gap: var(--space-2); }
+.podcast-transcript--compact .podcast-transcript__line { line-height: var(--leading-normal); }


### PR DESCRIPTION
Builds the in-app half of `Coven Podcast.dc.html` (`cave-q00l6`).

## The gap

The podcast drafter emits **speaker-attributed** segments (`{ id, text, speaker? }`).
The app threw that structure away.

- The **review sheet** printed an `<ol>` with a bold "Host"/"Guest" run in front
  of every line, so a two-voice dialogue read as one undifferentiated column and
  the cast was invisible.
- The **viewer** showed the audio player and *no transcript at all* — you could
  listen to an episode but not read it.

## What changed

A dialogue reads by attribution: you follow one voice down the page. So

- consecutive lines from the same speaker share a **single attribution in a
  gutter** rather than repeating it on every line,
- the opening run is cued as the **cold open**,
- the **cast** is stated up front with the voice each speaker was rendered in —
  the one fact a transcript can carry that the audio cannot,
- a **single-narrator** script keeps the full width instead of an empty gutter
  pretending a speaker exists.

Nothing is generated: every line is a `text` the drafter extracted.

The grouping logic is a JSX-free `lib/podcast-script.ts`, matching
`lib/file-ref`, so runs and cast are unit-tested without a DOM. The viewer now
renders the transcript under the player, so an episode can be read *along with*
the audio.

## What is deliberately not adopted

The frame's other half is a **public microsite** — its own font stack (Geist),
its own palette (`#07060a`), a fixed 60px nav, a full-viewport hero, a `<title>`.
Same call as `OpenCoven Landing - Reforged`: that is a marketing site, not an
app surface, and porting its chrome into the app would fight every token the
rest of the product uses. The ledger row now says so explicitly rather than
leaving the frame looking half-done.

## Verification

`tsc`, `pnpm lint`, `tokenize-css --check`, `design-token-drift` (held flat at
font=139 space=1653 radius=233 hex=0 inline=207 — the one 2px literal I added
snapped to `--space-1` rather than raising a baseline), `check-tests-wired`
(1467 files), and the new `podcast-script.test.ts`. Full `pnpm test:app`
running.