### PR TITLE
docs(security): design user-bound auth for loopback callers

### DIFF
--- a/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
+++ b/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
@@ -1,0 +1,158 @@
+# User-bound authentication for loopback callers — design
+
+Status: design for review
+Bead: `cave-ruw4z`
+Source: final security review of the daemon-connectivity audit (`cave-58eoq`)
+
+## The defect
+
+Cave treats *a connection from this machine* as *a connection from this user*.
+Those are not the same claim, and TCP loopback can only support the first.
+
+Verified in the current tree, not inferred:
+
+- `server.ts` calls `isDirectLoopbackRequest(req)`, which checks that
+  `req.socket.remoteAddress` is loopback, that no forwarding headers are
+  present, and that `Host` is loopback. When all three hold it stamps
+  `x-coven-cave-local-peer` with a per-boot secret.
+- `proxy.ts` reads that stamp as `trustedLocalPeer` and lets the request past
+  the mobile access gate with no credential.
+- `server.ts` repeats the exemption on the PTY upgrade path: the 401 is skipped
+  entirely when `isDirectLoopbackRequest(req)` holds, even while a token is
+  configured.
+
+The per-boot secret is doing real work, but not this work. It stops a *remote*
+client from forging the header — the server deletes any client-supplied copy
+before Next sees it. It says nothing about *which local user* opened the
+socket, because the kernel does not offer that over TCP.
+
+## Consequence
+
+Any process, run by **any OS user on the machine**, that connects to
+`127.0.0.1:<port>` with a loopback `Host` and no forwarding headers is
+authenticated.
+
+| Surface | What an unprivileged local user gets |
+| --- | --- |
+| REST (`/api/**`) | Privileged workspace APIs as the Cave user |
+| PTY upgrade (`/api/pty-ws`) | **A shell running as the Cave process owner** |
+
+The PTY row is the severe one. It is a local privilege-escalation primitive: a
+second account on a shared Mac, a compromised low-privilege service account, or
+any sandboxed helper that can open a loopback socket obtains an interactive
+shell with the Cave user's full authority, including its credentials and its
+project checkouts. Adopting an existing session is equally reachable.
+
+This is not a remote-exploit finding. It matters exactly to the degree that
+something untrusted can run locally — which, on a developer machine that
+executes agent-authored code, is not a remote scenario.
+
+## Why the exemption exists
+
+It is load-bearing, and removing it naively has already broken the product
+once. The comments in `server.ts` record it: **#714 dropped this exemption and
+401'd every local terminal**, reproducing the v0.0.72 "Terminal connection
+failed" regression that `server-pty-ws.test.ts` still guards. `proxy.ts` and the
+PTY path are deliberately symmetric so the desktop shell and a local browser
+both work with no token configured.
+
+So the requirement is not "add auth". It is **add auth without a credential
+prompt for the two callers that legitimately have none today**: the Tauri shell
+and a local browser tab.
+
+## Options
+
+| Option | Binds identity to | Works for Tauri shell | Works for local browser | Verdict |
+| --- | --- | --- | --- | --- |
+| Keep TCP + per-boot stamp | machine only | yes | yes | **status quo — the defect** |
+| `SO_PEERCRED` / `LOCAL_PEERCRED` | OS uid, kernel-enforced | yes | — | Unavailable on TCP; needs a UDS |
+| Unix domain socket, 0600 | OS uid, kernel-enforced | yes | **no** — browsers cannot speak UDS | Strongest, insufficient alone |
+| Capability token in a 0600 file | filesystem ownership | yes — it can read the file | not directly — a page cannot read a file | Viable with a bootstrap |
+| Capability token + one-time bootstrap URL | filesystem ownership, then cookie | yes | yes | **Recommended** |
+| OS keychain item | OS user | yes | no | Same browser gap, more moving parts |
+
+## Recommendation
+
+A **per-boot capability token, written to a mode-0600 file under the user's own
+state directory**, required for privileged loopback operations. Another OS user
+cannot read the file, so possession of the token is evidence of being *this*
+user — the property TCP loopback cannot supply.
+
+Delivery differs by caller, which is the whole compatibility story:
+
+- **Tauri shell** — reads the file directly at startup and attaches the token
+  on REST and on the PTY upgrade. No user-visible change.
+- **Local browser** — cannot read a 0600 file, so it is bootstrapped exactly
+  once: the dev server prints a loopback URL carrying the token (the model
+  Jupyter and VS Code tunnels use), and the first request exchanges it for an
+  `HttpOnly`, `SameSite=Strict`, loopback-scoped session cookie. Subsequent
+  navigations carry the cookie. The token never appears in a page or in
+  `document.cookie`.
+- **Explicit tokenless development** stays available, but must become
+  *deliberate* rather than the silent default: an environment variable whose
+  name says what it does, refused when the process is not on loopback, and
+  surfaced in the UI so a machine left in that mode is visible rather than
+  quietly open.
+
+A Unix domain socket remains the stronger endpoint for the PTY specifically,
+and nothing here forecloses it — the token path is what keeps the browser
+working, and the two compose.
+
+## Decision matrix
+
+The contract the tests should pin. "Token" means the capability token or the
+cookie minted from it.
+
+| Caller | Transport | Credential | REST `/api/**` | PTY upgrade |
+| --- | --- | --- | --- | --- |
+| Tauri shell | loopback | token | allow | allow |
+| Local browser, bootstrapped | loopback | cookie | allow | allow |
+| Local browser, not yet bootstrapped | loopback | none | redirect to bootstrap | 401 |
+| **Other local OS user** | loopback | none | **401** | **401** |
+| Any local caller | loopback | wrong/expired token | 401 | 401 |
+| Tailscale-forwarded device | forwarded | allowlisted tailnet node | allow | allow |
+| Tailscale-forwarded device | forwarded | access token | allow | allow |
+| Tailscale-forwarded device | forwarded | none | 401 | 401 |
+| Any caller | non-loopback `Host` | none | 403 | 403 |
+| Explicit tokenless dev opt-in | loopback | none | allow | allow |
+| Explicit tokenless dev opt-in | forwarded | none | **401** | **401** |
+
+The fourth row is the defect this design closes. The last row matters nearly as
+much: the tokenless escape hatch must never widen remote access.
+
+## What this does not change
+
+- The forwarding-header and `Host` checks stay exactly as they are; they are
+  what keeps a Serve-forwarded phone from being read as local, and this design
+  adds to them rather than replacing them.
+- The tailnet-node path is untouched. A WireGuard-backed device identity is
+  already stronger evidence than a shared bearer token.
+- No change to what any surface can do once authenticated. This is about who is
+  admitted, not about authorization.
+
+## Rollout
+
+Sequenced so the terminal never breaks, because it already has once:
+
+1. Mint and persist the token; attach it in the Tauri shell; **accept it but do
+   not yet require it**. Ship the decision-matrix tests against current
+   behavior so the change in each cell is visible in a diff.
+2. Add the browser bootstrap and cookie exchange.
+3. Flip the PTY path to require it, keeping the explicit tokenless opt-in.
+4. Flip REST.
+5. Consider a UDS endpoint for the PTY as defence in depth.
+
+Each step is independently revertible, and steps 3 and 4 are the only ones that
+can lock anyone out. Verify both in the native Tauri shell before landing —
+headless checks did not catch #714.
+
+## Verification this design owes
+
+- Decision-matrix tests for REST and PTY covering every row above, including
+  the tokenless-opt-in rows.
+- A test that a second local user cannot authenticate. Simulated by presenting
+  no token from a loopback socket, since a test cannot become another uid.
+- A regression test for #714: the local terminal connects with no user-visible
+  credential step, in the shell and in a local browser tab.
+- Proof that the token file is 0600 and refused when it is a symlink.
+- Proof the tokenless opt-in refuses to widen a forwarded request.

