### PR TITLE
chore(worktrees): version the scheduled sweep script and its prompt

### DIFF
--- a/scripts/worktree-sweep-prompt.md
+++ b/scripts/worktree-sweep-prompt.md
@@ -1,0 +1,92 @@
+Scheduled worktree sweep for the coven-cave repository. You are running
+unattended from a scheduler, with the primary checkout as your working
+directory. Other interactive sessions may be live on this same checkout right
+now. Assume nothing; verify everything.
+
+The wiring that launches you is machine-specific and lives outside the repo: a
+scheduler entry (launchd on macOS) invoking scripts/worktree-sweep.sh, and on
+macOS an app bundle holding the Full Disk Access grant that a scheduled job
+needs to read a protected folder. If that grant is missing the sweep aborts
+loudly rather than reporting an empty repository as "nothing to retire".
+
+Your job: run the lifecycle patrol and retire ONLY what has genuinely become
+cleanup-ready. Preserving a unit that should have been retired costs nothing.
+Destroying a unit that was still live is unrecoverable. When those two trade off,
+always preserve.
+
+## 1. Assess
+
+- Check GraphQL quota first: `gh api rate_limit --jq .resources.graphql`. If it is
+  nearly exhausted, STOP and report — the patrol will exit 1 with an incomplete
+  inventory, and an incomplete inventory must never be treated as "nothing to do".
+- Run `pnpm beads:worktrees:json` (takes several minutes). Skip the pnpm banner
+  before the first `{` when parsing. Each item's `lane` field is the
+  classification; `counts` is the tally.
+
+## 2. Decide
+
+- Retire ONLY units in lane `cleanup-ready`.
+- Preserve every unit in lane `active`, `cooldown`, `recovery`, `uncertain`, or
+  `retire-after-gate`, and state the reason for each in your report.
+- Preserve any unit with uncommitted changes or a live process cwd, regardless of
+  lane.
+- If the patrol reports `ok: false` or any probe warnings, preserve everything and
+  report. A degraded inventory is not evidence of retirability.
+
+## 3. Retire via the tool, not by hand
+
+If step 2 found at least one `cleanup-ready` unit, run:
+
+```
+pnpm beads:worktrees:apply --allow-unenforced-planes --max-retire 3
+```
+
+**Use this path rather than removing worktrees yourself.** Hand-retirement is a
+multi-step ritual performed from memory — prove retention, push an archive tag,
+unlock, remove, delete the branch, clear the bead's metadata record — and steps
+get skipped silently. Measured on 2026-08-10: of five hand-retired units, two
+were removed with no archive tag, so their squash-merged commits sat on no ref
+at all; and every hand-retirement left the bead's `metadata.coven.worktree`
+record behind, which then blocks that bead from ever holding another worktree.
+The apply path does retention proof, removal, metadata repair and audit as one
+fenced operation, so none of those steps can be forgotten.
+
+`--allow-unenforced-planes` is what makes this reachable while the beads and
+github maintenance planes stay unenforced (cave-wqa0b.3/.4, cave-3aqvr). It is
+explicit and audited: the run prints `DEGRADED APPLY` on stderr naming each
+waived plane before touching anything. Capture that banner in your report.
+
+**The local plane is still enforced and is never waived.** If apply refuses with
+`local-acquire-failed: gate-held`, another actor holds the maintenance gate —
+that is correct behaviour, not a failure. Report it and stop; do NOT fall back
+to hand-retirement to get around it, because the gate is what stops two actors
+retiring the same unit.
+
+`--max-retire 3` bounds the blast radius of an unattended run. Do not raise it.
+
+Other refusals to report rather than work around: `gate-incomplete` means the
+flag did not reach the command; anything naming the local plane means the
+exclusion is unavailable.
+
+- NEVER use WT_GUARD_BYPASS.
+- Do NOT delete remote branches. Remote deletion is proposal-only in this repo.
+- If something blocks on live processes, identify them
+  (`ps -o pid,ppid,etime,command -p <pid>`) and report by pid and command.
+  Leftover watcher loops from a dead session are safe to stop; another session's
+  live work is NOT.
+
+## 4. Close out
+
+For any retired unit whose work has merged, close its bead with the merge commit
+as evidence: `bd close <id> --reason "..."`. Do not close a bead on partial
+evidence — if only some of its acceptance criteria landed, leave it open and note
+what remains.
+
+## 5. Report
+
+Print: what apply retired (quote its own report rather than paraphrasing), the
+DEGRADED APPLY banner naming the waived planes, what was preserved and why,
+anything that blocked, and the final worktree count
+against the budget — currently 28 worktrees / 38 local branches, raised in PR
+#4472. If you retired nothing, say so plainly; with concurrent sessions active,
+"nothing was retirable" is the normal and correct outcome, not a failure.

