### PR TITLE
docs(sidecar): make the MAX_FILE_COUNT comment match the const

### DIFF
--- a/src-tauri/src/sidecar_archive_manifest.rs
+++ b/src-tauri/src/sidecar_archive_manifest.rs
@@ -7,8 +7,11 @@ pub(super) const ARCHIVE_FORMAT: &str = "tar.zst";
 pub(super) const MAX_ARCHIVE_BYTES: u64 = 80 * 1024 * 1024;
 pub(super) const MAX_UNPACKED_BYTES: u64 = 200 * 1024 * 1024 - 1;
 // Keep this in sync with scripts/sidecar-runtime-closure.mjs. The current
-// cross-platform closure peaks at 5,877 files (Windows, 2026-08-03, after the
-// src/app/api/x/ route handlers landed in #4235); preserve ten-file headroom.
+// cross-platform closure peaks at 5,916 files (Windows, 2026-08-04, after the
+// image carousel landed in #4315); preserve ten-file headroom. The two legs
+// differ — Ubuntu measured 5,913 the same day — so this must always be set
+// from the HIGHER leg, which is why a budget derived from an Ubuntu-only
+// figure has reddened windows-latest more than once.
 // Reverted to 5_841 once by a local merge citing the older 5,831 peak — see
 // #4249. It must not move DOWN while those routes exist.
 pub(super) const MAX_FILE_COUNT: u64 = 5_926;


### PR DESCRIPTION
Follow-up to #4331, from a review comment I merged past.

The comment above `MAX_FILE_COUNT` still said the closure *"peaks at 5,877 files (Windows, 2026-08-03)"* while the const it documents is now **5,926**, derived from Windows **5,916** measured today.

That is load-bearing rather than cosmetic. The documented procedure is "peak plus ten-file headroom" — so the next person sizing this budget reads 5,877 from the comment, computes 5,887, and reddens windows-latest immediately.

It now also records the fact that caused today outage: **the two legs differ** (Ubuntu 5,913 vs Windows 5,916 on the same tree), so the budget must always be taken from the HIGHER leg. A figure derived from Ubuntu alone is precisely what left Windows red while Ubuntu passed.

Comment-only change to one Rust file; `sidecar-bundle-deps` (the guard on the const) passes.