### PR TITLE
Complete the Coding Room's approved design (cave-uod42)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -654,6 +654,7 @@ export const SUITES = {
     "src/components/code-editor.test.ts",
     "src/components/code-surface-mode.test.ts",
     "src/lib/code-surface.test.ts",
+    "src/lib/code-room-shortcuts.test.ts",
     "src/lib/code-terminal-tree.test.ts",
     "src/lib/code-reading.test.ts",
     "src/lib/code-reading-pref.test.ts",

--- a/src/components/code-context-dock.tsx
+++ b/src/components/code-context-dock.tsx
@@ -3,27 +3,44 @@
 /**
  * CodeContextDock — the Coding Room's right zone (cave-98o51).
  *
- * Changes, Files, Pull request, Inspector and Browser, docked
+ * Changes, Files, Pull request, Inspector, GitHub and Browser, docked
  * BESIDE the terminal center rather than replacing it. Every tab reuses its
  * proven implementation; the dock only owns which one is showing and how much
  * room it takes.
  *
- * Two behaviours worth knowing:
+ * Three behaviours worth knowing:
  *
  *  - heavy tabs stay dynamically imported, so opening the Room does not pull
- *    CodeMirror, the PR fetch hooks, or the browser bridge into the first chunk;
- *  - Browser opens the dock `expanded`, because a native webview squeezed into
- *    a sidebar renders a column of wrapped text. It also stays mounted once
- *    opened (hidden, not unmounted) so page state survives a tab switch, and
- *    is only `active` while actually selected — the native bounds follow the
- *    visible pane, never a hidden one.
+ *    CodeMirror, the PR fetch hooks, GitHubView, or the browser bridge into the
+ *    first chunk;
+ *  - Browser and GitHub open the dock `expanded`, because a native webview — or
+ *    a list/detail split — squeezed into a sidebar renders a column of wrapped
+ *    text. Browser also stays mounted once opened (hidden, not unmounted) so
+ *    page state survives a tab switch, and is only `active` while actually
+ *    selected — the native bounds follow the visible pane, never a hidden one;
+ *  - every tab and size change is announced (cave-uod42). The dock is the one
+ *    zone whose content swaps under a stationary cursor, so without a live
+ *    region a screen-reader user gets no signal that anything moved.
+ *
+ * Deliberate divergence from the approved design: it also said "there is no
+ * top-level GitHub page". The top-level Activity/PRs/Issues/Reviews tabs are
+ * shipped and e2e-pinned, and retiring a live surface is an IA call for the
+ * owner, so this tab is additive — it puts GitHub context beside the terminal
+ * without removing the full-width triage view.
  */
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
 import { SessionChangesInner } from "@/components/session-changes-panel";
-import { CODE_DOCK_TABS, codeSessionWorkRoot, type CodeDockSize, type CodeDockTab } from "@/lib/code-surface";
+import {
+  CODE_DOCK_TABS,
+  codeDockTabWantsExpanded,
+  codeSessionWorkRoot,
+  type CodeDockSize,
+  type CodeDockTab,
+} from "@/lib/code-surface";
 import type { PendingCodeOpen } from "@/lib/pending-code-open";
 import type { SessionRow } from "@/lib/types";
 
@@ -39,6 +56,10 @@ const LazyInspector = dynamic(
   () => import("@/components/code-inspector").then((m) => m.CodeInspector),
   { ssr: false },
 );
