### PR TITLE
ci: fail the build on committed merge-conflict markers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,11 +32,27 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
+      # Guard: no committed merge-conflict markers anywhere in the tree.
+      # 23316da3 landed two unresolved conflict blocks in a component; the file
+      # stopped parsing, every route 500'd, and main stayed broken until
+      # 4ea88862. Nothing in this workflow would have caught it — `git diff
+      # --check` runs only in release.yml, by which point the artifact is
+      # already on main. Per-file guards exist and are worth keeping, but they
+      # only protect files someone already thought to protect.
+      #
+      # Deliberately not a new job or a required context: an added context that
+      # does not report is how a PR ends up BLOCKED with nothing failing. It
+      # rides the existing static-check job and runs before install, since a
+      # tree with markers cannot lint or typecheck meaningfully — but after
+      # setup-node, so it runs on the pinned Node rather than whatever the
+      # runner image happens to ship.
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+
+      - run: node scripts/check-conflict-markers.mjs
 
       - run: pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",
     "check:beads-jsonl": "node scripts/check-beads-jsonl-duplicates.mjs",
+    "check:conflict-markers": "node scripts/check-conflict-markers.mjs",
     "test": "node scripts/run-tests.mjs app",
     "test:app": "node scripts/run-tests.mjs app",
     "test:api": "node scripts/run-tests.mjs api",

