### PR TITLE
Standardize research landing root as a granted Cave project

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1198,6 +1198,7 @@ export const SUITES = {
     "src/lib/server/cave-home-migration-discard-guard.test.ts",
     "src/lib/server/cave-home-migration-fast-path.test.ts",
     "src/lib/testing/wait-for.test.ts",
+    "src/lib/server/research-landing.test.ts",
     "src/lib/server/claude-models.test.ts",
     "src/lib/server/copilot-models.test.ts",
     "src/lib/server/grok-models.test.ts",

--- a/src/lib/server/research-landing.test.ts
+++ b/src/lib/server/research-landing.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const tmp = await mkdtemp(path.join(tmpdir(), "research-landing-test-"));
+process.env.CAVE_PROJECT_PERMISSIONS_PATH_OVERRIDE = path.join(tmp, "permissions.json");
+process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(tmp, "permission-config.json");
+process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "projects.json");
+process.env.COVEN_RESEARCH_MISSIONS_DIR = path.join(tmp, "research-missions");
+
+const {
+  ensureResearchLandingAccess,
+  ensureResearchLandingProject,
+  migrateAdHocMissionGrants,
+  RESEARCH_LANDING_PROJECT_NAME,
+} = await import("./research-landing.ts");
+const { createProject, loadProjects } = await import("../cave-projects.ts");
+const {
+  createAccessGroup,
+  effectiveProjectAccess,
+  grantProjectToFamiliar,
+  listProjectGrants,
+  loadProjectPermissions,
+} = await import("../project-permissions.ts");
+const { researchMissionsRoot } = await import("./research-mission-store.ts");
+
+test.after(async () => {
+  await rm(tmp, { recursive: true, force: true });
+});
+
+test("the research landing root is registered as a Cave project exactly once", async () => {
+  const project = await ensureResearchLandingProject();
+  assert.equal(project.name, RESEARCH_LANDING_PROJECT_NAME);
+  assert.equal(project.root, researchMissionsRoot());
+  // The root exists on disk — a registered-but-missing directory would be
+  // dropped by savedCaveProjectRoots' validation and stay unusable.
+  assert.ok((await stat(researchMissionsRoot())).isDirectory());
+
+  const again = await ensureResearchLandingProject();
+  assert.equal(again.id, project.id, "re-ensuring returns the same project");
+  const projects = await loadProjects();
+  assert.equal(
+    projects.filter((entry) => entry.root === researchMissionsRoot()).length,
+    1,
+    "one project per landing root",
+  );
+});
+
+test("run-start access check grants the landing project to a familiar without access", async () => {
+  const first = await ensureResearchLandingAccess("sage");
+  assert.equal(first.granted, true, "missing access is granted");
+  const permissions = await loadProjectPermissions();
+  const effective = effectiveProjectAccess(permissions, "sage", first.project.id);
+  assert.equal(effective.level, "write");
+  const grant = (await listProjectGrants()).find(
+    (entry) => entry.familiarId === "sage" && entry.projectId === first.project.id,
+  );
+  assert.equal(grant?.source, "bootstrap");
+});
+
+test("an existing grant is left untouched on later runs", async () => {
+  const before = await listProjectGrants();
+  const second = await ensureResearchLandingAccess("sage");
+  assert.equal(second.granted, false, "effective access short-circuits the grant");
+  assert.deepEqual(await listProjectGrants(), before, "no grant record changed");
+});
+
+test("ad-hoc per-mission grants migrate onto the landing project", async () => {
+  const landing = await ensureResearchLandingProject();
+  const missionRoot = path.join(researchMissionsRoot(), "research-legacy-mission");
+  const outside = await createProject({ name: "Unrelated", root: path.join(tmp, "unrelated") });
+  const adHoc = await createProject({ name: "research-legacy-mission", root: missionRoot });
+  await grantProjectToFamiliar({
+    familiarId: "echo",
+    projectId: adHoc.id,
+    source: "human",
+    access: "read",
+  });
+  await grantProjectToFamiliar({
+    familiarId: "echo",
+    projectId: outside.id,
+    source: "human",
+    access: "write",
+  });
+  // A group grant on the ad-hoc project must migrate its members too.
+  await createAccessGroup({
+    name: "Researchers",
+    memberFamiliarIds: ["astra"],
+    projectGrants: [{ projectId: adHoc.id, access: "write" }],
+  });
+
+  const result = await migrateAdHocMissionGrants(landing);
+  assert.equal(result.removedProjects, 1);
+  assert.deepEqual([...result.migratedFamiliarIds].sort(), ["astra", "echo"]);
+
+  const permissions = await loadProjectPermissions();
+  assert.equal(
+    effectiveProjectAccess(permissions, "echo", landing.id).level,
+    "read",
+    "the direct ad-hoc level carries over",
+  );
+  assert.equal(
+    effectiveProjectAccess(permissions, "astra", landing.id).level,
+    "write",
+    "the group ad-hoc level carries over",
+  );
+  const projects = await loadProjects();
+  assert.ok(!projects.some((entry) => entry.id === adHoc.id), "ad-hoc project removed");
+  assert.ok(projects.some((entry) => entry.id === outside.id), "unrelated project kept");
+  assert.ok(
+    !(await listProjectGrants()).some((entry) => entry.projectId === adHoc.id),
+    "no grant still points at the removed project",
+  );
+  assert.ok(
+    (await listProjectGrants()).some(
+      (entry) => entry.familiarId === "echo" && entry.projectId === outside.id,
+    ),
+    "grants outside the landing root are untouched",
+  );
+
+  const again = await migrateAdHocMissionGrants(landing);
+  assert.deepEqual(again, { removedProjects: 0, migratedFamiliarIds: [] }, "idempotent");
+});
+
+test("migration never downgrades an existing landing grant", async () => {
+  const landing = await ensureResearchLandingProject();
+  // sage already holds write on the landing project from the earlier test.
+  const adHoc = await createProject({
+    name: "research-old-mission",
+    root: path.join(researchMissionsRoot(), "research-old-mission"),
+  });
+  await grantProjectToFamiliar({
+    familiarId: "sage",
+    projectId: adHoc.id,
+    source: "human",
+    access: "read",
+  });
+  const result = await migrateAdHocMissionGrants(landing);
+  assert.equal(result.removedProjects, 1);
+  assert.deepEqual(result.migratedFamiliarIds, [], "write already satisfies read");
+  const permissions = await loadProjectPermissions();
+  assert.equal(effectiveProjectAccess(permissions, "sage", landing.id).level, "write");
+});

