### PR TITLE
Add a Cave-safe branch-to-merge skill for every familiar

### DIFF
--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -37,7 +37,7 @@ default. Warn at 12 worktrees or 30 local branches. Exceeding a budget never
 authorizes deletion; new managed work requires safe retirement or a bounded
 owner/reason/expiry exception.
 
-Use `pnpm beads:worktrees:create -- --bead cave-123 --branch
+Use `pnpm beads:worktrees:create --bead cave-123 --branch
 fix/cave-123-example --owner kitty --purpose "Repair example"` for managed
 creation. Raw `git worktree add` remains available but is not universally
 intercepted; it does not exempt the resulting worktree from lifecycle policy.

--- a/.agents/skills/branch-curator/SKILL.md
+++ b/.agents/skills/branch-curator/SKILL.md
@@ -37,9 +37,14 @@ default. Warn at 12 worktrees or 30 local branches. Exceeding a budget never
 authorizes deletion; new managed work requires safe retirement or a bounded
 owner/reason/expiry exception.
 
-Use `pnpm beads:worktrees:create --bead cave-123 --branch
-fix/cave-123-example --owner kitty --purpose "Repair example"` for managed
-creation. Raw `git worktree add` remains available but is not universally
+For managed creation:
+
+```bash
+pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example \
+  --owner kitty --purpose "Repair example"
+```
+
+Raw `git worktree add` remains available but is not universally
 intercepted; it does not exempt the resulting worktree from lifecycle policy.
 
 Recovery and archive dispositions require an owner, reason, and review date.

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -46,6 +46,7 @@ merge strategy, do not delete anything without the proof each phase names.
 
 ```bash
 bd show <id>                 # the Bead this branch implements
+git fetch origin             # refresh origin/main before branching from it
 git rev-parse --abbrev-ref HEAD
 root=$(git rev-parse --show-toplevel) && \
   primary=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)") && \

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -128,13 +128,21 @@ resolve a real conflict — and rebase in your own worktree, never by touching
 
 ## Phase 3: Present the options
 
-Only two endings exist here. Present exactly these:
+Only two endings exist here. First discover whether the branch already has an
+open PR — never try to create a duplicate:
+
+```bash
+branch=$(git branch --show-current)
+gh pr list --head "$branch" --base main --state open --json number,url,headRefOid
+```
+
+Present exactly these:
 
 ```
 How would you like to finish this branch?
 
-  A) Open a PR   -- push, open a pull request, land it via squash merge
-  B) Leave as-is -- keep the branch and worktree, decide later
+  A) Continue through a PR -- push, create one if none exists, or use the existing PR; land it via squash merge
+  B) Leave as-is           -- keep the branch and worktree, decide later
 ```
 
 **STOP — wait for the choice.** Do not assume a default.
@@ -146,16 +154,27 @@ owner's admin exemption is theirs, not yours.
 If the answer is B, say so plainly and stop — no cleanup, no worktree removal,
 no branch deletion. An unfinished branch is preserved by default.
 
-## Phase 4: Open the pull request
+## Phase 4: Create or bind the pull request
 
 Commits must be signed (`required_signatures` is on; the server rejects
 unsigned commits). Push after **every** commit — the remote is the only store a
 local actor cannot destroy.
 
 ```bash
-git push -u origin <branch>
-gh pr create --base main --head <branch> --title "…" --body "…"
+branch=$(git branch --show-current)
+git push -u origin "$branch"
+gh pr list --head "$branch" --base main --state open --json number,url,headRefOid
 ```
+
+If the listing is empty, create the PR:
+
+```bash
+gh pr create --base main --head "$branch" --title "…" --body "…"
+```
+
+If it contains exactly one PR, reuse it; do not run `gh pr create`. If it
+contains more than one PR, or its base/head is not the intended `main`/branch
+pair, stop and ask the maintainer to resolve the ambiguity rather than guessing.
 
 **Title** — imperative, under ~70 characters, describes the change not the
 branch name.
@@ -185,7 +204,10 @@ count.
 Nine required checks must pass:
 
 ```bash
+expected_head=$(git rev-parse HEAD)
+gh pr view <#> --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup
 gh pr checks <#> --watch
+gh pr view <#> --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
 - `Frontend build`
@@ -200,6 +222,10 @@ gh pr checks <#> --watch
 
 CodeQL is retired, and code scanning is fully off — nothing scans in its place.
 If a required context never reports, the PR sits `BLOCKED` with nothing failing.
+Before and after the watch, require `headRefOid` to equal `$expected_head` and
+each listed context to be complete and successful. A pass tied to an earlier
+SHA, or a pending, cancelled, stale, missing, or failed context, is incomplete;
+do not merge until the exact current head has all nine passes.
 
 The `E2E (Playwright)` leg runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs
 must dismiss onboarding and mock APIs via `page.route(...)` rather than expect a
@@ -238,14 +264,9 @@ bypasses the protection this skill exists to respect. Fix the actual blocker.
 
 ## Phase 7: Close out and retire the local unit
 
-```bash
-bd close <id> --reason="Merged in PR #<#>"
-```
-
-Close only after the merge lands, and record the branch, worktree, session,
-owner, and verification evidence on the Bead first.
-
-Then run the lifecycle patrol — it is the only sanctioned retirement route:
+Record the branch, worktree, session, owner, and verification evidence on the
+Bead, then run the lifecycle patrol before closing the PR-backed work — it is
+the only sanctioned retirement route:
 
 ```bash
 pnpm beads:worktrees                 # report only; changes nothing
@@ -258,6 +279,13 @@ reason. `retire-after-gate` is a classification, not deletion authority. A
 worktree created by bare `git worktree add` reports `uncertain` forever; retire
 it by hand through the archive-tag route and never hand-write the missing
 lifecycle metadata onto the Bead — that record is the evidence the gate checks.
+
+Only after the merge landed and that patrol evidence is recorded, close the
+Bead:
+
+```bash
+bd close <id> --reason="Merged in PR #<#>"
+```
 
 Destruction is guarded (`scripts/worktree-guard.mjs`, exit 2) for a dirty
 worktree, a HEAD on no remote ref, an unpushed branch tip, or a branch still

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -9,7 +9,7 @@ Take a finished branch to a merged commit on `main` without ever writing to
 `main` directly and without destroying another session's work.
 
 `main` in this repository is protected: pull request required, nine required
