### PR TITLE
feat(analytics): render the activity lattice (cave-yd3qu)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -733,6 +733,7 @@ export const SUITES = {
     "src/lib/mission-defs.test.ts",
     "src/lib/session-pulse.test.ts",
     "src/lib/activity-lattice.test.ts",
+    "src/components/familiar-activity-lattice.test.ts",
     "src/lib/session-trace.test.ts",
     "src/lib/first-run-stamps.test.ts",
     "src/lib/summoning-draft.test.ts",

--- a/src/components/familiar-activity-lattice.test.ts
+++ b/src/components/familiar-activity-lattice.test.ts
@@ -1,0 +1,155 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Wiring pins for the activity lattice (cave-yd3qu). The pure model already
+// had 24 assertions of its own in src/lib/activity-lattice.test.ts; what was
+// missing — and what this file covers — is that anything RENDERS it, and that
+// the rendering keeps the promises the frame and the model make.
+
+const lattice = await readFile(new URL("./familiar-activity-lattice.tsx", import.meta.url), "utf8");
+const stage = await readFile(new URL("./familiar-analytics-stage.tsx", import.meta.url), "utf8");
+const data = await readFile(new URL("./familiar-analytics-data.ts", import.meta.url), "utf8");
+const content = await readFile(new URL("./familiar-analytics-content.tsx", import.meta.url), "utf8");
+const css = await readFile(new URL("../styles/familiar-analytics.css", import.meta.url), "utf8");
+
+// ── The model is rendered at all ─────────────────────────────────────────────
+// The whole gap this closes: activity-lattice.ts shipped in #4335 and then sat
+// with no importer except its own test, so the surface still showed one time
+// view. If this regresses to zero consumers the module is dead code again.
+assert.match(
+  data,
+  /activityLattice: buildActivityLattice\(familiarSessions, data\.familiarId, now\)/,
+  "the analytics model builds the lattice from the familiar's own sessions",
+);
+assert.match(
+  content,
+  /lattice=\{model\.activityLattice\}/,
+  "the surface hands the lattice to the activity panel",
+);
+assert.match(
+  stage,
+  /<FamiliarActivityLattice[\s\S]{0,200}lattice=\{lattice\}/,
+  "the activity panel renders the lattice component",
+);
+
+// ── Three views, one lattice ─────────────────────────────────────────────────
+// "The 52-week density grid, the 8-week trend and the 14-day pulse sit in
+// distinct locations in one lattice, so the year, the quarter and the
+// fortnight can be compared rather than paged between."
+for (const view of ["year", "quarter", "fortnight"]) {
+  assert.match(
+    lattice,
+    new RegExp(`fa-lattice__cell--${view}`),
+    `the ${view} view has its own cell`,
+  );
+}
+// Paging between them is the failure mode being replaced, so the three must not
+// come back as a tab/step state inside this component.
+assert.doesNotMatch(
+  lattice,
+  /useState|activeView|currentView/,
+  "the lattice renders all three views at once — no view state to page between",
+);
+
+// ── The single-chart pulse it replaces is gone ───────────────────────────────
+assert.doesNotMatch(
+  stage,
+  /fa-pulse-panel__chart/,
+  "the one-view-at-a-time chart is replaced, not left beside the lattice",
+);
+
+// ── Every cell and point reports its own day on hover ────────────────────────
+// The frame is explicit about this, and it is what makes a dense grid legible
+// at all: a shade with no readout is a picture, not a measure.
+assert.match(
+  lattice,
+  /title=\{`\$\{day\.label\} · \$\{sessionCount\(day\.count\)\}`\}/,
+  "day cells report their own day and count on hover",
+);
+assert.match(
+  lattice,
+  /title=\{`\$\{weekLabel\(week\)\} · \$\{sessionCount\(week\.total\)\}`\}/,
+  "quarter bars report their own week span and total on hover",
+);
+
+// ── Only days select, because only days can be filtered ──────────────────────
+// The session list filters by day key (sessionDayKey). A clickable week would
+// promise a filter that does not exist, so weeks stay presentational.
+assert.match(
+  lattice,
+  /className="fa-lattice__pulse-day focus-ring"[\s\S]{0,400}onClick=\{\(\) => onSelectDay\(day\)\}/,
+  "fortnight days are buttons that select the day",
+);
+assert.doesNotMatch(
+  lattice,
+  /onSelectWeek|onClick=\{\(\) => onSelect\w*\(week\)/,
+  "weeks are not selectable — there is no week filter to select into",
+);
+
+// ── The year grid is summarised, not 364 tab stops ───────────────────────────
+assert.match(
+  lattice,
+  /className="fa-lattice__grid"\s*\n\s*role="img"/,
+  "the year grid carries one image role with a summarising label",
+);
+assert.match(
+  lattice,
+  /aria-label=\{\s*silent/,
+  "the year's label states the silent case rather than reading an empty grid",
+);
+
+// ── Density shades come from the model, never recomputed here ────────────────
+// buildActivityLattice guarantees a day carries the same count in all three
+// views; a second bucketing in the view would be free to disagree with it.
+assert.match(
+  lattice,
+  /data-step=\{densityStep\(day\.count, lattice\.peak\)\}/,
+  "shade steps come from the shared densityStep against the year's peak",
+);
+// Call syntax, not bare names: the header comment legitimately cites
+// `sessionDayKey` when explaining why weeks are not selectable, and a pin that
+// cannot tell prose from code fails on its own documentation.
+assert.doesNotMatch(
+  lattice,
+  /buildSessionPulse\(|sessionDayKey\(|new Date\(/,
+  "the view does no bucketing of its own",
+);
+
+// ── The lattice measures its OWN box ─────────────────────────────────────────
+// The analytics root already declares `container-name: fa`, but the lattice
+// docks inside a panel narrower than that root — querying the root would size
+// it against a box it never had. This is the cave-k3a9u failure in miniature:
+// a breakpoint that describes the wrong element is a breakpoint that lies.
+assert.match(
+  css,
+  /\.fa-lattice \{[^}]*container-name: fa-lattice/,
+  "the lattice declares its own container",
+);
+assert.match(
+  css,
+  /@container fa-lattice \(max-width: 560px\)/,
+  "the narrow rule queries the lattice's container by name, not the nearest one",
+);
+// A container query cannot restyle the element that declares the container, so
+// the grid has to be a child of the host — otherwise the rule silently no-ops.
+assert.match(
+  css,
+  /@container fa-lattice \(max-width: 560px\) \{\s*\.fa-lattice__views \{/,
+  "the narrow rule targets the child grid, not the host that declares the container",
+);
+assert.match(
+  lattice,
+  /className="fa-lattice"[\s\S]{0,200}className="fa-lattice__views"/,
+  "the host wraps the grid, matching what the container query targets",
+);
+
+// ── No hand-copied colour ────────────────────────────────────────────────────
+// The handoff paints its own hexes; the repo's ramp is a color-mix off a token
+// so the grid survives all 12 palettes and both modes.
+const latticeCss = css.slice(css.indexOf(".fa-lattice {"));
+assert.doesNotMatch(
+  latticeCss,
+  /#[0-9a-fA-F]{3,8}\b/,
+  "the lattice styles carry no literal colour",
+);

--- a/src/components/familiar-activity-lattice.test.ts
+++ b/src/components/familiar-activity-lattice.test.ts
@@ -67,10 +67,18 @@ assert.match(
   /title=\{`\$\{day\.label\} · \$\{sessionCount\(day\.count\)\}`\}/,
   "day cells report their own day and count on hover",
 );
+// The quarter reuses the shared Sparkline rather than a second hand-rolled bar
+// chart; the primitive owns the hover readout, so the week's own span is what
+// it reports. This also keeps one trend rendering in the app instead of two.
 assert.match(
   lattice,
-  /title=\{`\$\{weekLabel\(week\)\} · \$\{sessionCount\(week\.total\)\}`\}/,
-  "quarter bars report their own week span and total on hover",
+  /<Sparkline points=\{quarterPoints\}/,
+  "the quarter trend reuses the shared Sparkline primitive",
+);
+assert.match(
+  lattice,
+  /label: weekLabel\(week\),\s*\n\s*value: week\.total,/,
+  "each trend point is labelled with the week's own span and carries its total",
 );
 
 // ── Only days select, because only days can be filtered ──────────────────────

--- a/src/components/familiar-activity-lattice.test.ts
+++ b/src/components/familiar-activity-lattice.test.ts
@@ -95,6 +95,16 @@ assert.doesNotMatch(
   "weeks are not selectable — there is no week filter to select into",
 );
 
+// Every graphic in the lattice needs a text alternative, not just the grid.
+// The quarter's caption is aria-hidden, so without a label on the figure a
+// screen reader gets nothing at all for that view — found in review on #4425,
+// with all 18 checks green.
+assert.match(
+  lattice,
+  /className="fa-lattice__trend"[\s\S]{0,400}role="img"[\s\S]{0,200}aria-label=\{/,
+  "the quarter trend figure carries a role and a summarising label",
+);
+
 // ── The year grid is summarised, not 364 tab stops ───────────────────────────
 assert.match(
   lattice,
@@ -150,6 +160,14 @@ assert.match(
   lattice,
   /className="fa-lattice"[\s\S]{0,200}className="fa-lattice__views"/,
   "the host wraps the grid, matching what the container query targets",
+);
+
+// Swapping the quarter to the Sparkline made the bar rules dead; leaving them
+// would be the same inert-CSS problem this PR removed elsewhere.
+assert.doesNotMatch(
+  css,
+  /fa-lattice__week-bar/,
+  "no stylesheet rules survive for a DOM shape the lattice no longer renders",
 );
 
 // ── No hand-copied colour ────────────────────────────────────────────────────

--- a/src/components/familiar-activity-lattice.tsx
+++ b/src/components/familiar-activity-lattice.tsx
@@ -78,6 +78,11 @@ export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
   // The shared Sparkline owns the hover readout, so a week reports its own span
   // and total the same way the day cells report theirs — and reusing it keeps
   // one trend rendering in the app instead of a second hand-rolled bar chart.
+  const busiestWeek = lattice.quarter.reduce(
+    (best, week) => (best === null || week.total > best.total ? week : best),
+    null as (typeof lattice.quarter)[number] | null,
+  );
+  const busiestWeekLabel = busiestWeek ? `${weekLabel(busiestWeek)} with ${sessionCount(busiestWeek.total)}` : "—";
   const quarterPoints = lattice.quarter.map((week) => ({
     label: weekLabel(week),
     value: week.total,
@@ -138,7 +143,18 @@ export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
             {sessionCount(quarterTotal)} over {lattice.quarter.length} weeks
           </span>
         </header>
-        <figure className="fa-lattice__trend">
+        <figure
+          className="fa-lattice__trend"
+          // The Sparkline is a graphic: without a role and a label a screen
+          // reader gets nothing for the quarter, since the caption below is
+          // aria-hidden. Same treatment the thread-score trend already uses.
+          role="img"
+          aria-label={
+            silent
+              ? `Quarter trend: no sessions in the last ${lattice.quarter.length} weeks.`
+              : `Quarter trend: ${sessionCount(quarterTotal)} across the last ${lattice.quarter.length} weeks, busiest week ${busiestWeekLabel}.`
+          }
+        >
           <Sparkline points={quarterPoints} color="var(--accent-presence)" height={72} />
           <figcaption aria-hidden>
             Sessions per week, oldest to newest · hover for values

--- a/src/components/familiar-activity-lattice.tsx
+++ b/src/components/familiar-activity-lattice.tsx
@@ -1,0 +1,192 @@
+"use client";
+
+/**
+ * FamiliarActivityLattice — the year, the quarter and the fortnight of one
+ * familiar's session activity, in one lattice (cave-yd3qu).
+ *
+ * The surface already had a 14-day pulse, but it was the only time view on
+ * screen. That is the thing the approved design argues against: "the 52-week
+ * density grid, the 8-week trend and the 14-day pulse sit in distinct
+ * locations in one lattice, so the year, the quarter and the fortnight can be
+ * compared rather than paged between." A quiet fortnight means one thing
+ * against a quiet year and the opposite against a busy one, and you cannot see
+ * which if only one window is rendered.
+ *
+ * All three views come from `buildActivityLattice`, which derives them from a
+ * single 364-day pass — so a day carries the same count in every view by
+ * construction and the fortnight can never disagree with the year containing
+ * it. Nothing here re-buckets; this file is rendering only.
+ *
+ * Two deliberate asymmetries, both about not lying:
+ *
+ *  - Only DAY cells select. The session list filters by day key
+ *    (`sessionDayKey`), so a week has nothing to filter to — a clickable week
+ *    would promise a filter that does not exist. Weeks report on hover and
+ *    stay presentational.
+ *  - The year grid is one `role="img"` with a summarising label rather than
+ *    364 focusable cells. A screen-reader user gets the shape of the year in a
+ *    sentence; 364 tab stops would be a worse answer to the same question.
+ *    Sighted hover still reports every individual day, which is what the frame
+ *    asks for.
+ */
+
+import { memo } from "react";
+import { Icon } from "@/lib/icon";
+import {
+  densityStep,
+  type ActivityLattice,
+  type LatticeDay,
+  type LatticeWeek,
+} from "@/lib/activity-lattice";
+
+function sessionCount(count: number): string {
+  return `${count} session${count === 1 ? "" : "s"}`;
+}
+
+/** "Mar 3 – Mar 9" for a week's own span, read off its days rather than
+ *  recomputed, so the label cannot drift from the cells above it. */
+function weekLabel(week: LatticeWeek): string {
+  const first = week.days[0];
+  const last = week.days[week.days.length - 1];
+  if (!first || !last) return "";
+  return first.label === last.label ? first.label : `${first.label} – ${last.label}`;
+}
+
+function busiestDay(days: LatticeDay[]): LatticeDay | null {
+  return days.reduce<LatticeDay | null>(
+    (best, day) => (best === null || day.count > best.count ? day : best),
+    null,
+  );
+}
+
+export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
+  lattice,
+  onSelectDay,
+  selectedDayKey,
+}: {
+  lattice: ActivityLattice;
+  /** Selecting a day filters the session list — the same contract the pulse
+   *  chart already had, so the lattice adds views without adding vocabulary. */
+  onSelectDay: (day: LatticeDay) => void;
+  selectedDayKey: string | null;
+}) {
+  const yearDays = lattice.year.flatMap((week) => week.days);
+  const yearPeak = busiestDay(yearDays);
+  const quarterMax = Math.max(1, ...lattice.quarter.map((week) => week.total));
+  const fortnightMax = Math.max(1, ...lattice.fortnight.map((day) => day.count));
+  const quarterTotal = lattice.quarter.reduce((sum, week) => sum + week.total, 0);
+  const fortnightTotal = lattice.fortnight.reduce((sum, day) => sum + day.count, 0);
+  const silent = lattice.total === 0;
+
+  return (
+    // The host carries the container, not the grid: a container query cannot
+    // change the layout of the element that declares it, and the lattice has
+    // to answer for its OWN width rather than the analytics root's. It docks
+    // inside a panel narrower than that root, so querying the root would size
+    // the lattice against a box it never had.
+    <div className="fa-lattice" data-testid="familiar-activity-lattice">
+      <div className="fa-lattice__views">
+      {/* Year — the density grid. Weeks run left to right, weekdays top to
+          bottom, which is the reading most people already have from every
+          other contribution grid they have seen. */}
+      <section className="fa-lattice__cell fa-lattice__cell--year">
+        <header className="fa-lattice__head">
+          <Icon name="ph:calendar-blank" width={13} aria-hidden />
+          <b>Year</b>
+          <span className="fa-lattice__count">
+            {sessionCount(lattice.total)} over {lattice.year.length} weeks
+          </span>
+        </header>
+        <div
+          className="fa-lattice__grid"
+          role="img"
+          aria-label={
+            silent
+              ? `Year density: no sessions in the last ${lattice.year.length} weeks.`
+              : `Year density: ${sessionCount(lattice.total)} over ${lattice.year.length} weeks, busiest ${yearPeak?.label ?? "—"} with ${sessionCount(yearPeak?.count ?? 0)}.`
+          }
+        >
+          {lattice.year.map((week) => (
+            <div className="fa-lattice__week" key={week.key}>
+              {week.days.map((day) => (
+                <span
+                  key={day.key}
+                  className="fa-lattice__day"
+                  data-step={densityStep(day.count, lattice.peak)}
+                  data-selected={day.key === selectedDayKey ? "true" : undefined}
+                  // Hover reports the day itself — the frame's "every cell and
+                  // point reports its own day".
+                  title={`${day.label} · ${sessionCount(day.count)}`}
+                  aria-hidden
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </section>
+
+      {/* Quarter — weekly totals. Presentational: a week is not a filterable
+          unit (see the header note). */}
+      <section className="fa-lattice__cell fa-lattice__cell--quarter">
+        <header className="fa-lattice__head">
+          <Icon name="ph:chart-bar" width={13} aria-hidden />
+          <b>Quarter</b>
+          <span className="fa-lattice__count">
+            {sessionCount(quarterTotal)} over {lattice.quarter.length} weeks
+          </span>
+        </header>
+        <div
+          className="fa-lattice__trend"
+          role="img"
+          aria-label={`Quarter trend: ${sessionCount(quarterTotal)} across the last ${lattice.quarter.length} weeks.`}
+        >
+          {lattice.quarter.map((week) => (
+            <span
+              className="fa-lattice__week-bar"
+              key={week.key}
+              title={`${weekLabel(week)} · ${sessionCount(week.total)}`}
+              aria-hidden
+            >
+              <i
+                style={{ height: `${week.total === 0 ? 3 : Math.max(8, (week.total / quarterMax) * 100)}%` }}
+                data-empty={week.total === 0 ? "true" : undefined}
+              />
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* Fortnight — the existing pulse, now beside its own year rather than
+          standing in for one. These are the selectable cells. */}
+      <section className="fa-lattice__cell fa-lattice__cell--fortnight">
+        <header className="fa-lattice__head">
+          <Icon name="ph:waveform-bold" width={13} aria-hidden />
+          <b>Fortnight</b>
+          <span className="fa-lattice__count">{sessionCount(fortnightTotal)}</span>
+          <span className="fa-lattice__hint">select a day to filter sessions</span>
+        </header>
+        <div className="fa-lattice__pulse">
+          {lattice.fortnight.map((day) => (
+            <button
+              key={day.key}
+              type="button"
+              className="fa-lattice__pulse-day focus-ring"
+              data-empty={day.count === 0 ? "true" : undefined}
+              data-selected={day.key === selectedDayKey ? "true" : undefined}
+              aria-pressed={day.key === selectedDayKey}
+              aria-label={`${day.label}, ${sessionCount(day.count)}`}
+              title={`${day.label} · ${sessionCount(day.count)}`}
+              onClick={() => onSelectDay(day)}
+            >
+              <i
+                style={{ height: `${day.count === 0 ? 3 : Math.max(8, (day.count / fortnightMax) * 100)}%` }}
+                aria-hidden
+              />
+            </button>
+          ))}
+        </div>
+      </section>
+      </div>
+    </div>
+  );
+});

--- a/src/components/familiar-activity-lattice.tsx
+++ b/src/components/familiar-activity-lattice.tsx
@@ -32,6 +32,7 @@
 
 import { memo } from "react";
 import { Icon } from "@/lib/icon";
+import { Sparkline } from "@/components/ui/sparkline";
 import {
   densityStep,
   type ActivityLattice,
@@ -72,9 +73,15 @@ export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
 }) {
   const yearDays = lattice.year.flatMap((week) => week.days);
   const yearPeak = busiestDay(yearDays);
-  const quarterMax = Math.max(1, ...lattice.quarter.map((week) => week.total));
   const fortnightMax = Math.max(1, ...lattice.fortnight.map((day) => day.count));
   const quarterTotal = lattice.quarter.reduce((sum, week) => sum + week.total, 0);
+  // The shared Sparkline owns the hover readout, so a week reports its own span
+  // and total the same way the day cells report theirs — and reusing it keeps
+  // one trend rendering in the app instead of a second hand-rolled bar chart.
+  const quarterPoints = lattice.quarter.map((week) => ({
+    label: weekLabel(week),
+    value: week.total,
+  }));
   const fortnightTotal = lattice.fortnight.reduce((sum, day) => sum + day.count, 0);
   const silent = lattice.total === 0;
 
@@ -106,21 +113,17 @@ export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
               : `Year density: ${sessionCount(lattice.total)} over ${lattice.year.length} weeks, busiest ${yearPeak?.label ?? "—"} with ${sessionCount(yearPeak?.count ?? 0)}.`
           }
         >
-          {lattice.year.map((week) => (
-            <div className="fa-lattice__week" key={week.key}>
-              {week.days.map((day) => (
-                <span
-                  key={day.key}
-                  className="fa-lattice__day"
-                  data-step={densityStep(day.count, lattice.peak)}
-                  data-selected={day.key === selectedDayKey ? "true" : undefined}
-                  // Hover reports the day itself — the frame's "every cell and
-                  // point reports its own day".
-                  title={`${day.label} · ${sessionCount(day.count)}`}
-                  aria-hidden
-                />
-              ))}
-            </div>
+          {yearDays.map((day) => (
+            <span
+              key={day.key}
+              className="fa-lattice__day"
+              data-step={densityStep(day.count, lattice.peak)}
+              data-selected={day.key === selectedDayKey ? "true" : undefined}
+              // Hover reports the day itself — the frame's "every cell and
+              // point reports its own day".
+              title={`${day.label} · ${sessionCount(day.count)}`}
+              aria-hidden
+            />
           ))}
         </div>
       </section>
@@ -135,25 +138,12 @@ export const FamiliarActivityLattice = memo(function FamiliarActivityLattice({
             {sessionCount(quarterTotal)} over {lattice.quarter.length} weeks
           </span>
         </header>
-        <div
-          className="fa-lattice__trend"
-          role="img"
-          aria-label={`Quarter trend: ${sessionCount(quarterTotal)} across the last ${lattice.quarter.length} weeks.`}
-        >
-          {lattice.quarter.map((week) => (
-            <span
-              className="fa-lattice__week-bar"
-              key={week.key}
-              title={`${weekLabel(week)} · ${sessionCount(week.total)}`}
-              aria-hidden
-            >
-              <i
-                style={{ height: `${week.total === 0 ? 3 : Math.max(8, (week.total / quarterMax) * 100)}%` }}
-                data-empty={week.total === 0 ? "true" : undefined}
-              />
-            </span>
-          ))}
-        </div>
+        <figure className="fa-lattice__trend">
+          <Sparkline points={quarterPoints} color="var(--accent-presence)" height={72} />
+          <figcaption aria-hidden>
+            Sessions per week, oldest to newest · hover for values
+          </figcaption>
+        </figure>
       </section>
 
       {/* Fortnight — the existing pulse, now beside its own year rather than

--- a/src/components/familiar-analytics-content.tsx
+++ b/src/components/familiar-analytics-content.tsx
@@ -1981,6 +1981,7 @@ export function FamiliarAnalyticsContent({
         {pulseOpen ? (
           <PulseOverlay
             pulse={model.sessionPulse}
+            lattice={model.activityLattice}
             lastActive={model.growthReport?.lastActiveAt ?? model.recentSessions[0]?.updated_at ?? null}
             streakDays={model.progression?.streakDays ?? 0}
             onClose={() => setPulseOpen(false)}

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -14,6 +14,7 @@ import { deriveGrowthReport, type FamiliarGrowthReport } from "@/lib/familiar-gr
 import { deriveHealRequests, type SelfHealRequest } from "@/lib/familiar-heal-requests";
 import type { RetroFamiliarState, RetroRunsSnapshot } from "@/lib/retro-runs";
 import { buildSessionPulse, type PulseDay } from "@/lib/session-pulse";
+import { buildActivityLattice, type ActivityLattice } from "@/lib/activity-lattice";
 import {
   type ThreadSelfReport,
 } from "@/lib/thread-self-report";
@@ -94,6 +95,9 @@ export type FamiliarAnalyticsModel = {
   } | null;
   /** Per-day session counts for the trailing 14 days (oldest first). */
   sessionPulse: PulseDay[];
+  /** Year / quarter / fortnight of the same session series, derived together
+   *  so the three views can be compared rather than paged between (cave-yd3qu). */
+  activityLattice: ActivityLattice;
   /** This familiar's complete session history, newest first, for scoped evidence. */
   recentSessions: SessionRow[];
   errors: string[];
@@ -267,6 +271,7 @@ export function buildFamiliarAnalyticsModel(
         }
       : null,
     sessionPulse: buildSessionPulse(familiarSessions, data.familiarId, now),
+    activityLattice: buildActivityLattice(familiarSessions, data.familiarId, now),
     recentSessions: [...familiarSessions]
       .sort((a, b) => (a.updated_at < b.updated_at ? 1 : -1)),
     errors: data.errors,

--- a/src/components/familiar-analytics-stage.tsx
+++ b/src/components/familiar-analytics-stage.tsx
@@ -13,6 +13,8 @@ import { RelativeTime } from "@/components/ui/relative-time";
 import { Icon } from "@/lib/icon";
 import type { SelfHealRequest } from "@/lib/familiar-heal-requests";
 import { pulseTotal, type PulseDay } from "@/lib/session-pulse";
+import { FamiliarActivityLattice } from "@/components/familiar-activity-lattice";
+import type { ActivityLattice } from "@/lib/activity-lattice";
 import type { SessionRow } from "@/lib/types";
 
 // ─── Scope: one lens and one time window for the whole stage ─────────────────
@@ -665,6 +667,7 @@ export const SelfHealStrip = memo(function SelfHealStrip({
  */
 export const PulseOverlay = memo(function PulseOverlay({
   pulse,
+  lattice,
   lastActive,
   streakDays,
   onClose,
@@ -672,6 +675,10 @@ export const PulseOverlay = memo(function PulseOverlay({
   selectedDayKey,
 }: {
   pulse: PulseDay[];
+  /** All three time views. The stats below still read the fortnight, because
+   *  "peak day" and "sessions per day" are fortnight questions — the lattice
+   *  adds the year and the quarter beside it, it does not restate them. */
+  lattice: ActivityLattice;
   lastActive: string | null;
   streakDays: number;
   onClose: () => void;
@@ -679,7 +686,6 @@ export const PulseOverlay = memo(function PulseOverlay({
   selectedDayKey: string | null;
 }) {
   const total = pulseTotal(pulse);
-  const max = Math.max(1, ...pulse.map((day) => day.count));
   const peak = pulse.reduce<PulseDay | null>(
     (best, day) => (best === null || day.count > best.count ? day : best),
     null,
@@ -693,10 +699,10 @@ export const PulseOverlay = memo(function PulseOverlay({
   // focus and traps none. role="dialog" would have AT announce a modal that
   // never arrives.
   return (
-    <section className="fa-pulse-panel" aria-label={`Activity — last ${pulse.length} days`}>
+    <section className="fa-pulse-panel" aria-label="Activity — year, quarter and fortnight">
       <div className="fa-pulse-panel__head">
         <Icon name="ph:chart-line-up" width={15} aria-hidden />
-        <b>Activity — last {pulse.length} days</b>
+        <b>Activity</b>
         <span className="fa-band-count">
           {total} session{total === 1 ? "" : "s"}
           {peak && peak.count > 0 ? ` · peak ${peak.label}` : ""}
@@ -707,22 +713,11 @@ export const PulseOverlay = memo(function PulseOverlay({
           Collapse
         </button>
       </div>
-      <div className="fa-pulse-panel__chart">
-        {pulse.map((day) => (
-          <button
-            key={day.key}
-            type="button"
-            className={`fa-pulse-day${day.count === 0 ? " is-empty" : ""}${day.key === selectedDayKey ? " is-selected" : ""} focus-ring`}
-            aria-pressed={day.key === selectedDayKey}
-            title={`${day.label} · ${day.count} session${day.count === 1 ? "" : "s"}`}
-            onClick={() => onSelectDay(day)}
-          >
-            <b>{day.count}</b>
-            <i style={{ height: `${day.count === 0 ? 4 : Math.max(12, (day.count / max) * 100)}%` }} aria-hidden />
-            <span>{day.label}</span>
-          </button>
-        ))}
-      </div>
+      <FamiliarActivityLattice
+        lattice={lattice}
+        onSelectDay={onSelectDay}
+        selectedDayKey={selectedDayKey}
+      />
       <div className="fa-pulse-panel__stats">
         <span className="fa-pulse-stat fa-pulse-stat--good">
           <b>{peak?.count ?? 0}</b>

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -3074,25 +3074,25 @@
   color: var(--text-muted);
 }
 
-/* Year: weeks left to right, weekdays top to bottom. */
+/* Year: one grid, weeks left to right, weekdays top to bottom. Flowing 364
+   cells down columns of 7 needs no per-week wrapper — which also means ONE
+   gutter declaration instead of two. 2px is the micro-mark the density grid
+   needs: --space-1 (4px) is nearly as wide as a cell at 52 columns, so the
+   grid would read as more gutter than data. */
 .fa-lattice__grid {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-template-rows: repeat(7, 1fr);
+  grid-auto-columns: 1fr;
   gap: 2px;
   min-width: 0;
   overflow-x: auto;
   scrollbar-width: none;
 }
 .fa-lattice__grid::-webkit-scrollbar { display: none; }
-.fa-lattice__week {
-  display: grid;
-  grid-template-rows: repeat(7, 1fr);
-  gap: 2px;
-  flex: 1 1 0;
-  min-width: 5px;
-}
 .fa-lattice__day {
   aspect-ratio: 1;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   background: var(--bg-hover);
 }
 .fa-lattice__day[data-step="1"] { background: color-mix(in oklch, var(--accent-presence) 28%, transparent); }
@@ -3130,7 +3130,7 @@
 .fa-lattice__pulse-day i {
   display: block;
   width: 100%;
-  border-radius: 2px;
+  border-radius: var(--radius-sm);
   background: var(--accent-presence);
 }
 .fa-lattice__week-bar i[data-empty="true"],

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -3114,7 +3114,7 @@
   gap: var(--space-1);
   height: 72px;
 }
-.fa-lattice__week-bar,
+/* Only the fortnight draws bars; the quarter is a Sparkline. */
 .fa-lattice__pulse-day {
   display: flex;
   flex: 1;
@@ -3126,14 +3126,12 @@
   border: 0;
   background: transparent;
 }
-.fa-lattice__week-bar i,
 .fa-lattice__pulse-day i {
   display: block;
   width: 100%;
   border-radius: var(--radius-sm);
   background: var(--accent-presence);
 }
-.fa-lattice__week-bar i[data-empty="true"],
 .fa-lattice__pulse-day[data-empty="true"] i {
   background: var(--bg-hover);
 }

--- a/src/styles/familiar-analytics.css
+++ b/src/styles/familiar-analytics.css
@@ -2156,55 +2156,11 @@
 .fa-pulse-panel__head > svg { color: var(--accent-presence); }
 .fa-pulse-panel__head > b { font-size: var(--text-md); font-weight: 650; }
 .fa-pulse-panel__head .fa-ghost-btn { margin-left: auto; }
-.fa-pulse-panel__chart {
-  flex: 1;
-  min-height: 100px;
-  display: flex;
-  align-items: flex-end;
-  gap: var(--space-1);
-}
-.fa-pulse-day {
-  flex: 1;
-  min-width: 0;
-  height: 100%;
-  display: flex;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-  gap: var(--space-1);
-  padding: var(--space-1) 0;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: inherit;
-  font: inherit;
-  cursor: pointer;
-  transition: background var(--duration-fast) var(--ease-standard);
-}
-.fa-pulse-day:hover { background: color-mix(in oklch, var(--accent-presence) 9%, transparent); }
-.fa-pulse-day.is-selected { background: color-mix(in oklch, var(--accent-presence) 16%, transparent); }
-.fa-pulse-day b {
-  font-family: var(--font-mono);
-  font-size: var(--text-xs);
-  font-weight: 600;
-  color: var(--text-secondary);
-}
-.fa-pulse-day i {
-  width: 100%;
-  /* Rounded cap, square foot — the bar sits on the axis, so a bottom radius
-     would only lift it off the line it is measured against. */
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
-  background: color-mix(in oklch, var(--accent-presence) 70%, var(--bg-sunken));
-  box-shadow: 0 0 12px color-mix(in oklch, var(--accent-presence) 30%, transparent);
-}
-.fa-pulse-day.is-empty i { background: var(--bg-hover); box-shadow: none; }
-.fa-pulse-day span {
-  font-family: var(--font-mono);
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
-  white-space: nowrap;
-}
-
+/* The single 14-bar pulse chart that used to live here is gone: the activity
+   panel now renders the three-view lattice (.fa-lattice*, below), so a rule
+   set for .fa-pulse-panel__chart / .fa-pulse-day would style nothing. Dead
+   CSS that still looks live is how cave-k3a9u shipped a layout rule that had
+   never once applied. */
 /* ── Stage overlays ─────────────────────────────────────────────────────── */
 .fa-overlay {
   position: absolute;
@@ -3063,4 +3019,140 @@
   gap: var(--space-1);
   color: var(--color-success, var(--accent-presence));
   font-size: var(--text-xs);
+}
+
+/* ── Activity lattice (cave-yd3qu) ──────────────────────────────────────────
+   Year, quarter and fortnight in one lattice. The point of the layout is that
+   all three are on screen together: a quiet fortnight reads one way against a
+   quiet year and the opposite against a busy one, and paging between them
+   hides exactly that comparison. The year takes the full first row because a
+   52-week grid needs the width; the quarter and the fortnight share the second
+   row, where they are directly comparable to each other and to the year above.
+   Density shades are a color-mix ramp off --accent-presence, so the grid
+   survives all 12 palettes and both modes without a single literal colour. */
+.fa-lattice {
+  /* Host only. The container lives here so the query below asks how wide the
+     LATTICE is, not how wide the analytics root is — this docks inside a panel
+     narrower than that root. A container query also cannot restyle the element
+     that declares it, which is why the grid is a child. */
+  container-type: inline-size;
+  container-name: fa-lattice;
+  min-width: 0;
+}
+.fa-lattice__views {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+.fa-lattice__cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  min-width: 0;
+}
+.fa-lattice__cell--year {
+  grid-column: 1 / -1;
+}
+.fa-lattice__head {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  min-width: 0;
+  color: var(--text-secondary);
+  font-size: var(--text-2xs);
+}
+.fa-lattice__head b {
+  color: var(--text-primary);
+  font-size: var(--text-xs);
+}
+.fa-lattice__count {
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+.fa-lattice__hint {
+  margin-left: auto;
+  color: var(--text-muted);
+}
+
+/* Year: weeks left to right, weekdays top to bottom. */
+.fa-lattice__grid {
+  display: flex;
+  gap: 2px;
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.fa-lattice__grid::-webkit-scrollbar { display: none; }
+.fa-lattice__week {
+  display: grid;
+  grid-template-rows: repeat(7, 1fr);
+  gap: 2px;
+  flex: 1 1 0;
+  min-width: 5px;
+}
+.fa-lattice__day {
+  aspect-ratio: 1;
+  border-radius: 2px;
+  background: var(--bg-hover);
+}
+.fa-lattice__day[data-step="1"] { background: color-mix(in oklch, var(--accent-presence) 28%, transparent); }
+.fa-lattice__day[data-step="2"] { background: color-mix(in oklch, var(--accent-presence) 52%, transparent); }
+.fa-lattice__day[data-step="3"] { background: color-mix(in oklch, var(--accent-presence) 76%, transparent); }
+.fa-lattice__day[data-step="4"] { background: var(--accent-presence); }
+/* The selected day stays findable in the year even though the click happened
+   in the fortnight — that is the payoff of showing both at once. */
+.fa-lattice__day[data-selected="true"] {
+  outline: 1px solid var(--text-primary);
+  outline-offset: 1px;
+}
+
+/* Quarter: weekly totals. */
+.fa-lattice__trend,
+.fa-lattice__pulse {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-1);
+  height: 72px;
+}
+.fa-lattice__week-bar,
+.fa-lattice__pulse-day {
+  display: flex;
+  flex: 1;
+  align-items: flex-end;
+  justify-content: center;
+  min-width: 0;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+}
+.fa-lattice__week-bar i,
+.fa-lattice__pulse-day i {
+  display: block;
+  width: 100%;
+  border-radius: 2px;
+  background: var(--accent-presence);
+}
+.fa-lattice__week-bar i[data-empty="true"],
+.fa-lattice__pulse-day[data-empty="true"] i {
+  background: var(--bg-hover);
+}
+.fa-lattice__pulse-day {
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+.fa-lattice__pulse-day:hover i {
+  background: color-mix(in oklch, var(--accent-presence) 70%, var(--text-primary));
+}
+.fa-lattice__pulse-day[data-selected="true"] i {
+  background: var(--text-primary);
+}
+
+/* One column below the width where a 52-week grid and two charts stop being
+   readable side by side. Measured against the panel, not the viewport — this
+   surface docks beside other panes. */
+@container fa-lattice (max-width: 560px) {
+  .fa-lattice__views {
+    grid-template-columns: 1fr;
+  }
 }


### PR DESCRIPTION
Closes `cave-yd3qu`.

## The bead asked for something that already existed

`cave-yd3qu` said "build the full thread-signals surface" from the 514KB `Thread Signals.dc.html` — the largest frame in the Claude Design corpus. Almost all of it had already shipped as `familiar-analytics-content.tsx` (2150 lines). A scoping comment on the bead caught that back on 2026-08-03 and recommended re-scoping to the one confirmed gap; I re-verified that recommendation against today's `main` before acting, and the blocking hazard it named (two `l4ttp` worktrees mid-edit on the same component) has since cleared.

Then a second finding that comment did not have: **the pure model had already landed too.** `src/lib/activity-lattice.ts` merged as #4335 — itself an orphaned-WIP rescue for this same bead — with 24 assertions of its own, and has sat since with **no importer except its own test**. Its header even names the file expected to render it, `familiar-activity-lattice.tsx`, which nobody had written.

So the remaining work was the view. That is all this PR is.

## What it does

The approved design's argument is comparison:

> the 52-week density grid, the 8-week trend and the 14-day pulse sit in distinct locations in one lattice, so the year, the quarter and the fortnight can be compared rather than paged between. Every cell and point reports its own day on hover.

A quiet fortnight means one thing against a quiet year and the opposite against a busy one, and you cannot see which if only one window is on screen — which is exactly what the activity panel did, rendering a single 14-bar chart. That chart is now the three-view lattice, and its dead CSS goes with it.

Every view comes from `buildActivityLattice`'s single 364-day pass, so a day carries the same count in all three by construction and the fortnight can never disagree with the year containing it. The component does no bucketing of its own — pinned, because a second bucketing would be free to drift from the first.

## Two asymmetries, both about not promising what doesn't exist

- **Only day cells select.** The session list filters by day key (`sessionDayKey`), so a week has nothing to filter to. A clickable week would offer a filter that isn't there, so weeks report on hover and stay presentational.
- **The 364-cell year grid is one `role="img"` with a summarising label**, not 364 tab stops. Sighted hover still reports every individual day, which is what the frame asks for; a screen reader gets the shape of the year in a sentence rather than a fortnight's worth of cell announcements.

## The container is the lattice's own

The analytics root already declares `container-name: fa`, but the lattice docks inside a panel narrower than that root — querying the nearest container would size it against a box it never had. It declares its own container and the narrow rule queries it **by name**; the grid is a child of the host because a container query cannot restyle the element that declares it. Both are pinned.

That is `cave-k3a9u` in miniature, fixed earlier in the same session: a breakpoint that describes the wrong element is a breakpoint that lies.

## Dead CSS removed, not left

The old `.fa-pulse-panel__chart` / `.fa-pulse-day` rules style nothing now, so they're gone with a note in their place. Leaving inert CSS that still looks live is the precise failure `cave-k3a9u` shipped.

## Verification

- `pnpm typecheck` clean; `pnpm lint` clean (0 design drift).
- New `familiar-activity-lattice.test.ts` wired into the app suite (`check-tests-wired` green — the repo enforces this).
- The existing 24-assertion model test still passes untouched.
- Pins include two `doesNotMatch` guards: no view-paging state in the component, and no re-bucketing.
- Data is real throughout — `buildSessionPulse` over `SessionRow.updated_at`. No invented days.
