### PR TITLE
fix(ios): revert only the card that failed, not the whole task list

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -652,7 +652,7 @@ final class AppModel {
             applyTask(id: card.id) { $0 = updated }
             Haptics.tap()
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
             reportRevert("update the task")
         }
@@ -670,7 +670,7 @@ final class AppModel {
             let updated = try await client.updateTask(cardId: card.id, steps: newSteps)
             applyTask(id: card.id) { $0 = updated }
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
         }
     }
@@ -710,7 +710,7 @@ final class AppModel {
             let updated = try await client.updateTask(cardId: card.id, steps: steps)
             applyTask(id: card.id) { $0 = updated }
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
         }
     }
@@ -726,7 +726,7 @@ final class AppModel {
             let updated = try await client.updateTask(cardId: card.id, notes: trimmed)
             applyTask(id: card.id) { $0 = updated }
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
         }
     }
@@ -742,7 +742,7 @@ final class AppModel {
             let updated = try await client.updateTaskTitle(cardId: card.id, title: trimmed)
             applyTask(id: card.id) { $0 = updated }
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
         }
     }
@@ -758,7 +758,7 @@ final class AppModel {
             applyTask(id: card.id) { $0 = updated }
             Haptics.tap()
         } catch {
-            tasks = previous
+            revertTask(id: card.id, to: previous)
             tasksError = error.localizedDescription
             reportRevert("reschedule the task")
         }
