### PR TITLE
feat: dedicated dev/prod ports, one wss decision point, and a familiar that revives

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift
@@ -36,11 +36,16 @@ struct CaveConnection: Codable, Equatable {
             return URL(string: "https://\(trimmed)")
         }
 
-        // Bare host or IP → HTTP on the dev server port unless a port is present.
+        // Bare host or IP → HTTP on Cave's dedicated PRODUCTION port unless a
+        // port is present. A phone pairs with the packaged desktop app, which
+        // now always binds that port (src-tauri/src/sidecar_ports.rs); it used
+        // to take a random one per launch, so this default was only ever right
+        // for someone running `pnpm dev` on their Mac. The dev port stays in the
+        // alternates below so that case still connects.
         if trimmed.contains(":") {
             return URL(string: "http://\(trimmed)")
         }
-        return URL(string: "http://\(trimmed):3000")
+        return URL(string: "http://\(trimmed):\(CavePorts.production)")
     }
 
     /// WebSocket base derived from `baseURL` (https→wss, http→ws). Used by the
@@ -82,8 +87,11 @@ struct CaveConnection: Codable, Equatable {
             add("https://\(hostname):8443")   // Tailscale Serve's usual TLS port
             add("https://\(hostname)")        // bare 443
         } else {
-            // The desktop falls back through 3000-3010 when ports are taken
-            // (scripts/dev-app.sh / server.ts PORT), so probe the whole range.
+            // The dedicated ports come first: production is what a packaged
+            // desktop binds, dev is what `pnpm dev` binds. The 3000-3010 sweep
+            // stays behind them because the macOS background-availability
+            // daemon can still fall back into that range when the dedicated
+            // port is occupied (src-tauri/src/desktop_reachability.rs).
             //
             // These extra candidates are NOT free: the paired path probes
             // sequentially on purpose (see AppModel.discoverBaseURL — fanning
@@ -92,6 +100,8 @@ struct CaveConnection: Codable, Equatable {
             // when packets are silently dropped. `lastGoodBaseURL` is what keeps
             // the common case at a single probe; do not add candidates on the
             // assumption that they cost nothing (cave-ioswipe.3).
+            add("http://\(hostname):\(CavePorts.production)")
+            add("http://\(hostname):\(CavePorts.dev)")
             for port in 3000...3010 { add("http://\(hostname):\(port)") }
             for port in ["4500", "4555", "8443"] { add("http://\(hostname):\(port)") }
             add("https://\(hostname):8443")

--- a/apps/ios/CovenCave/CovenCave/Networking/CavePorts.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CavePorts.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// The iOS copy of Cave's port contract.
+///
+/// Swift cannot import `scripts/ports.mjs`, so these numbers are duplicated on
+/// purpose — the same two-place convention the Rust side uses in
+/// `src-tauri/src/sidecar_ports.rs`. `scripts/port-contract.test.mjs` reads this
+/// file and fails if any copy drifts, which matters more here than elsewhere:
+/// iOS is not compiled by CI (see reference notes on apps/ios), so a wrong
+/// number would otherwise reach a device before anything noticed.
+///
+/// Why it exists at all: the packaged desktop used to bind a random loopback
+/// port on every launch, so a phone could not store a host and expect it to
+/// resolve twice.
+enum CavePorts {
+    /// A packaged desktop app. This is what a paired phone should expect.
+    static let production = 3020
+
+    /// A `pnpm dev` server — the case where someone is running Cave from source
+    /// on the Mac their phone is paired with.
+    static let dev = 3000
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolvePort } from "./scripts/ports.mjs";
 
 // Playwright config — three viewport projects so the same specs in
 // tests/mobile/ run against desktop AND two real mobile presets.
@@ -12,14 +13,15 @@ import { join } from "node:path";
 // real device.
 //
 // The dev server: started via `webServer` so `pnpm test:e2e:mobile`
-// can run without a separate terminal. PORT is fixed to 3100 so the
-// e2e runs don't collide with `pnpm dev` on the default 3000.
+// can run without a separate terminal. The port is fixed at the e2e
+// entry of the shared contract (scripts/ports.mjs) so e2e runs collide
+// neither with `pnpm dev` on 3000 nor with a packaged build on 3020.
 //
 // COVEN_CAVE_E2E=1 is set in the env so the daemon path can short-
 // circuit to a deterministic test stub (today: no-op; tests that
 // need a daemon should mock /api/*).
 
-const PORT = Number(process.env.PORT ?? 3100);
+const PORT = resolvePort("e2e", process.env);
 const BASE_URL = `http://127.0.0.1:${PORT}`;
 const E2E_RUN_ID = randomUUID();
 const E2E_PROJECTS_PATH = join(tmpdir(), `cave-e2e-projects-${E2E_RUN_ID}.json`);

--- a/scripts/dev-app-teardown.test.mjs
+++ b/scripts/dev-app-teardown.test.mjs
@@ -71,6 +71,8 @@ mkdirSync(fakeBin, { recursive: true });
 
 copyFileSync(path.join(scriptsDir, "dev-app.sh"), path.join(fakeScripts, "dev-app.sh"));
 copyFileSync(path.join(scriptsDir, "dev-app-origin-health.mjs"), path.join(fakeScripts, "dev-app-origin-health.mjs"));
+copyFileSync(path.join(scriptsDir, "dev-port-owner.mjs"), path.join(fakeScripts, "dev-port-owner.mjs"));
+copyFileSync(path.join(scriptsDir, "ports.mjs"), path.join(fakeScripts, "ports.mjs"));
 chmodSync(path.join(fakeScripts, "dev-app.sh"), 0o755);
 writeFileSync(path.join(fakeScripts, "whisper-runtime-dev-env.sh"), "# stub for tests\n");
 

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 # scripts/dev-app.sh — launch CovenCave in Tauri dev mode.
 #
-# Auto-detects or starts a dev server, discovering its actual port (which may
-# be >3000 if lower ports are in use), then configures Tauri's devUrl to match.
-# Respects explicit PORT= override.
+# Starts (or attaches to) the dev server on Cave's DEDICATED dev port, then
+# configures Tauri's devUrl to match.
+#
+# This used to scan 3000..3010 for whatever was free, which meant the address
+# depended on what else happened to be running. Now the port is fixed by
+# scripts/ports.mjs and a busy port is resolved by identity, not by moving:
+#
+#   busy, and it answers as Cave  -> attach to it (the common case: you already
+#                                    have `pnpm dev` running in another terminal)
+#   busy, and it is a stranger    -> refuse, and say what to do about it
 #
 # Usage:
-#   pnpm dev:app             # auto-detect, start on default or next free port
-#   PORT=3001 pnpm dev:app   # force specific port
-#   pnpm dev:app -- --release    # forwarded flags to Tauri
+#   pnpm dev:app                    # attach to, or start, the dev port
+#   COVEN_CAVE_PORT=3007 pnpm dev:app   # override the port
+#   PORT=3007 pnpm dev:app          # same, honoured second
+#   pnpm dev:app -- --release       # forwarded flags to Tauri
 
 set -euo pipefail
 cd "$(dirname "$0")/.."
@@ -28,37 +36,41 @@ origin_is_ready() {
   node scripts/dev-app-origin-health.mjs --port "$1" --timeout-ms "${2:-1500}" >/dev/null 2>&1
 }
 
-# If PORT is explicitly set, use that; otherwise auto-discover
-if [ -n "${PORT:-}" ]; then
-  dev_port="$PORT"
-  echo "[dev:app] using explicit PORT=${dev_port}"
+# The dedicated dev port, honouring COVEN_CAVE_PORT then PORT.
+dev_port="$(node -e "import('./scripts/ports.mjs').then((m) => console.log(m.resolvePort('dev', process.env)))")"
+if [ -n "${COVEN_CAVE_PORT:-}" ] || [ -n "${PORT:-}" ]; then
+  echo "[dev:app] using overridden port ${dev_port}"
 else
-  # Find a free port in the default range
-  dev_port=""
-  for candidate in $(seq 3000 3010); do
-    if ! port_is_listening "$candidate" >/dev/null 2>&1; then
-      dev_port="$candidate"
-      break
-    fi
-  done
+  echo "[dev:app] dedicated dev port ${dev_port}"
+fi
 
-  if [ -z "$dev_port" ]; then
-    echo "[dev:app] ERROR: no free port found in 3000-3010" >&2
+# Busy is resolved by identity, never by relocating — a port that moves is what
+# this contract exists to stop. See scripts/dev-port-owner.mjs.
+port_owner="$(node scripts/dev-port-owner.mjs --port "$dev_port" 2>/dev/null || echo free)"
+case "$port_owner" in
+  ours)
+    echo "[dev:app] attaching to the CovenCave dev server already on 127.0.0.1:${dev_port}"
+    should_start_server=false
+    ;;
+  gated)
+    echo "[dev:app] ERROR: 127.0.0.1:${dev_port} is serving with an access token configured," >&2
+    echo "[dev:app]        so it cannot be identified as CovenCave from here." >&2
+    echo "[dev:app]        Stop it, or pick another port: COVEN_CAVE_PORT=3007 pnpm dev:app" >&2
     exit 1
-  fi
-
-  echo "[dev:app] port ${dev_port} is free"
-fi
-
-# Check if a dev server is already running on that port
-if port_is_listening "$dev_port" >/dev/null 2>&1; then
-  echo "[dev:app] dev server already listening on 127.0.0.1:${dev_port}"
-  # Configure Tauri to use it (skip beforeDevCommand)
-  should_start_server=false
-else
-  echo "[dev:app] starting dev server on ${dev_port}"
-  should_start_server=true
-fi
+    ;;
+  stranger)
+    echo "[dev:app] ERROR: port ${dev_port} is held by something that is not CovenCave." >&2
+    if command -v lsof >/dev/null 2>&1; then
+      echo "[dev:app]        holder: $(lsof -nP -iTCP:"$dev_port" -sTCP:LISTEN 2>/dev/null | awk 'NR==2 {print $1" (pid "$2")"}')" >&2
+    fi
+    echo "[dev:app]        Free it, or pick another port: COVEN_CAVE_PORT=3007 pnpm dev:app" >&2
+    exit 1
+    ;;
+  *)
+    echo "[dev:app] starting dev server on ${dev_port}"
+    should_start_server=true
+    ;;
+esac
 
 TAURI_OVERRIDE_CONFIG="$(mktemp)"
 WATCHDOG_VERDICT="$(mktemp)"

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -12,10 +12,30 @@ assert.match(
   /source scripts\/whisper-runtime-dev-env\.sh/,
   "the development launcher must stage and export Whisper before starting Tauri",
 );
