### PR TITLE
fix: keep linked Board mirrors, and restore cleared cards under their own ids

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -39,6 +39,8 @@ export const SUITES = {
     "src/lib/code-rail.test.ts",
     "src/lib/use-code-rail.test.ts",
     "src/lib/initial-prompt-handoff.test.ts",
+    "src/lib/cave-board-retention.test.ts",
+    "src/components/board-retention.test.ts",
     "src/lib/workspace-tiles.test.ts",
     "src/lib/page-drag.test.ts",
     "src/lib/familiar-drag.test.ts",
@@ -1640,6 +1642,9 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  // cave-board.ts resolves "@/lib/cave-board-types", "@/lib/task-github" and
+  // friends, so the retention suite cannot load without the alias resolver.
+  "src/lib/cave-board-retention.test.ts",
   // the picker imports the module under test, which resolves
   // "@/lib/code-surface" for the shared session-visibility rule.
   "src/lib/code-session-picker.test.ts",

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -42,6 +42,7 @@ const contracts: RouteContract[] = [
   { route: "/board/[id]/lifecycle", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board/[id]", methods: ["PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board/enrich-steps", methods: ["POST"], kind: "json", readsJson: true },
+  { route: "/board/restore", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/board", methods: ["GET", "POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/canvas", methods: ["GET", "PUT", "POST", "PATCH", "DELETE"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/capabilities", methods: ["GET"], kind: "json" },

--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -79,13 +79,24 @@ export async function PATCH(
 }
 
 export async function DELETE(
-  _req: Request,
+  req: Request,
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  const ok = await deleteCard(id);
-  if (!ok) {
+  // A card linked to a Bead is a durable reference target. Routine cleanup gets
+  // a 409 and has to unlink first; `?unlink=1` is the explicit stronger action
+  // for a caller that means it. The guard lives here, not in the client, because
+  // the store is the retention boundary (cave-xddxs).
+  const allowLinked = new URL(req.url).searchParams.get("unlink") === "1";
+  const outcome = await deleteCard(id, { allowLinked });
+  if (outcome === "not-found") {
     return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
+  }
+  if (outcome === "linked") {
+    return NextResponse.json(
+      { ok: false, error: "linked_bead_requires_unlink" },
+      { status: 409 },
+    );
   }
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/board/restore/route.ts
+++ b/src/app/api/board/restore/route.ts
@@ -1,0 +1,36 @@
+import { NextResponse } from "next/server";
+import { restoreCards, type Card } from "@/lib/cave-board";
+
+/**
+ * Put whole cards back under their original ids.
+ *
+ * Undo previously re-created cleared cards through `POST /api/board`, which
+ * mints a fresh id and accepts only a subset of fields — so every Bead and
+ * GitHub reference to the old id broke, and step state, Asana links,
+ * dependencies and lifecycle history were dropped on the floor (cave-xddxs).
+ *
+ * Restore is additive by construction: an id that is currently live is reported
+ * back as `skipped` rather than overwritten, so this can never clobber a card
+ * that returned by some other route while the undo banner was still up.
+ */
+export async function POST(req: Request) {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  const cards = (body as { cards?: unknown })?.cards;
+  if (!Array.isArray(cards)) {
+    return NextResponse.json({ ok: false, error: "cards array required" }, { status: 400 });
+  }
+  const usable = cards.filter(
+    (card): card is Card =>
+      Boolean(card) && typeof card === "object" && typeof (card as Card).id === "string",
+  );
+  if (usable.length === 0) {
+    return NextResponse.json({ ok: false, error: "no restorable cards" }, { status: 400 });
+  }
+  const { restored, skipped } = await restoreCards(usable);
+  return NextResponse.json({ ok: true, restored, skipped });
+}

--- a/src/components/board-clear-done.test.ts
+++ b/src/components/board-clear-done.test.ts
@@ -42,10 +42,29 @@ assert.match(
   "Board retry actions bypass a fresh warm-cache entry",
 );
 
-// handleUndoClear: re-create via POST.
+// handleUndoClear: RESTORE the stored records, don't re-create them.
+//
+// These two assertions used to pin the opposite — "undo re-creates cards via
+// POST /api/board" and "undo maps steps to {text}[] for POST". That was the
+// defect written down as a contract: re-creating minted a new card id (breaking
+// every Bead/GitHub reference to a completed mirror) and the {text}-only step
+// mapping is precisely how step state was lost. cave-xddxs replaced it.
 const undoFn = source.match(/const handleUndoClear = async[\s\S]*?\n {2}\};/)?.[0] ?? "";
-assert.match(undoFn, /"\/api\/board", \{[\s\S]*?method: "POST"/, "undo re-creates cards via POST /api/board");
-assert.match(undoFn, /steps: [\s\S]*?\.map\(\(s\) => \(\{ text: s\.text \}\)\)/, "undo maps steps to {text}[] for POST");
+assert.match(
+  undoFn,
+  /"\/api\/board\/restore", \{[\s\S]*?method: "POST"/,
+  "undo restores through /api/board/restore",
+);
+assert.match(
+  undoFn,
+  /body: JSON\.stringify\(\{ cards: banner\.snapshot \}\)/,
+  "undo sends the whole stored snapshot, not a rebuilt subset of fields",
+);
+assert.doesNotMatch(
+  undoFn,
+  /\.map\(\(s\) => \(\{ text: s\.text \}\)\)/,
+  "undo no longer flattens steps to text, which dropped done/doneAt/dates",
+);
 
 // Undo banner with an Undo action.
 assert.match(source, /clearedBanner &&/, "undo banner renders when a clear just happened");

--- a/src/components/board-retention.test.ts
+++ b/src/components/board-retention.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+// Client half of the Board mirror-retention contract (cave-xddxs). The STORE is
+// the retention boundary — see src/lib/cave-board-retention.test.ts, which
+// exercises the real guard. These assertions pin the experience around it: both
+// removal paths preserve linked mirrors and say so, and undo goes through the
+// restore endpoint instead of re-creating cards.
+
+const view = await readFile(new URL("./board-view.tsx", import.meta.url), "utf8");
+const route = await readFile(new URL("../app/api/board/[id]/route.ts", import.meta.url), "utf8");
+const restore = await readFile(new URL("../app/api/board/restore/route.ts", import.meta.url), "utf8");
+
+// ── Both removal paths preserve linked mirrors ──────────────────────────────
+// Clear done and bulk delete are separate code paths; a fix to one is not a fix
+// to the other, so each is pinned.
+assert.match(
+  view,
+  /const preserved = doneCards\.filter\(\(c\) => c\.beadRef\);\s*\n\s*const snapshot = doneCards\.filter\(\(c\) => !c\.beadRef\);/,
+  "Clear done splits linked mirrors out of the delete set",
+);
+assert.match(
+  view,
+  /const preserved = requested\.filter\(\(c\) => c\.beadRef\);\s*\n\s*const toRemove = requested\.filter\(\(c\) => !c\.beadRef\);/,
+  "bulk delete splits linked mirrors out of the delete set",
+);
+// Silently keeping them would be its own bug: the operator asked for a deletion
+// and must be told which ones did not happen.
+assert.match(view, /Kept \$\{preserved\.length\} linked/, "the preserved count is announced");
+
+// ── Undo restores rather than re-creates ────────────────────────────────────
+assert.match(
+  view,
+  /fetch\("\/api\/board\/restore", \{[\s\S]{0,200}?body: JSON\.stringify\(\{ cards: banner\.snapshot \}\)/,
+  "undo posts the stored snapshots to the restore endpoint",
+);
+// The old behaviour, and the whole defect: re-creating through the create route
+// minted a new id and dropped most fields.
+assert.doesNotMatch(
+  view,
+  /handleUndoClear[\s\S]{0,1200}?fetch\("\/api\/board", \{\s*\n?\s*method: "POST"/,
+  "undo no longer re-creates cleared cards through the create route",
+);
+
+// ── The server is the boundary ──────────────────────────────────────────────
+assert.match(
+  route,
+  /linked_bead_requires_unlink/,
+  "DELETE refuses a linked card with a named error",
+);
+assert.match(route, /\{ status: 409 \}/, "and refuses it with 409, not a generic failure");
+assert.match(
+  route,
+  /searchParams\.get\("unlink"\) === "1"/,
+  "an explicit unlink flag is the only way past the guard",
+);
+
+// ── Restore never clobbers ──────────────────────────────────────────────────
+assert.match(restore, /restoreCards/, "the restore route delegates to the store");
+assert.match(
+  restore,
+  /skipped/,
+  "and reports ids it declined to overwrite rather than silently winning",
+);
+
+console.log("board-retention.test.ts ok");

--- a/src/components/board-view.tsx
+++ b/src/components/board-view.tsx
@@ -624,12 +624,27 @@ export function BoardView({
   // Schedule a deferred, undoable delete of one or more cards. The cards hide at
   // once (via the `filtered` exclusion), and the actual DELETEs fire only when
   // the undo window lapses; Undo just drops the timer and the cards reappear.
-  const deleteCards = useCallback((toRemove: Card[]) => {
-    if (toRemove.length === 0) return;
+  const deleteCards = useCallback((requested: Card[]) => {
+    // Same retention rule as Clear done: a Bead-linked mirror is preserved and
+    // reported, not deleted. Without this the server's 409 would land as a
+    // generic "couldn't delete N tasks" failure, which reads as a bug rather
+    // than the deliberate protection it is (cave-xddxs).
+    const preserved = requested.filter((c) => c.beadRef);
+    const toRemove = requested.filter((c) => !c.beadRef);
+    if (toRemove.length === 0) {
+      if (preserved.length > 0) {
+        const noun = preserved.length === 1 ? "task" : "tasks";
+        announce(`Kept ${preserved.length} linked ${noun}. Unlink to delete.`);
+      }
+      return;
+    }
     const idSet = new Set(toRemove.map((c) => c.id));
     if (selectedCardId && idSet.has(selectedCardId)) setSelectedCardId(null);
     setClearedBanner(null); // one bottom undo affordance at a time
-    announce(`Deleted ${toRemove.length} task${toRemove.length === 1 ? "" : "s"}. Undo available.`);
+    const kept = preserved.length > 0
+      ? ` Kept ${preserved.length} linked task${preserved.length === 1 ? "" : "s"}.`
+      : "";
+    announce(`Deleted ${toRemove.length} task${toRemove.length === 1 ? "" : "s"}.${kept} Undo available.`);
     scheduleCardDelete(
       toRemove,
       `${toRemove.length} task${toRemove.length === 1 ? "" : "s"}`,
@@ -742,9 +757,21 @@ export function BoardView({
   };
 
   const handleClearDone = async () => {
-    const snapshot = doneCards;
+    // Cards linked to a Bead are durable reference targets, so routine cleanup
+    // preserves them and says so rather than deleting them silently. The server
+    // refuses them too (409 linked_bead_requires_unlink) — this filter is the
+    // experience, not the boundary (cave-xddxs).
+    const preserved = doneCards.filter((c) => c.beadRef);
+    const snapshot = doneCards.filter((c) => !c.beadRef);
     setClearConfirm(false);
-    if (snapshot.length === 0) return;
+    if (snapshot.length === 0) {
+      if (preserved.length > 0) {
+        const noun = preserved.length === 1 ? "task" : "tasks";
+        setActionError(null);
+        announce(`Kept ${preserved.length} linked ${noun}. Unlink to delete.`);
+      }
+      return;
+    }
     const ids = new Set(snapshot.map((c) => c.id));
     invalidateSurfaceResources("board:cards");
     // Optimistic remove + drop selection if it pointed at a cleared card.
@@ -776,7 +803,10 @@ export function BoardView({
     }
     if (cleared.length > 0) {
       setClearedBanner({ snapshot: cleared });
-      announce(`Cleared ${cleared.length} done task${cleared.length === 1 ? "" : "s"}. Undo available.`);
+      const kept = preserved.length > 0
+        ? ` Kept ${preserved.length} linked task${preserved.length === 1 ? "" : "s"}.`
+        : "";
+      announce(`Cleared ${cleared.length} done task${cleared.length === 1 ? "" : "s"}.${kept} Undo available.`);
     }
   };
 
@@ -786,33 +816,28 @@ export function BoardView({
     setClearedBanner(null);
     announce(`Restored ${banner.snapshot.length} cleared task${banner.snapshot.length === 1 ? "" : "s"}.`);
     try {
-      await Promise.all(
-        banner.snapshot.map((c) =>
-          fetch("/api/board", {
-            method: "POST",
-            headers: { "content-type": "application/json" },
-            body: JSON.stringify({
-              title: c.title,
-              notes: c.notes,
-              status: c.status,
-              priority: c.priority,
-              familiarId: c.familiarId,
-              modelOverride: c.modelOverride,
-              modelOverrideHarness: c.modelOverrideHarness,
-              sessionId: c.sessionId,
-              cwd: c.cwd,
-              projectId: c.projectId,
-              links: c.links,
-              github: c.github,
-              labels: c.labels,
-              startDate: c.startDate,
-              endDate: c.endDate,
-              template: c.template,
-              steps: c.steps.map((s) => ({ text: s.text })),
-            }),
-          }),
-        ),
-      );
+      // Restore the STORED cards, not a re-creation of them. Undo used to POST
+      // /api/board per card, which minted a new id and carried ~16 of the ~30
+      // fields — breaking every Bead/GitHub reference to the old id and losing
+      // step state, Asana links, dependencies and lifecycle history (cave-xddxs).
+      const res = await fetch("/api/board/restore", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cards: banner.snapshot }),
+      });
+      const json = await res.json().catch(() => null) as
+        | { ok?: boolean; restored?: string[]; skipped?: string[] }
+        | null;
+      if (!res.ok || !json?.ok) throw new Error("restore failed");
+      // A skipped id means that card came back by another route while the undo
+      // banner was up; restore never overwrites, so say nothing was lost.
+      if ((json.skipped?.length ?? 0) > 0) {
+        setActionError(
+          `${json.skipped!.length} task${json.skipped!.length === 1 ? " was" : "s were"} already back — left as they are.`,
+        );
+      } else {
+        setActionError(null);
+      }
     } catch {
       setActionError("Couldn't restore all cleared tasks — reload to check.");
     }

--- a/src/lib/cave-board-retention.test.ts
+++ b/src/lib/cave-board-retention.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Point the store at a scratch Cave home BEFORE importing it — the module
+// resolves board.json from caveHome() at import time. Never let this suite
+// touch a real ~/.coven board; these tests delete cards.
+const home = await mkdtemp(path.join(tmpdir(), "cave-board-retention-"));
+process.env.COVEN_CAVE_HOME = home;
+const BOARD = path.join(home, "board.json");
+
+const { deleteCard, restoreCards, cardForBeadRef, loadBoard } = await import("./cave-board.ts");
+
+const ISO = "2026-08-09T00:00:00.000Z";
+const card = (over: Record<string, unknown> = {}) => ({
+  id: "c-plain",
+  title: "Plain card",
+  notes: "",
+  status: "done",
+  priority: "medium",
+  familiarId: null,
+  sessionId: null,
+  cwd: null,
+  links: [],
+  github: [],
+  asana: [],
+  labels: [],
+  createdAt: ISO,
+  updatedAt: ISO,
+  lifecycle: "completed",
+  lifecycleAt: ISO,
+  retryCount: 0,
+  maxRetries: 3,
+  steps: [],
+  ...over,
+});
+
+const LINKED = card({
+  id: "c-linked",
+  title: "Linked mirror",
+  beadRef: { id: "cave-abc12", projectId: "proj-1" },
+});
+
+async function seed(cards: unknown[]) {
+  await mkdir(path.dirname(BOARD), { recursive: true });
+  await writeFile(BOARD, JSON.stringify({ version: 1, cards }), "utf8");
+}
+const ids = async () => (await loadBoard()).cards.map((c) => c.id).sort();
+
+// ── Retention: a linked mirror survives routine deletion ────────────────────
+await seed([card(), LINKED]);
+assert.equal(await deleteCard("c-linked"), "linked", "a linked card is refused, not deleted");
+assert.deepEqual(await ids(), ["c-linked", "c-plain"], "the refused card is still on the board");
+
+assert.equal(await deleteCard("c-plain"), "deleted", "an unlinked card deletes normally");
+assert.deepEqual(await ids(), ["c-linked"]);
+
+assert.equal(await deleteCard("c-missing"), "not-found", "a missing id is distinguishable from a refusal");
+
+// The explicit stronger action is the only way past the guard.
+assert.equal(
+  await deleteCard("c-linked", { allowLinked: true }),
+  "deleted",
+  "an explicit unlink-and-delete removes the linked card",
+);
+assert.deepEqual(await ids(), []);
+
+// ── A malformed ref is not a link ───────────────────────────────────────────
+// Both halves are required: a half-written ref must not make a card permanently
+// undeletable, which would be a worse failure than the one being fixed.
+for (const bad of [{ id: "cave-abc12" }, { projectId: "proj-1" }, { id: "", projectId: "p" }, "nope", null]) {
+  await seed([card({ id: "c-bad", beadRef: bad })]);
+  assert.equal(await deleteCard("c-bad"), "deleted", `beadRef ${JSON.stringify(bad)} is not a link`);
+}
+
+// ── Restore: same id, full fields ───────────────────────────────────────────
+const rich = card({
+  id: "c-rich",
+  title: "Rich card",
+  notes: "kept",
+  beadRef: { id: "cave-zzz99", projectId: "proj-9" },
+  asana: [{
+    id: "asana-1",
+    kind: "task",
+    gid: "1201",
+    title: "Ship retention",
+    url: "https://app.asana.com/0/1200/1201",
+  }],
+  labels: ["alpha", "beta"],
+  steps: [{ id: "s1", text: "step one", done: true, addedAt: ISO, doneAt: ISO }],
+  retryCount: 2,
+  maxRetries: 5,
+  createdAt: "2026-01-01T00:00:00.000Z",
+});
+await seed([rich]);
+const stored = (await loadBoard()).cards[0];
+assert.equal(await deleteCard("c-rich", { allowLinked: true }), "deleted");
+assert.deepEqual(await ids(), [], "precondition: the card is gone");
+
+const result = await restoreCards([stored]);
+assert.deepEqual(result.restored, ["c-rich"], "restore reports what it put back");
+assert.deepEqual(result.skipped, []);
+
+const back = (await loadBoard()).cards[0];
+assert.equal(back.id, "c-rich", "the ORIGINAL id is restored — the whole point");
+assert.equal(back.createdAt, "2026-01-01T00:00:00.000Z", "createdAt is not reset to now");
+assert.deepEqual(back.beadRef, { id: "cave-zzz99", projectId: "proj-9" }, "the Bead link survives");
+assert.equal(back.asana.length, 1, "Asana links survive (the create path drops them entirely)");
+assert.deepEqual(back.labels, ["alpha", "beta"]);
+assert.equal(back.retryCount, 2);
+assert.equal(back.maxRetries, 5);
+assert.equal(back.steps[0]?.done, true, "step STATE survives, not just step text");
+assert.equal(back.steps[0]?.doneAt, ISO);
+// The strongest statement available: the restored record equals the stored one.
+// Name the offending field — "objects differ" is useless when a card has ~30 of
+// them and the printed dump elides the one that matters.
+const differsOn = (a: unknown, b: unknown, keys: string[]) =>
+  keys.filter(
+    (key) =>
+      JSON.stringify((a as Record<string, unknown>)[key])
+      !== JSON.stringify((b as Record<string, unknown>)[key]),
+  );
+const allKeys = [...new Set([...Object.keys(stored), ...Object.keys(back)])];
+// `asana` is excluded ONLY because of cave-0b8t8: backfillCard is not
+// idempotent, so a stored Asana title is replaced by a generated one on the
+// NEXT load — restore writes the record back verbatim and the read still
+// differs. That is a pre-existing board-normalization defect, not a restore
+// defect, and it is asserted against separately below so this exclusion cannot
+// quietly hide a regression in the link itself.
+const differing = differsOn(stored, back, allKeys.filter((k) => k !== "asana"));
+assert.deepEqual(
+  differing,
+  [],
+  `a restored card is indistinguishable from the stored one; differing: ${differing
+    .map((k) => `${k} ${JSON.stringify((stored as Record<string, unknown>)[k])} -> ${JSON.stringify((back as Record<string, unknown>)[k])}`)
+    .join(" | ")}`,
+);
+// The Asana link's IDENTITY must still survive a restore — only its title is
+// subject to cave-0b8t8.
+assert.deepEqual(
+  differsOn(stored.asana[0], back.asana[0], ["id", "kind", "gid", "url", "projectGid"]),
+  [],
+  "a restored Asana link keeps its identity",
+);
+
+// ── Restore never clobbers a live card ──────────────────────────────────────
+const live = (await loadBoard()).cards[0];
+const impostor = { ...live, title: "Should not win" };
+const second = await restoreCards([impostor]);
+assert.deepEqual(second.restored, [], "a live id is not restored over");
+assert.deepEqual(second.skipped, ["c-rich"], "and is reported as skipped");
+assert.equal((await loadBoard()).cards[0].title, "Rich card", "the live card is untouched");
+
+// ── Bead → card resolution needs no prose ───────────────────────────────────
+const cards = (await loadBoard()).cards;
+assert.equal(cardForBeadRef(cards, "cave-zzz99")?.id, "c-rich", "a closed Bead resolves to its live card");
+assert.equal(cardForBeadRef(cards, "cave-nope"), null);
+assert.equal(cardForBeadRef(cards, ""), null, "an empty id never matches a card");
+
+// ── The board file is still well-formed after all of it ─────────────────────
+const raw = JSON.parse(await readFile(BOARD, "utf8"));
+assert.equal(raw.version, 1);
+assert.equal(Array.isArray(raw.cards), true);
+
+console.log("cave-board-retention.test.ts ok");

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -149,6 +149,23 @@ export type CardAsanaLink = {
   updatedAt?: string;
 };
 
+/**
+ * An explicit link from a Board card to the Bead it mirrors.
+ *
+ * The project id rides the reference even though the card already has a
+ * `projectId`: a task's execution project may be repointed later, and that must
+ * never silently repoint its delivery link at another repository.
+ *
+ * Shape deliberately matches the `cave-tjact` delivery-accounting design so the
+ * two efforts converge rather than fork — see that spec's "Board data model".
+ * Nothing infers a link: no title, note, label, PR or issue reference is read as
+ * one. A link exists only because someone set it.
+ */
+export type CardBeadRef = {
+  id: string;
+  projectId: string;
+};
+
 export type Card = {
   id: string;
   title: string;
@@ -164,6 +181,13 @@ export type Card = {
   cwd: string | null;
   /** Stable project ID from cave-projects.json. Preferred over cwd. */
   projectId?: string | null;
+  /**
+   * The Bead this card mirrors, when one was explicitly linked. Its presence is
+   * what makes the card a durable reference target, so routine Board cleanup
+   * refuses to delete it (see `deleteCard`) — a linked mirror must be unlinked
+   * deliberately before it can go.
+   */
+  beadRef?: CardBeadRef | null;
   links: string[];
   github: CardGitHubLink[];
   asana: CardAsanaLink[];

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_MAX_RETRIES,
   type Card,
   type CardAsanaLink,
+  type CardBeadRef,
   type CardGitHubLink,
   type CardLifecycle,
   type CardPriority,
@@ -41,6 +42,7 @@ export {
   STATUSES,
   type Card,
   type CardAsanaLink,
+  type CardBeadRef,
   type CardGitHubLink,
   type CardLifecycle,
   type CardPriority,
@@ -159,6 +161,22 @@ function normalizeBoardDate(value: string | null | undefined): string | null {
   return date.toISOString().slice(0, 10) === trimmed ? trimmed : null;
 }
 
+/**
+ * A link only counts when both halves are present and non-empty. Normalizing
+ * here matters in both directions: a malformed value must not fake a link (which
+ * would make a card undeletable for no reason), and must not be quietly dropped
+ * either — a half-written ref is treated as no link, which is the safe reading
+ * because deletion protection is then simply not claimed.
+ */
+function normalizeBeadRef(value: unknown): CardBeadRef | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Partial<CardBeadRef>;
+  const id = typeof raw.id === "string" ? raw.id.trim() : "";
+  const projectId = typeof raw.projectId === "string" ? raw.projectId.trim() : "";
+  if (!id || !projectId) return null;
+  return { id, projectId };
+}
+
 function backfillCard(c: Card | LegacyCard): Card {
   const lifecycle = c.lifecycle ?? inferLifecycle(c.status);
   const github = mergeGitHubLinks(normalizeGitHubLinks(c.github), ...gitHubLinksFromLinks(c.links));
@@ -171,6 +189,7 @@ function backfillCard(c: Card | LegacyCard): Card {
     status: statusForLifecycle(lifecycle, c.status),
     cwd: normalizeCwd(c.cwd),
     projectId: c.projectId ?? null,
+    beadRef: normalizeBeadRef((c as Card).beadRef),
     modelOverride: normalizeModelOverride(c.modelOverride),
     modelOverrideHarness: normalizeModelOverrideHarness(c.modelOverrideHarness),
     links,
@@ -518,15 +537,85 @@ export async function transitionCard(
   });
 }
 
-export async function deleteCard(id: string): Promise<boolean> {
+/** A linked mirror is a durable reference target; routine cleanup must not take
+ *  it. `linked` is refused rather than silently skipped so the caller can say so. */
+export type DeleteCardOutcome = "deleted" | "not-found" | "linked";
+
+/**
+ * Delete a card.
+ *
+ * A card carrying a `beadRef` is refused with `"linked"` unless the caller
+ * passes `allowLinked` — the explicit stronger removal action. This guard is
+ * server-side on purpose: client filtering improves the experience, but the
+ * store is the retention boundary, and a Board mirror deleted by a stray client
+ * takes a closed Bead's only durable pointer with it (cave-xddxs).
+ */
+export async function deleteCard(
+  id: string,
+  options: { allowLinked?: boolean } = {},
+): Promise<DeleteCardOutcome> {
   return withBoardLock(async () => {
   const board = await loadBoard();
-  const before = board.cards.length;
+  const card = board.cards.find((c) => c.id === id);
+  if (!card) return "not-found";
+  if (card.beadRef && !options.allowLinked) return "linked";
   board.cards = board.cards.filter((c) => c.id !== id);
-  if (board.cards.length === before) return false;
   await saveBoard(board);
-  return true;
+  return "deleted";
   });
+}
+
+/**
+ * Reinstate whole cards under their original ids.
+ *
+ * Undo used to re-create cleared cards through the normal create path, which
+ * mints a fresh id and carries only the subset of fields that path accepts — so
+ * every Bead or GitHub reference to the old id broke, and step state, asana
+ * links, dependencies and lifecycle history were silently dropped. Restoring
+ * writes the stored record back verbatim.
+ *
+ * An id that is currently live is skipped rather than overwritten: restore
+ * exists to undo a removal, never to clobber a card that came back by another
+ * route (a re-create, a sync, another session).
+ */
+export async function restoreCards(
+  cards: readonly Card[],
+): Promise<{ restored: string[]; skipped: string[] }> {
+  return withBoardLock(async () => {
+    const board = await loadBoard();
+    const live = new Set(board.cards.map((c) => c.id));
+    const restored: string[] = [];
+    const skipped: string[] = [];
+    for (const card of cards) {
+      if (!card?.id || typeof card.id !== "string") continue;
+      if (live.has(card.id)) {
+        skipped.push(card.id);
+        continue;
+      }
+      // Written back VERBATIM. Re-normalizing here would defeat the contract:
+      // backfillCard is not idempotent — re-running it over a card whose Asana
+      // URL has already been merged into `links` re-derives that link and
+      // overwrites its stored title with a generated one. loadBoard normalizes
+      // every card on read anyway, so nothing is skipped by not doing it twice.
+      board.cards.push(card);
+      live.add(card.id);
+      restored.push(card.id);
+    }
+    if (restored.length > 0) await saveBoard(board);
+    return { restored, skipped };
+  });
+}
+
+/**
+ * The live card mirroring a Bead, by Bead id.
+ *
+ * Pure so a caller can resolve against any snapshot. This is what lets a closed
+ * Bead's notes point at a card without appending supersession prose every time
+ * the Board is tidied: the reference is structured, and the id no longer churns.
+ */
+export function cardForBeadRef(cards: readonly Card[], beadId: string): Card | null {
+  if (!beadId) return null;
+  return cards.find((c) => c.beadRef?.id === beadId) ?? null;
 }
 
 export async function unlinkSessionFromCards(sessionId: string): Promise<number> {


### PR DESCRIPTION
Closes `cave-xddxs`.

## What was wrong

**Clear done** permanently `DELETE`d every done card, and **Undo** re-created them through `POST /api/board` — which mints a **new id** and accepts ~16 of a card's ~30 fields.

So a routine tidy-up broke every Bead and GitHub reference to a completed mirror, and "undo" silently dropped Asana links, step *state* (`done`/`doneAt`/dates — steps were re-sent as `{text}` only), `dependencies`, `primaryBlockerId`, `lifecycle`, `retryCount` and `createdAt`. Three closed Beads already ended up pointing at superseded card ids.

## What changed

**Retention (criterion 1).** A card carrying `beadRef` is refused by the store — `DELETE /api/board/{id}` → `409 linked_bead_requires_unlink`; `?unlink=1` is the explicit stronger action. The guard is server-side because that is the retention boundary, not the client. Clear done **and** bulk delete both filter linked cards out and report how many were kept, so the protection reads as deliberate rather than as a failed delete.

**Restore (criterion 2).** `POST /api/board/restore` writes stored records back **verbatim under their original ids**. A live id is reported as `skipped`, never overwritten, so restore can't clobber a card that returned by another route while the undo banner was up.

**Resolution (criterion 3).** `cardForBeadRef()` resolves a Bead id to its live card through the structured link — no supersession prose to parse.

**Tests (criterion 4).** `cave-board-retention.test.ts` drives the real store against a scratch `COVEN_CAVE_HOME`: the guard, the explicit-unlink override, malformed refs, exact-id restore, field fidelity, no-clobber, and Bead→card resolution. `board-retention.test.ts` pins the client/route half. Both wired into the `app` suite.

## Overlap with cave-tjact — read this before merging

`cave-tjact` is **in flight over the same files** and its spec has a *Linked-card retention* section covering criterion (1). The owner directed building the full xddxs contract anyway, so this deliberately adopts tjact's shapes to make the two reconcile rather than fight: identical `CardBeadRef { id, projectId }`, identical `409 linked_bead_requires_unlink`, identical skip-and-report bulk behaviour. Criterion (1) is satisfied via tjact's "explicit stronger removal action" branch rather than an archive, for the same reason.

Criterion (2) — the exact-id, full-field restore — is **not** covered by tjact and is where the actual data loss is.

## A pre-existing bug this surfaced — `cave-0b8t8` (filed, not fixed here)

`backfillCard` is not idempotent. Once an Asana URL is folded into `links`, the **next load** re-derives that link and overwrites its stored title with a generated `"Asana task <gid>"`. This bites on ordinary reload, not just restore. `restoreCards` therefore writes verbatim rather than re-normalizing — and the "restored card is indistinguishable from the stored one" assertion excludes exactly one field, `asana`, with the bead id named in the comment and a **separate assertion that the link's identity survives**, so the exclusion can't quietly hide a regression. The GitHub link path uses the same derive-and-merge shape and likely has the same defect.

## Verification

- Full `node scripts/run-tests.mjs app` suite — pass
- `pnpm exec tsc --noEmit`, `pnpm lint`, `node scripts/check-tests-wired.mjs` — pass

The suite first failed on `worktree-lifecycle-patrol` with `spawnSync ETIMEDOUT`. That was three-way machine contention, not this change: re-run alone on this branch it exits 0 with zero `ETIMEDOUT`, matching unmodified `main`. I checked rather than assumed because the first comparison had `main` passing while the branch failed.

## Note on the worktree

Built in an **unmanaged** worktree: `pnpm beads:worktrees:create` is currently broken repo-wide by an invalid `disposition` on `cave-l11sw` (filed as `cave-g9byt`), which fails the global inventory for every bead. Needs manual archive-tag retirement.