### PR TITLE
Harden CLI process boundaries

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1301,6 +1301,8 @@ export const SUITES = {
     "src/lib/daemon-startup-contract.test.ts",
     "src/lib/runtime-startup-throttle.test.ts",
     "src/lib/daemon-update-lifecycle.test.ts",
+    "src/lib/process-execution.test.ts",
+    "src/lib/process-boundary-contracts.test.ts",
     "src/app/api/projects/route.test.ts",
     "src/app/api/coven/exec/route.test.ts",
     "src/lib/coven-daemon.test.ts",

--- a/src/app/api/coven/exec/route.test.ts
+++ b/src/app/api/coven/exec/route.test.ts
@@ -21,6 +21,10 @@ assert.match(
   /isMissingExecutableError\(e\)[\s\S]*covenCliMissingError\(\)/,
   "missing Coven CLI spawn errors should return the stable install/setup payload",
 );
+assert.match(source, /BoundedProcessOutput/, "slash-command CLI output should be explicitly bounded");
+assert.match(source, /terminateProcessTree\(child\)/, "timeouts should terminate the owned process tree");
+assert.match(source, /detached: process\.platform !== "win32"/, "POSIX slash-command launches should own a process group");
+assert.doesNotMatch(source, /error: e\.message/, "spawn diagnostics must not expose raw executable paths");
 
 assert.match(
   source,

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
-import { stripAnsi } from "@/lib/ansi";
 import {
   COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
   covenLaunchCommand,

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -8,6 +8,11 @@ import {
 } from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "@/lib/process-execution";
+import {
   daemonDiagnosticContextFromRequest,
   DAEMON_DIAGNOSTIC_CORRELATION_HEADER,
   diagnosticError,
@@ -23,6 +28,8 @@ const SUBCOMMAND_ARGS: Record<string, string[]> = {
   doctor: [],
   daemon: ["status"],
 };
+const EXEC_TIMEOUT_MS = 6_000;
+const EXEC_OUTPUT_BYTES = 64 * 1024;
 
 export async function POST(req: Request) {
   const diagnostics = daemonDiagnosticContextFromRequest(req);
@@ -77,10 +84,12 @@ export async function POST(req: Request) {
         COVEN_CAVE_DIAGNOSTIC_OPERATION: operation,
         COVEN_CAVE_DIAGNOSTIC_ATTEMPT: "1",
       },
+      detached: process.platform !== "win32",
     });
-    let out = "";
-    let err = "";
+    const out = new BoundedProcessOutput(EXEC_OUTPUT_BYTES);
+    const err = new BoundedProcessOutput(EXEC_OUTPUT_BYTES);
     let settled = false;
+    let timedOut = false;
     const settle = (
       body: Record<string, unknown>,
       status: number,
@@ -90,6 +99,7 @@ export async function POST(req: Request) {
     ) => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       recordDaemonDiagnosticEvent(diagnostics, {
         component: "cli",
         operation,
@@ -106,24 +116,25 @@ export async function POST(req: Request) {
       });
       resolve(respond(body, status));
     };
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.stderr.on("data", (d) => (err += d.toString()));
-    const t = setTimeout(() => {
-      child.kill("SIGTERM");
+    const timeoutResponse = () =>
       settle(
-        { ok: false, error: "timeout", stdout: stripAnsi(out), stderr: stripAnsi(err) },
+        { ok: false, error: "timeout", stdout: out.text(), stderr: err.text() },
         504,
         "timed-out",
         "cli-timeout",
         "timeout",
       );
-    }, 6000);
+    child.stdout.on("data", (data) => out.append(data));
+    child.stderr.on("data", (data) => err.append(data));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void terminateProcessTree(child).finally(timeoutResponse);
+    }, EXEC_TIMEOUT_MS);
     child.on("error", (e) => {
-      clearTimeout(t);
       settle(
         isMissingExecutableError(e)
           ? covenCliMissingError()
-          : { ok: false, error: e.message },
+          : { ok: false, error: safeProcessErrorMessage(e, "Coven CLI") },
         500,
         "failed",
         "cli-spawn-error",
@@ -131,13 +142,16 @@ export async function POST(req: Request) {
       );
     });
     child.on("close", (code) => {
-      clearTimeout(t);
+      if (timedOut) {
+        timeoutResponse();
+        return;
+      }
       settle(
         {
           ok: code === 0,
           exitCode: code,
-          stdout: stripAnsi(out),
-          stderr: stripAnsi(err),
+          stdout: out.text(),
+          stderr: err.text(),
         },
         200,
         code === 0 ? "succeeded" : "failed",

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -5,7 +5,7 @@ const source = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   source,
-  /spawn\(launch\.command, \[\.\.\.launch\.fixedArgs, "--no-auto-update", "models"\]/,
+  /runProbe\(\s*launch\.command,\s*\[\.\.\.launch\.fixedArgs, "--no-auto-update", "models"\]/,
   "the harness catalog probe must not trigger Grok's automatic updater on routine UI refreshes",
 );
 
@@ -87,9 +87,7 @@ assert.match(
 );
 assert.match(
   source,
-  // The options object also carries `windowsHide: true` (see
-  // src/lib/child-spawn-window.test.ts); match `env` wherever it sits in it.
-  /function probeVersion\([\s\S]*?env: NodeJS\.ProcessEnv = covenSpawnEnv\(\)[\s\S]*?spawn\(binary,[\s\S]*?\{[^{}]*\benv,/,
+  /function probeVersion\([\s\S]*?env: NodeJS\.ProcessEnv = covenSpawnEnv\(\)[\s\S]*?runProbe\(binary,[\s\S]*?\{\s*env,/,
   "version probing accepts the exact launch environment instead of always rebuilding one",
 );
 assert.doesNotMatch(

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -236,6 +236,7 @@ function whichWith(binary: string, env: NodeJS.ProcessEnv): Promise<string | nul
     env,
     timeoutMs: 1_500,
     captureStderr: false,
+    redactOutput: false,
   }).then((result) => {
     if (result?.code !== 0) return null;
     const found = result.output.trim();

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -38,6 +38,10 @@ import {
   type HermesLaunchResolution,
   type RuntimeAvailabilitySummary,
 } from "@/lib/runtime-availability";
+import {
+  BoundedProcessOutput,
+  terminateProcessTree,
+} from "@/lib/process-execution";
 
 export const dynamic = "force-dynamic";
 
@@ -91,6 +95,58 @@ function resolvedCovenLaunch(): CovenLaunchCommand | null {
   } catch {
     return null;
   }
+}
+
+type ProbeResult = {
+  code: number | null;
+  output: string;
+};
+
+function runProbe(
+  command: string,
+  args: string[],
+  options: {
+    env: NodeJS.ProcessEnv;
+    timeoutMs: number;
+    captureStderr?: boolean;
+    redactOutput?: boolean;
+  },
+): Promise<ProbeResult | null> {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(command, args, {
+        windowsHide: true,
+        env: options.env,
+        stdio: ["ignore", "pipe", options.captureStderr === false ? "ignore" : "pipe"],
+        detached: process.platform !== "win32",
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    const output = new BoundedProcessOutput(64 * 1024, {
+      redact: options.redactOutput !== false,
+    });
+    let settled = false;
+    let timedOut = false;
+    const finish = (result: ProbeResult | null) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    child.stdout?.on("data", (data) => output.append(data));
+    child.stderr?.on("data", (data) => output.append(data));
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void terminateProcessTree(child).then(() => finish(null));
+    }, options.timeoutMs);
+    child.on("error", () => finish(null));
+    child.on("close", (code) =>
+      finish(timedOut ? null : { code, output: output.text() }),
+    );
+  });
 }
 
 // Mirrors the send route's launch dispatch: copilot/grok/hermes/opencode use
@@ -175,21 +231,17 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
 }
 
 function whichWith(binary: string, env: NodeJS.ProcessEnv): Promise<string | null> {
-  return new Promise((resolve) => {
-    const command = process.platform === "win32" ? "where" : "which";
-    const child = spawn(command, [binary], { windowsHide: true, env, stdio: ["ignore", "pipe", "ignore"] });
-    let out = "";
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.on("close", (code) => {
-      if (code !== 0) return resolve(null);
-      const found = out.trim();
-      resolve(
-        process.platform === "win32"
-          ? pickWindowsLauncher(found.split(/\r?\n/))
-          : found || null,
-      );
-    });
-    child.on("error", () => resolve(null));
+  const command = process.platform === "win32" ? "where" : "which";
+  return runProbe(command, [binary], {
+    env,
+    timeoutMs: 1_500,
+    captureStderr: false,
+  }).then((result) => {
+    if (result?.code !== 0) return null;
+    const found = result.output.trim();
+    return process.platform === "win32"
+      ? pickWindowsLauncher(found.split(/\r?\n/))
+      : found || null;
   });
 }
 
@@ -209,112 +261,56 @@ function probeVersion(
   fixedArgs: string[] = [],
   env: NodeJS.ProcessEnv = covenSpawnEnv(),
 ): Promise<string | null> {
-  return new Promise((resolve) => {
-    let child;
-    try {
-      child = spawn(binary, [...fixedArgs, ...args], { windowsHide: true, env, stdio: ["ignore", "pipe", "pipe"] });
-    } catch {
-      resolve(null);
-      return;
-    }
-    let out = "";
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.stderr.on("data", (d) => (out += d.toString()));
-    const t = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve(null);
-    }, 2500);
-    child.on("close", () => {
-      clearTimeout(t);
-      resolve(pickVersionLine(out));
-    });
-    child.on("error", () => {
-      clearTimeout(t);
-      resolve(null);
-    });
-  });
+  return runProbe(binary, [...fixedArgs, ...args], {
+    env,
+    timeoutMs: 2_500,
+  }).then((result) => result ? pickVersionLine(result.output) : null);
 }
 
 function probeGrokModels(
   launch: CovenLaunchCommand,
   env: NodeJS.ProcessEnv = covenSpawnEnv(),
 ): Promise<{ models: RuntimeModelOption[]; defaultModel: string | null }> {
-  return new Promise((resolve) => {
-    let child;
-    try {
-      child = spawn(launch.command, [...launch.fixedArgs, "--no-auto-update", "models"], { windowsHide: true, env, stdio: ["ignore", "pipe", "pipe"] });
-    } catch {
-      resolve({ models: [], defaultModel: null });
-      return;
-    }
-    let output = "";
-    child.stdout.on("data", (data) => (output += data.toString()));
-    child.stderr.on("data", (data) => (output += data.toString()));
-    const timeout = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve({ models: [], defaultModel: null });
-    }, 2500);
-    child.on("close", () => {
-      clearTimeout(timeout);
-      resolve(parseGrokModels(output));
-    });
-    child.on("error", () => {
-      clearTimeout(timeout);
-      resolve({ models: [], defaultModel: null });
-    });
-  });
+  return runProbe(
+    launch.command,
+    [...launch.fixedArgs, "--no-auto-update", "models"],
+    { env, timeoutMs: 2_500 },
+  ).then((result) =>
+    result
+      ? parseGrokModels(result.output)
+      : { models: [], defaultModel: null },
+  );
 }
 
 function covenSupportsAdapterList(): Promise<boolean> {
-  return new Promise((resolve) => {
-    const launch = resolvedCovenLaunch();
-    if (!launch) return resolve(false);
-    const { command, fixedArgs } = launch;
-    const child = spawn(command, [...fixedArgs, "--help"], { windowsHide: true, env: covenWrapperSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
-    let out = "";
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.stderr.on("data", (d) => (out += d.toString()));
-    const t = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve(false);
-    }, 1500);
-    child.on("close", (code) => {
-      clearTimeout(t);
-      resolve(code === 0 && covenHelpSupportsAdapterList(out));
-    });
-    child.on("error", () => {
-      clearTimeout(t);
-      resolve(false);
-    });
-  });
+  const launch = resolvedCovenLaunch();
+  if (!launch) return Promise.resolve(false);
+  const { command, fixedArgs } = launch;
+  return runProbe(command, [...fixedArgs, "--help"], {
+    env: covenWrapperSpawnEnv(),
+    timeoutMs: 1_500,
+  }).then((result) =>
+    result?.code === 0 && covenHelpSupportsAdapterList(result.output),
+  );
 }
 
 function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
-  return new Promise((resolve) => {
-    const launch = resolvedCovenLaunch();
-    if (!launch) return resolve([]);
-    const { command, fixedArgs } = launch;
-    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { windowsHide: true, env: covenWrapperSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
-    let out = "";
-    const t = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve([]);
-    }, 3000);
-    child.stdout.on("data", (d) => (out += d.toString()));
-    child.on("close", (code) => {
-      clearTimeout(t);
-      if (code !== 0) return resolve([]);
-      try {
-        const parsed = JSON.parse(out);
-        resolve(Array.isArray(parsed) ? parsed as CovenAdapterSummary[] : []);
-      } catch {
-        resolve([]);
-      }
-    });
-    child.on("error", () => {
-      clearTimeout(t);
-      resolve([]);
-    });
+  const launch = resolvedCovenLaunch();
+  if (!launch) return Promise.resolve([]);
+  const { command, fixedArgs } = launch;
+  return runProbe(command, [...fixedArgs, "adapter", "list", "--json"], {
+    env: covenWrapperSpawnEnv(),
+    timeoutMs: 3_000,
+    captureStderr: false,
+    redactOutput: false,
+  }).then((result) => {
+    if (result?.code !== 0) return [];
+    try {
+      const parsed = JSON.parse(result.output);
+      return Array.isArray(parsed) ? parsed as CovenAdapterSummary[] : [];
+    } catch {
+      return [];
+    }
   });
 }
 

--- a/src/app/api/hosts/route.ts
+++ b/src/app/api/hosts/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { execFile } from "node:child_process";
+import { spawn } from "node:child_process";
 import { hostname } from "node:os";
 import { loadConfig, saveConfig } from "@/lib/cave-config";
 import { chatHostOptions, sshHostRegistry, type ChatHostOption } from "@/lib/chat-hosts";
@@ -8,6 +8,7 @@ import { OmnigentClient } from "@/lib/omnigent/client";
 import { omnigentHostOptionId } from "@/lib/omnigent/ids";
 import { isOmnigentEnvConfigured, isOmnigentFleetActive, resolveOmnigentBaseUrl } from "@/lib/omnigent/token";
 import { rejectNonLocalRequest } from "@/lib/server/api-security";
+import { terminateProcessTree } from "@/lib/process-execution";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -18,13 +19,29 @@ const PROBE_TIMEOUT_MS = 3_500;
 
 function probeSshHost(host: string): Promise<boolean> {
   return new Promise((resolve) => {
-    const child = execFile(
+    const child = spawn(
       "ssh",
       ["-T", "-o", "BatchMode=yes", "-o", "ConnectTimeout=3", "--", host, "true"],
-      { windowsHide: true, timeout: PROBE_TIMEOUT_MS },
-      (error) => resolve(!error),
+      {
+        windowsHide: true,
+        stdio: "ignore",
+        detached: process.platform !== "win32",
+      },
     );
-    child.on("error", () => resolve(false));
+    let settled = false;
+    let timedOut = false;
+    const finish = (online: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(online);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void terminateProcessTree(child).then(() => finish(false));
+    }, PROBE_TIMEOUT_MS);
+    child.on("error", () => finish(false));
+    child.on("close", (code) => finish(!timedOut && code === 0));
   });
 }
 

--- a/src/app/api/launch/route.ts
+++ b/src/app/api/launch/route.ts
@@ -1,6 +1,11 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { resolveAllowedProjectPath } from "@/lib/server/project-paths";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "@/lib/process-execution";
 
 export const dynamic = "force-dynamic";
 
@@ -68,32 +73,51 @@ export async function POST(req: Request) {
     const child = spawn("osascript", ["-e", script], {
       stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
+      detached: true,
     });
-    let stderr = "";
-    child.stderr.on("data", (d) => (stderr += d.toString()));
+    const stderr = new BoundedProcessOutput(16 * 1024);
+    let settled = false;
+    let timedOut = false;
+    const finish = (response: Response) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(response);
+    };
+    child.stderr.on("data", (data) => stderr.append(data));
     const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve(
+      timedOut = true;
+      void terminateProcessTree(child).then(() => finish(
         NextResponse.json(
-          { ok: false, error: "launch timed out", stderr },
+          { ok: false, error: "launch timed out", stderr: stderr.text() },
           { status: 504 },
         ),
-      );
+      ));
     }, 4000);
     child.on("error", (err) => {
-      clearTimeout(timer);
-      resolve(
-        NextResponse.json({ ok: false, error: err.message }, { status: 500 }),
+      finish(
+        NextResponse.json(
+          { ok: false, error: safeProcessErrorMessage(err, "Terminal launcher") },
+          { status: 500 },
+        ),
       );
     });
     child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve(NextResponse.json({ ok: true, command }));
-      } else {
-        resolve(
+      if (timedOut) {
+        finish(
           NextResponse.json(
-            { ok: false, error: `osascript exited ${code}`, stderr },
+            { ok: false, error: "launch timed out", stderr: stderr.text() },
+            { status: 504 },
+          ),
+        );
+        return;
+      }
+      if (code === 0) {
+        finish(NextResponse.json({ ok: true, command }));
+      } else {
+        finish(
+          NextResponse.json(
+            { ok: false, error: `osascript exited ${code}`, stderr: stderr.text() },
             { status: 500 },
           ),
         );

--- a/src/app/api/mobile-handoff/route.ts
+++ b/src/app/api/mobile-handoff/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import QRCode from "qrcode";
-import { stripAnsi } from "@/lib/ansi";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "@/lib/process-execution";
 import { readMobileLastSeen } from "@/lib/server/mobile-paired";
 import {
   armMobileAccessSecret,
@@ -43,44 +47,62 @@ function runTailscale(args: string[], timeoutMs = 8000): Promise<TailscaleResult
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: tailscaleSpawnEnv(),
+      detached: process.platform !== "win32",
     });
-    let stdout = "";
-    let stderr = "";
+    const stdout = new BoundedProcessOutput(64 * 1024);
+    const stderr = new BoundedProcessOutput(64 * 1024);
+    let settled = false;
+    let timedOut = false;
+    const finish = (result: TailscaleResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
     const timer = setTimeout(() => {
-      child.kill("SIGTERM");
-      resolve({
-        ok: false,
-        status: null,
-        stdout: stripAnsi(stdout),
-        stderr: `tailscale ${args.join(" ")} timed out`,
+      timedOut = true;
+      void terminateProcessTree(child).then(() => {
+        finish({
+          ok: false,
+          status: null,
+          stdout: stdout.text(),
+          stderr: "Tailscale command timed out",
+        });
       });
     }, timeoutMs);
 
     child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
+      stdout.append(chunk);
     });
     child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
+      stderr.append(chunk);
     });
     child.on("error", (error) => {
-      clearTimeout(timer);
       const missing = (error as NodeJS.ErrnoException).code === "ENOENT";
-      resolve({
+      finish({
         ok: false,
         status: null,
-        stdout: stripAnsi(stdout),
+        stdout: stdout.text(),
         stderr: missing
           ? "Tailscale CLI not found. Install Tailscale or set TAILSCALE_BIN to the tailscale executable."
-          : error.message,
+          : safeProcessErrorMessage(error, "Tailscale CLI"),
       });
     });
     child.on("close", (status) => {
-      clearTimeout(timer);
-      resolve({
+      if (timedOut) {
+        finish({
+          ok: false,
+          status: null,
+          stdout: stdout.text(),
+          stderr: "Tailscale command timed out",
+        });
+        return;
+      }
+      finish({
         ok: status === 0,
         status,
-        stdout: stripAnsi(stdout),
-        stderr: stripAnsi(stderr),
+        stdout: stdout.text(),
+        stderr: stderr.text(),
       });
     });
   });

--- a/src/app/api/onboarding/install/install-process.ts
+++ b/src/app/api/onboarding/install/install-process.ts
@@ -1,6 +1,10 @@
 import { spawn } from "node:child_process";
-import { stripAnsi } from "@/lib/ansi";
 import { covenSpawnEnv } from "@/lib/coven-bin";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "@/lib/process-execution";
 import { redactSensitiveInstallOutput } from "./install-job-output";
 
 export type InstallProcessResult = {
@@ -21,22 +25,52 @@ export function runInstallProcess(
       stdio: ["ignore", "pipe", "pipe"],
       env: options.env ?? covenSpawnEnv(),
       shell: options.shell,
+      detached: process.platform !== "win32",
     });
-    let output = "";
-    const timer = setTimeout(() => child.kill("SIGTERM"), options.timeoutMs);
+    const output = new BoundedProcessOutput(8_192);
+    let settled = false;
+    let timedOut = false;
+    const finish = (result: InstallProcessResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      timedOut = true;
+      void terminateProcessTree(child).then(() => finish({
+        code: null,
+        signal: "SIGTERM",
+        output: redactSensitiveInstallOutput(output.text()),
+      }));
+    }, options.timeoutMs);
     child.stdout.on("data", (data) => {
-      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
+      output.append(data);
     });
     child.stderr.on("data", (data) => {
-      output = redactSensitiveInstallOutput(output + stripAnsi(data.toString()));
+      output.append(data);
     });
     child.on("error", (error) => {
-      clearTimeout(timer);
-      resolve({ code: 1, signal: null, output: error.message });
+      finish({
+        code: 1,
+        signal: null,
+        output: safeProcessErrorMessage(error, "Coven CLI"),
+      });
     });
     child.on("close", (code, signal) => {
-      clearTimeout(timer);
-      resolve({ code, signal, output });
+      if (timedOut) {
+        finish({
+          code: null,
+          signal: "SIGTERM",
+          output: redactSensitiveInstallOutput(output.text()),
+        });
+        return;
+      }
+      finish({
+        code,
+        signal,
+        output: redactSensitiveInstallOutput(output.text()),
+      });
     });
   });
 }

--- a/src/app/api/onboarding/install/install-process.ts
+++ b/src/app/api/onboarding/install/install-process.ts
@@ -17,14 +17,14 @@ export type InstallProcessResult = {
 export function runInstallProcess(
   command: string,
   args: string[],
-  options: { shell: boolean; timeoutMs: number; env?: NodeJS.ProcessEnv },
+  options: { timeoutMs: number; env?: NodeJS.ProcessEnv },
 ): Promise<InstallProcessResult> {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: options.env ?? covenSpawnEnv(),
-      shell: options.shell,
+      shell: false,
       detached: process.platform !== "win32",
     });
     const output = new BoundedProcessOutput(8_192);

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -519,7 +519,6 @@ function daemonLifecycleDependencies(job: InstallJob): DaemonUpdateDependencies 
         return { ok: false, detail: "Cave could not safely resolve the Coven Windows command shim." };
       }
       const stop = await runInstallProcess(command, [...fixedArgs, "daemon", "stop"], {
-        shell: false,
         timeoutMs: 8_000,
         env: covenWrapperSpawnEnv(),
       });

--- a/src/lib/first-project-gate-policy.test.ts
+++ b/src/lib/first-project-gate-policy.test.ts
@@ -155,3 +155,21 @@ test("a globally registered project does not bypass the gate when the active fam
   });
   assert.deepEqual(granted, { open: false, familiarId: "ember", blockChatLaunch: false });
 });
+
+test("without an active familiar, the gate does not pre-select one and block launch", () => {
+  const policy = resolveFirstProjectGatePolicy({
+    activeFamiliarId: null,
+    visibleFamiliars,
+    registeredProjects: [project],
+    accessibleProjects: [],
+    accessibleProjectsInitiallyResolved: true,
+    pendingGrant: null,
+    onboardingResolved: true,
+    onboardingOpen: false,
+    mode: "chat",
+    familiarsLoaded: true,
+    familiarRosterLoadedSuccessfully: true,
+    projectsInitiallyResolved: true,
+  });
+  assert.deepEqual(policy, { open: false, familiarId: null, blockChatLaunch: false });
+});

--- a/src/lib/first-project-gate-policy.ts
+++ b/src/lib/first-project-gate-policy.ts
@@ -36,7 +36,7 @@ export function resolveFirstProjectGatePolicy(
   input: FirstProjectGatePolicyInput,
 ): FirstProjectGatePolicy {
   const familiarId = input.pendingGrant?.familiarId
-    ?? preferredFirstProjectGateFamiliarId(input.activeFamiliarId, input.visibleFamiliars);
+    ?? input.activeFamiliarId;
   const accessibleProjects = input.accessibleProjects ?? input.registeredProjects;
   const accessibleProjectsInitiallyResolved = input.accessibleProjectsInitiallyResolved ?? true;
   const blockChatLaunch = input.onboardingResolved

--- a/src/lib/process-boundary-contracts.test.ts
+++ b/src/lib/process-boundary-contracts.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const [mobile, harnesses, launch, hosts, install] = await Promise.all([
+  readFile(new URL("../app/api/mobile-handoff/route.ts", import.meta.url), "utf8"),
+  readFile(new URL("../app/api/harnesses/route.ts", import.meta.url), "utf8"),
+  readFile(new URL("../app/api/launch/route.ts", import.meta.url), "utf8"),
+  readFile(new URL("../app/api/hosts/route.ts", import.meta.url), "utf8"),
+  readFile(new URL("../app/api/onboarding/install/install-process.ts", import.meta.url), "utf8"),
+]);
+
+for (const [name, source] of [
+  ["mobile handoff", mobile],
+  ["harness probes", harnesses],
+  ["Terminal launch", launch],
+  ["SSH host probe", hosts],
+  ["installer stop", install],
+]) {
+  assert.match(source, /terminateProcessTree/, `${name} should terminate the owned tree`);
+  assert.match(
+    source,
+    /detached: (?:process\.platform !== "win32"|true)/,
+    `${name} should own a POSIX process group`,
+  );
+}
+
+for (const [name, source] of [
+  ["mobile handoff", mobile],
+  ["harness probes", harnesses],
+  ["Terminal launch", launch],
+  ["installer stop", install],
+]) {
+  assert.match(source, /BoundedProcessOutput/, `${name} should cap retained process output`);
+}
+
+for (const [name, source] of [
+  ["mobile handoff", mobile],
+  ["harness probes", harnesses],
+  ["Terminal launch", launch],
+  ["SSH host probe", hosts],
+  ["installer stop", install],
+]) {
+  assert.match(source, /timedOut/, `${name} should preserve timeout semantics through close`);
+}
+
+assert.match(install, /shell: false/, "installer stop should never execute through a shell");
+assert.doesNotMatch(mobile, /stderr: error\.message/, "mobile diagnostics should not expose raw spawn errors");
+assert.doesNotMatch(launch, /error: err\.message/, "Terminal diagnostics should not expose raw spawn errors");
+
+console.log("process-boundary-contracts.test.ts: ok");

--- a/src/lib/process-boundary-contracts.test.ts
+++ b/src/lib/process-boundary-contracts.test.ts
@@ -48,7 +48,7 @@ for (const [name, source] of [
 assert.match(install, /shell: false/, "installer stop should never execute through a shell");
 assert.match(
   installService,
-  /if \(launch\.unresolvedWindowsShim\)/,
+  /if \(unresolvedWindowsShim\)/,
   "installer daemon stop should reject an unresolved Windows batch shim",
 );
 assert.match(

--- a/src/lib/process-boundary-contracts.test.ts
+++ b/src/lib/process-boundary-contracts.test.ts
@@ -2,12 +2,13 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-const [mobile, harnesses, launch, hosts, install] = await Promise.all([
+const [mobile, harnesses, launch, hosts, install, installService] = await Promise.all([
   readFile(new URL("../app/api/mobile-handoff/route.ts", import.meta.url), "utf8"),
   readFile(new URL("../app/api/harnesses/route.ts", import.meta.url), "utf8"),
   readFile(new URL("../app/api/launch/route.ts", import.meta.url), "utf8"),
   readFile(new URL("../app/api/hosts/route.ts", import.meta.url), "utf8"),
   readFile(new URL("../app/api/onboarding/install/install-process.ts", import.meta.url), "utf8"),
+  readFile(new URL("../app/api/onboarding/install/install-service.ts", import.meta.url), "utf8"),
 ]);
 
 for (const [name, source] of [
@@ -45,6 +46,16 @@ for (const [name, source] of [
 }
 
 assert.match(install, /shell: false/, "installer stop should never execute through a shell");
+assert.match(
+  installService,
+  /if \(launch\.unresolvedWindowsShim\)/,
+  "installer daemon stop should reject an unresolved Windows batch shim",
+);
+assert.match(
+  harnesses,
+  /function whichWith[\s\S]*?redactOutput: false/,
+  "executable discovery should preserve valid Nix store hashes",
+);
 assert.doesNotMatch(mobile, /stderr: error\.message/, "mobile diagnostics should not expose raw spawn errors");
 assert.doesNotMatch(launch, /error: err\.message/, "Terminal diagnostics should not expose raw spawn errors");
 

--- a/src/lib/process-execution.test.ts
+++ b/src/lib/process-execution.test.ts
@@ -51,6 +51,25 @@ test("bounded process output enforces its limit in UTF-8 bytes", () => {
   assert.doesNotMatch(output.text(), /\uFFFD/);
 });
 
+test("bounded process output decodes and redacts across process chunks", () => {
+  const output = new BoundedProcessOutput(200);
+  const unicode = Buffer.from("🦇");
+  output.append("Authorization: Bear");
+  output.append("er github_pat_abcdefghijklmnop");
+  output.append(Buffer.concat([
+    Buffer.from("qrstuvwxyz123456\n"),
+    unicode.subarray(0, 2),
+  ]));
+  output.append(Buffer.concat([
+    unicode.subarray(2),
+    Buffer.from("\n"),
+  ]));
+
+  assert.doesNotMatch(output.text(), /github_pat_|abcdefghijklmnop|qrstuvwxyz/);
+  assert.match(output.text(), /Authorization: \[redacted\]/);
+  assert.doesNotMatch(output.text(), /\uFFFD/);
+});
+
 test("POSIX tree cleanup escalates when a descendant survives the root", {
   skip: process.platform === "win32",
 }, async () => {

--- a/src/lib/process-execution.test.ts
+++ b/src/lib/process-execution.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { test } from "node:test";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "./process-execution.ts";
+
+test("bounded process output strips ANSI, redacts secrets, and retains a capped tail", () => {
+  const output = new BoundedProcessOutput(80);
+  output.append("\u001b[31mstarting\u001b[0m github_pat_abcdefghijklmnopqrstuvwxyz123456\n");
+  output.append("tail-".repeat(40));
+  const text = output.text();
+  assert.ok(Buffer.byteLength(text) <= 80);
+  assert.match(text, /^\[earlier output truncated\]\n/);
+  assert.doesNotMatch(text, /\u001b|github_pat_/);
+  assert.equal(output.wasTruncated(), true);
+});
+
+test("spawn failures use stable path-free diagnostics", () => {
+  assert.equal(
+    safeProcessErrorMessage(Object.assign(new Error("/private/bin/coven"), { code: "ENOENT" }), "Coven CLI"),
+    "Coven CLI executable was not found",
+  );
+  assert.equal(
+    safeProcessErrorMessage(Object.assign(new Error("/private/bin/coven"), { code: "EACCES" }), "Coven CLI"),
+    "Coven CLI executable is not permitted",
+  );
+  assert.equal(
+    safeProcessErrorMessage(new Error("/private/bin/coven"), "Coven CLI"),
+    "Coven CLI could not be started",
+  );
+});
+
+test("structured process output can be bounded without rewriting valid JSON", () => {
+  const output = new BoundedProcessOutput(200, { redact: false });
+  output.append('{"token":"github_pat_abcdefghijklmnopqrstuvwxyz123456"}');
+  assert.deepEqual(JSON.parse(output.text()), {
+    token: "github_pat_abcdefghijklmnopqrstuvwxyz123456",
+  });
+});
+
+test("bounded process output enforces its limit in UTF-8 bytes", () => {
+  const output = new BoundedProcessOutput(48);
+  output.append("prefix-" + "🦇".repeat(20));
+
+  assert.ok(Buffer.byteLength(output.text()) <= 48);
+  assert.match(output.text(), /^\[earlier output truncated\]\n/);
+  assert.doesNotMatch(output.text(), /\uFFFD/);
+});
+
+test("POSIX tree cleanup escalates when a descendant survives the root", {
+  skip: process.platform === "win32",
+}, async () => {
+  const child = spawn(process.execPath, ["-e", `
+    const { spawn } = require("node:child_process");
+    spawn(process.execPath, ["-e", "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"], {
+      stdio: "ignore",
+    });
+    process.on("SIGTERM", () => process.exit(0));
+    process.stdout.write("ready");
+    setInterval(() => {}, 1000);
+  `], {
+    detached: true,
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  assert.ok(child.pid);
+  try {
+    await Promise.race([
+      once(child.stdout!, "data"),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("fixture did not become ready")), 2_000),
+      ),
+    ]);
+    assert.equal(await terminateProcessTree(child, { graceMs: 500 }), true);
+    assert.throws(
+      () => process.kill(-child.pid!, 0),
+      (error: NodeJS.ErrnoException) => error.code === "ESRCH",
+    );
+  } finally {
+    try {
+      process.kill(-child.pid!, "SIGKILL");
+    } catch {
+      // The expected path already exhausted the process group.
+    }
+  }
+});

--- a/src/lib/process-execution.ts
+++ b/src/lib/process-execution.ts
@@ -1,0 +1,208 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { stripAnsi } from "./ansi.ts";
+import { redactSecretText } from "./secret-redaction.ts";
+
+const DEFAULT_TERMINATION_GRACE_MS = 1_000;
+const TRUNCATION_MARKER = "[earlier output truncated]\n";
+const TRUNCATION_MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER);
+
+function utf8Tail(value: string, maxBytes: number): string {
+  let start = value.length;
+  let retainedBytes = 0;
+
+  while (start > 0) {
+    let nextStart = start - 1;
+    const codeUnit = value.charCodeAt(nextStart);
+    if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff && nextStart > 0) {
+      const previous = value.charCodeAt(nextStart - 1);
+      if (previous >= 0xd800 && previous <= 0xdbff) nextStart -= 1;
+    }
+    const characterBytes = Buffer.byteLength(value.slice(nextStart, start));
+    if (retainedBytes + characterBytes > maxBytes) break;
+    retainedBytes += characterBytes;
+    start = nextStart;
+  }
+
+  return value.slice(start);
+}
+
+export class BoundedProcessOutput {
+  private value = "";
+  private truncated = false;
+  private readonly maxBytes: number;
+  private readonly redact: boolean;
+
+  constructor(maxBytes: number, options: { redact?: boolean } = {}) {
+    if (!Number.isSafeInteger(maxBytes) || maxBytes <= TRUNCATION_MARKER_BYTES) {
+      throw new Error("process output budget must exceed the truncation marker");
+    }
+    this.maxBytes = maxBytes;
+    this.redact = options.redact !== false;
+  }
+
+  append(chunk: string | Buffer): void {
+    const safeChunk = this.redact
+      ? sanitizeProcessOutput(chunk)
+      : stripAnsi(chunk.toString());
+    const nextValue = this.value + safeChunk;
+    if (Buffer.byteLength(nextValue) <= this.maxBytes) {
+      this.value = nextValue;
+      return;
+    }
+    this.truncated = true;
+    this.value =
+      TRUNCATION_MARKER
+      + utf8Tail(nextValue, this.maxBytes - TRUNCATION_MARKER_BYTES);
+  }
+
+  text(): string {
+    return this.redact ? redactSecretText(this.value) : this.value;
+  }
+
+  wasTruncated(): boolean {
+    return this.truncated;
+  }
+}
+
+export function sanitizeProcessOutput(chunk: string | Buffer): string {
+  return redactSecretText(stripAnsi(chunk.toString()));
+}
+
+export function safeProcessErrorMessage(
+  error: unknown,
+  label: string,
+): string {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? String(error.code)
+      : "";
+  if (code === "ENOENT") return `${label} executable was not found`;
+  if (code === "EACCES" || code === "EPERM") {
+    return `${label} executable is not permitted`;
+  }
+  return `${label} could not be started`;
+}
+
+function isMissingProcess(error: unknown): boolean {
+  return Boolean(
+    error
+    && typeof error === "object"
+    && "code" in error
+    && error.code === "ESRCH",
+  );
+}
+
+function waitForChildExit(child: ChildProcess, timeoutMs: number): Promise<boolean> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve(true);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.off("close", onClose);
+      resolve(value);
+    };
+    const onClose = () => finish(true);
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    child.once("close", onClose);
+  });
+}
+
+function processGroupAlive(pid: number): boolean {
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch (error) {
+    return !isMissingProcess(error);
+  }
+}
+
+async function waitForProcessGroupExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!processGroupAlive(pid)) return true;
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
+  return !processGroupAlive(pid);
+}
+
+async function terminateWindowsTree(
+  child: ChildProcess,
+  timeoutMs: number,
+): Promise<boolean> {
+  if (child.pid === undefined) {
+    try {
+      child.kill("SIGTERM");
+    } catch {
+      return child.exitCode !== null || child.signalCode !== null;
+    }
+    return waitForChildExit(child, timeoutMs);
+  }
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: boolean) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    const killer = spawn(
+      "taskkill.exe",
+      ["/PID", String(child.pid), "/T", "/F"],
+      { stdio: "ignore", windowsHide: true },
+    );
+    const timer = setTimeout(() => finish(false), timeoutMs);
+    killer.once("error", () => finish(false));
+    killer.once("close", (code) => finish(code === 0));
+  });
+}
+
+/**
+ * Terminate the exact tree owned by a direct spawn. Callers must launch POSIX
+ * children with `detached: true` so the child owns the process group.
+ */
+export async function terminateProcessTree(
+  child: ChildProcess,
+  options: {
+    platform?: NodeJS.Platform;
+    graceMs?: number;
+  } = {},
+): Promise<boolean> {
+  const platform = options.platform ?? process.platform;
+  const graceMs = options.graceMs ?? DEFAULT_TERMINATION_GRACE_MS;
+  if (platform === "win32") {
+    return terminateWindowsTree(child, graceMs);
+  }
+  const pid = child.pid;
+  if (pid === undefined) {
+    try {
+      child.kill("SIGTERM");
+    } catch (error) {
+      return isMissingProcess(error);
+    }
+    if (await waitForChildExit(child, graceMs)) return true;
+    try {
+      child.kill("SIGKILL");
+    } catch (error) {
+      return isMissingProcess(error);
+    }
+    return waitForChildExit(child, graceMs);
+  }
+  try {
+    process.kill(-pid, "SIGTERM");
+  } catch (error) {
+    if (isMissingProcess(error)) return true;
+    return false;
+  }
+  await waitForChildExit(child, graceMs);
+  if (!processGroupAlive(pid)) return true;
+  try {
+    process.kill(-pid, "SIGKILL");
+  } catch (error) {
+    if (!isMissingProcess(error)) return false;
+  }
+  return waitForProcessGroupExit(pid, graceMs);
+}

