### PR TITLE
test(chat): e2e coverage for the sessions list and the earlier-turns fold

### DIFF
--- a/tests/chat-sessions-surface.spec.ts
+++ b/tests/chat-sessions-surface.spec.ts
@@ -69,9 +69,14 @@ async function openSessionsList(page: Page) {
   await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions } }));
   await page.goto("/");
   await page.waitForSelector(".shell-frame", { timeout: 30_000 });
-  await page.evaluate(() =>
-    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } })));
-  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+  await page.waitForFunction(
+    () => {
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } }));
+      return document.querySelector(".chat-surface") !== null;
+    },
+    undefined,
+    { timeout: 30_000 },
+  );
   // The surface lands on the new-chat launcher with Sessions already selected,
   // so clicking that tab fires no onChange. Bounce off Projects to make the
   // router hand back the list.

--- a/tests/chat-sessions-surface.spec.ts
+++ b/tests/chat-sessions-surface.spec.ts
@@ -1,0 +1,163 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * The Sessions list (cave-n3jg2, "Chat Session - Prototype.dc.html").
+ *
+ * The list's model has unit tests (chat-session-status / -activity / -sort) and
+ * its wiring has source-text pins, but nothing asserted that the surface
+ * behaves. These do. Behavioural only — cave-oqawv spent a night repairing five
+ * stale source pins, not one of which had ever caught a real defect.
+ */
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+const iso = (minAgo: number) => new Date(Date.now() - minAgo * 60_000).toISOString();
+
+type Seed = {
+  id: string;
+  title: string;
+  status: string;
+  ago: number;
+  born: number;
+  branch?: string;
+  diff?: { additions: number; deletions: number };
+};
+
+/** Chosen so every band and every chip has a known population:
+ *  running x1 (Active now), completed x2 (today + older), failed x1 (yesterday). */
+const SEEDS: Seed[] = [
+  { id: "s-run", title: "Prune the merged worktrees", status: "running", ago: 0, born: 40, branch: "main", diff: { additions: 53, deletions: 6 } },
+  { id: "s-done-today", title: "Worktree and branch cleanup", status: "completed", ago: 45, born: 170, branch: "main", diff: { additions: 102, deletions: 0 } },
+  { id: "s-fail", title: "Diagnose the failed CI workflow", status: "failed", ago: 1_500, born: 1_560, branch: "fix/ci" },
+  { id: "s-done-old", title: "Optimize the image pipeline", status: "completed", ago: 13_000, born: 13_100, branch: "perf/images" },
+];
+
+const sessions = SEEDS.map((s) => ({
+  id: s.id,
+  project_root: "/repo",
+  harness: "copilot",
+  model: "github/gpt-5",
+  title: s.title,
+  status: s.status,
+  exit_code: null,
+  archived_at: null,
+  created_at: iso(s.born),
+  updated_at: iso(s.ago),
+  familiarId: FAMILIAR.id,
+  workBranch: s.branch ?? null,
+  diff: s.diff ?? null,
+  hasLocalConversation: true,
+}));
+
+const rows = (page: Page) => page.locator(".chat-session-card");
+const chip = (page: Page, name: string) =>
+  page.locator(".chat-status-chip").filter({ hasText: new RegExp(`^${name}`) }).first();
+const bands = (page: Page) => page.locator(".chat-activity-header__label");
+
+async function openSessionsList(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:active-familiar", "nova");
+  });
+  await page.route("**/api/familiars**", (r) => r.fulfill({ json: { ok: true, familiars: [FAMILIAR] } }));
+  await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions } }));
+  await page.goto("/");
+  await page.waitForSelector(".shell-frame", { timeout: 30_000 });
+  await page.evaluate(() =>
+    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } })));
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+  // The surface lands on the new-chat launcher with Sessions already selected,
+  // so clicking that tab fires no onChange. Bounce off Projects to make the
+  // router hand back the list.
+  const tab = (re: RegExp) => page.locator('.chat-scope-tabs [role="tab"]', { hasText: re }).first();
+  await tab(/projects/i).click();
+  await tab(/sessions/i).click();
+  await expect(rows(page).first()).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("sessions list", () => {
+  test.beforeEach(async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name !== "desktop", "the list's card layout is desktop-only (min-width: 768px)");
+    await openSessionsList(page);
+  });
+
+  test("status chips filter the list and count what the search found", async ({ page }) => {
+    await expect(rows(page)).toHaveCount(SEEDS.length);
+
+    // Each chip carries its own count, so "what failed?" is legible before you
+    // press anything.
+    await expect(chip(page, "All")).toContainText(String(SEEDS.length));
+    await expect(chip(page, "Running")).toContainText("1");
+    await expect(chip(page, "Completed")).toContainText("2");
+    await expect(chip(page, "Failed")).toContainText("1");
+
+    await chip(page, "Failed").click();
+    await expect(chip(page, "Failed")).toHaveAttribute("aria-pressed", "true");
+    await expect(rows(page)).toHaveCount(1);
+    await expect(rows(page).first()).toContainText("Diagnose the failed CI workflow");
+
+    // The counts are drawn from the SEARCHED set, not the filtered one — so
+    // pressing one chip must not renumber the others. Without this the numbers
+    // would collapse to "1 and zeroes" the moment you filtered.
+    await expect(chip(page, "Completed")).toContainText("2");
+    await expect(chip(page, "All")).toContainText(String(SEEDS.length));
+
+    await chip(page, "All").click();
+    await expect(rows(page)).toHaveCount(SEEDS.length);
+  });
+
+  test("running work floats into Active now regardless of when it started", async ({ page }) => {
+    const labels = await bands(page).allTextContents();
+    expect(labels.map((l) => l.trim().toLowerCase())).toContain("active now");
+
+    // The running session is the first row: its band leads the list, which is
+    // the whole point — live work is always in the same place.
+    await expect(rows(page).first()).toContainText("Prune the merged worktrees");
+
+    // Its own band header reports how many rows sit under it.
+    const activeHeader = page.locator('.chat-activity-header[data-bucket="active"]');
+    await expect(activeHeader).toBeVisible();
+    await expect(activeHeader.locator(".chat-activity-header__count")).toHaveText("1");
+  });
+
+  test("a row reports its own branch, a labelled state, and how long it ran", async ({ page }) => {
+    const running = rows(page).first();
+
+    // The status is a LABEL, not just a tint — colour is never the only channel.
+    await expect(running.locator(".chat-session-pill")).toContainText(/running/i);
+    await expect(running.locator(".chat-session-pill")).toHaveAttribute("data-state", "running");
+
+    // The session's OWN working branch, never the checkout's current one.
+    await expect(running.locator(".chat-session-branch")).toContainText("main");
+
+    // Elapsed time, and the working-tree delta the session produced.
+    await expect(running.locator(".chat-session-stat").first()).toHaveText(/\d/);
+    await expect(running.locator('.chat-session-stat[data-kind="adds"]')).toContainText("53");
+
+    // A failed run wears a danger spine as well as its pill, so the state
+    // survives a colour-blind read as a shape.
+    const failed = rows(page).filter({ hasText: "Diagnose the failed CI workflow" }).first();
+    await expect(failed).toHaveAttribute("data-status", "failed");
+  });
+
+  test("the list never presents an order it has not named", async ({ page }) => {
+    // Default: recency, which is the order that earns activity bands.
+    await expect(page.locator(".chat-sessions-sort")).toContainText("Recent activity");
+    await expect(bands(page).first()).toHaveText(/active now/i);
+
+    await page.locator(".chat-sessions-sort").click();
+    await page.getByRole("menuitemradio", { name: "Oldest" }).click();
+
+    await expect(page.locator(".chat-sessions-sort")).toContainText("Oldest");
+    // A flat order drops the bands for a single named heading, so the reading
+    // order and the header always agree.
+    await expect(bands(page).first()).toHaveText(/oldest first/i);
+    await expect(rows(page).first()).toContainText("Optimize the image pipeline");
+  });
+});

