### PR TITLE
Compile iOS changes on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,21 @@ permissions:
   contents: read
 
 jobs:
-  build:
-    name: Frontend build
+  paths:
+    name: Select validation
     if: github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha
     runs-on: ubuntu-latest
-    timeout-minutes: 60
-    env:
-      NEXT_PUBLIC_CAVE_CRAFTS: "1"
+    timeout-minutes: 5
+    outputs:
+      frontend: ${{ steps.paths.outputs.frontend }}
+      rust: ${{ steps.paths.outputs.rust }}
+      e2e: ${{ steps.paths.outputs.e2e }}
+      ios: ${{ steps.paths.outputs.ios }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           persist-credentials: false
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: 24
-          cache: pnpm
 
       - id: paths
         name: Select path-aware validation
@@ -51,12 +47,70 @@ jobs:
       - run: node scripts/check-conflict-markers.mjs
       - run: node --test scripts/ci-paths.test.mjs
 
+  ios:
+    name: iOS build
+    needs: paths
+    if: needs.paths.outputs.ios == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: brew install xcodegen
+      - run: bash scripts/ios-xcodegen.sh
+
+      - name: Compile the iOS app
+        working-directory: apps/ios/CovenCave
+        run: xcodebuild -scheme CovenCave -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
+
+  build:
+    name: Frontend build
+    needs: [paths, ios]
+    if: always() && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      NEXT_PUBLIC_CAVE_CRAFTS: "1"
+    steps:
+      - name: Require selected validation
+        env:
+          PATHS_RESULT: ${{ needs.paths.result }}
+          IOS_ENABLED: ${{ needs.paths.outputs.ios }}
+          IOS_RESULT: ${{ needs.ios.result }}
+        run: |
+          set -euo pipefail
+          test "$PATHS_RESULT" = "success"
+          if [ "$IOS_ENABLED" = "true" ]; then
+            test "$IOS_RESULT" = "success"
+          fi
+
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: pnpm
+
       - name: Install JavaScript dependencies
-        if: steps.paths.outputs.frontend == 'true' || steps.paths.outputs.e2e == 'true'
+        if: needs.paths.outputs.frontend == 'true' || needs.paths.outputs.e2e == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Validate frontend
-        if: steps.paths.outputs.frontend == 'true'
+        if: needs.paths.outputs.frontend == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -76,10 +130,10 @@ jobs:
           exit 1
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2026-03-27
-        if: steps.paths.outputs.rust == 'true'
+        if: needs.paths.outputs.rust == 'true'
 
       - name: Install Tauri system dependencies
-        if: steps.paths.outputs.rust == 'true'
+        if: needs.paths.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -94,12 +148,12 @@ jobs:
             librsvg2-dev
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: steps.paths.outputs.rust == 'true'
+        if: needs.paths.outputs.rust == 'true'
         with:
           workspaces: src-tauri -> target
 
       - name: Validate Rust
-        if: steps.paths.outputs.rust == 'true'
+        if: needs.paths.outputs.rust == 'true'
         working-directory: src-tauri
         shell: bash
         run: |
@@ -111,16 +165,17 @@ jobs:
           cargo test --locked --lib
 
       - name: Install Playwright browsers
-        if: steps.paths.outputs.e2e == 'true'
+        if: needs.paths.outputs.e2e == 'true'
         run: pnpm exec playwright install --with-deps chromium webkit
 
       - name: Validate end-to-end behavior
-        if: steps.paths.outputs.e2e == 'true'
+        if: needs.paths.outputs.e2e == 'true'
         run: pnpm exec playwright test
 
       - name: Report skipped suites
-        if: steps.paths.outputs.frontend != 'true' || steps.paths.outputs.rust != 'true' || steps.paths.outputs.e2e != 'true'
+        if: needs.paths.outputs.frontend != 'true' || needs.paths.outputs.rust != 'true' || needs.paths.outputs.e2e != 'true' || needs.paths.outputs.ios != 'true'
         run: |
-          echo "frontend=${{ steps.paths.outputs.frontend }}"
-          echo "rust=${{ steps.paths.outputs.rust }}"
-          echo "e2e=${{ steps.paths.outputs.e2e }}"
+          echo "frontend=${{ needs.paths.outputs.frontend }}"
+          echo "rust=${{ needs.paths.outputs.rust }}"
+          echo "e2e=${{ needs.paths.outputs.e2e }}"
+          echo "ios=${{ needs.paths.outputs.ios }} (${{ needs.ios.result }})"

--- a/apps/ios/CovenCave/CovenCave/Voice/VoiceMediaSession.swift
+++ b/apps/ios/CovenCave/CovenCave/Voice/VoiceMediaSession.swift
@@ -34,8 +34,14 @@ final class VoiceMediaSession: VoiceMediaSessionManaging {
             throw VoiceCallMediaError.speechRecognitionDenied
         }
 
+        // Xcode 26 renamed this option; release CI still compiles with Xcode 16.
+#if compiler(>=6.2)
+        let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetoothHFP
+#else
+        let bluetoothOption: AVAudioSession.CategoryOptions = .allowBluetooth
+#endif
         try session.setCategory(.playAndRecord, mode: .voiceChat,
-                                options: [.allowBluetoothHFP, .defaultToSpeaker])
+                                options: [bluetoothOption, .defaultToSpeaker])
         try session.setActive(true)
         observeAudioChanges()
     }

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -9,6 +9,8 @@ const RUST_PATH = /^(?:src-tauri\/|Cargo\.(?:toml|lock)$|rust-toolchain)/;
 const ROOT_RUNTIME_PATH = /^[^/]+\.(?:[cm]?[jt]s|tsx?)$/;
 const E2E_PATH =
   /^(?:src\/(?:app|components|lib|styles)\/|tests\/|server\.(?:mjs|ts)$|playwright\.config|package\.json$|pnpm-lock\.yaml$)/;
