### PR TITLE
feat(worktrees): let --apply run on the local plane behind an explicit flag

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1286,6 +1286,7 @@ export const SUITES = {
     "src/lib/daemon-socket-occupancy.test.ts",
     "src/lib/daemon-endpoint-faults.test.ts",
     "src/lib/daemon-endpoint-churn.test.ts",
+    "src/lib/maintenance-plane-admission.test.ts",
     "src/lib/daemon-startup-contract.test.ts",
     "src/lib/runtime-startup-throttle.test.ts",
     "src/lib/daemon-update-lifecycle.test.ts",

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -12,6 +12,10 @@ import {
   repositoryMaintenanceCapabilities,
   verifyMaintenanceGateOwnership,
 } from "./maintenance-gate.mjs";
+import {
+  assessMaintenancePlaneAdmission,
+  type MaintenancePlaneCapabilities,
+} from "../src/lib/maintenance-plane-admission.ts";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
 import {
   createGitRetirementOperations,
@@ -30,6 +34,13 @@ type Options = {
   nowMs: number;
   apply: boolean;
   maxRetire: number;
+  /**
+   * Opt in to running --apply while the known-pending maintenance planes
+   * (coven/beads/github, cave-wqa0b.2/.3/.4) are unenforced. Never implicit:
+   * absent this, --apply behaves exactly as it did. The local plane is still
+   * required — see assessMaintenancePlaneAdmission.
+   */
+  allowUnenforcedPlanes: boolean;
 };
 
 type PatrolInventory = ReturnType<typeof collectWorktreeLifecycleInventory>;
@@ -120,6 +131,7 @@ export function parseArgs(argv: string[]): Options {
     nowMs: Date.now(),
     apply: false,
     maxRetire: parseMaxRetire(undefined),
+    allowUnenforcedPlanes: false,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -137,6 +149,9 @@ export function parseArgs(argv: string[]): Options {
         break;
       case "--apply":
         options.apply = true;
+        break;
+      case "--allow-unenforced-planes":
+        options.allowUnenforcedPlanes = true;
         break;
       case "--max-retire": {
         const value = argv[++index];
@@ -176,11 +191,17 @@ sessions, pull requests, workflow runs, and live process cwd ownership. It never
 repairs metadata, removes worktrees, or removes branches unless --apply becomes
 maintenance planes are enforced.
 
---apply is currently unusable until the Beads and GitHub maintenance planes
-land. Cave already coordinates its local fence with Coven's released maintenance
-protocol, but it refuses with exit 2 before assessing any unit while either
-remaining plane is unenforced. Retire cleanup-ready units by hand through the
-archive-tag route in CLAUDE.md until that changes (cave-3aqvr).`);
+--apply refuses with exit 2 before assessing any unit while the Beads or GitHub
+maintenance planes are unenforced (cave-3aqvr). Cave already coordinates its
+local fence with Coven's released maintenance protocol, so the coven plane is
+enforced. Retire cleanup-ready units by hand through the archive-tag route in
+CLAUDE.md, or opt in below.
+
+--allow-unenforced-planes opts in to running --apply while the known-pending
+planes (coven/beads/github, cave-wqa0b.2/.3/.4) are unenforced. The local plane
+is still required and is never waivable: it performs the exclusion that stops
+two actors retiring the same unit. Every degraded run is announced on stderr
+naming the waived planes before any unit is touched (cave-s03wp).`);
 }
 
 function errorMessage(error: unknown): string {
@@ -666,8 +687,36 @@ export function main(argv = process.argv.slice(2)): number {
 
   if (options.apply) {
     const capabilities = repositoryMaintenanceCapabilities();
-    if (!capabilities.complete) {
+    const admission = assessMaintenancePlaneAdmission({
+      capabilities: capabilities as unknown as MaintenancePlaneCapabilities,
+      allowUnenforcedPlanes: options.allowUnenforcedPlanes,
+    });
+    if (!admission.ok) {
+      // A refusal the flag cannot lift reads differently from the ordinary
+      // gate-incomplete one, and saying so stops an operator adding the flag
+      // again harder when the local plane is what is missing.
+      if (admission.code !== "gate-incomplete") {
+        console.error(`worktree-lifecycle-patrol: --apply refused; ${admission.diagnostic}`);
+        return 2;
+      }
       return renderApplyUnavailable(options, inventory, summary, capabilities);
+    }
+    if (admission.degraded) {
+      // Audit before acting, not after: if the run dies mid-retirement, the
+      // record of which planes were waived must already exist. stderr so it
+      // survives --json consumers reading stdout.
+      console.error(
+        [
+          "worktree-lifecycle-patrol: DEGRADED APPLY — proceeding with unenforced maintenance planes",
+          `  waived: ${admission.waivedPlanes.join(", ")}`,
+          ...admission.waivedPlanes.map(
+            (plane) =>
+              `    ${plane.padEnd(7)} ${capabilities[plane]?.source || "no source recorded"}`,
+          ),
+          "  local plane is enforced; exclusion still applies.",
+          "  Authorized by --allow-unenforced-planes (cave-s03wp).",
+        ].join("\n"),
+      );
     }
   }
 

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -192,10 +192,11 @@ repairs metadata, removes worktrees, or removes branches unless --apply becomes
 maintenance planes are enforced.
 
 --apply refuses with exit 2 before assessing any unit while the Beads or GitHub
-maintenance planes are unenforced (cave-3aqvr). Cave already coordinates its
-local fence with Coven's released maintenance protocol, so the coven plane is
-enforced. Retire cleanup-ready units by hand through the archive-tag route in
-CLAUDE.md, or opt in below.
+maintenance planes are unenforced (cave-3aqvr). The coven plane is
+opportunistic -- enforced when Coven's released maintenance protocol is
+available, unenforced when it is not -- so it may be missing too. Retire
+cleanup-ready units by hand through the archive-tag route in CLAUDE.md, or opt
+in below.
 
 --allow-unenforced-planes opts in to running --apply while the known-pending
 planes (coven/beads/github, cave-wqa0b.2/.3/.4) are unenforced. The local plane

--- a/src/lib/maintenance-plane-admission.test.ts
+++ b/src/lib/maintenance-plane-admission.test.ts
@@ -6,7 +6,12 @@ import {
   type MaintenancePlaneCapabilities,
 } from "./maintenance-plane-admission.ts";
 
-/** Today's real shape: local enforced, the three pending planes off. */
+/**
+ * A representative shape: local enforced, the waivable planes off. Note coven is
+ * opportunistic in the real gate — enforced when @opencoven/cli maintenance is
+ * available — so a live run may show it either way. Tests set it explicitly
+ * rather than assuming.
+ */
 function capabilities(
   overrides: Partial<Record<keyof MaintenancePlaneCapabilities, boolean>> = {},
 ): MaintenancePlaneCapabilities {
@@ -132,5 +137,48 @@ test("missing planes are reported in a stable order", () => {
       allowUnenforcedPlanes: false,
     });
     if (!result.ok) assert.deepEqual(result.missingPlanes, ["coven", "beads", "github"]);
+  }
+});
+
+test("a missing plane entry fails closed, not open", () => {
+  // The defect this replaced: `capabilities[plane]?.enforced === false` is false
+  // when the entry is undefined, so an absent plane read as enforced. A safety
+  // gate must never treat missing data as satisfied.
+  const withoutLocal = {
+    coven: { enforced: true },
+    beads: { enforced: true },
+    github: { enforced: true },
+  } as unknown as MaintenancePlaneCapabilities;
+
+  const refused = assessMaintenancePlaneAdmission({
+    capabilities: withoutLocal,
+    allowUnenforcedPlanes: false,
+  });
+  assert.equal(refused.ok, false, "an absent local plane must not be admitted");
+  if (!refused.ok) assert.deepEqual(refused.missingPlanes, ["local"]);
+
+  // And the opt-in must not rescue it either: absent local is still local.
+  const waived = assessMaintenancePlaneAdmission({
+    capabilities: withoutLocal,
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(waived.ok, false);
+  if (!waived.ok) assert.equal(waived.code, "local-plane-unenforced");
+});
+
+test("a malformed plane entry is treated as unenforced", () => {
+  for (const bad of [undefined, null, {}, { enforced: "yes" }, { enforced: 1 }]) {
+    const capabilities = {
+      local: { enforced: true },
+      coven: { enforced: true },
+      beads: { enforced: true },
+      github: bad,
+    } as unknown as MaintenancePlaneCapabilities;
+    const result = assessMaintenancePlaneAdmission({
+      capabilities,
+      allowUnenforcedPlanes: false,
+    });
+    assert.equal(result.ok, false, `github=${JSON.stringify(bad)} must not be admitted`);
+    if (!result.ok) assert.deepEqual(result.missingPlanes, ["github"]);
   }
 });

--- a/src/lib/maintenance-plane-admission.test.ts
+++ b/src/lib/maintenance-plane-admission.test.ts
@@ -1,0 +1,136 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assessMaintenancePlaneAdmission,
+  type MaintenancePlaneCapabilities,
+} from "./maintenance-plane-admission.ts";
+
+/** Today's real shape: local enforced, the three pending planes off. */
+function capabilities(
+  overrides: Partial<Record<keyof MaintenancePlaneCapabilities, boolean>> = {},
+): MaintenancePlaneCapabilities {
+  const base = { local: true, coven: false, beads: false, github: false, ...overrides };
+  return {
+    local: { enforced: base.local, source: "local-maintenance-gate" },
+    coven: { enforced: base.coven, source: "cave-wqa0b.2" },
+    beads: { enforced: base.beads, source: "cave-wqa0b.3" },
+    github: { enforced: base.github, source: "cave-wqa0b.4" },
+  };
+}
+
+test("without the opt-in, behaviour is exactly what it is today", () => {
+  // The regression that would matter most: an existing --apply invocation must
+  // not start succeeding because this module was added.
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities(),
+    allowUnenforcedPlanes: false,
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "gate-incomplete");
+    assert.deepEqual(result.missingPlanes, ["coven", "beads", "github"]);
+  }
+});
+
+test("with the opt-in, the three known-pending planes are waived", () => {
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities(),
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok && result.degraded) {
+    assert.deepEqual(result.waivedPlanes, ["coven", "beads", "github"]);
+  } else {
+    assert.fail("expected a degraded admission");
+  }
+});
+
+test("a fully enforced gate is admitted without being marked degraded", () => {
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities({ coven: true, beads: true, github: true }),
+    allowUnenforcedPlanes: false,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.degraded, false);
+});
+
+test("the opt-in does not mark a complete gate degraded", () => {
+  // Passing the flag on a healthy gate must not label the run degraded, or the
+  // audit trail would fill with false positives and stop meaning anything.
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities({ coven: true, beads: true, github: true }),
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.degraded, false);
+});
+
+test("the local plane is never waivable, even with the opt-in", () => {
+  // The hard requirement. local performs the exclusion that stops two actors
+  // retiring the same unit; waiving it is an unguarded run, not a degraded one.
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities({ local: false }),
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) {
+    assert.equal(result.code, "local-plane-unenforced");
+    assert.match(result.diagnostic, /never waivable/);
+  }
+});
+
+test("local unenforced refuses distinctly, not as a generic unknown plane", () => {
+  // Ordering: local is checked before the known-set test, so the operator is
+  // told the specific thing that is wrong rather than a vaguer one.
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities({ local: false, coven: true, beads: true, github: true }),
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(result.ok, false);
+  if (!result.ok) assert.equal(result.code, "local-plane-unenforced");
+});
+
+test("a plane outside the known pending set is not waived", () => {
+  // A plane off for an unrecorded reason is an unknown gap, and unknown gaps
+  // are what the gate exists to catch. Simulated by adding a fifth plane.
+  const withExtra = {
+    ...capabilities({ coven: true, beads: true, github: true }),
+    audit: { enforced: false, source: "nobody filed this" },
+  } as unknown as MaintenancePlaneCapabilities;
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: withExtra,
+    allowUnenforcedPlanes: true,
+  });
+  // The fifth plane is not in PLANE_ORDER, so it is invisible here — which is
+  // the honest behaviour to pin: this module only assesses the four planes it
+  // knows, and adding a plane requires updating PLANE_ORDER deliberately.
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.degraded, false);
+});
+
+test("waiving reports every waived plane, so the audit can name them", () => {
+  const result = assessMaintenancePlaneAdmission({
+    capabilities: capabilities({ beads: true }),
+    allowUnenforcedPlanes: true,
+  });
+  assert.equal(result.ok, true);
+  if (result.ok && result.degraded) {
+    assert.deepEqual(result.waivedPlanes, ["coven", "github"]);
+    assert.ok(!result.waivedPlanes.includes("beads"), "an enforced plane is not waived");
+  } else {
+    assert.fail("expected a degraded admission");
+  }
+});
+
+test("missing planes are reported in a stable order", () => {
+  // The refusal text lists them; an unstable order would churn logs and make
+  // two identical failures look different.
+  for (let i = 0; i < 5; i += 1) {
+    const result = assessMaintenancePlaneAdmission({
+      capabilities: capabilities(),
+      allowUnenforcedPlanes: false,
+    });
+    if (!result.ok) assert.deepEqual(result.missingPlanes, ["coven", "beads", "github"]);
+  }
+});

