### PR TITLE
fix: supervise packaged Windows sidecar recovery

### DIFF
--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -915,7 +915,12 @@ test("Windows packaged sidecar starts without a console window", async () => {
 
 test("Windows first launch paints progress and supports recovery while the sidecar starts", async () => {
   const [launcher, startupPage] = await Promise.all([
-    readNativeHost("tauri_setup.rs", "sidecar_startup.rs"),
+    readNativeHost(
+      "tauri_setup.rs",
+      "sidecar_startup.rs",
+      "sidecar_supervisor.rs",
+      "sidecar_lifecycle.rs",
+    ),
     readFile(new URL("./frontend-stub/startup.html", import.meta.url), "utf8"),
     access(new URL("./frontend-stub/cave-icon.png", import.meta.url)),
   ]);
@@ -939,6 +944,36 @@ test("Windows first launch paints progress and supports recovery while the sidec
     launcher,
     /window\.location\.replace\(/,
     "readiness must replace startup.html in session history so history.back() cannot return to the splash screen",
+  );
+  assert.match(
+    launcher,
+    /spawn_sidecar_startup\(app\.handle\(\)\.clone\(\), startup_control\)\?;\s*spawn_sidecar_supervisor\(app\.handle\(\)\.clone\(\)\)/,
+    "Windows must start post-ready supervision beside the startup owner",
+  );
+  assert.match(
+    launcher,
+    /spawn_sidecar_startup\(app\.clone\(\), Arc::clone\(control\.inner\(\)\)\)/,
+    "automatic Windows recovery must reuse SidecarStartupControl instead of racing it",
+  );
+  assert.match(
+    launcher,
+    /recovery_observation\(\s*recovery_pending,\s*sidecar_liveness\(&app\),\s*startup_in_progress\(&app\)/,
+    "the supervisor must wait for an owned startup and observe the resulting child",
+  );
+  assert.match(
+    launcher,
+    /stop_after_startup_attempt\(\)/,
+    "failed Windows startup workers must wait for the liveness probe and release their process job",
+  );
+  assert.match(
+    launcher,
+    /refreshed_sidecar_window_url[\s\S]*QUICK_CHAT_WINDOW_LABEL,\s*NOTCH_WINDOW_LABEL/,
+    "sidecar recovery must rotate auth for already-open auxiliary windows",
+  );
+  assert.match(
+    launcher,
+    /supervisor\.request_stop\(\)[\s\S]*control\.request_shutdown\(\)/,
+    "Windows shutdown must stop supervision before cancelling startup and the process job",
   );
   assert.match(
     startupPage,

--- a/src-tauri/src/sidecar_lifecycle.rs
+++ b/src-tauri/src/sidecar_lifecycle.rs
@@ -194,6 +194,10 @@ impl SidecarStartupControl {
         self.running.store(false, Ordering::Release);
     }
 
+    pub(super) fn is_running(&self) -> bool {
+        self.running.load(Ordering::Acquire)
+    }
+
     pub(super) fn request_cancel(&self) -> Result<(), String> {
         if !self.running.load(Ordering::Acquire) {
             return Err("sidecar startup is not running".to_string());
@@ -210,6 +214,10 @@ impl SidecarStartupControl {
     pub(super) fn request_shutdown(&self) {
         self.shutdown_requested.store(true, Ordering::Release);
         self.cancel_requested.store(true, Ordering::Release);
+    }
+
+    pub(super) fn is_shutdown_requested(&self) -> bool {
+        self.shutdown_requested.load(Ordering::Acquire)
     }
 
     pub(super) fn status(&self) -> Result<SidecarStartupStatus, String> {
@@ -272,6 +280,22 @@ impl SidecarState {
             .0
             .lock()
             .map_err(|_| "sidecar process lock is poisoned".to_string())?;
+        let Some(child) = guard.take() else {
+            return Ok(());
+        };
+        drop(guard);
+        stop_sidecar_child(child)
+    }
+
+    #[cfg(target_os = "windows")]
+    pub(super) fn stop_after_startup_attempt(&self) -> Result<(), String> {
+        // Startup failure runs on the worker thread, not the UI/exit path.
+        // Wait for the supervisor's brief liveness probe so cleanup cannot
+        // leave a failed child holding the selected port.
+        let mut guard = match self.0.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
         let Some(child) = guard.take() else {
             return Ok(());
         };
@@ -349,6 +373,9 @@ pub(super) fn stop_sidecar_child(mut process: SidecarProcess) -> Result<(), Stri
 
 #[cfg(all(desktop, target_os = "windows"))]
 pub(super) fn shutdown_owned_processes(app: &tauri::AppHandle) {
+    if let Some(supervisor) = app.try_state::<Arc<SidecarSupervisor>>() {
+        supervisor.request_stop();
+    }
     if let Some(control) = app.try_state::<Arc<SidecarStartupControl>>() {
         control.request_shutdown();
     }

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -202,15 +202,58 @@ pub(super) fn node_arg_path(path: &Path) -> PathBuf {
 /// history. Both first startup and later supervisor revivals use this exact
 /// path so URL escaping and the native-navigation fallback cannot drift.
 #[cfg(desktop)]
-pub(super) fn replace_main_window_url(app: &tauri::AppHandle, url: Url) -> Result<(), String> {
-    let window = app
-        .get_webview_window("main")
-        .ok_or_else(|| "main window is unavailable".to_string())?;
+fn navigate_sidecar_window(window: &tauri::WebviewWindow, url: Url) -> Result<(), String> {
     let escaped = url.to_string().replace('"', "%22");
     window
         .eval(format!("window.location.replace(\"{escaped}\");"))
         .or_else(|_| window.navigate(url))
-        .map_err(|error| format!("could not navigate the main window: {error}"))
+        .map_err(|error| format!("could not navigate the {} window: {error}", window.label()))
+}
+
+#[cfg(desktop)]
+pub(super) fn refreshed_sidecar_window_url(startup_url: &Url, current_url: &Url) -> Url {
+    let presentation_query: Vec<_> = current_url
+        .query_pairs()
+        .filter(|(key, _)| key != "covenCaveToken" && key != "coven_access_token")
+        .map(|(key, value)| (key.into_owned(), value.into_owned()))
+        .collect();
+    let mut refreshed = startup_url.clone();
+    refreshed.set_path(current_url.path());
+    refreshed.set_fragment(current_url.fragment());
+    for (key, value) in presentation_query {
+        refreshed.query_pairs_mut().append_pair(&key, &value);
+    }
+    refreshed
+}
+
+#[cfg(desktop)]
+pub(super) fn replace_main_window_url(app: &tauri::AppHandle, url: Url) -> Result<(), String> {
+    let main_window = app
+        .get_webview_window("main")
+        .ok_or_else(|| "main window is unavailable".to_string())?;
+    navigate_sidecar_window(&main_window, url.clone())?;
+
+    for label in [QUICK_CHAT_WINDOW_LABEL, NOTCH_WINDOW_LABEL] {
+        let Some(window) = app.get_webview_window(label) else {
+            continue;
+        };
+        let target = match window.url() {
+            Ok(current) => refreshed_sidecar_window_url(&url, &current),
+            Err(error) => {
+                log::warn!(
+                    "[cave] could not inspect the {label} window during sidecar recovery: {error}; closing the stale auxiliary window"
+                );
+                let _ = window.close();
+                continue;
+            }
+        };
+        if let Err(error) = navigate_sidecar_window(&window, target) {
+            log::warn!("[cave] {error}; closing the stale auxiliary window");
+            let _ = window.close();
+        }
+    }
+
+    Ok(())
 }
 
 #[cfg(desktop)]
@@ -570,7 +613,7 @@ pub(super) fn spawn_sidecar_startup(
             let final_status = match result {
                 Ok(_url) if thread_control.is_cancelled() => {
                     if let Some(sidecar) = app.try_state::<SidecarState>() {
-                        if let Err(error) = sidecar.stop() {
+                        if let Err(error) = sidecar.stop_after_startup_attempt() {
                             log::warn!("[cave] could not stop cancelled sidecar: {error}");
                         }
                     }
@@ -587,7 +630,7 @@ pub(super) fn spawn_sidecar_startup(
                         Ok(()) => SidecarStartupStatus::ready(),
                         Err(error) => {
                             if let Some(sidecar) = app.try_state::<SidecarState>() {
-                                if let Err(stop_error) = sidecar.stop() {
+                                if let Err(stop_error) = sidecar.stop_after_startup_attempt() {
                                     log::warn!(
                                         "[cave] could not stop sidecar after navigation failure: {stop_error}"
                                     );
@@ -599,7 +642,7 @@ pub(super) fn spawn_sidecar_startup(
                 }
                 Err(SidecarStartError::Cancelled) => {
                     if let Some(sidecar) = app.try_state::<SidecarState>() {
-                        if let Err(error) = sidecar.stop() {
+                        if let Err(error) = sidecar.stop_after_startup_attempt() {
                             log::warn!("[cave] could not stop cancelled sidecar: {error}");
                         }
                     }
@@ -607,7 +650,7 @@ pub(super) fn spawn_sidecar_startup(
                 }
                 Err(SidecarStartError::Failed(error)) => {
                     if let Some(sidecar) = app.try_state::<SidecarState>() {
-                        if let Err(stop_error) = sidecar.stop() {
+                        if let Err(stop_error) = sidecar.stop_after_startup_attempt() {
                             log::warn!(
                                 "[cave] could not stop sidecar after startup failure: {stop_error}"
                             );

--- a/src-tauri/src/sidecar_supervisor.rs
+++ b/src-tauri/src/sidecar_supervisor.rs
@@ -23,13 +23,10 @@
 //! Windows startup path already uses so the dead page does not linger in
 //! session history.
 //!
-//! ## Scope
-//!
-//! Deliberately not wired on Windows. There, `spawn_sidecar_startup` owns
-//! startup through `SidecarStartupControl` (a cancellable state machine with
-//! its own status events), and a second actor calling `start_sidecar_runtime`
-//! concurrently would race it. Windows keeps its manual retry until that
-//! control learns to own the automatic path too.
+//! On Windows every revival is scheduled through `SidecarStartupControl`, the
+//! same owner used by initial and manual startup. The supervisor observes that
+//! control and never calls `start_sidecar_runtime` beside it, so automatic,
+//! manual, and shutdown paths cannot start duplicate process jobs.
 //!
 //! Startup diagnostics, readiness handshakes and version coherence are NOT
 //! this module's business — that is cave-3qas7.6 (#4318), whose design note
@@ -167,10 +164,9 @@ impl SidecarSupervisor {
 
 /// Watch the running sidecar and bring it back when it dies unexpectedly.
 ///
-/// Not wired on Windows — see the module docs: `SidecarStartupControl` owns
-/// startup there and a second actor calling `start_sidecar_runtime` would race
-/// its state machine.
-#[cfg(all(desktop, not(target_os = "windows")))]
+/// Windows recovery is delegated to `SidecarStartupControl`; other platforms
+/// retain the synchronous startup path.
+#[cfg(desktop)]
 pub(super) fn spawn_sidecar_supervisor(app: tauri::AppHandle) {
     std::thread::spawn(move || {
         let mut budget = ReviveBudget::defaults();
@@ -179,7 +175,11 @@ pub(super) fn spawn_sidecar_supervisor(app: tauri::AppHandle) {
             if !sleep_unless_stopping(&app, SUPERVISOR_POLL_INTERVAL) {
                 return;
             }
-            match recovery_observation(recovery_pending, sidecar_liveness(&app)) {
+            match recovery_observation(
+                recovery_pending,
+                sidecar_liveness(&app),
+                startup_in_progress(&app),
+            ) {
                 RecoveryObservation::Recovered => {
                     // Forget any earlier crash history so an unrelated failure
                     // weeks into a session gets a full budget.
@@ -212,8 +212,13 @@ pub(super) fn spawn_sidecar_supervisor(app: tauri::AppHandle) {
             if !sleep_unless_stopping(&app, delay) {
                 return;
             }
+            if startup_in_progress(&app) {
+                recovery_pending = true;
+                continue;
+            }
             match revive(&app) {
                 ReviveOutcome::Revived => recovery_pending = false,
+                ReviveOutcome::Scheduled => recovery_pending = true,
                 ReviveOutcome::Failed => {}
                 ReviveOutcome::Cancelled => return,
             }
@@ -223,7 +228,7 @@ pub(super) fn spawn_sidecar_supervisor(app: tauri::AppHandle) {
 
 /// True unless the app asked to stop while we were waiting. Polled in short
 /// slices so a fifteen-minute cooldown never delays quitting.
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
 fn sleep_unless_stopping(app: &tauri::AppHandle, total: Duration) -> bool {
     const SLICE: Duration = Duration::from_millis(250);
     let mut waited = Duration::ZERO;
@@ -238,7 +243,7 @@ fn sleep_unless_stopping(app: &tauri::AppHandle, total: Duration) -> bool {
     !is_stopping(app)
 }
 
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
 fn is_stopping(app: &tauri::AppHandle) -> bool {
     app.try_state::<Arc<SidecarSupervisor>>()
         .is_some_and(|supervisor| supervisor.is_stopping())
@@ -252,7 +257,22 @@ fn is_stopping(app: &tauri::AppHandle) -> bool {
 /// would silently RESET the revive budget, so a respawn that failed and left no
 /// child behind would look like a recovery and never be retried. Unknown means
 /// "do nothing": neither revive, nor forgive the crash history.
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
+fn startup_in_progress(app: &tauri::AppHandle) -> bool {
+    #[cfg(target_os = "windows")]
+    {
+        return app
+            .try_state::<Arc<SidecarStartupControl>>()
+            .is_some_and(|control| control.is_running());
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = app;
+        false
+    }
+}
+
+#[cfg(desktop)]
 #[derive(Debug, PartialEq, Eq)]
 enum SidecarLiveness {
     Alive,
@@ -260,7 +280,7 @@ enum SidecarLiveness {
     Unknown,
 }
 
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
 #[derive(Debug, PartialEq, Eq)]
 enum RecoveryObservation {
     Recovered,
@@ -272,10 +292,21 @@ enum RecoveryObservation {
 /// child from `SidecarState`. Without this episode bit, `Unknown` would make
 /// the supervisor wait forever. Conversely, only a later live probe proves a
 /// successful revive remained healthy long enough to restore the budget.
-#[cfg(all(desktop, not(target_os = "windows")))]
-fn recovery_observation(recovery_pending: bool, liveness: SidecarLiveness) -> RecoveryObservation {
+#[cfg(desktop)]
+fn recovery_observation(
+    recovery_pending: bool,
+    liveness: SidecarLiveness,
+    startup_running: bool,
+) -> RecoveryObservation {
+    if startup_running {
+        return RecoveryObservation::Wait;
+    }
     if recovery_pending {
-        return RecoveryObservation::Revive;
+        return if liveness == SidecarLiveness::Alive {
+            RecoveryObservation::Recovered
+        } else {
+            RecoveryObservation::Revive
+        };
     }
     match liveness {
         SidecarLiveness::Alive => RecoveryObservation::Recovered,
@@ -284,7 +315,7 @@ fn recovery_observation(recovery_pending: bool, liveness: SidecarLiveness) -> Re
     }
 }
 
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
 fn sidecar_liveness(app: &tauri::AppHandle) -> SidecarLiveness {
     let Some(state) = app.try_state::<SidecarState>() else {
         return SidecarLiveness::Unknown;
@@ -306,9 +337,10 @@ fn sidecar_liveness(app: &tauri::AppHandle) -> SidecarLiveness {
     }
 }
 
-#[cfg(all(desktop, not(target_os = "windows")))]
+#[cfg(desktop)]
 enum ReviveOutcome {
     Revived,
+    Scheduled,
     Failed,
     Cancelled,
 }
@@ -343,6 +375,7 @@ fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
                     log::info!("[cave] sidecar revived and the window was reopened");
                     ReviveOutcome::Revived
                 }
+
                 Err(error) => {
                     log::warn!("[cave] sidecar revived but the window did not follow: {error}");
                     cleanup_failed_revival(app);
@@ -360,6 +393,32 @@ fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
         Err(SidecarStartError::Failed(error)) => {
             log::warn!("[cave] sidecar revive failed: {error}");
             cleanup_failed_revival(app);
+            ReviveOutcome::Failed
+        }
+    }
+}
+
+#[cfg(all(desktop, target_os = "windows"))]
+fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
+    let Some(control) = app.try_state::<Arc<SidecarStartupControl>>() else {
+        log::warn!("[cave] sidecar revive failed: startup control is unavailable");
+        return ReviveOutcome::Failed;
+    };
+    if control.is_shutdown_requested() || is_stopping(app) {
+        return ReviveOutcome::Cancelled;
+    }
+    match sidecar_startup::spawn_sidecar_startup(app.clone(), Arc::clone(control.inner())) {
+        Ok(()) => ReviveOutcome::Scheduled,
+        Err(_error) if control.is_running() => {
+            log::info!("[cave] sidecar recovery joined an existing startup");
+            ReviveOutcome::Scheduled
+        }
+        Err(error) if control.is_shutdown_requested() => {
+            log::info!("[cave] sidecar recovery cancelled during shutdown: {error}");
+            ReviveOutcome::Cancelled
+        }
+        Err(error) => {
+            log::warn!("[cave] sidecar revive could not start: {error}");
             ReviveOutcome::Failed
         }
     }
@@ -433,26 +492,71 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
     fn failed_revival_stays_pending_when_child_state_is_unknown() {
         assert_eq!(
-            recovery_observation(true, SidecarLiveness::Unknown),
+            recovery_observation(true, SidecarLiveness::Unknown, false),
             RecoveryObservation::Revive,
             "cleanup leaves no recorded child, but a failed revival still needs its next attempt"
         );
     }
 
     #[test]
-    #[cfg(not(target_os = "windows"))]
     fn only_an_observed_live_revival_restores_the_budget() {
         assert_eq!(
-            recovery_observation(false, SidecarLiveness::Alive),
+            recovery_observation(false, SidecarLiveness::Alive, false),
             RecoveryObservation::Recovered,
         );
         assert_eq!(
-            recovery_observation(false, SidecarLiveness::Unknown),
+            recovery_observation(false, SidecarLiveness::Unknown, false),
             RecoveryObservation::Wait,
             "unknown is not proof that a successful revival stayed alive"
+        );
+    }
+
+    #[test]
+    fn an_owned_startup_suppresses_duplicate_revival() {
+        assert_eq!(
+            recovery_observation(false, SidecarLiveness::Unknown, true),
+            RecoveryObservation::Wait,
+            "initial and manual startup own recovery until they finish"
+        );
+        assert_eq!(
+            recovery_observation(true, SidecarLiveness::Dead, true),
+            RecoveryObservation::Wait,
+            "a retained dead child must not start a second worker concurrently"
+        );
+        assert_eq!(
+            recovery_observation(true, SidecarLiveness::Alive, true),
+            RecoveryObservation::Wait,
+            "process liveness alone is not readiness while startup still owns the child"
+        );
+    }
+
+    #[test]
+    fn a_scheduled_revival_recovers_only_after_the_child_is_live() {
+        assert_eq!(
+            recovery_observation(true, SidecarLiveness::Alive, false),
+            RecoveryObservation::Recovered,
+        );
+    }
+
+    #[test]
+    fn recovery_rotates_auxiliary_window_auth_without_losing_presentation_state() {
+        let startup = Url::parse(
+            "http://127.0.0.1:43123/?covenCaveToken=new-sidecar&coven_access_token=new-mobile",
+        )
+        .unwrap();
+        let current = Url::parse(
+            "http://127.0.0.1:43123/quick-chat?notch=1&fit=1&covenCaveToken=old-sidecar",
+        )
+        .unwrap();
+
+        let refreshed = sidecar_startup::refreshed_sidecar_window_url(&startup, &current);
+
+        assert_eq!(refreshed.path(), "/quick-chat");
+        assert_eq!(
+            refreshed.query(),
+            Some("covenCaveToken=new-sidecar&coven_access_token=new-mobile&notch=1&fit=1")
         );
     }
 }

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -366,6 +366,7 @@ pub fn run() {
                     let startup_control =
                         Arc::clone(app.state::<Arc<SidecarStartupControl>>().inner());
                     spawn_sidecar_startup(app.handle().clone(), startup_control)?;
+                    spawn_sidecar_supervisor(app.handle().clone());
                     None
                 }
                 #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Summary
- observe packaged Windows sidecar liveness after readiness and schedule bounded recovery through `SidecarStartupControl`
- prevent duplicate/manual startup races and stop supervision before shutdown cancellation and process-job teardown
- rotate auth across main, Quick Chat, and Notch navigation while preserving presentation state
- cover crash recovery, failed revival, cooldown/refill, startup ownership, navigation cleanup, and release wiring

## Validation
- `rustfmt --edition 2021 --check --config skip_children=true src-tauri/src/sidecar_lifecycle.rs src-tauri/src/sidecar_startup.rs src-tauri/src/sidecar_supervisor.rs src-tauri/src/tauri_setup.rs`
- `cargo test --lib sidecar_supervisor::tests` (9 passed)
- `cargo test --lib` (95 passed)
- `cargo check --lib`
- `node src-tauri/release-runtime.test.mjs` (24 passed)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm check:tests-wired`
- `git diff --check`

Bead: `cave-58eoq.1`