### PR TITLE
fix: reap Unix sidecars on parent exit

### DIFF
--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -13,6 +13,7 @@ const [
   mobileScript,
   uninstall,
   docs,
+  server,
 ] = await Promise.all([
   read("../src-tauri/src/desktop_reachability.rs"),
   read("../src-tauri/src/tauri_setup.rs"),
@@ -23,6 +24,7 @@ const [
   read("./mobile-tailscale.sh"),
   read("./uninstall-app.sh"),
   read("../docs/mobile-tailscale.md"),
+  read("../server.ts"),
 ]);
 
 assert.match(
@@ -165,6 +167,31 @@ assert.match(
   startup,
   /wait_for_sidecar_ready[\s\S]*sidecar_reachability_ready\(app, port, sidecar_pid\)/,
   "Serve repair and the power monitor must start only after the selected port is ready",
+);
+assert.match(
+  startup,
+  /configure_unix_sidecar_parent_watchdog\(&mut command\)/,
+  "packaged Unix sidecars must inherit an exact parent-death lease",
+);
+assert.match(
+  lifecycle,
+  /stdin\(Stdio::piped\(\)\)[\s\S]*COVEN_CAVE_PARENT_WATCHDOG[\s\S]*stdin-eof[\s\S]*process_group\(0\)/,
+  "the Unix parent lease must be an inherited pipe and the child must own its process group",
+);
+assert.match(
+  lifecycle,
+  /child\.stdin\.take\(\)[\s\S]*Duration::from_secs\(2\)[\s\S]*could not inspect watched sidecar/,
+  "normal Unix cleanup must close the same parent lease with a bounded fallback",
+);
+assert.match(
+  server,
+  /COVEN_CAVE_PARENT_WATCHDOG === "stdin-eof"[\s\S]*process\.stdin\.once\("end"[\s\S]*process\.stdin\.once\("error"[\s\S]*process\.stdin\.resume\(\)/,
+  "the packaged server must attach exact-parent EOF handlers before starting stdin flow",
+);
+assert.match(
+  server,
+  /function terminatePackagedUnixSidecarTree[\s\S]*process\.kill\(-process\.pid, "SIGKILL"\)/,
+  "parent EOF must kill the packaged server's owned Unix process group",
 );
 assert.match(
   reachability,

--- a/server.mjs
+++ b/server.mjs
@@ -55,6 +55,25 @@ const LEGACY_ACCESS_COOKIE = "coven_access_token";
 const ACCESS_QUERY_PARAM = "coven_access_token";
 const SIDECAR_QUERY_PARAM = "covenCaveToken";
 const sessions = /* @__PURE__ */ new Map();
+function terminatePackagedUnixSidecarTree() {
+  for (const session of sessions.values()) {
+    try {
+      session.pty.kill();
+    } catch {
+    }
+  }
+  sessions.clear();
+  try {
+    process.kill(-process.pid, "SIGKILL");
+  } catch {
+    process.exit(1);
+  }
+}
+if (process.platform !== "win32" && process.env.COVEN_CAVE_PARENT_WATCHDOG === "stdin-eof") {
+  process.stdin.once("end", terminatePackagedUnixSidecarTree);
+  process.stdin.once("error", terminatePackagedUnixSidecarTree);
+  process.stdin.resume();
+}
 const SCROLLBACK_LIMIT_BYTES = 256 * 1024;
 const PTY_FRAME_COALESCE_MS = 8;
 const PTY_FRAME_MAX_BYTES = 16 * 1024;

--- a/server.ts
+++ b/server.ts
@@ -120,6 +120,37 @@ type PtySession = {
 
 const sessions = new Map<string, PtySession>();
 
+// Packaged Unix sidecars receive stdin as a private pipe whose write end is
+// owned only by the Tauri GUI. EOF therefore identifies the exact parent
+// lifetime without polling a reusable PID. The sidecar is also launched as
+// its own process-group leader, so one signal removes the root and ordinary
+// descendants; node-pty sessions are asked to stop explicitly because a PTY
+// may create a separate session/process group.
+function terminatePackagedUnixSidecarTree(): void {
+  for (const session of sessions.values()) {
+    try {
+      session.pty.kill();
+    } catch {
+      // The PTY may already have exited.
+    }
+  }
+  sessions.clear();
+  try {
+    process.kill(-process.pid, "SIGKILL");
+  } catch {
+    process.exit(1);
+  }
+}
+
+if (
+  process.platform !== "win32" &&
+  process.env.COVEN_CAVE_PARENT_WATCHDOG === "stdin-eof"
+) {
+  process.stdin.once("end", terminatePackagedUnixSidecarTree);
+  process.stdin.once("error", terminatePackagedUnixSidecarTree);
+  process.stdin.resume();
+}
+
 // Recent-output ring replayed to a (re)attaching client so it repaints the
 // screen instead of staring at a blank pane. Matches the Rust desktop PTY's
 // 256KB ring (src-tauri/src/pty.rs).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -88,3 +88,8 @@ objc2-foundation = "0.3"
 objc2-speech = "0.3"
 objc2-avf-audio = "0.3"
 block2 = "0.6"
+
+# Unix lifecycle tests hard-kill exact owned process groups. Keep libc
+# test-only on Linux while reusing the macOS runtime dependency above.
+[target.'cfg(unix)'.dev-dependencies]
+libc = "0.2"

--- a/src-tauri/src/app_lifecycle_tests.rs
+++ b/src-tauri/src/app_lifecycle_tests.rs
@@ -450,6 +450,139 @@ fn sidecar_cleanup_is_idempotent_when_no_child_is_running() {
     state.stop().expect("second empty cleanup");
 }
 
+#[cfg(unix)]
+const UNIX_PARENT_DEATH_HELPER_ROLE: &str = "COVEN_CAVE_TEST_PARENT_DEATH_ROLE";
+
+#[cfg(unix)]
+#[test]
+fn unix_parent_death_parent_helper() {
+    use std::io::{BufRead, BufReader, Write};
+
+    if std::env::var(UNIX_PARENT_DEATH_HELPER_ROLE).as_deref() != Ok("parent") {
+        return;
+    }
+
+    let mut command = Command::new("sh");
+    command
+        .args([
+            "-c",
+            "sleep 30 & descendant=$!; echo CHILD_READY $descendant; cat >/dev/null; kill -KILL 0",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    configure_unix_sidecar_parent_watchdog(&mut command);
+    let mut child = command.spawn().expect("spawn watched sidecar fixture");
+    let mut readiness = String::new();
+    BufReader::new(child.stdout.take().expect("child stdout"))
+        .read_line(&mut readiness)
+        .expect("read child readiness");
+    println!("PARENT_READY {} {}", child.id(), readiness.trim());
+    std::io::stdout().flush().expect("flush parent readiness");
+
+    // Skip every Rust destructor to model a crash/force-quit. Kernel fd close
+    // is the only notification the child receives.
+    unsafe { libc::_exit(0) }
+}
+
+#[cfg(unix)]
+#[test]
+fn repeated_abrupt_parent_exit_reaps_the_exact_sidecar_process_group() {
+    use std::io::{BufRead, BufReader};
+
+    for cycle in 1..=3 {
+        let mut parent = Command::new(std::env::current_exe().expect("current test executable"))
+            .args([
+                "--exact",
+                "app_lifecycle_tests::unix_parent_death_parent_helper",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(UNIX_PARENT_DEATH_HELPER_ROLE, "parent")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn abrupt parent fixture");
+        let mut reader = BufReader::new(parent.stdout.take().expect("parent stdout"));
+        let mut readiness = String::new();
+        loop {
+            readiness.clear();
+            let read = reader
+                .read_line(&mut readiness)
+                .expect("read parent readiness");
+            assert_ne!(read, 0, "cycle {cycle}: parent exited before readiness");
+            if readiness.contains("PARENT_READY") {
+                break;
+            }
+        }
+        let readiness = readiness
+            .split_once("PARENT_READY")
+            .map(|(_, fields)| format!("PARENT_READY{fields}"))
+            .expect("readiness marker");
+        let fields = readiness.split_whitespace().collect::<Vec<_>>();
+        assert_eq!(fields.first(), Some(&"PARENT_READY"), "{readiness}");
+        assert_eq!(fields.get(2), Some(&"CHILD_READY"), "{readiness}");
+        let child_pid: i32 = fields[1].parse().expect("numeric child pid");
+        let descendant_pid: i32 = fields[3].parse().expect("numeric descendant pid");
+        assert!(parent.wait().expect("wait for abrupt parent").success());
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let child_gone = unsafe { libc::kill(child_pid, 0) } != 0;
+            let descendant_gone = unsafe { libc::kill(descendant_pid, 0) } != 0;
+            if child_gone && descendant_gone {
+                break;
+            }
+            if Instant::now() >= deadline {
+                unsafe {
+                    libc::kill(-child_pid, libc::SIGKILL);
+                }
+                panic!(
+                    "crash/relaunch cycle {cycle}: parent EOF did not promptly reap sidecar {child_pid} and descendant {descendant_pid}"
+                );
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn normal_cleanup_closes_the_parent_lease_and_reaps_the_sidecar_group() {
+    use std::io::{BufRead, BufReader};
+
+    let mut command = Command::new("sh");
+    command
+        .args([
+            "-c",
+            "sleep 30 & descendant=$!; echo CHILD_READY $descendant; cat >/dev/null; kill -KILL 0",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    configure_unix_sidecar_parent_watchdog(&mut command);
+    let mut child = command.spawn().expect("spawn watched sidecar fixture");
+    let mut readiness = String::new();
+    BufReader::new(child.stdout.take().expect("child stdout"))
+        .read_line(&mut readiness)
+        .expect("read child readiness");
+    let fields = readiness.split_whitespace().collect::<Vec<_>>();
+    assert_eq!(fields.first(), Some(&"CHILD_READY"), "{readiness}");
+    let descendant_pid: i32 = fields[1].parse().expect("numeric descendant pid");
+
+    stop_sidecar_child(SidecarProcess::new(child)).expect("stop watched sidecar group");
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    while unsafe { libc::kill(descendant_pid, 0) } == 0 {
+        if Instant::now() >= deadline {
+            unsafe {
+                libc::kill(descendant_pid, libc::SIGKILL);
+            }
+            panic!("normal cleanup left descendant {descendant_pid} alive");
+        }
+        thread::sleep(Duration::from_millis(20));
+    }
+}
+
 #[cfg(not(target_os = "windows"))]
 #[test]
 fn startup_failure_stops_and_reaps_owned_sidecar() {

--- a/src-tauri/src/sidecar_lifecycle.rs
+++ b/src-tauri/src/sidecar_lifecycle.rs
@@ -1,5 +1,18 @@
 use super::*;
 
+#[cfg(all(desktop, unix))]
+pub(super) fn configure_unix_sidecar_parent_watchdog(command: &mut Command) {
+    use std::os::unix::process::CommandExt;
+
+    // The parent retains the write end inside `Child`; an abrupt GUI exit
+    // closes it in the kernel even when Rust destructors never run. A fresh
+    // process group lets the watched Node root terminate its owned tree.
+    command
+        .stdin(Stdio::piped())
+        .env("COVEN_CAVE_PARENT_WATCHDOG", "stdin-eof");
+    command.process_group(0);
+}
+
 #[cfg(desktop)]
 pub(super) struct SidecarProcess {
     child: Child,
@@ -293,6 +306,28 @@ pub(super) fn stop_sidecar_child(mut process: SidecarProcess) -> Result<(), Stri
 
     #[cfg(not(target_os = "windows"))]
     {
+        #[cfg(unix)]
+        if process.child.stdin.take().is_some() {
+            // Normal shutdown uses the same exact-parent lease as crash
+            // shutdown so Node can reap PTYs and its isolated process group.
+            // Fall back to the existing direct kill if a broken child ignores
+            // EOF; application teardown remains strictly bounded.
+            let deadline = Instant::now() + Duration::from_secs(2);
+            loop {
+                if process
+                    .child
+                    .try_wait()
+                    .map_err(|error| format!("could not inspect watched sidecar: {error}"))?
+                    .is_some()
+                {
+                    return Ok(());
+                }
+                if Instant::now() >= deadline {
+                    break;
+                }
+                thread::sleep(Duration::from_millis(20));
+            }
+        }
         if process
             .child
             .try_wait()

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -368,6 +368,8 @@ pub(super) fn start_sidecar_runtime(
         command.env("LD_LIBRARY_PATH", whisper_dir);
     }
 
+    #[cfg(unix)]
+    configure_unix_sidecar_parent_watchdog(&mut command);
     command.stdout(Stdio::piped()).stderr(Stdio::piped());
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

- launch packaged macOS/Linux sidecars in an owned process group with a kernel-backed stdin parent lease
- reap node-pty sessions and the exact owned Unix sidecar group when the GUI parent exits, including crash/force-quit paths
- preserve the existing Windows Job Object lifecycle unchanged
- add repeated abrupt-parent and normal-cleanup regression coverage

Bead: `cave-d5uzi`

## Verification

- `node --test scripts/desktop-reachability.test.mjs`
- `cargo test --manifest-path src-tauri/Cargo.toml --lib app_lifecycle_tests` (21 passed)
- `cargo check --manifest-path src-tauri/Cargo.toml --locked`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app` (1103 files passed)
- `pnpm test:api` (341 files passed)
- `pnpm test:mobile` (84 files passed)
- `pnpm build`
- Cave staged pre-commit guard (6 files scanned)