### PR TITLE
test(e2e): wait for citation chips, not prose, before asserting on them

### DIFF
--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -165,6 +165,34 @@ async function openReader(page: Page, turn: TurnSpec) {
   await expect(page.locator(".cave-reader-doc .cave-md")).toContainText(marker.slice(0, 24), {
     timeout: 30_000,
   });
+
+  // ...and finally for the CITATION CHIPS, which the prose wait does not reach.
+  //
+  // Two separate steps produce them, and the prose wait only covers neither:
+  // the footnote pipeline rewrites `[^mdn]` into an `a[href^="#cite-"]`, and
+  // then a useEffect in ui/citation.tsx walks those anchors and adds
+  // `cave-citation-chip`. Measured on a cold server, at the instant the prose
+  // marker settles the document holds ZERO citation anchors — not undecorated
+  // ones, none at all. So prose-is-present is a proxy for a milestone it has
+  // not reached, and callers then assert on the result inside expect()'s
+  // default 5s window. That is the race that reds this spec: `toHaveCount(2)`
+  // read 0 with the prose fully rendered, twice on 2026-08-08 in unrelated PRs
+  // (cave-t69ok) — a second round on the cold-start race cave-n7wm5 hardened.
+  //
+  // Deriving the count from the fixture's own footnote definitions keeps this
+  // fixture-agnostic the way the prose wait is: BARE_ANSWER declares none, so
+  // the wait is skipped rather than hanging on a turn that never had chips.
+  // Counting undecorated anchors instead would be vacuous — with zero anchors
+  // present, "none are undecorated" is satisfied instantly and guards nothing.
+  const expectedCitations = new Set(
+    [...turn.text.matchAll(/^\[\^([^\]]+)\]:/gm)].map((match) => match[1]),
+  ).size;
+  if (expectedCitations > 0) {
+    await expect(page.locator(".cave-reader-doc .cave-md a.cave-citation-chip")).toHaveCount(
+      expectedCitations,
+      { timeout: 30_000 },
+    );
+  }
 }
 
 test("cited sources render as chips, with no footnote plumbing left in the prose", async ({ page }) => {

--- a/tests/reader.spec.ts
+++ b/tests/reader.spec.ts
@@ -168,7 +168,7 @@ async function openReader(page: Page, turn: TurnSpec) {
 
   // ...and finally for the CITATION CHIPS, which the prose wait does not reach.
   //
-  // Two separate steps produce them, and the prose wait only covers neither:
+  // Two separate steps produce them, and the prose wait covers neither:
   // the footnote pipeline rewrites `[^mdn]` into an `a[href^="#cite-"]`, and
   // then a useEffect in ui/citation.tsx walks those anchors and adds
   // `cave-citation-chip`. Measured on a cold server, at the instant the prose


### PR DESCRIPTION
Closes `cave-t69ok`.

## The flake

`tests/reader.spec.ts:170` — *"cited sources render as chips"* — failed twice on 2026-08-08 in two unrelated PRs, and passed on rerun both times:

- `main` push run `31272873956` (commit `78d5b17daf`, PR #4429 — daemon `address_in_use`)
- PR #4434 run `31277198252` (the conflict-marker CI gate, which touches only `scripts/` and `ci.yml`)

Because it lands on the commit immediately after a green one, it is indistinguishable from a regression until you re-run. Two sessions spent diagnosis time ruling their own change in or out.

## Root cause

`openReader` already waits for the prose to render — hardening added by `cave-n7wm5` for this same cold-start race. But **prose is a proxy for a milestone it does not reach.**

Two further steps produce a chip:

1. the footnote pipeline rewrites `[^mdn]` into an `a[href^="#cite-"]`, then
2. a `useEffect` in `src/components/ui/citation.tsx:252` walks those anchors and adds the `cave-citation-chip` class.

Callers then assert on the result of step 2 inside `expect()`'s **default 5s window**, not the 30s the prose wait used.

## Measured, not assumed

I instrumented `openReader` with a temporary probe (removed before commit) reporting the state at the exact instant the prose marker settles:

| server | citation anchors at prose-settle | chips | wait to 2 chips |
|---|---|---|---|
| cold (first run, 35s) | **0** | 0 | — |
| warm | 2 | 2 | 8ms |

On a cold server the document holds **zero** citation anchors at that moment — not undecorated ones, none at all. On a warm server the chips are already there. The gap is cold-specific, which is exactly the condition CI runs under: two parallel workers against a `next dev` that compiles routes on demand.

To be precise about the limits of that evidence: this shows the gap exists cold, not that it exceeds five seconds locally. The evidence it *can* is the two CI failures, both reading `Expected: 2, Received: 0` with the prose fully rendered.

## The fix

Wait for the chips themselves, with the same 30s budget the prose wait uses. The expected count is derived from the fixture's own footnote definitions, which keeps `openReader` fixture-agnostic in the way the prose wait already is — `BARE_ANSWER` declares none, so the wait is skipped rather than hanging on a turn that never had chips. All six cited callers benefit, not just the one that failed.

## A wrong first attempt, and why the measurement mattered

My first version waited for **zero undecorated anchors** (`a[href^="#cite-"]:not(.cave-citation-chip)`). It looks equivalent and is vacuous: with no anchors present at all, "none are undecorated" is satisfied instantly. It would have passed every run while guarding nothing — the same failure mode as a CI gate that can never fail. The probe is what caught it, and it is called out in the code comment so the next person does not re-derive it.

## Verification

- `tests/reader.spec.ts` — all 12 tests green locally on the `desktop` project, twice.
- `tsc --noEmit` clean.
- The first test still pays the cold compile (~54s observed), so the spec's existing 240s serial budget is unchanged and untouched.

No production code changes — this is test-only.
