### PR TITLE
fix(e2e): expect the inset focus ring the Sessions tab renders

### DIFF
--- a/tests/code-surface.spec.ts
+++ b/tests/code-surface.spec.ts
@@ -338,28 +338,24 @@ test.describe("code surface (Coding familiar's room)", () => {
     await page.keyboard.press("Tab");
     await sessionsTab.focus();
     await expect(sessionsTab).toBeFocused();
+    // Report the real computed values rather than a collapsed boolean: a bare
+    // `outlineMatchesToken: false` hides which half mismatched. The tab carries
+    // `focus-ring-inset`, so the ring is drawn inside the box — width
+    // `--ring-width` (2px) at the negated offset, not the outset `--ring-offset`.
     await expect
       .poll(
         () =>
           sessionsTab.evaluate((element) => {
             const style = getComputedStyle(element);
-            const root = getComputedStyle(document.documentElement);
-            // Compare numerically: the tokens compute to `calc()` expressions
-            // that never string-equal the browser-evaluated pixel values.
-            // `.focus-ring` uses the OUTSET --ring-offset, not the inset
-            // variant, so the expected offset is positive.
-            const ringWidth = Number.parseFloat(root.getPropertyValue("--ring-width"));
-            const ringOffset = Number.parseFloat(root.getPropertyValue("--ring-offset"));
             return {
               focusVisible: element.matches(":focus-visible"),
-              outlineMatchesToken:
-                Number.parseFloat(style.outlineWidth) === ringWidth &&
-                Number.parseFloat(style.outlineOffset) === ringOffset,
+              outlineWidth: style.outlineWidth,
+              outlineOffset: style.outlineOffset,
             };
           }),
         { timeout: 30_000 },
       )
-      .toEqual({ focusVisible: true, outlineMatchesToken: true });
+      .toEqual({ focusVisible: true, outlineWidth: "2px", outlineOffset: "-2px" });
 
     // Resize only after the desktop Code surface has mounted. Starting at a
     // phone width intentionally routes to the mobile workshop fallback.


### PR DESCRIPTION
The Code surface Sessions tab carries `focus-ring-inset`, whose rule sets `outline-offset: calc(-1 * var(--ring-width))` — the **negated** width. The assertion currently on `main` compares that against the **outset** `--ring-offset` (`+2px`), so `outlineMatchesToken` evaluates false on every run and `E2E (Playwright)` fails on `main` at `tests/code-surface.spec.ts:309`.

This is my own bad merge resolution coming back: I resolved a conflict there by guessing the offset sign instead of reading which ring class the element renders. Fixing it at the source.

Two changes:

1. **Correct the expectation** to the inset ring (`2px` at `-2px`).
2. **Assert the computed strings directly** instead of collapsing width and offset into a single `outlineMatchesToken` boolean. That boolean reported only `false`, which hid which half diverged and cost two full CI rounds to narrow down.

The failure signature is deterministic in CI (identical on the initial run and both retries, never flaky), and the fix follows directly from the `.focus-ring-inset` rule in `src/styles/globals/foundations.css`.