### PR TITLE
fix(research): stack "More sources" vertically in the evidence rail (cave-l2hkx)

### DIFF
--- a/src/components/role-surfaces/research-reader-shared.test.ts
+++ b/src/components/role-surfaces/research-reader-shared.test.ts
@@ -30,4 +30,37 @@ assert.match(source, /<aside className="rr-col rr-rail"/);
 assert.match(source, /onRefClick/);
 assert.match(source, /onPublish/);
 
+// ── "More sources" scrolls with the rail, never sideways (cave-l2hkx) ───────
+// The strip used to be `display:flex` in row direction with `overflow-x:auto`
+// and 152px fixed-width cards, which put a second, competing scroll axis inside
+// a rail that already scrolls vertically (.rr-col is overflow:auto). Reported
+// from the running app: s01 visible, s02 clipped mid-word at the rail edge, and
+// 12 of 14 sources off-screen.
+//
+// Measured before/after against this stylesheet with a real browser: row
+// direction overflowed the 268px rail by 1964px with cards clipped; column
+// direction overflows by 0 and every card renders at the full 268px.
+const css = await readFile(new URL("../../styles/research-reader.css", import.meta.url), "utf8");
+const strip = css.match(/^\.rr-srcscroll \{([^}]*)\}/m);
+assert.ok(strip, "the .rr-srcscroll rule still exists");
+assert.match(strip[1], /flex-direction:\s*column/, "the sources strip stacks vertically");
+assert.doesNotMatch(
+  strip[1],
+  /overflow-x\s*:\s*(auto|scroll)/,
+  "the sources strip must not introduce its own horizontal scroll — the rail owns scrolling",
+);
+const mini = css.match(/^\.rr-srcmini \{([^}]*)\}/m);
+assert.ok(mini, "the .rr-srcmini rule still exists");
+assert.doesNotMatch(
+  mini[1],
+  /width:\s*\d+px/,
+  "source cards fill the rail rather than sitting at a fixed pixel width that overflows it",
+);
+// The hand-rolled horizontal scrollbar went with the axis it scrolled; leaving
+// it would render a drag-thumb wired to a container that no longer scrolls.
+for (const dead of ["rr-srctrack", "rr-srcthumb"]) {
+  assert.ok(!css.includes(dead), `${dead} is gone with the horizontal strip`);
+  assert.ok(!source.includes(dead), `${dead} has no leftover markup or handler`);
+}
+
 console.log("research-reader-shared: all assertions passed");

--- a/src/components/role-surfaces/research-reader.tsx
+++ b/src/components/role-surfaces/research-reader.tsx
@@ -108,9 +108,6 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
   const documentReaderApiRef = useRef<DocumentReaderApi | null>(null);
   const pbarRef = useRef<HTMLDivElement | null>(null);
   const tipRef = useRef<HTMLDivElement | null>(null);