+const IOS_PATH =
+  /^(?:apps\/ios\/|scripts\/(?:ios-xcodegen\.sh|build-ios-(?:markdown|terminal)\.mjs|ci-paths(?:\.test)?\.mjs)$|package\.json$|pnpm-lock\.yaml$|\.github\/workflows\/ci\.yml$)/;
 
 export function classifyCiPaths(paths) {
   const normalized = paths
@@ -18,6 +20,7 @@ export function classifyCiPaths(paths) {
     frontend: normalized.some((file) => FRONTEND_PATH.test(file) || ROOT_RUNTIME_PATH.test(file)),
     rust: normalized.some((file) => RUST_PATH.test(file)),
     e2e: normalized.some((file) => E2E_PATH.test(file) || ROOT_RUNTIME_PATH.test(file)),
+    ios: normalized.some((file) => IOS_PATH.test(file)),
   };
 }
 
@@ -47,7 +50,7 @@ function main() {
   const paths = changedPaths(base, head);
   const result = paths
     ? classifyCiPaths(paths)
-    : { frontend: true, rust: true, e2e: true };
+    : { frontend: true, rust: true, e2e: true, ios: true };
   for (const [name, enabled] of Object.entries(result)) {
     process.stdout.write(`${name}=${enabled}\n`);
   }

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -8,6 +8,7 @@ test("documentation-only changes run only the baseline CI contract", () => {
     frontend: false,
     rust: false,
     e2e: false,
+    ios: false,
   });
 });
 
@@ -16,8 +17,10 @@ test("workflow and script changes run frontend validation", () => {
     frontend: true,
     rust: false,
     e2e: false,
+    ios: true,
   });
   assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).frontend, true);
+  assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).ios, false);
 });
 
 test("Rust-only changes avoid frontend and E2E work", () => {
@@ -25,6 +28,7 @@ test("Rust-only changes avoid frontend and E2E work", () => {
     frontend: false,
     rust: true,
     e2e: false,
+    ios: false,
   });
 });
 
@@ -33,6 +37,7 @@ test("user-facing frontend changes include E2E", () => {
     frontend: true,
     rust: false,
     e2e: true,
+    ios: false,
   });
 });
 
@@ -41,6 +46,7 @@ test("shared dependency changes exercise every relevant web gate", () => {
     frontend: true,
     rust: true,
     e2e: true,
+    ios: true,
   });
 });
 
@@ -49,5 +55,23 @@ test("root runtime hooks receive frontend and end-to-end validation", () => {
     frontend: true,
     rust: false,
     e2e: true,
+    ios: false,
   });
+});
+
+test("iOS sources and generators request the macOS build", () => {
+  assert.deepEqual(classifyCiPaths(["apps/ios/CovenCave/CovenCave/State/AppModel.swift"]), {
+    frontend: false,
+    rust: false,
+    e2e: false,
+    ios: true,
+  });
+  for (const path of [
+    "scripts/ios-xcodegen.sh",
+    "scripts/build-ios-markdown.mjs",
+    "scripts/build-ios-terminal.mjs",
+    "scripts/ci-paths.mjs",
+  ]) {
+    assert.equal(classifyCiPaths([path]).ios, true, path);
+  }
 });

