### PR TITLE
fix(ios): make the session picker actually switch conversations

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -200,6 +200,19 @@ final class AppModel {
         threadToOpen = thread
     }
 
+    /// Switch the visible conversation to one chosen in the session picker.
+    ///
+    /// Re-choosing the conversation already open is a no-op: routing it through
+    /// `requestOpen` would tear down and rebuild the very chat being looked at,
+    /// losing scroll position for no gain. Returns whether a switch was
+    /// actually requested, so the caller can skip its haptic when nothing moved.
+    @discardableResult
+    func switchConversation(to chosen: ChatThread, currentThreadId: String?) -> Bool {
+        guard chosen.id != currentThreadId else { return false }
+        requestOpen(chosen)
+        return true
+    }
+
     /// Consume the launch-thread intent only after its thread is available.
     /// A delayed thread restore leaves the id pending for `ChatsHomeView` to
     /// retry when hydration publishes its matching thread.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -55,8 +55,11 @@ struct ChatView: View {
     @State private var showSessionDetails = false
     @State private var showSessionPicker = false
     @State private var showVoiceCall = false
-    /// Navigation path handed to the session picker. It pushes nothing, but
-    /// FamiliarThreadsView requires the binding.
+    /// Inert navigation path handed to the session picker to satisfy its
+    /// binding. The picker runs in `onSelect` mode, so it never pushes — a
+    /// chosen session is switched to via `switchToSession` instead. Pushing
+    /// here would strand the selection: this sheet's `NavigationStack` is not
+    /// bound to it.
     @State private var pickerPath: [ChatRoute] = []
     @Namespace private var pickerZoomNamespace
     @State private var atBottom = true
@@ -369,7 +372,9 @@ struct ChatView: View {
                 NavigationStack {
                     FamiliarThreadsView(familiar: familiar,
                                         path: $pickerPath,
-                                        zoomNamespace: pickerZoomNamespace)
+                                        zoomNamespace: pickerZoomNamespace,
+                                        onSelect: { chosen in switchToSession(chosen) },
+                                        currentThreadId: thread.id)
                 }
             } else {
                 // Group threads and any thread whose familiar no longer
@@ -382,6 +387,22 @@ struct ChatView: View {
                 }
             }
         }
+    }
+
+    /// Switch the chat to a session chosen in the picker: close the picker,
+    /// then hand the thread to the chat list, which makes it the detail
+    /// column's conversation and clears any pushed navigation. The chosen
+    /// session then stays put until something asks for another one.
+    ///
+    /// Re-picking the session already open only closes the sheet — routing it
+    /// through `requestOpen` would rebuild the very chat being looked at.
+    private func switchToSession(_ chosen: ChatThread) {
+        showSessionPicker = false
+        guard chosen.id != thread.id else { return }
+        // Persist the composer draft before the detail column swaps away.
+        flushDraftPersistence()
+        Haptics.tap()
+        app.switchConversation(to: chosen, currentThreadId: thread.id)
     }
 
     private var sessionDetailsCard: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -382,12 +382,14 @@ struct FamiliarThreadsView: View {
         case .local(let thread):
             // Laid out beside the row rather than overlaid on it: ThreadRow's
             // preview runs two lines to the trailing edge, so an overlay mark
-            // would print on top of the text.
+            // would print on top of the text. The zoom stays anchored on the
+            // row itself, not this wrapper, so the transition geometry is
+            // unchanged by the mark.
             HStack(spacing: 8) {
                 ThreadRow(thread: thread)
+                    .matchedTransitionSource(id: thread.id, in: zoomNamespace)
                 currentMark(for: thread.id)
             }
-            .matchedTransitionSource(id: thread.id, in: zoomNamespace)
         case .server(let session):
             ServerSessionRow(session: session)
         }

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -7,11 +7,25 @@ import SwiftUI
 /// fresh, separate thread.
 struct FamiliarThreadsView: View {
     @Environment(AppModel.self) private var app
+    @Environment(\.dismiss) private var dismiss
     let familiar: Familiar
     @Binding var path: [ChatRoute]
     /// Namespace owned by `ChatsHomeView`; local thread rows register as
     /// zoom-transition sources so the pushed conversation grows out of them.
     var zoomNamespace: Namespace.ID
+    /// Picker mode. When set, choosing a row hands the thread back to the
+    /// presenter instead of pushing it onto `path`.
+    ///
+    /// This exists because pushing does not work when the view is presented as
+    /// a sheet: ChatView's session switcher wraps it in its own
+    /// `NavigationStack` that is *not* bound to `path`, so every
+    /// `path.append` wrote into state nothing rendered and the tap did
+    /// nothing at all. Handing the thread back lets the presenter close the
+    /// sheet and switch the conversation for real.
+    var onSelect: ((ChatThread) -> Void)? = nil
+    /// The conversation already on screen behind the picker, marked as current
+    /// so switching is a visible move rather than a guess.
+    var currentThreadId: String? = nil
     @State private var renamingThread: ChatThread?
     /// An on-device thread awaiting delete confirmation (swipe or context menu).
     @State private var pendingDelete: ChatThread?
@@ -100,6 +114,13 @@ struct FamiliarThreadsView: View {
                     }
                 }
             }
