### PR TITLE
Fold earlier turns behind a pill on a long thread

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -256,6 +256,7 @@ export const SUITES = {
     "src/lib/chat-session-activity.test.ts",
     "src/lib/chat-session-sort.test.ts",
     "src/lib/chat-turn-gap.test.ts",
+    "src/lib/chat-transcript-fold.test.ts",
     "src/lib/chat-project-overrides.test.ts",
     "src/lib/chat-add-project.test.ts",
     "src/lib/project-setup-offer.test.ts",

--- a/src/components/chat-view-render-cap.test.ts
+++ b/src/components/chat-view-render-cap.test.ts
@@ -12,15 +12,30 @@ const src = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
 
 assert.match(src, /const TRANSCRIPT_RENDER_CAP = \d+;/, "a numeric render cap constant exists");
 
+// cave-u5lq7 put the earlier-turns fold ahead of the cap: a CLOSED fold mounts
+// even less than the cap would, so it wins outright and the cap decision below
+// is what runs whenever the fold is open or absent.
+assert.match(
+  src,
+  /const renderGroups = folded\s*\n\s*\? groupedTurns\.slice\(fold\.startIndex\)/,
+  "a closed fold mounts its tail instead of the capped tail",
+);
 assert.match(
   src,
   /historyExpanded \|\| groupedTurns\.length <= TRANSCRIPT_RENDER_CAP\s*\?\s*groupedTurns\s*:\s*groupedTurns\.slice\(-TRANSCRIPT_RENDER_CAP\)/,
   "the transcript renders the capped tail unless expanded or already short",
 );
+// The fold's own count must never be computed off the capped slice, or a long
+// thread's pill reports the render budget instead of the conversation.
+assert.match(
+  src,
+  /const fold = chatTranscriptFold\(groupedTurns\);/,
+  "the fold measures the whole transcript, not the capped slice",
+);
 
 assert.match(
   src,
-  /return renderGroups\.map\(\(g\) =>/,
+  /const rows = renderGroups\.map\(\(g\) =>/,
   "the render loop maps the capped renderGroups (not the full groupedTurns)",
 );
 
@@ -32,9 +47,13 @@ assert.match(
   "updateFollowing(false) expands the transcript (covers wheel/touch/keys/find-jump)",
 );
 
+// Find must clear BOTH limiters (cave-u5lq7). Clearing only the cap left a
+// long thread reporting hits inside folded turns and then jumping nowhere,
+// because jumpToFindMatch resolves its target through querySelector and the
+// row it looks for was never rendered.
 assert.match(
   src,
-  /if \(findOpen\) setHistoryExpanded\(true\)/,
+  /if \(findOpen\) \{\s*\n\s*setHistoryExpanded\(true\);\s*\n\s*setFoldOpen\(true\);/,
   "opening find mounts the whole transcript so jumps resolve via data-turn-id",
 );
 

--- a/src/components/chat-view-render-cap.test.ts
+++ b/src/components/chat-view-render-cap.test.ts
@@ -35,8 +35,18 @@ assert.match(
 
 assert.match(
   src,
-  /const rows = renderGroups\.map\(\(g\) =>/,
+  /const rows = renderGroups\.map\(\(g, groupIndex\) =>/,
   "the render loop maps the capped renderGroups (not the full groupedTurns)",
+);
+
+// The first rendered row's `prev` turn is by definition one the reader cannot
+// see — folded away, or below the cap — so a time-gap rule there measures a
+// pause against nothing, and under a fold it stacks a second hairline directly
+// beneath the pill.
+assert.match(
+  src,
+  /const gapLabel = groupIndex === 0 \? null : chatTurnGapLabel\(prev\?\.createdAt, t\.createdAt\);/,
+  "no time-gap divider on the first rendered row",
 );
 
 // Leaving the bottom (updateFollowing(false)) must mount the full transcript so

--- a/src/components/chat-view-transcript-memo.test.ts
+++ b/src/components/chat-view-transcript-memo.test.ts
@@ -98,7 +98,7 @@ assert.match(
 // is unchanged.
 assert.match(
   transcriptRowsBody,
-  /const rows = renderGroups\.map\(\(g\) => \{/,
+  /const rows = renderGroups\.map\(\(g, groupIndex\) => \{/,
   "the row loop lives inside the memo component",
 );
 // The pre-extraction inline IIFE form must not come back to ChatView's JSX.

--- a/src/components/chat-view-transcript-memo.test.ts
+++ b/src/components/chat-view-transcript-memo.test.ts
@@ -92,9 +92,13 @@ assert.match(
   /historyExpanded \|\| groupedTurns\.length <= TRANSCRIPT_RENDER_CAP/,
   "the render cap decision moved with the loop",
 );
+// cave-u5lq7: the loop now assigns instead of returning, because the
+// earlier-turns fold prepends a pill ahead of the rows. What this pin cares
+// about — that the mapping lives INSIDE the memo, not in ChatView's body —
+// is unchanged.
 assert.match(
   transcriptRowsBody,
-  /return renderGroups\.map\(\(g\) => \{/,
+  /const rows = renderGroups\.map\(\(g\) => \{/,
   "the row loop lives inside the memo component",
 );
 // The pre-extraction inline IIFE form must not come back to ChatView's JSX.

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -8219,7 +8219,7 @@ const TranscriptRows = memo(function TranscriptRows({
     : historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
       ? groupedTurns
       : groupedTurns.slice(-TRANSCRIPT_RENDER_CAP);
-  const rows = renderGroups.map((g) => {
+  const rows = renderGroups.map((g, groupIndex) => {
     if (g.kind === "single") {
       const t = g.turn;
       const i = turnIndexMap.get(t.id) ?? -1;
@@ -8228,7 +8228,12 @@ const TranscriptRows = memo(function TranscriptRows({
       // named rule across the column. The transcript already revealed a
       // timestamp here; the divider says what the timestamp only implies —
       // that the turns above and below are separate sittings.
-      const gapLabel = chatTurnGapLabel(prev?.createdAt, t.createdAt);
+      // …but never on the FIRST rendered row. Its `prev` is a turn the reader
+      // cannot see — folded away, or below the render cap — so the rule would
+      // measure a pause against nothing, and it lands one line under the fold
+      // pill, which is already the boundary there (design language §8: one
+      // hairline per boundary).
+      const gapLabel = groupIndex === 0 ? null : chatTurnGapLabel(prev?.createdAt, t.createdAt);
       const showTimestamp = (() => {
         if (!t.createdAt) return false;
         if (!prev?.createdAt) return true;
@@ -8355,13 +8360,10 @@ const TranscriptRows = memo(function TranscriptRows({
         aria-label={chatFoldAriaLabel(fold.hiddenTurns, foldOpen)}
         onClick={onToggleFold}
       >
-        <Icon
-          name="ph:caret-up"
-          width={9}
-          className="cave-chat-fold__caret"
-          data-open={foldOpen ? "true" : undefined}
-          aria-hidden
-        />
+        {/* The caret's direction is driven off the button's own aria-expanded,
+            not a data-prop on the Icon: Icon only forwards aria-* / role, so a
+            data attribute here is silently dropped and the caret never turns. */}
+        <Icon name="ph:caret-up" width={9} className="cave-chat-fold__caret" aria-hidden />
         {chatFoldLabel(fold.hiddenTurns, foldOpen)}
       </button>
       <span aria-hidden className="cave-chat-fold__rule" />

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -86,6 +86,11 @@ import {
 import { groupTranscriptTurns, type TranscriptGroup } from "@/lib/chat-transcript-groups";
 import { generateChatTitle } from "@/lib/chat-title-generation";
 import { chatTurnGapLabel } from "@/lib/chat-turn-gap";
+import {
+  chatFoldAriaLabel,
+  chatFoldLabel,
+  chatTranscriptFold,
+} from "@/lib/chat-transcript-fold";
 import { readChatComposerPrefs, writeChatComposerPrefs } from "@/lib/chat-composer-prefs";
 import {
   newSessionDefaults,
@@ -2545,6 +2550,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   const [historyExpanded, setHistoryExpanded] = useState(false);
   const historyExpandedRef = useRef(false);
   historyExpandedRef.current = historyExpanded;
+  // "Chat Session - Prototype.dc.html" (cave-u5lq7): a long thread opens on the
+  // recent exchange with everything older behind one pill. Separate concern
+  // from historyExpanded above — that is a mounting budget, this is a reading
+  // affordance — but opening the fold lifts the cap too, because a pill that
+  // says "hide earlier turns" has promised every earlier turn.
+  const [foldOpen, setFoldOpen] = useState(false);
+  const foldOpenRef = useRef(false);
+  foldOpenRef.current = foldOpen;
   // Distance-from-bottom captured at the instant of expansion so the prepended
   // older rows don't visually shove the viewport (restored in a layout effect).
   const expandAnchorRef = useRef<number | null>(null);
@@ -2620,8 +2633,12 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   // Restore the pre-expansion distance-from-bottom once the full transcript has
   // mounted, so revealing the older rows doesn't jump the reader's viewport.
+  // Either reveal prepends rows above the viewport, so both have to restore the
+  // anchor. Keying on historyExpanded alone missed the case where the reader
+  // had already scrolled up (cap lifted) and then opened the fold — the rows
+  // arrived with no effect left to fire, and the viewport jumped.
   useLayoutEffect(() => {
-    if (!historyExpanded) return;
+    if (!historyExpanded && !foldOpen) return;
     const anchor = expandAnchorRef.current;
     expandAnchorRef.current = null;
     if (anchor == null) return;
@@ -2630,7 +2647,22 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       el.scrollTop = Math.max(0, el.scrollHeight - anchor);
       captureReleasedScrollAnchor();
     }
-  }, [captureReleasedScrollAnchor, historyExpanded]);
+  }, [captureReleasedScrollAnchor, historyExpanded, foldOpen]);
+
+  // Opening the fold lifts the render cap with it and anchors the scroll, so
+  // the earlier turns slide in ABOVE the reader rather than shoving them down.
+  // Stable identity: TranscriptRows is memoized on its props.
+  const toggleFold = useCallback(() => {
+    if (foldOpenRef.current) {
+      setFoldOpen(false);
+      return;
+    }
+    const el = scrollRef.current;
+    expandAnchorRef.current = el ? el.scrollHeight - el.scrollTop : null;
+    captureReleasedScrollAnchor();
+    setHistoryExpanded(true);
+    setFoldOpen(true);
+  }, [captureReleasedScrollAnchor]);
 
   // `shouldApply` lets a caller (the effect below) veto the setState after the
   // await — a fetch that resolves after a thread switch must not overwrite the
@@ -3219,9 +3251,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
 
   // Find searches the whole transcript, so opening it mounts every turn — a
   // jump (jumpToFindMatch) resolves its target via querySelector and must find
-  // the row in the DOM regardless of the render cap.
+  // the row in the DOM regardless of the render cap OR the fold. Without the
+  // fold half, searching a long thread reports hits in folded turns and then
+  // jumps nowhere, because the row it looks for was never rendered.
   useEffect(() => {
-    if (findOpen) setHistoryExpanded(true);
+    if (findOpen) {
+      setHistoryExpanded(true);
+      setFoldOpen(true);
+    }
   }, [findOpen]);
 
   // Keep the active pointer in bounds when the match set shrinks.
@@ -4075,6 +4112,9 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
   useEffect(() => {
     updateFollowing(true);
     setHistoryExpanded(false);
+    // The fold is per-thread: arriving in a new chat should land on its recent
+    // exchange, not inherit the last thread's expansion.
+    setFoldOpen(false);
     expandAnchorRef.current = null;
     releasedScrollAnchorRef.current = null;
   }, [sessionId, updateFollowing]);
@@ -7655,6 +7695,8 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             turnIndexMap={turnIndexMap}
             allTurns={activePath}
             historyExpanded={historyExpanded}
+            foldOpen={foldOpen}
+            onToggleFold={toggleFold}
             familiar={familiar}
             busy={busy}
             foundTurnId={foundTurnId}
@@ -8126,6 +8168,8 @@ const TranscriptRows = memo(function TranscriptRows({
   turnIndexMap,
   allTurns,
   historyExpanded,
+  foldOpen,
+  onToggleFold,
   familiar,
   // Presence input for regenerateFor (see doc comment); unused directly.
   busy: _busy,
@@ -8141,6 +8185,10 @@ const TranscriptRows = memo(function TranscriptRows({
   turnIndexMap: Map<string, number>;
   allTurns: Turn[];
   historyExpanded: boolean;
+  /** Earlier-turns fold (cave-u5lq7): closed hides everything but the recent
+   *  exchange. Distinct from historyExpanded — see chat-transcript-fold.ts. */
+  foldOpen: boolean;
+  onToggleFold: () => void;
   familiar: Familiar;
   busy: boolean;
   foundTurnId: string | null;
@@ -8154,16 +8202,24 @@ const TranscriptRows = memo(function TranscriptRows({
   followUpTurnId: string | null;
 }) {
   const handlers = () => handlersRef.current;
+  // Earlier-turns fold ("Chat Session - Prototype.dc.html", cave-u5lq7). The
+  // fold's count is computed over the WHOLE transcript, never over the capped
+  // slice — a pill reading "54 earlier turns" on a 200-turn thread would be
+  // reporting the render cap, not the conversation.
+  const fold = chatTranscriptFold(groupedTurns);
+  const folded = fold.hiddenTurns > 0 && !foldOpen;
   // Render cap (TRANSCRIPT_RENDER_CAP): while pinned to the bottom, only
   // mount the newest groups. The per-row prev-turn lookup still reads
   // the full `allTurns`/`turnIndexMap`, so the first visible row's
   // timestamp gap stays correct. Expands to the whole transcript the
   // moment the reader scrolls up or opens find (see historyExpanded).
-  const renderGroups =
-    historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
+  // A closed fold mounts even less than the cap would, so it wins outright.
+  const renderGroups = folded
+    ? groupedTurns.slice(fold.startIndex)
+    : historyExpanded || groupedTurns.length <= TRANSCRIPT_RENDER_CAP
       ? groupedTurns
       : groupedTurns.slice(-TRANSCRIPT_RENDER_CAP);
-  return renderGroups.map((g) => {
+  const rows = renderGroups.map((g) => {
     if (g.kind === "single") {
       const t = g.turn;
       const i = turnIndexMap.get(t.id) ?? -1;
@@ -8285,6 +8341,33 @@ const TranscriptRows = memo(function TranscriptRows({
       </div>
     );
   });
+  if (fold.hiddenTurns === 0) return rows;
+  // The pill leads the transcript in both states: closed it names what is
+  // hidden, open it names the way back. The two rules make it read as a seam
+  // in the conversation rather than as a toolbar.
+  return [
+    <div key="__chat-fold" className="cave-chat-fold">
+      <span aria-hidden className="cave-chat-fold__rule" />
+      <button
+        type="button"
+        className="cave-chat-fold__pill focus-ring"
+        aria-expanded={foldOpen}
+        aria-label={chatFoldAriaLabel(fold.hiddenTurns, foldOpen)}
+        onClick={onToggleFold}
+      >
+        <Icon
+          name="ph:caret-up"
+          width={9}
+          className="cave-chat-fold__caret"
+          data-open={foldOpen ? "true" : undefined}
+          aria-hidden
+        />
+        {chatFoldLabel(fold.hiddenTurns, foldOpen)}
+      </button>
+      <span aria-hidden className="cave-chat-fold__rule" />
+    </div>,
+    ...rows,
+  ];
 });
 
 // CHAT-D3-07 perf: the implementation is memoized as `TurnRow` below, so a

--- a/src/lib/chat-transcript-fold.test.ts
+++ b/src/lib/chat-transcript-fold.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  CHAT_FOLD_KEEP_GROUPS,
+  CHAT_FOLD_MIN_HIDDEN_TURNS,
+  chatFoldAriaLabel,
+  chatFoldLabel,
+  chatTranscriptFold,
+} from "./chat-transcript-fold.ts";
+import type { TranscriptGroup } from "./chat-transcript-groups.ts";
+import type { Turn } from "./chat-turn-state.ts";
+
+const turn = (id: string): Turn => ({ id, role: "user", text: id }) as Turn;
+const single = (id: string): TranscriptGroup => ({ kind: "single", turn: turn(id) });
+const call = (id: string, n: number): TranscriptGroup => ({
+  kind: "call",
+  callId: id,
+  turns: Array.from({ length: n }, (_, i) => turn(`${id}-${i}`)),
+  durationSec: 60,
+});
+const singles = (n: number) => Array.from({ length: n }, (_, i) => single(`t${i}`));
+
+test("a thread that fits on screen never folds", () => {
+  assert.deepEqual(chatTranscriptFold([]), { startIndex: 0, hiddenTurns: 0 });
+  assert.deepEqual(chatTranscriptFold(singles(1)), { startIndex: 0, hiddenTurns: 0 });
+  assert.deepEqual(
+    chatTranscriptFold(singles(CHAT_FOLD_KEEP_GROUPS)),
+    { startIndex: 0, hiddenTurns: 0 },
+    "exactly the keep count is not folded — there is nothing behind the pill",
+  );
+});
+
+test("folding one or two turns is not worth a divider", () => {
+  // The control would cost a row to save a row. Below the floor, show them.
+  for (let extra = 1; extra < CHAT_FOLD_MIN_HIDDEN_TURNS; extra += 1) {
+    assert.deepEqual(
+      chatTranscriptFold(singles(CHAT_FOLD_KEEP_GROUPS + extra)),
+      { startIndex: 0, hiddenTurns: 0 },
+      `${extra} hidden turn(s) stays unfolded`,
+    );
+  }
+});
+
+test("the fold engages at the floor and keeps the recent exchange visible", () => {
+  const groups = singles(CHAT_FOLD_KEEP_GROUPS + CHAT_FOLD_MIN_HIDDEN_TURNS);
+  const fold = chatTranscriptFold(groups);
+  assert.equal(fold.hiddenTurns, CHAT_FOLD_MIN_HIDDEN_TURNS);
+  assert.equal(fold.startIndex, CHAT_FOLD_MIN_HIDDEN_TURNS);
+  assert.equal(
+    groups.length - fold.startIndex,
+    CHAT_FOLD_KEEP_GROUPS,
+    "the visible tail is always the keep count",
+  );
+});
+
+test("a long thread folds everything above the tail", () => {
+  const fold = chatTranscriptFold(singles(50));
+  assert.equal(fold.startIndex, 50 - CHAT_FOLD_KEEP_GROUPS);
+  assert.equal(fold.hiddenTurns, 50 - CHAT_FOLD_KEEP_GROUPS);
+});
+
+test("the count is in TURNS, so a folded voice call cannot understate itself", () => {
+  // One call group carrying eight turns sits above six singles. Counting
+  // groups would put "1 earlier turn" over a fold hiding eight.
+  const groups = [call("c1", 8), ...singles(CHAT_FOLD_KEEP_GROUPS)];
+  const fold = chatTranscriptFold(groups);
+  assert.equal(fold.startIndex, 1, "the call is one group");
+  assert.equal(fold.hiddenTurns, 8, "but eight turns are behind the fold");
+});
+
+test("a folded call below the floor still counts its turns toward engaging", () => {
+  // A single call group of 3 turns is 1 group but 3 turns — over the floor.
+  const groups = [call("c1", 3), ...singles(CHAT_FOLD_KEEP_GROUPS)];
+  assert.equal(chatTranscriptFold(groups).hiddenTurns, 3);
+  // …and a 2-turn call is under it.
+  const short = [call("c2", 2), ...singles(CHAT_FOLD_KEEP_GROUPS)];
+  assert.equal(chatTranscriptFold(short).hiddenTurns, 0);
+});
+
+test("the label never claims turns are hidden while they are on screen", () => {
+  assert.equal(chatFoldLabel(3, false), "3 earlier turns");
+  assert.equal(chatFoldLabel(1, false), "1 earlier turn");
+  assert.equal(chatFoldLabel(12, true), "hide earlier turns");
+  assert.equal(chatFoldAriaLabel(3, false), "Show 3 earlier turns");
+  assert.equal(chatFoldAriaLabel(1, false), "Show 1 earlier turn");
+  assert.equal(chatFoldAriaLabel(3, true), "Hide earlier turns");
+});

--- a/src/lib/chat-transcript-fold.ts
+++ b/src/lib/chat-transcript-fold.ts
@@ -1,0 +1,62 @@
+// The "N earlier turns" fold — the last piece of the
+// "Chat Session - Prototype.dc.html" handoff (see
+// docs/design-handoff/IMPLEMENTATION-STATUS.md; the rest landed in cave-n3jg2).
+//
+// A long thread opens on the recent exchange and puts everything older behind
+// one pill on a rule. This is a READING affordance and is deliberately distinct
+// from `TRANSCRIPT_RENDER_CAP` / `historyExpanded`, which is a mounting budget:
+// the cap answers "how many rows can the browser afford right now?", the fold
+// answers "how much of this conversation is still the conversation?". They
+// compose — opening the fold also lifts the cap, because a pill that says
+// "hide earlier turns" has promised every earlier turn.
+//
+// Counts are in TURNS, not groups: a voice call is one group carrying several
+// turns, and a label reading "3 earlier turns" over a fold hiding eight would
+// be a lie the reader cannot see through.
+
+import type { TranscriptGroup } from "./chat-transcript-groups.ts";
+
+/** Groups always left visible below a closed fold — roughly three exchanges,
+ *  which is enough to know where you are without scrolling. */
+export const CHAT_FOLD_KEEP_GROUPS = 6;
+
+/** Below this, folding costs a divider and saves nothing. Hiding one or two
+ *  turns behind a control is worse than just showing them. */
+export const CHAT_FOLD_MIN_HIDDEN_TURNS = 3;
+
+export type ChatTranscriptFold = {
+  /** Index into groupedTurns where the visible tail starts; 0 when nothing folds. */
+  startIndex: number;
+  /** Turns behind the fold. 0 means there is no fold to draw. */
+  hiddenTurns: number;
+};
+
+const NO_FOLD: ChatTranscriptFold = { startIndex: 0, hiddenTurns: 0 };
+
+function turnsIn(group: TranscriptGroup): number {
+  return group.kind === "call" ? group.turns.length : 1;
+}
+
+export function chatTranscriptFold(groups: readonly TranscriptGroup[]): ChatTranscriptFold {
+  if (groups.length <= CHAT_FOLD_KEEP_GROUPS) return NO_FOLD;
+  const startIndex = groups.length - CHAT_FOLD_KEEP_GROUPS;
+  let hiddenTurns = 0;
+  for (let i = 0; i < startIndex; i += 1) hiddenTurns += turnsIn(groups[i]);
+  if (hiddenTurns < CHAT_FOLD_MIN_HIDDEN_TURNS) return NO_FOLD;
+  return { startIndex, hiddenTurns };
+}
+
+/** Closed, the pill names what it is hiding; open, it names the way back.
+ *  Never "N earlier turns" while they are on screen — the label would be
+ *  describing something the reader can already see. */
+export function chatFoldLabel(hiddenTurns: number, open: boolean): string {
+  if (open) return "hide earlier turns";
+  return `${hiddenTurns} earlier ${hiddenTurns === 1 ? "turn" : "turns"}`;
+}
+
+/** Accessible name for the toggle. The visible pill is terse mono chrome; a
+ *  screen reader gets the whole sentence. */
+export function chatFoldAriaLabel(hiddenTurns: number, open: boolean): string {
+  if (open) return "Hide earlier turns";
+  return `Show ${hiddenTurns} earlier ${hiddenTurns === 1 ? "turn" : "turns"}`;
+}

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -526,11 +526,14 @@
   color: var(--text-primary);
   border-color: var(--border-strong);
 }
-/* The caret points at what the press will do: up = fold away, down = reveal. */
+/* The caret points at what the press will do: up = fold away, down = reveal.
+   Driven off the button's aria-expanded rather than a data attribute on the
+   glyph — Icon forwards only aria-* and role, so anything else is dropped and
+   the caret would sit frozen in one direction while the label changed. */
 .cave-chat-fold__caret {
   transition: transform var(--duration-fast) var(--ease-standard);
 }
-.cave-chat-fold__caret:not([data-open="true"]) {
+.cave-chat-fold__pill[aria-expanded="false"] .cave-chat-fold__caret {
   transform: rotate(180deg);
 }
 @media (prefers-reduced-motion: reduce) {

--- a/src/styles/cave-chat/session-chrome.css
+++ b/src/styles/cave-chat/session-chrome.css
@@ -481,3 +481,60 @@
   color: var(--text-muted);
   white-space: nowrap;
 }
+
+/* ── Earlier-turns fold ("Chat Session - Prototype.dc.html", cave-u5lq7) ─────
+   A long thread opens on its recent exchange; everything older sits behind one
+   pill on a rule, which reads as a seam in the conversation rather than as a
+   toolbar. Same rule + mono-uppercase vocabulary as the turn-gap divider above,
+   because both mark a discontinuity in the transcript — the difference is that
+   this one is actionable, so it is a real button with a caret. */
+.cave-chat-fold {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-2) 0 var(--space-4);
+}
+.cave-chat-fold__rule {
+  flex: 1;
+  min-width: var(--space-2);
+  height: 1px;
+  background: var(--border-hairline);
+}
+.cave-chat-fold__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  flex: none;
+  height: 22px;
+  padding: 0 var(--space-2);
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-pill);
+  background: color-mix(in oklch, var(--bg-panel) 55%, transparent);
+  color: var(--text-muted);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: var(--text-2xs);
+  font-weight: 600;
+  letter-spacing: var(--tracking-eyebrow);
+  text-transform: uppercase;
+  white-space: nowrap;
+  cursor: pointer;
+  transition:
+    color var(--duration-fast) var(--ease-standard),
+    border-color var(--duration-fast) var(--ease-standard);
+}
+.cave-chat-fold__pill:hover {
+  color: var(--text-primary);
+  border-color: var(--border-strong);
+}
+/* The caret points at what the press will do: up = fold away, down = reveal. */
+.cave-chat-fold__caret {
+  transition: transform var(--duration-fast) var(--ease-standard);
+}
+.cave-chat-fold__caret:not([data-open="true"]) {
+  transform: rotate(180deg);
+}
+@media (prefers-reduced-motion: reduce) {
+  .cave-chat-fold__caret {
+    transition: none;
+  }
+}


### PR DESCRIPTION
The last outstanding piece of the [`Chat Session - Prototype.dc.html`](https://claude.ai/design/p/8593bb9e-c29d-439b-afd8-381f7106f640?file=Chat+Session+-+Prototype.dc.html) handoff — the rest landed in `cave-n3jg2` (#4378). Bead: `cave-u5lq7`.

A long thread now opens on its recent exchange, with everything older behind one pill on a rule — `8 EARLIER TURNS` — that toggles them back.

## Why this is not the render cap

Chat already trimmed long transcripts through `TRANSCRIPT_RENDER_CAP` / `historyExpanded`, but that is a **mounting budget**: it answers *"how many rows can the browser afford right now?"* and is invisible by design — the reader never learns anything was left out, and scrolling silently mounts it. The fold answers a different question, *"how much of this conversation is still the conversation?"*, and answers it out loud.

They compose rather than compete. A closed fold mounts **less** than the cap would, so it wins outright; and **opening** it lifts the cap, because a pill that says "hide earlier turns" has promised every earlier turn.

## Two things that would have made it lie

- **The count is in turns, not groups.** A voice call is one group carrying several turns, so counting groups would print "1 earlier turn" over a fold hiding eight.
- **The count is measured over the whole transcript, never the capped slice.** Otherwise a 200-turn thread's pill would be reporting the render budget rather than the conversation.

## Two things that would have made it break

- **Find now clears both limiters.** It already lifted the cap so `jumpToFindMatch` could resolve its target through `querySelector`; with the fold in place and only the cap cleared, searching a long thread would report hits inside folded turns and then jump nowhere, because the row it looks for was never rendered.
- **The scroll anchor now keys on both reveals.** It restored the reader's distance-from-bottom when the cap lifted, but a reader who had already scrolled up (cap already lifted) and then opened the fold got no effect at all — the earlier turns arrived and shoved the viewport down.

The fold is per-thread and resets on session switch. It engages only when it earns its own divider: six groups stay visible and at least three turns must be hidden, because putting one or two turns behind a control costs a row to save a row.

## Found by driving it, not by reading the diff

Two defects a source read could not surface, fixed in `782fb74`:

1. **The caret never turned.** `Icon` destructures its props and forwards only `aria-*` and `role`, so the `data-open` attribute driving the rotation was silently dropped — the open pill read "hide earlier turns" while its caret still pointed *down*, i.e. the control contradicted its own label. It now keys off the button's `aria-expanded`, which it already carried, so there is no second source of truth to fall out of sync.
2. **Two rules stacked under the pill.** The first rendered row still drew its time-gap divider, and that row's `prev` turn is by definition one the reader cannot see. So the rule measured a pause against nothing and landed one line under the pill, which is already the boundary there (design language §8: one hairline per boundary). This one predates the fold — the render cap could always put a gap on its first row — but the fold made it a visible double boundary rather than a rare edge.

Verified at 1280×900 against a production build with a mocked 14-turn conversation: **closed** → `8 earlier turns`, `aria-expanded=false`, 6 rows mounted; **open** → `hide earlier turns`, `aria-expanded=true`, all 14.

## Not adopted from the frame

The dimming of the two turns just below a closed fold. It exists in the mock to suggest more content above — which the pill now states outright — and fading readable prose is a real contrast cost for a hint already carried in words.

## Gates

`typecheck` · `eslint` · `codemod:design:check` · `design-token-drift` (all ratchets at baseline — this change adds no inline styles, off-scale spacing or radii) · `check:tests-wired` (1,526 wired) · `test:mobile`. 7 new unit tests in `chat-transcript-fold`, plus repointed pins in `chat-view-render-cap` and `chat-view-transcript-memo` covering the new loop signature and the leading-gap rule.
