### PR TITLE
ci: reduce routine validation fanout

### DIFF
--- a/.agents/skills/branch-to-merge/SKILL.md
+++ b/.agents/skills/branch-to-merge/SKILL.md
@@ -8,8 +8,8 @@ description: Use when finishing work on a Coven Cave branch and landing it on pr
 Take a finished branch to a merged commit on `main` without ever writing to
 `main` directly and without destroying another session's work.
 
-`main` in this repository is protected: pull request required, nine required
-status checks, no force-push, no deletion. A pull request is
+`main` in this repository is protected: pull request required, one required
+status check, no force-push, no deletion. A pull request is
 the **only** path an agent may use. This skill is the Cave-specific replacement
 for generic "finish a branch" workflows that offer a local merge into the base
 branch — that option does not exist here.
@@ -104,7 +104,7 @@ Every path in the diff must belong to this Bead. Unrelated files mean you
 committed someone else's work — split them out before continuing.
 
 If verification fails, **STOP** and fix it. A red PR wastes the reviewer and
-burns nine CI legs.
+burns the required CI run.
 
 ## Phase 2: Base branch
 
@@ -202,7 +202,7 @@ count.
 
 ## Phase 5: Checks and review
 
-Nine required checks must pass:
+One required check must pass:
 
 ```bash
 expected_head=$(git rev-parse HEAD)
@@ -212,25 +212,17 @@ gh pr view <#> --json headRefOid,mergeable,mergeStateStatus,statusCheckRollup
 ```
 
 - `Frontend build`
-- `Rust check`
-- `E2E (Playwright)`
-- `Cross-environment (ubuntu-latest)`
-- `Cross-environment (windows-latest)`
-- `Cross-environment required`
-- `Sidecar runtime (ubuntu-latest)`
-- `Sidecar runtime (windows-latest)`
-- `Sidecar runtime required`
 
 CodeQL is retired, and code scanning is fully off — nothing scans in its place.
 If a required context never reports, the PR sits `BLOCKED` with nothing failing.
 Before and after the watch, require `headRefOid` to equal `$expected_head` and
 each listed context to be complete and successful. A pass tied to an earlier
 SHA, or a pending, cancelled, stale, missing, or failed context, is incomplete;
-do not merge until the exact current head has all nine passes.
+do not merge until the exact current head has the required pass.
 
-The `E2E (Playwright)` leg runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs
-must dismiss onboarding and mock APIs via `page.route(...)` rather than expect a
-live daemon.
+The path-aware `Frontend build` job runs Playwright daemon-less
+(`COVEN_CAVE_E2E=1`) when user-facing paths change, so e2e specs must dismiss
+onboarding and mock APIs via `page.route(...)` rather than expect a live daemon.
 
 Then read the review threads. Conversation resolution is **no longer** a merge
 gate, which makes reading them a discipline rather than a requirement — and the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ on:
     branches: [main]
 
 concurrency:
-  # A recovered workflow_dispatch and a late pull_request delivery for the
-  # same commit must supersede one another instead of running two full suites.
   group: ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
@@ -23,115 +21,51 @@ permissions:
   contents: read
 
 jobs:
-  # This was ONE job running lint → typecheck → tests → build in sequence, for
-  # 11m07s (cave-awu). Nothing in that chain consumed anything the previous
-  # step produced, so the ordering bought nothing but wall clock. Measured on
-  # run 31229051374: install 18s, lint 11s, typecheck 41s, check:tests-wired
-  # 0s, test:app 5m03s, test:api 2m44s, test:mobile 4s, build 1m55s.
-  #
-  # Split three ways below; the critical path becomes the test:app leg plus its
-  # own ~25s setup, so ~5m30s rather than 11m. Each leg re-pays checkout +
-  # install, which is the ~25s price of the parallelism.
-  frontend-static:
-    name: Frontend lint & types
+  build:
+    name: Frontend build
     if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
     runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~1min).
-    timeout-minutes: 10
+    timeout-minutes: 60
+    env:
+      NEXT_PUBLIC_CAVE_CRAFTS: "1"
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
-      # Guard: no committed merge-conflict markers anywhere in the tree.
-      # 23316da3 landed two unresolved conflict blocks in a component; the file
-      # stopped parsing, every route 500'd, and main stayed broken until
-      # 4ea88862. Nothing in this workflow would have caught it — `git diff
-      # --check` runs only in release.yml, by which point the artifact is
-      # already on main. Per-file guards exist and are worth keeping, but they
-      # only protect files someone already thought to protect.
-      #
-      # Deliberately not a new job or a required context: an added context that
-      # does not report is how a PR ends up BLOCKED with nothing failing. It
-      # rides the existing static-check job and runs before install, since a
-      # tree with markers cannot lint or typecheck meaningfully — but after
-      # setup-node, so it runs on the pinned Node rather than whatever the
-      # runner image happens to ship.
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 24
+          cache: pnpm
+
+      - id: paths
+        name: Select path-aware validation
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}
+        run: node scripts/ci-paths.mjs --base "$BASE_SHA" --head "$HEAD_SHA" >> "$GITHUB_OUTPUT"
 
       - run: node scripts/check-conflict-markers.mjs
+      - run: node --test scripts/ci-paths.test.mjs
 
-      - run: pnpm install --frozen-lockfile
+      - name: Install JavaScript dependencies
+        if: steps.paths.outputs.frontend == 'true' || steps.paths.outputs.e2e == 'true'
+        run: pnpm install --frozen-lockfile
 
-      - run: pnpm lint
-
-      - run: pnpm typecheck
-
-      # Guard: every *.test.ts/.mjs on disk must be wired into a CI test
-      # script (test:app/api/mobile) — authored tests can't silently never
-      # run. See scripts/check-tests-wired.mjs for the allowlist.
-      #
-      # This guard belongs with the static checks rather than with any one
-      # suite: it asserts across ALL THREE suite scripts, so pinning it to a
-      # single matrix leg below would imply a scope it does not have.
-      - run: pnpm check:tests-wired
-
-  frontend-tests:
-    name: Frontend tests (${{ matrix.suite }})
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~5min for the app suite).
-    timeout-minutes: 20
-    strategy:
-      # One suite failing must not cancel the others; a partial report cannot
-      # distinguish an isolated break from a systemic one.
-      fail-fast: false
-      matrix:
-        # Split by the existing script boundaries rather than by any new
-        # partitioning, so a failure still names the same suite it always did.
-        # api and mobile stay separate legs even though mobile takes 4s — the
-        # mobile smokes (drawer wiring, no-zoom input font sizes, safe-area
-        # tokens; see docs/mobile-readiness.md) are the checklist's entry point
-        # and are easier to find as their own check than buried behind api.
-        suite: [app, api, mobile]
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm test:${{ matrix.suite }}
-
-  frontend-bundle:
-    name: Frontend bundle
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~2min, up to 3 attempts).
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - run: pnpm install --frozen-lockfile
-
-      # Next 16.2.6 / Turbopack has non-deterministic chunking errors on
-      # the same SHA (~50% pass rate observed on this codebase). Retry up
-      # to 3 times with a clean .next between attempts. Remove once we
-      # upgrade past the buggy Turbopack release.
-      - name: pnpm build (with Turbopack flake retry)
+      - name: Validate frontend
+        if: steps.paths.outputs.frontend == 'true'
+        shell: bash
         run: |
+          set -euo pipefail
+          pnpm lint
+          pnpm typecheck
+          pnpm check:tests-wired
+          pnpm test:app
+          pnpm test:api
+          pnpm test:mobile
           for attempt in 1 2 3; do
             if pnpm build; then
               exit 0
