### PR TITLE
chore(sidecar): raise the runtime file-count budget to 5,915

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_901/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_915/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 for (const runtimeFile of [
   "dist/compiled/webpack/webpack-lib.js",
@@ -283,7 +283,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_901;/,
+  /const MAX_FILE_COUNT: u64 = 5_915;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -181,7 +181,13 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // measured at 5,902 on Ubuntu CI. Nothing else in that change reaches the
   // sidecar: the shared one-shot runner it adds replaces code that was already
   // inside enrich-steps' route.
-  fileCount: 5_902,
+  // 2026-08-03 (live call transcript, cave-zr9dx): src/lib/voice/call-transcript.ts
+  // joins the closure through the call overlay. On the tree carrying BOTH that
+  // file and the rewrite route above, CI measured 5,902 on Ubuntu and 5,905 on
+  // Windows — so 5,902 was the Ubuntu figure with no headroom at all, and the
+  // Windows leg was still red at it. Set from the HIGHER figure plus the same
+  // ten-file cross-platform headroom the entries above use.
+  fileCount: 5_915,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -102,10 +102,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_902);
+  assert.ok(metrics.fileCount <= 5_915);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_902,
+    fileCount: 5_915,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -256,7 +256,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_901);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_915);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -11,7 +11,7 @@ pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // src/app/api/x/ route handlers landed in #4235); preserve ten-file headroom.
 // Reverted to 5_841 once by a local merge citing the older 5,831 peak — see
 // #4249. It must not move DOWN while those routes exist.
-pub(super) const MAX_FILE_COUNT: u64 = 5_901;
+pub(super) const MAX_FILE_COUNT: u64 = 5_915;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]


### PR DESCRIPTION
`Sidecar runtime` is red on `main`, on both platforms.

Two changes each added one file to the traced closure — `/api/chat/rewrite` (cave-xailn) and `src/lib/voice/call-transcript.ts` (cave-zr9dx, merged in #4296 before that leg finished reporting). On the tree carrying both, CI measured **5,902 on Ubuntu and 5,905 on Windows**.

The budget was then set to `5_902` — the Ubuntu figure with no headroom at all, which leaves the Windows leg failing at `fileCount 5905 exceeds target 5901`/`5902`. This sets it from the **higher** figure plus the same ten-file cross-platform buffer every neighbouring entry uses, and keeps both measurement notes beside the number as that comment block asks.

The ceiling is pinned in five places — the closure budget, its two guard tests, the smoke assertion, and the Rust `MAX_FILE_COUNT`. All five move together; a partial bump just relocates the failure.

The expanded-byte ceiling is untouched.