### PR TITLE
fix(worktrees): make the budget refusal name the exception it would admit

### DIFF
--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -256,7 +256,7 @@
     {
       "id": 43,
       "prompt": "Create a second worktree for the same active Bead even though the repository already exceeds its worktree budget.",
-      "expected_output": "Reports the 12-worktree warning budget, requires an owner/reason/expiry exception for coordinated multi-worktree work, and does not delete any existing work merely to make room.",
+      "expected_output": "Reports the 12-worktree budget as a refusal rather than a warning, names the owner/reason/expiry/path exception that would be admitted for coordinated multi-worktree work, declines to substitute a bare `git worktree add` because that unit could never be retired, and does not delete any existing work merely to make room.",
       "files": []
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,9 @@
 - **The command has two distinct failure modes, and only one of them justifies
   the fallback.** Telling them apart is the whole game, because the wrong choice
   creates a worktree nothing can ever retire.
-  - **Refused, exit 2** (`creating a worktree would exceed the 12-worktree
-    budget`, or `Bead … already owns a registered worktree`). The gate ran fine
-    and declined. **Do not fall back to `git worktree add` here.** Every refusal
+  - **Exit 2 — refused by the admission gate** (`creating a worktree would
+    exceed the 12-worktree budget`, or `Bead … already owns a registered
+    worktree`). The gate ran fine and declined. **Do not fall back to `git worktree add` here.** Every refusal
     from this path is lifted by an attributed, expiring exception, and the
     refusal itself now prints the exact rerun. The budget counts every
     registered worktree in the checkout, not just yours, so a concurrent session
@@ -29,17 +29,17 @@
     pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example \
       --owner kitty --purpose "Repair example" \
       --exception-owner kitty \
-      --exception-reason "why this is worth exceeding the budget" \
-      --exception-expires-at 2026-08-10T00:00:00Z \
+      --exception-reason "why this exception is needed" \
+      --exception-expires-at 'REPLACE-WITH-FUTURE-UTC-ISO-INSTANT' \
       --exception-path /abs/path/to/.worktrees/cave-123-example
     ```
 
-    All four `--exception-*` flags are required together. The expiry must be a
-    canonical UTC ISO instant in the future, and every `--exception-path` must be
-    absolute. The exception is recorded on the Bead alongside the worktree, so
-    the unit still lands with full lifecycle metadata and stays retirable — this
-    is a sanctioned path, not a bypass.
-  - **Errored, exit 1** (`lifecycle inventory is incomplete: …`). The command
+    All four `--exception-*` flags are required together. Replace
+    `REPLACE-WITH-FUTURE-UTC-ISO-INSTANT` with a canonical UTC ISO instant in the
+    future; every `--exception-path` must be absolute. The exception is recorded on the
+    Bead alongside the worktree, so the unit still lands with full lifecycle metadata
+    and stays retirable — this is a sanctioned path, not a bypass.
+  - **Exit 1 — errored because the lifecycle inventory is incomplete.** The command
     could not build a **complete** inventory, which needs live GitHub queries, so
     it fails when the GraphQL quota is exhausted (`API rate limit already
     exceeded`) and when any commit's PR association comes back malformed (`pull

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,19 +14,50 @@
   (`worktree-lifecycle-create: unknown option: --`). `--bead`, `--branch`,
   `--owner` and `--purpose` are all required; `--start-point` defaults to
   `origin/main` and the worktree is placed under `.worktrees/`.
-- That command refuses to create anything unless it can build a **complete**
-  lifecycle inventory, which means live GitHub queries. It therefore fails when
-  the GraphQL quota is exhausted (`API rate limit already exceeded`) and when any
-  commit's PR association comes back malformed (`pull request node returned
-  malformed fields or a mismatched head OID`) — a repo-state condition no amount
-  of waiting clears. When it will not run, fall back to `git worktree add -b
-  <branch> .worktrees/<branch> origin/main` and know the trade: that worktree
-  carries no lifecycle metadata, so `pnpm beads:worktrees` will class it
-  `uncertain` ("structured lifecycle metadata backfill required") forever and
-  `pnpm beads:worktrees:apply` can never retire it. Retire it by hand through the
-  archive-tag route in [`CLAUDE.md`](CLAUDE.md), and never hand-write the missing
-  metadata onto the Bead — that record is the evidence the retirement gate
-  checks.
+- **The command has two distinct failure modes, and only one of them justifies
+  the fallback.** Telling them apart is the whole game, because the wrong choice
+  creates a worktree nothing can ever retire.
+  - **Refused, exit 2** (`creating a worktree would exceed the 12-worktree
+    budget`, or `Bead … already owns a registered worktree`). The gate ran fine
+    and declined. **Do not fall back to `git worktree add` here.** Every refusal
+    from this path is lifted by an attributed, expiring exception, and the
+    refusal itself now prints the exact rerun. The budget counts every
+    registered worktree in the checkout, not just yours, so a concurrent session
+    can block you and retiring your own units may not lift it:
+
+    ```bash
+    pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example \
+      --owner kitty --purpose "Repair example" \
+      --exception-owner kitty \
+      --exception-reason "why this is worth exceeding the budget" \
+      --exception-expires-at 2026-08-10T00:00:00Z \
+      --exception-path /abs/path/to/.worktrees/cave-123-example
+    ```
+
+    All four `--exception-*` flags are required together. The expiry must be a
+    canonical UTC ISO instant in the future, and every `--exception-path` must be
+    absolute. The exception is recorded on the Bead alongside the worktree, so
+    the unit still lands with full lifecycle metadata and stays retirable — this
+    is a sanctioned path, not a bypass.
+  - **Errored, exit 1** (`lifecycle inventory is incomplete: …`). The command
+    could not build a **complete** inventory, which needs live GitHub queries, so
+    it fails when the GraphQL quota is exhausted (`API rate limit already
+    exceeded`) and when any commit's PR association comes back malformed (`pull
+    request node returned malformed fields or a mismatched head OID`) — a
+    repo-state condition no amount of waiting clears. An exception cannot rescue
+    this: the inventory throws before admission is ever assessed. Only here is
+    the fallback justified:
+
+    ```bash
+    git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort
+    ```
+
+    Know the trade: that worktree carries no lifecycle metadata, so
+    `pnpm beads:worktrees` will class it `uncertain` ("structured lifecycle
+    metadata backfill required") forever and `pnpm beads:worktrees:apply` can
+    never retire it. Retire it by hand through the archive-tag route in
+    [`CLAUDE.md`](CLAUDE.md), and never hand-write the missing metadata onto the
+    Bead — that record is the evidence the retirement gate checks.
 - After a PR merges, run `pnpm beads:worktrees`, record the merged unit's
   disposition, and use `pnpm beads:worktrees:apply` only when it reports a
   complete repository maintenance transaction. Local cleanup is bounded and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,7 +230,7 @@ outright with `unknown option: --`. That broken form was documented here and in
 Confusing these is how the repo accumulates worktrees that nothing can retire.
 Read the exit code.
 
-**Exit 2 — refused by the budget. Use an exception, not the fallback.**
+**Exit 2 — refused by the admission gate. Use an exception, not the fallback.**
 
 ```text
 worktree-lifecycle-create: creating a worktree would exceed the 12-worktree budget
@@ -248,16 +248,17 @@ since `cave-no5nr` the refusal prints the exact admissible rerun:
 pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example \
   --owner <you> --purpose "…" \
   --exception-owner <you> \
-  --exception-reason "why this is worth exceeding the budget" \
-  --exception-expires-at 2026-08-10T00:00:00Z \
+  --exception-reason "why this exception is needed" \
+  --exception-expires-at 'REPLACE-WITH-FUTURE-UTC-ISO-INSTANT' \
   --exception-path /abs/path/to/.worktrees/cave-123-example
 ```
 
-All four `--exception-*` flags are required together; the expiry must be a
-canonical UTC ISO instant in the future (`YYYY-MM-DDTHH:MM:SS(.sss)Z`) and every
-path must be absolute. The exception is stored on the bead next to the worktree
-record, so the unit lands with **full lifecycle metadata and stays retirable**.
-This is the sanctioned path, not a bypass — the same gate admits it.
+All four `--exception-*` flags are required together; replace
+`REPLACE-WITH-FUTURE-UTC-ISO-INSTANT` with a canonical UTC ISO instant in the
+future (`YYYY-MM-DDTHH:MM:SS(.sss)Z`), and ensure every path is absolute. The
+exception is stored on the bead next to the worktree record, so the unit lands with
+**full lifecycle metadata and stays retirable**. This is the sanctioned path,
+not a bypass — the same gate admits it.
 
 Note the deliberate asymmetry between the two surfaces that read this number:
 the patrol reports `exceeded` as `count > 12`, while creation refuses at

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,15 +225,61 @@ worktree lands under `.worktrees/` (the script refuses any path escaping it).
 outright with `unknown option: --`. That broken form was documented here and in
 `AGENTS.md` until 2026-08-03.
 
-⚠️ **The managed command can refuse to run, and the fallback has a cost.** It
-builds a *complete* lifecycle inventory first, which needs live GitHub queries,
-so it fails when the GraphQL quota is exhausted and when any commit's PR
-association returns `malformed fields or a mismatched head OID` — the latter is
-repo state, not a transient, so waiting does not clear it. Both were hit on
-2026-08-03. When it will not run:
+### ⚠️ Two failure modes — only one of them justifies the fallback
+
+Confusing these is how the repo accumulates worktrees that nothing can retire.
+Read the exit code.
+
+**Exit 2 — refused by the budget. Use an exception, not the fallback.**
+
+```text
+worktree-lifecycle-create: creating a worktree would exceed the 12-worktree budget
+```
+
+`WORKTREE_WARNING_BUDGET = 12` (`src/lib/worktree-lifecycle.ts`) counts **every
+registered worktree in the checkout**, not yours. With ~20 concurrent sessions
+this is over budget essentially always, so cleaning up your own units will not
+reliably lift it and waiting does not either.
+
+Every refusal from this path is lifted by an attributed, expiring exception, and
+since `cave-no5nr` the refusal prints the exact admissible rerun:
 
 ```bash
-git worktree add -b <branch> .worktrees/<branch> origin/main   # fallback only
+pnpm beads:worktrees:create --bead cave-123 --branch fix/cave-123-example \
+  --owner <you> --purpose "…" \
+  --exception-owner <you> \
+  --exception-reason "why this is worth exceeding the budget" \
+  --exception-expires-at 2026-08-10T00:00:00Z \
+  --exception-path /abs/path/to/.worktrees/cave-123-example
+```
+
+All four `--exception-*` flags are required together; the expiry must be a
+canonical UTC ISO instant in the future (`YYYY-MM-DDTHH:MM:SS(.sss)Z`) and every
+path must be absolute. The exception is stored on the bead next to the worktree
+record, so the unit lands with **full lifecycle metadata and stays retirable**.
+This is the sanctioned path, not a bypass — the same gate admits it.
+
+Note the deliberate asymmetry between the two surfaces that read this number:
+the patrol reports `exceeded` as `count > 12`, while creation refuses at
+`count >= 12`, because one more unit is what would take it over. At exactly 12
+the patrol is quiet and creation is refused; that is "*would* exceed", not an
+off-by-one.
+
+**Exit 1 — the command could not run. Fallback is the only option.**
+
+```text
+worktree-lifecycle-create: lifecycle inventory is incomplete: …
+```
+
+It builds a *complete* lifecycle inventory first, which needs live GitHub
+queries, so it fails when the GraphQL quota is exhausted and when any commit's PR
+association returns `malformed fields or a mismatched head OID` — the latter is
+repo state, not a transient, so waiting does not clear it. Both were hit on
+2026-08-03. An exception cannot rescue this: the inventory throws *before*
+admission is assessed, so the exception is never consulted.
+
+```bash
+git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort
 ```
 
 A worktree made this way has **no lifecycle metadata**, so `pnpm beads:worktrees`

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -421,7 +421,9 @@ test("evals cover every new authorization and race boundary", () => {
   assert.match(eval39.expected_output, /never mutates the remote/i);
   assert.match(eval39.expected_output, /Commit age is not remote-ref recency/);
 
-  assert.match(byId.get(43).expected_output, /12-worktree warning budget/i);
+  assert.match(byId.get(43).expected_output, /12-worktree budget/i);
+  assert.match(byId.get(43).expected_output, /exception that would be admitted/i);
+  assert.match(byId.get(43).expected_output, /never be retired/i);
   assert.match(byId.get(43).expected_output, /does not delete any existing work/i);
   assert.match(byId.get(44).expected_output, /cleanup-ready patrol unit/i);
   assert.match(byId.get(44).expected_output, /reports any remote ref as a proposal rather than deleting it/i);

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -104,7 +104,7 @@ test("worktree refusal docs require a future exception and confine the fallback"
     assert.match(exitTwo, /refused by (?:the )?admission gate/i);
     assert.match(exitTwo, /--exception-reason "why this exception is needed"/);
     assert.match(exitTwo, /--exception-expires-at 'REPLACE-WITH-FUTURE-UTC-ISO-INSTANT'/);
-    assert.match(exitTwo, /Replace `REPLACE-WITH-FUTURE-UTC-ISO-INSTANT`/);
+    assert.match(exitTwo, /replace\s+`REPLACE-WITH-FUTURE-UTC-ISO-INSTANT`/i);
     assert.doesNotMatch(exitTwo, /git worktree add -b/);
     assert.doesNotMatch(exitTwo, /2026-08-10T00:00:00Z/);
     assert.match(exitOne, /lifecycle inventory is incomplete/i);

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -93,6 +93,26 @@ and authorization; never retry the refused removal in the current batch.`;
   assert.ok(proof.includes(guardFixContract));
 });
 
