### PR TITLE
Retain unpushed worktree commits automatically

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -30,6 +30,19 @@
         "matcher": "Bash"
       }
     ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "node \"$CLAUDE_PROJECT_DIR/scripts/worktree-retention-push.mjs\"",
+            "statusMessage": "Retaining commits on origin…",
+            "timeout": 60,
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
     "SessionStart": [
       {
         "hooks": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -531,6 +531,40 @@ to `.claude/worktree-autolock.log` (gitignored, JSON lines). Disable for a
 command with `WT_AUTOLOCK_DISABLE=1`. It never blocks a tool call and always
 exits 0 — if it cannot read a worktree, it leaves it alone.
 
+**Retention push (automatic, NON-blocking).** A PostToolUse hook —
+`scripts/worktree-retention-push.mjs`, matcher Bash — pushes any worktree
+whose HEAD holds commits reachable from no remote ref, so a local actor cannot
+destroy them. This is the enforcement of the "push your branch to origin after
+every commit" discipline above, which as advice did not hold: a 2026-08-09
+sweep found **174 commits across five branches on no remote ref at all**,
+including 135 on `docs/cave-zs85n-chat-sidebar-attention`. Two of those
+branches were back at risk **25 minutes** after a manual push, because live
+sessions kept committing locally — it is a continuous leak, not a backlog.
+
+It complements rather than duplicates the two hooks above, and neither of them
+covers this: the guard blocks destructive Bash *from a Claude session*, and the
+auto-lock defends against GitHub Desktop. A lock is a delay, not a backup — a
+second `--force` still takes the worktree, and neither hook moves a single
+commit off this machine.
+
+It pushes the **branch** first, because a remote branch is what every other
+surface here reads as retention and a fast-forward push cannot rewrite anyone's
+work. When that is refused — a diverged branch, or `branch-cap.yml` rolling
+back a newly created branch above 40 — it falls back to a tag named for the
+exact commit (`retention/<flattened-branch>-<short-sha>`). That tag is
+immutable and unique, so it never force-updates, never collides, and
+`branch-cap.yml` ignores it (`ref_type == 'branch'` only). It never merges,
+never opens a PR, never deletes or rewrites a ref, and **skips `main`** —
+pushing that is the direct-to-main move this file forbids.
+
+Throttled to once a minute (`.claude/worktree-retention-push.stamp`) and capped
+at 3 pushes per pass to bound the latency added to one tool call; pushed
+worktrees drop out of the at-risk set, so successive passes reach the rest.
+Every push and every failure is appended to
+`.claude/worktree-retention-push.log` (gitignored, JSON lines). Disable for a
+command with `WT_RETENTION_PUSH_DISABLE=1`. It never blocks a tool call and
+always exits 0.
+
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:6cd5cc61 -->
 ## Beads Issue Tracker

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1179,6 +1179,7 @@ export const SUITES = {
     "scripts/surface-claim-guard.test.mjs",
     "scripts/worktree-guard.test.mjs",
     "scripts/worktree-autolock.test.mjs",
+    "scripts/worktree-retention-push.test.mjs",
     "scripts/branch-curator-manual-cleanup-contract.test.mjs",
     "scripts/branch-to-merge-contract.test.mjs",
     "scripts/git-hooks-pre-commit.test.mjs",

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+// Push commits that exist on no remote, so a local actor cannot destroy them.
+//
+// CLAUDE.md's corollary discipline is "push your branch to origin after every
+// commit — the remote is the only store a local actor can't destroy". That is
+// advice, and advice does not hold: a 2026-08-09 sweep found 174 commits
+// across five branches sitting on no remote ref at all, including 135 on
+// `docs/cave-zs85n-chat-sidebar-attention`. Two of those branches were back at
+// risk 25 minutes after being pushed by hand, because live sessions kept
+// committing locally. It is a continuous leak, not a backlog.
+//
+// The neighbouring hooks defend the two other failure modes and neither covers
+// this one: `worktree-guard.mjs` blocks destructive Bash *from a Claude
+// session*, and `worktree-autolock.mjs` locks at-risk worktrees against
+// GitHub Desktop. A lock is a delay, not a backup — a second `--force` still
+// takes the worktree, and neither hook moves a single commit off this machine.
+//
+// Retention here is a push, never a merge and never a PR: nothing lands, and
+// no branch is deleted or rewritten.
+//
+// Advisory only: this never blocks a tool call and always exits 0.
+
+import { execFileSync } from "node:child_process";
+import { appendFileSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const THROTTLE_MS = 60_000;
+// Bounds worst-case latency added to one tool call. Pushed worktrees drop out
+// of the at-risk set, so successive passes reach the rest.
+const MAX_PUSHES_PER_PASS = 3;
+const PUSH_TIMEOUT_MS = 20_000;
+
+function projectRoot() {
+  return process.env.CLAUDE_PROJECT_DIR || process.cwd();
+}
+
+function git(args, cwd, timeout = 10_000) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    timeout,
+    env: { ...process.env, GIT_OPTIONAL_LOCKS: "0" },
+  });
+}
+
+export function parseWorktrees(porcelain) {
+  const records = [];
+  let current = null;
+  for (const rawLine of porcelain.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (line.startsWith("worktree ")) {
+      current = { path: line.slice("worktree ".length), bare: false };
+      records.push(current);
+      continue;
+    }
+    if (!current) continue;
+    if (line === "bare") current.bare = true;
+  }
+  return records;
+}
+
+// A tag name cannot carry `/` safely alongside a sibling of the same prefix —
+// git cannot hold both `retention/fix` and `retention/fix/foo`, so a second
+// branch sharing a prefix would collide. Flatten, exactly as the archive-tag
+// route in CLAUDE.md does.
+export function retentionTag(branch, sha) {
+  const slug = String(branch).replace(/[^A-Za-z0-9._-]+/g, "-").replace(/^-+|-+$/g, "");
+  return `retention/${slug || "detached"}-${String(sha).slice(0, 9)}`;
+}
+
+// Commits reachable from HEAD but from no remote-tracking ref — the same
+// "retained on a remote" test the guard and the autolock hook apply.
+export function unpushedCount(worktreePath) {
+  try {
+    const n = Number(git(["rev-list", "--count", "HEAD", "--not", "--remotes"], worktreePath).trim());
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0; // unborn HEAD, or unreadable mid-creation — leave it alone
+  }
+}
+
+function branchOf(worktreePath) {
+  try {
+    const name = git(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath).trim();
+    return name && name !== "HEAD" ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+function throttled(root) {
+  const stamp = path.join(root, ".claude", "worktree-retention-push.stamp");
+  try {
+    if (Date.now() - statSync(stamp).mtimeMs < THROTTLE_MS) return true;
+  } catch {
+    // no stamp yet — run
+  }
+  try {
+    mkdirSync(path.dirname(stamp), { recursive: true });
+    writeFileSync(stamp, String(Date.now()));
+  } catch {
+    // best effort; a missing stamp only costs an extra pass
+  }
+  return false;
+}
+
+function record(root, entry) {
+  try {
+    appendFileSync(
+      path.join(root, ".claude", "worktree-retention-push.log"),
+      `${JSON.stringify({ at: new Date().toISOString(), ...entry })}\n`,
+    );
+  } catch {
+    // logging must never break a tool call
+  }
+}
+
+// Branch first: a remote branch is what every other surface here already reads
+// as retention, and a fast-forward push cannot rewrite anyone's work. When it
+// is refused — a diverged branch, or `branch-cap.yml` rolling back a newly
+// created branch above 40 — fall back to a tag named for the exact commit.
+// The tag is immutable and unique, so it never force-updates and never
+// collides, and `branch-cap.yml` ignores it (`ref_type == 'branch'` only).
+export function retain(worktreePath, root, branch) {
+  const sha = git(["rev-parse", "HEAD"], worktreePath).trim();
+  if (branch) {
+    try {
+      git(["push", "origin", `refs/heads/${branch}:refs/heads/${branch}`], worktreePath, PUSH_TIMEOUT_MS);
+      return { verdict: "pushed-branch", branch, sha };
+    } catch (error) {
+      record(root, {
+        verdict: "branch-push-failed",
+        worktree: worktreePath,
+        branch,
+        error: String(error?.message ?? error).slice(0, 300),
+      });
+    }
+  }
+  const tag = retentionTag(branch ?? "detached", sha);
+  git(["push", "origin", `${sha}:refs/tags/${tag}`], worktreePath, PUSH_TIMEOUT_MS);
+  return { verdict: "pushed-tag", branch, sha, tag };
+}
+
+function main() {
+  const root = projectRoot();
+  if (process.env.WT_RETENTION_PUSH_DISABLE === "1") return;
+  if (throttled(root)) return;
+
+  let worktrees;
+  try {
+    worktrees = parseWorktrees(git(["worktree", "list", "--porcelain"], root));
+  } catch {
+    return; // not a git repo, or git unavailable — nothing to do
+  }
+
+  let pushes = 0;
+  for (const wt of worktrees) {
+    if (pushes >= MAX_PUSHES_PER_PASS) break;
+    if (wt.bare) continue;
+    const unpushed = unpushedCount(wt.path);
+    if (unpushed === 0) continue;
+    const branch = branchOf(wt.path);
+    // `main` is protected and never the thing at risk; pushing it is exactly
+    // the direct-to-main move the repository forbids.
+    if (branch === "main") continue;
+    pushes += 1;
+    try {
+      record(root, { worktree: wt.path, unpushed, ...retain(wt.path, root, branch) });
+    } catch (error) {
+      record(root, {
+        verdict: "retention-failed",
+        worktree: wt.path,
+        branch,
+        unpushed,
+        error: String(error?.message ?? error).slice(0, 300),
+      });
+    }
+  }
+}
+
+// Real-path comparison, matching worktree-autolock.mjs: a naive URL/argv
+// comparison breaks on paths with spaces and on macOS symlinked /tmp, and a
+// guard that silently never runs is the worst outcome.
+function isDirectRun() {
+  const entry = process.argv[1];
+  if (!entry) return false;
+  try {
+    return realpathSync(entry) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
+  try {
+    main();
+  } catch {
+    // advisory hook: never fail the tool call
+  }
+  process.exit(0);
+}

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
+
+import { parseWorktrees, retain, retentionTag, unpushedCount } from "./worktree-retention-push.mjs";
+
+// Fixtures must not inherit machine-level git config. A global
+// `core.hooksPath` points every repo on this machine at one hook directory,
+// so a fixture clone or commit would run this project's hooks — correctness
+// noise, and tens of seconds per git call.
+const ISOLATED = {
+  ...process.env,
+  GIT_CONFIG_GLOBAL: NULL_DEVICE,
+  GIT_CONFIG_SYSTEM: NULL_DEVICE,
+  GIT_CONFIG_NOSYSTEM: "1",
+};
+
+function git(args, cwd) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: ISOLATED,
+  });
+}
+
+// Reading a bare repo by cwd is refused when safe.bareRepository is
+// "explicit" (set on some dev machines), so address it as a git dir.
+function bare(args, gitDir) {
+  return git(["--git-dir", gitDir, ...args], path.dirname(gitDir));
+}
+
+function configure(repo) {
+  git(["config", "user.email", "test@example.com"], repo);
+  git(["config", "user.name", "Test"], repo);
+  git(["config", "commit.gpgsign", "false"], repo);
+}
+
+// A real bare remote, not a stub: the whole point of this hook is that a
+// commit actually leaves the machine, and a mocked push proves nothing.
+function scaffold() {
+  const root = mkdtempSync(path.join(tmpdir(), "retention-push-"));
+  const remote = path.join(root, "remote.git");
+  const work = path.join(root, "work");
+  git(["init", "--bare", "-b", "main", remote], root);
+  git(["clone", remote, work], root);
+  configure(work);
+  writeFileSync(path.join(work, "seed.txt"), "seed\n");
+  git(["add", "-A"], work);
+  git(["commit", "-m", "seed"], work);
+  git(["push", "origin", "main"], work);
+  return { root, remote, work };
+}
+
+function commit(work, name) {
+  writeFileSync(path.join(work, `${name}.txt`), `${name}\n`);
+  git(["add", "-A"], work);
+  git(["commit", "-m", name], work);
+}
+
+test("parseWorktrees reads paths and skips nothing it was given", () => {
+  const records = parseWorktrees("worktree /a\nHEAD abc\n\nworktree /b\nbare\n");
+  assert.deepEqual(
+    records.map((r) => [r.path, r.bare]),
+    [
+      ["/a", false],
+      ["/b", true],
+    ],
+  );
+});
+
+test("retentionTag flattens slashes so sibling branches cannot collide", () => {
+  const a = retentionTag("fix/cave-1", "abcdef1234567");
+  const b = retentionTag("fix/cave-1/sub", "abcdef1234567");
+  assert.equal(a, "retention/fix-cave-1-abcdef123");
+  assert.notEqual(a, b);
+  // git cannot hold a tag and a directory of the same name; a flattened name
+  // is never a prefix-directory of its sibling.
+  assert.ok(!b.startsWith(`${a}/`));
+});
+
+test("retentionTag names the exact commit, so a second push never force-updates", () => {
+  assert.notEqual(retentionTag("b", "1111111111"), retentionTag("b", "2222222222"));
+});
+
+test("unpushedCount counts only commits absent from every remote", () => {
+  const { root, work } = scaffold();
+  try {
+    assert.equal(unpushedCount(work), 0);
+    commit(work, "one");
+    commit(work, "two");
+    assert.equal(unpushedCount(work), 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("retain pushes the branch, and the commit really lands on the remote", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/topic"], work);
+    commit(work, "one");
+    const sha = git(["rev-parse", "HEAD"], work).trim();
+
+    const result = retain(work, root, "feat/topic");
+
+    assert.equal(result.verdict, "pushed-branch");
+    assert.equal(bare(["rev-parse", "refs/heads/feat/topic"], remote).trim(), sha);
+    git(["fetch", "-q", "origin"], work);
+    assert.equal(unpushedCount(work), 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("retain falls back to a tag when the branch push is refused", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/topic"], work);
+    commit(work, "one");
+    git(["push", "-q", "origin", "feat/topic"], work);
+
+    // Diverge the remote so a plain (non-forced) branch push must be refused,
+    // which is the real shape of the fallback: two sessions on one branch.
+    const clone = path.join(root, "other");
+    git(["clone", "-q", remote, clone], root);
+    configure(clone);
+    git(["checkout", "-q", "feat/topic"], clone);
+    commit(clone, "theirs");
+    git(["push", "-q", "origin", "feat/topic"], clone);
+
+    commit(work, "mine");
+    const sha = git(["rev-parse", "HEAD"], work).trim();
+
+    const result = retain(work, root, "feat/topic");
+
+    assert.equal(result.verdict, "pushed-tag");
+    assert.equal(bare(["rev-parse", `refs/tags/${result.tag}^{commit}`], remote).trim(), sha);
+    // The other session's branch tip is untouched — retention never rewrites.
+    assert.notEqual(bare(["rev-parse", "refs/heads/feat/topic"], remote).trim(), sha);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("retain retains a detached HEAD, which has no branch to push", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    commit(work, "one");
+    const sha = git(["rev-parse", "HEAD"], work).trim();
+    git(["checkout", "-q", "--detach", sha], work);
+
+    const result = retain(work, root, null);
+
+    assert.equal(result.verdict, "pushed-tag");
+    assert.equal(bare(["rev-parse", `refs/tags/${result.tag}^{commit}`], remote).trim(), sha);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Why

A retention sweep on 2026-08-09 found **174 commits across five branches reachable from no remote ref at all** — 135 of them on a single branch. Pushing them by hand did not settle it: **two branches were back at risk 25 minutes later**, because live sessions keep committing locally. It is a continuous leak, not a backlog, so "push your branch after every commit" as written advice does not hold.

Neither existing hook covers this gap. `worktree-guard` blocks destructive Bash *from a Claude session*; `worktree-autolock` defends against GitHub Desktop. A lock is a delay, not a backup — a second `--force` still takes the worktree — and neither moves a single commit off this machine.

## What

`scripts/worktree-retention-push.mjs`, a PostToolUse hook (matcher `Bash`) that pushes any worktree whose HEAD holds commits on no remote ref.

- **Branch push first** — a remote branch is what every other surface here reads as retention, and a fast-forward push cannot rewrite anyone's work.
- **Tag fallback** when that is refused (diverged branch, or `branch-cap.yml` rolling back a new branch above 40): `retention/<flattened-branch>-<short-sha>`. Named for the exact commit, so it is immutable, never force-updates, never collides between sibling branches, and is exempt from the cap (`ref_type == 'branch'` only) and from `release.yml` (`v*` only).
- **Never** merges, opens a PR, deletes, or rewrites a ref. **Skips `main`** — pushing that is the direct-to-main move `CLAUDE.md` forbids.
- Throttled to 60s via a stamp file, capped at 3 pushes per pass to bound latency added to one tool call. Pushed worktrees leave the at-risk set, so successive passes reach the rest. Logs JSON lines to `.claude/worktree-retention-push.log` (gitignored), disable with `WT_RETENTION_PUSH_DISABLE=1`, always exits 0.

## Verification

Ran live against this checkout, not just the fixtures. It found three worktrees that had drifted at risk, retained each on origin (`pushed-branch`), and a re-scan reported nothing at risk. The throttle held on an immediate second invocation (log unchanged); clearing the stamp let the next pass pick up a worktree that had drifted in between.

- `node --test scripts/worktree-retention-push.test.mjs` — 7/7 pass in 3.3s
- `pnpm check:tests-wired` — all 1583 test files wired
- `eslint` clean on both new files

Tests scaffold a **real bare remote** rather than mocking git, so they assert commits genuinely land, and that the tag fallback leaves another session's branch tip untouched. They also neutralise this machine's global `core.hooksPath`, which otherwise makes every temp fixture run this project's hooks (85s to 3s).
