### PR TITLE
feat(search): provider contract, registry, and live file provider (unit 3, part 1)

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -459,6 +459,7 @@ export const SUITES = {
     "src/lib/command-palette-search.test.ts",
     "src/lib/search-query.test.ts",
     "src/lib/search-index-store.test.ts",
+    "src/lib/search-provider.test.ts",
     "src/lib/command-palette-salem-context.test.ts",
     "src/lib/command-palette-scope.test.ts",
     "src/lib/recent-searches.test.ts",
@@ -1649,6 +1650,9 @@ const STRIP_TYPES_MJS = new Set([
 // Tests whose import graph reaches the "@/..." path alias and therefore need
 // the alias-resolving loader (`scripts/test-alias-register.mjs`).
 const ALIAS_LOADER = new Set([
+  // the file provider wraps server/project-paths.ts, which resolves "@/lib/..."
+  // for the project allow-list; the suite cannot load without the resolver.
+  "src/lib/search-provider.test.ts",
   // cave-board.ts resolves "@/lib/cave-board-types", "@/lib/task-github" and
   // friends, so the retention suite cannot load without the alias resolver.
   "src/lib/cave-board-retention.test.ts",

--- a/src/lib/search-file-provider.ts
+++ b/src/lib/search-file-provider.ts
@@ -180,21 +180,34 @@ export function createFileSearchProvider(options: FileProviderOptions): SearchPr
       }
 
       const projectId = options.activeProjectId();
-      if (
-        context.allowedProjectIds !== null &&
-        projectId !== null &&
-        !context.allowedProjectIds.includes(projectId)
-      ) {
-        return {
-          documents: [],
-          diagnostics: [
-            {
-              providerId: FILE_PROVIDER_ID,
-              code: "permission-denied",
-              message: "project is not readable by this requester",
-            },
-          ],
-        };
+      const denied = {
+        documents: [] as SearchDocument[],
+        diagnostics: [
+          {
+            providerId: FILE_PROVIDER_ID,
+            code: "permission-denied" as const,
+            message: "project is not readable by this requester",
+          },
+        ],
+      };
+
+      // Both checks fail CLOSED on an unresolvable identity. An earlier version
+      // skipped the id check whenever `activeProjectId()` returned null, which
+      // meant an unidentifiable project searched successfully in a restricted
+      // context — the restriction was enforced only when there was something to
+      // enforce it against.
+      if (context.allowedProjectIds !== null) {
+        if (projectId === null) return denied;
+        if (!context.allowedProjectIds.includes(projectId)) return denied;
+      }
+      // And the root restriction was previously not enforced at all. A caller
+      // limited to specific roots must not search one it was never granted,
+      // whatever the project id says.
+      if (context.allowedProjectRoots !== null) {
+        const granted = context.allowedProjectRoots.some(
+          (candidate) => path.resolve(candidate) === path.resolve(root),
+        );
+        if (!granted) return denied;
       }
 
       let stdout: string;
@@ -207,8 +220,10 @@ export function createFileSearchProvider(options: FileProviderOptions): SearchPr
             {
               providerId: FILE_PROVIDER_ID,
               code: "unavailable",
-              // Category only. The underlying error can carry a path.
-              message: error instanceof Error && /ENOENT/.test(error.message)
+              // Category only — the underlying error can carry a path.
+              // Read `code`, not the message: Node sets ENOENT on the error
+              // object itself, and message formats are not a stable contract.
+              message: (error as { code?: unknown } | null)?.code === "ENOENT"
                 ? "ripgrep is not installed"
                 : "file search failed",
             },

--- a/src/lib/search-file-provider.ts
+++ b/src/lib/search-file-provider.ts
@@ -1,0 +1,275 @@
+/**
+ * search-file-provider — current-project file bodies as a LIVE search provider
+ * (cave-ychtl.3).
+ *
+ * This is the security-sensitive provider, and its design rule is that it adds
+ * no new access path. Every guard the existing project-search route relies on
+ * is reused here rather than reimplemented:
+ *
+ *   - the root must resolve through `resolveAllowedProjectPath`, or be a root
+ *     the daemon already holds a live session for;
+ *   - ripgrep is spawned through `execFile` with an ARGUMENT ARRAY — never a
+ *     shell — so a query can never be interpreted as a command;
+ *   - the query is passed after `--`, so it can never be read as a flag;
+ *   - `.env*` stays excluded by glob at both depths;
+ *   - ripgrep's own `.gitignore`/hidden/binary defaults keep results on the
+ *     same git-visible surface as the rest of the product.
+ *
+ * A second implementation of any of those is a second thing to get wrong, and
+ * the reason the file corpus is LIVE rather than indexed is the same instinct:
+ * indexing repository bodies would copy content out of the place whose
+ * permissions govern it.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ */
+
+import { execFile } from "node:child_process";
+import path from "node:path";
+import { parseRipgrepJson } from "./project-search.ts";
+import { resolveAllowedProjectPath } from "./server/project-paths.ts";
+import { normalizeSearchDocument, type SearchDocument } from "./search-document.ts";
+import {
+  permitsByProject,
+  type SearchProvider,
+  type SearchProviderDiagnostic,
+  type SearchProviderQuery,
+  type SearchRequesterContext,
+} from "./search-provider.ts";
+
+export const FILE_PROVIDER_ID = "files";
+
+/** Mirrors the route's caps so neither side can drift into being the loose one. */
+const RG_TIMEOUT_MS = 15_000;
+const MAX_RG_BUFFER = 16 * 1024 * 1024;
+const MAX_QUERY_LEN = 1024;
+const RG_MAX_COUNT = 50;
+
+export type FileProviderOptions = {
+  /** Resolves the active project root; null when no project scope is active. */
+  activeProjectRoot: () => string | null;
+  /** Project id for the active root, used for permissions and result scope. */
+  activeProjectId: () => string | null;
+  /** Roots the daemon holds a live session for — the route's second allowance. */
+  sessionRoots?: () => string[];
+  /** Injectable for tests. Defaults to a real ripgrep spawn. */
+  runSearch?: (cwd: string, args: string[]) => Promise<{ stdout: string; code: number }>;
+};
+
+function runRipgrep(cwd: string, args: string[]): Promise<{ stdout: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "rg",
+      args,
+      { windowsHide: true, cwd, timeout: RG_TIMEOUT_MS, maxBuffer: MAX_RG_BUFFER },
+      (error, stdout) => {
+        if (!error) return resolve({ stdout, code: 0 });
+        // Exit 1 is "no matches", which is a successful search.
+        if ((error as { code?: number }).code === 1) return resolve({ stdout: stdout ?? "", code: 1 });
+        reject(error);
+      },
+    );
+  });
+}
+
+/**
+ * Build ripgrep's arguments.
+ *
+ * The query goes last, after `--`, and is never interpolated anywhere. Keep it
+ * that way: this array is the only reason a query containing `-e` or `--type`
+ * is data rather than instruction.
+ */
+export function buildFileSearchArgs(query: string): string[] {
+  return [
+    "--json",
+    "--max-count",
+    String(RG_MAX_COUNT),
+    "--max-columns",
+    "2000",
+    "--no-messages",
+    "--fixed-strings",
+    "--smart-case",
+    "--glob",
+    "!.env*",
+    "--glob",
+    "!**/.env*",
+    "--",
+    query,
+    ".",
+  ];
+}
+
+/**
+ * Whether `root` is a root this provider may search.
+ *
+ * Exported so the contract is testable directly: the allowance is the static
+ * project allow-list OR a root the daemon already booted a session in, and
+ * nothing else.
+ */
+export function resolveSearchableRoot(
+  root: string,
+  sessionRoots: string[],
+): string | null {
+  const allowed = resolveAllowedProjectPath(root);
+  if (allowed) return allowed;
+  const normalized = path.resolve(root);
+  return sessionRoots.some((candidate) => path.resolve(candidate) === normalized)
+    ? normalized
+    : null;
+}
+
+export function createFileSearchProvider(options: FileProviderOptions): SearchProvider {
+  const run = options.runSearch ?? runRipgrep;
+
+  return {
+    id: FILE_PROVIDER_ID,
+    kind: "live",
+    entityTypes: ["file"],
+    // No status, runtime, room or tag on a file. Declaring them would make the
+    // provider selectable for queries it cannot honor, which is exactly the
+    // silent widening the spec forbids.
+    supportedFilters: ["type", "project", "has"],
+
+    async fingerprint() {
+      // A live provider is never indexed, so its fingerprint only has to be
+      // stable. Returning a changing value would invite a caller to try to
+      // index it.
+      return `${FILE_PROVIDER_ID}:live`;
+    },
+
+    permits(document, context) {
+      return permitsByProject(document, context);
+    },
+
+    async query(
+      query: SearchProviderQuery,
+      context: SearchRequesterContext,
+    ): Promise<{ documents: SearchDocument[]; diagnostics: SearchProviderDiagnostic[] }> {
+      const diagnostics: SearchProviderDiagnostic[] = [];
+      const term = [query.text, ...query.phrases].join(" ").trim();
+      if (term.length === 0) return { documents: [], diagnostics };
+      if (term.length > MAX_QUERY_LEN) {
+        return {
+          documents: [],
+          diagnostics: [
+            { providerId: FILE_PROVIDER_ID, code: "malformed-source", message: "query too long" },
+          ],
+        };
+      }
+
+      const requestedRoot = options.activeProjectRoot();
+      if (!requestedRoot) {
+        // No project scope means nothing to search. This is not an error and
+        // must not read as one — a file result simply cannot exist yet.
+        return { documents: [], diagnostics };
+      }
+
+      const root = resolveSearchableRoot(requestedRoot, options.sessionRoots?.() ?? []);
+      if (!root) {
+        // Refused, and the diagnostic deliberately names no path — a denial
+        // must not disclose the location it denied.
+        return {
+          documents: [],
+          diagnostics: [
+            {
+              providerId: FILE_PROVIDER_ID,
+              code: "permission-denied",
+              message: "project root is not searchable",
+            },
+          ],
+        };
+      }
+
+      const projectId = options.activeProjectId();
+      if (
+        context.allowedProjectIds !== null &&
+        projectId !== null &&
+        !context.allowedProjectIds.includes(projectId)
+      ) {
+        return {
+          documents: [],
+          diagnostics: [
+            {
+              providerId: FILE_PROVIDER_ID,
+              code: "permission-denied",
+              message: "project is not readable by this requester",
+            },
+          ],
+        };
+      }
+
+      let stdout: string;
+      try {
+        ({ stdout } = await run(root, buildFileSearchArgs(term)));
+      } catch (error) {
+        return {
+          documents: [],
+          diagnostics: [
+            {
+              providerId: FILE_PROVIDER_ID,
+              code: "unavailable",
+              // Category only. The underlying error can carry a path.
+              message: error instanceof Error && /ENOENT/.test(error.message)
+                ? "ripgrep is not installed"
+                : "file search failed",
+            },
+          ],
+        };
+      }
+
+      const parsed = parseRipgrepJson(stdout, { maxMatches: query.limit });
+      const documents: SearchDocument[] = [];
+      for (const group of parsed.files) {
+        const relativePath = group.path;
+        const firstMatch = group.matches[0];
+        const document = normalizeSearchDocument({
+          // Relative path only: `providerId + id` must not embed an absolute
+          // filesystem location, since the id travels into result payloads.
+          id: relativePath,
+          providerId: FILE_PROVIDER_ID,
+          entityType: "file",
+          title: path.basename(relativePath),
+          body: group.matches.map((match) => match.preview).join("\n"),
+          excerpt: firstMatch?.preview?.trim() ?? "",
+          projectId,
+          // projectRoot stays null: the coordinator permission-checks on
+          // projectId, and emitting the absolute root would put it in a payload
+          // the requester may not be entitled to see.
+          projectRoot: null,
+          familiarId: null,
+          roomId: null,
+          sessionId: null,
+          runtime: null,
+          status: null,
+          tags: [],
+          createdAt: null,
+          updatedAt: null,
+          sourceType: "file",
+          permissions: projectId ? [{ kind: "project", id: projectId }] : [],
+          // Live results are never indexed, so the version only needs to
+          // distinguish this answer from another for the same path.
+          sourceVersion: `${group.matches.length}:${firstMatch?.line ?? 0}`,
+          action: {
+            id: "open-file",
+            label: `Open ${path.basename(relativePath)}`,
+            href: `/projects/files?path=${encodeURIComponent(relativePath)}`,
+          },
+          secondaryActions: [],
+        });
+        if (document) documents.push(document);
+      }
+
+      if (parsed.truncated) {
+        diagnostics.push({
+          providerId: FILE_PROVIDER_ID,
+          code: "malformed-source",
+          message: "file results were truncated",
+        });
+      }
+
+      return {
+        documents: documents.filter((document) => permitsByProject(document, context)),
+        diagnostics,
+      };
+    },
+  };
+}

--- a/src/lib/search-provider.test.ts
+++ b/src/lib/search-provider.test.ts
@@ -132,6 +132,14 @@ assert.throws(
   const familiarDoc = { ...doc, permissions: [{ kind: "familiar", id: "cody" }], projectId: null };
   assert.equal(permitsByProject(familiarDoc, { ...unrestricted, familiarId: "nova" }), false);
   assert.equal(permitsByProject(familiarDoc, { ...unrestricted, familiarId: "cody" }), true);
+  // No active familiar fails CLOSED. `familiarId: null` means this surface has
+  // no familiar, not "every familiar" — reading it as unrestricted is how a
+  // familiar-scoped row leaks into an unscoped search.
+  assert.equal(
+    permitsByProject(familiarDoc, { ...unrestricted, familiarId: null }),
+    false,
+    "a familiar-scoped document is hidden when there is no active familiar",
+  );
 }
 
 /* ---------------------------------------------------------------------- */
@@ -284,7 +292,14 @@ assert.throws(
     activeProjectRoot: () => "/tmp",
     activeProjectId: () => "proj",
     sessionRoots: () => ["/tmp"],
-    runSearch: async () => { throw new Error("spawn rg ENOENT /secret/path"); },
+    runSearch: async () => {
+      // The real shape: Node puts ENOENT on the error object, and the message
+      // can carry a path. Detection reads code; the assertion below proves the
+      // message never reaches the diagnostic.
+      const error = new Error("spawn rg ENOENT /secret/path");
+      error.code = "ENOENT";
+      throw error;
+    },
   });
   const { documents, diagnostics } = await p.query(
     { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
@@ -311,6 +326,86 @@ assert.throws(
     }),
     false,
   );
+}
+
+/* ---------------------------------------------------------------------- */
+/* File provider fails closed on an unresolvable identity                  */
+/* ---------------------------------------------------------------------- */
+
+// A restricted requester and a project the provider cannot identify must be a
+// DENIAL, not a search. An earlier version skipped the id check whenever
+// activeProjectId() returned null, so the restriction applied only when there
+// was something to apply it against.
+{
+  let ran = false;
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => null,
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => { ran = true; return { stdout: "", code: 0 }; },
+  });
+  const { documents, diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    { allowedProjectIds: ["proj"], allowedProjectRoots: null, familiarId: null },
+  );
+  assert.equal(ran, false, "an unidentifiable project must not be searched under a restriction");
+  assert.deepEqual(documents, []);
+  assert.equal(diagnostics[0].code, "permission-denied");
+}
+
+// allowedProjectRoots is enforced, not merely declared. A caller limited to
+// specific roots must not search one it was never granted.
+{
+  let ran = false;
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => { ran = true; return { stdout: "", code: 0 }; },
+  });
+  const { documents, diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    { allowedProjectIds: null, allowedProjectRoots: ["/somewhere/else"], familiarId: null },
+  );
+  assert.equal(ran, false, "a root outside the granted list must not be searched");
+  assert.deepEqual(documents, []);
+  assert.equal(diagnostics[0].code, "permission-denied");
+}
+
+// A granted root still works, so the check above is not simply refusing
+// everything.
+{
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => ({ stdout: "", code: 1 }),
+  });
+  const { diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    { allowedProjectIds: ["proj"], allowedProjectRoots: ["/tmp"], familiarId: null },
+  );
+  assert.deepEqual(diagnostics, [], "a granted root and id searches normally");
+}
+
+// ENOENT is read off error.code, not the message — message formats are not a
+// stable contract, and a path can appear in them.
+{
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => {
+      const error = new Error("some message with no marker");
+      error.code = "ENOENT";
+      throw error;
+    },
+  });
+  const { diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.equal(diagnostics[0].message, "ripgrep is not installed");
 }
 
 console.log("search-provider.test.ts: ok");