+test("worktree refusal docs require a future exception and confine the fallback", () => {
+  for (const [name, source] of [["AGENTS.md", agents], ["CLAUDE.md", read("CLAUDE.md")]]) {
+    const exitTwoStart = source.indexOf("Exit 2");
+    const exitOneStart = source.indexOf("Exit 1", exitTwoStart);
+    assert.notEqual(exitTwoStart, -1, `${name} must document exit 2`);
+    assert.notEqual(exitOneStart, -1, `${name} must document exit 1`);
+    const exitTwo = source.slice(exitTwoStart, exitOneStart);
+    const exitOne = source.slice(exitOneStart);
+    assert.match(exitTwo, /refused by (?:the )?admission gate/i);
+    assert.match(exitTwo, /--exception-reason "why this exception is needed"/);
+    assert.match(exitTwo, /--exception-expires-at 'REPLACE-WITH-FUTURE-UTC-ISO-INSTANT'/);
+    assert.match(exitTwo, /Replace `REPLACE-WITH-FUTURE-UTC-ISO-INSTANT`/);
+    assert.doesNotMatch(exitTwo, /git worktree add -b/);
+    assert.doesNotMatch(exitTwo, /2026-08-10T00:00:00Z/);
+    assert.match(exitOne, /lifecycle inventory is incomplete/i);
+    assert.match(exitOne, /exception cannot rescue/i);
+    assert.match(exitOne, /git worktree add -b/);
+  }
+});
+
 test("normative proof scopes remote deletion and uses exact expected OIDs", () => {
   const selection = section(
     proof,

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1084,7 +1084,7 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
       worktreePath: existingPath,
     });
   });
