### PR TITLE
fix(ci): recover a cancelled run that is the newest for a static head

### DIFF
--- a/scripts/ci-recovery.mjs
+++ b/scripts/ci-recovery.mjs
@@ -172,15 +172,21 @@ async function getPull(context, number) {
  */
 const APPROVAL_GATED = "action_required";
 
+/** A run GitHub stopped before it reported a verdict. */
+const CANCELLED = "cancelled";
+
 /**
  * Whether a run counts as CI having actually covered this head.
  *
- * Deliberately narrow. A FAILED run is coverage — it reported a verdict. A
- * `cancelled` run is normally superseded by a newer push that has its own run,
- * and recovering it would fight that. `startup_failure` genuinely produced no
- * coverage, but re-dispatching a workflow that cannot start would just loop, so
- * it is left to a human. Only the approval gate is both no-coverage AND fixed
- * by a fresh dispatch.
+ * Deliberately narrow. A FAILED run is coverage — it reported a verdict.
+ * `startup_failure` genuinely produced no coverage, but re-dispatching a
+ * workflow that cannot start would just loop, so it is left to a human.
+ *
+ * `cancelled` is judged by POSITION rather than here, in {@link decideRecovery}:
+ * a cancelled run underneath a newer one was superseded and is nobody's
+ * problem, while a cancelled run that is the newest for a static head is a
+ * wedge (cave-geaji). This predicate cannot see position, so it deliberately
+ * does not try to answer that.
  */
 function isCoverage(run) {
   if (run.status === "in_progress") return true;
@@ -198,6 +204,28 @@ async function decideRecovery(context, runs, now) {
   );
   if (recentRecovery) return { recover: false, reason: "recovery_cooldown" };
 
+  // `runs` is fetched filtered by head_sha and sorted newest-first, so runs[0]
+  // is the newest run for THIS exact head.
+  const latest = runs[0];
+
+  // A cancelled run is normally superseded by a newer push that carries its own
+  // run — which is why cave-qshvl classified `cancelled` as coverage. That
+  // holds right up until the cancelled run is the NEWEST one for a head that
+  // has not moved: nothing is coming to replace it, the required context
+  // reports `cancelled` rather than `success` forever, and the pull request is
+  // wedged with no path to green.
+  //
+  // Checked against the LATEST run rather than "every run is cancelled",
+  // because GitHub's rollup shows the most recent check-run per name. An older
+  // success underneath a newer cancellation does not unblock the PR, so it must
+  // not suppress recovery either.
+  //
+  // Observed on #4514: head 02f74118ff carried exactly one run, cancelled, and
+  // `pnpm ci:recovery` reported it as covered and declined to help (cave-geaji).
+  if (latest.status === "completed" && latest.conclusion === CANCELLED) {
+    return { recover: true, reason: "cancelled_latest_run" };
+  }
+
   if (runs.some(isCoverage)) {
     return { recover: false, reason: "ci_present" };
   }
@@ -209,7 +237,6 @@ async function decideRecovery(context, runs, now) {
     return { recover: true, reason: "approval_gated_run" };
   }
 
-  const latest = runs[0];
   if (latest.status !== "queued") return { recover: false, reason: "ci_present" };
   if (latest.createdAt > now - RECOVERY_GRACE_MS) {
     return { recover: false, reason: "ci_queued" };

--- a/scripts/ci-recovery.test.mjs
+++ b/scripts/ci-recovery.test.mjs
@@ -559,7 +559,11 @@ test("a completed run that actually ran is still coverage, including a failure",
   // The fix must not turn every completed run into a recovery candidate. A
   // FAILED run reported a verdict, so CI covered this head and re-dispatching
   // would just re-run a known failure.
-  for (const conclusion of ["success", "failure", "cancelled", "timed_out"]) {
+  //
+  // `cancelled` is deliberately NOT in this list — see the two tests below. It
+  // was here originally (cave-qshvl) on the reasoning that a newer push
+  // supersedes it, which is true only when a newer run actually exists.
+  for (const conclusion of ["success", "failure", "timed_out"]) {
     const pr = pull();
     const ran = workflowRun({ id: 9200, status: "completed", conclusion, headSha: pr.head.sha });
     const fixture = githubFixture({ pulls: [pr], runsBySha: { [pr.head.sha]: [ran] } });
@@ -572,6 +576,63 @@ test("a completed run that actually ran is still coverage, including a failure",
       `conclusion=${conclusion} is coverage and must not be recovered`,
     );
   }
+});
+
+test("a cancelled run that is the NEWEST for a static head is recovered", async () => {
+  // The wedge cave-geaji fixes. Nothing is coming to replace this run: the head
+  // has not moved, so the required context reports `cancelled` rather than
+  // `success` forever and the PR has no path to green.
+  //
+  // Live case: #4514 head 02f74118ff carried exactly one run, cancelled, and
+  // `pnpm ci:recovery` reported "0 eligible" while the PR sat blocked.
+  const pr = pull();
+  const cancelled = workflowRun({
+    id: 9300,
+    status: "completed",
+    conclusion: "cancelled",
+    headSha: pr.head.sha,
+  });
+  const fixture = githubFixture({ pulls: [pr], runsBySha: { [pr.head.sha]: [cancelled] } });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+  assert.equal(result.recoveries.length, 1, "a cancelled newest run must be recoverable");
+  assert.equal(result.recoveries[0].reason, "cancelled_latest_run");
+});
+
+test("a cancelled run underneath a NEWER run is left alone", async () => {
+  // The case the original reasoning describes and gets right: something newer
+  // is already running for this head, so the cancellation was a supersession
+  // and dispatching again would fight it.
+  const pr = pull();
+  const cancelled = workflowRun({
+    id: 9400,
+    status: "completed",
+    conclusion: "cancelled",
+    headSha: pr.head.sha,
+    // Both NOW-relative and outside the grace window, so this exercises the
+    // supersession rule rather than incidentally landing in `ci_queued`.
+    createdAt: new Date(NOW - RECOVERY_GRACE_MS - 2_000).toISOString(),
+  });
+  const newer = workflowRun({
+    id: 9401,
+    status: "in_progress",
+    conclusion: null,
+    headSha: pr.head.sha,
+    createdAt: new Date(NOW - RECOVERY_GRACE_MS - 1_000).toISOString(),
+  });
+  const fixture = githubFixture({
+    pulls: [pr],
+    runsBySha: { [pr.head.sha]: [cancelled, newer] },
+  });
+
+  const result = await runCiRecovery(options(fixture.fetchImpl, false));
+
+  assert.deepEqual(
+    result.recoveries,
+    [],
+    "a superseded cancellation must not trigger a redundant dispatch",
+  );
 });
 
 test("one real run alongside an approval-gated one still counts as coverage", async () => {


### PR DESCRIPTION
Follow-up to #4505, which I merged earlier today. It got the approval gate
right and one adjacent case wrong.

## The gap

#4505 classified `cancelled` as coverage:

> A `cancelled` run is normally superseded by a newer push that has its own
> run, and recovering it would fight that.

True in the common case. False when the cancelled run is the **newest** for a
head that has not moved — nothing is coming to replace it, the required context
reports `cancelled` rather than `success` forever, and the PR is wedged with no
path to green. Which is exactly the state ci-recovery exists to clear.

## Observed live

PR #4514, head `02f74118ff`: exactly one CI run, `cancelled`, head static.

```
$ pnpm ci:recovery
CI recovery: 5 open PRs scanned; 0 eligible.
```

Blocked, with no local remedy — `gh run rerun` needs admin rights, and recovery
declined because it believed the head was covered. Its owner eventually had to
push a bump.

## The fix

Judge the **latest** run, not "every run is cancelled". GitHub's rollup shows
the most recent check-run per name, so an older success underneath a newer
cancellation does not unblock the PR and must not suppress recovery either.

`cancelled` moves out of `isCoverage` entirely. That predicate cannot see a
run's position among its siblings, and position is the whole question; it now
documents that rather than pretending to answer it.

Existing exclusions unchanged:

- a **failure** is still coverage — it reported a verdict;
- a **startup_failure** is still left to a human, since re-dispatching a
  workflow that cannot start would loop.

## Tests

`cancelled` drops out of the still-coverage list, and two new cases pin both
directions:

- cancelled-and-newest → recovers, reason `cancelled_latest_run`;
- cancelled-underneath-a-newer-run → left alone.

22 pass, plus the workflow contract test and 1611 files wired.

Also verified against live GitHub: the scan now correctly returns **0 eligible**,
because #4514's owner pushed a new head whose run is in progress. The unit tests
are what pin the wedge itself.

Closes cave-geaji.