### PR TITLE
perf(pty): bound streaming and add replay cursors

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_915/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_926/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 for (const runtimeFile of [
   "dist/compiled/webpack/webpack-lib.js",

--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -283,7 +283,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_915;/,
+  /const MAX_FILE_COUNT: u64 = 5_926;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -187,7 +187,10 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Windows — so 5,902 was the Ubuntu figure with no headroom at all, and the
   // Windows leg was still red at it. Set from the HIGHER figure plus the same
   // ten-file cross-platform headroom the entries above use.
-  fileCount: 5_915,
+  // 2026-08-04 (bounded PTY streaming and replay cursors, #4317): Windows
+  // CI measures 5,916 files. Keep the established ten-file cross-platform
+  // headroom rather than accepting the exact measured count.
+  fileCount: 5_926,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -102,10 +102,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_915);
+  assert.ok(metrics.fileCount <= 5_926);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_915,
+    fileCount: 5_926,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -256,7 +256,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_915);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_926);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/server.mjs
+++ b/server.mjs
@@ -56,17 +56,47 @@ const ACCESS_QUERY_PARAM = "coven_access_token";
 const SIDECAR_QUERY_PARAM = "covenCaveToken";
 const sessions = /* @__PURE__ */ new Map();
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+const PTY_FRAME_COALESCE_MS = 8;
+const PTY_FRAME_MAX_BYTES = 16 * 1024;
+const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 * 1024;
+const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013;
+const PTY_SLOW_CONSUMER_CLOSE_REASON = "slow terminal consumer; reconnect";
 const DETACH_GRACE_MS = (() => {
   const env = Number.parseInt(process.env.COVEN_CAVE_PTY_DETACH_GRACE_MS ?? "", 10);
   return Number.isFinite(env) && env > 0 ? env : 3e5;
 })();
 function appendScrollback(session, data) {
+  const nextEnd = session.streamEnd + data.length;
+  if (data.length >= SCROLLBACK_LIMIT_BYTES) {
+    session.scrollback = [data.subarray(data.length - SCROLLBACK_LIMIT_BYTES)];
+    session.scrollbackBytes = SCROLLBACK_LIMIT_BYTES;
+    session.scrollbackStart = nextEnd - SCROLLBACK_LIMIT_BYTES;
+    session.streamEnd = nextEnd;
+    return;
+  }
   session.scrollback.push(data);
   session.scrollbackBytes += data.length;
+  session.streamEnd = nextEnd;
   while (session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES && session.scrollback.length > 1) {
     const dropped = session.scrollback.shift();
-    if (dropped) session.scrollbackBytes -= dropped.length;
+    if (dropped) {
+      session.scrollbackBytes -= dropped.length;
+      session.scrollbackStart += dropped.length;
+    }
   }
+}
+function scrollbackFrom(session, cursor) {
+  const output = [];
+  let remaining = cursor - session.scrollbackStart;
+  for (const chunk of session.scrollback) {
+    if (remaining >= chunk.length) {
+      remaining -= chunk.length;
+      continue;
+    }
+    output.push(remaining > 0 ? chunk.subarray(remaining) : chunk);
+    remaining = 0;
+  }
+  return output;
 }
 function getTokensFromCookie(header) {
   if (!header) return [];
@@ -156,6 +186,14 @@ function isAllowedUpgradeSource(req, tokenAuthenticated = false) {
 }
 function firstQueryValue(value) {
   return Array.isArray(value) ? value[0] : value;
+}
+function parsePtyReplayCursor(value) {
+  const raw = firstQueryValue(value);
+  if (raw === void 0) return void 0;
+  if (raw === "-1") return -1;
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) return null;
+  const cursor = Number(raw);
+  return Number.isSafeInteger(cursor) ? cursor : null;
 }
 const UPGRADE_URL_BASE = "http://localhost";
 const MAX_UPGRADE_QUERY_SEGMENTS = 1e3;
