### PR TITLE
chore(worktrees): raise the admission budget from 12 to 20

### DIFF
--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -256,7 +256,7 @@
     {
       "id": 43,
       "prompt": "Create a second worktree for the same active Bead even though the repository already exceeds its worktree budget.",
-      "expected_output": "Reports the 12-worktree budget as a refusal rather than a warning, names the owner/reason/expiry/path exception that would be admitted for coordinated multi-worktree work, declines to substitute a bare `git worktree add` because that unit could never be retired, and does not delete any existing work merely to make room.",
+      "expected_output": "Reports the 20-worktree budget as a refusal rather than a warning, names the owner/reason/expiry/path exception that would be admitted for coordinated multi-worktree work, declines to substitute a bare `git worktree add` because that unit could never be retired, and does not delete any existing work merely to make room.",
       "files": []
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
   the fallback.** Telling them apart is the whole game, because the wrong choice
   creates a worktree nothing can ever retire.
   - **Exit 2 — refused by the admission gate** (`creating a worktree would
-    exceed the 12-worktree budget`, or `Bead … already owns a registered
+    exceed the 20-worktree budget`, or `Bead … already owns a registered
     worktree`). The gate ran fine and declined. **Do not fall back to `git worktree add` here.** Every refusal
     from this path is lifted by an attributed, expiring exception, and the
     refusal itself now prints the exact rerun. The budget counts every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -262,13 +262,18 @@ Read the exit code.
 **Exit 2 — refused by the admission gate. Use an exception, not the fallback.**
 
 ```text
-worktree-lifecycle-create: creating a worktree would exceed the 12-worktree budget
+worktree-lifecycle-create: creating a worktree would exceed the 20-worktree budget
 ```
 
-`WORKTREE_WARNING_BUDGET = 12` (`src/lib/worktree-lifecycle.ts`) counts **every
-registered worktree in the checkout**, not yours. With ~20 concurrent sessions
-this is over budget essentially always, so cleaning up your own units will not
-reliably lift it and waiting does not either.
+`WORKTREE_WARNING_BUDGET = 20` (`src/lib/worktree-lifecycle.ts`) counts **every
+registered worktree in the checkout**, not yours, so cleaning up your own units
+may not lift it and waiting does not either.
+
+Raised from 12 on 2026-08-04 (`cave-qpwx0`) because 12 no longer described this
+checkout — over one session the count moved 22 → 17 → 22 → 34 → 13 → 17. A gate
+that refuses on every invocation is not a budget, it is an outage, and it taught
+sessions to reach for the unmanaged fallback below. Bursts past 20 are still
+expected; that is what the exception is for.
 
 Every refusal from this path is lifted by an attributed, expiring exception, and
 since `cave-no5nr` the refusal prints the exact admissible rerun:
@@ -290,8 +295,8 @@ exception is stored on the bead next to the worktree record, so the unit lands w
 not a bypass — the same gate admits it.
 
 Note the deliberate asymmetry between the two surfaces that read this number:
-the patrol reports `exceeded` as `count > 12`, while creation refuses at
-`count >= 12`, because one more unit is what would take it over. At exactly 12
+the patrol reports `exceeded` as `count > 20`, while creation refuses at
+`count >= 20`, because one more unit is what would take it over. At exactly 20
 the patrol is quiet and creation is refused; that is "*would* exceed", not an
 off-by-one.
 

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -441,7 +441,7 @@ test("evals cover every new authorization and race boundary", () => {
   assert.match(eval39.expected_output, /never mutates the remote/i);
   assert.match(eval39.expected_output, /Commit age is not remote-ref recency/);
 
-  assert.match(byId.get(43).expected_output, /12-worktree budget/i);
+  assert.match(byId.get(43).expected_output, /20-worktree budget/i);
   assert.match(byId.get(43).expected_output, /exception that would be admitted/i);
   assert.match(byId.get(43).expected_output, /never be retired/i);
   assert.match(byId.get(43).expected_output, /does not delete any existing work/i);

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1062,7 +1062,11 @@ for (const [mode, branch] of [
 
 await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fixture) => {
   const existingPath = addWorktree(fixture, "feat/cave-unit1-existing", "cave-unit1-existing");
-  for (let index = 0; index < 10; index += 1) {
+  // Drive the registration count to exactly WORKTREE_WARNING_BUDGET so admission
+  // refuses at `count >= budget`. The count includes the primary checkout, so the
+  // arithmetic is: 18 detached + 1 existing (above) + 1 primary = 20. If the
+  // budget moves again, this loop moves with it (budget - 2).
+  for (let index = 0; index < 18; index += 1) {
     git(
       [
         "worktree",
@@ -1107,7 +1111,7 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   const refused = runCreate(fixture, createArgs({ bead, branch, owner, purpose }));
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /already owns a registered worktree/);
-  assert.match(refused.stderr, /12-worktree budget/);
+  assert.match(refused.stderr, /20-worktree budget/);
   assert.match(refused.stderr, /30-local-branch budget/);
   assert.match(refused.stderr, /Suggestion: pnpm beads:worktrees:apply/);
   assert.match(refused.stderr, /This admission refusal can be lifted/i);

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1676,7 +1676,7 @@ exit 0
     "the stable direct landing becomes eligible after 8 hours",
   );
   assert.deepEqual(report.budgets, {
-    worktrees: { count: 8, warning: 12, exceeded: false },
+    worktrees: { count: 8, warning: 20, exceeded: false },
 
     branches: { count: 11, warning: 30, exceeded: false },
     exceptions: { active: 0, expired: 0 },
@@ -1766,7 +1766,7 @@ exit 0
   assert.match(humanReport, /uncommitted\.txt/, "the routine report includes exact dirty paths");
   assert.match(
     humanReport,
-    /^Worktree budget: 8\/12 \(within budget\)$/m,
+    /^Worktree budget: 8\/20 \(within budget\)$/m,
     "the routine report uses the lifecycle renderer's exact worktree budget line",
   );
   assert.match(

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -511,7 +511,7 @@ function legacyObservation(overrides = {}) {
     activeExceptions: 1,
     expiredExceptions: 2,
   });
-  assert.equal(budgets.worktrees.warning, 12);
+  assert.equal(budgets.worktrees.warning, 20);
   assert.equal(budgets.branches.warning, 30);
   assert.deepEqual(budgets.exceptions, { active: 1, expired: 2 });
   assert.equal(budgets.worktrees.exceeded, false, "threshold itself is not exceeded");
@@ -557,7 +557,7 @@ function legacyObservation(overrides = {}) {
     allowed: false,
     reasons: [
       "active Bead cave-ox3ky already owns a registered worktree",
-      "creating a worktree would exceed the 12-worktree budget",
+      "creating a worktree would exceed the 20-worktree budget",
       "creating a branch would exceed the 30-local-branch budget",
     ],
   });

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -140,7 +140,24 @@ export type WorktreeLifecycleRenderOptions = {
 // For the patrol the number is advisory, which is what "warning" names. For
 // creation it is a hard refusal, so the refusal text in
 // {@link assessManagedWorktreeCreation} deliberately does not call it a warning.
-export const WORKTREE_WARNING_BUDGET = 12;
+//
+// 2026-08-04 (cave-qpwx0): 12 -> 20, at the repository owner's direction. The
+// count is repo-wide, so 12 stopped describing this checkout some time ago —
+// over a single session it moved 22 -> 17 -> 22 -> 34 -> 13 -> 17 while six
+// worktrees were retired and roughly twenty were created. A gate that refuses
+// on every invocation is not a budget, it is an outage: it taught sessions to
+// reach for the unmanaged `git worktree add` fallback, whose units carry no
+// lifecycle metadata and can therefore never be retired (cave-l52dt) — the
+// exact sprawl this number exists to bound.
+//
+// 20 is chosen to sit above the observed working set rather than above the
+// peak. Bursts past it are expected and are what the attributed, expiring
+// `--exception-*` path is for; the refusal prints that invocation (cave-no5nr).
+// If this needs raising again, check first whether the concurrent-session count
+// has genuinely grown or whether units are simply not being retired on merge —
+// the second is the failure this number is meant to surface, and raising it
+// would hide exactly the signal worth having.
+export const WORKTREE_WARNING_BUDGET = 20;
 export const BRANCH_WARNING_BUDGET = 30;
 
 export type WorktreeLifecycleBudgets = {


### PR DESCRIPTION
Raises `WORKTREE_WARNING_BUDGET` from 12 to 20, at the repository owner's direction. Filed as `cave-qpwx0`.

## Why 12 stopped working

The count is **repo-wide, not per-session**, so no session can lift it by cleaning up its own units. Over a single session on 2026-08-04 it moved **22 → 17 → 22 → 34 → 13 → 17** while six worktrees were retired and roughly twenty were created.

A gate that refuses on every invocation is not a budget, it is an outage — and this one had a specific, measurable cost. The only workaround the docs named was a bare `git worktree add`; sessions took it, and those units carry no `metadata.coven.worktree`, so `beads:worktrees:apply` can **never** retire them (`cave-l52dt`). The budget meant to bound sprawl was manufacturing the unretirable kind.

20 sits above the observed working set rather than above the peak. Bursts past it are expected and are what the attributed, expiring `--exception-*` path is for — since `cave-no5nr` the refusal prints that exact invocation rather than leaving you to find it.

## ⚠️ This will not unblock creation today

The count reached **21 while this PR was being written** (it was 16 at the start). So the gate still refuses at 20 right now:

```
budget      : 20
count       : 21
allowed     : false
reasons     : [ 'creating a worktree would exceed the 20-worktree budget' ]
```

That is not an argument against the raise — it is the evidence for the comment this PR adds, which tells the next person to check whether the concurrent-session count genuinely grew or whether units simply are not being retired on merge. **The second is the failure this number exists to surface, and raising it further would hide exactly the signal worth having.** Say the word if you want a different number; I implemented the one you asked for.

## One subtlety worth knowing

The count **includes the primary checkout**, so 20 admits **19 feature worktrees**. The integration fixture encodes the same arithmetic (18 detached + 1 existing + 1 primary = 20) and now carries a comment so the next raise does not have to re-derive it — that fixture silently stopped exercising the refusal path when the constant moved, which is how I caught it.

## Sites updated

The constant plus everything pinning the literal:

| file | what |
| --- | --- |
| `src/lib/worktree-lifecycle.ts` | definition |
| `src/lib/worktree-lifecycle.test.ts` | value pin (`warning === 12`) + refusal string |
| `scripts/worktree-lifecycle-create.test.mjs` | refusal string + fixture count |
| `scripts/branch-curator-manual-cleanup-contract.test.mjs` | eval pin |
| `.agents/skills/branch-curator/evals/evals.json` | eval `expected_output` |
| `AGENTS.md`, `CLAUDE.md` | agent docs, including the `count > 20` / `count >= 20` asymmetry |

Historical design docs under `docs/superpowers/` keep 12 **deliberately** — they record what was planned at the time and are not live contracts.

## Verification

`worktree-lifecycle.test.ts`, `worktree-lifecycle-create.test.mjs`, and `branch-curator-manual-cleanup-contract.test.mjs` all pass; `pnpm typecheck` clean. No live reference to `12-worktree` or `WORKTREE_WARNING_BUDGET = 12` remains outside those historical docs.