### PR TITLE
fix(chat): drop the streaming cursor that detached onto its own line

### DIFF
--- a/src/components/message-bubble-markdown.test.ts
+++ b/src/components/message-bubble-markdown.test.ts
@@ -231,18 +231,22 @@ assert.doesNotMatch(
   "a delayed render must not issue a fresh post-settlement stamp when its timer fires",
 );
 
-// Streaming cursor: with rendered HTML during pending, the ▌ affordance must
-// render as a SIBLING after the markdown container — never injected into the
-// sanitized HTML string.
-assert.match(
+// Streaming cursor: removed (cave-1yslk). The only placement that kept it out
+// of the sanitized HTML string was as a sibling of the markdown container, and
+// that container is a block-level <div> — so the cursor could never trail the
+// last rendered line and wrapped onto a row of its own, reading as a detached
+// grey bar after every streaming message. Restoring it means injecting into
+// the sanitized HTML, which is the thing the sibling placement existed to
+// avoid, so these assert its ABSENCE at both sites rather than its position.
+assert.doesNotMatch(
   markdownContent,
-  /dangerouslySetInnerHTML=\{\{ __html: html \}\}\s*\/>\s*\{\/\*[\s\S]*?\*\/\}\s*\{pending \? \(\s*<span[^>]*>▌<\/span>/,
-  "While pending, the streaming cursor renders as a sibling element after the markdown container",
+  /▌/u,
+  "no streaming cursor glyph is rendered — it detached onto its own line (cave-1yslk)",
 );
-assert.match(
+assert.doesNotMatch(
   markdownContent,
-  /\{pending && text \? \(\s*<span[^>]*>▌<\/span>/,
-  "The plain-text fallback keeps its cursor for the window before the first render lands",
+  /dangerouslySetInnerHTML=\{\{ __html: html \}\}\s*\/>[\s\S]{0,400}?\{pending \? \(\s*<span/,
+  "nothing pending-gated renders as a bare sibling span after the markdown container",
 );
 
 // ── CHAT-D3-03: renderCache must not grow unboundedly ─────────────────────

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -872,9 +872,6 @@ function MarkdownContent({ text, pending, onOpenUrl, citations = [], className }
     return (
       <span className={`whitespace-pre-wrap break-words text-[length:var(--text-md)] leading-relaxed${className ? ` ${className}` : ""}`}>
         {text}
-        {pending && text ? (
-          <span aria-hidden className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
-        ) : null}
       </span>
     );
   }
@@ -888,11 +885,20 @@ function MarkdownContent({ text, pending, onOpenUrl, citations = [], className }
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      {/* Streaming cursor as a SIBLING of the markdown container — never
-          injected into the sanitized HTML string. */}
-      {pending ? (
-        <span aria-hidden="true" className="ml-1 inline-block animate-pulse text-[var(--text-secondary)]">▌</span>
-      ) : null}
+      {/* No streaming cursor here. It used to render as a sibling of the
+          container above — the one placement that keeps it out of the
+          sanitized HTML string — but that container is a block-level <div>,
+          so the span could never trail the last rendered line and instead
+          wrapped onto a row of its own. What the reader saw was a detached
+          grey bar sitting between the message and whatever followed it,
+          after EVERY streaming message that had rendered markdown, which
+          reads as a rendering artifact rather than as a caret (cave-1yslk).
+
+          Putting it back requires appending it INSIDE the last inline
+          descendant of the sanitized HTML, which is exactly the injection
+          this placement was chosen to avoid. Progress is already legible
+          from the text growing, so the affordance is gone rather than
+          wrong. `pending` still drives progressive rendering below. */}
       <InlineCitationPreviews
         citations={citations}
         containerRef={containerRef}

--- a/src/components/message-bubble.tsx
+++ b/src/components/message-bubble.tsx
@@ -885,20 +885,11 @@ function MarkdownContent({ text, pending, onOpenUrl, citations = [], className }
         // eslint-disable-next-line react/no-danger
         dangerouslySetInnerHTML={{ __html: html }}
       />
-      {/* No streaming cursor here. It used to render as a sibling of the
-          container above — the one placement that keeps it out of the
-          sanitized HTML string — but that container is a block-level <div>,
-          so the span could never trail the last rendered line and instead
-          wrapped onto a row of its own. What the reader saw was a detached
-          grey bar sitting between the message and whatever followed it,
-          after EVERY streaming message that had rendered markdown, which
-          reads as a rendering artifact rather than as a caret (cave-1yslk).
-
-          Putting it back requires appending it INSIDE the last inline
-          descendant of the sanitized HTML, which is exactly the injection
-          this placement was chosen to avoid. Progress is already legible
-          from the text growing, so the affordance is gone rather than
-          wrong. `pending` still drives progressive rendering below. */}
+      {/* No streaming cursor here, and it cannot simply be re-added as a
+          sibling: this container is a block-level <div>, so the span wrapped
+          onto its own row as a detached bar instead of trailing the text
+          (cave-1yslk). Placing it correctly means injecting into the
+          sanitized HTML, which the sibling position existed to avoid. */}
       <InlineCitationPreviews
         citations={citations}
         containerRef={containerRef}
@@ -990,8 +981,7 @@ export type MessageBubbleProps = {
    *  at their chronological position. Assistant role only; when present they
    *  replace the single MarkdownContent render. `content` must still carry
    *  the FULL text so the Copy/Expand actions are unchanged. Only the LAST
-   *  text span streams (progressive markdown + ▌ cursor); earlier spans
-   *  render settled. */
+   *  text span streams (progressive markdown); earlier spans render settled. */
   segments?: MessageBubbleSegment[];
   /** The turn's tool events, forwarded to the reader's "How this was made"
    *  footer (batches, skills, error count). Assistant role only; absent turns
@@ -1126,8 +1116,7 @@ export function MessageBubble({ role, content, timestamp, showTimestamp = true, 
   // Assistant
   // CHAT-D4-01: with segments, only the LAST text span is the live streaming
   // edge — earlier spans are settled slices that never change retroactively,
-  // so they take MarkdownContent's settled path (cached render, no throttle,
-  // no cursor) and the ▌ cursor shows on at most one span.
+  // so they take MarkdownContent's settled path (cached render, no throttle).
   const lastTextIdx = segments
     ? segments.reduce((acc, seg, i) => (seg.kind === "text" ? i : acc), -1)
     : -1;

--- a/src/lib/session-debug.test.ts
+++ b/src/lib/session-debug.test.ts
@@ -499,12 +499,13 @@ assert.match(
   "CHAT-D4-01: interleaved tools retain their chronology while the shared run renderer preserves each ToolBlock",
 );
 
-// MessageBubble: only the LAST text span streams (progressive markdown +
-// cursor); settled spans render with pending=false.
+// MessageBubble: only the LAST text span streams (progressive markdown);
+// settled spans render with pending=false. The cursor this once also gated
+// was removed in cave-1yslk; `pending` still drives progressive rendering.
 assert.match(
   bubbleSource,
   /pending=\{pending && i === lastTextIdx\}/,
-  "CHAT-D4-01: the ▌ cursor / progressive render applies only to the last text span",
+  "CHAT-D4-01: progressive render applies only to the last text span",
 );
 assert.match(
   bubbleSource,


### PR DESCRIPTION
Reported from the running app: a small grey bar sitting on its own line between
a message and whatever followed it.

## What it was

The streaming cursor (`▌`) rendered as a **sibling** of the markdown container:

```tsx
<div className="cave-md" dangerouslySetInnerHTML={{ __html: html }} />
{pending ? <span …>▌</span> : null}
```

That placement was chosen deliberately — it is the only way to show a caret
without injecting into the sanitized HTML string — but `.cave-md` is a
block-level `<div>`, so the span can never sit at the end of the last rendered
line. It necessarily wraps onto a row of its own.

So this was not specific to one message. It appeared after **every** streaming
message that had rendered markdown, and read as a rendering artifact rather
than as a caret.

## Why remove rather than reposition

Putting a caret back at the end of the text means appending inside the last
inline descendant of the sanitized HTML — exactly the injection the sibling
placement existed to avoid. Progress is already legible from the text growing,
so the affordance goes rather than gets moved.

The plain-text fallback cursor goes with it. It only shows for the window
before the first render lands, so keeping it would flash a caret for a moment
and then lose it for the rest of the stream — a flicker, not an affordance.

`pending` still drives progressive rendering; only the glyph is gone.

## Tests

Two source-text assertions previously *required* the cursor and would have
failed this change. They now assert its **absence** at both sites, so it cannot
creep back without the block-container problem being solved first. A third
assertion in `session-debug.test.ts` still pins that only the last text span
streams — that behaviour is unchanged; only its wording mentioned the glyph.

Verified: `pnpm test:app` (1161 files), `pnpm lint`, `pnpm typecheck`.

Closes cave-1yslk.