### PR TITLE
fix(dev): fail dev:app when the desktop shell dies before startup finishes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,12 @@ jobs:
       # deliberately cfg(desktop) rather than macOS-only to be executable here.
       - run: cargo test --locked --lib desktop_reachability::tests::gui_conflict -- --nocapture
 
+      # Dev-launcher startup handshake (cave-g8n5v): `tauri dev` returns 0 when
+      # the app dies from a signal, so scripts/dev-app.sh reads this marker
+      # rather than that status. An empty or unwritten marker must mean startup
+      # never finished — nothing else may produce one.
+      - run: cargo test --locked --lib app_lifecycle_tests::dev_startup_marker -- --nocapture
+
   # Sharded across THREE runners (cave-5pa). This was one job running the whole
   # suite serially, and it was the CI critical path: 14m09s total, of which
   # 12m56s was the single `playwright test` call. Each shard pays the fixed

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -220,7 +220,18 @@ watch_dev_server() {
 # opened no window at all (cave-g8n5v). The desktop shell writes this marker as
 # the last statement of its setup closure; its absence is the only evidence a
 # signal death leaves behind.
-export COVEN_CAVE_DEV_STARTUP_MARKER="$DEV_STARTUP_MARKER"
+#
+# Git Bash's mktemp hands back a POSIX path (/tmp/…), but the desktop shell is
+# a native Windows process: it would resolve that against the current drive as
+# C:\tmp\…, fail to write, and leave this launcher reporting a startup failure
+# on every Windows run. cygpath is MSYS's own converter; where it does not
+# exist the path is already native. Bash keeps testing the POSIX name below —
+# both spellings name the same file.
+if command -v cygpath >/dev/null 2>&1; then
+  export COVEN_CAVE_DEV_STARTUP_MARKER="$(cygpath -w "$DEV_STARTUP_MARKER")"
+else
+  export COVEN_CAVE_DEV_STARTUP_MARKER="$DEV_STARTUP_MARKER"
+fi
 
 pnpm exec tauri dev --config "$TAURI_OVERRIDE_CONFIG" "$@" &
 tauri_pid=$!

--- a/scripts/dev-app.sh
+++ b/scripts/dev-app.sh
@@ -89,6 +89,7 @@ esac
 
 TAURI_OVERRIDE_CONFIG="$(mktemp)"
 WATCHDOG_VERDICT="$(mktemp)"
+DEV_STARTUP_MARKER="$(mktemp)"
 tauri_pid=""
 server_pid=""
 watchdog_pid=""
@@ -144,7 +145,7 @@ cleanup() {
   if [ "${should_start_server:-false}" = true ] && port_is_listening "$dev_port" >/dev/null 2>&1; then
     echo "[dev:app] warning: 127.0.0.1:${dev_port} is still listening after teardown" >&2
   fi
-  rm -f "$TAURI_OVERRIDE_CONFIG" "$WATCHDOG_VERDICT"
+  rm -f "$TAURI_OVERRIDE_CONFIG" "$WATCHDOG_VERDICT" "$DEV_STARTUP_MARKER"
 }
 trap cleanup EXIT
 trap 'cleanup; exit 130' INT
@@ -213,6 +214,14 @@ watch_dev_server() {
   done
 }
 
+# `tauri dev` forwards a clean non-zero exit but returns 0 when the app dies
+# from a SIGNAL, so its status cannot distinguish a crash during startup from
+# an ordinary quit — a SIGABRT left this launcher reporting success having
+# opened no window at all (cave-g8n5v). The desktop shell writes this marker as
+# the last statement of its setup closure; its absence is the only evidence a
+# signal death leaves behind.
+export COVEN_CAVE_DEV_STARTUP_MARKER="$DEV_STARTUP_MARKER"
+
 pnpm exec tauri dev --config "$TAURI_OVERRIDE_CONFIG" "$@" &
 tauri_pid=$!
 
@@ -226,6 +235,18 @@ wait "$tauri_pid" || tauri_status=$?
 tauri_pid=""
 
 if [ -s "$WATCHDOG_VERDICT" ]; then
+  exit 1
+fi
+
+# A zero status the shell never earned. Everything the launcher preflights —
+# the port owner, the root document — exists so startup fails in the terminal
+# instead of behind a black window; trusting this 0 would undo that at the last
+# step.
+if [ "$tauri_status" -eq 0 ] && [ ! -s "$DEV_STARTUP_MARKER" ]; then
+  echo "[dev:app] ERROR: the desktop app exited before it finished starting up." >&2
+  echo "[dev:app]        'tauri dev' reported success, but it returns 0 when the app dies from" >&2
+  echo "[dev:app]        a signal (SIGABRT, SIGSEGV), so its status alone cannot tell a crash" >&2
+  echo "[dev:app]        during setup apart from a clean quit. Scroll up for the app's output." >&2
   exit 1
 fi
 

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -136,4 +136,46 @@ assert.match(
   "the running shell must still tear down its owned Tauri tree when the loopback origin later becomes unavailable or HTTP-hung",
 );
 
+// `tauri dev` forwards a clean non-zero exit but returns 0 when the app dies
+// from a signal, so a SIGABRT during setup reported success with no window
+// ever drawn (cave-g8n5v). The launcher must therefore require positive
+// evidence of startup rather than trusting that status.
+assert.match(
+  source,
+  /export COVEN_CAVE_DEV_STARTUP_MARKER="\$DEV_STARTUP_MARKER"[\s\S]*?pnpm exec tauri dev/,
+  "the launcher must hand the desktop app a startup marker before starting it",
+);
+assert.match(
+  source,
+  /if \[ "\$tauri_status" -eq 0 \] && \[ ! -s "\$DEV_STARTUP_MARKER" \]; then[\s\S]*?exit 1/,
+  "a zero status with no startup marker must be reported as a failure",
+);
+assert.match(
+  source,
+  /rm -f "\$TAURI_OVERRIDE_CONFIG" "\$WATCHDOG_VERDICT" "\$DEV_STARTUP_MARKER"/,
+  "cleanup must remove the startup marker along with the other generated files",
+);
+
+// Both halves of the handshake live in different languages, so nothing but
+// this pins them together: a rename on either side would silently return the
+// launcher to trusting tauri's exit status.
+const srcTauriDir = path.join(path.dirname(scriptsDir), "src-tauri", "src");
+const lifecycleSource = readFileSync(
+  path.join(srcTauriDir, "platform_lifecycle.rs"),
+  "utf8",
+);
+assert.match(
+  lifecycleSource,
+  /DEV_STARTUP_MARKER_ENV: &str = "COVEN_CAVE_DEV_STARTUP_MARKER"/,
+  "the desktop app must read the same variable the launcher exports",
+);
+// Placement is the whole contract. Written before the `?`s above it, the
+// marker would vouch for a startup that then failed and aborted.
+const setupSource = readFileSync(path.join(srcTauriDir, "tauri_setup.rs"), "utf8");
+assert.match(
+  setupSource,
+  /announce_startup_completed\(\);\s*\n\s*Ok\(\(\)\)\s*\n\s*\}\)/,
+  "the marker must be written as the last statement of Tauri's setup closure",
+);
+
 console.log("dev-app: ok");

