### PR TITLE
Fix Home slash command handoff and discovery

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -623,6 +623,7 @@ export const SUITES = {
     "src/lib/use-composer-draft.test.ts",
     "src/lib/use-composer-history.test.ts",
     "src/lib/use-attachment-staging.test.ts",
+    "src/lib/slash-command-inline.test.ts",
     "src/lib/use-inline-slash-menus.test.ts",
     "src/lib/prompt-enhancer.test.ts",
     "src/lib/prompt-placeholders.test.ts",

--- a/src/components/board-chat-link.test.ts
+++ b/src/components/board-chat-link.test.ts
@@ -165,7 +165,7 @@ assert.match(
 );
 assert.match(
   chatView,
-  /const stagedInitialModelOverride = initialModelOverride !== undefined[\s\S]{0,900}?const initialSendOptions = stagedInitialModelOverride !== undefined[\s\S]{0,350}?sendRaw\([\s\S]{0,180}initialSendOptions,[\s\S]{0,220}runtimeHost: initialControls\?\.runtimeHost \}/,
+  /const stagedInitialModelOverride = initialModelOverride !== undefined[\s\S]{0,900}?const initialSendOptions = stagedInitialModelOverride !== undefined[\s\S]{0,700}?sendRaw\([\s\S]{0,180}initialSendOptions,[\s\S]{0,220}runtimeHost: initialControls\?\.runtimeHost \}/,
   "an auto-sent Board prompt passes its model through ChatSendOptions, not the typed controls payload",
 );
 assert.match(

--- a/src/components/chat-canvas-command.test.ts
+++ b/src/components/chat-canvas-command.test.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
 // /canvas command: chat generates inline with a prompt; without one it shows a
 // usage hint (the Canvas page moved to feature/journal-canvas-surface). The
-// workspace-level /canvas hands off to a chat.
+// workspace-level /canvas declines local handling so Home can hand the exact
+// command to a mounted ChatView.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
@@ -16,7 +17,11 @@ assert.match(
   /command === "\/canvas"[\s\S]{0,300}?appendSystem\("Describe what to sketch/,
   "promptless /canvas shows a usage hint instead of opening a page",
 );
-assert.match(ws, /case "\/canvas":[\s\S]{0,400}?startFamiliarChat\(activeId\)/, "workspace /canvas hands off to a chat");
+assert.match(
+  ws,
+  /case "\/canvas":[\s\S]{0,240}?return false;/,
+  "workspace /canvas leaves Home to hand the exact command to ChatView",
+);
 assert.doesNotMatch(ws, /cave:journal-set-tab/, "no Canvas-tab navigation remains");
 
 console.log("chat /canvas command wiring: ok");

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -820,7 +820,7 @@ assert.match(
 );
 assert.match(
   slashBranch,
-  /cmd\.argPlaceholder && canonicalize\(text\.trim\(\)\) !== cmd\.name[\s\S]*setText\(cmd\.name \+ " "\)/,
+  /cmd\.argPlaceholder &&[\s\S]*canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*completeCommand\(cmd\.name, true\)/,
   "Slash-menu Enter autocompletes argument-taking commands (like Tab) instead of running them bare",
 );
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3374,6 +3374,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       : modelState?.effectiveModel && modelState.effectiveModel !== "unknown"
       ? modelState.effectiveModel
       : "";
+  const [composerCaret, setComposerCaret] = useState(0);
+  const completeComposerText = useCallback((nextText: string, nextCaret: number) => {
+    setInput(nextText);
+    setComposerCaret(nextCaret);
+    requestAnimationFrame(() => {
+      const textarea = inputRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(nextCaret, nextCaret);
+    });
+  }, []);
   const {
     skills,
     prompts,
@@ -3389,10 +3400,13 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     slashIdx,
     setSlashIdx,
     slashListboxId,
+    completeCommand,
     handleKeyDown: handleMenuKey,
   } = useInlineSlashMenus({
     text: input,
     setText: setInput,
+    caret: composerCaret,
+    onCompleteText: completeComposerText,
     modelHarness,
     modelOptionsOverride: composerModelOptions,
     onPickModel: (id) => {
@@ -3468,9 +3482,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // @-file mentions (CHAT-D1-04). Typing `@` opens a workspace-file picker
   // for the selected predetermined project. The file index is fetched once
   // per root from /api/project/files and fuzzy-filtered client-side. Mentions
-  // stay disjoint from the slash menu: `@` is mid-token, `/` first-token-only.
+  // stay disjoint from the slash menu because each requires its own boundary.
   const mentionRoot = activeProjectRoot.trim();
-  const [composerCaret, setComposerCaret] = useState(0);
   const [mentionIdx, setMentionIdx] = useState(0);
   // Esc hides the picker for the current input; any edit brings it back.
   const [mentionDismissed, setMentionDismissed] = useState(false);
@@ -5797,6 +5810,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               : {}),
           }
         : undefined;
+      if (
+        (initialAttachments?.length ?? 0) === 0 &&
+        intentFromSlash(initialPrompt)
+      ) {
+        return;
+      }
       void sendRaw(
         initialPrompt,
         initialAttachments ?? [],
@@ -6775,7 +6794,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                           ref={active ? activeSlashOptionRef : null}
                           onMouseEnter={() => setSlashIdx(i)}
                           onClick={() => {
-                            setInput(cmd.name + (cmd.argPlaceholder ? " " : ""));
+                            completeCommand(cmd.name, Boolean(cmd.argPlaceholder));
                             inputRef.current?.focus();
                           }}
                           className={`flex w-full items-center gap-3 rounded-lg px-3 py-2.5 text-left text-[length:var(--text-base)] transition-colors ${

--- a/src/components/familiar-quick-switch.tsx
+++ b/src/components/familiar-quick-switch.tsx
@@ -17,6 +17,7 @@ type Props = {
   placement?: "bottom-start" | "bottom-end" | "top-start" | "top-end";
   /** Labels the switcher's trigger with the active familiar name. */
   labeled?: boolean;
+  singleRequired?: boolean;
 };
 
 /**
@@ -35,6 +36,7 @@ export function FamiliarQuickSwitch({
   onSelectFamiliar,
   placement = "bottom-start",
   labeled = false,
+  singleRequired = false,
 }: Props) {
   return (
     <div className="familiar-quickswitch">
@@ -47,6 +49,7 @@ export function FamiliarQuickSwitch({
         onSelectFamiliar={onSelectFamiliar}
         placement={placement}
         labeled={labeled}
+        singleRequired={singleRequired}
       />
     </div>
   );

--- a/src/components/familiar-switcher.test.ts
+++ b/src/components/familiar-switcher.test.ts
@@ -30,6 +30,11 @@ assert.match(
 );
 assert.match(
   source,
+  /singleRequired\s*\? "Choose familiar"\s*: "All familiars"/,
+  "a required single-familiar picker never labels its empty state as All familiars",
+);
+assert.match(
+  source,
   /familiar-switcher__trigger-caret/,
   "the labeled trigger carries a dropdown caret (it reads as a selector)",
 );

--- a/src/components/familiar-switcher.test.ts
+++ b/src/components/familiar-switcher.test.ts
@@ -58,7 +58,11 @@ assert.match(
   "the checkbox zone and ⌘/Ctrl-click both mean multi",
 );
 assert.match(source, /if \(!multi\) setOpen\(false\);/, "multi picks keep the menu open for more toggles");
-assert.match(source, /aria-multiselectable="true"/, "the listbox announces multiselect");
+assert.match(
+  source,
+  /aria-multiselectable=\{singleRequired \? undefined : true\}/,
+  "the listbox announces multiselect except on single-familiar surfaces",
+);
 assert.match(
   source,
   /className=\{`familiar-switcher__checkbox\$\{isActive \? " is-checked" : ""\}`\}/,
@@ -124,7 +128,7 @@ assert.match(source, /setFamiliarOrder\(arrayMove\(/, "reorder persists the new 
 // fades in on hover/focus, when checked, or while a multiselect scope is live.
 assert.match(
   source,
-  /data-multi=\{multiScope \? "true" : undefined\}/,
+  /data-multi=\{!singleRequired && multiScope \? "true" : undefined\}/,
   "the list flags a live multiselect scope so CSS can keep all checkboxes visible",
 );
 assert.match(

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -41,6 +41,9 @@ type Props = {
   placement?: "bottom-start" | "bottom-end" | "top-start" | "top-end";
   /** Shows the current familiar name beside the avatar on surfaces with room. */
   labeled?: boolean;
+  /** Home launches one familiar at a time, so it hides the All row and
+   * multiselect affordance while retaining the shared picker. */
+  singleRequired?: boolean;
 };
 
 /**
@@ -59,6 +62,7 @@ export function FamiliarSwitcher({
   onSelectFamiliar,
   placement = "bottom-start",
   labeled = false,
+  singleRequired = false,
 }: Props) {
   const { openFamiliarStudio, openFamiliarStudioListView } = useFamiliarStudio();
   const triggerRef = useRef<HTMLButtonElement | null>(null);
@@ -78,6 +82,11 @@ export function FamiliarSwitcher({
   /** Row activation: the checkbox zone (or ⌘/Ctrl-click) toggles membership and
    *  keeps the menu open for more picks; a plain click solo-selects and closes. */
   const pickFamiliar = (id: string, e: ReactMouseEvent) => {
+    if (singleRequired) {
+      onSelectFamiliar(id);
+      setOpen(false);
+      return;
+    }
     const multi =
       e.metaKey || e.ctrlKey ||
       Boolean((e.target as HTMLElement).closest(".familiar-switcher__checkbox"));
@@ -125,12 +134,12 @@ export function FamiliarSwitcher({
 
   // Trigger copy: a ≥2 multiselect summarizes the scope; otherwise the single
   // active familiar (or the All scope) names the control.
-  const triggerText = multiScope
+  const triggerText = !singleRequired && multiScope
     ? `${multiScope.size} familiars`
     : active
       ? active.display_name
       : "All familiars";
-  const triggerLabel = multiScope
+  const triggerLabel = !singleRequired && multiScope
     ? `Switch familiar — scope: ${multiScope.size} familiars`
     : active
       ? `Switch familiar — current: ${active.display_name}`
@@ -234,10 +243,10 @@ export function FamiliarSwitcher({
               className="familiar-switcher__list"
               role="listbox"
               aria-label="Switch familiar"
-              aria-multiselectable="true"
-              data-multi={multiScope ? "true" : undefined}
+              aria-multiselectable={singleRequired ? undefined : true}
+              data-multi={!singleRequired && multiScope ? "true" : undefined}
             >
-              <li>
+              {!singleRequired ? <li>
                 <button
                   type="button"
                   role="option"
@@ -251,7 +260,7 @@ export function FamiliarSwitcher({
                   <span className="familiar-switcher__option-name">All familiars</span>
                   {!multiScope && activeFamiliarId == null ? <Icon name="ph:check" width={12} aria-hidden /> : null}
                 </button>
-              </li>
+              </li> : null}
 
               {filtered.map((f) => {
                 const isActive = isScoped(f.id);
@@ -266,7 +275,11 @@ export function FamiliarSwitcher({
                       className={`familiar-switcher__option${isActive ? " is-active" : ""}`}
                       style={{ ["--familiar-accent" as string]: f.color } as CSSProperties}
                       onClick={(e) => pickFamiliar(f.id, e)}
-                      title={`${f.display_name} · ${presence.label} · click switches, checkbox or ⌘-click multi-selects, drag into a chat to start a coven`}
+                      title={
+                        singleRequired
+                          ? `${f.display_name} · ${presence.label}`
+                          : `${f.display_name} · ${presence.label} · click switches, checkbox or ⌘-click multi-selects, drag into a chat to start a coven`
+                      }
                       // Drag a familiar into a chat thread to add them to it
                       // (cave-76yfq). Only this plain-listbox branch is
                       // draggable — the reorder branch above is a dnd-kit
@@ -288,9 +301,11 @@ export function FamiliarSwitcher({
                     >
                       {/* Checkbox zone — clicking it toggles this familiar in the
                           multiselect scope and keeps the menu open. */}
-                      <span className={`familiar-switcher__checkbox${isActive ? " is-checked" : ""}`} aria-hidden>
-                        {isActive ? <Icon name="ph:check" width={10} /> : null}
-                      </span>
+                      {!singleRequired ? (
+                        <span className={`familiar-switcher__checkbox${isActive ? " is-checked" : ""}`} aria-hidden>
+                          {isActive ? <Icon name="ph:check" width={10} /> : null}
+                        </span>
+                      ) : null}
                       <span className="familiar-switcher__avatar">
                         <FamiliarAvatar familiar={f} size="sm" />
                         <span className={`familiar-switcher__presence ${presence.dot}`} aria-hidden />

--- a/src/components/familiar-switcher.tsx
+++ b/src/components/familiar-switcher.tsx
@@ -138,12 +138,16 @@ export function FamiliarSwitcher({
     ? `${multiScope.size} familiars`
     : active
       ? active.display_name
-      : "All familiars";
+      : singleRequired
+        ? "Choose familiar"
+        : "All familiars";
   const triggerLabel = !singleRequired && multiScope
     ? `Switch familiar — scope: ${multiScope.size} familiars`
     : active
       ? `Switch familiar — current: ${active.display_name}`
-      : "Switch familiar — scope: all familiars";
+      : singleRequired
+        ? "Choose familiar"
+        : "Switch familiar — scope: all familiars";
 
   return (
     <>

--- a/src/components/home-composer-hide-archived.test.ts
+++ b/src/components/home-composer-hide-archived.test.ts
@@ -79,13 +79,12 @@ assert.match(
   "The familiar context should check whether activeFamiliarId points at an archived familiar",
 );
 
-// 5. The familiar picker itself is gone from home (selection lives in the side
-//    panel), so no dropdown may render familiars — visibleFamiliars only feeds
-//    the default-selection fallback above.
-assert.doesNotMatch(
+// 5. Home exposes the resolved, non-archived familiar list in the explicit
+//    launch-context picker.
+assert.match(
   source,
-  /HomeSelect|Choose chat agent/,
-  "HomeComposer should not render a familiar picker (side panel owns selection)",
+  /<FamiliarQuickSwitch[\s\S]*familiars=\{familiars\}/,
+  "HomeComposer should render the familiar picker from its resolved roster",
 );
 
 console.log("home-composer-hide-archived.test.ts: ok");

--- a/src/components/home-composer-polish.test.ts
+++ b/src/components/home-composer-polish.test.ts
@@ -107,10 +107,10 @@ assert.doesNotMatch(
   /hc-footer-band/,
   "the legacy hc- footer band stays retired — the shared cave-composer-footer-band carries the context pill",
 );
-assert.doesNotMatch(
+assert.match(
   source,
-  /HomeSelect|Choose chat agent/,
-  "the home familiar selector is removed (selection lives in the side panel)",
+  /<FamiliarQuickSwitch[\s\S]*labeled[\s\S]*singleRequired/,
+  "the home familiar selector is labeled and constrained to one launch target",
 );
 assert.doesNotMatch(
   source,
@@ -131,8 +131,8 @@ assert.match(
 assert.doesNotMatch(css, /\.hc-action-bar\b/, "the bespoke action-bar CSS is gone (chat composer footer styles apply)");
 assert.doesNotMatch(
   css,
-  /\.hc-familiar-selector|\.hc-home-select/,
-  "the familiar-selector / home-select CSS is removed with the selector",
+  /\.hc-home-select/,
+  "home reuses the shared familiar picker instead of custom select CSS",
 );
 assert.doesNotMatch(
   css,

--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -226,7 +226,11 @@ assert.doesNotMatch(
   /\/api\/chat\/send/,
   "HomeComposer must not send chats itself — its cancel-after-session-event pattern aborted the request, killed the harness, and lost the transcript. Chat sends belong to ChatView.",
 );
-
+assert.match(
+  source,
+  /const handled = onSlash\?\.\(command, args\) \?\? false;[\s\S]*?if \(handled\) \{[\s\S]*?return;[\s\S]*?\}[\s\S]*?onStartChat\(prompt, selectedFamiliarId, selectedProjectRoot, \{[\s\S]*?initialControls: initialChatControls/,
+  "Home should launch a real chat when a slash command requires chat-owned context",
+);
 assert.match(
   source,
   /onStartChat\(prompt, selectedFamiliarId, selectedProjectRoot, \{\s*initialControls: initialChatControls,[\s\S]*?\}\)/,
@@ -251,18 +255,16 @@ assert.match(
   "HomeComposer should invalidate warmed tasks and clear staged attachments after creating a board card",
 );
 
-// ── Familiar selector removed from home ──────────────────────────────────────
-// The active familiar is chosen in the side panel; home must not duplicate the
-// selector. The footer band's second chip is the runtime + model picker.
-assert.doesNotMatch(
+// ── Familiar selector is explicit at the launch point ────────────────────────
+assert.match(
   source,
   /onSetActiveFamiliar/,
-  "HomeComposer no longer takes an active-familiar setter (selection lives in the side panel)",
+  "HomeComposer accepts the active-familiar setter",
 );
-assert.doesNotMatch(
+assert.match(
   source,
-  /HomeSelect|Choose chat agent|hc-access-chip/,
-  "HomeComposer no longer renders the home familiar selector chip",
+  /<FamiliarQuickSwitch[\s\S]*activeFamiliarId=\{selectedFamiliarId \|\| null\}[\s\S]*singleRequired/,
+  "HomeComposer shows a labeled, single-familiar picker beside launch context",
 );
 
 assert.doesNotMatch(
@@ -338,6 +340,11 @@ assert.doesNotMatch(
 // aria-activedescendant conveys the highlight while focus stays in the textarea.
 
 const chatSource = await readFile(new URL("./chat-view.tsx", import.meta.url), "utf8");
+assert.match(
+  chatSource,
+  /initialAttachments\?\.length \?\? 0\) === 0 &&[\s\S]*?intentFromSlash\(initialPrompt\)[\s\S]*?return;/,
+  "ChatView should execute a Home-handoff slash command after mounting instead of sending it as plain harness text",
+);
 // HomeComposer delegates its popover JSX to the shared HomeSlashMenu component
 // (Task 6: collapse the three near-duplicate popovers into one); ChatView still
 // inlines its own menus, so the ARIA/JSX assertions below check each in its
@@ -428,7 +435,7 @@ assert.match(
 );
 
 // ── /skill + /skills inline picker (mirrors /model) ──────────────────────────
-assert.match(menusHook, /skillSlashOptions\(text, skills\)/, "the shared hook offers inline /skill autocomplete");
+assert.match(menusHook, /skillSlashOptions\(activeInvocation\?\.input \?\? "", skills\)/, "the shared hook offers caret-scoped inline /skill autocomplete");
 assert.match(source, /command === "\/skill" \|\| command === "\/skills"/, "HomeComposer handles the /skill and /skills commands");
 assert.match(
   source,
@@ -531,7 +538,7 @@ assert.match(
 
 assert.match(
   menusHook,
-  /modelSlashOptions\(text, modelHarness, modelOptionsOverride\)/,
+  /modelSlashOptions\(activeInvocation\?\.input \?\? "", modelHarness, modelOptionsOverride\)/,
   "the shared hook offers inline /model autocomplete",
 );
 assert.match(
@@ -563,7 +570,7 @@ assert.doesNotMatch(
 // these pins hold the call sites, the hook test holds the semantics.
 assert.match(
   source,
-  /const \[text, setText\] = useState\(""\);[\s\S]{0,260}?const \[draftRestored, setDraftRestored\] = useState\(false\);[\s\S]{0,260}?useLayoutEffect\(\(\) => \{\s*setText\(readComposerDraft\(HOME_DRAFT_KEY\)\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
+  /const \[text, setText\] = useState\(""\);[\s\S]{0,260}?const \[composerCaret, setComposerCaret\] = useState\(0\);[\s\S]{0,260}?const \[draftRestored, setDraftRestored\] = useState\(false\);[\s\S]{0,320}?useLayoutEffect\(\(\) => \{\s*const restored = readComposerDraft\(HOME_DRAFT_KEY\);\s*setText\(restored\);\s*setComposerCaret\(restored\.length\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
   "home composer restores the persisted draft before paint from an SSR-stable empty snapshot",
 );
 assert.match(
@@ -746,12 +753,12 @@ assert.match(
 );
 assert.match(
   menusHook,
-  /slashDismissed \? null : modelSlashOptions\(text, modelHarness, modelOptionsOverride\)/,
+  /slashDismissed \? null : modelSlashOptions\(activeInvocation\?\.input \?\? "", modelHarness, modelOptionsOverride\)/,
   "the model menu respects the dismissed flag",
 );
 assert.match(
   menusHook,
-  /slashDismissed \? null : skillSlashOptions\(text, skills\)/,
+  /slashDismissed \? null : skillSlashOptions\(activeInvocation\?\.input \?\? "", skills\)/,
   "the skill menu respects the dismissed flag",
 );
 assert.match(

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -19,7 +19,8 @@ import {
   useRef,
   useState,
 } from "react";
-import type { Familiar, SessionRow } from "@/lib/types";
+import type { SessionRow } from "@/lib/types";
+import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 import type { InitialCommandControls } from "@/lib/command-controls";
 import { Icon } from "@/lib/icon";
 import { isRuntimeDefaultModelArg, resolveModelArg } from "@/lib/slash-model";
@@ -58,6 +59,7 @@ import { useKeySymbols } from "@/lib/platform-keys";
 import { inventoryProvenanceLabel, useRuntimeModelInventory } from "@/lib/use-runtime-model-options";
 import { canonicalHarnessId, COMPATIBILITY_ADAPTERS } from "@/lib/harness-adapters";
 import { HomeSlashMenu } from "@/components/home/home-slash-menu";
+import { FamiliarQuickSwitch } from "@/components/familiar-quick-switch";
 import { useHomeModelState } from "@/components/home/use-home-model-state";
 import { HomeFromTaskRow, type HomeTaskOrigin } from "@/components/home/home-from-task";
 import { HomeContinue } from "@/components/home/home-continue";
@@ -91,8 +93,9 @@ import {
 export type { Destination } from "@/components/home/home-destinations";
 
 type Props = {
-  familiars: Familiar[];
+  familiars: ResolvedFamiliar[];
   activeFamiliarId: string | null;
+  onSetActiveFamiliar: (familiarId: string) => void;
   sessions: SessionRow[];
   /** Open a new chat that sends `prompt` through ChatView's streaming path.
    *  Home never talks to the chat API itself — a fire-and-cancel send here
@@ -111,7 +114,7 @@ type Props = {
   onToast: (msg: string) => void;
   /** Submit a slash command. Mirrors the chat composer's escape hatch so
    *  `/inbox`, `/board`, `/remind …` etc. work from the home screen too. */
-  onSlash?: (command: string, args: string) => void;
+  onSlash?: (command: string, args: string) => boolean;
   /** Resume a recent chat from the Continue column's session cards. */
   onOpenSession?: (sessionId: string, familiarId: string | null) => void;
   /** Voice new-chat: start a live voice call in a brand-new chat with this
@@ -134,6 +137,7 @@ const HOME_COMPOSER_MAX_HEIGHT = 332;
 export function HomeComposer({
   familiars,
   activeFamiliarId,
+  onSetActiveFamiliar,
   sessions,
   onStartChat,
   onNavigateToBoard,
@@ -145,9 +149,12 @@ export function HomeComposer({
   // Hydrate from the same empty draft SSR emitted, then restore local storage
   // before paint so textarea and Send-button state update in one React commit.
   const [text, setText] = useState("");
+  const [composerCaret, setComposerCaret] = useState(0);
   const [draftRestored, setDraftRestored] = useState(false);
   useLayoutEffect(() => {
-    setText(readComposerDraft(HOME_DRAFT_KEY));
+    const restored = readComposerDraft(HOME_DRAFT_KEY);
+    setText(restored);
+    setComposerCaret(restored.length);
     setDraftRestored(true);
   }, []);
   const [destination, setDestination] = useState<Destination>("chat");
@@ -188,6 +195,16 @@ export function HomeComposer({
   }, []);
   const { announce } = useAnnouncer();
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const completeComposerText = useCallback((nextText: string, nextCaret: number) => {
+    setText(nextText);
+    setComposerCaret(nextCaret);
+    requestAnimationFrame(() => {
+      const textarea = textareaRef.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(nextCaret, nextCaret);
+    });
+  }, []);
   // Attachments staged in the composer (cap 10, mirroring the chat composer);
   // handed to the opened chat on submit. Shared hook — home adds the limit
   // toast + SR announce and defers refocus a tick (the chat composer is silent).
@@ -370,10 +387,13 @@ export function HomeComposer({
     slashIdx,
     setSlashIdx,
     slashListboxId,
+    completeCommand,
     handleKeyDown: handleMenuKey,
   } = useInlineSlashMenus({
     text,
     setText,
+    caret: composerCaret,
+    onCompleteText: completeComposerText,
     modelHarness,
     modelOptionsOverride: runtimeModelOptions,
     onPickModel: (id) => { handleSelectModel(id); onToast(`Model set to ${id}.`); setText(""); },
@@ -626,13 +646,32 @@ export function HomeComposer({
         insertPromptTemplate(template);
         return;
       }
-      if (onSlash) {
+      const handled = onSlash?.(command, args) ?? false;
+      if (handled) {
         pushHistory(prompt);
         setText("");
-        onSlash(command, args);
-      } else {
-        onToast(`Slash commands aren't wired up here yet — try ${command} from a chat.`);
+        return;
       }
+      if (!selectedFamiliarId) {
+        onToast("No familiar yet — summon one to run this command. Your draft is saved.");
+        requestSummonFamiliar();
+        return;
+      }
+      if (!projectLaunchReady) {
+        onToast(projectLaunchMessage);
+        return;
+      }
+      if (!(await waitForRuntimeWrite())) {
+        onToast("Runtime selection could not be saved; chat was not started.");
+        return;
+      }
+      pushHistory(prompt);
+      setText("");
+      clearDraft();
+      clearAttachments();
+      onStartChat(prompt, selectedFamiliarId, selectedProjectRoot, {
+        initialControls: initialChatControls,
+      });
       return;
     }
 
@@ -916,7 +955,7 @@ export function HomeComposer({
               const cmd = slashSuggestions[i];
               const s = skillCommandRows[i - slashSuggestions.length];
               if (cmd) {
-                setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
+                completeCommand(cmd.name, Boolean(cmd.argPlaceholder));
                 textareaRef.current?.focus();
               } else if (s) {
                 invokeSkill(s);
@@ -1002,7 +1041,13 @@ export function HomeComposer({
           rows={1}
           value={text}
           readOnly={!draftRestored}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => {
+            setText(e.target.value);
+            setComposerCaret(e.target.selectionStart ?? e.target.value.length);
+          }}
+          onSelect={(e) => setComposerCaret(e.currentTarget.selectionStart ?? e.currentTarget.value.length)}
+          onClick={(e) => setComposerCaret(e.currentTarget.selectionStart ?? e.currentTarget.value.length)}
+          onKeyUp={(e) => setComposerCaret(e.currentTarget.selectionStart ?? e.currentTarget.value.length)}
           onPaste={handlePaste}
           onKeyDown={handleKeyDown}
           disabled={sending}
@@ -1219,6 +1264,17 @@ export function HomeComposer({
             above. Send hugs bottom-right, vertically aligned. */}
         <div className="cave-composer-footer-band home-composer-toolbar">
           <div className="home-composer-toolbar__left">
+            <FamiliarQuickSwitch
+              familiars={familiars}
+              activeFamiliarId={selectedFamiliarId || null}
+              sessions={sessions}
+              onSelectFamiliar={(id) => {
+                if (id) onSetActiveFamiliar(id);
+              }}
+              placement="top-start"
+              labeled
+              singleRequired
+            />
             <ComposerContextChips
               projects={projects}
               projectValue={displayProjectId}

--- a/src/components/quick-chat-controls.tsx
+++ b/src/components/quick-chat-controls.tsx
@@ -2,7 +2,7 @@
 
 import "@/styles/cave-composer.css";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useRef, useState } from "react";
 // The slash menu popover reuses the home composer's .hc-slash-* affordance —
 // this stylesheet is global-scoped, so importing it here makes the menu render
 // identically in the tray window (which never mounts the home composer).
@@ -330,6 +330,17 @@ export function QuickChatComposer({
   const modelHarness = canonicalHarnessId(familiar?.harness ?? "claude");
   const runtimeModelInventory = useRuntimeModelInventory(modelHarness, familiar?.id);
   const runtimeModelOptions = runtimeModelInventory.models;
+  const [composerCaret, setComposerCaret] = useState(draft.length);
+  const completeComposerText = useCallback((nextText: string, nextCaret: number) => {
+    onDraftChange(nextText);
+    setComposerCaret(nextCaret);
+    requestAnimationFrame(() => {
+      const textarea = composerRef?.current;
+      if (!textarea) return;
+      textarea.focus();
+      textarea.setSelectionRange(nextCaret, nextCaret);
+    });
+  }, [composerRef, onDraftChange]);
   // Shared inline menus (/command listbox + Skills group, /model, /skill,
   // /prompt pickers) — same hook as the home/chat composers so the keyboard
   // grammar transfers. The pick callbacks reference the helpers declared just
@@ -338,6 +349,8 @@ export function QuickChatComposer({
   const menu = useInlineSlashMenus({
     text: draft,
     setText: onDraftChange,
+    caret: composerCaret,
+    onCompleteText: completeComposerText,
     modelHarness,
     modelOptionsOverride: runtimeModelOptions,
     onPickModel: (id) => {
@@ -667,7 +680,7 @@ export function QuickChatComposer({
             const cmd = menu.slashSuggestions[i];
             const s = menu.skillCommandRows[i - menu.slashSuggestions.length];
             if (cmd) {
-              onDraftChange(cmd.name + (cmd.argPlaceholder ? " " : ""));
+              menu.completeCommand(cmd.name, Boolean(cmd.argPlaceholder));
               composerRef?.current?.focus();
             } else if (s) {
               invokeSkillOption(s);
@@ -725,7 +738,13 @@ export function QuickChatComposer({
         aria-expanded={slashMenuOpen}
         aria-controls={slashMenuOpen ? menu.slashListboxId : undefined}
         aria-activedescendant={slashMenuOpen ? `${menu.slashListboxId}-opt-${menu.slashIdx}` : undefined}
-        onChange={(event) => onDraftChange(event.target.value)}
+        onChange={(event) => {
+          onDraftChange(event.target.value);
+          setComposerCaret(event.target.selectionStart ?? event.target.value.length);
+        }}
+        onSelect={(event) => setComposerCaret(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
+        onClick={(event) => setComposerCaret(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
+        onKeyUp={(event) => setComposerCaret(event.currentTarget.selectionStart ?? event.currentTarget.value.length)}
         onKeyDown={onKeyDown}
         onPaste={handlePaste}
         placeholder={familiar ? `Message @${familiar.id}…` : "@sage summarize what needs attention"}

--- a/src/components/shell-first-paint.test.ts
+++ b/src/components/shell-first-paint.test.ts
@@ -61,8 +61,8 @@ assert.match(
 
 assert.match(
   homeComposer,
-  /useLayoutEffect\(\(\) => \{\s*setText\(readComposerDraft\(HOME_DRAFT_KEY\)\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
-  "HomeComposer must restore a persisted draft before paint without hydrating mismatched controls",
+  /useLayoutEffect\(\(\) => \{\s*const restored = readComposerDraft\(HOME_DRAFT_KEY\);\s*setText\(restored\);\s*setComposerCaret\(restored\.length\);\s*setDraftRestored\(true\);\s*\}, \[\]\)/,
+  "HomeComposer must restore a persisted draft and its caret before paint without hydrating mismatched controls",
 );
 
 console.log("shell-first-paint.test.ts OK");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2616,11 +2616,9 @@ export function Workspace() {
         setMode("journal"); // opens the Grimoire on its Journal tab (see setMode)
         return true;
       case "/canvas":
-        // The Canvas page moved to feature/journal-canvas-surface. /canvas is
-        // chat-inline now: hand off to a fresh chat and let its composer's
-        // /canvas handler take over (args typed here aren't forwarded).
-        startFamiliarChat(activeId);
-        return true;
+        // /canvas is chat-inline. Home falls back to a new chat with the exact
+        // command so ChatView can execute it after mounting.
+        return false;
       case "/chats":
       case "/agents":
       case "/chat":
@@ -2703,7 +2701,8 @@ export function Workspace() {
       case "/codex":
       case "/claude":
         // These need composer context; route to the chat view's slash handler.
-        routerRef.current?.runSlash(command);
+        if (!routerRef.current) return false;
+        routerRef.current.runSlash(command);
         return true;
     }
     return false;
@@ -3258,8 +3257,9 @@ export function Workspace() {
       <AskSalemView familiars={familiars} activeFamiliarId={activeId} />
     ) : (
       <HomeComposer
-        familiars={familiars}
+        familiars={resolvedFamiliars}
         activeFamiliarId={activeId}
+        onSetActiveFamiliar={setActiveId}
         sessions={sessions}
         onStartChat={(prompt, fid, projectRoot, opts) =>
           startFamiliarChat(fid, projectRoot, prompt, opts?.initialControls ?? null, opts?.initialAttachments ?? null)
@@ -3267,7 +3267,7 @@ export function Workspace() {
         onStartVoiceCall={(fid, projectRoot) => startVoiceChat(fid, projectRoot)}
         onNavigateToBoard={() => setMode("board")}
         onToast={pushToast}
-        onSlash={(command, args) => onPaletteIntent({ kind: "slash", command, args })}
+        onSlash={handleSlashIntent}
         onOpenSession={(sessionId, familiarId) => openFamiliarSession(sessionId, familiarId)}
       />
     );

--- a/src/lib/slash-command-inline.test.ts
+++ b/src/lib/slash-command-inline.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import {
+  inlineSlashInvocation,
+  replaceInlineSlashRange,
+} from "./slash-commands.ts";
+
+assert.deepEqual(
+  inlineSlashInvocation("please /ima", 11),
+  {
+    start: 7,
+    caret: 11,
+    tokenEnd: 11,
+    input: "/ima",
+    commandToken: "/ima",
+  },
+  "a command token after prose should own the caret",
+);
+
+assert.deepEqual(
+  inlineSlashInvocation("first line\nthen /model cla", 26),
+  {
+    start: 16,
+    caret: 26,
+    tokenEnd: 22,
+    input: "/model cla",
+    commandToken: "/model",
+  },
+  "argument pickers should receive the invocation on later lines",
+);
+
+assert.equal(
+  inlineSlashInvocation("https://example.com/path", 12),
+  null,
+  "URL slashes should not open the command menu",
+);
+
+assert.deepEqual(
+  replaceInlineSlashRange("please /ima after", 7, 11, "/image"),
+  { text: "please /image after", caret: 13 },
+  "completion should preserve text outside the active slash range",
+);
+
+console.log("slash-command-inline.test.ts: ok");

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -92,6 +92,59 @@ export function matchSlash(prefix: string): SlashCommand[] {
   );
 }
 
+export type InlineSlashInvocation = {
+  start: number;
+  caret: number;
+  tokenEnd: number;
+  input: string;
+  commandToken: string;
+};
+
+/**
+ * Find the slash invocation that owns the caret. A slash may begin the draft
+ * or follow whitespace, which keeps URLs and path fragments from opening the
+ * command menu while allowing commands after prose or on later lines.
+ */
+export function inlineSlashInvocation(
+  text: string,
+  caret: number,
+): InlineSlashInvocation | null {
+  const boundedCaret = Math.max(0, Math.min(caret, text.length));
+  const beforeCaret = text.slice(0, boundedCaret);
+  let start = beforeCaret.lastIndexOf("/");
+
+  while (start >= 0) {
+    if (start === 0 || /\s/.test(beforeCaret[start - 1] ?? "")) {
+      const input = beforeCaret.slice(start);
+      if (!input.includes("\n")) {
+        const commandToken = input.split(/\s/, 1)[0] ?? "";
+        let tokenEnd = start + commandToken.length;
+        while (tokenEnd < text.length && !/\s/.test(text[tokenEnd] ?? "")) {
+          tokenEnd += 1;
+        }
+        return { start, caret: boundedCaret, tokenEnd, input, commandToken };
+      }
+    }
+    start = beforeCaret.lastIndexOf("/", start - 1);
+  }
+
+  return null;
+}
+
+export function replaceInlineSlashRange(
+  text: string,
+  start: number,
+  end: number,
+  replacement: string,
+): { text: string; caret: number } {
+  const safeStart = Math.max(0, Math.min(start, text.length));
+  const safeEnd = Math.max(safeStart, Math.min(end, text.length));
+  return {
+    text: `${text.slice(0, safeStart)}${replacement}${text.slice(safeEnd)}`,
+    caret: safeStart + replacement.length,
+  };
+}
+
 /** Render a /help block grouped by section. */
 export function formatHelp(): string {
   const sections: Record<string, string> = {

--- a/src/lib/slash-prompt.test.ts
+++ b/src/lib/slash-prompt.test.ts
@@ -81,7 +81,11 @@ assert.match(slashCmds, /name: "\/prompts"/, "/prompts is registered");
 // by BOTH composers; the insert-not-send contract stays pinned per composer.
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 const menusHook = await readFile(new URL("./use-inline-slash-menus.ts", import.meta.url), "utf8");
-assert.match(menusHook, /promptSlashOptions\(text, prompts\)/, "the shared hook computes the inline /prompt options");
+assert.match(
+  menusHook,
+  /promptSlashOptions\(activeInvocation\?\.input \?\? "", prompts\)/,
+  "the shared hook computes /prompt options from the invocation at the caret",
+);
 assert.match(menusHook, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "menuOpen includes the prompt picker");
 assert.match(chatView, /command === "\/prompt" \|\| command === "\/prompts"/, "chat-view dispatches /prompt and /prompts");
 assert.match(chatView, /role="listbox" aria-label="Prompts"/, "chat-view renders a Prompts listbox");

--- a/src/lib/slash-skill.test.ts
+++ b/src/lib/slash-skill.test.ts
@@ -107,7 +107,7 @@ assert.match(slashCmds, /name: "\/skills"/, "/skills is registered");
 // what a pick DOES (send in-thread vs start-a-chat) stays per composer.
 const chatView = await readFile(new URL("../components/chat-view.tsx", import.meta.url), "utf8");
 const menusHook = await readFile(new URL("./use-inline-slash-menus.ts", import.meta.url), "utf8");
-assert.match(menusHook, /skillSlashOptions\(text, skills\)/, "the shared hook computes the inline /skill options");
+assert.match(menusHook, /skillSlashOptions\(activeInvocation\?\.input \?\? "", skills\)/, "the shared hook computes the caret-scoped inline /skill options");
 assert.match(menusHook, /const menuOpen = modelMenuActive \|\| skillMenuActive \|\| promptMenuActive \|\| slashSuggestions\.length > 0 \|\| skillCommandRows\.length > 0;/, "menuOpen includes the skill picker and the Skills group");
 assert.match(chatView, /command === "\/skill" \|\| command === "\/skills"/, "chat-view dispatches /skill and /skills");
 assert.match(chatView, /sendRaw\(buildSkillPrompt\(skill, skillArgs\)\)/, "typed /skill arguments are forwarded into the invocation");
@@ -115,7 +115,7 @@ assert.match(chatView, /sendRaw\(buildSkillPrompt\(s\)\)/, "picking a skill send
 assert.match(chatView, /const invokeSkillOption = \(s: SkillOption\)/, "chat-view shares one skill-invoke helper across picker, menu and clicks");
 assert.match(chatView, /onPickSkill: \(s\) => invokeSkillOption\(s\)/, "the hook's skill picks route through chat-view's invoke helper");
 assert.match(chatView, /s\.argumentHint && input\.trim\(\)\.toLowerCase\(\) !== filled\.toLowerCase\(\)/, "a hinted skill autofills /skill <id> for argument editing instead of sending");
-assert.match(menusHook, /skillCommandMatches\(firstWord, skills\)/, "the shared hook surfaces skills in the top-level command menu");
+assert.match(menusHook, /skillCommandMatches\(activeInvocation\.commandToken, skills\)/, "the shared hook surfaces skills at the active slash token");
 assert.match(chatView, /role="listbox" aria-label="Skills"/, "chat-view renders a Skills listbox");
 assert.match(menusHook, /fetch\("\/api\/skills\/local"/, "the shared hook sources skills from the local skill scan");
 

--- a/src/lib/use-inline-slash-menus.test.ts
+++ b/src/lib/use-inline-slash-menus.test.ts
@@ -44,6 +44,11 @@ assert.match(
   /replaceInlineSlashRange\(text, start, end, replacement\)/,
   "completion preserves surrounding draft text instead of replacing the whole composer",
 );
+assert.match(
+  src,
+  /let replacementEnd = activeInvocation\.caret;[\s\S]*?while \(replacementEnd < text\.length && !\/\\s\/\.test\(text\[replacementEnd\] \?\? ""\)\)[\s\S]*?completeRange\(activeInvocation\.start, replacementEnd, replacement\)/,
+  "argument completion replaces the rest of the token after a mid-token caret",
+);
 
 // ── Esc-dismiss: one flag, all four pickers, typing re-opens ─────────────────
 assert.match(

--- a/src/lib/use-inline-slash-menus.test.ts
+++ b/src/lib/use-inline-slash-menus.test.ts
@@ -7,7 +7,7 @@ const src = readFileSync(new URL("./use-inline-slash-menus.ts", import.meta.url)
 // ── Signature: pick semantics stay per-composer via callbacks ────────────────
 assert.match(
   src,
-  /export function useInlineSlashMenus\(opts: \{\s*text: string;\s*setText: \(t: string\) => void;\s*modelHarness: string;\s*modelOptionsOverride\?: RuntimeModelOption\[\];\s*onPickModel:[\s\S]*?onPickSkill:[\s\S]*?onInsertPrompt:[\s\S]*?onRunCommand:[\s\S]*?onNoMatchEnter\?:/,
+  /export function useInlineSlashMenus\(opts: \{\s*text: string;\s*setText: \(t: string\) => void;\s*caret: number;\s*onCompleteText\?:[\s\S]*?modelHarness: string;\s*modelOptionsOverride\?: RuntimeModelOption\[\];\s*onPickModel:[\s\S]*?onPickSkill:[\s\S]*?onInsertPrompt:[\s\S]*?onRunCommand:[\s\S]*?onNoMatchEnter\?:/,
   "useInlineSlashMenus takes the text pair + pick callbacks — what a pick DOES stays per-composer",
 );
 assert.match(
@@ -33,11 +33,16 @@ assert.match(
   "unconsumed keys report false so history recall and Enter-send still run",
 );
 
-// ── First-token-only matching (menus never open mid-sentence) ────────────────
+// ── Caret-scoped matching (menus open after prose and on later lines) ─────────
 assert.match(
   src,
-  /const firstWord = text\.trimStart\(\)\.split\(\/\\s\/\)\[0\] \?\? "";\s*\n\s*if \(!firstWord\.startsWith\("\/"\) \|\| text\.trimStart\(\)\.includes\(" "\)\) return \[\];/,
-  "slash suggestions surface only while the user is still typing the command token",
+  /inlineSlashInvocation\(text, caret\)/,
+  "slash suggestions derive from the invocation that owns the caret",
+);
+assert.match(
+  src,
+  /replaceInlineSlashRange\(text, start, end, replacement\)/,
+  "completion preserves surrounding draft text instead of replacing the whole composer",
 );
 
 // ── Esc-dismiss: one flag, all four pickers, typing re-opens ─────────────────
@@ -48,7 +53,7 @@ assert.match(
 );
 assert.match(
   src,
-  /slashDismissed \? null : modelSlashOptions\(text, modelHarness, modelOptionsOverride\)/,
+  /slashDismissed \? null : modelSlashOptions\(activeInvocation\?\.input \?\? "", modelHarness, modelOptionsOverride\)/,
   "dismissal nulls the /model options",
 );
 assert.match(
@@ -72,7 +77,7 @@ assert.match(
 // ── Enter on a command: autocomplete-then-run ────────────────────────────────
 assert.match(
   src,
-  /if \(cmd && cmd\.argPlaceholder && canonicalize\(text\.trim\(\)\) !== cmd\.name\) \{\s*\n\s*setText\(cmd\.name \+ " "\);\s*\n\s*\} else if \(cmd\) \{\s*\n\s*cbRef\.current\.onRunCommand\(cmd\);\s*\n\s*\} else if \(s\) \{\s*\n\s*cbRef\.current\.onPickSkill\(s\);\s*\n\s*\} else \{\s*\n\s*cbRef\.current\.onNoMatchEnter\?\.\(\);\s*\n\s*\}/,
+  /canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*?completeCommand\(cmd\.name, true\);[\s\S]*?\} else if \(cmd\) \{[\s\S]*?cbRef\.current\.onRunCommand\(cmd\);/,
   "Enter autocompletes argument-taking commands, runs exact ones, picks skills, and defers no-match to the caller (home submits; chat consumes)",
 );
 

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -206,9 +206,13 @@ export function useInlineSlashMenus(opts: {
   const completeInvocation = useCallback(
     (replacement: string) => {
       if (!activeInvocation) return;
-      completeRange(activeInvocation.start, activeInvocation.caret, replacement);
+      let replacementEnd = activeInvocation.caret;
+      while (replacementEnd < text.length && !/\s/.test(text[replacementEnd] ?? "")) {
+        replacementEnd += 1;
+      }
+      completeRange(activeInvocation.start, replacementEnd, replacement);
     },
-    [activeInvocation, completeRange],
+    [activeInvocation, completeRange, text],
   );
 
   const handleKeyDown = useCallback(

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -1,7 +1,13 @@
 "use client";
 
 import { useCallback, useEffect, useId, useMemo, useRef, useState, type KeyboardEvent } from "react";
-import { canonicalize, matchSlash, type SlashCommand } from "@/lib/slash-commands";
+import {
+  canonicalize,
+  inlineSlashInvocation,
+  matchSlash,
+  replaceInlineSlashRange,
+  type SlashCommand,
+} from "@/lib/slash-commands";
 import { modelSlashOptions } from "@/lib/slash-model";
 import type { RuntimeModelOption } from "@/lib/runtime-models";
 import { skillCommandMatches, skillSlashOptions, type SkillOption } from "@/lib/slash-skill";
@@ -15,7 +21,7 @@ import { orderPrompts, readPromptFavorites, readPromptRecents } from "@/lib/prom
  *
  * Why this exists: the chat composer (chat-view.tsx) and the home composer
  * (home-composer.tsx) each hand-rolled the identical menu machinery — the
- * first-token-only matching rule, the skills/prompts fetches, the roving
+ * caret-scoped matching rule, the skills/prompts fetches, the roving
  * index that runs from the command list into the Skills group, the shared
  * listbox id behind the textarea's combobox ARIA, Esc-dismiss with
  * typing-reopens, and the ↑↓/Tab/Enter keyboard branches. One implementation
@@ -37,6 +43,8 @@ import { orderPrompts, readPromptFavorites, readPromptRecents } from "@/lib/prom
 export function useInlineSlashMenus(opts: {
   text: string;
   setText: (t: string) => void;
+  caret: number;
+  onCompleteText?: (text: string, caret: number) => void;
   modelHarness: string;
   modelOptionsOverride?: RuntimeModelOption[];
   onPickModel: (id: string) => void;
@@ -60,9 +68,10 @@ export function useInlineSlashMenus(opts: {
   setSlashIdx: (updater: number | ((i: number) => number)) => void;
   slashListboxId: string;
   dismiss: () => void;
+  completeCommand: (command: string, appendSpace?: boolean) => void;
   handleKeyDown: (e: KeyboardEvent<HTMLTextAreaElement>) => boolean;
 } {
-  const { text, setText, modelHarness, modelOptionsOverride } = opts;
+  const { text, setText, caret, modelHarness, modelOptionsOverride } = opts;
   // Latest-ref for the pick callbacks (usePausablePoll pattern) so inline
   // arrows at the call site don't churn handleKeyDown's identity per render.
   const cbRef = useRef(opts);
@@ -76,13 +85,20 @@ export function useInlineSlashMenus(opts: {
     setSlashDismissed(false);
   }, [text]);
 
-  // Slash suggestions — surface only while the user is still typing the
-  // command token (no whitespace yet).
+  const activeInvocation = useMemo(
+    () => inlineSlashInvocation(text, caret),
+    [text, caret],
+  );
+  const commandTokenActive = Boolean(
+    activeInvocation && !/\s/.test(activeInvocation.input),
+  );
+
+  // Slash suggestions surface while the caret is inside a command token. The
+  // token can appear after prose or on a later line.
   const slashMatches: SlashCommand[] = useMemo(() => {
-    const firstWord = text.trimStart().split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || text.trimStart().includes(" ")) return [];
-    return matchSlash(firstWord);
-  }, [text]);
+    if (!activeInvocation || !commandTokenActive) return [];
+    return matchSlash(activeInvocation.commandToken);
+  }, [activeInvocation, commandTokenActive]);
   const slashSuggestions: SlashCommand[] = slashDismissed ? [] : slashMatches;
 
   // Skills for the inline `/skill` / `/skills` picker — fetched once from the
@@ -131,14 +147,14 @@ export function useInlineSlashMenus(opts: {
   // While typing "/model <partial>", the menu shows model options instead of
   // commands (an inline picker). null ⇒ not in /model arg position.
   const modelOptions = useMemo(
-    () => (slashDismissed ? null : modelSlashOptions(text, modelHarness, modelOptionsOverride)),
-    [text, modelHarness, modelOptionsOverride, slashDismissed],
+    () => (slashDismissed ? null : modelSlashOptions(activeInvocation?.input ?? "", modelHarness, modelOptionsOverride)),
+    [activeInvocation, modelHarness, modelOptionsOverride, slashDismissed],
   );
   const modelMenuActive = (modelOptions?.length ?? 0) > 0;
   // Inline `/skill` / `/skills` picker — null ⇒ not in a skill-picker position.
   const skillOptions = useMemo(
-    () => (slashDismissed ? null : skillSlashOptions(text, skills)),
-    [text, skills, slashDismissed],
+    () => (slashDismissed ? null : skillSlashOptions(activeInvocation?.input ?? "", skills)),
+    [activeInvocation, skills, slashDismissed],
   );
   const skillMenuActive = (skillOptions?.length ?? 0) > 0;
   // Inline `/prompt` / `/prompts` picker — null ⇒ not in a prompt-picker
@@ -147,20 +163,16 @@ export function useInlineSlashMenus(opts: {
   // the very next open.
   const promptOptions = useMemo(() => {
     if (slashDismissed) return null;
-    const options = promptSlashOptions(text, prompts);
+    const options = promptSlashOptions(activeInvocation?.input ?? "", prompts);
     return options ? orderPrompts(options, readPromptFavorites(), readPromptRecents()) : null;
-  }, [text, prompts, slashDismissed]);
+  }, [activeInvocation, prompts, slashDismissed]);
   const promptMenuActive = (promptOptions?.length ?? 0) > 0;
-  // Skills surfaced directly in the command menu — typing `/revi` finds the
-  // code-review skill without the /skill prefix. Same first-token-only rule as
-  // slashSuggestions so arg positions never double-render.
+  // Skills surfaced directly in the command menu — typing `/revi` at the caret
+  // finds the code-review skill without the /skill prefix.
   const skillCommandRows: SkillOption[] = useMemo(() => {
-    if (slashDismissed) return [];
-    const t = text.trimStart();
-    const firstWord = t.split(/\s/)[0] ?? "";
-    if (!firstWord.startsWith("/") || t.includes(" ")) return [];
-    return skillCommandMatches(firstWord, skills);
-  }, [text, skills, slashDismissed]);
+    if (slashDismissed || !activeInvocation || !commandTokenActive) return [];
+    return skillCommandMatches(activeInvocation.commandToken, skills);
+  }, [activeInvocation, commandTokenActive, skills, slashDismissed]);
 
   // The slash-command, /model, /skill and /prompt pickers are mutually
   // exclusive inline listboxes sharing one listbox id, so the composer's
@@ -170,6 +182,34 @@ export function useInlineSlashMenus(opts: {
   const slashListboxId = useId();
 
   const dismiss = useCallback(() => setSlashDismissed(true), []);
+  const completeRange = useCallback(
+    (start: number, end: number, replacement: string) => {
+      const completed = replaceInlineSlashRange(text, start, end, replacement);
+      if (opts.onCompleteText) opts.onCompleteText(completed.text, completed.caret);
+      else setText(completed.text);
+    },
+    [opts.onCompleteText, setText, text],
+  );
+  const completeCommand = useCallback(
+    (command: string, appendSpace = false) => {
+      if (!activeInvocation) return;
+      const suffixStartsWithSpace = /\s/.test(text[activeInvocation.tokenEnd] ?? "");
+      const replacement = `${command}${appendSpace && !suffixStartsWithSpace ? " " : ""}`;
+      completeRange(
+        activeInvocation.start,
+        activeInvocation.tokenEnd,
+        replacement,
+      );
+    },
+    [activeInvocation, completeRange, text],
+  );
+  const completeInvocation = useCallback(
+    (replacement: string) => {
+      if (!activeInvocation) return;
+      completeRange(activeInvocation.start, activeInvocation.caret, replacement);
+    },
+    [activeInvocation, completeRange],
+  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>): boolean => {
@@ -188,7 +228,7 @@ export function useInlineSlashMenus(opts: {
         const opts = modelOptions;
         if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
         if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
-        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) setText(`/model ${m.id}`); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const m = opts[slashIdx]; if (m) completeInvocation(`/model ${m.id}`); return true; }
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           const m = opts[slashIdx];
@@ -201,7 +241,7 @@ export function useInlineSlashMenus(opts: {
         const opts = skillOptions;
         if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
         if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
-        if (e.key === "Tab") { e.preventDefault(); const s = opts[slashIdx]; if (s) setText(`/skill ${s.id}`); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const s = opts[slashIdx]; if (s) completeInvocation(`/skill ${s.id}`); return true; }
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           const s = opts[slashIdx];
@@ -215,7 +255,7 @@ export function useInlineSlashMenus(opts: {
         const opts = promptOptions;
         if (e.key === "ArrowDown") { e.preventDefault(); setSlashIdx((i) => Math.min(i + 1, opts.length - 1)); return true; }
         if (e.key === "ArrowUp") { e.preventDefault(); setSlashIdx((i) => Math.max(i - 1, 0)); return true; }
-        if (e.key === "Tab") { e.preventDefault(); const p = opts[slashIdx]; if (p) setText(`/prompt ${p.id}`); return true; }
+        if (e.key === "Tab") { e.preventDefault(); const p = opts[slashIdx]; if (p) completeInvocation(`/prompt ${p.id}`); return true; }
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           const p = opts[slashIdx];
@@ -243,8 +283,8 @@ export function useInlineSlashMenus(opts: {
           e.preventDefault();
           const cmd = slashSuggestions[slashIdx];
           const s = skillAt(slashIdx);
-          if (cmd) setText(cmd.name + (cmd.argPlaceholder ? " " : ""));
-          else if (s) setText(`/skill ${s.id} `);
+          if (cmd) completeCommand(cmd.name, Boolean(cmd.argPlaceholder));
+          else if (s) completeCommand(`/skill ${s.id}`, true);
           return true;
         }
         if (e.key === "Enter" && !e.shiftKey) {
@@ -254,8 +294,12 @@ export function useInlineSlashMenus(opts: {
           // If the highlighted command takes an argument and the input isn't
           // the exact command yet, autocomplete first (like Tab) so the user
           // can fill in args; otherwise run the highlighted suggestion.
-          if (cmd && cmd.argPlaceholder && canonicalize(text.trim()) !== cmd.name) {
-            setText(cmd.name + " ");
+          if (
+            cmd &&
+            cmd.argPlaceholder &&
+            canonicalize(activeInvocation?.commandToken ?? "") !== cmd.name
+          ) {
+            completeCommand(cmd.name, true);
           } else if (cmd) {
             cbRef.current.onRunCommand(cmd);
           } else if (s) {
@@ -281,6 +325,9 @@ export function useInlineSlashMenus(opts: {
       slashIdx,
       text,
       setText,
+      completeCommand,
+      completeInvocation,
+      activeInvocation,
     ],
   );
 
@@ -300,6 +347,7 @@ export function useInlineSlashMenus(opts: {
     setSlashIdx,
     slashListboxId,
     dismiss,
+    completeCommand,
     handleKeyDown,
   };
 }


### PR DESCRIPTION
## Summary
- launch chat-owned slash commands from Home through a mounted ChatView
- show the active familiar in the Home composer context row
- discover and complete slash commands at the caret anywhere in Home, Chat, and Quick Chat without replacing surrounding text
- add regression coverage for inline parsing, handoff, picker semantics, and source contracts

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1,081 files)
- `env -u COVEN_PIPER_BIN -u COVEN_KOKORO_BIN pnpm test:api` (336 files; removes Cave app ambient voice overrides to match CI)
- `pnpm check:tests-wired`
- `pnpm build`
- browser verification of Home familiar selection, mid-message slash details/completion, and Home `/help` execution in Chat

Bead: `cave-8vnxd`