-status checks, signed commits, no force-push, no deletion. A pull request is
+status checks, no force-push, no deletion. A pull request is
 the **only** path an agent may use. This skill is the Cave-specific replacement
 for generic "finish a branch" workflows that offer a local merge into the base
 branch — that option does not exist here.
@@ -156,9 +156,9 @@ no branch deletion. An unfinished branch is preserved by default.
 
 ## Phase 4: Create or bind the pull request
 
-Commits must be signed (`required_signatures` is on; the server rejects
-unsigned commits). Push after **every** commit — the remote is the only store a
-local actor cannot destroy.
+Sign commits when you can, but `required_signatures: false` means an unsigned
+commit is not a merge blocker. Push after **every** commit — the remote is the
+only store a local actor cannot destroy.
 
 ```bash
 branch=$(git branch --show-current)
@@ -348,7 +348,7 @@ improvise cleanup here.
 | `GH006: Protected branch update failed` | You pushed to `main`. Use a branch and a PR. |
 | PR `BLOCKED`, `MERGEABLE`, nothing failing | Suspect a required context that no longer reports; diff `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the PR's checks. |
 | "the base branch policy prohibits the merge" | Generic. Check required contexts, then whether `required_conversation_resolution` was re-enabled. |
-| Push rejected — unsigned commit | Signatures are required; sign with `-S` and re-push. |
+| PR `BLOCKED`, every required check passes | Check whether `required_signatures` changed; it is currently off, so a missing signature is not the blocker. |
 | Worktree guard exits 2 | Live work. Investigate; bypass only with explicit maintainer authorization. |
 | `worktree-lifecycle-create` budget refusal | Rerun with the printed `--exception-*` flags. Do not fall back to `git worktree add` for a budget refusal. |
 | `unknown option: --` | Drop the `--` before the flags; pnpm forwards it. |

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -21,9 +21,15 @@ through `gh`, then retire the local unit through the lifecycle patrol. Every
 destructive step needs evidence, and anything ambiguous is preserved rather
 than cleaned up.
 
-**Never** run `git checkout main && git merge <branch>`, `git push origin
-main`, or `gh pr merge --admin`. If a change cannot go through a PR, stop and
-surface it to the maintainer.
+**Never** run any of these:
+
+```bash
+git checkout main && git merge <branch>
+git push origin main
+gh pr merge <#> --admin
+```
+
+If a change cannot go through a PR, stop and surface it to the maintainer.
 
 Force-pushing is not banned outright — rebasing your own PR branch is a normal
 part of Phase 2. Never force-push a branch you do not own, and never force-push
@@ -47,11 +53,17 @@ git -C . rev-parse --show-toplevel   # confirm you are in the worktree, not the 
 - The branch must be claimed: `bd update <id> --claim` if it is not.
 - Work from the branch's own worktree. The primary checkout usually holds other
   sessions' uncommitted files; committing from there sweeps up their work.
-- Managed worktrees come from `pnpm beads:worktrees:create --bead <id> --branch
-  <branch> --owner <you> --purpose "…"` (no `--` before the flags). If that
-  command refused on budget, the sanctioned rerun adds `--exception-owner`,
-  `--exception-reason`, `--exception-expires-at` and `--exception-path`; a bare
-  `git worktree add` produces a unit the patrol can never retire.
+- Managed worktrees come from the command below (no `--` before the flags):
+
+  ```bash
+  pnpm beads:worktrees:create --bead <id> --branch <branch> \
+    --owner <you> --purpose "…"
+  ```
+
+  If that command refused on budget, the sanctioned rerun adds
+  `--exception-owner`, `--exception-reason`, `--exception-expires-at` and
+  `--exception-path`; a bare `git worktree add` produces a unit the patrol can
+  never retire.
 
 ## Phase 1: Verify before anything else
 
@@ -304,4 +316,3 @@ improvise cleanup here.
 | `beads` | Claim in Phase 0, close in Phase 7 |
 | `branch-curator` | Owns multi-branch audit, pruning, and deletion proofs |
 | `run-cave-app` | Verifying a native-only surface before Phase 1 passes |
-| `requesting-code-review` | Optional between Phase 4 and Phase 5 |

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -315,7 +315,7 @@ improvise cleanup here.
 | "the base branch policy prohibits the merge" | Generic. Check required contexts, then whether `required_conversation_resolution` was re-enabled. |
 | Push rejected — unsigned commit | Signatures are required; sign with `-S` and re-push. |
 | Worktree guard exits 2 | Live work. Investigate; bypass only with explicit maintainer authorization. |
-| `worktree-lifecycle-create` budget refusal | Rerun with the printed `--exception-*` flags. Never fall back to `git worktree add`. |
+| `worktree-lifecycle-create` budget refusal | Rerun with the printed `--exception-*` flags. Do not fall back to `git worktree add` for a budget refusal. |
 | `unknown option: --` | Drop the `--` before the flags; pnpm forwards it. |
 | Patrol reports `uncertain` | Preserve the unit and record owner + reason. |
 | Merge conflict | Resolve in the worktree, re-verify, force-push your own branch only. |

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -237,12 +237,14 @@ gate blocked three real defects in a single day while it was on, each one past a
 fully green suite.
 
 ```bash
-gh api graphql -f query='{repository(owner:"OpenCoven",name:"coven-cave"){pullRequest(number:<#>){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{id isResolved path comments(first:1){nodes{author{login} body}}}}}}}'
+gh api graphql -f query='{repository(owner:"OpenCoven",name:"coven-cave"){pullRequest(number:<#>){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{id isResolved path comments(first:100){pageInfo{hasNextPage endCursor} nodes{author{login} body}}}}}}}'
 ```
 
 Page with `reviewThreads(first:100, after:"<endCursor>")` until `hasNextPage` is
-false — a partial listing is worse than none. Fix what is real, reply naming the
-fixing commit, then optionally resolve:
+false — a partial listing is worse than none. Also page any thread whose
+`comments` pageInfo has `hasNextPage: true`: query that thread by node id with
+`comments(first:100, after:"<endCursor>")` until false. Fix what is real, reply
+naming the fixing commit, then optionally resolve:
 
 ```bash
 gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<PRRT_…>

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -247,6 +247,11 @@ false — a partial listing is worse than none. Also page any thread whose
 naming the fixing commit, then optionally resolve:
 
 ```bash
