### PR TITLE
feat(discord): point the presence buttons at the Coven and the Cave

### DIFF
--- a/docs/discord-rich-presence.md
+++ b/docs/discord-rich-presence.md
@@ -65,9 +65,18 @@ means that build shipped without it.
 2. Run `cargo check --manifest-path src-tauri/Cargo.toml`.
 3. Launch CovenCave with `pnpm dev:app` and inspect its Discord profile card.
    It should show the Cave icon, generic status, and elapsed time.
-4. From a second Discord account, confirm the two public buttons point to
-   CovenCave and its GitHub repository. Discord does not show the publisher
-   its own Rich Presence buttons.
+4. From a second Discord account, confirm the two public buttons — **Join the
+   Coven** (`https://discord.gg/opencoven`) and **Enter the Cave**
+   (`https://opencoven.ai`) — and that clicking the Cave art asset opens the
+   GitHub repository. Discord does not show the publisher its own Rich Presence
+   buttons.
+
+Discord caps an activity at **two** buttons and rejects a third, which is why
+the repository link lives on the art asset's `large_url` rather than in a third
+button. A button can only open a URL, so presence cannot offer a screen-share
+action; Discord's equivalent is the Spectate flow, which needs `Secrets` and a
+`Party` on the payload plus an `ACTIVITY_SPECTATE` handler, none of which this
+worker implements.
 
 The worker retries while Discord is closed and reconnects after Discord
 restarts. The native app icon and Discord art asset are managed separately.

--- a/src-tauri/src/discord_presence.rs
+++ b/src-tauri/src/discord_presence.rs
@@ -25,18 +25,21 @@ fn unix_now() -> i64 {
 
 fn build_activity(started_at: i64) -> activity::Activity<'static> {
     activity::Activity::new()
-        .details("Desktop control room for OpenCoven")
-        .state("Working with familiars")
+        .details("Summoning familiars")
+        .state("In the Cave")
         .timestamps(activity::Timestamps::new().start(started_at))
         .assets(
             activity::Assets::new()
                 .large_image(ASSET_KEY)
                 .large_text("CovenCave")
-                .large_url("https://opencoven.ai"),
+                // Discord caps an activity at two buttons, so the repository
+                // link lives on the clickable art asset and both buttons stay
+                // free for the two destinations that recruit.
+                .large_url("https://github.com/OpenCoven/coven-cave"),
         )
         .buttons(vec![
-            activity::Button::new("Open CovenCave", "https://opencoven.ai"),
-            activity::Button::new("View on GitHub", "https://github.com/OpenCoven/coven-cave"),
+            activity::Button::new("Join the Coven", "https://discord.gg/opencoven"),
+            activity::Button::new("Enter the Cave", "https://opencoven.ai"),
         ])
 }
 
@@ -192,14 +195,35 @@ mod tests {
         let activity = build_activity(1_700_000_000);
         let serialized = serde_json::to_value(activity).expect("activity should serialize");
 
-        assert_eq!(serialized["details"], "Desktop control room for OpenCoven");
-        assert_eq!(serialized["state"], "Working with familiars");
+        assert_eq!(serialized["details"], "Summoning familiars");
+        assert_eq!(serialized["state"], "In the Cave");
         assert_eq!(serialized["assets"]["large_image"], ASSET_KEY);
-        assert_eq!(serialized["timestamps"]["start"], 1_700_000_000);
-        assert_eq!(serialized["buttons"][0]["url"], "https://opencoven.ai");
         assert_eq!(
-            serialized["buttons"][1]["url"],
+            serialized["assets"]["large_url"],
             "https://github.com/OpenCoven/coven-cave"
+        );
+        assert_eq!(serialized["timestamps"]["start"], 1_700_000_000);
+        assert_eq!(serialized["buttons"][0]["label"], "Join the Coven");
+        assert_eq!(
+            serialized["buttons"][0]["url"],
+            "https://discord.gg/opencoven"
+        );
+        assert_eq!(serialized["buttons"][1]["label"], "Enter the Cave");
+        assert_eq!(serialized["buttons"][1]["url"], "https://opencoven.ai");
+    }
+
+    #[test]
+    fn activity_stays_within_the_two_button_discord_limit() {
+        let activity = build_activity(1_700_000_000);
+        let serialized = serde_json::to_value(activity).expect("activity should serialize");
+
+        let buttons = serialized["buttons"]
+            .as_array()
+            .expect("activity should carry buttons");
+        assert!(
+            buttons.len() <= 2,
+            "Discord rejects an activity with more than 2 buttons, got {}",
+            buttons.len()
         );
     }
 


### PR DESCRIPTION
Closes cave-0rw.

## What

The Discord Rich Presence card spent both button slots on links that anyone already looking at the card mostly has — **Open CovenCave** → opencoven.ai and **View on GitHub** → the repo.

**Discord caps an activity at two buttons** and rejects a third ([crate docs](https://docs.rs/discord-rich-presence/1.1.0/discord_rich_presence/activity/struct.Activity.html#method.buttons): *"An activity may contain no more than 2 buttons"*), so those two slots are the scarce resource. This gives them to the two destinations that actually recruit, and moves the repository link onto the art asset's `large_url` — the big Cave icon is clickable — so nothing is lost.

| | Before | After |
|---|---|---|
| `details` | Desktop control room for OpenCoven | **Summoning familiars** |
| `state` | Working with familiars | **In the Cave** |
| Button 1 | Open CovenCave → opencoven.ai | **Join the Coven** → https://discord.gg/opencoven |
| Button 2 | View on GitHub → repo | **Enter the Cave** → https://opencoven.ai |
| Icon click (`large_url`) | opencoven.ai | the repository |

The invite is the one already canonical across the repo (`CONTRIBUTING.md:107`, `SECURITY.md:36`, `PROVENANCE.md:13`, and the iOS settings row).

## Privacy

Unchanged and deliberate: every string is a static literal. No project name, repository path, prompt, memory, terminal output, or conversation content enters the payload — the constraint stated at `discord_presence.rs:66-67` and in the doc still holds.

## Notes

- `activity_type` was considered and left alone — the alternatives render as *"Competing in CovenCave"* / *"Watching CovenCave"*, which read worse than the default *Playing*.
- A screen-share button is not possible: Rich Presence buttons open a URL and nothing else. Discord's equivalent is the Spectate flow, which needs `Secrets` + a `Party` on the payload plus an `ACTIVITY_SPECTATE` handler. Recorded in the doc as a known limit rather than left for the next person to rediscover.
- The lowercase `covencave` title on the card is the Discord application's name in the Developer Portal, not a value this repository controls.

## Test

- New `activity_stays_within_the_two_button_discord_limit` pins the cap, which otherwise fails at Discord rather than at compile time.
- `activity_is_generic_and_uses_the_stable_cave_asset_key` extended to assert both button labels, both URLs, and the new `large_url`.
- `cargo test --lib discord_presence` — 6 passed, 0 failed.
- `cargo fmt --check` clean for the edited file. (Pre-existing diffs in `build.rs` and `lib.rs` are untouched and predate this branch.)