### PR TITLE
fix(ci): raise the sidecar file-count budget past the conjure-flow step

### DIFF
--- a/scripts/sidecar-runtime-closure.mjs
+++ b/scripts/sidecar-runtime-closure.mjs
@@ -204,7 +204,23 @@ export const SIDECAR_RUNTIME_BUDGETS = Object.freeze({
   // attributing it. Ten files is about ten merges at this rate, so this will
   // recur; the durable fix is to size the headroom to the growth rate or stop the
   // closure growing, not to keep adding ten.
-  fileCount: 5_926,
+  // 2026-08-05 (conjure flow, cave-2nsm3): the entry above predicted "roughly a
+  // file per merge, diffuse across many PRs" — and one merge broke that model.
+  // feat/cave-3rz-conjure-flow (3f2630d6d1) landed the scry/rite/foil surface in
+  // a single push: src/lib/scry*.ts, src/lib/foil/*, src/lib/rite-flow.ts,
+  // src/lib/cave-familiar-foil.ts, src/lib/use-scry.ts and their components all
+  // join the closure at once. CI measured 5,957 on Ubuntu and 5,959 on Windows —
+  // 33 over a budget that had 10 files of headroom, so this was never going to be
+  // absorbed. Set from the HIGHER figure plus the usual ten, per the convention
+  // above; Windows still governs, though at +2 here rather than the +3 the entry
+  // above recorded.
+  //
+  // Both legs were red, unlike #4315 where only Windows crossed — that is the
+  // signature of a step change rather than headroom running out, and it is worth
+  // reading the measured counts before assuming otherwise. Note this budget was
+  // NOT what made main red: it went red on a direct push whose own CI run was
+  // cancelled by push churn, so nothing reported the step until a PR ran.
+  fileCount: 5_969,
   unpackedBytes: 200 * 1024 * 1024 - 1,
 });
 


### PR DESCRIPTION
Both **Sidecar runtime** legs are red on `main`, and on every PR that inherits it:

```
Error: sidecar runtime fileCount 5957 exceeds target 5926   (ubuntu-latest)
Error: sidecar runtime fileCount 5959 exceeds target 5926   (windows-latest)
```

`feat/cave-3rz-conjure-flow` (`3f2630d6d1`) landed the scry / rite / foil surface in a single push — `src/lib/scry*.ts`, `src/lib/foil/*`, `src/lib/rite-flow.ts`, `src/lib/cave-familiar-foil.ts`, `src/lib/use-scry.ts` and their components all join the closure at once. That is **33 files over a budget carrying 10 files of headroom**, so it was never going to be absorbed.

Set from the higher measured figure plus the same ten-file cross-platform headroom every entry in that comment block uses: **5,959 + 10 = 5,969**. Windows still governs, at +2 over Ubuntu here rather than the +3 previously recorded.

## Why the comment grew

The budget note written at `cave-k5n56` predicted growth of "roughly a file per merge, diffuse across many PRs", and told the next reader to treat a red here as headroom running out rather than as the last merge misbehaving. This merge is the counter-example, so the new entry records it: **both** legs went red at once, where #4315 crossed only on Windows — that asymmetry is the tell for a step change versus a slow squeeze, and it is cheap to check the measured counts before attributing blame.

## Scope

This is the sidecar half of `main`'s red. The `pnpm test:api` and E2E failures are repaired separately in #4388; both PRs are needed before `main` is green. Neither failure is a product regression — this one is a ratchet that a large feature stepped over, and the step went unreported because the direct push that carried it had its own CI run cancelled by push churn.

Bead: `cave-2nsm3`