### PR TITLE
fix(worktree): count a pushed tag as retention before re-pushing a branch

### DIFF
--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -70,14 +70,61 @@ export function retentionTag(branch, sha) {
   return `retention/${slug || "detached"}-${String(sha).slice(0, 9)}`;
 }
 
-// Commits reachable from HEAD but from no remote-tracking ref — the same
-// "retained on a remote" test the guard and the autolock hook apply.
+// Commits reachable from HEAD but from no remote-tracking ref.
+//
+// `--remotes` is refs/remotes/*, which is remote-tracking BRANCHES only. Git
+// keeps no remote-tracking refs for tags at all, so a branch archived as a
+// pushed tag still counts as unpushed here — see remoteTagCommits below, which
+// supplies the half this cannot see.
 export function unpushedCount(worktreePath) {
   try {
     const n = Number(git(["rev-list", "--count", "HEAD", "--not", "--remotes"], worktreePath).trim());
     return Number.isFinite(n) ? n : 0;
   } catch {
     return 0; // unborn HEAD, or unreadable mid-creation — leave it alone
+  }
+}
+
+export function headSha(worktreePath) {
+  try {
+    return git(["rev-parse", "HEAD"], worktreePath).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Commit ids the remote currently advertises as tags.
+ *
+ * The guard already treats "a remote branch OR a tag pushed to a remote" as
+ * retention. This hook did not, so it re-pushed branches whose heads were
+ * already archived: on 2026-08-10 twelve merged branches were tagged, verified
+ * on the remote and deleted, and eight were re-created within minutes — every
+ * one of them a branch whose worktree still existed. The two surfaces disagreed
+ * about the same repository state, and the archive-tag retirement route in
+ * CLAUDE.md could not work while they did (cave-nw3hq).
+ *
+ * Both ref forms are collected. An annotated tag advertises the tag object at
+ * `refs/tags/x` and its commit at `refs/tags/x^{}`; a lightweight tag
+ * advertises the commit directly. Taking both means the peeled commit is always
+ * present, and the extra tag-object ids can never collide with a commit id.
+ *
+ * Returns null when the remote cannot be reached, which the caller treats as
+ * "no proof" and pushes — the safe direction. Wrongly pushing costs a redundant
+ * ref; wrongly skipping leaves commits on one machine, which is the leak this
+ * hook exists to stop.
+ */
+export function remoteTagCommits(worktreePath) {
+  try {
+    const output = git(["ls-remote", "--tags", "origin"], worktreePath, PUSH_TIMEOUT_MS);
+    const oids = new Set();
+    for (const line of output.split("\n")) {
+      const oid = line.slice(0, 40);
+      if (/^[0-9a-f]{40}$/.test(oid)) oids.add(oid);
+    }
+    return oids;
+  } catch {
+    return null;
   }
 }
 
@@ -155,7 +202,18 @@ function main() {
     return; // not a git repo, or git unavailable — nothing to do
   }
 
+  // Resolved lazily and at most once per pass: only worktrees that look at
+  // risk need it, and a pass where nothing is at risk should stay offline.
+  let tagCommits;
+  const tagRetained = (worktreePath) => {
+    if (tagCommits === undefined) tagCommits = remoteTagCommits(root);
+    if (!tagCommits || tagCommits.size === 0) return false;
+    const head = headSha(worktreePath);
+    return head !== null && tagCommits.has(head);
+  };
+
   let pushes = 0;
+  const skipped = [];
   for (const wt of worktrees) {
     if (pushes >= MAX_PUSHES_PER_PASS) break;
     if (wt.bare) continue;
@@ -165,6 +223,20 @@ function main() {
     // `main` is protected and never the thing at risk; pushing it is exactly
     // the direct-to-main move the repository forbids.
     if (branch === "main") continue;
+
+    // Already archived: the remote advertises a tag at exactly this HEAD, which
+    // is the guard's own definition of retained. Re-creating the branch here is
+    // what undid twelve deliberate archive-and-delete retirements (cave-nw3hq).
+    //
+    // Exact HEAD only. A tag that merely CONTAINS this head would also be
+    // retention, but proving it needs the tag's commit locally and therefore a
+    // fetch — too much for a hook on every tool call. That case still pushes,
+    // which costs a redundant ref rather than a lost commit.
+    if (tagRetained(wt.path)) {
+      skipped.push(branch ?? wt.path);
+      continue;
+    }
+
     pushes += 1;
     try {
       record(root, { worktree: wt.path, unpushed, ...retain(wt.path, root, branch) });
@@ -177,6 +249,18 @@ function main() {
         error: String(error?.message ?? error).slice(0, 300),
       });
     }
+  }
+
+  // One summary line, not one per worktree. A skip is a steady state — an
+  // archived branch whose worktree still exists stays skipped every pass — so
+  // logging each one individually would write a line a minute per worktree
+  // forever. The count is what tells you the rule is doing something.
+  if (skipped.length > 0) {
+    record(root, {
+      verdict: "skipped-tag-retained",
+      count: skipped.length,
+      branches: skipped.slice(0, 10),
+    });
   }
 }
 

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -7,7 +7,14 @@ import test from "node:test";
 
 const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
 
-import { parseWorktrees, retain, retentionTag, unpushedCount } from "./worktree-retention-push.mjs";
+import {
+  headSha,
+  parseWorktrees,
+  remoteTagCommits,
+  retain,
+  retentionTag,
+  unpushedCount,
+} from "./worktree-retention-push.mjs";
 
 // Fixtures must not inherit machine-level git config. A global
 // `core.hooksPath` points every repo on this machine at one hook directory,
@@ -159,6 +166,72 @@ test("retain retains a detached HEAD, which has no branch to push", () => {
 
     assert.equal(result.verdict, "pushed-tag");
     assert.equal(bare(["rev-parse", `refs/tags/${result.tag}^{commit}`], remote).trim(), sha);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("remoteTagCommits sees a pushed tag, which --remotes never can", () => {
+  // The exact shape of the cave-nw3hq incident: a merged branch is archived as
+  // a pushed tag and deleted from the remote. `git rev-list --not --remotes`
+  // still calls its commits unpushed, because remote-tracking refs exist for
+  // branches and never for tags — so the hook re-created twelve branches it had
+  // just been asked to retire.
+  const { root, work } = scaffold();
+  try {
+    git(["checkout", "-b", "fix/archived"], work);
+    commit(work, "one");
+    git(["push", "origin", "fix/archived"], work);
+    const head = headSha(work);
+
+    // Archive exactly as the retirement route does, then drop the branch.
+    git(["tag", "-a", "archive/fix-archived-2026-08-10", "-m", "archive", head], work);
+    git(["push", "origin", "archive/fix-archived-2026-08-10"], work);
+    git(["push", "origin", "--delete", "fix/archived"], work);
+    git(["fetch", "--prune", "origin"], work);
+
+    assert.ok(
+      unpushedCount(work) > 0,
+      "precondition: with the branch gone, --remotes alone calls this unpushed",
+    );
+
+    const tags = remoteTagCommits(work);
+    assert.ok(tags instanceof Set, "the remote answered");
+    assert.ok(
+      tags.has(head),
+      "the archived head is advertised as a tag, so it is retained after all",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("remoteTagCommits collects the peeled commit of an annotated tag", () => {
+  // An annotated tag advertises the TAG OBJECT at refs/tags/x and the commit at
+  // refs/tags/x^{}. Reading only the first would compare a tag-object id against
+  // a commit id and never match — the check would silently never fire.
+  const { root, work } = scaffold();
+  try {
+    commit(work, "two");
+    git(["push", "origin", "main"], work);
+    const head = headSha(work);
+    git(["tag", "-a", "annotated-example", "-m", "annotated", head], work);
+    git(["push", "origin", "annotated-example"], work);
+
+    const tags = remoteTagCommits(work);
+    assert.ok(tags.has(head), "the peeled commit is present, not just the tag object");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("remoteTagCommits returns null when the remote cannot be reached", () => {
+  // No proof means push, which is the safe direction: a redundant ref costs
+  // nothing, a skipped push leaves commits on one machine.
+  const { root, work } = scaffold();
+  try {
+    git(["remote", "set-url", "origin", path.join(root, "does-not-exist.git")], work);
+    assert.equal(remoteTagCommits(work), null);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
The retention hook decided "at risk" with `git rev-list --not --remotes`.
`--remotes` is `refs/remotes/*` — remote-tracking **branches** — and git keeps
no remote-tracking refs for tags at all. So a branch archived as a pushed tag
still looked unpushed, and the hook re-created it.

## What that cost

On 2026-08-10 it undid a deliberate curation pass. Twelve merged branches were
archived with signed tags at their exact heads, verified on the remote, then
deleted. **Eight were back within minutes**, and the hook's own log names them:

```
17:34:03 pushed-branch chore/cave-58eoq-8-path-aware-ci        829c425156
17:34:08 pushed-branch fix/cave-qshvl-recovery-approval-gate   0a2dff134a
```

Both had archive tags on the remote at exactly those SHAs. The correlation was
exact: every resurrected branch had a live worktree, every deletion that stuck
had none.

## The real problem: two definitions of one word

`worktree-guard.mjs` counts retention as *"a remote branch **or** a tag pushed
to a remote"*. This hook counted only the branch. The archive-tag retirement
route `CLAUDE.md` prescribes cannot work while the two disagree about the same
repository state — and each resurrection also spends branch-cap headroom that
curation had just reclaimed.

## The fix

One `ls-remote --tags` per pass, resolved lazily so a pass with nothing at risk
stays offline. A worktree is skipped only when the remote advertises a tag at
**exactly** its HEAD.

Two deliberate limits, both erring toward pushing:

- A tag that merely *contains* the head is also retention, but proving it needs
  the tag's commit locally and therefore a fetch — too much for a hook that runs
  on every tool call. That case still pushes.
- If the remote is unreachable there is no proof, so it pushes, exactly as today.

Wrongly pushing costs a redundant ref. Wrongly skipping leaves commits on one
machine, which is the leak this hook exists to stop.

Skips log **one summary line per pass**, not one per worktree — a skip is a
steady state, so per-worktree logging would write a line a minute, forever.

## Tests

The incident itself: archive, delete, then assert both halves — that
`unpushedCount` *still* calls it unpushed (the precondition that caused the
resurrection) and that the tag lookup does see the head.

Plus the annotated-tag peel, which is the subtle one: an annotated tag
advertises the tag object at `refs/tags/x` and the commit at `refs/tags/x^{}`,
so reading only the first would compare a tag-object id against a commit id and
never match — the check would silently never fire. And the unreachable-remote
fallback.

10 pass; 1614 files wired.

Closes cave-nw3hq.