--- a/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
+++ b/docs/superpowers/specs/2026-08-10-loopback-user-bound-auth-design.md
@@ -60,65 +60,105 @@ So the requirement is not "add auth". It is **add auth without a credential
 prompt for the two callers that legitimately have none today**: the Tauri shell
 and a local browser tab.
 
+## Scope decision: the desktop shell is the only credentialed caller
+
+Settled at the owner's direction, and it is the decision that shapes everything
+below: **a local browser tab is not a first-class authenticated caller.** Only
+the Tauri shell holds a credential.
+
+That removes the hardest constraint in this design. Every option below was
+previously judged on whether a web page could satisfy it, and the browser is
+the reason the weaker options were even on the list — a page cannot read a
+0600 file and cannot speak a Unix socket, so accommodating it forced a
+credential through a URL. With the browser out of scope, the strongest
+mechanism available becomes the simplest one to adopt.
+
+The cost is real and stated plainly rather than buried: **browser-driven work
+now depends on the explicit tokenless opt-in.** That covers `pnpm dev` in a
+normal browser, the browser-driven verification flows, and any Playwright run
+that is not already daemon-less. Those become deliberate opt-in territory
+instead of silently authenticated, which is the point — but it is a workflow
+change, not merely a security tightening, and whoever implements it should
+expect to touch those entry points.
+
 ## Options
 
