### PR TITLE
fix(code): unbreak main — collapse the redundant sessions-rail ternary

### DIFF
--- a/src/components/code-session-rail.tsx
+++ b/src/components/code-session-rail.tsx
@@ -100,7 +100,7 @@ export function CodeSessionRail({
     <nav
       aria-label="Coding sessions"
       className={`flex h-full min-h-0 flex-col ${
-        open ? (onExpand ? "py-2" : openRailClassName) : "items-center gap-1"
+        open ? openRailClassName : "items-center gap-1"
       }`}
     >
       {newButton}


### PR DESCRIPTION
**`main` is currently red and this unblocks it.** The latest push run on main (`de5fef3ab`) fails `Frontend tests (app)`, which fails its aggregate `Frontend build` — a required context. Every open PR inherits it, because CI tests each PR merged with main.

## Cause

Commit `48894720c4` ("update chat") was pushed **directly to main**, so no PR CI gated it. It drifted the sessions-rail className away from what `code-surface-mode.test.ts` pins as source text.

The test expects:
```js
open ? openRailClassName : "items-center gap-1"
```

main had drifted to:
```js
open ? (onExpand ? "py-2" : openRailClassName) : "items-center gap-1"
```

## Why collapsing it is safe

The inner ternary is a no-op. `openRailClassName` is already defined as `onExpand ? "py-2" : "overflow-y-auto py-2"`, so:

- `onExpand` truthy → `openRailClassName` **is** `"py-2"`, and the inner ternary yields `"py-2"` — identical.
- `onExpand` falsy → the inner ternary yields `openRailClassName` — identical.

Both branches reduce to `openRailClassName` alone. **Zero behaviour change.** The nested-scroll-container fix that `48894720c4` intended is fully preserved, because `openRailClassName` encodes exactly the same `onExpand` condition — the component simply stops saying it twice.

## Verification

`code-surface-mode.test.ts` passes, `eslint` clean on the touched file, `pnpm typecheck` clean.

## Note

This is the failure mode the direct-to-main exemption produces: a change that a PR's required checks would have caught before landing. Flagging it as evidence, not as an argument to change the setting — that is the owner's call and documented as deliberate.