### PR TITLE
docs(worktrees): say plainly that beads:worktrees:apply is gate-blocked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,10 +70,16 @@
     never retire it. Retire it by hand through the archive-tag route in
     [`CLAUDE.md`](CLAUDE.md), and never hand-write the missing metadata onto the
     Bead — that record is the evidence the retirement gate checks.
-- After a PR merges, run `pnpm beads:worktrees`, record the merged unit's
-  disposition, and use `pnpm beads:worktrees:apply` only when it reports a
-  complete repository maintenance transaction. Local cleanup is bounded and
-  exact-OID guarded; remote deletion remains proposal-only.
+- After a PR merges, run `pnpm beads:worktrees` and record the merged unit's
+  disposition. **`pnpm beads:worktrees:apply` cannot retire anything today** — it
+  exits 2 with `missing maintenance planes: coven, beads, github`, which
+  `scripts/maintenance-gate.mjs` hard-codes off pending `cave-wqa0b.2/.3/.4`
+  (all BLOCKED). That is not a local fault and a retry will not clear it, so
+  hand-retirement through the archive-tag route in [`CLAUDE.md`](CLAUDE.md) is
+  the expected path until those land (`cave-3aqvr`). Prove retention first: a
+  squash-merge leaves the branch commits on no remote ref, so a merged PR is not
+  retention and a pushed archive tag is. Local cleanup is bounded and exact-OID
+  guarded; remote deletion remains proposal-only.
 - Run `pnpm beads:worktrees` before closing PR-backed work. Record each local
   worktree as removed and verified or intentionally preserved with an owner and
   reason; `retire-after-gate` is a classification, not automatic deletion

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,11 +364,47 @@ out. See `cave-l52dt`.
 - `git worktree remove --force` when status is dirty — investigate first; uncommitted edits may belong to another live session.
 
 **After an exact-head squash merge:** normal completion uses the lifecycle patrol.
-Run `pnpm beads:worktrees`; when the full maintenance
-transaction is available, `pnpm beads:worktrees:apply` retires proven-safe
-local state. If it reports active, recovery, cooldown, uncertain, or
-gate-incomplete, preserve the unit and record its owner/reason. Never bypass
+Run `pnpm beads:worktrees`. If it reports active, recovery, cooldown, uncertain,
+or gate-incomplete, preserve the unit and record its owner/reason. Never bypass
 the worktree guard to force completion.
+
+⚠️ **`pnpm beads:worktrees:apply` does not work today, and this is not a local
+fault.** It exits 2 before assessing a single unit:
+
+```text
+worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: coven, beads, github
+```
+
+`scripts/maintenance-gate.mjs` hard-codes three of the four planes to
+`enforced: false`, each pointing at unbuilt work — `coven` → `cave-wqa0b.2`,
+`beads` → `cave-wqa0b.3`, `github` → `cave-wqa0b.4`. All three are **BLOCKED**,
+so `--apply` is unreachable for the foreseeable future and no retry, credential
+or daemon will change that. Tracked by `cave-3aqvr`.
+
+**So hand-retirement is the norm right now, not the exception.** For a unit the
+patrol already classified `cleanup-ready`, use the archive-tag route in the
+worktree-guard section below.
+
+⚠️ **Prove retention before removing anything — a merged PR is NOT retention.**
+A squash-merge leaves the branch's own commits on no remote ref, so
+`git branch -r --contains <head>` comes back empty even though the work shipped.
+Check for an existing archive tag first, and create one if there is none:
+
+```bash
+git ls-remote --tags origin | grep <branch-slug>          # already archived?
+gh pr list --head <branch> --state all --json number,state,mergedAt
+git tag -s archive/<branch-with-slashes-as-dashes>-<date> <exact-head> -m "…"
+git push origin archive/<…>                               # a LOCAL-only tag does not count
+git worktree unlock <path> && git worktree remove <path>
+git branch -D <branch>
+```
+
+Verified 2026-08-08 retiring `cave-93jz1` / `cave-g8n5v` / `cave-na7oc`: two
+already had pushed archive tags, and `cave-g8n5v` had none — its two commits
+existed only inside GitHub's PR record for #4426, so removing it without tagging
+first would have been lossy. Also note `git log @{u}..HEAD` is worthless as an
+"is it pushed" check on these branches: the upstream ref is gone, so the command
+errors and a naive `| wc -l` reports a reassuring `0`.
 
 ## Starting the Tauri desktop app
 

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -170,7 +170,12 @@ Builds a read-only lifecycle report for every registered worktree and direct
 local branch. The patrol correlates local state with claims, Beads, Coven
 sessions, pull requests, workflow runs, and live process cwd ownership. It never
 removes worktrees or branches unless --apply becomes available after all