--- a/tests/chat-transcript-fold.spec.ts
+++ b/tests/chat-transcript-fold.spec.ts
@@ -1,0 +1,172 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * The earlier-turns fold (cave-u5lq7, "Chat Session - Prototype.dc.html").
+ *
+ * The fold's model has unit tests (src/lib/chat-transcript-fold.test.ts) and the
+ * wiring has source-text pins, but neither can tell you the control actually
+ * works — a source pin asserts that code LOOKS a certain way and goes stale the
+ * moment something is renamed. cave-oqawv had to repair five such pins in one
+ * night, none of which had ever caught a defect. These assertions are
+ * behavioural on purpose.
+ */
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+const SESSION_ID = "fold-e2e";
+const iso = (minAgo: number) => new Date(Date.now() - minAgo * 60_000).toISOString();
+
+/** 7 exchanges = 14 turns = 14 groups. The fold keeps 6 groups, so 8 turns hide. */
+const TURNS = Array.from({ length: 7 }).flatMap((_, i) => [
+  {
+    id: `u${i}`,
+    parentId: i === 0 ? null : `a${i - 1}`,
+    role: "user",
+    text: `Question ${i + 1} about the worktree sweep.`,
+    createdAt: iso(400 - i * 20),
+  },
+  {
+    id: `a${i}`,
+    parentId: `u${i}`,
+    role: "assistant",
+    text: `Answer ${i + 1}. Prose long enough to occupy a row in the reading column.`,
+    createdAt: iso(399 - i * 20),
+  },
+]);
+
+const SESSION = {
+  id: SESSION_ID,
+  project_root: "/repo",
+  harness: "copilot",
+  model: "github/gpt-5",
+  title: "A thread long enough to fold",
+  status: "completed",
+  exit_code: null,
+  archived_at: null,
+  created_at: iso(420),
+  updated_at: iso(1),
+  familiarId: FAMILIAR.id,
+  hasLocalConversation: true,
+};
+
+const foldPill = (page: Page) => page.locator(".cave-chat-fold__pill");
+const turns = (page: Page) => page.locator("[data-turn-id]");
+
+async function openFoldedThread(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:active-familiar", "nova");
+  });
+  // CI runs daemon-less (COVEN_CAVE_E2E=1): every surface is driven from mocks.
+  await page.route("**/api/familiars**", (r) => r.fulfill({ json: { ok: true, familiars: [FAMILIAR] } }));
+  await page.route("**/api/sessions/list**", (r) => r.fulfill({ json: { ok: true, sessions: [SESSION] } }));
+  await page.route("**/api/chat/conversation/**", (r) =>
+    r.request().method() === "GET"
+      ? r.fulfill({
+          json: {
+            ok: true,
+            conversation: { sessionId: SESSION_ID, familiarId: FAMILIAR.id, turns: TURNS, activeLeafId: "a6" },
+            context: null,
+          },
+        })
+      : r.fulfill({ json: { ok: true } }),
+  );
+  await page.goto("/");
+  await page.waitForSelector(".shell-frame", { timeout: 30_000 });
+  // cave:agents-open-session is handled by ChatSurface, so the surface has to
+  // be MOUNTED before the event is dispatched — the app boots on home, where
+  // that listener does not exist yet and the event lands on nothing.
+  await page.evaluate(() =>
+    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } })));
+  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+  await page.evaluate((id) =>
+    window.dispatchEvent(
+      new CustomEvent("cave:agents-open-session", { detail: { sessionId: id, familiarId: "nova" } }),
+    ), SESSION_ID);
+  await expect(turns(page).first()).toBeVisible({ timeout: 30_000 });
+}
+
+test.describe("earlier-turns fold", () => {
+  test("a long thread opens folded, names what it hides, and reveals every turn", async ({ page }) => {
+    await openFoldedThread(page);
+
+    // Closed: only the recent exchange is mounted, and the pill counts TURNS —
+    // not groups. Counting groups would print "1 earlier turn" over a fold
+    // hiding a whole voice call.
+    const foldedCount = await turns(page).count();
+    expect(foldedCount, "a closed fold mounts only the kept tail").toBeLessThan(TURNS.length);
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
+    await expect(foldPill(page)).toContainText(`${TURNS.length - foldedCount} earlier`);
+
+    // The accessible name is a sentence, not the terse mono chrome.
+    await expect(foldPill(page)).toHaveAttribute("aria-label", /^Show \d+ earlier turns?$/);
+
+    // Open: every turn is reachable, and the label names the way back rather
+    // than continuing to claim turns are hidden while they are on screen.
+    await foldPill(page).click();
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true");
+    await expect(turns(page)).toHaveCount(TURNS.length);
+    await expect(foldPill(page)).toContainText("hide earlier turns");
+    await expect(foldPill(page)).toHaveAttribute("aria-label", "Hide earlier turns");
+
+    // And it folds back, so the control is a toggle rather than a one-way door.
+    await foldPill(page).click();
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
+    await expect(turns(page)).toHaveCount(foldedCount);
+  });
+
+  test("the caret inverts with the fold rather than pointing one way forever", async ({ page }) => {
+    await openFoldedThread(page);
+    const caret = page.locator(".cave-chat-fold__caret");
+
+    // Closed the caret points DOWN (press to reveal); open it points UP (press
+    // to fold away). This shipped broken once: the rotation was driven by a
+    // data-prop on <Icon>, which forwards only aria-*/role, so the attribute
+    // was dropped and the open pill read "hide earlier turns" beside a caret
+    // still pointing down — the control contradicting its own label.
+    // Poll rather than read once: the caret has a transform TRANSITION, so the
+    // computed style still reports the previous value for a frame after
+    // aria-expanded flips. Reading immediately caught the old matrix and made
+    // a working caret look frozen.
+    const transform = () => caret.evaluate((el) => getComputedStyle(el).transform);
+    const ROTATED_180 = "matrix(-1, 0, 0, -1, 0, 0)";
+
+    await expect
+      .poll(transform, { message: "closed, the caret points down (press to reveal)" })
+      .toBe(ROTATED_180);
+
+    await foldPill(page).click();
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true");
+
+    // Open, the rotation is dropped entirely — the caret points up, at what the
+    // press now does.
+    await expect
+      .poll(transform, { message: "open, the caret points up (press to fold away)" })
+      .not.toBe(ROTATED_180);
+  });
+
+  test("opening find clears the fold so a hit in a hidden turn is reachable", async ({ page }) => {
+    await openFoldedThread(page);
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "false");
+    expect(await turns(page).count(), "starts folded").toBeLessThan(TURNS.length);
+
+    // Find searches the WHOLE transcript and jumps by resolving [data-turn-id]
+    // in the DOM. With the fold closed, a hit in a folded turn would be
+    // reported and then jump nowhere, because that row was never rendered.
+    // Find therefore has to clear the fold as well as the render cap.
+    await page.keyboard.press(process.platform === "darwin" ? "Meta+f" : "Control+f");
+
+    await expect(foldPill(page)).toHaveAttribute("aria-expanded", "true", { timeout: 10_000 });
+    await expect(turns(page)).toHaveCount(TURNS.length);
+
+    // The oldest turn — the one furthest behind the fold — is now addressable,
+    // which is the property the jump depends on.
+    await expect(page.locator('[data-turn-id="u0"]')).toHaveCount(1);
+  });
+});

