### PR TITLE
fix(ios): drop the duplicate /auto slash entry

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/SlashCommand.swift
@@ -88,13 +88,6 @@ enum SlashCatalog {
                      description: "Pick or set the model for this chat. Pass an id/name or open the picker.",
                      argPlaceholder: "model", section: .chat,
                      availability: .native, action: .switchModel),
-        // Desktop-only: iOS has no autonomous-mission plumbing, so the command
-        // is catalogued (recognised, and explained when typed) rather than
-        // silently unknown. Promote to .native if iOS ever runs missions.
-        SlashCommand(name: "/auto", aliases: ["/autopilot"], hint: "hands-off mission",
-                     description: "Run a mission autonomously: the familiar may ask a few clarifying questions up front, then works silently and only pings you on completion or when blocked.",
-                     argPlaceholder: "mission…", section: .chat,
-                     availability: .desktopOnly, action: .desktopOnly("Autopilot")),
         SlashCommand(name: "/skill", hint: "run a skill",
                      description: "Invoke a skill — pass a name or pick from the menu as you type.",
                      argPlaceholder: "name", section: .chat,


### PR DESCRIPTION
Two independent fixes for the same red `main` landed, so the iOS slash catalog now has **two** `/auto` entries:

- `baa41acbc5` — "mirror /auto into the slash catalog, unbreaking main" (landed first)
- `20fcb32ab1` — #4299, mine

Both are `.desktopOnly` with the same behaviour, so this isn't a semantic choice. It removes the one #4299 added and keeps the one that landed first. Mine sat earlier in the array, so it was the entry lookups actually resolved to — the other was effectively dead code.

This was duplicate work on my part. I ran a coordination check when starting the branch this came from, but not again before opening #4299 — for a break that was blocking every PR and was therefore likely being fixed concurrently.

One file, seven deletions. `ios-slash-commands.test.mjs` passes with a single entry; mobile suite green (82 files); `swiftc -parse` clean.