### PR TITLE
fix(reader): align heading text with body copy and scale h3–h6

### DIFF
--- a/src/styles/document-reader.css
+++ b/src/styles/document-reader.css
@@ -168,7 +168,23 @@
   scroll-margin-top: var(--space-5);
 }
 
+/* Heading scale by level — the shared reader renders h2–h6, so deeper
+   headings must step down or every section reads as a sibling of the last. */
+h3.document-reader__heading {
+  margin-top: var(--space-6);
+  font-size: var(--text-md);
+}
+
+h4.document-reader__heading,
+h5.document-reader__heading,
+h6.document-reader__heading {
+  margin-top: var(--space-5);
+  color: var(--text-secondary);
+  font-size: var(--text-base);
+}
+
 .document-reader__section-toggle {
+  position: relative;
   display: flex;
   width: 100%;
   align-items: center;
@@ -182,13 +198,19 @@
   cursor: pointer;
 }
 
+/* The accent tick hangs into the left margin so heading TEXT sits on the
+   same edge as body copy — the inline-flex tick used to push every heading
+   ~12px right of its own paragraphs. */
 .document-reader__section-toggle::before {
+  position: absolute;
+  top: 50%;
+  left: calc(-1 * (var(--space-1) + var(--space-2)));
   width: var(--space-1);
   height: var(--space-4);
   border-radius: var(--radius-pill);
   background: var(--document-reader-accent);
   content: "";
-  flex: none;
+  transform: translateY(-50%);
 }
 
 .document-reader__section-caret {

--- a/src/styles/research-reader.css
+++ b/src/styles/research-reader.css
@@ -144,10 +144,34 @@
   color: var(--text-primary);
   scroll-margin-top: 20px;
 }
+/* Deeper section headings step down from h2 — the reader renders h2–h6 and
+   they otherwise all land at the h2 size. */
+.rr-doc h3 {
+  font-family: var(--font-inter);
+  font-weight: 600;
+  font-size: var(--text-md);
+  line-height: 1.3;
+  margin: var(--space-6) 0 var(--space-3);
+  color: var(--text-primary);
+  scroll-margin-top: 20px;
+}
+.rr-doc h4,
+.rr-doc h5,
+.rr-doc h6 {
+  font-family: var(--font-inter);
+  font-weight: 600;
+  font-size: var(--text-base);
+  line-height: 1.3;
+  margin: var(--space-5) 0 var(--space-2);
+  color: var(--text-secondary);
+  scroll-margin-top: 20px;
+}
 /* The real <h2> keeps heading semantics; an inner button carries the collapse
    control so no interactive element nests inside another. */
-.rr-h2-btn { display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: none; border: none; padding: 0; margin: 0; font: inherit; color: inherit; cursor: pointer; }
-.rr-h2-btn::before { content: ""; width: 3px; height: 15px; border-radius: 2px; background: var(--research-accent); flex: none; }
+.rr-h2-btn { position: relative; display: flex; align-items: center; gap: 10px; width: 100%; text-align: left; background: none; border: none; padding: 0; margin: 0; font: inherit; color: inherit; cursor: pointer; }
+/* The accent tick hangs in the left margin so heading text shares the body
+   copy's left edge instead of stair-stepping 13px right of it. */
+.rr-h2-btn::before { content: ""; position: absolute; top: 50%; left: -13px; width: 3px; height: 15px; border-radius: 2px; background: var(--research-accent); transform: translateY(-50%); }
 .rr-sec-caret { margin-left: auto; color: var(--text-muted); transition: transform var(--duration-fast) var(--ease-standard); }
 .rr-h2-btn:hover .rr-sec-caret { color: var(--text-secondary); }
 .rr-h2-btn[data-open="false"] .rr-sec-caret { transform: rotate(-90deg); }


### PR DESCRIPTION
## What

Two typography defects in the reader surfaces (chat expand reader, research briefs, canonical/familiar memory docs — everything on the shared `DocumentReader` plus `research-reader.css`):

1. **Indentation** — the accent tick before each collapsible section heading was an inline flex item, pushing heading text ~12–13px right of its own body copy. Headings, paragraphs, and lists each had a different left edge. The tick now hangs in the left margin (`position: absolute`, negative offset, vertically centered), so all text shares one column edge.
2. **Sizing** — both sheets render `h2`–`h6` (`headingTag()` in `document-reader.tsx`) but only styled `h2`, so every subsection heading rendered at its parent's size (e.g. `RQ1.` under `Findings by research question`). Added a stepped scale: h3 at `--text-md`, h4–h6 at `--text-base` with secondary ink, with top margins tightening as levels deepen.

## Audit

Swept every other `::before`/tick idiom in `src/styles` for the same defect: `gh-section-edge` (GitHub detail), kanban priority rails, activity-rail markers are all either edge-anchored absolutes or chrome on non-prose micro-labels — no other surface indents prose headings this way. Only these two sheets were affected.

## Verification

- `document-reader-view.test.ts`, `css-module-order.test.ts` — pass
- `design-token-drift.test.ts` ratchet — pass (no new judgment categories)
- `pnpm codemod:design:check` — 0 files with drift

Bead: cave-53wcn