### PR TITLE
test(ios): verify the session switch with a real tap in the simulator

### DIFF
--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -399,6 +399,19 @@ final class AppModel {
         // fixture state and the preview never touches the saved thread store.
         if ProcessInfo.processInfo.arguments.contains("--ui-preview-empty-chat") {
             configureEmptyChatPreview()
+            if ProcessInfo.processInfo.arguments.contains("--ui-preview-second-thread") {
+                // A second conversation with the same familiar, so the session
+                // switcher has somewhere to switch *to*. Without it the picker
+                // lists one row and a UI test cannot tell a working switch
+                // apart from the dead-end it replaced.
+                threads.append(
+                    ChatThread(
+                        id: "ui-preview-second-chat",
+                        title: "Chat with Nyx on Jul 27",
+                        familiarIds: ["nyx"]
+                    )
+                )
+            }
             ChatTurnNotifier.shared.app = self
             return
         }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -449,6 +449,9 @@ struct ChatView: View {
                 )
             }
             .buttonStyle(.plain)
+            .accessibilityIdentifier("Switch session")
+            .accessibilityLabel("Session")
+            .accessibilityValue(thread.title)
             .disabled(thread.isGroup)
             ForEach(presentedModelControlCapabilities) { capability in
                 Divider()

--- a/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/FamiliarThreadsView.swift
@@ -209,6 +209,7 @@ struct FamiliarThreadsView: View {
                     }
                 }
                     .buttonStyle(.plain)
+                    .accessibilityIdentifier("Thread row \(entry.id)")
                     .accessibilityAddTraits(
                         (selectMode && isSelected(entry)) || (isPicking && !selectMode && isCurrent(entry))
                             ? .isSelected : [])

--- a/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/SessionSwitchUITests.swift
@@ -1,0 +1,81 @@
+import XCTest
+
+/// Drives the session switcher the way a thumb does.
+///
+/// The bug this covers was invisible to every host-side test: ChatView
+/// presented the picker inside a `NavigationStack` with no `path:` binding, so
+/// the picker's `path.append` wrote into state nothing rendered and tapping a
+/// session did nothing whatsoever. Unit tests over `AppModel` prove the routing
+/// contract, but only a real tap proves the sheet dismissal and the navigation
+/// mutation survive happening in the same state update.
+final class SessionSwitchUITests: XCTestCase {
+
+    private let firstThread = "Chat with Nyx on Jul 26"
+    private let secondThread = "Chat with Nyx on Jul 27"
+
+    private func launchInFirstThread() -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = ["--ui-preview-empty-chat", "--ui-preview-second-thread"]
+        app.launchEnvironment["CAVE_OPEN_THREAD"] = "ui-preview-empty-chat"
+        app.launch()
+        XCTAssertTrue(app.navigationBars[firstThread].waitForExistence(timeout: 15),
+                      "the launch thread opens")
+        return app
+    }
+
+    /// Opens the switcher from the chat's session controls.
+    private func openSessionPicker(_ app: XCUIApplication) {
+        let controls = app.buttons["Session controls"]
+        XCTAssertTrue(controls.waitForExistence(timeout: 10), "session controls are reachable")
+        controls.tap()
+
+        let sessionRow = app.buttons["Switch session"].firstMatch
+        XCTAssertTrue(sessionRow.waitForExistence(timeout: 10), "the details card offers Session")
+        sessionRow.tap()
+    }
+
+    /// The whole point: tapping a session switches to it, closes the switcher,
+    /// and stays there. Before the fix every one of these three assertions
+    /// failed — the tap was a complete no-op.
+    @MainActor
+    func testTappingASessionSwitchesToItAndClosesThePicker() {
+        let app = launchInFirstThread()
+        openSessionPicker(app)
+
+        let target = app.buttons["Thread row local-ui-preview-second-chat"].firstMatch
+        XCTAssertTrue(target.waitForExistence(timeout: 10), "the other session is listed")
+        target.tap()
+
+        // Switches.
+        XCTAssertTrue(app.navigationBars[secondThread].waitForExistence(timeout: 10),
+                      "tapping a session opens it")
+        // Closes the switcher. Asserted via the picker's own rows rather than
+        // its Done button: Done arrived with the fix, so a pre-fix build would
+        // pass a Done-based check for the wrong reason.
+        XCTAssertFalse(app.buttons["Thread row local-ui-preview-empty-chat"].exists,
+                       "the picker sheet is dismissed")
+        // Stays put.
+        XCTAssertFalse(app.navigationBars[firstThread].exists,
+                       "the previous conversation is gone")
+
+        sleep(1)
+        XCTAssertTrue(app.navigationBars[secondThread].exists,
+                      "the chosen session stays put rather than snapping back")
+    }
+
+    /// Leaving the switcher without choosing must be possible. Presented as a
+    /// sheet there is no back button, so before the fix the only exits were a
+    /// swipe or picking something.
+    @MainActor
+    func testDoneLeavesThePickerOnTheCurrentSession() {
+        let app = launchInFirstThread()
+        openSessionPicker(app)
+
+        let done = app.buttons["Done"]
+        XCTAssertTrue(done.waitForExistence(timeout: 10), "picker mode offers a way out")
+        done.tap()
+
+        XCTAssertTrue(app.navigationBars[firstThread].waitForExistence(timeout: 10),
+                      "dismissing without choosing keeps the current conversation")
+    }
+}


### PR DESCRIPTION
The session-switcher fix (#4322) shipped with its actual failure mode unverified.

Every test over it exercised `AppModel.switchConversation`. That proves the routing contract and nothing else — the bug they were written for lived in the *view* layer, where a sheet's `NavigationStack` was not bound to the path the picker pushed into, so taps wrote into dead state. No host-side test could have seen that. (#4325 fixed a separate problem: one of those tests asserted nothing at all.)

`SessionSwitchUITests` closes the gap by driving the simulator the way a thumb does: tap the session controls, open the switcher, tap the other conversation, then assert the three things that were broken — it switches, the sheet closes, and the chosen session is still there a beat later rather than snapping back.

**The test was checked against the pre-fix code.** Removing `onSelect:` from ChatView's picker makes three of its four assertions fail, so it earns its keep. The dismissal assertion queries the picker's own rows rather than its Done button on purpose — Done arrived with the fix, so a Done-based check would pass a pre-fix build for the wrong reason.

Supporting changes, both needed to make the test possible:

- `--ui-preview-second-thread`. The empty-chat fixture ships one thread, so a switch had nowhere to go and a passing test could not be told apart from the dead-end it replaced.
- Accessibility identifiers on the two tappable elements. Both are `Button`s with composed labels, so neither surfaced to a query. The details-card row gets `Switch session` plus the explicit label and value it was missing for VoiceOver; picker rows get `Thread row <entry id>`. Keyed on ids rather than titles, so a copy change cannot quietly break the test.

Verification: 2/2 `SessionSwitchUITests` and 374/374 `CovenCaveTests` on iPhone 16 Pro, 82/82 `pnpm test:mobile`.
