### PR TITLE
docs: correct the signature guidance CLAUDE.md still asserts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ yours. Use a PR.
 **Current settings** (verified live; `gh api repos/OpenCoven/coven-cave/branches/main/protection`):
 
 - PR required before merging — **0 approvals** (you can self-merge once checks pass; no second human needed for solo work).
-- Required status checks — **all NINE** must pass (widened 2026-08-01 from five): `Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment (ubuntu-latest)`, `Cross-environment (windows-latest)`, `Cross-environment required`, `Sidecar runtime (ubuntu-latest)`, `Sidecar runtime (windows-latest)`, `Sidecar runtime required`. The four matrix legs were added alongside their `*-required` rollups. The rollups already fail unless `needs.<job>.result == 'success'`, so this is defense in depth rather than a gap being closed — it removes the dependency on those aggregation scripts staying correct. Classic branch protection is the active enforcement layer. Ruleset `19123333` lists the same nine checks but is currently disabled, so it does not provide a second gate. Only `ci.yml` runs on `pull_request` and no job carries a skippable `if:`, which is why requiring the legs is safe — a required context that never reports is what leaves a PR stuck `BLOCKED` with nothing failing. **`CodeQL` is retired** (2026-07-31): the ruleset's `code_scanning` rule went first, then the required context in classic branch protection, and now the workflow itself. Code scanning is fully off — GitHub default setup is `not-configured`, so nothing scans in its place. If you ever see a PR stuck `BLOCKED` with `mergeable: MERGEABLE`, no failing check and every conversation resolved, suspect a required context that no longer reports; compare `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the checks the PR actually runs. The `E2E (Playwright)` job runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs must be self-contained — dismiss onboarding (`cave:onboarding:dismissed=1`) and drive surfaces via `page.route(...)` API mocks rather than a live daemon.
+- Required status checks — **all NINE** must pass (widened 2026-08-01 from five): `Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment (ubuntu-latest)`, `Cross-environment (windows-latest)`, `Cross-environment required`, `Sidecar runtime (ubuntu-latest)`, `Sidecar runtime (windows-latest)`, `Sidecar runtime required`. The four matrix legs were added alongside their `*-required` rollups. The rollups already fail unless `needs.<job>.result == 'success'`, so this is defense in depth rather than a gap being closed — it removes the dependency on those aggregation scripts staying correct. Classic branch protection is the active enforcement layer. Ruleset `19123333` lists the same nine checks but is currently disabled, so it does not provide a second gate. Only `ci.yml` runs on `pull_request` and no job carries a skippable `if:`, which is why requiring the legs is safe — a required context that never reports is what leaves a PR stuck `BLOCKED` with nothing failing. **`CodeQL` is retired** (2026-07-31): the ruleset's `code_scanning` rule went first, then the required context in classic branch protection, and now the workflow itself. Code scanning is fully off — GitHub default setup is `not-configured`, so nothing scans in its place. If you ever see a PR stuck `BLOCKED` with `mergeable: MERGEABLE`, no failing check and every conversation resolved, check two things: a required context that no longer reports (compare `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the checks the PR actually runs), and `required_signatures` (see the signatures bullet below — it produced exactly this symptom on three PRs and is now off). The `E2E (Playwright)` job runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs must be self-contained — dismiss onboarding (`cave:onboarding:dismissed=1`) and drive surfaces via `page.route(...)` API mocks rather than a live daemon.
 - Review conversations are **no longer required to be resolved**
   (`required_conversation_resolution` was turned OFF on 2026-08-01, at the
   user's direction). A PR with green checks merges with open threads.
@@ -61,9 +61,38 @@ yours. Use a PR.
   gh api repos/OpenCoven/coven-cave/branches/main/protection \
     --jq .required_conversation_resolution.enabled
   ```
-- Commit signatures are **required** (`required_signatures`) — the server
-  rejects unsigned commits outright, so the global `-S` rule is enforced, not
-  merely advised.
+- Commit signatures are **NOT required** (`required_signatures: false` as of
+  2026-08-03, at the owner's direction). The global `-S` rule is therefore
+  advisory here: an unsigned commit merges fine, it just never earns the green
+  *Verified* badge on GitHub. Sign anyway when you can — but do not treat a
+  missing signature as a blocker.
+
+  **This was flipped because it was silently blocking merges.** While it was
+  on, three PRs sat `BLOCKED` with all nine required checks green, zero
+  approvals outstanding, and every review thread resolved. GitHub never says
+  the word "signature" anywhere in that state — not in the PR UI, not in
+  `gh pr merge` output, not in `mergeStateStatus`, which reads only `BLOCKED`
+  against `mergeable: MERGEABLE`. #4308 flipped to `CLEAN` the instant the
+  setting came off, with no other change.
+
+  So when a PR is `BLOCKED` with nothing failing, check signatures **as part
+  of the standard sweep** rather than after exhausting everything else:
+
+  ```bash
+  gh api repos/OpenCoven/coven-cave/branches/main/protection \
+    --jq .required_signatures.enabled
+  gh api repos/OpenCoven/coven-cave/pulls/<#>/commits \
+    --jq '.[] | "\(.sha[0:9]) \(.commit.verification.verified) \(.commit.verification.reason)"'
+  ```
+
+  ⚠️ **Do not verify signatures with `git log --show-signature` or `%G?`
+  locally** — this checkout has no allowed-signers file, so `%G?` prints `E`
+  for *every* commit including ones GitHub reports as `verified=true`. The API
+  field `commit.verification.verified` is the only reliable signal.
+
+  Note also that unsigned commits here come from a **second git identity**
+  ("Timothy Wayne Gregg") that lacks `commit.gpgsign` / `user.signingkey`,
+  not from the primary one. A single PR can mix both authors.
 - Branches do **not** need to be up to date with `main` (`strict: false`), so
   being behind is never the reason a merge is blocked.
 - 🔒 `enforce_admins = false` — **the repository owner is exempt, by standing
@@ -146,7 +175,7 @@ gh api repos/OpenCoven/coven-cave/rulesets/19123333 \
 ```bash
 # work on a branch (in a worktree, per the convention below)
 pnpm beads:worktrees:create --bead <id> --branch <branch> --owner <you> --purpose "…"
-# … commit (signed, per the global -S rule) …
+# … commit (signing is optional — see the signatures bullet above) …
 git push -u origin <branch>
 gh pr create --base main --head <branch> --title "…" --body "…"
 # wait for the required checks to go green. Resolving review threads is NO


### PR DESCRIPTION
`required_signatures` was turned off on `main` on 2026-08-03 at the owner's direction, but CLAUDE.md still states that *"the server rejects unsigned commits outright, so the global `-S` rule is enforced, not merely advised."* Left as-is that sends the next session chasing a rule that is not there.

## Why this is worth more than a flag flip

While the setting was on it blocked merges **silently**. Three PRs sat `BLOCKED` with:

- all nine required checks green,
- zero approvals outstanding,
- every review thread resolved,
- `mergeable: MERGEABLE`.

GitHub never names signatures in that state — not in the PR UI, not in `gh pr merge` output, not in `mergeStateStatus`. The correlation was exact: #4308 (4/4 unsigned), #4283 (4/5), #4315 (1/6) were all blocked; the two PRs with zero unsigned commits were `CLEAN`. #4308 flipped to `CLEAN` the instant the setting came off, with no other change.

## What changed

- The signatures bullet now states the setting is off, that signing is advisory (unsigned merges fine, just no *Verified* badge), and carries the diagnostic recipe.
- The `BLOCKED`-with-nothing-failing diagnostic at line 27 previously pointed **only** at a phantom required context. It now names signatures too, since that produced this exact symptom.
- The PR-workflow snippet no longer tells you to commit "signed, per the global `-S` rule".

## Two traps recorded

- **`git log --show-signature` / `%G?` are useless in this checkout.** There is no allowed-signers file, so `%G?` prints `E` for *every* commit — including ones the API reports `verified=true`. Only `commit.verification.verified` from the API is reliable. I nearly misread main as unsigned because of this.
- **Unsigned commits come from a second git identity** ("Timothy Wayne Gregg") lacking `commit.gpgsign` / `user.signingkey`, not the primary one. A single PR can mix both authors.

Docs-only change.