### PR TITLE
test(windows): stop the native-browser fixture flaking on a 15s budget

### DIFF
--- a/scripts/windows-native-browser-regression.test.mjs
+++ b/scripts/windows-native-browser-regression.test.mjs
@@ -337,6 +337,41 @@ assert.match(source, /installedAppMutationInvoked = \$false/);
 assert.match(source, /msiMutationInvoked = \$false/);
 assert.match(source, /unrelatedProcessTerminationInvoked = \$false/);
 
+// PowerShell needs seconds just to start on a cold GitHub Windows runner,
+// before this fixture parses and runs a script of this size. The 15s budget
+// these spawns used to carry left so little headroom that a contended runner
+// tripped it — and a tripped budget is indistinguishable from a real failure
+// at the assertion, because spawnSync kills the child and reports
+// `status: null` with no output to explain itself. That reded a PR whose diff
+// touched only apps/ios/**, which CI never builds (cave-rx5yl). Generous
+// enough that only a genuine hang trips it, still bounded so a hang fails the
+// job rather than hanging it.
+const POWERSHELL_TIMEOUT_MS = 120_000;
+
+function runPowerShell(args, extraOptions = {}) {
+  return spawnSync("powershell.exe", args, {
+    encoding: "utf8",
+    timeout: POWERSHELL_TIMEOUT_MS,
+    ...extraOptions,
+  });
+}
+
+/** Explain a spawn result well enough to act on — a timeout says so by name,
+ *  rather than surfacing as `null !== 0` above two empty strings. */
+function describeSpawn(label, result) {
+  let cause;
+  if (result.error?.code === "ETIMEDOUT") {
+    cause = `timed out after ${POWERSHELL_TIMEOUT_MS}ms (killed with ${result.signal ?? "no signal"})`;
+  } else if (result.error) {
+    cause = `spawn failed: ${result.error.message}`;
+  } else if (result.signal) {
+    cause = `killed with ${result.signal}`;
+  } else {
+    cause = `exited with status ${result.status}`;
+  }
+  return `${label}: ${cause}\nstdout:\n${result.stdout ?? ""}\nstderr:\n${result.stderr ?? ""}`;
+}
+
 // On Windows, exercise the production script's parser and DryRun path as a
 // fast fixture. node.exe is only an identity fixture: DryRun must not launch it.
 if (process.platform === "win32") {
@@ -344,43 +379,40 @@ if (process.platform === "win32") {
   const output = `${fixtureRoot}.json`;
   const profile = `${fixtureRoot}-profile`;
   try {
-    const parse = spawnSync(
-      "powershell.exe",
+    // Previously unbounded: a PowerShell that never returned would have hung
+    // the job to its own timeout rather than failing this test.
+    const parse = runPowerShell(
       [
         "-NoProfile",
         "-NonInteractive",
         "-Command",
         "$e=$null;$t=$null;[System.Management.Automation.Language.Parser]::ParseFile($env:COVEN_HARNESS_PATH,[ref]$t,[ref]$e)|Out-Null;if($e.Count){$e|% Message;exit 1}",
       ],
-      { encoding: "utf8", env: { ...process.env, COVEN_HARNESS_PATH: scriptPath } },
+      { env: { ...process.env, COVEN_HARNESS_PATH: scriptPath } },
     );
-    assert.equal(parse.status, 0, `PowerShell parser rejected ${basename(scriptPath)}:\n${parse.stderr}\n${parse.stdout}`);
+    assert.equal(parse.status, 0, describeSpawn(`PowerShell parser rejected ${basename(scriptPath)}`, parse));
 
-    const dryRun = spawnSync(
-      "powershell.exe",
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        scriptPath,
-        "-Executable",
-        process.execPath,
-        "-WebView2Profile",
-        profile,
-        "-PreparationMode",
-        "Passive",
-        "-StartupProbeOnly",
-        "-Cycles",
-        "0",
-        "-OutputPath",
-        output,
-        "-DryRun",
-      ],
-      { encoding: "utf8", timeout: 15_000 },
-    );
-    assert.equal(dryRun.status, 0, `DryRun fixture failed:\n${dryRun.stderr}\n${dryRun.stdout}`);
+    const dryRun = runPowerShell([
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+      "-Executable",
+      process.execPath,
+      "-WebView2Profile",
+      profile,
+      "-PreparationMode",
+      "Passive",
+      "-StartupProbeOnly",
+      "-Cycles",
+      "0",
+      "-OutputPath",
+      output,
+      "-DryRun",
+    ]);
+    assert.equal(dryRun.status, 0, describeSpawn("DryRun fixture failed", dryRun));
     const report = JSON.parse(readFileSync(output, "utf8"));
     assert.equal(report.status, "dry-run");
     assert.equal(resolve(report.candidate.path), resolve(process.execPath));
@@ -410,22 +442,26 @@ if (process.platform === "win32") {
     );
 
     mkdirSync(profile);
-    const existingProfile = spawnSync(
-      "powershell.exe",
-      [
-        "-NoProfile",
-        "-NonInteractive",
-        "-ExecutionPolicy",
-        "Bypass",
-        "-File",
-        scriptPath,
-        "-Executable",
-        process.execPath,
-        "-WebView2Profile",
-        profile,
-        "-DryRun",
-      ],
-      { encoding: "utf8", timeout: 15_000 },
+    const existingProfile = runPowerShell([
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-File",
+      scriptPath,
+      "-Executable",
+      process.execPath,
+      "-WebView2Profile",
+      profile,
+      "-DryRun",
+    ]);
+    // A killed process reports `status: null`, which `notEqual(…, 0)` accepts —
+    // so demand a real exit code first. Otherwise a timeout could read as the
+    // very rejection this asserts, turning a guard into a false green.
+    assert.equal(
+      typeof existingProfile.status,
+      "number",
+      describeSpawn("pre-existing-profile rejection never ran to completion", existingProfile),
     );
     assert.notEqual(existingProfile.status, 0, "a pre-existing profile path must be rejected even when empty");
     assert.match(`${existingProfile.stderr}\n${existingProfile.stdout}`, /Launch profile must not already exist/);

--- a/scripts/windows-native-browser-regression.test.mjs
+++ b/scripts/windows-native-browser-regression.test.mjs
@@ -342,17 +342,21 @@ assert.match(source, /unrelatedProcessTerminationInvoked = \$false/);
 // these spawns used to carry left so little headroom that a contended runner
 // tripped it — and a tripped budget is indistinguishable from a real failure
 // at the assertion, because spawnSync kills the child and reports
-// `status: null` with no output to explain itself. That reded a PR whose diff
-// touched only apps/ios/**, which CI never builds (cave-rx5yl). Generous
+// `status: null` with no output to explain itself. That turned a PR red whose
+// diff touched only apps/ios/**, which CI never builds (cave-rx5yl). Generous
 // enough that only a genuine hang trips it, still bounded so a hang fails the
 // job rather than hanging it.
 const POWERSHELL_TIMEOUT_MS = 120_000;
 
 function runPowerShell(args, extraOptions = {}) {
+  // Caller options go first on purpose: the budget and encoding are the two
+  // things this helper exists to guarantee, and a caller that overrode the
+  // timeout would reintroduce the flake while describeSpawn still reported
+  // POWERSHELL_TIMEOUT_MS — a diagnostic that lies is worse than none.
   return spawnSync("powershell.exe", args, {
+    ...extraOptions,
     encoding: "utf8",
     timeout: POWERSHELL_TIMEOUT_MS,
-    ...extraOptions,
   });
 }
 


### PR DESCRIPTION
`Cross-environment (windows-latest)` went red on #4281 — a PR whose diff touched only `apps/ios/**`, files CI never builds. It passed on re-run. This is that flake.

## Why it failed

`scripts/windows-native-browser-regression.test.mjs` spawns `powershell.exe` with `timeout: 15_000`. PowerShell needs seconds just to start on a cold GitHub Windows runner, before the fixture parses and runs a script of this size — 15s left almost no headroom, and a contended runner tripped it.

## Why the failure was unreadable

On timeout Node kills the child and reports `status: null` with **empty** stdout and stderr. The assertion interpolated only those two, so the entire CI report was:

```
AssertionError [ERR_ASSERTION]: DryRun fixture failed:


null !== 0
```

Verified directly rather than assumed:

```js
spawnSync("sleep", ["5"], { encoding: "utf8", timeout: 300 })
// status: null | signal: SIGTERM | error.code: ETIMEDOUT | stdout: "" stderr: ""
```

## The fix

Budget goes to 120s — generous enough that only a genuine hang trips it, still bounded so a hang fails the job instead of hanging it — and every spawn routes through one helper that names what happened:

```
DryRun fixture failed: timed out after 120000ms (killed with SIGTERM)
```

while a genuine non-zero exit still reads plainly (`exited with status 3`, with the output beneath it).

## Two neighbouring holes the same investigation turned up

- **The parser spawn had no timeout at all.** A PowerShell that never returned would have hung the job to its own limit rather than failing this test. Bounded now.
- **`assert.notEqual(existingProfile.status, 0)` is satisfied by `null`.** A timed-out run could read as the rejection that assertion exists to prove. It now demands a real exit code first. In practice the following `assert.match` on process output made this unreachable — a killed process has nothing to match — but a guard shouldn't depend on the line after it.

## Verification

Honest limits: the changed branch is `if (process.platform === "win32")`, so **I cannot execute it on macOS**. What I did verify locally:

- the test still passes (`windows-native-browser-regression.test.mjs: ok`) and the file parses under `node --check`;
- the `spawnSync` timeout semantics the fix depends on, measured directly (above);
- the new diagnostic's output for a timeout, a signal kill, and a plain non-zero exit.

The Windows path itself is exercised by this PR's own `Cross-environment (windows-latest)` leg.

Closes cave-rx5yl
