### PR TITLE
Group sidepanel destinations into collapsible sections

### DIFF
--- a/src/components/roles-tools-navigation.test.ts
+++ b/src/components/roles-tools-navigation.test.ts
@@ -60,7 +60,7 @@ assert.doesNotMatch(
 // ── Navigation: one Tools entry for the merged hub ───────────────────────────
 assert.match(
   navigation,
-  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Manage what you own and preview the curated Skills shelf", quiet: true \},/,
+  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Manage what you own and preview the curated Skills shelf", group: "explore", quiet: true \},/,
   "The navigation registry should describe the owned inventory and curated Skills shelf truthfully",
 );
 assert.doesNotMatch(

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -123,6 +123,11 @@ assert.match(
 );
 assert.match(
   source,
+  /itemSelector: "\.sidebar-section-label, \.sidebar-folder-row"/,
+  "section toggles and destinations share one roving keyboard sequence",
+);
+assert.match(
+  source,
   /<div id=\{contentId\} className="sidebar-section__content">\s*\{children\}/,
   "section rows remain mounted so the icon rail can render every destination",
 );

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -70,10 +70,76 @@ assert.match(
   "Sidebar should keep the main navigation in one continuous scrollable rail",
 );
 
-assert.doesNotMatch(
+assert.match(source, /function SidebarSection\(/, "sidebar destinations should share one collapsible section component");
+assert.match(
   source,
-  /function SidebarSection|<SidebarSection|sidebar-section-label|fm\.group === "work"|fm\.group === "tools"/,
-  "Left sidepanel should render one flat list without collapsible Work/Tools sections",
+  /const storageKey = `cave:sidebar:section:\$\{sectionId\}`;/,
+  "each section derives an independent persisted preference key from its label",
+);
+assert.match(
+  source,
+  /const \[collapsed, setCollapsed\] = React\.useState\(false\);/,
+  "sections default open for SSR-safe first paint",
+);
+assert.match(
+  source,
+  /try \{\s*setCollapsed\(window\.localStorage\.getItem\(storageKey\) === "1"\);\s*\} catch \{/,
+  "saved collapse state hydrates safely when localStorage is unavailable",
+);
+assert.match(
+  source,
+  /window\.localStorage\.setItem\(storageKey, next \? "1" : "0"\)/,
+  "each section persists only its own collapse state",
+);
+assert.match(
+  source,
+  /aria-controls=\{contentId\}\s*aria-expanded=\{!collapsed\}/,
+  "section toggles expose their controlled content and expanded state",
+);
+assert.match(
+  source,
+  /<SidebarSection label="Work"[^>]*>[\s\S]{0,1800}?workItems\.map/,
+  "Work contains its registry-filtered destination rows",
+);
+assert.match(
+  source,
+  /<SidebarSection label="Explore"[^>]*>[\s\S]{0,1200}?exploreItems\.map/,
+  "Explore contains its registry-filtered destination rows",
+);
+assert.match(
+  source,
+  /item\.group === "work"[\s\S]{0,180}item\.group === "explore"/,
+  "section membership is derived from the workspace navigation registry",
+);
+assert.match(
+  source,
+  /<SidebarSection label="Rooms"[^>]*>[\s\S]{0,1800}?props\.roleSurfaces!\.map\(\(room\) =>/,
+  "dynamic role-surface rooms use the same collapsible section treatment",
+);
+assert.match(
+  source,
+  /itemsVersion: navItemsVersion/,
+  "collapsing a section re-synchronizes roving navigation to visible rows",
+);
+assert.match(
+  source,
+  /<div id=\{contentId\} className="sidebar-section__content">\s*\{children\}/,
+  "section rows remain mounted so the icon rail can render every destination",
+);
+assert.match(
+  styles,
+  /\.sidebar-section--collapsed \.sidebar-section__content \{\s*display: none;/,
+  "collapsed sections hide their rows in the expanded panel",
+);
+assert.match(
+  styles,
+  /\.shell-nav--rail \.sidebar-section--collapsed \.sidebar-section__content \{\s*display: flex;/,
+  "the icon rail restores rows from collapsed sections",
+);
+assert.match(
+  styles,
+  /\.shell-nav--rail \.sidebar-section-label,[\s\S]{0,100}\.recent-activity \{\s*display: none;/,
+  "the icon rail hides section headings while retaining destination icons",
 );
 
 // The standalone Knowledge section is gone; Library is now isolated on its
@@ -112,8 +178,17 @@ assert.match(
 
 assert.match(
   navigation,
-  /\{ id: "home", label: "Home"/,
-  "Home is the first workspace destination",
+  /\{ id: "home", label: "Home", iconName: "ph:house-bold",[^}]*group: "work"/,
+  "Home starts the Work destination group",
+);
+assert.match(navigation, /\{ id: "chat", label: "Chat", iconName: "ph:chats",[^}]*group: "work"/, "Chat belongs to Work");
+assert.match(navigation, /\{ id: "board", label: "Tasks", iconName: "ph:kanban",[^}]*group: "work"/, "Tasks belongs to Work");
+assert.match(navigation, /\{ id: "inbox", label: "Rituals", iconName: "ph:calendar-check",[^}]*group: "work"/, "Rituals belongs to Work");
+assert.match(navigation, /\{ id: "grimoire", label: "Memories", iconName: "ph:books",[^}]*group: "explore"/, "Memories belongs to Explore");
+assert.match(
+  navigation,
+  /\{ id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold",[^}]*group: "explore"/,
+  "Marketplace belongs to Explore",
 );
 
 assert.doesNotMatch(
@@ -191,7 +266,7 @@ assert.doesNotMatch(
 // it) but is navHidden, so it renders no sidebar row — summoned on demand.
 assert.match(
   navigation,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", group: "work", navHidden: true \}/,
   "Browser is kept for ⌘5/palette but hidden from the sidebar rows (navHidden)",
 );
 
@@ -454,11 +529,8 @@ assert.match(
   "The 56px rail has no room for text — the version line hides there",
 );
 
-// Quiet cluster (§8): occasional destinations stay in the same flat list but
-// render muted-until-hover, with the first quiet row opening a spacing gap.
-// Chat-first hierarchy (cave-xsq.8): the prominent cluster is exactly the
-// ⌘-numbered daily set (Home ⌘1 · Chat ⌘2 · Tasks ⌘3 · Schedules ⌘4); Memories
-// leads the quiet cluster, followed by Marketplace/GitHub/Work Queue.
+// Explore retains quiet row treatment, while its section header now owns the
+// separation from the daily Work destinations.
 assert.match(
   navigation,
   /\{ id: "journal",[^}]*navHidden: true \}/,
@@ -480,19 +552,9 @@ assert.match(
   "Marketplace is in the quiet cluster",
 );
 assert.match(
-  source,
-  /quietLead=\{Boolean\(fm\.quiet\) && !rows\[i - 1\]\?\.quiet\}/,
-  "the first quiet row opens the spacing gap (indexed on the rendered list after navHidden filtering)",
-);
-assert.match(
   styles,
   /\.sidebar-folder-row--quiet \{[^}]*color: var\(--text-muted\);/,
   "quiet rows read muted at rest",
-);
-assert.match(
-  styles,
-  /\.sidebar-folder-row--quiet-lead \{[^}]*margin-top: var\(--space-3\);/,
-  "the quiet cluster opens with spacing, not a hairline divider",
 );
 
 // ── Split-open marker ────────────────────────────────────────────────────────

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -244,7 +244,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
   }, []);
   useRovingTabIndex({
     containerRef: navScrollRef,
-    itemSelector: ".sidebar-folder-row",
+    itemSelector: ".sidebar-section-label, .sidebar-folder-row",
     orientation: "vertical",
     itemsVersion: navItemsVersion,
   });

--- a/src/components/sidebar-minimal.tsx
+++ b/src/components/sidebar-minimal.tsx
@@ -5,7 +5,7 @@
  *
  * Layout (top to bottom):
  *   1. Familiar scope selector + New chat CTA
- *   2. App destinations as one flat visible list
+ *   2. Grouped app destinations and role-surface rooms
  *   3. Footer: Dashboard, Settings
  */
 
@@ -98,7 +98,6 @@ function FolderRow({
   kbd,
   description,
   quiet,
-  quietLead,
   onClick,
 }: {
   id: string;
@@ -109,9 +108,6 @@ function FolderRow({
   kbd?: string;
   description?: string;
   quiet?: boolean;
-  /** First quiet row opens the spacing gap between the daily destinations
-   *  and the demoted cluster (surface step, no divider — §8). */
-  quietLead?: boolean;
   onClick: () => void;
 }) {
   const active = state === "active";
@@ -132,7 +128,7 @@ function FolderRow({
   return (
     <button
       type="button"
-      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}${split ? " sidebar-folder-row--split" : ""}${quiet ? " sidebar-folder-row--quiet" : ""}${quietLead ? " sidebar-folder-row--quiet-lead" : ""}`}
+      className={`sidebar-folder-row${active ? " sidebar-folder-row--active" : ""}${split ? " sidebar-folder-row--split" : ""}${quiet ? " sidebar-folder-row--quiet" : ""}`}
       aria-current={active ? "page" : undefined}
       title={title}
       draggable={draggable || undefined}
@@ -161,6 +157,68 @@ function FolderRow({
   );
 }
 
+function SidebarSection({
+  label,
+  children,
+  onCollapsedChange,
+}: {
+  label: string;
+  children: React.ReactNode;
+  onCollapsedChange?: () => void;
+}) {
+  const sectionId = label.toLowerCase().replace(/\s+/g, "-");
+  const storageKey = `cave:sidebar:section:${sectionId}`;
+  const contentId = `sidebar-section-${sectionId}`;
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  React.useEffect(() => {
+    try {
+      setCollapsed(window.localStorage.getItem(storageKey) === "1");
+    } catch {
+      // Ignore unavailable storage, as RecentActivityRollup does.
+    }
+  }, [storageKey]);
+
+  React.useEffect(() => {
+    onCollapsedChange?.();
+  }, [collapsed, onCollapsedChange]);
+
+  const toggle = React.useCallback(() => {
+    setCollapsed((current) => {
+      const next = !current;
+      try {
+        window.localStorage.setItem(storageKey, next ? "1" : "0");
+      } catch {
+        // Ignore unavailable storage, as RecentActivityRollup does.
+      }
+      return next;
+    });
+  }, [storageKey]);
+
+  return (
+    <section className={`sidebar-folders sidebar-section${collapsed ? " sidebar-section--collapsed" : ""}`}>
+      <button
+        type="button"
+        className="sidebar-section-label focus-ring"
+        aria-controls={contentId}
+        aria-expanded={!collapsed}
+        onClick={toggle}
+      >
+        <span className="sidebar-section-label__text">{label}</span>
+        <Icon
+          name="ph:caret-down-bold"
+          width={CAVE_ICON_SIZE.sidePanelChevron}
+          height={CAVE_ICON_SIZE.sidePanelChevron}
+          className={`sidebar-section-label__chevron${collapsed ? " sidebar-section-label__chevron--collapsed" : ""}`}
+        />
+      </button>
+      <div id={contentId} className="sidebar-section__content">
+        {children}
+      </div>
+    </section>
+  );
+}
+
 export function SidebarMinimal(props: SidebarMinimalProps) {
   const {
     mode,
@@ -177,16 +235,27 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
     responseNeeded,
   } = props;
 
-  // Arrow-key navigation across the flat nav rows: one tab stop, Up/Down moves
-  // focus, Home/End jumps. Uses the shared roving-tabindex hook.
+  // Arrow-key navigation across the currently visible nav rows: one tab stop,
+  // Up/Down moves focus, Home/End jumps. Uses the shared roving-tabindex hook.
   const navScrollRef = React.useRef<HTMLDivElement | null>(null);
-  useRovingTabIndex({ containerRef: navScrollRef, itemSelector: ".sidebar-folder-row", orientation: "vertical" });
+  const [navItemsVersion, setNavItemsVersion] = React.useState(0);
+  const handleSectionCollapsedChange = React.useCallback(() => {
+    setNavItemsVersion((version) => version + 1);
+  }, []);
+  useRovingTabIndex({
+    containerRef: navScrollRef,
+    itemSelector: ".sidebar-folder-row",
+    orientation: "vertical",
+    itemsVersion: navItemsVersion,
+  });
 
   // Projects lives only inside the Familiars surface's Projects tab now (and ⌘9 /
   // the /projects deep-link in workspace.tsx open it there) — no sidebar entry.
   const handleModeSelect = (id: WorkspaceNavMode) => {
     onModeChange(id);
   };
+  const workItems = VISIBLE_WORKSPACE_NAV_ITEMS.filter((item) => item.group === "work");
+  const exploreItems = VISIBLE_WORKSPACE_NAV_ITEMS.filter((item) => item.group === "explore");
 
   return (
     <nav className="sidebar-minimal" aria-label="Primary">
@@ -231,26 +300,42 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
       </div>
 
       <div className="sidebar-nav-scroll" ref={navScrollRef}>
-        {VISIBLE_WORKSPACE_NAV_ITEMS.map((fm: WorkspaceNavItem, i, rows) => (
-          <FolderRow
-            key={fm.id}
-            id={fm.id}
-            label={fm.label}
-            iconName={fm.iconName}
-            // Active follows the primary mode (Roles/Capabilities keep the
-            // Marketplace hub lit); pages open as split tiles get a lighter
-            // "open in split" state instead. Derivation in lib/sidebar-nav-state.
-            state={sidebarRowState(fm.id, mode, props.splitPageModes)}
-            badge={MODE_BADGES[fm.id]?.(props)}
-            kbd={fm.kbd}
-            description={fm.description}
-            quiet={fm.quiet}
-            // Index the RENDERED list — a navHidden entry between quiet rows
-            // must not throw off the "first quiet row" gap.
-            quietLead={Boolean(fm.quiet) && !rows[i - 1]?.quiet}
-            onClick={() => handleModeSelect(fm.id)}
-          />
-        ))}
+        <SidebarSection label="Work" onCollapsedChange={handleSectionCollapsedChange}>
+          {workItems.map((fm: WorkspaceNavItem) => (
+            <FolderRow
+              key={fm.id}
+              id={fm.id}
+              label={fm.label}
+              iconName={fm.iconName}
+              // Active follows the primary mode (Roles/Capabilities keep the
+              // Marketplace hub lit); pages open as split tiles get a lighter
+              // "open in split" state instead. Derivation in lib/sidebar-nav-state.
+              state={sidebarRowState(fm.id, mode, props.splitPageModes)}
+              badge={MODE_BADGES[fm.id]?.(props)}
+              kbd={fm.kbd}
+              description={fm.description}
+              quiet={fm.quiet}
+              onClick={() => handleModeSelect(fm.id)}
+            />
+          ))}
+        </SidebarSection>
+
+        <SidebarSection label="Explore" onCollapsedChange={handleSectionCollapsedChange}>
+          {exploreItems.map((fm: WorkspaceNavItem) => (
+            <FolderRow
+              key={fm.id}
+              id={fm.id}
+              label={fm.label}
+              iconName={fm.iconName}
+              state={sidebarRowState(fm.id, mode, props.splitPageModes)}
+              badge={MODE_BADGES[fm.id]?.(props)}
+              kbd={fm.kbd}
+              description={fm.description}
+              quiet={fm.quiet}
+              onClick={() => handleModeSelect(fm.id)}
+            />
+          ))}
+        </SidebarSection>
 
         {/* Role Surface rooms — the active familiar's or selected scope's
             vocation workspaces.
@@ -258,10 +343,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
             names a role. The cluster label keeps them reading as chambers of
             the Cave rather than more app tabs. */}
         {(props.roleSurfaces?.length ?? 0) > 0 && (
-          <>
-            <div className="sidebar-rooms-label" aria-hidden>
-              Rooms
-            </div>
+          <SidebarSection label="Rooms" onCollapsedChange={handleSectionCollapsedChange}>
             {props.roleSurfaces!.map((room) => (
               <FolderRow
                 key={room.mode}
@@ -278,7 +360,7 @@ export function SidebarMinimal(props: SidebarMinimalProps) {
                 }}
               />
             ))}
-          </>
+          </SidebarSection>
         )}
 
         <RecentActivityRollup

--- a/src/components/sidepanel-keyboard-nav.test.ts
+++ b/src/components/sidepanel-keyboard-nav.test.ts
@@ -4,9 +4,13 @@ import { readFileSync } from "node:fs";
 
 const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "utf8");
 
-// Left nav rows are arrow-navigable via the shared roving-tabindex hook.
+// Section toggles and nav rows are one arrow-navigable sequence.
 assert.match(sidebar, /import \{ useRovingTabIndex \} from "@\/lib\/use-roving-tabindex"/, "sidebar imports the roving hook");
-assert.match(sidebar, /useRovingTabIndex\(\{[\s\S]*?itemSelector: "\.sidebar-folder-row"[\s\S]*?orientation: "vertical"/, "nav rows rove vertically");
+assert.match(
+  sidebar,
+  /useRovingTabIndex\(\{[\s\S]*?itemSelector: "\.sidebar-section-label, \.sidebar-folder-row"[\s\S]*?orientation: "vertical"/,
+  "section toggles and nav rows rove vertically",
+);
 assert.match(sidebar, /<div className="sidebar-nav-scroll" ref=\{navScrollRef\}>/, "the nav scroll container is the roving keydown target");
 
 // The companion rail (whose tabs also roved) was removed with the right panel.

--- a/src/components/workspace-familiars-landing.test.ts
+++ b/src/components/workspace-familiars-landing.test.ts
@@ -316,7 +316,7 @@ assert.match(
 
 assert.match(
   navigation,
-  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true \}/,
+  /\{ id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", group: "work", navHidden: true \}/,
   "Browser is kept for ⌘5/palette but navHidden from rendered navigation rows",
 );
 

--- a/src/lib/use-roving-tabindex.test.ts
+++ b/src/lib/use-roving-tabindex.test.ts
@@ -35,6 +35,15 @@ assert.match(
   "hook sets tabindex on items",
 );
 
+// Reset every matching row before assigning the visible rove set's tab stop.
+// CSS-only visibility changes can reveal a previously hidden row between React
+// renders, so leaving that row at tabindex=0 would create multiple tab stops.
+assert.match(
+  source,
+  /const allItems = Array\.from\(container\.querySelectorAll<HTMLElement>\(itemSelector\)\);[\s\S]*?allItems\.forEach\(\(item\) => \{\s*item\.tabIndex = -1;\s*\}\);[\s\S]*?const items = getItems\(\);[\s\S]*?item\.tabIndex = 0;/,
+  "resets all matching rows before assigning the visible rove set's tab stop",
+);
+
 // Loop is opt-in (default false to match WAI-ARIA APG composite-widget guidance).
 assert.match(
   source,

--- a/src/lib/use-roving-tabindex.ts
+++ b/src/lib/use-roving-tabindex.ts
@@ -11,6 +11,8 @@ type Options = {
   itemSelector: string;
   /** Which arrow keys move focus. Default "both". */
   orientation?: Orientation;
+  /** Increment when CSS visibility changes alter the navigable item set. */
+  itemsVersion?: unknown;
   /** Wrap from last → first / first → last. Default false. */
   loop?: boolean;
   /**
@@ -35,6 +37,7 @@ export function useRovingTabIndex({
   containerRef,
   itemSelector,
   orientation = "both",
+  itemsVersion,
   loop = false,
   columns,
 }: Options) {
@@ -59,6 +62,17 @@ export function useRovingTabIndex({
   // activeIndex if the list shrunk below it — without this, a dynamic list
   // can leave the tab stop out of range (next ArrowDown lands on nothing).
   useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    // CSS-only visibility changes can reveal rows before React has another
+    // chance to render. Reset every matching row so only the visible rove set
+    // receives a tab stop below.
+    const allItems = Array.from(container.querySelectorAll<HTMLElement>(itemSelector));
+    allItems.forEach((item) => {
+      item.tabIndex = -1;
+    });
+
     const items = getItems();
     if (items.length === 0) return;
     if (activeRef.current >= items.length) {
@@ -69,11 +83,9 @@ export function useRovingTabIndex({
     items.forEach((item, i) => {
       if (i === activeRef.current) {
         item.tabIndex = 0;
-      } else {
-        item.tabIndex = -1;
       }
     });
-  }, [getItems, activeIndex]);
+  }, [containerRef, getItems, itemSelector, activeIndex, itemsVersion]);
 
   useEffect(() => {
     const container = containerRef.current;

--- a/src/lib/workspace-navigation.test.ts
+++ b/src/lib/workspace-navigation.test.ts
@@ -31,6 +31,21 @@ assert.match(
   /export const PRIMARY_WORKSPACE_NAV_ITEMS = VISIBLE_WORKSPACE_NAV_ITEMS\.filter\(\(item\) => !item\.quiet\)/,
   "the registry owns the promoted mobile destinations",
 );
+assert.match(
+  registry,
+  /group: "work" \| "explore";/,
+  "every workspace destination must declare a sidebar group",
+);
+assert.match(
+  registry,
+  /\{ id: "browser",[\s\S]*?group: "(?:work|explore)"/,
+  "hidden Browser remains classified for future visible navigation",
+);
+assert.match(
+  registry,
+  /\{ id: "salem",[\s\S]*?group: "(?:work|explore)"/,
+  "hidden Ask Salem remains classified for future visible navigation",
+);
 
 assert.match(
   sidebar,

--- a/src/lib/workspace-navigation.ts
+++ b/src/lib/workspace-navigation.ts
@@ -7,6 +7,7 @@ export type WorkspaceNavItem = {
   id: WorkspaceNavMode;
   label: string;
   iconName: IconName;
+  group: "work" | "explore";
   kbd?: string;
   description: string;
   quiet?: boolean;
@@ -14,15 +15,15 @@ export type WorkspaceNavItem = {
 };
 
 export const WORKSPACE_NAV_ITEMS: readonly WorkspaceNavItem[] = [
-  { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions" },
-  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven" },
-  { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects" },
-  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Inbox, calendar, and scheduled jobs in one place" },
-  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in Memories", quiet: true, navHidden: true },
-  { id: "grimoire", label: "Memories", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", quiet: true },
-  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", navHidden: true },
-  { id: "salem", label: "Ask Salem", iconName: "ph:cat", description: "Ask the docs familiar — grounded answers from the Coven index and your Cave", navHidden: true },
-  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Manage what you own and preview the curated Skills shelf", quiet: true },
+  { id: "home", label: "Home", iconName: "ph:house-bold", kbd: "⌘1", description: "Overview and quick actions", group: "work" },
+  { id: "chat", label: "Chat", iconName: "ph:chats", kbd: "⌘2", description: "Talk with your familiars — 1:1 or a Group tab for a whole coven", group: "work" },
+  { id: "board", label: "Tasks", iconName: "ph:kanban", kbd: "⌘3", description: "Track tasks across projects", group: "work" },
+  { id: "inbox", label: "Rituals", iconName: "ph:calendar-check", kbd: "⌘4", description: "Inbox, calendar, and scheduled jobs in one place", group: "work" },
+  { id: "journal", label: "Journal", iconName: "ph:book-open", description: "Your familiars' daily reflections — a tab in Memories", group: "explore", quiet: true, navHidden: true },
+  { id: "grimoire", label: "Memories", iconName: "ph:books", description: "Edit memory, knowledge, and journal markdown as living documents", group: "explore", quiet: true },
+  { id: "browser", label: "Browser", iconName: "ph:globe", kbd: "⌘5", description: "Built-in web browser", group: "work", navHidden: true },
+  { id: "salem", label: "Ask Salem", iconName: "ph:cat", description: "Ask the docs familiar — grounded answers from the Coven index and your Cave", group: "explore", navHidden: true },
+  { id: "marketplace", label: "Marketplace", iconName: "ph:storefront-bold", description: "Manage what you own and preview the curated Skills shelf", group: "explore", quiet: true },
 ];
 
 export const VISIBLE_WORKSPACE_NAV_ITEMS = WORKSPACE_NAV_ITEMS.filter((item) => !item.navHidden);

--- a/src/styles/sidebar-minimal/activity-rail.css
+++ b/src/styles/sidebar-minimal/activity-rail.css
@@ -49,11 +49,15 @@
 }
 
 /* Section headers and the recent-activity rollup have no compact form, so
-   they drop out entirely in the rail. (Rooms cluster label included.) */
+   they drop out entirely in the rail. Section contents stay mounted and
+   visible: a collapsed expanded-panel group must never remove its rail icons. */
 .shell-nav--rail .sidebar-section-label,
-.shell-nav--rail .sidebar-rooms-label,
 .shell-nav--rail .recent-activity {
   display: none;
+}
+
+.shell-nav--rail .sidebar-section--collapsed .sidebar-section__content {
+  display: flex;
 }
 
 /* ── Rail-only bookends (chat-revamp phase D) ────────────────────────────────

--- a/src/styles/sidebar-minimal/navigation-recents.css
+++ b/src/styles/sidebar-minimal/navigation-recents.css
@@ -9,7 +9,7 @@
 .sidebar-section__content {
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: inherit;
 }
 
 .sidebar-section--collapsed .sidebar-section__content {

--- a/src/styles/sidebar-minimal/navigation-recents.css
+++ b/src/styles/sidebar-minimal/navigation-recents.css
@@ -6,6 +6,16 @@
   gap: 2px;
 }
 
+.sidebar-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-section--collapsed .sidebar-section__content {
+  display: none;
+}
+
 .sidebar-addins {
   padding-top: var(--space-1);
 }


### PR DESCRIPTION
## Summary
- group Home, Chat, Tasks, and Rituals under Work
- group Memories and Marketplace under Explore
- make Work, Explore, and Rooms independently collapsible with persisted, accessible state
- preserve every destination in the collapsed icon rail and keep keyboard roving to one visible tab stop
- make workspace navigation grouping exhaustive and update source-contract tests

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `env -u NPM_CONFIG_PREFIX -u COVEN_PIPER_BIN -u COVEN_KOKORO_BIN -u COVEN_WHISPER_CPP_BIN pnpm test:api`
- `pnpm check:tests-wired`
- `git diff --check`
- rendered Playwright verification of grouping, persistence, rail parity, and keyboard tab-stop behavior

Bead: `cave-bo8op`