### PR TITLE
feat(worktrees): clear a Bead's provably dead worktree record

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "beads:worktrees": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave",
     "beads:worktrees:json": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --json",
     "beads:worktrees:create": "node --experimental-strip-types scripts/worktree-lifecycle-create.ts",
+    "beads:worktrees:clear-record": "node --experimental-strip-types scripts/worktree-lifecycle-clear-record.ts",
     "beads:worktrees:apply": "node --experimental-strip-types scripts/worktree-lifecycle-patrol.ts --repo OpenCoven/coven-cave --apply",
     "beads:patrol": "pnpm beads:prs:patrol && pnpm beads:worktrees",
     "beads:patrol:apply": "pnpm beads:prs:patrol:apply && pnpm beads:worktrees",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1283,6 +1283,7 @@ export const SUITES = {
     "src/lib/daemon-socket-occupancy.test.ts",
     "src/lib/daemon-endpoint-faults.test.ts",
     "src/lib/daemon-endpoint-churn.test.ts",
+    "src/lib/worktree-record-clearance.test.ts",
     "src/lib/daemon-startup-contract.test.ts",
     "src/lib/runtime-startup-throttle.test.ts",
     "src/lib/daemon-update-lifecycle.test.ts",

--- a/scripts/worktree-lifecycle-clear-record.ts
+++ b/scripts/worktree-lifecycle-clear-record.ts
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * Clear a Bead's stale worktree record (cave-xbc87).
+ *
+ * Hand-retiring a worktree leaves `metadata.coven.worktree` behind, still
+ * naming a path that no longer exists. `worktree-lifecycle-create` then refuses
+ * that Bead — "primary structured worktree metadata is not currently
+ * registered" — so it can never hold another worktree. Since
+ * `beads:worktrees:apply` is unreachable while three maintenance planes are
+ * unenforced (cave-3aqvr), hand-retirement is the only route available, and
+ * every retirement leaks one of these.
+ *
+ * This command removes ONLY a record whose worktree is provably absent, and
+ * refuses every ambiguous case. The decision itself lives in
+ * src/lib/worktree-record-clearance.ts and is unit-tested there; this file is
+ * the boundary that gathers real state and performs the write.
+ *
+ * It deliberately does not: touch any other Bead, remove directories, delete
+ * refs, or write a record. Its only mutation is dropping one key.
+ */
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+import {
+  assessWorktreeRecordClearance,
+  type WorktreeRecordClearance,
+} from "../src/lib/worktree-record-clearance.ts";
+
+type Args = { bead: string; owner: string; reason: string; dryRun: boolean; json: boolean };
+
+function fail(message: string, code = 2): never {
+  process.stderr.write(`worktree-lifecycle-clear-record: ${message}\n`);
+  process.exit(code);
+}
+
+function parseArgs(argv: readonly string[]): Args {
+  const values = new Map<string, string>();
+  let dryRun = false;
+  let json = false;
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+    if (arg === "--json") {
+      json = true;
+      continue;
+    }
+    if (!arg.startsWith("--")) fail(`unexpected argument: ${arg}`);
+    const next = argv[i + 1];
+    if (next === undefined || next.startsWith("--")) fail(`${arg} requires a value`);
+    values.set(arg, next);
+    i += 1;
+  }
+  const bead = values.get("--bead") ?? "";
+  const owner = values.get("--owner") ?? "";
+  const reason = values.get("--reason") ?? "";
+  if (!bead) fail("--bead is required");
+  return { bead, owner, reason, dryRun, json };
+}
+
+function git(args: readonly string[]): string {
+  return execFileSync("git", args as string[], { encoding: "utf8" });
+}
+
+/** Absolute paths git currently reports as registered worktrees. */
+function registeredWorktreePaths(): string[] {
+  return git(["worktree", "list", "--porcelain"])
+    .split("\n")
+    .filter((line) => line.startsWith("worktree "))
+    .map((line) => line.slice("worktree ".length).trim())
+    .filter(Boolean);
+}
+
+type BeadMetadata = { coven?: { worktree?: Record<string, unknown> } & Record<string, unknown> };
+
+function loadBead(beadId: string): { metadata: BeadMetadata } {
+  const raw = execFileSync("bd", ["show", beadId, "--json"], { encoding: "utf8" });
+  const parsed = JSON.parse(raw);
+  const bead = Array.isArray(parsed) ? parsed[0] : parsed;
+  if (!bead) fail(`Bead ${beadId} was not found`);
+  return { metadata: (bead.metadata ?? {}) as BeadMetadata };
+}
+
+function main(): void {
+  const args = parseArgs(process.argv.slice(2));
+  const { metadata } = loadBead(args.bead);
+  const record = metadata.coven?.worktree ?? null;
+
+  const recordPath = typeof record?.path === "string" ? record.path : "";
+  const verdict: WorktreeRecordClearance = assessWorktreeRecordClearance({
+    record,
+    registeredPaths: registeredWorktreePaths(),
+    // existsSync rather than a stat on a directory: a leftover file or symlink
+    // at the path is still something, and something is a reason to refuse.
+    pathExistsOnDisk: recordPath.length > 0 ? existsSync(recordPath) : false,
+    owner: args.owner,
+    reason: args.reason,
+  });
+
+  if (!verdict.ok) {
+    if (args.json) process.stdout.write(`${JSON.stringify(verdict)}\n`);
+    fail(`${verdict.code}: ${verdict.diagnostic}`);
+  }
+
+  if (args.dryRun) {
+    const report = { ...verdict, bead: args.bead, dryRun: true };
+    process.stdout.write(`${JSON.stringify(report)}\n`);
+    return;
+  }
+
+  // Preserve every other coven key. Only the worktree record is dropped, and
+  // the clearance is recorded next to it so the removal stays attributable.
+  const coven: Record<string, unknown> = { ...(metadata.coven ?? {}) };
+  delete coven.worktree;
+  coven.worktreeClearedAt = new Date().toISOString();
+  coven.worktreeClearedBy = args.owner;
+  coven.worktreeClearedReason = args.reason;
+  coven.worktreeClearedPath = verdict.clearedPath;
+
+  execFileSync("bd", ["update", args.bead, "--metadata", JSON.stringify({ coven }), "--json"], {
+    encoding: "utf8",
+  });
+
+  // Read back rather than trusting the write: a silent no-op here would leave
+  // the Bead just as blocked while reporting success.
+  const after = loadBead(args.bead);
+  if (after.metadata.coven?.worktree) {
+    fail("bd update reported success but the record is still present on the Bead", 1);
+  }
+
+  const report = { ...verdict, bead: args.bead, dryRun: false };
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+}
+
+main();

