### PR TITLE
fix: bound desktop sidecar output

### DIFF
--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -58,8 +58,13 @@ assert.match(
 );
 assert.match(
   reachability,
-  /create_fresh_log_file[\s\S]*\.truncate\(true\)/,
-  "each daemon launch must discard stale readiness output before repairing Serve",
+  /let sidecar_output = Arc::new\(Mutex::new\(SidecarOutputTail::default\(\)\)\)[\s\S]*stdout\(Stdio::piped\(\)\)[\s\S]*stderr\(Stdio::piped\(\)\)[\s\S]*capture_sidecar_output/,
+  "background sidecars must drain readiness output into a bounded in-memory tail",
+);
+assert.doesNotMatch(
+  reachability,
+  /sidecar-daemon-server\.log|create_fresh_log_file/,
+  "background sidecars must not accumulate persistent launch logs",
 );
 assert.match(
   reachability,

--- a/src-tauri/src/app_lifecycle_tests.rs
+++ b/src-tauri/src/app_lifecycle_tests.rs
@@ -206,17 +206,36 @@ fn notch_url_carries_the_presentation_state_to_the_page() {
 }
 
 #[test]
-fn sidecar_log_paths_are_isolated_by_process_and_port() {
-    let log_dir = std::env::temp_dir().join("covencave-sidecar-log-path-test");
-    let first = sidecar_log_path(&log_dir, 41001);
-    let second = sidecar_log_path(&log_dir, 41002);
+fn sidecar_output_tail_retains_only_the_newest_256_kibibytes() {
+    let mut output = SidecarOutputTail::default();
+    output.push(&vec![b'a'; SIDECAR_OUTPUT_TAIL_BYTES]);
+    output.push(b"newest");
 
-    assert_ne!(first, second);
-    let expected = format!("sidecar-{}-41001.log", std::process::id());
-    assert_eq!(
-        first.file_name().and_then(|name| name.to_str()),
-        Some(expected.as_str())
+    let captured = output.snapshot();
+    assert_eq!(captured.len(), SIDECAR_OUTPUT_TAIL_BYTES);
+    assert!(captured.ends_with(b"newest"));
+
+    output.push(&vec![b'b'; SIDECAR_OUTPUT_TAIL_BYTES + 32]);
+    assert_eq!(output.snapshot(), vec![b'b'; SIDECAR_OUTPUT_TAIL_BYTES]);
+}
+
+#[test]
+fn stdout_and_stderr_feed_one_shared_bounded_sidecar_tail() {
+    let output = Arc::new(Mutex::new(SidecarOutputTail::default()));
+    let stdout = capture_sidecar_output(
+        std::io::Cursor::new(b"stdout line\n".to_vec()),
+        Arc::clone(&output),
     );
+    let stderr = capture_sidecar_output(
+        std::io::Cursor::new(b"stderr line\n".to_vec()),
+        Arc::clone(&output),
+    );
+
+    stdout.join().expect("join stdout capture");
+    stderr.join().expect("join stderr capture");
+    let text = output.lock().expect("output tail").text();
+    assert!(text.contains("stdout line"));
+    assert!(text.contains("stderr line"));
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -229,39 +248,41 @@ fn packaged_sidecar_start_timeout_allows_slow_cold_start() {
 fn sidecar_port_wait_is_cancellable_and_detects_readiness() {
     let listener = TcpListener::bind("127.0.0.1:0").expect("bind readiness fixture");
     let port = listener.local_addr().expect("fixture address").port();
-    let log_dir = std::env::temp_dir().join(format!(
-        "covencave-sidecar-ready-test-{}-{}",
-        std::process::id(),
-        port
-    ));
-    std::fs::create_dir_all(&log_dir).expect("create log fixture dir");
-    let log_path = log_dir.join("sidecar.log");
+    let output = Arc::new(Mutex::new(SidecarOutputTail::default()));
 
     // A listening port without the sidecar's own ready log line must NOT
     // be trusted — that's the port-squatting scenario this guards against.
-    std::fs::write(&log_path, "starting up\n").expect("write log fixture");
+    output.lock().expect("output tail").push(b"starting up\n");
     assert!(matches!(
-        wait_for_sidecar_ready(port, &log_path, Duration::from_millis(600), || false),
+        wait_for_sidecar_ready(
+            port,
+            &output,
+            Duration::from_millis(600),
+            || false,
+            || false
+        ),
         PortWaitResult::TimedOut
     ));
 
-    std::fs::write(
-        &log_path,
-        format!("starting up\n> Ready on http://127.0.0.1:{}\n", port),
-    )
-    .expect("write ready log fixture");
     assert!(matches!(
-        wait_for_sidecar_ready(port, &log_path, Duration::from_secs(1), || false),
+        wait_for_sidecar_ready(port, &output, Duration::from_secs(1), || false, || true),
+        PortWaitResult::Exited
+    ));
+
+    output
+        .lock()
+        .expect("output tail")
+        .push(format!("> Ready on http://127.0.0.1:{}\n", port).as_bytes());
+    assert!(matches!(
+        wait_for_sidecar_ready(port, &output, Duration::from_secs(1), || false, || false),
         PortWaitResult::Ready
     ));
     drop(listener);
 
     assert!(matches!(
-        wait_for_sidecar_ready(port, &log_path, Duration::from_secs(1), || true),
+        wait_for_sidecar_ready(port, &output, Duration::from_secs(1), || true, || false),
         PortWaitResult::Cancelled
     ));
-
-    let _ = std::fs::remove_dir_all(&log_dir);
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -1427,16 +1427,6 @@ fn daemon_port() -> Result<u16, String> {
     find_free_port().ok_or_else(|| "no free loopback port is available".to_string())
 }
 
-#[cfg(desktop)]
-fn create_fresh_log_file(path: &Path) -> Result<std::fs::File, String> {
-    std::fs::OpenOptions::new()
-        .create(true)
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .map_err(|error| format!("could not create {}: {error}", path.display()))
-}
-
 #[cfg(all(desktop, target_os = "macos"))]
 fn daemon_shutdown_requested() -> bool {
     DAEMON_SHUTDOWN_REQUESTED.load(Ordering::Acquire)
@@ -1565,19 +1555,7 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     let auth_token = sidecar_auth_token();
     let mobile_access_token =
         load_or_create_mobile_access_token(&app_data_dir.join(MOBILE_ACCESS_TOKEN_FILE));
-    let log_dir = std::env::var("HOME")
-        .map(PathBuf::from)
-        .map_err(|_| "HOME is unavailable".to_string())?
-        .join("Library")
-        .join("Logs")
-        .join("CovenCave");
-    std::fs::create_dir_all(&log_dir)
-        .map_err(|error| format!("could not create {}: {error}", log_dir.display()))?;
-    let server_log = log_dir.join("sidecar-daemon-server.log");
-    let stdout = create_fresh_log_file(&server_log)?;
-    let stderr = stdout
-        .try_clone()
-        .map_err(|error| format!("could not duplicate {}: {error}", server_log.display()))?;
+    let sidecar_output = Arc::new(Mutex::new(SidecarOutputTail::default()));
 
     let mut command = Command::new(&node);
     command
@@ -1592,9 +1570,9 @@ fn run_sidecar_daemon() -> Result<i32, String> {
         .env("COVEN_KOKORO_BIN", &kokoro)
         .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
         .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token)
-        .stdin(Stdio::null());
-    command.stdout(Stdio::from(stdout));
-    command.stderr(Stdio::from(stderr));
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
     // Take the same lease as GUI startup immediately before creating the
     // child. A GUI that wins this lease writes its marker first; a daemon that
     // wins records its child before releasing it, so the GUI can stop it
@@ -1609,6 +1587,24 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not start background sidecar: {error}"))?;
+    let stdout = match child.stdout.take() {
+        Some(stdout) => stdout,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("background sidecar stdout pipe was unavailable".to_string());
+        }
+    };
+    let stderr = match child.stderr.take() {
+        Some(stderr) => stderr,
+        None => {
+            let _ = child.kill();
+            let _ = child.wait();
+            return Err("background sidecar stderr pipe was unavailable".to_string());
+        }
+    };
+    capture_sidecar_output(stdout, Arc::clone(&sidecar_output));
+    capture_sidecar_output(stderr, Arc::clone(&sidecar_output));
     let child_pid = child.id();
     let identity = match process_identity(child_pid) {
         Some(identity) => identity,
@@ -1631,9 +1627,13 @@ fn run_sidecar_daemon() -> Result<i32, String> {
     }
     drop(ownership);
 
-    match wait_for_sidecar_ready(port, &server_log, Duration::from_secs(30), || {
-        gui_is_active(&app_data_dir) || daemon_shutdown_requested()
-    }) {
+    match wait_for_sidecar_ready(
+        port,
+        &sidecar_output,
+        Duration::from_secs(30),
+        || gui_is_active(&app_data_dir) || daemon_shutdown_requested(),
+        || child.try_wait().ok().flatten().is_some(),
+    ) {
         PortWaitResult::Ready => {}
         PortWaitResult::Cancelled => {
             let _ = child.kill();
@@ -1641,12 +1641,21 @@ fn run_sidecar_daemon() -> Result<i32, String> {
             let _ = std::fs::remove_file(&state_path);
             return Ok(0);
         }
+        PortWaitResult::Exited => {
+            let _ = child.wait();
+            let _ = std::fs::remove_file(&state_path);
+            return Err(format!(
+                "background sidecar exited before becoming ready on port {port}. Bounded sidecar output tail:\n{}",
+                sidecar_output_text(&sidecar_output)
+            ));
+        }
         PortWaitResult::TimedOut => {
             let _ = child.kill();
             let _ = child.wait();
             let _ = std::fs::remove_file(&state_path);
             return Err(format!(
-                "background sidecar did not become ready on port {port}"
+                "background sidecar did not become ready on port {port}. Bounded sidecar output tail:\n{}",
+                sidecar_output_text(&sidecar_output)
             ));
         }
     }
@@ -1901,24 +1910,5 @@ mod tests {
         )
         .expect("GUI ownership state deserializes");
         assert_eq!(restored.sidecar.expect("sidecar is retained").port, 3007);
-    }
-
-    #[test]
-    fn daemon_readiness_log_is_empty_for_each_launch() {
-        let path = std::env::temp_dir().join(format!(
-            "coven-daemon-ready-test-{}-{:?}.log",
-            std::process::id(),
-            std::thread::current().id()
-        ));
-        std::fs::write(&path, "> Ready on http://127.0.0.1:3000\n").expect("seed stale log");
-        let mut fresh = create_fresh_log_file(&path).expect("truncate daemon log");
-        fresh
-            .write_all(b"> Ready on http://127.0.0.1:3007\n")
-            .expect("write new readiness");
-        fresh.sync_all().expect("flush readiness");
-        let log = std::fs::read_to_string(&path).expect("read fresh daemon log");
-        assert!(!log.contains("3000"));
-        assert!(log.contains("3007"));
-        let _ = std::fs::remove_file(path);
     }
 }

--- a/src-tauri/src/sidecar_lifecycle.rs
+++ b/src-tauri/src/sidecar_lifecycle.rs
@@ -23,6 +23,13 @@ impl SidecarProcess {
         self.child.id()
     }
 
+    pub(super) fn has_exited(&mut self) -> Result<bool, String> {
+        self.child
+            .try_wait()
+            .map(|status| status.is_some())
+            .map_err(|error| format!("could not inspect sidecar process: {error}"))
+    }
+
     /// A reachability assertion may only follow the exact child retained by
     /// this state. PID existence alone is not ownership: the OS may reuse a
     /// PID after a crashed sidecar exits.
@@ -59,6 +66,7 @@ pub(super) enum SidecarStartError {
 pub(super) enum PortWaitResult {
     Ready,
     Cancelled,
+    Exited,
     TimedOut,
 }
 

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -1,4 +1,89 @@
 use super::*;
+use std::collections::VecDeque;
+use std::io::Read;
+
+#[cfg(desktop)]
+pub(super) const SIDECAR_OUTPUT_TAIL_BYTES: usize = 256 * 1024;
+
+#[cfg(desktop)]
+#[derive(Default)]
+pub(super) struct SidecarOutputTail {
+    bytes: VecDeque<u8>,
+}
+
+#[cfg(desktop)]
+impl SidecarOutputTail {
+    pub(super) fn push(&mut self, chunk: &[u8]) {
+        if chunk.len() >= SIDECAR_OUTPUT_TAIL_BYTES {
+            self.bytes.clear();
+            self.bytes.extend(
+                chunk[chunk.len() - SIDECAR_OUTPUT_TAIL_BYTES..]
+                    .iter()
+                    .copied(),
+            );
+            return;
+        }
+
+        let overflow = self
+            .bytes
+            .len()
+            .saturating_add(chunk.len())
+            .saturating_sub(SIDECAR_OUTPUT_TAIL_BYTES);
+        if overflow > 0 {
+            self.bytes.drain(..overflow);
+        }
+        self.bytes.extend(chunk.iter().copied());
+    }
+
+    #[cfg(test)]
+    pub(super) fn snapshot(&self) -> Vec<u8> {
+        self.bytes.iter().copied().collect()
+    }
+
+    pub(super) fn text(&self) -> String {
+        let bytes: Vec<u8> = self.bytes.iter().copied().collect();
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+}
+
+#[cfg(desktop)]
+pub(super) fn capture_sidecar_output(
+    mut reader: impl Read + Send + 'static,
+    output: Arc<Mutex<SidecarOutputTail>>,
+) -> thread::JoinHandle<()> {
+    thread::spawn(move || {
+        let mut buffer = [0_u8; 8192];
+        loop {
+            match reader.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    if let Ok(mut output) = output.lock() {
+                        output.push(&buffer[..read]);
+                    } else {
+                        break;
+                    }
+                }
+                Err(error) => {
+                    log::warn!("[cave] sidecar output capture stopped: {error}");
+                    break;
+                }
+            }
+        }
+    })
+}
+
+#[cfg(desktop)]
+pub(super) fn sidecar_output_text(output: &Arc<Mutex<SidecarOutputTail>>) -> String {
+    let captured = output
+        .lock()
+        .map(|output| output.text())
+        .unwrap_or_else(|_| "(could not read sidecar output)".to_string());
+    if captured.is_empty() {
+        "(no output captured)".to_string()
+    } else {
+        captured
+    }
+}
 
 #[cfg(desktop)]
 pub(super) fn find_free_port() -> Option<u16> {
@@ -46,9 +131,10 @@ pub(super) fn live_dev_server_url(app: &tauri::App) -> Option<tauri::Url> {
 #[cfg(desktop)]
 pub(super) fn wait_for_sidecar_ready(
     port: u16,
-    log_path: &Path,
+    output: &Arc<Mutex<SidecarOutputTail>>,
     timeout: Duration,
     should_cancel: impl Fn() -> bool,
+    mut child_exited: impl FnMut() -> bool,
 ) -> PortWaitResult {
     use std::net::{SocketAddr, TcpStream};
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
@@ -60,8 +146,12 @@ pub(super) fn wait_for_sidecar_ready(
         if should_cancel() {
             return PortWaitResult::Cancelled;
         }
-        let logged_ready = std::fs::read_to_string(log_path)
-            .map(|log| log.lines().any(|line| line.trim() == ready_line))
+        if child_exited() {
+            return PortWaitResult::Exited;
+        }
+        let logged_ready = output
+            .lock()
+            .map(|output| output.text().lines().any(|line| line.trim() == ready_line))
             .unwrap_or(false);
         if logged_ready && TcpStream::connect_timeout(&addr, Duration::from_millis(200)).is_ok() {
             return PortWaitResult::Ready;
@@ -69,11 +159,6 @@ pub(super) fn wait_for_sidecar_ready(
         thread::sleep(Duration::from_millis(150));
     }
     PortWaitResult::TimedOut
-}
-
-#[cfg(desktop)]
-pub(super) fn sidecar_log_path(log_dir: &Path, port: u16) -> PathBuf {
-    log_dir.join(format!("sidecar-{}-{port}.log", std::process::id()))
 }
 
 #[cfg(desktop)]
@@ -190,41 +275,10 @@ pub(super) fn start_sidecar_runtime(
     })?;
     log::info!("[cave] using bundled Whisper at {}", whisper_cli.display());
 
-    // Capture sidecar logs so startup failures can be surfaced in the local
-    // preparation window instead of leaving a blank webview.
-    let log_dir = {
-        #[cfg(target_os = "macos")]
-        {
-            std::env::var("HOME")
-                .map(|home| PathBuf::from(home).join("Library/Logs/CovenCave"))
-                .unwrap_or_else(|_| std::env::temp_dir())
-        }
-        #[cfg(target_os = "windows")]
-        {
-            PathBuf::from(
-                std::env::var("APPDATA")
-                    .unwrap_or_else(|_| std::env::temp_dir().to_string_lossy().into()),
-            )
-            .join("CovenCave")
-            .join("logs")
-        }
-        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-        {
-            std::env::var("HOME")
-                .map(|home| PathBuf::from(home).join(".local/share/CovenCave/logs"))
-                .unwrap_or_else(|_| std::env::temp_dir())
-        }
-    };
-    if let Err(error) = std::fs::create_dir_all(&log_dir) {
-        log::warn!(
-            "[cave] could not create sidecar log directory {}: {error}",
-            log_dir.display()
-        );
-    }
-    let log_path = sidecar_log_path(&log_dir, port);
-    log::info!("[cave] sidecar log -> {}", log_path.display());
-    let stdout_log = std::fs::File::create(&log_path).ok();
-    let stderr_log = stdout_log.as_ref().and_then(|file| file.try_clone().ok());
+    // Keep startup evidence in one fixed-size memory tail. Reader threads keep
+    // draining both pipes for the sidecar's lifetime, so successful launches
+    // do not leave persistent per-process log files behind.
+    let sidecar_output = Arc::new(Mutex::new(SidecarOutputTail::default()));
 
     let server_dir = server_entry.parent().ok_or_else(|| {
         SidecarStartError::Failed("server entry has no parent directory".to_string())
@@ -314,16 +368,7 @@ pub(super) fn start_sidecar_runtime(
         command.env("LD_LIBRARY_PATH", whisper_dir);
     }
 
-    if let Some(output) = stdout_log {
-        command.stdout(Stdio::from(output));
-    } else {
-        command.stdout(Stdio::null());
-    }
-    if let Some(error_output) = stderr_log {
-        command.stderr(Stdio::from(error_output));
-    } else {
-        command.stderr(Stdio::null());
-    }
+    command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     #[cfg(target_os = "windows")]
     {
@@ -333,6 +378,16 @@ pub(super) fn start_sidecar_runtime(
     let mut child = command.spawn().map_err(|error| {
         SidecarStartError::Failed(format!("failed to spawn node sidecar: {error}"))
     })?;
+    let stdout = child.stdout.take().ok_or_else(|| {
+        let _ = child.kill();
+        SidecarStartError::Failed("node sidecar stdout pipe was unavailable".to_string())
+    })?;
+    let stderr = child.stderr.take().ok_or_else(|| {
+        let _ = child.kill();
+        SidecarStartError::Failed("node sidecar stderr pipe was unavailable".to_string())
+    })?;
+    capture_sidecar_output(stdout, Arc::clone(&sidecar_output));
+    capture_sidecar_output(stderr, Arc::clone(&sidecar_output));
     #[cfg(target_os = "windows")]
     let child = {
         if let Err(error) = process_job.assign_child(&child) {
@@ -369,28 +424,41 @@ pub(super) fn start_sidecar_runtime(
 
     on_step(SidecarStartupStep::WaitingForService);
     let sidecar_start_timeout = sidecar_start_timeout();
-    match wait_for_sidecar_ready(port, &log_path, sidecar_start_timeout, &should_cancel) {
+    let child_exited = || {
+        sidecar_state
+            .0
+            .lock()
+            .map(|mut sidecar| {
+                sidecar
+                    .as_mut()
+                    .is_none_or(|sidecar| sidecar.has_exited().unwrap_or(true))
+            })
+            .unwrap_or(true)
+    };
+    match wait_for_sidecar_ready(
+        port,
+        &sidecar_output,
+        sidecar_start_timeout,
+        &should_cancel,
+        child_exited,
+    ) {
         PortWaitResult::Ready => {}
         PortWaitResult::Cancelled => return Err(SidecarStartError::Cancelled),
-        PortWaitResult::TimedOut => {
-            let tail = std::fs::read_to_string(&log_path)
-                .ok()
-                .map(|contents| {
-                    let lines: Vec<&str> = contents.lines().rev().take(8).collect();
-                    let mut tail = lines.into_iter().rev().collect::<Vec<_>>().join("\n");
-                    if tail.is_empty() {
-                        tail.push_str("(no output captured)");
-                    }
-                    tail
-                })
-                .unwrap_or_else(|| "(could not read sidecar log)".to_string());
+        result @ (PortWaitResult::Exited | PortWaitResult::TimedOut) => {
+            let reason = match result {
+                PortWaitResult::Exited => "exited before becoming ready".to_string(),
+                PortWaitResult::TimedOut => format!(
+                    "did not become ready within {}s",
+                    sidecar_start_timeout.as_secs()
+                ),
+                _ => unreachable!(),
+            };
             return Err(SidecarStartError::Failed(format!(
-                "Sidecar (node {}) did not become ready on port {} within {}s.\n\nLast lines from {}:\n{}",
+                "Sidecar (node {}) {} on port {}.\n\nBounded sidecar output tail:\n{}",
                 node.display(),
+                reason,
                 port,
-                sidecar_start_timeout.as_secs(),
-                log_path.display(),
-                tail
+                sidecar_output_text(&sidecar_output)
             )));
         }
     }

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -238,6 +238,16 @@ assert.match(
 );
 assert.match(
   tauriSource,
-  /wait_for_sidecar_ready\(port, &log_path, sidecar_start_timeout, &should_cancel\)/,
-  "Tauri sidecar should require the launched sidecar's ready log before trusting the URL",
+  /wait_for_sidecar_ready\(\s*port,\s*&sidecar_output,\s*sidecar_start_timeout,\s*&should_cancel,\s*child_exited,\s*\)/,
+  "Tauri sidecar should require bounded launch output and a live child before trusting the URL",
+);
+assert.match(
+  tauriSource,
+  /let child_exited = \|\|[\s\S]*sidecar\.has_exited\(\)/,
+  "Tauri sidecar readiness should detect an early child exit",
+);
+assert.doesNotMatch(
+  tauriSource,
+  /sidecar_log_path|sidecar-daemon-server\.log|create_fresh_log_file/,
+  "Tauri sidecar should not persist daemon launch output",
 );


### PR DESCRIPTION
## Summary
- replace persistent desktop sidecar launch logs with a shared 256 KiB in-memory stdout/stderr tail
- keep readiness tied to the launched process and fail immediately when it exits
- include the bounded tail in startup timeout/exit diagnostics without accumulating files

Follow-up for #599. Bead: `cave-tx3f8`.

## Verification
- `cargo test --manifest-path src-tauri/Cargo.toml --lib app_lifecycle_tests` (18 passed)
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `rustfmt --edition 2021 --check` on all four touched Rust files
- `node scripts/desktop-reachability.test.mjs`
- `node src/middleware.test.ts`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` (1,103 files passed)
- `pnpm test:api` (341 files passed)
- `pnpm test:mobile` (84 files passed)
- `pnpm build`
- repository pre-commit secret/privacy guard (6 files scanned)