### PR TITLE
feat(search): normalized document contract and SQLite FTS5 index (unit 2)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -458,6 +458,7 @@ export const SUITES = {
     "src/components/command-palette-save-link.test.ts",
     "src/lib/command-palette-search.test.ts",
     "src/lib/search-query.test.ts",
+    "src/lib/search-index-store.test.ts",
     "src/lib/command-palette-salem-context.test.ts",
     "src/lib/command-palette-scope.test.ts",
     "src/lib/recent-searches.test.ts",

--- a/src/lib/search-document.ts
+++ b/src/lib/search-document.ts
@@ -1,0 +1,161 @@
+/**
+ * search-document — the normalized document and result contracts every search
+ * provider emits (cave-ychtl.2).
+ *
+ * One shape for every corpus is what lets the coordinator rank projects,
+ * familiars, tasks, sessions and files against each other at all. Providers
+ * normalize INTO this and stop there: they never return pre-ranked rows, never
+ * decide presentation, and never leak storage detail a requester cannot see.
+ *
+ * Pure module: types, guards, and normalization only. The store that persists
+ * these lives in ./search-index-store.ts.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ */
+
+export type SearchPermission = {
+  /** Permission dimension, e.g. "project" or "familiar". */
+  kind: string;
+  /** Identifier within that dimension the requester must hold. */
+  id: string;
+};
+
+export type SearchAction = {
+  /** Stable action id the surface maps to a handler. */
+  id: string;
+  label: string;
+  /** In-app target. Never an absolute filesystem path. */
+  href?: string;
+};
+
+export type SearchDocument = {
+  /** Unique within the provider. `providerId + id` is the index identity. */
+  id: string;
+  providerId: string;
+  entityType: string;
+  title: string;
+  body: string;
+  excerpt: string;
+  projectId: string | null;
+  projectRoot: string | null;
+  familiarId: string | null;
+  roomId: string | null;
+  sessionId: string | null;
+  runtime: string | null;
+  status: string | null;
+  tags: string[];
+  createdAt: string | null;
+  updatedAt: string | null;
+  sourceType: string;
+  permissions: SearchPermission[];
+  /**
+   * Provider-owned fingerprint of the SOURCE for this document — an mtime, a
+   * store revision, a content digest. Changing it is what marks the document
+   * dirty; equal fingerprints let a refresh skip the row entirely.
+   */
+  sourceVersion: string;
+  action: SearchAction;
+  secondaryActions: SearchAction[];
+};
+
+/**
+ * The index identity. Providers may reuse ids; the pair must be unique.
+ *
+ * The separator is an explicit NUL rather than a space because either half may
+ * legitimately contain spaces, and `"a b" + "c"` must not collide with
+ * `"a" + "b c"`. Every caller uses THIS function — building the key by hand
+ * somewhere else is how the two spellings drift apart and a refresh starts
+ * deleting the rows it just wrote.
+ */
+export const SEARCH_DOCUMENT_KEY_SEPARATOR = "\u0000";
+
+export function searchDocumentKey(document: Pick<SearchDocument, "providerId" | "id">): string {
+  return `${document.providerId}${SEARCH_DOCUMENT_KEY_SEPARATOR}${document.id}`;
+}
+
+export type SearchMatchReason =
+  | "exact-title"
+  | "phrase"
+  | "title-prefix"
+  | "title-token"
+  | "fuzzy-title"
+  | "text";
+
+export type SearchResult = {
+  document: SearchDocument;
+  /** Why this matched, for tests and for explaining a row in the UI. */
+  reasons: SearchMatchReason[];
+  /** Raw FTS relevance. The coordinator normalizes across providers. */
+  relevance: number;
+};
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const stringOrNull = (value: unknown): string | null =>
+  typeof value === "string" && value.length > 0 ? value : null;
+
+function normalizeAction(value: unknown, fallbackId: string): SearchAction {
+  if (!isPlainObject(value)) return { id: fallbackId, label: "" };
+  const href = stringOrNull(value.href);
+  return {
+    id: typeof value.id === "string" ? value.id : fallbackId,
+    label: typeof value.label === "string" ? value.label : "",
+    ...(href ? { href } : {}),
+  };
+}
+
+/**
+ * Coerce a provider's object into a well-formed document.
+ *
+ * Deliberately total rather than throwing: a provider emitting one malformed
+ * row should cost that row its fidelity, not abort a whole refresh and leave
+ * the index stale. Missing text becomes empty, not `undefined`, so FTS never
+ * sees a null column.
+ */
+export function normalizeSearchDocument(input: unknown): SearchDocument | null {
+  if (!isPlainObject(input)) return null;
+  const id = stringOrNull(input.id);
+  const providerId = stringOrNull(input.providerId);
+  const entityType = stringOrNull(input.entityType);
+  if (!id || !providerId || !entityType) return null;
+
+  const tags = Array.isArray(input.tags)
+    ? [...new Set(input.tags.filter((tag): tag is string => typeof tag === "string" && tag.length > 0))]
+    : [];
+  const permissions = Array.isArray(input.permissions)
+    ? input.permissions.flatMap((entry) => {
+        if (!isPlainObject(entry)) return [];
+        const kind = stringOrNull(entry.kind);
+        const permissionId = stringOrNull(entry.id);
+        return kind && permissionId ? [{ kind, id: permissionId }] : [];
+      })
+    : [];
+  const secondaryActions = Array.isArray(input.secondaryActions)
+    ? input.secondaryActions.map((entry, index) => normalizeAction(entry, `${id}:secondary:${index}`))
+    : [];
+
+  return {
+    id,
+    providerId,
+    entityType,
+    title: typeof input.title === "string" ? input.title : "",
+    body: typeof input.body === "string" ? input.body : "",
+    excerpt: typeof input.excerpt === "string" ? input.excerpt : "",
+    projectId: stringOrNull(input.projectId),
+    projectRoot: stringOrNull(input.projectRoot),
+    familiarId: stringOrNull(input.familiarId),
+    roomId: stringOrNull(input.roomId),
+    sessionId: stringOrNull(input.sessionId),
+    runtime: stringOrNull(input.runtime),
+    status: stringOrNull(input.status),
+    tags,
+    createdAt: stringOrNull(input.createdAt),
+    updatedAt: stringOrNull(input.updatedAt),
+    sourceType: typeof input.sourceType === "string" ? input.sourceType : providerId,
+    permissions,
+    sourceVersion: typeof input.sourceVersion === "string" ? input.sourceVersion : "",
+    action: normalizeAction(input.action, `${id}:open`),
+    secondaryActions,
+  };
+}

--- a/src/lib/search-document.ts
+++ b/src/lib/search-document.ts
@@ -73,6 +73,22 @@ export function searchDocumentKey(document: Pick<SearchDocument, "providerId" | 
   return `${document.providerId}${SEARCH_DOCUMENT_KEY_SEPARATOR}${document.id}`;
 }
 
+/**
+ * Recover just the index identity from a row that failed to normalize.
+ *
+ * A refresh needs to know that the source still PRODUCED an id even when the
+ * row around it is unusable, so the deletion pass does not read a malformed
+ * row as a withdrawn one and drop the last good copy of that document.
+ */
+export function rawDocumentIdentity(
+  input: unknown,
+): Pick<SearchDocument, "providerId" | "id"> | null {
+  if (!isPlainObject(input)) return null;
+  const id = stringOrNull(input.id);
+  const providerId = stringOrNull(input.providerId);
+  return id && providerId ? { providerId, id } : null;
+}
+
 export type SearchMatchReason =
   | "exact-title"
   | "phrase"

--- a/src/lib/search-index-store.test.ts
+++ b/src/lib/search-index-store.test.ts
@@ -144,6 +144,40 @@ assert.notEqual(
   index.close();
 }
 
+// A row that fails to normalize must lose ONLY its own fidelity. It still
+// counts as "the source produced this id", or the deletion pass reads it as
+// withdrawn and drops the last good copy — and a provider whose rows all fail
+// would clear itself entirely.
+{
+  const index = await openSearchIndex(dbPath("malformed"));
+  index.refreshProvider("tasks", "fp-1", () => [doc(), doc({ id: "task-2", title: "Sidebar polish", body: "Adjust the rail", excerpt: "Adjust the rail", sourceVersion: "z" })]);
+  assert.equal(index.documentCount(), 2);
+
+  // entityType missing => normalizeSearchDocument returns null, but the row
+  // still identifies itself.
+  const outcome = index.refreshProvider("tasks", "fp-2", () => [
+    { id: "task-1", providerId: "tasks" },
+    doc({ id: "task-2", title: "Sidebar polish", body: "Adjust the rail", excerpt: "Adjust the rail", sourceVersion: "z" }),
+  ]);
+  assert.equal(outcome.removed, 0, "a malformed row must not be read as a deletion");
+  assert.equal(index.documentCount(), 2, "the previously indexed copy survives");
+  assert.equal(index.match({ text: "composer" }).length, 1, "and stays searchable");
+
+  // Every row malformed must not empty the provider.
+  const allBad = index.refreshProvider("tasks", "fp-3", () => [
+    { id: "task-1", providerId: "tasks" },
+    { id: "task-2", providerId: "tasks" },
+  ]);
+  assert.equal(allBad.removed, 0);
+  assert.equal(index.documentCount(), 2, "a wholly malformed scan must not clear the provider");
+
+  // A row that identifies nothing cannot be protected, and a genuine
+  // withdrawal still deletes.
+  const withdrawn = index.refreshProvider("tasks", "fp-4", () => [doc()]);
+  assert.equal(withdrawn.removed, 1, "a genuinely withdrawn document is still removed");
+  index.close();
+}
+
 /* ---------------------------------------------------------------------- */
 /* Failed refresh keeps the last verified snapshot and marks it stale      */
 /* ---------------------------------------------------------------------- */

--- a/src/lib/search-index-store.test.ts
+++ b/src/lib/search-index-store.test.ts
@@ -1,0 +1,288 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, statSync, symlinkSync, writeFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  openSearchIndex,
+  searchIndexPath,
+  SEARCH_INDEX_SCHEMA_VERSION,
+} from "./search-index-store.ts";
+import { normalizeSearchDocument, searchDocumentKey } from "./search-document.ts";
+
+const root = mkdtempSync(path.join(tmpdir(), "cave-search-index-"));
+const dbPath = (name) => path.join(root, `${name}.sqlite`);
+
+function doc(overrides = {}) {
+  return {
+    id: "task-1",
+    providerId: "tasks",
+    entityType: "task",
+    title: "Composer rename",
+    body: "Rename the composer button",
+    excerpt: "Rename the composer button",
+    projectId: "coven-cave",
+    projectRoot: "/repo",
+    familiarId: "cody",
+    roomId: null,
+    sessionId: null,
+    runtime: null,
+    status: "blocked",
+    tags: ["ux"],
+    createdAt: "2026-08-01T00:00:00Z",
+    updatedAt: "2026-08-02T00:00:00Z",
+    sourceType: "tasks",
+    permissions: [{ kind: "project", id: "coven-cave" }],
+    sourceVersion: "v1",
+    action: { id: "open-task", label: "Open task", href: "/tasks/task-1" },
+    secondaryActions: [],
+    ...overrides,
+  };
+}
+
+/* ---------------------------------------------------------------------- */
+/* Document normalization                                                  */
+/* ---------------------------------------------------------------------- */
+
+// A malformed row loses its own fidelity rather than throwing — one bad
+// document must not abort a refresh and leave every other row stale.
+assert.equal(normalizeSearchDocument(null), null);
+assert.equal(normalizeSearchDocument({ id: "x" }), null);
+assert.equal(normalizeSearchDocument({ id: "x", providerId: "p" }), null);
+{
+  const normalized = normalizeSearchDocument({ id: "x", providerId: "p", entityType: "task" });
+  assert.equal(normalized.title, "", "missing text becomes empty, never undefined, so FTS sees no null");
+  assert.deepEqual(normalized.tags, []);
+  assert.deepEqual(normalized.permissions, []);
+  assert.equal(normalized.action.id, "x:open");
+}
+assert.equal(searchDocumentKey({ providerId: "tasks", id: "task-1" }), "tasks\u0000task-1");
+assert.notEqual(
+  searchDocumentKey({ providerId: "a b", id: "c" }),
+  searchDocumentKey({ providerId: "a", id: "b c" }),
+  "the separator must not let two different identities collide",
+);
+
+/* ---------------------------------------------------------------------- */
+/* Schema, permissions, and symlink refusal                                */
+/* ---------------------------------------------------------------------- */
+
+{
+  const file = dbPath("basic");
+  const index = await openSearchIndex(file);
+  assert.equal(index.documentCount(), 0);
+  assert.equal((statSync(file).mode & 0o777), 0o600, "index file is private (0600)");
+  index.close();
+
+  // Reopening an existing database migrates idempotently rather than failing.
+  const again = await openSearchIndex(file);
+  assert.equal(again.documentCount(), 0);
+  again.close();
+  assert.equal(SEARCH_INDEX_SCHEMA_VERSION, 1);
+}
+
+// A symlinked path is a redirection of where we write. Refuse, do not follow.
+{
+  const target = dbPath("symlink-target");
+  writeFileSync(target, "");
+  const link = dbPath("symlink-link");
+  symlinkSync(target, link);
+  await assert.rejects(() => openSearchIndex(link), /must not be a symlink/);
+}
+
+// The path is overridable, which is what lets a backup builder exclude it.
+{
+  const previous = process.env.COVEN_CAVE_SEARCH_INDEX;
+  process.env.COVEN_CAVE_SEARCH_INDEX = "/tmp/example-search-index.sqlite";
+  assert.equal(searchIndexPath(), "/tmp/example-search-index.sqlite");
+  if (previous === undefined) delete process.env.COVEN_CAVE_SEARCH_INDEX;
+  else process.env.COVEN_CAVE_SEARCH_INDEX = previous;
+}
+
+/* ---------------------------------------------------------------------- */
+/* Refresh: upsert, fingerprint skip, deletion                             */
+/* ---------------------------------------------------------------------- */
+
+{
+  const index = await openSearchIndex(dbPath("refresh"));
+
+  const first = index.refreshProvider("tasks", "fp-1", () => [doc()]);
+  assert.equal(first.skipped, false);
+  assert.equal(first.upserted, 1);
+  assert.equal(index.documentCount(), 1);
+
+  // An unchanged fingerprint skips the scan entirely. This is the whole reason
+  // providers carry one.
+  let collected = 0;
+  const second = index.refreshProvider("tasks", "fp-1", () => {
+    collected += 1;
+    return [doc()];
+  });
+  assert.equal(second.skipped, true);
+  assert.equal(collected, 0, "an unchanged fingerprint must not even collect");
+
+  // A moved fingerprint rescans, and an unchanged row inside it is left alone
+  // because the provider's own sourceVersion did not move.
+  const third = index.refreshProvider("tasks", "fp-2", () => [doc()]);
+  assert.equal(third.skipped, false);
+  assert.equal(third.upserted, 0, "sourceVersion unchanged means no rewrite");
+
+  // A changed sourceVersion rewrites the row.
+  const fourth = index.refreshProvider("tasks", "fp-3", () => [
+    doc({ title: "Composer rename v2", sourceVersion: "v2" }),
+  ]);
+  assert.equal(fourth.upserted, 1);
+  assert.equal(index.match({ text: "v2" }).length, 1);
+
+  // A document the source stops producing must leave the index, or a deleted
+  // task answers searches forever.
+  const fifth = index.refreshProvider("tasks", "fp-4", () => []);
+  assert.equal(fifth.removed, 1);
+  assert.equal(index.documentCount(), 0);
+  assert.equal(index.match({ text: "composer" }).length, 0, "FTS rows are removed too");
+
+  index.close();
+}
+
+/* ---------------------------------------------------------------------- */
+/* Failed refresh keeps the last verified snapshot and marks it stale      */
+/* ---------------------------------------------------------------------- */
+
+{
+  const index = await openSearchIndex(dbPath("stale"));
+  index.refreshProvider("tasks", "fp-1", () => [doc()]);
+  assert.equal(index.providerState("tasks").stale, false);
+
+  const failed = index.refreshProvider("tasks", "fp-2", () => {
+    throw new Error("source unavailable");
+  });
+  assert.equal(failed.stale, true);
+  assert.match(failed.error, /source unavailable/);
+
+  // The point: the previous snapshot is intact and searchable, just flagged.
+  assert.equal(index.documentCount(), 1, "a failed refresh must not empty the index");
+  const state = index.providerState("tasks");
+  assert.equal(state.stale, true);
+  assert.equal(
+    state.fingerprint,
+    "fp-1",
+    "the recorded fingerprint stays at the last COMPLETED refresh — it describes which snapshot the surviving rows came from, and must not advance to the one that failed",
+  );
+  assert.equal(index.match({ text: "composer" })[0].stale, true, "rows report their staleness");
+
+  // A stale provider is never skipped, even if the fingerprint matches.
+  const recovered = index.refreshProvider("tasks", "fp-1", () => [doc()]);
+  assert.equal(recovered.skipped, false, "a stale provider must re-scan");
+  assert.equal(index.providerState("tasks").stale, false);
+
+  index.close();
+}
+
+// A partial failure mid-collection rolls back rather than half-updating.
+{
+  const index = await openSearchIndex(dbPath("rollback"));
+  index.refreshProvider("tasks", "fp-1", () => [doc()]);
+  index.refreshProvider("tasks", "fp-2", () => ({
+    *[Symbol.iterator]() {
+      yield doc({ id: "task-2", title: "Second", sourceVersion: "v9" });
+      throw new Error("collection blew up halfway");
+    },
+  }));
+  assert.equal(index.documentCount(), 1, "the half-written second document is rolled back");
+  assert.equal(index.match({ text: "Second" }).length, 0);
+  index.close();
+}
+
+/* ---------------------------------------------------------------------- */
+/* Corruption is quarantined and rebuilt, never repaired                   */
+/* ---------------------------------------------------------------------- */
+
+{
+  const file = dbPath("corrupt");
+  const index = await openSearchIndex(file);
+  index.refreshProvider("tasks", "fp-1", () => [doc()]);
+  index.close();
+
+  writeFileSync(file, "this is not a sqlite database at all");
+
+  const reopened = await openSearchIndex(file);
+  assert.equal(reopened.documentCount(), 0, "a corrupt index rebuilds empty rather than failing");
+  assert.equal(existsSync(`${file}.corrupt`), true, "the damaged file is kept as evidence");
+  // And it is immediately usable again.
+  reopened.refreshProvider("tasks", "fp-1", () => [doc()]);
+  assert.equal(reopened.documentCount(), 1);
+  reopened.close();
+}
+
+/* ---------------------------------------------------------------------- */
+/* Matching: FTS plus metadata filters                                     */
+/* ---------------------------------------------------------------------- */
+
+{
+  const index = await openSearchIndex(dbPath("match"));
+  index.refreshProvider("tasks", "fp-1", () => [
+    doc({ id: "t1", title: "Composer rename", status: "blocked", sourceVersion: "a" }),
+    doc({
+      id: "t2",
+      title: "Sidebar polish",
+      body: "Adjust the rail",
+      status: "open",
+      familiarId: "nova",
+      sourceVersion: "b",
+    }),
+  ]);
+  index.refreshProvider("projects", "fp-1", () => [
+    doc({
+      id: "p1",
+      providerId: "projects",
+      entityType: "project",
+      title: "Coven Cave",
+      body: "The desktop app",
+      status: null,
+      sourceType: "projects",
+      sourceVersion: "c",
+    }),
+  ]);
+
+  assert.equal(index.documentCount(), 3);
+  assert.equal(index.match({ text: "composer" }).length, 1);
+  assert.equal(index.match({ text: "rail" }).length, 1);
+  // Prefix matching, so results appear while typing.
+  assert.equal(index.match({ text: "compo" }).length, 1);
+  // Tags are indexed.
+  assert.equal(index.match({ text: "ux" }).length >= 1, true);
+
+  // Metadata filters narrow without touching FTS.
+  assert.equal(index.match({ entityTypes: ["project"] }).length, 1);
+  assert.equal(index.match({ statuses: ["blocked"] }).length, 1);
+  assert.equal(index.match({ familiarIds: ["nova"] }).length, 1);
+  assert.equal(index.match({ providerIds: ["projects"] }).length, 1);
+  // Combined.
+  assert.equal(index.match({ text: "composer", statuses: ["open"] }).length, 0);
+
+  // A quoted phrase requires the whole phrase.
+  assert.equal(index.match({ phrases: ["Composer rename"] }).length, 1);
+  assert.equal(index.match({ phrases: ["rename Composer"] }).length, 0);
+
+  // A term with FTS syntax in it is escaped rather than executed.
+  assert.doesNotThrow(() => index.match({ text: 'weird" OR title:x' }));
+  assert.doesNotThrow(() => index.match({ text: "NEAR(" }));
+
+  // Documents round trip intact through storage.
+  const [row] = index.match({ text: "composer" });
+  assert.equal(row.document.action.href, "/tasks/task-1");
+  assert.deepEqual(row.document.tags, ["ux"]);
+  assert.deepEqual(row.document.permissions, [{ kind: "project", id: "coven-cave" }]);
+  assert.equal(row.stale, false);
+
+  // The limit is bounded regardless of what a caller asks for.
+  assert.equal(index.match({ limit: 100000 }).length <= 500, true);
+
+  index.rebuild();
+  assert.equal(index.documentCount(), 0, "rebuild drops everything — the index is derivative");
+  assert.equal(index.providerState("tasks"), null);
+  index.close();
+}
+
+rmSync(root, { recursive: true, force: true });
+console.log("search-index-store.test.ts: ok");