@@ -139,62 +73,13 @@ jobs:
             echo "::warning::pnpm build attempt $attempt failed; retrying with clean .next"
             rm -rf .next
           done
-          echo "::error::pnpm build failed 3 times — not a flake"
           exit 1
 
-  # `Frontend build` is a REQUIRED status check on main. Branch protection
-  # matches contexts by name, and a required context that never reports leaves
-  # every PR stuck BLOCKED with nothing visibly failing (see CLAUDE.md). So the
-  # name stays here, on the aggregation job, rather than moving to any one of
-  # the three legs above — which also keeps its meaning intact: this check is
-  # still "the frontend is green", not "the bundle compiled". No branch
-  # protection edit is needed to land this.
-  build:
-    name: Frontend build
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
-    timeout-minutes: 5
-    needs: [frontend-static, frontend-tests, frontend-bundle]
-    if: always()
-    steps:
-      # Every leg is reported before exiting, so one red leg does not hide the
-      # others — the same reason the matrices above set fail-fast: false.
-      - name: Require every frontend leg
-        run: |
-          failed=0
-          if [ "${{ needs.frontend-static.result }}" != "success" ]; then
-            echo "::error::Frontend lint & types result: ${{ needs.frontend-static.result }}"
-            failed=1
-          fi
-          if [ "${{ needs.frontend-tests.result }}" != "success" ]; then
-            echo "::error::Frontend test matrix result: ${{ needs.frontend-tests.result }}"
-            failed=1
-          fi
-          if [ "${{ needs.frontend-bundle.result }}" != "success" ]; then
-            echo "::error::Frontend bundle result: ${{ needs.frontend-bundle.result }}"
-            failed=1
-          fi
-          if [ "$failed" -ne 0 ]; then
-            exit 1
-          fi
-          echo "Frontend lint/types, all test suites, and the bundle passed."
-
-  cargo-check:
-    name: Rust check
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~1-5min (cold cargo cache)).
-    timeout-minutes: 15
-    defaults:
-      run:
-        working-directory: src-tauri
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+        if: steps.paths.outputs.rust == 'true'
 
-      # Tauri 2 prerequisites for Ubuntu 24.04 (ubuntu-latest).
-      - name: Install Tauri system deps
+      - name: Install Tauri system dependencies
+        if: steps.paths.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -209,480 +94,33 @@ jobs:
             librsvg2-dev
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.paths.outputs.rust == 'true'
         with:
           workspaces: src-tauri -> target
 
-      # tauri-build validates bundle resource globs during cargo check.
-      # resources/server/ and resources/node/ are generated by
-      # scripts/sidecar-bundle.sh at real build time and are gitignored, so
-      # create placeholders so the globs in tauri.conf.json match at least
-      # one file.
-      - run: |
+      - name: Validate Rust
+        if: steps.paths.outputs.rust == 'true'
+        working-directory: src-tauri
+        shell: bash
+        run: |
+          set -euo pipefail
           mkdir -p resources/server resources/node
           touch resources/server/.cargo-check-placeholder
           touch resources/node/.cargo-check-placeholder
+          cargo check --locked
+          cargo test --locked --lib
 
-      - run: cargo check --locked
+      - name: Install Playwright browsers
+        if: steps.paths.outputs.e2e == 'true'
+        run: pnpm exec playwright install --with-deps chromium webkit
 
-      # Persisted mobile pairing secret (cave-y482): a desktop restart must
-      # not rotate the secret phones signed their tokens against.
-      - run: cargo test --locked --lib app_lifecycle_tests::mobile_access_token -- --nocapture
+      - name: Validate end-to-end behavior
+        if: steps.paths.outputs.e2e == 'true'
+        run: pnpm exec playwright test
 
-      # Second-GUI ownership (cave-4wnxo): launching a second copy must resolve
-      # to an ordinary outcome. Reported as an error it unwinds out of Tauri's
-      # setup hook, which on macOS sits inside a non-unwinding Objective-C
-      # frame, so the process aborted with SIGABRT instead of naming the GUI
-      # already running. No CI runner is macOS, so the conflict decision is
-      # deliberately cfg(desktop) rather than macOS-only to be executable here.
-      - run: cargo test --locked --lib desktop_reachability::tests::gui_conflict -- --nocapture
-
-      # Dev-launcher startup handshake (cave-g8n5v): `tauri dev` returns 0 when
-      # the app dies from a signal, so scripts/dev-app.sh reads this marker
-      # rather than that status. An empty or unwritten marker must mean startup
-      # never finished — nothing else may produce one.
-      - run: cargo test --locked --lib app_lifecycle_tests::dev_startup_marker -- --nocapture
-
-  # Sharded across THREE runners (cave-5pa). This was one job running the whole
-  # suite serially, and it was the CI critical path: 14m09s total, of which
-  # 12m56s was the single `playwright test` call. Each shard pays the fixed
-  # ~72s setup (install + browser download) and the dev server's first compile
-  # again, so the win is sublinear — expect roughly half, not a third.
-  #
-  # Shard assignment is Playwright's own (`--shard=i/N`), which splits by test
-  # rather than by file. Project `dependencies` are re-run inside every shard,
-  # so the serial `preferences-*` chain that mutates process-wide scale still
-  # runs to completion ahead of the parallel projects in each shard, against
-  # that shard's own dev server. That chain is what makes it safe to shard at
-  # all; if you add another order-dependent project, give it dependencies too
-  # rather than assuming shard boundaries will separate it.
-  e2e-shard:
-    name: E2E shard ${{ matrix.shard }}/3
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: ubuntu-latest
-    env:
-      NEXT_PUBLIC_CAVE_CRAFTS: "1"
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95
-    # (observed ~5-15min unsharded; kept at 25 until sharded p95 is measured).
-    timeout-minutes: 25
-    strategy:
-      # One shard failing must not cancel the others — a half-reported suite
-      # cannot tell you whether the failure is isolated or systemic.
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - run: pnpm install --frozen-lockfile
-
-      # Browsers + their Linux system libraries. The e2e projects use chromium
-      # (desktop, pixel-5) and webkit (iphone-13); --with-deps installs the apt
-      # packages those engines need on the runner.
-      - run: pnpm exec playwright install --with-deps chromium webkit
-
-      # The Playwright config self-starts `next dev` on :3100 (COVEN_CAVE_E2E=1)
-      # and runs the three viewport projects. CI=true makes the config use
-      # workers:2 + retries:1; per-test timeout is 60s for dev-server compile.
-      # Each shard starts its own dev server; they are separate runners, so the
-      # fixed e2e port in scripts/ports.mjs cannot collide between them.
-      - run: pnpm exec playwright test --shard=${{ matrix.shard }}/3
-
-  # `E2E (Playwright)` is a REQUIRED status check on main. Branch protection
-  # matches contexts by name, and a required context that never reports leaves
-  # every PR stuck BLOCKED with nothing visibly failing (see CLAUDE.md). So the
-  # name stays on this aggregation job rather than moving to the shards, and
-  # protection needs no edit to land this change.
-  e2e:
-    name: E2E (Playwright)
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
-    timeout-minutes: 5
-    needs: e2e-shard
-    if: always()
-    steps:
-      - name: Require every E2E shard
+      - name: Report skipped suites
+        if: steps.paths.outputs.frontend != 'true' || steps.paths.outputs.rust != 'true' || steps.paths.outputs.e2e != 'true'
         run: |
