### PR TITLE
test(runtime): cover stale runtime startup cleanup

### DIFF
--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -385,6 +385,34 @@ test("automatic recovery checks lifecycle ownership before it checks the address
   assert.equal(result.code, "address_in_use");
 });
 
+test("a stale runtime discovered after launch is rejected and the owned tree is cleaned up", async () => {
+  const child = fakeChild();
+  let cleanupCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 0,
+    installedVersion: async () => "1.2.3",
+    readHealthDocument: async () => ({
+      ok: true,
+      apiVersion: "v1",
+      covenVersion: "1.2.2",
+    }),
+    spawnImpl: () => child,
+    terminateLaunchTree: async () => {
+      cleanupCalls += 1;
+      return { attempted: true, completed: true, mode: "process-group" };
+    },
+    platform: "linux",
+  });
+
+  assert.equal(cleanupCalls, 1);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "runtime_incompatible");
+  assert.equal(result.status, 409);
+  assert.match(result.error, /does not match the installed runtime/i);
+  assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "process-group" });
+});
+
 test("Windows cleanup delegates the complete owned tree to taskkill", async () => {
   const child = fakeChild(5199);
   let taskkillPid = null;

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -179,6 +179,8 @@ type StartLocalDaemonOptions = {
   readinessPollMs?: number;
   /** Test seams keep launch ownership and timeout cleanup executable. */
   probe?: () => Promise<{ ok: boolean }>;
+  /** Injectable health document that still exercises compatibility assessment. */
+  readHealthDocument?: () => Promise<DaemonStartupHealth | null>;
   /** Injectable installed-version seam for deterministic startup coherence tests. */
   installedVersion?: () => Promise<string | null>;
   /** Injectable address-occupancy seam for deterministic already-bound tests. */
@@ -232,6 +234,7 @@ let activeDaemonStart: Promise<DaemonStartResult> | null = null;
 function hasTestSeam(options: StartLocalDaemonOptions): boolean {
   return Boolean(
     options.probe
+    || options.readHealthDocument
     || options.spawnImpl
     || options.terminateLaunchTree
     || options.installedVersion
@@ -289,6 +292,7 @@ async function runLocalDaemonStart({
   startTimeoutMs = 8000,
   readinessPollMs = 250,
   probe: probeOverride,
+  readHealthDocument: readHealthDocumentOverride,
   installedVersion,
   inspectAddress = () => inspectDaemonAddress({ socketPath: socketPath() }),
   spawnImpl = spawn,
@@ -304,14 +308,18 @@ async function runLocalDaemonStart({
   const compatibilityState: { current: DaemonStartupCompatibility | null } = { current: null };
   const currentCompatibility = (): DaemonStartupCompatibility | null => compatibilityState.current;
   const expectedVersion = probeOverride ? null : await (installedVersion ?? installedCovenVersion)();
-  const probe = probeOverride ?? (async () => {
+  const readHealthDocument = readHealthDocumentOverride ?? (async () => {
     const response = await callDaemonTarget<DaemonStartupHealth>(localDaemonTarget(), {
       path: "/api/v1/health",
       timeoutMs: healthTimeoutMs,
       retryTransportFailure: false,
     });
-    if (!response.ok || !response.data) return { ok: false };
-    compatibilityState.current = assessDaemonStartupCompatibility(response.data, expectedVersion);
+    return response.ok && response.data ? response.data : null;
+  });
+  const probe = probeOverride ?? (async () => {
+    const health = await readHealthDocument();
+    if (!health) return { ok: false };
+    compatibilityState.current = assessDaemonStartupCompatibility(health, expectedVersion);
     return { ok: compatibilityState.current.ok };
   });
   const startedAt = Date.now();


### PR DESCRIPTION
## What

Completes the remaining managed-start compatibility path for #4318 after #4429 landed the occupied-address behavior:

- adds an injectable health-document seam that still runs the production startup compatibility assessment;
- exercises a stale runtime discovered after launch;
- proves the stable runtime_incompatible 409 result and cleanup of the owned process tree.

The branch is rebased onto verified #4429 merge 78d5b17dafff4f12370cd511f83de9027e444038; its superseded occupied-address classifier is no longer part of this diff.

## Verification

- daemon-start focused suite — 21/21
- pnpm typecheck
- git diff --check
- previous pre-rebase exact head — 20/20 CI; current exact-head CI rerunning
- independent maintainer review — no actionable findings

Closes #4318