### PR TITLE
fix(release): decouple daemon versions and harden Windows publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ permissions:
 
 jobs:
   daemon-package:
-    name: Verify matching Coven daemon package
+    name: Verify available Coven daemon package
     runs-on: ubuntu-24.04
     steps:
       - name: Validate Windows diagnostics mode
@@ -112,56 +112,25 @@ jobs:
           node-version: 24
 
       # Cave updates the user's local daemon through @opencoven/cli before
-      # replacing itself. Refuse to publish a Cave version until the matching
-      # daemon package exists, or the client could only reinstall an older
-      # daemon while presenting a successful desktop update.
-      - name: Require matching @opencoven/cli release
+      # replacing itself. Cave and the daemon have independent release lines:
+      # require a published package, but never compare its version to Cave's.
+      - name: Require published @opencoven/cli release
         shell: bash
-        env:
-          RAW_RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
-          TAG="$RAW_RELEASE_TAG"
-          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid release tag. Expected format: vMAJOR.MINOR.PATCH[-PRERELEASE]"
+          if ! LATEST=$(npm view "@opencoven/cli@latest" version); then
+            echo "::error::@opencoven/cli@latest must resolve before publishing Coven Cave."
             exit 1
           fi
-          VERSION="${TAG#v}"
-          LATEST=$(npm view "@opencoven/cli@latest" version)
-          if ! node - "$LATEST" "$VERSION" <<'NODE'
-          const parse = value => {
-            const match = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?$/.exec(value);
-            return match && { core: match.slice(1, 4).map(Number), pre: match[4]?.split(".") ?? [] };
-          };
-          const compare = (left, right) => {
-            const a = parse(left);
-            const b = parse(right);
-            if (!a || !b) return null;
-            for (let index = 0; index < 3; index += 1) {
-              if (a.core[index] !== b.core[index]) return a.core[index] < b.core[index] ? -1 : 1;
-            }
-            if (!a.pre.length || !b.pre.length) return a.pre.length === b.pre.length ? 0 : a.pre.length ? -1 : 1;
-            for (let index = 0; index < Math.max(a.pre.length, b.pre.length); index += 1) {
-              const av = a.pre[index];
-              const bv = b.pre[index];
-              if (av === undefined || bv === undefined) return av === undefined ? -1 : 1;
-              if (av === bv) continue;
-              const an = /^\d+$/.test(av);
-              const bn = /^\d+$/.test(bv);
-              if (an && bn) return Number(av) < Number(bv) ? -1 : 1;
-              if (an !== bn) return an ? -1 : 1;
-              return av < bv ? -1 : 1;
-            }
-            return 0;
-          };
-          process.exit(compare(process.argv[2], process.argv[3]) >= 0 ? 0 : 1);
+          LATEST="$LATEST" node <<'NODE'
+          const version = process.env.LATEST ?? "";
+          const strictSemver = /^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-((?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+          if (version.includes("\n") || !strictSemver.test(version)) {
+            console.error(`::error::@opencoven/cli@latest resolved to an invalid version: ${JSON.stringify(version)}`);
+            process.exit(1);
+          }
           NODE
-          then
-            echo "::error::Coven Cave $VERSION requires an @opencoven/cli release >= $VERSION, but npm latest is '${LATEST:-nothing}'."
-            echo "::error::Promote @opencoven/cli $VERSION (or newer) to latest before retrying this Cave release."
-            exit 1
-          fi
-          echo "Verified @opencoven/cli@latest ($LATEST) satisfies the Cave daemon update for version $VERSION."
+          echo "Verified @opencoven/cli@latest resolves to published daemon version $LATEST."
 
   source-version:
     name: Verify tag matches stamped source
@@ -651,17 +620,39 @@ jobs:
             throw "Expected exactly one budget-approved MSI, found $($msis.Count)"
           }
 
-          gh release view $env:RELEASE_TAG *> $null
-          if ($LASTEXITCODE -ne 0) {
-            gh release create $env:RELEASE_TAG `
-              --verify-tag `
-              --title "CovenCave $env:RELEASE_TAG" `
-              --notes "Release artifacts are still being assembled by the release workflow."
-            if ($LASTEXITCODE -ne 0) {
+          # Windows PowerShell promotes native stderr to an ErrorRecord. Probe
+          # failures are expected while the first matrix leg creates a release,
+          # so isolate that non-zero result from the step-wide Stop policy.
+          function Test-GitHubRelease {
+            $previousErrorActionPreference = $ErrorActionPreference
+            try {
+              $ErrorActionPreference = "SilentlyContinue"
+              gh release view $env:RELEASE_TAG *> $null
+              return $LASTEXITCODE -eq 0
+            } finally {
+              $ErrorActionPreference = $previousErrorActionPreference
+            }
+          }
+
+          if (-not (Test-GitHubRelease)) {
+            $createExitCode = 1
+            $previousErrorActionPreference = $ErrorActionPreference
+            try {
+              # A concurrent matrix leg can win this create race. Preserve the
+              # exit code so the verified follow-up probe decides the outcome.
+              $ErrorActionPreference = "Continue"
+              gh release create $env:RELEASE_TAG `
+                --verify-tag `
+                --title "CovenCave $env:RELEASE_TAG" `
+                --notes "Release artifacts are still being assembled by the release workflow."
+              $createExitCode = $LASTEXITCODE
+            } finally {
+              $ErrorActionPreference = $previousErrorActionPreference
+            }
+            if ($createExitCode -ne 0) {
               # Another matrix leg may have created the release concurrently.
               Start-Sleep -Seconds 5
-              gh release view $env:RELEASE_TAG *> $null
-              if ($LASTEXITCODE -ne 0) {
+              if (-not (Test-GitHubRelease)) {
                 throw "Could not create or find release $env:RELEASE_TAG"
               }
             }

--- a/scripts/release-macos-signing.test.mjs
+++ b/scripts/release-macos-signing.test.mjs
@@ -307,6 +307,30 @@ test("release packages and checksum manifest receive GitHub artifact attestation
   );
 });
 
