### PR TITLE
feat(afs): add the Cave agent filesystem surfaces

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -22,6 +22,7 @@ import { fileURLToPath } from "node:url";
 /** Suite name -> ordered list of repo-relative test file paths. */
 export const SUITES = {
   app: [
+    "src/lib/afs.test.ts",
     "src/lib/array-content-equal.test.ts",
     "src/lib/native-notify.test.ts",
     "src/lib/session-list-equal.test.ts",

--- a/src/app/api/afs/[id]/commit/route.ts
+++ b/src/app/api/afs/[id]/commit/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+import { readJsonBody, rejectNonLocalRequest } from "@/lib/server/api-security";
+import { MAX_SESSION_JSON_BYTES } from "@/lib/server/session-security";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type CommitBody = {
+  branch?: string | null;
+  message?: string | null;
+  coAuthors?: string[] | null;
+};
+
+/**
+ * Materialize a delta into a signed git branch.
+ *
+ * Commit is an explicit operator action: Cave never materializes
+ * automatically, so this route exists only behind a deliberate click. There
+ * is no dryRun mode on the daemon yet (bead coven-y7a), which is why the pane
+ * previews from diff counts and says so.
+ */
+export async function POST(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const { id } = await params;
+  const parsed = await readJsonBody<CommitBody>(req, MAX_SESSION_JSON_BYTES);
+  if (!parsed.ok) return parsed.response;
+
+  const body: CommitBody = parsed.body ?? {};
+  const branch = typeof body.branch === "string" ? body.branch.trim() : "";
+  const message = typeof body.message === "string" ? body.message.trim() : "";
+  const coAuthors = Array.isArray(body.coAuthors)
+    ? body.coAuthors.filter(
+        (author: unknown): author is string => typeof author === "string" && author.trim().length > 0,
+      )
+    : [];
+
+  const res = await callDaemon<unknown>({
+    method: "POST",
+    path: `/api/v1/afs/sessions/${encodeURIComponent(id)}/commit`,
+    body: {
+      ...(branch ? { branch } : {}),
+      ...(message ? { message } : {}),
+      ...(coAuthors.length > 0 ? { coAuthors } : {}),
+    },
+    // Materialization walks the change set and shells out to git; the default
+    // 4s budget is too tight for a real repository.
+    timeoutMs: 60_000,
+    // A commit is not idempotent — a transport retry could land two branches.
+    retryTransportFailure: false,
+  });
+
+  if (!res.ok) {
+    // afs.base_diverged, afs.path_outside_root, afs.copy_up_too_large,
+    // afs.commit_conflict and afs.commit_unsigned all reach the operator
+    // verbatim; the whole point of the codes is that they are actionable.
+    return NextResponse.json(res.data ?? { error: res.error }, { status: res.status || 502 });
+  }
+  return NextResponse.json(res.data);
+}

--- a/src/app/api/afs/[id]/diff/route.ts
+++ b/src/app/api/afs/[id]/diff/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import type { AfsDiff } from "@/lib/afs";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const { id } = await params;
+  const res = await callDaemon<AfsDiff>({ path: `/api/v1/afs/sessions/${encodeURIComponent(id)}/diff` });
+  if (!res.ok) {
+    // Pass the daemon's structured error through rather than flattening it:
+    // the dotted code is what the pane renders.
+    return NextResponse.json(res.data ?? { error: res.error }, { status: res.status || 502 });
+  }
+  return NextResponse.json(res.data);
+}

--- a/src/app/api/afs/[id]/timeline/route.ts
+++ b/src/app/api/afs/[id]/timeline/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import type { AfsTimeline } from "@/lib/afs";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/** The daemon rejects anything outside 1..=1000; clamp rather than 400. */
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 1000;
+
+export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const { id } = await params;
+  const search = new URL(req.url).searchParams;
+  const since = Number.parseInt(search.get("since") ?? "0", 10);
+  const requested = Number.parseInt(search.get("limit") ?? "", 10);
+  const limit = Number.isFinite(requested)
+    ? Math.min(Math.max(requested, 1), MAX_LIMIT)
+    : DEFAULT_LIMIT;
+
+  const query = `since=${Number.isFinite(since) && since > 0 ? since : 0}&limit=${limit}`;
+  const res = await callDaemon<AfsTimeline>({
+    path: `/api/v1/afs/sessions/${encodeURIComponent(id)}/timeline?${query}`,
+  });
+  if (!res.ok) {
+    return NextResponse.json(res.data ?? { error: res.error }, { status: res.status || 502 });
+  }
+  return NextResponse.json(res.data);
+}

