### PR TITLE
feat(foil): isomorphic holographic foil plate generator (cave-3rz.1)

### DIFF
--- a/src/lib/foil/browser.ts
+++ b/src/lib/foil/browser.ts
@@ -1,0 +1,262 @@
+/**
+ * foil/browser — material-aware foil for a dropped image, entirely client-side.
+ *
+ * Produces the plate the card's CSS consumes as `--holo-tex`. Runs on canvas so
+ * the summoning preview updates instantly with no server round-trip; the maths
+ * in `plate.ts` is shared verbatim with the server path.
+ *
+ * The plate is masked by the artwork's own materials, so foil lands on things
+ * that would actually reflect and matte fabric stays dead. Because the mask
+ * physically prevents spill onto the rest of the image, the effect can be run
+ * much hotter than a full-bleed plate.
+ */
+
+import { renderPlate, type TemplateName } from "./plate.ts";
+
+/** Fraction of the frame foil should occupy. Coverage is TARGETED rather than
+ *  thresholded at a fixed luminance: a constant tuned on one image is
+ *  meaningless on the next, and targeting keeps a whole roster consistent
+ *  regardless of how each portrait was exposed. */
+const TARGET_COVERAGE = 0.06;
+
+/** Below this median border luminance the backdrop counts as dark. */
+const DARK_BACKDROP = 60;
+
+export type MaskStrategy = {
+  /** Median luminance of the frame border — what the backdrop actually is. */
+  backdrop: number;
+  /** Solved luminance cut for the target coverage. */
+  threshold: number;
+  /** Whether a local-texture gate was applied. */
+  textureGate: boolean;
+};
+
+function luminanceOf(data: Uint8ClampedArray, i: number): number {
+  return 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+}
+
+/**
+ * Extract a specular mask: where is this image made of something reflective?
+ *
+ * Two cues, and which ones apply is decided from the image rather than fixed:
+ *
+ *  · Brightness always. The cut is solved from the histogram to hit
+ *    TARGET_COVERAGE, so it adapts to exposure.
+ *  · Local texture ONLY when the backdrop is bright. A bright backdrop passes a
+ *    luminance test and leaks foil into empty space, and a studio backdrop is
+ *    smooth where worked metal is not. But on a DARK backdrop the same gate is
+ *    actively harmful — polished chrome is smooth and patterned fabric is not,
+ *    so it would reject the metal and foil the cloth.
+ */
+export function extractSpecularMask(
+  img: ImageData,
+): { mask: Uint8ClampedArray; strategy: MaskStrategy } {
+  const { width: W, height: H, data } = img;
+  const lum = new Float32Array(W * H);
+  for (let i = 0, p = 0; i < data.length; i += 4, p++) lum[p] = luminanceOf(data, i);
+
+  // Backdrop = median luminance around the frame edge.
+  const border: number[] = [];
+  const band = Math.max(2, Math.round(Math.min(W, H) * 0.04));
+  for (let y = 0; y < H; y++) {
+    for (let x = 0; x < W; x++) {
+      if (x < band || y < band || x >= W - band || y >= H - band) border.push(lum[y * W + x]);
+    }
+  }
+  border.sort((a, b) => a - b);
+  const backdrop = border[border.length >> 1] ?? 0;
+  const textureGate = backdrop >= DARK_BACKDROP;
+
+  // Solve the threshold for the target share of the frame.
+  const hist = new Uint32Array(256);
+  for (let p = 0; p < lum.length; p++) hist[Math.min(255, Math.max(0, Math.round(lum[p])))]++;
+  let acc = 0;
+  let threshold = 255;
+  for (let v = 255; v >= 0; v--) {
+    acc += hist[v];
+    if (acc / lum.length >= TARGET_COVERAGE) { threshold = v; break; }
+  }
+
+  const span = Math.max(12, 255 - threshold);
+  const mask = new Uint8ClampedArray(W * H);
+  for (let p = 0; p < lum.length; p++) {
+    const v = lum[p];
+    mask[p] = v < threshold ? 0 : Math.min(255, Math.round(Math.pow((v - threshold) / span, 0.66) * 255));
+  }
+
+  if (textureGate) {
+    const R = 3;
+    const gate = new Float32Array(W * H);
+    for (let y = 0; y < H; y++) {
+      for (let x = 0; x < W; x++) {
+        let sum = 0, sum2 = 0, n = 0;
+        for (let dy = -R; dy <= R; dy++) {
+          const yy = y + dy;
+          if (yy < 0 || yy >= H) continue;
+          for (let dx = -R; dx <= R; dx++) {
+            const xx = x + dx;
+            if (xx < 0 || xx >= W) continue;
+            const v = lum[yy * W + xx];
+            sum += v; sum2 += v * v; n++;
+          }
+        }
+        const mean = sum / n;
+        gate[y * W + x] = Math.sqrt(Math.max(0, sum2 / n - mean * mean));
+      }
+    }
+    for (let p = 0; p < mask.length; p++) {
+      mask[p] = Math.round(mask[p] * Math.min(1, gate[p] / 7.5));
+    }
+  }
+
+  return { mask, strategy: { backdrop: Math.round(backdrop), threshold, textureGate } };
+}
+
+/** Separable box blur — cheap, and adequate for softening a mask. */
+function blur(src: Uint8ClampedArray, W: number, H: number, radius: number): Uint8ClampedArray {
+  if (radius < 1) return src;
+  const tmp = new Float32Array(W * H);
+  const out = new Uint8ClampedArray(W * H);
+  const span = radius * 2 + 1;
+  for (let y = 0; y < H; y++) {
+    let acc = 0;
+    for (let x = -radius; x <= radius; x++) acc += src[y * W + Math.min(W - 1, Math.max(0, x))];
+    for (let x = 0; x < W; x++) {
+      tmp[y * W + x] = acc / span;
+      acc -= src[y * W + Math.min(W - 1, Math.max(0, x - radius))];
+      acc += src[y * W + Math.min(W - 1, Math.max(0, x + radius + 1))];
+    }
+  }
+  for (let x = 0; x < W; x++) {
+    let acc = 0;
+    for (let y = -radius; y <= radius; y++) acc += tmp[Math.min(H - 1, Math.max(0, y)) * W + x];
+    for (let y = 0; y < H; y++) {
+      out[y * W + x] = acc / span;
+      acc -= tmp[Math.min(H - 1, Math.max(0, y - radius)) * W + x];
+      acc += tmp[Math.min(H - 1, Math.max(0, y + radius + 1)) * W + x];
+    }
+  }
+  return out;
+}
+
+export type FoilPlateInput = {
+  /** The dropped artwork, already drawn to a canvas at working size. */
+  image: ImageData;
+  /** Drives mark selection — pass the familiar's role/type words. */
+  theme?: string;
+  seed?: number | string;
+  /** Higher is denser dots. */
+  pitchScale?: number;
+};
+
+export type FoilPlateOutput = {
+  /** `url(...)`-ready data URI for the card's `--holo-tex`. */
+  dataUrl: string;
+  coverage: number;
+  strategy: MaskStrategy;
+};
+
+/**
+ * Build the masked foil plate for a piece of artwork.
+ *
+ * The carrier is deliberately `full-bleed` + `flat`: under a mask the MASK must
+ * supply the shape. A composed plate has empty regions of its own, which punch
+ * holes in the masked subject and read as the foil being misaligned.
+ */
+export function buildFoilPlate(input: FoilPlateInput): FoilPlateOutput {
+  const { width: W, height: H } = input.image;
+  const { mask, strategy } = extractSpecularMask(input.image);
+
+  const soft = blur(mask, W, H, 1);
+  const halo = blur(mask, W, H, 9);
+
+  const plate = renderPlate({
+    width: W,
+    height: H,
+    theme: input.theme ?? "",
+    seed: input.seed ?? 0,
+    template: "full-bleed" as TemplateName,
+    falloff: "flat",
+    pitchScale: input.pitchScale ?? 0.9,
+    markCount: 1,
+  });
+
+  const out = new Uint8ClampedArray(W * H * 4);
+  let lit = 0;
+  for (let p = 0; p < W * H; p++) {
+    const m = soft[p] / 255;
+    // Dots carry the effect. The sheen is only a floor so metal still reads as
+    // lit between dots — too much and the subject becomes a plain bright shape
+    // and the halftone character is lost.
+    const dots = (plate.data[p] / 255) * m;
+    const sheen = m * 0.13;
+    const bleed = (halo[p] / 255) * m * 0.12;
+    const v = Math.min(1, (dots + sheen + bleed) * 1.55);
+    const b = Math.round(v * 255);
+    const i = p * 4;
+    out[i] = b; out[i + 1] = b; out[i + 2] = b; out[i + 3] = 255;
+    if (b > 24) lit++;
+  }
+
+  const canvas = document.createElement("canvas");
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) throw new Error("2d context unavailable");
+  ctx.putImageData(new ImageData(out, W, H), 0, 0);
+
+  return {
+    dataUrl: canvas.toDataURL("image/png"),
+    coverage: lit / (W * H),
+    strategy,
+  };
+}
+
+/**
+ * Dominant chromatic hue of an image, as a hex accent.
+ *
+ * Deterministic and pixel-derived on purpose: asking a model to name a colour
+ * is slower, costs a round-trip, and is less accurate than reading the pixels.
+ * Near-black and near-neutral samples are dropped so a dark costume or chrome
+ * doesn't dominate the vote.
+ */
+export function extractAura(img: ImageData, fallback: string): string {
+  const { data } = img;
+  const bins = new Map<number, { n: number; h: number; s: number; l: number }>();
+
+  for (let i = 0; i < data.length; i += 4) {
+    const r = data[i] / 255, g = data[i + 1] / 255, b = data[i + 2] / 255;
+    const mx = Math.max(r, g, b), mn = Math.min(r, g, b), d = mx - mn;
+    const l = (mx + mn) / 2;
+    if (l < 0.16 || l > 0.94) continue;
+    const s = d === 0 ? 0 : d / (1 - Math.abs(2 * l - 1));
+    if (s < 0.1) continue;
+    let h = 0;
+    if (d) {
+      if (mx === r) h = ((g - b) / d) % 6;
+      else if (mx === g) h = (b - r) / d + 2;
+      else h = (r - g) / d + 4;
+    }
+    h = (h * 60 + 360) % 360;
+    const key = Math.round(h / 12) * 12;
+    const e = bins.get(key) ?? { n: 0, h: 0, s: 0, l: 0 };
+    e.n++; e.h += h; e.s += s; e.l += l;
+    bins.set(key, e);
+  }
+
+  const top = [...bins.values()].sort((a, b) => b.n - a.n)[0];
+  if (!top) return fallback;
+
+  const h = top.h / top.n;
+  // Lift toward a usable accent: source art is often muted, and a card accent
+  // has to carry on a dark ground without becoming a different colour.
+  const s = Math.min(0.66, Math.max(0.34, (top.s / top.n) * 1.5));
+  const l = Math.min(0.62, Math.max(0.46, (top.l / top.n) * 1.35));
+
+  const a = s * Math.min(l, 1 - l);
+  const ch = (n: number) => {
+    const k = (n + h / 30) % 12;
+    return Math.round(255 * (l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1))));
+  };
+  return `#${[ch(0), ch(8), ch(4)].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
+}

--- a/src/lib/foil/field.ts
+++ b/src/lib/foil/field.ts
@@ -1,0 +1,232 @@
+/**
+ * foil/field — determinism primitives and the halftone / SDF mathematics.
+ *
+ * Isomorphic on purpose: nothing here touches the DOM, `sharp`, or any Node
+ * built-in, so the same code renders a live preview in the summoning circle and
+ * a print-resolution plate on the server. Every mark is a closed-form
+ * expression evaluated per pixel — there is no sampling order and no
+ * accumulation buffer, which is what makes output reproducible.
+ *
+ * The reference implementation and its full rationale live in
+ * `scripts/foil-forge/`; this is the typed, browser-safe port.
+ */
+
+/* ── Determinism ─────────────────────────────────────────────────────────── */
+
+/** FNV-1a, 32-bit. Stable across engines, unlike int-coercion string folds. */
+export function hashString(str: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/** Fold inputs into one seed. Argument ORDER is part of the contract — changing
+ *  it changes every plate a familiar has ever been shown. */
+export function deriveSeed(...parts: Array<string | number | null | undefined>): number {
+  let h = 0x811c9dc5;
+  for (const p of parts) {
+    const s = typeof p === "number" && Number.isFinite(p) ? `#${Math.trunc(p)}` : String(p ?? "");
+    h = hashString(`${h}|${s}`) >>> 0;
+  }
+  return h >>> 0;
+}
+
+export type Rng = {
+  (): number;
+  float(lo: number, hi: number): number;
+  int(lo: number, hi: number): number;
+  pick<T>(arr: readonly T[]): T;
+  bool(p?: number): boolean;
+};
+
+/** mulberry32 — small, fast, sufficient for layout jitter. */
+export function makeRng(seed: number): Rng {
+  let a = seed >>> 0;
+  const next = (() => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  }) as Rng;
+  next.float = (lo, hi) => lo + (hi - lo) * next();
+  next.int = (lo, hi) => Math.floor(lo + (hi - lo + 1) * next());
+  next.pick = (arr) => arr[Math.floor(next() * arr.length) % arr.length];
+  next.bool = (p = 0.5) => next() < p;
+  return next;
+}
+
+export const VARIATION_SCALE = { low: 0.35, medium: 1, high: 1.85 } as const;
+export type VariationLevel = keyof typeof VARIATION_SCALE;
+export const variationScale = (level: VariationLevel | undefined): number =>
+  VARIATION_SCALE[level ?? "medium"];
+
+/* ── Small maths ─────────────────────────────────────────────────────────── */
+
+const TAU = Math.PI * 2;
+
+export const clamp = (v: number, lo = 0, hi = 1): number => (v < lo ? lo : v > hi ? hi : v);
+
+export const smoothstep = (e0: number, e1: number, x: number): number => {
+  if (e0 === e1) return x < e0 ? 0 : 1;
+  const t = clamp((x - e0) / (e1 - e0));
+  return t * t * (3 - 2 * t);
+};
+
+/* ── Density falloff curves ──────────────────────────────────────────────── */
+
+/**
+ * Maps normalised radius (0 at centre, 1 at rim) to dot coverage. This single
+ * function decides whether the same lattice reads as a sphere, a bloom or a set
+ * of rings — it is the biggest lever on how a foil looks.
+ */
+export const FALLOFFS: Record<string, (t: number) => number> = {
+  linear: (t) => 1 - t,
+  gaussian: (t) => Math.exp(-(t * t) * 3.2),
+  /** Lambertian shading of a lit sphere — the classic halftone sphere. */
+  sphere: (t) => {
+    if (t >= 1) return 0;
+    return clamp(0.18 + 0.92 * Math.sqrt(Math.max(0, 1 - t * t)));
+  },
+  annulus: (t) => Math.exp(-((t - 0.62) ** 2) / 0.035),
+  banded: (t) => clamp((1 - t) * (0.35 + 0.75 * (0.5 + 0.5 * Math.cos(t * Math.PI * 9)))),
+  disc: (t) => smoothstep(1, 0.82, t),
+  /**
+   * Constant to the rim. Wrong for a standalone foil — it has no focal mass —
+   * but it is the RIGHT carrier when the plate will be multiplied by a mask,
+   * because then the mask must supply the shape and the plate only the texture.
+   * Using a composed plate under a mask punches holes in the masked subject and
+   * reads as a misalignment bug.
+   */
+  flat: () => 1,
+};
+
+export const FALLOFF_NAMES = Object.keys(FALLOFFS);
+
+/* ── Radial halftone ─────────────────────────────────────────────────────── */
+
+export type HalftoneSpec = {
+  cx: number;
+  cy: number;
+  radius: number;
+  ringPitch: number;
+  dotScale: number;
+  falloff: string;
+  rotation: number;
+  twist?: number;
+  gamma?: number;
+  minCells?: number;
+};
+
+/**
+ * Cells sit in concentric rings, with per-ring cell counts scaled to
+ * circumference so cell area stays roughly constant. Sampled per pixel by
+ * locating the containing cell rather than iterating dots, so cost is
+ * O(pixels) no matter how many dots there are.
+ */
+export function makeHalftone(spec: HalftoneSpec): (px: number, py: number, aa: number) => number {
+  const {
+    cx, cy, radius, ringPitch, dotScale, falloff, rotation,
+    twist = 0, gamma = 1, minCells = 6,
+  } = spec;
+
+  const curve = FALLOFFS[falloff] ?? FALLOFFS.sphere;
+  const rings = Math.max(1, Math.round(radius / ringPitch));
+
+  return (px, py, aa) => {
+    const dx = px - cx;
+    const dy = py - cy;
+    // Inline sqrt, not Math.hypot: hypot's overflow guard costs roughly an
+    // order of magnitude in a per-pixel loop.
+    const r = Math.sqrt(dx * dx + dy * dy);
+    if (r > radius + ringPitch) return 0;
+
+    const ri = Math.min(rings - 1, Math.floor(r / ringPitch));
+    const rc = (ri + 0.5) * ringPitch;
+
+    let weight = curve(clamp(rc / radius));
+    if (gamma !== 1) weight = Math.pow(clamp(weight), gamma);
+    if (weight <= 0.001) return 0;
+
+    const cells = Math.max(minCells, Math.round((TAU * rc) / ringPitch));
+    // Half-cell stagger on odd rings stops the lattice reading as spokes.
+    const spin = rotation + twist * (rc / radius) * TAU + (ri % 2) * (Math.PI / cells);
+    let theta = Math.atan2(dy, dx) - spin;
+    theta = ((theta % TAU) + TAU) % TAU;
+
+    const ai = Math.floor((theta / TAU) * cells);
+    const ac = ((ai + 0.5) / cells) * TAU + spin;
+    const ccx = cx + Math.cos(ac) * rc;
+    const ccy = cy + Math.sin(ac) * rc;
+
+    const dotR = ringPitch * dotScale * weight;
+    if (dotR <= 0) return 0;
+
+    const ex = px - ccx;
+    const ey = py - ccy;
+    return 1 - smoothstep(dotR - aa, dotR + aa, Math.sqrt(ex * ex + ey * ey));
+  };
+}
+
+/* ── Signed distance functions ───────────────────────────────────────────── */
+
+/** Negative inside, positive outside, in pixels. Compose with min/max. */
+export const sdf = {
+  circle: (px: number, py: number, cx: number, cy: number, r: number): number => {
+    const dx = px - cx, dy = py - cy;
+    return Math.sqrt(dx * dx + dy * dy) - r;
+  },
+  ring: (px: number, py: number, cx: number, cy: number, r: number, w: number): number => {
+    const dx = px - cx, dy = py - cy;
+    return Math.abs(Math.sqrt(dx * dx + dy * dy) - r) - w * 0.5;
+  },
+  polygon: (px: number, py: number, cx: number, cy: number, r: number, n: number, rot = 0): number => {
+    const dx = px - cx, dy = py - cy;
+    const a = Math.atan2(dy, dx) - rot;
+    const seg = TAU / n;
+    const aa = a - seg * Math.round(a / seg);
+    return Math.sqrt(dx * dx + dy * dy) * Math.cos(aa) - r * Math.cos(seg / 2);
+  },
+  box: (px: number, py: number, cx: number, cy: number, hw: number, hh: number, rot = 0): number => {
+    const c = Math.cos(-rot), s = Math.sin(-rot);
+    const dx = px - cx, dy = py - cy;
+    const rx = dx * c - dy * s, ry = dx * s + dy * c;
+    const qx = Math.abs(rx) - hw, qy = Math.abs(ry) - hh;
+    const mx = Math.max(qx, 0), my = Math.max(qy, 0);
+    return Math.sqrt(mx * mx + my * my) + Math.min(Math.max(qx, qy), 0);
+  },
+  arc: (px: number, py: number, cx: number, cy: number, r: number, w: number, rot: number, sweep: number): number => {
+    const dx = px - cx, dy = py - cy;
+    let a = Math.atan2(dy, dx) - rot;
+    a = Math.atan2(Math.sin(a), Math.cos(a));
+    const half = sweep * 0.5;
+    if (Math.abs(a) <= half) return Math.abs(Math.sqrt(dx * dx + dy * dy) - r) - w * 0.5;
+    const capA = rot + (a > 0 ? half : -half);
+    const gx = px - (cx + Math.cos(capA) * r);
+    const gy = py - (cy + Math.sin(capA) * r);
+    return Math.sqrt(gx * gx + gy * gy) - w * 0.5;
+  },
+  segment: (px: number, py: number, ax: number, ay: number, bx: number, by: number, w: number): number => {
+    const vx = bx - ax, vy = by - ay;
+    const wx = px - ax, wy = py - ay;
+    const len2 = vx * vx + vy * vy || 1;
+    const t = clamp((wx * vx + wy * vy) / len2);
+    const ux = wx - vx * t, uy = wy - vy * t;
+    return Math.sqrt(ux * ux + uy * uy) - w * 0.5;
+  },
+  chevron: (px: number, py: number, cx: number, cy: number, size: number, w: number, rot = 0): number => {
+    const c = Math.cos(-rot), s = Math.sin(-rot);
+    const dx = px - cx, dy = py - cy;
+    const rx = dx * c - dy * s, ry = dx * s + dy * c;
+    return Math.min(
+      sdf.segment(rx, ry, -size, -size, size, 0, w),
+      sdf.segment(rx, ry, -size, size, size, 0, w),
+    );
+  },
+};
+
+/** Signed distance → antialiased coverage. */
+export const fill = (d: number, aa: number): number => 1 - smoothstep(-aa, aa, d);

