### PR TITLE
fix(budgets): report thin headroom everywhere, reseat the caps by rate

### DIFF
--- a/scripts/budget-headroom.mjs
+++ b/scripts/budget-headroom.mjs
@@ -1,0 +1,45 @@
+// Shared thin-headroom reporting for the build budgets.
+//
+// Every budget in this repo is a ratchet: a number seeded once against a
+// measured snapshot, then eroded by ordinary work until it blocks something.
+// Three did exactly that on 2026-08-04/05 — the sidecar runtime file count went
+// red on main and blocked every PR (cave-k5n56), the worktree admission budget
+// refused on every invocation (cave-qpwx0), and the Next standalone file count
+// reached 6,993 of 7,000 (cave-yizcb).
+//
+// Reporting remaining headroom on every build turns that erosion into a visible
+// slope instead of a cliff. This lives in its own module because the constant
+// was previously private to bundle-budget.mjs, so standalone-budget.mjs had NO
+// thin detection at all: the gates with the MOST headroom warned loudly (1.8%,
+// 1.2%) while the one with 0.10% printed a clean check. A duplicated threshold
+// would have drifted the same way — one definition, two callers.
+//
+// Deliberately does NOT fail. This is signal, not a new gate: a thin budget is
+// information for the next author, not a reason to block the current one.
+export const THIN_HEADROOM_PCT = 2;
+
+// Each gate reports in the unit it is actually budgeted in. KB suits the CSS and
+// JS caps; a 480 MiB artifact ceiling rendered in KB ("97953.0 KB") is unreadable
+// at exactly the moment someone needs to read it.
+export const asBytes = (value) => `${(value / 1024).toFixed(1).padStart(6)} KB`;
+export const asMebibytes = (value) => `${(value / 1024 / 1024).toFixed(1).padStart(6)} MiB`;
+export const asCount = (unit) => (value) => `${String(value).padStart(6)} ${unit}`;
+
+/**
+ * Format one budget's remaining headroom.
+ *
+ * Returns `{ pct, line, thin }` rather than printing, so callers keep control of
+ * their own output shape and of how they accumulate the thin set.
+ * `used > budget` returns `null` — the caller's failure branch reports overage,
+ * and a negative "headroom" line would only muddy it.
+ */
+export function headroomOf(used, budget, format = asBytes) {
+  const left = budget - used;
+  if (left < 0) return null;
+  const pct = (left / budget) * 100;
+  const thin = pct < THIN_HEADROOM_PCT;
+  const line =
+    `  ${format(left)} headroom  (${pct.toFixed(1)}%)` +
+    (thin ? "  ⚠ THIN — the next change of any size may fail this gate" : "");
+  return { pct, line, thin };
+}

