### PR TITLE
Scope the Relations graph to the selected familiars

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1020,6 +1020,7 @@ export const SUITES = {
     "src/lib/wiki-link-parser.test.ts",
     "src/lib/wiki-link-resolve.test.ts",
     "src/lib/grimoire-graph.test.ts",
+    "src/lib/grimoire-graph-scope.test.ts",
     "src/lib/grimoire-force.test.ts",
     "src/lib/recent-colors.test.ts",
 	    "src/components/ui/color-picker.test.ts",

--- a/src/components/grimoire-graph-view.test.ts
+++ b/src/components/grimoire-graph-view.test.ts
@@ -99,4 +99,24 @@ assert.match(
   "the graph status pill reads at --text-xs, not 10px",
 );
 
+// ── Familiar scoping (cave-relations-scope) ──────────────────────────────────
+// The graph arrives ALREADY scoped by grimoire-view; this component's job is
+// to make the narrowing legible instead of silently showing less.
+assert.match(view, /scopeLabel\?: string \| null;/, "the view accepts the active familiar-scope label");
+assert.match(
+  view,
+  /scopeLabel \? `No relations for \$\{scopeLabel\}` : "Nothing to graph yet"/,
+  "an empty graph blames the scope, not the corpus, when a familiar is selected",
+);
+assert.match(
+  view,
+  /Memory is scoped to \{scopeLabel\}\. Stitches and journal days stay coven-wide\./,
+  "the filter card states what the scope does and does not narrow",
+);
+assert.match(
+  view,
+  /\{meta\.memory\.total\} memory files\s*\n\s*\{scopeLabel \? " across the coven" : ""\}/,
+  "the truncation count stays honest under a scope — those totals are coven-wide",
+);
+
 console.log("grimoire-graph-view.test.ts: ok");

--- a/src/components/grimoire-graph-view.tsx
+++ b/src/components/grimoire-graph-view.tsx
@@ -144,6 +144,7 @@ function readPalette(el: HTMLElement): Palette {
 export function GrimoireGraphView({
   graph,
   meta,
+  scopeLabel,
   scanning,
   scanError,
   onOpen,
@@ -152,6 +153,9 @@ export function GrimoireGraphView({
    *  client-built knowledge graph (so something always paints instantly). */
   graph: DocGraph;
   meta?: GrimoireGraphMeta | null;
+  /** Who the shell's familiar multiselect has narrowed memory to, if anyone —
+   *  the graph arrives already scoped, this only makes that visible. */
+  scopeLabel?: string | null;
   /** True while the full-corpus scan is still in flight. */
   scanning?: boolean;
   /** Set when the full scan failed — the local graph stays up. */
@@ -751,11 +755,15 @@ export function GrimoireGraphView({
       <div className="grid h-full min-h-0 place-items-center p-8">
         <EmptyState
           icon="ph:graph"
-          headline={scanning ? "Weaving the graph…" : "Nothing to graph yet"}
+          headline={
+            scanning ? "Weaving the graph…" : scopeLabel ? `No relations for ${scopeLabel}` : "Nothing to graph yet"
+          }
           subtitle={
             scanning
               ? "Scanning your knowledge, memory, and journal for connections."
-              : "Create a knowledge entry, memory file, or journal day and it appears here — [[wiki-links]], tags, and mentions weave them together."
+              : scopeLabel
+                ? "Nothing in this scope has anything to weave together. Widen the familiar selection to see the whole coven's relations."
+                : "Create a knowledge entry, memory file, or journal day and it appears here — [[wiki-links]], tags, and mentions weave them together."
           }
         />
       </div>
@@ -951,9 +959,15 @@ export function GrimoireGraphView({
                 />
               </label>
             </div>
+            {scopeLabel ? (
+              <p className="text-[length:var(--text-sm)] leading-snug text-[var(--text-muted)]">
+                Memory is scoped to {scopeLabel}. Stitches and journal days stay coven-wide.
+              </p>
+            ) : null}
             {memoryTruncated && meta ? (
               <p className="text-[length:var(--text-sm)] leading-snug text-[var(--text-muted)]">
-                Scanned the {meta.memory.scanned} most recent of {meta.memory.total} memory files.
+                Scanned the {meta.memory.scanned} most recent of {meta.memory.total} memory files
+                {scopeLabel ? " across the coven" : ""}.
               </p>
             ) : null}
             {scanError ? (

--- a/src/components/grimoire-launcher.test.ts
+++ b/src/components/grimoire-launcher.test.ts
@@ -23,7 +23,11 @@ assert.match(
   /onShowJournal=\{\(\) => setView\("journal"\)\}[\s\S]{0,80}onShowGraph=\{\(\) => setView\("graph"\)\}/,
   "the journal and graph tiles switch tabs",
 );
-assert.match(view, /graph=\{graph\}/, "the launcher sees the same scan-or-local graph as the canvas");
+assert.match(
+  view,
+  /graph=\{scopedGraph\}/,
+  "the launcher sees the same scan-or-local graph as the canvas, narrowed by the same familiar scope",
+);
 
 // ── Header: centered segmented tabs + contextual dashed New stitch pill ─────
 

--- a/src/components/grimoire-view.test.ts
+++ b/src/components/grimoire-view.test.ts
@@ -156,6 +156,33 @@ assert.match(
   "the Workspace hands Memories the same familiar scope as Tasks and Schedules",
 );
 
+// ── …and so is the Relations graph ──────────────────────────────────────────
+// The graph reads the SAME multiselect as the rail, so Relations can never
+// show a familiar's memory that the navigator beside it is hiding.
+assert.match(
+  view,
+  /const memoryOwnerByNodeId = useMemo\(\(\) => buildMemoryOwnerIndex\(memory \?\? \[\]\), \[memory\]\)/,
+  "ownership is indexed from the UNSCOPED inventory — the graph itself carries only paths",
+);
+assert.match(
+  view,
+  /const scopedGraph = useMemo\(\s*\(\) => scopeDocGraph\(graph, memoryScope, memoryOwnerByNodeId\)/,
+  "the graph is narrowed by the same memoryScope the Memory rail uses",
+);
+assert.match(view, /graph=\{scopedGraph\}/, "the launcher's graph stats reflect the scope, like its memory stats");
+assert.match(
+  view,
+  /<GrimoireGraphView\s*\n\s*graph=\{scopedGraph\}[\s\S]{0,160}scopeLabel=\{memoryScopeLabel\}/,
+  "the Relations canvas renders the scoped graph and is told who it is scoped to",
+);
+// Backlinks and [[wiki-link]] resolution stay on the UNSCOPED graph: a
+// document's own connections are an integrity signal, not a corpus browse.
+assert.match(
+  view,
+  /const backlinks = useMemo<GrimoireBacklink\[\]>\(\(\) => \{[\s\S]{0,400}new Map\(graph\.nodes\.map/,
+  "backlinks keep reading the unscoped graph so link integrity survives a UI filter",
+);
+
 // ── Detail: the right transport per source ───────────────────────────────────
 
 assert.match(view, /<MemoryMdEditor/, "memory docs edit through the mtime-guarded memory editor");

--- a/src/components/grimoire-view.tsx
+++ b/src/components/grimoire-view.tsx
@@ -48,6 +48,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useMemoryFile } from "@/lib/use-memory-file";
 import { resolveOutgoingLinks, type WikiDocIndex, type WikiDocRef } from "@/lib/wiki-link-resolve";
 import { buildDocGraph, type DocGraph, type GraphEdgeType } from "@/lib/grimoire-graph";
+import { buildMemoryOwnerIndex, scopeDocGraph } from "@/lib/grimoire-graph-scope";
 import type { GrimoireGraphMeta } from "@/lib/server/grimoire-graph-scan";
 import { knowledgeEntryFlags } from "@/lib/knowledge-flags";
 import {
@@ -1235,6 +1236,22 @@ export function GrimoireView({
   // knowledge graph until then — the graph is never blank while docs exist.
   const graph = scan?.graph ?? localGraph;
 
+  // Ownership lives on the memory inventory, not on the graph (nodes carry only
+  // paths), so the lookup is built from the UNSCOPED list — filtering it first
+  // would leave every dropped file unattributable.
+  const memoryOwnerByNodeId = useMemo(() => buildMemoryOwnerIndex(memory ?? []), [memory]);
+
+  // The Relations graph follows the same multiselect as the Memory rail: an
+  // empty selection is "All", otherwise memory nodes narrow to the selected
+  // familiars while stitches and journal days stay coven-wide. Backlinks and
+  // [[wiki-link]] resolution deliberately keep reading the unscoped `graph` — a
+  // document's own connections are an integrity signal, not a corpus browse,
+  // and must not change shape because a UI filter is on.
+  const scopedGraph = useMemo(
+    () => scopeDocGraph(graph, memoryScope, memoryOwnerByNodeId),
+    [graph, memoryScope, memoryOwnerByNodeId],
+  );
+
   // Incoming connections for the active doc (Obsidian's linked/unlinked
   // mentions), straight off the graph — selectionKey matches docRefKey.
   const backlinks = useMemo<GrimoireBacklink[]>(() => {
@@ -1361,7 +1378,7 @@ export function GrimoireView({
         knowledge={knowledge ?? []}
         memory={scopedMemory}
         journal={journal ?? []}
-        graph={graph}
+        graph={scopedGraph}
         journalTitle={(date) => journalDayLabel(date, dateTimePrefs)}
         onOpen={openDoc}
         onNewStitch={openStitchNew}
@@ -1863,8 +1880,9 @@ export function GrimoireView({
             </div>
             <div className="min-h-0 flex-1">
               <GrimoireGraphView
-                graph={graph}
+                graph={scopedGraph}
                 meta={scan?.meta ?? null}
+                scopeLabel={memoryScopeLabel}
                 scanning={scanning}
                 scanError={scan ? null : scanError}
                 onOpen={(ref) => {

--- a/src/lib/grimoire-graph-scope.test.ts
+++ b/src/lib/grimoire-graph-scope.test.ts
@@ -1,0 +1,125 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  buildMemoryOwnerIndex,
+  memoryGraphNodeId,
+  scopeDocGraph,
+} from "./grimoire-graph-scope.ts";
+
+const node = (id, kind, degree = 0) => ({ id, ref: null, kind, title: id, degree });
+const edge = (source, target, type = "link") => ({ id: `${type}:${source}=>${target}`, source, target, type });
+
+// A small corpus: one stitch, echo's + sage's memory, a journal day, two tags.
+const graph = () => ({
+  nodes: [
+    node("knowledge:stitch-a", "knowledge", 3),
+    node(memoryGraphNodeId("/echo/one.md"), "memory", 2),
+    node(memoryGraphNodeId("/sage/two.md"), "memory", 2),
+    node(memoryGraphNodeId("/pool/shared.md"), "memory", 1),
+    node("journal:2026-08-05", "journal", 1),
+    node("tag:shared", "tag", 2),
+    node("tag:sage-only", "tag", 1),
+  ],
+  edges: [
+    edge("knowledge:stitch-a", memoryGraphNodeId("/echo/one.md")),
+    edge("knowledge:stitch-a", memoryGraphNodeId("/sage/two.md")),
+    edge(memoryGraphNodeId("/echo/one.md"), "journal:2026-08-05", "mention"),
+    edge("knowledge:stitch-a", "tag:shared", "tag"),
+    edge(memoryGraphNodeId("/sage/two.md"), "tag:sage-only", "tag"),
+    edge(memoryGraphNodeId("/pool/shared.md"), "tag:shared", "tag"),
+  ],
+});
+
+const owners = buildMemoryOwnerIndex([
+  { fullPath: "/echo/one.md", familiarId: "echo" },
+  { fullPath: "/sage/two.md", familiarId: "sage" },
+  { fullPath: "/pool/shared.md", familiarId: null },
+]);
+
+// ── Empty scope is "All" — untouched, and the SAME reference so memoized
+//    consumers don't rerender for nothing.
+{
+  const g = graph();
+  assert.equal(scopeDocGraph(g, new Set(), owners), g, "empty scope returns the graph by reference");
+}
+
+// ── The core guarantee: only the selected familiar's memory survives.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), owners);
+  const ids = scoped.nodes.map((n) => n.id);
+  assert.ok(ids.includes(memoryGraphNodeId("/echo/one.md")), "own memory kept");
+  assert.ok(!ids.includes(memoryGraphNodeId("/sage/two.md")), "another familiar's memory dropped");
+  assert.ok(
+    !ids.includes(memoryGraphNodeId("/pool/shared.md")),
+    "ownerless shared-pool memory hidden while a familiar is selected",
+  );
+}
+
+// ── Stitches and journal stay coven-wide (they carry no owner, and they are
+//    the graph's connective tissue).
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), owners);
+  const ids = scoped.nodes.map((n) => n.id);
+  assert.ok(ids.includes("knowledge:stitch-a"), "knowledge is never scoped out");
+  assert.ok(ids.includes("journal:2026-08-05"), "journal is never scoped out");
+}
+
+// ── No dangling edges: every edge endpoint still exists.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), owners);
+  const ids = new Set(scoped.nodes.map((n) => n.id));
+  for (const e of scoped.edges) {
+    assert.ok(ids.has(e.source), `edge ${e.id} source survives`);
+    assert.ok(ids.has(e.target), `edge ${e.id} target survives`);
+  }
+  assert.ok(
+    !scoped.edges.some((e) => e.source === memoryGraphNodeId("/sage/two.md")),
+    "edges out of a dropped node are pruned",
+  );
+}
+
+// ── A tag that loses every edge is pruned; a tag still pointed at survives.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), owners);
+  const ids = scoped.nodes.map((n) => n.id);
+  assert.ok(!ids.includes("tag:sage-only"), "a tag orphaned by scoping is pruned");
+  assert.ok(ids.includes("tag:shared"), "a tag the stitch still points at survives");
+}
+
+// ── Degree is recomputed, not carried over from the unscoped graph.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), owners);
+  const byId = new Map(scoped.nodes.map((n) => [n.id, n]));
+  assert.equal(byId.get("knowledge:stitch-a").degree, 2, "stitch lost its sage edge");
+  assert.equal(byId.get(memoryGraphNodeId("/echo/one.md")).degree, 2);
+  assert.equal(byId.get("tag:shared").degree, 1, "tag lost the shared-pool edge");
+}
+
+// ── Multiselect: two familiars both survive.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo", "sage"]), owners);
+  const ids = scoped.nodes.map((n) => n.id);
+  assert.ok(ids.includes(memoryGraphNodeId("/echo/one.md")));
+  assert.ok(ids.includes(memoryGraphNodeId("/sage/two.md")));
+  assert.ok(ids.includes("tag:sage-only"), "the tag is no longer orphaned");
+  assert.ok(!ids.includes(memoryGraphNodeId("/pool/shared.md")), "ownerless still hidden");
+}
+
+// ── A memory node absent from the inventory fails CLOSED — an unattributable
+//    path must not leak into a scoped view.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["echo"]), new Map());
+  assert.ok(
+    !scoped.nodes.some((n) => n.kind === "memory"),
+    "unknown ownership is treated as ownerless and hidden",
+  );
+}
+
+// ── Scoping to a familiar with no memory leaves the shared corpus intact.
+{
+  const scoped = scopeDocGraph(graph(), new Set(["thoth"]), owners);
+  assert.ok(!scoped.nodes.some((n) => n.kind === "memory"), "no memory for thoth");
+  assert.ok(scoped.nodes.some((n) => n.id === "knowledge:stitch-a"), "stitches remain");
+}
+
+console.log("grimoire-graph-scope tests passed");

--- a/src/lib/grimoire-graph-scope.ts
+++ b/src/lib/grimoire-graph-scope.ts
@@ -1,0 +1,81 @@
+// Narrow the Grimoire doc graph to the shell's familiar multiselect, mirroring
+// what the Memory navigator rail already does.
+//
+// Only MEMORY nodes carry an owner, so only memory nodes are scoped. Stitches
+// and journal days stay coven-wide for the same reason the rail keeps them:
+// knowledge is deliberately shared, and they are the graph's connective tissue —
+// dropping them would shred the very relations the view exists to show.
+//
+// Dropping nodes is not enough on its own. Edges whose endpoint disappeared
+// would dangle, and a tag node that loses every edge becomes a floating orphan
+// that the unscoped graph can never produce (tag nodes only exist because some
+// doc pointed at them). So this prunes both and recomputes `degree`, which the
+// renderer uses for node size — leaving the pre-scope degree would draw a
+// memory-heavy stitch as a hub with no visible spokes.
+
+import { familiarInScope } from "./familiar-multiselect.ts";
+import type { DocGraph, DocGraphEdge, DocGraphNode } from "./grimoire-graph.ts";
+
+/** Node id of a memory doc, matching `docRefKey({ kind: "memory", path })`. */
+export function memoryGraphNodeId(fullPath: string): string {
+  return `memory:${fullPath}`;
+}
+
+/**
+ * Build the `memoryGraphNodeId -> familiarId` lookup the scope needs from the
+ * loaded memory inventory. Ownership lives only on the inventory entries; the
+ * graph itself carries just paths.
+ */
+export function buildMemoryOwnerIndex(
+  entries: readonly { fullPath: string; familiarId?: string | null }[],
+): Map<string, string | null> {
+  const owners = new Map<string, string | null>();
+  for (const entry of entries) {
+    owners.set(memoryGraphNodeId(entry.fullPath), entry.familiarId ?? null);
+  }
+  return owners;
+}
+
+/**
+ * Restrict `graph` to `scope`. An empty scope is "All" and returns the graph
+ * untouched (same reference, so memoized consumers never rerender for nothing).
+ *
+ * A memory node whose owner is unknown — not in the inventory, or an ownerless
+ * shared pool such as `~/.coven/memory` — is treated as ownerless and hidden
+ * while a familiar is selected, matching `memory-file-scope`'s rule. Failing
+ * closed here is deliberate: a path we cannot attribute must not leak into a
+ * scoped view.
+ */
+export function scopeDocGraph(
+  graph: DocGraph,
+  scope: ReadonlySet<string>,
+  memoryOwnerByNodeId: ReadonlyMap<string, string | null>,
+): DocGraph {
+  if (scope.size === 0) return graph;
+
+  const kept = new Set<string>();
+  const nodes: DocGraphNode[] = [];
+  for (const node of graph.nodes) {
+    if (node.kind === "memory" && !familiarInScope(scope, memoryOwnerByNodeId.get(node.id) ?? null)) {
+      continue;
+    }
+    kept.add(node.id);
+    nodes.push(node);
+  }
+
+  const edges: DocGraphEdge[] = graph.edges.filter((e) => kept.has(e.source) && kept.has(e.target));
+
+  const degree = new Map<string, number>();
+  for (const e of edges) {
+    degree.set(e.source, (degree.get(e.source) ?? 0) + 1);
+    degree.set(e.target, (degree.get(e.target) ?? 0) + 1);
+  }
+
+  // A tag with no surviving edge is meaningless — prune it. Tag edges only ever
+  // touch that tag, so removing one strands no further edges.
+  const scopedNodes = nodes
+    .filter((n) => n.kind !== "tag" || (degree.get(n.id) ?? 0) > 0)
+    .map((n) => ({ ...n, degree: degree.get(n.id) ?? 0 }));
+
+  return { nodes: scopedNodes, edges };
+}


### PR DESCRIPTION
Closes `cave-agmbk`.

## What and why

The Memories surface already narrows its Memory rail and launcher stats to the shell's familiar multiselect. The **Relations** graph beside them did not — it drew every familiar's memory nodes, so Relations could show memory that the navigator two inches to its left was hiding.

## The approach

New pure `src/lib/grimoire-graph-scope.ts` with `scopeDocGraph(graph, scope, owners)`. Filtering nodes alone is not enough, so it also:

- **prunes edges** whose endpoint disappeared, so nothing dangles;
- **prunes tag nodes** left with no edges — the unscoped graph can never produce a tagless tag, since tags only exist because a doc pointed at one;
- **recomputes `degree`** — the renderer sizes nodes by it, so a carried-over degree would draw hubs with no visible spokes.

An empty scope is the canonical "All" and returns the graph **by reference**, so memoized consumers never rerender for nothing.

## Two deliberate boundaries

- **Stitches and journal days stay coven-wide**, matching the rail. Knowledge is explicitly not memory, and those nodes are the connective tissue the graph exists to show.
- **Backlinks and wiki-link resolution keep reading the unscoped graph.** A document's own connections are an integrity signal, not a corpus browse, and must not change shape because a UI filter is on. Pinned by a test.

Ownership is indexed from the **unscoped** inventory, because graph nodes carry only paths — filtering first would leave every dropped file unattributable. A memory node whose owner cannot be determined (absent from the inventory, or an ownerless shared pool like `~/.coven/memory`) **fails closed** and is hidden while a familiar is selected, matching `memory-file-scope`.

## Copy

Scoping silently is its own bug, so the surface says what happened: an empty graph reads *"No relations for Echo"* rather than *"Nothing to graph yet"*, the filter card states *"Memory is scoped to Echo. Stitches and journal days stay coven-wide,"* and the truncation notice gains *"across the coven"* so its totals are not misread as the scope's.

## Verification

- `pnpm typecheck` clean; `pnpm exec eslint` on both changed components clean; `pnpm codemod:design:check` 0 drift; `check:tests-wired` 1525/1525.
- 8 new cases in `grimoire-graph-scope.test.ts` (empty-scope identity, foreign/ownerless exclusion, no dangling edges, orphaned-tag pruning, degree recomputation, multiselect, fail-closed on unknown ownership).
- New assertions in `grimoire-view.test.ts` and `grimoire-graph-view.test.ts`; `grimoire-launcher.test.ts` updated — it pinned `graph={graph}` and correctly caught the change.
- **Live in the built app** at 1440x900: **All** shows 456 nodes (Memory 400); **Echo** shows 91 nodes (Memory 35), with Knowledge 17 / Journal 21 / Tags 18 unchanged in both.

## Note on the worktree

`pnpm beads:worktrees:create` exited **1** (`lifecycle inventory is incomplete: conflicting structured path ownership for .worktrees/cave-o1rqu-ios-testflight`) — an unrelated repo-state condition, which is the one case the docs sanction the plain `git worktree add` fallback. This branch's worktree therefore carries no lifecycle metadata and will need manual retirement.
