### PR TITLE
fix(worktrees): stop refusals suggesting a command the gate cannot run

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1120,11 +1120,11 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   assert.match(refused.stderr, /already owns a registered worktree/);
   assert.match(refused.stderr, /20-worktree budget/);
   assert.match(refused.stderr, /30-local-branch budget/);
-  // A refusal must not send the operator to a command that cannot run. Three of
-  // the four maintenance planes are hard-coded unenforced, so `--apply` exits 2
-  // before assessing anything — yet this line was printed on EVERY refusal
-  // (cave-wmkn4). It now names the unenforced planes and the hand-retirement
-  // route instead, and the suggestion returns on its own once the planes land.
+  // A refusal must not send the operator to a command that cannot run. Today,
+  // three of the four maintenance planes are hard-coded unenforced, so `--apply`
+  // exits 2 before assessing anything — yet this line was printed on EVERY
+  // refusal (cave-wmkn4). If the maintenance planes later become enforced and
+  // `--apply` becomes runnable, this assertion should be updated accordingly.
   assert.doesNotMatch(
     refused.stderr,
     /Suggestion: pnpm beads:worktrees:apply/,

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1120,7 +1120,22 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   assert.match(refused.stderr, /already owns a registered worktree/);
   assert.match(refused.stderr, /20-worktree budget/);
   assert.match(refused.stderr, /30-local-branch budget/);
-  assert.match(refused.stderr, /Suggestion: pnpm beads:worktrees:apply/);
+  // A refusal must not send the operator to a command that cannot run. Three of
+  // the four maintenance planes are hard-coded unenforced, so `--apply` exits 2
+  // before assessing anything — yet this line was printed on EVERY refusal
+  // (cave-wmkn4). It now names the unenforced planes and the hand-retirement
+  // route instead, and the suggestion returns on its own once the planes land.
+  assert.doesNotMatch(
+    refused.stderr,
+    /Suggestion: pnpm beads:worktrees:apply/,
+    "an unrunnable command must not be suggested",
+  );
+  assert.match(refused.stderr, /cannot run here — unenforced maintenance planes: .*coven/);
+  assert.match(
+    refused.stderr,
+    /a merged PR is not retention/,
+    "the hand-retirement route must state the trap that makes it lossy",
+  );
   assert.match(refused.stderr, /This admission refusal can be lifted/i);
   assert.doesNotMatch(refused.stderr, /worth exceeding the budget/i);
   // The refusal must name the escape hatch it would accept. Without this the

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -853,30 +853,47 @@ function exceptionSuggestion(options: ManagedCreateOptions, worktreePath: string
  * bare `git worktree add`, which yields a permanently `uncertain` unit, or
  * hand-editing the bead, which is the forgery cave-l52dt rules out.
  *
- * Derived from the gate rather than restated, so this cannot drift: when those
- * planes do land, the suggestion starts appearing again on its own.
+ * Uses `capabilities.complete` to gate the suggestion — the same field the
+ * patrol itself uses — rather than counting per-plane `enforced === false`.
+ * A newly added unenforced plane, or any other condition that sets
+ * `complete=false`, will suppress the suggestion even if the listed-plane scan
+ * would have wrongly cleared it.
+ *
+ * `includeRetireByHand` controls whether the hand-retirement route is printed.
+ * It is only relevant for budget refusals; non-budget refusals (duplicate
+ * metadata, missing primary registration) should omit it.
  */
 function maintenanceSuggestion(
   capabilities = repositoryMaintenanceCapabilities(),
+  includeRetireByHand = true,
 ): string[] {
+  if (capabilities?.complete) return ["Suggestion: pnpm beads:worktrees:apply"];
   const planes = ["coven", "beads", "github", "local"] as const;
   const missing = planes.filter((plane) => capabilities?.[plane]?.enforced === false);
-  if (missing.length === 0) return ["Suggestion: pnpm beads:worktrees:apply"];
-  return [
+  const lines: string[] = [
     `Note: pnpm beads:worktrees:apply cannot run here — unenforced maintenance planes: ${missing.join(", ")}.`,
-    "Retire by hand instead: prove retention (a remote branch, or a pushed archive tag —",
-    "a merged PR is not retention, since a squash leaves the branch's commits on no remote ref),",
-    "then `git worktree unlock <path> && git worktree remove <path> && git branch -d <branch>`.",
   ];
+  if (includeRetireByHand) {
+    lines.push(
+      "Retire by hand instead: prove retention (a remote branch, or a pushed archive tag —",
+      "a merged PR is not retention, since a squash leaves the branch's commits on no remote ref),",
+      "then `git worktree unlock <path> && git worktree remove <path> && git branch -d <branch>`.",
+    );
+  }
+  return lines;
 }
 
-function refusalOutcome(reasons: string[], suggestion: string[] = []): Outcome {
+function refusalOutcome(
+  reasons: string[],
+  suggestion: string[] = [],
+  includeRetireByHand = true,
+): Outcome {
   return {
     status: 2,
     stdout: null,
     stderr: [
       ...reasons.map((reason) => `worktree-lifecycle-create: ${reason}`),
-      ...maintenanceSuggestion(),
+      ...maintenanceSuggestion(undefined, includeRetireByHand),
       ...suggestion,
     ],
     createdReport: null,
@@ -1602,12 +1619,15 @@ function execute(
         `Bead ${options.beadId} already has structured worktree metadata; a current worktree exception is required to append another record`,
       ],
       exceptionSuggestion(options, worktreePath),
+      false,
     );
   }
   if (primaryRegistrationMissing) {
-    return refusalOutcome([
-      `Bead ${options.beadId} primary structured worktree metadata is not currently registered`,
-    ]);
+    return refusalOutcome(
+      [`Bead ${options.beadId} primary structured worktree metadata is not currently registered`],
+      [],
+      false,
+    );
   }
   const existingPaths = existingOwnedPaths(inventory.items, options.beadId);
 

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -869,9 +869,13 @@ function maintenanceSuggestion(
 ): string[] {
   if (capabilities?.complete) return ["Suggestion: pnpm beads:worktrees:apply"];
   const planes = ["coven", "beads", "github", "local"] as const;
-  const missing = planes.filter((plane) => capabilities?.[plane]?.enforced === false);
+  const missing = capabilities
+    ? planes.filter((plane) => capabilities[plane]?.enforced === false)
+    : [];
+  const planeSummary =
+    missing.length > 0 ? missing.join(", ") : "unknown (capabilities unavailable)";
   const lines: string[] = [
-    `Note: pnpm beads:worktrees:apply cannot run here — unenforced maintenance planes: ${missing.join(", ")}.`,
+    `Note: pnpm beads:worktrees:apply cannot run here — unenforced maintenance planes: ${planeSummary}.`,
   ];
   if (includeRetireByHand) {
     lines.push(

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -18,6 +18,7 @@ import {
   heartbeatWriterIntent,
   registerWriterIntent,
   releaseWriterIntent,
+  repositoryMaintenanceCapabilities,
 } from "./maintenance-gate.mjs";
 
 const REPOSITORY = "OpenCoven/coven-cave";
@@ -836,13 +837,46 @@ function exceptionSuggestion(options: ManagedCreateOptions, worktreePath: string
   ];
 }
 
+/**
+ * Only suggest the patrol's `--apply` when it can actually run.
+ *
+ * This line used to be unconditional, on EVERY refusal this script emits —
+ * budget, duplicate metadata, orphaned record alike. But `--apply` refuses
+ * outright whenever any maintenance plane is unenforced, and
+ * `repositoryMaintenanceCapabilities()` has three of the four hard-coded to
+ * `false` against unbuilt work, so the suggestion has never been runnable in
+ * this repository (cave-wmkn4).
+ *
+ * A refusal that prints an impossible next step is worse than one that prints
+ * none: it sends the operator through a command that exits 2, and the documented
+ * escapes they reach for next are the ones the guard rules exist to forbid — a
+ * bare `git worktree add`, which yields a permanently `uncertain` unit, or
+ * hand-editing the bead, which is the forgery cave-l52dt rules out.
+ *
+ * Derived from the gate rather than restated, so this cannot drift: when those
+ * planes do land, the suggestion starts appearing again on its own.
+ */
+function maintenanceSuggestion(
+  capabilities = repositoryMaintenanceCapabilities(),
+): string[] {
+  const planes = ["coven", "beads", "github", "local"] as const;
+  const missing = planes.filter((plane) => capabilities?.[plane]?.enforced === false);
+  if (missing.length === 0) return ["Suggestion: pnpm beads:worktrees:apply"];
+  return [
+    `Note: pnpm beads:worktrees:apply cannot run here — unenforced maintenance planes: ${missing.join(", ")}.`,
+    "Retire by hand instead: prove retention (a remote branch, or a pushed archive tag —",
+    "a merged PR is not retention, since a squash leaves the branch's commits on no remote ref),",
+    "then `git worktree unlock <path> && git worktree remove <path> && git branch -d <branch>`.",
+  ];
+}
+
 function refusalOutcome(reasons: string[], suggestion: string[] = []): Outcome {
   return {
     status: 2,
     stdout: null,
     stderr: [
       ...reasons.map((reason) => `worktree-lifecycle-create: ${reason}`),
-      "Suggestion: pnpm beads:worktrees:apply",
+      ...maintenanceSuggestion(),
       ...suggestion,
     ],
     createdReport: null,


### PR DESCRIPTION
Closes `cave-wmkn4`.

## The defect

`scripts/worktree-lifecycle-create.ts:839` `refusalOutcome()` appended the literal `Suggestion: pnpm beads:worktrees:apply` to **every** refusal it emits — budget, duplicate metadata, orphaned record alike, before any caller-supplied suggestion.

That command cannot run. `scripts/maintenance-gate.mjs` `repositoryMaintenanceCapabilities()` hard-codes `coven`, `beads` and `github` to `enforced: false` against unbuilt work, and the patrol refuses `--apply` whenever any plane is unenforced:

```
worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: coven, beads, github
```

It has never been runnable in this repository. Re-verified on current `main` tonight — those three are still `false` even though `cave-3aqvr` is closed; only the refusal's wording changed there.

**Scope note:** the bead described this as the orphaned-record refusal's problem. It is not scoped to that path — fixing it at `refusalOutcome` covers every refusal at once, and fixing only the orphaned-record path would have left the rest misleading.

## Why it matters more than a wrong string

A refusal that prints an impossible next step is worse than one that prints none. The operator runs it, gets exit 2, and then reaches for the escapes the guard rules exist to forbid:

- a bare `git worktree add` — the unit carries no lifecycle metadata, so the patrol reports it `uncertain` **permanently** and automated retirement can never remove it;
- hand-editing the bead metadata — the forgery `cave-l52dt` rules out.

Both paths were walked tonight while landing other work, which is how this surfaced.

## The fix

The suggestion is now **derived from the gate** rather than restated, so it cannot drift and reappears on its own once those planes land:

- all planes enforced → the original `Suggestion: pnpm beads:worktrees:apply`;
- any plane unenforced → name which ones, and give the route that actually works.

The working route deliberately leads with the trap that makes it lossy if skipped:

> prove retention (a remote branch, or a pushed archive tag — **a merged PR is not retention**, since a squash leaves the branch's commits on no remote ref), then `git worktree unlock` / `git worktree remove` / `git branch -d`.

That warning is not theoretical. Retiring nine worktrees by hand earlier tonight, `git branch -r --contains <head>` came back **empty for every one** despite all being merged.

## Verification

- `node scripts/worktree-lifecycle-create.test.mjs` → exit **0**. This is the check that actually exercises `refusalOutcome` through a fixture.
- The existing assertion pinned the old string, so it was updated deliberately: it now pins the *absence* of the unrunnable suggestion, the named unenforced planes, and the retention warning.
- `tsc --noEmit` clean — it caught a real typing bug on the way (indexing the capabilities object with a bare `string`), fixed with a typed key tuple.
- `check:tests-wired` — 1577 files.

One honest note on method: my first attempt to verify this was a live `beads:worktrees:create` probe, which exited **1** on `metadata.coven.worktree path must be inside the managed .worktrees root` — a different code path (`errorOutcome`) that never reaches the changed code. Had I not captured its full output I would have reported a passing probe that ran none of this. The fixture test is the real evidence.

## Not addressed here

- `scripts/maintenance-gate.mjs` still hard-codes the three planes; this change makes the refusal honest about that rather than fixing it. That remains `cave-wqa0b.2/.3/.4`.
- The orphaned-record deadlock itself (`cave-525id`) is being implemented separately in `scripts/worktree-lifecycle-metadata-repair.ts`. Confirmed non-overlapping: that work touches the inventory, patrol and repair scripts, and does not touch `worktree-lifecycle-create.ts` or `maintenance-gate.mjs`.
- The probe above suggests `cave-wmkn4`'s own bead metadata holds a record whose path is outside `.worktrees`. Noted, not chased.
