### PR TITLE
Add UI consistency foundation

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "lint:design": "eslint \"src/components/**/*.tsx\" --max-warnings=0",
     "typecheck": "tsc --noEmit",
     "check:tests-wired": "node scripts/check-tests-wired.mjs",
+    "check:ui-consistency": "node scripts/ui-consistency.mjs",
     "check:beads-jsonl": "node scripts/check-beads-jsonl-duplicates.mjs",
     "check:conflict-markers": "node scripts/check-conflict-markers.mjs",
     "test": "node scripts/run-tests.mjs app",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1064,6 +1064,7 @@ export const SUITES = {
 	    "src/components/ui/color-picker.test.ts",
 	    "src/components/ui/button.test.ts",
 	    "src/components/ui/field.test.ts",
+	    "src/app/aesthetic/aesthetic-fields.test.ts",
 	    "src/components/ui/popover.test.ts",
     "src/components/ui/popover-submenu.test.ts",
     "src/lib/submenu-position.test.ts",

--- a/scripts/ui-consistency-baseline.json
+++ b/scripts/ui-consistency-baseline.json
@@ -1,0 +1,230 @@
+{
+  "version": 1,
+  "sourceRevision": "2a74cc55325f8afb309d262614889f2b9d024a07",
+  "inventory": {
+    "reactTsxFiles": 433,
+    "nativeIosSwiftFiles": 105,
+    "tauriRustFiles": 36,
+    "reactPlaceholderAssignments": 230,
+    "sharedPrimitiveUses": {
+      "Button": 511,
+      "IconButton": 68,
+      "SearchInput": 19,
+      "StandardSelect": 66,
+      "EmptyState": 80,
+      "ErrorState": 38
+    }
+  },
+  "findings": [
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/chat-list.tsx",
+      "excerpt": "<select value={groupBy} onChange={(e) => setGroupBy(normalizeChatGroupBy(e.target.value))} aria-label=\"Group sessions by\" className=\"chat-list-group-select focus-ring h-7 shrink-0 cursor-pointer rounded-[var(--radius-pill)] border border-[var(--border-hairline)] bg-transparent px-2.5 text-[length:var(--text-xs)] text-[var(--text-secondary)]\" >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/chat-view.tsx",
+      "excerpt": "<select className=\"focus-ring shrink-0 rounded-md border border-[color-mix(in_oklch,var(--color-warning)_42%,transparent)] bg-[var(--bg-base)]/60 px-2 py-1 text-[length:var(--text-xs)] font-medium text-[var(--text-primary)]\" defaultValue=\"\" disabled={busy} aria-label=\"Pick a project to run this chat in\" onChange={(event) => { if (event.target.value) onPickProject(event.target.value); }} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/first-project-gate.tsx",
+      "excerpt": "<select id=\"first-project-gate-existing\" value={selectedExistingProjectId} onChange={(event) => { setSelectedExistingProjectId(event.target.value); setSubmitError(null); }} disabled={submitting} className=\"focus-ring h-10 w-full rounded-[var(--radius-control)] border border-[var(--border-strong)] bg-[var(--bg-base)] px-3 text-[length:var(--text-md)] text-[var(--text-primary)]\" >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/messenger-surface.tsx",
+      "excerpt": "<select value={selected.channel} onChange={(e) => updateSelected({ channel: e.target.value as MessageChannel })} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/messenger-surface.tsx",
+      "excerpt": "<select value={selected.tone} onChange={(e) => updateSelected({ tone: e.target.value })}>"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-evidence-ledger.tsx",
+      "excerpt": "<select value={source.status} disabled={busy} onChange={(event) => void act({ action: \"update-source\", sourceId: source.id, patch: { status: event.target.value as ResearchSourceRef[\"status\"] }, })} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-guest-voice\" className=\"research-studio__select focus-ring\" value={mediaGuestVoice} aria-describedby=\"research-studio-config-guest-voice-help\" aria-invalid={mediaConfigurationError ? true : undefined} aria-errormessage={ mediaConfigurationError ? \"research-studio-config-media-error\" : undefined } onChange={(event) => onMediaGuestVoiceChange(event.target.value) } >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-length\" className=\"research-studio__select focus-ring\" value={mediaLength} aria-describedby=\"research-studio-config-length-help\" aria-invalid={mediaConfigurationError ? true : undefined} aria-errormessage={ mediaConfigurationError ? \"research-studio-config-media-error\" : undefined } onChange={(event) => onMediaLengthChange(event.target.value as ResearchMediaLength) } >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-local-voice\" className=\"research-studio__select focus-ring\" value={mediaVoice} aria-describedby=\"research-studio-config-voice-help\" aria-invalid={mediaConfigurationError ? true : undefined} aria-errormessage={ mediaConfigurationError ? \"research-studio-config-media-error\" : undefined } onChange={(event) => onMediaVoiceChange(event.target.value)} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-provider\" className=\"research-studio__select focus-ring\" value={mediaProvider} aria-describedby=\"research-studio-config-provider-help\" aria-invalid={mediaConfigurationError ? true : undefined} aria-errormessage={ mediaConfigurationError ? \"research-studio-config-media-error\" : undefined } onChange={(event) => { const provider = event.target.value as ResearchMediaProvider; onMediaProviderChange(provider); onMediaVoiceChange( provider === \"local\" ? (readiness?.providers.local.voices[0]?.id ?? \"\") : (readiness?.providers.elevenlabs.defaultVoiceId ?? \"\"), ); }} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-source\" className=\"research-studio__select\" value={selectedSourceId ?? \"\"} onChange={(event) => onSelectSource(event.target.value)} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-studio-modals.tsx",
+      "excerpt": "<select id=\"research-studio-config-style\" className=\"research-studio__select focus-ring\" value={mediaStyle} aria-describedby=\"research-studio-config-style-help\" onChange={(event) => onMediaStyleChange(event.target.value as ResearchPodcastStyle) } >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/role-surfaces/research-tab-studio.tsx",
+      "excerpt": "<select id=\"research-studio-source\" className=\"research-studio__select\" value={effectiveSourceId ?? \"\"} onChange={(event) => setSourceId(event.target.value)} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/salem/ask-salem-view.tsx",
+      "excerpt": "<select className=\"ask-salem__picker-select focus-ring\" aria-label=\"Familiar whose connected model writes the answers\" value={selectedFamiliar.id} onChange={(e) => setPickedFamiliarId(e.target.value)} >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/stitch-intake.tsx",
+      "excerpt": "<select value={collection} onChange={(e) => setCollection(e.target.value)} aria-label=\"Destination collection\" className=\"focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-transparent px-2 py-1.5 text-[length:var(--text-sm)] text-[var(--text-primary)]\" >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/stitch-intake.tsx",
+      "excerpt": "<select value={sessionId} onChange={(e) => setSessionId(e.target.value)} aria-label=\"Chat session to pin\" className=\"focus-ring w-full rounded-md border border-[var(--border-hairline)] bg-transparent px-2 py-1.5 text-[length:var(--text-sm)] text-[var(--text-primary)]\" >"
+    },
+    {
+      "rule": "components/no-native-select",
+      "path": "src/components/weave-rail.tsx",
+      "excerpt": "<select className=\"wv-select focus-ring\" value={scope.familiar ?? \"\"} onChange={(e) => onScope({ ...scope, familiar: e.target.value === \"\" ? null : e.target.value }) } >"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "apps/ios/CovenCave/CovenCave/Views/ChatView.swift",
+      "excerpt": "let clipped = excerpt.count > 140 ? \"\\(excerpt.prefix(137))...\" : excerpt"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/automations/cron-detail-panel.tsx",
+      "excerpt": "{busy ? \"Saving...\" : \"Save changes\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "label: \"Assign to...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "label: \"Move to...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "label: \"Priority...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "placeholder=\"Assign to...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "placeholder=\"Move to...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/board-view.tsx",
+      "excerpt": "placeholder=\"Priority...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/chat-canvas-view.tsx",
+      "excerpt": "headline=\"Loading saved sketches...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/chat-canvas-view.tsx",
+      "excerpt": "subtitle=\"Fetching saved sketches from the canvas store...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/command-palette.tsx",
+      "excerpt": "Asking Salem through salem.opencoven.ai..."
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/familiar-chatout-codex/FamiliarChatoutCodexSurface.tsx",
+      "excerpt": "create a Codex-style famil..."
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/familiar-chatout-codex/FamiliarChatoutCodexSurface.tsx",
+      "excerpt": "macOS Application Pri..."
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/familiar-menu-bar.tsx",
+      "excerpt": "placeholder=\"Search Cave...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/familiar-studio-brain-tab.tsx",
+      "excerpt": "label: \"Custom...\""
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/familiars-memory-view.tsx",
+      "excerpt": "placeholder={ lockToFamiliar && selectedFamiliar?.display_name ? `Search ${selectedFamiliar.display_name}'s memory…` : \"Search memory...\" }"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/marketplace/craft-create-drawer.tsx",
+      "excerpt": "Loading roles..."
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/mobile-handoff-modal.tsx",
+      "excerpt": "{loading ? \"Starting...\" : \"No QR\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/open-coven-tools-update.tsx",
+      "excerpt": "..."
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/settings-shell.tsx",
+      "excerpt": "{saving ? \"Saving...\" : \"Save Omnigent\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/task-work-cockpit.tsx",
+      "excerpt": "{lookupState === \"error\" ? \"Couldn't check the work session\" : \"Preparing work session...\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/task-work-cockpit.tsx",
+      "excerpt": "{unlinking ? \"Unlinking...\" : \"Unlink missing session\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/task-work-github.tsx",
+      "excerpt": "{loading ? \"Refreshing...\" : \"Refresh\"}"
+    },
+    {
+      "rule": "copy/no-ascii-ellipsis",
+      "path": "src/components/top-bar.tsx",
+      "excerpt": "placeholder=\"Search or ask Salem...\""
+    },
+    {
+      "rule": "copy/no-generic-submit",
+      "path": "src/components/salem/salem-pathfinder-card.tsx",
+      "excerpt": "Submit"
+    }
+  ]
+}