--- a/src/lib/worktree-record-clearance.test.ts
+++ b/src/lib/worktree-record-clearance.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assessWorktreeRecordClearance } from "./worktree-record-clearance.ts";
+
+const OWNER = "Val Alexander";
+const REASON = "worktree hand-retired after PR #4489 merged";
+
+function assess(overrides: Partial<Parameters<typeof assessWorktreeRecordClearance>[0]> = {}) {
+  return assessWorktreeRecordClearance({
+    record: { path: "/repo/.worktrees/gone", branch: "fix/gone", disposition: "active" },
+    registeredPaths: ["/repo", "/repo/.worktrees/live"],
+    pathExistsOnDisk: false,
+    owner: OWNER,
+    reason: REASON,
+    ...overrides,
+  });
+}
+
+test("a record whose worktree is gone from git and disk may be cleared", () => {
+  const result = assess();
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.clearedPath, "/repo/.worktrees/gone");
+});
+
+test("a record whose worktree git still registers is never cleared", () => {
+  // The failure that matters: clearing this would strand a live unit outside
+  // the lifecycle system, where no patrol would ever assess it again.
+  const result = assess({
+    record: { path: "/repo/.worktrees/live", branch: "fix/live", disposition: "active" },
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "worktree-still-registered");
+    assert.match(result.diagnostic, /strand a live unit/);
+  }
+});
+
+test("a path git forgot but that still exists on disk is refused, not cleared", () => {
+  // Unregistered but present means an unmanaged fallback worktree or debris.
+  // The record is the only remaining pointer to it, so removing the record
+  // would hide it rather than resolve it.
+  const result = assess({ pathExistsOnDisk: true });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "path-still-present");
+    assert.match(result.diagnostic, /only remaining pointer/);
+  }
+});
+
+test("trailing separators do not smuggle a live worktree past the check", () => {
+  // A record written with a trailing slash must still match git's registration,
+  // or the safety check becomes a formatting coincidence.
+  const result = assess({
+    record: { path: "/repo/.worktrees/live/", branch: "fix/live", disposition: "active" },
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "worktree-still-registered");
+
+  const reversed = assess({
+    record: { path: "/repo/.worktrees/live", branch: "fix/live", disposition: "active" },
+    registeredPaths: ["/repo/.worktrees/live/"],
+  });
+  assert.equal(reversed.ok, false);
+  if (!reversed.ok) assert.equal(reversed.code, "worktree-still-registered");
+});
+
+test("a bead with no record has nothing to clear", () => {
+  const result = assess({ record: null });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "no-record");
+});
+
+test("a record naming no usable path is repaired deliberately, never cleared blindly", () => {
+  for (const path of [undefined, null, "", "   ", 42, {}]) {
+    const result = assess({ record: { path, branch: "fix/x", disposition: "active" } as never });
+    assert.equal(result.ok, false, `path ${JSON.stringify(path)} must not be clearable`);
+    if (!result.ok) assert.equal(result.code, "malformed-record");
+  }
+});
+
+test("clearance is refused without an owner and a reason", () => {
+  // An unattributed clearance is indistinguishable from the forging the
+  // worktree rules exist to prevent, so attribution is a precondition rather
+  // than a log line written afterwards.
+  for (const overrides of [
+    { owner: "" },
+    { owner: "   " },
+    { reason: "" },
+    { reason: "  " },
+    { owner: "", reason: "" },
+  ]) {
+    const result = assess(overrides);
+    assert.equal(result.ok, false, `${JSON.stringify(overrides)} must not be clearable`);
+    if (!result.ok) assert.equal(result.code, "unattributed");
+  }
+});
+
+test("attribution is checked before anything else, so a bad request cannot probe state", () => {
+  // Ordering matters: an unattributed caller should not learn whether a path is
+  // registered by reading which refusal comes back.
+  const result = assess({
+    owner: "",
+    record: { path: "/repo/.worktrees/live", branch: "fix/live", disposition: "active" },
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "unattributed");
+});
+
+test("the disposition of a dead record does not change the verdict", () => {
+  // A record is cleared because its worktree is gone, not because of what the
+  // record claims about itself — otherwise a wrong disposition would protect a
+  // dead record forever.
+  for (const disposition of ["active", "pr", "recovery", "archive", "nonsense"]) {
+    const result = assess({
+      record: { path: "/repo/.worktrees/gone", branch: "fix/gone", disposition },
+    });
+    assert.equal(result.ok, true, `disposition ${disposition} must not block clearance`);
+  }
+});

--- a/src/lib/worktree-record-clearance.ts
+++ b/src/lib/worktree-record-clearance.ts
@@ -1,0 +1,115 @@
+/**
+ * Deciding whether a bead's worktree record may be cleared (cave-xbc87).
+ *
+ * Hand-retiring a worktree leaves the owning bead's `metadata.coven.worktree`
+ * record behind, still claiming a path that no longer exists. That is not
+ * cosmetic: `worktree-lifecycle-create` refuses a bead whose primary record
+ * names an unregistered path, so the bead can never get another worktree
+ * (reproduced 2026-08-10 on cave-58eoq.4). And because
+ * `beads:worktrees:apply` is unreachable while three maintenance planes are
+ * unenforced (cave-3aqvr), hand-retirement is the only route available — so
+ * every retirement leaks a record.
+ *
+ * The repository rules are emphatic that lifecycle metadata is not to be
+ * hand-edited: that record is the evidence the retirement gate reads, and
+ * forging one is the bypass the guard exists to prevent (cave-l52dt). Clearing
+ * a record whose worktree provably does not exist is the opposite operation —
+ * it removes a false claim rather than fabricating a true-looking one — but
+ * only if "provably" is enforced rather than asserted. That is this module's
+ * entire job, kept pure so it can be tested exhaustively without a repository.
+ *
+ * The refusal is deliberately asymmetric. Clearing a record for a worktree that
+ * still exists would strand a live unit outside the lifecycle system, where no
+ * patrol would ever see it again. Failing to clear a genuinely dead record only
+ * costs an error message. So every ambiguous case refuses.
+ */
+
+export type WorktreeRecordClearanceInput = {
+  /** The bead's primary record, or null when it holds none. */
+  record: { path?: unknown; branch?: unknown; disposition?: unknown } | null;
+  /** Absolute paths git currently reports as registered worktrees. */
+  registeredPaths: readonly string[];
+  /** Whether the record's path currently exists on disk, in any form. */
+  pathExistsOnDisk: boolean;
+  /** Who is asking. Recorded so a cleared record is attributable. */
+  owner: string;
+  /** Why. Recorded for the same reason. */
+  reason: string;
+};
+
+export type WorktreeRecordClearance =
+  | { ok: true; clearedPath: string }
+  | { ok: false; code: ClearanceRefusal; diagnostic: string };
+
+export type ClearanceRefusal =
+  | "no-record"
+  | "malformed-record"
+  | "worktree-still-registered"
+  | "path-still-present"
+  | "unattributed";
+
+/** Normalises a path for comparison without resolving symlinks (callers pass real paths). */
+function trimTrailingSeparators(value: string): string {
+  return value.replace(/[/\\]+$/, "");
+}
+
+export function assessWorktreeRecordClearance(
+  input: WorktreeRecordClearanceInput,
+): WorktreeRecordClearance {
+  const owner = typeof input.owner === "string" ? input.owner.trim() : "";
+  const reason = typeof input.reason === "string" ? input.reason.trim() : "";
+  if (owner.length === 0 || reason.length === 0) {
+    return {
+      ok: false,
+      code: "unattributed",
+      diagnostic:
+        "clearing a lifecycle record requires --owner and --reason: an unattributed clearance is indistinguishable from the forging this gate exists to prevent",
+    };
+  }
+
+  if (input.record === null || input.record === undefined) {
+    return {
+      ok: false,
+      code: "no-record",
+      diagnostic: "this Bead holds no worktree record, so there is nothing to clear",
+    };
+  }
+
+  const path = input.record.path;
+  if (typeof path !== "string" || path.trim().length === 0) {
+    // A record naming no usable path cannot be proven dead — there is nothing
+    // to check against git. Refusing keeps this command from becoming a way to
+    // delete records that merely look inconvenient.
+    return {
+      ok: false,
+      code: "malformed-record",
+      diagnostic:
+        "the record names no usable path, so its worktree cannot be proven absent; repair it deliberately rather than clearing it blindly",
+    };
+  }
+
+  const recordPath = trimTrailingSeparators(path);
+  const registered = input.registeredPaths.map(trimTrailingSeparators);
+  if (registered.includes(recordPath)) {
+    return {
+      ok: false,
+      code: "worktree-still-registered",
+      diagnostic:
+        `git still reports ${recordPath} as a registered worktree; clearing its record would strand a live unit outside the lifecycle system`,
+    };
+  }
+
+  if (input.pathExistsOnDisk) {
+    // Unregistered but present means something is there that git does not know
+    // about — an unmanaged fallback worktree, or debris. Either way it is not
+    // this command's business, and removing the record would hide it.
+    return {
+      ok: false,
+      code: "path-still-present",
+      diagnostic:
+        `${recordPath} still exists on disk even though git does not register it; investigate before clearing, because the record is the only remaining pointer to it`,
+    };
+  }
+
+  return { ok: true, clearedPath: recordPath };
+}


### PR DESCRIPTION
`cave-xbc87`. Adds `pnpm beads:worktrees:clear-record`.

## The problem, reproduced first-hand

Hand-retiring a worktree leaves `metadata.coven.worktree` behind, still naming a path that no longer exists. That is **not cosmetic** — `worktree-lifecycle-create` refuses such a Bead:

```
Bead cave-58eoq.4 primary structured worktree metadata is not currently registered
```

So the Bead can never hold another worktree. I hit this on `cave-58eoq.4` after retiring its increment-1 worktree, and had to file a child Bead as a workaround.

And it is systemic: `beads:worktrees:apply` is unreachable while three maintenance planes are unenforced (`cave-3aqvr`), so **hand-retirement is the only route available**, and every retirement leaks a record. The patrol currently reports **17**.

## Why this does not violate the anti-forging rule

The worktree rules are emphatic that lifecycle metadata must not be hand-edited — that record is the evidence the retirement gate reads, and forging one is the bypass the guard exists to prevent (`cave-l52dt`). Clearing a record whose worktree is *provably absent* is the opposite operation: it removes a false claim rather than fabricating a true-looking one.

That only holds if **"provably" is enforced rather than asserted**, which is this change's entire job.

## What it refuses

| condition | why |
|---|---|
| worktree still registered with git | clearing would strand a live unit outside the lifecycle system, where no patrol sees it again |
| path still exists on disk though git forgot it | an unmanaged fallback or debris — the record is the only remaining pointer to it |
| record names no usable path | absence cannot be proven |
| Bead holds no record | nothing to clear |
| `--owner` or `--reason` missing | an unattributed clearance is indistinguishable from forging |

Two details that are easy to get wrong and are pinned by tests: **attribution is checked first**, so an unattributed caller cannot learn whether a path is registered by reading which refusal comes back; and **trailing separators are normalised on both sides**, so the live-worktree check is not a formatting coincidence.

## Structure

The decision is pure — `src/lib/worktree-record-clearance.ts` — so it is exhaustively testable without a repository. The CLI is the boundary: it gathers real state, applies the verdict, preserves every other `coven` key, and records who cleared what and why next to the removal. It **reads the Bead back** rather than trusting the write, because a silent no-op would leave the Bead just as blocked while reporting success. `--dry-run` reports the verdict without mutating.

It deliberately does not touch any other Bead, remove directories, delete refs, or write a record. Its only mutation is dropping one key.

## Verification against real state

- dry-run on `cave-58eoq.4` → identifies its dead record as clearable
- same command on `cave-58eoq.4.1`, whose worktree is live → refuses `worktree-still-registered`
- omitting attribution → refuses `unattributed`

9 unit tests; `check:tests-wired` (1609 files), `pnpm typecheck`, `pnpm lint` all exit 0.

## Not included

Actually clearing the 17 existing records. That is a separate, deliberate act per record — this PR only provides the sanctioned means.