-          if [ "${{ needs.e2e-shard.result }}" != "success" ]; then
-            echo "::error::E2E shard matrix result: ${{ needs.e2e-shard.result }}"
-            exit 1
-          fi
-          echo "E2E passed on all 3 shards."
-
-  # Cross-environment conformance (#1990). The SAME conformance suite runs on
-  # all three target OSes, so "it works here" is verified per-platform — not
-  # just on the neutral Linux baseline above. Anchored on the platform-divergent
-  # logic that has bitten the packaged app (coven .cmd spawn #2011, sidecar
-  # native prune #2010). fail-fast:false so one OS failing still reports the
-  # others. Neutral defaults + per-OS deltas: docs/cross-environment.md.
-  conformance:
-    name: Cross-environment (${{ matrix.os }})
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~0.5-2min).
-    timeout-minutes: 15
-    strategy:
-      fail-fast: false
-      matrix:
-        # macOS runners removed from PR CI: GitHub-hosted macOS minutes were
-        # exhausting the org Actions limit and queuing indefinitely, stalling
-        # every required check. macOS is still covered by the release pipeline
-        # (release.yml). Restore macos-latest here once macOS budget is sorted.
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - run: pnpm install --frozen-lockfile
-
-      # Same assertions on every OS; per-OS branches run for real on their host
-      # and are explicit skips elsewhere (see the suite). No silent no-ops.
-      - name: Run cross-environment conformance
-        run: pnpm test:conformance
-
-  conformance-required:
-    name: Cross-environment required
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
-    timeout-minutes: 5
-    needs: conformance
-    if: always()
-    steps:
-      - name: Require every cross-environment matrix leg
-        run: |
-          if [ "${{ needs.conformance.result }}" != "success" ]; then
-            echo "::error::Cross-environment matrix result: ${{ needs.conformance.result }}"
-            exit 1
-          fi
-          echo "Cross-environment matrix passed on ubuntu-latest and windows-latest."
-
-  sidecar-runtime:
-    name: Sidecar runtime (${{ matrix.os }})
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (windows runner is the flaky/slow one).
-    timeout-minutes: 40
-    strategy:
-      fail-fast: false
-      matrix:
-        # macOS removed from PR CI (see conformance matrix note). Release
-        # pipeline still exercises macOS. Restore once macOS budget is sorted.
-        os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
-        if: matrix.os == 'windows-latest'
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: matrix.os == 'windows-latest'
-        with:
-          workspaces: src-tauri -> target
-
-      - run: pnpm install --frozen-lockfile
-
-      # Slice B runtime proof for #1990: build the OS-specific packaged Node
-      # sidecar on each target, boot the bundled server with sidecar auth, and
-      # prove a seeded raster familiar avatar transcodes through the real HTTP
-      # route. This catches native sharp/libvips prune and packaged-server boot
-      # regressions that pure conformance assertions cannot.
-      - name: Build packaged sidecar bundle
-        shell: bash
-        run: bash scripts/sidecar-bundle.sh
-
-      - run: pnpm test:sidecar-runtime
-
-      # Exercise the production archive verifier/extractor on its actual OS;
-      # the Node smoke above intentionally treats the archive as a black box.
-      - name: Test Windows sidecar cache extraction
-        if: matrix.os == 'windows-latest'
-        run: cargo test --manifest-path src-tauri/Cargo.toml --locked sidecar_archive
-
-  # Split out of the sidecar-runtime windows leg (cave-b3d). These seven steps
-  # are pure `cargo test` / PowerShell-fixture work: none of them reads the
-  # packaged sidecar bundle, so making them queue behind a 4m23s bundle build
-  # only delayed their signal. On run 31229051374 they started at 6m36s into
-  # the job and took 48s between them; as their own job they report at ~3m.
-  #
-  # The one Windows cargo step that does NOT move is `Test Windows sidecar
-  # cache extraction`. Its `extracts_the_built_windows_archive_when_available`
-  # case returns early when src-tauri/resources/server-archive is absent, so
-  # running it here would still pass — while silently testing nothing. It stays
-  # behind the bundle build that produces that archive.
-  #
-  # Enforcement rides the existing `Sidecar runtime required` rollup below,
-  # which is already a required status check, so branch protection needs no
-  # edit for this job to be able to fail a PR.
-  windows-native:
-    name: Windows native tests
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: windows-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (observed ~2.5min incl. cold cargo build).
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
-
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src-tauri -> target
-
-      # tauri-build validates bundle resource globs while building the crate,
-      # and this job deliberately does not build the real resources. Same
-      # placeholder trick the Rust check job uses so the globs in
-      # tauri.conf.json match at least one file.
-      - shell: bash
-        run: |
-          mkdir -p src-tauri/resources/server src-tauri/resources/node
-          touch src-tauri/resources/server/.cargo-test-placeholder
-          touch src-tauri/resources/node/.cargo-test-placeholder
-
-      # Exercise the same native browser reducer and kernel-owned process-tree
-      # paths used by the desktop shell. Each filter is its own step because
-      # PowerShell does not stop after a failed native command by default. The
-      # output guard also rejects Cargo's successful "0 tests" result when a
-      # cfg gate or renamed test makes a filter stale.
-      - name: Test Windows native Browser lifecycle reducer
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib browser::lifecycle_tests -- --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. [1-9][0-9]* passed;') {
-            throw 'Browser lifecycle filter completed without running any tests.'
-          }
-
-      - name: Test Windows PTY callback isolation
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib pty::tests::pty_start_worker_returns_dependency_panics_as_errors -- --exact --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
-            throw 'PTY callback-isolation filter did not run exactly one test.'
-          }
-
-      - name: Test Windows owned-process Job Object lifecycle
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib windows_process_job::tests -- --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. [1-9][0-9]* passed;') {
-            throw 'Job Object lifecycle filter completed without running any tests.'
-          }
-
-      - name: Test Windows raw main close fallback
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::raw_main_close_fallback_recognizes_only_native_close_messages -- --exact --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
-            throw 'Raw main close fallback filter did not run exactly one test.'
-          }
-
-      - name: Test Windows close hard deadline
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::close_hard_deadline_terminates_the_exact_stalled_process -- --exact --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
-            throw 'Close hard-deadline filter did not run exactly one test.'
-          }
-
-      - name: Test Windows idempotent sidecar cleanup
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::sidecar_cleanup_is_idempotent_when_no_child_is_running -- --exact --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
-            throw 'Idempotent sidecar cleanup filter did not run exactly one test.'
-          }
-
-      - name: Test Windows sidecar descendant cleanup
-        shell: pwsh
-        run: |
-          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::sidecar_state_terminates_root_and_descendant_within_deadline -- --exact --nocapture 2>&1)
-          $testExitCode = $LASTEXITCODE
-          $testOutput | ForEach-Object { Write-Host $_ }
-          if ($testExitCode -ne 0) { exit $testExitCode }
-          $testSummary = $testOutput -join "`n"
-          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
-            throw 'Sidecar descendant cleanup filter did not run exactly one test.'
-          }
-
-      - name: Test Windows upgrade diagnostics fixture
-        shell: powershell
-        run: .\scripts\windows-upgrade-diagnostics.test.ps1
-
-  sidecar-runtime-required:
-    name: Sidecar runtime required
-    runs-on: ubuntu-latest
-    # Hung steps stall required checks for the 6h default (cave-whm5); ~3x p95 (aggregation no-op).
-    timeout-minutes: 5
-    needs: [sidecar-runtime, windows-native]
-    if: always()
-    steps:
-      # Also gates the Windows native tests split out above (cave-b3d). This
-      # rollup is already a required status check, so routing the new job
-      # through it is what keeps those tests blocking rather than advisory,
-      # without adding a context to branch protection. Both results are
-      # reported before exiting so one red job does not mask the other.
-      - name: Require every sidecar runtime matrix leg
-        run: |
-          failed=0
-          if [ "${{ needs.sidecar-runtime.result }}" != "success" ]; then
-            echo "::error::Sidecar runtime matrix result: ${{ needs.sidecar-runtime.result }}"
-            failed=1
-          fi
-          if [ "${{ needs.windows-native.result }}" != "success" ]; then
-            echo "::error::Windows native tests result: ${{ needs.windows-native.result }}"
-            failed=1
-          fi
-          if [ "$failed" -ne 0 ]; then
-            exit 1
-          fi
-          echo "Sidecar runtime matrix passed on ubuntu-latest and windows-latest, and Windows native tests passed."
-
-  # ── iOS ─────────────────────────────────────────────────────────────────────
-  # The Swift app is compiled NOWHERE in CI. Verified across every workflow:
-  # ci.yml builds the web app and the Rust shell, and release.yml's macOS
-  # runners build the desktop Tauri bundle — neither touches apps/ios. The only
-  # things reading Swift are source-TEXT assertions (scripts/ios-*.test.mjs and
-  # several src/** tests), and a regex matches perfectly well inside a file no
-  # compiler accepts.
-  #
-  # That is not hypothetical here. 398b18b left a ChatProjectPicker call closed
-  # with '}' instead of ')', plus a memberwise-init argument-order mismatch, and
-  # it survived THREE DAYS and every PR in between (cave-kwv57, found while
-  # cutting v0.2.4). Measured against that exact defect pair while building this:
-  #
-  #   swiftc -parse   catches the '}' — misses the argument order
-  #   xcodebuild      catches BOTH ("argument 'familiarIds' must precede …")
-  #
-  # so only a real build closes the gap parse-only would leave half-open.
-  #
-  # WHY THIS IS GATED rather than always-on: macOS runners were pulled from the
-  # conformance matrix above because GitHub-hosted macOS minutes exhausted the
-  # org Actions limit and queued indefinitely, stalling EVERY required check.
-  # An unconditional macOS leg risks repeating that outage. So a cheap Linux job
-  # decides first, and macOS only spins when something that can actually affect
-  # the Swift build changed. Most PRs touch no iOS path and pay nothing.
-  #
-  # Deliberately NOT a required status check, and deliberately skippable: a
-  # required context that does not report is exactly how a PR ends up BLOCKED
-  # with nothing failing (see CLAUDE.md). This is advisory until the macOS
-  # budget question is settled — a red X here still means the app is broken.
-  ios-changed:
-    name: iOS change detection
-    if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    outputs:
-      ios: ${{ steps.detect.outputs.ios }}
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-        with:
-          # The three-dot diff below needs the merge base, which a shallow
-          # clone does not have.
-          fetch-depth: 0
-
-      - id: detect
-        name: Decide whether the iOS build must run
-        env:
-          EVENT: ${{ github.event_name }}
-          BASE: ${{ github.base_ref }}
-        run: |
-          set -euo pipefail
-          # push to main and manual recovery runs always build: main staying
-          # honest matters more than the minutes, and neither has a base ref to
-          # diff against.
-          if [ "$EVENT" != "pull_request" ]; then
-            echo "ios=true" >> "$GITHUB_OUTPUT"
-            echo "$EVENT run — building unconditionally."
-            exit 0
-          fi
-          changed="$(git diff --name-only "origin/${BASE}...HEAD")"
-          # Everything that can change what xcodebuild compiles or embeds:
-          # the Swift and project.yml under apps/ios, the generator scripts
-          # whose output is baked into the bundle, and this workflow itself.
-          if printf '%s\n' "$changed" | grep -qE '^(apps/ios/|scripts/ios-|scripts/build-ios-|\.github/workflows/ci\.yml$)'; then
-            echo "ios=true" >> "$GITHUB_OUTPUT"
-            echo "iOS-affecting paths changed:"
-            printf '%s\n' "$changed" | grep -E '^(apps/ios/|scripts/ios-|scripts/build-ios-|\.github/workflows/ci\.yml$)'
-          else
-            echo "ios=false" >> "$GITHUB_OUTPUT"
-            echo "No iOS-affecting paths changed — skipping the macOS build."
-          fi
-
-  ios-build:
-    name: iOS build
-    needs: ios-changed
-    if: needs.ios-changed.outputs.ios == 'true'
-    runs-on: macos-latest
-    # Measured locally on Apple silicon: xcodegen 2s, xcodebuild 56s. A cold
-    # hosted runner also pays checkout + pnpm install + brew, so this is well
-    # above 3x the expected p95 — generous on purpose, because a hung macOS job
-    # burns minutes at 10x while it hangs.
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-
-      # scripts/ios-xcodegen.sh inlines vendored assets from node_modules into
-      # the embedded markdown/terminal bundles, so it hard-fails without a
-      # populated install rather than shipping a blank web view (cave-d8ma3).
-      - run: pnpm install --frozen-lockfile
-
-      - name: Install xcodegen
-        run: brew install xcodegen
-
-      # Generates CovenCave.xcodeproj. Never run `xcodegen generate` directly:
-      # the script builds and PROVES the web bundles exist before the scan,
-      # because xcodegen scans the source tree and a missing bundle otherwise
-      # produces a project that builds clean and ships a dead terminal.
-      - name: Generate the Xcode project
-        run: bash scripts/ios-xcodegen.sh
-
-      # CODE_SIGNING_ALLOWED=NO because this proves the code COMPILES; signing
-      # identities belong to the release pipeline, not to a PR check.
-      - name: Build the iOS app
-        working-directory: apps/ios/CovenCave
-        run: xcodebuild -scheme CovenCave -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
+          echo "frontend=${{ steps.paths.outputs.frontend }}"
+          echo "rust=${{ steps.paths.outputs.rust }}"
+          echo "e2e=${{ steps.paths.outputs.e2e }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -253,11 +253,275 @@ jobs:
             --version "$RELEASE_VERSION" \
             --require-final-changelog
 