--- a/src/lib/search-index-store.ts
+++ b/src/lib/search-index-store.ts
@@ -1,0 +1,556 @@
+/**
+ * search-index-store — the derivative SQLite/FTS5 index behind global search
+ * (cave-ychtl.2).
+ *
+ * The index is ALWAYS derivative. Every row can be rebuilt from an
+ * authoritative source, which is what makes the aggressive failure handling
+ * here safe: a corrupt database is quarantined and recreated rather than
+ * repaired, and a failed refresh discards its own partial work instead of
+ * half-updating a provider. Nothing unique lives in this file, so losing it
+ * costs a rescan and nothing else.
+ *
+ * FTS5 availability was verified before this was planned — `node:sqlite` ships
+ * it with no third-party dependency (SQLite 3.53.1). `node:sqlite` is still
+ * experimental, so it is imported lazily, following the pattern already used in
+ * src/lib/threads-adapters.ts.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ */
+
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+import { caveHome } from "./coven-paths.ts";
+import {
+  normalizeSearchDocument,
+  searchDocumentKey,
+  type SearchDocument,
+} from "./search-document.ts";
+
+/** Bump only alongside a migration in {@link migrate}. */
+export const SEARCH_INDEX_SCHEMA_VERSION = 1;
+
+const DB_BASENAME = "search-index.sqlite";
+
+/**
+ * Where the derivative index lives: under Cave's local state, beside nothing
+ * authoritative, and deliberately NOT inside the daemon database.
+ *
+ * Exported so anything that builds a backup or export payload has one place to
+ * consult in order to leave it out. No exporter exists today, so this is the
+ * hook rather than an enforced exclusion — stated plainly instead of implied.
+ */
+export function searchIndexPath(): string {
+  return process.env.COVEN_CAVE_SEARCH_INDEX ?? path.join(caveHome(), DB_BASENAME);
+}
+
+export type ProviderIndexState = {
+  providerId: string;
+  /** Last fingerprint a refresh COMPLETED with. */
+  fingerprint: string | null;
+  /** True when the last refresh failed, so rows are last-known-good. */
+  stale: boolean;
+  documentCount: number;
+  updatedAt: string | null;
+};
+
+export type RefreshOutcome = {
+  providerId: string;
+  /** No work done because the fingerprint matched. */
+  skipped: boolean;
+  upserted: number;
+  removed: number;
+  stale: boolean;
+  error?: string;
+};
+
+export type SearchIndexQuery = {
+  /** Free text, matched across title, body and tags. */
+  text?: string;
+  /** Exact phrases, all of which must be present. */
+  phrases?: string[];
+  entityTypes?: string[];
+  projectIds?: string[];
+  familiarIds?: string[];
+  statuses?: string[];
+  providerIds?: string[];
+  limit?: number;
+};
+
+export type SearchIndexRow = {
+  document: SearchDocument;
+  relevance: number;
+  stale: boolean;
+};
+
+export type SearchIndex = {
+  readonly file: string;
+  refreshProvider(
+    providerId: string,
+    fingerprint: string,
+    collect: () => Iterable<unknown>,
+  ): RefreshOutcome;
+  providerState(providerId: string): ProviderIndexState | null;
+  match(query: SearchIndexQuery): SearchIndexRow[];
+  documentCount(): number;
+  /** Drop everything and recreate the schema. The index is derivative. */
+  rebuild(): void;
+  close(): void;
+};
+
+type DatabaseHandle = {
+  exec(sql: string): void;
+  prepare(sql: string): {
+    all(...params: unknown[]): Record<string, unknown>[];
+    get(...params: unknown[]): Record<string, unknown> | undefined;
+    run(...params: unknown[]): unknown;
+  };
+  close(): void;
+};
+
+/**
+ * Lazy import so the experimental-module warning is paid only by callers that
+ * actually open an index — importing this module must stay free. Same pattern
+ * as src/lib/threads-adapters.ts.
+ */
+async function loadSqlite(): Promise<{ DatabaseSync: new (file: string) => DatabaseHandle }> {
+  return (await import("node:sqlite")) as unknown as {
+    DatabaseSync: new (file: string) => DatabaseHandle;
+  };
+}
+
+const SCHEMA = `
+CREATE TABLE IF NOT EXISTS schema_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+CREATE TABLE IF NOT EXISTS documents (
+  provider_id TEXT NOT NULL,
+  doc_id TEXT NOT NULL,
+  entity_type TEXT NOT NULL,
+  title TEXT NOT NULL,
+  body TEXT NOT NULL,
+  excerpt TEXT NOT NULL,
+  project_id TEXT,
+  project_root TEXT,
+  familiar_id TEXT,
+  room_id TEXT,
+  session_id TEXT,
+  runtime TEXT,
+  status TEXT,
+  tags TEXT NOT NULL,
+  created_at TEXT,
+  updated_at TEXT,
+  source_type TEXT NOT NULL,
+  permissions TEXT NOT NULL,
+  source_version TEXT NOT NULL,
+  action TEXT NOT NULL,
+  secondary_actions TEXT NOT NULL,
+  PRIMARY KEY (provider_id, doc_id)
+);
+CREATE INDEX IF NOT EXISTS documents_entity ON documents(entity_type);
+CREATE INDEX IF NOT EXISTS documents_project ON documents(project_id);
+CREATE INDEX IF NOT EXISTS documents_familiar ON documents(familiar_id);
+CREATE INDEX IF NOT EXISTS documents_status ON documents(status);
+CREATE VIRTUAL TABLE IF NOT EXISTS documents_fts USING fts5(
+  title,
+  body,
+  tags,
+  provider_id UNINDEXED,
+  doc_id UNINDEXED
+);
+CREATE TABLE IF NOT EXISTS provider_state (
+  provider_id TEXT PRIMARY KEY,
+  fingerprint TEXT,
+  stale INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT
+);
+`;
+
+function ensureNotSymlink(file: string): void {
+  // A symlinked database is a redirection of where we write; refuse rather than
+  // follow it. Checked with lstat so the link itself is inspected.
+  let entry;
+  try {
+    entry = lstatSync(/* turbopackIgnore: true */ file);
+  } catch {
+    return; // absent is fine — it will be created
+  }
+  if (entry.isSymbolicLink()) {
+    throw new Error("search index path must not be a symlink");
+  }
+}
+
+function quarantine(file: string): void {
+  // Keep the damaged file next to the new one rather than deleting it: it costs
+  // nothing to retain, and a corrupt index is evidence about whatever produced
+  // it. The name is stable so repeated corruption overwrites one artifact
+  // instead of growing a pile.
+  try {
+    renameSync(/* turbopackIgnore: true */ file, `${file}.corrupt`);
+  } catch {
+    try {
+      rmSync(/* turbopackIgnore: true */ file, { force: true });
+    } catch {
+      /* the open below will surface anything still wrong */
+    }
+  }
+}
+
+function applyFilePermissions(file: string): void {
+  try {
+    const entry = statSync(/* turbopackIgnore: true */ file);
+    if ((entry.mode & 0o777) !== 0o600) {
+      chmodSync(/* turbopackIgnore: true */ file, 0o600);
+    }
+  } catch {
+    /* a freshly created database may not be flushed yet; retried next open */
+  }
+}
+
+function migrate(database: DatabaseHandle): void {
+  database.exec(SCHEMA);
+  const row = database
+    .prepare("SELECT value FROM schema_meta WHERE key = 'version'")
+    .get() as { value?: string } | undefined;
+  const current = Number(row?.value ?? 0);
+  if (current === SEARCH_INDEX_SCHEMA_VERSION) return;
+  if (current > SEARCH_INDEX_SCHEMA_VERSION) {
+    // A newer Cave wrote this. Refuse to reinterpret it — the index is
+    // derivative, so discarding and rebuilding is cheaper than guessing.
+    throw new Error("search index schema is newer than this build");
+  }
+  database
+    .prepare("INSERT OR REPLACE INTO schema_meta (key, value) VALUES ('version', ?)")
+    .run(String(SEARCH_INDEX_SCHEMA_VERSION));
+}
+
+async function openDatabase(file: string): Promise<DatabaseHandle> {
+  const { DatabaseSync } = await loadSqlite();
+  mkdirSync(/* turbopackIgnore: true */ path.dirname(file), { recursive: true });
+  ensureNotSymlink(file);
+
+  const open = () => {
+    const database = new DatabaseSync(file);
+    database.exec("PRAGMA journal_mode = WAL");
+    database.exec("PRAGMA foreign_keys = ON");
+    migrate(database);
+    return database;
+  };
+
+  try {
+    const database = open();
+    applyFilePermissions(file);
+    return database;
+  } catch (error) {
+    // Corrupt, truncated, or schema-incompatible. Quarantine and rebuild —
+    // never repair, because every row is reproducible from its source.
+    if (file === ":memory:") throw error;
+    quarantine(file);
+    const database = open();
+    applyFilePermissions(file);
+    return database;
+  }
+}
+
+const toRow = (record: Record<string, unknown>): SearchDocument => {
+  const parseJson = <T,>(value: unknown, fallback: T): T => {
+    if (typeof value !== "string") return fallback;
+    try {
+      return JSON.parse(value) as T;
+    } catch {
+      return fallback;
+    }
+  };
+  return normalizeSearchDocument({
+    id: record.doc_id,
+    providerId: record.provider_id,
+    entityType: record.entity_type,
+    title: record.title,
+    body: record.body,
+    excerpt: record.excerpt,
+    projectId: record.project_id,
+    projectRoot: record.project_root,
+    familiarId: record.familiar_id,
+    roomId: record.room_id,
+    sessionId: record.session_id,
+    runtime: record.runtime,
+    status: record.status,
+    tags: parseJson(record.tags, [] as string[]),
+    createdAt: record.created_at,
+    updatedAt: record.updated_at,
+    sourceType: record.source_type,
+    permissions: parseJson(record.permissions, [] as SearchDocument["permissions"]),
+    sourceVersion: record.source_version,
+    action: parseJson(record.action, { id: "", label: "" }),
+    secondaryActions: parseJson(record.secondary_actions, [] as SearchDocument["secondaryActions"]),
+  })!;
+};
+
+/** Escape a term for an FTS5 MATCH expression by quoting it. */
+function ftsTerm(term: string): string {
+  return `"${term.replaceAll('"', '""')}"`;
+}
+
+function buildMatchExpression(query: SearchIndexQuery): string | null {
+  const clauses: string[] = [];
+  for (const phrase of query.phrases ?? []) {
+    const trimmed = phrase.trim();
+    if (trimmed.length > 0) clauses.push(ftsTerm(trimmed));
+  }
+  const words = (query.text ?? "")
+    .split(/\s+/)
+    .map((word) => word.trim())
+    .filter((word) => word.length > 0);
+  for (const word of words) clauses.push(`${ftsTerm(word)}*`);
+  return clauses.length > 0 ? clauses.join(" AND ") : null;
+}
+
+export async function openSearchIndex(
+  file: string = searchIndexPath(),
+): Promise<SearchIndex> {
+  const database = await openDatabase(file);
+
+  const readProviderState = (providerId: string): ProviderIndexState | null => {
+    const row = database
+      .prepare("SELECT fingerprint, stale, updated_at FROM provider_state WHERE provider_id = ?")
+      .get(providerId) as
+      | { fingerprint?: string | null; stale?: number; updated_at?: string | null }
+      | undefined;
+    if (!row) return null;
+    const count = database
+      .prepare("SELECT COUNT(*) AS n FROM documents WHERE provider_id = ?")
+      .get(providerId) as { n?: number } | undefined;
+    return {
+      providerId,
+      fingerprint: row.fingerprint ?? null,
+      stale: Boolean(row.stale),
+      documentCount: Number(count?.n ?? 0),
+      updatedAt: row.updated_at ?? null,
+    };
+  };
+
+  return {
+    get file() {
+      return file;
+    },
+
+    refreshProvider(providerId, fingerprint, collect) {
+      const previous = readProviderState(providerId);
+      if (previous && !previous.stale && previous.fingerprint === fingerprint) {
+        // The source has not moved. Skipping is the whole point of carrying a
+        // fingerprint — a refresh that rescans an unchanged corpus is the cost
+        // this design exists to avoid.
+        return { providerId, skipped: true, upserted: 0, removed: 0, stale: false };
+      }
+
+      let upserted = 0;
+      let removed = 0;
+      database.exec("BEGIN IMMEDIATE");
+      try {
+        const seen = new Set<string>();
+        const insertDocument = database.prepare(
+          `INSERT INTO documents (
+             provider_id, doc_id, entity_type, title, body, excerpt,
+             project_id, project_root, familiar_id, room_id, session_id,
+             runtime, status, tags, created_at, updated_at, source_type,
+             permissions, source_version, action, secondary_actions
+           ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+           ON CONFLICT(provider_id, doc_id) DO UPDATE SET
+             entity_type=excluded.entity_type, title=excluded.title,
+             body=excluded.body, excerpt=excluded.excerpt,
+             project_id=excluded.project_id, project_root=excluded.project_root,
+             familiar_id=excluded.familiar_id, room_id=excluded.room_id,
+             session_id=excluded.session_id, runtime=excluded.runtime,
+             status=excluded.status, tags=excluded.tags,
+             created_at=excluded.created_at, updated_at=excluded.updated_at,
+             source_type=excluded.source_type, permissions=excluded.permissions,
+             source_version=excluded.source_version, action=excluded.action,
+             secondary_actions=excluded.secondary_actions`,
+        );
+        const deleteFts = database.prepare(
+          "DELETE FROM documents_fts WHERE provider_id = ? AND doc_id = ?",
+        );
+        const insertFts = database.prepare(
+          "INSERT INTO documents_fts (title, body, tags, provider_id, doc_id) VALUES (?,?,?,?,?)",
+        );
+        const existingVersion = database.prepare(
+          "SELECT source_version FROM documents WHERE provider_id = ? AND doc_id = ?",
+        );
+
+        for (const raw of collect()) {
+          const document = normalizeSearchDocument(raw);
+          // One malformed row loses its own fidelity; it does not abort the
+          // refresh and leave every other document stale.
+          if (!document || document.providerId !== providerId) continue;
+          seen.add(searchDocumentKey(document));
+
+          const prior = existingVersion.get(providerId, document.id) as
+            | { source_version?: string }
+            | undefined;
+          if (prior && prior.source_version === document.sourceVersion && document.sourceVersion !== "") {
+            continue; // unchanged row, per the provider's own fingerprint
+          }
+
+          insertDocument.run(
+            document.providerId,
+            document.id,
+            document.entityType,
+            document.title,
+            document.body,
+            document.excerpt,
+            document.projectId,
+            document.projectRoot,
+            document.familiarId,
+            document.roomId,
+            document.sessionId,
+            document.runtime,
+            document.status,
+            JSON.stringify(document.tags),
+            document.createdAt,
+            document.updatedAt,
+            document.sourceType,
+            JSON.stringify(document.permissions),
+            document.sourceVersion,
+            JSON.stringify(document.action),
+            JSON.stringify(document.secondaryActions),
+          );
+          deleteFts.run(document.providerId, document.id);
+          insertFts.run(
+            document.title,
+            document.body,
+            document.tags.join(" "),
+            document.providerId,
+            document.id,
+          );
+          upserted += 1;
+        }
+
+        // Documents the source no longer produces must leave the index, or a
+        // deleted task keeps answering searches forever.
+        const present = database
+          .prepare("SELECT doc_id FROM documents WHERE provider_id = ?")
+          .all(providerId) as { doc_id: string }[];
+        const deleteDocument = database.prepare(
+          "DELETE FROM documents WHERE provider_id = ? AND doc_id = ?",
+        );
+        for (const row of present) {
+          // Same key function as the insert side. Building it by hand here is
+          // exactly how the two spellings drift and this loop starts deleting
+          // rows the loop above just wrote.
+          if (seen.has(searchDocumentKey({ providerId, id: row.doc_id }))) continue;
+          deleteDocument.run(providerId, row.doc_id);
+          deleteFts.run(providerId, row.doc_id);
+          removed += 1;
+        }
+
+        database
+          .prepare(
+            `INSERT INTO provider_state (provider_id, fingerprint, stale, updated_at)
+             VALUES (?, ?, 0, ?)
+             ON CONFLICT(provider_id) DO UPDATE SET
+               fingerprint=excluded.fingerprint, stale=0, updated_at=excluded.updated_at`,
+          )
+          .run(providerId, fingerprint, new Date().toISOString());
+        database.exec("COMMIT");
+        return { providerId, skipped: false, upserted, removed, stale: false };
+      } catch (error) {
+        database.exec("ROLLBACK");
+        // The last verified snapshot survives untouched; it is simply flagged
+        // so callers can say "these results may be out of date" rather than
+        // presenting a half-written index as current.
+        database
+          .prepare(
+            `INSERT INTO provider_state (provider_id, fingerprint, stale, updated_at)
+             VALUES (?, NULL, 1, ?)
+             ON CONFLICT(provider_id) DO UPDATE SET stale=1, updated_at=excluded.updated_at`,
+          )
+          .run(providerId, new Date().toISOString());
+        return {
+          providerId,
+          skipped: false,
+          upserted: 0,
+          removed: 0,
+          stale: true,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    },
+
+    providerState: readProviderState,
+
+    match(query) {
+      const expression = buildMatchExpression(query);
+      const conditions: string[] = [];
+      const params: unknown[] = [];
+
+      const inClause = (column: string, values: string[] | undefined) => {
+        if (!values || values.length === 0) return;
+        conditions.push(`d.${column} IN (${values.map(() => "?").join(",")})`);
+        params.push(...values);
+      };
+
+      let sql: string;
+      if (expression) {
+        sql = `SELECT d.*, bm25(documents_fts) AS relevance
+               FROM documents_fts f
+               JOIN documents d ON d.provider_id = f.provider_id AND d.doc_id = f.doc_id
+               WHERE documents_fts MATCH ?`;
+        params.push(expression);
+      } else {
+        sql = "SELECT d.*, 0 AS relevance FROM documents d WHERE 1=1";
+      }
+
+      inClause("entity_type", query.entityTypes);
+      inClause("project_id", query.projectIds);
+      inClause("familiar_id", query.familiarIds);
+      inClause("status", query.statuses);
+      inClause("provider_id", query.providerIds);
+      if (conditions.length > 0) sql += ` AND ${conditions.join(" AND ")}`;
+      sql += expression ? " ORDER BY relevance" : " ORDER BY d.updated_at DESC";
+      sql += ` LIMIT ${Math.max(1, Math.min(query.limit ?? 50, 500))}`;
+
+      const staleProviders = new Set(
+        (database.prepare("SELECT provider_id FROM provider_state WHERE stale = 1").all() as {
+          provider_id: string;
+        }[]).map((row) => row.provider_id),
+      );
+
+      return (database.prepare(sql).all(...params) as Record<string, unknown>[]).map((record) => ({
+        document: toRow(record),
+        relevance: Number(record.relevance ?? 0),
+        stale: staleProviders.has(String(record.provider_id)),
+      }));
+    },
+
+    documentCount() {
+      const row = database.prepare("SELECT COUNT(*) AS n FROM documents").get() as
+        | { n?: number }
+        | undefined;
+      return Number(row?.n ?? 0);
+    },
+
+    rebuild() {
+      database.exec("BEGIN IMMEDIATE");
+      try {
+        database.exec("DELETE FROM documents");
+        database.exec("DELETE FROM documents_fts");
+        database.exec("DELETE FROM provider_state");
+        database.exec("COMMIT");
+      } catch (error) {
+        database.exec("ROLLBACK");
+        throw error;
+      }
+    },
+
+    close() {
+      database.close();
+    },
+  };
+}

--- a/src/lib/search-index-store.ts
+++ b/src/lib/search-index-store.ts
@@ -29,6 +29,7 @@ import path from "node:path";
 import { caveHome } from "./coven-paths.ts";
 import {
   normalizeSearchDocument,
+  rawDocumentIdentity,
   searchDocumentKey,
   type SearchDocument,
 } from "./search-document.ts";
@@ -386,9 +387,19 @@ export async function openSearchIndex(
 
         for (const raw of collect()) {
           const document = normalizeSearchDocument(raw);
-          // One malformed row loses its own fidelity; it does not abort the
-          // refresh and leave every other document stale.
-          if (!document || document.providerId !== providerId) continue;
+          if (!document || document.providerId !== providerId) {
+            // One malformed row loses its own fidelity — but ONLY its own. It
+            // must still count as "the source produced this id", or the
+            // deletion pass below reads it as withdrawn and drops the
+            // last good copy; a provider whose rows all fail to normalize
+            // would otherwise clear itself entirely. Identify it from the raw
+            // row so it can be protected even though it cannot be rewritten.
+            const identity = rawDocumentIdentity(raw);
+            if (identity && identity.providerId === providerId) {
+              seen.add(searchDocumentKey(identity));
+            }
+            continue;
+          }
           seen.add(searchDocumentKey(document));
 
           const prior = existingVersion.get(providerId, document.id) as


### PR DESCRIPTION
Closes cave-ychtl.2. Second implementation unit of the global intelligent search program (cave-ychtl), independent of unit 1 (#4481) by design — the plan has them running in parallel.

## What this is

**`src/lib/search-document.ts`** — the normalized `SearchDocument` every provider emits, plus the result contract. One shape across projects, familiars, tasks, sessions and files is what lets the coordinator rank them against each other at all.

`normalizeSearchDocument` is deliberately **total rather than throwing**: a provider emitting one malformed row costs that row its fidelity, not the whole refresh. Missing text becomes empty string, never `undefined`, so FTS never sees a null column.

**`src/lib/search-index-store.ts`** — the derivative SQLite/FTS5 index.

## Why the failure handling is blunt

The index is **always derivative** — every row is reproducible from an authoritative source. That is what licenses the posture here: a corrupt database is quarantined and rebuilt rather than repaired, and a failed refresh discards its own partial work rather than half-updating a provider. Losing the file costs a rescan and nothing else.

Store properties, per the spec: mode-0600, under Cave local state, separate from the daemon database, symlinked paths refused via `lstat`, transactional refreshes, deletable and rebuildable without user data loss.

## FTS5 with no new dependency

The repo has no third-party SQLite driver — it uses Node's built-in `node:sqlite`. Whether that build ships FTS5 decided whether this unit was buildable as designed, so it was **verified by execution before the plan was written**: `CREATE VIRTUAL TABLE … USING fts5`, an insert, and `MATCH … ORDER BY rank` all succeed on SQLite 3.53.1.

The import is lazy, matching the pattern already documented in `src/lib/threads-adapters.ts`, since `node:sqlite` is still flagged experimental. That makes the open path async while every other store operation stays synchronous.

## Refresh semantics

- A matching **provider fingerprint** skips collection entirely — the test asserts the collector is never even called, since avoiding the rescan is the whole reason providers carry one.
- A matching per-document **`sourceVersion`** skips that row's rewrite.
- Documents the source stops producing are **removed from both tables**, or a deleted task answers searches forever.
- A failure **rolls back** and marks the provider stale while the last verified snapshot stays searchable and flagged.
- The recorded fingerprint deliberately stays at the last **completed** refresh, because it describes which snapshot the surviving rows came from. A stale provider is never skipped even when the fingerprint matches.

## Two bugs the tests caught

**A NUL byte landed in the source** where a space was intended, as the key separator. The real defect it exposed was not the character: the store built the *same* key by hand in a second place with a literal space, so the two could never match and the deletion pass would have deleted every row the upsert pass had just written. The separator is now an explicit escape sequence — correct regardless, since either half may contain spaces and `"a b" + "c"` must not collide with `"a" + "b c"` — and both sites call the one key function. Pinned by a collision test.

**A test asserted the wrong contract.** It expected a failed refresh to null the stored fingerprint. Retaining the last completed value is the truthful record, and safe because a stale provider never skips. The test was corrected, not the code, and the assertion message now says why.

## Verification

| Gate | Result |
| --- | --- |
| `src/lib/search-index-store.test.ts` | passes |
| `pnpm check:tests-wired` | all 1590 wired |
| `pnpm typecheck` | clean |
| `pnpm lint` | see checks |
| `pnpm test:app` / `test:api` | see checks |

Coverage: 0600 permissions, symlink refusal, idempotent migration, fingerprint skip, `sourceVersion` skip, deletion propagation into FTS, stale-snapshot survival, mid-collection rollback, corruption quarantine and rebuild, FTS-syntax escaping, and a bounded result limit.

## Scope

Nothing queries this yet. Ranking, permission re-checks, provider selection and the `/api/search` contract are unit 4; the five MVP providers are unit 3. `match()` here is the primitive those build on — it applies FTS and metadata filters and returns raw `bm25` relevance, with no ranking policy of its own.
