### PR TITLE
fix(ci): stop reading an approval-gated run as CI coverage

### DIFF
--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -169,6 +169,34 @@ async function getPull(context, number) {
   return parsePull(await response.json());
 }
 
+/**
+ * GitHub's manual-approval gate. A run parked behind it reports
+ * `status: "completed"` with `conclusion: "action_required"` and ZERO jobs, so
+ * the pull request shows no checks whatsoever.
+ *
+ * Reading only `status` therefore mistook it for finished CI and refused to
+ * recover, leaving Copilot-authored PRs wedged with an empty check rollup
+ * (cave-qshvl). `conclusion` was not merely unused — parseRun dropped it, so
+ * this decision could not have consulted it.
+ */
+const APPROVAL_GATED = "action_required";
+
+/**
+ * Whether a run counts as CI having actually covered this head.
+ *
+ * Deliberately narrow. A FAILED run is coverage — it reported a verdict. A
+ * `cancelled` run is normally superseded by a newer push that has its own run,
+ * and recovering it would fight that. `startup_failure` genuinely produced no
+ * coverage, but re-dispatching a workflow that cannot start would just loop, so
+ * it is left to a human. Only the approval gate is both no-coverage AND fixed
+ * by a fresh dispatch.
+ */
+function isCoverage(run) {
+  if (run.status === "in_progress") return true;
+  if (run.status !== "completed") return false;
+  return run.conclusion !== APPROVAL_GATED;
+}
+
 async function decideRecovery(context, runs, now) {
   if (runs.length === 0) return { recover: true, reason: "missing_ci_run" };
 
@@ -179,8 +207,15 @@ async function decideRecovery(context, runs, now) {
   );
   if (recentRecovery) return { recover: false, reason: "recovery_cooldown" };
 
-  if (runs.some((run) => run.status === "completed" || run.status === "in_progress")) {
+  if (runs.some(isCoverage)) {
     return { recover: false, reason: "ci_present" };
+  }
+
+  // Every run is parked behind the manual-approval gate, so the PR has no
+  // checks at all and never will until someone approves or a fresh run is
+  // dispatched. Recovering is exactly right here.
+  if (runs.length > 0 && runs.every((run) => run.conclusion === APPROVAL_GATED)) {
+    return { recover: true, reason: "approval_gated_run" };
   }
 
   const latest = runs[0];
@@ -313,6 +348,8 @@ function parsePull(value) {
 function parseRun(value) {
   const id = value?.id;
   const status = value?.status;
+  // Null while a run is queued or in progress; a string once it completes.
+  const conclusion = value?.conclusion ?? null;
   const event = value?.event;
   const createdAt = Date.parse(value?.created_at);
   const headSha = value?.head_sha;
@@ -328,7 +365,8 @@ function parseRun(value) {
     typeof headSha !== "string" ||
     !/^[0-9a-f]{40}$/i.test(headSha) ||
     typeof displayTitle !== "string" ||
-    displayTitle.length === 0
+    displayTitle.length === 0 ||
+    (conclusion !== null && typeof conclusion !== "string")
   ) {
     throw new Error("CI workflow run response contained a malformed entry");
   }
@@ -343,6 +381,7 @@ function parseRun(value) {
   return {
     id,
     status,
+    conclusion,
     event,
     createdAt,
     headSha,

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -348,7 +348,14 @@ function parsePull(value) {
 function parseRun(value) {
   const id = value?.id;
   const status = value?.status;
-  // Null while a run is queued or in progress; a string once it completes.
+  // Normally null while a run is queued or in progress and a string once it
+  // completes, but validated as string-or-null against ANY status rather than
+  // keyed to `status === "completed"`. A completed run that reports no
+  // conclusion is odd, not malformed, and the only consumer below asks whether
+  // the conclusion IS the approval gate — a null answers "no" and the run is
+  // treated as coverage. Throwing there would turn a harmless API quirk into a
+  // dead recovery tool, which is a worse failure than reading one odd run
+  // conservatively.
   const conclusion = value?.conclusion ?? null;
   const event = value?.event;
   const createdAt = Date.parse(value?.created_at);

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -45,6 +45,7 @@ function pull({
 function workflowRun({
   id = 9001,
   status = "completed",
+  conclusion = status === "completed" ? "success" : null,
   event = "pull_request",
   createdAt = new Date(NOW - RECOVERY_GRACE_MS - 1).toISOString(),
   headSha = "a".repeat(40),
@@ -53,6 +54,7 @@ function workflowRun({
   return {
     id,
     status,
+    conclusion,
     event,
     created_at: createdAt,
     head_sha: headSha,
@@ -540,4 +542,56 @@ test("pull pagination never forwards the token to a cross-origin Link URL", asyn
   assert.deepEqual(requests, [
     `https://api.github.test/repos/${REPOSITORY}/pulls?state=open&per_page=100`,
   ]);
+});
+
+test("an approval-gated run is not CI coverage and is recovered", async () => {
+  // GitHub parks a first-time-contributor run behind manual approval: the run
+  // reports status=completed with conclusion=action_required and ZERO jobs, so
+  // the PR shows no checks at all. Reading only `status` mistook that for
+  // finished CI and wedged Copilot-authored PRs indefinitely (cave-qshvl).
+  const pr = pull();
+  const gated = workflowRun({
+    id: 9100,
+    status: "completed",
+    conclusion: "action_required",
+    headSha: pr.head.sha,
+  });
+  const fixture = githubFixture({ pulls: [pr], runsBySha: { [pr.head.sha]: [gated] } });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+  assert.equal(result.recoveries.length, 1, "an approval-gated head must be recoverable");
+  assert.equal(result.recoveries[0].reason, "approval_gated_run");
+});
+
+test("a completed run that actually ran is still coverage, including a failure", async () => {
+  // The fix must not turn every completed run into a recovery candidate. A
+  // FAILED run reported a verdict, so CI covered this head and re-dispatching
+  // would just re-run a known failure.
+  for (const conclusion of ["success", "failure", "cancelled", "timed_out"]) {
+    const pr = pull();
+    const ran = workflowRun({ id: 9200, status: "completed", conclusion, headSha: pr.head.sha });
+    const fixture = githubFixture({ pulls: [pr], runsBySha: { [pr.head.sha]: [ran] } });
+
+    const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+    assert.deepEqual(
+      result.recoveries,
+      [],
+      `conclusion=${conclusion} is coverage and must not be recovered`,
+    );
+  }
+});
+
+test("one real run alongside an approval-gated one still counts as coverage", async () => {
+  // Only when EVERY run is gated is the head genuinely uncovered. A gated run
+  // sitting beside a real one must not trigger a redundant dispatch.
+  const pr = pull();
+  const gated = workflowRun({ id: 9300, status: "completed", conclusion: "action_required", headSha: pr.head.sha });
+  const real = workflowRun({ id: 9301, status: "completed", conclusion: "success", headSha: pr.head.sha });
+  const fixture = githubFixture({ pulls: [pr], runsBySha: { [pr.head.sha]: [gated, real] } });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+  assert.deepEqual(result.recoveries, []);
 });


### PR DESCRIPTION
Closes cave-qshvl.

## The bug

GitHub parks a first-time-contributor run behind its manual-approval gate. That run reports `status: "completed"` with `conclusion: "action_required"` and **zero jobs** — so the PR shows no checks at all, and never will until someone approves it.

`decideRecovery` classified purely on `status`:

```js
if (runs.some((run) => run.status === "completed" || run.status === "in_progress")) {
  return { recover: false, reason: "ci_present" };
}
```

`completed` read as finished CI, so recovery never fired and Copilot-authored PRs sat `BLOCKED` with an empty check rollup. The empty-run detection below that branch was unreachable for this case, since it only applies when `status === "queued"`.

## The root cause was one layer deeper

Not merely "the check ignores `conclusion`" — **`parseRun` never captured `conclusion` at all**, so the decision could not have consulted it even in principle. It is now parsed, validated as string-or-null (null while a run is queued or in progress), and returned.

## Scoped narrowly, on purpose

Only the approval gate recovers, under a new reason `approval_gated_run`. The other non-success conclusions are deliberately left as coverage, and the reasoning is in the code so nobody assumes they were overlooked:

- **`failure`** — reported a verdict. That *is* coverage; re-dispatching just re-runs a known failure.
- **`cancelled`** — normally superseded by a newer push that carries its own run; recovering it would fight that.
- **`startup_failure`** — genuinely no coverage, but re-dispatching a workflow that cannot start would loop, so it is left to a human.

Recovery also requires **every** run on the head to be gated. One real run beside a gated one still counts as coverage, so a stray gated run cannot trigger a redundant dispatch.

## Tests

- an approval-gated head recovers, with reason `approval_gated_run`
- four real conclusions — `success`, `failure`, `cancelled`, `timed_out` — all remain coverage and do not recover
- a mixed head (gated + real) does not recover

The `workflowRun` fixture gained a `conclusion` field defaulting to `success` for completed runs, so existing tests keep asserting the same behavior.

## Verification

| Gate | Result |
| --- | --- |
| `scripts/ci-recovery.test.mjs` | 20 pass, 0 fail |
| `scripts/ci-recovery-workflow.test.mjs` | passes |
| `pnpm check:tests-wired` | all 1605 wired |
| `git diff --check` | clean |

## Note for the next editor

`decideRecovery` is `async`, and the string `"function decideRecovery("` matches the **tail** of that declaration. Splicing text at that anchor orphans the `async` and breaks the `await` inside — which is exactly what happened once while writing this, and `node --check` on the test file passes while the *module* is the broken one.

## Scope note

The bead cites PR #4487 as the live example. That PR has since resolved — it now has 20 check-runs and a successful run — so the symptom is no longer observable there. The defect in the code is unchanged and was verified directly: `ci-recovery.mjs` had zero references to `.conclusion` before this change.
