### PR TITLE
fix(shell): keep the sidebar open when leaving Chat for Home

### DIFF
--- a/src/components/shell-layout.ts
+++ b/src/components/shell-layout.ts
@@ -36,6 +36,60 @@ export function resolveShellNavOpenPreference(
     : { open: persistedOpen, shouldPersist: false };
 }
 
+/** Nav policy names, mirrored from `ShellNavPolicy` in shell.tsx so this pure
+ *  module stays importable from the plain node:assert test harness. */
+export type ShellNavPolicyName =
+  | "remembered"
+  | "visit-collapsed"
+  | "chat-contextual";
+
+type ResolveShellNavPolicyHandoffOptions = {
+  /** Policy the shell is leaving; null before the first render settles. */
+  fromPolicy: ShellNavPolicyName | null;
+  /** Policy the shell is entering. */
+  toPolicy: ShellNavPolicyName;
+  /** Nav open state the user can currently SEE, not what is persisted. */
+  visibleNavOpen: boolean;
+  /** `cave:shell:nav-open`, or null when it has never been written. */
+  persistedOpen: boolean | null;
+  /** True only when the persisted value came from a user-driven resize.
+   *  First-run minimization also writes this key, and that write must not be
+   *  mistaken for the user asking for a collapsed sidebar. */
+  persistedFromUser: boolean;
+};
+
+/**
+ * Hand the nav's visible open state across a policy change instead of
+ * re-reading a preference the outgoing policy never maintained.
+ *
+ * `chat-contextual` force-opens the nav on entry and deliberately never writes
+ * `cave:shell:nav-open` (the persistence branch in shell.tsx is gated on the
+ * remembered policy). Meanwhile first-run minimization seeds that same key to
+ * `false`. So a user sitting in Chat with an open sidebar has `false` on disk
+ * without ever having collapsed anything — and clicking Home, which swaps to
+ * the remembered policy, collapsed the sidebar out from under the click.
+ *
+ * Returns the state to adopt, or null to leave the existing remembered logic
+ * alone. An explicit user collapse still wins: this only rescues the seeded
+ * case.
+ */
+export function resolveShellNavPolicyHandoff({
+  fromPolicy,
+  toPolicy,
+  visibleNavOpen,
+  persistedOpen,
+  persistedFromUser,
+}: ResolveShellNavPolicyHandoffOptions): { open: boolean; persist: boolean } | null {
+  if (fromPolicy !== "chat-contextual" || toPolicy !== "remembered") return null;
+  // Nothing to carry: the user left Chat with the nav already closed.
+  if (!visibleNavOpen) return null;
+  // The user's own choice is authoritative — never overwrite it.
+  if (persistedFromUser) return null;
+  // Already open on disk; the remembered path will do the right thing.
+  if (persistedOpen === true) return null;
+  return { open: true, persist: true };
+}
+
 function isCompleteLayout(
   layout: ShellPanelLayout,
   panelIds = Object.keys(layout),

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -22,6 +22,8 @@ const resolveShellLayoutPersistence =
 const resolveShellNavOpenPreference =
   shellLayout.resolveShellNavOpenPreference ??
   (() => ({ open: true, shouldPersist: false }));
+const resolveShellNavPolicyHandoff =
+  shellLayout.resolveShellNavPolicyHandoff ?? (() => null);
 
 assert.equal(resolveShellNavWidth("300"), 300, "a valid persisted nav width is retained");
 assert.equal(resolveShellNavWidth("999"), 420, "nav width is clamped to the desktop maximum");
@@ -41,6 +43,80 @@ assert.deepEqual(
   resolveShellNavOpenPreference(true, false),
   { open: true, shouldPersist: false },
   "first-run minimization never overwrites an existing user preference",
+);
+
+// Leaving Chat for a remembered destination (Home, Tasks, Rituals, …) must not
+// collapse the sidebar the user is looking at. Chat never maintains
+// cave:shell:nav-open, and first-run minimization seeds it false, so the
+// remembered path would otherwise read a `false` nobody chose.
+const chatToHome = {
+  fromPolicy: "chat-contextual",
+  toPolicy: "remembered",
+  visibleNavOpen: true,
+  persistedOpen: false,
+  persistedFromUser: false,
+};
+
+assert.deepEqual(
+  resolveShellNavPolicyHandoff(chatToHome),
+  { open: true, persist: true },
+  "leaving Chat carries the visible sidebar forward over a seeded collapse",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, persistedFromUser: true }),
+  null,
+  "a sidebar the user collapsed themselves stays collapsed when leaving Chat",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, visibleNavOpen: false }),
+  null,
+  "leaving Chat with the nav already closed has nothing to carry",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, persistedOpen: true }),
+  null,
+  "an already-open preference needs no handoff",
+);
+
+assert.deepEqual(
+  resolveShellNavPolicyHandoff({ ...chatToHome, persistedOpen: null }),
+  { open: true, persist: true },
+  "an unwritten preference is carried like a seeded one",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, fromPolicy: "remembered" }),
+  null,
+  "remembered-to-remembered navigation keeps using the stored preference",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, toPolicy: "visit-collapsed" }),
+  null,
+  "policies that collapse on purpose are never overridden by the handoff",
+);
+
+assert.equal(
+  resolveShellNavPolicyHandoff({ ...chatToHome, fromPolicy: null }),
+  null,
+  "the first settled render is not a policy transition",
+);
+
+// The handoff has to run BEFORE the destination-layout effect reads the
+// preference, and useLayoutEffect order is declaration order.
+assert.ok(
+  shell.indexOf("resolveShellNavPolicyHandoff") <
+    shell.indexOf("const navPrefArmedGroupRef"),
+  "the policy handoff effect is declared above the destination-layout restore",
+);
+
+// Only the user-driven resize may claim authorship of the preference.
+assert.ok(
+  compactWhitespace(shell).includes('writeNavOpenPref(open, "user")'),
+  "the user-driven resize records itself as the authoritative preference",
 );
 
 assert.equal(
@@ -512,7 +588,7 @@ assert.match(
 // churn is programmatic) and the code-rail auto-collapse must not be active.
 assert.match(
   shell,
-  /navPolicy === "remembered" &&\s*\n\s*navPrefArmedGroupRef\.current === groupId &&\s*\n\s*!railAutoCollapsedNavRef\.current\s*\n?\s*\) \{\s*\n\s*writeNavOpenPref\(open\);/,
+  /navPolicy === "remembered" &&\s*\n\s*navPrefArmedGroupRef\.current === groupId &&\s*\n\s*!railAutoCollapsedNavRef\.current\s*\n?\s*\) \{[\s\S]*?writeNavOpenPref\(open, "user"\);/,
   "onResize persists the state only for user-driven changes on the armed group",
 );
 // The code-rail coupling raises its flag BEFORE collapsing, so the resulting

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -33,6 +33,7 @@ import {
   resolveShellDestinationLayout,
   resolveShellLayoutPersistence,
   resolveShellNavOpenPreference,
+  resolveShellNavPolicyHandoff,
   SHELL_NAV_DEFAULT_PX,
   SHELL_NAV_MAX_PX,
   SHELL_NAV_MIN_PX,
@@ -158,6 +159,13 @@ function markShellMinimizeApplied(id: string): void {
 // collapse/restore coupling and programmatic group-swap layout churn don't).
 const NAV_OPEN_PREF_KEY = "cave:shell:nav-open";
 const NAV_WIDTH_PREF_KEY = "cave:shell:nav-width";
+// Who wrote NAV_OPEN_PREF_KEY. The key alone can't distinguish "the user
+// collapsed the sidebar" from "first-run minimization guessed collapsed", and
+// those must be treated differently on a policy handoff — only the former is a
+// choice worth preserving. A missing value reads as "seed", which is the safe
+// direction for installs that predate this key (worst case a sidebar stays
+// open).
+const NAV_OPEN_SOURCE_KEY = "cave:shell:nav-open:source";
 function readNavOpenPref(): boolean | null {
   if (typeof window === "undefined") return null;
   try {
@@ -167,17 +175,26 @@ function readNavOpenPref(): boolean | null {
     return null;
   }
 }
-function writeNavOpenPref(open: boolean): void {
+function readNavOpenFromUser(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(NAV_OPEN_SOURCE_KEY) === "user";
+  } catch {
+    return false;
+  }
+}
+function writeNavOpenPref(open: boolean, source: "user" | "seed" = "seed"): void {
   if (typeof window === "undefined") return;
   try {
     window.localStorage.setItem(NAV_OPEN_PREF_KEY, open ? "1" : "0");
+    window.localStorage.setItem(NAV_OPEN_SOURCE_KEY, source);
   } catch {
     /* ignore — strict privacy mode or quota */
   }
 }
 function seedNavOpenPref(defaultOpen: boolean): boolean {
   const resolved = resolveShellNavOpenPreference(readNavOpenPref(), defaultOpen);
-  if (resolved.shouldPersist) writeNavOpenPref(resolved.open);
+  if (resolved.shouldPersist) writeNavOpenPref(resolved.open, "seed");
   return resolved.open;
 }
 function readNavWidthPref(): string | null {
@@ -422,6 +439,11 @@ function ShellInner({
   // match the Cave's minimized default. The mounted layout effects restore a
   // remembered open panel before the first post-hydration paint.
   const [navOpen, setNavOpen] = useState(chatContextual);
+  // Mirror of navOpen for effects that need the CURRENT visible state without
+  // taking navOpen as a dependency (the policy handoff must fire on the policy
+  // change, not on every sidebar toggle).
+  const navOpenRef = useRef(navOpen);
+  navOpenRef.current = navOpen;
   const defaultNavSize =
     chatContextual || mounted ? `${NAV_OPEN_PX}px` : `${NAV_RAIL_PX}px`;
 
@@ -570,6 +592,36 @@ function ShellInner({
     markShellMinimizeApplied(groupId);
     group.setLayout({ ...cur, nav: railPct, detail: cur.detail + (nav - railPct) });
   }, [settled, isMobile, groupId, chatContextual, preferredNavWidth]);
+
+  // Policy handoff — MUST stay declared above the destination-layout effect
+  // below, because useLayoutEffects run in declaration order and that one reads
+  // the preference this one repairs.
+  //
+  // Leaving Chat swaps `chat-contextual` for `remembered` AND changes groupId,
+  // so the restore effect re-reads `cave:shell:nav-open`. Chat never maintains
+  // that key (its persistence branch is gated on the remembered policy) while
+  // first-run minimization seeds it to `false` — so the sidebar the user was
+  // looking at, and had just clicked "Home" inside, collapsed to the rail. Carry
+  // the visible state across instead. An explicit user collapse still wins; see
+  // resolveShellNavPolicyHandoff.
+  const navHandoffPolicyRef = useRef<ShellNavPolicy | null>(null);
+  useLayoutEffect(() => {
+    if (!mounted) return;
+    const fromPolicy = navHandoffPolicyRef.current;
+    navHandoffPolicyRef.current = navPolicy;
+    if (isMobile) return;
+    const handoff = resolveShellNavPolicyHandoff({
+      fromPolicy,
+      toPolicy: navPolicy,
+      visibleNavOpen: navOpenRef.current,
+      persistedOpen: readNavOpenPref(),
+      persistedFromUser: readNavOpenFromUser(),
+    });
+    if (!handoff) return;
+    // Seed, not "user": carrying state forward is not the user expressing a
+    // preference, so a later genuine toggle still outranks it.
+    if (handoff.persist) writeNavOpenPref(handoff.open, "seed");
+  }, [mounted, isMobile, navPolicy]);
 
   // The library retains an in-memory layout by panel-id set when Group's id
   // changes. Restore the destination group's complete saved/default layout
@@ -911,7 +963,10 @@ function ShellInner({
             navPrefArmedGroupRef.current === groupId &&
             !railAutoCollapsedNavRef.current
           ) {
-            writeNavOpenPref(open);
+            // The ONE user-authored write — everything else that touches this
+            // key is seeding, and the policy handoff must be able to tell them
+            // apart.
+            writeNavOpenPref(open, "user");
           }
         }}
       >


### PR DESCRIPTION
## Symptom

From **Chat**, the left sidebar is open. Clicking **Home** in it navigates *and*
snaps the sidebar shut to the 56px icon rail — the panel the user just clicked in
disappears under the click. Same for any non-Chat destination reached from Chat
(Tasks, Rituals, Memories, Marketplace); Home is just the one people hit first.

## Cause

The two nav policies keep their open/closed state in different places, and
nothing hands state from one to the other.

`workspace.tsx` picks between exactly two of them:

```tsx
navPolicy={mode === "chat" ? "chat-contextual" : "remembered"}
```

- **`chat-contextual`** force-opens the nav on entry and deliberately never
  writes `cave:shell:nav-open` — the `onResize` persistence branch is gated on
  `navPolicy === "remembered"`. So while you are in Chat, the visible sidebar
  state is recorded nowhere.
- **`remembered`** reads that key via `seedNavOpenPref(false)`.
- That key is very often `"0"` **without the user having collapsed anything**:
  first-run minimization writes it, and so does the collapsed-default layout
  detection. `resolveShellNavOpenPreference(null, false)` returns
  `{ open: false, shouldPersist: true }` — already asserted in
  `shell-nav-memory.test.ts`.

Clicking Home flips the policy to `remembered` **and** changes `groupId` (Chat
has its own `.chat-contextual` group). Two effects then fire and both read that
stale-but-persisted `false`: the destination-layout `useLayoutEffect`, and the
settle effect that calls `panel.collapse()`.

## Fix

Hand the **visible** state across the policy change instead of re-reading a
preference the outgoing policy never maintained.

- New `cave:shell:nav-open:source` key records whether `cave:shell:nav-open` was
  written by a user-driven resize (`"user"`) or by seeding (`"seed"`). A missing
  value reads as `"seed"` — the safe direction for existing installs, where the
  worst case is a sidebar that stays open.
- New pure helper `resolveShellNavPolicyHandoff` in `shell-layout.ts` returns
  `{ open: true, persist: true }` **only** for `chat-contextual → remembered`
  where the nav is visibly open, the persisted value was not user-authored, and
  it is not already `true`. Everything else returns `null` and the existing
  remembered logic runs untouched — **an explicit user collapse still wins.**
- The effect applying it is declared **above** the destination-layout restore,
  because `useLayoutEffect`s run in declaration order and that one reads the key
  this one repairs. An assertion pins that ordering so a future reshuffle can't
  silently reintroduce the bug.

Keeping the decision in a pure helper matches how the rest of this module is
tested — `shell-nav-memory.test.ts` is a plain `node:assert` script over the
pure helpers.

## Verification

- `node --experimental-strip-types src/components/shell-nav-memory.test.ts` — passes, with new cases for: the seeded collapse being carried, a user-authored collapse being honored, an already-closed nav having nothing to carry, an unwritten preference, and the three non-transitions (`remembered → remembered`, `→ visit-collapsed`, first settled render).
- `pnpm exec tsc --noEmit` — clean.
- `pnpm lint` — clean (0 drift, eslint `--max-warnings=0`).
- `pnpm exec vitest run src/components` — **61 failed / 416 passed**, byte-identical to the same run on the unmodified base commit. Those failures are pre-existing on `main` and unrelated to this change.

## Not covered

Mobile drawer behavior is already correct (`dismissNavMobile` is a desktop
no-op). The `visit-collapsed` policy is untouched (nothing currently passes it),
as is first-run minimize-by-default.

## Note for the reviewer

This branch was created with the last-resort `git worktree add` fallback, so it
carries **no `metadata.coven.worktree` record** and the lifecycle patrol will
report it `uncertain`. The sanctioned `pnpm beads:worktrees:create` could not run
in this checkout — `.beads/` has no database (`bd create` → *no beads database
found*) and the script fails earlier still with `spawnSync bd ENOENT`. Per
`CLAUDE.md` I did **not** hand-write the missing metadata onto a bead; retiring
this worktree needs the manual archive-tag route.
