### PR TITLE
fix(desktop): report a second GUI instead of aborting macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,14 @@ jobs:
       # not rotate the secret phones signed their tokens against.
       - run: cargo test --locked --lib app_lifecycle_tests::mobile_access_token -- --nocapture
 
+      # Second-GUI ownership (cave-4wnxo): launching a second copy must resolve
+      # to an ordinary outcome. Reported as an error it unwinds out of Tauri's
+      # setup hook, which on macOS sits inside a non-unwinding Objective-C
+      # frame, so the process aborted with SIGABRT instead of naming the GUI
+      # already running. No CI runner is macOS, so the conflict decision is
+      # deliberately cfg(desktop) rather than macOS-only to be executable here.
+      - run: cargo test --locked --lib desktop_reachability::tests::gui_conflict -- --nocapture
+
   e2e:
     name: E2E (Playwright)
     runs-on: ubuntu-latest

--- a/scripts/desktop-reachability.test.mjs
+++ b/scripts/desktop-reachability.test.mjs
@@ -105,8 +105,22 @@ assert.match(
 );
 assert.match(
   reachability,
-  /another CovenCave GUI already owns desktop reachability/,
+  /conflicts_with_live_gui\([\s\S]*?\) \{\s*return Ok\(GuiReachability::AlreadyOwnedBy \{/,
   "a second GUI must not overwrite the live GUI ownership marker",
+);
+// cave-4wnxo: the conflict must stay inside `Ok`. Reported as `Err` it unwinds
+// out of Tauri's setup hook, which on macOS runs inside tao's
+// did_finish_launching — an Objective-C frame that cannot unwind — so the
+// runtime aborts with SIGABRT instead of naming the GUI already running.
+assert.doesNotMatch(
+  reachability,
+  /Err\("another CovenCave GUI already owns desktop reachability"/,
+  "a live second GUI is an ordinary outcome, not a setup error that aborts macOS",
+);
+assert.match(
+  reachability,
+  /fn conflicts_with_live_gui\([\s\S]*?existing\.pid != current\.pid && lease_matches\(/,
+  "ownership conflicts must compare process identity, not a reusable PID alone",
 );
 assert.match(
   reachability,
@@ -143,9 +157,18 @@ assert.match(
   /run_sidecar_daemon_if_requested\(\)[\s\S]*tauri::Builder::default/,
   "the background entrypoint must exit before constructing a GUI",
 );
+const reachabilityCall = setup.indexOf("prepare_gui_reachability(app.handle())?");
+assert.ok(reachabilityCall !== -1, "the setup hook must still prepare GUI reachability");
 assert.ok(
-  setup.indexOf("check_app_translocation();") < setup.indexOf("prepare_gui_reachability(app.handle())?;"),
+  setup.indexOf("check_app_translocation();") < reachabilityCall,
   "AppTranslocation must be rejected before reachability can install a LaunchAgent",
+);
+// The conflict has to be handled at the call site rather than propagated. See
+// the abort note above: `?` on this outcome is what SIGABRTs a second launch.
+assert.match(
+  setup,
+  /match prepare_gui_reachability\(app\.handle\(\)\)\? \{[\s\S]*?GuiReachability::Acquired => \{\}[\s\S]*?GuiReachability::AlreadyOwnedBy \{ pid \} => report_existing_gui_owner\(pid\)/,
+  "a second GUI must be reported and exited cleanly, never propagated into a non-unwinding panic",
 );
 assert.match(
   setup,

--- a/src-tauri/src/desktop_reachability.rs
+++ b/src-tauri/src/desktop_reachability.rs
@@ -915,8 +915,18 @@ fn remove_gui_ownership_if_owned(app_data_dir: &Path, owner: &ProcessLease) {
     }
 }
 
+/// Take reachability ownership for this GUI, or report the GUI that already
+/// holds it.
+///
+/// A live second owner returns `Ok(GuiReachability::AlreadyOwnedBy)` rather
+/// than `Err`. This is not cosmetic: the caller runs inside Tauri's setup hook,
+/// which on macOS executes within tao's `did_finish_launching` — an
+/// Objective-C callback that cannot unwind. An `Err` there becomes a `panic!`
+/// in a non-unwinding frame, which the runtime escalates to SIGABRT, so a
+/// perfectly ordinary "it's already running" turned into a crash report.
+/// `Err` is therefore reserved for genuine failures to determine ownership.
 #[cfg(all(desktop, target_os = "macos"))]
-pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), String> {
+pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<GuiReachability, String> {
     let app_data_dir = app
         .path()
         .app_data_dir()
@@ -924,12 +934,14 @@ pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), Str
     let _ownership = acquire_reachability_ownership_lease(&app_data_dir)?;
     let current_gui = current_process_lease()?;
     if let Some(existing) = read_gui_ownership_state(&app_data_dir) {
-        if lease_matches(
+        if conflicts_with_live_gui(
             &existing.lease,
+            &current_gui,
             process_identity(existing.lease.pid).as_deref(),
-        ) && existing.lease.pid != current_gui.pid
-        {
-            return Err("another CovenCave GUI already owns desktop reachability".to_string());
+        ) {
+            return Ok(GuiReachability::AlreadyOwnedBy {
+                pid: existing.lease.pid,
+            });
         }
         if existing.lease.pid == current_gui.pid && existing.lease.identity == current_gui.identity
         {
@@ -972,12 +984,14 @@ pub(super) fn prepare_gui_reachability(app: &tauri::AppHandle) -> Result<(), Str
     } else if launch_agent_installed() {
         uninstall_launch_agent(&app_data_dir)?;
     }
-    Ok(())
+    Ok(GuiReachability::Acquired)
 }
 
 #[cfg(all(desktop, not(target_os = "macos")))]
-pub(super) fn prepare_gui_reachability(_app: &tauri::AppHandle) -> Result<(), String> {
-    Ok(())
+pub(super) fn prepare_gui_reachability(
+    _app: &tauri::AppHandle,
+) -> Result<GuiReachability, String> {
+    Ok(GuiReachability::Acquired)
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -1100,6 +1114,42 @@ fn process_identity(pid: u32) -> Option<String> {
 #[cfg(desktop)]
 fn lease_matches(lease: &ProcessLease, current_identity: Option<&str>) -> bool {
     current_identity.is_some_and(|current| current == lease.identity)
+}
+
+/// What starting this GUI meant for reachability ownership.
+///
+/// Finding a live owner is an ordinary second-instance outcome, not a setup
+/// failure, so it is reported as `Ok` and left for the caller to act on. See
+/// `prepare_gui_reachability` for why the distinction is load-bearing.
+#[cfg(desktop)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum GuiReachability {
+    /// This process now owns reachability.
+    Acquired,
+    /// A different, still-live GUI owns it; this process must not take over.
+    // Only macOS records GUI ownership, so nothing constructs this elsewhere.
+    #[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+    AlreadyOwnedBy { pid: u32 },
+}
+
+/// Whether a recorded ownership lease belongs to a *different* GUI that is
+/// still alive.
+///
+/// Split out from `prepare_gui_reachability` so the conflict decision can be
+/// tested without a live `AppHandle` — and kept on `cfg(desktop)` rather than
+/// macOS so that test actually runs in CI, which has no macOS runner.
+///
+/// A recorded PID alone proves nothing: PIDs are reused. `lease_matches`
+/// compares the kernel-recorded birth timestamp, so a reused PID reads as a
+/// dead owner and this GUI is free to claim ownership.
+#[cfg(desktop)]
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn conflicts_with_live_gui(
+    existing: &ProcessLease,
+    current: &ProcessLease,
+    existing_identity: Option<&str>,
+) -> bool {
+    existing.pid != current.pid && lease_matches(existing, existing_identity)
 }
 
 #[cfg(all(desktop, target_os = "macos"))]
@@ -1910,6 +1960,69 @@ mod tests {
             Some("Thu Jul 24 12:00:01 2026 /usr/bin/unrelated")
         ));
         assert!(!lease_matches(&lease, None));
+    }
+
+    fn lease(pid: u32, identity: &str) -> ProcessLease {
+        ProcessLease {
+            pid,
+            identity: identity.to_string(),
+        }
+    }
+
+    #[test]
+    fn gui_conflict_detects_a_live_second_gui() {
+        let existing = lease(4001, "birth-a");
+        let current = lease(4002, "birth-b");
+        assert!(conflicts_with_live_gui(
+            &existing,
+            &current,
+            Some("birth-a")
+        ));
+    }
+
+    #[test]
+    fn gui_conflict_ignores_reentrant_setup_by_the_same_gui() {
+        // macOS lifecycle restoration can re-enter setup in the same process.
+        // Treating that as a second instance would make the app exit on resume.
+        let same = lease(4001, "birth-a");
+        assert!(!conflicts_with_live_gui(&same, &same, Some("birth-a")));
+    }
+
+    #[test]
+    fn gui_conflict_ignores_a_recycled_pid() {
+        // The recorded owner died and the OS handed its PID to something else.
+        // Comparing PIDs alone would lock the user out of their own app.
+        let existing = lease(4001, "birth-a");
+        let current = lease(4002, "birth-b");
+        assert!(!conflicts_with_live_gui(
+            &existing,
+            &current,
+            Some("birth-of-some-unrelated-process")
+        ));
+    }
+
+    #[test]
+    fn gui_conflict_ignores_a_dead_owner() {
+        // No identity at all means the recorded PID is not running.
+        let existing = lease(4001, "birth-a");
+        let current = lease(4002, "birth-b");
+        assert!(!conflicts_with_live_gui(&existing, &current, None));
+    }
+
+    #[test]
+    fn gui_conflict_is_a_success_outcome_not_an_error() {
+        // The regression this guards (cave-4wnxo): reporting a second GUI as
+        // `Err` propagates out of Tauri's setup hook, which on macOS cannot
+        // unwind, so the process aborts with SIGABRT rather than saying what
+        // happened. Keeping the conflict inside `Ok` makes that unrepresentable
+        // — a caller cannot `?` it into a panic.
+        let conflict: Result<GuiReachability, String> =
+            Ok(GuiReachability::AlreadyOwnedBy { pid: 4001 });
+        assert!(conflict.is_ok());
+        assert_ne!(
+            conflict.expect("a live second GUI is not a setup failure"),
+            GuiReachability::Acquired
+        );
     }
 
     #[test]

--- a/src-tauri/src/platform_lifecycle.rs
+++ b/src-tauri/src/platform_lifecycle.rs
@@ -101,6 +101,25 @@ pub(super) fn check_app_translocation() {
     }
 }
 
+/// Report the GUI that already owns desktop reachability, then leave.
+///
+/// Exits the process rather than returning an error to Tauri's setup hook.
+/// On macOS that hook runs inside tao's `did_finish_launching`, an
+/// Objective-C callback that cannot unwind, so a propagated error becomes a
+/// panic in a non-unwinding frame and the runtime aborts with SIGABRT — a
+/// crash report for the entirely ordinary case of launching a second copy.
+/// This mirrors `check_app_translocation`: say what happened, exit cleanly.
+#[cfg(desktop)]
+pub(super) fn report_existing_gui_owner(pid: u32) -> ! {
+    log::warn!(
+        "[cave] another CovenCave GUI (pid {pid}) already owns desktop reachability; this instance is exiting"
+    );
+    show_fatal_dialog(&format!(
+        "CovenCave is already running (process {pid}).\n\nSwitch to the window that is already open, or quit it before starting another copy."
+    ));
+    std::process::exit(1);
+}
+
 // This hook sits below Tao/Tauri's event dispatch. WRY waits for WebView2
 // environment/controller creation inside a nested Windows message pump. A
 // WM_CLOSE received there is otherwise buffered by Tao until the active event

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -312,7 +312,16 @@ pub fn run() {
             check_app_translocation();
 
             app.handle().plugin(tauri_plugin_notification::init())?;
-            prepare_gui_reachability(app.handle())?;
+            // A second GUI must not be reported through `?`. This closure is
+            // Tauri's setup hook, which on macOS runs inside tao's
+            // `did_finish_launching` — an Objective-C callback that cannot
+            // unwind — so an error here aborts with SIGABRT instead of
+            // surfacing the conflict. Report it and exit like a translocated
+            // app does. Genuine ownership failures still propagate.
+            match prepare_gui_reachability(app.handle())? {
+                GuiReachability::Acquired => {}
+                GuiReachability::AlreadyOwnedBy { pid } => report_existing_gui_owner(pid),
+            }
             discord_presence::start();
 
             // Desktop auto-update: updater checks/downloads/installs signed


### PR DESCRIPTION
Closes `cave-4wnxo`.

## The bug

Launching a second CovenCave GUI aborts the process with SIGABRT and a 30-frame Rust backtrace, instead of saying that the app is already running.

`prepare_gui_reachability` returned the conflict as an `Err`, and the call site propagated it with `?`. That `?` sits inside Tauri's setup hook, which on macOS runs within tao's `did_finish_launching` — an Objective-C frame that **cannot unwind**. Tauri turns the `Err` into a `panic!`, the panic hits a non-unwinding frame, and the runtime escalates it to an abort:

```
Failed to setup app: error encountered during setup hook:
  another CovenCave GUI already owns desktop reachability
panic in a function that cannot unwind
thread caused non-unwinding panic. aborting.
```

Reproduced live three times on `main` by starting `dev:app` while `/Applications/CovenCave.app` held ownership. The bead recorded it in the mirror direction (installed app launched while a dev GUI held ownership) — same seam, either way round.

## The fix

Make the conflict a **success outcome** rather than an error:

```rust
pub(super) enum GuiReachability {
    Acquired,
    AlreadyOwnedBy { pid: u32 },
}
```

This is the load-bearing part. Because the conflict now lives inside `Ok`, a caller *cannot* `?` it into a panic — the type system rules out the regression rather than a comment asking future callers not to. `Err` stays reserved for genuine failures to determine ownership, which should still propagate.

The call site then handles it the way a translocated app is already handled (`check_app_translocation`): name the owning process, show a dialog, exit cleanly.

## Testing, and an honest gap

The conflict decision is extracted into `conflicts_with_live_gui` and placed on `cfg(desktop)` rather than macOS-only — deliberately, so the tests can run in CI. **No CI job runs macOS** (`Rust check` and both matrix legs are ubuntu/windows), which is why this entire module had zero coverage. The Rust job also only runs *named* tests, so the new ones are wired explicitly and share a `gui_conflict_` prefix so the filter selects exactly them and doesn't enable a module of never-CI-run tests.

Coverage includes the PID-reuse subtleties, since comparing PIDs alone would lock a user out of their own app after a crash:

| case | conflict? |
|---|---|
| different live GUI | yes |
| re-entrant setup, same process | no — macOS lifecycle restoration re-enters setup |
| recorded PID recycled by another process | no — identity differs |
| recorded owner dead | no |

The four source-text assertions in `desktop-reachability.test.mjs` were each verified to **fail against `main`**, so they are real gates rather than vacuous ones.

## Verified end to end

Identical attach conditions, installed app holding ownership:

| build | outcome | `dev-app.sh` exit |
|---|---|---|
| `main` | SIGABRT + 30-frame backtrace | **0** |
| this PR | one WARN naming pid 40105 | **1** |

Note the exit code. `tauri dev` propagates a clean non-zero exit but silently discards a signal death, so on `main` the launcher reported *success* having opened no window. This PR fixes that as a consequence of exiting cleanly, but the masking itself remains for any future signal death (SIGSEGV, another non-unwinding panic) and is tracked as `cave-g8n5v`.

Local: `cargo check` clean (no new warnings), 16/16 `desktop_reachability` tests, CI's named `app_lifecycle_tests::mobile_access_token`, and `check-tests-wired` at 1544/1544.

## Not done

The bead allows "focuses **or** reports the existing owner". This implements *reports*. Focusing another process's window needs `NSRunningApplication` from `objc2-app-kit`, which is not a dependency — adding it would touch `Cargo.lock` and the sidecar CI legs for a UX nicety, so it seemed the wrong trade against a crash fix.
