### PR TITLE
fix: charge a malformed worktree record to the unit it names, not the repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,8 +57,12 @@
     So the order is **check quota → rerun → only then fall back**. Genuinely
     structural failures name the repository itself (`canonical repository
     identity mismatch`, `canonical repository identity changed between pages`);
-    those do not improve with a retry. Reach for the fallback only after a
-    retry failed:
+    those do not improve with a retry. A malformed worktree record on a bead
+    (`Bead cave-… worktree metadata: …`) is structural too, but since
+    `cave-g9byt` it is charged only to the unit it names — so if one reaches
+    you, it claims the exact branch or path you asked for. Pick another branch
+    or have its owner repair it; do not hand-edit someone else's record. Reach
+    for the fallback only after a retry failed:
 
     ```bash
     git worktree add -b <branch> .worktrees/<branch> origin/main   # last resort

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -364,6 +364,25 @@ Failures that really are structural name the repository identity instead —
 `canonical repository identity mismatch`, `canonical repository identity
 changed between pages` — and a retry will not help those.
 
+One more structural cause, and the one that reads most like someone else's
+problem: **a malformed worktree record on a bead that claims your branch or
+your path** — `Bead cave-… worktree metadata: disposition is invalid`, or any
+of the sibling `… metadata:` messages. Since `cave-g9byt` such a record is
+charged to the unit it names and to no other, so a bad record elsewhere in the
+checkout no longer touches you. Seeing one here means it claims the exact
+branch or path you asked for, which is a genuine collision: pick a different
+branch, or get the record's owner to repair it. A record naming neither a
+usable branch nor a usable path claims something unnameable and still blocks
+everything until it is fixed.
+
+Before `cave-g9byt` this was repository-wide: `cave-l11sw` wrote
+`disposition: "removed-externally-after-merge"`, outside the accepted
+`active | pr | recovery | archive` set, and every bead's creation failed
+deterministically until a human hand-edited another owner's lifecycle record —
+the one repair the worktree rules forbid. The patrol now names such a record
+under *"Malformed worktree metadata on beads whose units are gone"* rather than
+failing every unit closed over it.
+
 So: **check quota, rerun, and only then** consider
 
 ```bash

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1796,4 +1796,110 @@ await withFixture(
   },
 );
 
