### PR TITLE
chore(sidecar): raise the file-count budget to 5,926 — unbreaks main on windows-latest

### DIFF
--- a/scripts/sidecar-bundle-deps.test.mjs
+++ b/scripts/sidecar-bundle-deps.test.mjs
@@ -77,7 +77,7 @@ for (const forbiddenRoot of [
 ]) {
   assert.match(closureSource, new RegExp(forbiddenRoot.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")), `runtime verifier must exclude ${forbiddenRoot}`);
 }
-assert.match(closureSource, /fileCount: 5_915/, "runtime closure must retain combined cross-platform headroom");
+assert.match(closureSource, /fileCount: 5_926/, "runtime closure must retain combined cross-platform headroom");
 assert.match(closureSource, /unpackedBytes: 200 \* 1024 \* 1024 - 1/, "runtime closure must stay strictly below 200 MiB expanded");
 for (const runtimeFile of [
   "dist/compiled/webpack/webpack-lib.js",
@@ -283,7 +283,7 @@ assert.match(
 );
 assert.match(
   rustArchiveSource,
-  /const MAX_FILE_COUNT: u64 = 5_915;/,
+  /const MAX_FILE_COUNT: u64 = 5_926;/,
   "Windows archive extractor must accept the shared runtime file-count budget",
 );
 assert.match(manifestSource, /isSymbolicLink\(\)/, "archive input must reject symlinks");

--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -187,7 +187,13 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Windows — so 5,902 was the Ubuntu figure with no headroom at all, and the
   // Windows leg was still red at it. Set from the HIGHER figure plus the same
   // ten-file cross-platform headroom the entries above use.
-  fileCount: 5_915,
+  // 2026-08-04 (image carousel, #4315): src/components/image-carousel.tsx and the
+  // chat-view wiring that renders it join the closure. CI measured 5,913 on Ubuntu
+  // and 5,916 on Windows — the ten-file headroom above was fully consumed and the
+  // Windows leg went one over while Ubuntu still passed, which is why only that
+  // leg was red. Set from the HIGHER figure plus the same ten-file cross-platform
+  // headroom every entry above uses.
+  fileCount: 5_926,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 

--- a/scripts/sidecar-runtime-closure.test.mjs
+++ b/scripts/sidecar-runtime-closure.test.mjs
@@ -102,10 +102,10 @@ try {
 
   await assembleSidecarRuntime(projectRoot, standaloneRoot, dependencyRoot, destination);
   const metrics = await verifySidecarRuntime(destination);
-  assert.ok(metrics.fileCount <= 5_915);
+  assert.ok(metrics.fileCount <= 5_926);
   assert.ok(metrics.unpackedBytes < 200 * 1024 * 1024);
   assert.deepEqual(SIDECAR_RUNTIME_BUDGETS, {
-    fileCount: 5_915,
+    fileCount: 5_926,
     unpackedBytes: 200 * 1024 * 1024 - 1,
   });
 

--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -256,7 +256,7 @@ async function main() {
     assert.match(manifest.payloadSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.treeSha256, /^[a-f0-9]{64}$/);
     assert.match(manifest.archiveSha256, /^[a-f0-9]{64}$/);
-    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_915);
+    assert.ok(manifest.fileCount > 0 && manifest.fileCount <= 5_926);
     assert.ok(manifest.archiveBytes > 0 && manifest.archiveBytes <= 80 * 1024 * 1024);
     assert.ok(manifest.unpackedBytes > 0 && manifest.unpackedBytes < 200 * 1024 * 1024);
     extractedSidecarRoot = await mkdtemp(path.join(os.tmpdir(), "coven-cave-sidecar-archive-"));

--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -11,7 +11,7 @@ pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // src/app/api/x/ route handlers landed in #4235); preserve ten-file headroom.
 // Reverted to 5_841 once by a local merge citing the older 5,831 peak — see
 // #4249. It must not move DOWN while those routes exist.
-pub(super) const MAX_FILE_COUNT: u64 = 5_915;
+pub(super) const MAX_FILE_COUNT: u64 = 5_926;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]


### PR DESCRIPTION
Closes cave-ryaqu. Unbreaks `main`.

`main` is red on **Sidecar runtime (windows-latest)**:

```
Error: sidecar runtime fileCount 5916 exceeds target 5915
```

Only that leg. **Ubuntu measured 5,913 and passed**, which is why the failure looks partial — the two platforms genuinely produce different file counts, and the budget is one shared number.

## What consumed the headroom

The `5_915` entry was set from Windows 5,905 plus the ten-file cross-platform headroom that every entry in that block uses.

**#4315** ("share images through one carousel familiars can drive") adds `src/components/image-carousel.tsx` and the `chat-view.tsx` wiring that renders it. Both reach the closure — consuming the whole ten-file headroom and putting Windows one over.

**#4307**, which landed in the same range, adds only `scripts/branch-to-merge-contract.test.mjs` and a `run-tests.mjs` entry. Test scripts don't reach the sidecar, so it isn't a contributor.

## The number

**5,916 + 10 = 5,926** — the higher leg plus the same ten-file headroom the block's own comments prescribe:

> *"Set from the HIGHER figure plus the same ten-file cross-platform headroom the entries above use."*

Deliberately **not** 5,916. A budget with zero headroom is why this ratchet went red four separate times today (5,841 → 5,887 → 5,901 → 5,902 → 5,915 → now). Setting it tight guarantees the next file that reaches the closure re-breaks `main`, and the convention here already says otherwise.

## All seven copies moved together

This value is hand-synced, and a partial update trades one red check for another:

| file | site |
|---|---|
| `scripts/sidecar-runtime-closure.mjs` | the budget itself |
| `scripts/sidecar-bundle-deps.test.mjs` | pins the closure literal **and** the Rust const |
| `scripts/sidecar-runtime-closure.test.mjs` | two sites (`<=` assertion and a fixture) |
| `scripts/sidecar-runtime-smoke.mjs` | manifest ceiling |
| `src-tauri/src/sidecar_archive_manifest.rs` | `MAX_FILE_COUNT` |

`git grep 5_915` returns nothing afterwards.

## Verification

- `scripts/sidecar-bundle-deps.test.mjs` → ok (this is the guard that catches a half-synced budget)
- `scripts/sidecar-runtime-closure.test.mjs` → ok

The real proof is the Windows leg in CI on this PR, since the count is measured there, not locally.
