### PR TITLE
Show per-root read/write level in runtime-scope preamble

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -542,14 +542,20 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /filterProjectsForFamiliar\(projects, body\.familiarId\)/,
-  "Local Cave chat should derive grant-aware project roots for the familiar before building the runtime prompt",
+  /listAccessibleProjects\(projects, body\.familiarId\)/,
+  "Local Cave chat should derive grant-aware project roots (with each root's access level) for the familiar before building the runtime prompt",
 );
 
 assert.match(
   chatRoute,
   /allowedProjectRoots: grantedProjectRoots/,
   "The runtime prompt should include every project root the familiar is granted, not only the spawn cwd",
+);
+
+assert.match(
+  chatRoute,
+  /projectRootAccess: grantedProjectRootAccess/,
+  "The runtime prompt should carry each granted root's read/write access level so the boundary preamble can annotate it",
 );
 
 assert.match(

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -228,8 +228,9 @@ import {
 import {
   ProjectAccessDeniedError,
   assertProjectAccess,
-  filterProjectsForFamiliar,
+  listAccessibleProjects,
 } from "@/lib/project-permissions";
+import type { ProjectAccessLevel } from "@/lib/project-access-levels";
 import {
   buildTaskContext,
   buildTaskAwarePrompt,
@@ -2396,14 +2397,26 @@ export async function POST(req: Request) {
   const hermesVerbosity = controlCapabilities.some(
     (capability) => capability.parameter === "text.verbosity",
   ) ? controlValidation.values.verbosity : undefined;
-  const grantedProjectRoots = sshRuntime
+  // listAccessibleProjects (not just filterProjectsForFamiliar) so the
+  // per-root read/write level survives into the runtime-scope preamble
+  // below instead of collapsing to "has any access".
+  const accessibleProjects = sshRuntime
     ? []
-    : (await filterProjectsForFamiliar(projects, body.familiarId)).map((project) => project.root);
+    : await listAccessibleProjects(projects, body.familiarId);
+  const grantedProjectRoots = accessibleProjects.map((entry) => entry.project.root);
+  const grantedProjectRootAccess: Record<string, ProjectAccessLevel> = Object.fromEntries(
+    accessibleProjects.map((entry) => [entry.project.root, entry.access]),
+  );
   // The selected project is always the runtime root. Familiar identity files
   // are injected separately and remain an allowed side directory below.
   const runtimeScope: RuntimeScope = sshRuntime
     ? { kind: "ssh", host: sshRuntime.host, root: sshRuntime.cwd }
-    : { kind: "local", root: cwd, allowedProjectRoots: grantedProjectRoots };
+    : {
+        kind: "local",
+        root: cwd,
+        allowedProjectRoots: grantedProjectRoots,
+        projectRootAccess: grantedProjectRootAccess,
+      };
   // Boundary sentinel: watches the harness's streamed tool calls for paths
   // outside the granted roots. Never blocks the stream — violations surface
   // as a progress notice at turn end and steer the NEXT turn via a prompt

--- a/src/lib/chat-runtime-scope.test.ts
+++ b/src/lib/chat-runtime-scope.test.ts
@@ -108,6 +108,47 @@ await assert.rejects(
   assert.match(preamble, /remote runtime boundary/);
 }
 
+{
+  const docs = path.join(home, "docs");
+  const readOnlyChild = path.join(home, "docs", "public");
+  const preamble = buildRuntimeScopePreamble({
+    kind: "local",
+    root: repo,
+    allowedProjectRoots: [repo, docs, readOnlyChild],
+    projectRootAccess: { [docs]: "write", [readOnlyChild]: "read" },
+  });
+  assert.match(
+    preamble,
+    new RegExp(`${docs.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\(read \\+ write\\)`),
+    "write-granted roots should render their level",
+  );
+  assert.match(
+    preamble,
+    new RegExp(`${readOnlyChild.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*\\(read-only\\)`),
+    "read-only roots should be annotated so the familiar doesn't assume write access",
+  );
+  assert.match(
+    preamble,
+    /Roots marked \(read-only\) above permit reading, browsing, and chatting only/,
+    "a read-only root should trigger the caveat line",
+  );
+}
+
+{
+  const docs = path.join(home, "docs");
+  const preamble = buildRuntimeScopePreamble({
+    kind: "local",
+    root: repo,
+    allowedProjectRoots: [repo, docs],
+    projectRootAccess: { [docs]: "write" },
+  });
+  assert.doesNotMatch(
+    preamble,
+    /read-only/,
+    "an all-write grant set should not emit the read-only caveat line",
+  );
+}
+
 assert.equal(
   buildPromptWithRuntimeScope("hello", { kind: "local", root: repo }),
   `${buildRuntimeScopePreamble({ kind: "local", root: repo })}\n\nCurrent user message:\nhello`,

--- a/src/lib/chat-runtime-scope.ts
+++ b/src/lib/chat-runtime-scope.ts
@@ -1,6 +1,7 @@
 import { realpath, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import path from "node:path";
+import type { ProjectAccessLevel } from "@/lib/project-access-levels";
 
 type RuntimeScopeErrorCode =
   | "project_root_required"
@@ -24,7 +25,16 @@ type ResolveLocalRuntimeOptions = {
 };
 
 export type RuntimeScope =
-  | { kind: "local"; root: string; allowedProjectRoots?: string[] }
+  | {
+      kind: "local";
+      root: string;
+      allowedProjectRoots?: string[];
+      /** Per-root effective access level (keyed by the exact string in
+       * `allowedProjectRoots`), so the preamble can tell the familiar which
+       * granted roots are read-only vs. read+write. Roots absent from this
+       * map render unannotated (legacy behavior — treated as full access). */
+      projectRootAccess?: Record<string, ProjectAccessLevel>;
+    }
   | { kind: "ssh"; host: string; root: string };
 
 /** Normalize a path so Node's fs functions don't EISDIR on bare Windows
@@ -116,13 +126,29 @@ export function buildRuntimeScopePreamble(scope: RuntimeScope): string {
   if (scope.kind === "local") {
     const allowedProjectRoots = uniqueAllowedProjectRoots(scope.root, scope.allowedProjectRoots);
     if (allowedProjectRoots.length > 0) {
+      const access = scope.projectRootAccess;
+      // Only annotate when the caller actually threaded per-root levels
+      // through — omitting `projectRootAccess` keeps prior behavior (and
+      // prior test expectations) byte-for-byte unchanged.
+      const readOnlyRoots = access
+        ? allowedProjectRoots.filter((root) => access[root] === "read")
+        : [];
       return [
         "Runtime filesystem boundary:",
         "- This is the local runtime boundary for this Cave session.",
         `- Primary root: ${scope.root}`,
         "- Granted project roots:",
-        ...allowedProjectRoots.map((root) => `  - ${root}`),
+        ...allowedProjectRoots.map((root) => {
+          const level = access?.[root];
+          const suffix = level === "read" ? " (read-only)" : level === "write" ? " (read + write)" : "";
+          return `  - ${root}${suffix}`;
+        }),
         "- You may read, edit, create, delete, commit, push, and run commands inside the primary root and the granted project roots listed above.",
+        ...(readOnlyRoots.length > 0
+          ? [
+              "- Roots marked (read-only) above permit reading, browsing, and chatting only — do not edit, create, delete, commit, or push inside them, and do not run shell commands there.",
+            ]
+          : []),
         "- Do not read, edit, create, delete, commit, push, or run commands against files outside those listed roots.",
       ].join("\n");
     }


### PR DESCRIPTION
## What

The runtime-scope preamble injected at the top of every chat prompt lists
granted project roots but doesn't say whether each one is read-only or
read+write — every root gets an identical "you may read, edit, create,
delete, commit, push" instruction. That's out of step with the server-side
enforcement (`assertProjectAccess`, `WRITE_SURFACES` in
`project-access-levels.ts`), which does correctly gate file-write/shell to
`write`-level grants.

## Fix

- `RuntimeScope`'s local variant gains an optional `projectRootAccess` map
  (`root -> "read" | "write"`).
- `buildRuntimeScopePreamble` annotates each granted root — `(read-only)` /
  `(read + write)` — and adds a caveat line when any listed root is
  read-only. Omitting the map preserves prior output exactly (existing tests
  pass unchanged).
- `chat/send/route.ts` now sources `grantedProjectRoots` from
  `listAccessibleProjects` (which already returns `{ project, access }`
  pairs) instead of `filterProjectsForFamiliar`, so the level survives into
  the `RuntimeScope` passed to the preamble builder.

## Not in scope

Nested/overlapping project-root precedence (a stricter child grant
overriding a looser parent grant) was independently verified as already
correct via `projectRootForPath`'s longest-matching-root resolution — no
change needed there.

## Testing

- `node src/lib/chat-runtime-scope.test.ts` — new coverage for annotated
  read-only/write roots, the caveat line, and the all-write no-caveat case,
  plus prior assertions unchanged.
- `npx tsc --noEmit` — clean.

Bead: cave-0tkwx
