### PR TITLE
feat(settings): make Workspace path's Browse actually choose a folder

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1165,6 +1165,7 @@ export const SUITES = {
     "src/app/api/daemon/travel/reconcile/route.test.ts",
     "src/app/api/tailscale/devices/route.test.ts",
     "src/app/api/config/route.test.ts",
+    "src/app/api/config/workspace-path/route.test.ts",
     "src/app/api/opencoven-executions-route.test.ts",
     "src/app/api/opencoven-submissions-route.test.ts",
     "src/app/api/familiars/route.test.ts",
@@ -1439,6 +1440,7 @@ export const SUITES = {
     "src/lib/server/canonical-path.test.ts",
     "src/lib/server/project-paths.test.ts",
     "src/lib/server/home-browse.test.ts",
+    "src/lib/server/workspace-root-store.test.ts",
     "src/lib/server/session-project-roots.test.ts",
     "src/lib/server/familiar-avatar.test.ts",
     "src/lib/server/skill-scan.test.ts",
@@ -1571,6 +1573,8 @@ const ALIAS_LOADER = new Set([
   "src/components/role-surfaces/review-readiness.test.ts",
   // the diff route resolves "@/lib/github-token".
   "src/app/api/github/diff/route.test.ts",
+  // imports the store, which resolves "@/lib/coven-paths" and "@/lib/server/…".
+  "src/lib/server/workspace-root-store.test.ts",
   // imports the route module, which resolves "@/lib/server/..." aliases.
   "src/app/api/daemon/travel/reconcile/route.test.ts",
   "src/app/api/familiars/route.test.ts",

--- a/src/app/api/config/workspace-path/route.test.ts
+++ b/src/app/api/config/workspace-path/route.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const source = readFileSync(fileURLToPath(new URL("./route.ts", import.meta.url)), "utf8");
+
+// Re-pointing where a machine stores its workspaces is a host-level change.
+// The folder browser that feeds this route is loopback-only; so is this.
+assert.match(
+  source,
+  /export async function GET\(req: NextRequest\) \{\s*const denied = rejectNonLocalRequest\(req\);\s*if \(denied\) return denied;/,
+  "GET is loopback-gated",
+);
+assert.match(
+  source,
+  /export async function POST\(req: NextRequest\) \{\s*const denied = rejectNonLocalRequest\(req\);\s*if \(denied\) return denied;/,
+  "POST is loopback-gated",
+);
+
+assert.match(
+  source,
+  /import \{ saveWorkspaceRoot, workspaceRootStatus \} from "@\/lib\/server\/workspace-root-store"/,
+  "the route delegates validation and persistence to the store",
+);
+assert.doesNotMatch(
+  source,
+  /writeFile|mkdir|JSON\.parse\(readFileSync/,
+  "the route never writes the override itself",
+);
+
+assert.match(
+  source,
+  /const dir = typeof body\?\.dir === "string" \? body\.dir : "";/,
+  "a non-string dir is coerced to an empty request rather than trusted",
+);
+
+// Each refusal reason maps to a distinct status so the field can tell "you
+// can't change this" from "that folder is wrong".
+for (const [reason, status] of [
+  ["env-pinned", "409"],
+  ["invalid-path", "400"],
+  ["unbounded", "400"],
+  ["write-failed", "500"],
+] as const) {
+  assert.match(
+    source,
+    new RegExp(`case "${reason}":[\\s\\S]*?status: ${status}`),
+    `${reason} answers ${status}`,
+  );
+}
+
+assert.match(
+  source,
+  /return NextResponse\.json\(\{ ok: true, \.\.\.workspaceRootStatus\(\) \}\);/,
+  "a successful save answers with the freshly resolved status",
+);
+
+console.log("config/workspace-path route.test.ts: ok");

--- a/src/app/api/config/workspace-path/route.ts
+++ b/src/app/api/config/workspace-path/route.ts
@@ -1,0 +1,63 @@
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+import { NextRequest, NextResponse } from "next/server";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { saveWorkspaceRoot, workspaceRootStatus } from "@/lib/server/workspace-root-store";
+
+/**
+ * Read and set the workspace root shown in Settings → General → Workspace.
+ *
+ * Split out from `/api/config` because the workspace root is not a CaveConfig
+ * key: `covenWorkspaceRoot()` resolves it synchronously for path checks, so it
+ * lives in its own small file rather than the async config store.
+ *
+ * Security: loopback-only, like the folder browser that feeds it. Re-pointing
+ * where a machine stores its workspaces is a host-level change, not something a
+ * phone on the tailnet should be able to do. The submitted path is re-derived
+ * by the same trusted volume-root walk the browser uses.
+ */
+export async function GET(req: NextRequest) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
+
+  return NextResponse.json({ ok: true, ...workspaceRootStatus() });
+}
+
+export async function POST(req: NextRequest) {
+  const denied = rejectNonLocalRequest(req);
+  if (denied) return denied;
+
+  let body: { dir?: unknown };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+
+  const dir = typeof body?.dir === "string" ? body.dir : "";
+  const result = await saveWorkspaceRoot(dir);
+  if (result.ok) {
+    return NextResponse.json({ ok: true, ...workspaceRootStatus() });
+  }
+
+  switch (result.reason) {
+    case "env-pinned":
+      return NextResponse.json(
+        { ok: false, error: "The workspace path is pinned by an environment variable." },
+        { status: 409 },
+      );
+    case "invalid-path":
+      return NextResponse.json({ ok: false, error: "That folder isn't available." }, { status: 400 });
+    case "unbounded":
+      return NextResponse.json(
+        { ok: false, error: "Pick a folder inside a drive, not the drive itself." },
+        { status: 400 },
+      );
+    case "write-failed":
+      return NextResponse.json(
+        { ok: false, error: "Couldn't save the workspace path." },
+        { status: 500 },
+      );
+  }
+}

--- a/src/components/settings-shell-polish.test.ts
+++ b/src/components/settings-shell-polish.test.ts
@@ -371,8 +371,8 @@ assert.ok(workspacePathField.length > 0, "WorkspacePathField source should remai
 assert.match(workspacePathField, /const ctl = new AbortController\(\)/, "the workspace path field should own its AbortController");
 assert.match(
   workspacePathField,
-  /fetch\("\/api\/config", \{ cache: "no-store", signal: ctl\.signal \}\)/,
-  "the workspace path field should read the narrow config route for workspacePath",
+  /fetch\("\/api\/config\/workspace-path", \{ cache: "no-store", signal: ctl\.signal \}\)/,
+  "the workspace path field should read the narrow workspace-path route",
 );
 assert.doesNotMatch(
   workspacePathField,
@@ -381,10 +381,52 @@ assert.doesNotMatch(
 );
 assert.match(
   workspacePathField,
-  /if \(!ctl\.signal\.aborted && j\.workspacePath\) setPath\(j\.workspacePath\)/,
+  /if \(ctl\.signal\.aborted\) return;/,
   "the workspace path field should stay silent after unmount while applying workspacePath",
 );
 assert.match(workspacePathField, /return \(\) => ctl\.abort\(\)/, "the workspace path field should abort on unmount");
+
+// Browse used to mean "hand the path to the OS file manager": a no-op on the
+// web build, and never a way to CHANGE the root. It now opens the in-app
+// folder browser (no native dialog) and persists the pick; revealing the
+// folder natively survives as its own desktop-only control.
+assert.match(
+  workspacePathField,
+  /<DirectoryPickerModal\s+open=\{pickerOpen\}/,
+  "Browse opens the shared in-app folder browser",
+);
+assert.match(workspacePathField, /onClick=\{\(\) => setPickerOpen\(true\)\}/, "the Browse button opens the picker");
+assert.match(
+  workspacePathField,
+  /method: "POST",[\s\S]*body: JSON\.stringify\(\{ dir \}\)/,
+  "choosing a folder persists it through the workspace-path route",
+);
+assert.match(workspacePathField, /announce\("Workspace path saved\."\)/, "a saved path announces");
+assert.match(
+  workspacePathField,
+  /disabled=\{Boolean\(envPin\) \|\| saving\}/,
+  "an env-pinned workspace root cannot be changed from Settings",
+);
+assert.match(
+  workspacePathField,
+  /Pinned by the \{envPin\} environment variable\./,
+  "an env pin explains itself instead of silently ignoring the pick",
+);
+assert.match(
+  workspacePathField,
+  /aria-label="Open workspace folder in file manager"/,
+  "revealing the folder natively survives as its own control",
+);
+assert.match(
+  shellSource,
+  /import \{ DirectoryPickerModal \} from "@\/components\/directory-picker-modal"/,
+  "the settings shell reuses the shared picker rather than a second browser",
+);
+assert.match(
+  dashboardCss,
+  /\.settings-workspace-actions\s*\{[\s\S]*?display:\s*flex/,
+  "the workspace row lays its actions out in a row",
+);
 assert.match(source, /aria-label="Server hub URL"/, "the hub URL input is labelled");
 assert.match(source, /aria-label="Executor addresses, one per line"/, "the executor textarea is labelled");
 assert.match(source, /focusTarget\.focus\(\{ preventScroll: true \}\)/, "a search/deep-link jump moves focus to the target group");

--- a/src/components/settings-shell.tsx
+++ b/src/components/settings-shell.tsx
@@ -10,6 +10,7 @@ import { SettingsGroup, settingsGroupId } from "@/components/ui/settings-group";
 import { Button } from "@/components/ui/button";
 import { ErrorState } from "@/components/ui/error-state";
 import { IconButton } from "@/components/ui/icon-button";
+import { DirectoryPickerModal } from "@/components/directory-picker-modal";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { SettingControlRow, Segmented } from "@/components/ui/settings-controls";
 import { SearchInput } from "@/components/ui/search-input";
@@ -936,24 +937,70 @@ function ScheduledSyncSettings() {
   );
 }
 
+/**
+ * Workspace path — read the current root, and let Browse *change* it.
+ *
+ * Browse used to hand the path to the OS file manager (`shell_open_path`),
+ * which meant it did nothing at all on the web build and, on desktop, could
+ * only ever show you the folder you already had. Choosing a different one had
+ * no UI at all. It now opens the in-app folder browser — the same modal the
+ * new-project flow uses, so this works identically on web and desktop with no
+ * native dialog — and persists the pick through /api/config/workspace-path.
+ *
+ * Revealing the folder in the OS file manager is still available on desktop,
+ * as its own control rather than as the meaning of "Browse".
+ */
 function WorkspacePathField() {
   const [path, setPath] = useState("");
+  const [envPin, setEnvPin] = useState<string | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
   const desktop = useIsTauriDesktop();
   const { announce } = useAnnouncer();
   const [openError, setOpenError] = useState("");
 
   useEffect(() => {
     const ctl = new AbortController();
-    fetch("/api/config", { cache: "no-store", signal: ctl.signal })
+    fetch("/api/config/workspace-path", { cache: "no-store", signal: ctl.signal })
       .then((r) => r.json())
-      .then((j: { workspacePath?: string }) => {
-        if (!ctl.signal.aborted && j.workspacePath) setPath(j.workspacePath);
+      .then((j: { workspacePath?: string; envPin?: string | null }) => {
+        if (ctl.signal.aborted) return;
+        if (j.workspacePath) setPath(j.workspacePath);
+        setEnvPin(j.envPin ?? null);
       })
       .catch(() => {});
     return () => ctl.abort();
   }, []);
 
-  const browse = async () => {
+  const choose = async (dir: string) => {
+    setPickerOpen(false);
+    setSaving(true);
+    setOpenError("");
+    try {
+      const res = await fetch("/api/config/workspace-path", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        cache: "no-store",
+        body: JSON.stringify({ dir }),
+      });
+      const body = (await res.json()) as { ok?: boolean; workspacePath?: string; error?: string };
+      if (!res.ok || !body.ok || !body.workspacePath) {
+        const message = body.error ?? "Couldn't save the workspace path.";
+        setOpenError(message);
+        announce(message, "assertive");
+        return;
+      }
+      setPath(body.workspacePath);
+      announce("Workspace path saved.");
+    } catch {
+      setOpenError("Couldn't save the workspace path.");
+      announce("Couldn't save the workspace path.", "assertive");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reveal = async () => {
     if (!desktop || !path) return;
     setOpenError("");
     try {
@@ -974,17 +1021,43 @@ function WorkspacePathField() {
         aria-label="Workspace path"
         className="settings-workspace-path focus-ring"
       />
-      <Button
-        variant="secondary"
-        size="sm"
-        leadingIcon="ph:folder-open"
-        disabled={!desktop || !path}
-        title={desktop ? "Open workspace folder" : "Available in the desktop app"}
-        onClick={() => void browse()}
-      >
-        Browse
-      </Button>
+      <div className="settings-workspace-actions">
+        <Button
+          variant="secondary"
+          size="sm"
+          leadingIcon="ph:folder-open"
+          disabled={Boolean(envPin) || saving}
+          title={
+            envPin
+              ? `Pinned by ${envPin}`
+              : "Choose where Coven stores familiar workspaces"
+          }
+          onClick={() => setPickerOpen(true)}
+        >
+          {saving ? "Saving…" : "Browse"}
+        </Button>
+        {desktop ? (
+          <IconButton
+            icon="ph:arrow-square-out"
+            aria-label="Open workspace folder in file manager"
+            title="Open workspace folder in file manager"
+            size="sm"
+            disabled={!path}
+            onClick={() => void reveal()}
+          />
+        ) : null}
+      </div>
+      {envPin ? (
+        <p className="settings-workspace-hint">
+          Pinned by the {envPin} environment variable.
+        </p>
+      ) : null}
       {openError ? <p role="alert" className="settings-workspace-error">{openError}</p> : null}
+      <DirectoryPickerModal
+        open={pickerOpen}
+        onClose={() => setPickerOpen(false)}
+        onSelect={(dir) => void choose(dir)}
+      />
     </div>
   );
 }

--- a/src/lib/coven-paths.ts
+++ b/src/lib/coven-paths.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
@@ -23,13 +24,59 @@ export function covenWorkspacesRoot(): string {
   return process.env.COVEN_WORKSPACES_ROOT || path.join(covenHome(), "workspaces");
 }
 
+/**
+ * Env vars that pin the workspace root outright, in precedence order. These are
+ * deployment configuration — when one is set, Settings shows the value as
+ * read-only rather than letting a pick silently lose to the environment.
+ */
+export const WORKSPACE_ROOT_ENV_VARS = [
+  "COVEN_WORKSPACE_ROOT",
+  "WORKSPACE_ROOT",
+  "NEXT_PUBLIC_WORKSPACE_ROOT",
+] as const;
+
+/** The env var currently pinning the workspace root, if any. */
+export function workspaceRootEnvPin(): { name: string; value: string } | null {
+  for (const name of WORKSPACE_ROOT_ENV_VARS) {
+    const value = process.env[name];
+    if (value) return { name, value };
+  }
+  return null;
+}
+
+/** File holding the workspace root the user chose in Settings. */
+export function workspaceRootOverrideFile(): string {
+  return path.join(caveHome(), "workspace-root.json");
+}
+
+/**
+ * The workspace root chosen in Settings, or null when none has been saved.
+ *
+ * Read synchronously (and uncached) on purpose: `covenWorkspaceRoot()` is a
+ * sync API called from sync callers like project-paths' allowed-root list, and
+ * a cache here would keep serving the old root to in-flight requests right
+ * after the user picks a new one. The file is a few dozen bytes.
+ */
+export function readWorkspaceRootOverride(): string | null {
+  try {
+    const raw = fs.readFileSync(/* turbopackIgnore: true */ workspaceRootOverrideFile(), "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return null;
+    const value = (parsed as { workspacePath?: unknown }).workspacePath;
+    return typeof value === "string" && value.trim() ? value : null;
+  } catch {
+    // Absent (the common case), unreadable, or malformed — fall through to the
+    // env pin / default rather than failing every path resolution.
+    return null;
+  }
+}
+
+/**
+ * Where familiar workspaces live. An env pin wins (deployment config), then the
+ * root chosen in Settings, then the default beneath `~/.coven`.
+ */
 export function covenWorkspaceRoot(): string {
-  return (
-    process.env.COVEN_WORKSPACE_ROOT ||
-    process.env.WORKSPACE_ROOT ||
-    process.env.NEXT_PUBLIC_WORKSPACE_ROOT ||
-    covenWorkspacesRoot()
-  );
+  return workspaceRootEnvPin()?.value || readWorkspaceRootOverride() || covenWorkspacesRoot();
 }
 
 export function familiarWorkspacesRoot(): string {

--- a/src/lib/server/workspace-root-store.test.ts
+++ b/src/lib/server/workspace-root-store.test.ts
@@ -1,0 +1,146 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import {
+  covenWorkspaceRoot,
+  readWorkspaceRootOverride,
+  workspaceRootEnvPin,
+  workspaceRootOverrideFile,
+} from "../coven-paths.ts";
+import {
+  clearWorkspaceRoot,
+  saveWorkspaceRoot,
+  validateWorkspaceRoot,
+  workspaceRootStatus,
+} from "./workspace-root-store.ts";
+
+const TEST_ARTIFACTS_ROOT = path.join(process.cwd(), ".test-artifacts");
+
+const ENV_KEYS = [
+  "COVEN_HOME",
+  "COVEN_CAVE_HOME",
+  "COVEN_WORKSPACES_ROOT",
+  "COVEN_WORKSPACE_ROOT",
+  "WORKSPACE_ROOT",
+  "NEXT_PUBLIC_WORKSPACE_ROOT",
+] as const;
+
+/** Run `body` against a scratch Cave home with every workspace env var cleared. */
+async function withScratchHome(body: (base: string) => Promise<void> | void) {
+  const saved = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
+  fs.mkdirSync(TEST_ARTIFACTS_ROOT, { recursive: true });
+  const base = fs.mkdtempSync(path.join(TEST_ARTIFACTS_ROOT, "workspace-root-"));
+  for (const key of ENV_KEYS) delete process.env[key];
+  process.env.COVEN_HOME = base;
+  try {
+    await body(base);
+  } finally {
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    fs.rmSync(base, { recursive: true, force: true });
+  }
+}
+
+test("with nothing saved the root falls back to the default beneath the Cave home", async () => {
+  await withScratchHome((base) => {
+    assert.equal(readWorkspaceRootOverride(), null);
+    assert.equal(covenWorkspaceRoot(), path.join(base, "workspaces"));
+    assert.deepEqual(workspaceRootStatus(), {
+      workspacePath: path.join(base, "workspaces"),
+      envPin: null,
+      chosen: false,
+    });
+  });
+});
+
+test("a saved root is what covenWorkspaceRoot resolves to", async () => {
+  await withScratchHome(async (base) => {
+    const target = path.join(base, "elsewhere", "workspaces");
+    fs.mkdirSync(target, { recursive: true });
+
+    const result = await saveWorkspaceRoot(target);
+
+    assert.deepEqual(result, { ok: true, workspacePath: target });
+    assert.equal(readWorkspaceRootOverride(), target);
+    assert.equal(covenWorkspaceRoot(), target);
+    assert.equal(workspaceRootStatus().chosen, true);
+  });
+});
+
+test("the saved root survives a reread and can be cleared", async () => {
+  await withScratchHome(async (base) => {
+    const target = path.join(base, "picked");
+    fs.mkdirSync(target, { recursive: true });
+    await saveWorkspaceRoot(target);
+    assert.equal(covenWorkspaceRoot(), target);
+
+    await clearWorkspaceRoot();
+
+    assert.equal(readWorkspaceRootOverride(), null);
+    assert.equal(covenWorkspaceRoot(), path.join(base, "workspaces"));
+  });
+});
+
+test("an env pin wins over a saved root and blocks saving a new one", async () => {
+  await withScratchHome(async (base) => {
+    const saved = path.join(base, "saved");
+    const pinned = path.join(base, "pinned");
+    fs.mkdirSync(saved, { recursive: true });
+    fs.mkdirSync(pinned, { recursive: true });
+    await saveWorkspaceRoot(saved);
+
+    process.env.COVEN_WORKSPACE_ROOT = pinned;
+
+    assert.deepEqual(workspaceRootEnvPin(), { name: "COVEN_WORKSPACE_ROOT", value: pinned });
+    assert.equal(covenWorkspaceRoot(), pinned, "the env pin wins the resolution");
+    assert.equal(workspaceRootStatus().envPin, "COVEN_WORKSPACE_ROOT");
+    // Saving under a pin would persist a preference the app then ignores.
+    assert.deepEqual(await saveWorkspaceRoot(path.join(base, "saved")), {
+      ok: false,
+      reason: "env-pinned",
+    });
+  });
+});
+
+test("a malformed override file degrades to the default instead of throwing", async () => {
+  await withScratchHome((base) => {
+    fs.mkdirSync(path.dirname(workspaceRootOverrideFile()), { recursive: true });
+    fs.writeFileSync(workspaceRootOverrideFile(), "{not json");
+    assert.equal(readWorkspaceRootOverride(), null);
+    assert.equal(covenWorkspaceRoot(), path.join(base, "workspaces"));
+
+    fs.writeFileSync(workspaceRootOverrideFile(), JSON.stringify({ workspacePath: "   " }));
+    assert.equal(readWorkspaceRootOverride(), null, "a blank value is not a choice");
+  });
+});
+
+test("validation refuses relative, missing, and unbounded roots", async () => {
+  await withScratchHome((base) => {
+    const real = path.join(base, "real");
+    fs.mkdirSync(real, { recursive: true });
+
+    assert.deepEqual(validateWorkspaceRoot(real), { ok: true, workspacePath: real });
+    assert.deepEqual(validateWorkspaceRoot(""), { ok: false, reason: "invalid-path" });
+    assert.deepEqual(validateWorkspaceRoot("relative/dir"), { ok: false, reason: "invalid-path" });
+    assert.deepEqual(validateWorkspaceRoot(path.join(base, "ghost")), {
+      ok: false,
+      reason: "invalid-path",
+    });
+    // A whole drive (or "/") is never a sane place to store workspaces.
+    assert.deepEqual(validateWorkspaceRoot(path.parse(real).root), {
+      ok: false,
+      reason: "unbounded",
+    });
+  });
+});
+
+test("a file (not a directory) is never accepted as a workspace root", async () => {
+  await withScratchHome((base) => {
+    const file = path.join(base, "notes.txt");
+    fs.writeFileSync(file, "x");
+    assert.deepEqual(validateWorkspaceRoot(file), { ok: false, reason: "invalid-path" });
+  });
+});

--- a/src/lib/server/workspace-root-store.ts
+++ b/src/lib/server/workspace-root-store.ts
@@ -1,0 +1,97 @@
+import fs from "node:fs";
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import {
+  caveHome,
+  covenWorkspaceRoot,
+  readWorkspaceRootOverride,
+  workspaceRootEnvPin,
+  workspaceRootOverrideFile,
+} from "@/lib/coven-paths";
+import { resolveBrowsableDir } from "@/lib/server/home-browse";
+import { writeJsonAtomic } from "@/lib/server/atomic-write";
+
+/**
+ * Persistence for the workspace root chosen in Settings → General → Workspace.
+ *
+ * Kept in its own tiny file (`<caveHome>/workspace-root.json`) rather than in
+ * cave-config.json: `covenWorkspaceRoot()` is synchronous and is consulted by
+ * sync callers (project-paths' allowed-root list), while the config store is
+ * async and imports this module's dependencies — routing the read through it
+ * would mean an import cycle and an async ripple through every path helper.
+ *
+ * The read half lives in coven-paths.ts (no cycle, sync); this module owns
+ * validation and the write.
+ */
+
+export type SaveWorkspaceRootResult =
+  | { ok: true; workspacePath: string }
+  | { ok: false; reason: "env-pinned" | "invalid-path" | "unbounded" | "write-failed" };
+
+/** True for a bare volume root: "/" or a Windows drive root like "C:\". */
+function isVolumeRoot(value: string): boolean {
+  return value === path.parse(value).root;
+}
+
+/**
+ * Validate a requested workspace root.
+ *
+ * Reuses `resolveBrowsableDir` so the accepted path is re-derived from its
+ * volume root by the same trusted directory walk the folder browser uses — the
+ * request string is never handed to the filesystem as a path. A bare volume
+ * root or `$HOME` itself is refused for the same reason the picker won't let
+ * you select one: pointing workspace storage at an entire drive or home
+ * directory is always a mistake.
+ */
+export function validateWorkspaceRoot(requested: string): SaveWorkspaceRootResult {
+  const raw = (requested ?? "").trim();
+  if (!raw || !path.isAbsolute(raw)) return { ok: false, reason: "invalid-path" };
+  const resolved = resolveBrowsableDir(raw);
+  if (!resolved) return { ok: false, reason: "invalid-path" };
+  if (isVolumeRoot(resolved)) return { ok: false, reason: "unbounded" };
+  return { ok: true, workspacePath: resolved };
+}
+
+/**
+ * Persist the chosen workspace root. Refuses while an env var pins the value —
+ * saving under a pin would write a preference the app then ignores.
+ */
+export async function saveWorkspaceRoot(requested: string): Promise<SaveWorkspaceRootResult> {
+  if (workspaceRootEnvPin()) return { ok: false, reason: "env-pinned" };
+
+  const validated = validateWorkspaceRoot(requested);
+  if (!validated.ok) return validated;
+
+  try {
+    await mkdir(/* turbopackIgnore: true */ caveHome(), { recursive: true });
+    await writeJsonAtomic(workspaceRootOverrideFile(), {
+      workspacePath: validated.workspacePath,
+      savedAt: new Date().toISOString(),
+    });
+  } catch {
+    return { ok: false, reason: "write-failed" };
+  }
+  return validated;
+}
+
+/** Drop the saved choice and fall back to the default root. */
+export async function clearWorkspaceRoot(): Promise<void> {
+  await fs.promises.rm(workspaceRootOverrideFile(), { force: true });
+}
+
+export type WorkspaceRootStatus = {
+  workspacePath: string;
+  /** The env var pinning the value, when one is set (the field goes read-only). */
+  envPin: string | null;
+  /** True once the user has picked a root rather than inheriting the default. */
+  chosen: boolean;
+};
+
+export function workspaceRootStatus(): WorkspaceRootStatus {
+  const pin = workspaceRootEnvPin();
+  return {
+    workspacePath: covenWorkspaceRoot(),
+    envPin: pin?.name ?? null,
+    chosen: !pin && readWorkspaceRootOverride() !== null,
+  };
+}

--- a/src/styles/dashboard.css
+++ b/src/styles/dashboard.css
@@ -509,6 +509,19 @@
   font-size: var(--text-sm);
 }
 
+.settings-workspace-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.settings-workspace-hint {
+  grid-column: 1 / -1;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--text-xs);
+}
+
 .settings-workspace-error {
   grid-column: 1 / -1;
   margin: 0;


### PR DESCRIPTION
## Why

Settings → General → Workspace has a **Browse** button next to the workspace path. It called `shell_open_path` — hand the *current* path to the OS file manager.

Two consequences:

- On the **web build** it does nothing. The button is gated on `useIsTauriDesktop()`, so outside the desktop shell it's simply disabled.
- On **desktop**, the most it could ever do is show you the folder you already had. **There was no way to change the workspace root from the UI at all** — the only lever was setting `COVEN_WORKSPACE_ROOT` / `WORKSPACE_ROOT` / `NEXT_PUBLIC_WORKSPACE_ROOT` and restarting.

So a control that reads as "pick a folder" could never pick a folder.

## What changed

**Browse opens the in-app folder browser** — the same `DirectoryPickerModal` the new-project flow uses. No native dialog, so it behaves identically on web and desktop. Selecting a folder persists it.

**Revealing the folder in the OS file manager survives** as its own desktop-only icon button, rather than as the meaning of "Browse".

### Persistence

The chosen root goes to `<caveHome>/workspace-root.json` rather than into `cave-config.json`. `covenWorkspaceRoot()` is **synchronous** and is consulted by sync callers — notably `project-paths.ts`'s allowed-root list, which runs on every project access check. Routing that read through the async config store would mean an import cycle (`cave-config` already depends on these path helpers) and an async ripple through every path helper in the app.

Resolution order:

| Precedence | Source | Behavior in Settings |
|---|---|---|
| 1 | `COVEN_WORKSPACE_ROOT` / `WORKSPACE_ROOT` / `NEXT_PUBLIC_WORKSPACE_ROOT` | field read-only, names the pinning variable |
| 2 | the root chosen in Settings | editable |
| 3 | `covenWorkspacesRoot()` (`~/.coven/workspaces`) | editable |

An env var still wins — it's deployment configuration. But rather than silently discarding a pick, the field disables Browse and says *"Pinned by the `COVEN_WORKSPACE_ROOT` environment variable."*

The override read is deliberately **uncached**: a cache would keep serving the old root to in-flight requests immediately after a save, and the file is a few dozen bytes.

### Validation and access

`validateWorkspaceRoot` runs the submitted path through `resolveBrowsableDir`, so an accepted root is re-derived from its volume root by the same trusted directory walk the folder browser uses — the request string is never handed to the filesystem as a path. A bare volume root (`C:\`, `/`) is refused for the same reason the picker won't let you select one.

`GET`/`POST /api/config/workspace-path` are loopback-gated. Re-pointing where a machine stores its workspaces is a host-level change, not something a phone on the tailnet should be able to do.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` (design codemod + eslint) — clean
- `node scripts/check-tests-wired.mjs` — 1500 files wired
- `src/lib/server/workspace-root-store.test.ts` — 7 pass (new): default fallback, save→resolve round-trip, clear, env pin winning *and* blocking a save, malformed/blank override degrading to the default, and refusal of relative / missing / file / bare-volume-root paths
- `src/app/api/config/workspace-path/route.test.ts` — pass (new): both verbs loopback-gated, delegation to the store, each refusal reason mapped to its own status
- `src/lib/coven-paths.test.ts` — pass unchanged, so the existing env-precedence contract is intact
- `src/components/settings-shell-polish.test.ts` — pass, updated for the new behavior

**Not verified by render.** Unlike the picker-rails PR, I could not get a render smoke of this field: `SettingsShell` pulls in the Next app router and every sibling settings group, so exercising it needs a real DOM plus a mock per group. The field's wiring is covered by source-level assertions only. Worth a manual click-through of Settings → General → Workspace before merge.

## Diff review

- `src/lib/coven-paths.ts` — the new precedence and the sync override read
- `src/lib/server/workspace-root-store.ts` — validation and the atomic write
- `src/app/api/config/workspace-path/route.ts` — gate, delegation, status mapping
- `src/components/settings-shell.tsx` — `WorkspacePathField`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