-  const bead = "cave-o'reilly";
+  const bead = "cave-unit1-special";
   const branch = "feat/cave-unit1-o'reilly";
   const owner = "Kitty O'Neil; touch should-not-run";
   const purpose = "Use $HOME and 'quotes'; no side effects";

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1091,11 +1091,20 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   updateFixture(fixture, (state) => {
     state.issues[0].id = bead;
   });
-  const refused = runCreate(
+  const incompleteInventory = runCreate(
     fixture,
     createArgs({ bead, branch, owner, purpose }),
     { CAVE_TEST_GH_FAIL: "1" },
   );
+  assert.equal(incompleteInventory.status, 1, incompleteInventory.stderr);
+  assert.match(incompleteInventory.stderr, /inventory.*unavailable/i);
+  assert.doesNotMatch(
+    incompleteInventory.stderr,
+    /--exception-(?:owner|reason|expires-at|path)/,
+    "an incomplete inventory must not advertise an exception before admission",
+  );
+
+  const refused = runCreate(fixture, createArgs({ bead, branch, owner, purpose }));
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /already owns a registered worktree/);
   assert.match(refused.stderr, /12-worktree budget/);
@@ -1141,8 +1150,20 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   ]);
   assert.match(expiresAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
   assert.ok(Date.parse(expiresAt) > Date.now(), `suggested expiry must be future: ${expiresAt}`);
-  assert.equal(readJson(fixture.stateFile).counts.update, 0);
-  assert.equal(refState(fixture.repo, `refs/heads/${branch}`), null);
+  assert.equal(readJson(fixture.stateFile).counts.update, 0, "the refused command must not persist metadata");
+  assert.equal(refState(fixture.repo, `refs/heads/${branch}`), null, "the refused command must not create a branch");
+
+  const admitted = runCreate(fixture, suggestedArgs.slice(1));
+  assert.equal(admitted.status, 0, admitted.stderr);
+  const report = parseJsonOutput(admitted);
+  assert.equal(report.branch, branch);
+  assert.equal(report.path, path.join(fixture.repo, ".worktrees", "cave-unit1-o-reilly"));
+  assert.deepEqual(report.metadata.coven.worktrees[0].exception, {
+    owner,
+    reason: "why this exception is needed",
+    expiresAt,
+    additionalPaths: [path.join(fixture.repo, ".worktrees", "cave-unit1-o-reilly")],
+  });
 });
 
 await withFixture({}, async (fixture) => {
@@ -1159,11 +1180,7 @@ await withFixture({}, async (fixture) => {
     ".worktrees",
     "cave-unit1-stale-replacement",
   );
-  const refused = runCreate(
-    fixture,
-    createArgs({ branch }),
-    { CAVE_TEST_GH_FAIL: "1" },
-  );
+  const refused = runCreate(fixture, createArgs({ branch }));
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /structured worktree metadata|exception/i);
   assert.equal(pathEntry(requestedPath).exists, false);
@@ -1195,11 +1212,7 @@ await withFixture({}, async (fixture) => {
       },
     });
   });
