### PR TITLE
fix(chat rail): retire the utilities band, quiet the New chat CTA

### DIFF
--- a/src/components/nav-section-tabs.test.ts
+++ b/src/components/nav-section-tabs.test.ts
@@ -56,6 +56,14 @@ assert.match(
   /\.sidebar-action-row\s*\{[\s\S]*?\bwidth:\s*100%;/,
   "the Home New chat action remains full width",
 );
+// Quiet primary: New chat keeps its button chrome (full width, border, own
+// surface) but no longer takes a solid accent fill on either rail. The tint
+// still derives from --accent-presence so the brand hue is present.
+assert.match(
+  homeChrome,
+  /\.sidebar-actions:not\(\.sidebar-actions--footer\) \.sidebar-action-row \{[\s\S]*?background: color-mix\(in oklch, var\(--accent-presence\) 9%, transparent\);[\s\S]*?color: var\(--text-primary\);/,
+  "the Home New chat action is a tinted quiet button, not a solid accent fill",
+);
 
 assert.match(
   chatSidebar,
@@ -72,10 +80,16 @@ assert.doesNotMatch(
   /<div className="cnav__switcher">[\s\S]*?Sidebar options[\s\S]*?<\/header>/,
   "the Chat selector row has no trailing Sidebar options button",
 );
+// The Scheduled/Plugins icon chips and the band that carried them are retired:
+// both destinations live in the Home rail's list, and dropping the band gives
+// Chat the same tabs → switcher → New chat rhythm as Home. Sidebar options
+// (the only entry point for "Show archived") moves onto the grouping-tabs row.
+assert.doesNotMatch(chatSidebar, /cnav__utilities|cnav__mini/, "the Scheduled/Plugins utilities band is retired");
+assert.doesNotMatch(chatChrome, /\.cnav__utilities|\.cnav__mini/, "the utilities band styles are retired with it");
 assert.match(
   chatSidebar,
-  /<div className="cnav__quick">[\s\S]*?New chat[\s\S]*?<div className="cnav__utilities">[\s\S]*?Scheduled[\s\S]*?Plugins[\s\S]*?Sidebar options/,
-  "Scheduled, Plugins, and Sidebar options remain below the primary action",
+  /<div className="cnav__quick">[\s\S]*?New chat[\s\S]*?<div className="cnav__tabs-row">[\s\S]*?<Tabs<ChatSidebarView>[\s\S]*?Sidebar options/,
+  "Sidebar options rides at the end of the grouping-tabs row, below the primary action",
 );
 assert.match(
   chatChrome,
@@ -86,6 +100,11 @@ assert.match(
   chatChrome,
   /\.cnav__new\s*\{[\s\S]*?\bwidth:\s*100%;/,
   "the Chat New chat action remains full width",
+);
+assert.match(
+  chatChrome,
+  /\.cnav__new\s*\{[\s\S]*?background: color-mix\(in oklch, var\(--accent-presence\) 9%, transparent\);[\s\S]*?color: var\(--text-primary\);/,
+  "the Chat New chat action is a tinted quiet button, not a solid accent fill",
 );
 assert.match(
   chatSidebar,

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -34,14 +34,14 @@ assert.match(workspaceSidebar, /function groupMeta\(group: ChatProjectGroup\): s
 assert.match(workspaceSidebar, /<ProjectAvatar name=\{label\} root=\{group\.projectRoot\} color=\{group\.projectColor\} size="sm" className="cnav__folder" \/>/, "group header avatar uses the explicit project color");
 assert.match(workspaceSidebar, /<span className="cnav__group-text">[\s\S]*?cnav__group-name[\s\S]*?<span className="cnav__group-meta">\{groupMeta\(group\)\}<\/span>/, "group header stacks name over the activity meta line");
 assert.doesNotMatch(workspaceSidebar, /cnav__count/, "the count badge is retired — the meta line carries the count");
-// One-row quick actions: New chat + the Scheduled/Plugins icon chips share a
-// single row (no stacked mini-row), and the header hosts the familiar switcher.
-assert.doesNotMatch(workspaceSidebar, /cnav__mini-row/, "the stacked mini-row is retired — quick actions are one row");
-assert.match(workspaceSidebar, /aria-label=\{scheduledCount \? `Scheduled \(\$\{scheduledCount\}\)` : "Scheduled"\}/, "Scheduled shortcut is an icon chip with an accessible name");
-assert.match(workspaceSidebar, /type WorkspaceSidebarMode = "home" \| "inbox" \| "marketplace";/, "sidebar navigation callback should accept only Home, Scheduled, and Plugins destinations");
+// Quick actions are New chat alone: the Scheduled/Plugins icon chips and the
+// band that carried them are retired (both destinations live in the Home rail's
+// list), so the only navigation shortcut left is the standalone-host Home
+// button. The header hosts the familiar switcher.
+assert.doesNotMatch(workspaceSidebar, /cnav__mini-row|cnav__mini|cnav__utilities/, "the utilities band and its icon chips are retired");
+assert.doesNotMatch(workspaceSidebar, /scheduledCount/, "the Scheduled chip's badge prop goes with it");
+assert.match(workspaceSidebar, /type WorkspaceSidebarMode = "home";/, "sidebar navigation callback should accept only the Home destination");
 assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("home"\)\}/, "Home button should navigate through the explicit sidebar callback");
-assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("inbox"\)\}/, "Scheduled button should navigate through the explicit sidebar callback");
-assert.match(workspaceSidebar, /onClick=\{\(\) => onNavigate\("marketplace"\)\}/, "Plugins button should navigate through the explicit sidebar callback");
 assert.doesNotMatch(workspaceSidebar, /cave:navigate-mode/, "workspace-sidebar should not dispatch raw mode events for its own navigation buttons");
 // The Chats primary-nav header keeps a labeled familiar switcher near thread
 // navigation (#2747, restored by cave-l3ay after #2750 briefly removed it as a
@@ -49,7 +49,6 @@ assert.doesNotMatch(workspaceSidebar, /cave:navigate-mode/, "workspace-sidebar s
 assert.match(workspaceSidebar, /<header className="cnav__header">[\s\S]*?<FamiliarSwitcher/, "the chat sidebar header hosts the familiar switcher");
 assert.doesNotMatch(workspaceSidebar, /cnav__eyebrow/, "the old Recent eyebrow stays retired");
 assert.match(workspaceSidebar, /ph:git-pull-request/, "should support PR glyph on thread rows");
-assert.match(workspaceSidebar, /scheduledCount/, "should accept scheduledCount prop");
 // Hover row-actions order: bookmark (pin) → archive → delete, so archive sits
 // to the RIGHT of the bookmark button. The archive button flips to unarchive
 // on archived rows, and the sidebar options menu exposes Show archived
@@ -95,7 +94,7 @@ assert.ok((chatSidebarBlock.match(/dismissNavMobile/g) ?? []).length >= 6, "chat
 assert.match(workspace, /onOpenSession=\{\(session\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "opening a chat session dismisses the mobile nav drawer");
 assert.match(workspace, /onOpenSessionInSplit=\{\(session\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "opening a split chat dismisses the mobile nav drawer");
 assert.match(workspace, /onNewChat=\{\(projectRoot\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "starting a new chat dismisses the mobile nav drawer");
-assert.match(workspace, /onNavigate=\{\(nextMode\) => \{[\s\S]*?setMode\(nextMode\);[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "sidebar Home, Scheduled, and Plugins routes dismiss the mobile nav drawer");
+assert.match(workspace, /onNavigate=\{\(nextMode\) => \{[\s\S]*?setMode\(nextMode\);[\s\S]*?dismissNavMobile\(\);[\s\S]*?\}\}/, "the sidebar Home route dismisses the mobile nav drawer");
 assert.match(workspace, /onOpenUrl=\{\(url\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?openUrlInApp\(url\);[\s\S]*?\}\}/, "sidebar PR links dismiss the mobile nav drawer before opening");
 assert.match(workspace, /onOpenSettings=\{\(\) => \{[\s\S]*?dismissNavMobile\(\);[\s\S]*?nextRouter\.push\("\/settings"\);[\s\S]*?\}\}/, "chat sidebar settings dismisses the mobile nav drawer");
 assert.match(workspace, /hideThreadRail/, "ChatSurface keeps its internal thread rail hidden");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -40,7 +40,7 @@ import { NavSectionTabs } from "@/components/nav-section-tabs";
 import type { NavSection } from "@/lib/nav-section";
 import type { ResolvedFamiliar } from "@/lib/familiar-resolve";
 
-type WorkspaceSidebarMode = "home" | "inbox" | "marketplace";
+type WorkspaceSidebarMode = "home";
 
 type Props = {
   sessions: SessionRow[];
@@ -57,8 +57,9 @@ type Props = {
   /** ⌥↵ / ⌥-click / drag on a thread row: open it in a split pane beside the
    *  current chat (the chat surface falls back to a plain open on mobile). */
   onOpenSessionInSplit?: (session: SessionRow) => void;
-  /** Home / Scheduled / Plugins shortcuts route through Workspace so it can
-   *  coordinate mode changes with mobile drawer dismissal. */
+  /** The Home shortcut routes through Workspace so it can coordinate the mode
+   *  change with mobile drawer dismissal. Only rendered for standalone hosts
+   *  that mount this rail without the Home | Chat section tabs. */
   onNavigate: (mode: WorkspaceSidebarMode) => void;
   /** Global section switcher (Home | Chat). This sidebar hosts the Code room,
    *  so the tabs ride at its top too — leaving Code returns to the Home rail. */
@@ -71,8 +72,6 @@ type Props = {
   /** Opens the thread's pull request in the in-app browser (PR badge click);
    *  without it the badge falls back to a new tab. Same chain as chat-list. */
   onOpenUrl?: (url: string) => void;
-  /** Badge count for the Scheduled shortcut (from code-sidebar). */
-  scheduledCount?: number;
   /** Opens Settings — powers the shared footer so Chat keeps the same
    *  Dashboard/Settings footer as every other surface. */
   onOpenSettings: () => void;
@@ -353,7 +352,6 @@ export function WorkspaceSidebar({
   onDeleteSession,
   onSessionsChanged,
   onOpenUrl,
-  scheduledCount,
   onOpenSettings,
 }: Props) {
   const { projects, createProject, createProjectOrThrow, reload } = useProjects({ familiarId: activeFamiliarId });
@@ -599,8 +597,21 @@ export function WorkspaceSidebar({
           </button>
         </div>
 
-        {/* Secondary chat utilities follow the full-width primary action. */}
-        <div className="cnav__utilities">
+        {/* Grouping tabs share their row with the overflow menu. The standalone
+            utilities band (Scheduled / Plugins icon chips) is retired — both
+            destinations live in the Home rail's list, and dropping the band
+            gives Chat the same tabs → switcher → New chat rhythm as Home. */}
+        <div className="cnav__tabs-row">
+          <Tabs<ChatSidebarView>
+            items={CHAT_SIDEBAR_TABS}
+            value={view}
+            onChange={selectView}
+            ariaLabel="Group chats"
+            className="cnav__tabs"
+            size="sm"
+            idPrefix="chat-sidebar-group"
+            fill
+          />
           {/* The Home tab above owns the exit now; the icon button only remains
               when the section switcher is not mounted (standalone hosts). */}
           {onSectionChange ? null : (
@@ -609,32 +620,11 @@ export function WorkspaceSidebar({
               aria-label="Go to Home"
               title="Home"
               onClick={() => onNavigate("home")}
-              className="cnav__back focus-ring ml-auto"
+              className="cnav__back focus-ring"
             >
               <Icon name="ph:house-bold" width={15} aria-hidden />
             </button>
           )}
-          <button
-            type="button"
-            title="Scheduled"
-            aria-label={scheduledCount ? `Scheduled (${scheduledCount})` : "Scheduled"}
-            onClick={() => onNavigate("inbox")}
-            className="cnav__mini focus-ring"
-          >
-            <Icon name="ph:clock" width={14} className="cnav__mini-icon" aria-hidden />
-            {typeof scheduledCount === "number" && scheduledCount > 0 ? (
-              <span className="cnav__mini-count">{scheduledCount}</span>
-            ) : null}
-          </button>
-          <button
-            type="button"
-            title="Plugins"
-            aria-label="Plugins"
-            onClick={() => onNavigate("marketplace")}
-            className="cnav__mini focus-ring"
-          >
-            <Icon name="ph:plugs" width={14} className="cnav__mini-icon" aria-hidden />
-          </button>
           <button
             ref={menuAnchorRef}
             type="button"
@@ -643,7 +633,7 @@ export function WorkspaceSidebar({
             aria-expanded={menuOpen}
             title="Sidebar options"
             onClick={() => setMenuOpen((cur) => !cur)}
-            className={`cnav__back focus-ring${onSectionChange ? " ml-auto" : ""}`}
+            className="cnav__back focus-ring"
           >
             <Icon name="ph:dots-three-bold" width={15} aria-hidden />
           </button>
@@ -672,17 +662,6 @@ export function WorkspaceSidebar({
             </div>
           </Popover>
         </div>
-
-        <Tabs<ChatSidebarView>
-          items={CHAT_SIDEBAR_TABS}
-          value={view}
-          onChange={selectView}
-          ariaLabel="Group chats"
-          className="cnav__tabs"
-          size="sm"
-          idPrefix="chat-sidebar-group"
-          fill
-        />
 
         <div className="cnav__search-wrap">
           <label className="cnav__search">

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -3103,7 +3103,6 @@ export function Workspace() {
         shellRef.current?.dismissNavMobile();
         openUrlInApp(url);
       }}
-      scheduledCount={scheduleNeedsCount}
       onOpenSettings={() => {
         shellRef.current?.dismissNavMobile();
         nextRouter.push("/settings");

--- a/src/styles/globals/shell-navigation.css
+++ b/src/styles/globals/shell-navigation.css
@@ -335,39 +335,36 @@
   height: 34px;
   padding: 0 var(--space-2);
   border-radius: 10px;
-  /* Filled brand accent (--accent-presence): New chat is the panel's primary
-     action, so it gets the solid treatment with its paired on-accent ink.
-     Hover shifts through --accent-presence-hover (WCAG-AA pair, cave-c7hy).
-     var(--accent) is the shadcn surface token and rendered this button's
-     chrome nearly invisible. */
-  border: 1px solid var(--accent-presence);
-  background: var(--accent-presence);
-  color: var(--accent-presence-foreground);
+  /* Quiet primary: New chat still reads as the panel's one button — full width,
+     bordered, its own surface — but it no longer shouts with a solid accent
+     fill. The tint derives from --accent-presence so the brand hue is present
+     without the label needing --accent-presence-foreground to stay legible;
+     ink is plain --text-primary, which holds in every theme. */
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 24%, var(--border-hairline));
+  background: color-mix(in oklch, var(--accent-presence) 9%, transparent);
+  color: var(--text-primary);
   font-size: var(--text-sm);
   font-weight: 560;
   text-align: left;
   transition: background var(--duration-fast) var(--ease-standard),
     border-color var(--duration-fast) var(--ease-standard);
 }
-.cnav__utilities {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: 0 var(--cnav-pad) var(--space-2);
-}
 .cnav__new:hover {
-  background: var(--accent-presence-hover);
-  border-color: var(--accent-presence-hover);
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
 }
 .cnav__new-icon {
   flex-shrink: 0;
-  color: var(--accent-presence-foreground);
+  color: var(--text-secondary);
+}
+.cnav__new:hover .cnav__new-icon {
+  color: var(--text-primary);
 }
 .cnav__new-kbd {
   flex: none;
   font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  color: color-mix(in oklch, var(--accent-presence-foreground) 62%, transparent);
+  color: var(--text-muted);
 }
 .cnav__new-label {
   flex: 1;
@@ -386,55 +383,20 @@
   border: 1px solid var(--border-hairline);
   background: color-mix(in oklch, var(--foreground) 5%, transparent);
 }
-.cnav__mini {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex: 0 0 auto;
-  height: 34px;
-  min-width: 30px;
-  padding: 0 var(--space-1);
-  border-radius: 10px;
-  border: 1px solid var(--border-hairline);
-  color: var(--text-secondary);
-  font-size: var(--text-xs);
-  transition: background var(--duration-fast) var(--ease-standard),
-    color var(--duration-fast) var(--ease-standard);
-}
-.cnav__mini:hover {
-  background: var(--bg-hover);
-  color: var(--text-primary);
-}
-.cnav__mini-icon {
-  flex-shrink: 0;
-  color: var(--text-muted);
-}
-/* Count rides the chip's corner (overlay, not inline) so the icon chips stay
-   narrow enough for the one-row layout at the sidebar's minimum width. */
-.cnav__mini-count {
-  position: absolute;
-  top: -5px;
-  right: -5px;
-  min-width: 15px;
-  height: 15px;
-  padding: 0 3px;
-  display: grid;
-  place-items: center;
-  border-radius: var(--radius-pill);
-  border: 1px solid var(--bg-raised);
-  background: color-mix(in oklch, var(--foreground) 12%, var(--bg-raised));
-  font-size: var(--text-2xs);
-  font-weight: 650;
-  color: var(--text-secondary);
-  font-variant-numeric: tabular-nums;
-}
-
 /* Grouping is a first-class choice, not a setting hidden in the overflow menu.
    The two visible tabs mirror the reference rail while retaining the existing
-   persisted Recent/Projects preference. */
-.cnav__tabs {
+   persisted Recent/Projects preference. The overflow menu rides at the end of
+   the same row — the separate utilities band it used to share with the
+   Scheduled/Plugins chips is retired. */
+.cnav__tabs-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
   margin: 0 var(--cnav-pad) var(--space-2);
+}
+.cnav__tabs {
+  flex: 1 1 auto;
+  min-width: 0;
 }
 
 /* Search */

--- a/src/styles/sidebar-minimal/shell-chrome.css
+++ b/src/styles/sidebar-minimal/shell-chrome.css
@@ -160,22 +160,24 @@
   color: var(--text-primary);
 }
 
-/* "New chat" is the top CTA — a filled accent button: solid --accent-presence
-   with its paired on-accent ink (--accent-presence-foreground, not
-   --text-primary — monochrome palettes vanish the label otherwise), so the
-   panel's one primary action stands out. Hover shifts through
-   --accent-presence-hover, the direction-aware WCAG-AA pair (cave-c7hy). */
+/* "New chat" is the top CTA — a quiet button rather than a solid accent fill:
+   full width, bordered, on its own tinted surface, so it still reads as the
+   panel's one primary action without shouting. The tint derives from
+   --accent-presence to keep the brand hue present; ink stays --text-primary,
+   which holds on a near-transparent surface in every palette (the old solid
+   fill needed --accent-presence-foreground for exactly that reason). Matches
+   .cnav__new on the Chat rail. */
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row {
-  background: var(--accent-presence);
-  color: var(--accent-presence-foreground);
-  border: 2px solid var(--accent-presence);
-  font-weight: 600;
+  background: color-mix(in oklch, var(--accent-presence) 9%, transparent);
+  color: var(--text-primary);
+  border: 1px solid color-mix(in oklch, var(--accent-presence) 24%, var(--border-hairline));
+  font-weight: 560;
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row:hover {
-  background: var(--accent-presence-hover);
-  color: var(--accent-presence-foreground);
-  border-color: var(--accent-presence-hover);
+  background: color-mix(in oklch, var(--accent-presence) 16%, transparent);
+  color: var(--text-primary);
+  border-color: color-mix(in oklch, var(--accent-presence) 40%, var(--border-hairline));
 }
 
 .sidebar-actions:not(.sidebar-actions--footer) .sidebar-action-row .sidebar-action-icon {


### PR DESCRIPTION
## What

The Chat sidebar carried a band under the full-width **New chat** action holding **Scheduled** (clock + count badge) and **Plugins** (plugs) icon chips alongside the overflow menu. Both destinations already live in the Home rail's destination list, so the band was duplicate navigation and an extra horizontal rhythm the Home rail does not have.

- Drops the band and both chips — and with them the `scheduledCount` prop and the `inbox` / `marketplace` members of `WorkspaceSidebarMode`.
- **Sidebar options survives the removal**: it is the only entry point for *Show archived*, so it moves onto the Recent/Projects grouping-tabs row. Not into the header — #4381's alignment work deliberately cleared that spot, and `nav-section-tabs.test.ts` pins it empty.
- **New chat becomes a quiet button**: same full width, border, radius and ⌘N hint, but the solid `--accent-presence` fill gives way to a 9% accent tint over transparent, a hairline-plus-accent border and `--text-primary` ink (hover to 16%). Applied to the Home rail's action row too, so the two rails stay aligned rather than re-splitting one commit after they were matched.

## Verification

- `pnpm lint` — design codemod check + eslint, clean.
- `pnpm exec tsc --noEmit` — clean.
- The pinning source-text tests updated in this PR pass, plus `sidebar-minimal`, `sidepanel-badges`, `chat-rail-modern-redesign`.
- Playwright over a live server, dark and light: the band is absent, `.cnav__new` measures 204px inside its 224px padded parent, and the button still reads as a button in both themes.

Bead: `cave-hnjwv`