--- a/src/lib/search-provider.test.ts
+++ b/src/lib/search-provider.test.ts
@@ -1,0 +1,316 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import {
+  createProviderRegistry,
+  permitsByProject,
+  providerHonorsQuery,
+  selectProviders,
+} from "./search-provider.ts";
+import {
+  buildFileSearchArgs,
+  createFileSearchProvider,
+  FILE_PROVIDER_ID,
+} from "./search-file-provider.ts";
+
+const provider = (overrides = {}) => ({
+  id: "tasks",
+  kind: "indexed",
+  entityTypes: ["task"],
+  supportedFilters: ["type", "status", "project", "familiar", "tag"],
+  fingerprint: async () => "fp",
+  permits: () => true,
+  ...overrides,
+});
+
+const unrestricted = { allowedProjectIds: null, allowedProjectRoots: null, familiarId: null };
+
+/* ---------------------------------------------------------------------- */
+/* Provider selection — the filtered-empty contract                        */
+/* ---------------------------------------------------------------------- */
+
+// A provider that cannot honor a filter must be EXCLUDED, not allowed to
+// ignore it. Ignoring is how `status:blocked` starts returning projects, which
+// have no status — the spec calls that silently widening.
+{
+  const tasks = provider();
+  const projects = provider({
+    id: "projects",
+    entityTypes: ["project"],
+    supportedFilters: ["type", "project", "tag"],
+  });
+
+  const statusQuery = {
+    entityTypes: [],
+    filters: [{ key: "status", operator: "is", value: "blocked", origin: "syntax" }],
+  };
+  assert.equal(providerHonorsQuery(tasks, statusQuery), true);
+  assert.equal(
+    providerHonorsQuery(projects, statusQuery),
+    false,
+    "a provider without status must be excluded rather than ignore the filter",
+  );
+  assert.deepEqual(
+    selectProviders([tasks, projects], statusQuery).map((entry) => entry.id),
+    ["tasks"],
+  );
+}
+
+// Declaring a filter is not enough — it must also APPLY to an entity type the
+// provider emits, or honoring it is vacuous.
+{
+  const projectsClaimingStatus = provider({
+    id: "projects",
+    entityTypes: ["project"],
+    supportedFilters: ["type", "status"],
+  });
+  assert.equal(
+    providerHonorsQuery(projectsClaimingStatus, {
+      entityTypes: [],
+      filters: [{ key: "status", operator: "is", value: "blocked", origin: "syntax" }],
+    }),
+    false,
+    "status does not apply to projects, so claiming it must not win selection",
+  );
+}
+
+// An entity-type scope narrows to providers that can emit it.
+{
+  const tasks = provider();
+  const files = provider({ id: "files", entityTypes: ["file"], supportedFilters: ["type"] });
+  assert.deepEqual(
+    selectProviders([tasks, files], { entityTypes: ["file"], filters: [] }).map((e) => e.id),
+    ["files"],
+  );
+}
+
+/* ---------------------------------------------------------------------- */
+/* Registry                                                                */
+/* ---------------------------------------------------------------------- */
+
+// Duplicate ids would collide on providerId+docId in the index, so one
+// provider would silently overwrite the other's documents.
+assert.throws(
+  () => createProviderRegistry([provider(), provider()]),
+  /duplicate search provider id: tasks/,
+);
+
+{
+  const registry = createProviderRegistry([
+    provider(),
+    provider({ id: "files", kind: "live", entityTypes: ["file"], supportedFilters: ["type"] }),
+  ]);
+  assert.equal(registry.byId("files").kind, "live");
+  assert.equal(registry.byId("missing"), null);
+  assert.deepEqual(registry.indexed().map((e) => e.id), ["tasks"]);
+  assert.deepEqual(registry.live().map((e) => e.id), ["files"]);
+}
+
+/* ---------------------------------------------------------------------- */
+/* Permissions fail closed                                                 */
+/* ---------------------------------------------------------------------- */
+
+{
+  const doc = {
+    id: "t1", providerId: "tasks", entityType: "task", title: "", body: "", excerpt: "",
+    projectId: "secret", projectRoot: null, familiarId: null, roomId: null, sessionId: null,
+    runtime: null, status: null, tags: [], createdAt: null, updatedAt: null,
+    sourceType: "tasks", permissions: [{ kind: "project", id: "secret" }],
+    sourceVersion: "v", action: { id: "a", label: "" }, secondaryActions: [],
+  };
+
+  assert.equal(permitsByProject(doc, unrestricted), true, "unrestricted context sees everything");
+  assert.equal(
+    permitsByProject(doc, { ...unrestricted, allowedProjectIds: ["other"] }),
+    false,
+    "a project the requester has no entry for is hidden, not shown",
+  );
+  assert.equal(
+    permitsByProject(doc, { ...unrestricted, allowedProjectIds: ["secret"] }),
+    true,
+  );
+
+  const familiarDoc = { ...doc, permissions: [{ kind: "familiar", id: "cody" }], projectId: null };
+  assert.equal(permitsByProject(familiarDoc, { ...unrestricted, familiarId: "nova" }), false);
+  assert.equal(permitsByProject(familiarDoc, { ...unrestricted, familiarId: "cody" }), true);
+}
+
+/* ---------------------------------------------------------------------- */
+/* File provider — the security-sensitive one                              */
+/* ---------------------------------------------------------------------- */
+
+// The argument array IS the injection defence: the query is data because it
+// sits after `--`, never because it was escaped.
+{
+  const args = buildFileSearchArgs("--type=js -e evil");
+  const separator = args.indexOf("--");
+  assert.ok(separator > 0, "a bare -- separator must be present");
+  assert.equal(
+    args[separator + 1],
+    "--type=js -e evil",
+    "the query is the single argument after --, flags and all",
+  );
+  assert.equal(args[separator + 2], ".", "the search path follows the query");
+  assert.ok(args.includes("--fixed-strings"), "queries are literal by default");
+}
+
+// `.env` exclusion survives at both depths.
+{
+  const args = buildFileSearchArgs("token");
+  assert.ok(args.includes("!.env*"));
+  assert.ok(args.includes("!**/.env*"));
+}
+
+// A root outside the allow-list and outside the daemon's session roots is
+// refused, and the refusal names no path.
+{
+  let ran = false;
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/definitely/not/allowed",
+    activeProjectId: () => "proj",
+    sessionRoots: () => [],
+    runSearch: async () => { ran = true; return { stdout: "", code: 0 }; },
+  });
+  const { documents, diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.equal(ran, false, "a refused root must not reach ripgrep at all");
+  assert.deepEqual(documents, []);
+  assert.equal(diagnostics[0].code, "permission-denied");
+  // Check for PATH leakage specifically — an earlier version of this assertion
+  // also banned the word "not", which the ordinary phrase "is not searchable"
+  // trips. The contract is about paths, not vocabulary.
+  assert.doesNotMatch(diagnostics[0].message, /\//, "a denial must not contain a path separator");
+  assert.doesNotMatch(diagnostics[0].message, /definitely/, "nor any segment of the denied path");
+}
+
+// No active project is an empty result, NOT an error — a file result simply
+// cannot exist yet, and a diagnostic here would read as a broken provider.
+{
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => null,
+    activeProjectId: () => null,
+    runSearch: async () => ({ stdout: "", code: 0 }),
+  });
+  const result = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.deepEqual(result.documents, []);
+  assert.deepEqual(result.diagnostics, []);
+}
+
+// An empty query does no work rather than matching everything.
+{
+  let ran = false;
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => { ran = true; return { stdout: "", code: 0 }; },
+  });
+  const result = await p.query(
+    { text: "  ", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.equal(ran, false);
+  assert.deepEqual(result.documents, []);
+}
+
+// A session root the daemon already booted is searchable — the route's second
+// allowance, preserved.
+{
+  const events = [
+    JSON.stringify({ type: "begin", data: { path: { text: "src/app.ts" } } }),
+    JSON.stringify({
+      type: "match",
+      data: {
+        path: { text: "src/app.ts" },
+        lines: { text: "const needle = 1\n" },
+        line_number: 12,
+        submatches: [{ start: 6, end: 12 }],
+      },
+    }),
+    JSON.stringify({ type: "end", data: { path: { text: "src/app.ts" } } }),
+  ].join("\n");
+
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => ({ stdout: events, code: 0 }),
+  });
+  const { documents } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.equal(documents.length, 1);
+  const [doc] = documents;
+  assert.equal(doc.providerId, FILE_PROVIDER_ID);
+  assert.equal(doc.entityType, "file");
+  assert.equal(doc.id, "src/app.ts", "the id is a RELATIVE path");
+  assert.equal(doc.title, "app.ts");
+  assert.equal(
+    doc.projectRoot,
+    null,
+    "the absolute root is never emitted into a result payload",
+  );
+  assert.doesNotMatch(JSON.stringify(doc), /\/tmp/, "no absolute path anywhere in the document");
+  assert.deepEqual(doc.permissions, [{ kind: "project", id: "proj" }]);
+}
+
+// A requester who cannot read the project gets nothing, and ripgrep is never
+// spawned on their behalf.
+{
+  let ran = false;
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => { ran = true; return { stdout: "", code: 0 }; },
+  });
+  const { documents, diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    { ...unrestricted, allowedProjectIds: ["someone-else"] },
+  );
+  assert.equal(ran, false, "permission is checked BEFORE spawning a search");
+  assert.deepEqual(documents, []);
+  assert.equal(diagnostics[0].code, "permission-denied");
+}
+
+// A ripgrep failure is a safe category, never the raw error.
+{
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => "/tmp",
+    activeProjectId: () => "proj",
+    sessionRoots: () => ["/tmp"],
+    runSearch: async () => { throw new Error("spawn rg ENOENT /secret/path"); },
+  });
+  const { documents, diagnostics } = await p.query(
+    { text: "needle", phrases: [], filters: [], projectIds: [], familiarIds: [], entityTypes: [], limit: 10 },
+    unrestricted,
+  );
+  assert.deepEqual(documents, []);
+  assert.equal(diagnostics[0].code, "unavailable");
+  assert.equal(diagnostics[0].message, "ripgrep is not installed");
+  assert.doesNotMatch(diagnostics[0].message, /secret/, "the raw error must not leak");
+}
+
+// The file provider declares only filters it can honor, so it is not selected
+// for a status query it would have to ignore.
+{
+  const p = createFileSearchProvider({
+    activeProjectRoot: () => null,
+    activeProjectId: () => null,
+  });
+  assert.equal(p.kind, "live", "file bodies are never indexed");
+  assert.equal(
+    providerHonorsQuery(p, {
+      entityTypes: [],
+      filters: [{ key: "status", operator: "is", value: "blocked", origin: "syntax" }],
+    }),
+    false,
+  );
+}
+
+console.log("search-provider.test.ts: ok");

