### PR TITLE
fix(ci): install deps before running CI recovery

### DIFF
--- a/.github/workflows/ci-recovery.yml
+++ b/.github/workflows/ci-recovery.yml
@@ -23,9 +23,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+
+      # scripts/ci-recovery.mjs imports "yaml"; without an install the job dies
+      # at module resolution before it can assess a single PR.
+      - run: pnpm install --frozen-lockfile
 
       - name: Detect and recover missing CI
         env:


### PR DESCRIPTION
The scheduled `Recover missing PR CI` job has been failing on every run with `ERR_MODULE_NOT_FOUND: Cannot find package 'yaml'`.

The job goes checkout → setup-node → `node scripts/ci-recovery.mjs --apply` with no install step, so it dies at module resolution before assessing a single PR. `yaml` is a real dependency in `package.json`; nothing was ever installed.

Adds `pnpm/action-setup` + `pnpm install --frozen-lockfile`, matching every job in `ci.yml`.

Verified locally: read-only `node scripts/ci-recovery.mjs` now completes — `CI recovery: 0 open PRs scanned; 0 eligible.`