### PR TITLE
fix(runtime): name an occupied daemon address instead of a bare early exit

### DIFF
--- a/docs/runtime-startup-supervision.md
+++ b/docs/runtime-startup-supervision.md
@@ -20,6 +20,20 @@ a routine settings or session write from replacing migrated data with empty
 defaults. Restore a backup for malformed data, or update Cave for a newer
 configuration version.
 
+An address someone else already holds is its own outcome rather than a generic
+early exit. Once the health probe has failed, Cave connects to the daemon
+address to learn whether anything is accepting there; a completed connection
+means the occupant is something Cave cannot adopt, so the start is refused with
+`address_in_use` and no launcher is spawned. Only a proven connection refuses —
+a refused or absent socket launches, and an address that cannot be read at all
+stays unknown and launches too, because a false refusal strands a user whose
+socket is merely unreadable. A restart skips the check entirely: the occupant it
+would find is the daemon the caller asked to replace. The launcher's own bind
+failure is classified the same way, which closes the window between the check
+and the bind. Cave never deletes a socket file to clear the address; removing
+one a live owner still holds is how two daemons come to believe they own the
+same home.
+
 The daemon starter retains its bounded health deadline and owned-process-tree
 cleanup. A launcher exit alone never means ready; the final readiness probe must
 pass the runtime contract before Cave reports success.

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1245,6 +1245,7 @@ export const SUITES = {
     "src/app/api/travel/offline-work-queue.test.ts",
     "src/lib/executor-status.test.ts",
     "src/lib/daemon-start.test.ts",
+    "src/lib/daemon-socket-occupancy.test.ts",
     "src/lib/daemon-startup-contract.test.ts",
     "src/lib/runtime-startup-throttle.test.ts",
     "src/lib/daemon-update-lifecycle.test.ts",

--- a/src/lib/daemon-desktop-auto-start.test.ts
+++ b/src/lib/daemon-desktop-auto-start.test.ts
@@ -164,6 +164,26 @@ function response(ok, payload) {
   assert.deepEqual(refreshes, [undefined], "deferral immediately rechecks ordinary connection state");
 }
 
+{
+  const errors = [];
+  const refreshes = [];
+  const outcome = await runWorkspaceDaemonStart({
+    automatic: true,
+    fetchImpl: async () => response(false, {
+      ok: false,
+      code: "address_in_use",
+      error: "Another process is already using the local Coven daemon address.",
+    }),
+    dismissError: () => assert.fail("deferred recovery has no prior error to dismiss"),
+    reportError: (message) => errors.push(message),
+    refreshStatus: async (opts) => { refreshes.push(opts); },
+  });
+
+  assert.equal(outcome, "deferred", "an address another process holds is not ours to retry against");
+  assert.deepEqual(errors, [], "automatic address deferral stays out of the error banner");
+  assert.deepEqual(refreshes, [undefined]);
+}
+
 
 // ── Opt-in auto-restart (cave-bqywj) ────────────────────────────────────────
 // Boot auto-start has always been one-shot: the coordinator consumes its

--- a/src/lib/daemon-desktop-auto-start.ts
+++ b/src/lib/daemon-desktop-auto-start.ts
@@ -184,7 +184,11 @@ export async function runWorkspaceDaemonStart(input: {
     );
     const payload = daemonStartPayload(await response.json().catch(() => ({})));
     if (!response.ok || payload.ok === false) {
-      if (input.automatic && payload.code === "owner_unreachable") {
+      // Both codes mean someone else holds the daemon: an unconfirmed
+      // lifecycle owner, or a process already bound to its address. Neither is
+      // ours to displace, and retrying spends revive budget on a refusal that
+      // cannot change until that owner goes away.
+      if (input.automatic && (payload.code === "owner_unreachable" || payload.code === "address_in_use")) {
         await input.refreshStatus();
         return "deferred";
       }

--- a/src/lib/daemon-socket-occupancy.test.ts
+++ b/src/lib/daemon-socket-occupancy.test.ts
@@ -1,0 +1,117 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { test } from "node:test";
+import { inspectDaemonAddress, reportsDaemonAddressInUse } from "./daemon-socket-occupancy.ts";
+
+function fakeSocket() {
+  const socket = Object.assign(new EventEmitter(), {
+    destroyed: false,
+    destroy() {
+      this.destroyed = true;
+    },
+  });
+  return socket;
+}
+
+function connectError(code) {
+  return Object.assign(new Error(`connect ${code}`), { code });
+}
+
+test("a completed connection proves the address is occupied", async () => {
+  const socket = fakeSocket();
+  const occupancy = inspectDaemonAddress({
+    socketPath: "/tmp/coven.sock",
+    connectImpl: () => {
+      queueMicrotask(() => socket.emit("connect"));
+      return socket;
+    },
+  });
+  assert.equal(await occupancy, "occupied");
+  assert.equal(socket.destroyed, true, "the probe must not leave a connection open on the daemon");
+});
+
+for (const code of ["ECONNREFUSED", "ENOENT"]) {
+  test(`${code} means nothing is accepting, so a launch may proceed`, async () => {
+    const socket = fakeSocket();
+    const occupancy = inspectDaemonAddress({
+      socketPath: "/tmp/coven.sock",
+      connectImpl: () => {
+        queueMicrotask(() => socket.emit("error", connectError(code)));
+        return socket;
+      },
+    });
+    assert.equal(await occupancy, "free");
+  });
+}
+
+for (const code of ["EACCES", "EPERM", undefined]) {
+  test(`${code ?? "an unlabelled error"} describes our ability to ask, not the address`, async () => {
+    const socket = fakeSocket();
+    const occupancy = inspectDaemonAddress({
+      socketPath: "/tmp/coven.sock",
+      connectImpl: () => {
+        queueMicrotask(() => socket.emit("error", code ? connectError(code) : new Error("opaque")));
+        return socket;
+      },
+    });
+    assert.equal(await occupancy, "unknown", "an unreadable address must never refuse a launch");
+  });
+}
+
+test("a synchronous connect throw is classified rather than propagated", async () => {
+  const occupancy = await inspectDaemonAddress({
+    socketPath: "/tmp/coven.sock",
+    connectImpl: () => {
+      throw connectError("ENOENT");
+    },
+  });
+  assert.equal(occupancy, "free");
+});
+
+test("a silent address is ambiguous, not occupied", async () => {
+  const socket = fakeSocket();
+  const occupancy = await inspectDaemonAddress({
+    socketPath: "/tmp/coven.sock",
+    timeoutMs: 1,
+    connectImpl: () => socket,
+  });
+  assert.equal(occupancy, "unknown");
+  assert.equal(socket.destroyed, true, "a timed-out probe still releases its socket");
+});
+
+test("only the first outcome settles the probe", async () => {
+  const socket = fakeSocket();
+  const occupancy = inspectDaemonAddress({
+    socketPath: "/tmp/coven.sock",
+    connectImpl: () => {
+      queueMicrotask(() => {
+        socket.emit("connect");
+        socket.emit("error", connectError("ECONNREFUSED"));
+      });
+      return socket;
+    },
+  });
+  assert.equal(await occupancy, "occupied", "a post-connect teardown error must not rewrite the verdict");
+});
+
+for (
+  const output of [
+    "listen EADDRINUSE: address already in use",
+    "Error: bind failed, address in use",
+    "socket /Users/x/.coven/coven.sock in use",
+    "port 8787 in use",
+  ]
+) {
+  assert.equal(reportsDaemonAddressInUse(output), true, `launcher output must be recognised: ${output}`);
+}
+
+assert.equal(reportsDaemonAddressInUse("daemon exited with status 1"), false);
+assert.equal(reportsDaemonAddressInUse(undefined, null, ""), false);
+assert.equal(
+  reportsDaemonAddressInUse("", "listen EADDRINUSE"),
+  true,
+  "either captured stream is enough to name the cause",
+);
+
+console.log("daemon-socket-occupancy.test.ts: ok");

--- a/src/lib/daemon-socket-occupancy.ts
+++ b/src/lib/daemon-socket-occupancy.ts
@@ -1,0 +1,84 @@
+import { connect, type Socket } from "node:net";
+
+/**
+ * Whether the local daemon's address is already bound.
+ *
+ * The health probe cannot answer this. It collapses two opposite situations
+ * into one not-ok: a refused connection, where a launch will succeed, and a
+ * stranger that accepts and answers something unusable, where the launch is
+ * already doomed to fail its bind. Only a raw connect separates them.
+ */
+export type DaemonAddressOccupancy = "free" | "occupied" | "unknown";
+
+/**
+ * Launcher output for an address that is already bound. The local daemon binds
+ * a UNIX socket path (a named pipe on Windows) rather than a TCP port, so the
+ * port shapes are here for the hub and executor launchers that do.
+ */
+const DAEMON_ADDRESS_IN_USE_PATTERN =
+  /EADDRINUSE|address (?:already )?in use|socket .*in use|port .*in use/i;
+
+/** True when any captured launcher stream blames an already-bound address. */
+export function reportsDaemonAddressInUse(...texts: Array<string | undefined | null>): boolean {
+  return texts.some((text) => typeof text === "string" && DAEMON_ADDRESS_IN_USE_PATTERN.test(text));
+}
+
+function occupancyForConnectError(error: unknown): DaemonAddressOccupancy {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  // Nothing is accepting on the address: either no socket file exists, or a
+  // dead one remains that the daemon's own bind replaces. Both are launchable,
+  // and neither is Cave's to delete — removing a socket file that a live owner
+  // still holds is how two daemons end up believing they own the same home.
+  if (code === "ECONNREFUSED" || code === "ENOENT") return "free";
+  // EACCES, EPERM, and anything else describe our ability to ask, not the
+  // address. Refusing a launch on those would strand a user whose socket is
+  // merely unreadable, so they stay unknown and the launch proceeds.
+  return "unknown";
+}
+
+/**
+ * Probes whether something is currently accepting on the daemon address.
+ *
+ * Deliberately conservative: only a completed connection proves occupancy, and
+ * only a refusal proves freedom. Everything else is unknown, because this
+ * result is used to refuse a start, and a false refusal is worse than a launch
+ * that fails with its own diagnostic.
+ */
+export function inspectDaemonAddress(input: {
+  socketPath: string;
+  timeoutMs?: number;
+  connectImpl?: (socketPath: string) => Socket;
+}): Promise<DaemonAddressOccupancy> {
+  const timeoutMs = input.timeoutMs ?? 750;
+  const connectImpl = input.connectImpl ?? ((socketPath: string) => connect({ path: socketPath }));
+
+  return new Promise((resolve) => {
+    let socket: Socket | null = null;
+    let settled = false;
+    const settle = (occupancy: DaemonAddressOccupancy) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      try {
+        socket?.destroy();
+      } catch {
+        // A socket that is already torn down needs nothing from us.
+      }
+      resolve(occupancy);
+    };
+
+    // A backlogged listener can accept slowly enough to look like silence.
+    // That is genuinely ambiguous, so it does not refuse a launch.
+    const timer = setTimeout(() => settle("unknown"), timeoutMs);
+    timer.unref?.();
+
+    try {
+      socket = connectImpl(input.socketPath);
+    } catch (error) {
+      settle(occupancyForConnectError(error));
+      return;
+    }
+    socket.once("connect", () => settle("occupied"));
+    socket.once("error", (error) => settle(occupancyForConnectError(error)));
+  });
+}

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -29,6 +29,8 @@ assert.match(daemonStart, /sanitizeDaemonStartDiagnostic\(stderr\)/, "launcher s
 assert.match(daemonStart, /assessDaemonStartupCompatibility/, "readiness must validate runtime coherence, not only socket reachability");
 assert.match(daemonStart, /code: "runtime_incompatible"/, "a stale or incompatible runtime has a stable actionable outcome");
 assert.match(daemonStart, /RuntimeStartupThrottle/, "repeated failed starts must be bounded to prevent a restart storm");
+assert.match(daemonStart, /code: "address_in_use"/, "an address someone else holds has its own actionable outcome");
+assert.match(daemonStart, /inspectDaemonAddress/, "occupancy is proven by connecting, not inferred from a failed health probe");
 assert.match(daemonStart, /activeDaemonStart/, "concurrent start requests must share one owned launch");
 
 for (const [payload, expected] of [
@@ -164,6 +166,10 @@ test("automatic recovery still starts after lifecycle proves stopped", async () 
     automatic: true,
     probe: async () => ({ ok: ++probes >= 2 }),
     inspectLifecycle: async () => ({ status: "stopped" }),
+    // Declared, not defaulted: the real probe would connect to this machine's
+    // own daemon socket and refuse, making the result depend on whether the
+    // developer running the suite happens to have a daemon up.
+    inspectAddress: async () => "free",
     spawnImpl: () => {
       spawnCalls += 1;
       return child;
@@ -264,6 +270,119 @@ test("an exited but unhealthy launcher is cleaned up before it is reported", asy
   assert.equal(result.ok, false);
   assert.equal(result.code, "runner_exited");
   assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "windows-tree" });
+});
+
+test("an occupied-address launcher failure is named, not reported as a bare early exit", async () => {
+  const child = fakeChild();
+  let cleanupCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 1,
+    probe: async () => ({ ok: false }),
+    spawnImpl: () => {
+      queueMicrotask(() => {
+        child.stderr.write("listen EADDRINUSE: address already in use");
+        child.emit("close", 1);
+      });
+      return child;
+    },
+    terminateLaunchTree: async () => {
+      cleanupCalls += 1;
+      return { attempted: true, completed: true, mode: "windows-tree" };
+    },
+    platform: "win32",
+  });
+
+  assert.equal(cleanupCalls, 1);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "address_in_use", "the launcher's own bind failure outranks the exit it caused");
+  assert.equal(result.status, 409);
+  assert.match(result.error, /already using the local Coven daemon address/i);
+  assert.match(result.error, /then try again/i, "the diagnostic carries one next step");
+  assert.match(result.stderr, /EADDRINUSE|address already in use/, "the raw launcher output stays diagnosable");
+  assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "windows-tree" });
+});
+
+test("an already-bound address is refused by name instead of spawning a doomed launcher", async () => {
+  let spawnCalls = 0;
+  const result = await startLocalDaemon({
+    probe: async () => ({ ok: false }),
+    inspectAddress: async () => "occupied",
+    spawnImpl: () => {
+      spawnCalls += 1;
+      return fakeChild();
+    },
+  });
+
+  assert.equal(spawnCalls, 0, "a launcher that cannot win its own bind must never be started");
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "address_in_use");
+  assert.equal(result.status, 409);
+  assert.equal(result.launchMode, "none");
+  assert.match(result.error, /already using the local Coven daemon address/i);
+  assert.doesNotMatch(result.error, /[\\/]/, "the diagnostic never carries a socket path across the API boundary");
+});
+
+for (const occupancy of ["free", "unknown"]) {
+  test(`a ${occupancy} address still launches`, async () => {
+    let spawnCalls = 0;
+    let probes = 0;
+    const child = fakeChild();
+    const result = await startLocalDaemon({
+      probe: async () => ({ ok: ++probes >= 2 }),
+      inspectAddress: async () => occupancy,
+      spawnImpl: () => {
+        spawnCalls += 1;
+        return child;
+      },
+    });
+
+    assert.equal(spawnCalls, 1, "only proven occupancy refuses; an unreadable address must not strand a start");
+    assert.equal(result.ok, true);
+  });
+}
+
+test("restart never consults occupancy, because the occupant is what it replaces", async () => {
+  let inspections = 0;
+  let probes = 0;
+  const child = fakeChild();
+  const result = await startLocalDaemon({
+    restart: true,
+    probe: async () => ({ ok: ++probes >= 2 }),
+    inspectAddress: async () => {
+      inspections += 1;
+      return "occupied";
+    },
+    spawnImpl: () => child,
+  });
+
+  assert.equal(inspections, 0, "a restart that refused its own daemon's address could never restart anything");
+  assert.equal(result.ok, true);
+});
+
+test("automatic recovery checks lifecycle ownership before it checks the address", async () => {
+  const order = [];
+  let spawnCalls = 0;
+  const result = await startLocalDaemon({
+    automatic: true,
+    probe: async () => ({ ok: false }),
+    inspectLifecycle: async () => {
+      order.push("lifecycle");
+      return { status: "stopped" };
+    },
+    inspectAddress: async () => {
+      order.push("address");
+      return "occupied";
+    },
+    spawnImpl: () => {
+      spawnCalls += 1;
+      return fakeChild();
+    },
+  });
+
+  assert.deepEqual(order, ["lifecycle", "address"], "a live owner is the more specific answer and reports first");
+  assert.equal(spawnCalls, 0);
+  assert.equal(result.code, "address_in_use");
 });
 
 test("Windows cleanup delegates the complete owned tree to taskkill", async () => {

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
-import { callDaemonTarget, localDaemonTarget } from "./coven-daemon.ts";
+import { callDaemonTarget, localDaemonTarget, socketPath } from "./coven-daemon.ts";
 import { covenBin, covenLaunchCommand } from "./coven-bin.ts";
 import { covenCliMissingError, isMissingExecutableError } from "./coven-spawn-error.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
@@ -13,6 +13,11 @@ import {
   type DaemonStartupHealth,
 } from "./daemon-startup-contract.ts";
 import { RuntimeStartupThrottle } from "./runtime-startup-throttle.ts";
+import {
+  inspectDaemonAddress,
+  reportsDaemonAddressInUse,
+  type DaemonAddressOccupancy,
+} from "./daemon-socket-occupancy.ts";
 
 export type DaemonStartResult =
   | { ok: true; alreadyRunning: true; readinessAttempts: number; elapsedMs: number; launchMode: "none" }
@@ -34,7 +39,8 @@ export type DaemonStartResult =
       | "readiness_timeout"
       | "runtime_incompatible"
       | "restart_throttled"
-      | "owner_unreachable";
+      | "owner_unreachable"
+      | "address_in_use";
     error: string;
     stdout: string;
     stderr: string;
@@ -175,6 +181,8 @@ type StartLocalDaemonOptions = {
   probe?: () => Promise<{ ok: boolean }>;
   /** Injectable installed-version seam for deterministic startup coherence tests. */
   installedVersion?: () => Promise<string | null>;
+  /** Injectable address-occupancy seam for deterministic already-bound tests. */
+  inspectAddress?: () => Promise<DaemonAddressOccupancy>;
   spawnImpl?: typeof spawn;
   terminateLaunchTree?: (child: ChildProcess) => Promise<DaemonLaunchCleanup>;
   inspectLifecycle?: () => Promise<DaemonLifecycleInspection>;
@@ -222,8 +230,24 @@ const daemonStartThrottle = new RuntimeStartupThrottle();
 let activeDaemonStart: Promise<DaemonStartResult> | null = null;
 
 function hasTestSeam(options: StartLocalDaemonOptions): boolean {
-  return Boolean(options.probe || options.spawnImpl || options.terminateLaunchTree || options.installedVersion || options.platform);
+  return Boolean(
+    options.probe
+    || options.spawnImpl
+    || options.terminateLaunchTree
+    || options.installedVersion
+    || options.inspectAddress
+    || options.platform,
+  );
 }
+
+/**
+ * One next step for an address someone else already holds. Deliberately names
+ * no socket path, PID, or command line: this crosses the API boundary, and the
+ * diagnostics sanitizer would redact a home-relative path into uselessness
+ * anyway.
+ */
+const ADDRESS_IN_USE_DIAGNOSTIC =
+  "Another process is already using the local Coven daemon address. Stop that process, or restart Cave so it can reconnect, then try again.";
 
 export function startLocalDaemon(options: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
   if (hasTestSeam(options)) return runLocalDaemonStart(options);
@@ -266,6 +290,7 @@ async function runLocalDaemonStart({
   readinessPollMs = 250,
   probe: probeOverride,
   installedVersion,
+  inspectAddress = () => inspectDaemonAddress({ socketPath: socketPath() }),
   spawnImpl = spawn,
   terminateLaunchTree = terminateDaemonLaunchTree,
   inspectLifecycle = inspectDaemonLifecycle,
@@ -327,6 +352,29 @@ async function runLocalDaemonStart({
         stderr: "",
         status: 409,
         readinessAttempts: 2,
+        elapsedMs: Date.now() - startedAt,
+        launchMode: "none",
+      };
+    }
+  }
+
+  // Reaching here without `restart` means the health probe already failed, so
+  // an address that is nonetheless bound belongs to something Cave cannot
+  // adopt. Spawning against it produces a launcher that dies on its own bind
+  // and a diagnostic that names neither cause nor next step, so refuse by name
+  // instead. `restart` skips this deliberately: the address it would find
+  // occupied is the very daemon the caller asked to replace.
+  if (!restart) {
+    const occupancy = await inspectAddress();
+    if (occupancy === "occupied") {
+      return {
+        ok: false,
+        code: "address_in_use",
+        error: ADDRESS_IN_USE_DIAGNOSTIC,
+        stdout: "",
+        stderr: "",
+        status: 409,
+        readinessAttempts: automatic ? 2 : 1,
         elapsedMs: Date.now() - startedAt,
         launchMode: "none",
       };
@@ -434,6 +482,25 @@ async function runLocalDaemonStart({
   // readiness deadline.
   const runnerExitedBeforeCleanup = exitCode !== undefined;
   const cleanup = await terminateLaunchTree(child);
+  // The preflight above cannot close the window between its probe and the
+  // daemon's bind, and it never runs at all for `restart`. When the launcher
+  // itself blames the address, that is a better answer than the exit it caused:
+  // "the launcher exited" describes the symptom, this describes the cause.
+  if (reportsDaemonAddressInUse(stdout, stderr)) {
+    return {
+      ok: false,
+      code: "address_in_use",
+      error: ADDRESS_IN_USE_DIAGNOSTIC,
+      stdout: sanitizeDaemonStartDiagnostic(stdout),
+      stderr: sanitizeDaemonStartDiagnostic(stderr),
+      status: 409,
+      readinessAttempts: readiness.attempts + 1,
+      elapsedMs: Date.now() - startedAt,
+      launchMode,
+      exitCode,
+      cleanup,
+    };
+  }
   if (runnerExitedBeforeCleanup) {
     return {
       ok: false, code: "runner_exited", error: "daemon launcher exited before health became ready",


### PR DESCRIPTION
Closes the last named failure in `cave-3qas7.6`'s acceptance matrix that still lacked an actionable diagnostic. Sub-bead `cave-3qas7.6.2`, tracking issue #4318.

## The gap

A managed start against an address something else already holds came back as the generic `runner_exited` outcome — *"daemon launcher exited before health became ready"* — which names neither the cause nor a next step. It also spawned a launcher that was doomed at its own bind, and then cleaned up the tree it had just created for no purpose.

The audit on #4318 called this out directly: *"No managed-start occupied-port behavior test. The only explicit `EADDRINUSE` coverage is onboarding failure classification, not `startLocalDaemon`."*

## What changed

**Refuse by name, before spawning.** Once the health probe has failed, Cave connects to the daemon address to learn whether anything is accepting there. The health probe cannot answer this on its own — it collapses a refused connection and a stranger that accepts and answers something unusable into one not-ok, and those two need opposite handling.

The probe is deliberately conservative, because its result refuses a start:

| observation | verdict | effect |
|---|---|---|
| connection completes | `occupied` | refuse with `address_in_use`, never spawn |
| `ECONNREFUSED` / `ENOENT` | `free` | launch |
| `EACCES`, `EPERM`, anything else, timeout | `unknown` | launch |

Only proven occupancy refuses. An address Cave cannot read describes our ability to ask, not the address, and a false refusal would strand a user whose socket is merely unreadable.

**`restart` skips the check entirely.** The occupant it would find is the very daemon the caller asked to replace — a restart that refused its own daemon's address could never restart anything. That is pinned by a test.

**The launcher's own bind failure is classified the same way**, which closes the window between the check and the bind, and covers `restart` where no preflight ran. When the launcher blames the address, that outranks the exit it caused: *"the launcher exited"* is the symptom, this is the cause. The raw stderr still rides along sanitized, so the failure stays diagnosable.

**Cave never deletes a socket file to clear the address.** Removing one a live owner still holds is how two daemons come to believe they own the same home. A stale file is the runtime's to replace on its own bind.

**Automatic recovery defers on `address_in_use`** the way it already defers on `owner_unreachable`. Both mean someone else holds the daemon; retrying spends revive budget on a refusal that cannot change until that owner goes away. This keeps `cave-9pqt9`'s ownership-safety property intact.

## Diagnostic wording

`address_in_use` returns 409 with:

> Another process is already using the local Coven daemon address. Stop that process, or restart Cave so it can reconnect, then try again.

No socket path, PID, or command line — this crosses the API boundary, and the diagnostics sanitizer would redact a home-relative path into uselessness anyway. A test asserts the message carries no path separator.

## Coordination — read before merging

Another live session is working the parent bead in `.worktrees/cave-3qas7-6-startup-evidence` and has an unpushed commit `0d7926da` adding a `readHealthDocument` seam and a stale-runtime-after-launch test. **None of that is in this PR** — this branch was deliberately rebased off it so it does not publish their work.

One overlap: their commit contains a test asserting `runner_exited` for an `EADDRINUSE` launcher failure, pinning the behavior this PR changes. This PR carries the equivalent test under a new name, keeping their stderr-preservation and cleanup assertions. Whoever rebases second takes this version of that block. A notice explaining this was left in their worktree.

## Verification

- `node scripts/run-tests.mjs app` — 1132 files, and `api` — 357 files, both green.
- `tsc --noEmit` clean; `check-tests-wired` confirms the new test file is registered.
- New `daemon-socket-occupancy.test.ts`: 9 cases covering each verdict, a synchronous connect throw, socket release on both the settled and timed-out paths, and first-outcome-wins so a post-connect teardown error cannot rewrite the verdict.
- New starter cases: refusal without spawning, `free`/`unknown` still launching, `restart` never consulting occupancy, lifecycle ownership reported before address occupancy, and the post-spawn classifier.

One pre-existing test now declares `inspectAddress: async () => "free"`. It previously reached the default, which connects to the developer's own daemon socket, making the result depend on whether a daemon happened to be running locally.

### Unrelated observation

`"automatic recovery still starts after lifecycle proves stopped"` takes 5–7 s, on `main` as well as here — not from this change. Every dependency it needs is injected, so the cost is most likely `covenBin()` being evaluated as an argument to the injected `spawnImpl`. Not filed; noting it where it will be found.