### PR TITLE
feat(chat): Rewrite the answer in the reader — Full / Condense / ELI5

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -225,6 +225,7 @@ export const SUITES = {
     "src/lib/chat-thread-instruments.test.ts",
     "src/lib/chat-tool-batches.test.ts",
     "src/lib/reader-outline.test.ts",
+    "src/lib/auto-status-blocks.test.ts",
     "src/lib/reader-rewrite.test.ts",
     "src/lib/reader-provenance.test.ts",
     "src/lib/chat-queue-followups.test.ts",

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -176,7 +176,12 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // /api/research/generations/infographic route plus the SVG/PNG renderer
   // chunk traced at 5,888 on Ubuntu and 5,891 on Windows. Set from the
   // HIGHER figure plus the same ten-file headroom.
-  fileCount: 5_901,
+  // +1 (2026-08-03, cave-xailn): POST /api/chat/rewrite backs the reader's
+  // Rewrite control. One new route handler, one new file in the closure —
+  // measured at 5,902 on Ubuntu CI. Nothing else in that change reaches the
+  // sidecar: the shared one-shot runner it adds replaces code that was already
+  // inside enrich-steps' route.
+  fileCount: 5_902,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -102,10 +102,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_901);
+  assert.ok(metrics.fileCount <= 5_902);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_901,
+    fileCount: 5_902,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 


### PR DESCRIPTION
`Reader.dc.html` frame 3a puts a **Rewrite** control in the reader head: **Full / Condense / ELI5**.

Deferred from #4255 on the grounds that the capability did not exist. **That was wrong** — `board/enrich-steps` has been making one-shot model calls all along. What did not exist was a *reusable* form of it.

### Structure

- **`src/lib/server/coven-oneshot.ts`** — `runCoven` lifted out of `enrich-steps`, which now calls it. One implementation of the spawn/abort/settle dance rather than two drifting copies.
- **`src/lib/reader-rewrite.ts`** — prompts and reply extraction, pure and unit-tested. The prompt forbids answering, researching, or adding anything: *a "condensed" answer that quietly invents a claim is worse than no condensation.* Extraction reads the harness stream shapes defensively, so a partial stream still yields its prose.
- **`POST /api/chat/rewrite`** — deliberately **not** a chat turn.

### Four decisions, each a place this could have gone wrong quietly

- **Full is never a model call.** It is the answer as written — free, instant.
- **No `--archive`.** `enrich-steps` archives because its runs are real work; a reading aid must not file a session every time someone presses a toggle.
- **Nothing is persisted.** Reload and you are back to the answer as written: the rewrite is a lens, not a revision of what the familiar said.
- **Over-long answers are refused, not truncated.** Half an answer rewritten reads exactly like a whole one.

`501` retires the control rather than leaving a button that fails identically on every press. Any other failure shows inline and keeps the answer readable — a failed lens must never blank the document.

### Two defects found by looking, not by testing

1. **The rail lied.** While a rewrite was displayed, the contents rail still listed the *original's* headings and the estimate still counted its words — so clicking an entry scrolled to a heading the body no longer had. I saw it in a screenshot. Rail, estimate, copy and export now all follow the displayed lens.
2. **A runtime crash `tsc` could not see.** Moving that derivation put `outline` after `navOpen`'s lazy initializer, which reads it — a temporal-dead-zone error through a closure. Typecheck passed; the reader threw `ReferenceError` and never opened. **`tests/reader.spec.ts` caught it.**

And one where the product was right and I was wrong: my rail test hung on `.cave-reader-rail__meta` after switching lenses — but that lives *inside* the rail, which correctly unmounts when a rewrite has no headings. I fixed the assertion, not the code.

### Pins

Three moved with the extraction (`harness-spawn-env`, the `enrich-steps` route, and the reader's own). Each was re-pointed at the shared runner **and** at the callers, so the guarantee stays end-to-end rather than becoming "the lib has it somewhere".

### Verification

**12/12** e2e (including the four rewrite paths and both failure modes), **11/11** unit, full app suite `RUNNER_EXIT=0`, typecheck and lint clean, `codemod:design:check` clean, drift ratchet unchanged, `check:tests-wired` at 1468.

One note on that suite: an earlier run failed on `codex-oauth-port.test.ts`. That was my own concurrency — I had Playwright's server on 3100 running alongside it. Re-run on a quiet machine, it is green, and the test passes 8/8 in isolation.
