### PR TITLE
Harden exact-head branch merges

### DIFF
--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -261,8 +261,22 @@ gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t
 **Confirmation required.** Then:
 
 ```bash
-gh pr merge <#> --squash --delete-branch
+set -euo pipefail
+expected_head=$(git rev-parse HEAD)
+actual_head=$(gh pr view <#> --json headRefOid --jq .headRefOid)
+test "$actual_head" = "$expected_head"
+gh pr checks <#> --required
+gh pr merge <#> --squash --match-head-commit "$expected_head"
 ```
+
+Repeat the exact-head and required-check verification in the merge command's
+shell: shell variables from Phase 5 may not persist between tool calls.
+`--match-head-commit` then makes GitHub reject the merge if the PR head changes
+between that final check and the merge.
+
+Do not pass `--delete-branch`. That flag asks `gh` to delete both local and
+remote branches immediately after merging. Local retirement belongs to the
+Phase 7 lifecycle patrol, and remote deletion remains proposal-only.
 
 The squash message summarizes the whole branch, not the last commit, and
 carries any human `Co-authored-by:` trailers.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,11 +186,18 @@ gh api graphql -f query='{repository(owner:"OpenCoven",name:"coven-cave"){pullRe
 # until it is false — a partial listing is worse than no listing.
 # fix what is real, reply naming the commit, then per thread id (optional now):
 gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t=<PRRT_…>
-gh pr merge <#> --squash --delete-branch
+set -euo pipefail
+expected_head=$(git rev-parse HEAD)
+actual_head=$(gh pr view <#> --json headRefOid --jq .headRefOid)
+test "$actual_head" = "$expected_head"
+gh pr checks <#> --required
+gh pr merge <#> --squash --match-head-commit "$expected_head"
 ```
 
 `gh pr merge` on a blocked PR suggests `--admin`. Don't. It bypasses the
 protection this section exists to describe; fix the actual blocker instead.
+Do not add `--delete-branch`: local retirement belongs to the lifecycle patrol,
+and remote deletion remains proposal-only.
 
 Squash-merge through `gh`/the PR UI still works — it's a merge, not a direct push. Non-admin pushes to `main` are blocked server-side; admin-authenticated agent sessions are bound by the repository rule above. Don't work around protection to land your own change — and in particular, **do not touch `enforce_admins` in either direction**: it is the owner's setting, currently off by their standing instruction. If a change can't go through a PR, surface it to the owner.
 
@@ -332,7 +339,7 @@ out. See `cave-l52dt`.
 - Symlink `node_modules` from the main checkout — Next.js + pnpm workspaces are fragile around this.
 - `git worktree remove --force` when status is dirty — investigate first; uncommitted edits may belong to another live session.
 
-**After `gh pr merge --squash --delete-branch`:** normal completion uses the lifecycle patrol.
+**After an exact-head squash merge:** normal completion uses the lifecycle patrol.
 Run `pnpm beads:worktrees`; when the full maintenance
 transaction is available, `pnpm beads:worktrees:apply` retires proven-safe
 local state. If it reports active, recovery, cooldown, uncertain, or

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -85,7 +85,11 @@ test("skill offers a PR as the only path onto main", () => {
     !/^\s*[BC]\) (Merge|Squash merge)/m.test(skill),
     "skill must not offer a local merge into the base branch",
   );
-  assert.ok(skill.includes("gh pr merge <#> --squash --delete-branch"));
+  const mergeCommands = skill.match(/^gh pr merge .*$/gm) ?? [];
+  assert.ok(
+    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head"'),
+  );
+  assert.ok(mergeCommands.every((command) => !command.includes("--delete-branch")));
 });
 
 test("skill reuses an existing PR instead of creating a duplicate", () => {
@@ -98,6 +102,25 @@ test("skill requires all checks on the exact current PR head", () => {
   assert.ok(skill.includes("expected_head=$(git rev-parse HEAD)"));
   assert.ok(skill.includes("Before and after the watch, require `headRefOid` to equal `$expected_head`"));
   assert.ok(skill.includes("pending, cancelled, stale, missing, or failed context"));
+  assert.ok(
+    skill.includes('--match-head-commit "$expected_head"'),
+    "merge must atomically reject a PR head that changed after verification",
+  );
+  assert.ok(skill.includes('actual_head=$(gh pr view <#> --json headRefOid --jq .headRefOid)'));
+  assert.ok(skill.includes('test "$actual_head" = "$expected_head"'));
+  assert.ok(skill.includes("gh pr checks <#> --required"));
+  assert.ok(skill.includes("set -euo pipefail"));
+});
+
+test("CLAUDE.md documents the same exact-head, patrol-safe merge", () => {
+  const mergeCommands = claude.match(/^gh pr merge .*$/gm) ?? [];
+  assert.ok(
+    mergeCommands.includes('gh pr merge <#> --squash --match-head-commit "$expected_head"'),
+  );
+  assert.ok(mergeCommands.every((command) => !command.includes("--delete-branch")));
+  assert.ok(claude.includes('test "$actual_head" = "$expected_head"'));
+  assert.ok(claude.includes("gh pr checks <#> --required"));
+  assert.ok(claude.includes("set -euo pipefail"));
 });
 
 test("skill mirrors the protected-main policy that governs its PR lifecycle", () => {


### PR DESCRIPTION
## Summary
- re-verify the PR head and required checks in the merge shell
- bind squash merges atomically with `--match-head-commit`
- leave local retirement to the lifecycle patrol and remote deletion proposal-only
- align `CLAUDE.md` and strengthen contract coverage against reordered deletion flags

## Verification
- `node --test scripts/branch-to-merge-contract.test.mjs scripts/branch-curator-manual-cleanup-contract.test.mjs`
- delete-flag assertion mutation-verified

Bead: `cave-fukqe`