### PR TITLE
feat(search): query state, filter registry, and deterministic parser (unit 1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -457,6 +457,7 @@ export const SUITES = {
     "src/components/command-palette-polish.test.ts",
     "src/components/command-palette-save-link.test.ts",
     "src/lib/command-palette-search.test.ts",
+    "src/lib/search-query.test.ts",
     "src/lib/command-palette-salem-context.test.ts",
     "src/lib/command-palette-scope.test.ts",
     "src/lib/recent-searches.test.ts",

--- a/src/lib/search-filters.ts
+++ b/src/lib/search-filters.ts
@@ -1,0 +1,330 @@
+/**
+ * search-filters — the versioned query state and the declarative filter
+ * registry behind global intelligent search (cave-ychtl.1).
+ *
+ * The registry is the point of the design: adding a status, an entity type, or
+ * a whole new filter key is a DATA change here, not another branch in the
+ * parser and not another special case in the React surface. Anything that has
+ * to know what a filter means — the parser, the URL serializer, completions,
+ * chip labels, provider applicability — reads it from this table.
+ *
+ * Pure module: no I/O, no React, no clock. Callers that need "now" (relative
+ * dates) pass it in, so every rule here is deterministic and unit-testable.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ * Plan: docs/superpowers/plans/2026-08-09-global-intelligent-search-implementation.md
+ */
+
+/** Query-state version. Bump only with a migration and a fail-closed path. */
+export const SEARCH_QUERY_VERSION = 1;
+
+export type SearchFilterOperator = "is" | "has" | "after" | "before";
+
+/**
+ * Where a filter came from. This is not bookkeeping — it drives behavior:
+ * Command/Control+Enter removes only `context` scopes, and the surface renders
+ * `natural-language` chips so an inferred filter is visible and removable
+ * rather than a hidden reinterpretation of what the user typed.
+ */
+export type SearchFilterOrigin = "syntax" | "natural-language" | "picker" | "context";
+
+export type SearchFilter = {
+  key: string;
+  operator: SearchFilterOperator;
+  value: string | boolean;
+  origin: SearchFilterOrigin;
+};
+
+export type SearchScopeDimension = "project" | "familiar" | "room" | "session" | "runtime";
+
+export type SearchScope = {
+  dimension: SearchScopeDimension;
+  id: string;
+  label: string;
+  /** Derived from the active workspace rather than asked for. */
+  implicit: boolean;
+};
+
+export type SearchPresentation = "top" | "grouped";
+
+export type SearchQueryState = {
+  version: typeof SEARCH_QUERY_VERSION;
+  text: string;
+  phrases: string[];
+  filters: SearchFilter[];
+  scopes: SearchScope[];
+  presentation: SearchPresentation;
+};
+
+export type SearchFilterValueKind = "enum" | "text" | "date";
+
+export type SearchFilterDefinition = {
+  key: string;
+  /** Accepted spellings in `key:value` syntax, besides `key` itself. */
+  aliases: string[];
+  operator: SearchFilterOperator;
+  valueKind: SearchFilterValueKind;
+  /** Whether the registry permits the same key more than once. */
+  multiple: boolean;
+  /** Completion values. Authoritative for `enum`; advisory for `text`. */
+  values: string[];
+  /** Entity types this filter can narrow, or "all". Drives filtered-empty. */
+  entityTypes: string[] | "all";
+  /** Stable URL parameter name; never the raw key, so keys can be renamed. */
+  urlKey: string;
+  chipLabel: (value: string | boolean) => string;
+};
+
+/** MVP entity types. Later provider slices add to this list, not to the parser. */
+export const SEARCH_ENTITY_TYPES = [
+  "project",
+  "familiar",
+  "task",
+  "session",
+  "chat",
+  "file",
+] as const;
+
+export type SearchEntityType = (typeof SEARCH_ENTITY_TYPES)[number];
+
+/** Statuses the MVP providers can express. Data, not parser branches. */
+export const SEARCH_STATUS_VALUES = [
+  "open",
+  "in_progress",
+  "blocked",
+  "done",
+  "closed",
+  "failed",
+  "running",
+] as const;
+
+/** Signals reachable through `has:` — "with errors", "needs a decision". */
+export const SEARCH_HAS_VALUES = [
+  "errors",
+  "decision",
+  "attachment",
+  "files",
+] as const;
+
+const title = (value: string) =>
+  value.length === 0 ? value : `${value[0]!.toUpperCase()}${value.slice(1)}`;
+
+const readableStatus = (value: string | boolean) =>
+  typeof value === "string" ? title(value.replaceAll("_", " ")) : String(value);
+
+export const SEARCH_FILTER_DEFINITIONS: readonly SearchFilterDefinition[] = Object.freeze([
+  {
+    key: "type",
+    aliases: ["kind", "is"],
+    operator: "is",
+    valueKind: "enum",
+    multiple: true,
+    values: [...SEARCH_ENTITY_TYPES],
+    entityTypes: "all",
+    urlKey: "type",
+    chipLabel: (value) => title(String(value)),
+  },
+  {
+    key: "status",
+    aliases: ["state"],
+    operator: "is",
+    valueKind: "enum",
+    multiple: true,
+    values: [...SEARCH_STATUS_VALUES],
+    entityTypes: ["task", "session", "chat"],
+    urlKey: "status",
+    chipLabel: (value) => readableStatus(value),
+  },
+  {
+    key: "project",
+    aliases: ["repo", "workspace"],
+    operator: "is",
+    valueKind: "text",
+    multiple: true,
+    values: [],
+    entityTypes: "all",
+    urlKey: "project",
+    chipLabel: (value) => `Project: ${String(value)}`,
+  },
+  {
+    key: "familiar",
+    aliases: ["agent", "who"],
+    operator: "is",
+    valueKind: "text",
+    multiple: true,
+    values: [],
+    entityTypes: ["task", "session", "chat", "familiar"],
+    urlKey: "familiar",
+    chipLabel: (value) => `Familiar: ${String(value)}`,
+  },
+  {
+    key: "room",
+    aliases: [],
+    operator: "is",
+    valueKind: "text",
+    multiple: false,
+    values: [],
+    entityTypes: ["session", "chat"],
+    urlKey: "room",
+    chipLabel: (value) => `Room: ${String(value)}`,
+  },
+  {
+    key: "runtime",
+    aliases: ["harness"],
+    operator: "is",
+    valueKind: "text",
+    multiple: false,
+    values: [],
+    entityTypes: ["session", "chat"],
+    urlKey: "runtime",
+    chipLabel: (value) => `Runtime: ${String(value)}`,
+  },
+  {
+    key: "source",
+    aliases: [],
+    operator: "is",
+    valueKind: "text",
+    multiple: true,
+    values: [],
+    entityTypes: "all",
+    urlKey: "source",
+    chipLabel: (value) => `Source: ${String(value)}`,
+  },
+  {
+    key: "has",
+    aliases: ["with"],
+    operator: "has",
+    valueKind: "enum",
+    multiple: true,
+    values: [...SEARCH_HAS_VALUES],
+    entityTypes: "all",
+    urlKey: "has",
+    chipLabel: (value) => `Has ${String(value)}`,
+  },
+  {
+    key: "after",
+    aliases: ["since"],
+    operator: "after",
+    valueKind: "date",
+    multiple: false,
+    values: [],
+    entityTypes: "all",
+    urlKey: "after",
+    chipLabel: (value) => `After ${String(value)}`,
+  },
+  {
+    key: "before",
+    aliases: ["until"],
+    operator: "before",
+    valueKind: "date",
+    multiple: false,
+    values: [],
+    entityTypes: "all",
+    urlKey: "before",
+    chipLabel: (value) => `Before ${String(value)}`,
+  },
+  {
+    key: "tag",
+    aliases: ["label"],
+    operator: "is",
+    valueKind: "text",
+    multiple: true,
+    values: [],
+    entityTypes: "all",
+    urlKey: "tag",
+    chipLabel: (value) => `#${String(value)}`,
+  },
+]);
+
+const BY_LOOKUP: ReadonlyMap<string, SearchFilterDefinition> = (() => {
+  const map = new Map<string, SearchFilterDefinition>();
+  for (const definition of SEARCH_FILTER_DEFINITIONS) {
+    map.set(definition.key, definition);
+    for (const alias of definition.aliases) map.set(alias, definition);
+  }
+  return map;
+})();
+
+const BY_URL_KEY: ReadonlyMap<string, SearchFilterDefinition> = new Map(
+  SEARCH_FILTER_DEFINITIONS.map((definition) => [definition.urlKey, definition]),
+);
+
+/** Resolve a typed key or alias, case-insensitively. */
+export function filterDefinition(key: string): SearchFilterDefinition | null {
+  return BY_LOOKUP.get(key.trim().toLowerCase()) ?? null;
+}
+
+export function filterDefinitionForUrlKey(urlKey: string): SearchFilterDefinition | null {
+  return BY_URL_KEY.get(urlKey) ?? null;
+}
+
+/** ISO calendar date, the only date shape `after`/`before` accept. */
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isIsoCalendarDate(value: string): boolean {
+  if (!ISO_DATE.test(value)) return false;
+  const parsed = new Date(`${value}T00:00:00Z`);
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().startsWith(value);
+}
+
+/**
+ * Whether `value` is acceptable for `definition`.
+ *
+ * A rejection is never an error: the caller leaves the token in searchable text
+ * and offers completions instead. That is what keeps the spec's promise that
+ * search never fails because someone typed a colon.
+ */
+export function isValidFilterValue(
+  definition: SearchFilterDefinition,
+  value: string,
+): boolean {
+  if (value.length === 0) return false;
+  if (definition.valueKind === "enum") {
+    return definition.values.includes(value.toLowerCase());
+  }
+  if (definition.valueKind === "date") return isIsoCalendarDate(value);
+  return true;
+}
+
+/** Completions for a partially typed key, in registry order. */
+export function completeFilterKeys(prefix: string): SearchFilterDefinition[] {
+  const needle = prefix.trim().toLowerCase();
+  return SEARCH_FILTER_DEFINITIONS.filter(
+    (definition) =>
+      definition.key.startsWith(needle) ||
+      definition.aliases.some((alias) => alias.startsWith(needle)),
+  );
+}
+
+/** Completions for a partially typed value of a known key. */
+export function completeFilterValues(
+  definition: SearchFilterDefinition,
+  prefix: string,
+): string[] {
+  const needle = prefix.trim().toLowerCase();
+  return definition.values.filter((value) => value.startsWith(needle));
+}
+
+/** Whether a filter can narrow an entity type at all — drives filtered-empty. */
+export function filterAppliesToEntity(
+  definition: SearchFilterDefinition,
+  entityType: string,
+): boolean {
+  return definition.entityTypes === "all" || definition.entityTypes.includes(entityType);
+}
+
+export function chipLabelFor(filter: SearchFilter): string {
+  const definition = filterDefinition(filter.key);
+  return definition ? definition.chipLabel(filter.value) : `${filter.key}: ${String(filter.value)}`;
+}
+
+export function emptySearchQueryState(): SearchQueryState {
+  return {
+    version: SEARCH_QUERY_VERSION,
+    text: "",
+    phrases: [],
+    filters: [],
+    scopes: [],
+    presentation: "top",
+  };
+}

--- a/src/lib/search-query.test.ts
+++ b/src/lib/search-query.test.ts
@@ -1,0 +1,378 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  broadenToGlobal,
+  parseSearchQuery,
+  searchQueryFromUrlParams,
+  searchQueryToUrlParams,
+  searchQueryToUrlString,
+} from "./search-query.ts";
+import {
+  chipLabelFor,
+  completeFilterKeys,
+  completeFilterValues,
+  emptySearchQueryState,
+  filterAppliesToEntity,
+  filterDefinition,
+  isIsoCalendarDate,
+  SEARCH_FILTER_DEFINITIONS,
+  SEARCH_QUERY_VERSION,
+} from "./search-filters.ts";
+
+/** Filters as `key=value` pairs, so table rows stay readable. */
+const pairs = (state) => state.filters.map((filter) => `${filter.key}=${String(filter.value)}`).sort();
+const parse = (input, options) => parseSearchQuery(input, options);
+
+/* ---------------------------------------------------------------------- */
+/* Lexical parsing                                                         */
+/* ---------------------------------------------------------------------- */
+
+// Free text survives untouched.
+{
+  const { state } = parse("rename the composer", { naturalLanguage: false });
+  assert.equal(state.text, "rename the composer");
+  assert.deepEqual(state.filters, []);
+  assert.deepEqual(state.phrases, []);
+  assert.equal(state.version, SEARCH_QUERY_VERSION);
+  assert.equal(state.presentation, "top");
+}
+
+// Quoted exact phrases leave the free text.
+{
+  const { state } = parse('composer "exact phrase" tail', { naturalLanguage: false });
+  assert.deepEqual(state.phrases, ["exact phrase"]);
+  assert.equal(state.text, "composer tail");
+}
+
+// key:value filters, including a quoted multi-word value.
+{
+  const { state } = parse('type:task status:blocked room:"code workshop"', {
+    naturalLanguage: false,
+  });
+  assert.deepEqual(pairs(state), ["room=code workshop", "status=blocked", "type=task"]);
+  assert.equal(state.text, "");
+  assert.equal(
+    state.filters.every((filter) => filter.origin === "syntax"),
+    true,
+    "typed filters are attributed to syntax, not inference",
+  );
+}
+
+// Aliases resolve to the canonical key.
+{
+  const { state } = parse("kind:task label:ux agent:cody", { naturalLanguage: false });
+  assert.deepEqual(pairs(state), ["familiar=cody", "tag=ux", "type=task"]);
+}
+
+// Operators come from the registry, not from the token shape.
+{
+  const { state } = parse("has:errors after:2026-08-01 before:2026-08-09", {
+    naturalLanguage: false,
+  });
+  const byKey = Object.fromEntries(state.filters.map((filter) => [filter.key, filter.operator]));
+  assert.deepEqual(byKey, { has: "has", after: "after", before: "before" });
+}
+
+/* ---------------------------------------------------------------------- */
+/* Forgiveness — the load-bearing contract                                 */
+/* ---------------------------------------------------------------------- */
+
+// THE rule: a colon never breaks search. Every malformed shape below stays
+// searchable text, and none of them throws.
+for (const input of [
+  "ratio:",
+  "nonsense:value",
+  "status:",
+  "status:not-a-status",
+  "after:not-a-date",
+  "after:2026-13-45",
+  ":leading",
+  'unmatched "quote here',
+  "http://example.com/path",
+]) {
+  const result = parse(input, { naturalLanguage: false });
+  assert.ok(result.state.text.length > 0, `"${input}" must remain searchable text`);
+  assert.deepEqual(result.state.filters, [], `"${input}" must not produce a filter`);
+}
+
+// An unknown key offers key completions when it is a near miss.
+{
+  const { suggestions } = parse("stat:blocked", { naturalLanguage: false });
+  const keys = suggestions.find((entry) => entry.kind === "filter-key");
+  assert.ok(keys, "a near-miss key suggests real keys");
+  assert.ok(keys.options.includes("status"));
+}
+
+// A known key with no value offers its values.
+{
+  const { state, suggestions } = parse("status:", { naturalLanguage: false });
+  assert.equal(state.text, "status:");
+  const values = suggestions.find((entry) => entry.kind === "filter-value");
+  assert.equal(values.key, "status");
+  assert.ok(values.options.includes("blocked"));
+}
+
+// A known key with a bad value suggests the near matches only.
+{
+  const { suggestions } = parse("status:blo", { naturalLanguage: false });
+  const values = suggestions.find((entry) => entry.kind === "filter-value");
+  assert.deepEqual(values.options, ["blocked"]);
+}
+
+// An unmatched quote is reported but its content stays searchable.
+{
+  const { state, suggestions } = parse('alpha "beta gamma', { naturalLanguage: false });
+  assert.equal(state.text, "alpha beta gamma");
+  assert.deepEqual(state.phrases, []);
+  assert.ok(suggestions.some((entry) => entry.kind === "unmatched-quote"));
+}
+
+// An empty quoted string is dropped rather than becoming a match-everything phrase.
+{
+  const { state } = parse('alpha "" beta', { naturalLanguage: false });
+  assert.deepEqual(state.phrases, []);
+  assert.equal(state.text, "alpha beta");
+}
+
+/* ---------------------------------------------------------------------- */
+/* Repetition, per the registry                                            */
+/* ---------------------------------------------------------------------- */
+
+// `type` permits multiple values, so both survive.
+{
+  const { state } = parse("type:task type:session", { naturalLanguage: false });
+  assert.deepEqual(pairs(state), ["type=session", "type=task"]);
+}
+
+// `room` does not, so the later value corrects the earlier one.
+{
+  const { state } = parse("room:alpha room:beta", { naturalLanguage: false });
+  assert.deepEqual(pairs(state), ["room=beta"]);
+}
+
+// An exact repeat is idempotent rather than duplicated.
+{
+  const { state } = parse("tag:ux tag:ux", { naturalLanguage: false });
+  assert.deepEqual(pairs(state), ["tag=ux"]);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Deterministic natural language                                          */
+/* ---------------------------------------------------------------------- */
+
+const now = new Date("2026-08-09T12:00:00Z");
+
+// The spec's worked example, chip for chip — and "show" must not survive as
+// search text, or every result would have to contain the word "show".
+{
+  const { state } = parse("show blocked tasks for Cody", { now });
+  assert.deepEqual(pairs(state), ["familiar=Cody", "status=blocked", "type=task"]);
+  assert.equal(state.text, "");
+  assert.equal(
+    state.filters.every((filter) => filter.origin === "natural-language"),
+    true,
+    "inferred filters are attributed so the surface can show them as removable chips",
+  );
+}
+
+// The spec's other pairing.
+{
+  const { state } = parse("failed sessions", { now });
+  assert.deepEqual(pairs(state), ["status=failed", "type=session"]);
+}
+
+// Project by name.
+{
+  const { state } = parse("in Psyche Build", { now });
+  assert.deepEqual(pairs(state), ["project=Psyche Build"]);
+}
+
+// Signals.
+{
+  assert.deepEqual(pairs(parse("with errors", { now }).state), ["has=errors"]);
+  assert.deepEqual(pairs(parse("needs a decision", { now }).state), ["has=decision"]);
+}
+
+// Relative dates resolve against the caller's clock, not a hidden one.
+{
+  assert.deepEqual(pairs(parse("today", { now }).state), ["after=2026-08-09"]);
+  assert.deepEqual(pairs(parse("yesterday", { now }).state), [
+    "after=2026-08-08",
+    "before=2026-08-09",
+  ]);
+  assert.deepEqual(pairs(parse("last week", { now }).state), ["after=2026-08-02"]);
+  assert.deepEqual(pairs(parse("last 3 days", { now }).state), ["after=2026-08-06"]);
+}
+
+// With no clock supplied, date language is left alone rather than guessed.
+{
+  const { state } = parse("last week", {});
+  assert.deepEqual(state.filters, []);
+  assert.equal(state.text, "last week");
+}
+
+// Ambiguity is preserved, never silently interpreted.
+for (const input of ["blocked", "sessions", "for", "in", "cody"]) {
+  const { state } = parse(input, { now });
+  assert.deepEqual(state.filters, [], `"${input}" is ambiguous and must not infer a filter`);
+  assert.equal(state.text, input);
+}
+
+// A lowercase name after "for" is not a proper noun, so it stays text.
+{
+  const { state } = parse("notes for tomorrow", { now });
+  assert.deepEqual(state.filters, []);
+  assert.equal(state.text, "notes for tomorrow");
+}
+
+// Typed syntax and inference compose, and typed values are not overwritten.
+{
+  const { state } = parse("type:file blocked tasks", { now });
+  assert.deepEqual(pairs(state), ["status=blocked", "type=file", "type=task"]);
+}
+
+// Language rules can be turned off wholesale.
+{
+  const { state } = parse("show blocked tasks for Cody", { now, naturalLanguage: false });
+  assert.deepEqual(state.filters, []);
+  assert.equal(state.text, "show blocked tasks for Cody");
+}
+
+/* ---------------------------------------------------------------------- */
+/* Canonical URL round trip                                                */
+/* ---------------------------------------------------------------------- */
+
+// Serialization is canonical: same state, byte-identical link, every time.
+{
+  const a = parse('type:task type:session tag:ux "exact phrase" composer', { now }).state;
+  const b = parse('composer tag:ux type:session "exact phrase" type:task', { now }).state;
+  assert.equal(searchQueryToUrlString(a), searchQueryToUrlString(b));
+}
+
+// Round trip restores chips, phrases, text, and presentation.
+{
+  const original = {
+    ...parse('type:task status:blocked tag:ux "exact phrase" composer', { now }).state,
+    presentation: "grouped",
+  };
+  const restored = searchQueryFromUrlParams(searchQueryToUrlParams(original));
+  assert.equal(restored.text, original.text);
+  assert.deepEqual(restored.phrases, original.phrases);
+  assert.deepEqual(pairs(restored), pairs(original));
+  assert.equal(restored.presentation, "grouped");
+}
+
+// Default presentation is omitted from the link rather than spelled out.
+{
+  const params = searchQueryToUrlParams(parse("composer", { now }).state);
+  assert.equal(params.has("view"), false);
+}
+
+// Explicit scopes travel; implicit ones do not, because they belong to the
+// sharer's workspace and would silently narrow a recipient's results.
+{
+  const state = {
+    ...emptySearchQueryState(),
+    scopes: [
+      { dimension: "project", id: "coven-cave", label: "Coven Cave", implicit: false },
+      { dimension: "room", id: "code", label: "Code", implicit: true },
+    ],
+  };
+  const params = searchQueryToUrlParams(state);
+  assert.deepEqual(params.getAll("scope"), ["project:coven-cave"]);
+  const restored = searchQueryFromUrlParams(params);
+  assert.equal(restored.scopes.length, 1);
+  assert.equal(restored.scopes[0].implicit, false);
+}
+
+// An unknown future version falls closed to plain text rather than applying
+// filters whose meaning may have changed.
+{
+  const params = new URLSearchParams();
+  params.set("v", "999");
+  params.set("q", "composer");
+  params.append("type", "task");
+  params.append("scope", "project:coven-cave");
+  const restored = searchQueryFromUrlParams(params);
+  assert.equal(restored.text, "composer");
+  assert.deepEqual(restored.filters, []);
+  assert.deepEqual(restored.scopes, []);
+  assert.equal(restored.version, SEARCH_QUERY_VERSION);
+}
+
+// A missing version is treated as current, so hand-written links work.
+{
+  const params = new URLSearchParams("q=composer&type=task");
+  const restored = searchQueryFromUrlParams(params);
+  assert.deepEqual(pairs(restored), ["type=task"]);
+}
+
+// Garbage in a link is ignored rather than fatal.
+{
+  const params = new URLSearchParams("v=1&type=not-a-type&status=blocked&scope=bogus&scope=:x");
+  const restored = searchQueryFromUrlParams(params);
+  assert.deepEqual(pairs(restored), ["status=blocked"]);
+  assert.deepEqual(restored.scopes, []);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Broadening                                                              */
+/* ---------------------------------------------------------------------- */
+
+// Command/Control+Enter drops context scopes and keeps explicit filters.
+{
+  const state = {
+    ...parse("type:task", { now }).state,
+    scopes: [
+      { dimension: "project", id: "coven-cave", label: "Coven Cave", implicit: true },
+      { dimension: "familiar", id: "cody", label: "Cody", implicit: false },
+    ],
+  };
+  const broadened = broadenToGlobal(state);
+  assert.deepEqual(broadened.scopes.map((scope) => scope.id), ["cody"]);
+  assert.deepEqual(pairs(broadened), ["type=task"]);
+}
+
+/* ---------------------------------------------------------------------- */
+/* The registry is data                                                    */
+/* ---------------------------------------------------------------------- */
+
+// Every documented key exists, so the spec's filter list and the registry
+// cannot drift apart silently.
+for (const key of [
+  "type", "status", "project", "familiar", "room",
+  "runtime", "source", "has", "after", "before", "tag",
+]) {
+  assert.ok(filterDefinition(key), `registry is missing the documented key ${key}`);
+}
+
+// URL keys are unique, or two filters would collide in a link.
+{
+  const urlKeys = SEARCH_FILTER_DEFINITIONS.map((definition) => definition.urlKey);
+  assert.equal(new Set(urlKeys).size, urlKeys.length);
+}
+
+// Applicability is declared, which is what makes a truthful filtered-empty
+// state possible instead of silently widening.
+{
+  assert.equal(filterAppliesToEntity(filterDefinition("status"), "task"), true);
+  assert.equal(filterAppliesToEntity(filterDefinition("status"), "project"), false);
+  assert.equal(filterAppliesToEntity(filterDefinition("tag"), "project"), true);
+}
+
+// Completions and chip labels come from the table.
+{
+  assert.ok(completeFilterKeys("st").some((definition) => definition.key === "status"));
+  assert.deepEqual(completeFilterValues(filterDefinition("type"), "ta"), ["task"]);
+  assert.equal(chipLabelFor({ key: "status", operator: "is", value: "in_progress", origin: "syntax" }), "In progress");
+  assert.equal(chipLabelFor({ key: "tag", operator: "is", value: "ux", origin: "syntax" }), "#ux");
+}
+
+// Date validation rejects impossible calendar dates, not just bad shapes.
+{
+  assert.equal(isIsoCalendarDate("2026-08-09"), true);
+  assert.equal(isIsoCalendarDate("2026-02-30"), false);
+  assert.equal(isIsoCalendarDate("2026-8-9"), false);
+}
+
+console.log("search-query.test.ts: ok");

--- a/src/lib/search-query.test.ts
+++ b/src/lib/search-query.test.ts
@@ -119,6 +119,24 @@ for (const input of [
   assert.deepEqual(values.options, ["blocked"]);
 }
 
+// An unmatched quote is held out of the language pass entirely. Someone typing
+// `"blocked tasks` is spelling an exact phrase; letting inference consume those
+// words would turn a half-typed quote into chips, which is the opposite of the
+// contract that unmatched quotes stay searchable text.
+{
+  const { state, suggestions } = parse('\"blocked tasks', { now: new Date('2026-08-09T12:00:00Z') });
+  assert.deepEqual(state.filters, [], "unmatched-quote content must never become chips");
+  assert.equal(state.text, "blocked tasks");
+  assert.ok(suggestions.some((entry) => entry.kind === "unmatched-quote"));
+}
+
+// The same words WITHOUT the quote do infer, which is what proves the quote is
+// what suppressed it rather than the rule being broken.
+{
+  const { state } = parse("blocked tasks", { now: new Date("2026-08-09T12:00:00Z") });
+  assert.deepEqual(pairs(state), ["status=blocked", "type=task"]);
+}
+
 // An unmatched quote is reported but its content stays searchable.
 {
   const { state, suggestions } = parse('alpha "beta gamma', { naturalLanguage: false });

--- a/src/lib/search-query.ts
+++ b/src/lib/search-query.ts
@@ -1,0 +1,503 @@
+/**
+ * search-query — the deterministic parser, natural-language rules, and
+ * canonical URL contract for global intelligent search (cave-ychtl.1).
+ *
+ * The governing rule, from the spec: **search never fails because a user typed
+ * a colon.** Unknown keys, unknown values, unmatched quotes, and half-typed
+ * tokens are not errors — they stay searchable text and earn a suggestion. The
+ * only thing that ever "fails" here is an unknown query VERSION, which falls
+ * closed to plain text rather than applying filters we cannot interpret.
+ *
+ * Everything is pure and clock-free: relative-date rules take `now` from the
+ * caller, so `last week` is testable without freezing time.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ * Plan: docs/superpowers/plans/2026-08-09-global-intelligent-search-implementation.md
+ */
+
+import {
+  SEARCH_QUERY_VERSION,
+  SEARCH_FILTER_DEFINITIONS,
+  completeFilterKeys,
+  completeFilterValues,
+  emptySearchQueryState,
+  filterDefinition,
+  filterDefinitionForUrlKey,
+  isValidFilterValue,
+  type SearchFilter,
+  type SearchFilterDefinition,
+  type SearchFilterOrigin,
+  type SearchPresentation,
+  type SearchQueryState,
+  type SearchScope,
+  type SearchScopeDimension,
+} from "./search-filters.ts";
+
+export type SearchSuggestion =
+  | { kind: "filter-key"; token: string; options: string[] }
+  | { kind: "filter-value"; token: string; key: string; options: string[] }
+  | { kind: "unmatched-quote"; token: string; options: [] };
+
+export type SearchParseResult = {
+  state: SearchQueryState;
+  /** Advisory completions for tokens that stayed in text. Never an error. */
+  suggestions: SearchSuggestion[];
+};
+
+export type ParseSearchQueryOptions = {
+  /** Reference instant for relative dates. Required for `last week` etc. */
+  now?: Date;
+  /** Scopes carried in from workspace context or a restored link. */
+  scopes?: SearchScope[];
+  presentation?: SearchPresentation;
+  /** Set false to parse syntax only, leaving language untouched. */
+  naturalLanguage?: boolean;
+};
+
+type RawToken = {
+  /** Text as typed, with quote characters removed. */
+  value: string;
+  /**
+   * The token opened with a quote, so it is an exact phrase.
+   *
+   * Position matters, not mere presence: `room:"code workshop"` also contains
+   * quotes but is a filter with a quoted VALUE, and treating any quoted token
+   * as a phrase silently drops the filter.
+   */
+  startedQuoted: boolean;
+  /** A quote was opened and never closed. */
+  unterminated: boolean;
+};
+
+const FILTER_TOKEN = /^([A-Za-z_][A-Za-z0-9_-]*):([\s\S]*)$/;
+
+/**
+ * Split on whitespace while respecting double quotes, including quoted filter
+ * values (`room:"code workshop"`), and report an unterminated quote rather than
+ * throwing on it.
+ */
+function tokenize(input: string): RawToken[] {
+  const tokens: RawToken[] = [];
+  let buffer = "";
+  let quoted = false;
+  let sawQuote = false;
+  let startedQuoted = false;
+  let unterminated = false;
+
+  const flush = () => {
+    if (buffer.length === 0 && !sawQuote) return;
+    tokens.push({ value: buffer, startedQuoted, unterminated });
+    buffer = "";
+    sawQuote = false;
+    startedQuoted = false;
+    unterminated = false;
+  };
+
+  for (let index = 0; index < input.length; index += 1) {
+    const char = input[index]!;
+    if (char === '"') {
+      if (!sawQuote && buffer.length === 0) startedQuoted = true;
+      sawQuote = true;
+      quoted = !quoted;
+      continue;
+    }
+    if (!quoted && /\s/.test(char)) {
+      flush();
+      continue;
+    }
+    buffer += char;
+  }
+  if (quoted) unterminated = true;
+  flush();
+  return tokens;
+}
+
+function addFilter(
+  filters: SearchFilter[],
+  definition: SearchFilterDefinition,
+  value: string,
+  origin: SearchFilterOrigin,
+): void {
+  const normalized = definition.valueKind === "enum" ? value.toLowerCase() : value;
+  const duplicate = filters.some(
+    (filter) => filter.key === definition.key && filter.value === normalized,
+  );
+  if (duplicate) return;
+  if (!definition.multiple) {
+    // The registry permits one value for this key, so a later occurrence is a
+    // correction rather than an addition. Last one wins, deterministically.
+    const existing = filters.findIndex((filter) => filter.key === definition.key);
+    if (existing >= 0) filters.splice(existing, 1);
+  }
+  filters.push({
+    key: definition.key,
+    operator: definition.operator,
+    value: normalized,
+    origin,
+  });
+}
+
+const ENTITY_PLURALS: ReadonlyMap<string, string> = new Map([
+  ["tasks", "task"],
+  ["task", "task"],
+  ["sessions", "session"],
+  ["session", "session"],
+  ["chats", "chat"],
+  ["chat", "chat"],
+  ["projects", "project"],
+  ["project", "project"],
+  ["familiars", "familiar"],
+  ["familiar", "familiar"],
+  ["files", "file"],
+  ["file", "file"],
+]);
+
+const STATUS_WORDS: ReadonlyMap<string, string> = new Map([
+  ["blocked", "blocked"],
+  ["failed", "failed"],
+  ["failing", "failed"],
+  ["open", "open"],
+  ["done", "done"],
+  ["closed", "closed"],
+  ["running", "running"],
+]);
+
+/**
+ * Filler that only ever introduces a query. Stripped when it LEADS the input,
+ * never mid-sentence — the spec's own example, `show blocked tasks for Cody`,
+ * has to reduce to three chips, and leaving "show" behind would silently
+ * require the word "show" to appear in every result.
+ */
+const LEADING_FILLER = ["show", "show me", "find", "find me", "search for", "search", "list", "get"];
+
+const STOP_WORDS = new Set([
+  "the", "a", "an", "this", "that", "these", "those", "my", "our", "all", "any",
+  "last", "next", "today", "yesterday", "week", "days", "day",
+]);
+
+function isoDate(instant: Date): string {
+  return instant.toISOString().slice(0, 10);
+}
+
+function shiftDays(instant: Date, days: number): Date {
+  return new Date(instant.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+/** A capitalized run reads as a proper noun — a familiar or project name. */
+function properNounRun(words: string[], start: number, limit = 3): string[] {
+  const run: string[] = [];
+  for (let index = start; index < words.length && run.length < limit; index += 1) {
+    const word = words[index]!;
+    if (!/^[A-Z][\w'-]*$/.test(word)) break;
+    if (STOP_WORDS.has(word.toLowerCase())) break;
+    run.push(word);
+  }
+  return run;
+}
+
+/**
+ * Consume only high-confidence language. Anything ambiguous stays in `text`;
+ * there is deliberately no low-confidence interpretation, because a hidden
+ * wrong filter is worse than an unfiltered search.
+ */
+function applyNaturalLanguage(
+  words: string[],
+  filters: SearchFilter[],
+  now: Date | undefined,
+): string[] {
+  let remaining = [...words];
+
+  // Leading filler, longest match first.
+  for (const filler of [...LEADING_FILLER].sort((a, b) => b.length - a.length)) {
+    const parts = filler.split(" ");
+    const head = remaining.slice(0, parts.length).map((word) => word.toLowerCase());
+    if (parts.length <= remaining.length && head.join(" ") === filler) {
+      remaining = remaining.slice(parts.length);
+      break;
+    }
+  }
+
+  const kept: string[] = [];
+  for (let index = 0; index < remaining.length; index += 1) {
+    const word = remaining[index]!;
+    const lower = word.toLowerCase();
+    const nextLower = remaining[index + 1]?.toLowerCase();
+
+    // Relative dates. Skipped entirely when the caller supplied no clock,
+    // rather than inventing one.
+    if (now) {
+      if (lower === "today") {
+        addFilter(filters, filterDefinition("after")!, isoDate(now), "natural-language");
+        continue;
+      }
+      if (lower === "yesterday") {
+        addFilter(filters, filterDefinition("after")!, isoDate(shiftDays(now, -1)), "natural-language");
+        addFilter(filters, filterDefinition("before")!, isoDate(now), "natural-language");
+        continue;
+      }
+      if (lower === "last" && nextLower === "week") {
+        addFilter(filters, filterDefinition("after")!, isoDate(shiftDays(now, -7)), "natural-language");
+        index += 1;
+        continue;
+      }
+      const days = Number(nextLower);
+      if (
+        lower === "last" &&
+        Number.isInteger(days) &&
+        days > 0 &&
+        remaining[index + 2]?.toLowerCase() === "days"
+      ) {
+        addFilter(filters, filterDefinition("after")!, isoDate(shiftDays(now, -days)), "natural-language");
+        index += 2;
+        continue;
+      }
+    }
+
+    // Signals.
+    if (lower === "with" && nextLower === "errors") {
+      addFilter(filters, filterDefinition("has")!, "errors", "natural-language");
+      index += 1;
+      continue;
+    }
+    if (
+      (lower === "needs" || lower === "needing") &&
+      (nextLower === "a" || nextLower === "decision") &&
+      (nextLower === "decision" || remaining[index + 2]?.toLowerCase() === "decision")
+    ) {
+      addFilter(filters, filterDefinition("has")!, "decision", "natural-language");
+      index += nextLower === "decision" ? 1 : 2;
+      continue;
+    }
+
+    // Entity + status, the spec's `blocked tasks` / `failed sessions`.
+    const status = STATUS_WORDS.get(lower);
+    const entityAfterStatus = nextLower ? ENTITY_PLURALS.get(nextLower) : undefined;
+    if (status && entityAfterStatus) {
+      addFilter(filters, filterDefinition("status")!, status, "natural-language");
+      addFilter(filters, filterDefinition("type")!, entityAfterStatus, "natural-language");
+      index += 1;
+      continue;
+    }
+
+    // `for <Familiar>` and `in <Project>`.
+    if ((lower === "for" || lower === "in") && index + 1 < remaining.length) {
+      const run = properNounRun(remaining, index + 1);
+      if (run.length > 0) {
+        const key = lower === "for" ? "familiar" : "project";
+        addFilter(filters, filterDefinition(key)!, run.join(" "), "natural-language");
+        index += run.length;
+        continue;
+      }
+    }
+
+    kept.push(word);
+  }
+
+  return kept;
+}
+
+/**
+ * Parse raw input into query state plus advisory suggestions.
+ *
+ * Never throws and never rejects input. Callers render `state` immediately and
+ * may show `suggestions` alongside it.
+ */
+export function parseSearchQuery(
+  input: string,
+  options: ParseSearchQueryOptions = {},
+): SearchParseResult {
+  const { now, scopes = [], presentation = "top", naturalLanguage = true } = options;
+  const filters: SearchFilter[] = [];
+  const phrases: string[] = [];
+  const suggestions: SearchSuggestion[] = [];
+  const words: string[] = [];
+
+  for (const token of tokenize(input)) {
+    if (token.unterminated) {
+      // An open quote is a half-typed phrase, not a syntax error. Keep the
+      // content searchable and say why the phrase did not form.
+      if (token.value.length > 0) words.push(...token.value.split(/\s+/).filter(Boolean));
+      suggestions.push({ kind: "unmatched-quote", token: token.value, options: [] });
+      continue;
+    }
+
+    if (token.startedQuoted) {
+      // A closed quote is an exact phrase — including an empty one, which we
+      // simply drop rather than treating as a match-everything phrase.
+      if (token.value.length > 0 && !phrases.includes(token.value)) phrases.push(token.value);
+      continue;
+    }
+
+    const match = FILTER_TOKEN.exec(token.value);
+    if (!match) {
+      if (token.value.length > 0) words.push(token.value);
+      continue;
+    }
+
+    const [, rawKey, rawValue] = match as unknown as [string, string, string];
+    const definition = filterDefinition(rawKey);
+
+    if (!definition) {
+      // Unknown key: searchable text, plus key completions if it looks like a
+      // near miss.
+      words.push(token.value);
+      const options_ = completeFilterKeys(rawKey).map((candidate) => candidate.key);
+      if (options_.length > 0) {
+        suggestions.push({ kind: "filter-key", token: token.value, options: options_ });
+      }
+      continue;
+    }
+
+    if (rawValue.length === 0) {
+      // `status:` — incomplete, so it stays text and offers its values.
+      words.push(token.value);
+      suggestions.push({
+        kind: "filter-value",
+        token: token.value,
+        key: definition.key,
+        options: definition.values,
+      });
+      continue;
+    }
+
+    if (!isValidFilterValue(definition, rawValue)) {
+      words.push(token.value);
+      suggestions.push({
+        kind: "filter-value",
+        token: token.value,
+        key: definition.key,
+        options: completeFilterValues(definition, rawValue),
+      });
+      continue;
+    }
+
+    addFilter(filters, definition, rawValue, "syntax");
+  }
+
+  const remainingWords = naturalLanguage
+    ? applyNaturalLanguage(words, filters, now)
+    : words;
+
+  return {
+    state: {
+      version: SEARCH_QUERY_VERSION,
+      text: remainingWords.join(" "),
+      phrases,
+      filters,
+      scopes,
+      presentation,
+    },
+    suggestions,
+  };
+}
+
+/* ---------------------------------------------------------------------- */
+/* Canonical URL contract                                                  */
+/* ---------------------------------------------------------------------- */
+
+const VERSION_PARAM = "v";
+const TEXT_PARAM = "q";
+const PHRASE_PARAM = "phrase";
+const SCOPE_PARAM = "scope";
+const VIEW_PARAM = "view";
+
+const SCOPE_DIMENSIONS = new Set<SearchScopeDimension>([
+  "project",
+  "familiar",
+  "room",
+  "session",
+  "runtime",
+]);
+
+/**
+ * Serialize to canonical, ordered parameters so the same state always produces
+ * a byte-identical link — otherwise "Copy search link" yields a different URL
+ * each time and nothing downstream can cache or compare it.
+ *
+ * Implicit scopes are deliberately NOT serialized: they are derived from the
+ * sharer's workspace, and re-asserting them in a recipient's context would
+ * silently narrow their results to a room they are not in.
+ */
+export function searchQueryToUrlParams(state: SearchQueryState): URLSearchParams {
+  const params = new URLSearchParams();
+  params.set(VERSION_PARAM, String(state.version));
+  if (state.text.trim().length > 0) params.set(TEXT_PARAM, state.text.trim());
+  for (const phrase of [...state.phrases].sort()) params.append(PHRASE_PARAM, phrase);
+
+  for (const definition of SEARCH_FILTER_DEFINITIONS) {
+    const values = state.filters
+      .filter((filter) => filter.key === definition.key)
+      .map((filter) => String(filter.value))
+      .sort();
+    for (const value of values) params.append(definition.urlKey, value);
+  }
+
+  const explicitScopes = state.scopes
+    .filter((scope) => !scope.implicit)
+    .map((scope) => `${scope.dimension}:${scope.id}`)
+    .sort();
+  for (const scope of explicitScopes) params.append(SCOPE_PARAM, scope);
+
+  if (state.presentation !== "top") params.set(VIEW_PARAM, state.presentation);
+  return params;
+}
+
+export function searchQueryToUrlString(state: SearchQueryState): string {
+  return searchQueryToUrlParams(state).toString();
+}
+
+/**
+ * Restore state from a link.
+ *
+ * An unknown version falls closed to plain text: we keep whatever free text the
+ * link carried and drop every filter and scope, because applying a filter whose
+ * meaning changed between versions is worse than searching too broadly. A
+ * missing version is treated as the current one so hand-written links work.
+ */
+export function searchQueryFromUrlParams(params: URLSearchParams): SearchQueryState {
+  const rawVersion = params.get(VERSION_PARAM);
+  const text = (params.get(TEXT_PARAM) ?? "").trim();
+
+  if (rawVersion !== null && Number(rawVersion) !== SEARCH_QUERY_VERSION) {
+    return { ...emptySearchQueryState(), text };
+  }
+
+  const filters: SearchFilter[] = [];
+  for (const [key, value] of params.entries()) {
+    const definition = filterDefinitionForUrlKey(key);
+    if (!definition) continue;
+    if (!isValidFilterValue(definition, value)) continue;
+    addFilter(filters, definition, value, "syntax");
+  }
+
+  const scopes: SearchScope[] = [];
+  for (const raw of params.getAll(SCOPE_PARAM)) {
+    const separator = raw.indexOf(":");
+    if (separator <= 0) continue;
+    const dimension = raw.slice(0, separator) as SearchScopeDimension;
+    const id = raw.slice(separator + 1);
+    if (!SCOPE_DIMENSIONS.has(dimension) || id.length === 0) continue;
+    if (scopes.some((scope) => scope.dimension === dimension && scope.id === id)) continue;
+    scopes.push({ dimension, id, label: id, implicit: false });
+  }
+
+  const view = params.get(VIEW_PARAM);
+  return {
+    version: SEARCH_QUERY_VERSION,
+    text,
+    phrases: [...new Set(params.getAll(PHRASE_PARAM).filter((phrase) => phrase.length > 0))].sort(),
+    filters,
+    scopes,
+    presentation: view === "grouped" ? "grouped" : "top",
+  };
+}
+
+/**
+ * Drop implicit (context) scopes — the Command/Control+Enter behavior.
+ *
+ * Explicit filters survive on purpose: broadening means "stop assuming where I
+ * am", not "throw away what I asked for".
+ */
+export function broadenToGlobal(state: SearchQueryState): SearchQueryState {
+  return { ...state, scopes: state.scopes.filter((scope) => !scope.implicit) };
+}

--- a/src/lib/search-query.ts
+++ b/src/lib/search-query.ts
@@ -168,7 +168,9 @@ const STATUS_WORDS: ReadonlyMap<string, string> = new Map([
  * has to reduce to three chips, and leaving "show" behind would silently
  * require the word "show" to appear in every result.
  */
-const LEADING_FILLER = ["show", "show me", "find", "find me", "search for", "search", "list", "get"];
+const LEADING_FILLER = ["show", "show me", "find", "find me", "search for", "search", "list", "get"]
+  // Longest first, computed once: parsing runs on every keystroke.
+  .sort((a, b) => b.length - a.length);
 
 const STOP_WORDS = new Set([
   "the", "a", "an", "this", "that", "these", "those", "my", "our", "all", "any",
@@ -208,7 +210,7 @@ function applyNaturalLanguage(
   let remaining = [...words];
 
   // Leading filler, longest match first.
-  for (const filler of [...LEADING_FILLER].sort((a, b) => b.length - a.length)) {
+  for (const filler of LEADING_FILLER) {
     const parts = filler.split(" ");
     const head = remaining.slice(0, parts.length).map((word) => word.toLowerCase());
     if (parts.length <= remaining.length && head.join(" ") === filler) {
@@ -311,12 +313,20 @@ export function parseSearchQuery(
   const phrases: string[] = [];
   const suggestions: SearchSuggestion[] = [];
   const words: string[] = [];
+  /** Text that must reach the query verbatim, never through inference. */
+  const literalWords: string[] = [];
 
   for (const token of tokenize(input)) {
     if (token.unterminated) {
       // An open quote is a half-typed phrase, not a syntax error. Keep the
       // content searchable and say why the phrase did not form.
-      if (token.value.length > 0) words.push(...token.value.split(/\s+/).filter(Boolean));
+      //
+      // It is held OUT of the natural-language pass on purpose. Someone typing
+      // `"blocked tasks` is spelling an exact phrase, and letting the language
+      // rules consume those words would turn a half-typed quote into
+      // `status:blocked` + `type:task` chips — the opposite of the contract
+      // that unmatched quotes stay searchable text.
+      if (token.value.length > 0) literalWords.push(token.value);
       suggestions.push({ kind: "unmatched-quote", token: token.value, options: [] });
       continue;
     }
@@ -334,7 +344,8 @@ export function parseSearchQuery(
       continue;
     }
 
-    const [, rawKey, rawValue] = match as unknown as [string, string, string];
+    const rawKey = match[1] ?? "";
+    const rawValue = match[2] ?? "";
     const definition = filterDefinition(rawKey);
 
     if (!definition) {
@@ -374,9 +385,10 @@ export function parseSearchQuery(
     addFilter(filters, definition, rawValue, "syntax");
   }
 
-  const remainingWords = naturalLanguage
-    ? applyNaturalLanguage(words, filters, now)
-    : words;
+  const remainingWords = [
+    ...(naturalLanguage ? applyNaturalLanguage(words, filters, now) : words),
+    ...literalWords,
+  ];
 
   return {
     state: {


### PR DESCRIPTION
Closes cave-ychtl.1. First implementation unit of the global intelligent search program (cave-ychtl).

Authorized by the merged spec and plan — the spec's delivery boundary required both before any implementation, and both are on `main`.

## What this is

Pure TypeScript. No I/O, no React, no clock. Two modules and one test file.

**`src/lib/search-filters.ts`** — the versioned query state (`SearchQueryState`, `SearchFilter`, `SearchScope`) exactly as the spec types it, plus the declarative filter registry covering all eleven documented keys: `type`, `status`, `project`, `familiar`, `room`, `runtime`, `source`, `has`, `after`, `before`, `tag`.

Each entry owns its aliases, operator, value kind, whether repetition is permitted, completion values, entity applicability, chip label, and URL key. That is the design's actual payload: adding a status or an entity type is a data edit in this table, not another branch in the parser and not another special case in the search UI. A test asserts every documented key resolves, so the spec's list and the registry cannot drift apart silently.

**`src/lib/search-query.ts`** — the tokenizer, parser, deterministic natural-language rules, canonical URL serializer/restorer, and `broadenToGlobal`.

## The load-bearing contract

From the spec: **search never fails because a user typed a colon.** Unknown keys, unknown values, unmatched quotes, and half-typed tokens are not errors — they stay searchable text and earn a suggestion.

A table asserts exactly that across nine malformed inputs — `ratio:`, `nonsense:value`, `status:`, `status:not-a-status`, `after:not-a-date`, `after:2026-13-45`, `:leading`, an unmatched quote, and a bare URL — each of which must remain searchable text and produce no filter. The only thing that ever fails closed is an unknown query *version*, which drops to plain text rather than applying filters whose meaning may have changed.

## Three decisions that are judgment, not transcription

**Leading filler is stripped.** The spec's worked example, `show blocked tasks for Cody`, must reduce to exactly three chips. Left in, "show" becomes free text and every result would have to contain that word — the spec's own example would return nothing. A small set of leading verbs is consumed, and only when it leads the query.

**Relative dates take the clock from the caller.** `parseSearchQuery` accepts `now`. Given no clock, date language is left as text rather than resolved against a hidden `Date.now()`. The module stays pure and `last week` is testable without freezing time.

**Implicit scopes are not serialized into shared links.** They derive from the sharer's workspace, so re-asserting them in a recipient's context would silently narrow results to a room that person is not in. Explicit scopes travel; implicit ones re-derive on arrival.

Ambiguity is preserved throughout: `blocked`, `sessions`, `for`, `in`, and a lowercase name after `for` all stay text and infer nothing. There is deliberately no low-confidence interpretation, because a hidden wrong filter is worse than an unfiltered search.

## A real bug the tests caught

The first tokenizer tracked *whether* a token contained a quote but not *where*. `room:"code workshop"` therefore parsed as an exact phrase and the filter silently vanished. Position matters — a token that opens with a quote is a phrase; a token with a quoted value is a filter. Fixed, and pinned by the parser table.

## Verification

| Gate | Result |
| --- | --- |
| `src/lib/search-query.test.ts` | passes |
| `pnpm check:tests-wired` | all 1590 wired |
| `pnpm typecheck` | clean |
| `pnpm lint` | clean, 0 design drift, 0 ESLint warnings |
| `git diff --check` | clean |
| `pnpm test:app` | see checks |
| `pnpm test:api` | see checks |

## Scope

Nothing renders this yet. No provider, no store, no coordinator, no UI — those are units 2 through 7, and unit 2 (the SQLite FTS5 store) is independent of this one and can proceed in parallel.