--- a/src/app/api/afs/route.ts
+++ b/src/app/api/afs/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { callDaemon } from "@/lib/coven-daemon";
+import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import {
+  afsSessionForCovenSession,
+  readAfsCapabilities,
+  type AfsCapabilities,
+  type AfsSession,
+} from "@/lib/afs";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+/**
+ * Capabilities plus the AFS delta bound to a Cave session.
+ *
+ * AFS routes expose a session's working tree, so — like session handoff —
+ * they are same-user local IPC and every entry point rejects a non-local
+ * request (`specs/coven-agent-fs/DESIGN.md` §3).
+ *
+ * One round trip answers "should the pane render at all, and does this
+ * session even have a delta", which is the question every pane asks first.
+ */
+export type AfsOverviewResponse = {
+  ok: boolean;
+  capabilities: AfsCapabilities;
+  session: AfsSession | null;
+  error?: string;
+};
+
+export async function GET(req: Request) {
+  const forbidden = rejectNonLocalRequest(req);
+  if (forbidden) return forbidden;
+
+  const covenSessionId = new URL(req.url).searchParams.get("sessionId") ?? "";
+
+  const health = await callDaemon<unknown>({ path: "/api/v1/health" });
+  const capabilities = readAfsCapabilities(health.data);
+
+  // A daemon without AFS is a supported state, not a failure: Cave and the
+  // daemon ship on decoupled versions. Report it and let the pane hide.
+  if (!capabilities.afs) {
+    return NextResponse.json<AfsOverviewResponse>({ ok: true, capabilities, session: null });
+  }
+
+  const listed = await callDaemon<{ sessions?: AfsSession[] }>({ path: "/api/v1/afs/sessions" });
+  if (!listed.ok) {
+    return NextResponse.json<AfsOverviewResponse>(
+      {
+        ok: false,
+        capabilities,
+        session: null,
+        error: listed.error ?? "The daemon could not list agent filesystem sessions.",
+      },
+      { status: listed.status || 502 },
+    );
+  }
+
+  const sessions = listed.data?.sessions ?? [];
+  return NextResponse.json<AfsOverviewResponse>({
+    ok: true,
+    capabilities,
+    session: afsSessionForCovenSession(sessions, covenSessionId),
+  });
+}

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -20,6 +20,12 @@ type RouteContract = {
 const contracts: RouteContract[] = [
   { route: "/access-groups", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/access-groups/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
+  // AFS routes expose a session's working tree, so every one is same-user
+  // local IPC (specs/coven-agent-fs/DESIGN.md section 3).
+  { route: "/afs", methods: ["GET"], kind: "json", localOriginGuard: true },
+  { route: "/afs/[id]/commit", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded", localOriginGuard: true },
+  { route: "/afs/[id]/diff", methods: ["GET"], kind: "json", localOriginGuard: true },
+  { route: "/afs/[id]/timeline", methods: ["GET"], kind: "json", localOriginGuard: true },
   { route: "/app/build-info", methods: ["GET"], kind: "json" },
   { route: "/app/latest-release", methods: ["GET"], kind: "json" },
   { route: "/asana/assigned", methods: ["GET"], kind: "json" },

--- a/src/components/afs-pane.tsx
+++ b/src/components/afs-pane.tsx
@@ -217,7 +217,7 @@ function ChangesPane({ sessionId }: { sessionId: string }) {
       ) : (
         <ul className="list-none">
           {tree.map((node) => (
-            <TreeRow key={node.path} node={node} depth={0} />
+            <TreeRow key={node.path} node={node} />
           ))}
         </ul>
       )}
@@ -231,13 +231,15 @@ const CHANGE_BADGE: Record<AfsChange["change"], string> = {
   deleted: "D",
 };
 
-function TreeRow({ node, depth }: { node: AfsTreeNode; depth: number }) {
+/**
+ * Depth is expressed by the nested `<ul>` itself rather than a computed
+ * `paddingLeft`, so indentation stays on the spacing scale and this component
+ * contributes no inline style for the design-token drift ratchet to count.
+ */
+function TreeRow({ node }: { node: AfsTreeNode }) {
   return (
     <li>
-      <div
-        className="flex items-center gap-2 text-[length:var(--text-xs)]"
-        style={{ paddingLeft: `${depth * 12}px` }}
-      >
+      <div className="flex items-center gap-2 text-[length:var(--text-xs)]">
         {node.change ? (
           <span
             aria-label={node.change.change}
@@ -263,9 +265,9 @@ function TreeRow({ node, depth }: { node: AfsTreeNode; depth: number }) {
         ) : null}
       </div>
       {node.children.length > 0 ? (
-        <ul className="list-none">
+        <ul className="list-none pl-3">
           {node.children.map((child) => (
-            <TreeRow key={child.path} node={child} depth={depth + 1} />
+            <TreeRow key={child.path} node={child} />
           ))}
         </ul>
       ) : null}

--- a/src/components/afs-pane.tsx
+++ b/src/components/afs-pane.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+/**
+ * AfsPane — the per-session agent filesystem surface (bead cave-je2q9,
+ * upstream coven-gr1), implementing `specs/coven-agent-fs/DESIGN.md` §6:
+ * Changes, Timeline, and Commit.
+ *
+ * Every read goes through Cave's own `/api/afs/*` routes, which proxy the
+ * daemon. Nothing here opens a delta or recomputes a diff — the Rust
+ * authority boundary is the whole point of the design.
+ *
+ * Degraded states are first-class rather than afterthoughts: `afs: false`
+ * hides the pane outright, `afsMount: false` disables mount controls, and
+ * `afsCommit: false` disables commit while showing why.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Icon } from "@/lib/icon";
+import { Button } from "@/components/ui/button";
+import {
+  buildChangeTree,
+  changeTotal,
+  commitAvailability,
+  commitPreview,
+  defaultCommitBranch,
+  groupTimelineByTurn,
+  mountAvailability,
+  type AfsCapabilities,
+  type AfsChange,
+  type AfsDiff,
+  type AfsSession,
+  type AfsTimeline,
+  type AfsTreeNode,
+} from "@/lib/afs";
+
+type Overview = {
+  ok: boolean;
+  capabilities: AfsCapabilities;
+  session: AfsSession | null;
+  error?: string;
+};
+
+type Phase<T> = { phase: "loading" } | { phase: "ready"; data: T } | { phase: "error"; message: string };
+
+const AFS_TABS = ["changes", "timeline", "commit"] as const;
+type AfsTab = (typeof AFS_TABS)[number];
+
+const TAB_LABEL: Record<AfsTab, string> = {
+  changes: "Changes",
+  timeline: "Timeline",
+  commit: "Commit",
+};
+
+/** Daemon errors arrive as a structured envelope; surface the dotted code. */
+function errorMessage(payload: unknown, fallback: string): string {
+  if (payload && typeof payload === "object") {
+    const error = (payload as { error?: unknown }).error;
+    if (typeof error === "string") return error;
+    if (error && typeof error === "object") {
+      const { code, message } = error as { code?: string; message?: string };
+      if (code && message) return `${code}: ${message}`;
+      if (message) return message;
+      if (code) return code;
+    }
+  }
+  return fallback;
+}
+
+async function getJson<T>(url: string, fallback: string): Promise<T> {
+  const res = await fetch(url, { cache: "no-store" });
+  const payload: unknown = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(errorMessage(payload, fallback));
+  return payload as T;
+}
+
+export function AfsPane({ sessionId }: { sessionId: string }) {
+  const [overview, setOverview] = useState<Phase<Overview>>({ phase: "loading" });
+  const [tab, setTab] = useState<AfsTab>("changes");
+  const [reloadToken, setReloadToken] = useState(0);
+
+  const reload = useCallback(() => setReloadToken((token) => token + 1), []);
+
+  useEffect(() => {
+    let cancelled = false;
+    setOverview({ phase: "loading" });
+    getJson<Overview>(`/api/afs?sessionId=${encodeURIComponent(sessionId)}`, "Could not read agent filesystem state.")
+      .then((data) => {
+        if (!cancelled) setOverview({ phase: "ready", data });
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setOverview({ phase: "error", message: error.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId, reloadToken]);
+
+  if (overview.phase === "loading") {
+    return <p className="p-3 text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading agent filesystem…</p>;
+  }
+  if (overview.phase === "error") {
+    return <PaneError message={overview.message} onRetry={reload} />;
+  }
+
+  const { capabilities, session } = overview.data;
+
+  // `afs: false` hides the pane entirely — the daemon has no AFS support at
+  // all, so there is nothing to degrade gracefully into.
+  if (!capabilities.afs) return null;
+
+  if (!session) {
+    return (
+      <p className="p-3 text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+        This session has no agent filesystem delta.
+      </p>
+    );
+  }
+
+  return (
+    <section aria-label="Agent filesystem" className="flex min-h-0 flex-col gap-2 p-2">
+      <div role="tablist" aria-label="Agent filesystem view" className="flex items-center gap-1">
+        {AFS_TABS.map((id) => (
+          <button
+            key={id}
+            role="tab"
+            type="button"
+            aria-selected={tab === id}
+            className={`focus-ring rounded px-2 py-1 text-[length:var(--text-xs)] transition-colors ${
+              tab === id
+                ? "bg-[var(--surface-raised)] text-[var(--text-primary)]"
+                : "text-[var(--text-secondary)] hover:text-[var(--text-primary)]"
+            }`}
+            onClick={() => setTab(id)}
+          >
+            {TAB_LABEL[id]}
+          </button>
+        ))}
+        <span className="grow" />
+        <MountBadge capabilities={capabilities} />
+      </div>
+
+      {tab === "changes" ? <ChangesPane sessionId={session.id} /> : null}
+      {tab === "timeline" ? <TimelinePane sessionId={session.id} /> : null}
+      {tab === "commit" ? (
+        <CommitPane session={session} capabilities={capabilities} onCommitted={reload} />
+      ) : null}
+    </section>
+  );
+}
+
+function PaneError({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex items-center gap-2 p-3 text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+      <span className="text-[var(--text-danger)]">{message}</span>
+      <Button size="sm" variant="ghost" onClick={onRetry}>
+        Retry
+      </Button>
+    </div>
+  );
+}
+
+/** Mount controls are shown but disabled when no backend is advertised. */
+function MountBadge({ capabilities }: { capabilities: AfsCapabilities }) {
+  const mount = mountAvailability(capabilities);
+  return (
+    <span
+      className="text-[length:var(--text-xs)] text-[var(--text-secondary)]"
+      title={mount.enabled ? `Mount backend: ${mount.backend}` : mount.reason}
+    >
+      {mount.enabled ? `Mount: ${mount.backend}` : "Mount unavailable"}
+    </span>
+  );
+}
+
+function ChangesPane({ sessionId }: { sessionId: string }) {
+  const [state, setState] = useState<Phase<AfsDiff>>({ phase: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ phase: "loading" });
+    getJson<AfsDiff>(`/api/afs/${encodeURIComponent(sessionId)}/diff`, "Could not read the change set.")
+      .then((data) => {
+        if (!cancelled) setState({ phase: "ready", data });
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setState({ phase: "error", message: error.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  if (state.phase === "loading") {
+    return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading changes…</p>;
+  }
+  if (state.phase === "error") {
+    return <p className="text-[length:var(--text-xs)] text-[var(--text-danger)]">{state.message}</p>;
+  }
+
+  const diff = state.data;
+  const tree = buildChangeTree(diff.changes);
+
+  return (
+    <div className="min-h-0 overflow-auto">
+      <p className="mb-1 text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+        {diff.counts.added} added · {diff.counts.modified} modified · {diff.counts.deleted} deleted ·{" "}
+        {diff.counts.bytes} bytes
+      </p>
+      {/* Truncation is an explicit affordance, never a silently short diff. */}
+      {diff.truncated ? (
+        <p className="mb-1 text-[length:var(--text-xs)] text-[var(--text-warning)]">
+          Diff truncated — this list is incomplete.
+        </p>
+      ) : null}
+      {tree.length === 0 ? (
+        <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">No changes against the base.</p>
+      ) : (
+        <ul className="list-none">
+          {tree.map((node) => (
+            <TreeRow key={node.path} node={node} depth={0} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+const CHANGE_BADGE: Record<AfsChange["change"], string> = {
+  added: "A",
+  modified: "M",
+  deleted: "D",
+};
+
+function TreeRow({ node, depth }: { node: AfsTreeNode; depth: number }) {
+  return (
+    <li>
+      <div
+        className="flex items-center gap-2 text-[length:var(--text-xs)]"
+        style={{ paddingLeft: `${depth * 12}px` }}
+      >
+        {node.change ? (
+          <span
+            aria-label={node.change.change}
+            className="w-3 shrink-0 text-[var(--text-secondary)]"
+          >
+            {CHANGE_BADGE[node.change.change]}
+          </span>
+        ) : (
+          <span aria-hidden className="w-3 shrink-0" />
+        )}
+        <span className="truncate text-[var(--text-primary)]">{node.name}</span>
+        {node.change ? (
+          <span className="shrink-0 text-[var(--text-secondary)]">{node.change.bytes}B</span>
+        ) : null}
+        {/* An unexplained change is marked, never hidden (DESIGN.md §4.4). */}
+        {node.change?.attribution === "unknown" ? (
+          <span
+            className="shrink-0 text-[var(--text-warning)]"
+            title="No provenance record explains this change"
+          >
+            unattributed
+          </span>
+        ) : null}
+      </div>
+      {node.children.length > 0 ? (
+        <ul className="list-none">
+          {node.children.map((child) => (
+            <TreeRow key={child.path} node={child} depth={depth + 1} />
+          ))}
+        </ul>
+      ) : null}
+    </li>
+  );
+}
+
+function TimelinePane({ sessionId }: { sessionId: string }) {
+  const [state, setState] = useState<Phase<AfsTimeline>>({ phase: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ phase: "loading" });
+    getJson<AfsTimeline>(`/api/afs/${encodeURIComponent(sessionId)}/timeline`, "Could not read the timeline.")
+      .then((data) => {
+        if (!cancelled) setState({ phase: "ready", data });
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setState({ phase: "error", message: error.message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  const groups = useMemo(
+    () => (state.phase === "ready" ? groupTimelineByTurn(state.data.entries) : []),
+    [state],
+  );
+
+  if (state.phase === "loading") {
+    return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">Loading timeline…</p>;
+  }
+  if (state.phase === "error") {
+    return <p className="text-[length:var(--text-xs)] text-[var(--text-danger)]">{state.message}</p>;
+  }
+  if (groups.length === 0) {
+    return <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">No recorded operations.</p>;
+  }
+
+  return (
+    <div className="min-h-0 overflow-auto">
+      {groups.map((group) => (
+        <div key={group.turn ?? "unbound"} className="mb-2">
+          <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+            {group.turn === null ? "No turn recorded" : `Turn ${group.turn}`}
+          </p>
+          <ul className="list-none">
+            {group.entries.map((entry) => (
+              <li key={entry.seq} className="flex items-center gap-2 text-[length:var(--text-xs)]">
+                <span className="w-10 shrink-0 text-[var(--text-secondary)]">{entry.op}</span>
+                <span className="truncate text-[var(--text-primary)]">{entry.path}</span>
+                {entry.toolCallId == null ? (
+                  <span className="shrink-0 text-[var(--text-warning)]" title="No tool call is linked to this operation">
+                    unlinked
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+      {state.data.hasMore ? (
+        <p className="text-[length:var(--text-xs)] text-[var(--text-secondary)]">
+          More entries available — this view is paginated.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+function CommitPane({
+  session,
+  capabilities,
+  onCommitted,
+}: {
+  session: AfsSession;
+  capabilities: AfsCapabilities;
+  onCommitted: () => void;
+}) {
+  const [branch, setBranch] = useState(defaultCommitBranch(session));
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<{ kind: "ok" | "error"; message: string } | null>(null);
+
+  const availability = commitAvailability(capabilities, session);
+  const preview = commitPreview(session, { counts: session.changes }, branch);
+
+  const run = useCallback(async () => {
+    setBusy(true);
+    setResult(null);
+    try {
+      const res = await fetch(`/api/afs/${encodeURIComponent(session.id)}/commit`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ branch }),
+      });
+      const payload: unknown = await res.json().catch(() => null);
+      if (!res.ok) throw new Error(errorMessage(payload, "Commit failed."));
+      const commit = (payload as { commit?: string }).commit ?? "";
+      setResult({ kind: "ok", message: `Materialized ${branch} at ${commit.slice(0, 7)}.` });
+      onCommitted();
+    } catch (error) {
+      setResult({ kind: "error", message: (error as Error).message });
+    } finally {
+      setBusy(false);
+    }
+  }, [branch, onCommitted, session.id]);
+
+  return (
+    <div className="flex flex-col gap-2 text-[length:var(--text-xs)]">
+      <label className="flex flex-col gap-1">
+        <span className="text-[var(--text-secondary)]">Branch</span>
+        <input
+          className="focus-ring rounded border border-[var(--border-subtle)] bg-[var(--surface-sunken)] px-2 py-1 text-[var(--text-primary)]"
+          value={branch}
+          onChange={(event) => setBranch(event.target.value)}
+          spellCheck={false}
+        />
+      </label>
+
+      <p className="text-[var(--text-secondary)]">
+        {changeTotal(preview.counts)} files · {preview.counts.bytes} bytes would be applied.
+      </p>
+      {/* The preview is derived from the change set, not a daemon dry run
+          (bead coven-y7a). Saying so is the honest affordance. */}
+      <p className="text-[var(--text-secondary)]">{preview.caveat}</p>
+
+      {availability.enabled ? null : (
+        <p className="text-[var(--text-warning)]">{availability.reason}</p>
+      )}
+
+      <div>
+        <Button size="sm" disabled={!availability.enabled || busy} onClick={run}>
+          <Icon name="ph:git-branch-bold" width={12} height={12} aria-hidden />
+          {busy ? "Committing…" : "Commit"}
+        </Button>
+      </div>
+
+      {result ? (
+        <p className={result.kind === "ok" ? "text-[var(--text-success)]" : "text-[var(--text-danger)]"}>
+          {result.message}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/code-review-rail.tsx
+++ b/src/components/code-review-rail.tsx
@@ -20,6 +20,7 @@ import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { SessionChangesInner } from "@/components/session-changes-panel";
+import { AfsPane } from "@/components/afs-pane";
 import {
   clampCodeRailWidth,
   codeRailDiffBar,
@@ -221,6 +222,19 @@ export function CodeReviewRail({
           >
             Pull request
           </button>
+          {/* The agent filesystem delta, which is not the checkout's working
+              tree. The pane hides itself when the daemon reports afs: false,
+              so the tab can lead to an empty surface on an older daemon. */}
+          <button
+            type="button"
+            role="tab"
+            aria-selected={tab === "filesystem"}
+            data-selected={tab === "filesystem" ? "true" : undefined}
+            className="focus-ring code-rail__tab"
+            onClick={() => onTabChange("filesystem")}
+          >
+            Filesystem
+          </button>
         </div>
         <span className="code-rail__spacer" />
         {/* The rail is a sidebar; a conversation, a commit list and a unified
@@ -296,6 +310,10 @@ export function CodeReviewRail({
             />
           </div>
         </>
+      ) : tab === "filesystem" ? (
+        <div className="code-rail__body">
+          <AfsPane key={row.id} sessionId={row.id} />
+        </div>
       ) : (
         <div className="code-rail__body">
           <LazyPr key={row.id} row={row} />

--- a/src/lib/afs.test.ts
+++ b/src/lib/afs.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  afsSessionForCovenSession,
+  buildChangeTree,
+  changeTotal,
+  commitAvailability,
+  commitPreview,
+  defaultCommitBranch,
+  groupTimelineByTurn,
+  mountAvailability,
+  readAfsCapabilities,
+  unattributedPaths,
+  type AfsCapabilities,
+  type AfsChange,
+  type AfsSession,
+  type AfsTimelineEntry,
+} from "./afs.ts";
+
+const CAPS: AfsCapabilities = { afs: true, afsMount: false, afsCommit: true };
+
+function session(overrides: Partial<AfsSession> = {}): AfsSession {
+  return {
+    id: "afs-1",
+    name: null,
+    state: "open",
+    base: { fingerprint: "fp", commit: "abc", files: 2, skipped: 0 },
+    binding: { sessionId: "sess-1", familiarId: null, beadId: null },
+    changes: { added: 1, modified: 0, deleted: 0, bytes: 10 },
+    ...overrides,
+  };
+}
+
+function change(overrides: Partial<AfsChange> = {}): AfsChange {
+  return { path: "/src/a.rs", change: "added", bytes: 1, attribution: "recorded", ...overrides };
+}
+
+test("capabilities read false against a daemon with no AFS support", () => {
+  // Cave and the daemon ship decoupled, so an older daemon reports nothing.
+  assert.deepEqual(readAfsCapabilities({}), { afs: false, afsMount: false, afsCommit: false });
+  assert.deepEqual(readAfsCapabilities(null), { afs: false, afsMount: false, afsCommit: false });
+  assert.deepEqual(readAfsCapabilities({ capabilities: { afs: true, afsMount: false, afsCommit: true } }), {
+    afs: true,
+    afsMount: false,
+    afsCommit: true,
+  });
+});
+
+test("a mount backend name is carried through, false stays false", () => {
+  assert.deepEqual(readAfsCapabilities({ capabilities: { afsMount: "nfs" } }).afsMount, "nfs");
+  // An empty string is not a backend.
+  assert.equal(readAfsCapabilities({ capabilities: { afsMount: "" } }).afsMount, false);
+  assert.equal(mountAvailability(CAPS).enabled, false);
+  assert.deepEqual(mountAvailability({ ...CAPS, afsMount: "nfs" }), { enabled: true, backend: "nfs" });
+});
+
+test("a session with no delta is absence, not failure", () => {
+  assert.equal(afsSessionForCovenSession([], "sess-1"), null);
+  assert.equal(afsSessionForCovenSession([session()], "other"), null);
+  assert.equal(afsSessionForCovenSession([session()], ""), null);
+});
+
+test("discarded deltas are ignored and an open delta wins over a committed one", () => {
+  const discarded = session({ id: "afs-old", state: "discarded" });
+  assert.equal(afsSessionForCovenSession([discarded], "sess-1"), null);
+
+  const committed = session({ id: "afs-done", state: "committed" });
+  const open = session({ id: "afs-live", state: "open" });
+  assert.equal(afsSessionForCovenSession([committed, open], "sess-1")?.id, "afs-live");
+  // With no open delta, a committed one still surfaces as the audit record.
+  assert.equal(afsSessionForCovenSession([committed], "sess-1")?.id, "afs-done");
+});
+
+test("commit is disabled with a reason for every blocking state", () => {
+  const noCapability = commitAvailability({ ...CAPS, afsCommit: false }, session());
+  assert.equal(noCapability.enabled, false);
+  assert.match(noCapability.enabled ? "" : noCapability.reason, /afsCommit: false/);
+
+  const noDelta = commitAvailability(CAPS, null);
+  assert.equal(noDelta.enabled, false);
+
+  const notOpen = commitAvailability(CAPS, session({ state: "committed" }));
+  assert.equal(notOpen.enabled, false);
+  assert.match(notOpen.enabled ? "" : notOpen.reason, /committed/);
+
+  const empty = commitAvailability(CAPS, session({ changes: { added: 0, modified: 0, deleted: 0, bytes: 0 } }));
+  assert.equal(empty.enabled, false);
+
+  assert.deepEqual(commitAvailability(CAPS, session()), { enabled: true });
+});
+
+test("the default branch mirrors the daemon's own rule", () => {
+  assert.equal(defaultCommitBranch({ id: "afs-1", name: null }), "afs/afs-1");
+  assert.equal(defaultCommitBranch({ id: "afs-1", name: "tidy" }), "afs/tidy");
+});
+
+test("the commit preview declares that it is not a real dry run", () => {
+  const counts = { added: 2, modified: 1, deleted: 0, bytes: 30 };
+  const preview = commitPreview(session(), { counts });
+  assert.equal(preview.branch, "afs/afs-1");
+  assert.deepEqual(preview.counts, counts);
+  // coven-y7a adds a real dryRun; until then the UI must not imply one.
+  assert.equal(preview.exact, false);
+  assert.match(preview.caveat, /can still be refused/);
+  assert.equal(commitPreview(session(), { counts }, "  custom/branch  ").branch, "custom/branch");
+  assert.equal(commitPreview(session(), { counts }, "   ").branch, "afs/afs-1");
+});
+
+test("unattributed changes are reported so they can be marked", () => {
+  const changes = [change(), change({ path: "/src/b.rs", attribution: "unknown" })];
+  assert.deepEqual(unattributedPaths({ changes }), ["/src/b.rs"]);
+});
+
+test("change total counts files, not bytes", () => {
+  assert.equal(changeTotal({ added: 1, modified: 2, deleted: 3, bytes: 999 }), 6);
+});
+
+test("timeline groups by turn and keeps unbound entries last", () => {
+  const entry = (seq: number, turn: number | null): AfsTimelineEntry => ({
+    seq,
+    op: "write",
+    path: `/f${seq}`,
+    bytes: 1,
+    at: seq,
+    turn,
+  });
+  const groups = groupTimelineByTurn([entry(1, 2), entry(2, null), entry(3, 1), entry(4, 2)]);
+  assert.deepEqual(
+    groups.map((group) => group.turn),
+    [1, 2, null],
+  );
+  // Order within a turn is the daemon's order, not re-sorted.
+  assert.deepEqual(
+    groups[1].entries.map((e) => e.seq),
+    [1, 4],
+  );
+  // An operation nobody can account for is kept, never dropped.
+  assert.equal(groups[2].entries.length, 1);
+});
+
+test("the change tree nests paths with directories before files", () => {
+  const tree = buildChangeTree([
+    change({ path: "/README.md" }),
+    change({ path: "/src/b.rs" }),
+    change({ path: "/src/a.rs" }),
+  ]);
+  assert.deepEqual(
+    tree.map((node) => node.name),
+    ["src", "README.md"],
+  );
+  const src = tree[0];
+  assert.equal(src.change, null, "a synthesized directory carries no change");
+  assert.deepEqual(
+    src.children.map((node) => node.name),
+    ["a.rs", "b.rs"],
+  );
+  assert.equal(src.children[0].path, "/src/a.rs");
+  assert.equal(src.children[0].change?.change, "added");
+});

--- a/src/lib/afs.ts
+++ b/src/lib/afs.ts
@@ -1,0 +1,300 @@
+/**
+ * AFS (agent filesystem) wire shapes and the pure logic behind Cave's
+ * filesystem pane — bead cave-je2q9, tracked upstream as coven-gr1.
+ *
+ * Cave reads AFS exclusively through the daemon's `/api/v1/afs/*` routes. It
+ * holds no SQLite handle on a delta and reimplements no diff or overlay
+ * logic, so the Rust authority boundary in
+ * `specs/coven-agent-fs/DESIGN.md` §6 applies unchanged. Everything here is
+ * either a shape the daemon owns or a decision about how to *present* what it
+ * returned.
+ */
+
+/** Capability flags from `GET /api/v1/health`. */
+export type AfsCapabilities = {
+  /** AFS routes exist at all. When false the pane does not render. */
+  afs: boolean;
+  /** A mount backend name, or false when none is available. */
+  afsMount: string | false;
+  /** Whether the daemon can materialize a delta into a git branch. */
+  afsCommit: boolean;
+};
+
+export type AfsChangeKind = "added" | "modified" | "deleted";
+
+/** `"recorded"` when a provenance row explains the change, else `"unknown"`. */
+export type AfsAttribution = "recorded" | "unknown";
+
+export type AfsChange = {
+  path: string;
+  change: AfsChangeKind;
+  bytes: number;
+  attribution: AfsAttribution;
+  ino?: number | null;
+  baseIno?: number | null;
+  mode?: number | null;
+};
+
+export type AfsChangeCounts = {
+  added: number;
+  modified: number;
+  deleted: number;
+  bytes: number;
+};
+
+export type AfsDiff = {
+  changes: AfsChange[];
+  counts: AfsChangeCounts;
+  /** The daemon truncated the change set; never render a silently short diff. */
+  truncated: boolean;
+};
+
+export type AfsTimelineEntry = {
+  seq: number;
+  op: string;
+  path: string;
+  toPath?: string | null;
+  bytes: number;
+  at: number;
+  sessionId?: string | null;
+  familiarId?: string | null;
+  beadId?: string | null;
+  turn?: number | null;
+  toolCallId?: number | null;
+};
+
+export type AfsTimeline = {
+  entries: AfsTimelineEntry[];
+  nextCursor?: number | null;
+  hasMore: boolean;
+};
+
+export type AfsSession = {
+  id: string;
+  name?: string | null;
+  state: "open" | "committing" | "committed" | "discarded" | string;
+  base: { fingerprint: string; commit?: string | null; files: number; skipped: number };
+  binding: {
+    sessionId?: string | null;
+    familiarId?: string | null;
+    beadId?: string | null;
+  };
+  changes: AfsChangeCounts;
+};
+
+/**
+ * Read capabilities defensively.
+ *
+ * Cave and the daemon ship on decoupled versions (#4450), so a daemon with no
+ * AFS support at all is a normal state, not an error — it simply reports
+ * nothing, and every flag reads false.
+ */
+export function readAfsCapabilities(payload: unknown): AfsCapabilities {
+  const caps =
+    payload && typeof payload === "object"
+      ? ((payload as { capabilities?: Record<string, unknown> }).capabilities ?? {})
+      : {};
+  const mount = caps.afsMount;
+  return {
+    afs: caps.afs === true,
+    afsMount: typeof mount === "string" && mount.length > 0 ? mount : false,
+    afsCommit: caps.afsCommit === true,
+  };
+}
+
+/**
+ * Find the AFS delta bound to a Cave session.
+ *
+ * Most Cave sessions have no delta — AFS is opt-in per session — so absence is
+ * the common case and must not read as a failure. Discarded deltas are
+ * ignored: they are audit records, not live working state.
+ */
+export function afsSessionForCovenSession(
+  sessions: readonly AfsSession[],
+  covenSessionId: string,
+): AfsSession | null {
+  if (!covenSessionId) return null;
+  const live = sessions.filter(
+    (session) => session.binding.sessionId === covenSessionId && session.state !== "discarded",
+  );
+  if (live.length === 0) return null;
+  // An open delta is the one an operator can still act on; prefer it over a
+  // committed one from an earlier round on the same session.
+  return live.find((session) => session.state === "open") ?? live[0];
+}
+
+export type CommitAvailability =
+  | { enabled: true }
+  | { enabled: false; reason: string };
+
+/**
+ * Whether the Commit action can run, and if not, why — in the operator's
+ * words rather than a bare disabled control.
+ */
+export function commitAvailability(
+  capabilities: AfsCapabilities,
+  session: Pick<AfsSession, "state" | "changes"> | null,
+): CommitAvailability {
+  if (!capabilities.afsCommit) {
+    return {
+      enabled: false,
+      reason:
+        "This daemon does not support commit materialization (health reports afsCommit: false). Upgrade the daemon to enable it.",
+    };
+  }
+  if (!session) {
+    return { enabled: false, reason: "This session has no agent filesystem delta." };
+  }
+  if (session.state !== "open") {
+    return {
+      enabled: false,
+      reason: `The delta is ${session.state}; commit requires an open session.`,
+    };
+  }
+  if (changeTotal(session.changes) === 0) {
+    return { enabled: false, reason: "No changes to materialize." };
+  }
+  return { enabled: true };
+}
+
+export type MountAvailability = { enabled: false; reason: string } | { enabled: true; backend: string };
+
+/** Mount controls are shown but disabled when no backend is advertised. */
+export function mountAvailability(capabilities: AfsCapabilities): MountAvailability {
+  if (capabilities.afsMount === false) {
+    return {
+      enabled: false,
+      reason: "No mount backend is available on this platform (health reports afsMount: false).",
+    };
+  }
+  return { enabled: true, backend: capabilities.afsMount };
+}
+
+/** File-count total. Deliberately excludes bytes, which is a separate axis. */
+export function changeTotal(counts: AfsChangeCounts): number {
+  return counts.added + counts.modified + counts.deleted;
+}
+
+/** Default branch the daemon would pick, mirroring DESIGN.md §5 step 3. */
+export function defaultCommitBranch(session: Pick<AfsSession, "id" | "name">): string {
+  return `afs/${session.name && session.name.length > 0 ? session.name : session.id}`;
+}
+
+/**
+ * The commit preview.
+ *
+ * This is derived from the diff change set, NOT from a daemon dry run — the
+ * commit route has no dryRun mode yet (upstream bead coven-y7a). The
+ * distinction matters and is surfaced rather than hidden: counts describe the
+ * change set, but they do not exercise base verification, path-escape
+ * rejection, the copy-up cap, or branch conflicts, so a clean-looking preview
+ * can still be refused. `exact: false` is what the UI uses to say so.
+ */
+export type CommitPreview = {
+  branch: string;
+  counts: AfsChangeCounts;
+  exact: boolean;
+  caveat: string;
+};
+
+export function commitPreview(
+  session: Pick<AfsSession, "id" | "name">,
+  diff: Pick<AfsDiff, "counts">,
+  branchOverride?: string,
+): CommitPreview {
+  const branch =
+    branchOverride && branchOverride.trim().length > 0
+      ? branchOverride.trim()
+      : defaultCommitBranch(session);
+  return {
+    branch,
+    counts: diff.counts,
+    exact: false,
+    caveat:
+      "Preview is derived from the change set. It does not check whether the base has moved, whether a path would escape the repository, or whether the branch already exists — commit can still be refused.",
+  };
+}
+
+/** Unattributed changes are marked, never hidden (DESIGN.md §4.4). */
+export function unattributedPaths(diff: Pick<AfsDiff, "changes">): string[] {
+  return diff.changes.filter((change) => change.attribution === "unknown").map((change) => change.path);
+}
+
+export type TimelineTurn = {
+  /** null groups every entry the daemon could not bind to a turn. */
+  turn: number | null;
+  entries: AfsTimelineEntry[];
+};
+
+/**
+ * Group timeline entries by turn, preserving daemon order within each group.
+ *
+ * Entries with no turn are kept in their own trailing group rather than
+ * dropped: an operation nobody can account for is exactly what an audit
+ * timeline exists to show.
+ */
+export function groupTimelineByTurn(entries: readonly AfsTimelineEntry[]): TimelineTurn[] {
+  const groups: TimelineTurn[] = [];
+  const index = new Map<number | null, TimelineTurn>();
+  for (const entry of entries) {
+    const turn = typeof entry.turn === "number" ? entry.turn : null;
+    let group = index.get(turn);
+    if (!group) {
+      group = { turn, entries: [] };
+      index.set(turn, group);
+      groups.push(group);
+    }
+    group.entries.push(entry);
+  }
+  // Unbound entries sort last; bound turns keep first-seen order.
+  return groups.sort((left, right) => {
+    if (left.turn === right.turn) return 0;
+    if (left.turn === null) return 1;
+    if (right.turn === null) return -1;
+    return left.turn - right.turn;
+  });
+}
+
+/** A tree node for the Changes pane. */
+export type AfsTreeNode = {
+  name: string;
+  path: string;
+  children: AfsTreeNode[];
+  change: AfsChange | null;
+};
+
+/**
+ * Build a directory tree from flat change paths.
+ *
+ * Directories are synthesized from the paths themselves; the daemon reports
+ * files, and git does not track empty directories.
+ */
+export function buildChangeTree(changes: readonly AfsChange[]): AfsTreeNode[] {
+  const root: AfsTreeNode = { name: "", path: "", children: [], change: null };
+  for (const change of changes) {
+    const parts = change.path.split("/").filter((part) => part.length > 0);
+    let node = root;
+    parts.forEach((part, depth) => {
+      const path = `/${parts.slice(0, depth + 1).join("/")}`;
+      let next = node.children.find((child) => child.name === part);
+      if (!next) {
+        next = { name: part, path, children: [], change: null };
+        node.children.push(next);
+      }
+      if (depth === parts.length - 1) next.change = change;
+      node = next;
+    });
+  }
+  sortTree(root.children);
+  return root.children;
+}
+
+function sortTree(nodes: AfsTreeNode[]): void {
+  nodes.sort((left, right) => {
+    const leftIsDir = left.children.length > 0;
+    const rightIsDir = right.children.length > 0;
+    if (leftIsDir !== rightIsDir) return leftIsDir ? -1 : 1;
+    return left.name.localeCompare(right.name);
+  });
+  for (const node of nodes) sortTree(node.children);
+}

--- a/src/lib/code-side-rail.test.ts
+++ b/src/lib/code-side-rail.test.ts
@@ -19,6 +19,8 @@ const {
 
 assert.equal(isCodeRailTab("changes"), true);
 assert.equal(isCodeRailTab("pr"), true);
+// The AFS delta (cave-je2q9) — distinct from the checkout's working tree.
+assert.equal(isCodeRailTab("filesystem"), true);
 assert.equal(isCodeRailTab("terminal"), false);
 assert.equal(isCodeRailTab(null), false);
 

--- a/src/lib/code-side-rail.ts
+++ b/src/lib/code-side-rail.ts
@@ -13,8 +13,13 @@
  * the diff is.
  */
 
-/** Rail tabs. `changes` is the working tree; `pr` is the pull request. */
-export const CODE_RAIL_TABS = ["changes", "pr"] as const;
+/**
+ * Rail tabs. `changes` is the working tree; `pr` is the pull request;
+ * `filesystem` is the AFS delta (cave-je2q9) — a session's agent-filesystem
+ * change set, provenance timeline, and commit action, which is a different
+ * thing from the checkout's working tree.
+ */
+export const CODE_RAIL_TABS = ["changes", "pr", "filesystem"] as const;
 export type CodeRailTab = (typeof CODE_RAIL_TABS)[number];
 
 export function isCodeRailTab(value: string | null | undefined): value is CodeRailTab {


### PR DESCRIPTION
## Summary

Implements [`specs/coven-agent-fs/DESIGN.md` §6](https://github.com/OpenCoven/coven/blob/main/specs/coven-agent-fs/DESIGN.md) for bead `cave-je2q9`, tracked upstream as `coven-gr1`. Adds **Changes**, **Timeline**, and **Commit** for a session's agent filesystem delta.

Cave reads exclusively through the daemon's `/api/v1/afs/*` routes — it opens no delta and recomputes no diff, so the Rust authority boundary holds structurally rather than by discipline. The daemon side landed upstream in coven #684 (read/lifecycle routes) and #690 (commit materialization).

## Placement — rail tab, not a fourth column

My first instinct was a fourth `CODE_WORKBENCH_STEPS` column. Reading the layout changed that: the three-column split carries measured width math (`codeRoomFits`, `CODE_ROOM_*_WIDTH_PX`, `code-rail-fit.test.ts`) that several in-flight units are actively touching. The review rail already owns tab chrome, width handling, and the narrow-step fallback, so **Filesystem** joins `changes` and `pr` as a third `CODE_RAIL_TABS` entry instead. Smaller diff, no layout risk, and it inherits responsive behaviour for free.

## Degraded states are the live path, not a fallback

Cave and the daemon ship on decoupled versions (#4450), so **a daemon with no AFS support is a normal state** — likely the one most users are on right now, since the daemon routes only just merged.

- `afs: false` → the pane hides entirely
- `afsMount: false` → mount reads "unavailable" with the daemon's reason (this is the *current* state upstream, pending `coven-x77`)
- `afsCommit: false` → commit disabled, reason shown
- no delta for the session → absence, not an error

Unattributed changes are marked, never hidden, and diff truncation renders as an explicit affordance — both per DESIGN.md §4.4. A clean timeline over a diff carrying unexplained files is worse than no timeline.

## The dryRun gap, made structural

DESIGN.md §6 specifies a `dryRun` commit preview. The daemon route has no such mode, so the preview is derived from `afs.session.diff` counts. Rather than let the UI imply a check it never ran, `commitPreview` returns `exact: false` plus a caveat the pane renders: counts describe the change set but do not exercise base verification, path-escape rejection, the copy-up cap, or branch conflicts, so a clean-looking preview can still be refused.

Real dryRun is filed upstream as **`coven-y7a`**, which blocks `coven-gr1` for full §6 conformance.

## Security and transport

All four routes call `rejectNonLocalRequest` first — AFS exposes a session's working tree, which DESIGN.md §3 classifies as same-user local IPC, the same posture as session handoff. `api-contracts.test.ts` verifies the `localOriginGuard: true` claim against the source rather than taking the declaration's word for it.

Commit needed two non-default `callDaemon` settings: `timeoutMs: 60_000` because materialization walks the change set and shells out to git (the 4s default would abort mid-commit on a real repo), and `retryTransportFailure: false` because a commit is not idempotent — the default retry could land two branches from one click.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (0 design-token drift, eslint `--max-warnings=0`)
- `pnpm check:tests-wired` — all 1578 test files wired
- `pnpm check:conflict-markers` — clean
- `api-contracts.test.ts` — 275 route contracts pass
- `src/lib/afs.test.ts` — 11 new tests, wired into `SUITES.app`
- `code-side-rail.test.ts`, `code-surface.test.ts` — pass with the new tab

**Pre-existing failure, not from this branch:** `src/components/code-rail-fit.test.ts` fails identically on clean `main` (a CSS assertion, "the reopen rail reserves in-flow layout width"). Verified by running it on an unmodified checkout.

**Note:** the `commit-msg` hook rejected a `Co-authored-by` trailer for the AI assistant, since it requires a person's numeric no-reply identity. The trailer was dropped rather than worked around.