### PR TITLE
fix: content-bearing podcast closers, enforced host share, distinct interview shape

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -677,7 +677,10 @@ test("podcast styles branch the drafter without inventing findings", () => {
   const interview = draftPodcastContent(source, "standard", "interview");
   assert.equal(interview.kind, "podcast");
   if (interview.kind !== "podcast") return;
-  assert.ok(interview.script[0].text.includes("my guest walks us through"));
+  assert.ok(
+    interview.script[0].text.includes("what actually holds up"),
+    "interview opening frames the tension, not the format",
+  );
   assert.ok(
     interview.script.some((segment) =>
       segment.text.startsWith("Walk me through this part — Gating mechanisms"),
@@ -689,6 +692,163 @@ test("podcast styles branch the drafter without inventing findings", () => {
   assert.deepEqual(
     draftPodcastContent(source, "standard"),
     draftPodcastContent(source, "standard", "breakdown"),
+  );
+});
+
+test("podcast closers restate the section's lead finding verbatim as the takeaway", () => {
+  // Charm re-review (cave-upkaf): "got it" closers acknowledged but never
+  // synthesized. A short declarative lead sentence now returns in the host's
+  // closing turn, verbatim — content-bearing synthesis without invention.
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Gating mechanisms",
+      "",
+      "- Gates bind proxies, not purposes. The rest of the section keeps going.",
+      "",
+      "## Consolidation levers",
+      "",
+      "- Does goal-guarding generalize?",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const hosts = content.script.filter((segment) => segment.speaker === "host");
+  assert.ok(
+    hosts.some((segment) =>
+      segment.text.endsWith("keep this: Gates bind proxies, not purposes."),
+    ),
+    "a declarative lead sentence is restated verbatim in the host closer",
+  );
+  // A question is not a takeaway — restating "Does it generalize?" as the
+  // synthesis would be an editorial bug, so that section falls back to the
+  // acknowledgment closer.
+  assert.ok(
+    !hosts.some((segment) => segment.text.includes(": Does goal-guarding generalize?")),
+    "question-lead sections never get a question restated as the takeaway",
+  );
+});
+
+test("podcast host carries at least 20% of dialogue characters on realistic findings", () => {
+  // Charm re-review (cave-upkaf): host/guest balance measured 16.2%/83.8%
+  // against a 20–30% target. Content-bearing closers are the lever; this pins
+  // the floor on a fixture shaped like a real findings artifact.
+  const bullet =
+    "The evaluated gating mechanism held its measured containment rate across every replication run. " +
+    "Reviewers traced the residual drift to prompt-surface mutations rather than weight updates. " +
+    "The strongest observed failure mode was benchmark overfitting during the promotion step. " +
+    "Holdout tasks caught the regression before any mutation was promoted to production.";
+  const markdown = [
+    "# Findings",
+    "",
+    "## Gating mechanisms",
+    "",
+    `- ${bullet}`,
+    "",
+    "## Consolidation levers",
+    "",
+    `- ${bullet}`,
+    "",
+    "## Promotion safeguards",
+    "",
+    `- ${bullet}`,
+    "",
+    "## Rollback discipline",
+    "",
+    `- ${bullet}`,
+  ].join("\n");
+  for (const style of ["breakdown", "debate", "interview"] as const) {
+    const content = draftPodcastContent({
+      mission,
+      artifact: { key: "findings", title: "Findings — eval pricing" },
+      markdown,
+    }, "standard", style);
+    assert.equal(content.kind, "podcast");
+    if (content.kind !== "podcast") return;
+    const hostChars = content.script
+      .filter((segment) => segment.speaker === "host")
+      .reduce((sum, segment) => sum + segment.text.length, 0);
+    const totalChars = content.script.reduce((sum, segment) => sum + segment.text.length, 0);
+    const share = hostChars / totalChars;
+    assert.ok(
+      share >= 0.2,
+      `${style} host share stays at or above 20% (measured ${(share * 100).toFixed(1)}%)`,
+    );
+  }
+});
+
+test("podcast interview shapes its own turns — capped guest answers, host reactions, one challenge", () => {
+  // Charm re-review (cave-9wkyq): interview was "breakdown wearing an
+  // interview opening" — 5 of 8 turns identical. Interview now caps guest
+  // turns near 100 words, reacts between the splits, and spends exactly one
+  // real challenge on the contested section.
+  const sentences = Array.from(
+    { length: 40 },
+    (_, i) => `Claim number ${i + 1} holds under repeated evaluation pressure.`,
+  ).join(" ");
+  const source = {
+    mission,
+    artifact: { key: "findings", title: "Findings — eval pricing" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Gating mechanisms",
+      "",
+      `- ${sentences}`,
+      "",
+      "## Unresolved conflicts",
+      "",
+      "- Does goal-guarding generalize?",
+      "",
+      "## Consolidation levers",
+      "",
+      "- Gates bind proxies, not purposes.",
+    ].join("\n"),
+  };
+  const interview = draftPodcastContent(source, "standard", "interview");
+  assert.equal(interview.kind, "podcast");
+  if (interview.kind !== "podcast") return;
+  const guests = interview.script.filter((segment) => segment.speaker === "guest");
+  assert.ok(guests.length > 3, "long answers split into multiple guest turns");
+  for (const turn of guests) {
+    const words = turn.text.split(/\s+/).length;
+    assert.ok(words <= 100, `guest turns stay near 100 words (got ${words})`);
+    assert.match(turn.text, /^[A-Z0-9(“"']/, "split guest turns open at a sentence boundary");
+    assert.match(turn.text, /[.!?…]["'”’)\]]*$/, "split guest turns close at a sentence boundary");
+  }
+  // The host reacts between split guest turns instead of vanishing.
+  const scripted = interview.script;
+  let sawInterjection = false;
+  for (let index = 1; index < scripted.length - 1; index += 1) {
+    if (
+      scripted[index].speaker === "host" &&
+      scripted[index - 1].speaker === "guest" &&
+      scripted[index + 1].speaker === "guest"
+    ) {
+      sawInterjection = true;
+      break;
+    }
+  }
+  assert.ok(sawInterjection, "a host reaction lands between split guest turns");
+  // Exactly one challenge per episode, and it lands on the contested section.
+  const challenges = scripted.filter((segment) =>
+    segment.text.includes("Make the case for this one."),
+  );
+  assert.equal(challenges.length, 1, "exactly one challenge per episode");
+  assert.ok(
+    challenges[0].text.includes("Unresolved conflicts"),
+    "the challenge lands on the contested section",
+  );
+  // And the interview no longer drafts the same script as breakdown.
+  const breakdown = draftPodcastContent(source, "standard", "breakdown");
+  assert.equal(breakdown.kind, "podcast");
+  if (breakdown.kind !== "podcast") return;
+  assert.ok(
+    interview.script.length !== breakdown.script.length,
+    "interview is not breakdown wearing an interview opening",
   );
 });
 

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -1044,7 +1044,11 @@ function contestedSectionsFirst(units: NarrationUnit[]): NarrationUnit[] {
  * through distinct editorial jobs (orient / define / challenge / connect /
  * turn-to-practice) instead of repeating one generic line, and every section
  * ends on a short host synthesis turn rather than the guest's last list item
- * (cave-jckyz, Charm review #2/#5). Style guidance for dense research:
+ * (cave-jckyz, Charm review #2/#5). Closers are content-bearing: when the
+ * section's lead sentence is short enough, the host restates it verbatim as
+ * the takeaway instead of a bare acknowledgment (cave-upkaf, Charm
+ * re-review — measured host share was 16.2% against a 20–30% target and
+ * "got it" closers never synthesized). Style guidance for dense research:
  * breakdown (default) > interview (host as listener proxy) > recap > debate
  * (only when the source has genuinely competing interpretations).
  */
@@ -1068,16 +1072,25 @@ const PODCAST_DIALOGUE_TEMPLATES: Record<
         ],
         section,
       ),
-    closer: (section) =>
-      rotated(
-        [
-          "Okay — that one's on the board.",
-          "Good. Let's keep moving.",
-          "That's the takeaway there.",
-          "Noted — that piece matters.",
-        ],
-        section,
-      ),
+    closer: (section, takeaway) =>
+      takeaway
+        ? rotated(
+            [
+              `So if you keep one piece of that, keep this: ${takeaway}`,
+              `The takeaway there — ${takeaway}`,
+              `Put that one on the board: ${takeaway}`,
+            ],
+            section,
+          )
+        : rotated(
+            [
+              "Okay — that one's on the board.",
+              "Good. Let's keep moving.",
+              "That's the takeaway there.",
+              "Noted — that piece matters.",
+            ],
+            section,
+          ),
   }),
   debate: (missionTitle) => ({
     opening: `Welcome to the debate — today we're stress-testing “${spokenTitle(missionTitle)}”, starting where the findings are most contested.`,
@@ -1091,40 +1104,74 @@ const PODCAST_DIALOGUE_TEMPLATES: Record<
         ],
         section,
       ),
-    closer: (section) =>
-      rotated(
-        [
-          "So the jury's still out on that one.",
-          "Fair — I'll grant that point.",
-          "We'll have to leave that one contested.",
-          "That lands. Next round.",
-        ],
-        section,
-      ),
+    closer: (section, takeaway) =>
+      takeaway
+        ? rotated(
+            [
+              `Where that leaves us: ${takeaway}`,
+              `Then the record shows it: ${takeaway}`,
+              `If that holds, it holds on this: ${takeaway}`,
+            ],
+            section,
+          )
+        : rotated(
+            [
+              "So the jury's still out on that one.",
+              "Fair — I'll grant that point.",
+              "We'll have to leave that one contested.",
+              "That lands. Next round.",
+            ],
+            section,
+          ),
   }),
   interview: (missionTitle) => ({
-    opening: `Today my guest walks us through “${spokenTitle(missionTitle)}”. Let's get into it.`,
+    opening: `My guest has spent real time inside “${spokenTitle(missionTitle)}” — and I want to know what actually holds up. Let's get into it.`,
     framing: (title, section) =>
       rotated(
         [
           `Walk me through this part — ${speakable(title)}`,
           `For listeners just joining us, what does this actually mean? ${speakable(title)}`,
-          `Push back on me for a second here. ${speakable(title)}`,
+          `Where did this one surprise you? ${speakable(title)}`,
           `How does that square with what you said earlier? ${speakable(title)}`,
           `And for someone who wants to apply this tomorrow? ${speakable(title)}`,
         ],
         section,
       ),
-    closer: (section) =>
+    closer: (section, takeaway) =>
+      takeaway
+        ? rotated(
+            [
+              `So if I'm hearing you right: ${takeaway}`,
+              `Let me play that back — ${takeaway}`,
+              `So the version I'd repeat to a friend: ${takeaway}`,
+            ],
+            section,
+          )
+        : rotated(
+            [
+              "Got it — that's much clearer now.",
+              "That's a really useful way to put it.",
+              "Right — I hadn't thought of it that way.",
+              "Okay, that helps. Let's go on.",
+            ],
+            section,
+          ),
+    // Interview's own turn shape (cave-9wkyq): the guest never monologues —
+    // long answers split into short conversational turns with the host
+    // reacting in between, and exactly one real challenge lands per episode.
+    maxGuestTurnWords: 100,
+    interjection: (index) =>
       rotated(
         [
-          "Got it — that's much clearer now.",
-          "That's a really useful way to put it.",
-          "Right — I hadn't thought of it that way.",
-          "Okay, that helps. Let's go on.",
+          "Okay — keep going.",
+          "Right, so there's more to it.",
+          "Stay on this one — what else?",
+          "And that's not the whole story, is it?",
         ],
-        section,
+        index,
       ),
+    challenge: (title) =>
+      `You knew I'd push back somewhere — here's where. Make the case for this one. ${speakable(title)}`,
   }),
 };
 
@@ -1160,9 +1207,77 @@ type DialogueTemplate = {
   opening: string;
   /** Templated host bridge into a titled section; structure, never findings. */
   framing: (title: string, section: number) => string;
-  /** Templated host synthesis turn closing a titled section. */
-  closer: (section: number) => string;
+  /**
+   * Templated host synthesis turn closing a titled section. When the section
+   * yields a short declarative lead sentence, it arrives as `takeaway` and the
+   * closer restates it verbatim (cave-upkaf) — content-bearing synthesis, not
+   * an acknowledgment, without inventing a word.
+   */
+  closer: (section: number, takeaway?: string) => string;
+  /**
+   * Cap on guest-turn length in words. Longer answers split at sentence
+   * boundaries into separate turns so the guest never monologues (cave-9wkyq).
+   */
+  maxGuestTurnWords?: number;
+  /** Short templated host reaction slotted between split guest turns. */
+  interjection?: (index: number) => string;
+  /**
+   * One-per-episode challenge bridge, spent on the first contested section
+   * (never on furniture headings) in place of the rotating framing line.
+   */
+  challenge?: (title: string) => string;
 };
+
+const MAX_TAKEAWAY_CHARS = 160;
+
+/** First sentence of a chunk, when whole (terminator + trailing quotes). */
+const FIRST_SENTENCE_RE = /^[\s\S]*?[.!?…]["'”’)\]]*(?=\s|$)/;
+
+/**
+ * The section's lead sentence, restated verbatim by content-bearing closers.
+ * Declarative sentences only — a question restated as "the takeaway" is not a
+ * synthesis — and only when short enough to work as a spoken bookend.
+ */
+function sectionTakeaway(chunks: string[]): string | undefined {
+  const lead = chunks[0]?.trimStart();
+  if (!lead) return undefined;
+  const sentence = lead.match(FIRST_SENTENCE_RE)?.[0]?.trim();
+  if (!sentence || sentence.length > MAX_TAKEAWAY_CHARS) return undefined;
+  return /\.["'”’)\]]*$/.test(sentence) ? sentence : undefined;
+}
+
+/**
+ * Splits a chunk into sentence-bounded turns of at most `maxWords` words. A
+ * single sentence over the cap stays whole — a turn never opens or closes
+ * mid-sentence (cave-2emgc).
+ */
+function splitTurnByWordCap(text: string, maxWords: number): string[] {
+  const sentences: string[] = [];
+  let last = 0;
+  for (const match of text.matchAll(SENTENCE_BREAK_RE)) {
+    const end = match.index + match[0].length;
+    sentences.push(text.slice(last, end).trim());
+    last = end;
+  }
+  const tail = text.slice(last).trim();
+  if (tail) sentences.push(tail);
+  const turns: string[] = [];
+  let current = "";
+  let words = 0;
+  for (const sentence of sentences) {
+    const count = sentence.split(/\s+/).length;
+    if (current && words + count > maxWords) {
+      turns.push(current);
+      current = sentence;
+      words = count;
+    } else {
+      current = current ? `${current} ${sentence}` : sentence;
+      words += count;
+    }
+  }
+  if (current) turns.push(current);
+  return turns;
+}
 
 /**
  * Turns narration units into alternating host/guest turns. Framing lines are
@@ -1181,10 +1296,25 @@ function draftDialogueScript(
   if (units.length === 0 || template.opening.length > template.budget) {
     return [];
   }
+  // The episode's single challenge lands on the first contested real section;
+  // when nothing is contested it falls to the last real section — but never
+  // to an episode's only one, which carries the whole rapport.
+  let challengeUnit: NarrationUnit | null = null;
+  if (template.challenge) {
+    const eligible = units.filter(
+      (unit) =>
+        unit.title !== null &&
+        furnitureQuestion(unit.title.replace(/^\d+[.)]\s*/, "")) === null,
+    );
+    challengeUnit =
+      eligible.find((unit) => CONTESTED_TITLE_RE.test(unit.title ?? "")) ??
+      (eligible.length > 1 ? eligible[eligible.length - 1] : null);
+  }
   push(template.opening, "host");
   // Heading-less lines have no title to frame, so delivery alternates.
   let alternate: ResearchPodcastSpeaker = "guest";
   let section = 0;
+  let interjections = 0;
   outer: for (const unit of units) {
     const chunks = splitMediaDraftText(unit.text);
     if (chunks.length === 0) continue;
@@ -1192,18 +1322,40 @@ function draftDialogueScript(
       // Document furniture becomes a listener question; real headings get the
       // style's rotating bridge (list numbering never gets spoken).
       const heading = unit.title.replace(/^\d+[.)]\s*/, "");
-      const framing = furnitureQuestion(heading) ?? template.framing(heading, section);
+      const framing =
+        furnitureQuestion(heading) ??
+        (unit === challengeUnit && template.challenge
+          ? template.challenge(heading)
+          : template.framing(heading, section));
       // Never leave an orphan host question: the framing line only enters
       // when at least its first findings chunk also fits the budget.
       if (used + framing.length + chunks[0].length > template.budget) break;
       push(framing, "host");
+      let guestTurnsInSection = 0;
       for (const chunk of chunks) {
-        if (used + chunk.length > template.budget) break outer;
-        push(chunk, "guest");
+        const guestTurns = template.maxGuestTurnWords
+          ? splitTurnByWordCap(chunk, template.maxGuestTurnWords)
+          : [chunk];
+        for (const turn of guestTurns) {
+          if (guestTurnsInSection > 0 && template.interjection) {
+            // A host reaction between guest turns only enters when the guest
+            // turn it introduces also fits — no orphan interjections.
+            const interjection = template.interjection(interjections);
+            if (used + interjection.length + turn.length > template.budget) {
+              break outer;
+            }
+            push(interjection, "host");
+            interjections += 1;
+          } else if (used + turn.length > template.budget) {
+            break outer;
+          }
+          push(turn, "guest");
+          guestTurnsInSection += 1;
+        }
       }
       // Host synthesis bookend — a section ends on the host's turn, not the
       // guest's last list item. Skipped only when the budget is spent.
-      const closer = template.closer(section);
+      const closer = template.closer(section, sectionTakeaway(chunks));
       if (used + closer.length <= template.budget) {
         push(closer, "host");
       }


### PR DESCRIPTION
Implements Charm's two remaining editorial notes from her re-review of the tuned podcast templates (beads **cave-upkaf**, **cave-9wkyq**).

## What changed

### Content-bearing closers + host share floor (cave-upkaf)
Charm measured host/guest balance at **16.2% / 83.8%** against a 20–30% target, and noted closers acknowledged ("Got it — that's much clearer now.") but never synthesized.

- Section closers now restate the section's short declarative lead sentence **verbatim** as the takeaway (`So if you keep one piece of that, keep this: …`). Extractive discipline holds: the host never invents a word — questions are never restated as takeaways, and sections without a suitable sentence fall back to the old acknowledgments.
- New regression pins **host share ≥ 20%** across breakdown, debate, and interview on a realistic findings fixture.

### Distinct interview turn shape (cave-9wkyq)
Charm: interview was "breakdown wearing an interview opening" — 5 of 8 turns identical, opening described the format instead of framing tension.

- Guest turns capped near **100 words**, split at sentence boundaries (never opening/closing mid-sentence).
- Rotating host reactions land **between** the split guest turns.
- Exactly **one real challenge** per episode, spent on the first contested section — never on furniture headings, never on an episode's only section.
- Opening now frames the tension ("…and I want to know what actually holds up").

Breakdown/debate scripts are unchanged apart from takeaway closers; the `default === breakdown` identity test still passes.

## Verification
- `node --experimental-strip-types --test src/lib/server/research-generations.test.ts` — **44/44** (3 new regressions)
- `node --experimental-strip-types --test src/lib/server/research-podcast-pipeline.test.ts` — **13/13**
- `pnpm exec tsc --noEmit` — clean