### PR TITLE
fix(worktrees): gate the remaining two --apply suggestions

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -36,6 +36,33 @@ const realGit = process.env.PATH.split(path.delimiter)
 assert.ok(realGit, "the test requires git on PATH");
 assert.equal(existsSync(script), true, "managed worktree creator module must exist");
 
+// Every emitter of the `--apply` suggestion must go through maintenanceSuggestion(),
+// which gates it on capabilities.complete. The suggestion is unrunnable while any
+// maintenance plane is unenforced, and a refusal that names an impossible next step
+// pushes the operator toward the unmanaged fallbacks the guard rules forbid.
+//
+// Structural, not a count. cave-wmkn4 fixed refusalOutcome and left two compensate
+// paths emitting the literal directly (cave-e4n3l); the miss survived verification
+// because grepping the literal returns a nonzero count either way — the gated branch
+// legitimately contains it. So assert on WHERE it appears: exactly one occurrence,
+// on the line that returns it from behind the capabilities check.
+{
+  const createSource = readFileSync(script, "utf8");
+  const suggestionLines = createSource
+    .split("\n")
+    .filter((line) => line.includes('"Suggestion: pnpm beads:worktrees:apply"'));
+  assert.equal(
+    suggestionLines.length,
+    1,
+    `the --apply suggestion must have exactly one emitter; found ${suggestionLines.length}:\n${suggestionLines.join("\n")}`,
+  );
+  assert.match(
+    suggestionLines[0],
+    /capabilities\?\.complete/,
+    "the sole emitter must be the branch gated on capabilities.complete",
+  );
+}
+
 function run(command, args, cwd, options = {}) {
   return spawnSync(command, args, {
     cwd,

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -1811,7 +1811,11 @@ function execute(
         ...freshAssessment.reasons.map(
           (reason) => `worktree-lifecycle-create: ${reason}`,
         ),
-        "Suggestion: pnpm beads:worktrees:apply",
+        // Same gate as refusalOutcome (cave-wmkn4): never advertise a command
+        // the maintenance planes make unrunnable. This is the compensate path —
+        // a refusal found AFTER the worktree was created — so it reaches the
+        // user in exactly the situation where a dead next step is most costly.
+        ...maintenanceSuggestion(),
         ...exceptionSuggestion(options, worktreePath),
       ],
     );
@@ -1852,7 +1856,11 @@ function execute(
       exitCode === 2
         ? [
             `worktree-lifecycle-create: ${message}`,
-            "Suggestion: pnpm beads:worktrees:apply",
+            // Gated for the same reason as above. `includeRetireByHand` is
+            // false here: this is compensate's generic exit-2 message, which
+            // covers refusals that are not about the worktree budget, and
+            // retire-by-hand advice is only a remedy for the budget ones.
+            ...maintenanceSuggestion(undefined, false),
           ]
         : [],
     );


### PR DESCRIPTION
Closes `cave-e4n3l`. Completes `cave-wmkn4` (#4448).

## What #4448 missed

#4448 routed `refusalOutcome` through `maintenanceSuggestion()`, which gates the `pnpm beads:worktrees:apply` suggestion on `capabilities.complete`. That was correct but not exhaustive — **two other emitters** still printed the literal unconditionally, both on the `compensate()` path:

- the post-creation fresh-assessment refusal (exit 2), alongside `exceptionSuggestion`;
- `compensate`'s generic exit-2 message.

`compensate()` is the rollback for a refusal discovered **after** the worktree has already been created. That is the worst place to print a dead next step: the operator is holding a half-created unit and gets told to run a command that `maintenance-gate.mjs` guarantees exits 2.

## The fix

Both now route through the same gate. The generic exit-2 path passes `includeRetireByHand: false` — retire-by-hand is a remedy for the *worktree budget*, and says nothing useful about the other refusals that path carries. That preserves the distinction #4448 introduced rather than blanket-printing advice.

## The guard, and why it is structural

The new assertion requires the literal to appear **exactly once**, and to sit on the line guarded by `capabilities.complete`.

Counting alone cannot express this. Grepping the literal returns a nonzero count whether or not the bug is present, because the gated branch legitimately contains the string. That ambiguity is precisely how verifying #4448 nearly reported these two emitters as fixed — the count was 2, which is indistinguishable from "correct plus one stray". Only reading the structure separated them.

**The guard was verified by breaking it.** Injecting an unconditional emitter into `errorOutcome` fails the run in seconds:

```
AssertionError: the --apply suggestion must have exactly one emitter; found 2:
```

It runs at import, before the fixture work, so a violation surfaces immediately rather than after several minutes. A guard nobody has watched fail is not yet a guard — and that mistake has been made twice today already, so this one was tested in the failing direction before being trusted.

## Verification

- `node scripts/worktree-lifecycle-create.test.mjs` → exit **0** with the guard in place.
- Injected-violation run → fails as quoted above; file restored and confirmed clean (`git diff` shows only the two intended files).
- `tsc --noEmit` clean.
- Structural re-check of the source: the only surviving occurrence is line 870, the `capabilities?.complete` branch; `maintenanceSuggestion(` now has three call sites.
