### PR TITLE
Accept current Coven daemon health shape

### DIFF
--- a/src/lib/daemon-startup-contract.test.ts
+++ b/src/lib/daemon-startup-contract.test.ts
@@ -15,6 +15,18 @@ assert.deepEqual(assessDaemonStartupCompatibility(healthy, "1.2.3"), {
   apiVersion: "v1",
 });
 
+assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion: "coven.daemon.v1" }, "1.2.3"), {
+  ok: true,
+  daemonVersion: "1.2.3",
+  apiVersion: "coven.daemon.v1",
+});
+
+assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "0.0.0" }, "1.2.3"), {
+  ok: true,
+  daemonVersion: "1.2.3",
+  apiVersion: "v1",
+});
+
 assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion: "v2" }, "1.2.3"), {
   ok: false,
   code: "unsupported_api",

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -1,7 +1,7 @@
 import { exactSemver } from "./exact-semver.ts";
 
 /** The named daemon API versions Cave can safely adopt. */
-export const SUPPORTED_DAEMON_API_VERSIONS = new Set(["1", "v1"]);
+export const SUPPORTED_DAEMON_API_VERSIONS = new Set(["1", "v1", "coven.daemon.v1"]);
 
 export type DaemonStartupHealth = {
   ok?: unknown;
@@ -46,8 +46,8 @@ export function assessDaemonStartupCompatibility(
     };
   }
 
-  const daemonVersion = exactSemver(health.covenVersion);
-  if (!daemonVersion) {
+  const reportedDaemonVersion = exactSemver(health.covenVersion);
+  if (!reportedDaemonVersion) {
     return {
       ok: false,
       code: "invalid_runtime_version",
@@ -64,6 +64,7 @@ export function assessDaemonStartupCompatibility(
     };
   }
 
+  const daemonVersion = reportedDaemonVersion === "0.0.0" ? expectedVersion : reportedDaemonVersion;
   if (daemonVersion !== expectedVersion) {
     return {
       ok: false,


### PR DESCRIPTION
## Summary
- Accept the current named daemon API version, `coven.daemon.v1`, during Cave startup compatibility checks.
- Treat daemon health `covenVersion: "0.0.0"` as a placeholder only after Cave has verified the installed Coven CLI version.
- Add regression coverage for both compatibility cases.

## Root Cause
Cave rejected a healthy local daemon because the daemon now reports API version `coven.daemon.v1`, while Cave accepted only `1` and `v1`. The same Windows v0.2.5 health shape can report `covenVersion: "0.0.0"`, which the status display already treats as a placeholder.

## Validation
- `node --experimental-strip-types src\lib\daemon-startup-contract.test.ts`
- `node --experimental-strip-types src\lib\daemon-start.test.ts`
- `pnpm test:daemon-faults`
- `pnpm check:tests-wired`
- `pnpm typecheck`