### PR TITLE
docs: point the worktree-retirement section at live work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@
   protocol; the remaining Beads and GitHub planes are still unenforced. That is
   not a local fault and a retry will not clear it, so
   hand-retirement through the archive-tag route in [`CLAUDE.md`](CLAUDE.md) is
-  the expected path until those land (`cave-3aqvr`). Prove retention first: a
+  the expected path until those land (`cave-wqa0b.3` and `cave-wqa0b.4`; the
+  residue they leave behind is `cave-xbc87`). Prove retention first: a
   squash-merge leaves the branch commits on no remote ref, so a merged PR is not
   retention and a pushed archive tag is. Local cleanup is bounded and exact-OID
   guarded; remote deletion remains proposal-only.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -425,7 +425,7 @@ Run `pnpm beads:worktrees`. If it reports active, recovery, cooldown, uncertain,
 or gate-incomplete, preserve the unit and record its owner/reason. Never bypass
 the worktree guard to force completion.
 
-⚠️ **`pnpm beads:worktrees:apply` does not work today, and this is not a local
+⚠️ **A plain `pnpm beads:worktrees:apply` refuses, and this is not a local
 fault.** It exits 2 before assessing a single unit:
 
 ```text
@@ -434,13 +434,37 @@ worktree-lifecycle-patrol: --apply unavailable; missing maintenance planes: bead
 
 `scripts/maintenance-gate.mjs` composes Cave's local writer-intent fence with
 the released Coven 0.2.5 maintenance protocol. The Beads (`cave-wqa0b.3`) and
-GitHub (`cave-wqa0b.4`) planes remain `enforced: false`, so `--apply` is
-unreachable until those land; no retry, credential, or daemon will change that.
-Tracked by `cave-3aqvr`.
+GitHub (`cave-wqa0b.4`) planes remain `enforced: false`, so a plain `--apply`
+refuses; no retry, credential, or daemon will change that. Both are blocked
+outside this repository — `cave-wqa0b.3` on an upstream Beads pre-write hook
+(`gastownhall/beads#5193`), `cave-wqa0b.4` on provisioning a dedicated GitHub
+App — so neither is agent-actionable here. The metadata residue this leaves
+behind is `cave-xbc87`. Don't follow the parent `cave-3aqvr`: it is closed
+(option 3 landed as PR #4432; options 1 and 2 were split out).
 
-**So hand-retirement is the norm right now, not the exception.** For a unit the
-patrol already classified `cleanup-ready`, use the archive-tag route in the
-worktree-guard section below.
+**But `--apply` is no longer a dead end.** `--allow-unenforced-planes`
+(`cave-s03wp`) opts into running it while those known-pending planes are
+unenforced:
+
+```bash
+pnpm beads:worktrees:apply --allow-unenforced-planes
+```
+
+The `local` plane is still required and is **never** waivable — it performs the
+exclusion that stops two actors retiring the same unit, so waiving it would be
+an unguarded run rather than a degraded one, and it is refused with its own
+distinct message. Every degraded run prints the waived planes and what blocks
+each one to stderr *before* the first unit is touched, so the record survives a
+run that dies midway.
+
+Note the admission test reads `enforced !== true`, not `=== false`: a plane
+whose entry is missing or malformed counts as unenforced. That direction is
+deliberate — a safety gate that reads absent data as "fine" fails open.
+
+**So retirement is either the degraded apply above or hand-retirement — both
+are sanctioned, neither is a workaround.** For a unit the patrol already
+classified `cleanup-ready`, use the archive-tag route in the worktree-guard
+section below.
 
 ⚠️ **Prove retention before removing anything — a merged PR is NOT retention.**
 A squash-merge leaves the branch's own commits on no remote ref, so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -458,8 +458,10 @@ each one to stderr *before* the first unit is touched, so the record survives a
 run that dies midway.
 
 Note the admission test reads `enforced !== true`, not `=== false`: a plane
-whose entry is missing or malformed counts as unenforced. That direction is
-deliberate — a safety gate that reads absent data as "fine" fails open.
+whose entry is missing or malformed counts as unenforced, so the gate **fails
+closed** on absent data. `=== false` would be the bug — it would treat a
+missing or malformed entry as "not disabled, therefore fine" and waive the
+exclusion silently. Don't tidy it in that direction.
 
 **So retirement is either the degraded apply above or hand-retirement — both
 are sanctioned, neither is a workaround.** For a unit the patrol already


### PR DESCRIPTION
## The ask

`CLAUDE.md` and `AGENTS.md` both closed the "`beads:worktrees:apply` cannot retire anything" paragraph with **"Tracked by `cave-3aqvr`"**. That Bead is **closed** — option 3 landed as PR #4432, options 1 and 2 were split out — so anyone following the pointer lands on a closed bug instead of the work that actually blocks the gate. The live Beads were already named a sentence earlier: `cave-wqa0b.3`, `cave-wqa0b.4`, plus `cave-xbc87` for the metadata residue.

## What that turned up

Repointing the citation meant reading the paragraph around it, and it was materially out of date:

- **It said `--apply` is unreachable**, and that "no retry, credential, or daemon will change that." A `--allow-unenforced-planes` opt-in has since landed (`cave-s03wp`). It waives only `coven`/`beads`/`github`; `local` is **never** waivable — it performs the exclusion that stops two actors retiring the same unit — and waiving it is refused with its own distinct message rather than folded into a generic one. Degraded runs print the waived planes and what blocks each to stderr *before* the first unit is touched, so the audit record survives a run that dies midway.
- **"Hand-retirement is the norm"** read as though it were the only route. Both are sanctioned now; neither is a workaround.

I also recorded why the admission test reads `enforced !== true` rather than `=== false`: a missing or malformed plane entry counts as unenforced, so the gate fails closed on absent data. That is easy to "tidy" into a bug.

## On the earlier claim I'm removing

An earlier version of this branch asserted that `complete` is a hard-coded literal gating `--apply`, and that landing the last plane would leave it refusing with an empty plane list. **That was wrong** and is not in this diff. Admission is computed from the planes directly in `src/lib/maintenance-plane-admission.ts`; `capabilities.complete` is read in exactly one place — `worktree-lifecycle-create.ts:1000` — to decide whether to print a *suggestion*. I had read an older revision out of a stale checkout. Corrected on `cave-wqa0b` too, since I had recorded it there.

## Verification

Every claim in the new text checked against source at this head:

- `--allow-unenforced-planes` — `worktree-lifecycle-patrol.ts:153`, help at `:201`, degraded banner at `:718`
- `WAIVABLE_PLANES = {coven, beads, github}` and local-never-waivable — `maintenance-plane-admission.ts:61`, `:99`
- `enforced !== true` — `maintenance-plane-admission.ts:75`
- `cave-3aqvr` CLOSED, `cave-wqa0b.3`/`.4` BLOCKED, `cave-xbc87` OPEN — via `bd show`

Documentation only; no behaviour change.

Closes `cave-83fjg`.