### PR TITLE
fix(desktop): point Discord Rich Presence at opencoven.ai

### DIFF
--- a/docs/discord-rich-presence.md
+++ b/docs/discord-rich-presence.md
@@ -11,7 +11,7 @@ any user content.
 2. Use [`assets/brand/cave-icon.png`](../assets/brand/cave-icon.png) as both
    its application icon and a Rich Presence Art Asset named `covencave`.
    Discord lowercases asset keys; keep this key stable.
-3. Set the application website to `https://covencave.ai` and repository to
+3. Set the application website to `https://opencoven.ai` and repository to
    `https://github.com/OpenCoven/coven-cave`.
 4. Provide its public Application ID as `COVENCAVE_DISCORD_APPLICATION_ID` at
    build time. The ID is not a secret. Never add a client secret, bot token,

--- a/src-tauri/src/discord_presence.rs
+++ b/src-tauri/src/discord_presence.rs
@@ -32,10 +32,10 @@ fn build_activity(started_at: i64) -> activity::Activity<'static> {
             activity::Assets::new()
                 .large_image(ASSET_KEY)
                 .large_text("CovenCave")
-                .large_url("https://covencave.ai"),
+                .large_url("https://opencoven.ai"),
         )
         .buttons(vec![
-            activity::Button::new("Open CovenCave", "https://covencave.ai"),
+            activity::Button::new("Open CovenCave", "https://opencoven.ai"),
             activity::Button::new("View on GitHub", "https://github.com/OpenCoven/coven-cave"),
         ])
 }
@@ -196,7 +196,7 @@ mod tests {
         assert_eq!(serialized["state"], "Working with familiars");
         assert_eq!(serialized["assets"]["large_image"], ASSET_KEY);
         assert_eq!(serialized["timestamps"]["start"], 1_700_000_000);
-        assert_eq!(serialized["buttons"][0]["url"], "https://covencave.ai");
+        assert_eq!(serialized["buttons"][0]["url"], "https://opencoven.ai");
         assert_eq!(
             serialized["buttons"][1]["url"],
             "https://github.com/OpenCoven/coven-cave"


### PR DESCRIPTION
## Problem

The Discord Rich Presence card published by the desktop shell pointed at
`https://covencave.ai` in two places. That domain **has no DNS record at all**
(`NXDOMAIN` — it is not registered), so clicking the presence artwork or the
`Open CovenCave` button in Discord landed on a browser error page.

The project's live domain is `opencoven.ai`, which is what every other
outbound link in the codebase already uses (`docs.`, `salem.`, `mind.`,
`pod.`, `feedback.`, plus `/terms` and `/privacy`).

Confirmed the Discord application's own metadata is not the source — the app
(`1529254721091801180`) has no `terms_of_service_url`, `privacy_policy_url`,
or `custom_install_url` set, so the URL came entirely from this code.

## Change

Four one-line edits:

- `src-tauri/src/discord_presence.rs` — `large_url` (the click target on the
  presence artwork, which is what a user actually reported hitting)
- `src-tauri/src/discord_presence.rs` — the `Open CovenCave` button target
- `src-tauri/src/discord_presence.rs` — the test assertion pinning that URL
- `docs/discord-rich-presence.md` — setup step 3 instructed operators to
  register the same wrong website

The `View on GitHub` button already pointed at the correct repository URL and
is unchanged.

## Verification

```
cargo test --manifest-path src-tauri/Cargo.toml --no-default-features discord_presence
```

```
running 5 tests
test discord_presence::tests::publishing_consumes_the_activity_response ... ok
test discord_presence::tests::activity_is_generic_and_uses_the_stable_cave_asset_key ... ok
test discord_presence::tests::publishing_answers_ping_before_reading_activity_response ... ok
test discord_presence::tests::publishing_rejects_non_frame_responses ... ok
test discord_presence::tests::publishing_rejects_discord_error_events ... ok

test result: ok. 5 passed; 0 failed
```

`rg 'covencave\.ai'` over the tree returns no matches after the change.

## Note on reach

Presence is published by the installed desktop app over Discord IPC, so this
only takes effect for builds shipped after it merges. Existing installs keep
pointing at the dead domain until they update. Registering `covencave.ai` and
301-ing it to `opencoven.ai` would fix every current install immediately and
close a plausible typo-squat vector — worth doing separately, regardless of
this PR.