### PR TITLE
fix(release): wire COVENCAVE_DISCORD_APPLICATION_ID into release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,6 +168,11 @@ jobs:
     needs: daemon-package
     env:
       COVEN_CAVE_X_PRODUCTION_CLIENT_ID: ${{ vars.COVEN_CAVE_X_PRODUCTION_CLIENT_ID }}
+      # Public Discord application ID, read by option_env! at compile time in
+      # src-tauri/src/discord_presence.rs. Without it every shipped binary
+      # compiles with DISCORD_APPLICATION_ID = None and Rich Presence is
+      # permanently disabled. Not a secret, so a repository variable is enough.
+      COVENCAVE_DISCORD_APPLICATION_ID: ${{ vars.COVENCAVE_DISCORD_APPLICATION_ID }}
     permissions:
       contents: write
       id-token: write

--- a/docs/discord-rich-presence.md
+++ b/docs/discord-rich-presence.md
@@ -24,8 +24,14 @@ For a local desktop build, set the variable before launching the app:
 COVENCAVE_DISCORD_APPLICATION_ID=<public-application-id> pnpm dev:app
 ```
 
-Release builds must receive the same public variable. Without it, CovenCave
-continues normally and logs that Discord activity is disabled.
+Release builds receive the same public variable from the
+`COVENCAVE_DISCORD_APPLICATION_ID` repository variable, wired into the `build`
+job in [`.github/workflows/release.yml`](../.github/workflows/release.yml).
+**That repository variable must be set, or every shipped binary silently ships
+with Rich Presence disabled** — `option_env!` resolves at compile time, so an
+unset variable is baked into the artifact and cannot be fixed at runtime.
+Without it CovenCave continues normally and logs that Discord activity is
+disabled.
 
 ## Verify
 
@@ -40,3 +46,23 @@ continues normally and logs that Discord activity is disabled.
 
 The worker retries while Discord is closed and reconnects after Discord
 restarts. The native app icon and Discord art asset are managed separately.
+
+## What Rich Presence does not control
+
+Discord shows CovenCave in several places, and only the profile activity card
+comes from this code. The others are not configurable from this repository:
+
+- **Go Live / stream picker.** While connected to a voice channel, Discord
+  scans running processes and lists them as streamable sources, labelled from
+  the executable's `ProductName` (`CovenCave`, set by `productName` in
+  `src-tauri/tauri.conf.json`). Its icon is resolved against Discord's own
+  verified-games database, not the Rich Presence art assets. An unrecognised
+  application renders a generic placeholder there, and no asset upload,
+  application rename, or embedded executable icon changes it. The row is
+  visible only to the local user and only while in voice.
+- **Detected-activity entries.** These also come from process scanning and are
+  managed under Discord's Settings → Registered Games, independent of the
+  application ID used here.
+
+A placeholder icon in either surface is not a Rich Presence defect. Verify
+presence from the profile card, per the steps above.


### PR DESCRIPTION
## Problem

Discord Rich Presence has **never worked in a released build**.

`src-tauri/src/discord_presence.rs:14` reads the application ID via `option_env!`, which resolves at **compile time**:

```rust
const DISCORD_APPLICATION_ID: Option<&str> = option_env!("COVENCAVE_DISCORD_APPLICATION_ID");
```

`COVENCAVE_DISCORD_APPLICATION_ID` was referenced only in `docs/discord-rich-presence.md` and the source itself — it was set in **no** workflow or build script. Every shipped binary therefore compiled with `DISCORD_APPLICATION_ID = None`, took the early return at `discord_presence.rs:69-74`, and logged:

```
[discord-presence] COVENCAVE_DISCORD_APPLICATION_ID is not configured; Discord activity is disabled
```

Confirmed empirically: a local `pnpm dev:app` build without the variable logs exactly that line and never connects. Exporting the variable and rebuilding produces `[discord-presence] CovenCave presence published` and a working card.

Because the value is baked into the artifact, this cannot be corrected at runtime — a shipped build with the variable unset is permanently inert.

`docs/discord-rich-presence.md:27` already stated the requirement ("Release builds must receive the same public variable"); nothing implemented it.

## Change

- **`.github/workflows/release.yml`** — add `COVENCAVE_DISCORD_APPLICATION_ID` to the `build` job's `env:` block, matching the existing `COVEN_CAVE_X_PRODUCTION_CLIENT_ID` pattern. The env is job-level, so it applies to every matrix leg including the macOS `scripts/release.sh` path. The ID is public, so a repository **variable** is sufficient — no secret involved.
- **`docs/discord-rich-presence.md`** — state that the repository variable must be set or builds silently ship disabled, and add a "What Rich Presence does not control" section.

## ⚠️ Action required before this has any effect

A maintainer must set the repository variable — this PR only consumes it:

```
Settings → Secrets and variables → Actions → Variables → New repository variable
Name:  COVENCAVE_DISCORD_APPLICATION_ID
Value: <public application ID>
```

Without it the expression resolves to an empty string and behavior is unchanged from today. I did not set it, as that is a repository-configuration change outside this PR.

## Why the doc section was added

Time was lost diagnosing a placeholder icon that turned out not to be Rich Presence at all. Discord's **Go Live / stream picker** lists running processes labelled from the executable's `ProductName` (`CovenCave`, from `src-tauri/tauri.conf.json`), and resolves their icons against Discord's own verified-games database — not against Rich Presence art assets. An unrecognised app shows a generic placeholder there, and no asset upload, application rename, or embedded executable icon changes it.

Evidence: that row's label stayed `CovenCave` across three Discord application renames while the presence status line tracked each one; and both the debug and installed binaries do carry embedded icons, so the placeholder is not a missing-icon problem.

## Verification

- `release.yml` parses as valid YAML; `jobs.build.env` contains both `COVEN_CAVE_X_PRODUCTION_CLIENT_ID` and `COVENCAVE_DISCORD_APPLICATION_ID`.
- Presence confirmed working end-to-end locally by exporting the variable and rebuilding — published with the `covencave` art asset resolving.
- **Not verified:** the release workflow itself was not executed, as that requires a tag push and the repository variable. The change is declarative and follows an existing working pattern in the same block.
- No Rust or TypeScript source changed; no behavioral change to the app outside build configuration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)