### PR TITLE
fix(research): hex palette for video renderer — sharp/librsvg renders oklch() as black

### DIFF
--- a/src/lib/server/research-video-renderer.test.ts
+++ b/src/lib/server/research-video-renderer.test.ts
@@ -61,38 +61,32 @@ function escapeRegExp(value: string): string {
 test("server SVG uses a concrete palette pinned to the Coven foundations", async () => {
   const svg = storyboardSceneToSvg(scene);
   assert.doesNotMatch(svg, /var\(/);
+  // Sharp's librsvg silently renders oklch() fills as black (cave-6f88w), so
+  // every palette color must be plain hex and no oklch may reach the SVG.
+  assert.doesNotMatch(svg, /oklch\(/);
   for (const value of Object.values(COVEN_VIDEO_RENDER_PALETTE)) {
+    assert.match(value, /^#[0-9a-f]{6}$/);
     assert.match(svg, new RegExp(escapeRegExp(value)));
   }
 
+  // The hex values are the sRGB equivalents of these foundations.css
+  // declarations; if the source tokens move, this pin flags the drift.
+  const paletteSources: Record<string, string> = {
+    "--background": "oklch(0.225 0.004 291)",
+    "--accent-presence": COVEN_VIDEO_RENDER_PALETTE.accent,
+    "--foreground": "oklch(0.985 0 0)",
+    "--muted-foreground": "oklch(0.66 0.010 291)",
+  };
   const foundations = await readFile(
     new URL("../../styles/globals/foundations.css", import.meta.url),
     "utf8",
   );
-  assert.match(
-    foundations,
-    new RegExp(
-      `--background:\\s*${escapeRegExp(COVEN_VIDEO_RENDER_PALETTE.background)}`,
-    ),
-  );
-  assert.match(
-    foundations,
-    new RegExp(
-      `--accent-presence:\\s*${escapeRegExp(COVEN_VIDEO_RENDER_PALETTE.accent)}`,
-    ),
-  );
-  assert.match(
-    foundations,
-    new RegExp(
-      `--foreground:\\s*${escapeRegExp(COVEN_VIDEO_RENDER_PALETTE.primaryText)}`,
-    ),
-  );
-  assert.match(
-    foundations,
-    new RegExp(
-      `--muted-foreground:\\s*${escapeRegExp(COVEN_VIDEO_RENDER_PALETTE.secondaryText)}`,
-    ),
-  );
+  for (const [token, value] of Object.entries(paletteSources)) {
+    assert.match(
+      foundations,
+      new RegExp(`${escapeRegExp(token)}:\\s*${escapeRegExp(value)}`),
+    );
+  }
 });
 
 test("Sharp emits an opaque 1280x720 still with distinct background and accent", async () => {

--- a/src/lib/server/research-video-renderer.ts
+++ b/src/lib/server/research-video-renderer.ts
@@ -22,15 +22,18 @@ const VIDEO_HEIGHT = 720;
 const COMMAND_OUTPUT_MAX_BYTES = 256 * 1024;
 
 /**
- * Concrete server-artifact palette. These values mirror the default Coven
- * declarations in src/styles/globals/foundations.css; SVGs rendered by Sharp
- * cannot inherit browser CSS variables.
+ * Concrete server-artifact palette. These hex values are the sRGB equivalents
+ * of the default Coven oklch declarations in
+ * src/styles/globals/foundations.css. SVGs rendered by Sharp cannot inherit
+ * browser CSS variables, and Sharp's librsvg does not parse oklch() at all —
+ * oklch fills silently render as black (cave-6f88w; same defect fixed for the
+ * infographic renderer in cave-ga0t5) — so the palette must stay in hex here.
  */
 export const COVEN_VIDEO_RENDER_PALETTE = {
-  background: "oklch(0.225 0.004 291)",
+  background: "#1c1b1d",
   accent: "#9386d0",
-  primaryText: "oklch(0.985 0 0)",
-  secondaryText: "oklch(0.66 0.010 291)",
+  primaryText: "#fafafa",
+  secondaryText: "#929198",
 } as const;
 
 export type ResearchVideoRenderPalette = {


### PR DESCRIPTION
## Summary

`COVEN_VIDEO_RENDER_PALETTE` in `src/lib/server/research-video-renderer.ts` carried three `oklch()` values (background, primaryText, secondaryText). Sharp's librsvg does not parse `oklch()` — such fills silently render as **black**, so storyboard stills and research video frames rendered with a black background and black text. This is the same latent defect fixed for the infographic renderer in cave-ga0t5 / PR #4279.

## Changes

- Convert the three oklch palette values to their sRGB hex equivalents (same conversions used by the merged infographic renderer):
  - `oklch(0.225 0.004 291)` → `#1c1b1d` (background)
  - `oklch(0.985 0 0)` → `#fafafa` (primaryText)
  - `oklch(0.66 0.010 291)` → `#929198` (secondaryText)
  - accent was already hex (`#9386d0`)
- Document the librsvg/oklch failure in the palette comment.
- Extend the palette test into a regression guard: generated SVG must contain no `oklch(`, every palette value must be 6-digit hex, and each hex value stays pinned to the `foundations.css` token it was derived from (drift detector preserved).

## Verification

- `node --test src/lib/server/research-video-renderer.test.ts` — 7/7 pass (includes the Sharp pixel test asserting distinct background/accent in the rendered still)
- `pnpm typecheck` — clean

Bead: cave-6f88w
