### PR TITLE
Fix contextual iOS new chat

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
+++ b/apps/ios/CovenCave/CovenCave/Networking/CaveClient+Dev.swift
@@ -1,13 +1,6 @@
 import Foundation
 
 extension CaveClient {
-    private static let devSharedSession: URLSession = {
-        let config = URLSessionConfiguration.default
-        config.timeoutIntervalForRequest = 25
-        config.waitsForConnectivity = true
-        return URLSession(configuration: config)
-    }()
-
     /// Project roots remain shared by Terminal and the chat Projects panel.
     func projects() async throws -> [ProjectInfo] {
         try await projects(familiarId: nil)
@@ -53,7 +46,7 @@ extension CaveClient {
         if let token = CaveConnection.accessToken {
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
-        let (data, response) = try await Self.devSharedSession.data(for: request)
+        let (data, response) = try await data(for: request)
         if let http = response as? HTTPURLResponse, !(200..<300).contains(http.statusCode) {
             throw Self.serverResponseError(statusCode: http.statusCode, data: data)
         }

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -371,6 +371,35 @@ final class AppModel {
         return CaveClient(connection: connection)
     }
 
+    #if DEBUG
+    @ObservationIgnored private var previewChatProjects: [ProjectInfo]?
+    #endif
+
+    var canLoadChatProjects: Bool {
+        #if DEBUG
+        if previewChatProjects != nil { return true }
+        #endif
+        return client != nil
+    }
+
+    var canRecoverChatProjectConnection: Bool {
+        #if DEBUG
+        if previewChatProjects != nil { return false }
+        #endif
+        return connection != nil
+    }
+
+    func loadChatProjects(familiarIds: [String]) async throws -> [ProjectInfo] {
+        #if DEBUG
+        if let previewChatProjects {
+            return previewChatProjects
+        }
+        #endif
+
+        guard let client else { throw CaveError.notConfigured }
+        return try await client.projects(familiarIds: familiarIds)
+    }
+
     /// familiarId → when its chats were last viewed. A familiar reads as
     /// "unread" when its latest activity is newer than this. Persisted.
     var familiarViews: [String: Date] = [:]
@@ -524,6 +553,22 @@ final class AppModel {
                 familiarIds: ["nyx"]
             ),
         ]
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("--ui-preview-new-chat-projects")
+            || arguments.contains("--ui-preview-new-chat-project-retry")
+            || arguments.contains("--ui-preview-new-chat-project-empty-retry") {
+            threads.first?.projectRoot = "/repos/coven-cave"
+            previewChatProjects = [
+                ProjectInfo(
+                    id: "coven-cave",
+                    name: "Coven Cave",
+                    root: "/repos/coven-cave",
+                    color: nil,
+                    updatedAt: nil,
+                    access: .write
+                ),
+            ]
+        }
         connectionState = .connected
     }
 

--- a/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatProjectPicker.swift
@@ -50,8 +50,26 @@ struct ChatProjectPicker: View {
         )
     }
 
+    #if DEBUG
+    private enum PreviewInitialState {
+        case empty
+        case failure
+    }
+
+    private var previewInitialState: PreviewInitialState? {
+        let arguments = ProcessInfo.processInfo.arguments
+        if arguments.contains("--ui-preview-new-chat-project-retry") {
+            return .failure
+        }
+        if arguments.contains("--ui-preview-new-chat-project-empty-retry") {
+            return .empty
+        }
+        return nil
+    }
+    #endif
+
     var body: some View {
-        Group {
+        VStack(alignment: .leading, spacing: 0) {
             if familiarKey.isEmpty {
                 Label(
                     "Choose a familiar before selecting a project.",
@@ -75,8 +93,11 @@ struct ChatProjectPicker: View {
                         systemImage: "folder.badge.questionmark"
                     )
                     .foregroundStyle(.secondary)
-                    if let onManageAccess {
-                        Button("Project access", action: onManageAccess)
+                    HStack(spacing: 12) {
+                        Button("Retry") { reloadToken += 1 }
+                        if let onManageAccess {
+                            Button("Project access", action: onManageAccess)
+                        }
                     }
                 }
             } else {
@@ -109,6 +130,7 @@ struct ChatProjectPicker: View {
             }
         }
         .pickerStyle(.menu)
+        .accessibilityIdentifier("New chat project")
         .accessibilityHint("Chooses where this chat can work")
     }
 
@@ -141,6 +163,22 @@ struct ChatProjectPicker: View {
             return
         }
 
+        #if DEBUG
+        if refreshToken == 0, reloadToken == 0 {
+            switch previewInitialState {
+            case .failure:
+                errorMessage = "Couldn’t load projects."
+                resolvedLoadKey = identity.key
+                return
+            case .empty:
+                resolvedLoadKey = identity.key
+                return
+            case nil:
+                break
+            }
+        }
+        #endif
+
         isLoading = true
         defer {
             if loadGeneration == identity.generation {
@@ -148,7 +186,7 @@ struct ChatProjectPicker: View {
             }
         }
 
-        guard app.client != nil else {
+        guard app.canLoadChatProjects else {
             guard loadGeneration == identity.generation else { return }
             isLoading = false
             errorMessage = "Connect to your Cave to load projects."
@@ -159,12 +197,10 @@ struct ChatProjectPicker: View {
         do {
             let loaded = try await ChatProjectSelection.loadProjectsWithRecovery(
                 load: {
-                    guard let currentClient = app.client else {
-                        throw CaveError.notConfigured
-                    }
-                    return try await currentClient.projects(familiarIds: familiarKey)
+                    try await app.loadChatProjects(familiarIds: familiarKey)
                 },
                 recover: { _ in
+                    guard app.canRecoverChatProjectConnection else { return false }
                     await app.recoverConnectionInBackground()
                     return app.connectionState == .connected
                 }

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -8,6 +8,23 @@ enum ChatRoute: Hashable {
     case thread(ChatThread)
 }
 
+@MainActor
+enum ChatNewConversationContext {
+    static func fixedFamiliarId(
+        selection: ChatRoute?,
+        detailPath: [ChatRoute]
+    ) -> String? {
+        guard let visibleRoute = detailPath.last ?? selection else { return nil }
+        switch visibleRoute {
+        case .familiar(let familiar):
+            return familiar.id
+        case .thread(let thread):
+            let familiarIds = ChatProjectSelection.familiarKey(thread.familiarIds)
+            return familiarIds.count == 1 ? familiarIds[0] : nil
+        }
+    }
+}
+
 /// The Chats destination, shaped like Messages: one vertical list of
 /// *familiars*, each row previewing the last thing said in that familiar's
 /// landing chat. There is no cross-familiar "Recent" list — a familiar is the
@@ -32,6 +49,7 @@ struct ChatsHomeView: View {
     /// All-familiars roster sheet.
     @State private var showFamiliars = false
     @State private var showProjects = false
+    @State private var appliedPreviewLaunchIntent = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     /// Anchors the iOS 18 zoom transition: thread rows mark themselves as
     /// sources; the pushed conversation zooms out of its row.
@@ -54,6 +72,7 @@ struct ChatsHomeView: View {
             if ProcessInfo.processInfo.arguments.contains("--ui-open-familiars") {
                 showFamiliars = true
             }
+            applyPreviewLaunchIntent()
             #endif
         }
     }
@@ -114,7 +133,7 @@ struct ChatsHomeView: View {
             }
             .onChange(of: app.newChatRequested) { _, requested in
                 guard requested else { return }
-                presentNewChat()
+                presentContextualNewChat()
                 app.newChatRequested = false
             }
             .onChange(of: app.chatSearchRequested) { _, requested in
@@ -222,6 +241,19 @@ struct ChatsHomeView: View {
         showNewChat = true
     }
 
+    private func presentContextualNewChat() {
+        presentNewChat(
+            fixedFamiliarId: ChatNewConversationContext.fixedFamiliarId(
+                selection: selection,
+                detailPath: detailPath
+            )
+        )
+    }
+
+    private func presentGeneralNewChat() {
+        presentNewChat()
+    }
+
     /// Large-title header pinned to the top, mirroring the Read / Tasks
     /// destinations so every destination title aligns at the same flush position.
     private var header: some View {
@@ -239,7 +271,7 @@ struct ChatsHomeView: View {
             }
             CircularIconButton(systemImage: "square.and.pencil",
                                label: "New chat") {
-                presentNewChat()
+                presentContextualNewChat()
             }
         }
         .padding(.horizontal, 16)
@@ -274,7 +306,7 @@ struct ChatsHomeView: View {
 
             CircularIconButton(systemImage: "square.and.pencil",
                                label: "New chat") {
-                presentNewChat()
+                presentContextualNewChat()
             }
         }
         .padding(.horizontal, 12)
@@ -325,7 +357,7 @@ struct ChatsHomeView: View {
     private func consumeGlobalRequests() {
         consumeThreadRequest(app.threadToOpen)
         if app.newChatRequested {
-            presentNewChat()
+            presentContextualNewChat()
             app.newChatRequested = false
         }
         if app.chatSearchRequested {
@@ -376,10 +408,25 @@ struct ChatsHomeView: View {
         } description: {
             Text("Pull to refresh once your desktop is connected, or start a group chat.")
         } actions: {
-            Button("New chat") { presentNewChat() }
+            Button("New chat") { presentGeneralNewChat() }
                 .buttonStyle(.borderedProminent)
         }
     }
+
+    #if DEBUG
+    private func applyPreviewLaunchIntent() {
+        let arguments = ProcessInfo.processInfo.arguments
+        guard !appliedPreviewLaunchIntent,
+              arguments.contains("--ui-open-contextual-new-chat")
+        else { return }
+
+        appliedPreviewLaunchIntent = true
+        if let thread = app.mostRecentThread {
+            selection = .thread(thread)
+        }
+        presentContextualNewChat()
+    }
+    #endif
 
     private func loadFailure(_ error: String) -> some View {
         ContentUnavailableView {

--- a/apps/ios/CovenCave/CovenCaveTests/ChatNewConversationContextTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatNewConversationContextTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class ChatNewConversationContextTests: XCTestCase {
+    private func familiar(_ id: String) -> Familiar {
+        Familiar(
+            id: id,
+            displayName: id.capitalized,
+            role: nil,
+            description: nil,
+            pronouns: nil,
+            color: nil,
+            status: "active",
+            harness: nil,
+            model: nil,
+            icon: nil,
+            avatarUrl: nil,
+            activeSessions: nil,
+            memoryFreshness: nil
+        )
+    }
+
+    func testSelectedFamiliarUsesItsId() {
+        XCTAssertEqual(
+            ChatNewConversationContext.fixedFamiliarId(
+                selection: .familiar(familiar("nyx")),
+                detailPath: []
+            ),
+            "nyx"
+        )
+    }
+
+    func testSelectedDirectThreadUsesItsFamiliar() {
+        let thread = ChatThread(title: "Direct", familiarIds: ["nyx"])
+
+        XCTAssertEqual(
+            ChatNewConversationContext.fixedFamiliarId(
+                selection: .thread(thread),
+                detailPath: []
+            ),
+            "nyx"
+        )
+    }
+
+    func testVisibleDetailThreadOverridesSidebarSelection() {
+        let thread = ChatThread(title: "Direct", familiarIds: ["sage"])
+
+        XCTAssertEqual(
+            ChatNewConversationContext.fixedFamiliarId(
+                selection: .familiar(familiar("nyx")),
+                detailPath: [.thread(thread)]
+            ),
+            "sage"
+        )
+    }
+
+    func testVisibleGroupThreadKeepsGeneralMode() {
+        let thread = ChatThread(title: "Group", familiarIds: ["nyx", "sage"])
+
+        XCTAssertNil(
+            ChatNewConversationContext.fixedFamiliarId(
+                selection: .familiar(familiar("nyx")),
+                detailPath: [.thread(thread)]
+            )
+        )
+    }
+
+    func testMissingContextKeepsGeneralMode() {
+        XCTAssertNil(
+            ChatNewConversationContext.fixedFamiliarId(
+                selection: nil,
+                detailPath: []
+            )
+        )
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/ChatProjectClientTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/ChatProjectClientTests.swift
@@ -1,0 +1,84 @@
+import Foundation
+import XCTest
+@testable import CovenCave
+
+private final class ChatProjectURLProtocol: URLProtocol {
+    static var handler: ((URLRequest) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool { true }
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+    override func startLoading() {
+        do {
+            let handler = try XCTUnwrap(Self.handler)
+            let (response, data) = try handler(request)
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+final class ChatProjectClientTests: XCTestCase {
+    override func tearDown() {
+        ChatProjectURLProtocol.handler = nil
+        super.tearDown()
+    }
+
+    func testProjectRequestUsesInjectedSessionAndRetriesTransientFailure() async throws {
+        var attempts = 0
+        ChatProjectURLProtocol.handler = { request in
+            attempts += 1
+            XCTAssertEqual(request.url?.path, "/api/projects")
+            XCTAssertEqual(
+                URLComponents(url: try XCTUnwrap(request.url), resolvingAgainstBaseURL: false)?
+                    .queryItems?.first(where: { $0.name == "familiarId" })?.value,
+                "nyx"
+            )
+            if attempts == 1 {
+                throw URLError(.networkConnectionLost)
+            }
+            let response = try XCTUnwrap(
+                HTTPURLResponse(
+                    url: try XCTUnwrap(request.url),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: ["Content-Type": "application/json"]
+                )
+            )
+            return (
+                response,
+                Data(
+                    """
+                    {
+                      "ok": true,
+                      "projects": [{
+                        "id": "cave",
+                        "name": "Coven Cave",
+                        "root": "/repos/cave",
+                        "access": "write"
+                      }]
+                    }
+                    """.utf8
+                )
+            )
+        }
+
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [ChatProjectURLProtocol.self]
+        let client = CaveClient(
+            connection: CaveConnection(host: "http://cave.test:3000"),
+            session: URLSession(configuration: configuration)
+        )
+
+        let projects = try await client.projects(familiarId: "nyx")
+
+        XCTAssertEqual(attempts, 2)
+        XCTAssertEqual(projects.map(\.id), ["cave"])
+        XCTAssertEqual(projects.first?.access, .write)
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
+++ b/apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+final class NewChatUITests: XCTestCase {
+    private func launchContextualNewChat(projectArgument: String) -> XCUIApplication {
+        let app = XCUIApplication()
+        app.launchArguments = [
+            "--ui-preview-empty-chat",
+            projectArgument,
+            "--ui-open-contextual-new-chat",
+        ]
+        app.launch()
+        XCTAssertTrue(app.navigationBars["New chat"].waitForExistence(timeout: 15))
+        XCTAssertFalse(app.staticTexts["Choose familiars"].exists)
+        XCTAssertFalse(app.staticTexts["1 selected"].exists)
+        return app
+    }
+
+    @MainActor
+    func testContextualNewChatRetriesProjectFailureWithoutFamiliarReselection() {
+        let app = launchContextualNewChat(
+            projectArgument: "--ui-preview-new-chat-project-retry"
+        )
+
+        let retry = app.buttons["Retry"]
+        XCTAssertTrue(retry.waitForExistence(timeout: 10), "project failure offers Retry")
+        retry.tap()
+
+        XCTAssertTrue(app.buttons["New chat project"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Start"].isEnabled)
+    }
+
+    @MainActor
+    func testEmptyProjectStateRetriesWithoutFamiliarReselection() {
+        let app = launchContextualNewChat(
+            projectArgument: "--ui-preview-new-chat-project-empty-retry"
+        )
+
+        XCTAssertTrue(
+            app.staticTexts["This familiar has no accessible projects."]
+                .waitForExistence(timeout: 10)
+        )
+        let retry = app.buttons["Retry"]
+        XCTAssertTrue(retry.exists, "empty project state offers Retry")
+        XCTAssertTrue(app.buttons["Project access"].exists)
+        retry.tap()
+
+        XCTAssertTrue(app.buttons["New chat project"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Start"].isEnabled)
+    }
+}

--- a/docs/superpowers/plans/2026-08-03-ios-familiar-new-chat.md
+++ b/docs/superpowers/plans/2026-08-03-ios-familiar-new-chat.md
@@ -8,6 +8,34 @@
 
 **Tech Stack:** SwiftUI, Swift concurrency, XCTest source contracts, Node.js test runner, XcodeGen/xcodebuild.
 
+## 2026-08-06 revision: contextual compose and project transport repair
+
+The fixed-familiar mode below has landed. The remaining user-visible gap is
+that Chats compose still calls the general presenter even when the visible
+route already identifies one familiar. The remaining project failure is in the
+client boundary: `CaveClient+Dev.swift` creates a separate URL session instead
+of using `CaveClient.data(for:)`, bypassing injected transports and the normal
+bounded GET retry policy.
+
+Implement this revision test-first:
+
+1. Add a pure `ChatNewConversationContext` resolver beside `ChatRoute`. Prefer
+   the last detail route over the sidebar selection and return a familiar only
+   for a familiar route or a direct thread with exactly one distinct familiar.
+2. Route header, bottom-bar, drawer, and consumed global New Chat intents
+   through contextual presentation. Keep the no-familiars empty action
+   explicitly general so group creation remains discoverable.
+3. Move project requests onto `CaveClient.data(for:)`; remove the projects
+   extension's private URL session.
+4. Add native tests for direct/group/absent context and an injected-transport
+   test proving a transient project GET retries and decodes the authorized
+   project response.
+5. Add a DEBUG-only project fixture to `AppModel` and a simulator UI test that
+   proves contextual New Chat hides the roster, exposes Retry after a forced
+   project failure, and enables Start after retry resolves the project.
+6. Extend `scripts/ios-chat-project-contract.test.mjs`, run focused native/UI
+   tests, the wired mobile contract, and the iOS build.
+
 ---
 
 ## File map

--- a/docs/superpowers/specs/2026-08-03-ios-familiar-new-chat-design.md
+++ b/docs/superpowers/specs/2026-08-03-ios-familiar-new-chat-design.md
@@ -29,7 +29,16 @@ the user cannot repair access without leaving the flow.
   familiar.
 
 `FamiliarThreadsView` and familiar-specific launch actions use fixed mode.
-Global compose actions continue using general mode.
+Global compose actions resolve the visible Chats route before presenting:
+
+- a selected familiar fixes that familiar;
+- a selected direct thread fixes its sole familiar;
+- a direct thread pushed within a familiar's history fixes its sole familiar;
+- a group thread or no visible route keeps general mode.
+
+This makes compose contextual without silently choosing a "most recent"
+familiar the user is not currently viewing. The empty-state action remains an
+explicit general-mode escape hatch for choosing one or more familiars.
 
 `ChatProjectPicker` continues querying `/api/projects?familiarId=...` through
 the existing `CaveClient.projects(familiarIds:)` path. It does not fall back to
@@ -43,6 +52,13 @@ closing New Chat.
 The Start action remains disabled until the picker resolves a valid project
 root. A successful launch persists that root on the new thread, preserving the
 existing first-turn request contract.
+
+Project discovery must use `CaveClient.data(for:)`, the same request boundary
+as the rest of the REST client. The projects extension must not create its own
+URL session because that bypasses injected test transports and the bounded GET
+retry policy. The picker still performs one higher-level connection recovery
+after those request retries are exhausted, so endpoint relocation and ordinary
+transient transport recovery remain separate and bounded.
 
 ## Error handling
 
@@ -60,8 +76,13 @@ existing first-turn request contract.
 - Verify fixed mode hides the familiar roster and keeps exactly one familiar.
 - Verify general mode still renders editable familiar selection.
 - Verify familiar-specific entry points pass fixed mode.
+- Verify global compose resolves a visible direct-chat familiar but preserves
+  general mode for group or absent context.
 - Verify an empty project response exposes Project access and reloads after the
   permissions sheet closes.
+- Verify project discovery uses the injected client transport and survives one
+  transient request failure without requiring endpoint relocation.
+- Drive a simulator fixture that opens contextual New Chat with no familiar
+  roster, surfaces a project load failure, and resolves the project after Retry.
 - Preserve the existing project-selection unit and first-turn provenance tests.
 - Run the repository's wired iOS source-contract tests and an iOS app build.
-

--- a/scripts/ios-chat-project-contract.test.mjs
+++ b/scripts/ios-chat-project-contract.test.mjs
@@ -11,6 +11,7 @@ const [
   connection,
   thread,
   appModel,
+  devClient,
   newChat,
   chat,
   picker,
@@ -18,6 +19,9 @@ const [
   familiarThreads,
   nativeContractTests,
   nativeSelectionTests,
+  nativeClientTests,
+  nativeContextTests,
+  uiTests,
   snapshotTests,
   runner,
 ] = await Promise.all([
@@ -27,6 +31,7 @@ const [
   read(`${iosRoot}/Networking/CaveConnection.swift`),
   read(`${iosRoot}/State/ChatThread.swift`),
   read(`${iosRoot}/State/AppModel.swift`),
+  read(`${iosRoot}/Networking/CaveClient+Dev.swift`),
   read(`${iosRoot}/Views/NewChatView.swift`),
   read(`${iosRoot}/Views/ChatView.swift`),
   read(`${iosRoot}/Views/ChatProjectPicker.swift`),
@@ -34,6 +39,9 @@ const [
   read(`${iosRoot}/Views/FamiliarThreadsView.swift`),
   read("apps/ios/CovenCave/CovenCaveTests/ChatProjectContractTests.swift"),
   read("apps/ios/CovenCave/CovenCaveTests/ChatProjectSelectionTests.swift"),
+  read("apps/ios/CovenCave/CovenCaveTests/ChatProjectClientTests.swift"),
+  read("apps/ios/CovenCave/CovenCaveTests/ChatNewConversationContextTests.swift"),
+  read("apps/ios/CovenCave/CovenCaveUITests/NewChatUITests.swift"),
   read("apps/ios/CovenCave/CovenCaveTests/ThreadSnapshotStoreTests.swift"),
   read("scripts/run-tests.mjs"),
 ]);
@@ -80,8 +88,18 @@ assert.match(
 );
 assert.match(
   picker,
-  /currentClient\.projects\(familiarIds: familiarKey\)/,
+  /app\.loadChatProjects\(familiarIds: familiarKey\)/,
   "the picker must request projects scoped to every selected familiar",
+);
+assert.match(
+  devClient,
+  /let \(data, response\) = try await data\(for: request\)/,
+  "project discovery must use the client's injected, retrying request boundary",
+);
+assert.doesNotMatch(
+  devClient,
+  /devSharedSession/,
+  "project discovery must not bypass the client request boundary with a private session",
 );
 assert.match(
   picker,
@@ -144,6 +162,11 @@ assert.match(
   picker,
   /else if projects\.isEmpty \{[\s\S]*(?:if\s+let\s+onManageAccess\s*\{\s*Button\(\s*"Project access"\s*,\s*action:\s*onManageAccess\s*\)\s*\}|guard\s+let\s+onManageAccess\s*=\s*onManageAccess\s*else\s*\{[\s\S]*?\}\s*Button\(\s*"Project access"\s*,\s*action:\s*onManageAccess\s*\))/,
   "the empty project list must guard the Project access button behind a non-nil manage-access action",
+);
+assert.match(
+  picker,
+  /else if projects\.isEmpty \{[\s\S]*Button\("Retry"\) \{ reloadToken \+= 1 \}[\s\S]*if let onManageAccess/,
+  "the empty project list must support an immediate retry before optional access repair",
 );
 assert.match(
   picker,
@@ -308,6 +331,26 @@ assert.match(
   "home familiar shortcuts must open fixed-familiar New Chat from familiar rows",
 );
 assert.match(
+  home,
+  /enum ChatNewConversationContext[\s\S]*static func fixedFamiliarId\([\s\S]*detailPath\.last \?\? selection/,
+  "Chats must resolve New Chat context from the visible detail route before the sidebar selection",
+);
+assert.match(
+  home,
+  /private func presentContextualNewChat\(\)[\s\S]*ChatNewConversationContext\.fixedFamiliarId\([\s\S]*selection: selection,[\s\S]*detailPath: detailPath/,
+  "contextual compose must derive its fixed familiar from the visible Chats route",
+);
+assert.match(
+  home,
+  /label: "New chat"\) \{\s*presentContextualNewChat\(\)/,
+  "Chats compose controls must use contextual New Chat",
+);
+assert.match(
+  home,
+  /Button\("New chat"\) \{ presentGeneralNewChat\(\) \}/,
+  "the no-context empty action must preserve explicit general New Chat",
+);
+assert.match(
   familiarThreads,
   /NewChatView\([\s\S]*fixedFamiliarId: familiar\.id/,
   "familiar history shortcuts must enter fixed-familiar New Chat",
@@ -336,6 +379,21 @@ assert.match(
   nativeSelectionTests,
   /testSharedProjectsRequireEveryParticipantScope[\s\S]*testResolvedRootUsesFirstAccessibleRecentRoot[\s\S]*testExplicitImportParticipantsCannotExpandProjectSendScope/,
   "native tests must cover group intersection, deterministic resolution, and import scope",
+);
+assert.match(
+  nativeContextTests,
+  /testSelectedDirectThreadUsesItsFamiliar[\s\S]*testVisibleGroupThreadKeepsGeneralMode[\s\S]*testMissingContextKeepsGeneralMode/,
+  "native tests must cover direct, group, and absent New Chat context",
+);
+assert.match(
+  nativeClientTests,
+  /testProjectRequestUsesInjectedSessionAndRetriesTransientFailure/,
+  "native tests must prove project discovery uses the retrying injected transport",
+);
+assert.match(
+  uiTests,
+  /testContextualNewChatRetriesProjectFailureWithoutFamiliarReselection[\s\S]*testEmptyProjectStateRetriesWithoutFamiliarReselection/,
+  "simulator tests must cover transport and empty-project retry-to-success",
 );
 assert.match(
   snapshotTests,

--- a/scripts/ios-connection-stability.test.mjs
+++ b/scripts/ios-connection-stability.test.mjs
@@ -31,8 +31,13 @@ assert.match(
 );
 assert.match(
   devClient,
-  /private static let devSharedSession: URLSession = \{/,
-  "dev-tab calls should share one session too",
+  /data\(for: request\)/,
+  "dev-tab calls should reuse the core shared REST session",
+);
+assert.doesNotMatch(
+  devClient,
+  /URLSessionConfiguration|URLSession\(/,
+  "dev-tab calls should not allocate a separate session",
 );
 assert.match(
   terminal,

--- a/scripts/ios-self-healing-sync.test.mjs
+++ b/scripts/ios-self-healing-sync.test.mjs
@@ -80,8 +80,13 @@ assert.match(
 );
 assert.match(
   devClient,
-  /config\.waitsForConnectivity = true/,
-  "developer API requests should wait briefly for connectivity too",
+  /data\(for: request\)/,
+  "developer API requests should inherit the core client's connectivity wait and retry policy",
+);
+assert.doesNotMatch(
+  devClient,
+  /URLSessionConfiguration|URLSession\(/,
+  "developer API requests should not bypass the resilient client with a private session",
 );
 assert.match(client, /func data\(for req: URLRequest\) async throws -> \(Data, URLResponse\)/, "CaveClient should centralize resilient request data loading");
 assert.match(


### PR DESCRIPTION
## Summary
- reuse the visible single familiar when starting a new iOS chat while preserving general group compose
- load familiar-scoped projects through the shared resilient CaveClient transport
- add recoverable project empty/error states and simulator coverage for retry behavior

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `pnpm test:mobile`
- `xcodebuild test ... -only-testing:CovenCaveTests`
- `xcodebuild test ... -only-testing:CovenCaveUITests/NewChatUITests`
- final code review: no significant findings

Bead: `cave-y0blo`