### PR TITLE
fix(mobile): fail closed on Tailscale Serve permission errors

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -19,6 +19,7 @@ import {
   MOBILE_INVITE_TTL_MS,
   nativeAppDiscoveryProof,
   resolveIosInstallUrl,
+  shouldAllowMagicDnsFallback,
   tailnetDiscoveryProof,
   tailscaleBin,
   tailscaleSpawnEnv,
@@ -332,13 +333,32 @@ async function ensureNativeAppServeReady(
     const parsed = parseServeStatus(status.stdout);
     if (!("error" in parsed)) serveStatus = parsed.value;
   }
-  const tailnetDiscovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+  const tailnetDiscovery = tailnetDiscoveryProof({
+    selfStatus,
+    serveStatus,
+    backendUrl: backend,
+    // A successful status command with no matching handler proves there is no
+    // live route. MagicDNS alone only identifies the node; it does not publish
+    // the loopback backend.
+    allowMagicDnsFallback: shouldAllowMagicDnsFallback({
+      serveOk: serve.ok,
+      serveError: serveWarning ?? "",
+      statusOk: status.ok,
+    }),
+  });
   let discovery: ReturnType<typeof nativeAppDiscoveryProof> = tailnetDiscovery;
   let fallbackWarning: string | null = null;
   if (!tailnetDiscovery.ok) {
     const httpServe = await runTailscale(["serve", "--bg", `--http=${backendPort(backend)}`, backend]);
     if (httpServe.ok) {
-      discovery = nativeAppDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+      discovery = nativeAppDiscoveryProof({
+        selfStatus,
+        serveStatus,
+        backendUrl: backend,
+        // The explicit HTTP Serve fallback is addressed by Tailscale IP. Do
+        // not replace it with an unproven MagicDNS HTTPS URL.
+        allowMagicDnsFallback: false,
+      });
       if (discovery.ok && discovery.source === "tailscale-ip-http") {
         fallbackWarning = serveWarning
           ? `${serveWarning} Using the Tailscale IP fallback for the native app.`
@@ -494,7 +514,16 @@ async function mobileHandoffReady(
     if (!("error" in parsed)) serveStatus = parsed.value;
   }
 
-  const discovery = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl: backend });
+  const discovery = tailnetDiscoveryProof({
+    selfStatus,
+    serveStatus,
+    backendUrl: backend,
+    allowMagicDnsFallback: shouldAllowMagicDnsFallback({
+      serveOk: serve.ok,
+      serveError: serveWarning ?? "",
+      statusOk: status.ok,
+    }),
+  });
 
   if (!discovery.ok) {
     // Nothing usable — surface the most actionable error we have.

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -218,6 +218,11 @@ assert.match(
   /Pairing secret unavailable/,
   "the access-rung failure explains the self-provisioned pairing secret instead of quoting pnpm incantations",
 );
+assert.match(
+  settings,
+  /Tailscale Serve needs permission[\s\S]{0,300}sudo tailscale set --operator=\$USER/,
+  "Linux Serve permission failures show the one-time operator fix instead of generic restart advice",
+);
 assert.match(settings, /Technical details/, "the raw handoff error stays available behind a disclosure");
 
 // ── Guided pairing checklist (cave-jr4r.1) ───────────────────────────────────
@@ -331,24 +336,25 @@ assert.match(
 assert.doesNotMatch(tauriConfig, /"deep-link"[\s\S]*"scheme": \["opencoven"\]/, "iOS app should not register a custom app connect URL scheme");
 assert.doesNotMatch(tauriLib, /tauri_plugin_deep_link::init/, "iOS shell should not install the deep-link plugin");
 
-// Resilient handoff: when `tailscale serve --bg` fails (e.g. macOS "GUI failed
-// to start, CLIError 3"), the route must NOT hard-fail. It should fall back to
-// the MagicDNS host so the invite link + QR still generate, returning the serve
-// error as a non-fatal warning instead.
+// Resilient handoff: when `tailscale serve --bg` fails but Serve status is
+// unreadable (e.g. macOS "GUI failed to start, CLIError 3"), the route may use
+// MagicDNS because a daemon-owned route can still be live. A readable empty
+// status is different: it proves no route exists and must not become a false
+// success merely because the node has a MagicDNS name.
 assert.doesNotMatch(
   handoffRoute,
   /error: "failed to start tailscale serve"/,
-  "serve --bg failure must not short-circuit the whole handoff",
+  "serve --bg failure must not short-circuit a handoff when status cannot be read",
 );
 assert.match(
   handoffRoute,
-  /tailnetDiscoveryProof\(\{\s*selfStatus,\s*serveStatus,\s*backendUrl: backend\s*\}\)/,
-  "route falls back through the shared Tailscale discovery proof when the serve config can't be read",
+  /tailnetDiscoveryProof\(\{[\s\S]{0,400}allowMagicDnsFallback: shouldAllowMagicDnsFallback\(\{[\s\S]{0,180}serveError: serveWarning \?\? ""[\s\S]{0,100}statusOk: status\.ok/,
+  "MagicDNS fallback is blocked by permission-denied Serve mutations even when Serve status is unreadable",
 );
 assert.match(
   handoffRoute,
-  /nativeAppDiscoveryProof\(\{\s*selfStatus,\s*serveStatus,\s*backendUrl: backend\s*\}\)/,
-  "native mobile mode should use a native-specific fallback when MagicDNS is unavailable",
+  /nativeAppDiscoveryProof\(\{[\s\S]{0,300}allowMagicDnsFallback: false/,
+  "the explicit native HTTP fallback must use its Tailscale IP instead of an unproven HTTPS hostname",
 );
 assert.match(
   handoffRoute,

--- a/src/components/settings-phone.tsx
+++ b/src/components/settings-phone.tsx
@@ -102,6 +102,12 @@ export function classifyTailscaleFailure(raw: string): { headline: string; hint:
       hint: "Open Tailscale and sign in — pairing resumes here automatically.",
     };
   }
+  if (kind === "serve-permission") {
+    return {
+      headline: "Tailscale Serve needs permission",
+      hint: "On Linux, run `sudo tailscale set --operator=$USER` once, then retry phone pairing.",
+    };
+  }
   if (kind === "serve-failed") {
     return {
       headline: "Tailscale Serve couldn’t start",

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -13,6 +13,7 @@ import {
   OFFICIAL_IOS_INSTALL_URL,
   resolveIosInstallUrl,
   resolveTailscaleBin,
+  shouldAllowMagicDnsFallback,
   tailnetDiscoveryProof,
   tailscaleIpHost,
 } from "./mobile-handoff.ts";
@@ -36,6 +37,32 @@ const status = {
   },
 };
 const signingKey = ["handoff", "mobile", "key"].join("-");
+
+{
+  assert.equal(
+    shouldAllowMagicDnsFallback({
+      serveOk: false,
+      serveError: "sending serve config: Access denied: serve config denied",
+      statusOk: false,
+    }),
+    false,
+    "permission denial must not become a MagicDNS success when Serve status is also unreadable",
+  );
+  assert.equal(
+    shouldAllowMagicDnsFallback({
+      serveOk: false,
+      serveError: "GUI failed to start (CLIError 3)",
+      statusOk: false,
+    }),
+    true,
+    "non-permission CLI failures may still use MagicDNS when daemon status is unreadable",
+  );
+  assert.equal(
+    shouldAllowMagicDnsFallback({ serveOk: true, serveError: "", statusOk: true }),
+    false,
+    "a readable Serve status remains authoritative",
+  );
+}
 
 {
   const url = findServeUrl(status, "http://127.0.0.1:3000");
@@ -172,6 +199,34 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
       serveUrl,
       source: "magicdns-self-status",
     },
+  );
+  assert.deepEqual(
+    tailnetDiscoveryProof({
+      selfStatus: self,
+      serveStatus: {},
+      backendUrl: "http://127.0.0.1:3000",
+      allowMagicDnsFallback: false,
+    }),
+    {
+      ok: false,
+      reason: "tailscale serve route not found for http://127.0.0.1:3000",
+    },
+    "a readable empty Serve status must not promote a bare MagicDNS name to a live route",
+  );
+  assert.deepEqual(
+    nativeAppDiscoveryProof({
+      selfStatus: { Self: { DNSName: "cave.tailnet.example.ts.net.", TailscaleIPs: ["100.101.102.103"] } },
+      serveStatus: {},
+      backendUrl: "http://127.0.0.1:3000",
+      allowMagicDnsFallback: false,
+    }),
+    {
+      ok: true,
+      host: "100.101.102.103:3000",
+      serveUrl: "http://100.101.102.103:3000/",
+      source: "tailscale-ip-http",
+    },
+    "the explicit HTTP fallback must use the Tailscale IP even when MagicDNS exists",
   );
   assert.deepEqual(
     tailnetDiscoveryProof({ selfStatus: {}, serveStatus: {}, backendUrl: "http://127.0.0.1:3000" }),

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -4,8 +4,23 @@ import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
 import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import { appTokenTtlMs } from "./mobile-token-refresh.ts";
+import { classifyTailscaleFailureKind } from "./tailscale-failure.ts";
 
 export const MOBILE_INVITE_TTL_MS = 8 * 60 * 60 * 1000;
+
+export function shouldAllowMagicDnsFallback({
+  serveOk,
+  serveError,
+  statusOk,
+}: {
+  serveOk: boolean;
+  serveError: string;
+  statusOk: boolean;
+}) {
+  if (statusOk) return false;
+  if (!serveOk && classifyTailscaleFailureKind(serveError) === "serve-permission") return false;
+  return true;
+}
 
 type TailscaleServeStatus = {
   Web?: Record<
@@ -206,10 +221,12 @@ export function tailnetDiscoveryProof({
   selfStatus,
   serveStatus,
   backendUrl,
+  allowMagicDnsFallback = true,
 }: {
   selfStatus: unknown;
   serveStatus: unknown;
   backendUrl: string;
+  allowMagicDnsFallback?: boolean;
 }): TailnetDiscoveryProof {
   const fromServe = findServeUrl(serveStatus, backendUrl);
   const host = magicDnsHost(selfStatus);
@@ -222,7 +239,7 @@ export function tailnetDiscoveryProof({
     };
   }
 
-  const fromMagicDns = magicDnsServeUrl(selfStatus);
+  const fromMagicDns = allowMagicDnsFallback ? magicDnsServeUrl(selfStatus) : null;
   if (fromMagicDns && host) {
     return {
       ok: true,
@@ -234,7 +251,9 @@ export function tailnetDiscoveryProof({
 
   return {
     ok: false,
-    reason: "tailscale serve URL not found and status --self had no MagicDNS DNSName",
+    reason: allowMagicDnsFallback
+      ? "tailscale serve URL not found and status --self had no MagicDNS DNSName"
+      : `tailscale serve route not found for ${backendUrl}`,
   };
 }
 
@@ -254,12 +273,19 @@ export function nativeAppDiscoveryProof({
   selfStatus,
   serveStatus,
   backendUrl,
+  allowMagicDnsFallback = true,
 }: {
   selfStatus: unknown;
   serveStatus: unknown;
   backendUrl: string;
+  allowMagicDnsFallback?: boolean;
 }): NativeAppDiscoveryProof {
-  const tailnet = tailnetDiscoveryProof({ selfStatus, serveStatus, backendUrl });
+  const tailnet = tailnetDiscoveryProof({
+    selfStatus,
+    serveStatus,
+    backendUrl,
+    allowMagicDnsFallback,
+  });
   if (tailnet.ok) return tailnet;
 
   const serveUrl = nativeHttpServeUrl(selfStatus, backendUrl);

--- a/src/lib/tailscale-failure.test.ts
+++ b/src/lib/tailscale-failure.test.ts
@@ -19,6 +19,15 @@ test("classifies actionable Tailscale installation and session states", () => {
   }
 });
 
+test("classifies Serve permission failures separately from generic Serve failures", () => {
+  assert.equal(
+    classifyTailscaleFailureKind(
+      "sending serve config: Access denied: serve config denied. Use 'sudo tailscale set --operator=$USER' once.",
+    ),
+    "serve-permission",
+  );
+});
+
 test("classifies Serve failures without treating similar words as Serve", () => {
   assert.equal(classifyTailscaleFailureKind("tailscale serve failed"), "serve-failed");
   assert.equal(classifyTailscaleFailureKind("pairing service unavailable"), "unknown");

--- a/src/lib/tailscale-failure.ts
+++ b/src/lib/tailscale-failure.ts
@@ -3,6 +3,7 @@ export type TailscaleFailureKind =
   | "not-installed"
   | "signed-out"
   | "not-running"
+  | "serve-permission"
   | "serve-failed"
   | "unknown";
 
@@ -26,6 +27,14 @@ export function classifyTailscaleFailureKind(raw: string): TailscaleFailureKind 
       text.includes("unreachable"))
   ) {
     return "not-running";
+  }
+  if (
+    text.includes("serve") &&
+    (text.includes("serve config denied") ||
+      text.includes("sudo tailscale serve") ||
+      text.includes("tailscale set --operator"))
+  ) {
+    return "serve-permission";
   }
   if (/\bserve\b/.test(text)) {
     return "serve-failed";


### PR DESCRIPTION
## Summary

Prevent Linux Tailscale Serve permission failures from being reported as successful mobile pairing routes.

## Why

Cave intentionally binds its sidecar to loopback and relies on Tailscale Serve for phone access. On Linux, an unconfigured Tailscale operator causes `tailscale serve --bg` to fail with `serve config denied`.

The handoff flow could still promote the node's MagicDNS hostname to a successful HTTPS route even when `tailscale serve status --json` showed no matching handler. This produced a valid-looking QR/link for a route that did not exist: the phone reached the machine, but Cave did not respond.

A second edge case existed when both the Serve mutation and status read were permission-denied: the unreadable status still enabled the MagicDNS fallback.

## Changes

- Treat a readable Serve status with no matching backend handler as proof that the route is absent.
- Disable MagicDNS fallback after a recognized Serve permission denial, including when Serve status is unreadable.
- Keep the macOS resilience path for non-permission CLI failures where a daemon-owned route may already exist.
- Ensure the explicit native HTTP fallback uses the Tailscale IP rather than substituting an unproven HTTPS MagicDNS URL.
- Classify Linux Serve permission failures separately and show the one-time remediation:
  `sudo tailscale set --operator=$USER`
- Add regression coverage for readable-empty status, permission-denied status, HTTP fallback selection, and user-facing guidance.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:mobile` — 84 test files passed
- `pnpm test:api` — 341 test files passed
- `pnpm build`
- `git diff --check`
- Production reproduction on Linux:
  - before operator setup: `tailscale serve status` returned `No serve config`; Cave returned a MagicDNS invite with a Serve permission warning
  - after `sudo tailscale set --operator=$USER`: Tailscale Serve published the current loopback sidecar and the phone connected successfully
  - unauthenticated HTTPS probe reached the Cave access gate with HTTP 401, confirming the tailnet route while preserving token protection

## Risk + rollout notes

The sidecar remains loopback-only. This change does not broaden Cave to LAN interfaces or bypass mobile authentication.

The main compatibility risk is the existing macOS MagicDNS fallback. It remains available only when Serve status cannot be read and the Serve mutation did not fail with a recognized permission-denial signature.