### PR TITLE
fix(shell): collapse the Chat sidebar to the icon rail, not to nothing

### DIFF
--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -16,7 +16,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/,
+  /const contextualNav =\s*\n\s*navSection === "code" && \(navOpen \|\| isMobile\) \? chatSidebar : sidebar;/,
   "workspace selects the session-list rail across the Code section while expanded, and the destination rail once collapsed",
 );
 assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/);

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -16,8 +16,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const contextualNav = navSection === "code" \? chatSidebar : sidebar;/,
-  "workspace should select the session-list rail for the whole Code section",
+  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/,
+  "workspace selects the session-list rail across the Code section while expanded, and the destination rail once collapsed",
 );
 assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/);
 assert.match(

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -596,7 +596,7 @@ assert.doesNotMatch(
 );
 assert.match(chatSurface, /const compactRail = hideThreadRail/, "ChatSurface compact mode is driven only by hideThreadRail");
 assert.match(chatSurface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "Chat keeps Projects as its second primary tab");
-assert.match(workspace, /const contextualNav = navSection === "code" \? chatSidebar : sidebar;/, "the Code section replaces the global nav with the contextual Chats sidebar");
+assert.match(workspace, /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/, "the expanded Code section replaces the global nav with the contextual Chats sidebar");
 assert.match(workspace, /nav=\{contextualNav\}\s*list=\{undefined\}/, "workspace mounts the contextual Chat nav without an independent list pane");
 assert.doesNotMatch(chatRouter, /surface\?:|surface=\{surface\}/, "ChatRouter must not forward a surface prop");
 assert.doesNotMatch(chatView, /surface\?:|surface === "code"|Ask for follow-up changes/, "ChatView must not carry Code-specific composer copy this phase");

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -596,7 +596,7 @@ assert.doesNotMatch(
 );
 assert.match(chatSurface, /const compactRail = hideThreadRail/, "ChatSurface compact mode is driven only by hideThreadRail");
 assert.match(chatSurface, /\{\s*id:\s*"projects",\s*label:\s*"Projects"\s*\}/, "Chat keeps Projects as its second primary tab");
-assert.match(workspace, /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/, "the expanded Code section replaces the global nav with the contextual Chats sidebar");
+assert.match(workspace, /const contextualNav =\s*\n\s*navSection === "code" && \(navOpen \|\| isMobile\) \? chatSidebar : sidebar;/, "the expanded Code section replaces the global nav with the contextual Chats sidebar");
 assert.match(workspace, /nav=\{contextualNav\}\s*list=\{undefined\}/, "workspace mounts the contextual Chat nav without an independent list pane");
 assert.doesNotMatch(chatRouter, /surface\?:|surface=\{surface\}/, "ChatRouter must not forward a surface prop");
 assert.doesNotMatch(chatView, /surface\?:|surface === "code"|Ask for follow-up changes/, "ChatView must not carry Code-specific composer copy this phase");

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -34,8 +34,8 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const contextualNav = navSection === "code" \? chatSidebar : sidebar;[\s\S]*nav=\{contextualNav\}\s*list=\{undefined\}/,
-  "WorkspaceSidebar replaces the normal sidenav in Code and SidebarMinimal returns outside it",
+  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;[\s\S]*nav=\{contextualNav\}\s*list=\{undefined\}/,
+  "WorkspaceSidebar replaces the normal sidenav in an expanded Code room; SidebarMinimal returns outside it and when collapsed",
 );
 
 console.log("familiar-quick-switch component: all assertions passed");

--- a/src/components/familiar-quick-switch.test.ts
+++ b/src/components/familiar-quick-switch.test.ts
@@ -34,7 +34,7 @@ assert.match(
 );
 assert.match(
   workspace,
-  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;[\s\S]*nav=\{contextualNav\}\s*list=\{undefined\}/,
+  /const contextualNav =\s*\n\s*navSection === "code" && \(navOpen \|\| isMobile\) \? chatSidebar : sidebar;[\s\S]*nav=\{contextualNav\}\s*list=\{undefined\}/,
   "WorkspaceSidebar replaces the normal sidenav in an expanded Code room; SidebarMinimal returns outside it and when collapsed",
 );
 