--- a/src/lib/process-execution.ts
+++ b/src/lib/process-execution.ts
@@ -1,10 +1,12 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 import { stripAnsi } from "./ansi.ts";
 import { redactSecretText } from "./secret-redaction.ts";
 
 const DEFAULT_TERMINATION_GRACE_MS = 1_000;
 const TRUNCATION_MARKER = "[earlier output truncated]\n";
 const TRUNCATION_MARKER_BYTES = Buffer.byteLength(TRUNCATION_MARKER);
+const REDACTION_CONTEXT_BYTES = 4 * 1024;
 
 function utf8Tail(value: string, maxBytes: number): string {
   let start = value.length;
@@ -27,10 +29,12 @@ function utf8Tail(value: string, maxBytes: number): string {
 }
 
 export class BoundedProcessOutput {
-  private value = "";
+  private rawValue = "";
   private truncated = false;
   private readonly maxBytes: number;
   private readonly redact: boolean;
+  private readonly decoder = new StringDecoder("utf8");
+  private finished = false;
 
   constructor(maxBytes: number, options: { redact?: boolean } = {}) {
     if (!Number.isSafeInteger(maxBytes) || maxBytes <= TRUNCATION_MARKER_BYTES) {
@@ -41,22 +45,34 @@ export class BoundedProcessOutput {
   }
 
   append(chunk: string | Buffer): void {
-    const safeChunk = this.redact
-      ? sanitizeProcessOutput(chunk)
-      : stripAnsi(chunk.toString());
-    const nextValue = this.value + safeChunk;
-    if (Buffer.byteLength(nextValue) <= this.maxBytes) {
-      this.value = nextValue;
+    if (this.finished) return;
+    const decoded = this.decoder.write(
+      typeof chunk === "string" ? Buffer.from(chunk) : chunk,
+    );
+    const nextValue = this.rawValue + decoded;
+    const rawBudget = this.maxBytes + REDACTION_CONTEXT_BYTES;
+    if (Buffer.byteLength(nextValue) <= rawBudget) {
+      this.rawValue = nextValue;
       return;
     }
     this.truncated = true;
-    this.value =
-      TRUNCATION_MARKER
-      + utf8Tail(nextValue, this.maxBytes - TRUNCATION_MARKER_BYTES);
+    this.rawValue = utf8Tail(nextValue, rawBudget);
   }
 
   text(): string {
-    return this.redact ? redactSecretText(this.value) : this.value;
+    if (!this.finished) {
+      this.rawValue += this.decoder.end();
+      this.finished = true;
+    }
+    const sanitized = this.redact
+      ? redactSecretText(stripAnsi(this.rawValue))
+      : stripAnsi(this.rawValue);
+    if (!this.truncated && Buffer.byteLength(sanitized) <= this.maxBytes) {
+      return sanitized;
+    }
+    this.truncated = true;
+    return TRUNCATION_MARKER
+      + utf8Tail(sanitized, this.maxBytes - TRUNCATION_MARKER_BYTES);
   }
 
   wasTruncated(): boolean {

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -769,7 +769,6 @@ test("automation execution is bounded, redacted, direct, and tree-owned", async 
   assert.match(source, /terminateProcessTreeImpl\(child\)/);
   assert.match(source, /safeProcessErrorMessage\(err, "Automation runtime"\)/);
   assert.match(source, /output\.on\("error"/);
-  assert.match(source, /safeProcessErrorMessage\(error, "Automation log"\)/);
   assert.match(source, /detached: process\.platform !== "win32"/);
   assert.doesNotMatch(source, /\.stdout\?\.pipe\(out\)|\.stderr\?\.pipe\(out\)/);
 });

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -764,9 +764,12 @@ test("native Windows crosses the installed official shim boundary without launch
 test("automation execution is bounded, redacted, direct, and tree-owned", async () => {
   const source = await readFile(new URL("./automation-runner.ts", import.meta.url), "utf8");
   assert.match(source, /MAX_RUN_LOG_BYTES/);
+  assert.match(source, /new BoundedProcessOutput\(MAX_RUN_LOG_BYTES\)/);
   assert.match(source, /AUTOMATION_TIMEOUT_MS/);
-  assert.match(source, /terminateProcessTree\(child\)/);
+  assert.match(source, /terminateProcessTreeImpl\(child\)/);
   assert.match(source, /safeProcessErrorMessage\(err, "Automation runtime"\)/);
+  assert.match(source, /output\.on\("error"/);
+  assert.match(source, /safeProcessErrorMessage\(error, "Automation log"\)/);
   assert.match(source, /detached: process\.platform !== "win32"/);
   assert.doesNotMatch(source, /\.stdout\?\.pipe\(out\)|\.stderr\?\.pipe\(out\)/);
 });

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -760,3 +760,13 @@ test("native Windows crosses the installed official shim boundary without launch
   assert.equal(result.status, 0, result.stderr || result.error?.message);
   assert.match(result.stdout, /codex/i);
 });
+
+test("automation execution is bounded, redacted, direct, and tree-owned", async () => {
+  const source = await readFile(new URL("./automation-runner.ts", import.meta.url), "utf8");
+  assert.match(source, /MAX_RUN_LOG_BYTES/);
+  assert.match(source, /AUTOMATION_TIMEOUT_MS/);
+  assert.match(source, /terminateProcessTree\(child\)/);
+  assert.match(source, /safeProcessErrorMessage\(err, "Automation runtime"\)/);
+  assert.match(source, /detached: process\.platform !== "win32"/);
+  assert.doesNotMatch(source, /\.stdout\?\.pipe\(out\)|\.stderr\?\.pipe\(out\)/);
+});

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -12,6 +12,12 @@ import {
   type CodexManagedPackage,
 } from "../codex-bin.ts";
 import { sanitizeAboutDiagnosticText } from "../about-diagnostics.ts";
+import { MAX_RUN_LOG_BYTES } from "./automation-log-paths.ts";
+import {
+  BoundedProcessOutput,
+  safeProcessErrorMessage,
+  terminateProcessTree,
+} from "@/lib/process-execution";
 import type { CodexAutomation } from "@/lib/codex-automations-types";
 import {
   recordRun,
@@ -143,6 +149,7 @@ export function spawnCodexExecInvocation(
       ),
       shell: false,
       windowsHide: true,
+      detached: process.platform !== "win32",
     },
   ]);
   // Install the stream error handler before the first byte is written. A
@@ -191,11 +198,15 @@ export function monitorCodexAutomationCompletion(
   runId: string,
   dependencies: {
     output?: Writable;
+    outputBuffer?: BoundedProcessOutput;
+    timeoutMs?: number;
+    terminateProcessTreeImpl?: typeof terminateProcessTree;
     updateRunImpl?: UpdateRunImpl;
     reportPersistenceError?: (error: Error) => void;
   } = {},
 ): void {
   const updateRunImpl = dependencies.updateRunImpl ?? updateRun;
+  const terminateProcessTreeImpl = dependencies.terminateProcessTreeImpl ?? terminateProcessTree;
   const reportPersistenceError = dependencies.reportPersistenceError ?? ((error: Error) => {
     const detail = sanitizeAboutDiagnosticText(error.message);
     console.error(
@@ -210,6 +221,8 @@ export function monitorCodexAutomationCompletion(
   let closeCode: number | null = null;
   let childError: Error | null = null;
   let deliveryResult: CodexPromptDeliveryResult | null = null;
+  let timedOut = false;
+  let timeout: NodeJS.Timeout | null = null;
   let logResult: CodexPromptDeliveryResult | null = dependencies.output
     ? null
     : { ok: true };
@@ -259,6 +272,14 @@ export function monitorCodexAutomationCompletion(
     // Waiting for it lets a real runtime exit code/stderr outrank an earlier
     // secondary EPIPE without risking a later status overwrite.
     if (terminalPersisted || !closeSeen || !deliveryResult || !logResult) return;
+    if (timedOut) {
+      persist({
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        summary: "Run exceeded the two-hour execution limit",
+      });
+      return;
+    }
     if (childError) {
       persist({
         status: "failed",
@@ -322,6 +343,7 @@ export function monitorCodexAutomationCompletion(
     },
   );
   child.once("close", (code) => {
+    if (timeout) clearTimeout(timeout);
     closeSeen = true;
     closeCode = code;
     maybeEndOutput();
@@ -329,6 +351,7 @@ export function monitorCodexAutomationCompletion(
   });
 
   const output = dependencies.output;
+  const outputBuffer = dependencies.outputBuffer;
   const sources = [child.stdout, child.stderr]
     .filter((source): source is Readable => source !== null);
   const pendingSources = new Set<Readable>(sources);
@@ -347,7 +370,7 @@ export function monitorCodexAutomationCompletion(
     if (!output || outputEndRequested || logResult || !closeSeen || pendingSources.size > 0) return;
     outputEndRequested = true;
     try {
-      output.end();
+      output.end(outputBuffer?.text());
     } catch (error) {
       logResult = { ok: false, error: asError(error, "Codex output log failed") };
       maybePersistTerminal();
@@ -363,13 +386,23 @@ export function monitorCodexAutomationCompletion(
     });
     output.on("error", (error) => {
       if (!logResult) {
-        logResult = { ok: false, error: asError(error, "Codex output log failed") };
+        logResult = {
+          ok: false,
+          error: new Error(safeProcessErrorMessage(error, "Automation log")),
+        };
       }
       // Once the sink fails, drain both pipes so the child cannot block on a
       // full stdout/stderr buffer while we wait for its authoritative close.
       for (const source of sources) {
         source.unpipe(output);
         source.resume();
+      }
+      if (!closeSeen) {
+        void terminateProcessTreeImpl(child).finally(() => {
+          closeSeen = true;
+          pendingSources.clear();
+          maybePersistTerminal();
+        });
       }
       maybePersistTerminal();
     });
@@ -379,11 +412,29 @@ export function monitorCodexAutomationCompletion(
       source.once("error", (error) => settleSource(source, error));
       if (source.readableEnded || source.destroyed) {
         settleSource(source);
+      } else if (outputBuffer) {
+        source.on("data", (chunk: Buffer | string) => outputBuffer.append(chunk));
       } else {
         source.pipe(output, { end: false });
       }
     }
     maybeEndOutput();
+  }
+
+  if (dependencies.timeoutMs !== undefined) {
+    timeout = setTimeout(() => {
+      timedOut = true;
+      deliveryResult ??= {
+        ok: false,
+        error: new Error("Codex automation timed out before prompt delivery completed"),
+      };
+      void terminateProcessTreeImpl(child).finally(() => {
+        closeSeen = true;
+        pendingSources.clear();
+        maybeEndOutput();
+        maybePersistTerminal();
+      });
+    }, dependencies.timeoutMs);
   }
 }
 
@@ -414,7 +465,12 @@ export function startCodexExecWithOwnedLog(
       launched.child,
       launched.promptDelivery,
       runId,
-      { output, ...(updateRunImpl ? { updateRunImpl } : {}) },
+      {
+        output,
+        outputBuffer: new BoundedProcessOutput(MAX_RUN_LOG_BYTES),
+        timeoutMs: AUTOMATION_TIMEOUT_MS,
+        ...(updateRunImpl ? { updateRunImpl } : {}),
+      },
     );
     return launched;
   } catch (error) {
@@ -426,7 +482,7 @@ export function startCodexExecWithOwnedLog(
     // and stop the child rather than leaving it blocked on an unread pipe.
     launched.child.stdout?.resume();
     launched.child.stderr?.resume();
-    try { launched.child.kill(); } catch { /* child already settled */ }
+    void terminateProcessTree(launched.child);
     throw error;
   }
 }
@@ -472,7 +528,7 @@ export async function startAutomationRun(auto: CodexAutomation): Promise<Automat
     await updateRun(run.id, {
       status: "failed",
       finishedAt: new Date().toISOString(),
-      summary: err instanceof Error ? err.message : "could not start run",
+      summary: safeProcessErrorMessage(err, "Automation runtime"),
     });
   }
   return run;

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -386,10 +386,7 @@ export function monitorCodexAutomationCompletion(
     });
     output.on("error", (error) => {
       if (!logResult) {
-        logResult = {
-          ok: false,
-          error: new Error(safeProcessErrorMessage(error, "Automation log")),
-        };
+        logResult = { ok: false, error: asError(error, "Codex output log failed") };
       }
       // Once the sink fails, drain both pipes so the child cannot block on a
       // full stdout/stderr buffer while we wait for its authoritative close.

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -20,6 +20,8 @@ import {
   type AutomationRunRecord,
 } from "@/lib/automation-runs.ts";
 
+const AUTOMATION_TIMEOUT_MS = 2 * 60 * 60 * 1_000;
+
 export type CodexExecInvocation = {
   command: string;
   args: string[];


### PR DESCRIPTION
## Summary
- bound and redact CLI/probe/install output with UTF-8 byte-accurate budgets
- enforce direct process execution, explicit timeouts, and descendant-tree cleanup across API and automation boundaries
- preserve correlated daemon diagnostics and stable path-free spawn failures

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- focused process execution and boundary contracts

Bead: `cave-58eoq.6`