### PR TITLE
Fix Tailscale Serve route proof

### DIFF
--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -19,6 +19,7 @@ import {
   MOBILE_INVITE_TTL_MS,
   nativeAppDiscoveryProof,
   resolveIosInstallUrl,
+  serveRouteFailure,
   shouldAllowMagicDnsFallback,
   tailnetDiscoveryProof,
   tailscaleBin,
@@ -343,7 +344,6 @@ async function ensureNativeAppServeReady(
     // the loopback backend.
     allowMagicDnsFallback: shouldAllowMagicDnsFallback({
       serveOk: serve.ok,
-      serveError: serveWarning ?? "",
       statusOk: status.ok,
     }),
   });
@@ -378,12 +378,17 @@ async function ensureNativeAppServeReady(
   }
 
   if (!discovery.ok) {
-    const routeDetail = fallbackWarning ?? serveWarning ?? discovery.reason;
+    const routeFailure = serveRouteFailure({
+      backendUrl: backend,
+      serveError: fallbackWarning ?? serveWarning,
+      statusError: status.stderr,
+    });
+    const routeDetail = routeFailure.error;
     return NextResponse.json(
       {
         ok: false,
         error: routeDetail,
-        stderr: fallbackWarning ?? serveWarning ?? status.stderr,
+        stderr: routeFailure.stderr,
         backendUrl: backend,
         steps: buildPairingSteps({
           access: { ok: true },
@@ -521,18 +526,22 @@ async function mobileHandoffReady(
     backendUrl: backend,
     allowMagicDnsFallback: shouldAllowMagicDnsFallback({
       serveOk: serve.ok,
-      serveError: serveWarning ?? "",
       statusOk: status.ok,
     }),
   });
 
   if (!discovery.ok) {
+    const routeFailure = serveRouteFailure({
+      backendUrl: backend,
+      serveError: serveWarning,
+      statusError: status.stderr,
+    });
     // Nothing usable — surface the most actionable error we have.
     return NextResponse.json(
       {
         ok: false,
-        error: serveWarning ?? discovery.reason,
-        stderr: serveWarning ?? status.stderr,
+        error: routeFailure.error,
+        stderr: routeFailure.stderr,
         backendUrl: backend,
       },
       { status: 500 },

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -382,6 +382,7 @@ async function ensureNativeAppServeReady(
       backendUrl: backend,
       serveError: fallbackWarning ?? serveWarning,
       statusError: status.stderr,
+      routeReason: discovery.reason,
     });
     const routeDetail = routeFailure.error;
     return NextResponse.json(
@@ -535,6 +536,7 @@ async function mobileHandoffReady(
       backendUrl: backend,
       serveError: serveWarning,
       statusError: status.stderr,
+      routeReason: discovery.reason,
     });
     // Nothing usable — surface the most actionable error we have.
     return NextResponse.json(

--- a/src/components/mobile-handoff.test.ts
+++ b/src/components/mobile-handoff.test.ts
@@ -336,20 +336,19 @@ assert.match(
 assert.doesNotMatch(tauriConfig, /"deep-link"[\s\S]*"scheme": \["opencoven"\]/, "iOS app should not register a custom app connect URL scheme");
 assert.doesNotMatch(tauriLib, /tauri_plugin_deep_link::init/, "iOS shell should not install the deep-link plugin");
 
-// Resilient handoff: when `tailscale serve --bg` fails but Serve status is
-// unreadable (e.g. macOS "GUI failed to start, CLIError 3"), the route may use
-// MagicDNS because a daemon-owned route can still be live. A readable empty
-// status is different: it proves no route exists and must not become a false
-// success merely because the node has a MagicDNS name.
+// A failed `tailscale serve --bg` mutation (including macOS CLIError 3) never
+// promotes MagicDNS on its own. A matching route in readable Serve status is
+// independently proven by tailnetDiscoveryProof; an empty or mismatched status
+// must remain unavailable.
 assert.doesNotMatch(
   handoffRoute,
   /error: "failed to start tailscale serve"/,
-  "serve --bg failure must not short-circuit a handoff when status cannot be read",
+  "route discovery remains centralized instead of treating a failed Serve mutation as a success",
 );
 assert.match(
   handoffRoute,
-  /tailnetDiscoveryProof\(\{[\s\S]{0,400}allowMagicDnsFallback: shouldAllowMagicDnsFallback\(\{[\s\S]{0,180}serveError: serveWarning \?\? ""[\s\S]{0,100}statusOk: status\.ok/,
-  "MagicDNS fallback is blocked by permission-denied Serve mutations even when Serve status is unreadable",
+  /tailnetDiscoveryProof\(\{[\s\S]{0,400}allowMagicDnsFallback: shouldAllowMagicDnsFallback\(\{[\s\S]{0,180}serveOk: serve\.ok,[\s\S]{0,100}statusOk: status\.ok/,
+  "MagicDNS fallback requires a successful Serve mutation and an unreadable status",
 );
 assert.match(
   handoffRoute,

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -46,15 +46,7 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
       statusOk: false,
     }),
     false,
-    "a failed Serve mutation must not become a MagicDNS success when status is unreadable",
-  );
-  assert.equal(
-    shouldAllowMagicDnsFallback({
-      serveOk: false,
-      statusOk: false,
-    }),
-    false,
-    "macOS CLIError 3 needs a matching route in Serve status before a handoff can succeed",
+    "a failed Serve mutation, including macOS CLIError 3, needs a matching route in status before a handoff can succeed",
   );
   assert.equal(
     shouldAllowMagicDnsFallback({
@@ -80,6 +72,13 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.match(failure.error, /serve config unavailable/);
   assert.match(failure.error, /Enable HTTPS for this tailnet at https:\/\/login\.tailscale\.com\/admin\/dns/);
   assert.equal(failure.stderr, "serve config unavailable");
+
+  const missingRoute = serveRouteFailure({
+    backendUrl: "http://127.0.0.1:3000",
+    routeReason: "tailscale serve route not found for http://127.0.0.1:3000",
+  });
+  assert.match(missingRoute.error, /tailscale serve route not found/);
+  assert.equal(missingRoute.stderr, undefined);
 }
 
 {

--- a/src/lib/mobile-handoff.test.ts
+++ b/src/lib/mobile-handoff.test.ts
@@ -13,6 +13,7 @@ import {
   OFFICIAL_IOS_INSTALL_URL,
   resolveIosInstallUrl,
   resolveTailscaleBin,
+  serveRouteFailure,
   shouldAllowMagicDnsFallback,
   tailnetDiscoveryProof,
   tailscaleIpHost,
@@ -42,26 +43,43 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
   assert.equal(
     shouldAllowMagicDnsFallback({
       serveOk: false,
-      serveError: "sending serve config: Access denied: serve config denied",
       statusOk: false,
     }),
     false,
-    "permission denial must not become a MagicDNS success when Serve status is also unreadable",
+    "a failed Serve mutation must not become a MagicDNS success when status is unreadable",
   );
   assert.equal(
     shouldAllowMagicDnsFallback({
       serveOk: false,
-      serveError: "GUI failed to start (CLIError 3)",
+      statusOk: false,
+    }),
+    false,
+    "macOS CLIError 3 needs a matching route in Serve status before a handoff can succeed",
+  );
+  assert.equal(
+    shouldAllowMagicDnsFallback({
+      serveOk: true,
       statusOk: false,
     }),
     true,
-    "non-permission CLI failures may still use MagicDNS when daemon status is unreadable",
+    "a successful Serve mutation may use MagicDNS when its follow-up status read is unavailable",
   );
   assert.equal(
-    shouldAllowMagicDnsFallback({ serveOk: true, serveError: "", statusOk: true }),
+    shouldAllowMagicDnsFallback({ serveOk: true, statusOk: true }),
     false,
     "a readable Serve status remains authoritative",
   );
+}
+
+{
+  const failure = serveRouteFailure({
+    backendUrl: "http://127.0.0.1:3000",
+    serveError: "serve config unavailable",
+    statusError: "status should not replace Serve stderr",
+  });
+  assert.match(failure.error, /serve config unavailable/);
+  assert.match(failure.error, /Enable HTTPS for this tailnet at https:\/\/login\.tailscale\.com\/admin\/dns/);
+  assert.equal(failure.stderr, "serve config unavailable");
 }
 
 {
@@ -212,6 +230,26 @@ const signingKey = ["handoff", "mobile", "key"].join("-");
       reason: "tailscale serve route not found for http://127.0.0.1:3000",
     },
     "a readable empty Serve status must not promote a bare MagicDNS name to a live route",
+  );
+  const linuxMismatchedServeStatus = {
+    Web: {
+      [`${serveHost}:443`]: {
+        Handlers: { "/": { Proxy: "http://127.0.0.1:4242" } },
+      },
+    },
+  };
+  assert.deepEqual(
+    tailnetDiscoveryProof({
+      selfStatus: self,
+      serveStatus: linuxMismatchedServeStatus,
+      backendUrl: "http://127.0.0.1:3000",
+      allowMagicDnsFallback: false,
+    }),
+    {
+      ok: false,
+      reason: "tailscale serve route not found for http://127.0.0.1:3000",
+    },
+    "a Linux Serve status for another loopback backend must not promote MagicDNS to a live route",
   );
   assert.deepEqual(
     nativeAppDiscoveryProof({

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -4,22 +4,40 @@ import path from "node:path";
 import { signMobileAccessToken } from "./mobile-access-token.ts";
 import { scrubSidecarInternalEnv } from "./coven-bin.ts";
 import { appTokenTtlMs } from "./mobile-token-refresh.ts";
-import { classifyTailscaleFailureKind } from "./tailscale-failure.ts";
 
 export const MOBILE_INVITE_TTL_MS = 8 * 60 * 60 * 1000;
 
 export function shouldAllowMagicDnsFallback({
   serveOk,
-  serveError,
   statusOk,
 }: {
   serveOk: boolean;
-  serveError: string;
   statusOk: boolean;
 }) {
-  if (statusOk) return false;
-  if (!serveOk && classifyTailscaleFailureKind(serveError) === "serve-permission") return false;
-  return true;
+  // A successful `serve` mutation proves the requested backend was published,
+  // even when a follow-up status read is unavailable. A failed mutation,
+  // including macOS CLIError 3, needs a matching route in status before it can
+  // be used; a MagicDNS name only identifies the machine, not a Serve route.
+  return serveOk && !statusOk;
+}
+
+export function serveRouteFailure({
+  backendUrl,
+  serveError,
+  statusError,
+}: {
+  backendUrl: string;
+  serveError?: string | null;
+  statusError?: string | null;
+}) {
+  const guidance =
+    `Tailscale Serve did not publish ${backendUrl}. ` +
+    "Enable HTTPS for this tailnet at https://login.tailscale.com/admin/dns, then retry.";
+  const stderr = serveError?.trim() || statusError?.trim() || undefined;
+  return {
+    error: stderr ? `${stderr} ${guidance}` : guidance,
+    stderr,
+  };
 }
 
 type TailscaleServeStatus = {

--- a/src/lib/mobile-handoff.ts
+++ b/src/lib/mobile-handoff.ts
@@ -25,17 +25,20 @@ export function serveRouteFailure({
   backendUrl,
   serveError,
   statusError,
+  routeReason,
 }: {
   backendUrl: string;
   serveError?: string | null;
   statusError?: string | null;
+  routeReason?: string | null;
 }) {
   const guidance =
     `Tailscale Serve did not publish ${backendUrl}. ` +
     "Enable HTTPS for this tailnet at https://login.tailscale.com/admin/dns, then retry.";
   const stderr = serveError?.trim() || statusError?.trim() || undefined;
+  const reason = routeReason?.trim();
   return {
-    error: stderr ? `${stderr} ${guidance}` : guidance,
+    error: [stderr, reason, guidance].filter(Boolean).join(" "),
     stderr,
   };
 }


### PR DESCRIPTION
Fixes cave-2cavx.

- fail closed after a failed Serve mutation unless a matching status route proves the backend
- surface Serve stderr with tailnet HTTPS enablement guidance
- cover empty and mismatched Linux-shaped Serve status cases

Verification:
- node --experimental-strip-types src/lib/mobile-handoff.test.ts
- node --experimental-strip-types src/components/mobile-handoff.test.ts
- node --experimental-strip-types scripts/cross-environment.test.ts
- pnpm test:mobile
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build