### PR TITLE
fix(research): Resources grid strands single-item groups

### DIFF
--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -238,3 +238,27 @@ test("manual zero-result announcements suppress duplicate EmptyState live output
   assert.match(emptyState, /live = true/);
   assert.match(emptyState, /role=\{live \? "status" : undefined\}/);
 });
+
+test("the grid collapses empty tracks, and the card cap is grid-only (cave-93jz1)", () => {
+  // auto-FILL keeps the empty tracks it created, so a group holding fewer links
+  // than the row fits left its cards stranded at the 250px minimum beside dead
+  // space. auto-fit collapses them.
+  assert.match(styles, /\.research-res__items\[data-view="grid"\] \{[\s\S]*?repeat\(auto-fit, minmax\(250px, 1fr\)\)/);
+  assert.doesNotMatch(
+    styles,
+    /\.research-res__items\[data-view="grid"\] \{[\s\S]*?repeat\(auto-fill/,
+    "auto-fill strands single-item groups — see cave-93jz1",
+  );
+  // …but collapsing alone would stretch ONE saved link across the whole row,
+  // so the card carries a cap. Measured: a lone card renders 360px against
+  // 255px in a packed row — recognisably the same component.
+  assert.match(styles, /\.research-res-card\[data-view="grid"\] \{ max-width: 360px; \}/);
+  // The cap must NOT reach the rows view, whose cards span the full surface
+  // (measured 1314px at 1440), nor the phone breakpoint's single column
+  // (measured 496px at 520) — capping either re-creates the gap it fixes.
+  assert.doesNotMatch(styles, /\.research-res-card \{[^}]*max-width: 360px/);
+  assert.match(
+    styles,
+    /@container research-desk \(max-width: 560px\) \{[\s\S]*?\.research-res-card\[data-view="grid"\] \{ max-width: none; \}/,
+  );
+});

--- a/src/components/role-surfaces/research-tab-resources.test.ts
+++ b/src/components/role-surfaces/research-tab-resources.test.ts
@@ -240,25 +240,43 @@ test("manual zero-result announcements suppress duplicate EmptyState live output
 });
 
 test("the grid collapses empty tracks, and the card cap is grid-only (cave-93jz1)", () => {
-  // auto-FILL keeps the empty tracks it created, so a group holding fewer links
-  // than the row fits left its cards stranded at the 250px minimum beside dead
-  // space. auto-fit collapses them.
-  assert.match(styles, /\.research-res__items\[data-view="grid"\] \{[\s\S]*?repeat\(auto-fit, minmax\(250px, 1fr\)\)/);
-  assert.doesNotMatch(
-    styles,
-    /\.research-res__items\[data-view="grid"\] \{[\s\S]*?repeat\(auto-fill/,
-    "auto-fill strands single-item groups — see cave-93jz1",
-  );
-  // …but collapsing alone would stretch ONE saved link across the whole row,
-  // so the card carries a cap. Measured: a lone card renders 360px against
-  // 255px in a packed row — recognisably the same component.
-  assert.match(styles, /\.research-res-card\[data-view="grid"\] \{ max-width: 360px; \}/);
-  // The cap must NOT reach the rows view, whose cards span the full surface
-  // (measured 1314px at 1440), nor the phone breakpoint's single column
-  // (measured 496px at 520) — capping either re-creates the gap it fixes.
-  assert.doesNotMatch(styles, /\.research-res-card \{[^}]*max-width: 360px/);
-  assert.match(
-    styles,
-    /@container research-desk \(max-width: 560px\) \{[\s\S]*?\.research-res-card\[data-view="grid"\] \{ max-width: none; \}/,
-  );
+  // Assertions are scoped to ONE rule body each. An unbounded [\s\S]*? from a
+  // selector runs to the end of the sheet, which both false-FAILS (an
+  // unrelated later `auto-fill` reads as this rule regressing) and
+  // false-PASSES (a later `auto-fit` satisfies the check even if this rule
+  // was reverted). Slice the body, then assert inside it.
+  const ruleBody = (selector: string, from = 0): string => {
+    const at = styles.indexOf(selector, from);
+    assert.notEqual(at, -1, `missing rule: ${selector}`);
+    const open = styles.indexOf("{", at);
+    const close = styles.indexOf("}", open);
+    assert.ok(open !== -1 && close !== -1, `unterminated rule: ${selector}`);
+    return styles.slice(open + 1, close);
+  };
+
+  // The base grid rule (the one that declares `display: grid`, not the 560px
+  // single-column override that shares its selector).
+  const grid = ruleBody('.research-res__items[data-view="grid"]');
+  assert.match(grid, /display: grid/, "sliced the base rule, not an override");
+  // auto-FILL creates and KEEPS empty tracks, so a group holding fewer links
+  // than the row fits leaves its cards stranded at the 250px minimum beside
+  // dead space. auto-fit collapses them.
+  assert.match(grid, /grid-template-columns: repeat\(auto-fit, minmax\(250px, 1fr\)\)/);
+  assert.doesNotMatch(grid, /auto-fill/, "auto-fill strands single-item groups — cave-93jz1");
+
+  // Collapsing alone would stretch ONE saved link across the whole row, so the
+  // card carries a cap. Measured: a lone card renders 360px against 255px in a
+  // packed row — recognisably the same component.
+  assert.match(ruleBody('.research-res-card[data-view="grid"]'), /max-width: 360px/);
+
+  // The cap must not reach the rows view, whose cards span the full surface
+  // (measured 1314px at 1440) — capping there shrinks every row to a quarter.
+  assert.doesNotMatch(ruleBody(".research-res-card {"), /max-width/);
+
+  // …nor the phone breakpoint's single column (measured 496px filling a 520px
+  // viewport), where a cap re-creates the very gap this fixes. Search from the
+  // start of that container block so the override, not the base rule, is read.
+  const narrowAt = styles.indexOf("@container research-desk (max-width: 560px)");
+  assert.notEqual(narrowAt, -1);
+  assert.match(ruleBody('.research-res-card[data-view="grid"]', narrowAt), /max-width: none/);
 });

--- a/src/styles/globals/surface-research-resources.css
+++ b/src/styles/globals/surface-research-resources.css
@@ -431,9 +431,14 @@
 
 /* ── Item cards: grid and rows variants. ── */
 .research-res__items { margin-top: 10px; }
+/* auto-FIT, not auto-fill: auto-fill keeps the empty tracks it created, so a
+   group holding fewer links than the row fits left its cards stranded at the
+   minimum width beside dead space (cave-93jz1). auto-fit collapses those
+   tracks — paired with the card cap below, which stops the collapse turning a
+   single saved link into one 1300px-wide card. */
 .research-res__items[data-view="grid"] {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
   gap: 10px;
 }
 .research-res__items[data-view="rows"] {
@@ -460,6 +465,12 @@
   transition: border-color 150ms ease, transform 150ms ease, box-shadow 150ms ease;
   --res-kind: var(--research-accent);
 }
+/* Grid only — rows view is a flex column whose cards must span the full width,
+   and a cap there would shrink every row to a third of the surface.
+   The cap sits just above the widest track a packed row produces, so a lone
+   card reads as the same component as one in a full group rather than as a
+   banner. */
+.research-res-card[data-view="grid"] { max-width: 360px; }
 .research-res-card[data-category="github"] { --res-kind: var(--text-secondary); }
 .research-res-card[data-category="docs"] { --res-kind: var(--color-info); }
 .research-res-card[data-category="paper"] { --res-kind: var(--color-danger); }
@@ -879,6 +890,8 @@
   }
   .research-res__intake-footer .ui-btn { width: 100%; }
   .research-res__items[data-view="grid"] { grid-template-columns: 1fr; }
+  /* Single column already: capping here would re-create the gap this fixes. */
+  .research-res-card[data-view="grid"] { max-width: none; }
   .research-res-card[data-view="rows"] { flex-wrap: wrap; }
   .research-res-card[data-view="rows"] .research-res-card__sub { flex-basis: 100%; order: 3; }
   .research-res-card[data-view="rows"] .research-res-card__footer {


### PR DESCRIPTION
Fixes `cave-93jz1`, found while driving the merged Research Desk (#4417) in a production build.

## The bug

`surface-research-resources.css` used `repeat(auto-fill, minmax(250px, 1fr))`. **`auto-fill` creates and keeps empty tracks**, so a group holding fewer links than the row fits leaves its cards at the 250px minimum beside a wide dead area. Most visible at one link per group — which is the common case for "In this run".

Groups with 5+ links filled the row and looked correct, which is why it survived this long.

## The fix, and why it needed two parts

`auto-fit` collapses the empty tracks. On its own that overcorrects: one saved link would stretch into a ~1300px card. So the card also carries a cap.

Measured in a production build at 1440px:

| | lone card | packed row |
|---|---|---|
| before | 255px, beside ~1000px dead space | 255px each |
| after | **360px** | 255px each (unchanged) |

360px sits just above the widest track a packed row produces, so a lone card reads as *the same component* as one in a full group rather than as a banner.

## The cap is scoped twice, deliberately

Both escapes would re-create the very gap this removes, so each is pinned by the test:

- **`[data-view="grid"]`, never the bare card** — rows view is a flex column whose cards span the surface (measured 1314px). A cap there would shrink every row to a quarter width.
- **Lifted at the 560px breakpoint**, where the grid is already one column (measured 496px filling a 520px viewport).

## Not a regression from #4417

The `auto-fill` rule predates the Research Desk rebuild. The new kind-banded card header just makes each card read as a more definite object, so the short row became conspicuous. Calling that out so nobody bisects into the redesign looking for it.

## Verification

Driven in a real browser against a production build, with fixtures giving one group a single link and another seven — the exact comparison the bead asks for. All three cases measured, not eyeballed: grid 1440 (360 vs 255), rows 1440 (1314, uncapped), grid 520 (496, filling).

`pnpm lint`, the token-drift ratchets and `tokenize-css.mjs` are all clean — `max-width` is not a ratcheted property, and no baseline moved. The new test in `research-tab-resources.test.ts` pins `auto-fit`, the exact cap, and both scope boundaries, so a future `auto-fill` or an unscoped cap fails CI rather than quietly regressing.