+gh api graphql -f query='query($thread:ID!,$cursor:String!){node(id:$thread){... on PullRequestReviewThread{comments(first:100,after:$cursor){pageInfo{hasNextPage endCursor} nodes{author{login} body}}}}}' \
+  -f thread=<PRRT_…> -f cursor='<endCursor>'
+```
+
+```bash
 gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<PRRT_…>
 ```
 

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: branch-to-merge
+description: Use when finishing work on a Coven Cave branch and landing it on protected `main` — verification, pull request, required checks, review threads, squash merge, and lifecycle retirement. Trigger on "merge this", "finish the branch", "land this work", "open a PR", "branch to merge", "done with this branch", or "clean up after the merge".
+---
+
+# Branch To Merge
+
+Take a finished branch to a merged commit on `main` without ever writing to
+`main` directly and without destroying another session's work.
+
+`main` in this repository is protected: pull request required, nine required
+status checks, signed commits, no force-push, no deletion. A pull request is
+the **only** path an agent may use. This skill is the Cave-specific replacement
+for generic "finish a branch" workflows that offer a local merge into the base
+branch — that option does not exist here.
+
+## Core rule
+
+Verify, push, open a PR, get the checks green, read the review, squash-merge
+through `gh`, then retire the local unit through the lifecycle patrol. Every
+destructive step needs evidence, and anything ambiguous is preserved rather
+than cleaned up.
+
+**Never** run `git checkout main && git merge <branch>`, `git push origin
+main`, or `gh pr merge --admin`. If a change cannot go through a PR, stop and
+surface it to the maintainer.
+
+Force-pushing is not banned outright — rebasing your own PR branch is a normal
+part of Phase 2. Never force-push a branch you do not own, and never force-push
+away commits nothing else retains.
+
+## Skill type
+
+**RIGID** — run the phases in order. Do not skip verification, do not invent a
+merge strategy, do not delete anything without the proof each phase names.
+
+## Phase 0: Confirm the unit of work
+
+[HARD-GATE] Before touching the branch, know which Bead owns it.
+
+```bash
+bd show <id>                 # the Bead this branch implements
+git rev-parse --abbrev-ref HEAD
+git -C . rev-parse --show-toplevel   # confirm you are in the worktree, not the primary checkout
+```
+
+- The branch must be claimed: `bd update <id> --claim` if it is not.
+- Work from the branch's own worktree. The primary checkout usually holds other
+  sessions' uncommitted files; committing from there sweeps up their work.
+- Managed worktrees come from `pnpm beads:worktrees:create --bead <id> --branch
+  <branch> --owner <you> --purpose "…"` (no `--` before the flags). If that
+  command refused on budget, the sanctioned rerun adds `--exception-owner`,
+  `--exception-reason`, `--exception-expires-at` and `--exception-path`; a bare
+  `git worktree add` produces a unit the patrol can never retire.
+
+## Phase 1: Verify before anything else
+
+[HARD-GATE] Do not push, open, or merge a PR on unverified work. "It passed
+earlier" is not verification.
+
+```bash
+pnpm typecheck
+pnpm lint                 # includes the design-token ESLint gate + codemod check
+pnpm test:app
+pnpm test:api
+pnpm check:tests-wired    # a new test file that no runner invokes is not a test
+```
+
+Add `pnpm test:e2e`, `pnpm test:mobile`, or `cargo check` when the diff touches
+those surfaces. Touching UI? Walk §9 of `docs/coven-design-language.md` first.
+
+Then confirm the diff is PR-shaped:
+
+```bash
+git status --porcelain
+git --no-pager diff origin/main...HEAD --stat
+```
+
+Every path in the diff must belong to this Bead. Unrelated files mean you
+committed someone else's work — split them out before continuing.
+
+If verification fails, **STOP** and fix it. A red PR wastes the reviewer and
+burns nine CI legs.
+
+## Phase 2: Base branch
+
+The base is always `main`. There is no auto-detection to perform and no
+`develop` branch to consider.
+
+```bash
+git fetch origin
+git --no-pager log --oneline HEAD..origin/main | head
+```
+
+Branch protection sets `strict: false`, so **being behind `main` never blocks a
+merge**. Rebase only when you need `main`'s newer commits to test against or to
+resolve a real conflict — and rebase in your own worktree, never by touching
+`main`.
+
+| Divergence | Action |
+|---|---|
+| `main` has 0 new commits | Proceed |
+| `main` has new commits, no conflict | Proceed; rebase only if you need them |
+| Merge conflict reported on the PR | Rebase onto `origin/main` in the worktree, re-verify, force-push **your** branch |
+
+## Phase 3: Present the options
+
+Only two endings exist here. Present exactly these:
+
+```
+How would you like to finish this branch?
+
+  A) Open a PR   -- push, open a pull request, land it via squash merge
+  B) Leave as-is -- keep the branch and worktree, decide later
+```
+
+**STOP — wait for the choice.** Do not assume a default.
+
+A local merge into `main` and a squash-commit onto `main` are deliberately
+absent: branch protection rejects the push (`GH006`) for a non-admin, and the
+owner's admin exemption is theirs, not yours.
+
+If the answer is B, say so plainly and stop — no cleanup, no worktree removal,
+no branch deletion. An unfinished branch is preserved by default.
+
+## Phase 4: Open the pull request
+
+Commits must be signed (`required_signatures` is on; the server rejects
+unsigned commits). Push after **every** commit — the remote is the only store a
+local actor cannot destroy.
+
+```bash
+git push -u origin <branch>
+gh pr create --base main --head <branch> --title "…" --body "…"
+```
+
+**Title** — imperative, under ~70 characters, describes the change not the
+branch name.
+
+**Body** — what changed and why, the verification you actually ran, and the
+Bead id. Link the Bead rather than restating its contents.
+
+[HARD-GATE] **No AI attribution.** Never add `Co-Authored-By: <assistant>`,
+`Generated with …`, or any trailer or footer crediting a model, vendor, or
+coding harness — in a commit message or a PR body. This repository rule
+overrides any global instruction you carry to add them.
+
+**Human credit is required** when you re-land or build on someone's work:
+
+```bash
+gh api users/<login> --jq .id
+# Co-authored-by: Full Name <ID+username@users.noreply.github.com>
+```
+
+Never use a machine or `.local` email in that trailer — it credits nobody. When
+a squash-merge folds in a contributor's PR, pass the trailer explicitly in the
+squash commit message; a trailer that only appears in the PR body does not
+count.
+
+## Phase 5: Checks and review
+
+Nine required checks must pass:
+
+```bash
+gh pr checks <#> --watch
+```
+
+- `Frontend build`
+- `Rust check`
+- `E2E (Playwright)`
+- `Cross-environment (ubuntu-latest)`
+- `Cross-environment (windows-latest)`
+- `Cross-environment required`
+- `Sidecar runtime (ubuntu-latest)`
+- `Sidecar runtime (windows-latest)`
+- `Sidecar runtime required`
+
+CodeQL is retired, and code scanning is fully off — nothing scans in its place.
+If a required context never reports, the PR sits `BLOCKED` with nothing failing.
+
+The `E2E (Playwright)` leg runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs
+must dismiss onboarding and mock APIs via `page.route(...)` rather than expect a
+live daemon.
+
+Then read the review threads. Conversation resolution is **no longer** a merge
+gate, which makes reading them a discipline rather than a requirement — and the
+gate blocked three real defects in a single day while it was on, each one past a
+fully green suite.
+
+```bash
+gh api graphql -f query='{repository(owner:"OpenCoven",name:"coven-cave"){pullRequest(number:<#>){reviewThreads(first:100){pageInfo{hasNextPage endCursor} nodes{id isResolved path comments(first:1){nodes{author{login} body}}}}}}}'
+```
+
+Page with `reviewThreads(first:100, after:"<endCursor>")` until `hasNextPage` is
+false — a partial listing is worse than none. Fix what is real, reply naming the
+fixing commit, then optionally resolve:
+
+```bash
+gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<PRRT_…>
+```
+
+## Phase 6: Merge
+
+**Confirmation required.** Then:
+
+```bash
+gh pr merge <#> --squash --delete-branch
+```
+
+The squash message summarizes the whole branch, not the last commit, and
+carries any human `Co-authored-by:` trailers.
+
+`gh` will dangle `--admin` at you on a blocked PR. **Do not use it** — it
+bypasses the protection this skill exists to respect. Fix the actual blocker.
+
+## Phase 7: Close out and retire the local unit
+
+```bash
+bd close <id> --reason="Merged in PR #<#>"
+```
+
+Close only after the merge lands, and record the branch, worktree, session,
+owner, and verification evidence on the Bead first.
+
+Then run the lifecycle patrol — it is the only sanctioned retirement route:
+
+```bash
+pnpm beads:worktrees                 # report only; changes nothing
+pnpm beads:worktrees:apply           # only when it reports a complete maintenance transaction
+```
+
+If the patrol reports the unit as `active`, `recovery`, `cooldown`,
+`uncertain`, or the gate as incomplete, **preserve it** and record the owner and
+reason. `retire-after-gate` is a classification, not deletion authority. A
+worktree created by bare `git worktree add` reports `uncertain` forever; retire
+it by hand through the archive-tag route and never hand-write the missing
+lifecycle metadata onto the Bead — that record is the evidence the gate checks.
+
+Destruction is guarded (`scripts/worktree-guard.mjs`, exit 2) for a dirty
+worktree, a HEAD on no remote ref, an unpushed branch tip, or a branch still
+heading an open PR. To retire a branch whose commits must survive, archive it —
+a pushed tag outlives the branch a merge deletes:
+
+```bash
+git tag -s archive/<branch-with-slashes-flattened>-<date> <oid>
+git push origin archive/<branch-with-slashes-flattened>-<date>
+```
+
+Flatten slashes: `fix/foo` → `archive/fix-foo-<date>`. Git cannot hold both a
+tag `archive/fix` and `archive/fix/foo`. A local-only tag does not count.
+
+For anything broader than this one branch — auditing, pruning, or deleting a
+set of branches or worktrees — hand off to **branch-curator**. Do not
+improvise cleanup here.
+
+## Confirmation requirements
+
+[HARD-GATE] Ask before each of these. Never proceed on assumption.
+
+| Operation | Why |
+|---|---|
+| Merging the PR | Lands on protected `main` |
+| `bd close` | Others rely on the Bead's status |
+| Removing a worktree | May discard another session's uncommitted work |
+| Deleting a local or remote branch | Unrecoverable if nothing retains the commits |
+| Rebasing / force-pushing the PR branch | Rewrites history the review is anchored to |
+| Any `WT_GUARD_BYPASS=1` rerun | Overrides the guard protecting live work |
+
+## Anti-patterns
+
+| Anti-pattern | Why it is wrong | Instead |
+|---|---|---|
+| `git checkout main && git merge <branch>` | Bypasses every required check | Open a PR |
+| `gh pr merge --admin` | Defeats branch protection | Fix the blocker |
+| Committing from the primary checkout | Sweeps up other sessions' uncommitted work | Commit from the branch's worktree |
+| `git add -A` on a shared checkout | Same failure, at scale (see #585) | Stage explicit paths |
+| Removing the worktree at PR creation | Destroys live work; the PR is not merged yet | Retire only after merge, via the patrol |
+| Bare `git worktree add` to dodge a budget refusal | Produces a permanently unretirable unit | Rerun with the attributed `--exception-*` flags |
+| AI attribution trailers | Repository rule forbids them | Credit humans only |
+| Machine-email `Co-authored-by` | Credits nobody | Numeric-id no-reply form |
+| Committing only locally | A local actor can destroy it | Push after every commit |
+| Treating a stale branch as dead | Age is not proof | Preserve; use branch-curator's evidence gates |
+| Leaving a merged Bead open | Sweeps have to re-derive state by hand | Close with evidence |
+| `in_progress` on work nobody is doing now | Four states wearing one status | `open`, `blocked`, or `deferred` |
+
+## Error handling
+
+| Symptom | Action |
+|---|---|
+| `GH006: Protected branch update failed` | You pushed to `main`. Use a branch and a PR. |
+| PR `BLOCKED`, `MERGEABLE`, nothing failing | Suspect a required context that no longer reports; diff `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the PR's checks. |
+| "the base branch policy prohibits the merge" | Generic. Check required contexts, then whether `required_conversation_resolution` was re-enabled. |
+| Push rejected — unsigned commit | Signatures are required; sign with `-S` and re-push. |
+| Worktree guard exits 2 | Live work. Investigate; bypass only with explicit maintainer authorization. |
+| `worktree-lifecycle-create` budget refusal | Rerun with the printed `--exception-*` flags. Never fall back to `git worktree add`. |
+| `unknown option: --` | Drop the `--` before the flags; pnpm forwards it. |
+| Patrol reports `uncertain` | Preserve the unit and record owner + reason. |
+| Merge conflict | Resolve in the worktree, re-verify, force-push your own branch only. |
+
+## Integration points
+
+| Skill | Integration |
+|---|---|
+| `beads` | Claim in Phase 0, close in Phase 7 |
+| `branch-curator` | Owns multi-branch audit, pruning, and deletion proofs |
+| `run-cave-app` | Verifying a native-only surface before Phase 1 passes |
+| `requesting-code-review` | Optional between Phase 4 and Phase 5 |