--- a/scripts/ci-recovery-workflow.test.mjs
+++ b/scripts/ci-recovery-workflow.test.mjs
@@ -38,10 +38,12 @@ const ciSource = await readFile(new URL("../.github/workflows/ci.yml", import.me
 const ciWorkflow = parse(ciSource);
 assert.deepEqual(
   Object.keys(ciWorkflow.jobs),
-  ["build"],
-  "routine CI must keep exactly one always-reporting required job",
+  ["paths", "ios", "build"],
+  "routine CI classifies once, runs path-aware iOS validation, then reports through the required job",
 );
 assert.equal(ciWorkflow.jobs.build.name, "Frontend build");
+assert.deepEqual(ciWorkflow.jobs.build.needs, ["paths", "ios"]);
+assert.equal(ciWorkflow.jobs.ios.name, "iOS build");
 assert.equal(
   ciWorkflow["run-name"],
   "CI ${{ github.event_name }} ${{ inputs.expected_sha || github.sha }}",
@@ -61,13 +63,35 @@ assert.equal(
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}",
   "late pull_request delivery and its recovery dispatch must share one concurrency key",
 );
-for (const jobName of ["build"]) {
+const expectedJobGuards = {
+  paths: "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",
+  ios:
+    "needs.paths.outputs.ios == 'true' && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
+  build:
+    "always() && (github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha)",
+};
+for (const [jobName, guard] of Object.entries(expectedJobGuards)) {
   assert.equal(
     ciWorkflow.jobs[jobName].if,
-    "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha",
+    guard,
     `${jobName} must not run a recovery dispatch after the branch head moves`,
   );
 }
+assert.equal(
+  ciWorkflow.jobs.ios.steps.some((step) => step.run === "bash scripts/ios-xcodegen.sh"),
+  true,
+  "PR iOS validation uses the canonical generator",
+);
+assert.equal(
+  ciWorkflow.jobs.ios.steps.some((step) => step.run?.startsWith("xcodebuild ")),
+  true,
+  "PR iOS validation compiles the app without signing",
+);
+const prerequisite = ciWorkflow.jobs.build.steps.find(
+  (step) => step.name === "Require selected validation",
+);
+assert.ok(prerequisite, "the required Frontend build aggregates prerequisite job results");
+assert.match(prerequisite.run, /test "\$IOS_RESULT" = "success"/);
 
 const releaseSource = await readFile(
   new URL("../.github/workflows/release.yml", import.meta.url),

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -11,7 +11,11 @@ const EXPECTED_CONCURRENCY_GROUP =
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}";
 const EXPECTED_JOB_GUARD =
   "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha";
-const GUARDED_JOB_NAMES = ["build"];
+const EXPECTED_JOB_GUARDS = {
+  paths: EXPECTED_JOB_GUARD,
+  ios: `needs.paths.outputs.ios == 'true' && (${EXPECTED_JOB_GUARD})`,
+  build: `always() && (${EXPECTED_JOB_GUARD})`,
+};
 
 export async function runCiRecovery({
   apply = false,
@@ -280,7 +284,9 @@ async function workflowSupportsExpectedSha(context, sha) {
     hasCompleteExpectedInput &&
     workflow["run-name"] === EXPECTED_RUN_NAME &&
     workflow?.concurrency?.group === EXPECTED_CONCURRENCY_GROUP &&
-    GUARDED_JOB_NAMES.every((name) => workflow?.jobs?.[name]?.if === EXPECTED_JOB_GUARD);
+    Object.entries(EXPECTED_JOB_GUARDS).every(
+      ([name, guard]) => workflow?.jobs?.[name]?.if === guard,
+    );
   if (hasCompleteGuardedContract) return true;
 
   const hasGuardedProtocolMarker =

--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -287,7 +287,14 @@ async function workflowSupportsExpectedSha(context, sha) {
     Object.entries(EXPECTED_JOB_GUARDS).every(
       ([name, guard]) => workflow?.jobs?.[name]?.if === guard,
     );
-  if (hasCompleteGuardedContract) return true;
+  const hasPreviousGuardedContract =
+    hasCompleteExpectedInput &&
+    workflow["run-name"] === EXPECTED_RUN_NAME &&
+    workflow?.concurrency?.group === EXPECTED_CONCURRENCY_GROUP &&
+    workflow?.jobs?.build?.if === EXPECTED_JOB_GUARD &&
+    !Object.hasOwn(workflow?.jobs ?? {}, "paths") &&
+    !Object.hasOwn(workflow?.jobs ?? {}, "ios");
+  if (hasCompleteGuardedContract || hasPreviousGuardedContract) return true;
 
   const hasGuardedProtocolMarker =
     hasExpectedInput || JSON.stringify(workflow).includes("inputs.expected_sha");

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -68,7 +68,11 @@ const GUARDED_CONCURRENCY =
   "ci-${{ github.event.pull_request.head.sha || inputs.expected_sha || github.sha }}";
 const GUARDED_JOB_IF =
   "github.event_name != 'workflow_dispatch' || github.sha == inputs.expected_sha";
-const GUARDED_JOB_NAMES = ["build"];
+const GUARDED_JOB_IFS = {
+  paths: GUARDED_JOB_IF,
+  ios: `needs.paths.outputs.ios == 'true' && (${GUARDED_JOB_IF})`,
+  build: `always() && (${GUARDED_JOB_IF})`,
+};
 const GUARDED_CI_WORKFLOW = [
   "name: CI",
   `run-name: ${GUARDED_RUN_NAME}`,
@@ -81,9 +85,9 @@ const GUARDED_CI_WORKFLOW = [
   "concurrency:",
   `  group: ${GUARDED_CONCURRENCY}`,
   "jobs:",
-  ...GUARDED_JOB_NAMES.flatMap((name) => [
+  ...Object.entries(GUARDED_JOB_IFS).flatMap(([name, condition]) => [
     `  ${name}:`,
-    `    if: ${GUARDED_JOB_IF}`,
+    `    if: ${condition}`,
   ]),
   "",
 ].join("\n");
@@ -244,7 +248,7 @@ test("apply fails closed when the required job lacks the expected SHA guard", as
     pulls: [pr],
     workflowsBySha: {
       [pr.head.sha]: GUARDED_CI_WORKFLOW.replace(
-        `  build:\n    if: ${GUARDED_JOB_IF}`,
+        `  build:\n    if: ${GUARDED_JOB_IFS.build}`,
         "  build:\n    if: success()",
       ),
     },

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -91,6 +91,22 @@ const GUARDED_CI_WORKFLOW = [
   ]),
   "",
 ].join("\n");
+const PREVIOUS_GUARDED_CI_WORKFLOW = [
+  "name: CI",
+  `run-name: ${GUARDED_RUN_NAME}`,
+  "on:",
+  "  workflow_dispatch:",
+  "    inputs:",
+  "      expected_sha:",
+  "        required: true",
+  "        type: string",
+  "concurrency:",
+  `  group: ${GUARDED_CONCURRENCY}`,
+  "jobs:",
+  "  build:",
+  `    if: ${GUARDED_JOB_IF}`,
+  "",
+].join("\n");
 
 function githubFixture({ pulls, runsBySha = {}, jobsByRun = {}, workflowsBySha = {} }) {
   const requests = [];
@@ -178,6 +194,30 @@ test("report-only mode identifies an aged PR with no CI run without dispatching"
 test("apply dispatches one fresh CI run for a qualifying same-repository head", async () => {
   const pr = pull();
   const fixture = githubFixture({ pulls: [pr] });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, true));
+
+  assert.equal(result.recoveries[0].dispatched, true);
+  assert.deepEqual(
+    fixture.requests.filter((request) => request.method === "POST"),
+    [
+      {
+        method: "POST",
+        path: `/repos/${REPOSITORY}/actions/workflows/ci.yml/dispatches`,
+        body: { ref: pr.head.ref, inputs: { expected_sha: pr.head.sha } },
+      },
+    ],
+  );
+});
+
+test("apply preserves expected_sha for the previous complete guarded workflow", async () => {
+  const pr = pull();
+  const fixture = githubFixture({
+    pulls: [pr],
+    workflowsBySha: {
+      [pr.head.sha]: PREVIOUS_GUARDED_CI_WORKFLOW,
+    },
+  });
 
   const result = await runCiRecovery(options(fixture.fetchImpl, true));
 


### PR DESCRIPTION
## Summary
- classify iOS-affecting paths in the shared CI selector
- compile the generated Xcode project on macOS only when iOS inputs change
- aggregate the iOS result into the existing required `Frontend build` check
- preserve exact-head recovery guards across all CI jobs
- keep Bluetooth HFP configuration source-compatible with the Xcode 16 release runner and Xcode 26 development toolchains

The first PR run immediately exposed an existing release compile failure: Xcode 16 does not define the Xcode-26 spelling `.allowBluetoothHFP`. The compatibility branch preserves the same HFP option on both compiler generations.

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm test:mobile`
- `pnpm check:tests-wired`
- `node --test scripts/ci-paths.test.mjs scripts/ci-recovery.test.mjs scripts/ci-recovery-workflow.test.mjs`
- `bash scripts/ios-xcodegen.sh`
- unsigned generic-device `xcodebuild`

Bead: `cave-h4xbd`