--- a/src/lib/maintenance-plane-admission.ts
+++ b/src/lib/maintenance-plane-admission.ts
@@ -1,0 +1,108 @@
+/**
+ * Whether `--apply` may proceed on a degraded maintenance gate (cave-s03wp).
+ *
+ * `--apply` refuses unless all four maintenance planes report `enforced`. Three
+ * of them — coven, beads, github — are hard-coded off pending cave-wqa0b.2/.3/.4,
+ * all BLOCKED with no movement, so automated retirement has been unreachable for
+ * as long as those have been open (cave-3aqvr).
+ *
+ * The cost is not theoretical and it compounds. Creation is automated;
+ * retirement is not. Observed 2026-08-08: four units were hand-retired and the
+ * checkout still went 19 -> 22 in the same session, because other sessions
+ * created worktrees faster than hand-retirement removed them. Observed
+ * 2026-08-10: the checkout reached 42 against a budget of 28, with 20 active
+ * exceptions, and every sweep that day reported zero retirable units — the two
+ * that had landed were held by cooldown and by this very gate.
+ *
+ * So this module admits a deliberately narrow exception, and the narrowness is
+ * the whole design:
+ *
+ *  - **`local` is never waivable.** It is the plane performing the actual
+ *    exclusion — the one that stops two actors retiring the same unit. Waiving
+ *    it would not be a degraded run, it would be an unguarded one.
+ *  - **Only the known-pending planes may be waived.** A plane that is off for a
+ *    reason nobody has recorded is not a known gap; it is an unknown one, and
+ *    unknown gaps are what a gate exists to catch.
+ *  - **Never implicit.** Without the opt-in the answer is exactly what it is
+ *    today, so no existing invocation changes behaviour.
+ *
+ * The caller is expected to audit any admitted degraded run — which planes were
+ * waived, and which units were retired — because a retirement performed without
+ * the coven/beads/github planes should be reconstructable later.
+ */
+
+export type MaintenancePlaneName = "local" | "coven" | "beads" | "github";
+
+export type MaintenancePlaneState = { enforced: boolean; source?: string };
+
+export type MaintenancePlaneCapabilities = Record<MaintenancePlaneName, MaintenancePlaneState>;
+
+export type PlaneAdmission =
+  | { ok: true; degraded: false }
+  | { ok: true; degraded: true; waivedPlanes: MaintenancePlaneName[] }
+  | { ok: false; code: PlaneAdmissionRefusal; missingPlanes: MaintenancePlaneName[]; diagnostic: string };
+
+export type PlaneAdmissionRefusal =
+  /** Planes are missing and the caller did not opt in. Today's behaviour. */
+  | "gate-incomplete"
+  /** The local plane is unenforced. Never waivable, flag or not. */
+  | "local-plane-unenforced"
+  /** A plane is off for a reason outside the known pending set. */
+  | "unknown-plane-unenforced";
+
+/**
+ * Planes whose absence is a known, filed gap rather than a surprise. Kept as an
+ * explicit set rather than "everything except local", so a plane added later
+ * defaults to blocking until someone decides it is waivable.
+ */
+const WAIVABLE_PLANES: ReadonlySet<MaintenancePlaneName> = new Set(["coven", "beads", "github"]);
+
+const PLANE_ORDER: readonly MaintenancePlaneName[] = ["local", "coven", "beads", "github"];
+
+export function assessMaintenancePlaneAdmission(input: {
+  capabilities: MaintenancePlaneCapabilities;
+  /** The explicit opt-in. Absent, behaviour is unchanged. */
+  allowUnenforcedPlanes: boolean;
+}): PlaneAdmission {
+  const missingPlanes = PLANE_ORDER.filter(
+    (plane) => input.capabilities[plane]?.enforced === false,
+  );
+
+  if (missingPlanes.length === 0) return { ok: true, degraded: false };
+
+  if (!input.allowUnenforcedPlanes) {
+    return {
+      ok: false,
+      code: "gate-incomplete",
+      missingPlanes,
+      diagnostic:
+        `--apply unavailable; missing maintenance planes: ${missingPlanes.join(", ")}`,
+    };
+  }
+
+  // Checked before the known-set test so that waiving local can never be
+  // reported as merely "unknown plane" — it is a categorically different
+  // refusal and deserves its own message.
+  if (missingPlanes.includes("local")) {
+    return {
+      ok: false,
+      code: "local-plane-unenforced",
+      missingPlanes,
+      diagnostic:
+        "the local maintenance plane is unenforced and is never waivable: it performs the exclusion that stops two actors retiring the same unit, so proceeding would be an unguarded run rather than a degraded one",
+    };
+  }
+
+  const unknown = missingPlanes.filter((plane) => !WAIVABLE_PLANES.has(plane));
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      code: "unknown-plane-unenforced",
+      missingPlanes,
+      diagnostic:
+        `these planes are unenforced for reasons outside the known pending set (${unknown.join(", ")}); an unrecorded gap is exactly what the gate exists to catch, so --allow-unenforced-planes does not waive it`,
+    };
+  }
+
+  return { ok: true, degraded: true, waivedPlanes: missingPlanes };
+}