+test("Windows release publication treats an absent release as a recoverable probe result", () => {
+  const buildJob = getWorkflowJob("build");
+  const publishStep = buildJob.slice(
+    buildJob.indexOf("name: Publish validated Windows MSI"),
+    buildJob.indexOf("name: Sign Linux/Windows updater artifact"),
+  );
+
+  assert.match(
+    publishStep,
+    /function Test-GitHubRelease[\s\S]*ErrorActionPreference = "SilentlyContinue"[\s\S]*gh release view \$env:RELEASE_TAG \*> \$null[\s\S]*return \$LASTEXITCODE -eq 0/,
+    "the expected not-found probe must not terminate the PowerShell step",
+  );
+  assert.match(
+    publishStep,
+    /ErrorActionPreference = "Continue"[\s\S]*gh release create \$env:RELEASE_TAG[\s\S]*\$createExitCode = \$LASTEXITCODE/,
+    "a concurrent create race must be handled by exit code and a follow-up probe",
+  );
+  assert.match(
+    publishStep,
+    /if \(-not \(Test-GitHubRelease\)\)[\s\S]*if \(\$createExitCode -ne 0\)[\s\S]*if \(-not \(Test-GitHubRelease\)\)/,
+    "both initial absence and a losing create race must use the non-terminating probe",
+  );
+});
+
 test("sidecar bundle prunes foreign native packages before release bundling", () => {
   assert.match(sidecarScript, /prune_foreign_native_packages\(\)/);
   assert.match(sidecarScript, /process\.platform/);

--- a/scripts/stamp-release.test.mjs
+++ b/scripts/stamp-release.test.mjs
@@ -1048,9 +1048,39 @@ function workflowJob(source, jobName) {
   return source.slice(startIndex, nextMatch?.index ?? source.length);
 }
 
-assert.match(yml, /daemon-package:\s*\n\s+name: Verify matching Coven daemon package/, "release has a daemon package gate");
-assert.match(yml, /npm view "@opencoven\/cli@latest" version/, "daemon gate verifies the package installed by the client");
-assert.match(yml, /process\.argv\[2\], process\.argv\[3\]\) >= 0/, "daemon gate requires latest CLI to satisfy the Cave version");
+assert.match(yml, /daemon-package:\s*\n\s+name: Verify available Coven daemon package/, "release has a daemon package gate");
+const daemonPackageJob = workflowJob(yml, "daemon-package");
+assert.match(
+  daemonPackageJob,
+  /if ! LATEST=\$\(npm view "@opencoven\/cli@latest" version\); then/,
+  "daemon gate requires the package installed by the client to resolve",
+);
+assert.match(
+  daemonPackageJob,
+  /const strictSemver = \/\^.+\$\//,
+  "daemon gate validates the registry response as strict SemVer",
+);
+const strictSemverLiteral = daemonPackageJob.match(
+  /const strictSemver = (\/\^.+\$\/);/,
+)?.[1];
+assert.ok(strictSemverLiteral, "daemon gate exposes its strict SemVer contract");
+const strictSemver = new RegExp(strictSemverLiteral.slice(1, -1));
+for (const version of ["0.2.4", "1.2.3-rc.1", "1.2.3+build.7", "1.2.3-rc.1+build.7"]) {
+  assert.match(version, strictSemver, `daemon gate accepts published SemVer ${version}`);
+}
+for (const version of ["", "v1.2.3", "01.2.3", "1.2.3-01", "1.2.3-", "1.2.3\n2.0.0"]) {
+  assert.doesNotMatch(version, strictSemver, `daemon gate rejects invalid registry response ${JSON.stringify(version)}`);
+}
+assert.match(
+  daemonPackageJob,
+  /version\.includes\("\\n"\)/,
+  "daemon gate rejects a multi-version registry response",
+);
+assert.doesNotMatch(
+  daemonPackageJob,
+  /RAW_RELEASE_TAG|VERSION="\$\{TAG#v\}"|process\.argv\[3\]|requires an @opencoven\/cli release >=/,
+  "daemon and Cave releases have independent version lines",
+);
 const sourceVersionJob = workflowJob(yml, "source-version");
 assert.match(
   yml,


### PR DESCRIPTION
## Why

Cave and @opencoven/cli have independent release lines, but the release workflow required the daemon latest version to be greater than or equal to the Cave tag. That stale coupling blocked the first signed v0.2.5 release attempt even though Cave already installs and validates the daemon independently.

The recovery run also exposed a Windows PowerShell bug: with ErrorActionPreference=Stop, the expected release-not-found probe terminated before its create-or-race fallback could run.

## What changed

- Keep the daemon package as a fail-closed release prerequisite.
- Require @opencoven/cli@latest to resolve to one strict SemVer.
- Remove every comparison between the daemon package version and the Cave release tag.
- Pin stable, prerelease, build-metadata, malformed, empty, and multi-value registry responses in the release regression test.
- Make the Windows release probe non-terminating while preserving fail-closed create, re-probe, and upload behavior.
- Add a regression test for the exact Windows publication ordering and error-policy contract.

## Verification

- node scripts/stamp-release.test.mjs
- node scripts/release-macos-signing.test.mjs
- workflow YAML parse
- pnpm release:verify --version 0.2.5
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired — all 1,577 files wired
- Windows PowerShell 5.1 native-stderr/nonzero probe simulation
- git diff --check
- independent workflow, SemVer, and PowerShell review — no blockers
- pnpm test:app reached 115 files before two chmod/EACCES assertions failed on the Windows-mounted WSL filesystem
- pnpm test:api reached 158 files before its explicit project-root-outside-home environment guard stopped the suite

Exact-head CI is the authority for the two WSL host-boundary cases.

## Release context

The signed v0.2.5 tag remains immutable at aa9d43013afc5637d07e9a794e7df24d0d6e7652. The initial run 31290534414 failed only at the old version-comparison gate and created no release artifacts. @opencoven/cli@latest then advanced to 0.2.5.

Attempt 2 built the Linux AppImage successfully but its workflow token was denied while creating the GitHub Release. The maintainer recovery created the verified-tag release with canonical notes; macOS artifacts are publishing, and the failed Linux/Windows legs will be rerun against that release.