### PR TITLE
fix(ios): handle credentialFailure in the connection live check

### DIFF
--- a/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
+++ b/apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift
@@ -38,6 +38,11 @@ struct ConnectionView: View {
         case found(port: Int?)
         /// Desktop answered but is token-gated — it IS the desktop; pair it.
         case pairingRequired
+        /// Something answered, but the stored credential cannot safely be sent
+        /// to it. Distinct from `failed`: the address is reachable, so saying
+        /// "couldn't reach" would be untrue and would send the user hunting a
+        /// network problem that does not exist.
+        case credentialBlocked(String)
         case failed(ProbeFailure?)
     }
 
@@ -363,6 +368,13 @@ struct ConnectionView: View {
             )
             .font(.caption.weight(.medium))
             .foregroundStyle(chrome.accent)
+        case .credentialBlocked(let message):
+            Label(
+                message,
+                systemImage: "lock.trianglebadge.exclamationmark"
+            )
+            .font(.caption)
+            .foregroundStyle(.orange)
         case .failed(let failure):
             Label(
                 failure.map(\.previewLine) ?? "Couldn’t reach that address yet.",
@@ -392,6 +404,8 @@ struct ConnectionView: View {
             liveCheck = .found(port: url.port)
         case .unauthorized:
             liveCheck = .pairingRequired
+        case .credentialFailure(let message):
+            liveCheck = .credentialBlocked(message)
         case .unreachable(let failure):
             liveCheck = .failed(failure)
         }


### PR DESCRIPTION
Fixes cave-hslk2.

## Why

`main` does not compile for iOS:

```
apps/ios/CovenCave/CovenCave/Views/ConnectionView.swift:390:9: error: switch must be exhaustive
```

`AppModel.DiscoveryOutcome` gained a `credentialFailure(String)` case, but `ConnectionView` still switched over only `found` / `unauthorized` / `unreachable`.

It stayed hidden because the `iOS build` job is path-filtered and skips on most pull requests. It surfaced only when a `workflow_dispatch` CI-recovery run built the target unconditionally — meaning the next PR to touch `apps/ios` would have been blocked by a break it did not cause.

## What

Handle the case honestly instead of folding it into `failed`. That branch renders **"Couldn't reach that address yet."** when it carries no `ProbeFailure`, which is false here: the endpoint *answered*: only the stored credential cannot safely be sent to it. Reporting it as unreachable would send the user hunting a network problem that does not exist.

So this adds a distinct `credentialBlocked(String)` live-check state that surfaces the real reason, in the same spirit as the existing `pairingRequired` case — which already exists precisely because "found but token-gated" deserved different words from "unreachable".

Three-hunk diff in one file: the new enum case, its rendering, and the mapping from `DiscoveryOutcome`.

## Verification

- `swiftc -parse` clean on the changed file.
- `ConnectionView` holds the only `switch` over `LiveCheckState` in the app (grepped across `apps/ios`), so adding a case makes no other switch non-exhaustive.
- A full local `xcodebuild` could not run here — package resolution cannot fetch the pinned `WebRTC` revision in this environment — so the authoritative check is CI. This PR touches `apps/ios`, so the path-filtered `iOS build` job runs on it: the same job that caught the break.
