### PR TITLE
fix: task work conversation fills the cockpit; code rail docks on the right

### DIFF
--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -32,6 +32,33 @@ assert.match(
 const cockpitCss = await readFile(new URL("../styles/task-work-cockpit.css", import.meta.url), "utf8");
 assert.match(
   cockpitCss,
-  /\.task-work-cockpit__group \.cave-chat-linear \{[\s\S]{0,200}?flex: 1;[\s\S]{0,200}?min-width: 0;/,
-  "the cockpit conversation fills its panel (task-chat alignment)",
+  /\.task-work-cockpit__body > \.cave-chat-linear,\n\.task-work-cockpit__group \.cave-chat-linear \{[\s\S]{0,200}?flex: 1;[\s\S]{0,200}?min-width: 0;/,
+  "the cockpit conversation fills its row in BOTH branches (task-chat alignment)",
+);
+// The bridge-backed first-send branch renders ChatView as a direct child of the
+// body with no Group/Panel, so a `__group`-scoped stretch rule missed it and
+// that branch shrink-wrapped to its reading measure inside a wide cockpit.
+assert.match(
+  source,
+  /<div className="task-work-cockpit__body">\s*\{initialPrompt && familiar \? \(\s*<ChatView/,
+  "the initialPrompt branch mounts ChatView directly in the body row",
+);
+
+// The collapsed code rail is an in-flow flex child sized against a flex ROW
+// (44px wide, full height). The cockpit root is a flex COLUMN, so hosting it
+// there docked it as a stub in the bottom-left corner under the composer.
+// It belongs inside the body row, before the body closes.
+const bodyStart = source.indexOf('<div className="task-work-cockpit__body">');
+const railStart = source.indexOf('className="workspace-rail-reopen focus-ring"');
+const sheetStart = source.indexOf("<WorkspaceRailSheet");
+assert.ok(bodyStart > -1 && railStart > bodyStart, "the reopen rail renders after the cockpit body opens");
+// The `</div>` immediately before the rail sheet closes the body row, so the
+// rail button must fall on the inside of it.
+const bodyEnd = source.lastIndexOf("</div>", sheetStart);
+assert.ok(bodyEnd > bodyStart, "the cockpit body row closes before the rail sheet");
+assert.ok(railStart < bodyEnd, "the reopen rail renders inside the cockpit body row, not as a column child");
+assert.match(
+  cockpitCss,
+  /\.task-work-cockpit__body > \.workspace-rail-reopen \{[\s\S]{0,200}?flex: 0 0 44px;[\s\S]{0,200}?align-self: stretch;/,
+  "the reopen rail reserves a full-height 44px column beside the conversation",
 );

--- a/src/components/task-work-cockpit.tsx
+++ b/src/components/task-work-cockpit.tsx
@@ -284,22 +284,29 @@ export function TaskWorkCockpit({
             </span>
           </div>
         )}
+        {/* Collapsed code rail: a full-height reopen rail on the cockpit's
+            right edge, mirroring the chat surface. It must sit INSIDE the body
+            row — the cockpit root is a flex column, so as a root child the
+            rail collapsed into a 44px stub in the bottom-left corner under the
+            composer instead of a full-height edge rail. In flow here it
+            reserves its own width, so the conversation ends beside it rather
+            than underneath. */}
+        {railController.rail.available
+        && !railController.rail.open
+        && !railController.isMobile
+        && !railController.paneNarrow ? (
+          <button
+            type="button"
+            aria-label="Show code rail"
+            title="Show code rail"
+            className="workspace-rail-reopen focus-ring"
+            onClick={railController.rail.reopen}
+          >
+            <Icon name="ph:sidebar-simple" width={15} aria-hidden />
+            <span className="workspace-rail-reopen__label">Code</span>
+          </button>
+        ) : null}
       </div>
-      {railController.rail.available
-      && !railController.rail.open
-      && !railController.isMobile
-      && !railController.paneNarrow ? (
-        <button
-          type="button"
-          aria-label="Show code rail"
-          title="Show code rail"
-          className="workspace-rail-reopen focus-ring"
-          onClick={railController.rail.reopen}
-        >
-          <Icon name="ph:sidebar-simple" width={15} aria-hidden />
-          <span className="workspace-rail-reopen__label">Code</span>
-        </button>
-      ) : null}
       <WorkspaceRailSheet controller={railController} familiar={familiar} sessionId={railSession?.id ?? null} />
     </section>
   );

--- a/src/styles/task-work-cockpit.css
+++ b/src/styles/task-work-cockpit.css
@@ -210,14 +210,32 @@
   flex: 1;
 }
 
-/* The conversation Panel is a horizontal flex row; ChatView's root
- * (.cave-chat-linear) carries no width of its own, so as a flex item it
- * shrink-wrapped to its content — the thread + composer sat left-crammed
- * beside dead space when viewing a task's chat. Fill the panel so the
- * cockpit conversation aligns exactly like the standalone chat surface. */
+/* The cockpit body (and the conversation Panel inside it) is a horizontal flex
+ * row; ChatView's root (.cave-chat-linear) carries no width of its own, so as a
+ * flex item it shrink-wrapped to its content — the thread + composer sat
+ * left-crammed beside dead space when viewing a task's chat. Fill the row so
+ * the cockpit conversation aligns exactly like the standalone chat surface.
+ *
+ * Scoped to the BODY, not the Group: the bridge-backed first-send branch
+ * (`initialPrompt`) renders ChatView as a direct child of the body with no
+ * Group/Panel around it, so a `__group`-only rule left that branch shrink-
+ * wrapped at ~1090px inside a 2000px cockpit. */
+.task-work-cockpit__body > .cave-chat-linear,
 .task-work-cockpit__group .cave-chat-linear {
   flex: 1;
   min-width: 0;
+}
+
+/* The collapsed code rail is an in-flow flex child that reserves its own 44px
+ * of layout width beside the conversation (never over it) and runs the full
+ * height of the row — the contract .workspace-rail-reopen is written against
+ * on the chat surface, whose root is a flex ROW. The cockpit root is a flex
+ * COLUMN, so hosting the button there docked it as a stub under the composer
+ * at the bottom-left corner. It lives in the body row instead; this pins the
+ * geometry so a future column-child regression is visible. */
+.task-work-cockpit__body > .workspace-rail-reopen {
+  flex: 0 0 44px;
+  align-self: stretch;
 }
 
 .task-work-cockpit__state {

--- a/tests/task-work-fit.spec.ts
+++ b/tests/task-work-fit.spec.ts
@@ -1,0 +1,230 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Task Work cockpit fit: the conversation must fill the cockpit at any width,
+// and the collapsed code rail must be a full-height strip on the RIGHT edge.
+//
+// Both regressions were structural, not cosmetic:
+//   1. ChatView's root (.cave-chat-linear) carries no width of its own. The
+//      cockpit body is a flex ROW, so as a direct flex child the whole chat
+//      shrink-wrapped to its 64rem reading measure — on a 1900px cockpit the
+//      thread, header actions and composer sat crammed in the left ~1090px
+//      with ~800px of dead gutter beside them. A pre-existing stretch rule was
+//      scoped to `.task-work-cockpit__group`, which the bridge-backed
+//      first-send branch (`initialPrompt`) never renders.
+//   2. .workspace-rail-reopen is written against a flex ROW (44px wide, full
+//      height, in flow so it reserves its own width). The cockpit ROOT is a
+//      flex COLUMN, so hosting it there docked it as a stub in the bottom-left
+//      corner under the composer.
+//
+// Daemon-less like every spec here: onboarding dismissed, all routes mocked.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+const WIDE = { width: 1900, height: 1000 };
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+const card = (over: Record<string, unknown>) => ({
+  notes: "",
+  status: "running",
+  priority: "high",
+  familiarId: "nova",
+  sessionId: null,
+  cwd: "/repo/alpha",
+  links: [],
+  github: [],
+  asana: [],
+  labels: [],
+  createdAt: ISO,
+  updatedAt: ISO,
+  lifecycle: "running",
+  lifecycleAt: ISO,
+  retryCount: 0,
+  maxRetries: 3,
+  steps: [],
+  ...over,
+});
+
+const LINKED_CARD = card({
+  id: "card-linked",
+  title: "Linked task — resumes an existing work session",
+  sessionId: "s-work",
+});
+const FRESH_CARD = card({ id: "card-fresh", title: "Fresh task — first send goes through the bridge" });
+
+const WORK_SESSION = {
+  id: "s-work",
+  title: "Phase 1B: spoke protocol",
+  status: "running",
+  origin: "chat",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local",
+  project_root: "/repo/alpha",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+async function openBoard(page: Page, cards: unknown[], sessions: unknown[]) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:code-rail:pinned:v1", "false");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [FAMILIAR] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions } }));
+  await page.route("**/api/board", (route) =>
+    route.request().method() === "GET"
+      ? route.fulfill({ json: { ok: true, cards } })
+      : route.fulfill({ json: { ok: true, card: cards[0] } }),
+  );
+  // A repo-linked session makes the code rail AVAILABLE; zero changed files
+  // keeps it collapsed, which is exactly when the reopen strip renders.
+  await page.route("**/api/changes**", (route) => route.fulfill({ json: { ok: true, files: [] } }));
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: "t1", role: "assistant", text: "On it.", createdAt: ISO }] },
+        context: {},
+      },
+    }),
+  );
+  // The bridge-backed start: board POSTs here, then hands the first prompt to
+  // ChatView through TaskWorkCockpit's `initialPrompt` branch.
+  await page.route("**/api/board/*/chat", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        sessionId: "s-bridge",
+        familiarId: "nova",
+        bridge: "native-chat",
+        initialPrompt: "Add the Coven stateless spoke protocol.",
+        card: { ...FRESH_CARD, sessionId: "s-bridge" },
+      },
+    }),
+  );
+  await page.route("**/api/chat/send**", (route) => route.fulfill({ json: { ok: true } }));
+
+  await page.setViewportSize(WIDE);
+  // `#card-<id>` is the board's own deep link into a card drawer — steadier
+  // than hunting the kanban tile by its title text.
+  await page.goto(`/?mode=board#card-${(cards[0] as { id: string }).id}`);
+  await page.waitForSelector(".board-shell", { timeout: 30_000 });
+}
+
+/** Take the open card drawer's Work action into the cockpit. */
+async function openCockpit(page: Page, action: "Start work" | "linked") {
+  await page.waitForSelector(".board-drawer-field", { timeout: 30_000 });
+  if (action === "Start work") {
+    await page.locator(".board-drawer-chat-cta").first().click();
+  } else {
+    await page.locator(".board-drawer-chat-card--linked").click();
+  }
+  await page.waitForSelector(".task-work-cockpit .cave-chat-linear", { timeout: 30_000 });
+}
+
+/** Geometry of the cockpit body row and the chat that should fill it. */
+function fit(page: Page) {
+  return page.evaluate(() => {
+    const rect = (el: Element | null | undefined) => {
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { left: Math.round(r.left), right: Math.round(r.right), width: Math.round(r.width), top: Math.round(r.top), bottom: Math.round(r.bottom) };
+    };
+    const box = (selector: string) => rect(document.querySelector(selector));
+    const body = document.querySelector(".task-work-cockpit__body");
+    const chat = document.querySelector(".task-work-cockpit .cave-chat-linear");
+    // The rightmost edge anything in the body row reaches. Short of the body's
+    // own right edge means a dead gutter — the exact regression under test.
+    const rowRight = body
+      ? Math.round(Math.max(...[...body.children].map((c) => c.getBoundingClientRect().right)))
+      : null;
+    return {
+      body: rect(body),
+      chat: rect(chat),
+      // Whatever directly hosts the chat: the body row itself on the
+      // bridge-start branch, the conversation Panel when a Group is mounted.
+      chatHost: rect(chat?.parentElement),
+      header: box(".task-work-cockpit__header"),
+      reopen: box(".task-work-cockpit .workspace-rail-reopen"),
+      rowRight,
+    };
+  });
+}
+
+test.describe("Task Work cockpit fit", () => {
+  test("the bridge-backed first-send conversation fills the cockpit", async ({ page }) => {
+    await openBoard(page, [FRESH_CARD], []);
+    await openCockpit(page, "Start work");
+
+    const { body, chat, chatHost, header, reopen, rowRight } = await fit(page);
+    expect(body).not.toBeNull();
+    expect(chat).not.toBeNull();
+    // On this branch ChatView mounts straight into the body row.
+    expect(chatHost!.width).toBe(body!.width);
+    // The chat starts at the body's left edge and ends at the body's right edge
+    // (minus the reopen strip, when it is showing). Before the fix the chat was
+    // ~1090px inside a ~1900px body — a ~800px dead gutter.
+    const reserved = reopen ? reopen.width : 0;
+    expect(chat!.left).toBe(body!.left);
+    expect(body!.width - chat!.width).toBe(reserved);
+    // Nothing is left over on the right.
+    expect(rowRight).toBe(body!.right);
+    // And the conversation spans the same measure as the full-bleed header.
+    expect(body!.width).toBe(header!.width);
+  });
+
+  test("the collapsed code rail is a full-height strip on the cockpit's right edge", async ({ page }) => {
+    await openBoard(page, [FRESH_CARD], []);
+    await openCockpit(page, "Start work");
+
+    const { body, chat, reopen } = await fit(page);
+    expect(reopen, "the repo-linked cockpit shows the collapsed code rail").not.toBeNull();
+    // Right edge of the body, not the bottom-left corner.
+    expect(reopen!.right).toBe(body!.right);
+    expect(reopen!.top).toBe(body!.top);
+    expect(reopen!.bottom).toBe(body!.bottom);
+    // In flow: it reserves its own width, so the chat ends where it begins.
+    expect(chat!.right).toBe(reopen!.left);
+  });
+
+  test("a resumed work session fills the cockpit too", async ({ page }) => {
+    await openBoard(page, [LINKED_CARD], [WORK_SESSION]);
+    await openCockpit(page, "linked");
+
+    // A resumed session mounts the Group, and the cockpit auto-reopens the code
+    // rail beside the conversation — so the chat fills its PANEL rather than the
+    // whole row, and the row itself is still fully consumed.
+    const { body, chat, chatHost, header, rowRight } = await fit(page);
+    expect(chat!.left).toBe(chatHost!.left);
+    expect(chat!.width).toBe(chatHost!.width);
+    expect(chatHost!.left).toBe(body!.left);
+    expect(rowRight).toBe(body!.right);
+    expect(body!.width).toBe(header!.width);
+  });
+
+  test("the cockpit conversation still fills a narrow window", async ({ page }) => {
+    await openBoard(page, [FRESH_CARD], []);
+    await openCockpit(page, "Start work");
+    await page.setViewportSize({ width: 900, height: 900 });
+    await page.waitForTimeout(300);
+
+    const { body, chat, reopen } = await fit(page);
+    expect(chat!.left).toBe(body!.left);
+    expect(chat!.right).toBe(reopen ? reopen.left : body!.right);
+    // No horizontal overflow off the cockpit.
+    const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+    expect(overflow).toBeLessThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
## What was wrong

Two structural fit defects on a task's chat page, both visible at once on a wide window:

1. **The conversation shrink-wrapped.** ChatView's root (`.cave-chat-linear`) carries no width of its own. `.task-work-cockpit__body` is a flex **row**, so as a direct flex child the whole chat collapsed to its 64rem reading measure — thread, header actions and composer crammed into the left ~1090px of a ~1900px cockpit, with ~800px of dead gutter beside them while the header still spanned full width.

   A stretch rule for exactly this already existed, but it was scoped to `.task-work-cockpit__group`. The bridge-backed first-send branch (`initialPrompt` — a task whose conversation id is reserved before its first send) renders **no** Group: it mounts `ChatView` straight into the body. That branch persists for the whole first work session, so it is the one you actually look at after starting a task.

2. **The collapsed code rail docked in the wrong corner.** `.workspace-rail-reopen` is written against a flex **row** — 44px wide, `height: 100%`, in flow so it reserves its own layout width beside the conversation (that is how it behaves on the chat surface, whose root is a row). The cockpit **root** is a flex **column**, so hosting the button there rendered it as a short 44px stub in the bottom-left corner under the composer.

## What changed

- `src/styles/task-work-cockpit.css` — widen the stretch rule from `__group` to the body row, so both branches fill; pin the reopen rail's `44px` / `align-self: stretch` box.
- `src/components/task-work-cockpit.tsx` — move the reopen rail inside the body row.
- `src/components/task-work-cockpit.test.ts` — pin both, including that the rail renders inside the body row rather than as a column child.
- `tests/task-work-fit.spec.ts` — new. Drives the board into the cockpit through both entry paths (mocked, daemon-less) and measures: the chat fills its host, the row leaves no gutter on the right, and the reopen strip spans the full height of the body's right edge. Checked at 1900px and again at 900px.

## Verification

- `node --experimental-strip-types src/components/task-work-cockpit.test.ts` — pass
- `pnpm exec tsc --noEmit` — pass
- `pnpm lint` (design codemod check + eslint) — pass
- `tests/task-work-fit.spec.ts` — **not run locally.** Two attempts died for environment reasons, not spec reasons: the first reused another session's dev server on the shared e2e port 3100, and the second was OOM-killed mid-run (load average hit 207 on this machine). The `E2E (Playwright)` required check is the verification for it; happy to iterate if it fails there.

## Known gap, filed separately — cave-6une3

The reopen strip is a **dead end** on the bridge-start branch: that branch mounts no rail Panel, so clicking Code hides the strip and shows nothing. It predates this PR (the button was equally dead in the corner). The obvious fix — one Group for both branches — is not safe as written: the Group carries `key={showInline ? "conversation-rail" : "conversation"}`, so toggling the rail **remounts** ChatView, and ChatView guards its auto-send with an instance ref (`initialPromptSentRef`, `chat-view.tsx:5948`). A remount would re-send the task's first prompt. That guard has to survive a remount first, so it is deliberately out of this PR's blast radius.