### PR TITLE
Avoid nested scrolling in the code session rail

### DIFF
--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -64,6 +64,7 @@ export function CodeSessionRail({
   onExpand,
 }: CodeSessionRailProps) {
   const groups = groupCodeRailSessions(sessions);
+  const openRailClassName = onExpand ? "py-2" : "overflow-y-auto py-2";
   const newButton = open && onNewSession ? (
     <div className="px-2 pb-1">
       <button
@@ -93,7 +94,7 @@ export function CodeSessionRail({
   return (
     <nav
       aria-label="Coding sessions"
-      className={`flex h-full min-h-0 flex-col ${open ? "overflow-y-auto py-2" : "items-center gap-1"}`}
+      className={`flex h-full min-h-0 flex-col ${open ? openRailClassName : "items-center gap-1"}`}
     >
       {newButton}
       {groups.map((group) => (

--- a/src/components/code-surface-mode.test.ts
+++ b/src/components/code-surface-mode.test.ts
@@ -509,6 +509,16 @@ assert.match(
   /onClick=\{\(\) => \{\s*onExpand\?\.\(\);\s*onSelect\(row\.id\);/,
   "collapsed session buttons expand before selection",
 );
+assert.match(
+  rail,
+  /const openRailClassName = onExpand \? "py-2" : "overflow-y-auto py-2";/,
+  "SurfaceRail-hosted sessions defer scrolling to the shared rail while the narrow standalone list remains scrollable",
+);
+assert.match(
+  rail,
+  /open \? openRailClassName : "items-center gap-1"/,
+  "the session navigation applies the layout-specific open-state scrolling contract",
+);
 
 assert.match(
   composer,


### PR DESCRIPTION
## Summary
- let the shared `SurfaceRail` own scrolling for the wide Code sessions rail
- preserve independent scrolling for the narrow list-first layout
- pin both paths in the existing code surface contract test

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`

Bead: `cave-iixug`