### PR TITLE
fix(ios): generate the web bundles before xcodegen scans

### DIFF
--- a/apps/ios/CovenCave/README.md
+++ b/apps/ios/CovenCave/README.md
@@ -19,11 +19,10 @@ phased plan and architecture.
 # from the repo root: build the web bundles the app embeds (Resources/markdown.html
 # and Resources/terminal.html — generated & gitignored, the Xcode build can't run
 # node). Needs `pnpm install`. Skipping the terminal bundle ships a blank Terminal tab.
-node scripts/build-ios-markdown.mjs
-node scripts/build-ios-terminal.mjs
+bash scripts/ios-xcodegen.sh   # builds the bundles, verifies them, then
+                               # runs xcodegen — in that order, which matters
 
 cd apps/ios/CovenCave
-xcodegen generate          # produces CovenCave.xcodeproj from project.yml
 open CovenCave.xcodeproj    # ⌘R to run, or:
 
 xcodebuild -project CovenCave.xcodeproj -scheme CovenCave \

--- a/scripts/ios-project-generation.test.mjs
+++ b/scripts/ios-project-generation.test.mjs
@@ -45,9 +45,13 @@ assert.match(
   /set -euo pipefail/,
   "the wrapper should abort on any failing step",
 );
+// wrapperCode, not wrapper: the header comment names all three files, so a
+// full-text search passes even when the check loop does not mention them. This
+// is the third assertion in this file to have that shape — see the two notes
+// above. Search executable lines only.
 for (const resource of ["markdown.html", "terminal.html", "markdown.css"]) {
   assert.ok(
-    wrapper.includes(resource),
+    wrapperCode.includes(resource),
     `the wrapper should assert ${resource} exists before generating the project`,
   );
 }