--- a/src/lib/server/research-landing.ts
+++ b/src/lib/server/research-landing.ts
@@ -1,0 +1,155 @@
+import { mkdir } from "node:fs/promises";
+import type { CaveProject } from "../cave-projects.ts";
+import { createProject, deleteProject, loadProjects, projectForRoot } from "../cave-projects.ts";
+import {
+  accessLevelSatisfies,
+  maxAccessLevel,
+  normalizeAccessLevel,
+  type ProjectAccessLevel,
+} from "../project-access-levels.ts";
+import {
+  effectiveProjectAccess,
+  grantProjectToFamiliar,
+  loadProjectPermissions,
+  revokeAllGrantsForProject,
+} from "../project-permissions.ts";
+import { researchMissionsRoot } from "./research-mission-store.ts";
+
+/**
+ * research-landing.ts
+ *
+ * The standard place research lands: every mission workspace lives under
+ * researchMissionsRoot() (~/.coven/cave/research-missions). This module makes
+ * that landing root a first-class Cave project so the normal grant machinery
+ * covers it — a familiar granted the landing project sees ALL of its research
+ * output in later chat sessions (the chat boundary is built from registered
+ * projects via filterProjectsForFamiliar), instead of relying on ad-hoc
+ * per-mission grants that nobody remembers to add.
+ */
+
+export const RESEARCH_LANDING_PROJECT_NAME = "Research Missions";
+
+/**
+ * Idempotently register the research landing root as a Cave project. The
+ * directory is created first: project-paths' savedCaveProjectRoots() drops
+ * roots that fail statSync, so a registered-but-missing directory would be
+ * silently unusable.
+ */
+export async function ensureResearchLandingProject(): Promise<CaveProject> {
+  const root = researchMissionsRoot();
+  await mkdir(/* turbopackIgnore: true */ root, { recursive: true });
+  const existing = projectForRoot(root, await loadProjects());
+  if (existing) return existing;
+  // createProject is idempotent per root — a concurrent registration returns
+  // the already-persisted record.
+  return createProject({ name: RESEARCH_LANDING_PROJECT_NAME, root });
+}
+
+export type ResearchLandingAccess = {
+  project: CaveProject;
+  /** True when this call added the grant (vs. already effective). */
+  granted: boolean;
+};
+
+/**
+ * Ensure the familiar can reach the research landing root: register the
+ * landing project if needed, fold any legacy ad-hoc per-mission grants into
+ * it, and add a write grant when the familiar has no effective access. An
+ * existing grant (direct or via group) is left untouched — this never
+ * upgrades or downgrades a level a human chose.
+ */
+export async function ensureResearchLandingAccess(
+  familiarId: string,
+): Promise<ResearchLandingAccess> {
+  const project = await ensureResearchLandingProject();
+  await migrateAdHocMissionGrants(project);
+  const permissions = await loadProjectPermissions();
+  const effective = effectiveProjectAccess(permissions, familiarId, project.id);
+  if (effective.level) return { project, granted: false };
+  await grantProjectToFamiliar({
+    familiarId,
+    projectId: project.id,
+    source: "bootstrap",
+    access: "write",
+    actor: "system",
+  });
+  return { project, granted: true };
+}
+
+export type AdHocMissionGrantMigration = {
+  /** Ad-hoc per-mission projects removed from the registry. */
+  removedProjects: number;
+  /** Familiars whose ad-hoc access was folded into the landing project. */
+  migratedFamiliarIds: string[];
+};
+
+/** Registered project roots use forward slashes with no trailing separator. */
+function normalizeRegisteredRoot(root: string): string {
+  const normalized = root.replace(/\\/g, "/");
+  let end = normalized.length;
+  while (end > 0 && normalized[end - 1] === "/") end--;
+  return normalized.slice(0, end) || "/";
+}
+
+/**
+ * Fold legacy ad-hoc grants into the standard landing project. Before the
+ * landing project existed, reaching a mission's output from chat required
+ * registering the individual mission directory as its own project and
+ * granting THAT — leaving one narrow, easily-forgotten grant per mission.
+ * Every registered project strictly inside the landing root is such a relic:
+ * each familiar with access (direct or via group) gets at least the same
+ * level on the landing project, then the per-mission project and all of its
+ * grants are removed. Idempotent and cheap when no ad-hoc project exists.
+ */
+export async function migrateAdHocMissionGrants(
+  landing: CaveProject,
+): Promise<AdHocMissionGrantMigration> {
+  const landingRoot = normalizeRegisteredRoot(landing.root);
+  const adHoc = (await loadProjects()).filter((project) =>
+    project.id !== landing.id &&
+    normalizeRegisteredRoot(project.root).startsWith(landingRoot + "/"),
+  );
+  if (adHoc.length === 0) return { removedProjects: 0, migratedFamiliarIds: [] };
+
+  // Highest access each familiar held on any ad-hoc mission project, from
+  // direct grants and group grants alike — the landing grant must not be
+  // weaker than what the migration removes.
+  const permissions = await loadProjectPermissions();
+  const adHocIds = new Set(adHoc.map((project) => project.id));
+  const levels = new Map<string, ProjectAccessLevel>();
+  const record = (familiarId: string, access: unknown) => {
+    const level = normalizeAccessLevel(access);
+    levels.set(familiarId, maxAccessLevel(levels.get(familiarId) ?? null, level) ?? level);
+  };
+  for (const grant of permissions.projectGrants) {
+    if (adHocIds.has(grant.projectId)) record(grant.familiarId, grant.access);
+  }
+  for (const group of permissions.accessGroups ?? []) {
+    for (const grant of group.projectGrants) {
+      if (!adHocIds.has(grant.projectId)) continue;
+      for (const familiarId of group.memberFamiliarIds) record(familiarId, grant.access);
+    }
+  }
+
+  const migratedFamiliarIds: string[] = [];
+  for (const [familiarId, level] of levels) {
+    const effective = effectiveProjectAccess(permissions, familiarId, landing.id);
+    if (accessLevelSatisfies(effective.level, level)) continue;
+    await grantProjectToFamiliar({
+      familiarId,
+      projectId: landing.id,
+      source: "bootstrap",
+      access: level,
+      actor: "system",
+    });
+    migratedFamiliarIds.push(familiarId);
+  }
+
+  for (const project of adHoc) {
+    // Grants first: a crash between the two operations must leave the grants
+    // pointing at a still-registered project, never orphaned records.
+    await revokeAllGrantsForProject(project.id);
+    await deleteProject(project.id);
+  }
+  return { removedProjects: adHoc.length, migratedFamiliarIds };
+}