-  const refused = runCreate(
-    fixture,
-    createArgs({ branch }),
-    { CAVE_TEST_GH_FAIL: "1" },
-  );
+  const refused = runCreate(fixture, createArgs({ branch }));
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /primary.*registered|registered.*primary/i);
   assert.equal(pathEntry(requestedPath).exists, false);

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1083,9 +1083,17 @@ await withFixture({}, async (fixture) => {
   );
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /already owns a registered worktree/);
-  assert.match(refused.stderr, /12-worktree warning budget/);
-  assert.match(refused.stderr, /30-local-branch warning budget/);
+  assert.match(refused.stderr, /12-worktree budget/);
+  assert.match(refused.stderr, /30-local-branch budget/);
   assert.match(refused.stderr, /Suggestion: pnpm beads:worktrees:apply/);
+  // The refusal must name the escape hatch it would accept. Without this the
+  // only workaround the docs offered was a bare `git worktree add`, whose units
+  // automated retirement can never remove (cave-no5nr).
+  assert.match(refused.stderr, /--exception-owner/);
+  assert.match(refused.stderr, /--exception-reason/);
+  assert.match(refused.stderr, /--exception-expires-at/);
+  assert.match(refused.stderr, /--exception-path/);
+  assert.match(refused.stderr, /do not fall back to a bare `git worktree add`/i);
   assert.equal(readJson(fixture.stateFile).counts.update, 0);
   assert.equal(
     refState(fixture.repo, "refs/heads/feat/cave-unit1-budget-refused"),

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -100,8 +100,11 @@ function defaultIssue(id = "cave-unit1") {
   };
 }
 