--- a/src/lib/search-provider.ts
+++ b/src/lib/search-provider.ts
@@ -1,0 +1,179 @@
+/**
+ * search-provider — the contract every search corpus implements, and the
+ * registry the coordinator selects from (cave-ychtl.3).
+ *
+ * A provider does four things and no more: report a fingerprint for its
+ * source, emit normalized documents, declare which filters it can honor, and
+ * decide whether a given requester may see a document. It never ranks, never
+ * decides presentation, and never reaches past its own source. Ranking and the
+ * second permission check belong to the coordinator (unit 4) — a provider that
+ * pre-ranks makes cross-corpus comparison impossible, which is the entire
+ * reason the normalized document exists.
+ *
+ * Two kinds exist, and the difference is not cosmetic:
+ *
+ *   - INDEXED providers are collected into the FTS5 store ahead of a query.
+ *     They are bounded corpora whose whole content can sit in a local index.
+ *   - LIVE providers are queried at request time and never indexed. Project
+ *     file bodies are the motivating case: indexing every repository would
+ *     duplicate potentially huge workspaces and add watcher and staleness
+ *     problems the design explicitly rejects.
+ *
+ * Spec: docs/superpowers/specs/2026-08-03-global-intelligent-search-design.md
+ * Plan: docs/superpowers/plans/2026-08-09-global-intelligent-search-implementation.md
+ */
+
+import type { SearchDocument } from "./search-document.ts";
+import { filterAppliesToEntity, filterDefinition, type SearchFilter } from "./search-filters.ts";
+
+/**
+ * What the caller is allowed to see, resolved before any provider runs.
+ *
+ * Passed IN rather than discovered by each provider, so one provider cannot
+ * quietly widen its own scope, and so the coordinator can re-apply the same
+ * context after ranking.
+ */
+export type SearchRequesterContext = {
+  /** Project ids the requester may read. `null` means unrestricted. */
+  allowedProjectIds: string[] | null;
+  /** Absolute project roots the requester may read. `null` means unrestricted. */
+  allowedProjectRoots: string[] | null;
+  /** The active familiar, when a surface has one. */
+  familiarId: string | null;
+};
+
+export type SearchProviderQuery = {
+  text: string;
+  phrases: string[];
+  filters: SearchFilter[];
+  /** Hard scopes already resolved to ids by the coordinator. */
+  projectIds: string[];
+  familiarIds: string[];
+  entityTypes: string[];
+  limit: number;
+};
+
+export type SearchProviderDiagnostic = {
+  providerId: string;
+  /** Safe category, never a raw error or a path. */
+  code: "unavailable" | "timeout" | "permission-denied" | "malformed-source";
+  message: string;
+};
+
+export type SearchProvider = {
+  id: string;
+  /** Entity types this provider can emit. Drives selection and filtered-empty. */
+  entityTypes: string[];
+  /** Filter keys this provider can honor. Others make it inapplicable. */
+  supportedFilters: string[];
+  kind: "indexed" | "live";
+  /**
+   * Cheap signature of the source. Equal fingerprints let a refresh skip the
+   * corpus entirely, so this must change whenever any document would.
+   */
+  fingerprint(): Promise<string>;
+  /** Indexed providers only: the full corpus, normalized. */
+  collect?(context: SearchRequesterContext): Promise<unknown[]>;
+  /** Live providers only: answer this query directly. */
+  query?(
+    query: SearchProviderQuery,
+    context: SearchRequesterContext,
+  ): Promise<{ documents: SearchDocument[]; diagnostics: SearchProviderDiagnostic[] }>;
+  /**
+   * Whether this requester may see this document.
+   *
+   * Applied by the provider AND again by the coordinator. The duplication is
+   * deliberate: a provider is the only thing that understands its own
+   * permission model, and the coordinator is the only thing that cannot be
+   * skipped.
+   */
+  permits(document: SearchDocument, context: SearchRequesterContext): boolean;
+};
+
+/**
+ * Whether a provider can honor every filter in a query.
+ *
+ * A provider that cannot honor a filter must be EXCLUDED rather than allowed
+ * to ignore it. Ignoring a filter is how a search for `status:blocked` starts
+ * returning projects, which have no status — the spec calls that silently
+ * widening, and requires a truthful filtered-empty state instead.
+ */
+export function providerHonorsQuery(
+  provider: SearchProvider,
+  query: Pick<SearchProviderQuery, "filters" | "entityTypes">,
+): boolean {
+  if (query.entityTypes.length > 0) {
+    const overlap = query.entityTypes.some((type) => provider.entityTypes.includes(type));
+    if (!overlap) return false;
+  }
+  for (const filter of query.filters) {
+    if (!provider.supportedFilters.includes(filter.key)) return false;
+    const definition = filterDefinition(filter.key);
+    if (!definition) continue;
+    // The filter must also apply to at least one entity type this provider
+    // emits, or honoring it is vacuous.
+    const applicable = provider.entityTypes.some((type) =>
+      filterAppliesToEntity(definition, type),
+    );
+    if (!applicable) return false;
+  }
+  return true;
+}
+
+/** Providers applicable to a query, in registration order. */
+export function selectProviders(
+  providers: readonly SearchProvider[],
+  query: Pick<SearchProviderQuery, "filters" | "entityTypes">,
+): SearchProvider[] {
+  return providers.filter((provider) => providerHonorsQuery(provider, query));
+}
+
+/**
+ * Default permission check: a document is visible when the requester may read
+ * its project, and when a familiar-scoped document belongs to the active
+ * familiar.
+ *
+ * Fails CLOSED on an unknown project — a document naming a project the caller
+ * has no entry for is hidden rather than shown, because the alternative leaks
+ * the existence of projects the requester cannot open.
+ */
+export function permitsByProject(
+  document: SearchDocument,
+  context: SearchRequesterContext,
+): boolean {
+  if (context.allowedProjectIds !== null && document.projectId !== null) {
+    if (!context.allowedProjectIds.includes(document.projectId)) return false;
+  }
+  if (context.allowedProjectRoots !== null && document.projectRoot !== null) {
+    if (!context.allowedProjectRoots.includes(document.projectRoot)) return false;
+  }
+  for (const permission of document.permissions) {
+    if (permission.kind === "project") {
+      if (context.allowedProjectIds !== null && !context.allowedProjectIds.includes(permission.id)) {
+        return false;
+      }
+    }
+    if (permission.kind === "familiar") {
+      if (context.familiarId !== null && context.familiarId !== permission.id) return false;
+    }
+  }
+  return true;
+}
+
+export function createProviderRegistry(providers: readonly SearchProvider[]) {
+  const ids = providers.map((provider) => provider.id);
+  const duplicate = ids.find((id, index) => ids.indexOf(id) !== index);
+  if (duplicate) {
+    // Two providers sharing an id would collide on `providerId + docId` in the
+    // index, so one would silently overwrite the other's documents.
+    throw new Error(`duplicate search provider id: ${duplicate}`);
+  }
+  return {
+    all: () => [...providers],
+    byId: (id: string) => providers.find((provider) => provider.id === id) ?? null,
+    select: (query: Pick<SearchProviderQuery, "filters" | "entityTypes">) =>
+      selectProviders(providers, query),
+    indexed: () => providers.filter((provider) => provider.kind === "indexed"),
+    live: () => providers.filter((provider) => provider.kind === "live"),
+  };
+}

