### PR TITLE
fix: never restate a list enumerator as a podcast takeaway

### DIFF
--- a/src/lib/server/research-generations.test.ts
+++ b/src/lib/server/research-generations.test.ts
@@ -743,6 +743,47 @@ test("podcast closers restate the section's lead finding verbatim as the takeawa
   );
 });
 
+test("podcast closers never restate a list enumerator as the takeaway", () => {
+  // cave-8ksv1: real artifacts open sections with numbered lists, and the
+  // enumerator's own dot matched as a complete "sentence" — closers rendered
+  // "The takeaway there — 1." Strip the marker and take the real sentence.
+  const content = draftPodcastContent({
+    mission,
+    artifact: { key: "findings", title: "Findings — decision criteria" },
+    markdown: [
+      "# Findings",
+      "",
+      "## Decision criteria",
+      "",
+      "1. Scope of evolution decides the safeguard family. Prompts want spec regression; weights want drift benchmarks.",
+      "2. Reversibility budget comes second.",
+      "",
+      "## Numeric leads",
+      "",
+      "42. 17 3.5. The rest of this section is prose.",
+    ].join("\n"),
+  }, "standard");
+  assert.equal(content.kind, "podcast");
+  if (content.kind !== "podcast") return;
+  const hosts = content.script.filter((segment) => segment.speaker === "host");
+  assert.ok(
+    !hosts.some((segment) => /[—:] ?\d{1,3}\.$/.test(segment.text)),
+    "no closer ends on a bare enumerator",
+  );
+  assert.ok(
+    hosts.some((segment) =>
+      segment.text.includes("Scope of evolution decides the safeguard family."),
+    ),
+    "the sentence after the enumerator is the takeaway",
+  );
+  // A "sentence" with no letters is structure, not synthesis — that section
+  // falls back to the acknowledgment closer instead of restating "17 3.5."
+  assert.ok(
+    !hosts.some((segment) => segment.text.includes("17 3.5.")),
+    "letterless numeric fragments never become the takeaway",
+  );
+});
+
 test("podcast host carries at least 20% of dialogue characters on realistic findings", () => {
   // Charm re-review (cave-upkaf): host/guest balance measured 16.2%/83.8%
   // against a 20–30% target. Content-bearing closers are the lever; this pins

--- a/src/lib/server/research-generations.ts
+++ b/src/lib/server/research-generations.ts
@@ -1234,16 +1234,31 @@ const MAX_TAKEAWAY_CHARS = 160;
 const FIRST_SENTENCE_RE = /^[\s\S]*?[.!?…]["'”’)\]]*(?=\s|$)/;
 
 /**
+ * A list enumerator or bullet marker opening a chunk (`1.`, `2)`, `a.`, `-`,
+ * `*`, `•`). Stripped before sentence extraction: on real artifacts a section
+ * often leads with a numbered list, and the enumerator's own dot otherwise
+ * matches as a complete "sentence" — closers then restate "1." as the
+ * takeaway (cave-8ksv1).
+ */
+const LEAD_LIST_MARKER_RE = /^(?:[-*•]|(?:\d{1,3}|[a-z])[.)])\s+/i;
+
+/** Spoken-substance gate: at least three words, at least one with letters. */
+const TAKEAWAY_SUBSTANCE_RE = /(?:\S+\s+){2}\S/;
+
+/**
  * The section's lead sentence, restated verbatim by content-bearing closers.
  * Declarative sentences only — a question restated as "the takeaway" is not a
  * synthesis — and only when short enough to work as a spoken bookend. Any
- * non-question terminator qualifies; only `?` disqualifies.
+ * non-question terminator qualifies; only `?` disqualifies. A leading list
+ * marker is not part of the sentence, and a match without real word content
+ * (three words, one carrying letters) is structure, not a takeaway.
  */
 function sectionTakeaway(chunks: string[]): string | undefined {
-  const lead = chunks[0]?.trimStart();
+  const lead = chunks[0]?.trimStart().replace(LEAD_LIST_MARKER_RE, "");
   if (!lead) return undefined;
   const sentence = lead.match(FIRST_SENTENCE_RE)?.[0]?.trim();
   if (!sentence || sentence.length > MAX_TAKEAWAY_CHARS) return undefined;
+  if (!TAKEAWAY_SUBSTANCE_RE.test(sentence) || !/\p{L}/u.test(sentence)) return undefined;
   return /\?["'”’)\]]*$/.test(sentence) ? undefined : sentence;
 }
 


### PR DESCRIPTION
## Problem

Fresh drafts of the identity-preservation episodes (for Charm's re-review of cave-upkaf/cave-9wkyq) exposed a defect the fixtures missed: real artifacts open sections with numbered lists, and the enumerator's own dot matches `FIRST_SENTENCE_RE` as a complete sentence. Content-bearing closers then restate it verbatim:

> The takeaway there — 1.

Worse than the generic fallback, and it suppresses host share (verbatim restatement is the share mechanism — fresh drafts measured 13.6%/16.9% vs the 20% floor).

## Fix

- Strip a leading list marker (`1.`, `2)`, `a.`, `-`, `*`, `•`) before sentence extraction, so the real lead sentence becomes the takeaway.
- Require spoken substance — at least three words, at least one carrying letters — before a match qualifies; letterless numeric fragments fall back to the acknowledgment closer.

## Verification

- `research-generations.test.ts`: 45/45 (1 new regression covering enumerator leads and letterless fragments)
- `tsc --noEmit` clean

Bead: cave-8ksv1