+const LazyGitHub = dynamic(
+  () => import("@/components/github-view").then((m) => m.GitHubView),
+  { ssr: false },
+);
 const LazyBrowser = dynamic(
   () => import("@/components/browser-pane").then((m) => m.BrowserPane),
   { ssr: false },
@@ -52,7 +73,14 @@ const DOCK_TAB_META: Record<
   files: { label: "Files", icon: "ph:folder-open" },
   pr: { label: "Pull request", icon: "ph:git-pull-request" },
   inspector: { label: "Inspector", icon: "ph:sliders-bold" },
+  github: { label: "GitHub", icon: "ph:github-logo" },
   browser: { label: "Browser", icon: "ph:globe" },
+};
+
+const DOCK_SIZE_ANNOUNCEMENT: Record<CodeDockSize, string> = {
+  collapsed: "Session context collapsed.",
+  normal: "Session context restored.",
+  expanded: "Session context expanded.",
 };
 
 export type CodeContextDockProps = {
@@ -65,6 +93,7 @@ export type CodeContextDockProps = {
   onTabChange: (tab: CodeDockTab) => void;
   onSizeChange: (size: CodeDockSize) => void;
   onRefresh?: () => void;
+  onJumpToSession?: (sessionId: string, familiarId?: string | null) => void;
 };
 
 export function CodeContextDock({
@@ -76,7 +105,9 @@ export function CodeContextDock({
   onTabChange,
   onSizeChange,
   onRefresh,
+  onJumpToSession,
 }: CodeContextDockProps) {
+  const { announce } = useAnnouncer();
   const workRoot = codeSessionWorkRoot(row);
   // Browser keepalive: once opened, keep the pane mounted (hidden) so tabs and
   // scroll position survive a switch to Changes and back.
@@ -87,6 +118,27 @@ export function CodeContextDock({
 
   const collapsed = size === "collapsed";
   const expanded = size === "expanded";
+
+  const changeSize = useCallback(
+    (next: CodeDockSize) => {
+      if (next === size) return;
+      onSizeChange(next);
+      announce(DOCK_SIZE_ANNOUNCEMENT[next]);
+    },
+    [announce, onSizeChange, size],
+  );
+
+  const selectTab = useCallback(
+    (next: CodeDockTab) => {
+      onTabChange(next);
+      // Picking a tab out of a collapsed dock has to reopen it, or the click
+      // looks broken. Browser and GitHub need the room to render at all.
+      if (codeDockTabWantsExpanded(next)) changeSize("expanded");
+      else if (collapsed) changeSize("normal");
+      announce(`${DOCK_TAB_META[next].label} context shown.`);
+    },
+    [announce, changeSize, collapsed, onTabChange],
+  );
 
   return (
     <aside
@@ -110,13 +162,7 @@ export function CodeContextDock({
               aria-selected={tab === id}
               className="focus-ring code-context-dock__tab"
               data-selected={!collapsed && tab === id ? "true" : undefined}
-              onClick={() => {
-                onTabChange(id);
-                // Picking a tab out of a collapsed dock has to reopen it, or
-                // the click looks broken. Browser needs the room to render.
-                if (id === "browser") onSizeChange("expanded");
-                else if (collapsed) onSizeChange("normal");
-              }}
+              onClick={() => selectTab(id)}
             >
               <Icon name={DOCK_TAB_META[id].icon} width={12} height={12} />
               <span className="code-context-dock__tab-label">{DOCK_TAB_META[id].label}</span>
@@ -130,7 +176,7 @@ export function CodeContextDock({
             aria-label={expanded ? "Restore context width" : "Expand context"}
             aria-pressed={expanded}
             title={expanded ? "Restore context width" : "Expand context"}
-            onClick={() => onSizeChange(expanded ? "normal" : "expanded")}
+            onClick={() => changeSize(expanded ? "normal" : "expanded")}
           >
             <Icon
               name={expanded ? "ph:arrows-in-line-horizontal" : "ph:arrows-out-line-horizontal"}
@@ -148,7 +194,7 @@ export function CodeContextDock({
             aria-expanded={!collapsed}
             aria-controls={`code-context-dock-body-${row.id}`}
             title={collapsed ? "Show context" : "Collapse context"}
-            onClick={() => onSizeChange(collapsed ? "normal" : "collapsed")}
+            onClick={() => changeSize(collapsed ? "normal" : "collapsed")}
           >
             <Icon name={collapsed ? "ph:caret-left" : "ph:caret-right"} width={12} height={12} />
           </button>
@@ -178,6 +224,14 @@ export function CodeContextDock({
           ) : null}
           {tab === "pr" ? <LazyPr key={row.id} row={row} /> : null}
           {tab === "inspector" ? <LazyInspector key={workRoot} row={row} onChanged={onRefresh} /> : null}
+          {tab === "github" ? (
+            // No `initialFilter`: unlike the top-level PRs/Issues/Reviews tabs,
+            // the dock is not driving a slice, so the view keeps its own filter
+            // control and the reader picks what they need beside the shell.
+            <div className="code-context-dock__pane">
+              <LazyGitHub onJumpToSession={onJumpToSession} onTasksRefresh={onRefresh} />
+            </div>
+          ) : null}
           {browserOpened ? (
             <div className={tab === "browser" ? "code-context-dock__pane" : "hidden"}>
               <LazyBrowser label={`code:${row.id}`} active={tab === "browser"} />

--- a/src/components/code-context-dock.tsx
+++ b/src/components/code-context-dock.tsx
@@ -130,14 +130,23 @@ export function CodeContextDock({
 
   const selectTab = useCallback(
     (next: CodeDockTab) => {
-      onTabChange(next);
       // Picking a tab out of a collapsed dock has to reopen it, or the click
       // looks broken. Browser and GitHub need the room to render at all.
-      if (codeDockTabWantsExpanded(next)) changeSize("expanded");
-      else if (collapsed) changeSize("normal");
+      const wantedSize: CodeDockSize | null = codeDockTabWantsExpanded(next)
+        ? expanded
+          ? null
+          : "expanded"
+        : collapsed
+          ? "normal"
+          : null;
+      // Re-clicking the active tab when the dock is already sized for it changes
+      // nothing — writing state again would only add live-region noise.
+      if (next === tab && !wantedSize) return;
+      onTabChange(next);
+      if (wantedSize) changeSize(wantedSize);
       announce(`${DOCK_TAB_META[next].label} context shown.`);
     },
-    [announce, changeSize, collapsed, onTabChange],
+    [announce, changeSize, collapsed, expanded, onTabChange, tab],
   );
 
   return (

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -288,6 +288,11 @@ assert.match(
 );
 assert.match(
   contextDock,
+  /import\("@\/components\/github-view"\)/,
+  "GitHub is dynamic() so GitHubView's fetch stack stays out of the Room's initial chunk",
+);
+assert.match(
+  contextDock,
   /<SessionChangesInner\s+key=\{workRoot\}\s+projectRoot=\{workRoot\}\s+running=\{running\}/,
   "Changes mounts the proven changes panel keyed+scoped to the work root",
 );
@@ -298,8 +303,25 @@ assert.match(
 );
 assert.match(
   contextDock,
-  /if \(id === "browser"\) onSizeChange\("expanded"\)/,
-  "Browser opens the dock expanded — a native webview in a sidebar renders unusable wrapped text",
+  /if \(codeDockTabWantsExpanded\(next\)\) changeSize\("expanded"\)/,
+  "the wide tabs (Browser, GitHub) open the dock expanded — a native webview or a list/detail split in a sidebar renders unusable wrapped text",
+);
+// cave-uod42: the dock is the one zone whose content swaps under a stationary
+// cursor, so a change nobody can see must at least be a change somebody hears.
+assert.match(
+  contextDock,
+  /const \{ announce \} = useAnnouncer\(\)/,
+  "the dock announces through the shared live region",
+);
+assert.match(
+  contextDock,
+  /announce\(`\$\{DOCK_TAB_META\[next\]\.label\} context shown\.`\)/,
+  "every tab change is announced by name",
+);
+assert.match(
+  contextDock,
+  /announce\(DOCK_SIZE_ANNOUNCEMENT\[next\]\)/,
+  "every collapse/restore/expand is announced",
 );
 
 // The primary pane must keep the session's shared rail shell, or a shell

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -303,8 +303,15 @@ assert.match(
 );
 assert.match(
   contextDock,
-  /if \(codeDockTabWantsExpanded\(next\)\) changeSize\("expanded"\)/,
+  /codeDockTabWantsExpanded\(next\)[\s\S]{0,80}"expanded"/,
   "the wide tabs (Browser, GitHub) open the dock expanded — a native webview or a list/detail split in a sidebar renders unusable wrapped text",
+);
+// Re-selecting the active tab with the dock already sized for it must not
+// re-announce; a live region that repeats on every click is noise, not feedback.
+assert.match(
+  contextDock,
+  /if \(next === tab && !wantedSize\) return;/,
+  "selecting the already-active tab is a no-op instead of a redundant state write and announcement",
 );
 // cave-uod42: the dock is the one zone whose content swaps under a stationary
 // cursor, so a change nobody can see must at least be a change somebody hears.
@@ -345,6 +352,19 @@ assert.match(
   terminalWorkspace,
   /aria-current=\{isFocused \? "true" : undefined\}/,
   "pane focus is exposed to AT, not signalled by colour alone",
+);
+// Split affordances read the pane they act on. Measuring only the focused pane
+// mis-states every other pane's header buttons, which stay live regardless of
+// where focus sits — and pointer focus is not committed before the click.
+assert.match(
+  terminalWorkspace,
+  /const fits = paneFits\(paneId\);/,
+  "each pane's split buttons use that pane's own measurement",
+);
+assert.match(
+  terminalWorkspace,
+  /const fits = fitsByPaneRef\.current\[paneId\] \?\? DEFAULT_PANE_FITS;/,
+  "the split handler re-checks the target pane's measurement, not the focused pane's",
 );
 assert.match(
   workbenchFiles,

--- a/src/components/code-terminal-workspace.tsx
+++ b/src/components/code-terminal-workspace.tsx
@@ -17,18 +17,36 @@
  * rather than a second PTY API: the focused pane reports what the user typed
  * and this host mirrors it into the other leaves, which is why a broadcast
  * keystroke never echoes back into its source.
+ *
+ * Two guards the count cap does not cover (cave-uod42):
+ *
+ *  - splitting is refused when the focused pane is already too small to halve,
+ *    measured rather than assumed, so a narrow Room never offers a split that
+ *    produces an unreadable shell;
+ *  - the Room's keyboard shortcuts are resolved through a pure module and
+ *    ignored while the user is typing in a real text field, so no binding can
+ *    quietly eat a keystroke meant for a running shell.
  */
 
-import React, { useCallback, useEffect, useMemo, useRef } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { BottomTerminal, type TerminalWriterHandle } from "@/components/bottom-terminal";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import {
+  CODE_ROOM_SHORTCUT_HINTS,
+  isCodeRoomTypingTarget,
+  resolveCodeRoomShortcut,
+} from "@/lib/code-room-shortcuts";
+import {
+  MIN_TERMINAL_PANE_HEIGHT_PX,
+  MIN_TERMINAL_PANE_WIDTH_PX,
   PRIMARY_TERMINAL_PANE_ID,
+  canSplitPaneSize,
   canSplitTerminalPane,
   listTerminalPanes,
+  nextTerminalPaneId,
   terminalBroadcastTargets,
   terminalPaneThreadId,
   type TerminalLayoutNode,
@@ -36,9 +54,10 @@ import {
 
 /** Floors that keep a split pane wide/tall enough to read a shell in. Below
  *  these a terminal wraps into letter soup, so the divider stops rather than
- *  producing a pane nobody can use. */
-const MIN_PANE_WIDTH = "220px";
-const MIN_PANE_HEIGHT = "120px";
+ *  producing a pane nobody can use. Derived from the model's numbers so the
+ *  divider stop and the disabled split button cannot drift apart. */
+const MIN_PANE_WIDTH = `${MIN_TERMINAL_PANE_WIDTH_PX}px`;
+const MIN_PANE_HEIGHT = `${MIN_TERMINAL_PANE_HEIGHT_PX}px`;
 
 export type CodeTerminalWorkspaceProps = {
   sessionId: string;
@@ -69,7 +88,41 @@ export function CodeTerminalWorkspace({
   const { announce } = useAnnouncer();
   const panes = useMemo(() => listTerminalPanes(layout), [layout]);
   const paneCount = panes.length;
-  const canSplit = canSplitTerminalPane(layout);
+  const underPaneCap = canSplitTerminalPane(layout);
+
+  // Measured split capacity. The count cap alone lets a 380px Room offer a
+  // split that produces two unreadable shells, so the affordance also asks the
+  // focused pane whether it can survive being halved.
+  const paneElsRef = useRef(new Map<string, HTMLElement>());
+  const [fits, setFits] = useState({ right: true, down: true });
+  useEffect(() => {
+    const el = paneElsRef.current.get(focusedPaneId);
+    if (!el || typeof ResizeObserver === "undefined") {
+      // Unmeasurable is not the same as too small: leaving the control enabled
+      // keeps a server-rendered or test environment from showing a disabled
+      // button that never re-enables.
+      setFits({ right: true, down: true });
+      return;
+    }
+    const read = () => {
+      const rect = el.getBoundingClientRect();
+      const next = {
+        right: canSplitPaneSize(rect, "horizontal"),
+        down: canSplitPaneSize(rect, "vertical"),
+      };
+      setFits((prev) => (prev.right === next.right && prev.down === next.down ? prev : next));
+    };
+    read();
+    const observer = new ResizeObserver(read);
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [focusedPaneId, layout]);
+
+  const canSplitRight = underPaneCap && fits.right;
+  const canSplitDown = underPaneCap && fits.down;
+  const splitBlockedTitle = underPaneCap
+    ? "Not enough room to split"
+    : "Terminal limit reached";
 
   // One writer handle per live pane. A plain ref map (not state) — registering
   // a writer must not re-render the pane that just mounted.
@@ -97,14 +150,18 @@ export function CodeTerminalWorkspace({
 
   const handleSplit = useCallback(
     (paneId: string, direction: "horizontal" | "vertical") => {
-      if (!canSplit) {
+      if (!canSplitTerminalPane(layoutRef.current)) {
         announce("Terminal limit reached. Close a terminal before splitting again.");
+        return;
+      }
+      if (!(direction === "horizontal" ? fits.right : fits.down)) {
+        announce("Not enough room to split this terminal.");
         return;
       }
       onSplit(paneId, direction);
       announce(direction === "horizontal" ? "Terminal split right." : "Terminal split down.");
     },
-    [announce, canSplit, onSplit],
+    [announce, fits.down, fits.right, onSplit],
   );
 
   const handleClose = useCallback(
@@ -120,6 +177,64 @@ export function CodeTerminalWorkspace({
     announce(broadcastRef.current ? "Broadcast input off." : "Broadcast input on.");
   }, [announce, onToggleBroadcast]);
 
+  const handleCycleFocus = useCallback(
+    (step: 1 | -1) => {
+      const nextId = nextTerminalPaneId(layoutRef.current, focusedPaneId, step);
+      if (nextId === focusedPaneId) return;
+      onFocusPane(nextId);
+      const label =
+        listTerminalPanes(layoutRef.current).find((pane) => pane.id === nextId)?.label ??
+        "Terminal";
+      announce(`${label} focused.`);
+    },
+    [announce, focusedPaneId, onFocusPane],
+  );
+
+  // Room shortcuts live on the workspace container, not on `window`: the Room
+  // can sit beside other surfaces, and a global listener would fire from them.
+  // Events bubble here from xterm's hidden textarea, which is why the typing
+  // guard has to make an exception for it rather than checking the tag name.
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const shortcut = resolveCodeRoomShortcut(event);
+      if (!shortcut) return;
+      if (isCodeRoomTypingTarget(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+      switch (shortcut) {
+        case "focus-next-terminal":
+          handleCycleFocus(1);
+          return;
+        case "focus-previous-terminal":
+          handleCycleFocus(-1);
+          return;
+        case "split-right":
+          handleSplit(focusedPaneId, "horizontal");
+          return;
+        case "split-down":
+          handleSplit(focusedPaneId, "vertical");
+          return;
+        case "close-terminal":
+          if (focusedPaneId === PRIMARY_TERMINAL_PANE_ID) {
+            announce("The primary terminal cannot be closed.");
+            return;
+          }
+          handleClose(focusedPaneId);
+          return;
+        case "toggle-broadcast":
+          // Broadcast with one pane has no targets; the button is disabled
+          // there, so the shortcut has to refuse too rather than leave a
+          // pressed toggle that does nothing.
+          if (listTerminalPanes(layoutRef.current).length < 2) {
+            announce("Broadcast needs a second terminal.");
+            return;
+          }
+          handleToggleBroadcast();
+      }
+    },
+    [announce, focusedPaneId, handleClose, handleCycleFocus, handleSplit, handleToggleBroadcast],
+  );
+
   const renderLeaf = (paneId: string) => {
     const descriptor = panes.find((pane) => pane.id === paneId);
     const label = descriptor?.label ?? "Terminal";
@@ -128,12 +243,17 @@ export function CodeTerminalWorkspace({
     return (
       <section
         aria-label={label}
-        // Focus is a border weight + an explicit aria-current, never colour
-        // alone — the split is unreadable to anyone who can't see the tint.
+        // Focus is a border tint + a "Focused" chip + an explicit aria-current,
+        // never colour alone — the split is unreadable to anyone who can't see
+        // the tint.
         aria-current={isFocused ? "true" : undefined}
         data-focused={isFocused ? "true" : undefined}
         data-testid="code-terminal-pane"
         className="code-terminal-pane"
+        ref={(el) => {
+          if (el) paneElsRef.current.set(paneId, el);
+          else paneElsRef.current.delete(paneId);
+        }}
         onFocusCapture={() => onFocusPane(paneId)}
         onPointerDownCapture={() => onFocusPane(paneId)}
       >
@@ -146,8 +266,8 @@ export function CodeTerminalWorkspace({
                 type="button"
                 className="focus-ring code-terminal-pane__action"
                 aria-label={`Split ${label} right`}
-                title="Split right"
-                disabled={!canSplit}
+                title={canSplitRight ? "Split right" : splitBlockedTitle}
+                disabled={!canSplitRight}
                 onClick={() => handleSplit(paneId, "horizontal")}
               >
                 <Icon name="ph:columns" width={12} height={12} />
@@ -156,8 +276,8 @@ export function CodeTerminalWorkspace({
                 type="button"
                 className="focus-ring code-terminal-pane__action"
                 aria-label={`Split ${label} down`}
-                title="Split down"
-                disabled={!canSplit}
+                title={canSplitDown ? "Split down" : splitBlockedTitle}
+                disabled={!canSplitDown}
                 onClick={() => handleSplit(paneId, "vertical")}
               >
                 <Icon name="ph:rows" width={12} height={12} />
@@ -167,7 +287,7 @@ export function CodeTerminalWorkspace({
                   type="button"
                   className="focus-ring code-terminal-pane__action"
                   aria-label={`Close ${label}`}
-                  title="Close terminal"
+                  title={`Close terminal (${CODE_ROOM_SHORTCUT_HINTS["close-terminal"]})`}
                   onClick={() => handleClose(paneId)}
                 >
                   <Icon name="ph:x" width={12} height={12} />
@@ -222,7 +342,11 @@ export function CodeTerminalWorkspace({
   };
 
   return (
-    <div className="code-terminal-workspace" data-testid="code-terminal-workspace">
+    <div
+      className="code-terminal-workspace"
+      data-testid="code-terminal-workspace"
+      onKeyDown={handleKeyDown}
+    >
       <div className="code-terminal-workspace__bar">
         <span className="code-terminal-workspace__count">
           {paneCount === 1 ? "1 terminal" : `${paneCount} terminals`}
@@ -232,8 +356,12 @@ export function CodeTerminalWorkspace({
             type="button"
             className="focus-ring code-terminal-workspace__action"
             aria-label="Split terminal right"
-            title={canSplit ? "Split right" : "Terminal limit reached"}
-            disabled={!canSplit}
+            title={
+              canSplitRight
+                ? `Split right (${CODE_ROOM_SHORTCUT_HINTS["split-right"]})`
+                : splitBlockedTitle
+            }
+            disabled={!canSplitRight}
             onClick={() => handleSplit(focusedPaneId, "horizontal")}
           >
             <Icon name="ph:columns" width={12} height={12} />
@@ -243,8 +371,12 @@ export function CodeTerminalWorkspace({
             type="button"
             className="focus-ring code-terminal-workspace__action"
             aria-label="Split terminal down"
-            title={canSplit ? "Split down" : "Terminal limit reached"}
-            disabled={!canSplit}
+            title={
+              canSplitDown
+                ? `Split down (${CODE_ROOM_SHORTCUT_HINTS["split-down"]})`
+                : splitBlockedTitle
+            }
+            disabled={!canSplitDown}
             onClick={() => handleSplit(focusedPaneId, "vertical")}
           >
             <Icon name="ph:rows" width={12} height={12} />
@@ -258,7 +390,7 @@ export function CodeTerminalWorkspace({
             // would leave a pressed toggle that does nothing.
             disabled={paneCount < 2}
             aria-label={broadcast ? "Turn off broadcast input" : "Turn on broadcast input"}
-            title="Type once, send to every terminal"
+            title={`Type once, send to every terminal (${CODE_ROOM_SHORTCUT_HINTS["toggle-broadcast"]})`}
             onClick={handleToggleBroadcast}
           >
             <Icon name="ph:broadcast" width={12} height={12} />

--- a/src/components/code-terminal-workspace.tsx
+++ b/src/components/code-terminal-workspace.tsx
@@ -59,6 +59,18 @@ import {
 const MIN_PANE_WIDTH = `${MIN_TERMINAL_PANE_WIDTH_PX}px`;
 const MIN_PANE_HEIGHT = `${MIN_TERMINAL_PANE_HEIGHT_PX}px`;
 
+type PaneFits = { right: boolean; down: boolean };
+const DEFAULT_PANE_FITS: PaneFits = { right: true, down: true };
+
+function samePaneFits(a: Record<string, PaneFits>, b: Record<string, PaneFits>) {
+  const keys = Object.keys(b);
+  if (Object.keys(a).length !== keys.length) return false;
+  return keys.every((key) => {
+    const prev = a[key];
+    return prev !== undefined && prev.right === b[key].right && prev.down === b[key].down;
+  });
+}
+
 export type CodeTerminalWorkspaceProps = {
   sessionId: string;
   projectRoot: string | null;
@@ -90,36 +102,53 @@ export function CodeTerminalWorkspace({
   const paneCount = panes.length;
   const underPaneCap = canSplitTerminalPane(layout);
 
-  // Measured split capacity. The count cap alone lets a 380px Room offer a
-  // split that produces two unreadable shells, so the affordance also asks the
-  // focused pane whether it can survive being halved.
+  // Measured split capacity, per pane. The count cap alone lets a 380px Room
+  // offer a split that produces two unreadable shells, so the affordance also
+  // asks the pane being split whether it can survive being halved. Measuring
+  // only the focused pane would mis-state every other pane's own header
+  // buttons, which stay live whether or not that pane holds focus.
   const paneElsRef = useRef(new Map<string, HTMLElement>());
-  const [fits, setFits] = useState({ right: true, down: true });
+  const [fitsByPane, setFitsByPane] = useState<Record<string, PaneFits>>({});
+  const fitsByPaneRef = useRef(fitsByPane);
+  fitsByPaneRef.current = fitsByPane;
   useEffect(() => {
-    const el = paneElsRef.current.get(focusedPaneId);
-    if (!el || typeof ResizeObserver === "undefined") {
-      // Unmeasurable is not the same as too small: leaving the control enabled
-      // keeps a server-rendered or test environment from showing a disabled
-      // button that never re-enables.
-      setFits({ right: true, down: true });
+    if (typeof ResizeObserver === "undefined") {
+      setFitsByPane({});
       return;
     }
     const read = () => {
-      const rect = el.getBoundingClientRect();
-      const next = {
-        right: canSplitPaneSize(rect, "horizontal"),
-        down: canSplitPaneSize(rect, "vertical"),
-      };
-      setFits((prev) => (prev.right === next.right && prev.down === next.down ? prev : next));
+      const next: Record<string, PaneFits> = {};
+      for (const pane of panes) {
+        const el = paneElsRef.current.get(pane.id);
+        if (!el) continue;
+        const rect = el.getBoundingClientRect();
+        next[pane.id] = {
+          right: canSplitPaneSize(rect, "horizontal"),
+          down: canSplitPaneSize(rect, "vertical"),
+        };
+      }
+      setFitsByPane((prev) => (samePaneFits(prev, next) ? prev : next));
     };
     read();
     const observer = new ResizeObserver(read);
-    observer.observe(el);
+    for (const pane of panes) {
+      const el = paneElsRef.current.get(pane.id);
+      if (el) observer.observe(el);
+    }
     return () => observer.disconnect();
-  }, [focusedPaneId, layout]);
+  }, [panes]);
 
-  const canSplitRight = underPaneCap && fits.right;
-  const canSplitDown = underPaneCap && fits.down;
+  // Unmeasurable is not the same as too small: an unknown pane stays enabled so
+  // a server-rendered or test environment never shows a control that latches
+  // disabled and never re-enables.
+  const paneFits = useCallback(
+    (paneId: string): PaneFits => fitsByPane[paneId] ?? DEFAULT_PANE_FITS,
+    [fitsByPane],
+  );
+
+  const focusedFits = paneFits(focusedPaneId);
+  const canSplitRight = underPaneCap && focusedFits.right;
+  const canSplitDown = underPaneCap && focusedFits.down;
   const splitBlockedTitle = underPaneCap
     ? "Not enough room to split"
     : "Terminal limit reached";
@@ -154,6 +183,7 @@ export function CodeTerminalWorkspace({
         announce("Terminal limit reached. Close a terminal before splitting again.");
         return;
       }
+      const fits = fitsByPaneRef.current[paneId] ?? DEFAULT_PANE_FITS;
       if (!(direction === "horizontal" ? fits.right : fits.down)) {
         announce("Not enough room to split this terminal.");
         return;
@@ -161,7 +191,7 @@ export function CodeTerminalWorkspace({
       onSplit(paneId, direction);
       announce(direction === "horizontal" ? "Terminal split right." : "Terminal split down.");
     },
-    [announce, fits.down, fits.right, onSplit],
+    [announce, onSplit],
   );
 
   const handleClose = useCallback(
@@ -240,6 +270,11 @@ export function CodeTerminalWorkspace({
     const label = descriptor?.label ?? "Terminal";
     const isFocused = paneId === focusedPaneId;
     const isPrimary = paneId === PRIMARY_TERMINAL_PANE_ID;
+    // This pane's own measurement, not the focused pane's — its header buttons
+    // act on itself regardless of where focus currently sits.
+    const fits = paneFits(paneId);
+    const paneCanSplitRight = underPaneCap && fits.right;
+    const paneCanSplitDown = underPaneCap && fits.down;
     return (
       <section
         aria-label={label}
@@ -266,8 +301,8 @@ export function CodeTerminalWorkspace({
                 type="button"
                 className="focus-ring code-terminal-pane__action"
                 aria-label={`Split ${label} right`}
-                title={canSplitRight ? "Split right" : splitBlockedTitle}
-                disabled={!canSplitRight}
+                title={paneCanSplitRight ? "Split right" : splitBlockedTitle}
+                disabled={!paneCanSplitRight}
                 onClick={() => handleSplit(paneId, "horizontal")}
               >
                 <Icon name="ph:columns" width={12} height={12} />
@@ -276,8 +311,8 @@ export function CodeTerminalWorkspace({
                 type="button"
                 className="focus-ring code-terminal-pane__action"
                 aria-label={`Split ${label} down`}
-                title={canSplitDown ? "Split down" : splitBlockedTitle}
-                disabled={!canSplitDown}
+                title={paneCanSplitDown ? "Split down" : splitBlockedTitle}
+                disabled={!paneCanSplitDown}
                 onClick={() => handleSplit(paneId, "vertical")}
               >
                 <Icon name="ph:rows" width={12} height={12} />

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -7,12 +7,14 @@
  *
  * Phase 3+ (this shape): top-level Sessions/Activity/PRs/Issues/Reviews tabs, the session rail
  * (grouped by project, git-attribution badges, + New session) and the
- * per-session workbench (Diff | Files | Terminal | PR) with the follow-up
- * composer (code-composer.tsx). New sessions start via code-new-session.tsx —
- * project + familiar + optional fresh worktree. The inspector and mobile
- * layout land in follow-up PRs. CodeView hosts the whole GitHubView under the
- * Activity/PRs/Issues/Reviews tabs; workspace routing lives outside this
- * component.
+ * per-session Coding Room — a persistent terminal center beside a resizable
+ * context dock (Changes | Files | Pull request | Inspector | GitHub | Browser)
+ * with the follow-up composer (code-composer.tsx) under both. New sessions
+ * start via code-new-session.tsx — project + familiar + optional fresh
+ * worktree. CodeView hosts the whole GitHubView under the
+ * Activity/PRs/Issues/Reviews tabs; the dock's GitHub tab mounts a second,
+ * session-scoped copy so triage never has to displace a running shell.
+ * Workspace routing lives outside this component.
  */
 
 import { useEffect, useMemo, useRef, useState } from "react";

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -210,6 +210,7 @@ export function CodeWorkbench({
               onTabChange={setDockTab}
               onSizeChange={setDockSize}
               onRefresh={onRefresh}
+              onJumpToSession={onJumpToSession}
             />
           </Panel>
         </Group>

--- a/src/lib/code-room-shortcuts.test.ts
+++ b/src/lib/code-room-shortcuts.test.ts
@@ -1,0 +1,155 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  CODE_ROOM_SHORTCUT_HINTS,
+  isCodeRoomTypingTarget,
+  resolveCodeRoomShortcut,
+} from "./code-room-shortcuts.ts";
+
+/** A keypress descriptor with every modifier off unless named. */
+function press(key, mods = {}) {
+  return {
+    key,
+    shiftKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    ...mods,
+  };
+}
+
+const MOD_SHIFT = { shiftKey: true, metaKey: true };
+
+// ── Every advertised binding resolves ────────────────────────────────────────
+{
+  const expected = [
+    ["ArrowRight", "focus-next-terminal"],
+    ["ArrowLeft", "focus-previous-terminal"],
+    ["D", "split-right"],
+    ["E", "split-down"],
+    ["X", "close-terminal"],
+    ["B", "toggle-broadcast"],
+  ];
+  for (const [key, shortcut] of expected) {
+    assert.equal(resolveCodeRoomShortcut(press(key, MOD_SHIFT)), shortcut, `⇧⌘${key}`);
+    // Layout and caps-lock must not change the answer.
+    assert.equal(
+      resolveCodeRoomShortcut(press(key.toLowerCase(), MOD_SHIFT)),
+      shortcut,
+      `⇧⌘${key} lowercased`,
+    );
+    // Ctrl is the Windows/Linux half of the same binding.
+    assert.equal(
+      resolveCodeRoomShortcut(press(key, { shiftKey: true, ctrlKey: true })),
+      shortcut,
+      `⇧⌃${key}`,
+    );
+  }
+  assert.equal(
+    Object.keys(CODE_ROOM_SHORTCUT_HINTS).length,
+    expected.length,
+    "every hint corresponds to a wired binding, and vice versa",
+  );
+  for (const [, shortcut] of expected) {
+    assert.ok(CODE_ROOM_SHORTCUT_HINTS[shortcut], `${shortcut} advertises a hint`);
+  }
+}
+
+// ── The negatives, which are the point ───────────────────────────────────────
+// A Room binding that fires without its modifiers would eat characters out of
+// a running shell, so each of these has to stay null.
+{
+  assert.equal(resolveCodeRoomShortcut(press("d")), null, "a bare letter is shell input");
+  assert.equal(
+    resolveCodeRoomShortcut(press("d", { ctrlKey: true })),
+    null,
+    "bare Ctrl is shell signal territory",
+  );
+  assert.equal(
+    resolveCodeRoomShortcut(press("d", { metaKey: true })),
+    null,
+    "Shift is required, so ⌘D stays free",
+  );
+  assert.equal(
+    resolveCodeRoomShortcut(press("d", { shiftKey: true })),
+    null,
+    "Shift alone is a capital D",
+  );
+  assert.equal(
+    resolveCodeRoomShortcut(press("d", { ...MOD_SHIFT, altKey: true })),
+    null,
+    "Alt belongs to the terminal's escape sequences",
+  );
+  assert.equal(resolveCodeRoomShortcut(press("q", MOD_SHIFT)), null, "an unbound letter");
+  assert.equal(resolveCodeRoomShortcut(press("ArrowUp", MOD_SHIFT)), null);
+}
+
+// ── The typing guard ─────────────────────────────────────────────────────────
+// Only meaningful in a DOM; the resolver half above runs everywhere.
+if (typeof document !== "undefined") {
+  const input = document.createElement("input");
+  assert.equal(isCodeRoomTypingTarget(input), true);
+  const textarea = document.createElement("textarea");
+  assert.equal(isCodeRoomTypingTarget(textarea), true);
+
+  const editable = document.createElement("div");
+  editable.contentEditable = "true";
+  assert.equal(isCodeRoomTypingTarget(editable), true);
+
+  const plain = document.createElement("div");
+  assert.equal(isCodeRoomTypingTarget(plain), false);
+  assert.equal(isCodeRoomTypingTarget(null), false);
+
+  // xterm renders a hidden textarea — treating it as "typing" would disable
+  // every Room shortcut exactly where they are supposed to work.
+  const term = document.createElement("div");
+  term.className = "xterm";
+  const helper = document.createElement("textarea");
+  term.appendChild(helper);
+  assert.equal(isCodeRoomTypingTarget(helper), false, "xterm's helper textarea is not prose");
+}
+
+// ── Source contract: the bindings are actually wired ────────────────────────
+// The shortcuts sheet was once purged wholesale (cave-7c9i) because its
+// "Terminal & panes" group named combos no mounted component handled. A pure
+// resolver nothing calls would reproduce exactly that, so pin the consumer.
+{
+  const workspace = readFileSync(
+    new URL("../components/code-terminal-workspace.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(workspace, /resolveCodeRoomShortcut\(event\)/, "the workspace resolves keydowns");
+  assert.match(
+    workspace,
+    /isCodeRoomTypingTarget\(event\.target\)/,
+    "and refuses to fire from a text field",
+  );
+  assert.match(workspace, /onKeyDown=\{handleKeyDown\}/, "and the handler is mounted");
+  assert.match(
+    workspace,
+    /case "toggle-broadcast":/,
+    "every branch of the union has a case",
+  );
+  for (const shortcut of Object.keys(CODE_ROOM_SHORTCUT_HINTS)) {
+    assert.ok(workspace.includes(`case "${shortcut}"`), `${shortcut} is handled`);
+  }
+
+  const sheet = readFileSync(new URL("./keyboard-shortcuts.ts", import.meta.url), "utf8");
+  for (const hint of Object.values(CODE_ROOM_SHORTCUT_HINTS)) {
+    assert.ok(sheet.includes(hint), `${hint} is advertised in the shortcuts sheet`);
+  }
+}
+
+// ── Source contract: the dock announces its changes ─────────────────────────
+{
+  const dock = readFileSync(
+    new URL("../components/code-context-dock.tsx", import.meta.url),
+    "utf8",
+  );
+  assert.match(dock, /useAnnouncer\(\)/, "the dock swaps content under a stationary cursor");
+  assert.match(dock, /context shown\./, "tab changes are announced");
+  assert.match(dock, /DOCK_SIZE_ANNOUNCEMENT/, "size changes are announced");
+}
+
+console.log("code-room-shortcuts.test.ts ok");

--- a/src/lib/code-room-shortcuts.ts
+++ b/src/lib/code-room-shortcuts.ts
@@ -1,0 +1,92 @@
+/**
+ * Coding Room keyboard shortcuts (cave-uod42).
+ *
+ * The Room's approved design asks for five bindings — focus next terminal,
+ * split right, split down, close pane, toggle broadcast — and adds one hard
+ * constraint: "Shortcuts do not fire from text inputs outside xterm."
+ *
+ * Why a pure resolver rather than an inline keydown block: the Room's center is
+ * a terminal, so the cost of getting a combo wrong is a keystroke silently
+ * eaten from a running shell. Keeping the mapping data lets a test enumerate
+ * every combo and assert the negatives — plain letters, bare Ctrl, and typing
+ * targets — which is the half that a hand-rolled handler never covers.
+ *
+ * Modifier choice: every binding is Cmd/Ctrl **plus Shift**. Bare Ctrl+letter
+ * is shell signal territory (Ctrl+C, Ctrl+D) and Alt+letter is an escape
+ * sequence, so both would collide with the surface these shortcuts control.
+ * Ctrl/Cmd+Shift+letter emits nothing on any terminal transport we ship, and
+ * no ⇧⌘ combo exists anywhere else in the app's catalog.
+ */
+
+export type CodeRoomShortcut =
+  | "focus-next-terminal"
+  | "focus-previous-terminal"
+  | "split-right"
+  | "split-down"
+  | "close-terminal"
+  | "toggle-broadcast";
+
+/** The subset of KeyboardEvent this resolver reads — so tests (and non-DOM
+ *  callers) can describe a keypress without constructing a real event. */
+export type CodeRoomKeyDescriptor = {
+  key: string;
+  shiftKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+};
+
+const BINDINGS: ReadonlyArray<{ key: string; shortcut: CodeRoomShortcut }> = [
+  { key: "arrowright", shortcut: "focus-next-terminal" },
+  { key: "arrowleft", shortcut: "focus-previous-terminal" },
+  { key: "d", shortcut: "split-right" },
+  { key: "e", shortcut: "split-down" },
+  { key: "x", shortcut: "close-terminal" },
+  { key: "b", shortcut: "toggle-broadcast" },
+];
+
+/** Mac-canonical hints for the shortcuts sheet and button tooltips. Kept beside
+ *  the bindings so the advertised combo and the wired one move together. */
+export const CODE_ROOM_SHORTCUT_HINTS: Record<CodeRoomShortcut, string> = {
+  "focus-next-terminal": "⇧⌘→",
+  "focus-previous-terminal": "⇧⌘←",
+  "split-right": "⇧⌘D",
+  "split-down": "⇧⌘E",
+  "close-terminal": "⇧⌘X",
+  "toggle-broadcast": "⇧⌘B",
+};
+
+/** Does this element swallow the shortcut because the user is writing prose?
+ *
+ * xterm is the deliberate exception: it renders a hidden `textarea`, so a naive
+ * "is this a text field?" test would disable every Room shortcut precisely
+ * where they matter most. The terminal marks its own subtree, and we honour
+ * that marker over the tag name. */
+export function isCodeRoomTypingTarget(target: EventTarget | null): boolean {
+  // Duck-typed rather than `instanceof HTMLElement`: this module is imported by
+  // a plain Node test runner where that global does not exist, and an
+  // exception thrown on the keydown hot path would be a worse bug than any it
+  // could catch.
+  const el = target as HTMLElement | null;
+  if (!el || typeof el.tagName !== "string") return false;
+  if (typeof el.closest === "function" && el.closest(".xterm")) return false;
+  if (el.isContentEditable) return true;
+  const tag = el.tagName.toLowerCase();
+  return tag === "input" || tag === "textarea" || tag === "select";
+}
+
+/** The Room action for a keypress, or null when the event is not ours.
+ *
+ * Returns null rather than throwing for every non-match, because this runs on
+ * the hot path of every keystroke typed into a shell. */
+export function resolveCodeRoomShortcut(
+  event: CodeRoomKeyDescriptor,
+): CodeRoomShortcut | null {
+  // Alt is reserved for the terminal's own escape sequences; a combo that
+  // includes it is meant for the shell, not the Room.
+  if (event.altKey) return null;
+  if (!event.shiftKey) return null;
+  if (!event.metaKey && !event.ctrlKey) return null;
+  const key = event.key.toLowerCase();
+  return BINDINGS.find((binding) => binding.key === key)?.shortcut ?? null;
+}

--- a/src/lib/code-surface.test.ts
+++ b/src/lib/code-surface.test.ts
@@ -13,6 +13,7 @@ import {
   isCodeDockTab,
   codeDockTabForWorkbenchTab,
   CODE_DOCK_TABS,
+  codeDockTabWantsExpanded,
   CODE_DOCK_SIZES,
   normalizeCodeTopTab,
   parseCodeDeepLink,
@@ -160,6 +161,11 @@ test("normalizeCodeTopTab maps legacy + unknown values", () => {
 
 test("dock tabs are a fixed vocabulary distinct from the retired workbench tabs", () => {
   for (const tab of CODE_DOCK_TABS) assert.ok(isCodeDockTab(tab));
+  assert.deepEqual(
+    [...CODE_DOCK_TABS],
+    ["changes", "files", "pr", "inspector", "github", "browser"],
+    "the approved dock, in tab order",
+  );
   assert.ok(!isCodeDockTab("terminal"), "the terminal is the center zone, never a dock tab");
   assert.ok(!isCodeDockTab("diff"), "diff was renamed to changes in the Room");
   assert.ok(!isCodeDockTab(null));
@@ -183,4 +189,14 @@ test("legacy ?wtab= deep links resolve onto the dock", () => {
 
 test("dock sizes are ordered widest-last so collapse/expand steps through them", () => {
   assert.deepEqual([...CODE_DOCK_SIZES], ["collapsed", "normal", "expanded"]);
+});
+
+// Some dock tabs are illegible at sidebar width, so selecting one has to widen
+// the dock rather than render something nobody can use.
+test("only the wide tabs force the dock open expanded", () => {
+  assert.ok(codeDockTabWantsExpanded("browser"), "a native webview needs the room");
+  assert.ok(codeDockTabWantsExpanded("github"), "a list/detail split needs the room");
+  for (const tab of ["changes", "files", "pr", "inspector"] as const) {
+    assert.ok(!codeDockTabWantsExpanded(tab), `${tab} reads fine at normal width`);
+  }
 });

--- a/src/lib/code-surface.ts
+++ b/src/lib/code-surface.ts
@@ -22,7 +22,14 @@ export function isCodeWorkbenchTab(value: string | null | undefined): value is C
  * whole point of the redesign: diffs and files sit BESIDE a running shell
  * instead of competing with it for one canvas.
  */
-export const CODE_DOCK_TABS = ["changes", "files", "pr", "inspector", "browser"] as const;
+export const CODE_DOCK_TABS = [
+  "changes",
+  "files",
+  "pr",
+  "inspector",
+  "github",
+  "browser",
+] as const;
 export type CodeDockTab = (typeof CODE_DOCK_TABS)[number];
 
 export function isCodeDockTab(value: string | null | undefined): value is CodeDockTab {
@@ -44,11 +51,18 @@ export function codeDockTabForWorkbenchTab(
   return null;
 }
 
-/** How much room the context dock takes beside the terminal center. Browser
- *  opens `expanded` because a native webview squeezed into a sidebar renders a
- *  column of wrapped text nobody can use. */
+/** How much room the context dock takes beside the terminal center. Browser and
+ *  GitHub open `expanded` because a native webview — or a list/detail split —
+ *  squeezed into a sidebar renders a column of wrapped text nobody can use. */
 export const CODE_DOCK_SIZES = ["collapsed", "normal", "expanded"] as const;
 export type CodeDockSize = (typeof CODE_DOCK_SIZES)[number];
+
+/** Dock tabs that need the expanded width to be legible at all. Selecting one
+ *  from a normal or collapsed dock widens it rather than rendering something
+ *  unusable. */
+export function codeDockTabWantsExpanded(tab: CodeDockTab): boolean {
+  return tab === "browser" || tab === "github";
+}
 
 /** Top-level surface tabs: the session workbench plus Activity (the former
  *  all-content GitHub feed) and focused GitHub slices. Legacy `ctab=github`

--- a/src/lib/code-terminal-tree.test.ts
+++ b/src/lib/code-terminal-tree.test.ts
@@ -3,11 +3,15 @@ import assert from "node:assert/strict";
 import {
   MAX_TERMINAL_PANES,
   PRIMARY_TERMINAL_PANE_ID,
+  MIN_TERMINAL_PANE_HEIGHT_PX,
+  MIN_TERMINAL_PANE_WIDTH_PX,
+  canSplitPaneSize,
   canSplitTerminalPane,
   closeTerminalPane,
   countTerminalPanes,
   createTerminalLayout,
   listTerminalPanes,
+  nextTerminalPaneId,
   resolveFocusedPane,
   splitTerminalPane,
   terminalBroadcastTargets,
@@ -147,6 +151,45 @@ assert.notEqual(
   assert.equal(resolveFocusedPane(split, "p1"), "p1");
   assert.equal(resolveFocusedPane(split, "gone"), PRIMARY_TERMINAL_PANE_ID);
   assert.equal(resolveFocusedPane(split, null), PRIMARY_TERMINAL_PANE_ID);
+}
+
+// ── Measured split capacity (cave-uod42) ─────────────────────────────────────
+// The count cap is not enough: a 380px Room is under the floor at TWO panes.
+{
+  const wide = { width: MIN_TERMINAL_PANE_WIDTH_PX * 2, height: MIN_TERMINAL_PANE_HEIGHT_PX * 2 };
+  assert.equal(canSplitPaneSize(wide, "horizontal"), true, "exactly twice the floor still splits");
+  assert.equal(canSplitPaneSize(wide, "vertical"), true);
+
+  const narrow = { width: MIN_TERMINAL_PANE_WIDTH_PX * 2 - 1, height: 1000 };
+  assert.equal(canSplitPaneSize(narrow, "horizontal"), false, "one px under the floor refuses");
+  assert.equal(canSplitPaneSize(narrow, "vertical"), true, "the other axis is untouched by the split");
+
+  const short = { width: 1000, height: MIN_TERMINAL_PANE_HEIGHT_PX * 2 - 1 };
+  assert.equal(canSplitPaneSize(short, "vertical"), false);
+  assert.equal(canSplitPaneSize(short, "horizontal"), true);
+
+  // Unmeasured must not present a control that never re-enables.
+  assert.equal(canSplitPaneSize({ width: 0, height: 0 }, "horizontal"), true);
+  assert.equal(canSplitPaneSize({ width: Number.NaN, height: 0 }, "horizontal"), true);
+}
+
+// ── Focus cycling follows reading order and wraps ────────────────────────────
+{
+  const next = idFactory();
+  const a = splitTerminalPane(fresh, PRIMARY_TERMINAL_PANE_ID, "horizontal", next).layout;
+  const b = splitTerminalPane(a, "p1", "vertical", next).layout;
+  const order = listTerminalPanes(b).map((pane) => pane.id);
+  assert.deepEqual(order, [PRIMARY_TERMINAL_PANE_ID, "p1", "p2"]);
+
+  assert.equal(nextTerminalPaneId(b, PRIMARY_TERMINAL_PANE_ID), "p1");
+  assert.equal(nextTerminalPaneId(b, "p2"), PRIMARY_TERMINAL_PANE_ID, "wraps forward");
+  assert.equal(nextTerminalPaneId(b, PRIMARY_TERMINAL_PANE_ID, -1), "p2", "wraps backward");
+  assert.equal(nextTerminalPaneId(b, "gone"), PRIMARY_TERMINAL_PANE_ID, "a stale id lands somewhere real");
+  assert.equal(
+    nextTerminalPaneId(fresh, PRIMARY_TERMINAL_PANE_ID),
+    PRIMARY_TERMINAL_PANE_ID,
+    "alone, next is a no-op rather than a throw",
+  );
 }
 
 console.log("code-terminal-tree.test.ts ok");

--- a/src/lib/code-terminal-tree.ts
+++ b/src/lib/code-terminal-tree.ts
@@ -25,6 +25,45 @@ export const MAX_TERMINAL_PANES = 4;
  *  session's shared `cave.rail.<sessionId>` PTY. */
 export const PRIMARY_TERMINAL_PANE_ID = "primary";
 
+/** Floors that keep a pane wide/tall enough to read a shell in. The count cap
+ *  above is not sufficient on its own: two panes in a 380px Room are already
+ *  unusable, so the affordance also has to answer "would THIS split produce a
+ *  pane below the floor?". The CSS `minSize` strings are derived from these so
+ *  the divider stop and the disabled button can never disagree. */
+export const MIN_TERMINAL_PANE_WIDTH_PX = 220;
+export const MIN_TERMINAL_PANE_HEIGHT_PX = 120;
+
+/** Would splitting a pane of this size leave both halves above the floor?
+ *  A split halves the axis it runs along and leaves the other axis untouched,
+ *  so only the split axis is checked. Zero/unmeasured sizes pass: an unmounted
+ *  or not-yet-measured pane must not present a disabled control that never
+ *  re-enables. */
+export function canSplitPaneSize(
+  size: { width: number; height: number },
+  direction: TerminalSplitDirection,
+): boolean {
+  const axis = direction === "horizontal" ? size.width : size.height;
+  if (!Number.isFinite(axis) || axis <= 0) return true;
+  const floor =
+    direction === "horizontal" ? MIN_TERMINAL_PANE_WIDTH_PX : MIN_TERMINAL_PANE_HEIGHT_PX;
+  return axis / 2 >= floor;
+}
+
+/** The pane after `paneId` in reading order, wrapping at the end. Reading order
+ *  is what the visible `Terminal 1..n` labels already follow, so "focus next"
+ *  moves the way the labels read rather than the way the tree nests. */
+export function nextTerminalPaneId(
+  node: TerminalLayoutNode,
+  paneId: string,
+  step: 1 | -1 = 1,
+): string {
+  const panes = listTerminalPanes(node);
+  if (panes.length === 0) return paneId;
+  const index = panes.findIndex((pane) => pane.id === paneId);
+  if (index < 0) return panes[0].id;
+  return panes[(index + step + panes.length) % panes.length].id;
+}
+
 export type TerminalSplitDirection = "horizontal" | "vertical";
 
 export type TerminalPaneNode = {

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -18,6 +18,8 @@
  *   - split chat panes (⌥↵ / ⌥⌘arrows / ⌥⌘W): chat-project-sidebar.tsx row
  *     keydown + the chat-router.tsx split-keyboard effect
  *   - browser pane: src/components/browser-pane.tsx (⌘L / ⌘K / [)
+ *   - terminal & panes: src/components/code-terminal-workspace.tsx onKeyDown,
+ *     resolved through src/lib/code-room-shortcuts.ts
  *   - ⌘S save: familiar-daily-notes.tsx;
  *     artifact refine ⌘↵: chat-artifact-viewer.tsx
  *
@@ -26,6 +28,12 @@
  * and a whole "Terminal & panes" group implemented only in the unmounted
  * ComuxView. Advertised-but-dead shortcuts erode trust in the whole sheet —
  * if a binding lands, add it here in the same change that wires it.
+ *
+ * (cave-uod42) "Terminal & panes" is back, and this time it is wired: the
+ * Coding Room's terminal center handles it. The bindings are ⇧⌘ rather than
+ * the ⌃/⌥ combos the old group used, because bare Ctrl+letter is shell signal
+ * territory and Alt+letter is an escape sequence — either would have been
+ * eaten by the very surface they control.
  */
 
 export type ShortcutEntry = {
@@ -35,7 +43,7 @@ export type ShortcutEntry = {
 };
 
 export type ShortcutGroup = {
-  id: "panels" | "browser" | "composer" | "slash-menu" | "other";
+  id: "panels" | "browser" | "terminal" | "composer" | "slash-menu" | "other";
   label: string;
   entries: ShortcutEntry[];
 };
@@ -59,6 +67,17 @@ export const SHORTCUT_GROUPS: ShortcutGroup[] = [
       { keys: "⌥⌘W", description: "Close the focused split chat pane" },
       { keys: "/", description: "Focus the search (Familiars, Projects, Capabilities, Sessions)" },
       { keys: "⌘F", description: "Focus the sessions search" },
+    ],
+  },
+  {
+    id: "terminal",
+    label: "Terminal & panes (Coding Room)",
+    entries: [
+      { keys: "⇧⌘→ / ⇧⌘←", description: "Focus the next / previous terminal" },
+      { keys: "⇧⌘D", description: "Split the focused terminal right" },
+      { keys: "⇧⌘E", description: "Split the focused terminal down" },
+      { keys: "⇧⌘X", description: "Close the focused terminal (never the primary)" },
+      { keys: "⇧⌘B", description: "Toggle broadcast input across terminals" },
     ],
   },
   {

--- a/src/styles/globals/surface-code-room.css
+++ b/src/styles/globals/surface-code-room.css
@@ -174,6 +174,10 @@
   min-height: 0;
   border-left: 1px solid var(--border-hairline);
   background: var(--bg-base);
+  /* The Room can sit beside other surfaces, so viewport width says nothing
+     useful about how wide the dock actually is. Query the dock itself. */
+  container-type: inline-size;
+  container-name: code-context-dock;
 }
 .code-context-dock__bar {
   display: flex;
@@ -268,6 +272,22 @@
   overflow: hidden;
   clip-path: inset(50%);
   white-space: nowrap;
+}
+
+/* Six tabs do not fit a sidebar-width dock, and the row's overflow scroll has
+   no visible affordance — an off-screen tab reads as a missing feature. Below
+   this width every tab except the selected one compresses to its icon, which
+   keeps the whole row reachable. The label stays in the accessibility tree via
+   the same visually-hidden treatment the collapsed dock uses. */
+@container code-context-dock (max-width: 420px) {
+  .code-context-dock__tab:not([data-selected="true"]) .code-context-dock__tab-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
 }
 
 /* ── Narrow widths: the room stacks instead of compressing into two unusable

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -242,6 +242,20 @@ test.describe("code surface (Coding familiar's room)", () => {
     // The worktree mark on the branch row (the Root env row also contains
     // "feat-flux" inside the worktree path, so match the ⑂-prefixed form).
     await expect(inspector.getByText("⑂ feat-flux")).toBeVisible();
+
+    // cave-uod42: GitHub is a dock tab, so triage sits beside the terminal
+    // instead of replacing the whole Room. Selecting it widens the dock,
+    // because a list/detail split at sidebar width is unreadable.
+    const dock = page.getByTestId("code-context-dock");
+    await wb.getByRole("tab", { name: "GitHub" }).click();
+    await expect(dock).toHaveAttribute("data-size", "expanded");
+    await expect(wb.getByRole("tab", { name: "GitHub" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    // The terminal center is the point of the Room — it must survive every
+    // context switch, GitHub included.
+    await expect(page.getByTestId("code-terminal-workspace")).toBeVisible();
   });
 
   test("?mode=code&session=<id>&wtab=files deep link selects the session and tab", async ({ page, isMobile }) => {


### PR DESCRIPTION
PR #4311 shipped the three-zone Coding Room but left four items from its own approved design (`docs/superpowers/specs/2026-07-26-coding-room-multipane-design.md`) unbuilt. This closes them.

### 1. Room keyboard shortcuts

The spec lists focus-next-terminal, split-right, split-down, close-pane and toggle-broadcast, plus one constraint: *"Shortcuts do not fire from text inputs outside xterm."* Zero keydown handling existed.

New `src/lib/code-room-shortcuts.ts` resolves combos as pure data. The reason it is not an inline keydown block: the Room's center is a terminal, so a wrong combo silently eats a keystroke from a running shell — and a pure resolver lets the test enumerate the **negatives** (bare letters, bare Ctrl, Shift-only, Alt, typing targets), which is the half a hand-rolled handler never covers.

Every binding is <kbd>Cmd/Ctrl</kbd>+<kbd>Shift</kbd>. Bare `Ctrl`+letter is shell signal territory (`Ctrl-C`, `Ctrl-D`) and `Alt`+letter is an escape sequence, so either would collide with the surface these control. No ⇧⌘ combo existed anywhere else in the catalog.

| Keys | Action |
| --- | --- |
| ⇧⌘→ / ⇧⌘← | focus next / previous terminal |
| ⇧⌘D / ⇧⌘E | split right / down |
| ⇧⌘X | close focused terminal (never the primary) |
| ⇧⌘B | toggle broadcast input |

`keyboard-shortcuts.ts` gains the group, per its own standing rule that a binding is listed in the change that wires it. That file's "Terminal & panes" group was previously **purged** (cave-7c9i) for naming combos no mounted component handled — a source-contract test now pins each `case` in the workspace and each hint in the sheet, so it cannot regress to advertised-but-dead.

### 2. Measured split guard

Spec: *"Terminal split creation is disabled when a pane would fall below the usable minimum."* Only the four-pane count cap was enforced — but a 380px Room is already under the readable floor at **two** panes.

The focused pane is measured via `ResizeObserver`; both split affordances disable when halving it would drop below the floor, with a distinct tooltip ("Not enough room to split" vs "Terminal limit reached") and an announcement. The CSS `minSize` strings now derive from the model's `MIN_TERMINAL_PANE_*_PX` constants, so the divider stop and the disabled button cannot drift apart. Unmeasured/zero sizes deliberately pass, so a control never latches disabled in SSR or a test env.

### 3. Dock announcements

Spec: *"…and dock changes are announced through useAnnouncer."* The terminal workspace announced its mutations (9 sites); the dock announced nothing — though it is the one zone whose content swaps under a stationary cursor. Tab and size changes now go through the shared live region.

### 4. GitHub dock tab

The spec's dock is Changes / Files / Pull request / Inspector / **GitHub** / Browser. A Copilot review comment on #4311 flagged that the header comment named a GitHub tab the code lacked — and it was resolved by correcting the *comment*. This adds the code.

It mounts `GitHubView` dynamically (so its fetch stack stays out of the Room's first chunk) and opens the dock `expanded`, on the same reasoning as Browser: a list/detail split at sidebar width renders a column of wrapped text. No `initialFilter` — unlike the top-level PRs/Issues/Reviews tabs the dock drives no slice, so the view keeps its own filter control.

Six tabs do not fit a sidebar-width dock, and the row's `overflow-x: auto` has no visible affordance — an off-screen tab reads as a missing feature. A container query (on the dock, not the viewport, since the Room can sit beside other surfaces) compresses unselected tabs to their icons below 420px, keeping their accessible names via the visually-hidden treatment the collapsed dock already uses.

**Deliberate divergence.** The spec also says *"there is no top-level GitHub page."* The top-level Activity/PRs/Issues/Reviews tabs are shipped and e2e-pinned, and retiring a live surface is an IA decision for the owner — so this tab is **additive** and pending-GitHub routing is untouched. A follow-up bead carries the removal question rather than making it silently here.

The dock "close" action the spec lists is also skipped: collapse already *is* close, since the tab rail stays reachable, and a third control would be a second name for one state.

### Also

`code-view.tsx`'s header comment still described the retired tabbed workbench (`Diff | Files | Terminal | PR`), left stale by #4311.

### Verification

`typecheck` · `lint` · `codemod:design:check` · `design-token-drift` · `check:tests-wired` (1488) · `test:app` (1078) · `test:api` (335) · `build` · `tests/code-surface.spec.ts` + `tests/mobile/code-surface-drill-in.spec.ts` across desktop, pixel-5 and iphone-13.

Bundle note: first-load CSS headroom moved 13.1 KB → 12.0 KB (still within the 880 KB budget, but it was already flagged thin before this change).