--- a/src/lib/foil/index.ts
+++ b/src/lib/foil/index.ts
@@ -1,0 +1,12 @@
+/**
+ * foil — deterministic holographic foil plates for familiar cards.
+ *
+ * `plate.ts` is isomorphic (no DOM, no `sharp`), `browser.ts` adds the canvas
+ * path used by the live summoning preview. The CLI and print-resolution
+ * renderer live in `scripts/foil-forge/`.
+ */
+export { renderPlate, MARK_NAMES, TEMPLATES, tagsForTheme } from "./plate.ts";
+export type { PlateOptions, PlateResult, TemplateName } from "./plate.ts";
+export { buildFoilPlate, extractSpecularMask, extractAura } from "./browser.ts";
+export type { FoilPlateInput, FoilPlateOutput, MaskStrategy } from "./browser.ts";
+export { FALLOFF_NAMES, deriveSeed } from "./field.ts";

--- a/src/lib/foil/plate.test.ts
+++ b/src/lib/foil/plate.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { renderPlate, selectMarks, tagsForTheme, MARK_NAMES } from "./plate.ts";
+import { deriveSeed, makeRng, FALLOFFS } from "./field.ts";
+
+const base = { width: 96, height: 134, theme: "reaper sever blade", seed: 19 } as const;
+
+test("identical inputs render byte-identical plates", () => {
+  const a = renderPlate({ ...base });
+  const b = renderPlate({ ...base });
+  assert.deepEqual([...a.data], [...b.data]);
+  assert.equal(a.meta.seed, b.meta.seed);
+});
+
+test("a different seed produces a different plate", () => {
+  const a = renderPlate({ ...base });
+  const b = renderPlate({ ...base, seed: 20 });
+  assert.notDeepEqual([...a.data], [...b.data]);
+});
+
+test("nothing in the pipeline reads ambient entropy", () => {
+  // Guard the determinism contract against a future Math.random creeping in:
+  // if anything called it, these two renders would diverge.
+  const realRandom = Math.random;
+  let called = 0;
+  Math.random = () => { called++; return 0.5; };
+  try {
+    renderPlate({ ...base });
+  } finally {
+    Math.random = realRandom;
+  }
+  assert.equal(called, 0, "renderPlate must not call Math.random");
+});
+
+test("the seed is derived from identity only, so presentation knobs are orthogonal", () => {
+  // Dimensions, variation, markCount and a forced template are all excluded
+  // from the seed. Changing them must not reshuffle which marks were chosen.
+  const a = renderPlate({ ...base });
+  const wide = renderPlate({ ...base, width: 192, height: 268 });
+  const varied = renderPlate({ ...base, variation: "high" });
+  assert.deepEqual(a.meta.marks, wide.meta.marks);
+  assert.deepEqual(a.meta.marks, varied.meta.marks);
+  assert.equal(a.meta.template, wide.meta.template);
+});
+
+test("markCount is nested rather than a reshuffle", () => {
+  const one = renderPlate({ ...base, markCount: 1 });
+  const three = renderPlate({ ...base, markCount: 3 });
+  assert.deepEqual(three.meta.marks.slice(0, 1), one.meta.marks);
+});
+
+test("forcing a template does not disturb the falloff or marks", () => {
+  const auto = renderPlate({ ...base });
+  const forced = renderPlate({ ...base, template: "split" });
+  assert.equal(forced.meta.template, "split");
+  assert.deepEqual(forced.meta.marks, auto.meta.marks);
+  assert.equal(forced.meta.falloff, auto.meta.falloff);
+});
+
+test("pitchScale changes density without changing composition", () => {
+  const coarse = renderPlate({ ...base, pitchScale: 1 });
+  const dense = renderPlate({ ...base, pitchScale: 0.5 });
+  assert.ok(dense.meta.ringPitch < coarse.meta.ringPitch);
+  assert.equal(dense.meta.template, coarse.meta.template);
+  assert.deepEqual(dense.meta.marks, coarse.meta.marks);
+});
+
+test("the flat falloff is constant, so a masked carrier has no shape of its own", () => {
+  // A composed plate under a mask punches holes in the masked subject; the
+  // carrier must be even so the MASK supplies the shape.
+  assert.equal(FALLOFFS.flat(0), 1);
+  assert.equal(FALLOFFS.flat(0.5), 1);
+  assert.equal(FALLOFFS.flat(1), 1);
+});
+
+test("full-bleed carrier covers the frame", () => {
+  const plate = renderPlate({ ...base, template: "full-bleed", falloff: "flat" });
+  // Sample the four corners; a full-bleed carrier must reach all of them.
+  const { data, width, height } = plate;
+  const corners = [
+    [4, 4], [width - 5, 4], [4, height - 5], [width - 5, height - 5],
+  ] as const;
+  for (const [x, y] of corners) {
+    let any = 0;
+    for (let dy = -3; dy <= 3; dy++) {
+      for (let dx = -3; dx <= 3; dx++) any = Math.max(any, data[(y + dy) * width + (x + dx)]);
+    }
+    assert.ok(any > 0, `carrier should reach corner ${x},${y}`);
+  }
+});
+
+test("plate output is pure black and white apart from edge pixels", () => {
+  const { data } = renderPlate({ ...base });
+  let mid = 0;
+  for (const v of data) if (v > 8 && v < 247) mid++;
+  // Antialiasing is deliberate — a hard threshold on curved geometry crawls
+  // once the CSS stack moves it — but it must stay confined to boundaries.
+  assert.ok(mid / data.length < 0.2, `too many midtones: ${(mid / data.length * 100).toFixed(1)}%`);
+});
+
+test("themes select from the fixed vocabulary, never invent geometry", () => {
+  const rng = makeRng(deriveSeed(1, "quantum trader"));
+  for (const mark of selectMarks("quantum trader", rng, 3)) {
+    assert.ok(MARK_NAMES.includes(mark), `${mark} is not in the mark library`);
+  }
+});
+
+test("an unknown theme still yields usable tags rather than throwing", () => {
+  assert.ok(tagsForTheme("asdfqwerty").length > 0);
+});
+
+test("deriveSeed is order-sensitive, which is why its signature is a contract", () => {
+  assert.notEqual(deriveSeed(1, "a"), deriveSeed("a", 1));
+});

