### PR TITLE
fix(worktree): renew the maintenance fence while the lifecycle inventory runs

### DIFF
--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -33,11 +33,18 @@ export {
 /**
  * How often a long fenced READ should renew its lease.
  *
- * A quarter of the shorter lease (Coven's, below), so one renewal can fail and
- * the next still land before expiry. This exists because a fenced read can
- * outlive its lease: the worktree lifecycle inventory measured 120.8s and 149s
- * on a 39-worktree checkout against a 120s Coven lease, and nothing renewed it
- * while it ran (cave-cs9g1).
+ * Exists because a fenced read can outlive its lease: the worktree lifecycle
+ * inventory measured 120.8s and 149s on a 39-worktree checkout against a 120s
+ * Coven lease, and nothing renewed it while it ran (cave-cs9g1).
+ *
+ * A quarter of the shorter lease (Coven's, below). The headroom is NOT there to
+ * survive a failed renewal — renewal is fail-closed, so a failure aborts the
+ * read rather than waiting for a next attempt. It is there because renewal
+ * fires on progress, not on a clock: the hook is only reached between external
+ * commands, and a single command can itself run for tens of seconds (`command`
+ * in the inventory defaults to a 30s timeout, and some calls allow longer). So
+ * the true interval between renewals is 30s plus however long the command that
+ * crosses the boundary takes, and the lease has to tolerate that overshoot.
  */
 export const FENCE_RENEWAL_INTERVAL_MS = 30_000;
 
@@ -55,8 +62,12 @@ export const FENCE_RENEWAL_INTERVAL_MS = 30_000;
  * work, which is what actually got slower as the checkout grew.
  *
  * The first call after construction is always throttled — the lease was just
- * taken or renewed, so there is nothing to renew yet. Errors from `renew`
- * propagate; a caller that has lost its fence should stop.
+ * taken or renewed, so there is nothing to renew yet.
+ *
+ * Fail-closed: errors from `renew` propagate and are expected to abort the
+ * work. There is deliberately no retry or swallow here, because the only
+ * reason renewal fails is that the fence is gone, and work that continues past
+ * that point is no longer excluding the writers it believes it is.
  */
 export function createFenceRenewal(
   renew,

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -30,6 +30,51 @@ export {
   releaseWriterIntent,
 };
 
+/**
+ * How often a long fenced READ should renew its lease.
+ *
+ * A quarter of the shorter lease (Coven's, below), so one renewal can fail and
+ * the next still land before expiry. This exists because a fenced read can
+ * outlive its lease: the worktree lifecycle inventory measured 120.8s and 149s
+ * on a 39-worktree checkout against a 120s Coven lease, and nothing renewed it
+ * while it ran (cave-cs9g1).
+ */
+export const FENCE_RENEWAL_INTERVAL_MS = 30_000;
+
+/**
+ * Wrap a renew function so it runs at most once per interval.
+ *
+ * Intended for work that reports progress far more often than a lease needs
+ * renewing — the inventory calls its hook once per external command, hundreds
+ * of times — where renewing on every call would spawn a fence process per
+ * command.
+ *
+ * Renewal is driven by progress rather than a timer on purpose: the callers
+ * that need this are synchronous, so they never yield and no timer callback
+ * would ever run. Anchoring to progress also means renewal scales with the
+ * work, which is what actually got slower as the checkout grew.
+ *
+ * The first call after construction is always throttled — the lease was just
+ * taken or renewed, so there is nothing to renew yet. Errors from `renew`
+ * propagate; a caller that has lost its fence should stop.
+ */
+export function createFenceRenewal(
+  renew,
+  { intervalMs = FENCE_RENEWAL_INTERVAL_MS, now = () => Date.now() } = {},
+) {
+  if (typeof renew !== "function") throw new TypeError("renew must be a function");
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    throw new RangeError("intervalMs must be a positive finite number");
+  }
+  let last = now();
+  return () => {
+    const current = now();
+    if (current - last < intervalMs) return;
+    last = current;
+    renew();
+  };
+}
+
 export const COVEN_MAINTENANCE_MINIMUM_VERSION = "0.2.5";
 export const DEFAULT_COVEN_DRAIN_TIMEOUT_MS = 30_000;
 export const COVEN_OWNER_LEASE_MS = 120_000;

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -69,6 +69,7 @@ export const SUITES = {
     "scripts/install-git-hooks.test.mjs",
     "scripts/worktree-lifecycle-retirement.test.mjs",
     "scripts/worktree-lifecycle-patrol.test.mjs",
+    "scripts/worktree-lifecycle-fence-renewal.test.mjs",
     "scripts/worktree-status.test.mjs",
     "scripts/worktree-session-exit-retirement.test.mjs",
     "src/lib/board-cache-events.test.ts",
@@ -1665,6 +1666,7 @@ const STRIP_TYPES_MJS = new Set([
   "scripts/research-media-ffmpeg.integration.test.mjs",
   // imports ./worktree-lifecycle-inventory.ts
   "scripts/worktree-lifecycle-retirement.test.mjs",
+  "scripts/worktree-lifecycle-fence-renewal.test.mjs",
 ]);
 
 // Tests whose import graph reaches the "@/..." path alias and therefore need

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -20,6 +20,7 @@ import {
 } from "./worktree-lifecycle-inventory.ts";
 import {
   acquireMaintenanceGate,
+  createFenceRenewal,
   heartbeatMaintenanceGate,
   MAX_FENCED_MUTATION_TIMEOUT_MS,
   releaseMaintenanceGate,
@@ -1746,6 +1747,11 @@ function execute(
     repo: REPOSITORY,
     root,
     nowMs: Date.now(),
+    // The inventory outlives the Coven lease on a large checkout, so renew it
+    // as the inventory works instead of only after it finishes (cave-cs9g1).
+    onProgress: createFenceRenewal(() =>
+      heartbeatBoth(leases, "during lifecycle inventory"),
+    ),
   });
   heartbeatBoth(leases, "after lifecycle inventory");
   // Global failures still abort: if GitHub was unreachable or the canonical

--- a/scripts/worktree-lifecycle-fence-renewal.test.mjs
+++ b/scripts/worktree-lifecycle-fence-renewal.test.mjs
@@ -57,11 +57,16 @@ test("a failing renewal propagates so the fenced read stops", () => {
   assert.throws(() => hook(), (error) => error === boom);
 });
 
-test("the renewal interval leaves room for a failed renewal inside the Coven lease", () => {
+test("the renewal interval leaves headroom for command-boundary overshoot", () => {
+  // Renewal fires between external commands, never mid-command, so the real
+  // gap between renewals is the interval PLUS the command that crosses it —
+  // and commands can run for tens of seconds. The margin covers that overshoot.
+  // It is not there to survive a failed renewal: renewal is fail-closed, so a
+  // failure aborts the read instead of waiting for a next attempt.
   assert.ok(
     FENCE_RENEWAL_INTERVAL_MS * 2 < COVEN_OWNER_LEASE_MS,
-    `renewal every ${FENCE_RENEWAL_INTERVAL_MS}ms must allow one failure and a retry ` +
-      `inside the ${COVEN_OWNER_LEASE_MS}ms Coven lease`,
+    `renewal every ${FENCE_RENEWAL_INTERVAL_MS}ms must still land well inside the ` +
+      `${COVEN_OWNER_LEASE_MS}ms Coven lease once a slow command is added to it`,
   );
 });
 

--- a/scripts/worktree-lifecycle-fence-renewal.test.mjs
+++ b/scripts/worktree-lifecycle-fence-renewal.test.mjs
@@ -1,0 +1,160 @@
+// Fence renewal during the lifecycle inventory (cave-cs9g1).
+//
+// The bug: the Coven owner lease is 120s, the inventory that runs inside it
+// took 120.8s and 149s on a 39-worktree checkout, and nothing renewed the lease
+// while it ran — so every `beads:worktrees:create` died on the heartbeat that
+// followed the inventory. These tests pin the two properties that fix depends
+// on, both of which are easy to regress silently:
+//
+//   1. renewal is throttled, or the hook spawns a Coven CLI per git command;
+//   2. a renewal failure ABORTS the read rather than being swallowed, because
+//      an inventory that continues after losing its fence is a snapshot of a
+//      repository other writers were free to mutate.
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  COVEN_OWNER_LEASE_MS,
+  createFenceRenewal,
+  FENCE_RENEWAL_INTERVAL_MS,
+} from "./maintenance-gate.mjs";
+import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
+
+test("renewal is throttled so a per-command hook cannot spawn a fence process per command", () => {
+  let clock = 0;
+  let renewals = 0;
+  const hook = createFenceRenewal(() => { renewals += 1; }, { now: () => clock });
+
+  // Immediately after acquisition there is nothing to renew.
+  hook();
+  clock = FENCE_RENEWAL_INTERVAL_MS - 1;
+  hook();
+  assert.equal(renewals, 0, "renewal must not fire before the interval elapses");
+
+  clock = FENCE_RENEWAL_INTERVAL_MS;
+  hook();
+  assert.equal(renewals, 1, "renewal must fire once the interval has elapsed");
+
+  // Hundreds of commands can land inside one interval; they must collapse.
+  for (let i = 0; i < 500; i += 1) hook();
+  assert.equal(renewals, 1, "calls inside the same interval must collapse to one renewal");
+
+  clock = FENCE_RENEWAL_INTERVAL_MS * 2;
+  hook();
+  assert.equal(renewals, 2, "the interval must restart from the last renewal");
+});
+
+test("a failing renewal propagates so the fenced read stops", () => {
+  let clock = 0;
+  const boom = new Error("fence lost");
+  const hook = createFenceRenewal(() => { throw boom; }, { now: () => clock });
+  clock = FENCE_RENEWAL_INTERVAL_MS;
+  assert.throws(() => hook(), (error) => error === boom);
+});
+
+test("the renewal interval leaves room for a failed renewal inside the Coven lease", () => {
+  assert.ok(
+    FENCE_RENEWAL_INTERVAL_MS * 2 < COVEN_OWNER_LEASE_MS,
+    `renewal every ${FENCE_RENEWAL_INTERVAL_MS}ms must allow one failure and a retry ` +
+      `inside the ${COVEN_OWNER_LEASE_MS}ms Coven lease`,
+  );
+});
+
+test("a throwing progress hook aborts the inventory instead of being swallowed", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "cave-fence-renewal-"));
+  try {
+    execFileSync("git", ["init", "--quiet", dir], { stdio: "ignore" });
+
+    const sentinel = new Error("fence lost mid-inventory");
+    let calls = 0;
+    assert.throws(
+      () =>
+        collectWorktreeLifecycleInventory({
+          repo: "OpenCoven/coven-cave",
+          root: dir,
+          nowMs: Date.now(),
+          onProgress: () => {
+            calls += 1;
+            throw sentinel;
+          },
+        }),
+      // The exact error must survive. `command` wraps spawn failures into a
+      // CommandResult, and an earlier draft ran the hook inside that catch —
+      // which turned a lost fence into an ordinary "invocation failed" and let
+      // the inventory carry on unfenced.
+      (error) => error === sentinel,
+      "a hook that throws must propagate out of the inventory unchanged",
+    );
+    assert.equal(calls, 1, "the inventory must stop at the first failed renewal");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("the hook fires repeatedly, not just once, as the inventory runs commands", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "cave-fence-renewal-"));
+  try {
+    execFileSync("git", ["init", "--quiet", dir], { stdio: "ignore" });
+
+    // Renewal is worthless if it fires once and stops, so require several —
+    // then abort, to keep a fixture inventory from running its full GitHub
+    // probe inside the unit suite.
+    const done = new Error("enough");
+    let calls = 0;
+    assert.throws(
+      () =>
+        collectWorktreeLifecycleInventory({
+          repo: "OpenCoven/coven-cave",
+          root: dir,
+          nowMs: Date.now(),
+          onProgress: () => {
+            calls += 1;
+            if (calls >= 5) throw done;
+          },
+        }),
+      (error) => error === done,
+    );
+    assert.equal(calls, 5);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("an aborted inventory does not leave the next one unfenced", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "cave-fence-renewal-"));
+  try {
+    execFileSync("git", ["init", "--quiet", dir], { stdio: "ignore" });
+
+    // The hook lives in module state, so it is set on entry and restored on
+    // exit. If that restore were skipped on the throwing path, a read that
+    // aborted would silently disarm renewal for every read after it.
+    const stop = new Error("stop");
+    const runAborting = () => {
+      let calls = 0;
+      assert.throws(
+        () =>
+          collectWorktreeLifecycleInventory({
+            repo: "OpenCoven/coven-cave",
+            root: dir,
+            nowMs: Date.now(),
+            onProgress: () => {
+              calls += 1;
+              throw stop;
+            },
+          }),
+        (error) => error === stop,
+      );
+      return calls;
+    };
+
+    assert.equal(runAborting(), 1, "first read must drive its hook");
+    assert.equal(runAborting(), 1, "a read after an aborted one must still drive its hook");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -25,6 +25,23 @@ export interface WorktreeLifecycleInventoryOptions {
   repo: string;
   root: string;
   nowMs: number;
+  /**
+   * Called after every external command this inventory runs.
+   *
+   * A caller holding a lease over the inventory cannot renew it with a timer:
+   * this function is synchronous and every second of it is spent inside
+   * `spawnSync`, so the event loop never turns and no `setInterval` fires. The
+   * hook is the only place renewal can happen, and anchoring it to commands
+   * rather than to wall-clock means renewal tracks work actually done — the
+   * inventory gets slower as the checkout grows, and so does the renewal.
+   *
+   * Throwing from the hook aborts the inventory. That is deliberate: a caller
+   * whose fence has been lost should stop reading a repository it no longer
+   * excludes writers from, rather than finishing and reporting a snapshot
+   * taken without exclusion. Callers that merely want progress should not
+   * throw.
+   */
+  onProgress?: () => void;
 }
 
 export interface WorktreeLifecycleInventory {
@@ -274,12 +291,55 @@ function isIsoCalendarDate(value: string): boolean {
   );
 }
 
+/**
+ * Progress hook for the in-flight inventory, or null when none is running.
+ *
+ * Module state rather than a threaded parameter because `command` is called
+ * from well over a hundred sites; threading it would be a large diff for no
+ * added safety. `collectWorktreeLifecycleInventory` is synchronous and
+ * single-threaded, so the only way two inventories could interleave is
+ * re-entrance from inside the hook, which `runProgressHook` refuses.
+ */
+let activeProgressHook: (() => void) | null = null;
+let insideProgressHook = false;
+
+function runProgressHook(): void {
+  // A hook that ran a command would re-enter this and recurse without bound.
+  // Note the reach of this guard: anything the hook does — including starting
+  // a whole nested inventory — runs with progress reporting suppressed, so a
+  // nested read never drives its own hook. That is intended (the outer fence
+  // is the one being held) but it means a nested inventory cannot abort
+  // through its own hook.
+  if (activeProgressHook === null || insideProgressHook) return;
+  insideProgressHook = true;
+  try {
+    activeProgressHook();
+  } finally {
+    insideProgressHook = false;
+  }
+}
+
 function command(
   executable: string,
   args: string[],
   cwd: string,
   timeout = 30_000,
   env: NodeJS.ProcessEnv = process.env,
+): CommandResult {
+  const result = runCommand(executable, args, cwd, timeout, env);
+  // Deliberately OUTSIDE runCommand's catch: a hook that throws is reporting a
+  // lost fence, and swallowing it there would turn that into an ordinary
+  // "invocation failed" result and let the inventory continue unfenced.
+  runProgressHook();
+  return result;
+}
+
+function runCommand(
+  executable: string,
+  args: string[],
+  cwd: string,
+  timeout: number,
+  env: NodeJS.ProcessEnv,
 ): CommandResult {
   try {
     const result = spawnSync(executable, args, {
@@ -2797,6 +2857,20 @@ function classifyInventoryObservation(
 }
 
 export function collectWorktreeLifecycleInventory(
+  options: WorktreeLifecycleInventoryOptions,
+): WorktreeLifecycleInventory {
+  const previousHook = activeProgressHook;
+  activeProgressHook = options.onProgress ?? null;
+  try {
+    return collectInventory(options);
+  } finally {
+    // Restore rather than null out, so a nested call (tests, tooling) cannot
+    // silently disarm an outer inventory's fence renewal.
+    activeProgressHook = previousHook;
+  }
+}
+
+function collectInventory(
   options: WorktreeLifecycleInventoryOptions,
 ): WorktreeLifecycleInventory {
   const requestedRoot = normalizeAbsoluteWorktreePath(options.root);


### PR DESCRIPTION
## The failure

`pnpm beads:worktrees:create` — the only sanctioned path to a worktree carrying lifecycle metadata — failed on **every** invocation of this checkout:

```
worktree-lifecycle-create: maintenance fence heartbeat failed during after lifecycle inventory:
  coven-heartbeat-failed: coven-heartbeat-unavailable
worktree-lifecycle-create: maintenance fence release failed: coven-release-failed: coven-release-unavailable
exit 1
```

Introduced by #4487, which made the Coven maintenance plane enforced. Before that the plane was inert, so the lease it hands out was never load-bearing.

## Measured cause

The Coven owner lease is `COVEN_OWNER_LEASE_MS = 120_000`. The lifecycle inventory runs *inside* it and is not renewed while it runs — the only heartbeats are before and after:

| run | inventory | lease | result |
|---|---|---|---|
| standalone measurement | 120.8s | 120s | over by 0.7% |
| full `create` | 149s | 120s | over by 24% |

Both exceed the lease, so on this checkout (39 registered worktrees) the failure is **deterministic**, not intermittent. On a smaller or warmer checkout it fits and succeeds, which is how it reads as flaky — and why the documented "almost every exit 1 is transient, retry" advice is actively misleading here. Inventory time scales with registered worktrees and GitHub latency, so the margin degrades as the repo grows.

## Why not a timer

`collectWorktreeLifecycleInventory` is synchronous and spends essentially all of its wall-clock inside `spawnSync`. The event loop never turns, so a `setInterval` heartbeat would never fire. Renewal has to be driven by the work itself.

## The fix

- `WorktreeLifecycleInventoryOptions` gains an optional `onProgress`, invoked after every external command. All git and gh calls funnel through one private `command` helper, so that is a single choke point rather than a hundred call sites.
- `createFenceRenewal` (in `maintenance-gate.mjs`, next to the lease it renews) throttles to one renewal per 30s — a quarter of the lease, leaving room for one renewal to fail and the next to still land. Without throttling the hook would spawn a Coven CLI process per git command.
- Renewal is anchored to progress rather than wall-clock, so it scales with the work that actually got slower.

Two deliberate details:

- **The hook runs outside the spawn `try/catch`.** Inside it, a throw would have been folded into a `CommandResult` and the inventory would have continued reading a repository it no longer excluded writers from. A lost fence must abort the read.
- **The module-level hook is restored, not nulled, on exit**, so a read that aborts cannot silently disarm renewal for the next one. Covered by a test.

## Not fixed here

When the Coven release fails, the composite `release` returns before releasing the local fence, stranding it for its full 600s TTL — during which *every* create in the checkout refuses with `gate-held`, then with `gate-stale` once expired, because nothing in shipping code ever passes `takeoverStale`. I hit this three times today, and a second session hit it independently while this PR was being written.

I left it alone on purpose: keeping the local fence held mirrors an explicit decision in `acquire` ("releasing it would knowingly split the two writer populations during recovery"), so reversing it deserves its own review rather than a drive-by. This fix removes the expiry that triggers it. Follow-ups are recorded on `cave-cs9g1`, including making a dead owner `pid` reclaimable without waiting out the TTL — the gate already records the pid and nothing reads it.

## Verification

- new `scripts/worktree-lifecycle-fence-renewal.test.mjs`, 6 tests, 0.78s — throttling, collapse of hundreds of calls into one renewal, propagation of a failed renewal, abort-not-swallow, and no state leaking between reads
- wired into `run-tests.mjs` (`check-tests-wired`: all 1613 files wired)
- `tsc --noEmit` clean; existing `worktree-lifecycle-create.test.mjs` passes

Fixes `cave-cs9g1`.