### PR TITLE
ci(ios): compile the Swift app on macOS, gated by change detection (cave-kwv57)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,3 +575,114 @@ jobs:
             exit 1
           fi
           echo "Sidecar runtime matrix passed on ubuntu-latest and windows-latest, and Windows native tests passed."
+
+  # ── iOS ─────────────────────────────────────────────────────────────────────
+  # The Swift app is compiled NOWHERE in CI. Verified across every workflow:
+  # ci.yml builds the web app and the Rust shell, and release.yml's macOS
+  # runners build the desktop Tauri bundle — neither touches apps/ios. The only
+  # things reading Swift are source-TEXT assertions (scripts/ios-*.test.mjs and
+  # several src/** tests), and a regex matches perfectly well inside a file no
+  # compiler accepts.
+  #
+  # That is not hypothetical here. 398b18b left a ChatProjectPicker call closed
+  # with '}' instead of ')', plus a memberwise-init argument-order mismatch, and
+  # it survived THREE DAYS and every PR in between (cave-kwv57, found while
+  # cutting v0.2.4). Measured against that exact defect pair while building this:
+  #
+  #   swiftc -parse   catches the '}' — misses the argument order
+  #   xcodebuild      catches BOTH ("argument 'familiarIds' must precede …")
+  #
+  # so only a real build closes the gap parse-only would leave half-open.
+  #
+  # WHY THIS IS GATED rather than always-on: macOS runners were pulled from the
+  # conformance matrix above because GitHub-hosted macOS minutes exhausted the
+  # org Actions limit and queued indefinitely, stalling EVERY required check.
+  # An unconditional macOS leg risks repeating that outage. So a cheap Linux job
+  # decides first, and macOS only spins when something that can actually affect
+  # the Swift build changed. Most PRs touch no iOS path and pay nothing.
+  #
+  # Deliberately NOT a required status check, and deliberately skippable: a
+  # required context that does not report is exactly how a PR ends up BLOCKED
+  # with nothing failing (see CLAUDE.md). This is advisory until the macOS
+  # budget question is settled — a red X here still means the app is broken.
+  ios-changed:
+    name: iOS change detection
+    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ios: ${{ steps.detect.outputs.ios }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          # The three-dot diff below needs the merge base, which a shallow
+          # clone does not have.
+          fetch-depth: 0
+
+      - id: detect
+        name: Decide whether the iOS build must run
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          # push to main and manual recovery runs always build: main staying
+          # honest matters more than the minutes, and neither has a base ref to
+          # diff against.
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+            echo "$EVENT run — building unconditionally."
+            exit 0
+          fi
+          changed="$(git diff --name-only "origin/${BASE}...HEAD")"
+          # Everything that can change what xcodebuild compiles or embeds:
+          # the Swift and project.yml under apps/ios, the generator scripts
+          # whose output is baked into the bundle, and this workflow itself.
+          if printf '%s\n' "$changed" | grep -qE '^(apps/ios/|scripts/ios-|scripts/build-ios-|\.github/workflows/ci\.yml$)'; then
+            echo "ios=true" >> "$GITHUB_OUTPUT"
+            echo "iOS-affecting paths changed:"
+            printf '%s\n' "$changed" | grep -E '^(apps/ios/|scripts/ios-|scripts/build-ios-|\.github/workflows/ci\.yml$)'
+          else
+            echo "ios=false" >> "$GITHUB_OUTPUT"
+            echo "No iOS-affecting paths changed — skipping the macOS build."
+          fi
+
+  ios-build:
+    name: iOS build
+    needs: ios-changed
+    if: needs.ios-changed.outputs.ios == 'true'
+    runs-on: macos-latest
+    # Measured locally on Apple silicon: xcodegen 2s, xcodebuild 56s. A cold
+    # hosted runner also pays checkout + pnpm install + brew, so this is well
+    # above 3x the expected p95 — generous on purpose, because a hung macOS job
+    # burns minutes at 10x while it hangs.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+
+      # scripts/ios-xcodegen.sh inlines vendored assets from node_modules into
+      # the embedded markdown/terminal bundles, so it hard-fails without a
+      # populated install rather than shipping a blank web view (cave-d8ma3).
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install xcodegen
+        run: brew install xcodegen
+
+      # Generates CovenCave.xcodeproj. Never run `xcodegen generate` directly:
+      # the script builds and PROVES the web bundles exist before the scan,
+      # because xcodegen scans the source tree and a missing bundle otherwise
+      # produces a project that builds clean and ships a dead terminal.
+      - name: Generate the Xcode project
+        run: bash scripts/ios-xcodegen.sh
+
+      # CODE_SIGNING_ALLOWED=NO because this proves the code COMPILES; signing
+      # identities belong to the release pipeline, not to a PR check.
+      - name: Build the iOS app
+        working-directory: apps/ios/CovenCave
+        run: xcodebuild -scheme CovenCave -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build

--- a/scripts/ios-build-ci.test.mjs
+++ b/scripts/ios-build-ci.test.mjs
@@ -35,9 +35,12 @@ assert.match(
 // the wrapper builds and PROVES the embedded web bundles exist before the scan,
 // because xcodegen scans the tree and a missing bundle otherwise yields a
 // project that builds clean and ships a blank markdown view (cave-d8ma3).
+// Anchored to a real `run:` step for the same reason as the xcodebuild check
+// above — an unanchored match is satisfied by the comment four lines up, which
+// is precisely the mistake that check was already rewritten to avoid.
 assert.match(
   workflow,
-  /bash scripts\/ios-xcodegen\.sh/,
+  /^ +run: bash scripts\/ios-xcodegen\.sh$/m,
   "the project is generated through the wrapper that proves the web bundles exist first",
 );
 assert.doesNotMatch(

--- a/scripts/ios-build-ci.test.mjs
+++ b/scripts/ios-build-ci.test.mjs
@@ -1,0 +1,95 @@
+// The iOS build leg must keep existing, and must keep being reachable.
+//
+// Every other ios-*.test.mjs in this suite reads Swift as SOURCE TEXT. That is
+// useful for pinning contracts, but a regex matches perfectly well inside a
+// file no compiler accepts — so none of them can tell a broken build from a
+// working one. 398b18b proved it: a ChatProjectPicker call closed with '}'
+// instead of ')', plus a memberwise-init argument-order mismatch, survived
+// three days and every PR in between because nothing in any workflow compiled
+// the app (cave-kwv57).
+//
+// ci.yml now has a macOS leg that does. This guards the two ways it could
+// quietly stop protecting anything: the job being removed, or its change
+// detection being narrowed until it never fires on a Swift edit.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+
+// ── The job exists and actually compiles ────────────────────────────────────
+assert.match(workflow, /^ {2}ios-build:$/m, "ci.yml defines the iOS build job");
+assert.match(
+  workflow,
+  /ios-build:[\s\S]{0,400}runs-on: macos-latest/,
+  "the iOS build runs on macOS — xcodebuild cannot run anywhere else",
+);
+// Anchored to a real `run:` step, NOT merely present in the file. The looser
+// form passed while the command sat commented out behind `echo skip` — a guard
+// satisfied by a comment is not a guard.
+assert.match(
+  workflow,
+  /^ +run: xcodebuild -scheme CovenCave -destination 'generic\/platform=iOS' CODE_SIGNING_ALLOWED=NO build$/m,
+  "the job runs a real xcodebuild as an executable step — a source-text check cannot replace it (that is what failed for three days)",
+);
+// xcodegen must go through the wrapper, never `xcodegen generate` directly:
+// the wrapper builds and PROVES the embedded web bundles exist before the scan,
+// because xcodegen scans the tree and a missing bundle otherwise yields a
+// project that builds clean and ships a blank markdown view (cave-d8ma3).
+assert.match(
+  workflow,
+  /bash scripts\/ios-xcodegen\.sh/,
+  "the project is generated through the wrapper that proves the web bundles exist first",
+);
+assert.doesNotMatch(
+  workflow,
+  /^\s+run: xcodegen generate\s*$/m,
+  "never call xcodegen generate directly — it scans before the bundles exist (cave-d8ma3)",
+);
+
+// ── It stays reachable ──────────────────────────────────────────────────────
+// The macOS leg is gated because macOS minutes once exhausted the org Actions
+// limit and queued indefinitely, stalling every required check. Gating is the
+// point — but a gate that never opens is the same as having deleted the job,
+// and that failure is silent, so the trigger set is pinned here.
+assert.match(
+  workflow,
+  /ios-build:[\s\S]{0,200}needs: ios-changed[\s\S]{0,200}if: needs\.ios-changed\.outputs\.ios == 'true'/,
+  "the macOS leg is gated on the cheap Linux detection job",
+);
+// Read the ACTUAL grep pattern out of the detection step rather than searching
+// the whole file: every one of these paths also appears in the comments above,
+// so a whole-file `includes` stays green even when the live pattern has been
+// narrowed to never match a Swift edit.
+const detectPattern = workflow.match(/grep -qE '(\^\([^']+\))'/);
+assert.ok(detectPattern, "the detection step still uses an anchored grep pattern");
+for (const path of [
+  "apps/ios/", // the Swift and project.yml
+  "scripts/ios-", // the xcodegen wrapper and the source-text contracts
+  "scripts/build-ios-", // generators whose output is embedded in the bundle
+]) {
+  assert.ok(
+    detectPattern[1].includes(path),
+    `iOS change detection must still trigger on ${path} — a Swift edit that does not run the build is the exact gap this job closes`,
+  );
+}
+// A push to main (and a manual recovery run) must build unconditionally: main
+// staying honest is worth more than the minutes, and neither event has a base
+// ref to diff against, so the detection would otherwise fall through to false.
+assert.match(
+  workflow,
+  /if \[ "\$EVENT" != "pull_request" \]; then\s*\n\s*echo "ios=true"/,
+  "non-PR events build unconditionally rather than silently skipping",
+);
+
+// ── It must NOT be a required status check ──────────────────────────────────
+// Branch protection requires nine contexts, none of them these. A required
+// context that does not report is how a PR ends up BLOCKED with nothing
+// failing, and this job deliberately does not report on most PRs. If it is ever
+// promoted to required, it must lose the gate in the same change.
+assert.doesNotMatch(
+  workflow,
+  /ios-build[\s\S]{0,200}\n {2}(conformance-required|sidecar-runtime-required):/,
+  "the iOS legs are not folded into a required rollup while they are still skippable",
+);
+
+console.log("ios-build-ci.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1530,6 +1530,7 @@ export const SUITES = {
     "src/lib/mobile-handoff.test.ts",
     "src/lib/mobile-mode-reconcile.test.ts",
     "src/lib/mobile-token-refresh.test.ts",
+    "scripts/ios-build-ci.test.mjs",
     "scripts/ios-app-store-assets.test.mjs",
     "scripts/ios-chat-project-contract.test.mjs",
     "scripts/ios-chat-familiars-home.test.mjs",


### PR DESCRIPTION
Closes **cave-kwv57**.

## The gap

**The iOS app is compiled nowhere.** I checked every workflow: `ci.yml` builds the web app and the Rust shell; `release.yml`'s macOS runners build the **desktop** Tauri bundle. Neither touches `apps/ios`. The conformance matrix's note that *"macOS is still covered by the release pipeline"* is true for desktop conformance and does **not** extend to iOS.

What *does* read Swift is a pile of source-**text** assertions — `scripts/ios-*.test.mjs` plus several `src/**` tests — and a regex matches perfectly well inside a file no compiler accepts.

That isn't hypothetical. `398b18b` left a `ChatProjectPicker` call closed with `}` instead of `)`, plus a memberwise-init argument-order mismatch, and it survived **three days and every PR in between**.

## Why a real build, not a cheap parse

I measured both defects against both candidate gates before choosing:

| `398b18b` defect | `swiftc -parse` (Linux, 1×) | `xcodebuild` (macOS, 10×) |
| --- | --- | --- |
| `}` instead of `)` | caught | caught |
| memberwise argument order | **missed** (exit 0) | caught — `argument 'familiarIds' must precede 'recentRoots'` |

A Linux parse-only job would have closed *half* the gap. Locally: xcodegen 2s, xcodebuild 56s, 143 Swift files.

## Why it's gated

This is about an outage, not tidiness. macOS runners were pulled from the conformance matrix because GitHub-hosted macOS minutes **exhausted the org Actions limit and queued indefinitely, stalling every required check**. An unconditional macOS leg risks repeating exactly that.

So a cheap ubuntu job decides first, and macOS only spins when a path that can actually affect the Swift build changed — `apps/ios/**`, `scripts/ios-*`, `scripts/build-ios-*`, or `ci.yml` itself. Most PRs pay nothing. Push-to-main and manual recovery runs build unconditionally, since neither has a base ref to diff against and main staying honest outranks the minutes.

**Deliberately not a required status check, and deliberately skippable.** A required context that does not report is how a PR ends up `BLOCKED` with nothing failing. This is advisory until the macOS budget question is settled — but a red X here still means the app does not build.

## Guarding the guard

`scripts/ios-build-ci.test.mjs` covers the two ways this could quietly stop protecting anything: the job being removed, or its change detection being narrowed until it never fires on a Swift edit.

**Two of those guards were fake on the first pass**, and only the mutants revealed it:

- asserting the `xcodebuild` string appeared *anywhere* in the file passed while the command sat commented out behind `echo skip` → now anchored to a real `run:` step
- `workflow.includes("apps/ios/")` passed because that string also appears in my own explanatory comment → now reads the actual grep pattern out of the detection step

All five mutants now fail as intended:

| Mutation | Caught by |
| --- | --- |
| Job moved off macOS | `runs-on` assertion |
| Build commented out behind `echo skip` | anchored `run:` assertion |
| Detection narrowed to drop `apps/ios/` | live-grep-pattern assertion |
| `xcodegen generate` called directly (bypassing the cave-d8ma3 bundle proof) | wrapper assertion |
| Push-to-main no longer building unconditionally | non-PR-event assertion |

## Verification

`typecheck` 0 · `lint` 0 · `check-tests-wired` 1576 · `check-conflict-markers` clean · `git diff --check` clean · `test:mobile` 85 files · `test:app` 1139 files · 0 failures.

This PR touches `ci.yml`, so **it triggers its own iOS build leg** — the run on this PR is the end-to-end proof that the job works.