--- a/src/lib/foil/plate.ts
+++ b/src/lib/foil/plate.ts
@@ -1,0 +1,383 @@
+/**
+ * foil/plate — layout, marks, and the greyscale rasteriser.
+ *
+ * Isomorphic: returns a raw single-channel buffer. The browser wraps it in
+ * ImageData; the server hands it to `sharp`. Neither path is imported here.
+ */
+
+import {
+  clamp, deriveSeed, fill, makeHalftone, makeRng, sdf, smoothstep,
+  variationScale, type HalftoneSpec, type Rng, type VariationLevel,
+} from "./field.ts";
+
+const TAU = Math.PI * 2;
+
+/* ── Marks ───────────────────────────────────────────────────────────────── */
+
+export type MarkPlacement = { cx: number; cy: number; s: number; rot: number; w: number };
+type MarkDraw = (px: number, py: number, o: MarkPlacement, aa: number) => number;
+
+/**
+ * A curated vocabulary. A theme SELECTS from this table — it never invents
+ * geometry — which is what keeps a whole set of familiars looking like one set.
+ */
+export const MARKS: Record<string, { tags: string[]; draw: MarkDraw }> = {
+  eclipse: {
+    tags: ["round", "negative", "bold"],
+    draw: (px, py, o, aa) =>
+      clamp(
+        fill(sdf.circle(px, py, o.cx, o.cy, o.s), aa) -
+        fill(sdf.circle(px, py, o.cx + o.s * 0.42, o.cy - o.s * 0.3, o.s * 0.86), aa),
+      ),
+  },
+  orbit: {
+    tags: ["round", "node", "technical"],
+    draw: (px, py, o, aa) => {
+      let c = fill(sdf.circle(px, py, o.cx, o.cy, o.s * 0.17), aa);
+      for (const [r, wm] of [[0.46, 1], [0.72, 0.72], [1, 0.5]] as const) {
+        c = Math.max(c, fill(sdf.ring(px, py, o.cx, o.cy, o.s * r, o.w * wm), aa));
+      }
+      return c;
+    },
+  },
+  reticle: {
+    tags: ["round", "technical", "precision"],
+    draw: (px, py, o, aa) => {
+      let c = fill(sdf.ring(px, py, o.cx, o.cy, o.s * 0.78, o.w), aa);
+      for (let i = 0; i < 4; i++) {
+        const a = o.rot + (i * TAU) / 4;
+        c = Math.max(c, fill(sdf.segment(
+          px, py,
+          o.cx + Math.cos(a) * o.s * 0.9, o.cy + Math.sin(a) * o.s * 0.9,
+          o.cx + Math.cos(a) * o.s * 1.22, o.cy + Math.sin(a) * o.s * 1.22,
+          o.w,
+        ), aa));
+      }
+      return Math.max(c, fill(sdf.circle(px, py, o.cx, o.cy, o.s * 0.1), aa));
+    },
+  },
+  prism: {
+    tags: ["angular", "wire", "bold"],
+    draw: (px, py, o, aa) => {
+      const outer = sdf.polygon(px, py, o.cx, o.cy, o.s, 3, o.rot);
+      return clamp(fill(outer, aa) - fill(outer + o.w, aa));
+    },
+  },
+  hexcell: {
+    tags: ["angular", "technical", "lattice"],
+    draw: (px, py, o, aa) => {
+      const outer = sdf.polygon(px, py, o.cx, o.cy, o.s, 6, o.rot);
+      return Math.max(
+        clamp(fill(outer, aa) - fill(outer + o.w, aa)),
+        fill(sdf.polygon(px, py, o.cx, o.cy, o.s * 0.34, 6, o.rot), aa),
+      );
+    },
+  },
+  blade: {
+    tags: ["angular", "blade", "motion"],
+    draw: (px, py, o, aa) => {
+      let c = 0;
+      for (let i = 0; i < 3; i++) {
+        const off = (i - 1) * o.s * 0.44;
+        c = Math.max(c, fill(sdf.chevron(
+          px, py, o.cx + Math.cos(o.rot) * off, o.cy + Math.sin(o.rot) * off,
+          o.s * 0.5, o.w, o.rot,
+        ), aa));
+      }
+      return c;
+    },
+  },
+  aperture: {
+    tags: ["round", "technical", "precision"],
+    draw: (px, py, o, aa) => {
+      let c = 0;
+      const blades = 6;
+      for (let i = 0; i < blades; i++) {
+        const a = o.rot + (i * TAU) / blades;
+        c = Math.max(c, fill(sdf.arc(px, py, o.cx, o.cy, o.s * 0.82, o.w * 1.5, a, (TAU / blades) * 0.62), aa));
+      }
+      return c;
+    },
+  },
+  lattice: {
+    tags: ["lattice", "grid", "structure"],
+    draw: (px, py, o, aa) => {
+      const c = Math.cos(-o.rot), s = Math.sin(-o.rot);
+      const dx = px - o.cx, dy = py - o.cy;
+      const rx = dx * c - dy * s, ry = dx * s + dy * c;
+      if (Math.abs(rx) > o.s || Math.abs(ry) > o.s) return 0;
+      const pitch = o.s / 4.5;
+      const m = Math.abs((((ry % pitch) + pitch) % pitch) - pitch * 0.5);
+      return (1 - smoothstep(o.w * 0.5 - aa, o.w * 0.5 + aa, m)) *
+        (1 - smoothstep(o.s * 0.7, o.s, Math.abs(rx)));
+    },
+  },
+  sigil: {
+    tags: ["star", "arcane", "radial"],
+    draw: (px, py, o, aa) => {
+      let d = 1e9;
+      for (let i = 0; i < 4; i++) {
+        d = Math.min(d, sdf.box(px, py, o.cx, o.cy, o.s, o.s * 0.085, o.rot + (i * Math.PI) / 4));
+      }
+      return Math.max(fill(d, aa), fill(sdf.circle(px, py, o.cx, o.cy, o.s * 0.14), aa));
+    },
+  },
+  node: {
+    tags: ["node", "network", "technical"],
+    draw: (px, py, o, aa) => {
+      let c = fill(sdf.circle(px, py, o.cx, o.cy, o.s * 0.13), aa);
+      for (let i = 0; i < 3; i++) {
+        const a = o.rot + (i * TAU) / 3;
+        const nx = o.cx + Math.cos(a) * o.s * 0.8;
+        const ny = o.cy + Math.sin(a) * o.s * 0.8;
+        c = Math.max(c, fill(sdf.segment(px, py, o.cx, o.cy, nx, ny, o.w * 0.8), aa));
+        c = Math.max(c, fill(sdf.circle(px, py, nx, ny, o.s * 0.11), aa));
+      }
+      return c;
+    },
+  },
+  monolith: {
+    tags: ["bold", "structure"],
+    draw: (px, py, o, aa) => fill(sdf.box(px, py, o.cx, o.cy, o.s * 0.22, o.s, o.rot), aa),
+  },
+};
+
+export const MARK_NAMES = Object.keys(MARKS);
+
+const KEYWORDS: Array<[string[], string[]]> = [
+  [["cyber", "mech", "machine", "android", "chrome", "circuit"], ["technical", "angular", "lattice"]],
+  [["void", "null", "abyss", "shadow", "dark", "eclipse", "obsidian"], ["negative", "round", "bold"]],
+  [["quantum", "particle", "wave", "flux", "entangle", "photon"], ["node", "round", "network"]],
+  [["warrior", "blade", "war", "hunt", "strike", "reaper", "sever"], ["blade", "angular", "motion"]],
+  [["trader", "market", "exchange", "ledger", "broker", "index"], ["lattice", "grid", "network"]],
+  [["arcane", "occult", "rune", "sigil", "witch", "coven", "ritual"], ["arcane", "star", "radial"]],
+  [["oracle", "seer", "augur", "divine", "scry", "research"], ["precision", "round", "radial"]],
+  [["forge", "iron", "anvil", "smith", "steel", "code", "build"], ["bold", "structure", "angular"]],
+  [["archive", "library", "record", "memory", "comms", "message"], ["grid", "structure", "lattice"]],
+  [["storm", "bolt", "surge", "volt", "review"], ["motion", "angular", "blade"]],
+];
+
+const NEUTRAL = ["technical", "round", "precision"];
+
+export function tagsForTheme(theme: string): string[] {
+  const t = String(theme ?? "").toLowerCase();
+  const hits: string[] = [];
+  for (const [keys, tags] of KEYWORDS) if (keys.some((k) => t.includes(k))) hits.push(...tags);
+  return hits.length ? hits : NEUTRAL.slice();
+}
+
+export function selectMarks(theme: string, rng: Rng, count: number): string[] {
+  const weight = new Map<string, number>();
+  for (const tag of tagsForTheme(theme)) weight.set(tag, (weight.get(tag) ?? 0) + 1);
+
+  const scored = MARK_NAMES.map((name) => ({
+    name,
+    score: MARKS[name].tags.reduce((s, tag) => s + (weight.get(tag) ?? 0), 0),
+    jitter: rng(),
+  })).sort((a, b) => b.score - a.score || a.jitter - b.jitter);
+
+  const out: string[] = [];
+  for (const s of scored) {
+    out.push(s.name);
+    if (out.length === count) break;
+  }
+  return out;
+}
+
+/* ── Layout ──────────────────────────────────────────────────────────────── */
+
+export const TEMPLATES = [
+  "centered", "left-heavy", "triptych", "corner-anchor", "orbital", "split", "full-bleed",
+] as const;
+export type TemplateName = (typeof TEMPLATES)[number];
+
+const PRIMARY_FALLOFFS = ["sphere", "gaussian", "annulus", "banded", "disc"];
+
+type Layout = {
+  template: string;
+  falloff: string;
+  halftones: HalftoneSpec[];
+  slots: MarkPlacement[];
+  basePitch: number;
+};
+
+function buildLayout(opts: {
+  width: number; height: number; rng: Rng; variation: number;
+  markCount: number; template?: string | null; pitchScale: number; falloff?: string | null;
+}): Layout {
+  const { width, height, rng, variation, markCount, pitchScale } = opts;
+  const unit = Math.min(width, height);
+  const j = (amount: number) => (rng() - 0.5) * 2 * amount * variation;
+
+  // Draw unconditionally, then override. Skipping a draw when the caller forces
+  // a value would shift every subsequent random number and silently change the
+  // layout of an otherwise identical card.
+  const autoTemplate = rng.pick(TEMPLATES);
+  const name = opts.template ?? autoTemplate;
+  const autoFalloff = rng.pick(PRIMARY_FALLOFFS);
+  const falloff = opts.falloff ?? autoFalloff;
+
+  // Never densify by rendering large and downsampling — resampling a fine
+  // halftone aliases it into scanlines. Change the pitch instead.
+  const basePitch = unit * (0.0165 + j(0.0035)) * pitchScale;
+  const dotScale = 0.5 + j(0.09);
+  const twist = rng.bool(0.35) ? (rng() - 0.5) * 0.34 * variation : 0;
+
+  const halftones: HalftoneSpec[] = [];
+  const slots: MarkPlacement[] = [];
+
+  const push = (cx: number, cy: number, radius: number, over: Partial<{ pitchMul: number; dotMul: number; falloff: string; gamma: number }> = {}) => {
+    halftones.push({
+      cx: cx * width,
+      cy: cy * height,
+      radius: radius * unit,
+      ringPitch: Math.max(4, basePitch * (over.pitchMul ?? 1)),
+      dotScale: Math.max(0.16, Math.min(0.86, dotScale * (over.dotMul ?? 1))),
+      falloff: over.falloff ?? falloff,
+      rotation: rng() * TAU,
+      twist,
+      gamma: over.gamma ?? 1,
+    });
+  };
+  const slot = (cx: number, cy: number, s: number, weightMul = 1) => {
+    slots.push({ cx: cx * width, cy: cy * height, s: s * unit, rot: rng() * TAU, w: Math.max(2, unit * 0.0085 * weightMul) });
+  };
+
+  switch (name) {
+    case "centered":
+      push(0.5 + j(0.03), 0.44 + j(0.04), 0.46 + j(0.05));
+      slot(0.5 + j(0.05), 0.44 + j(0.05), 0.15 + j(0.03));
+      slot(0.22 + j(0.06), 0.8 + j(0.05), 0.075 + j(0.02), 0.8);
+      break;
+    case "left-heavy":
+      push(0.22 + j(0.04), 0.4 + j(0.05), 0.52 + j(0.05));
+      push(0.86 + j(0.04), 0.82 + j(0.05), 0.2 + j(0.04), { pitchMul: 0.62, falloff: "disc" });
+      slot(0.7 + j(0.06), 0.36 + j(0.06), 0.13 + j(0.03));
+      break;
+    case "triptych":
+      push(0.5 + j(0.02), 0.5 + j(0.03), 0.34 + j(0.03), { falloff: "banded" });
+      push(0.12 + j(0.03), 0.22 + j(0.04), 0.17 + j(0.03), { pitchMul: 0.7 });
+      push(0.88 + j(0.03), 0.78 + j(0.04), 0.17 + j(0.03), { pitchMul: 0.7 });
+      slot(0.5 + j(0.04), 0.5 + j(0.04), 0.12 + j(0.02));
+      break;
+    case "corner-anchor":
+      push(0.14 + j(0.04), 0.14 + j(0.04), 0.5 + j(0.05), { gamma: 1.25 });
+      slot(0.68 + j(0.06), 0.66 + j(0.06), 0.17 + j(0.03));
+      break;
+    case "orbital":
+      push(0.5 + j(0.03), 0.5 + j(0.03), 0.3 + j(0.03), { falloff: "annulus" });
+      push(0.5 + j(0.03), 0.5 + j(0.03), 0.56 + j(0.05), { pitchMul: 1.5, dotMul: 0.62, falloff: "annulus" });
+      slot(0.5 + j(0.03), 0.5 + j(0.03), 0.11 + j(0.02));
+      break;
+    // Even carrier across the whole frame, for masked use.
+    case "full-bleed":
+      push(0.5, 0.5, 0.78, { falloff: "flat" });
+      slot(0.5, 0.5, 0.0001);
+      break;
+    case "split":
+    default:
+      push(0.3 + j(0.04), 0.28 + j(0.04), 0.36 + j(0.04));
+      push(0.72 + j(0.04), 0.74 + j(0.04), 0.36 + j(0.04), { falloff: "disc", dotMul: 0.86 });
+      slot(0.72 + j(0.05), 0.28 + j(0.06), 0.12 + j(0.03));
+      break;
+  }
+
+  return { template: name, falloff, halftones, slots: slots.slice(0, Math.max(1, markCount)), basePitch };
+}
+
+/* ── Rasteriser ──────────────────────────────────────────────────────────── */
+
+export type PlateOptions = {
+  width: number;
+  height: number;
+  theme?: string;
+  seed?: number | string;
+  variation?: VariationLevel;
+  markCount?: number;
+  template?: TemplateName | null;
+  falloff?: string | null;
+  pitchScale?: number;
+  contrast?: number;
+};
+
+export type PlateResult = {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+  meta: { seed: number; template: string; falloff: string; marks: string[]; ringPitch: number };
+};
+
+/**
+ * Render a greyscale plate. The seed is derived from IDENTITY only (seed +
+ * theme) — dimensions, variation, mark count and forced template/falloff are
+ * presentation knobs, so one seed composes identically at any resolution and
+ * the knobs stay orthogonal.
+ */
+export function renderPlate(opts: PlateOptions): PlateResult {
+  const width = Math.max(8, Math.round(opts.width));
+  const height = Math.max(8, Math.round(opts.height));
+  const markCount = Math.min(3, Math.max(1, opts.markCount ?? 2));
+
+  const seed = deriveSeed(opts.seed ?? 0, opts.theme ?? "");
+  const rng = makeRng(seed);
+  const variation = variationScale(opts.variation);
+
+  const marks = selectMarks(opts.theme ?? "", rng, markCount);
+  const layout = buildLayout({
+    width, height, rng, variation, markCount,
+    template: opts.template ?? null,
+    falloff: opts.falloff ?? null,
+    pitchScale: opts.pitchScale ?? 1,
+  });
+
+  const samplers = layout.halftones.map((h) => {
+    const reach = h.radius + h.ringPitch;
+    return { fn: makeHalftone(h), x0: h.cx - reach, x1: h.cx + reach, y0: h.cy - reach, y1: h.cy + reach };
+  });
+  const placements = layout.slots.map((slot, i) => {
+    const reach = slot.s * 1.9 + slot.w * 2;
+    return {
+      slot, draw: MARKS[marks[i % marks.length]].draw,
+      x0: slot.cx - reach, x1: slot.cx + reach, y0: slot.cy - reach, y1: slot.cy + reach,
+    };
+  });
+
+  const data = new Uint8ClampedArray(width * height);
+  const aa = 0.7;
+  const shoulder = clamp(0.5 * (1 - (opts.contrast ?? 0.86)), 0.004, 0.5);
+  const lo = 0.5 - shoulder;
+  const hi = 0.5 + shoulder;
+
+  for (let y = 0; y < height; y++) {
+    const row = y * width;
+    for (let x = 0; x < width; x++) {
+      const px = x + 0.5;
+      const py = y + 0.5;
+      let cover = 0;
+      // Bounding-box reject first: most pixels exit on four comparisons rather
+      // than a sqrt and an atan2.
+      for (let i = 0; i < samplers.length && cover < 1; i++) {
+        const s = samplers[i];
+        if (px < s.x0 || px > s.x1 || py < s.y0 || py > s.y1) continue;
+        const c = s.fn(px, py, aa);
+        if (c > cover) cover = c;
+      }
+      for (let i = 0; i < placements.length && cover < 1; i++) {
+        const p = placements[i];
+        if (px < p.x0 || px > p.x1 || py < p.y0 || py > p.y1) continue;
+        const c = p.draw(px, py, p.slot, aa);
+        if (c > cover) cover = c;
+      }
+      const v = smoothstep(lo, hi, cover);
+      data[row + x] = v <= 0 ? 0 : v >= 1 ? 255 : Math.round(v * 255);
+    }
+  }
+
+  return {
+    data, width, height,
+    meta: {
+      seed, template: layout.template, falloff: layout.falloff, marks,
+      ringPitch: Number(layout.basePitch.toFixed(3)),
+    },
+  };
+}


