### PR TITLE
test(ios): make the session-stickiness test actually assert stickiness

### DIFF
--- a/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/SessionSwitchTests.swift
@@ -48,17 +48,21 @@ final class SessionSwitchTests: XCTestCase {
         XCTAssertTrue(app.threadToOpen === chosen)
     }
 
-    /// The chosen session must stay put: consuming the request clears the
-    /// one-shot so nothing re-opens a different thread behind the user's back.
-    func testRequestIsAOneShotSoTheChosenSessionSticks() {
+    /// The chosen session must stay put once opened. After the view consumes
+    /// the one-shot request, that session is now the current one — so the
+    /// picker offering it again must not re-request it and rebuild the chat.
+    func testChosenSessionSticksAfterTheRequestIsConsumed() {
         let app = AppModel()
         let chosen = thread("sticky-session")
 
-        app.switchConversation(to: chosen, currentThreadId: "current-session")
+        XCTAssertTrue(app.switchConversation(to: chosen, currentThreadId: "previous-session"))
         XCTAssertTrue(app.threadToOpen === chosen)
 
         // ChatsHomeView clears the intent once it has opened the thread.
         app.threadToOpen = nil
+
+        // Re-picking it now that it is the open conversation must do nothing.
+        XCTAssertFalse(app.switchConversation(to: chosen, currentThreadId: chosen.id))
         XCTAssertNil(app.threadToOpen)
     }
 }


### PR DESCRIPTION
Follow-up to #4322.

That PR's fourth test was vacuous where it mattered most. Its final assertion checked `threadToOpen` was nil on the line immediately after setting it to nil — it would have passed against any implementation, including one that never sticks.

Assert the real property instead: once `ChatsHomeView` consumes the one-shot and the chosen thread *is* the open conversation, offering it again in the picker must not re-request it. That no-op is what keeps the chosen session put rather than rebuilding the chat under the user — the "keeps to the chosen session" half of the original bug.

Also tightened the setup so the initial switch asserts it returned `true` from a genuinely different session, rather than discarding the result.

Verified: 4/4 `SessionSwitchTests` and 374/374 `CovenCaveTests` pass on iPhone 16 Pro.