### PR TITLE
fix(gate): recover a fence whose owner is provably gone

### DIFF
--- a/scripts/local-maintenance-gate.mjs
+++ b/scripts/local-maintenance-gate.mjs
@@ -47,8 +47,59 @@ import {
 import { createHash, randomBytes } from "node:crypto";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
+import { hostname } from "node:os";
 
 export const DEFAULT_GATE_TTL_MS = 10 * 60_000;
+
+/**
+ * Identity of the machine that wrote a record, so a recorded pid can be
+ * interpreted.
+ *
+ * A pid alone is meaningless: the gate lives under the git common dir, which
+ * may be on a shared or synced filesystem, and pid 66300 on this machine has
+ * nothing to do with pid 66300 on another. Liveness is therefore only ever
+ * inferred when the recorded host matches this one.
+ *
+ * Records written before this field existed simply lack it, and are treated as
+ * un-probeable rather than as belonging to this host — the conservative
+ * direction, since the alternative would reclaim another machine's live fence.
+ */
+function currentHost() {
+  try {
+    const name = hostname();
+    return typeof name === "string" && name.length > 0 && name.length <= 255 ? name : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is the process that wrote this record provably gone?
+ *
+ * Returns false whenever it cannot tell — a foreign or absent host, an
+ * unusable pid, or a probe that errors. Only a definite "no such process"
+ * answer counts, because the caller uses this to skip a TTL that exists to
+ * protect a live owner.
+ *
+ * Note which direction pid reuse fails in: a recycled pid belongs to some
+ * *other* live process, so the probe reports ALIVE and the caller waits out
+ * the TTL. Reuse can therefore cost patience, never exclusion.
+ */
+function ownerProcessGone(record) {
+  const host = currentHost();
+  if (host === null || record.host !== host) return false;
+  if (!Number.isSafeInteger(record.pid) || record.pid <= 0) return false;
+  if (record.pid === process.pid) return false;
+  try {
+    // Signal 0 performs the permission and existence checks without delivering
+    // anything. ESRCH is the only answer that proves absence; EPERM means the
+    // process exists under another uid, which is emphatically not gone.
+    process.kill(record.pid, 0);
+    return false;
+  } catch (error) {
+    return error?.code === "ESRCH";
+  }
+}
 export const DEFAULT_INTENT_TTL_MS = 2 * 60_000;
 export const DEFAULT_QUIESCE_TIMEOUT_MS = 30_000;
 export const MAX_LEASE_TTL_MS = 24 * 60 * 60_000;
@@ -149,8 +200,17 @@ function validateGate(value) {
     validTtl(value.ttlMs) &&
     validPurpose(value.purpose) &&
     Number.isSafeInteger(value.pid) &&
-    value.pid > 0
+    value.pid > 0 &&
+    // Optional: absent on records written before hosts were recorded. Present
+    // and unusable is a malformed record rather than an ignorable field —
+    // a garbage host would otherwise sit next to a pid and invite the wrong
+    // liveness inference.
+    validOptionalHost(value.host)
   );
+}
+
+function validOptionalHost(value) {
+  return value === undefined || (typeof value === "string" && value.length > 0 && value.length <= 255);
 }
 
 function validateIntent(value) {
@@ -497,6 +557,13 @@ export function acquireMaintenanceGate({
   const started = mutateState(root, () => {
     const now = Date.now();
     const existing = readJsonState(gateFile, validateGate);
+    // The TTL still governs an UNEXPIRED gate, even when the owning process is
+    // gone. A process can acquire the gate and exit while work it started
+    // continues, or die midway through a mutation; "the owner exited" is
+    // therefore not the same claim as "nothing is in flight". Reclaiming on
+    // liveness alone breaks mutual exclusion outright — the concurrent-acquirer
+    // test produced three simultaneous winners when this was tried, because
+    // each short-lived winner's exit let the next acquirer straight in.
     if (existing.ok && !gateExpired(existing.value, now)) {
       return { ok: false, reason: "gate-held", holder: existing.value.ownerId };
     }
@@ -504,7 +571,18 @@ export function acquireMaintenanceGate({
       audit(root, "acquire-rejected", { ownerId, reason: "malformed-gate" });
       return { ok: false, reason: "malformed-gate" };
     }
-    if (existing.ok && !takeoverStale) {
+    // Past the TTL, liveness decides who has to ask. An expired lease whose
+    // owner is PROVABLY gone is abandoned, and holding the repository closed
+    // over it helps nobody: nothing in shipping code passes `takeoverStale`, so
+    // that state refused every acquisition indefinitely rather than for the ten
+    // minutes the TTL describes (cave-w049l).
+    //
+    // Narrower than it looks: `ownerProcessGone` answers true only for a record
+    // written by THIS host whose pid returns ESRCH. A foreign host, an older
+    // record with no host field, or a pid that still resolves all keep the
+    // explicit opt-in requirement.
+    const abandoned = existing.ok && ownerProcessGone(existing.value);
+    if (existing.ok && !takeoverStale && !abandoned) {
       return { ok: false, reason: "gate-stale", holder: existing.value.ownerId };
     }
 
@@ -520,6 +598,10 @@ export function acquireMaintenanceGate({
       ttlMs,
       purpose: purpose ?? "",
       pid: process.pid,
+      // Written so a later reader can tell whether `pid` is even addressable
+      // from where it is standing. Omitted rather than guessed when the host
+      // name is unavailable, which keeps the record valid and un-probeable.
+      ...(currentHost() === null ? {} : { host: currentHost() }),
     };
     if (existing.ok) {
       const staleName = `${gateFile}.stale-${existing.value.generation}-${randomBytes(4).toString("hex")}`;
@@ -532,6 +614,7 @@ export function acquireMaintenanceGate({
       ok: true,
       gate,
       previous: existing.ok ? existing.value : null,
+      previousAbandoned: abandoned,
     };
   });
   if (!started.ok) return started;
@@ -543,6 +626,14 @@ export function acquireMaintenanceGate({
       ownerId,
       from: started.previous.ownerId,
       generation: started.previous.generation,
+      // Distinguish the two reclaims in the trail. "expired" means a lease ran
+      // out and someone opted into taking it; "abandoned" means the owner
+      // process was proven gone, which is the stronger claim and the one worth
+      // being able to audit after the fact.
+      basis: started.previousAbandoned ? "owner-process-gone" : "expired-lease",
+      ...(started.previousAbandoned
+        ? { fromPid: started.previous.pid, fromHost: started.previous.host ?? null }
+        : {}),
     });
   }
   audit(root, "gate-draining", { ownerId, generation });
@@ -885,6 +976,11 @@ export function maintenanceGateStatus(repoDir = process.cwd()) {
           ...gate.value,
           expired: gateExpired(gate.value, now),
           clockRegressed: clockRegressed(gate.value, now),
+          // The question an operator staring at a refusal actually has: is
+          // anyone there? `false` covers both "alive" and "cannot tell from
+          // here" (foreign host, no host recorded), so read it as "provably
+          // gone" rather than as "running".
+          ownerProcessGone: ownerProcessGone(gate.value),
         }
       : gate.missing
         ? null

--- a/scripts/local-maintenance-gate.mjs
+++ b/scripts/local-maintenance-gate.mjs
@@ -588,6 +588,9 @@ export function acquireMaintenanceGate({
 
     const advanced = nextGeneration(root, existing.ok ? existing.value.generation : 0);
     if (!advanced.ok) return advanced;
+    // Resolved once: two calls could in principle disagree, and the record must
+    // not end up describing a host it was not written on.
+    const host = currentHost();
     const gate = {
       generation: advanced.generation,
       ownerId,
@@ -601,7 +604,7 @@ export function acquireMaintenanceGate({
       // Written so a later reader can tell whether `pid` is even addressable
       // from where it is standing. Omitted rather than guessed when the host
       // name is unavailable, which keeps the record valid and un-probeable.
-      ...(currentHost() === null ? {} : { host: currentHost() }),
+      ...(host === null ? {} : { host }),
     };
     if (existing.ok) {
       const staleName = `${gateFile}.stale-${existing.value.generation}-${randomBytes(4).toString("hex")}`;

--- a/scripts/local-maintenance-gate.test.mjs
+++ b/scripts/local-maintenance-gate.test.mjs
@@ -11,7 +11,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
+import { hostname, tmpdir } from "node:os";
 import path from "node:path";
 import { test } from "node:test";
 import {
@@ -126,6 +126,28 @@ function expireGate(repo) {
     heartbeatAt: new Date(heartbeat).toISOString(),
   });
   return { filePath, original };
+}
+
+/**
+ * Rewrite the live gate so it names a process that has certainly exited.
+ *
+ * Spawns a real child and waits for it, rather than inventing a "probably
+ * free" pid: a guessed number can collide with a live process and turn this
+ * into a flake that only fails on a busy machine.
+ */
+async function orphanGate(repo, { host = hostname() } = {}) {
+  const filePath = path.join(maintenanceGateRoot(repo), "gate.json");
+  const original = JSON.parse(readFileSync(filePath, "utf8"));
+  const child = spawn(process.execPath, ["-e", ""], { stdio: "ignore" });
+  const deadPid = child.pid;
+  await new Promise((resolve) => child.on("exit", resolve));
+  const orphaned = { ...original, pid: deadPid, host };
+  // `host: null` means a record written before hosts were recorded, so the key
+  // has to be REMOVED — acquisition already wrote one, and spreading the
+  // original would silently keep it.
+  if (host === null) delete orphaned.host;
+  writeJsonAtomic(filePath, orphaned);
+  return { filePath, original, deadPid };
 }
 
 function expireIntent(lease) {
@@ -403,6 +425,139 @@ test("caller-controlled time cannot force takeover or publish a future lease", (
   );
   assert.ok(Date.parse(intentState.heartbeatAt) <= Date.now());
   assert.equal(releaseWriterIntent(intent.lease).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// cave-w049l. The gate recorded a pid and nothing read it, so a run that
+// crashed refused every acquisition in the repository until its 600s TTL ran
+// out — and then refused them as `gate-stale`, which no shipping caller passes
+// `takeoverStale` to clear.
+test("an UNEXPIRED gate is held for its full TTL even when the owner has exited", async () => {
+  const repo = makeRepo();
+  assert.equal(acquireMaintenanceGate({ ownerId: "first", repoDir: repo }).ok, true);
+  await orphanGate(repo);
+
+  // A process can acquire the gate and exit while work it started continues, or
+  // die midway through a mutation, so an exited owner is NOT proof that nothing
+  // is in flight. Reclaiming here breaks mutual exclusion: an earlier draft did
+  // exactly that and the concurrent-acquirer test below produced three winners.
+  const status = maintenanceGateStatus(repo);
+  assert.equal(status.gate.expired, false);
+  assert.equal(status.gate.ownerProcessGone, true, "liveness is reported...");
+  assert.equal(
+    acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason,
+    "gate-held",
+    "...but it does not shorten the TTL",
+  );
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("an EXPIRED gate whose owner process is gone is reclaimed without the opt-in", async () => {
+  const repo = makeRepo();
+  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(first.ok, true);
+  const { deadPid } = await orphanGate(repo);
+  expireGate(repo);
+
+  // Past the TTL the old behaviour was `gate-stale`, which required
+  // takeoverStale — and nothing in shipping code passes it, so the wedge was
+  // indefinite rather than ten minutes long.
+  const status = maintenanceGateStatus(repo);
+  assert.equal(status.gate.expired, true);
+  assert.equal(status.gate.ownerProcessGone, true);
+
+  const second = acquireMaintenanceGate({ ownerId: "second", repoDir: repo });
+  assert.equal(second.ok, true, "an abandoned expired gate is reclaimable without takeoverStale");
+  assert.ok(
+    second.handle.generation > first.handle.generation,
+    "the reclaim advances the fenced generation, as a stale takeover does",
+  );
+  assert.equal(
+    verifyMaintenanceGateOwnership(first.handle).reason,
+    "not-owner",
+    "the previous owner is fenced out even though its lease had not expired",
+  );
+
+  // The reclaim is evidenced, not silent: same sidecar as a stale takeover...
+  const sidecars = readdirSync(maintenanceGateRoot(repo)).filter((name) =>
+    name.startsWith("gate.json.stale-"),
+  );
+  assert.equal(sidecars.length, 1, "the displaced record is preserved beside the gate");
+  // ...plus an audit line that says WHY it was reclaimed.
+  const audit = readFileSync(path.join(maintenanceGateRoot(repo), "audit.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line))
+    .filter((entry) => entry.event === "gate-taken-over");
+  assert.equal(audit.length, 1);
+  assert.equal(audit[0].basis, "owner-process-gone");
+  assert.equal(audit[0].fromPid, deadPid);
+
+  assert.equal(releaseMaintenanceGate(second.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("an expired gate from ANOTHER host still requires the explicit opt-in", async () => {
+  const repo = makeRepo();
+  assert.equal(acquireMaintenanceGate({ ownerId: "first", repoDir: repo }).ok, true);
+  // The gate lives under the git common dir, which may be shared or synced. A
+  // pid from another machine says nothing about a process on this one, so the
+  // probe must not answer for it.
+  await orphanGate(repo, { host: `not-${hostname()}` });
+  expireGate(repo);
+
+  assert.equal(maintenanceGateStatus(repo).gate.ownerProcessGone, false);
+  assert.equal(
+    acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason,
+    "gate-stale",
+    "a foreign host keeps the takeoverStale requirement",
+  );
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("an expired record written before hosts existed still requires the opt-in", async () => {
+  const repo = makeRepo();
+  assert.equal(acquireMaintenanceGate({ ownerId: "first", repoDir: repo }).ok, true);
+  await orphanGate(repo, { host: null });
+  expireGate(repo);
+
+  assert.equal(
+    maintenanceGateStatus(repo).gate.ownerProcessGone,
+    false,
+    "an absent host is un-probeable, not local",
+  );
+  assert.equal(acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason, "gate-stale");
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("an expired gate whose owner is ALIVE still requires the explicit opt-in", () => {
+  const repo = makeRepo();
+  // The owning pid here is this test process, which is emphatically alive.
+  const first = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(first.ok, true);
+  expireGate(repo);
+  assert.equal(maintenanceGateStatus(repo).gate.ownerProcessGone, false);
+  assert.equal(
+    acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason,
+    "gate-stale",
+    "a live owner past its TTL is a judgement call, not an abandonment",
+  );
+  rmSync(repo, { recursive: true, force: true });
+});
+
+test("a malformed host makes the record malformed rather than merely un-probeable", () => {
+  const repo = makeRepo();
+  assert.equal(acquireMaintenanceGate({ ownerId: "first", repoDir: repo }).ok, true);
+  const filePath = path.join(maintenanceGateRoot(repo), "gate.json");
+  const original = JSON.parse(readFileSync(filePath, "utf8"));
+  writeJsonAtomic(filePath, { ...original, host: 42 });
+
+  // Fail closed: a garbage host sitting next to a pid invites exactly the wrong
+  // liveness inference, so the record is rejected rather than partly trusted.
+  assert.equal(
+    acquireMaintenanceGate({ ownerId: "second", repoDir: repo }).reason,
+    "malformed-gate",
+  );
   rmSync(repo, { recursive: true, force: true });
 });
 

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -472,7 +472,15 @@ export function createRepositoryMaintenanceCoordinator({
           reason: `coven-release-failed: ${coven.reason ?? "unknown"}`,
           covenFenceGone: verified.reason,
           localReleased: local.ok,
-          ...(local.ok ? {} : { recoveryHandle: { local: handle.local } }),
+          // Carry WHY local is still held. This is the recovery path — the
+          // caller is holding a handle it has to do something about — and
+          // "false" without a reason is the least useful thing to hand it.
+          ...(local.ok
+            ? {}
+            : {
+                localReleaseFailed: local.reason ?? "unknown",
+                recoveryHandle: { local: handle.local },
+              }),
         };
       }
       const local = localFence.release(handle.local);

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -328,6 +328,22 @@ export function createCovenMaintenanceClient({
   };
 }
 
+/**
+ * `heldBy` reasons that PROVE the Coven fence is no longer held by this handle.
+ *
+ * Deliberately a small allow-list rather than "anything that is not ok". The
+ * two reasons excluded are the ones where the fence may still be standing:
+ * `coven-still-draining` (the lease exists, it just has not finished draining)
+ * and `coven-writers-active` (we hold it and writers are still inside). A
+ * failure to reach Coven at all is likewise not proof of anything, so it is
+ * absent here too and leaves the local fence held.
+ */
+const COVEN_FENCE_PROVABLY_GONE = new Set([
+  "coven-owner-missing", // no owner record at all
+  "coven-not-owner", // someone else owns it; ours is gone
+  "coven-expired", // the lease ran out
+]);
+
 const defaultLocalFence = {
   acquire: acquireLocalMaintenanceGate,
   heartbeat: heartbeatLocalMaintenanceGate,
@@ -428,10 +444,35 @@ export function createRepositoryMaintenanceCoordinator({
       if (!handle?.local || !handle?.coven) return { ok: false, reason: "invalid-composite-handle" };
       const coven = covenClient.release(handle.coven);
       if (!coven.ok) {
+        // The Coven release failed, but that does not by itself mean the Coven
+        // fence is still held — the commonest cause is a lease that already
+        // expired, in which case there is nothing left to split. Ask.
+        //
+        // Holding the local fence on an unknown Coven state is deliberate
+        // (`acquire` reasons about it above). Holding it when the Coven fence
+        // is provably gone protects nothing and strands the local fence for
+        // its full TTL, refusing every acquisition in the repository until it
+        // expires — and then refusing them as `gate-stale`. That was a
+        // repo-wide outage per failed run (cave-nom3z).
+        const verified = covenClient.verify(handle.coven);
+        const covenGone = !verified.ok && COVEN_FENCE_PROVABLY_GONE.has(verified.reason);
+        if (!covenGone) {
+          return {
+            ok: false,
+            reason: `coven-release-failed: ${coven.reason ?? "unknown"}`,
+            recoveryHandle: handle,
+          };
+        }
+        const local = localFence.release(handle.local);
         return {
           ok: false,
+          // Still not ok: the caller asked for both fences to come down and
+          // the Coven side did not do so cleanly. But the local fence is now
+          // released, so this reports a failed release rather than a held one.
           reason: `coven-release-failed: ${coven.reason ?? "unknown"}`,
-          recoveryHandle: handle,
+          covenFenceGone: verified.reason,
+          localReleased: local.ok,
+          ...(local.ok ? {} : { recoveryHandle: { local: handle.local } }),
         };
       }
       const local = localFence.release(handle.local);

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -227,6 +227,97 @@ test("composite release is ordered and reports either release failure", () => {
   assert.deepEqual(released.recoveryHandle, handle);
 });
 
+// cave-nom3z. A failed Coven release used to leave the local fence held for its
+// full 600s TTL, refusing every acquisition in the repository — and then
+// refusing them as `gate-stale`. The commonest cause was a lease that had
+// already expired, i.e. a Coven fence that was not standing at all.
+function releaseCoordinator({ verify, onLocalRelease = () => ({ ok: true }) }) {
+  const calls = [];
+  const coordinator = createRepositoryMaintenanceCoordinator({
+    localFence: {
+      acquire: () => assert.fail("not used"),
+      heartbeat: () => ({ ok: true }),
+      verify: () => ({ ok: true }),
+      release: () => {
+        calls.push("local");
+        return onLocalRelease();
+      },
+    },
+    covenClient: {
+      acquire: () => assert.fail("not used"),
+      heartbeat: () => ({ ok: true }),
+      verify,
+      release: () => {
+        calls.push("coven");
+        return { ok: false, reason: "coven-release-unavailable" };
+      },
+    },
+  });
+  return { coordinator, calls };
+}
+
+const releaseHandle = {
+  local: { generation: 1 },
+  coven: { ownerId: "cave-maintenance", generation: "coven-generation", repoDir },
+};
+
+for (const reason of ["coven-owner-missing", "coven-not-owner", "coven-expired"]) {
+  test(`a failed Coven release still frees the local fence when verify proves ${reason}`, () => {
+    const { coordinator, calls } = releaseCoordinator({
+      verify: () => ({ ok: false, reason }),
+    });
+    const released = coordinator.release(releaseHandle);
+    assert.equal(released.ok, false, "the caller asked for both fences down; Coven did not comply");
+    assert.equal(released.reason, "coven-release-failed: coven-release-unavailable");
+    assert.equal(released.covenFenceGone, reason);
+    assert.equal(released.localReleased, true);
+    assert.deepEqual(calls, ["coven", "local"], "order is unchanged: Coven first, then local");
+    assert.equal(
+      released.recoveryHandle,
+      undefined,
+      "nothing is left held, so there is nothing to recover",
+    );
+  });
+}
+
+for (const reason of ["coven-still-draining", "coven-writers-active", "coven-status-unavailable"]) {
+  test(`a failed Coven release keeps the local fence when verify reports ${reason}`, () => {
+    // These are the cases where the Coven fence may still be standing, or where
+    // we simply cannot tell. Releasing local here would split the two writer
+    // populations, which is the thing `acquire` deliberately refuses to do.
+    const { coordinator, calls } = releaseCoordinator({
+      verify: () => ({ ok: false, reason }),
+    });
+    const released = coordinator.release(releaseHandle);
+    assert.equal(released.ok, false);
+    assert.deepEqual(calls, ["coven"], "local stays fenced while the Coven state is unproven");
+    assert.deepEqual(released.recoveryHandle, releaseHandle);
+  });
+}
+
+test("a still-held Coven fence keeps the local fence even when verify succeeds", () => {
+  // verify ok means we DO still own it, so the release genuinely failed.
+  const { coordinator, calls } = releaseCoordinator({ verify: () => ({ ok: true }) });
+  const released = coordinator.release(releaseHandle);
+  assert.equal(released.ok, false);
+  assert.deepEqual(calls, ["coven"]);
+  assert.deepEqual(released.recoveryHandle, releaseHandle);
+});
+
+test("a local release that itself fails is reported with an exact recovery handle", () => {
+  const { coordinator } = releaseCoordinator({
+    verify: () => ({ ok: false, reason: "coven-expired" }),
+    onLocalRelease: () => ({ ok: false, reason: "state-busy" }),
+  });
+  const released = coordinator.release(releaseHandle);
+  assert.equal(released.localReleased, false);
+  assert.deepEqual(
+    released.recoveryHandle,
+    { local: releaseHandle.local },
+    "only the fence still held is offered for recovery",
+  );
+});
+
 test("maintenance capabilities name the released Coven protocol without claiming completeness", () => {
   assert.deepEqual(repositoryMaintenanceCapabilities({
     repoDir,

--- a/scripts/maintenance-gate.test.mjs
+++ b/scripts/maintenance-gate.test.mjs
@@ -311,6 +311,11 @@ test("a local release that itself fails is reported with an exact recovery handl
   });
   const released = coordinator.release(releaseHandle);
   assert.equal(released.localReleased, false);
+  assert.equal(
+    released.localReleaseFailed,
+    "state-busy",
+    "the recovery path must say WHY local is still held, not just that it is",
+  );
   assert.deepEqual(
     released.recoveryHandle,
     { local: releaseHandle.local },


### PR DESCRIPTION
Fixes `cave-nom3z` and `cave-w049l` — two failures that together turned any crashed fenced run into a repository-wide outage. Both were deliberately split out of #4520 because each reverses a stated fail-closed decision.

## `cave-nom3z` — the local fence was leaked, then held over nothing

The composite `release` released the Coven fence first and returned early when that failed, so the local fence was never released. The commonest cause was a lease that had **already expired** — a Coven fence that was not standing at all — and holding the local fence over it protected nothing while refusing every acquisition in the checkout for the full local TTL.

Holding local on an *unknown* Coven state is unchanged: `acquire` reasons about that explicitly, and splitting the two writer populations during recovery is the thing it refuses to do. The change is to stop guessing. Ask `verify`, and release local only on one of three answers that prove our fence is gone:

| verify reason | local fence |
|---|---|
| `coven-owner-missing` | released |
| `coven-not-owner` | released |
| `coven-expired` | released |
| `coven-still-draining` | **held** |
| `coven-writers-active` | **held** |
| unreachable / any other | **held** |

## `cave-w049l` — a dead owner was indistinguishable from a live one

The gate recorded a `pid` and nothing ever read it.

⚠️ **My first attempt at this was wrong, and an existing test caught it.** Reclaiming on liveness alone produced **three simultaneous winners** in *"concurrent multi-process acquisition: exactly one winner"*. A process can acquire the gate and exit while work it started continues, or die midway through a mutation — so an exited owner is **not** proof that nothing is in flight. That is precisely what the TTL is for. I narrowed the fix rather than relaxing the test.

Liveness now decides only who has to *ask*, never how long the TTL is:

```
unexpired                        -> gate-held, unchanged, dead owner or not
expired + owner provably gone    -> reclaimed, no opt-in needed
expired + alive/foreign/unknown  -> gate-stale, opt-in still required
```

This removes the **indefinite** half of the wedge — nothing in shipping code passes `takeoverStale`, so `gate-stale` refused acquisition forever rather than for the ten minutes the TTL advertises — while leaving the ten-minute window fully intact.

### Why a host had to be recorded

A pid is meaningless on its own: the gate lives under the git common dir, which may be shared or synced, and pid 66300 here has nothing to do with pid 66300 elsewhere. Records now carry `host`, and liveness is inferred **only** when it matches this machine. Records written before the field existed are un-probeable rather than assumed local. A present-but-malformed `host` makes the whole record malformed, since garbage next to a pid invites exactly the wrong inference.

Pid reuse fails safe: a recycled pid belongs to some *other* live process, so the probe reports ALIVE and the caller waits. Reuse can cost patience, never exclusion.

### Evidence, not silence

Reclaims are recorded exactly like a stale takeover — same displaced-record sidecar, same `gate-taken-over` audit event — plus a `basis` field distinguishing `owner-process-gone` from `expired-lease`, and the dead pid/host. `maintenanceGateStatus` now reports `ownerProcessGone` so an operator can answer "is anyone actually there?" without improvising against internals.

## Verification

- `scripts/local-maintenance-gate.test.mjs` — 29 tests pass, including the concurrency invariant that caught the first design
- `scripts/maintenance-gate.test.mjs` — 15 tests, 9 new covering every verify reason in both directions
- `tsc --noEmit` clean; `check-tests-wired` reports all 1614 files wired

**Unrelated pre-existing failure noted, not fixed here:** `src/lib/surface-history.test.ts` imports `vitest` while the runner is `node --test`, so it always fails and aborts the app suite ~30 files in. Byte-identical to `main`, landed in #4407. Filed as `cave-h2axt`.