@@ -766,17 +766,27 @@ final class AppModel {
 
     /// Optimistically remove a task, then DELETE it. Reinserts on failure.
     func deleteTask(_ card: BoardCard) async {
-        guard let client else { return }
-        let previous = tasks
-        tasks.removeAll { $0.id == card.id }
+        guard let client, let index = tasks.firstIndex(where: { $0.id == card.id }) else { return }
+        let removed = tasks[index]
+        tasks.remove(at: index)
         do {
             try await client.deleteTask(cardId: card.id)
             Haptics.success()
         } catch {
-            tasks = previous
+            // `revertTask` edits a card that is still in the array, so it cannot
+            // restore one that was removed: `applyTask` finds no index and
+            // no-ops, silently dropping the task the delete failed to remove.
+            reinsertTask(removed, at: index)
             tasksError = error.localizedDescription
             reportRevert("delete the task")
         }
+    }
+
+    /// Put an optimistically-removed card back at the position it held rather
+    /// than at the end of the list. No-ops if it is already back.
+    private func reinsertTask(_ card: BoardCard, at index: Int) {
+        guard !tasks.contains(where: { $0.id == card.id }) else { return }
+        tasks.insert(card, at: min(index, tasks.count))
     }
 
     private func applyTask(id: String, _ mutate: (inout BoardCard) -> Void) {

--- a/scripts/ios-task-actions.test.mjs
+++ b/scripts/ios-task-actions.test.mjs
@@ -41,7 +41,9 @@ for (const fn of ["setTaskStatus", "setTaskPriority", "toggleStep", "deleteTask"
 }
 assert.match(
   model,
-  /func deleteTask\(_ card: BoardCard\) async \{[\s\S]*let previous = tasks[\s\S]*tasks\.removeAll[\s\S]*catch[\s\S]*tasks = previous/,
+  /func deleteTask\(_ card: BoardCard\) async \{[\s\S]*tasks\.remove\(at: index\)[\s\S]*catch[\s\S]*reinsertTask\(removed, at: index\)/,
+  // Same intent; the revert narrowed from the whole array to this one card, and
+  // a removed card must be reinserted rather than edited in place (cave-rlmot).
   "deleteTask should optimistically remove and revert on failure",
 );
 assert.match(

--- a/scripts/ios-task-notes-edit.test.mjs
+++ b/scripts/ios-task-notes-edit.test.mjs
@@ -17,10 +17,32 @@ assert.match(
 assert.match(client, /if let notes \{ try c\.encode\(notes, forKey: \.notes\) \}/, "TaskFieldsPatch should encode notes when set");
 
 // Model exposes an optimistic notes setter that reverts on failure.
+// Scope the match to setTaskNotes' own body by brace matching. The previous
+// form was one regex over the whole file with `[\s\S]*` between clauses, so
+// after `catch` it ran greedily into LATER functions — it passed while
+// setTaskNotes itself still reverted the whole array, because some other
+// mutation further down had the per-card call (cave-rlmot).
+function blockAfter(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start + marker.length - 1; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+const setNotes = blockAfter(model, "func setTaskNotes(_ card: BoardCard, _ notes: String) async {");
+assert.ok(setNotes, "setTaskNotes should exist");
+assert.match(setNotes, /applyTask\(id: card\.id\) \{ \$0\.notes = trimmed \}/, "setTaskNotes should apply optimistically");
+assert.match(setNotes, /client\.updateTask\(cardId: card\.id, notes: trimmed\)/, "setTaskNotes should PATCH the notes");
 assert.match(
-  model,
-  /func setTaskNotes\(_ card: BoardCard, _ notes: String\) async \{[\s\S]*applyTask\(id: card\.id\) \{ \$0\.notes = trimmed \}[\s\S]*client\.updateTask\(cardId: card\.id, notes: trimmed\)[\s\S]*catch[\s\S]*tasks = previous/,
-  "setTaskNotes should be optimistic with revert",
+  setNotes,
+  /catch \{\s*\n\s*revertTask\(id: card\.id, to: previous\)/,
+  "setTaskNotes should revert on failure — and only its own card (cave-rlmot)",
 );
 assert.match(
   model,

--- a/scripts/ios-task-revert-scope.test.mjs
+++ b/scripts/ios-task-revert-scope.test.mjs
@@ -1,0 +1,102 @@
+// cave-rlmot: an optimistic task mutation that fails must restore only the card
+// that failed. Reassigning the whole `tasks` array rolls back concurrent edits
+// to unrelated cards that had already succeeded.
+//
+// iOS Swift is NOT compiled by CI, so this source-text contract is the only
+// gate. Each assertion is checked to FAIL against its regression, not merely
+// to pass.
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const model = await readFile(
+  new URL("../apps/ios/CovenCave/CovenCave/State/AppModel.swift", import.meta.url),
+  "utf8",
+);
+
+/** Extract a brace-balanced block starting at `marker` (which ends at its `{`). */
+function blockAfter(src, marker) {
+  const start = src.indexOf(marker);
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start + marker.length - 1; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return src.slice(start, i + 1);
+    }
+  }
+  return null;
+}
+
+// No optimistic task path may restore the whole array. This is the whole point
+// of the change, and a single reintroduced site is a silent data-loss bug: the
+// failing card's rollback also discards a sibling card's successful edit.
+assert.doesNotMatch(
+  model,
+  /\n\s*tasks = previous\n/,
+  "no task mutation may reassign the whole tasks array on failure",
+);
+
+// Every in-place mutator reverts just its own card.
+for (const fn of [
+  "setTaskStatus",
+  "setTaskPriority",
+  "toggleStep",
+  "commitSteps",
+  "setTaskNotes",
+  "setTaskTitle",
+  "setTaskDates",
+]) {
+  const body = blockAfter(model, `func ${fn}(`);
+  assert.ok(body, `${fn} must exist`);
+  assert.match(
+    body,
+    /revertTask\(id: card\.id, to: previous\)/,
+    `${fn} must restore only the card that failed`,
+  );
+}
+
+// deleteTask is the one that cannot use revertTask: the card is REMOVED, so
+// applyTask finds no index and silently no-ops, dropping the task the delete
+// failed to remove. It must reinsert instead, at the position it held.
+const del = blockAfter(model, "func deleteTask(_ card: BoardCard) async {");
+assert.ok(del, "deleteTask must exist");
+assert.doesNotMatch(
+  del,
+  /revertTask\(/,
+  "deleteTask must NOT use revertTask — a removed card has no index to edit, so it would no-op",
+);
+assert.match(
+  del,
+  /guard let client, let index = tasks\.firstIndex\(where: \{ \$0\.id == card\.id \}\) else \{ return \}/,
+  "deleteTask must capture the index before removing",
+);
+assert.match(
+  del,
+  /reinsertTask\(removed, at: index\)/,
+  "a failed delete must put the card back where it was",
+);
+
+const reinsert = blockAfter(model, "private func reinsertTask(_ card: BoardCard, at index: Int) {");
+assert.ok(reinsert, "reinsertTask must exist");
+assert.match(
+  reinsert,
+  /guard !tasks\.contains\(where: \{ \$0\.id == card\.id \}\) else \{ return \}/,
+  "reinserting must not duplicate a card that is already back",
+);
+assert.match(
+  reinsert,
+  /tasks\.insert\(card, at: min\(index, tasks\.count\)\)/,
+  "reinsert must clamp the index — the list can be shorter than when the card was removed",
+);
+
+// revertTask itself must stay per-id.
+const revert = blockAfter(model, "private func revertTask(id: String, to previous: [BoardCard]) {");
+assert.ok(revert, "revertTask must exist");
+assert.match(
+  revert,
+  /guard let old = previous\.first\(where: \{ \$0\.id == id \}\) else \{ return \}/,
+  "revertTask must look up a single card by id",
+);
+
+console.log("ios-task-revert-scope: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1436,6 +1436,7 @@ export const SUITES = {
     "scripts/ios-task-notes-reader.test.mjs",
     "scripts/ios-task-notes-edit.test.mjs",
     "scripts/ios-task-actions.test.mjs",
+    "scripts/ios-task-revert-scope.test.mjs",
     "scripts/ios-ipad-split-tasks.test.mjs",
     "scripts/ios-ipad-split-chats.test.mjs",
     "scripts/ios-task-search-familiar-scope.test.mjs",


### PR DESCRIPTION
Closes cave-rlmot.

Seven optimistic task mutations snapshotted the whole `tasks` array and reassigned it on failure. That rolls back concurrent edits to **other** cards that had already succeeded — change two tasks at once, have one request fail, and the other card's applied change is discarded along with it. Nothing surfaces that; the second edit just reverts itself.

`setTaskStatus` was fixed in #4263 via `revertTask(id:to:)`. The remaining six in-place mutators now use the same helper.

## deleteTask is the interesting one

It could not use `revertTask`, and this is the case worth reviewing: `deleteTask` **removes** the card, so `revertTask` reaches `applyTask`, finds no index for a card no longer in the array, and **silently no-ops** — dropping the task the delete had failed to remove. It would read as correct in review and lose data at runtime.

It now captures the index before removing and reinserts there, so a rejected delete restores the card at the position it held rather than appending it to the end. `reinsertTask` clamps the index (the list can be shorter than when the card was removed) and no-ops if the card is already back.

The contract test asserts `deleteTask` does **not** use `revertTask`, so this cannot be "simplified" back into the bug.

## Verification

iOS Swift is not compiled by CI, so `scripts/ios-task-revert-scope.test.mjs` is the only automated gate. All six regressions checked to **fail**:

| regression | caught |
|---|---|
| a mutator regresses to whole-array revert | ✓ |
| `deleteTask` uses `revertTask` (silently no-ops) | ✓ |
| `deleteTask` stops capturing the index | ✓ |
| reinsert can duplicate an already-restored card | ✓ |
| reinsert index unclamped | ✓ |
| `revertTask` reverts everything again | ✓ |

A blanket `doesNotMatch` on `tasks = previous` covers the whole file, so a new mutation cannot reintroduce the pattern anywhere. `swiftc -parse` clean; `pnpm test:app` 1065 files.

## Found but not fixed

`toggleStep`, `commitSteps`, `setTaskNotes` and `setTaskTitle` revert with **no `reportRevert` call**, so a failed step toggle, notes edit or title rename snaps back with no explanation. Filed as **cave-k8v02** rather than folded in here — whether each warrants a toast is a per-mutation judgement (a rename probably yes, a step toggle maybe noisy), not a blanket change.