--- a/src/lib/server/research-mission-runner-automation-scheduling.test.ts
+++ b/src/lib/server/research-mission-runner-automation-scheduling.test.ts
@@ -56,6 +56,8 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     fingerprintMission: async () => "checkpoint-before",
     missionWorkspacePath: (id) => `/tmp/research-missions/${id}`,
     resolveProjectRoot: async (root) => root,
+    ensureResearchAccess: async () => {},
+    checkFamiliarRootAccess: async () => null,
     now: () => NOW,
     randomId: () => "mission-1",
     ...overrides,

--- a/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
+++ b/src/lib/server/research-mission-runner-concurrency-terminal.test.ts
@@ -75,6 +75,8 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     fingerprintMission: async () => "checkpoint-before",
     missionWorkspacePath: (id) => `/tmp/research-missions/${id}`,
     resolveProjectRoot: async (root) => root,
+    ensureResearchAccess: async () => {},
+    checkFamiliarRootAccess: async () => null,
     now: () => NOW,
     randomId: () => "mission-1",
     ...overrides,

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -81,6 +81,8 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     fingerprintMission: async () => "checkpoint-before",
     missionWorkspacePath: (id) => `/tmp/research-missions/${id}`,
     resolveProjectRoot: async (root) => root,
+    ensureResearchAccess: async () => {},
+    checkFamiliarRootAccess: async () => null,
     now: () => NOW,
     randomId: () => "mission-1",
     ...overrides,