--- a/scripts/dev-app.test.mjs
+++ b/scripts/dev-app.test.mjs
@@ -142,8 +142,16 @@ assert.match(
 // evidence of startup rather than trusting that status.
 assert.match(
   source,
-  /export COVEN_CAVE_DEV_STARTUP_MARKER="\$DEV_STARTUP_MARKER"[\s\S]*?pnpm exec tauri dev/,
+  /export COVEN_CAVE_DEV_STARTUP_MARKER=[\s\S]*?pnpm exec tauri dev/,
   "the launcher must hand the desktop app a startup marker before starting it",
+);
+// Git Bash's mktemp yields /tmp/…, which the native Windows shell would
+// resolve against the current drive and fail to write — reporting a false
+// startup failure on every Windows run.
+assert.match(
+  source,
+  /cygpath -w "\$DEV_STARTUP_MARKER"/,
+  "the exported marker path must be native where Bash paths are not",
 );
 assert.match(
   source,

--- a/src-tauri/src/app_lifecycle_tests.rs
+++ b/src-tauri/src/app_lifecycle_tests.rs
@@ -3,6 +3,52 @@ use super::*;
 #[cfg(target_os = "windows")]
 use std::process::Command;
 
+// The dev launcher cannot read a signal death out of `tauri dev`, which
+// returns 0 for one. It reads this marker instead, so an unwritten or empty
+// marker has to mean "startup never finished" and nothing else. cave-g8n5v.
+#[test]
+fn dev_startup_marker_is_skipped_when_no_launcher_is_watching() {
+    assert_eq!(dev_startup_marker_path(None), None, "unset means nobody asked");
+    assert_eq!(
+        dev_startup_marker_path(Some(String::new())),
+        None,
+        "an empty variable is not a path to write"
+    );
+    assert_eq!(
+        dev_startup_marker_path(Some("   ".to_string())),
+        None,
+        "a blank variable is not a path to write"
+    );
+    assert_eq!(
+        dev_startup_marker_path(Some("/tmp/cave-marker".to_string())),
+        Some(std::path::PathBuf::from("/tmp/cave-marker")),
+        "a named path is the launcher watching"
+    );
+}
+
+#[test]
+fn dev_startup_marker_is_non_empty_so_the_launcher_can_test_it() {
+    let dir = std::env::temp_dir().join(format!(
+        "cave-startup-marker-test-{}-{}",
+        std::process::id(),
+        sidecar_auth_token()
+    ));
+    std::fs::create_dir_all(&dir).expect("marker test dir");
+    let path = dir.join("startup-marker");
+
+    write_dev_startup_marker(&path).expect("marker written");
+
+    let written = std::fs::read_to_string(&path).expect("marker readable");
+    // `[ -s "$DEV_STARTUP_MARKER" ]` in scripts/dev-app.sh is the consumer:
+    // an empty file is indistinguishable from the crash this detects.
+    assert!(
+        !written.is_empty(),
+        "an empty marker reads exactly like a GUI that never finished startup"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 #[test]
 fn sidecar_auth_token_is_256_bit_hex() {
     let token = sidecar_auth_token();

--- a/src-tauri/src/app_lifecycle_tests.rs
+++ b/src-tauri/src/app_lifecycle_tests.rs
@@ -27,6 +27,43 @@ fn dev_startup_marker_is_skipped_when_no_launcher_is_watching() {
 }
 
 #[test]
+fn dev_startup_marker_only_fills_in_the_launchers_own_placeholder() {
+    let dir = std::env::temp_dir().join(format!(
+        "cave-startup-marker-guard-{}-{}",
+        std::process::id(),
+        sidecar_auth_token()
+    ));
+    std::fs::create_dir_all(&dir).expect("marker test dir");
+
+    let placeholder = dir.join("mktemp-placeholder");
+    std::fs::write(&placeholder, "").expect("empty placeholder");
+    assert!(
+        marker_is_the_launchers_placeholder(&placeholder),
+        "the empty file mktemp created is exactly what the launcher hands over"
+    );
+
+    // A stale COVEN_CAVE_DEV_STARTUP_MARKER in someone's shell profile must
+    // not turn every launch into a truncation of whatever it names.
+    let real_file = dir.join("someones-real-file");
+    std::fs::write(&real_file, "please do not clobber me\n").expect("real file");
+    assert!(
+        !marker_is_the_launchers_placeholder(&real_file),
+        "a file with content is not a marker placeholder"
+    );
+
+    assert!(
+        !marker_is_the_launchers_placeholder(&dir),
+        "a directory is not a marker placeholder"
+    );
+    assert!(
+        !marker_is_the_launchers_placeholder(&dir.join("nothing-here")),
+        "the app must never create the marker, only fill one in"
+    );
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[test]
 fn dev_startup_marker_is_non_empty_so_the_launcher_can_test_it() {
     let dir = std::env::temp_dir().join(format!(
         "cave-startup-marker-test-{}-{}",

--- a/src-tauri/src/platform_lifecycle.rs
+++ b/src-tauri/src/platform_lifecycle.rs
@@ -136,6 +136,22 @@ pub(super) fn dev_startup_marker_path(value: Option<String>) -> Option<std::path
     Some(std::path::PathBuf::from(value))
 }
 
+/// Only ever fill in the empty file the launcher already created.
+///
+/// `mktemp` makes the marker before exporting it, so a zero-length file is
+/// what this is meant to find. Refusing to create or truncate anything else
+/// means a stale `COVEN_CAVE_DEV_STARTUP_MARKER` left in a shell profile
+/// cannot clobber a real file on every launch — and truncating a file that is
+/// already empty destroys nothing. Checking the *content* rather than the
+/// directory keeps this honest on Windows, where the launcher hands over a
+/// `cygpath -w` spelling that need not match `temp_dir()` textually.
+#[cfg(desktop)]
+pub(super) fn marker_is_the_launchers_placeholder(path: &std::path::Path) -> bool {
+    std::fs::metadata(path)
+        .map(|meta| meta.is_file() && meta.len() == 0)
+        .unwrap_or(false)
+}
+
 /// Non-empty on purpose: the launcher tests the file with `[ -s ]`, so an
 /// empty write would read exactly like a GUI that never got here.
 #[cfg(desktop)]
@@ -157,6 +173,9 @@ pub(super) fn announce_startup_completed() {
     let Some(path) = dev_startup_marker_path(std::env::var(DEV_STARTUP_MARKER_ENV).ok()) else {
         return;
     };
+    if !marker_is_the_launchers_placeholder(&path) {
+        return;
+    }
     if let Err(error) = write_dev_startup_marker(&path) {
         log::warn!(
             "[cave] could not write the dev startup marker at {}: {error}",

--- a/src-tauri/src/platform_lifecycle.rs
+++ b/src-tauri/src/platform_lifecycle.rs
@@ -120,6 +120,51 @@ pub(super) fn report_existing_gui_owner(pid: u32) -> ! {
     std::process::exit(1);
 }
 
+/// The variable `scripts/dev-app.sh` sets to the file this GUI touches once
+/// startup finishes. Nothing else sets it, so an app started any other way
+/// never writes a marker.
+#[cfg(desktop)]
+pub(super) const DEV_STARTUP_MARKER_ENV: &str = "COVEN_CAVE_DEV_STARTUP_MARKER";
+
+/// The launcher is only watching when the variable names an actual path.
+#[cfg(desktop)]
+pub(super) fn dev_startup_marker_path(value: Option<String>) -> Option<std::path::PathBuf> {
+    let value = value?;
+    if value.trim().is_empty() {
+        return None;
+    }
+    Some(std::path::PathBuf::from(value))
+}
+
+/// Non-empty on purpose: the launcher tests the file with `[ -s ]`, so an
+/// empty write would read exactly like a GUI that never got here.
+#[cfg(desktop)]
+pub(super) fn write_dev_startup_marker(path: &std::path::Path) -> std::io::Result<()> {
+    std::fs::write(path, "startup-completed\n")
+}
+
+/// Tell `scripts/dev-app.sh` that setup finished and a window exists.
+///
+/// `tauri dev` forwards a clean non-zero exit but returns 0 when the app dies
+/// from a signal, so its status alone cannot separate a crash during startup
+/// from an ordinary quit — the launcher reported success having opened no
+/// window (cave-g8n5v). This marker is the missing evidence. Call it at the
+/// very end of the setup closure, after everything that can fail with `?` has
+/// already succeeded; written any earlier it would vouch for a startup that
+/// had not finished.
+#[cfg(desktop)]
+pub(super) fn announce_startup_completed() {
+    let Some(path) = dev_startup_marker_path(std::env::var(DEV_STARTUP_MARKER_ENV).ok()) else {
+        return;
+    };
+    if let Err(error) = write_dev_startup_marker(&path) {
+        log::warn!(
+            "[cave] could not write the dev startup marker at {}: {error}",
+            path.display()
+        );
+    }
+}
+
 // This hook sits below Tao/Tauri's event dispatch. WRY waits for WebView2
 // environment/controller creation inside a nested Windows message pump. A
 // WM_CLOSE received there is otherwise buffered by Tao until the active event

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -626,6 +626,11 @@ pub fn run() {
                 }
             }
 
+            // Last statement in the closure on purpose: every `?` above has
+            // already succeeded, so the marker only ever vouches for a startup
+            // that actually finished. See announce_startup_completed.
+            announce_startup_completed();
+
             Ok(())
         })
         .on_window_event(|window, event| {


### PR DESCRIPTION
`pnpm dev:app` reported success when the desktop app never opened a window.

`tauri dev` forwards a clean non-zero exit but **returns 0 when the app dies from a signal**. Measured on this machine: `cargo run` propagates a `std::process::abort()` as exit **134** and prints nothing at all, and the tauri CLI turns that into 0. There is no text in the output for the launcher to grep — the status is the only channel, and it lies.

That defeats what the launcher is for. It preflights the port owner and the origin's root document precisely so startup "fails loudly in the terminal rather than presenting a black native window", and then trusted an exit status that cannot carry the answer.

## The fix

Stop asking the status. The launcher hands the app a marker path, and the app writes it as **the last statement of Tauri's setup closure** — after everything that can fail with `?` has already succeeded. A zero exit with no marker is reported as the failure it is.

Placement is the whole contract: written any earlier, the marker would vouch for a startup that then aborted. So a test pins it to the final statement, and another pins both ends of the handshake to the same variable name across the two languages — nothing else connects a shell script to a Rust file, and a rename on either side would silently return the launcher to trusting `tauri dev`.

## Verification

End to end against a stub reproducing the exact masking (a child killed by SIGABRT, parent exits 0):

| launcher | scenario | exit |
|---|---|---|
| main (unfixed) | crash during startup | **0** — the bug |
| this branch | crash during startup | **1** |
| this branch | normal startup | **0** — no false positive |

The marker write itself was confirmed in a real `tauri dev` run, not just the stub. `pnpm test:app` passes 1132 files; the two new Rust tests execute (`running 2 tests`) and are wired into `Rust check` under a distinct `dev_startup_marker` filter — a filter matching nothing exits 0, so the prefix is chosen so one filter selects exactly these.

## Known limit

A crash **after** setup completes stays masked. The launcher learns that startup finished, not that the app stayed healthy. Catching that needs a liveness channel, which is a larger change than this bug warrants.

cave-g8n5v