-| Option | Binds identity to | Works for Tauri shell | Works for local browser | Verdict |
-| --- | --- | --- | --- | --- |
-| Keep TCP + per-boot stamp | machine only | yes | yes | **status quo — the defect** |
-| `SO_PEERCRED` / `LOCAL_PEERCRED` | OS uid, kernel-enforced | yes | — | Unavailable on TCP; needs a UDS |
-| Unix domain socket, 0600 | OS uid, kernel-enforced | yes | **no** — browsers cannot speak UDS | Strongest, insufficient alone |
-| Capability token in a 0600 file | filesystem ownership | yes — it can read the file | not directly — a page cannot read a file | Viable with a bootstrap |
-| Capability token + one-time bootstrap URL | filesystem ownership, then cookie | yes | yes | **Recommended** |
-| OS keychain item | OS user | yes | no | Same browser gap, more moving parts |
+| Option | Binds identity to | Works for Tauri shell | Verdict |
+| --- | --- | --- | --- |
+| Keep TCP + per-boot stamp | machine only | yes | **status quo — the defect** |
+| Capability token in a 0600 file | filesystem ownership | yes — it reads the file | Good; portable |
+| Unix domain socket, 0600 + peer credentials | **OS uid, kernel-enforced** | yes | **Recommended** |
+| OS keychain item | OS user | yes | Equivalent identity, more moving parts |
+| ~~Capability token + bootstrap URL~~ | filesystem, then cookie | yes | **Dropped** — existed only to serve the browser |
+
+A Unix domain socket is stronger than a token file in a way that matters: the
+uid is supplied by the kernel on the socket itself (`SO_PEERCRED` on Linux,
+`LOCAL_PEERCRED` / `getsockopt(SOL_LOCAL, …)` on macOS), so there is no secret
+to leak, copy, or accidentally log. A token file is only as good as its
+permissions and everything that ever reads it. On Windows the equivalent is a
+named pipe with an ACL restricted to the current user.
 
 ## Recommendation
 
-A **per-boot capability token, written to a mode-0600 file under the user's own
-state directory**, required for privileged loopback operations. Another OS user
-cannot read the file, so possession of the token is evidence of being *this*
-user — the property TCP loopback cannot supply.
+**Serve privileged loopback operations over a Unix domain socket whose peer uid
+must equal the server's own**, with a named pipe restricted to the current user
+as the Windows equivalent.
 