@@ -213,6 +215,52 @@ test("an unallowed configured project root fails fast with an actionable error",
   assert.match(result.lastError ?? "", /"\/missing\/repo" is not an allowed project path/);
   assert.match(result.lastError ?? "", /mission workspace/);
   assert.ok(allowedResearchActions(result).includes("retry"));
+});
+
+test("run start ensures the familiar's standard research landing access", async () => {
+  const ensured: string[] = [];
+  const runner = makeResearchMissionRunner(deps({
+    ensureResearchAccess: async (familiarId) => {
+      ensured.push(familiarId);
+    },
+  }));
+  const result = await runner.createAndStart(INPUT);
+  assert.deepEqual(ensured, ["sage"]);
+  assert.equal(result.status, "running");
+});
+
+test("a configured project root the familiar cannot access fails fast before launch", async () => {
+  let starts = 0;
+  const checked: Array<[string, string]> = [];
+  const runner = makeResearchMissionRunner(deps({
+    checkFamiliarRootAccess: async (familiarId, projectRoot) => {
+      checked.push([familiarId, projectRoot]);
+      return `Familiar "${familiarId}" does not have access to project root "${projectRoot}".`;
+    },
+    startFlow: async () => {
+      starts += 1;
+      return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
+    },
+  }));
+  const result = await runner.createAndStart({ ...INPUT, projectRoot: "/allowed/repo" });
+  assert.equal(starts, 0, "no session may launch against a root the familiar cannot use");
+  assert.deepEqual(checked, [["sage", "/allowed/repo"]]);
+  assert.equal(result.status, "failed");
+  assert.match(result.lastError ?? "", /does not have access to project root "\/allowed\/repo"/);
+  assert.ok(allowedResearchActions(result).includes("retry"));
+});
+
+test("the default mission workspace never requires a familiar root-access check", async () => {
+  let checks = 0;
+  const runner = makeResearchMissionRunner(deps({
+    checkFamiliarRootAccess: async () => {
+      checks += 1;
+      return "should never be consulted";
+    },
+  }));
+  const result = await runner.createAndStart(INPUT);
+  assert.equal(checks, 0);
+  assert.equal(result.status, "running");
 });
 
 test("travel launch remains honestly queued", async () => {

--- a/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
+++ b/src/lib/server/research-mission-runner-reconciliation-evidence.test.ts
@@ -58,6 +58,8 @@ function deps(overrides: Partial<ResearchMissionRunnerDeps> = {}): ResearchMissi
     fingerprintMission: async () => "checkpoint-before",
     missionWorkspacePath: (id) => `/tmp/research-missions/${id}`,
     resolveProjectRoot: async (root) => root,
+    ensureResearchAccess: async () => {},
+    checkFamiliarRootAccess: async () => null,
     now: () => NOW,
     randomId: () => "mission-1",
     ...overrides,

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -132,6 +132,21 @@ export type ResearchMissionRunnerDeps = {
   missionWorkspacePath(id: string): string;
   /** Resolve a candidate project root to a normalized allowed path, or null. */
   resolveProjectRoot(root: string): Promise<string | null>;
+  /**
+   * Run-start preflight: make sure the mission's familiar can reach the
+   * standard research landing root (where every mission workspace lives), so
+   * finished research is visible from the familiar's later sessions without a
+   * manual grant. Best-effort by contract — implementations MUST NOT throw; a
+   * failed grant degrades to results that land but aren't chat-reachable.
+   */
+  ensureResearchAccess(familiarId: string): Promise<void>;
+  /**
+   * Familiar-level access check for a configured project root at run start.
+   * Returns an actionable error message when the root is a registered project
+   * the familiar cannot use; null when access is fine (including
+   * allowed-but-unregistered roots such as the mission workspace).
+   */
+  checkFamiliarRootAccess(familiarId: string, projectRoot: string): Promise<string | null>;
   now(): Date;
   randomId(): string;
 };
@@ -541,18 +556,31 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
    * Resolve the project root an iteration will run in before any session is
    * spawned. A configured-but-unallowed root fails fast with an actionable
    * message (the flow executor would only say "invalid project root"); the
-   * default mission workspace always resolves.
+   * default mission workspace always resolves. Every start path (create,
+   * next iteration, retry) routes through here, so this is also where run
+   * preflight lives: the familiar's standard-landing grant is ensured, and a
+   * configured registered root the familiar cannot use is refused before a
+   * session is spent.
    */
   const missionStartTarget = async (
     mission: ResearchMission,
   ): Promise<{ ok: true; projectRoot: string } | { ok: false; error: string }> => {
+    // Standard landing access: research artifacts always land in the mission
+    // workspace under the research landing root — make sure the mission's
+    // familiar can reach them from later sessions before this run produces
+    // anything. Best-effort by contract: implementations never throw.
+    await deps.ensureResearchAccess(mission.familiarId);
     if (mission.projectRoot) {
       const resolved = await deps.resolveProjectRoot(mission.projectRoot);
-      if (resolved) return { ok: true, projectRoot: resolved };
-      return {
-        ok: false,
-        error: `Project root "${mission.projectRoot}" is not an allowed project path. Retry in the mission workspace, or set a valid root (an existing Cave project or workspace folder).`,
-      };
+      if (!resolved) {
+        return {
+          ok: false,
+          error: `Project root "${mission.projectRoot}" is not an allowed project path. Retry in the mission workspace, or set a valid root (an existing Cave project or workspace folder).`,
+        };
+      }
+      const denied = await deps.checkFamiliarRootAccess(mission.familiarId, resolved);
+      if (denied) return { ok: false, error: denied };
+      return { ok: true, projectRoot: resolved };
     }
     const workspace = deps.missionWorkspacePath(mission.id);
     const resolved = await deps.resolveProjectRoot(workspace);
@@ -1542,6 +1570,35 @@ export function makeProductionResearchMissionRunner() {
     resolveProjectRoot: async (root) => {
       const { normalizeProjectRoot } = await import("./session-security.ts");
       return normalizeProjectRoot(root);
+    },
+    ensureResearchAccess: async (familiarId) => {
+      // Never let a landing-grant failure block the run itself: the mission
+      // workspace stays writable through builtInProjectRoots either way, so
+      // the worst outcome of a failure here is today's status quo (results
+      // land but need a manual grant to be chat-reachable).
+      try {
+        const { ensureResearchLandingAccess } = await import("./research-landing.ts");
+        await ensureResearchLandingAccess(familiarId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`research landing grant for ${familiarId} failed: ${message}`);
+      }
+    },
+    checkFamiliarRootAccess: async (familiarId, projectRoot) => {
+      const { assertProjectRootAccess, ProjectAccessDeniedError } = await import(
+        "../project-permissions.ts"
+      );
+      try {
+        await assertProjectRootAccess({ familiarId }, projectRoot, "session-launch", {
+          allowUnregisteredRoot: true,
+        });
+        return null;
+      } catch (error) {
+        if (error instanceof ProjectAccessDeniedError) {
+          return `Familiar "${familiarId}" does not have access to project root "${projectRoot}". Grant the project to this familiar in Permissions, or clear the mission's project root to run in its workspace.`;
+        }
+        throw error;
+      }
     },
     now: () => new Date(),
     randomId: () => `research-${crypto.randomUUID()}`,


### PR DESCRIPTION
## Problem

Research missions always land in one standard place — `researchMissionsRoot()` (`~/.coven/cave/research-missions/<mission>`) — but that root was invisible to the familiar grant machinery. The chat boundary is built from registered projects with grants (`filterProjectsForFamiliar`), so finished research was unreachable from the familiar's later sessions unless someone hand-registered the individual mission directory as its own project and granted it. Exactly one such ad-hoc per-mission grant exists in the live permission store today — the symptom this PR removes.

## Changes

**`src/lib/server/research-landing.ts` (new)**
- `ensureResearchLandingProject()` — idempotently registers the landing root as the **Research Missions** Cave project (one per root, mkdir first so the registered root always stats).
- `ensureResearchLandingAccess(familiarId)` — adds a write grant only when the familiar has no effective access; a human-chosen level is never upgraded or downgraded.
- `migrateAdHocMissionGrants(landing)` — folds legacy per-mission project grants (direct **and** group) into the landing project at the same-or-stronger level, then removes the ad-hoc projects and every grant record pointing at them (`revokeAllGrantsForProject` + `deleteProject`). Idempotent; runs as part of the run-start ensure.

**`src/lib/server/research-mission-runner.ts`**
- Two new runner deps wired into `missionStartTarget` — the chokepoint every start path (create / next iteration / retry) routes through:
  - `ensureResearchAccess` — best-effort landing grant at every run start; a failure logs and degrades to today's behavior, never blocks the run.
  - `checkFamiliarRootAccess` — a configured **registered** project root the mission familiar cannot use now fails fast with an actionable message instead of spending a session (`assertProjectRootAccess` with `allowUnregisteredRoot: true`, so the mission workspace default keeps working unchecked).

Chat sessions need no changes: the landing grant flows into `grantedProjectRoots` automatically.

## Verification

- `research-landing.test.ts`: registration idempotence, run-start grant, no-touch on existing grants, ad-hoc migration (direct + group, level carry-over, unrelated projects untouched, idempotence), no-downgrade guarantee.
- Runner suites extended: landing access ensured at start, familiar-denied configured root fails before launch, workspace default skips the check. 82 tests pass across the five touched suites.
- `tsc --noEmit` clean.

Bead: cave-6tlhq