### PR TITLE
Diagnose managed npm cold-start timeouts

### DIFF
--- a/src/lib/server/managed-node-toolchain.test.ts
+++ b/src/lib/server/managed-node-toolchain.test.ts
@@ -199,8 +199,70 @@ test("managed Node probe gives npm a cold-start budget without slowing the Node 
     assert.equal(probe.status, "ready");
     assert.deepEqual(calls.map(({ args, timeout }) => ({ args, timeout })), [
       { args: ["--version"], timeout: 1_500 },
-      { args: [paths.npmCli, "--version"], timeout: 10_000 },
+      { args: [paths.npmCli, "--version"], timeout: 15_000 },
     ]);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("managed Node probe labels npm timeouts with an actionable deadline", async () => {
+  const home = await mkdtemp(path.join(tmpdir(), "coven-managed-node-timeout-"));
+  const env = { NODE_ENV: "test" } satisfies NodeJS.ProcessEnv;
+  const paths = managedNodePaths("linux", "x64", env, home);
+  assert.ok(paths);
+  await mkdir(path.dirname(paths.node), { recursive: true });
+  await mkdir(path.dirname(paths.npmCli), { recursive: true });
+  await writeFile(paths.node, "");
+  await writeFile(paths.npmCli, "");
+
+  try {
+    const probe = await probeManagedNodeToolchain({
+      platform: "linux",
+      architecture: "x64",
+      env,
+      home,
+      exec: async (_command, args) => {
+        if (args[0] === "--version") return { stdout: `v${MANAGED_NODE_VERSION}\n`, stderr: "" };
+        throw Object.assign(new Error("Command failed"), { killed: true, signal: "SIGTERM" });
+      },
+    });
+
+    assert.equal(probe.status, "unusable");
+    assert.match(probe.detail, /Managed npm probe timed out after 15000ms/);
+    assert.match(probe.detail, /Retry setup/);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
+test("managed Node probe preserves non-timeout errors", async () => {
+  const home = await mkdtemp(path.join(tmpdir(), "coven-managed-node-error-"));
+  const env = { NODE_ENV: "test" } satisfies NodeJS.ProcessEnv;
+  const paths = managedNodePaths("linux", "x64", env, home);
+  assert.ok(paths);
+  await mkdir(path.dirname(paths.node), { recursive: true });
+  await mkdir(path.dirname(paths.npmCli), { recursive: true });
+  await writeFile(paths.node, "");
+  await writeFile(paths.npmCli, "");
+
+  try {
+    const probe = await probeManagedNodeToolchain({
+      platform: "linux",
+      architecture: "x64",
+      env,
+      home,
+      exec: async (_command, args) => {
+        if (args[0] === "--version") return { stdout: `v${MANAGED_NODE_VERSION}\n`, stderr: "" };
+        throw new Error("npm package metadata is corrupt");
+      },
+    });
+
+    assert.deepEqual(probe, {
+      status: "unusable",
+      detail: "npm package metadata is corrupt",
+      paths,
+    });
   } finally {
     await rm(home, { recursive: true, force: true });
   }

--- a/src/lib/server/managed-node-toolchain.ts
+++ b/src/lib/server/managed-node-toolchain.ts
@@ -16,7 +16,7 @@ import { extractSafeTarGz, extractSafeZip } from "./managed-node-archive.ts";
 const execFileAsync = promisify(execFile);
 const INSTALL_TIMEOUT_MS = 5 * 60_000;
 const NODE_PROBE_TIMEOUT_MS = 1_500;
-const NPM_PROBE_TIMEOUT_MS = 10_000;
+const NPM_PROBE_TIMEOUT_MS = 15_000;
 
 export type ManagedNodePaths = {
   platform: ManagedNodePlatform;
@@ -42,6 +42,30 @@ type ManagedNodeProbeExec = (
   args: readonly string[],
   options: { env: NodeJS.ProcessEnv; timeout: number },
 ) => Promise<{ stdout: string; stderr: string }>;
+
+function isProbeTimeout(error: unknown): boolean {
+  if (!error || typeof error !== "object") return false;
+  const processError = error as { code?: unknown; killed?: unknown };
+  return processError.killed === true || processError.code === "ETIMEDOUT";
+}
+
+async function runManagedNodeProbe(
+  run: ManagedNodeProbeExec,
+  label: "Node.js" | "npm",
+  file: string,
+  args: readonly string[],
+  env: NodeJS.ProcessEnv,
+  timeout: number,
+): Promise<{ stdout: string; stderr: string }> {
+  try {
+    return await run(file, args, { env, timeout });
+  } catch (error) {
+    if (!isProbeTimeout(error)) throw error;
+    throw new Error(
+      `Managed ${label} probe timed out after ${timeout}ms. Retry setup; on Windows, antivirus scanning may delay the first launch.`,
+    );
+  }
+}
 
 function supportedPlatform(platform: NodeJS.Platform): platform is ManagedNodePlatform {
   return platform === "win32" || platform === "darwin" || platform === "linux";
@@ -137,8 +161,8 @@ export async function probeManagedNodeToolchain(
   const run = options.exec ?? execFileAsync;
   try {
     const [{ stdout }, npm] = await Promise.all([
-      run(paths.node, ["--version"], { env, timeout: NODE_PROBE_TIMEOUT_MS }),
-      run(paths.node, [paths.npmCli, "--version"], { env, timeout: NPM_PROBE_TIMEOUT_MS }),
+      runManagedNodeProbe(run, "Node.js", paths.node, ["--version"], env, NODE_PROBE_TIMEOUT_MS),
+      runManagedNodeProbe(run, "npm", paths.node, [paths.npmCli, "--version"], env, NPM_PROBE_TIMEOUT_MS),
     ]);
     if (!npm.stdout.trim()) return { status: "unusable", detail: "npm did not report a version", paths };
     const version = stdout.trim().replace(/^v/, "");


### PR DESCRIPTION
## Summary
- keep the managed Node probe deadline at 1.5 seconds
- allow the heavier npm cold-start probe up to 15 seconds
- replace opaque killed-process errors with labeled, actionable timeout diagnostics while preserving other failures
- add regression coverage for deadlines, timeout reporting, and non-timeout errors

## Verification
- focused managed-node-toolchain tests (10/10)
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` (1585/1585)
- `pnpm test:app` (1146 test files)
- `git diff --check`

Bead: `cave-jircu`
Related: #4355