### PR TITLE
fix(ios): keep the ⌘1–4 tab shortcuts out of the accessibility tree

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/RootView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/RootView.swift
@@ -226,6 +226,13 @@ struct MainShellView: View {
                     app.selectedTab = tab
                 } label: { EmptyView() }
                 .keyboardShortcut(KeyEquivalent(Character("\(index + 1)")), modifiers: .command)
+                // An EmptyView label gives VoiceOver nothing to announce, so
+                // without this each shortcut lands in the accessibility tree as
+                // an unnamed button. They only host the ⌘-key equivalents and
+                // duplicate the tab bar, which is already reachable — so hide
+                // them from assistive tech rather than inventing names for
+                // controls a VoiceOver user should never land on.
+                .accessibilityHidden(true)
             }
         }
         // Keep the app chrome in step with desktop theme changes: re-fetch while

--- a/scripts/ios-accessible-controls.test.mjs
+++ b/scripts/ios-accessible-controls.test.mjs
@@ -1,0 +1,121 @@
+// Pins the iOS accessible-name contract (cave-9s4lv).
+//
+// A SwiftUI control derives its VoiceOver name from its label. When the label
+// renders no text — `label: { EmptyView() }`, or an icon with no title — the
+// control still lands in the accessibility tree, just nameless: VoiceOver
+// announces "button" and nothing else. That is invisible to every other gate
+// we run, because it compiles cleanly and no Xcode test asserts on it.
+//
+// These are source pins because Swift isn't compiled in CI.
+import { strict as assert } from "node:assert";
+import { readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+const appRoot = join(root, "apps/ios/CovenCave/CovenCave");
+
+function swiftFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) swiftFiles(full, out);
+    else if (entry.name.endsWith(".swift")) out.push(full);
+  }
+  return out;
+}
+
+/// Returns the balanced `{ … }` span starting at `open`, or null if unbalanced.
+function braceSpan(src, open) {
+  let depth = 0;
+  for (let i = open; i < src.length; i += 1) {
+    if (src[i] === "{") depth += 1;
+    else if (src[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return { body: src.slice(open, i + 1), end: i + 1 };
+    }
+  }
+  return null;
+}
+
+/// The modifier chain attached to the control that ends at `from`.
+///
+/// Comments are dropped rather than counted: a fixed character budget would
+/// otherwise let a long explanatory comment push the very modifier being
+/// asserted on out of view, which reads as a failure in the code instead of in
+/// this parser. The walk stops at the first line that isn't a modifier, so a
+/// sibling declaration's modifiers can never be mistaken for this control's.
+function trailingModifiers(src, from) {
+  const kept = [];
+  for (const raw of src.slice(from).split("\n")) {
+    const line = raw.replace(/\/\/.*$/, "").trim();
+    if (line === "") continue;
+    if (!line.startsWith(".")) break;
+    kept.push(line);
+  }
+  return kept.join("\n");
+}
+
+/// Every `Button { … } label: { … }` in the tree, with the label body and the
+/// modifiers that follow it.
+function buttonsWithLabelBlocks() {
+  const found = [];
+  for (const file of swiftFiles(appRoot)) {
+    const src = readFileSync(file, "utf8");
+    const re = /\bButton\s*\{/g;
+    let match;
+    while ((match = re.exec(src))) {
+      const action = braceSpan(src, src.indexOf("{", match.index));
+      if (!action) continue;
+      const gap = src.slice(action.end, action.end + 40);
+      if (!/^\s*label:\s*\{/.test(gap)) continue;
+      const label = braceSpan(src, action.end + gap.indexOf("{"));
+      if (!label) continue;
+      found.push({
+        file: relative(root, file),
+        line: src.slice(0, match.index).split("\n").length,
+        label: label.body,
+        modifiers: trailingModifiers(src, label.end),
+      });
+    }
+  }
+  return found;
+}
+
+test("no Button ships an EmptyView label without hiding it from assistive tech", () => {
+  const offenders = buttonsWithLabelBlocks()
+    .filter((b) => /^\{\s*EmptyView\(\)\s*\}$/.test(b.label.replace(/\s+/g, " ").trim()))
+    .filter((b) => !/accessibilityHidden\(\s*true\s*\)/.test(b.modifiers))
+    .map((b) => `${b.file}:${b.line}`);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `A Button whose label is EmptyView() has no accessible name — VoiceOver ` +
+      `announces a bare "button". Either give it a real label, or, if it exists ` +
+      `only to host a keyboard shortcut that duplicates a reachable control, ` +
+      `mark it .accessibilityHidden(true). Offenders:\n  ${offenders.join("\n  ")}`,
+  );
+});
+
+test("the ⌘1–4 destination shortcuts stay out of the accessibility tree", () => {
+  const rootView = readFileSync(join(appRoot, "Views/RootView.swift"), "utf8");
+  const shortcuts = rootView.slice(rootView.indexOf("AppTab.shortcutOrder"));
+  assert.match(
+    shortcuts.slice(0, 900),
+    /label:\s*\{\s*EmptyView\(\)\s*\}[\s\S]{0,200}?keyboardShortcut[\s\S]{0,600}?accessibilityHidden\(true\)/,
+    "RootView's hardware-keyboard tab shortcuts must stay accessibilityHidden — " +
+      "they carry no label and duplicate the already-reachable tab bar.",
+  );
+});
+
+test("controls the session-switch UI tests drive keep their identifiers", () => {
+  // SessionSwitchUITests queries these by identifier. Both are Buttons with
+  // composed labels, which surface no queryable name on their own, so dropping
+  // the identifier silently makes the switcher untestable again (cave-vut6z).
+  const chatView = readFileSync(join(appRoot, "Views/ChatView.swift"), "utf8");
+  assert.match(chatView, /accessibilityIdentifier\("Switch session"\)/);
+
+  const threads = readFileSync(join(appRoot, "Views/FamiliarThreadsView.swift"), "utf8");
+  assert.match(threads, /accessibilityIdentifier\("Thread row \\\(entry\.id\)"\)/);
+});

--- a/scripts/ios-accessible-controls.test.mjs
+++ b/scripts/ios-accessible-controls.test.mjs
@@ -82,7 +82,7 @@ function buttonsWithLabelBlocks() {
   return found;
 }
 
-test("no Button ships an EmptyView label without hiding it from assistive tech", () => {
+test("no Button { } label: { EmptyView() } ships without hiding it from assistive tech", () => {
   const offenders = buttonsWithLabelBlocks()
     .filter((b) => /^\{\s*EmptyView\(\)\s*\}$/.test(b.label.replace(/\s+/g, " ").trim()))
     .filter((b) => !/accessibilityHidden\(\s*true\s*\)/.test(b.modifiers))
@@ -91,7 +91,7 @@ test("no Button ships an EmptyView label without hiding it from assistive tech",
   assert.deepEqual(
     offenders,
     [],
-    `A Button whose label is EmptyView() has no accessible name — VoiceOver ` +
+    `A Button { } label: { EmptyView() } has no accessible name — VoiceOver ` +
       `announces a bare "button". Either give it a real label, or, if it exists ` +
       `only to host a keyboard shortcut that duplicates a reachable control, ` +
       `mark it .accessibilityHidden(true). Offenders:\n  ${offenders.join("\n  ")}`,
@@ -100,7 +100,13 @@ test("no Button ships an EmptyView label without hiding it from assistive tech",
 
 test("the ⌘1–4 destination shortcuts stay out of the accessibility tree", () => {
   const rootView = readFileSync(join(appRoot, "Views/RootView.swift"), "utf8");
-  const shortcuts = rootView.slice(rootView.indexOf("AppTab.shortcutOrder"));
+  const anchorIndex = rootView.indexOf("AppTab.shortcutOrder");
+  assert.notEqual(
+    anchorIndex,
+    -1,
+    "AppTab.shortcutOrder anchor not found in RootView.swift — has the shortcut block been renamed or removed?",
+  );
+  const shortcuts = rootView.slice(anchorIndex);
   assert.match(
     shortcuts.slice(0, 900),
     /label:\s*\{\s*EmptyView\(\)\s*\}[\s\S]{0,200}?keyboardShortcut[\s\S]{0,600}?accessibilityHidden\(true\)/,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1516,6 +1516,7 @@ export const SUITES = {
     "scripts/ios-swipe-reply.test.mjs",
     "scripts/ios-unread-badges.test.mjs",
     "scripts/ios-familiar-row-actions.test.mjs",
+    "scripts/ios-accessible-controls.test.mjs",
     "scripts/ios-group-mentions.test.mjs",
     "scripts/ios-reply-feedback.test.mjs",
     "scripts/ios-link-previews.test.mjs",


### PR DESCRIPTION
An audit of every interactive control in the iOS client — Buttons, Menus, toolbar items, tap gestures — turned up exactly one genuinely nameless set, and it is fixed here.

## The defect

`RootView` hosts the ⌘1–4 destination switches as four Buttons with `label: { EmptyView() }`, parked in a `.background` so they contribute no layout. An `EmptyView` label gives VoiceOver nothing to derive a name from, so all four still land in the accessibility tree announcing a bare "button".

They duplicate the tab bar, which is already reachable and properly labelled. So a VoiceOver user gains nothing by finding them and loses by swiping past four unlabelled controls. Hiding beats naming here — the shortcut is a hardware-keyboard affordance — and `.accessibilityHidden(true)` is the convention this codebase already uses in nine other views for exactly this case.

## The pin

Swift isn't compiled in CI, so nothing would have caught this and nothing would catch its return. `scripts/ios-accessible-controls.test.mjs` fails on any Button whose label is `EmptyView()` without an `accessibilityHidden`, and separately pins the two identifiers `SessionSwitchUITests` drives — both sit on Buttons with composed labels, which expose no queryable name on their own, so dropping one silently makes the session switcher untestable again (cave-vut6z).

**Checked against the unfixed code:** both new pins fail with the modifier removed and pass with it restored. The parser strips comments rather than counting them toward a character budget — my first version failed on my own fix because the explanatory comment pushed the modifier out of a fixed window, which reads as a bug in the code instead of in the test.

## What the audit found everywhere else

Labelling is in good shape: 78 `accessibilityLabel` call sites, and every other candidate my scans flagged derives a name from text inside a row helper (`label: { row(command) }`), or from `Label("View options", systemImage:)`. No other control is nameless.

The real remaining gap is **identifiers** — two repo-wide, both added for the switcher tests. That matters for testability, not VoiceOver, so I left it alone rather than mass-adding names no test consumes yet.

## ⚠️ CI will be red for reasons that predate this branch

`main` is currently failing `Frontend build`, which is a required check, so this PR cannot go green until that is repaired. Both failures reproduce on this branch's base commit with my changes stashed:

- `pnpm test:mobile` → `scripts/ios-claude-design-fidelity.test.mjs`. The sidebar-nav restructure moved `FamiliarsListView` out of `ChatsHomeView` into `RootView` and changed what its callback does, but left the source pin asserting the old shape.
- `pnpm check:tests-wired` → `src/lib/nav-section.test.ts` and `src/components/nav-section-tabs.test.ts` are on disk but wired into no CI suite.

Both trace to `4ea88862b3` "Restructure sidebar nav from sections to tabbed layout", a single-parent commit with no PR number — pushed directly to `main`, so the nine required checks never ran on it. I have left that work alone since it is in flight and not mine to reshape.