--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Scheduled worktree lifecycle sweep.
+#
+# Drives a real agent rather than scripting `git worktree remove` directly, and
+# that is deliberate. Deciding whether a worktree is retirable needs judgement
+# the guard rails encode: is the unit in cooldown, does it hold uncommitted
+# work, is another live session sitting in it, are its commits reachable from
+# any remote ref. A blind script removing `cleanup-ready` units would sooner or
+# later destroy live work — which is what happened on 2026-07-03.
+#
+# The agent's instructions live in worktree-sweep-prompt.md beside this file.
+# Both are versioned here rather than only on one machine, because the prompt
+# carries the retirement discipline (the --max-retire bound, why a held gate is
+# not a reason to fall back to hand-retirement) and that reasoning is worth
+# more than the twenty lines of shell around it. See cave-6qzo0.
+#
+# Machine-specific wiring — the launchd plist and, on macOS, an app bundle that
+# holds the Full Disk Access grant — stays out of the repo. See the header of
+# worktree-sweep-prompt.md for what that wiring has to provide.
+#
+# Environment:
+#   SWEEP_LOG   override the log path (default: $HOME/.claude/logs/…)
+#   SWEEP_REPO  override the repository root (default: this script's checkout)
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+# Derive the checkout from the script's own location so this works from any
+# clone. An explicit override still wins, for a scheduler that copies the
+# script elsewhere.
+#
+# Note this resolves to the *containing* checkout, so invoking the copy inside a
+# linked worktree targets that worktree — and `git worktree list` there still
+# enumerates every unit in the repository. The scheduled job is pinned to the
+# primary checkout, which is what you want; running it by hand from a worktree
+# is a live sweep of the whole repository, not a scoped one. Use --dry-run
+# semantics by reading the prompt first, or set SWEEP_REPO deliberately.
+REPO="${SWEEP_REPO:-$(cd "$script_dir/.." && pwd -P)}"
+PROMPT_FILE="$script_dir/worktree-sweep-prompt.md"
+LOG="${SWEEP_LOG:-$HOME/.claude/logs/coven-cave-worktree-sweep.log}"
+# Keyed by checkout, so two clones on one machine cannot block each other.
+LOCK="/tmp/worktree-sweep-$(printf '%s' "$REPO" | shasum | cut -c1-12).lock"
+
+mkdir -p "$(dirname "$LOG")"
+
+# Rotate BEFORE the redirect below. Rotating afterwards would be a no-op that
+# looks like it worked: the shell's already-open fd follows the moved inode, so
+# every subsequent line lands in the rotated file and the "current" log stays
+# empty.
+if [[ -f "$LOG" ]] && [[ $(wc -c <"$LOG") -gt 1048576 ]]; then
+  mv "$LOG" "$LOG.1"
+  rotated=1
+fi
+
+exec >>"$LOG" 2>&1
+[[ -n "${rotated:-}" ]] && echo "[sweep] rotated previous log to $(basename "$LOG").1"
+
+# Desktop notification, macOS only and best-effort. Deliberately NOT fired on
+# the common case: a sweep that correctly retires nothing is the normal outcome,
+# and a daily "nothing happened" banner is how a notification earns itself being
+# ignored. Only a real retirement or a genuine failure interrupts anyone.
+notify() {
+  command -v osascript >/dev/null 2>&1 || return 0
+  local title="$1" msg="$2"
+  osascript -e "display notification \"${msg//\"/\\\"}\" with title \"${title//\"/\\\"}\"" \
+    >/dev/null 2>&1 || echo "[sweep] (notification failed; continuing)"
+}
+
+echo "=============================================================="
+echo "[sweep] start $(date -Iseconds)"
+
+# The lock records its owner's pid, because a bare mkdir lock is a silent-failure
+# trap: if a run is SIGKILLed, or the machine sleeps mid-sweep, the EXIT trap
+# never fires, the directory persists, and every future run exits 0 saying
+# "another sweep holds the lock" — no error, no sweep, forever. A stale lock must
+# therefore be reclaimable, and reclaiming it must be loud.
+if ! mkdir "$LOCK" 2>/dev/null; then
+  owner=$(cat "$LOCK/pid" 2>/dev/null || echo "")
+  if [[ -n "$owner" ]] && kill -0 "$owner" 2>/dev/null; then
+    echo "[sweep] a live sweep (pid $owner) holds $LOCK; exiting without action"
+    exit 0
+  fi
+  echo "[sweep] STALE lock at $LOCK (owner pid '${owner:-unknown}' is not running) — reclaiming"
+  rm -rf "$LOCK"
+  if ! mkdir "$LOCK" 2>/dev/null; then
+    echo "[sweep] ABORT: could not reclaim $LOCK"
+    notify "Worktree sweep FAILED" "Could not reclaim a stale lock; the sweep is not running."
+    exit 1
+  fi
+fi
+echo $$ >"$LOCK/pid"
+trap 'rm -rf "$LOCK" 2>/dev/null' EXIT
+
+if [[ ! -f "$PROMPT_FILE" ]]; then
+  echo "[sweep] ABORT: prompt file missing at $PROMPT_FILE"
+  exit 1
+fi
+cd "$REPO" || { echo "[sweep] ABORT: cannot cd to $REPO"; exit 1; }
+
+# A scheduler does not source a login profile.
+export PATH="$HOME/.local/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:$PATH"
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "[sweep] ABORT: claude CLI not on PATH"
+  exit 1
+fi
+
+# Filesystem-permission preflight. On macOS a scheduled job gets no access to a
+# protected directory (~/Documents and friends) unless the launching binary has
+# been granted it. Without this check the symptom is subtle: `cd` succeeds, then
+# every git call fails and the agent runs against an empty view of the
+# repository — which looks exactly like "nothing to retire".
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  echo "[sweep] ABORT: cannot read the git repository at $REPO."
+  echo "[sweep] On macOS this is usually a Full Disk Access gap: scheduled jobs"
+  echo "[sweep] get no access to protected folders. Grant it to whatever binary"
+  echo "[sweep] the scheduler launches, then rerun."
+  notify "Worktree sweep FAILED" "Cannot read the repo — the sweep is doing nothing."
+  exit 1
+fi
+
+before=$(git worktree list | wc -l | tr -d ' ')
+echo "[sweep] repo: $REPO"
+echo "[sweep] repo HEAD: $(git rev-parse --short HEAD 2>/dev/null) on $(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
+echo "[sweep] registered worktrees: $before"
+echo "[sweep] --- agent output follows ---"
+
+# Tools are scoped deliberately: no Write, no Edit. This job inspects, retires
+# worktrees, and closes beads. It has no business editing source files.
+claude -p "$(cat "$PROMPT_FILE")" \
+  --allowed-tools "Bash,Read,Grep,Glob" \
+  --output-format text
+status=$?
+
+after=$(git worktree list | wc -l | tr -d ' ')
+echo "[sweep] --- agent exited with status $status ---"
+echo "[sweep] worktrees remaining: $after"
+
+# Count the worktrees here rather than trusting the agent's summary — a
+# retirement is a filesystem fact, not a claim.
+if [[ "$status" -ne 0 ]]; then
+  notify "Worktree sweep errored" "Agent exited $status. Check the log."
+elif [[ "$after" -lt "$before" ]]; then
+  notify "Worktree sweep: $(( before - after )) retired" \
+    "$before -> $after worktrees. Log: $LOG"
+else
+  echo "[sweep] no change ($before -> $after); no notification sent"
+fi
+
+echo "[sweep] end $(date -Iseconds)"
+exit "$status"