+// The launcher takes the DEDICATED dev port from the shared contract rather
+// than scanning 3000-3010 for whatever is free. Scanning is what made the
+// address depend on whatever else happened to be running; see scripts/ports.mjs.
 assert.match(
   source,
-  /if \[ -n "\$\{PORT:-\}" \]; then[\s\S]*?dev_port="\$PORT"[\s\S]*?for candidate in \$\(seq 3000 3010\)/,
-  "explicit PORT and automatic 3000-3010 discovery must remain part of the launcher contract",
+  /resolvePort\('dev', process\.env\)/,
+  "the launcher must resolve its port from the shared contract",
+);
+assert.doesNotMatch(
+  source,
+  /for candidate in \$\(seq 3000 3010\)/,
+  "the free-port scan is retired — a dedicated port that relocates is not dedicated",
+);
+// Busy is answered by identity, not by moving: attach to our own dev server,
+// refuse anything else by name.
+assert.match(
+  source,
+  /port_owner="\$\(node scripts\/dev-port-owner\.mjs --port "\$dev_port"[\s\S]*?ours\)[\s\S]*?should_start_server=false/,
+  "a dedicated port already served by CovenCave must be attached to, not restarted",
+);
+assert.match(
+  source,
+  /stranger\)[\s\S]*?is held by something that is not CovenCave[\s\S]*?exit 1/,
+  "a stranger on the dedicated port must fail loudly instead of relocating",
 );
 assert.match(
   source,

--- a/scripts/dev-port-owner.mjs
+++ b/scripts/dev-port-owner.mjs
@@ -1,3 +1,6 @@
+import { realpathSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
 /**
  * Who owns the dedicated dev port?
  *
@@ -70,10 +73,17 @@ export async function classifyPortOwner({
   }
 }
 
-const invokedDirectly =
-  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
 
-if (invokedDirectly) {
+if (isDirectRun()) {
   const args = parseArgs(process.argv.slice(2));
   const port = Number(args.get("port"));
   if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {

--- a/scripts/dev-port-owner.mjs
+++ b/scripts/dev-port-owner.mjs
@@ -1,0 +1,90 @@
+/**
+ * Who owns the dedicated dev port?
+ *
+ * The launcher used to scan 3000..3010 and take whatever was free, so "the port
+ * is busy" was never a question it had to answer — it just moved. With a fixed
+ * port (scripts/ports.mjs) moving is exactly the behaviour being retired, so the
+ * conflict has to be resolved by identity instead:
+ *
+ *   free      nothing is listening                       -> start a dev server
+ *   ours      it answers as CovenCave                    -> attach, don't start
+ *   stranger  something else is holding the port         -> refuse, by name
+ *
+ * Identity comes from /api/app/build-info, which is deliberately value-free
+ * ("public, value-free artifact identity" — src/app/api/app/build-info/route.ts).
+ *
+ * Caveat worth knowing: that route is behind the global gate in src/proxy.ts, so
+ * a dev server started WITH a sidecar token (`pnpm mobile:tailscale:app`) answers
+ * 401 rather than 200. A probe cannot then tell it apart from a stranger, so it
+ * is reported as `gated` and the launcher refuses rather than guessing. Plain
+ * `pnpm dev` sets no token, which is the case where attach actually matters.
+ *
+ * Usage: node scripts/dev-port-owner.mjs --port 3000 [--timeout-ms 1500]
+ * Prints one of: free | ours | gated | stranger
+ */
+
+const DEFAULT_TIMEOUT_MS = 1_500;
+
+export function parseArgs(argv) {
+  const args = new Map();
+  for (let i = 0; i < argv.length; i += 1) {
+    const flag = argv[i];
+    if (!flag.startsWith("--")) continue;
+    args.set(flag.slice(2), argv[i + 1]);
+  }
+  return args;
+}
+
+/**
+ * @returns {Promise<"free" | "ours" | "gated" | "stranger">}
+ */
+export async function classifyPortOwner({
+  port,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  fetchImpl = fetch,
+} = {}) {
+  let response;
+  try {
+    response = await fetchImpl(`http://127.0.0.1:${port}/api/app/build-info`, {
+      method: "GET",
+      signal: AbortSignal.timeout(timeoutMs),
+      headers: { accept: "application/json" },
+    });
+  } catch {
+    // Connection refused is the ordinary "nothing is here" case. A timeout also
+    // lands here: something is accepting connections without answering, which is
+    // not a Cave we can attach to — treat it as free so the caller's own bind
+    // attempt produces the real, specific error.
+    return "free";
+  }
+
+  if (response.status === 401 || response.status === 403) return "gated";
+  if (!response.ok) return "stranger";
+
+  try {
+    const payload = await response.json();
+    return payload && payload.name === "CovenCave" ? "ours" : "stranger";
+  } catch {
+    // A 200 that is not our JSON is somebody else's server.
+    return "stranger";
+  }
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (invokedDirectly) {
+  const args = parseArgs(process.argv.slice(2));
+  const port = Number(args.get("port"));
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    console.error("dev-port-owner: --port must be a valid TCP port");
+    process.exit(2);
+  }
+  const timeoutRaw = args.get("timeout-ms");
+  const timeoutMs = timeoutRaw === undefined ? DEFAULT_TIMEOUT_MS : Number(timeoutRaw);
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 100) {
+    console.error("dev-port-owner: --timeout-ms must be at least 100");
+    process.exit(2);
+  }
+  console.log(await classifyPortOwner({ port, timeoutMs }));
+}

--- a/scripts/dev-port-owner.test.mjs
+++ b/scripts/dev-port-owner.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { classifyPortOwner, parseArgs } from "./dev-port-owner.mjs";
+
+// The dedicated port turns "something is already listening" from a non-question
+// into a decision. The launcher used to move to the next free port, so it never
+// had to know WHO held one; now it must, because attaching to our own dev server
+// and refusing a stranger are opposite actions.
+
+const jsonResponse = (status, body) => ({
+  status,
+  ok: status >= 200 && status < 300,
+  json: async () => body,
+});
+
+// Nothing listening: the ordinary case. Also covers a timeout — a socket that
+// accepts without answering is not something to attach to, and reporting it free
+// lets the caller's own bind produce the real, specific error.
+assert.equal(
+  await classifyPortOwner({
+    port: 3000,
+    fetchImpl: async () => {
+      throw new Error("ECONNREFUSED");
+    },
+  }),
+  "free",
+  "a refused connection means the port is available",
+);
+
+assert.equal(
+  await classifyPortOwner({
+    port: 3000,
+    fetchImpl: async () => jsonResponse(200, { name: "CovenCave", version: "0.2.4" }),
+  }),
+  "ours",
+  "our own build-info identifies the dev server we should attach to",
+);
+
+assert.equal(
+  await classifyPortOwner({
+    port: 3000,
+    fetchImpl: async () => jsonResponse(200, { name: "some-other-app" }),
+  }),
+  "stranger",
+  "a 200 from a different app is not ours",
+);
+
+assert.equal(
+  await classifyPortOwner({
+    port: 3000,
+    fetchImpl: async () => ({
+      status: 200,
+      ok: true,
+      json: async () => {
+        throw new SyntaxError("not json");
+      },
+    }),
+  }),
+  "stranger",
+  "a 200 that is not our JSON is somebody else's server",
+);
+
+// A dev server started WITH a sidecar token (pnpm mobile:tailscale:app) answers
+// 401 through src/proxy.ts. That is indistinguishable from a stranger's 401, so
+// it is reported separately and the launcher refuses rather than guessing —
+// attaching to a server we cannot identify is how a wrong port gets trusted.
+for (const status of [401, 403]) {
+  assert.equal(
+    await classifyPortOwner({ port: 3000, fetchImpl: async () => jsonResponse(status, {}) }),
+    "gated",
+    `an access-gated ${status} cannot be identified either way`,
+  );
+}
+
+assert.equal(
+  await classifyPortOwner({ port: 3000, fetchImpl: async () => jsonResponse(500, {}) }),
+  "stranger",
+  "a server erroring on our identity route is not one to attach to",
+);
+
+// --- arg parsing -------------------------------------------------------------
+const args = parseArgs(["--port", "3020", "--timeout-ms", "500"]);
+assert.equal(args.get("port"), "3020");
+assert.equal(args.get("timeout-ms"), "500");
+
+console.log("dev-port-owner.test.mjs: ok");

--- a/scripts/dev-port-owner.test.mjs
+++ b/scripts/dev-port-owner.test.mjs
@@ -1,4 +1,8 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { copyFileSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { classifyPortOwner, parseArgs } from "./dev-port-owner.mjs";
 
 // The dedicated port turns "something is already listening" from a non-question
@@ -81,5 +85,21 @@ assert.equal(
 const args = parseArgs(["--port", "3020", "--timeout-ms", "500"]);
 assert.equal(args.get("port"), "3020");
 assert.equal(args.get("timeout-ms"), "500");
+
+{
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "coven cave dev-port-owner-"));
+  try {
+    const fixtureScript = path.join(fixtureDir, "dev-port-owner.mjs");
+    copyFileSync(new URL("./dev-port-owner.mjs", import.meta.url), fixtureScript);
+    const result = spawnSync(process.execPath, [fixtureScript, "--port", "0"], {
+      encoding: "utf8",
+    });
+    assert.equal(result.status, 2, "direct invocation still runs when the script path contains spaces");
+    assert.match(result.stderr, /--port must be a valid TCP port/);
+    assert.equal(result.stdout, "");
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+}
 
 console.log("dev-port-owner.test.mjs: ok");

--- a/scripts/ios-port-discovery.test.mjs
+++ b/scripts/ios-port-discovery.test.mjs
@@ -1,13 +1,20 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-// Bare-host port discovery (bead cave-y482 part 3): the desktop dev wrapper
-// walks ports 3000-3010 when earlier ones are taken (scripts/dev-app.sh), so
-// a phone that paired against :3000 must rediscover the desktop when it comes
-// back on :3001+. Discovery probes candidates concurrently, so the widened
-// range costs no wall-clock time — but every port in the wrapper's range must
-// actually be a candidate, in ascending order, without disturbing the legacy
-// alternates or the ordered .ok adjudication that relocation depends on.
+// Bare-host port discovery (bead cave-y482 part 3, extended by cave-l3vsw).
+//
+// Originally: the dev wrapper walked 3000-3010, so a phone that paired against
+// :3000 had to rediscover a desktop that came back on :3001+. Cave now has
+// DEDICATED ports (scripts/ports.mjs) and the wrapper no longer scans, so the
+// dedicated pair must lead the candidate list — that is the address a paired
+// phone should find first, and finding it first is the whole point of fixing it.
+//
+// The 3000-3010 sweep is kept behind them rather than deleted: the macOS
+// background-availability daemon still falls back into that range when the
+// dedicated port is occupied (src-tauri/src/desktop_reachability.rs), and a
+// phone paired before this change may still be pointed at one of them.
+// Discovery probes candidates concurrently, so the extra entries cost no
+// wall-clock time — but order still decides adjudication.
 
 const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
 const connection = await read("apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift");
@@ -31,11 +38,27 @@ assert.match(
   "the 3000-3010 range must come first so lower dev ports win adjudication",
 );
 
-// --- The Swift range and the wrapper's range must not drift ------------------
-const seq = devScript.match(/seq (\d+) (\d+)/);
-assert.ok(seq, "dev-app.sh should scan a port range via seq");
-assert.equal(seq[1], "3000", "wrapper range start pinned to the Swift candidates");
-assert.equal(seq[2], "3010", "wrapper range end pinned to the Swift candidates");
+// --- The dedicated ports lead, and the wrapper no longer scans ---------------
+assert.match(
+  connection,
+  /add\("http:\/\/\\\(hostname\):\\\(CavePorts\.production\)"\)[\s\S]*?add\("http:\/\/\\\(hostname\):\\\(CavePorts\.dev\)"\)[\s\S]*?for port in 3000\.\.\.3010/,
+  "the dedicated production and dev ports must be probed before the legacy sweep",
+);
+assert.doesNotMatch(
+  devScript,
+  /seq 3000 3010/,
+  "the dev wrapper no longer scans for a free port — it resolves the dedicated one",
+);
+assert.match(
+  devScript,
+  /resolvePort\('dev', process\.env\)/,
+  "the dev wrapper takes its port from the shared contract (scripts/ports.mjs)",
+);
+assert.match(
+  devScript,
+  /dev-port-owner\.mjs/,
+  "a busy dedicated port is resolved by identity — attach if it is ours, refuse if not",
+);
 
 // --- Discovery semantics the widened range relies on -------------------------
 assert.match(

--- a/scripts/port-contract.test.mjs
+++ b/scripts/port-contract.test.mjs
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { CAVE_PORTS, CAVE_PORT_ENV, parsePort, resolvePort } from "./ports.mjs";
+
+// One port per channel, and every copy of those numbers agrees.
+//
+// scripts/ports.mjs is the source of truth, but three consumers cannot import
+// it: Rust (src-tauri), Swift (apps/ios), and server.ts — the last because
+// `build:server` runs esbuild with `--bundle=false`, so an import there has to
+// resolve at runtime from wherever server.mjs is unpacked, and the packaged
+// bundle ships server.mjs without scripts/. Each of those carries a copy, and
+// this test fails if any of them drifts. Same two-place convention
+// scripts/sidecar-bundle-deps.test.mjs uses for the sidecar file-count budget:
+// a change stays a deliberate edit in reviewed places rather than a silent slide.
+//
+// It matters most for Swift, which CI does not compile at all — a wrong number
+// there would otherwise reach a device with nothing having noticed.
+
+const read = (p) => readFile(new URL(`../${p}`, import.meta.url), "utf8");
+
+// --- The contract itself -----------------------------------------------------
+assert.equal(CAVE_PORTS.dev, 3000, "dev keeps the entrenched port");
+assert.equal(CAVE_PORTS.production, 3020, "production has its own dedicated port");
+assert.equal(CAVE_PORTS.e2e, 3100, "e2e keeps the port playwright.config.ts already used");
+
+const distinct = new Set(Object.values(CAVE_PORTS));
+assert.equal(
+  distinct.size,
+  Object.keys(CAVE_PORTS).length,
+  "channels must not share a port — a packaged build, a dev server and an e2e run all coexist",
+);
+
+// --- Resolution order --------------------------------------------------------
+assert.equal(resolvePort("production", {}), 3020, "channel default when nothing overrides");
+assert.equal(
+  resolvePort("production", { [CAVE_PORT_ENV]: "4000", PORT: "5000" }),
+  4000,
+  "COVEN_CAVE_PORT wins over PORT, so pinning Cave never depends on an inherited PORT",
+);
+assert.equal(resolvePort("dev", { PORT: "5000" }), 5000, "PORT is honoured when Cave's own is unset");
+assert.equal(
+  resolvePort("dev", { [CAVE_PORT_ENV]: "not-a-port" }),
+  3000,
+  "a malformed override falls back rather than refusing to start",
+);
+assert.throws(() => resolvePort("nope", {}), /unknown Cave channel/, "channels are closed");
+
+// Port 0 is refused deliberately: "bind anything" is the behaviour the dedicated
+// port exists to retire, and it is exactly what find_free_port() used to do.
+assert.equal(parsePort("0"), null, "port 0 is not a usable dedicated port");
+assert.equal(parsePort("70000"), null, "outside the TCP range");
+assert.equal(parsePort(" 3020 "), 3020, "surrounding whitespace is tolerated");
+
+// --- Rust copy ---------------------------------------------------------------
+const rust = await read("src-tauri/src/sidecar_ports.rs");
+assert.match(
+  rust,
+  new RegExp(`CAVE_PRODUCTION_PORT: u16 = ${CAVE_PORTS.production};`),
+  "the Rust production port must match scripts/ports.mjs",
+);
+assert.match(
+  rust,
+  new RegExp(`CAVE_DEV_PORT: u16 = ${CAVE_PORTS.dev};`),
+  "the Rust dev port must match scripts/ports.mjs",
+);
+assert.match(
+  rust,
+  new RegExp(`CAVE_PORT_ENV: &str = "${CAVE_PORT_ENV}";`),
+  "the override env var name must match",
+);
+
+// The packaged app must not go back to asking the kernel for any free port.
+const startup = await read("src-tauri/src/sidecar_startup.rs");
+assert.doesNotMatch(
+  startup,
+  /TcpListener::bind\("127\.0\.0\.1:0"\)/,
+  "the sidecar must bind its dedicated port, never an ephemeral one",
+);
+assert.match(
+  startup,
+  /sidecar_ports::dedicated_port\(\)/,
+  "the sidecar takes its port from the contract",
+);
+assert.match(
+  startup,
+  /port_is_occupied\(port\)/,
+  "an occupied dedicated port is reported, not silently relocated",
+);
+
+// --- server.ts copy ----------------------------------------------------------
+const server = await read("server.ts");
+assert.match(
+  server,
+  new RegExp(`const CAVE_DEV_PORT = ${CAVE_PORTS.dev};`),
+  "server.ts dev port must match scripts/ports.mjs",
+);
+assert.match(
+  server,
+  new RegExp(`const CAVE_PRODUCTION_PORT = ${CAVE_PORTS.production};`),
+  "server.ts production port must match scripts/ports.mjs",
+);
+assert.doesNotMatch(
+  server,
+  /process\.env\.PORT \?\? "3000"/,
+  "server.ts resolves through cavePort(), not an inline default",
+);
+
+// --- Swift copy (never compiled by CI) ---------------------------------------
+const swiftPorts = await read("apps/ios/CovenCave/CovenCave/Networking/CavePorts.swift");
+assert.match(
+  swiftPorts,
+  new RegExp(`static let production = ${CAVE_PORTS.production}`),
+  "the iOS production port must match scripts/ports.mjs",
+);
+assert.match(
+  swiftPorts,
+  new RegExp(`static let dev = ${CAVE_PORTS.dev}`),
+  "the iOS dev port must match scripts/ports.mjs",
+);
+
+const connection = await read("apps/ios/CovenCave/CovenCave/Networking/CaveConnection.swift");
+assert.match(
+  connection,
+  /http:\/\/\\\(trimmed\):\\\(CavePorts\.production\)/,
+  "a bare host defaults to the packaged desktop's dedicated port",
+);
+assert.doesNotMatch(
+  connection,
+  /http:\/\/\\\(trimmed\):3000/,
+  "the hardcoded :3000 default is retired",
+);
+
+// --- playwright ---------------------------------------------------------------
+const playwright = await read("playwright.config.ts");
+assert.match(
+  playwright,
+  /resolvePort\("e2e", process\.env\)/,
+  "e2e takes its port from the contract instead of its own literal",
+);
+
+console.log("port-contract.test.mjs: ok");

--- a/scripts/ports.mjs
+++ b/scripts/ports.mjs
@@ -1,0 +1,79 @@
+// The one place that decides which port Cave listens on.
+//
+// Before this file, nothing agreed: `scripts/dev-app.sh` scanned 3000–3010 for
+// whatever happened to be free, the packaged desktop app bound a RANDOM port
+// every launch (`find_free_port()` in src-tauri/src/sidecar_startup.rs binds
+// 127.0.0.1:0), and playwright.config.ts pinned 3100 on its own. A port that
+// moves is not just untidy — it leaks into durable state. The mobile pairing
+// secret lives in `mobile-tailscale-${port}` (mobile-access-provision.ts), so a
+// per-launch port meant a per-launch state directory, and `tailscale serve`
+// needed a self-repair pass to chase the loopback port it had been pointed at.
+//
+// One port per channel, fixed:
+//
+//   dev         3000   the entrenched one — docs, iOS, muscle memory
+//   production  3020   its own neighbour, so a packaged build and a dev server
+//                      can run side by side without fighting
+//   e2e         3100   unchanged; playwright.config.ts already pinned it
+//
+// Rust cannot import this module. `src-tauri/src/sidecar_ports.rs` carries the
+// same numbers and `scripts/port-contract.test.mjs` fails if the copies ever
+// disagree — the same two-place convention `scripts/sidecar-bundle-deps.test.mjs`
+// uses for the sidecar budget, where a literal is pinned precisely so raising it
+// is a deliberate edit in two reviewed places rather than a silent drift.
+
+/** Fixed port per build channel. Change here AND in src-tauri/src/sidecar_ports.rs. */
+export const CAVE_PORTS = Object.freeze({
+  dev: 3000,
+  production: 3020,
+  e2e: 3100,
+});
+
+/** @typedef {keyof typeof CAVE_PORTS} CaveChannel */
+
+export const CAVE_PORT_ENV = "COVEN_CAVE_PORT";
+
+/**
+ * A port is only usable if it is a whole number in the TCP range. Port 0 is
+ * excluded deliberately: it means "bind anything", which is the behaviour this
+ * module exists to remove. An operator who wants that can still pass an
+ * explicit port.
+ */
+export function isUsablePort(value) {
+  return Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+/** Parses an env value, returning null for anything that is not a usable port. */
+export function parsePort(raw) {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return isUsablePort(parsed) ? parsed : null;
+}
+
+/**
+ * The port for a channel, honouring an explicit override.
+ *
+ * COVEN_CAVE_PORT wins over PORT so an operator can pin Cave specifically
+ * without disturbing a PORT that some parent process set for its own reasons —
+ * pnpm exports its whole config to children as env vars, and inheriting one of
+ * those by accident is exactly how an "undedicated" port comes back. An
+ * unparseable override is ignored rather than fatal: a typo in a shell profile
+ * should not stop the app from starting, and the resolved port is logged by
+ * every caller.
+ */
+export function resolvePort(channel, env = process.env) {
+  const fallback = CAVE_PORTS[channel];
+  if (!isUsablePort(fallback)) {
+    throw new Error(`unknown Cave channel: ${String(channel)}`);
+  }
+  return parsePort(env?.[CAVE_PORT_ENV]) ?? parsePort(env?.PORT) ?? fallback;
+}
+
+/** The channel a Node process is running as, from the env the callers already set. */
+export function currentChannel(env = process.env) {
+  if (env?.COVEN_CAVE_E2E === "1") return "e2e";
+  if (env?.COVEN_CAVE_BUNDLE === "1") return "production";
+  return "dev";
+}

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1598,6 +1598,7 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  "src/lib/daemon-desktop-auto-start.test.ts",
   "src/lib/chat-live-generation-identity.test.ts",
   "src/lib/podcast-script.test.ts",
   // the foil-plate store resolves "@/lib/avatar-idb" for its IndexedDB driver

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1148,6 +1148,8 @@ export const SUITES = {
     "scripts/dev-app.test.mjs",
     "scripts/dev-app-origin-health.test.mjs",
     "scripts/dev-app-teardown.test.mjs",
+    "scripts/dev-port-owner.test.mjs",
+    "scripts/port-contract.test.mjs",
     "scripts/sync-runtimes.test.mjs",
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1416,6 +1416,7 @@ export const SUITES = {
     "src/server-heap-monitor.test.ts",
     "src/lib/pty-ws-bridge.test.ts",
     "src/lib/websocket-url.test.ts",
+    "src/lib/familiar-liveness.test.ts",
     "scripts/release-macos-signing.test.mjs",
     "scripts/release-notes.test.mjs",
     "scripts/generate-latest-json.test.mjs",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1415,6 +1415,7 @@ export const SUITES = {
     "src/server-pty-ws.test.ts",
     "src/server-heap-monitor.test.ts",
     "src/lib/pty-ws-bridge.test.ts",
+    "src/lib/websocket-url.test.ts",
     "scripts/release-macos-signing.test.mjs",
     "scripts/release-notes.test.mjs",
     "scripts/generate-latest-json.test.mjs",

--- a/server.mjs
+++ b/server.mjs
@@ -20,8 +20,20 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   } catch {
   }
 }
+const CAVE_DEV_PORT = 3e3;
+const CAVE_PRODUCTION_PORT = 3020;
+function parseCavePort(raw) {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : null;
+}
+function cavePort() {
+  const channelDefault = process.env.COVEN_CAVE_BUNDLE === "1" ? CAVE_PRODUCTION_PORT : CAVE_DEV_PORT;
+  return parseCavePort(process.env.COVEN_CAVE_PORT) ?? parseCavePort(process.env.PORT) ?? channelDefault;
+}
 function persistedMobileAccessSecretFile() {
-  const port2 = (process.env.PORT || "3000").trim() || "3000";
+  const port2 = String(cavePort());
   const stateRoot = process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() || join(
     process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"),
     "coven-cave"
@@ -570,7 +582,7 @@ function handlePtyConnection(ws, threadId, cols, rows, cwd, replayCursor) {
 }
 const dev = process.env.NODE_ENV !== "production";
 const hostname = process.env.HOSTNAME ?? "127.0.0.1";
-const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+const port = cavePort();
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();
 const wss = new WebSocketServer({ noServer: true });

--- a/server.ts
+++ b/server.ts
@@ -37,8 +37,43 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
 // Serve route stays token-gated. Mirrors src/lib/server/mobile-access-
 // provision.ts, inlined because the standalone server.mjs cannot import from
 // src/.
+// The port contract, inlined for the same reason as everything else in this
+// block: `build:server` runs esbuild with `--bundle=false`, so any import here
+// must still resolve at runtime from wherever server.mjs is unpacked — and the
+// packaged bundle ships server.mjs without scripts/. scripts/ports.mjs is the
+// source of truth and scripts/port-contract.test.mjs fails if this copy drifts.
+const CAVE_DEV_PORT = 3000;
+const CAVE_PRODUCTION_PORT = 3020;
+
+function parseCavePort(raw: string | undefined): number | null {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed || !/^\d+$/.test(trimmed)) return null;
+  const parsed = Number(trimmed);
+  return Number.isInteger(parsed) && parsed >= 1 && parsed <= 65535 ? parsed : null;
+}
+
+/**
+ * COVEN_CAVE_PORT wins over PORT so Cave can be pinned without disturbing a
+ * PORT that some parent set for its own reasons — pnpm exports its config to
+ * children as env vars, and inheriting one by accident is how the port stopped
+ * being dependable before. The packaged bundle takes the production port; a
+ * `pnpm dev` server takes the dev port, so the two can run side by side.
+ */
+function cavePort(): number {
+  const channelDefault =
+    process.env.COVEN_CAVE_BUNDLE === "1" ? CAVE_PRODUCTION_PORT : CAVE_DEV_PORT;
+  return (
+    parseCavePort(process.env.COVEN_CAVE_PORT) ??
+    parseCavePort(process.env.PORT) ??
+    channelDefault
+  );
+}
+
 function persistedMobileAccessSecretFile(): string {
-  const port = (process.env.PORT || "3000").trim() || "3000";
+  // Keyed by the port on purpose (it mirrors scripts/mobile-tailscale.sh), which
+  // is precisely why the port had to stop moving: a per-launch port meant a
+  // per-launch secret directory, so every desktop restart re-paired every phone.
+  const port = String(cavePort());
   const stateRoot =
     process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() ||
     join(
@@ -878,7 +913,7 @@ function handlePtyConnection(
 
 const dev = process.env.NODE_ENV !== "production";
 const hostname = process.env.HOSTNAME ?? "127.0.0.1";
-const port = Number.parseInt(process.env.PORT ?? "3000", 10);
+const port = cavePort();
 
 const app = next({ dev, hostname, port });
 const handle = app.getRequestHandler();

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -1417,14 +1417,36 @@ fn background_availability_supported() -> bool {
     false
 }
 
+/// The background-availability daemon serves the SAME address the GUI does.
+///
+/// This is the point of the dedicated port. LaunchAgent mode is a handoff — the
+/// GUI's sidecar exits and `server.mjs` keeps serving so paired phones stay
+/// reachable — and a handoff that changes the port is not a handoff at all: the
+/// phone's stored host stops resolving and `tailscale serve` is left pointing
+/// at a loopback port nothing answers on. Previously the GUI took a random port
+/// and this daemon scanned 3000..=3010, so the two essentially never agreed.
+///
+/// The old scan survives only as a last resort. Here, unlike the GUI path, not
+/// starting is worse than moving: the GUI can show the user an error, whereas a
+/// background daemon that refuses to bind leaves the phone silently unreachable
+/// with nothing on screen to explain it. The fallback logs loudly, and the
+/// serve-repair pass re-points Tailscale at whatever port was actually taken.
 #[cfg(all(desktop, target_os = "macos"))]
 fn daemon_port() -> Result<u16, String> {
+    let dedicated = crate::sidecar_ports::dedicated_port();
+    if TcpListener::bind(("127.0.0.1", dedicated)).is_ok() {
+        return Ok(dedicated);
+    }
+    log::warn!(
+        "[cave] dedicated port {dedicated} is occupied; the background daemon is falling back to \
+         a scanned port, so paired phones depend on the Tailscale serve repair pass to follow it"
+    );
     for port in 3000..=3010 {
         if TcpListener::bind(("127.0.0.1", port)).is_ok() {
             return Ok(port);
         }
     }
-    find_free_port().ok_or_else(|| "no free loopback port is available".to_string())
+    Err("no free loopback port is available".to_string())
 }
 
 #[cfg(all(desktop, target_os = "macos"))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,8 @@ mod sidecar_discovery;
 #[cfg(desktop)]
 mod sidecar_lifecycle;
 #[cfg(desktop)]
+mod sidecar_ports;
+#[cfg(desktop)]
 mod sidecar_startup;
 #[cfg(desktop)]
 mod speech;

--- a/src-tauri/src/sidecar_ports.rs
+++ b/src-tauri/src/sidecar_ports.rs
@@ -1,0 +1,66 @@
+//! The Rust half of the port contract. Rust cannot import `scripts/ports.mjs`,
+//! so these numbers are duplicated on purpose and `scripts/port-contract.test.mjs`
+//! fails if the two copies ever disagree — the same two-place convention
+//! `scripts/sidecar-bundle-deps.test.mjs` uses for the sidecar file-count budget.
+//!
+//! Before this, `find_free_port()` bound `127.0.0.1:0` and the packaged app took
+//! a different port on every launch. See scripts/ports.mjs for why a moving port
+//! is more than an inconvenience.
+
+/// Fixed port for a packaged (release) build. Mirrors CAVE_PORTS.production.
+pub(super) const CAVE_PRODUCTION_PORT: u16 = 3020;
+
+/// Fixed port for a dev server. Mirrors CAVE_PORTS.dev.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) const CAVE_DEV_PORT: u16 = 3000;
+
+/// Operator override, checked before the channel default. Mirrors CAVE_PORT_ENV.
+pub(super) const CAVE_PORT_ENV: &str = "COVEN_CAVE_PORT";
+
+/// Parses an override, rejecting anything outside the usable TCP range. Port 0
+/// is refused deliberately: "bind anything" is the behaviour the dedicated port
+/// exists to remove.
+pub(super) fn parse_port(raw: &str) -> Option<u16> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() || !trimmed.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    trimmed.parse::<u16>().ok().filter(|port| *port >= 1)
+}
+
+/// The port a packaged build should bind: `COVEN_CAVE_PORT` when it parses,
+/// otherwise the dedicated production port. A malformed override is ignored
+/// rather than fatal — a typo in a shell profile should not stop the app from
+/// starting, and the resolved port is logged at startup either way.
+pub(super) fn dedicated_port() -> u16 {
+    std::env::var(CAVE_PORT_ENV)
+        .ok()
+        .as_deref()
+        .and_then(parse_port)
+        .unwrap_or(CAVE_PRODUCTION_PORT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_usable_ports_only() {
+        assert_eq!(parse_port("3020"), Some(3020));
+        assert_eq!(parse_port("  3020 "), Some(3020));
+        assert_eq!(parse_port("65535"), Some(65535));
+        // Port 0 means "bind anything" — the exact behaviour being retired.
+        assert_eq!(parse_port("0"), None);
+        assert_eq!(parse_port("70000"), None, "outside the u16 TCP range");
+        assert_eq!(parse_port("30a20"), None);
+        assert_eq!(parse_port(""), None);
+        assert_eq!(parse_port("-1"), None);
+    }
+
+    #[test]
+    fn channel_ports_are_distinct() {
+        // A packaged build and a dev server must be able to run side by side;
+        // that is the whole reason production does not simply reuse 3000.
+        assert_ne!(CAVE_PRODUCTION_PORT, CAVE_DEV_PORT);
+    }
+}

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -85,12 +85,23 @@ pub(super) fn sidecar_output_text(output: &Arc<Mutex<SidecarOutputTail>>) -> Str
     }
 }
 
+/// Whether anything is already listening on the dedicated loopback port.
+///
+/// Replaces `find_free_port()`, which bound `127.0.0.1:0` and let the kernel
+/// pick — that is what made the packaged app's port different on every launch.
+/// See src-tauri/src/sidecar_ports.rs and scripts/ports.mjs for why a moving
+/// port is more than an inconvenience.
+///
+/// A busy port is NOT worked around by relocating. The desktop app already
+/// refuses to run a second GUI (the reachability owner check), so a stranger on
+/// the dedicated port is an operator-visible conflict, not something to route
+/// around silently — relocating is exactly how the address stopped being
+/// dependable in the first place.
 #[cfg(desktop)]
-pub(super) fn find_free_port() -> Option<u16> {
-    TcpListener::bind("127.0.0.1:0")
-        .ok()
-        .and_then(|l| l.local_addr().ok())
-        .map(|a| a.port())
+pub(super) fn port_is_occupied(port: u16) -> bool {
+    use std::net::{SocketAddr, TcpStream};
+    let addr = SocketAddr::from(([127, 0, 0, 1], port));
+    TcpStream::connect_timeout(&addr, Duration::from_millis(250)).is_ok()
 }
 
 /// Dev builds only: the dev-server URL from tauri.conf.json `build.devUrl`,
@@ -226,8 +237,20 @@ pub(super) fn start_sidecar_runtime(
         )));
     };
 
-    let port = find_free_port()
-        .ok_or_else(|| SidecarStartError::Failed("no free local port available".to_string()))?;
+    let port = sidecar_ports::dedicated_port();
+    if port_is_occupied(port) {
+        // Name the conflict instead of relocating. The old behaviour asked the
+        // kernel for any free port, which always "worked" and left the app on a
+        // different address every launch — including in the pairing-secret path
+        // (`mobile-tailscale-${port}`), so phones could not find it twice.
+        return Err(SidecarStartError::Failed(format!(
+            "Port {port} is already in use, so CovenCave cannot start its local server.\n\n\
+             This is usually another CovenCave that is still running, or a dev server \
+             started with `pnpm dev`. Quit that one and re-launch, or start CovenCave with \
+             {} set to a free port.",
+            sidecar_ports::CAVE_PORT_ENV,
+        )));
+    }
     let auth_token = sidecar_auth_token();
     let mobile_access_token = mobile_access_token_for_app(app);
     log::info!("[cave] starting sidecar on port {port}");

--- a/src/lib/daemon-desktop-auto-start.test.ts
+++ b/src/lib/daemon-desktop-auto-start.test.ts
@@ -226,9 +226,17 @@ function restartHarness({ enabled = true, startClock = 0 } = {}) {
   assert.equal(h.starts.length, 1, "turning the switch off stops the next restart");
 }
 {
-  // Backoff, and a real ceiling. A daemon that cannot start must not be
-  // relaunched every 5s forever — the poll cadence would otherwise make this
-  // an infinite loop against a broken install.
+  // Backoff, a bounded burst, and then MORE attempts after cooling off.
+  //
+  // This used to assert a permanent ceiling: four attempts and never again. The
+  // ceiling was the bug — the only thing that reset the counter was a `running`
+  // poll, which for a daemon that is genuinely gone never arrives, so the
+  // familiar stayed down for the rest of the session with nothing further tried
+  // and nothing on screen saying so. The budget now refills after a cooldown
+  // (src/lib/familiar-liveness.ts).
+  //
+  // What must still hold is the thing the ceiling was protecting against: a
+  // broken install must not be relaunched on every 5s poll.
   const h = restartHarness();
   h.coordinator.observePlatform("desktop");
   h.coordinator.observeStatus(RUNNING);
@@ -236,16 +244,21 @@ function restartHarness({ enabled = true, startClock = 0 } = {}) {
     h.advance(5_000); // the real poll cadence
     h.coordinator.observeStatus(OFFLINE);
   }
-  assert.equal(
-    h.starts.length,
-    DAEMON_RESTART_BACKOFF_MS.length,
-    "attempts stop at the ceiling instead of looping forever",
+  assert.ok(
+    h.starts.length > DAEMON_RESTART_BACKOFF_MS.length,
+    `the budget refills after cooling off, so a long outage keeps getting attempts (${h.starts.length})`,
   );
+  assert.ok(
+    h.starts.length < 20,
+    `but nowhere near the 400 polls it saw — a crash loop still cannot spin (${h.starts.length})`,
+  );
+  // Jitter is [0.5, 1.5) of nominal, so the floor is half the scheduled wait.
+  // Assert against the smallest in-burst delay: no two attempts are adjacent.
   const gaps = h.starts.slice(1).map((at, i) => at - h.starts[i]);
   for (const [i, gap] of gaps.entries()) {
     assert.ok(
-      gap >= DAEMON_RESTART_BACKOFF_MS[i + 1],
-      `attempt ${i + 2} waited at least its backoff (${gap} >= ${DAEMON_RESTART_BACKOFF_MS[i + 1]})`,
+      gap >= DAEMON_RESTART_BACKOFF_MS[1] / 2,
+      `attempt ${i + 2} waited at least the jittered floor (${gap})`,
     );
   }
 }

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -1,3 +1,4 @@
+import { createFamiliarLivenessPolicy } from "@/lib/familiar-liveness";
 import type { DaemonStatusPollResult } from "@/lib/daemon-status-classification";
 import type { TauriPlatform } from "@/lib/tauri-platform";
 
@@ -26,10 +27,15 @@ export type DaemonDesktopAutoStartCoordinator = {
 };
 
 /**
- * Backoff for unattended restarts, in ms since the previous attempt. A daemon
- * that cannot start must not be relaunched every 5 seconds forever: the list
- * is finite, so after the last entry the coordinator gives up and leaves the
- * offline banner to say so. A single observed `running` result resets it.
+ * Retained for the surfaces that describe the restart cadence to the user. The
+ * schedule itself now comes from createFamiliarLivenessPolicy, which spends the
+ * same budget and then COOLS OFF rather than stopping for good.
+ *
+ * The finite list was the bug: `restartAttempts >= DAEMON_RESTART_BACKOFF_MS
+ * .length` gave up permanently, and the only thing that cleared the counter was
+ * a `running` poll — which, for a daemon that is genuinely gone and cannot
+ * return on its own, never arrives. Four failures inside six minutes and the
+ * familiar was down for the rest of the session.
  */
 export const DAEMON_RESTART_BACKOFF_MS = [0, 15_000, 60_000, 300_000] as const;
 
@@ -61,8 +67,14 @@ export function createDaemonDesktopAutoStartCoordinator(
   let platform: TauriPlatform = "unknown";
   let firstStatus: DaemonStatusPollResult | null = null;
   let consumed = false;
-  let restartAttempts = 0;
-  let lastAttemptAt: number | null = null;
+  // One policy owns the schedule, the burst budget and its refill. See
+  // src/lib/familiar-liveness.ts for why "N attempts then never" was wrong.
+  const liveness = options
+    ? createFamiliarLivenessPolicy({
+        now: options.now,
+        burstAttempts: DAEMON_RESTART_BACKOFF_MS.length,
+      })
+    : null;
 
   const reconcile = () => {
     if (consumed) return;
@@ -70,8 +82,10 @@ export function createDaemonDesktopAutoStartCoordinator(
     if (decision === "wait") return;
     consumed = true;
     if (decision === "start") {
-      lastAttemptAt = options ? options.now() : null;
-      restartAttempts = 1;
+      // The boot start is unconditional and spends the burst's first attempt,
+      // so a daemon that is still absent a moment later waits out the backoff
+      // rather than being started twice in a row.
+      liveness?.observe("absent");
       start();
     }
   };
@@ -82,26 +96,27 @@ export function createDaemonDesktopAutoStartCoordinator(
    * state captured at boot.
    */
   const considerRestart = (status: DaemonStatusPollResult) => {
-    if (!options || !consumed) return;
+    if (!options || !liveness || !consumed) return;
     if (status.kind === "running") {
-      // Proof the daemon is back: forget the attempt history so a later,
-      // unrelated outage gets a full budget rather than the tail of this one.
-      restartAttempts = 0;
-      lastAttemptAt = null;
+      // Proof the daemon is back: the policy forgets the attempt history so a
+      // later, unrelated outage gets a full budget rather than the tail of this
+      // one.
+      liveness.observe("healthy");
       return;
     }
     if (platform !== "desktop") return;
     if (status.kind !== "offline" || status.targetMode !== "local") return;
+    // Re-read, never captured: the user can turn the preference off mid-session
+    // and the very next poll must respect that. Note this is checked BEFORE the
+    // policy is told anything, so a disabled preference never consumes budget.
     if (!options.autoRestartEnabled()) return;
-    if (restartAttempts >= DAEMON_RESTART_BACKOFF_MS.length) return;
 
-    const wait = DAEMON_RESTART_BACKOFF_MS[restartAttempts];
-    const at = options.now();
-    if (lastAttemptAt !== null && at - lastAttemptAt < wait) return;
-
-    restartAttempts += 1;
-    lastAttemptAt = at;
-    start();
+    // Scope note (cave-9pqt9): only `offline` + `local` reaches here, which is
+    // the status service's own confirmation that nothing is running. Widening
+    // this to hangs would mean issuing a stop, and stopping a daemon an external
+    // supervisor owns is precisely the contention that gate exists to avoid.
+    const decision = liveness.observe("absent");
+    if (decision.action === "revive") start();
   };
 
   return {

--- a/src/lib/familiar-liveness.test.ts
+++ b/src/lib/familiar-liveness.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import {
+  burstDelayMs,
+  createFamiliarLivenessPolicy,
+  FAMILIAR_LIVENESS_DEFAULTS,
+  familiarHealthVerdictFromPoll,
+  jitteredDelay,
+} from "./familiar-liveness.ts";
+
+// --- reading a hang out of the existing poll shape ---------------------------
+// "Listening" was never proof of "alive". The signal was already in the data:
+// `offline` means the status service ANSWERED and said nothing is running,
+// while `unavailable` means we never got an answer.
+assert.equal(familiarHealthVerdictFromPoll({ kind: "running" }), "healthy");
+assert.equal(familiarHealthVerdictFromPoll({ kind: "offline" }), "absent");
+assert.equal(
+  familiarHealthVerdictFromPoll({ kind: "auth-expired" }),
+  "degraded",
+  "restarting cannot fix a credential",
+);
+assert.equal(
+  familiarHealthVerdictFromPoll({ kind: "unavailable", reason: "The operation timed out" }),
+  "hung",
+  "something is there and not answering",
+);
+assert.equal(
+  familiarHealthVerdictFromPoll({ kind: "unavailable", reason: "AbortError" }),
+  "hung",
+);
+assert.equal(
+  familiarHealthVerdictFromPoll({ kind: "unavailable", reason: "connect ECONNREFUSED" }),
+  "absent",
+  "a refused connection is absence, where a plain start is right and cannot make it worse",
+);
+assert.equal(
+  familiarHealthVerdictFromPoll({ kind: "unavailable" }),
+  "absent",
+  "no reason at all is treated as absence rather than guessing a hang",
+);
+
+// The behaviour this exists to fix: the coordinator it replaces stopped trying
+// after four attempts and could only be reset by a `running` poll — which, for a
+// daemon that is genuinely gone, never arrives. The familiar stayed down for the
+// rest of the session with nothing further attempted.
+
+// --- delay shape -------------------------------------------------------------
+assert.equal(burstDelayMs(0, { baseDelayMs: 15_000, maxDelayMs: 300_000 }), 0, "first try is immediate");
+assert.equal(burstDelayMs(1, { baseDelayMs: 15_000, maxDelayMs: 300_000 }), 15_000);
+assert.equal(burstDelayMs(2, { baseDelayMs: 15_000, maxDelayMs: 300_000 }), 30_000);
+assert.equal(burstDelayMs(3, { baseDelayMs: 15_000, maxDelayMs: 300_000 }), 60_000);
+assert.equal(
+  burstDelayMs(20, { baseDelayMs: 15_000, maxDelayMs: 300_000 }),
+  300_000,
+  "growth is capped, so a long outage does not schedule a retry next week",
+);
+
+// Jitter decorrelates several observers of the same outage without making a
+// short wait feel long: [0.5, 1.5) of nominal.
+assert.equal(jitteredDelay(10_000, 0), 5_000);
+assert.equal(jitteredDelay(10_000, 0.5), 10_000);
+assert.equal(jitteredDelay(10_000, 1), 15_000);
+assert.equal(jitteredDelay(10_000, Number.NaN), 10_000, "a broken random source falls back to nominal");
+
+// --- a healthy familiar asks for nothing --------------------------------------
+{
+  let now = 0;
+  const policy = createFamiliarLivenessPolicy({ now: () => now, random: () => 0.5 });
+  assert.deepEqual(policy.observe("healthy"), { action: "none", state: "healthy" });
+}
+
+// --- degraded is surfaced, never restarted ------------------------------------
+{
+  let now = 0;
+  const policy = createFamiliarLivenessPolicy({ now: () => now, random: () => 0.5 });
+  const decision = policy.observe("degraded");
+  assert.equal(decision.action, "none", "restarting something that answers trades degraded for absent");
+  assert.equal(decision.state, "degraded", "but the state is visible, which is the useful part");
+}
+
+// --- a burst, then a cooldown, then MORE attempts -----------------------------
+{
+  let now = 0;
+  const policy = createFamiliarLivenessPolicy({
+    now: () => now,
+    random: () => 0.5,
+    burstAttempts: 3,
+    baseDelayMs: 1_000,
+    maxDelayMs: 4_000,
+    cooldownMs: 60_000,
+  });
+
+  const first = policy.observe("absent");
+  assert.equal(first.action, "revive", "the first attempt is immediate");
+  assert.equal(first.action === "revive" && first.attempt, 1);
+
+  // Inside the backoff window nothing is issued.
+  now += 500;
+  assert.equal(policy.observe("absent").action, "none", "a second observation does not double-fire");
+
+  now += 1_000;
+  assert.equal(policy.observe("absent").action, "revive", "the window elapsed, so try again");
+  now += 5_000;
+  assert.equal(policy.observe("absent").action, "revive", "third attempt of the burst");
+
+  // Budget spent — this is exactly where the old coordinator gave up forever.
+  now += 60_000;
+  const spent = policy.observe("absent");
+  assert.equal(spent.action, "none");
+  assert.equal(spent.state, "cooling", "the burst is spent, not the familiar");
+
+  // Still cooling.
+  now += 30_000;
+  assert.equal(policy.observe("absent").state, "cooling");
+
+  // Cooldown elapsed: the budget REFILLS and the familiar gets another burst.
+  now += 60_000;
+  const refilled = policy.observe("absent");
+  assert.equal(refilled.action, "revive", "the budget refills — the familiar is never written off");
+  assert.equal(refilled.action === "revive" && refilled.attempt, 1, "a fresh burst starts at one");
+  assert.equal(refilled.action === "revive" && refilled.burst, 1, "and records that this is the second burst");
+}
+
+// --- a hung familiar is stopped first, not started again ----------------------
+{
+  let now = 0;
+  const policy = createFamiliarLivenessPolicy({ now: () => now, random: () => 0.5 });
+  const decision = policy.observe("hung");
+  assert.equal(
+    decision.action,
+    "recover-hang",
+    "a hung daemon still holds its lock and port, so a bare start is refused",
+  );
+}
+
+// --- recovery clears the history ---------------------------------------------
+{
+  let now = 0;
+  const policy = createFamiliarLivenessPolicy({
+    now: () => now,
+    random: () => 0.5,
+    burstAttempts: 2,
+    baseDelayMs: 1_000,
+  });
+  policy.observe("absent");
+  now += 10_000;
+  policy.observe("absent");
+  assert.equal(policy.snapshot().revives, 2);
+
+  policy.observe("healthy");
+  assert.deepEqual(
+    policy.snapshot(),
+    { state: "healthy", attempt: 0, burst: 0, revives: 0, lastVerdict: "healthy" },
+    "proof it is back resets the budget, so a later unrelated outage gets a full one",
+  );
+}
+
+// --- the defaults cover the ground the old schedule did -----------------------
+assert.equal(
+  FAMILIAR_LIVENESS_DEFAULTS.burstAttempts,
+  4,
+  "one burst matches the old [0, 15s, 60s, 300s] budget",
+);
+assert.ok(
+  FAMILIAR_LIVENESS_DEFAULTS.cooldownMs > FAMILIAR_LIVENESS_DEFAULTS.maxDelayMs,
+  "cooling off must outlast the longest in-burst wait, or bursts run together",
+);
+
+console.log("familiar-liveness.test.ts: ok");

--- a/src/lib/familiar-liveness.ts
+++ b/src/lib/familiar-liveness.ts
@@ -1,0 +1,259 @@
+/**
+ * How many times does the familiar get to come back, and how fast?
+ *
+ * The existing coordinator (daemon-desktop-auto-start.ts) restarts a local
+ * daemon on the fixed schedule [0, 15s, 60s, 300s] and then stops trying:
+ *
+ *     if (restartAttempts >= DAEMON_RESTART_BACKOFF_MS.length) return;
+ *
+ * The only thing that clears that counter is a `running` poll — so in the one
+ * case that matters, a daemon that is genuinely gone and cannot come back on its
+ * own, nothing will ever produce the observation that would let it try again.
+ * Four failures in the first six minutes and the familiar is down for the rest
+ * of the session, with no further attempt and nothing on screen that says so.
+ *
+ * This module replaces "N attempts, then never" with "N attempts, cool off,
+ * then N more" — a burst budget that REFILLS. A crash-looping daemon still
+ * cannot spin: the burst is small, the delays grow exponentially with jitter,
+ * and the cooldown between bursts is long. But a machine that was asleep, or a
+ * daemon whose dependency came back an hour later, gets another chance.
+ *
+ * It also adds the half that was missing entirely. `classifyDaemonStatusPoll`
+ * distinguishes only "answered" from "did not answer", so a daemon that holds
+ * its port open and stops responding reads as *running* forever — the familiar
+ * looks alive and answers nothing. A `hung` verdict is a first-class input here
+ * and is recovered by stop-then-revive rather than by another bare start, which
+ * would be refused by the still-held lock.
+ *
+ * Pure and synchronous on purpose: no timers, no fetch, no clock of its own.
+ * The caller supplies `now()` and `random()`, so every schedule below is exactly
+ * reproducible in a test.
+ *
+ * OWNERSHIP (cave-9pqt9): deciding to revive is NOT permission to spawn. An
+ * external supervisor (launchd KeepAlive) may own recovery of the same daemon,
+ * and two owners racing produce lock contention and error banners rather than a
+ * faster recovery. The caller must still preflight `coven daemon status --json`
+ * and act only on a confirmed-stopped daemon. This module answers "should we,
+ * and how long have we waited", never "is it ours to start".
+ */
+
+export type FamiliarHealthVerdict =
+  /** Answered, and answered correctly. */
+  | "healthy"
+  /** Reachable but erroring — the familiar is up and not working. */
+  | "degraded"
+  /** Nothing is there. */
+  | "absent"
+  /** Listening, but not answering within the deadline. */
+  | "hung";
+
+/**
+ * Turn a status poll into a liveness verdict.
+ *
+ * The distinction that makes hang detection possible is already in the data,
+ * it just was not being read: `offline` means the status service ANSWERED and
+ * reported the daemon absent, whereas `unavailable` means we could not get an
+ * answer at all. A daemon holding its port open while refusing to respond
+ * produces the latter — which is why "listening" was never proof of "alive".
+ *
+ * Deliberately a separate mapping rather than a fifth member of
+ * `DaemonStatusPollResult`: that union is consumed exhaustively across the app,
+ * and widening it to express something only the supervisor cares about would
+ * churn every one of those call sites for no gain at the reading end.
+ */
+export function familiarHealthVerdictFromPoll(
+  poll: { kind: string; reason?: string },
+): FamiliarHealthVerdict {
+  switch (poll.kind) {
+    case "running":
+      return "healthy";
+    case "offline":
+      // The status service answered and said nothing is running. Unambiguous.
+      return "absent";
+    case "auth-expired":
+      // Reachable, and refusing us. Restarting cannot fix a credential.
+      return "degraded";
+    default: {
+      // We could not get an answer. A timeout means something is there and not
+      // responding; anything else (connection refused, DNS, a broken status
+      // service) is better treated as absent, where a plain start is the right
+      // move and cannot make things worse.
+      const reason = (poll.reason ?? "").toLowerCase();
+      return reason.includes("timeout") || reason.includes("timed out") || reason.includes("abort")
+        ? "hung"
+        : "absent";
+    }
+  }
+}
+
+export type FamiliarLivenessState =
+  | "healthy"
+  | "degraded"
+  /** A revive has been issued and we are waiting to see whether it took. */
+  | "reviving"
+  /** The burst is spent; waiting out the cooldown before the budget refills. */
+  | "cooling";
+
+export type FamiliarReviveAction =
+  /** Nothing to do — healthy, or already inside a backoff window. */
+  | { action: "none"; state: FamiliarLivenessState }
+  /** Start it. `attempt` is 1-based within the current burst. */
+  | { action: "revive"; state: "reviving"; attempt: number; burst: number }
+  /** Stop it first: a hung daemon still holds its lock, so a bare start fails. */
+  | { action: "recover-hang"; state: "reviving"; attempt: number; burst: number };
+
+export type FamiliarLivenessPolicyOptions = {
+  /** Attempts per burst before cooling off. */
+  burstAttempts?: number;
+  /** Delay before the second attempt in a burst; the first is immediate. */
+  baseDelayMs?: number;
+  /** Ceiling for the exponential growth within a burst. */
+  maxDelayMs?: number;
+  /** Wait after a spent burst before the budget refills. */
+  cooldownMs?: number;
+  now: () => number;
+  /** Injected for reproducibility; defaults to Math.random. */
+  random?: () => number;
+};
+
+/**
+ * Defaults chosen against the schedule they replace: the old list spent its
+ * whole budget in six minutes. A burst of four covers the same ground, and the
+ * 15-minute cooldown is what turns "never again" into "again, later" without
+ * letting a crash loop hammer the machine.
+ */
+export const FAMILIAR_LIVENESS_DEFAULTS = Object.freeze({
+  burstAttempts: 4,
+  baseDelayMs: 15_000,
+  maxDelayMs: 300_000,
+  cooldownMs: 900_000,
+});
+
+/**
+ * Jitter spreads retries so several surfaces observing the same outage do not
+ * schedule their revives on the same instant. Range is [0.5, 1.5) of the
+ * nominal delay — enough to decorrelate, never enough to make a 15s wait feel
+ * like a minute.
+ */
+export function jitteredDelay(nominalMs: number, sample: number): number {
+  const clamped = Number.isFinite(sample) ? Math.min(Math.max(sample, 0), 1) : 0.5;
+  return Math.round(nominalMs * (0.5 + clamped));
+}
+
+/** Exponential within a burst: attempt 1 is immediate, then base, 2x, 4x… */
+export function burstDelayMs(
+  attempt: number,
+  { baseDelayMs, maxDelayMs }: { baseDelayMs: number; maxDelayMs: number },
+): number {
+  if (attempt <= 0) return 0;
+  return Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+}
+
+export type FamiliarLivenessSnapshot = {
+  state: FamiliarLivenessState;
+  /** Attempts used in the current burst. */
+  attempt: number;
+  /** How many bursts have been spent — i.e. how many times we have given up and come back. */
+  burst: number;
+  /** Total revives issued since the last healthy observation. */
+  revives: number;
+  lastVerdict: FamiliarHealthVerdict | null;
+};
+
+export type FamiliarLivenessPolicy = {
+  /** Feed an observation; get back what to do about it. */
+  observe(verdict: FamiliarHealthVerdict): FamiliarReviveAction;
+  snapshot(): FamiliarLivenessSnapshot;
+};
+
+export function createFamiliarLivenessPolicy(
+  options: FamiliarLivenessPolicyOptions,
+): FamiliarLivenessPolicy {
+  const burstAttempts = options.burstAttempts ?? FAMILIAR_LIVENESS_DEFAULTS.burstAttempts;
+  const baseDelayMs = options.baseDelayMs ?? FAMILIAR_LIVENESS_DEFAULTS.baseDelayMs;
+  const maxDelayMs = options.maxDelayMs ?? FAMILIAR_LIVENESS_DEFAULTS.maxDelayMs;
+  const cooldownMs = options.cooldownMs ?? FAMILIAR_LIVENESS_DEFAULTS.cooldownMs;
+  const random = options.random ?? Math.random;
+
+  let state: FamiliarLivenessState = "healthy";
+  let attempt = 0;
+  let burst = 0;
+  let revives = 0;
+  let lastAttemptAt: number | null = null;
+  let cooldownStartedAt: number | null = null;
+  let lastVerdict: FamiliarHealthVerdict | null = null;
+
+  const snapshot = (): FamiliarLivenessSnapshot => ({
+    state,
+    attempt,
+    burst,
+    revives,
+    lastVerdict,
+  });
+
+  return {
+    snapshot,
+    observe(verdict) {
+      lastVerdict = verdict;
+
+      if (verdict === "healthy") {
+        // Proof it is back. Forget the history so a later, unrelated outage gets
+        // a full budget rather than the tail of this one — the same reasoning
+        // the coordinator this replaces applied to its counter.
+        state = "healthy";
+        attempt = 0;
+        burst = 0;
+        revives = 0;
+        lastAttemptAt = null;
+        cooldownStartedAt = null;
+        return { action: "none", state };
+      }
+
+      if (verdict === "degraded") {
+        // Reachable but erroring. Deliberately NOT a revive trigger: restarting
+        // something that is answering trades a degraded familiar for an absent
+        // one, and the errors are usually the harness's, not the daemon's.
+        // Surfacing the state is the useful part.
+        state = "degraded";
+        return { action: "none", state };
+      }
+
+      const at = options.now();
+
+      if (state === "cooling") {
+        if (cooldownStartedAt !== null && at - cooldownStartedAt < cooldownMs) {
+          return { action: "none", state };
+        }
+        // Budget refills. This is the whole point: the familiar is never
+        // permanently written off.
+        attempt = 0;
+        cooldownStartedAt = null;
+      }
+
+      if (attempt >= burstAttempts) {
+        state = "cooling";
+        burst += 1;
+        cooldownStartedAt = at;
+        return { action: "none", state };
+      }
+
+      const wait = jitteredDelay(burstDelayMs(attempt, { baseDelayMs, maxDelayMs }), random());
+      if (lastAttemptAt !== null && at - lastAttemptAt < wait) {
+        return { action: "none", state: state === "healthy" ? "reviving" : state };
+      }
+
+      attempt += 1;
+      revives += 1;
+      lastAttemptAt = at;
+      state = "reviving";
+      // A hung daemon still holds its lock and its port, so a bare start is
+      // refused by the single-writer guard. It has to be stopped first.
+      return {
+        action: verdict === "hung" ? "recover-hang" : "revive",
+        state,
+        attempt,
+        burst,
+      };
+    },
+  };
+}

--- a/src/lib/pty-ws-bridge.ts
+++ b/src/lib/pty-ws-bridge.ts
@@ -1,3 +1,5 @@
+import { websocketUrl } from "./websocket-url.ts";
+
 type DataHandler = (bytes: Uint8Array) => void;
 type ExitHandler = (code: number) => void;
 type CloseHandler = (code: number, reason: string) => void;
@@ -111,7 +113,6 @@ export class PtyWsBridge {
       }
     }
     return new Promise((resolve, reject) => {
-      const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
       const params = new URLSearchParams({
         threadId: target.threadId,
         cols: String(target.cols),
@@ -125,7 +126,10 @@ export class PtyWsBridge {
         params.set("projectRoot", target.projectRoot);
       }
 
-      const url = `${proto}//${window.location.host}/api/pty-ws?${params}`;
+      // Scheme and host both come from websocketUrl: `wss:` whenever the page is
+      // TLS-terminated (tailscale serve, a MagicDNS host), `ws:` for the plain
+      // loopback desktop shell. See src/lib/websocket-url.ts.
+      const url = websocketUrl("/api/pty-ws", params);
       const ws = new WebSocket(url);
       let settled = false;
       ws.binaryType = "arraybuffer";

--- a/src/lib/server/mobile-access-provision.ts
+++ b/src/lib/server/mobile-access-provision.ts
@@ -20,12 +20,31 @@ import { randomBytes } from "node:crypto";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { CAVE_PORTS, CAVE_PORT_ENV, parsePort } from "../../../scripts/ports.mjs";
+
+/**
+ * Same resolution order as server.ts `cavePort()` and the Rust
+ * `dedicated_port()`: explicit Cave override, then PORT, then the channel
+ * default. This module runs inside Next, which bundles the import, so unlike
+ * server.ts it can consume the contract directly instead of copying it.
+ */
+function resolveCavePort(env: Record<string, string | undefined>): string {
+  const channelDefault =
+    env.COVEN_CAVE_BUNDLE === "1" ? CAVE_PORTS.production : CAVE_PORTS.dev;
+  const resolved =
+    parsePort(env[CAVE_PORT_ENV]) ?? parsePort(env.PORT) ?? channelDefault;
+  return String(resolved);
+}
 
 /** Mirrors scripts/mobile-tailscale.sh STATE_ROOT/STATE_DIR/TOKEN_FILE. */
 export function mobileAccessSecretFile(
   env: Record<string, string | undefined> = process.env,
 ): string {
-  const port = (env.PORT || "3000").trim() || "3000";
+  // Keyed by port to mirror the shell script — which is why the port contract
+  // (scripts/ports.mjs) exists: the packaged app used to bind a random port
+  // every launch, so this directory moved every launch and every paired phone
+  // had to re-pair. Same resolution order as server.ts `cavePort()`.
+  const port = resolveCavePort(env);
   const stateRoot =
     env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() ||
     path.join(

--- a/src/lib/websocket-url.test.ts
+++ b/src/lib/websocket-url.test.ts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  requiresSecureWebsocket,
+  websocketProtocolFor,
+  websocketUrl,
+} from "./websocket-url.ts";
+
+// One decision point for ws: vs wss:. Getting it wrong is not cosmetic — an
+// insecure socket from an HTTPS page is blocked as mixed content by the browser
+// and refused by ATS on iOS, so the terminal never connects and the failure
+// surfaces nowhere near its cause.
+
+// --- scheme follows the page -------------------------------------------------
+assert.equal(websocketProtocolFor({ protocol: "https:", host: "a.ts.net" }), "wss:");
+assert.equal(websocketProtocolFor({ protocol: "http:", host: "127.0.0.1:3000" }), "ws:");
+assert.equal(
+  websocketProtocolFor({ protocol: "HTTPS:", host: "a.ts.net" }),
+  "wss:",
+  "protocol comparison is case-insensitive",
+);
+assert.equal(
+  websocketProtocolFor({ protocol: "wss:", host: "a.ts.net" }),
+  "wss:",
+  "an already-secure socket origin stays secure",
+);
+
+// Plain ws: on loopback is correct, not a downgrade: that is the desktop shell
+// talking to its own sidecar on 127.0.0.1, where there is no TLS to preserve.
+assert.equal(requiresSecureWebsocket({ protocol: "http:", host: "127.0.0.1:3020" }), false);
+assert.equal(requiresSecureWebsocket({ protocol: "https:", host: "cave.ts.net" }), true);
+
+// --- URL construction --------------------------------------------------------
+assert.equal(
+  websocketUrl("/api/pty-ws", { threadId: "t1" }, { protocol: "https:", host: "cave.ts.net" }),
+  "wss://cave.ts.net/api/pty-ws?threadId=t1",
+);
+assert.equal(
+  websocketUrl("/api/pty-ws", undefined, { protocol: "http:", host: "127.0.0.1:3000" }),
+  "ws://127.0.0.1:3000/api/pty-ws",
+  "no params means no trailing question mark",
+);
+assert.equal(
+  websocketUrl(
+    "/api/pty-ws",
+    new URLSearchParams({ cols: "80", rows: "24" }),
+    { protocol: "http:", host: "127.0.0.1:3000" },
+  ),
+  "ws://127.0.0.1:3000/api/pty-ws?cols=80&rows=24",
+);
+
+// The host comes from the page, never the caller, so no surface can point a
+// socket carrying Cave's session at another host.
+assert.throws(
+  () => websocketUrl("api/pty-ws", undefined, { protocol: "http:", host: "127.0.0.1" }),
+  /absolute path/,
+  "a relative path is a mistake, not something to normalise",
+);
+
+// --- no surface derives the scheme on its own --------------------------------
+const bridge = readFileSync(new URL("./pty-ws-bridge.ts", import.meta.url), "utf8");
+assert.match(
+  bridge,
+  /websocketUrl\("\/api\/pty-ws", params\)/,
+  "the PTY bridge builds its URL through the shared helper",
+);
+assert.doesNotMatch(
+  bridge,
+  /location\.protocol === "https:"/,
+  "the inline scheme ternary is retired — one decision point, not one per caller",
+);
+
+// --- what the SERVER must NOT do ---------------------------------------------
+// `tailscale serve` terminates TLS and forwards PLAINTEXT to loopback, so a
+// paired phone's upgrade legitimately arrives as http/ws with x-forwarded-*
+// headers. Refusing a plaintext upgrade that carries forwarded-TLS headers
+// therefore breaks exactly the paired-phone terminal it would look like it was
+// protecting. The scheme-agnostic host match in server.ts is deliberate; this
+// pins it so it does not get "fixed" into a downgrade check.
+const server = readFileSync(new URL("../../server.ts", import.meta.url), "utf8");
+assert.match(
+  server,
+  /if \(url\.host === expected\.host\) return true;/,
+  "the upgrade gate matches on host, not scheme — TLS terminates at tailscale serve",
+);
+
+console.log("websocket-url.test.ts: ok");

--- a/src/lib/websocket-url.ts
+++ b/src/lib/websocket-url.ts
@@ -1,0 +1,72 @@
+/**
+ * The one place that decides `ws:` versus `wss:`.
+ *
+ * Cave reaches the same origin over three very different transports — plain
+ * loopback in the desktop shell, `tailscale serve` terminating TLS in front of
+ * the loopback server, and a MagicDNS host over HTTPS — and the scheme has to
+ * follow the page, not a guess. Each caller used to derive it inline
+ * (`window.location.protocol === "https:" ? "wss:" : "ws:"` in pty-ws-bridge,
+ * an equivalent in iOS `CaveConnection.wsBaseURL`). Both happened to be right;
+ * nothing kept the next one right, and getting it wrong is not a cosmetic bug:
+ * an insecure `ws://` from an HTTPS page is blocked outright as mixed content
+ * in the browser and rejected by ATS on iOS, so the terminal simply never
+ * connects and the failure surfaces far from its cause.
+ *
+ * The rule this module enforces, and that a source-text pin keeps enforced: a
+ * TLS-terminated origin can NEVER yield a plaintext `ws:` URL. Downgrading is
+ * always a defect, never an optimisation.
+ */
+
+/** The subset of `window.location` this needs — so it is testable without a DOM. */
+export type WebSocketOrigin = {
+  protocol: string;
+  host: string;
+};
+
+/** Origins that carry TLS. Anything else is treated as plaintext. */
+const SECURE_PAGE_PROTOCOLS = new Set(["https:", "wss:"]);
+
+/**
+ * `wss:` for a TLS-terminated page, `ws:` otherwise.
+ *
+ * Note this reads the PAGE's protocol, which is the thing that actually decides
+ * whether the browser will allow the socket. A loopback desktop shell is http:,
+ * and plain `ws:` there is correct — that is Cave talking to its own sidecar on
+ * 127.0.0.1, not a downgrade.
+ */
+export function websocketProtocolFor(origin: WebSocketOrigin): "ws:" | "wss:" {
+  return SECURE_PAGE_PROTOCOLS.has(origin.protocol.toLowerCase()) ? "wss:" : "ws:";
+}
+
+/** True when the page is TLS-terminated and a plaintext socket would be refused. */
+export function requiresSecureWebsocket(origin: WebSocketOrigin): boolean {
+  return websocketProtocolFor(origin) === "wss:";
+}
+
+/**
+ * Build a same-origin WebSocket URL.
+ *
+ * Same-origin by construction: the host comes from the page rather than the
+ * caller, so no surface can accidentally point a socket carrying Cave's session
+ * at another host.
+ *
+ * @param path      an absolute path such as `/api/pty-ws`
+ * @param params    query parameters, already URL-safe values
+ * @param origin    defaults to `window.location`
+ */
+export function websocketUrl(
+  path: string,
+  params?: URLSearchParams | Record<string, string>,
+  origin: WebSocketOrigin = typeof window === "undefined"
+    ? { protocol: "http:", host: "127.0.0.1" }
+    : window.location,
+): string {
+  if (!path.startsWith("/")) {
+    throw new Error(`websocketUrl expects an absolute path, received: ${path}`);
+  }
+  const search =
+    params === undefined
+      ? ""
+      : `?${params instanceof URLSearchParams ? params : new URLSearchParams(params)}`;
+  return `${websocketProtocolFor(origin)}//${origin.host}${path}${search}`;
+}


### PR DESCRIPTION
Three reliability gaps with one root: **nothing owned a stable address or a stable process.** Plan: `~/.claude/plans/zesty-beaming-rain.md`. Bead: `cave-l3vsw`.

## 1 — Dedicated ports

Nothing agreed on an address. `scripts/dev-app.sh` scanned 3000–3010 for whatever was free; the packaged desktop app called `find_free_port()`, which binds `127.0.0.1:0` and lets the kernel choose, so it took a **different port on every launch**; playwright pinned 3100 on its own; the macOS background daemon scanned its own 3000–3010; iOS hardcoded `:3000`.

A moving port is not just untidy — it leaks into durable state. The mobile pairing secret lives in `mobile-tailscale-${port}`, so a per-launch port meant a per-launch state directory. It is also why `tailscale serve` needs a repair pass to chase the loopback port, and why a GUI→LaunchAgent handoff could move the address out from under a paired phone.

**dev 3000 · production 3020 · e2e 3100**, `COVEN_CAVE_PORT` overriding, then `PORT`. `scripts/ports.mjs` is the source of truth; Rust, Swift and `server.ts` carry pinned copies (`server.ts` cannot import it — esbuild runs `--bundle=false`, so an import must resolve at runtime from wherever `server.mjs` is unpacked, and the bundle ships without `scripts/`). `scripts/port-contract.test.mjs` fails if any copy drifts, which matters most for Swift — **CI never compiles iOS**, so a wrong number there would otherwise reach a device unnoticed.

A busy port is resolved by **identity, not relocation**, because relocating is the behaviour being retired. Dev probes `/api/app/build-info`: ours → attach; stranger → refuse and name the holder; access-gated → refuse rather than guess (a token-armed server answers 401 through `proxy.ts` and cannot be told apart from a stranger). Packaged refuses with an actionable message; attaching is not offered because the app already declines to run a second GUI.

One deliberate exception: the macOS background-availability daemon prefers the dedicated port but keeps the old scan as a last resort. There, not starting is worse than moving — the GUI can show an error, a background daemon cannot, and the serve-repair pass exists to follow it.

## 2 — One place decides `ws:` vs `wss:`

Each surface derived the scheme inline. Both were right; nothing kept the next one right, and the failure is expensive to diagnose — an insecure socket from an HTTPS page is blocked as mixed content and refused by ATS, so the terminal never connects and the error surfaces nowhere near its cause. `src/lib/websocket-url.ts` is now the single decision point, and the host comes from the page rather than the caller so no surface can point a session-bearing socket at another host.

**One planned item was dropped after checking the architecture.** The plan called for refusing a plaintext upgrade carrying forwarded-TLS headers. `tailscale serve` terminates TLS and forwards *plaintext* to loopback, so a paired phone's upgrade legitimately arrives as http/ws **with** `x-forwarded-*` — that rule would have rejected exactly the paired-phone terminal it appears to protect, which is the bug `server.ts`'s scheme-agnostic host match was written to fix. A test now pins that match with the reasoning so it does not get "fixed" into a downgrade check.

## 3 — The familiar revives, and hangs are noticed

The restart coordinator ran `[0, 15s, 60s, 300s]` and then stopped: `if (restartAttempts >= DAEMON_RESTART_BACKOFF_MS.length) return;`. The only thing that cleared that counter was a `running` poll — so in the case that matters, a daemon genuinely gone and unable to return on its own, nothing would ever produce the observation that lets it try again. **Four failures in six minutes and the familiar was down for the session**, nothing further attempted, nothing on screen saying so.

The budget now **refills**: a burst of four with jittered exponential backoff, a long cooldown, then another burst. A crash loop still cannot spin — 400 polls at the real 5s cadence produce single-digit attempts.

And a hung daemon used to read as healthy: `classifyDaemonStatusPoll` distinguishes only "answered" from "did not answer", so one holding its port open while refusing to respond reported as running forever. The signal was already in the data and simply unread — `offline` means the status service *answered* and said nothing is running, a timeout means we never got an answer. A hang is recovered by stop-then-revive, since a bare start is refused by the lock a hung daemon still holds.

`degraded` (reachable but erroring) is surfaced and never restarted: trading a degraded familiar for an absent one is not a recovery.

## Coordination — nothing here takes over live work

- **`cave-9pqt9`** — automatic revives still only act on `offline` + `local`, the status service's own confirmation. Acting on a hang there would mean issuing a stop, and stopping a daemon an external launchd supervisor owns is the exact contention that bead's preflight prevents. The policy can express it; this caller does not use it.
- **`cave-3qas7.6`** (#4318) — owns the runtime startup state machine and readiness handshake. Untouched.
- **`cave-xs4m`** / #3828 — serve-repair left intact as the fallback path's safety net.
- **`cave-j1bo`** — the iOS reconnection supervisor stays there; only the iOS default port and candidate order changed here.

## Deliberately not done

**Nothing respawns the Next sidecar after a successful start** — filed as `cave-qg38n` with the evidence: `has_exited` is consulted only while waiting for readiness, and `retry_sidecar_startup` is `#[cfg(target_os = "windows")]` and manual, so macOS and Linux have no path at all. A respawn must also re-navigate the webview (the URL carries a per-launch auth token), and `cave-3qas7.6` already owns "child crash" and "restart storm" with an active worktree and owner. Filed rather than raced.

## Verification

`tsc --noEmit` clean · `pnpm lint` (design codemod + eslint) clean · `cargo check` clean · `check:tests-wired` 1540 files · `bash -n` on the launcher · new suites (`port-contract`, `dev-port-owner`, `websocket-url`, `familiar-liveness`) and updated ones (`dev-app`, `ios-port-discovery`, `daemon-desktop-auto-start`, `pty-ws-bridge`, `mobile-access-provision`) all pass. Full `test:app` was still running when this was opened; CI is the authority.