### PR TITLE
fix(chat): normalize pseudo-lists and strip orphan footnote refs

### DIFF
--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -74,6 +74,7 @@ import {
   closeTrailingFence,
   createMarkdownRenderGate,
   getRenderedMarkdown as renderCacheGet,
+  normalizePseudoLists,
   scanFenceFilenames,
   type MarkdownRenderGate,
 } from "@/lib/message-markdown-stream";
@@ -668,8 +669,13 @@ async function mdToHtml(
   // cascades and swallows the rest of the message as a fake code block.
   // Pre-scan filenames (positional, one per fence opener) so we can re-attach
   // them after stripping the suffix for the parser.
-  const fenceFilenames = scanFenceFilenames(markdown);
-  const normalized = markdown.replace(/^(\s*```\s*[\w+.-]+):\S+/gm, "$1");
+  // Pseudo-list normalization runs first: @create-markdown/core lacks lazy
+  // continuation, so wrapped list items (and `1)` / `**1. Title**` markers)
+  // otherwise render as dense paragraph fragments. Fence lines pass through
+  // untouched, so the positional filename scan stays aligned.
+  const listNormalized = normalizePseudoLists(markdown);
+  const fenceFilenames = scanFenceFilenames(listNormalized);
+  const normalized = listNormalized.replace(/^(\s*```\s*[\w+.-]+):\S+/gm, "$1");
 
   const blocks: Block[] = coalesceAdjacentNumberedLists(parse(normalized));
 

--- a/src/lib/citations.test.ts
+++ b/src/lib/citations.test.ts
@@ -305,3 +305,38 @@ test("parseCitations reads a worktree file reference into a repo citation", () =
     assert.equal(parsed.citations[0].domain, "example.com");
   }
 });
+
+test("orphan numeric footnote refs are stripped instead of leaking literal text", () => {
+  // No definitions anywhere in the turn — the [^1] must not render as prose.
+  const cited = renderCitedBody("The quality levers[^1]: prompts, seeds, and reviews.");
+  assert.equal(cited.body, "The quality levers: prompts, seeds, and reviews.");
+  assert.equal(cited.citations.length, 0);
+
+  // Definitions exist but one ref points at a label that was never defined.
+  const mixed = renderCitedBody([
+    "Known[^a] and unknown[^2].",
+    "",
+    '[^a]: https://example.com/guide "A web guide"',
+  ].join("\n"));
+  assert.match(mixed.body, /Known\[example\.com\]\(#cite-1\) and unknown\./);
+});
+
+test("orphan stripping leaves code spans, fences, and non-numeric labels alone", () => {
+  const cited = renderCitedBody([
+    "Match with `[^1]` inside code[^1].",
+    "```js",
+    "const re = /[^1]/;",
+    "```",
+    "A regex class [^a-z] stays put.",
+  ].join("\n"));
+  assert.equal(
+    cited.body,
+    [
+      "Match with `[^1]` inside code.",
+      "```js",
+      "const re = /[^1]/;",
+      "```",
+      "A regex class [^a-z] stays put.",
+    ].join("\n"),
+  );
+});

--- a/src/lib/citations.ts
+++ b/src/lib/citations.ts
@@ -256,6 +256,10 @@ export function sourcesToCitations(sources: readonly SourceLike[]): Citation[] {
 const DEF_RE = /^\[\^([^\]]+)\]:[ \t]+(.+?)[ \t]*$/gm;
 // An inline reference: `[^label]` NOT immediately followed by `:` (that's a def).
 const REF_RE = /\[\^([^\]]+)\](?!:)/g;
+// After definition lines are removed, a remaining `[^label]` is a reference
+// even when a colon follows it in prose ("the levers[^1]: are…") — REF_RE's
+// lookahead would skip exactly that shape and leak it as literal text.
+const REF_AFTER_DEFS_RE = /\[\^([^\]]+)\]/g;
 const MD_LINK_RE = /^\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)(?:[ \t]+—[ \t]+(.+))?$/;
 const ANGLE_URL_RE = /^<(https?:\/\/[^\s>]+)>(?:[ \t]+—[ \t]+(.+))?$/;
 const BARE_URL_RE = /^(https?:\/\/\S+)(?:[ \t]+"([^"]+)")?(?:[ \t]+—[ \t]+(.+))?$/;
