### PR TITLE
Add correlated daemon lifecycle diagnostics

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -164,6 +164,7 @@ export const SUITES = {
     "src/lib/daemon-desktop-auto-start.test.ts",
     "src/lib/daemon-recovery-presentation.test.ts",
     "src/lib/about-diagnostics.test.ts",
+    "src/lib/server/daemon-diagnostics.test.ts",
     "src/lib/backup-passphrase-strength.test.ts",
     "src/lib/settings-general-summary.test.ts",
     "src/lib/browser-navigation-queue.test.ts",

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -936,13 +936,13 @@ test("Windows first launch paints progress and supports recovery while the sidec
   );
   assert.match(
     launcher,
-    /spawn_sidecar_startup\(\s*app\.handle\(\)\.clone\(\),\s*startup_control,\s*NativeStartupTerminalPolicy::RecordAtLifecycleTerminal,\s*\)\?;\s*spawn_sidecar_supervisor\(app\.handle\(\)\.clone\(\)\)/,
+    /spawn_sidecar_startup\(\s*app\.handle\(\)\.clone\(\),\s*startup_control,\s*NativeStartupTerminalPolicy::RecordAtLifecycleTerminal,\s*"sidecar-startup",\s*1,\s*\)\?;\s*spawn_sidecar_supervisor\(app\.handle\(\)\.clone\(\)\)/,
     "Windows must start post-ready supervision beside the startup owner",
   );
   assert.match(
     launcher,
-    /spawn_sidecar_startup\(\s*app\.clone\(\),\s*Arc::clone\(control\.inner\(\)\),\s*sidecar_startup::NativeStartupTerminalPolicy::DeferredToSupervisor,\s*\)/,
-    "automatic Windows recovery must reuse SidecarStartupControl instead of racing it",
+    /spawn_sidecar_startup\(\s*app\.clone\(\),\s*Arc::clone\(control\.inner\(\)\),\s*sidecar_startup::NativeStartupTerminalPolicy::DeferredToSupervisor,\s*"sidecar-recovery",\s*attempt,\s*\)/,
+    "automatic Windows recovery must reuse SidecarStartupControl and carry its attempt identity",
   );
   assert.match(
     launcher,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,8 @@ mod sidecar_auth;
 #[cfg(desktop)]
 mod sidecar_discovery;
 #[cfg(desktop)]
+mod sidecar_diagnostics;
+#[cfg(desktop)]
 mod sidecar_lifecycle;
 #[cfg(desktop)]
 mod sidecar_ports;

--- a/src-tauri/src/reliability_metrics.rs
+++ b/src-tauri/src/reliability_metrics.rs
@@ -489,7 +489,7 @@ where
     Ok(())
 }
 
-fn write_private_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
+pub(super) fn write_private_atomic(path: &Path, contents: &[u8]) -> Result<(), String> {
     let parent = path
         .parent()
         .ok_or_else(|| "reliability path has no parent".to_string())?;

--- a/src-tauri/src/sidecar_diagnostics.rs
+++ b/src-tauri/src/sidecar_diagnostics.rs
@@ -1,3 +1,4 @@
+use super::reliability_metrics::write_private_atomic;
 use rand::{rngs::OsRng, RngCore};
 use serde_json::{json, Value};
 use std::fs;
@@ -161,11 +162,15 @@ impl SidecarDiagnosticContext {
     }
 }
 
-fn append_bounded_event(path: &Path, event: &Value) -> Result<(), std::io::Error> {
+pub(super) fn reset_native_diagnostics_file(path: &Path) -> Result<(), String> {
+    let _guard = DIAGNOSTIC_FILE_LOCK
+        .lock()
+        .unwrap_or_else(|error| error.into_inner());
+    write_private_atomic(path, b"")
+}
+
+fn append_bounded_event(path: &Path, event: &Value) -> Result<(), String> {
     let _guard = DIAGNOSTIC_FILE_LOCK.lock().unwrap_or_else(|error| error.into_inner());
-    if let Some(parent) = path.parent() {
-        fs::create_dir_all(parent)?;
-    }
     let mut bytes = fs::read(path).unwrap_or_default();
     bytes.extend_from_slice(event.to_string().as_bytes());
     bytes.push(b'\n');
@@ -178,9 +183,7 @@ fn append_bounded_event(path: &Path, event: &Value) -> Result<(), std::io::Error
             .unwrap_or(target);
         bytes.drain(..start);
     }
-    let tmp_path = path.with_extension("jsonl.tmp");
-    fs::write(&tmp_path, &bytes)?;
-    fs::rename(&tmp_path, path)
+    write_private_atomic(path, &bytes)
 }
 
 #[cfg(test)]
@@ -246,6 +249,22 @@ mod tests {
         assert!(retained.len() <= MAX_NATIVE_DIAGNOSTIC_BYTES);
         assert_eq!(retained.first(), Some(&b'{'));
         assert_eq!(retained.last(), Some(&b'\n'));
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn app_start_resets_native_events_from_prior_processes() {
+        let path = std::env::temp_dir().join(format!(
+            "coven-sidecar-diagnostics-reset-{}-{}.jsonl",
+            std::process::id(),
+            NEXT_GENERATION.fetch_add(1, Ordering::Relaxed),
+        ));
+        append_bounded_event(&path, &json!({ "eventId": "prior-launch" }))
+            .expect("write prior launch event");
+
+        reset_native_diagnostics_file(&path).expect("reset native diagnostics");
+
+        assert_eq!(fs::read(&path).expect("read reset diagnostics"), b"");
         let _ = fs::remove_file(path);
     }
 }

--- a/src-tauri/src/sidecar_diagnostics.rs
+++ b/src-tauri/src/sidecar_diagnostics.rs
@@ -1,0 +1,249 @@
+use rand::{rngs::OsRng, RngCore};
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
+
+pub(super) const CORRELATION_ID_ENV: &str = "COVEN_CAVE_CORRELATION_ID";
+pub(super) const DIAGNOSTIC_GENERATION_ENV: &str = "COVEN_CAVE_DIAGNOSTIC_GENERATION";
+pub(super) const DIAGNOSTIC_OPERATION_ENV: &str = "COVEN_CAVE_DIAGNOSTIC_OPERATION";
+pub(super) const DIAGNOSTIC_ATTEMPT_ENV: &str = "COVEN_CAVE_DIAGNOSTIC_ATTEMPT";
+pub(super) const NATIVE_VERSION_ENV: &str = "COVEN_CAVE_NATIVE_VERSION";
+pub(super) const NATIVE_PROTOCOL_VERSION_ENV: &str = "COVEN_CAVE_NATIVE_PROTOCOL_VERSION";
+pub(super) const NATIVE_DIAGNOSTICS_FILE_ENV: &str = "COVEN_CAVE_NATIVE_DIAGNOSTICS_FILE";
+pub(super) const NATIVE_DIAGNOSTICS_FILE_NAME: &str = "daemon-diagnostics.jsonl";
+
+static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+static DIAGNOSTIC_FILE_LOCK: Mutex<()> = Mutex::new(());
+const MAX_NATIVE_DIAGNOSTIC_BYTES: usize = 256 * 1024;
+
+pub(super) struct SidecarDiagnosticContext {
+    pub(super) correlation_id: String,
+    pub(super) generation: u64,
+    pub(super) operation: &'static str,
+    pub(super) attempt: u32,
+    pub(super) cave_version: String,
+    pub(super) diagnostics_file: Option<PathBuf>,
+    current_phase: Mutex<&'static str>,
+    started_at: Instant,
+}
+
+impl SidecarDiagnosticContext {
+    pub(super) fn new(
+        operation: &'static str,
+        attempt: u32,
+        cave_version: String,
+        diagnostics_file: Option<PathBuf>,
+    ) -> Self {
+        let mut bytes = [0_u8; 16];
+        OsRng.fill_bytes(&mut bytes);
+        let correlation_id = bytes
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        Self {
+            correlation_id,
+            generation: NEXT_GENERATION.fetch_add(1, Ordering::Relaxed),
+            operation,
+            attempt: attempt.max(1),
+            cave_version,
+            diagnostics_file,
+            current_phase: Mutex::new("startup"),
+            started_at: Instant::now(),
+        }
+    }
+
+    pub(super) fn current_phase(&self) -> &'static str {
+        *self
+            .current_phase
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+    }
+
+    fn event_value(
+        &self,
+        phase: &'static str,
+        outcome: &'static str,
+        endpoint_classification: &'static str,
+        error_classification: Option<&'static str>,
+        os_error_code: Option<i32>,
+    ) -> Value {
+        let timestamp_unix_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_millis())
+            .unwrap_or_default();
+        json!({
+            "schemaVersion": 1,
+            "eventId": format!(
+                "{}:{}:native:{}:{}:{}",
+                self.correlation_id,
+                self.generation,
+                phase,
+                outcome,
+                timestamp_unix_ms,
+            ),
+            "correlationId": self.correlation_id,
+            "generation": self.generation,
+            "timestampUnixMs": timestamp_unix_ms,
+            "component": "tauri",
+            "operation": self.operation,
+            "phase": phase,
+            "attempt": self.attempt,
+            "durationMs": self.started_at.elapsed().as_millis(),
+            "outcome": outcome,
+            "process": {
+                "pid": std::process::id(),
+                "platformBirthId": Value::Null,
+            },
+            "versions": {
+                "cave": self.cave_version,
+                "protocol": "1",
+            },
+            "endpoint": {
+                "kind": "loopback-http",
+                "classification": endpoint_classification,
+                "status": Value::Null,
+            },
+            "error": error_classification.map(|classification| json!({
+                "classification": classification,
+                "code": os_error_code,
+                "message": Value::Null,
+            })),
+        })
+    }
+
+    pub(super) fn record(
+        &self,
+        phase: &'static str,
+        outcome: &'static str,
+        endpoint_classification: &'static str,
+        error_classification: Option<&'static str>,
+        os_error_code: Option<i32>,
+    ) {
+        *self
+            .current_phase
+            .lock()
+            .unwrap_or_else(|error| error.into_inner()) = phase;
+        let event = self.event_value(
+            phase,
+            outcome,
+            endpoint_classification,
+            error_classification,
+            os_error_code,
+        );
+        log::info!(
+            target: "coven_sidecar_diagnostics",
+            "{}",
+            event
+        );
+        if let Some(path) = self.diagnostics_file.as_deref() {
+            if append_bounded_event(path, &event).is_err() {
+                log::warn!("[cave] native diagnostic event retention was unavailable");
+            }
+        }
+    }
+
+    pub(super) fn record_io_error(
+        &self,
+        phase: &'static str,
+        endpoint_classification: &'static str,
+        error: &std::io::Error,
+    ) {
+        self.record(
+            phase,
+            "failed",
+            endpoint_classification,
+            Some("os-error"),
+            error.raw_os_error(),
+        );
+    }
+}
+
+fn append_bounded_event(path: &Path, event: &Value) -> Result<(), std::io::Error> {
+    let _guard = DIAGNOSTIC_FILE_LOCK.lock().unwrap_or_else(|error| error.into_inner());
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut bytes = fs::read(path).unwrap_or_default();
+    bytes.extend_from_slice(event.to_string().as_bytes());
+    bytes.push(b'\n');
+    if bytes.len() > MAX_NATIVE_DIAGNOSTIC_BYTES {
+        let target = bytes.len() - MAX_NATIVE_DIAGNOSTIC_BYTES;
+        let start = bytes[target..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|offset| target + offset + 1)
+            .unwrap_or(target);
+        bytes.drain(..start);
+    }
+    fs::write(path, bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnostic_event_is_structured_and_contains_no_raw_error_text() {
+        let context = SidecarDiagnosticContext::new(
+            "sidecar-recovery",
+            2,
+            "0.2.5".to_string(),
+            None,
+        );
+        let serialized = context
+            .event_value(
+                "startup",
+                "failed",
+                "spawn-failed",
+                Some("os-error"),
+                Some(13),
+            )
+            .to_string();
+
+        assert_eq!(context.correlation_id.len(), 32);
+        assert!(context
+            .correlation_id
+            .chars()
+            .all(|character| character.is_ascii_hexdigit()));
+        assert!(serialized.contains(r#""operation":"sidecar-recovery""#));
+        assert!(serialized.contains(r#""attempt":2"#));
+        assert!(serialized.contains(r#""classification":"os-error""#));
+        assert!(serialized.contains(r#""code":13"#));
+        assert!(!serialized.contains("/Users/"));
+        assert!(!serialized.contains("token="));
+
+        context.record(
+            "sidecar-spawn",
+            "failed",
+            "spawn-failed",
+            Some("os-error"),
+            Some(13),
+        );
+        assert_eq!(context.current_phase(), "sidecar-spawn");
+    }
+
+    #[test]
+    fn native_event_file_retention_is_bounded_on_complete_lines() {
+        let path = std::env::temp_dir().join(format!(
+            "coven-sidecar-diagnostics-{}-{}.jsonl",
+            std::process::id(),
+            NEXT_GENERATION.fetch_add(1, Ordering::Relaxed),
+        ));
+        let large = json!({
+            "schemaVersion": 1,
+            "eventId": "bounded-test",
+            "padding": "x".repeat(8_192),
+        });
+        for _ in 0..64 {
+            append_bounded_event(&path, &large).expect("append bounded event");
+        }
+        let retained = fs::read(&path).expect("read bounded events");
+        assert!(retained.len() <= MAX_NATIVE_DIAGNOSTIC_BYTES);
+        assert_eq!(retained.first(), Some(&b'{'));
+        assert_eq!(retained.last(), Some(&b'\n'));
+        let _ = fs::remove_file(path);
+    }
+}

--- a/src-tauri/src/sidecar_diagnostics.rs
+++ b/src-tauri/src/sidecar_diagnostics.rs
@@ -178,7 +178,9 @@ fn append_bounded_event(path: &Path, event: &Value) -> Result<(), std::io::Error
             .unwrap_or(target);
         bytes.drain(..start);
     }
-    fs::write(path, bytes)
+    let tmp_path = path.with_extension("jsonl.tmp");
+    fs::write(&tmp_path, &bytes)?;
+    fs::rename(&tmp_path, path)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -485,9 +485,66 @@ pub(super) fn replace_main_window_url(app: &tauri::AppHandle, url: Url) -> Resul
 #[cfg(desktop)]
 pub(super) fn start_sidecar_runtime(
     app: &tauri::AppHandle,
+    operation: &'static str,
+    attempt: u32,
     mut on_step: impl FnMut(SidecarStartupStep),
     should_cancel: impl Fn() -> bool,
 ) -> Result<Url, SidecarStartError> {
+    let diagnostics = sidecar_diagnostics::SidecarDiagnosticContext::new(
+        operation,
+        attempt,
+        app.package_info().version.to_string(),
+        app.path()
+            .app_local_data_dir()
+            .ok()
+            .map(|directory| directory.join(sidecar_diagnostics::NATIVE_DIAGNOSTICS_FILE_NAME)),
+    );
+    let lifecycle_phase = if operation == "sidecar-recovery" {
+        "recovery"
+    } else {
+        "startup"
+    };
+    diagnostics.record(
+        lifecycle_phase,
+        "started",
+        "dedicated-sidecar",
+        None,
+        None,
+    );
+    let result = run_sidecar_runtime(app, &diagnostics, &mut on_step, should_cancel);
+    match &result {
+        Ok(_) => diagnostics.record(lifecycle_phase, "succeeded", "ready", None, None),
+        Err(SidecarStartError::Cancelled) => {
+            diagnostics.record(lifecycle_phase, "cancelled", "cancelled", None, None)
+        }
+        Err(SidecarStartError::Failed(_)) => {
+            let failed_phase = diagnostics.current_phase();
+            diagnostics.record(
+                failed_phase,
+                "failed",
+                "startup-failed",
+                Some("sidecar-start-failed"),
+                None,
+            )
+        }
+    }
+    result
+}
+
+#[cfg(desktop)]
+fn run_sidecar_runtime(
+    app: &tauri::AppHandle,
+    diagnostics: &sidecar_diagnostics::SidecarDiagnosticContext,
+    on_step: &mut impl FnMut(SidecarStartupStep),
+    should_cancel: impl Fn() -> bool,
+) -> Result<Url, SidecarStartError> {
+    diagnostics.record(
+        "preparing-runtime",
+        "started",
+        "resource-discovery",
+        None,
+        None,
+    );
     on_step(SidecarStartupStep::PreparingRuntime);
     let resource_dir = app.path().resource_dir().map_err(|error| {
         SidecarStartError::failed(
@@ -631,6 +688,20 @@ pub(super) fn start_sidecar_runtime(
         None => log::warn!("[cave] `coven` CLI not found on disk - onboarding will prompt install"),
     }
 
+    diagnostics.record(
+        "preparing-runtime",
+        "succeeded",
+        "runtime-ready",
+        None,
+        None,
+    );
+    diagnostics.record(
+        "sidecar-spawn",
+        "started",
+        "node-process",
+        None,
+        None,
+    );
     on_step(SidecarStartupStep::StartingService);
     if should_cancel() {
         return Err(SidecarStartError::Cancelled);
@@ -639,12 +710,14 @@ pub(super) fn start_sidecar_runtime(
     #[cfg(target_os = "windows")]
     let (mut command, process_job, launch_gate) = {
         let process_job = windows_process_job::ProcessJob::new().map_err(|error| {
+            diagnostics.record_io_error("sidecar-spawn", "process-job-failed", &error);
             SidecarStartError::failed(
                 ReliabilityFailureClass::Permissions,
                 format!("could not create sidecar process job: {error}"),
             )
         })?;
         let launch_gate = windows_process_job::ProcessLaunchGate::new().map_err(|error| {
+            diagnostics.record_io_error("sidecar-spawn", "launch-gate-failed", &error);
             SidecarStartError::failed(
                 ReliabilityFailureClass::Permissions,
                 format!("could not create sidecar launch gate: {error}"),
@@ -653,6 +726,7 @@ pub(super) fn start_sidecar_runtime(
         let launcher = launch_gate
             .launcher(&node, [&server_js_arg])
             .map_err(|error| {
+                diagnostics.record_io_error("sidecar-spawn", "launcher-preparation-failed", &error);
                 SidecarStartError::failed(
                     ReliabilityFailureClass::Permissions,
                     format!("could not prepare sidecar launch gate: {error}"),
@@ -674,7 +748,34 @@ pub(super) fn start_sidecar_runtime(
         .env("NODE_ENV", "production")
         .env("COVEN_WHISPER_CPP_BIN", &whisper_cli)
         .env("COVEN_CAVE_AUTH_TOKEN", &auth_token)
-        .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token);
+        .env("COVEN_CAVE_ACCESS_TOKEN", &mobile_access_token)
+        .env(
+            sidecar_diagnostics::CORRELATION_ID_ENV,
+            &diagnostics.correlation_id,
+        )
+        .env(
+            sidecar_diagnostics::DIAGNOSTIC_GENERATION_ENV,
+            diagnostics.generation.to_string(),
+        )
+        .env(
+            sidecar_diagnostics::DIAGNOSTIC_OPERATION_ENV,
+            diagnostics.operation,
+        )
+        .env(
+            sidecar_diagnostics::DIAGNOSTIC_ATTEMPT_ENV,
+            diagnostics.attempt.to_string(),
+        )
+        .env(
+            sidecar_diagnostics::NATIVE_VERSION_ENV,
+            &diagnostics.cave_version,
+        )
+        .env(
+            sidecar_diagnostics::NATIVE_PROTOCOL_VERSION_ENV,
+            "1",
+        );
+    if let Some(path) = diagnostics.diagnostics_file.as_deref() {
+        command.env(sidecar_diagnostics::NATIVE_DIAGNOSTICS_FILE_ENV, path);
+    }
 
     if cfg!(debug_assertions) {
         // Development uses the explicit COVEN_PIPER_BIN/PATH fallback from the
@@ -708,6 +809,7 @@ pub(super) fn start_sidecar_runtime(
     }
 
     let mut child = command.spawn().map_err(|error| {
+        diagnostics.record_io_error("sidecar-spawn", "spawn-failed", &error);
         SidecarStartError::failed(
             ReliabilityFailureClass::Permissions,
             format!("failed to spawn node sidecar: {error}"),
@@ -732,6 +834,7 @@ pub(super) fn start_sidecar_runtime(
     #[cfg(target_os = "windows")]
     let child = {
         if let Err(error) = process_job.assign_child(&child) {
+            diagnostics.record_io_error("sidecar-spawn", "process-ownership-failed", &error);
             let _ = child.kill();
             return Err(SidecarStartError::failed(
                 ReliabilityFailureClass::Permissions,
@@ -739,6 +842,7 @@ pub(super) fn start_sidecar_runtime(
             ));
         }
         if let Err(error) = launch_gate.release() {
+            diagnostics.record_io_error("sidecar-spawn", "launch-gate-release-failed", &error);
             let _ = process_job.terminate();
             let _ = child.kill();
             return Err(SidecarStartError::failed(
@@ -766,6 +870,20 @@ pub(super) fn start_sidecar_runtime(
         }
     }
 
+    diagnostics.record(
+        "sidecar-spawn",
+        "succeeded",
+        "process-owned",
+        None,
+        None,
+    );
+    diagnostics.record(
+        "readiness",
+        "started",
+        "authenticated-loopback",
+        None,
+        None,
+    );
     on_step(SidecarStartupStep::WaitingForService);
     let sidecar_start_timeout = sidecar_start_timeout();
     let child_exited = || {
@@ -824,6 +942,13 @@ pub(super) fn start_sidecar_runtime(
             ));
         }
     }
+    diagnostics.record(
+        "readiness",
+        "succeeded",
+        "authenticated-loopback",
+        None,
+        None,
+    );
 
     sidecar_reachability_ready(app, port, sidecar_pid);
 
@@ -886,6 +1011,8 @@ pub(super) fn spawn_sidecar_startup(
     app: tauri::AppHandle,
     control: Arc<SidecarStartupControl>,
     terminal_policy: NativeStartupTerminalPolicy,
+    operation: &'static str,
+    attempt: u32,
 ) -> Result<(), String> {
     control.begin()?;
     let started = Instant::now();
@@ -913,6 +1040,8 @@ pub(super) fn spawn_sidecar_startup(
             let cancel_control = Arc::clone(&thread_control);
             let result = start_sidecar_runtime(
                 &app,
+                operation,
+                attempt,
                 move |step| {
                     let status = match step {
                         SidecarStartupStep::PreparingRuntime => SidecarStartupStatus::preparing(),
@@ -1052,6 +1181,8 @@ pub(super) fn retry_sidecar_startup(
         app,
         Arc::clone(state.inner()),
         NativeStartupTerminalPolicy::RecordAtLifecycleTerminal,
+        "sidecar-manual-retry",
+        1,
     )
 }
 

--- a/src-tauri/src/sidecar_startup.rs
+++ b/src-tauri/src/sidecar_startup.rs
@@ -517,7 +517,7 @@ pub(super) fn start_sidecar_runtime(
         Err(SidecarStartError::Cancelled) => {
             diagnostics.record(lifecycle_phase, "cancelled", "cancelled", None, None)
         }
-        Err(SidecarStartError::Failed(_)) => {
+        Err(SidecarStartError::Failed { .. }) => {
             let failed_phase = diagnostics.current_phase();
             diagnostics.record(
                 failed_phase,

--- a/src-tauri/src/sidecar_supervisor.rs
+++ b/src-tauri/src/sidecar_supervisor.rs
@@ -328,7 +328,7 @@ pub(super) fn spawn_sidecar_supervisor(app: tauri::AppHandle) {
                 recovery_pending = true;
                 continue;
             }
-            let revive_outcome = revive(&app);
+            let revive_outcome = revive(&app, budget.attempt());
             #[cfg(not(target_os = "windows"))]
             let revive_crossed_measurement_deadline =
                 rotate_timed_out_recovery_episode(&app, &mut recovery_episode);
@@ -751,12 +751,18 @@ fn cleanup_failed_revival(app: &tauri::AppHandle) {
 }
 
 #[cfg(all(desktop, not(target_os = "windows")))]
-fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
+fn revive(app: &tauri::AppHandle, attempt: u32) -> ReviveOutcome {
     let should_cancel = {
         let app = app.clone();
         move || is_stopping(&app)
     };
-    match sidecar_startup::start_sidecar_runtime(app, |_| {}, should_cancel) {
+    match sidecar_startup::start_sidecar_runtime(
+        app,
+        "sidecar-recovery",
+        attempt,
+        |_| {},
+        should_cancel,
+    ) {
         Ok(url) => {
             pty::trust_main_origin(&url);
             remember_main_startup_url(&url);
@@ -800,7 +806,7 @@ fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
 }
 
 #[cfg(all(desktop, target_os = "windows"))]
-fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
+fn revive(app: &tauri::AppHandle, attempt: u32) -> ReviveOutcome {
     let Some(control) = app.try_state::<Arc<SidecarStartupControl>>() else {
         log::warn!("[cave] sidecar revive failed: startup control is unavailable");
         return ReviveOutcome::Failed {
@@ -814,6 +820,8 @@ fn revive(app: &tauri::AppHandle) -> ReviveOutcome {
         app.clone(),
         Arc::clone(control.inner()),
         sidecar_startup::NativeStartupTerminalPolicy::DeferredToSupervisor,
+        "sidecar-recovery",
+        attempt,
     ) {
         Ok(()) => ReviveOutcome::Scheduled,
         Err(_error) if control.is_running() => {

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -336,6 +336,15 @@ pub fn run() {
                 app.state::<Arc<ReliabilityRecorder>>()
                     .configure(app_data_dir);
             }
+            if let Ok(app_local_data_dir) = app.path().app_local_data_dir() {
+                let diagnostics_path =
+                    app_local_data_dir.join(sidecar_diagnostics::NATIVE_DIAGNOSTICS_FILE_NAME);
+                if let Err(error) =
+                    sidecar_diagnostics::reset_native_diagnostics_file(&diagnostics_path)
+                {
+                    log::warn!("[cave] could not reset native diagnostics for this launch: {error}");
+                }
+            }
             // The updater's Windows pre-exit path clears the application
             // resource table after validating the package and before starting
             // msiexec. Dropping this guard stops/reaps the sidecar even though

--- a/src-tauri/src/tauri_setup.rs
+++ b/src-tauri/src/tauri_setup.rs
@@ -415,6 +415,8 @@ pub fn run() {
                         app.handle().clone(),
                         startup_control,
                         NativeStartupTerminalPolicy::RecordAtLifecycleTerminal,
+                        "sidecar-startup",
+                        1,
                     )?;
                     spawn_sidecar_supervisor(app.handle().clone());
                     None
@@ -422,7 +424,13 @@ pub fn run() {
                 #[cfg(not(target_os = "windows"))]
                 {
                     let startup_started = std::time::Instant::now();
-                    let sidecar_url = match start_sidecar_runtime(app.handle(), |_| {}, || false) {
+                    let sidecar_url = match start_sidecar_runtime(
+                        app.handle(),
+                        "sidecar-startup",
+                        1,
+                        |_| {},
+                        || false,
+                    ) {
                         Ok(url) => {
                             pending_native_startup_terminal = Some((
                                 startup_started,

--- a/src/app/api/api-contracts.test.ts
+++ b/src/app/api/api-contracts.test.ts
@@ -73,6 +73,7 @@ const contracts: RouteContract[] = [
   { route: "/coven/exec", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/daemon/capabilities", methods: ["GET"], kind: "json" },
   { route: "/daemon/connection", methods: ["GET"], kind: "json" },
+  { route: "/daemon/diagnostics", methods: ["GET"], kind: "json" },
   { route: "/daemon/probe", methods: ["POST"], kind: "json", readsJson: true, invalidJson: "guarded" },
   { route: "/daemon/start", methods: ["POST"], kind: "json" },
   { route: "/daemon/status", methods: ["GET"], kind: "json" },

--- a/src/app/api/coven/exec/route.test.ts
+++ b/src/app/api/coven/exec/route.test.ts
@@ -22,4 +22,20 @@ assert.match(
   "missing Coven CLI spawn errors should return the stable install/setup payload",
 );
 
+assert.match(
+  source,
+  /COVEN_CAVE_CORRELATION_ID:\s*diagnostics\.correlationId/,
+  "allowlisted CLI children inherit the request correlation",
+);
+assert.match(
+  source,
+  /recordDaemonDiagnosticEvent\(diagnostics/,
+  "CLI execution emits structured local lifecycle events",
+);
+assert.match(
+  source,
+  /DAEMON_DIAGNOSTIC_CORRELATION_HEADER/,
+  "CLI responses expose the correlation without exposing command output in diagnostics",
+);
+
 console.log("coven exec route.test.ts: ok");

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -3,6 +3,12 @@ import { spawn } from "node:child_process";
 import { stripAnsi } from "@/lib/ansi";
 import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
+import {
+  daemonDiagnosticContextFromRequest,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+  diagnosticError,
+  recordDaemonDiagnosticEvent,
+} from "@/lib/server/daemon-diagnostics";
 
 export const dynamic = "force-dynamic";
 
@@ -15,61 +21,113 @@ const SUBCOMMAND_ARGS: Record<string, string[]> = {
 };
 
 export async function POST(req: Request) {
+  const diagnostics = daemonDiagnosticContextFromRequest(req);
+  const respond = (body: Record<string, unknown>, status = 200) =>
+    NextResponse.json(
+      { ...body, correlationId: diagnostics.correlationId },
+      {
+        status,
+        headers: {
+          [DAEMON_DIAGNOSTIC_CORRELATION_HEADER]: diagnostics.correlationId,
+        },
+      },
+    );
   let body: { command?: string };
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+    return respond({ ok: false, error: "invalid json body" }, 400);
   }
   if (!body.command || !ALLOWED.has(body.command)) {
-    return NextResponse.json(
-      { ok: false, error: "command not allowed" },
-      { status: 400 },
-    );
+    return respond({ ok: false, error: "command not allowed" }, 400);
   }
 
   const args = [body.command, ...(SUBCOMMAND_ARGS[body.command] ?? [])];
+  const operation = `coven-${body.command}`;
+  const startedAt = Date.now();
+  recordDaemonDiagnosticEvent(diagnostics, {
+    component: "cli",
+    operation,
+    phase: "execution",
+    outcome: "started",
+    process: { pid: process.pid },
+    endpoint: { kind: "cli", classification: "allowlisted-command" },
+  });
 
   return new Promise<Response>((resolve) => {
     const { command, fixedArgs } = covenLaunchCommand();
     const child = spawn(command, [...fixedArgs, ...args], {
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: covenSpawnEnv(),
+      env: {
+        ...covenSpawnEnv(),
+        COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
+        COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
+        COVEN_CAVE_DIAGNOSTIC_OPERATION: operation,
+        COVEN_CAVE_DIAGNOSTIC_ATTEMPT: "1",
+      },
     });
     let out = "";
     let err = "";
+    let settled = false;
+    const settle = (
+      body: Record<string, unknown>,
+      status: number,
+      outcome: "succeeded" | "failed" | "timed-out",
+      error?: unknown,
+    ) => {
+      if (settled) return;
+      settled = true;
+      recordDaemonDiagnosticEvent(diagnostics, {
+        component: "cli",
+        operation,
+        phase: "execution",
+        durationMs: Date.now() - startedAt,
+        outcome,
+        process: { pid: child.pid },
+        endpoint: {
+          kind: "cli",
+          classification: outcome === "succeeded" ? "completed" : outcome,
+          status,
+        },
+        error: error ? diagnosticError(error, outcome) : null,
+      });
+      resolve(respond(body, status));
+    };
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (err += d.toString()));
     const t = setTimeout(() => {
       child.kill("SIGTERM");
-      resolve(
-        NextResponse.json(
-          { ok: false, error: "timeout", stdout: stripAnsi(out), stderr: stripAnsi(err) },
-          { status: 504 },
-        ),
+      settle(
+        { ok: false, error: "timeout", stdout: stripAnsi(out), stderr: stripAnsi(err) },
+        504,
+        "timed-out",
+        "timeout",
       );
     }, 6000);
     child.on("error", (e) => {
       clearTimeout(t);
-      resolve(
-        NextResponse.json(
-          isMissingExecutableError(e)
-            ? covenCliMissingError()
-            : { ok: false, error: e.message },
-          { status: 500 },
-        ),
+      settle(
+        isMissingExecutableError(e)
+          ? covenCliMissingError()
+          : { ok: false, error: e.message },
+        500,
+        "failed",
+        e,
       );
     });
     child.on("close", (code) => {
       clearTimeout(t);
-      resolve(
-        NextResponse.json({
+      settle(
+        {
           ok: code === 0,
           exitCode: code,
           stdout: stripAnsi(out),
           stderr: stripAnsi(err),
-        }),
+        },
+        200,
+        code === 0 ? "succeeded" : "failed",
+        code === 0 ? undefined : `CLI exited with status ${code ?? "unknown"}`,
       );
     });
   });

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -74,6 +74,7 @@ export async function POST(req: Request) {
       body: Record<string, unknown>,
       status: number,
       outcome: "succeeded" | "failed" | "timed-out",
+      classification: string,
       error?: unknown,
     ) => {
       if (settled) return;
@@ -87,7 +88,7 @@ export async function POST(req: Request) {
         process: { pid: child.pid },
         endpoint: {
           kind: "cli",
-          classification: outcome === "succeeded" ? "completed" : outcome,
+          classification,
           status,
         },
         error: error ? diagnosticError(error, outcome) : null,
@@ -102,6 +103,7 @@ export async function POST(req: Request) {
         { ok: false, error: "timeout", stdout: stripAnsi(out), stderr: stripAnsi(err) },
         504,
         "timed-out",
+        "cli-timeout",
         "timeout",
       );
     }, 6000);
@@ -113,6 +115,7 @@ export async function POST(req: Request) {
           : { ok: false, error: e.message },
         500,
         "failed",
+        "cli-spawn-error",
         e,
       );
     });
@@ -127,6 +130,7 @@ export async function POST(req: Request) {
         },
         200,
         code === 0 ? "succeeded" : "failed",
+        code === 0 ? "completed" : "cli-error",
         code === 0 ? undefined : `CLI exited with status ${code ?? "unknown"}`,
       );
     });

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -91,7 +91,7 @@ export async function POST(req: Request) {
           classification,
           status,
         },
-        error: error ? diagnosticError(error, outcome) : null,
+        error: error ? diagnosticError(error, classification) : null,
       });
       resolve(respond(body, status));
     };

--- a/src/app/api/daemon/diagnostics/route.ts
+++ b/src/app/api/daemon/diagnostics/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server";
+import { installedCovenVersion } from "@/lib/coven-version";
+import {
+  buildDaemonDiagnosticBundle,
+  listDaemonDiagnosticEvents,
+} from "@/lib/server/daemon-diagnostics";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  const bundle = buildDaemonDiagnosticBundle({
+    events: listDaemonDiagnosticEvents(),
+    runtime: {
+      platform: process.platform,
+      architecture: process.arch,
+      nodeVersion: process.version,
+      caveVersion: await installedCovenVersion(),
+    },
+  });
+  return NextResponse.json(bundle, {
+    headers: {
+      "cache-control": "no-store",
+      "content-disposition": 'attachment; filename="coven-cave-daemon-diagnostics.json"',
+    },
+  });
+}

--- a/src/app/api/daemon/probe/route.test.ts
+++ b/src/app/api/daemon/probe/route.test.ts
@@ -34,5 +34,9 @@ test("probe rejects a bearer-protected remote HTTP hub before calling it", async
 const route = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 assert.match(route, /export const runtime = "nodejs"/);
 assert.match(route, /export const dynamic = "force-dynamic"/);
-assert.match(route, /probeDaemonUrl\(url\)/);
+assert.match(
+  route,
+  /probeDaemonUrl\(url, undefined, Date\.now, diagnostics\)/,
+  "the route passes its correlation context into the health probe",
+);
 assert.match(route, /invalid hub URL/);

--- a/src/app/api/daemon/probe/route.test.ts
+++ b/src/app/api/daemon/probe/route.test.ts
@@ -5,12 +5,12 @@ import test from "node:test";
 import { probeDaemonUrl } from "../../../../lib/server/daemon-probe.ts";
 
 test("probe helper accepts a stubbed daemon caller for route-level outcomes", async () => {
-  const result = await probeDaemonUrl("http://hub.tailnet:8787", async () => ({
+  const result = await probeDaemonUrl("http://hub.tailnet:8787", { call: async () => ({
     ok: false,
     status: 503,
     data: null,
     error: "maintenance",
-  }), () => 5);
+  }), now: () => 5 });
   assert.equal(result.reachable, false);
   assert.equal(result.reason, "hub unhealthy: maintenance");
 });
@@ -36,7 +36,7 @@ assert.match(route, /export const runtime = "nodejs"/);
 assert.match(route, /export const dynamic = "force-dynamic"/);
 assert.match(
   route,
-  /probeDaemonUrl\(url, undefined, Date\.now, diagnostics\)/,
+  /probeDaemonUrl\(url, \{ diagnostics \}\)/,
   "the route passes its correlation context into the health probe",
 );
 assert.match(route, /invalid hub URL/);

--- a/src/app/api/daemon/probe/route.test.ts
+++ b/src/app/api/daemon/probe/route.test.ts
@@ -5,12 +5,15 @@ import test from "node:test";
 import { probeDaemonUrl } from "../../../../lib/server/daemon-probe.ts";
 
 test("probe helper accepts a stubbed daemon caller for route-level outcomes", async () => {
-  const result = await probeDaemonUrl("http://hub.tailnet:8787", { call: async () => ({
-    ok: false,
-    status: 503,
-    data: null,
-    error: "maintenance",
-  }), now: () => 5 });
+  const result = await probeDaemonUrl("http://hub.tailnet:8787", {
+    call: async () => ({
+      ok: false,
+      status: 503,
+      data: null,
+      error: "maintenance",
+    }),
+    now: () => 5,
+  });
   assert.equal(result.reachable, false);
   assert.equal(result.reason, "hub unhealthy: maintenance");
 });

--- a/src/app/api/daemon/probe/route.ts
+++ b/src/app/api/daemon/probe/route.ts
@@ -42,7 +42,7 @@ export async function POST(req: Request) {
     : "";
   if (!url) return respond({ ok: false, error: "invalid hub URL" }, 400);
   try {
-    return respond(await probeDaemonUrl(url, undefined, Date.now, diagnostics));
+    return respond(await probeDaemonUrl(url, { diagnostics }));
   } catch {
     return respond({ ok: false, error: "invalid hub URL" }, 400);
   }

--- a/src/app/api/daemon/probe/route.ts
+++ b/src/app/api/daemon/probe/route.ts
@@ -1,23 +1,49 @@
 import { NextResponse } from "next/server";
 import { probeDaemonUrl } from "@/lib/server/daemon-probe";
+import {
+  daemonDiagnosticContextFromRequest,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+  diagnosticError,
+  recordDaemonDiagnosticEvent,
+} from "@/lib/server/daemon-diagnostics";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 export async function POST(req: Request) {
+  const diagnostics = daemonDiagnosticContextFromRequest(req);
+  const respond = (body: Record<string, unknown>, status = 200) =>
+    NextResponse.json(
+      { ...body, correlationId: diagnostics.correlationId },
+      {
+        status,
+        headers: {
+          [DAEMON_DIAGNOSTIC_CORRELATION_HEADER]: diagnostics.correlationId,
+        },
+      },
+    );
   let body: unknown;
   try {
     body = await req.json();
   } catch {
-    return NextResponse.json({ ok: false, error: "invalid JSON body" }, { status: 400 });
+    recordDaemonDiagnosticEvent(diagnostics, {
+      component: "next",
+      operation: "daemon-probe",
+      phase: "validation",
+      outcome: "failed",
+      process: { pid: process.pid },
+      endpoint: { kind: "hub-http", classification: "invalid-request" },
+      error: diagnosticError("invalid JSON body", "invalid-request"),
+    });
+    return respond({ ok: false, error: "invalid JSON body" }, 400);
   }
   const url = typeof body === "object" && body !== null && "url" in body
     ? String((body as { url?: unknown }).url ?? "").trim()
     : "";
-  if (!url) return NextResponse.json({ ok: false, error: "invalid hub URL" }, { status: 400 });
+  if (!url) return respond({ ok: false, error: "invalid hub URL" }, 400);
   try {
-    return NextResponse.json(await probeDaemonUrl(url));
+    return respond(await probeDaemonUrl(url, undefined, Date.now, diagnostics));
   } catch {
-    return NextResponse.json({ ok: false, error: "invalid hub URL" }, { status: 400 });
+    return respond({ ok: false, error: "invalid hub URL" }, 400);
   }
 }

--- a/src/app/api/daemon/start/route.test.ts
+++ b/src/app/api/daemon/start/route.test.ts
@@ -6,8 +6,8 @@ const source = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /startLocalDaemon\(\{ restart, automatic \}\)/,
-  "daemon start should pass explicit restart and automatic intent to the shared starter",
+  /startLocalDaemonOperation\(\{[\s\S]*restart,[\s\S]*automatic,[\s\S]*diagnostics: daemonDiagnosticContextFromRequest\(request\),[\s\S]*\}\)/,
+  "daemon start should pass restart, automatic intent, and request correlation to the shared starter",
 );
 
 assert.match(
@@ -30,8 +30,14 @@ assert.match(
 
 assert.match(
   source,
-  /NextResponse\.json\(result, \{ status: "status" in result \? result\.status : 200 \}\)/,
+  /status: "status" in result \? result\.status : 200/,
   "daemon start route should preserve helper-provided error statuses",
+);
+
+assert.match(
+  source,
+  /\[DAEMON_DIAGNOSTIC_CORRELATION_HEADER\]: operation\.diagnostics\.correlationId/,
+  "daemon start route should return the correlation id in a response header",
 );
 
 console.log("daemon start route.test.ts: ok");

--- a/src/app/api/daemon/start/route.ts
+++ b/src/app/api/daemon/start/route.ts
@@ -1,5 +1,9 @@
 import { NextResponse } from "next/server";
-import { startLocalDaemon } from "@/lib/daemon-start";
+import { startLocalDaemonOperation } from "@/lib/daemon-start";
+import {
+  daemonDiagnosticContextFromRequest,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+} from "@/lib/server/daemon-diagnostics";
 
 export const dynamic = "force-dynamic";
 
@@ -16,6 +20,19 @@ export async function POST(request: Request) {
   // (e.g. a launchd KeepAlive agent) for the socket — the supervisor relaunches
   // its copy while the restart spawns another, churning the socket. A healthy
   // daemon means "start" has nothing to do, so report it as already running.
-  const result = await startLocalDaemon({ restart, automatic });
-  return NextResponse.json(result, { status: "status" in result ? result.status : 200 });
+  const operation = startLocalDaemonOperation({
+    restart,
+    automatic,
+    diagnostics: daemonDiagnosticContextFromRequest(request),
+  });
+  const result = await operation.result;
+  return NextResponse.json(
+    { ...result, correlationId: operation.diagnostics.correlationId },
+    {
+      status: "status" in result ? result.status : 200,
+      headers: {
+        [DAEMON_DIAGNOSTIC_CORRELATION_HEADER]: operation.diagnostics.correlationId,
+      },
+    },
+  );
 }

--- a/src/app/api/daemon/status/route.test.ts
+++ b/src/app/api/daemon/status/route.test.ts
@@ -24,8 +24,8 @@ assert.match(
 
 assert.match(
   source,
-  /snapshot = await loadDaemonStatusSnapshot\(\)[\s\S]*?return caveHomeStatusUnavailable\(error\)/,
-  "Cave home lock failures should return a structured status response instead of HTTP 500",
+  /snapshot = await loadDaemonStatusSnapshot\(\)[\s\S]*?return respond\(caveHomeStatusUnavailable\(error\)\)/,
+  "Cave home lock failures should return a correlated structured status response instead of HTTP 500",
 );
 
 assert.match(
@@ -42,8 +42,8 @@ assert.match(
 
 assert.match(
   source,
-  /callDaemonTarget<Health>\(target, daemonHealthRequest\(\)\)/,
-  "the health request and status metadata should use the same resolved daemon target",
+  /callDaemonTarget<Health>\(target, \{[\s\S]*?daemonHealthRequest\(\)[\s\S]*?diagnostics[\s\S]*?\}\)/,
+  "the health request, status metadata, and correlation should use the same resolved daemon target",
 );
 
 assert.match(

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -18,6 +18,10 @@ import { daemonHealthRequest, daemonHealthResponseSucceeded } from "@/lib/server
 import { assessDaemonStartupCompatibility, type DaemonStartupHealth } from "@/lib/daemon-startup-contract";
 import { classifyHubFailure } from "@/lib/server/daemon-probe";
 import { reconcileDaemonTravelState } from "@/lib/server/daemon-travel-reconcile";
+import {
+  daemonDiagnosticContextFromRequest,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+} from "@/lib/server/daemon-diagnostics";
 import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 
 export const dynamic = "force-dynamic";
@@ -64,20 +68,30 @@ function isCaveHomeStatusFailure(error: unknown): boolean {
 
 function caveHomeStatusUnavailable(error?: unknown) {
   if (isCaveConfigCompatibilityError(error)) {
-    return NextResponse.json({
+    return {
       running: false,
       availability: "incompatible",
       reason: error.message,
-    });
+    };
   }
-  return NextResponse.json({
+  return {
     running: false,
     availability: "status-unavailable",
     reason: "Cave home is temporarily busy; status will retry automatically",
-  });
+  };
 }
 
-export async function GET() {
+export async function GET(request: Request) {
+  const diagnostics = daemonDiagnosticContextFromRequest(request);
+  const respond = (body: Record<string, unknown>) =>
+    NextResponse.json(
+      { ...body, correlationId: diagnostics.correlationId },
+      {
+        headers: {
+          [DAEMON_DIAGNOSTIC_CORRELATION_HEADER]: diagnostics.correlationId,
+        },
+      },
+    );
   let snapshot: Awaited<ReturnType<typeof loadDaemonStatusSnapshot>>;
   try {
     snapshot = await loadDaemonStatusSnapshot();
@@ -87,7 +101,7 @@ export async function GET() {
       ? String((error as NodeJS.ErrnoException).code ?? "")
       : "reconciliation";
     console.warn("[daemon-status] Cave home status snapshot unavailable", { code });
-    return caveHomeStatusUnavailable(error);
+    return respond(caveHomeStatusUnavailable(error));
   }
   const { config } = snapshot;
   const target = daemonTargetForConfig(config);
@@ -101,7 +115,7 @@ export async function GET() {
       travel: travelState,
       hubReachable: false,
     });
-    return NextResponse.json({
+    return respond({
       running: false,
       availability: "misconfigured",
       reason: target.error,
@@ -118,7 +132,11 @@ export async function GET() {
   // and failure classification. Reloading config inside callDaemon() created
   // a race where a connection-mode change could query one target while the
   // response claimed (and classified) another.
-  const res = await callDaemonTarget<Health>(target, daemonHealthRequest());
+  const res = await callDaemonTarget<Health>(target, {
+    ...daemonHealthRequest(),
+    diagnostics,
+    diagnosticOperation: "daemon-status-health",
+  });
   const health = daemonHealthResponseSucceeded(res) ? res.data : null;
   const daemonHealthy = health !== null;
   const installedVersion = daemonHealthy && target.mode === "local"
@@ -136,7 +154,7 @@ export async function GET() {
   });
   const root = covenWorkspaceRoot();
   if (!daemonHealthy || (compatibility && !compatibility.ok)) {
-    return NextResponse.json({
+    return respond({
       running: false,
       availability: compatibility && !compatibility.ok ? "incompatible" : failureAvailability(target, res),
       reason: compatibility && !compatibility.ok ? compatibility.diagnostic : failureReason(target, res),
@@ -154,7 +172,7 @@ export async function GET() {
     !daemonVersion || daemonVersion === "0.0.0"
       ? await installedCovenVersion()
       : installedVersion;
-  return NextResponse.json({
+  return respond({
     running: true,
     availability: "online",
     checkedAt,

--- a/src/lib/coven-daemon.test.ts
+++ b/src/lib/coven-daemon.test.ts
@@ -1,6 +1,11 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
+import {
+  clearDaemonDiagnosticEventsForTests,
+  createDaemonDiagnosticContext,
+  listDaemonDiagnosticEvents,
+} from "./server/daemon-diagnostics.ts";
 
 const {
   normalizeDaemonError,
@@ -245,9 +250,11 @@ const {
 // Hub requests authenticate with the extracted mobile access token.
 {
   let authorization = "";
+  let correlationId = "";
   let requestedUrl = "";
   const server = createServer((req, res) => {
     authorization = req.headers.authorization ?? "";
+    correlationId = String(req.headers["x-coven-correlation-id"] ?? "");
     requestedUrl = req.url ?? "";
     res.writeHead(200, { "content-type": "application/json" });
     res.end(JSON.stringify({ ok: true }));
@@ -255,6 +262,11 @@ const {
   await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
   const address = server.address();
   assert.ok(address && typeof address === "object");
+  clearDaemonDiagnosticEventsForTests();
+  const diagnostics = createDaemonDiagnosticContext({
+    correlationId: "22222222-2222-4222-8222-222222222222",
+    generation: 9,
+  });
 
   try {
     const res = await callDaemonTarget(
@@ -264,12 +276,36 @@ const {
         url: `http://127.0.0.1:${address.port}`,
         accessToken: "v1.signed",
       },
-      { path: "/api/v1/health", timeoutMs: 500 },
+      {
+        path: "/api/v1/health",
+        timeoutMs: 500,
+        diagnostics,
+        diagnosticOperation: "daemon-probe-health",
+      },
     );
 
     assert.equal(res.ok, true);
     assert.equal(authorization, "Bearer v1.signed");
+    assert.equal(correlationId, diagnostics.correlationId);
     assert.equal(requestedUrl, "/api/v1/health");
+    assert.deepEqual(
+      listDaemonDiagnosticEvents().map(
+        ({ correlationId: eventCorrelationId, generation, operation, endpoint, outcome }) => ({
+          correlationId: eventCorrelationId,
+          generation,
+          operation,
+          endpoint,
+          outcome,
+        }),
+      ),
+      [{
+        correlationId: diagnostics.correlationId,
+        generation: diagnostics.generation,
+        operation: "daemon-probe-health",
+        endpoint: { kind: "hub-http", classification: "online", status: 200 },
+        outcome: "succeeded",
+      }],
+    );
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -384,6 +420,11 @@ const {
 // flake: a briefly-busy daemon shouldn't surface a hard error for a read).
 {
   let attempts = 0;
+  clearDaemonDiagnosticEventsForTests();
+  const diagnostics = createDaemonDiagnosticContext({
+    correlationId: "33333333-3333-4333-8333-333333333333",
+    generation: 11,
+  });
   const server = createServer((req, res) => {
     attempts += 1;
     if (attempts === 1) {
@@ -398,10 +439,43 @@ const {
   try {
     const res = await callDaemonTarget(
       { mode: "hub", label: "Server hub", url: `http://127.0.0.1:${port}` },
-      { path: "/api/v1/familiars", timeoutMs: 500 },
+      {
+        path: "/api/v1/familiars",
+        timeoutMs: 500,
+        diagnostics,
+        diagnosticOperation: "daemon-familiars",
+      },
     );
     assert.equal(res.ok, true, "GET should succeed via the retry");
     assert.equal(attempts, 2, "exactly one retry");
+    assert.deepEqual(
+      listDaemonDiagnosticEvents().map(
+        ({ correlationId, generation, operation, attempt, outcome }) => ({
+          correlationId,
+          generation,
+          operation,
+          attempt,
+          outcome,
+        }),
+      ),
+      [
+        {
+          correlationId: "33333333-3333-4333-8333-333333333333",
+          generation: 11,
+          operation: "daemon-familiars",
+          attempt: 1,
+          outcome: "failed",
+        },
+        {
+          correlationId: "33333333-3333-4333-8333-333333333333",
+          generation: 11,
+          operation: "daemon-familiars",
+          attempt: 2,
+          outcome: "succeeded",
+        },
+      ],
+      "request retries preserve correlation and increment attempt",
+    );
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
@@ -428,6 +502,38 @@ const {
   } finally {
     await new Promise((resolve) => server.close(resolve));
   }
+}
+
+// Transport failures retain only the stable OS code and sanitized message.
+{
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address();
+  await new Promise((resolve) => server.close(resolve));
+  clearDaemonDiagnosticEventsForTests();
+  const diagnostics = createDaemonDiagnosticContext({
+    correlationId: "44444444-4444-4444-8444-444444444444",
+    generation: 12,
+  });
+  const res = await callDaemonTarget(
+    { mode: "hub", label: "Server hub", url: `http://127.0.0.1:${port}` },
+    {
+      path: "/api/v1/health",
+      timeoutMs: 100,
+      retryTransportFailure: false,
+      diagnostics,
+      diagnosticOperation: "daemon-health",
+    },
+  );
+  assert.equal(res.ok, false);
+  const [event] = listDaemonDiagnosticEvents();
+  assert.equal(event.error?.classification, "transport-error");
+  assert.equal(event.error?.code, "ECONNREFUSED");
+  assert.doesNotMatch(
+    event.error?.message ?? "",
+    /Users|127\.0\.0\.1|coven_access_token|token=/,
+    "OS diagnostics never retain paths, addresses, or credentials",
+  );
 }
 
 // Opt-in response caps accept a body exactly at the boundary, reject the next

--- a/src/lib/coven-daemon.ts
+++ b/src/lib/coven-daemon.ts
@@ -14,6 +14,13 @@ export {
   isSecureHubCredentialTransport,
   normalizeHubUrl,
 } from "./hub-url.ts";
+import {
+  createDaemonDiagnosticContext,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+  diagnosticError,
+  recordDaemonDiagnosticEvent,
+  type DaemonDiagnosticContext,
+} from "./server/daemon-diagnostics.ts";
 
 type SocketPathResolverOptions = {
   platform?: NodeJS.Platform;
@@ -159,6 +166,9 @@ export type DaemonRequest = {
   timeoutMs?: number;
   maxResponseBytes?: number;
   retryTransportFailure?: boolean;
+  diagnostics?: DaemonDiagnosticContext;
+  diagnosticOperation?: string;
+  diagnosticAttempt?: number;
 };
 
 export type DaemonResponse<T = unknown> = {
@@ -168,23 +178,11 @@ export type DaemonResponse<T = unknown> = {
   error?: string;
 };
 
-export async function callDaemon<T = unknown>({
-  method = "GET",
-  path: reqPath,
-  body,
-  timeoutMs = 4000,
-  maxResponseBytes,
-  retryTransportFailure = true,
-}: DaemonRequest): Promise<DaemonResponse<T>> {
+export async function callDaemon<T = unknown>(
+  request: DaemonRequest,
+): Promise<DaemonResponse<T>> {
   const target = await loadDaemonTarget();
-  return callDaemonTarget<T>(target, {
-    method,
-    path: reqPath,
-    body,
-    timeoutMs,
-    maxResponseBytes,
-    retryTransportFailure,
-  });
+  return callDaemonTarget<T>(target, request);
 }
 
 export async function callDaemonTarget<T = unknown>(
@@ -196,15 +194,29 @@ export async function callDaemonTarget<T = unknown>(
     timeoutMs = 4000,
     maxResponseBytes,
     retryTransportFailure = true,
+    diagnostics = createDaemonDiagnosticContext(),
+    diagnosticOperation = "daemon-request",
+    diagnosticAttempt = 1,
   }: DaemonRequest,
 ): Promise<DaemonResponse<T>> {
   if (target.mode === "unconfigured-hub") {
-    return {
+    const result = {
       ok: false,
       status: 0,
       data: null,
       error: target.error,
     };
+    recordDaemonDiagnosticEvent(diagnostics, {
+      component: "daemon",
+      operation: diagnosticOperation,
+      phase: "target-resolution",
+      attempt: diagnosticAttempt,
+      outcome: "failed",
+      process: { pid: process.pid },
+      endpoint: { kind: "none", classification: "unconfigured-hub" },
+      error: diagnosticError(target.error, "configuration-error"),
+    });
+    return result;
   }
 
   const first = await callDaemonTargetOnce<T>(target, {
@@ -213,6 +225,9 @@ export async function callDaemonTarget<T = unknown>(
     body,
     timeoutMs,
     maxResponseBytes,
+    diagnostics,
+    diagnosticOperation,
+    diagnosticAttempt,
   });
   // Retry transport-level failures (status 0: timeout/reset/refused) once for
   // reads unless the caller opts out — a briefly-busy daemon must not surface
@@ -228,12 +243,27 @@ export async function callDaemonTarget<T = unknown>(
       timeoutMs,
       maxResponseBytes,
       retryTransportFailure,
+      diagnostics,
+      diagnosticOperation,
+      diagnosticAttempt: diagnosticAttempt + 1,
     });
   }
   return first;
 }
 
 const GET_RETRY_DELAY_MS = 250;
+
+function diagnosticResponseVersions(data: unknown): Record<string, string> {
+  if (!data || typeof data !== "object") return {};
+  const record = data as Record<string, unknown>;
+  return Object.fromEntries(
+    [
+      ["api", record.apiVersion],
+      ["daemon", record.covenVersion],
+      ["service", record.version],
+    ].filter((entry): entry is [string, string] => typeof entry[1] === "string"),
+  );
+}
 
 function callDaemonTargetOnce<T = unknown>(
   target: Exclude<DaemonTarget, { mode: "unconfigured-hub" }>,
@@ -243,6 +273,9 @@ function callDaemonTargetOnce<T = unknown>(
     body,
     timeoutMs = 4000,
     maxResponseBytes,
+    diagnostics = createDaemonDiagnosticContext(),
+    diagnosticOperation = "daemon-request",
+    diagnosticAttempt = 1,
   }: DaemonRequest,
 ): Promise<DaemonResponse<T>> {
   if (
@@ -258,11 +291,44 @@ function callDaemonTargetOnce<T = unknown>(
     });
   }
   return new Promise((resolve) => {
+    const startedAt = Date.now();
     let settled = false;
-    const settle = (value: DaemonResponse<T>) => {
+    const settle = (value: DaemonResponse<T>, sourceError?: unknown) => {
       if (settled) return;
       settled = true;
       clearTimeout(deadline);
+      const errorClassification = value.ok
+        ? null
+        : value.status === 0
+          ? "transport-error"
+          : value.status === 401 || value.status === 403
+            ? "authorization-error"
+            : value.error === "malformed response"
+              ? "malformed-response"
+              : value.error === "daemon response exceeded size limit"
+                ? "response-size-limit"
+                : "http-error";
+      recordDaemonDiagnosticEvent(diagnostics, {
+        component: "daemon",
+        operation: diagnosticOperation,
+        phase: "response",
+        attempt: diagnosticAttempt,
+        durationMs: Date.now() - startedAt,
+        outcome: value.ok ? "succeeded" : "failed",
+        process: { pid: process.pid },
+        versions: diagnosticResponseVersions(value.data),
+        endpoint: {
+          kind: target.mode === "hub" ? "hub-http" : "local-socket",
+          classification: value.ok ? "online" : errorClassification ?? "unknown",
+          status: value.status,
+        },
+        error: errorClassification
+          ? diagnosticError(
+              sourceError ?? value.error ?? `daemon http ${value.status}`,
+              errorClassification,
+            )
+          : null,
+      });
       resolve(value);
     };
 
@@ -275,6 +341,7 @@ function callDaemonTargetOnce<T = unknown>(
     if (target.mode === "hub" && target.accessToken) {
       headers.authorization = `Bearer ${target.accessToken}`;
     }
+    headers[DAEMON_DIAGNOSTIC_CORRELATION_HEADER] = diagnostics.correlationId;
     const requestOptions =
       target.mode === "hub"
         ? (() => {
@@ -329,7 +396,10 @@ function callDaemonTargetOnce<T = unknown>(
         // A response that errors mid-body (daemon crash, connection reset)
         // never emits "end" — without this handler the promise would hang.
         res.on("error", (err) => {
-          settle({ ok: false, status: 0, data: null, error: normalizeDaemonError(err) });
+          settle(
+            { ok: false, status: 0, data: null, error: normalizeDaemonError(err) },
+            err,
+          );
         });
         res.on("end", () => {
           const raw = Buffer.concat(chunks).toString("utf8");
@@ -372,7 +442,7 @@ function callDaemonTargetOnce<T = unknown>(
         status: 0,
         data: null,
         error: normalizeDaemonError(err),
-      });
+      }, err);
     });
 
     if (payload) req.write(payload);

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -11,6 +11,11 @@ import {
   terminateDaemonLaunchTree,
 } from "./daemon-start.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
+import {
+  clearDaemonDiagnosticEventsForTests,
+  createDaemonDiagnosticContext,
+  listDaemonDiagnosticEvents,
+} from "./server/daemon-diagnostics.ts";
 
 const daemonStart = await readFile(new URL("./daemon-start.ts", import.meta.url), "utf8");
 const readinessSource = await readFile(new URL("./daemon-readiness.ts", import.meta.url), "utf8");
@@ -75,6 +80,57 @@ test("a foreground launcher is successful as soon as health becomes ready", asyn
     sleep: async (ms) => { now += ms; },
   });
   assert.deepEqual(result, { ready: true, attempts: 3, elapsedMs: 200, runnerExited: false });
+});
+
+test("daemon startup propagates one correlation into the CLI child and lifecycle events", async () => {
+  clearDaemonDiagnosticEventsForTests();
+  const diagnostics = createDaemonDiagnosticContext({
+    correlationId: "55555555-5555-4555-8555-555555555555",
+    generation: 4,
+  });
+  let spawnEnv: NodeJS.ProcessEnv | undefined;
+  const result = await startLocalDaemon({
+    restart: true,
+    diagnostics,
+    startTimeoutMs: 50,
+    readinessPollMs: 1,
+    probe: async () => ({ ok: true }),
+    spawnImpl: (_command, _args, options) => {
+      spawnEnv = options.env;
+      return fakeChild();
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(spawnEnv?.COVEN_CAVE_CORRELATION_ID, diagnostics.correlationId);
+  assert.equal(spawnEnv?.COVEN_CAVE_DIAGNOSTIC_GENERATION, "4");
+  assert.equal(spawnEnv?.COVEN_CAVE_DIAGNOSTIC_OPERATION, "daemon-start");
+  const events = listDaemonDiagnosticEvents();
+  assert.deepEqual(
+    events.map(({ correlationId, generation, operation, phase, outcome }) => ({
+      correlationId,
+      generation,
+      operation,
+      phase,
+      outcome,
+    })),
+    [
+      {
+        correlationId: "55555555-5555-4555-8555-555555555555",
+        generation: 4,
+        operation: "daemon-start",
+        phase: "startup",
+        outcome: "started",
+      },
+      {
+        correlationId: "55555555-5555-4555-8555-555555555555",
+        generation: 4,
+        operation: "daemon-start",
+        phase: "startup",
+        outcome: "succeeded",
+      },
+    ],
+  );
 });
 
 test("the deadline performs one final health probe before reporting timeout", async () => {

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -18,6 +18,12 @@ import {
   reportsDaemonAddressInUse,
   type DaemonAddressOccupancy,
 } from "./daemon-socket-occupancy.ts";
+import {
+  createDaemonDiagnosticContext,
+  diagnosticError,
+  recordDaemonDiagnosticEvent,
+  type DaemonDiagnosticContext,
+} from "./server/daemon-diagnostics.ts";
 
 export type DaemonStartResult =
   | { ok: true; alreadyRunning: true; readinessAttempts: number; elapsedMs: number; launchMode: "none" }
@@ -220,6 +226,7 @@ type StartLocalDaemonOptions = {
   terminateLaunchTree?: (child: ChildProcess) => Promise<DaemonLaunchCleanup>;
   inspectLifecycle?: () => Promise<DaemonLifecycleInspection>;
   platform?: NodeJS.Platform;
+  diagnostics?: DaemonDiagnosticContext;
 };
 
 export type DaemonLifecycleInspection = {
@@ -236,13 +243,26 @@ export function parseDaemonLifecycleInspection(value: unknown): DaemonLifecycleI
     : { status: "unknown" };
 }
 
-async function inspectDaemonLifecycle(): Promise<DaemonLifecycleInspection> {
+async function inspectDaemonLifecycle(
+  diagnostics?: DaemonDiagnosticContext,
+): Promise<DaemonLifecycleInspection> {
   try {
     const { command, fixedArgs } = covenLaunchCommand();
     const { stdout } = await execFileAsync(
       command,
       [...fixedArgs, "daemon", "status", "--json"],
-      { encoding: "utf8", env: harnessSpawnEnv(), timeout: 2_500, windowsHide: true },
+      {
+        encoding: "utf8",
+        env: {
+          ...harnessSpawnEnv(),
+          ...(diagnostics ? {
+            COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
+            COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
+          } : {}),
+        },
+        timeout: 2_500,
+        windowsHide: true,
+      },
     );
     return parseDaemonLifecycleInspection(JSON.parse(stdout));
   } catch {
@@ -260,6 +280,11 @@ export function sanitizeDaemonStartDiagnostic(value: string): string {
 }
 
 const daemonStartCoordinator = new RuntimeStartupCoordinator<DaemonStartResult>();
+export type DaemonStartOperation = {
+  diagnostics: DaemonDiagnosticContext;
+  result: Promise<DaemonStartResult>;
+};
+let activeDaemonStart: DaemonStartOperation | null = null;
 
 function hasTestSeam(options: StartLocalDaemonOptions): boolean {
   return Boolean(
@@ -284,26 +309,116 @@ function hasTestSeam(options: StartLocalDaemonOptions): boolean {
 const ADDRESS_IN_USE_DIAGNOSTIC =
   "Another process is already using the local Coven daemon address. Stop that process, or restart Cave so it can reconnect, then try again.";
 
-export function startLocalDaemon(options: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
-  if (hasTestSeam(options)) return runLocalDaemonStart(options);
-  return daemonStartCoordinator.run(
-    () => runLocalDaemonStart(options),
-    (retryAfterMs) => ({
-      ok: false,
-      code: "restart_throttled",
-      error: `Cave paused repeated daemon restarts. Try again in ${Math.ceil(retryAfterMs / 1_000)} seconds.`,
-      stdout: "",
-      stderr: "",
-      status: 429,
-      readinessAttempts: 0,
-      elapsedMs: 0,
-      launchMode: "none",
-    }),
-    (result) => result.ok,
+export function startLocalDaemonOperation(
+  options: StartLocalDaemonOptions = {},
+): DaemonStartOperation {
+  const diagnostics = options.diagnostics ?? createDaemonDiagnosticContext();
+  if (hasTestSeam(options)) {
+    return {
+      diagnostics,
+      result: runLocalDaemonStart({ ...options, diagnostics }),
+    };
+  }
+  if (activeDaemonStart) return activeDaemonStart;
+
+  const result = daemonStartCoordinator.run(
+    () => runLocalDaemonStart({ ...options, diagnostics }),
+    (retryAfterMs) => {
+      const throttledResult: DaemonStartResult = {
+        ok: false,
+        code: "restart_throttled",
+        error: `Cave paused repeated daemon restarts. Try again in ${Math.ceil(retryAfterMs / 1_000)} seconds.`,
+        stdout: "",
+        stderr: "",
+        status: 429,
+        readinessAttempts: 0,
+        elapsedMs: 0,
+        launchMode: "none",
+      };
+      recordDaemonDiagnosticEvent(diagnostics, {
+        component: "next",
+        operation: options.automatic ? "daemon-recovery" : "daemon-start",
+        phase: "admission",
+        outcome: "deferred",
+        process: { pid: process.pid },
+        endpoint: { kind: "local-socket", classification: "restart-throttled" },
+        error: diagnosticError(throttledResult.error, throttledResult.code),
+      });
+      return throttledResult;
+    },
+    (operationResult) => operationResult.ok,
   );
+  const operation: DaemonStartOperation = {
+    diagnostics,
+    result,
+  };
+  activeDaemonStart = operation;
+  const releaseOperation = () => {
+    if (activeDaemonStart === operation) activeDaemonStart = null;
+  };
+  void result.then(releaseOperation, releaseOperation);
+  return operation;
 }
 
-async function runLocalDaemonStart({
+export function startLocalDaemon(
+  options: StartLocalDaemonOptions = {},
+): Promise<DaemonStartResult> {
+  return startLocalDaemonOperation(options).result;
+}
+
+async function runLocalDaemonStart(
+  options: StartLocalDaemonOptions,
+): Promise<DaemonStartResult> {
+  const diagnostics = options.diagnostics ?? createDaemonDiagnosticContext();
+  const operation = options.automatic ? "daemon-recovery" : "daemon-start";
+  const startedAt = Date.now();
+  recordDaemonDiagnosticEvent(diagnostics, {
+    component: "next",
+    operation,
+    phase: "startup",
+    outcome: "started",
+    process: { pid: process.pid },
+    endpoint: { kind: "local-socket", classification: "local-daemon" },
+  });
+  try {
+    const result = await runLocalDaemonStartCore({ ...options, diagnostics });
+    recordDaemonDiagnosticEvent(diagnostics, {
+      component: "next",
+      operation,
+      phase: "startup",
+      durationMs: Date.now() - startedAt,
+      outcome: result.ok ? "succeeded" : result.code === "readiness_timeout"
+        ? "timed-out"
+        : result.code === "owner_unreachable" || result.code === "restart_throttled"
+          ? "deferred"
+          : "failed",
+      process: { pid: process.pid },
+      endpoint: {
+        kind: "local-socket",
+        classification: result.ok
+          ? result.alreadyRunning ? "already-running" : "ready"
+          : result.code,
+        status: result.ok ? 200 : result.status,
+      },
+      error: result.ok ? null : diagnosticError(result.error, result.code),
+    });
+    return result;
+  } catch (error) {
+    recordDaemonDiagnosticEvent(diagnostics, {
+      component: "next",
+      operation,
+      phase: "startup",
+      durationMs: Date.now() - startedAt,
+      outcome: "failed",
+      process: { pid: process.pid },
+      endpoint: { kind: "local-socket", classification: "unexpected-error" },
+      error: diagnosticError(error, "unexpected-error"),
+    });
+    throw error;
+  }
+}
+
+async function runLocalDaemonStartCore({
   restart: restartRequested = false,
   automatic = false,
   healthTimeoutMs = 1500,
@@ -327,8 +442,9 @@ async function runLocalDaemonStart({
   spawnEnvironment = harnessSpawnEnv,
   spawnImpl = spawn,
   terminateLaunchTree = terminateDaemonLaunchTree,
-  inspectLifecycle = inspectDaemonLifecycle,
+  inspectLifecycle,
   platform = process.platform,
+  diagnostics = createDaemonDiagnosticContext(),
 }: StartLocalDaemonOptions = {}): Promise<DaemonStartResult> {
   // The lifecycle preflight below is the whole point of the automatic path, and
   // `restart` skips it. Both flags arrive from a request body, so an automatic
@@ -343,6 +459,8 @@ async function runLocalDaemonStart({
       path: "/api/v1/health",
       timeoutMs: healthTimeoutMs,
       retryTransportFailure: false,
+      diagnostics,
+      diagnosticOperation: automatic ? "daemon-recovery-health" : "daemon-start-health",
     });
     return response.ok && response.data ? response.data : null;
   });
@@ -375,7 +493,7 @@ async function runLocalDaemonStart({
   }
 
   if (automatic && !restart) {
-    const lifecycle = await inspectLifecycle();
+    const lifecycle = await (inspectLifecycle ?? (() => inspectDaemonLifecycle(diagnostics)))();
     if (lifecycle.status === "running") {
       return { ok: true, alreadyRunning: true, readinessAttempts: 2, elapsedMs: Date.now() - startedAt, launchMode: "none" };
     }
@@ -430,7 +548,13 @@ async function runLocalDaemonStart({
     // The daemon must never hold scoped vault secrets: daemon-launched
     // sessions would inherit them wholesale. Scoped keys flow only through
     // Cave's own per-familiar spawn path (cave-4nu6).
-    env: spawnEnvironment(),
+    env: {
+      ...spawnEnvironment(),
+      COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
+      COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
+      COVEN_CAVE_DIAGNOSTIC_OPERATION: automatic ? "daemon-recovery" : "daemon-start",
+      COVEN_CAVE_DIAGNOSTIC_ATTEMPT: "1",
+    },
     shell: launch.shell ?? false,
   });
   let stdout = "";

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -245,6 +245,8 @@ export function parseDaemonLifecycleInspection(value: unknown): DaemonLifecycleI
 
 async function inspectDaemonLifecycle(
   diagnostics?: DaemonDiagnosticContext,
+  operation?: string,
+  attempt?: number,
 ): Promise<DaemonLifecycleInspection> {
   try {
     const { command, fixedArgs } = covenLaunchCommand();
@@ -258,6 +260,8 @@ async function inspectDaemonLifecycle(
           ...(diagnostics ? {
             COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
             COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
+            ...(operation != null ? { COVEN_CAVE_DIAGNOSTIC_OPERATION: operation } : {}),
+            ...(attempt != null ? { COVEN_CAVE_DIAGNOSTIC_ATTEMPT: String(attempt) } : {}),
           } : {}),
         },
         timeout: 2_500,
@@ -493,7 +497,7 @@ async function runLocalDaemonStartCore({
   }
 
   if (automatic && !restart) {
-    const lifecycle = await (inspectLifecycle ?? (() => inspectDaemonLifecycle(diagnostics)))();
+    const lifecycle = await (inspectLifecycle ?? (() => inspectDaemonLifecycle(diagnostics, automatic ? "daemon-recovery" : "daemon-start", 1)))();
     if (lifecycle.status === "running") {
       return { ok: true, alreadyRunning: true, readinessAttempts: 2, elapsedMs: Date.now() - startedAt, launchMode: "none" };
     }

--- a/src/lib/harness-spawn-env.test.ts
+++ b/src/lib/harness-spawn-env.test.ts
@@ -247,7 +247,11 @@ const assistSource = read("./server/assist-runner.ts");
 assert.match(assistSource, /env: harnessSpawnEnv\(\)/, "assist runs no longer inherit the full process env");
 
 const daemonStartSource = read("./daemon-start.ts");
-assert.match(daemonStartSource, /env: harnessSpawnEnv\(\)/, "the daemon is started without scoped vault secrets");
+assert.match(
+  daemonStartSource,
+  /spawnEnvironment = harnessSpawnEnv[\s\S]*?env: \{\s*\.\.\.spawnEnvironment\(\),[\s\S]*?COVEN_CAVE_CORRELATION_ID/,
+  "the daemon defaults to a scoped environment seam and adds only diagnostic metadata",
+);
 assert.doesNotMatch(daemonStartSource, /covenSpawnEnv/);
 
 const vaultRouteSource = read("../app/api/vault/route.ts");

--- a/src/lib/server/daemon-diagnostics.test.ts
+++ b/src/lib/server/daemon-diagnostics.test.ts
@@ -1,0 +1,201 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import {
+  buildDaemonDiagnosticBundle,
+  clearDaemonDiagnosticEventsForTests,
+  createDaemonDiagnosticContext,
+  daemonDiagnosticContextFromRequest,
+  DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
+  DAEMON_DIAGNOSTIC_MAX_EVENTS,
+  listDaemonDiagnosticEvents,
+  parseNativeDaemonDiagnosticEvents,
+  recordDaemonDiagnosticEvent,
+  seedNativeDaemonDiagnosticEvents,
+} from "./daemon-diagnostics.ts";
+
+const STARTUP_CORRELATION = "11111111-1111-4111-8111-111111111111";
+const NATIVE_CORRELATION = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+clearDaemonDiagnosticEventsForTests();
+const context = createDaemonDiagnosticContext({
+  correlationId: STARTUP_CORRELATION,
+  generation: 7,
+});
+const secret = ["ghp", "1234567890abcdefghijklmnopqrstuv"].join("_");
+for (let index = 0; index < DAEMON_DIAGNOSTIC_MAX_EVENTS + 5; index += 1) {
+  recordDaemonDiagnosticEvent(context, {
+    component: "daemon",
+    operation: "health-request",
+    phase: "response",
+    attempt: index + 1,
+    durationMs: index,
+    outcome: index % 2 === 0 ? "succeeded" : "failed",
+    versions: { daemon: "0.2.5" },
+    endpoint: {
+      kind: "local-socket",
+      classification: index % 2 === 0 ? "online" : "transport-error",
+      status: index % 2 === 0 ? 200 : 0,
+    },
+    error: index % 2 === 0 ? null : {
+      classification: "socket-error",
+      code: "EACCES",
+      message: `failed at /Users/Example Person/.coven/coven.sock?token=${secret}`,
+    },
+  });
+}
+
+const retained = listDaemonDiagnosticEvents();
+assert.equal(retained.length, DAEMON_DIAGNOSTIC_MAX_EVENTS, "retention is bounded");
+assert.equal(retained[0]?.attempt, 6, "the bounded ring drops the oldest events first");
+assert.equal(
+  retained.every((event) => event.correlationId === context.correlationId && event.generation === 7),
+  true,
+  "one correlation and operation generation follow the retained lifecycle",
+);
+assert.deepEqual(
+  retained.at(-1)?.endpoint,
+  { kind: "local-socket", classification: "online", status: 200 },
+  "endpoint kind, classification, and status remain structured",
+);
+
+const bundle = JSON.stringify(buildDaemonDiagnosticBundle({
+  events: [
+    ...retained,
+    {
+      ...retained[0],
+      eventId: `${secret}:unsafe-export-event`,
+      correlationId: secret,
+      versions: { daemon: `/Users/Example Person/bin?token=${secret}` },
+      error: {
+        classification: "os-error",
+        code: "EACCES",
+        message: `failed at /Users/Example Person/private?token=${secret}`,
+      },
+    },
+  ],
+  generatedAt: "2026-08-10T00:00:00.000Z",
+  runtime: {
+    platform: "darwin",
+    architecture: "arm64",
+    nodeVersion: "v24.18.1",
+    caveVersion: "0.2.5",
+  },
+}));
+assert.match(bundle, /coven-cave-daemon-diagnostics/, "the export carries a manifest");
+assert.match(bundle, /"included":false/, "telemetry is explicitly excluded");
+assert.equal(
+  /ghp_|Example Person|\/Users\/|coven\.sock|access_token|token=/.test(bundle),
+  false,
+  "exported events exclude secrets and personal paths",
+);
+assert.notEqual(
+  createDaemonDiagnosticContext({ correlationId: secret }).correlationId,
+  secret,
+  "secret-shaped request values cannot become correlation IDs",
+);
+const maliciousRequestContext = daemonDiagnosticContextFromRequest(new Request("http://cave.local", {
+  headers: { [DAEMON_DIAGNOSTIC_CORRELATION_HEADER]: secret },
+}));
+assert.notEqual(
+  maliciousRequestContext.correlationId,
+  secret,
+  "request headers accept only UUID-shaped correlations",
+);
+const previousNativeCorrelation = process.env.COVEN_CAVE_CORRELATION_ID;
+process.env.COVEN_CAVE_CORRELATION_ID = NATIVE_CORRELATION;
+assert.equal(
+  daemonDiagnosticContextFromRequest(new Request("http://cave.local")).correlationId,
+  NATIVE_CORRELATION,
+  "sidecar API requests inherit the native startup or recovery correlation",
+);
+if (previousNativeCorrelation === undefined) {
+  delete process.env.COVEN_CAVE_CORRELATION_ID;
+} else {
+  process.env.COVEN_CAVE_CORRELATION_ID = previousNativeCorrelation;
+}
+
+clearDaemonDiagnosticEventsForTests();
+seedNativeDaemonDiagnosticEvents({
+  COVEN_CAVE_CORRELATION_ID: NATIVE_CORRELATION,
+  COVEN_CAVE_DIAGNOSTIC_GENERATION: "3",
+  COVEN_CAVE_DIAGNOSTIC_OPERATION: "sidecar-recovery",
+  COVEN_CAVE_DIAGNOSTIC_ATTEMPT: "2",
+  COVEN_CAVE_NATIVE_VERSION: "0.2.5",
+  COVEN_CAVE_NATIVE_PROTOCOL_VERSION: "1",
+});
+const nativeEvents = listDaemonDiagnosticEvents();
+assert.deepEqual(
+  nativeEvents.map(({ component, correlationId, generation, operation, attempt, phase }) => ({
+    component,
+    correlationId,
+    generation,
+    operation,
+    attempt,
+    phase,
+  })),
+  [
+    {
+      component: "tauri",
+      correlationId: NATIVE_CORRELATION,
+      generation: 3,
+      operation: "sidecar-recovery",
+      attempt: 2,
+      phase: "sidecar-handoff",
+    },
+    {
+      component: "sidecar",
+      correlationId: NATIVE_CORRELATION,
+      generation: 3,
+      operation: "sidecar-recovery",
+      attempt: 2,
+      phase: "process-boot",
+    },
+  ],
+  "the native handoff seeds both Tauri and sidecar events with one correlation",
+);
+
+const parsedNative = parseNativeDaemonDiagnosticEvents(`${JSON.stringify({
+  schemaVersion: 1,
+  eventId: `${NATIVE_CORRELATION}:3:native:startup:failed:1`,
+  correlationId: NATIVE_CORRELATION,
+  generation: 3,
+  timestampUnixMs: 1_786_320_000_000,
+  component: "tauri",
+  operation: "sidecar-recovery",
+  phase: "startup",
+  attempt: 2,
+  durationMs: 42,
+  outcome: "failed",
+  process: { pid: 42, platformBirthId: null },
+  versions: { cave: "0.2.5", protocol: "1" },
+  endpoint: { kind: "loopback-http", classification: "startup-failed", status: null },
+  error: {
+    classification: "os-error",
+    code: 13,
+    message: `failed at /Users/Example Person/private?token=${secret}`,
+  },
+})}\n`);
+assert.equal(parsedNative.length, 1, "native JSONL events use the shared event contract");
+assert.equal(
+  /ghp_|Example Person|\/Users\/|token=/.test(JSON.stringify(parsedNative)),
+  false,
+  "native evidence is sanitized again at the export boundary",
+);
+
+const diagnosticsRoute = await readFile(
+  new URL("../../app/api/daemon/diagnostics/route.ts", import.meta.url),
+  "utf8",
+);
+assert.match(
+  diagnosticsRoute,
+  /content-disposition[\s\S]*coven-cave-daemon-diagnostics\.json/i,
+  "the diagnostic bundle is user-exportable with a stable filename",
+);
+assert.match(
+  diagnosticsRoute,
+  /buildDaemonDiagnosticBundle/,
+  "the export route uses the redacted manifest builder",
+);
+
+console.log("daemon-diagnostics.test.ts: ok");

--- a/src/lib/server/daemon-diagnostics.ts
+++ b/src/lib/server/daemon-diagnostics.ts
@@ -241,7 +241,7 @@ export function daemonDiagnosticContextFromRequest(request: Request): DaemonDiag
     request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER),
   );
   const matchingNativeCorrelationId =
-    request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER) === nativeCorrelationId
+    safeCorrelationId(request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER))?.toLowerCase() === nativeCorrelationId?.toLowerCase()
       ? nativeCorrelationId
       : null;
   return createDaemonDiagnosticContext({

--- a/src/lib/server/daemon-diagnostics.ts
+++ b/src/lib/server/daemon-diagnostics.ts
@@ -241,7 +241,8 @@ export function daemonDiagnosticContextFromRequest(request: Request): DaemonDiag
     request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER),
   );
   const matchingNativeCorrelationId =
-    safeCorrelationId(request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER))?.toLowerCase() === nativeCorrelationId?.toLowerCase()
+    safeCorrelationId(request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER))?.toLowerCase()
+      === nativeCorrelationId?.toLowerCase()
       ? nativeCorrelationId
       : null;
   return createDaemonDiagnosticContext({

--- a/src/lib/server/daemon-diagnostics.ts
+++ b/src/lib/server/daemon-diagnostics.ts
@@ -1,0 +1,610 @@
+import { createHash, randomUUID } from "node:crypto";
+import { closeSync, fstatSync, openSync, readSync } from "node:fs";
+import { sanitizeAboutDiagnosticText } from "../about-diagnostics.ts";
+
+export const DAEMON_DIAGNOSTIC_CORRELATION_HEADER = "x-coven-correlation-id";
+export const DAEMON_DIAGNOSTIC_MAX_EVENTS = 256;
+const DAEMON_DIAGNOSTIC_MAX_NATIVE_BYTES = 256 * 1024;
+
+export type DaemonDiagnosticContext = {
+  correlationId: string;
+  generation: number;
+};
+
+export type DaemonDiagnosticComponent = "tauri" | "sidecar" | "next" | "daemon" | "cli";
+export type DaemonDiagnosticOutcome =
+  | "started"
+  | "succeeded"
+  | "failed"
+  | "cancelled"
+  | "timed-out"
+  | "deferred";
+export type DaemonDiagnosticEndpointKind =
+  | "none"
+  | "local-socket"
+  | "loopback-http"
+  | "hub-http"
+  | "cli";
+
+export type DaemonDiagnosticEvent = {
+  schemaVersion: 1;
+  eventId: string;
+  correlationId: string;
+  generation: number;
+  timestamp: string;
+  component: DaemonDiagnosticComponent;
+  severity: "debug" | "info" | "warn" | "error";
+  operation: string;
+  phase: string;
+  attempt: number;
+  durationMs: number;
+  outcome: DaemonDiagnosticOutcome;
+  process: {
+    pid: number | null;
+    platformBirthId: string | null;
+  };
+  versions: Record<string, string>;
+  endpoint: {
+    kind: DaemonDiagnosticEndpointKind;
+    classification: string;
+    status: number | null;
+  };
+  error: {
+    classification: string;
+    code: string | null;
+    message: string | null;
+  } | null;
+};
+
+export type DaemonDiagnosticEventInput = {
+  component: DaemonDiagnosticComponent;
+  severity?: DaemonDiagnosticEvent["severity"];
+  operation: string;
+  phase: string;
+  attempt?: number;
+  durationMs?: number;
+  outcome: DaemonDiagnosticOutcome;
+  process?: {
+    pid?: number | null;
+    platformBirthId?: string | null;
+  };
+  versions?: Record<string, string | null | undefined>;
+  endpoint?: {
+    kind: DaemonDiagnosticEndpointKind;
+    classification?: string;
+    status?: number | null;
+  };
+  error?: {
+    classification: string;
+    code?: string | null;
+    message?: string | null;
+  } | null;
+  timestamp?: string;
+};
+
+type DaemonDiagnosticStore = {
+  nextGeneration: number;
+  nextEvent: number;
+  events: DaemonDiagnosticEvent[];
+  seededNativeCorrelations: Set<string>;
+};
+
+const daemonDiagnosticGlobal = globalThis as typeof globalThis & {
+  __covenDaemonDiagnosticStore?: DaemonDiagnosticStore;
+};
+
+function store(): DaemonDiagnosticStore {
+  daemonDiagnosticGlobal.__covenDaemonDiagnosticStore ??= {
+    nextGeneration: 1,
+    nextEvent: 1,
+    events: [],
+    seededNativeCorrelations: new Set(),
+  };
+  return daemonDiagnosticGlobal.__covenDaemonDiagnosticStore;
+}
+
+function safeToken(value: string | null | undefined, fallback: string): string {
+  const trimmed = value?.trim() ?? "";
+  return /^[a-z0-9][a-z0-9._:-]{0,63}$/i.test(trimmed) ? trimmed : fallback;
+}
+
+function safeCorrelationId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return /^[0-9a-f]{32}$/i.test(trimmed)
+    || /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(trimmed)
+    ? trimmed
+    : null;
+}
+
+function safeRequestCorrelationId(value: string | null | undefined): string | null {
+  const trimmed = value?.trim() ?? "";
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    .test(trimmed)
+    ? trimmed
+    : null;
+}
+
+function normalizedEventId(
+  value: string | null | undefined,
+  correlationId: string,
+  generation: number,
+): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed.startsWith(`${correlationId}:`) || trimmed.length > 512) return null;
+  const digest = createHash("sha256").update(trimmed).digest("hex").slice(0, 16);
+  return `${correlationId}:${generation}:${digest}`;
+}
+
+function safePositiveInteger(value: number | null | undefined, fallback: number): number {
+  return Number.isSafeInteger(value) && Number(value) > 0 ? Number(value) : fallback;
+}
+
+function safeDuration(value: number | null | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, Math.round(Number(value))) : 0;
+}
+
+function safeStatus(value: number | null | undefined): number | null {
+  return Number.isInteger(value) && Number(value) >= 0 && Number(value) <= 999
+    ? Number(value)
+    : null;
+}
+
+function safeTimestamp(value: string | null | undefined): string {
+  return value && Number.isFinite(Date.parse(value))
+    ? new Date(value).toISOString()
+    : new Date().toISOString();
+}
+
+function safeVersions(
+  versions: Record<string, string | null | undefined> | undefined,
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(versions ?? {})
+      .filter(([key, value]) => /^[a-z][a-z0-9.-]{0,31}$/i.test(key) && typeof value === "string")
+      .map(([key, value]) => [key, sanitizeAboutDiagnosticText(value as string).slice(0, 64)])
+      .filter(([, value]) => Boolean(value)),
+  );
+}
+
+function safeDiagnosticMessage(value: string): string {
+  return sanitizeAboutDiagnosticText(value)
+    .replace(/\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b/g, "[network endpoint omitted]")
+    .replace(/\blocalhost(?::\d{1,5})?\b/gi, "[network endpoint omitted]")
+    .replace(/\[::1\](?::\d{1,5})?/g, "[network endpoint omitted]");
+}
+
+function safeError(input: DaemonDiagnosticEventInput["error"]): DaemonDiagnosticEvent["error"] {
+  if (!input) return null;
+  const code = input.code && /^[A-Z0-9_-]{1,32}$/i.test(input.code) ? input.code : null;
+  const classification = safeToken(input.classification, "unknown");
+  const message = classification === "transport-error"
+    || classification === "socket-error"
+    || classification === "os-error"
+      ? null
+      : input.message ? safeDiagnosticMessage(input.message) : null;
+  return {
+    classification,
+    code,
+    message,
+  };
+}
+
+function isDiagnosticOutcome(value: unknown): value is DaemonDiagnosticOutcome {
+  return value === "started"
+    || value === "succeeded"
+    || value === "failed"
+    || value === "cancelled"
+    || value === "timed-out"
+    || value === "deferred";
+}
+
+function timestampFromUnixMs(value: number): string {
+  return Number.isFinite(value) && value >= 0 && value <= 8.64e15
+    ? new Date(value).toISOString()
+    : new Date(0).toISOString();
+}
+
+function appendEvent(event: DaemonDiagnosticEvent): DaemonDiagnosticEvent {
+  const diagnosticStore = store();
+  diagnosticStore.events.push(event);
+  if (diagnosticStore.events.length > DAEMON_DIAGNOSTIC_MAX_EVENTS) {
+    diagnosticStore.events.splice(
+      0,
+      diagnosticStore.events.length - DAEMON_DIAGNOSTIC_MAX_EVENTS,
+    );
+  }
+  return event;
+}
+
+export function createDaemonDiagnosticContext(input: {
+  correlationId?: string | null;
+  generation?: number | null;
+} = {}): DaemonDiagnosticContext {
+  const diagnosticStore = store();
+  const generation = safePositiveInteger(
+    input.generation,
+    diagnosticStore.nextGeneration++,
+  );
+  diagnosticStore.nextGeneration = Math.max(
+    diagnosticStore.nextGeneration,
+    generation + 1,
+  );
+  return {
+    correlationId: safeCorrelationId(input.correlationId) ?? randomUUID(),
+    generation,
+  };
+}
+
+export function daemonDiagnosticContextFromRequest(request: Request): DaemonDiagnosticContext {
+  const nativeCorrelationId = safeCorrelationId(process.env.COVEN_CAVE_CORRELATION_ID);
+  const requestedCorrelationId = safeRequestCorrelationId(
+    request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER),
+  );
+  const matchingNativeCorrelationId =
+    request.headers.get(DAEMON_DIAGNOSTIC_CORRELATION_HEADER) === nativeCorrelationId
+      ? nativeCorrelationId
+      : null;
+  return createDaemonDiagnosticContext({
+    correlationId: requestedCorrelationId
+      ?? matchingNativeCorrelationId
+      ?? nativeCorrelationId,
+  });
+}
+
+export function recordDaemonDiagnosticEvent(
+  context: DaemonDiagnosticContext,
+  input: DaemonDiagnosticEventInput,
+): DaemonDiagnosticEvent {
+  const diagnosticStore = store();
+  return appendEvent({
+    schemaVersion: 1,
+    eventId: `${context.correlationId}:${context.generation}:${diagnosticStore.nextEvent++}`,
+    correlationId: context.correlationId,
+    generation: context.generation,
+    timestamp: safeTimestamp(input.timestamp),
+    component: input.component,
+    severity: input.severity ?? (input.outcome === "failed" ? "error" : "info"),
+    operation: safeToken(input.operation, "unknown"),
+    phase: safeToken(input.phase, "unknown"),
+    attempt: safePositiveInteger(input.attempt, 1),
+    durationMs: safeDuration(input.durationMs),
+    outcome: input.outcome,
+    process: {
+      pid: Number.isSafeInteger(input.process?.pid) && Number(input.process?.pid) > 0
+        ? Number(input.process?.pid)
+        : null,
+      platformBirthId: input.process?.platformBirthId
+        ? safeToken(input.process.platformBirthId, "unknown")
+        : null,
+    },
+    versions: safeVersions(input.versions),
+    endpoint: {
+      kind: input.endpoint?.kind ?? "none",
+      classification: safeToken(
+        input.endpoint?.classification,
+        input.endpoint?.kind ? "unknown" : "not-applicable",
+      ),
+      status: safeStatus(input.endpoint?.status),
+    },
+    error: safeError(input.error),
+  });
+}
+
+export function diagnosticError(
+  error: unknown,
+  classification: string,
+): NonNullable<DaemonDiagnosticEventInput["error"]> {
+  const candidate = typeof error === "object" && error !== null
+    ? error as NodeJS.ErrnoException
+    : null;
+  return {
+    classification,
+    code: typeof candidate?.code === "string" ? candidate.code : null,
+    message: error instanceof Error ? error.message : typeof error === "string" ? error : null,
+  };
+}
+
+export function seedNativeDaemonDiagnosticEvents(
+  env: NodeJS.ProcessEnv = process.env,
+): void {
+  const correlationId = safeCorrelationId(env.COVEN_CAVE_CORRELATION_ID);
+  if (!correlationId) return;
+  const diagnosticStore = store();
+  if (diagnosticStore.seededNativeCorrelations.has(correlationId)) return;
+  diagnosticStore.seededNativeCorrelations.add(correlationId);
+  const context = createDaemonDiagnosticContext({
+    correlationId,
+    generation: Number(env.COVEN_CAVE_DIAGNOSTIC_GENERATION),
+  });
+  const common = {
+    operation: safeToken(env.COVEN_CAVE_DIAGNOSTIC_OPERATION, "sidecar-startup"),
+    attempt: Number(env.COVEN_CAVE_DIAGNOSTIC_ATTEMPT),
+    versions: {
+      cave: env.COVEN_CAVE_NATIVE_VERSION,
+      protocol: env.COVEN_CAVE_NATIVE_PROTOCOL_VERSION,
+      node: process.version,
+    },
+    endpoint: {
+      kind: "loopback-http" as const,
+      classification: "dedicated-sidecar",
+    },
+  };
+  recordDaemonDiagnosticEvent(context, {
+    ...common,
+    component: "tauri",
+    phase: "sidecar-handoff",
+    outcome: "succeeded",
+    process: { pid: process.ppid },
+  });
+  recordDaemonDiagnosticEvent(context, {
+    ...common,
+    component: "sidecar",
+    phase: "process-boot",
+    outcome: "started",
+    process: { pid: process.pid },
+  });
+}
+
+export function parseNativeDaemonDiagnosticEvents(raw: string): DaemonDiagnosticEvent[] {
+  return raw
+    .split(/\r?\n/)
+    .flatMap((line): DaemonDiagnosticEvent[] => {
+      if (!line.trim()) return [];
+      let parsed: Record<string, unknown>;
+      try {
+        const value = JSON.parse(line);
+        if (!value || typeof value !== "object" || Array.isArray(value)) return [];
+        parsed = value as Record<string, unknown>;
+      } catch {
+        return [];
+      }
+      const correlationId = safeCorrelationId(
+        typeof parsed.correlationId === "string" ? parsed.correlationId : null,
+      );
+      const generation = safePositiveInteger(
+        typeof parsed.generation === "number" ? parsed.generation : null,
+        0,
+      );
+      const outcome = parsed.outcome;
+      const eventId = normalizedEventId(
+        typeof parsed.eventId === "string" ? parsed.eventId : null,
+        correlationId ?? "",
+        generation,
+      );
+      if (!correlationId || !generation || !eventId || !isDiagnosticOutcome(outcome)) return [];
+
+      const processValue = parsed.process && typeof parsed.process === "object"
+        ? parsed.process as Record<string, unknown>
+        : {};
+      const versionsValue = parsed.versions && typeof parsed.versions === "object"
+        ? parsed.versions as Record<string, unknown>
+        : {};
+      const endpointValue = parsed.endpoint && typeof parsed.endpoint === "object"
+        ? parsed.endpoint as Record<string, unknown>
+        : {};
+      const errorValue = parsed.error && typeof parsed.error === "object"
+        ? parsed.error as Record<string, unknown>
+        : null;
+      const endpointKind = endpointValue.kind;
+      const kind: DaemonDiagnosticEndpointKind =
+        endpointKind === "local-socket"
+        || endpointKind === "loopback-http"
+        || endpointKind === "hub-http"
+        || endpointKind === "cli"
+          ? endpointKind
+          : "none";
+      const timestampUnixMs = typeof parsed.timestampUnixMs === "number"
+        ? parsed.timestampUnixMs
+        : Number(parsed.timestampUnixMs);
+
+      return [{
+        schemaVersion: 1,
+        eventId,
+        correlationId,
+        generation,
+        timestamp: timestampFromUnixMs(timestampUnixMs),
+        component: "tauri",
+        severity: outcome === "failed" ? "error" : "info",
+        operation: safeToken(
+          typeof parsed.operation === "string" ? parsed.operation : null,
+          "unknown",
+        ),
+        phase: safeToken(typeof parsed.phase === "string" ? parsed.phase : null, "unknown"),
+        attempt: safePositiveInteger(
+          typeof parsed.attempt === "number" ? parsed.attempt : null,
+          1,
+        ),
+        durationMs: safeDuration(
+          typeof parsed.durationMs === "number" ? parsed.durationMs : null,
+        ),
+        outcome,
+        process: {
+          pid: Number.isSafeInteger(processValue.pid) && Number(processValue.pid) > 0
+            ? Number(processValue.pid)
+            : null,
+          platformBirthId: typeof processValue.platformBirthId === "string"
+            ? safeToken(processValue.platformBirthId, "unknown")
+            : null,
+        },
+        versions: safeVersions(Object.fromEntries(
+          Object.entries(versionsValue).map(([key, value]) => [
+            key,
+            typeof value === "string" ? value : null,
+          ]),
+        )),
+        endpoint: {
+          kind,
+          classification: safeToken(
+            typeof endpointValue.classification === "string"
+              ? endpointValue.classification
+              : null,
+            "unknown",
+          ),
+          status: safeStatus(
+            typeof endpointValue.status === "number" ? endpointValue.status : null,
+          ),
+        },
+        error: errorValue
+          ? safeError({
+              classification: typeof errorValue.classification === "string"
+                ? errorValue.classification
+                : "unknown",
+              code: typeof errorValue.code === "string" || typeof errorValue.code === "number"
+                ? String(errorValue.code)
+                : null,
+              message: typeof errorValue.message === "string" ? errorValue.message : null,
+            })
+          : null,
+      }];
+    });
+}
+
+function readNativeDaemonDiagnosticEvents(
+  env: NodeJS.ProcessEnv = process.env,
+): DaemonDiagnosticEvent[] {
+  const filePath = env.COVEN_CAVE_NATIVE_DIAGNOSTICS_FILE;
+  if (!filePath) return [];
+  let descriptor: number | null = null;
+  try {
+    descriptor = openSync(filePath, "r");
+    const size = fstatSync(descriptor).size;
+    const length = Math.min(size, DAEMON_DIAGNOSTIC_MAX_NATIVE_BYTES);
+    const buffer = Buffer.alloc(length);
+    readSync(descriptor, buffer, 0, length, Math.max(0, size - length));
+    return parseNativeDaemonDiagnosticEvents(buffer.toString("utf8"));
+  } catch {
+    return [];
+  } finally {
+    if (descriptor !== null) closeSync(descriptor);
+  }
+}
+
+export function listDaemonDiagnosticEvents(): DaemonDiagnosticEvent[] {
+  seedNativeDaemonDiagnosticEvents();
+  const eventsById = new Map<string, DaemonDiagnosticEvent>();
+  for (const event of [...readNativeDaemonDiagnosticEvents(), ...store().events]) {
+    eventsById.set(event.eventId, event);
+  }
+  return [...eventsById.values()]
+    .sort((left, right) => left.timestamp.localeCompare(right.timestamp))
+    .slice(-DAEMON_DIAGNOSTIC_MAX_EVENTS)
+    .map((event) => structuredClone(event));
+}
+
+export function clearDaemonDiagnosticEventsForTests(): void {
+  daemonDiagnosticGlobal.__covenDaemonDiagnosticStore = {
+    nextGeneration: 1,
+    nextEvent: 1,
+    events: [],
+    seededNativeCorrelations: new Set(),
+  };
+}
+
+function sanitizeEventForExport(event: DaemonDiagnosticEvent): DaemonDiagnosticEvent {
+  const correlationId = safeCorrelationId(event.correlationId) ?? "invalid-correlation";
+  const generation = safePositiveInteger(event.generation, 1);
+  const endpointKind = event.endpoint?.kind;
+  const kind: DaemonDiagnosticEndpointKind =
+    endpointKind === "local-socket"
+    || endpointKind === "loopback-http"
+    || endpointKind === "hub-http"
+    || endpointKind === "cli"
+      ? endpointKind
+      : "none";
+  return {
+    schemaVersion: 1,
+    eventId: normalizedEventId(event.eventId, correlationId, generation)
+      ?? `${correlationId}:${generation}:redacted-event`,
+    correlationId,
+    generation,
+    timestamp: safeTimestamp(event.timestamp),
+    component: event.component === "tauri"
+      || event.component === "sidecar"
+      || event.component === "next"
+      || event.component === "daemon"
+      || event.component === "cli"
+        ? event.component
+        : "next",
+    severity: event.severity === "debug"
+      || event.severity === "info"
+      || event.severity === "warn"
+      || event.severity === "error"
+        ? event.severity
+        : "error",
+    operation: safeToken(event.operation, "unknown"),
+    phase: safeToken(event.phase, "unknown"),
+    attempt: safePositiveInteger(event.attempt, 1),
+    durationMs: safeDuration(event.durationMs),
+    outcome: isDiagnosticOutcome(event.outcome) ? event.outcome : "failed",
+    process: {
+      pid: Number.isSafeInteger(event.process?.pid) && Number(event.process?.pid) > 0
+        ? Number(event.process?.pid)
+        : null,
+      platformBirthId: event.process?.platformBirthId
+        ? safeToken(event.process.platformBirthId, "unknown")
+        : null,
+    },
+    versions: safeVersions(event.versions),
+    endpoint: {
+      kind,
+      classification: safeToken(event.endpoint?.classification, "unknown"),
+      status: safeStatus(event.endpoint?.status),
+    },
+    error: safeError(event.error),
+  };
+}
+
+export function buildDaemonDiagnosticBundle(input: {
+  events?: DaemonDiagnosticEvent[];
+  generatedAt?: string;
+  runtime?: {
+    platform?: string | null;
+    architecture?: string | null;
+    nodeVersion?: string | null;
+    caveVersion?: string | null;
+  };
+} = {}) {
+  const events = (input.events ?? listDaemonDiagnosticEvents()).slice(
+    -DAEMON_DIAGNOSTIC_MAX_EVENTS,
+  ).map(sanitizeEventForExport);
+  return {
+    manifest: {
+      schemaVersion: 1,
+      kind: "coven-cave-daemon-diagnostics",
+      generatedAt: safeTimestamp(input.generatedAt),
+      retention: {
+        scope: "current-sidecar-process",
+        maxEvents: DAEMON_DIAGNOSTIC_MAX_EVENTS,
+        includedEvents: events.length,
+      },
+      included: [
+        "bounded daemon lifecycle events",
+        "correlation and operation generations",
+        "sanitized endpoint, version, duration, outcome, and OS error classifications",
+      ],
+      excluded: [
+        "credentials and secret values",
+        "URL query and fragment values",
+        "personal and machine-local paths",
+        "command lines, raw stdout and stderr, and conversation content",
+        "unrelated environment variables",
+        "opt-in telemetry",
+      ],
+      telemetry: {
+        included: false,
+        collectionEnabledByExport: false,
+      },
+    },
+    runtime: {
+      platform: safeToken(input.runtime?.platform, "unknown"),
+      architecture: safeToken(input.runtime?.architecture, "unknown"),
+      nodeVersion: input.runtime?.nodeVersion
+        ? sanitizeAboutDiagnosticText(input.runtime.nodeVersion).slice(0, 64)
+        : "unknown",
+      caveVersion: input.runtime?.caveVersion
+        ? sanitizeAboutDiagnosticText(input.runtime.caveVersion).slice(0, 64)
+        : "unknown",
+    },
+    events,
+  };
+}

--- a/src/lib/server/daemon-probe.test.ts
+++ b/src/lib/server/daemon-probe.test.ts
@@ -5,22 +5,28 @@ import { probeDaemonUrl } from "./daemon-probe.ts";
 import { HUB_ACCESS_TOKEN_KEY } from "../hub-access-token.ts";
 
 test("reports a reachable healthy hub with latency", async () => {
-  const result = await probeDaemonUrl("server.tailnet:8787", { call: async (target, request) => {
-    assert.equal(target.mode, "hub");
-    assert.equal(target.url, "http://server.tailnet:8787");
-    assert.deepEqual(request, daemonHealthRequest());
-    return { ok: true, status: 200, data: { ok: true } };
-  }, now: () => 42 });
+  const result = await probeDaemonUrl("server.tailnet:8787", {
+    call: async (target, request) => {
+      assert.equal(target.mode, "hub");
+      assert.equal(target.url, "http://server.tailnet:8787");
+      assert.deepEqual(request, daemonHealthRequest());
+      return { ok: true, status: 200, data: { ok: true } };
+    },
+    now: () => 42,
+  });
   assert.deepEqual(result, { ok: true, reachable: true, status: 200, latencyMs: 0 });
 });
 
 test("classifies unauthorized hubs that answered", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
-    ok: false,
-    status: 401,
-    data: null,
-    error: "unauthorized",
-  }), now: () => 10 });
+  const result = await probeDaemonUrl("http://server.tailnet:8787", {
+    call: async () => ({
+      ok: false,
+      status: 401,
+      data: null,
+      error: "unauthorized",
+    }),
+    now: () => 10,
+  });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,
@@ -31,11 +37,14 @@ test("classifies unauthorized hubs that answered", async () => {
 });
 
 test("treats explicit unhealthy health payloads as answered but unreachable", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
-    ok: true,
-    status: 200,
-    data: { ok: false },
-  }), now: () => 10 });
+  const result = await probeDaemonUrl("http://server.tailnet:8787", {
+    call: async () => ({
+      ok: true,
+      status: 200,
+      data: { ok: false },
+    }),
+    now: () => 10,
+  });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,
@@ -46,11 +55,14 @@ test("treats explicit unhealthy health payloads as answered but unreachable", as
 });
 
 test("preserves legacy healthy payloads without ok", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
-    ok: true,
-    status: 200,
-    data: { apiVersion: "1" },
-  }), now: () => 10 });
+  const result = await probeDaemonUrl("http://server.tailnet:8787", {
+    call: async () => ({
+      ok: true,
+      status: 200,
+      data: { apiVersion: "1" },
+    }),
+    now: () => 10,
+  });
   assert.deepEqual(result, {
     ok: true,
     reachable: true,
@@ -60,12 +72,15 @@ test("preserves legacy healthy payloads without ok", async () => {
 });
 
 test("classifies transport failures as unreachable", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
-    ok: false,
-    status: 0,
-    data: null,
-    error: "daemon timeout",
-  }), now: () => 100 });
+  const result = await probeDaemonUrl("http://server.tailnet:8787", {
+    call: async () => ({
+      ok: false,
+      status: 0,
+      data: null,
+      error: "daemon timeout",
+    }),
+    now: () => 100,
+  });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,

--- a/src/lib/server/daemon-probe.test.ts
+++ b/src/lib/server/daemon-probe.test.ts
@@ -94,10 +94,12 @@ test("never forwards the process-wide credential to an ad-hoc probe origin", asy
   const previous = process.env[HUB_ACCESS_TOKEN_KEY];
   process.env[HUB_ACCESS_TOKEN_KEY] = "global-secret";
   try {
-    await probeDaemonUrl("https://attacker.example.test:8443", async (target) => {
-      assert.equal(target.mode, "hub");
-      assert.equal(target.accessToken, undefined);
-      return { ok: true, status: 200, data: { ok: true } };
+    await probeDaemonUrl("https://attacker.example.test:8443", {
+      call: async (target) => {
+        assert.equal(target.mode, "hub");
+        assert.equal(target.accessToken, undefined);
+        return { ok: true, status: 200, data: { ok: true } };
+      },
     });
   } finally {
     if (previous === undefined) delete process.env[HUB_ACCESS_TOKEN_KEY];

--- a/src/lib/server/daemon-probe.test.ts
+++ b/src/lib/server/daemon-probe.test.ts
@@ -5,22 +5,22 @@ import { probeDaemonUrl } from "./daemon-probe.ts";
 import { HUB_ACCESS_TOKEN_KEY } from "../hub-access-token.ts";
 
 test("reports a reachable healthy hub with latency", async () => {
-  const result = await probeDaemonUrl("server.tailnet:8787", async (target, request) => {
+  const result = await probeDaemonUrl("server.tailnet:8787", { call: async (target, request) => {
     assert.equal(target.mode, "hub");
     assert.equal(target.url, "http://server.tailnet:8787");
     assert.deepEqual(request, daemonHealthRequest());
     return { ok: true, status: 200, data: { ok: true } };
-  }, () => 42);
+  }, now: () => 42 });
   assert.deepEqual(result, { ok: true, reachable: true, status: 200, latencyMs: 0 });
 });
 
 test("classifies unauthorized hubs that answered", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", async () => ({
+  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
     ok: false,
     status: 401,
     data: null,
     error: "unauthorized",
-  }), () => 10);
+  }), now: () => 10 });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,
@@ -31,11 +31,11 @@ test("classifies unauthorized hubs that answered", async () => {
 });
 
 test("treats explicit unhealthy health payloads as answered but unreachable", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", async () => ({
+  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
     ok: true,
     status: 200,
     data: { ok: false },
-  }), () => 10);
+  }), now: () => 10 });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,
@@ -46,11 +46,11 @@ test("treats explicit unhealthy health payloads as answered but unreachable", as
 });
 
 test("preserves legacy healthy payloads without ok", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", async () => ({
+  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
     ok: true,
     status: 200,
     data: { apiVersion: "1" },
-  }), () => 10);
+  }), now: () => 10 });
   assert.deepEqual(result, {
     ok: true,
     reachable: true,
@@ -60,12 +60,12 @@ test("preserves legacy healthy payloads without ok", async () => {
 });
 
 test("classifies transport failures as unreachable", async () => {
-  const result = await probeDaemonUrl("http://server.tailnet:8787", async () => ({
+  const result = await probeDaemonUrl("http://server.tailnet:8787", { call: async () => ({
     ok: false,
     status: 0,
     data: null,
     error: "daemon timeout",
-  }), () => 100);
+  }), now: () => 100 });
   assert.deepEqual(result, {
     ok: true,
     reachable: false,

--- a/src/lib/server/daemon-probe.ts
+++ b/src/lib/server/daemon-probe.ts
@@ -8,6 +8,7 @@ import {
   type DaemonTarget,
 } from "../coven-daemon.ts";
 import { daemonHealthRequest, daemonHealthResponseSucceeded } from "./daemon-health-request.ts";
+import type { DaemonDiagnosticContext } from "./daemon-diagnostics.ts";
 
 export type DaemonProbeResult = {
   ok: true;
@@ -30,6 +31,7 @@ export async function probeDaemonUrl(
   url: string,
   call: CallDaemonTarget = callDaemonTarget,
   now: () => number = Date.now,
+  diagnostics?: DaemonDiagnosticContext,
 ): Promise<DaemonProbeResult> {
   const resolvedTarget = daemonTargetForConfig({
     multiHost: { mode: "hub", hubUrl: url, executorUrls: [] },
@@ -58,7 +60,16 @@ export async function probeDaemonUrl(
       reason: "Hub access tokens require HTTPS unless the endpoint is loopback.",
     };
   }
-  const response = await call(target, daemonHealthRequest());
+  const response = await call(
+    target,
+    diagnostics
+      ? {
+          ...daemonHealthRequest(),
+          diagnostics,
+          diagnosticOperation: "daemon-probe-health",
+        }
+      : daemonHealthRequest(),
+  );
   const latencyMs = Math.max(0, now() - startedAt);
   if (daemonHealthResponseSucceeded(response)) {
     return { ok: true, reachable: true, status: response.status, latencyMs };

--- a/src/lib/server/daemon-probe.ts
+++ b/src/lib/server/daemon-probe.ts
@@ -27,7 +27,7 @@ export function classifyHubFailure(res: DaemonResponse<unknown>): string {
   return `hub unreachable: ${detail}`;
 }
 
-export type DaemonProbeOptions = {
+export type ProbeDaemonUrlOptions = {
   call?: CallDaemonTarget;
   now?: () => number;
   diagnostics?: DaemonDiagnosticContext;
@@ -35,9 +35,12 @@ export type DaemonProbeOptions = {
 
 export async function probeDaemonUrl(
   url: string,
-  options: DaemonProbeOptions = {},
+  {
+    call = callDaemonTarget,
+    now = Date.now,
+    diagnostics,
+  }: ProbeDaemonUrlOptions = {},
 ): Promise<DaemonProbeResult> {
-  const { call = callDaemonTarget, now = Date.now, diagnostics } = options;
   const resolvedTarget = daemonTargetForConfig({
     multiHost: { mode: "hub", hubUrl: url, executorUrls: [] },
   });

--- a/src/lib/server/daemon-probe.ts
+++ b/src/lib/server/daemon-probe.ts
@@ -27,12 +27,17 @@ export function classifyHubFailure(res: DaemonResponse<unknown>): string {
   return `hub unreachable: ${detail}`;
 }
 
+export type DaemonProbeOptions = {
+  call?: CallDaemonTarget;
+  now?: () => number;
+  diagnostics?: DaemonDiagnosticContext;
+};
+
 export async function probeDaemonUrl(
   url: string,
-  call: CallDaemonTarget = callDaemonTarget,
-  now: () => number = Date.now,
-  diagnostics?: DaemonDiagnosticContext,
+  options: DaemonProbeOptions = {},
 ): Promise<DaemonProbeResult> {
+  const { call = callDaemonTarget, now = Date.now, diagnostics } = options;
   const resolvedTarget = daemonTargetForConfig({
     multiHost: { mode: "hub", hubUrl: url, executorUrls: [] },
   });


### PR DESCRIPTION
## Summary
- correlate Tauri startup and recovery with sidecar, Next, daemon transport, and CLI lifecycle events
- retain bounded native and server-side diagnostic evidence with sanitized endpoint and OS error classifications
- add a redacted user-exportable diagnostics manifest while keeping telemetry separate

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- `cargo check`

Bead: `cave-58eoq.3`