### PR TITLE
test: repair two more wiring pins /auto mission mode left red on main

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -25,6 +25,7 @@ const contracts: RouteContract[] = [
   { route: "/asana/assigned", methods: ["GET"], kind: "json" },
   { route: "/asana/workspaces", methods: ["GET"], kind: "json" },
   { route: "/asana/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },
+  { route: "/auto-mode/feedback", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/backup/export", methods: ["POST"], kind: "stream", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/backup/restore", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/backup/sync", methods: ["GET", "PUT"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },

--- a/src/components/skill-stage-card-wiring.test.ts
+++ b/src/components/skill-stage-card-wiring.test.ts
@@ -18,10 +18,20 @@ assert.match(
   /const skillSplit = extractSkillMarkers\(ghSafeVisible\);/,
   "skill markers extract on both streaming and settled paths (live stage while the agent works)",
 );
+// Pinned as a flow, not a call site: marker extractors keep being inserted
+// between the skill split and next-paths (auto-mission status was the last),
+// so naming `extractNextPaths(skillSplit.visible)` goes stale every time. What
+// must hold is that the skill-stripped visible feeds the rest of the chain and
+// that next-paths never runs on text still carrying skill markers.
 assert.match(
   chatView,
-  /extractNextPaths\(skillSplit\.visible\)/,
+  /const skillSplit = extractSkillMarkers\(ghSafeVisible\);[\s\S]{0,600}\(skillSplit\.visible\)/,
   "downstream text flows from the skill-stripped visible — raw markers never render",
+);
+assert.doesNotMatch(
+  chatView,
+  /extractNextPaths\((?:ghSafeVisible|turn\.text|reasoningSplit\.visible)\)/,
+  "next-paths never runs on text upstream of the skill split",
 );
 assert.match(chatView, /<SkillStageCard key=\{u\.name\} name=\{u\.name\} stage=\{u\.stage\} note=\{u\.note\} \/>/, "assistant turns render one card per skill name");
 assert.match(


### PR DESCRIPTION
Follow-up to #4296, which was merged before its second CI run finished. Two more `pnpm test:app` / `pnpm test:api` failures that predate both PRs and come from the same commit (3bde7b0, /auto mission mode) are still red on `main`:

- **`skill-stage-card-wiring.test.ts`** — pinned `extractNextPaths(skillSplit.visible)` by its exact argument, and `extractAutoStatusMarkers` was inserted between them. Re-pinned as the flow it exists to protect: the skill-stripped visible feeds the rest of the chain, and next-paths never runs on text upstream of the skill split (now asserted directly, so the next marker extractor to join the chain doesn't re-break it).
- **`api-contracts.test.ts`** — `/auto-mode/feedback` shipped without a contract entry, so the route-coverage check fails. Entry added to match the route as written: `GET` + `POST`, JSON, guarded body parse, local-origin guard on `POST`.

Neither changes behavior; both are assertion/coverage repairs. Verified locally: each file passes, and the twelve other tests that reference the same marker chain still pass unchanged.