### PR TITLE
test(api): drop the duplicate /auto-mode/feedback contract entry

### DIFF
--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -22,7 +22,6 @@ const contracts: RouteContract[] = [
   { route: "/access-groups/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/app/build-info", methods: ["GET"], kind: "json" },
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
-  { route: "/auto-mode/feedback", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
   { route: "/asana/assigned", methods: ["GET"], kind: "json" },
   { route: "/asana/workspaces", methods: ["GET"], kind: "json" },
   { route: "/asana/pat", methods: ["GET", "POST", "DELETE"], kind: "json", readsJson: true, invalidJson: "fallback-empty" },


### PR DESCRIPTION
One of the two failures keeping `main` red. Filed as `cave-x4fsf`.

## The bug

`src/app/api/api-contracts.test.ts` listed `/auto-mode/feedback` twice — lines 25 and 29, byte-identical. The route exists once on disk, so the `deepEqual` against the discovered route list fails:

```
AssertionError: every src/app/api route must have an API contract entry
  actual   ... '/auto-mode/feedback',
  expected ... '/auto-mode/feedback', '/auto-mode/feedback',
```

It is the only duplicate in the array — `grep -oE 'route: "[^"]+"' | sort | uniq -d` returns exactly this one.

I removed the **line 25** copy rather than line 29: the list is alphabetical, and line 25 sat between `/app/latest-release` and `/asana/assigned`, while line 29 is correctly placed between `/asana/pat` and `/backup/export`.

Introduced by `198b4b20b7` — *"test: repair two more wiring pins /auto mission mode left red on main"* — whose entire change to this file was that one added line. A repair for a red `main` that left it red a different way. Both it and the feature it repaired reached `main` as direct merges, so neither faced the required checks.

## ⚠️ This PR will be red on its own, and that is expected

`main` has **two independent** failures, and `pnpm test:app`/`test:api` stop at the first, so only one is visible at a time:

| # | failure | fixed by |
| --- | --- | --- |
| 1 | `offScaleSpacingPx` ratchet 1664 > baseline 1653 | **#4303** |
| 2 | duplicate `/auto-mode/feedback` contract entry | **this PR** |

They deadlock: #4303 fails on failure 2, and this PR fails on failure 1. **Neither can go green independently.** Verified locally on both trees.

Failure 1 is entirely `src/styles/cave-chat/activity.css` (47 → 58 off-scale spacing values: 5× `gap: 6px`, 2× `padding: 2px`, 2× `padding: 6px`, 1× `padding: 10px`, 1× `gap: 2px`), from `a411e3bcf3` (cave-zr9dx). I measured this by replicating the scanner in `design-token-drift.test.ts` — same `stripComments`/`DECL_RE`/`PX_RE` and the same tables from `tokenize-css.mjs` — and reproduced both totals exactly (baseline commit `7316804273` → 1653, current main → 1664). Every other CSS file in the tree is unchanged.

I deliberately did **not** duplicate #4303's fix here. Its author already snapped 10 of the 11 values and wrote the justification for banking the highlight's `2px`; scanning its head tree (`aa22bd111c`) confirms activity.css drops to 48 and the total to 1654, matching the baseline it raises. Copying that work would conflict with a live branch.

**Breaking the deadlock needs one of:** #4303 taking this one-line change onto its branch, or a maintainer landing one of the two through the owner exemption. That is the owner's call, not something I'll reach for.

## Verification

`node --experimental-strip-types src/app/api/api-contracts.test.ts` → **266 route contracts passed**.