### PR DESCRIPTION
`cave-6qzo0`.

## Why

The scheduled worktree sweep ran from a script and prompt that existed on exactly one machine and in no history. That became more consequential on 2026-08-10, when the sweep switched from hand-retirement to `beads:worktrees:apply --allow-unenforced-planes` (`cave-s03wp`): **nothing in the repository recorded that the scheduled sweeps had changed behaviour**, and the prompt carries the discipline that makes that change safe —

- the `--max-retire 3` bound on an unattended run,
- the rule that `local-acquire-failed: gate-held` is *correct behaviour*, not a reason to fall back to hand-retirement,
- and why the apply path is used at all: hand-retirement is a multi-step ritual done from memory, and on 2026-08-10 two of five hand-retired units were removed with **no archive tag**, while every one left behind the bead metadata record that then blocks that bead from holding another worktree.

Losing that file loses the reasoning, not just the shell.

## Portable, not a copy of one machine's files

- repository root derived from the script's own location — no absolute user path in either file
- `SWEEP_LOG` and `SWEEP_REPO` overridable
- lock keyed by checkout, so two clones cannot block each other
- notification is macOS-only and best-effort (`command -v osascript`), so the script runs anywhere

The scheduler entry and, on macOS, the app bundle holding the Full Disk Access grant stay **out** of the repository — they are machine-specific — but the script header and prompt now state what that wiring must provide, so it is reconstructable.

## Behaviours preserved deliberately

Both were bugs found the hard way and are worth not re-introducing:

- **log rotation happens before the redirect.** Rotating afterwards is a no-op that looks like it worked — the shell's open fd follows the moved inode, so output lands in the rotated file and the "current" log stays empty.
- **the lock records its owner pid and stale locks are reclaimed loudly.** A bare `mkdir` lock is a silent-failure trap: a SIGKILLed run leaves it behind and every later run exits 0 saying "another sweep holds the lock" — no error, no sweep, forever.
- **the filesystem preflight aborts loudly.** Without it, a permissions gap lets `cd` succeed while every git call fails, and the agent runs against an empty view of the repository — which looks exactly like "nothing to retire".

## Verification

Ran the committed copy: it derives the repo root, passes the preflight, redirects to the overridden log, and reaches the agent. `check:tests-wired` (1614 files) and `pnpm lint` both exit 0.

One property is documented rather than fixed: deriving the root from the script's location means invoking a worktree's copy sweeps the **whole repository**, since `git worktree list` there enumerates every unit. The scheduled job is pinned to the primary checkout, which is what is wanted, but running it by hand from a worktree is not scoped — noted in the script.