### PR TITLE
fix(daemon): supervisor-safe automatic recovery (cave-9pqt9)

### DIFF
--- a/docs/superpowers/plans/2026-08-03-supervisor-safe-daemon-recovery.md
+++ b/docs/superpowers/plans/2026-08-03-supervisor-safe-daemon-recovery.md
@@ -1,0 +1,84 @@
+# Supervisor-safe Daemon Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recover a local daemon without competing with an existing supervisor and without transiently presenting successful recovery as daemon instability.
+
+**Architecture:** Add a CLI lifecycle preflight to the server-side start boundary, keep the daemon serve lock authoritative, and return a structured deferred outcome when another live owner is unreachable. Thread automatic/manual intent through the start client and give Workspace a bounded recovery presentation state that suppresses transient banners but restores the existing actionable failure state after two confirmed offline polls.
+
+**Tech Stack:** TypeScript, Node child processes, Next.js route handlers, React state, Node test runner.
+
+---
+
+### Task 1: Pin lifecycle-safe automatic start behavior
+
+**Files:**
+- Modify: `src/lib/daemon-start.test.ts`
+- Modify: `src/lib/daemon-start.ts`
+
+- [ ] Add failing tests that inject lifecycle results and assert `stale` and
+  `unknown` automatic starts return `code: "owner_unreachable"` without calling
+  `spawnImpl`.
+- [ ] Run `node --experimental-strip-types src/lib/daemon-start.test.ts` and
+  confirm both cases fail because the preflight contract does not exist.
+- [ ] Add `automatic?: boolean` and an injectable lifecycle inspector to
+  `startLocalDaemon`; normalize `coven daemon status --json` into running,
+  stopped, stale, or unknown and fail closed only for automatic starts.
+- [ ] Add a failing launcher-exit race test in which health becomes ready during
+  the bounded grace, then extend readiness polling after runner exit without
+  weakening timeout cleanup.
+- [ ] Re-run the focused daemon-start test and confirm it passes.
+
+### Task 2: Thread automatic intent and structured outcomes through the API
+
+**Files:**
+- Modify: `src/app/api/daemon/start/route.test.ts`
+- Modify: `src/app/api/daemon/start/route.ts`
+- Modify: `src/lib/daemon-desktop-auto-start.test.ts`
+- Modify: `src/lib/daemon-desktop-auto-start.ts`
+
+- [ ] Add failing route coverage proving `{ automatic: true }` reaches
+  `startLocalDaemon({ automatic: true })` while an empty/manual body does not.
+- [ ] Add failing client coverage proving automatic requests send the intent,
+  distinguish a deferred `owner_unreachable` response from a hard failure, and
+  preserve the unbound WebView fetch call.
+- [ ] Run both focused tests and confirm the new assertions fail for missing
+  request/outcome behavior.
+- [ ] Implement a discriminated `started | deferred | failed` client outcome;
+  preserve manual error reporting and suppress automatic deferred diagnostics.
+- [ ] Re-run both focused tests and confirm they pass.
+
+### Task 3: Make the shell quiet only during bounded recovery
+
+**Files:**
+- Modify: `src/components/workspace-daemon-connection.test.ts`
+- Modify: `src/components/daemon-start-button.test.ts`
+- Modify: `src/components/chat-surface.test.ts`
+- Modify: `src/components/workspace.tsx`
+
+- [ ] Add failing source-contract assertions for automatic start intent,
+  `recovering`/`deferred` state, immediate clear on running, two-offline-poll
+  exhaustion, and suppression of only `daemon-offline`/`daemon-start-error`.
+- [ ] Run the three focused tests and confirm failure on the absent recovery
+  state machine.
+- [ ] Implement the smallest Workspace state/ref integration: automatic starts
+  enter recovering, deferred outcomes receive two offline polls, running clears
+  immediately, and manual starts retain immediate diagnostics.
+- [ ] Re-run the focused tests and confirm all pass.
+
+### Task 4: Verify the complete recovery contract
+
+**Files:**
+- Modify only if test wiring is missing: `scripts/run-tests.mjs`
+- Update Bead evidence: `cave-9pqt9`
+
+- [ ] Run `pnpm check:tests-wired` and confirm every modified/new test is wired.
+- [ ] Run the focused daemon start, route, coordinator, and Workspace suites.
+- [ ] Run `pnpm typecheck`, `pnpm lint`, and `git diff --check`.
+- [ ] Start the native app with `bash scripts/dev-app.sh`, verify a healthy
+  daemon produces no banner, and verify a simulated bounded automatic recovery
+  does not disturb the live daemon or its SQLite state.
+- [ ] Record branch, unmanaged-worktree retirement requirement, root-cause
+  evidence, and verification output on `cave-9pqt9`. Do not commit or push
+  without Val's explicit authorization.
+

