### PR TITLE
Fix section tabs token drift

### DIFF
--- a/src/styles/sidebar-minimal/section-tabs.css
+++ b/src/styles/sidebar-minimal/section-tabs.css
@@ -13,8 +13,8 @@
   grid-auto-columns: 1fr;
   gap: var(--space-1);
   flex-shrink: 0;
-  margin: 0 6px var(--space-1);
-  padding: 3px;
+  margin: 0 var(--space-1) var(--space-1);
+  padding: var(--space-1);
   border-radius: var(--radius-control);
   background: var(--bg-sunken);
   border: 1px solid color-mix(in oklch, var(--border-hairline) 55%, transparent);
@@ -24,7 +24,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 6px;
+  gap: var(--space-1);
   min-height: 26px;
   padding: 0 var(--space-2);
   border: 0;
@@ -75,7 +75,7 @@
 .shell-nav--rail .nav-sections {
   grid-auto-flow: row;
   grid-auto-columns: auto;
-  margin-inline: 4px;
+  margin-inline: var(--space-1);
 }
 
 .shell-nav--rail .nav-sections__label {


### PR DESCRIPTION
## What changed
- replace the Home/Code section tabs’ on-scale `4px` literal with `--space-1`
- snap the three new off-grid `3px`/`6px` spacing values to the same 4px token
- keep the existing `offScaleSpacingPx` baseline at 1654 instead of accepting new drift

## Verification
- `src/lib/design-token-drift.test.ts` (space ratchet = 1654)
- `src/components/nav-section-tabs.test.ts`
- `src/components/chat-sidebar-wiring.test.ts`
- `pnpm lint`

Full `pnpm typecheck` remains blocked by the pre-existing `src/components/canvas-editor.test.ts(204,1): TS1128` failure already present on `origin/main`.

Bead: cave-98wy1