### PR TITLE
chore(release): stamp v0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,103 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.2.4] - 2026-08-06
+
+> _One-line teaser — edit before merge._
+
+Patch release on top of v0.2.3.
+
+### Changes
+- fix(release): refresh the iOS build stamp on every release cut
+- fix(onboarding): allow cold managed npm startup on Windows (#4359)
+- fix(chat): harden capability help probes (#4363)
+- fix: reap Unix sidecars on parent exit (#4374)
+- fix: bound desktop sidecar output (#4373)
+- Update interactions.jsonl
+- perf(pty): bound streaming and add replay cursors (#4362)
+- fix: restore Canvas and focus-ring contracts (#4367)
+- WIP: activity lattice (cave-yd3qu) (#4335)
+- Improve chat discovery, titles, and reflection archiving (#4357)
+- Stop creation exceptions from blocking worktree retirement (#4366)
+- Add the orchestration task validator and readiness derivation (#4343)
+- test: close sidebar test gaps (#4358)
+- fix: make sidecar reap test portable (#4368)
+- Update interactions.jsonl
+- fix(ios): keep the ⌘1–4 tab shortcuts out of the accessibility tree (#4360)
+- wip: preserve uncommitted work before worktree cleanup
+- Update navigation E2E contracts
+- Update iOS familiar chat contract tests
+- Remove Play mode from canvas editor
+- Register workspace path API contract
+- Finish sidebar section contract cleanup
+- Update sidebar CSS module order contract
+- Update familiar switcher contract test
+- Update Code sidebar contract test
+- Update sidebar keyboard navigation contract
+- Improve adaptive chat context controls (#4356)
+- Update sidebar section contract test
+- Fix Canvas editor merge remnants
+- fix(attachments): parse image data URLs without a regex over the payload (#4340)
+- Restructure sidebar nav from sections to tabbed layout
+- Update interactions.jsonl
+- feat(picker): give the web folder picker Explorer's Quick access and This PC rails (#4352)
+- Update sidebar-minimal.tsx
+- fix(budgets): report thin headroom everywhere, reseat the caps by rate (#4353)
+- feat(settings): make Workspace path's Browse actually choose a folder
+- Update interactions.jsonl
+- fix: contain async polling failures (#4349)
+- Update interactions.jsonl
+- chore(worktrees): raise the admission budget from 12 to 20 (#4348)
+- Update interactions.jsonl
+- fix(ios): generate the web bundles before xcodegen scans (#4345)
+- Update interactions.jsonl
+- Group sidepanel destinations into collapsible sections (#4347)
+- Harden exact-head branch merges (#4346)
+- feat: add mission catalog with renown bonuses
+- wip(global-home-code-sections): snapshot uncommitted work in progress
+- Fix Home slash command handoff and discovery (#4342)
+- Restore accessible solo-to-coven promotion (#4295)
+- fix(chat): inject familiar contract (SOUL.md/IDENTITY.md) into chat prompt assembly (#4344)
+- Update interactions.jsonl
+- wip(fix-cave-l4ttp-analytics-followup): snapshot uncommitted work in progress
+- wip(cave-y0blo-ios-familiar-new-chat): snapshot uncommitted work in progress
+- wip(cave-4mqfl-chat-spec-reader): snapshot uncommitted work in progress
+- wip(cave-2tmly-projects-consolidation): snapshot uncommitted work in progress
+- fix(daemon): keep automatic recovery fail-closed when restart is set
+- wip: preserve supervisor-safe daemon recovery
+- fix(runtime): supervise daemon startup coherence (#4329)
+- docs(sidecar): record that the file-count budget is a rate problem (#4332)
+- wip: preserve copilot launch timeout fix
+- docs: define the orchestration-ready task contract (#4306)
+- docs(sidecar): make the MAX_FILE_COUNT comment match the const (#4333)
+- Ignore Psyche temp files
+- chore(sidecar): raise the file-count budget to 5,926 for the image carousel (#4331)
+- Lift notification dropdown above content (#4273)
+- feat(chat): share images through one carousel familiars can drive (#4315)
+- Add a Cave-safe branch-to-merge skill for every familiar (#4307)
+- fix(analytics): align scoped workbench evidence (#4283)
+- test(ios): verify the session switch with a real tap in the simulator (#4326)
+- test(ios): make the session-stickiness test actually assert stickiness (#4325)
+- test(ios): make the stickiness test actually exercise the switch
+- Complete the Coding Room's approved design (cave-uod42) (#4319)
+- fix(ios): make the session picker actually switch conversations (#4322)
+- fix(ios): keep the zoom anchored on the thread row itself
+- docs: correct the signature guidance CLAUDE.md still asserts (#4321)
+- fix(ios): make the session picker actually switch conversations
+- fix(worktrees): make the budget refusal name the exception it would admit (#4308)
+- wip: preserve canvas artifact interaction
+- wip: preserve iOS familiar new chat
+- Add fast local worktree status dashboard (#4313)
+- fix(voice): snap the call overlay's spacing to the scale, bank the highlight's 2px (#4303)
+- feat(code): rebuild the Coding Room as a three-zone workbench (#4311)
+- feat(canvas,voice): playable sketches, a waiting-room arcade, and iOS voice calls (#4314)
+- test(api): drop the duplicate /auto-mode/feedback contract entry
+- docs(worktrees): cover recency wording in policy scan
+- snapshot(onboarding): commit the recovered cave-d8i6p working tree
+- snapshot(onboarding): preserve uncommitted cave-d8i6p work in progress
+- fix(analytics): align scoped workbench evidence
+
+
 ## [0.2.3] - 2026-08-03
 
 > Live call transcripts, answer rewriting in the reader, a familiar analytics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,100 +9,51 @@ breaking config changes; patch releases stay additive.
 
 ## [0.2.4] - 2026-08-06
 
-> _One-line teaser — edit before merge._
+> A tabbed sidebar, the Coding Room rebuilt as a three-zone workbench, image
+> carousels familiars can drive, and a release stamp that finally moves the iOS
+> build number.
 
 Patch release on top of v0.2.3.
 
-### Changes
-- fix(release): refresh the iOS build stamp on every release cut
-- fix(onboarding): allow cold managed npm startup on Windows (#4359)
-- fix(chat): harden capability help probes (#4363)
-- fix: reap Unix sidecars on parent exit (#4374)
-- fix: bound desktop sidecar output (#4373)
-- Update interactions.jsonl
-- perf(pty): bound streaming and add replay cursors (#4362)
-- fix: restore Canvas and focus-ring contracts (#4367)
-- WIP: activity lattice (cave-yd3qu) (#4335)
-- Improve chat discovery, titles, and reflection archiving (#4357)
-- Stop creation exceptions from blocking worktree retirement (#4366)
-- Add the orchestration task validator and readiness derivation (#4343)
-- test: close sidebar test gaps (#4358)
-- fix: make sidecar reap test portable (#4368)
-- Update interactions.jsonl
-- fix(ios): keep the ⌘1–4 tab shortcuts out of the accessibility tree (#4360)
-- wip: preserve uncommitted work before worktree cleanup
-- Update navigation E2E contracts
-- Update iOS familiar chat contract tests
-- Remove Play mode from canvas editor
-- Register workspace path API contract
-- Finish sidebar section contract cleanup
-- Update sidebar CSS module order contract
-- Update familiar switcher contract test
-- Update Code sidebar contract test
-- Update sidebar keyboard navigation contract
-- Improve adaptive chat context controls (#4356)
-- Update sidebar section contract test
-- Fix Canvas editor merge remnants
-- fix(attachments): parse image data URLs without a regex over the payload (#4340)
-- Restructure sidebar nav from sections to tabbed layout
-- Update interactions.jsonl
-- feat(picker): give the web folder picker Explorer's Quick access and This PC rails (#4352)
-- Update sidebar-minimal.tsx
-- fix(budgets): report thin headroom everywhere, reseat the caps by rate (#4353)
-- feat(settings): make Workspace path's Browse actually choose a folder
-- Update interactions.jsonl
-- fix: contain async polling failures (#4349)
-- Update interactions.jsonl
-- chore(worktrees): raise the admission budget from 12 to 20 (#4348)
-- Update interactions.jsonl
-- fix(ios): generate the web bundles before xcodegen scans (#4345)
-- Update interactions.jsonl
-- Group sidepanel destinations into collapsible sections (#4347)
-- Harden exact-head branch merges (#4346)
-- feat: add mission catalog with renown bonuses
-- wip(global-home-code-sections): snapshot uncommitted work in progress
-- Fix Home slash command handoff and discovery (#4342)
-- Restore accessible solo-to-coven promotion (#4295)
-- fix(chat): inject familiar contract (SOUL.md/IDENTITY.md) into chat prompt assembly (#4344)
-- Update interactions.jsonl
-- wip(fix-cave-l4ttp-analytics-followup): snapshot uncommitted work in progress
-- wip(cave-y0blo-ios-familiar-new-chat): snapshot uncommitted work in progress
-- wip(cave-4mqfl-chat-spec-reader): snapshot uncommitted work in progress
-- wip(cave-2tmly-projects-consolidation): snapshot uncommitted work in progress
-- fix(daemon): keep automatic recovery fail-closed when restart is set
-- wip: preserve supervisor-safe daemon recovery
-- fix(runtime): supervise daemon startup coherence (#4329)
-- docs(sidecar): record that the file-count budget is a rate problem (#4332)
-- wip: preserve copilot launch timeout fix
-- docs: define the orchestration-ready task contract (#4306)
-- docs(sidecar): make the MAX_FILE_COUNT comment match the const (#4333)
-- Ignore Psyche temp files
-- chore(sidecar): raise the file-count budget to 5,926 for the image carousel (#4331)
-- Lift notification dropdown above content (#4273)
-- feat(chat): share images through one carousel familiars can drive (#4315)
-- Add a Cave-safe branch-to-merge skill for every familiar (#4307)
-- fix(analytics): align scoped workbench evidence (#4283)
-- test(ios): verify the session switch with a real tap in the simulator (#4326)
-- test(ios): make the session-stickiness test actually assert stickiness (#4325)
-- test(ios): make the stickiness test actually exercise the switch
-- Complete the Coding Room's approved design (cave-uod42) (#4319)
-- fix(ios): make the session picker actually switch conversations (#4322)
-- fix(ios): keep the zoom anchored on the thread row itself
-- docs: correct the signature guidance CLAUDE.md still asserts (#4321)
-- fix(ios): make the session picker actually switch conversations
-- fix(worktrees): make the budget refusal name the exception it would admit (#4308)
-- wip: preserve canvas artifact interaction
-- wip: preserve iOS familiar new chat
-- Add fast local worktree status dashboard (#4313)
-- fix(voice): snap the call overlay's spacing to the scale, bank the highlight's 2px (#4303)
-- feat(code): rebuild the Coding Room as a three-zone workbench (#4311)
-- feat(canvas,voice): playable sketches, a waiting-room arcade, and iOS voice calls (#4314)
-- test(api): drop the duplicate /auto-mode/feedback contract entry
-- docs(worktrees): cover recency wording in policy scan
-- snapshot(onboarding): commit the recovered cave-d8i6p working tree
-- snapshot(onboarding): preserve uncommitted cave-d8i6p work in progress
-- fix(analytics): align scoped workbench evidence
+### Added
 
+- Rebuilt the Coding Room as a three-zone workbench and landed its approved design (#4311, #4319).
+- Added a shared chat image carousel that familiars can drive (#4315).
+- Added playable canvas sketches, a waiting-room arcade, and iOS voice calls (#4314).
+- Restructured sidebar navigation from stacked sections into a tabbed layout, with collapsible side-panel destination groups (#4347).
+- Gave the web folder picker Explorer's Quick access and This PC rails, and made Settings > Workspace path's Browse actually choose a folder (#4352).
+- Added a mission catalog with renown bonuses, and the first cut of the activity lattice (#4335).
+- Added the orchestration task validator with readiness derivation, and wrote down the orchestration-ready task contract (#4343, #4306).
+- Added a Cave-safe branch-to-merge skill available to every familiar (#4307).
+- Added a fast local worktree status dashboard (#4313).
+
+### Changed
+
+- Bounded PTY streaming and added replay cursors, so a busy terminal no longer floods its client (#4362).
+- Bounded desktop sidecar output (#4373).
+- Improved chat discovery, titles, and reflection archiving (#4357), and the adaptive chat context controls (#4356).
+- Injected the familiar contract (`SOUL.md` / `IDENTITY.md`) into chat prompt assembly (#4344).
+- Raised the worktree admission budget from 12 to 20 (#4348) and the sidecar file-count budget to 5,926 for the image carousel, recording that the budget is a rate problem rather than a count problem (#4331, #4332, #4333).
+- Hardened exact-head branch merges (#4346), stopped creation exceptions from blocking worktree retirement (#4366), and made a budget refusal name the exception that would admit it (#4308).
+- Lifted the notification dropdown above page content (#4273).
+- Removed Play mode from the canvas editor.
+
+### Fixed
+
+- **`scripts/stamp-release.mjs` now refreshes the iOS `CURRENT_PROJECT_VERSION` build stamp alongside `MARKETING_VERSION`.** A stamped release used to carry the previous cut's build number, which App Store Connect rejects as a duplicate — that is what blocked the v0.2.3 TestFlight upload.
+- Fixed the iOS session picker not switching conversations, kept the thread-row zoom anchored to the row itself, and kept the ⌘1–4 tab shortcuts out of the accessibility tree (#4322, #4360).
+- Fixed the iOS build generating its web bundles after xcodegen had already scanned for them (#4345).
+- Fixed cold managed npm startup on Windows during onboarding (#4359).
+- Hardened chat capability help probes (#4363).
+- Reaped Unix sidecars on parent exit (#4374), with a portable test for it (#4368).
+- Restored the Canvas and focus-ring contracts and cleared the Canvas editor merge remnants (#4367).
+- Parsed image data URLs without running a regex over the whole payload (#4340).
+- Reported thin budget headroom everywhere and reseated the caps by rate (#4353).
+- Contained async polling failures (#4349).
+- Fixed the Home slash-command handoff and discovery (#4342), and restored accessible solo-to-coven promotion (#4295).
+- Kept automatic daemon recovery fail-closed when restart is set, and supervised daemon startup coherence (#4329).
+- Aligned scoped analytics workbench evidence (#4283).
+- Snapped the voice call overlay's spacing to the scale (#4303).
 
 ## [0.2.3] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Patch release on top of v0.2.3.
 
 ### Fixed
 
+- **The iOS app compiles again.** A `ChatProjectPicker` call in `ChatView` closed its argument list with `}` instead of `)`, and `refreshToken` sat between the flag and the callbacks so the memberwise initializer's argument order disagreed with both call sites. The Swift target had not built since 2026-08-03; CI never noticed, because it builds the web app and the Rust shell but not the Swift one.
 - **`scripts/stamp-release.mjs` now refreshes the iOS `CURRENT_PROJECT_VERSION` build stamp alongside `MARKETING_VERSION`.** A stamped release used to carry the previous cut's build number, which App Store Connect rejects as a duplicate — that is what blocked the v0.2.3 TestFlight upload.
 - Fixed the iOS session picker not switching conversations, kept the thread-row zoom anchored to the row itself, and kept the ⌘1–4 tab shortcuts out of the accessibility tree (#4322, #4360).
 - Fixed the iOS build generating its web bundles after xcodegen had already scanned for them (#4345).

--- a/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
@@ -10,9 +10,12 @@ struct ChatProjectPicker: View {
     let recentRoots: [String]
     @Binding var selectedRoot: String?
     @Binding var isResolved: Bool
+    // Declaration order IS the memberwise initializer's argument order, so it
+    // has to match how the call sites read: the required `refreshToken` ahead
+    // of the defaulted flag and callbacks.
+    let refreshToken: Int
     var requiresExplicitSelection = false
     var onResolved: (() -> Void)?
-    let refreshToken: Int
     var onManageAccess: (() -> Void)?
 
     @State private var projects: [ProjectInfo] = []

--- a/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatView.swift
@@ -488,7 +488,7 @@ struct ChatView: View {
                     thread.needsProjectSelection = false
                     app.touch(thread)
                 }
-            }
+            )
             .padding(.horizontal, 16)
             .padding(.vertical, 8)
             .background(chrome.bgRaised)

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -103,10 +103,10 @@ struct NewChatView: View {
                             selectedRoot: $selectedProjectRoot,
                             isResolved: $projectResolved,
                             refreshToken: projectRefreshToken,
+                            onResolved: nil,
                             onManageAccess: fixedFamiliar == nil ? nil : {
                                 showProjectAccess = true
-                            },
-                            onResolved: nil
+                            }
                         )
                     }
                 }

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.2.3"
+    MARKETING_VERSION: "0.2.4"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026080322"
+    CURRENT_PROJECT_VERSION: "2026080601"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -12,6 +12,9 @@ settings:
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
     # A date stamp is monotonic without anyone tracking the last value.
+    # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
+    # every cut — a release stamp that moved only the marketing version is how
+    # v0.2.3 shipped a build number App Store Connect had already seen.
     CURRENT_PROJECT_VERSION: "2026080322"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/scripts/stamp-release.mjs
+++ b/scripts/stamp-release.mjs
@@ -9,7 +9,9 @@
 // locations by hand. This script:
 //   1. REFUSES when another stamp PR is already open (the collision guard);
 //   2. bumps the five version locations (package.json, tauri.conf.json,
-//      Cargo.toml, Cargo.lock's `app` package, apps/ios/CovenCave/project.yml);
+//      Cargo.toml, Cargo.lock's `app` package, apps/ios/CovenCave/project.yml —
+//      whose iOS entry carries BOTH the marketing version and the
+//      CURRENT_PROJECT_VERSION build stamp, see nextIosBuildStamp);
 //   3. drafts the CHANGELOG section from `git log v<prev>..HEAD` subjects —
 //      a starting point to edit in the PR, not prose to trust blindly;
 //   4. branches, commits SIGNED (-S), pushes, and opens the PR via the REST
@@ -22,10 +24,14 @@ import { execFileSync } from "node:child_process";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { replaceCanonicalYamlStringSetting } from "./release-yaml-settings.mjs";
+import {
+  readCanonicalYamlStringSetting,
+  replaceCanonicalYamlStringSetting,
+} from "./release-yaml-settings.mjs";
 
 const ROOT = path.resolve(import.meta.dirname, "..");
 const IOS_MARKETING_VERSION_PATH = ["settings", "base", "MARKETING_VERSION"];
+const IOS_BUILD_VERSION_PATH = ["settings", "base", "CURRENT_PROJECT_VERSION"];
 
 // ── pure helpers (exported for scripts/stamp-release.test.mjs) ───────────────
 
@@ -39,13 +45,53 @@ export function bumpVersion(current, level = "patch") {
   throw new Error(`unknown bump level: "${level}"`);
 }
 
+/** The iOS CFBundleVersion stamp: a YYYYMMDDHH instant in UTC.
+ *
+ * App Store Connect requires CFBundleVersion to be unique and strictly
+ * increasing per app, and a stamp left at its previous value rejects the
+ * upload — which is exactly what happened to v0.2.3 on 2026-08-03, because the
+ * release stamp bumped MARKETING_VERSION and left this one behind. The date
+ * shape is monotonic without anyone tracking the last uploaded value; the
+ * `current` guard covers the one case it isn't (two cuts in the same UTC hour,
+ * or a clock that went backwards), by stepping one past what the file holds.
+ */
+export function nextIosBuildStamp(current, date = new Date()) {
+  const format = (utcMs) => {
+    const d = new Date(utcMs);
+    const pad = (n, width) => String(n).padStart(width, "0");
+    return (
+      `${pad(d.getUTCFullYear(), 4)}${pad(d.getUTCMonth() + 1, 2)}` +
+      `${pad(d.getUTCDate(), 2)}${pad(d.getUTCHours(), 2)}`
+    );
+  };
+  const nowMs = date.getTime();
+  if (!Number.isFinite(nowMs)) throw new Error("iOS build stamp needs a valid date");
+  const stamp = format(nowMs);
+  if (!/^\d{10}$/.test(stamp)) {
+    throw new Error(`unusable iOS build stamp for ${date.toISOString()}: "${stamp}"`);
+  }
+  // Same-hour re-cut (or a clock that stepped backwards): advance a whole UTC
+  // hour off the recorded stamp rather than adding 1 to the integer, so the
+  // result stays a well-formed YYYYMMDDHH instant instead of an hour "24".
+  if (typeof current === "string" && /^\d{10}$/.test(current) && current >= stamp) {
+    const [y, m, d, h] = [
+      Number(current.slice(0, 4)),
+      Number(current.slice(4, 6)),
+      Number(current.slice(6, 8)),
+      Number(current.slice(8, 10)),
+    ];
+    return format(Date.UTC(y, m - 1, d, h + 1));
+  }
+  return stamp;
+}
+
 /** The five stamp locations and how each encodes the version. */
 export const STAMP_FILES = [
   { path: "package.json", kind: "json-version" },
   { path: "src-tauri/tauri.conf.json", kind: "json-version" },
   { path: "src-tauri/Cargo.toml", kind: "toml-version" },
   { path: "src-tauri/Cargo.lock", kind: "cargo-lock-app" },
-  { path: "apps/ios/CovenCave/project.yml", kind: "yaml-marketing-version" },
+  { path: "apps/ios/CovenCave/project.yml", kind: "yaml-ios-versions" },
 ];
 
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
@@ -80,12 +126,29 @@ export function stampContent(kind, content, oldVersion, newVersion) {
   return { content, replaced };
 }
 
-export function applyReplacement(kind, contents, nextVersion, relativePath = "<unknown>") {
-  if (kind === "yaml-marketing-version") {
-    return replaceCanonicalYamlStringSetting(
+export function applyReplacement(
+  kind,
+  contents,
+  nextVersion,
+  relativePath = "<unknown>",
+  now = new Date(),
+) {
+  if (kind === "yaml-ios-versions") {
+    const stamped = replaceCanonicalYamlStringSetting(
       contents,
       IOS_MARKETING_VERSION_PATH,
       nextVersion,
+      relativePath,
+    );
+    const currentBuild = readCanonicalYamlStringSetting(
+      stamped,
+      IOS_BUILD_VERSION_PATH,
+      relativePath,
+    );
+    return replaceCanonicalYamlStringSetting(
+      stamped,
+      IOS_BUILD_VERSION_PATH,
+      nextIosBuildStamp(currentBuild, now),
       relativePath,
     );
   }
@@ -184,9 +247,11 @@ function main() {
     const before = readFileSync(abs, "utf8");
     let content;
     let replaced;
-    if (kind === "yaml-marketing-version") {
+    if (kind === "yaml-ios-versions") {
       content = applyReplacement(kind, before, next, relativePath);
-      replaced = 1;
+      // MARKETING_VERSION + CURRENT_PROJECT_VERSION — App Store Connect
+      // rejects an upload whose build stamp did not move.
+      replaced = 2;
     } else {
       ({ content, replaced } = stampContent(kind, before, current, next));
       if (replaced === 0) {

--- a/scripts/stamp-release.test.mjs
+++ b/scripts/stamp-release.test.mjs
@@ -8,6 +8,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import {
   bumpVersion,
+  nextIosBuildStamp,
   STAMP_FILES,
   applyReplacement,
   stampContent,
@@ -57,30 +58,120 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   const { replaced } = stampContent("toml-version", `[package]\nname = "app"\nversion = "0.0.159"\n`, "0.0.159", "0.0.160");
   assert.equal(replaced, 1);
 }
+// ── nextIosBuildStamp: the CFBundleVersion the App Store checks ──────────────
 {
   assert.equal(
+    nextIosBuildStamp("2026080322", new Date("2026-08-06T01:40:38Z")),
+    "2026080601",
+    "a fresh cut takes the current YYYYMMDDHH UTC instant",
+  );
+  assert.equal(
+    nextIosBuildStamp("2026080322", new Date("2026-09-07T09:05:00Z")),
+    "2026090709",
+    "month/day/hour are zero-padded to keep the stamp ten digits",
+  );
+  assert.equal(
+    nextIosBuildStamp(undefined, new Date("2026-08-06T01:40:38Z")),
+    "2026080601",
+    "an unreadable previous stamp still yields the current instant",
+  );
+  // The whole point: a stamp that did not move is what App Store Connect
+  // rejects, so a same-hour re-cut must still advance.
+  assert.equal(
+    nextIosBuildStamp("2026080601", new Date("2026-08-06T01:59:00Z")),
+    "2026080602",
+    "a second cut in the same UTC hour advances an hour",
+  );
+  assert.equal(
+    nextIosBuildStamp("2026080623", new Date("2026-08-06T23:10:00Z")),
+    "2026080700",
+    "advancing off hour 23 rolls the date rather than emitting hour 24",
+  );
+  assert.equal(
+    nextIosBuildStamp("2026123123", new Date("2026-12-31T23:10:00Z")),
+    "2027010100",
+    "advancing off the last hour of the year rolls the year",
+  );
+  assert.equal(
+    nextIosBuildStamp("2026090101", new Date("2026-08-06T01:40:38Z")),
+    "2026090102",
+    "a backwards clock never regresses the stamp",
+  );
+  for (const stamp of [
+    nextIosBuildStamp("2026080601", new Date("2026-08-06T01:59:00Z")),
+    nextIosBuildStamp("2026080623", new Date("2026-08-06T23:10:00Z")),
+  ]) {
+    assert.match(stamp, /^\d{10}$/, "every advanced stamp keeps the ten-digit shape");
+    assert.ok(
+      Number(stamp.slice(8, 10)) <= 23,
+      "every advanced stamp keeps a real UTC hour (src/lib/app-version.test.ts pins this)",
+    );
+  }
+  assert.throws(() => nextIosBuildStamp("1", new Date("nope")), /valid date/);
+}
+
+{
+  const now = new Date("2026-08-06T01:40:38Z");
+  assert.equal(
     applyReplacement(
-      "yaml-marketing-version",
+      "yaml-ios-versions",
       [
         "name: CovenCave",
         "settings:",
         "  base:",
         '    MARKETING_VERSION: "0.2.1"',
-        '    CURRENT_PROJECT_VERSION: "1"',
+        '    CURRENT_PROJECT_VERSION: "2026080322"',
         "",
       ].join("\n"),
       "0.2.2",
       "apps/ios/CovenCave/project.yml",
+      now,
     ),
     [
       "name: CovenCave",
       "settings:",
       "  base:",
       '    MARKETING_VERSION: "0.2.2"',
-      '    CURRENT_PROJECT_VERSION: "1"',
+      '    CURRENT_PROJECT_VERSION: "2026080601"',
       "",
     ].join("\n"),
-    "the canonical scalar is replaced without changing quoting, indentation, or the build version",
+    "both canonical scalars are replaced without changing quoting or indentation",
+  );
+  assert.throws(
+    () =>
+      applyReplacement(
+        "yaml-ios-versions",
+        ["name: Example", "settings:", "  base:", '    MARKETING_VERSION: "0.2.1"', ""].join("\n"),
+        "0.2.2",
+        "apps/ios/CovenCave/project.yml",
+        now,
+      ),
+    /must define CURRENT_PROJECT_VERSION exactly once.*was not found/,
+    "a project.yml with no build stamp fails loudly instead of shipping a stale CFBundleVersion",
+  );
+  assert.throws(
+    () =>
+      applyReplacement(
+        "yaml-ios-versions",
+        [
+          "name: Example",
+          "settings:",
+          "  base:",
+          '    MARKETING_VERSION: "0.2.1"',
+          '    CURRENT_PROJECT_VERSION: "2026080322"',
+          "targets:",
+          "  Example:",
+          "    settings:",
+          "      base:",
+          '        CURRENT_PROJECT_VERSION: "9"',
+          "",
+        ].join("\n"),
+        "0.2.2",
+        "apps/ios/CovenCave/project.yml",
+        now,
+      ),
+    /must define CURRENT_PROJECT_VERSION exactly once/,
+    "a target-level build-stamp override makes the release setting ambiguous",
   );
   for (const [label, source] of [
     [
@@ -93,7 +184,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
     ],
   ]) {
     assert.throws(
-      () => applyReplacement("yaml-marketing-version", source, "0.2.2", "apps/ios/CovenCave/project.yml"),
+      () => applyReplacement("yaml-ios-versions", source, "0.2.2", "apps/ios/CovenCave/project.yml"),
       (err) => {
         const message = String(err?.message ?? err);
         assert.match(message, /apps\/ios\/CovenCave\/project\.yml/);
@@ -134,7 +225,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
     assert.throws(
       () =>
         applyReplacement(
-          "yaml-marketing-version",
+          "yaml-ios-versions",
           source,
           "0.2.2",
           "apps/ios/CovenCave/project.yml",
@@ -171,7 +262,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
     assert.throws(
       () =>
         applyReplacement(
-          "yaml-marketing-version",
+          "yaml-ios-versions",
           lines.join("\n"),
           "0.2.2",
           "apps/ios/CovenCave/project.yml",
@@ -188,7 +279,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   assert.throws(
     () =>
       applyReplacement(
-        "yaml-marketing-version",
+        "yaml-ios-versions",
         [
           "name: Example",
           "targets:",
@@ -207,7 +298,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   assert.throws(
     () =>
       applyReplacement(
-        "yaml-marketing-version",
+        "yaml-ios-versions",
         [
           "name: Example",
           "settings:",
@@ -229,7 +320,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   assert.throws(
     () =>
       applyReplacement(
-        "yaml-marketing-version",
+        "yaml-ios-versions",
         ["name: Example", "settings:", "  base:", '    CURRENT_PROJECT_VERSION: "1"', ""].join(
           "\n",
         ),
@@ -241,7 +332,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   assert.throws(
     () =>
       applyReplacement(
-        "yaml-marketing-version",
+        "yaml-ios-versions",
         [
           "name: Example",
           "settings:",
@@ -258,7 +349,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
   assert.throws(
     () =>
       applyReplacement(
-        "yaml-marketing-version",
+        "yaml-ios-versions",
         [
           "name: Example",
           "settings:",
@@ -276,7 +367,7 @@ assert.throws(() => bumpVersion("1.2.3", "mega"), /unknown bump level/);
     STAMP_FILES.find(
       (entry) => entry.path === "apps/ios/CovenCave/project.yml",
     )?.kind,
-    "yaml-marketing-version",
+    "yaml-ios-versions",
   );
 }
 assert.equal(STAMP_FILES.length, 5, "exactly the five stamp locations");
@@ -338,6 +429,11 @@ await import(new URL(script, "file://"));
     changedFiles,
     expectedChangedFiles,
     `dry run should report exactly the five stamped manifests:\n${dryRun.stdout}`,
+  );
+  assert.match(
+    dryRun.stdout,
+    /would stamp apps\/ios\/CovenCave\/project\.yml \(2 occurrences\)/,
+    "the iOS manifest stamps both the marketing version and the build stamp",
   );
   assert.match(dryRun.stdout, /\(dry run — nothing written\)/, "dry run banner is preserved");
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.2.3"
+version = "0.2.4"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Cuts **v0.2.4** and ships the iOS client to TestFlight off it.

## What is in here

1. **`fix(ios): repair the project picker call that broke the Swift build`** — the iOS app has not compiled since 2026-08-03. `398b18b` converted `ChatView`'s `ChatProjectPicker` trailing closure into a labelled `onResolved:` argument but left the call's closing brace as `}` instead of `)` (`expected ')' in expression list`, then `extraneous '}' at top level` 1,500 lines further down), and it added `refreshToken` to `ChatProjectPicker` *between* the flag and the callbacks, leaving the memberwise initializer's argument order disagreeing with both call sites. Nothing caught either: CI builds the web app and the Rust shell, never the Swift target, and `scripts/ios-*.test.mjs` reads the Swift as text. Filed `cave-kwv57` to add the missing CI leg.

2. **`fix(release): refresh the iOS build stamp on every release cut`** — the stamp script bumped `MARKETING_VERSION` in `apps/ios/CovenCave/project.yml` and left `CURRENT_PROJECT_VERSION` at whatever the previous cut uploaded. App Store Connect requires `CFBundleVersion` to be unique and increasing per app, so the duplicate is rejected — that is what blocked the v0.2.3 TestFlight upload on 2026-08-03, and it had to be repaired by hand afterwards. The iOS stamp kind now writes both scalars, taking the build number from `nextIosBuildStamp()`: the current `YYYYMMDDHH` UTC instant, advanced a whole UTC hour when the recorded stamp is already at or past it (so a same-hour re-cut still moves, and never emits an hour `24`). A `project.yml` missing the stamp, or overriding it per target, now fails the cut instead of silently shipping a stale number.

3. **`chore(release): stamp v0.2.4`** — the five version locations, produced by `node scripts/stamp-release.mjs`. The iOS manifest now reports 2 occurrences rather than 1: `MARKETING_VERSION: "0.2.4"` and `CURRENT_PROJECT_VERSION: "2026080601"`.

4. **The v0.2.4 CHANGELOG entry**, grouped from the 87 commits since `v0.2.3`.

## Verification

- `xcodebuild -scheme CovenCave -configuration Release -destination 'generic/platform=iOS' archive` — **ARCHIVE SUCCEEDED**, `CFBundleShortVersionString 0.2.4` / `CFBundleVersion 2026080601`; `xcodebuild -exportArchive` with `method: app-store-connect` produced a signed 11.5 MB IPA. Before the fix the same command failed with 2 Swift parse errors.
- `node scripts/stamp-release.test.mjs` — ok, with new coverage for `nextIosBuildStamp` (padding, same-hour advance, hour-23 and year-end rollover, backwards clock) and for both new failure modes.
- `node --experimental-strip-types src/lib/app-version.test.ts` — ok; it pins the ten-digit `YYYYMMDDHH` shape and real UTC hour the advance path has to keep.
- `node scripts/ios-chat-project-contract.test.mjs` — ok.

## Not in this PR

No `v0.2.4` tag. Pushing one fires `release.yml` and publishes the desktop builds; that is a separate, explicit step.