--- a/docs/superpowers/specs/2026-08-03-supervisor-safe-daemon-recovery-design.md
+++ b/docs/superpowers/specs/2026-08-03-supervisor-safe-daemon-recovery-design.md
@@ -1,0 +1,85 @@
+# Supervisor-safe daemon recovery
+
+## Problem
+
+Cave treats a definitive local-offline connection poll as permission to run
+`coven daemon start`. That is safe when Cave is the only lifecycle owner, but
+not when launchd, systemd, or another supervisor already owns a foreground
+`coven daemon serve` process. A live but temporarily unreachable owner still
+holds `daemon-serve.lock`; a competing start correctly fails rather than risk
+two SQLite writers, while the supervisor may repeatedly relaunch and Cave may
+show transient offline/start-failed banners.
+
+The live machine evidence on 2026-08-03 showed exactly this state: one healthy
+launchd-owned daemon, a serve-lifetime lock held by that process, 1,752 launchd
+runs, and repeated lock-contention diagnostics. The lock is protection, not
+the defect. The defect is Cave treating health failure as proof that no owner
+exists.
+
+## Requirements
+
+1. Never weaken the serve-lifetime lock, remove daemon state, or signal an
+   unverified PID.
+2. Automatic recovery must not spawn when the CLI reports a live but
+   unreachable daemon owner.
+3. A supervisor that wins a start race must count as successful recovery even
+   if Cave's launcher exits non-zero.
+4. The shell must stay quiet during a bounded automatic recovery window.
+5. A still-offline daemon after that window must restore the existing truthful,
+   actionable banner. Manual Start remains immediately diagnostic.
+6. Existing sessions and the SQLite ledger remain untouched throughout.
+
+## Design
+
+### Lifecycle preflight
+
+`startLocalDaemon` gains an injectable automatic-recovery preflight backed by
+`coven daemon status --json`. The normalized result is `running`, `stopped`,
+`stale`, or `unknown`.
+
+- `running`: return the existing already-running success.
+- `stopped`: continue with the existing start path.
+- `stale`: return a structured `owner_unreachable` deferred result without
+  spawning or signaling anything.
+- `unknown`: fail closed for automatic recovery with a structured deferred
+  result; manual Start retains the current direct diagnostic path.
+
+This check is advisory and race-prone by construction, so the existing
+serve-lifetime lock remains authoritative.
+
+### Start-race grace
+
+If the launcher exits before health is ready, readiness continues for a short,
+bounded grace instead of taking one immediate final probe. This accepts the
+case where a supervisor acquires ownership just after Cave's attempted start.
+If no healthy daemon appears, Cave reports the original failure and cleans up
+only the process tree it launched.
+
+### UI recovery state
+
+Automatic calls post `{ automatic: true }`; manual calls keep the current
+request shape. Workspace tracks a small recovery presentation state:
+
+- `recovering`: an automatic request is in flight; suppress offline and start
+  error banners.
+- `deferred`: a live/unknown owner prevented a competing spawn; suppress the
+  banner for two fresh connection polls.
+- `idle`: healthy or no recovery underway.
+- `failed`: bounded recovery did not return health; use the existing banner and
+  manual Start action.
+
+A running connection poll immediately clears recovery state. Two subsequent
+definitive offline polls exhaust a deferred window. Status-unavailable and
+authentication failures keep their existing distinct UI paths.
+
+## Verification
+
+- Unit tests prove stale/unknown automatic preflight never calls `spawn`.
+- Unit tests prove stopped automatic recovery still starts and a supervisor
+  winner during exit grace returns success.
+- Workspace/source contracts prove automatic and manual request shapes differ,
+  recovering/deferred states suppress only the daemon-offline/start-error
+  banners, and bounded exhaustion restores them.
+- Focused app/API tests, typecheck, test wiring, and a native Tauri smoke prove
+  the final behavior without disturbing the running user daemon.
+

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -140,6 +140,7 @@ export const SUITES = {
     "src/lib/daemon-connection-supervisor.test.ts",
     "src/lib/daemon-status-classification.test.ts",
     "src/lib/daemon-desktop-auto-start.test.ts",
+    "src/lib/daemon-recovery-presentation.test.ts",
     "src/lib/about-diagnostics.test.ts",
     "src/lib/backup-passphrase-strength.test.ts",
     "src/lib/settings-general-summary.test.ts",

--- a/src/app/api/daemon/start/route.test.ts
+++ b/src/app/api/daemon/start/route.test.ts
@@ -4,7 +4,11 @@ import { readFile } from "node:fs/promises";
 
 const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
-assert.match(source, /startLocalDaemon\(\{ restart \}\)/, "daemon start should use the shared local daemon starter");
+assert.match(
+  source,
+  /startLocalDaemon\(\{ restart, automatic \}\)/,
+  "daemon start should pass explicit restart and automatic intent to the shared starter",
+);
 
 assert.match(
   source,
@@ -16,6 +20,12 @@ assert.match(
   source,
   /const restart = body\?\.restart === true/,
   "daemon start route should accept an explicit restart option",
+);
+
+assert.match(
+  source,
+  /const automatic = body\?\.automatic === true/,
+  "daemon start route should accept explicit automatic-recovery intent",
 );
 
 assert.match(

--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -4,14 +4,18 @@ import { startLocalDaemon } from "@/lib/daemon-start";
 export const dynamic = "force-dynamic";
 
 export async function POST(request: Request) {
-  const body = (await request.json().catch(() => null)) as { restart?: boolean } | null;
+  const body = (await request.json().catch(() => null)) as {
+    restart?: boolean;
+    automatic?: boolean;
+  } | null;
   const restart = body?.restart === true;
+  const automatic = body?.automatic === true;
 
   // Idempotent start: if a daemon is already serving, don't spawn `coven daemon
   // start`. That subcommand *restarts* the daemon, which fights a supervisor
   // (e.g. a launchd KeepAlive agent) for the socket — the supervisor relaunches
   // its copy while the restart spawns another, churning the socket. A healthy
   // daemon means "start" has nothing to do, so report it as already running.
-  const result = await startLocalDaemon({ restart });
+  const result = await startLocalDaemon({ restart, automatic });
   return NextResponse.json(result, { status: "status" in result ? result.status : 200 });
 }

--- a/src/components/daemon-start-button.test.ts
+++ b/src/components/daemon-start-button.test.ts
@@ -27,8 +27,8 @@ assert.match(
 
 assert.match(
   workspace,
-  /const startDaemon = useCallback\([\s\S]*await waitForDaemonUpdateIdle\(\)[\s\S]*runWorkspaceDaemonStart\(\{[\s\S]*fetchImpl: fetch[\s\S]*refreshStatus: refreshDaemonStatus/,
-  "Workspace automatic and manual starts should share the behaviorally tested start flow",
+  /const startDaemon = useCallback\(async \(\{ automatic = false \}: \{ automatic\?: boolean \} = \{\}\) => \{[\s\S]*daemonRecoveryPresentation\(current,[\s\S]*await waitForDaemonUpdateIdle\(\)[\s\S]*runWorkspaceDaemonStart\(\{[\s\S]*automatic,[\s\S]*fetchImpl: fetch[\s\S]*refreshStatus: refreshDaemonStatus/,
+  "Workspace automatic and manual starts should share one flow with explicit intent",
 );
 
 assert.match(

--- a/src/components/workspace-daemon-connection.test.ts
+++ b/src/components/workspace-daemon-connection.test.ts
@@ -168,6 +168,16 @@ test("Workspace applies connection polls through the existing classifier-driven 
   );
   assert.match(
     applyPoll,
+    /setDaemonRecovery\(\(current\) => daemonRecoveryPresentation\(current, \{ type: "offline" \}\)\)/,
+    "definitive offline polls should advance the bounded recovery presentation window",
+  );
+  assert.match(
+    applyPoll,
+    /result\.kind === "running"[\s\S]*setDaemonRecovery\(\(current\) => daemonRecoveryPresentation\(current, \{ type: "running" \}\)\)/,
+    "healthy status should clear recovery presentation immediately",
+  );
+  assert.match(
+    applyPoll,
     /setDaemonRunning\(true\)[\s\S]*daemonHealthyStreakRef\.current \+= 1/,
     "running polls should continue to advance the healthy streak",
   );
@@ -180,5 +190,23 @@ test("Workspace applies connection polls through the existing classifier-driven 
     applyPoll,
     /if \(daemonHealthyStreakRef\.current >= 2\) setDaemonOffline\(false\)/,
     "ordinary background recovery should still require two healthy polls before clearing offline",
+  );
+});
+
+test("Workspace keeps automatic recovery quiet but restores truthful banners after exhaustion", () => {
+  assert.match(
+    workspace,
+    /startDaemonRef\.current\(\{ automatic: true \}\)/,
+    "coordinator-owned starts should carry automatic intent",
+  );
+  assert.match(
+    workspace,
+    /setDaemonRecovery\(\(current\) => daemonRecoveryPresentation\(current, \{[\s\S]*type: automatic \? "automatic-start" : "manual-start"[\s\S]*runWorkspaceDaemonStart\(\{[\s\S]*automatic,[\s\S]*setDaemonRecovery\(\(current\) => daemonRecoveryPresentation\(current, \{ type: "start-outcome", outcome \}\)\)/,
+    "automatic start lifecycle should drive the pure recovery presentation state",
+  );
+  assert.match(
+    workspace,
+    /if \(!daemonOffline \|\| authExpired \|\| daemonRecovery\.quiet\)/,
+    "offline and start-error banners should stay dismissed only while bounded recovery is quiet",
   );
 });

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -82,6 +82,10 @@ import {
   createDaemonDesktopAutoStartCoordinator,
   runWorkspaceDaemonStart,
 } from "@/lib/daemon-desktop-auto-start";
+import {
+  daemonRecoveryPresentation,
+  initialDaemonRecoveryPresentation,
+} from "@/lib/daemon-recovery-presentation";
 import { readDaemonAutomation } from "@/lib/daemon-automation-pref";
 import { waitForDaemonUpdateIdle } from "@/lib/app-update-daemon";
 import { useTauriPlatform } from "@/lib/tauri-platform";
@@ -569,15 +573,16 @@ export function Workspace() {
   // the fix is re-auth (reload to the gate page), not "Start daemon" (cave-wkp5).
   const [authExpired, setAuthExpired] = useState(false);
   const [daemonStatusUnavailable, setDaemonStatusUnavailable] = useState<string | null>(null);
+  const [daemonRecovery, setDaemonRecovery] = useState(initialDaemonRecoveryPresentation);
   const daemonHealthyStreakRef = useRef(0);
   const daemonConnectionSupervisorRef = useRef<ReturnType<typeof createDaemonConnectionSupervisor> | null>(null);
   const daemonTravelReconcileRequesterRef = useRef<ReturnType<typeof createDaemonTravelReconcileRequester> | null>(null);
-  const startDaemonRef = useRef<() => Promise<void>>(async () => {});
+  const startDaemonRef = useRef<({ automatic }?: { automatic?: boolean }) => Promise<void>>(async () => {});
   const daemonAutoStartCoordinatorRef = useRef<ReturnType<typeof createDaemonDesktopAutoStartCoordinator> | null>(null);
   if (daemonAutoStartCoordinatorRef.current === null) {
     daemonAutoStartCoordinatorRef.current = createDaemonDesktopAutoStartCoordinator(
       () => {
-        void startDaemonRef.current();
+        void startDaemonRef.current({ automatic: true });
       },
       {
         // Read per decision, not captured: Settings → Daemon → Automation can
@@ -784,6 +789,7 @@ export function Workspace() {
     // live UI state, but can never turn into a delayed automatic restart.
     daemonAutoStartCoordinatorRef.current!.observeStatus(result);
     if (result.kind === "running") {
+      setDaemonRecovery((current) => daemonRecoveryPresentation(current, { type: "running" }));
       setAcceptedLocalDaemonHealthy(result.targetMode === "local");
     } else {
       setAcceptedLocalDaemonHealthy(false);
@@ -805,6 +811,7 @@ export function Workspace() {
 
     setDaemonStatusUnavailable(null);
     if (result.kind === "offline") {
+      setDaemonRecovery((current) => daemonRecoveryPresentation(current, { type: "offline" }));
       daemonHealthyStreakRef.current = 0;
       setDaemonRunning(false);
       setDaemonOffline(true);
@@ -825,12 +832,16 @@ export function Workspace() {
     await daemonConnectionSupervisorRef.current?.refresh({ fresh: opts?.fresh === true || opts?.trusted === true });
   }, []);
 
-  const startDaemon = useCallback(async () => {
+  const startDaemon = useCallback(async ({ automatic = false }: { automatic?: boolean } = {}) => {
+    setDaemonRecovery((current) => daemonRecoveryPresentation(current, {
+      type: automatic ? "automatic-start" : "manual-start",
+    }));
     // The release-alignment trigger may be replacing the CLI after observing
     // this same offline state. Starting the old binary during that window can
     // lock coven.exe on Windows and make the update fail.
     await waitForDaemonUpdateIdle();
-    await runWorkspaceDaemonStart({
+    const outcome = await runWorkspaceDaemonStart({
+      automatic,
       fetchImpl: fetch,
       dismissError: () => dismissBanner("daemon-start-error"),
       reportError: (message) => pushBanner({
@@ -840,6 +851,9 @@ export function Workspace() {
       }),
       refreshStatus: refreshDaemonStatus,
     });
+    if (automatic) {
+      setDaemonRecovery((current) => daemonRecoveryPresentation(current, { type: "start-outcome", outcome }));
+    }
   }, [dismissBanner, pushBanner, refreshDaemonStatus]);
   startDaemonRef.current = startDaemon;
 
@@ -1036,7 +1050,7 @@ export function Workspace() {
   // token is rejected the daemon state is unknowable — suppress this banner
   // in favour of the re-auth one (cave-wkp5).
   useEffect(() => {
-    if (!daemonOffline || authExpired) {
+    if (!daemonOffline || authExpired || daemonRecovery.quiet) {
       dismissBanner("daemon-offline");
       dismissBanner("daemon-start-error");
     } else if (daemonStatusResolved) {
@@ -1054,7 +1068,7 @@ export function Workspace() {
         },
       });
     }
-  }, [daemonOffline, daemonStatusResolved, authExpired, pushBanner, dismissBanner, startDaemon]);
+  }, [daemonOffline, daemonStatusResolved, authExpired, daemonRecovery.quiet, pushBanner, dismissBanner, startDaemon]);
 
   // A status-service failure, timeout, malformed response, or non-local target
   // problem does not prove the local daemon is stopped. Keep that uncertainty

--- a/src/lib/daemon-desktop-auto-start.test.ts
+++ b/src/lib/daemon-desktop-auto-start.test.ts
@@ -98,7 +98,7 @@ function response(ok, payload) {
   const refreshes = [];
   let dismissed = 0;
   const errors = [];
-  const ok = await runWorkspaceDaemonStart({
+  const outcome = await runWorkspaceDaemonStart({
     fetchImpl: async function (...args) {
       assert.equal(this, undefined, "WebView fetch must not receive the dependency object as its receiver");
       requests.push(args);
@@ -108,8 +108,8 @@ function response(ok, payload) {
     reportError: (message) => errors.push(message),
     refreshStatus: async (opts) => { refreshes.push(opts); },
   });
-  assert.equal(ok, true);
-  assert.deepEqual(requests, [["/api/daemon/start", { method: "POST" }]], "automatic start never sends restart mode");
+  assert.equal(outcome, "started");
+  assert.deepEqual(requests, [["/api/daemon/start", { method: "POST" }]], "manual start keeps its existing request shape");
   assert.equal(dismissed, 1);
   assert.deepEqual(errors, []);
   assert.deepEqual(refreshes, [{ trusted: true }], "success performs the trusted refresh");
@@ -128,11 +128,40 @@ function response(ok, payload) {
     reportError: (message) => errors.push(message),
     refreshStatus: async (opts) => { refreshes.push(opts); },
   };
-  assert.equal(await runWorkspaceDaemonStart(deps), false);
-  assert.equal(await runWorkspaceDaemonStart(deps), false, "manual retry remains available after failure");
+  assert.equal(await runWorkspaceDaemonStart(deps), "failed");
+  assert.equal(await runWorkspaceDaemonStart(deps), "failed", "manual retry remains available after failure");
   assert.equal(requests, 2);
   assert.deepEqual(errors, ["Coven CLI missing", "Coven CLI missing"]);
   assert.deepEqual(refreshes, [undefined, undefined], "failure keeps ordinary status authoritative");
+}
+
+{
+  const requests = [];
+  const refreshes = [];
+  const errors = [];
+  const outcome = await runWorkspaceDaemonStart({
+    automatic: true,
+    fetchImpl: async (...args) => {
+      requests.push(args);
+      return response(false, {
+        ok: false,
+        code: "owner_unreachable",
+        error: "automatic recovery deferred",
+      });
+    },
+    dismissError: () => assert.fail("deferred recovery has no prior error to dismiss"),
+    reportError: (message) => errors.push(message),
+    refreshStatus: async (opts) => { refreshes.push(opts); },
+  });
+
+  assert.equal(outcome, "deferred");
+  assert.deepEqual(requests, [["/api/daemon/start", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ automatic: true }),
+  }]]);
+  assert.deepEqual(errors, [], "automatic ownership deferral stays out of the error banner");
+  assert.deepEqual(refreshes, [undefined], "deferral immediately rechecks ordinary connection state");
 }
 
 

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -133,9 +133,12 @@ export function createDaemonStatusRequestGate() {
 
 type DaemonStartPayload = {
   ok?: unknown;
+  code?: unknown;
   error?: unknown;
   stderr?: unknown;
 };
+
+export type WorkspaceDaemonStartOutcome = "started" | "deferred" | "failed";
 
 function daemonStartPayload(value: unknown): DaemonStartPayload {
   return value && typeof value === "object" ? value as DaemonStartPayload : {};
@@ -143,19 +146,33 @@ function daemonStartPayload(value: unknown): DaemonStartPayload {
 
 /** Shared automatic/manual Workspace start behavior with injectable effects. */
 export async function runWorkspaceDaemonStart(input: {
+  automatic?: boolean;
   fetchImpl: typeof fetch;
   dismissError(): void;
   reportError(message: string): void;
   refreshStatus(opts?: { trusted?: boolean; fresh?: boolean }): Promise<void>;
-}): Promise<boolean> {
+}): Promise<WorkspaceDaemonStartOutcome> {
   try {
     // Keep the injected function unbound. Calling `input.fetchImpl(...)`
     // supplies `input` as the receiver, which WebView2's native fetch rejects
     // with "Illegal invocation".
     const { fetchImpl } = input;
-    const response = await fetchImpl("/api/daemon/start", { method: "POST" });
+    const response = await fetchImpl(
+      "/api/daemon/start",
+      input.automatic
+        ? {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ automatic: true }),
+        }
+        : { method: "POST" },
+    );
     const payload = daemonStartPayload(await response.json().catch(() => ({})));
     if (!response.ok || payload.ok === false) {
+      if (input.automatic && payload.code === "owner_unreachable") {
+        await input.refreshStatus();
+        return "deferred";
+      }
       const message =
         typeof payload.error === "string" && payload.error.trim()
           ? payload.error
@@ -166,10 +183,10 @@ export async function runWorkspaceDaemonStart(input: {
     }
     input.dismissError();
     await input.refreshStatus({ trusted: true });
-    return true;
+    return "started";
   } catch (error) {
     input.reportError(error instanceof Error ? error.message : "daemon did not start");
     await input.refreshStatus();
-    return false;
+    return "failed";
   }
 }

--- a/src/lib/daemon-readiness.ts
+++ b/src/lib/daemon-readiness.ts
@@ -16,6 +16,8 @@ export async function waitForDaemonReadiness(input: {
   probe: ReadinessProbe;
   timeoutMs: number;
   pollMs: number;
+  /** Keep accepting a supervisor winner briefly after the launcher exits. */
+  runnerExitGraceMs?: number;
   runnerExited: () => boolean;
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
@@ -24,19 +26,29 @@ export async function waitForDaemonReadiness(input: {
   const sleep = input.sleep ?? ((ms) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const startedAt = now();
   let attempts = 0;
+  let runnerExitedAt: number | null = null;
   while (true) {
     attempts += 1;
     if ((await input.probe()).ok) {
       return { ready: true, attempts, elapsedMs: now() - startedAt, runnerExited: input.runnerExited() };
     }
-    const elapsedMs = now() - startedAt;
-    if (input.runnerExited() || elapsedMs >= input.timeoutMs) {
+    const checkedAt = now();
+    const elapsedMs = checkedAt - startedAt;
+    const runnerExited = input.runnerExited();
+    if (runnerExited && runnerExitedAt === null) runnerExitedAt = checkedAt;
+    const runnerGraceElapsed = runnerExitedAt !== null &&
+      checkedAt - runnerExitedAt >= (input.runnerExitGraceMs ?? 0);
+    if (runnerGraceElapsed || elapsedMs >= input.timeoutMs) {
       // A final probe closes the race where a foreground runner publishes its
       // socket just after the previous request, or exits after daemonizing.
       attempts += 1;
       const ready = (await input.probe()).ok;
       return { ready, attempts, elapsedMs: now() - startedAt, runnerExited: input.runnerExited() };
     }
-    await sleep(Math.min(input.pollMs, Math.max(1, input.timeoutMs - elapsedMs)));
+    const timeoutRemaining = input.timeoutMs - elapsedMs;
+    const runnerGraceRemaining = runnerExitedAt === null
+      ? timeoutRemaining
+      : (input.runnerExitGraceMs ?? 0) - (checkedAt - runnerExitedAt);
+    await sleep(Math.min(input.pollMs, Math.max(1, timeoutRemaining), Math.max(1, runnerGraceRemaining)));
   }
 }

--- a/src/lib/daemon-recovery-presentation.test.ts
+++ b/src/lib/daemon-recovery-presentation.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  daemonRecoveryPresentation,
+  initialDaemonRecoveryPresentation,
+} from "./daemon-recovery-presentation.ts";
+
+test("automatic ownership deferral stays quiet for two subsequent offline polls", () => {
+  let state = initialDaemonRecoveryPresentation;
+  state = daemonRecoveryPresentation(state, { type: "automatic-start" });
+  assert.equal(state.phase, "recovering");
+  assert.equal(state.quiet, true);
+
+  state = daemonRecoveryPresentation(state, { type: "start-outcome", outcome: "deferred" });
+  assert.deepEqual(state, { phase: "deferred", quiet: true, offlinePollsRemaining: 2 });
+
+  state = daemonRecoveryPresentation(state, { type: "offline" });
+  assert.deepEqual(state, { phase: "deferred", quiet: true, offlinePollsRemaining: 1 });
+
+  state = daemonRecoveryPresentation(state, { type: "offline" });
+  assert.deepEqual(state, { phase: "failed", quiet: false, offlinePollsRemaining: 0 });
+});
+
+test("running health clears recovery immediately and fences a late start outcome", () => {
+  let state = daemonRecoveryPresentation(initialDaemonRecoveryPresentation, {
+    type: "automatic-start",
+  });
+  state = daemonRecoveryPresentation(state, { type: "running" });
+  assert.deepEqual(state, initialDaemonRecoveryPresentation);
+
+  state = daemonRecoveryPresentation(state, { type: "start-outcome", outcome: "deferred" });
+  assert.deepEqual(state, initialDaemonRecoveryPresentation);
+});
+
+test("hard automatic failure becomes visible immediately", () => {
+  let state = daemonRecoveryPresentation(initialDaemonRecoveryPresentation, {
+    type: "automatic-start",
+  });
+  state = daemonRecoveryPresentation(state, { type: "start-outcome", outcome: "failed" });
+  assert.deepEqual(state, { phase: "failed", quiet: false, offlinePollsRemaining: 0 });
+});
+
+test("a manual retry exits quiet recovery so its diagnostics remain visible", () => {
+  let state = daemonRecoveryPresentation(initialDaemonRecoveryPresentation, {
+    type: "automatic-start",
+  });
+  state = daemonRecoveryPresentation(state, { type: "start-outcome", outcome: "deferred" });
+  state = daemonRecoveryPresentation(state, { type: "manual-start" });
+  assert.deepEqual(state, initialDaemonRecoveryPresentation);
+});
+
+test("a started result gets one final quiet poll unless running already won", () => {
+  let state = daemonRecoveryPresentation(initialDaemonRecoveryPresentation, {
+    type: "automatic-start",
+  });
+  state = daemonRecoveryPresentation(state, { type: "start-outcome", outcome: "started" });
+  assert.deepEqual(state, { phase: "deferred", quiet: true, offlinePollsRemaining: 1 });
+  state = daemonRecoveryPresentation(state, { type: "offline" });
+  assert.equal(state.quiet, false);
+});

--- a/src/lib/daemon-recovery-presentation.ts
+++ b/src/lib/daemon-recovery-presentation.ts
@@ -1,0 +1,49 @@
+import type { WorkspaceDaemonStartOutcome } from "./daemon-desktop-auto-start.ts";
+
+export type DaemonRecoveryPresentation = {
+  phase: "idle" | "recovering" | "deferred" | "failed";
+  quiet: boolean;
+  offlinePollsRemaining: number;
+};
+
+export type DaemonRecoveryPresentationEvent =
+  | { type: "automatic-start" }
+  | { type: "manual-start" }
+  | { type: "start-outcome"; outcome: WorkspaceDaemonStartOutcome }
+  | { type: "running" }
+  | { type: "offline" };
+
+export const initialDaemonRecoveryPresentation: DaemonRecoveryPresentation = {
+  phase: "idle",
+  quiet: false,
+  offlinePollsRemaining: 0,
+};
+
+/** Pure UI state: quiet only while ownership-safe recovery can still heal. */
+export function daemonRecoveryPresentation(
+  current: DaemonRecoveryPresentation,
+  event: DaemonRecoveryPresentationEvent,
+): DaemonRecoveryPresentation {
+  if (event.type === "running") return initialDaemonRecoveryPresentation;
+  if (event.type === "manual-start") return initialDaemonRecoveryPresentation;
+  if (event.type === "automatic-start") {
+    return { phase: "recovering", quiet: true, offlinePollsRemaining: 0 };
+  }
+  if (event.type === "start-outcome") {
+    // A trusted running poll can win while the start request is settling.
+    if (current.phase !== "recovering") return current;
+    if (event.outcome === "failed") {
+      return { phase: "failed", quiet: false, offlinePollsRemaining: 0 };
+    }
+    return {
+      phase: "deferred",
+      quiet: true,
+      offlinePollsRemaining: event.outcome === "deferred" ? 2 : 1,
+    };
+  }
+  if (current.phase !== "deferred") return current;
+  const remaining = current.offlinePollsRemaining - 1;
+  return remaining > 0
+    ? { ...current, offlinePollsRemaining: remaining }
+    : { phase: "failed", quiet: false, offlinePollsRemaining: 0 };
+}

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { readFile } from "node:fs/promises";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
 import {
+  parseDaemonLifecycleInspection,
   startLocalDaemon,
   terminateDaemonLaunchTree,
 } from "./daemon-start.ts";
@@ -29,6 +30,16 @@ assert.match(daemonStart, /assessDaemonStartupCompatibility/, "readiness must va
 assert.match(daemonStart, /code: "runtime_incompatible"/, "a stale or incompatible runtime has a stable actionable outcome");
 assert.match(daemonStart, /RuntimeStartupThrottle/, "repeated failed starts must be bounded to prevent a restart storm");
 assert.match(daemonStart, /activeDaemonStart/, "concurrent start requests must share one owned launch");
+
+for (const [payload, expected] of [
+  [{ status: "running", ok: true }, { status: "running" }],
+  [{ status: "stopped", ok: false }, { status: "stopped" }],
+  [{ status: "stale", ok: false, pid: 42 }, { status: "stale" }],
+  [{ status: "future" }, { status: "unknown" }],
+  [null, { status: "unknown" }],
+]) {
+  assert.deepEqual(parseDaemonLifecycleInspection(payload), expected);
+}
 
 function fakeChild(pid = 4321) {
   const child = Object.assign(new EventEmitter(), {
@@ -89,6 +100,60 @@ test("an exited launcher reports not-ready only after its final probe", async ()
     sleep: async () => assert.fail("an exited launcher should not sleep"),
   });
   assert.deepEqual(result, { ready: true, attempts: 2, elapsedMs: 0, runnerExited: true });
+});
+
+test("an exited launcher keeps probing through a bounded supervisor grace", async () => {
+  let now = 0;
+  let probes = 0;
+  const result = await waitForDaemonReadiness({
+    probe: async () => ({ ok: ++probes === 3 }),
+    timeoutMs: 1000,
+    pollMs: 100,
+    runnerExitGraceMs: 200,
+    runnerExited: () => true,
+    now: () => now,
+    sleep: async (ms) => { now += ms; },
+  });
+  assert.deepEqual(result, { ready: true, attempts: 3, elapsedMs: 200, runnerExited: true });
+});
+
+for (const lifecycle of ["stale", "unknown"]) {
+  test(`automatic recovery defers without spawning when lifecycle is ${lifecycle}`, async () => {
+    let spawnCalls = 0;
+    const result = await startLocalDaemon({
+      automatic: true,
+      probe: async () => ({ ok: false }),
+      inspectLifecycle: async () => ({ status: lifecycle }),
+      spawnImpl: () => {
+        spawnCalls += 1;
+        return fakeChild();
+      },
+    });
+
+    assert.equal(spawnCalls, 0, "a live or unconfirmed owner must never get a competing daemon");
+    assert.equal(result.ok, false);
+    assert.equal(result.code, "owner_unreachable");
+    assert.equal(result.status, 409);
+    assert.equal(result.launchMode, "none");
+  });
+}
+
+test("automatic recovery still starts after lifecycle proves stopped", async () => {
+  const child = fakeChild();
+  let spawnCalls = 0;
+  let probes = 0;
+  const result = await startLocalDaemon({
+    automatic: true,
+    probe: async () => ({ ok: ++probes >= 2 }),
+    inspectLifecycle: async () => ({ status: "stopped" }),
+    spawnImpl: () => {
+      spawnCalls += 1;
+      return child;
+    },
+  });
+
+  assert.equal(spawnCalls, 1);
+  assert.equal(result.ok, true);
 });
 
 test("a readiness timeout terminates the Windows launch tree", async () => {

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -138,6 +138,24 @@ for (const lifecycle of ["stale", "unknown"]) {
   });
 }
 
+test("an automatic request cannot use restart to skip the lifecycle preflight", async () => {
+  let spawnCalls = 0;
+  const result = await startLocalDaemon({
+    automatic: true,
+    restart: true,
+    probe: async () => ({ ok: false }),
+    inspectLifecycle: async () => ({ status: "stale" }),
+    spawnImpl: () => {
+      spawnCalls += 1;
+      return fakeChild();
+    },
+  });
+
+  assert.equal(spawnCalls, 0, "restart must not let an automatic request bypass the fail-closed preflight");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "owner_unreachable");
+});
+
 test("automatic recovery still starts after lifecycle proves stopped", async () => {
   const child = fakeChild();
   let spawnCalls = 0;

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,7 +1,7 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 import { callDaemonTarget, localDaemonTarget } from "./coven-daemon.ts";
-import { covenBin } from "./coven-bin.ts";
+import { covenBin, covenLaunchCommand } from "./coven-bin.ts";
 import { covenCliMissingError, isMissingExecutableError } from "./coven-spawn-error.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
@@ -28,7 +28,13 @@ export type DaemonStartResult =
   }
   | {
     ok: false;
-    code: "spawn_failed" | "runner_exited" | "readiness_timeout" | "runtime_incompatible" | "restart_throttled";
+    code:
+      | "spawn_failed"
+      | "runner_exited"
+      | "readiness_timeout"
+      | "runtime_incompatible"
+      | "restart_throttled"
+      | "owner_unreachable";
     error: string;
     stdout: string;
     stderr: string;
@@ -160,6 +166,8 @@ export async function terminateDaemonLaunchTree(
 
 type StartLocalDaemonOptions = {
   restart?: boolean;
+  /** Automatic recovery fails closed when another lifecycle owner is possible. */
+  automatic?: boolean;
   healthTimeoutMs?: number;
   startTimeoutMs?: number;
   readinessPollMs?: number;
@@ -169,8 +177,37 @@ type StartLocalDaemonOptions = {
   installedVersion?: () => Promise<string | null>;
   spawnImpl?: typeof spawn;
   terminateLaunchTree?: (child: ChildProcess) => Promise<DaemonLaunchCleanup>;
+  inspectLifecycle?: () => Promise<DaemonLifecycleInspection>;
   platform?: NodeJS.Platform;
 };
+
+export type DaemonLifecycleInspection = {
+  status: "running" | "stopped" | "stale" | "unknown";
+};
+
+export function parseDaemonLifecycleInspection(value: unknown): DaemonLifecycleInspection {
+  if (!value || typeof value !== "object" || !("status" in value)) {
+    return { status: "unknown" };
+  }
+  const status = value.status;
+  return status === "running" || status === "stopped" || status === "stale"
+    ? { status }
+    : { status: "unknown" };
+}
+
+async function inspectDaemonLifecycle(): Promise<DaemonLifecycleInspection> {
+  try {
+    const { command, fixedArgs } = covenLaunchCommand();
+    const { stdout } = await execFileAsync(
+      command,
+      [...fixedArgs, "daemon", "status", "--json"],
+      { encoding: "utf8", env: harnessSpawnEnv(), timeout: 2_500, windowsHide: true },
+    );
+    return parseDaemonLifecycleInspection(JSON.parse(stdout));
+  } catch {
+    return { status: "unknown" };
+  }
+}
 
 /**
  * Process output can contain local paths, npm configuration, and credentials.
@@ -223,6 +260,7 @@ export function startLocalDaemon(options: StartLocalDaemonOptions = {}): Promise
 
 async function runLocalDaemonStart({
   restart = false,
+  automatic = false,
   healthTimeoutMs = 1500,
   startTimeoutMs = 8000,
   readinessPollMs = 250,
@@ -230,6 +268,7 @@ async function runLocalDaemonStart({
   installedVersion,
   spawnImpl = spawn,
   terminateLaunchTree = terminateDaemonLaunchTree,
+  inspectLifecycle = inspectDaemonLifecycle,
   platform = process.platform,
 }: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
   const compatibilityState: { current: DaemonStartupCompatibility | null } = { current: null };
@@ -267,6 +306,28 @@ async function runLocalDaemonStart({
     }
   }
 
+  if (automatic && !restart) {
+    const lifecycle = await inspectLifecycle();
+    if (lifecycle.status === "running") {
+      return { ok: true, alreadyRunning: true, readinessAttempts: 2, elapsedMs: Date.now() - startedAt, launchMode: "none" };
+    }
+    if (lifecycle.status !== "stopped") {
+      return {
+        ok: false,
+        code: "owner_unreachable",
+        error: lifecycle.status === "stale"
+          ? "daemon owner is still running but health is unavailable; automatic recovery deferred"
+          : "daemon lifecycle could not be confirmed; automatic recovery deferred",
+        stdout: "",
+        stderr: "",
+        status: 409,
+        readinessAttempts: 2,
+        elapsedMs: Date.now() - startedAt,
+        launchMode: "none",
+      };
+    }
+  }
+
   const launchMode = platform === "win32" ? "shell" : "direct";
   const child = spawnImpl(covenBin(), ["daemon", "start"], {
     stdio: ["ignore", "pipe", "pipe"],
@@ -297,6 +358,7 @@ async function runLocalDaemonStart({
     probe,
     timeoutMs: startTimeoutMs,
     pollMs: readinessPollMs,
+    runnerExitGraceMs: Math.min(1_500, startTimeoutMs),
     runnerExited: () => spawnError !== null || exitCode !== undefined,
   });
   if (readiness.ready) {

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -259,7 +259,7 @@ export function startLocalDaemon(options: StartLocalDaemonOptions = {}): Promise
 }
 
 async function runLocalDaemonStart({
-  restart = false,
+  restart: restartRequested = false,
   automatic = false,
   healthTimeoutMs = 1500,
   startTimeoutMs = 8000,
@@ -271,6 +271,11 @@ async function runLocalDaemonStart({
   inspectLifecycle = inspectDaemonLifecycle,
   platform = process.platform,
 }: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
+  // The lifecycle preflight below is the whole point of the automatic path, and
+  // `restart` skips it. Both flags arrive from a request body, so an automatic
+  // request never restarts — otherwise `{automatic, restart}` spawns a competing
+  // daemon against a live owner.
+  const restart = automatic ? false : restartRequested;
   const compatibilityState: { current: DaemonStartupCompatibility | null } = { current: null };
   const currentCompatibility = (): DaemonStartupCompatibility | null => compatibilityState.current;
   const expectedVersion = probeOverride ? null : await (installedVersion ?? installedCovenVersion)();


### PR DESCRIPTION
> **Draft / WIP — preserved snapshot, not yet verified.** Opened as a draft so CI runs but it cannot be merged by accident.

## Provenance

This was **uncommitted work found orphaned** in a local worktree (`.worktrees/cave-9pqt9-daemon-recovery`) — no owning Coven session or claim. It was preserved as a single signed commit so it stopped being a sole copy in a bare worktree, then pushed here for visibility and a CI signal.

## What it is

Supervisor-safe daemon recovery for bead **cave-9pqt9**. The branch carries its own design docs:

- `docs/superpowers/plans/2026-08-03-supervisor-safe-daemon-recovery.md`
- `docs/superpowers/specs/2026-08-03-supervisor-safe-daemon-recovery-design.md`

542 insertions across implementation + tests + docs:

- `src/lib/daemon-start.ts`, `daemon-readiness.ts`, `daemon-desktop-auto-start.ts` — start/readiness/auto-start logic
- `src/lib/daemon-recovery-presentation.ts` (+ test) — new recovery presentation module
- `src/app/api/daemon/start/route.ts`, `src/components/workspace.tsx` — wiring
- matching `*.test.ts` for each, wired into the app suite via `scripts/run-tests.mjs`

## Not yet done (why it's a draft)

- [ ] Not confirmed to build or pass locally — needs `pnpm test:app` / `pnpm typecheck`.
- [ ] Branch base is **5 commits behind `main`**; rebase before merge.
- [ ] Original author/session unknown — needs an owner to finish and verify.

Do not merge until the boxes above are cleared.