### PR TITLE
perf(pty): bound streaming and add replay cursors

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -383,7 +383,14 @@ function queuePtyOutput(threadId, session, data) {
   while (offset < data.length && session.ws) {
     const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
     const take = Math.min(room, data.length - offset);
-    session.pendingOutput.push(data.subarray(offset, offset + take));
+    const chunk = data.subarray(offset, offset + take);
+    if (session.pendingOutputBytes + take === PTY_FRAME_MAX_BYTES) {
+      session.pendingOutput.push(chunk);
+    } else {
+      const boundedChunk = Buffer.allocUnsafeSlow(chunk.length);
+      chunk.copy(boundedChunk);
+      session.pendingOutput.push(boundedChunk);
+    }
     session.pendingOutputBytes += take;
     offset += take;
     if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {

--- a/server.mjs
+++ b/server.mjs
@@ -56,17 +56,47 @@ const ACCESS_QUERY_PARAM = "coven_access_token";
 const SIDECAR_QUERY_PARAM = "covenCaveToken";
 const sessions = /* @__PURE__ */ new Map();
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+const PTY_FRAME_COALESCE_MS = 8;
+const PTY_FRAME_MAX_BYTES = 16 * 1024;
+const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 * 1024;
+const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013;
+const PTY_SLOW_CONSUMER_CLOSE_REASON = "slow terminal consumer; reconnect";
 const DETACH_GRACE_MS = (() => {
   const env = Number.parseInt(process.env.COVEN_CAVE_PTY_DETACH_GRACE_MS ?? "", 10);
   return Number.isFinite(env) && env > 0 ? env : 3e5;
 })();
 function appendScrollback(session, data) {
+  const nextEnd = session.streamEnd + data.length;
+  if (data.length >= SCROLLBACK_LIMIT_BYTES) {
+    session.scrollback = [Buffer.from(data.subarray(data.length - SCROLLBACK_LIMIT_BYTES))];
+    session.scrollbackBytes = SCROLLBACK_LIMIT_BYTES;
+    session.scrollbackStart = nextEnd - SCROLLBACK_LIMIT_BYTES;
+    session.streamEnd = nextEnd;
+    return;
+  }
   session.scrollback.push(data);
   session.scrollbackBytes += data.length;
+  session.streamEnd = nextEnd;
   while (session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES && session.scrollback.length > 1) {
     const dropped = session.scrollback.shift();
-    if (dropped) session.scrollbackBytes -= dropped.length;
+    if (dropped) {
+      session.scrollbackBytes -= dropped.length;
+      session.scrollbackStart += dropped.length;
+    }
   }
+}
+function scrollbackFrom(session, cursor) {
+  const output = [];
+  let remaining = cursor - session.scrollbackStart;
+  for (const chunk of session.scrollback) {
+    if (remaining >= chunk.length) {
+      remaining -= chunk.length;
+      continue;
+    }
+    output.push(remaining > 0 ? chunk.subarray(remaining) : chunk);
+    remaining = 0;
+  }
+  return output;
 }
 function getTokensFromCookie(header) {
   if (!header) return [];
@@ -156,6 +186,14 @@ function isAllowedUpgradeSource(req, tokenAuthenticated = false) {
 }
 function firstQueryValue(value) {
   return Array.isArray(value) ? value[0] : value;
+}
+function parsePtyReplayCursor(value) {
+  const raw = firstQueryValue(value);
+  if (raw === void 0) return void 0;
+  if (raw === "-1") return -1;
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) return null;
+  const cursor = Number(raw);
+  return Number.isSafeInteger(cursor) ? cursor : null;
 }
 const UPGRADE_URL_BASE = "http://localhost";
 const MAX_UPGRADE_QUERY_SEGMENTS = 1e3;
@@ -265,12 +303,124 @@ function sanitizedEnv() {
   return env;
 }
 function sendPtyData(ws, data) {
-  if (ws.readyState !== WebSocket.OPEN) return;
-  const encoded = Buffer.from(data, "utf8");
-  const frame = Buffer.allocUnsafe(1 + encoded.length);
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(1 + data.length);
   frame[0] = 1;
-  encoded.copy(frame, 1);
-  ws.send(frame);
+  data.copy(frame, 1);
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function sendPtyReplayCursor(ws, cursor, reset) {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(10);
+  frame[0] = 6;
+  frame.writeDoubleLE(cursor, 1);
+  frame[9] = reset ? 1 : 0;
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+function clearPendingPtyOutput(session) {
+  if (session.flushTimer) {
+    clearTimeout(session.flushTimer);
+    session.flushTimer = null;
+  }
+  session.pendingOutput = [];
+  session.pendingOutputBytes = 0;
+}
+function armPtyDetach(threadId, session) {
+  if (session.detachTimer) clearTimeout(session.detachTimer);
+  session.detachTimer = setTimeout(() => {
+    const current = sessions.get(threadId);
+    if (current !== session || current.ws) return;
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+    }
+  }, DETACH_GRACE_MS);
+}
+function detachPtyConsumer(threadId, session, ws) {
+  if (session.ws !== ws) return;
+  session.ws = null;
+  clearPendingPtyOutput(session);
+  armPtyDetach(threadId, session);
+}
+function evictSlowPtyConsumer(threadId, session, ws) {
+  if (session.ws !== ws) return;
+  detachPtyConsumer(threadId, session, ws);
+  try {
+    ws.close(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON);
+  } catch {
+  }
+}
+function flushPtyOutput(threadId, session) {
+  session.flushTimer = null;
+  const ws = session.ws;
+  if (!ws || session.pendingOutputBytes === 0) return;
+  const chunks = session.pendingOutput;
+  clearPendingPtyOutput(session);
+  const payload = Buffer.concat(chunks);
+  if (ws.readyState !== WebSocket.OPEN || session.ws !== ws) return;
+  if (ws.bufferedAmount + payload.length + 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT) {
+    evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  if (!sendPtyData(ws, payload)) {
+    detachPtyConsumer(threadId, session, ws);
+  }
+}
+function queuePtyOutput(threadId, session, data) {
+  if (!session.ws || data.length === 0) return;
+  let offset = 0;
+  while (offset < data.length && session.ws) {
+    const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
+    const take = Math.min(room, data.length - offset);
+    session.pendingOutput.push(data.subarray(offset, offset + take));
+    session.pendingOutputBytes += take;
+    offset += take;
+    if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {
+      flushPtyOutput(threadId, session);
+    }
+  }
+  if (session.ws && session.pendingOutputBytes > 0 && !session.flushTimer) {
+    session.flushTimer = setTimeout(
+      () => flushPtyOutput(threadId, session),
+      PTY_FRAME_COALESCE_MS
+    );
+  }
+}
+function replayPtyOutput(threadId, session, replayCursor) {
+  if (!session.ws || session.scrollbackBytes === 0) {
+    if (session.ws && replayCursor !== void 0) {
+      sendPtyReplayCursor(
+        session.ws,
+        session.streamEnd,
+        replayCursor !== -1 && replayCursor !== session.streamEnd
+      );
+    }
+    return;
+  }
+  if (replayCursor === void 0) {
+    for (const chunk of session.scrollback) queuePtyOutput(threadId, session, chunk);
+    return;
+  }
+  const validCursor = replayCursor >= session.scrollbackStart && replayCursor <= session.streamEnd;
+  const start = validCursor && replayCursor !== -1 ? replayCursor : session.scrollbackStart;
+  const reset = replayCursor !== -1 && !validCursor;
+  const ws = session.ws;
+  if (!ws || ws.bufferedAmount + 10 > PTY_WS_BUFFERED_AMOUNT_LIMIT || !sendPtyReplayCursor(ws, start, reset)) {
+    if (ws) evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  for (const chunk of scrollbackFrom(session, start)) queuePtyOutput(threadId, session, chunk);
 }
 function sendPtyExit(ws, exitCode) {
   if (ws.readyState !== WebSocket.OPEN) return;
@@ -279,7 +429,7 @@ function sendPtyExit(ws, exitCode) {
   frame.writeInt32LE(exitCode, 1);
   ws.send(frame);
 }
-function spawnPty(threadId, ws, cols, rows, cwd) {
+function spawnPty(threadId, ws, cols, rows, cwd, replayCursor) {
   const shell = pty.spawn(defaultShell(), defaultShellArgs(), {
     name: "xterm-256color",
     cols: cols > 0 ? cols : 120,
@@ -297,20 +447,28 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
   });
   const session = {
     pty: shell,
-    ws,
+    ws: null,
     scrollback: [],
     scrollbackBytes: 0,
+    scrollbackStart: 0,
+    streamEnd: 0,
+    pendingOutput: [],
+    pendingOutputBytes: 0,
+    flushTimer: null,
     detachTimer: null
   };
   sessions.set(threadId, session);
   shell.onData((data) => {
-    appendScrollback(session, Buffer.from(data, "utf8"));
-    if (session.ws) sendPtyData(session.ws, data);
+    const bytes = Buffer.from(data, "utf8");
+    appendScrollback(session, bytes);
+    queuePtyOutput(threadId, session, bytes);
   });
   shell.onExit(({ exitCode }) => {
     const current = sessions.get(threadId);
+    if (session.ws) flushPtyOutput(threadId, session);
     if (current?.pty === shell) {
       if (current.detachTimer) clearTimeout(current.detachTimer);
+      clearPendingPtyOutput(current);
       sessions.delete(threadId);
     }
     if (session.ws) {
@@ -318,6 +476,7 @@ function spawnPty(threadId, ws, cols, rows, cwd) {
       session.ws.close(1e3, "pty exit");
     }
   });
+  adoptSession(threadId, session, ws, cols, rows, replayCursor);
 }
 function rawDataToBuffer(data) {
   if (Buffer.isBuffer(data)) return data;
@@ -339,6 +498,7 @@ function onWsMessage(threadId, data) {
     }
   } else if (tag === 5) {
     if (session.detachTimer) clearTimeout(session.detachTimer);
+    clearPendingPtyOutput(session);
     sessions.delete(threadId);
     try {
       session.pty.kill();
@@ -346,12 +506,13 @@ function onWsMessage(threadId, data) {
     }
   }
 }
-function adoptSession(session, ws, cols, rows) {
+function adoptSession(threadId, session, ws, cols, rows, replayCursor) {
   if (session.detachTimer) {
     clearTimeout(session.detachTimer);
     session.detachTimer = null;
   }
   const previous = session.ws;
+  clearPendingPtyOutput(session);
   session.ws = ws;
   if (previous && previous !== ws) {
     try {
@@ -365,32 +526,20 @@ function adoptSession(session, ws, cols, rows) {
     } catch {
     }
   }
-  if (session.scrollbackBytes > 0) {
-    sendPtyData(ws, Buffer.concat(session.scrollback).toString("utf8"));
-  }
+  replayPtyOutput(threadId, session, replayCursor);
 }
-function handlePtyConnection(ws, threadId, cols, rows, cwd) {
+function handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor) {
   const existing = sessions.get(threadId);
   if (existing) {
-    adoptSession(existing, ws, cols, rows);
+    adoptSession(threadId, existing, ws, cols, rows, replayCursor);
   } else {
-    spawnPty(threadId, ws, cols, rows, cwd);
+    spawnPty(threadId, ws, cols, rows, cwd, replayCursor);
   }
   ws.on("message", (data) => onWsMessage(threadId, data));
   ws.on("close", () => {
     const session = sessions.get(threadId);
     if (!session || session.ws !== ws) return;
-    session.ws = null;
-    if (session.detachTimer) clearTimeout(session.detachTimer);
-    session.detachTimer = setTimeout(() => {
-      const current = sessions.get(threadId);
-      if (current !== session || current.ws) return;
-      sessions.delete(threadId);
-      try {
-        session.pty.kill();
-      } catch {
-      }
-    }, DETACH_GRACE_MS);
+    detachPtyConsumer(threadId, session, ws);
   });
 }
 const dev = process.env.NODE_ENV !== "production";
@@ -442,6 +591,12 @@ server.on("upgrade", (req, socket, head) => {
     socket.destroy();
     return;
   }
+  const replayCursor = parsePtyReplayCursor(query.ptyReplayCursor);
+  if (replayCursor === null) {
+    socket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    socket.destroy();
+    return;
+  }
   let cwd;
   try {
     cwd = validateCwd(query.projectRoot ? String(query.projectRoot) : void 0);
@@ -453,7 +608,7 @@ server.on("upgrade", (req, socket, head) => {
   const cols = Number.parseInt(String(query.cols ?? "120"), 10);
   const rows = Number.parseInt(String(query.rows ?? "40"), 10);
   wss.handleUpgrade(req, socket, head, (ws) => {
-    handlePtyConnection(ws, threadId, cols, rows, cwd);
+    handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor);
   });
 });
 server.keepAliveTimeout = 75e3;

--- a/server.ts
+++ b/server.ts
@@ -604,7 +604,17 @@ function queuePtyOutput(threadId: string, session: PtySession, data: Buffer): vo
   while (offset < data.length && session.ws) {
     const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
     const take = Math.min(room, data.length - offset);
-    session.pendingOutput.push(data.subarray(offset, offset + take));
+    const chunk = data.subarray(offset, offset + take);
+    // Full frames flush synchronously. A short final slice survives until the
+    // coalescing timer, so give it a bounded backing allocation instead of
+    // pinning an arbitrarily large node-pty callback through a Buffer view.
+    if (session.pendingOutputBytes + take === PTY_FRAME_MAX_BYTES) {
+      session.pendingOutput.push(chunk);
+    } else {
+      const boundedChunk = Buffer.allocUnsafeSlow(chunk.length);
+      chunk.copy(boundedChunk);
+      session.pendingOutput.push(boundedChunk);
+    }
     session.pendingOutputBytes += take;
     offset += take;
     if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {

--- a/server.ts
+++ b/server.ts
@@ -106,6 +106,14 @@ type PtySession = {
    *  client repaints the screen instead of staring at a blank pane. */
   scrollback: Buffer[];
   scrollbackBytes: number;
+  /** Absolute byte cursor at the front of the retained scrollback ring. */
+  scrollbackStart: number;
+  /** Absolute cursor immediately after the newest PTY byte. */
+  streamEnd: number;
+  /** Coalesced output waiting for one bounded WebSocket frame. */
+  pendingOutput: Buffer[];
+  pendingOutputBytes: number;
+  flushTimer: NodeJS.Timeout | null;
   /** Pending kill while detached — cleared when a client reattaches. */
   detachTimer: NodeJS.Timeout | null;
 };
@@ -116,6 +124,16 @@ const sessions = new Map<string, PtySession>();
 // screen instead of staring at a blank pane. Matches the Rust desktop PTY's
 // 256KB ring (src-tauri/src/pty.rs).
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
+// PTYs often emit a write-sized chunk for every line. Coalesce a short burst
+// before framing it, but cap the userland queue and every individual frame.
+const PTY_FRAME_COALESCE_MS = 8;
+const PTY_FRAME_MAX_BYTES = 16 * 1024;
+// `ws` otherwise retains arbitrary output for a client whose TCP receive
+// window stopped advancing. This is deliberately larger than one legacy
+// scrollback replay, so a healthy reattach is never evicted for the replay.
+const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 * 1024;
+const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013;
+const PTY_SLOW_CONSUMER_CLOSE_REASON = "slow terminal consumer; reconnect";
 // How long a shell survives after its socket drops before being reaped. A
 // terminal pane remounts whenever the Comux layout restructures (split,
 // drag-reorganize, tab switch) or the page reloads; killing the shell the
@@ -131,15 +149,47 @@ const DETACH_GRACE_MS = (() => {
 })();
 
 function appendScrollback(session: PtySession, data: Buffer): void {
+  const nextEnd = session.streamEnd + data.length;
+  // Retain the tail even if one node-pty callback is larger than the entire
+  // ring. The old `length > 1` loop kept that one large callback forever.
+  if (data.length >= SCROLLBACK_LIMIT_BYTES) {
+    // `subarray` alone would retain the oversized callback's entire backing
+    // allocation. Copy the bounded tail so retained memory matches the ring.
+    session.scrollback = [Buffer.from(data.subarray(data.length - SCROLLBACK_LIMIT_BYTES))];
+    session.scrollbackBytes = SCROLLBACK_LIMIT_BYTES;
+    session.scrollbackStart = nextEnd - SCROLLBACK_LIMIT_BYTES;
+    session.streamEnd = nextEnd;
+    return;
+  }
+
   session.scrollback.push(data);
   session.scrollbackBytes += data.length;
+  session.streamEnd = nextEnd;
   while (
     session.scrollbackBytes > SCROLLBACK_LIMIT_BYTES &&
     session.scrollback.length > 1
   ) {
     const dropped = session.scrollback.shift();
-    if (dropped) session.scrollbackBytes -= dropped.length;
+    if (dropped) {
+      session.scrollbackBytes -= dropped.length;
+      session.scrollbackStart += dropped.length;
+    }
   }
+}
+
+/** Return retained output beginning at an absolute stream cursor. */
+function scrollbackFrom(session: PtySession, cursor: number): Buffer[] {
+  const output: Buffer[] = [];
+  let remaining = cursor - session.scrollbackStart;
+  for (const chunk of session.scrollback) {
+    if (remaining >= chunk.length) {
+      remaining -= chunk.length;
+      continue;
+    }
+    output.push(remaining > 0 ? chunk.subarray(remaining) : chunk);
+    remaining = 0;
+  }
+  return output;
 }
 
 function getTokensFromCookie(header: string | undefined): string[] {
@@ -287,6 +337,18 @@ function isAllowedUpgradeSource(req: IncomingMessage, tokenAuthenticated = false
 
 function firstQueryValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
+}
+
+/** `-1` is a capability probe: cursor-aware clients use it on their first
+ * attach, then send the last delivered absolute byte cursor on reconnect.
+ * Absence remains the legacy full-replay protocol. */
+function parsePtyReplayCursor(value: string | string[] | undefined): number | undefined | null {
+  const raw = firstQueryValue(value);
+  if (raw === undefined) return undefined;
+  if (raw === "-1") return -1;
+  if (!/^(?:0|[1-9]\d*)$/.test(raw)) return null;
+  const cursor = Number(raw);
+  return Number.isSafeInteger(cursor) ? cursor : null;
 }
 
 type UpgradeQuery = Record<string, string | string[] | undefined>;
@@ -445,13 +507,156 @@ function sanitizedEnv(): Record<string, string> {
   return env;
 }
 
-function sendPtyData(ws: WebSocket, data: string): void {
-  if (ws.readyState !== WebSocket.OPEN) return;
-  const encoded = Buffer.from(data, "utf8");
-  const frame = Buffer.allocUnsafe(1 + encoded.length);
+function sendPtyData(ws: WebSocket, data: Buffer): boolean {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(1 + data.length);
   frame[0] = 0x01;
-  encoded.copy(frame, 1);
-  ws.send(frame);
+  data.copy(frame, 1);
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Cursor control frames are opt-in (`ptyReplayCursor` query parameter), so
+ * legacy clients continue to receive the original 0x01 + terminal bytes wire
+ * format unchanged. The cursor is a safe integer stored as Float64 LE; that
+ * covers many petabytes while working in every supported WebView. */
+function sendPtyReplayCursor(ws: WebSocket, cursor: number, reset: boolean): boolean {
+  if (ws.readyState !== WebSocket.OPEN) return false;
+  const frame = Buffer.allocUnsafe(10);
+  frame[0] = 0x06;
+  frame.writeDoubleLE(cursor, 1);
+  frame[9] = reset ? 1 : 0;
+  try {
+    ws.send(frame);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clearPendingPtyOutput(session: PtySession): void {
+  if (session.flushTimer) {
+    clearTimeout(session.flushTimer);
+    session.flushTimer = null;
+  }
+  session.pendingOutput = [];
+  session.pendingOutputBytes = 0;
+}
+
+function armPtyDetach(threadId: string, session: PtySession): void {
+  if (session.detachTimer) clearTimeout(session.detachTimer);
+  session.detachTimer = setTimeout(() => {
+    const current = sessions.get(threadId);
+    if (current !== session || current.ws) return;
+    sessions.delete(threadId);
+    try {
+      session.pty.kill();
+    } catch {
+      // Already gone.
+    }
+  }, DETACH_GRACE_MS);
+}
+
+function detachPtyConsumer(threadId: string, session: PtySession, ws: WebSocket): void {
+  if (session.ws !== ws) return;
+  session.ws = null;
+  clearPendingPtyOutput(session);
+  armPtyDetach(threadId, session);
+}
+
+function evictSlowPtyConsumer(threadId: string, session: PtySession, ws: WebSocket): void {
+  if (session.ws !== ws) return;
+  // Closing only the transport is intentional: output remains in the bounded
+  // ring and the live PTY gets the normal reconnect grace window.
+  detachPtyConsumer(threadId, session, ws);
+  try {
+    ws.close(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON);
+  } catch {
+    // The close handler is only cleanup; the session is already detached.
+  }
+}
+
+function flushPtyOutput(threadId: string, session: PtySession): void {
+  session.flushTimer = null;
+  const ws = session.ws;
+  if (!ws || session.pendingOutputBytes === 0) return;
+
+  const chunks = session.pendingOutput;
+  clearPendingPtyOutput(session);
+  const payload = Buffer.concat(chunks);
+  if (ws.readyState !== WebSocket.OPEN || session.ws !== ws) return;
+  if (ws.bufferedAmount + payload.length + 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT) {
+    evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  if (!sendPtyData(ws, payload)) {
+    detachPtyConsumer(threadId, session, ws);
+  }
+}
+
+function queuePtyOutput(threadId: string, session: PtySession, data: Buffer): void {
+  if (!session.ws || data.length === 0) return;
+  let offset = 0;
+  while (offset < data.length && session.ws) {
+    const room = PTY_FRAME_MAX_BYTES - session.pendingOutputBytes;
+    const take = Math.min(room, data.length - offset);
+    session.pendingOutput.push(data.subarray(offset, offset + take));
+    session.pendingOutputBytes += take;
+    offset += take;
+    if (session.pendingOutputBytes === PTY_FRAME_MAX_BYTES) {
+      flushPtyOutput(threadId, session);
+    }
+  }
+  if (session.ws && session.pendingOutputBytes > 0 && !session.flushTimer) {
+    session.flushTimer = setTimeout(
+      () => flushPtyOutput(threadId, session),
+      PTY_FRAME_COALESCE_MS,
+    );
+  }
+}
+
+/** Queue either the missed suffix (cursor clients) or the bounded complete
+ * ring (legacy clients). Sending the cursor control frame first means every
+ * following 0x01 payload advances the client cursor byte-for-byte. */
+function replayPtyOutput(
+  threadId: string,
+  session: PtySession,
+  replayCursor: number | undefined,
+): void {
+  if (!session.ws || session.scrollbackBytes === 0) {
+    if (session.ws && replayCursor !== undefined) {
+      sendPtyReplayCursor(
+        session.ws,
+        session.streamEnd,
+        replayCursor !== -1 && replayCursor !== session.streamEnd,
+      );
+    }
+    return;
+  }
+
+  if (replayCursor === undefined) {
+    for (const chunk of session.scrollback) queuePtyOutput(threadId, session, chunk);
+    return;
+  }
+
+  const validCursor =
+    replayCursor >= session.scrollbackStart && replayCursor <= session.streamEnd;
+  const start = validCursor && replayCursor !== -1 ? replayCursor : session.scrollbackStart;
+  const reset = replayCursor !== -1 && !validCursor;
+  const ws = session.ws;
+  if (
+    !ws ||
+    ws.bufferedAmount + 10 > PTY_WS_BUFFERED_AMOUNT_LIMIT ||
+    !sendPtyReplayCursor(ws, start, reset)
+  ) {
+    if (ws) evictSlowPtyConsumer(threadId, session, ws);
+    return;
+  }
+  for (const chunk of scrollbackFrom(session, start)) queuePtyOutput(threadId, session, chunk);
 }
 
 function sendPtyExit(ws: WebSocket, exitCode: number): void {
@@ -462,7 +667,14 @@ function sendPtyExit(ws: WebSocket, exitCode: number): void {
   ws.send(frame);
 }
 
-function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, cwd?: string): void {
+function spawnPty(
+  threadId: string,
+  ws: WebSocket,
+  cols: number,
+  rows: number,
+  cwd: string | undefined,
+  replayCursor: number | undefined,
+): void {
   const shell = pty.spawn(defaultShell(), defaultShellArgs(), {
     name: "xterm-256color",
     cols: cols > 0 ? cols : 120,
@@ -481,9 +693,14 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
 
   const session: PtySession = {
     pty: shell,
-    ws,
+    ws: null,
     scrollback: [],
     scrollbackBytes: 0,
+    scrollbackStart: 0,
+    streamEnd: 0,
+    pendingOutput: [],
+    pendingOutputBytes: 0,
+    flushTimer: null,
     detachTimer: null,
   };
   sessions.set(threadId, session);
@@ -493,13 +710,17 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
     // (split/reorg remount, reload, sleep/wake) sees what happened while it
     // was away. Route live output to the CURRENTLY-attached socket, not the
     // spawn-time one — adoptSession swaps session.ws on reattach.
-    appendScrollback(session, Buffer.from(data, "utf8"));
-    if (session.ws) sendPtyData(session.ws, data);
+    const bytes = Buffer.from(data, "utf8");
+    appendScrollback(session, bytes);
+    queuePtyOutput(threadId, session, bytes);
   });
   shell.onExit(({ exitCode }: { exitCode?: number | null }) => {
     const current = sessions.get(threadId);
+    // Ensure all bytes observed before onExit stay ahead of the exit frame.
+    if (session.ws) flushPtyOutput(threadId, session);
     if (current?.pty === shell) {
       if (current.detachTimer) clearTimeout(current.detachTimer);
+      clearPendingPtyOutput(current);
       sessions.delete(threadId);
     }
     if (session.ws) {
@@ -507,6 +728,8 @@ function spawnPty(threadId: string, ws: WebSocket, cols: number, rows: number, c
       session.ws.close(1000, "pty exit");
     }
   });
+
+  adoptSession(threadId, session, ws, cols, rows, replayCursor);
 }
 
 function rawDataToBuffer(data: RawData): Buffer {
@@ -535,6 +758,7 @@ function onWsMessage(threadId: string, data: RawData): void {
     // just drops the socket, which the close handler treats as a transient
     // detach — leaking the shell (and its foreground job) for DETACH_GRACE_MS.
     if (session.detachTimer) clearTimeout(session.detachTimer);
+    clearPendingPtyOutput(session);
     sessions.delete(threadId);
     try {
       session.pty.kill();
@@ -548,16 +772,19 @@ function onWsMessage(threadId: string, data: RawData): void {
  *  socket (if any) is told it was replaced, the pending detach-kill is
  *  cancelled, and the scrollback ring is replayed so the client repaints. */
 function adoptSession(
+  threadId: string,
   session: PtySession,
   ws: WebSocket,
   cols: number,
   rows: number,
+  replayCursor: number | undefined,
 ): void {
   if (session.detachTimer) {
     clearTimeout(session.detachTimer);
     session.detachTimer = null;
   }
   const previous = session.ws;
+  clearPendingPtyOutput(session);
   session.ws = ws;
   if (previous && previous !== ws) {
     try {
@@ -573,9 +800,7 @@ function adoptSession(
       // Exited between adopt and resize; onExit handles the rest.
     }
   }
-  if (session.scrollbackBytes > 0) {
-    sendPtyData(ws, Buffer.concat(session.scrollback).toString("utf8"));
-  }
+  replayPtyOutput(threadId, session, replayCursor);
 }
 
 function handlePtyConnection(
@@ -584,6 +809,7 @@ function handlePtyConnection(
   cols: number,
   rows: number,
   cwd?: string,
+  replayCursor?: number,
 ): void {
   // Same threadId while the shell is alive (tab switch, page reload, network
   // blip, second window) → adopt the running PTY instead of killing it.
@@ -591,9 +817,9 @@ function handlePtyConnection(
   // every reconnect.
   const existing = sessions.get(threadId);
   if (existing) {
-    adoptSession(existing, ws, cols, rows);
+    adoptSession(threadId, existing, ws, cols, rows, replayCursor);
   } else {
-    spawnPty(threadId, ws, cols, rows, cwd);
+    spawnPty(threadId, ws, cols, rows, cwd, replayCursor);
   }
 
   ws.on("message", (data: RawData) => onWsMessage(threadId, data));
@@ -605,18 +831,7 @@ function handlePtyConnection(
     // Detach, don't kill: give the client a grace window to come back
     // (layout restructure remount, reload, sleep/wake). The ring keeps
     // collecting output; the timer reaps only truly-abandoned shells.
-    session.ws = null;
-    if (session.detachTimer) clearTimeout(session.detachTimer);
-    session.detachTimer = setTimeout(() => {
-      const current = sessions.get(threadId);
-      if (current !== session || current.ws) return;
-      sessions.delete(threadId);
-      try {
-        session.pty.kill();
-      } catch {
-        // Already gone.
-      }
-    }, DETACH_GRACE_MS);
+    detachPtyConsumer(threadId, session, ws);
   });
 }
 
@@ -698,6 +913,13 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
+  const replayCursor = parsePtyReplayCursor(query.ptyReplayCursor);
+  if (replayCursor === null) {
+    socket.write("HTTP/1.1 400 Bad Request\r\n\r\n");
+    socket.destroy();
+    return;
+  }
+
   let cwd: string | undefined;
   try {
     cwd = validateCwd(query.projectRoot ? String(query.projectRoot) : undefined);
@@ -711,7 +933,7 @@ server.on("upgrade", (req, socket, head) => {
   const rows = Number.parseInt(String(query.rows ?? "40"), 10);
 
   wss.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-    handlePtyConnection(ws, threadId, cols, rows, cwd);
+    handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor);
   });
 });
 

--- a/src/components/bottom-terminal-ws-bridge.test.ts
+++ b/src/components/bottom-terminal-ws-bridge.test.ts
@@ -18,7 +18,8 @@ console.log("bottom-terminal-ws-bridge.test.ts OK");
 
 // ── Disconnect recovery (the "terminal stopped accepting input" class) ───────
 assert.match(src, /bridge\.onClose\(/, "terminal reacts to a dropped socket instead of freezing");
-assert.match(src, /terminal disconnected — reconnecting/, "drop is announced in the pane");
+assert.match(src, /srAnnounce\("Terminal disconnected, reconnecting", "assertive"\)/, "drop is announced without writing non-PTY bytes into xterm");
+assert.doesNotMatch(src, /terminal disconnected — reconnecting/, "reconnect status never corrupts byte-continuous terminal state");
 assert.match(src, /const RECONNECT_DELAYS_MS = \[0, 1000, 3000\]/, "reconnect retries with capped backoff");
 assert.match(
   src,
@@ -43,9 +44,9 @@ assert.match(
   /sendToPtyRef\.current = null;/,
   "teardown drops the writer so a broadcast can't write into an unmounted pane",
 );
-assert.match(src, /term\.reset\(\);[\s\S]{0,400}await bridge\.reconnect\(\)/, "screen resets before reattach so the server replay paints clean");
-assert.match(src, /term\.reset\(\);[\s\S]{0,300}decoderRef\.current = new TextDecoder/, "the streaming decoder is reset on reconnect so replayed scrollback decodes cleanly");
-assert.match(src, /reason === "replaced"/, "a take-over by another window is announced, not fought with reconnects");
+assert.match(src, /if \(!bridge\.hasReplayCursor\) \{[\s\S]{0,260}term\.reset\(\);[\s\S]{0,400}await bridge\.reconnect\(\)/, "older full-replay servers reset before reattach");
+assert.match(src, /bridge\.onReplayReset\(\(\) => \{[\s\S]{0,300}term\.reset\(\);[\s\S]{0,300}decoderRef\.current = new TextDecoder/, "expired cursor fallback resets the terminal and decoder before bounded full replay");
+assert.match(src, /reason === "replaced"[\s\S]{0,260}srAnnounce/, "a take-over by another window is announced, not fought with reconnects");
 
 // ── PTY lifetime is decoupled from view lifetime ──────────────────────────────
 // Unmount is usually a keepalive tab-switch remount; killing the PTY there

--- a/src/components/bottom-terminal.tsx
+++ b/src/components/bottom-terminal.tsx
@@ -696,6 +696,15 @@ export function BottomTerminal({
         term.write(bytes);
         pushToMirror(bytes);
       });
+      bridge.onReplayReset(() => {
+        // The server kept the PTY alive but its bounded retained-output window
+        // no longer reaches this client cursor. Reset immediately before its
+        // legacy-style full replay; otherwise the tail would be appended to a
+        // stale terminal state.
+        term.reset();
+        decoderRef.current = new TextDecoder("utf-8", { fatal: false });
+        pendingMirrorRef.current = "";
+      });
       bridge.onExit((code) => {
         announce(
           `\r\n\x1b[2m[exit ${code} — press any key to start a new shell]\x1b[0m\r\n`,
@@ -720,14 +729,17 @@ export function BottomTerminal({
             }
             if (disposed) return;
             try {
-              // The server replays its scrollback ring on reattach; reset
-              // first so the replay paints a clean screen instead of
-              // appending a duplicate of what's already visible.
-              term.reset();
-              // Reset the streaming decoder (+ pending buffer) too: a mid-char
-              // socket drop left partial bytes that would corrupt the mirror.
-              decoderRef.current = new TextDecoder("utf-8", { fatal: false });
-              pendingMirrorRef.current = "";
+              // Cursor-aware servers replay only the bytes missed while this
+              // socket was down. Keeping xterm intact makes that replay
+              // byte-for-byte continuous; a retained-window gap is signalled
+              // through onReplayReset above and falls back to full replay.
+              // An older server does not understand the opt-in query and
+              // retains full replay, so preserve its historical reset path.
+              if (!bridge.hasReplayCursor) {
+                term.reset();
+                decoderRef.current = new TextDecoder("utf-8", { fatal: false });
+                pendingMirrorRef.current = "";
+              }
               await bridge.reconnect();
               bridge.resize(term.cols, term.rows);
               return;
@@ -735,9 +747,6 @@ export function BottomTerminal({
               /* next delay */
             }
           }
-          announce(
-            "\r\n\x1b[2m[terminal reconnect failed — press any key to retry]\x1b[0m\r\n",
-          );
           srAnnounce("Terminal reconnect failed; press any key to retry", "assertive");
         } finally {
           reconnecting = false;
@@ -747,9 +756,6 @@ export function BottomTerminal({
       bridge.onClose((_code, reason) => {
         if (disposed) return;
         if (reason === "replaced") {
-          announce(
-            "\r\n\x1b[2m[this terminal was opened in another window — view detached]\x1b[0m\r\n",
-          );
           srAnnounce("This terminal was opened in another window; this view is detached", "assertive");
           return;
         }
@@ -757,7 +763,6 @@ export function BottomTerminal({
           // onExit already announced; a keypress starts a fresh shell.
           return;
         }
-        announce("\r\n\x1b[2m[terminal disconnected — reconnecting…]\x1b[0m\r\n");
         srAnnounce("Terminal disconnected, reconnecting", "assertive");
         void attemptReconnect();
       });

--- a/src/lib/pty-ws-bridge.test.ts
+++ b/src/lib/pty-ws-bridge.test.ts
@@ -9,6 +9,7 @@ assert.match(src, /new WebSocket\(url\)/, "bridge opens a WebSocket");
 assert.match(src, /binaryType\s*=\s*"arraybuffer"/, "bridge receives binary frames");
 assert.match(src, /0x01/, "bridge handles output tag 0x01");
 assert.match(src, /0x02/, "bridge handles exit tag 0x02");
+assert.match(src, /0x06/, "bridge handles replay-cursor control frames");
 assert.match(src, /frame\[0\]\s*=\s*0x03/, "bridge sends input tag 0x03");
 assert.match(src, /frame\[0\]\s*=\s*0x04/, "bridge sends resize tag 0x04");
 assert.match(src, /setUint16\(1,\s*cols,\s*true\)/, "resize encodes cols little-endian");
@@ -51,6 +52,138 @@ assert.match(
   "a prior (possibly zombie) socket is torn down before re-dialing",
 );
 console.log("pty-ws-bridge iOS-resume assertions: ok");
+
+// ── Cursor replay ────────────────────────────────────────────────────────────
+assert.match(src, /ptyReplayCursor: String\(this\.replayCursor \?\? -1\)/, "new connections opt into cursor replay");
+assert.match(src, /private replayCursor: number \| null = null/, "bridge tracks the last delivered absolute byte cursor");
+assert.match(src, /get hasReplayCursor\(\): boolean/, "bridge distinguishes older full-replay servers");
+assert.match(src, /this\.replayCursor \+= payload\.byteLength/, "each terminal payload advances the cursor by exact bytes");
+assert.match(src, /onReplayReset\(cb: ReplayResetHandler\)/, "bridge exposes bounded-replay fallback reset handling");
+assert.match(src, /getFloat64\(0, true\)/, "cursor control frame decodes its safe integer position");
+console.log("pty-ws-bridge cursor replay assertions: ok");
+
+// Execute the cursor protocol across real bridge reconnects. This is behavioral
+// coverage rather than a source-pattern assertion: the next URL proves exact
+// byte advancement, an old socket is allowed to deliver an already-queued
+// message after replacement, and an expired cursor resets immediately before
+// the bounded full replay.
+{
+  type Listener = (event: any) => void;
+  class FakeWebSocket {
+    static readonly CONNECTING = 0;
+    static readonly OPEN = 1;
+    static readonly CLOSED = 3;
+    static readonly instances: FakeWebSocket[] = [];
+
+    readonly listeners = new Map<string, Listener[]>();
+    readonly sent: Uint8Array[] = [];
+    readonly url: string;
+    readyState = FakeWebSocket.CONNECTING;
+    binaryType = "";
+
+    constructor(url: string) {
+      this.url = url;
+      FakeWebSocket.instances.push(this);
+    }
+
+    addEventListener(type: string, listener: Listener): void {
+      const listeners = this.listeners.get(type) ?? [];
+      listeners.push(listener);
+      this.listeners.set(type, listeners);
+    }
+
+    emit(type: string, event: any): void {
+      for (const listener of this.listeners.get(type) ?? []) listener(event);
+    }
+
+    open(): void {
+      this.readyState = FakeWebSocket.OPEN;
+      this.emit("open", {});
+    }
+
+    message(frame: Uint8Array): void {
+      const data = frame.buffer.slice(frame.byteOffset, frame.byteOffset + frame.byteLength);
+      this.emit("message", { data });
+    }
+
+    send(frame: Uint8Array): void {
+      this.sent.push(frame);
+    }
+
+    close(code = 1000, reason = ""): void {
+      this.readyState = FakeWebSocket.CLOSED;
+      this.emit("close", { code, reason });
+    }
+  }
+
+  const cursorFrame = (cursor: number, reset = false): Uint8Array => {
+    const frame = new Uint8Array(10);
+    frame[0] = 0x06;
+    new DataView(frame.buffer).setFloat64(1, cursor, true);
+    frame[9] = reset ? 1 : 0;
+    return frame;
+  };
+  const dataFrame = (text: string): Uint8Array => {
+    const bytes = new TextEncoder().encode(text);
+    const frame = new Uint8Array(bytes.length + 1);
+    frame[0] = 0x01;
+    frame.set(bytes, 1);
+    return frame;
+  };
+  const replayCursor = (socket: FakeWebSocket): string | null =>
+    new URL(socket.url).searchParams.get("ptyReplayCursor");
+
+  Object.assign(globalThis, {
+    window: { location: { protocol: "http:", host: "cave.test" } },
+    WebSocket: FakeWebSocket,
+  });
+  const { PtyWsBridge } = await import("./pty-ws-bridge.ts");
+  const bridge = new PtyWsBridge();
+  const events: string[] = [];
+  bridge.onData((bytes) => events.push(`data:${new TextDecoder().decode(bytes)}`));
+  bridge.onReplayReset(() => events.push("reset"));
+
+  const firstConnect = bridge.connect("cursor-e2e", 80, 24);
+  const first = FakeWebSocket.instances.at(-1)!;
+  assert.equal(replayCursor(first), "-1", "the first attach negotiates cursor replay");
+  first.open();
+  await firstConnect;
+  first.message(cursorFrame(100));
+  first.message(dataFrame("abc"));
+  first.close(1006, "network lost");
+
+  const secondConnect = bridge.reconnect();
+  const second = FakeWebSocket.instances.at(-1)!;
+  assert.equal(replayCursor(second), "103", "reconnect requests exactly the first missed byte");
+  second.open();
+  await secondConnect;
+
+  // A message already queued by the replaced socket must not mutate terminal
+  // state or the shared replay cursor after the new request has been sent.
+  first.message(cursorFrame(900));
+  first.message(dataFrame("stale"));
+  assert.deepEqual(events, ["data:abc"], "a replaced socket cannot deliver stale output");
+
+  second.message(cursorFrame(103));
+  second.message(dataFrame("def"));
+  second.close(1006, "network lost again");
+
+  const thirdConnect = bridge.reconnect();
+  const third = FakeWebSocket.instances.at(-1)!;
+  assert.equal(replayCursor(third), "106", "suffix replay advances by exact payload bytes");
+  third.open();
+  await thirdConnect;
+  third.message(cursorFrame(0, true));
+  third.message(dataFrame("fresh"));
+  assert.deepEqual(
+    events,
+    ["data:abc", "data:def", "reset", "data:fresh"],
+    "an expired cursor resets before bounded full replay",
+  );
+  bridge.dispose();
+}
+
+console.log("pty-ws-bridge behavioral cursor replay: ok");
 
 // ── Explicit tab-close reaps the shell (cave-wujw) ────────────────────────────
 // Closing a terminal tab on the WS transport used to just drop the socket, which

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -1,6 +1,7 @@
 type DataHandler = (bytes: Uint8Array) => void;
 type ExitHandler = (code: number) => void;
 type CloseHandler = (code: number, reason: string) => void;
+type ReplayResetHandler = () => void;
 
 // Fail a connect that never reaches OPEN. On iOS a WKWebView WebSocket opened
 // right after the app resumes can hang in CONNECTING forever — no open, no
@@ -30,6 +31,10 @@ export class PtyWsBridge {
   private dataHandlers: DataHandler[] = [];
   private exitHandlers: ExitHandler[] = [];
   private closeHandlers: CloseHandler[] = [];
+  private replayResetHandlers: ReplayResetHandler[] = [];
+  /** Absolute byte position immediately after the last output delivered to
+   * xterm. It lets reconnects request only bytes missed while disconnected. */
+  private replayCursor: number | null = null;
   private lastConnect: {
     threadId: string;
     cols: number;
@@ -54,11 +59,25 @@ export class PtyWsBridge {
     this.closeHandlers.push(cb);
   }
 
+  /** The retained replay window no longer covers this client. Clear the
+   * terminal before the server's bounded full-replay fallback is written. */
+  onReplayReset(cb: ReplayResetHandler): void {
+    this.replayResetHandlers.push(cb);
+  }
+
   get isOpen(): boolean {
     return this.ws?.readyState === WebSocket.OPEN;
   }
 
+  /** False only when talking to an older server that ignored cursor
+   * negotiation. Those servers still replay the whole bounded ring, so the
+   * terminal must reset before reconnecting to avoid duplicate screen state. */
+  get hasReplayCursor(): boolean {
+    return this.replayCursor !== null;
+  }
+
   connect(threadId: string, cols: number, rows: number, projectRoot?: string): Promise<void> {
+    this.replayCursor = null;
     this.lastConnect = { threadId, cols, rows, projectRoot };
     return this.open();
   }
@@ -97,6 +116,10 @@ export class PtyWsBridge {
         threadId: target.threadId,
         cols: String(target.cols),
         rows: String(target.rows),
+        // `-1` opts into the cursor protocol without claiming a position for
+        // this newly-created terminal. Older servers ignore the extra query
+        // key and retain their legacy full-replay behavior.
+        ptyReplayCursor: String(this.replayCursor ?? -1),
       });
       if (target.projectRoot) {
         params.set("projectRoot", target.projectRoot);
@@ -136,16 +159,29 @@ export class PtyWsBridge {
         /* close fires next with the real detail */
       });
       ws.addEventListener("message", (event) => {
+        // A data/control frame can already be queued when reconnect replaces
+        // its socket. Only the current socket may mutate terminal state or the
+        // shared absolute replay cursor.
+        if (this.ws !== ws) return;
         if (!(event.data instanceof ArrayBuffer)) return;
         const buf = new Uint8Array(event.data);
         const tag = buf[0];
         if (tag === 0x01) {
           const payload = buf.slice(1);
+          if (this.replayCursor !== null) this.replayCursor += payload.byteLength;
           for (const cb of this.dataHandlers) cb(payload);
         } else if (tag === 0x02 && buf.length >= 5) {
           const view = new DataView(event.data, 1);
           const code = view.getInt32(0, true);
           for (const cb of this.exitHandlers) cb(code);
+        } else if (tag === 0x06 && buf.byteLength >= 10) {
+          const view = new DataView(event.data, 1, 8);
+          const cursor = view.getFloat64(0, true);
+          if (!Number.isSafeInteger(cursor) || cursor < 0) return;
+          this.replayCursor = cursor;
+          if (buf[9] === 1) {
+            for (const cb of this.replayResetHandlers) cb();
+          }
         }
       });
       ws.addEventListener("close", (event) => {
@@ -219,6 +255,7 @@ export class PtyWsBridge {
     this.dataHandlers = [];
     this.exitHandlers = [];
     this.closeHandlers = [];
+    this.replayResetHandlers = [];
     const ws = this.ws;
     this.ws = null;
     if (ws && ws.readyState !== WebSocket.CLOSED) {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -588,8 +588,19 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
     }),
   );
 
-  queuePtyOutput("coalesce", session, Buffer.alloc(frameLimit * 2 + 3, 0x61));
+  const oversizedCallback = Buffer.alloc(frameLimit * 8 + 3, 0x61);
+  queuePtyOutput("coalesce", session, oversizedCallback);
   assert.ok(sent.slice(1).every((frame) => frame.length - 1 <= frameLimit), "large output is split into bounded frames");
+  assert.equal(session.pendingOutputBytes, 3, "only the short final frame remains queued");
+  assert.notEqual(
+    session.pendingOutput[0]?.buffer,
+    oversizedCallback.buffer,
+    "a short pending frame must not pin an oversized PTY callback allocation",
+  );
+  assert.ok(
+    (session.pendingOutput[0]?.buffer.byteLength ?? 0) <= frameLimit,
+    "pending output owns a bounded backing allocation",
+  );
 
   const slowWs = { ...ws, bufferedAmount: bufferedLimit, closeCode: 0, close(code: number) { this.closeCode = code; } };
   const slow = { ...session, ws: slowWs, pendingOutput: [] as Buffer[], pendingOutputBytes: 0, flushTimer: null, detachTimer: null };

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -198,6 +198,7 @@ assert.match(
 );
 assert.match(src, /frame\[0\]\s*=\s*0x01/, "server sends output tag 0x01");
 assert.match(src, /frame\[0\]\s*=\s*0x02/, "server sends exit tag 0x02");
+assert.match(src, /frame\[0\]\s*=\s*0x06/, "cursor-aware clients receive a replay-cursor control frame");
 assert.match(src, /tag === 0x03/, "server receives input tag 0x03");
 assert.match(src, /tag === 0x04/, "server receives resize tag 0x04");
 assert.match(src, /tag === 0x05/, "server receives an explicit kill tag 0x05 (cave-wujw)");
@@ -307,13 +308,13 @@ assert.match(
 //    socket after adoptSession swapped session.ws — one replay then silence.
 assert.match(
   src,
-  /shell\.onData\(\(data: string\) => \{[\s\S]*?if \(session\.ws\) sendPtyData\(session\.ws, data\)/,
-  "live PTY output routes to the current session.ws, not the spawn-time socket",
+  /shell\.onData\(\(data: string\) => \{[\s\S]*?queuePtyOutput\(threadId, session, bytes\)/,
+  "live PTY output enters the current session's bounded output queue",
 );
 assert.match(
   src,
-  /session\.scrollbackBytes > 0[\s\S]{0,80}sendPtyData\(ws, Buffer\.concat\(session\.scrollback\)/,
-  "adoptSession replays the scrollback ring to a reattaching client",
+  /replayPtyOutput\(threadId, session, replayCursor\)/,
+  "adoptSession replays only the retained cursor suffix, or legacy full ring",
 );
 // 3. A detach grace window: on socket close the shell is detached (session.ws
 //    nulled) and a timer reaps it later, instead of an immediate kill. A quick
@@ -325,7 +326,7 @@ assert.match(
 );
 assert.match(
   src,
-  /ws\.on\("close", \(\) => \{[\s\S]*?session\.ws = null;[\s\S]*?setTimeout\([\s\S]*?DETACH_GRACE_MS\)/,
+  /function detachPtyConsumer\([\s\S]*?session\.ws = null;[\s\S]*?armPtyDetach\(threadId, session\)/,
   "closing the socket detaches and arms a reap timer rather than killing the shell immediately",
 );
 assert.match(
@@ -346,6 +347,42 @@ assert.match(
   /const DETACH_GRACE_MS = [\s\S]{0,200}?300_000/,
   "detach grace defaults to 5 minutes so a backgrounded phone reattaches to a live shell",
 );
+
+// High-output sessions must not create an unbounded application queue or let
+// ws retain unlimited bytes for a stalled browser. The PTY remains alive; only
+// the current socket is closed with the retryable RFC 6455 code 1013.
+assert.match(src, /const PTY_FRAME_COALESCE_MS = 8/, "output coalescing has a short bounded latency");
+assert.match(src, /const PTY_FRAME_MAX_BYTES = 16 \* 1024/, "each output frame is bounded");
+assert.match(src, /const PTY_WS_BUFFERED_AMOUNT_LIMIT = 512 \* 1024/, "WebSocket buffering has a ceiling");
+assert.match(
+  src,
+  /ws\.bufferedAmount \+ payload\.length \+ 1 > PTY_WS_BUFFERED_AMOUNT_LIMIT[\s\S]{0,160}evictSlowPtyConsumer/,
+  "a slow consumer is evicted before buffered output exceeds the cap",
+);
+assert.match(
+  src,
+  /ws\.close\(PTY_SLOW_CONSUMER_CLOSE_CODE, PTY_SLOW_CONSUMER_CLOSE_REASON\)/,
+  "slow clients receive a retryable close reason",
+);
+assert.match(
+  src,
+  /const PTY_SLOW_CONSUMER_CLOSE_CODE = 1013/,
+  "slow-client eviction uses WebSocket Try Again Later",
+);
+assert.match(
+  src,
+  /function clearPendingPtyOutput[\s\S]*?pendingOutputBytes = 0/,
+  "a detached or replaced client cannot donate stale queued bytes to the next client",
+);
+
+// Cursor protocol: absence preserves existing full replay. New bridge clients
+// negotiate with -1, receive the retained stream origin, then reconnect with
+// their last delivered absolute byte cursor.
+assert.match(src, /function parsePtyReplayCursor/, "server parses the opt-in replay cursor");
+assert.match(src, /query\.ptyReplayCursor/, "upgrade passes the cursor into PTY attachment");
+assert.match(src, /replayCursor === undefined/, "legacy clients retain full replay");
+assert.match(src, /scrollbackFrom\(session, start\)/, "cursor replay starts at the retained byte suffix");
+assert.match(src, /const reset = replayCursor !== -1 && !validCursor/, "expired cursors request a client reset before full fallback replay");
 
 // Idle keep-alive: Node's 5s default closes idle sockets just as pooled
 // clients (URLSession on iOS, tailscale serve upstreams) reuse them, which
@@ -405,6 +442,161 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
     undefined,
     "empty segments consume maxKeys so credentials beyond the legacy cutoff stay ignored",
   );
+
+}
+
+{
+  const cursorBlock = src.match(/function firstQueryValue[\s\S]+?(?=\ntype UpgradeQuery)/);
+  assert.ok(cursorBlock, "cursor parser is available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${cursorBlock[0]}\nexport { parsePtyReplayCursor };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  const cursorModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const parsePtyReplayCursor = cursorModule.parsePtyReplayCursor as (
+    raw: string | string[] | undefined,
+  ) => number | undefined | null;
+  assert.equal(parsePtyReplayCursor(undefined), undefined, "missing cursor preserves legacy replay");
+  assert.equal(parsePtyReplayCursor("-1"), -1, "-1 negotiates cursor support on first attach");
+  assert.equal(parsePtyReplayCursor("42"), 42, "safe integer cursor is accepted");
+  assert.equal(parsePtyReplayCursor("4.2"), null, "fractional cursor is rejected");
+  assert.equal(parsePtyReplayCursor("-2"), null, "only the documented -1 sentinel is accepted");
+  assert.equal(parsePtyReplayCursor("9007199254740992"), null, "unsafe integer cursor is rejected");
+}
+
+// Execute the pure ring helpers independently of Next, node-pty, and an
+// actual socket. This protects both the one-large-chunk memory cap and exact
+// cursor slicing used for reconnect replay.
+{
+  const ringBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  assert.ok(ringBlock, "scrollback helpers are available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${ringBlock[0]}\nexport { appendScrollback, scrollbackFrom, SCROLLBACK_LIMIT_BYTES };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  const ringModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const appendScrollback = ringModule.appendScrollback as (session: {
+    scrollback: Buffer[];
+    scrollbackBytes: number;
+    scrollbackStart: number;
+    streamEnd: number;
+  }, data: Buffer) => void;
+  const scrollbackFrom = ringModule.scrollbackFrom as (session: {
+    scrollback: Buffer[];
+    scrollbackStart: number;
+  }, cursor: number) => Buffer[];
+  const limit = ringModule.SCROLLBACK_LIMIT_BYTES as number;
+  const session = { scrollback: [] as Buffer[], scrollbackBytes: 0, scrollbackStart: 0, streamEnd: 0 };
+
+  appendScrollback(session, Buffer.from("first"));
+  appendScrollback(session, Buffer.from("-second"));
+  assert.equal(session.streamEnd, 12, "stream end advances by delivered bytes");
+  assert.equal(Buffer.concat(scrollbackFrom(session, 5)).toString(), "-second", "cursor suffix excludes already delivered bytes");
+
+  const large = Buffer.alloc(limit + 17, 0x78);
+  appendScrollback(session, large);
+  assert.equal(session.scrollbackBytes, limit, "one oversized PTY callback cannot exceed scrollback cap");
+  assert.equal(session.scrollbackStart, session.streamEnd - limit, "oversized callback advances retained cursor origin");
+  assert.equal(Buffer.concat(scrollbackFrom(session, session.scrollbackStart)).length, limit, "retained replay is bounded and byte exact");
+  assert.equal(
+    session.scrollback[0].buffer.byteLength,
+    limit,
+    "the retained tail owns a right-sized allocation instead of pinning the oversized callback",
+  );
+}
+
+// Exercise the coalescer with a socket double. This catches regressions that a
+// source-pattern test cannot: small bursts must become one frame, every frame
+// stays capped, and a slow consumer is detached without killing its PTY.
+{
+  const stateBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  const streamingBlock = src.match(/function sendPtyData[\s\S]+?(?=\nfunction sendPtyExit)/);
+  assert.ok(stateBlock && streamingBlock, "streaming helpers are available for behavioral coverage");
+  const { transformSync } = await import("esbuild");
+  const transformed = transformSync(
+    `${stateBlock[0]}\n${streamingBlock[0]}\nexport { PTY_FRAME_MAX_BYTES, PTY_WS_BUFFERED_AMOUNT_LIMIT, queuePtyOutput };`,
+    { loader: "ts", format: "esm", target: "node24" },
+  );
+  (globalThis as typeof globalThis & { WebSocket: { OPEN: number } }).WebSocket = { OPEN: 1 };
+  const streamModule = await import(
+    `data:text/javascript;base64,${Buffer.from(transformed.code).toString("base64")}`,
+  );
+  const queuePtyOutput = streamModule.queuePtyOutput as (
+    threadId: string,
+    session: Record<string, unknown>,
+    data: Buffer,
+  ) => void;
+  const frameLimit = streamModule.PTY_FRAME_MAX_BYTES as number;
+  const bufferedLimit = streamModule.PTY_WS_BUFFERED_AMOUNT_LIMIT as number;
+  const sent: Buffer[] = [];
+  const ws = {
+    readyState: 1,
+    bufferedAmount: 0,
+    send(frame: Buffer) { sent.push(frame); },
+    close() {},
+  };
+  const session = {
+    ws,
+    pendingOutput: [] as Buffer[],
+    pendingOutputBytes: 0,
+    flushTimer: null as NodeJS.Timeout | null,
+    detachTimer: null as NodeJS.Timeout | null,
+    pty: { kill() { throw new Error("slow-consumer eviction must not kill the PTY"); } },
+  };
+  queuePtyOutput("coalesce", session, Buffer.from("one"));
+  queuePtyOutput("coalesce", session, Buffer.from("-two"));
+  await new Promise((resolve) => setTimeout(resolve, 16));
+  assert.deepEqual(sent.map((frame) => frame.subarray(1).toString()), ["one-two"], "a short output burst is coalesced into one frame");
+
+  // #598 baseline metric: the legacy path emitted one frame per PTY callback.
+  // A deterministic same-tick burst must materially reduce
+  // `pty_output_frames_per_burst`, not merely prove that two writes can merge.
+  const burstFrames: Buffer[] = [];
+  const burstWs = {
+    ...ws,
+    send(frame: Buffer) { burstFrames.push(frame); },
+  };
+  const burst = {
+    ...session,
+    ws: burstWs,
+    pendingOutput: [] as Buffer[],
+    pendingOutputBytes: 0,
+    flushTimer: null as NodeJS.Timeout | null,
+    detachTimer: null as NodeJS.Timeout | null,
+  };
+  const legacyFrames = 128;
+  for (let i = 0; i < legacyFrames; i++) {
+    queuePtyOutput("frame-metric", burst, Buffer.from(`line-${i.toString().padStart(3, "0")}\n`));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 16));
+  assert.ok(
+    burstFrames.length <= legacyFrames / 8,
+    `#598 pty_output_frames_per_burst must improve materially: before=${legacyFrames} after=${burstFrames.length}`,
+  );
+  console.log(
+    JSON.stringify({
+      metric: "pty_output_frames_per_burst",
+      issue: 598,
+      before: legacyFrames,
+      after: burstFrames.length,
+    }),
+  );
+
+  queuePtyOutput("coalesce", session, Buffer.alloc(frameLimit * 2 + 3, 0x61));
+  assert.ok(sent.slice(1).every((frame) => frame.length - 1 <= frameLimit), "large output is split into bounded frames");
+
+  const slowWs = { ...ws, bufferedAmount: bufferedLimit, closeCode: 0, close(code: number) { this.closeCode = code; } };
+  const slow = { ...session, ws: slowWs, pendingOutput: [] as Buffer[], pendingOutputBytes: 0, flushTimer: null, detachTimer: null };
+  queuePtyOutput("slow", slow, Buffer.alloc(frameLimit, 0x62));
+  assert.equal(slowWs.closeCode, 1013, "only a slow WebSocket is evicted with Try Again Later");
+  assert.equal(slow.ws, null, "slow consumer is detached while the PTY remains owned by its session");
+  if (slow.detachTimer) clearTimeout(slow.detachTimer);
 }
 
 // Twin parity: `pnpm start` runs the committed server.mjs, not server.ts, so a


### PR DESCRIPTION
## Summary

Bounds PTY WebSocket streaming and adds opt-in absolute-byte replay cursors while preserving the existing PTY and bounded legacy replay. This supersedes #4330 and preserves Timothy Wayne Gregg’s contribution through a linked co-author trailer.

## Why

Closes #4317. A stalled browser could grow WebSocket buffering without a ceiling, and reconnects replayed the entire retained ring rather than only missed output.

## Changes

- Coalesce PTY bursts into frames capped at 16 KiB.
- Evict only slow consumers at a 512 KiB buffered-amount ceiling with retryable close code 1013; retain the PTY for reconnect.
- Keep the 256 KiB scrollback allocation truly bounded, including one oversized callback.
- Add opt-in cursor metadata, suffix-only reconnect replay, expired-cursor reset, and stale-socket ownership guards.
- Keep legacy full replay when either side lacks cursor support.
- Add behavioral protocol, allocation, backpressure, and frame-reduction coverage.

## Verification

- `pnpm build:server` (generated `server.mjs` matches)
- `node --experimental-strip-types src/lib/pty-ws-bridge.test.ts`
- `node --experimental-strip-types src/components/bottom-terminal-ws-bridge.test.ts`
- `node --experimental-strip-types src/server-pty-ws.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,520 files)
- `git diff --check origin/main...HEAD`
- #598 `pty_output_frames_per_burst`: before 128, after 1

## Risk + rollout notes

The cursor protocol is opt-in. Legacy clients retain the prior bounded full replay. If a cursor falls outside the retained 256 KiB window, the client resets before receiving the bounded fallback replay. No PTY process is killed for slow-client eviction.