+            // Presented as a sheet there is no back button, so picker mode
+            // needs an explicit way out that isn't "pick something".
+            ToolbarItem(placement: .topBarLeading) {
+                if isPicking && !selectMode {
+                    Button("Done") { dismiss() }
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 if selectMode {
                     Button("Cancel") { exitSelect() }
@@ -166,7 +187,10 @@ struct FamiliarThreadsView: View {
             NewChatView(initialFamiliarIds: [familiar.id]) { thread in
                 showNewChat = false
                 Haptics.tap()
-                path.append(.thread(thread))
+                // Same routing as a tapped row: in picker mode a brand-new
+                // chat must reach the presenter too, or "New chat" from the
+                // session switcher silently does nothing.
+                choose(thread)
             }
         }
     }
@@ -185,7 +209,9 @@ struct FamiliarThreadsView: View {
                     }
                 }
                     .buttonStyle(.plain)
-                    .accessibilityAddTraits(selectMode && isSelected(entry) ? .isSelected : [])
+                    .accessibilityAddTraits(
+                        (selectMode && isSelected(entry)) || (isPicking && !selectMode && isCurrent(entry))
+                            ? .isSelected : [])
                     .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     // Only on-device threads can be renamed/deleted from here; a
                     // server-only session lives on the desktop, so its rows offer
@@ -339,26 +365,64 @@ struct FamiliarThreadsView: View {
         return false
     }
 
+    /// Whether a row is the conversation already open behind the picker.
+    private func isCurrent(_ entry: Entry) -> Bool {
+        guard let currentThreadId else { return false }
+        if case .local(let thread) = entry { return thread.id == currentThreadId }
+        return false
+    }
+
+    /// Picker mode — presented as a sheet to choose a session, rather than
+    /// pushed as a browsable list.
+    private var isPicking: Bool { onSelect != nil }
+
     @ViewBuilder
     private func row(_ entry: Entry) -> some View {
         switch entry {
         case .local(let thread):
-            ThreadRow(thread: thread)
-                .matchedTransitionSource(id: thread.id, in: zoomNamespace)
+            // Laid out beside the row rather than overlaid on it: ThreadRow's
+            // preview runs two lines to the trailing edge, so an overlay mark
+            // would print on top of the text.
+            HStack(spacing: 8) {
+                ThreadRow(thread: thread)
+                currentMark(for: thread.id)
+            }
+            .matchedTransitionSource(id: thread.id, in: zoomNamespace)
         case .server(let session):
             ServerSessionRow(session: session)
+        }
+    }
+
+    /// Marks the conversation already open behind the picker. Colour is not the
+    /// only channel — the row also carries the `.isSelected` trait for
+    /// VoiceOver, and the glyph itself is a distinct shape.
+    @ViewBuilder
+    private func currentMark(for threadId: String) -> some View {
+        if isPicking && !selectMode && threadId == currentThreadId {
+            Image(systemName: "checkmark.circle.fill")
+                .font(.footnote)
+                .foregroundStyle(Color.accentColor)
+                .accessibilityHidden(true)
+        }
+    }
+
+    /// Hand a chosen conversation to the presenter (picker mode) or push it.
+    private func choose(_ thread: ChatThread) {
+        if let onSelect {
+            onSelect(thread)
+        } else {
+            path.append(.thread(thread))
         }
     }
 
     private func open(_ entry: Entry) {
         switch entry {
         case .local(let thread):
-            path.append(.thread(thread))
+            choose(thread)
         case .server(let session):
             // Bind the server session to a local thread (and pull its history),
             // then open it like any other.
-            let thread = app.openServerSession(session, familiarId: familiar.id)
-            path.append(.thread(thread))
+            choose(app.openServerSession(session, familiarId: familiar.id))
         }
     }
 

--- a/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import CovenCave
+
+/// The session switcher's routing contract.
+///
+/// Choosing a session in ChatView's picker used to do nothing at all: the
+/// picker pushed onto a `[ChatRoute]` binding whose `NavigationStack` was never
+/// bound to it, so the tap wrote into state nothing rendered. The switch now
+/// goes through `AppModel`, which is what these tests pin.
+@MainActor
+final class SessionSwitchTests: XCTestCase {
+
+    private func thread(_ id: String) -> ChatThread {
+        ChatThread(id: id, title: id, familiarIds: ["nyx"])
+    }
+
+    /// The switch must actually reach the chat list, not dead-end.
+    func testSwitchingToAnotherSessionRequestsItAndSelectsChats() {
+        let app = AppModel()
+        app.selectedTab = .settings
+        let chosen = thread("other-session")
+
+        XCTAssertTrue(app.switchConversation(to: chosen, currentThreadId: "current-session"))
+
+        XCTAssertTrue(app.threadToOpen === chosen)
+        XCTAssertEqual(app.selectedTab, .chats)
+    }
+
+    /// Re-picking the conversation already open must not rebuild it — that
+    /// would tear down the chat being looked at and lose scroll position.
+    func testChoosingTheCurrentSessionIsANoOp() {
+        let app = AppModel()
+        let current = thread("current-session")
+
+        XCTAssertFalse(app.switchConversation(to: current, currentThreadId: "current-session"))
+
+        XCTAssertNil(app.threadToOpen)
+    }
+
+    /// A chat with nothing open behind it (no current id) still switches,
+    /// rather than being mistaken for a no-op.
+    func testSwitchingWithNoCurrentSessionStillOpens() {
+        let app = AppModel()
+        let chosen = thread("first-session")
+
+        XCTAssertTrue(app.switchConversation(to: chosen, currentThreadId: nil))
+
+        XCTAssertTrue(app.threadToOpen === chosen)
+    }
+
+    /// The chosen session must stay put: consuming the request clears the
+    /// one-shot so nothing re-opens a different thread behind the user's back.
+    func testRequestIsAOneShotSoTheChosenSessionSticks() {
+        let app = AppModel()
+        let chosen = thread("sticky-session")
+
+        app.switchConversation(to: chosen, currentThreadId: "current-session")
+        XCTAssertTrue(app.threadToOpen === chosen)
+
+        // ChatsHomeView clears the intent once it has opened the thread.
+        app.threadToOpen = nil
+        XCTAssertNil(app.threadToOpen)
+    }
+}


### PR DESCRIPTION
Closes cave-vut6z.

## The bug

Tapping a session in ChatView's session switcher did **nothing at all** — the sheet stayed open and the conversation never changed. "New chat" launched from inside that sheet was equally dead.

`ChatView` presents `FamiliarThreadsView` in a `.sheet` wrapped in its own `NavigationStack` **with no `path:` binding**. `FamiliarThreadsView.open()` appended to that binding — ChatView's `@State pickerPath` — which nothing renders. Every tap wrote into state no view was observing.

The original code half-knew this; its comment read *"It pushes nothing, but FamiliarThreadsView requires the binding."* What it missed is that `path.append` was the view's **only** way to open a thread, so satisfying the binding with an inert array silently removed the feature.

## The fix

`FamiliarThreadsView` gets an explicit picker mode. With `onSelect` set, a chosen row — and a newly created chat — is handed back to the presenter instead of pushed. `ChatView` routes that through the new `AppModel.switchConversation`, which sets `threadToOpen` + `selectedTab`; `ChatsHomeView` then clears `detailPath` and makes the chosen thread the detail column's conversation.

That satisfies all three requirements: it **switches**, the menu **closes**, and the chosen session **stays put** until something asks for another one.

Pushed browsing (`FamiliarThreadsView` reached from the chat list) is untouched — with no `onSelect`, `choose` still appends to `path`.

## UI/UX

- The conversation already open is **marked current**, laid out *beside* the row rather than overlaid — `ThreadRow`'s preview runs two lines to the trailing edge, so an overlay printed on top of the text.
- That mark is **not colour-only**: the row also carries `.isSelected` for VoiceOver.
- Picker mode gets a **Done** button. Presented as a sheet there is no back button, so leaving without choosing had no affordance at all.
- **Re-picking the open session** only closes the sheet, rather than routing through `requestOpen` and rebuilding the chat being looked at (losing scroll position for no gain).
- The **composer draft is flushed** before the detail column swaps away.

## Verification

- 4 new `SessionSwitchTests` pinning `switchConversation` (switches, no-ops on re-pick, handles a nil current id, one-shot intent).
- **374/374 `CovenCaveTests` pass** on iPhone 16 Pro.
- `pnpm check:tests-wired` clean.
