### PR TITLE
fix(code): make the Code Workshop sessions rail collapsible (recovered work)

### DIFF
--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -122,7 +122,7 @@ export function CodeSessionRail({
                       onSelect(row.id);
                     }}
                     aria-current={selected ? "true" : undefined}
-                    aria-label={open ? undefined : `Open ${title}, ${activity}`}
+                    aria-label={open ? undefined : `Open ${title} in ${group.label}, ${activity}`}
                     title={open ? undefined : title}
                     className={
                       open

--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -51,11 +51,20 @@ export type CodeSessionRailProps = {
   selectedId: string | null;
   onSelect: (sessionId: string) => void;
   onNewSession?: () => void;
+  open?: boolean;
+  onExpand?: () => void;
 };
 
-export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }: CodeSessionRailProps) {
+export function CodeSessionRail({
+  sessions,
+  selectedId,
+  onSelect,
+  onNewSession,
+  open = true,
+  onExpand,
+}: CodeSessionRailProps) {
   const groups = groupCodeRailSessions(sessions);
-  const newButton = onNewSession ? (
+  const newButton = open && onNewSession ? (
     <div className="px-2 pb-1">
       <button
         type="button"
@@ -68,6 +77,9 @@ export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }
     </div>
   ) : null;
   if (groups.length === 0) {
+    if (!open) {
+      return <nav aria-label="Coding sessions" className="flex h-full min-h-0 flex-col" />;
+    }
     return (
       <div className="flex h-full flex-col py-2">
         {newButton}
@@ -79,52 +91,82 @@ export function CodeSessionRail({ sessions, selectedId, onSelect, onNewSession }
     );
   }
   return (
-    <nav aria-label="Coding sessions" className="flex h-full min-h-0 flex-col overflow-y-auto py-2">
-      {newButton}      {groups.map((group) => (
+    <nav
+      aria-label="Coding sessions"
+      className={`flex h-full min-h-0 flex-col ${open ? "overflow-y-auto py-2" : "items-center gap-1"}`}
+    >
+      {newButton}
+      {groups.map((group) => (
         <section key={group.root || "(unknown)"} className="mb-2">
-          <div
-            className="truncate px-3 py-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-[var(--text-secondary)]"
-            title={group.root || undefined}
-          >
-            {group.label}
-          </div>
-          <ul className="flex flex-col">
+          {open ? (
+            <div
+              className="truncate px-3 py-1 text-[length:var(--text-2xs)] font-semibold uppercase tracking-wider text-[var(--text-secondary)]"
+              title={group.root || undefined}
+            >
+              {group.label}
+            </div>
+          ) : null}
+          <ul className={`flex flex-col ${open ? "" : "items-center gap-1"}`}>
             {group.sessions.map((row) => {
               const branch = codeSessionBranch(row);
               const diffstat = codeSessionDiffstat(row);
               const selected = row.id === selectedId;
+              const title = row.title || row.id;
+              const activity = codeSessionActivity(row);
               return (
                 <li key={row.id}>
                   <button
                     type="button"
-                    onClick={() => onSelect(row.id)}
+                    onClick={() => {
+                      onExpand?.();
+                      onSelect(row.id);
+                    }}
                     aria-current={selected ? "true" : undefined}
-                    className={`focus-ring-inset flex w-full flex-col gap-0.5 px-3 py-1.5 text-left ${
-                      selected ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]"
-                    }`}
+                    aria-label={open ? undefined : `Open ${title}, ${activity}`}
+                    title={open ? undefined : title}
+                    className={
+                      open
+                        ? `focus-ring-inset flex w-full flex-col gap-0.5 px-3 py-1.5 text-left ${
+                            selected ? "bg-[var(--bg-hover)]" : "hover:bg-[var(--bg-hover)]"
+                          }`
+                        : `focus-ring relative flex h-8 w-8 items-center justify-center rounded-[var(--radius-sm)] text-[var(--text-muted)] hover:bg-[var(--bg-hover)] hover:text-[var(--text-primary)] ${
+                            selected ? "bg-[var(--bg-hover)] text-[var(--text-primary)]" : ""
+                          }`
+                    }
                   >
-                    <span className="flex min-w-0 items-center gap-1.5">
-                      <ActivityDot row={row} />
-                      <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
-                        {row.title || row.id}
-                      </span>
-                    </span>
-                    {(branch || diffstat || row.pullRequest || row.git?.isWorktree) ? (
-                      <span className="flex min-w-0 items-center gap-1.5 pl-3">
-                        {row.git?.isWorktree ? (
-                          <Icon name="ph:git-fork" width={10} height={10} className="shrink-0 text-[var(--text-muted)]" />
-                        ) : null}
-                        {branch ? (
-                          <span className="min-w-0 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={branch}>
-                            {branch}
+                    {open ? (
+                      <>
+                        <span className="flex min-w-0 items-center gap-1.5">
+                          <ActivityDot row={row} />
+                          <span className="min-w-0 truncate text-[length:var(--text-xs)] text-[var(--text-primary)]">
+                            {title}
+                          </span>
+                        </span>
+                        {(branch || diffstat || row.pullRequest || row.git?.isWorktree) ? (
+                          <span className="flex min-w-0 items-center gap-1.5 pl-3">
+                            {row.git?.isWorktree ? (
+                              <Icon name="ph:git-fork" width={10} height={10} className="shrink-0 text-[var(--text-muted)]" />
+                            ) : null}
+                            {branch ? (
+                              <span className="min-w-0 truncate font-mono text-[length:var(--text-2xs)] text-[var(--text-muted)]" title={branch}>
+                                {branch}
+                              </span>
+                            ) : null}
+                            {diffstat ? (
+                              <span className="shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-secondary)]">{diffstat}</span>
+                            ) : null}
+                            {row.pullRequest ? <PrChip pr={row.pullRequest} /> : null}
                           </span>
                         ) : null}
-                        {diffstat ? (
-                          <span className="shrink-0 font-mono text-[length:var(--text-2xs)] text-[var(--text-secondary)]">{diffstat}</span>
-                        ) : null}
-                        {row.pullRequest ? <PrChip pr={row.pullRequest} /> : null}
-                      </span>
-                    ) : null}
+                      </>
+                    ) : (
+                      <>
+                        <Icon name="ph:terminal-window" width={16} height={16} aria-hidden />
+                        <span className="absolute right-1 top-1">
+                          <ActivityDot row={row} />
+                        </span>
+                      </>
+                    )}
                   </button>
                 </li>
               );

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -501,8 +501,8 @@ assert.match(
 );
 assert.match(
   rail,
-  /aria-label=\{open \? undefined : `Open \$\{title\}, \$\{activity\}`\}/,
-  "collapsed session buttons identify the session and expose activity without relying on color",
+  /aria-label=\{open \? undefined : `Open \$\{title\} in \$\{group\.label\}, \$\{activity\}`\}/,
+  "collapsed session buttons identify the session, project, and activity without relying on color",
 );
 assert.match(
   rail,

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -490,6 +490,27 @@ const newSession = await readFile(new URL("./code-new-session.tsx", import.meta.
 const rail = await readFile(new URL("./code-session-rail.tsx", import.meta.url), "utf8");
 
 assert.match(
+  codeView,
+  /<SurfaceRail[\s\S]*storageKey="cave:code:sessions-rail"[\s\S]*title="Sessions"[\s\S]*ariaLabel="Coding sessions"/,
+  "Code Workshop sessions use the shared persisted left rail",
+);
+assert.match(
+  codeView,
+  /\{fitsRail \? \(\s*<SurfaceRail[\s\S]*\) : \(\s*<div[\s\S]*<CodeSessionRail/,
+  "the measured layout uses the collapsible rail only when it fits and preserves narrow list-first drill-in",
+);
+assert.match(
+  rail,
+  /aria-label=\{open \? undefined : `Open \$\{title\}, \$\{activity\}`\}/,
+  "collapsed session buttons identify the session and expose activity without relying on color",
+);
+assert.match(
+  rail,
+  /onClick=\{\(\) => \{\s*onExpand\?\.\(\);\s*onSelect\(row\.id\);/,
+  "collapsed session buttons expand before selection",
+);
+
+assert.match(
   composer,
   /streamFamiliarText\(\{\s*familiarId: row\.familiarId,\s*sessionId: row\.id,/,
   "the composer RESUMES the selected session (sessionId rides) — never forks a new thread",
@@ -657,7 +678,17 @@ assert.match(
 );
 assert.match(
   codeView,
-  /fitsRail \? "block w-64 border-r" : selected \? "hidden" : "block w-full"/,
+  /\{fitsRail \? \(\s*<SurfaceRail/,
+  "a Room wide enough for both zones uses the collapsible shared sessions rail",
+);
+assert.match(
+  codeView,
+  /defaultWidth=\{CODE_ROOM_RAIL_WIDTH_PX\}/,
+  "the persisted rail starts at the width used by the measured layout model",
+);
+assert.match(
+  codeView,
+  /\$\{selected \? "hidden" : "block w-full"\}/,
   "picking a session hides the rail only while the Room is too narrow for both",
 );
 assert.match(

--- a/src/components/code-view.tsx
+++ b/src/components/code-view.tsx
@@ -22,6 +22,7 @@ import dynamic from "next/dynamic";
 import { Icon } from "@/lib/icon";
 import {
   CODE_GITHUB_TABS,
+  CODE_ROOM_RAIL_WIDTH_PX,
   codeRoomFitsRail,
   codeSessionWorkRoot,
   groupCodeRailSessions,
@@ -36,6 +37,7 @@ import { CodeWorkbench } from "@/components/code-workbench";
 import { CodeNewSession } from "@/components/code-new-session";
 import { CodeSourceContext } from "@/components/code-source-context";
 import { GithubOrganizationSettings } from "@/components/settings-github";
+import { SurfaceRail } from "@/components/ui/surface-rail";
 import type { GitHubItemTarget } from "@/lib/github-item-url";
 import type { PendingCodeOpen } from "@/lib/pending-code-open";
 import { codeTopTabForGitHubTarget, type PendingCodeNavigation } from "@/lib/pending-code-navigation";
@@ -229,6 +231,12 @@ export function CodeView({
       ? workbenchTarget.open.origin
       : null;
   const originSessionId = workbenchTarget?.open.sessionId ?? null;
+  const selectSession = (sessionId: string) => {
+    // A manual switch is a context change — drop any pending file focus so it
+    // cannot replay into the newly picked workbench.
+    setWorkbenchTarget(null);
+    setSelectedId(sessionId);
+  };
 
   const selected = useMemo(() => {
     if (!selectedId) return null;
@@ -316,28 +324,53 @@ export function CodeView({
               rail beside the workbench, the rail is the landing screen and the
               workbench replaces it once a session is picked (Back returns).
               Driven by the Room's measured width, not the viewport — this
-              surface can sit in a split beside another page (cave-k3a9u).
-              w-64 is CODE_ROOM_RAIL_WIDTH_PX. */}
-          <div
-            className={`${
-              fitsRail ? "block w-64 border-r" : selected ? "hidden" : "block w-full"
-            } shrink-0 border-[var(--border-hairline)]`}
-          >
-            <CodeSessionRail
-              sessions={sessions}
-              selectedId={selectedId ?? null}
-              onSelect={(id) => {
-                // A manual switch is a context change — drop any pending file
-                // focus so it can't replay into the newly picked workbench.
-                setWorkbenchTarget(null);
-                setSelectedId(id);
-              }}
-              onNewSession={() => {
-                setNewSessionSeed("");
-                setNewSessionOpen(true);
-              }}
-            />
-          </div>
+              surface can sit in a split beside another page (cave-k3a9u). */}
+          {fitsRail ? (
+            <SurfaceRail
+              storageKey="cave:code:sessions-rail"
+              title="Sessions"
+              ariaLabel="Coding sessions"
+              defaultWidth={CODE_ROOM_RAIL_WIDTH_PX}
+              actions={
+                <button
+                  type="button"
+                  onClick={() => {
+                    setNewSessionSeed("");
+                    setNewSessionOpen(true);
+                  }}
+                  title="New session"
+                  aria-label="New session"
+                  className="focus-ring text-[var(--accent-presence)]"
+                >
+                  <Icon name="ph:plus-bold" width={14} aria-hidden />
+                </button>
+              }
+            >
+              {(open, setOpen) => (
+                <CodeSessionRail
+                  sessions={sessions}
+                  selectedId={selectedId ?? null}
+                  onSelect={selectSession}
+                  open={open}
+                  onExpand={() => setOpen(true)}
+                />
+              )}
+            </SurfaceRail>
+          ) : (
+            <div
+              className={`${selected ? "hidden" : "block w-full"} shrink-0 border-[var(--border-hairline)]`}
+            >
+              <CodeSessionRail
+                sessions={sessions}
+                selectedId={selectedId ?? null}
+                onSelect={selectSession}
+                onNewSession={() => {
+                  setNewSessionSeed("");
+                  setNewSessionOpen(true);
+                }}
+              />
+            </div>
+          )}
           <div
             className={`${selected || fitsRail ? "flex" : "hidden"} min-w-0 flex-1 flex-col`}
           >


### PR DESCRIPTION
Closes cave-47ar4. Unblocks cave-24d2r.1 and its parent cave-24d2r.

## What this is

The Code Workshop sessions rail wrapped in the shared collapsible/resizable
`SurfaceRail`, preserving familiar-scoped grouping, session selection, the
new-session flow, desktop persistence, and mobile list-first behavior.

**This is a recovery, not a reimplementation.** The work was written and fully
verified on 2026-08-08 — `test:app` 1137 files, `test:api` 357,
`check:tests-wired` 1570, typecheck, lint, focused suites, clean review — then
held pending approval and never pushed. By 2026-08-09 its branch
`fix/cave-24d2r-1-code-sessions-rail` was gone locally *and* on the remote, and
its worktree directory with it. The two commits survived only as unreferenced
git objects, one `git gc` from being unrecoverable.

Before anything else, the exact tip was pushed to `origin` as
`fix/cave-24d2r-1-code-sessions-rail` (`94498f63ce`), preserving the original
commits unrebased as an archive. This PR is those same two commits rebased onto
current `main`.

Confirmed unshipped before recovering: neither commit was an ancestor of
`origin/main`, and `main`'s `code-session-rail.tsx` contained no `SurfaceRail`
reference — so this is not residue of something already landed.

## The two commits

- `feat(code): make sessions rail collapsible` — `code-session-rail.tsx`,
  `code-view.tsx`, `code-surface-mode.test.ts`
- `fix(code): preserve project context in collapsed sessions` — collapsed rows
  omitted project context from their accessible names; fixed by including
  `group.label`, with the contract assertion strengthened to match

Rebase onto current `main` applied cleanly with no conflicts. Net diff is three
files, +164/−58 — identical in scope to what was reviewed.

## Verification on the rebased head

| Gate | Result |
| --- | --- |
| `code-surface-mode` | ok |
| `code-surface` | 17/17 |
| `surface-rail` | 10/10 |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean, 0 design drift, 0 ESLint warnings |
| `pnpm check:tests-wired` | all 1585 wired |
| `pnpm test:app` | 1146 files, 0 failures |
| `pnpm test:api` | 362 files, 0 failures |

Both commits are signed and carry no AI-attribution trailers — the archive
snapshot's forbidden trailer was excluded when the work was originally
reconstructed, and that exclusion survives here.

## Note for reviewers

`cave-24d2r.1`'s bead metadata still points at the destroyed worktree, so
`beads:worktrees:create --bead cave-24d2r.1` is refused with "primary structured
worktree metadata is not currently registered". That record was deliberately
left untouched — repairing another owner's lifecycle metadata by hand is what
the worktree rules forbid — which is why this PR is tracked under a fresh bead.
