### PR TITLE
feat(proxy): authorize remote access by tailnet device identity

### DIFF
--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -2,6 +2,9 @@
 
 This runs CovenCave's browser surface on your development machine and exposes it privately to your phone through Tailscale Serve with a short-lived mobile invite.
 
+For a device you own, you can skip the invite entirely — see
+[Tokenless access by tailnet device identity](#tokenless-access-by-tailnet-device-identity).
+
 ## Requirements
 
 - Tailscale installed and signed in on the development machine.
@@ -139,6 +142,62 @@ Do not run CovenCave with `-H 0.0.0.0` for mobile access. Binding to all interfa
 ```bash
 pnpm mobile:tailscale:stop
 ```
+
+## Tokenless access by tailnet device identity
+
+The invite flow authorizes a phone with a **shared bearer secret** that you copy,
+deep-link, or scan. It works, but the secret is transferable: anything that
+learns it is you. For a device you own, you can authorize the *device itself*
+instead and stop minting invites.
+
+Find the stable node ID of the devices you want to admit:
+
+```bash
+node scripts/tailnet-allowlist.mjs                  # list every visible device
+node scripts/tailnet-allowlist.mjs my-phone        # emit the env line for one
+```
+
+Then start the server with that allowlist:
+
+```bash
+COVEN_CAVE_TAILNET_ALLOWED_NODES=nEXAMPLE0000011CNTRL pnpm dev
+```
+
+That device now reaches the app over Tailscale Serve with no token at all. Every
+other tailnet node is refused, so this is *not* the old "anyone on the tailnet"
+behavior — tailnet membership alone has never been authorization here, and still
+isn't.
+
+**How it is enforced.** `server.ts` is the only component that sees the raw TCP
+socket. It resolves the forwarded tailnet address against a `tailscale status`
+poll (refreshed every 30s), checks the resulting stable node ID against the
+allowlist, and stamps a header signed with a per-boot secret that never leaves
+the process. `proxy.ts` verifies that stamp in constant time. Any client-supplied
+copy of the header is deleted before Next ever sees the request, so the stamp
+cannot be forged from outside.
+
+**Why the forwarded address is trusted here.** The TCP peer must already be
+loopback, because Tailscale Serve terminates TLS and forwards to `127.0.0.1`. A
+local process able to forge the forwarded-for header could instead connect
+straight to loopback, which grants strictly *more* authority. So reading it adds
+no new exposure while upgrading remote auth from a shared secret to WireGuard
+device identity.
+
+**Fail-closed behavior.** No allowlist means no tailnet access. An unreadable
+`tailscale status` clears the allowlist rather than leaving stale entries, so a
+revoked device loses access instead of coasting on a cached mapping. Revoking a
+device takes at most one refresh interval.
+
+**Notes and limits.**
+
+- Stable node IDs are used deliberately: hostnames and tailnet IPs both move,
+  node IDs survive renames, IP changes, and re-authentication.
+- Local-only surfaces (Codex automation runs) stay off this path exactly as they
+  stay off the invite path — a forwarded Host cannot prove a loopback origin.
+- This authorizes a **device**, not a person. Anyone holding an unlocked
+  allowlisted phone is that device. Pair it with the device's own biometric lock,
+  and see `cave-brksh` for making that lock a fact the server can verify rather
+  than a client-side claim.
 
 ## Troubleshooting
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -965,6 +965,7 @@ export const SUITES = {
     "src/components/labels-and-live-regions.test.ts",
     "src/components/workspace-inspector-mount.test.ts",
     "src/middleware.test.ts",
+    "src/tailnet-identity.test.ts",
     "src/lib/font-settings.test.ts",
     "src/lib/font-wiring.test.ts",
     "src/lib/cave-config.test.ts",

--- a/scripts/tailnet-allowlist.mjs
+++ b/scripts/tailnet-allowlist.mjs
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+//
+// Lists the tailnet devices this machine can see, with the stable node IDs the
+// tailnet identity gate (cave-zm6pn) admits, and prints the env line to set.
+//
+//   node scripts/tailnet-allowlist.mjs                 # list devices
+//   node scripts/tailnet-allowlist.mjs my-phone my-laptop   # emit env for these
+//
+// Match is by prefix against the device's short DNS name or hostname, so
+// `my-phone` is enough. Stable node IDs are what the gate stores because they
+// survive IP changes, renames, and re-authentication — a hostname or IP does
+// not.
+
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const TAILSCALE_BIN = process.env.COVEN_CAVE_TAILSCALE_BIN ?? "tailscale";
+
+function shortName(peer) {
+  const dns = (peer.DNSName ?? "").replace(/\.$/, "");
+  return dns.split(".")[0] || peer.HostName || "";
+}
+
+async function main() {
+  let status;
+  try {
+    const { stdout } = await execFileAsync(TAILSCALE_BIN, ["status", "--json"], {
+      maxBuffer: 16 * 1024 * 1024,
+    });
+    status = JSON.parse(stdout);
+  } catch (err) {
+    console.error(`tailnet-allowlist: could not read tailscale status: ${err?.message ?? err}`);
+    console.error("Is Tailscale running? Set COVEN_CAVE_TAILSCALE_BIN if it is not on PATH.");
+    process.exit(1);
+  }
+
+  const peers = Object.values(status.Peer ?? {})
+    .map((peer) => ({
+      id: peer.ID,
+      name: shortName(peer),
+      os: peer.OS ?? "",
+      online: Boolean(peer.Online),
+      ips: peer.TailscaleIPs ?? [],
+    }))
+    .filter((peer) => peer.id)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  const wanted = process.argv.slice(2);
+  if (wanted.length === 0) {
+    if (peers.length === 0) {
+      console.log("No tailnet peers visible.");
+      return;
+    }
+    console.log("Tailnet devices (stable node ID is what the allowlist stores):\n");
+    for (const peer of peers) {
+      const mark = peer.online ? "●" : "○";
+      const os = peer.os ? ` ${peer.os}` : "";
+      console.log(`  ${mark} ${peer.name.padEnd(24)} ${peer.id}${os}`);
+      console.log(`    ${peer.ips.join("  ")}`);
+    }
+    console.log("\n● online  ○ offline");
+    console.log("\nTo allow specific devices, re-run with their names:");
+    console.log(`  node scripts/tailnet-allowlist.mjs ${peers[0].name}`);
+    return;
+  }
+
+  const selected = [];
+  const missing = [];
+  for (const want of wanted) {
+    const match = peers.find(
+      (peer) => peer.name === want || peer.name.startsWith(want) || peer.id === want,
+    );
+    if (match) selected.push(match);
+    else missing.push(want);
+  }
+
+  if (missing.length > 0) {
+    console.error(`tailnet-allowlist: no tailnet device matched: ${missing.join(", ")}`);
+    console.error("Run with no arguments to list what is visible.");
+    process.exit(1);
+  }
+
+  for (const peer of selected) {
+    console.error(`# ${peer.name} -> ${peer.id}`);
+  }
+  console.log(`COVEN_CAVE_TAILNET_ALLOWED_NODES=${selected.map((peer) => peer.id).join(",")}`);
+}
+
+await main();

--- a/server.mjs
+++ b/server.mjs
@@ -1,14 +1,17 @@
+import { execFile } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { getHeapStatistics, writeHeapSnapshot } from "node:v8";
 import next from "next";
 import { WebSocket, WebSocketServer } from "ws";
 const require2 = createRequire(import.meta.url);
 const pty = require2("node-pty");
+const execFileAsync = promisify(execFile);
 if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDALONE_CONFIG) {
   try {
     const requiredServerFiles = JSON.parse(
@@ -185,6 +188,77 @@ function isLoopbackAddress(value) {
   if (value === "::1" || value === "127.0.0.1") return true;
   if (value.startsWith("::ffff:")) return value.slice("::ffff:".length) === "127.0.0.1";
   return false;
+}
+function isTailscaleAddress(value) {
+  const address = value.startsWith("::ffff:") ? value.slice("::ffff:".length) : value;
+  if (address.includes(".")) {
+    const parts = address.split(".").map((part) => Number(part));
+    return parts.length === 4 && parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) && parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127;
+  }
+  return address.toLowerCase().startsWith("fd7a:115c:a1e0:");
+}
+function normalizeForwardedAddress(value) {
+  let address = value.trim();
+  if (address.startsWith("[")) {
+    const close = address.indexOf("]");
+    if (close > 0) return address.slice(1, close).toLowerCase();
+  }
+  if ((address.match(/:/g) ?? []).length === 1) address = address.split(":")[0];
+  if (address.startsWith("::ffff:")) address = address.slice("::ffff:".length);
+  return address.toLowerCase();
+}
+const TAILNET_PEER_HEADER = "x-coven-cave-tailnet-peer";
+const TAILNET_PEER_SECRET = randomUUID();
+process.env.COVEN_CAVE_TAILNET_PEER_SECRET = TAILNET_PEER_SECRET;
+const TAILNET_STATUS_REFRESH_MS = 3e4;
+function allowedTailnetNodeIds() {
+  const raw = process.env.COVEN_CAVE_TAILNET_ALLOWED_NODES ?? "";
+  return new Set(
+    raw.split(",").map((entry) => entry.trim()).filter((entry) => entry.length > 0)
+  );
+}
+let tailnetPeerAddresses = /* @__PURE__ */ new Map();
+let tailnetRefreshInFlight = false;
+async function refreshTailnetPeers() {
+  const allowed = allowedTailnetNodeIds();
+  if (allowed.size === 0) {
+    tailnetPeerAddresses = /* @__PURE__ */ new Map();
+    return;
+  }
+  if (tailnetRefreshInFlight) return;
+  tailnetRefreshInFlight = true;
+  try {
+    const { stdout } = await execFileAsync(
+      process.env.COVEN_CAVE_TAILSCALE_BIN ?? "tailscale",
+      ["status", "--json"],
+      { timeout: 1e4, maxBuffer: 16 * 1024 * 1024 }
+    );
+    const status = JSON.parse(stdout);
+    const next2 = /* @__PURE__ */ new Map();
+    for (const peer of Object.values(status.Peer ?? {})) {
+      const nodeId = peer.ID;
+      if (!nodeId || !allowed.has(nodeId)) continue;
+      for (const ip of peer.TailscaleIPs ?? []) {
+        next2.set(normalizeForwardedAddress(ip), nodeId);
+      }
+    }
+    tailnetPeerAddresses = next2;
+  } catch (err) {
+    tailnetPeerAddresses = /* @__PURE__ */ new Map();
+    console.warn("[cave] tailnet peer refresh failed:", err?.message ?? err);
+  } finally {
+    tailnetRefreshInFlight = false;
+  }
+}
+function resolveTailnetPeer(req) {
+  if (tailnetPeerAddresses.size === 0) return null;
+  if (!isLoopbackAddress(req.socket.remoteAddress)) return null;
+  const forwarded = req.headers["x-forwarded-for"];
+  const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(",")[0];
+  if (!first) return null;
+  const address = normalizeForwardedAddress(first);
+  if (!isTailscaleAddress(address)) return null;
+  return tailnetPeerAddresses.get(address) ?? null;
 }
 function isDirectLoopbackRequest(req) {
   if (!isLoopbackAddress(req.socket.remoteAddress)) return false;
@@ -590,8 +664,13 @@ await app.prepare();
 const nextUpgradeHandler = app.getUpgradeHandler();
 const server = createServer((req, res) => {
   delete req.headers[LOCAL_PEER_HEADER];
+  delete req.headers[TAILNET_PEER_HEADER];
   if (isDirectLoopbackRequest(req)) {
     req.headers[LOCAL_PEER_HEADER] = LOCAL_PEER_SECRET;
+  }
+  const tailnetNodeId = resolveTailnetPeer(req);
+  if (tailnetNodeId) {
+    req.headers[TAILNET_PEER_HEADER] = `${TAILNET_PEER_SECRET}:${tailnetNodeId}`;
   }
   void handle(req, res);
 });
@@ -612,7 +691,8 @@ server.on("upgrade", (req, socket, head) => {
     });
     return;
   }
-  const tokenAuthenticated = isPtyAuthRequired() ? isAuthorized(req, query) : false;
+  const tailnetAuthenticated = resolveTailnetPeer(req) !== null;
+  const tokenAuthenticated = tailnetAuthenticated || (isPtyAuthRequired() ? isAuthorized(req, query) : false);
   if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
     socket.destroy();
@@ -654,6 +734,10 @@ server.headersTimeout = 8e4;
 server.listen(port, hostname, () => {
   console.log(`> Ready on http://${hostname}:${port}`);
 });
+if (allowedTailnetNodeIds().size > 0) {
+  void refreshTailnetPeers();
+  setInterval(() => void refreshTailnetPeers(), TAILNET_STATUS_REFRESH_MS).unref();
+}
 server.once("error", (err) => {
   console.error(err);
   process.exit(1);

--- a/server.ts
+++ b/server.ts
@@ -1,9 +1,11 @@
+import { execFile } from "node:child_process";
 import { createHmac, randomUUID } from "node:crypto";
 import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { getHeapStatistics, writeHeapSnapshot } from "node:v8";
 
 import next from "next";
@@ -11,6 +13,7 @@ import { WebSocket, WebSocketServer, type RawData } from "ws";
 
 const require = createRequire(import.meta.url);
 const pty: typeof import("node-pty") = require("node-pty");
+const execFileAsync = promisify(execFile);
 
 // Packaged desktop builds (the Tauri sidecar) run this server from inside the
 // .app bundle, where next.config.ts is not shipped. The standalone build
@@ -330,6 +333,135 @@ function isLoopbackAddress(value: string | undefined): boolean {
   if (value === "::1" || value === "127.0.0.1") return true;
   if (value.startsWith("::ffff:")) return value.slice("::ffff:".length) === "127.0.0.1";
   return false;
+}
+
+/**
+ * True for a Tailscale CGNAT address: 100.64.0.0/10 (v4) or the fd7a:115c:a1e0::/48
+ * ULA range (v6). Mirrors isTailscaleIpHost in src/proxy-helpers.ts.
+ */
+function isTailscaleAddress(value: string): boolean {
+  const address = value.startsWith("::ffff:") ? value.slice("::ffff:".length) : value;
+  if (address.includes(".")) {
+    const parts = address.split(".").map((part) => Number(part));
+    return (
+      parts.length === 4 &&
+      parts.every((part) => Number.isInteger(part) && part >= 0 && part <= 255) &&
+      parts[0] === 100 &&
+      parts[1] >= 64 &&
+      parts[1] <= 127
+    );
+  }
+  return address.toLowerCase().startsWith("fd7a:115c:a1e0:");
+}
+
+/**
+ * Normalizes an x-forwarded-for hop into a bare address: strips IPv6 brackets
+ * and any `:port` suffix, and unwraps IPv4-mapped IPv6.
+ */
+function normalizeForwardedAddress(value: string): string {
+  let address = value.trim();
+  if (address.startsWith("[")) {
+    const close = address.indexOf("]");
+    if (close > 0) return address.slice(1, close).toLowerCase();
+  }
+  // A bare IPv6 literal contains multiple colons and carries no port here; only
+  // strip a trailing :port from IPv4 (or bracket-less host:port) forms.
+  if ((address.match(/:/g) ?? []).length === 1) address = address.split(":")[0];
+  if (address.startsWith("::ffff:")) address = address.slice("::ffff:".length);
+  return address.toLowerCase();
+}
+
+// Tailnet identity gate (cave-zm6pn). Remote (phone) access is authorized by
+// per-device Tailscale identity rather than a shared bearer secret. Only stable
+// node IDs named in COVEN_CAVE_TAILNET_ALLOWED_NODES are admitted; an empty
+// allowlist disables the feature entirely (fail closed — no allowlist, no
+// tailnet access).
+//
+// Why x-forwarded-for is trustworthy HERE specifically: the TCP peer must
+// already be loopback, because `tailscale serve` terminates TLS and forwards to
+// 127.0.0.1. A local process able to forge this header could instead connect
+// directly to loopback, which grants strictly MORE authority (full local-peer
+// trust via isDirectLoopbackRequest). So reading it adds no new exposure while
+// upgrading remote auth from a shared secret to WireGuard-backed device
+// identity.
+const TAILNET_PEER_HEADER = "x-coven-cave-tailnet-peer";
+const TAILNET_PEER_SECRET = randomUUID();
+process.env.COVEN_CAVE_TAILNET_PEER_SECRET = TAILNET_PEER_SECRET;
+const TAILNET_STATUS_REFRESH_MS = 30_000;
+
+function allowedTailnetNodeIds(): Set<string> {
+  const raw = process.env.COVEN_CAVE_TAILNET_ALLOWED_NODES ?? "";
+  return new Set(
+    raw
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0),
+  );
+}
+
+/**
+ * address -> stable node ID, for allowlisted peers only. Refreshed off a
+ * `tailscale status --json` poll rather than resolved per request: the request
+ * handler below is synchronous and a per-request subprocess would add tens of
+ * milliseconds to every request. A stale entry can only ever name a node that
+ * was allowlisted anyway, and the refresh interval bounds how long a revoked
+ * device keeps working.
+ */
+let tailnetPeerAddresses = new Map<string, string>();
+let tailnetRefreshInFlight = false;
+
+async function refreshTailnetPeers(): Promise<void> {
+  const allowed = allowedTailnetNodeIds();
+  if (allowed.size === 0) {
+    tailnetPeerAddresses = new Map();
+    return;
+  }
+  if (tailnetRefreshInFlight) return;
+  tailnetRefreshInFlight = true;
+  try {
+    const { stdout } = await execFileAsync(
+      process.env.COVEN_CAVE_TAILSCALE_BIN ?? "tailscale",
+      ["status", "--json"],
+      { timeout: 10_000, maxBuffer: 16 * 1024 * 1024 },
+    );
+    const status = JSON.parse(stdout) as {
+      Peer?: Record<string, { ID?: string; TailscaleIPs?: string[] }>;
+    };
+    const next = new Map<string, string>();
+    for (const peer of Object.values(status.Peer ?? {})) {
+      const nodeId = peer.ID;
+      if (!nodeId || !allowed.has(nodeId)) continue;
+      for (const ip of peer.TailscaleIPs ?? []) {
+        next.set(normalizeForwardedAddress(ip), nodeId);
+      }
+    }
+    tailnetPeerAddresses = next;
+  } catch (err) {
+    // Fail closed: an unreadable tailnet status must never leave a previously
+    // built allowlist standing, or a revoked device would keep its access for
+    // as long as `tailscale` stayed broken.
+    tailnetPeerAddresses = new Map();
+    console.warn("[cave] tailnet peer refresh failed:", (err as Error)?.message ?? err);
+  } finally {
+    tailnetRefreshInFlight = false;
+  }
+}
+
+/**
+ * The allowlisted stable node ID behind a Tailscale-Serve-forwarded request, or
+ * null. Requires a loopback TCP peer (Serve always forwards over loopback) and
+ * a forwarded-for hop that is both a Tailscale CGNAT address and currently
+ * mapped to an allowlisted node.
+ */
+function resolveTailnetPeer(req: IncomingMessage): string | null {
+  if (tailnetPeerAddresses.size === 0) return null;
+  if (!isLoopbackAddress(req.socket.remoteAddress)) return null;
+  const forwarded = req.headers["x-forwarded-for"];
+  const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded)?.split(",")[0];
+  if (!first) return null;
+  const address = normalizeForwardedAddress(first);
+  if (!isTailscaleAddress(address)) return null;
+  return tailnetPeerAddresses.get(address) ?? null;
 }
 
 /**
@@ -923,11 +1055,16 @@ await app.prepare();
 const nextUpgradeHandler = app.getUpgradeHandler();
 
 const server = createServer((req, res) => {
-  // The local-peer stamp is trustworthy only because any client-supplied copy
-  // dies here, before Next (and proxy.ts) ever see the request.
+  // Both stamps are trustworthy only because any client-supplied copy dies
+  // here, before Next (and proxy.ts) ever see the request.
   delete req.headers[LOCAL_PEER_HEADER];
+  delete req.headers[TAILNET_PEER_HEADER];
   if (isDirectLoopbackRequest(req)) {
     req.headers[LOCAL_PEER_HEADER] = LOCAL_PEER_SECRET;
+  }
+  const tailnetNodeId = resolveTailnetPeer(req);
+  if (tailnetNodeId) {
+    req.headers[TAILNET_PEER_HEADER] = `${TAILNET_PEER_SECRET}:${tailnetNodeId}`;
   }
   void handle(req, res);
 });
@@ -956,7 +1093,14 @@ server.on("upgrade", (req, socket, head) => {
   // forwards the `<host>.ts.net` Host) legitimately arrives with a
   // non-loopback Host and must pass the source gate on the strength of its
   // token — mirroring proxy.ts's isAllowedApiHost relaxation on REST.
-  const tokenAuthenticated = isPtyAuthRequired() ? isAuthorized(req, query) : false;
+  //
+  // An allowlisted tailnet node is a credential in its own right (cave-zm6pn):
+  // its WireGuard-backed device identity is strictly stronger evidence than the
+  // shared bearer token this branch was built for, so it satisfies both the
+  // source gate below and the auth requirement after it.
+  const tailnetAuthenticated = resolveTailnetPeer(req) !== null;
+  const tokenAuthenticated =
+    tailnetAuthenticated || (isPtyAuthRequired() ? isAuthorized(req, query) : false);
 
   if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
     socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
@@ -1025,6 +1169,13 @@ server.headersTimeout = 80_000;
 server.listen(port, hostname, () => {
   console.log(`> Ready on http://${hostname}:${port}`);
 });
+
+// Prime the tailnet allowlist immediately, then keep it fresh. unref() so the
+// poll never holds the process open on its own.
+if (allowedTailnetNodeIds().size > 0) {
+  void refreshTailnetPeers();
+  setInterval(() => void refreshTailnetPeers(), TAILNET_STATUS_REFRESH_MS).unref();
+}
 
 server.once("error", (err: NodeJS.ErrnoException) => {
   console.error(err);

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -25,13 +25,37 @@ assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing side
 assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject unsafe origins");
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
-assert.match(source, /isAllowedApiHost\(requestHost, mobileAccessAuthenticated\)/, "valid mobile access should satisfy the API host gate");
+// Remote ingress is a verified mobile invite OR an allowlisted tailnet device
+// (cave-zm6pn). Both are proven credentials; neither is the bare
+// COVEN_CAVE_TAILNET_TRUST flag, which must never relax a gate on its own.
+assert.match(source, /const remoteIngress = mobileAccessAuthenticated \|\| tailnetPeerVerified/, "remote ingress is a verified invite or a verified tailnet device");
+assert.match(source, /isAllowedApiHost\(requestHost, remoteIngress\)/, "verified remote ingress should satisfy the API host gate");
 assert.doesNotMatch(source, /isAllowedApiHost\([^)]*tailnetTrusted[^)]*\)/, "tailnet membership alone must not relax the API host gate");
 assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "the tailnet-trust flag should survive only as a taint marker that further restricts automation ingress");
+// The tailnet half of remoteIngress must come from the server.ts-minted stamp
+// verified against the per-boot secret — never from a client-controlled Host or
+// from the env flag above.
 assert.match(
   source,
+  /const tailnetNodeId = verifiedTailnetNode\(\s*req\.headers\.get\(TAILNET_PEER_HEADER\),\s*process\.env\.COVEN_CAVE_TAILNET_PEER_SECRET,\s*\)/,
+  "tailnet ingress is authorized by the verified per-boot stamp, not by a client-controlled header",
+);
+assert.match(
+  source,
+  /const tailnetPeerVerified = tailnetNodeId !== null/,
+  "tailnet verification is derived from a resolved node id",
+);
+assert.match(
+  source,
+  /nextWithMobileAccessMarker\(req, remoteIngress\)/,
+  "proxy should forward the verified remote-ingress state into downstream request headers",
+);
+// A tailnet device is remote by construction, so it must carry the mobile
+// marker — otherwise desktop-only routes would treat a phone as local.
+assert.doesNotMatch(
+  source,
   /nextWithMobileAccessMarker\(req, mobileAccessAuthenticated\)/,
-  "proxy should forward the verified mobile-access state into downstream request headers",
+  "tailnet ingress must not be excluded from the mobile marker (desktop-only routes rely on it)",
 );
 assert.match(source, /const origin = req\.headers\.get\("origin"\)/, "API origin gate should read the source origin header once");
 assert.match(source, /const referer = req\.headers\.get\("referer"\)/, "API referer gate should read the source referer header once");
@@ -59,7 +83,7 @@ assert.doesNotMatch(
 );
 assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.method\)/, "state-changing GET webhooks should have a dedicated tokenless CSRF guard");
 assert.match(source, /isLocalOnlyAutomationRun\(req\.nextUrl\.pathname, req\.method\)/, "run-now automation execution should have a dedicated local-only proxy guard");
-assert.match(source, /mobileAccessAuthenticated \|\| tailnetTrusted \|\| !isLoopbackHost\(requestHost\)/, "run-now automation execution must deny mobile, tailnet, and non-loopback proxy ingress");
+assert.match(source, /remoteIngress \|\| tailnetTrusted \|\| !isLoopbackHost\(requestHost\)/, "run-now automation execution must deny mobile, tailnet-device, tailnet-flagged, and non-loopback proxy ingress");
 assert.match(source, /missing request source/, "tokenless GET webhooks should reject absent Origin and Referer headers");
 // cave-gzje: a verified signed mobile invite is the paired phone's credential.
 // The final sidecar gate must admit it (the phone can never learn the
@@ -67,8 +91,8 @@ assert.match(source, /missing request source/, "tokenless GET webhooks should re
 // extend to mobile-cookie-authenticated requests in exchange.
 assert.match(
   source,
-  /if \(!sidecarAuthenticated && !mobileAccessAuthenticated\) \{/,
-  "the sidecar gate must admit mobile-access-authenticated requests — packaged phones hold no sidecar token",
+  /if \(!sidecarAuthenticated && !remoteIngress\) \{/,
+  "the sidecar gate must admit verified remote ingress — neither a packaged phone nor an allowlisted tailnet device holds the sidecar token",
 );
 assert.match(
   source,
@@ -123,7 +147,7 @@ assert.doesNotMatch(
 // the bypass ran first and silently let non-loopback callers through during
 // `pnpm dev` if anything ever bound the dev server outside 127.0.0.1.
 {
-  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, mobileAccessAuthenticated)");
+  const hostIdx = source.indexOf("isAllowedApiHost(requestHost, remoteIngress)");
   const originIdx = source.indexOf("isAllowedRequestSourceAny(origin, expectedOrigins)");
   const refererIdx = source.indexOf("isAllowedRequestSourceAny(referer, expectedOrigins)");
   const contentTypeIdx = source.indexOf("unsupported content-type");
@@ -167,8 +191,8 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /shouldRequireMobileAccessCredential\(\s*req\.headers\.get\("host"\),\s*suppliedTokens\.length > 0,\s*trustedLocalPeer,?\s*\)/,
-  "the mobile gate must consult the verified local-peer stamp",
+  /shouldRequireMobileAccessCredential\(\s*req\.headers\.get\("host"\),\s*suppliedTokens\.length > 0,\s*trustedLocalPeer,\s*tailnetPeerVerified,?\s*\)/,
+  "the mobile gate must consult the verified local-peer stamp and the verified tailnet device",
 );
 // The marker classifies mobile INGRESS, not credential possession: a mobile
 // invite cookie in a local desktop browser (auto-sent after a pairing link
@@ -182,8 +206,8 @@ assert.match(
 );
 assert.match(
   source,
-  /mobileAccessGate\(req, trustedLocalPeer\)/,
-  "the local-peer stamp is verified once in proxy() and shared with the mobile gate",
+  /mobileAccessGate\(req, trustedLocalPeer, tailnetPeerVerified\)/,
+  "the local-peer and tailnet stamps are verified once in proxy() and shared with the mobile gate",
 );
 
 // ── HTML access gate for unauthenticated browser navigations ──────────────

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -126,7 +126,13 @@ export function shouldRequireMobileAccessCredential(
   _host: string | null,
   _hasSuppliedCredential: boolean,
   trustedLocalPeer = false,
+  tailnetPeerVerified = false,
 ) {
+  // An allowlisted tailnet device (cave-zm6pn) has already proven a stronger
+  // credential than the shared pairing secret this gate asks for: WireGuard
+  // device identity resolved by server.ts off the raw socket. Requiring the
+  // invite token on top would defeat the point of replacing it.
+  if (tailnetPeerVerified) return false;
   // The Host header is client-controlled, so it cannot prove that the actual
   // TCP peer is loopback — a host value alone never exempts a request. The
   // one thing that CAN prove it is server.ts, which sees the raw socket: it
@@ -149,6 +155,27 @@ export function shouldRequireMobileAccessCredential(
 export function isTrustedLocalPeer(headerValue: string | null, secret: string | undefined) {
   if (!headerValue || !secret) return false;
   return timingSafeEqualString(headerValue, secret);
+}
+
+/**
+ * The allowlisted Tailscale stable node ID behind this request, or null.
+ *
+ * Mirrors TAILNET_PEER_HEADER in server.ts, which is the only component that
+ * can mint this stamp: it sees the raw socket, deletes any client-supplied copy
+ * of the header, resolves the forwarded tailnet address against a
+ * `tailscale status` allowlist, and stamps `<perBootSecret>:<nodeId>`. The
+ * secret never leaves that process, so a match proves the peer is an
+ * allowlisted device rather than merely something claiming to be one. An unset
+ * secret — Next running without server.ts in front — fails closed.
+ */
+export function verifiedTailnetNode(headerValue: string | null, secret: string | undefined) {
+  if (!headerValue || !secret) return null;
+  const separator = headerValue.indexOf(":");
+  if (separator <= 0) return null;
+  const supplied = headerValue.slice(0, separator);
+  const nodeId = headerValue.slice(separator + 1);
+  if (!nodeId) return null;
+  return timingSafeEqualString(supplied, secret) ? nodeId : null;
 }
 
 export function bearerFromReferer(value: string | null, expectedOrigin: string) {
@@ -286,6 +313,7 @@ export const ACCESS_TOKEN_COOKIE = "coven_cave_access";
 // requests whose TCP peer it verified as direct loopback. Mirrored in
 // server.ts, which cannot import from src/.
 export const LOCAL_PEER_HEADER = "x-coven-cave-local-peer";
+export const TAILNET_PEER_HEADER = "x-coven-cave-tailnet-peer";
 export const ACCESS_TOKEN_QUERY_PARAM = "coven_access_token";
 export const TOKEN_PARAM = "covenCaveToken";
 export const TOKEN_HEADER = "x-coven-cave-token";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,8 @@ import {
   isTrustedLocalPeer,
   isHtmlNavigationRequest,
   accessGatePage,
+  TAILNET_PEER_HEADER,
+  verifiedTailnetNode,
 } from "./proxy-helpers";
 import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
 
@@ -76,7 +78,11 @@ async function mobileAccessVerification(
   return null;
 }
 
-async function mobileAccessGate(req: NextRequest, trustedLocalPeer: boolean) {
+async function mobileAccessGate(
+  req: NextRequest,
+  trustedLocalPeer: boolean,
+  tailnetPeerVerified: boolean,
+) {
   const expected = configuredMobileAccessToken();
   if (!expected) return null;
 
@@ -86,6 +92,7 @@ async function mobileAccessGate(req: NextRequest, trustedLocalPeer: boolean) {
       req.headers.get("host"),
       suppliedTokens.length > 0,
       trustedLocalPeer,
+      tailnetPeerVerified,
     )
   ) {
     return null;
@@ -184,7 +191,16 @@ export async function proxy(req: NextRequest) {
     req.headers.get(LOCAL_PEER_HEADER),
     process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
   );
-  const mobileRes = await mobileAccessGate(req, trustedLocalPeer);
+  // The allowlisted tailnet device behind a Tailscale-Serve-forwarded request
+  // (cave-zm6pn), resolved by server.ts off the raw socket and stamped with a
+  // per-boot secret. This REPLACES the shared pairing token for remote access:
+  // a device proven by WireGuard identity needs no invite to paste.
+  const tailnetNodeId = verifiedTailnetNode(
+    req.headers.get(TAILNET_PEER_HEADER),
+    process.env.COVEN_CAVE_TAILNET_PEER_SECRET,
+  );
+  const tailnetPeerVerified = tailnetNodeId !== null;
+  const mobileRes = await mobileAccessGate(req, trustedLocalPeer, tailnetPeerVerified);
   if (mobileRes) return mobileRes;
 
   if (!req.nextUrl.pathname.startsWith("/api/")) {
@@ -226,7 +242,12 @@ export async function proxy(req: NextRequest) {
   // but the flag still marks tailnet ingress below so local-only automation
   // runs stay off that path.
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
-  if (!isAllowedApiHost(requestHost, mobileAccessAuthenticated)) {
+  // Remote ingress is now EITHER a verified mobile invite or an allowlisted
+  // tailnet device. Both are non-local by construction, so both relax the host
+  // gate (a Serve-forwarded <host>.ts.net Host) and both must carry the mobile
+  // marker below so desktop-only routes keep 403ing.
+  const remoteIngress = mobileAccessAuthenticated || tailnetPeerVerified;
+  if (!isAllowedApiHost(requestHost, remoteIngress)) {
     return jsonError(403, "forbidden host");
   }
 
@@ -236,7 +257,7 @@ export async function proxy(req: NextRequest) {
   // authenticated: their forwarded Host value is client/forwarder-controlled
   // and cannot prove that the original peer was loopback.
   if (isLocalOnlyAutomationRun(req.nextUrl.pathname, req.method)) {
-    if (mobileAccessAuthenticated || tailnetTrusted || !isLoopbackHost(requestHost)) {
+    if (remoteIngress || tailnetTrusted || !isLoopbackHost(requestHost)) {
       return jsonError(403, "forbidden local-only endpoint");
     }
   }
@@ -303,10 +324,10 @@ export async function proxy(req: NextRequest) {
   if (!sidecarToken) {
     return process.env.COVEN_CAVE_BUNDLE === "1"
       ? jsonError(500, "missing sidecar auth token")
-      : nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
+      : nextWithMobileAccessMarker(req, remoteIngress);
   }
 
-  if (!sidecarAuthenticated && !mobileAccessAuthenticated) {
+  if (!sidecarAuthenticated && !remoteIngress) {
     // A verified signed mobile invite is the paired phone's credential: the
     // token is minted by this desktop from its access secret and already
     // passed mobileAccessGate above. Requiring the webview's per-launch
@@ -317,7 +338,7 @@ export async function proxy(req: NextRequest) {
     return jsonError(401, "unauthorized");
   }
 
-  return nextWithMobileAccessMarker(req, mobileAccessAuthenticated);
+  return nextWithMobileAccessMarker(req, remoteIngress);
 }
 
 export const config = {

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -87,8 +87,8 @@ assert.match(
 );
 assert.match(
   src,
-  /delete req\.headers\[LOCAL_PEER_HEADER\];\s*if \(isDirectLoopbackRequest\(req\)\) \{\s*req\.headers\[LOCAL_PEER_HEADER\] = LOCAL_PEER_SECRET;/,
-  "client-supplied local-peer headers are stripped before the server stamps its own",
+  /delete req\.headers\[LOCAL_PEER_HEADER\];\s*delete req\.headers\[TAILNET_PEER_HEADER\];\s*if \(isDirectLoopbackRequest\(req\)\) \{\s*req\.headers\[LOCAL_PEER_HEADER\] = LOCAL_PEER_SECRET;/,
+  "client-supplied local-peer and tailnet-peer headers are both stripped before the server stamps its own",
 );
 assert.match(src, /SIDECAR_QUERY_PARAM = "covenCaveToken"/, "PTY WebSocket auth accepts the sidecar token query param used by native WebSockets");
 // Credentials are verified BEFORE the source gate: a paired device over
@@ -99,8 +99,16 @@ assert.match(src, /SIDECAR_QUERY_PARAM = "covenCaveToken"/, "PTY WebSocket auth 
 // tab never connects" bug (cave-iz1j).
 assert.match(
   src,
-  /const tokenAuthenticated = isPtyAuthRequired\(\) \? isAuthorized\(req, query\) : false;/,
-  "PTY upgrade verifies the access or sidecar token before the source gate",
+  /const tokenAuthenticated =\s*tailnetAuthenticated \|\| \(isPtyAuthRequired\(\) \? isAuthorized\(req, query\) : false\);/,
+  "PTY upgrade verifies the access/sidecar token, or an allowlisted tailnet device, before the source gate",
+);
+// An allowlisted tailnet device is a credential in its own right (cave-zm6pn):
+// resolved off the raw socket, it is stronger evidence than the shared bearer
+// token, so the terminal must not 403 a device the REST surface already admits.
+assert.match(
+  src,
+  /const tailnetAuthenticated = resolveTailnetPeer\(req\) !== null;/,
+  "PTY upgrade treats an allowlisted tailnet device as authenticated",
 );
 assert.match(
   src,
@@ -217,7 +225,7 @@ assert.match(src, /isLoopbackAddress\(req\.socket\.remoteAddress\)/, "server ver
 // Tailscale Serve forwards the <host>.ts.net Host. The iOS terminal may use
 // that host only after the mobile access token authenticates the upgrade;
 // tailnet membership alone must not relax the host gate.
-assert.match(src, /const tokenAuthenticated = isPtyAuthRequired\(\) \? isAuthorized\(req, query\) : false/, "the upgrade credential is verified before the host gate");
+assert.match(src, /const tokenAuthenticated =\s*tailnetAuthenticated \|\| \(isPtyAuthRequired\(\) \? isAuthorized\(req, query\) : false\)/, "the upgrade credential — token or allowlisted tailnet device — is verified before the host gate");
 assert.match(
   src,
   /if \(tokenAuthenticated\) return sameOrigin\(req\.headers\.origin, `http:\/\/\$\{host\}`\);\s*\n\s*return false;/,

--- a/src/tailnet-identity.test.ts
+++ b/src/tailnet-identity.test.ts
@@ -1,0 +1,171 @@
+// @ts-nocheck
+//
+// Tailnet identity gate (cave-zm6pn). Remote access is authorized by per-device
+// Tailscale identity instead of a shared pairing secret. Two halves are tested
+// here:
+//
+//   1. Behavior — verifiedTailnetNode / shouldRequireMobileAccessCredential,
+//      exercised with concrete inputs so a refactor that keeps the source text
+//      but breaks the gate is still caught.
+//   2. Source pinning of server.ts, which is the ONLY component that can mint
+//      the stamp (it alone sees the raw socket) and which cannot import from
+//      src/ — esbuild emits server.mjs with --bundle=false — so the invariants
+//      are duplicated there and must be held in agreement by assertion.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  verifiedTailnetNode,
+  shouldRequireMobileAccessCredential,
+  TAILNET_PEER_HEADER,
+} from "./proxy-helpers.ts";
+
+// ─── verifiedTailnetNode ───────────────────────────────────────────────────
+const SECRET = "0f1e2d3c-4b5a-6978-8796-a5b4c3d2e1f0";
+const NODE = "nEXAMPLE0000011CNTRL";
+
+assert.equal(
+  verifiedTailnetNode(`${SECRET}:${NODE}`, SECRET),
+  NODE,
+  "a stamp bearing the per-boot secret yields the node id",
+);
+
+// The whole point of the stamp: a client cannot forge it, because the secret
+// never leaves server.ts. These are the shapes an attacker actually controls.
+assert.equal(
+  verifiedTailnetNode(`wrong-secret:${NODE}`, SECRET),
+  null,
+  "a stamp with the wrong secret is refused",
+);
+assert.equal(
+  verifiedTailnetNode(NODE, SECRET),
+  null,
+  "a bare node id with no secret is refused",
+);
+assert.equal(
+  verifiedTailnetNode(`:${NODE}`, SECRET),
+  null,
+  "an empty secret segment is refused",
+);
+assert.equal(
+  verifiedTailnetNode(`${SECRET}:`, SECRET),
+  null,
+  "an empty node id is refused",
+);
+assert.equal(verifiedTailnetNode(null, SECRET), null, "an absent header is refused");
+assert.equal(verifiedTailnetNode("", SECRET), null, "an empty header is refused");
+
+// Next running without server.ts in front has no secret to compare against.
+// That must deny rather than admit — otherwise the gate opens exactly when the
+// component that enforces it is missing.
+assert.equal(
+  verifiedTailnetNode(`${SECRET}:${NODE}`, undefined),
+  null,
+  "an unset per-boot secret fails closed",
+);
+assert.equal(
+  verifiedTailnetNode(`${SECRET}:${NODE}`, ""),
+  null,
+  "an empty per-boot secret fails closed",
+);
+
+// Split on the FIRST colon only: the secret is a UUID (no colons) but node ids
+// are opaque and must survive verbatim.
+assert.equal(
+  verifiedTailnetNode(`${SECRET}:node:with:colons`, SECRET),
+  "node:with:colons",
+  "only the first colon separates secret from node id",
+);
+
+// ─── shouldRequireMobileAccessCredential ───────────────────────────────────
+// A verified tailnet device has already presented stronger evidence than the
+// shared invite token, so it must not be challenged for one.
+assert.equal(
+  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false, false, true),
+  false,
+  "a verified tailnet peer needs no pairing token",
+);
+assert.equal(
+  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false, false, false),
+  true,
+  "an unverified tailnet-looking host is still challenged",
+);
+assert.equal(
+  shouldRequireMobileAccessCredential("127.0.0.1:3000", false, true, false),
+  false,
+  "the socket-verified local peer exemption is unchanged",
+);
+assert.equal(
+  shouldRequireMobileAccessCredential("127.0.0.1:3000", false, false, false),
+  true,
+  "a loopback Host alone still proves nothing (the header is client-controlled)",
+);
+
+// ─── server.ts source pinning ──────────────────────────────────────────────
+const src = readFileSync(new URL("../server.ts", import.meta.url), "utf8");
+
+assert.match(
+  src,
+  /const TAILNET_PEER_HEADER = "x-coven-cave-tailnet-peer";/,
+  "server.ts must use the same header name as src/proxy-helpers.ts (it cannot import it)",
+);
+assert.equal(
+  TAILNET_PEER_HEADER,
+  "x-coven-cave-tailnet-peer",
+  "the src/ mirror of the header name must match server.ts",
+);
+assert.match(
+  src,
+  /const TAILNET_PEER_SECRET = randomUUID\(\);\s*process\.env\.COVEN_CAVE_TAILNET_PEER_SECRET = TAILNET_PEER_SECRET;/,
+  "the stamp secret is minted fresh per boot and never inherited from ambient env",
+);
+
+// Any client-supplied copy of the header must die before Next sees the request,
+// or the stamp proves nothing at all.
+assert.match(
+  src,
+  /delete req\.headers\[TAILNET_PEER_HEADER\];/,
+  "a client-supplied tailnet stamp is stripped before Next handles the request",
+);
+
+// Fail-closed shape: no allowlist means no tailnet access, and an unreadable
+// `tailscale status` must clear the map rather than leave a stale one standing
+// (otherwise a revoked device keeps working for as long as the CLI is broken).
+assert.match(
+  src,
+  /if \(allowed\.size === 0\) \{\s*tailnetPeerAddresses = new Map\(\);\s*return;\s*\}/,
+  "an empty allowlist disables tailnet access entirely",
+);
+assert.match(
+  src,
+  /catch \(err\) \{[\s\S]*?tailnetPeerAddresses = new Map\(\);/,
+  "a failed tailnet refresh clears the allowlist instead of keeping stale entries",
+);
+
+// The peer must be loopback (Serve forwards over loopback), the forwarded hop
+// must be a Tailscale CGNAT address, and it must map to an allowlisted node.
+// Dropping any one of these turns the gate into a client-controlled header.
+assert.match(
+  src,
+  /function resolveTailnetPeer\(req: IncomingMessage\): string \| null \{\s*if \(tailnetPeerAddresses\.size === 0\) return null;\s*if \(!isLoopbackAddress\(req\.socket\.remoteAddress\)\) return null;/,
+  "tailnet resolution requires a socket-verified loopback peer and a non-empty allowlist",
+);
+assert.match(
+  src,
+  /if \(!isTailscaleAddress\(address\)\) return null;/,
+  "the forwarded hop must be a Tailscale CGNAT address",
+);
+assert.match(
+  src,
+  /return tailnetPeerAddresses\.get\(address\) \?\? null;/,
+  "only an address currently mapped to an allowlisted node resolves",
+);
+
+// The allowlist is by STABLE node id — not hostname, not IP, both of which move.
+assert.match(
+  src,
+  /if \(!nodeId \|\| !allowed\.has\(nodeId\)\) continue;/,
+  "peers are admitted by stable node id membership in the allowlist",
+);
+
+console.log("tailnet-identity.test.ts: ok");


### PR DESCRIPTION
Closes cave-zm6pn.

Authorizes a phone by **WireGuard device identity** instead of a shared bearer
secret, so a device you own reaches the app over Tailscale Serve with no invite
token at all.

### Why not just "anyone on the tailnet"

That was built once (#1329) and deliberately reverted (#3310) on the grounds
that *tailnet membership alone is not authorization* — Serve exposes every
`/api` route, and any node, including one shared into the tailnet, would have
been admitted. That reasoning still holds and this change does not re-open it.
Access here is an **explicit per-device allowlist**; every tailnet node not on
it is refused exactly as before.

### How it is enforced

`server.ts` is the only component that sees the raw TCP socket, so it is the
only one that can mint trust. It:

1. deletes any client-supplied copy of `x-coven-cave-tailnet-peer` before Next
   sees the request, so the stamp cannot be forged from outside;
2. resolves the forwarded tailnet address against a `tailscale status --json`
   poll (30s refresh, kept off the request path so nothing forks a subprocess
   per request);
3. checks the resulting **stable node ID** against
   `COVEN_CAVE_TAILNET_ALLOWED_NODES`;
4. stamps a header signed with a per-boot secret that never leaves the process.

`proxy.ts` verifies that stamp in constant time and treats a verified node as
remote ingress — the same authority a valid invite token grants, and no more.
This mirrors the existing `LOCAL_PEER_SECRET` pattern rather than inventing a
second trust mechanism.

Stable node IDs are used deliberately: hostnames and tailnet IPs both move,
node IDs survive renames, IP changes, and re-authentication.

### Why reading the forwarded address is safe here

The TCP peer must already be loopback, because Tailscale Serve terminates TLS
and forwards to `127.0.0.1`. A local process able to forge the forwarded-for
header could instead connect straight to loopback, which grants strictly *more*
authority. So reading it adds no new exposure.

### Fail-closed

- No allowlist configured → no tailnet access, and the poll never starts.
- An unreadable `tailscale status` **clears** the map rather than leaving stale
  entries, so a revoked device loses access instead of coasting on a cached
  mapping. Revocation takes at most one refresh interval.
- Local-only surfaces (Codex automation runs) stay off this path exactly as
  they stay off the invite path — a forwarded Host cannot prove a loopback
  origin.

### Verification

Live gate exercised against a running server:

| case | result |
| --- | --- |
| allowlisted phone, no token | 200 |
| non-allowlisted tailnet node | 401 |
| public (non-tailnet) source address | 401 |
| forged `x-coven-cave-tailnet-peer` stamp | 401 |
| legacy signed invite token | 200 (unchanged) |
| direct loopback | 200 (unchanged) |
| allowlisted phone → local-only automation route | 403 |
| allowlist unset | 401 |

`pnpm test:app` green. `pnpm test:api` fails only on `dev-app-teardown`, which
reproduces identically on a clean `main` checkout — filed as `cave-voglb`, not
caused by this branch.

### Notes

- `server.mjs` is regenerated via `pnpm build:server` (checked-in artifact,
  pinned by test).
- New `src/tailnet-identity.test.ts` covers the verifier's failure modes and
  source-pins the `server.ts` invariants the two files must agree on — the
  esbuild bundle-less build means `server.ts` cannot import from `src/`.
- No iOS change is needed for the tokenless path: `CaveInvite` already accepts
  a bare host and `CaveClient` attaches a token only when one exists.
- This authorizes a **device**, not a person. Follow-up `cave-brksh` makes the
  device's biometric lock a fact the server can verify rather than a
  client-side claim.
- The worktree for this branch was created with the `git worktree add` fallback
  after `beads:worktrees:create` hit an exit-1 inventory failure, so it carries
  no lifecycle metadata and needs the manual archive-tag retirement route.
