### PR TITLE
fix: restore Canvas and focus-ring contracts

### DIFF
--- a/src/components/canvas-editor.test.ts
+++ b/src/components/canvas-editor.test.ts
@@ -125,6 +125,7 @@ assert.match(
 
 // ── Editor source pins ──────────────────────────────────────────────────────
 const editor = readFileSync(new URL("./canvas-editor.tsx", import.meta.url), "utf8");
+const editorStyles = readFileSync(new URL("../styles/canvas-editor.css", import.meta.url), "utf8");
 
 // Contract the gallery agent wires against.
 assert.match(editor, /export function CanvasEditor\(props: \{/, "CanvasEditor is exported");
@@ -137,6 +138,11 @@ assert.match(
   "editor reports server-accepted artifact updates",
 );
 assert.match(editor, /import "@\/styles\/canvas-editor\.css";/, "editor imports its stylesheet");
+assert.doesNotMatch(
+  editorStyles,
+  /\.canvas-editor__play-(?:card|row)\b/,
+  "retired Play mode does not leave dead stylesheet selectors",
+);
 
 // Inspector wiring replicates the viewer's deliberate security boundary.
 assert.match(

--- a/src/styles/canvas-editor.css
+++ b/src/styles/canvas-editor.css
@@ -328,25 +328,6 @@
   border-radius: var(--radius-card);
   background: var(--bg-base);
 }
-/* Play mode: the sketch owns its own input, so the aside only explains the
-   handover and offers a way back to frame one. */
-.canvas-editor__play-card {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-2);
-  align-items: flex-start;
-  padding: var(--space-3);
-  border: 1px solid color-mix(in oklch, var(--accent-presence) 34%, transparent);
-  border-radius: var(--radius-card);
-  background: color-mix(in oklch, var(--accent-presence) 14%, var(--bg-base));
-}
-.canvas-editor__play-row {
-  display: flex;
-  gap: var(--space-2);
-  align-items: center;
-  font-size: var(--text-sm);
-  color: var(--text-secondary);
-}
 .canvas-editor__sel-label {
   font-size: var(--text-base);
   font-weight: 600;

--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -324,7 +324,20 @@ test.describe("code surface (Coding familiar's room)", () => {
     const sessionsTab = page.getByRole("tab", { name: "Sessions" });
     await sessionsTab.focus();
     await expect(sessionsTab).toBeFocused();
-    await expect(sessionsTab).toHaveClass(/focus-ring-inset/);
+    await expect(sessionsTab).toHaveClass(/\bfocus-ring(?:\s|$)/);
+    await expect
+      .poll(
+        () =>
+          sessionsTab.evaluate((element) => {
+            const style = getComputedStyle(element);
+            return {
+              outlineOffset: style.outlineOffset,
+              outlineWidth: style.outlineWidth,
+            };
+          }),
+        { timeout: 30_000 },
+      )
+      .toEqual({ outlineOffset: "2px", outlineWidth: "2px" });
 
     await page.getByRole("button", { name: "GitHub organization settings" }).click();
     const popover = page.getByRole("dialog", { name: "GitHub organization settings" });


### PR DESCRIPTION
## Summary

Finishes the post-merge cleanup from #4365 and restores behavioral focus-ring coverage.

## Why

#4365 merged with two required review findings still present: retired Canvas Play selectors remained in the stylesheet, and the Code surface E2E asserted only a class name after CI observed the wrong computed ring.

Tracked by Bead `cave-65ol1`.

## Changes

- Remove the dead `.canvas-editor__play-card` and `.canvas-editor__play-row` rules.
- Add a Canvas source contract that prevents retired Play selectors from returning.
- Assert the current `focus-ring` token and its computed `2px` width / `2px` offset with a 30-second CSS readiness window.

## Verification

- `pnpm exec vitest run src/components/canvas-editor.test.ts`
- `PORT=3199 pnpm exec playwright test tests/code-surface.spec.ts --project=desktop --no-deps --grep "organization settings move focus inside"`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1,511 files)
- `git diff --check origin/main...HEAD`

## Risk + rollout notes

Low risk: one dead-CSS deletion and test-only coverage changes. No runtime behavior or data migration.