-function createFixture({ issues = [defaultIssue()] } = {}) {
-  const fixtureRoot = mkdtempSync(path.join(tmpdir(), "cave-worktree-create-"));
+function createFixture({
+  issues = [defaultIssue()],
+  fixturePrefix = "cave-worktree-create-",
+} = {}) {
+  const fixtureRoot = mkdtempSync(path.join(tmpdir(), fixturePrefix));
   const repoEntry = path.join(fixtureRoot, "repo");
   const origin = path.join(fixtureRoot, "origin.git");
   const bin = path.join(fixtureRoot, "bin");
@@ -914,6 +917,11 @@ await withFixture({}, async (fixture) => {
   );
   assert.equal(incompleteInventory.status, 1);
   assert.match(incompleteInventory.stderr, /inventory.*unavailable/i);
+  assert.doesNotMatch(
+    incompleteInventory.stderr,
+    /--exception-(?:owner|reason|expires-at|path)/,
+    "an incomplete inventory is an exit-1 error, not an exception-admission refusal",
+  );
   assert.equal(
     refState(fixture.repo, "refs/heads/feat/cave-unit1-incomplete-inventory"),
     null,
@@ -1052,7 +1060,7 @@ for (const [mode, branch] of [
   });
 }
 
-await withFixture({}, async (fixture) => {
+await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fixture) => {
   const existingPath = addWorktree(fixture, "feat/cave-unit1-existing", "cave-unit1-existing");
   for (let index = 0; index < 10; index += 1) {
     git(
@@ -1076,9 +1084,16 @@ await withFixture({}, async (fixture) => {
       worktreePath: existingPath,
     });
   });
+  const bead = "cave-o'reilly";
+  const branch = "feat/cave-unit1-o'reilly";
+  const owner = "Kitty O'Neil; touch should-not-run";
+  const purpose = "Use $HOME and 'quotes'; no side effects";
+  updateFixture(fixture, (state) => {
+    state.issues[0].id = bead;
+  });
   const refused = runCreate(
     fixture,
-    createArgs({ branch: "feat/cave-unit1-budget-refused" }),
+    createArgs({ bead, branch, owner, purpose }),
     { CAVE_TEST_GH_FAIL: "1" },
   );
   assert.equal(refused.status, 2, refused.stderr);
@@ -1086,19 +1101,48 @@ await withFixture({}, async (fixture) => {
   assert.match(refused.stderr, /12-worktree budget/);
   assert.match(refused.stderr, /30-local-branch budget/);
   assert.match(refused.stderr, /Suggestion: pnpm beads:worktrees:apply/);
+  assert.match(refused.stderr, /This admission refusal can be lifted/i);
+  assert.doesNotMatch(refused.stderr, /worth exceeding the budget/i);
   // The refusal must name the escape hatch it would accept. Without this the
   // only workaround the docs offered was a bare `git worktree add`, whose units
   // automated retirement can never remove (cave-no5nr).
-  assert.match(refused.stderr, /--exception-owner/);
-  assert.match(refused.stderr, /--exception-reason/);
-  assert.match(refused.stderr, /--exception-expires-at/);
-  assert.match(refused.stderr, /--exception-path/);
   assert.match(refused.stderr, /do not fall back to a bare `git worktree add`/i);
-  assert.equal(readJson(fixture.stateFile).counts.update, 0);
-  assert.equal(
-    refState(fixture.repo, "refs/heads/feat/cave-unit1-budget-refused"),
-    null,
+  const suggested = refused.stderr.match(/  pnpm beads:worktrees:create \\[\s\S]*$/);
+  assert.ok(suggested, `refusal must include an executable rerun: ${refused.stderr}`);
+  const parsedSuggestion = run(
+    "bash",
+    [
+      "-c",
+      `pnpm() { printf '%s\n' "$@"; }\n${suggested[0].replace(/^  /gm, "")}`,
+    ],
+    fixture.repo,
   );
+  assert.equal(parsedSuggestion.status, 0, parsedSuggestion.stderr);
+  const suggestedArgs = parsedSuggestion.stdout.trim().split("\n");
+  const expiresAt = suggestedArgs.at(suggestedArgs.indexOf("--exception-expires-at") + 1);
+  assert.deepEqual(suggestedArgs, [
+    "beads:worktrees:create",
+    "--bead",
+    bead,
+    "--branch",
+    branch,
+    "--owner",
+    owner,
+    "--purpose",
+    purpose,
+    "--exception-owner",
+    owner,
+    "--exception-reason",
+    "why this exception is needed",
+    "--exception-expires-at",
+    expiresAt,
+    "--exception-path",
+    path.join(fixture.repo, ".worktrees", "cave-unit1-o-reilly"),
+  ]);
+  assert.match(expiresAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  assert.ok(Date.parse(expiresAt) > Date.now(), `suggested expiry must be future: ${expiresAt}`);
+  assert.equal(readJson(fixture.stateFile).counts.update, 0);
+  assert.equal(refState(fixture.repo, `refs/heads/${branch}`), null);
 });
 
 await withFixture({}, async (fixture) => {

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -1520,12 +1520,6 @@ function execute(
     initialException,
     initialNowMs,
   );
-  if (!localPreflight.assessment.allowed) {
-    return refusalOutcome(
-      localPreflight.assessment.reasons,
-      exceptionSuggestion(options, worktreePath),
-    );
-  }
   const initialRecords = [
     ...(initialCoven.primary ? [initialCoven.primary] : []),
     ...initialCoven.additional,
@@ -1539,24 +1533,13 @@ function execute(
   ) {
     throw new CliError("intended worktree duplicates existing metadata");
   }
-  if (initialCoven.primary !== null && initialException === null) {
-    return refusalOutcome(
-      [
-        `Bead ${options.beadId} already has structured worktree metadata; a current worktree exception is required to append another record`,
-      ],
-      exceptionSuggestion(options, worktreePath),
-    );
-  }
-  if (
+  const requiresCurrentException =
+    initialCoven.primary !== null && initialException === null;
+  const primaryRegistrationMissing =
     initialCoven.primary !== null &&
     !localPreflight.registeredPaths.has(
       canonicalExistingCandidate(initialCoven.primary.path),
-    )
-  ) {
-    return refusalOutcome([
-      `Bead ${options.beadId} primary structured worktree metadata is not currently registered`,
-    ]);
-  }
+    );
 
   const inventory = collectWorktreeLifecycleInventory({
     repo: REPOSITORY,
@@ -1571,6 +1554,29 @@ function execute(
   const errors = [...inventory.globalErrors, ...inventoryErrors(inventory.items)];
   if (errors.length > 0) {
     throw new CliError(`lifecycle inventory is incomplete: ${errors.join("; ")}`);
+  }
+  // A local admission preflight can identify a refusal cheaply, but it cannot
+  // replace the complete inventory. Check the inventory first so an outage
+  // remains an exit-1 error rather than advertising an exception that cannot
+  // reach admission.
+  if (!localPreflight.assessment.allowed) {
+    return refusalOutcome(
+      localPreflight.assessment.reasons,
+      exceptionSuggestion(options, worktreePath),
+    );
+  }
+  if (requiresCurrentException) {
+    return refusalOutcome(
+      [
+        `Bead ${options.beadId} already has structured worktree metadata; a current worktree exception is required to append another record`,
+      ],
+      exceptionSuggestion(options, worktreePath),
+    );
+  }
+  if (primaryRegistrationMissing) {
+    return refusalOutcome([
+      `Bead ${options.beadId} primary structured worktree metadata is not currently registered`,
+    ]);
   }
   const existingPaths = existingOwnedPaths(inventory.items, options.beadId);
 

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -817,16 +817,13 @@ function exceptionSuggestion(options: ManagedCreateOptions, worktreePath: string
   const expiresAt = new Date(Date.now() + EXCEPTION_SUGGESTION_WINDOW_MS).toISOString();
   return [
     "",
-    "The worktree budget counts every registered worktree in this checkout, not",
-    "just yours, so a concurrent session can block you and retiring your own units",
-    "may not lift it.",
+    "This admission refusal can be lifted with an attributed, expiring exception",
+    "that applies to this worktree path. The same gate admits it and the unit",
+    "stays retirable:",
     "",
     "Do not fall back to a bare `git worktree add`: a worktree created that way",
     "carries no lifecycle metadata, so the patrol reports it `uncertain`",
     "permanently and `pnpm beads:worktrees:apply` can never retire it.",
-    "",
-    "If this worktree is worth exceeding the budget, rerun with an attributed,",
-    "expiring exception. The same gate admits it and the unit stays retirable:",
     "",
     "  pnpm beads:worktrees:create \\",
     `    --bead ${shellQuote(options.beadId)} \\`,
@@ -834,7 +831,7 @@ function exceptionSuggestion(options: ManagedCreateOptions, worktreePath: string
     `    --owner ${shellQuote(options.owner)} \\`,
     `    --purpose ${shellQuote(options.purpose)} \\`,
     `    --exception-owner ${shellQuote(options.owner)} \\`,
-    "    --exception-reason 'why this is worth exceeding the budget' \\",
+    "    --exception-reason 'why this exception is needed' \\",
     `    --exception-expires-at ${expiresAt} \\`,
     `    --exception-path ${shellQuote(worktreePath)}`,
   ];

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -795,13 +795,59 @@ function existingOwnedPaths(
   ];
 }
 
-function refusalOutcome(reasons: string[]): Outcome {
+const EXCEPTION_SUGGESTION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+/**
+ * The `--exception-*` rerun that this refusal would admit.
+ *
+ * A gate that does not name its own escape hatch gets routed around: the only
+ * workaround the prose docs used to offer was a bare `git worktree add`, which
+ * produces a unit with no lifecycle metadata that automated retirement can never
+ * remove. That is how a budget meant to cap sprawl came to feed it. Printing the
+ * admissible command makes the sanctioned path the easy one.
+ *
+ * Only pass this for refusals an exception genuinely lifts — see
+ * {@link assessManagedWorktreeCreation}, whose every reason qualifies.
+ */
+function exceptionSuggestion(options: ManagedCreateOptions, worktreePath: string): string[] {
+  const expiresAt = new Date(Date.now() + EXCEPTION_SUGGESTION_WINDOW_MS).toISOString();
+  return [
+    "",
+    "The worktree budget counts every registered worktree in this checkout, not",
+    "just yours, so a concurrent session can block you and retiring your own units",
+    "may not lift it.",
+    "",
+    "Do not fall back to a bare `git worktree add`: a worktree created that way",
+    "carries no lifecycle metadata, so the patrol reports it `uncertain`",
+    "permanently and `pnpm beads:worktrees:apply` can never retire it.",
+    "",
+    "If this worktree is worth exceeding the budget, rerun with an attributed,",
+    "expiring exception. The same gate admits it and the unit stays retirable:",
+    "",
+    "  pnpm beads:worktrees:create \\",
+    `    --bead ${shellQuote(options.beadId)} \\`,
+    `    --branch ${shellQuote(options.branch)} \\`,
+    `    --owner ${shellQuote(options.owner)} \\`,
+    `    --purpose ${shellQuote(options.purpose)} \\`,
+    `    --exception-owner ${shellQuote(options.owner)} \\`,
+    "    --exception-reason 'why this is worth exceeding the budget' \\",
+    `    --exception-expires-at ${expiresAt} \\`,
+    `    --exception-path ${shellQuote(worktreePath)}`,
+  ];
+}
+
+function refusalOutcome(reasons: string[], suggestion: string[] = []): Outcome {
   return {
     status: 2,
     stdout: null,
     stderr: [
       ...reasons.map((reason) => `worktree-lifecycle-create: ${reason}`),
       "Suggestion: pnpm beads:worktrees:apply",
+      ...suggestion,
     ],
     createdReport: null,
   };
@@ -1478,7 +1524,10 @@ function execute(
     initialNowMs,
   );
   if (!localPreflight.assessment.allowed) {
-    return refusalOutcome(localPreflight.assessment.reasons);
+    return refusalOutcome(
+      localPreflight.assessment.reasons,
+      exceptionSuggestion(options, worktreePath),
+    );
   }
   const initialRecords = [
     ...(initialCoven.primary ? [initialCoven.primary] : []),
@@ -1494,9 +1543,12 @@ function execute(
     throw new CliError("intended worktree duplicates existing metadata");
   }
   if (initialCoven.primary !== null && initialException === null) {
-    return refusalOutcome([
-      `Bead ${options.beadId} already has structured worktree metadata; a current worktree exception is required to append another record`,
-    ]);
+    return refusalOutcome(
+      [
+        `Bead ${options.beadId} already has structured worktree metadata; a current worktree exception is required to append another record`,
+      ],
+      exceptionSuggestion(options, worktreePath),
+    );
   }
   if (
     initialCoven.primary !== null &&
@@ -1539,7 +1591,9 @@ function execute(
     budgets: inventory.budgets,
     exception: exceptionForAssessment(admissionException),
   });
-  if (!assessment.allowed) return refusalOutcome(assessment.reasons);
+  if (!assessment.allowed) {
+    return refusalOutcome(assessment.reasons, exceptionSuggestion(options, worktreePath));
+  }
 
   assertRefAndPathAbsent(root, fullRef, worktreePath);
   heartbeatBoth(leases, "before git worktree add");
@@ -1700,6 +1754,7 @@ function execute(
           (reason) => `worktree-lifecycle-create: ${reason}`,
         ),
         "Suggestion: pnpm beads:worktrees:apply",
+        ...exceptionSuggestion(options, worktreePath),
       ],
     );
   }

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -557,8 +557,8 @@ function legacyObservation(overrides = {}) {
     allowed: false,
     reasons: [
       "active Bead cave-ox3ky already owns a registered worktree",
-      "creating a worktree would exceed the 12-worktree warning budget",
-      "creating a branch would exceed the 30-local-branch warning budget",
+      "creating a worktree would exceed the 12-worktree budget",
+      "creating a branch would exceed the 30-local-branch budget",
     ],
   });
 }

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -130,6 +130,16 @@ export type WorktreeLifecycleRenderOptions = {
   includeFooter?: boolean;
 };
 
+// These thresholds serve two surfaces with deliberately different arithmetic.
+// The patrol reports `exceeded` as `count > budget` — "the repository is over
+// its budget right now". Managed creation refuses at `count >= budget`, because
+// one more unit is what would take it over. So at exactly the budget the patrol
+// reports nothing while creation is refused; that is the intended reading of
+// "creating a worktree WOULD exceed", not an off-by-one.
+//
+// For the patrol the number is advisory, which is what "warning" names. For
+// creation it is a hard refusal, so the refusal text in
+// {@link assessManagedWorktreeCreation} deliberately does not call it a warning.
 export const WORKTREE_WARNING_BUDGET = 12;
 export const BRANCH_WARNING_BUDGET = 30;
 
@@ -607,6 +617,12 @@ export function calculateLifecycleBudgets({
   };
 }
 
+/**
+ * Every reason this returns is lifted by a valid exception — each one is guarded
+ * on `!validException` below. Callers may therefore present the `--exception-*`
+ * invocation as a real remedy for any refusal from here, which is not true of
+ * refusals assembled elsewhere.
+ */
 export function assessManagedWorktreeCreation({
   beadId,
   requestedPath,
@@ -629,11 +645,13 @@ export function assessManagedWorktreeCreation({
     reasons.push(`active Bead ${beadId} already owns a registered worktree`);
   }
   if (!validException && budgets.worktrees.count >= budgets.worktrees.warning) {
-    reasons.push(`creating a worktree would exceed the ${WORKTREE_WARNING_BUDGET}-worktree warning budget`);
+    reasons.push(
+      `creating a worktree would exceed the ${WORKTREE_WARNING_BUDGET}-worktree budget`,
+    );
   }
   if (!validException && budgets.branches.count >= budgets.branches.warning) {
     reasons.push(
-      `creating a branch would exceed the ${BRANCH_WARNING_BUDGET}-local-branch warning budget`,
+      `creating a branch would exceed the ${BRANCH_WARNING_BUDGET}-local-branch budget`,
     );
   }
 


### PR DESCRIPTION
Fixes the loop where the worktree budget gate was feeding the sprawl it exists to cap. Filed as `cave-no5nr`.

## The problem

`pnpm beads:worktrees:create` refuses when the checkout is over the 12-worktree budget:

```
worktree-lifecycle-create: creating a worktree would exceed the 12-worktree warning budget
Suggestion: pnpm beads:worktrees:apply
```

Three things compound here:

1. **The budget is repo-wide.** `WORKTREE_WARNING_BUDGET` is compared against every registered worktree in the checkout, not the caller's own. With ~20 concurrent sessions it is over budget essentially always, so no session can unblock itself by cleaning up. Observed today: the count went 22 → 17 → 22 within one session as five sessions retired units and five more created them.
2. **The suggested remedy usually cannot help.** `beads:worktrees:apply` retires nothing when every unit is active or dirty, which is the normal state.
3. **The only documented workaround causes permanent damage.** AGENTS.md and CLAUDE.md offered a bare `git worktree add` fallback. That unit carries no `metadata.coven.worktree` record, so the patrol classes it `uncertain` forever and `beads:worktrees:apply` can *never* retire it — `allowLegacyMissingMetadata` is hard-coded `false` with no flag to relax it (see `cave-l52dt`).

Blocked session → fallback → unretirable unit → higher count → harder block.

## The escape hatch already existed

`worktree-lifecycle-create.ts` accepts `--exception-owner`, `--exception-reason`, `--exception-expires-at` and repeatable `--exception-path`, all validated by `applicableManagedCreationException`. It is a good design — attributed, reasoned, expiring, scoped to one path rather than a global override — and the unit still lands with full lifecycle metadata, so it stays retirable.

Nothing documented it. Confirmed absent from `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md` and `docs/`. Sessions took the damaging fallback because it was the only workaround named.

## Changes

**The refusal now names the rerun it would admit.** Every reason `assessManagedWorktreeCreation` produces is guarded on `!validException`, so an exception lifts all of them — the suggestion is a real remedy, not a guess. Emitted at all three assessment-refusal sites plus the post-creation recheck:

```
  pnpm beads:worktrees:create \
    --bead 'cave-no5nr' \
    --branch 'fix/cave-no5nr-verify-refusal' \
    --owner 'Val Alexander' \
    --purpose 'Verify the refusal names its escape hatch' \
    --exception-owner 'Val Alexander' \
    --exception-reason 'why this is worth exceeding the budget' \
    --exception-expires-at 2026-08-10T22:06:28.178Z \
    --exception-path '/Users/.../.worktrees/cave-no5nr-verify-refusal'
```

**Dropped "warning" from the refusal text.** It returns `allowed: false`; calling it a warning invited the reading that creation had proceeded. The *constant* keeps its name — the patrol genuinely does use the number as an advisory threshold. A comment now records why the two surfaces compare it differently (`>` for the patrol, `>=` for creation), so the boundary reads as intended rather than as an off-by-one.

**Docs split the two failure modes**, since conflating them is what routed blocked sessions to the fallback:

| exit | meaning | remedy |
| --- | --- | --- |
| 2 | refused by the gate | an exception lifts it — **do not** use the fallback |
| 1 | `lifecycle inventory is incomplete` | throws *before* admission is assessed, so an exception cannot help; fallback is the only option |

## Verification

- Ran the new code against the **live over-budget checkout**: the refusal prints the suggestion, and its `--exception-path` correctly matches the slugified directory.
- **Dogfooded the exception path** to create this branch's own worktree — exit 0, landed `active`, with the exception recorded on the bead alongside the worktree.
- `pnpm typecheck` clean.
- `src/lib/worktree-lifecycle.test.ts`, `scripts/worktree-lifecycle-create.test.mjs` (new `--exception-*` assertions), `scripts/branch-curator-manual-cleanup-contract.test.mjs` all pass.

## Deliberately not changed

Whether **12** is the right number for a checkout that routinely carries 20+ live sessions, and whether the count should exclude clean fully-pushed worktrees (which are free to remove). Both change gate semantics and are the owner's call, not a drive-by. Noted on the bead.