### PR TITLE
test(sidebar): guard against committed merge artifacts recurring (cave-2hh5q)

### DIFF
--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -587,10 +587,17 @@ for (const [name, text, loader] of [
 //    happened, which is the difference between a five-minute fix and the
 //    outage that produced this bead.
 //
+//    All FOUR marker kinds, not three: `|||||||` opens the base section under
+//    `merge.conflictStyle = diff3` / `zdiff3`, which is a per-contributor git
+//    setting this repo does not pin. A complete diff3 conflict would still trip
+//    the other three, so this mainly covers a partial resolution that clears
+//    `<<<<<<<` / `=======` / `>>>>>>>` and leaves the base section behind —
+//    which is precisely the artifact a hand-edited conflict tends to strand.
+//
 //    Anchored at line start on purpose: a seven-character run only reads as a
 //    conflict marker when it opens the line, and `=======` appears mid-line in
 //    legitimate comment rules and CSS.
-const CONFLICT_MARKER = /^(?:<{7}|={7}|>{7})/m;
+const CONFLICT_MARKER = /^(?:<{7}|\|{7}|={7}|>{7})/m;
 for (const [name, text] of [
   ["sidebar-minimal.tsx", source],
   ["sidebar-rail-header.tsx", railHeaderSource],

--- a/src/components/sidebar-minimal.test.ts
+++ b/src/components/sidebar-minimal.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { transformSync } from "esbuild";
 
 const styles = [
   readFileSync(new URL("../styles/sidebar-minimal.css", import.meta.url), "utf8"),
@@ -15,6 +16,9 @@ const source = readFileSync(new URL("./sidebar-minimal.tsx", import.meta.url), "
 const railHeaderSource = readFileSync(new URL("./sidebar-rail-header.tsx", import.meta.url), "utf8");
 const railHeaderCss = readFileSync(new URL("../styles/globals/rail-header.css", import.meta.url), "utf8");
 const navigation = readFileSync(new URL("../lib/workspace-navigation.ts", import.meta.url), "utf8");
+// The Home/Code split itself — the sidebar reaches the registry only through
+// this module, so a committed artifact here breaks the rail just as badly.
+const navSection = readFileSync(new URL("../lib/nav-section.ts", import.meta.url), "utf8");
 const workspace = readFileSync(new URL("./workspace.tsx", import.meta.url), "utf8");
 // The footer (Dashboard + Settings + version) lives in a shared component so it
 // stays identical when Chat replaces SidebarMinimal with WorkspaceSidebar.
@@ -546,6 +550,89 @@ assert.match(
   styles,
   /\.sidebar-folder-row--split \{[^}]*color-mix\(in oklch, var\(--accent-presence\)/,
   "the split marker reuses the active accent at a lighter wash",
+);
+
+// ── Committed merge-artifact guard (cave-2hh5q) ──────────────────────────────
+// 23316da3 committed two unresolved conflict-marker blocks into this component.
+// The file stopped PARSING, so every route 500'd — including
+// /api/app/build-info — until 4ea88862 repaired it (cave-tbdnt).
+//
+// The whole suite above stayed green through it. That is the point worth
+// keeping: every assertion in this file is a source-TEXT match, and a regex is
+// perfectly happy to find its pattern inside a file no compiler would accept.
+// Text pinning cannot, even in principle, notice that a file stopped parsing.
+// So this section adds the two checks that can.
+
+// 1. Parse the component for real. This is the guard that generalizes: it fails
+//    on conflict markers, but equally on any other syntax breakage that a
+//    source-text assertion would sail straight past. esbuild's parser is the
+//    same one Next uses to transform the file, so a pass here means the route
+//    can at least build.
+for (const [name, text, loader] of [
+  ["sidebar-minimal.tsx", source, "tsx"],
+  ["sidebar-rail-header.tsx", railHeaderSource, "tsx"],
+  ["sidebar-footer.tsx", footer, "tsx"],
+  ["nav-section.ts", navSection, "ts"],
+  ["workspace-navigation.ts", navigation, "ts"],
+]) {
+  assert.doesNotThrow(
+    () => transformSync(text, { loader, sourcefile: name }),
+    `${name} must parse — a source-text assertion cannot tell a broken file from a working one`,
+  );
+}
+
+// 2. Name the artifact explicitly as well. The parse check already rejects a
+//    conflicted file, but it reports a bare "Expression expected" pointing at
+//    whichever line the parser gave up on; this one says what actually
+//    happened, which is the difference between a five-minute fix and the
+//    outage that produced this bead.
+//
+//    Anchored at line start on purpose: a seven-character run only reads as a
+//    conflict marker when it opens the line, and `=======` appears mid-line in
+//    legitimate comment rules and CSS.
+const CONFLICT_MARKER = /^(?:<{7}|={7}|>{7})/m;
+for (const [name, text] of [
+  ["sidebar-minimal.tsx", source],
+  ["sidebar-rail-header.tsx", railHeaderSource],
+  ["sidebar-footer.tsx", footer],
+  ["nav-section.ts", navSection],
+  ["workspace-navigation.ts", navigation],
+  ["the sidebar stylesheets", styles],
+  ["rail-header.css", railHeaderCss],
+]) {
+  assert.doesNotMatch(
+    text,
+    CONFLICT_MARKER,
+    `${name} must not carry unresolved Git conflict markers (cave-2hh5q / cave-tbdnt)`,
+  );
+}
+
+// ── Stale navigation identifier (cave-2hh5q) ─────────────────────────────────
+// The conflicted merge left BOTH sides live in the file at once: the old flat
+// `VISIBLE_WORKSPACE_NAV_ITEMS.map(...)` and its tabbed replacement. The flat
+// list is the whole registry, unsplit — mapping it here would render every Home
+// destination under Code and every Code destination under Home, while each
+// individual row assertion above kept passing, because the rows themselves are
+// unchanged. Only the section split is allowed to reach the registry.
+assert.doesNotMatch(
+  source,
+  /VISIBLE_WORKSPACE_NAV_ITEMS/,
+  "the sidebar must reach nav rows through navItemsForSection(section), never the unsplit VISIBLE_WORKSPACE_NAV_ITEMS list",
+);
+assert.match(
+  navSection,
+  /export function navItemsForSection\(section: NavSection\)[\s\S]{0,160}navSectionForMode\(item\.id\) === section/,
+  "navItemsForSection must keep filtering by section — a passthrough would un-split the rail without failing a row assertion",
+);
+
+// Recent Activity is Code-only (cave-24d2r): Home is destinations, Code is live
+// work. The prop assertions above fire wherever the rollup is mounted, so
+// without this the section gate could be dropped and every one of them would
+// still pass.
+assert.match(
+  source,
+  /section === "code" \? \(\s*<RecentActivityRollup/,
+  "Recent Activity renders only in the Code section — Home stays destinations-only",
 );
 
 console.log("sidebar-minimal.test.ts (shell-ia-lastmile) OK");


### PR DESCRIPTION
Closes the regression half of **cave-2hh5q**.

## Why this exists

`23316da3` committed two unresolved conflict-marker blocks into
`src/components/sidebar-minimal.tsx`. The file stopped **parsing**, so every
route 500'd — including `/api/app/build-info` — until `4ea88862` repaired it
(cave-tbdnt, now closed).

The whole suite stayed green through that outage, and that is the part this PR
addresses. Every assertion in `sidebar-minimal.test.ts` is a source-**text**
match, and a regex is perfectly happy to find its pattern inside a file no
compiler would accept. Text pinning cannot, even in principle, notice that a
file stopped parsing.

The parse repair itself is already on main — this PR adds only the coverage that
stops it recurring silently. No production code is touched.

## What it adds

All in `src/components/sidebar-minimal.test.ts` (+87, test-only):

- **A real parse check.** `sidebar-minimal.tsx`, `sidebar-rail-header.tsx`,
  `sidebar-footer.tsx`, `nav-section.ts` and `workspace-navigation.ts` go
  through esbuild. This is the guard that generalizes: it fails on conflict
  markers, but equally on any other syntax breakage a text assertion would sail
  straight past.
- **An explicit marker check**, across those sources plus the sidebar
  stylesheets. The parse check already rejects a conflicted `.tsx`, but reports
  a bare `Expression expected` at whichever line the parser gave up on; this one
  says what actually happened. Anchored at line start on purpose — `=======`
  appears mid-line in legitimate CSS and comment rules, so an unanchored match
  produces false positives. It also covers CSS, which parses fine with a marker
  in it and so is invisible to the check above.
- **A ban on direct `VISIBLE_WORKSPACE_NAV_ITEMS` access from the sidebar.** The
  conflicted merge left *both* the old flat `.map(...)` and its tabbed
  replacement live in the file at once. That list is the whole registry,
  unsplit, so mapping it renders every Home destination under Code and every
  Code destination under Home — while each individual row assertion keeps
  passing, because the rows themselves are unchanged.
- **`navItemsForSection` pinned to actually filter**, and **Recent Activity
  pinned to Code-only** (cave-24d2r). The existing rollup prop assertions fire
  wherever it is mounted, so the section gate could be dropped without failing
  one of them.

## Verification

Mutation-tested rather than trusted on a green run — a guard that cannot fail is
worth nothing. Six defects introduced one at a time, each caught with its
intended message:

| Mutation | Caught by |
| --- | --- |
| Conflict-marker block reintroduced (the actual `23316da3` defect) | parse check |
| Sidebar remapped to the flat unsplit registry | section-filter assertion |
| Direct registry import added, `navItemsForSection` call kept | stale-identifier ban |
| Code-only gate dropped from Recent Activity | section-gate assertion |
| `navItemsForSection` stubbed to a passthrough | filter assertion |
| Marker appended to CSS (parses fine) | marker check |

On `537b0866da`: `pnpm typecheck` exit 0, `pnpm lint` exit 0,
`git diff --check` clean, `pnpm test:app` **1132 test files passed**, 0 failures.
Exit codes captured directly rather than through a pipe.

## Follow-ups filed, not folded in here

- **cave-rbs9o** — there is no repo-wide conflict-marker gate. `ci.yml` has
  none; `git diff --check` runs only in `release.yml`, which is after the
  artifact is already on main. Deliberately not built here: adding a required
  check is the documented way to strand PRs as `BLOCKED`.
- **cave-525id** — an orphaned worktree metadata record permanently locks a bead
  out of managed worktree creation. Hit while setting this branch up.