--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -47,7 +47,9 @@ merge strategy, do not delete anything without the proof each phase names.
 ```bash
 bd show <id>                 # the Bead this branch implements
 git rev-parse --abbrev-ref HEAD
-git -C . rev-parse --show-toplevel   # confirm you are in the worktree, not the primary checkout
+root=$(git rev-parse --show-toplevel) && \
+  primary=$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)") && \
+  test "$root" != "$primary" || { printf '%s\n' 'refusing to commit from the primary checkout'; exit 1; }
 ```
 
 - The branch must be claimed: `bd update <id> --claim` if it is not.
@@ -60,10 +62,19 @@ git -C . rev-parse --show-toplevel   # confirm you are in the worktree, not the 
     --owner <you> --purpose "…"
   ```
 
-  If that command refused on budget, the sanctioned rerun adds
+  A budget refusal is not a reason to bypass managed creation: rerun with
   `--exception-owner`, `--exception-reason`, `--exception-expires-at` and
-  `--exception-path`; a bare `git worktree add` produces a unit the patrol can
-  never retire.
+  `--exception-path`. If the command cannot build its complete lifecycle
+  inventory (for example, the GitHub quota is exhausted), use the documented
+  fallback instead:
+
+  ```bash
+  git worktree add -b <branch> .worktrees/<branch> origin/main
+  ```
+
+  That fallback has no lifecycle metadata, so the patrol will keep it
+  `uncertain` and can never retire it automatically. Preserve it and later use
+  the archive-tag route; never hand-write lifecycle metadata onto the Bead.
 
 ## Phase 1: Verify before anything else
 

--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,12 @@ package-lock.json
 /public/sandbox/
 /docs/audits
 test-results/
+# Agent skill installs are machine-local by default. Skills that every familiar
+# must load are the exception and ARE tracked (`.agents/skills/beads`,
+# `branch-curator`, `branch-to-merge`, …) — because this rule ignores the whole
+# directory, adding one needs an explicit `git add -f .agents/skills/<name>/`.
+# Without the `-f` the file is silently dropped and the skill reaches nobody
+# else, which is exactly how a "shared" skill ends up existing on one machine.
 /.agents
 
 # design-sync machine state

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -138,6 +138,11 @@ test("skill mirrors the protected-main policy that governs its PR lifecycle", ()
     /Also page any thread whose\n`comments` pageInfo has `hasNextPage: true`/,
     "the skill must not omit replies when a review thread has more than 100 comments",
   );
+  assert.match(
+    skill,
+    /node\(id:\$thread\)\{\.\.\. on PullRequestReviewThread\{comments\(first:100,after:\$cursor\)/,
+    "the skill must provide a copyable query for paginating comments on a thread",
+  );
 
   assert.match(
     claude,

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -103,10 +103,11 @@ test("skill requires all checks on the exact current PR head", () => {
 test("skill mirrors the protected-main policy that governs its PR lifecycle", () => {
   assert.match(
     claude,
-    /Commit signatures are \*\*required\*\* \(`required_signatures`\)/,
-    "CLAUDE.md no longer documents the required-signature policy",
+    /Commit signatures are \*\*NOT required\*\* \(`required_signatures: false`/,
+    "CLAUDE.md no longer documents the optional-signature policy",
   );
-  assert.match(skill, /Commits must be signed \(`required_signatures` is on/);
+  assert.match(skill, /Sign commits when you can, but `required_signatures: false`/);
+  assert.ok(!skill.includes("Push rejected — unsigned commit"));
 
   assert.match(
     claude,

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -182,6 +182,22 @@ test("skill uses the managed worktree command in its documented form", () => {
   assert.ok(skill.includes("--exception-expires-at"));
 });
 
+test("skill refreshes origin before creating a branch from origin/main", () => {
+  const phaseZero = skill.slice(
+    skill.indexOf("## Phase 0:"),
+    skill.indexOf("## Phase 1:"),
+  );
+  const fetch = phaseZero.indexOf("git fetch origin");
+  const managedCreate = phaseZero.indexOf("pnpm beads:worktrees:create");
+  const fallbackCreate = phaseZero.indexOf("git worktree add -b <branch>");
+
+  assert.ok(fetch !== -1, "Phase 0 must refresh origin before branching");
+  assert.ok(
+    fetch < managedCreate && fetch < fallbackCreate,
+    "Phase 0 must refresh origin before either worktree creation path",
+  );
+});
+
 test("skill retires local units through the patrol, never by improvisation", () => {
   assert.ok(/^pnpm beads:worktrees(?:\s|$)/m.test(skill), "skill must run the report-only patrol");
   assert.ok(skill.includes("pnpm beads:worktrees:apply"));

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -223,8 +223,10 @@ test("every skill named as an integration point actually exists in this repo", (
 });
 
 test("skill handles a managed-worktree inventory outage without forging metadata", () => {
+  const normalizedAgents = agents.replace(/\s+/g, " ");
   assert.ok(
-    agents.includes("When it will not run, fall back to `git worktree add -b"),
+    normalizedAgents.includes("lifecycle inventory") &&
+      normalizedAgents.includes("git worktree add -b <branch> .worktrees/<branch> origin/main"),
     "AGENTS.md no longer documents the managed-worktree fallback",
   );
   assert.ok(skill.includes("git worktree add -b <branch> .worktrees/<branch> origin/main"));

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -100,6 +100,43 @@ test("skill requires all checks on the exact current PR head", () => {
   assert.ok(skill.includes("pending, cancelled, stale, missing, or failed context"));
 });
 