--- a/scripts/ios-project-generation.test.mjs
+++ b/scripts/ios-project-generation.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// cave-d8ma3: on a fresh clone the three Resources bundles do not exist yet —
+// they are gitignored build artifacts. `xcodegen generate` SCANS the source
+// directory, so anything absent at generate time never enters the resource
+// build phase. project.yml's preBuildScripts generate them, but that runs at
+// BUILD time (after the scan) and is deliberately non-fatal, so the archive
+// succeeds and ships an app with a blank markdown view and a dead terminal.
+//
+// The order therefore has to be structural, not documentary: generate the
+// bundles, prove they exist, and only then run xcodegen.
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+const wrapper = await read("scripts/ios-xcodegen.sh");
+const simulator = await read("scripts/ios-simulator.sh");
+const readme = await read("apps/ios/CovenCave/README.md");
+
+// --- the wrapper generates first, then scans ---------------------------------
+// Compare positions in CODE only. These files explain themselves at length, and
+// an indexOf over the whole text finds "xcodegen generate" in the header comment
+// long before the actual command — which reports the order backwards.
+const code = (src) =>
+  src
+    .split("\n")
+    .map((line) => (line.trim().startsWith("#") ? "" : line))
+    .join("\n");
+const wrapperCode = code(wrapper);
+const genIdx = wrapperCode.indexOf("build-ios-markdown.mjs");
+const termIdx = wrapperCode.indexOf("build-ios-terminal.mjs");
+const scanIdx = wrapperCode.indexOf("xcodegen generate");
+assert.ok(genIdx > 0, "the wrapper should build the markdown bundle");
+assert.ok(termIdx > 0, "the wrapper should build the terminal bundle");
+assert.ok(scanIdx > 0, "the wrapper should run xcodegen");
+assert.ok(
+  genIdx < scanIdx && termIdx < scanIdx,
+  "both bundles must be generated BEFORE xcodegen scans for sources",
+);
+
+// --- and refuses to scan when a bundle is missing -----------------------------
+// Non-fatal generation is what makes this silent. The wrapper is the one place
+// that must fail loudly, so a missing bundle can never reach an archive.
+assert.match(
+  wrapper,
+  /set -euo pipefail/,
+  "the wrapper should abort on any failing step",
+);
+for (const resource of ["markdown.html", "terminal.html", "markdown.css"]) {
+  assert.ok(
+    wrapper.includes(resource),
+    `the wrapper should assert ${resource} exists before generating the project`,
+  );
+}
+// Anchored to the missing-bundle block itself. A bare /exit 1/ over the whole
+// file passes on the unrelated xcodegen/node preflight exits, so deleting this
+// very guard left the assertion green — verified by mutation.
+const missingBlock = wrapperCode.match(/if \[ \$\{#missing\[@\]\}[\s\S]*?\nfi/);
+assert.ok(missingBlock, "the wrapper should branch on the missing-bundle list");
+assert.match(
+  missingBlock[0],
+  /exit 1/,
+  "a missing bundle should exit non-zero rather than warn",
+);
+
+// --- nothing else may call xcodegen directly ----------------------------------
+// A second call site is how this regresses: ios-simulator.sh had exactly this
+// bug — it ran `xcodegen generate` with no generation step ahead of it.
+assert.doesNotMatch(
+  code(simulator),
+  /^\s*xcodegen generate/m,
+  "ios-simulator.sh must go through the wrapper, not call xcodegen itself",
+);
+assert.match(
+  simulator,
+  /ios-xcodegen\.sh/,
+  "ios-simulator.sh should invoke the wrapper",
+);
+
+// --- the documented path is the enforced one ----------------------------------
+assert.match(
+  readme,
+  /ios-xcodegen\.sh/,
+  "the README should point at the wrapper so the manual archive path matches CI",
+);
+
+console.log("ios-project-generation.test.mjs: ok");

--- a/scripts/ios-simulator.sh
+++ b/scripts/ios-simulator.sh
@@ -20,8 +20,12 @@ udid="$(xcrun simctl list devices available -j \
   exit 1
 }
 
+# Via the wrapper, never `xcodegen generate` directly: the web bundles are
+# gitignored, and a scan that runs before they exist produces a project without
+# them (cave-d8ma3).
+"$ROOT/scripts/ios-xcodegen.sh"
+
 cd "$IOS_ROOT"
-xcodegen generate
 xcodebuild \
   -project CovenCave.xcodeproj \
   -scheme CovenCave \

--- a/scripts/ios-xcodegen.sh
+++ b/scripts/ios-xcodegen.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Generate CovenCave.xcodeproj — the ONLY supported way to run xcodegen here.
+#
+# Resources/{markdown.html,terminal.html,markdown.css} are gitignored build
+# artifacts. `xcodegen generate` SCANS the source directory, so on a fresh
+# clone — where those files do not exist yet — they never enter the resource
+# build phase. project.yml regenerates them in preBuildScripts, but that runs
+# at BUILD time (after the scan) and is deliberately non-fatal so a machine
+# without node still builds against the Swift fallbacks.
+#
+# The result was an archive that succeeded with no warning and shipped an app
+# rendering assistant replies blank and a dead terminal (cave-d8ma3, hit while
+# cutting v0.2.3 from a clean clone). The README documented the right order;
+# nothing enforced it.
+#
+# So: build the bundles, PROVE they exist, then scan. A missing bundle exits
+# non-zero here rather than warning, because this is the last point where the
+# failure is still visible.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IOS_ROOT="$ROOT/apps/ios/CovenCave"
+RESOURCES="$IOS_ROOT/CovenCave/Resources"
+
+command -v xcodegen >/dev/null 2>&1 || {
+  echo "[ios] missing xcodegen (brew install xcodegen)" >&2
+  exit 1
+}
+command -v node >/dev/null 2>&1 || {
+  echo "[ios] missing node — cannot build the web bundles the app embeds." >&2
+  echo "[ios] Generating the project without them ships a blank markdown view" >&2
+  echo "[ios] and a dead terminal, so this is fatal here (cave-d8ma3)." >&2
+  exit 1
+}
+
+echo "[ios] building web bundles"
+if ! ( cd "$ROOT" && node scripts/build-ios-markdown.mjs && node scripts/build-ios-terminal.mjs ); then
+  echo "" >&2
+  echo "[ios] web bundle generation failed." >&2
+  echo "[ios] The generators inline vendored assets from node_modules (xterm's" >&2
+  echo "[ios] CSS, the markdown/mermaid bundle), so a checkout that has not run" >&2
+  echo "[ios] 'pnpm install' fails here with a missing-module error." >&2
+  echo "[ios] Run 'pnpm install' at the repo root, then re-run this script." >&2
+  exit 1
+fi
+
+# The generators can succeed while writing nothing useful; check the artifacts
+# themselves, not the exit code, since the exit code is what fooled us before.
+missing=()
+for resource in markdown.html terminal.html markdown.css; do
+  [ -s "$RESOURCES/$resource" ] || missing+=("$resource")
+done
+if [ ${#missing[@]} -gt 0 ]; then
+  echo "[ios] web bundles missing or empty after generation: ${missing[*]}" >&2
+  echo "[ios] refusing to run xcodegen — a scan now would produce a project" >&2
+  echo "[ios] without these resources, and the build would silently succeed." >&2
+  exit 1
+fi
+
+echo "[ios] generating project"
+cd "$IOS_ROOT"
+xcodegen generate

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1454,6 +1454,7 @@ export const SUITES = {
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-project-contract.test.mjs",
     "scripts/ios-chat-familiars-home.test.mjs",
+    "scripts/ios-project-generation.test.mjs",
     "scripts/ios-chat-restyle.test.mjs",
     "scripts/ios-claude-design-fidelity.test.mjs",
     "scripts/ios-modern-polish.test.mjs",


### PR DESCRIPTION
Closes cave-d8ma3.

`Resources/{markdown.html,terminal.html,markdown.css}` are gitignored build artifacts. **`xcodegen generate` scans the source directory**, so on a fresh clone they don't exist at scan time and never enter the resource build phase.

`project.yml` regenerates them in `preBuildScripts` — but that runs at *build* time, after the scan, and is deliberately non-fatal so a machine without node still builds against the Swift fallbacks. The archive then succeeds **with no warning** and ships an app that renders assistant replies blank and a dead terminal. Hit while cutting v0.2.3 from a clean clone.

## Measured, not argued

`terminal.html` references in the generated `project.pbxproj`, on a genuinely fresh worktree:

| path | real references |
|---|---|
| bare `xcodegen generate` | **0** |
| `scripts/ios-xcodegen.sh` | **4** — `PBXFileReference`, `PBXBuildFile`, and both list memberships |

The old project does show 3 textual hits, which is why this is easy to misread: they're the prebuild script's own *name* (`Generate web bundles (markdown.html + terminal.html)`), not references. `markdown.css` showed a flat 0 either way.

## The fix

The README already documented generate-then-scan. Nothing enforced it, and the one scripted call site — `ios-simulator.sh` — did it in the wrong order.

So the order is now structural: **one wrapper** (`scripts/ios-xcodegen.sh`) that builds the bundles, verifies the artifacts exist and are non-empty, and only then runs xcodegen. It **exits 1 rather than warning**, because this is the last point where the failure is still visible — non-fatality is precisely what made the original bug silent.

`ios-simulator.sh` now calls the wrapper; the README leads with it.

A generator failure also explains itself. The bundles inline vendored assets from `node_modules`, so a checkout that hasn't run `pnpm install` fails here — previously with a raw missing-module stack trace, now with that instruction.

## Verification

Behavioural, on a fresh worktree:

- No `node_modules` → wrapper **exits 1** with the `pnpm install` message; xcodegen never runs.
- After `pnpm install` → all three bundles generated, xcodegen succeeds, and all three appear in the build phase.

The new test pins three guarantees, each **mutation-verified**: reorder the wrapper so xcodegen runs first, drop the missing-bundle guard, or restore a direct `xcodegen generate` in `ios-simulator.sh` — each fails the test.

One of those assertions was **vacuous on first write**: a bare `/exit 1/` matched the wrapper's unrelated xcodegen/node preflight exits, so deleting the guard it was meant to protect left it green. It's now anchored to the missing-bundle block. The ordering assertion had the same class of bug — `indexOf` found "xcodegen generate" in the header *comment* — and now compares positions in code with comments stripped.

`pnpm check:tests-wired` → 1,497 files.
