### PR TITLE
fix(windows): stop console windows popping up over the app (cave-7jb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+### Fixed
+
+- Windows: console windows no longer pop up over the app when Cave runs a CLI.
+  Every child process now launches with `windowsHide: true`. Most visible in the
+  Research Desk, where a single mission iteration opened one window per familiar
+  step (cave-7jb).
+
 ## [0.2.4] - 2026-08-06
 
 > A tabbed sidebar, the Coding Room rebuilt as a three-zone workbench, image

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -124,6 +124,7 @@ export const SUITES = {
     "src/lib/model-control-capabilities.test.ts",
     "src/lib/chat-transcript-groups.test.ts",
     "src/components/chat-view-chunk-coalescing.test.ts",
+    "src/lib/child-spawn-window.test.ts",
     "src/lib/chunk-coalescer.test.ts",
     "src/components/chat-view-scroll-pin.test.ts",
     "src/components/home/use-home-model-state.test.ts",

--- a/src/app/api/beads/prs/route.ts
+++ b/src/app/api/beads/prs/route.ts
@@ -35,6 +35,7 @@ const MERGED_PR_LIMIT = "30";
 
 async function ghPrList(repoRoot: string, args: string[]): Promise<unknown> {
   const { stdout } = await execFileAsync("gh", args, {
+    windowsHide: true,
     cwd: repoRoot, // cwd's repo → gh targets the right OWNER/REPO without hardcoding
     env: { ...caveToolSpawnEnv(), GH_PROMPT_DISABLED: "1" },
     timeout: GH_TIMEOUT_MS,

--- a/src/app/api/changes/route.ts
+++ b/src/app/api/changes/route.ts
@@ -54,6 +54,7 @@ const DIFF_CAP_CHARS = 200 * 1024;
 /** Run git via execFile (argument array, no shell interpolation). */
 function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync("git", args, {
+    windowsHide: true,
     cwd,
     timeout: GIT_TIMEOUT_MS,
     maxBuffer: MAX_GIT_BUFFER,
@@ -73,11 +74,11 @@ function gitStatus(cwd: string, args: string[]): Promise<{ stdout: string; stder
 /** Network git (push) and `gh` can take longer than the read-only 10s budget. */
 const NET_TIMEOUT_MS = 60_000;
 function gitLong(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync("git", args, { cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
+  return execFileAsync("git", args, { windowsHide: true, cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
 }
 /** Run the GitHub CLI (argument array, no shell) for PR creation. */
 function ghCli(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync("gh", args, { cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
+  return execFileAsync("gh", args, { windowsHide: true, cwd, timeout: NET_TIMEOUT_MS, maxBuffer: MAX_GIT_BUFFER });
 }
 
 const PR_URL_RE = /https:\/\/github\.com\/[^\s]+\/pull\/\d+/;

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -194,6 +194,7 @@ export function probeHelpOutcome(
     };
     try {
       const child = spawn(/* turbopackIgnore: true */ command, args, {
+        windowsHide: true,
         env,
         cwd,
         stdio: input === undefined ? ["ignore", "pipe", "pipe"] : ["pipe", "pipe", "pipe"],
@@ -288,6 +289,7 @@ function probeOutput(
     };
     try {
       const child = spawn(/* turbopackIgnore: true */ command, args, {
+        windowsHide: true,
         env,
         stdio: ["ignore", "pipe", "pipe"],
         ...openCodeProbeSpawnOptions(),

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1094,6 +1094,7 @@ function openClawChatResponse(args: {
       const spawnChild = (mode: "gateway" | "local") => {
         const argv = openClawAgentArgs(args.harnessPrompt, agentId, conversationId, mode);
         return spawn(/* turbopackIgnore: true */ openclawLaunch.command, [...openclawLaunch.fixedArgs, ...argv], {
+          windowsHide: true,
           cwd,
           stdio: ["ignore", "pipe", "pipe"],
           env: openclawEnv,
@@ -4405,6 +4406,7 @@ export async function POST(req: Request) {
             ? (() => {
                 const sshArgs = spawnArgs;
                 return spawn("ssh", sshArgs, {
+                  windowsHide: true,
                   stdio: ["ignore", "pipe", "pipe"],
                   env: harnessSpawnEnv(body.familiarId),
                 });
@@ -4491,6 +4493,10 @@ export async function POST(req: Request) {
                     cwd: localPlan.cwd ?? cwd,
                     env: localPlan.env,
                     shell: false,
+                    // The sidecar runs without a console (CREATE_NO_WINDOW), so
+                    // a console-subsystem child would be given a fresh, visible
+                    // one. Every research familiar step spawns through here.
+                    windowsHide: true,
                   } as const;
                   if (openCodeDirect) {
                     const child = spawn(/* turbopackIgnore: true */ command.command, command.args, {

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -33,6 +33,7 @@ export async function POST(req: Request) {
   return new Promise<Response>((resolve) => {
     const { command, fixedArgs } = covenLaunchCommand();
     const child = spawn(command, [...fixedArgs, ...args], {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: covenSpawnEnv(),
     });

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -87,7 +87,9 @@ assert.match(
 );
 assert.match(
   source,
-  /function probeVersion\([\s\S]*?env: NodeJS\.ProcessEnv = covenSpawnEnv\(\)[\s\S]*?spawn\(binary,[\s\S]*?\{ env,/,
+  // The options object also carries `windowsHide: true` (see
+  // src/lib/child-spawn-window.test.ts); match `env` wherever it sits in it.
+  /function probeVersion\([\s\S]*?env: NodeJS\.ProcessEnv = covenSpawnEnv\(\)[\s\S]*?spawn\(binary,[\s\S]*?\{[^{}]*\benv,/,
   "version probing accepts the exact launch environment instead of always rebuilding one",
 );
 assert.doesNotMatch(

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -150,7 +150,7 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
 function whichWith(binary: string, env: NodeJS.ProcessEnv): Promise<string | null> {
   return new Promise((resolve) => {
     const command = process.platform === "win32" ? "where" : "which";
-    const child = spawn(command, [binary], { env, stdio: ["ignore", "pipe", "ignore"] });
+    const child = spawn(command, [binary], { windowsHide: true, env, stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.on("close", (code) => {
@@ -185,7 +185,7 @@ function probeVersion(
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(binary, [...fixedArgs, ...args], { env, stdio: ["ignore", "pipe", "pipe"] });
+      child = spawn(binary, [...fixedArgs, ...args], { windowsHide: true, env, stdio: ["ignore", "pipe", "pipe"] });
     } catch {
       resolve(null);
       return;
@@ -215,7 +215,7 @@ function probeGrokModels(
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(launch.command, [...launch.fixedArgs, "--no-auto-update", "models"], { env, stdio: ["ignore", "pipe", "pipe"] });
+      child = spawn(launch.command, [...launch.fixedArgs, "--no-auto-update", "models"], { windowsHide: true, env, stdio: ["ignore", "pipe", "pipe"] });
     } catch {
       resolve({ models: [], defaultModel: null });
       return;
@@ -241,7 +241,7 @@ function probeGrokModels(
 function covenSupportsAdapterList(): Promise<boolean> {
   return new Promise((resolve) => {
     const { command, fixedArgs } = covenLaunchCommand();
-    const child = spawn(command, [...fixedArgs, "--help"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(command, [...fixedArgs, "--help"], { windowsHide: true, env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -263,7 +263,7 @@ function covenSupportsAdapterList(): Promise<boolean> {
 function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   return new Promise((resolve) => {
     const { command, fixedArgs } = covenLaunchCommand();
-    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { windowsHide: true, env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     const t = setTimeout(() => {
       child.kill("SIGTERM");

--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -21,7 +21,7 @@ function probeSshHost(host: string): Promise<boolean> {
     const child = execFile(
       "ssh",
       ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=3", "--", host, "true"],
-      { timeout: PROBE_TIMEOUT_MS },
+      { windowsHide: true, timeout: PROBE_TIMEOUT_MS },
       (error) => resolve(!error),
     );
     child.on("error", () => resolve(false));

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -39,6 +39,7 @@ function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult
   return new Promise((resolve) => {
     const bin = tailscaleBin();
     const child = spawn(bin, args, {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: tailscaleSpawnEnv(),
     });

--- a/src/app/api/onboarding/install/install-process.ts
+++ b/src/app/api/onboarding/install/install-process.ts
@@ -17,6 +17,7 @@ export function runInstallProcess(
 ): Promise<InstallProcessResult> {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: covenSpawnEnv(),
       shell: options.shell,

--- a/src/app/api/onboarding/install/route.ts
+++ b/src/app/api/onboarding/install/route.ts
@@ -139,6 +139,7 @@ async function commandPath(
   const find = async (env: NodeJS.ProcessEnv) => {
     try {
       const { stdout } = await execFileAsync(finder, [binary], {
+        windowsHide: true,
         env,
         timeout: 1500,
       });
@@ -779,6 +780,7 @@ async function runInstallJob(
     }
 
     child = spawn(plan.command, plan.args, {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: plan.env,
       shell: plan.shell,

--- a/src/app/api/onboarding/ssh-check/route.ts
+++ b/src/app/api/onboarding/ssh-check/route.ts
@@ -61,6 +61,7 @@ export async function POST(req: Request) {
 
   return new Promise<Response>((resolve) => {
     const child = spawn("ssh", args, {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: covenSpawnEnv(),
     });

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -146,6 +146,7 @@ async function commandPath(
   const result = await withinDeadline(async (signal) => {
     try {
       const { stdout } = await execFileAsync(command, [binary], {
+        windowsHide: true,
         env,
         signal,
         timeout: remainingTimeout(1500, deadline),
@@ -262,6 +263,7 @@ async function loadCovenAdapterSummaries(
       command,
       [...fixedArgs, "--help"],
       {
+        windowsHide: true,
         env,
         signal,
         timeout: remainingTimeout(1500, deadline),
@@ -275,6 +277,7 @@ async function loadCovenAdapterSummaries(
       command,
       [...fixedArgs, "adapter", "list", "--json"],
       {
+        windowsHide: true,
         env,
         signal,
         timeout: remainingTimeout(3000, deadline),

--- a/src/app/api/project/files/route.ts
+++ b/src/app/api/project/files/route.ts
@@ -58,6 +58,7 @@ const cache = new Map<string, { at: number; payload: FilesPayload }>();
 /** Run git via execFile (argument array, no shell interpolation). */
 function git(cwd: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
   return execFileAsync("git", args, {
+    windowsHide: true,
     cwd,
     timeout: GIT_TIMEOUT_MS,
     maxBuffer: MAX_GIT_BUFFER,

--- a/src/app/api/project/search/route.ts
+++ b/src/app/api/project/search/route.ts
@@ -50,7 +50,7 @@ function runRipgrep(cwd: string, args: string[]): Promise<RgResult> {
     execFile(
       "rg",
       args,
-      { cwd, timeout: RG_TIMEOUT_MS, maxBuffer: MAX_RG_BUFFER },
+      { windowsHide: true, cwd, timeout: RG_TIMEOUT_MS, maxBuffer: MAX_RG_BUFFER },
       (err, stdout) => {
         if (!err) return resolve({ stdout, code: 0 });
         const code = (err as { code?: number }).code;
@@ -101,7 +101,7 @@ async function resolveSearchRoot(root: string): Promise<RootResolution> {
   // index. Reuse the daemon-session list already fetched above.
   try {
     const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
-      execFile("git", ["rev-parse", "--is-inside-work-tree"], { cwd: real, timeout: 10_000 }, (err, stdout) => {
+      execFile("git", ["rev-parse", "--is-inside-work-tree"], { windowsHide: true, cwd: real, timeout: 10_000 }, (err, stdout) => {
         if (err) reject(err);
         else resolve({ stdout });
       });

--- a/src/app/api/scry/route.ts
+++ b/src/app/api/scry/route.ts
@@ -189,6 +189,7 @@ function runCoven(
     try {
       const { command, fixedArgs } = covenLaunchCommand();
       child = spawn(command, [...fixedArgs, ...args], {
+        windowsHide: true,
         // No familiar means no familiar workspace: run where the app runs.
         cwd: process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -103,6 +103,7 @@ export async function POST(req: Request) {
     try {
       const { command, fixedArgs } = covenLaunchCommand();
       await execFileAsync(command, [...fixedArgs, "sacrifice", s.id, "--yes"], {
+        windowsHide: true,
         env: covenSpawnEnv(),
         timeout: SACRIFICE_TIMEOUT_MS,
       });

--- a/src/app/api/skills/directory/install/route.ts
+++ b/src/app/api/skills/directory/install/route.ts
@@ -77,6 +77,7 @@ export async function POST(req: Request) {
 
   try {
     const { stdout, stderr } = await execFileAsync("npx", args, {
+      windowsHide: true,
       cwd: process.cwd(),
       timeout: INSTALL_TIMEOUT_MS,
       maxBuffer: MAX_INSTALL_BUFFER,

--- a/src/app/api/skills/directory/use/route.ts
+++ b/src/app/api/skills/directory/use/route.ts
@@ -90,6 +90,7 @@ export async function POST(req: Request) {
   const args = buildUseArgs(target, skill);
   try {
     const { stdout, stderr } = await execFileAsync("npx", args, {
+      windowsHide: true,
       cwd: process.cwd(),
       timeout: USE_TIMEOUT_MS,
       maxBuffer: MAX_USE_BUFFER,

--- a/src/lib/branch-pr-context.ts
+++ b/src/lib/branch-pr-context.ts
@@ -79,7 +79,7 @@ function repoSlug(root: string): Promise<string> {
     execFile(
       "git",
       ["-C", root, "remote", "get-url", "origin"],
-      { timeout: 10_000, env: GH_ENV() },
+      { windowsHide: true, timeout: 10_000, env: GH_ENV() },
       (err, stdout) => {
         if (err) return reject(err);
         const m = /github\.com[:/]([^/\s]+\/[^/\s]+?)(?:\.git)?\s*$/.exec(stdout.trim());
@@ -108,7 +108,7 @@ const defaultRunner: BranchPrRunner = async (root, branch) => {
         "-f",
         "per_page=1",
       ],
-      { cwd: root, timeout: 10_000, env: GH_ENV() },
+      { windowsHide: true, cwd: root, timeout: 10_000, env: GH_ENV() },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });
@@ -127,7 +127,7 @@ const defaultUrlRunner: UrlPrRunner = (url) => {
     execFile(
       "gh",
       ["api", "-X", "GET", `repos/${slug}/pulls/${number}`],
-      { timeout: 10_000, env: GH_ENV() },
+      { windowsHide: true, timeout: 10_000, env: GH_ENV() },
       (err, stdout) => (err ? reject(err) : resolve(stdout)),
     );
   });

--- a/src/lib/child-spawn-window.test.ts
+++ b/src/lib/child-spawn-window.test.ts
@@ -1,0 +1,195 @@
+// @ts-nocheck
+// Guard: every child process Cave launches must carry `windowsHide: true`.
+//
+// Why this is a build gate rather than a style preference. The Tauri shell
+// starts the Node sidecar with CREATE_NO_WINDOW (see
+// `src-tauri/src/sidecar_startup.rs`), so the server process running our route
+// handlers has **no console attached**. Under Win32, `CreateProcess` on a
+// console-subsystem child from a console-less parent *allocates a new console*
+// — a real, visible conhost window — unless the child is given
+// CREATE_NO_WINDOW as well. Node spells that flag `windowsHide: true`.
+//
+// So on Windows a plain `spawn("git", …)` pops a black terminal window over the
+// app. The Research Desk made it impossible to miss: one mission iteration runs
+// seven `familiar` steps and every one of them opened a window (cave-7jb).
+//
+// The option is a no-op off Windows, so there is no platform branch to get
+// wrong — it belongs on every call, unconditionally.
+//
+// ⚠️ What it does NOT fix: a child launched through `shell: true`, or a
+// `.cmd`/`.bat` npm shim executed by `cmd.exe`. That window belongs to the
+// shell, not to the child. Resolve shims to a direct executable first with
+// `covenLaunchCommandForBinary()` (`src/lib/coven-bin.ts`).
+//
+// This mirrors the Rust-side assertion in `src-tauri/release-runtime.test.mjs`,
+// which pins `creation_flags(0x08000000)` on the sidecar launcher itself.
+
+import assert from "node:assert/strict";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+// `exec`/`execFile`/`spawn` and their Sync/Async (promisified) aliases. The
+// lookbehind keeps `RegExp.prototype.exec` — always called as `re.exec(` — out
+// of the results.
+const CHILD_PROCESS_CALL = /(?<![.\w$])(spawn|exec|execFile)(?:Sync|Async)?\s*\(/g;
+
+/**
+ * Call sites that forward an options object they do not own, so the flag is
+ * asserted at the object's definition instead. Keep this list short and give
+ * every entry a reason: an unexplained waiver is how the gate rots.
+ */
+const FORWARDS_CALLER_OPTIONS = new Map([
+  [
+    "lib/opencoven-tools-resolve.ts:30",
+    "default NpmPrefixExecFile impl; the type requires windowsHide: true from callers",
+  ],
+  [
+    "lib/opencoven-tools-status.ts:319",
+    "default execLatestVersion impl; the type requires windowsHide: true from callers",
+  ],
+  [
+    "lib/server/research-video-renderer.ts:186",
+    "default SpawnProcess impl; the type requires windowsHide: true from callers",
+  ],
+]);
+
+function sourceFiles(dir: string): string[] {
+  const found: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) found.push(...sourceFiles(full));
+    else if (/\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry)) found.push(full);
+  }
+  return found;
+}
+
+/**
+ * Replace comment and string/template bodies with spaces. Byte offsets survive,
+ * so line numbers stay accurate while prose mentioning `spawn(` cannot match.
+ */
+function blankNonCode(source: string): string {
+  const out = source.split("");
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to && k < out.length; k += 1) {
+      if (out[k] !== "\n") out[k] = " ";
+    }
+  };
+  let i = 0;
+  while (i < source.length) {
+    const pair = source.slice(i, i + 2);
+    if (pair === "//") {
+      const end = source.indexOf("\n", i);
+      const stop = end === -1 ? source.length : end;
+      blank(i, stop);
+      i = stop;
+    } else if (pair === "/*") {
+      const end = source.indexOf("*/", i + 2);
+      const stop = end === -1 ? source.length : end + 2;
+      blank(i, stop);
+      i = stop;
+    } else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
+      const quote = source[i];
+      let k = i + 1;
+      while (k < source.length) {
+        if (source[k] === "\\") k += 2;
+        else if (source[k] === quote) break;
+        else k += 1;
+      }
+      blank(i + 1, k);
+      i = k + 1;
+    } else i += 1;
+  }
+  return out.join("");
+}
+
+function matchingParen(code: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < code.length; i += 1) {
+    if (code[i] === "(") depth += 1;
+    else if (code[i] === ")") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+  }
+  return -1;
+}
+
+/** `const <name> = { … }` / `const <name> = { … } as const` body, if any. */
+function objectLiteralNamed(code: string, name: string): string | null {
+  const declaration = new RegExp(`(?<![.\\w$])${name}\\s*(?::[^=]*)?=\\s*\\{`).exec(code);
+  if (!declaration) return null;
+  const open = code.indexOf("{", declaration.index);
+  let depth = 0;
+  for (let i = open; i < code.length; i += 1) {
+    if (code[i] === "{") depth += 1;
+    else if (code[i] === "}") {
+      depth -= 1;
+      if (depth === 0) return code.slice(open, i + 1);
+    }
+  }
+  return null;
+}
+
+const offenders: string[] = [];
+const unusedWaivers = new Set(FORWARDS_CALLER_OPTIONS.keys());
+
+for (const file of sourceFiles(SRC_ROOT)) {
+  const raw = readFileSync(file, "utf8");
+  // Only files that actually import child_process launch anything. Without
+  // this, unrelated local helpers named `spawn` (the canvas particle emitter in
+  // `scry-glitch.tsx`, for one) would be flagged forever.
+  if (!/from\s+["']node:child_process["']/.test(raw)) continue;
+
+  const code = blankNonCode(raw);
+  const relative = path.relative(SRC_ROOT, file).replace(/\\/g, "/");
+  CHILD_PROCESS_CALL.lastIndex = 0;
+  let match: RegExpExecArray | null;
+  while ((match = CHILD_PROCESS_CALL.exec(code)) !== null) {
+    const open = match.index + match[0].length - 1;
+    const close = matchingParen(code, open);
+    if (close === -1) continue;
+    const call = code.slice(open, close + 1);
+    const line = raw.slice(0, match.index).split("\n").length;
+    const site = `${relative}:${line}`;
+
+    if (/windowsHide/.test(call)) continue;
+
+    // The options object may be spread in (`{ ...spawnOptions, … }`) or passed
+    // by name. Resolve one level: a same-file object literal carrying the flag
+    // satisfies the guard.
+    const referenced = Array.from(call.matchAll(/(?:\.\.\.|,\s*)([A-Za-z_$][\w$]*)\s*[,)]/g))
+      .map((reference) => reference[1])
+      .some((name) => /windowsHide/.test(objectLiteralNamed(code, name) ?? ""));
+    if (referenced) continue;
+
+    if (FORWARDS_CALLER_OPTIONS.has(site)) {
+      unusedWaivers.delete(site);
+      continue;
+    }
+    offenders.push(`${site}  ${call.slice(0, 70).replace(/\s+/g, " ")}`);
+  }
+}
+
+assert.deepEqual(
+  offenders,
+  [],
+  `child process launched without windowsHide: true — on Windows each of these opens a console window over the app (see the header of this file):\n  ${offenders.join("\n  ")}`,
+);
+
+assert.deepEqual(
+  Array.from(unusedWaivers),
+  [],
+  "FORWARDS_CALLER_OPTIONS lists call sites that no longer exist or no longer need a waiver — delete them",
+);
+
+// The scanner must actually be looking at something; an empty sweep (a moved
+// source root, a broken regex) would pass the assertions above vacuously.
+assert.ok(
+  sourceFiles(SRC_ROOT).some((file) =>
+    /from\s+["']node:child_process["']/.test(readFileSync(file, "utf8")),
+  ),
+  "no child_process importers found under src/ — the guard is scanning the wrong tree",
+);

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -278,6 +278,7 @@ function loginShellPath(discovery: DiscoveryOptions): string | null {
   if (timeout <= 0) return null;
   try {
     const out = execFileSync(/* turbopackIgnore: true */ shell, ["-ilc", "echo $PATH"], {
+      windowsHide: true,
       encoding: "utf-8",
       timeout,
       env: discovery.env,
@@ -333,6 +334,7 @@ function windowsRegistryPath(discovery: DiscoveryOptions): string | null {
     if (timeout <= 0) break;
     try {
       const out = execFileSync("reg", ["query", key, "/v", "Path"], {
+        windowsHide: true,
         encoding: "utf-8",
         timeout,
         env: discovery.env,
@@ -394,6 +396,7 @@ export function covenBin(): string {
   if (process.platform === "win32") {
     try {
       const out = execFileSync("where", ["coven"], {
+        windowsHide: true,
         encoding: "utf-8",
         timeout: 1500,
         env: {

--- a/src/lib/coven-version.ts
+++ b/src/lib/coven-version.ts
@@ -28,6 +28,7 @@ export async function installedCovenVersion(): Promise<string | null> {
   try {
     const { command, fixedArgs } = covenLaunchCommand();
     const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, "--version"], {
+      windowsHide: true,
       env: covenSpawnEnv(),
       timeout: 2500,
     });

--- a/src/lib/grok-bin.ts
+++ b/src/lib/grok-bin.ts
@@ -99,6 +99,7 @@ export function grokBin(): string {
   if (process.platform === "win32") {
     try {
       const output = execFileSync("where", ["grok"], {
+        windowsHide: true,
         encoding: "utf8",
         timeout: 1500,
         env: covenSpawnEnv(),

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -87,6 +87,7 @@ function loginShellPath(): string | null {
   const shell = env["SHELL"] ?? ["/bin", "zsh"].join("/");
   try {
     const out = execFileSync(shell, ["-ilc", "echo $PATH"], {
+      windowsHide: true,
       encoding: "utf-8",
       timeout: 4000,
     });

--- a/src/lib/omnigent/token.ts
+++ b/src/lib/omnigent/token.ts
@@ -146,7 +146,7 @@ async function mintDatabricksToken(workspaceHost: string): Promise<string | null
     const { stdout } = await execFileAsync(
       "databricks",
       ["auth", "token", "--host", workspaceHost],
-      { timeout: 15_000, maxBuffer: 256 * 1024, env: process.env },
+      { windowsHide: true, timeout: 15_000, maxBuffer: 256 * 1024, env: process.env },
     );
     const text = stdout.trim();
     if (!text) return null;

--- a/src/lib/openclaw-bridge.ts
+++ b/src/lib/openclaw-bridge.ts
@@ -174,6 +174,7 @@ async function loadOpenClawAgents(): Promise<OpenClawAgentSummary[]> {
   } = await import("./openclaw-bin.ts");
   return new Promise((resolve) => {
     const child = spawn(openClawBin(), openClawSpawnArgs(["agents", "list", "--json"]), {
+      windowsHide: true,
       stdio: ["ignore", "pipe", "ignore"],
       env: openClawSpawnEnv(),
       shell: openClawNeedsShell(),

--- a/src/lib/opencoven-tools-resolve.ts
+++ b/src/lib/opencoven-tools-resolve.ts
@@ -23,7 +23,7 @@ const execFileAsync = promisify(execFile);
 type NpmPrefixExecFile = (
   command: string,
   args: readonly string[],
-  options: { env: NodeJS.ProcessEnv; timeout: number },
+  options: { env: NodeJS.ProcessEnv; timeout: number; windowsHide: true },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 const defaultNpmPrefixExecFile: NpmPrefixExecFile = async (command, args, options) => {
@@ -126,7 +126,7 @@ export async function npmGlobalPrefixFromNpmPath(
     const { stdout } = await (dependencies.execFile ?? defaultNpmPrefixExecFile)(
       launch.command,
       [...launch.fixedArgs, "prefix", "-g"],
-      { env, timeout: 5000 },
+      { windowsHide: true, env, timeout: 5000 },
     );
     const prefix = stdout.trim();
     return prefix || null;
@@ -138,7 +138,7 @@ export async function npmGlobalPrefixFromNpmPath(
 async function defaultNpmGlobalPrefix(env: NodeJS.ProcessEnv): Promise<string | null> {
   const finder = process.platform === "win32" ? "where" : "which";
   try {
-    const { stdout: npmOut } = await execFileAsync(finder, ["npm"], { env, timeout: 1500 });
+    const { stdout: npmOut } = await execFileAsync(finder, ["npm"], { windowsHide: true, env, timeout: 1500 });
     const npm =
       process.platform === "win32"
         ? pickWindowsLauncher(npmOut.split(/\r?\n/))

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -77,7 +77,7 @@ type NpmLatestCheckDependencies = {
   execFile?: (
     command: string,
     args: string[],
-    options: { env: NodeJS.ProcessEnv; timeout: number },
+    options: { env: NodeJS.ProcessEnv; timeout: number; windowsHide: true },
   ) => Promise<{ stdout: string }>;
   now?: () => Date;
 };
@@ -142,7 +142,7 @@ async function commandPath(
   const timeout = options.timeoutMs ?? LOOKUP_TIMEOUT_MS;
   const find = async (env: NodeJS.ProcessEnv): Promise<CommandPathResult> => {
     try {
-      const { stdout } = await execFileAsync(finder, [binary], { env, timeout });
+      const { stdout } = await execFileAsync(finder, [binary], { windowsHide: true, env, timeout });
       const lines = stdout.split(/\r?\n/);
       return {
         path:
@@ -286,7 +286,7 @@ export async function probeOpenCovenBinaryAt(
     const { stdout, stderr } = await execFileAsync(
       launch.command,
       [...launch.fixedArgs, ...tool.versionArgs],
-      { env, timeout: options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS },
+      { windowsHide: true, env, timeout: options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS },
     );
     const version = firstSemver(`${stdout}\n${stderr}`);
     return {
@@ -314,7 +314,7 @@ export async function probeOpenCovenBinaryAt(
 async function execLatestVersion(
   command: string,
   args: string[],
-  options: { env: NodeJS.ProcessEnv; timeout: number },
+  options: { env: NodeJS.ProcessEnv; timeout: number; windowsHide: true },
 ): Promise<{ stdout: string }> {
   const { stdout } = await execFileAsync(command, args, options);
   return { stdout: String(stdout) };
@@ -358,7 +358,7 @@ async function npmPathFromEnvironment(
 ): Promise<string | null> {
   const finder = platform === "win32" ? "where" : "which";
   try {
-    const { stdout } = await exec(finder, ["npm"], { env, timeout: 1500 });
+    const { stdout } = await exec(finder, ["npm"], { windowsHide: true, env, timeout: 1500 });
     const lines = stdout.split(/\r?\n/);
     return platform === "win32"
       ? pickWindowsLauncher(lines)
@@ -447,7 +447,7 @@ export async function checkNpmLatestVersion(
     const { stdout } = await exec(
       launch.command,
       [...launch.fixedArgs, "view", tool.packageName, "version", "--json"],
-      { env, timeout: 5000 },
+      { windowsHide: true, env, timeout: 5000 },
     );
     const parsed = JSON.parse(stdout);
     const latest = typeof parsed === "string" ? firstSemver(parsed) : null;

--- a/src/lib/queue-project-readiness.ts
+++ b/src/lib/queue-project-readiness.ts
@@ -130,6 +130,7 @@ type GitTopLevel =
 async function gitTopLevel(root: string): Promise<GitTopLevel> {
   try {
     const { stdout } = await execFileAsync("git", ["rev-parse", "--show-toplevel"], {
+      windowsHide: true,
       cwd: /* turbopackIgnore: true */ root,
       env: caveToolSpawnEnv(),
       timeout: GIT_TIMEOUT_MS,

--- a/src/lib/server/beads-cli.ts
+++ b/src/lib/server/beads-cli.ts
@@ -10,7 +10,13 @@ type ExecResult = { stdout: string; stderr: string };
 type Exec = (
   file: string,
   args: string[],
-  options: { cwd?: string; env: NodeJS.ProcessEnv; timeout: number; maxBuffer: number },
+  options: {
+    cwd?: string;
+    env: NodeJS.ProcessEnv;
+    timeout: number;
+    maxBuffer: number;
+    windowsHide: true;
+  },
 ) => Promise<ExecResult>;
 
 export type BdResult =
@@ -25,6 +31,7 @@ class BdUnavailableError extends Error {}
 
 async function wslPath(exec: Exec, value: string, env: NodeJS.ProcessEnv): Promise<string> {
   const { stdout } = await exec("wsl.exe", ["-e", "wslpath", "-a", "-u", value], {
+    windowsHide: true,
     env,
     timeout: BD_TIMEOUT_MS,
     maxBuffer: MAX_BD_BUFFER,
@@ -45,6 +52,7 @@ async function runBdViaWsl(
     wslPath(exec, repoRoot, env),
     wslPath(exec, beadsDir, env),
     exec("wsl.exe", ["-e", "sh", "-lc", "command -v bd"], {
+      windowsHide: true,
       env,
       timeout: BD_TIMEOUT_MS,
       maxBuffer: MAX_BD_BUFFER,
@@ -69,7 +77,7 @@ async function runBdViaWsl(
       bd,
       ...args,
     ],
-    { env, timeout: BD_TIMEOUT_MS, maxBuffer: MAX_BD_BUFFER },
+    { windowsHide: true, env, timeout: BD_TIMEOUT_MS, maxBuffer: MAX_BD_BUFFER },
   );
 }
 
@@ -89,6 +97,7 @@ export async function runBdCommand(
 
   try {
     const { stdout, stderr } = await exec("bd", args, {
+      windowsHide: true,
       cwd: repoRoot,
       env,
       timeout: BD_TIMEOUT_MS,

--- a/src/lib/server/chat-work-branch.ts
+++ b/src/lib/server/chat-work-branch.ts
@@ -31,6 +31,7 @@ export async function captureWorkBranch(cwd: string | null): Promise<string | nu
   if (!cwd) return null;
   try {
     const { stdout } = await execFileAsync("git", ["branch", "--show-current"], {
+      windowsHide: true,
       cwd,
       encoding: "utf8",
       timeout: GIT_TIMEOUT_MS,

--- a/src/lib/server/codex-oauth-port.ts
+++ b/src/lib/server/codex-oauth-port.ts
@@ -69,6 +69,7 @@ export async function pidHoldingPort(port: number): Promise<number | null> {
   let stdout: string;
   try {
     const result = await execFileAsync("lsof", ["-ti", `tcp:${port}`], {
+      windowsHide: true,
       timeout: 2000,
     });
     stdout = result.stdout;
@@ -104,7 +105,7 @@ export async function describePid(pid: number): Promise<string> {
     const { stdout } = await execFileAsync(
       "ps",
       ["-o", "command=", "-p", String(pid)],
-      { timeout: 2000 },
+      { windowsHide: true, timeout: 2000 },
     );
     return stdout.trim();
   } catch {

--- a/src/lib/server/coven-oneshot.ts
+++ b/src/lib/server/coven-oneshot.ts
@@ -58,6 +58,7 @@ export function runCovenOneShot(
       let settled = false;
       const { command, fixedArgs } = covenLaunchCommand();
       const child = spawn(command, [...fixedArgs, ...args], {
+        windowsHide: true,
         cwd: cwd ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
         env: harnessSpawnEnv(familiarId),

--- a/src/lib/server/flow-copilot-session.ts
+++ b/src/lib/server/flow-copilot-session.ts
@@ -110,6 +110,7 @@ export function startCopilotFlowRun(launch: CopilotFlowLaunch): CopilotFlowStart
     fixedArgs: [],
   };
   const child = spawn(command.command, [...command.fixedArgs, ...args], {
+    windowsHide: true,
     cwd: launch.projectRoot,
     env: harnessSpawnEnv(launch.familiarId),
     stdio: ["ignore", "pipe", "pipe"],

--- a/src/lib/server/issue-worktree-provision.ts
+++ b/src/lib/server/issue-worktree-provision.ts
@@ -35,7 +35,7 @@ const FETCH_TIMEOUT_MS = 10_000;
 const MAX_GIT_BUFFER = 16 * 1024 * 1024;
 
 function git(cwd: string, args: string[], timeout: number = GIT_TIMEOUT_MS) {
-  return execFileAsync("git", args, { cwd, env: caveToolSpawnEnv(), timeout, maxBuffer: MAX_GIT_BUFFER });
+  return execFileAsync("git", args, { windowsHide: true, cwd, env: caveToolSpawnEnv(), timeout, maxBuffer: MAX_GIT_BUFFER });
 }
 
 export type RepoRootResolution =

--- a/src/lib/server/onboarding-prerequisite-probes.ts
+++ b/src/lib/server/onboarding-prerequisite-probes.ts
@@ -40,7 +40,7 @@ function platformId(): "win32" | "darwin" | "linux" | "ios" | "android" {
 async function commandPath(binary: string): Promise<string | null> {
   const command = process.platform === "win32" ? "where" : "which";
   try {
-    const { stdout } = await execFileAsync(command, [binary], { env: covenSpawnEnv(), timeout: PROBE_TIMEOUT_MS });
+    const { stdout } = await execFileAsync(command, [binary], { windowsHide: true, env: covenSpawnEnv(), timeout: PROBE_TIMEOUT_MS });
     const lines = stdout.split(/\r?\n/);
     return process.platform === "win32" ? pickWindowsLauncher(lines) : lines.map((line) => line.trim()).find(Boolean) ?? null;
   } catch {
@@ -99,7 +99,7 @@ async function desktopNativeProbe(definition: PrerequisiteDefinition): Promise<P
   }
   if (definition.id === "windows-webview2") {
     try {
-      const { stdout } = await execFileAsync("reg", ["query", "HKLM\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients", "/s"], { timeout: PROBE_TIMEOUT_MS });
+      const { stdout } = await execFileAsync("reg", ["query", "HKLM\\SOFTWARE\\Microsoft\\EdgeUpdate\\Clients", "/s"], { windowsHide: true, timeout: PROBE_TIMEOUT_MS });
       return /webview2/i.test(stdout) ? { state: "pass", detail: "WebView2 runtime is registered for this Windows installation." } : { state: "unknown", detail: "WebView2 could not be confirmed from the registry." };
     } catch {
       return { state: "unknown", detail: "WebView2 is installed by the CovenCave MSI; registry probing was unavailable." };
@@ -108,7 +108,7 @@ async function desktopNativeProbe(definition: PrerequisiteDefinition): Promise<P
   if (definition.id === "linux-desktop-runtime") {
     const session = process.env.WAYLAND_DISPLAY || process.env.DISPLAY;
     try {
-      const { stdout } = await execFileAsync("ldconfig", ["-p"], { timeout: PROBE_TIMEOUT_MS });
+      const { stdout } = await execFileAsync("ldconfig", ["-p"], { windowsHide: true, timeout: PROBE_TIMEOUT_MS });
       const webkit = /libwebkit2gtk-4\.1/i.test(stdout);
       const fuse = await commandPath("fusermount3") ?? await commandPath("fusermount");
       if (!webkit || !session) {

--- a/src/lib/server/openclaw-device-credentials.ts
+++ b/src/lib/server/openclaw-device-credentials.ts
@@ -129,6 +129,7 @@ function decodePayload(secret: string): unknown {
 function defaultRunSecurity(args: string[], input?: string): SecurityResult {
   try {
     const stdout = execFileSync(SECURITY_BIN, args, {
+      windowsHide: true,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
       ...(input === undefined ? {} : { input }),

--- a/src/lib/server/opencode-models.ts
+++ b/src/lib/server/opencode-models.ts
@@ -37,6 +37,7 @@ export function listOpenCodeModels(familiarId?: string | null): Promise<RuntimeM
         return;
       }
       const child = spawn(launch.command, launch.args, {
+        windowsHide: true,
         // Match the chat spawn's vault scope. A provider key can be granted to
         // one familiar only, and listing its authenticated OpenCode models must
         // not silently drop that key by using the unscoped probe environment.

--- a/src/lib/server/process-intent-lock.ts
+++ b/src/lib/server/process-intent-lock.ts
@@ -107,21 +107,19 @@ async function processStartIdentity(pid: number): Promise<string | null> {
         `$p = Get-CimInstance Win32_Process -Filter "ProcessId = ${pid}"`,
         `if ($null -ne $p) { $p.CreationDate.ToUniversalTime().Ticks }`,
       ].join("; ");
-      const { stdout } = await execFileAsync("powershell.exe", [
-        "-NoProfile",
-        "-NonInteractive",
-        "-Command",
-        script,
-      ]);
+      const { stdout } = await execFileAsync(
+        "powershell.exe",
+        ["-NoProfile", "-NonInteractive", "-Command", script],
+        { windowsHide: true },
+      );
       const startedAt = stdout.trim();
       if (startedAt) return `win32:${startedAt}`;
     } else {
-      const { stdout } = await execFileAsync("ps", [
-        "-o",
-        "lstart=",
-        "-p",
-        String(pid),
-      ]);
+      const { stdout } = await execFileAsync(
+        "ps",
+        ["-o", "lstart=", "-p", String(pid)],
+        { windowsHide: true },
+      );
       const startedAt = stdout.trim().replace(/\s+/g, " ");
       if (startedAt) return `${process.platform}:${startedAt}`;
     }

--- a/src/lib/server/research-media-readiness.ts
+++ b/src/lib/server/research-media-readiness.ts
@@ -15,7 +15,7 @@ import { resolveSecret } from "../vault.ts";
 import { speechEnginesReadiness } from "../voice/speech-models.ts";
 
 const execFileAsync = promisify(execFile);
-const probeOptions = { timeout: 3_000, maxBuffer: 32 * 1024 };
+const probeOptions = { windowsHide: true, timeout: 3_000, maxBuffer: 32 * 1024 };
 
 type ReadinessVoice = {
   id: string;

--- a/src/lib/server/research-video-renderer.ts
+++ b/src/lib/server/research-video-renderer.ts
@@ -141,6 +141,7 @@ type SpawnProcess = (
   options: {
     cwd: string;
     stdio: ["ignore", "pipe", "pipe"];
+    windowsHide: true;
   },
 ) => SpawnedProcess;
 
@@ -186,6 +187,7 @@ export function runResearchVideoCommand(
   const child = spawnProcess(command, args, {
     cwd: options.cwd,
     stdio: ["ignore", "pipe", "pipe"],
+    windowsHide: true,
   });
   const killGraceMs = options.killGraceMs ?? 2_000;
   const escalateKill = options.escalateKill ?? true;

--- a/src/lib/server/stuck-created-sweep.ts
+++ b/src/lib/server/stuck-created-sweep.ts
@@ -93,6 +93,7 @@ export async function sweepStuckCreatedSessions(opts: {
       try {
         const { command, fixedArgs } = covenLaunchCommand();
         await execFileAsync(command, [...fixedArgs, "sacrifice", id, "--yes"], {
+          windowsHide: true,
           env: covenSpawnEnv(),
           timeout: SACRIFICE_TIMEOUT_MS,
         });

--- a/src/lib/server/tailscale-devices.ts
+++ b/src/lib/server/tailscale-devices.ts
@@ -87,7 +87,7 @@ export function loadTailscaleDevices(timeoutMs = 5000): Promise<TailscaleDevices
     execFile(
       tailscaleBin(),
       ["status", "--json"],
-      { encoding: "utf8", timeout: timeoutMs, env: tailscaleSpawnEnv(), maxBuffer: 2 * 1024 * 1024 },
+      { windowsHide: true, encoding: "utf8", timeout: timeoutMs, env: tailscaleSpawnEnv(), maxBuffer: 2 * 1024 * 1024 },
       (error, stdout, stderr) => {
         if (error) {
           resolve({ ok: false, reason: typedTailscaleFailure(error, `${stdout} ${stderr}`) });

--- a/src/lib/session-git-enrich.ts
+++ b/src/lib/session-git-enrich.ts
@@ -48,6 +48,7 @@ export type GitRunner = (projectRoot: string, args: string[]) => Promise<string 
 export const defaultGitRunner: GitRunner = async (projectRoot, args) => {
   try {
     const { stdout } = await execFileAsync("git", args, {
+      windowsHide: true,
       cwd: projectRoot,
       encoding: "utf8",
       timeout: GIT_TIMEOUT_MS,


### PR DESCRIPTION
## The bug

On Windows, running research in the Research Desk pops black terminal windows
over the app — one per familiar step, so seven per mission iteration.

## Cause

The Tauri shell starts the Node sidecar with `CREATE_NO_WINDOW`
(`src-tauri/src/sidecar_startup.rs:415`), so the server process running our
route handlers has **no console attached**. Under Win32, `CreateProcess` on a
console-subsystem child from a console-less parent *allocates a new console* — a
real, visible conhost window — unless the child is given `CREATE_NO_WINDOW` too.
Node spells that flag `windowsHide: true`.

The harness spawn every research familiar step goes through
(`src/app/api/chat/send/route.ts`) built its options with `cwd`, `env` and
`shell: false`, but no `windowsHide`. Most other spawn sites were the same.

It reads as an omission rather than a decision, because the sites right next to
it already get it right — `chat-send-capabilities.ts:153` (taskkill),
`grok-compatibility.ts`, `claude-models.ts`, `daemon-start.ts`, and the
`coven-bin.ts` toolchain probes all pass it.

## The fix

`windowsHide: true` on every `child_process` call under `src/` — 70 sites across
45 files. It is a no-op off Windows, so there is no platform branch to get
wrong.

Three call sites forward an options object they do not own
(`NpmPrefixExecFile`, `execLatestVersion`, `SpawnProcess`). Their signatures now
*require* `windowsHide: true`, so the obligation moves to the caller and the
compiler checks it.

Two spawns had no options argument at all — including
`execFileAsync("powershell.exe", …)` in `process-intent-lock.ts`, which opened a
PowerShell window.

## The ratchet

`src/lib/child-spawn-window.test.ts` fails the build on any new call site that
omits the flag. It parses every `node:child_process` importer under `src/`,
blanks comments and string bodies so prose can't match, and resolves one level
of indirection for options passed by name or spread. Waivers are an explicit
three-entry list, each with a reason, and the test fails if a waiver stops being
needed.

This mirrors `src-tauri/release-runtime.test.mjs`, which already pins
`creation_flags(0x08000000)` on the Rust sidecar launcher.

Verified it catches a regression: deleting the flag from `chat-work-branch.ts`
fails the test with that exact file and line.

**What it does not cover**, called out in the test header: a child launched via
`shell: true` or a `.cmd`/`.bat` shim run by `cmd.exe`. That window belongs to
the shell, not the child. `covenLaunchCommandForBinary()` already resolves npm
shims to a direct executable, so the harness path is covered.

## Test note

One existing source-shape assertion in `api/harnesses/route.test.ts` pinned
`{ env,` as the *literal start* of the options object. It now matches `env`
wherever it sits, which is what it meant to assert.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- New guard test passes; confirmed it fails when the flag is removed
- Sibling tests for all 45 changed modules, plus every source-shape test that
  reads a changed module, run individually

Six of those failed **identically on `origin/main`** with the change stashed —
all pre-existing Windows-environment failures (symlink creation, `chmod`,
looking for a PATH entry literally named `git` rather than `git.exe`, a fixture
directory with a trailing space). Only `api/harnesses/route.test.ts` was a real
regression from this change, and it is fixed here. CI on Linux is the real
signal for those six.