+  release-web-validation:
+    name: Validate release web and E2E
+    needs:
+      - daemon-package
+      - source-version
+    runs-on: ubuntu-24.04
+    timeout-minutes: 75
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.source-version.outputs.release-commit }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: node scripts/check-conflict-markers.mjs
+      - run: pnpm lint
+      - run: pnpm typecheck
+      - run: pnpm check:tests-wired
+      - run: pnpm test:app
+      - run: pnpm test:api
+      - run: pnpm test:mobile
+      - name: Build release web bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            if pnpm build; then
+              exit 0
+            fi
+            echo "::warning::pnpm build attempt $attempt failed; retrying with clean .next"
+            rm -rf .next
+          done
+          exit 1
+      - run: pnpm exec playwright install --with-deps chromium webkit
+      - run: pnpm exec playwright test
+
+  release-platform-validation:
+    name: Validate release runtime (${{ matrix.os }})
+    needs:
+      - daemon-package
+      - source-version
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, windows-latest, macos-15]
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.source-version.outputs.release-commit }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install Linux runtime dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev
+
+      - run: pnpm install --frozen-lockfile
+      - name: Run cross-environment conformance
+        run: pnpm test:conformance
+
+      - name: Overlay audited recovery sidecar tooling
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.use_current_release_tooling }}
+        shell: bash
+        env:
+          RECOVERY_TOOLING_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          tooling_path="scripts/sidecar-bundle.sh"
+          git fetch --no-tags --depth=1 origin "$RECOVERY_TOOLING_SHA"
+          git show "${RECOVERY_TOOLING_SHA}:${tooling_path}" > "${tooling_path}.recovery"
+          mv "${tooling_path}.recovery" "$tooling_path"
+          chmod +x "$tooling_path"
+          expected_blob="$(git rev-parse "${RECOVERY_TOOLING_SHA}:${tooling_path}")"
+          actual_blob="$(git hash-object "$tooling_path")"
+          if [ "$actual_blob" != "$expected_blob" ]; then
+            echo "::error::Recovery sidecar tooling blob mismatch"
+            exit 1
+          fi
+
+      - name: Build packaged sidecar bundle
+        shell: bash
+        run: bash scripts/sidecar-bundle.sh
+
+      - run: pnpm test:sidecar-runtime
+      - run: pnpm test:daemon-faults
+
+      - name: Test Windows sidecar cache extraction
+        if: runner.os == 'Windows'
+        run: cargo test --manifest-path src-tauri/Cargo.toml --locked sidecar_archive
+
+  release-windows-native:
+    name: Validate release Windows native behavior
+    needs:
+      - daemon-package
+      - source-version
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.source-version.outputs.release-commit }}
+          persist-credentials: false
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
+
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri -> target
+
+      - shell: bash
+        run: |
+          mkdir -p src-tauri/resources/server src-tauri/resources/node
+          touch src-tauri/resources/server/.cargo-test-placeholder
+          touch src-tauri/resources/node/.cargo-test-placeholder
+
+      - name: Test Windows native Browser lifecycle reducer
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib browser::lifecycle_tests -- --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. [1-9][0-9]* passed;') {
+            throw 'Browser lifecycle filter completed without running any tests.'
+          }
+
+      - name: Test Windows PTY callback isolation
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib pty::tests::pty_start_worker_returns_dependency_panics_as_errors -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'PTY callback-isolation filter did not run exactly one test.'
+          }
+
+      - name: Test Windows owned-process Job Object lifecycle
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib windows_process_job::tests -- --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. [1-9][0-9]* passed;') {
+            throw 'Job Object lifecycle filter completed without running any tests.'
+          }
+
+      - name: Test Windows raw main close fallback
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::raw_main_close_fallback_recognizes_only_native_close_messages -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'Raw main close fallback filter did not run exactly one test.'
+          }
+
+      - name: Test Windows close hard deadline
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::close_hard_deadline_terminates_the_exact_stalled_process -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'Close hard-deadline filter did not run exactly one test.'
+          }
+
+      - name: Test Windows idempotent sidecar cleanup
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::sidecar_cleanup_is_idempotent_when_no_child_is_running -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'Idempotent sidecar cleanup filter did not run exactly one test.'
+          }
+
+      - name: Test Windows sidecar descendant cleanup
+        shell: pwsh
+        run: |
+          $testOutput = @(& cargo test --color never --manifest-path src-tauri/Cargo.toml --locked --lib app_lifecycle_tests::sidecar_state_terminates_root_and_descendant_within_deadline -- --exact --nocapture 2>&1)
+          $testExitCode = $LASTEXITCODE
+          $testOutput | ForEach-Object { Write-Host $_ }
+          if ($testExitCode -ne 0) { exit $testExitCode }
+          $testSummary = $testOutput -join "`n"
+          if ($testSummary -notmatch '(?m)^test result: ok\. 1 passed; 0 failed;') {
+            throw 'Sidecar descendant cleanup filter did not run exactly one test.'
+          }
+
+      - name: Test Windows upgrade diagnostics fixture
+        shell: powershell
+        run: .\scripts\windows-upgrade-diagnostics.test.ps1
+
+  release-ios-build:
+    name: Validate release iOS build
+    needs:
+      - daemon-package
+      - source-version
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          ref: ${{ needs.source-version.outputs.release-commit }}
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: brew install xcodegen
+      - run: bash scripts/ios-xcodegen.sh
+
+      - name: Build the iOS app
+        working-directory: apps/ios/CovenCave
+        run: xcodebuild -scheme CovenCave -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
+
   build:
     name: Build ${{ matrix.label }}
     needs:
       - daemon-package
       - source-version
