### PR TITLE
feat(rooms): gate Role Surface rooms behind build feature flags (cave-u6pq0)

### DIFF
--- a/docs/role-surfaces.md
+++ b/docs/role-surfaces.md
@@ -15,6 +15,7 @@ vocation (an analyst's desk, an operations center, an archive…).
 | Generic host | `src/components/role-surface-host.tsx` | Looks the surface up, applies contributions (shortcuts, toolbar, status, notifications, commands), renders it inside room chrome |
 | Rooms | `src/components/role-surfaces/` | The registered surfaces themselves + `surface-room.tsx` layout primitives |
 | Manifest | `src/components/role-surfaces/register.tsx` | The ONE place initial rooms are named; code-split via `next/dynamic` |
+| Build visibility | `src/lib/room-flags.ts` | Which registered rooms a *build* may show (see below) |
 
 The shell (`workspace.tsx`, `sidebar-minimal.tsx`, `shell.tsx`) handles only
 the generic `surface:<id>` workspace mode. It never names a role —
@@ -24,13 +25,66 @@ the generic `surface:<id>` workspace mode. It never names a role —
 
 1. `workspace.tsx` imports the manifest for its side effect; every module that
    calls `registerRoleSurface` at import time appears identically.
-2. `useRoleSurfaceSession` builds one `RoleSurfaceContext` per active familiar
-   and resolves `resolveVisibleRoleSurfaces(listRoleSurfaces(), roleIds, ctx)`:
-   role match → `shouldDisplay` gate → priority sort.
+2. `useRoleSurfaceSession` filters the registry through `roomEnabledInBuild`
+   (build visibility, below), then resolves
+   `resolveVisibleRoleSurfaces(surfaces, roleIds, ctx)`: role match →
+   `shouldDisplay` gate → priority sort.
 3. Visible surfaces render as sidebar rows (the "Rooms" cluster) whose mode is
    `surface:<id>`; the detail pane routes that mode to `RoleSurfaceHost`.
 4. Room UI state survives switching surfaces and familiars via
    `useRoleSurfaceState(familiarId, surfaceId, initial)`.
+
+## Build visibility (which rooms ship)
+
+Registration says a room **exists**; `src/lib/room-flags.ts` says a build may
+**show** it. A room has to clear both, and then role matching, before anyone
+gets in. The registry stays open — this is a release gate, not an architecture
+change.
+
+A production build ships `PRODUCTION_ROOM_IDS`:
+
+| Room | Ships in production |
+| --- | --- |
+| Research Desk (`researcher-desk`) | ✅ |
+| Chart Room (`navigator-chart-room`) | ✅ |
+| Code Workshop (`code`) | dev only — under construction |
+| Review Deck (`reviewer-review-deck`) | dev only — under construction |
+| Writing Desk (`scribe-writing-desk`) | dev only — under construction |
+| Watchtower (`sentinel-watchtower`) | dev only — under construction |
+| Comms Operations (`messenger-ops`) | dev only — under construction |
+| The Archive (`indexer-archive`) | dev only — under construction |
+
+A **dev build shows every room**, so an unfinished room is fully workable; it
+joins the table's shipped half by moving its id into `PRODUCTION_ROOM_IDS`.
+
+Override the default for a build with `NEXT_PUBLIC_CAVE_ROOMS`:
+
+```bash
+NEXT_PUBLIC_CAVE_ROOMS=all                    # every registered room
+NEXT_PUBLIC_CAVE_ROOMS=researcher-desk,code   # exactly these two
+```
+
+When set, the variable is the **complete** allowlist — it replaces the default
+rather than adding to it, in both directions, so what a build shows is always
+readable off one value. Like every `NEXT_PUBLIC_*` flag it is inlined at build
+time, not read at runtime.
+
+Two consequences worth knowing:
+
+- The gate is applied once, in `useRoleSurfaceSession`, *before* role matching.
+  A room the build doesn't ship therefore has no sidebar row, no command-palette
+  entry, and no restorable `surface:<id>` mode — there is no consumer of
+  `visibleSurfaces` that can route around it.
+- Reaching such a room directly (a stored mode, a `?mode=` link) lands on
+  `RoleSurfaceHost`'s **"still under construction and isn't part of this
+  build"** panel rather than the role-mismatch one, and the Familiar Studio
+  Type picker appends the same sentence to a Type whose room is absent. A build
+  gate that reported itself as a role problem would send people to change roles
+  that were never the issue.
+
+Adding a room means adding its id to `KNOWN_ROOM_IDS` too;
+`src/lib/room-flags.test.ts` fails otherwise, so a new room cannot reach a
+production build merely by being registered.
 
 ## Role assignment
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -74,6 +74,7 @@ export const SUITES = {
     "src/components/workspace-canonical-memory-lazy-familiar.test.tsx",
     "src/lib/workspace-github-task-context.test.ts",
     "src/lib/role-surfaces.test.ts",
+    "src/lib/room-flags.test.ts",
     "src/lib/use-role-surfaces-loader.test.ts",
     "src/lib/familiar-types.test.ts",
     "src/lib/research-missions.test.ts",

--- a/src/components/familiar-studio-identity-tab.tsx
+++ b/src/components/familiar-studio-identity-tab.tsx
@@ -11,7 +11,8 @@ import {
   useFamiliarOverrides,
   type FamiliarOverride,
 } from "@/lib/cave-familiar-overrides";
-import { FAMILIAR_TYPES, parseFamiliarTypeIds } from "@/lib/familiar-types";
+import { FAMILIAR_TYPES, parseFamiliarTypeIds, type FamiliarTypeSpec } from "@/lib/familiar-types";
+import { roomEnabledInBuild } from "@/lib/room-flags";
 import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { FamiliarStudioLookTab } from "@/components/familiar-studio-look-tab";
@@ -236,6 +237,19 @@ function FamiliarGrimoireFiles({ familiarId }: { familiarId: string }) {
 }
 
 /**
+ * A type's unlock line. Every type still grants its role token, but a build
+ * that doesn't ship the promised room would otherwise leave the picker
+ * advertising a door that opens onto nothing — so say so here rather than let
+ * the user find out by clicking (`src/lib/room-flags.ts`).
+ */
+function familiarTypeHint(spec: FamiliarTypeSpec): string {
+  if (spec.roomId && !roomEnabledInBuild(spec.roomId)) {
+    return `${spec.description} That room is still under construction and isn't part of this build.`;
+  }
+  return spec.description;
+}
+
+/**
  * The explicit familiar Type picker (cave-cc5r / cave-gud8): a chip
  * checkbox-row over the static FAMILIAR_TYPES table. Multiple types may be
  * selected; the choice is stored comma-separated in the same `familiarType`
@@ -270,7 +284,7 @@ function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
               type="button"
               role="checkbox"
               aria-checked={isChecked}
-              title={t.description}
+              title={familiarTypeHint(t)}
               className={`focus-ring familiar-studio-type-chip${isChecked ? " familiar-studio-type-chip--active" : ""}`}
               onClick={() => {
                 if (t.id === "general") {
@@ -297,10 +311,10 @@ function FamiliarTypePicker({ familiar }: { familiar: ResolvedFamiliar }) {
         })}
       </div>
       {selectedIds.length === 0 ? (
-        <p className="familiar-studio-identity__hint">{FAMILIAR_TYPES[0].description}</p>
+        <p className="familiar-studio-identity__hint">{familiarTypeHint(FAMILIAR_TYPES[0])}</p>
       ) : (
         FAMILIAR_TYPES.filter((s) => selectedIds.includes(s.id)).map((s) => (
-          <p key={s.id} className="familiar-studio-identity__hint">{s.description}</p>
+          <p key={s.id} className="familiar-studio-identity__hint">{familiarTypeHint(s)}</p>
         ))
       )}
     </div>

--- a/src/components/role-surface-host.tsx
+++ b/src/components/role-surface-host.tsx
@@ -9,6 +9,10 @@
  * actions, status indicators, notifications, commands) and renders it inside
  * the room chrome. The Cave shell never branches on a specific role — every
  * role-specific behavior lives behind this one component.
+ *
+ * Two gates decide whether the room opens, and the closed door names the one
+ * that closed it: `src/lib/room-flags.ts` says whether this BUILD ships the
+ * room at all, and role matching says whether this FAMILIAR holds it.
  */
 
 import { Component, useEffect, useMemo, useRef, type ReactNode } from "react";
@@ -22,6 +26,7 @@ import {
   type RoleSurfaceContext,
   type RoleSurfaceContribution,
 } from "@/lib/role-surfaces";
+import { roomEnabledInBuild } from "@/lib/room-flags";
 import { useRoleSurfaceStateSnapshot } from "@/lib/role-surface-state";
 
 /** A broken surface must never take the shell down with it. */
@@ -68,6 +73,10 @@ export function RoleSurfaceHost({
   onLeave: () => void;
 }) {
   const surface = getRoleSurface(surfaceId);
+  // A room this build doesn't ship is registered and role-matchable but never
+  // reaches `visibleSurfaces`. Distinguish it so the closed door tells the
+  // truth — "under construction" rather than "you lack the role".
+  const shippedInBuild = surface != null && roomEnabledInBuild(surface.id);
   const available = surface != null && context != null && visibleSurfaces.some((s) => s.id === surface.id);
   const roleStateSnapshot = useRoleSurfaceStateSnapshot(
     context?.activeFamiliar.id ?? null,
@@ -121,6 +130,20 @@ export function RoleSurfaceHost({
   }
 
   if (!available) {
+    // A build that doesn't ship the room is a settled fact — it needs no role
+    // manifest to decide, so say so immediately rather than waiting on a load
+    // that cannot change the answer.
+    if (surface && !shippedInBuild) {
+      return (
+        <div className="role-surface-unavailable">
+          <Icon name="ph:hammer" width={22} height={22} aria-hidden />
+          <p>{surface.title} is still under construction and isn't part of this build.</p>
+          <button type="button" className="role-surface-chip focus-ring" onClick={onLeave}>
+            Back to the Cave
+          </button>
+        </div>
+      );
+    }
     // While role manifests are still loading, hold judgment quietly instead of
     // flashing "unavailable" for a room that's about to resolve.
     if (!rolesLoaded) return <div className="role-surface-unavailable" aria-busy="true" />;

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -52,17 +52,21 @@ export type FamiliarTypeSpec = {
   /** The role token this type grants (matched against RoleSurface.role /
    *  aliases after normalizeRoleId). Null for General — no room. */
   roleToken: string | null;
+  /** The Role Surface id this type unlocks (`role-surfaces/ids.ts`), or null
+   *  for General. Named here so a surface can tell the user when the room a
+   *  type promises isn't in this build — see `src/lib/room-flags.ts`. */
+  roomId: string | null;
   /** One-line unlock description shown under the Identity-tab picker. */
   description: string;
   iconName: IconName;
 };
 
 export const FAMILIAR_TYPES: readonly FamiliarTypeSpec[] = [
-  { id: "general", label: "General", roleToken: null, description: "No dedicated room — every shared surface, nothing extra.", iconName: "ph:sparkle" },
-  { id: "coding", label: "Coding", roleToken: "coder", description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
-  { id: "research", label: "Research", roleToken: "researcher", description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
-  { id: "review", label: "Review", roleToken: "reviewer", description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
-  { id: "comms", label: "Comms", roleToken: "messenger", description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
+  { id: "general", label: "General", roleToken: null, roomId: null, description: "No dedicated room — every shared surface, nothing extra.", iconName: "ph:sparkle" },
+  { id: "coding", label: "Coding", roleToken: "coder", roomId: "code", description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
+  { id: "research", label: "Research", roleToken: "researcher", roomId: "researcher-desk", description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
+  { id: "review", label: "Review", roleToken: "reviewer", roomId: "reviewer-review-deck", description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
+  { id: "comms", label: "Comms", roleToken: "messenger", roomId: "messenger-ops", description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
 ];
 
 /** The explicit default: a familiar with no stored type is General. */

--- a/src/lib/familiar-types.ts
+++ b/src/lib/familiar-types.ts
@@ -22,6 +22,12 @@
  */
 
 import type { IconName } from "./icon.tsx";
+import {
+  CODE_SURFACE_ID,
+  MESSENGER_SURFACE_ID,
+  RESEARCHER_SURFACE_ID,
+  REVIEWER_SURFACE_ID,
+} from "../components/role-surfaces/ids.ts";
 
 export type FamiliarTypeId =
   | "general"
@@ -63,10 +69,10 @@ export type FamiliarTypeSpec = {
 
 export const FAMILIAR_TYPES: readonly FamiliarTypeSpec[] = [
   { id: "general", label: "General", roleToken: null, roomId: null, description: "No dedicated room — every shared surface, nothing extra.", iconName: "ph:sparkle" },
-  { id: "coding", label: "Coding", roleToken: "coder", roomId: "code", description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
-  { id: "research", label: "Research", roleToken: "researcher", roomId: "researcher-desk", description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
-  { id: "review", label: "Review", roleToken: "reviewer", roomId: "reviewer-review-deck", description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
-  { id: "comms", label: "Comms", roleToken: "messenger", roomId: "messenger-ops", description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
+  { id: "coding", label: "Coding", roleToken: "coder", roomId: CODE_SURFACE_ID, description: "Unlocks the Code room — multi-session coding with diffs, files, branches, worktrees, and GitHub.", iconName: "ph:code" },
+  { id: "research", label: "Research", roleToken: "researcher", roomId: RESEARCHER_SURFACE_ID, description: "Unlocks the Research Desk — bounded missions, evidence, and durable knowledge artifacts.", iconName: "ph:detective" },
+  { id: "review", label: "Review", roleToken: "reviewer", roomId: REVIEWER_SURFACE_ID, description: "Unlocks the Review Deck — queued change reviews with verdicts and notes.", iconName: "ph:git-branch" },
+  { id: "comms", label: "Comms", roleToken: "messenger", roomId: MESSENGER_SURFACE_ID, description: "Unlocks Comms Operations — outbound and inbound communication across channels.", iconName: "ph:paper-plane-tilt" },
 ];
 
 /** The explicit default: a familiar with no stored type is General. */

--- a/src/lib/room-flags.test.ts
+++ b/src/lib/room-flags.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  KNOWN_ROOM_IDS,
+  PRODUCTION_ROOM_IDS,
+  filterEnabledRoomIds,
+  parseRoomsSetting,
+  resolveRoomVisibility,
+  type RoomVisibilityEnv,
+} from "./room-flags.ts";
+import { FAMILIAR_TYPES } from "./familiar-types.ts";
+
+const CODE = "code";
+const RESEARCH = "researcher-desk";
+const CHART = "navigator-chart-room";
+
+const repoFile = (relative: string) =>
+  readFileSync(fileURLToPath(new URL(`../../${relative}`, import.meta.url)), "utf8");
+
+const dev: RoomVisibilityEnv = { production: false };
+const prod: RoomVisibilityEnv = { production: true };
+
+test("a production build ships the Research Desk and the Chart Room, and nothing else", () => {
+  assert.deepEqual([...PRODUCTION_ROOM_IDS], [RESEARCH, CHART]);
+  const shown = filterEnabledRoomIds(prod, KNOWN_ROOM_IDS);
+  assert.deepEqual(shown, [RESEARCH, CHART], "unfinished rooms stay out of production");
+});
+
+test("a dev build shows every registered room, including the Coding familiar's", () => {
+  assert.deepEqual(filterEnabledRoomIds(dev, KNOWN_ROOM_IDS), [...KNOWN_ROOM_IDS]);
+  assert.equal(resolveRoomVisibility(dev)(CODE), true, "the Coding Room is workable in dev");
+  assert.equal(resolveRoomVisibility(prod)(CODE), false, "…and under construction in production");
+});
+
+test("an unset or blank NEXT_PUBLIC_CAVE_ROOMS falls back to the build default", () => {
+  for (const rooms of [undefined, null, "", "   ", ",", " , ,"]) {
+    assert.equal(parseRoomsSetting(rooms), null, `blank setting: ${JSON.stringify(rooms)}`);
+    assert.equal(resolveRoomVisibility({ production: true, rooms })(CODE), false);
+    assert.equal(resolveRoomVisibility({ production: false, rooms })(CODE), true);
+  }
+});
+
+test("NEXT_PUBLIC_CAVE_ROOMS=all opens every room, in production too", () => {
+  for (const rooms of ["all", "ALL", " all ", "*", "code,all"]) {
+    assert.deepEqual(parseRoomsSetting(rooms), { kind: "all" }, `all setting: ${rooms}`);
+    assert.deepEqual(filterEnabledRoomIds({ production: true, rooms }, KNOWN_ROOM_IDS), [
+      ...KNOWN_ROOM_IDS,
+    ]);
+  }
+});
+
+test("an explicit list is the complete allowlist — it replaces the default both ways", () => {
+  const widened: RoomVisibilityEnv = { production: true, rooms: "researcher-desk, code" };
+  assert.deepEqual(filterEnabledRoomIds(widened, KNOWN_ROOM_IDS), [RESEARCH, CODE]);
+  assert.equal(
+    resolveRoomVisibility(widened)(CHART),
+    false,
+    "naming rooms drops the defaults it didn't name",
+  );
+
+  const narrowed: RoomVisibilityEnv = { production: false, rooms: "navigator-chart-room" };
+  assert.deepEqual(filterEnabledRoomIds(narrowed, KNOWN_ROOM_IDS), [CHART]);
+  assert.equal(resolveRoomVisibility(narrowed)(CODE), false, "a dev build can narrow too");
+});
+
+test("an unknown id opens no room rather than everything", () => {
+  const env: RoomVisibilityEnv = { production: true, rooms: "not-a-room" };
+  assert.deepEqual(filterEnabledRoomIds(env, KNOWN_ROOM_IDS), []);
+});
+
+test("ids are matched case-insensitively and tolerate ragged separators", () => {
+  const env: RoomVisibilityEnv = { production: true, rooms: " Code ,, NAVIGATOR-CHART-ROOM ," };
+  assert.deepEqual(filterEnabledRoomIds(env, KNOWN_ROOM_IDS), [CHART, CODE]);
+});
+
+// ── The lists stay honest ────────────────────────────────────────────────────
+
+test("every room register.tsx registers is classified in KNOWN_ROOM_IDS", () => {
+  const ids = repoFile("src/components/role-surfaces/ids.ts");
+  const register = repoFile("src/components/role-surfaces/register.tsx");
+
+  const constantToId = new Map<string, string>();
+  for (const [, name, value] of ids.matchAll(/export const (\w+) = "([^"]+)";/g)) {
+    constantToId.set(name, value);
+  }
+  const registered = [...register.matchAll(/registerRoleSurface\(\{\s*id: (\w+),/g)].map(
+    ([, constant]) => {
+      const id = constantToId.get(constant);
+      assert.ok(id, `${constant} is exported from ids.ts`);
+      return id;
+    },
+  );
+
+  assert.ok(registered.length > 0, "register.tsx registers rooms by id constant");
+  assert.deepEqual(
+    [...registered].sort(),
+    [...KNOWN_ROOM_IDS].sort(),
+    "a new room must be classified in room-flags.ts before it can reach a build",
+  );
+});
+
+test("PRODUCTION_ROOM_IDS only names rooms that exist", () => {
+  for (const id of PRODUCTION_ROOM_IDS) {
+    assert.ok(KNOWN_ROOM_IDS.includes(id), `${id} is a registered room`);
+  }
+});
+
+test("every familiar Type points at a room that exists", () => {
+  for (const spec of FAMILIAR_TYPES) {
+    if (spec.roleToken == null) {
+      assert.equal(spec.roomId, null, `${spec.id} unlocks no room, so it names none`);
+      continue;
+    }
+    assert.ok(spec.roomId, `${spec.id} names the room it unlocks`);
+    assert.ok(KNOWN_ROOM_IDS.includes(spec.roomId!), `${spec.id} → ${spec.roomId} is a real room`);
+  }
+});
+
+test("the Studio Type picker says so when a build doesn't ship the promised room", () => {
+  const picker = repoFile("src/components/familiar-studio-identity-tab.tsx");
+  assert.match(
+    picker,
+    /if \(spec\.roomId && !roomEnabledInBuild\(spec\.roomId\)\) \{[\s\S]{0,200}?still under construction and isn't part of this build\./,
+  );
+  assert.match(picker, /title=\{familiarTypeHint\(t\)\}/, "the chip tooltip is honest");
+  assert.match(picker, /\{familiarTypeHint\(s\)\}/, "and so is the selected-type hint");
+});
+
+// ── The Coding familiar's room stays registered ──────────────────────────────
+
+test("the Coding familiar's room is registered for the coder role", () => {
+  const register = repoFile("src/components/role-surfaces/register.tsx");
+  assert.match(
+    register,
+    /id: CODE_SURFACE_ID,\s*role: "coder",/,
+    "the Code room is registered under the coder role",
+  );
+  assert.match(register, /render: \(context\) => <CodeRoom context=\{context\} \/>/);
+
+  const types = repoFile("src/lib/familiar-types.ts");
+  assert.match(
+    types,
+    /id: "coding",[^}]*roleToken: "coder"/,
+    "the Coding familiar Type still grants the coder role token",
+  );
+});
+
+// ── The gate is applied where it can't be routed around ──────────────────────
+
+test("build visibility filters the registry at the single visibleSurfaces choke point", () => {
+  const hook = repoFile("src/lib/use-role-surfaces.ts");
+  assert.match(hook, /import \{ roomEnabledInBuild \} from "@\/lib\/room-flags";/);
+  assert.match(
+    hook,
+    /listRoleSurfaces\(\)\.filter\(\(surface\) => roomEnabledInBuild\(surface\.id\)\)/,
+    "rooms are filtered before role matching, so no consumer of visibleSurfaces can miss it",
+  );
+});
+
+test("a room this build doesn't ship reads as under construction, not as a role mismatch", () => {
+  const host = repoFile("src/components/role-surface-host.tsx");
+  assert.match(host, /const shippedInBuild = surface != null && roomEnabledInBuild\(surface\.id\);/);
+  assert.match(
+    host,
+    /if \(surface && !shippedInBuild\) \{[\s\S]{0,400}?is still under construction and isn't part of this build\./,
+  );
+  const constructionAt = host.indexOf("still under construction");
+  const roleMismatchAt = host.indexOf("doesn't hold the ");
+  assert.ok(constructionAt > 0 && roleMismatchAt > 0);
+  assert.ok(
+    constructionAt < roleMismatchAt,
+    "the build gate answers first — a role manifest can't change its verdict",
+  );
+});

--- a/src/lib/room-flags.ts
+++ b/src/lib/room-flags.ts
@@ -1,0 +1,136 @@
+/**
+ * room-flags — which registered rooms a *build* is allowed to show.
+ *
+ * The Role Surface registry is deliberately open: any module can call
+ * `registerRoleSurface` and its room appears (see `docs/role-surfaces.md`).
+ * That is the right shape for the architecture and the wrong shape for a
+ * release, because a room can be registered long before it is finished. This
+ * module is the second gate — registration says a room *exists*, this says a
+ * build may *show* it. Role matching still decides whether a given familiar
+ * gets in; a room has to clear both.
+ *
+ * Production ships only the rooms that are done — the Research Desk and the
+ * Chart Room. Every other room stays registered and fully workable in a dev
+ * build, and joins `PRODUCTION_ROOM_IDS` when it is ready.
+ *
+ * Escape hatch: `NEXT_PUBLIC_CAVE_ROOMS` overrides the default for a build.
+ *
+ *   NEXT_PUBLIC_CAVE_ROOMS=all                    every registered room
+ *   NEXT_PUBLIC_CAVE_ROOMS=researcher-desk,code   exactly those two
+ *
+ * The variable, when set, is the COMPLETE allowlist — it replaces the default
+ * rather than adding to it, in both directions, so what a build shows is
+ * always readable off one value. Ids are the registry ids in
+ * `src/components/role-surfaces/ids.ts`.
+ *
+ * Kept free of JSX and of the component registry so the rules are unit-testable
+ * under plain `node --experimental-strip-types`.
+ */
+
+import {
+  CODE_SURFACE_ID,
+  INDEXER_SURFACE_ID,
+  MESSENGER_SURFACE_ID,
+  NAVIGATOR_SURFACE_ID,
+  RESEARCHER_SURFACE_ID,
+  REVIEWER_SURFACE_ID,
+  SCRIBE_SURFACE_ID,
+  SENTINEL_SURFACE_ID,
+  // Relative + extensioned, like role-surfaces.ts's own imports, so the rules
+  // stay runnable under bare `node --experimental-strip-types`.
+} from "../components/role-surfaces/ids.ts";
+
+/**
+ * Every room the manifest registers. Listing them here is what makes adding a
+ * room a deliberate release decision: `room-flags.test.ts` fails when
+ * `register.tsx` registers an id this list doesn't carry, so a new room can't
+ * reach a production build just by existing.
+ */
+export const KNOWN_ROOM_IDS: readonly string[] = [
+  RESEARCHER_SURFACE_ID,
+  NAVIGATOR_SURFACE_ID,
+  CODE_SURFACE_ID,
+  REVIEWER_SURFACE_ID,
+  SCRIBE_SURFACE_ID,
+  SENTINEL_SURFACE_ID,
+  MESSENGER_SURFACE_ID,
+  INDEXER_SURFACE_ID,
+];
+
+/**
+ * The rooms a production build shows. The rest are under construction — they
+ * stay registered, stay reachable in a dev build, and move up here one at a
+ * time as they land.
+ */
+export const PRODUCTION_ROOM_IDS: readonly string[] = [
+  RESEARCHER_SURFACE_ID,
+  NAVIGATOR_SURFACE_ID,
+];
+
+/** The inputs that decide room visibility for a build. */
+export type RoomVisibilityEnv = {
+  /** True for a production build (`NODE_ENV === "production"`). */
+  production: boolean;
+  /** Raw `NEXT_PUBLIC_CAVE_ROOMS`; absent/blank means "use the default". */
+  rooms?: string | null | undefined;
+};
+
+/** An explicit operator override, or null when the build default applies. */
+export type RoomAllowlist = { kind: "all" } | { kind: "list"; ids: ReadonlySet<string> };
+
+/**
+ * Parse `NEXT_PUBLIC_CAVE_ROOMS`. Returns null when the variable is absent or
+ * blank, which means "fall back to the build default" — an operator who has
+ * not spoken is not the same as one who asked for nothing.
+ */
+export function parseRoomsSetting(raw: string | null | undefined): RoomAllowlist | null {
+  const tokens = (raw ?? "")
+    .split(",")
+    .map((token) => token.trim().toLowerCase())
+    .filter(Boolean);
+  if (tokens.length === 0) return null;
+  if (tokens.includes("all") || tokens.includes("*")) return { kind: "all" };
+  return { kind: "list", ids: new Set(tokens) };
+}
+
+/**
+ * The visibility predicate for a build: explicit override first, then a
+ * dev build (everything), then the production allowlist.
+ */
+export function resolveRoomVisibility(env: RoomVisibilityEnv): (roomId: string) => boolean {
+  const override = parseRoomsSetting(env.rooms);
+  if (override) {
+    if (override.kind === "all") return () => true;
+    const { ids } = override;
+    return (roomId) => ids.has(roomId);
+  }
+  if (!env.production) return () => true;
+  const shipped = new Set(PRODUCTION_ROOM_IDS);
+  return (roomId) => shipped.has(roomId);
+}
+
+/** The room ids a build shows, in the order given. */
+export function filterEnabledRoomIds(
+  env: RoomVisibilityEnv,
+  roomIds: readonly string[],
+): string[] {
+  const enabled = resolveRoomVisibility(env);
+  return roomIds.filter(enabled);
+}
+
+/**
+ * This build's environment. Both reads are literal `process.env.X` member
+ * accesses on purpose — that is the only form Next inlines into the client
+ * bundle, and a computed lookup would silently resolve to undefined there.
+ */
+export function buildRoomVisibilityEnv(): RoomVisibilityEnv {
+  return {
+    production: process.env.NODE_ENV === "production",
+    rooms: process.env.NEXT_PUBLIC_CAVE_ROOMS,
+  };
+}
+
+/** Does this build show the room? Registration and role matching still apply. */
+export function roomEnabledInBuild(roomId: string): boolean {
+  return resolveRoomVisibility(buildRoomVisibilityEnv())(roomId);
+}

--- a/src/lib/room-flags.ts
+++ b/src/lib/room-flags.ts
@@ -130,7 +130,20 @@ export function buildRoomVisibilityEnv(): RoomVisibilityEnv {
   };
 }
 
+/**
+ * Both inputs are build-time constants Next inlines into the bundle, so the
+ * predicate cannot change while the app runs — resolve it once rather than
+ * re-reading the env, re-splitting the setting and re-allocating a Set on
+ * every call. It is called per room per render (the surface filter), and again
+ * per Type chip in Familiar Studio.
+ *
+ * Tests exercise `resolveRoomVisibility` directly with an explicit env, which
+ * is why this cache never needs a reset hook.
+ */
+let buildRoomVisibility: ((roomId: string) => boolean) | null = null;
+
 /** Does this build show the room? Registration and role matching still apply. */
 export function roomEnabledInBuild(roomId: string): boolean {
-  return resolveRoomVisibility(buildRoomVisibilityEnv())(roomId);
+  buildRoomVisibility ??= resolveRoomVisibility(buildRoomVisibilityEnv());
+  return buildRoomVisibility(roomId);
 }

--- a/src/lib/use-role-surfaces.ts
+++ b/src/lib/use-role-surfaces.ts
@@ -24,6 +24,7 @@ import {
   type SurfaceMemoryEntry,
   type ToolRegistry,
 } from "@/lib/role-surfaces";
+import { roomEnabledInBuild } from "@/lib/room-flags";
 
 /** `/api/roles` entry fields this bridge consumes. */
 type RoleEntryWire = FamiliarRoleManifest & {
@@ -362,7 +363,10 @@ export function useRoleSurfaceSession(input: {
     ? contextsByFamiliarId.get(familiar.id) ?? null
     : null;
   const { visibleSurfaces, surfaceFamiliarIds } = useMemo(() => {
-    const surfaces = listRoleSurfaces();
+    // Build visibility is the outer gate: a room registered but not shipped in
+    // this build never reaches role matching, so it appears in no sidebar row,
+    // no command-palette entry, and no restored `surface:<id>` mode.
+    const surfaces = listRoleSurfaces().filter((surface) => roomEnabledInBuild(surface.id));
     const visibleById = new Map<string, RoleSurface>();
     const owners = new Map<string, string[]>();
     for (const candidate of candidateFamiliars) {


### PR DESCRIPTION
Registration says a room **exists**; nothing said whether a build should **show**
it. So every registered room shipped, finished or not. This adds the second
gate: `src/lib/room-flags.ts`.

A production build ships the rooms that are done — **Research Desk** and
**Chart Room**. Every other room stays registered and fully workable in a dev
build, and joins `PRODUCTION_ROOM_IDS` when it lands.

## On the Coding room

The Coding familiar's room was never removed — it is registered as `code`
("Code Workshop") and was rebuilt six commits ago in #4423. Rather than
re-introduce something that was already there, this pins it: `room-flags.test.ts`
now fails if `register.tsx` stops registering it under the `coder` role, or if
the Coding familiar Type stops granting that token. It is dev-visible today and
production-gated with the rest of the under-construction set.

## The gate

- Applied **once**, in `useRoleSurfaceSession`, *before* role matching — so a
  room this build doesn't ship has no sidebar row, no command-palette entry and
  no restorable `surface:<id>` mode. There is no consumer of `visibleSurfaces`
  that can route around it.
- `NEXT_PUBLIC_CAVE_ROOMS` overrides the default for a build:
  `all` opens everything; a comma list is the **complete** allowlist (it
  replaces the default in both directions, so what a build shows is readable
  off one value). Inlined at build time like every `NEXT_PUBLIC_*` flag.
- Adding a room means adding its id to `KNOWN_ROOM_IDS`; the test fails
  otherwise, so a new room cannot reach production merely by being registered.

## Honesty at the closed door

A build gate that reported itself as a role problem would send people to change
roles that were never the issue. So:

- `RoleSurfaceHost` shows **"… is still under construction and isn't part of
  this build."** rather than "doesn't hold the *X* role", and answers
  immediately — no role manifest can change that verdict.
- The Familiar Studio Type picker appends the same sentence to a Type whose room
  is absent, instead of advertising a door that opens onto nothing.
  `FamiliarTypeSpec` gained a `roomId` so the picker can tell.

## Verification

- `src/lib/room-flags.test.ts` — 14 cases: the production set, dev showing
  everything, blank/`all`/list/unknown-id parsing, case and separator handling,
  plus source pins on the choke point, the host copy, the picker copy, the
  registry↔`KNOWN_ROOM_IDS` agreement and the Coding room's registration.
- Real browser, live server, production allowlist simulated
  (`NEXT_PUBLIC_CAVE_ROOMS=researcher-desk,navigator-chart-room`): a coding
  familiar at `?mode=code` gets the under-construction panel and no sidebar row;
  a research familiar's Research Desk still opens. (Scratch spec, not committed.)
- `pnpm typecheck`, `pnpm lint`, `pnpm check:tests-wired`, `pnpm test:app`,
  `pnpm build` (bundle + standalone budgets green).