-Delivery differs by caller, which is the whole compatibility story:
-
-- **Tauri shell** — reads the file directly at startup and attaches the token
-  on REST and on the PTY upgrade. No user-visible change.
-- **Local browser** — cannot read a 0600 file, so it is bootstrapped exactly
-  once: the dev server prints a loopback URL carrying the token (the model
-  Jupyter and VS Code tunnels use), and the first request exchanges it for an
-  `HttpOnly`, `SameSite=Strict`, loopback-scoped session cookie. Subsequent
-  navigations carry the cookie. The token never appears in a page or in
-  `document.cookie`.
+- **Tauri shell** — connects over the socket instead of TCP. It already owns
+  its transport, so this is an internal change with no user-visible step: no
+  token to store, no secret to leak, no file whose permissions can drift.
+- **Everything else on TCP loopback** — keeps the existing `Host`, origin, and
+  forwarding-header checks, and additionally requires a real credential
+  (access token or allowlisted tailnet node) for anything privileged. The
+  machine-only stamp stops being sufficient on its own.
 - **Explicit tokenless development** stays available, but must become
   *deliberate* rather than the silent default: an environment variable whose
-  name says what it does, refused when the process is not on loopback, and
+  name says what it does, refused when the request is not on loopback, and
   surfaced in the UI so a machine left in that mode is visible rather than
-  quietly open.
+  quietly open. With the browser out of scope this is no longer a convenience —
+  it is the sanctioned path for browser-driven development, so its ergonomics
+  matter more than they would have.
 
-A Unix domain socket remains the stronger endpoint for the PTY specifically,
-and nothing here forecloses it — the token path is what keeps the browser
-working, and the two compose.
+Why the socket rather than the 0600 token file that was recommended before the
+scope decision: the token existed to be *transportable* to a caller that could
+not be identified any other way. Once the only credentialed caller is a process
+we control, the kernel can answer the identity question directly and no secret
+needs to exist at all. A token file is a secret whose safety depends on its
+permissions staying right forever, on nothing logging it, and on no future
+caller copying it somewhere convenient.
+
+Keep the token file only if the shell's transport turns out to be impractical
+to move — it is a genuine fallback with a materially weaker guarantee, not an
+equal alternative.
 
 ## Decision matrix
 
-The contract the tests should pin. "Token" means the capability token or the
-cookie minted from it.
+The contract the tests should pin. "Access token" is the existing shared
+credential; the desktop shell presents no token at all, because the socket
+identifies it.
 
 | Caller | Transport | Credential | REST `/api/**` | PTY upgrade |
 | --- | --- | --- | --- | --- |
-| Tauri shell | loopback | token | allow | allow |
-| Local browser, bootstrapped | loopback | cookie | allow | allow |
-| Local browser, not yet bootstrapped | loopback | none | redirect to bootstrap | 401 |
-| **Other local OS user** | loopback | none | **401** | **401** |
-| Any local caller | loopback | wrong/expired token | 401 | 401 |
+| Tauri shell | **unix socket** | kernel-verified peer uid | allow | allow |
+| Any caller | unix socket | peer uid ≠ server uid | **401** | **401** |
+| Local browser | loopback TCP | none | **401** | **401** |
+| Local browser | loopback TCP | access token | allow | allow |
+| **Other local OS user** | loopback TCP | none | **401** | **401** |
+| Any local caller | loopback TCP | wrong/expired token | 401 | 401 |
 | Tailscale-forwarded device | forwarded | allowlisted tailnet node | allow | allow |
 | Tailscale-forwarded device | forwarded | access token | allow | allow |
 | Tailscale-forwarded device | forwarded | none | 401 | 401 |
 | Any caller | non-loopback `Host` | none | 403 | 403 |
-| Explicit tokenless dev opt-in | loopback | none | allow | allow |
+| Explicit tokenless dev opt-in | loopback TCP | none | allow | allow |
 | Explicit tokenless dev opt-in | forwarded | none | **401** | **401** |
 