-maintenance planes are enforced.`);
+maintenance planes are enforced.
+
+--apply is currently unusable: the coven, beads and github planes are hard-coded
+off in scripts/maintenance-gate.mjs pending unbuilt work, so it refuses with
+exit 2 before assessing any unit. Retire cleanup-ready units by hand through the
+archive-tag route in CLAUDE.md until that changes (cave-3aqvr).`);
 }
 
 function errorMessage(error: unknown): string {
@@ -224,8 +229,32 @@ function renderApplyUnavailable(
       }),
     );
   } else {
+    // Name the blocking work and the route that does function. Bare
+    // "missing maintenance planes" reads as a local fault, so sessions retry
+    // it, then reach for `git worktree add` -- the unmanaged fallback whose
+    // worktrees carry no lifecycle metadata and can never be retired at all
+    // (cave-l52dt). The planes are unimplemented, not unavailable (cave-3aqvr).
+    // The blocking Bead per plane is read from the capability's own `source`
+    // rather than a second map here, so this cannot drift from the gate.
     console.error(
-      `worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: ${missingPlanes.join(", ")}`,
+      [
+        `worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: ${missingPlanes.join(", ")}`,
+        "",
+        "This is not a local fault and a retry will not clear it. These planes are",
+        "hard-coded off in scripts/maintenance-gate.mjs pending unbuilt work:",
+        ...missingPlanes.map(
+          (plane) => `  ${plane.padEnd(7)} blocked on ${capabilities[plane].source || "an unfiled Bead"}`,
+        ),
+        "",
+        "Until those land, automated retirement is unavailable and hand-retirement",
+        "is the expected path -- NOT a workaround. Retire a cleanup-ready unit via",
+        "the archive-tag route in CLAUDE.md (worktree-guard section), and prove",
+        "retention BEFORE removing anything: a merged PR is not retention, because",
+        "a squash-merge leaves the branch commits on no remote ref. Tag the exact",
+        "head, push the tag, confirm it is on the REMOTE, then remove.",
+        "",
+        "Tracked by cave-3aqvr.",
+      ].join("\n"),
     );
   }
   return 2;


### PR DESCRIPTION
Option 3 from `cave-3aqvr`: keep the maintenance gate shut, but stop it reading
as a local fault.

## The problem

`pnpm beads:worktrees:apply` cannot retire anything and never could. It exits 2
before assessing a single unit:

```
worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: coven, beads, github
```

`scripts/maintenance-gate.mjs` hard-codes three of the four planes to
`enforced: false`, each pointing at unbuilt work — `coven` → `cave-wqa0b.2`,
`beads` → `cave-wqa0b.3`, `github` → `cave-wqa0b.4`. All three are **BLOCKED**.

Both operator docs presented patrol/apply as the normal completion path, hedged
only by *"when the full maintenance transaction is available"* — which reads as
"if the inventory is healthy", not "this is unimplemented". The refusal named no
cause and no remedy. Together that pushes a session toward the unmanaged
`git worktree add` fallback, which produces exactly the worktree that can never
be retired (`cave-l52dt`).

## What changed

- **`scripts/worktree-lifecycle-patrol.ts`** — the refusal now names the
  blocking Bead per plane, says a retry will not clear it, and points at the
  archive-tag route as today's expected path. The Bead per plane is read from
  each capability's own `source` field rather than a second map here, so it
  cannot drift from the gate. `--help` no longer implies the planes merely need
  to become enforced.
- **`CLAUDE.md`** — replaces the hedge with the actual state, and documents the
  retention rule below.
- **`AGENTS.md`** — same correction to "use `pnpm beads:worktrees:apply` only
  when it reports a complete repository maintenance transaction".

## The retention rule this also captures

A merged PR is **not** retention. A squash-merge leaves the branch's own commits
on no remote ref, so `git branch -r --contains <head>` is empty even though the
work shipped. Retiring on "the PR merged" alone can therefore be lossy — hit
while retiring `cave-g8n5v`, whose two commits existed only inside GitHub's PR
record for #4426. The docs now require proving a pushed archive tag first, and
warn that `git log @{u}..HEAD` is useless here: the upstream ref is gone, so it
errors and a naive `| wc -l` reports a reassuring `0`.

## Deliberately not changed

The AGENTS.md sentence pinned verbatim by
`branch-curator-manual-cleanup-contract.test.mjs` is left byte-identical. That
contract guards the automatic-versus-manual deletion boundary; the explanation
belongs in the unpinned bullet above it. I broke it first and reverted rather
than edit the guarded string.

## Verification

- `tsc --noEmit` clean
- new refusal exercised live against this checkout — output in the Bead
- `worktree-lifecycle-retirement`, `maintenance-gate`,
  `branch-curator-manual-cleanup-contract`, `beads-familiar-workflow`,
  `branch-to-merge-contract`, `worktree-lifecycle-create` all pass