-  const stripRef = useRef<HTMLDivElement | null>(null);
-  const trackRef = useRef<HTMLDivElement | null>(null);
-  const thumbRef = useRef<HTMLButtonElement | null>(null);
 
   const doc = useMemo(
     () => parseFindingsDoc(markdown ?? "", mission.sources),
@@ -305,72 +302,6 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
     return () => {
       document.removeEventListener("pointermove", move);
       document.removeEventListener("pointerup", up);
-    };
-  }, []);
-
-  // ── "more sources" strip: reflect + drag the scroll thumb ────────────────
-  const updateThumb = () => {
-    const strip = stripRef.current;
-    const track = trackRef.current;
-    const thumb = thumbRef.current;
-    if (!strip || !track || !thumb) return;
-    const max = strip.scrollWidth - strip.clientWidth;
-    if (max <= 1) {
-      track.hidden = true;
-      return;
-    }
-    track.hidden = false;
-    const tw = track.clientWidth;
-    const thw = Math.max(28, tw * (strip.clientWidth / strip.scrollWidth));
-    thumb.style.width = `${thw}px`;
-    thumb.style.left = `${(strip.scrollLeft / max) * (tw - thw)}px`;
-  };
-  useEffect(() => {
-    updateThumb();
-    window.addEventListener("resize", updateThumb);
-    return () => window.removeEventListener("resize", updateThumb);
-  }, [miniSources.length, railOn, railWidth]);
-
-  const thumbDrag = useRef<{ x: number; left: number } | null>(null);
-  const stripDrag = useRef<{ x: number; sl: number } | null>(null);
-  const onThumbDown = (event: React.PointerEvent) => {
-    thumbDrag.current = { x: event.clientX, left: parseFloat(thumbRef.current?.style.left || "0") || 0 };
-    thumbRef.current?.setPointerCapture(event.pointerId);
-    event.preventDefault();
-    event.stopPropagation();
-  };
-  const onStripDown = (event: React.PointerEvent) => {
-    if ((event.target as HTMLElement).closest(".rr-srcthumb")) return;
-    stripDrag.current = { x: event.clientX, sl: stripRef.current?.scrollLeft ?? 0 };
-  };
-  useEffect(() => {
-    const move = (event: PointerEvent) => {
-      const strip = stripRef.current;
-      const track = trackRef.current;
-      const thumb = thumbRef.current;
-      if (thumbDrag.current && strip && track && thumb) {
-        const tw = track.clientWidth;
-        const thw = thumb.offsetWidth;
-        const nl = Math.max(0, Math.min(tw - thw, thumbDrag.current.left + (event.clientX - thumbDrag.current.x)));
-        strip.scrollLeft = tw - thw > 0 ? (nl / (tw - thw)) * (strip.scrollWidth - strip.clientWidth) : 0;
-      } else if (stripDrag.current && strip) {
-        const dx = event.clientX - stripDrag.current.x;
-        if (Math.abs(dx) > 3) strip.classList.add("is-dragging");
-        strip.scrollLeft = stripDrag.current.sl - dx;
-      }
-    };
-    const up = () => {
-      thumbDrag.current = null;
-      if (stripDrag.current) {
-        stripDrag.current = null;
-        stripRef.current?.classList.remove("is-dragging");
-      }
-    };
-    window.addEventListener("pointermove", move);
-    window.addEventListener("pointerup", up);
-    return () => {
-      window.removeEventListener("pointermove", move);
-      window.removeEventListener("pointerup", up);
     };
   }, []);
 
@@ -650,7 +581,7 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
                 {miniSources.length ? (
                   <div className="rr-more">
                     <div className="rr-more__label">More sources · {miniSources.length}</div>
-                    <div className="rr-srcscroll" ref={stripRef} onScroll={updateThumb} onPointerDown={onStripDown}>
+                    <div className="rr-srcscroll">
                       {miniSources.map((source) => {
                         const view = statusView(source.status);
                         const toneClass = view.refTone === "warn" ? " rr-sref--warn" : view.refTone === "muted" ? " rr-sref--muted" : "";
@@ -669,9 +600,6 @@ export function ResearchReader({ mission, artifact, markdown, onClose, onOpenUrl
                           </button>
                         );
                       })}
-                    </div>
-                    <div className="rr-srctrack" ref={trackRef}>
-                      <button className="rr-srcthumb" ref={thumbRef} type="button" aria-label="Scroll sources" onPointerDown={onThumbDown} />
                     </div>
                   </div>
                 ) : null}

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -295,18 +295,19 @@
 /* ── "more sources" strip ── */
 .rr-more { margin-top: 6px; }
 .rr-more__label { font: 600 9px var(--font-mono); letter-spacing: 0.06em; text-transform: uppercase; color: var(--text-muted); margin-bottom: 8px; }
-.rr-srcscroll { display: flex; gap: 8px; overflow-x: auto; padding-bottom: 2px; scrollbar-width: none; cursor: grab; }
-.rr-srcscroll::-webkit-scrollbar { display: none; }
-.rr-srcscroll.is-dragging { cursor: grabbing; }
-.rr-srcmini { flex: none; width: 152px; padding: 9px 10px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-raised); cursor: pointer; transition: border-color var(--duration-fast); text-align: left; }
+/* Stacks vertically and rides the rail's own scroll (.rr-col is overflow:auto,
+   .rr-rail__list is already a column). It used to be a row with overflow-x and
+   152px fixed cards, which put a second, competing scroll axis inside an
+   otherwise vertical surface: titles truncated mid-word and 12 of 14 sources
+   sat off the rail edge (cave-l2hkx). No overflow here on purpose — the rail
+   scrolls, this does not. */
+.rr-srcscroll { display: flex; flex-direction: column; gap: 8px; }
+.rr-srcmini { width: 100%; padding: 9px 10px; border: 1px solid var(--border); border-radius: var(--radius-md); background: var(--bg-raised); cursor: pointer; transition: border-color var(--duration-fast); text-align: left; }
 .rr-srcmini:hover { border-color: var(--border-strong); }
 .rr-srcmini--rejected { border-style: dashed; }
 .rr-srcmini__title { font-size: var(--text-xs); font-weight: 500; color: var(--text-primary); line-height: 1.35; margin-top: 6px; }
 .rr-srcmini--rejected .rr-srcmini__title { color: var(--text-secondary); }
 .rr-srcmini__meta { font: 400 9px var(--font-mono); color: var(--text-muted); margin-top: 4px; }