+// A malformed structured record used to deny creation to EVERY bead, because
+// every task's record errors were folded into every unit's metadata errors.
+// cave-l11sw wrote `disposition: "removed-externally-after-merge"` — outside the
+// accepted set — and `pnpm beads:worktrees:create` then failed deterministically
+// for every bead in the checkout with "lifecycle inventory is incomplete", with
+// no repair available that the worktree rules permit: correcting another owner's
+// lifecycle record is exactly the hand-edit they forbid. A record names the
+// branch and path it claims even when the rest of it is invalid, so it
+// disqualifies that unit and no other (cave-g9byt).
+function writeMalformedRecord(fixture, { beadId, branch, worktreePath }) {
+  const state = readJson(fixture.stateFile);
+  const issue = state.issues.find((candidate) => candidate.id === beadId);
+  assert.ok(issue, `fixture must carry ${beadId}`);
+  issue.metadata = {
+    ...issue.metadata,
+    coven: {
+      ...issue.metadata?.coven,
+      worktree: {
+        branch,
+        path: worktreePath,
+        owner: "kitty",
+        purpose: "Malformed record fixture",
+        createdAt: "2026-08-09T09:09:52.185Z",
+        // The exact value from cave-l11sw. Every other field is valid, so the
+        // record fails on this alone and the assertions below cannot pass by
+        // accident on some unrelated validation error.
+        disposition: "removed-externally-after-merge",
+      },
+    },
+  };
+  writeJson(fixture.stateFile, state);
+}
+
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    writeMalformedRecord(fixture, {
+      beadId: "cave-unit2",
+      branch: "feat/cave-unit2-orphan",
+      // No worktree is ever registered here — the shape cave-l11sw was in, its
+      // managed worktree having been removed outside the lifecycle after merge.
+      worktreePath: path.join(fixture.repo, ".worktrees", "cave-unit2-orphan"),
+    });
+
+    const created = runCreate(fixture, createArgs());
+    assert.doesNotMatch(
+      created.stderr,
+      /lifecycle inventory is incomplete/,
+      "another bead's malformed record must not block an unrelated creation",
+    );
+    assert.equal(created.status, 0, `create must succeed: ${created.stderr}`);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example") !== null,
+      true,
+      "the requested branch is actually created",
+    );
+  },
+);
+
+// The scoping above must not become a way to create *over* a claim. A record
+// already naming this branch is the collision the abort was protecting, and a
+// malformed record is no less a claim than a valid one.
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    writeMalformedRecord(fixture, {
+      beadId: "cave-unit2",
+      branch: "feat/cave-unit1-example",
+      worktreePath: path.join(fixture.repo, ".worktrees", "cave-unit1-example"),
+    });
+
+    const refused = runCreate(fixture, createArgs());
+    assert.notEqual(refused.status, 0, "a claimed branch must not be created over");
+    assert.match(refused.stderr, /lifecycle inventory is incomplete/);
+    assert.match(refused.stderr, /disposition is invalid/);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example"),
+      null,
+      "no branch is created when the request collides with a claim",
+    );
+  },
+);
+
+// Same for the path, which a differently-named branch can still land on: the
+// creator slugifies `feat/`, `fix/`, `docs/` and `chore/` away, so `fix/x` and
+// `feat/x` both resolve to `.worktrees/x`.
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    writeMalformedRecord(fixture, {
+      beadId: "cave-unit2",
+      branch: "fix/cave-unit1-example",
+      worktreePath: path.join(fixture.repo, ".worktrees", "cave-unit1-example"),
+    });
+
+    const refused = runCreate(fixture, createArgs());
+    assert.notEqual(refused.status, 0, "a claimed path must not be created over");
+    assert.match(refused.stderr, /lifecycle inventory is incomplete/);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example"),
+      null,
+      "no branch is created when the request collides with a claimed path",
+    );
+  },
+);
+
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1855,6 +1855,45 @@ await withFixture(
   },
 );
 
+// Scoping is about the malformed record, not whether its worktree still
+// exists. An active malformed unit remains uncertain in the patrol, but it
+// cannot deny an unrelated managed creation.
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    const existingBranch = "feat/cave-unit2-existing";
+    const existingPath = path.join(
+      fixture.repo,
+      ".worktrees",
+      "cave-unit2-existing",
+    );
+    const existing = runCreate(
+      fixture,
+      createArgs({ bead: "cave-unit2", branch: existingBranch }),
+    );
+    assert.equal(existing.status, 0, `fixture create must succeed: ${existing.stderr}`);
+
+    writeMalformedRecord(fixture, {
+      beadId: "cave-unit2",
+      branch: existingBranch,
+      worktreePath: existingPath,
+    });
+
+    const created = runCreate(fixture, createArgs());
+    assert.doesNotMatch(
+      created.stderr,
+      /lifecycle inventory is incomplete/,
+      "an active malformed unit must not block an unrelated creation",
+    );
+    assert.equal(created.status, 0, `create must succeed: ${created.stderr}`);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example") !== null,
+      true,
+      "the unrelated branch is actually created",
+    );
+  },
+);
+
 // The scoping above must not become a way to create *over* a claim. A record
 // already naming this branch is the collision the abort was protecting, and a
 // malformed record is no less a claim than a valid one.
@@ -1901,5 +1940,51 @@ await withFixture(
     );
   },
 );
