### PR TITLE
docs(worktree): treat incomplete lifecycle inventory as transient

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,9 @@
 
     So the order is **check quota → rerun → only then fall back**. Genuinely
     structural failures name the repository itself (`canonical repository
-    identity mismatch`, `canonical repository identity changed`); those do not
-    improve with a retry. Reach for the fallback only after a retry failed:
+    identity mismatch`, `canonical repository identity changed between pages`);
+    those do not improve with a retry. Reach for the fallback only after a
+    retry failed:
 
     ```bash
     git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,13 +40,24 @@
     Bead alongside the worktree, so the unit still lands with full lifecycle metadata
     and stays retirable — this is a sanctioned path, not a bypass.
   - **Exit 1 — errored because the lifecycle inventory is incomplete.** The command
-    could not build a **complete** inventory, which needs live GitHub queries, so
-    it fails when the GraphQL quota is exhausted (`API rate limit already
-    exceeded`) and when any commit's PR association comes back malformed (`pull
-    request node returned malformed fields or a mismatched head OID`) — a
-    repo-state condition no amount of waiting clears. An exception cannot rescue
-    this: the inventory throws before admission is ever assessed. Only here is
-    the fallback justified:
+    could not build a **complete** inventory, which needs live GitHub queries. An
+    exception cannot rescue this: the inventory throws before admission is ever
+    assessed. **Almost every exit 1 is transient — retry before you conclude
+    otherwise.** Two failures dominate, and both clear on their own:
+    - the GraphQL quota is exhausted (`API rate limit already exceeded`) — that
+      pool is separate from REST and refills hourly, so `gh api rate_limit --jq
+      .resources.graphql` tells you when to retry;
+    - a commit's PR association comes back malformed or absent (`commit
+      association connection is unavailable`, `pull request node returned
+      malformed fields or a mismatched head OID`) — usually a degraded or
+      throttled GitHub response rather than repository state. Observed
+      2026-08-06: a warning of exactly this shape vanished on a rerun minutes
+      later, once quota had recovered, with nothing else changed.
+
+    So the order is **check quota → rerun → only then fall back**. Genuinely
+    structural failures name the repository itself (`canonical repository
+    identity mismatch`, `canonical repository identity changed`); those do not
+    improve with a retry. Reach for the fallback only after a retry failed:
 
     ```bash
     git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -325,10 +325,10 @@ any repository change:
   after the reset rather than working around it.
 - **A commit's PR association came back malformed or absent** — `commit
   association connection is unavailable`, or `malformed fields or a mismatched
-  head OID`. This reads structural but usually is not: the inventory raises the
-  first message whenever GitHub simply returns no commit object
-  (`worktree-lifecycle-inventory.ts:858`), which is what a degraded or throttled
-  response looks like. Observed 2026-08-06 — a `pnpm beads:worktrees` run
+  head OID`. This reads structural but usually is not: the inventory throws
+  `commit association connection is unavailable` whenever GitHub simply returns
+  no commit object, which is what a degraded or throttled response looks like.
+  Observed 2026-08-06 — a `pnpm beads:worktrees` run
   emitted exactly that warning, and a rerun minutes later, after quota recovered
   from ~1k to ~2.9k remaining, reported `probe warnings: 0` and `ok: true` with
   nothing else changed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -307,18 +307,37 @@ the patrol reports `exceeded` as `count > 20`, while creation refuses at
 the patrol is quiet and creation is refused; that is "*would* exceed", not an
 off-by-one.
 
-**Exit 1 — the command could not run. Fallback is the only option.**
+**Exit 1 — the command could not run. Retry first; the fallback is a last resort.**
 
 ```text
 worktree-lifecycle-create: lifecycle inventory is incomplete: …
 ```
 
 It builds a *complete* lifecycle inventory first, which needs live GitHub
-queries, so it fails when the GraphQL quota is exhausted and when any commit's PR
-association returns `malformed fields or a mismatched head OID` — the latter is
-repo state, not a transient, so waiting does not clear it. Both were hit on
-2026-08-03. An exception cannot rescue this: the inventory throws *before*
+queries. An exception cannot rescue this: the inventory throws *before*
 admission is assessed, so the exception is never consulted.
+
+**Almost every exit 1 is transient.** The two common causes both clear without
+any repository change:
+
+- **GraphQL quota exhausted.** That pool is separate from REST and refills
+  hourly. Check it with `gh api rate_limit --jq .resources.graphql` and retry
+  after the reset rather than working around it.
+- **A commit's PR association came back malformed or absent** — `commit
+  association connection is unavailable`, or `malformed fields or a mismatched
+  head OID`. This reads structural but usually is not: the inventory raises the
+  first message whenever GitHub simply returns no commit object
+  (`worktree-lifecycle-inventory.ts:858`), which is what a degraded or throttled
+  response looks like. Observed 2026-08-06 — a `pnpm beads:worktrees` run
+  emitted exactly that warning, and a rerun minutes later, after quota recovered
+  from ~1k to ~2.9k remaining, reported `probe warnings: 0` and `ok: true` with
+  nothing else changed.
+
+Failures that really are structural name the repository identity instead —
+`canonical repository identity mismatch`, `canonical repository identity
+changed between pages` — and a retry will not help those.
+
+So: **check quota, rerun, and only then** consider
 
 ```bash
 git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort


### PR DESCRIPTION
Closes cave-yja0c.

## The defect

`AGENTS.md` and `CLAUDE.md` both told agents that when `worktree-lifecycle-create` fails on a malformed PR association, it is **"a repo-state condition no amount of waiting clears"**, and CLAUDE.md headed the section **"Fallback is the only option."**

Both then send the reader to:

```bash
git worktree add -b <branch> .worktrees/<branch> origin/main
```

The same docs explain what that costs: a worktree made this way has no lifecycle metadata, so the patrol classes it `uncertain` **permanently** and `pnpm beads:worktrees:apply` can never retire it (`allowLegacyMissingMetadata` is hard-coded `false`). So the guidance converted a transient GitHub hiccup into unretirable local state.

## Evidence it is transient

A `pnpm beads:worktrees` run on 2026-08-06 emitted:

```
probe warning: associated PR inventory returned malformed data for f6f0f0dc0c81…:
commit association connection is unavailable
```

A rerun minutes later — after the GraphQL pool recovered from ~1k to ~2.9k remaining — reported `probe warnings: 0` and `ok: true`, with no other change.

The code agrees. `scripts/worktree-lifecycle-inventory.ts:858` raises that message whenever `repository.object` is simply not a record, i.e. GitHub returned no commit object. That is a degraded or throttled response, not repository state. The genuinely structural checks sit right beside it and name the repository instead (`canonical repository identity mismatch` at :852, `canonical repository identity changed between pages` at :855).

## The change

Docs-only. Both files now:

- order the response as **check quota → rerun → fall back only after a retry failed**;
- point at `gh api rate_limit --jq .resources.graphql` (a separate pool from REST, refills hourly);
- **separate the transient failure family from the structural one**, so a reader can tell which they are holding.

## Contract preserved

`branch-curator-manual-cleanup-contract.test.mjs` pins this exact section. Exit 1 still documents `lifecycle inventory is incomplete`, that an exception cannot rescue it, and the `git worktree add -b` fallback; exit 2 still carries the exception recipe and still contains no fallback.

```
ℹ tests 5   ℹ pass 5   ℹ fail 0
```