### PR TITLE
fix(chat): align worktree menu labels

### DIFF
--- a/src/components/chat-composer-footer-band.test.ts
+++ b/src/components/chat-composer-footer-band.test.ts
@@ -148,6 +148,11 @@ assert.match(
 );
 assert.match(
   pill,
+  /open=\{menu === "worktree"\}[\s\S]*?ariaLabel="Worktree actions"[\s\S]*?menuLabel="Worktree actions"/,
+  "the worktree chip opens a menu whose accessible labels match the trigger",
+);
+assert.match(
+  pill,
   /ComposerContextView\s*=\s*null\s*\|[\s\S]*?"worktree"/,
   "ComposerContextView supports the worktree picker state",
 );

--- a/src/components/composer-context-pill.tsx
+++ b/src/components/composer-context-pill.tsx
@@ -216,6 +216,8 @@ export function ComposerContextPickers({
         placement={context.config.popoverPlacement}
         projectRoot={context.root}
         onSwitched={context.reload}
+        ariaLabel={view === "worktree" ? "Worktree actions" : undefined}
+        menuLabel={view === "worktree" ? "Worktree actions" : undefined}
         {...branchPopoverExtras(context)}
       />
       {context.addFlow.addError ? (
@@ -368,6 +370,8 @@ export function ComposerContextChips(props: ComposerContextProps) {
           placement={context.config.popoverPlacement}
           projectRoot={context.root}
           onSwitched={context.reload}
+          ariaLabel="Worktree actions"
+          menuLabel="Worktree actions"
           {...branchPopoverExtras(context)}
         />
       ) : null}

--- a/src/components/composer-git-chip.test.ts
+++ b/src/components/composer-git-chip.test.ts
@@ -125,6 +125,11 @@ assert.match(
 );
 assert.match(
   chip,
+  /ariaLabel = "Switch branch"[\s\S]*?menuLabel = "Branches"[\s\S]*?<Popover[\s\S]*?ariaLabel=\{ariaLabel\}[\s\S]*?<PopoverBody role="menu" ariaLabel=\{menuLabel\}>[\s\S]*?<PopoverLabel>\{ariaLabel\}<\/PopoverLabel>/,
+  "the shared branch menu exposes overridable popover and menu labels while preserving branch defaults",
+);
+assert.match(
+  chip,
   /\/api\/changes\?projectRoot=\$\{encodeURIComponent\(root\)\}&branches=1/,
   "opening the menu lists local branches via the changes route's ?branches=1 query",
 );

--- a/src/components/composer-git-chip.tsx
+++ b/src/components/composer-git-chip.tsx
@@ -114,6 +114,8 @@ export function GitBranchMenuPopover({
   pr,
   onOpenPr,
   onOpenChanges,
+  ariaLabel = "Switch branch",
+  menuLabel = "Branches",
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -129,6 +131,10 @@ export function GitBranchMenuPopover({
   onOpenPr?: (url: string) => void;
   /** …and the Git-changes drill-through. */
   onOpenChanges?: () => void;
+  /** Accessible and visible heading for the opened popover. */
+  ariaLabel?: string;
+  /** Accessible name for the menu body. */
+  menuLabel?: string;
 }) {
   const root = projectRoot?.trim() ? projectRoot : undefined;
   const menuOpen = open;
@@ -277,10 +283,10 @@ export function GitBranchMenuPopover({
       anchorRef={anchorRef}
       placement={placement}
       minWidth={240}
-      ariaLabel="Switch branch"
+      ariaLabel={ariaLabel}
     >
-      <PopoverBody role="menu" ariaLabel="Branches">
-        <PopoverLabel>Switch branch</PopoverLabel>
+      <PopoverBody role="menu" ariaLabel={menuLabel}>
+        <PopoverLabel>{ariaLabel}</PopoverLabel>
         {rows === null ? (
           <div className="cave-composer-git-chip__menu-note">Loading branches…</div>
         ) : (


### PR DESCRIPTION
## Summary
- make the shared branch/worktree popover labels overridable while preserving branch defaults
- label worktree-triggered menus consistently as “Worktree actions” for visible and assistive UI
- add focused source-pin regressions for the accessible-name contract

## Verification
- `node --experimental-strip-types src/components/chat-composer-footer-band.test.ts`
- `node --experimental-strip-types src/components/composer-git-chip.test.ts`
- `pnpm typecheck`
- changed-file ESLint
- `pnpm codemod:design:check`
- `git diff --check`

Bead: `cave-hlzo7`