--- a/src/components/shell-left-panels-fit.test.ts
+++ b/src/components/shell-left-panels-fit.test.ts
@@ -100,8 +100,8 @@ assert.match(
 // Collapse-to-rail must survive the px conversion.
 assert.match(
   shell,
-  /collapsedSize=\{isMobile \|\| chatContextual \? 0 : NAV_RAIL_PX\}/,
-  "Chat and mobile nav collapse fully while normal desktop nav keeps the icon rail",
+  /collapsedSize=\{isMobile \? 0 : NAV_RAIL_PX\}/,
+  "only mobile nav collapses fully; every desktop surface keeps the icon rail",
 );
 assert.match(
   shell,

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -651,7 +651,7 @@ assert.match(
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 assert.match(
   workspace,
-  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/,
+  /const contextualNav =\s*\n\s*navSection === "code" && \(navOpen \|\| isMobile\) \? chatSidebar : sidebar;/,
   "the collapsed Code room renders the destination rail, not the session list",
 );
 assert.match(

--- a/src/components/shell-nav-memory.test.ts
+++ b/src/components/shell-nav-memory.test.ts
@@ -458,7 +458,7 @@ assert.match(
 );
 assert.match(
   destinationLayoutEffect,
-  /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?preferredNavPixels: preferredNavWidth,[\s\S]*?collapsedNavPixels: chatContextual \? 0 : NAV_RAIL_PX,[\s\S]*?isMobile,/,
+  /resolveShellDestinationLayout\(\{[\s\S]*?savedLayout: defaultLayout,[\s\S]*?defaultPanelPixels: \{ \.\.\.\(!twoPane && \{ list: 260 \}\) \},[\s\S]*?preferredNavPixels: preferredNavWidth,[\s\S]*?collapsedNavPixels: isMobile \? 0 : NAV_RAIL_PX,[\s\S]*?isMobile,/,
   "every desktop group transition resolves its own saved/default layout with the active shared nav width",
 );
 assert.match(
@@ -601,8 +601,8 @@ assert.match(
 
 assert.match(
   shell,
-  /const navPeekEnabled = navPolicy === "remembered" && !isMobile && !navOpen;/,
-  "hover-to-peek is disabled for visit-collapsed and chat-contextual routes",
+  /const navPeekEnabled = !isMobile && !navOpen;/,
+  "hover-to-peek covers every desktop policy now that they all collapse to a rail",
 );
 assert.match(
   shell,
@@ -611,18 +611,53 @@ assert.match(
 );
 assert.match(
   shell,
-  /className=\{`shell-nav\$\{!isMobile && !chatContextual && !navOpen \? \(navPeekVisible \? " shell-nav--peek" : " shell-nav--rail"\) : ""\}`\}/,
-  "Chat's zero-width collapsed sidebar never receives remembered navigation rail or peek styling",
+  /className=\{`shell-nav\$\{!isMobile && !navOpen \? \(navPeekVisible \? " shell-nav--peek" : " shell-nav--rail"\) : ""\}`\}/,
+  "every collapsed desktop sidebar, Chat included, gets rail or peek styling",
 );
 assert.match(
   shell,
   /onMouseEnter=\{navPeekEnabled \? \(\) => setNavPeeking\(true\) : undefined\}/,
-  "hover enter only peeks when the remembered nav policy allows it",
+  "hover enter peeks whenever a desktop rail is showing",
 );
 assert.match(
   shell,
   /onMouseLeave=\{navPeekEnabled \? \(\) => setNavPeeking\(false\) : undefined\}/,
-  "hover leave only peeks when the remembered nav policy allows it",
+  "hover leave peeks whenever a desktop rail is showing",
+);
+
+// The reported bug: collapsing in Chat made the sidebar vanish outright. Only
+// mobile — where the nav is an overlay drawer over the content — still closes
+// to zero.
+assert.match(
+  shell,
+  /collapsedSize=\{isMobile \? 0 : NAV_RAIL_PX\}/,
+  "only mobile drawers close fully; every desktop surface collapses to the icon rail",
+);
+assert.match(
+  shell,
+  /collapsedNavPixels: isMobile \? 0 : NAV_RAIL_PX,/,
+  "the restored destination layout describes the same collapsed width as the panel",
+);
+// Chat collapsing to a rail changes what the panel LOOKS like, not who owns the
+// remembered preference — the #4404 handoff depends on Chat never writing it.
+assert.match(
+  shell,
+  /!chatContextual &&\s*\n\s*isShellNavCollapsedLayout\(\{/,
+  "Chat still never seeds the remembered nav-open preference",
+);
+
+// The session list has no rail form, so the collapsed Code room falls back to
+// the destination rail rather than rendering a squeezed session list.
+const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
+assert.match(
+  workspace,
+  /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/,
+  "the collapsed Code room renders the destination rail, not the session list",
+);
+assert.match(
+  workspace,
+  /onNavOpenChange=\{setNavOpen\}/,
+  "workspace tracks the shell's nav open state to drive that fallback",
 );
 
 assert.match(

--- a/src/components/shell.tsx
+++ b/src/components/shell.tsx
@@ -451,7 +451,10 @@ function ShellInner({
   // floats it open as an overlay (navPeeking) without changing the collapse
   // state. Reset whenever the rail goes away (expanded or mobile).
   const [navPeeking, setNavPeeking] = useState(false);
-  const navPeekEnabled = navPolicy === "remembered" && !isMobile && !navOpen;
+  // Every desktop policy now collapses to the rail, so peek applies to all of
+  // them. It used to be remembered-only because Chat collapsed to zero width,
+  // leaving nothing to hover.
+  const navPeekEnabled = !isMobile && !navOpen;
   const navPeekVisible = navPeekEnabled && navPeeking;
   useEffect(() => {
     if (!navPeekEnabled) setNavPeeking(false);
@@ -658,6 +661,10 @@ function ShellInner({
           : 0),
       0,
     );
+    // Still gated on !chatContextual: Chat must never write the REMEMBERED
+    // preference (cave:shell:nav-open). Chat collapsing to a rail changes what
+    // the panel looks like, not who owns that preference — the handoff added in
+    // #4404 depends on Chat leaving it alone.
     if (
       !chatContextual &&
       isShellNavCollapsedLayout({
@@ -677,7 +684,9 @@ function ShellInner({
       groupSize,
       defaultPanelPixels: { ...(!twoPane && { list: 260 }) },
       preferredNavPixels: preferredNavWidth,
-      collapsedNavPixels: chatContextual ? 0 : NAV_RAIL_PX,
+      // Matches the Panel's collapsedSize below — Chat collapses to the rail
+      // now, not to zero, so the restored layout must describe the same width.
+      collapsedNavPixels: isMobile ? 0 : NAV_RAIL_PX,
       isMobile,
     });
     if (!destinationLayout) return;
@@ -948,7 +957,12 @@ function ShellInner({
         collapsible
         // Contextual Chat and mobile drawers close fully; normal desktop
         // navigation collapses to its icons-only rail.
-        collapsedSize={isMobile || chatContextual ? 0 : NAV_RAIL_PX}
+        // Mobile drawers close fully (they overlay the content). Every desktop
+        // surface — Chat included — collapses to the icons-only rail instead,
+        // so the destinations stay reachable. Chat used to collapse to zero,
+        // which left no rail, no peek target, and no visible way to reach any
+        // other surface.
+        collapsedSize={isMobile ? 0 : NAV_RAIL_PX}
         panelRef={navRef}
         onResize={(size) => {
           const open = (size.inPixels ?? 0) > NAV_OPEN_THRESHOLD_PX;
@@ -973,7 +987,7 @@ function ShellInner({
         {/* CHAT-D13-05: every complementary landmark carries a distinct
             accessible name (axe landmark-unique). */}
         <aside
-          className={`shell-nav${!isMobile && !chatContextual && !navOpen ? (navPeekVisible ? " shell-nav--peek" : " shell-nav--rail") : ""}`}
+          className={`shell-nav${!isMobile && !navOpen ? (navPeekVisible ? " shell-nav--peek" : " shell-nav--rail") : ""}`}
           aria-label="Sidebar"
           onMouseEnter={navPeekEnabled ? () => setNavPeeking(true) : undefined}
           onMouseLeave={navPeekEnabled ? () => setNavPeeking(false) : undefined}

--- a/src/components/sidepanel-nav-peek.test.ts
+++ b/src/components/sidepanel-nav-peek.test.ts
@@ -7,7 +7,7 @@ const globals = readFileSync(new URL("../app/globals.css", import.meta.url), "ut
 
 // Hover-to-peek state + handlers on the collapsed nav rail.
 assert.match(shell, /const \[navPeeking, setNavPeeking\] = useState\(false\)/, "shell tracks a nav peek state");
-assert.match(shell, /const navPeekEnabled = navPolicy === "remembered" && !isMobile && !navOpen;/, "shell derives whether peek is allowed from nav policy and breakpoint");
+assert.match(shell, /const navPeekEnabled = !isMobile && !navOpen;/, "peek is allowed on every desktop surface with a collapsed rail, Chat included");
 assert.match(shell, /const navPeekVisible = navPeekEnabled && navPeeking;/, "shell derives visible peek state synchronously from the policy-gated flag");
 assert.match(shell, /navPeekVisible \? " shell-nav--peek" : " shell-nav--rail"/, "only a policy-allowed peek renders the overlay class");
 assert.match(shell, /onMouseEnter=\{navPeekEnabled \? \(\) => setNavPeeking\(true\) : undefined\}/, "hovering starts the peek only when the gated handler is armed");

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -71,7 +71,7 @@ assert.doesNotMatch(workspaceSidebar, /workspace-sidebar__rail|chat-sidebar__rai
 // "Search projects or threads…" clipped); the aria-label keeps the full scope.
 assert.match(workspaceSidebar, /placeholder="Search chats…"/, "search placeholder fits the narrow panel");
 assert.match(workspaceSidebar, /aria-label="Search projects and threads"/, "search keeps its descriptive accessible name");
-assert.match(workspace, /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/, "workspace keeps the session rail across the expanded Code section");
+assert.match(workspace, /const contextualNav =\s*\n\s*navSection === "code" && \(navOpen \|\| isMobile\) \? chatSidebar : sidebar;/, "workspace keeps the session rail across the expanded Code section");
 assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/, "workspace should not mount Chats in the list slot");
 assert.match(workspace, /navPolicy=\{mode === "chat" \? "chat-contextual" : "remembered"\}/, "chat mode activates the contextual nav policy");
 assert.doesNotMatch(workspace, /navPolicy=\{mode === "chat" \? "visit-collapsed" : "remembered"\}/, "chat mode should not use the obsolete visit-collapsed policy");

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -71,7 +71,7 @@ assert.doesNotMatch(workspaceSidebar, /workspace-sidebar__rail|chat-sidebar__rai
 // "Search projects or threads…" clipped); the aria-label keeps the full scope.
 assert.match(workspaceSidebar, /placeholder="Search chats…"/, "search placeholder fits the narrow panel");
 assert.match(workspaceSidebar, /aria-label="Search projects and threads"/, "search keeps its descriptive accessible name");
-assert.match(workspace, /const contextualNav = navSection === "code" \? chatSidebar : sidebar;/, "workspace keeps the session rail across the Code section");
+assert.match(workspace, /const contextualNav = navSection === "code" && navOpen \? chatSidebar : sidebar;/, "workspace keeps the session rail across the expanded Code section");
 assert.doesNotMatch(workspace, /const list = mode === "chat" \? chatSidebar : undefined;/, "workspace should not mount Chats in the list slot");
 assert.match(workspace, /navPolicy=\{mode === "chat" \? "chat-contextual" : "remembered"\}/, "chat mode activates the contextual nav policy");
 assert.doesNotMatch(workspace, /navPolicy=\{mode === "chat" \? "visit-collapsed" : "remembered"\}/, "chat mode should not use the obsolete visit-collapsed policy");

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -2989,6 +2989,11 @@ export function Workspace() {
   // rather than stored, so the rail and the surface can never disagree — deep
   // links, ⌘K and restored last-surface strings all land in the right room.
   const navSection = navSectionForMode(mode);
+  // Mirrors the Shell's nav panel open/collapsed state (Shell already fires
+  // onNavOpenChange; this is the first consumer). Drives which component the
+  // nav hosts when collapsed — see contextualNav below. Starts open to match
+  // the Shell's own pre-hydration assumption for the Code room.
+  const [navOpen, setNavOpen] = useState(true);
   const handleSectionChange = useCallback(
     (next: NavSection) => {
       if (navSectionForMode(modeRef.current) === next) return;
@@ -3108,7 +3113,18 @@ export function Workspace() {
 
   // The Code room keeps the session-list rail across all of its surfaces (Chat,
   // the workbench, the browser); Home uses the destination rail.
-  const contextualNav = navSection === "code" ? chatSidebar : sidebar;
+  //
+  // ...but only while the nav is EXPANDED. The session list has no icon-rail
+  // form, so a collapsed Code room used to render it at zero width and the
+  // sidebar vanished outright — no rail, no peek target, no way to reach any
+  // other destination. Collapsed, fall back to SidebarMinimal, which does have
+  // rail chrome; it carries `section`, so the rail shows the Code room's own
+  // destinations and its Home/Chat section tabs.
+  //
+  // Deliberately keyed on navOpen and NOT on hover-peek: peek is an overlay
+  // that leaves the collapse state alone, so keying on it would remount this
+  // subtree on every mouse pass.
+  const contextualNav = navSection === "code" && navOpen ? chatSidebar : sidebar;
 
   // renderSurface maps a workspace mode to its surface element. Extracted so the
   // same machinery renders both the primary detail and a dragged-in split
@@ -3442,6 +3458,7 @@ export function Workspace() {
         onPromoteSplitTile={promoteSplitTile}
         onDropSplitPage={openSplitPage}
         navPolicy={mode === "chat" ? "chat-contextual" : "remembered"}
+        onNavOpenChange={setNavOpen}
         topBar={({ navDrawerOpen }) => (
           <>
             <FamiliarMenuBar

--- a/src/components/workspace.tsx
+++ b/src/components/workspace.tsx
@@ -18,6 +18,7 @@ import {
   type WorkspaceMode as WorkspaceModeFromDaemon,
 } from "@/lib/workspace-mode";
 import { navSectionForMode, type NavSection } from "@/lib/nav-section";
+import { useIsMobile } from "@/lib/use-viewport";
 import { clearChatHash, clearModeParam, readChatHash, readModeParam } from "@/lib/workspace-url-state";
 import {
   canMoveWorkspaceNavigation,
@@ -2994,6 +2995,8 @@ export function Workspace() {
   // nav hosts when collapsed — see contextualNav below. Starts open to match
   // the Shell's own pre-hydration assumption for the Code room.
   const [navOpen, setNavOpen] = useState(true);
+  // Same breakpoint the Shell uses; on mobile the nav is a drawer, not a rail.
+  const isMobile = useIsMobile();
   const handleSectionChange = useCallback(
     (next: NavSection) => {
       if (navSectionForMode(modeRef.current) === next) return;
@@ -3124,7 +3127,14 @@ export function Workspace() {
   // Deliberately keyed on navOpen and NOT on hover-peek: peek is an overlay
   // that leaves the collapse state alone, so keying on it would remount this
   // subtree on every mouse pass.
-  const contextualNav = navSection === "code" && navOpen ? chatSidebar : sidebar;
+  //
+  // Mobile is exempt: there is no rail there — the nav is a full-width overlay
+  // drawer — so the session list is always the right content, and navOpen
+  // tracks the desktop panel rather than the drawer (it reads false while the
+  // drawer is open). Without this the mobile Chat drawer rendered the
+  // destination sidebar and lost its search field.
+  const contextualNav =
+    navSection === "code" && (navOpen || isMobile) ? chatSidebar : sidebar;
 
   // renderSurface maps a workspace mode to its surface element. Extracted so the
   // same machinery renders both the primary detail and a dragged-in split


### PR DESCRIPTION
## Symptom

On **Chat**, collapse the sidebar (⌃B or the floating top-left toggle) and the
whole panel disappears — zero width, no icons. On every other surface the same
gesture leaves a 56px icon rail with the destination glyphs.

The cost: from collapsed Chat there is **no visible way to reach any other
destination**. Home, Tasks, Rituals, Memories and Marketplace are all gone.
Recovery is the floating toggle or the ⌃B binding — both of which you have to
already know about.

## Cause

Four things conspire, in `shell.tsx` and `workspace.tsx`:

1. `collapsedSize={isMobile || chatContextual ? 0 : NAV_RAIL_PX}` — Chat
   collapses to zero. (Correct for mobile, where the nav overlays the content.)
2. The `shell-nav--rail` class is gated on `!chatContextual`, so a non-zero
   collapsed panel wouldn't paint rail styling anyway.
3. `navPeekEnabled` requires `navPolicy === "remembered"`, so hover-to-peek —
   the recovery affordance everywhere else — is off exactly where the sidebar
   has vanished.
4. **The nav hosts the wrong component to be a rail.** `contextualNav` is
   `navSection === "code" ? chatSidebar : sidebar`, and `WorkspaceSidebar` is a
   session list with a search field and tabs. `SidebarMinimal` — the one with
   rail chrome (`.sidebar-brand-mark`, `.sidebar-user-avatar`, icon-only rows)
   — is only mounted outside the Code room. So widening the collapsed size
   alone would squeeze a session list into 56px rather than produce a rail.
   This is very likely why zero-width was chosen in the first place.

## Fix

- `collapsedSize={isMobile ? 0 : NAV_RAIL_PX}` — only mobile drawers close
  fully; every desktop surface collapses to the rail.
- Drop `!chatContextual` from the rail/peek class condition.
- `navPeekEnabled = !isMobile && !navOpen` — peek covers every desktop policy
  now that they all collapse to a rail.
- `collapsedNavPixels` for the destination-layout resolve matches the panel's
  new collapsed size.
- `contextualNav = navSection === "code" && navOpen ? chatSidebar : sidebar` —
  collapsed, the Code room renders `SidebarMinimal`, which carries `section`, so
  the rail shows the Code room's own destinations and its Home/Chat section
  tabs. Workspace tracks nav state through Shell's **existing** `onNavOpenChange`
  prop (this is its first consumer).

Keyed on `navOpen` and deliberately **not** on hover-peek: peek is an overlay
that leaves the collapse state alone, so keying on it would remount the subtree
on every mouse pass.

### What is deliberately unchanged

Chat still never seeds the remembered `cave:shell:nav-open` preference. That
`!chatContextual` guard is load-bearing for the policy handoff landed in #4404,
and a new assertion pins it. Chat collapsing to a rail changes what the panel
looks like, not who owns that preference.

## ⚠️ This reverses a test-pinned design decision

The old behavior was intentional and asserted as such. `shell-nav-memory.test.ts`
read *"Chat's zero-width collapsed sidebar never receives remembered navigation
rail or peek styling"*, and `shell-left-panels-fit.test.ts` read *"Chat and
mobile nav collapse fully…"*. Six test files across four surfaces pinned the old
expressions.

Those assertions are **updated to state the new intent, not deleted** — the
source-regex coverage stays at full strength. But a reviewer who believes the
zero-width collapse was protecting something I haven't found should say so; this
PR is a deliberate reversal on the report that the vanishing sidebar is a bug.

## Verification

- `pnpm exec vitest run src/components` — **61 failed / 416 passed, exactly the
  baseline on `84f6b461`**. My first pass regressed this to 66; the five new
  failures were the stale source-regex assertions above, now updated. Delta is
  zero.
- `node --experimental-strip-types src/components/shell-nav-memory.test.ts` —
  passes, with new assertions for the collapsed size, the layout width, the
  preserved `!chatContextual` seeding guard, and both workspace wiring lines.
- `pnpm exec tsc --noEmit`, `pnpm lint` — clean.
- **Not yet verified in the running app.** The manual check: on Chat press ⌃B →
  a 56px icon rail with destination glyphs, not an empty gutter; click Home from
  that rail; hover it to peek; then ⌃B on Home and confirm the off-Chat rail is
  unchanged.

## Note for the reviewer

Created with the last-resort `git worktree add` fallback, so it carries no
`metadata.coven.worktree` record and the lifecycle patrol will report it
`uncertain`. `pnpm beads:worktrees:create` cannot run in this checkout — `.beads/`
has no database (`bd create` → *no beads database found*) and the script fails
earlier at `spawnSync bd ENOENT`. Per `CLAUDE.md` I did not hand-write the
missing metadata; retirement needs the manual archive-tag route.