-.rr-srctrack { position: relative; height: 6px; border-radius: var(--radius-pill); background: var(--bg-subtle); margin-top: 7px; }
-.rr-srcthumb { position: absolute; top: 0; left: 0; height: 6px; min-width: 28px; border-radius: var(--radius-pill); background: var(--border-strong); cursor: grab; transition: background var(--duration-fast); border: none; padding: 0; }
-.rr-srcthumb:hover, .rr-srcthumb:active { background: var(--research-accent); }
 
 /* ── tooltip ── */
 .rr-tip {


### PR DESCRIPTION
Closes **cave-l2hkx**. Reported from the running app with a screenshot: `s01` fully visible, `s02` clipped mid-word at the rail edge, 12 of 14 sources off-screen.

## Cause

```css
.rr-srcscroll { display: flex; gap: 8px; overflow-x: auto; ... cursor: grab; }
.rr-srcmini   { flex: none; width: 152px; ... }
```

Fixed-width cards in a **row**-direction flex container with `overflow-x`. That puts a second, competing scroll axis inside a surface that is vertical everywhere else — `.rr-col` is already `overflow: auto` and `.rr-rail__list` is already a `flex-direction: column`. So the rail scrolls one way and the strip inside it scrolls the other.

## Measured, not assumed

Rendered the component's exact DOM against this stylesheet in a real browser, at the rail's actual 268px inner width, before and after:

| | before | after |
| --- | --- | --- |
| horizontal overflow | **1964px** | **0** |
| `flex-direction` | `row` | `column` |
| card width | 152px fixed | 268px — fills the rail |
| clipped at rail edge | **yes** | no |
| rail vertical scroll | 0 | 787px |

The **before** run reproduces the reported screenshot exactly — that is what gives the after run its weight. Same harness, same stylesheet, only the CSS moved.

> Worth recording: the first measurement looked like a pass (`horizontal overflow: 0`) but `firstCardWidth: 0` gave it away. The real stylesheet sets `.rr-rail { display: none }` unless `[data-rail="true"]`, and the harness override came *before* it, so the rail collapsed to 0×0 and every overflow check passed trivially. Fixed the cascade rather than reporting the false green.

## Also removes the scrollbar that went with it

`.rr-srctrack` / `.rr-srcthumb`, `stripRef`/`trackRef`/`thumbRef`, `updateThumb()`, a resize listener and two pointer-drag effects — **66 lines whose only job was moving `scrollLeft`**. Leaving them would have meant a drag-thumb wired to a container that no longer scrolls sideways. Net **−71 lines**.

## Guard

Assertions in `research-reader-shared.test.ts` parse the rules **out of the stylesheet** rather than grepping the whole file, so a mention inside a comment cannot satisfy them. Mutation-tested:

| Mutation | Caught by |
| --- | --- |
| Strip reverted to a horizontal row | `flex-direction: column` assertion |
| Fixed-width cards restored | card-width assertion |
| Dead scrollbar creeps back into the markup | `rr-srcthumb` absence assertion |

`typecheck` 0 · `lint` 0 · `check-tests-wired` 1577 · `check-conflict-markers` clean · `git diff --check` clean · `test:app` 1140 files · 0 failures.