-The fourth row is the defect this design closes. The last row matters nearly as
-much: the tokenless escape hatch must never widen remote access.
+Row five is the defect this design closes — and note it is now closed by the
+*absence* of a rule rather than the presence of one: nothing on TCP loopback is
+privileged by virtue of being local, so there is no exemption left to get wrong.
+
+Row three is the deliberate cost of the scope decision. A plain local browser
+gets 401 unless it presents a token or the tokenless opt-in is on. The last row
+still matters most for safety: the escape hatch must never widen remote access.
 
 ## What this does not change
 
@@ -134,25 +174,44 @@ much: the tokenless escape hatch must never widen remote access.
 
 Sequenced so the terminal never breaks, because it already has once:
 
-1. Mint and persist the token; attach it in the Tauri shell; **accept it but do
-   not yet require it**. Ship the decision-matrix tests against current
-   behavior so the change in each cell is visible in a diff.
-2. Add the browser bootstrap and cookie exchange.
-3. Flip the PTY path to require it, keeping the explicit tokenless opt-in.
-4. Flip REST.
-5. Consider a UDS endpoint for the PTY as defence in depth.
+1. Ship the decision-matrix tests against **current** behavior, so every cell
+   that changes later shows up as a deliberate diff rather than a surprise.
+2. Open the unix socket alongside the existing TCP listener and serve both.
+   Nothing requires it yet; nothing can break.
+3. Move the Tauri shell onto the socket. Verify in the native shell, at both
+   pane widths, that the terminal and REST still work.
+4. Make the tokenless opt-in explicit, named, loopback-only, and visible in the
+   UI — **before** anything starts refusing, so the escape hatch exists by the
+   time people need it.
+5. Remove the direct-loopback exemption from the PTY path.
+6. Remove it from REST.
 
-Each step is independently revertible, and steps 3 and 4 are the only ones that
-can lock anyone out. Verify both in the native Tauri shell before landing —
-headless checks did not catch #714.
+Steps 5 and 6 are the only ones that can lock anyone out, and by then the shell
+is already off TCP and the opt-in already exists. Each step is independently
+revertible.
+
+Verify steps 3, 5 and 6 in the native Tauri shell rather than headlessly.
+Headless checks did not catch #714, and the failure mode is specifically that
+the terminal stops connecting — which a passing API test will not show.
+
+Note for step 5: `server.ts` currently reads `isDirectLoopbackRequest(req)`
+twice for two different purposes — stamping the local-peer header, and skipping
+the PTY 401. Only the second is being removed. Deleting the helper outright
+would also break the stamp that the Serve-forwarding logic depends on.
 
 ## Verification this design owes
 
 - Decision-matrix tests for REST and PTY covering every row above, including
-  the tokenless-opt-in rows.
-- A test that a second local user cannot authenticate. Simulated by presenting
-  no token from a loopback socket, since a test cannot become another uid.
+  the tokenless-opt-in rows. Landed **first**, against current behavior, so
+  each later flip shows up as a deliberate diff.
+- A test that a socket peer whose uid differs from the server's is refused.
+- A test that an uncredentialed loopback TCP caller is refused once steps 5–6
+  land — the defect row, asserted directly rather than implied.
 - A regression test for #714: the local terminal connects with no user-visible
-  credential step, in the shell and in a local browser tab.
-- Proof that the token file is 0600 and refused when it is a symlink.
+  credential step **in the native shell**.
+- Proof the socket path is 0600, refused when it is a symlink, and unlinked on
+  clean shutdown rather than left claimable by whoever binds it next.
 - Proof the tokenless opt-in refuses to widen a forwarded request.
+- A test that a plain local browser is refused without the opt-in — the cost of
+  the scope decision, pinned rather than discovered later by a confused
+  developer.


### PR DESCRIPTION
Addresses the design half of cave-ruw4z, raised by the final security review of the daemon-connectivity audit (cave-58eoq).