@@ -341,21 +345,55 @@ export type ParsedCitations = {
   order: Map<string, number>;
 };
 
+/** A numeric footnote label (`[^1]`). Only these are safe to strip when
+ * orphaned — an alphabetic `[^a-z]` in prose is more likely a regex class. */
+const NUMERIC_LABEL_RE = /^\d{1,4}$/;
+
+/**
+ * Apply `fn` to the stretches of `text` outside fenced code blocks and inline
+ * code spans, leaving code verbatim. Line-based fences (```), backtick-run
+ * aware inline spans.
+ */
+function replaceOutsideCode(text: string, fn: (segment: string) => string): string {
+  const lines = text.split("\n");
+  let inFence = false;
+  const out = lines.map((line) => {
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      return line;
+    }
+    if (inFence) return line;
+    // Split into inline-code spans (kept) and prose (transformed).
+    return line
+      .split(/(`+[^`]*`+)/g)
+      .map((part) => (part.startsWith("`") ? part : fn(part)))
+      .join("");
+  });
+  return out.join("\n");
+}
+
 export function renderCitationReferences(
   text: string,
   parsed: Pick<ParsedCitations, "citations" | "order">,
 ): string {
-  if (parsed.citations.length === 0) return text;
   const byNumber = new Map(parsed.citations.map((citation) => [citation.n, citation]));
   const withoutDefinitions = text.replace(DEF_RE, "");
   const body = withoutDefinitions === text
     ? text
     : withoutDefinitions.replace(/\n{3,}/g, "\n\n").trimEnd();
-  return body.replace(REF_RE, (whole, label: string) => {
-    const n = parsed.order.get(label);
-    const citation = n ? byNumber.get(n) : undefined;
-    return citation ? `[${citationInlineLabel(citation)}](#cite-${n})` : whole;
-  });
+  if (!body.includes("[^")) return body;
+  return replaceOutsideCode(body, (segment) =>
+    segment.replace(REF_AFTER_DEFS_RE, (whole, label: string) => {
+      const n = parsed.order.get(label);
+      const citation = n ? byNumber.get(n) : undefined;
+      if (citation) return `[${citationInlineLabel(citation)}](#cite-${n})`;
+      // Orphan ref — the model cited a footnote it never defined. Leaking the
+      // literal `[^1]` into prose reads as a typo, so numeric orphans are
+      // dropped. Non-numeric labels stay: they may be regex classes or other
+      // legitimate bracket text.
+      return NUMERIC_LABEL_RE.test(label) ? "" : whole;
+    }),
+  );
 }
 
 /**
@@ -411,7 +449,9 @@ export function parseCitations(text: string): ParsedCitations {
  */
 export function renderCitedBody(text: string): { body: string; citations: Citation[] } {
   const parsed = parseCitations(text);
-  if (parsed.citations.length === 0) return { body: text, citations: [] };
+  // Run the reference pass even with zero citations: it strips orphan numeric
+  // refs (`[^1]` with no matching definition) that would otherwise leak into
+  // the rendered prose as literal text.
   return {
     body: renderCitationReferences(parsed.body, parsed),
     citations: parsed.citations,

--- a/src/lib/message-markdown-stream.test.ts
+++ b/src/lib/message-markdown-stream.test.ts
@@ -82,3 +82,45 @@ test("a trailing callback keeps the stamp issued before a single settle", async 
   await Promise.resolve();
   assert.equal(gate.apply(scheduledStamp), false);
 });
+
+test("normalizePseudoLists joins wrapped item lines back onto their marker (lazy continuation)", () => {
+  const { normalizePseudoLists } = markdownStream;
+  assert.equal(
+    normalizePseudoLists("1. **one** — text that\nwraps onto a second line\n2. **two** — more"),
+    "1. **one** — text that wraps onto a second line\n2. **two** — more",
+  );
+  assert.equal(
+    normalizePseudoLists("- one — text\nwraps\n- two"),
+    "- one — text wraps\n- two",
+  );
+});
+
+test("normalizePseudoLists converts paren and bold-wrapped numbered markers in real runs", () => {
+  const { normalizePseudoLists } = markdownStream;
+  assert.equal(
+    normalizePseudoLists("Levers:\n1) one\n2) two\n3) three"),
+    "Levers:\n1. one\n2. two\n3. three",
+  );
+  assert.equal(
+    normalizePseudoLists("**1. Skills-first** — start here\n**2. Pipeline** — capture"),
+    "1. **Skills-first** — start here\n2. **Pipeline** — capture",
+  );
+  // A lone `1)` line is prose, not a list.
+  assert.equal(normalizePseudoLists("Levers:\n1) only item"), "Levers:\n1) only item");
+});
+
+test("normalizePseudoLists never rewrites fenced code and stops at block boundaries", () => {
+  const { normalizePseudoLists } = markdownStream;
+  const fenced = "```txt\n1) not a list\nwrapped\n2) still code\n```";
+  assert.equal(normalizePseudoLists(fenced), fenced);
+  // Blank lines end a run; paragraphs after the list stay separate.
+  assert.equal(
+    normalizePseudoLists("1. one\n2. two\n\nA closing paragraph."),
+    "1. one\n2. two\n\nA closing paragraph.",
+  );
+  // Headings and quotes are never swallowed as continuations.
+  assert.equal(
+    normalizePseudoLists("1. one\n# Heading\n2. two"),
+    "1. one\n# Heading\n2. two",
+  );
+});

--- a/src/lib/message-markdown-stream.ts
+++ b/src/lib/message-markdown-stream.ts
@@ -60,6 +60,128 @@ export function closeTrailingFence(markdown: string): string {
   return inFence ? `${markdown}\n\`\`\`` : markdown;
 }
 
+// ── Pseudo-list normalization ────────────────────────────────────────────────
+// @create-markdown/core has no lazy-continuation support: a wrapped list-item
+// line splits the list into `numberedList, paragraph, numberedList` fragments,
+// and single newlines inside a paragraph collapse to spaces — so a model reply
+// whose items wrap (or that uses `1)` / `**1. Title**` markers) renders as one
+// dense wall of text. Normalize those shapes into real markdown lists before
+// parsing. Content inside code fences is never touched.
+
+/** `1. item` (real numbered marker the parser already understands). */
+const NUM_MARKER_RE = /^(\s{0,3})(\d{1,3})\.\s+\S/;
+/** `1) item` (paren marker the parser treats as prose). */
+const PAREN_MARKER_RE = /^(\s{0,3})(\d{1,3})\)\s+(\S.*)$/;
+/** `**1. Title** — rest` (bold-wrapped marker the parser treats as prose). */
+const BOLD_NUM_MARKER_RE = /^(\s{0,3})\*\*(\d{1,3})[.)]\s*([^*]+?)\*\*(.*)$/;
+/** `- item` / `* item` / `+ item`. */
+const BULLET_MARKER_RE = /^(\s{0,3})[-*+]\s+\S/;
+/** Lines a lazy continuation must never swallow. */
+const BLOCK_START_RE = /^\s*(?:#{1,6}\s|>|```|\||[-*_]\s*(?:[-*_]\s*){2,}$|={3,}\s*$)/;
+
+type ListMarkerKind = "numbered" | "paren" | "boldnum" | "bullet";
+
+function listMarkerKind(line: string): ListMarkerKind | null {
+  if (BLOCK_START_RE.test(line)) return null;
+  if (NUM_MARKER_RE.test(line)) return "numbered";
+  if (PAREN_MARKER_RE.test(line)) return "paren";
+  if (BOLD_NUM_MARKER_RE.test(line)) return "boldnum";
+  if (BULLET_MARKER_RE.test(line)) return "bullet";
+  return null;
+}
+
+/**
+ * Rewrite pseudo-list shapes into lists the markdown parser recognizes:
+ * wrapped item text is joined back onto its marker line (CommonMark lazy
+ * continuation, which the parser lacks), and — when a run holds two or more
+ * numbered markers — `1)` markers become `1.` and `**1. Title**` unwraps to
+ * `1. **Title**`. Fenced code passes through verbatim.
+ */
+export function normalizePseudoLists(markdown: string): string {
+  const lines = markdown.split("\n");
+  const out: string[] = [];
+  let inFence = false;
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (/^\s*```/.test(line)) {
+      inFence = !inFence;
+      out.push(line);
+      i += 1;
+      continue;
+    }
+    if (inFence) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+
+    const startKind = listMarkerKind(line);
+    if (!startKind) {
+      out.push(line);
+      i += 1;
+      continue;
+    }
+
+    // Collect the contiguous run: marker lines of the same family plus the
+    // continuation lines attached to them. Blank lines, fences, block starts,
+    // and other-family markers end the run.
+    const family = startKind === "bullet" ? "bullet" : "numbered";
+    type RunLine = { text: string; kind: ListMarkerKind | null };
+    const run: RunLine[] = [];
+    let j = i;
+    while (j < lines.length) {
+      const candidate = lines[j];
+      if (!candidate.trim() || /^\s*```/.test(candidate)) break;
+      if (BLOCK_START_RE.test(candidate)) break;
+      const kind = listMarkerKind(candidate);
+      if (kind) {
+        const candidateFamily = kind === "bullet" ? "bullet" : "numbered";
+        if (candidateFamily !== family) break;
+        run.push({ text: candidate, kind });
+      } else {
+        run.push({ text: candidate, kind: null });
+      }
+      j += 1;
+    }
+
+    const markerCount = run.filter((r) => r.kind !== null).length;
+    // Paren/bold markers only convert when the run clearly reads as a list
+    // (two or more numbered markers); a lone `1)` or `**1.**` line stays prose.
+    const convert = family === "numbered" && markerCount >= 2;
+    // Continuations rejoin their item whenever the run holds a real list the
+    // parser would otherwise fragment.
+    const join = convert || run.some((r) => r.kind === "numbered" || r.kind === "bullet");
+
+    if (!convert && !join) {
+      for (const r of run) out.push(r.text);
+      i = j;
+      continue;
+    }
+
+    for (const r of run) {
+      let text = r.text;
+      if (convert && r.kind === "paren") {
+        text = text.replace(PAREN_MARKER_RE, (_m, indent, n, rest) => `${indent}${n}. ${rest}`);
+      } else if (convert && r.kind === "boldnum") {
+        text = text.replace(
+          BOLD_NUM_MARKER_RE,
+          (_m, indent, n, title, rest) => `${indent}${n}. **${title.trim()}**${rest}`,
+        );
+      }
+      if (r.kind === null && join && out.length > 0) {
+        out[out.length - 1] = `${out[out.length - 1].replace(/\s+$/, "")} ${text.trim()}`;
+        continue;
+      }
+      out.push(text);
+    }
+    i = j;
+  }
+
+  return out.join("\n");
+}
+
 /** Preserve filename labels while normalizing fence info for the markdown parser. */
 export function scanFenceFilenames(markdown: string): Array<string | null> {
   const filenames: Array<string | null> = [];


### PR DESCRIPTION
Bead: cave-olkpe. Fixes the wall-of-text rendering Val reported from a Sage chat reply.

## Problem
1. `@create-markdown/core` has no lazy-continuation: a list item whose text wraps onto the next line splits the list into `numberedList, paragraph, numberedList` fragments, and single newlines inside paragraphs collapse to spaces — so numbered replies render as one dense paragraph. `1)` markers and bold-wrapped `**1. Title**` markers never parse as lists at all.
2. `parseCitations` returns the body untouched when a turn has no footnote definitions, so a model's orphan `[^1]` leaks into the prose as literal text. `REF_RE`'s `(?!:)` lookahead also skipped the exact reported shape (`the levers[^1]:`).

## Fix
- `normalizePseudoLists()` in `src/lib/message-markdown-stream.ts` — fence-aware pre-parse pass: joins wrapped continuation lines back onto their marker (CommonMark lazy continuation), converts `N)` → `N.` and unwraps `**N. Title**` → `N. **Title**` when a run holds ≥2 numbered markers. Wired into `mdToHtml` before the fence-filename scan (fence lines pass through untouched, so positional scanning stays aligned).
- `renderCitationReferences` now runs even with zero citations and strips orphan **numeric** refs outside code spans/fences (post-definition-strip, colon-tolerant). Non-numeric labels like `[^a-z]` stay put — they may be regex classes. `renderCitedBody` no longer early-returns.

## Validation
- `node --test` on `message-markdown-stream.test.ts` + `citations.test.ts` (23 pass, incl. 5 new tests) and `citations-directive` / `citation` / `message-reader` / `message-bubble-markdown` / `message-bubble-code-header` (27 pass)
- `pnpm typecheck` clean
- Pipeline sanity: the three reported wall shapes now parse as `numberedList` blocks