### PR TITLE
Improve adaptive chat context controls

### DIFF
--- a/docs/superpowers/plans/2026-08-04-adaptive-chat-context-controls.md
+++ b/docs/superpowers/plans/2026-08-04-adaptive-chat-context-controls.md
@@ -1,0 +1,681 @@
+# Adaptive Chat Context Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move project, worktree, branch, and model controls out of an active chat's composer and into its header while keeping the same controls in a footer below the new-chat composer.
+
+**Architecture:** Extend the existing `ComposerContextChips` controller rather than introducing another context state model. The shared component will render independently anchored project, worktree, branch, and model controls; `ChatView` will mount it in exactly one adaptive location, while existing picker, access, model, and Git handlers remain authoritative.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, tokenized CSS, Node source-contract tests, existing Project/Runtime/Git popovers.
+
+---
+
+## File map
+
+- Modify `src/components/composer-context-pill.tsx`: split worktree from branch, preserve independent popover anchors, and expose a labelled control group suitable for header or composer placement.
+- Modify `src/components/chat-view.tsx`: build the shared context node once and place it in the active header or new-chat footer without duplicating state or callbacks.
+- Modify `src/styles/cave-composer.css`: keep shared chip styling and add the single-line overflow contract used by both placements.
+- Modify `src/styles/cave-chat/activity.css`: size and position the active-chat context strip beneath `MetaLine`.
+- Modify `src/styles/cave-chat/transcript.css`: preserve mobile visibility and touch behavior for the header context strip.
+- Modify `src/components/chat-composer-footer-band.test.ts`: pin adaptive placement, control order, worktree/branch separation, and narrow-width behavior.
+- Modify `src/components/chat-header-row.test.ts`: pin the active-header control group and ensure context is not duplicated in the active composer.
+- Modify `src/components/chat-view-polish-header-composer.test.ts`: update the source contract from one unconditional footer mount to two conditional placements.
+- Modify `src/components/chat-view-first-class.test.ts`: update the expected shared-control mount count and location assertions.
+- Modify `src/components/composer-git-chip.test.ts`: pin separate worktree and branch triggers against the existing Git menu behavior.
+
+### Task 1: Split worktree and branch into independent shared controls
+
+**Files:**
+- Modify: `src/components/composer-context-pill.tsx:35-80, 170-227, 230-362`
+- Modify: `src/components/chat-composer-footer-band.test.ts:74-137`
+- Modify: `src/components/composer-git-chip.test.ts`
+
+- [ ] **Step 1: Write the failing source-contract tests**
+
+Update `src/components/chat-composer-footer-band.test.ts` so the shared component is required to render project, worktree, branch, and model in that order:
+
+```ts
+assert.match(
+  pill,
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?context\.worktree \? \([\s\S]*?aria-label=\{`Worktree: \$\{context\.worktree\} — open worktree actions`\}[\s\S]*?aria-label=\{`Branch: \$\{context\.branch\} — switch branch or create a worktree`\}[\s\S]*?aria-label=\{`Model: \$\{modelLabel\} — change model`\}/,
+  "context controls should read Project / Worktree / Branch / Model in order",
+);
+assert.match(
+  pill,
+  /const worktreeRef = useRef<HTMLButtonElement \| null>\(null\)[\s\S]*?const branchRef = useRef<HTMLButtonElement \| null>\(null\)/,
+  "worktree and branch should have independent trigger anchors",
+);
+assert.doesNotMatch(
+  pill,
+  /\{context\.worktree \? ` · \$\{context\.worktree\}` : ""\}/,
+  "worktree should no longer be folded into the branch label",
+);
+```
+
+Add matching assertions to `src/components/composer-git-chip.test.ts`:
+
+```ts
+assert.match(
+  pill,
+  /aria-label=\{`Worktree: \$\{context\.worktree\} — open worktree actions`\}/,
+  "worktree-backed roots should expose a dedicated worktree control",
+);
+assert.match(
+  pill,
+  /menu === "worktree"[\s\S]*?<GitBranchMenuPopover/,
+  "the worktree control should reuse the existing Git action popover",
+);
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-composer-footer-band.test.ts
+node --experimental-strip-types src/components/composer-git-chip.test.ts
+```
+
+Expected: both commands fail because `ComposerContextView` has no `worktree` state and worktree is still text inside the branch button.
+
+- [ ] **Step 3: Add a worktree view and independent anchor**
+
+In `src/components/composer-context-pill.tsx`, extend the view type and refs:
+
+```ts
+export type ComposerContextView = null | "project" | "worktree" | "branch" | "model";
+
+const projectRef = useRef<HTMLButtonElement | null>(null);
+const worktreeRef = useRef<HTMLButtonElement | null>(null);
+const branchRef = useRef<HTMLButtonElement | null>(null);
+const modelRef = useRef<HTMLButtonElement | null>(null);
+```
+
+Keep `ComposerContextPickers` compatible with callers from the actions menu by treating both Git views as the existing Git popover:
+
+```tsx
+<GitBranchMenuPopover
+  open={view === "worktree" || view === "branch"}
+  onOpenChange={(open) =>
+    onViewChange(open ? (view === "worktree" ? "worktree" : "branch") : null)
+  }
+  anchorRef={anchorRef}
+  placement={context.config.popoverPlacement}
+  projectRoot={context.root}
+  onSwitched={context.reload}
+  {...branchPopoverExtras(context)}
+/>
+```
+
+- [ ] **Step 4: Render controls in the approved order**
+
+Replace the button sequence in `ComposerContextChips` with:
+
+```tsx
+<button
+  ref={projectRef}
+  type="button"
+  className="cave-context-chip focus-ring"
+  disabled={props.disabled}
+  aria-haspopup="dialog"
+  aria-expanded={menu === "project"}
+  aria-label={`Project: ${projectLabel} — change project`}
+  title={
+    context.selectedProject
+      ? `${context.selectedProject.root}${projectAccess ? ` · ${projectAccess} access` : ""}`
+      : context.emptyProjectLabel
+  }
+  onClick={() => setMenu((current) => (current === "project" ? null : "project"))}
+>
+  <span className="cave-context-chip__lead" aria-hidden>
+    {context.selectedProject ? (
+      <ProjectAvatar
+        name={context.selectedProject.name}
+        root={context.selectedProject.root}
+        color={context.selectedProject.color}
+        size="sm"
+      />
+    ) : (
+      <Icon name="ph:folder" width={13} aria-hidden />
+    )}
+  </span>
+  <span className="cave-context-chip__text">{projectLabel}</span>
+  <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+</button>
+
+{context.hasGit && context.worktree ? (
+  <button
+    ref={worktreeRef}
+    type="button"
+    className="cave-context-chip focus-ring"
+    disabled={props.disabled}
+    aria-haspopup="menu"
+    aria-expanded={menu === "worktree"}
+    aria-label={`Worktree: ${context.worktree} — open worktree actions`}
+    title={`Worktree: ${context.worktree} · ${context.dirtyLabel}`}
+    onClick={() => setMenu((current) => (current === "worktree" ? null : "worktree"))}
+  >
+    <span className="cave-context-chip__lead" aria-hidden>
+      <Icon name="ph:tree-structure" width={13} aria-hidden />
+    </span>
+    <span className="cave-context-chip__text">{context.worktree}</span>
+    <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+  </button>
+) : null}
+
+{context.hasGit ? (
+  <button
+    ref={branchRef}
+    type="button"
+    className="cave-context-chip focus-ring"
+    disabled={props.disabled}
+    aria-haspopup="menu"
+    aria-expanded={menu === "branch"}
+    aria-label={`Branch: ${context.branch} — switch branch or create a worktree`}
+    title={`Branch: ${context.branch} · ${context.dirtyLabel}`}
+    onClick={() => setMenu((current) => (current === "branch" ? null : "branch"))}
+  >
+    <span className="cave-context-chip__lead" aria-hidden>
+      <Icon name="ph:git-branch" width={13} aria-hidden />
+    </span>
+    <span className="cave-context-chip__text">
+      {context.branch}
+      {context.count > 0 ? ` · +${context.count}` : ""}
+    </span>
+    <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+  </button>
+) : null}
+
+<button
+  ref={modelRef}
+  type="button"
+  className="cave-context-chip focus-ring"
+  disabled={props.disabled || context.config.modelDisabled}
+  aria-haspopup="dialog"
+  aria-expanded={menu === "model"}
+  aria-label={`Model: ${modelLabel} — change model`}
+  title={`Runtime: ${context.runtimeName}${context.modelLabel ? ` · Model: ${context.modelLabel}` : ""}`}
+  onClick={() => setMenu((current) => (current === "model" ? null : "model"))}
+>
+  <span className="cave-context-chip__lead cave-runtime-chip__logo" aria-hidden>
+    <RuntimeLogo runtime={context.config.runtime} size={13} />
+  </span>
+  <span className="cave-context-chip__text">{modelLabel}</span>
+  <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+</button>
+```
+
+Use one Git popover instance per trigger so focus returns to the button that opened it:
+
+```tsx
+{context.hasGit && context.worktree ? (
+  <GitBranchMenuPopover
+    open={menu === "worktree"}
+    onOpenChange={(open) => setMenu(open ? "worktree" : null)}
+    anchorRef={worktreeRef}
+    placement={context.config.popoverPlacement}
+    projectRoot={context.root}
+    onSwitched={context.reload}
+    {...branchPopoverExtras(context)}
+  />
+) : null}
+{context.hasGit ? (
+  <GitBranchMenuPopover
+    open={menu === "branch"}
+    onOpenChange={(open) => setMenu(open ? "branch" : null)}
+    anchorRef={branchRef}
+    placement={context.config.popoverPlacement}
+    projectRoot={context.root}
+    onSwitched={context.reload}
+    {...branchPopoverExtras(context)}
+  />
+) : null}
+```
+
+- [ ] **Step 5: Run the targeted tests**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-composer-footer-band.test.ts
+node --experimental-strip-types src/components/composer-git-chip.test.ts
+node --experimental-strip-types src/components/composer-actions-menu.test.ts
+```
+
+Expected: all three print their `: ok` success lines.
+
+- [ ] **Step 6: Commit the shared-control change**
+
+```bash
+git add src/components/composer-context-pill.tsx \
+  src/components/chat-composer-footer-band.test.ts \
+  src/components/composer-git-chip.test.ts
+git commit -m "feat(chat): split worktree and branch controls"
+```
+
+### Task 2: Mount context adaptively in ChatView
+
+**Files:**
+- Modify: `src/components/chat-view.tsx:6568-6604, 7144-7180, 7201-7327`
+- Modify: `src/components/chat-header-row.test.ts:15-104, 172-184`
+- Modify: `src/components/chat-view-polish-header-composer.test.ts`
+- Modify: `src/components/chat-view-first-class.test.ts`
+
+- [ ] **Step 1: Write failing adaptive-placement tests**
+
+Replace the unconditional footer assertions in `src/components/chat-header-row.test.ts` with:
+
+```ts
+assert.match(
+  source,
+  /const chatContextControls = \([\s\S]*?<ComposerContextChips[\s\S]*?ariaLabel=\{inlineComposer \? "New chat context" : "Session context"\}/,
+  "ChatView should build one shared context-control node",
+);
+assert.match(
+  source,
+  /\{inlineComposer \? \([\s\S]*?cave-composer-footer-band__cluster[\s\S]*?\{chatContextControls\}[\s\S]*?\) : null\}/,
+  "new chats should render context in the composer footer",
+);
+assert.match(
+  source,
+  /\{!inlineComposer \? \([\s\S]*?cave-chat-header-context[\s\S]*?\{chatContextControls\}[\s\S]*?\) : null\}/,
+  "active chats should render context beneath MetaLine",
+);
+assert.doesNotMatch(
+  source,
+  /<MetaLine[\s\S]*?<ComposerContextChips/,
+  "the shared node should prevent duplicate picker state in the header",
+);
+```
+
+Update `src/components/chat-view-polish-header-composer.test.ts` and
+`src/components/chat-view-first-class.test.ts` to expect one component
+construction and two conditional placements:
+
+```ts
+assert.equal(
+  source.match(/<ComposerContextChips/g)?.length,
+  1,
+  "ChatView should construct the shared context controls once",
+);
+assert.match(source, /\{inlineComposer \? \([\s\S]*?\{chatContextControls\}/);
+assert.match(source, /\{!inlineComposer \? \([\s\S]*?\{chatContextControls\}/);
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-header-row.test.ts
+node --experimental-strip-types src/components/chat-view-polish-header-composer.test.ts
+node --experimental-strip-types src/components/chat-view-first-class.test.ts
+```
+
+Expected: failures show that context controls are still mounted unconditionally in the composer footer.
+
+- [ ] **Step 3: Add a group label to the shared component**
+
+Extend `ComposerContextProps` in `src/components/composer-context-pill.tsx`:
+
+```ts
+export type ComposerContextProps = {
+  ariaLabel?: string;
+  // existing fields remain unchanged
+};
+```
+
+Wrap the controls and their popovers in a labelled group:
+
+```tsx
+return (
+  <div
+    className="cave-context-controls"
+    role="group"
+    aria-label={props.ariaLabel ?? "Chat context"}
+  >
+    {/* independent buttons and existing popovers */}
+  </div>
+);
+```
+
+Keep error text and the add-project modal inside this wrapper so each placement
+retains the complete interaction flow.
+
+- [ ] **Step 4: Build one shared context node in ChatView**
+
+Immediately after `inlineComposer` and popover-placement derivation in
+`src/components/chat-view.tsx`, create:
+
+```tsx
+const chatContextControls = (
+  <ComposerContextChips
+    projects={projects}
+    projectValue={resolvedProjectId}
+    onProjectChange={setProjectIdDraft}
+    familiarId={familiar.id ?? null}
+    createProject={createProject}
+    createProjectOrThrow={createProjectOrThrow}
+    runtime={modelHarness}
+    modelValue={composerModelValue}
+    modelOptions={composerModelOptions}
+    onPickRuntime={handleSelectRuntime}
+    onPickModel={handleSelectModel}
+    promotableModel={promotableModel}
+    onPromoteModelToDefault={handlePromoteModelToDefault}
+    modelDisabled={busy}
+    projectRoot={activeProjectRoot}
+    onOpenUrl={onOpenUrl}
+    registerCurrentRoot={setupCandidateRoot ?? undefined}
+    onRegisterCurrentRoot={
+      setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
+    }
+    popoverPlacement={composerPopoverPlacement}
+    ariaLabel={inlineComposer ? "New chat context" : "Session context"}
+  />
+);
+```
+
+Do not derive a second project, model, or Git state for the header.
+
+- [ ] **Step 5: Restrict composer context to new chats**
+
+Change the composer footer in `src/components/chat-view.tsx` to:
+
+```tsx
+<div className="cave-composer-footer-band">
+  {inlineComposer ? (
+    <div className="cave-composer-footer-band__cluster">
+      {chatContextControls}
+    </div>
+  ) : null}
+  {linkedContextRow}
+  {followUp.suggestions.length > 0 && !busy ? (
+    <div className="cave-chat-followups">
+      <FollowUpCards paths={followUp.suggestions} onActivate={handleFollowUp} />
+    </div>
+  ) : null}
+</div>
+```
+
+The footer remains available for linked work and follow-up suggestions in an
+active chat; only runtime context leaves it.
+
+- [ ] **Step 6: Add the active header placement**
+
+Immediately after `</MetaLine>` and before `</header>`, render:
+
+```tsx
+{!inlineComposer ? (
+  <div className="cave-chat-header-context">
+    {chatContextControls}
+  </div>
+) : null}
+```
+
+This keeps the context beneath the title row, avoids nesting interactive
+controls inside the `role="status"` live region, and leaves all session action
+buttons inside `MetaLine`.
+
+- [ ] **Step 7: Run adaptive-placement tests**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-header-row.test.ts
+node --experimental-strip-types src/components/chat-view-polish-header-composer.test.ts
+node --experimental-strip-types src/components/chat-view-first-class.test.ts
+node --experimental-strip-types src/components/chat-view.test.ts
+```
+
+Expected: all four print their success lines, including the project registration
+and add-project wiring assertions.
+
+- [ ] **Step 8: Commit adaptive placement**
+
+```bash
+git add src/components/composer-context-pill.tsx \
+  src/components/chat-view.tsx \
+  src/components/chat-header-row.test.ts \
+  src/components/chat-view-polish-header-composer.test.ts \
+  src/components/chat-view-first-class.test.ts
+git commit -m "feat(chat): place context controls adaptively"
+```
+
+### Task 3: Add header and narrow-screen layout contracts
+
+**Files:**
+- Modify: `src/styles/cave-composer.css:1019-1082`
+- Modify: `src/styles/cave-chat/activity.css:634-677`
+- Modify: `src/styles/cave-chat/transcript.css:538-615`
+- Modify: `src/components/chat-composer-footer-band.test.ts:148-171, 265-291`
+
+- [ ] **Step 1: Add failing CSS contract tests**
+
+Add these assertions to `src/components/chat-composer-footer-band.test.ts`:
+
+```ts
+assert.match(
+  css,
+  /\.cave-context-controls \{[\s\S]*?display: flex;[\s\S]*?overflow-x: auto;[\s\S]*?white-space: nowrap;/,
+  "shared context controls should remain one horizontally scrollable line",
+);
+assert.match(
+  activityCss,
+  /\.cave-chat-header-context \{[\s\S]*?min-width: 0;[\s\S]*?overflow: hidden;/,
+  "the active header should contain context overflow without widening the pane",
+);
+assert.match(
+  transcriptCss,
+  /@media \(max-width: 767px\)[\s\S]*?\.cave-chat-header-context[\s\S]*?\.cave-context-chip \{[\s\S]*?min-height: var\(--touch-target\);/,
+  "mobile header context controls should retain touch targets",
+);
+```
+
+Remove assertions that require all context chips to live in
+`.cave-composer-footer-band__cluster`.
+
+- [ ] **Step 2: Run the CSS contract test to verify it fails**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-composer-footer-band.test.ts
+```
+
+Expected: failure reports missing `.cave-context-controls` overflow and
+`.cave-chat-header-context` containment rules.
+
+- [ ] **Step 3: Add shared single-line overflow styling**
+
+In `src/styles/cave-composer.css`, keep the existing cluster rule and add:
+
+```css
+.cave-context-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: thin;
+  overscroll-behavior-inline: contain;
+}
+
+.cave-context-controls > .cave-context-chip {
+  flex: 0 0 auto;
+}
+```
+
+Keep existing tokenized hover, open, disabled, text truncation, and focus-ring
+styles unchanged.
+
+- [ ] **Step 4: Style active-header placement**
+
+In `src/styles/cave-chat/activity.css`, add:
+
+```css
+.cave-chat-header-context {
+  min-width: 0;
+  overflow: hidden;
+  padding-inline-start: calc(var(--space-6) + var(--space-2));
+}
+
+.cave-chat-header-context .cave-context-chip {
+  height: var(--space-6);
+  font-size: var(--text-xs);
+}
+```
+
+The inline start offset aligns context after the familiar avatar without
+altering `MetaLine` or introducing absolute positioning.
+
+- [ ] **Step 5: Preserve mobile visibility and touch sizing**
+
+In the existing mobile block in `src/styles/cave-chat/transcript.css`, keep the
+header context visible even though `.cave-chat-meta-line` is hidden:
+
+```css
+.cave-chat-header-context {
+  display: block;
+  padding-inline-start: 0;
+}
+
+.cave-chat-header-context .cave-context-chip {
+  min-height: var(--touch-target);
+}
+```
+
+Do not add `.cave-chat-header-context` to the rule that hides
+`.cave-chat-meta-line` and `.cave-chat-linked-context`.
+
+- [ ] **Step 6: Run targeted UI source tests**
+
+Run:
+
+```bash
+node --experimental-strip-types src/components/chat-composer-footer-band.test.ts
+node --experimental-strip-types src/components/chat-header-row.test.ts
+node --experimental-strip-types src/components/composer-git-chip.test.ts
+node --experimental-strip-types src/components/chat-view-polish-header-composer.test.ts
+node --experimental-strip-types src/components/chat-view-first-class.test.ts
+```
+
+Expected: every command prints its `: ok` line.
+
+- [ ] **Step 7: Run type and design gates**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm lint
+pnpm check:tests-wired
+```
+
+Expected: TypeScript exits cleanly, the design codemod/lint reports no
+violations, and all modified tests are registered.
+
+- [ ] **Step 8: Run the app test suite**
+
+Run:
+
+```bash
+pnpm test:app
+```
+
+Expected: the app suite completes with zero failures.
+
+- [ ] **Step 9: Inspect the real responsive UI**
+
+Use the repository's `run-cave-app` skill to open:
+
+1. A new chat and confirm project, worktree when applicable, branch, and model
+   appear beneath rather than inside the writing surface.
+2. An active chat and confirm those controls appear beneath the title and are
+   absent from the composer.
+3. A worktree-backed chat and confirm worktree and branch are both visible and
+   independently clickable.
+4. A narrow viewport and confirm the strip scrolls horizontally while each
+   focused control remains visible.
+
+Expected: placement changes exactly once at session creation, popovers anchor to
+their own triggers, and the composer writing area does not shift unexpectedly.
+
+- [ ] **Step 10: Commit layout and verification updates**
+
+```bash
+git add src/styles/cave-composer.css \
+  src/styles/cave-chat/activity.css \
+  src/styles/cave-chat/transcript.css \
+  src/components/chat-composer-footer-band.test.ts
+git commit -m "style(chat): finish adaptive context layout"
+```
+
+### Task 4: Prepare the PR-shaped handoff
+
+**Files:**
+- Modify: Bead `cave-qvh18` through `bd`
+
+- [ ] **Step 1: Review the branch diff**
+
+Run:
+
+```bash
+git status --short --branch
+git diff --check origin/main...HEAD
+git diff --stat origin/main...HEAD
+```
+
+Expected: only the approved spec, implementation plan, adaptive chat context
+implementation, related styles, and targeted tests appear; `git diff --check`
+prints nothing.
+
+- [ ] **Step 2: Record verification and lifecycle evidence**
+
+Run:
+
+```bash
+bd update cave-qvh18 --notes "Implemented adaptive chat context controls in managed worktree /Users/buns/Documents/GitHub/OpenCoven/coven-cave/.worktrees/cave-qvh18-adaptive-chat-context on branch docs/cave-qvh18-adaptive-chat-context. Verified targeted chat context/header/Git tests, pnpm typecheck, pnpm lint, pnpm check:tests-wired, pnpm test:app, and responsive new/active/worktree chat behavior."
+```
+
+Expected: `bd` confirms the issue update. Keep the Bead `in_progress` until the
+branch is merged or explicit completion criteria permit closure.
+
+- [ ] **Step 3: Push the branch for protected-PR transport**
+
+Run:
+
+```bash
+git push -u origin docs/cave-qvh18-adaptive-chat-context
+```
+
+Expected: the remote branch is created and local status reports it tracking
+`origin/docs/cave-qvh18-adaptive-chat-context`.
+
+- [ ] **Step 4: Open the pull request**
+
+Run:
+
+```bash
+gh pr create \
+  --base main \
+  --head docs/cave-qvh18-adaptive-chat-context \
+  --title "Improve adaptive chat context controls" \
+  --body "## Summary
+- move active-chat project, worktree, branch, and model controls into the header
+- keep the same independently clickable controls below the new-chat composer
+- preserve worktree and branch visibility, picker safeguards, and narrow-screen access
+
+## Verification
+- targeted chat context/header/Git source tests
+- pnpm typecheck
+- pnpm lint
+- pnpm check:tests-wired
+- pnpm test:app
+- responsive UI pass"
+```
+
+Expected: `gh` prints the new pull-request URL. Do not push directly to `main`.

--- a/docs/superpowers/specs/2026-08-04-adaptive-chat-context-controls-design.md
+++ b/docs/superpowers/specs/2026-08-04-adaptive-chat-context-controls-design.md
@@ -1,0 +1,160 @@
+# Adaptive chat context controls
+
+**Bead:** `cave-qvh18`  
+**Status:** Approved design  
+**Scope:** Chat project, worktree, branch, and model controls
+
+## Problem
+
+Chat currently repeats project, branch, and model context in the composer even
+after a session is active. This gives configuration controls too much visual
+weight, crowds the writing surface, and duplicates context already associated
+with the active session.
+
+The controls still need to remain visible and directly editable. Project access,
+model switching, branch changes, and worktree creation are consequential actions,
+so hiding them in a generic overflow menu would make the interface cleaner at
+the cost of discoverability.
+
+## Decision
+
+Use adaptive placement:
+
+- **Active chat:** render context directly below the title in the top chat row.
+- **New chat:** render the same context controls in a footer attached below the
+  composer, outside the text-entry area.
+- Remove project, worktree, branch, and model controls from the active-chat
+  composer.
+
+The visible order is:
+
+`Project › Worktree · Branch · Model`
+
+Worktree is conditional, but it does not replace branch. When a session is
+rooted in a worktree, both values remain visible because they answer different
+questions: the worktree identifies the checkout and the branch identifies its
+Git ref.
+
+## Interaction model
+
+Each value remains an independent control rather than becoming one combined
+context menu:
+
+- **Project** opens the existing searchable project picker and add-project flow.
+- **Worktree** opens the existing worktree or Git context action appropriate to
+  the current checkout.
+- **Branch** opens the existing branch picker, branch switching, worktree
+  creation, pull-request, and Git-changes actions.
+- **Model** opens the existing runtime and model picker.
+
+The implementation must reuse the existing picker components and handlers.
+Placement changes must not create a second source of truth for selected values
+or duplicate project, model, or Git mutation logic.
+
+Controls with no truthful value are omitted. In particular, worktree is absent
+for a normal checkout and Git controls are absent for a non-repository project.
+
+## Layout
+
+### Active chat
+
+The context row sits below the title and primary session actions, inside the
+existing sticky header. It uses quiet, compact controls so the title remains the
+header's strongest element. The row may share established context-row chrome,
+but interactive values must retain distinct focus and hover states.
+
+The composer contains only message composition and message-adjacent actions. It
+does not render project, worktree, branch, or model controls, and it does not
+reserve empty space for the removed footer cluster.
+
+### New chat
+
+Before a session exists, context remains adjacent to the action it configures.
+The controls render in a true footer below the composer panel, separated from
+the writing area by a hairline. This preserves configuration visibility without
+making the controls appear to be part of the message.
+
+### Narrow screens
+
+The context row stays available on narrow screens. It uses a single-line,
+horizontally scrollable control strip rather than wrapping into a tall header
+or hiding lower-priority values. Keyboard focus must scroll the focused control
+into view through normal browser behavior.
+
+## State and safeguards
+
+Existing safeguards remain authoritative:
+
+- Model switching is disabled while a response is streaming.
+- Project changes continue through the current project-access validation and
+  authorization flow.
+- Branch and worktree actions retain existing Git validation, error reporting,
+  mutation announcements, and worktree handoff behavior.
+- Popover failures remain visible in the popover that initiated the action.
+- Successful mutations continue to use the existing announcer behavior and
+  state refresh paths.
+
+Moving controls must not make a session appear to change context before the
+underlying operation succeeds.
+
+## Accessibility
+
+Every control must:
+
+- expose an accessible name containing its kind and current value;
+- preserve `aria-expanded` and the appropriate popup relationship;
+- use the shared visible focus-ring treatment;
+- return focus to its trigger when its popover closes;
+- retain a text or icon-plus-text distinction so color is never the only
+  channel.
+
+The context strip has a group label such as `Session context` for active chats
+and `New chat context` before launch. Horizontal overflow must remain operable
+with keyboard, pointer, and touch input.
+
+## Error handling
+
+This change introduces no new fallback behavior. Missing context is represented
+by an omitted control, while failed fetches or mutations use the existing
+explicit error surfaces. The UI must not silently substitute the first project,
+a default branch, or a default model when the selected value cannot be
+resolved.
+
+## Testing
+
+Targeted tests must cover:
+
+- active chats render the controls in the top context row and not in the
+  composer;
+- new chats render the controls in the composer footer;
+- controls appear in project, worktree, branch, model order;
+- worktree and branch both render for worktree-backed sessions;
+- each value opens its own existing picker;
+- model switching remains unavailable while streaming;
+- absent worktree and Git values omit only their corresponding controls;
+- accessible names, popup state, and focus-return wiring remain intact;
+- narrow layouts retain every available control in a horizontal strip.
+
+Existing project, runtime/model, branch, worktree, composer, and chat-header
+tests should be updated rather than replaced by broad snapshots.
+
+## Out of scope
+
+- Changing how projects, worktrees, branches, or models are selected or stored.
+- Combining all context into one menu.
+- Changing session launch defaults.
+- Redesigning linked tasks, pull-request affiliation, usage statistics, or
+  other header metadata.
+- Changing the native iOS chat layout.
+
+## Acceptance criteria
+
+1. An active chat shows independently clickable project, worktree when present,
+   branch when present, and model controls in its top context row.
+2. Those controls do not render in the active-chat composer.
+3. A new chat shows the same available controls in a footer outside the text
+   input.
+4. Worktree-backed chats display both worktree and branch.
+5. Existing selection behavior, safeguards, errors, announcements, and
+   accessibility semantics are preserved.
+6. The context strip remains usable without hiding values at narrow widths.

--- a/docs/superpowers/specs/2026-08-04-adaptive-chat-context-controls-design.md
+++ b/docs/superpowers/specs/2026-08-04-adaptive-chat-context-controls-design.md
@@ -1,7 +1,7 @@
 # Adaptive chat context controls
 
-**Bead:** `cave-qvh18`  
-**Status:** Approved design  
+**Bead:** `cave-qvh18`
+**Status:** Approved design
 **Scope:** Chat project, worktree, branch, and model controls
 
 ## Problem

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -344,13 +344,18 @@ assert.match(
   "shared context controls should remain one horizontally scrollable line",
 );
 assert.match(
+  css,
+  /\.cave-context-controls \{[^}]*padding-block: calc\(var\(--ring-offset\) \+ var\(--ring-width\)\);/,
+  "context controls need padding-block so overflow-y clip preserves the full focus-ring outline",
+);
+assert.match(
   activityCss,
   /\.cave-chat-header-context \{[\s\S]*?min-width: 0;[\s\S]*?overflow: hidden;/,
   "the active header should contain context overflow without widening the pane",
 );
 assert.match(
   transcriptCss,
-  /@media \(max-width: 767px\)[\s\S]*?\.cave-chat-header-context[\s\S]*?\.cave-context-chip \{[\s\S]*?min-height: var\(--touch-target\);/,
+  /@media \(max-width: 767px\)[\s\S]*?\.cave-chat-header-context[\s\S]*?\.cave-context-chip \{[^}]*min-height: var\(--touch-target\);/,
   "mobile header context controls should retain touch targets",
 );
 

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -337,4 +337,21 @@ assert.match(
   "grouped choice panels wrap inside the popover rather than the composer footer",
 );
 
+// ── Adaptive context overflow + header containment + mobile touch targets ────
+assert.match(
+  css,
+  /\.cave-context-controls \{[\s\S]*?display: flex;[\s\S]*?overflow-x: auto;[\s\S]*?white-space: nowrap;/,
+  "shared context controls should remain one horizontally scrollable line",
+);
+assert.match(
+  activityCss,
+  /\.cave-chat-header-context \{[\s\S]*?min-width: 0;[\s\S]*?overflow: hidden;/,
+  "the active header should contain context overflow without widening the pane",
+);
+assert.match(
+  transcriptCss,
+  /@media \(max-width: 767px\)[\s\S]*?\.cave-chat-header-context[\s\S]*?\.cave-context-chip \{[\s\S]*?min-height: var\(--touch-target\);/,
+  "mobile header context controls should retain touch targets",
+);
+
 console.log("chat-composer-footer-band.test.ts: ok");

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -60,10 +60,22 @@ assert.match(
   /className="cave-composer-control-row"[\s\S]*?className="cave-composer-footer-band"/,
   "the footer band renders after the composer controls, inside the panel",
 );
+// chatContextControls is constructed once with all runtime/model picker props preserved
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?<\/div>\s*\n\s*\{linkedContextRow\}[\s\S]*?<div className="cave-chat-followups">[\s\S]*?<FollowUpCards/,
-  "the band leads with context and linked work, then carries the latest assistant options",
+  /const chatContextControls = \([\s\S]*?<ComposerContextChips[\s\S]*?runtime=\{modelHarness\}[\s\S]*?modelValue=\{composerModelValue\}[\s\S]*?onPickRuntime=\{handleSelectRuntime\}[\s\S]*?onPickModel=\{handleSelectModel\}/,
+  "chatContextControls is constructed once as ComposerContextChips with preserved runtime/model picker props",
+);
+// New chats (inlineComposer): cluster mounts in footer band; active chats: session header
+assert.match(
+  source,
+  /className="cave-composer-footer-band">[\s\S]*?\{inlineComposer \? \([\s\S]*?<div className="cave-composer-footer-band__cluster">[\s\S]*?\{chatContextControls\}[\s\S]*?<\/div>[\s\S]*?\) : null\}[\s\S]*?\{linkedContextRow\}[\s\S]*?<FollowUpCards/,
+  "the band conditionally mounts the context cluster (inlineComposer only); linked work and follow-ups always follow",
+);
+assert.match(
+  source,
+  /cave-chat-header-context">\{chatContextControls\}/,
+  "active chat mounts the context controls in the session header (.cave-chat-header-context)",
 );
 assert.doesNotMatch(
   source.match(/<footer[\s\S]*?className="cave-composer-shell"/)?.[0] ?? "",

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 // Source pins for the chat composer's context grammar after the 2026-07-22
 // split (cave-g21f) and the adaptive-placement refactor: context chips
-// (ComposerContextChips — project · model · branch) are constructed once as
+// (ComposerContextChips — project · worktree · branch · model) are constructed once as
 // chatContextControls and placed adaptively: footer-band cluster for new chats
 // (inlineComposer), session-header div for active chats (!inlineComposer).
 // The linked-work strip always lives in the footer band regardless of
@@ -84,7 +84,7 @@ assert.doesNotMatch(
   "latest assistant options no longer float above the composer shell",
 );
 
-// ── Split chips (cave-g21f): project · model · branch as separate controls ──
+// ── Split chips (cave-g21f): project · worktree · branch · model as separate controls ──
 assert.match(
   source,
   /<ComposerContextChips\s*\n\s*projects=\{projects\}\s*\n\s*projectValue=\{resolvedProjectId\}\s*\n\s*onProjectChange=\{setProjectIdDraft\}/,

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -1,11 +1,12 @@
 // @ts-nocheck
 // Source pins for the chat composer's context grammar after the 2026-07-22
-// split (cave-g21f): the footer band carries project · model · branch as
-// three separate chips (ComposerContextChips) on the left — each opening its
-// own picker — and the linked-work strip (tasks · GitHub · link/create) on
-// the right. The grouped ComposerActionsMenu keeps its four groups. The
-// write surface stays minimal: textarea, then attach · voice · grouped menu ·
-// circular send.
+// split (cave-g21f) and the adaptive-placement refactor: context chips
+// (ComposerContextChips — project · model · branch) are constructed once as
+// chatContextControls and placed adaptively: footer-band cluster for new chats
+// (inlineComposer), session-header div for active chats (!inlineComposer).
+// The linked-work strip always lives in the footer band regardless of
+// placement. The grouped ComposerActionsMenu keeps its four groups. The write
+// surface stays minimal: textarea, then attach · voice · grouped menu · send.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -50,7 +51,7 @@ assert.doesNotMatch(
   "the standalone attach button is gone from the control row (it lives in the + menu now)",
 );
 assert.doesNotMatch(controlRow, /<ComposerPlusMenu/, "the composer actions should no longer expose the legacy plus menu");
-assert.doesNotMatch(controlRow, /<ComposerContextChips/, "the context chips live in the footer band, not the control row");
+assert.doesNotMatch(controlRow, /<ComposerContextChips/, "the context chips are placed adaptively (footer band for inlineComposer, session header for !inlineComposer) — never in the control row");
 assert.doesNotMatch(controlRow, /<ComposerOptionsMenu/, "the composer actions should no longer expose the legacy options menu");
 assert.doesNotMatch(source, /<ComposerLinkedWorkActions\b/, "ChatView should not mount the menu-row linked-work actions directly — the band uses the chip strip");
 
@@ -167,13 +168,27 @@ assert.match(
   "runtime and branch pickers honor the caller's preferred vertical side",
 );
 
-// ── The header no longer hosts the linked-context strip ─────────────────────
+// ── Header: MetaLine + adaptive context controls (never linkedContextRow) ───
 const header = source.match(/<header className="cave-chat-linear-header[\s\S]*?<\/header>/)?.[0] ?? "";
 assert.ok(header, "chat header is present");
 assert.doesNotMatch(
   header,
   /linkedContextRow/,
-  "the header renders MetaLine only — the linked-context strip stays in the band",
+  "the header never carries the linked-context strip (that always stays in the band)",
+);
+// For active chats (!inlineComposer) the header hosts chatContextControls in
+// .cave-chat-header-context; for new chats they move to the footer band.
+assert.match(
+  source,
+  /!inlineComposer[\s\S]{0,200}cave-chat-header-context[\s\S]{0,200}\{chatContextControls\}/,
+  "active chats (!inlineComposer) mount context controls in .cave-chat-header-context inside the header",
+);
+// Interactive controls must not be nested inside MetaLine's live region —
+// the context div is placed *after* </MetaLine>, not inside it.
+assert.doesNotMatch(
+  source.match(/<MetaLine(?![A-Za-z])[\s\S]*?<\/MetaLine>/)?.[0] ?? "",
+  /chatContextControls/,
+  "chatContextControls is not nested inside MetaLine's live region",
 );
 
 // ── Band chrome: attached underside strip, one tone deeper ──────────────────

--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -114,10 +114,29 @@ assert.doesNotMatch(
 );
 
 // ── Each chip opens its own picker; the hub popover is gone ─────────────────
+// Grammar: Project > Worktree (conditional) > Branch > Model in control order
 assert.match(
   pill,
-  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?aria-label=\{`Model: \$\{modelLabel\} — change model`\}[\s\S]*?aria-label=\{`Branch: \$\{context\.branch\} — switch branch or create a worktree`\}/,
-  "the chips read Project / Model / Branch as separately labelled controls in order",
+  /aria-label=\{`Project: \$\{projectLabel\} — change project`\}[\s\S]*?aria-label=\{`Worktree: \$\{context\.worktree\} — open worktree actions`\}[\s\S]*?aria-label=\{`Branch: \$\{context\.branch\} — switch branch or create a worktree`\}[\s\S]*?aria-label=\{`Model: \$\{modelLabel\} — change model`\}/,
+  "the chips read Project / Worktree / Branch / Model as separately labelled controls in order",
+);
+assert.match(pill, /const worktreeRef = useRef/, "worktree has its own independent ref anchor");
+assert.match(pill, /const branchRef = useRef/, "branch has its own independent ref anchor");
+assert.match(pill, /name="ph:tree-structure"/, "the worktree chip uses the tree-structure icon");
+assert.doesNotMatch(
+  pill,
+  /aria-label=\{`Branch:[\s\S]{0,200}?context\.worktree[\s\S]{0,50}?`\}/,
+  "worktree is no longer folded into the branch chip's accessible name",
+);
+assert.match(
+  pill,
+  /open=\{menu === "worktree"\}[\s\S]*?anchorRef=\{worktreeRef\}[\s\S]*?open=\{menu === "branch"\}[\s\S]*?anchorRef=\{branchRef\}/,
+  "worktree and branch each have a separate GitBranchMenuPopover with its own open state and anchor",
+);
+assert.match(
+  pill,
+  /ComposerContextView\s*=\s*null\s*\|[\s\S]*?"worktree"/,
+  "ComposerContextView supports the worktree picker state",
 );
 assert.match(pill, /context\.hasGit \? \(/, "the branch chip elides for git-less composers (home, no-project chats)");
 assert.doesNotMatch(

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -72,6 +72,20 @@ assert.match(
   /inlineComposer[\s\S]{0,200}cave-composer-footer-band__cluster[\s\S]{0,200}\{chatContextControls\}/,
   "the footer band cluster carries chatContextControls only when inlineComposer",
 );
+// The context section label flips with placement: "New chat context" when the
+// composer is inline (new-chat), "Session context" when docked to an active chat.
+assert.match(
+  source,
+  /ariaLabel=\{inlineComposer \? "New chat context" : "Session context"\}/,
+  'chatContextControls passes ariaLabel={inlineComposer ? "New chat context" : "Session context"}',
+);
+// The context div must be immediately after </MetaLine> — interactive controls
+// must not be nested inside MetaLine's live region.
+assert.match(
+  source,
+  /<\/MetaLine>\s*\{!inlineComposer \? \(\s*<div className="cave-chat-header-context">\{chatContextControls\}<\/div>/,
+  ".cave-chat-header-context appears immediately after </MetaLine>, outside the live region",
+);
 assert.match(
   source,
   /!inlineComposer[\s\S]{0,200}cave-chat-header-context[\s\S]{0,200}\{chatContextControls\}/,

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -67,6 +67,11 @@ assert.match(
   /const chatContextControls = \([\s\S]{0,50}\n\s*<ComposerContextChips/,
   "ComposerContextChips is constructed once as chatContextControls",
 );
+assert.doesNotMatch(
+  source,
+  /<MetaLine[\s>][\s\S]*?<ComposerContextChips/,
+  "the shared node should prevent duplicate picker state in the header",
+);
 assert.match(
   source,
   /inlineComposer[\s\S]{0,200}cave-composer-footer-band__cluster[\s\S]{0,200}\{chatContextControls\}/,

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -59,12 +59,28 @@ assert.doesNotMatch(
   "ChatView does not mount linked-work actions directly",
 );
 
-// The 2026-07-21 "both" reconciliation: the footer band came back (context
-// pill + linked-work chip strip) alongside the grouped composer menu.
+// Context controls are constructed once as chatContextControls and placed
+// adaptively — new-chat footer (inlineComposer) or active-chat header (!inlineComposer).
+// The linkedContextRow always rides the footer band regardless of placement.
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips[\s\S]*?\{linkedContextRow\}/,
-  "the footer band carries the context chips and the linked-context strip",
+  /const chatContextControls = \([\s\S]{0,50}\n\s*<ComposerContextChips/,
+  "ComposerContextChips is constructed once as chatContextControls",
+);
+assert.match(
+  source,
+  /inlineComposer[\s\S]{0,200}cave-composer-footer-band__cluster[\s\S]{0,200}\{chatContextControls\}/,
+  "the footer band cluster carries chatContextControls only when inlineComposer",
+);
+assert.match(
+  source,
+  /!inlineComposer[\s\S]{0,200}cave-chat-header-context[\s\S]{0,200}\{chatContextControls\}/,
+  "the active-chat header carries chatContextControls after MetaLine",
+);
+assert.match(
+  source,
+  /className="cave-composer-footer-band"[\s\S]*?\{linkedContextRow\}/,
+  "the footer band always carries the linked-context strip",
 );
 
 assert.match(

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -179,17 +179,28 @@ assert.match(
   "a send waits for the runtime binding write instead of launching the previous harness",
 );
 assert.doesNotMatch(source, /<ComposerPlusMenu/, "legacy plus-menu composition should be gone");
-// "Both" reconciliation (2026-07-21): the context pill returned with the
-// footer band — but only there, never back in the control row.
+// Context controls are constructed once as chatContextControls and placed
+// adaptively — footer for new chats (inlineComposer), header for active chats.
+// This avoids duplicated picker state while the control row stays context-free.
 assert.equal(
   source.match(/<ComposerContextChips/g)?.length,
   1,
-  "the context chips mount exactly once — in the footer band",
+  "ComposerContextChips is constructed exactly once (as chatContextControls)",
 );
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips/,
-  "the context chips live in the footer band, not the control row",
+  /const chatContextControls = \([\s\S]{0,50}\n\s*<ComposerContextChips/,
+  "chatContextControls wraps the single ComposerContextChips construction",
+);
+assert.match(
+  source,
+  /inlineComposer[\s\S]{0,200}cave-composer-footer-band__cluster[\s\S]{0,200}\{chatContextControls\}/,
+  "the context controls ride the footer band only for new-chat (inlineComposer)",
+);
+assert.match(
+  source,
+  /!inlineComposer[\s\S]{0,200}cave-chat-header-context[\s\S]{0,200}\{chatContextControls\}/,
+  "the context controls ride the header for active chats (!inlineComposer)",
 );
 assert.doesNotMatch(source, /<ComposerOptionsMenu/, "legacy options-menu composition should be gone");
 

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -154,12 +154,17 @@ assert.match(
   /context=\{\{[\s\S]*linkedWork=\{\{[\s\S]*improve=\{\{[\s\S]*response=\{\{/,
   "the grouped menu receives Context, Linked Work, Improve, and Response contracts in visual order",
 );
-// The context chips (project · model · branch) live in the footer band below
-// the controls (2026-07-21 wide-column pass) — not in the utility row.
+// Context controls are placed adaptively via chatContextControls — new-chat
+// footer when inlineComposer, active-chat header when not. Not in the utility row.
 assert.match(
   source,
-  /className="cave-composer-footer-band">\s*\n\s*<div className="cave-composer-footer-band__cluster">\s*\n\s*<ComposerContextChips/,
-  "the context chips anchor the footer band",
+  /const chatContextControls = \([\s\S]{0,50}\n\s*<ComposerContextChips/,
+  "chatContextControls is the single ComposerContextChips construction",
+);
+assert.match(
+  source,
+  /inlineComposer[\s\S]{0,200}cave-composer-footer-band__cluster[\s\S]{0,200}\{chatContextControls\}/,
+  "new-chat footer carries chatContextControls when inlineComposer",
 );
 assert.doesNotMatch(
   source,
@@ -177,12 +182,11 @@ assert.match(
   "the grouped Response section carries Access, Model, and only selected-model capability controls with prompt guidance labelled",
 );
 assert.doesNotMatch(source, /<ComposerPlusMenu/, "legacy plus-menu composition should be gone");
-// "Both" reconciliation (2026-07-21): the context chips ride the footer
-// band — but only there, never back in the control row.
+// "Both" reconciliation updated: context chips still construct exactly once.
 assert.equal(
   source.match(/<ComposerContextChips/g)?.length,
   1,
-  "the context chips mount exactly once — in the footer band",
+  "the context chips construct exactly once — as chatContextControls",
 );
 assert.doesNotMatch(source, /<ComposerOptionsMenu/, "legacy options-menu composition should be gone");
 assert.doesNotMatch(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -6599,9 +6599,39 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   // renders inline there and docked everywhere else. Extracted to a variable
   // rather than duplicated: a second composer would mean two textareas sharing
   // nothing, with draft, project, model, branch and enhance state forked.
+  // Context controls follow the same pattern: constructed once as
+  // chatContextControls and placed adaptively — footer cluster for new chats
+  // (inlineComposer) and session header for active chats (!inlineComposer)
+  // so picker state is never duplicated.
   const inlineComposer = sessionId === null;
   const composerPopoverPlacement = inlineComposer ? "bottom-start" : undefined;
   const composerAutocompletePosition = inlineComposer ? "top-full mt-2" : "bottom-full mb-2";
+  const chatContextControls = (
+    <ComposerContextChips
+      projects={projects}
+      projectValue={resolvedProjectId}
+      onProjectChange={setProjectIdDraft}
+      familiarId={familiar.id ?? null}
+      createProject={createProject}
+      createProjectOrThrow={createProjectOrThrow}
+      runtime={modelHarness}
+      modelValue={composerModelValue}
+      modelOptions={composerModelOptions}
+      onPickRuntime={handleSelectRuntime}
+      onPickModel={handleSelectModel}
+      promotableModel={promotableModel}
+      onPromoteModelToDefault={handlePromoteModelToDefault}
+      modelDisabled={busy}
+      projectRoot={activeProjectRoot}
+      onOpenUrl={onOpenUrl}
+      registerCurrentRoot={setupCandidateRoot ?? undefined}
+      onRegisterCurrentRoot={
+        setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
+      }
+      popoverPlacement={composerPopoverPlacement}
+      ariaLabel={inlineComposer ? "New chat context" : "Session context"}
+    />
+  );
   const composerNode = (
         <footer
           className="cave-composer-dock"
@@ -7141,36 +7171,15 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   </div>
                 </div>
               </div>
-              {/* Footer band — the darker strip attached to the panel's
-                  underside carries context and linked work first, then the
-                  latest assistant options. Suggestions stay hidden while a
-                  response streams so stale actions cannot be activated. */}
+              {/* Footer band — carries linked work and latest assistant options.
+                  Context controls ride here only for new chats (inlineComposer);
+                  active chats show them in the session header instead. */}
               <div className="cave-composer-footer-band">
-                <div className="cave-composer-footer-band__cluster">
-                  <ComposerContextChips
-                    projects={projects}
-                    projectValue={resolvedProjectId}
-                    onProjectChange={setProjectIdDraft}
-                    familiarId={familiar.id ?? null}
-                    createProject={createProject}
-                    createProjectOrThrow={createProjectOrThrow}
-                    runtime={modelHarness}
-                    modelValue={composerModelValue}
-                    modelOptions={composerModelOptions}
-                    onPickRuntime={handleSelectRuntime}
-                    onPickModel={handleSelectModel}
-                    promotableModel={promotableModel}
-                    onPromoteModelToDefault={handlePromoteModelToDefault}
-                    modelDisabled={busy}
-                    projectRoot={activeProjectRoot}
-                    onOpenUrl={onOpenUrl}
-                    registerCurrentRoot={setupCandidateRoot ?? undefined}
-                    onRegisterCurrentRoot={
-                      setupCandidateRoot ? () => setProjectSetupRoot(setupCandidateRoot) : undefined
-                    }
-                    popoverPlacement={composerPopoverPlacement}
-                  />
-                </div>
+                {inlineComposer ? (
+                  <div className="cave-composer-footer-band__cluster">
+                    {chatContextControls}
+                  </div>
+                ) : null}
                 {linkedContextRow}
                 {followUp.suggestions.length > 0 && !busy ? (
                   <div className="cave-chat-followups">
@@ -7324,6 +7333,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             />
           </div>
         </MetaLine>
+        {!inlineComposer ? (
+          <div className="cave-chat-header-context">{chatContextControls}</div>
+        ) : null}
       </header>
       {/* Chat.dc.html 2a: find slides open as a band under the title row —
           controls over a scrollable list of every hit. The list is the point:

--- a/src/components/composer-actions-menu.test.ts
+++ b/src/components/composer-actions-menu.test.ts
@@ -134,7 +134,7 @@ assert.match(styles, /\.composer-actions__panel[\s\S]*overscroll-behavior: conta
 
 assert.match(
   context,
-  /export\s+type\s+ComposerContextView\s*=\s*null\s*\|\s*"project"\s*\|\s*"model"\s*\|\s*"branch"/,
+  /export\s+type\s+ComposerContextView\s*=\s*null\s*\|\s*"project"\s*\|\s*"model"\s*\|\s*"branch"\s*\|\s*"worktree"/,
 );
 assert.match(context, /export\s+type\s+ComposerContextProps\s*=\s*\{/);
 assert.match(context, /export\s+function\s+useComposerContextActions/);

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -77,6 +77,7 @@ export type ComposerContextProps = {
    *  prefer opening below. Docked composers keep each picker's existing side. */
   popoverPlacement?: "bottom-start" | "top-start";
   disabled?: boolean;
+  ariaLabel?: string;
 };
 
 export type ComposerContextController = ReturnType<typeof useComposerContextActions>;
@@ -241,7 +242,7 @@ export function ComposerContextChips(props: ComposerContextProps) {
   const modelLabel = context.modelLabel ?? context.runtimeName;
 
   return (
-    <>
+    <div className="cave-context-controls" role="group" aria-label={props.ariaLabel ?? "Chat context"}>
       <button
         ref={projectRef}
         type="button"
@@ -387,6 +388,6 @@ export function ComposerContextChips(props: ComposerContextProps) {
         </span>
       ) : null}
       {context.canAddProject ? context.addFlow.addProjectModal : null}
-    </>
+    </div>
   );
 }

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -32,7 +32,7 @@ import {
   type RuntimeModelOption,
 } from "@/lib/runtime-models";
 
-export type ComposerContextView = null | "project" | "model" | "branch";
+export type ComposerContextView = null | "project" | "model" | "branch" | "worktree";
 
 export type ComposerContextProps = {
   projects: CaveProject[];
@@ -209,8 +209,8 @@ export function ComposerContextPickers({
         onPromoteModelToDefault={context.config.onPromoteModelToDefault}
       />
       <GitBranchMenuPopover
-        open={view === "branch"}
-        onOpenChange={(open) => onViewChange(open ? "branch" : null)}
+        open={view === "branch" || view === "worktree"}
+        onOpenChange={(open) => onViewChange(open ? view : null)}
         anchorRef={anchorRef}
         placement={context.config.popoverPlacement}
         projectRoot={context.root}
@@ -230,8 +230,9 @@ export function ComposerContextPickers({
 export function ComposerContextChips(props: ComposerContextProps) {
   const [menu, setMenu] = useState<ComposerContextView>(null);
   const projectRef = useRef<HTMLButtonElement | null>(null);
-  const modelRef = useRef<HTMLButtonElement | null>(null);
+  const worktreeRef = useRef<HTMLButtonElement | null>(null);
   const branchRef = useRef<HTMLButtonElement | null>(null);
+  const modelRef = useRef<HTMLButtonElement | null>(null);
   const context = useComposerContextActions(props);
   const projectLabel = context.selectedProjectLabel;
   const projectAccess = context.selectedProject?.access
@@ -271,6 +272,47 @@ export function ComposerContextChips(props: ComposerContextProps) {
         <span className="cave-context-chip__text">{projectLabel}</span>
         <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
       </button>
+      {context.hasGit && context.worktree ? (
+        <button
+          ref={worktreeRef}
+          type="button"
+          className="cave-context-chip focus-ring"
+          disabled={props.disabled}
+          aria-haspopup="menu"
+          aria-expanded={menu === "worktree"}
+          aria-label={`Worktree: ${context.worktree} — open worktree actions`}
+          title={`Worktree: ${context.worktree} · ${context.dirtyLabel}`}
+          onClick={() => setMenu((c) => (c === "worktree" ? null : "worktree"))}
+        >
+          <span className="cave-context-chip__lead" aria-hidden>
+            <Icon name="ph:tree-structure" width={13} aria-hidden />
+          </span>
+          <span className="cave-context-chip__text">{context.worktree}</span>
+          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+        </button>
+      ) : null}
+      {context.hasGit ? (
+        <button
+          ref={branchRef}
+          type="button"
+          className="cave-context-chip focus-ring"
+          disabled={props.disabled}
+          aria-haspopup="menu"
+          aria-expanded={menu === "branch"}
+          aria-label={`Branch: ${context.branch} — switch branch or create a worktree`}
+          title={`Branch: ${context.branch} · ${context.dirtyLabel}`}
+          onClick={() => setMenu((c) => (c === "branch" ? null : "branch"))}
+        >
+          <span className="cave-context-chip__lead" aria-hidden>
+            <Icon name="ph:git-branch" width={13} aria-hidden />
+          </span>
+          <span className="cave-context-chip__text">
+            {context.branch}
+            {context.count > 0 ? ` · +${context.count}` : ""}
+          </span>
+          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
+        </button>
+      ) : null}
       <button
         ref={modelRef}
         type="button"
@@ -288,29 +330,6 @@ export function ComposerContextChips(props: ComposerContextProps) {
         <span className="cave-context-chip__text">{modelLabel}</span>
         <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
       </button>
-      {context.hasGit ? (
-        <button
-          ref={branchRef}
-          type="button"
-          className="cave-context-chip focus-ring"
-          disabled={props.disabled}
-          aria-haspopup="menu"
-          aria-expanded={menu === "branch"}
-          aria-label={`Branch: ${context.branch} — switch branch or create a worktree`}
-          title={`Branch: ${context.branch} · ${context.dirtyLabel}${context.worktree ? ` · Worktree: ${context.worktree}` : ""}`}
-          onClick={() => setMenu((c) => (c === "branch" ? null : "branch"))}
-        >
-          <span className="cave-context-chip__lead" aria-hidden>
-            <Icon name="ph:git-branch" width={13} aria-hidden />
-          </span>
-          <span className="cave-context-chip__text">
-            {context.branch}
-            {context.count > 0 ? ` · +${context.count}` : ""}
-            {context.worktree ? ` · ${context.worktree}` : ""}
-          </span>
-          <Icon name="ph:caret-down" width={9} aria-hidden className="cave-context-chip__chevron" />
-        </button>
-      ) : null}
 
       <ProjectPickerPopover
         open={menu === "project"}
@@ -340,6 +359,17 @@ export function ComposerContextChips(props: ComposerContextProps) {
         promotableModel={context.config.promotableModel ?? null}
         onPromoteModelToDefault={context.config.onPromoteModelToDefault}
       />
+      {context.hasGit && context.worktree ? (
+        <GitBranchMenuPopover
+          open={menu === "worktree"}
+          onOpenChange={(open) => setMenu(open ? "worktree" : null)}
+          anchorRef={worktreeRef}
+          placement={context.config.popoverPlacement}
+          projectRoot={context.root}
+          onSwitched={context.reload}
+          {...branchPopoverExtras(context)}
+        />
+      ) : null}
       {context.hasGit ? (
         <GitBranchMenuPopover
           open={menu === "branch"}

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -2,15 +2,15 @@
 
 import "@/styles/cave-composer.css";
 
-// ComposerContextChips — the composer footer's context controls (cave-g21f):
-// project, model, and (for repo-rooted chats) branch ride as separate,
+// ComposerContextChips — adaptive context controls (cave-g21f):
+// Placed in the new-chat composer footer and active-chat header. Project,
+// model, and (for repo-rooted chats) worktree/branch ride as independent,
 // individually labelled chips. Each opens its own picker popover anchored to
 // the chip itself (ProjectPickerPopover, ComposerRuntimePopover,
-// GitBranchMenuPopover), so every existing flow — project switching +
-// add-project, runtime/model switching, branch switch / new worktree / PR
-// open / git-changes drill-through — stays one click away. This replaced the
-// combined "Project · Model · branch" pill and its hub popover (2026-07-22)
-// on both the chat and home composers.
+// GitBranchMenuPopover), so every workflow — project switching + add-project,
+// runtime/model switching, branch switch / new worktree / PR open / git-changes
+// drill-through — stays one click away. This replaced the combined
+// "Project · Model · branch" pill and its hub popover (2026-07-22).
 
 import { useMemo, useRef, useState, type RefObject } from "react";
 import { Icon } from "@/lib/icon";

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -48,6 +48,17 @@ assert.match(
   /window\.dispatchEvent\(new CustomEvent\("cave:changes-open"\)\)/,
   "the pill keeps the Git-changes drill-through",
 );
+// ── Worktree is a separate chip; branch label no longer folds it in ──────────
+assert.match(
+  pill,
+  /aria-label=\{`Worktree: \$\{context\.worktree\} — open worktree actions`\}/,
+  "the worktree chip carries its own dedicated accessible name",
+);
+assert.doesNotMatch(
+  pill,
+  /name="ph:git-branch"[\s\S]{0,400}?context\.worktree/,
+  "worktree no longer appears inside the branch chip's text content",
+);
 
 // ── Git-less chats render nothing — the chip gates on a loaded repo status ──
 assert.match(

--- a/src/components/composer-runtime-chip.test.ts
+++ b/src/components/composer-runtime-chip.test.ts
@@ -83,8 +83,8 @@ assert.match(
 );
 assert.match(
   chatView,
-  /className="cave-composer-footer-band[^"]*"[^>]*>[\s\S]*?<ComposerContextChips/,
-  "the pill anchors the composer footer band — always visible, session or not (2026-07-21 wide-column pass moved it down from the utility row)",
+  /const chatContextControls = \([\s\S]*?<ComposerContextChips[\s\S]*?runtime=\{modelHarness\}[\s\S]*?onPickRuntime=\{handleSelectRuntime\}[\s\S]*?onPickModel=\{handleSelectModel\}/,
+  "chatContextControls is constructed once with live runtime/model state; new chat (inlineComposer) mounts it in the footer cluster, active chat in cave-chat-header-context",
 );
 
 // ── Runtime switching is real: familiar-level config, optimistic + refetch ──

--- a/src/styles/cave-chat/activity.css
+++ b/src/styles/cave-chat/activity.css
@@ -860,6 +860,20 @@ details[open] > .cave-tool-summary::before {
   cursor: default;
 }
 
+/* Active-chat header context strip: sits beneath MetaLine and contains the
+   adaptive context controls without widening the pane or nesting in the
+   live region. */
+.cave-chat-header-context {
+  min-width: 0;
+  overflow: hidden;
+  padding-inline-start: calc(var(--space-6) + var(--space-2));
+}
+
+.cave-chat-header-context .cave-context-chip {
+  height: var(--space-6);
+  font-size: var(--text-xs);
+}
+
 .cave-chat-session-actions {
   display: inline-flex;
   min-width: 0;

--- a/src/styles/cave-chat/transcript.css
+++ b/src/styles/cave-chat/transcript.css
@@ -614,6 +614,16 @@
     display: none;
   }
 
+  /* Keep the header context strip visible on mobile with full touch targets. */
+  .cave-chat-header-context {
+    display: block;
+    padding-inline-start: 0;
+  }
+
+  .cave-chat-header-context .cave-context-chip {
+    min-height: var(--touch-target);
+  }
+
   .cave-mobile-header-identity {
     position: relative;
     display: flex;

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -1081,6 +1081,25 @@
   opacity: 0.7;
 }
 
+/* Shared adaptive context controls: a single horizontally scrollable row for
+   project · worktree · branch · model chips in both footer-band and header. */
+.cave-context-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  white-space: nowrap;
+  scrollbar-width: thin;
+  overscroll-behavior-inline: contain;
+}
+
+.cave-context-controls > .cave-context-chip {
+  flex: 0 0 auto;
+}
+
 /* Circular 32px send: accent outline on transparent at rest; ~18% accent tint
    once the draft is non-empty; the busy variant keeps cancel's red ✕ in the
    same circle. */

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -1091,6 +1091,7 @@
   max-width: 100%;
   overflow-x: auto;
   overflow-y: hidden;
+  padding-block: calc(var(--ring-offset) + var(--ring-width));
   white-space: nowrap;
   scrollbar-width: thin;
   overscroll-behavior-inline: contain;

--- a/src/styles/cave-composer.css
+++ b/src/styles/cave-composer.css
@@ -1016,9 +1016,9 @@
   .composer-actions__icon--live { animation: none; }
 }
 
-/* Footer context chips (cave-g21f) — project · model · branch ride as
-   separate quiet controls in the footer band; each opens its own picker
-   anchored to the chip. Shared by the chat and home composers. */
+/* Shared adaptive context controls (cave-g21f): project · worktree · branch · model
+   appear as independent picker chips in new-chat footer band and active-chat header;
+   each opens its own picker anchored to the chip. */
 .cave-composer-footer-band__cluster {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- move active-chat project, worktree, branch, and model controls into the header
- keep the same independently clickable controls below the new-chat composer
- preserve worktree and branch visibility, picker safeguards, focus treatment, and narrow-screen access

## Verification
- targeted chat context/header/Git source tests
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:app` (1082 test files)
- `pnpm build`
- responsive Playwright UI pass at desktop and 430px
- whole-branch code review approved

Bead: `cave-qvh18`