### PR TITLE
fix: run the highlighted Home slash command, not the surrounding prose

### DIFF
--- a/src/components/home-composer.test.ts
+++ b/src/components/home-composer.test.ts
@@ -233,6 +233,11 @@ assert.match(
 );
 assert.match(
   source,
+  /onRunCommand: \(cmd\) => \{\s*void handleSubmit\(inlineSlashCommandPrompt\(text, composerCaret, cmd\.name\)\);\s*\}/,
+  "Home should execute the active inline command instead of submitting surrounding prose",
+);
+assert.match(
+  source,
   /onStartChat\(prompt, selectedFamiliarId, selectedProjectRoot, \{\s*initialControls: initialChatControls,[\s\S]*?\}\)/,
   "HomeComposer should hand the selected agent chat prompt, attachments, host, and model intent to the workspace",
 );

--- a/src/components/home-composer.tsx
+++ b/src/components/home-composer.tsx
@@ -45,7 +45,7 @@ import { useComposerHistory } from "@/lib/use-composer-history";
 import { useDictation } from "@/lib/voice/use-dictation";
 import { useAttachmentStaging } from "@/lib/use-attachment-staging";
 import { useInlineSlashMenus } from "@/lib/use-inline-slash-menus";
-import { canonicalize } from "@/lib/slash-commands";
+import { canonicalize, inlineSlashCommandPrompt } from "@/lib/slash-commands";
 import { useArchivedFamiliars } from "@/lib/cave-familiar-archive";
 import { useProjects } from "@/lib/use-projects";
 import { NO_PROJECT_ID, recentChatProjectRoot } from "@/lib/chat-projects";
@@ -367,8 +367,9 @@ export function HomeComposer({
   // /prompt pickers) — shared hook (use-inline-slash-menus). What a pick DOES
   // stays home's: model picks toast + clear, skill picks start a new chat
   // (invokeSkill), prompts insert-for-editing, and Enter on a command (or
-  // nothing highlighted) falls through to handleSubmit — home dispatches the
-  // typed text, so slash commands also land in the ↑ history.
+  // nothing highlighted) falls through to handleSubmit. Highlighted commands
+  // dispatch the active invocation directly so surrounding prose is not sent
+  // to the harness.
   const modelHarness = canonicalHarnessId(
     modelState?.harness ?? selectedFamiliar?.harness ?? "claude",
   );
@@ -399,7 +400,9 @@ export function HomeComposer({
     onPickModel: (id) => { handleSelectModel(id); onToast(`Model set to ${id}.`); setText(""); },
     onPickSkill: (s) => invokeSkill(s),
     onInsertPrompt: (p) => insertPromptTemplate(p),
-    onRunCommand: () => { void handleSubmit(); },
+    onRunCommand: (cmd) => {
+      void handleSubmit(inlineSlashCommandPrompt(text, composerCaret, cmd.name));
+    },
     onNoMatchEnter: () => { void handleSubmit(); },
   });
 
@@ -572,8 +575,8 @@ export function HomeComposer({
   );
 
 
-  const handleSubmit = useCallback(async () => {
-    const prompt = text.trim();
+  const handleSubmit = useCallback(async (promptOverride?: string) => {
+    const prompt = (promptOverride ?? text).trim();
     // Allow an attachments-only send (chat can carry files with no text); every
     // other path still needs a prompt and is guarded per-destination below.
     if ((!prompt && attachments.length === 0) || sending) return;

--- a/src/lib/slash-command-inline.test.ts
+++ b/src/lib/slash-command-inline.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import {
+  inlineSlashCommandPrompt,
   inlineSlashInvocation,
   replaceInlineSlashRange,
 } from "./slash-commands.ts";
@@ -38,6 +39,18 @@ assert.deepEqual(
   replaceInlineSlashRange("please /ima after", 7, 11, "/image"),
   { text: "please /image after", caret: 13 },
   "completion should preserve text outside the active slash range",
+);
+
+assert.equal(
+  inlineSlashCommandPrompt("please /he", 10, "/help"),
+  "/help",
+  "running an inline suggestion should use the highlighted canonical command",
+);
+
+assert.equal(
+  inlineSlashCommandPrompt("please /run inspect this", 24, "/run"),
+  "/run inspect this",
+  "running an inline suggestion should preserve arguments without surrounding prose",
 );
 
 console.log("slash-command-inline.test.ts: ok");

--- a/src/lib/slash-commands.ts
+++ b/src/lib/slash-commands.ts
@@ -131,6 +131,18 @@ export function inlineSlashInvocation(
   return null;
 }
 
+export function inlineSlashCommandPrompt(
+  text: string,
+  caret: number,
+  command: string,
+): string {
+  const invocation = inlineSlashInvocation(text, caret);
+  if (!invocation) return command;
+
+  const args = invocation.input.slice(invocation.commandToken.length).trim();
+  return args ? `${command} ${args}` : command;
+}
+
 export function replaceInlineSlashRange(
   text: string,
   start: number,

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -32,7 +32,7 @@ import { orderPrompts, readPromptFavorites, readPromptRecents } from "@/lib/prom
  * - onPickSkill: home starts a new chat, chat sends in-thread;
  * - onInsertPrompt: both insert-for-editing (never send) — but with their own
  *   caret/announce plumbing;
- * - onRunCommand: home submits the typed text, chat runs the slash intent;
+ * - onRunCommand: each composer runs the highlighted slash intent;
  * - onNoMatchEnter: home falls through to submit; chat consumes and does
  *   nothing.
  *


### PR DESCRIPTION
Closes `cave-eh5ge`.

## What was wrong

Pressing Enter on a **highlighted inline slash command** in the Home composer submitted the *whole draft*. `onRunCommand` fell through to `handleSubmit()` with the untouched text, so a command typed after prose — `please /help` — was sent to the harness as literal text instead of executing.

## What changed

`inlineSlashCommandPrompt(text, caret, command)` resolves the caret's inline invocation, swaps in the highlighted canonical command, keeps that invocation's arguments, and drops everything around it. `handleSubmit` takes an optional prompt override, so the existing submit path still runs it — which matters because that path is what puts slash commands in the ↑ history.

```
"please /he"              caret 10, highlight /help  ->  "/help"
"please /run inspect this" caret 24, highlight /run   ->  "/run inspect this"
```

Five files, +40/−7.

## Provenance

The patch was implemented in a prior session and left uncommitted in `.worktrees/cave-eh5ge-inline-home-dispatch` "pending review/PR preparation" (see the bead's 2026-08-09 handoff note). I reviewed it, rebased it from its original base `477402bf02` onto current `main` (14 commits), and re-ran the gates — the recorded verification predates all of those commits, so it needed redoing rather than trusting.

## Review note

`handleSubmit` gaining an optional first parameter is the one risky edge: if it were ever passed bare as an event handler, React would hand it the event object as `promptOverride`. I checked every call site — all five wrap it in an arrow function (`() => void handleSubmit()`), so nothing can leak in. Worth keeping in mind if a future caller passes it directly.

## Verification (re-run on the rebased branch)

- `src/lib/slash-command-inline.test.ts` — pass (covers both the no-args and args-preserved cases)
- `src/components/home-composer.test.ts` — pass (pins the `onRunCommand` wiring)
- `pnpm exec tsc --noEmit` — pass
- `pnpm lint` — pass
- `node scripts/check-tests-wired.mjs` — pass