### PR TITLE
docs(sidecar): record that the file-count budget is a rate problem

### DIFF
--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -193,6 +193,17 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // Windows leg went one over while Ubuntu still passed, which is why only that
   // leg was red. Set from the HIGHER figure plus the same ten-file cross-platform
   // headroom every entry above uses.
+  // 2026-08-04 (headroom rate, cave-k5n56): worth recording that the entry
+  // above is a rate problem, not a one-feature one. main's Windows leg measured
+  // 5,914 at ab27ef62d8 and 5,915 at 39eadf26eb — sitting exactly ON the budget,
+  // reporting green with zero headroom — before #4315 added the single file that
+  // crossed it. Growth is roughly a file per merge, diffuse across many PRs, and
+  // Windows governs at a consistent +3 over Ubuntu (5914/5911, 5915/5912,
+  // 5916/5913). So read a red here as the headroom running out rather than as the
+  // last merge misbehaving, and check the previous runs' measured counts before
+  // attributing it. Ten files is about ten merges at this rate, so this will
+  // recur; the durable fix is to size the headroom to the growth rate or stop the
+  // closure growing, not to keep adding ten.
   fileCount: 5_926,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });


### PR DESCRIPTION
**Scope changed while this was in CI.** The budget raise this branch carried landed independently on `main` first — same `5_926` value, all six sites. Rebasing left only the part `main`'s entry does not say, so this is now an **11-line comment-only** change.

`main`'s entry correctly records that the ten-file headroom was fully consumed and that only the Windows leg went over. What it doesn't say is that **no single feature caused it**:

| `main` | ubuntu | windows | budget | result |
| --- | --- | --- | --- | --- |
| `ab27ef62d8` | 5911 | 5914 | 5915 | pass — 1 file spare |
| `39eadf26eb` | 5912 | **5915** | 5915 | pass — **0 files spare, reported green** |
| `4fe6f08e45` (#4315) | 5913 | 5916 | 5915 | **FAIL** |

Growth is roughly **one file per merge**, spread across many PRs. #4315 added the single file that crossed a line `main` was already sitting on. Windows governs at a consistent **+3** over Ubuntu.

## Why write it down

The natural reading of a red here is *"the last merge added too much"*, which sends the next person to audit an innocent PR — I made exactly that mistake before measuring. The note says to check the previous runs' measured counts first, and that ten files is about ten merges at this rate, so this recurs until the headroom is sized to the rate or the closure stops growing.

## Verification

`sidecar-runtime-closure.test.mjs` and `sidecar-bundle-deps.test.mjs` both pass. No behavior change — the only edit is a comment.