### PR TITLE
Enforce orchestration invariants at Board mutators

### DIFF
--- a/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
+++ b/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
@@ -184,8 +184,9 @@ at the offending field:
 | `dependency_dangling` | I4, unknown `taskId` or `primaryBlockerId` |
 | `dependency_needs_evidence` | I5 |
 | `dependency_invalid` | Dependency payload is malformed or repeats an id |
-| `primary_blocker_invalid` | Primary blocker is neither null nor a non-empty id |
+| `primary_blocker_invalid` | Primary blocker or pin has an invalid runtime shape |
 | `next_step_invalid` | Next-step payload is missing required structured fields |
+| `next_step_requires_approval` | Dispatch or execution was attempted before approval cleared |
 | `dependency_authorship` | I6, automation tried to overwrite a human dependency |
 | `next_step_authorship` | I6, automation tried to overwrite a human next step |
 

--- a/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
+++ b/docs/superpowers/specs/2026-08-03-orchestration-ready-task-shape-design.md
@@ -183,6 +183,9 @@ at the offending field:
 | `dependency_cycle` | I4, task edge closes a cycle |
 | `dependency_dangling` | I4, unknown `taskId` or `primaryBlockerId` |
 | `dependency_needs_evidence` | I5 |
+| `dependency_invalid` | Dependency payload is malformed or repeats an id |
+| `primary_blocker_invalid` | Primary blocker is neither null nor a non-empty id |
+| `next_step_invalid` | Next-step payload is missing required structured fields |
 | `dependency_authorship` | I6, automation tried to overwrite a human dependency |
 | `next_step_authorship` | I6, automation tried to overwrite a human next step |
 

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1327,6 +1327,7 @@ export const SUITES = {
     "src/lib/server/runtime-compatibility-registry.test.ts",
     "src/app/api/board/enrich-steps/route.test.ts",
     "src/app/api/board/route.test.ts",
+    "src/app/api/board/orchestration-route.test.ts",
     "src/app/api/board/[id]/chat/route.test.ts",
     "src/app/api/sessions/route.test.ts",
     "src/app/api/sessions/list/route.test.ts",
@@ -1689,6 +1690,7 @@ const ALIAS_LOADER = new Set([
   "src/components/role-surfaces/research-studio-providers.test.ts",
   "src/lib/daemon-desktop-auto-start.test.ts",
   "src/lib/cave-board-orchestration.test.ts",
+  "src/app/api/board/orchestration-route.test.ts",
   "src/lib/chat-live-generation-identity.test.ts",
   "src/lib/podcast-script.test.ts",
   // resolves "@/lib/tool-visual" for the batch band's tint

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1107,6 +1107,7 @@ export const SUITES = {
     "src/lib/server/codex-oauth-port.test.ts",
     "src/lib/env-local-bundle.test.ts",
     "src/lib/cave-board-schedule.test.ts",
+    "src/lib/cave-board-orchestration.test.ts",
     "src/lib/cave-board-model-override.test.ts",
     "src/components/ui/tabs.test.ts",
     "src/components/ui/charts/charts.test.ts",
@@ -1687,6 +1688,7 @@ const ALIAS_LOADER = new Set([
   "src/components/role-surfaces/research-library-view.test.ts",
   "src/components/role-surfaces/research-studio-providers.test.ts",
   "src/lib/daemon-desktop-auto-start.test.ts",
+  "src/lib/cave-board-orchestration.test.ts",
   "src/lib/chat-live-generation-identity.test.ts",
   "src/lib/podcast-script.test.ts",
   // resolves "@/lib/tool-visual" for the batch band's tint
@@ -1833,6 +1835,7 @@ const ALIAS_LOADER = new Set([
   "src/lib/cave-board-ops.test.ts",
   "src/lib/cave-board-attachments.test.ts",
   "src/lib/cave-board-schedule.test.ts",
+  "src/lib/cave-board-orchestration.test.ts",
   "src/lib/cave-board-model-override.test.ts",
   "src/lib/salem/pathfinder-feedback.test.ts",
   "src/lib/message-feedback-rollup.test.ts",

--- a/src/app/api/board/[id]/lifecycle/route.ts
+++ b/src/app/api/board/[id]/lifecycle/route.ts
@@ -14,23 +14,33 @@ export async function POST(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  let body: { to?: string; reason?: string; retry?: boolean };
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
   }
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  const body = rawBody as { to?: unknown; reason?: unknown; retry?: unknown };
   if (!body.to || !LIFECYCLES.includes(body.to as CardLifecycle)) {
     return NextResponse.json(
       { ok: false, error: `missing or invalid 'to' (must be one of: ${LIFECYCLES.join(", ")})` },
       { status: 400 },
     );
   }
+  if (body.reason !== undefined && typeof body.reason !== "string") {
+    return NextResponse.json({ ok: false, error: "invalid reason" }, { status: 400 });
+  }
+  if (body.retry !== undefined && typeof body.retry !== "boolean") {
+    return NextResponse.json({ ok: false, error: "invalid retry flag" }, { status: 400 });
+  }
   try {
     const card = await transitionCard(id, {
       to: body.to as CardLifecycle,
-      reason: body.reason,
-      retry: body.retry,
+      reason: body.reason as string | undefined,
+      retry: body.retry as boolean | undefined,
     });
     if (!card) {
       return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });

--- a/src/app/api/board/[id]/lifecycle/route.ts
+++ b/src/app/api/board/[id]/lifecycle/route.ts
@@ -1,5 +1,10 @@
 import { NextResponse } from "next/server";
-import { transitionCard, type CardLifecycle, LIFECYCLES } from "@/lib/cave-board";
+import {
+  LIFECYCLES,
+  OrchestrationValidationError,
+  transitionCard,
+  type CardLifecycle,
+} from "@/lib/cave-board";
 import { handleTaskCompletion } from "@/lib/task-archive-nudge-emit";
 
 export const dynamic = "force-dynamic";
@@ -38,6 +43,12 @@ export async function POST(
     }
     return NextResponse.json({ ok: true, card });
   } catch (err) {
+    if (err instanceof OrchestrationValidationError) {
+      return NextResponse.json(
+        { ok: false, error: "orchestration_invalid", errors: err.errors },
+        { status: 422 },
+      );
+    }
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "transition failed" },
       { status: 409 },

--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -2,18 +2,27 @@ import { NextResponse } from "next/server";
 import {
   deleteCard,
   loadBoard,
+  OrchestrationValidationError,
   updateCard,
   type CardLifecycle,
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
-import type { CardStep } from "@/lib/cave-board-types";
+import type { CardStep, TaskDependency, TaskNextStep } from "@/lib/cave-board-types";
 import type { CardAsanaLink, CardGitHubLink } from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
-import type { CardOps } from "@/lib/board-card-ops";
+import type { CardOps, CardPatch } from "@/lib/board-card-ops";
 import { trustedProjectCwd } from "@/lib/cave-projects";
 
 export const dynamic = "force-dynamic";
+
+const PATCH_FIELDS = [
+  "title", "notes", "status", "lifecycle", "lifecycleReason", "priority",
+  "familiarId", "modelOverride", "modelOverrideHarness", "sessionId", "cwd",
+  "projectId", "links", "github", "asana", "labels", "startDate", "endDate",
+  "needsHuman", "runningSince", "steps", "attachments", "dependencies",
+  "primaryBlockerId", "primaryBlockerPinned", "nextStep", "ops",
+] as const satisfies readonly (keyof CardPatch)[];
 
 export async function PATCH(
   req: Request,
@@ -43,6 +52,10 @@ export async function PATCH(
     runningSince: string | undefined;
     steps: CardStep[];
     attachments: ChatAttachment[];
+    dependencies: TaskDependency[];
+    primaryBlockerId: string | null;
+    primaryBlockerPinned: boolean;
+    nextStep: TaskNextStep | null;
     /** Intent ops for array fields — applied against the current card under
      * the board lock so concurrent element edits don't clobber each other. */
     ops: CardOps;
@@ -71,7 +84,22 @@ export async function PATCH(
       if (resolved.ok) body = { ...body, cwd: resolved.root };
     }
   }
-  const card = await updateCard(id, body);
+  const patch = Object.fromEntries(
+    PATCH_FIELDS.filter((field) => Object.prototype.hasOwnProperty.call(body, field))
+      .map((field) => [field, body[field]]),
+  ) as CardPatch;
+  let card;
+  try {
+    card = await updateCard(id, patch);
+  } catch (error) {
+    if (error instanceof OrchestrationValidationError) {
+      return NextResponse.json(
+        { ok: false, error: "orchestration_invalid", errors: error.errors },
+        { status: 422 },
+      );
+    }
+    throw error;
+  }
   if (!card) {
     return NextResponse.json({ ok: false, error: "not found" }, { status: 404 });
   }

--- a/src/app/api/board/[id]/route.ts
+++ b/src/app/api/board/[id]/route.ts
@@ -3,8 +3,8 @@ import {
   deleteCard,
   loadBoard,
   OrchestrationValidationError,
+  STATUSES,
   updateCard,
-  type CardLifecycle,
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
@@ -17,10 +17,10 @@ import { trustedProjectCwd } from "@/lib/cave-projects";
 export const dynamic = "force-dynamic";
 
 const PATCH_FIELDS = [
-  "title", "notes", "status", "lifecycle", "lifecycleReason", "priority",
+  "title", "notes", "status", "lifecycleReason", "priority",
   "familiarId", "modelOverride", "modelOverrideHarness", "sessionId", "cwd",
   "projectId", "links", "github", "asana", "labels", "startDate", "endDate",
-  "needsHuman", "runningSince", "steps", "attachments", "dependencies",
+  "needsHuman", "steps", "attachments", "dependencies",
   "primaryBlockerId", "primaryBlockerPinned", "nextStep", "ops",
 ] as const satisfies readonly (keyof CardPatch)[];
 
@@ -29,11 +29,10 @@ export async function PATCH(
   { params }: { params: Promise<{ id: string }> },
 ) {
   const { id } = await params;
-  let body: Partial<{
+  type PatchBody = Partial<{
     title: string;
     notes: string;
     status: CardStatus;
-    lifecycle: CardLifecycle;
     lifecycleReason: string | undefined;
     priority: CardPriority;
     familiarId: string | null;
@@ -49,7 +48,6 @@ export async function PATCH(
     startDate: string | null;
     endDate: string | null;
     needsHuman: boolean;
-    runningSince: string | undefined;
     steps: CardStep[];
     attachments: ChatAttachment[];
     dependencies: TaskDependency[];
@@ -60,10 +58,24 @@ export async function PATCH(
      * the board lock so concurrent element edits don't clobber each other. */
     ops: CardOps;
   }>;
+  let rawBody: unknown;
   try {
-    body = await req.json();
+    rawBody = await req.json();
   } catch {
     return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  if (!rawBody || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return NextResponse.json({ ok: false, error: "invalid json body" }, { status: 400 });
+  }
+  let body = rawBody as PatchBody;
+  if (body.status !== undefined && !STATUSES.includes(body.status as CardStatus)) {
+    return NextResponse.json({ ok: false, error: "invalid status" }, { status: 400 });
+  }
+  if (body.lifecycleReason !== undefined && typeof body.lifecycleReason !== "string") {
+    return NextResponse.json({ ok: false, error: "invalid lifecycle reason" }, { status: 400 });
+  }
+  if (body.needsHuman !== undefined && typeof body.needsHuman !== "boolean") {
+    return NextResponse.json({ ok: false, error: "invalid needs-human flag" }, { status: 400 });
   }
   // Keep a card's cwd consistent with its project, server-side (cave-pw83):
   //  - assigning a project (projectId set) → derive cwd from it, ignoring the body's;

--- a/src/app/api/board/enrich-steps/route.test.ts
+++ b/src/app/api/board/enrich-steps/route.test.ts
@@ -116,6 +116,16 @@ assert.match(
   /await updateCard\(card\.id, \{[\s\S]*notes:[\s\S]*startDate:[\s\S]*endDate:[\s\S]*links:[\s\S]*github:[\s\S]*sessionId:/,
   "Enrich route should persist simplified description, dates, associated issue links, and chat assignment together",
 );
+assert.match(
+  source,
+  /\}, \{ automated: true \}\)/,
+  "Enrich writes must identify themselves as automation for authorship enforcement",
+);
+assert.match(
+  source,
+  /error instanceof OrchestrationValidationError[\s\S]*reason: "orchestration_invalid"[\s\S]*errors: error\.errors/,
+  "Enrich should report field-specific orchestration rejections per card",
+);
 
 assert.match(
   source,

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -548,7 +548,7 @@ export async function POST(req: Request) {
             needsHuman: normalized.needsHuman,
             lifecycleReason: normalized.lifecycleReason,
             lifecycleAt: normalized.lifecycleAt,
-          });
+          }, { automated: true });
           if (!updated) {
             push({ kind: "skip", cardId: card.id, reason: "card_missing" });
             continue;
@@ -572,7 +572,7 @@ export async function POST(req: Request) {
           needsHuman: normalized.needsHuman,
           lifecycleReason: normalized.lifecycleReason,
           lifecycleAt: normalized.lifecycleAt,
-        });
+        }, { automated: true });
         if (!updated) {
           push({ kind: "skip", cardId: card.id, reason: "card_missing" });
           continue;

--- a/src/app/api/board/enrich-steps/route.ts
+++ b/src/app/api/board/enrich-steps/route.ts
@@ -1,4 +1,8 @@
-import { loadBoard, updateCard } from "@/lib/cave-board";
+import {
+  loadBoard,
+  OrchestrationValidationError,
+  updateCard,
+} from "@/lib/cave-board";
 import {
   LIFECYCLES,
   PRIORITIES,
@@ -534,7 +538,47 @@ export async function POST(req: Request) {
             push({ kind: "skip", cardId: card.id, reason: "no_task_metadata_parsed" });
             continue;
           }
-          const updated = await updateCard(card.id, {
+          let updated;
+          try {
+            updated = await updateCard(card.id, {
+              notes: normalized.notes,
+              steps: normalized.steps,
+              status: normalized.status,
+              lifecycle: normalized.lifecycle,
+              priority: normalized.priority,
+              startDate: normalized.startDate,
+              endDate: normalized.endDate,
+              links: normalized.links,
+              github: normalized.github,
+              sessionId: normalized.sessionId,
+              needsHuman: normalized.needsHuman,
+              lifecycleReason: normalized.lifecycleReason,
+              lifecycleAt: normalized.lifecycleAt,
+            }, { automated: true });
+          } catch (error) {
+            if (error instanceof OrchestrationValidationError) {
+              push({
+                kind: "skip",
+                cardId: card.id,
+                reason: "orchestration_invalid",
+                errors: error.errors,
+              });
+              continue;
+            }
+            throw error;
+          }
+          if (!updated) {
+            push({ kind: "skip", cardId: card.id, reason: "card_missing" });
+            continue;
+          }
+          push({ kind: "done", cardId: card.id, count: normalized.steps.length });
+          continue;
+        }
+
+        const normalized = applyGitHubState(card, normalizeTaskEnrichment(card, enrichment, now), githubState, now);
+        let updated;
+        try {
+          updated = await updateCard(card.id, {
             notes: normalized.notes,
             steps: normalized.steps,
             status: normalized.status,
@@ -549,30 +593,18 @@ export async function POST(req: Request) {
             lifecycleReason: normalized.lifecycleReason,
             lifecycleAt: normalized.lifecycleAt,
           }, { automated: true });
-          if (!updated) {
-            push({ kind: "skip", cardId: card.id, reason: "card_missing" });
+        } catch (error) {
+          if (error instanceof OrchestrationValidationError) {
+            push({
+              kind: "skip",
+              cardId: card.id,
+              reason: "orchestration_invalid",
+              errors: error.errors,
+            });
             continue;
           }
-          push({ kind: "done", cardId: card.id, count: normalized.steps.length });
-          continue;
+          throw error;
         }
-
-        const normalized = applyGitHubState(card, normalizeTaskEnrichment(card, enrichment, now), githubState, now);
-        const updated = await updateCard(card.id, {
-          notes: normalized.notes,
-          steps: normalized.steps,
-          status: normalized.status,
-          lifecycle: normalized.lifecycle,
-          priority: normalized.priority,
-          startDate: normalized.startDate,
-          endDate: normalized.endDate,
-          links: normalized.links,
-          github: normalized.github,
-          sessionId: normalized.sessionId,
-          needsHuman: normalized.needsHuman,
-          lifecycleReason: normalized.lifecycleReason,
-          lifecycleAt: normalized.lifecycleAt,
-        }, { automated: true });
         if (!updated) {
           push({ kind: "skip", cardId: card.id, reason: "card_missing" });
           continue;

--- a/src/app/api/board/orchestration-route.test.ts
+++ b/src/app/api/board/orchestration-route.test.ts
@@ -48,6 +48,34 @@ assert.equal(createdResponse.status, 200);
 const createdBody = await createdResponse.json();
 const cardId = createdBody.card.id as string;
 
+const invalidStatus = await PATCH(
+  request("PATCH", { status: "teleported" }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(invalidStatus.status, 400);
+assert.equal((await invalidStatus.json()).error, "invalid status");
+
+const derivedStatus = await PATCH(
+  request("PATCH", {
+    status: "done",
+    lifecycle: "failed",
+    lifecycleReason: "Marked done from a linked chat",
+    needsHuman: true,
+  }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(derivedStatus.status, 200);
+const derivedStatusBody = await derivedStatus.json();
+assert.equal(derivedStatusBody.card.lifecycle, "completed");
+assert.equal(derivedStatusBody.card.needsHuman, false);
+assert.equal(derivedStatusBody.card.lifecycleReason, "Marked done from a linked chat");
+
+const resetStatus = await PATCH(
+  request("PATCH", { status: "backlog" }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(resetStatus.status, 200);
+
 const invalidPatch = await PATCH(
   request("PATCH", {
     id: "forged-id",
@@ -84,6 +112,34 @@ assert.notEqual(
   "PATCH cannot replace createdAt",
 );
 assert.equal(renamedBody.card.title, "Renamed safely");
+
+const approvalResponse = await POST(request("POST", {
+  title: "Approval route target",
+  nextStep: {
+    summary: "Approve task dispatch",
+    requiresApproval: true,
+    origin: "human",
+    updatedAt: new Date().toISOString(),
+  },
+}));
+const approvalId = (await approvalResponse.json()).card.id as string;
+const blockedDispatch = await transition(
+  request("POST", { to: "dispatched" }),
+  { params: Promise.resolve({ id: approvalId }) },
+);
+assert.equal(blockedDispatch.status, 422);
+assert.ok(
+  (await blockedDispatch.json()).errors.some(
+    (error: { code: string }) => error.code === "next_step_requires_approval",
+  ),
+);
+
+const malformedReason = await transition(
+  request("POST", { to: "dispatched", reason: {} }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(malformedReason.status, 400);
+assert.equal((await malformedReason.json()).error, "invalid reason");
 
 const boardPath = path.join(caveHome, "board.json");
 const boardFile = JSON.parse(await readFile(boardPath, "utf8"));

--- a/src/app/api/board/orchestration-route.test.ts
+++ b/src/app/api/board/orchestration-route.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const caveHome = await mkdtemp(path.join(tmpdir(), "cave-board-orchestration-route-"));
+process.env.HOME = caveHome;
+process.env.COVEN_HOME = path.join(caveHome, ".coven");
+process.env.COVEN_CAVE_HOME = caveHome;
+
+const { POST } = await import("./route.ts");
+const { PATCH } = await import("./[id]/route.ts");
+const { POST: transition } = await import("./[id]/lifecycle/route.ts");
+
+function request(method: "POST" | "PATCH", body: unknown): Request {
+  return new Request("http://127.0.0.1/api/board", {
+    method,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const invalidCreate = await POST(request("POST", {
+  title: "Invalid blocked task",
+  status: "blocked",
+}));
+assert.equal(invalidCreate.status, 422);
+const invalidCreateBody = await invalidCreate.json();
+assert.equal(invalidCreateBody.error, "orchestration_invalid");
+assert.deepEqual(
+  new Set(invalidCreateBody.errors.map((error: { code: string }) => error.code)),
+  new Set(["blocked_requires_dependency", "blocked_requires_next_step"]),
+);
+
+const malformedCreate = await POST(request("POST", {
+  title: "Malformed dependency",
+  dependencies: [null],
+}));
+assert.equal(malformedCreate.status, 422);
+assert.ok(
+  (await malformedCreate.json()).errors.some(
+    (error: { code: string }) => error.code === "dependency_invalid",
+  ),
+);
+
+const createdResponse = await POST(request("POST", { title: "Patch target" }));
+assert.equal(createdResponse.status, 200);
+const createdBody = await createdResponse.json();
+const cardId = createdBody.card.id as string;
+
+const invalidPatch = await PATCH(
+  request("PATCH", {
+    id: "forged-id",
+    createdAt: "2000-01-01T00:00:00.000Z",
+    status: "blocked",
+  }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(invalidPatch.status, 422);
+const invalidPatchBody = await invalidPatch.json();
+assert.equal(invalidPatchBody.error, "orchestration_invalid");
+assert.ok(
+  invalidPatchBody.errors.some(
+    (error: { code: string; field: string }) =>
+      error.code === "blocked_requires_dependency" && error.field === "dependencies",
+  ),
+  "PATCH returns field-specific orchestration errors",
+);
+
+const rename = await PATCH(
+  request("PATCH", {
+    id: "forged-id",
+    createdAt: "2000-01-01T00:00:00.000Z",
+    title: "Renamed safely",
+  }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(rename.status, 200);
+const renamedBody = await rename.json();
+assert.equal(renamedBody.card.id, cardId, "PATCH cannot replace the card id");
+assert.notEqual(
+  renamedBody.card.createdAt,
+  "2000-01-01T00:00:00.000Z",
+  "PATCH cannot replace createdAt",
+);
+assert.equal(renamedBody.card.title, "Renamed safely");
+
+const boardPath = path.join(caveHome, "board.json");
+const boardFile = JSON.parse(await readFile(boardPath, "utf8"));
+const transitionTarget = boardFile.cards.find(
+  (card: { id: string }) => card.id === cardId,
+);
+transitionTarget.dependencies = [{
+  id: "resolved-without-evidence",
+  kind: "human",
+  label: "Record the decision",
+  state: "resolved",
+  origin: "human",
+  createdAt: new Date().toISOString(),
+}];
+await writeFile(boardPath, JSON.stringify(boardFile));
+
+const invalidTransition = await transition(
+  request("POST", { to: "dispatched" }),
+  { params: Promise.resolve({ id: cardId }) },
+);
+assert.equal(invalidTransition.status, 422);
+const invalidTransitionBody = await invalidTransition.json();
+assert.equal(invalidTransitionBody.error, "orchestration_invalid");
+assert.ok(
+  invalidTransitionBody.errors.some(
+    (error: { code: string }) => error.code === "dependency_needs_evidence",
+  ),
+  "lifecycle APIs preserve structured orchestration errors",
+);
+
+console.log("board/orchestration-route.test.ts: ok");

--- a/src/app/api/board/route.test.ts
+++ b/src/app/api/board/route.test.ts
@@ -36,5 +36,8 @@ assert.match(
   /error: "invalid priority"/,
   "invalid priority responses must use a stable error string",
 );
+assert.match(source, /OrchestrationValidationError/, "POST must handle orchestration validation errors");
+assert.match(source, /error: "orchestration_invalid"/, "POST must return a stable orchestration error");
+assert.match(source, /errors: error\.errors/, "POST must return field-specific orchestration errors");
 
 console.log("board/route.test.ts: ok");

--- a/src/app/api/board/route.ts
+++ b/src/app/api/board/route.ts
@@ -2,12 +2,18 @@ import { NextResponse } from "next/server";
 import {
   createCard,
   loadBoard,
+  OrchestrationValidationError,
   PRIORITIES,
   STATUSES,
   type CardPriority,
   type CardStatus,
 } from "@/lib/cave-board";
-import type { CardAsanaLink, CardGitHubLink } from "@/lib/cave-board-types";
+import type {
+  CardAsanaLink,
+  CardGitHubLink,
+  TaskDependency,
+  TaskNextStep,
+} from "@/lib/cave-board-types";
 import type { ChatAttachment } from "@/lib/chat-attachments";
 import { trustedProjectCwd } from "@/lib/cave-projects";
 
@@ -42,6 +48,10 @@ export async function POST(req: Request) {
     template?: string | null;
     steps?: { text: string }[];
     attachments?: ChatAttachment[];
+    dependencies?: TaskDependency[];
+    primaryBlockerId?: string | null;
+    primaryBlockerPinned?: boolean;
+    nextStep?: TaskNextStep | null;
   };
   try {
     body = await req.json();
@@ -69,26 +79,41 @@ export async function POST(req: Request) {
     }
     cwd = resolved.root;
   }
-  const card = await createCard({
-    title: body.title,
-    notes: body.notes,
-    status: body.status,
-    priority: body.priority,
-    familiarId: body.familiarId,
-    modelOverride: body.modelOverride,
-    modelOverrideHarness: body.modelOverrideHarness,
-    sessionId: body.sessionId,
-    cwd,
-    projectId: body.projectId,
-    links: body.links,
-    github: body.github,
-    asana: body.asana,
-    labels: body.labels,
-    startDate: body.startDate,
-    endDate: body.endDate,
-    template: body.template,
-    steps: body.steps,
-    attachments: body.attachments,
-  });
+  let card;
+  try {
+    card = await createCard({
+      title: body.title,
+      notes: body.notes,
+      status: body.status,
+      priority: body.priority,
+      familiarId: body.familiarId,
+      modelOverride: body.modelOverride,
+      modelOverrideHarness: body.modelOverrideHarness,
+      sessionId: body.sessionId,
+      cwd,
+      projectId: body.projectId,
+      links: body.links,
+      github: body.github,
+      asana: body.asana,
+      labels: body.labels,
+      startDate: body.startDate,
+      endDate: body.endDate,
+      template: body.template,
+      steps: body.steps,
+      attachments: body.attachments,
+      dependencies: body.dependencies,
+      primaryBlockerId: body.primaryBlockerId,
+      primaryBlockerPinned: body.primaryBlockerPinned,
+      nextStep: body.nextStep,
+    });
+  } catch (error) {
+    if (error instanceof OrchestrationValidationError) {
+      return NextResponse.json(
+        { ok: false, error: "orchestration_invalid", errors: error.errors },
+        { status: 422 },
+      );
+    }
+    throw error;
+  }
   return NextResponse.json({ ok: true, card });
 }

--- a/src/components/composer-linked-work-actions.test.ts
+++ b/src/components/composer-linked-work-actions.test.ts
@@ -28,8 +28,8 @@ assert.match(
 );
 assert.match(
   source,
-  /fetch\(`\/api\/board\/\$\{encodeURIComponent\(t\.id\)\}`,[\s\S]*?method: "PATCH"[\s\S]*?lifecycle: "completed"[\s\S]*?lifecycleReason: sessionId[\s\S]*?Marked done from chat \(session \$\{sessionId\}\)/,
-  "mark-done keeps the exact board PATCH lifecycle mutation path",
+  /fetch\(`\/api\/board\/\$\{encodeURIComponent\(t\.id\)\}`,[\s\S]*?method: "PATCH"[\s\S]*?status: "done"[\s\S]*?lifecycleReason: sessionId[\s\S]*?Marked done from chat \(session \$\{sessionId\}\)/,
+  "mark-done uses the status mutation path so the server derives lifecycle",
 );
 assert.match(
   source,

--- a/src/components/composer-linked-work-actions.tsx
+++ b/src/components/composer-linked-work-actions.tsx
@@ -90,7 +90,7 @@ function useLinkedWorkController({
         method: "PATCH",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({
-          lifecycle: "completed",
+          status: "done",
           lifecycleReason: sessionId
             ? `Marked done from chat (session ${sessionId})`
             : "Marked done from chat",

--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -79,6 +79,26 @@ await assert.rejects(
   },
 );
 
+const malformedPinTarget = await board.createCard({ title: "Malformed pin target" });
+await assert.rejects(
+  board.updateCard(malformedPinTarget.id, {
+    primaryBlockerPinned: "false" as never,
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("primary_blocker_invalid"));
+    return true;
+  },
+);
+await assert.rejects(
+  board.updateCard(malformedPinTarget.id, {
+    primaryBlockerPinned: null as never,
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("primary_blocker_invalid"));
+    return true;
+  },
+);
+
 const blocker = {
   id: "human-blocker",
   kind: "human" as const,
@@ -145,6 +165,28 @@ await assert.rejects(
   },
 );
 
+const normalizedStatus = await board.createCard({ title: "Normalize status writes" });
+const normalizedDone = await board.updateCard(normalizedStatus.id, { status: "done" });
+assert.equal(normalizedDone?.lifecycle, "completed", "status writes derive lifecycle under the lock");
+
+const approvalGate = await board.createCard({
+  title: "Approval-gated dispatch",
+  nextStep: humanNextStep,
+});
+assert.equal(approvalGate.needsHuman, true);
+await assert.rejects(
+  board.transitionCard(approvalGate.id, { to: "dispatched" }),
+  (error) => {
+    assert.deepEqual(errorCodes(error), ["next_step_requires_approval"]);
+    return true;
+  },
+);
+await board.updateCard(approvalGate.id, {
+  nextStep: { ...humanNextStep, requiresApproval: false },
+});
+const approvedDispatch = await board.transitionCard(approvalGate.id, { to: "dispatched" });
+assert.equal(approvedDispatch?.lifecycle, "dispatched");
+
 const running = await board.createCard({ title: "Failing run" });
 await board.updateCard(running.id, { retryCount: running.maxRetries });
 await board.transitionCard(running.id, { to: "dispatched" });
@@ -172,9 +214,10 @@ const humanRun = await board.createCard({
   title: "Preserve human direction",
 });
 await board.transitionCard(humanRun.id, { to: "dispatched" });
-await board.updateCard(humanRun.id, { nextStep: humanNextStep });
+const humanActionStep = { ...humanNextStep, requiresApproval: false };
+await board.updateCard(humanRun.id, { nextStep: humanActionStep });
 const humanFailed = await board.transitionCard(humanRun.id, { to: "failed" });
-assert.deepEqual(humanFailed?.nextStep, humanNextStep, "lifecycle automation preserves human next steps");
+assert.deepEqual(humanFailed?.nextStep, humanActionStep, "lifecycle automation preserves human next steps");
 
 const pinnedBlocker = {
   ...blocker,

--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const tmpHome = await mkdtemp(path.join(tmpdir(), "cave-board-orchestration-"));
+process.env.HOME = tmpHome;
+
+const board = await import("./cave-board.ts");
+const now = new Date().toISOString();
+
+function errorCodes(error: unknown): string[] {
+  assert.ok(error instanceof board.OrchestrationValidationError);
+  return error.errors.map((entry) => entry.code);
+}
+
+await assert.rejects(
+  board.createCard({ title: "Invalid blocked task", status: "blocked" }),
+  (error) => {
+    assert.deepEqual(
+      new Set(errorCodes(error)),
+      new Set(["blocked_without_dependency", "blocked_without_primary", "blocked_without_next_step"]),
+    );
+    return true;
+  },
+);
+
+const blocker = {
+  id: "human-blocker",
+  kind: "human" as const,
+  label: "Maintainer decision",
+  state: "unresolved" as const,
+  origin: "human" as const,
+  createdAt: now,
+};
+const humanNextStep = {
+  summary: "Ask the maintainer to choose an approach",
+  requiresApproval: true,
+  origin: "human" as const,
+  updatedAt: now,
+};
+const blocked = await board.createCard({
+  title: "Valid blocked task",
+  status: "blocked",
+  dependencies: [blocker],
+  primaryBlockerId: blocker.id,
+  nextStep: humanNextStep,
+});
+assert.equal(blocked.needsHuman, true, "approval-gated next steps set needsHuman");
+
+await assert.rejects(
+  board.updateCard(blocked.id, { dependencies: [] }, { automated: true }),
+  (error) => {
+    const codes = errorCodes(error);
+    assert.ok(codes.includes("dependency_authorship"), "automation cannot remove human dependencies");
+    assert.ok(codes.includes("blocked_without_dependency"), "projected blocked state is validated");
+    return true;
+  },
+);
+
+const running = await board.createCard({ title: "Failing run", status: "in-progress" });
+await board.updateCard(running.id, { lifecycle: "dispatched" });
+const failed = await board.transitionCard(running.id, { to: "failed", reason: "Tests failed" });
+assert.equal(failed?.status, "blocked");
+assert.equal(failed?.needsHuman, true);
+assert.equal(failed?.nextStep?.origin, "system");
+assert.equal(failed?.nextStep?.requiresApproval, true);
+const failureBlocker = failed?.dependencies?.find((entry) => entry.id === failed.primaryBlockerId);
+assert.equal(failureBlocker?.kind, "execution");
+assert.equal(failureBlocker?.origin, "system");
+assert.match(failureBlocker?.label ?? "", /Tests failed/);
+
+const cancelledRun = await board.createCard({ title: "Cancelled run", status: "in-progress" });
+await board.updateCard(cancelledRun.id, { lifecycle: "dispatched" });
+const cancelled = await board.transitionCard(cancelledRun.id, {
+  to: "cancelled",
+  reason: "Stopped by operator",
+});
+assert.equal(cancelled?.status, "blocked");
+assert.equal(cancelled?.dependencies?.find((entry) => entry.id === cancelled.primaryBlockerId)?.kind, "execution");
+assert.equal(cancelled?.nextStep?.summary, "Review the failed run and choose retry or repair");
+
+const humanRun = await board.createCard({
+  title: "Preserve human direction",
+  status: "in-progress",
+  nextStep: humanNextStep,
+});
+await board.updateCard(humanRun.id, { lifecycle: "dispatched" });
+const humanFailed = await board.transitionCard(humanRun.id, { to: "failed" });
+assert.deepEqual(humanFailed?.nextStep, humanNextStep, "lifecycle automation preserves human next steps");
+
+console.log("cave-board-orchestration.test.ts OK");

--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -1,12 +1,39 @@
 import assert from "node:assert/strict";
-import { mkdtemp } from "node:fs/promises";
+import { mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
 const tmpHome = await mkdtemp(path.join(tmpdir(), "cave-board-orchestration-"));
 process.env.HOME = tmpHome;
+process.env.COVEN_CAVE_HOME = tmpHome;
+
+const legacyUpdatedAt = "2026-08-01T12:00:00.000Z";
+await mkdir(tmpHome, { recursive: true });
+await writeFile(
+  path.join(tmpHome, "board.json"),
+  JSON.stringify({
+    version: 1,
+    cards: [{
+      id: "legacy-blocked",
+      title: "Legacy blocked task",
+      notes: "",
+      status: "blocked",
+      priority: "medium",
+      familiarId: null,
+      sessionId: null,
+      cwd: null,
+      links: [],
+      github: [],
+      asana: [],
+      labels: [],
+      createdAt: legacyUpdatedAt,
+      updatedAt: legacyUpdatedAt,
+    }],
+  }),
+);
 
 const board = await import("./cave-board.ts");
+const orchestration = await import("./task-orchestration.ts");
 const now = new Date().toISOString();
 
 function errorCodes(error: unknown): string[] {
@@ -14,13 +41,40 @@ function errorCodes(error: unknown): string[] {
   return error.errors.map((entry) => entry.code);
 }
 
+const initial = await board.loadBoard();
+const legacy = initial.cards.find((card) => card.id === "legacy-blocked");
+assert.ok(legacy, "legacy blocked cards load without throwing");
+assert.deepEqual(legacy.dependencies, [], "legacy cards backfill an empty dependency list");
+assert.equal(legacy.primaryBlockerId, null, "legacy cards backfill a null primary blocker");
+assert.equal(legacy.primaryBlockerPinned, false, "legacy cards backfill an unpinned blocker");
+assert.equal(legacy.nextStep, null, "legacy cards backfill a null next step");
+assert.equal(orchestration.deriveReadiness(legacy, initial.cards), "incomplete");
+assert.ok(
+  orchestration.repairRecommendations(legacy, initial.cards).length >= 2,
+  "legacy cards expose concrete repair recommendations",
+);
+
 await assert.rejects(
   board.createCard({ title: "Invalid blocked task", status: "blocked" }),
   (error) => {
     assert.deepEqual(
       new Set(errorCodes(error)),
-      new Set(["blocked_without_dependency", "blocked_without_primary", "blocked_without_next_step"]),
+      new Set([
+        "blocked_requires_dependency",
+        "blocked_requires_next_step",
+      ]),
     );
+    return true;
+  },
+);
+
+await assert.rejects(
+  board.createCard({
+    title: "Malformed dependency payload",
+    dependencies: [null] as never,
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("dependency_invalid"));
     return true;
   },
 );
@@ -53,13 +107,47 @@ await assert.rejects(
   (error) => {
     const codes = errorCodes(error);
     assert.ok(codes.includes("dependency_authorship"), "automation cannot remove human dependencies");
-    assert.ok(codes.includes("blocked_without_dependency"), "projected blocked state is validated");
+    assert.ok(codes.includes("blocked_requires_dependency"), "projected blocked state is validated");
     return true;
   },
 );
 
-const running = await board.createCard({ title: "Failing run", status: "in-progress" });
-await board.updateCard(running.id, { lifecycle: "dispatched" });
+await assert.rejects(
+  board.updateCard(blocked.id, {
+    dependencies: [{ ...blocker, state: "resolved", evidence: "Decision recorded" }],
+  }),
+  (error) => {
+    const codes = errorCodes(error);
+    assert.ok(codes.includes("blocked_requires_dependency"));
+    assert.ok(codes.includes("blocked_requires_primary"));
+    return true;
+  },
+);
+
+await assert.rejects(
+  board.updateCard(blocked.id, {
+    nextStep: { ...humanNextStep, summary: "  " },
+  }),
+  (error) => {
+    assert.ok(errorCodes(error).includes("blocked_requires_next_step"));
+    return true;
+  },
+);
+
+const enhanceTarget = await board.createCard({ title: "Enhance target" });
+await assert.rejects(
+  board.updateCard(enhanceTarget.id, { status: "blocked" }, { automated: true }),
+  (error) => {
+    const codes = errorCodes(error);
+    assert.ok(codes.includes("blocked_requires_dependency"));
+    assert.ok(codes.includes("blocked_requires_next_step"));
+    return true;
+  },
+);
+
+const running = await board.createCard({ title: "Failing run" });
+await board.updateCard(running.id, { retryCount: running.maxRetries });
+await board.transitionCard(running.id, { to: "dispatched" });
 const failed = await board.transitionCard(running.id, { to: "failed", reason: "Tests failed" });
 assert.equal(failed?.status, "blocked");
 assert.equal(failed?.needsHuman, true);
@@ -70,8 +158,8 @@ assert.equal(failureBlocker?.kind, "execution");
 assert.equal(failureBlocker?.origin, "system");
 assert.match(failureBlocker?.label ?? "", /Tests failed/);
 
-const cancelledRun = await board.createCard({ title: "Cancelled run", status: "in-progress" });
-await board.updateCard(cancelledRun.id, { lifecycle: "dispatched" });
+const cancelledRun = await board.createCard({ title: "Cancelled run" });
+await board.transitionCard(cancelledRun.id, { to: "dispatched" });
 const cancelled = await board.transitionCard(cancelledRun.id, {
   to: "cancelled",
   reason: "Stopped by operator",
@@ -82,11 +170,42 @@ assert.equal(cancelled?.nextStep?.summary, "Review the failed run and choose ret
 
 const humanRun = await board.createCard({
   title: "Preserve human direction",
-  status: "in-progress",
-  nextStep: humanNextStep,
 });
-await board.updateCard(humanRun.id, { lifecycle: "dispatched" });
+await board.transitionCard(humanRun.id, { to: "dispatched" });
+await board.updateCard(humanRun.id, { nextStep: humanNextStep });
 const humanFailed = await board.transitionCard(humanRun.id, { to: "failed" });
 assert.deepEqual(humanFailed?.nextStep, humanNextStep, "lifecycle automation preserves human next steps");
+
+const pinnedBlocker = {
+  ...blocker,
+  id: "pinned-primary",
+  createdAt: new Date(Date.now() + 1).toISOString(),
+};
+const pinnedFailure = await board.createCard({
+  title: "Preserve pinned failure blocker",
+  dependencies: [pinnedBlocker],
+  primaryBlockerId: pinnedBlocker.id,
+  primaryBlockerPinned: true,
+});
+await board.transitionCard(pinnedFailure.id, { to: "dispatched" });
+const pinnedFailed = await board.transitionCard(pinnedFailure.id, { to: "failed" });
+assert.equal(pinnedFailed?.primaryBlockerId, pinnedBlocker.id);
+assert.equal(pinnedFailed?.primaryBlockerPinned, true);
+assert.ok(
+  pinnedFailed?.dependencies?.some((dependency) => dependency.kind === "execution"),
+  "failure still records its execution dependency behind a pinned primary",
+);
+
+const pinnedCancellation = await board.createCard({
+  title: "Preserve pinned cancellation blocker",
+  dependencies: [{ ...pinnedBlocker, id: "pinned-cancellation" }],
+  primaryBlockerId: "pinned-cancellation",
+  primaryBlockerPinned: true,
+});
+const pinnedCancelled = await board.transitionCard(pinnedCancellation.id, {
+  to: "cancelled",
+});
+assert.equal(pinnedCancelled?.primaryBlockerId, "pinned-cancellation");
+assert.equal(pinnedCancelled?.primaryBlockerPinned, true);
 
 console.log("cave-board-orchestration.test.ts OK");

--- a/src/lib/cave-board-orchestration.test.ts
+++ b/src/lib/cave-board-orchestration.test.ts
@@ -80,6 +80,11 @@ await assert.rejects(
 );
 
 const malformedPinTarget = await board.createCard({ title: "Malformed pin target" });
+const defaultedPin = await board.createCard({
+  title: "Undefined pin defaults",
+  primaryBlockerPinned: undefined,
+});
+assert.equal(defaultedPin.primaryBlockerPinned, false);
 await assert.rejects(
   board.updateCard(malformedPinTarget.id, {
     primaryBlockerPinned: "false" as never,
@@ -89,6 +94,10 @@ await assert.rejects(
     return true;
   },
 );
+const undefinedPinPatch = await board.updateCard(malformedPinTarget.id, {
+  primaryBlockerPinned: undefined,
+});
+assert.equal(undefinedPinPatch?.primaryBlockerPinned, false);
 await assert.rejects(
   board.updateCard(malformedPinTarget.id, {
     primaryBlockerPinned: null as never,

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -94,6 +94,9 @@ export type OrchestrationErrorCode =
   | "dependency_cycle"
   | "dependency_dangling"
   | "dependency_needs_evidence"
+  | "dependency_invalid"
+  | "primary_blocker_invalid"
+  | "next_step_invalid"
   | "dependency_authorship"
   | "next_step_authorship";
 

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -104,7 +104,7 @@ export type OrchestrationErrorCode =
 export type OrchestrationError = {
   code: OrchestrationErrorCode;
   /** Card field the error belongs to, for inspector focus. */
-  field: "dependencies" | "primaryBlockerId" | "nextStep";
+  field: "dependencies" | "primaryBlockerId" | "primaryBlockerPinned" | "nextStep";
   message: string;
   /** The dependency at fault, when the error is about one. */
   dependencyId?: string;

--- a/src/lib/cave-board-types.ts
+++ b/src/lib/cave-board-types.ts
@@ -97,6 +97,7 @@ export type OrchestrationErrorCode =
   | "dependency_invalid"
   | "primary_blocker_invalid"
   | "next_step_invalid"
+  | "next_step_requires_approval"
   | "dependency_authorship"
   | "next_step_authorship";
 

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -12,6 +12,8 @@ import {
   type CardLifecycle,
   type CardPriority,
   type CardStatus,
+  type TaskDependency,
+  type TaskNextStep,
 } from "@/lib/cave-board-types";
 import {
   mergeLinksWithGitHub,
@@ -33,6 +35,10 @@ import {
 } from "@/lib/chat-attachments";
 import { applyCardOps, hasCardOps, type CardPatch } from "@/lib/board-card-ops";
 import { canonicalHarnessId } from "@/lib/harness-adapters";
+import {
+  assertValidOrchestration,
+  OrchestrationValidationError,
+} from "@/lib/task-orchestration";
 
 export {
   DEFAULT_MAX_RETRIES,
@@ -47,7 +53,10 @@ export {
   type CardLifecycle,
   type CardPriority,
   type CardStatus,
+  type TaskDependency,
+  type TaskNextStep,
 } from "@/lib/cave-board-types";
+export { OrchestrationValidationError } from "@/lib/task-orchestration";
 
 const BOARD_PATH = path.join(caveHome(), "board.json");
 
@@ -203,6 +212,7 @@ function backfillCard(c: Card | LegacyCard): Card {
     retryCount: c.retryCount ?? 0,
     maxRetries: c.maxRetries ?? DEFAULT_MAX_RETRIES,
     steps: c.steps ?? [],
+    dependencies: c.dependencies ?? [],
   } as Card;
 }
 
@@ -300,6 +310,10 @@ export type NewCardInput = {
   steps?: { text: string }[];
   /** Files staged in the composer, carried onto the card at creation time. */
   attachments?: ChatAttachment[];
+  dependencies?: TaskDependency[];
+  primaryBlockerId?: string | null;
+  primaryBlockerPinned?: boolean;
+  nextStep?: TaskNextStep | null;
 };
 
 /** Store attachments lean: normalize (bounds text + validates image payloads),
@@ -347,9 +361,15 @@ export async function createCard(input: NewCardInput): Promise<Card> {
       .map((s) => (s?.text ?? "").trim())
       .filter(Boolean)
       .map((text) => ({ id: crypto.randomUUID(), text, done: false, addedAt: now })),
+    dependencies: input.dependencies ?? [],
+    primaryBlockerId: input.primaryBlockerId ?? null,
+    primaryBlockerPinned: input.primaryBlockerPinned ?? false,
+    nextStep: input.nextStep ?? null,
   };
+  if (card.nextStep?.requiresApproval) card.needsHuman = true;
   const attachments = boardAttachments(input.attachments);
   if (attachments) card.attachments = attachments;
+  assertValidOrchestration(card, { cards: board.cards });
   board.cards.push(card);
   await saveBoard(board);
   return card;
@@ -359,6 +379,7 @@ export async function createCard(input: NewCardInput): Promise<Card> {
 export async function updateCard(
   id: string,
   patchWithOps: CardPatch,
+  options: { automated?: boolean } = {},
 ): Promise<Card | null> {
   return withBoardLock(async () => {
   const board = await loadBoard();
@@ -428,12 +449,26 @@ export async function updateCard(
     attachments: "attachments" in patch
       ? boardAttachments(patch.attachments ?? undefined)
       : current.attachments,
+    dependencies: "dependencies" in patch ? patch.dependencies ?? [] : current.dependencies ?? [],
+    primaryBlockerId: "primaryBlockerId" in patch
+      ? patch.primaryBlockerId ?? null
+      : current.primaryBlockerId ?? null,
+    primaryBlockerPinned: "primaryBlockerPinned" in patch
+      ? patch.primaryBlockerPinned ?? false
+      : current.primaryBlockerPinned ?? false,
+    nextStep: "nextStep" in patch ? patch.nextStep ?? null : current.nextStep ?? null,
   };
+  if (next.nextStep?.requiresApproval) next.needsHuman = true;
   if (next.lifecycle === "running" && !next.runningSince) {
     next.runningSince = next.updatedAt;
   } else if (next.lifecycle !== "running") {
     delete next.runningSince;
   }
+  assertValidOrchestration(next, {
+    cards: board.cards,
+    previous: current,
+    automated: options.automated,
+  });
   board.cards[idx] = next;
   await saveBoard(board);
   return next;
@@ -472,6 +507,31 @@ export type TransitionInput = {
   reason?: string;
   retry?: boolean;
 };
+
+function executionDependency(
+  to: "failed" | "cancelled",
+  reason: string | undefined,
+  now: string,
+): TaskDependency {
+  const outcome = to === "failed" ? "Run failed" : "Run was cancelled";
+  return {
+    id: crypto.randomUUID(),
+    kind: "execution",
+    label: reason?.trim() ? `${outcome}: ${reason.trim()}` : outcome,
+    state: "unresolved",
+    origin: "system",
+    createdAt: now,
+  };
+}
+
+function failureNextStep(now: string): TaskNextStep {
+  return {
+    summary: "Review the failed run and choose retry or repair",
+    requiresApproval: true,
+    origin: "system",
+    updatedAt: now,
+  };
+}
 
 export async function transitionCard(
   id: string,
@@ -512,6 +572,10 @@ export async function transitionCard(
     next.needsHuman = false;
   } else if (to === "failed") {
     const exhausted = current.retryCount >= current.maxRetries;
+    const blocker = executionDependency(to, reason, now);
+    next.dependencies = [...(current.dependencies ?? []), blocker];
+    next.primaryBlockerId = blocker.id;
+    next.nextStep = current.nextStep?.origin === "human" ? current.nextStep : failureNextStep(now);
     if (exhausted) {
       // Auto-rollback: failed without remaining retries → Blocked with
       // `needs human` flag. Spec section 3 (rollback behavior).
@@ -519,6 +583,7 @@ export async function transitionCard(
       next.needsHuman = true;
     } else {
       next.status = "blocked";
+      next.needsHuman = true;
     }
   } else if (to === "queued") {
     if (retry) {
@@ -527,10 +592,19 @@ export async function transitionCard(
     next.status = "backlog";
     next.needsHuman = false;
   } else if (to === "cancelled") {
+    const blocker = executionDependency(to, reason, now);
+    next.dependencies = [...(current.dependencies ?? []), blocker];
+    next.primaryBlockerId = blocker.id;
+    next.nextStep = current.nextStep?.origin === "human" ? current.nextStep : failureNextStep(now);
     next.status = "blocked";
-    next.needsHuman = false;
+    next.needsHuman = true;
   }
 
+  assertValidOrchestration(next, {
+    cards: board.cards,
+    previous: current,
+    automated: true,
+  });
   board.cards[idx] = next;
   await saveBoard(board);
   return next;

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -78,6 +78,20 @@ function statusForLifecycle(lifecycle: CardLifecycle, currentStatus: CardStatus)
   return currentStatus;
 }
 
+function statusForWrite(
+  lifecycle: CardLifecycle,
+  requestedStatus: CardStatus | undefined,
+  currentStatus: CardStatus,
+): CardStatus {
+  if (lifecycle !== "queued") {
+    return statusForLifecycle(lifecycle, currentStatus);
+  }
+  if (requestedStatus === "inbox" || requestedStatus === "backlog") {
+    return requestedStatus;
+  }
+  return currentStatus === "inbox" ? "inbox" : "backlog";
+}
+
 function normalizeList(values: string[] | undefined): string[] {
   return [...new Set(toStringList(values).map((value) => value.trim()).filter(Boolean))];
 }
@@ -211,7 +225,8 @@ function backfillCard(c: Card | LegacyCard): Card {
     steps: c.steps ?? [],
     dependencies: c.dependencies ?? [],
     primaryBlockerId: c.primaryBlockerId ?? null,
-    primaryBlockerPinned: c.primaryBlockerPinned ?? false,
+    primaryBlockerPinned:
+      typeof c.primaryBlockerPinned === "boolean" ? c.primaryBlockerPinned : false,
     nextStep: c.nextStep ?? null,
   } as Card;
 }
@@ -363,7 +378,8 @@ export async function createCard(input: NewCardInput): Promise<Card> {
       .map((text) => ({ id: crypto.randomUUID(), text, done: false, addedAt: now })),
     dependencies: input.dependencies ?? [],
     primaryBlockerId: input.primaryBlockerId ?? null,
-    primaryBlockerPinned: input.primaryBlockerPinned ?? false,
+    primaryBlockerPinned:
+      "primaryBlockerPinned" in input ? input.primaryBlockerPinned! : false,
     nextStep: input.nextStep ?? null,
   };
   if (card.nextStep?.requiresApproval) card.needsHuman = true;
@@ -394,6 +410,17 @@ export async function updateCard(
   const patch: Partial<Omit<Card, "id" | "createdAt">> = hasCardOps(ops)
     ? { ...plain, ...applyCardOps(current, ops, new Date().toISOString()) }
     : plain;
+  const now = new Date().toISOString();
+  const requestedStatus = "status" in patch ? patch.status : undefined;
+  const nextLifecycle =
+    ("lifecycle" in patch ? patch.lifecycle : undefined) ??
+    (requestedStatus ? inferLifecycle(requestedStatus) : current.lifecycle);
+  const nextStatus =
+    "status" in patch || "lifecycle" in patch
+      ? statusForWrite(nextLifecycle, requestedStatus, current.status)
+      : current.status;
+  const lifecycleChanged = nextLifecycle !== current.lifecycle;
+  const statusChanged = nextStatus !== current.status;
   // Resolve the structured connection lists once, then fold both back into
   // `links` so the URL list stays the union of everything attached (github +
   // asana + explicit links) — same invariant createCard/backfill maintain.
@@ -410,7 +437,13 @@ export async function updateCard(
     ...patch,
     id: current.id,
     createdAt: current.createdAt,
-    updatedAt: new Date().toISOString(),
+    status: nextStatus,
+    lifecycle: nextLifecycle,
+    lifecycleAt: lifecycleChanged ? now : current.lifecycleAt,
+    lifecycleReason: lifecycleChanged
+      ? ("lifecycleReason" in patch ? patch.lifecycleReason : undefined)
+      : current.lifecycleReason,
+    updatedAt: now,
     labels: patch.labels
       ? normalizeList(patch.labels)
       : current.labels,
@@ -454,10 +487,11 @@ export async function updateCard(
       ? patch.primaryBlockerId ?? null
       : current.primaryBlockerId ?? null,
     primaryBlockerPinned: "primaryBlockerPinned" in patch
-      ? patch.primaryBlockerPinned ?? false
+      ? patch.primaryBlockerPinned!
       : current.primaryBlockerPinned ?? false,
     nextStep: "nextStep" in patch ? patch.nextStep ?? null : current.nextStep ?? null,
   };
+  if (statusChanged) next.needsHuman = next.status === "blocked";
   if (next.nextStep?.requiresApproval) next.needsHuman = true;
   if (next.lifecycle === "running" && !next.runningSince) {
     next.runningSince = next.updatedAt;

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -35,10 +35,7 @@ import {
 } from "@/lib/chat-attachments";
 import { applyCardOps, hasCardOps, type CardPatch } from "@/lib/board-card-ops";
 import { canonicalHarnessId } from "@/lib/harness-adapters";
-import {
-  assertValidOrchestration,
-  OrchestrationValidationError,
-} from "@/lib/task-orchestration";
+import { assertValidOrchestration } from "@/lib/task-orchestration";
 
 export {
   DEFAULT_MAX_RETRIES,
@@ -213,6 +210,9 @@ function backfillCard(c: Card | LegacyCard): Card {
     maxRetries: c.maxRetries ?? DEFAULT_MAX_RETRIES,
     steps: c.steps ?? [],
     dependencies: c.dependencies ?? [],
+    primaryBlockerId: c.primaryBlockerId ?? null,
+    primaryBlockerPinned: c.primaryBlockerPinned ?? false,
+    nextStep: c.nextStep ?? null,
   } as Card;
 }
 
@@ -533,6 +533,36 @@ function failureNextStep(now: string): TaskNextStep {
   };
 }
 
+function applyExecutionBlocker(
+  current: Card,
+  next: Card,
+  blocker: TaskDependency,
+  now: string,
+): void {
+  const currentDependencies = Array.isArray(current.dependencies)
+    ? current.dependencies
+    : [];
+  const pinnedPrimary = current.primaryBlockerPinned
+    ? currentDependencies.find(
+        (dependency) =>
+          dependency?.id === current.primaryBlockerId &&
+          dependency.state === "unresolved",
+      )
+    : undefined;
+
+  next.dependencies = [...currentDependencies, blocker];
+  if (pinnedPrimary) {
+    next.primaryBlockerId = pinnedPrimary.id;
+  } else {
+    next.primaryBlockerId = blocker.id;
+    if (current.primaryBlockerPinned) next.primaryBlockerPinned = false;
+  }
+  next.nextStep =
+    current.nextStep?.origin === "human" ? current.nextStep : failureNextStep(now);
+  next.status = "blocked";
+  next.needsHuman = true;
+}
+
 export async function transitionCard(
   id: string,
   { to, reason, retry }: TransitionInput,
@@ -571,20 +601,8 @@ export async function transitionCard(
     next.status = "done";
     next.needsHuman = false;
   } else if (to === "failed") {
-    const exhausted = current.retryCount >= current.maxRetries;
     const blocker = executionDependency(to, reason, now);
-    next.dependencies = [...(current.dependencies ?? []), blocker];
-    next.primaryBlockerId = blocker.id;
-    next.nextStep = current.nextStep?.origin === "human" ? current.nextStep : failureNextStep(now);
-    if (exhausted) {
-      // Auto-rollback: failed without remaining retries → Blocked with
-      // `needs human` flag. Spec section 3 (rollback behavior).
-      next.status = "blocked";
-      next.needsHuman = true;
-    } else {
-      next.status = "blocked";
-      next.needsHuman = true;
-    }
+    applyExecutionBlocker(current, next, blocker, now);
   } else if (to === "queued") {
     if (retry) {
       next.retryCount = current.retryCount + 1;
@@ -593,13 +611,10 @@ export async function transitionCard(
     next.needsHuman = false;
   } else if (to === "cancelled") {
     const blocker = executionDependency(to, reason, now);
-    next.dependencies = [...(current.dependencies ?? []), blocker];
-    next.primaryBlockerId = blocker.id;
-    next.nextStep = current.nextStep?.origin === "human" ? current.nextStep : failureNextStep(now);
-    next.status = "blocked";
-    next.needsHuman = true;
+    applyExecutionBlocker(current, next, blocker, now);
   }
 
+  if (next.nextStep?.requiresApproval) next.needsHuman = true;
   assertValidOrchestration(next, {
     cards: board.cards,
     previous: current,

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -379,7 +379,7 @@ export async function createCard(input: NewCardInput): Promise<Card> {
     dependencies: input.dependencies ?? [],
     primaryBlockerId: input.primaryBlockerId ?? null,
     primaryBlockerPinned:
-      "primaryBlockerPinned" in input ? input.primaryBlockerPinned! : false,
+      input.primaryBlockerPinned === undefined ? false : input.primaryBlockerPinned,
     nextStep: input.nextStep ?? null,
   };
   if (card.nextStep?.requiresApproval) card.needsHuman = true;
@@ -487,7 +487,9 @@ export async function updateCard(
       ? patch.primaryBlockerId ?? null
       : current.primaryBlockerId ?? null,
     primaryBlockerPinned: "primaryBlockerPinned" in patch
-      ? patch.primaryBlockerPinned!
+      ? patch.primaryBlockerPinned === undefined
+        ? current.primaryBlockerPinned ?? false
+        : patch.primaryBlockerPinned
       : current.primaryBlockerPinned ?? false,
     nextStep: "nextStep" in patch ? patch.nextStep ?? null : current.nextStep ?? null,
   };

--- a/src/lib/session-status.test.ts
+++ b/src/lib/session-status.test.ts
@@ -57,8 +57,8 @@ assert.match(
 );
 assert.match(
   linkedWork,
-  /lifecycle: "completed",\s*lifecycleReason: sessionId/,
-  "the linked-work action flips through the card lifecycle machine with an audit reason (status derives server-side)",
+  /status: "done",\s*lifecycleReason: sessionId/,
+  "the linked-work action marks the card done with an audit reason and lets the server derive lifecycle",
 );
 assert.match(
   chatView,

--- a/src/lib/task-orchestration.test.ts
+++ b/src/lib/task-orchestration.test.ts
@@ -104,6 +104,14 @@ function codes(errors) {
     ["primary_blocker_invalid"],
   );
 
+  const malformedPin = card("malformed-pin", {
+    primaryBlockerPinned: "false",
+  });
+  assert.deepEqual(
+    codes(validateOrchestration(malformedPin, { cards: [malformedPin] })),
+    ["primary_blocker_invalid"],
+  );
+
   const duplicateDependencies = card("duplicate-dependencies", {
     dependencies: [
       dep("same", { kind: "human" }),
@@ -181,6 +189,25 @@ function codes(errors) {
     codes(validateOrchestration(whitespace, { cards: [upstream, whitespace] })),
     ["blocked_requires_next_step"],
     "a whitespace-only summary is not a next step",
+  );
+}
+
+// ── I7: approval blocks execution ────────────────────────────────────────────
+
+{
+  const queued = card("approval-queued", {
+    nextStep: step({ requiresApproval: true }),
+  });
+  assert.deepEqual(validateOrchestration(queued, { cards: [queued] }), []);
+
+  const running = {
+    ...queued,
+    status: "running",
+    lifecycle: "running",
+  };
+  assert.deepEqual(
+    codes(validateOrchestration(running, { cards: [running], previous: queued })),
+    ["next_step_requires_approval"],
   );
 }
 

--- a/src/lib/task-orchestration.test.ts
+++ b/src/lib/task-orchestration.test.ts
@@ -77,6 +77,45 @@ function codes(errors) {
   return errors.map((error) => error.code).sort();
 }
 
+// Runtime callers cross a JSON boundary. Malformed records must be rejected
+// with field errors instead of crashing or persisting type-invalid data.
+{
+  const malformedDependency = card("malformed-dependency", {
+    dependencies: [null],
+  });
+  assert.deepEqual(
+    codes(validateOrchestration(malformedDependency, { cards: [malformedDependency] })),
+    ["dependency_invalid"],
+  );
+
+  const malformedNextStep = card("malformed-next-step", {
+    nextStep: { summary: "Rerun tests" },
+  });
+  assert.deepEqual(
+    codes(validateOrchestration(malformedNextStep, { cards: [malformedNextStep] })),
+    ["next_step_invalid"],
+  );
+
+  const malformedPrimary = card("malformed-primary", {
+    primaryBlockerId: 42,
+  });
+  assert.deepEqual(
+    codes(validateOrchestration(malformedPrimary, { cards: [malformedPrimary] })),
+    ["primary_blocker_invalid"],
+  );
+
+  const duplicateDependencies = card("duplicate-dependencies", {
+    dependencies: [
+      dep("same", { kind: "human" }),
+      dep("same", { kind: "human" }),
+    ],
+  });
+  assert.deepEqual(
+    codes(validateOrchestration(duplicateDependencies, { cards: [duplicateDependencies] })),
+    ["dependency_invalid"],
+  );
+}
+
 // ── I1: the blocked triple ───────────────────────────────────────────────────
 
 {

--- a/src/lib/task-orchestration.test.ts
+++ b/src/lib/task-orchestration.test.ts
@@ -111,6 +111,10 @@ function codes(errors) {
     codes(validateOrchestration(malformedPin, { cards: [malformedPin] })),
     ["primary_blocker_invalid"],
   );
+  assert.equal(
+    validateOrchestration(malformedPin, { cards: [malformedPin] })[0]?.field,
+    "primaryBlockerPinned",
+  );
 
   const duplicateDependencies = card("duplicate-dependencies", {
     dependencies: [

--- a/src/lib/task-orchestration.ts
+++ b/src/lib/task-orchestration.ts
@@ -240,6 +240,21 @@ export type OrchestrationContext = {
   automated?: boolean;
 };
 
+export class OrchestrationValidationError extends Error {
+  readonly errors: OrchestrationError[];
+
+  constructor(errors: OrchestrationError[]) {
+    super("Task orchestration validation failed");
+    this.name = "OrchestrationValidationError";
+    this.errors = errors;
+  }
+}
+
+export function assertValidOrchestration(card: Card, ctx: OrchestrationContext): void {
+  const errors = validateOrchestration(card, ctx);
+  if (errors.length > 0) throw new OrchestrationValidationError(errors);
+}
+
 /**
  * Every way a write can violate the contract. Returns all of them rather than
  * the first, so the inspector can mark every bad field in one pass instead of

--- a/src/lib/task-orchestration.ts
+++ b/src/lib/task-orchestration.ts
@@ -28,8 +28,54 @@ export function isGraphEdge(dep: TaskDependency): boolean {
   return dep.kind === "task" && typeof dep.taskId === "string" && dep.taskId.length > 0;
 }
 
+const DEPENDENCY_KINDS = new Set([
+  "task",
+  "github",
+  "human",
+  "credential",
+  "service",
+  "execution",
+  "external",
+]);
+const DEPENDENCY_STATES = new Set(["unresolved", "resolved", "waived"]);
+const RECORD_ORIGINS = new Set(["human", "enhance", "system"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isOptionalString(value: unknown): boolean {
+  return value === undefined || value === null || typeof value === "string";
+}
+
+function isTimestamp(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+function isValidDependencyShape(value: unknown): value is TaskDependency {
+  if (!isRecord(value)) return false;
+  return (
+    isNonEmpty(value.id) &&
+    typeof value.kind === "string" &&
+    DEPENDENCY_KINDS.has(value.kind) &&
+    isNonEmpty(value.label) &&
+    typeof value.state === "string" &&
+    DEPENDENCY_STATES.has(value.state) &&
+    typeof value.origin === "string" &&
+    RECORD_ORIGINS.has(value.origin) &&
+    isTimestamp(value.createdAt) &&
+    isOptionalString(value.taskId) &&
+    isOptionalString(value.ref) &&
+    isOptionalString(value.url) &&
+    isOptionalString(value.resolvedAt) &&
+    isOptionalString(value.resolvedBy) &&
+    isOptionalString(value.evidence)
+  );
+}
+
 export function dependenciesOf(card: Pick<Card, "dependencies">): TaskDependency[] {
-  return card.dependencies ?? [];
+  const raw = (card as { dependencies?: unknown }).dependencies;
+  return Array.isArray(raw) ? raw.filter(isValidDependencyShape) : [];
 }
 
 export function unresolvedOf(card: Pick<Card, "dependencies">): TaskDependency[] {
@@ -40,8 +86,24 @@ function isNonEmpty(value: unknown): value is string {
   return typeof value === "string" && value.trim().length > 0;
 }
 
+function isValidNextStepShape(step: unknown): step is TaskNextStep {
+  if (!isRecord(step)) return false;
+  return (
+    typeof step.summary === "string" &&
+    typeof step.requiresApproval === "boolean" &&
+    typeof step.origin === "string" &&
+    RECORD_ORIGINS.has(step.origin) &&
+    isTimestamp(step.updatedAt) &&
+    isOptionalString(step.actorFamiliarId) &&
+    isOptionalString(step.capability) &&
+    isOptionalString(step.target) &&
+    (step.inputs === undefined ||
+      (Array.isArray(step.inputs) && step.inputs.every((input) => typeof input === "string")))
+  );
+}
+
 export function isValidNextStep(step: TaskNextStep | null | undefined): step is TaskNextStep {
-  return step != null && isNonEmpty(step.summary);
+  return isValidNextStepShape(step) && isNonEmpty(step.summary);
 }
 
 function sameOptionalString(left: string | null | undefined, right: string | null | undefined): boolean {
@@ -265,6 +327,67 @@ export function validateOrchestration(
   ctx: OrchestrationContext,
 ): OrchestrationError[] {
   const errors: OrchestrationError[] = [];
+  const rawDependencies = (card as { dependencies?: unknown }).dependencies;
+  if (rawDependencies !== undefined && rawDependencies !== null) {
+    if (!Array.isArray(rawDependencies)) {
+      errors.push({
+        code: "dependency_invalid",
+        field: "dependencies",
+        message: "Dependencies must be an array of complete dependency records.",
+      });
+    } else {
+      const seen = new Set<string>();
+      for (const raw of rawDependencies) {
+        const dependencyId =
+          isRecord(raw) && typeof raw.id === "string" ? raw.id : undefined;
+        if (!isValidDependencyShape(raw)) {
+          errors.push({
+            code: "dependency_invalid",
+            field: "dependencies",
+            ...(dependencyId ? { dependencyId } : {}),
+            message: "Every dependency must include a valid id, kind, label, state, origin, and createdAt.",
+          });
+          continue;
+        }
+        if (seen.has(raw.id)) {
+          errors.push({
+            code: "dependency_invalid",
+            field: "dependencies",
+            dependencyId: raw.id,
+            message: `Dependency id "${raw.id}" is duplicated.`,
+          });
+        }
+        seen.add(raw.id);
+      }
+    }
+  }
+
+  const rawPrimary = (card as { primaryBlockerId?: unknown }).primaryBlockerId;
+  if (
+    rawPrimary !== undefined &&
+    rawPrimary !== null &&
+    !isNonEmpty(rawPrimary)
+  ) {
+    errors.push({
+      code: "primary_blocker_invalid",
+      field: "primaryBlockerId",
+      message: "The primary blocker must be a non-empty dependency id or null.",
+    });
+  }
+
+  const rawNextStep = (card as { nextStep?: unknown }).nextStep;
+  if (
+    rawNextStep !== undefined &&
+    rawNextStep !== null &&
+    !isValidNextStepShape(rawNextStep)
+  ) {
+    errors.push({
+      code: "next_step_invalid",
+      field: "nextStep",
+      message: "The next step must include a summary, approval flag, origin, and updatedAt.",
+    });
+  }
+
   const deps = dependenciesOf(card);
   const unresolved = unresolvedOf(card);
   const live = new Set(ctx.cards.map((other) => other.id));

--- a/src/lib/task-orchestration.ts
+++ b/src/lib/task-orchestration.ts
@@ -378,7 +378,7 @@ export function validateOrchestration(
   if (rawPinned !== undefined && typeof rawPinned !== "boolean") {
     errors.push({
       code: "primary_blocker_invalid",
-      field: "primaryBlockerId",
+      field: "primaryBlockerPinned",
       message: "The primary blocker pin must be true or false.",
     });
   }

--- a/src/lib/task-orchestration.ts
+++ b/src/lib/task-orchestration.ts
@@ -374,6 +374,14 @@ export function validateOrchestration(
       message: "The primary blocker must be a non-empty dependency id or null.",
     });
   }
+  const rawPinned = (card as { primaryBlockerPinned?: unknown }).primaryBlockerPinned;
+  if (rawPinned !== undefined && typeof rawPinned !== "boolean") {
+    errors.push({
+      code: "primary_blocker_invalid",
+      field: "primaryBlockerId",
+      message: "The primary blocker pin must be true or false.",
+    });
+  }
 
   const rawNextStep = (card as { nextStep?: unknown }).nextStep;
   if (
@@ -385,6 +393,17 @@ export function validateOrchestration(
       code: "next_step_invalid",
       field: "nextStep",
       message: "The next step must include a summary, approval flag, origin, and updatedAt.",
+    });
+  }
+  if (
+    (card.lifecycle === "dispatched" || card.lifecycle === "running") &&
+    isValidNextStepShape(rawNextStep) &&
+    rawNextStep.requiresApproval
+  ) {
+    errors.push({
+      code: "next_step_requires_approval",
+      field: "nextStep",
+      message: "Clear the next step's approval requirement before dispatching this task.",
     });
   }
 


### PR DESCRIPTION
## Summary
- Validate create, update, and lifecycle projections inside the Board write lock.
- Synthesize execution blockers for failed and cancelled runs while preserving human direction.
- Return structured orchestration errors and reject unsafe runtime payloads across Board APIs.
- Derive lifecycle from status writes and refuse approval-gated dispatch.

## Verification
- env -u NPM_CONFIG_PREFIX -u npm_config_prefix pnpm test:app (1,167 test files)
- pnpm test:api (369 test files)
- pnpm typecheck
- pnpm lint
- pnpm check:tests-wired (1,615 wired test files)
- Focused orchestration mutator, API, Enhance, linked-work, and session-status regressions.

## Recovery
Reconstructs the retained cave-q76cq Phase 2 archive on current main through recovery Bead cave-rpfn7. The stale original lifecycle record remains preserved for gated repair.