### PR TITLE
feat(chat): inline mp3/mp4 playback for chat attachments (cave-zglk9)

### DIFF
--- a/src/app/api/chat/attachment/route.test.ts
+++ b/src/app/api/chat/attachment/route.test.ts
@@ -15,7 +15,7 @@ const OUTSIDE = mkdtempSync(join(tmpdir(), "chat-attachment-route-outside-"));
 process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = ROOT;
 
 const { GET } = await import("./route.ts");
-const { saveChatImageAttachment } = await import("@/lib/server/chat-attachment-store");
+const { saveChatImageAttachment, saveChatMediaAttachment } = await import("@/lib/server/chat-attachment-store");
 
 after(() => {
   rmSync(ROOT, { recursive: true, force: true });
@@ -53,6 +53,23 @@ test("a stored image is served with its own bytes and mime type", async () => {
 
   const body = Buffer.from(await res.arrayBuffer());
   assert.deepEqual(body, PIXEL, "the served bytes are the stored bytes");
+});
+
+test("a stored media attachment is served for inline playback", async () => {
+  // Bigger than the 5MB image cap — proves the read path uses the media cap.
+  const clip = Buffer.alloc(6 * 1024 * 1024, 9);
+  const storedId = await saveChatMediaAttachment(
+    `data:video/mp4;base64,${clip.toString("base64")}`,
+    "video/mp4",
+  );
+  assert.ok(storedId, "the store minted a media id");
+
+  const res = await GET(localRequest(`id=${encodeURIComponent(storedId)}`));
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get("content-type"), "video/mp4");
+  assert.equal(res.headers.get("content-length"), String(clip.byteLength));
+  const body = Buffer.from(await res.arrayBuffer());
+  assert.deepEqual(body, clip, "the served bytes are the stored bytes");
 });
 
 test("a non-local request is refused before the store is touched", async () => {

--- a/src/app/api/chat/send/chat-send-attachments.ts
+++ b/src/app/api/chat/send/chat-send-attachments.ts
@@ -2,11 +2,13 @@ import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
+  cleanMediaDataUrl,
   MAX_ATTACHMENT_IMAGE_BYTES,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
 import {
   saveChatImageAttachment,
+  saveChatMediaAttachment,
   sweepChatImageAttachments,
 } from "@/lib/server/chat-attachment-store";
 
@@ -49,9 +51,10 @@ export async function writeImageAttachmentsToTemp(
 }
 
 /**
- * Give each image attachment a durable copy and stamp its id onto the record
- * the transcript will keep. `persisted` is the metadata-only shape (payloads
- * already stripped); `source` still holds the pixels.
+ * Give each image and playable-media attachment a durable copy and stamp its
+ * id onto the record the transcript will keep. `persisted` is the
+ * metadata-only shape (payloads already stripped); `source` still holds the
+ * bytes.
  *
  * Best effort by design: a store failure leaves that attachment exactly as it
  * was before — metadata only — rather than failing the send.
@@ -60,15 +63,23 @@ export async function persistImageAttachments(
   persisted: ChatAttachment[],
   source: ChatAttachment[],
 ): Promise<ChatAttachment[]> {
-  const anyImages = source.some(
-    (attachment) => attachment.dataUrl && attachment.mimeType?.startsWith("image/"),
+  const anyPayloads = source.some(
+    (attachment) =>
+      attachment.dataUrl &&
+      (attachment.mimeType?.startsWith("image/") || cleanMediaDataUrl(attachment.dataUrl)),
   );
-  if (!anyImages) return persisted;
+  if (!anyPayloads) return persisted;
   const stored = await Promise.all(
     persisted.map(async (attachment, index) => {
       const origin = source[index];
-      if (!origin?.dataUrl || !origin.mimeType?.startsWith("image/")) return attachment;
-      const storedId = await saveChatImageAttachment(origin.dataUrl, origin.mimeType);
+      if (!origin?.dataUrl) return attachment;
+      let storedId: string | null = null;
+      if (origin.mimeType?.startsWith("image/")) {
+        storedId = await saveChatImageAttachment(origin.dataUrl, origin.mimeType);
+      } else {
+        const media = cleanMediaDataUrl(origin.dataUrl);
+        if (media) storedId = await saveChatMediaAttachment(media.dataUrl, media.mimeType);
+      }
       return storedId ? { ...attachment, storedId } : attachment;
     }),
   );

--- a/src/app/api/chat/send/chat-send-image-persistence.test.ts
+++ b/src/app/api/chat/send/chat-send-image-persistence.test.ts
@@ -76,6 +76,33 @@ test("a forged storedId is discarded rather than fetched", () => {
   assert.equal(chatAttachmentSrc(forged), null, "and nothing is fetched for them");
 });
 
+test("a media attachment gains a storedId the same way", async () => {
+  const clip = Buffer.from("fake-mp4-bytes-through-the-send-path");
+  const attachments = normalizeChatAttachments([
+    {
+      name: "teaser.mp4",
+      type: "video/mp4",
+      mimeType: "video/mp4",
+      size: clip.byteLength,
+      dataUrl: `data:video/mp4;base64,${clip.toString("base64")}`,
+    },
+  ]);
+  assert.ok(attachments[0].dataUrl, "the media payload survives normalization");
+  const [persisted] = await persistImageAttachments(
+    stripPreviewOnlyAttachmentFields(attachments),
+    attachments,
+  );
+  assert.ok(persisted.storedId, "the clip records where its durable copy lives");
+  assert.match(persisted.storedId, /\.mp4$/);
+  assert.equal(persisted.dataUrl, undefined, "the payload stays out of the transcript");
+  assert.deepEqual(
+    readFileSync(join(ROOT, persisted.storedId)),
+    clip,
+    "the stored bytes are the attached bytes",
+  );
+  assert.ok(chatAttachmentSrc(persisted), "the player resolves to the serving route");
+});
+
 test("a turn with no images does no store work", async () => {
   const attachments = normalizeChatAttachments([TEXT_FILE]);
   const before = readdirSync(ROOT).length;

--- a/src/components/chat-attachment-cards.test.ts
+++ b/src/components/chat-attachment-cards.test.ts
@@ -14,14 +14,14 @@ assert.match(cards, /aria-modal="true"/, "attachment preview remains a modal dia
 assert.match(cards, /export function AttachmentList/, "attachment chips have a dedicated presentation component");
 assert.match(cards, /export function InlineImageAttachments/, "familiar-produced images have an inline presentation component");
 assert.match(cards, /export function AttachmentThumb/, "staged attachments have a chip-sized preview component");
-assert.match(chatView, /import \{ AttachmentList, AttachmentThumb, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment \} from "\.\/chat-attachment-cards"/, "ChatView consumes the attachment presentation boundary");
+assert.match(chatView, /import \{[^}]*\bAttachmentList\b[^}]*\bAttachmentThumb\b[^}]*\bInlineImageAttachments\b[^}]*\bformatAttachmentBytes\b[^}]*\bisInlineImageAttachment\b[^}]*\} from "\.\/chat-attachment-cards"/, "ChatView consumes the attachment presentation boundary");
 
 // Both transcript paths — the turn you sent and the turn a familiar produced —
 // render images as images and keep the chip list for everything that has no
 // pixels to show. A user-attached screenshot used to appear only as a filename
 // (cave-xrvns follow-up), which is indistinguishable from a text file.
 const inlineSplits = chatView.match(
-  /<InlineImageAttachments attachments=\{turn\.attachments\} \/>\s*\{turn\.attachments\.some\(\(a\) => !isInlineImageAttachment\(a\)\) \? \(\s*<AttachmentList attachments=\{turn\.attachments\.filter\(\(a\) => !isInlineImageAttachment\(a\)\)\} \/>/g,
+  /<InlineImageAttachments attachments=\{turn\.attachments\} \/>[\s\S]{0,400}?\{turn\.attachments\.some\(\(a\) => !isInlineImageAttachment\(a\)[\s\S]{0,120}?\) \? \([\s\S]{0,200}?<AttachmentList attachments=\{turn\.attachments\.filter\(\(a\) => !isInlineImageAttachment\(a\)/g,
 ) ?? [];
 assert.equal(
   inlineSplits.length,

--- a/src/components/chat-attachment-cards.tsx
+++ b/src/components/chat-attachment-cards.tsx
@@ -2,7 +2,8 @@ import { useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ImageCarousel } from "@/components/image-carousel";
 import { AuthedImage } from "@/components/ui/authed-image";
-import { attachmentIcon, chatAttachmentSrc, type ChatAttachment } from "@/lib/chat-attachments";
+import { useAuthedImageState } from "@/lib/authed-image";
+import { attachmentIcon, attachmentMediaKind, chatAttachmentSrc, type ChatAttachment } from "@/lib/chat-attachments";
 import { Icon } from "@/lib/icon";
 import { useFocusTrap } from "@/lib/use-focus-trap";
 
@@ -108,6 +109,82 @@ export function isInlineImageAttachment(attachment: ChatAttachment): boolean {
   return Boolean(
     (attachment.mimeType ?? attachment.type)?.startsWith("image/") &&
       chatAttachmentSrc(attachment),
+  );
+}
+
+/**
+ * True when the attachment is playable media we can actually mount — an
+ * allowlisted audio/video mime with either an in-memory payload (the turn you
+ * just sent) or a durable stored copy. Anything else stays a chip.
+ */
+export function isInlineMediaAttachment(attachment: ChatAttachment): boolean {
+  return Boolean(attachmentMediaKind(attachment) && chatAttachmentSrc(attachment));
+}
+
+/**
+ * One inline player. The stored copy lives behind `/api/chat/attachment`,
+ * which the packaged sidecar gates on a header only the patched
+ * `window.fetch` carries — a native `<video src="/api/…">` would 401
+ * (cave-wgc2). So the bytes come through the shared authed fetch→blob cache;
+ * a `blob:` source also gives WebKit free seeking, which the whole-file
+ * serving route does not. Native controls only — no autoplay, no motion
+ * until the user asks for it.
+ */
+function InlineMediaPlayer({ attachment }: { attachment: ChatAttachment }) {
+  const kind = attachmentMediaKind(attachment);
+  const { url, status } = useAuthedImageState(chatAttachmentSrc(attachment));
+  if (!kind) return null;
+  if (status === "error") return null;
+  if (!url) {
+    return (
+      <div
+        className="flex h-12 w-72 max-w-full items-center gap-2 rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40 px-3 text-[length:var(--text-xs)] text-[var(--text-muted)]"
+        role="status"
+        aria-label={`Loading ${attachment.name}`}
+      >
+        <Icon name={attachmentIcon(attachment)} width={13} className="shrink-0" />
+        <span className="truncate">{attachment.name}</span>
+      </div>
+    );
+  }
+  if (kind === "audio") {
+    return (
+      <figure className="max-w-full">
+        <figcaption className="mb-1 flex items-center gap-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+          <Icon name="ph:waveform" width={12} className="shrink-0" />
+          <span className="truncate">{attachment.name}</span>
+        </figcaption>
+        <audio controls preload="metadata" src={url} className="block w-80 max-w-full" aria-label={attachment.name} />
+      </figure>
+    );
+  }
+  return (
+    <figure className="max-w-full overflow-hidden rounded-lg border border-[var(--border-hairline)] bg-[var(--bg-raised)]/40">
+      <video controls preload="metadata" src={url} className="block max-h-80 max-w-full" aria-label={attachment.name} />
+      <figcaption className="flex items-center gap-1.5 px-3 py-1.5 text-[length:var(--text-xs)] text-[var(--text-muted)]">
+        <Icon name="ph:video" width={12} className="shrink-0" />
+        <span className="truncate">{attachment.name}</span>
+        <span className="ml-auto shrink-0">{formatAttachmentBytes(attachment.size)}</span>
+      </figcaption>
+    </figure>
+  );
+}
+
+/**
+ * Full-bleed inline players for audio/video attachments — a familiar's
+ * generated teaser mp4, a user's voice memo — mirroring how
+ * {@link InlineImageAttachments} mounts pictures. Attachments that fail the
+ * media allowlist (or hold no payload) stay in the chip list instead.
+ */
+export function InlineMediaAttachments({ attachments }: { attachments: ChatAttachment[] }) {
+  const media = attachments.filter(isInlineMediaAttachment);
+  if (media.length === 0) return null;
+  return (
+    <div className="mt-2 flex flex-col gap-2">
+      {media.map((attachment, index) => (
+        <InlineMediaPlayer key={`${attachment.name}-${index}`} attachment={attachment} />
+      ))}
+    </div>
   );
 }
 

--- a/src/components/chat-view-first-class.test.ts
+++ b/src/components/chat-view-first-class.test.ts
@@ -71,8 +71,8 @@ assert.match(
 
 assert.match(
   source,
-  /const CHAT_ATTACHMENT_ACCEPT = \[[\s\S]*"image\/\*"[\s\S]*"video\/\*"[\s\S]*"application\/pdf"[\s\S]*"\.md"[\s\S]*"\.json"[\s\S]*\]\.join\(","\)/,
-  "Chat attachments should explicitly accept images, videos, documents, and common text/code files",
+  /const CHAT_ATTACHMENT_ACCEPT = \[[\s\S]*"image\/\*"[\s\S]*"video\/\*"[\s\S]*"audio\/\*"[\s\S]*"application\/pdf"[\s\S]*"\.md"[\s\S]*"\.json"[\s\S]*\]\.join\(","\)/,
+  "Chat attachments should explicitly accept images, videos, audio, documents, and common text/code files",
 );
 
 assert.match(

--- a/src/components/chat-view-polish-attachments-mentions.test.ts
+++ b/src/components/chat-view-polish-attachments-mentions.test.ts
@@ -24,8 +24,8 @@ assert.match(
 
 assert.match(
   attachmentsLib,
-  /if \(file\.size > MAX_ATTACHMENT_IMAGE_BYTES\) \{[\s\S]*?attachment\.truncated = true;/,
-  "Oversized image attachments should be capped at capture time and marked like truncated text",
+  /const cap = mediaMime \? MAX_ATTACHMENT_MEDIA_BYTES : MAX_ATTACHMENT_IMAGE_BYTES;[\s\S]*?if \(file\.size > cap\) \{[\s\S]*?attachment\.truncated = true;/,
+  "Oversized image and media attachments should be capped at capture time and marked like truncated text",
 );
 
 assert.match(

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -302,7 +302,7 @@ import {
 import { streamFamiliarText } from "@/lib/familiar-stream";
 import { usePromptEnhance } from "@/lib/use-prompt-enhance";
 import { EnhanceStrip } from "@/components/composer-enhance";
-import { AttachmentList, AttachmentThumb, InlineImageAttachments, formatAttachmentBytes, isInlineImageAttachment } from "./chat-attachment-cards";
+import { AttachmentList, AttachmentThumb, InlineImageAttachments, InlineMediaAttachments, formatAttachmentBytes, isInlineImageAttachment, isInlineMediaAttachment } from "./chat-attachment-cards";
 import { preloadMarkdownPreview } from "@/lib/markdown-preview";
 import {
   type CreationRefreshState,
@@ -549,6 +549,7 @@ const CHUNK_FLUSH_MS = 40;
 const CHAT_ATTACHMENT_ACCEPT = [
   "image/*",
   "video/*",
+  "audio/*",
   "application/pdf",
   "application/json",
   "text/*",
@@ -8611,14 +8612,15 @@ function TurnRowImpl({
                 onOpenUrl={onOpenUrl}
                 branchNav={branchNav}
               />
-              {/* An image you attached renders as the image, matching the
-                  assistant path — the chip list only carries what has no
-                  pixels to show (text files, oversize/undelivered images). */}
+              {/* An image or playable clip you attached renders as itself,
+                  matching the assistant path — the chip list only carries what
+                  has nothing to show (text files, oversize/undelivered). */}
               {turn.attachments?.length ? (
                 <>
                   <InlineImageAttachments attachments={turn.attachments} />
-                  {turn.attachments.some((a) => !isInlineImageAttachment(a)) ? (
-                    <AttachmentList attachments={turn.attachments.filter((a) => !isInlineImageAttachment(a))} />
+                  <InlineMediaAttachments attachments={turn.attachments} />
+                  {turn.attachments.some((a) => !isInlineImageAttachment(a) && !isInlineMediaAttachment(a)) ? (
+                    <AttachmentList attachments={turn.attachments.filter((a) => !isInlineImageAttachment(a) && !isInlineMediaAttachment(a))} />
                   ) : null}
                 </>
               ) : null}
@@ -8881,13 +8883,14 @@ function TurnRowImpl({
               </div>
             ) : null}
             {/* Agent-produced inline attachments: images render full-bleed
-                (e.g. /image generations), everything else stays a file chip
-                that opens the lightbox. */}
+                (e.g. /image generations), audio/video mount as players, and
+                everything else stays a file chip that opens the lightbox. */}
             {turn.attachments?.length ? (
               <>
                 <InlineImageAttachments attachments={turn.attachments} />
-                {turn.attachments.some((a) => !isInlineImageAttachment(a)) ? (
-                  <AttachmentList attachments={turn.attachments.filter((a) => !isInlineImageAttachment(a))} />
+                <InlineMediaAttachments attachments={turn.attachments} />
+                {turn.attachments.some((a) => !isInlineImageAttachment(a) && !isInlineMediaAttachment(a)) ? (
+                  <AttachmentList attachments={turn.attachments.filter((a) => !isInlineImageAttachment(a) && !isInlineMediaAttachment(a))} />
                 ) : null}
               </>
             ) : null}

--- a/src/lib/chat-attachments.test.ts
+++ b/src/lib/chat-attachments.test.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import {
+  attachmentMediaKind,
   buildPromptWithAttachments,
   normalizeChatAttachments,
   stripPreviewOnlyAttachmentFields,
@@ -73,6 +74,55 @@ assert.match(
   /2\. bundle\.zip \(application\/zip, 2\.0 KB\)\n\(file attached as metadata only — text content was not available\)/,
 );
 assert.doesNotMatch(mediaPrompt, /\(content unavailable\)/);
+
+// Audio gets its own metadata-only wording, distinct from video's.
+{
+  const audioPrompt = buildPromptWithAttachments("Listen.", normalizeChatAttachments([
+    { name: "memo.mp3", type: "audio/mpeg", mimeType: "audio/mpeg", size: 4096 },
+  ]));
+  assert.match(
+    audioPrompt,
+    /1\. memo\.mp3 \(audio\/mpeg, 4\.0 KB\)\n\(audio attached as metadata only — sound is not decoded yet\)/,
+  );
+}
+
+// ── Playable media data URLs ─────────────────────────────────────────────────
+// Allowlisted audio/video ride the same dataUrl channel as images, with the
+// larger media cap; anything off the allowlist is stripped as before.
+{
+  const clip = `data:video/mp4;base64,${"QUJD".repeat(64)}`;
+  const [video] = normalizeChatAttachments([
+    { name: "demo.mp4", type: "video/mp4", size: 192, dataUrl: clip },
+  ]);
+  assert.equal(video.dataUrl, clip, "an allowlisted video payload survives normalization");
+  assert.equal(video.mimeType, "video/mp4");
+  assert.equal(attachmentMediaKind(video), "video");
+
+  const [audio] = normalizeChatAttachments([
+    { name: "memo.mp3", type: "audio/mpeg", size: 192, dataUrl: `data:audio/mpeg;base64,${"QUJD".repeat(64)}` },
+  ]);
+  assert.ok(audio.dataUrl, "an allowlisted audio payload survives normalization");
+  assert.equal(attachmentMediaKind(audio), "audio");
+
+  const [mkv] = normalizeChatAttachments([
+    { name: "demo.mkv", type: "video/x-matroska", size: 192, dataUrl: `data:video/x-matroska;base64,${"QUJD".repeat(64)}` },
+  ]);
+  assert.equal(mkv.dataUrl, undefined, "media off the allowlist is stripped");
+  assert.equal(attachmentMediaKind(mkv), null);
+
+  // Media past the 50MB cap is refused by size.
+  const bigBody = "QUJD".repeat(Math.floor((51 * 1024 * 1024) / 3));
+  const [oversize] = normalizeChatAttachments([
+    { name: "big.mp4", type: "video/mp4", dataUrl: `data:video/mp4;base64,${bigBody}` },
+  ]);
+  assert.equal(oversize.dataUrl, undefined, "media past the cap is dropped");
+
+  // The send-body strip keeps validated media payloads alongside images.
+  const kept = stripPreviewOnlyAttachmentFieldsKeepingImages([
+    { name: "demo.mp4", type: "video/mp4", mimeType: "video/mp4", size: 192, dataUrl: clip },
+  ]);
+  assert.equal(kept[0].dataUrl, clip, "media payloads survive the keeping-images strip");
+}
 
 const attachmentOnly = buildPromptWithAttachments("", [attachments[0]]);
 assert.match(attachmentOnly, /^Review the attached file\./);

--- a/src/lib/chat-attachments.ts
+++ b/src/lib/chat-attachments.ts
@@ -4,6 +4,10 @@ export const MAX_ATTACHMENT_TEXT_CHARS = 64_000;
 /** Hard cap on a decoded image payload, enforced on capture (client) and on
  * normalize (server) — the server never trusts the client-side check. */
 export const MAX_ATTACHMENT_IMAGE_BYTES = 5 * 1024 * 1024;
+/** Hard cap on a decoded audio/video payload. Larger than the image cap
+ * because even a short mp4 clears 5 MB; enforced on capture, on normalize,
+ * and again by the attachment store on both save and read. */
+export const MAX_ATTACHMENT_MEDIA_BYTES = 50 * 1024 * 1024;
 export const IMAGE_ATTACHMENTS_UNSUPPORTED_NOTE =
   "(image attachments are not supported by this harness)";
 const IMAGE_NOT_DELIVERED_NOTE =
@@ -12,8 +16,30 @@ const IMAGE_METADATA_ONLY_NOTE =
   "(image attached as metadata only — task cards don't store image content)";
 const VIDEO_METADATA_ONLY_NOTE =
   "(video attached as metadata only — frames and audio are not decoded yet)";
+const AUDIO_METADATA_ONLY_NOTE =
+  "(audio attached as metadata only — sound is not decoded yet)";
 const FILE_METADATA_ONLY_NOTE =
   "(file attached as metadata only — text content was not available)";
+
+/**
+ * The playable-media allowlist: MIME types the chat can round-trip through the
+ * durable attachment store and hand to a native `<audio>`/`<video>` element.
+ * The value is the extension the store mints into the stored id, so it must
+ * stay consistent with `MIME_BY_EXT` in `lib/server/chat-attachment-store.ts`.
+ * Anything not listed here stays a metadata-only chip.
+ */
+export const MEDIA_EXT_BY_MIME: Record<string, string> = {
+  "audio/mpeg": "mp3",
+  "audio/mp3": "mp3",
+  "audio/mp4": "m4a",
+  "audio/x-m4a": "m4a",
+  "audio/wav": "wav",
+  "audio/x-wav": "wav",
+  "audio/ogg": "ogg",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "video/quicktime": "mov",
+};
 
 export type ChatAttachment = {
   name: string;
@@ -128,6 +154,13 @@ const MAX_DATA_URL_HEADER_CHARS = 128;
 const MAX_IMAGE_DATA_URL_CHARS =
   Math.ceil(MAX_ATTACHMENT_IMAGE_BYTES / 3) * 4 + 128;
 
+/** Header of a base64 audio/video data URL — validated against the
+ * {@link MEDIA_EXT_BY_MIME} allowlist after this shape check. */
+const MEDIA_DATA_URL_HEADER_RE = /^data:((?:audio|video)\/[a-z0-9.+-]{1,60});base64$/i;
+
+const MAX_MEDIA_DATA_URL_CHARS =
+  Math.ceil(MAX_ATTACHMENT_MEDIA_BYTES / 3) * 4 + 128;
+
 /**
  * Is this the base64 body of a data URL?
  *
@@ -186,12 +219,51 @@ export function cleanImageDataUrl(
   return { dataUrl, mimeType: header[1].toLowerCase() };
 }
 
+/**
+ * Validate a base64 audio/video data URL against the playable-media allowlist
+ * and the media size cap. Same non-backtracking machinery as
+ * {@link cleanImageDataUrl} — the header regex never touches the payload, and
+ * the body scan is linear with constant stack (see the V8 note above).
+ */
+export function cleanMediaDataUrl(
+  dataUrl: unknown,
+): { dataUrl: string; mimeType: string } | null {
+  if (typeof dataUrl !== "string" || dataUrl.length > MAX_MEDIA_DATA_URL_CHARS) return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma < 0 || comma > MAX_DATA_URL_HEADER_CHARS) return null;
+  const header = MEDIA_DATA_URL_HEADER_RE.exec(dataUrl.slice(0, comma));
+  if (!header) return null;
+  const mimeType = header[1].toLowerCase();
+  // Allowlist, not prefix: only types the store can mint an extension for.
+  if (!MEDIA_EXT_BY_MIME[mimeType]) return null;
+  const body = dataUrl.slice(comma + 1);
+  if (!isBase64Body(body)) return null;
+  const decodedBytes = base64DecodedBytes(body);
+  if (decodedBytes === 0 || decodedBytes > MAX_ATTACHMENT_MEDIA_BYTES) return null;
+  return { dataUrl, mimeType };
+}
+
 function isImageAttachment(attachment: ChatAttachment): boolean {
   return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("image/"));
 }
 
 function isVideoAttachment(attachment: ChatAttachment): boolean {
   return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("video/"));
+}
+
+function isAudioAttachment(attachment: ChatAttachment): boolean {
+  return Boolean((attachment.mimeType ?? attachment.type)?.startsWith("audio/"));
+}
+
+/**
+ * "audio" / "video" when the attachment is playable media on the allowlist,
+ * null otherwise. Drives the inline player and the send/persist media paths,
+ * so a mime outside {@link MEDIA_EXT_BY_MIME} never reaches a native element.
+ */
+export function attachmentMediaKind(attachment: ChatAttachment): "audio" | "video" | null {
+  const mimeType = (attachment.mimeType ?? attachment.type ?? "").toLowerCase();
+  if (!MEDIA_EXT_BY_MIME[mimeType]) return null;
+  return mimeType.startsWith("audio/") ? "audio" : "video";
 }
 
 export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
@@ -202,9 +274,11 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
       const raw = (item && typeof item === "object") ? item as Record<string, unknown> : {};
       const rawText = typeof raw.text === "string" ? raw.text.replace(/\r\n/g, "\n") : undefined;
       const text = rawText != null ? rawText.slice(0, MAX_ATTACHMENT_TEXT_CHARS) : undefined;
-      // Image payloads ride through normalization (bounded + validated) so the
-      // server can hand them to the harness. Everything else stays metadata-only.
+      // Image and playable-media payloads ride through normalization (bounded
+      // + validated) so the server can persist them. Everything else stays
+      // metadata-only.
       const image = cleanImageDataUrl(raw.dataUrl);
+      const media = image ? null : cleanMediaDataUrl(raw.dataUrl);
       const mimeType = cleanType(raw.mimeType);
       const storedId = cleanStoredId(raw.storedId);
       return {
@@ -215,6 +289,7 @@ export function normalizeChatAttachments(input: unknown): ChatAttachment[] {
         ...(text != null ? { text } : {}),
         ...(rawText != null && rawText.length > MAX_ATTACHMENT_TEXT_CHARS ? { truncated: true } : {}),
         ...(image ? { mimeType: image.mimeType, dataUrl: image.dataUrl } : {}),
+        ...(media ? { mimeType: media.mimeType, dataUrl: media.dataUrl } : {}),
         ...(storedId ? { storedId } : {}),
       };
     });
@@ -224,16 +299,19 @@ export function stripPreviewOnlyAttachmentFields(attachments: ChatAttachment[]):
   return attachments.map(({ dataUrl: _dataUrl, mimeType: _mimeType, ...attachment }) => attachment);
 }
 
-/** Send-body variant of stripPreviewOnlyAttachmentFields: image attachments
- * keep their bounded `dataUrl`/`mimeType` (the only channel that gets the
- * pixels to the harness); everything else is stripped to metadata. */
+/** Send-body variant of stripPreviewOnlyAttachmentFields: image and playable
+ * media attachments keep their bounded `dataUrl`/`mimeType` (the only channel
+ * that gets the bytes to the server for persistence); everything else is
+ * stripped to metadata. */
 export function stripPreviewOnlyAttachmentFieldsKeepingImages(
   attachments: ChatAttachment[],
 ): ChatAttachment[] {
   return attachments.map((attachment) => {
     const { dataUrl, mimeType, ...rest } = attachment;
     const image = mimeType?.startsWith("image/") ? cleanImageDataUrl(dataUrl) : null;
-    return image ? { ...rest, mimeType: image.mimeType, dataUrl: image.dataUrl } : rest;
+    if (image) return { ...rest, mimeType: image.mimeType, dataUrl: image.dataUrl };
+    const media = cleanMediaDataUrl(dataUrl);
+    return media ? { ...rest, mimeType: media.mimeType, dataUrl: media.dataUrl } : rest;
   });
 }
 
@@ -298,6 +376,8 @@ export function buildPromptWithAttachments(
       }
     } else if (isVideoAttachment(attachment)) {
       body = VIDEO_METADATA_ONLY_NOTE;
+    } else if (isAudioAttachment(attachment)) {
+      body = AUDIO_METADATA_ONLY_NOTE;
     } else {
       body = FILE_METADATA_ONLY_NOTE;
     }
@@ -333,6 +413,7 @@ export function attachmentIcon(attachment: Pick<ChatAttachment, "mimeType" | "ty
   const mimeType = attachment.mimeType ?? attachment.type ?? "";
   if (mimeType.startsWith("image/")) return "ph:camera";
   if (mimeType.startsWith("video/")) return "ph:video";
+  if (mimeType.startsWith("audio/")) return "ph:waveform";
   if (mimeType.startsWith("text/") || /json|xml|yaml|toml|csv|javascript|typescript/.test(mimeType)) {
     return "ph:file-text";
   }
@@ -340,7 +421,8 @@ export function attachmentIcon(attachment: Pick<ChatAttachment, "mimeType" | "ty
 }
 
 /** Convert a picked File into a ComposerAttachment: inline text bodies, embed
- *  small images as data URLs, keep everything else as metadata (truncated). */
+ *  small images and playable media as data URLs, keep everything else as
+ *  metadata (truncated). */
 export async function fileToAttachment(file: File): Promise<ComposerAttachment> {
   const attachment: ComposerAttachment = {
     id: crypto.randomUUID(),
@@ -349,12 +431,14 @@ export async function fileToAttachment(file: File): Promise<ComposerAttachment> 
     mimeType: file.type || undefined,
     size: file.size,
   };
+  const mediaMime = MEDIA_EXT_BY_MIME[file.type.toLowerCase()] ? file.type.toLowerCase() : null;
   if (isTextLike(file)) {
     const text = await file.slice(0, MAX_ATTACHMENT_TEXT_CHARS).text();
     attachment.text = text;
     if (file.size > new Blob([text]).size) attachment.truncated = true;
-  } else if (file.type.startsWith("image/")) {
-    if (file.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+  } else if (file.type.startsWith("image/") || mediaMime) {
+    const cap = mediaMime ? MAX_ATTACHMENT_MEDIA_BYTES : MAX_ATTACHMENT_IMAGE_BYTES;
+    if (file.size > cap) {
       attachment.truncated = true;
       return attachment;
     }

--- a/src/lib/server/agent-attachments.test.ts
+++ b/src/lib/server/agent-attachments.test.ts
@@ -16,6 +16,7 @@ const originalEnv = {
   NEXT_PUBLIC_WORKSPACE_ROOT: process.env.NEXT_PUBLIC_WORKSPACE_ROOT,
   OPENCLAW_WORKSPACE_ROOT: process.env.OPENCLAW_WORKSPACE_ROOT,
   CAVE_PROJECTS_PATH_OVERRIDE: process.env.CAVE_PROJECTS_PATH_OVERRIDE,
+  COVEN_CAVE_CHAT_ATTACHMENTS_DIR: process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR,
 };
 
 function restoreEnv() {
@@ -28,6 +29,7 @@ function restoreEnv() {
 const allowed = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-allowed-"));
 const outside = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-outside-"));
 const globalOnly = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-global-"));
+const attachmentStore = await mkdtemp(path.join(tmpdir(), "coven-agent-attach-store-"));
 
 try {
   // Make `globalOnly` globally allowed while tests pass only `allowed` as the
@@ -35,6 +37,7 @@ try {
   process.env.WORKSPACE_ROOT = globalOnly;
   process.env.COVEN_HOME = path.join(allowed, ".coven");
   process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(allowed, "cave-projects.json");
+  process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = attachmentStore;
   delete process.env.COVEN_WORKSPACES_ROOT;
   delete process.env.COVEN_WORKSPACE_ROOT;
   delete process.env.NEXT_PUBLIC_WORKSPACE_ROOT;
@@ -143,6 +146,47 @@ try {
     assert.equal(out.text, "nope");
   }
 
+  // --- media attachment → durable store copy + storedId, no data URL ---
+  {
+    const mp4Path = path.join(allowed, "teaser.mp4");
+    const clip = Buffer.from("fake-mp4-bytes-for-agent-marker");
+    await writeFile(mp4Path, clip);
+    const { readChatImageAttachment } = await import("./chat-attachment-store.ts");
+
+    const text = `Watch this.\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: mp4Path })}\n\`\`\``;
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
+    assert.equal(out.attachments.length, 1, "media attachment parsed");
+    assert.equal(out.attachments[0].name, "teaser.mp4");
+    assert.equal(out.attachments[0].mimeType, "video/mp4");
+    assert.equal(out.attachments[0].size, clip.byteLength);
+    assert.equal(out.attachments[0].dataUrl, undefined, "media never inlines as a data URL");
+    assert.ok(out.attachments[0].storedId, "media carries a durable stored id");
+    const read = await readChatImageAttachment(out.attachments[0].storedId);
+    assert.equal(read.mimeType, "video/mp4");
+    assert.deepEqual(read.data, clip, "the stored copy holds the exact bytes");
+  }
+
+  // --- media larger than the image cap still rides through ---
+  {
+    const bigPath = path.join(allowed, "long.mp3");
+    await writeFile(bigPath, Buffer.alloc(6 * 1024 * 1024, 3));
+    const text = `\`\`\`coven:attachment\n${JSON.stringify({ path: bigPath })}\n\`\`\``;
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
+    assert.equal(out.attachments.length, 1, "6MB audio is admitted under the media cap");
+    assert.equal(out.attachments[0].mimeType, "audio/mpeg");
+    assert.ok(out.attachments[0].storedId, "oversize-for-image audio still stores");
+  }
+
+  // --- media outside allowed roots → dropped like any other path ---
+  {
+    const outsideMedia = path.join(outside, "secret.mp4");
+    await writeFile(outsideMedia, "not yours");
+    const text = `nope\n\n\`\`\`coven:attachment\n${JSON.stringify({ path: outsideMedia })}\n\`\`\``;
+    const out = parseAgentAttachments(text, { allowedRoots: [allowed] });
+    assert.equal(out.attachments.length, 0, "out-of-root media is dropped");
+    assert.equal(out.text, "nope");
+  }
+
   // --- no marker → passthrough ---
   {
     const out = parseAgentAttachments("plain reply", { allowedRoots: [allowed] });
@@ -154,6 +198,7 @@ try {
   await rm(allowed, { recursive: true, force: true });
   await rm(outside, { recursive: true, force: true });
   await rm(globalOnly, { recursive: true, force: true });
+  await rm(attachmentStore, { recursive: true, force: true });
 }
 
 console.log("agent-attachments.test.ts: ok");

--- a/src/lib/server/agent-attachments.ts
+++ b/src/lib/server/agent-attachments.ts
@@ -4,9 +4,11 @@ import {
   cleanImageDataUrl,
   extractAgentAttachmentMarkers,
   MAX_ATTACHMENT_IMAGE_BYTES,
+  MAX_ATTACHMENT_MEDIA_BYTES,
   MAX_ATTACHMENT_TEXT_CHARS,
   type ChatAttachment,
 } from "@/lib/chat-attachments";
+import { saveChatMediaAttachmentFromFileSync } from "@/lib/server/chat-attachment-store";
 
 /**
  * Server-side parser for agent-produced inline attachments.
@@ -41,6 +43,20 @@ const IMAGE_EXT_MIME: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",
   ".webp": "image/webp",
+};
+
+/** Playable media a familiar can surface inline. Copied into the durable
+ * attachment store (not inlined as a data URL — a data URL would bloat the
+ * stream 4/3 and the media cap is 10× the image cap) and referenced by
+ * `storedId`; keep in lockstep with MEDIA_EXT_BY_MIME in chat-attachments.ts. */
+const MEDIA_EXT_MIME: Record<string, string> = {
+  ".mp3": "audio/mpeg",
+  ".m4a": "audio/mp4",
+  ".wav": "audio/wav",
+  ".ogg": "audio/ogg",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
 };
 
 const TEXT_EXTS = new Set([
@@ -125,11 +141,24 @@ function buildAttachment(marker: AttachmentMarker, options: AgentAttachmentParse
   } catch {
     return null;
   }
-  if (!stat.isFile() || stat.size > MAX_AGENT_ATTACHMENT_BYTES) return null;
+  const ext = path.extname(resolved).toLowerCase();
+  const mediaMime = MEDIA_EXT_MIME[ext];
+  const maxBytes = mediaMime ? MAX_ATTACHMENT_MEDIA_BYTES : MAX_AGENT_ATTACHMENT_BYTES;
+  if (!stat.isFile() || stat.size > maxBytes) return null;
 
   const name = marker.name ?? sanitizeAttachmentName(path.basename(resolved));
-  const ext = path.extname(resolved).toLowerCase();
   const size = stat.size;
+
+  if (mediaMime) {
+    // Copy into the durable store and reference by storedId: the client's
+    // chatAttachmentSrc resolves it to /api/chat/attachment for playback, and
+    // the transcript keeps the id so the player survives a reload.
+    const storedId = saveChatMediaAttachmentFromFileSync(resolved, mediaMime);
+    if (storedId) {
+      return { name, size, type: mediaMime, mimeType: mediaMime, storedId };
+    }
+    return { name, size, type: mediaMime, mimeType: mediaMime };
+  }
 
   const imageMime = IMAGE_EXT_MIME[ext];
   if (imageMime) {

--- a/src/lib/server/chat-attachment-store.test.ts
+++ b/src/lib/server/chat-attachment-store.test.ts
@@ -12,10 +12,13 @@ process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = root;
 const {
   CHAT_ATTACHMENT_MAX_AGE_MS,
   ChatAttachmentStoreError,
+  chatAttachmentMaxBytes,
   chatAttachmentMimeType,
   isValidChatAttachmentId,
   readChatImageAttachment,
   saveChatImageAttachment,
+  saveChatMediaAttachment,
+  saveChatMediaAttachmentFromFileSync,
   sweepChatImageAttachments,
 } = await import("./chat-attachment-store.ts");
 
@@ -103,6 +106,52 @@ test("a missing attachment reports missing, not a crash", async () => {
   await assert.rejects(
     () => readChatImageAttachment("11111111-2222-4333-8444-555555555555.png"),
     (error: unknown) => error instanceof ChatAttachmentStoreError && error.code === "missing",
+  );
+});
+
+test("a media payload round-trips through the store", async () => {
+  const clip = Buffer.from("fake-mp4-bytes-for-roundtrip");
+  const dataUrl = `data:video/mp4;base64,${clip.toString("base64")}`;
+  const storedId = await saveChatMediaAttachment(dataUrl, "video/mp4");
+  assert.ok(storedId, "saving an allowlisted video returns an id");
+  assert.match(storedId, /\.mp4$/, "the extension comes from the mime type");
+  assert.equal(chatAttachmentMimeType(storedId), "video/mp4");
+
+  const read = await readChatImageAttachment(storedId);
+  assert.equal(read.mimeType, "video/mp4");
+  assert.deepEqual(read.data, clip, "the bytes come back unchanged");
+});
+
+test("media outside the allowlist is refused", async () => {
+  const dataUrl = `data:video/x-matroska;base64,${Buffer.from("mkv").toString("base64")}`;
+  assert.equal(await saveChatMediaAttachment(dataUrl, "video/x-matroska"), null);
+  assert.equal(saveChatMediaAttachmentFromFileSync("/tmp/whatever.mkv", "video/x-matroska"), null);
+});
+
+test("a media file copies into the store synchronously", async () => {
+  const source = path.join(outside, "teaser.mp4");
+  const clip = Buffer.from("fake-mp4-bytes-for-file-copy");
+  await writeFile(source, clip);
+  const storedId = saveChatMediaAttachmentFromFileSync(source, "video/mp4");
+  assert.ok(storedId, "copying a valid mp4 returns an id");
+  const meta = await stat(path.join(root, storedId));
+  assert.equal(meta.mode & 0o777, 0o600, "copied media is owner-only");
+  const read = await readChatImageAttachment(storedId);
+  assert.deepEqual(read.data, clip);
+});
+
+test("media reads use the media cap, not the image cap", async () => {
+  // Larger than the 5MB image cap but under the 50MB media cap.
+  const big = Buffer.alloc(6 * 1024 * 1024, 7);
+  const source = path.join(outside, "big.mp3");
+  await writeFile(source, big);
+  const storedId = saveChatMediaAttachmentFromFileSync(source, "audio/mpeg");
+  assert.ok(storedId, "a 6MB mp3 is admitted under the media cap");
+  const read = await readChatImageAttachment(storedId);
+  assert.equal(read.data.byteLength, big.byteLength, "the read path honors the media cap");
+  assert.ok(
+    chatAttachmentMaxBytes(storedId) > chatAttachmentMaxBytes("5b1f0e64-6b0e-4b6b-9f3a-0d1c2e3f4a5b.png"),
+    "media ids carry a larger cap than image ids",
   );
 });
 

--- a/src/lib/server/chat-attachment-store.ts
+++ b/src/lib/server/chat-attachment-store.ts
@@ -1,12 +1,17 @@
 import { lstat, mkdir, open, readdir, realpath, rm, writeFile } from "node:fs/promises";
+import fs from "node:fs";
 import path from "node:path";
 import { randomUUID } from "node:crypto";
 
-import { MAX_ATTACHMENT_IMAGE_BYTES } from "../chat-attachments.ts";
+import {
+  MAX_ATTACHMENT_IMAGE_BYTES,
+  MAX_ATTACHMENT_MEDIA_BYTES,
+  MEDIA_EXT_BY_MIME,
+} from "../chat-attachments.ts";
 import { caveHome } from "../coven-paths.ts";
 
 /**
- * Durable home for chat image attachments.
+ * Durable home for chat image and audio/video attachments.
  *
  * The conversation store deliberately keeps base64 payloads out of its JSON
  * (a 5 MB screenshot would be ~6.7 MB of transcript), and the temp copy handed
@@ -37,6 +42,15 @@ const MIME_BY_EXT: Record<string, string> = {
   tif: "image/tiff",
   tiff: "image/tiff",
   webp: "image/webp",
+  // Playable media — keep in lockstep with MEDIA_EXT_BY_MIME in
+  // chat-attachments.ts, which allowlists what the chat surfaces will play.
+  m4a: "audio/mp4",
+  mov: "video/quicktime",
+  mp3: "audio/mpeg",
+  mp4: "video/mp4",
+  ogg: "audio/ogg",
+  wav: "audio/wav",
+  webm: "video/webm",
 };
 /** Files older than this are swept opportunistically on write. */
 export const CHAT_ATTACHMENT_MAX_AGE_MS = 180 * 24 * 60 * 60 * 1000;
@@ -75,6 +89,15 @@ export function chatAttachmentMimeType(storedId: string): string | null {
 
 export function isValidChatAttachmentId(value: unknown): value is string {
   return typeof value === "string" && SAFE_STORED_ID.test(value);
+}
+
+/** Size cap for a stored id, by what its extension says it holds: images keep
+ * the tight image cap, playable media get the larger media cap. */
+export function chatAttachmentMaxBytes(storedId: string): number {
+  const mimeType = chatAttachmentMimeType(storedId) ?? "";
+  return mimeType.startsWith("audio/") || mimeType.startsWith("video/")
+    ? MAX_ATTACHMENT_MEDIA_BYTES
+    : MAX_ATTACHMENT_IMAGE_BYTES;
 }
 
 function isContained(root: string, candidate: string): boolean {
@@ -139,6 +162,82 @@ export async function saveChatImageAttachment(
   }
 }
 
+/**
+ * Persist one validated audio/video payload from a data URL (the user-send
+ * path). Returns the stored id, or null when the payload is unusable —
+ * callers fall back to metadata-only rather than failing the send.
+ */
+export async function saveChatMediaAttachment(
+  dataUrl: string,
+  mimeType: string,
+): Promise<string | null> {
+  const ext = MEDIA_EXT_BY_MIME[mimeType.toLowerCase()];
+  if (!ext) return null;
+  const comma = dataUrl.indexOf(",");
+  if (comma === -1) return null;
+  const payload = Buffer.from(dataUrl.slice(comma + 1), "base64");
+  if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_MEDIA_BYTES) return null;
+  try {
+    const root = await resolvedRoot(true);
+    const storedId = `${randomUUID()}.${ext}`;
+    if (!SAFE_STORED_ID.test(storedId)) return null;
+    const target = path.join(/* turbopackIgnore: true */ root, storedId);
+    if (!isContained(root, target)) return null;
+    await writeFile(/* turbopackIgnore: true */ target, payload, { mode: 0o600, flag: "wx" });
+    return storedId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Persist a media file by copying it into the store — the agent-attachment
+ * path, where the source already lives on disk inside a granted root and
+ * base64 round-tripping a multi-megabyte mp4 through a data URL would be pure
+ * waste. Synchronous because `parseAgentAttachments` is synchronous.
+ *
+ * `sourcePath` MUST already be validated by the caller (realpath inside an
+ * allowed root, regular file, size under the media cap) — this function only
+ * re-checks the size and copies.
+ */
+export function saveChatMediaAttachmentFromFileSync(
+  sourcePath: string,
+  mimeType: string,
+): string | null {
+  const ext = MEDIA_EXT_BY_MIME[mimeType.toLowerCase()];
+  if (!ext) return null;
+  try {
+    const meta = fs.lstatSync(/* turbopackIgnore: true */ sourcePath);
+    if (!meta.isFile() || meta.size === 0 || meta.size > MAX_ATTACHMENT_MEDIA_BYTES) return null;
+    const root = resolvedRootSync();
+    const storedId = `${randomUUID()}.${ext}`;
+    if (!SAFE_STORED_ID.test(storedId)) return null;
+    const target = path.join(/* turbopackIgnore: true */ root, storedId);
+    if (!isContained(root, target)) return null;
+    // COPYFILE_EXCL refuses to follow a symlink planted at the target,
+    // mirroring the `wx` flag on the async write path.
+    fs.copyFileSync(/* turbopackIgnore: true */ sourcePath, target, fs.constants.COPYFILE_EXCL);
+    fs.chmodSync(/* turbopackIgnore: true */ target, 0o600);
+    return storedId;
+  } catch {
+    return null;
+  }
+}
+
+/** Sync twin of {@link resolvedRoot} for the sync agent-attachment save. */
+function resolvedRootSync(): string {
+  const root = chatAttachmentRoot();
+  fs.mkdirSync(/* turbopackIgnore: true */ root, { recursive: true, mode: 0o700 });
+  const meta = fs.lstatSync(/* turbopackIgnore: true */ root);
+  if (meta.isSymbolicLink()) {
+    throw new ChatAttachmentStoreError("symlink", "attachment store root is a symlink");
+  }
+  if (!meta.isDirectory()) {
+    throw new ChatAttachmentStoreError("symlink", "attachment store root is not a directory");
+  }
+  return fs.realpathSync(/* turbopackIgnore: true */ root);
+}
+
 /** Read a stored attachment's bytes. Throws rather than serving anything the
  * id did not literally name. */
 export async function readChatImageAttachment(
@@ -171,7 +270,8 @@ export async function readChatImageAttachment(
   if (!meta.isFile()) {
     throw new ChatAttachmentStoreError("missing", "attachment not found");
   }
-  if (meta.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+  const maxBytes = chatAttachmentMaxBytes(storedId);
+  if (meta.size > maxBytes) {
     throw new ChatAttachmentStoreError("too-large", "attachment exceeds the size limit");
   }
   const handle = await open(/* turbopackIgnore: true */ target, "r");
@@ -179,7 +279,7 @@ export async function readChatImageAttachment(
     // Re-check through the open descriptor: the path could have been swapped
     // between lstat and open.
     const stat = await handle.stat();
-    if (!stat.isFile() || stat.size > MAX_ATTACHMENT_IMAGE_BYTES) {
+    if (!stat.isFile() || stat.size > maxBytes) {
       throw new ChatAttachmentStoreError("missing", "attachment not found");
     }
     const data = Buffer.alloc(stat.size);


### PR DESCRIPTION
## What

Playable media (mp3, m4a, wav, ogg / mp4, webm, mov) now renders as native `<audio>`/`<video controls>` players in chat — on agent-emitted `coven:attachment` markers and on user sends — instead of dead file chips. Motivating case: a familiar renders a HyperFrames teaser mp4 and surfaces it playable in the conversation.

## How

- **Shared lib** (`chat-attachments.ts`): 50MB media cap (images keep 5MB), explicit mime allowlist, `cleanMediaDataUrl` mirroring the non-backtracking `cleanImageDataUrl` (header-only regex + linear base64 scan — never a pattern over the payload), `attachmentMediaKind`, media payloads survive normalization and the keeping-images strip, audio metadata-only prompt note, `ph:waveform` icon.
- **Store** (`chat-attachment-store.ts`): media extensions in `MIME_BY_EXT` (lockstep comment with the allowlist), per-mime read caps via `chatAttachmentMaxBytes`, `saveChatMediaAttachment` (dataUrl, user-send path), `saveChatMediaAttachmentFromFileSync` (agent path — copies the already-on-disk file instead of base64 round-tripping; `COPYFILE_EXCL` + 0600 mirrors the async `wx` path).
- **Agent parser** (`agent-attachments.ts`): allowlisted media files inside granted roots store a durable copy and ride as `storedId` with the media cap; existing root/symlink confinement unchanged.
- **Send route** (`chat-send-attachments.ts`): `persistImageAttachments` also persists validated media payloads; payload still never reaches the transcript.
- **Client** (`chat-attachment-cards.tsx`, `chat-view.tsx`): `InlineMediaAttachments` feeds players from the existing authed fetch→blob cache — a native `src` 401s in the packaged sidecar (token rides the patched `window.fetch`), and blob URLs make seeking work without Range support. Media leaves the chip list; `audio/*` joins the composer accept list. No autoplay; native controls; tokens only.

## Verification

- `pnpm typecheck` clean
- Touched test files green with the runner's exact node args: chat-attachments, chat-attachment-store (media round-trip, sync file copy, media-vs-image caps, allowlist refusals), agent-attachments (media marker → storedId, 6MB audio over image cap, out-of-root drop), attachment route (6MB stored mp4 served), send persistence (media gains storedId), chat-view-first-class (accept-list pin extended to audio/*)
- `pnpm exec eslint` clean on touched components; `pnpm codemod:design:check` 0 drift

Bead: cave-zglk9