--- a/scripts/check-conflict-markers.mjs
+++ b/scripts/check-conflict-markers.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Repo-wide guard against committed merge-conflict markers.
+//
+// 23316da3 committed two unresolved conflict blocks into
+// src/components/sidebar-minimal.tsx. The file stopped parsing, so every route
+// 500'd — including /api/app/build-info — and main stayed broken until
+// 4ea88862 (cave-tbdnt / cave-2hh5q). Nothing in the PR gate saw it.
+//
+// The per-file guards that exist are worth keeping: they name the defect
+// precisely for the file they cover. But they only ever protect a file someone
+// already thought to protect, which by definition excludes the next file this
+// happens to. This is the repo-wide half.
+
+import { execFileSync } from "node:child_process";
+
+/**
+ * Only `<<<<<<<` and `>>>>>>>` trigger a failure, never a bare `=======`.
+ *
+ * Seven `<` or `>` at the start of a line is not something any language,
+ * markup, or comment style produces. Seven `=` at the start of a line is: it is
+ * a Markdown setext H1 underline, and it also shows up in ASCII rules and
+ * banner comments. A real conflict always carries an opening and a closing
+ * marker, so dropping the ambiguous one costs no detection while removing the
+ * whole false-positive class the bead warned about.
+ *
+ * Anchoring matters for the same reason — `=======` and `>>>>>>>` both appear
+ * mid-line in legitimate code, so an unanchored search is unusable.
+ */
+const MARKER_PATTERN = "^(<{7}|>{7})( |$)";
+
+/** Human-readable, so a failure explains itself without reading this file. */
+const MARKER_DESCRIPTION = "a line beginning with <<<<<<< or >>>>>>>";
+
+/**
+ * Parses `git grep -nz` output.
+ *
+ * `-z` replaces the `:` field separators with NUL; records stay newline
+ * terminated. It is worth the extra parsing because a path may legitimately
+ * contain a colon, and colon-splitting would silently mis-attribute the hit.
+ *
+ * An unparseable record throws rather than being skipped. A guard that quietly
+ * drops what it cannot read reports a clean tree for a dirty one, which is
+ * exactly how the first version of this file passed a fixture full of markers.
+ */
+export function parseMarkerHits(output) {
+  const hits = [];
+  for (const record of output.split("\n")) {
+    if (!record) continue;
+    const fields = record.split("\0");
+    if (fields.length < 3) {
+      throw new Error(`unparseable git grep record: ${JSON.stringify(record)}`);
+    }
+    const [file, rawLine, ...rest] = fields;
+    const line = Number.parseInt(rawLine, 10);
+    if (!Number.isInteger(line)) {
+      throw new Error(`unparseable git grep line number: ${JSON.stringify(record)}`);
+    }
+    hits.push({ file, line, text: rest.join("\0") });
+  }
+  return hits;
+}
+
+export function findConflictMarkers(cwd = process.cwd()) {
+  let output = "";
+  try {
+    output = execFileSync(
+      "git",
+      // -I skips binaries, so a stray byte sequence in an image cannot fail the
+      // build. -z keeps paths with spaces or newlines parseable.
+      ["grep", "-nIzE", MARKER_PATTERN, "--", "."],
+      { cwd, encoding: "utf8", maxBuffer: 32 * 1024 * 1024 },
+    );
+  } catch (error) {
+    // git grep exits 1 for "no matches", which is the healthy case. Anything
+    // else — not a repository, a bad pattern — must fail loudly rather than be
+    // read as a clean tree.
+    if (error && error.status === 1 && !error.stderr?.toString().trim()) return [];
+    throw error;
+  }
+  return parseMarkerHits(output);
+}
+
+function main() {
+  const hits = findConflictMarkers();
+  if (hits.length === 0) {
+    console.log("✓ no committed conflict markers");
+    return;
+  }
+  console.error(
+    `✗ committed merge-conflict markers in ${new Set(hits.map((hit) => hit.file)).size} file(s):`,
+  );
+  for (const hit of hits) {
+    console.error(`  ${hit.file}:${hit.line}: ${hit.text.trimEnd()}`);
+  }
+  console.error("");
+  console.error(`This check fails on ${MARKER_DESCRIPTION}.`);
+  console.error("Finish the merge, or remove the markers, then commit again.");
+  process.exit(1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) main();

--- a/scripts/check-conflict-markers.test.mjs
+++ b/scripts/check-conflict-markers.test.mjs
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { findConflictMarkers, parseMarkerHits } from "./check-conflict-markers.mjs";
+
+const CHECK = fileURLToPath(new URL("./check-conflict-markers.mjs", import.meta.url));
+
+function fixtureRepo(files) {
+  const root = mkdtempSync(path.join(tmpdir(), "conflict-marker-"));
+  execFileSync("git", ["init", "-q", "."], { cwd: root });
+  for (const [name, contents] of Object.entries(files)) {
+    const target = path.join(root, name);
+    mkdirSync(path.dirname(target), { recursive: true });
+    writeFileSync(target, contents);
+  }
+  execFileSync("git", ["add", "-A"], { cwd: root });
+  return root;
+}
+
+test("an unresolved conflict block is reported with file and line", () => {
+  const root = fixtureRepo({
+    "src/broken.ts": "const a = 1;\n<<<<<<< HEAD\nconst b = 2;\n=======\nconst b = 3;\n>>>>>>> other\n",
+  });
+  try {
+    const hits = findConflictMarkers(root);
+    assert.deepEqual(
+      hits.map((hit) => [hit.file, hit.line]),
+      [["src/broken.ts", 2], ["src/broken.ts", 6]],
+      "both the opening and closing marker are reported",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a clean tree reports nothing", () => {
+  const root = fixtureRepo({ "src/fine.ts": "const a = 1;\n" });
+  try {
+    assert.deepEqual(findConflictMarkers(root), []);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The whole reason this guard narrows to `<<<<<<<` and `>>>>>>>`: seven `=` at
+// the start of a line is a Markdown setext H1 underline, so a bare `=======`
+// cannot be a failure condition without breaking ordinary documentation.
+test("legitimate line-start text is not mistaken for a marker", () => {
+  const root = fixtureRepo({
+    "docs/page.md": "Title\n=======\n\nSetext H1 underlines are seven equals signs.\n",
+    "docs/rule.md": "Section\n=================================\n",
+    "src/quoted.ts": 'const opening = "<<<<<<<";\nconst closing = ">>>>>>>";\n',
+    "src/indented.ts": "function f() {\n  <<<<<<< not at line start\n}\n",
+    "src/arrows.ts": "const shifted = 1 >>>>>>> 2;\nconst compare = a <<<<<<< b;\n",
+  });
+  try {
+    assert.deepEqual(findConflictMarkers(root), [], "no false positive survives");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a marker with no trailing label still fails", () => {
+  const root = fixtureRepo({ "src/bare.ts": "<<<<<<<\nconst a = 1;\n>>>>>>>\n" });
+  try {
+    assert.deepEqual(
+      findConflictMarkers(root).map((hit) => hit.line),
+      [1, 3],
+      "git writes a label, but a hand-edited marker without one is still unresolved",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the CLI exits non-zero on a dirty tree and zero on a clean one", () => {
+  const dirty = fixtureRepo({ "a.ts": "<<<<<<< HEAD\n" });
+  const clean = fixtureRepo({ "a.ts": "const a = 1;\n" });
+  try {
+    assert.throws(
+      () => execFileSync(process.execPath, [CHECK], { cwd: dirty, stdio: "pipe" }),
+      (error) => error.status === 1,
+      "a gate that cannot fail is not a gate",
+    );
+    execFileSync(process.execPath, [CHECK], { cwd: clean, stdio: "pipe" });
+  } finally {
+    rmSync(dirty, { recursive: true, force: true });
+    rmSync(clean, { recursive: true, force: true });
+  }
+});
+
+// `git grep -z` separates path, line and text with NUL rather than `:`. The
+// first version of this checker split on `:` instead, matched nothing, and so
+// reported a clean tree for a fixture full of markers.
+test("NUL-separated records parse, and a malformed one throws rather than reporting clean", () => {
+  // A real NUL, written as an escape: a raw one makes this file read as
+  // binary to grep and to `git grep -I`, and `\0` before a digit is an
+  // octal escape that ESM rejects in strict mode.
+  const NUL = "\u0000";
+  assert.deepEqual(
+    parseMarkerHits(`src/a.ts${NUL}2${NUL}<<<<<<< HEAD\n`),
+    [{ file: "src/a.ts", line: 2, text: "<<<<<<< HEAD" }],
+  );
+  assert.deepEqual(
+    parseMarkerHits(`weird:name.ts${NUL}9${NUL}>>>>>>> x\n`)[0].file,
+    "weird:name.ts",
+    "a colon in the path must not be read as a field separator",
+  );
+  assert.throws(() => parseMarkerHits("src/a.ts:2:<<<<<<< HEAD\n"), /unparseable/);
+  assert.throws(() => parseMarkerHits(`src/a.ts${NUL}notanumber${NUL}x\n`), /unparseable/);
+});
+
+console.log("check-conflict-markers.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -59,6 +59,7 @@ export const SUITES = {
     "scripts/test-alias-loader.test.mjs",
     "scripts/maintenance-gate.test.mjs",
     "scripts/check-beads-jsonl-duplicates.test.mjs",
+    "scripts/check-conflict-markers.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",
     "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",


### PR DESCRIPTION
Closes `cave-rbs9o`.

## The gap

`23316da3` committed two unresolved conflict blocks into `src/components/sidebar-minimal.tsx`. The file stopped parsing, so **every route 500'd** — including `/api/app/build-info` — and `main` stayed broken until `4ea88862` repaired it.

Nothing in the PR gate would have caught it, and nothing did until now:

- `ci.yml` has no conflict-marker or `git diff --check` step. The only `conflict` hit in that file is `cargo test gui_conflict`, unrelated.
- `git diff --check` *does* run in `release.yml` at lines 234, 261 and 877 — but that is release time. By then the artifact is already on `main`.
- Existing coverage is per-file and incidental: `ios-chat-project-contract.test.mjs` asserts the iOS picker has no markers, and `cave-2hh5q` added the same guard plus an esbuild parse check for one component and its stylesheets.

Those per-file guards are worth keeping — they name the defect precisely for the file they cover — but they only ever protect a file someone already thought to protect, which by definition excludes the next file this happens to. This is the repo-wide half.

## What changed

`scripts/check-conflict-markers.mjs` runs `git grep -nIzE '^(<{7}|>{7})( |$)'` over tracked text files, wired as one step in the existing **Frontend lint & types** job.

Deliberately **not a new job or a required context**: an added context that never reports is precisely how a PR ends up `BLOCKED` with nothing failing. It runs after `setup-node` so it uses the pinned Node 24 rather than whatever the runner image ships, and before `pnpm install` since it needs none.

## Two departures from the bead's literal suggestion

**A bare `=======` does not fail the build.** The bead noted `=======` appears mid-line in legitimate CSS, which anchoring solves. But anchoring is necessary and not sufficient — seven `=` at the *start* of a line is a Markdown setext H1 underline, so an anchored `=======` check would fail on ordinary documentation. Seven `<` or `>` at line start is not something any language or markup produces, and a real conflict always carries both an opening and a closing marker, so dropping the ambiguous one costs no detection while removing the whole false-positive class.

**`git diff --check` against the merge base is not added.** It would import trailing-whitespace enforcement the repo has not opted into, and its conflict detection is weaker for this defect: it sees only added lines in a diff, whereas the failure mode here was markers sitting in the tree.

## A bug I shipped and caught

The first version of the checker reported a clean tree against a fixture full of markers. `git grep -z` separates path, line and text with **NUL**, not colons; the parser split on colons, matched nothing, and returned zero hits. A gate that cannot fail is worse than no gate — it manufactures confidence.

Fixed, and hardened against a repeat: an unparseable record now **throws** rather than being skipped, and *"the CLI exits non-zero on a dirty tree"* is an explicit test. The raw NUL that briefly ended up in the test source was also replaced with a six-character escape sequence — a literal NUL makes the file read as binary to `grep`, and would make this very check's `-I` flag skip it.

## Verification

- `node scripts/run-tests.mjs app` — 1138 files green; `api` — 357 files green.
- `tsc --noEmit` clean, `pnpm lint` clean, `check-tests-wired` confirms the new test is registered (1571 files).
- The gate passes on the current tree, so it does not land red.
- Six tests over throwaway git fixtures: detection with file and line, clean tree, the false-positive suite (setext headers, quoted markers, indented markers, shift operators), markers with no trailing label, CLI exit codes both ways, and NUL-record parsing including the malformed-record throw.

One note on the local runs: an initial `api` run failed on `harness-routing-codex-direct.test.ts` while a second `api` suite from a concurrent session was running. It passes standalone and on re-run. The only `run-tests.mjs` edit here is a single line inside the `app` array, which starts at line 24; `api` starts at 1164.
