### PR TITLE
build(desktop): default the Discord application ID so local builds publish presence

### DIFF
--- a/docs/discord-rich-presence.md
+++ b/docs/discord-rich-presence.md
@@ -13,25 +13,50 @@ any user content.
    Discord lowercases asset keys; keep this key stable.
 3. Set the application website to `https://opencoven.ai` and repository to
    `https://github.com/OpenCoven/coven-cave`.
-4. Provide its public Application ID as `COVENCAVE_DISCORD_APPLICATION_ID` at
-   build time. The ID is not a secret. Never add a client secret, bot token,
-   OAuth credential, project name, repository path, prompt, memory, terminal
-   output, or conversation data to the presence payload.
+4. Record its public Application ID as the `DEFAULT_APPLICATION_ID` constant in
+   [`src-tauri/build.rs`](../src-tauri/build.rs). The ID is not a secret. Never
+   add a client secret, bot token, OAuth credential, project name, repository
+   path, prompt, memory, terminal output, or conversation data to the presence
+   payload.
 
-For a local desktop build, set the variable before launching the app:
+## Where the Application ID comes from
+
+`src-tauri/build.rs` supplies `COVENCAVE_DISCORD_APPLICATION_ID` to the compiler
+on every build, so **no environment variable is needed** — a plain `pnpm dev:app`,
+`cargo build --release`, or `tauri build` all produce a binary that publishes
+presence.
+
+Set the variable to override the default (a fork running its own Discord
+application):
 
 ```bash
-COVENCAVE_DISCORD_APPLICATION_ID=<public-application-id> pnpm dev:app
+COVENCAVE_DISCORD_APPLICATION_ID=<other-public-application-id> pnpm dev:app
 ```
 
-Release builds receive the same public variable from the
-`COVENCAVE_DISCORD_APPLICATION_ID` repository variable, wired into the `build`
-job in [`.github/workflows/release.yml`](../.github/workflows/release.yml).
-**That repository variable must be set, or every shipped binary silently ships
-with Rich Presence disabled** — `option_env!` resolves at compile time, so an
-unset variable is baked into the artifact and cannot be fixed at runtime.
-Without it CovenCave continues normally and logs that Discord activity is
-disabled.
+Set it to the empty string to build presence out deliberately; CovenCave then
+continues normally and logs that Discord activity is disabled.
+
+Release builds still pass the `COVENCAVE_DISCORD_APPLICATION_ID` repository
+variable through the `build` job in
+[`.github/workflows/release.yml`](../.github/workflows/release.yml). That is now
+belt-and-braces rather than load-bearing: if the repository variable is ever
+unset, the build script's default keeps shipped binaries working.
+
+**Why the default exists.** `option_env!` resolves at compile time, so a build
+that does not see the variable bakes in `DISCORD_APPLICATION_ID = None` and
+cannot be repaired at runtime. Such a binary is indistinguishable from a healthy
+one — the only signal is a single log line, and Windows release builds set
+`windows_subsystem = "windows"`, so there is no console to print it to. Presence
+simply never appears, which reads as a Discord problem rather than a build one.
+
+To confirm any binary carries the ID:
+
+```bash
+rg -a -o '1529254721091801180|opencoven\.ai' <path-to-app-binary>
+```
+
+Two matches means presence is wired and points at the right domain; no matches
+means that build shipped without it.
 
 ## Verify
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,8 +4,44 @@ use std::path::{Path, PathBuf};
 
 fn main() {
   emit_sidecar_file_count_budget();
+  emit_discord_application_id();
   tauri_build::build()
 }
+
+/// Supply `COVENCAVE_DISCORD_APPLICATION_ID` so local builds get Rich Presence.
+///
+/// `discord_presence.rs` reads this through `option_env!`, which resolves at
+/// compile time. A build that does not see the variable bakes in
+/// `DISCORD_APPLICATION_ID = None` and can never publish activity, and nothing
+/// at runtime can repair it. Until now only `release.yml` passed the variable,
+/// so every local `cargo build` / `pnpm dev:app` / `tauri build` produced a
+/// presence-less binary that is indistinguishable from a working one — the sole
+/// signal is one log line, and on Windows release builds
+/// `windows_subsystem = "windows"` means there is no console to print it to.
+///
+/// Defaulting here removes that trap. The ID is public: it ships inside every
+/// binary, Discord serves it from an unauthenticated endpoint, and
+/// `release.yml` already carries it in a comment.
+///
+/// An explicit variable still wins, so CI and forks pointing at their own
+/// application are unaffected. Setting it to the empty string is an explicit
+/// opt-out and keeps the "not configured" branch reachable.
+///
+/// Unlike the budget above, a missing value here is not a correctness hazard —
+/// it degrades one cosmetic integration — so this defaults rather than panics.
+fn emit_discord_application_id() {
+  const DEFAULT_APPLICATION_ID: &str = "1529254721091801180";
+
+  // `option_env!` alone never triggers a rebuild when the variable changes;
+  // only a build script declaring the dependency does.
+  println!("cargo:rerun-if-env-changed={DISCORD_APPLICATION_ID_VAR}");
+
+  let application_id = env::var(DISCORD_APPLICATION_ID_VAR)
+    .unwrap_or_else(|_| DEFAULT_APPLICATION_ID.to_string());
+  println!("cargo:rustc-env={DISCORD_APPLICATION_ID_VAR}={application_id}");
+}
+
+const DISCORD_APPLICATION_ID_VAR: &str = "COVENCAVE_DISCORD_APPLICATION_ID";
 
 /// Generate `MAX_FILE_COUNT` from `scripts/sidecar-runtime-budget.json`.
 ///


