### PR TITLE
feat(canvas,voice): playable sketches, a waiting-room arcade, and iOS voice calls

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -54,6 +54,7 @@ struct ChatView: View {
     @State private var showPermissionFamiliarPicker = false
     @State private var showSessionDetails = false
     @State private var showSessionPicker = false
+    @State private var showVoiceCall = false
     /// Navigation path handed to the session picker. It pushes nothing, but
     /// FamiliarThreadsView requires the binding.
     @State private var pickerPath: [ChatRoute] = []
@@ -115,6 +116,22 @@ struct ChatView: View {
         return members.filter { $0.displayName.lowercased().contains(q) || $0.id.lowercased().contains(q) }
     }
     private var showingMentionMenu: Bool { !mentionMatches.isEmpty }
+
+    // A voice call targets a single familiar, so the call button only appears
+    // on one-to-one threads whose familiar is known. Group threads have no
+    // single callee.
+    private var voiceCallFamiliar: Familiar? {
+        guard !thread.isGroup, let id = thread.familiarIds.first else { return nil }
+        return app.familiar(id)
+    }
+
+    // The server session for the callee, when the thread already has one.
+    // Empty for a brand-new chat; the call engine treats that as a fresh
+    // session for the familiar.
+    private var voiceCallSessionId: String {
+        guard let id = thread.familiarIds.first else { return "" }
+        return thread.sessionIds[id] ?? ""
+    }
 
     private func writeDraftPersistence(_ value: String, key: String) {
         if value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
@@ -199,6 +216,17 @@ struct ChatView: View {
                 .accessibilityLabel("\(thread.title), \(chatPresence.label)")
             }
             ToolbarItem(placement: .topBarTrailing) {
+                if let familiar = voiceCallFamiliar {
+                    Button {
+                        Haptics.tap()
+                        showVoiceCall = true
+                    } label: {
+                        Image(systemName: "phone.fill")
+                    }
+                    .accessibilityLabel("Call \(familiar.displayName)")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     Haptics.tap()
                     showSessionDetails.toggle()
@@ -269,6 +297,15 @@ struct ChatView: View {
         }
         .sheet(item: $responseReader) { item in
             ResponseReaderView(item: item)
+        }
+        .fullScreenCover(isPresented: $showVoiceCall) {
+            if let familiar = voiceCallFamiliar {
+                LiveVoiceCallView(
+                    familiar: familiar,
+                    sessionId: voiceCallSessionId,
+                    client: app.client
+                )
+            }
         }
         // A new chat linked to a task acquires its server session only after the
         // first reply; once streaming stops, push that sessionId onto the card.

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/CaveVoiceTurnSender.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/CaveVoiceTurnSender.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Bridges the on-device `AppleVoiceTransport` to the existing chat stream:
+/// a recognized utterance is sent through `POST /api/chat/send` and the
+/// assistant's completed reply is collected from the SSE frames so the
+/// synthesizer can speak it. The transport is turn-based, so collapsing the
+/// stream into a single final reply matches its listen→send→speak loop.
+@MainActor
+final class CaveVoiceTurnSender: VoiceTurnSending {
+    private let client: CaveClient
+
+    init(client: CaveClient) {
+        self.client = client
+    }
+
+    func sendRecognizedTurn(_ text: String, familiarId: String,
+                            sessionId: String) async throws -> VoiceTurnReply {
+        let body = CaveClient.SendBody(
+            familiarId: familiarId,
+            prompt: text,
+            sessionId: sessionId.isEmpty ? nil : sessionId,
+            projectRoot: nil,
+            attachments: nil,
+            runId: UUID().uuidString
+        )
+
+        var reply = ""
+        for try await frame in client.sendStream(body) {
+            switch frame.event {
+            case .assistantChunk(let chunk):
+                reply += chunk
+            case .assistantReplace(let full):
+                reply = full
+            case .error(let message):
+                throw CaveError.transport(message)
+            case .done(let isError, _, _, _, _, _, _, _, _, _, _, _, _, _, _):
+                if isError {
+                    throw CaveError.transport("The familiar could not answer this turn.")
+                }
+            default:
+                break
+            }
+        }
+
+        return VoiceTurnReply(segmentID: UUID().uuidString, text: reply)
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallModel.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallModel.swift
@@ -1,0 +1,159 @@
+import Foundation
+
+/// Owns the lifecycle of one live voice call from the UI's perspective: it
+/// selects the transport from the familiar's voice metadata, mints a Realtime
+/// grant when needed, builds the engine's `VoiceCallCoordinator`, and offers
+/// the on-device call as a graceful fallback when a grant can't be minted.
+///
+/// The pure decisions (transport plan, phase→copy, error→recovery) live in
+/// `VoiceTransportPlanner` / `VoiceCallCopy` so they can be tested without a
+/// simulator; this type is the thin @MainActor glue that wires them to the
+/// engine and the network.
+@MainActor
+@Observable
+final class LiveVoiceCallModel {
+    /// The pre-call / call lifecycle the surface renders around the engine's
+    /// own `VoiceCallState`.
+    enum Launch: Equatable {
+        /// Nothing has started yet.
+        case idle
+        /// Minting a Realtime grant on the desktop, before any coordinator.
+        case minting
+        /// A coordinator is running; read `state.phase` for the live status.
+        case live
+        /// A Realtime grant could not be minted; offering the on-device call.
+        case fallbackOffer(VoiceCallErrorCopy)
+        /// No desktop connection at all — neither transport can run.
+        case unavailable(VoiceCallErrorCopy)
+    }
+
+    let familiar: Familiar
+    /// The transport the familiar's metadata asked for. The live call may run
+    /// on-device instead if the operator accepts the fallback offer.
+    let plannedMode: VoiceCallMode
+
+    private(set) var launch: Launch = .idle
+    private(set) var state: VoiceCallState
+
+    private let sessionId: String
+    private let client: CaveClient?
+    private var coordinator: VoiceCallCoordinator?
+
+    init(familiar: Familiar, sessionId: String, client: CaveClient?) {
+        self.familiar = familiar
+        self.sessionId = sessionId
+        self.client = client
+        let mode = VoiceTransportPlanner.plan(for: familiar)
+        self.plannedMode = mode
+        self.state = VoiceCallState(mode: mode)
+    }
+
+    /// The mode the current (or most recent) coordinator runs. Drives the copy
+    /// so a call that fell back to on-device is described as on-device.
+    var activeMode: VoiceCallMode { state.mode }
+
+    var isMuted: Bool { state.isMuted }
+
+    func start() async {
+        switch plannedMode {
+        case .realtime: await startRealtime()
+        case .native: await startOnDevice()
+        }
+    }
+
+    func toggleMute() {
+        guard let coordinator, !state.phase.isTerminal else { return }
+        coordinator.setMuted(!state.isMuted)
+    }
+
+    func end() {
+        coordinator?.end()
+    }
+
+    /// Rebuild a fresh coordinator and retry the transport that just failed.
+    func retry() async {
+        let mode = state.mode
+        resetForRestart(mode: mode)
+        switch mode {
+        case .realtime: await startRealtime()
+        case .native: await startOnDevice()
+        }
+    }
+
+    /// Accept the on-device fallback after a Realtime grant couldn't be minted.
+    func acceptOnDeviceFallback() async {
+        resetForRestart(mode: .native)
+        await startOnDevice()
+    }
+
+    // MARK: - Transport startup
+
+    private func startRealtime() async {
+        guard let client else {
+            launch = .unavailable(disconnectedCopy)
+            return
+        }
+        launch = .minting
+        do {
+            let response = try await client.mintVoiceSession(
+                familiarId: familiar.id, sessionId: sessionId
+            )
+            let context = VoiceCallTransportContext(
+                familiarId: familiar.id, sessionId: sessionId, grant: response.grant
+            )
+            await launchCoordinator(
+                mode: .realtime,
+                transport: OpenAIRealtimeTransport(),
+                mediaSession: VoiceMediaSession(),
+                context: context
+            )
+        } catch {
+            // A grant we couldn't mint is the fallback trigger, not a dead end.
+            launch = .fallbackOffer(VoiceCallCopy.mintFailureFallback(error.localizedDescription))
+        }
+    }
+
+    private func startOnDevice() async {
+        guard let client else {
+            launch = .unavailable(disconnectedCopy)
+            return
+        }
+        let context = VoiceCallTransportContext(
+            familiarId: familiar.id, sessionId: sessionId, grant: nil
+        )
+        await launchCoordinator(
+            mode: .native,
+            transport: AppleVoiceTransport(turnSender: CaveVoiceTurnSender(client: client)),
+            mediaSession: VoiceMediaSession(),
+            context: context
+        )
+    }
+
+    private func launchCoordinator(mode: VoiceCallMode, transport: VoiceCallTransport,
+                                   mediaSession: VoiceMediaSessionManaging,
+                                   context: VoiceCallTransportContext) async {
+        let coordinator = VoiceCallCoordinator(
+            mode: mode, transport: transport, mediaSession: mediaSession, context: context
+        )
+        coordinator.onStateChange = { [weak self] state in self?.state = state }
+        self.coordinator = coordinator
+        self.state = coordinator.state
+        launch = .live
+        await coordinator.start()
+    }
+
+    private func resetForRestart(mode: VoiceCallMode) {
+        coordinator = nil
+        state = VoiceCallState(mode: mode)
+        launch = .idle
+    }
+
+    private var disconnectedCopy: VoiceCallErrorCopy {
+        VoiceCallErrorCopy(
+            title: "Not connected",
+            message: "Connect to your desktop to start a voice call with \(familiar.displayName).",
+            recovery: .dismiss,
+            offersOnDeviceFallback: false
+        )
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/LiveVoiceCallView.swift
@@ -1,0 +1,326 @@
+import SwiftUI
+import UIKit
+
+/// The live voice-call surface. Owns a `LiveVoiceCallModel` and renders from
+/// the engine's published `VoiceCallState`: identity, phase, live transcript,
+/// mute, and end-call, plus actionable recovery for every terminal/error phase
+/// and the on-device fallback offer.
+struct LiveVoiceCallView: View {
+    @Environment(\.chrome) private var chrome
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openURL) private var openURL
+
+    @State private var model: LiveVoiceCallModel
+
+    init(familiar: Familiar, sessionId: String, client: CaveClient?) {
+        _model = State(initialValue: LiveVoiceCallModel(
+            familiar: familiar, sessionId: sessionId, client: client
+        ))
+    }
+
+    var body: some View {
+        ZStack {
+            chrome.bgBase.ignoresSafeArea()
+            VStack(spacing: 20) {
+                header
+                Divider().overlay(chrome.border)
+                content
+            }
+            .padding(20)
+        }
+        .task { await model.start() }
+        .onChange(of: model.state.phase) { _, phase in
+            if phase == .ended { dismiss() }
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 12) {
+            AvatarView(familiar: model.familiar,
+                       url: model.familiar.avatarUrl.flatMap(URL.init(string:)),
+                       size: 48)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.familiar.displayName)
+                    .font(.headline)
+                    .foregroundStyle(chrome.textPrimary)
+                Text(VoiceCallCopy.modeLabel(model.activeMode))
+                    .font(.subheadline)
+                    .foregroundStyle(chrome.textSecondary)
+            }
+            Spacer()
+            Button {
+                Haptics.tap()
+                model.end()
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.body.weight(.semibold))
+                    .foregroundStyle(chrome.textSecondary)
+                    .frame(width: 36, height: 36)
+                    .background(chrome.bgRaised, in: Circle())
+            }
+            .accessibilityLabel("Close voice call")
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Content routing
+
+    @ViewBuilder private var content: some View {
+        switch model.launch {
+        case .idle, .minting:
+            connecting(VoiceCallCopy.mintingStatus)
+        case .unavailable(let copy):
+            errorCard(copy)
+        case .fallbackOffer(let copy):
+            errorCard(copy)
+        case .live:
+            liveContent
+        }
+    }
+
+    @ViewBuilder private var liveContent: some View {
+        if case .error(let code) = model.state.phase {
+            errorCard(VoiceCallCopy.error(for: code, mode: model.activeMode))
+        } else {
+            VStack(spacing: 20) {
+                statusHeader
+                transcript
+                controls
+            }
+        }
+    }
+
+    // MARK: - Status
+
+    private var statusHeader: some View {
+        let copy = VoiceCallCopy.status(for: model.state.phase, mode: model.activeMode)
+        return VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                phaseIndicator
+                Text(copy.label)
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(chrome.textPrimary)
+            }
+            if let detail = copy.detail {
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(chrome.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel([copy.label, copy.detail].compactMap { $0 }.joined(separator: ". "))
+    }
+
+    private var phaseIndicator: some View {
+        Circle()
+            .fill(chrome.accent)
+            .frame(width: 10, height: 10)
+            .opacity(model.state.isAudioActive ? 1 : 0.4)
+            .scaleEffect(pulse ? 1.35 : 1)
+            .animation(
+                reduceMotion || !model.state.isAudioActive
+                    ? nil
+                    : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                value: pulse
+            )
+            .onAppear { pulse = true }
+            .accessibilityHidden(true)
+    }
+
+    @State private var pulse = false
+
+    private func connecting(_ copy: VoiceCallStatusCopy) -> some View {
+        VStack(spacing: 14) {
+            Spacer()
+            ProgressView()
+                .controlSize(.large)
+                .tint(chrome.accent)
+            Text(copy.label)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(chrome.textPrimary)
+            if let detail = copy.detail {
+                Text(detail)
+                    .font(.subheadline)
+                    .foregroundStyle(chrome.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Transcript
+
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 12) {
+                    if model.state.transcript.isEmpty {
+                        Text("The conversation will appear here as you talk.")
+                            .font(.subheadline)
+                            .foregroundStyle(chrome.textMuted)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, 24)
+                    }
+                    ForEach(model.state.transcript) { row in
+                        transcriptRow(row).id(row.id)
+                    }
+                }
+                .padding(.vertical, 4)
+            }
+            .onChange(of: model.state.transcript.last?.id) { _, id in
+                guard let id else { return }
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.2)) {
+                    proxy.scrollTo(id, anchor: .bottom)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func transcriptRow(_ row: VoiceTranscriptRow) -> some View {
+        let isUser = row.role == .user
+        let speaker = isUser ? "You" : model.familiar.displayName
+        return VStack(alignment: isUser ? .trailing : .leading, spacing: 3) {
+            Text(speaker.uppercased())
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(chrome.textMuted)
+            Text(row.text)
+                .font(.body)
+                .foregroundStyle(row.isFinal ? chrome.textPrimary : chrome.textSecondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(isUser ? chrome.accent.opacity(0.16) : chrome.bgRaised,
+                            in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .frame(maxWidth: .infinity, alignment: isUser ? .trailing : .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(speaker): \(row.text)")
+    }
+
+    // MARK: - Controls
+
+    private var controls: some View {
+        HStack(spacing: 16) {
+            Button {
+                Haptics.tap()
+                model.toggleMute()
+            } label: {
+                controlLabel(
+                    systemName: model.isMuted ? "mic.slash.fill" : "mic.fill",
+                    title: model.isMuted ? "Unmute" : "Mute",
+                    tint: model.isMuted ? chrome.textSecondary : chrome.accent,
+                    fill: chrome.bgRaised
+                )
+            }
+            .disabled(model.state.phase.isTerminal)
+            .accessibilityLabel(model.isMuted ? "Unmute microphone" : "Mute microphone")
+            .accessibilityValue(model.isMuted ? "Muted" : "On")
+
+            Button {
+                Haptics.tap()
+                model.end()
+                dismiss()
+            } label: {
+                controlLabel(
+                    systemName: "phone.down.fill",
+                    title: "End",
+                    tint: .white,
+                    fill: .red
+                )
+            }
+            .accessibilityLabel("End call")
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func controlLabel(systemName: String, title: String,
+                              tint: Color, fill: Color) -> some View {
+        VStack(spacing: 6) {
+            Image(systemName: systemName)
+                .font(.title2)
+                .foregroundStyle(tint)
+                .frame(width: 60, height: 60)
+                .background(fill, in: Circle())
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(chrome.textSecondary)
+        }
+    }
+
+    // MARK: - Error / fallback
+
+    private func errorCard(_ copy: VoiceCallErrorCopy) -> some View {
+        VStack(spacing: 14) {
+            Spacer()
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.largeTitle)
+                .foregroundStyle(chrome.accent)
+                .accessibilityHidden(true)
+            Text(copy.title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(chrome.textPrimary)
+                .multilineTextAlignment(.center)
+            Text(copy.message)
+                .font(.subheadline)
+                .foregroundStyle(chrome.textSecondary)
+                .multilineTextAlignment(.center)
+            VStack(spacing: 10) {
+                recoveryButton(copy.recovery)
+                if copy.offersOnDeviceFallback {
+                    Button {
+                        Haptics.tap()
+                        Task { await model.acceptOnDeviceFallback() }
+                    } label: {
+                        Text("Call on device instead")
+                            .frame(maxWidth: .infinity)
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(chrome.accent)
+                }
+                Button("Close") {
+                    model.end()
+                    dismiss()
+                }
+                .foregroundStyle(chrome.textSecondary)
+            }
+            .padding(.top, 4)
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 8)
+        .accessibilityElement(children: .contain)
+    }
+
+    @ViewBuilder private func recoveryButton(_ recovery: VoiceCallErrorCopy.Recovery) -> some View {
+        switch recovery {
+        case .retry:
+            Button {
+                Haptics.tap()
+                Task { await model.retry() }
+            } label: {
+                Text("Try again").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(chrome.accent)
+        case .openSettings:
+            Button {
+                Haptics.tap()
+                if let url = URL(string: UIApplication.openSettingsURLString) { openURL(url) }
+            } label: {
+                Text("Open Settings").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(chrome.accent)
+        case .dismiss:
+            EmptyView()
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/Voice/VoiceCallPresentation.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/Voice/VoiceCallPresentation.swift
@@ -1,0 +1,214 @@
+import Foundation
+
+/// Pure, UI-independent presentation logic for a live voice call. The view and
+/// view-model read these mappings so the SwiftUI layer stays a thin renderer
+/// and the phase→copy / error→recovery decisions can be unit-tested without a
+/// simulator, network, or audio session.
+
+/// How the call surface should describe a non-terminal phase.
+struct VoiceCallStatusCopy: Equatable {
+    let label: String
+    /// Secondary line; nil when the label alone is enough.
+    let detail: String?
+}
+
+/// A terminal error rendered as actionable copy plus the one recovery the
+/// reducer and platform actually allow from here.
+struct VoiceCallErrorCopy: Equatable {
+    enum Recovery: Equatable {
+        /// Rebuild the coordinator and try the same transport again.
+        case retry
+        /// The failure is a denied system permission; only Settings fixes it.
+        case openSettings
+        /// Nothing the operator can do in-app; only dismiss.
+        case dismiss
+    }
+
+    let title: String
+    let message: String
+    let recovery: Recovery
+    /// Whether to additionally offer the on-device call as a graceful fallback.
+    /// Only meaningful while the failed call was a Realtime call.
+    let offersOnDeviceFallback: Bool
+}
+
+/// Chooses the transport for a call and the fallback when Realtime cannot be
+/// reached. Kept separate from `VoiceCallMode.forVoiceProvider` so the fallback
+/// rule has one testable home.
+enum VoiceTransportPlanner {
+    /// The transport a familiar's published voice metadata asks for.
+    static func plan(for familiar: Familiar) -> VoiceCallMode {
+        VoiceCallMode.forVoiceProvider(familiar.voiceProvider)
+    }
+
+    /// The graceful fallback when the planned transport cannot start. Realtime
+    /// degrades to the on-device call; the on-device call has nothing further
+    /// to fall back to.
+    static func fallback(after mode: VoiceCallMode) -> VoiceCallMode? {
+        switch mode {
+        case .realtime: .native
+        case .native: nil
+        }
+    }
+}
+
+enum VoiceCallCopy {
+    static func modeLabel(_ mode: VoiceCallMode) -> String {
+        switch mode {
+        case .realtime: "Live voice"
+        case .native: "On-device voice"
+        }
+    }
+
+    /// Non-terminal phase → status copy. Terminal phases (`.error`, `.ended`)
+    /// are handled by `error(for:mode:)` and the ended state respectively.
+    static func status(for phase: VoiceCallPhase, mode: VoiceCallMode) -> VoiceCallStatusCopy {
+        switch phase {
+        case .idle:
+            return VoiceCallStatusCopy(label: "Ready", detail: nil)
+        case .requestingPermission:
+            return VoiceCallStatusCopy(
+                label: "Waiting for microphone",
+                detail: "Allow access to start talking."
+            )
+        case .connecting:
+            return VoiceCallStatusCopy(
+                label: mode == .realtime ? "Connecting" : "Starting",
+                detail: mode == .realtime ? "Opening the live voice channel…" : nil
+            )
+        case .listening:
+            return VoiceCallStatusCopy(label: "Listening", detail: nil)
+        case .processing:
+            return VoiceCallStatusCopy(label: "Thinking", detail: nil)
+        case .speaking:
+            return VoiceCallStatusCopy(label: "Speaking", detail: nil)
+        case .ended:
+            return VoiceCallStatusCopy(label: "Call ended", detail: nil)
+        case .error:
+            // Callers render errors through `error(for:mode:)`; this keeps the
+            // switch exhaustive without duplicating that mapping.
+            return VoiceCallStatusCopy(label: "Call ended", detail: nil)
+        }
+    }
+
+    /// Copy shown while the desktop is minting a Realtime grant, before the
+    /// coordinator's own phases take over.
+    static var mintingStatus: VoiceCallStatusCopy {
+        VoiceCallStatusCopy(label: "Connecting", detail: "Reaching the live voice provider…")
+    }
+
+    /// The offer shown when a Realtime grant could not be minted (no API key,
+    /// offline, or the desktop refused). This is a real, actionable fallback —
+    /// the operator can still talk to the familiar entirely on-device.
+    static func mintFailureFallback(_ underlying: String?) -> VoiceCallErrorCopy {
+        let detail = cleaned(underlying)
+        let message = detail.map { "The desktop couldn't start a live voice call: \($0)" }
+            ?? "The desktop couldn't start a live voice call. This usually means no voice API key is configured or the desktop is offline."
+        return VoiceCallErrorCopy(
+            title: "Live voice unavailable",
+            message: message,
+            recovery: .retry,
+            offersOnDeviceFallback: true
+        )
+    }
+
+    /// Terminal error code (from the reducer / transports) → operator-facing
+    /// copy and the single recovery that can actually help from here.
+    static func error(for code: String, mode: VoiceCallMode) -> VoiceCallErrorCopy {
+        let realtime = mode == .realtime
+
+        switch code {
+        case "microphone_denied":
+            return VoiceCallErrorCopy(
+                title: "Microphone access is off",
+                message: "Coven Cave needs the microphone for a voice call. Turn it on in Settings, then start the call again.",
+                recovery: .openSettings,
+                offersOnDeviceFallback: false
+            )
+        case "speech_recognition_denied":
+            return VoiceCallErrorCopy(
+                title: "Speech recognition is off",
+                message: "An on-device call transcribes your speech on this iPhone. Allow Speech Recognition in Settings to continue.",
+                recovery: .openSettings,
+                offersOnDeviceFallback: false
+            )
+        case "speech_recognizer_unavailable":
+            return VoiceCallErrorCopy(
+                title: "Speech recognition unavailable",
+                message: "This iPhone can't transcribe speech right now. Check that a language is downloaded for dictation and try again.",
+                recovery: .retry,
+                offersOnDeviceFallback: false
+            )
+        case "speech_audio_engine_failed", "speech_recognition_failed":
+            return VoiceCallErrorCopy(
+                title: "Couldn't hear you",
+                message: "The microphone stopped unexpectedly. Try the call again.",
+                recovery: .retry,
+                offersOnDeviceFallback: false
+            )
+        case "voice_turn_send_failed":
+            return VoiceCallErrorCopy(
+                title: "Reply didn't come through",
+                message: "The familiar couldn't be reached for that turn. Check your connection to the desktop and try again.",
+                recovery: .retry,
+                offersOnDeviceFallback: false
+            )
+        case "audio_interrupted":
+            return VoiceCallErrorCopy(
+                title: "Call interrupted",
+                message: "Another app or an incoming call took over audio. Start the call again when you're ready.",
+                recovery: .retry,
+                offersOnDeviceFallback: realtime
+            )
+        case "audio_route_changed":
+            return VoiceCallErrorCopy(
+                title: "Audio device changed",
+                message: "Your headphones or speaker changed mid-call. Start the call again to reconnect audio.",
+                recovery: .retry,
+                offersOnDeviceFallback: realtime
+            )
+        default:
+            if code.hasPrefix("realtime_") {
+                return realtimeError(code)
+            }
+            return VoiceCallErrorCopy(
+                title: "Call ended",
+                message: "Something went wrong with the call. Try again.",
+                recovery: .retry,
+                offersOnDeviceFallback: realtime
+            )
+        }
+    }
+
+    private static func realtimeError(_ code: String) -> VoiceCallErrorCopy {
+        let message: String
+        switch code {
+        case "realtime_grant_missing", "realtime_connection_url_invalid":
+            message = "The desktop's voice grant was incomplete. Retry, or switch to an on-device call."
+        case "realtime_empty_sdp_answer":
+            message = "The voice provider didn't answer. Retry, or switch to an on-device call."
+        case "realtime_event_decode_failed":
+            message = "The live voice stream sent something unexpected. Retry, or switch to an on-device call."
+        default:
+            if code.hasPrefix("realtime_signaling_failed_") {
+                message = "The voice provider refused the connection. Retry, or switch to an on-device call."
+            } else if code.hasPrefix("realtime_ice_") {
+                message = "The live voice connection dropped. Retry, or switch to an on-device call."
+            } else {
+                message = "The live voice call failed. Retry, or switch to an on-device call."
+            }
+        }
+        return VoiceCallErrorCopy(
+            title: "Live voice call failed",
+            message: message,
+            recovery: .retry,
+            offersOnDeviceFallback: true
+        )
+    }
+
+    private static func cleaned(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/VoiceCallPresentationTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/VoiceCallPresentationTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import CovenCave
+
+final class VoiceCallPresentationTests: XCTestCase {
+    private func familiar(voiceProvider: String?) -> Familiar {
+        var json: [String: Any] = ["id": "familiar", "display_name": "Nova"]
+        if let voiceProvider { json["voiceProvider"] = voiceProvider }
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return try! JSONDecoder().decode(Familiar.self, from: data)
+    }
+
+    // MARK: - Transport selection
+
+    func testPlannerSelectsRealtimeOnlyForOpenAIProvider() {
+        XCTAssertEqual(VoiceTransportPlanner.plan(for: familiar(voiceProvider: "openai")), .realtime)
+        XCTAssertEqual(VoiceTransportPlanner.plan(for: familiar(voiceProvider: "anthropic")), .native)
+        XCTAssertEqual(VoiceTransportPlanner.plan(for: familiar(voiceProvider: nil)), .native)
+    }
+
+    func testFallbackDegradesRealtimeToOnDeviceAndNativeHasNoFallback() {
+        XCTAssertEqual(VoiceTransportPlanner.fallback(after: .realtime), .native)
+        XCTAssertNil(VoiceTransportPlanner.fallback(after: .native))
+    }
+
+    // MARK: - Phase → status copy
+
+    func testConnectingCopyDiffersByTransport() {
+        XCTAssertEqual(VoiceCallCopy.status(for: .connecting, mode: .realtime).label, "Connecting")
+        XCTAssertEqual(VoiceCallCopy.status(for: .connecting, mode: .native).label, "Starting")
+    }
+
+    func testActivePhasesMapToTheirLabels() {
+        XCTAssertEqual(VoiceCallCopy.status(for: .listening, mode: .native).label, "Listening")
+        XCTAssertEqual(VoiceCallCopy.status(for: .processing, mode: .native).label, "Thinking")
+        XCTAssertEqual(VoiceCallCopy.status(for: .speaking, mode: .realtime).label, "Speaking")
+    }
+
+    // MARK: - Error → recovery mapping
+
+    func testDeniedPermissionsRouteToSettingsWithNoFallback() {
+        let mic = VoiceCallCopy.error(for: "microphone_denied", mode: .realtime)
+        XCTAssertEqual(mic.recovery, .openSettings)
+        XCTAssertFalse(mic.offersOnDeviceFallback)
+
+        let speech = VoiceCallCopy.error(for: "speech_recognition_denied", mode: .native)
+        XCTAssertEqual(speech.recovery, .openSettings)
+        XCTAssertFalse(speech.offersOnDeviceFallback)
+    }
+
+    func testRealtimeFailuresRetryAndOfferOnDeviceFallback() {
+        for code in ["realtime_grant_missing", "realtime_signaling_failed_401",
+                     "realtime_ice_5", "realtime_empty_sdp_answer",
+                     "realtime_event_decode_failed"] {
+            let copy = VoiceCallCopy.error(for: code, mode: .realtime)
+            XCTAssertEqual(copy.recovery, .retry, code)
+            XCTAssertTrue(copy.offersOnDeviceFallback, code)
+        }
+    }
+
+    func testOnDeviceTransportFailuresRetryWithoutFallback() {
+        for code in ["speech_recognizer_unavailable", "speech_audio_engine_failed",
+                     "speech_recognition_failed", "voice_turn_send_failed"] {
+            let copy = VoiceCallCopy.error(for: code, mode: .native)
+            XCTAssertEqual(copy.recovery, .retry, code)
+            XCTAssertFalse(copy.offersOnDeviceFallback, code)
+        }
+    }
+
+    func testAudioInterruptionOffersFallbackOnlyWhenRealtime() {
+        XCTAssertTrue(VoiceCallCopy.error(for: "audio_interrupted", mode: .realtime).offersOnDeviceFallback)
+        XCTAssertFalse(VoiceCallCopy.error(for: "audio_interrupted", mode: .native).offersOnDeviceFallback)
+    }
+
+    func testUnknownErrorRetriesAndFallsBackOnlyForRealtime() {
+        let realtime = VoiceCallCopy.error(for: "totally_unexpected", mode: .realtime)
+        XCTAssertEqual(realtime.recovery, .retry)
+        XCTAssertTrue(realtime.offersOnDeviceFallback)
+
+        let native = VoiceCallCopy.error(for: "totally_unexpected", mode: .native)
+        XCTAssertEqual(native.recovery, .retry)
+        XCTAssertFalse(native.offersOnDeviceFallback)
+    }
+
+    // MARK: - Mint fallback offer
+
+    func testMintFailureIsAFallbackOfferNotADeadError() {
+        let copy = VoiceCallCopy.mintFailureFallback("no API key configured")
+        XCTAssertEqual(copy.recovery, .retry)
+        XCTAssertTrue(copy.offersOnDeviceFallback)
+        XCTAssertTrue(copy.message.contains("no API key configured"))
+    }
+
+    func testMintFailureWithoutDetailStillExplainsAndOffersFallback() {
+        let copy = VoiceCallCopy.mintFailureFallback(nil)
+        XCTAssertTrue(copy.offersOnDeviceFallback)
+        XCTAssertFalse(copy.message.isEmpty)
+    }
+
+    func testModeLabelsAreDistinct() {
+        XCTAssertNotEqual(VoiceCallCopy.modeLabel(.realtime), VoiceCallCopy.modeLabel(.native))
+    }
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -577,6 +577,8 @@ export const SUITES = {
     "src/lib/canvas-inspector.test.ts",
     "src/lib/canvas-inspector-channel.test.ts",
     "src/lib/canvas-inspector-chromium.test.ts",
+    "src/lib/arcade/glitter-crypt.test.ts",
+    "src/lib/arcade/glitter-crypt-chromium.test.ts",
     "src/lib/artifact-open.test.ts",
     "src/lib/refine-suggestions.test.ts",
     "src/lib/canvas-react-harness.test.ts",

--- a/src/components/arcade-panel.tsx
+++ b/src/components/arcade-panel.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * The arcade panel — somewhere to put your hands during dead air.
+ *
+ * A voice call spends real seconds doing nothing you can watch: asking for the
+ * mic, minting a session, connecting, and then waiting on the familiar to
+ * think. This mounts Glitter Crypt into that gap.
+ *
+ * Three constraints shape it, and all three are load-bearing:
+ *
+ * 1. **Silent.** It plays *over* a live call, so the game never touches audio
+ *    or `getUserMedia`. Enforced by an assertion in `glitter-crypt.test.ts`,
+ *    not by good intentions.
+ * 2. **Opt-in.** It never appears unasked. A game that ambushes someone
+ *    mid-call is a bug, and the toggle is off until it is pressed.
+ * 3. **Disposable.** All state lives inside the iframe, so unmounting is the
+ *    entire teardown — no rAF loop or listener survives it.
+ *
+ * The iframe is `sandbox="allow-scripts"` with no `allow-same-origin`, so the
+ * document sits on an opaque origin: it cannot reach our storage, cookies, or
+ * DOM. That is why the game has to be one self-contained string.
+ */
+
+import { useMemo, useRef, useState } from "react";
+import { Icon } from "@iconify/react";
+import { ARCADE_TAGLINE, ARCADE_TITLE, buildArcadeSrcDoc } from "@/lib/arcade/glitter-crypt";
+import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
+
+type Props = {
+  /** Rendered under the title — say what the caller is waiting on. */
+  waitingLabel?: string;
+  onClose: () => void;
+};
+
+export function ArcadePanel({ waitingLabel, onClose }: Props) {
+  const reducedMotion = usePrefersReducedMotion();
+  const frameRef = useRef<HTMLIFrameElement | null>(null);
+  // Bumping this remounts the document. An identical `srcDoc` does not reload
+  // an iframe, so a played-out run could never return to frame one without it.
+  const [runNonce, setRunNonce] = useState(0);
+
+  const srcDoc = useMemo(
+    () => buildArcadeSrcDoc({ reducedMotion }),
+    [reducedMotion],
+  );
+
+  return (
+    <section className="arcade-panel" aria-label={`${ARCADE_TITLE} — something to do while you wait`}>
+      <header className="arcade-panel__header">
+        <div className="arcade-panel__heading">
+          <Icon icon="ph:magic-wand-fill" aria-hidden="true" />
+          <strong className="arcade-panel__title">{ARCADE_TITLE}</strong>
+        </div>
+        <p className="arcade-panel__tagline">{waitingLabel ?? ARCADE_TAGLINE}</p>
+        <div className="arcade-panel__actions">
+          <button
+            type="button"
+            className="arcade-panel__action focus-ring"
+            aria-label="Restart the game"
+            title="Restart"
+            onClick={() => {
+              setRunNonce((n) => n + 1);
+              // The fresh document has to take the keyboard back, or the next
+              // keypress lands on the dialog behind it.
+              requestAnimationFrame(() => frameRef.current?.focus());
+            }}
+          >
+            <Icon icon="ph:arrow-counter-clockwise" />
+          </button>
+          <button
+            type="button"
+            className="arcade-panel__action focus-ring"
+            aria-label={`Close ${ARCADE_TITLE}`}
+            title="Close"
+            onClick={onClose}
+          >
+            <Icon icon="ph:x" />
+          </button>
+        </div>
+      </header>
+      <iframe
+        key={runNonce}
+        ref={frameRef}
+        className="arcade-panel__frame"
+        title={`${ARCADE_TITLE} — playable`}
+        sandbox="allow-scripts"
+        srcDoc={srcDoc}
+      />
+      <p className="arcade-panel__hint">
+        Move with WASD, turn with the arrow keys, zap with space. Nothing here makes a sound.
+      </p>
+    </section>
+  );
+}

--- a/src/components/arcade-panel.tsx
+++ b/src/components/arcade-panel.tsx
@@ -23,7 +23,7 @@
  */
 
 import { useMemo, useRef, useState } from "react";
-import { Icon } from "@iconify/react";
+import { Icon } from "@/lib/icon";
 import { ARCADE_TAGLINE, ARCADE_TITLE, buildArcadeSrcDoc } from "@/lib/arcade/glitter-crypt";
 import { usePrefersReducedMotion } from "@/lib/use-prefers-reduced-motion";
 
@@ -49,7 +49,7 @@ export function ArcadePanel({ waitingLabel, onClose }: Props) {
     <section className="arcade-panel" aria-label={`${ARCADE_TITLE} — something to do while you wait`}>
       <header className="arcade-panel__header">
         <div className="arcade-panel__heading">
-          <Icon icon="ph:magic-wand-fill" aria-hidden="true" />
+          <Icon name="ph:magic-wand-fill" aria-hidden />
           <strong className="arcade-panel__title">{ARCADE_TITLE}</strong>
         </div>
         <p className="arcade-panel__tagline">{waitingLabel ?? ARCADE_TAGLINE}</p>
@@ -66,7 +66,7 @@ export function ArcadePanel({ waitingLabel, onClose }: Props) {
               requestAnimationFrame(() => frameRef.current?.focus());
             }}
           >
-            <Icon icon="ph:arrow-counter-clockwise" />
+            <Icon name="ph:arrow-counter-clockwise" />
           </button>
           <button
             type="button"
@@ -75,7 +75,7 @@ export function ArcadePanel({ waitingLabel, onClose }: Props) {
             title="Close"
             onClick={onClose}
           >
-            <Icon icon="ph:x" />
+            <Icon name="ph:x" />
           </button>
         </div>
       </header>

--- a/src/components/canvas-add-tile.tsx
+++ b/src/components/canvas-add-tile.tsx
@@ -83,6 +83,9 @@ export function CanvasAddTile({
   onActiveArtifactChange: (id: string | null) => void;
 }) {
   const [state, dispatch] = useReducer(addTileReducer, INITIAL_ADD_TILE_STATE);
+  // Not reducer state: it survives across generations on purpose, because
+  // someone building a game makes several in a row.
+  const [playable, setPlayable] = useState(false);
   const [chosenFamiliar, setChosenFamiliar] = useState<string | null>(null);
   const [familiars, setFamiliars] = useState<Familiar[]>([]);
   const [refineText, setRefineText] = useState("");
@@ -274,14 +277,14 @@ export function CanvasAddTile({
       purpose: "create",
       prompt: state.prompt,
       title: titleFromPrompt(state.prompt),
-      generationPrompt: buildSketchPrompt(state.prompt),
+      generationPrompt: buildSketchPrompt(state.prompt, { playable }),
       originalIntent: state.prompt,
     });
     if (started.runId !== runId) return;
     ownedRunsRef.current.set(runId, revision);
     setHiddenRunId(null);
     dispatch({ type: "begin-generation", runId, identity });
-  }, [activeFamiliar, state.identity, state.prompt, state.revision]);
+  }, [activeFamiliar, playable, state.identity, state.prompt, state.revision]);
 
   const refine = useCallback(() => {
     const ask = refineText.trim();
@@ -712,6 +715,24 @@ export function CanvasAddTile({
               </div>
             ) : null}
             <div className="chat-canvas-add__row">
+              {/* Playable is a different output contract, not a phrasing hint —
+                  a game needs a loop, input handling, and a restart, and
+                  asking for them in prose does not reliably get them. */}
+              <button
+                type="button"
+                className="chat-canvas-add__playable focus-ring"
+                aria-pressed={playable}
+                aria-label="Generate a playable game instead of a static sketch"
+                title="Make it playable"
+                onClick={() => {
+                  const next = !playable;
+                  setPlayable(next);
+                  announce(next ? "Playable game mode on" : "Playable game mode off");
+                }}
+              >
+                <Icon name="ph:magic-wand" width={12} />
+                <span>Playable</span>
+              </button>
               {/* Who draws this is an identity, not a form field — the avatar
                   and name carry it the way the roster does everywhere else. */}
               <button

--- a/src/components/canvas-editor.test.ts
+++ b/src/components/canvas-editor.test.ts
@@ -177,10 +177,18 @@ assert.match(
   "the three modes render with the mock's tooltips",
 );
 assert.match(editor, /aria-pressed=\{mode === id\}/, "mode toggles expose pressed state");
+// The inspector's injected handler preventDefaults every trusted click, so
+// leaving it on is what made a generated sketch impossible to actually use.
+// Play mode turns it off; nothing else may.
 assert.match(
   editor,
-  /if \(!inspectorLoaded\) return;[\s\S]{0,120}?setEnabled\(true\)/,
-  "selection is enabled in every mode once the inspector authenticates",
+  /if \(!inspectorLoaded\) return;[\s\S]{0,160}?setEnabled\(mode !== "play"\)/,
+  "selection is enabled in every mode except play, once the inspector authenticates",
+);
+assert.match(
+  editor,
+  /modeButton\("play", "Play", "Run the sketch for real — clicks and keys reach it"\)/,
+  "play is offered as a first-class mode alongside select/comment/edit",
 );
 
 // Escape routes through the shared resolver: field → selection → expand.

--- a/src/components/canvas-editor.tsx
+++ b/src/components/canvas-editor.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 // Full-surface sketch editor for the Canvas tab (design-handoff redesign).
-// Three modes over the sandboxed sketch iframe: Select (inspect a component),
-// Comment (pin persisted annotations to components), and Edit (live inline
-// style experiments driven through the inspector channel). A design-chat rail
-// runs refine requests through the same familiar generation path as the
-// inline artifact viewer and persists accepted revisions to /api/canvas.
+// Four modes over the sandboxed sketch iframe: Select (inspect a component),
+// Comment (pin persisted annotations to components), Edit (live inline
+// style experiments driven through the inspector channel), and Play (hands the
+// sketch back its own input so it actually runs). A design-chat rail runs
+// refine requests through the same familiar generation path as the inline
+// artifact viewer and persists accepted revisions to /api/canvas.
+//
+// Play mode exists because the inspector swallows input. Its injected script
+// calls preventDefault + stopImmediatePropagation on every trusted click and
+// on Enter/Space, so while it is enabled NO generated sketch can ever be
+// interacted with — buttons, forms, and games are all inert. Play is the one
+// mode that disables it, which is what makes a generated sketch playable.
 
 import "@/styles/canvas-editor.css";
 
@@ -38,7 +45,7 @@ import {
   type CanvasViewportPresetId,
 } from "@/lib/canvas-viewport";
 
-type EditorMode = "select" | "comment" | "edit";
+type EditorMode = "select" | "comment" | "edit" | "play";
 
 type ChatMessage = {
   id: string;
@@ -187,6 +194,10 @@ export function CanvasEditor(props: {
   const [fullscreenAvailable, setFullscreenAvailable] = useState(false);
   const [viewportId, setViewportId] = useState<CanvasViewportPresetId>("fill");
   const [viewportScale, setViewportScale] = useState(1);
+  // Bumped to remount the sketch from scratch ("Restart"). A game that has been
+  // played to a game-over has no other way back to its first frame, and
+  // re-rendering identical srcDoc would not reload the iframe.
+  const [runNonce, setRunNonce] = useState(0);
   // Whether the current selection rides along with the next design-chat
   // message. Picking a component attaches it (that's why you picked it); the
   // chip's detach lets you ask a general question without losing the pick.
@@ -222,7 +233,7 @@ export function CanvasEditor(props: {
   attachedRef.current = attached;
   onArtifactUpdatedRef.current = onArtifactUpdated;
 
-  const inspectorGeneration = useMemo(() => crypto.randomUUID(), [kind, code]);
+  const inspectorGeneration = useMemo(() => crypto.randomUUID(), [kind, code, runNonce]);
   const srcDoc = useMemo(
     () => (
       kind === "react"
@@ -339,16 +350,36 @@ export function CanvasEditor(props: {
     }, 250);
   }, []);
 
-  // Selection stays enabled in every mode — the modes change what the aside
-  // does with the selected component, not whether one can be picked.
+  // Selection stays enabled in Select/Comment/Edit — those modes change what
+  // the aside does with the selected component, not whether one can be picked.
+  // Play is the exception: the inspector is the thing eating the sketch's
+  // input, so playing means turning it off. Disabling also clears the
+  // highlight and restores the tabindexes the inspector added.
   useEffect(() => {
     if (!inspectorLoaded) return;
     try {
-      inspectorChannelRef.current?.setEnabled(true);
+      inspectorChannelRef.current?.setEnabled(mode !== "play");
     } catch {
       // A srcdoc navigation may close the previous port between render and load.
     }
-  }, [inspectorLoaded]);
+  }, [inspectorLoaded, mode]);
+
+  // Entering Play drops the stale selection (the aside no longer shows it) and
+  // hands the sketch keyboard focus, without which a WASD/arrow-key game would
+  // look broken until the user happened to click inside the frame.
+  useEffect(() => {
+    if (mode !== "play") return;
+    setSelection(null);
+    const frame = frameRef.current;
+    if (!frame) return;
+    const handle = requestAnimationFrame(() => frame.focus());
+    return () => cancelAnimationFrame(handle);
+  }, [mode, srcDoc]);
+
+  const restartSketch = useCallback(() => {
+    setRunNonce((current) => current + 1);
+    setAnnouncement("Sketch restarted from its first frame.");
+  }, []);
 
   // Sandbox runtime failures surface as an overlay alert; the same
   // e.source-identity check as the bootstrap listener (see cave-mnz1 above).
@@ -781,7 +812,13 @@ export function CanvasEditor(props: {
   // ── Render ────────────────────────────────────────────────────────────────
 
   const selectionLabel = selection ? selection.label || selection.selector : "Nothing selected";
-  const panelTitle = mode === "edit" ? "Inspector" : mode === "comment" ? "Comments" : "Selection";
+  const panelTitle = mode === "edit"
+    ? "Inspector"
+    : mode === "comment"
+      ? "Comments"
+      : mode === "play"
+        ? "Play"
+        : "Selection";
 
   const modeButton = (id: EditorMode, label: string, title: string) => (
     <button
@@ -872,6 +909,7 @@ export function CanvasEditor(props: {
           {modeButton("select", "Select", "Select components")}
           {modeButton("comment", "Comment", "Pin comments to components")}
           {modeButton("edit", "Edit", "Edit fonts, borders, padding")}
+          {modeButton("play", "Play", "Run the sketch for real — clicks and keys reach it")}
         </span>
         <button type="button" className="canvas-editor__done focus-ring" onClick={onClose}>
           Done
@@ -964,6 +1002,35 @@ export function CanvasEditor(props: {
                     </span>
                   </div>
                 ) : null}
+              </>
+            ) : null}
+
+            {mode === "play" ? (
+              <>
+                <p className="canvas-editor__hint">
+                  The sketch is live — clicks, typing, and key presses go straight to it
+                  instead of selecting components. Use this to actually play a generated
+                  game or drive a real form.
+                </p>
+                <div className="canvas-editor__play-card">
+                  <span className="canvas-editor__play-row">
+                    <Icon name="ph:cursor-click" width={13} aria-hidden />
+                    Click the sketch once if keys aren&rsquo;t registering — it needs focus.
+                  </span>
+                  <span className="canvas-editor__play-row">
+                    <Icon name="ph:play" width={13} aria-hidden />
+                    Switch back to Select to inspect, comment, or restyle.
+                  </span>
+                  <button
+                    type="button"
+                    className="canvas-editor__sel-action focus-ring"
+                    title="Reload the sketch from its first frame"
+                    onClick={restartSketch}
+                  >
+                    <Icon name="ph:arrow-counter-clockwise" width={11} aria-hidden />
+                    Restart sketch
+                  </button>
+                </div>
               </>
             ) : null}
 

--- a/src/components/chat-canvas-tab.test.ts
+++ b/src/components/chat-canvas-tab.test.ts
@@ -553,7 +553,16 @@ assert.match(
 assert.match(addTile, /startCanvasGeneration\(\{/, "describe starts the navigation-safe Canvas generation owner");
 assert.match(addTile, /What would you like to create\?/, "default path asks for intent, not an implementation mode");
 assert.match(addTile, /Create preview/, "primary action creates a preview");
-assert.match(addTile, /buildSketchPrompt\(state\.prompt\)/, "prompts are wrapped with the shared sketch contract");
+assert.match(
+  addTile,
+  /buildSketchPrompt\(state\.prompt, \{ playable \}\)/,
+  "prompts are wrapped with the shared sketch contract, carrying the playable flag",
+);
+assert.match(
+  addTile,
+  /aria-pressed=\{playable\}/,
+  "the playable toggle reports its pressed state to assistive tech",
+);
 assert.match(addTile, /buildRefinePrompt\(state\.result\.code, ask, state\.result\.kind\)/, "refine reuses the shared refine contract");
 assert.match(generationRegistry, /buildArtifactRepairPrompt/, "format recovery uses the bounded repair prompt");
 assert.match(generationRegistry, /sessionId: result\.sessionId/, "repair resumes the same hidden Canvas session");

--- a/src/components/chat-canvas-view.tsx
+++ b/src/components/chat-canvas-view.tsx
@@ -30,8 +30,8 @@ import {
 // /api/canvas). Until this tab, saved artifacts had no surface after the
 // standalone Canvas page retired — save was a one-way door. This closes the
 // loop: browse saved sketches (toolbar search + kind filter), click one for a
-// non-interactive preview modal, open it in the full-surface Canvas editor,
-// or delete it.
+// preview modal (still by default, Play hands it real input), open it in the
+// full-surface Canvas editor, or delete it.
 
 type LoadState = "loading" | "ready" | "error";
 
@@ -50,6 +50,11 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
   // In-place expand: the preview dialog grows to fill the viewport. Reset per
   // sketch so the next preview always opens at the normal size.
   const [previewExpanded, setPreviewExpanded] = useState(false);
+  // Hand the sketch its own input back. Off by default so the modal stays a
+  // safe glance at the render; on, clicks and keys reach the sandbox, which is
+  // the only way a generated game or form is testable without the editor.
+  // Reset per sketch, same as expand.
+  const [previewPlaying, setPreviewPlaying] = useState(false);
   const [editorId, setEditorId] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [activeComposerId, setActiveComposerId] = useState<string | null>(null);
@@ -172,6 +177,7 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
 
   useEffect(() => {
     setPreviewExpanded(false);
+    setPreviewPlaying(false);
   }, [previewId]);
 
   useFocusTrap(preview !== null, previewDialogRef, {
@@ -368,8 +374,9 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
           </p>
         ) : null}
       </div>
-      {/* Preview modal: the sketch rendered live but non-interactive. Running
-          it for real (and refining/commenting) happens in the editor. */}
+      {/* Preview modal: the sketch rendered live. Still by default; the Play
+          toggle hands input back so it actually runs. Refining/commenting
+          still happens in the editor. */}
       {preview ? (
         <div
           className="chat-canvas-preview-backdrop"
@@ -396,6 +403,16 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
               <button
                 type="button"
                 className="chat-canvas-preview__expand focus-ring"
+                title={previewPlaying ? "Stop interacting with the sketch" : "Interact with the sketch"}
+                aria-label={previewPlaying ? "Stop interacting with the sketch" : "Interact with the sketch"}
+                aria-pressed={previewPlaying}
+                onClick={() => setPreviewPlaying((current) => !current)}
+              >
+                <Icon name={previewPlaying ? "ph:pause" : "ph:play"} width={15} aria-hidden />
+              </button>
+              <button
+                type="button"
+                className="chat-canvas-preview__expand focus-ring"
                 title={previewExpanded ? "Restore preview" : "Expand preview"}
                 aria-label={previewExpanded ? "Restore preview" : "Expand preview"}
                 aria-pressed={previewExpanded}
@@ -417,12 +434,15 @@ export function ChatCanvasView({ familiarId }: { familiarId: string | null }) {
                 className="chat-canvas-preview__frame"
                 title={`Preview of ${preview.title}`}
                 sandbox="allow-scripts"
+                data-playing={previewPlaying || undefined}
                 srcDoc={preview.kind === "react" ? buildReactSrcDoc(preview.code) : buildPreviewSrcDoc(preview.code)}
-                tabIndex={-1}
+                tabIndex={previewPlaying ? 0 : -1}
               />
             </div>
             <p className="chat-canvas-preview__hint">
-              Sketch preview — open it in the editor to run it live.
+              {previewPlaying
+                ? "Live — clicks and keys reach the sketch. Click inside it first if keys aren't registering."
+                : "Still preview — press Play to interact, or open it in the editor to refine it."}
             </p>
             <footer className="chat-canvas-preview__foot">
               <Button

--- a/src/components/voice-call-overlay.test.ts
+++ b/src/components/voice-call-overlay.test.ts
@@ -372,4 +372,44 @@ assert.match(
   "the send button reads as disabled while the reply draft is empty",
 );
 
+// ── Arcade ───────────────────────────────────────────────────────────────────
+// The point of mounting a game here is the dead air: mic prompt, session mint,
+// connect. These assertions pin the three properties that make it acceptable
+// to put a game inside a phone call — opt-in, silent, and disposable.
+assert.match(
+  component,
+  /const WAITING_STATES = new Set\(\["requesting-mic", "minting-session", "connecting"\]\)/,
+  "the arcade is offered exactly in the states where nothing is happening yet",
+);
+assert.match(
+  component,
+  /useState\(false\);\s*\n\s*const waiting = WAITING_STATES\.has\(state\.state\)/,
+  "the arcade is opt-in — it never opens on its own",
+);
+assert.match(
+  component,
+  /\{waiting && !arcadeOpen && \(/,
+  "the invitation only appears during the wait, never mid-conversation",
+);
+assert.match(
+  component,
+  /aria-pressed=\{arcadeOpen\}/,
+  "the footer arcade control reports its pressed state to assistive tech",
+);
+assert.doesNotMatch(
+  component,
+  /<ArcadePanel[^>]*\bautoPlay\b/,
+  "nothing auto-starts the game",
+);
+assert.match(
+  styles,
+  /\.arcade-panel__frame\s*\{[\s\S]*?aspect-ratio:/,
+  "the game window holds a stable shape instead of collapsing to zero height",
+);
+assert.match(
+  styles,
+  /\.voice-call-overlay__arcade-invite\s*\{[\s\S]*?background:\s*color-mix\(in oklch, var\(--accent-presence\)/,
+  "the invitation is a token-derived tint, not a hardcoded color",
+);
+
 console.log("voice-call-overlay.test.ts: ok");

--- a/src/components/voice-call-overlay.tsx
+++ b/src/components/voice-call-overlay.tsx
@@ -28,6 +28,15 @@ import type { LiveSession, VoiceSessionGrant, VoiceEarsEngine, VoiceMouthEngine 
 import { voiceErrorHint } from "@/lib/voice/types";
 import { voiceRecoveryVaultKey } from "@/lib/voice/vault-key-recovery";
 import { reduce, initialState, type CallState } from "./voice-call-overlay-state";
+import { ArcadePanel } from "./arcade-panel";
+
+/**
+ * States where the caller is waiting on machinery rather than on a person:
+ * the mic prompt, the session mint, and the connection handshake. These are
+ * where the arcade is offered, because they are the beats with nothing to
+ * look at and no way to tell a slow connection from a stuck one.
+ */
+const WAITING_STATES = new Set(["requesting-mic", "minting-session", "connecting"]);
 
 type Props = {
   familiar: Familiar;
@@ -253,6 +262,9 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
   const [savingKey, setSavingKey] = useState(false);
   const [keySaveError, setKeySaveError] = useState<string | null>(null);
   const [settingsOpenError, setSettingsOpenError] = useState<string | null>(null);
+  // Opt-in, always. A game that appears unasked during a call is a bug.
+  const [arcadeOpen, setArcadeOpen] = useState(false);
+  const waiting = WAITING_STATES.has(state.state);
   useEffect(() => {
     if (state.state !== "error") {
       setKeyDraft("");
@@ -332,6 +344,25 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
           {state.state === "live" && <span className="voice-call-overlay__duration">{mm}:{ss}</span>}
         </header>
         <div className="voice-call-overlay__body">
+          {arcadeOpen && (
+            <ArcadePanel
+              waitingLabel={waiting ? `${labelFor(state)} — play while you wait.` : undefined}
+              onClose={() => setArcadeOpen(false)}
+            />
+          )}
+          {/* The invitation only appears in the dead air, and only once. Offered
+              during `live` too via the footer control, but never advertised
+              there — mid-conversation is not the moment to pitch a game. */}
+          {waiting && !arcadeOpen && (
+            <button
+              type="button"
+              className="voice-call-overlay__arcade-invite focus-ring"
+              onClick={() => setArcadeOpen(true)}
+            >
+              <Icon icon="ph:magic-wand-fill" aria-hidden="true" />
+              <span>Play Glitter Crypt while you wait</span>
+            </button>
+          )}
           {state.state === "live" && (state.earsEngine || state.mouthEngine) && (
             <div className="voice-call-overlay__engines">
               {state.earsEngine && (
@@ -509,6 +540,16 @@ export function VoiceCallOverlay({ familiar, sessionId, onClose }: Props) {
               disabled={state.state !== "live"}
             >
               <Icon icon={state.muted ? "ph:microphone-slash-fill" : "ph:microphone-fill"} />
+            </button>
+            <button
+              type="button"
+              className="voice-call-overlay__control focus-ring"
+              aria-label={arcadeOpen ? "Close Glitter Crypt" : "Play Glitter Crypt"}
+              title={arcadeOpen ? "Close Glitter Crypt" : "Play Glitter Crypt"}
+              aria-pressed={arcadeOpen}
+              onClick={() => setArcadeOpen((open) => !open)}
+            >
+              <Icon icon="ph:magic-wand-fill" />
             </button>
             {/* Barge-in without typing: cut the familiar off mid-sentence.
                 Only offered while it is actually speaking, so the control

--- a/src/lib/arcade/glitter-crypt-chromium.test.ts
+++ b/src/lib/arcade/glitter-crypt-chromium.test.ts
@@ -1,0 +1,168 @@
+// @ts-nocheck
+// Runs the arcade for real in headless Chromium. The pure test next door can
+// only prove the document is well-formed; this proves the game LOOP executes —
+// which is the whole claim being made about it. Skips cleanly when the
+// Playwright browser is not installed, matching canvas-inspector-chromium.
+import assert from "node:assert/strict";
+import { existsSync } from "node:fs";
+import { chromium } from "@playwright/test";
+
+import { buildArcadeSrcDoc } from "./glitter-crypt.ts";
+
+const executablePath = chromium.executablePath();
+if (!existsSync(executablePath)) {
+  console.log(`glitter-crypt-chromium.test.ts skipped: browser not installed at ${executablePath}`);
+} else {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage({ viewport: { width: 640, height: 400 } });
+
+    const failures = [];
+    page.on("pageerror", (error) => failures.push(String(error)));
+    page.on("console", (message) => {
+      if (message.type() === "error") failures.push(message.text());
+    });
+
+    await page.setContent(buildArcadeSrcDoc(), { waitUntil: "load" });
+
+    // ── Boot ────────────────────────────────────────────────────────────────
+    assert.equal(
+      await page.locator("#veil-title").textContent(),
+      "GLITTER CRYPT",
+      "opens on the title veil rather than dropping the player in cold",
+    );
+    assert.equal(await page.locator("#wave").textContent(), "1", "starts on wave 1");
+    assert.equal(await page.locator("#score").textContent(), "0", "starts with nothing hexed");
+    assert.equal(
+      await page.locator("#hearts").textContent(),
+      "\u2665\u2665\u2665\u2665\u2665",
+      "starts on five full hearts",
+    );
+
+    const size = await page.evaluate(() => {
+      const canvas = document.getElementById("view");
+      return { w: canvas.width, h: canvas.height };
+    });
+    assert.ok(size.w >= 120 && size.w <= 480, `internal width is capped for cost (got ${size.w})`);
+    assert.ok(size.h > 0, "the canvas has height");
+
+    // The first frame must already have painted walls — if the raycaster threw,
+    // the canvas would be a single flat color.
+    const distinctColors = () => page.evaluate(() => {
+      const canvas = document.getElementById("view");
+      const ctx = canvas.getContext("2d");
+      const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const seen = new Set();
+      for (let i = 0; i < data.length; i += 4) {
+        seen.add((data[i] << 16) | (data[i + 1] << 8) | data[i + 2]);
+      }
+      return seen.size;
+    });
+    assert.ok(await distinctColors() > 4, "the first frame renders a shaded scene, not a flat fill");
+
+    // ── The veil's button starts the game ───────────────────────────────────
+    await page.locator("#veil-action").click();
+    assert.ok(await page.locator("#veil").isHidden(), "entering the crypt dismisses the veil");
+
+    const framebuffer = () => page.evaluate(() => {
+      const canvas = document.getElementById("view");
+      const ctx = canvas.getContext("2d");
+      return Array.from(ctx.getImageData(0, 0, canvas.width, 1).data).join(",");
+    });
+
+    // ── Movement actually moves ─────────────────────────────────────────────
+    const before = await framebuffer();
+    await page.keyboard.down("ArrowUp");
+    await page.waitForTimeout(450);
+    await page.keyboard.up("ArrowUp");
+    assert.notEqual(await framebuffer(), before, "holding forward changes the view");
+
+    // ── Turning actually turns ──────────────────────────────────────────────
+    const beforeTurn = await framebuffer();
+    await page.keyboard.down("ArrowRight");
+    await page.waitForTimeout(450);
+    await page.keyboard.up("ArrowRight");
+    assert.notEqual(await framebuffer(), beforeTurn, "holding turn changes the view");
+
+    // ── Pause ───────────────────────────────────────────────────────────────
+    await page.keyboard.press("Escape");
+    assert.ok(await page.locator("#veil").isVisible(), "Escape pauses to the veil");
+    assert.equal(await page.locator("#veil-title").textContent(), "PAUSED");
+    // Pausing must actually stop the simulation, not just draw over it.
+    await page.locator("#veil-action").click();
+    assert.ok(await page.locator("#veil").isHidden(), "Resume returns to play");
+
+    // ── Firing hexes a wisp ─────────────────────────────────────────────────
+    // Aim deliberately rather than sweeping blind: read the bearing to the
+    // nearest wisp, turn onto it, then fire. A blind sweep at 2.5 rad/s steps
+    // clean over the aim window between shots, which says nothing about
+    // whether firing works.
+    const snapshot = () => page.evaluate(() => window.__ARCADE_SNAPSHOT__());
+
+    const opening = await snapshot();
+    assert.equal(opening.state, "playing", "the sim is running");
+    assert.ok(opening.alive > 0, "wave 1 spawned wisps");
+
+    // Budget by wall clock, not by attempt count. Under a loaded CI box the
+    // page gets fewer animation frames per real second, so a fixed number of
+    // iterations buys an unpredictable amount of simulated time — which is
+    // exactly the flake this loop kept producing.
+    let hexed = 0;
+    let aimedShots = 0;
+    const deadline = Date.now() + 60_000;
+    while (Date.now() < deadline && hexed === 0) {
+      const now = await snapshot();
+      hexed = now.score;
+      if (hexed > 0) break;
+      if (now.state !== "playing") {
+        // Dying is a legitimate outcome of standing still. Re-enter and keep
+        // going; the assertion below is about firing, not about surviving.
+        await page.locator("#veil-action").click();
+        await page.waitForTimeout(120);
+        continue;
+      }
+      if (Math.abs(now.bearing) > 0.06) {
+        // TURN_SPEED is 2.5 rad/s; hold just long enough to close the gap.
+        const hold = Math.min(260, Math.max(16, (Math.abs(now.bearing) / 2.5) * 1000));
+        const key = now.bearing > 0 ? "ArrowRight" : "ArrowLeft";
+        await page.keyboard.down(key);
+        await page.waitForTimeout(hold);
+        await page.keyboard.up(key);
+        continue;
+      }
+      // Aimed. A shot can still be eaten by a wall between us, so give the
+      // wisp time to close rather than spinning on a blocked line of sight.
+      await page.keyboard.press("Space");
+      aimedShots += 1;
+      await page.waitForTimeout(aimedShots > 8 ? 220 : 70);
+    }
+    assert.ok(hexed > 0, "aiming at a wisp and zapping it raises the hexed count");
+
+    const afterKill = await snapshot();
+    assert.ok(afterKill.alive < opening.alive, "the hexed wisp is gone from the wave");
+
+    // The latch: a tap that starts and ends between two frames must still fire.
+    // Proved by the muzzle flash, which only fire() sets.
+    const tapFired = await page.evaluate(async () => {
+      const canvas = document.getElementById("view");
+      const ctx = canvas.getContext("2d");
+      const sample = () => {
+        const x = Math.round(canvas.width / 2);
+        const y = Math.round(canvas.height / 2);
+        return Array.from(ctx.getImageData(x - 12, y - 12, 24, 24).data).join(",");
+      };
+      // Clear any cooldown left over from the aiming loop above.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      const before = sample();
+      window.dispatchEvent(new KeyboardEvent("keydown", { code: "Space" }));
+      window.dispatchEvent(new KeyboardEvent("keyup", { code: "Space" }));
+      await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+      return before !== sample();
+    });
+    assert.ok(tapFired, "a tap shorter than one frame still fires");
+
+    assert.deepEqual(failures, [], "the game runs without a single page error");
+  } finally {
+    await browser.close();
+  }
+}

--- a/src/lib/arcade/glitter-crypt.test.ts
+++ b/src/lib/arcade/glitter-crypt.test.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import { ARCADE_TAGLINE, ARCADE_TITLE, buildArcadeSrcDoc } from "./glitter-crypt.ts";
+
+assert.equal(typeof ARCADE_TITLE, "string");
+assert.ok(ARCADE_TITLE.length > 0, "the arcade names itself");
+assert.ok(ARCADE_TAGLINE.length > 0, "the arcade describes itself for surfaces that offer it");
+
+const doc = buildArcadeSrcDoc();
+
+assert.match(doc, /^<!doctype html>/i, "is a full document");
+assert.match(doc, /<canvas id="view"/, "renders into a canvas");
+assert.ok(doc.includes(ARCADE_TITLE), "the document carries the arcade title");
+
+// The whole point of the module: one self-contained string. A network fetch or
+// an external asset would defeat both the sandbox story and instant startup.
+assert.doesNotMatch(doc, /<script src=/i, "loads no external script");
+assert.doesNotMatch(doc, /<link /i, "loads no external stylesheet");
+assert.doesNotMatch(doc, /https?:\/\//i, "references no remote origin");
+assert.doesNotMatch(doc, /\bfetch\s*\(|XMLHttpRequest|WebSocket|EventSource/, "makes no network call");
+assert.doesNotMatch(doc, /localStorage|sessionStorage|indexedDB|document\.cookie/, "persists nothing");
+
+// It plays OVER a live voice call, so it must never make a sound and never
+// reach for the microphone.
+assert.doesNotMatch(
+  doc,
+  /AudioContext|webkitAudioContext|new Audio|<audio|getUserMedia|speechSynthesis/,
+  "never touches audio or the microphone",
+);
+
+// Reduced motion is a real switch, not decoration.
+const motionOn = buildArcadeSrcDoc({ reducedMotion: false });
+const motionOff = buildArcadeSrcDoc({ reducedMotion: true });
+assert.match(motionOn, /__ARCADE_REDUCED_MOTION__ = false/, "motion defaults on");
+assert.match(motionOff, /__ARCADE_REDUCED_MOTION__ = true/, "reduced motion is threaded into the document");
+assert.match(buildArcadeSrcDoc(), /__ARCADE_REDUCED_MOTION__ = false/, "omitted options mean full motion");
+assert.match(
+  doc,
+  /REDUCED \? 0 : Math\.round\(shake/,
+  "screen shake is the first thing reduced motion drops",
+);
+
+// A raycaster with no depth buffer draws sprites through walls; keep the
+// occlusion test wired to the same corrected depth the walls write.
+assert.match(doc, /zbuffer\[col\] = depth/, "wall depth is recorded per column");
+assert.match(doc, /if \(zbuffer\[col\] < dist \* Math\.cos\(angle\)\) continue/, "sprites test against it");
+
+// Controls have to be discoverable: the opening veil is the only place that
+// explains them.
+for (const key of ["W", "A", "S", "D", "Space"]) {
+  assert.ok(doc.includes(`<kbd>${key}</kbd>`), `the opening veil documents ${key}`);
+}
+assert.match(doc, /data-hold="fire"/, "coarse pointers get a fire control");
+assert.match(doc, /@media \(pointer: coarse\)/, "touch controls stay off for mouse users");
+
+// Accessibility: the canvas and the live HUD both have to be nameable.
+assert.match(doc, /aria-label="Glitter Crypt game view"/, "the canvas is named");
+assert.match(doc, /hearts remaining/, "the heart count is announced, not just glyphs");
+
+// Spawn distance is a feel constraint with a floor AND a ceiling: too close is
+// an ambush the player cannot answer, too far is dead seconds spent watching a
+// wisp walk across the map. Asserted against the source because the live
+// distance starts drifting the moment anything moves.
+assert.match(
+  doc,
+  /if \(away < 4\.5 \|\| away > 9\) continue;/,
+  "wisps spawn inside a bounded band — never on top of the player, never a dull walk away",
+);

--- a/src/lib/arcade/glitter-crypt.ts
+++ b/src/lib/arcade/glitter-crypt.ts
@@ -1,0 +1,700 @@
+// The Cave arcade: a self-contained first-person shooter that runs in the same
+// opaque-origin `sandbox="allow-scripts"` iframe the canvas sketches use.
+//
+// It exists so a voice call has something to DO during the dead air — minting a
+// session, connecting, and waiting on the familiar to think. Constraints that
+// fall out of that:
+//
+//   * SILENT. It plays over a live voice call, so it never makes a sound and
+//     never touches the microphone or any audio API.
+//   * No network, no storage, no imports. One string, fully self-contained,
+//     so it renders instantly and cannot leak anything out of the sandbox.
+//   * Pausable and disposable — the caller unmounts the iframe and the whole
+//     game goes with it.
+//
+// Literal colors ON PURPOSE, same rule as the canvas editor's swatches: this
+// styles the SKETCH document inside the sandbox, not app chrome. App theme
+// tokens never reach that document, so semantic tokens cannot apply here.
+
+/** Title shown in the arcade chrome and used as the iframe's accessible name. */
+export const ARCADE_TITLE = "Glitter Crypt";
+
+/** One-line description of the game for surfaces that offer it. */
+export const ARCADE_TAGLINE = "Sweep the crypt, banish the wisps, keep your hearts.";
+
+export type ArcadeOptions = {
+  /**
+   * Mirrors `prefers-reduced-motion`. The game still runs — refusing to render
+   * it would be worse — but head-bob, screen shake, and the hit flash are cut,
+   * since those are the parts that actually provoke motion sickness.
+   */
+  reducedMotion?: boolean;
+};
+
+/**
+ * Build the arcade's full HTML document. Pure and DOM-free so it is unit
+ * testable, matching the canvas harness builders next door.
+ */
+export function buildArcadeSrcDoc(options: ArcadeOptions = {}): string {
+  const reducedMotion = options.reducedMotion === true ? "true" : "false";
+  return [
+    "<!doctype html>",
+    '<html lang="en">',
+    "<head>",
+    '<meta charset="utf-8" />',
+    '<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />',
+    `<title>${ARCADE_TITLE}</title>`,
+    "<style>",
+    STYLE,
+    "</style>",
+    "</head>",
+    "<body>",
+    BODY,
+    "<script>",
+    `window.__ARCADE_REDUCED_MOTION__ = ${reducedMotion};`,
+    GAME_SCRIPT,
+    "</script>",
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+const STYLE = `
+  * { box-sizing: border-box; }
+  :root { color-scheme: dark; }
+  html, body {
+    margin: 0; height: 100%; overflow: hidden;
+    background: #140b21;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    color: #ffd8f2;
+    -webkit-user-select: none; user-select: none;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: none;
+  }
+  #stage { position: relative; width: 100%; height: 100%; }
+  canvas {
+    display: block; width: 100%; height: 100%;
+    image-rendering: pixelated; cursor: crosshair;
+  }
+  canvas:focus-visible { outline: 2px solid #ff8fd0; outline-offset: -2px; }
+
+  .hud {
+    position: absolute; left: 0; right: 0; top: 0;
+    display: flex; align-items: center; gap: 14px;
+    padding: 10px 14px; font-size: 13px; letter-spacing: 0.06em;
+    text-shadow: 0 1px 0 #2a0d3d; pointer-events: none;
+  }
+  .hud b { font-weight: 700; color: #ff8fd0; }
+  .hud .spacer { flex: 1; }
+  .hearts { letter-spacing: 2px; font-size: 15px; }
+
+  .veil {
+    position: absolute; inset: 0; display: grid; place-content: center;
+    gap: 10px; text-align: center; padding: 24px;
+    background: rgba(20, 11, 33, 0.86);
+  }
+  .veil[hidden] { display: none; }
+  .veil h1 { margin: 0; font-size: 22px; letter-spacing: 0.12em; color: #ff8fd0; }
+  .veil p { margin: 0; font-size: 13px; line-height: 1.7; color: #d9bdf2; max-width: 36ch; }
+  .veil kbd {
+    display: inline-block; padding: 1px 6px; border-radius: 5px;
+    border: 1px solid #6d4a91; background: #2c1a44; color: #ffd8f2;
+    font: inherit; font-size: 12px;
+  }
+  .veil button {
+    justify-self: center; margin-top: 6px; padding: 9px 20px; font: inherit;
+    font-size: 13px; letter-spacing: 0.1em; color: #21102f; background: #ff8fd0;
+    border: 0; border-radius: 999px; cursor: pointer;
+  }
+  .veil button:focus-visible { outline: 3px solid #b58cff; outline-offset: 2px; }
+
+  /* Touch controls: only for coarse pointers, so a mouse never sees them. */
+  .touch { position: absolute; inset: auto 0 0 0; display: none; gap: 10px; padding: 14px; }
+  @media (pointer: coarse) { .touch { display: flex; } }
+  .touch button {
+    flex: 1; padding: 16px 0; font: inherit; font-size: 15px;
+    color: #ffd8f2; background: rgba(94, 58, 130, 0.55);
+    border: 1px solid rgba(255, 143, 208, 0.45); border-radius: 12px;
+  }
+  .touch button.fire { flex: 1.4; background: rgba(255, 143, 208, 0.32); }
+`;
+
+const BODY = `
+<div id="stage">
+  <canvas id="view" tabindex="0" aria-label="Glitter Crypt game view"></canvas>
+  <div class="hud">
+    <span class="hearts" id="hearts"></span>
+    <span class="spacer"></span>
+    <span>WAVE <b id="wave">1</b></span>
+    <span>HEXED <b id="score">0</b></span>
+  </div>
+  <div class="veil" id="veil">
+    <h1 id="veil-title">GLITTER CRYPT</h1>
+    <p id="veil-body">
+      <kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd> or arrows to move &middot;
+      <kbd>Q</kbd><kbd>E</kbd> to strafe &middot; mouse to look &middot;
+      <kbd>Space</kbd> or click to zap &middot; <kbd>Esc</kbd> to pause.
+    </p>
+    <button id="veil-action" type="button">Enter the crypt</button>
+  </div>
+  <div class="touch">
+    <button type="button" data-hold="left" aria-label="Turn left">&#8592;</button>
+    <button type="button" data-hold="fwd" aria-label="Move forward">&#8593;</button>
+    <button type="button" data-hold="right" aria-label="Turn right">&#8594;</button>
+    <button type="button" class="fire" data-hold="fire" aria-label="Zap">ZAP</button>
+  </div>
+</div>
+`;
+
+// Kept as one plain string (no nested template literals, no ${}) so the whole
+// document assembles by join without escaping games.
+const GAME_SCRIPT = `
+(function () {
+  "use strict";
+
+  var REDUCED = window.__ARCADE_REDUCED_MOTION__ === true;
+
+  var MAP = [
+    "1111111111111111",
+    "1..............1",
+    "1..22..1111..3.1",
+    "1..2.......1...1",
+    "1..2...44..1...1",
+    "1......4.......1",
+    "1.3....4...222.1",
+    "1.3........2...1",
+    "1.3....11..2...1",
+    "1......1.......1",
+    "1..44..1....33.1",
+    "1..4...1.......1",
+    "1......1..22...1",
+    "1.........2....1",
+    "1..............1",
+    "1111111111111111"
+  ];
+  var MAP_W = MAP[0].length;
+  var MAP_H = MAP.length;
+
+  // Wall palette by map digit, [lit face, shaded face].
+  var WALLS = {
+    "1": ["#b58cff", "#7d5cc0"],
+    "2": ["#ff8fd0", "#c2609b"],
+    "3": ["#7de3f4", "#4a9db0"],
+    "4": ["#ffe08a", "#c2a752"]
+  };
+
+  var FOV = Math.PI / 3;
+  var MAX_DEPTH = 20;
+  var MOVE_SPEED = 2.9;
+  var TURN_SPEED = 2.5;
+  var ENEMY_SPEED = 1.05;
+  var FIRE_COOLDOWN = 0.26;
+  var HIT_GRACE = 1.1;
+  var AIM_TOLERANCE = 0.13;
+
+  var canvas = document.getElementById("view");
+  var ctx = canvas.getContext("2d", { alpha: false });
+  var veil = document.getElementById("veil");
+  var veilTitle = document.getElementById("veil-title");
+  var veilBody = document.getElementById("veil-body");
+  var veilAction = document.getElementById("veil-action");
+  var heartsEl = document.getElementById("hearts");
+  var waveEl = document.getElementById("wave");
+  var scoreEl = document.getElementById("score");
+
+  var W = 1, H = 1;
+  var zbuffer = new Float32Array(1);
+
+  function resize() {
+    var rect = canvas.getBoundingClientRect();
+    // Render at a capped internal width: a raycaster costs one DDA per column,
+    // and past ~480 columns the extra detail is invisible but the cost is not.
+    W = Math.max(120, Math.min(480, Math.round(rect.width) || 320));
+    var ratio = rect.width > 0 ? rect.height / rect.width : 0.62;
+    H = Math.max(90, Math.round(W * ratio));
+    canvas.width = W;
+    canvas.height = H;
+    zbuffer = new Float32Array(W);
+  }
+
+  function cellAt(x, y) {
+    var ix = Math.floor(x), iy = Math.floor(y);
+    if (ix < 0 || iy < 0 || ix >= MAP_W || iy >= MAP_H) return "1";
+    return MAP[iy].charAt(ix);
+  }
+  function solid(x, y) { return cellAt(x, y) !== "."; }
+
+  var player = null, enemies = [], keys = Object.create(null);
+  var state = "menu", score = 0, wave = 1;
+  var shake = 0, flash = 0, bob = 0, fireTimer = 0, muzzle = 0, turnBias = 0;
+  // A tap can begin and end between two animation frames. Sampling only the
+  // held state would silently swallow that shot, so a press latches here and
+  // the next frame that is off cooldown consumes it.
+  var fireQueued = false;
+
+  function reset(full) {
+    player = { x: 1.5, y: 1.5, a: 0, hearts: 5, grace: 0 };
+    keys = Object.create(null);
+    shake = 0; flash = 0; bob = 0; fireTimer = 0; muzzle = 0; turnBias = 0;
+    fireQueued = false;
+    if (full) { score = 0; wave = 1; }
+    spawnWave();
+    updateHud();
+  }
+
+  function spawnWave() {
+    var count = Math.min(3 + wave, 9);
+    enemies = [];
+    var guard = 0;
+    while (enemies.length < count && guard < 900) {
+      guard++;
+      var x = 1 + Math.random() * (MAP_W - 2);
+      var y = 1 + Math.random() * (MAP_H - 2);
+      if (solid(x, y)) continue;
+      var dx = x - player.x, dy = y - player.y;
+      var away = Math.sqrt(dx * dx + dy * dy);
+      // Near enough that the wave opens promptly (a wisp crawling in from the
+      // far corner of the map is eight dead seconds), far enough to be fair.
+      if (away < 4.5 || away > 9) continue;
+      enemies.push({
+        x: x, y: y, alive: true, hurt: 0,
+        wobble: Math.random() * 6.28,
+        hp: wave > 4 ? 2 : 1
+      });
+    }
+  }
+
+  function updateHud() {
+    var hearts = "";
+    for (var i = 0; i < 5; i++) hearts += i < player.hearts ? "\\u2665" : "\\u2661";
+    heartsEl.textContent = hearts;
+    heartsEl.setAttribute("aria-label", player.hearts + " of 5 hearts remaining");
+    waveEl.textContent = String(wave);
+    scoreEl.textContent = String(score);
+  }
+
+  function showVeil(title, body, action) {
+    veilTitle.textContent = title;
+    veilBody.innerHTML = body;
+    veilAction.textContent = action;
+    veil.hidden = false;
+    veilAction.focus();
+  }
+
+  // ── Input ────────────────────────────────────────────────────────────────
+
+  function setKey(code, down) {
+    if (code === "ArrowLeft" || code === "KeyA") keys.left = down;
+    else if (code === "ArrowRight" || code === "KeyD") keys.right = down;
+    else if (code === "ArrowUp" || code === "KeyW") keys.fwd = down;
+    else if (code === "ArrowDown" || code === "KeyS") keys.back = down;
+    else if (code === "KeyQ") keys.strafeL = down;
+    else if (code === "KeyE") keys.strafeR = down;
+    else if (code === "Space") { keys.fire = down; if (down) fireQueued = true; }
+    else return false;
+    return true;
+  }
+
+  window.addEventListener("keydown", function (e) {
+    if (e.code === "KeyR" && state !== "playing") { advance(); return; }
+    if (e.code === "Escape" && state === "playing") { pause(); return; }
+    if (setKey(e.code, true)) e.preventDefault();
+  });
+  window.addEventListener("keyup", function (e) {
+    if (setKey(e.code, false)) e.preventDefault();
+  });
+  // A blurred window never delivers keyup, which would otherwise leave the
+  // player sprinting into a wall forever after a tab switch.
+  window.addEventListener("blur", function () {
+    keys = Object.create(null);
+    turnBias = 0;
+    fireQueued = false;
+  });
+
+  canvas.addEventListener("mousemove", function (e) {
+    var rect = canvas.getBoundingClientRect();
+    if (!rect.width) return;
+    var offset = (e.clientX - rect.left) / rect.width - 0.5;
+    // Dead zone through the middle so the crosshair can rest.
+    turnBias = Math.abs(offset) < 0.12 ? 0 : offset * 2.2;
+  });
+  canvas.addEventListener("mouseleave", function () { turnBias = 0; });
+  canvas.addEventListener("mousedown", function (e) {
+    e.preventDefault();
+    canvas.focus();
+    keys.fire = true;
+    fireQueued = true;
+  });
+  window.addEventListener("mouseup", function () { keys.fire = false; });
+
+  var holds = document.querySelectorAll("[data-hold]");
+  for (var h = 0; h < holds.length; h++) {
+    (function (button) {
+      var key = button.getAttribute("data-hold");
+      var press = function (e) {
+        e.preventDefault();
+        keys[key] = true;
+        if (key === "fire") fireQueued = true;
+      };
+      var release = function (e) { keys[key] = false; };
+      button.addEventListener("touchstart", press, { passive: false });
+      button.addEventListener("touchend", release);
+      button.addEventListener("touchcancel", release);
+      button.addEventListener("mousedown", press);
+      button.addEventListener("mouseup", release);
+      button.addEventListener("mouseleave", release);
+    })(holds[h]);
+  }
+
+  veilAction.addEventListener("click", advance);
+
+  /** The veil's one button means whatever the current stop calls for. */
+  function advance() {
+    if (state === "over" || state === "menu") reset(state === "over");
+    else if (state === "cleared") spawnWave();
+    veil.hidden = true;
+    state = "playing";
+    last = 0;
+    canvas.focus();
+  }
+
+  // ── Simulation ───────────────────────────────────────────────────────────
+
+  function tryMove(nx, ny) {
+    // Axis-separated so sliding along a wall feels right instead of sticking.
+    var pad = 0.22;
+    if (!solid(nx + Math.sign(nx - player.x) * pad, player.y)) player.x = nx;
+    if (!solid(player.x, ny + Math.sign(ny - player.y) * pad)) player.y = ny;
+  }
+
+  function step(dt) {
+    var turn = 0;
+    if (keys.left) turn -= 1;
+    if (keys.right) turn += 1;
+    player.a += (turn + turnBias) * TURN_SPEED * dt;
+
+    var fwd = (keys.fwd ? 1 : 0) - (keys.back ? 1 : 0);
+    var side = (keys.strafeR ? 1 : 0) - (keys.strafeL ? 1 : 0);
+    if (fwd || side) {
+      var cos = Math.cos(player.a), sin = Math.sin(player.a);
+      tryMove(
+        player.x + (cos * fwd - sin * side) * MOVE_SPEED * dt,
+        player.y + (sin * fwd + cos * side) * MOVE_SPEED * dt
+      );
+      bob += dt * 9;
+    }
+
+    fireTimer -= dt;
+    if ((keys.fire || fireQueued) && fireTimer <= 0) {
+      fireQueued = false;
+      fire();
+      fireTimer = FIRE_COOLDOWN;
+    }
+    muzzle = Math.max(0, muzzle - dt * 5);
+    shake = Math.max(0, shake - dt * 3);
+    flash = Math.max(0, flash - dt * 2);
+    player.grace = Math.max(0, player.grace - dt);
+
+    var living = 0;
+    for (var i = 0; i < enemies.length; i++) {
+      var e = enemies[i];
+      if (!e.alive) continue;
+      living++;
+      e.wobble += dt * 3;
+      e.hurt = Math.max(0, e.hurt - dt);
+
+      var dx = player.x - e.x, dy = player.y - e.y;
+      var dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      var sx = e.x + (dx / dist) * ENEMY_SPEED * dt;
+      var sy = e.y + (dy / dist) * ENEMY_SPEED * dt;
+      if (!solid(sx, e.y)) e.x = sx;
+      if (!solid(e.x, sy)) e.y = sy;
+
+      if (dist < 0.55 && player.grace <= 0) {
+        player.hearts--;
+        player.grace = HIT_GRACE;
+        shake = REDUCED ? 0 : 1;
+        flash = REDUCED ? 0 : 1;
+        // Shove the wisp back so one contact costs one heart, not five.
+        e.x -= (dx / dist) * 1.2;
+        e.y -= (dy / dist) * 1.2;
+        updateHud();
+        if (player.hearts <= 0) { gameOver(); return; }
+      }
+    }
+
+    if (living === 0) {
+      wave++;
+      updateHud();
+      state = "cleared";
+      showVeil(
+        "WAVE " + (wave - 1) + " CLEARED",
+        "The crypt goes quiet. <b>" + score + "</b> hexed so far. Wave " + wave + " is bigger.",
+        "Next wave"
+      );
+    }
+  }
+
+  function fire() {
+    muzzle = 1;
+    var best = null, bestDist = Infinity;
+    for (var i = 0; i < enemies.length; i++) {
+      var e = enemies[i];
+      if (!e.alive) continue;
+      var dx = e.x - player.x, dy = e.y - player.y;
+      var dist = Math.sqrt(dx * dx + dy * dy);
+      var angle = Math.atan2(dy, dx) - player.a;
+      while (angle < -Math.PI) angle += Math.PI * 2;
+      while (angle > Math.PI) angle -= Math.PI * 2;
+      // A nearer wisp subtends a wider angle, so tolerance scales with range.
+      if (Math.abs(angle) > AIM_TOLERANCE + 0.35 / Math.max(dist, 1)) continue;
+      if (dist >= bestDist) continue;
+      if (castRay(player.a + angle).dist < dist) continue; // wall in the way
+      best = e; bestDist = dist;
+    }
+    if (!best) return;
+    best.hp--;
+    best.hurt = 0.3;
+    if (best.hp > 0) return;
+    best.alive = false;
+    score++;
+    updateHud();
+  }
+
+  function gameOver() {
+    state = "over";
+    showVeil(
+      "BANISHED",
+      "The wisps took your last heart on wave <b>" + wave + "</b>, with <b>" + score +
+        "</b> hexed. Press <kbd>R</kbd> or the button to crawl back in.",
+      "Try again"
+    );
+  }
+
+  function pause() {
+    state = "paused";
+    showVeil(
+      "PAUSED",
+      "The crypt waits. Nothing in here makes a sound, so your call is safe.",
+      "Resume"
+    );
+  }
+
+  // ── Raycasting ───────────────────────────────────────────────────────────
+
+  function castRay(angle) {
+    var sinA = Math.sin(angle), cosA = Math.cos(angle);
+    var mapX = Math.floor(player.x), mapY = Math.floor(player.y);
+    var deltaX = Math.abs(1 / (cosA || 1e-6));
+    var deltaY = Math.abs(1 / (sinA || 1e-6));
+    var stepX, stepY, sideX, sideY;
+
+    if (cosA < 0) { stepX = -1; sideX = (player.x - mapX) * deltaX; }
+    else { stepX = 1; sideX = (mapX + 1 - player.x) * deltaX; }
+    if (sinA < 0) { stepY = -1; sideY = (player.y - mapY) * deltaY; }
+    else { stepY = 1; sideY = (mapY + 1 - player.y) * deltaY; }
+
+    var side = 0, tile = "1", guard = 0;
+    while (guard++ < 128) {
+      if (sideX < sideY) { sideX += deltaX; mapX += stepX; side = 0; }
+      else { sideY += deltaY; mapY += stepY; side = 1; }
+      if (mapX < 0 || mapY < 0 || mapX >= MAP_W || mapY >= MAP_H) break;
+      tile = MAP[mapY].charAt(mapX);
+      if (tile !== ".") break;
+    }
+    var dist = side === 0 ? sideX - deltaX : sideY - deltaY;
+    return { dist: Math.max(dist, 0.0001), side: side, tile: tile };
+  }
+
+  function render() {
+    var shakeY = REDUCED ? 0 : Math.round(shake * 4 * Math.sin(performance.now() / 22));
+    var bobY = REDUCED ? 0 : Math.round(Math.sin(bob) * 1.6);
+    var horizon = Math.round(H / 2) + shakeY + bobY;
+
+    // Ceiling and floor as two flat bands — cheap, and the palette carries it.
+    ctx.fillStyle = "#1d1030";
+    ctx.fillRect(0, 0, W, horizon);
+    ctx.fillStyle = "#2a1c3d";
+    ctx.fillRect(0, horizon, W, H - horizon);
+
+    for (var col = 0; col < W; col++) {
+      var angle = player.a - FOV / 2 + (col / W) * FOV;
+      var hit = castRay(angle);
+      // Fisheye correction: project onto the view plane, not along the ray.
+      var depth = hit.dist * Math.cos(angle - player.a);
+      zbuffer[col] = depth;
+      if (depth > MAX_DEPTH) continue;
+
+      var height = Math.min(H * 2.2, (H / depth) * 0.9);
+      var top = horizon - height / 2;
+      var palette = WALLS[hit.tile] || WALLS["1"];
+      ctx.fillStyle = palette[hit.side];
+      ctx.fillRect(col, top, 1, height);
+
+      var fog = Math.min(0.78, (depth / MAX_DEPTH) * 1.5);
+      if (fog > 0.02) {
+        ctx.fillStyle = "rgba(20, 11, 33, " + fog.toFixed(3) + ")";
+        ctx.fillRect(col, top, 1, height);
+      }
+    }
+
+    drawEnemies(horizon);
+    drawCrosshair(horizon);
+
+    if (flash > 0 && !REDUCED) {
+      ctx.fillStyle = "rgba(255, 92, 158, " + (flash * 0.34).toFixed(3) + ")";
+      ctx.fillRect(0, 0, W, H);
+    }
+    if (player.grace > 0) {
+      // A steady vignette, not a strobe: it has to read while REDUCED too.
+      ctx.strokeStyle = "rgba(255, 92, 158, 0.5)";
+      ctx.lineWidth = 3;
+      ctx.strokeRect(1.5, 1.5, W - 3, H - 3);
+    }
+  }
+
+  function drawEnemies(horizon) {
+    // Far to near, so nearer wisps paint over farther ones.
+    var order = [];
+    for (var i = 0; i < enemies.length; i++) {
+      var e = enemies[i];
+      if (!e.alive) continue;
+      var ddx = e.x - player.x, ddy = e.y - player.y;
+      order.push({ e: e, d: ddx * ddx + ddy * ddy });
+    }
+    order.sort(function (a, b) { return b.d - a.d; });
+
+    for (var j = 0; j < order.length; j++) {
+      var en = order[j].e;
+      var ex = en.x - player.x, ey = en.y - player.y;
+      var dist = Math.sqrt(ex * ex + ey * ey);
+      if (dist > MAX_DEPTH) continue;
+
+      var angle = Math.atan2(ey, ex) - player.a;
+      while (angle < -Math.PI) angle += Math.PI * 2;
+      while (angle > Math.PI) angle -= Math.PI * 2;
+      if (Math.abs(angle) > FOV * 0.75) continue;
+
+      var screenX = (0.5 + angle / FOV) * W;
+      var col = Math.floor(screenX);
+      if (col < 0 || col >= W) continue;
+      // Compare like with like: zbuffer holds fisheye-corrected depth.
+      if (zbuffer[col] < dist * Math.cos(angle)) continue;
+
+      var size = Math.min(H * 1.4, (H / dist) * 0.5);
+      var float = REDUCED ? 0 : Math.sin(en.wobble) * size * 0.06;
+      var cy = horizon + size * 0.12 + float;
+      var core = en.hurt > 0 ? "#fff0f8" : "#eaffff";
+      var halo = en.hurt > 0 ? "#ff8fd0" : "#7de3f4";
+      var haze = en.hurt > 0 ? "rgba(255, 143, 208, 0)" : "rgba(125, 227, 244, 0)";
+
+      ctx.save();
+      ctx.globalAlpha = 0.92;
+      var glow = ctx.createRadialGradient(screenX, cy, size * 0.05, screenX, cy, size * 0.5);
+      glow.addColorStop(0, core);
+      glow.addColorStop(0.45, halo);
+      glow.addColorStop(1, haze);
+      ctx.fillStyle = glow;
+      ctx.beginPath();
+      ctx.arc(screenX, cy, size * 0.5, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Two eyes, so it reads as a creature rather than a light.
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = "#2a1c3d";
+      var eye = Math.max(1, size * 0.055);
+      ctx.beginPath();
+      ctx.arc(screenX - size * 0.13, cy - size * 0.05, eye, 0, Math.PI * 2);
+      ctx.arc(screenX + size * 0.13, cy - size * 0.05, eye, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+  }
+
+  function drawCrosshair(horizon) {
+    var cx = Math.round(W / 2);
+    ctx.strokeStyle = muzzle > 0 ? "#fff2fb" : "rgba(255, 143, 208, 0.85)";
+    ctx.lineWidth = 1;
+    var arm = muzzle > 0 ? 9 : 6;
+    ctx.beginPath();
+    ctx.moveTo(cx - arm, horizon); ctx.lineTo(cx - 2, horizon);
+    ctx.moveTo(cx + 2, horizon); ctx.lineTo(cx + arm, horizon);
+    ctx.moveTo(cx, horizon - arm); ctx.lineTo(cx, horizon - 2);
+    ctx.moveTo(cx, horizon + 2); ctx.lineTo(cx, horizon + arm);
+    ctx.stroke();
+
+    if (muzzle > 0) {
+      ctx.fillStyle = "rgba(255, 242, 251, " + (muzzle * 0.5).toFixed(3) + ")";
+      ctx.beginPath();
+      ctx.arc(cx, horizon, 3 + muzzle * 5, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  // ── Loop ─────────────────────────────────────────────────────────────────
+
+  var last = 0, raf = 0;
+
+  function frame(now) {
+    raf = requestAnimationFrame(frame);
+    if (!last) last = now;
+    // Clamp dt so a backgrounded tab does not teleport the player through a
+    // wall on the first frame after it resumes.
+    var dt = Math.min((now - last) / 1000, 0.05);
+    last = now;
+    if (state === "playing") step(dt);
+    render();
+  }
+
+  // The host unmounts the iframe to dispose of the game, but pause on hidden
+  // anyway so a backgrounded call is not burning a render loop.
+  document.addEventListener("visibilitychange", function () {
+    if (document.hidden && state === "playing") pause();
+  });
+
+  window.addEventListener("resize", function () { resize(); render(); });
+  window.addEventListener("pagehide", function () {
+    if (raf) cancelAnimationFrame(raf);
+    raf = 0;
+  });
+
+  // Test hook. Everything above is closure-private, which leaves an automated
+  // check reduced to diffing pixels — that can tell you the screen changed but
+  // not whether the simulation is actually correct. This exposes a read-only
+  // snapshot inside the sandbox only; the frame is opaque-origin, so nothing
+  // outside it can reach this.
+  window.__ARCADE_SNAPSHOT__ = function () {
+    var nearest = null, nearestDist = Infinity;
+    for (var i = 0; i < enemies.length; i++) {
+      var e = enemies[i];
+      if (!e.alive || !player) continue;
+      var dx = e.x - player.x, dy = e.y - player.y;
+      var d = Math.sqrt(dx * dx + dy * dy);
+      if (d < nearestDist) { nearestDist = d; nearest = e; }
+    }
+    var bearing = 0;
+    if (nearest) {
+      bearing = Math.atan2(nearest.y - player.y, nearest.x - player.x) - player.a;
+      while (bearing < -Math.PI) bearing += Math.PI * 2;
+      while (bearing > Math.PI) bearing -= Math.PI * 2;
+    }
+    return {
+      state: state,
+      score: score,
+      wave: wave,
+      hearts: player ? player.hearts : 0,
+      x: player ? player.x : 0,
+      y: player ? player.y : 0,
+      angle: player ? player.a : 0,
+      alive: enemies.filter(function (e) { return e.alive; }).length,
+      nearest: nearestDist,
+      bearing: bearing
+    };
+  };
+
+  resize();
+  reset(true);
+  render();
+  raf = requestAnimationFrame(frame);
+})();
+`;

--- a/src/lib/canvas-artifacts.test.ts
+++ b/src/lib/canvas-artifacts.test.ts
@@ -82,6 +82,23 @@ assert.match(prompt, /EXACTLY ONE fenced code block/, "sketch prompt constrains 
 assert.match(prompt, /a login form/, "sketch prompt carries the user's ask");
 assert.match(buildSketchPrompt("  "), /a simple example UI/, "blank ask gets a sensible default");
 
+// Playable is a different contract, not a phrasing tweak: a game that cannot
+// restart, cannot be played without a keyboard, or makes noise over a live
+// voice call is a broken deliverable, so the prompt states each of those.
+const game = buildSketchPrompt("a dungeon crawler", { playable: true });
+assert.match(game, /a dungeon crawler/, "game prompt carries the user's ask");
+assert.match(game, /requestAnimationFrame/, "game prompt demands a real loop, not setInterval");
+assert.match(game, /restart control/, "game prompt demands a restart without a page reload");
+assert.match(game, /touch or click controls/, "game prompt demands non-keyboard input");
+assert.match(game, /Stay SILENT/, "game prompt forbids audio so it can play over a call");
+assert.match(game, /prefers-reduced-motion/, "game prompt respects reduced motion");
+assert.match(game, /Never use `localStorage`/, "game prompt rules out storage the sandbox cannot provide");
+assert.match(
+  buildSketchPrompt("  ", { playable: true }),
+  /a tiny arcade game/,
+  "blank playable ask gets a game-shaped default, not a UI one",
+);
+
 const refine = buildRefinePrompt("<!doctype html><html></html>", "make it dark mode");
 assert.match(refine, /make it dark mode/, "refine prompt carries the change request");
 assert.match(refine, /<!doctype html><html><\/html>/, "refine prompt embeds the current document");

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -197,8 +197,48 @@ export function clampArtifactCode(code: string): string {
  * familiar. Constrains output to one self-contained document so extraction is
  * deterministic — no build step, no external files, no prose.
  */
-export function buildSketchPrompt(userPrompt: string): string {
-  const ask = (userPrompt ?? "").trim() || "a simple example UI";
+export type SketchPromptOptions = {
+  /**
+   * Ask for something *playable* rather than something to look at.
+   *
+   * The default contract produces a polished, static-ish component, which is
+   * the wrong shape for a game: a game needs its own loop, its own input
+   * handling, and a way to start over without a reload. Turning this on swaps
+   * in those requirements instead of bolting them onto the ask, so the model
+   * is not left to infer them from the word "game".
+   */
+  playable?: boolean;
+};
+
+export function buildSketchPrompt(userPrompt: string, options: SketchPromptOptions = {}): string {
+  const ask = (userPrompt ?? "").trim() || (options.playable ? "a tiny arcade game" : "a simple example UI");
+  if (options.playable) {
+    return [
+      "You are generating a PLAYABLE GAME for a live sandbox inside a design canvas.",
+      "",
+      "Output EXACTLY ONE fenced code block and nothing else — no prose before or after.",
+      "Use a ```html block: a COMPLETE self-contained document starting with `<!doctype html>`,",
+      "with all CSS inlined in <style> and all JS inlined in <script>. No external files,",
+      "no CDN, no network access of any kind — it must run on an opaque origin.",
+      "",
+      "It MUST actually be playable:",
+      "- Run a real loop with `requestAnimationFrame` and delta time, not `setInterval` ticks.",
+      "- Handle keyboard on `window` (WASD and/or arrows) AND provide touch or click controls,",
+      "  so it works without a keyboard. Call `preventDefault()` on the keys you consume.",
+      "- Show live state — score, lives, or progress — as visible text.",
+      "- Have a fail or win condition and a restart control that returns to the first frame",
+      "  WITHOUT reloading the page.",
+      "- Never use `localStorage`, `sessionStorage`, cookies, or `fetch`: the sandbox has no",
+      "  same-origin access and any such call throws.",
+      "- Stay SILENT. No `Audio`, no `AudioContext`, no `getUserMedia`. It may be played over",
+      "  a live voice call.",
+      "- Respect `prefers-reduced-motion: reduce` by damping screen shake and flashing.",
+      "",
+      "Size the play area to the viewport and keep it responsive.",
+      "",
+      `Build this game: ${ask}`,
+    ].join("\n");
+  }
   return [
     "You are generating a UI for a live preview sandbox inside a design canvas.",
     "",

--- a/src/styles/canvas-editor.css
+++ b/src/styles/canvas-editor.css
@@ -328,6 +328,25 @@
   border-radius: var(--radius-card);
   background: var(--bg-base);
 }
+/* Play mode: the sketch owns its own input, so the aside only explains the
+   handover and offers a way back to frame one. */
+.canvas-editor__play-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  align-items: flex-start;
+  padding: var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, transparent);
+  border-radius: var(--radius-card);
+  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
+}
+.canvas-editor__play-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+}
 .canvas-editor__sel-label {
   font-size: var(--text-base);
   font-weight: 600;

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -1060,8 +1060,104 @@ details[open] > .cave-tool-summary::before {
   padding: var(--space-5) var(--space-4);
 }
 
-.voice-call-overlay__engines {
-  display: flex;
+/* Arcade — Glitter Crypt mounted into the dead air of a call.
+   Full-bleed inside the body because the body centers its children, and a
+   centered game window with slack on either side reads as a mistake. */
+.voice-call-overlay__arcade-invite {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, transparent);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--accent-presence) 12%, transparent);
+  color: var(--text-primary);
+  font-size: var(--text-sm);
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+
+.voice-call-overlay__arcade-invite:hover {
+  border-color: color-mix(in oklch, var(--accent-presence) 52%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 20%, transparent);
+}
+
+.arcade-panel {
+  display: grid;
+  width: 100%;
+  gap: var(--space-2);
+  justify-items: stretch;
+}
+
+.arcade-panel__header {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: center;
+  gap: var(--space-1) var(--space-2);
+}
+
+.arcade-panel__heading {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--accent-presence);
+}
+
+.arcade-panel__title {
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+}
+
+.arcade-panel__tagline {
+  grid-column: 1;
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+}
+
+.arcade-panel__actions {
+  grid-column: 2;
+  grid-row: 1 / span 2;
+  display: inline-flex;
+  gap: var(--space-1);
+}
+
+.arcade-panel__action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: color-mix(in oklch, var(--bg-base) 54%, transparent);
+  color: var(--text-secondary);
+  transition:
+    background var(--duration-fast) var(--ease-standard),
+    color var(--duration-fast) var(--ease-standard);
+}
+
+.arcade-panel__action:hover {
+  background: color-mix(in oklch, var(--bg-hover) 70%, transparent);
+  color: var(--text-primary);
+}
+
+.arcade-panel__frame {
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 30%, transparent);
+  border-radius: var(--radius-panel);
+  background: var(--bg-base);
+}
+
+.arcade-panel__hint {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.voice-call-overlay__engines {  display: flex;
   flex-wrap: wrap;
   justify-content: center;
   gap: 6px;

--- a/src/styles/chat-canvas.css
+++ b/src/styles/chat-canvas.css
@@ -281,10 +281,11 @@
 }
 
 /* ── Preview modal ─────────────────────────────────────────────────────────
-   Clicking a card opens the sketch rendered live but non-interactive
-   (pointer-events off, same opaque-origin sandbox as thumbnails). Running it
-   for real happens in the editor. Bespoke dialog (useFocusTrap) because the
-   shared Modal owns a breadcrumb header/footer this layout replaces. */
+   Clicking a card opens the sketch rendered live. It starts as a still preview
+   (pointer-events off, same opaque-origin sandbox as thumbnails); the Play
+   toggle hands input back so the sketch actually runs. Bespoke dialog
+   (useFocusTrap) because the shared Modal owns a breadcrumb header/footer this
+   layout replaces. */
 .chat-canvas-preview-backdrop {
   position: fixed;
   inset: 0;
@@ -379,6 +380,11 @@
   border: 0;
   display: block;
   pointer-events: none;
+}
+/* Play toggle hands the sandbox its own input back (cave canvas interactivity).
+   Isolation is unchanged — still an opaque-origin allow-scripts sandbox. */
+.chat-canvas-preview__frame[data-playing] {
+  pointer-events: auto;
 }
 .chat-canvas-preview__hint {
   margin: 0;
@@ -709,6 +715,27 @@
   cursor: pointer;
 }
 .chat-canvas-add__suggestion:hover { border-color: var(--border-strong); color: var(--text-primary); }
+
+/* Playable toggle — pressed state uses the one accent token, tinted per the
+   state recipe, so it reads as engaged without introducing a second hue. */
+.chat-canvas-add__playable {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: var(--bg-base);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  padding: var(--space-1) var(--space-2);
+  cursor: pointer;
+}
+.chat-canvas-add__playable:hover { border-color: var(--border-strong); color: var(--text-primary); }
+.chat-canvas-add__playable[aria-pressed="true"] {
+  border-color: color-mix(in oklch, var(--accent-presence) 38%, transparent);
+  background: color-mix(in oklch, var(--accent-presence) 14%, transparent);
+  color: var(--accent-presence);
+}
 .chat-canvas-add__result-head,
 .chat-canvas-add__code-head {
   display: flex;


### PR DESCRIPTION
Three things, in dependency order — the second and third only work because of the first.

## 1. Canvas sketches were never interactive

`canvas-inspector.ts` injects a click handler that calls `preventDefault()` + `stopImmediatePropagation()` on **every trusted click**, and the same on Enter/Space, so it can report a selection back to the editor. `canvas-editor.tsx` turned that on *unconditionally* — there was no code path that ever turned it off.

So the gallery's own promise, "open it in the editor to run it live", was false for every sketch ever generated. `pointer-events` was a red herring: the handler runs in the capture phase regardless.

- Fourth **`play`** mode on the editor, gating the inspector (`setEnabled(mode !== "play")`). Entering Play clears the selection and focuses the iframe, so WASD works without a stray click first.
- **Restart sketch** — an identical `srcDoc` does not reload an iframe, so a played-out sketch previously had no way back to frame one.
- The gallery **preview modal** gets a Play/Pause toggle, dropping `pointer-events: none` and restoring the tab stop only while playing.
- Corrected the hint copy and three comments that described the old, false behaviour.

The sandbox is unchanged — `sandbox="allow-scripts"` with no `allow-same-origin`, so this hands input to an opaque-origin document without weakening isolation.

## 2. Glitter Crypt — something to do during dead air

A call spends real seconds on the mic prompt, the session mint, and the handshake, with nothing to look at and no way to tell a slow connection from a stuck one. `src/lib/arcade/glitter-crypt.ts` builds a pastel raycaster as one self-contained document; `arcade-panel.tsx` mounts it into that gap.

Three properties make a game acceptable inside a phone call, and each is pinned by a test rather than by intent:

| Property | Why | Enforced by |
| --- | --- | --- |
| **Silent** | It plays over a live call | assertion: no `Audio`, `AudioContext`, or `getUserMedia` |
| **Opt-in** | A game that ambushes you mid-call is a bug | assertion: invite renders only in waiting states |
| **Disposable** | Unmounting must be the whole teardown | all state lives in the iframe |

`glitter-crypt-chromium.test.ts` runs it in real headless Chromium — boots, renders a shaded frame, moves, turns, pauses, **aims at a wisp and kills it**. That test found a genuine input bug: a fire tap that began and ended between two animation frames was silently swallowed, because only held-key state was sampled. Fixed with a latch consumed by the next off-cooldown frame.

Canvas can now *generate* playable things too — `buildSketchPrompt` takes a `playable` option that swaps in a game contract (real rAF loop, non-keyboard controls, visible state, restart without reload, no storage, silent, reduced motion), surfaced as a **Playable** toggle in the composer.

## 3. iOS voice calls were complete and unreachable

`apps/ios/.../Voice/` already held a full engine — OpenAI Realtime transport, an on-device Apple transport, coordinator, media session, event decoder, three test suites — and `CaveClient` already minted session grants. Nothing outside that folder referenced any of it. Dead code with no UI.

- `LiveVoiceCallView` + `LiveVoiceCallModel` — the SwiftUI surface: live transcript, mute, end, error cards.
- `VoiceCallPresentation` — transport plan and phase/error copy, kept pure so it is testable without a simulator.
- Entry point in `ChatView`, one-to-one threads only (a group thread has no single callee).
- Grant-mint failure is a **real offer**, not a dead end: it falls back to the on-device transport rather than just reporting that live voice is off.

Mic and speech usage strings were already in `Info.plist`.

## Verification

- `pnpm typecheck` OK
- `pnpm lint` (design gate + codemod check) OK
- `pnpm check:tests-wired` OK — both new arcade suites registered
- `pnpm test:app` OK — **1075 test files**
- Browser arcade test green **6x in parallel** to shake out timing flake
- `xcodebuild` build OK, **370 iOS unit tests pass** (12 new)

## Review notes

- Literal hex inside `glitter-crypt.ts` is deliberate and matches existing precedent: app theme tokens never reach a sandboxed opaque-origin document, so semantic tokens cannot apply there. All app chrome (`arcade-panel`, the composer toggle, the invite) is fully tokenized.
- `window.__ARCADE_SNAPSHOT__` is a read-only test hook. Safe because the iframe is opaque-origin, and it is what turned the browser test from pixel-diffing into real assertions.
- Two pre-existing assertions were updated rather than deleted: one pinned `setEnabled(true)` — the exact bug being fixed — and one pinned the old `buildSketchPrompt` call shape.