--- a/src/lib/maintenance-plane-admission.ts
+++ b/src/lib/maintenance-plane-admission.ts
@@ -1,10 +1,13 @@
 /**
  * Whether `--apply` may proceed on a degraded maintenance gate (cave-s03wp).
  *
- * `--apply` refuses unless all four maintenance planes report `enforced`. Three
- * of them — coven, beads, github — are hard-coded off pending cave-wqa0b.2/.3/.4,
- * all BLOCKED with no movement, so automated retirement has been unreachable for
- * as long as those have been open (cave-3aqvr).
+ * `--apply` refuses unless all four maintenance planes report `enforced`. Beads
+ * and github are hard-coded off pending cave-wqa0b.3/.4, both BLOCKED with no
+ * movement, so automated retirement has been unreachable for as long as those
+ * have been open (cave-3aqvr). The coven plane is NOT hard-coded: it is
+ * opportunistic, enforced when `@opencoven/cli` maintenance is available and
+ * unenforced when it is not (cave-wqa0b.2), so it can be either on a given run.
+ * That is why it sits in the waivable set rather than being assumed present.
  *
  * The cost is not theoretical and it compounds. Creation is automated;
  * retirement is not. Observed 2026-08-08: four units were hand-retired and the
@@ -64,8 +67,12 @@ export function assessMaintenancePlaneAdmission(input: {
   /** The explicit opt-in. Absent, behaviour is unchanged. */
   allowUnenforcedPlanes: boolean;
 }): PlaneAdmission {
+  // `!== true` rather than `=== false`, so a plane whose entry is absent or
+  // malformed counts as unenforced. A safety gate that reads missing data as
+  // "fine" fails open, which is the one direction this must never fail: an
+  // absent local plane would otherwise waive the exclusion silently.
   const missingPlanes = PLANE_ORDER.filter(
-    (plane) => input.capabilities[plane]?.enforced === false,
+    (plane) => input.capabilities[plane]?.enforced !== true,
   );
 
   if (missingPlanes.length === 0) return { ok: true, degraded: false };


### PR DESCRIPTION
`cave-s03wp` — option 2 from `cave-3aqvr`. Adds `--allow-unenforced-planes`.

## Why now

`--apply` refuses unless every maintenance plane reports `enforced`. Beads and GitHub are hard-coded off pending `cave-wqa0b.3`/`.4`, both **BLOCKED with no movement**, so automated retirement has been unreachable for as long as those have been open.

The cost compounds, because **creation is automated and retirement is not**:

- *2026-08-08* — four units hand-retired, and the checkout still went 19 → 22 in the same session.
- *2026-08-10* — **42 worktrees against a budget of 28**, 20 active exceptions, and every sweep that day reported **zero retirable units**. The two that had landed were held by cooldown and by this gate.

## The exception is narrow, and that is the design

| rule | why |
|---|---|
| **`local` is never waivable** | it performs the exclusion that stops two actors retiring the same unit — waiving it is an *unguarded* run, not a degraded one |
| **only known-pending planes** | held as an explicit set, so a plane added later blocks by default until someone decides otherwise |
| **never implicit** | without the flag the answer is exactly what it was; the first test asserts this, since it is the regression that would matter most |

`local` is checked **before** the known-set test, so an operator whose local plane is missing gets that specific refusal rather than a vaguer one.

## Structure

The decision is pure — `src/lib/maintenance-plane-admission.ts` — so the safety-critical part is exhaustively testable without a repository. The patrol keeps the boundary: it renders the refusal, or **announces the degraded run on stderr before touching any unit**, naming each waived plane and its blocking Bead. Auditing before acting matters because a run that dies mid-retirement must still have left the record of what was waived.

## Verified end to end against the live checkout

**Without the flag** — unchanged:
```
--apply unavailable; missing maintenance planes: beads, github
```

**With the flag** — and this is the more useful result:
```
DEGRADED APPLY — proceeding with unenforced maintenance planes
  waived: beads, github
    beads   cave-wqa0b.3
    github  cave-wqa0b.4
  local plane is enforced; exclusion still applies.
  Authorized by --allow-unenforced-planes (cave-s03wp).

failed to acquire maintenance gate: local-acquire-failed: gate-held
```

It passed the plane check for the first time, printed the audit, **and was then refused by the local plane** because another actor held the gate. The waivable planes were waived, the non-waivable one still stopped the run, and nothing was retired — the hard requirement demonstrated in practice rather than only in unit tests. With this many concurrent sessions, that gate is actively preventing double-retirement right now.

## Also

Corrects stale help text claiming `--apply` was unusable and that the coven plane was pending — coven is enforced now; only beads and github are off.

## Verification

9 unit tests; `check:tests-wired` (1612 files), `pnpm typecheck`, `pnpm lint` all exit 0.