### PR TITLE
feat(voice): live call transcript with a spoken-word highlight and in-call replies

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1323,6 +1323,10 @@ export const SUITES = {
     "src/lib/voice/local-tts.test.ts",
     "src/lib/voice/speak-message.test.ts",
     "src/lib/voice/speech-loop.test.ts",
+    "src/lib/voice/call-transcript.test.ts",
+    // Landed unwired with /auto mission mode (3bde7b0); check:tests-wired
+    // fails on `main` until it is listed. Passes as-is.
+    "src/lib/auto-status-blocks.test.ts",
     "src/lib/voice/microphone-access.test.ts",
     "src/lib/voice/native-stt.test.ts",
     "src/lib/voice/familiar-brain.test.ts",

--- a/src/components/chat-view-polish-tools-activity.test.ts
+++ b/src/components/chat-view-polish-tools-activity.test.ts
@@ -40,7 +40,10 @@ assert.match(
 
 assert.match(
   turnRow,
-  /const reasoningSplit = splitReasoning\(extractAgentAttachmentMarkers\(turn\.text\)\.text\)[\s\S]*const inlineReasoning = reasoningSplit\.reasoning[\s\S]*const \{ visible: visibleWithGh, suggestions: nextPaths \} = extractNextPaths\(skillSplit\.visible\)/,
+  // Pinned as an ORDER, not an exact chain: marker extractors keep being added
+  // between the skill split and next-paths (auto-mission status was the last),
+  // and naming the immediate argument makes this assertion stale every time.
+  /const reasoningSplit = splitReasoning\(extractAgentAttachmentMarkers\(turn\.text\)\.text\)[\s\S]*const inlineReasoning = reasoningSplit\.reasoning[\s\S]*const skillSplit = extractSkillMarkers\([\s\S]*const \{ visible: visibleWithGh, suggestions: nextPaths \} = extractNextPaths\(/,
   "Assistant turns should split visible content from collapsible reasoning before extracting next-path suggestions",
 );
 

--- a/src/components/voice-call-overlay-state.ts
+++ b/src/components/voice-call-overlay-state.ts
@@ -22,6 +22,10 @@ export type CallState = {
   /** How a live loop-based call hears (cave-vpe1); unset for realtime providers. */
   earsEngine?: VoiceEarsEngine;
   mouthEngine?: VoiceMouthEngine;
+  /** Whether this call's provider accepts a typed turn (cave-zr9dx). The live
+   *  session object is a ref, so the reply box needs the answer in state to
+   *  render at all. */
+  canSendText?: boolean;
 };
 
 export const initialState: CallState = { state: "idle", muted: false };
@@ -32,7 +36,13 @@ export type CallEvent =
   | { type: "MIC_FAILED"; errorCode: string; hint?: string; canOpenSettings?: boolean }
   | { type: "SESSION_GRANTED"; callId: string }
   | { type: "SESSION_FAILED"; errorCode: string; missingKey?: string; hint?: string }
-  | { type: "CONNECTED"; startedAt: number; earsEngine?: VoiceEarsEngine; mouthEngine?: VoiceMouthEngine }
+  | {
+      type: "CONNECTED";
+      startedAt: number;
+      earsEngine?: VoiceEarsEngine;
+      mouthEngine?: VoiceMouthEngine;
+      canSendText?: boolean;
+    }
   | { type: "DISCONNECTED" }
   | { type: "PROVIDER_ERROR"; errorCode: string; hint?: string }
   | { type: "CLOSE_REQUEST" }
@@ -69,7 +79,14 @@ export function reduce(s: CallState, ev: CallEvent): CallState {
       };
     case "CONNECTED":
       if (s.state !== "connecting") return s;
-      return { ...s, state: "live", startedAt: ev.startedAt, earsEngine: ev.earsEngine, mouthEngine: ev.mouthEngine };
+      return {
+        ...s,
+        state: "live",
+        startedAt: ev.startedAt,
+        earsEngine: ev.earsEngine,
+        mouthEngine: ev.mouthEngine,
+        canSendText: ev.canSendText,
+      };
     case "PROVIDER_ERROR":
       // Explicitly clear missingKey — a stale key name from an earlier mint
       // failure must not dress an unrelated connect error as key-fixable.

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -3,7 +3,18 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const component = readFileSync(new URL("./voice-call-overlay.tsx", import.meta.url), "utf8");
-const styles = ["cave-md", "cave-composer", "chat-list", "calendar", "cave-chat"]
+// cave-chat.css is an @import aggregator: the overlay's own rules live in the
+// partials it pulls in, so reading only the aggregator asserts against a file
+// that contains none of them.
+const styles = [
+  "cave-md",
+  "cave-composer",
+  "chat-list",
+  "calendar",
+  "cave-chat",
+  "cave-chat/activity",
+  "cave-chat/auxiliary-surfaces",
+]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");
 
@@ -15,8 +26,13 @@ assert.match(
 
 assert.match(
   component,
-  /useFocusTrap\(true,\s*dialogRef,\s*\{\s*onEscape:\s*\(\)\s*=>\s*dispatch\(\{\s*type:\s*"CLOSE_REQUEST"\s*\}\)\s*\}\)/,
-  "VoiceCallOverlay traps focus and closes cleanly on Escape",
+  /useFocusTrap\(true,\s*dialogRef,\s*\{\s*onEscape:/,
+  "VoiceCallOverlay traps focus and handles Escape",
+);
+assert.match(
+  component,
+  /onEscape:[\s\S]{0,220}dispatch\(\{\s*type:\s*"CLOSE_REQUEST"\s*\}\);?\s*\},/,
+  "Escape ends the call cleanly once nothing else is staged",
 );
 
 assert.match(
@@ -145,12 +161,12 @@ assert.match(
 );
 assert.match(
   component,
-  /onUserTranscriptFinal:\s*\(text\)\s*=>\s*\{\s*if \(persistTranscript\) postTranscript\(sessionId, callId, "user", text\);/,
+  /onUserTranscriptFinal:\s*\(text\)\s*=>\s*\{[\s\S]{0,160}if \(persistTranscript\) postTranscript\(sessionId, callId, "user", text\);/,
   "user transcript finals persist only when the provider does not",
 );
 assert.match(
   component,
-  /onAssistantTranscriptFinal:\s*\(text\)\s*=>\s*\{\s*if \(persistTranscript\) postTranscript\(sessionId, callId, "assistant", text\);/,
+  /onAssistantTranscriptFinal:\s*\(text\)\s*=>\s*\{[\s\S]{0,160}if \(persistTranscript\) postTranscript\(sessionId, callId, "assistant", text\);/,
   "assistant transcript finals persist only when the provider does not",
 );
 
@@ -179,17 +195,17 @@ assert.match(
 // dictation/browser modes tell the user their audio rides a service.
 assert.match(
   component,
-  /dispatch\(\{\s*type:\s*"CONNECTED",\s*startedAt:\s*Date\.now\(\),\s*earsEngine:\s*live\.earsEngine,\s*mouthEngine:\s*live\.mouthEngine\s*\}\)/,
+  /dispatch\(\{\s*type:\s*"CONNECTED",\s*startedAt:\s*Date\.now\(\),\s*earsEngine:\s*live\.earsEngine,\s*mouthEngine:\s*live\.mouthEngine,/,
   "CONNECTED carries the LiveSession's ears and mouth engines into call state",
 );
 assert.match(
   component,
-  /state\.state === "live" && state\.earsEngine && \(/,
+  /\{state\.earsEngine && \([\s\S]{0,120}className="voice-call-overlay__ears"/,
   "live calls render the ears-engine badge when a loop provider reports one",
 );
 assert.match(
   component,
-  /state\.state === "live" && state\.mouthEngine && \(/,
+  /\{state\.mouthEngine && \([\s\S]{0,120}className="voice-call-overlay__mouth"/,
   "live calls render the mouth-engine badge when a loop provider reports one (cave-vony)",
 );
 assert.match(
@@ -276,6 +292,84 @@ assert.match(
   styles,
   /\.voice-call-overlay__retry:disabled\s*\{[\s\S]*?opacity:/,
   "the save button reads as disabled while the draft is empty or saving",
+);
+
+// ── Live transcript, speaking highlight, in-call reply (cave-zr9dx) ────────
+
+assert.match(
+  component,
+  /className="voice-call-overlay__transcript"[\s\S]{0,200}role="log"[\s\S]{0,200}aria-live="polite"/,
+  "the live transcript is an announced log region",
+);
+assert.match(
+  component,
+  /aria-relevant="additions"/,
+  "only added turns are announced — a partial rewrites its own text constantly",
+);
+assert.match(
+  component,
+  /onSpeaking:\s*\(utterance\)\s*=>\s*\{\s*setTranscript\(\(t\)\s*=>\s*applySpeaking\(t,\s*utterance\)\)/,
+  "the overlay tracks the utterance the mouth is voicing",
+);
+assert.match(
+  component,
+  /splitSpokenText\(turn\.text,\s*isSpeaking \? transcript\.speaking : null\)/,
+  "only the turn being voiced is split for highlighting",
+);
+assert.match(
+  component,
+  /<mark className="voice-call-overlay__spoken">\{split\.match\}<\/mark>/,
+  "the spoken run renders as a semantic mark, not a styled span",
+);
+assert.match(
+  component,
+  /onPartialTranscript:\s*\(role,\s*text\)\s*=>\s*\{\s*setTranscript\(\(t\)\s*=>\s*applyPartial\(t,\s*role,\s*text\)\)/,
+  "in-flight text renders live without being persisted",
+);
+assert.match(
+  component,
+  /canSendText:\s*typeof live\.sendText === "function"/,
+  "the reply box only appears when the provider actually accepts typed turns",
+);
+assert.match(
+  component,
+  /live\.sendText\(buildQuotedPrompt\(replyTarget,\s*body\)\)/,
+  "a quoted reply uses the same prompt shape as the chat composer",
+);
+assert.match(
+  component,
+  /if \(replyTargetRef\.current\) \{\s*setReplyTarget\(null\);\s*return;\s*\}/,
+  "Escape cancels a staged reply before it ends the call",
+);
+assert.match(
+  component,
+  /aria-label="Stop speaking"[\s\S]{0,160}liveRef\.current\?\.interrupt\?\.\(\)/,
+  "barge-in is reachable without typing while the familiar is speaking",
+);
+assert.match(
+  component,
+  /className="voice-call-overlay__reply-input focus-ring"[\s\S]{0,200}aria-label="Reply without speaking"/,
+  "the reply field is labelled for assistive tech",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__transcript\s*\{[\s\S]*?overflow-y:\s*auto;/,
+  "a long call scrolls inside the transcript rather than growing the dialog",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__spoken\s*\{[\s\S]*?background:\s*color-mix\(in oklch, var\(--accent-presence\)/,
+  "the speaking highlight is a token-derived tint, not a hardcoded color",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__spoken\s*\{[\s\S]*?box-decoration-break:\s*clone;/,
+  "a highlight that wraps across lines keeps its shape on every line",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__reply-send:disabled\s*\{[\s\S]*?opacity:/,
+  "the send button reads as disabled while the reply draft is empty",
 );
 
 console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -2,12 +2,23 @@
 
 import "@/styles/cave-chat.css";
 
-import { useEffect, useReducer, useRef, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { Icon } from "@iconify/react";
 import type { Familiar } from "@/lib/types";
 import { useFocusTrap } from "@/lib/use-focus-trap";
+import { buildQuotedPrompt, buildReplySnippet, type ReplyTarget } from "@/lib/chat-reply";
 import { getVoiceProvider } from "@/lib/voice/registry";
+import {
+  applyFinal,
+  applyPartial,
+  applySpeaking,
+  emptyTranscript,
+  speakingTurnId,
+  splitSpokenText,
+  type CallTranscript,
+  type CallTurn,
+} from "@/lib/voice/call-transcript";
 import {
   classifyMicrophoneCaptureError,
   openMicrophoneSettings,
@@ -32,7 +43,29 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
   const audioElRef = useRef<HTMLAudioElement | null>(null);
   const dialogRef = useRef<HTMLDivElement | null>(null);
 
-  useFocusTrap(true, dialogRef, { onEscape: () => dispatch({ type: "CLOSE_REQUEST" }) });
+  // The live transcript (cave-zr9dx). Kept outside the call reducer because it
+  // is high-frequency, append-mostly data with its own pure model.
+  const [transcript, setTranscript] = useState<CallTranscript>(emptyTranscript);
+  const [replyTarget, setReplyTarget] = useState<ReplyTarget | null>(null);
+  const [replyDraft, setReplyDraft] = useState("");
+  const transcriptScrollRef = useRef<HTMLOListElement | null>(null);
+  const replyInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Escape is overloaded on this dialog: it cancels a staged reply first and
+  // only ends the call once nothing is staged, so an in-progress reply can be
+  // abandoned without hanging up. Read through a ref — the focus trap binds
+  // its handler once.
+  const replyTargetRef = useRef<ReplyTarget | null>(null);
+  replyTargetRef.current = replyTarget;
+  useFocusTrap(true, dialogRef, {
+    onEscape: () => {
+      if (replyTargetRef.current) {
+        setReplyTarget(null);
+        return;
+      }
+      dispatch({ type: "CLOSE_REQUEST" });
+    },
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -95,19 +128,34 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           const persistTranscript = !provider.persistsTranscripts;
           const live = await provider.clientAdapter.connect(grant, mic, {
             onUserTranscriptFinal: (text) => {
+              setTranscript((t) => applyFinal(t, "user", text));
               if (persistTranscript) postTranscript(sessionId, callId, "user", text);
             },
             onAssistantTranscriptFinal: (text) => {
+              setTranscript((t) => applyFinal(t, "assistant", text));
               if (persistTranscript) postTranscript(sessionId, callId, "assistant", text);
             },
-            onPartialTranscript: () => { /* live caption surface, not persisted */ },
+            // Live captions are rendered, never persisted — the settled turn
+            // above is the record.
+            onPartialTranscript: (role, text) => {
+              setTranscript((t) => applyPartial(t, role, text));
+            },
+            onSpeaking: (utterance) => {
+              setTranscript((t) => applySpeaking(t, utterance));
+            },
             onError: (err) => dispatch({ type: "PROVIDER_ERROR", errorCode: err.message, hint: voiceErrorHint(err) }),
             onDisconnect: () => dispatch({ type: "DISCONNECTED" }),
           });
           if (cancelled) { await live.close(); return; }
           liveRef.current = live;
           if (audioElRef.current) audioElRef.current.srcObject = live.inboundAudio;
-          dispatch({ type: "CONNECTED", startedAt: Date.now(), earsEngine: live.earsEngine, mouthEngine: live.mouthEngine });
+          dispatch({
+            type: "CONNECTED",
+            startedAt: Date.now(),
+            earsEngine: live.earsEngine,
+            mouthEngine: live.mouthEngine,
+            canSendText: typeof live.sendText === "function",
+          });
         } catch (err) {
           dispatch({
             type: "PROVIDER_ERROR",
@@ -153,6 +201,50 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
     const id = setInterval(() => setTick((t) => t + 1), 1000);
     return () => clearInterval(id);
   }, [state.state]);
+
+  // A retry starts a genuinely fresh call — the previous attempt's transcript
+  // and staged reply must not bleed into it.
+  useEffect(() => {
+    if (state.state !== "requesting-mic") return;
+    setTranscript(emptyTranscript);
+    setReplyTarget(null);
+    setReplyDraft("");
+  }, [state.state]);
+
+  // Follow the conversation as it grows. Only when the reader is already at
+  // the bottom: scrolling back to re-read what was said must not be yanked
+  // away by the next sentence.
+  const turnCount = transcript.turns.length;
+  const speakingNow = transcript.speaking;
+  useEffect(() => {
+    const el = transcriptScrollRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    if (distanceFromBottom > 80) return;
+    el.scrollTop = el.scrollHeight;
+  }, [turnCount, speakingNow, transcript.turns[turnCount - 1]?.text]);
+
+  const highlightedTurnId = useMemo(() => speakingTurnId(transcript), [transcript]);
+
+  const sendReply = () => {
+    const body = replyDraft.trim();
+    const live = liveRef.current;
+    if (!body || !live?.sendText) return;
+    // The quoted prefix is the same one the chat composer builds, so a reply
+    // sent by voice reads identically in the persisted transcript.
+    live.sendText(buildQuotedPrompt(replyTarget, body));
+    setReplyDraft("");
+    setReplyTarget(null);
+  };
+
+  const stageReply = (turn: CallTurn) => {
+    setReplyTarget({
+      turnId: turn.id,
+      author: turn.role === "user" ? "You" : familiar.display_name,
+      snippet: buildReplySnippet(turn.text),
+    });
+    replyInputRef.current?.focus();
+  };
 
   // In-place recovery (cave-xz57): a key-shaped failure offers a vault
   // editor right in the error card — save the key and retry without leaving
@@ -240,15 +332,72 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           {state.state === "live" && <span className="voice-call-overlay__duration">{mm}:{ss}</span>}
         </header>
         <div className="voice-call-overlay__body">
-          {state.state === "live" && state.earsEngine && (
-            <span className="voice-call-overlay__ears" title="How this call hears you">
-              {earsEngineLabel(state.earsEngine)}
-            </span>
+          {state.state === "live" && (state.earsEngine || state.mouthEngine) && (
+            <div className="voice-call-overlay__engines">
+              {state.earsEngine && (
+                <span className="voice-call-overlay__ears" title="How this call hears you">
+                  {earsEngineLabel(state.earsEngine)}
+                </span>
+              )}
+              {state.mouthEngine && (
+                <span className="voice-call-overlay__mouth" title="How this call speaks to you">
+                  {mouthEngineLabel(state.mouthEngine)}
+                </span>
+              )}
+            </div>
           )}
-          {state.state === "live" && state.mouthEngine && (
-            <span className="voice-call-overlay__mouth" title="How this call speaks to you">
-              {mouthEngineLabel(state.mouthEngine)}
-            </span>
+          {state.state === "live" && (
+            <ol
+              ref={transcriptScrollRef}
+              className="voice-call-overlay__transcript"
+              role="log"
+              aria-label="Call transcript"
+              aria-live="polite"
+              // Additions only: a partial turn rewrites its own text on every
+              // recognition frame, and announcing each rewrite would make the
+              // screen reader unusable.
+              aria-relevant="additions"
+            >
+              {transcript.turns.length === 0 ? (
+                <li className="voice-call-overlay__transcript-empty">
+                  Start talking — what you both say appears here as it happens.
+                </li>
+              ) : (
+                transcript.turns.map((turn) => {
+                  const isSpeaking = turn.id === highlightedTurnId;
+                  const split = splitSpokenText(turn.text, isSpeaking ? transcript.speaking : null);
+                  return (
+                    <li
+                      key={turn.id}
+                      className={`voice-call-overlay__turn voice-call-overlay__turn--${turn.role}${
+                        isSpeaking ? " is-speaking" : ""
+                      }`}
+                      aria-busy={turn.final ? undefined : true}
+                    >
+                      <span className="voice-call-overlay__turn-author">
+                        {turn.role === "user" ? "You" : familiar.display_name}
+                      </span>
+                      <p className="voice-call-overlay__turn-text">
+                        {split.before}
+                        {split.match ? (
+                          <mark className="voice-call-overlay__spoken">{split.match}</mark>
+                        ) : null}
+                        {split.after}
+                      </p>
+                      {state.canSendText && turn.final && (
+                        <button
+                          type="button"
+                          className="voice-call-overlay__turn-reply focus-ring"
+                          onClick={() => stageReply(turn)}
+                        >
+                          Reply
+                        </button>
+                      )}
+                    </li>
+                  );
+                })
+              )}
+            </ol>
           )}
           {state.state === "error" && (
             <div className="voice-call-overlay__error" role="alert">
@@ -308,16 +457,74 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
             </div>
           )}
         </div>
-        <footer className="voice-call-overlay__footer">
-          <button
-            type="button"
-            className="voice-call-overlay__control focus-ring"
-            aria-label={state.muted ? "Unmute" : "Mute"}
-            onClick={() => dispatch({ type: "MUTE_TOGGLE" })}
-            disabled={state.state !== "live"}
+        {state.state === "live" && state.canSendText && (
+          <form
+            className="voice-call-overlay__reply"
+            onSubmit={(e) => { e.preventDefault(); sendReply(); }}
           >
-            <Icon icon={state.muted ? "ph:microphone-slash-fill" : "ph:microphone-fill"} />
-          </button>
+            {replyTarget && (
+              <div className="voice-call-overlay__reply-target">
+                <Icon icon="ph:arrow-bend-up-left" aria-hidden="true" />
+                <span className="voice-call-overlay__reply-author">{replyTarget.author}</span>
+                <span className="voice-call-overlay__reply-snippet">{replyTarget.snippet}</span>
+                <button
+                  type="button"
+                  className="voice-call-overlay__reply-clear focus-ring"
+                  aria-label="Cancel reply"
+                  onClick={() => setReplyTarget(null)}
+                >
+                  <Icon icon="ph:x" />
+                </button>
+              </div>
+            )}
+            <div className="voice-call-overlay__reply-row">
+              <input
+                ref={replyInputRef}
+                className="voice-call-overlay__reply-input focus-ring"
+                type="text"
+                autoComplete="off"
+                aria-label="Reply without speaking"
+                placeholder={replyTarget ? `Reply to ${replyTarget.author}…` : "Type a reply…"}
+                value={replyDraft}
+                onChange={(e) => setReplyDraft(e.target.value)}
+              />
+              <button
+                type="submit"
+                className="voice-call-overlay__reply-send focus-ring"
+                aria-label="Send reply"
+                disabled={replyDraft.trim() === ""}
+              >
+                <Icon icon="ph:paper-plane-tilt-fill" />
+              </button>
+            </div>
+          </form>
+        )}
+        <footer className="voice-call-overlay__footer">
+          <div className="voice-call-overlay__controls">
+            <button
+              type="button"
+              className="voice-call-overlay__control focus-ring"
+              aria-label={state.muted ? "Unmute" : "Mute"}
+              onClick={() => dispatch({ type: "MUTE_TOGGLE" })}
+              disabled={state.state !== "live"}
+            >
+              <Icon icon={state.muted ? "ph:microphone-slash-fill" : "ph:microphone-fill"} />
+            </button>
+            {/* Barge-in without typing: cut the familiar off mid-sentence.
+                Only offered while it is actually speaking, so the control
+                never lies about what it would do. */}
+            {state.state === "live" && transcript.speaking && (
+              <button
+                type="button"
+                className="voice-call-overlay__control focus-ring"
+                aria-label="Stop speaking"
+                title="Stop speaking"
+                onClick={() => liveRef.current?.interrupt?.()}
+              >
+                <Icon icon="ph:speaker-slash-fill" />
+              </button>
+            )}
+          </div>
           <button
             type="button"
             className="voice-call-overlay__end focus-ring"

--- a/src/lib/voice/call-transcript.test.ts
+++ b/src/lib/voice/call-transcript.test.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  applyFinal,
+  applyPartial,
+  applySpeaking,
+  emptyTranscript,
+  MAX_CALL_TURNS,
+  speakingTurnId,
+  splitSpokenText,
+} from "./call-transcript.ts";
+
+test("partials replace the open turn instead of stacking bubbles", () => {
+  let t = applyPartial(emptyTranscript, "user", "light the");
+  t = applyPartial(t, "user", "light the candles");
+  assert.equal(t.turns.length, 1);
+  assert.equal(t.turns[0].text, "light the candles");
+  assert.equal(t.turns[0].final, false);
+});
+
+test("a partial from the other role opens its own turn", () => {
+  let t = applyPartial(emptyTranscript, "user", "light the candles");
+  t = applyPartial(t, "assistant", "All seven of");
+  assert.deepEqual(
+    t.turns.map((turn) => [turn.role, turn.text]),
+    [
+      ["user", "light the candles"],
+      ["assistant", "All seven of"],
+    ],
+  );
+  assert.notEqual(t.turns[0].id, t.turns[1].id, "turn ids stay unique");
+});
+
+test("a final settles the open turn it was built from", () => {
+  let t = applyPartial(emptyTranscript, "assistant", "All seven of");
+  t = applyFinal(t, "assistant", "All seven of them are lit.");
+  assert.equal(t.turns.length, 1);
+  assert.equal(t.turns[0].text, "All seven of them are lit.");
+  assert.equal(t.turns[0].final, true);
+});
+
+test("a repeated final does not stutter the transcript", () => {
+  // Realtime providers emit a `done` transcript for text the overlay may
+  // already have settled.
+  let t = applyFinal(emptyTranscript, "assistant", "All seven are lit.");
+  t = applyFinal(t, "assistant", "All seven are lit.");
+  assert.equal(t.turns.length, 1);
+});
+
+test("a final with no open turn lands as its own turn", () => {
+  let t = applyFinal(emptyTranscript, "user", "light the candles");
+  t = applyFinal(t, "assistant", "Done.");
+  assert.deepEqual(
+    t.turns.map((turn) => turn.role),
+    ["user", "assistant"],
+  );
+});
+
+test("blank text never opens a turn", () => {
+  assert.equal(applyPartial(emptyTranscript, "user", "   ").turns.length, 0);
+  assert.equal(applyFinal(emptyTranscript, "user", "\n").turns.length, 0);
+});
+
+test("a long call keeps a bounded window of turns", () => {
+  let t = emptyTranscript;
+  for (let i = 0; i < MAX_CALL_TURNS + 12; i += 1) {
+    t = applyFinal(t, i % 2 === 0 ? "user" : "assistant", `turn ${i}`);
+  }
+  assert.equal(t.turns.length, MAX_CALL_TURNS);
+  assert.equal(t.turns[t.turns.length - 1].text, `turn ${MAX_CALL_TURNS + 11}`);
+});
+
+test("speaking is normalized and clears", () => {
+  const t = applySpeaking(emptyTranscript, "  All seven are lit.  ");
+  assert.equal(t.speaking, "All seven are lit.");
+  assert.equal(applySpeaking(t, null).speaking, null);
+  assert.equal(applySpeaking(t, "   ").speaking, null);
+  assert.equal(applySpeaking(t, "All seven are lit."), t, "an unchanged utterance is not a new state");
+});
+
+test("splitSpokenText brackets the spoken sentence inside the turn", () => {
+  const text = "The candles are lit. All seven of them. Shall we begin?";
+  const split = splitSpokenText(text, "All seven of them.");
+  assert.equal(split.before, "The candles are lit. ");
+  assert.equal(split.match, "All seven of them.");
+  assert.equal(split.after, " Shall we begin?");
+});
+
+test("splitSpokenText tolerates rewrapped whitespace", () => {
+  // The chunker trims what it hands the mouth; a streamed reply can wrap
+  // differently by the time it settles.
+  const split = splitSpokenText("Ready when you\nare, witch.", "Ready when you are,");
+  assert.equal(split.match, "Ready when you\nare,");
+  assert.equal(split.after, " witch.");
+});
+
+test("splitSpokenText never drops words when the utterance is absent", () => {
+  const split = splitSpokenText("Nothing like it here.", "a sentence from another turn");
+  assert.equal(split.before, "Nothing like it here.");
+  assert.equal(split.match, "");
+  assert.equal(split.after, "");
+});
+
+test("splitSpokenText survives regex-shaped utterances", () => {
+  const split = splitSpokenText("Cost is $5 (plus tax).", "$5 (plus tax).");
+  assert.equal(split.match, "$5 (plus tax).");
+});
+
+test("the highlight tracks the newest matching assistant turn", () => {
+  let t = applyFinal(emptyTranscript, "assistant", "Ready when you are.");
+  t = applyFinal(t, "user", "again please");
+  t = applyFinal(t, "assistant", "Ready when you are.");
+  t = applySpeaking(t, "Ready when you are.");
+  assert.equal(speakingTurnId(t), t.turns[2].id, "the reply being voiced now wins");
+});
+
+test("the highlight never lands on a user turn", () => {
+  let t = applyFinal(emptyTranscript, "user", "Ready when you are.");
+  t = applySpeaking(t, "Ready when you are.");
+  assert.equal(speakingTurnId(t), null);
+});
+
+test("no utterance means no highlighted turn", () => {
+  const t = applyFinal(emptyTranscript, "assistant", "Ready when you are.");
+  assert.equal(speakingTurnId(t), null);
+});

--- a/src/lib/voice/call-transcript.ts
+++ b/src/lib/voice/call-transcript.ts
@@ -1,0 +1,174 @@
+// The live transcript a call renders while it is up.
+//
+// Three signals feed it, and they do not arrive in tidy turn order:
+//   partial   — the ACCUMULATED text of the turn currently being transcribed
+//               (ears) or streamed (brain); replaces, never appends
+//   final     — the settled text of a completed turn
+//   speaking  — the utterance the mouth is voicing RIGHT NOW. Loop providers
+//               voice sentence chunks (speech-loop.ts), so this is a substring
+//               of the assistant turn, which is exactly what lets the overlay
+//               highlight the words being spoken instead of the whole reply.
+//
+// Everything here is pure so the highlight logic is testable without a
+// microphone, a synthesizer, or a DOM.
+
+export type CallTurnRole = "user" | "assistant";
+
+export type CallTurn = {
+  id: string;
+  role: CallTurnRole;
+  text: string;
+  /** False while the turn is still being transcribed or streamed. */
+  final: boolean;
+};
+
+export type CallTranscript = {
+  turns: CallTurn[];
+  /** Monotonic source for turn ids — stable React keys across updates. */
+  seq: number;
+  /** The utterance being voiced right now, or null when the mouth is idle. */
+  speaking: string | null;
+};
+
+export const emptyTranscript: CallTranscript = { turns: [], seq: 0, speaking: null };
+
+/** How many turns a single call keeps in view. A long call must not grow the
+ *  DOM without bound; the persisted chat transcript is the durable record. */
+export const MAX_CALL_TURNS = 60;
+
+function trimToCap(turns: CallTurn[]): CallTurn[] {
+  return turns.length <= MAX_CALL_TURNS ? turns : turns.slice(turns.length - MAX_CALL_TURNS);
+}
+
+/**
+ * Fold in the accumulated text of an in-flight turn. A partial for the role
+ * that already owns the open turn REPLACES it; anything else opens a new one,
+ * which is what makes a mid-reply user interjection render as its own bubble.
+ */
+export function applyPartial(
+  transcript: CallTranscript,
+  role: CallTurnRole,
+  text: string,
+): CallTranscript {
+  if (!text.trim()) return transcript;
+  const last = transcript.turns[transcript.turns.length - 1];
+  if (last && !last.final && last.role === role) {
+    if (last.text === text) return transcript;
+    const turns = transcript.turns.slice(0, -1);
+    turns.push({ ...last, text });
+    return { ...transcript, turns };
+  }
+  const seq = transcript.seq + 1;
+  return {
+    ...transcript,
+    seq,
+    turns: trimToCap([...transcript.turns, { id: `t${seq}`, role, text, final: false }]),
+  };
+}
+
+/**
+ * Settle a turn. An open turn of the same role is upgraded in place (the
+ * partials that built it were the same utterance); otherwise the final lands
+ * as a new turn. A final identical to the previous settled turn of that role
+ * is dropped — realtime providers emit a `done` transcript for text we may
+ * already have settled, and a call must not stutter.
+ */
+export function applyFinal(
+  transcript: CallTranscript,
+  role: CallTurnRole,
+  text: string,
+): CallTranscript {
+  const settled = text.trim();
+  if (!settled) return transcript;
+  const turns = transcript.turns.slice();
+  const last = turns[turns.length - 1];
+  if (last && !last.final && last.role === role) {
+    turns[turns.length - 1] = { ...last, text: settled, final: true };
+    return { ...transcript, turns };
+  }
+  if (last && last.final && last.role === role && last.text === settled) {
+    return transcript;
+  }
+  const seq = transcript.seq + 1;
+  return {
+    ...transcript,
+    seq,
+    turns: trimToCap([...turns, { id: `t${seq}`, role, text: settled, final: true }]),
+  };
+}
+
+/** Record (or clear) the utterance the mouth is voicing. */
+export function applySpeaking(
+  transcript: CallTranscript,
+  utterance: string | null,
+): CallTranscript {
+  const next = utterance && utterance.trim() ? utterance.trim() : null;
+  if (next === transcript.speaking) return transcript;
+  return { ...transcript, speaking: next };
+}
+
+export type SpokenSplit = {
+  before: string;
+  /** The spoken run, empty when this turn is not the one being voiced. */
+  match: string;
+  after: string;
+};
+
+/** Regex-escape, then let any whitespace run match any other. The chunker
+ *  trims what it hands the mouth, and a streamed reply can rewrap, so an
+ *  exact `indexOf` misses highlights it should have found. */
+function spokenPattern(spoken: string): RegExp {
+  const escaped = spoken
+    .trim()
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\s+/g, "\\s+");
+  return new RegExp(escaped);
+}
+
+/**
+ * Split a turn's text around the utterance being spoken, so the overlay can
+ * wrap the middle in a highlight. Returns the whole text as `before` when the
+ * utterance is absent from it — the highlight is an enhancement, never a
+ * reason to drop words from the transcript.
+ */
+export function splitSpokenText(text: string, spoken: string | null): SpokenSplit {
+  if (!spoken || !spoken.trim()) return { before: text, match: "", after: "" };
+  const exact = text.indexOf(spoken);
+  if (exact >= 0) {
+    return {
+      before: text.slice(0, exact),
+      match: text.slice(exact, exact + spoken.length),
+      after: text.slice(exact + spoken.length),
+    };
+  }
+  let found: RegExpExecArray | null = null;
+  try {
+    found = spokenPattern(spoken).exec(text);
+  } catch {
+    // A pathological chunk that won't compile is simply not highlighted.
+    found = null;
+  }
+  if (!found) return { before: text, match: "", after: "" };
+  return {
+    before: text.slice(0, found.index),
+    match: found[0],
+    after: text.slice(found.index + found[0].length),
+  };
+}
+
+/**
+ * Which turn the highlight belongs to: the LAST assistant turn whose text
+ * contains the spoken utterance. Scanning from the end matters because a
+ * familiar repeats itself across a long call, and the highlight must track the
+ * reply being voiced now, not the first one that happened to match.
+ */
+export function speakingTurnId(transcript: CallTranscript): string | null {
+  const { speaking, turns } = transcript;
+  if (!speaking) return null;
+  for (let i = turns.length - 1; i >= 0; i -= 1) {
+    const turn = turns[i]!;
+    if (turn.role !== "assistant") continue;
+    if (splitSpokenText(turn.text, speaking).match) return turn.id;
+  }
+  return null;
+}

--- a/src/lib/voice/elevenlabs.ts
+++ b/src/lib/voice/elevenlabs.ts
@@ -108,20 +108,42 @@ export function createElevenLabsMouth(opts: {
   let cancelled = false;
   let currentAudio: HTMLAudioElement | null = null;
   let currentUrl: string | null = null;
+  let currentAbort: AbortController | null = null;
+  /** Settles the promise `speak()` is parked on, so a stop mid-playback lets
+   *  the speech loop's queue keep draining instead of wedging on an `onended`
+   *  that a pause never fires. */
+  let settlePlayback: (() => void) | null = null;
+  /** Bumped by every stop so a synthesis already in flight can tell that its
+   *  utterance has been abandoned. */
+  let generation = 0;
 
   const releaseCurrent = () => {
     if (currentUrl) URL.revokeObjectURL(currentUrl);
     currentUrl = null;
     currentAudio = null;
+    currentAbort = null;
+    settlePlayback = null;
+  };
+
+  const stopCurrent = () => {
+    generation += 1;
+    currentAbort?.abort();
+    currentAudio?.pause();
+    const settle = settlePlayback;
+    releaseCurrent();
+    settle?.();
   };
 
   return {
     async speak(text: string) {
       if (cancelled) return;
+      const gen = generation;
       const clamped =
         text.length > ELEVENLABS_TTS_MAX_CHARS
           ? `${text.slice(0, ELEVENLABS_TTS_MAX_CHARS - 1)}…`
           : text;
+      const controller = new AbortController();
+      currentAbort = controller;
       let res: Response;
       try {
         res = await fetchImpl("/api/voice/elevenlabs/tts", {
@@ -132,13 +154,18 @@ export function createElevenLabsMouth(opts: {
             voiceId: opts.voiceId,
             modelId: opts.modelId,
           }),
+          signal: controller.signal,
         });
       } catch {
+        // An abandoned utterance is not a call failure — a barge-in aborted
+        // its own request on purpose.
+        if (cancelled || gen !== generation || controller.signal.aborted) return;
         throw new VoiceConnectError(
           "elevenlabs_tts_failed",
           "Couldn't reach the ElevenLabs speech proxy — check your connection.",
         );
       }
+      if (cancelled || gen !== generation) return;
       if (!res.ok) {
         let code = "elevenlabs_tts_failed";
         let hint: string | undefined;
@@ -150,16 +177,20 @@ export function createElevenLabsMouth(opts: {
         throw new VoiceConnectError(code, hint);
       }
       const blob = await res.blob();
-      if (cancelled) return;
+      if (cancelled || gen !== generation) return;
       const url = URL.createObjectURL(blob);
       currentUrl = url;
       await new Promise<void>((resolve) => {
         const audio = new Audio();
         currentAudio = audio;
+        let settled = false;
         const done = () => {
+          if (settled) return;
+          settled = true;
           releaseCurrent();
           resolve();
         };
+        settlePlayback = done;
         audio.onended = done;
         audio.onerror = done;
         audio.src = url;
@@ -168,8 +199,11 @@ export function createElevenLabsMouth(opts: {
     },
     cancel() {
       cancelled = true;
-      currentAudio?.pause();
-      releaseCurrent();
+      stopCurrent();
+    },
+    // Barge-in: stop this utterance but stay usable, unlike cancel().
+    interrupt() {
+      stopCurrent();
     },
   };
 }

--- a/src/lib/voice/local-tts.ts
+++ b/src/lib/voice/local-tts.ts
@@ -54,6 +54,10 @@ export function createLocalTtsMouth(options: {
   let currentAudio: HTMLAudioElement | null = null;
   let currentUrl: string | null = null;
   let settlePlayback: (() => void) | null = null;
+  /** Bumped by every stop. A long utterance is spoken as several chunks, so
+   *  an interrupt has to stop the chunks still queued inside `speak()` too —
+   *  not just the one already playing. */
+  let generation = 0;
 
   const releaseCurrent = () => {
     currentAbort = null;
@@ -141,19 +145,29 @@ export function createLocalTtsMouth(options: {
     }
   };
 
+  const stopCurrent = () => {
+    generation += 1;
+    currentAbort?.abort();
+    currentAudio?.pause();
+    settlePlayback?.();
+    releaseCurrent();
+  };
+
   return {
     async speak(text: string) {
+      const gen = generation;
       for (const chunk of splitLocalTtsText(text)) {
-        if (cancelled) return;
+        if (cancelled || gen !== generation) return;
         await speakChunk(chunk);
       }
     },
     cancel() {
       cancelled = true;
-      currentAbort?.abort();
-      currentAudio?.pause();
-      settlePlayback?.();
-      releaseCurrent();
+      stopCurrent();
+    },
+    // Barge-in: stop this utterance but stay usable, unlike cancel().
+    interrupt() {
+      stopCurrent();
     },
   };
 }

--- a/src/lib/voice/openai-realtime.test.ts
+++ b/src/lib/voice/openai-realtime.test.ts
@@ -17,7 +17,13 @@ let lastDataChannel: { onmessage: ((ev: { data: unknown }) => void) | null; clos
   onconnectionstatechange: unknown = null;
   addTrack() {}
   createDataChannel() {
-    lastDataChannel = { onmessage: null, close() {} };
+    lastDataChannel = {
+      onmessage: null,
+      readyState: "open",
+      sent: [],
+      send(payload: string) { this.sent.push(JSON.parse(payload)); },
+      close() {},
+    };
     return lastDataChannel;
   }
   async createOffer() { return { type: "offer", sdp: "v=0\r\n" }; }
@@ -182,4 +188,100 @@ test("data-channel error events surface provider message as hint under a stable 
   assert.ok(seen instanceof VoiceConnectError, "onError receives VoiceConnectError");
   assert.equal((seen as any).message, "provider_error");
   assert.equal((seen as any).hint, "session expired");
+});
+
+// ── Live transcript + typed replies (cave-zr9dx) ──────────────────────────
+
+test("assistant deltas accumulate into whole-turn partials and a speaking signal", async () => {
+  nextResponse = new Response("v=0\r\n", { status: 201 });
+  const partials: [string, string][] = [];
+  const speaking: (string | null)[] = [];
+  const finals: string[] = [];
+  await openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, {
+    ...noopCallbacks,
+    onPartialTranscript(role: string, text: string) { partials.push([role, text]); },
+    onSpeaking(utterance: string | null) { speaking.push(utterance); },
+    onAssistantTranscriptFinal(text: string) { finals.push(text); },
+  });
+  const deltas = ["The candles ", "are lit."];
+  for (const delta of deltas) {
+    lastDataChannel?.onmessage?.({
+      data: JSON.stringify({ type: "response.output_audio_transcript.delta", delta }),
+    });
+  }
+  // Every other provider reports the accumulated turn; this adapter owes the
+  // same contract so the live transcript renders by replacement.
+  assert.deepEqual(partials, [
+    ["assistant", "The candles "],
+    ["assistant", "The candles are lit."],
+  ]);
+  assert.deepEqual(speaking, ["The candles ", "The candles are lit."]);
+
+  lastDataChannel?.onmessage?.({
+    data: JSON.stringify({
+      type: "response.output_audio_transcript.done",
+      transcript: "The candles are lit.",
+    }),
+  });
+  assert.deepEqual(finals, ["The candles are lit."]);
+  assert.equal(speaking[speaking.length - 1], null, "the highlight clears when the turn ends");
+});
+
+test("a second response starts from empty, not from the previous turn's text", async () => {
+  nextResponse = new Response("v=0\r\n", { status: 201 });
+  const partials: string[] = [];
+  await openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, {
+    ...noopCallbacks,
+    onPartialTranscript(_role: string, text: string) { partials.push(text); },
+  });
+  const delta = (delta: string) =>
+    lastDataChannel?.onmessage?.({
+      data: JSON.stringify({ type: "response.output_audio_transcript.delta", delta }),
+    });
+  delta("First.");
+  lastDataChannel?.onmessage?.({
+    data: JSON.stringify({ type: "response.output_audio_transcript.done", transcript: "First." }),
+  });
+  delta("Second.");
+  assert.deepEqual(partials, ["First.", "Second."]);
+});
+
+test("sendText queues a user item, asks for a response, and reports the turn", async () => {
+  nextResponse = new Response("v=0\r\n", { status: 201 });
+  const userFinals: string[] = [];
+  const session = await openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, {
+    ...noopCallbacks,
+    onUserTranscriptFinal(text: string) { userFinals.push(text); },
+  });
+  session.sendText("  say that again  ");
+  assert.deepEqual(
+    lastDataChannel?.sent.map((ev: any) => ev.type),
+    ["conversation.item.create", "response.create"],
+  );
+  assert.deepEqual(lastDataChannel?.sent[0].item.content, [
+    { type: "input_text", text: "say that again" },
+  ]);
+  // A typed turn never passes through input-audio transcription, so the
+  // adapter is the only thing that can put it in the transcript.
+  assert.deepEqual(userFinals, ["say that again"]);
+  session.sendText("   ");
+  assert.equal(lastDataChannel?.sent.length, 2, "a blank reply sends nothing");
+});
+
+test("a typed reply mid-answer cancels the response first, and never otherwise", async () => {
+  nextResponse = new Response("v=0\r\n", { status: 201 });
+  const session = await openaiRealtimeProvider.clientAdapter.connect(sdpGrant, fakeMic, noopCallbacks);
+  // Nothing in flight: `response.cancel` with no active response comes back as
+  // an error event, so it must not be sent.
+  session.interrupt();
+  assert.deepEqual(lastDataChannel?.sent, []);
+
+  lastDataChannel?.onmessage?.({
+    data: JSON.stringify({ type: "response.output_audio_transcript.delta", delta: "Once upon" }),
+  });
+  session.sendText("stop");
+  assert.deepEqual(
+    lastDataChannel?.sent.map((ev: any) => ev.type),
+    ["response.cancel", "conversation.item.create", "response.create"],
+  );
 });

--- a/src/lib/voice/openai-realtime.ts
+++ b/src/lib/voice/openai-realtime.ts
@@ -73,7 +73,8 @@ const clientAdapter: VoiceClientAdapter = {
     for (const track of mic.getAudioTracks()) pc.addTrack(track, mic);
 
     const events = pc.createDataChannel("oai-events");
-    events.onmessage = (ev) => handleEvent(ev.data, callbacks);
+    const stream = createRealtimeEventStream(callbacks);
+    events.onmessage = (ev) => stream.handle(ev.data);
     pc.onconnectionstatechange = () => {
       if (pc.connectionState === "failed") {
         callbacks.onDisconnect();
@@ -111,10 +112,48 @@ const clientAdapter: VoiceClientAdapter = {
 
     const localTracks = mic.getAudioTracks();
 
+    const send = (payload: unknown) => {
+      if (events.readyState !== "open") return false;
+      try {
+        events.send(JSON.stringify(payload));
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    /** Cut the model off mid-answer. Only when a response is actually in
+     *  flight — `response.cancel` with nothing to cancel comes back as an
+     *  error event, which would surface to the user as a call failure. */
+    const interrupt = () => {
+      if (!stream.isResponding()) return;
+      send({ type: "response.cancel" });
+      stream.endResponse();
+    };
+
     return {
       inboundAudio: inbound,
       setMuted(muted) {
         for (const t of localTracks) t.enabled = !muted;
+      },
+      interrupt,
+      sendText(text: string) {
+        const trimmed = text.trim();
+        if (!trimmed) return;
+        interrupt();
+        const queued = send({
+          type: "conversation.item.create",
+          item: {
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: trimmed }],
+          },
+        });
+        if (!queued) return;
+        send({ type: "response.create" });
+        // Typed turns never pass through input-audio transcription, so the
+        // transcript only gets this turn if we report it ourselves.
+        callbacks.onUserTranscriptFinal(trimmed);
       },
       async close() {
         try { events.close(); } catch { /* ignore */ }
@@ -124,25 +163,63 @@ const clientAdapter: VoiceClientAdapter = {
   },
 };
 
-function handleEvent(raw: unknown, callbacks: VoiceCallbacks) {
-  if (typeof raw !== "string") return;
-  let ev: any;
-  try { ev = JSON.parse(raw); } catch { return; }
-  const type = ev?.type as string | undefined;
-  if (!type) return;
-  if (type === "conversation.item.input_audio_transcription.completed") {
-    if (typeof ev.transcript === "string") callbacks.onUserTranscriptFinal(ev.transcript);
-  } else if (type === "response.output_audio_transcript.done" || type === "response.audio_transcript.done") {
-    // GA name first; beta name kept for compatibility.
-    if (typeof ev.transcript === "string") callbacks.onAssistantTranscriptFinal(ev.transcript);
-  } else if (type === "response.output_audio_transcript.delta" || type === "response.audio_transcript.delta") {
-    if (typeof ev.delta === "string") callbacks.onPartialTranscript("assistant", ev.delta);
-  } else if (type === "conversation.item.input_audio_transcription.delta") {
-    if (typeof ev.delta === "string") callbacks.onPartialTranscript("user", ev.delta);
-  } else if (type === "error") {
-    const detail = typeof ev.error?.message === "string" ? ev.error.message : undefined;
-    callbacks.onError(new VoiceConnectError("provider_error", detail));
-  }
+/**
+ * Realtime's transcript events are DELTAS; every other provider reports the
+ * accumulated turn (see `VoiceCallbacks.onPartialTranscript`). Accumulating
+ * here keeps that contract one adapter wide instead of pushing it onto every
+ * consumer, and gives the call transcript whole-turn text to highlight.
+ *
+ * The audio and its transcript stream together, so a live assistant delta is
+ * also the best "being spoken right now" signal this provider has — there is
+ * no utterance queue to read, the way a speech-loop call has.
+ */
+export function createRealtimeEventStream(callbacks: VoiceCallbacks) {
+  let assistant = "";
+  let user = "";
+  let responding = false;
+
+  const endResponse = () => {
+    responding = false;
+    assistant = "";
+    callbacks.onSpeaking?.(null);
+  };
+
+  return {
+    isResponding: () => responding,
+    endResponse,
+    handle(raw: unknown) {
+      if (typeof raw !== "string") return;
+      let ev: any;
+      try { ev = JSON.parse(raw); } catch { return; }
+      const type = ev?.type as string | undefined;
+      if (!type) return;
+      if (type === "conversation.item.input_audio_transcription.completed") {
+        user = "";
+        if (typeof ev.transcript === "string") callbacks.onUserTranscriptFinal(ev.transcript);
+      } else if (type === "response.output_audio_transcript.done" || type === "response.audio_transcript.done") {
+        // GA name first; beta name kept for compatibility.
+        if (typeof ev.transcript === "string") callbacks.onAssistantTranscriptFinal(ev.transcript);
+        endResponse();
+      } else if (type === "response.output_audio_transcript.delta" || type === "response.audio_transcript.delta") {
+        if (typeof ev.delta === "string") {
+          responding = true;
+          assistant += ev.delta;
+          callbacks.onPartialTranscript("assistant", assistant);
+          callbacks.onSpeaking?.(assistant);
+        }
+      } else if (type === "conversation.item.input_audio_transcription.delta") {
+        if (typeof ev.delta === "string") {
+          user += ev.delta;
+          callbacks.onPartialTranscript("user", user);
+        }
+      } else if (type === "response.done" || type === "response.cancelled") {
+        endResponse();
+      } else if (type === "error") {
+        const detail = typeof ev.error?.message === "string" ? ev.error.message : undefined;
+        callbacks.onError(new VoiceConnectError("provider_error", detail));
+      }
+    },
+  };
 }
 
 export const openaiRealtimeProvider: VoiceProvider = {

--- a/src/lib/voice/speech-loop.test.ts
+++ b/src/lib/voice/speech-loop.test.ts
@@ -99,11 +99,40 @@ function fakeMouth() {
   };
 }
 
-function loopFixture({ brain, earsEngine, mouthEngine } = {}) {
+/** A mouth that parks mid-utterance until interrupted or released — the shape
+ *  barge-in actually has to work against. */
+function deferredMouth() {
+  const spoken = [];
+  let release = null;
+  return {
+    spoken,
+    release: () => { const r = release; release = null; r?.(); },
+    mouth: {
+      speak(text) {
+        spoken.push(text);
+        return new Promise((resolve) => { release = resolve; });
+      },
+      cancel() {
+        spoken.push("<cancel>");
+        const r = release;
+        release = null;
+        r?.();
+      },
+      interrupt() {
+        spoken.push("<interrupt>");
+        const r = release;
+        release = null;
+        r?.();
+      },
+    },
+  };
+}
+
+function loopFixture({ brain, earsEngine, mouthEngine, mouth: injected } = {}) {
   const ears = fakeEars();
   const mic = fakeMic();
-  const mouth = fakeMouth();
-  const events = { userFinals: [], assistantFinals: [], errors: [] };
+  const mouth = injected ?? fakeMouth();
+  const events = { userFinals: [], assistantFinals: [], errors: [], speaking: [] };
   const session = connectSpeechLoop({
     mic: mic.stream,
     ears: ears.factory,
@@ -114,6 +143,7 @@ function loopFixture({ brain, earsEngine, mouthEngine } = {}) {
       onUserTranscriptFinal: (t) => events.userFinals.push(t),
       onAssistantTranscriptFinal: (t) => events.assistantFinals.push(t),
       onPartialTranscript: () => {},
+      onSpeaking: (utterance) => events.speaking.push(utterance),
       onError: (err) => events.errors.push(err),
       onDisconnect: () => {},
     },
@@ -315,4 +345,149 @@ test("web ears route finals, partials, and non-routine errors", () => {
     recognition.onerror({ error: "audio-capture" });
     assert.deepEqual(got.errors, ["stt_audio-capture"]);
   });
+});
+
+// ── Live transcript, highlight, and typed replies (cave-zr9dx) ─────────────
+
+test("each queued utterance is announced as it starts and silence on drain", async () => {
+  const { ears, events } = loopFixture({
+    brain: async (userText, speak) => {
+      speak("First sentence out loud.");
+      speak("Second sentence out loud.");
+      return "First sentence out loud. Second sentence out loud.";
+    },
+  });
+  ears.handlers.onFinal("say two things");
+  await tick();
+  await tick();
+  await tick();
+
+  // The highlight follows the QUEUE, one sentence at a time, then clears —
+  // that is what lets the overlay mark only the words being heard.
+  assert.deepEqual(events.speaking, [
+    "First sentence out loud.",
+    "Second sentence out loud.",
+    null,
+  ]);
+});
+
+test("a typed reply becomes a real turn and barges in on the synthesizer", async () => {
+  const mouth = deferredMouth();
+  const { ears, events, session } = loopFixture({
+    mouth,
+    brain: async (userText, speak) => {
+      const reply = `heard: ${userText}`;
+      speak(reply);
+      return reply;
+    },
+  });
+
+  ears.handlers.onFinal("tell me a long story");
+  await tick();
+  await tick();
+  assert.deepEqual(mouth.spoken, ["heard: tell me a long story"]);
+  assert.equal(events.speaking[events.speaking.length - 1], "heard: tell me a long story");
+
+  session.sendText("  actually, stop  ");
+  await tick();
+  await tick();
+  await tick();
+
+  // The utterance in flight is cut off, the highlight clears immediately, and
+  // the typed text lands in the transcript exactly like a spoken final.
+  assert.ok(mouth.spoken.includes("<interrupt>"), "the mouth was interrupted");
+  assert.deepEqual(events.userFinals, ["tell me a long story", "actually, stop"]);
+  assert.ok(events.speaking.includes(null), "the highlight cleared on barge-in");
+  assert.ok(
+    events.assistantFinals.includes("heard: actually, stop"),
+    "the typed turn reached the brain",
+  );
+  assert.deepEqual(events.errors, []);
+});
+
+test("a blank typed reply is not a turn", async () => {
+  let brainCalls = 0;
+  const { events, session } = loopFixture({
+    brain: async () => { brainCalls += 1; return ""; },
+  });
+  session.sendText("   ");
+  await tick();
+  assert.equal(brainCalls, 0);
+  assert.deepEqual(events.userFinals, []);
+});
+
+test("interrupt drops the queue behind the current utterance and hands the floor back", async () => {
+  const mouth = deferredMouth();
+  const { ears, events, session } = loopFixture({
+    mouth,
+    brain: async (userText, speak) => {
+      speak("One.");
+      speak("Two.");
+      speak("Three.");
+      return "One. Two. Three.";
+    },
+  });
+  ears.handlers.onFinal("count");
+  await tick();
+  await tick();
+  assert.deepEqual(mouth.spoken, ["One."]);
+
+  session.interrupt();
+  await tick();
+  await tick();
+
+  // Only the sentence already in flight was ever voiced; the rest is dropped
+  // and the ears are listening again.
+  assert.deepEqual(mouth.spoken.filter((s) => !s.startsWith("<")), ["One."]);
+  assert.equal(events.speaking[events.speaking.length - 1], null);
+  assert.equal(ears.log[ears.log.length - 1], "listen");
+});
+
+test("a typed reply still works while the mic is muted", async () => {
+  const { events, session } = loopFixture();
+  session.setMuted(true);
+  session.sendText("typing instead");
+  await tick();
+  await tick();
+  assert.deepEqual(events.userFinals, ["typing instead"]);
+  assert.deepEqual(events.assistantFinals, ["heard: typing instead"]);
+});
+
+test("a closed session ignores typed replies", async () => {
+  const { events, session } = loopFixture();
+  await session.close();
+  session.sendText("too late");
+  await tick();
+  assert.deepEqual(events.userFinals, []);
+});
+
+test("a barged-in brain cannot refill the queue it was cut off from", async () => {
+  const mouth = deferredMouth();
+  let emit = null;
+  const { ears, session } = loopFixture({
+    mouth,
+    // A streaming brain: it keeps producing sentences after the barge-in.
+    brain: async (userText, speak) => {
+      speak("Once upon a time.");
+      await new Promise((resolve) => { emit = () => { speak("And then more."); resolve(); }; });
+      return "Once upon a time. And then more.";
+    },
+  });
+  ears.handlers.onFinal("tell me a story");
+  await tick();
+  await tick();
+  assert.deepEqual(mouth.spoken, ["Once upon a time."]);
+
+  session.interrupt();
+  await tick();
+  emit();
+  await tick();
+  await tick();
+
+  // The sentence the muzzled turn emitted after the interrupt is dropped —
+  // otherwise the familiar talks over the person who just stopped it.
+  assert.deepEqual(
+    mouth.spoken.filter((s) => !s.startsWith("<")),
+    ["Once upon a time."],
+  );
 });

--- a/src/lib/voice/speech-loop.ts
+++ b/src/lib/voice/speech-loop.ts
@@ -31,11 +31,16 @@ export type SpeechBrain = (
 ) => Promise<string>;
 
 /** The mouth half of the loop: voice one utterance, resolving when playback
- *  finishes. `cancel()` stops playback immediately (call ending). The default
- *  mouth is the system synthesizer; ElevenLabs plugs in a network mouth. */
+ *  finishes. `cancel()` stops playback immediately and retires the mouth (call
+ *  ending). `interrupt()` also stops playback but leaves the mouth usable —
+ *  barge-in, when a typed reply arrives mid-sentence — and must settle the
+ *  in-flight `speak()` promise so the loop's queue keeps draining. A mouth
+ *  without one simply finishes the current utterance. The default mouth is the
+ *  system synthesizer; ElevenLabs plugs in a network mouth. */
 export type SpeechMouth = {
   speak(text: string): Promise<void>;
   cancel(): void;
+  interrupt?(): void;
 };
 
 /** The system speechSynthesis mouth — AVSpeechSynthesizer voices on macOS
@@ -63,6 +68,11 @@ export function createSystemSynthMouth(voiceName?: string): SpeechMouth {
       });
     },
     cancel() {
+      if (typeof window !== "undefined") window.speechSynthesis?.cancel();
+    },
+    // speechSynthesis.cancel() fires `onend` on the utterance in flight, so
+    // the pending speak() settles and the queue keeps draining.
+    interrupt() {
       if (typeof window !== "undefined") window.speechSynthesis?.cancel();
     },
   };
@@ -258,6 +268,9 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
   const utterances: string[] = [];
   let speaking = false;
   let onQueueDrained: (() => void) | null = null;
+  /** Bumped by every barge-in; a brain turn only feeds the queue while its
+   *  own epoch is still current. */
+  let speechEpoch = 0;
 
   const ears = earsFactory({
     onPartial: (text) => {
@@ -286,18 +299,24 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
     if (closed) {
       utterances.length = 0;
       speaking = false;
+      callbacks.onSpeaking?.(null);
       onQueueDrained?.();
       return;
     }
     const text = utterances.shift();
     if (text === undefined) {
       speaking = false;
+      callbacks.onSpeaking?.(null);
       onQueueDrained?.();
       listen();
       return;
     }
     speaking = true;
     hush();
+    // The transcript highlight rides the queue, not the brain: this is the
+    // exact sentence the synthesizer is about to voice, so the overlay can
+    // mark those words as they are heard (cave-zr9dx).
+    callbacks.onSpeaking?.(text);
     mouth
       .speak(text)
       .catch((err) => {
@@ -321,6 +340,23 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
     if (!speaking) speakNext();
   };
 
+  /** Barge-in: drop whatever is still queued and stop the utterance in
+   *  flight, without ending the call. The mouth's `interrupt()` settles the
+   *  pending speak() so `speakNext` runs, finds an empty queue, and hands the
+   *  floor back to the ears. A mouth without one finishes its current
+   *  sentence — the queue behind it is still dropped. */
+  const interrupt = () => {
+    if (closed) return;
+    // Muzzle the turn already in flight. A streaming brain goes on emitting
+    // sentences after the barge-in, and without this they refill the queue we
+    // just cleared — the familiar would talk over the reply that stopped it.
+    speechEpoch += 1;
+    utterances.length = 0;
+    mouth.interrupt?.();
+    callbacks.onSpeaking?.(null);
+    if (!speaking) listen();
+  };
+
   /** Resolves once every queued utterance has been voiced. */
   const queueDrained = () =>
     new Promise<void>((resolve) => {
@@ -336,8 +372,12 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
       return;
     }
     brainBusy = true;
+    const epoch = speechEpoch;
     try {
-      const finalText = await opts.brain(userText, enqueueSpeech);
+      const finalText = await opts.brain(userText, (chunk) => {
+        if (epoch !== speechEpoch) return;
+        enqueueSpeech(chunk);
+      });
       if (closed) return;
       callbacks.onAssistantTranscriptFinal(finalText);
       await queueDrained();
@@ -376,6 +416,18 @@ export function connectSpeechLoop(opts: SpeechLoopOptions): LiveSession {
       for (const track of mic.getAudioTracks()) track.enabled = !next;
       if (next) hush();
       else listen();
+    },
+    interrupt,
+    // A typed reply is a first-class turn: it barges in on whatever the
+    // familiar was still saying, lands in the transcript like a spoken one,
+    // and goes to the same brain. Muting the mic does not disable it — that
+    // is the point of being able to type instead of speak.
+    sendText(text: string) {
+      const trimmed = text.trim();
+      if (closed || !trimmed) return;
+      interrupt();
+      callbacks.onUserTranscriptFinal(trimmed);
+      void askBrain(trimmed);
     },
     async close() {
       closed = true;

--- a/src/lib/voice/types.ts
+++ b/src/lib/voice/types.ts
@@ -43,7 +43,17 @@ export interface VoiceClientAdapter {
 export type VoiceCallbacks = {
   onUserTranscriptFinal: (text: string) => void;
   onAssistantTranscriptFinal: (text: string) => void;
-  onPartialTranscript: (role: "user" | "assistant", delta: string) => void;
+  /** The ACCUMULATED text of the turn in flight, not a delta. Every adapter
+   *  owes the caller whole-turn text so the live transcript can render it by
+   *  replacement; the realtime adapter accumulates its own deltas to honor
+   *  this. */
+  onPartialTranscript: (role: "user" | "assistant", text: string) => void;
+  /** The utterance the call's mouth is voicing right now, or null when it
+   *  falls silent. Loop providers pass the exact sentence chunk they handed
+   *  the synthesizer — a substring of the assistant turn, which is what lets
+   *  the overlay highlight the words being spoken. Realtime providers, whose
+   *  audio and transcript stream together, pass the accumulated turn text. */
+  onSpeaking?: (utterance: string | null) => void;
   onError: (err: Error) => void;
   onDisconnect: () => void;
 };
@@ -52,6 +62,14 @@ export interface LiveSession {
   inboundAudio: MediaStream;
   setMuted(muted: boolean): void;
   close(): Promise<void>;
+  /** Send a typed turn into the live call — the reply affordance in the call
+   *  transcript. Absent when the provider has no text channel, which is how
+   *  the overlay decides whether to offer a reply box at all. */
+  sendText?(text: string): void;
+  /** Stop the utterance in flight without ending the call (barge-in). A reply
+   *  sent mid-sentence interrupts first, so the familiar stops talking over
+   *  the person who just answered it. */
+  interrupt?(): void;
   /** Which recognition engine this call's ears run on, for loop-based
    *  providers (cave-vpe1). Cloud realtime sessions (their model IS the
    *  ears) leave it unset. */

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -1107,7 +1107,9 @@ details[open] > .cave-tool-summary::before {
 }
 
 .voice-call-overlay__dialog {
-  width: min(360px, calc(100vw - 32px));
+  /* Wide enough to read a live transcript, not so wide it stops reading like
+     a call (cave-zr9dx). */
+  width: min(460px, calc(100vw - 32px));
   overflow: hidden;
   border: 1px solid var(--border-hairline);
   border-radius: var(--radius-control);
@@ -1159,9 +1161,17 @@ details[open] > .cave-tool-summary::before {
 .voice-call-overlay__body {
   display: grid;
   min-height: 120px;
-  place-items: center;
+  align-content: center;
+  justify-items: center;
   gap: var(--space-2);
   padding: var(--space-5) var(--space-4);
+}
+
+.voice-call-overlay__engines {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 6px;
 }
 
 /* How the call hears (cave-vpe1) and speaks (cave-vony): honest engine
@@ -1174,6 +1184,174 @@ details[open] > .cave-tool-summary::before {
   border-radius: var(--radius-pill);
   padding: 2px 10px;
   letter-spacing: 0.02em;
+}
+
+/* Live call transcript (cave-zr9dx) — the conversation as it happens, with
+   the sentence the familiar is voicing marked in place. */
+.voice-call-overlay__transcript {
+  display: grid;
+  width: 100%;
+  max-height: 320px;
+  gap: var(--space-3);
+  overflow-y: auto;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  overscroll-behavior: contain;
+}
+
+.voice-call-overlay__transcript-empty {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+  line-height: 1.45;
+  text-align: center;
+}
+
+.voice-call-overlay__turn {
+  display: grid;
+  gap: 2px;
+  justify-items: start;
+}
+
+.voice-call-overlay__turn--user {
+  justify-items: end;
+  text-align: right;
+}
+
+.voice-call-overlay__turn-author {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.voice-call-overlay__turn-text {
+  max-width: 90%;
+  margin: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-md);
+  background: color-mix(in oklch, var(--bg-base) 45%, transparent);
+  padding: 6px 10px;
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  line-height: 1.5;
+  text-align: left;
+  overflow-wrap: anywhere;
+}
+
+.voice-call-overlay__turn--user .voice-call-overlay__turn-text {
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+}
+
+/* The words being spoken right now. A tinted run rather than a block
+   highlight: it has to be legible against a bubble that is already tinted,
+   in both themes. */
+.voice-call-overlay__spoken {
+  border-radius: var(--radius-sm);
+  background: color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  padding: 0 2px;
+  color: var(--text-primary);
+  box-decoration-break: clone;
+  -webkit-box-decoration-break: clone;
+}
+
+.voice-call-overlay__turn.is-speaking .voice-call-overlay__turn-text {
+  border-color: color-mix(in oklch, var(--accent-presence) 45%, var(--border-hairline));
+}
+
+.voice-call-overlay__turn-reply {
+  border: 0;
+  background: none;
+  padding: 0;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: color var(--duration-fast) var(--ease-standard);
+}
+
+.voice-call-overlay__turn-reply:hover {
+  color: var(--text-primary);
+}
+
+/* Reply without speaking — a typed turn barges in on the synthesizer and
+   lands in the same conversation. */
+.voice-call-overlay__reply {
+  display: grid;
+  gap: 6px;
+  border-top: 1px solid var(--border-hairline);
+  padding: var(--space-3) var(--space-4);
+}
+
+.voice-call-overlay__reply-target {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 6px;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
+.voice-call-overlay__reply-author {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.voice-call-overlay__reply-snippet {
+  overflow: hidden;
+  flex: 1 1 auto;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.voice-call-overlay__reply-clear {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  border: 0;
+  background: none;
+  padding: 2px;
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.voice-call-overlay__reply-row {
+  display: flex;
+  gap: 6px;
+}
+
+.voice-call-overlay__reply-input {
+  min-width: 0;
+  flex: 1;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 70%, transparent);
+  padding: 6px var(--space-2);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+}
+
+.voice-call-overlay__reply-send {
+  display: inline-flex;
+  min-width: 34px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-raised);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background var(--duration-fast) var(--ease-standard);
+}
+
+.voice-call-overlay__reply-send:hover:not(:disabled) {
+  background: var(--bg-hover);
+}
+
+.voice-call-overlay__reply-send:disabled {
+  opacity: 0.45;
+  cursor: default;
 }
 
 .voice-call-overlay__error {
@@ -1232,6 +1410,12 @@ details[open] > .cave-tool-summary::before {
 .voice-call-overlay__fix-error {
   color: var(--color-danger);
   font-size: var(--text-xs);
+}
+
+.voice-call-overlay__controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .voice-call-overlay__footer {


### PR DESCRIPTION
## What

A call was a black box: a duration, two engine badges, and audio. You could not see what had been heard, could not tell which words were being spoken, and had no way to answer except by talking over the synthesizer.

- **Live transcript.** The overlay renders the conversation as it happens. `src/lib/voice/call-transcript.ts` is the pure model — partials replace the open turn, finals settle it, and a repeated final (realtime providers re-report `done` text) does not stutter the list.
- **Spoken-word highlight.** The speech loop's utterance queue already knows exactly what the mouth is about to say, so it reports that chunk via a new `onSpeaking` callback and the overlay marks it in place. The lookup is whitespace-tolerant because a streamed reply rewraps between chunking and settling; when the utterance can't be located the whole turn still renders unhighlighted, never truncated.
- **Reply without speaking.** `LiveSession.sendText` barges in on the synthesizer, lands the typed text as a real turn, and runs it through the same brain. A per-turn **Reply** button stages a quoted reply using the chat composer's own `buildQuotedPrompt` shape, so it reads identically in the persisted transcript. Escape cancels a staged reply before it ends the call, and a **Stop speaking** control offers barge-in without typing.

## Barge-in needed three fixes to actually hold

1. `SpeechMouth.interrupt()` stops playback while leaving the mouth usable — `cancel()` retires it permanently, which is right for a call ending and wrong for a reply.
2. Both network mouths (ElevenLabs, local Piper) now settle the promise `speak()` is parked on. A bare `pause()` never fires `onended`, so the loop's queue would have wedged mid-drain.
3. A streaming brain goes on emitting sentences after the interrupt, so a turn only feeds the queue while its speech epoch is current. Without this the familiar talks over the person who just stopped it.

## Contract cleanup

Realtime's transcript events are **deltas** while every other provider reports the **accumulated** turn. That contract is now stated on `VoiceCallbacks` and honored inside the one adapter that broke it, instead of being pushed onto every consumer.

## Two pre-existing `main` failures, repaired

Both are in files this change already touches, and `main` is red on both today:

- `voice-call-overlay.test.ts` asserts against `cave-chat.css`, which became an `@import` aggregator when the sheet was split — so every one of its style assertions was matching against a file containing none of those rules. Verified failing on a clean `main` checkout with *"voice overlay is fixed, centered, and above mobile chrome"*. Now reads the partials too.
- `src/lib/auto-status-blocks.test.ts` landed unwired with /auto mission mode (3bde7b0), failing `pnpm check:tests-wired`. Wired; it passes as-is.

## Verification

- `src/lib/voice/call-transcript.test.ts` — 15 new tests over the model and the highlight split (regex-shaped utterances, rewrapped whitespace, newest-match wins, never a user turn).
- `speech-loop.test.ts` — 7 new tests: per-utterance speaking signal, typed turns while muted, blank replies ignored, closed-session replies ignored, queue dropped behind the current utterance, muzzled brain.
- `openai-realtime.test.ts` — 4 new tests: delta accumulation, per-response reset, `sendText` wire shape, and that `response.cancel` is sent only when a response is actually in flight (it errors otherwise).
- `pnpm lint`, `tsc --noEmit`, `pnpm check:tests-wired` clean.