### PR TITLE
fix(code): make the Coding Room's narrow layout real and measured (cave-k3a9u)

### DIFF
--- a/src/components/code-context-dock.tsx
+++ b/src/components/code-context-dock.tsx
@@ -90,6 +90,15 @@ export type CodeContextDockProps = {
   running: boolean;
   /** A routed file/diff open, already resolved to this session. */
   openTarget?: PendingCodeOpen;
+  /** False while the dock is mounted but off-screen — the narrow Room's
+   *  terminal step (cave-k3a9u). Kept mounted so tab choice and the Browser
+   *  keepalive survive a step change, but the native webview must go inactive
+   *  or it draws over a container that is no longer showing. */
+  visible?: boolean;
+  /** Present only in the narrow Room, where the dock is a drill-in step rather
+   *  than a column: replaces collapse/expand (both meaningless at full width)
+   *  with a Back control to the terminal. */
+  onBack?: () => void;
   onTabChange: (tab: CodeDockTab) => void;
   onSizeChange: (size: CodeDockSize) => void;
   onRefresh?: () => void;
@@ -102,6 +111,8 @@ export function CodeContextDock({
   size,
   running,
   openTarget,
+  visible = true,
+  onBack,
   onTabChange,
   onSizeChange,
   onRefresh,
@@ -113,8 +124,14 @@ export function CodeContextDock({
   // scroll position survive a switch to Changes and back.
   const [browserOpened, setBrowserOpened] = useState(false);
   useEffect(() => {
-    if (tab === "browser") setBrowserOpened(true);
-  }, [tab]);
+    if (tab === "browser" && visible) setBrowserOpened(true);
+  }, [tab, visible]);
+
+  // The native browser is only active when its tab is selected AND the dock is
+  // on screen. A native webview positions itself over the container's box, so
+  // leaving it active behind a hidden dock paints it over whatever replaced it.
+  // (Collapsing needs no term here — a collapsed dock renders no body at all.)
+  const browserActive = tab === "browser" && visible;
 
   const collapsed = size === "collapsed";
   const expanded = size === "expanded";
@@ -179,34 +196,51 @@ export function CodeContextDock({
           ))}
         </div>
         <div className="code-context-dock__actions">
-          <button
-            type="button"
-            className="focus-ring code-context-dock__action"
-            aria-label={expanded ? "Restore context width" : "Expand context"}
-            aria-pressed={expanded}
-            title={expanded ? "Restore context width" : "Expand context"}
-            onClick={() => changeSize(expanded ? "normal" : "expanded")}
-          >
-            <Icon
-              name={expanded ? "ph:arrows-in-line-horizontal" : "ph:arrows-out-line-horizontal"}
-              width={12}
-              height={12}
-            />
-          </button>
-          <button
-            type="button"
-            className="focus-ring code-context-dock__action"
-            aria-label={collapsed ? "Show context" : "Collapse context"}
-            // aria-expanded, not aria-pressed: this reveals and hides the dock
-            // body, so it is a disclosure. It is also what now carries the
-            // collapsed state, since the tabs keep their real selection.
-            aria-expanded={!collapsed}
-            aria-controls={`code-context-dock-body-${row.id}`}
-            title={collapsed ? "Show context" : "Collapse context"}
-            onClick={() => changeSize(collapsed ? "normal" : "collapsed")}
-          >
-            <Icon name={collapsed ? "ph:caret-left" : "ph:caret-right"} width={12} height={12} />
-          </button>
+          {onBack ? (
+            // Narrow Room: the dock is a step, not a column. Collapse and
+            // expand both describe a width this dock does not have here, so
+            // the one action that means anything is going back.
+            <button
+              type="button"
+              className="focus-ring code-context-dock__action"
+              aria-label="Back to terminal"
+              title="Back to terminal"
+              onClick={onBack}
+            >
+              <Icon name="ph:caret-left" width={12} height={12} />
+            </button>
+          ) : (
+            <>
+              <button
+                type="button"
+                className="focus-ring code-context-dock__action"
+                aria-label={expanded ? "Restore context width" : "Expand context"}
+                aria-pressed={expanded}
+                title={expanded ? "Restore context width" : "Expand context"}
+                onClick={() => changeSize(expanded ? "normal" : "expanded")}
+              >
+                <Icon
+                  name={expanded ? "ph:arrows-in-line-horizontal" : "ph:arrows-out-line-horizontal"}
+                  width={12}
+                  height={12}
+                />
+              </button>
+              <button
+                type="button"
+                className="focus-ring code-context-dock__action"
+                aria-label={collapsed ? "Show context" : "Collapse context"}
+                // aria-expanded, not aria-pressed: this reveals and hides the dock
+                // body, so it is a disclosure. It is also what now carries the
+                // collapsed state, since the tabs keep their real selection.
+                aria-expanded={!collapsed}
+                aria-controls={`code-context-dock-body-${row.id}`}
+                title={collapsed ? "Show context" : "Collapse context"}
+                onClick={() => changeSize(collapsed ? "normal" : "collapsed")}
+              >
+                <Icon name={collapsed ? "ph:caret-left" : "ph:caret-right"} width={12} height={12} />
+              </button>
+            </>
+          )}
         </div>
       </div>
       {collapsed ? null : (
@@ -243,7 +277,7 @@ export function CodeContextDock({
           ) : null}
           {browserOpened ? (
             <div className={tab === "browser" ? "code-context-dock__pane" : "hidden"}>
-              <LazyBrowser label={`code:${row.id}`} active={tab === "browser"} />
+              <LazyBrowser label={`code:${row.id}`} active={browserActive} />
             </div>
           ) : null}
         </div>

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -241,19 +241,26 @@ assert.match(
   "the context dock scopes every tab to the same work root",
 );
 
-// The three zones, in order: the terminal center and the dock are siblings of
-// ONE resizable group, which is what keeps the shell mounted while context
-// changes. A layout that nested the dock inside the terminal, or swapped them
-// into the same slot, would reintroduce the tab behaviour this replaced.
+// The three zones, in order: while the Room is wide enough, the terminal center
+// and the dock are siblings of ONE resizable group, which is what keeps the
+// shell mounted while context changes. A layout that nested the dock inside the
+// terminal, or swapped them into the same slot, would reintroduce the tab
+// behaviour this replaced. (The dock body itself lives in a renderDock helper
+// so the wide and narrow layouts cannot drift apart — cave-k3a9u.)
 assert.match(
   workbench,
-  /<CodeTerminalWorkspace[\s\S]*?<Separator[\s\S]*?<CodeContextDock/,
+  /<CodeTerminalWorkspace[\s\S]*?<Separator[\s\S]*?renderDock\(\{ visible: true \}\)/,
   "the Room renders terminal center, a separator, then the context dock",
 );
 assert.match(
   workbench,
-  /minSize=\{MIN_TERMINAL_WIDTH\}/,
-  "the terminal center holds a width floor so the divider can starve context but never the shell",
+  /const renderDock = \(\{ visible, onBack \}[\s\S]{0,120}<CodeContextDock/,
+  "one dock definition serves both layouts",
+);
+assert.match(
+  workbench,
+  /minSize=\{fitsSplit \? MIN_TERMINAL_WIDTH : "0px"\}/,
+  "the terminal center holds a width floor while there is a divider to defend it against",
 );
 assert.doesNotMatch(
   workbench,
@@ -298,8 +305,8 @@ assert.match(
 );
 assert.match(
   contextDock,
-  /\{browserOpened \? \([\s\S]*?active=\{tab === "browser"\}/,
-  "Browser stays mounted once opened (keepalive) and is active only while selected, so native bounds follow the visible pane",
+  /\{browserOpened \? \([\s\S]*?active=\{browserActive\}/,
+  "Browser stays mounted once opened (keepalive) and is active only while selected AND the dock is visible, so native bounds follow the visible pane",
 );
 assert.match(
   contextDock,
@@ -528,12 +535,14 @@ assert.match(
   "code-view threads the workspace's tasks refresh into the workbench",
 );
 
-// ── Mobile drill-in (list-first below md) ────────────────────────────────────
+// ── Narrow drill-in (list-first, measured) ───────────────────────────
 
-// Below the md breakpoint the rail is the landing screen: no newest-session
-// auto-pick on narrow mounts, an explicit Back (null) suppresses re-selection,
-// and the rail/workbench swap is pure CSS (hidden md:block / hidden md:flex)
-// so desktop keeps the three-pane layout untouched.
+// When the Room is too narrow to hold the rail beside a usable workbench, the
+// rail is the landing screen: no newest-session auto-pick, an explicit Back
+// (null) suppresses re-selection, and the rail/workbench swap is driven by the
+// Room's OWN measured width. It used to key off the viewport (`md:`), which
+// this surface cannot ask about honestly — it renders inside the role-surface
+// host beside the sidebar and can sit in a split (cave-k3a9u).
 assert.match(
   codeView,
   /useState<string \| null \| undefined>\(\s*deepLink\?\.sessionId \?\? undefined,?\s*\)/,
@@ -558,30 +567,143 @@ assert.match(
   /useEffect\(\(\) => \{\s*const params = new URLSearchParams\(window\.location\.search\);\s*if \(!params\.has\("session"\)/,
   "the ?session/ctab/wtab strip happens in a mount effect, not the initializer",
 );
-assert.match(
+assert.doesNotMatch(
   codeView,
-  /window\.matchMedia\("\(max-width: 767px\)"\)\.matches/,
-  "narrow mounts land on the session list, not the newest workbench",
+  /matchMedia|\bmd:(block|flex|hidden|w-64|border-r)/,
+  "the Room decides from its measured box, never a viewport query or md: class",
 );
 assert.match(
   codeView,
-  /if \(narrowMountRef\.current\) return;/,
-  "the auto-pick effect honors the narrow-mount guard",
+  /const roomWidth = useMeasuredWidth\(roomRef\);/,
+  "the Room measures its own width",
 );
 assert.match(
   codeView,
-  /\$\{selected \? "hidden md:block" : "block"\}/,
-  "picking a session hides the rail below md only",
+  /const fitsRail = codeRoomFitsRail\(roomWidth, isMobile\);/,
+  "the rail breakpoint comes from the shared layout model, not a literal",
+);
+// The landing decision is captured once and lives in STATE, not just a ref: a
+// ref set inside one effect cannot re-run the auto-pick effect that reads it,
+// so the measurement would land and auto-pick would never fire.
+assert.match(
+  codeView,
+  /const \[narrowLanding, setNarrowLanding\] = useState<boolean \| null>\(null\);/,
+  "the narrow-landing decision is state so the auto-pick effect re-runs on it",
 );
 assert.match(
   codeView,
-  /\$\{selected \? "flex" : "hidden md:flex"\}/,
-  "the workbench column is hidden below md until a session is picked",
+  /if \(narrowLanding !== false\) return;/,
+  "auto-pick waits for a decision and is skipped entirely when narrow",
 );
 assert.match(
   codeView,
-  /aria-label="Back to sessions"[\s\S]{0,80}onClick=\{\(\) => setSelectedId\(null\)\}/,
-  "the mobile Back affordance clears the selection explicitly",
+  /if \(roomWidth === null && typeof ResizeObserver !== "undefined"\) return;/,
+  "the decision waits for a real measurement only when one is actually coming",
+);
+assert.match(
+  codeView,
+  /fitsRail \? "block w-64 border-r" : selected \? "hidden" : "block w-full"/,
+  "picking a session hides the rail only while the Room is too narrow for both",
+);
+assert.match(
+  codeView,
+  /\$\{selected \|\| fitsRail \? "flex" : "hidden"\}/,
+  "the workbench column is hidden on a narrow Room until a session is picked",
+);
+assert.match(
+  codeView,
+  /aria-label="Back to sessions"[\s\S]{0,120}onClick=\{\(\) => setSelectedId\(null\)\}/,
+  "the narrow Back affordance clears the selection explicitly",
+);
+
+// ── Room narrow layout: the split drill-in (cave-k3a9u) ─────────────────────
+
+// THE BUG THIS GUARDS. The Room shipped with
+//   @media (max-width: 900px) { .code-room__group { flex-direction: column } }
+// which never once applied. `react-resizable-panels` renders its Group with an
+// INLINE style whose own keys land after the caller's spread:
+//   { height, width, overflow, ...userStyle, display:"flex",
+//     flexDirection: orientation === "horizontal" ? "row" : "column", ... }
+// Inline beats every class selector, and the library's key beats even a passed
+// `style`. So the rule was inert, and at 390px the Room rendered two columns
+// whose minimums alone sum to 620px. Orientation is a PROP, never CSS.
+const roomCss = await readFile(
+  new URL("../styles/globals/surface-code-room.css", import.meta.url),
+  "utf8",
+);
+assert.doesNotMatch(
+  roomCss,
+  /\.code-room__group[^}]*flex-direction/,
+  "a CSS flex-direction on the panel group is dead code — the library sets it inline",
+);
+assert.doesNotMatch(
+  roomCss,
+  /@media[^{]*max-width:\s*900px/,
+  "the 900px stacking query is retired; the workbench decides in JS instead",
+);
+assert.match(
+  workbench,
+  /const fitsSplit = codeWorkbenchFitsSplit\(bodyWidth, isMobile\);/,
+  "the split/drill-in decision is measured, from the shared layout model",
+);
+assert.match(
+  workbench,
+  /useState<CodeWorkbenchStep>\("terminal"\)/,
+  "the narrow workbench lands on the terminal, not the dock",
+);
+// The terminal must never unmount across the breakpoint: remounting it would
+// drop the live PTY attachment and the scrollback with it. It keeps ONE slot
+// in the tree and only the dock's presence changes around it.
+assert.match(
+  workbench,
+  /visible=\{showTerminal\}/,
+  "the terminal is hidden via its supported keepalive prop, never unmounted",
+);
+assert.doesNotMatch(
+  workbench,
+  /fitsSplit \? \([\s\S]{0,400}<Panel[\s\S]{0,600}\) : \([\s\S]{0,400}<Panel/,
+  "the layouts must not fork into two separate terminal Panels",
+);
+// Announcing from inside a setState updater is a render-phase setState on the
+// live region — React re-invokes updaters while rendering, and it warned
+// exactly that ("Cannot update a component while rendering a different
+// component") until this moved into an effect.
+assert.doesNotMatch(
+  workbench,
+  /setStep\(\([\s\S]{0,200}announce\(/,
+  "the step announcement must not run inside the setState updater",
+);
+assert.match(
+  workbench,
+  /announcedStepRef\.current = step;/,
+  "the step change is announced from an effect, so routed steps announce too",
+);
+
+// A routed diff/file open on a narrow Room has to bring the dock forward too,
+// or it silently points a hidden dock at the right tab and looks like a no-op.
+assert.match(
+  workbench,
+  /setStep\("context"\)/,
+  "a routed open drills into Context so the target is actually visible",
+);
+
+// A mounted-but-hidden dock cannot keep the browser active: BrowserPane draws a
+// NATIVE webview positioned over its container's box, which `display:none` does
+// not clip — it would paint straight over the terminal.
+assert.match(
+  contextDock,
+  /const browserActive = tab === "browser" && visible;/,
+  "the native webview is deactivated whenever the dock is hidden",
+);
+assert.match(
+  contextDock,
+  /visible\?: boolean;/,
+  "the dock takes an explicit visibility prop rather than inferring it",
+);
+assert.match(
+  contextDock,
+  /onBack\?: \(\) => void;/,
+  "the narrow dock offers a way back to the terminal",
 );
 
 // ── Chat stays untouched this phase ──────────────────────────────────────────

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -687,6 +687,17 @@ assert.match(
   "a routed open drills into Context so the target is actually visible",
 );
 
+// A dock collapsed while the Room was wide must not survive into the narrow
+// step. The narrow dock renders no body when collapsed AND offers Back instead
+// of collapse/expand, so the Context step would be a blank surface with no
+// control to recover it: collapse on desktop, narrow the Room, step to Context.
+// Found in review on #4418 — every check was green.
+assert.match(
+  workbench,
+  /size=\{fitsSplit \? dockSize : "normal"\}/,
+  "the narrow dock renders at normal size so the Context step can never be blank",
+);
+
 // A mounted-but-hidden dock cannot keep the browser active: BrowserPane draws a
 // NATIVE webview positioned over its container's box, which `display:none` does
 // not clip — it would paint straight over the terminal.

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -22,6 +22,7 @@ import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import {
   CODE_GITHUB_TABS,
+  codeRoomFitsRail,
   codeSessionWorkRoot,
   groupCodeRailSessions,
   isCodeGithubTab,
@@ -39,6 +40,8 @@ import type { GitHubItemTarget } from "@/lib/github-item-url";
 import type { PendingCodeOpen } from "@/lib/pending-code-open";
 import { codeTopTabForGitHubTarget, type PendingCodeNavigation } from "@/lib/pending-code-navigation";
 import type { SessionRow } from "@/lib/types";
+import { useIsMobile } from "@/lib/use-viewport";
+import { useMeasuredWidth } from "@/lib/use-measured-width";
 
 // GitHubView keeps its own chunk: CodeView opens far more often than its
 // GitHub tabs, and github-view is a 3k-line surface (same split posture as
@@ -156,10 +159,24 @@ export function CodeView({
   const pendingNewIdRef = useRef<string | null>(null);
   // On a phone the rail IS the landing screen — auto-picking the newest
   // session would skip the list and drop the user straight into a workbench
-  // with no context. Captured once at mount (Tailwind md breakpoint).
-  const narrowMountRef = useRef(
-    typeof window !== "undefined" && window.matchMedia("(max-width: 767px)").matches,
-  );
+  // with no context. Decided once, from the Room's own measured width: this
+  // surface renders inside the role-surface host and can sit in a split, so a
+  // viewport query answers a question nobody asked (cave-k3a9u).
+  const roomRef = useRef<HTMLDivElement | null>(null);
+  const roomWidth = useMeasuredWidth(roomRef);
+  const isMobile = useIsMobile();
+  const fitsRail = codeRoomFitsRail(roomWidth, isMobile);
+  const narrowLandingRef = useRef<boolean | null>(null);
+  const [narrowLanding, setNarrowLanding] = useState<boolean | null>(null);
+  useEffect(() => {
+    if (narrowLandingRef.current !== null) return;
+    // Hold for the first real measurement when one is coming. Without
+    // ResizeObserver none ever arrives, so take the viewport fallback rather
+    // than never deciding — that would strand auto-pick permanently.
+    if (roomWidth === null && typeof ResizeObserver !== "undefined") return;
+    narrowLandingRef.current = !codeRoomFitsRail(roomWidth, isMobile);
+    setNarrowLanding(narrowLandingRef.current);
+  }, [roomWidth, isMobile]);
 
   const groups = useMemo(() => groupCodeRailSessions(sessions), [sessions]);
 
@@ -226,14 +243,14 @@ export function CodeView({
       return;
     }
     if (selectedId === null) return;
-    if (narrowMountRef.current) return;
+    if (narrowLanding !== false) return;
     if (selectedId && pendingNewIdRef.current === selectedId) return;
     const first = groups[0]?.sessions[0];
     if (first) setSelectedId(first.id);
-  }, [groups, selected, selectedId]);
+  }, [groups, selected, selectedId, narrowLanding]);
 
   return (
-    <div className="flex h-full min-h-0 flex-col">
+    <div ref={roomRef} className="flex h-full min-h-0 flex-col">
       <div className="flex shrink-0 items-center gap-1 border-b border-[var(--border-hairline)] px-3 py-1.5">
         <div
           role="tablist"
@@ -290,10 +307,16 @@ export function CodeView({
         </div>
       ) : (
         <div className="flex min-h-0 flex-1">
-          {/* Mobile drill-in: below md the rail is the landing screen and the
-              workbench replaces it once a session is picked (Back returns). */}
+          {/* Narrow drill-in: when the Room itself is too narrow to hold the
+              rail beside the workbench, the rail is the landing screen and the
+              workbench replaces it once a session is picked (Back returns).
+              Driven by the Room's measured width, not the viewport — this
+              surface can sit in a split beside another page (cave-k3a9u).
+              w-64 is CODE_ROOM_RAIL_WIDTH_PX. */}
           <div
-            className={`${selected ? "hidden md:block" : "block"} w-full shrink-0 border-[var(--border-hairline)] md:w-64 md:border-r`}
+            className={`${
+              fitsRail ? "block w-64 border-r" : selected ? "hidden" : "block w-full"
+            } shrink-0 border-[var(--border-hairline)]`}
           >
             <CodeSessionRail
               sessions={sessions}
@@ -307,20 +330,24 @@ export function CodeView({
               onNewSession={() => setNewSessionOpen(true)}
             />
           </div>
-          <div className={`${selected ? "flex" : "hidden md:flex"} min-w-0 flex-1 flex-col`}>
+          <div
+            className={`${selected || fitsRail ? "flex" : "hidden"} min-w-0 flex-1 flex-col`}
+          >
             {selected ? (
               <>
-                <div className="shrink-0 border-b border-[var(--border-hairline)] px-2 py-1 md:hidden">
-                  <button
-                    type="button"
-                    aria-label="Back to sessions"
-                    onClick={() => setSelectedId(null)}
-                    className="focus-ring inline-flex items-center gap-1 rounded px-1.5 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
-                  >
-                    <Icon name="ph:caret-left" width={12} height={12} />
-                    Sessions
-                  </button>
-                </div>
+                {fitsRail ? null : (
+                  <div className="shrink-0 border-b border-[var(--border-hairline)] px-2 py-1">
+                    <button
+                      type="button"
+                      aria-label="Back to sessions"
+                      onClick={() => setSelectedId(null)}
+                      className="focus-ring inline-flex items-center gap-1 rounded px-1.5 py-1 text-[length:var(--text-xs)] text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+                    >
+                      <Icon name="ph:caret-left" width={12} height={12} />
+                      Sessions
+                    </button>
+                  </div>
+                )}
                 {activeOrigin ? (
                   <CodeSourceContext
                     origin={activeOrigin}

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -190,7 +190,13 @@ export function CodeWorkbench({
     <CodeContextDock
       row={row}
       tab={dockTab}
-      size={dockSize}
+      // A narrow dock is a full-width STEP, so it renders at `normal` whatever
+      // the split was left at. Passing `collapsed` through would render no body
+      // and — since the narrow dock offers Back instead of collapse/expand — no
+      // control to undo it: collapse the dock on a wide Room, narrow the Room,
+      // step to Context, and you land on a blank surface. The state itself is
+      // left alone so returning to the split restores the width you chose.
+      size={fitsSplit ? dockSize : "normal"}
       running={running}
       openTarget={openTarget}
       visible={visible}

--- a/src/components/code-workbench.tsx
+++ b/src/components/code-workbench.tsx
@@ -23,13 +23,16 @@
  * from Chat's rail is the SAME shell here.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import "@/styles/globals/surface-code-room.css";
 import { Icon } from "@/lib/icon";
 import { Button } from "@/components/ui/button";
 import { SeparatorHandle } from "@/components/ui/separator-handle";
 import { relativeTime } from "@/lib/relative-time";
+import { useAnnouncer } from "@/components/ui/live-region";
+import { useIsMobile } from "@/lib/use-viewport";
+import { useMeasuredWidth } from "@/lib/use-measured-width";
 import { CodeComposer } from "@/components/code-composer";
 import { CodeContextDock } from "@/components/code-context-dock";
 import { CodeTerminalWorkspace } from "@/components/code-terminal-workspace";
@@ -39,8 +42,12 @@ import {
   codeSessionBranch,
   codeSessionDiffstat,
   codeSessionWorkRoot,
+  codeWorkbenchFitsSplit,
+  CODE_ROOM_MIN_DOCK_WIDTH_PX,
+  CODE_ROOM_MIN_TERMINAL_WIDTH_PX,
   type CodeDockSize,
   type CodeDockTab,
+  type CodeWorkbenchStep,
   type CodeWorkbenchTab,
 } from "@/lib/code-surface";
 import {
@@ -56,11 +63,12 @@ import type { SessionRow } from "@/lib/types";
 
 /** The terminal keeps this much room whatever the dock does — the center is
  *  the priority surface, so dragging the divider can starve context but never
- *  the shell. */
-const MIN_TERMINAL_WIDTH = "320px";
+ *  the shell. Both derive from the pure model so the constraint and the
+ *  breakpoint that decides whether to apply it can never drift apart. */
+const MIN_TERMINAL_WIDTH = `${CODE_ROOM_MIN_TERMINAL_WIDTH_PX}px`;
 const DOCK_MIN_WIDTH: Record<CodeDockSize, string> = {
   collapsed: "44px",
-  normal: "300px",
+  normal: `${CODE_ROOM_MIN_DOCK_WIDTH_PX}px`,
   expanded: "460px",
 };
 
@@ -85,13 +93,50 @@ export function CodeWorkbench({
     () => codeDockTabForWorkbenchTab(initialTab) ?? "changes",
   );
   const [dockSize, setDockSize] = useState<CodeDockSize>("normal");
+  const { announce } = useAnnouncer();
+
+  // Narrow layout (cave-k3a9u). Measured against the workbench's OWN body, not
+  // the viewport: this component renders inside the role-surface host beside
+  // the app sidebar and can be placed in a split, so the viewport says nothing
+  // useful about the width these two zones actually got. `useIsMobile` is only
+  // the stand-in for the frames before the first measurement lands.
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  const bodyWidth = useMeasuredWidth(bodyRef);
+  const isMobile = useIsMobile();
+  const fitsSplit = codeWorkbenchFitsSplit(bodyWidth, isMobile);
+  // Terminal is the landing step — the shell is the Room's priority surface.
+  const [step, setStep] = useState<CodeWorkbenchStep>("terminal");
+  const showTerminal = fitsSplit || step === "terminal";
+  const showDock = fitsSplit || step === "context";
+
+  const goToStep = useCallback((next: CodeWorkbenchStep) => {
+    setStep(next);
+  }, []);
+
+  // Announce the step from an effect, never from inside the setState updater.
+  // React re-invokes updaters during the render phase, so announcing there
+  // called setState on the live region mid-render ("Cannot update a component
+  // while rendering a different component"). Doing it here also covers the
+  // steps taken by routing and session switches, not just the buttons.
+  // Silent while the split is showing both zones — the step means nothing then.
+  const announcedStepRef = useRef<CodeWorkbenchStep>("terminal");
+  useEffect(() => {
+    if (announcedStepRef.current === step) return;
+    announcedStepRef.current = step;
+    if (fitsSplit) return;
+    announce(step === "context" ? "Context shown." : "Terminal shown.");
+  }, [step, fitsSplit, announce]);
+
   // A routed open outranks the resting/deep-linked tab — a diff jump shows
   // Changes, a file open shows Files (re-applied per nonce), and either one
-  // reopens a collapsed dock so the routed target is actually visible.
+  // reopens a collapsed dock so the routed target is actually visible. On a
+  // narrow Room "visible" also means the context STEP: pointing a hidden dock
+  // at the right tab would look like the jump silently did nothing.
   useEffect(() => {
     if (!openTarget) return;
     setDockTab(openTarget.kind === "changes" ? "changes" : "files");
     setDockSize((size) => (size === "collapsed" ? "normal" : size));
+    setStep("context");
   }, [openTarget]);
 
   // Terminal center. The layout is per-session: switching sessions resets to a
@@ -106,6 +151,7 @@ export function CodeWorkbench({
     setLayout(fresh);
     setFocusedPaneId(resolveFocusedPane(fresh, null));
     setBroadcast(false);
+    setStep("terminal");
   }, [row.id]);
 
   const handleSplit = useCallback((paneId: string, direction: TerminalSplitDirection) => {
@@ -135,6 +181,26 @@ export function CodeWorkbench({
   const diffstat = codeSessionDiffstat(row);
   const pr = row.pullRequest;
   const running = codeSessionActivity(row) === "running";
+
+  // One dock definition for both layouts. It renders in two different tree
+  // slots (inside the split Panel, or as the narrow step), so it remounts when
+  // the Room crosses the breakpoint — a resize or a rotation, not a step
+  // change, which is the transition worth keeping cheap.
+  const renderDock = ({ visible, onBack }: { visible: boolean; onBack?: () => void }) => (
+    <CodeContextDock
+      row={row}
+      tab={dockTab}
+      size={dockSize}
+      running={running}
+      openTarget={openTarget}
+      visible={visible}
+      onBack={onBack}
+      onTabChange={setDockTab}
+      onSizeChange={setDockSize}
+      onRefresh={onRefresh}
+      onJumpToSession={onJumpToSession}
+    />
+  );
 
   return (
     <div className="flex h-full min-h-0 flex-col">
@@ -171,49 +237,78 @@ export function CodeWorkbench({
             </div>
           </div>
           <div className="flex shrink-0 items-center gap-1.5">
+            {fitsSplit ? null : (
+              // Narrow Room: the third drill-in step. Sessions -> Terminal ->
+              // Context, with the dock's own Back returning here.
+              <Button
+                size="sm"
+                variant="ghost"
+                aria-label="Show context"
+                onClick={() => goToStep("context")}
+              >
+                <Icon name="ph:sidebar-simple" width={12} height={12} />
+                Context
+              </Button>
+            )}
             <Button size="sm" onClick={() => onJumpToSession(row.id, row.familiarId)}>
               Open in Chat
             </Button>
           </div>
         </div>
       </div>
-      <div className="flex min-h-0 flex-1">
-        <Group className="code-room__group" orientation="horizontal">
-          <Panel id={`code-room-terminal-${row.id}`} className="code-room__panel" minSize={MIN_TERMINAL_WIDTH}>
-            <CodeTerminalWorkspace
-              sessionId={row.id}
-              projectRoot={workRoot}
-              layout={layout}
-              focusedPaneId={focusedPaneId}
-              visible
-              broadcast={broadcast}
-              onFocusPane={setFocusedPaneId}
-              onSplit={handleSplit}
-              onClosePane={handleClosePane}
-              onToggleBroadcast={() => setBroadcast((on) => !on)}
-            />
-          </Panel>
-          <Separator className="shell-separator code-room__sep">
-            <SeparatorHandle orientation="col" />
-          </Separator>
-          <Panel
-            id={`code-room-dock-${row.id}`}
-            className="code-room__panel"
-            minSize={DOCK_MIN_WIDTH[dockSize]}
-          >
-            <CodeContextDock
-              row={row}
-              tab={dockTab}
-              size={dockSize}
-              running={running}
-              openTarget={openTarget}
-              onTabChange={setDockTab}
-              onSizeChange={setDockSize}
-              onRefresh={onRefresh}
-              onJumpToSession={onJumpToSession}
-            />
-          </Panel>
-        </Group>
+      <div className="flex min-h-0 flex-1" ref={bodyRef}>
+        {/* The terminal Panel holds the SAME tree slot in both layouts, so the
+            shell never unmounts — not when the dock leaves the split, and not
+            when the narrow Room steps to Context. It goes `visible={false}`
+            there, which is BottomTerminal's hidden-keepalive state: output
+            keeps buffering and the refit waits until it is on screen again. */}
+        <div className={showTerminal ? "flex min-h-0 min-w-0 flex-1" : "hidden"}>
+          <Group className="code-room__group" orientation="horizontal">
+            <Panel
+              id={`code-room-terminal-${row.id}`}
+              className="code-room__panel"
+              // Narrow: the terminal is the whole width, so a 320px floor would
+              // be a constraint against nothing.
+              minSize={fitsSplit ? MIN_TERMINAL_WIDTH : "0px"}
+            >
+              <CodeTerminalWorkspace
+                sessionId={row.id}
+                projectRoot={workRoot}
+                layout={layout}
+                focusedPaneId={focusedPaneId}
+                visible={showTerminal}
+                broadcast={broadcast}
+                onFocusPane={setFocusedPaneId}
+                onSplit={handleSplit}
+                onClosePane={handleClosePane}
+                onToggleBroadcast={() => setBroadcast((on) => !on)}
+              />
+            </Panel>
+            {fitsSplit ? (
+              <>
+                <Separator className="shell-separator code-room__sep">
+                  <SeparatorHandle orientation="col" />
+                </Separator>
+                <Panel
+                  id={`code-room-dock-${row.id}`}
+                  className="code-room__panel"
+                  minSize={DOCK_MIN_WIDTH[dockSize]}
+                >
+                  {renderDock({ visible: true })}
+                </Panel>
+              </>
+            ) : null}
+          </Group>
+        </div>
+        {fitsSplit ? null : (
+          // Narrow: the dock stays MOUNTED across step changes (tab choice and
+          // the Browser keepalive would otherwise reset on every trip), so it
+          // is hidden rather than unmounted — and told it is hidden, because a
+          // native webview left active would paint over the terminal.
+          <div className={showDock ? "flex min-h-0 min-w-0 flex-1" : "hidden"}>
+            {renderDock({ visible: showDock, onBack: () => goToStep("terminal") })}
+          </div>
+        )}
       </div>
       <CodeComposer row={row} onJumpToSession={onJumpToSession} />
     </div>

--- a/src/lib/code-surface.test.ts
+++ b/src/lib/code-surface.test.ts
@@ -17,6 +17,15 @@ import {
   CODE_DOCK_SIZES,
   normalizeCodeTopTab,
   parseCodeDeepLink,
+  CODE_ROOM_RAIL_WIDTH_PX,
+  CODE_ROOM_MIN_TERMINAL_WIDTH_PX,
+  CODE_ROOM_MIN_DOCK_WIDTH_PX,
+  CODE_ROOM_SPLIT_MIN_WIDTH_PX,
+  CODE_ROOM_RAIL_MIN_WIDTH_PX,
+  CODE_WORKBENCH_STEPS,
+  codeRoomFits,
+  codeRoomFitsRail,
+  codeWorkbenchFitsSplit,
 } from "./code-surface.ts";
 import type { SessionRow } from "./types.ts";
 
@@ -199,4 +208,74 @@ test("only the wide tabs force the dock open expanded", () => {
   for (const tab of ["changes", "files", "pr", "inspector"] as const) {
     assert.ok(!codeDockTabWantsExpanded(tab), `${tab} reads fine at normal width`);
   }
+});
+
+// ---------------------------------------------------------------------------
+// Room layout model (cave-k3a9u)
+//
+// The shipped Room tried to stack itself with a CSS media query that
+// `react-resizable-panels` overrode with an inline `flex-direction`, so the
+// narrow layout never rendered at all. The replacement decides in JS from a
+// measured width, which is what these cover.
+// ---------------------------------------------------------------------------
+
+test("the rail breakpoint is derived from the split breakpoint, not written twice", () => {
+  assert.equal(
+    CODE_ROOM_SPLIT_MIN_WIDTH_PX,
+    CODE_ROOM_MIN_TERMINAL_WIDTH_PX + CODE_ROOM_MIN_DOCK_WIDTH_PX,
+    "the split needs exactly the two zones it contains",
+  );
+  assert.equal(
+    CODE_ROOM_RAIL_MIN_WIDTH_PX,
+    CODE_ROOM_RAIL_WIDTH_PX + CODE_ROOM_SPLIT_MIN_WIDTH_PX,
+    "the rail breakpoint must move with the split one — the old 768px/900px " +
+      "pair disagreed, leaving 768-900px specified as neither shape",
+  );
+  assert.ok(
+    CODE_ROOM_RAIL_MIN_WIDTH_PX > CODE_ROOM_SPLIT_MIN_WIDTH_PX,
+    "the rail must give up its column before the dock gives up its own",
+  );
+});
+
+test("an unmeasured width falls back to the caller's guess rather than reading as narrow", () => {
+  // null/undefined mean "no measurement yet" (SSR, first paint, or no
+  // ResizeObserver). Treating that as 0 would render the narrow layout on
+  // every desktop first paint and flash.
+  for (const width of [null, undefined, 0, -1, Number.NaN]) {
+    assert.equal(
+      codeRoomFits(width, 500, true),
+      false,
+      `unmeasured ${String(width)} on a phone stays narrow`,
+    );
+    assert.equal(
+      codeRoomFits(width, 500, false),
+      true,
+      `unmeasured ${String(width)} on a desktop stays wide`,
+    );
+  }
+});
+
+test("a measured width beats the fallback in both directions", () => {
+  // The whole point of measuring: a wide viewport holding a narrow Room must
+  // resolve narrow, and vice versa.
+  assert.equal(codeRoomFits(400, 500, false), false, "a narrow Room in a wide window");
+  assert.equal(codeRoomFits(600, 500, true), true, "a wide Room reported by a mobile UA");
+  assert.equal(codeRoomFits(500, 500, true), true, "exactly the minimum still fits");
+  assert.equal(codeRoomFits(499, 500, false), false, "one pixel under does not");
+});
+
+test("the two Room breakpoints apply their own constants", () => {
+  assert.ok(codeWorkbenchFitsSplit(CODE_ROOM_SPLIT_MIN_WIDTH_PX, true));
+  assert.ok(!codeWorkbenchFitsSplit(CODE_ROOM_SPLIT_MIN_WIDTH_PX - 1, false));
+  assert.ok(codeRoomFitsRail(CODE_ROOM_RAIL_MIN_WIDTH_PX, true));
+  assert.ok(!codeRoomFitsRail(CODE_ROOM_RAIL_MIN_WIDTH_PX - 1, false));
+  // A 390px phone is the case that was broken: two columns whose minimums
+  // already sum past the whole screen.
+  assert.ok(!codeWorkbenchFitsSplit(390, true), "a phone drills in");
+  assert.ok(!codeRoomFitsRail(390, true), "a phone lands on the rail");
+});
+
+test("the narrow workbench lands on the terminal", () => {
+  assert.deepEqual([...CODE_WORKBENCH_STEPS], ["terminal", "context"]);
+  assert.equal(CODE_WORKBENCH_STEPS[0], "terminal", "the shell is the Room's priority surface");
 });

--- a/src/lib/code-surface.ts
+++ b/src/lib/code-surface.ts
@@ -64,6 +64,79 @@ export function codeDockTabWantsExpanded(tab: CodeDockTab): boolean {
   return tab === "browser" || tab === "github";
 }
 
+/**
+ * Room layout thresholds (cave-k3a9u).
+ *
+ * These are the ONE source of truth for how much width each zone needs; the
+ * CSS `minSize` strings are derived from them so a number can never drift
+ * between the constraint and the decision to apply it.
+ *
+ * They are measured against the Room's own box, never the viewport. The
+ * approved design is explicit about this — "container queries or measured
+ * panel width drive compact behavior; viewport width alone is insufficient
+ * because the Room can appear beside other pages" — and it is not a
+ * formality: the Room renders inside the role-surface host beside the app
+ * sidebar and can be placed in a split, so viewport width systematically
+ * overstates the width the Room actually got.
+ */
+export const CODE_ROOM_RAIL_WIDTH_PX = 256;
+export const CODE_ROOM_MIN_TERMINAL_WIDTH_PX = 320;
+export const CODE_ROOM_MIN_DOCK_WIDTH_PX = 300;
+
+/** Below this the terminal and the dock cannot both be legible, so the
+ *  workbench drills in (Terminal <-> Context) instead of showing two crushed
+ *  columns. */
+export const CODE_ROOM_SPLIT_MIN_WIDTH_PX =
+  CODE_ROOM_MIN_TERMINAL_WIDTH_PX + CODE_ROOM_MIN_DOCK_WIDTH_PX;
+
+/** Below this the session rail cannot sit beside a workbench that still fits
+ *  its split, so the rail becomes the landing step. Derived from the two
+ *  zones it must accompany, which is what keeps this breakpoint and the split
+ *  breakpoint from disagreeing the way 768px and 900px did. */
+export const CODE_ROOM_RAIL_MIN_WIDTH_PX =
+  CODE_ROOM_RAIL_WIDTH_PX + CODE_ROOM_SPLIT_MIN_WIDTH_PX;
+
+/** The narrow workbench's two steps. Terminal is the landing step — the shell
+ *  is the Room's priority surface — and Context is reached explicitly. */
+export const CODE_WORKBENCH_STEPS = ["terminal", "context"] as const;
+export type CodeWorkbenchStep = (typeof CODE_WORKBENCH_STEPS)[number];
+
+/**
+ * Does a measured box have room for a zone that needs `minWidth`?
+ *
+ * `width === null` means "not measured yet" — the first paint, SSR, or a test
+ * environment without ResizeObserver. That is not the same as "too narrow", so
+ * the caller supplies a viewport-derived guess to use until the real number
+ * arrives. Guessing wide on a phone would flash a crushed two-column layout
+ * before correcting, which is exactly the bug this replaces.
+ */
+export function codeRoomFits(
+  width: number | null | undefined,
+  minWidth: number,
+  fallbackNarrow: boolean,
+): boolean {
+  if (width === null || width === undefined || !Number.isFinite(width) || width <= 0) {
+    return !fallbackNarrow;
+  }
+  return width >= minWidth;
+}
+
+/** Can the Room show the session rail beside a usable workbench? */
+export function codeRoomFitsRail(
+  width: number | null | undefined,
+  fallbackNarrow: boolean,
+): boolean {
+  return codeRoomFits(width, CODE_ROOM_RAIL_MIN_WIDTH_PX, fallbackNarrow);
+}
+
+/** Can the workbench show the terminal center and the context dock at once? */
+export function codeWorkbenchFitsSplit(
+  width: number | null | undefined,
+  fallbackNarrow: boolean,
+): boolean {
+  return codeRoomFits(width, CODE_ROOM_SPLIT_MIN_WIDTH_PX, fallbackNarrow);
+}
+
 /** Top-level surface tabs: the session workbench plus Activity (the former
  *  all-content GitHub feed) and focused GitHub slices. Legacy `ctab=github`
  *  deep links normalize onto Activity. */

--- a/src/lib/use-measured-width.ts
+++ b/src/lib/use-measured-width.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect, useState, type RefObject } from "react";
+
+/**
+ * Live width of an element's content box, or `null` until it has been measured
+ * (cave-k3a9u).
+ *
+ * `null` is deliberately distinct from `0`. A caller deciding a layout has to
+ * tell "this box is genuinely tiny" apart from "no measurement has arrived
+ * yet" — on the server, on the first paint, and in test environments without
+ * ResizeObserver — because those want opposite fallbacks.
+ *
+ * Reach for this instead of a viewport media query whenever the thing being
+ * sized is a panel rather than the page. A surface that can sit beside other
+ * surfaces, inside a split, or next to the app sidebar has a width the viewport
+ * does not describe.
+ */
+export function useMeasuredWidth(ref: RefObject<HTMLElement | null>): number | null {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element || typeof ResizeObserver === "undefined") return;
+    const read = (next: number) => {
+      setWidth((previous) => (previous === next ? previous : next));
+    };
+    read(element.clientWidth);
+    const observer = new ResizeObserver((entries) => {
+      read(entries[0]?.contentRect.width ?? element.clientWidth);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref]);
+
+  return width;
+}

--- a/src/styles/globals/surface-code-room.css
+++ b/src/styles/globals/surface-code-room.css
@@ -290,14 +290,11 @@
   }
 }
 
-/* ── Narrow widths: the room stacks instead of compressing into two unusable
-   columns. The terminal stays first because it is the priority surface. ── */
-@media (max-width: 900px) {
-  .code-room__group {
-    flex-direction: column;
-  }
-  .code-context-dock {
-    border-left: none;
-    border-top: 1px solid var(--border-hairline);
-  }
-}
+/* ── Narrow widths: the Room does NOT stack here.
+   A `flex-direction: column` override was tried and could never work —
+   react-resizable-panels sets flexDirection INLINE from its orientation prop
+   (it even spreads a caller's `style` before its own), and an inline
+   declaration beats any class selector. The rule sat here silently doing
+   nothing while a 390px Room rendered two columns whose minimums add up to
+   620px. The narrow layout is now a real drill-in owned by CodeWorkbench,
+   decided from the Room's MEASURED width rather than the viewport (cave-k3a9u). ── */

--- a/tests/mobile/code-surface-drill-in.spec.ts
+++ b/tests/mobile/code-surface-drill-in.spec.ts
@@ -1,9 +1,16 @@
 import { expect, test, type Page } from "@playwright/test";
 
-// Code surface mobile drill-in (cave-k0ua): below the md breakpoint the
-// session rail IS the landing screen — no auto-pick of the newest session —
-// and choosing a session replaces the list with the full-width workbench,
-// returned from via the "Back to sessions" affordance.
+// Code surface mobile drill-in (cave-k0ua, extended cave-k3a9u): on a narrow
+// Room the session rail IS the landing screen — no auto-pick of the newest
+// session — and choosing a session replaces the list with the full-width
+// workbench, returned from via the "Back to sessions" affordance.
+//
+// The full flow is Sessions -> Terminal -> Context, per the approved design.
+// The third step never existed: the Room tried to stack itself with a CSS
+// media query that react-resizable-panels overrides with an inline
+// flex-direction, so at 390px it rendered two columns whose minimums alone
+// (320px terminal + 300px dock) already exceed the screen. This spec is the
+// end-to-end proof that the replacement actually renders.
 //
 // Lives under tests/mobile/ because Playwright's mobile projects
 // (pixel-5 / iphone-13) only match specs there (see playwright.config.ts
@@ -61,17 +68,33 @@ test.describe("code surface mobile drill-in", () => {
     await expect(page.getByRole("button", { name: "Back to sessions" })).toHaveCount(0);
     await expect(page.getByRole("tablist", { name: "Session context" })).toHaveCount(0);
 
-    // Drill in: the workbench replaces the list.
+    // Drill in (step 2): the workbench replaces the list, landing on the
+    // TERMINAL — the shell is the Room's priority surface. The dock is mounted
+    // but hidden, so its tablist must not be visible.
     await railRow.click();
     await expect(page.getByRole("heading", { name: "Refactor auth flow" })).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByRole("tablist", { name: "Session context" })).toBeVisible();
     await expect(railRow).toBeHidden();
+    const dockTabs = page.getByRole("tablist", { name: "Session context" });
+    await expect(dockTabs).toBeHidden();
+
+    // Step 3: Context is reached explicitly and the terminal steps aside.
+    const contextButton = page.getByRole("button", { name: "Show context" });
+    await expect(contextButton).toBeVisible();
+    await contextButton.click();
+    await expect(dockTabs).toBeVisible();
+
+    // ...and the dock's own Back returns to the terminal. Collapse/expand are
+    // meaningless at full width, so Back is the only action offered here.
+    await expect(page.getByRole("button", { name: "Collapse context" })).toHaveCount(0);
+    await page.getByRole("button", { name: "Back to terminal" }).click();
+    await expect(dockTabs).toBeHidden();
+    await expect(contextButton).toBeVisible();
 
     // Back: the list returns and stays (no auto-pick re-selects the session).
     await page.getByRole("button", { name: "Back to sessions" }).click();
     await expect(railRow).toBeVisible();
-    await expect(page.getByRole("tablist", { name: "Session context" })).toHaveCount(0);
+    await expect(dockTabs).toHaveCount(0);
     await page.waitForTimeout(600);
-    await expect(page.getByRole("tablist", { name: "Session context" })).toHaveCount(0);
+    await expect(dockTabs).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Closes `cave-k3a9u`.

## The bug

The Room shipped with a stacking rule that **never once applied**:

```css
@media (max-width: 900px) { .code-room__group { flex-direction: column } }
```

`react-resizable-panels` (4.12.2) renders its `Group` with an **inline** `flexDirection` taken from the `orientation` prop, and its own keys land *after* the caller's `style` spread:

```js
style: { height, width, overflow, ...userStyle,
         display: "flex",
         flexDirection: c === "horizontal" ? "row" : "column", ... }
```

An inline declaration beats any class selector, and the library's key beats even a passed `style`. Orientation is a **prop**, never CSS. With the rule inert, a 390px phone rendered two side-by-side columns whose minimums alone — 320px terminal + 300px dock — already exceed the screen.

## Why the fix isn't "make the rule apply"

The approved design (`cave-98o51`) asks for a drill-in, not a stack:

> **Phone:** the flow is Sessions → Terminal → Context. Back controls return to the prior step.

Only Sessions → Workbench existed; **Context had no step at all**. Repairing the media query would have shipped the wrong shape.

## What changed

- **The narrow Room is a real drill-in.** Terminal is the landing step (the shell is the Room's priority surface); Context is reached explicitly and returns via the dock's own Back. Collapse/expand are not offered there — both describe a width the dock does not have as a full-width step.
- **Both breakpoints are measured, from the Room's own box.** The design is explicit that this matters — *"container queries or measured panel width drive compact behavior; viewport width alone is insufficient because the Room can appear beside other pages"* — and it does: the Room renders inside the role-surface host beside the app sidebar and can sit in a split, so the viewport systematically overstates the width it actually got.
- **The two breakpoints now agree.** The rail keyed on `md:` (768px) and stacking on 900px, leaving 768–900px specified as neither shape. Both now derive from the same summed minimums, so a later change to a zone's floor moves the breakpoint with it instead of leaving it behind.
- **The dead rule is deleted**, replaced by a comment recording why that approach cannot work — the next person to reach for `flex-direction` here should find the answer in place.

## Two things that would have broken quietly

- **The terminal keeps one slot in the tree** across the breakpoint and goes `visible={false}` when stepped away rather than unmounting. Unmounting is what drops the PTY attachment and the scrollback with it. A test pins that the layouts cannot fork into two separate terminal `Panel`s.
- **The dock is told when it is hidden.** `BrowserPane` draws a *native* webview positioned over its container's box, which `display: none` does not clip — a mounted-but-hidden dock left `active` would paint the browser straight over the terminal.

A routed diff/file open also drills to Context now, since pointing a hidden dock at the right tab would look like the jump silently did nothing.

## Provenance

The bulk of this work was recovered from `archive/fix-cave-k3a9u-room-narrow-layout-20260805`, a WIP commit archived before the original worktree was destroyed. Cherry-picked onto current `main` across 184 commits with **zero conflicts**.

## Verification

- `pnpm typecheck` clean.
- Source-text pins added for every claim above, including two `doesNotMatch` guards that fail if the CSS rule or a viewport query returns.
- `tests/mobile/code-surface-drill-in.spec.ts` extended to walk all three steps and assert the dock's tablist is *hidden* on the terminal step — the previous expectation (dock visible immediately on drill-in) encoded the old two-step flow.
- Full `pnpm test:app` was still running locally when this opened; CI is the gate.