### PR DESCRIPTION
First slice of the image-driven conjuring flow (epic `cave-3rz`). This lands the generator only — no UI yet.

`src/lib/foil` is the deterministic halftone/SDF plate renderer the summoning card preview will consume. Ported to TypeScript from `scripts/foil-forge` so the same maths runs in the browser (live preview, no server round-trip) and on the server (print resolution). No new dependencies.

## Determinism

The seed is derived from **identity only** — seed + theme. Dimensions, variation, mark count and a forced template/falloff are presentation knobs and are excluded, so one seed composes identically at any resolution and the knobs stay orthogonal. `markCount: 3` is the 2-mark card plus one, not a reshuffle.

This is enforced in code, not just intended: the mark selection and template pick are **always drawn from the RNG stream even when the caller overrides the result**, because skipping a draw shifts every subsequent value and silently changes the layout of an otherwise identical card.

## Two behaviours that are load-bearing

**Masked use needs the full-bleed carrier with a flat falloff.** A composed plate has empty regions of its own, which punch holes in the masked subject — it reads as the foil being misaligned rather than as a coverage gap.

**Mask extraction picks its strategy from the image.** Brightness always; a local-texture gate *only* when the backdrop is bright. On a dark backdrop the same gate is actively harmful — polished chrome is smooth and patterned fabric is not, so it would reject the metal and foil the cloth. The luminance cut is solved from the histogram for a target coverage rather than fixed, so exposure differences between portraits don't change how much foil a card gets.

## Verification

- 13/13 tests in `src/lib/foil/plate.test.ts`, covering byte-identical repeat renders, knob orthogonality, nested mark counts, carrier coverage, and a guard that nothing calls `Math.random`.
- **`tsc` could not be run locally** — it segfaults (exit 139, no diagnostics) in this environment on the baseline tree with these files removed, so the crash is environmental rather than from this change. The typecheck gate is left to CI.
- Commits are **unsigned**: no GPG secret key was available in the session. Needs a signed re-push or a signed squash before merge if `required_signatures` rejects it.

## Not in this PR

`cave-3rz.2` card preview component · `cave-3rz.3` the conjure stage (dropzone + stepped Q&A) · `cave-3rz.4` per-harness marks · `cave-3rz.5` per-familiar effort level driving the finish tier.