### PR TITLE
fix: make sidecar reap test portable

### DIFF
--- a/src-tauri/src/app_lifecycle_tests.rs
+++ b/src-tauri/src/app_lifecycle_tests.rs
@@ -446,10 +446,16 @@ fn startup_failure_stops_and_reaps_owned_sidecar() {
 
     assert_eq!(message, "startup timed out");
     assert!(slot.lock().expect("sidecar slot").is_none());
-    assert_eq!(unsafe { libc::kill(child_pid as i32, 0) }, -1);
-    assert_eq!(
-        std::io::Error::last_os_error().raw_os_error(),
-        Some(libc::ESRCH)
+    let probe = Command::new("kill")
+        .arg("-0")
+        .arg(child_pid.to_string())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("probe reaped startup failure fixture");
+    assert!(
+        !probe.success(),
+        "startup failure fixture should no longer exist"
     );
 }
 


### PR DESCRIPTION
## Summary
- replace the Unix-only direct `libc::kill` probe with the portable POSIX `kill -0` command in the non-Windows lifecycle test
- restore Linux compilation without adding `libc` as a broader target dependency
- keep the test assertion that a failed startup process has been reaped

## Verification
- `rustfmt --check src-tauri/src/app_lifecycle_tests.rs`
- `cargo test --locked --manifest-path src-tauri/Cargo.toml --lib app_lifecycle_tests::startup_failure_stops_and_reaps_owned_sidecar -- --nocapture`
- `cargo check --locked --manifest-path src-tauri/Cargo.toml`
- `git diff --check origin/main...HEAD`

## Baseline note
`cargo fmt --check --manifest-path src-tauri/Cargo.toml` remains red on unrelated files already present on current `main`; the changed file passes `rustfmt --check`.

Bead: `cave-vw6jo`