--- a/src/lib/search-provider.ts
+++ b/src/lib/search-provider.ts
@@ -154,7 +154,14 @@ export function permitsByProject(
       }
     }
     if (permission.kind === "familiar") {
-      if (context.familiarId !== null && context.familiarId !== permission.id) return false;
+      // Exact match, and no active familiar fails CLOSED.
+      //
+      // `allowedProjectIds: null` means "unrestricted", but `familiarId: null`
+      // means "this surface has no active familiar" — not "every familiar".
+      // Reading the second like the first is how a familiar-scoped row leaks
+      // into an unscoped search: the requirement simply cannot be satisfied
+      // when there is no familiar to satisfy it.
+      if (context.familiarId !== permission.id) return false;
     }
   }
   return true;


### PR DESCRIPTION
Part of cave-ychtl.3. Delivers the shared provider contract, the registry, and the **live file provider**. The four indexed providers and the compatibility providers are split into **cave-ychtl.8**.

## Scope, stated up front

cave-ychtl.3 as written is five providers plus compatibility providers — each with its own source, permission model and fingerprint. This PR delivers the part that everything else depends on (the contract and registry) plus the one provider with real security consequences (files). The rest is a separate bead rather than a half-built version of itself.

**What is NOT here:** projects, familiars, tasks, sessions/chats, and the compatibility providers for commands, workspace destinations, settings and memory. Their data sources are identified in cave-ychtl.8 so the next unit starts from evidence rather than a survey.