@@ -265,12 +303,124 @@ function sanitizedEnv() {
   return env;
 }
 function sendPtyData(ws, data) {
-  if (ws.readyState !== WebSocket.OPEN) return;
-  const encoded = Buffer.from(data, "utf8");
-  const frame = Buffer.allocUnsafe(1 + encoded.length);
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(1 + data.length);
   frame[0] = 1;
-  encoded.copy(frame, 1);
-  ws.send(frame);
+  data.copy(frame, 1);
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function sendPtyReplayCursor(ws, cursor, reset) {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(10);
+  frame[0] = 6;
+  frame.writeDoubleLE(cursor, 1);
+  frame[9] = reset ? 1 : 0;
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function clearPendingPtyOutput(session) {
+  if (session.flushTimer) {
+    clearTimeout(session.flushTimer);
+    session.flushTimer = null;
+  }
+  session.pendingOutput = [];
+  session.pendingOutputBytes = 0;
+}
+function armPtyDetach(threadId, session) {
+  if (session.detachTimer) clearTimeout(session.detachTimer);
+  session.detachTimer = setTimeout(() => {
+    const current = sessions.get(threadId);
+    if (current !== session || current.ws) return;
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+    }
+  }, DETACH_GRACE_MS);
+}
+function detachPtyConsumer(threadId, session, ws) {
+  if (session.ws !== ws) return;
+  session.ws = null;
+  clearPendingPtyOutput(session);
+  armPtyDetach(threadId, session);
+}
+function evictSlowPtyConsumer(threadId, session, ws) {
+  if (session.ws !== ws) return;
+  detachPtyConsumer(threadId, session, ws);
+  try {
+    ws.close(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON);
+  } catch {
+  }
+}
+function flushPtyOutput(threadId, session) {
+  session.flushTimer = null;
+  const ws = session.ws;
+  if (!ws || session.pendingOutputBytes === 0) return;
+  const chunks = session.pendingOutput;
+  clearPendingPtyOutput(session);
+  const payload = Buffer.concat(chunks);
+  if (ws.readyState !== WebSocket.OPEN || session.ws !== ws) return;
+  if (ws.bufferedAmount + payload.length + 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT) {
+    evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  if (!sendPtyData(ws, payload)) {
+    detachPtyConsumer(threadId, session, ws);
+  }
+}
+function queuePtyOutput(threadId, session, data) {
+  if (!session.ws || data.length === 0) return;
+  let offset = 0;
+  while (offset < data.length && session.ws) {
+    const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
+    const take = Math.min(room, data.length - offset);
+    session.pendingOutput.push(data.subarray(offset, offset + take));
+    session.pendingOutputBytes += take;
+    offset += take;
+    if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {
+      flushPtyOutput(threadId, session);
+    }
+  }
+  if (session.ws && session.pendingOutputBytes > 0 && !session.flushTimer) {
+    session.flushTimer = setTimeout(
+      () => flushPtyOutput(threadId, session),
+      PTY_FRAME_COALESCE_MS
+    );
+  }
+}
+function replayPtyOutput(threadId, session, replayCursor) {
+  if (!session.ws || session.scrollbackBytes === 0) {
+    if (session.ws && replayCursor !== void 0) {
+      sendPtyReplayCursor(
+        session.ws,
+        session.streamEnd,
+        replayCursor !== -1 && replayCursor !== session.streamEnd
+      );
+    }
+    return;
+  }
+  if (replayCursor === void 0) {
+    for (const chunk of session.scrollback) queuePtyOutput(threadId, session, chunk);
+    return;
+  }
+  const validCursor = replayCursor >= session.scrollbackStart && replayCursor <= session.streamEnd;
+  const start = validCursor && replayCursor !== -1 ? replayCursor : session.scrollbackStart;
+  const reset = replayCursor !== -1 && !validCursor;
+  const ws = session.ws;
+  if (!ws || ws.bufferedAmount + 10 > PTY_WS_BUFFERED_AMOUNT_LIMIT || !sendPtyReplayCursor(ws, start, reset)) {
+    if (ws) evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  for (const chunk of scrollbackFrom(session, start)) queuePtyOutput(threadId, session, chunk);
 }
 function sendPtyExit(ws, exitCode) {
   if (ws.readyState !== WebSocket.OPEN) return;
@@ -279,7 +429,7 @@ function sendPtyExit(ws, exitCode) {
   frame.writeInt32LE(exitCode, 1);
   ws.send(frame);
 }
-function spawnPty(threadId, ws, cols, rows, cwd) {
+function spawnPty(threadId, ws, cols, rows, cwd, replayCursor) {
   const shell = pty.spawn(defaultShell(), defaultShellArgs(), {
     name: "xterm-256color",
     cols: cols > 0 ? cols : 120,
@@ -297,20 +447,28 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
   });
   const session = {
     pty: shell,
-    ws,
+    ws: null,
     scrollback: [],
     scrollbackBytes: 0,
+    scrollbackStart: 0,
+    streamEnd: 0,
+    pendingOutput: [],
+    pendingOutputBytes: 0,
+    flushTimer: null,
     detachTimer: null
   };
   sessions.set(threadId, session);
   shell.onData((data) => {
-    appendScrollback(session, Buffer.from(data, "utf8"));
-    if (session.ws) sendPtyData(session.ws, data);
+    const bytes = Buffer.from(data, "utf8");
+    appendScrollback(session, bytes);
+    queuePtyOutput(threadId, session, bytes);
   });
   shell.onExit(({ exitCode }) => {
     const current = sessions.get(threadId);
+    if (session.ws) flushPtyOutput(threadId, session);
     if (current?.pty === shell) {
       if (current.detachTimer) clearTimeout(current.detachTimer);
+      clearPendingPtyOutput(current);
       sessions.delete(threadId);
     }
     if (session.ws) {
@@ -318,6 +476,7 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
       session.ws.close(1e3, "pty exit");
     }
   });
+  adoptSession(threadId, session, ws, cols, rows, replayCursor);
 }
 function rawDataToBuffer(data) {
   if (Buffer.isBuffer(data)) return data;
@@ -339,6 +498,7 @@ function onWsMessage(threadId, data) {
     }
   } else if (tag === 5) {
     if (session.detachTimer) clearTimeout(session.detachTimer);
+    clearPendingPtyOutput(session);
     sessions.delete(threadId);
     try {
       session.pty.kill();
@@ -346,12 +506,13 @@ function onWsMessage(threadId, data) {
     }
   }
 }
-function adoptSession(session, ws, cols, rows) {
+function adoptSession(threadId, session, ws, cols, rows, replayCursor) {
   if (session.detachTimer) {
     clearTimeout(session.detachTimer);
     session.detachTimer = null;
   }
   const previous = session.ws;
+  clearPendingPtyOutput(session);
   session.ws = ws;
   if (previous && previous !== ws) {
     try {
@@ -365,32 +526,20 @@ function adoptSession(session, ws, cols, rows) {
     } catch {
     }
   }
-  if (session.scrollbackBytes > 0) {
-    sendPtyData(ws, Buffer.concat(session.scrollback).toString("utf8"));
-  }
+  replayPtyOutput(threadId, session, replayCursor);
 }
-function handlePtyConnection(ws, threadId, cols, rows, cwd) {
+function handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor) {
   const existing = sessions.get(threadId);
   if (existing) {
-    adoptSession(existing, ws, cols, rows);
+    adoptSession(threadId, existing, ws, cols, rows, replayCursor);
   } else {
-    spawnPty(threadId, ws, cols, rows, cwd);
+    spawnPty(threadId, ws, cols, rows, cwd, replayCursor);
   }
   ws.on("message", (data) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
     if (!session || session.ws !== ws) return;
-    session.ws = null;
-    if (session.detachTimer) clearTimeout(session.detachTimer);
-    session.detachTimer = setTimeout(() => {
-      const current = sessions.get(threadId);
-      if (current !== session || current.ws) return;
-      sessions.delete(threadId);
-      try {
-        session.pty.kill();
-      } catch {
-      }
-    }, DETACH_GRACE_MS);
+    detachPtyConsumer(threadId, session, ws);
   });
 }
 const dev = process.env.NODE_ENV !== "production";
@@ -442,6 +591,12 @@ server.on("upgrade", (req, socket, head) => {
     socket.destroy();
     return;
   }
+  const replayCursor = parsePtyReplayCursor(query.ptyReplayCursor);
+  if (replayCursor === null) {
+    socket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    socket.destroy();
+    return;
+  }
   let cwd;
   try {
     cwd = validateCwd(query.projectRoot ? String(query.projectRoot) : void 0);
@@ -453,7 +608,7 @@ server.on("upgrade", (req, socket, head) => {
   const cols = Number.parseInt(String(query.cols ?? "120"), 10);
   const rows = Number.parseInt(String(query.rows ?? "40"), 10);
   wss.handleUpgrade(req, socket, head, (ws) => {
-    handlePtyConnection(ws, threadId, cols, rows, cwd);
+    handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor);
   });
 });
 server.keepAliveTimeout = 75e3;

--- a/server.ts
+++ b/server.ts
@@ -106,6 +106,14 @@ type PtySession = {
    *  client repaints the screen instead of staring at a blank pane. */
   scrollback: Buffer[];
   scrollbackBytes: number;
+  /** Absolute byte cursor at the front of the retained scrollback ring. */
+  scrollbackStart: number;
+  /** Absolute cursor immediately after the newest PTY byte. */
+  streamEnd: number;
+  /** Coalesced output waiting for one bounded WebSocket frame. */
+  pendingOutput: Buffer[];
+  pendingOutputBytes: number;
+  flushTimer: NodeJS.Timeout | null;
   /** Pending kill while detached — cleared when a client reattaches. */
   detachTimer: NodeJS.Timeout | null;
 };
@@ -116,6 +124,16 @@ const sessions = new Map<string, PtySession>();
 // screen instead of staring at a blank pane. Matches the Rust desktop PTY's
 // 256KB ring (src-tauri/src/pty.rs).
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+// PTYs often emit a write-sized chunk for every line. Coalesce a short burst
+// before framing it, but cap the userland queue and every individual frame.
+const PTY_FRAME_COALESCE_MS = 8;
+const PTY_FRAME_MAX_BYTES = 16 * 1024;
+// `ws` otherwise retains arbitrary output for a client whose TCP receive
+// window stopped advancing. This is deliberately larger than one legacy
+// scrollback replay, so a healthy reattach is never evicted for the replay.
+const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 * 1024;
+const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013;
+const PTY_SLOW_CONSUMER_CLOSE_REASON = "slow terminal consumer; reconnect";
 // How long a shell survives after its socket drops before being reaped. A
 // terminal pane remounts whenever the Comux layout restructures (split,
 // drag-reorganize, tab switch) or the page reloads; killing the shell the
@@ -131,15 +149,45 @@ const DETACH_GRACE_MS = (() => {
 })();
 
 function appendScrollback(session: PtySession, data: Buffer): void {
+  const nextEnd = session.streamEnd + data.length;
+  // Retain the tail even if one node-pty callback is larger than the entire
+  // ring. The old `length > 1` loop kept that one large callback forever.
+  if (data.length >= SCROLLBACK_LIMIT_BYTES) {
+    session.scrollback = [data.subarray(data.length - SCROLLBACK_LIMIT_BYTES)];
+    session.scrollbackBytes = SCROLLBACK_LIMIT_BYTES;
+    session.scrollbackStart = nextEnd - SCROLLBACK_LIMIT_BYTES;
+    session.streamEnd = nextEnd;
+    return;
+  }
+
   session.scrollback.push(data);
   session.scrollbackBytes += data.length;
+  session.streamEnd = nextEnd;
   while (
     session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES &&
     session.scrollback.length > 1
   ) {
     const dropped = session.scrollback.shift();
-    if (dropped) session.scrollbackBytes -= dropped.length;
+    if (dropped) {
+      session.scrollbackBytes -= dropped.length;
+      session.scrollbackStart += dropped.length;
+    }
   }
+}
+
+/** Return retained output beginning at an absolute stream cursor. */
+function scrollbackFrom(session: PtySession, cursor: number): Buffer[] {
+  const output: Buffer[] = [];
+  let remaining = cursor - session.scrollbackStart;
+  for (const chunk of session.scrollback) {
+    if (remaining >= chunk.length) {
+      remaining -= chunk.length;
+      continue;
+    }
+    output.push(remaining > 0 ? chunk.subarray(remaining) : chunk);
+    remaining = 0;
+  }
+  return output;
 }
 
 function getTokensFromCookie(header: string | undefined): string[] {
@@ -287,6 +335,18 @@ function isAllowedUpgradeSource(req: IncomingMessage, tokenAuthenticated = false
 
 function firstQueryValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+/** `-1` is a capability probe: cursor-aware clients use it on their first
+ * attach, then send the last delivered absolute byte cursor on reconnect.
+ * Absence remains the legacy full-replay protocol. */
+function parsePtyReplayCursor(value: string | string[] | undefined): number | undefined | null {
+  const raw = firstQueryValue(value);
+  if (raw === undefined) return undefined;
+  if (raw === "-1") return -1;
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) return null;
+  const cursor = Number(raw);
+  return Number.isSafeInteger(cursor) ? cursor : null;
 }
 
 type UpgradeQuery = Record<string, string | string[] | undefined>;
@@ -445,13 +505,156 @@ function sanitizedEnv(): Record<string, string> {
   return env;
 }
 
-function sendPtyData(ws: WebSocket, data: string): void {
-  if (ws.readyState !== WebSocket.OPEN) return;
-  const encoded = Buffer.from(data, "utf8");
-  const frame = Buffer.allocUnsafe(1 + encoded.length);
+function sendPtyData(ws: WebSocket, data: Buffer): boolean {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(1 + data.length);
   frame[0] = 0x01;
-  encoded.copy(frame, 1);
-  ws.send(frame);
+  data.copy(frame, 1);
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Cursor control frames are opt-in (`ptyReplayCursor` query parameter), so
+ * legacy clients continue to receive the original 0x01 + terminal bytes wire
+ * format unchanged. The cursor is a safe integer stored as Float64 LE; that
+ * covers many petabytes while working in every supported WebView. */
+function sendPtyReplayCursor(ws: WebSocket, cursor: number, reset: boolean): boolean {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(10);
+  frame[0] = 0x06;
+  frame.writeDoubleLE(cursor, 1);
+  frame[9] = reset ? 1 : 0;
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearPendingPtyOutput(session: PtySession): void {
+  if (session.flushTimer) {
+    clearTimeout(session.flushTimer);
+    session.flushTimer = null;
+  }
+  session.pendingOutput = [];
+  session.pendingOutputBytes = 0;
+}
+
+function armPtyDetach(threadId: string, session: PtySession): void {
+  if (session.detachTimer) clearTimeout(session.detachTimer);
+  session.detachTimer = setTimeout(() => {
+    const current = sessions.get(threadId);
+    if (current !== session || current.ws) return;
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+      // Already gone.
+    }
+  }, DETACH_GRACE_MS);
+}
+
+function detachPtyConsumer(threadId: string, session: PtySession, ws: WebSocket): void {
+  if (session.ws !== ws) return;
+  session.ws = null;
+  clearPendingPtyOutput(session);
+  armPtyDetach(threadId, session);
+}
+
+function evictSlowPtyConsumer(threadId: string, session: PtySession, ws: WebSocket): void {
+  if (session.ws !== ws) return;
+  // Closing only the transport is intentional: output remains in the bounded
+  // ring and the live PTY gets the normal reconnect grace window.
+  detachPtyConsumer(threadId, session, ws);
+  try {
+    ws.close(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON);
+  } catch {
+    // The close handler is only cleanup; the session is already detached.
+  }
+}
+
+function flushPtyOutput(threadId: string, session: PtySession): void {
+  session.flushTimer = null;
+  const ws = session.ws;
+  if (!ws || session.pendingOutputBytes === 0) return;
+
+  const chunks = session.pendingOutput;
+  clearPendingPtyOutput(session);
+  const payload = Buffer.concat(chunks);
+  if (ws.readyState !== WebSocket.OPEN || session.ws !== ws) return;
+  if (ws.bufferedAmount + payload.length + 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT) {
+    evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  if (!sendPtyData(ws, payload)) {
+    detachPtyConsumer(threadId, session, ws);
+  }
+}
+
+function queuePtyOutput(threadId: string, session: PtySession, data: Buffer): void {
+  if (!session.ws || data.length === 0) return;
+  let offset = 0;
+  while (offset < data.length && session.ws) {
+    const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
+    const take = Math.min(room, data.length - offset);
+    session.pendingOutput.push(data.subarray(offset, offset + take));
+    session.pendingOutputBytes += take;
+    offset += take;
+    if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {
+      flushPtyOutput(threadId, session);
+    }
+  }
+  if (session.ws && session.pendingOutputBytes > 0 && !session.flushTimer) {
+    session.flushTimer = setTimeout(
+      () => flushPtyOutput(threadId, session),
+      PTY_FRAME_COALESCE_MS,
+    );
+  }
+}
+
+/** Queue either the missed suffix (cursor clients) or the bounded complete
+ * ring (legacy clients). Sending the cursor control frame first means every
+ * following 0x01 payload advances the client cursor byte-for-byte. */
+function replayPtyOutput(
+  threadId: string,
+  session: PtySession,
+  replayCursor: number | undefined,
+): void {
+  if (!session.ws || session.scrollbackBytes === 0) {
+    if (session.ws && replayCursor !== undefined) {
+      sendPtyReplayCursor(
+        session.ws,
+        session.streamEnd,
+        replayCursor !== -1 && replayCursor !== session.streamEnd,
+      );
+    }
+    return;
+  }
+
+  if (replayCursor === undefined) {
+    for (const chunk of session.scrollback) queuePtyOutput(threadId, session, chunk);
+    return;
+  }
+
+  const validCursor =
+    replayCursor >= session.scrollbackStart && replayCursor <= session.streamEnd;
+  const start = validCursor && replayCursor !== -1 ? replayCursor : session.scrollbackStart;
+  const reset = replayCursor !== -1 && !validCursor;
+  const ws = session.ws;
+  if (
+    !ws ||
+    ws.bufferedAmount + 10 > PTY_WS_BUFFERED_AMOUNT_LIMIT ||
+    !sendPtyReplayCursor(ws, start, reset)
+  ) {
+    if (ws) evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  for (const chunk of scrollbackFrom(session, start)) queuePtyOutput(threadId, session, chunk);
 }
 
 function sendPtyExit(ws: WebSocket, exitCode: number): void {
@@ -462,7 +665,14 @@ function sendPtyExit(ws: WebSocket, exitCode: number): void {
   ws.send(frame);
 }
 
-function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, cwd?: string): void {
+function spawnPty(
+  threadId: string,
+  ws: WebSocket,
+  cols: number,
+  rows: number,
+  cwd: string | undefined,
+  replayCursor: number | undefined,
+): void {
   const shell = pty.spawn(defaultShell(), defaultShellArgs(), {
     name: "xterm-256color",
     cols: cols > 0 ? cols : 120,
@@ -481,9 +691,14 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
 
   const session: PtySession = {
     pty: shell,
-    ws,
+    ws: null,
     scrollback: [],
     scrollbackBytes: 0,
+    scrollbackStart: 0,
+    streamEnd: 0,
+    pendingOutput: [],
+    pendingOutputBytes: 0,
+    flushTimer: null,
     detachTimer: null,
   };
   sessions.set(threadId, session);
@@ -493,13 +708,17 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
     // (split/reorg remount, reload, sleep/wake) sees what happened while it
     // was away. Route live output to the CURRENTLY-attached socket, not the
     // spawn-time one — adoptSession swaps session.ws on reattach.
-    appendScrollback(session, Buffer.from(data, "utf8"));
-    if (session.ws) sendPtyData(session.ws, data);
+    const bytes = Buffer.from(data, "utf8");
+    appendScrollback(session, bytes);
+    queuePtyOutput(threadId, session, bytes);
   });
   shell.onExit(({ exitCode }: { exitCode?: number | null }) => {
     const current = sessions.get(threadId);
+    // Ensure all bytes observed before onExit stay ahead of the exit frame.
+    if (session.ws) flushPtyOutput(threadId, session);
     if (current?.pty === shell) {
       if (current.detachTimer) clearTimeout(current.detachTimer);
+      clearPendingPtyOutput(current);
       sessions.delete(threadId);
     }
     if (session.ws) {
@@ -507,6 +726,8 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
       session.ws.close(1000, "pty exit");
     }
   });
+
+  adoptSession(threadId, session, ws, cols, rows, replayCursor);
 }
 
 function rawDataToBuffer(data: RawData): Buffer {
@@ -535,6 +756,7 @@ function onWsMessage(threadId: string, data: RawData): void {
     // just drops the socket, which the close handler treats as a transient
     // detach — leaking the shell (and its foreground job) for DETACH_GRACE_MS.
     if (session.detachTimer) clearTimeout(session.detachTimer);
+    clearPendingPtyOutput(session);
     sessions.delete(threadId);
     try {
       session.pty.kill();
@@ -548,16 +770,19 @@ function onWsMessage(threadId: string, data: RawData): void {
  *  socket (if any) is told it was replaced, the pending detach-kill is
  *  cancelled, and the scrollback ring is replayed so the client repaints. */
 function adoptSession(
+  threadId: string,
   session: PtySession,
   ws: WebSocket,
   cols: number,
   rows: number,
+  replayCursor: number | undefined,
 ): void {
   if (session.detachTimer) {
     clearTimeout(session.detachTimer);
     session.detachTimer = null;
   }
   const previous = session.ws;
+  clearPendingPtyOutput(session);
   session.ws = ws;
   if (previous && previous !== ws) {
     try {
@@ -573,9 +798,7 @@ function adoptSession(
       // Exited between adopt and resize; onExit handles the rest.
     }
   }
-  if (session.scrollbackBytes > 0) {
-    sendPtyData(ws, Buffer.concat(session.scrollback).toString("utf8"));
-  }
+  replayPtyOutput(threadId, session, replayCursor);
 }
 
 function handlePtyConnection(
@@ -584,6 +807,7 @@ function handlePtyConnection(
   cols: number,
   rows: number,
   cwd?: string,
+  replayCursor?: number,
 ): void {
   // Same threadId while the shell is alive (tab switch, page reload, network
   // blip, second window) → adopt the running PTY instead of killing it.
@@ -591,9 +815,9 @@ function handlePtyConnection(
   // every reconnect.
   const existing = sessions.get(threadId);
   if (existing) {
-    adoptSession(existing, ws, cols, rows);
+    adoptSession(threadId, existing, ws, cols, rows, replayCursor);
   } else {
-    spawnPty(threadId, ws, cols, rows, cwd);
+    spawnPty(threadId, ws, cols, rows, cwd, replayCursor);
   }
 
   ws.on("message", (data: RawData) => onWsMessage(threadId, data));
@@ -605,18 +829,7 @@ function handlePtyConnection(
     // Detach, don't kill: give the client a grace window to come back
     // (layout restructure remount, reload, sleep/wake). The ring keeps
     // collecting output; the timer reaps only truly-abandoned shells.
-    session.ws = null;
-    if (session.detachTimer) clearTimeout(session.detachTimer);
-    session.detachTimer = setTimeout(() => {
-      const current = sessions.get(threadId);
-      if (current !== session || current.ws) return;
-      sessions.delete(threadId);
-      try {
-        session.pty.kill();
-      } catch {
-        // Already gone.
-      }
-    }, DETACH_GRACE_MS);
+    detachPtyConsumer(threadId, session, ws);
   });
 }
 
@@ -698,6 +911,13 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
+  const replayCursor = parsePtyReplayCursor(query.ptyReplayCursor);
+  if (replayCursor === null) {
+    socket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
   let cwd: string | undefined;
   try {
     cwd = validateCwd(query.projectRoot ? String(query.projectRoot) : undefined);
@@ -711,7 +931,7 @@ server.on("upgrade", (req, socket, head) => {
   const rows = Number.parseInt(String(query.rows ?? "40"), 10);
 
   wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-    handlePtyConnection(ws, threadId, cols, rows, cwd);
+    handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor);
   });
 });
 

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -10,8 +10,10 @@ pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // cross-platform closure peaks at 5,877 files (Windows, 2026-08-03, after the
 // src/app/api/x/ route handlers landed in #4235); preserve ten-file headroom.
 // Reverted to 5_841 once by a local merge citing the older 5,831 peak — see
-// #4249. It must not move DOWN while those routes exist.
-pub(super) const MAX_FILE_COUNT: u64 = 5_915;
+// #4249. It must not move DOWN while those routes exist. The bounded PTY
+// streaming/replay-cursor closure measured 5,916 files on Windows in #4317;
+// retain the matching ten-file headroom used by the JavaScript packager.
+pub(super) const MAX_FILE_COUNT: u64 = 5_926;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -18,7 +18,8 @@ console.log("bottom-terminal-ws-bridge.test.ts OK");
 
 // ── Disconnect recovery (the "terminal stopped accepting input" class) ───────
 assert.match(src, /bridge\.onClose\(/, "terminal reacts to a dropped socket instead of freezing");
-assert.match(src, /terminal disconnected — reconnecting/, "drop is announced in the pane");
+assert.match(src, /srAnnounce\("Terminal disconnected, reconnecting", "assertive"\)/, "drop is announced without writing non-PTY bytes into xterm");
+assert.doesNotMatch(src, /terminal disconnected — reconnecting/, "reconnect status never corrupts byte-continuous terminal state");
 assert.match(src, /const RECONNECT_DELAYS_MS = \[0, 1000, 3000\]/, "reconnect retries with capped backoff");
 assert.match(
   src,
@@ -43,9 +44,9 @@ assert.match(
   /sendToPtyRef\.current = null;/,
   "teardown drops the writer so a broadcast can't write into an unmounted pane",
 );
-assert.match(src, /term\.reset\(\);[\s\S]{0,400}await bridge\.reconnect\(\)/, "screen resets before reattach so the server replay paints clean");
-assert.match(src, /term\.reset\(\);[\s\S]{0,300}decoderRef\.current = new TextDecoder/, "the streaming decoder is reset on reconnect so replayed scrollback decodes cleanly");
-assert.match(src, /reason === "replaced"/, "a take-over by another window is announced, not fought with reconnects");
+assert.match(src, /if \(!bridge\.hasReplayCursor\) \{[\s\S]{0,260}term\.reset\(\);[\s\S]{0,400}await bridge\.reconnect\(\)/, "older full-replay servers reset before reattach");
+assert.match(src, /bridge\.onReplayReset\(\(\) => \{[\s\S]{0,300}term\.reset\(\);[\s\S]{0,300}decoderRef\.current = new TextDecoder/, "expired cursor fallback resets the terminal and decoder before bounded full replay");
+assert.match(src, /reason === "replaced"[\s\S]{0,260}srAnnounce/, "a take-over by another window is announced, not fought with reconnects");
 
 // ── PTY lifetime is decoupled from view lifetime ──────────────────────────────
 // Unmount is usually a keepalive tab-switch remount; killing the PTY there

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -696,6 +696,15 @@ export function BottomTerminal({
         term.write(bytes);
         pushToMirror(bytes);
       });
+      bridge.onReplayReset(() => {
+        // The server kept the PTY alive but its bounded retained-output window
+        // no longer reaches this client cursor. Reset immediately before its
+        // legacy-style full replay; otherwise the tail would be appended to a
+        // stale terminal state.
+        term.reset();
+        decoderRef.current = new TextDecoder("utf-8", { fatal: false });
+        pendingMirrorRef.current = "";
+      });
       bridge.onExit((code) => {
         announce(
           `\r\n\x1b[2m[exit ${code} — press any key to start a new shell]\x1b[0m\r\n`,
@@ -720,14 +729,17 @@ export function BottomTerminal({
             }
             if (disposed) return;
             try {
-              // The server replays its scrollback ring on reattach; reset
-              // first so the replay paints a clean screen instead of
-              // appending a duplicate of what's already visible.
-              term.reset();
-              // Reset the streaming decoder (+ pending buffer) too: a mid-char
-              // socket drop left partial bytes that would corrupt the mirror.
-              decoderRef.current = new TextDecoder("utf-8", { fatal: false });
-              pendingMirrorRef.current = "";
+              // Cursor-aware servers replay only the bytes missed while this
+              // socket was down. Keeping xterm intact makes that replay
+              // byte-for-byte continuous; a retained-window gap is signalled
+              // through onReplayReset above and falls back to full replay.
+              // An older server does not understand the opt-in query and
+              // retains full replay, so preserve its historical reset path.
+              if (!bridge.hasReplayCursor) {
+                term.reset();
+                decoderRef.current = new TextDecoder("utf-8", { fatal: false });
+                pendingMirrorRef.current = "";
+              }
               await bridge.reconnect();
               bridge.resize(term.cols, term.rows);
               return;
@@ -735,9 +747,6 @@ export function BottomTerminal({
               /* next delay */
             }
           }
-          announce(
-            "\r\n\x1b[2m[terminal reconnect failed — press any key to retry]\x1b[0m\r\n",
-          );
           srAnnounce("Terminal reconnect failed; press any key to retry", "assertive");
         } finally {
           reconnecting = false;
@@ -747,9 +756,6 @@ export function BottomTerminal({
       bridge.onClose((_code, reason) => {
         if (disposed) return;
         if (reason === "replaced") {
-          announce(
-            "\r\n\x1b[2m[this terminal was opened in another window — view detached]\x1b[0m\r\n",
-          );
           srAnnounce("This terminal was opened in another window; this view is detached", "assertive");
           return;
         }
@@ -757,7 +763,6 @@ export function BottomTerminal({
           // onExit already announced; a keypress starts a fresh shell.
           return;
         }
-        announce("\r\n\x1b[2m[terminal disconnected — reconnecting…]\x1b[0m\r\n");
         srAnnounce("Terminal disconnected, reconnecting", "assertive");
         void attemptReconnect();
       });

--- a/src/lib/pty-ws-bridge.test.ts
+++ b/src/lib/pty-ws-bridge.test.ts
@@ -9,6 +9,7 @@ assert.match(src, /new WebSocket\(url\)/, "bridge opens a WebSocket");
 assert.match(src, /binaryType\s*=\s*"arraybuffer"/, "bridge receives binary frames");
 assert.match(src, /0x01/, "bridge handles output tag 0x01");
 assert.match(src, /0x02/, "bridge handles exit tag 0x02");
+assert.match(src, /0x06/, "bridge handles replay-cursor control frames");
 assert.match(src, /frame\[0\]\s*=\s*0x03/, "bridge sends input tag 0x03");
 assert.match(src, /frame\[0\]\s*=\s*0x04/, "bridge sends resize tag 0x04");
 assert.match(src, /setUint16\(1,\s*cols,\s*true\)/, "resize encodes cols little-endian");
@@ -51,6 +52,15 @@ assert.match(
   "a prior (possibly zombie) socket is torn down before re-dialing",
 );
 console.log("pty-ws-bridge iOS-resume assertions: ok");
+
+// ── Cursor replay ────────────────────────────────────────────────────────────
+assert.match(src, /ptyReplayCursor: String\(this\.replayCursor \?\? -1\)/, "new connections opt into cursor replay");
+assert.match(src, /private replayCursor: number \| null = null/, "bridge tracks the last delivered absolute byte cursor");
+assert.match(src, /get hasReplayCursor\(\): boolean/, "bridge distinguishes older full-replay servers");
+assert.match(src, /this\.replayCursor \+= payload\.byteLength/, "each terminal payload advances the cursor by exact bytes");
+assert.match(src, /onReplayReset\(cb: ReplayResetHandler\)/, "bridge exposes bounded-replay fallback reset handling");
+assert.match(src, /getFloat64\(0, true\)/, "cursor control frame decodes its safe integer position");
+console.log("pty-ws-bridge cursor replay assertions: ok");
 
 // ── Explicit tab-close reaps the shell (cave-wujw) ────────────────────────────
 // Closing a terminal tab on the WS transport used to just drop the socket, which

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -1,6 +1,7 @@
 type DataHandler = (bytes: Uint8Array) => void;
 type ExitHandler = (code: number) => void;
 type CloseHandler = (code: number, reason: string) => void;
+type ReplayResetHandler = () => void;
 
 // Fail a connect that never reaches OPEN. On iOS a WKWebView WebSocket opened
 // right after the app resumes can hang in CONNECTING forever — no open, no
@@ -30,6 +31,10 @@ export class PtyWsBridge {
   private dataHandlers: DataHandler[] = [];
   private exitHandlers: ExitHandler[] = [];
   private closeHandlers: CloseHandler[] = [];
+  private replayResetHandlers: ReplayResetHandler[] = [];
+  /** Absolute byte position immediately after the last output delivered to
+   * xterm. It lets reconnects request only bytes missed while disconnected. */
+  private replayCursor: number | null = null;
   private lastConnect: {
     threadId: string;
     cols: number;
@@ -54,11 +59,25 @@ export class PtyWsBridge {
     this.closeHandlers.push(cb);
   }
 
+  /** The retained replay window no longer covers this client. Clear the
+   * terminal before the server's bounded full-replay fallback is written. */
+  onReplayReset(cb: ReplayResetHandler): void {
+    this.replayResetHandlers.push(cb);
+  }
+
   get isOpen(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
   }
 
+  /** False only when talking to an older server that ignored cursor
+   * negotiation. Those servers still replay the whole bounded ring, so the
+   * terminal must reset before reconnecting to avoid duplicate screen state. */
+  get hasReplayCursor(): boolean {
+    return this.replayCursor !== null;
+  }
+
   connect(threadId: string, cols: number, rows: number, projectRoot?: string): Promise<void> {
+    this.replayCursor = null;
     this.lastConnect = { threadId, cols, rows, projectRoot };
     return this.open();
   }
@@ -97,6 +116,10 @@ export class PtyWsBridge {
         threadId: target.threadId,
         cols: String(target.cols),
         rows: String(target.rows),
+        // `-1` opts into the cursor protocol without claiming a position for
+        // this newly-created terminal. Older servers ignore the extra query
+        // key and retain their legacy full-replay behavior.
+        ptyReplayCursor: String(this.replayCursor ?? -1),
       });
       if (target.projectRoot) {
         params.set("projectRoot", target.projectRoot);
@@ -141,11 +164,20 @@ export class PtyWsBridge {
         const tag = buf[0];
         if (tag === 0x01) {
           const payload = buf.slice(1);
+          if (this.replayCursor !== null) this.replayCursor += payload.byteLength;
           for (const cb of this.dataHandlers) cb(payload);
         } else if (tag === 0x02 && buf.length >= 5) {
           const view = new DataView(event.data, 1);
           const code = view.getInt32(0, true);
           for (const cb of this.exitHandlers) cb(code);
+        } else if (tag === 0x06 && buf.byteLength >= 10) {
+          const view = new DataView(event.data, 1, 8);
+          const cursor = view.getFloat64(0, true);
+          if (!Number.isSafeInteger(cursor) || cursor < 0) return;
+          this.replayCursor = cursor;
+          if (buf[9] === 1) {
+            for (const cb of this.replayResetHandlers) cb();
+          }
         }
       });
       ws.addEventListener("close", (event) => {
@@ -219,6 +251,7 @@ export class PtyWsBridge {
     this.dataHandlers = [];
     this.exitHandlers = [];
     this.closeHandlers = [];
+    this.replayResetHandlers = [];
     const ws = this.ws;
     this.ws = null;
     if (ws && ws.readyState !== WebSocket.CLOSED) {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -197,6 +197,7 @@ assert.match(
 );
 assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
+assert.match(src, /frame\[0\]\s*=\s*0x06/, "cursor-aware clients receive a replay-cursor control frame");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");
 assert.match(src, /tag === 0x04/, "server receives resize tag 0x04");
 assert.match(src, /tag === 0x05/, "server receives an explicit kill tag 0x05 (cave-wujw)");
@@ -306,13 +307,13 @@ assert.match(
 //    socket after adoptSession swapped session.ws — one replay then silence.
 assert.match(
   src,
-  /shell\.onData\(\(data: string\) => \{[\s\S]*?if \(session\.ws\) sendPtyData\(session\.ws, data\)/,
-  "live PTY output routes to the current session.ws, not the spawn-time socket",
+  /shell\.onData\(\(data: string\) => \{[\s\S]*?queuePtyOutput\(threadId, session, bytes\)/,
+  "live PTY output enters the current session's bounded output queue",
 );
 assert.match(
   src,
-  /session\.scrollbackBytes > 0[\s\S]{0,80}sendPtyData\(ws, Buffer\.concat\(session\.scrollback\)/,
-  "adoptSession replays the scrollback ring to a reattaching client",
+  /replayPtyOutput\(threadId, session, replayCursor\)/,
+  "adoptSession replays only the retained cursor suffix, or legacy full ring",
 );
 // 3. A detach grace window: on socket close the shell is detached (session.ws
 //    nulled) and a timer reaps it later, instead of an immediate kill. A quick
@@ -324,7 +325,7 @@ assert.match(
 );
 assert.match(
   src,
-  /ws\.on\("close", \(\) => \{[\s\S]*?session\.ws = null;[\s\S]*?setTimeout\([\s\S]*?DETACH_GRACE_MS\)/,
+  /function detachPtyConsumer\([\s\S]*?session\.ws = null;[\s\S]*?armPtyDetach\(threadId, session\)/,
   "closing the socket detaches and arms a reap timer rather than killing the shell immediately",
 );
 assert.match(
@@ -345,6 +346,42 @@ assert.match(
   /const DETACH_GRACE_MS = [\s\S]{0,200}?300_000/,
   "detach grace defaults to 5 minutes so a backgrounded phone reattaches to a live shell",
 );
+
+// High-output sessions must not create an unbounded application queue or let
+// ws retain unlimited bytes for a stalled browser. The PTY remains alive; only
+// the current socket is closed with the retryable RFC 6455 code 1013.
+assert.match(src, /const PTY_FRAME_COALESCE_MS = 8/, "output coalescing has a short bounded latency");
+assert.match(src, /const PTY_FRAME_MAX_BYTES = 16 \* 1024/, "each output frame is bounded");
+assert.match(src, /const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 \* 1024/, "WebSocket buffering has a ceiling");
+assert.match(
+  src,
+  /ws\.bufferedAmount \+ payload\.length \+ 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT[\s\S]{0,160}evictSlowPtyConsumer/,
+  "a slow consumer is evicted before buffered output exceeds the cap",
+);
+assert.match(
+  src,
+  /ws\.close\(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON\)/,
+  "slow clients receive a retryable close reason",
+);
+assert.match(
+  src,
+  /const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013/,
+  "slow-client eviction uses WebSocket Try Again Later",
+);
+assert.match(
+  src,
+  /function clearPendingPtyOutput[\s\S]*?pendingOutputBytes = 0/,
+  "a detached or replaced client cannot donate stale queued bytes to the next client",
+);
+
+// Cursor protocol: absence preserves existing full replay. New bridge clients
+// negotiate with -1, receive the retained stream origin, then reconnect with
+// their last delivered absolute byte cursor.
+assert.match(src, /function parsePtyReplayCursor/, "server parses the opt-in replay cursor");
+assert.match(src, /query\.ptyReplayCursor/, "upgrade passes the cursor into PTY attachment");
+assert.match(src, /replayCursor === undefined/, "legacy clients retain full replay");
+assert.match(src, /scrollbackFrom\(session, start\)/, "cursor replay starts at the retained byte suffix");
+assert.match(src, /const reset = replayCursor !== -1 && !validCursor/, "expired cursors request a client reset before full fallback replay");
 
 // Idle keep-alive: Node's 5s default closes idle sockets just as pooled
 // clients (URLSession on iOS, tailscale serve upstreams) reuse them, which
@@ -404,6 +441,122 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
     undefined,
     "empty segments consume maxKeys so credentials beyond the legacy cutoff stay ignored",
   );
+
+}
+
+{
+  const cursorBlock = src.match(/function firstQueryValue[\s\S]+?(?=\ntype UpgradeQuery)/);
+  assert.ok(cursorBlock, "cursor parser is available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${cursorBlock[0]}\nexport { parsePtyReplayCursor };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  const cursorModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const parsePtyReplayCursor = cursorModule.parsePtyReplayCursor as (
+    raw: string | string[] | undefined,
+  ) => number | undefined | null;
+  assert.equal(parsePtyReplayCursor(undefined), undefined, "missing cursor preserves legacy replay");
+  assert.equal(parsePtyReplayCursor("-1"), -1, "-1 negotiates cursor support on first attach");
+  assert.equal(parsePtyReplayCursor("42"), 42, "safe integer cursor is accepted");
+  assert.equal(parsePtyReplayCursor("4.2"), null, "fractional cursor is rejected");
+  assert.equal(parsePtyReplayCursor("-2"), null, "only the documented -1 sentinel is accepted");
+  assert.equal(parsePtyReplayCursor("9007199254740992"), null, "unsafe integer cursor is rejected");
+}
+
+// Execute the pure ring helpers independently of Next, node-pty, and an
+// actual socket. This protects both the one-large-chunk memory cap and exact
+// cursor slicing used for reconnect replay.
+{
+  const ringBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  assert.ok(ringBlock, "scrollback helpers are available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${ringBlock[0]}\nexport { appendScrollback, scrollbackFrom, SCROLLBACK_LIMIT_BYTES };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  const ringModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const appendScrollback = ringModule.appendScrollback as (session: {
+    scrollback: Buffer[];
+    scrollbackBytes: number;
+    scrollbackStart: number;
+    streamEnd: number;
+  }, data: Buffer) => void;
+  const scrollbackFrom = ringModule.scrollbackFrom as (session: {
+    scrollback: Buffer[];
+    scrollbackStart: number;
+  }, cursor: number) => Buffer[];
+  const limit = ringModule.SCROLLBACK_LIMIT_BYTES as number;
+  const session = { scrollback: [] as Buffer[], scrollbackBytes: 0, scrollbackStart: 0, streamEnd: 0 };
+
+  appendScrollback(session, Buffer.from("first"));
+  appendScrollback(session, Buffer.from("-second"));
+  assert.equal(session.streamEnd, 12, "stream end advances by delivered bytes");
+  assert.equal(Buffer.concat(scrollbackFrom(session, 5)).toString(), "-second", "cursor suffix excludes already delivered bytes");
+
+  const large = Buffer.alloc(limit + 17, 0x78);
+  appendScrollback(session, large);
+  assert.equal(session.scrollbackBytes, limit, "one oversized PTY callback cannot exceed scrollback cap");
+  assert.equal(session.scrollbackStart, session.streamEnd - limit, "oversized callback advances retained cursor origin");
+  assert.equal(Buffer.concat(scrollbackFrom(session, session.scrollbackStart)).length, limit, "retained replay is bounded and byte exact");
+}
+
+// Exercise the coalescer with a socket double. This catches regressions that a
+// source-pattern test cannot: small bursts must become one frame, every frame
+// stays capped, and a slow consumer is detached without killing its PTY.
+{
+  const stateBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  const streamingBlock = src.match(/function sendPtyData[\s\S]+?(?=\nfunction sendPtyExit)/);
+  assert.ok(stateBlock && streamingBlock, "streaming helpers are available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${stateBlock[0]}\n${streamingBlock[0]}\nexport { PTY_FRAME_MAX_BYTES, PTY_WS_BUFFERED_AMOUNT_LIMIT, queuePtyOutput };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  (globalThis as typeof globalThis & { WebSocket: { OPEN: number } }).WebSocket = { OPEN: 1 };
+  const streamModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const queuePtyOutput = streamModule.queuePtyOutput as (
+    threadId: string,
+    session: Record<string, unknown>,
+    data: Buffer,
+  ) => void;
+  const frameLimit = streamModule.PTY_FRAME_MAX_BYTES as number;
+  const bufferedLimit = streamModule.PTY_WS_BUFFERED_AMOUNT_LIMIT as number;
+  const sent: Buffer[] = [];
+  const ws = {
+    readyState: 1,
+    bufferedAmount: 0,
+    send(frame: Buffer) { sent.push(frame); },
+    close() {},
+  };
+  const session = {
+    ws,
+    pendingOutput: [] as Buffer[],
+    pendingOutputBytes: 0,
+    flushTimer: null as NodeJS.Timeout | null,
+    detachTimer: null as NodeJS.Timeout | null,
+    pty: { kill() { throw new Error("slow-consumer eviction must not kill the PTY"); } },
+  };
+  queuePtyOutput("coalesce", session, Buffer.from("one"));
+  queuePtyOutput("coalesce", session, Buffer.from("-two"));
+  await new Promise((resolve) => setTimeout(resolve, 16));
+  assert.deepEqual(sent.map((frame) => frame.subarray(1).toString()), ["one-two"], "a short output burst is coalesced into one frame");
+
+  queuePtyOutput("coalesce", session, Buffer.alloc(frameLimit * 2 + 3, 0x61));
+  assert.ok(sent.slice(1).every((frame) => frame.length - 1 <= frameLimit), "large output is split into bounded frames");
+
+  const slowWs = { ...ws, bufferedAmount: bufferedLimit, closeCode: 0, close(code: number) { this.closeCode = code; } };
+  const slow = { ...session, ws: slowWs, pendingOutput: [] as Buffer[], pendingOutputBytes: 0, flushTimer: null, detachTimer: null };
+  queuePtyOutput("slow", slow, Buffer.alloc(frameLimit, 0x62));
+  assert.equal(slowWs.closeCode, 1013, "only a slow WebSocket is evicted with Try Again Later");
+  assert.equal(slow.ws, null, "slow consumer is detached while the PTY remains owned by its session");
+  if (slow.detachTimer) clearTimeout(slow.detachTimer);
 }
 
 // Twin parity: `pnpm start` runs the committed server.mjs, not server.ts, so a


### PR DESCRIPTION
Closes #4317

## Summary

PTY output was sent as one WebSocket frame per `node-pty` callback with no WebSocket backpressure limit. A stalled browser could therefore grow the transport queue without a bound. Reconnecting clients also replayed the entire retained scrollback each time, duplicating terminal output and disrupting screen continuity.

## Solution

Bound PTY streaming on the server and add an opt-in absolute-byte replay cursor protocol. Cursor-aware clients reconnect with the last delivered position and receive only missed output. If a client cursor has fallen outside the bounded replay ring, the server explicitly requests a terminal reset before replaying the latest retained output.

## Important changes

- Coalesce short PTY output bursts into frames no larger than 16 KiB.
- Cap a WebSocket consumer's buffered output at 512 KiB; detach and close only slow consumers with retryable code 1013 while preserving the PTY for the existing reconnect grace period.
- Keep the 256 KiB scrollback ring truly bounded even for a single oversized PTY callback.
- Add cursor metadata frames and client-side byte accounting so normal reconnects preserve the terminal screen and replay only the missing suffix.
- Retain legacy full-replay behavior for older clients and servers.
- Avoid writing reconnect-status text into xterm, which would otherwise corrupt byte-continuous terminal state; report status through the screen-reader announcer instead.
- Align the sidecar archive and runtime-closure file-count ceiling to the Windows CI measurement of 5,916 files, preserving the established ten-file headroom at 5,926.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — 1491 test files wired
- `node --experimental-strip-types src/server-pty-ws.test.ts`
- `node --experimental-strip-types src/lib/pty-ws-bridge.test.ts`
- `node --experimental-strip-types src/components/bottom-terminal-ws-bridge.test.ts`
- `pnpm test:app` — 1080 test files passed
- `pnpm build` — passed, including generated `server.mjs` parity and bundle budgets
- `git diff --check`

## Risks and follow-up

- Replay remains intentionally limited to the 256 KiB retained ring. A cursor older than that ring resets the terminal and replays the newest bounded output instead of attempting an unbounded history transfer.
- The sidecar file-count ceiling is a measured packaging budget, not a relaxation of archive integrity checks; the archive extractor and packager now share the same bounded limit.
- Native PTY/Tauri validation was not run from WSL because the `node-pty` native module is unavailable in this isolated dependency install. Platform CI or a native desktop host should exercise the end-to-end transport.
- The production build continues to emit existing non-failing Turbopack tracing warnings and thin CSS-budget warnings; the build completed successfully.