--- a/scripts/bundle-budget.mjs
+++ b/scripts/bundle-budget.mjs
@@ -25,6 +25,8 @@ import { readdirSync, statSync, existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { headroomOf } from "./budget-headroom.mjs";
+
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const nextDir = path.join(root, ".next");
 const chunksDir = path.join(nextDir, "static", "chunks");
@@ -137,8 +139,31 @@ const MAX_CHUNK_BYTES = (Number(process.env.BUNDLE_MAX_CHUNK_KB) || 2400) * 1024
 // handing the same warning to whoever ships next — which is the whole failure
 // this raise exists to end. It is a ceiling for this surface's growth, not a
 // licence for the next one.
+// RAISED home 880→940 (2026-08-05, cave-yizcb), and root deliberately LEFT at
+// 600. The convention above — "the smallest ceiling that clears the 2% THIN
+// threshold" — is what put us back here: 880 was chosen on 2026-08-03 as exactly
+// that, and home was under the threshold again two days later. Measured:
+//
+//   home: 862.2 KiB (2026-08-03) → 869 KiB = ~3.4 KiB/day. The 10.7 KiB left is
+//         ~3 days; even a fresh 2% (17.6 KiB) would be ~5. 940 leaves 71 KiB,
+//         about 21 days at the observed rate.
+//   root: 588 KiB (2026-08-03) → 589 KiB = ~0.5 KiB/day. Its 10.9 KiB is ALREADY
+//         ~21 days. It reads 1.8% and warns, but the warning is a proportion
+//         artifact: root is large, so a healthy absolute margin still looks thin.
+//         Raising it would buy growth that is not happening.
+//
+// That asymmetry is the point. A percentage says how much is left, never how
+// long — and it misleads in BOTH directions: root warns with three weeks of
+// room, while the standalone byte ceiling sat SILENT at 3.9% with about six days
+// (see scripts/standalone-budget.mjs, same bead). Derive the next raise from
+// measured growth and record the rate, not just the number.
+//
+// Reclaiming instead of raising (#3264) remains the better long-term answer for
+// home, and is deliberately not attempted here: the extraction candidates are in
+// files several concurrent sessions are editing right now, so it would conflict
+// badly. That is a scheduling constraint, not an argument that the raise is free.
 const MAX_ROOT_CSS_BYTES = (Number(process.env.BUNDLE_MAX_ROOT_CSS_KB) || 600) * 1024;
-const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 880) * 1024;
+const MAX_HOME_CSS_BYTES = (Number(process.env.BUNDLE_MAX_HOME_CSS_KB) || 940) * 1024;
 
 if (!existsSync(chunksDir)) {
   console.error(
@@ -157,20 +182,19 @@ const kb = (n) => (n / 1024).toFixed(0).padStart(6) + " KB";
 //
 // Deliberately does NOT fail: this is signal, not a new gate. A thin budget is
 // information for the next author, not a reason to block the current one.
-const THIN_HEADROOM_PCT = 2;
+//
+// The threshold and line formatting now live in scripts/budget-headroom.mjs
+// (cave-yizcb) so standalone-budget.mjs shares them rather than going without.
+// It had no thin detection at all, which is how it reached 0.10% headroom while
+// printing a clean check - the gates with the MOST room were the only ones
+// warning. A duplicated constant would have drifted the same way.
 const thin = [];
 
 function headroom(label, bytes, budget) {
-  const left = budget - bytes;
-  if (left < 0) return; // the caller's failure branch reports the overage
-  const pct = (left / budget) * 100;
-  const line = `  ${(left / 1024).toFixed(1).padStart(6)} KB headroom  (${pct.toFixed(1)}%)`;
-  if (pct < THIN_HEADROOM_PCT) {
-    thin.push(label);
-    console.log(`${line}  \u26a0 THIN — the next change of any size may fail this gate`);
-  } else {
-    console.log(line);
-  }
+  const report = headroomOf(bytes, budget);
+  if (!report) return; // the caller's failure branch reports the overage
+  if (report.thin) thin.push(label);
+  console.log(report.line);
 }
 const sizeOf = (relToNext) => {
   try {

--- a/scripts/bundle-budget.test.mjs
+++ b/scripts/bundle-budget.test.mjs
@@ -2,6 +2,10 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./bundle-budget.mjs", import.meta.url), "utf8");
+// The threshold and line formatting moved to a shared module (cave-yizcb) so
+// standalone-budget.mjs reports the same way instead of not at all. The
+// guarantees below did not move — they just live in two files now.
+const headroomSource = readFileSync(new URL("./budget-headroom.mjs", import.meta.url), "utf8");
 
 assert.match(
   source,
@@ -68,9 +72,14 @@ console.log("bundle-budget.test.mjs: ok");
 // without failing anything.
 
 assert.match(
-  source,
-  /const THIN_HEADROOM_PCT = \d+;/,
+  headroomSource,
+  /export const THIN_HEADROOM_PCT = \d+;/,
   "the thin-budget threshold is an explicit named constant, not a magic number",
+);
+assert.match(
+  source,
+  /import \{ headroomOf \} from "\.\/budget-headroom\.mjs";/,
+  "bundle-budget reports through the shared helper rather than its own copy",
 );
 assert.match(
   source,
@@ -78,15 +87,31 @@ assert.match(
   "one shared helper reports headroom, so every budget reports it the same way",
 );
 assert.match(
-  source,
-  /if \(left < 0\) return;/,
-  "headroom() defers to the caller's failure branch when a budget is already blown",
+  headroomSource,
+  /if \(left < 0\) return null;/,
+  "headroomOf() defers to the caller's failure branch when a budget is already blown",
 );
 assert.match(
-  source,
+  headroomSource,
   /THIN — the next change of any size may fail this gate/,
   "a thin budget warns in the words the next author needs",
 );
+// standalone-budget had NO thin detection at all, which is how its file count
+// reached 0.10% headroom while printing a clean check (cave-yizcb). Pin that it
+// reports, so the blind spot cannot silently return.
+const standaloneSource = readFileSync(new URL("./standalone-budget.mjs", import.meta.url), "utf8");
+assert.match(
+  standaloneSource,
+  /import \{[^}]*\bheadroomOf\b[^}]*\} from "\.\/budget-headroom\.mjs";/,
+  "standalone-budget reports headroom through the same shared helper",
+);
+for (const metric of ["fileCount", "unpackedBytes"]) {
+  assert.match(
+    standaloneSource,
+    new RegExp(`headroomOf\\(metrics\\.${metric}, STANDALONE_BUDGETS\\.${metric}`),
+    `standalone ${metric} reports its remaining headroom`,
+  );
+}
 assert.match(
   source,
   /within budget, but thin on \$\{thin\.join\(", "\)\}/,

--- a/scripts/standalone-budget.mjs
+++ b/scripts/standalone-budget.mjs
@@ -7,12 +7,36 @@ import { lstat, readdir } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import { asCount, asMebibytes, headroomOf } from "./budget-headroom.mjs";
+
 export const STANDALONE_BUDGETS = Object.freeze({
   // Clean Linux baseline (2026-07-16): 6,416 entries / 351,017,052 bytes.
   // Roughly 9% entry and 20% byte headroom absorbs platform-native package
   // variance while still catching a renewed repository-root trace immediately.
-  fileCount: 7_000,
-  unpackedBytes: 400 * 1024 * 1024,
+  //
+  // 2026-08-05 (cave-yizcb): reseated by RATE rather than by proportion.
+  // Measured 6,993 entries / 403,012,564 bytes — seven entries under the old
+  // 7,000 cap, and this script printed a clean check the whole way down because
+  // it had no thin reporting at all (that is fixed above).
+  //
+  //   entries: 6,416 -> 6,993 over 20 days = ~29/day. The original 584-entry
+  //            headroom lasted exactly those 20 days. 7,600 restores ~8%
+  //            (607 entries), which is ~21 days at the observed rate.
+  //   bytes:   351.0 MB -> 403.0 MB over the same 20 days = ~2.6 MB/day. The
+  //            remaining 15.7 MiB was ~6 days, yet 3.9% headroom sits ABOVE the
+  //            2% thin threshold — it would never have warned. 480 MiB leaves
+  //            ~77 MB, about 30 days.
+  //
+  // Sizing to the threshold instead of the rate is what keeps failing here. The
+  // sibling CSS cap was raised on 2026-08-03 to "the smallest ceiling that
+  // clears 2%" and was back under it two days later. A percentage cannot tell
+  // you how long you have; only the slope can. If you raise these again, derive
+  // the number from measured growth and write the rate down.
+  //
+  // Both ceilings still catch what this guard is for: a renewed repository-root
+  // trace overshoots by gigabytes and thousands of entries, not by 8%.
+  fileCount: 7_600,
+  unpackedBytes: 480 * 1024 * 1024,
 });
 
 export const STANDALONE_FORBIDDEN_ROOTS = Object.freeze([
@@ -99,6 +123,28 @@ if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.me
       `standalone-budget: ${metrics.fileCount} files, ${metrics.directoryCount} directories, ${metrics.unpackedBytes} bytes ` +
         `(limits: ${STANDALONE_BUDGETS.fileCount} files, ${STANDALONE_BUDGETS.unpackedBytes} bytes)`,
     );
+
+    // Report remaining headroom, the same way bundle-budget does. Without this
+    // the file count reached 6,993 of 7,000 while still printing a clean check
+    // (cave-yizcb): 0.10% headroom and silent, next to CSS gates warning at
+    // 1.8% and 1.2%. A pass/fail gate cannot show you a slope.
+    const reports = [
+      ["file count", headroomOf(metrics.fileCount, STANDALONE_BUDGETS.fileCount, asCount("files"))],
+      ["expanded bytes", headroomOf(metrics.unpackedBytes, STANDALONE_BUDGETS.unpackedBytes, asMebibytes)],
+    ];
+    const thin = [];
+    for (const [label, report] of reports) {
+      if (!report) continue;
+      if (report.thin) thin.push(label);
+      console.log(report.line);
+    }
+    if (thin.length > 0) {
+      console.log(
+        `\n⚠ standalone-budget: within budget, but thin on ${thin.join(", ")}.\n` +
+          `  Reclaim room (check what joined the Next trace) or raise the cap\n` +
+          `  deliberately with a justification — before it lands on someone else.`,
+      );
+    }
     console.log("✓ standalone-budget: within budget and free of local build roots.");
   } catch (error) {
     console.error(`✗ standalone-budget: ${error instanceof Error ? error.message : error}`);


### PR DESCRIPTION
Filed as `cave-yizcb`, from the `postbuild` output you pasted.

## The buried lead

The two gates shouting ⚠ THIN had ~11 KB of headroom each. The one printing a clean ✓ had **seven files**:

| gate | headroom | status |
| --- | --- | --- |
| root-layout CSS | 1.8% | ⚠ warns |
| initial route CSS | 1.2% | ⚠ warns |
| **standalone fileCount** | **0.10%** (6,993/7,000) | ✓ **silent** |
| standalone bytes | 3.9% | ✓ silent |

`standalone-budget.mjs` had **no thin detection at all** — just hard pass/fail. `THIN_HEADROOM_PCT` and the headroom reporter were private to `bundle-budget.mjs`, so the sibling script simply went without. They now live in `scripts/budget-headroom.mjs` and both import them: one definition, two callers, nothing to drift.

## A percentage cannot tell you how long you have

Reseating by measured growth instead of by threshold:

| budget | growth | old cap | new cap | why |
| --- | --- | --- | --- | --- |
| standalone entries | ~29/day | 7,000 | **7,600** | original 584-entry headroom lasted exactly 20 days; 7,600 restores ~8% ≈ 21 days |
| standalone bytes | ~2.6 MB/day | 400 MiB | **480 MiB** | 15.7 MiB left was ~6 days, yet 3.9% is **above** the threshold and would never warn |
| home CSS | ~3.4 KiB/day | 880 | **940** | 880 was set 2026-08-03 as "the smallest ceiling that clears 2%" — already under it two days later |
| root CSS | ~0.5 KiB/day | 600 | **600 (unchanged)** | its 10.9 KiB is **already ~21 days**; the 1.8% warning is a proportion artifact |

**That asymmetry is the finding.** The proportional threshold misleads in *both* directions — root CSS warns with three weeks of room, while the standalone byte ceiling sat silent with about six days. Every comment now records the *rate*, so the next raise is derived rather than guessed.

Leaving root at 600 is the deliberate half of this. Raising every budget that warns is the treadmill that produced today's three separate blockages; root doesn't need it and won't get it.

## Not done, on purpose

Reclaiming instead of raising (#3264, move surface CSS to component imports) is the better long-term answer for home CSS. The extraction candidates sit in files several concurrent sessions are actively editing, so attempting it now would conflict badly. That's a scheduling constraint, not a claim the raise is free.

## Verification

- Both `bundle-budget.test.mjs` and `standalone-budget.test.mjs` pass.
- The threshold / defer-on-overage / warning-wording assertions **moved to follow the code** into the shared module rather than being deleted; new assertions pin that `standalone-budget` reports at all, so the blind spot cannot silently return.
- **Checked non-vacuous**: the new assertions fail against the pre-change source (`git show HEAD:scripts/standalone-budget.mjs`) and pass against this one.
- Byte headroom now renders in MiB — `97953.0 KB` was unreadable at exactly the moment someone needs to read it.

Both ceilings still catch what the guard exists for: a renewed repository-root trace overshoots by gigabytes and thousands of entries, not by 8%.