## The contract

`SearchProvider` fixes what a provider may decide: report a fingerprint, emit normalized documents, declare honorable filters, judge its own permissions. It never ranks and never decides presentation — a provider that pre-ranks makes cross-corpus comparison impossible, which is the entire reason the normalized document exists.

The `indexed` / `live` split is not cosmetic. Indexed corpora are bounded and collected into the FTS5 store ahead of a query. Live corpora are queried at request time and never indexed — project file bodies being the motivating case, since indexing repositories would duplicate huge workspaces and add the watcher and staleness problems the spec explicitly rejects.

## The rule selection exists to enforce

**A provider that cannot honor a filter is excluded, not permitted to ignore it.** Ignoring is how `status:blocked` starts returning projects, which have no status — the spec calls that silently widening and requires a truthful filtered-empty state instead.

Declaring a filter is not sufficient either: it must also *apply* to an entity type the provider emits, or honoring it is vacuous. A projects provider that lists `status` in `supportedFilters` still loses selection, and there is a test for exactly that.

## The file provider

Its design rule is that it adds **no new access path**. Every guard the existing project-search route relies on is reused rather than reimplemented:

- the root must resolve through `resolveAllowedProjectPath`, or be a root the daemon already holds a live session for;
- ripgrep is spawned via `execFile` with an **argument array** — never a shell;
- the query is passed after `--`, so it can never be read as a flag;
- `.env*` stays excluded at both depths;
- ripgrep's `.gitignore`/hidden/binary defaults keep results on the same git-visible surface as the rest of the product.