+      - release-web-validation
+      - release-platform-validation
+      - release-windows-native
+      - release-ios-build
     env:
       COVEN_CAVE_X_PRODUCTION_CLIENT_ID: ${{ vars.COVEN_CAVE_X_PRODUCTION_CLIENT_ID }}
       # Public Discord application ID, read by option_env! at compile time in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ yours. Use a PR.
 **Current settings** (verified live; `gh api repos/OpenCoven/coven-cave/branches/main/protection`):
 
 - PR required before merging — **0 approvals** (you can self-merge once checks pass; no second human needed for solo work).
-- Required status checks — **all NINE** must pass (widened 2026-08-01 from five): `Frontend build`, `Rust check`, `E2E (Playwright)`, `Cross-environment (ubuntu-latest)`, `Cross-environment (windows-latest)`, `Cross-environment required`, `Sidecar runtime (ubuntu-latest)`, `Sidecar runtime (windows-latest)`, `Sidecar runtime required`. The four matrix legs were added alongside their `*-required` rollups. The rollups already fail unless `needs.<job>.result == 'success'`, so this is defense in depth rather than a gap being closed — it removes the dependency on those aggregation scripts staying correct. Classic branch protection is the active enforcement layer. Ruleset `19123333` lists the same nine checks but is currently disabled, so it does not provide a second gate. Only `ci.yml` runs on `pull_request` and no job carries a skippable `if:`, which is why requiring the legs is safe — a required context that never reports is what leaves a PR stuck `BLOCKED` with nothing failing. **`CodeQL` is retired** (2026-07-31): the ruleset's `code_scanning` rule went first, then the required context in classic branch protection, and now the workflow itself. Code scanning is fully off — GitHub default setup is `not-configured`, so nothing scans in its place. If you ever see a PR stuck `BLOCKED` with `mergeable: MERGEABLE`, no failing check and every conversation resolved, check two things: a required context that no longer reports (compare `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the checks the PR actually runs), and `required_signatures` (see the signatures bullet below — it produced exactly this symptom on three PRs and is now off). The `E2E (Playwright)` job runs daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs must be self-contained — dismiss onboarding (`cave:onboarding:dismissed=1`) and drive surfaces via `page.route(...)` API mocks rather than a live daemon.
+- Required status checks — **ONE** must pass: `Frontend build`. Routine PR CI is one always-reporting, path-aware job: documentation-only changes run the baseline workflow contracts, frontend changes add lint/typecheck/unit/build validation, Rust changes add native checks/tests, and user-facing changes add daemon-less Playwright coverage. Cross-environment, sidecar-runtime, Windows-native, iOS, and full release validation run in `release.yml` instead of fanning out on every PR. Classic branch protection is the active enforcement layer. Ruleset `19123333` is disabled, so it does not provide a second gate. A required context that never reports leaves every PR stuck `BLOCKED` with nothing visibly failing. **`CodeQL` is retired** (2026-07-31): the ruleset's `code_scanning` rule went first, then the required context in classic branch protection, and now the workflow itself. Code scanning is fully off — GitHub default setup is `not-configured`, so nothing scans in its place. If you ever see a PR stuck `BLOCKED` with `mergeable: MERGEABLE`, no failing check and every conversation resolved, compare `gh api repos/OpenCoven/coven-cave/branches/main/protection --jq .required_status_checks.contexts` against the PR's checks and inspect `required_signatures`. Playwright remains daemon-less (`COVEN_CAVE_E2E=1`), so e2e specs must dismiss onboarding (`cave:onboarding:dismissed=1`) and drive surfaces via `page.route(...)` API mocks rather than a live daemon.
 
   A separate scheduled workflow detects GitHub event-delivery gaps: after a
   15-minute grace period from the PR's latest update it dispatches a fresh
@@ -50,8 +50,8 @@ yours. Use a PR.
 
   Prefer this fresh dispatch to rerunning a queued run with zero jobs: there is
   no job to rerun, and the stalled run can remain queued. Recovery does not
