### PR TITLE
Exclude detached worktrees from the managed-creation admission budget

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1064,16 +1064,23 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   const existingPath = addWorktree(fixture, "feat/cave-unit1-existing", "cave-unit1-existing");
   // Drive the registration count to exactly WORKTREE_WARNING_BUDGET so admission
   // refuses at `count >= budget`. The count includes the primary checkout, so the
-  // arithmetic is: 18 detached + 1 existing (above) + 1 primary = 20. If the
+  // arithmetic is: 18 attached + 1 existing (above) + 1 primary = 20. If the
   // budget moves again, this loop moves with it (budget - 2).
+  //
+  // These MUST be branch-attached (cave-oenag). They were `--detach` until the
+  // budget stopped counting detached units, at which point this fixture stopped
+  // reaching the budget at all and the refusal below silently disappeared — the
+  // fixture was simulating sprawl with exactly the scratch space the budget now
+  // ignores. The separate detached case is asserted below.
   for (let index = 0; index < 18; index += 1) {
     git(
       [
         "worktree",
         "add",
         "-q",
-        "--detach",
-        path.join(fixture.repo, ".worktrees", `budget-detached-${index}`),
+        "-b",
+        `budget/attached-${index}`,
+        path.join(fixture.repo, ".worktrees", `budget-attached-${index}`),
         "origin/main",
       ],
       fixture.repo,

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -6,9 +6,8 @@ import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import {
   assessManagedWorktreeCreation,
-  BRANCH_WARNING_BUDGET,
+  calculateLifecycleBudgets,
   isDisposableIgnoredPath,
-  WORKTREE_WARNING_BUDGET,
   type LifecycleDisposition,
   type ManagedCreationException,
   type WorktreeLifecycleBudgets,
@@ -971,22 +970,20 @@ function assessLocalRefusalPreflight(
       requestedPath,
       nowMs,
       existingPaths: structuredPaths,
-      budgets: {
-        worktrees: {
-          count: registrations.length,
-          warning: WORKTREE_WARNING_BUDGET,
-          exceeded: registrations.length > WORKTREE_WARNING_BUDGET,
-        },
-        branches: {
-          count: branchCount,
-          warning: BRANCH_WARNING_BUDGET,
-          exceeded: branchCount > BRANCH_WARNING_BUDGET,
-        },
-        exceptions: {
-          active: 0,
-          expired: 0,
-        },
-      },
+      // Routed through the shared calculation rather than repeating the
+      // arithmetic here. This preflight is the surface that actually issues the
+      // refusal, so a second copy of the rule is a second place for it to drift
+      // — which is how the detached-unit exclusion (cave-oenag) could have
+      // landed in the report while the refusal kept the old count.
+      budgets: calculateLifecycleBudgets({
+        worktreeCount: registrations.length,
+        detachedWorktreeCount: registrations.filter(
+          (registration) => registration.branch === null,
+        ).length,
+        branchCount,
+        activeExceptions: 0,
+        expiredExceptions: 0,
+      }),
       exception: exceptionForAssessment(exception),
     }),
     registeredPaths,

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -2832,6 +2832,8 @@ export function collectWorktreeLifecycleInventory(
   ];
   const budgets = calculateLifecycleBudgets({
     worktreeCount: entries.length,
+    // `branch` is null exactly when the worktree is on a detached HEAD.
+    detachedWorktreeCount: entries.filter((entry) => entry.branch === null).length,
     branchCount: localRefs.length,
     activeExceptions: exceptions.filter(
       (exception) => Date.parse(exception.expiresAt) > options.nowMs,

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1767,7 +1767,10 @@ exit 0
   assert.match(humanReport, /uncommitted\.txt/, "the routine report includes exact dirty paths");
   assert.match(
     humanReport,
-    /^Worktree budget: 8\/20 \(within budget\)$/m,
+    // cave-oenag: this fixture registers one detached unit, so the assessed
+    // count is 7 of 8 and the line says which one it dropped. Anchored end-of-line
+    // so the note has to be present and exact, not merely tolerated.
+    /^Worktree budget: 7\/20 \(within budget\) — 1 detached unit not counted \(8 registered\)$/m,
     "the routine report uses the lifecycle renderer's exact worktree budget line",
   );
   assert.match(

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1676,7 +1676,8 @@ exit 0
     "the stable direct landing becomes eligible after 8 hours",
   );
   assert.deepEqual(report.budgets, {
-    worktrees: { count: 8, warning: 20, exceeded: false },
+    // cave-oenag: 8 registered, one of them detached, so 7 are assessed.
+    worktrees: { count: 7, registered: 8, detached: 1, warning: 20, exceeded: false },
 
     branches: { count: 11, warning: 30, exceeded: false },
     exceptions: { active: 0, expired: 0 },

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -228,6 +228,34 @@ function legacyObservation(overrides = {}) {
   assert.match(item.reasons.join("\n"), /metadata backfill/i);
 }
 
+// cave-oenag: a detached unit with no metadata is not a managed worktree
+// awaiting backfill — there is no bead to backfill onto. It reaches the same
+// fail-closed lane, but "backfill required" points the reader at a remedy that
+// cannot apply here.
+{
+  const item = classifyLifecycleUnit(
+    observation({
+      path: "/repo/.worktrees/_review-verify-76452b0",
+      metadata: null,
+      branch: null,
+      ref: null,
+      remoteRef: null,
+      remoteRefsContainingHead: [],
+      headOnDefaultBranch: true,
+    }),
+    NOW,
+  );
+  assert.equal(item.lane, "uncertain", "detached scratch still fails closed");
+  const reasons = item.reasons.join("\n");
+  assert.match(reasons, /detached HEAD with no lifecycle metadata/i);
+  assert.match(reasons, /prove retention first/i);
+  assert.doesNotMatch(
+    reasons,
+    /backfill/i,
+    "there is no bead to backfill a record onto, so it must not suggest one",
+  );
+}
+
 {
   const item = classifyLifecycleUnit(
     observation({
@@ -554,9 +582,104 @@ function legacyObservation(overrides = {}) {
   assert.equal(exceeded.branches.exceeded, true);
 }
 
+// cave-oenag: detached units are excluded from the assessment. They are never
+// made by the managed creator and can never be retired by the patrol, so
+// counting them lets units the gate has no authority over refuse the ones it
+// does.
+{
+  const withScratch = calculateLifecycleBudgets({
+    worktreeCount: WORKTREE_WARNING_BUDGET + 3,
+    detachedWorktreeCount: 3,
+    branchCount: 0,
+    activeExceptions: 0,
+    expiredExceptions: 0,
+  });
+  assert.equal(withScratch.worktrees.count, WORKTREE_WARNING_BUDGET, "detached units are not assessed");
+  assert.equal(
+    withScratch.worktrees.registered,
+    WORKTREE_WARNING_BUDGET + 3,
+    "every unit stays visible",
+  );
+  assert.equal(withScratch.worktrees.detached, 3);
+  assert.equal(
+    withScratch.worktrees.exceeded,
+    false,
+    "three scratch units do not push a full checkout over",
+  );
+
+  // The load-bearing assertion: the exclusion has to reach the refusal, not
+  // only the report. This is the exact shape that refused cave-oenag's own
+  // worktree creation — a checkout at the budget purely because of scratch.
+  const admission = assessManagedWorktreeCreation({
+    beadId: "cave-71ku9",
+    requestedPath: "/repo/.worktrees/cave-71ku9",
+    nowMs: NOW,
+    existingPaths: [],
+    budgets: calculateLifecycleBudgets({
+      worktreeCount: WORKTREE_WARNING_BUDGET + 3,
+      detachedWorktreeCount: 4,
+      branchCount: 0,
+      activeExceptions: 0,
+      expiredExceptions: 0,
+    }),
+  });
+  assert.deepEqual(
+    admission,
+    { allowed: true, reasons: [] },
+    "scratch worktrees no longer refuse managed creation",
+  );
+
+  // …and the budget still bites when the units are real branch-attached work.
+  const attachedOnly = assessManagedWorktreeCreation({
+    beadId: "cave-71ku9",
+    requestedPath: "/repo/.worktrees/cave-71ku9",
+    nowMs: NOW,
+    existingPaths: [],
+    budgets: calculateLifecycleBudgets({
+      worktreeCount: WORKTREE_WARNING_BUDGET,
+      detachedWorktreeCount: 0,
+      branchCount: 0,
+      activeExceptions: 0,
+      expiredExceptions: 0,
+    }),
+  });
+  assert.equal(attachedOnly.allowed, false, "the budget still refuses real branch-attached sprawl");
+
+  // Omitting the field reproduces the pre-cave-oenag arithmetic exactly.
+  const legacy = calculateLifecycleBudgets({
+    worktreeCount: 5,
+    branchCount: 0,
+    activeExceptions: 0,
+    expiredExceptions: 0,
+  });
+  assert.equal(legacy.worktrees.count, 5);
+  assert.equal(legacy.worktrees.detached, 0);
+  assert.equal(legacy.worktrees.registered, 5);
+
+  assert.throws(
+    () =>
+      calculateLifecycleBudgets({
+        worktreeCount: 2,
+        detachedWorktreeCount: 3,
+        branchCount: 0,
+        activeExceptions: 0,
+        expiredExceptions: 0,
+      }),
+    /detachedWorktreeCount must not exceed worktreeCount/,
+    "a detached count larger than the total is incoherent, not a clamp",
+  );
+}
+
 {
   for (const badCounts of [
     { worktreeCount: -1, branchCount: 0, activeExceptions: 0, expiredExceptions: 0 },
+    {
+      worktreeCount: 2,
+      detachedWorktreeCount: -1,
+      branchCount: 0,
+      activeExceptions: 0,
+      expiredExceptions: 0,
+    },
     { worktreeCount: 0, branchCount: 1.5, activeExceptions: 0, expiredExceptions: 0 },
     { worktreeCount: 0, branchCount: 0, activeExceptions: Number.NaN, expiredExceptions: 0 },
   ]) {
@@ -723,7 +846,7 @@ function legacyObservation(overrides = {}) {
     ),
   ];
   const budgets = {
-    worktrees: { count: 13, warning: 12, exceeded: true },
+    worktrees: { count: 13, registered: 13, detached: 0, warning: 12, exceeded: true },
     branches: { count: 31, warning: 30, exceeded: true },
     exceptions: { active: 1, expired: 2 },
   };
@@ -752,6 +875,38 @@ function legacyObservation(overrides = {}) {
   assert.ok(
     text.endsWith("Report only. No worktree or branch was changed."),
     "the final safety line remains exact and final",
+  );
+}
+
+// cave-oenag: the exclusion is reported, not silent — otherwise the assessed
+// number and the registered one differ with nothing to explain the gap.
+{
+  const summary = summarizeWorktreeLifecycle([], {
+    worktrees: { count: 18, registered: 22, detached: 4, warning: 20, exceeded: false },
+    branches: { count: 2, warning: 30, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  });
+  assert.match(
+    renderWorktreeLifecycleReport(summary),
+    /Worktree budget: 18\/20 \(within budget\) — 4 detached units not counted \(22 registered\)/,
+  );
+
+  const singular = summarizeWorktreeLifecycle([], {
+    worktrees: { count: 18, registered: 19, detached: 1, warning: 20, exceeded: false },
+    branches: { count: 2, warning: 30, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  });
+  assert.match(renderWorktreeLifecycleReport(singular), /1 detached unit not counted/);
+
+  const none = summarizeWorktreeLifecycle([], {
+    worktrees: { count: 18, registered: 18, detached: 0, warning: 20, exceeded: false },
+    branches: { count: 2, warning: 30, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  });
+  assert.match(
+    renderWorktreeLifecycleReport(none),
+    /Worktree budget: 18\/20 \(within budget\)\n/,
+    "a checkout with no scratch space reads exactly as it did before",
   );
 }
 
@@ -800,7 +955,7 @@ function legacyObservation(overrides = {}) {
   ];
   const text = renderWorktreeLifecycleReport(
     summarizeWorktreeLifecycle(items, {
-      worktrees: { count: 4, warning: 12, exceeded: false },
+      worktrees: { count: 4, registered: 4, detached: 0, warning: 12, exceeded: false },
       branches: { count: 4, warning: 30, exceeded: false },
       exceptions: { active: 0, expired: 0 },
     }),
@@ -839,7 +994,7 @@ function legacyObservation(overrides = {}) {
       },
     ],
     {
-      worktrees: { count: 2, warning: 12, exceeded: false },
+      worktrees: { count: 2, registered: 2, detached: 0, warning: 12, exceeded: false },
       branches: { count: 2, warning: 30, exceeded: false },
       exceptions: { active: 0, expired: 0 },
     },

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -160,9 +160,32 @@ export type WorktreeLifecycleRenderOptions = {
 export const WORKTREE_WARNING_BUDGET = 20;
 export const BRANCH_WARNING_BUDGET = 30;
 
+// Only branch-attached worktrees count against the admission budget.
+//
+// 2026-08-05 (cave-oenag): four detached units appeared at once — three review
+// scratch worktrees and one under /private/tmp — occupying a fifth of the
+// budget. With the budget at 20 and creation refusing at `count >= 20`, three
+// stale scratch units are the difference between managed creation working and
+// every session being refused.
+//
+// The exclusion is structural rather than a naming heuristic. The managed
+// creator always makes a branch, so a detached unit is by construction not one
+// of its units: the patrol cannot retire it (no `metadata.coven.worktree`
+// record, so it classes `uncertain` forever) and `pnpm beads:worktrees:apply`
+// will never touch it. Counting it therefore lets units the gate has no
+// authority over refuse the ones it does — the outage described in the
+// WORKTREE_WARNING_BUDGET note above, arriving by a different route.
+//
+// They are excluded, not hidden: `registered` and `detached` are reported
+// alongside `count` so a checkout accumulating scratch space still says so.
 export type WorktreeLifecycleBudgets = {
   worktrees: {
+    /** Branch-attached units — the number the budget is assessed against. */
     count: number;
+    /** Every registered worktree, including detached scratch space. */
+    registered: number;
+    /** `registered - count`: detached units, excluded from the assessment. */
+    detached: number;
     warning: typeof WORKTREE_WARNING_BUDGET;
     exceeded: boolean;
   };
@@ -326,6 +349,26 @@ function metadataBackfillReason(): string {
   return "structured lifecycle metadata backfill required before automated retirement can proceed";
 }
 
+// A detached unit with no metadata is not a managed worktree awaiting backfill —
+// the managed creator always makes a branch, so this one came from somewhere
+// else: a review harness, or `git worktree add --detach` for a read-only build.
+// Both reach the same `uncertain` lane, and neither is ever auto-retired, but
+// they call for opposite responses: backfill is impossible here (there is no
+// bead to write the record onto), while the owning tool is what should clean up.
+// Saying "backfill required" sends the reader after a remedy that cannot apply.
+//
+// The wording deliberately does not call these units disposable. cave-oenag
+// found three detached review worktrees holding 29–45 commits that existed on
+// no remote — at that moment they were the only reachable copy of that work.
+function detachedScratchReason(): string {
+  return (
+    "detached HEAD with no lifecycle metadata: no branch points at this work, so " +
+    "the managed creator did not make it — expect tooling scratch space. Automated " +
+    "retirement still refuses it; removal is by hand and loses any commit reachable " +
+    "only from this HEAD, so prove retention first (git branch/tag --contains)"
+  );
+}
+
 function withReasons(item: WorktreeLifecycleObservation, lane: WorktreeLifecycleLane, reasons: string[]) {
   return {
     ...item,
@@ -373,6 +416,9 @@ function classifyLifecycleUnitInternal(
   if (!observation.metadata) {
     if (legacyMissingMetadata) {
       return classifyLifecycleUnitWithoutMetadata(observation, nowMs);
+    }
+    if (!observation.branch) {
+      return withReasons(observation, "uncertain", [detachedScratchReason()]);
     }
     return withReasons(observation, "uncertain", [metadataBackfillReason()]);
   }
@@ -602,25 +648,40 @@ function assertNonnegativeInteger(name: string, value: number): void {
 
 export function calculateLifecycleBudgets({
   worktreeCount,
+  detachedWorktreeCount = 0,
   branchCount,
   activeExceptions,
   expiredExceptions,
 }: {
+  /** Every registered worktree, detached ones included. */
   worktreeCount: number;
+  /**
+   * How many of `worktreeCount` have no branch. Defaults to 0, which reproduces
+   * the pre-cave-oenag arithmetic for callers that do not distinguish them.
+   */
+  detachedWorktreeCount?: number;
   branchCount: number;
   activeExceptions: number;
   expiredExceptions: number;
 }): WorktreeLifecycleBudgets {
   assertNonnegativeInteger("worktreeCount", worktreeCount);
+  assertNonnegativeInteger("detachedWorktreeCount", detachedWorktreeCount);
   assertNonnegativeInteger("branchCount", branchCount);
   assertNonnegativeInteger("activeExceptions", activeExceptions);
   assertNonnegativeInteger("expiredExceptions", expiredExceptions);
+  if (detachedWorktreeCount > worktreeCount) {
+    throw new Error("detachedWorktreeCount must not exceed worktreeCount");
+  }
+
+  const attachedWorktreeCount = worktreeCount - detachedWorktreeCount;
 
   return {
     worktrees: {
-      count: worktreeCount,
+      count: attachedWorktreeCount,
+      registered: worktreeCount,
+      detached: detachedWorktreeCount,
       warning: WORKTREE_WARNING_BUDGET,
-      exceeded: worktreeCount > WORKTREE_WARNING_BUDGET,
+      exceeded: attachedWorktreeCount > WORKTREE_WARNING_BUDGET,
     },
     branches: {
       count: branchCount,
@@ -702,9 +763,16 @@ export function renderWorktreeLifecycleReport(
 ): string {
   const { includeFooter = true } = options;
   const { counts } = summary;
+  const { detached, registered } = summary.budgets.worktrees;
+  // Say so when the assessed number is smaller than the registered one, so the
+  // exclusion is legible rather than a discrepancy the reader has to derive.
+  const detachedNote =
+    detached > 0
+      ? ` — ${detached} detached unit${detached === 1 ? "" : "s"} not counted (${registered} registered)`
+      : "";
   const lines = [
     `Worktree lifecycle: ${summary.items.length} registered | ${counts.active} active | ${counts.recovery} recovery | ${counts.cooldown} cooldown | ${counts["retire-after-gate"]} cleanup-ready | ${counts.uncertain} uncertain | ${counts.protected} protected`,
-    `Worktree budget: ${summary.budgets.worktrees.count}/${summary.budgets.worktrees.warning} (${summary.budgets.worktrees.exceeded ? "exceeded" : "within budget"})`,
+    `Worktree budget: ${summary.budgets.worktrees.count}/${summary.budgets.worktrees.warning} (${summary.budgets.worktrees.exceeded ? "exceeded" : "within budget"})${detachedNote}`,
     `Local branch budget: ${summary.budgets.branches.count}/${summary.budgets.branches.warning} (${summary.budgets.branches.exceeded ? "exceeded" : "within budget"})`,
     `Managed exceptions: ${summary.budgets.exceptions.active} active | ${summary.budgets.exceptions.expired} expired`,
   ];


### PR DESCRIPTION
Closes cave-71ku9. Implements proposal 3 from cave-oenag.

## The problem

`WORKTREE_WARNING_BUDGET` counts every registered worktree, and managed
creation refuses at `count >= 20`. cave-oenag observed four **detached** units
at once — three review-harness scratch worktrees and one under `/private/tmp` —
occupying a fifth of that budget. Three of those are the difference between
managed creation working and every session being refused.

The units the budget refuses are not the units it is counting. A detached
worktree carries no `metadata.coven.worktree` record, so the patrol classes it
`uncertain` forever and `beads:worktrees:apply` can never retire it. Counting
it lets units the gate has no authority over refuse the ones it does.

That is not hypothetical here: this PR's own worktree was refused with
`creating a worktree would exceed the 20-worktree budget` and needed an
exception to exist at all.

## The change

**Only branch-attached worktrees are assessed.** The rule is structural, not a
naming heuristic — the managed creator always makes a branch, so a detached
unit is by construction not one of its units. No `_review-*` pattern to keep in
sync with whatever the harness names things next.

**Excluded, not hidden.** `registered` and `detached` sit alongside the
assessed count, and the report says which units it dropped:

```
Worktree budget: 18/20 (within budget) — 4 detached units not counted (22 registered)
```

**The refusal is routed through the same arithmetic.**
`worktree-lifecycle-create` had its own copy of the budget calculation, and it
is the surface that actually issues the refusal — so without this the exclusion
would have reached the report and not the refusal. It now calls
`calculateLifecycleBudgets`.

**A detached unit with no metadata gets its own `uncertain` reason.** The
generic "metadata backfill required" names a remedy that cannot apply, because
there is no bead to write the record onto.

## What this deliberately does not do

Proposal 2 from cave-oenag — auto-retiring clean, detached, non-remote units
past an age threshold — is **not** implemented and should not be. Three such
units turned out to hold 29–45 commits that existed on no remote; at that
moment they were the only reachable copy of that work. Age plus cleanliness
does not prove retention. No lane changes, nothing becomes auto-retirable, and
autolock is untouched — it was right to lock those.

## Verification

The create fixture reached the budget with **18 `--detach` worktrees**, which
is exactly the scratch space the budget now ignores. It therefore stopped
reaching the budget, and its refusal assertion would have passed only by
accident. Those are branch-attached now, so the fixture simulates the sprawl
the budget is actually for.

New coverage asserts the exclusion reaches the **refusal**, not just the
report: a checkout at the budget purely because of detached units admits
creation, while the same count of branch-attached units still refuses. Also
covers the report line, singular/zero wording, the incoherent `detached >
total` input, and that omitting the new field reproduces the old arithmetic
exactly.

Green locally: `worktree-lifecycle`, `-create`, `-patrol`, `-retirement`,
`worktree-autolock`, `worktree-guard`, `worktree-status`, and `tsc --noEmit`.