### PR TITLE
fix(worktree): charge per-unit metadata failures to the unit they name

### DIFF
--- a/scripts/worktree-lifecycle-create.test.mjs
+++ b/scripts/worktree-lifecycle-create.test.mjs
@@ -1987,4 +1987,93 @@ for (const unusableBranch of ["refs/heads/feat/cave-unit2-unnameable", " feat/ca
   );
 }
 
+// cave-1x9pz — the same outage as cave-g9byt, through an error it did not
+// cover. Every record here is VALID; what conflicts is which unit owns a path.
+//
+// The live shape: a managed worktree was created for one branch, then a session
+// checked a different branch out inside it. The bead's record still names the
+// original branch, so `metadataFor` resolving the unit at that path finds a
+// record claiming the path under another branch and reports "conflicting
+// structured path ownership".
+//
+// That error names exactly one unit. It reached `create` as repository-wide
+// anyway, because `create` recovered scoping by subtracting the record-level
+// claim errors — and this is not one; every record is well-formed. So an
+// unrelated bead could not create a worktree at all, and no exception could
+// rescue it: the inventory throws before admission is assessed.
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    const ownedBranch = "feat/cave-unit2-owned";
+    const ownedPath = path.join(fixture.repo, ".worktrees", "cave-unit2-owned");
+    const owned = runCreate(
+      fixture,
+      createArgs({ bead: "cave-unit2", branch: ownedBranch }),
+    );
+    assert.equal(owned.status, 0, `fixture create must succeed: ${owned.stderr}`);
+
+    // Check a DIFFERENT branch out inside that worktree, leaving the bead's
+    // record pointing at the branch it was created for.
+    const swapped = spawnSync(
+      "git",
+      ["-C", ownedPath, "checkout", "-b", "feat/cave-unit2-swapped"],
+      { encoding: "utf8" },
+    );
+    assert.equal(swapped.status, 0, `fixture checkout must succeed: ${swapped.stderr}`);
+
+    const created = runCreate(fixture, createArgs());
+    assert.doesNotMatch(
+      created.stderr,
+      /lifecycle inventory is incomplete/,
+      "a contested path on another unit must not block an unrelated creation",
+    );
+    assert.doesNotMatch(
+      created.stderr,
+      /conflicting structured path ownership/,
+      "the conflict belongs to the unit whose path is contested, not to this request",
+    );
+    assert.equal(created.status, 0, `create must succeed: ${created.stderr}`);
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example") !== null,
+      true,
+      "the unrelated branch is actually created",
+    );
+  },
+);
+
+// …and the other half, so the scoping does not become a way to create over a
+// contested path. Requesting the very path whose ownership is in dispute must
+// still refuse: a second worktree there is how the dispute becomes unresolvable.
+await withFixture(
+  { issues: [defaultIssue("cave-unit1"), defaultIssue("cave-unit2")] },
+  async (fixture) => {
+    const contestedPath = path.join(fixture.repo, ".worktrees", "cave-unit1-example");
+    const state = readJson(fixture.stateFile);
+    const issue = state.issues.find((candidate) => candidate.id === "cave-unit2");
+    // A fully VALID record — it simply claims the path this request wants,
+    // under a branch that is not the one being requested.
+    issue.metadata = {
+      coven: {
+        worktree: {
+          branch: "feat/cave-unit2-elsewhere",
+          path: contestedPath,
+          owner: "kitty",
+          purpose: "Contested path fixture",
+          createdAt: "2026-08-09T09:09:52.185Z",
+          disposition: "active",
+        },
+      },
+    };
+    writeJson(fixture.stateFile, state);
+
+    const refused = runCreate(fixture, createArgs());
+    assert.notEqual(refused.status, 0, "a contested path must not be created over");
+    assert.equal(
+      refState(fixture.repo, "refs/heads/feat/cave-unit1-example"),
+      null,
+      "no branch is created when the request lands on a contested path",
+    );
+  },
+);
+
 console.log("worktree-lifecycle-create.test.mjs: ok");

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -15,6 +15,7 @@ import {
 } from "../src/lib/worktree-lifecycle.ts";
 import {
   collectWorktreeLifecycleInventory,
+  type OrphanedWorktreeMetadataRecord,
   type WorktreeMetadataClaimError,
 } from "./worktree-lifecycle-inventory.ts";
 import {
@@ -777,20 +778,90 @@ function exceptionForPath(
  * unit in `uncertain`; this makes the create gate agree with that posture instead
  * of re-aborting the whole run (cave-c4f97).
  */
-function inventoryErrors(
-  items: WorktreeLifecycleItem[],
-  claims: WorktreeMetadataClaimError[],
+function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
+  // Read the inventory's own classification rather than re-deriving it. This
+  // used to fold EVERY unit's `metadataErrors` together and then subtract the
+  // record-level claim errors by string equality, on the theory that whatever
+  // survived was repository-wide. It was not: `metadataFor` produces five kinds
+  // of error and only one of them is a record-level claim, so an ownership
+  // conflict, a duplicate record, a duplicate path and a path/branch mismatch
+  // all survived the subtraction and aborted creation for every unrelated bead
+  // (cave-1x9pz).
+  //
+  // The live case that exposed it: one worktree had a different branch checked
+  // out than its bead's record claimed. A real defect, on exactly one unit —
+  // and it refused `--bead` for the whole checkout, which is precisely the
+  // outage cave-g9byt was written to end.
+  return [...new Set(items.flatMap((item) => item.metadataGlobalErrors))];
+}
+
+/**
+ * The per-unit metadata failures that stand in the way of THIS creation.
+ *
+ * A unit-scoped error belongs to the unit it names and to no other — but if the
+ * unit it names is the branch or the path being requested, it is this request's
+ * problem too. Creating a second worktree over a path whose ownership is
+ * already contested is how the contest becomes unresolvable.
+ */
+/**
+ * Well-formed records from OTHER beads that already claim this branch or path.
+ *
+ * `claimErrorsForRequest` refuses when the record claiming your path is
+ * malformed. Without this, a VALID record claiming the same path did not —
+ * which is backwards: a well-formed claim is the stronger claim, and the
+ * malformed one is only visible because its validation errors happen to travel
+ * with it. Creating into a path another bead already names produces a unit with
+ * two records claiming it, which is precisely the contested state the ownership
+ * conflict reports and nothing can resolve automatically.
+ *
+ * Scoped to the exact branch or path requested, so a stale record elsewhere
+ * still cannot refuse an unrelated creation — the whole point of cave-1x9pz.
+ */
+function orphanedClaimsForRequest(
+  orphaned: readonly OrphanedWorktreeMetadataRecord[],
+  beadId: string,
+  branch: string,
+  worktreePath: string,
 ): string[] {
-  const unitScopedErrors = new Set(
-    claims
-      .filter((claim) => claim.branch.length > 0 || claim.path !== null)
-      .flatMap((claim) => claim.errors),
-  );
+  const requested = normalizeCandidate(worktreePath);
+  const normalizedBead = beadId.toLowerCase();
+  return [
+    ...new Set(
+      orphaned
+        // The requesting bead's own records are handled upstream, where
+        // re-creating a unit the same bead used to own is a legitimate flow.
+        .filter((record) => record.beadId.toLowerCase() !== normalizedBead)
+        .filter(
+          (record) =>
+            record.branch === branch || normalizeCandidate(record.path) === requested,
+        )
+        .map(
+          (record) =>
+            `bead ${record.beadId} already claims ${
+              record.branch === branch ? `branch ${branch}` : `path ${record.path}`
+            }`,
+        ),
+    ),
+  ];
+}
+
+function contestedUnitErrors(
+  items: WorktreeLifecycleItem[],
+  branch: string,
+  worktreePath: string,
+): string[] {
+  const requested = normalizeCandidate(worktreePath);
   return [
     ...new Set(
       items
-        .flatMap((item) => item.metadataErrors)
-        .filter((error) => !unitScopedErrors.has(error)),
+        .filter(
+          (item) =>
+            item.branch === branch ||
+            (item.path !== null && normalizeCandidate(item.path) === requested),
+        )
+        .flatMap((item) =>
+          item.metadataErrors.filter((error) => !item.metadataGlobalErrors.includes(error)),
+        ),
     ),
   ];
 }
@@ -1664,8 +1735,15 @@ function execute(
   // records describing some other unit; see {@link claimErrorsForRequest}.
   const errors = [
     ...inventory.globalErrors,
-    ...inventoryErrors(inventory.items, inventory.metadataClaimErrors),
+    ...inventoryErrors(inventory.items),
+    ...contestedUnitErrors(inventory.items, options.branch, worktreePath),
     ...claimErrorsForRequest(inventory.metadataClaimErrors, options.branch, worktreePath),
+    ...orphanedClaimsForRequest(
+      inventory.orphanedMetadata,
+      options.beadId,
+      options.branch,
+      worktreePath,
+    ),
   ];
   if (errors.length > 0) {
     throw new CliError(`lifecycle inventory is incomplete: ${errors.join("; ")}`);

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -796,14 +796,6 @@ function inventoryErrors(items: WorktreeLifecycleItem[]): string[] {
 }
 
 /**
- * The per-unit metadata failures that stand in the way of THIS creation.
- *
- * A unit-scoped error belongs to the unit it names and to no other — but if the
- * unit it names is the branch or the path being requested, it is this request's
- * problem too. Creating a second worktree over a path whose ownership is
- * already contested is how the contest becomes unresolvable.
- */
-/**
  * Well-formed records from OTHER beads that already claim this branch or path.
  *
  * `claimErrorsForRequest` refuses when the record claiming your path is
@@ -845,6 +837,19 @@ function orphanedClaimsForRequest(
   ];
 }
 
+/**
+ * The per-unit metadata failures that stand in the way of THIS creation.
+ *
+ * A unit-scoped error belongs to the unit it names and to no other — but if the
+ * unit it names is the branch or the path being requested, it is this request's
+ * problem too. Creating a second worktree over a path whose ownership is
+ * already contested is how the contest becomes unresolvable.
+ *
+ * `metadataGlobalErrors` is subtracted because those are the repository-wide
+ * ones, already reported once by {@link inventoryErrors}; repeating them here
+ * would make an unrelated global failure look like a collision with this
+ * request.
+ */
 function contestedUnitErrors(
   items: WorktreeLifecycleItem[],
   branch: string,

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -2374,12 +2374,39 @@ function recordIsAttributable(record: StructuredMetadataRecord): boolean {
   return record.branchUsable || normalizeAbsoluteWorktreePath(record.path) !== null;
 }
 
+/**
+ * Resolve one unit's lifecycle metadata.
+ *
+ * Returns errors in TWO buckets, and the split is the whole point:
+ *
+ *   - `errors` — everything that disqualifies THIS unit. The unit fails closed
+ *     on all of it, exactly as before.
+ *   - `globalErrors` — the subset of `errors` that is repository-wide, i.e.
+ *     true regardless of which unit is being resolved. Only these may abort an
+ *     operation on some OTHER unit.
+ *
+ * Before cave-1x9pz the two were returned as one list, and `create.ts` tried to
+ * recover the distinction downstream by subtracting the record-level claim
+ * errors from it by string equality. That only ever identified one of the five
+ * kinds produced here, so an ownership conflict, a duplicate record, a
+ * duplicate path or a path/branch mismatch — all of them attributable to a
+ * single named unit — leaked out as repository-wide and refused creation for
+ * every unrelated bead. Which is the same outage cave-g9byt fixed for
+ * record-level errors, resurfacing through the four cases it did not cover.
+ *
+ * Nothing downstream has to guess now: the classification is made here, where
+ * the reason each error exists is still in scope.
+ */
 function metadataFor(
   branch: string | null,
   worktreePath: string | null,
   tasks: BeadTask[],
-): { metadata: WorktreeLifecycleMetadata | null; errors: string[] } {
-  if (!branch) return { metadata: null, errors: [] };
+): {
+  metadata: WorktreeLifecycleMetadata | null;
+  errors: string[];
+  globalErrors: string[];
+} {
+  if (!branch) return { metadata: null, errors: [], globalErrors: [] };
   const allRecords = tasks.flatMap((task) => task.structured);
   // One malformed record used to deny every unit in the repository, because
   // every task's record errors were folded in here wholesale. cave-l11sw wrote
@@ -2412,18 +2439,24 @@ function metadataFor(
             ...new Set(conflictingPathRecords.map((record) => record.branch || "<invalid branch>")),
           ].join(", ")}`,
         ];
+  // `globalErrors` above does not read `branch` or `worktreePath` at all — it is
+  // derived from `tasks` alone and is therefore identical for every unit. That
+  // is what makes it safe to abort someone else's operation on. The ownership
+  // conflict beside it names THIS unit's contested path, so it is not.
+  const repositoryWide = [...new Set(globalErrors)];
   const inventoryErrors = [...new Set([...globalErrors, ...ownershipErrors])];
   if (inventoryErrors.length > 0) {
-    return { metadata: null, errors: inventoryErrors };
+    return { metadata: null, errors: inventoryErrors, globalErrors: repositoryWide };
   }
   if (records.length > 1) {
     return {
       metadata: null,
       errors: [`duplicate structured worktree metadata records for ${branch}`],
+      globalErrors: [],
     };
   }
   const record = records[0];
-  if (!record) return { metadata: null, errors: [] };
+  if (!record) return { metadata: null, errors: [], globalErrors: [] };
   const normalizedRecordPath = normalizeAbsoluteWorktreePath(record.path);
   if (
     normalizedRecordPath !== null &&
@@ -2435,10 +2468,11 @@ function metadataFor(
     return {
       metadata: null,
       errors: [`duplicate structured worktree metadata paths for ${record.path}`],
+      globalErrors: [],
     };
   }
   if (record.errors.length > 0 || !record.metadata) {
-    return { metadata: null, errors: record.errors };
+    return { metadata: null, errors: record.errors, globalErrors: [] };
   }
   if (
     normalizedWorktreePath !== null &&
@@ -2447,9 +2481,10 @@ function metadataFor(
     return {
       metadata: null,
       errors: [`structured worktree metadata path does not match ${branch}`],
+      globalErrors: [],
     };
   }
-  return { metadata: record.metadata, errors: [] };
+  return { metadata: record.metadata, errors: [], globalErrors: [] };
 }
 
 export function probeRecordedPathAbsence(
@@ -3020,6 +3055,7 @@ export function collectWorktreeLifecycleInventory(
       probeErrors,
       metadata: metadata.metadata,
       metadataErrors: metadata.errors,
+      metadataGlobalErrors: metadata.globalErrors,
       remoteRef: remote.remoteRef,
       sessionIds: unit.path
         ? (sessionOwnership.sessionIdsByPath.get(unit.path) ?? [])

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -76,7 +76,23 @@ export type WorktreeLifecycleObservation = {
   updatedAtMs: number | null;
   probeErrors: string[];
   metadata: WorktreeLifecycleMetadata | null;
+  /**
+   * Everything disqualifying this unit's metadata. The unit fails closed on all
+   * of it.
+   */
   metadataErrors: string[];
+  /**
+   * The subset of {@link metadataErrors} that is repository-wide — true no
+   * matter which unit is being resolved, because it is derived from the beads
+   * alone rather than from this branch or path.
+   *
+   * Only these may abort an operation on a DIFFERENT unit. Everything else in
+   * `metadataErrors` names one unit and belongs to it: an ownership conflict, a
+   * duplicate record or path, a path that does not match its branch. Treating
+   * those as repository-wide is what made one bead's bad record refuse creation
+   * for every other bead (cave-1x9pz, and cave-g9byt before it).
+   */
+  metadataGlobalErrors: string[];
   remoteRef: WorktreeRemoteRef | null;
   sessionIds: string[];
 };
@@ -108,7 +124,16 @@ type LegacyWorktreeObservation = Pick<
 type WorktreeObservationCompatibilityFields = Partial<
   Pick<
     WorktreeLifecycleObservation,
-    "kind" | "ref" | "metadata" | "metadataErrors" | "remoteRef" | "sessionIds"
+    | "kind"
+    | "ref"
+    | "metadata"
+    | "metadataErrors"
+    // Optional alongside `metadataErrors` so a legacy observation that predates
+    // the split still parses; it reads as "nothing here is repository-wide",
+    // which is the conservative answer for a caller that never classified.
+    | "metadataGlobalErrors"
+    | "remoteRef"
+    | "sessionIds"
   >
 >;
 
@@ -620,6 +645,7 @@ function normalizeWorktreeObservation(
       probeErrors: observation.probeErrors,
       metadata: observation.metadata ?? null,
       metadataErrors: observation.metadataErrors ?? [],
+      metadataGlobalErrors: observation.metadataGlobalErrors ?? [],
       remoteRef: observation.remoteRef ?? null,
       sessionIds: observation.sessionIds ?? [],
     },


### PR DESCRIPTION
`pnpm beads:worktrees:create` refused for **every bead in the checkout**
because one worktree had a different branch checked out than its bead's record
claimed:

```
worktree-lifecycle-create: lifecycle inventory is incomplete:
conflicting structured path ownership for
…/.worktrees/cave-58eoq-4-1-endpoint-faults: fix/cave-58eoq-4-lifecycle-stress
```

A real defect, on exactly one unit — and no exception could rescue it, because
the inventory throws *before* admission is assessed. The only path left was the
unmanaged `git worktree add` fallback, which produces a worktree nothing can
retire. That is precisely the behaviour cave-g9byt exists to stop teaching.

## The scoping had four holes, not one

`metadataFor` produces five kinds of error and returned them as a single list.
Only one of them — a record's own validation failure — reaches `create.ts` as a
claim error, and `create.ts` recovered scoping by subtracting those claim
errors from the fold **by string equality**. The other four survived the
subtraction and aborted creation for every unrelated bead:

- `conflicting structured path ownership`
- `duplicate structured worktree metadata records for <branch>`
- `duplicate structured worktree metadata paths for <path>`
- `structured worktree metadata path does not match <branch>`

Every one of them names exactly one unit.

## The fix

Classify where the reason is still in scope. `metadataFor` now returns
`globalErrors` alongside `errors` — the subset that is repository-wide.

That subset is *provably* unit-independent: it reads neither `branch` nor
`worktreePath`, being derived from the beads alone, so it is identical for
every unit. `create.ts` reads it instead of guessing downstream.

## Two guards, so scoping doesn't become a licence

- **`contestedUnitErrors`** — a unit-scoped failure still refuses *this*
  request when it names the exact branch or path being requested. Creating a
  second worktree onto a contested path is how the contest becomes
  unresolvable.
- **`orphanedClaimsForRequest`** — closes an asymmetry the first guard
  exposed while writing its test. A **malformed** record claiming your path
  refused you; a **well-formed** one did not. That is backwards — the
  malformed record was only visible because its validation errors happened to
  travel with it, and a valid claim is the stronger claim.

## Unit behaviour is unchanged

Every unit still fails closed on all of its own `metadataErrors`. Only the
repository-wide *classification* changed, which is why the patrol's assertions
on those exact messages still hold.

## Tests

Two reproductions added to the create suite:

1. an unrelated bead creates successfully while another unit's path ownership
   is contested (the live failure above);
2. requesting the contested path itself is still refused.

The second one initially failed — and correctly so: it asserted behaviour that
never existed, which is how the well-formed-claim asymmetry surfaced.

Verified: create suite 171 s green, patrol suite 146 invocations / 682 s green,
`tsc --noEmit` clean.

Closes cave-1x9pz.