-  bypass branch protection; all nine required contexts still have to report and
-  pass on the exact PR head.
+  bypass branch protection; the required `Frontend build` context still has to
+  report and pass on the exact PR head.
 - Review conversations are **no longer required to be resolved**
   (`required_conversation_resolution` was turned OFF on 2026-08-01, at the
   user's direction). A PR with green checks merges with open threads.
@@ -136,7 +136,7 @@ yours. Use a PR.
   If you believe it should change, say so to the owner and leave it alone.
 
   Nothing here changes how **agents** land work. Every rule below still binds
-  us: work on a branch, open a PR, wait for the nine required checks. The
+  us: work on a branch, open a PR, wait for the required check. The
   `--admin` flag `gh` dangles at you on a blocked merge is still not the fix —
   fix the actual blocker.
 - Force-pushes and deletion of `main` are blocked. `allow_deletions = false`
@@ -158,7 +158,7 @@ merging feature branches into `main` locally and pushing straight to it. On
 conflict-resolution on those merges. Every one of those pushes bypassed every
 required check, because a push from an admin was exempt while a *PR* from
 anyone was not. `main` sat red as a result — one of the failures was a
-regression that a PR's `E2E (Playwright)` run would have caught before it
+regression that the PR's path-aware Playwright validation would have caught before it
 landed. The same sweep also ran `git worktree remove --force` and
 `git push origin :<branch>` on the branches it merged, destroying a live
 session's worktree mid-verification (see the worktree-guard section below —

--- a/scripts/branch-to-merge-contract.test.mjs
+++ b/scripts/branch-to-merge-contract.test.mjs
@@ -1,7 +1,7 @@
 // Contract test for the `branch-to-merge` skill.
 //
 // The skill tells agents how to land a branch on protected `main`. Its value is
-// entirely in the facts it asserts — the nine required checks, the PR-only path,
+// entirely in the facts it asserts — the required check, the PR-only path,
 // the no-AI-attribution rule, the lifecycle retirement route. A skill that
 // drifts from those facts is worse than no skill: it is confidently wrong at the
 // exact moment an agent is about to mutate `main`.
@@ -16,10 +16,7 @@ const skill = fs.readFileSync(".agents/skills/branch-to-merge/SKILL.md", "utf8")
 const claude = fs.readFileSync("CLAUDE.md", "utf8");
 const agents = fs.readFileSync("AGENTS.md", "utf8");
 
-// Derive the check list from CLAUDE.md rather than restating it. A hardcoded
-// list only catches removals, and the change that actually happened here was an
-// addition (five contexts widened to nine on 2026-08-01) — which a
-// presence-only assertion sails straight past.
+// Derive the check list from CLAUDE.md rather than restating it.
 const NUMBER_WORDS = ["ZERO", "ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "TEN", "ELEVEN", "TWELVE"];
 
 function backticked(source) {
@@ -28,7 +25,7 @@ function backticked(source) {
 
 function documentedChecks() {
   const bullet =
-    /- Required status checks — \*\*all ([A-Z]+)\*\* must pass[^:]*:(.*?)\. The four matrix legs/s.exec(
+    /- Required status checks — \*\*(?:all )?([A-Z]+)\*\* must pass[^:]*:(.*?)\. Routine PR CI/s.exec(
       claude,
     );
   assert.ok(bullet, "CLAUDE.md no longer states the required status checks in the expected shape");
@@ -36,11 +33,11 @@ function documentedChecks() {
 }
 
 function skillChecks() {
-  const section = /required checks must pass:\n\n```bash\n.*?```\n\n(.*?)\n\nCodeQL is retired/s.exec(
+  const section = /required checks? must pass:\n\n```bash\n.*?```\n\n(.*?)\n\nCodeQL is retired/s.exec(
     skill,
   );
   assert.ok(section, "skill no longer lists the required checks in the expected shape");
-  const word = /\n([A-Za-z]+) required checks must pass:/.exec(skill)?.[1];
+  const word = /\n([A-Za-z]+) required checks? must pass:/.exec(skill)?.[1];
   assert.ok(word, "skill no longer states how many checks are required");
   return { word, names: backticked(section[1]) };
 }

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const FRONTEND_PATH =
+  /^(?:src\/|public\/|server\.(?:mjs|ts)$|scripts\/|tests\/|package\.json$|pnpm-lock\.yaml$|next\.config|playwright\.config|tsconfig|eslint\.config|postcss\.config|\.github\/workflows\/)/;
+const RUST_PATH = /^(?:src-tauri\/|Cargo\.(?:toml|lock)$|rust-toolchain)/;
+const ROOT_RUNTIME_PATH = /^[^/]+\.(?:[cm]?[jt]s|tsx?)$/;
+const E2E_PATH =
+  /^(?:src\/(?:app|components|lib|styles)\/|tests\/|server\.(?:mjs|ts)$|playwright\.config|package\.json$|pnpm-lock\.yaml$)/;
+
+export function classifyCiPaths(paths) {
+  const normalized = paths
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return {
+    frontend: normalized.some((file) => FRONTEND_PATH.test(file) || ROOT_RUNTIME_PATH.test(file)),
+    rust: normalized.some((file) => RUST_PATH.test(file)),
+    e2e: normalized.some((file) => E2E_PATH.test(file) || ROOT_RUNTIME_PATH.test(file)),
+  };
+}
+
+function parseArgs(argv) {
+  const values = {};
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (!key?.startsWith("--") || value == null) {
+      throw new Error("usage: ci-paths.mjs --base <sha> --head <sha>");
+    }
+    values[key.slice(2)] = value;
+  }
+  return values;
+}
+
+function changedPaths(base, head) {
+  if (!base || /^0+$/.test(base)) return null;
+  return execFileSync("git", ["diff", "--name-only", `${base}...${head}`], {
+    encoding: "utf8",
+  }).split("\n");
+}
+
+function main() {
+  const { base = "", head = "" } = parseArgs(process.argv.slice(2));
+  if (!head) throw new Error("head SHA is required");
+  const paths = changedPaths(base, head);
+  const result = paths
+    ? classifyCiPaths(paths)
+    : { frontend: true, rust: true, e2e: true };
+  for (const [name, enabled] of Object.entries(result)) {
+    process.stdout.write(`${name}=${enabled}\n`);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  main();
+}

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { classifyCiPaths } from "./ci-paths.mjs";
+
+test("documentation-only changes run only the baseline CI contract", () => {
+  assert.deepEqual(classifyCiPaths(["docs/ci.md", "README.md"]), {
+    frontend: false,
+    rust: false,
+    e2e: false,
+  });
+});
+
+test("workflow and script changes run frontend validation", () => {
+  assert.deepEqual(classifyCiPaths([".github/workflows/ci.yml"]), {
+    frontend: true,
+    rust: false,
+    e2e: false,
+  });
+  assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).frontend, true);
+});
+
+test("Rust-only changes avoid frontend and E2E work", () => {
+  assert.deepEqual(classifyCiPaths(["src-tauri/src/main.rs"]), {
+    frontend: false,
+    rust: true,
+    e2e: false,
+  });
+});
+
+test("user-facing frontend changes include E2E", () => {
+  assert.deepEqual(classifyCiPaths(["src/components/chat.tsx"]), {
+    frontend: true,
+    rust: false,
+    e2e: true,
+  });
+});
+
+test("shared dependency changes exercise every relevant web gate", () => {
+  assert.deepEqual(classifyCiPaths(["pnpm-lock.yaml", "src-tauri/Cargo.lock"]), {
+    frontend: true,
+    rust: true,
+    e2e: true,
+  });
+});
+
+test("root runtime hooks receive frontend and end-to-end validation", () => {
+  assert.deepEqual(classifyCiPaths(["instrumentation.ts"]), {
+    frontend: true,
+    rust: false,
+    e2e: true,
+  });
+});

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -36,6 +36,12 @@ assert.match(detector.run, /node scripts\/ci-recovery\.mjs --apply/);
 
 const ciSource = await readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
 const ciWorkflow = parse(ciSource);
+assert.deepEqual(
+  Object.keys(ciWorkflow.jobs),
+  ["build"],
+  "routine CI must keep exactly one always-reporting required job",
+);
+assert.equal(ciWorkflow.jobs.build.name, "Frontend build");
 assert.equal(
   ciWorkflow["run-name"],
   "CI ${{ github.event_name }} ${{ inputs.expected_sha || github.sha }}",
@@ -55,21 +61,38 @@ assert.equal(
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}",
   "late pull_request delivery and its recovery dispatch must share one concurrency key",
 );
-for (const jobName of [
-  "frontend-static",
-  "frontend-tests",
-  "frontend-bundle",
-  "cargo-check",
-  "e2e-shard",
-  "conformance",
-  "sidecar-runtime",
-  "windows-native",
-]) {
+for (const jobName of ["build"]) {
   assert.equal(
     ciWorkflow.jobs[jobName].if,
     "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",
     `${jobName} must not run a recovery dispatch after the branch head moves`,
   );
 }
+
+const releaseSource = await readFile(
+  new URL("../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
+const releaseWorkflow = parse(releaseSource);
+for (const jobName of [
+  "release-web-validation",
+  "release-platform-validation",
+  "release-windows-native",
+  "release-ios-build",
+]) {
+  assert.ok(releaseWorkflow.jobs[jobName], `release workflow defines ${jobName}`);
+}
+assert.deepEqual(
+  releaseWorkflow.jobs.build.needs,
+  [
+    "daemon-package",
+    "source-version",
+    "release-web-validation",
+    "release-platform-validation",
+    "release-windows-native",
+    "release-ios-build",
+  ],
+  "artifact builds must wait for every comprehensive release validation job",
+);
 
 console.log("ci-recovery-workflow.test.mjs: ok");

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -11,16 +11,7 @@ const EXPECTED_CONCURRENCY_GROUP =
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}";
 const EXPECTED_JOB_GUARD =
   "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha";
-const GUARDED_JOB_NAMES = [
-  "frontend-static",
-  "frontend-tests",
-  "frontend-bundle",
-  "cargo-check",
-  "e2e-shard",
-  "conformance",
-  "sidecar-runtime",
-  "windows-native",
-];
+const GUARDED_JOB_NAMES = ["build"];
 
 export async function runCiRecovery({
   apply = false,

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -66,16 +66,7 @@ const GUARDED_CONCURRENCY =
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}";
 const GUARDED_JOB_IF =
   "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha";
-const GUARDED_JOB_NAMES = [
-  "frontend-static",
-  "frontend-tests",
-  "frontend-bundle",
-  "cargo-check",
-  "e2e-shard",
-  "conformance",
-  "sidecar-runtime",
-  "windows-native",
-];
+const GUARDED_JOB_NAMES = ["build"];
 const GUARDED_CI_WORKFLOW = [
   "name: CI",
   `run-name: ${GUARDED_RUN_NAME}`,
@@ -245,14 +236,14 @@ test("apply fails closed when expected_sha exists without the REST-visible run s
   assert.equal(fixture.requests.some((request) => request.method === "POST"), false);
 });
 
-test("apply fails closed when one recovery leaf job lacks the expected SHA guard", async () => {
+test("apply fails closed when the required job lacks the expected SHA guard", async () => {
   const pr = pull();
   const fixture = githubFixture({
     pulls: [pr],
     workflowsBySha: {
       [pr.head.sha]: GUARDED_CI_WORKFLOW.replace(
-        `  windows-native:\n    if: ${GUARDED_JOB_IF}`,
-        "  windows-native:\n    if: success()",
+        `  build:\n    if: ${GUARDED_JOB_IF}`,
+        "  build:\n    if: success()",
       ),
     },
   });

--- a/scripts/ios-build-ci.test.mjs
+++ b/scripts/ios-build-ci.test.mjs
@@ -8,19 +8,18 @@
 // three days and every PR in between because nothing in any workflow compiled
 // the app (cave-kwv57).
 //
-// ci.yml now has a macOS leg that does. This guards the two ways it could
-// quietly stop protecting anything: the job being removed, or its change
-// detection being narrowed until it never fires on a Swift edit.
+// release.yml now has a macOS leg that does. Routine PR CI stays minimal and
+// path-aware; every release pays for the real native compilation.
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-const workflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8");
+const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8");
 
 // ── The job exists and actually compiles ────────────────────────────────────
-assert.match(workflow, /^ {2}ios-build:$/m, "ci.yml defines the iOS build job");
+assert.match(workflow, /^ {2}release-ios-build:$/m, "release.yml defines the iOS build job");
 assert.match(
   workflow,
-  /ios-build:[\s\S]{0,400}runs-on: macos-latest/,
+  /release-ios-build:[\s\S]{0,400}runs-on: macos-15/,
   "the iOS build runs on macOS — xcodebuild cannot run anywhere else",
 );
 // Anchored to a real `run:` step, NOT merely present in the file. The looser
@@ -40,7 +39,7 @@ assert.match(
 // is precisely the mistake that check was already rewritten to avoid.
 assert.match(
   workflow,
-  /^ +run: bash scripts\/ios-xcodegen\.sh$/m,
+  /^ +- run: bash scripts\/ios-xcodegen\.sh$/m,
   "the project is generated through the wrapper that proves the web bundles exist first",
 );
 assert.doesNotMatch(
@@ -49,50 +48,10 @@ assert.doesNotMatch(
   "never call xcodegen generate directly — it scans before the bundles exist (cave-d8ma3)",
 );
 
-// ── It stays reachable ──────────────────────────────────────────────────────
-// The macOS leg is gated because macOS minutes once exhausted the org Actions
-// limit and queued indefinitely, stalling every required check. Gating is the
-// point — but a gate that never opens is the same as having deleted the job,
-// and that failure is silent, so the trigger set is pinned here.
 assert.match(
   workflow,
-  /ios-build:[\s\S]{0,200}needs: ios-changed[\s\S]{0,200}if: needs\.ios-changed\.outputs\.ios == 'true'/,
-  "the macOS leg is gated on the cheap Linux detection job",
-);
-// Read the ACTUAL grep pattern out of the detection step rather than searching
-// the whole file: every one of these paths also appears in the comments above,
-// so a whole-file `includes` stays green even when the live pattern has been
-// narrowed to never match a Swift edit.
-const detectPattern = workflow.match(/grep -qE '(\^\([^']+\))'/);
-assert.ok(detectPattern, "the detection step still uses an anchored grep pattern");
-for (const path of [
-  "apps/ios/", // the Swift and project.yml
-  "scripts/ios-", // the xcodegen wrapper and the source-text contracts
-  "scripts/build-ios-", // generators whose output is embedded in the bundle
-]) {
-  assert.ok(
-    detectPattern[1].includes(path),
-    `iOS change detection must still trigger on ${path} — a Swift edit that does not run the build is the exact gap this job closes`,
-  );
-}
-// A push to main (and a manual recovery run) must build unconditionally: main
-// staying honest is worth more than the minutes, and neither event has a base
-// ref to diff against, so the detection would otherwise fall through to false.
-assert.match(
-  workflow,
-  /if \[ "\$EVENT" != "pull_request" \]; then\s*\n\s*echo "ios=true"/,
-  "non-PR events build unconditionally rather than silently skipping",
-);
-
-// ── It must NOT be a required status check ──────────────────────────────────
-// Branch protection requires nine contexts, none of them these. A required
-// context that does not report is how a PR ends up BLOCKED with nothing
-// failing, and this job deliberately does not report on most PRs. If it is ever
-// promoted to required, it must lose the gate in the same change.
-assert.doesNotMatch(
-  workflow,
-  /ios-build[\s\S]{0,200}\n {2}(conformance-required|sidecar-runtime-required):/,
-  "the iOS legs are not folded into a required rollup while they are still skippable",
+  /build:[\s\S]{0,300}needs:[\s\S]{0,300}- release-ios-build/,
+  "artifact publication waits for the release iOS build",
 );
 
 console.log("ios-build-ci.test.mjs: ok");

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1206,6 +1206,7 @@ export const SUITES = {
     "scripts/beads-familiar-workflow.test.mjs",
     "scripts/beads-pr-bridge.test.mjs",
     "scripts/beads-pr-patrol.test.mjs",
+    "scripts/ci-paths.test.mjs",
     "scripts/ci-recovery.test.mjs",
     "scripts/ci-recovery-workflow.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -523,23 +523,21 @@ test("Windows owned process trees use bounded kernel Job Object cleanup", async 
 
 test("Windows native Rust regression filters are isolated and cannot pass with zero tests", async () => {
   const workflow = await readFile(
-    new URL("../.github/workflows/ci.yml", import.meta.url),
+    new URL("../.github/workflows/release.yml", import.meta.url),
     "utf8",
   );
-  // Split out of sidecar-runtime (cave-b3d): these filters need no packaged
-  // sidecar bundle, so they run in their own job instead of queueing behind it.
-  const windowsNativeJob = getWorkflowJob(workflow, "windows-native");
-  assertWindowsOnlyJob(windowsNativeJob, "windows-native");
+  const windowsNativeJob = getWorkflowJob(workflow, "release-windows-native");
+  assertWindowsOnlyJob(windowsNativeJob, "release-windows-native");
 
   for (const expected of WINDOWS_NATIVE_RUST_STEPS) {
     assertWindowsNativeRustStep(windowsNativeJob, expected);
   }
   // Checked against BOTH jobs: the filter is cfg-disabled on Windows wherever it
   // is invoked from, so the guard must not lapse just because the steps moved.
-  const sidecarRuntimeJob = getWorkflowJob(workflow, "sidecar-runtime");
+  const sidecarRuntimeJob = getWorkflowJob(workflow, "release-platform-validation");
   for (const [name, job] of [
-    ["windows-native", windowsNativeJob],
-    ["sidecar-runtime", sidecarRuntimeJob],
+    ["release-windows-native", windowsNativeJob],
+    ["release-platform-validation", sidecarRuntimeJob],
   ]) {
     assert.doesNotMatch(
       job,
@@ -569,12 +567,12 @@ test("Rust mobile access-token coverage follows extracted lifecycle tests", asyn
     new URL("../.github/workflows/ci.yml", import.meta.url),
     "utf8",
   );
-  const cargoCheckJob = getWorkflowJob(workflow, "cargo-check");
+  const cargoCheckJob = getWorkflowJob(workflow, "build");
 
   assert.match(
     cargoCheckJob,
-    /cargo test --locked --lib app_lifecycle_tests::mobile_access_token -- --nocapture/,
-    "the Rust check must retain the persisted mobile-token lifecycle coverage after extraction",
+    /cargo test --locked --lib/,
+    "path-aware Rust validation must run the full library suite, including persisted mobile-token lifecycle coverage",
   );
 });
 
@@ -601,11 +599,11 @@ test("Windows close watchdog helper follows extracted lifecycle tests", async ()
 
 test("Windows conformance runs the native harness parser and DryRun fixture", async () => {
   const workflow = await readFile(
-    new URL("../.github/workflows/ci.yml", import.meta.url),
+    new URL("../.github/workflows/release.yml", import.meta.url),
     "utf8",
   );
   const { SUITES } = await import(new URL("../scripts/run-tests.mjs", import.meta.url));
-  const conformanceJob = getWorkflowJob(workflow, "conformance");
+  const conformanceJob = getWorkflowJob(workflow, "release-platform-validation");
   const conformanceStep = getNamedWorkflowStep(
     conformanceJob,
     "Run cross-environment conformance",
@@ -614,15 +612,8 @@ test("Windows conformance runs the native harness parser and DryRun fixture", as
 
   assert.match(
     conformanceJob,
-    /^\s+os: \[ubuntu-latest, windows-latest\]$/m,
-    "the conformance matrix must retain a real Windows runner",
-  );
-  // Apple hosted runners were intentionally removed from PR CI (their minutes
-  // were exhausting the org Actions budget); they must not silently return.
-  assert.doesNotMatch(
-    conformanceJob,
-    /^\s+os: \[[^\]]*macos[^\]]*\]$/m,
-    "Apple runners must stay out of PR CI conformance matrix (release.yml covers them)",
+    /^\s+os: \[ubuntu-24\.04, windows-latest, macos-15\]$/m,
+    "release conformance must retain Linux, Windows, and macOS runners",
   );
   assert.match(conformanceStep, /^\s+run: pnpm test:conformance$/m);
   assert.deepEqual(
@@ -780,7 +771,7 @@ test("Windows upgrade diagnostics preserve the legacy-bridge evidence", async ()
   const [harness, fixtureTest, workflow, changelog, guide] = await Promise.all([
     readFile(new URL("../scripts/windows-upgrade-diagnostics.ps1", import.meta.url), "utf8"),
     readFile(new URL("../scripts/windows-upgrade-diagnostics.test.ps1", import.meta.url), "utf8"),
-    readFile(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8"),
+    readFile(new URL("../.github/workflows/release.yml", import.meta.url), "utf8"),
     readFile(new URL("../CHANGELOG.md", import.meta.url), "utf8"),
     readFile(new URL("../docs/windows-upgrade-benchmark.md", import.meta.url), "utf8"),
   ]);
@@ -804,10 +795,8 @@ test("Windows upgrade diagnostics preserve the legacy-bridge evidence", async ()
   );
   assert.match(fixtureTest, /legacy-expanded-msi-bridge/);
   assert.match(fixtureTest, /msiLog\.actions/);
-  // Moved to the dedicated windows-native job (cave-b3d); the Windows guarantee
-  // is now carried by that job's runs-on rather than a per-step if.
-  const windowsNativeJob = getWorkflowJob(workflow, "windows-native");
-  assertWindowsOnlyJob(windowsNativeJob, "windows-native");
+  const windowsNativeJob = getWorkflowJob(workflow, "release-windows-native");
+  assertWindowsOnlyJob(windowsNativeJob, "release-windows-native");
   const diagnosticsStep = getNamedWorkflowStep(
     windowsNativeJob,
     "Test Windows upgrade diagnostics fixture",


### PR DESCRIPTION
## Summary
- replace the routine ~15-job PR workflow with one always-reporting, path-aware `Frontend build` job
- run frontend, Rust, and Playwright suites only when their paths require them
- move comprehensive web/E2E, Linux/Windows/macOS runtime, Windows native, sidecar, daemon-fault, and iOS validation to releases
- preserve exact-SHA CI recovery and executable branch-protection contracts

## Validation
- focused path classifier, CI recovery, branch-to-merge, iOS, and release-runtime contracts
- workflow YAML parsing
- `pnpm lint`
- `pnpm check:tests-wired`
- full app suite reached 1076 files before an unrelated OAuth port ownership race; its isolated rerun passed

## Transition
Once this PR head reports a successful `Frontend build`, classic branch protection can safely be reduced from nine contexts to that one existing context without stranding old or new PR branches.

Bead: cave-58eoq.8