A second implementation of any of those is a second thing to get wrong.

Two properties the tests pin because they regress silently:

- **A refused root never reaches ripgrep**, and its diagnostic contains no path separator and no segment of the denied path — a denial must not disclose what it denied.
- **A result carries only the relative path.** `projectRoot` is null and the document is asserted to contain no absolute path anywhere, because the id and payload travel to the requester.

Permission is checked *before* spawning, so a requester who cannot read the project never causes a search to run on their behalf. A ripgrep failure surfaces as a safe category (`unavailable`), never the raw error, which can carry a path.

## Permissions fail closed

`permitsByProject` hides a document naming a project the requester has no entry for, rather than showing it — the alternative discloses that the project exists.

## Verification

| Gate | Result |
| --- | --- |
| `src/lib/search-provider.test.ts` | passes |
| `pnpm check:tests-wired` | all 1592 wired |
| `pnpm typecheck` | clean |
| `git diff --check` | clean |
| `pnpm lint`, `test:app`, `test:api` | see checks |

The suite is registered in `ALIAS_LOADER` because the file provider wraps `server/project-paths.ts`, which resolves `@/lib/...` — without the resolver the suite cannot load at all.

## Note on a test that was wrong first

The path-leak assertion originally banned the word `not`, which the ordinary phrase "is not searchable" trips. The contract is about paths, not vocabulary; it now checks for a path separator and for segments of the denied path, and says why in a comment so the next person does not re-broaden it.
