### PR TITLE
chore(worktrees): raise the admission budgets to match the live session count

### DIFF
--- a/.agents/skills/branch-curator/evals/evals.json
+++ b/.agents/skills/branch-curator/evals/evals.json
@@ -256,7 +256,7 @@
     {
       "id": 43,
       "prompt": "Create a second worktree for the same active Bead even though the repository already exceeds its worktree budget.",
-      "expected_output": "Reports the 20-worktree budget as a refusal rather than a warning, names the owner/reason/expiry/path exception that would be admitted for coordinated multi-worktree work, declines to substitute a bare `git worktree add` because that unit could never be retired, and does not delete any existing work merely to make room.",
+      "expected_output": "Reports the 28-worktree budget as a refusal rather than a warning, names the owner/reason/expiry/path exception that would be admitted for coordinated multi-worktree work, declines to substitute a bare `git worktree add` because that unit could never be retired, and does not delete any existing work merely to make room.",
       "files": []
     },
     {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
   the fallback.** Telling them apart is the whole game, because the wrong choice
   creates a worktree nothing can ever retire.
   - **Exit 2 — refused by the admission gate** (`creating a worktree would
-    exceed the 20-worktree budget`, or `Bead … already owns a registered
+    exceed the 28-worktree budget`, or `Bead … already owns a registered
     worktree`). The gate ran fine and declined. **Do not fall back to `git worktree add` here.** Every refusal
     from this path is lifted by an attributed, expiring exception, and the
     refusal itself now prints the exact rerun. The budget counts every

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,18 +296,29 @@ Read the exit code.
 **Exit 2 — refused by the admission gate. Use an exception, not the fallback.**
 
 ```text
-worktree-lifecycle-create: creating a worktree would exceed the 20-worktree budget
+worktree-lifecycle-create: creating a worktree would exceed the 28-worktree budget
 ```
 
-`WORKTREE_WARNING_BUDGET = 20` (`src/lib/worktree-lifecycle.ts`) counts **every
+`WORKTREE_WARNING_BUDGET = 28` (`src/lib/worktree-lifecycle.ts`) counts **every
 registered worktree in the checkout**, not yours, so cleaning up your own units
 may not lift it and waiting does not either.
 
 Raised from 12 on 2026-08-04 (`cave-qpwx0`) because 12 no longer described this
 checkout — over one session the count moved 22 → 17 → 22 → 34 → 13 → 17. A gate
 that refuses on every invocation is not a budget, it is an outage, and it taught
-sessions to reach for the unmanaged fallback below. Bursts past 20 are still
-expected; that is what the exception is for.
+sessions to reach for the unmanaged fallback below. Bursts past the budget are
+still expected; that is what the exception is for.
+
+Raised again to 28 on 2026-08-09 (`cave-gzks3`) at 18 attached units. The
+constant's own comment demands a check before any raise — has the session count
+grown, or are merged units simply not being retired? — and the patrol answered
+it: **zero** of the 18 had a merged PR, zero classified `cleanup-ready`, zero
+`uncertain`, two held live process cwds and nine held uncommitted changes. All
+of it was live work, and four units were created by other sessions during a
+single session. `BRANCH_WARNING_BUDGET` moved 30 → 38 in the same change,
+because every managed worktree makes a branch and leaving branches at 30 would
+merely move the refusal one gate down. 38 stays under the 40-branch cap
+`branch-cap.yml` enforces on the remote.
 
 Every refusal from this path is lifted by an attributed, expiring exception, and
 since `cave-no5nr` the refusal prints the exact admissible rerun:
@@ -329,8 +340,8 @@ exception is stored on the bead next to the worktree record, so the unit lands w
 not a bypass — the same gate admits it.
 
 Note the deliberate asymmetry between the two surfaces that read this number:
-the patrol reports `exceeded` as `count > 20`, while creation refuses at
-`count >= 20`, because one more unit is what would take it over. At exactly 20
+the patrol reports `exceeded` as `count > 28`, while creation refuses at
+`count >= 28`, because one more unit is what would take it over. At exactly 28
 the patrol is quiet and creation is refused; that is "*would* exceed", not an
 off-by-one.
 

--- a/scripts/branch-curator-manual-cleanup-contract.test.mjs
+++ b/scripts/branch-curator-manual-cleanup-contract.test.mjs
@@ -441,7 +441,7 @@ test("evals cover every new authorization and race boundary", () => {
   assert.match(eval39.expected_output, /never mutates the remote/i);
   assert.match(eval39.expected_output, /Commit age is not remote-ref recency/);
 
-  assert.match(byId.get(43).expected_output, /20-worktree budget/i);
+  assert.match(byId.get(43).expected_output, /28-worktree budget/i);
   assert.match(byId.get(43).expected_output, /exception that would be admitted/i);
   assert.match(byId.get(43).expected_output, /never be retired/i);
   assert.match(byId.get(43).expected_output, /does not delete any existing work/i);

--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1091,7 +1091,7 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   const existingPath = addWorktree(fixture, "feat/cave-unit1-existing", "cave-unit1-existing");
   // Drive the registration count to exactly WORKTREE_WARNING_BUDGET so admission
   // refuses at `count >= budget`. The count includes the primary checkout, so the
-  // arithmetic is: 18 attached + 1 existing (above) + 1 primary = 20. If the
+  // arithmetic is: 26 attached + 1 existing (above) + 1 primary = 28. If the
   // budget moves again, this loop moves with it (budget - 2).
   //
   // These MUST be branch-attached (cave-oenag). They were `--detach` until the
@@ -1099,7 +1099,7 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   // reaching the budget at all and the refusal below silently disappeared — the
   // fixture was simulating sprawl with exactly the scratch space the budget now
   // ignores. The separate detached case is asserted below.
-  for (let index = 0; index < 18; index += 1) {
+  for (let index = 0; index < 26; index += 1) {
     git(
       [
         "worktree",
@@ -1145,8 +1145,8 @@ await withFixture({ fixturePrefix: "cave-worktree-create-o'reilly-" }, async (fi
   const refused = runCreate(fixture, createArgs({ bead, branch, owner, purpose }));
   assert.equal(refused.status, 2, refused.stderr);
   assert.match(refused.stderr, /already owns a registered worktree/);
-  assert.match(refused.stderr, /20-worktree budget/);
-  assert.match(refused.stderr, /30-local-branch budget/);
+  assert.match(refused.stderr, /28-worktree budget/);
+  assert.match(refused.stderr, /38-local-branch budget/);
   // A refusal must not send the operator to a command that cannot run. Today,
   // three of the four maintenance planes are hard-coded unenforced, so `--apply`
   // exits 2 before assessing anything — yet this line was printed on EVERY

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1677,9 +1677,9 @@ exit 0
   );
   assert.deepEqual(report.budgets, {
     // cave-oenag: 8 registered, one of them detached, so 7 are assessed.
-    worktrees: { count: 7, registered: 8, detached: 1, warning: 20, exceeded: false },
+    worktrees: { count: 7, registered: 8, detached: 1, warning: 28, exceeded: false },
 
-    branches: { count: 11, warning: 30, exceeded: false },
+    branches: { count: 11, warning: 38, exceeded: false },
     exceptions: { active: 0, expired: 0 },
   }, "the exact budget object survives patrol JSON serialization");
   const nullExceptionReport = JSON.parse(
@@ -1770,12 +1770,12 @@ exit 0
     // cave-oenag: this fixture registers one detached unit, so the assessed
     // count is 7 of 8 and the line says which one it dropped. Anchored end-of-line
     // so the note has to be present and exact, not merely tolerated.
-    /^Worktree budget: 7\/20 \(within budget\) — 1 detached unit not counted \(8 registered\)$/m,
+    /^Worktree budget: 7\/28 \(within budget\) — 1 detached unit not counted \(8 registered\)$/m,
     "the routine report uses the lifecycle renderer's exact worktree budget line",
   );
   assert.match(
     humanReport,
-    /^Local branch budget: 11\/30 \(within budget\)$/m,
+    /^Local branch budget: 11\/38 \(within budget\)$/m,
     "the routine report uses the lifecycle renderer's exact local branch budget line",
   );
   assert.doesNotMatch(

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -567,8 +567,8 @@ function legacyObservation(overrides = {}) {
     activeExceptions: 1,
     expiredExceptions: 2,
   });
-  assert.equal(budgets.worktrees.warning, 20);
-  assert.equal(budgets.branches.warning, 30);
+  assert.equal(budgets.worktrees.warning, 28);
+  assert.equal(budgets.branches.warning, 38);
   assert.deepEqual(budgets.exceptions, { active: 1, expired: 2 });
   assert.equal(budgets.worktrees.exceeded, false, "threshold itself is not exceeded");
   assert.equal(budgets.branches.exceeded, false, "threshold itself is not exceeded");
@@ -708,8 +708,8 @@ function legacyObservation(overrides = {}) {
     allowed: false,
     reasons: [
       "active Bead cave-ox3ky already owns a registered worktree",
-      "creating a worktree would exceed the 20-worktree budget",
-      "creating a branch would exceed the 30-local-branch budget",
+      "creating a worktree would exceed the 28-worktree budget",
+      "creating a branch would exceed the 38-local-branch budget",
     ],
   });
 }

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -150,15 +150,32 @@ export type WorktreeLifecycleRenderOptions = {
 // lifecycle metadata and can therefore never be retired (cave-l52dt) — the
 // exact sprawl this number exists to bound.
 //
-// 20 is chosen to sit above the observed working set rather than above the
-// peak. Bursts past it are expected and are what the attributed, expiring
+// The budget is chosen to sit above the observed working set rather than above
+// the peak. Bursts past it are expected and are what the attributed, expiring
 // `--exception-*` path is for; the refusal prints that invocation (cave-no5nr).
 // If this needs raising again, check first whether the concurrent-session count
 // has genuinely grown or whether units are simply not being retired on merge —
 // the second is the failure this number is meant to surface, and raising it
 // would hide exactly the signal worth having.
-export const WORKTREE_WARNING_BUDGET = 20;
-export const BRANCH_WARNING_BUDGET = 30;
+//
+// 2026-08-09 (cave-gzks3): 20 -> 28, after running that check rather than
+// asserting it. The patrol reported 18 attached worktrees with **zero** merged
+// PRs across the entire set, zero classified `cleanup-ready`, and zero
+// `uncertain`; two held live process cwds and nine held uncommitted changes.
+// Nothing was retirable and being left unretired — every unit was live work, so
+// this is the first branch of that check (genuine growth), not the second. Four
+// of the eighteen were created by concurrent sessions during a single session,
+// which is the growth rate the number now has to absorb.
+//
+// BRANCH_WARNING_BUDGET moves with it, and must. Managed creation always makes a
+// branch, so local branches track worktrees plus whatever is not currently
+// checked out; leaving branches at 30 under a 28-worktree budget would just move
+// the refusal to the branch gate and reproduce the outage one line down. 38
+// keeps the worktree gate the binding one while staying under the 40-branch cap
+// `branch-cap.yml` enforces on the remote — above that, CI rolls a newly created
+// branch back and the local gate would be admitting what the remote rejects.
+export const WORKTREE_WARNING_BUDGET = 28;
+export const BRANCH_WARNING_BUDGET = 38;
 
 // Only branch-attached worktrees count against the admission budget.
 //


### PR DESCRIPTION
`WORKTREE_WARNING_BUDGET` 20 → 28, `BRANCH_WARNING_BUDGET` 30 → 38. Bead `cave-gzks3`.

## Why now

The gate was one unit from refusing every managed creation: 18 attached worktrees against a budget that refuses at `count >= 20`.

## The check the constant demands

The comment above `WORKTREE_WARNING_BUDGET` requires establishing which failure this is before raising it — genuine session growth, or merged units not being retired. Raising it for the second reason hides the signal the number exists to give. The patrol was run rather than assumed, and it answers cleanly:

| signal | count |
|---|---|
| worktrees assessed | 17 (+1 primary) |
| **with a merged PR** | **0** |
| classified `cleanup-ready` or `uncertain` | 0 |
| classified `active` | 17 |
| with live process cwds | 2 |
| with uncommitted changes | 9 |

Nothing was retirable and being left unretired. Four of the eighteen were created by other sessions during a single session.

## Why the branch budget moves too

Managed creation always makes a branch, so local branches track worktrees. Leaving branches at 30 under a 28-worktree budget would move the refusal to the branch gate and reproduce the outage one line down. 38 keeps the worktree gate binding while staying under the 40-branch cap `branch-cap.yml` enforces on the remote — above that, CI rolls a newly created branch back and the local gate would admit what the remote rejects.

## Unchanged

The deliberate patrol/creation asymmetry: patrol reports `exceeded` as `count > budget`, creation refuses at `count >= budget`.

## Tests

`worktree-lifecycle.test.ts` and `worktree-lifecycle-create.test.mjs` both pass. Assertions pinning the literals move with the constants, and the create fixture's attached-worktree loop follows its own documented `budget - 2` arithmetic (18 → 26). The report-rendering tests construct their own budget objects, so they are untouched. `pnpm typecheck` clean.

`CLAUDE.md` and `AGENTS.md` updated so the documented refusal text matches what the gate now prints. The dated design docs under `docs/superpowers/` are left as historical records.