--- a/scripts/ui-consistency-policy.mjs
+++ b/scripts/ui-consistency-policy.mjs
@@ -1,0 +1,146 @@
+import path from "node:path";
+
+export const LIVE_SOURCE_ROOTS = Object.freeze([
+  {
+    directory: "src/components",
+    extensions: [".tsx"],
+    exclude: [],
+  },
+  {
+    directory: "src/app",
+    extensions: [".tsx"],
+    exclude: ["src/app/mockup"],
+  },
+  {
+    directory: "apps/ios/CovenCave/CovenCave",
+    extensions: [".swift"],
+    exclude: [],
+  },
+  {
+    directory: "src-tauri/src",
+    extensions: [".rs"],
+    exclude: [],
+  },
+]);
+
+export const TSX_COPY_PROP_NAMES = Object.freeze([
+  "aria-label",
+  "cancelLabel",
+  "confirmLabel",
+  "description",
+  "headline",
+  "label",
+  "placeholder",
+  "subtitle",
+  "title",
+]);
+
+function quotedLiterals(line) {
+  const values = [];
+  for (const expression of [
+    /"((?:\\.|[^"\\])*)"/g,
+    /'((?:\\.|[^'\\])*)'/g,
+    /`((?:\\.|[^`\\])*)`/g,
+  ]) {
+    for (const match of line.matchAll(expression)) values.push(match[1]);
+  }
+  return values;
+}
+
+function capturedLiterals(line, expression) {
+  return [...line.matchAll(expression)].map((match) => match[1]);
+}
+
+function swiftUiLiterals(line) {
+  return capturedLiterals(
+    line,
+    /\b(?:Text|Button|Label|TextField|SecureField|ContentUnavailableView|navigationTitle|alert|confirmationDialog|accessibilityLabel)\s*\(\s*"((?:\\.|[^"\\])*)"/g,
+  );
+}
+
+function swiftSourceLiterals(line) {
+  if (/^\s*\/\//.test(line)) return [];
+  const withoutDiagnostics = line.replace(
+    /\b(?:print|debugPrint|NSLog|os_log|logger(?:\.\w+)+)\s*\([^)]*\)/g,
+    "",
+  );
+  return quotedLiterals(withoutDiagnostics);
+}
+
+function rustUiLiterals(line) {
+  const direct = capturedLiterals(
+    line,
+    /(?:\.title|set_title)\s*\(\s*"((?:\\.|[^"\\])*)"/g,
+  );
+  const scripts = quotedLiterals(line).filter((value) =>
+    /^display (?:alert|dialog)\b/.test(value),
+  );
+  return [...direct, ...scripts];
+}
+
+function hasAsciiEllipsis({ extension, line }) {
+  if (!line.includes("...")) return false;
+  if (extension === ".swift") {
+    return [...swiftUiLiterals(line), ...swiftSourceLiterals(line)].some(
+      (value) => value.includes("..."),
+    );
+  }
+  if (extension === ".rs") {
+    return rustUiLiterals(line).some((value) => value.includes("..."));
+  }
+  return false;
+}
+
+function isGenericSubmit({ extension, line }) {
+  if (extension === ".swift") {
+    return capturedLiterals(
+      line,
+      /\bButton\s*\(\s*"((?:\\.|[^"\\])*)"/g,
+    ).some((value) => value.trim() === "Submit");
+  }
+  return false;
+}
+
+function isNativeSelect({ extension, line }) {
+  return false;
+}
+
+export const ACTIVE_RULES = Object.freeze([
+  {
+    id: "components/no-native-select",
+    matches: isNativeSelect,
+  },
+  {
+    id: "copy/no-ascii-ellipsis",
+    matches: hasAsciiEllipsis,
+  },
+  {
+    id: "copy/no-generic-submit",
+    matches: isGenericSubmit,
+  },
+]);
+
+export const FUTURE_RULE_IDS = Object.freeze([
+  "copy/tasks-terminology",
+  "fields/no-placeholder-only-label",
+  "states/no-convincing-empty-on-error",
+]);
+
+export const SEMANTIC_EXCEPTIONS = Object.freeze([
+  {
+    rule: "components/no-native-select",
+    path: "src/components/role-surfaces/chart-room-parts.tsx",
+    excerpt:
+      '<select className="focus-ring" value={value} aria-label={label} disabled={disabled} onChange={(event) => onChange(event.target.value)} >',
+    reason:
+      "Chart Room intentionally overlays a native select beneath its painted compact label so platform picker and keyboard semantics remain intact.",
+  },
+]);
+
+export function isExcludedSource(relativePath, sourceRoot) {
+  const normalized = relativePath.split(path.sep).join("/");
+  if (/\.(?:test|spec|stories)\.[^.]+$/.test(normalized)) return true;
+  return sourceRoot.exclude.some(
+    (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
+  );
+}

--- a/scripts/ui-consistency.mjs
+++ b/scripts/ui-consistency.mjs
@@ -1,0 +1,409 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import ts from "typescript";
+import {
+  ACTIVE_RULES,
+  LIVE_SOURCE_ROOTS,
+  SEMANTIC_EXCEPTIONS,
+  TSX_COPY_PROP_NAMES,
+  isExcludedSource,
+} from "./ui-consistency-policy.mjs";
+
+const ACTIVE_RULE_IDS = new Set(ACTIVE_RULES.map((rule) => rule.id));
+const TSX_COPY_PROPS = new Set(TSX_COPY_PROP_NAMES);
+
+function toPosix(value) {
+  return value.split(path.sep).join("/");
+}
+
+export function normalizeExcerpt(line) {
+  return line.trim().replace(/\s+/g, " ");
+}
+
+export function findingKey(finding) {
+  return [finding.rule, finding.path, finding.excerpt].join("\u0000");
+}
+
+function compareByKey(a, b) {
+  return findingKey(a).localeCompare(findingKey(b));
+}
+
+function uniqueSortedFindings(findings) {
+  const byKey = new Map();
+  for (const finding of findings) byKey.set(findingKey(finding), finding);
+  return [...byKey.values()].sort(compareByKey);
+}
+
+function jsxTagNameText(tagName, sourceFile) {
+  return tagName.getText(sourceFile);
+}
+
+function renderedStringLiterals(expression) {
+  if (
+    ts.isStringLiteral(expression) ||
+    ts.isNoSubstitutionTemplateLiteral(expression)
+  ) {
+    return [expression.text];
+  }
+  if (ts.isTemplateExpression(expression)) {
+    return [
+      [
+        expression.head.text,
+        ...expression.templateSpans.map((span) => span.literal.text),
+      ].join(""),
+      ...expression.templateSpans.flatMap((span) =>
+        renderedStringLiterals(span.expression),
+      ),
+    ];
+  }
+  if (ts.isConditionalExpression(expression)) {
+    return [
+      ...renderedStringLiterals(expression.whenTrue),
+      ...renderedStringLiterals(expression.whenFalse),
+    ];
+  }
+  if (
+    ts.isBinaryExpression(expression) &&
+    expression.operatorToken.kind === ts.SyntaxKind.PlusToken
+  ) {
+    return [
+      ...renderedStringLiterals(expression.left),
+      ...renderedStringLiterals(expression.right),
+    ];
+  }
+  if (
+    ts.isBinaryExpression(expression) &&
+    expression.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+  ) {
+    return renderedStringLiterals(expression.right);
+  }
+  if (
+    ts.isBinaryExpression(expression) &&
+    (expression.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+      expression.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken)
+  ) {
+    return [
+      ...renderedStringLiterals(expression.left),
+      ...renderedStringLiterals(expression.right),
+    ];
+  }
+  if (
+    ts.isParenthesizedExpression(expression) ||
+    ts.isAsExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isNonNullExpression(expression)
+  ) {
+    return renderedStringLiterals(expression.expression);
+  }
+  return [];
+}
+
+function tsxStringValues(initializer) {
+  if (!initializer) return [];
+  if (ts.isStringLiteral(initializer)) return [initializer.text];
+  if (ts.isJsxExpression(initializer) && initializer.expression) {
+    return renderedStringLiterals(initializer.expression);
+  }
+  return [];
+}
+
+function scanTsxSource(sourcePath, source) {
+  const sourceFile = ts.createSourceFile(
+    sourcePath,
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX,
+  );
+  const findings = [];
+  const addFinding = (rule, node) => {
+    findings.push({
+      rule,
+      path: toPosix(sourcePath),
+      excerpt: normalizeExcerpt(
+        source.slice(node.getStart(sourceFile), node.getEnd()),
+      ),
+    });
+  };
+  const inspectCopy = (values, node) => {
+    if (values.some((value) => value.includes("..."))) {
+      addFinding("copy/no-ascii-ellipsis", node);
+    }
+    if (values.some((value) => value.trim() === "Submit")) {
+      addFinding("copy/no-generic-submit", node);
+    }
+  };
+
+  const visit = (node) => {
+    if (
+      (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) &&
+      jsxTagNameText(node.tagName, sourceFile) === "select"
+    ) {
+      addFinding("components/no-native-select", node);
+    }
+
+    if (ts.isJsxAttribute(node)) {
+      const name = node.name.getText(sourceFile);
+      if (TSX_COPY_PROPS.has(name)) {
+        inspectCopy(tsxStringValues(node.initializer), node);
+      }
+    } else if (ts.isPropertyAssignment(node)) {
+      const name = node.name.getText(sourceFile).replace(/^["']|["']$/g, "");
+      if (TSX_COPY_PROPS.has(name)) {
+        inspectCopy(renderedStringLiterals(node.initializer), node);
+      }
+    } else if (ts.isJsxText(node)) {
+      inspectCopy([node.text], node);
+    } else if (
+      ts.isJsxExpression(node) &&
+      node.parent &&
+      (ts.isJsxElement(node.parent) || ts.isJsxFragment(node.parent)) &&
+      node.expression
+    ) {
+      inspectCopy(renderedStringLiterals(node.expression), node);
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return uniqueSortedFindings(findings);
+}
+
+export function scanSource({ path: sourcePath, source }) {
+  const extension = path.extname(sourcePath);
+  if (extension === ".tsx") return scanTsxSource(sourcePath, source);
+  const findings = [];
+  for (const line of source.split(/\r?\n/)) {
+    for (const rule of ACTIVE_RULES) {
+      if (!rule.matches({ extension, line })) continue;
+      findings.push({
+        rule: rule.id,
+        path: toPosix(sourcePath),
+        excerpt: normalizeExcerpt(line),
+      });
+    }
+  }
+  return uniqueSortedFindings(findings);
+}
+
+function walk(directory, files = []) {
+  const entries = readdirSync(directory, { withFileTypes: true });
+
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (
+      entry.name === "node_modules" ||
+      entry.name === ".next" ||
+      entry.name === "target" ||
+      entry.name === "gen" ||
+      entry.name.startsWith(".")
+    ) {
+      continue;
+    }
+    const fullPath = path.join(directory, entry.name);
+    if (entry.isDirectory()) walk(fullPath, files);
+    else files.push(fullPath);
+  }
+  return files;
+}
+
+export function scanRepository(repoRoot) {
+  const findings = [];
+  for (const sourceRoot of LIVE_SOURCE_ROOTS) {
+    const absoluteRoot = path.join(repoRoot, sourceRoot.directory);
+    if (!statSync(absoluteRoot).isDirectory()) {
+      throw new Error(
+        `UI consistency source root is not a directory: ${sourceRoot.directory}`,
+      );
+    }
+    for (const absolutePath of walk(absoluteRoot, [])) {
+      const relativePath = toPosix(path.relative(repoRoot, absolutePath));
+      if (isExcludedSource(relativePath, sourceRoot)) continue;
+      if (!sourceRoot.extensions.includes(path.extname(relativePath))) continue;
+      findings.push(
+        ...scanSource({
+          path: relativePath,
+          source: readFileSync(absolutePath, "utf8"),
+        }),
+      );
+    }
+  }
+  return uniqueSortedFindings(findings);
+}
+
+function duplicateKeys(findings) {
+  const seen = new Set();
+  const duplicates = new Set();
+  for (const finding of findings) {
+    const key = findingKey(finding);
+    if (seen.has(key)) duplicates.add(key);
+    seen.add(key);
+  }
+  return [...duplicates].sort();
+}
+
+function isFinding(value) {
+  return (
+    value &&
+    typeof value === "object" &&
+    ACTIVE_RULE_IDS.has(value.rule) &&
+    typeof value.path === "string" &&
+    value.path.length > 0 &&
+    value.path === toPosix(value.path) &&
+    typeof value.excerpt === "string" &&
+    value.excerpt.length > 0 &&
+    value.excerpt === normalizeExcerpt(value.excerpt)
+  );
+}
+
+function isSorted(findings) {
+  return findings.every(
+    (finding, index) =>
+      index === 0 || compareByKey(findings[index - 1], finding) <= 0,
+  );
+}
+
+export function compareFindings(findings, baselineFindings, exceptions) {
+  const invalidBaselineFindings = baselineFindings.filter(
+    (finding) => !isFinding(finding),
+  );
+  const validBaselineFindings = baselineFindings.filter(isFinding);
+  const invalidExceptions = exceptions.filter(
+    (exception) => !isFinding(exception) || !exception.reason?.trim(),
+  );
+  const validExceptions = exceptions.filter(
+    (exception) => isFinding(exception) && exception.reason?.trim(),
+  );
+  const liveKeys = new Set(findings.map(findingKey));
+  const exceptionKeys = new Set(validExceptions.map(findingKey));
+  const activeFindings = findings.filter(
+    (finding) => !exceptionKeys.has(findingKey(finding)),
+  );
+  const activeKeys = new Set(activeFindings.map(findingKey));
+  const baselineKeys = new Set(validBaselineFindings.map(findingKey));
+  const newFindings = activeFindings.filter(
+    (finding) => !baselineKeys.has(findingKey(finding)),
+  );
+  const resolvedBaseline = validBaselineFindings.filter(
+    (finding) => !activeKeys.has(findingKey(finding)),
+  );
+  const staleExceptions = validExceptions.filter(
+    (exception) => !liveKeys.has(findingKey(exception)),
+  );
+  const duplicateBaselineKeys = duplicateKeys(validBaselineFindings);
+  const duplicateExceptionKeys = duplicateKeys(validExceptions);
+  const outOfOrderBaseline = isSorted(validBaselineFindings) ? [] : validBaselineFindings;
+
+  return {
+    ok:
+      newFindings.length === 0 &&
+      resolvedBaseline.length === 0 &&
+      staleExceptions.length === 0 &&
+      invalidExceptions.length === 0 &&
+      invalidBaselineFindings.length === 0 &&
+      duplicateBaselineKeys.length === 0 &&
+      duplicateExceptionKeys.length === 0 &&
+      outOfOrderBaseline.length === 0,
+    activeFindings,
+    newFindings,
+    resolvedBaseline,
+    staleExceptions,
+    invalidExceptions,
+    invalidBaselineFindings,
+    duplicateBaselineKeys,
+    duplicateExceptionKeys,
+    outOfOrderBaseline,
+  };
+}
+
+export function readBaseline(filePath) {
+  const parsed = JSON.parse(readFileSync(filePath, "utf8"));
+  if (
+    parsed.version !== 1 ||
+    typeof parsed.sourceRevision !== "string" ||
+    !/^[0-9a-f]{7,40}$/.test(parsed.sourceRevision) ||
+    !parsed.inventory ||
+    typeof parsed.inventory !== "object" ||
+    Array.isArray(parsed.inventory) ||
+    !Array.isArray(parsed.findings)
+  ) {
+    throw new Error(
+      "UI consistency baseline must have version 1, a Git sourceRevision, an inventory object, and a findings array.",
+    );
+  }
+  return parsed;
+}
+
+function printFindings(title, findings) {
+  if (!findings.length) return;
+  console.error(`\n${title}:`);
+  for (const finding of findings) {
+    console.error(`  ${finding.rule} · ${finding.path} · ${finding.excerpt}`);
+  }
+}
+
+function runCli() {
+  const repoRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const baseline = readBaseline(
+    path.join(repoRoot, "scripts/ui-consistency-baseline.json"),
+  );
+  const findings = scanRepository(repoRoot);
+  const result = compareFindings(
+    findings,
+    baseline.findings,
+    SEMANTIC_EXCEPTIONS,
+  );
+
+  if (process.argv.includes("--json")) {
+    console.log(
+      JSON.stringify(
+        {
+          sourceRevision: baseline.sourceRevision,
+          inventory: baseline.inventory,
+          findings,
+          exceptions: SEMANTIC_EXCEPTIONS,
+          result,
+        },
+        null,
+        2,
+      ),
+    );
+  } else if (result.ok) {
+    console.log(
+      `✓ UI consistency baseline matches ${result.activeFindings.length} finding(s); ` +
+        `${SEMANTIC_EXCEPTIONS.length} semantic exception(s)`,
+    );
+  } else {
+    printFindings("New findings", result.newFindings);
+    printFindings(
+      "Resolved baseline entries that must be removed",
+      result.resolvedBaseline,
+    );
+    printFindings("Stale semantic exceptions", result.staleExceptions);
+    printFindings(
+      "Semantic exceptions without valid reasons",
+      result.invalidExceptions,
+    );
+    printFindings("Invalid baseline findings", result.invalidBaselineFindings);
+    if (result.duplicateBaselineKeys.length) {
+      console.error("\nDuplicate baseline keys:");
+      for (const key of result.duplicateBaselineKeys) console.error(`  ${key}`);
+    }
+    if (result.duplicateExceptionKeys.length) {
+      console.error("\nDuplicate semantic exception keys:");
+      for (const key of result.duplicateExceptionKeys) console.error(`  ${key}`);
+    }
+    if (result.outOfOrderBaseline.length) {
+      console.error("\nBaseline findings must be sorted by rule, path, and excerpt.");
+    }
+    process.exitCode = 1;
+  }
+}
+
+const isDirect =
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isDirect) runCli();

--- a/scripts/ui-consistency.test.mjs
+++ b/scripts/ui-consistency.test.mjs
@@ -417,6 +417,8 @@ assert.equal(
       invalidExceptions: repositoryResult.invalidExceptions,
       invalidBaselineFindings: repositoryResult.invalidBaselineFindings,
       duplicateBaselineKeys: repositoryResult.duplicateBaselineKeys,
+      duplicateExceptionKeys: repositoryResult.duplicateExceptionKeys,
+      outOfOrderBaseline: repositoryResult.outOfOrderBaseline,
     },
     null,
     2,

--- a/scripts/ui-consistency.test.mjs
+++ b/scripts/ui-consistency.test.mjs
@@ -1,6 +1,18 @@
 import assert from "node:assert/strict";
 import { existsSync } from "node:fs";
 import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  compareFindings,
+  readBaseline,
+  scanRepository,
+  scanSource,
+} from "./ui-consistency.mjs";
+import {
+  ACTIVE_RULES,
+  SEMANTIC_EXCEPTIONS,
+} from "./ui-consistency-policy.mjs";
 
 function exactHeadingPattern(heading) {
   const escapedHeading = heading.replace(/[.*+?^\${}()|[\]\\]/g, "\\$&");
@@ -235,6 +247,182 @@ assert.ok(
   "AGENTS.md names the drift-ratchet gate",
 );
 
+// ── scanner rule pins ──────────────────────────────────────────────────────
+// Each active rule gets a positive and negative fixture. These assertions
+// prove the policy can reject drift without treating syntax or technical
+// diagnostics as user-facing copy.
+
+const tsxFindings = scanSource({
+  path: "src/components/example.tsx",
+  source: [
+    'const spread = { title: "History", ...shared };',
+    '<input placeholder="Search tasks..." />',
+    '<EmptyState subtitle="Loading saved sketches..." />',
+    '<span>Waiting for Sage...</span>',
+    '<button>Submit</button>',
+    'return <select value={value}>',
+  ].join("\n"),
+});
+assert.deepEqual(
+  tsxFindings.map((finding) => finding.rule),
+  [
+    "components/no-native-select",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-generic-submit",
+  ],
+  "scanner finds every seeded React rule without treating spread syntax as copy",
+);
+
+const multilineTsxFindings = scanSource({
+  path: "src/components/multiline.tsx",
+  source: [
+    "return (",
+    "  <section>",
+    "    <button>",
+    '      {"Submit"}',
+    "    </button>",
+    "    <select",
+    "      value={value}",
+    "    />",
+    '    <div>{saving ? "Saving..." : "Save"}</div>',
+    '    <>{busy && "Still saving..."}</>',
+    '    <span>{`Waiting ${name}...`}</span>',
+    '    <>{`Status ${busy ? "Loading..." : "Idle"}`}</>',
+    '    <>{(busy && "Loading...") || fallback}</>',
+    '    <>{"Loading..." ?? fallback}</>',
+    '    <div title="Run">{debug && console.log("Waiting...")}</div>',
+    "  </section>",
+    ");",
+  ].join("\n"),
+});
+assert.deepEqual(
+  multilineTsxFindings.map((finding) => finding.rule),
+  [
+    "components/no-native-select",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-ascii-ellipsis",
+    "copy/no-generic-submit",
+  ],
+  "scanner follows rendered TSX across lines without flagging technical literals",
+);
+assert.match(
+  multilineTsxFindings[0]?.excerpt ?? "",
+  /^<select value=\{value\} \/>$/,
+  "native-select excerpts include the normalized opening element",
+);
+
+const swiftFindings = scanSource({
+  path: "apps/ios/CovenCave/CovenCave/Views/Example.swift",
+  source: [
+    'Button("Submit") { save() }',
+    'Text("Loading tasks...")',
+    'Button("Save") { logger.debug("Waiting...") }',
+  ].join("\n"),
+});
+assert.deepEqual(
+  swiftFindings.map((finding) => finding.rule),
+  ["copy/no-ascii-ellipsis", "copy/no-generic-submit"],
+  "scanner applies equivalent copy rules to SwiftUI literals",
+);
+
+const rustFindings = scanSource({
+  path: "src-tauri/src/example.rs",
+  source: [
+    'window.set_title("Loading tasks...");',
+    'window.set_title(title); println!("Waiting...");',
+    'println!("Loading tasks...");',
+    'tracing::error!("Failed to display alert...");',
+  ].join("\n"),
+});
+assert.deepEqual(
+  rustFindings.map((finding) => finding.rule),
+  ["copy/no-ascii-ellipsis"],
+  "scanner checks UI-bound Rust copy but ignores log-only diagnostics",
+);
+
+assert.deepEqual(
+  ACTIVE_RULES.map((rule) => rule.id),
+  [
+    "components/no-native-select",
+    "copy/no-ascii-ellipsis",
+    "copy/no-generic-submit",
+  ],
+  "Phase 0 activates the approved rules in deterministic order",
+);
+
+const finding = {
+  rule: "copy/no-ascii-ellipsis",
+  path: "src/components/example.tsx",
+  excerpt: '<input placeholder="Search tasks..." />',
+};
+assert.equal(compareFindings([finding], [finding], []).ok, true, "exact baseline is clean");
+assert.equal(compareFindings([finding], [], []).newFindings.length, 1, "new debt fails");
+assert.equal(
+  compareFindings([], [finding], []).resolvedBaseline.length,
+  1,
+  "stale baseline debt fails",
+);
+assert.equal(
+  compareFindings(
+    [finding],
+    [],
+    [{ ...finding, reason: "Browser-owned syntax example." }],
+  ).ok,
+  true,
+  "reasoned semantic exception suppresses a live finding",
+);
+assert.equal(
+  compareFindings(
+    [],
+    [],
+    [{ ...finding, reason: "Browser-owned syntax example." }],
+  ).staleExceptions.length,
+  1,
+  "stale exceptions fail",
+);
+assert.equal(
+  compareFindings([finding], [], [{ ...finding, reason: "" }]).invalidExceptions.length,
+  1,
+  "exceptions require reasons",
+);
+assert.throws(
+  () => scanRepository("/definitely-not-a-coven-repository"),
+  /ENOENT|source root is not a directory/,
+  "missing live roots fail closed",
+);
+
+const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const baseline = readBaseline(
+  path.join(repositoryRoot, "scripts/ui-consistency-baseline.json"),
+);
+const repositoryResult = compareFindings(
+  scanRepository(repositoryRoot),
+  baseline.findings,
+  SEMANTIC_EXCEPTIONS,
+);
+assert.equal(
+  repositoryResult.ok,
+  true,
+  JSON.stringify(
+    {
+      newFindings: repositoryResult.newFindings,
+      resolvedBaseline: repositoryResult.resolvedBaseline,
+      staleExceptions: repositoryResult.staleExceptions,
+      invalidExceptions: repositoryResult.invalidExceptions,
+      invalidBaselineFindings: repositoryResult.invalidBaselineFindings,
+      duplicateBaselineKeys: repositoryResult.duplicateBaselineKeys,
+    },
+    null,
+    2,
+  ),
+);
+
 console.log(
-  `ui-consistency.test.mjs: copy contract ok; fact pins ok (${paletteCount} palettes, ${iconCount} icons)`,
+  `ui-consistency.test.mjs: contract, scanner, and baseline ok (${paletteCount} palettes, ${iconCount} icons)`,
 );

--- a/src/app/aesthetic/aesthetic-fields.test.ts
+++ b/src/app/aesthetic/aesthetic-fields.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const page = readFileSync(new URL("./page.tsx", import.meta.url), "utf8");
+const css = readFileSync(new URL("./aesthetic.css", import.meta.url), "utf8");
+
+for (const imported of ["Field", "TextInput", "TextArea"]) {
+  assert.match(page, new RegExp(`\\b${imported}\\b`), `aesthetic imports ${imported}`);
+}
+
+assert.match(page, /<Section title="Fields">/, "reference exposes a Fields section");
+assert.match(
+  page,
+  /className="shell-card aesthetic-field-grid"/,
+  "field matrix uses its reference-page class",
+);
+assert.doesNotMatch(
+  page.match(/<Section title="Fields">[\s\S]*?<\/Section>/)?.[0] ?? "",
+  /\bstyle=\{/,
+  "field matrix does not increase static inline-style drift",
+);
+assert.match(
+  css,
+  /\.aesthetic-field-grid[\s\S]*gap:\s*var\(--space-5\)[\s\S]*padding:\s*var\(--space-5\)/,
+  "field matrix spacing uses design tokens",
+);
+assert.match(
+  page,
+  /label="Project name"[\s\S]*description="Use the name people recognize in task and chat pickers\."[\s\S]*required/,
+  "required described state is visible",
+);
+assert.match(
+  page,
+  /label="Summary"[\s\S]*optional[\s\S]*<TextArea/,
+  "optional multiline state is visible",
+);
+assert.match(
+  page,
+  /label="Repository path"[\s\S]*error="Enter an absolute project path"/,
+  "invalid state is visible",
+);
+assert.match(page, /label="Saved owner"[\s\S]*readOnly/, "read-only state is visible");
+assert.match(
+  page,
+  /label="Unavailable runtime"[\s\S]*disabled/,
+  "disabled state is visible",
+);
+assert.match(
+  page,
+  /placeholder="e\.g\., Coven Cave"/,
+  "example placeholder follows the contract",
+);
+assert.match(
+  page,
+  /placeholder="Describe the task…"/,
+  "intent placeholder uses a true ellipsis",
+);
+
+console.log("aesthetic-fields.test.ts: ok");

--- a/src/app/aesthetic/aesthetic.css
+++ b/src/app/aesthetic/aesthetic.css
@@ -1,0 +1,6 @@
+.aesthetic-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 14rem), 1fr));
+  gap: var(--space-5);
+  padding: var(--space-5);
+}

--- a/src/app/aesthetic/page.tsx
+++ b/src/app/aesthetic/page.tsx
@@ -3,6 +3,11 @@
 // Lives at /aesthetic so designers/contributors can sanity-check tokens
 // without booting the full app.
 
+import { Field } from "@/components/ui/field";
+import { TextArea } from "@/components/ui/text-area";
+import { TextInput } from "@/components/ui/text-input";
+import "./aesthetic.css";
+
 const PALETTE: Array<{ name: string; cssVar: string; note?: string }> = [
   { name: "bg-base", cssVar: "--bg-base", note: "page background" },
   { name: "bg-raised", cssVar: "--bg-raised", note: "cards, panels" },
@@ -203,6 +208,40 @@ export default function AestheticPage() {
               Idle
             </span>
           </div>
+        </div>
+      </Section>
+
+      <Section title="Fields">
+        <div className="shell-card aesthetic-field-grid">
+          <Field
+            label="Project name"
+            description="Use the name people recognize in task and chat pickers."
+            required
+          >
+            <TextInput placeholder="e.g., Coven Cave" />
+          </Field>
+
+          <Field label="Summary" optional>
+            <TextArea placeholder="Describe the task…" />
+          </Field>
+
+          <Field label="Repository path" error="Enter an absolute project path">
+            <TextInput defaultValue="coven-cave" />
+          </Field>
+
+          <Field
+            label="Saved owner"
+            description="Read-only values remain selectable."
+          >
+            <TextInput defaultValue="Sage" readOnly />
+          </Field>
+
+          <Field
+            label="Unavailable runtime"
+            description="Install a runtime before choosing a model."
+          >
+            <TextInput placeholder="Choose a runtime first" disabled />
+          </Field>
         </div>
       </Section>
 

--- a/src/components/ui/field.test.ts
+++ b/src/components/ui/field.test.ts
@@ -5,7 +5,10 @@ import { readFileSync } from "node:fs";
 const field = readFileSync(new URL("./field.tsx", import.meta.url), "utf8");
 const input = readFileSync(new URL("./text-input.tsx", import.meta.url), "utf8");
 const area = readFileSync(new URL("./text-area.tsx", import.meta.url), "utf8");
-const css = readFileSync(new URL("../../app/globals.css", import.meta.url), "utf8");
+const css = readFileSync(
+  new URL("../../styles/globals/primitives.css", import.meta.url),
+  "utf8",
+);
 
 assert.match(field, /createContext<FieldContextValue \| null>/, "Field owns typed context");
 assert.match(field, /const generatedId = useId\(\)/, "Field generates a stable React id");


### PR DESCRIPTION
## Summary
- demonstrate shared field primitives on the live `/aesthetic` reference
- add deterministic cross-platform source conformance scanning with reviewed debt and reasoned exceptions
- fail on new drift, stale debt, stale exceptions, malformed baselines, and missing source roots

## Verification
- `node scripts/ui-consistency.test.mjs`
- `pnpm check:ui-consistency`
- `pnpm check:tests-wired`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`

Bead: `cave-xd1b.1`
Umbrella: `cave-xd1b`