--- a/tests/chat-transcript-fold.spec.ts
+++ b/tests/chat-transcript-fold.spec.ts
@@ -82,9 +82,14 @@ async function openFoldedThread(page: Page) {
   // cave:agents-open-session is handled by ChatSurface, so the surface has to
   // be MOUNTED before the event is dispatched — the app boots on home, where
   // that listener does not exist yet and the event lands on nothing.
-  await page.evaluate(() =>
-    window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } })));
-  await page.waitForSelector(".chat-surface", { timeout: 30_000 });
+  await page.waitForFunction(
+    () => {
+      window.dispatchEvent(new CustomEvent("cave:navigate-mode", { detail: { mode: "chat" } }));
+      return document.querySelector(".chat-surface") !== null;
+    },
+    undefined,
+    { timeout: 30_000 },
+  );
   await page.evaluate((id) =>
     window.dispatchEvent(
       new CustomEvent("cave:agents-open-session", { detail: { sessionId: id, familiarId: "nova" } }),


### PR DESCRIPTION
Closes cave-b76tb.

The Sessions list (cave-n3jg2) and the earlier-turns fold (cave-u5lq7) both
landed with unit tests for their models and source-text pins for their wiring.
Neither could tell you the surface actually works. A source pin asserts that
code *looks* a certain way and goes stale the moment something is renamed —
cave-oqawv spent a night repairing five such pins, none of which had ever
caught a defect. These seven tests are behavioural only.

## What they assert

**The fold** (`tests/chat-transcript-fold.spec.ts`)
- A long thread opens folded, and the pill counts **turns, not groups**.
  Counting groups would print "1 earlier turn" over a fold hiding a whole
  voice call. Opening reveals every turn; it folds back, so it is a toggle
  rather than a one-way door.
- The caret **inverts** with the fold. This shipped broken once: the rotation
  was driven by a `data-` prop on `<Icon>`, which forwards only `aria-*` and
  `role`, so the open pill read "hide earlier turns" beside a caret still
  pointing down — the control contradicting its own label.
- **Find clears the fold.** Find searches the whole transcript and jumps by
  resolving `[data-turn-id]` in the DOM, so a hit in a folded turn would be
  reported and then jump nowhere.

**The list** (`tests/chat-sessions-surface.spec.ts`)
- Status chips filter, and their counts stay drawn from the **searched** set —
  without that the numbers collapse to "1 and zeroes" the moment you filter.
- Running work floats into **Active now** regardless of when it started.
- A row reports its **own** working branch, a labelled state (not just a tint),
  and how long it ran.
- The sort menu renames its heading, so the list never presents an order it
  has not named.

## Verification

Every assertion was checked to bite, not just to pass:

| mutation | result |
|---|---|
| `CHAT_FOLD_KEEP_GROUPS = 999` (fold never engages) | all 3 fold tests fail |
| `filterChatRowsByStatus` → identity | chips test fails |
| running no longer forced to `active` | bands test fails |
| `"Oldest first"` heading renamed | sort test fails |

The row-chrome test is untargeted by those mutations and keeps passing, which
is the control. All constants restored; `git status` clean apart from the two
new specs.

7/7 pass locally single-worker. `pnpm lint` and `pnpm typecheck` clean.

⚠️ Note for anyone running these locally: the specs are additive and touch no
source. A 7-worker local run fails all of them at `page.goto` — that is
`next dev` cold-compile contention against a 60s test timeout, not the specs.
CI pins `workers: 2`.

Daemon-less per the E2E contract (`COVEN_CAVE_E2E=1`): onboarding dismissed via
localStorage, every surface driven from `page.route` mocks.