### PR TITLE
fix: accept any non-question terminator as takeaway-eligible

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -712,6 +712,10 @@ test("podcast closers restate the section's lead finding verbatim as the takeawa
       "## Consolidation levers",
       "",
       "- Does goal-guarding generalize?",
+      "",
+      "## Promotion safeguards",
+      "",
+      "- Holdouts catch the regression every time! The promotion step never saw it.",
     ].join("\n"),
   }, "standard");
   assert.equal(content.kind, "podcast");
@@ -729,6 +733,13 @@ test("podcast closers restate the section's lead finding verbatim as the takeawa
   assert.ok(
     !hosts.some((segment) => segment.text.includes(": Does goal-guarding generalize?")),
     "question-lead sections never get a question restated as the takeaway",
+  );
+  // Non-question terminators all qualify — an exclamation is still declarative.
+  assert.ok(
+    hosts.some((segment) =>
+      segment.text.includes("Holdouts catch the regression every time!"),
+    ),
+    "an exclamation-terminated lead sentence still becomes the takeaway",
   );
 });
 

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -1236,14 +1236,15 @@ const FIRST_SENTENCE_RE = /^[\s\S]*?[.!?…]["'”’)\]]*(?=\s|$)/;
 /**
  * The section's lead sentence, restated verbatim by content-bearing closers.
  * Declarative sentences only — a question restated as "the takeaway" is not a
- * synthesis — and only when short enough to work as a spoken bookend.
+ * synthesis — and only when short enough to work as a spoken bookend. Any
+ * non-question terminator qualifies; only `?` disqualifies.
  */
 function sectionTakeaway(chunks: string[]): string | undefined {
   const lead = chunks[0]?.trimStart();
   if (!lead) return undefined;
   const sentence = lead.match(FIRST_SENTENCE_RE)?.[0]?.trim();
   if (!sentence || sentence.length > MAX_TAKEAWAY_CHARS) return undefined;
-  return /\.["'”’)\]]*$/.test(sentence) ? sentence : undefined;
+  return /\?["'”’)\]]*$/.test(sentence) ? undefined : sentence;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #4454, addressing the Copilot review thread that landed there (the PR merged before the fix could ride along).

**Problem:** `sectionTakeaway` only accepted lead sentences terminated by `.`, while the sentence-splitting regexes treat `!` and `…` as terminators too. A declarative lead ending in `!` or `…` silently fell back to a content-free acknowledgment closer — exactly the editorial gap #4454 exists to close.

**Fix:** invert the check — any non-question terminator qualifies; only `?`-terminated leads are disqualified (questions must never be restated as takeaways).

**Test:** the takeaway-closer regression test now includes an exclamation-terminated lead section and asserts it becomes a spoken takeaway, alongside the existing question-exclusion assertion.

Verified: 44/44 `research-generations.test.ts`, `tsc --noEmit` clean.