### PR DESCRIPTION
## Problem

`src-tauri/src/discord_presence.rs` reads the application ID through
`option_env!`, which resolves **at compile time**:

```rust
const DISCORD_APPLICATION_ID: Option<&str> = option_env!("COVENCAVE_DISCORD_APPLICATION_ID");
```

Only `.github/workflows/release.yml` passed that variable. Every local build —
`pnpm dev:app`, `cargo build --release`, `tauri build` — compiled
`DISCORD_APPLICATION_ID = None`, producing a binary that can never publish Rich
Presence and cannot be repaired at runtime.

The failure is **silent and hard to attribute**. Such a binary is
indistinguishable from a healthy one; the only signal is a single log line, and
Windows release builds set `windows_subsystem = "windows"`, so there is no
console to print it to. Presence simply never appears, which reads as a Discord
problem rather than a build one.

This came up right after #4409 fixed the presence URLs: a locally built binary
carrying that fix would still have published nothing at all.

## Change

`src-tauri/build.rs` now supplies the value to the compiler on every build:

```rust
println!("cargo:rerun-if-env-changed={DISCORD_APPLICATION_ID_VAR}");
let application_id = env::var(DISCORD_APPLICATION_ID_VAR)
  .unwrap_or_else(|_| DEFAULT_APPLICATION_ID.to_string());
println!("cargo:rustc-env={DISCORD_APPLICATION_ID_VAR}={application_id}");
```

- **An explicit variable still wins**, so `release.yml` and forks running their
  own application are unaffected. The repository variable becomes
  belt-and-braces instead of load-bearing.
- **Empty string stays an explicit opt-out**, keeping the existing "not
  configured" branch reachable rather than dead code.
- **`rerun-if-env-changed` is required, not decorative.** `option_env!` in
  source does not trigger a rebuild when the variable changes; only a build
  script declaring the dependency does. Without it, overriding the variable
  would silently leave a stale binary — the same class of
  wrong-binary-looks-right bug this PR exists to remove.

The ID is not a secret: it ships inside every binary, Discord serves it from an
unauthenticated endpoint, and `release.yml` already carries it in a comment.

`discord_presence.rs` is untouched — `option_env!` simply always finds a value now.

Unlike `emit_sidecar_file_count_budget()` directly above it, this defaults
rather than panics: a missing budget relaxes a decompression-bomb guard, while
a missing ID degrades one cosmetic integration.

## Verification

Built with the variable **unset** — ID present:

```
$ echo "${COVENCAVE_DISCORD_APPLICATION_ID:-<unset>}"
<unset>
$ cargo build --manifest-path src-tauri/Cargo.toml
$ rg -a -o '1529254721091801180|opencoven\.ai' target/debug/app.exe | sort | uniq -c
      1 1529254721091801180
      1 opencoven.ai
```

Built with the variable **overridden** — override wins, default gone, and the
rebuild actually fired (14.6s, not a no-op), confirming `rerun-if-env-changed`:

```
$ COVENCAVE_DISCORD_APPLICATION_ID=1234567890123456789 cargo build --manifest-path src-tauri/Cargo.toml
$ rg -a -o '1529254721091801180|1234567890123456789' target/debug/app.exe | sort | uniq -c
      1 1234567890123456789
```

## Docs

`docs/discord-rich-presence.md` said the variable was required at build time and
warned that an unset one silently disables presence. That is no longer true for
local builds, so it is rewritten to describe where the ID comes from, how to
override or opt out, and how to check any binary:

```bash
rg -a -o '1529254721091801180|opencoven\.ai' <path-to-app-binary>
```

Leaving the doc stale was not an option — that same file is where the
`covencave.ai` instruction survived long enough to reach a shipped binary.