### PR TITLE
Add accessible iOS terminal composer

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Models/TerminalCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/TerminalCommand.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// The small command vocabulary owned by the native terminal composer.
+///
+/// This deliberately does not share chat's slash catalog: terminal input is
+/// shell input by default, so an unrecognised slash token must reach the PTY.
+enum TerminalCommand: Equatable {
+    case help
+    case clear
+    case chooseWorkingDirectory
+
+    struct Suggestion: Identifiable, Equatable {
+        let command: TerminalCommand
+        let name: String
+        let description: String
+
+        var id: String { name }
+    }
+
+    enum Disposition: Equatable {
+        case local(TerminalCommand)
+        case send(String)
+        case empty
+    }
+
+    static let suggestions = [
+        Suggestion(command: .help, name: "/help", description: "Show terminal commands"),
+        Suggestion(command: .clear, name: "/clear", description: "Clear the shell screen"),
+        Suggestion(command: .chooseWorkingDirectory, name: "/cwd", description: "Choose a working directory"),
+    ]
+
+    /// Recognise only the terminal vocabulary. Everything else, including
+    /// absolute paths such as `/usr/bin/env`, remains shell input.
+    static func parse(_ draft: String) -> Disposition {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .empty }
+
+        let token = trimmed
+            .split(maxSplits: 1, whereSeparator: \.isWhitespace)
+            .first
+            .map(String.init)?
+            .lowercased()
+
+        switch token {
+        case "/help", "/?":
+            return .local(.help)
+        case "/clear", "/cls":
+            return .local(.clear)
+        case "/cwd":
+            return .local(.chooseWorkingDirectory)
+        default:
+            return .send(trimmed)
+        }
+    }
+
+    static func matches(_ draft: String) -> [Suggestion] {
+        guard draft.hasPrefix("/"), !draft.contains(where: \.isWhitespace) else { return [] }
+        let query = draft.lowercased()
+        return suggestions.filter { $0.name.hasPrefix(query) }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Models/TerminalCommand.swift
+++ b/apps/ios/CovenCave/CovenCave/Models/TerminalCommand.swift
@@ -35,13 +35,7 @@ enum TerminalCommand: Equatable {
         let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return .empty }
 
-        let token = trimmed
-            .split(maxSplits: 1, whereSeparator: \.isWhitespace)
-            .first
-            .map(String.init)?
-            .lowercased()
-
-        switch token {
+        switch trimmed.lowercased() {
         case "/help", "/?":
             return .local(.help)
         case "/clear", "/cls":

--- a/apps/ios/CovenCave/CovenCave/State/AppModel.swift
+++ b/apps/ios/CovenCave/CovenCave/State/AppModel.swift
@@ -44,6 +44,29 @@ struct ToastMessage: Identifiable, Equatable {
     var style: Style = .info
 }
 
+/// A one-shot, operator-reviewed transfer from Terminal to a new chat.
+///
+/// The value is prefilled into chat but is never submitted by this handoff.
+struct TerminalFamiliarHandoff: Equatable {
+    let draft: String
+    let cwd: String?
+
+    var chatDraft: String {
+        let location = cwd ?? "Home"
+        return """
+        Please review this terminal input before I run it.
+
+        Working directory: \(location)
+
+        ```shell
+        \(draft)
+        ```
+
+        Explain what it does and flag risks. Do not execute anything.
+        """
+    }
+}
+
 @Observable
 @MainActor
 final class AppModel {
@@ -152,6 +175,9 @@ final class AppModel {
     var navigationDrawerOpen = false
     var newChatRequested = false
     var chatSearchRequested = false
+    /// Held only while the New Chat flow is selecting a familiar and project.
+    /// `applyTerminalFamiliarHandoff` turns it into an ordinary unsent chat draft.
+    var terminalFamiliarHandoff: TerminalFamiliarHandoff?
 
     /// The active confirmation toast, auto-dismissed by the overlay.
     var toast: ToastMessage?
@@ -198,6 +224,24 @@ final class AppModel {
     func requestOpen(_ thread: ChatThread) {
         selectedTab = .chats
         threadToOpen = thread
+    }
+
+    func requestTerminalFamiliarHandoff(draft: String, cwd: String?) {
+        let trimmed = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        terminalFamiliarHandoff = TerminalFamiliarHandoff(draft: trimmed, cwd: cwd)
+        selectedTab = .chats
+        newChatRequested = true
+    }
+
+    func applyTerminalFamiliarHandoff(to thread: ChatThread) {
+        guard let handoff = terminalFamiliarHandoff else { return }
+        setThreadDraft(thread.id, text: handoff.chatDraft)
+        terminalFamiliarHandoff = nil
+    }
+
+    func cancelTerminalFamiliarHandoff() {
+        terminalFamiliarHandoff = nil
     }
 
     /// Switch the visible conversation to one chosen in the session picker.

--- a/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
@@ -100,9 +100,16 @@ struct ChatsHomeView: View {
             .safeAreaInset(edge: .bottom, spacing: 0) { homeSearchBar }
             .sheet(
                 isPresented: $showNewChat,
-                onDismiss: { fixedNewChatFamiliarId = nil }
+                onDismiss: {
+                    fixedNewChatFamiliarId = nil
+                    app.cancelTerminalFamiliarHandoff()
+                }
             ) {
-                NewChatView(fixedFamiliarId: fixedNewChatFamiliarId) { thread in
+                NewChatView(
+                    fixedFamiliarId: fixedNewChatFamiliarId,
+                    initialProjectRoot: app.terminalFamiliarHandoff?.cwd
+                ) { thread in
+                    app.applyTerminalFamiliarHandoff(to: thread)
                     showNewChat = false
                     open(.thread(thread))
                 }

--- a/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/NewChatView.swift
@@ -35,12 +35,14 @@ struct NewChatView: View {
     init(
         initialFamiliarIds: [String] = [],
         fixedFamiliarId: String? = nil,
+        initialProjectRoot: String? = nil,
         onStart: @escaping (ChatThread) -> Void
     ) {
         self.fixedFamiliarId = fixedFamiliarId
         self.onStart = onStart
         let seededFamiliarIds = fixedFamiliarId.map { [$0] } ?? initialFamiliarIds
         _selected = State(initialValue: Set(seededFamiliarIds))
+        _selectedProjectRoot = State(initialValue: initialProjectRoot)
     }
 
     var body: some View {

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalComposer.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalComposer.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Accessible native input for the terminal. It intentionally sits outside the
+/// web view so VoiceOver, Dynamic Type, paste, and native focus all work.
+struct TerminalComposer: View {
+    @Binding var draft: String
+    let connected: Bool
+    let exited: Bool
+    let onSend: (String) -> Void
+    let onCommand: (TerminalCommand) -> Void
+    let onAskFamiliar: () -> Void
+
+    @FocusState private var focused: Bool
+
+    private var canSend: Bool {
+        connected && !exited
+            && !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var suggestions: [TerminalCommand.Suggestion] {
+        TerminalCommand.matches(draft)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if !suggestions.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(suggestions) { suggestion in
+                            Button {
+                                draft = suggestion.name
+                                focused = true
+                            } label: {
+                                Label(suggestion.name, systemImage: "command")
+                                    .font(.caption.weight(.semibold))
+                            }
+                            .buttonStyle(.bordered)
+                            .accessibilityLabel("\(suggestion.name), \(suggestion.description)")
+                        }
+                    }
+                }
+                .accessibilityLabel("Terminal command suggestions")
+            }
+
+            HStack(alignment: .bottom, spacing: 8) {
+                TextField("Command or shell input", text: $draft, axis: .vertical)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .font(.body)
+                    .lineLimit(1...5)
+                    .focused($focused)
+                    .submitLabel(.send)
+                    .onSubmit(send)
+                    .onKeyPress(keys: [.return]) { press in
+                        guard !press.modifiers.contains(.shift), canSend else { return .ignored }
+                        send()
+                        return .handled
+                    }
+                    .accessibilityLabel("Terminal command or shell input")
+                    .accessibilityHint(
+                        connected && !exited
+                            ? "Return sends. Shift Return adds a line. Type slash to discover terminal commands."
+                            : "Your draft is preserved until the terminal reconnects."
+                    )
+
+                Button(action: send) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.title2)
+                }
+                .buttonStyle(.borderless)
+                .disabled(!canSend)
+                .accessibilityLabel("Send to terminal")
+
+                Button(action: onAskFamiliar) {
+                    Image(systemName: "sparkles")
+                        .font(.title3)
+                }
+                .buttonStyle(.borderless)
+                .disabled(draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityLabel("Ask Familiar")
+                .accessibilityHint("Opens chat with this draft and working directory for review. Nothing runs automatically.")
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.thinMaterial)
+        .accessibilityElement(children: .contain)
+    }
+
+    private func send() {
+        guard canSend else { return }
+        switch TerminalCommand.parse(draft) {
+        case .local(let command):
+            draft = ""
+            onCommand(command)
+        case .send(let input):
+            draft = ""
+            onSend(input + "\n")
+        case .empty:
+            break
+        }
+    }
+}

--- a/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/TerminalView.swift
@@ -18,6 +18,8 @@ struct TerminalView: View {
     @State private var showingNewShorthand = false
     @State private var showingProjectPicker = false
     @State private var newShorthand = ""
+    @State private var draft = ""
+    @State private var showingTerminalHelp = false
 
     /// Per-cwd thread id → one durable shell per working directory.
     private var threadId: String { "ios-terminal::" + (cwd ?? "home") }
@@ -75,6 +77,16 @@ struct TerminalView: View {
             )
             .ignoresSafeArea(.container, edges: .bottom)
             Divider()
+            TerminalComposer(
+                draft: $draft,
+                connected: terminal.connected,
+                exited: terminal.exited,
+                onSend: { terminal.sendInput($0) },
+                onCommand: dispatchTerminalCommand,
+                onAskFamiliar: {
+                    app.requestTerminalFamiliarHandoff(draft: draft, cwd: cwd)
+                }
+            )
             keyRow
         }
         .task { if !app.projectsLoaded { await app.loadProjects() } }
@@ -115,6 +127,11 @@ struct TerminalView: View {
             Button("Cancel", role: .cancel) { newShorthand = "" }
         } message: {
             Text("This command is stored on this phone.")
+        }
+        .alert("Terminal commands", isPresented: $showingTerminalHelp) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("/clear clears the shell screen. /cwd chooses a working directory. Unknown slash input is sent to your shell.")
         }
     }
 
@@ -225,6 +242,17 @@ struct TerminalView: View {
         guard let wsBase = app.connection?.wsBaseURL else { return }
         terminal.connect(wsBase: wsBase, threadId: threadId,
                          projectRoot: cwd, cols: cols, rows: rows)
+    }
+
+    private func dispatchTerminalCommand(_ command: TerminalCommand) {
+        switch command {
+        case .help:
+            showingTerminalHelp = true
+        case .clear:
+            terminal.sendInput("clear\n")
+        case .chooseWorkingDirectory:
+            showingProjectPicker = true
+        }
     }
 
     private func switchCwd(_ root: String?) {

--- a/apps/ios/CovenCave/CovenCaveTests/TerminalComposerTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/TerminalComposerTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import CovenCave
+
+@MainActor
+final class TerminalComposerTests: XCTestCase {
+    func testRecognisedTerminalCommandsStayLocal() {
+        XCTAssertEqual(TerminalCommand.parse("/help"), .local(.help))
+        XCTAssertEqual(TerminalCommand.parse("/cls"), .local(.clear))
+        XCTAssertEqual(TerminalCommand.parse("/cwd"), .local(.chooseWorkingDirectory))
+    }
+
+    func testUnknownSlashInputPassesThroughToShell() {
+        XCTAssertEqual(
+            TerminalCommand.parse("/usr/bin/env swift --version"),
+            .send("/usr/bin/env swift --version")
+        )
+        XCTAssertEqual(TerminalCommand.parse("/workspace/scripts/check"), .send("/workspace/scripts/check"))
+    }
+
+    func testSuggestionsAreTerminalSpecific() {
+        XCTAssertEqual(TerminalCommand.matches("/c").map(\.name), ["/clear", "/cwd"])
+        XCTAssertTrue(TerminalCommand.matches("/clear now").isEmpty)
+    }
+
+    func testAskFamiliarHandoffIsAnUnsentChatDraftWithCwd() {
+        let app = AppModel()
+        app.selectedTab = .terminal
+        app.requestTerminalFamiliarHandoff(draft: "git status", cwd: "/repo")
+
+        XCTAssertEqual(app.selectedTab, .chats)
+        XCTAssertTrue(app.newChatRequested)
+        XCTAssertEqual(app.terminalFamiliarHandoff?.draft, "git status")
+        XCTAssertEqual(app.terminalFamiliarHandoff?.cwd, "/repo")
+
+        let thread = ChatThread(title: "Review", familiarIds: ["nova"], projectRoot: "/repo")
+        app.applyTerminalFamiliarHandoff(to: thread)
+
+        XCTAssertNil(app.terminalFamiliarHandoff)
+        XCTAssertTrue(app.threadDrafts[thread.id]?.contains("git status") == true)
+        XCTAssertTrue(app.threadDrafts[thread.id]?.contains("Working directory: /repo") == true)
+    }
+}

--- a/apps/ios/CovenCave/CovenCaveTests/TerminalComposerTests.swift
+++ b/apps/ios/CovenCave/CovenCaveTests/TerminalComposerTests.swift
@@ -14,6 +14,7 @@ final class TerminalComposerTests: XCTestCase {
             TerminalCommand.parse("/usr/bin/env swift --version"),
             .send("/usr/bin/env swift --version")
         )
+        XCTAssertEqual(TerminalCommand.parse("/clear now"), .send("/clear now"))
         XCTAssertEqual(TerminalCommand.parse("/workspace/scripts/check"), .send("/workspace/scripts/check"))
     }
 

--- a/scripts/ios-terminal-composer.test.mjs
+++ b/scripts/ios-terminal-composer.test.mjs
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const read = (path) => readFile(new URL(`../${path}`, import.meta.url), "utf8");
+const parser = await read("apps/ios/CovenCave/CovenCave/Models/TerminalCommand.swift");
+const composer = await read("apps/ios/CovenCave/CovenCave/Views/TerminalComposer.swift");
+const terminal = await read("apps/ios/CovenCave/CovenCave/Views/TerminalView.swift");
+const model = await read("apps/ios/CovenCave/CovenCave/State/AppModel.swift");
+const chats = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift");
+
+assert.match(
+  parser,
+  /case "\/help", "\/\?":[\s\S]*?case "\/clear", "\/cls":[\s\S]*?case "\/cwd":/,
+  "the parser should own exactly the terminal's local command vocabulary",
+);
+assert.match(
+  parser,
+  /default:\s*return \.send\(trimmed\)/,
+  "unknown slash-prefixed input must pass through unchanged to the shell",
+);
+assert.match(
+  composer,
+  /TextField\("Command or shell input", text: \$draft, axis: \.vertical\)[\s\S]*?\.lineLimit\(1\.\.\.5\)[\s\S]*?\.onSubmit\(send\)/,
+  "the native composer should support multiline editing and submit",
+);
+assert.match(
+  composer,
+  /onSend\(input \+ "\\n"\)/,
+  "sending must append exactly one newline at the native boundary",
+);
+assert.match(
+  composer,
+  /\.disabled\(!canSend\)[\s\S]*?accessibilityLabel\("Send to terminal"\)/,
+  "disconnected/exited sessions must preserve instead of dropping a draft",
+);
+assert.match(
+  terminal,
+  /XtermWebView\([\s\S]*?onInput: \{ terminal\.sendInput\(\$0\) \}[\s\S]*?TerminalComposer\(/,
+  "the native composer must sit outside the existing Xterm input path",
+);
+assert.match(
+  model,
+  /struct TerminalFamiliarHandoff[\s\S]*?func requestTerminalFamiliarHandoff[\s\S]*?selectedTab = \.chats[\s\S]*?newChatRequested = true/,
+  "Ask Familiar should hand off draft and cwd through the native chat flow",
+);
+assert.match(
+  chats,
+  /initialProjectRoot: app\.terminalFamiliarHandoff\?\.cwd[\s\S]*?app\.applyTerminalFamiliarHandoff\(to: thread\)/,
+  "the chat handoff should retain cwd and prefill the new chat",
+);
+assert.doesNotMatch(
+  model,
+  /requestTerminalFamiliarHandoff[\s\S]{0,1000}\.send\(/,
+  "Ask Familiar must never execute an AI-produced or terminal command",
+);
+
+console.log("ios-terminal-composer: OK");

--- a/scripts/ios-terminal-composer.test.mjs
+++ b/scripts/ios-terminal-composer.test.mjs
@@ -10,8 +10,8 @@ const chats = await read("apps/ios/CovenCave/CovenCave/Views/ChatsHomeView.swift
 
 assert.match(
   parser,
-  /case "\/help", "\/\?":[\s\S]*?case "\/clear", "\/cls":[\s\S]*?case "\/cwd":/,
-  "the parser should own exactly the terminal's local command vocabulary",
+  /switch trimmed\.lowercased\(\) \{[\s\S]*?case "\/help", "\/\?":[\s\S]*?case "\/clear", "\/cls":[\s\S]*?case "\/cwd":/,
+  "the parser should locally handle only exact terminal command strings",
 );
 assert.match(
   parser,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1606,6 +1606,7 @@ export const SUITES = {
     "scripts/ios-chat-thread-no-search.test.mjs",
     "scripts/ios-chat-tab-free.test.mjs",
     "scripts/ios-development-terminal-chrome.test.mjs",
+    "scripts/ios-terminal-composer.test.mjs",
     "scripts/ios-surface-failures.test.mjs",
     "scripts/ios-surface-load-discipline.test.mjs",
     "scripts/mobile-tailscale.test.mjs",


### PR DESCRIPTION
## Summary
- add a native, VoiceOver-friendly terminal composer outside XtermWebView with multiline, submit, slash discovery, and draft preservation
- keep local terminal commands separate from shell slash input and preserve existing PTY/Xterm paths
- hand Ask Familiar drafts and cwd into an unsent native chat draft

## Verification
- `node scripts/ios-terminal-composer.test.mjs`
- `pnpm test:mobile`
- `pnpm check:tests-wired`
- `xcodebuild -project CovenCave.xcodeproj -scheme CovenCave -sdk iphonesimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test ... -only-testing:CovenCaveTests/TerminalComposerTests`

Bead: `cave-nv1dk.2`