### PR TITLE
fix(dev-app): resolve the dev port without ANSI colour contamination

### DIFF
--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -37,7 +37,22 @@ origin_is_ready() {
 }
 
 # The dedicated dev port, honouring COVEN_CAVE_PORT then PORT.
-dev_port="$(node -e "import('./scripts/ports.mjs').then((m) => console.log(m.resolvePort('dev', process.env)))")"
+#
+# Write the digits directly instead of console.log'ing the Number: console.log
+# renders a Number through util.inspect, which wraps it in ANSI colour codes
+# whenever FORCE_COLOR is set. Agent harnesses and many CI runners set it, and
+# those escapes survive command substitution — the contaminated value then
+# reaches --port, fails dev-app-origin-health's /^\d+$/ check, and the launcher
+# dies instantly while reporting a readiness timeout it never actually waited
+# for. Strings are not colourised; Numbers are.
+dev_port="$(node -e "import('./scripts/ports.mjs').then((m) => process.stdout.write(String(m.resolvePort('dev', process.env))))")"
+case "$dev_port" in
+  ''|*[!0-9]*)
+    echo "[dev:app] ERROR: resolved dev port is not numeric: $(printf '%q' "$dev_port")" >&2
+    echo "[dev:app]        Something is decorating this command's stdout (FORCE_COLOR, a shell wrapper, a Node loader)." >&2
+    exit 1
+    ;;
+esac
 if [ -n "${COVEN_CAVE_PORT:-}" ] || [ -n "${PORT:-}" ]; then
   echo "[dev:app] using overridden port ${dev_port}"
 else

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -1,11 +1,11 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const source = readFileSync(
-  fileURLToPath(new URL("./dev-app.sh", import.meta.url)),
-  "utf8",
-);
+const scriptsDir = path.dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(path.join(scriptsDir, "dev-app.sh"), "utf8");
 
 assert.match(
   source,
@@ -24,6 +24,36 @@ assert.doesNotMatch(
   source,
   /for candidate in \$\(seq 3000 3010\)/,
   "the free-port scan is retired — a dedicated port that relocates is not dedicated",
+);
+
+// The captured port must be bare digits under FORCE_COLOR. `console.log` on a
+// Number renders through util.inspect, which colourises it; the ANSI escapes
+// survive command substitution, fail dev-app-origin-health's /^\d+$/ port
+// check, and make the launcher exit instantly while blaming a readiness
+// timeout it never waited for. Agent harnesses and CI runners set FORCE_COLOR
+// routinely, so run the launcher's own capture rather than trusting its shape.
+const portCapture = source.match(/^dev_port="\$\((node -e "[\s\S]*?")\)"$/m);
+assert.ok(portCapture, "the launcher must capture its dev port from a node one-liner");
+const capturedPort = execFileSync("bash", ["-c", portCapture[1]], {
+  cwd: path.dirname(scriptsDir),
+  encoding: "utf8",
+  env: { ...process.env, FORCE_COLOR: "3", COVEN_CAVE_PORT: "", PORT: "" },
+});
+// Trailing newlines are what command substitution itself strips, so trim to
+// assert the contract the launcher actually depends on rather than pinning
+// whether the one-liner happens to terminate its line.
+assert.match(
+  capturedPort.trim(),
+  /^\d+$/,
+  "the resolved dev port must be bare digits even when FORCE_COLOR decorates Node's output",
+);
+
+// A port that does arrive decorated has to say so. Silently handing it to the
+// readiness probe is what disguised this as an intermittent bind timeout.
+assert.match(
+  source,
+  /dev_port="\$\([\s\S]*?\)"\s*case "\$dev_port" in[\s\S]*?\|\*\[!0-9\]\*\)[\s\S]*?exit 1/,
+  "a non-numeric resolved port must fail loudly at capture, not downstream",
 );
 // Busy is answered by identity, not by moving: attach to our own dev server,
 // refuse anything else by name.


### PR DESCRIPTION
## The bug

`scripts/dev-app.sh` captured its dev port with:

```bash
dev_port="$(node -e "import('./scripts/ports.mjs').then((m) => console.log(m.resolvePort('dev', process.env)))")"
```

`console.log` renders a **Number** through `util.inspect`, which colourises it whenever `FORCE_COLOR` is set — agent harnesses and many CI runners set it routinely. So the capture returned `$'\e[33m3000\e[39m'`, not `3000`, and the escapes survived command substitution into every later use of `$dev_port`.

```
$ FORCE_COLOR=3 node -e 'console.log(3000)' | cat -v
^[[33m3000^[[39m
$ FORCE_COLOR=3 node -e 'console.log(String(3000))' | cat -v
3000
```

## Why it was misdiagnosed twice

`dev-app-origin-health.mjs` validates `--port` with `/^\d+$/`. A decorated port makes `cliArgs` return `null`, so the probe exits 1 **immediately**. The launcher then prints:

```
[dev:app] loopback origin on 127.0.0.1:<port> did not return the root document within 2s; desktop shell was not opened
```

That reads as a readiness timeout, but a `bash -x` trace shows it raised at **+0.1s**, having never waited at all — `origin_is_ready` swallows stdout and stderr, so a usage error is indistinguishable from an unready origin.

This was filed twice as a timing flake (cave-h73ee, cave-voglb). The suggested fix in both — raise the `waitFor` deadline — could not have worked, because no deadline was ever reached. It also explains the reported environment-dependence exactly: fails locally, green in CI, because CI does not set `FORCE_COLOR`.

**`pnpm dev:app` is broken the same way** in any `FORCE_COLOR` environment; the desktop shell never opens. That is the larger half of this bug — the failing test was the symptom that surfaced it.

## The fix

- Emit the port with `process.stdout.write(String(...))`. Strings are not colourised; Numbers are.
- Reject a non-numeric `$dev_port` at the point of capture, so a future decorator fails loudly instead of as a readiness timeout twenty seconds downstream.

## Verification

| | before | after |
|---|---|---|
| `node scripts/dev-app-teardown.test.mjs` | fails 3/3 | passes 3/3 |
| `pnpm typecheck` | clean | clean |
| `pnpm lint` | clean | clean |

The regression test is behavioural, not shape-based: it extracts the launcher's own one-liner from `dev-app.sh` and runs it under `FORCE_COLOR=3`, so it cannot drift from the script. Confirmed non-vacuous — restoring the old capture fails it with `actual: '\x1B[33m3000\x1B[39m\n'`.

## Scope

Every other `node` capture in `scripts/` emits a String (`process.platform`, `process.arch`, `encodeURIComponent`, `url.toString()`, `sidecar-target.mjs --sh`) and is unaffected. This was the only numeric one.

Fixes cave-h73ee. Closes cave-voglb as a duplicate.