### PR TITLE
Explain first-run local setup progress

### DIFF
--- a/src/components/onboarding-bootstrap-overlay.test.ts
+++ b/src/components/onboarding-bootstrap-overlay.test.ts
@@ -78,8 +78,18 @@ assert.match(
 );
 assert.doesNotMatch(
   source,
-  /Node\.js|npm|Coven CLI|Codex|Claude|Copilot|OpenClaw|package/i,
-  "first-run UI hides package and tool identities",
+  /Codex|Claude|Copilot|OpenClaw/i,
+  "first-run setup stays independent of provider runtimes",
+);
+assert.match(
+  source,
+  /private Node\.js and npm runtime, then verify the Coven CLI/,
+  "the local-components phase explains its concrete, Cave-owned work",
+);
+assert.match(
+  source,
+  /does not create Cave defaults or start a familiar runtime/,
+  "a local-components failure says which later work did not happen",
 );
 
 console.log("onboarding-bootstrap-overlay.test.ts: ok");

--- a/src/components/onboarding-bootstrap-overlay.tsx
+++ b/src/components/onboarding-bootstrap-overlay.tsx
@@ -266,6 +266,11 @@ export function OnboardingOverlay({
               <p className="mt-1 text-[length:var(--text-xs)] leading-4 text-[var(--text-secondary)]">
                 {state.failure.message}
               </p>
+              {state.failure.stage === "core-tools" ? (
+                <p className="mt-2 text-[length:var(--text-xs)] leading-4 text-[var(--text-secondary)]">
+                  This step prepares Cave’s private Node.js/npm runtime and the Coven CLI. It does not create Cave defaults or start a familiar runtime.
+                </p>
+              ) : null}
               <Button
                 variant="secondary"
                 size="sm"

--- a/src/lib/onboarding-bootstrap.ts
+++ b/src/lib/onboarding-bootstrap.ts
@@ -2,17 +2,20 @@ export const ONBOARDING_BOOTSTRAP_STAGES = [
   {
     id: "core-tools",
     label: "Prepare local components",
-    pendingDetail: "Cave will verify the local components it needs.",
+    pendingDetail:
+      "Cave will check its private Node.js and npm runtime, then verify the Coven CLI.",
   },
   {
     id: "workspace",
     label: "Create Cave defaults",
-    pendingDetail: "Cave will create user-scoped folders and defaults.",
+    pendingDetail:
+      "Waiting for local components. Cave will then create user-scoped folders and defaults.",
   },
   {
     id: "daemon",
     label: "Start local services",
-    pendingDetail: "Cave will start its local background service.",
+    pendingDetail:
+      "Waiting for setup. Cave will check the local service and start it only when needed.",
   },
 ] as const;
 

--- a/src/lib/server/onboarding-core-tools.ts
+++ b/src/lib/server/onboarding-core-tools.ts
@@ -82,19 +82,19 @@ export async function ensureOnboardingCoreTools(
   }
 
   if (!before.runtimeReady) {
-    await onProgress("Preparing Cave’s local runtime…");
+    await onProgress("Setting up Cave’s private Node.js and npm runtime…");
     if (!(await runReviewedInstall("managed-node"))) {
       return {
         ok: false,
         message:
-          "Setup stopped at Prepare local components. Check that your user application-data folder is writable, then retry setup.",
+          "Setup stopped at Prepare local components. Cave couldn’t prepare its private Node.js and npm runtime. No Cave defaults were created. Retry setup; if it happens again, restart Cave and try once more.",
       };
     }
   }
 
   const afterRuntime = await inspectOnboardingCoreTools();
   if (!afterRuntime.coreToolsReady) {
-    await onProgress("Preparing Cave’s core components…");
+    await onProgress("Installing and verifying the Coven CLI…");
     if (!(await runReviewedInstall("coven-cli"))) {
       return {
         ok: false,
@@ -104,7 +104,7 @@ export async function ensureOnboardingCoreTools(
     }
   }
 
-  await onProgress("Verifying Cave’s local components…");
+  await onProgress("Verifying the local runtime and Coven CLI…");
   const verified = await inspectOnboardingCoreTools();
   if (!verified.runtimeReady || !verified.coreToolsReady) {
     return {

--- a/tests/onboarding-wizard.spec.ts
+++ b/tests/onboarding-wizard.spec.ts
@@ -42,19 +42,22 @@ function state(overrides: Partial<BootstrapState> = {}): BootstrapState {
         id: "core-tools",
         label: "Prepare local components",
         status: "pending",
-        detail: "Cave will verify the local components it needs.",
+        detail:
+          "Cave will check its private Node.js and npm runtime, then verify the Coven CLI.",
       },
       {
         id: "workspace",
         label: "Create Cave defaults",
         status: "pending",
-        detail: "Cave will create user-scoped folders and defaults.",
+        detail:
+          "Waiting for local components. Cave will then create user-scoped folders and defaults.",
       },
       {
         id: "daemon",
         label: "Start local services",
         status: "pending",
-        detail: "Cave will start its local background service.",
+        detail:
+          "Waiting for setup. Cave will check the local service and start it only when needed.",
       },
     ],
     failure: null,
@@ -162,7 +165,7 @@ test.describe("onboarding bootstrap", () => {
               id: "core-tools",
               label: "Prepare local components",
               status: "running",
-              detail: "Preparing Cave’s local runtime…",
+              detail: "Setting up Cave’s private Node.js and npm runtime…",
             },
             ...state().stages.slice(1),
           ],
@@ -173,24 +176,14 @@ test.describe("onboarding bootstrap", () => {
 
     const dialog = setup(page);
     await dialog.getByRole("button", { name: "Set up Cave", exact: true }).click();
-    await expect(dialog.getByText("Preparing Cave’s local runtime…")).toBeVisible();
+    await expect(dialog.getByText("Setting up Cave’s private Node.js and npm runtime…")).toBeVisible();
     await expect(dialog.locator('[aria-current="step"]')).toContainText(
       "Prepare local components",
     );
     expect(confirmations).toBe(1);
 
-    const visibleText = await dialog.innerText();
-    for (const hidden of [
-      "Node.js",
-      "npm",
-      "Coven CLI",
-      "Codex",
-      "Claude",
-      "Copilot",
-      "OpenClaw",
-    ]) {
-      expect(visibleText).not.toContain(hidden);
-    }
+    await expect(dialog.getByText(/private Node\.js and npm runtime/)).toBeVisible();
+    await expect(dialog.getByText(/Waiting for local components/)).toBeVisible();
     await expect(dialog.getByText(/Provider sign-in is deferred/)).toBeVisible();
     await expect(dialog.getByText(/never asks for an administrator password/)).toBeVisible();
     await expect(dialog.getByText(/Git is optional/)).toBeVisible();
@@ -238,6 +231,40 @@ test.describe("onboarding bootstrap", () => {
     await expect(alert.getByRole("button", { name: "Retry setup" })).toHaveCount(1);
     await alert.getByRole("button", { name: "Retry setup" }).click();
     expect(retries).toBe(1);
+  });
+
+  test("explains what a local-components failure did and did not do", async ({
+    page,
+  }) => {
+    const failed = state({
+      confirmed: true,
+      status: "failed",
+      activeStage: "core-tools",
+      stages: state().stages.map((stage) =>
+        stage.id === "core-tools"
+          ? {
+              ...stage,
+              status: "failed",
+              detail: "Setup stopped at Prepare local components. Cave couldn’t prepare its private Node.js and npm runtime.",
+            }
+          : stage,
+      ),
+      failure: {
+        stage: "core-tools",
+        stageLabel: "Prepare local components",
+        message: "Setup stopped at Prepare local components. Cave couldn’t prepare its private Node.js and npm runtime. No Cave defaults were created. Retry setup; if it happens again, restart Cave and try once more.",
+        recoveryLabel: "Retry setup",
+      },
+    });
+    await gotoApp(page, (route) => route.fulfill({ json: payload(failed) }), {
+      dismissed: true,
+    });
+
+    const alert = setup(page).getByRole("alert");
+    await expect(alert).toContainText("No Cave defaults were created.");
+    await expect(alert).toContainText(
+      "It does not create Cave defaults or start a familiar runtime.",
+    );
   });
 
   test("skips onboarding when an existing setup is already ready", async ({


### PR DESCRIPTION
## Summary
- explain the Cave-managed Node.js/npm and Coven CLI work during first-run setup
- show that defaults and local-service work wait for local components
- clarify that a local-components failure occurred before defaults or familiar runtime startup

## Validation
- `node --experimental-strip-types src/components/onboarding-bootstrap-overlay.test.ts`
- `node --experimental-strip-types src/lib/onboarding-bootstrap.test.ts`
- `node --experimental-strip-types src/app/api/onboarding/bootstrap/route.test.ts`
- `node scripts/codemods/tokenize-css.mjs --check`
- `pnpm codemod:design:check`

## Limitations
- `pnpm lint` and the focused Playwright spec could not run because this fresh worktree has no linked `node_modules`; `pnpm install --frozen-lockfile` did not complete in this WSL environment.

Bead: cave-8ed (Beads CLI unavailable in this environment, so lifecycle metadata could not be registered.)