+
+// A record that names neither a usable branch nor a usable path claims
+// something unnameable, so it cannot be charged to any unit and has to keep
+// blocking everything. The trap is that `branch` is kept verbatim for
+// diagnostics: `refs/heads/…` and a whitespace-padded name are both non-blank
+// strings that NO unit will ever equal, so a "non-blank means it names a unit"
+// test would drop the record out of the repository-wide set and into a unit
+// that never matches — reaching no surface at all. Attribution reads the
+// validated flag instead.
+for (const unusableBranch of ["refs/heads/feat/cave-unit2-unnameable", " feat/cave-unit2-padded"]) {
+  await withFixture(
+    { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+    async (fixture) => {
+      const state = readJson(fixture.stateFile);
+      const issue = state.issues.find((candidate) => candidate.id === "cave-unit2");
+      issue.metadata = {
+        coven: {
+          worktree: {
+            branch: unusableBranch,
+            // Not a string, so no usable path either — the record names nothing.
+            path: 17,
+            owner: "kitty",
+            purpose: "Unnameable record fixture",
+            createdAt: "2026-08-09T09:09:52.185Z",
+            disposition: "active",
+          },
+        },
+      };
+      writeJson(fixture.stateFile, state);
+
+      const refused = runCreate(fixture, createArgs());
+      assert.notEqual(
+        refused.status,
+        0,
+        `an unnameable record (${JSON.stringify(unusableBranch)}) must keep blocking creation`,
+      );
+      assert.match(refused.stderr, /lifecycle inventory is incomplete/);
+      assert.match(refused.stderr, /branch must be an? .*exact local branch name/);
+      assert.equal(
+        refState(fixture.repo, "refs/heads/feat/cave-unit1-example"),
+        null,
+        "no branch is created while an unnameable record stands",
+      );
+    },
+  );
+}
 
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -759,10 +759,12 @@ function exceptionForPath(
  *
  * Creation reads exactly two things out of the inventory: the paths this bead
  * already owns ({@link existingOwnedPaths}) and the budget counts. The first is
- * derived from each item's path, taskIds and bead metadata, so a metadata error
- * can hide an owned path and let creation past a budget it should have hit —
- * that stays a hard stop, repo-wide. The second comes from local git facts
- * (worktree count, branch count, exception counts) and no probe touches it.
+ * derived from each item's path, taskIds and bead metadata. Errors that cannot
+ * be attributed to a branch or path can hide an owned path and remain a hard
+ * stop repo-wide. Errors on an attributable record are handled separately by
+ * {@link claimErrorsForRequest}: they block the unit they name, not every
+ * creation in the checkout. The second comes from local git facts (worktree
+ * count, branch count, exception counts) and no probe touches it.
  *
  * `probeErrors` are deliberately NOT included. They answer "is this unit safe to
  * RETIRE" — landing time, PR association, ref recency — which creation never
@@ -775,8 +777,22 @@ function exceptionForPath(
  * unit in `uncertain`; this makes the create gate agree with that posture instead
  * of re-aborting the whole run (cave-c4f97).
  */
-function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
-  return [...new Set(items.flatMap((item) => item.metadataErrors))];
+function inventoryErrors(
+  items: WorktreeLifecycleItem[],
+  claims: WorktreeMetadataClaimError[],
+): string[] {
+  const unitScopedErrors = new Set(
+    claims
+      .filter((claim) => claim.branch.length > 0 || claim.path !== null)
+      .flatMap((claim) => claim.errors),
+  );
+  return [
+    ...new Set(
+      items
+        .flatMap((item) => item.metadataErrors)
+        .filter((error) => !unitScopedErrors.has(error)),
+    ),
+  ];
 }
 
 /**
@@ -791,6 +807,10 @@ function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
  * malformed one is no less a claim than a valid one. A record naming neither a
  * usable branch nor a usable path claims something unnameable, so it keeps
  * blocking everything until someone repairs it.
+ *
+ * `claim.branch` is already blank unless the branch is one a unit could match,
+ * so a record carrying `refs/heads/foo` or ` foo` is unnameable here rather
+ * than a claim on `foo` — see {@link WorktreeMetadataClaimError}.
  */
 function claimErrorsForRequest(
   claims: WorktreeMetadataClaimError[],
@@ -1644,7 +1664,7 @@ function execute(
   // records describing some other unit; see {@link claimErrorsForRequest}.
   const errors = [
     ...inventory.globalErrors,
-    ...inventoryErrors(inventory.items),
+    ...inventoryErrors(inventory.items, inventory.metadataClaimErrors),
     ...claimErrorsForRequest(inventory.metadataClaimErrors, options.branch, worktreePath),
   ];
   if (errors.length > 0) {

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -13,7 +13,10 @@ import {
   type WorktreeLifecycleBudgets,
   type WorktreeLifecycleItem,
 } from "../src/lib/worktree-lifecycle.ts";
-import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
+import {
+  collectWorktreeLifecycleInventory,
+  type WorktreeMetadataClaimError,
+} from "./worktree-lifecycle-inventory.ts";
 import {
   heartbeatWriterIntent,
   registerWriterIntent,
@@ -774,6 +777,41 @@ function exceptionForPath(
  */
 function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
   return [...new Set(items.flatMap((item) => item.metadataErrors))];
+}
+
+/**
+ * The malformed metadata records that stand in the way of *this* creation.
+ *
+ * A record that fails validation still names the branch and path it claims, so
+ * it can be charged to the unit it describes instead of to the repository. That
+ * scoping is the whole point of cave-g9byt — one bead's bad `disposition` had
+ * been failing `--bead` for every other bead in the checkout — but it must not
+ * become a way to create *over* a claim: a record already holding this branch
+ * or this path is exactly the collision the abort was protecting, and a
+ * malformed one is no less a claim than a valid one. A record naming neither a
+ * usable branch nor a usable path claims something unnameable, so it keeps
+ * blocking everything until someone repairs it.
+ */
+function claimErrorsForRequest(
+  claims: WorktreeMetadataClaimError[],
+  branch: string,
+  worktreePath: string,
+): string[] {
+  const requested = normalizeCandidate(worktreePath);
+  return [
+    ...new Set(
+      claims
+        .filter((claim) => {
+          const unattributable = claim.branch.trim().length === 0 && claim.path === null;
+          return (
+            unattributable ||
+            claim.branch === branch ||
+            (claim.path !== null && normalizeCandidate(claim.path) === requested)
+          );
+        })
+        .flatMap((claim) => claim.errors),
+    ),
+  ];
 }
 
 function existingOwnedPaths(
@@ -1602,8 +1640,13 @@ function execute(
   // Global failures still abort: if GitHub was unreachable or the canonical
   // repository could not be resolved, the run did not see the repository at all
   // and no admission decision it makes is trustworthy. Per-unit probe errors do
-  // not abort — see {@link inventoryErrors}.
-  const errors = [...inventory.globalErrors, ...inventoryErrors(inventory.items)];
+  // not abort — see {@link inventoryErrors} — and neither do malformed metadata
+  // records describing some other unit; see {@link claimErrorsForRequest}.
+  const errors = [
+    ...inventory.globalErrors,
+    ...inventoryErrors(inventory.items),
+    ...claimErrorsForRequest(inventory.metadataClaimErrors, options.branch, worktreePath),
+  ];
   if (errors.length > 0) {
     throw new CliError(`lifecycle inventory is incomplete: ${errors.join("; ")}`);
   }

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -54,7 +54,12 @@ export interface WorktreeLifecycleInventory {
 }
 
 export interface WorktreeMetadataClaimError {
-  /** The branch the record claims; empty when the record does not name a usable one. */
+  /**
+   * The branch the record claims, empty when it does not name one a unit could
+   * match. A record keeps its branch string verbatim for diagnostics even when
+   * that string is `refs/heads/foo` or ` foo`, which no unit ever equals; this
+   * field is already normalized so readers do not have to know that.
+   */
   branch: string;
   /** The absolute path the record claims; null when it does not name a usable one. */
   path: string | null;
@@ -150,6 +155,17 @@ type BeadTask = {
 
 type StructuredMetadataRecord = {
   branch: string;
+  /**
+   * Whether `branch` is an exact local branch name, and so can match a unit.
+   *
+   * `branch` is kept verbatim for diagnostics, which means it can hold a value
+   * no unit will ever equal — `" foo"`, `refs/heads/foo`, `feat/bad..name`.
+   * Treating "non-blank" as "names a unit" would let such a record be charged
+   * to a unit that never matches it and drop out of the repository-wide set at
+   * the same time, so its error would reach no surface at all. Attribution has
+   * to read this flag, not the string.
+   */
+  branchUsable: boolean;
   path: string | null;
   metadata: WorktreeLifecycleMetadata | null;
   errors: string[];
@@ -1574,6 +1590,7 @@ function parseStructuredRecord(
   if (!isRecord(value)) {
     return {
       branch: "",
+      branchUsable: false,
       path: null,
       metadata: null,
       errors: [`${prefix}: record must be an object`],
@@ -1587,6 +1604,9 @@ function parseStructuredRecord(
       : null;
   const errors: string[] = [];
   const metadataErrors = (message: string) => errors.push(`${prefix}: ${message}`);
+  // Tracks the same two checks below, so attribution can ask whether this
+  // branch could match a unit rather than whether the string is non-blank.
+  let branchUsable = false;
   if (
     branch.trim().length === 0 ||
     branch.startsWith("refs/heads/") ||
@@ -1597,6 +1617,8 @@ function parseStructuredRecord(
     const branchCheck = git(root, ["check-ref-format", "--branch", branch]);
     if (!branchCheck.ok || branchCheck.stdout.trim() !== branch) {
       metadataErrors("branch must be a valid exact local branch name");
+    } else {
+      branchUsable = true;
     }
   }
   if (metadataPath === null) {
@@ -1640,9 +1662,12 @@ function parseStructuredRecord(
   const exception = parseException(worktree.exception, exceptionErrors);
   for (const error of exceptionErrors) metadataErrors(error);
 
-  if (errors.length > 0) return { branch, path: metadataPath, metadata: null, errors };
+  if (errors.length > 0) {
+    return { branch, branchUsable, path: metadataPath, metadata: null, errors };
+  }
   return {
     branch,
+    branchUsable,
     path: metadataPath,
     metadata: {
       beadId: taskId.toLowerCase(),
@@ -2273,10 +2298,7 @@ function matchingTasks(
  * cannot name, so no unit can be cleared of it and it stays repository-wide.
  */
 function recordIsAttributable(record: StructuredMetadataRecord): boolean {
-  return (
-    record.branch.trim().length > 0 ||
-    normalizeAbsoluteWorktreePath(record.path) !== null
-  );
+  return record.branchUsable || normalizeAbsoluteWorktreePath(record.path) !== null;
 }
 
 function metadataFor(
@@ -2929,7 +2951,11 @@ export function collectWorktreeLifecycleInventory(
     metadataClaimErrors: structuredRecords
       .filter((record) => record.errors.length > 0)
       .map((record) => ({
-        branch: record.branch,
+        // Blank unless the branch could actually match a unit, so a reader can
+        // treat "no branch and no path" as unnameable without re-deriving what
+        // makes a branch usable. A verbatim `refs/heads/foo` here would read as
+        // a claim on `foo` that nothing can ever match.
+        branch: record.branchUsable ? record.branch : "",
         path: normalizeAbsoluteWorktreePath(record.path),
         errors: record.errors,
       })),

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -40,6 +40,25 @@ export interface WorktreeLifecycleInventory {
    * read them here (cave-t9tlm).
    */
   globalErrors: string[];
+  /**
+   * Every structured worktree record across every bead that failed validation,
+   * with the branch and path it claims.
+   *
+   * A malformed record is charged to the unit it names rather than to the whole
+   * repository (cave-g9byt), so a record whose worktree no longer exists lands
+   * on no unit at all and would otherwise disappear silently. It is still a
+   * defect on someone's bead, and creation still has to refuse a request the
+   * record already claims, so both readers get it from here.
+   */
+  metadataClaimErrors: WorktreeMetadataClaimError[];
+}
+
+export interface WorktreeMetadataClaimError {
+  /** The branch the record claims; empty when the record does not name a usable one. */
+  branch: string;
+  /** The absolute path the record claims; null when it does not name a usable one. */
+  path: string | null;
+  errors: string[];
 }
 
 type CommandResult = {
@@ -117,6 +136,15 @@ type BeadTask = {
   status: string;
   text: string;
   structured: StructuredMetadataRecord[];
+  /**
+   * Errors in the *shape* of the bead's `coven` metadata rather than in any one
+   * record — `worktrees` not being an array, additional records without a
+   * primary. Nothing identifies a branch or a path, so nothing can scope them
+   * to a unit and they stay repository-wide.
+   *
+   * Errors inside a record live on that record's `errors` instead, so they can
+   * be charged to the branch and path it names — see {@link metadataFor}.
+   */
   structuredErrors: string[];
 };
 
@@ -1656,7 +1684,6 @@ function parseStructuredMetadata(
       root,
     );
     records.push(primary);
-    errors.push(...primary.errors);
   }
 
   if (value.coven.worktrees !== undefined) {
@@ -1676,7 +1703,6 @@ function parseStructuredMetadata(
           root,
         );
         records.push(parsed);
-        errors.push(...parsed.errors);
       });
     }
   }
@@ -2234,14 +2260,45 @@ function matchingTasks(
     .map((task) => task.id);
 }
 
+/**
+ * Whether a record identifies *some* unit, however invalid the rest of it is.
+ *
+ * A record names the branch and path it claims even when the rest of it fails
+ * validation — {@link parseStructuredRecord} keeps both fields and reports the
+ * failures separately — and that is what makes scoping possible: a record whose
+ * `disposition` is misspelled still says exactly which unit it describes. The
+ * branch and path matching below then charges it there and nowhere else.
+ *
+ * A record with neither a usable branch nor a usable path claims something we
+ * cannot name, so no unit can be cleared of it and it stays repository-wide.
+ */
+function recordIsAttributable(record: StructuredMetadataRecord): boolean {
+  return (
+    record.branch.trim().length > 0 ||
+    normalizeAbsoluteWorktreePath(record.path) !== null
+  );
+}
+
 function metadataFor(
   branch: string | null,
   worktreePath: string | null,
   tasks: BeadTask[],
 ): { metadata: WorktreeLifecycleMetadata | null; errors: string[] } {
   if (!branch) return { metadata: null, errors: [] };
-  const globalErrors = tasks.flatMap((task) => task.structuredErrors);
   const allRecords = tasks.flatMap((task) => task.structured);
+  // One malformed record used to deny every unit in the repository, because
+  // every task's record errors were folded in here wholesale. cave-l11sw wrote
+  // a `disposition` outside the accepted set and creation then failed for EVERY
+  // bead with "lifecycle inventory is incomplete", deterministically, until a
+  // human corrected another owner's record — the one repair the worktree rules
+  // forbid. A record that names its branch and path disqualifies that unit; it
+  // has nothing to say about anyone else's (cave-g9byt).
+  const globalErrors = [
+    ...tasks.flatMap((task) => task.structuredErrors),
+    ...allRecords
+      .filter((record) => !recordIsAttributable(record))
+      .flatMap((record) => record.errors),
+  ];
   const records = allRecords.filter((record) => record.branch === branch);
   const normalizedWorktreePath = normalizeAbsoluteWorktreePath(worktreePath);
   const conflictingPathRecords =
@@ -2779,7 +2836,17 @@ export function collectWorktreeLifecycleInventory(
       (record): record is StructuredMetadataRecord & { metadata: WorktreeLifecycleMetadata } =>
         record.errors.length === 0 && record.metadata !== null,
     )
-    .filter(() => tasks.tasks.every((task) => task.structuredErrors.length === 0))
+    // Exception validity stays repository-wide and fail-closed: a malformed
+    // record anywhere means the exception inventory is not known to be complete,
+    // and an exception wrongly believed present *loosens* a budget. Scoping in
+    // cave-g9byt applies to blocking a unit, not to relaxing one.
+    .filter(() =>
+      tasks.tasks.every(
+        (task) =>
+          task.structuredErrors.length === 0 &&
+          task.structured.every((candidate) => candidate.errors.length === 0),
+      ),
+    )
     .filter(
       (record) =>
         structuredRecords.filter((candidate) => candidate.branch === record.branch).length === 1,
@@ -2859,6 +2926,13 @@ export function collectWorktreeLifecycleInventory(
     ),
     budgets,
     globalErrors: [...new Set(branchGlobalErrors)],
+    metadataClaimErrors: structuredRecords
+      .filter((record) => record.errors.length > 0)
+      .map((record) => ({
+        branch: record.branch,
+        path: normalizeAbsoluteWorktreePath(record.path),
+        errors: record.errors,
+      })),
     inventoryFingerprint: fingerprint(
       initialWorktreeRaw,
       initialRefsRaw,

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1743,11 +1743,14 @@ exit 0
     { active: 1, expired: 0 },
     "semantically shared exceptions across flattened records count once",
   );
+  // Each of these disqualifies `feat/old` on its own terms: the first is a
+  // failure in the shape of the bead's metadata, naming no branch and no path,
+  // so nothing can scope it and it stays repository-wide; the other two are
+  // records that name `feat/old` or its path.
   for (const [environment, expectedError] of [
     ["LIFECYCLE_MALFORMED_WORKTREES", /worktrees must be an array/i],
     ["LIFECYCLE_DUPLICATE_WORKTREE_BRANCH", /duplicate.*(?:branch|records)/i],
     ["LIFECYCLE_DUPLICATE_WORKTREE_PATH", /conflicting structured path ownership/i],
-    ["LIFECYCLE_UNUSABLE_ADDITIONAL_BRANCH", /branch/i],
   ]) {
     const malformedMultiReport = JSON.parse(
       patrol(["--json"], { [environment]: "1" }),
@@ -1761,6 +1764,40 @@ exit 0
       expectedError,
     );
   }
+  // Which unit a malformed record disqualifies is the whole question. Charging
+  // every task's record errors to every unit is what let one bead's invalid
+  // `disposition` deny the entire checkout, `beads:worktrees:create` included,
+  // with no repair available that the worktree rules permit (cave-g9byt).
+  //
+  // Here the unusable branch sits on the *additional* record, which names path
+  // `${live}`. A record names the branch and path it claims even when the rest
+  // of it is invalid, so it disqualifies that unit — and leaves `feat/old`,
+  // whose own record is valid, alone. `feat/live` is dirty in this fixture, so
+  // it lands in `active` before metadata is consulted at all; assert on where
+  // the error landed rather than on the lane it produced.
+  const unusableBranchReport = JSON.parse(
+    patrol(["--json"], { LIFECYCLE_UNUSABLE_ADDITIONAL_BRANCH: "1" }),
+  );
+  assert.match(
+    unusableBranchReport.items
+      .find((item) => item.branch === "feat/live")
+      .metadataErrors.join("\n"),
+    /conflicting structured path ownership/i,
+    "the malformed record disqualifies the unit whose path it claims",
+  );
+  const unusableBranchBystander = unusableBranchReport.items.find(
+    (item) => item.branch === "feat/old",
+  );
+  assert.deepEqual(
+    unusableBranchBystander.metadataErrors,
+    [],
+    "a malformed record naming another unit's path leaves this unit's metadata intact",
+  );
+  assert.notEqual(
+    unusableBranchBystander.lane,
+    "uncertain",
+    "a malformed record describing another unit must not hold this one out of its lane",
+  );
   assert.equal(typeof report.inventoryFingerprint, "string");
   assert.ok(report.inventoryFingerprint.length > 0);
   const humanReport = patrol();

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -199,14 +199,18 @@ function orphanedMetadataClaims(inventory: PatrolInventory): string[] {
   return [
     ...new Set(
       inventory.metadataClaimErrors
-        .filter(
-          (claim) =>
-            !inventory.items.some(
-              (item) =>
-                (claim.branch.length > 0 && item.branch === claim.branch) ||
-                (claim.path !== null && item.path === claim.path),
-            ),
-        )
+        .filter((claim) => {
+          // A record naming neither a usable branch nor a usable path is not
+          // orphaned — it is unnameable, so it stays charged to every unit and
+          // is already visible in their lanes. Reporting it here would say the
+          // opposite of what the header promises: that nothing is blocked by it.
+          if (claim.branch.length === 0 && claim.path === null) return false;
+          return !inventory.items.some(
+            (item) =>
+              (claim.branch.length > 0 && item.branch === claim.branch) ||
+              (claim.path !== null && item.path === claim.path),
+          );
+        })
         .flatMap((claim) => claim.errors),
     ),
   ];

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -186,17 +186,56 @@ function summarizeInventory(inventory: PatrolInventory): PatrolSummary {
   return summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
 }
 
+/**
+ * Malformed metadata records that describe no unit the patrol can see.
+ *
+ * A record is charged to the branch and path it names (cave-g9byt), so one
+ * whose worktree was removed outside the lifecycle lands on nothing and would
+ * report as clean. It is still a defect on someone's bead — and the record that
+ * caused cave-g9byt was exactly this shape — so the patrol names it without
+ * moving any unit into a lane over it.
+ */
+function orphanedMetadataClaims(inventory: PatrolInventory): string[] {
+  return [
+    ...new Set(
+      inventory.metadataClaimErrors
+        .filter(
+          (claim) =>
+            !inventory.items.some(
+              (item) =>
+                (claim.branch.length > 0 && item.branch === claim.branch) ||
+                (claim.path !== null && item.path === claim.path),
+            ),
+        )
+        .flatMap((claim) => claim.errors),
+    ),
+  ];
+}
+
+function renderOrphanedMetadataClaims(inventory: PatrolInventory): string {
+  const claims = orphanedMetadataClaims(inventory);
+  if (claims.length === 0) return "";
+  return [
+    "",
+    "Malformed worktree metadata on beads whose units are gone (no unit is blocked by these;",
+    "the owning bead should repair or drop the record):",
+    ...claims.map((claim) => `- ${claim}`),
+  ].join("\n");
+}
+
 function buildJsonReport(
   options: Options,
   inventory: PatrolInventory,
   summary: PatrolSummary,
   extras: Record<string, unknown> = {},
 ) {
+  const orphanedClaims = orphanedMetadataClaims(inventory);
   return {
     ok: true,
     generatedAt: new Date(options.nowMs).toISOString(),
     ...summary,
     inventoryFingerprint: inventory.inventoryFingerprint,
+    ...(orphanedClaims.length > 0 ? { orphanedMetadataClaims: orphanedClaims } : {}),
     ...extras,
   };
 }
@@ -540,12 +579,12 @@ export function main(argv = process.argv.slice(2)): number {
             ...(postInventoryError ? { postInventoryError } : {}),
             retirement,
           })
-        : renderApplyReport(
+        : `${renderApplyReport(
             postSummary,
             retirement,
             warning,
             postInventoryError,
-          ),
+          )}${renderOrphanedMetadataClaims(reportingInventory)}`,
     );
     return outcome.status;
   }
@@ -553,7 +592,7 @@ export function main(argv = process.argv.slice(2)): number {
   console.log(
     options.json
       ? renderJsonReport(options, inventory, summary)
-      : renderWorktreeLifecycleReport(summary),
+      : `${renderWorktreeLifecycleReport(summary)}${renderOrphanedMetadataClaims(inventory)}`,
   );
   return 0;
 }


### PR DESCRIPTION
Closes cave-g9byt.

## Problem

A malformed `metadata.coven.worktree` record was folded into every lifecycle unit's `metadataErrors`. When cave-l11sw wrote the unsupported disposition `removed-externally-after-merge`, managed worktree creation failed repo-wide with `lifecycle inventory is incomplete`, even for unrelated beads.

## Fix

- Keep record-validation errors attached to the branch/path the record claims.
- Preserve repository-wide failure for records that name neither a usable branch nor a usable path.
- Refuse creation when the malformed record claims the requested branch or path, without blocking unrelated creation.
- Keep malformed exception metadata fail-closed because exceptions relax budget enforcement.
- Report dangling malformed records as a non-blocking patrol advisory.
- Document the scoped failure behavior in AGENTS.md and CLAUDE.md.

## Regression coverage

- Unrelated orphaned and active malformed records no longer block creation.
- Requested branch/path collisions still refuse creation.
- Unusable `refs/heads/…` and whitespace-padded branches with no valid path remain repository-wide blockers.
- Patrol metadata errors land only on the claimed unit; dangling claims remain visible.

## Verification

- `node scripts/worktree-lifecycle-create.test.mjs`
- `node scripts/worktree-lifecycle-patrol.test.mjs`
- `node scripts/worktree-lifecycle-retirement.test.mjs`
- `node scripts/branch-curator-manual-cleanup-contract.test.mjs`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
