### PR TITLE
Hide follow-up actions on historical chat turns

### DIFF
--- a/src/components/chat-follow-up-intents-wiring.test.ts
+++ b/src/components/chat-follow-up-intents-wiring.test.ts
@@ -9,7 +9,7 @@ const journal = await readFile(new URL("./journal/journal-entries.tsx", import.m
 assert.match(chatView, /import \{ FollowUpCards \} from "@\/components\/chat-follow-up-cards"/, "ChatView uses the shared typed follow-up cards");
 assert.match(chatView, /import \{ FollowUpTaskReview \} from "@\/components\/chat-follow-up-task-review"/, "ChatView owns the review-first task handoff");
 assert.match(chatView, /<FollowUpCards[\s\S]*paths=\{followUp\.suggestions\}[\s\S]*onActivate=\{handleFollowUp\}/, "the composer placement routes cards through typed handling");
-assert.match(chatView, /<FollowUpCards[\s\S]*paths=\{nextPaths\}[\s\S]*onActivate=\{onSuggestion\}/, "historical assistant turns use the same cards");
+assert.equal([...chatView.matchAll(/<FollowUpCards/g)].length, 1, "historical assistant turns never render action cards");
 assert.match(chatView, /setInput\(path\.prompt\);[\s\S]{0,160}inputRef\.current\?\.focus\(\)/, "reply follow-ups fill and focus the composer without sending");
 assert.match(chatView, /path\.kind === "task"[\s\S]{0,120}setTaskSuggestion\(path\)/, "task follow-ups open a review instead of sending");
 assert.match(chatView, /path\.actionId === "open-tasks"[\s\S]{0,180}new CustomEvent\("cave:navigate-mode", \{ detail: \{ mode: "board" \} \}\)/, "the action allowlist only navigates to Tasks");
@@ -31,6 +31,11 @@ assert.match(
   groupChat,
   /\.filter\(\(path\) => path\.kind === "reply"\)[\s\S]*?sendSuggestion\(\s*\n\s*path\.prompt,\s*\n\s*agent\.familiarId,/,
   "only filtered reply text reaches the group send path",
+);
+assert.match(
+  groupChat,
+  /const isLatestRun = runIndex === visibleRuns\.length - 1;[\s\S]*?isLatestRun && agent\.status === "complete"/,
+  "group-chat actions render only for the newest run",
 );
 assert.doesNotMatch(groupChat, /typed\.map\(/, "raw typed task/action paths never reach group rendering or sendSuggestion");
 assert.doesNotMatch(groupChat, /broadcast\(typed\b|sendSuggestion\(typed\b/, "task/action paths never reach group broadcast/send routing");

--- a/src/components/chat-view-polish-edit-review.test.ts
+++ b/src/components/chat-view-polish-edit-review.test.ts
@@ -4,7 +4,6 @@ import {
   attachmentsLib,
   attachStagingHook,
   emptyStateSource,
-  globalsSrc,
   menusHookSource,
   source,
   splitReasoning,
@@ -12,18 +11,18 @@ import {
   turnRow,
 } from "./chat-view-polish-fixtures.ts";
 
-// Follow-ups are compact intent cards in both transcript and composer
-// placements. Their visual grammar belongs to the shared component rather
-// than the legacy send-on-click chip row.
+// Follow-ups are ephemeral intent cards beside the composer, never transcript
+// history. Their visual grammar belongs to the shared component rather than
+// the legacy send-on-click chip row.
 assert.match(
   source,
   /import \{ FollowUpCards \} from "@\/components\/chat-follow-up-cards"/,
   "ChatView imports the shared typed follow-up cards",
 );
-assert.match(
-  source,
-  /<FollowUpCards paths=\{nextPaths\} onActivate=\{onSuggestion\} \/>/,
-  "historical transcript turns use the same cards",
+assert.equal(
+  [...source.matchAll(/<FollowUpCards/g)].length,
+  1,
+  "historical transcript turns never render follow-up cards",
 );
 assert.match(
   styles,
@@ -59,7 +58,7 @@ assert.ok(
 assert.match(source, /cave-edit-card/, "mutation tools render as an inline Codex edit card");
 assert.match(source, /diffStat/, "edit card derives a +/- stat");
 assert.match(source, /Review/, "edit card has a Review action");
-assert.match(globalsSrc, /\.cave-edit-card/, "edit card styling exists");
+assert.match(styles, /\.cave-edit-card/, "edit card styling exists");
 
 // Review adapts to where the edit can actually be reviewed: a file under the
 // session's project root jumps to the code rail's Changes diff; anything else
@@ -82,7 +81,7 @@ assert.match(
   /<EditCardActions targetFile=\{targetFile\} diff=\{inputDiff \?\? ""\} displayPath=\{displayPath\} \/>/,
   "edit-card actions render unconditionally (Review works without an absolute target path)",
 );
-assert.match(globalsSrc, /\.cave-review-modal/, "review modal styling exists");
+assert.match(styles, /\.cave-review-modal/, "review modal styling exists");
 assert.match(
   source,
   /if \(isEditTool\) \{[\s\S]*<details className="cave-tool-block cave-edit-card"[\s\S]*Edited \{base\}[\s\S]*<DurationText durationMs=\{tool\.durationMs\} \/>[\s\S]*Code changes[\s\S]*<SyntaxBlock text=\{inputDiff\} lang="diff" \/>[\s\S]*<\/details>/,
@@ -96,7 +95,7 @@ assert.match(source, /cave-edit-card__undo/, "edit card has an Undo action");
 assert.match(source, /ToolProjectRootContext/, "edit card resolves project root via context for revert");
 assert.match(source, /"\/api\/changes"/, "Undo posts to the changes revert API");
 assert.match(source, /cave:changes-refresh/, "Undo notifies the changes panel to refresh");
-assert.match(globalsSrc, /\.cave-edit-card__undo/, "Undo button styling exists");
+assert.match(styles, /\.cave-edit-card__undo/, "Undo button styling exists");
 
 // cave-zvr: composer send hygiene + picker Escape.
 // (3) send() clears the persisted draft synchronously — the 250ms debounced

--- a/src/components/chat-view-polish-fixtures.ts
+++ b/src/components/chat-view-polish-fixtures.ts
@@ -16,6 +16,7 @@ export const styles = [
   "cave-chat/activity",
   "cave-chat/transcript",
   "cave-chat/auxiliary-surfaces",
+  "globals/shell-cards-and-controls",
 ]
   .map((sheet) => readFileSync(new URL(`../styles/${sheet}.css`, import.meta.url), "utf8"))
   .join("\n");

--- a/src/components/chat-view-polish-tools-activity.test.ts
+++ b/src/components/chat-view-polish-tools-activity.test.ts
@@ -40,8 +40,8 @@ assert.match(
 
 assert.match(
   turnRow,
-  /inlineReasoning,[\s\S]*nextPaths,[\s\S]*\} = extractChatRenderedText\(turn\.text, \{ pending: Boolean\(turn\.pending\) \}\)/,
-  "Assistant turns should use the shared visible-text projection for reasoning and next paths",
+  /inlineReasoning,[\s\S]*\} = extractChatRenderedText\(turn\.text, \{ pending: Boolean\(turn\.pending\) \}\)/,
+  "Assistant turns should use the shared visible-text projection for reasoning and control-marker stripping",
 );
 
 assert.match(

--- a/src/components/chat-view-transcript-memo.test.ts
+++ b/src/components/chat-view-transcript-memo.test.ts
@@ -37,7 +37,7 @@ assert.match(
 // ── 3. Latest-ref pattern: reassigned every render, all typed actions ───────
 assert.match(
   src,
-  /transcriptHandlersRef\.current = \{\s*siblingsFor,\s*switchBranch,\s*editTurnInComposer,\s*regenerateFor,\s*replyFor,\s*askAboutFor,\s*readerPromptFor,\s*rerunWithFor,\s*send,\s*activateFollowUp: handleFollowUp,\s*\};/,
+  /transcriptHandlersRef\.current = \{\s*siblingsFor,\s*switchBranch,\s*editTurnInComposer,\s*regenerateFor,\s*replyFor,\s*askAboutFor,\s*readerPromptFor,\s*rerunWithFor,\s*send,\s*\};/,
   "the handlers ref must be reassigned in the render body so closures never go stale",
 );
 
@@ -56,7 +56,6 @@ for (const pattern of [
   /handlers\(\)\.regenerateFor\(t\)/,
   /handlers\(\)\.replyFor\(t\)/,
   /handlers\(\)\.editTurnInComposer\(t\)/,
-  /handlers\(\)\.activateFollowUp\(path\)/,
   /handlers\(\)\.send\(prompt\)/,
   /handlers\(\)\.switchBranch\(t\.id, -1\)/,
   /handlers\(\)\.siblingsFor\(t\.id\)/,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -3784,20 +3784,17 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return extractChatRenderedText(last.text).nextPaths.find((path) => path.kind === "reply") ?? null;
   }, [activePath]);
 
-  // Chat-revamp 1b: the LATEST settled turn's follow-up suggestions render as
-  // typed cards directly above the composer (aligned to the reading column) —
-  // the most actionable element sits closest to the input. That turn's in-turn
-  // card row is suppressed (followUp.turnId → TurnRow) so the suggestions
-  // never render twice; older turns keep their in-turn rows. The parser owns
-  // the product cap so every renderer stays aligned.
+  // The latest settled turn's follow-up suggestions render directly above the
+  // composer. Suggestions are ephemeral actions, not transcript history, so
+  // assistant rows only strip their control blocks and never render old cards.
   const followUp = useMemo(() => {
-    const empty = { turnId: null as string | null, suggestions: [] as NextPath[] };
+    const empty = { suggestions: [] as NextPath[] };
     const last = [...activePath]
       .reverse()
       .find((t) => t.role === "assistant" && !t.pending && !t.error);
     if (!last?.text) return empty;
     const suggestions = extractChatRenderedText(last.text).nextPaths;
-    return suggestions.length ? { turnId: last.id, suggestions } : empty;
+    return suggestions.length ? { suggestions } : empty;
   }, [activePath]);
 
   const handleFollowUp = useCallback((path: NextPath) => {
@@ -5941,7 +5938,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     readerPromptFor,
     rerunWithFor,
     send,
-    activateFollowUp: handleFollowUp,
   };
 
   // Auto-send a prompt handed off from the home composer. Deferred one
@@ -7826,7 +7822,6 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
             setExpandedAvatarTurnId={setExpandedAvatarTurnId}
             onOpenUrl={onOpenUrl}
             handlersRef={transcriptHandlersRef}
-            followUpTurnId={followUp.turnId}
           />
           {shouldShowChatArchiveNudge({
             taskLifecycle: linkedContext?.task?.lifecycle ?? null,
@@ -8280,7 +8275,6 @@ type TranscriptHandlers = {
   readerPromptFor: (turn: Turn) => { text: string; createdAt?: string } | undefined;
   rerunWithFor: (turn: Turn) => ((prompt: string) => void) | undefined;
   send: (override?: string) => Promise<void>;
-  activateFollowUp: (path: NextPath) => void;
 };
 
 /**
@@ -8315,7 +8309,6 @@ const TranscriptRows = memo(function TranscriptRows({
   setExpandedAvatarTurnId,
   onOpenUrl,
   handlersRef,
-  followUpTurnId,
 }: {
   groupedTurns: TranscriptGroup[];
   turnIndexMap: Map<string, number>;
@@ -8333,9 +8326,6 @@ const TranscriptRows = memo(function TranscriptRows({
   setExpandedAvatarTurnId: React.Dispatch<React.SetStateAction<string | null>>;
   onOpenUrl?: (url: string) => void;
   handlersRef: React.RefObject<TranscriptHandlers>;
-  /** The turn whose follow-up pills render above the composer instead of
-   *  in-turn (chat-revamp 1b) — TurnRow suppresses its own row for it. */
-  followUpTurnId: string | null;
 }) {
   const handlers = () => handlersRef.current;
   // Earlier-turns fold ("Chat Session - Prototype.dc.html", cave-u5lq7). The
@@ -8402,13 +8392,11 @@ const TranscriptRows = memo(function TranscriptRows({
           readerPrompt={handlers().readerPromptFor(t)}
           onRerunWith={handlers().rerunWithFor(t)}
           onOpenUrl={onOpenUrl}
-          onSuggestion={(path) => handlers().activateFollowUp(path)}
           onRequest={(prompt) => void handlers().send(prompt)}
           feedbackContext={feedbackContext}
           expanded={expandedAvatarTurnId === t.id}
           onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
           branchNav={singleBranchNav}
-          suppressSuggestions={t.id === followUpTurnId}
         />
       );
       if (!gapLabel) return row;
@@ -8469,13 +8457,11 @@ const TranscriptRows = memo(function TranscriptRows({
               readerPrompt={handlers().readerPromptFor(t)}
               onRerunWith={handlers().rerunWithFor(t)}
               onOpenUrl={onOpenUrl}
-              onSuggestion={(path) => handlers().activateFollowUp(path)}
               onRequest={(prompt) => void handlers().send(prompt)}
               feedbackContext={feedbackContext}
               expanded={expandedAvatarTurnId === t.id}
               onToggleAvatar={() => setExpandedAvatarTurnId((cur) => (cur === t.id ? null : t.id))}
               branchNav={groupBranchNav}
-              suppressSuggestions={t.id === followUpTurnId}
             />
           );
         })}
@@ -8526,19 +8512,13 @@ function TurnRowImpl({
   onOpenUrl,
   expanded = false,
   onToggleAvatar,
-  onSuggestion,
   onRequest,
   feedbackContext,
   branchNav,
-  suppressSuggestions = false,
 }: {
   turn: Turn;
-  onSuggestion?: (path: NextPath) => void;
   /** User-authored artifact feedback remains a normal chat send. */
   onRequest?: (prompt: string) => void;
-  /** Chat-revamp 1b: true for the latest settled turn, whose follow-up pills
-   *  render above the composer instead of at the turn's tail. */
-  suppressSuggestions?: boolean;
   familiar: Familiar;
   showTimestamp?: boolean;
   /** CHAT-D9-04: true while this turn is the just-jumped-to find match —
@@ -8704,7 +8684,6 @@ function TurnRowImpl({
     inlineReasoning,
     skillUpdates,
     autoStatusUpdate,
-    nextPaths,
   } = extractChatRenderedText(turn.text, { pending: Boolean(turn.pending) });
   const reasoning = turn.reasoning?.trim() || inlineReasoning;
   const turnStatus = turn.lifecycle ?? (turn.error ? "failed" : turn.pending ? "streaming" : "complete");
@@ -9003,12 +8982,6 @@ function TurnRowImpl({
                   );
                 })()
               : null}
-            {/* Typed follow-ups render LAST — reply fills the composer, task
-                opens review, and action routes to Tasks; they sit closest to
-                the composer and aren't pushed up by tool activity. */}
-            {nextPaths.length > 0 && !turn.pending && !suppressSuggestions && onSuggestion ? (
-              <FollowUpCards paths={nextPaths} onActivate={onSuggestion} />
-            ) : null}
             {/* Comment on the markdown artifact this turn produced: select any
                 passage above to leave a comment, then request a revision that
                 sends every comment back to the agent. Settled, substantial
@@ -9646,7 +9619,6 @@ function areTurnRowPropsEqual(prev: TurnRowProps, next: TurnRowProps): boolean {
     prev.showTimestamp === next.showTimestamp &&
     prev.found === next.found &&
     prev.expanded === next.expanded &&
-    prev.suppressSuggestions === next.suppressSuggestions &&
     Boolean(prev.onEdit) === Boolean(next.onEdit) &&
     Boolean(prev.onRegenerate) === Boolean(next.onRegenerate) &&
     Boolean(prev.onReply) === Boolean(next.onReply) &&

--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -66,6 +66,11 @@ test("GroupChatView schedules Broadcast and Round robin replies through /api/cha
   );
   assert.match(
     view,
+    /const isLatestRun = runIndex === visibleRuns\.length - 1;[\s\S]*?isLatestRun && agent\.status === "complete"/,
+    "renders next-path actions only for the newest coven run",
+  );
+  assert.match(
+    view,
     /sendSuggestion\(\s*\n\s*path\.prompt,\s*\n\s*agent\.familiarId,\s*\n\s*familiar\?\.display_name \?\? agent\.familiarId,/,
     "clicking a chip targets the familiar who authored it",
   );

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -1792,7 +1792,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                             formatTime={(iso) => formatChatRecency(iso, dtPrefs)}
                           />
                         ) : null}
-                        {visibleRuns.map((run) => {
+                        {visibleRuns.map((run, runIndex) => {
                           const targets = run.user.targetFamiliarIds
                             ?.map((id) => byId.get(id))
                             .filter((f): f is ResolvedFamiliar => Boolean(f));
@@ -1800,6 +1800,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                             ? byId.get(run.user.delegatedByFamiliarId)
                             : undefined;
                           const collapsed = collapsedRuns.has(run.id);
+                          const isLatestRun = runIndex === visibleRuns.length - 1;
                           // While one familiar is live, settled replies soft-clamp
                           // so the turn in progress owns the viewport (§4).
                           const someoneLive = run.agents.some(
@@ -1942,7 +1943,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
                                       // click here sends an ordinary message, never
                                       // a side effect, so only replies are offered.
                                       const suggestions: CovenSuggestion[] =
-                                        agent.status === "complete"
+                                        isLatestRun && agent.status === "complete"
                                           ? typed
                                               .filter((path) => path.kind === "reply")
                                               .map((path) => ({


### PR DESCRIPTION
## Summary
- keep typed follow-up actions only beside the latest eligible solo-chat reply
- hide suggestion actions from historical Coven runs while preserving control-marker stripping
- update focused source-pin regressions for the current chat architecture

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- focused follow-up, transcript memo, group chat, and layout tests

Bead: `cave-rodr5.1`