### PR TITLE
fix(ios): catalogue /auto so the cross-platform slash contract passes

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -88,6 +88,13 @@ enum SlashCatalog {
                      description: "Pick or set the model for this chat. Pass an id/name or open the picker.",
                      argPlaceholder: "model", section: .chat,
                      availability: .native, action: .switchModel),
+        // Desktop-only: iOS has no autonomous-mission plumbing, so the command
+        // is catalogued (recognised, and explained when typed) rather than
+        // silently unknown. Promote to .native if iOS ever runs missions.
+        SlashCommand(name: "/auto", aliases: ["/autopilot"], hint: "hands-off mission",
+                     description: "Run a mission autonomously: the familiar may ask a few clarifying questions up front, then works silently and only pings you on completion or when blocked.",
+                     argPlaceholder: "mission…", section: .chat,
+                     availability: .desktopOnly, action: .desktopOnly("Autopilot")),
         SlashCommand(name: "/skill", hint: "run a skill",
                      description: "Invoke a skill — pass a name or pick from the menu as you type.",
                      argPlaceholder: "name", section: .chat,


### PR DESCRIPTION
`main` is red and every PR inherits it.

`scripts/ios-slash-commands.test.mjs` requires every command in the desktop catalogue to exist in the iOS one unless explicitly excluded. Commit `3bde7b0617` ("Add /auto mission mode") added `/auto` to the desktop side only. **Reproduces on pristine `origin/main`** — this is not branch-local.

iOS has no autonomous-mission plumbing, so `/auto` is catalogued `.desktopOnly` rather than `.native`: recognised, and answered with the standard "lives on your desktop" toast instead of being silently unknown. Promote to `.native` if iOS ever runs missions.

The alternative was adding `/auto` to the test's exclusion list beside `/canvas` and `/save`. That list is for commands iOS should *never* surface; `/auto` is one it simply cannot run yet, so cataloguing it is the more accurate description and makes the command explain itself.

One file, seven lines. `ios-slash-commands.test.mjs` green, `swiftc -parse` clean.

Context: this fix was originally committed onto #4294, but that PR was merged at an earlier head so the commit never landed. Re-cut against current `main` — the old branch had drifted far enough that a PR from it would have reverted unrelated voice/reader work.