**Design only — no auth path changes in this PR.** It needs sign-off before anyone touches the gate, because the last attempt at this locked out every local terminal (see below).

## The defect, verified in the current tree

Cave treats *a connection from this machine* as *a connection from this user*. TCP loopback can only support the first.

- `server.ts` → `isDirectLoopbackRequest(req)` checks the socket peer is loopback, no forwarding headers are present, and `Host` is loopback. When all three hold it stamps `x-coven-cave-local-peer` with a per-boot secret.
- `proxy.ts` reads that stamp as `trustedLocalPeer` and admits the request with no credential.
- `server.ts` repeats the exemption on `/api/pty-ws`: the 401 is skipped entirely when `isDirectLoopbackRequest(req)` holds, **even while a token is configured**.

The per-boot secret is doing real work — it stops a *remote* client forging the header, since the server deletes any client-supplied copy before Next sees it. It says nothing about *which local user* opened the socket, because the kernel does not offer that over TCP.

## Consequence

Any process, run by **any OS user on the machine**, that connects to `127.0.0.1:<port>` with a loopback `Host` and no forwarding headers is authenticated.

| Surface | What an unprivileged local user gets |
| --- | --- |
| REST `/api/**` | Privileged workspace APIs as the Cave user |
| PTY upgrade | **An interactive shell as the Cave process owner** |

The PTY row is a local privilege-escalation primitive: a second account, a compromised service account, or any sandboxed helper that can open a loopback socket obtains a shell with the Cave user's full authority — credentials, project checkouts, and the ability to adopt existing sessions.

This is not a remote-exploit finding. It matters exactly to the degree that something untrusted can run locally, which on a machine that routinely executes agent-authored code is not a remote scenario.

## Why this is harder than "add auth"

The exemption is load-bearing and removing it naively has already broken the product once. `server.ts`'s own comments record it: **#714 dropped this exemption and 401'd every local terminal**, reproducing the v0.0.72 "Terminal connection failed" regression that `server-pty-ws.test.ts` still guards.

So the requirement is: add auth **without introducing a credential step for the two callers that legitimately have none today** — the Tauri shell and a local browser tab.

## Recommendation

A per-boot **capability token in a mode-0600 file** under the user's own state directory. Another OS user cannot read it, so possession is evidence of being *this* user — the property TCP loopback cannot supply.

Delivery differs by caller, which is the entire compatibility story:

- **Tauri shell** — reads the file directly and attaches the token. No user-visible change.
- **Local browser** — cannot read a 0600 file, so it is bootstrapped once via a loopback URL carrying the token (the Jupyter / VS Code tunnels model), exchanged immediately for an `HttpOnly`, `SameSite=Strict` cookie. The token never reaches page script.
- **Explicit tokenless development** survives, but becomes deliberate rather than the silent default, and is refused on forwarded requests so the escape hatch can never widen remote access.

A Unix domain socket is stronger for the PTY specifically and is kept as a later step — the token path is what keeps the browser working, and the two compose.

The doc includes the full **REST/PTY decision matrix** the tests should pin, covering every caller/transport/credential combination, plus the tokenless-opt-in rows.

## Rollout

Sequenced so the terminal never breaks, because it already has once: mint and *accept* the token before requiring it, ship the decision-matrix tests against current behavior so each cell's change is visible in a diff, add the browser bootstrap, then flip PTY, then REST. Only the last two can lock anyone out, and both must be verified in the native Tauri shell — headless checks did not catch #714.

## What is deliberately unchanged

The forwarding-header and `Host` checks stay exactly as they are; they are what keeps a Serve-forwarded phone from reading as local, and this design adds to them rather than replacing them. The tailnet-node path is untouched — a WireGuard-backed device identity is already stronger evidence than a shared bearer token. Nothing here changes what any surface may *do* once authenticated; this is admission, not authorization.
