### PR TITLE
test: close the two sidebar-test gaps left after #4365

### DIFF
--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -7,21 +7,19 @@ const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatRouter = readFileSync(new URL("./chat-router.tsx", import.meta.url), "utf8");
 // sidebar-minimal.css is only an import facade — the rules live in the modules
-// beside it, so read those too (the same set sidebar-minimal.test.ts reads).
-// Without them these assertions run against a file of @import lines and the
-// styling hooks below can never be found.
-const sidebarStyleModules = [
-  "shell-chrome.css",
-  "section-tabs.css",
-  "navigation-recents.css",
-  "familiars.css",
-  "activity-rail.css",
-];
+// it imports, so without them these assertions run against a file of @import
+// lines and the styling hooks below can never be found. The module list is
+// derived from the facade itself (as css-module-order.test.ts does) rather than
+// hardcoded: a hardcoded list goes stale the next time a module is added, which
+// is exactly how this test started passing over nothing.
+const sidebarStylesRoot = new URL("../styles/", import.meta.url);
+const sidebarFacade = readFileSync(new URL("sidebar-minimal.css", sidebarStylesRoot), "utf8");
 const styles = [
-  readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8"),
-  ...sidebarStyleModules.map((file) =>
-    readFileSync(new URL(`../styles/sidebar-minimal/${file}`, import.meta.url), "utf8"),
-  ),
+  sidebarFacade,
+  ...[...sidebarFacade.matchAll(/^@import\s+"([^"]+)";/gm)]
+    .map((match) => match[1])
+    .filter((specifier) => specifier.startsWith("."))
+    .map((specifier) => readFileSync(new URL(specifier, sidebarStylesRoot), "utf8")),
 ].join("\n");
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 

--- a/src/components/sidebar-familiar-filter.test.ts
+++ b/src/components/sidebar-familiar-filter.test.ts
@@ -6,7 +6,23 @@ const sidebar = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), 
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 const chatSurface = readFileSync(new URL("./chat-surface.tsx", import.meta.url), "utf8");
 const chatRouter = readFileSync(new URL("./chat-router.tsx", import.meta.url), "utf8");
-const styles = readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8");
+// sidebar-minimal.css is only an import facade — the rules live in the modules
+// beside it, so read those too (the same set sidebar-minimal.test.ts reads).
+// Without them these assertions run against a file of @import lines and the
+// styling hooks below can never be found.
+const sidebarStyleModules = [
+  "shell-chrome.css",
+  "section-tabs.css",
+  "navigation-recents.css",
+  "familiars.css",
+  "activity-rail.css",
+];
+const styles = [
+  readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8"),
+  ...sidebarStyleModules.map((file) =>
+    readFileSync(new URL(`../styles/sidebar-minimal/${file}`, import.meta.url), "utf8"),
+  ),
+].join("\n");
 const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "utf8");
 
 for (const [name, source] of [

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -79,9 +79,11 @@ assert.match(source, /role="tabpanel"[\s\S]*?aria-labelledby=\{`nav-section-tab-
 // them. Its section-heading half is dead — nothing emits sidebar-section*
 // anymore — but the recent-activity half is live: RecentActivityRollup still
 // renders in the Code section, and the 56px rail has no room for it.
+// Tolerant of the group's ordering: the dead .sidebar-section-label half should
+// eventually be deleted from this rule, and that cleanup must not fail here.
 assert.match(
   styles,
-  /\.shell-nav--rail \.recent-activity \{\s*display: none;/,
+  /\.shell-nav--rail \.recent-activity[^{]*\{[^}]*display:\s*none/,
   "the icon rail hides the recent-activity list while retaining destination icons",
 );
 

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -75,6 +75,15 @@ assert.match(source, /navItemsForSection\(section\)\.map/, "the active tab filte
 assert.match(source, /sectionRooms\.map\(\(room\) =>/, "dynamic role-surface rooms follow the active section");
 assert.match(source, /itemSelector: "\.sidebar-folder-row"/, "visible destinations share one roving keyboard sequence");
 assert.match(source, /role="tabpanel"[\s\S]*?aria-labelledby=\{`nav-section-tab-\$\{section\}`\}/, "the destination list is labeled by its active tab");
+// Retiring the SidebarSection assertions took this rule's only coverage with
+// them. Its section-heading half is dead — nothing emits sidebar-section*
+// anymore — but the recent-activity half is live: RecentActivityRollup still
+// renders in the Code section, and the 56px rail has no room for it.
+assert.match(
+  styles,
+  /\.shell-nav--rail \.recent-activity \{\s*display: none;/,
+  "the icon rail hides the recent-activity list while retaining destination icons",
+);
 
 // The standalone Knowledge section is gone; Library is now isolated on its
 // feature branch, so the integrated sidebar renders one flat app list.


### PR DESCRIPTION
Two gaps left over after #4365, which repaired the rest of the stale sidebar tests. Both verified against `main` at `2a71eed0`.

> **Scope note:** this PR started much wider — resolving the conflict markers `23316da3` left in `sidebar-minimal.tsx`, completing the half-merged canvas Play mode, a stray `);`, and two unwired tests. `4ea88862`, `27f5d490` and #4365 have since landed their own versions of all of that, so it's been narrowed to the residue that nothing else covers. The branch name is historical.

## 1. `sidebar-familiar-filter.test.ts` — still red on `main`

It asserts the familiar-selector styling hooks against `styles/sidebar-minimal.css`, which is now only an import facade, so the assertion has been running against a file of `@import` lines:

```css
@import "./sidebar-minimal/shell-chrome.css";
@import "./sidebar-minimal/section-tabs.css";
…
```

Now reads the facade plus its five modules — the same set `sidebar-minimal.test.ts` reads. This is the last sidebar test still failing after #4365.

## 2. `sidebar-minimal.test.ts` — a live rule lost its only coverage

Retiring the `SidebarSection` assertions took this rule with them:

```css
.shell-nav--rail .sidebar-section-label,
.shell-nav--rail .recent-activity { display: none; }
```

The heading half is genuinely dead — nothing emits `sidebar-section*` any more. **The `recent-activity` half is live:** `RecentActivityRollup` still renders in the Code section, and the 56px rail has no room for it. Nothing anywhere in the suite pinned it after the retirement, so the rail could regress silently. Re-added narrowed to the live half.

## Verification

Both assertions were checked for vacuity — each was confirmed to **fail** when the rule or hook it pins is removed, then pass again when restored:

| check | result |
| --- | --- |
| `sidebar-familiar-filter.test.ts` | fails on `main`, passes here; fails when the hook is renamed across all five modules |
| `sidebar-minimal.test.ts` | passes on `main`, still passes here; fails when `.shell-nav--rail .recent-activity` is removed |

The first attempt at that second control was wrong — renaming the class to `…-DISABLED` left the searched substring in place, so the test "passed" for the wrong reason. Redone with a non-overlapping name.