+test("skill mirrors the protected-main policy that governs its PR lifecycle", () => {
+  assert.match(
+    claude,
+    /Commit signatures are \*\*required\*\* \(`required_signatures`\)/,
+    "CLAUDE.md no longer documents the required-signature policy",
+  );
+  assert.match(skill, /Commits must be signed \(`required_signatures` is on/);
+
+  assert.match(
+    claude,
+    /Branches do \*\*not\*\* need to be up to date with `main` \(`strict: false`\)/,
+    "CLAUDE.md no longer documents non-strict required checks",
+  );
+  assert.match(skill, /Branch protection sets `strict: false`/);
+
+  assert.match(
+    claude,
+    /Review conversations are \*\*no longer required to be resolved\*\*/,
+    "CLAUDE.md no longer documents the review-conversation policy",
+  );
+  assert.match(skill, /Conversation resolution is \*\*no longer\*\* a merge\ngate/);
+
+  assert.match(
+    claude,
+    /If hasNextPage is true, page with `reviewThreads\(first:100, after:"<endCursor>"\)`/,
+    "CLAUDE.md no longer documents review-thread pagination",
+  );
+  assert.match(skill, /Page with `reviewThreads\(first:100, after:"<endCursor>"\)` until `hasNextPage` is/);
+
+  assert.match(
+    claude,
+    /gate-incomplete, preserve the unit/,
+    "CLAUDE.md no longer documents the lifecycle gate-incomplete behavior",
+  );
+  assert.match(skill, /or the gate as incomplete, \*\*preserve it\*\*/);
+});
+
 test("skill forbids the bypasses branch protection exists to stop", () => {
   assert.ok(skill.includes("`gh pr merge --admin`"));
   assert.ok(skill.includes("Do not use it"));

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -156,7 +156,27 @@ test("every skill named as an integration point actually exists in this repo", (
   const present = new Set(fs.readdirSync(".agents/skills"));
   for (const name of named) {
     assert.ok(present.has(name), `integration point \`${name}\` is not a skill in .agents/skills`);
+    const entrypoint = `.agents/skills/${name}/SKILL.md`;
+    assert.ok(
+      fs.existsSync(entrypoint) && fs.lstatSync(entrypoint).isFile(),
+      `integration point \`${name}\` has no regular SKILL.md entrypoint`,
+    );
   }
+});
+
+test("skill handles a managed-worktree inventory outage without forging metadata", () => {
+  assert.ok(
+    agents.includes("When it will not run, fall back to `git worktree add -b"),
+    "AGENTS.md no longer documents the managed-worktree fallback",
+  );
+  assert.ok(skill.includes("git worktree add -b <branch> .worktrees/<branch> origin/main"));
+  assert.ok(skill.includes("can never retire it automatically"));
+  assert.ok(skill.includes("never hand-write lifecycle metadata onto the Bead"));
+});
+
+test("skill refuses commits from the primary checkout", () => {
+  assert.ok(skill.includes("git rev-parse --path-format=absolute --git-common-dir"));
+  assert.ok(skill.includes('test "$root" != "$primary"'));
 });
 
 test("no inline code span is split across a newline", () => {

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -174,6 +174,18 @@ test("skill handles a managed-worktree inventory outage without forging metadata
   assert.ok(skill.includes("never hand-write lifecycle metadata onto the Bead"));
 });
 
+test("skill distinguishes a managed-worktree budget refusal from an inventory outage", () => {
+  assert.match(
+    skill,
+    /\| `worktree-lifecycle-create` budget refusal \| Rerun with the printed `--exception-\*` flags\. Do not fall back to `git worktree add` for a budget refusal\. \|/,
+    "a budget refusal must use its exception flags, while an inventory outage uses the documented fallback",
+  );
+  assert.ok(
+    skill.includes("If the command cannot build its complete lifecycle\n  inventory"),
+    "an inventory outage must retain the documented bare-worktree fallback",
+  );
+});
+
 test("skill refuses commits from the primary checkout", () => {
   assert.ok(skill.includes("git rev-parse --path-format=absolute --git-common-dir"));
   assert.ok(skill.includes('test "$root" != "$primary"'));

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -1,0 +1,141 @@
+// Contract test for the `branch-to-merge` skill.
+//
+// The skill tells agents how to land a branch on protected `main`. Its value is
+// entirely in the facts it asserts — the nine required checks, the PR-only path,
+// the no-AI-attribution rule, the lifecycle retirement route. A skill that
+// drifts from those facts is worse than no skill: it is confidently wrong at the
+// exact moment an agent is about to mutate `main`.
+//
+// So pin the claims to the documents that own them. When protection changes,
+// this test fails and the skill gets updated in the same PR.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const skill = fs.readFileSync(".agents/skills/branch-to-merge/SKILL.md", "utf8");
+const claude = fs.readFileSync("CLAUDE.md", "utf8");
+const agents = fs.readFileSync("AGENTS.md", "utf8");
+
+// Derive the check list from CLAUDE.md rather than restating it. A hardcoded
+// list only catches removals, and the change that actually happened here was an
+// addition (five contexts widened to nine on 2026-08-01) — which a
+// presence-only assertion sails straight past.
+const NUMBER_WORDS = ["ZERO", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "TEN", "ELEVEN", "TWELVE"];
+
+function backticked(source) {
+  return [...source.matchAll(/`([^`]+)`/g)].map((match) => match[1]);
+}
+
+function documentedChecks() {
+  const bullet =
+    /- Required status checks — \*\*all ([A-Z]+)\*\* must pass[^:]*:(.*?)\. The four matrix legs/s.exec(
+      claude,
+    );
+  assert.ok(bullet, "CLAUDE.md no longer states the required status checks in the expected shape");
+  return { word: bullet[1], names: backticked(bullet[2]) };
+}
+
+function skillChecks() {
+  const section = /required checks must pass:\n\n```bash\n.*?```\n\n(.*?)\n\nCodeQL is retired/s.exec(
+    skill,
+  );
+  assert.ok(section, "skill no longer lists the required checks in the expected shape");
+  const word = /\n([A-Za-z]+) required checks must pass:/.exec(skill)?.[1];
+  assert.ok(word, "skill no longer states how many checks are required");
+  return { word, names: backticked(section[1]) };
+}
+
+test("skill declares a name and a trigger-bearing description", () => {
+  assert.match(skill, /^---\nname: branch-to-merge\n/);
+  const description = /\ndescription: (.+)\n/.exec(skill)?.[1];
+  assert.ok(description, "missing description");
+  for (const trigger of ["merge this", "finish the branch", "open a PR"]) {
+    assert.ok(
+      description.includes(trigger),
+      `description is missing the "${trigger}" trigger`,
+    );
+  }
+});
+
+test("skill lists exactly the required status checks CLAUDE.md documents", () => {
+  const documented = documentedChecks();
+  const listed = skillChecks();
+
+  assert.deepEqual(
+    listed.names,
+    documented.names,
+    "the skill's check list has drifted from CLAUDE.md",
+  );
+  assert.equal(
+    documented.word,
+    NUMBER_WORDS[documented.names.length],
+    "CLAUDE.md's numeral disagrees with the list it introduces",
+  );
+  assert.equal(
+    listed.word.toUpperCase(),
+    NUMBER_WORDS[listed.names.length],
+    "the skill's numeral disagrees with the list it introduces",
+  );
+});
+
+test("skill offers a PR as the only path onto main", () => {
+  assert.ok(skill.includes("A) Open a PR"));
+  assert.ok(skill.includes("B) Leave as-is"));
+  assert.ok(
+    !/^\s*[BC]\) (Merge|Squash merge)/m.test(skill),
+    "skill must not offer a local merge into the base branch",
+  );
+  assert.ok(skill.includes("gh pr merge <#> --squash --delete-branch"));
+});
+
+test("skill forbids the bypasses branch protection exists to stop", () => {
+  assert.ok(skill.includes("`gh pr merge --admin`"));
+  assert.ok(skill.includes("Do not use it"));
+  assert.ok(skill.includes("git checkout main && git merge <branch>"));
+  assert.ok(
+    skill.includes("GH006"),
+    "skill must name the error a direct push to main produces",
+  );
+});
+
+test("skill carries the repository's no-AI-attribution rule", () => {
+  assert.ok(
+    agents.includes("credit an AI model"),
+    "AGENTS.md no longer carries the attribution rule this skill mirrors",
+  );
+  assert.ok(skill.includes("No AI attribution"));
+  assert.ok(skill.includes("ID+username@users.noreply.github.com"));
+});
+
+test("skill uses the managed worktree command in its documented form", () => {
+  assert.ok(skill.includes("pnpm beads:worktrees:create --bead"));
+  assert.ok(
+    !skill.includes("beads:worktrees:create -- --bead"),
+    "the `--` form is rejected by the flag parser",
+  );
+  assert.ok(skill.includes("--exception-owner"));
+  assert.ok(skill.includes("--exception-expires-at"));
+});
+
+test("skill retires local units through the patrol, never by improvisation", () => {
+  assert.ok(/^pnpm beads:worktrees(?:\s|$)/m.test(skill), "skill must run the report-only patrol");
+  assert.ok(skill.includes("pnpm beads:worktrees:apply"));
+  assert.ok(skill.includes("branch-curator"));
+  assert.ok(
+    skill.includes("git tag -s archive/"),
+    "skill must document the archive-tag route for retained commits",
+  );
+});
+
+test("skill bookends the work with Beads claim and close", () => {
+  assert.ok(skill.includes("bd update <id> --claim"));
+  assert.ok(skill.includes("bd close <id>"));
+});
+
+test("skill names verification commands that package.json actually defines", () => {
+  const scripts = JSON.parse(fs.readFileSync("package.json", "utf8")).scripts;
+  for (const command of ["typecheck", "lint", "test:app", "test:api", "check:tests-wired"]) {
+    assert.ok(scripts[command], `package.json no longer defines ${command}`);
+    assert.ok(skill.includes(`pnpm ${command}`), `skill no longer runs pnpm ${command}`);
+  }
+});

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -128,6 +128,16 @@ test("skill mirrors the protected-main policy that governs its PR lifecycle", ()
     "CLAUDE.md no longer documents review-thread pagination",
   );
   assert.match(skill, /Page with `reviewThreads\(first:100, after:"<endCursor>"\)` until `hasNextPage` is/);
+  assert.match(
+    skill,
+    /comments\(first:100\)\{pageInfo\{hasNextPage endCursor\}/,
+    "the initial review-thread query must read every comment on ordinary threads",
+  );
+  assert.match(
+    skill,
+    /Also page any thread whose\n`comments` pageInfo has `hasNextPage: true`/,
+    "the skill must not omit replies when a review thread has more than 100 comments",
+  );
 
   assert.match(
     claude,

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -139,3 +139,36 @@ test("skill names verification commands that package.json actually defines", () 
     assert.ok(skill.includes(`pnpm ${command}`), `skill no longer runs pnpm ${command}`);
   }
 });
+
+test("every skill named as an integration point actually exists in this repo", () => {
+  // A repo-tracked skill is loaded by familiars that may have none of the
+  // user-level skill library installed, so pointing at a skill that only
+  // exists in someone's home directory sends them after something they cannot
+  // invoke.
+  const table = /## Integration points\n\n\| Skill \| Integration \|\n\|---\|---\|\n(.*?)(?:\n\n|$)/s.exec(
+    skill,
+  );
+  assert.ok(table, "skill no longer has an integration-points table");
+
+  const named = [...table[1].matchAll(/^\| `([^`]+)` \|/gm)].map((match) => match[1]);
+  assert.ok(named.length > 0, "integration-points table lists no skills");
+
+  const present = new Set(fs.readdirSync(".agents/skills"));
+  for (const name of named) {
+    assert.ok(present.has(name), `integration point \`${name}\` is not a skill in .agents/skills`);
+  }
+});
+
+test("no inline code span is split across a newline", () => {
+  // CommonMark code spans cannot contain newlines, so a wrapped span renders
+  // as literal backticks and breaks copy/paste of the command inside it.
+  const withoutFences = skill.replace(/```[\s\S]*?```/g, "");
+  for (const [index, line] of withoutFences.split("\n").entries()) {
+    const backticks = (line.match(/`/g) ?? []).length;
+    assert.equal(
+      backticks % 2,
+      0,
+      `line ${index + 1} leaves a code span open across a newline: ${line.trim()}`,
+    );
+  }
+});

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -79,13 +79,25 @@ test("skill lists exactly the required status checks CLAUDE.md documents", () =>
 });
 
 test("skill offers a PR as the only path onto main", () => {
-  assert.ok(skill.includes("A) Open a PR"));
+  assert.ok(skill.includes("A) Continue through a PR"));
   assert.ok(skill.includes("B) Leave as-is"));
   assert.ok(
     !/^\s*[BC]\) (Merge|Squash merge)/m.test(skill),
     "skill must not offer a local merge into the base branch",
   );
   assert.ok(skill.includes("gh pr merge <#> --squash --delete-branch"));
+});
+
+test("skill reuses an existing PR instead of creating a duplicate", () => {
+  assert.ok(skill.includes('gh pr list --head "$branch" --base main --state open'));
+  assert.ok(skill.includes("If it contains exactly one PR, reuse it"));
+  assert.ok(skill.includes("do not run `gh pr create`"));
+});
+
+test("skill requires all checks on the exact current PR head", () => {
+  assert.ok(skill.includes("expected_head=$(git rev-parse HEAD)"));
+  assert.ok(skill.includes("Before and after the watch, require `headRefOid` to equal `$expected_head`"));
+  assert.ok(skill.includes("pending, cancelled, stale, missing, or failed context"));
 });
 
 test("skill forbids the bypasses branch protection exists to stop", () => {
@@ -130,6 +142,15 @@ test("skill retires local units through the patrol, never by improvisation", () 
 test("skill bookends the work with Beads claim and close", () => {
   assert.ok(skill.includes("bd update <id> --claim"));
   assert.ok(skill.includes("bd close <id>"));
+});
+
+test("skill records the lifecycle patrol before closing the Bead", () => {
+  const closeout = skill.slice(skill.indexOf("## Phase 7:"));
+  assert.ok(closeout.includes("before closing the PR-backed work"));
+  assert.ok(
+    closeout.indexOf("pnpm beads:worktrees") < closeout.indexOf("bd close <id>"),
+    "the patrol evidence must be recorded before bd close",
+  );
 });
 
 test("skill names verification commands that package.json actually defines", () => {

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1112,6 +1112,7 @@ export const SUITES = {
     "scripts/worktree-guard.test.mjs",
     "scripts/worktree-autolock.test.mjs",
     "scripts/branch-curator-manual-cleanup-contract.test.mjs",
+    "scripts/branch-to-merge-contract.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",
     "scripts/git-hooks-commit-msg.test.mjs",
     "scripts/secret-preflight.test.mjs",

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,12 +1,6 @@
 {
   "version": 1,
   "skills": {
-    "finishing-a-development-branch": {
-      "source": "pixel-process-ug/superkit-agents",
-      "sourceType": "github",
-      "skillPath": "templates/skills/finishing-a-development-branch/SKILL.md",
-      "computedHash": "3082a0354806a36de1915a821829e2b35099d2ec3435331eca5ea1721f483f33"
-    },
     "migrate-radix-to-base": {
       "source": "shadcn/ui",
       "sourceType": "github",


### PR DESCRIPTION
Bead: `cave-r2kaq`

## Why

A request for a "branch-to-merge" skill found nothing — it does not exist in any
registry. The closest real skill, `finishing-a-development-branch` from
`pixel-process-ug/superkit-agents`, was installed and then read. It is unsafe
here:

- it offers `git checkout main && git merge <branch>` as options B and C, which
  branch protection rejects (`GH006`) and which bypasses all nine required checks;
- it removes the worktree immediately after **PR creation**, before the merge —
  the exact destruction `scripts/worktree-guard.mjs` exists to block;
- it has no Beads claim/close, no lifecycle patrol, no review-thread step, and
  no attribution rule.

A skill that is confidently wrong at the moment an agent mutates `main` is worse
than no skill.

## What changed

- **New tracked skill** `.agents/skills/branch-to-merge/SKILL.md` — verification
  gate, base handling (`strict: false`, so behind-`main` never blocks), two
  endings only (continue through one PR — reuse an existing PR or create one — or leave as-is),
  signed commits, push-after-every-commit,
  paginated review-thread listing, `gh pr merge --squash --delete-branch`, then
  the lifecycle patrol before `bd close`. Defers all multi-branch cleanup to
  `branch-curator`.
- **Contract test** `scripts/branch-to-merge-contract.test.mjs`, wired into the
  `api` suite. It derives the required-check list from `CLAUDE.md` and asserts
  set equality plus the numeral, rather than restating the list — a hardcoded
  list only catches removals, and the change that actually happened was an
  addition (five contexts widened to nine). Mutation-checked: adding a tenth
  context to `CLAUDE.md` fails the test.
- **`skills-lock.json`** — drops the superseded vendored entry; the directory is
  removed from disk.
- **`.agents/skills/branch-curator/SKILL.md`** — fixes
  `beads:worktrees:create -- --bead`, a form the flag parser rejects with
  `unknown option: --`.
- **`.gitignore`** — notes that `/.agents` ignores the whole directory, so a
  skill meant for every familiar needs `git add -f` or it silently reaches nobody.

## Verification

- `node --test scripts/branch-to-merge-contract.test.mjs` — 17/17
- `node --test scripts/branch-curator-manual-cleanup-contract.test.mjs` — 4/4
- `node --test scripts/worktree-lifecycle-patrol.test.mjs` — pass
- `pnpm check:tests-wired` — all 1487 test files wired
- Mutation test: a fake tenth required check in `CLAUDE.md` fails the new test.
- Follow-up `16036d65`: existing PRs are reused rather than duplicated, exact-head CI is required before merge, and lifecycle patrol evidence is recorded before `bd close`.
- Every factual claim in the skill was reviewed against live branch protection,
  `scripts/worktree-lifecycle-create.ts`, `scripts/worktree-guard.mjs`, and
  `package.json`.


