### PR TITLE
fix(maintenance): carry the coven client's stderr into the failure reason

### DIFF
--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -99,8 +99,25 @@ function asText(value) {
   return typeof value === "string" ? value : "";
 }
 
-function commandFailure(operation) {
-  return { ok: false, reason: `coven-${operation}-unavailable` };
+/**
+ * Turn a failed `coven maintenance <op>` into a reason string.
+ *
+ * The suffix stays `-unavailable` because callers and tests match on it, but it
+ * now carries the client's own first line of stderr. Without that, EVERY
+ * non-zero exit read as "the subcommand is unavailable" — so an expired owner
+ * lease, which is the common failure, looked like a missing or too-old client.
+ * That cost a wrong root cause on cave-7w5cu: the reported version skew was
+ * real on PATH and entirely irrelevant, because the gate launches a different
+ * binary. One line of stderr would have said so.
+ */
+function commandFailure(operation, result) {
+  const detail = asText(result?.stderr).split("\n").find((line) => line.trim().length > 0);
+  return {
+    ok: false,
+    reason: detail
+      ? `coven-${operation}-unavailable: ${detail.trim().slice(0, 200)}`
+      : `coven-${operation}-unavailable`,
+  };
 }
 
 function parseCovenVersion(value) {
@@ -205,7 +222,7 @@ export function createCovenMaintenanceClient({
       args: ["--version"],
       cwd: repoDir,
     });
-    if (!result.ok) return commandFailure("version");
+    if (!result.ok) return commandFailure("version", result);
     const parsed = parseCovenVersion(result.stdout);
     if (!parsed) return { ok: false, reason: "coven-version-malformed" };
     if (!supportsCovenMaintenanceVersion(result.stdout)) {
@@ -225,7 +242,7 @@ export function createCovenMaintenanceClient({
       args: ["maintenance", "status", "--json"],
       cwd: repoDir,
     });
-    if (!result.ok) return commandFailure("status");
+    if (!result.ok) return commandFailure("status", result);
     const parsed = parseStatus(result.stdout);
     return parsed ? { ok: true, status: parsed } : { ok: false, reason: "coven-status-malformed" };
   }
@@ -238,7 +255,7 @@ export function createCovenMaintenanceClient({
       args: ["maintenance", "release", handle.ownerId, handle.generation],
       cwd: handle.repoDir,
     });
-    return result.ok ? { ok: true } : commandFailure("release");
+    return result.ok ? { ok: true } : commandFailure("release", result);
   }
 
   return {
@@ -261,7 +278,7 @@ export function createCovenMaintenanceClient({
         args: ["maintenance", "acquire", ownerId, "--wait-ms", String(waitMs), "--json"],
         cwd: repoDir,
       });
-      if (!result.ok) return commandFailure("acquire");
+      if (!result.ok) return commandFailure("acquire", result);
 
       const parsed = parseStatus(result.stdout);
       if (!parsed || !parsed.owner) {
@@ -309,7 +326,7 @@ export function createCovenMaintenanceClient({
         ],
         cwd: handle.repoDir,
       });
-      if (!result.ok) return commandFailure("heartbeat");
+      if (!result.ok) return commandFailure("heartbeat", result);
       const parsed = parseStatus(result.stdout);
       if (!parsed) return { ok: false, reason: "coven-heartbeat-output-malformed" };
       return heldBy(parsed, handle, Math.floor(now() / 1_000));
@@ -427,6 +444,7 @@ export function createRepositoryMaintenanceCoordinator({
     release(handle) {
       if (!handle?.local || !handle?.coven) return { ok: false, reason: "invalid-composite-handle" };
       const coven = covenClient.release(handle.coven);
+
       if (!coven.ok) {
         return {
           ok: false,

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -103,19 +103,25 @@ function asText(value) {
  * Turn a failed `coven maintenance <op>` into a reason string.
  *
  * The suffix stays `-unavailable` because callers and tests match on it, but it
- * now carries the client's own first line of stderr. Without that, EVERY
- * non-zero exit read as "the subcommand is unavailable" — so an expired owner
- * lease, which is the common failure, looked like a missing or too-old client.
- * That cost a wrong root cause on cave-7w5cu: the reported version skew was
- * real on PATH and entirely irrelevant, because the gate launches a different
- * binary. One line of stderr would have said so.
+ * now carries the client's own first NON-EMPTY line of stderr. Without that,
+ * EVERY non-zero exit read as "the subcommand is unavailable" — so an expired
+ * owner lease, which is the common failure, looked like a missing or too-old
+ * client. That cost a wrong root cause on cave-7w5cu: the reported version skew
+ * was real on PATH and entirely irrelevant, because the gate launches a
+ * different binary. One line of stderr would have said so.
+ *
+ * Matched rather than split: a failing client can emit a long backtrace, and
+ * only the first line is ever used, so there is no reason to allocate an array
+ * for the rest of it.
  */
 function commandFailure(operation, result) {
-  const detail = asText(result?.stderr).split("\n").find((line) => line.trim().length > 0);
+  // Horizontal whitespace only in the leading class — `\s` would span newlines
+  // and let the match start on a blank line, defeating the "non-empty" part.
+  const detail = asText(result?.stderr).match(/^[^\S\n]*(\S[^\n]*)/m)?.[1];
   return {
     ok: false,
     reason: detail
-      ? `coven-${operation}-unavailable: ${detail.trim().slice(0, 200)}`
+      ? `coven-${operation}-unavailable: ${detail.trimEnd().slice(0, 200)}`
       : `coven-${operation}-unavailable`,
   };
 }

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -250,3 +250,38 @@ test("maintenance capabilities name the released Coven protocol without claiming
     complete: false,
   });
 });
+
+test("a failed coven command carries the client's own stderr into the reason", () => {
+  // Every non-zero exit used to collapse to `coven-<op>-unavailable`, which
+  // reads as "the subcommand is missing or too old". The common failure is an
+  // expired owner lease, and that message sent a session after a version
+  // number that had nothing to do with it (cave-7w5cu). The suffix is kept so
+  // existing matchers still work; the detail is appended.
+  const coordinator = createRepositoryMaintenanceCoordinator({
+    covenClient: createCovenMaintenanceClient({
+      run: () => ({ ok: false, stdout: "", stderr: "error: owner lease expired\nbacktrace...", status: 1 }),
+      now: () => 0,
+    }),
+  });
+  const released = coordinator.release({
+    local: { generation: 1 },
+    coven: { ownerId: "cave-maintenance", generation: "g", repoDir },
+  });
+  assert.equal(released.ok, false);
+  assert.match(released.reason, /coven-release-unavailable: error: owner lease expired/);
+  assert.doesNotMatch(released.reason, /backtrace/, "only the first stderr line is carried");
+});
+
+test("a failed coven command with no stderr keeps the bare reason", () => {
+  const coordinator = createRepositoryMaintenanceCoordinator({
+    covenClient: createCovenMaintenanceClient({
+      run: () => ({ ok: false, stdout: "", stderr: "   \n\n", status: 1 }),
+      now: () => 0,
+    }),
+  });
+  const released = coordinator.release({
+    local: { generation: 1 },
+    coven: { ownerId: "cave-maintenance", generation: "g", repoDir },
+  });
+  assert.equal(released.reason, "coven-release-failed: coven-release-unavailable");
+});


### PR DESCRIPTION
Every non-zero exit from `coven maintenance <op>` collapsed to
`coven-<op>-unavailable`, discarding stderr.

That string reads as *"the subcommand is missing or too old"*. The common
failure is nothing of the kind — an expired owner lease produces the identical
message.

## It cost a wrong root cause

Chasing three stranded maintenance gates, I read `coven-heartbeat-unavailable`,
found `v0.2.4-recovery.1` on `PATH` against a `COVEN_MAINTENANCE_MINIMUM_VERSION`
of `0.2.5`, and filed version skew as the cause.

That was wrong. The gate never uses the binary on `PATH` — `covenLaunchCommand()`
resolves the nvm-installed **0.2.5**, which implements the subcommand fine, and
`repositoryMaintenanceCapabilities()` duly reports the plane enforced against
`@opencoven/cli@0.2.5`. One line of the client's own stderr would have said so
before any of that.

The `-unavailable` suffix is preserved so existing callers and tests still
match; the detail is appended — first non-empty stderr line, capped at 200
characters.

## What this deliberately does NOT change

Composite `release` still keeps the local fence when the Coven half fails. That
invariant is explicit and pinned:

```js
assert.deepEqual(calls, ["coven"], "local state stays fenced if Coven release fails");
```

I had written the reversal before finding that test. The stranding I actually
hit was the Coven lease expiring across the lifecycle inventory — **already
fixed by #4520**, which renews the fence while the inventory runs. Reversing a
deliberate, tested invariant to treat a symptom whose cause is fixed upstream
would be the wrong trade, so it is out.

The remaining gap — an abandoned fence has no reclaim path, so a crashed holder
blocks the checkout for its full TTL — is **cave-qqvfu**, and wants a
pid-liveness reclaim rather than a change to release ordering.

## Tests

Two cases: a failure with stderr carries the first line and nothing after it; a
failure with only blank stderr keeps the bare reason. 9 pass.

Closes cave-7w5cu.