### PR TITLE
WIP: copilot launch timeout fix (cave-jo5hu)

### DIFF
--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -317,8 +317,13 @@ assert.match(
 );
 assert.match(
   chatRoute,
-  /const copilotSpawnEnv = copilotDirect \? harnessSpawnEnv\(body\.familiarId\) : null;[\s\S]*?resolveCopilotRuntimeLaunch\(copilotManifestStream\.executable, \{[\s\S]*?spawnEnv: \(\) => copilotSpawnEnv![\s\S]*?probeCopilotCapability\(copilotManifestStream\.executable/,
-  "Copilot resolves and probes the manifest-declared executable in the exact familiar-scoped spawn environment",
+  /resolveCopilotRuntimeLaunch\(copilotManifestStream\.executable, \{[\s\S]*?spawnEnv: \(discoveryDeadline\) =>[\s\S]*?harnessSpawnEnv\(body\.familiarId, \{ discoveryDeadline \}\)[\s\S]*?probeCopilotCapability\(copilotManifestStream\.executable/,
+  "Copilot gives familiar-scoped PATH discovery its own deadline before resolving and probing the exact launch plan",
+);
+assert.doesNotMatch(
+  chatRoute,
+  /const copilotSpawnEnv = copilotDirect \? harnessSpawnEnv\(body\.familiarId\) : null/,
+  "chat does not consume the Copilot resolver's environment-discovery budget before the resolver starts",
 );
 assert.doesNotMatch(
   chatRoute,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1611,13 +1611,15 @@ export async function POST(req: Request) {
     : null;
 
   // Resolve the direct plan in the exact familiar-scoped environment passed to
-  // the child. The capability probe scrubs credentials only for `--version`;
-  // it must never discover a different launcher than the model spawn uses.
-  const copilotSpawnEnv = copilotDirect ? harnessSpawnEnv(body.familiarId) : null;
+  // the child. The resolver owns bounded PATH discovery so a cold desktop
+  // login-shell lookup cannot consume the launch-plan verification budget.
+  // The capability probe scrubs credentials only for `--version`; it must never
+  // discover a different launcher than the model spawn uses.
   const copilotManifestStream = copilotDirect ? copilotStreamSpec() : null;
   const copilotRuntimeLaunch = copilotManifestStream
     ? await resolveCopilotRuntimeLaunch(copilotManifestStream.executable, {
-        spawnEnv: () => copilotSpawnEnv!,
+        spawnEnv: (discoveryDeadline) =>
+          harnessSpawnEnv(body.familiarId, { discoveryDeadline }),
       })
     : null;
   const copilotCapability = copilotManifestStream && copilotRuntimeLaunch

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -62,12 +62,22 @@ assert.match(
 );
 assert.match(
   source,
-  /async function adapterAvailability[\s\S]*?id === "copilot"[\s\S]*?const copilotLaunch = await resolveCopilotRuntimeLaunch\(stream\.executable,[\s\S]*?spawnEnv: \(\) => harnessSpawnEnv\(null\)[\s\S]*?availability: summarizeRuntimeAvailability\(copilotLaunch\.availability\)[\s\S]*?copilotLaunch/,
+  /async function adapterAvailability[\s\S]*?id === "copilot"[\s\S]*?const copilotLaunch = await resolveCopilotRuntimeLaunch\(stream\.executable,[\s\S]*?spawnEnv: \(discoveryDeadline\) =>[\s\S]*?harnessSpawnEnv\(null, \{ discoveryDeadline \}\)[\s\S]*?availability: summarizeRuntimeAvailability\(copilotLaunch\.availability\)[\s\S]*?copilotLaunch/,
   "Copilot availability retains the shared exact launch plan for internal catalog probes",
 );
 assert.match(
   source,
-  /const runtime = await adapterAvailability\(h\.id\);[\s\S]*?const copilotLaunch = runtime\.copilotLaunch;[\s\S]*?const path =\s*copilotLaunch[\s\S]*?copilotLaunch\.availability\.state === "ready"[\s\S]*?copilotLaunch\.availability\.resolvedPath[\s\S]*?: await which\(h\.binary\)/,
+  /async function adapterAvailability[\s\S]*?if \(id === "copilot"\)[\s\S]*?resolveCopilotRuntimeLaunch[\s\S]*?const env = id === "opencode" \? openCodeSpawnEnv\(null\) : harnessSpawnEnv\(null\)/,
+  "Copilot resolves its deadline-aware environment before any generic environment can populate the PATH cache",
+);
+assert.match(
+  source,
+  /export async function GET\(\) \{[\s\S]*?const copilotRuntime = await adapterAvailability\("copilot"\);[\s\S]*?Promise\.all\([\s\S]*?const runtime = h\.id === "copilot"[\s\S]*?\? copilotRuntime[\s\S]*?: await adapterAvailability\(h\.id\)/,
+  "the harness catalog resolves Copilot before parallel generic adapter discovery can populate the PATH cache",
+);
+assert.match(
+  source,
+  /const runtime = h\.id === "copilot"[\s\S]*?\? copilotRuntime[\s\S]*?: await adapterAvailability\(h\.id\);[\s\S]*?const copilotLaunch = runtime\.copilotLaunch;[\s\S]*?const path =\s*copilotLaunch[\s\S]*?copilotLaunch\.availability\.state === "ready"[\s\S]*?copilotLaunch\.availability\.resolvedPath[\s\S]*?: await which\(h\.binary\)/,
   "the harness catalog reports the resolved Copilot launch target without running an independent which probe",
 );
 assert.match(
@@ -108,7 +118,7 @@ assert.match(
 );
 assert.match(
   source,
-  /resolveCopilotRuntimeLaunch\(stream\.executable,\s*\{\s*spawnEnv: \(\) => harnessSpawnEnv\(null\)/,
+  /resolveCopilotRuntimeLaunch\(stream\.executable,\s*\{\s*spawnEnv: \(discoveryDeadline\) =>[\s\S]*?harnessSpawnEnv\(null, \{ discoveryDeadline \}\)/,
   "Copilot status must resolve the same direct launcher in the shared harness environment as chat send",
 );
 

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -73,6 +73,20 @@ type AdapterAvailability = {
 // Same commands, same spawn env shape (no familiar → shared keys only), and
 // bounded filesystem stats only — this endpoint stays probe-cheap.
 async function adapterAvailability(id: string): Promise<AdapterAvailability> {
+  if (id === "copilot") {
+    const stream = copilotStreamSpec();
+    if (stream) {
+      const copilotLaunch = await resolveCopilotRuntimeLaunch(stream.executable, {
+        spawnEnv: (discoveryDeadline) =>
+          harnessSpawnEnv(null, { discoveryDeadline }),
+      });
+      return {
+        availability: summarizeRuntimeAvailability(copilotLaunch.availability),
+        copilotLaunch,
+      };
+    }
+    // No stream manifest → copilot chats fall back to `coven run` below.
+  }
   const env = id === "opencode" ? openCodeSpawnEnv(null) : harnessSpawnEnv(null);
   if (id === "codex") {
     return {
@@ -81,19 +95,6 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
         env,
       })),
     };
-  }
-  if (id === "copilot") {
-    const stream = copilotStreamSpec();
-    if (stream) {
-      const copilotLaunch = await resolveCopilotRuntimeLaunch(stream.executable, {
-        spawnEnv: () => harnessSpawnEnv(null),
-      });
-      return {
-        availability: summarizeRuntimeAvailability(copilotLaunch.availability),
-        copilotLaunch,
-      };
-    }
-    // No stream manifest → copilot chats fall back to `coven run` below.
   }
   if (id === "opencode") {
     const launch = openCodeLaunch([], process.platform, env);
@@ -290,6 +291,7 @@ async function countOpenClawAgents(): Promise<number> {
 }
 
 export async function GET() {
+  const copilotRuntime = await adapterAvailability("copilot");
   const openclawAgentCount = await countOpenClawAgents();
   const reports: HarnessReport[] = await Promise.all(
     COMPATIBILITY_ADAPTERS.map(async (h) => {
@@ -300,7 +302,9 @@ export async function GET() {
       // Windows PATH in WSL. `which grok` on Linux does not apply PATHEXT, so
       // using only the generic probe would hide a runnable Windows install
       // from the summoning circle even though the chat launcher can execute it.
-      const runtime = await adapterAvailability(h.id);
+      const runtime = h.id === "copilot"
+        ? copilotRuntime
+        : await adapterAvailability(h.id);
       const copilotLaunch = runtime.copilotLaunch;
       const hermesLaunch = runtime.hermesLaunch;
       const resolvedBinary = h.id === "grok" ? grokBin() : h.binary;

--- a/src/lib/server/copilot-capability-probe.test.ts
+++ b/src/lib/server/copilot-capability-probe.test.ts
@@ -267,7 +267,7 @@ let receivedDiscoveryDeadline: number | undefined;
 let launchResolutionCalls = 0;
 let identityCalls = 0;
 let versionSpawnCalls = 0;
-const discoveryTimeout = await probeCopilotCapability("copilot", {
+const slowDiscoveryProbe = await probeCopilotCapability("copilot", {
   now: () => deadlineClock,
   spawnEnv: (discoveryDeadline) => {
     receivedDiscoveryDeadline = discoveryDeadline;
@@ -276,35 +276,25 @@ const discoveryTimeout = await probeCopilotCapability("copilot", {
   },
   resolveLaunchCommand: async () => {
     launchResolutionCalls += 1;
-    return { command: "copilot", fixedArgs: [] };
+    return { command: process.execPath, fixedArgs: [] };
   },
   binaryIdentity: async () => {
     identityCalls += 1;
-    return "must-not-run";
+    return "copilot-slow-discovery-fixture";
   },
-  spawnImpl: (() => {
+  spawnImpl: delayedVersionSpawn(0, () => {
     versionSpawnCalls += 1;
-    throw new Error("must not spawn after discovery exhausts the deadline");
-  }) as typeof import("node:child_process").spawn,
+  }),
 });
-assert.equal(discoveryTimeout.version, null);
-assert.equal(discoveryTimeout.diagnostic, "probe-timeout");
 assert.equal(
-  discoveryTimeout.availability.state,
-  "probe_failed",
-  "environment discovery that consumes the resolution budget fails closed",
-);
-assert.match(
-  discoveryTimeout.availability.state === "probe_failed"
-    ? discoveryTimeout.availability.message
-    : "",
-  /timed out/i,
-  "discovery timeout remains a launch-probe cause instead of schema incompatibility",
+  slowDiscoveryProbe.version,
+  "1.0.75",
+  "slow environment discovery cannot consume the exact-plan and capability budget",
 );
 assert.equal(receivedDiscoveryDeadline, 11_500, "spawnEnv receives the absolute deadline");
-assert.equal(launchResolutionCalls, 0, "launch resolution does not start after discovery times out");
-assert.equal(identityCalls, 0, "binary identity work does not start after discovery times out");
-assert.equal(versionSpawnCalls, 0, "the version process does not start after discovery times out");
+assert.equal(launchResolutionCalls, 1, "launch resolution receives its own bounded phase");
+assert.equal(identityCalls, 1, "binary identity uses the fresh launch-plan deadline");
+assert.equal(versionSpawnCalls, 1, "the version process starts after the exact plan is verified");
 
 for (const state of ["missing", "unlaunchable"] as const) {
   clearCopilotCapabilityProbeCache();

--- a/src/lib/server/copilot-runtime-launch.test.ts
+++ b/src/lib/server/copilot-runtime-launch.test.ts
@@ -27,11 +27,13 @@ try {
     timeoutMs?: number;
   } | undefined;
   const exactEnv = { PATH: "" };
+  let readyClock = 1_000;
   const ready = await resolveCopilotRuntimeLaunch(process.execPath, {
     platform: "linux",
-    now: () => 1_000,
+    now: () => readyClock,
     spawnEnv: (deadline: number) => {
       capturedDeadline = deadline;
+      readyClock = 4_000;
       return exactEnv;
     },
     resolveLaunchCommand: async (_executable: string, options: typeof capturedResolveOptions) => {
@@ -45,9 +47,17 @@ try {
     }),
   });
   assert.equal(capturedDeadline, 3_500, "environment discovery receives one absolute deadline");
-  assert.equal(ready.deadline, capturedDeadline, "the launch plan owns that same absolute deadline");
+  assert.equal(
+    ready.deadline,
+    6_500,
+    "launcher and identity discovery receive a fresh deadline after slow environment discovery",
+  );
   assert.equal(capturedResolveOptions?.env, exactEnv, "launcher resolution uses the plan's exact env");
-  assert.equal(capturedResolveOptions?.timeoutMs, 2_500, "launcher resolution receives only remaining time");
+  assert.equal(
+    capturedResolveOptions?.timeoutMs,
+    2_500,
+    "slow environment discovery cannot consume the launcher-resolution budget",
+  );
   assert.equal(ready.availability.state, "ready");
 
   let timeAfterAvailability = 1_000;
@@ -89,7 +99,7 @@ try {
     "a timed-out plan retains the exact resolved fixed arguments",
   );
 
-  const deadlineSamples = [1_000, 3_499, 3_501];
+  const deadlineSamples = [1_000, 3_499, 6_001];
   let exhaustedResolutionCalls = 0;
   let nonPositiveTimeout: number | undefined;
   const exhaustedBeforeResolution = await resolveCopilotRuntimeLaunch("copilot", {
@@ -225,7 +235,7 @@ try {
   );
   assert.match(
     source,
-    /canonicalProbeSpawnEnv\(\{ discoveryDeadline, now \}\)/,
+    /canonicalProbeSpawnEnv\(\{ discoveryDeadline: environmentDeadline, now \}\)/,
     "the default launch plan uses Task 2's credential-free canonical env",
   );
   assert.doesNotMatch(

--- a/src/lib/server/copilot-runtime-launch.ts
+++ b/src/lib/server/copilot-runtime-launch.ts
@@ -6,7 +6,7 @@ import {
   type RuntimeAvailability,
 } from "../runtime-availability.ts";
 
-const COPILOT_LAUNCH_RESOLUTION_TIMEOUT_MS = 2_500;
+const COPILOT_LAUNCH_PHASE_TIMEOUT_MS = 2_500;
 
 const COPILOT_LAUNCH_TIMEOUT_MESSAGE =
   "The Copilot launch check timed out before Cave could verify the CLI. Retry after Copilot finishes starting.";
@@ -21,7 +21,7 @@ export type CopilotRuntimeLaunch = {
   fixedArgs: string[];
   /** Fixed argv artifacts required by the selected launch plan. */
   requiredFiles?: string[];
-  /** Absolute deadline shared by env, launcher, and identity discovery. */
+  /** Absolute deadline shared by launcher, availability, and identity discovery. */
   deadline: number;
   availability: RuntimeAvailability;
   /** Safe timeout marker retained for capability diagnostics. */
@@ -78,40 +78,34 @@ function failedPlan(input: {
 /**
  * Resolve and passively classify one exact Copilot launch plan.
  *
- * This boundary never runs Copilot. Environment construction, npm-shim
- * conversion, and filesystem availability all share one absolute deadline;
- * callers may run `--version` only after this returns `ready`, using the exact
- * command/fixed args and env returned here.
+ * This boundary never runs Copilot. Environment construction has its own
+ * bounded deadline because a cold desktop login-shell lookup may consume its
+ * entire budget. npm-shim conversion, filesystem availability, and identity
+ * discovery then share a fresh deadline. Callers may run `--version` only
+ * after this returns `ready`, using the exact command/fixed args and env
+ * returned here.
  */
 export async function resolveCopilotRuntimeLaunch(
   executable = "copilot",
   options: ResolveCopilotRuntimeLaunchOptions = {},
 ): Promise<CopilotRuntimeLaunch> {
   const now = options.now ?? Date.now;
-  const discoveryDeadline = now() + COPILOT_LAUNCH_RESOLUTION_TIMEOUT_MS;
+  const environmentDeadline = now() + COPILOT_LAUNCH_PHASE_TIMEOUT_MS;
   let env: NodeJS.ProcessEnv;
   try {
     env = options.spawnEnv
-      ? options.spawnEnv(discoveryDeadline)
-      : canonicalProbeSpawnEnv({ discoveryDeadline, now });
+      ? options.spawnEnv(environmentDeadline)
+      : canonicalProbeSpawnEnv({ discoveryDeadline: environmentDeadline, now });
   } catch {
     return failedPlan({
       executable,
       env: { NODE_ENV: process.env.NODE_ENV ?? "development" },
-      deadline: discoveryDeadline,
+      deadline: environmentDeadline,
       reason: "failed",
     });
   }
 
-  if (now() >= discoveryDeadline) {
-    return failedPlan({
-      executable,
-      env,
-      deadline: discoveryDeadline,
-      reason: "timeout",
-    });
-  }
-
+  const discoveryDeadline = now() + COPILOT_LAUNCH_PHASE_TIMEOUT_MS;
   const remaining = discoveryDeadline - now();
   if (remaining <= 0) {
     return failedPlan({


### PR DESCRIPTION
> **Draft / WIP — preserved snapshot.** Opened as a draft so CI runs but it cannot be merged by accident.

## Provenance

Uncommitted work found **orphaned** in a local worktree (no owning Coven session or claim), preserved as a signed commit and rebased onto current `main` for a CI signal. Bead **cave-jo5hu**.

## What it is

Server-side copilot runtime launch/timeout handling — 7 files with matching tests:

- `src/lib/server/copilot-runtime-launch.ts` (+ test), `copilot-capability-probe.test.ts`
- `src/app/api/chat/send/route.ts` + `harness-routing-copilot-jsonl.test.ts`
- `src/app/api/harnesses/route.ts` (+ test)

## Caveats (why it's a draft)

- [ ] Original branch base was **~150 commits behind `main`**; rebased cleanly with no textual conflicts, but **semantic drift is possible** — the CI run is the real check.
- [ ] Unverified by a human; no known owning session.
- [ ] Needs an owner to review, confirm intent, and take it forward.

Do not merge until CI is green and an owner has reviewed.