### PR TITLE
fix(research): harden cross-platform process launches

### DIFF
--- a/scripts/daemon-connectivity-faults.test.ts
+++ b/scripts/daemon-connectivity-faults.test.ts
@@ -82,7 +82,7 @@ test("delayed readiness, partial health, crash, hang, reset, and version skew st
 
   for (const [name, health, expectedCode] of [
     ["partial", { ok: true }, "runtime_incompatible"],
-    ["version-skew", { ok: true, apiVersion: "v1", covenVersion: "1.2.2" }, "runtime_incompatible"],
+    ["version-skew", { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "1.2.2" }, "runtime_incompatible"],
   ] as const) {
     const result = await startLocalDaemon({
       restart: true,

--- a/server.mjs
+++ b/server.mjs
@@ -232,7 +232,7 @@ async function refreshTailnetPeers() {
     const { stdout } = await execFileAsync(
       process.env.COVEN_CAVE_TAILSCALE_BIN ?? "tailscale",
       ["status", "--json"],
-      { timeout: 1e4, maxBuffer: 16 * 1024 * 1024 }
+      { timeout: 1e4, maxBuffer: 16 * 1024 * 1024, windowsHide: true }
     );
     const status = JSON.parse(stdout);
     const next2 = /* @__PURE__ */ new Map();

--- a/server.ts
+++ b/server.ts
@@ -430,7 +430,7 @@ async function refreshTailnetPeers(): Promise<void> {
     const { stdout } = await execFileAsync(
       process.env.COVEN_CAVE_TAILSCALE_BIN ?? "tailscale",
       ["status", "--json"],
-      { timeout: 10_000, maxBuffer: 16 * 1024 * 1024 },
+      { timeout: 10_000, maxBuffer: 16 * 1024 * 1024, windowsHide: true },
     );
     const status = JSON.parse(stdout) as {
       Peer?: Record<string, { ID?: string; TailscaleIPs?: string[] }>;

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -67,7 +67,7 @@ fs2 = "0.4.3"
 sha2 = "0.10"
 tar = "0.4"
 zstd = "0.13"
-windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Console", "Win32_System_JobObjects", "Win32_System_Threading", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
 
 # OS-level glass for the quick-chat tray window: NSVisualEffectView vibrancy
 # behind the transparent webview on macOS (the only platform we apply it on;

--- a/src-tauri/release-runtime.test.mjs
+++ b/src-tauri/release-runtime.test.mjs
@@ -902,6 +902,45 @@ test("Windows packaged sidecar starts without a console window", async () => {
   );
 });
 
+test("Windows app-owned console children share the native no-window launcher", async () => {
+  const [helper, discovery, shellCommands] = await Promise.all([
+    readNativeHost("windows_command.rs"),
+    readNativeHost("sidecar_discovery.rs"),
+    readNativeHost("shell_open_commands.rs"),
+  ]);
+
+  assert.match(
+    helper,
+    /fn hidden_command[\s\S]*command\.creation_flags\(CREATE_NO_WINDOW\)/,
+    "the shared helper must apply CREATE_NO_WINDOW to noninteractive native children",
+  );
+  assert.match(
+    helper,
+    /fn hidden_system32_command[\s\S]*windows_system32_binary\(program\)[\s\S]*current_dir\(system32\)/,
+    "system children must use absolute System32 programs and a trusted cwd",
+  );
+  assert.equal(
+    discovery.match(/windows_command::hidden_system32_command\("where\.exe"\)/g)?.length,
+    2,
+    "Node and Coven where.exe discovery must use the hidden launcher and an absolute System32 path",
+  );
+  assert.match(
+    shellCommands,
+    /CovenFolderPicker[\s\S]*windows_command::hidden_system32_command\(\s*r"WindowsPowerShell\\v1\.0\\powershell\.exe",?\s*\)[\s\S]*"-Sta"/,
+    "the visible folder picker must suppress only PowerShell's console host and resolve it from System32",
+  );
+  assert.equal(
+    shellCommands.match(/windows_command::hidden_system32_command\("rundll32\.exe"\)/g)?.length,
+    2,
+    "both URL launchers resolve rundll32 from System32 instead of the working directory",
+  );
+  assert.doesNotMatch(
+    `${discovery}\n${shellCommands}`,
+    /(?:Command::new|hidden_command)\("(?:where|powershell|rundll32)\.exe"\)/,
+    "console-subsystem discovery, dialog, and protocol hosts cannot use cwd-searchable bare names",
+  );
+});
+
 test("Windows first launch paints progress and supports recovery while the sidecar starts", async () => {
   const [launcher, startupPage] = await Promise.all([
     readNativeHost(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -84,6 +84,8 @@ mod tauri_setup;
 mod window_geometry;
 #[cfg(all(desktop, target_os = "windows"))]
 mod windows_process_job;
+#[cfg(all(desktop, target_os = "windows"))]
+mod windows_command;
 
 #[cfg(desktop)]
 use desktop_reachability::*;

--- a/src-tauri/src/shell_open_commands.rs
+++ b/src-tauri/src/shell_open_commands.rs
@@ -10,7 +10,7 @@ fn spawn_x_oauth_browser_launcher(url: &str) -> std::io::Result<std::process::Ch
     };
     #[cfg(target_os = "windows")]
     let mut command = {
-        let mut command = std::process::Command::new(windows_system32_binary("rundll32.exe"));
+        let mut command = windows_command::hidden_system32_command("rundll32.exe");
         command.args(["url.dll,FileProtocolHandler", url]);
         command
     };
@@ -110,7 +110,7 @@ pub(super) fn shell_open(url: String) -> Result<(), String> {
         // Use the Windows URL protocol handler directly instead of routing
         // attacker-controlled URLs through `cmd.exe /c start`, where shell
         // metacharacters such as `&` can execute additional commands.
-        std::process::Command::new("rundll32.exe")
+        windows_command::hidden_system32_command("rundll32.exe")
             .args(["url.dll,FileProtocolHandler", &url])
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -140,7 +140,7 @@ pub(super) fn shell_open_path(path: String) -> Result<(), String> {
     }
     #[cfg(target_os = "windows")]
     {
-        std::process::Command::new(windows_system32_binary("explorer.exe"))
+        windows_command::hidden_command(windows_system32_binary("explorer.exe"))
             .arg(&path)
             .spawn()
             .map_err(|e| e.to_string())?;
@@ -291,10 +291,12 @@ try {
     $owner.Close()
 }
 "#;
-        let output = std::process::Command::new("powershell.exe")
-            .args(["-NoProfile", "-Sta", "-Command", script])
-            .output()
-            .map_err(|e| e.to_string())?;
+        let output = windows_command::hidden_system32_command(
+            r"WindowsPowerShell\v1.0\powershell.exe",
+        )
+        .args(["-NoProfile", "-Sta", "-Command", script])
+        .output()
+        .map_err(|e| e.to_string())?;
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
             return Err(if stderr.is_empty() {

--- a/src-tauri/src/shell_open_tests.rs
+++ b/src-tauri/src/shell_open_tests.rs
@@ -25,6 +25,14 @@ fn windows_system32_binary_uses_an_absolute_system_path() {
     let path = path.to_string_lossy();
     assert!(path.starts_with(r"C:\") || path.contains(r":\"));
     assert!(path.ends_with(r"System32\rundll32.exe") || path.ends_with("System32/rundll32.exe"));
+
+    let powershell = super::windows_system32_binary(r"WindowsPowerShell\v1.0\powershell.exe");
+    let powershell = powershell.to_string_lossy();
+    assert!(powershell.starts_with(r"C:\") || powershell.contains(r":\"));
+    assert!(
+        powershell.ends_with(r"System32\WindowsPowerShell\v1.0\powershell.exe")
+            || powershell.ends_with("System32/WindowsPowerShell/v1.0/powershell.exe")
+    );
 }
 
 #[test]

--- a/src-tauri/src/shell_open_tests.rs
+++ b/src-tauri/src/shell_open_tests.rs
@@ -21,18 +21,21 @@ fn rejects_invalid_urls() {
 
 #[test]
 fn windows_system32_binary_uses_an_absolute_system_path() {
-    let path = super::windows_system32_binary("rundll32.exe");
-    let path = path.to_string_lossy();
-    assert!(path.starts_with(r"C:\") || path.contains(r":\"));
-    assert!(path.ends_with(r"System32\rundll32.exe") || path.ends_with("System32/rundll32.exe"));
+    // This contract runs on every CI host. Normalize only for the assertion:
+    // Unix PathBuf treats the backslashes in the Windows fallback/root-relative
+    // input as literal characters, so its debug string legitimately mixes both
+    // separator styles even though Windows resolves the same value normally.
+    let windows_path = |path: std::path::PathBuf| path.to_string_lossy().replace('\\', "/");
 
-    let powershell = super::windows_system32_binary(r"WindowsPowerShell\v1.0\powershell.exe");
-    let powershell = powershell.to_string_lossy();
-    assert!(powershell.starts_with(r"C:\") || powershell.contains(r":\"));
-    assert!(
-        powershell.ends_with(r"System32\WindowsPowerShell\v1.0\powershell.exe")
-            || powershell.ends_with("System32/WindowsPowerShell/v1.0/powershell.exe")
-    );
+    let path = windows_path(super::windows_system32_binary("rundll32.exe"));
+    assert!(path.starts_with("C:/") || path.contains(":/"));
+    assert!(path.ends_with("System32/rundll32.exe"));
+
+    let powershell = windows_path(super::windows_system32_binary(
+        r"WindowsPowerShell\v1.0\powershell.exe",
+    ));
+    assert!(powershell.starts_with("C:/") || powershell.contains(":/"));
+    assert!(powershell.ends_with("System32/WindowsPowerShell/v1.0/powershell.exe"));
 }
 
 #[test]

--- a/src-tauri/src/sidecar_discovery.rs
+++ b/src-tauri/src/sidecar_discovery.rs
@@ -129,7 +129,10 @@ pub(super) fn find_node(resource_dir: &Path) -> Option<PathBuf> {
         }
 
         // Last ditch: where.exe (Windows equivalent of `which`)
-        if let Ok(out) = std::process::Command::new("where.exe").arg("node").output() {
+        if let Ok(out) = windows_command::hidden_system32_command("where.exe")
+            .arg("node")
+            .output()
+        {
             let path = String::from_utf8_lossy(&out.stdout)
                 .lines()
                 .next()
@@ -230,7 +233,7 @@ pub(super) fn find_coven() -> Option<PathBuf> {
                 return Some(c.clone());
             }
         }
-        if let Ok(out) = std::process::Command::new("where.exe")
+        if let Ok(out) = windows_command::hidden_system32_command("where.exe")
             .arg("coven")
             .output()
         {

--- a/src-tauri/src/windows_command.rs
+++ b/src-tauri/src/windows_command.rs
@@ -1,0 +1,112 @@
+use std::ffi::OsStr;
+use std::os::windows::process::CommandExt;
+use std::process::Command;
+
+/// Win32 CREATE_NO_WINDOW. Apply only to app-owned, noninteractive children;
+/// intentional PTY shells keep their own visible terminal contract.
+pub(crate) const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+pub(crate) fn hidden_command(program: impl AsRef<OsStr>) -> Command {
+    let mut command = Command::new(program);
+    command.creation_flags(CREATE_NO_WINDOW);
+    command
+}
+
+/// Launch a Windows system program from the trusted System32 directory. An
+/// absolute argv[0] prevents executable planting, while the trusted cwd keeps
+/// utilities such as where.exe from searching a project directory first.
+pub(crate) fn hidden_system32_command(program: &str) -> Command {
+    let system32 = super::windows_system32_binary("");
+    let mut command = hidden_command(super::windows_system32_binary(program));
+    command.current_dir(system32);
+    command
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::process::Stdio;
+
+    const HELPER_ENV: &str = "COVEN_CAVE_HIDDEN_COMMAND_HELPER";
+    const CREATE_NEW_CONSOLE: u32 = 0x0000_0010;
+
+    #[test]
+    fn hidden_command_probe_child() {
+        if std::env::var_os(HELPER_ENV).is_none() {
+            return;
+        }
+        let console = unsafe { windows_sys::Win32::System::Console::GetConsoleWindow() };
+        print!(
+            "console={}",
+            if console.is_null() {
+                "absent"
+            } else {
+                "present"
+            }
+        );
+        std::io::stdout().flush().expect("flush console probe");
+    }
+
+    #[test]
+    fn hidden_command_suppresses_a_console_for_native_children() {
+        let mut visible_control_command =
+            Command::new(std::env::current_exe().expect("test executable"));
+        visible_control_command.creation_flags(CREATE_NEW_CONSOLE);
+        let visible_control = visible_control_command
+            .args([
+                "--exact",
+                "windows_command::tests::hidden_command_probe_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(HELPER_ENV, "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("spawn visible console control");
+
+        assert!(
+            visible_control.status.success(),
+            "visible control failed: {visible_control:?}"
+        );
+        assert!(
+            String::from_utf8_lossy(&visible_control.stdout).contains("console=present"),
+            "console probe cannot observe an ordinary console child; hidden-result proof would be inconclusive: {visible_control:?}"
+        );
+
+        let output = hidden_command(std::env::current_exe().expect("test executable"))
+            .args([
+                "--exact",
+                "windows_command::tests::hidden_command_probe_child",
+                "--nocapture",
+                "--test-threads=1",
+            ])
+            .env(HELPER_ENV, "1")
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .expect("spawn hidden console probe");
+
+        assert!(output.status.success(), "probe failed: {output:?}");
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains("console=absent"),
+            "hidden child acquired a console: {output:?}"
+        );
+    }
+
+    #[test]
+    fn system32_children_use_absolute_programs_and_a_trusted_working_directory() {
+        let command = hidden_system32_command("where.exe");
+        assert_eq!(
+            command.get_program(),
+            super::super::windows_system32_binary("where.exe")
+        );
+        assert_eq!(
+            command.get_current_dir(),
+            Some(super::super::windows_system32_binary("").as_path())
+        );
+    }
+}

--- a/src/app/api/chat/send/chat-send-capabilities.ts
+++ b/src/app/api/chat/send/chat-send-capabilities.ts
@@ -4,7 +4,11 @@ import { createReadStream } from "node:fs";
 import { realpath, stat } from "node:fs/promises";
 import path from "node:path";
 import type { Readable, Writable } from "node:stream";
-import { covenLaunchCommand } from "@/lib/coven-bin";
+import {
+  COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+  covenLaunchCommand,
+  covenWrapperSpawnEnv,
+} from "@/lib/coven-bin";
 import {
   covenRunSupportsAddDirFlag,
   covenRunSupportsModelFlag,
@@ -194,11 +198,11 @@ export function probeHelpOutcome(
     };
     try {
       const child = spawn(/* turbopackIgnore: true */ command, args, {
+        ...openCodeProbeSpawnOptions(),
         windowsHide: true,
         env,
         cwd,
         stdio: input === undefined ? ["ignore", "pipe", "pipe"] : ["pipe", "pipe", "pipe"],
-        ...openCodeProbeSpawnOptions(),
       }) as ChildProcessByStdio<Writable, Readable, Readable>;
       if (input !== undefined) child.stdin.end(input, "utf8");
       child.stdout.on("data", (chunk) => (output += chunk.toString()));
@@ -289,10 +293,10 @@ function probeOutput(
     };
     try {
       const child = spawn(/* turbopackIgnore: true */ command, args, {
+        ...openCodeProbeSpawnOptions(),
         windowsHide: true,
         env,
         stdio: ["ignore", "pipe", "pipe"],
-        ...openCodeProbeSpawnOptions(),
       });
       let overflowed = false;
       const append = (chunk: Buffer) => {
@@ -664,11 +668,22 @@ function cachedHelpOutcome(
 
 /** The `coven run --model` capability with its probe failures intact. */
 export function covenRunModelFlagOutcome(): Promise<HelpProbeOutcome> {
-  const { command, fixedArgs } = covenLaunchCommand();
+  let launch;
+  try {
+    launch = covenLaunchCommand();
+  } catch {
+    return Promise.resolve({ ok: false, reason: COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC });
+  }
+  const { command, fixedArgs } = launch;
   return cachedHelpOutcome(
     () => modelFlagProbe,
     (probe) => { modelFlagProbe = probe; },
-    () => probeHelpOutcome(command, [...fixedArgs, "run", "--help"], covenRunSupportsModelFlag),
+    () => probeHelpOutcome(
+      command,
+      [...fixedArgs, "run", "--help"],
+      covenRunSupportsModelFlag,
+      covenWrapperSpawnEnv(harnessSpawnEnv()),
+    ),
   );
 }
 
@@ -677,20 +692,34 @@ export function covenRunSupportsModel(): Promise<boolean> {
 }
 
 export function covenRunSupportsPermission(): Promise<boolean> {
-  const { command, fixedArgs } = covenLaunchCommand();
+  let launch;
+  try {
+    launch = covenLaunchCommand();
+  } catch {
+    return Promise.resolve(false);
+  }
+  const { command, fixedArgs } = launch;
   return (permissionFlagProbe ??= probeHelp(
     command,
     [...fixedArgs, "run", "--help"],
     covenRunSupportsPermissionFlag,
+    covenWrapperSpawnEnv(harnessSpawnEnv()),
   ));
 }
 
 export function covenRunSupportsAddDir(): Promise<boolean> {
-  const { command, fixedArgs } = covenLaunchCommand();
+  let launch;
+  try {
+    launch = covenLaunchCommand();
+  } catch {
+    return Promise.resolve(false);
+  }
+  const { command, fixedArgs } = launch;
   return (addDirFlagProbe ??= probeHelp(
     command,
     [...fixedArgs, "run", "--help"],
     covenRunSupportsAddDirFlag,
+    covenWrapperSpawnEnv(harnessSpawnEnv()),
   ));
 }
 

--- a/src/app/api/chat/send/harness-routing-codex-preflight.test.ts
+++ b/src/app/api/chat/send/harness-routing-codex-preflight.test.ts
@@ -5,8 +5,8 @@ const route = await readFile(new URL("./route.ts", import.meta.url), "utf8");
 
 assert.match(
   route,
-  /const env = harnessSpawnEnv\(body\.familiarId\);[\s\S]*?const launch = covenLaunchCommand\(\);[\s\S]*?runner: "coven",[\s\S]*?launch,[\s\S]*?const codexLaunchPlan =[\s\S]*?command: localRuntimePlan\.command,[\s\S]*?fixedArgs: localRuntimePlan\.fixedArgs,[\s\S]*?env: localRuntimePlan\.env/,
-  "Codex preflight owns the exact resolved Coven plan and familiar-scoped environment",
+  /const env = covenWrapperSpawnEnv\(harnessSpawnEnv\(body\.familiarId\)\);[\s\S]*?let launch: CovenLaunchCommand;[\s\S]*?launch = covenLaunchCommand\(\);[\s\S]*?runner: "coven",[\s\S]*?launch,[\s\S]*?const codexLaunchPlan =[\s\S]*?command: localRuntimePlan\.command,[\s\S]*?fixedArgs: localRuntimePlan\.fixedArgs,[\s\S]*?env: localRuntimePlan\.env/,
+  "Codex preflight owns the exact resolved Coven plan and familiar-scoped wrapper environment",
 );
 assert.match(
   route,

--- a/src/app/api/chat/send/offline-queue-replay.integration.test.ts
+++ b/src/app/api/chat/send/offline-queue-replay.integration.test.ts
@@ -42,7 +42,7 @@ async function listenHub(port = 0): Promise<number> {
     }
     if (req.method === "GET" && req.url === "/api/v1/health") {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ apiVersion: "1", covenVersion: "test", daemon: { status: "ok" } }));
+      res.end(JSON.stringify({ apiVersion: "coven.daemon.v1", covenVersion: "test", daemon: { status: "ok" } }));
       return;
     }
     res.writeHead(404, { "content-type": "application/json" });

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -36,7 +36,12 @@ import {
   toPersistedTools,
   ToolCallTracker,
 } from "@/lib/chat-tool-events";
-import { covenLaunchCommand, type CovenLaunchCommand } from "@/lib/coven-bin";
+import {
+  COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+  covenLaunchCommand,
+  covenWrapperSpawnEnv,
+  type CovenLaunchCommand,
+} from "@/lib/coven-bin";
 import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { sweepStuckCreatedSessions } from "@/lib/server/stuck-created-sweep";
 import {
@@ -1844,7 +1849,18 @@ export async function POST(req: Request) {
       : null;
   const codexSpawnEnv =
     !sshRuntime && binding.harness === "codex" ? harnessSpawnEnv(body.familiarId) : null;
-  const codexDirectLaunch = codexSpawnEnv ? codexLaunchCommand() : null;
+  const codexDirectLaunch = codexSpawnEnv
+    ? (() => {
+        try {
+          return codexLaunchCommand();
+        } catch {
+          // A missing Windows CLI has no safe bare-name fallback. Preserve the
+          // existing Coven-backed route, whose adapter preflight reports the
+          // actionable missing-runtime diagnostic without spawning from cwd.
+          return null;
+        }
+      })()
+    : null;
   // The same passive availability contract every direct runner uses. The
   // bounded capability probe below only runs against a launch-ready plan,
   // mirroring how Copilot gates its capability probe on launch readiness.
@@ -1928,8 +1944,20 @@ export async function POST(req: Request) {
         ...(codexLaunchAvailability ? { availability: codexLaunchAvailability } : {}),
       });
     } else if (!hermesDirect) {
-      const env = harnessSpawnEnv(body.familiarId);
-      const launch = covenLaunchCommand();
+      const env = covenWrapperSpawnEnv(harnessSpawnEnv(body.familiarId));
+      let launch: CovenLaunchCommand;
+      try {
+        launch = covenLaunchCommand();
+      } catch {
+        return new Response(
+          JSON.stringify({
+            ok: false,
+            error: COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+            code: RUNTIME_AVAILABILITY_ERROR_CODES.coven_missing,
+          }),
+          { status: 409, headers: { "content-type": "application/json" } },
+        );
+      }
       localRuntimePlan = createLocalRuntimePlan({
         runner: "coven",
         launch,

--- a/src/app/api/coven/exec/route.ts
+++ b/src/app/api/coven/exec/route.ts
@@ -1,7 +1,11 @@
 import { NextResponse } from "next/server";
 import { spawn } from "node:child_process";
 import { stripAnsi } from "@/lib/ansi";
-import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
+import {
+  COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+  covenLaunchCommand,
+  covenWrapperSpawnEnv,
+} from "@/lib/coven-bin";
 import { covenCliMissingError, isMissingExecutableError } from "@/lib/coven-spawn-error";
 import {
   daemonDiagnosticContextFromRequest,
@@ -54,13 +58,20 @@ export async function POST(req: Request) {
     endpoint: { kind: "cli", classification: "allowlisted-command" },
   });
 
+  let launch;
+  try {
+    launch = covenLaunchCommand();
+  } catch {
+    return respond({ ok: false, error: COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC }, 409);
+  }
+
   return new Promise<Response>((resolve) => {
-    const { command, fixedArgs } = covenLaunchCommand();
+    const { command, fixedArgs } = launch;
     const child = spawn(command, [...fixedArgs, ...args], {
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
       env: {
-        ...covenSpawnEnv(),
+        ...covenWrapperSpawnEnv(),
         COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
         COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
         COVEN_CAVE_DIAGNOSTIC_OPERATION: operation,

--- a/src/app/api/harnesses/route.test.ts
+++ b/src/app/api/harnesses/route.test.ts
@@ -42,8 +42,8 @@ assert.match(
 );
 assert.match(
   source,
-  /if \(id === "codex"\) \{[\s\S]*?await probeCodexRuntimeAvailability\(\{[\s\S]*?launch: covenLaunchCommand\(\),[\s\S]*?env,[\s\S]*?\}\)/,
-  "Codex status uses the resolved Coven launch plan and its scoped spawn environment",
+  /if \(id === "codex"\) \{[\s\S]*?const launch = resolvedCovenLaunch\(\);[\s\S]*?if \(!launch\)[\s\S]*?await probeCodexRuntimeAvailability\(\{[\s\S]*?launch,[\s\S]*?env,[\s\S]*?\}\)/,
+  "Codex status fails closed on a missing Coven CLI and otherwise probes the exact resolved plan",
 );
 assert.match(
   source,

--- a/src/app/api/harnesses/route.ts
+++ b/src/app/api/harnesses/route.ts
@@ -10,7 +10,15 @@ import {
   type AdapterReport,
   type CovenAdapterSummary,
 } from "@/lib/harness-adapters";
-import { covenLaunchCommand, covenSpawnEnv, pickWindowsLauncher, refreshCovenSpawnEnv, type CovenLaunchCommand } from "@/lib/coven-bin";
+import {
+  COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+  covenLaunchCommand,
+  covenSpawnEnv,
+  covenWrapperSpawnEnv,
+  pickWindowsLauncher,
+  refreshCovenSpawnEnv,
+  type CovenLaunchCommand,
+} from "@/lib/coven-bin";
 import { COPILOT_NO_AUTO_UPDATE_ARG, copilotStreamSpec } from "@/lib/copilot-stream";
 import { probeCodexRuntimeAvailability } from "@/lib/codex-runtime-availability";
 import { grokBin, grokLaunchCommandForBinary } from "@/lib/grok-bin";
@@ -68,6 +76,23 @@ type AdapterAvailability = {
   spawnEnv?: NodeJS.ProcessEnv;
 };
 
+function missingCovenAvailability(component?: "coven"): RuntimeAvailabilitySummary {
+  return {
+    state: "missing",
+    code: "runtime_missing",
+    message: COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC,
+    ...(component ? { component } : {}),
+  };
+}
+
+function resolvedCovenLaunch(): CovenLaunchCommand | null {
+  try {
+    return covenLaunchCommand();
+  } catch {
+    return null;
+  }
+}
+
 // Mirrors the send route's launch dispatch: copilot/grok/hermes/opencode use
 // their direct CLI launch plans, everything else launches through `coven run`.
 // Same commands, same spawn env shape (no familiar → shared keys only), and
@@ -89,9 +114,11 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
   }
   const env = id === "opencode" ? openCodeSpawnEnv(null) : harnessSpawnEnv(null);
   if (id === "codex") {
+    const launch = resolvedCovenLaunch();
+    if (!launch) return { availability: missingCovenAvailability("coven") };
     return {
       availability: summarizeRuntimeAvailability(await probeCodexRuntimeAvailability({
-        launch: covenLaunchCommand(),
+        launch,
         env,
       })),
     };
@@ -123,7 +150,8 @@ async function adapterAvailability(id: string): Promise<AdapterAvailability> {
       hermesLaunch,
     };
   }
-  const launch = covenLaunchCommand();
+  const launch = resolvedCovenLaunch();
+  if (!launch) return { availability: missingCovenAvailability() };
   if (id === "claude") {
     // The chat route launches Claude through `coven run`, so readiness means
     // both the outer Coven command and Claude in that same scoped env exist.
@@ -239,8 +267,10 @@ function probeGrokModels(
 
 function covenSupportsAdapterList(): Promise<boolean> {
   return new Promise((resolve) => {
-    const { command, fixedArgs } = covenLaunchCommand();
-    const child = spawn(command, [...fixedArgs, "--help"], { windowsHide: true, env: covenSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    const launch = resolvedCovenLaunch();
+    if (!launch) return resolve(false);
+    const { command, fixedArgs } = launch;
+    const child = spawn(command, [...fixedArgs, "--help"], { windowsHide: true, env: covenWrapperSpawnEnv(), stdio: ["ignore", "pipe", "pipe"] });
     let out = "";
     child.stdout.on("data", (d) => (out += d.toString()));
     child.stderr.on("data", (d) => (out += d.toString()));
@@ -261,8 +291,10 @@ function covenSupportsAdapterList(): Promise<boolean> {
 
 function loadCovenAdapterSummaries(): Promise<CovenAdapterSummary[]> {
   return new Promise((resolve) => {
-    const { command, fixedArgs } = covenLaunchCommand();
-    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { windowsHide: true, env: covenSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
+    const launch = resolvedCovenLaunch();
+    if (!launch) return resolve([]);
+    const { command, fixedArgs } = launch;
+    const child = spawn(command, [...fixedArgs, "adapter", "list", "--json"], { windowsHide: true, env: covenWrapperSpawnEnv(), stdio: ["ignore", "pipe", "ignore"] });
     let out = "";
     const t = setTimeout(() => {
       child.kill("SIGTERM");

--- a/src/app/api/launch/route.ts
+++ b/src/app/api/launch/route.ts
@@ -67,6 +67,7 @@ export async function POST(req: Request) {
   return new Promise<Response>((resolve) => {
     const child = spawn("osascript", ["-e", script], {
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
     let stderr = "";
     child.stderr.on("data", (d) => (stderr += d.toString()));

--- a/src/app/api/onboarding/install/install-process.ts
+++ b/src/app/api/onboarding/install/install-process.ts
@@ -13,13 +13,13 @@ export type InstallProcessResult = {
 export function runInstallProcess(
   command: string,
   args: string[],
-  options: { shell: boolean; timeoutMs: number },
+  options: { shell: boolean; timeoutMs: number; env?: NodeJS.ProcessEnv },
 ): Promise<InstallProcessResult> {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
-      env: covenSpawnEnv(),
+      env: options.env ?? covenSpawnEnv(),
       shell: options.shell,
     });
     let output = "";

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -12,8 +12,10 @@ import {
 } from "@/lib/server/global-npm-install-lane";
 import {
   covenBin,
+  covenLaunchCommand,
   caveToolSpawnEnv,
   covenSpawnEnv,
+  covenWrapperSpawnEnv,
   pickWindowsLauncher,
   refreshCovenBin,
   refreshCovenSpawnEnv,
@@ -255,8 +257,15 @@ async function spawnPlanFor(
 > {
   if (target.kind === "npm") {
     if (targetName === "coven-cli") {
-      const detected = covenBin();
-      if (path.isAbsolute(detected)) {
+      let detected: string | null = null;
+      try {
+        detected = covenBin();
+      } catch {
+        // A missing Windows CLI is exactly what this installer can repair.
+        // Continue onto Cave's reviewed managed npm toolchain; never replace
+        // the miss with a bare `coven`/`coven.exe` process lookup.
+      }
+      if (detected && path.isAbsolute(detected)) {
         const npm = await npmForDetectedCoven(detected);
         if (!npm) return { npmMissing: true };
         const launch = npmLaunchCommandForPath(npm.npmPath);
@@ -450,9 +459,14 @@ function daemonLifecycleDependencies(job: InstallJob): DaemonUpdateDependencies 
       };
     },
     stop: async (): Promise<DaemonCommandResult> => {
-      const stop = await runInstallProcess(covenBin(), ["daemon", "stop"], {
-        shell: process.platform === "win32",
+      const { command, fixedArgs, unresolvedWindowsShim } = covenLaunchCommand();
+      if (unresolvedWindowsShim) {
+        return { ok: false, detail: "Cave could not safely resolve the Coven Windows command shim." };
+      }
+      const stop = await runInstallProcess(command, [...fixedArgs, "daemon", "stop"], {
+        shell: false,
         timeoutMs: 8_000,
+        env: covenWrapperSpawnEnv(),
       });
       return { ok: stop.code === 0, detail: commandResultDetail(stop) };
     },

--- a/src/app/api/onboarding/status/route.test.ts
+++ b/src/app/api/onboarding/status/route.test.ts
@@ -135,6 +135,11 @@ assert.match(source, /onboardingStatusPayload\(steps, openCovenTools\)/);
 assert.doesNotMatch(source, /Install the Coven CLI from OpenCoven\/coven/);
 assert.match(
   source,
+  /process\.platform === "win32" && binary\.toLowerCase\(\) === "coven"[\s\S]{0,180}covenBinaryFromEnvironment\(env\)/,
+  "Windows onboarding resolves Coven from explicit absolute PATH entries without cwd-searching where.exe",
+);
+assert.match(
+  source,
   /async function checkGit\(\s*env: NodeJS\.ProcessEnv,\s*deadline: number,\s*discoveryState: EnvironmentDiscoveryState,\s*\): Promise<Step>/,
   "preflight checks for git within the request-scoped environment and deadline",
 );

--- a/src/app/api/onboarding/status/route.ts
+++ b/src/app/api/onboarding/status/route.ts
@@ -8,8 +8,10 @@ import { callDaemon } from "@/lib/coven-daemon";
 import { loadConfig } from "@/lib/cave-config";
 import { caveHome } from "@/lib/coven-paths";
 import {
+  covenBinaryFromEnvironment,
   covenLaunchCommandForBinary,
   covenSpawnEnv,
+  covenWrapperSpawnEnv,
   pickWindowsLauncher,
 } from "@/lib/coven-bin";
 import {
@@ -142,6 +144,14 @@ async function commandPath(
   deadline: number,
   discoveryState: EnvironmentDiscoveryState,
 ): Promise<ProbeResult<string>> {
+  if (process.platform === "win32" && binary.toLowerCase() === "coven") {
+    const found = covenBinaryFromEnvironment(env);
+    return found
+      ? { state: "ready", value: found }
+      : discoveryState === "ready"
+        ? { state: "absent", value: null }
+        : { state: "unavailable", value: null };
+  }
   const command = process.platform === "win32" ? "where" : "which";
   const result = await withinDeadline(async (signal) => {
     try {
@@ -259,12 +269,13 @@ async function loadCovenAdapterSummaries(
     const { command, fixedArgs, unresolvedWindowsShim } =
       covenLaunchCommandForBinary(pathProbe.value);
     if (unresolvedWindowsShim) throw new Error("unresolved Coven launcher");
+    const wrapperEnv = covenWrapperSpawnEnv(env);
     const { stdout: helpText } = await execFileAsync(
       command,
       [...fixedArgs, "--help"],
       {
         windowsHide: true,
-        env,
+        env: wrapperEnv,
         signal,
         timeout: remainingTimeout(1500, deadline),
       },
@@ -278,7 +289,7 @@ async function loadCovenAdapterSummaries(
       [...fixedArgs, "adapter", "list", "--json"],
       {
         windowsHide: true,
-        env,
+        env: wrapperEnv,
         signal,
         timeout: remainingTimeout(3000, deadline),
       },

--- a/src/app/api/sessions/prune/route.ts
+++ b/src/app/api/sessions/prune/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { sacrificeSessionLocal } from "@/lib/cave-config";
-import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenWrapperSpawnEnv } from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
 import { invalidateSessionsListCache } from "@/lib/server/sessions-list-cache";
 import { isValidSessionId } from "@/lib/server/session-id";
@@ -104,7 +104,7 @@ export async function POST(req: Request) {
       const { command, fixedArgs } = covenLaunchCommand();
       await execFileAsync(command, [...fixedArgs, "sacrifice", s.id, "--yes"], {
         windowsHide: true,
-        env: covenSpawnEnv(),
+        env: covenWrapperSpawnEnv(),
         timeout: SACRIFICE_TIMEOUT_MS,
       });
       pruned++;

--- a/src/lib/child-spawn-window.test.ts
+++ b/src/lib/child-spawn-window.test.ts
@@ -28,13 +28,19 @@ import assert from "node:assert/strict";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import ts from "typescript";
 
 const SRC_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const REPO_ROOT = path.resolve(SRC_ROOT, "..");
 
-// `exec`/`execFile`/`spawn` and their Sync/Async (promisified) aliases. The
-// lookbehind keeps `RegExp.prototype.exec` — always called as `re.exec(` — out
-// of the results.
-const CHILD_PROCESS_CALL = /(?<![.\w$])(spawn|exec|execFile)(?:Sync|Async)?\s*\(/g;
+const CHILD_PROCESS_EXPORTS = new Set([
+  "spawn",
+  "spawnSync",
+  "exec",
+  "execSync",
+  "execFile",
+  "execFileSync",
+]);
 
 /**
  * Call sites that forward an options object they do not own, so the flag is
@@ -45,10 +51,6 @@ const FORWARDS_CALLER_OPTIONS = new Map([
   [
     "lib/opencoven-tools-resolve.ts:30",
     "default NpmPrefixExecFile impl; the type requires windowsHide: true from callers",
-  ],
-  [
-    "lib/opencoven-tools-status.ts:319",
-    "default execLatestVersion impl; the type requires windowsHide: true from callers",
   ],
   [
     "lib/server/research-video-renderer.ts:186",
@@ -66,104 +68,390 @@ function sourceFiles(dir: string): string[] {
   return found;
 }
 
+function referencesChildProcessModule(raw: string): boolean {
+  return /(?:from\s+|import\s*\()\s*["']node:child_process["']/.test(raw);
+}
+
+type ChildProcessCall = { start: number; text: string; hasWindowsHide: boolean };
+
 /**
- * Replace comment and string/template bodies with spaces. Byte offsets survive,
- * so line numbers stay accurate while prose mentioning `spawn(` cannot match.
+ * Find child-process calls by symbol provenance rather than callee spelling.
+ * This follows imported functions through injected/defaulted aliases such as
+ * `spawnImpl = spawn`, wrapper variables, promisify(), and Reflect.apply().
  */
-function blankNonCode(source: string): string {
-  const out = source.split("");
-  const blank = (from: number, to: number) => {
-    for (let k = from; k < to && k < out.length; k += 1) {
-      if (out[k] !== "\n") out[k] = " ";
-    }
+function childProcessCalls(raw: string, fileName = "fixture.ts"): ChildProcessCall[] {
+  const absoluteFileName = path.resolve(fileName);
+  const source = ts.createSourceFile(
+    absoluteFileName,
+    raw,
+    ts.ScriptTarget.Latest,
+    true,
+    fileName.endsWith("x")
+      ? ts.ScriptKind.TSX
+      : fileName.endsWith(".mjs") || fileName.endsWith(".js")
+        ? ts.ScriptKind.JS
+        : ts.ScriptKind.TS,
+  );
+  // The checker binds every identifier to its lexical declaration even when
+  // imports themselves are not resolved. That distinction is load-bearing:
+  // an inner unsafe `opts` or `spawn` must never inherit safety/provenance from
+  // an unrelated outer declaration with the same text.
+  const defaultHost = ts.createCompilerHost({ noResolve: true, noLib: true });
+  const canonical = (candidate: string) => path.resolve(candidate);
+  const host: ts.CompilerHost = {
+    ...defaultHost,
+    fileExists: (candidate) => canonical(candidate) === absoluteFileName
+      || defaultHost.fileExists(candidate),
+    readFile: (candidate) => canonical(candidate) === absoluteFileName
+      ? raw
+      : defaultHost.readFile(candidate),
+    getSourceFile: (candidate, languageVersion) => canonical(candidate) === absoluteFileName
+      ? source
+      : defaultHost.getSourceFile(candidate, languageVersion),
   };
-  let i = 0;
-  while (i < source.length) {
-    const pair = source.slice(i, i + 2);
-    if (pair === "//") {
-      const end = source.indexOf("\n", i);
-      const stop = end === -1 ? source.length : end;
-      blank(i, stop);
-      i = stop;
-    } else if (pair === "/*") {
-      const end = source.indexOf("*/", i + 2);
-      const stop = end === -1 ? source.length : end + 2;
-      blank(i, stop);
-      i = stop;
-    } else if (source[i] === '"' || source[i] === "'" || source[i] === "`") {
-      const quote = source[i];
-      let k = i + 1;
-      while (k < source.length) {
-        if (source[k] === "\\") k += 2;
-        else if (source[k] === quote) break;
-        else k += 1;
+  const program = ts.createProgram(
+    [absoluteFileName],
+    {
+      noResolve: true,
+      noLib: true,
+      allowJs: true,
+      checkJs: false,
+      target: ts.ScriptTarget.Latest,
+    },
+    host,
+  );
+  const checker = program.getTypeChecker();
+  const boundSource = program.getSourceFile(absoluteFileName) ?? source;
+  const launchers = new Set<ts.Symbol>();
+  const launcherNamespaces = new Set<ts.Symbol>();
+  const initializers = new Map<ts.Symbol, ts.Expression>();
+
+  const symbolAt = (identifier: ts.Identifier): ts.Symbol | undefined =>
+    checker.getSymbolAtLocation(identifier);
+
+  for (const statement of boundSource.statements) {
+    if (!ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || statement.moduleSpecifier.text !== "node:child_process") continue;
+    const bindings = statement.importClause?.namedBindings;
+    const defaultSymbol = statement.importClause?.name
+      ? symbolAt(statement.importClause.name)
+      : undefined;
+    if (defaultSymbol) launcherNamespaces.add(defaultSymbol);
+    if (bindings && ts.isNamespaceImport(bindings)) {
+      const symbol = symbolAt(bindings.name);
+      if (symbol) launcherNamespaces.add(symbol);
+    } else if (bindings && ts.isNamedImports(bindings)) {
+      for (const specifier of bindings.elements) {
+        const imported = specifier.propertyName?.text ?? specifier.name.text;
+        const symbol = symbolAt(specifier.name);
+        if (CHILD_PROCESS_EXPORTS.has(imported) && symbol) launchers.add(symbol);
       }
-      blank(i + 1, k);
-      i = k + 1;
-    } else i += 1;
-  }
-  return out.join("");
-}
-
-function matchingParen(code: string, open: number): number {
-  let depth = 0;
-  for (let i = open; i < code.length; i += 1) {
-    if (code[i] === "(") depth += 1;
-    else if (code[i] === ")") {
-      depth -= 1;
-      if (depth === 0) return i;
     }
   }
-  return -1;
-}
 
-/** `const <name> = { … }` / `const <name> = { … } as const` body, if any. */
-function objectLiteralNamed(code: string, name: string): string | null {
-  const declaration = new RegExp(`(?<![.\\w$])${name}\\s*(?::[^=]*)?=\\s*\\{`).exec(code);
-  if (!declaration) return null;
-  const open = code.indexOf("{", declaration.index);
-  let depth = 0;
-  for (let i = open; i < code.length; i += 1) {
-    if (code[i] === "{") depth += 1;
-    else if (code[i] === "}") {
-      depth -= 1;
-      if (depth === 0) return code.slice(open, i + 1);
+  const collectInitializers = (node: ts.Node) => {
+    if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+      const symbol = symbolAt(node.name);
+      if (symbol) initializers.set(symbol, node.initializer);
     }
+    node.forEachChild(collectInitializers);
+  };
+  boundSource.forEachChild(collectInitializers);
+
+  const unwrapAlias = (expression: ts.Expression): ts.Expression => {
+    if (ts.isParenthesizedExpression(expression)
+      || ts.isAsExpression(expression)
+      || ts.isTypeAssertionExpression(expression)
+      || ts.isSatisfiesExpression(expression)) {
+      return unwrapAlias(expression.expression);
+    }
+    return expression;
+  };
+
+  const aliasesNamespace = (expression: ts.Expression | undefined): boolean => {
+    if (!expression) return false;
+    const unwrapped = unwrapAlias(expression);
+    if (ts.isIdentifier(unwrapped)) {
+      const symbol = symbolAt(unwrapped);
+      return !!symbol && launcherNamespaces.has(symbol);
+    }
+    if (ts.isBinaryExpression(unwrapped)
+      && (unwrapped.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+        || unwrapped.operatorToken.kind === ts.SyntaxKind.BarBarToken)) {
+      return aliasesNamespace(unwrapped.left) || aliasesNamespace(unwrapped.right);
+    }
+    if (ts.isConditionalExpression(unwrapped)) {
+      return aliasesNamespace(unwrapped.whenTrue) || aliasesNamespace(unwrapped.whenFalse);
+    }
+    return false;
+  };
+
+  const namespaceExport = (expression: ts.Expression): string | null => {
+    const unwrapped = unwrapAlias(expression);
+    if (ts.isPropertyAccessExpression(unwrapped)) {
+      const owner = unwrapAlias(unwrapped.expression);
+      const ownerSymbol = ts.isIdentifier(owner) ? symbolAt(owner) : undefined;
+      return ownerSymbol && launcherNamespaces.has(ownerSymbol) ? unwrapped.name.text : null;
+    }
+    if (ts.isElementAccessExpression(unwrapped) && ts.isStringLiteral(unwrapped.argumentExpression)) {
+      const owner = unwrapAlias(unwrapped.expression);
+      const ownerSymbol = ts.isIdentifier(owner) ? symbolAt(owner) : undefined;
+      return ownerSymbol && launcherNamespaces.has(ownerSymbol)
+        ? unwrapped.argumentExpression.text
+        : null;
+    }
+    return null;
+  };
+
+  const calleeReferencesLauncher = (expression: ts.Expression): boolean => {
+    const unwrapped = unwrapAlias(expression);
+    if (ts.isIdentifier(unwrapped)) {
+      const symbol = symbolAt(unwrapped);
+      return !!symbol && launchers.has(symbol);
+    }
+    const exported = namespaceExport(unwrapped);
+    if (exported) return CHILD_PROCESS_EXPORTS.has(exported);
+    if (ts.isPropertyAccessExpression(unwrapped) || ts.isElementAccessExpression(unwrapped)) {
+      const name = ts.isPropertyAccessExpression(unwrapped)
+        ? unwrapped.name
+        : unwrapped.argumentExpression;
+      const symbol = name && ts.isIdentifier(name) ? symbolAt(name) : undefined;
+      return !!symbol && launchers.has(symbol);
+    }
+    if (ts.isBinaryExpression(unwrapped)
+      && (unwrapped.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+        || unwrapped.operatorToken.kind === ts.SyntaxKind.BarBarToken)) {
+      return calleeReferencesLauncher(unwrapped.left) || calleeReferencesLauncher(unwrapped.right);
+    }
+    if (ts.isConditionalExpression(unwrapped)) {
+      return calleeReferencesLauncher(unwrapped.whenTrue)
+        || calleeReferencesLauncher(unwrapped.whenFalse);
+    }
+    return false;
+  };
+
+  const isLauncherCall = (expression: ts.Expression): boolean => {
+    const unwrapped = unwrapAlias(expression);
+    if (!ts.isCallExpression(unwrapped)) return false;
+    if (calleeReferencesLauncher(unwrapped.expression)) return true;
+    return ts.isPropertyAccessExpression(unwrapped.expression)
+      && ts.isIdentifier(unwrapped.expression.expression)
+      && unwrapped.expression.expression.text === "Reflect"
+      && unwrapped.expression.name.text === "apply"
+      && !!unwrapped.arguments[0]
+      && calleeReferencesLauncher(unwrapped.arguments[0]);
+  };
+
+  const aliasesLauncher = (expression: ts.Expression | undefined): boolean => {
+    if (!expression) return false;
+    const unwrapped = unwrapAlias(expression);
+    if (ts.isIdentifier(unwrapped)) {
+      const symbol = symbolAt(unwrapped);
+      return !!symbol && launchers.has(symbol);
+    }
+    if (ts.isBinaryExpression(unwrapped)
+      && (unwrapped.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken
+        || unwrapped.operatorToken.kind === ts.SyntaxKind.BarBarToken)) {
+      return aliasesLauncher(unwrapped.left) || aliasesLauncher(unwrapped.right);
+    }
+    if (ts.isConditionalExpression(unwrapped)) {
+      return aliasesLauncher(unwrapped.whenTrue) || aliasesLauncher(unwrapped.whenFalse);
+    }
+    if (ts.isCallExpression(unwrapped)
+      && ts.isIdentifier(unwrapped.expression)
+      && unwrapped.expression.text === "promisify") {
+      return aliasesLauncher(unwrapped.arguments[0]);
+    }
+    if (ts.isArrowFunction(unwrapped)) {
+      return ts.isBlock(unwrapped.body)
+        ? unwrapped.body.statements.length === 1
+          && ts.isReturnStatement(unwrapped.body.statements[0])
+          && !!unwrapped.body.statements[0].expression
+          && isLauncherCall(unwrapped.body.statements[0].expression)
+        : isLauncherCall(unwrapped.body);
+    }
+    return false;
+  };
+
+  const typeReferencesLauncher = (
+    type: ts.TypeNode | undefined,
+    resolving = new Set<ts.Symbol>(),
+  ): boolean => {
+    if (!type) return false;
+    if (ts.isTypeQueryNode(type)) {
+      const tail = ts.isIdentifier(type.exprName) ? type.exprName : type.exprName.right;
+      const symbol = symbolAt(tail);
+      if (symbol && launchers.has(symbol)) return true;
+      if (ts.isQualifiedName(type.exprName)) {
+        const owner = type.exprName.left;
+        if (ts.isIdentifier(owner)) {
+          const ownerSymbol = symbolAt(owner);
+          if (
+            ownerSymbol
+            && launcherNamespaces.has(ownerSymbol)
+            && CHILD_PROCESS_EXPORTS.has(type.exprName.right.text)
+          ) return true;
+        }
+      }
+    }
+    if (ts.isImportTypeNode(type)
+      && ts.isLiteralTypeNode(type.argument)
+      && ts.isStringLiteral(type.argument.literal)
+      && type.argument.literal.text === "node:child_process"
+      && type.qualifier
+      && CHILD_PROCESS_EXPORTS.has(
+        ts.isIdentifier(type.qualifier) ? type.qualifier.text : type.qualifier.right.text,
+      )) return true;
+    if (ts.isTypeReferenceNode(type)) {
+      const tail = ts.isIdentifier(type.typeName) ? type.typeName : type.typeName.right;
+      const symbol = symbolAt(tail);
+      if (symbol && !resolving.has(symbol)) {
+        const next = new Set(resolving);
+        next.add(symbol);
+        if (symbol.declarations?.some((declaration) =>
+          ts.isTypeAliasDeclaration(declaration)
+          && typeReferencesLauncher(declaration.type, next))) return true;
+      }
+    }
+    let found = false;
+    type.forEachChild((child) => {
+      if (!found && ts.isTypeNode(child) && typeReferencesLauncher(child, resolving)) found = true;
+    });
+    return found;
+  };
+
+  // Alias discovery is a small fixed point because wrappers can be chained.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    const visitAliases = (node: ts.Node) => {
+      if ((ts.isVariableDeclaration(node)
+          || ts.isParameter(node)
+          || ts.isBindingElement(node)
+          || ts.isPropertySignature(node)
+          || ts.isPropertyDeclaration(node))
+        && ts.isIdentifier(node.name)) {
+        const symbol = symbolAt(node.name);
+        const initializer = "initializer" in node ? node.initializer : undefined;
+        if (
+          symbol
+          && !launchers.has(symbol)
+          && (aliasesLauncher(initializer) || typeReferencesLauncher(node.type))
+        ) {
+          launchers.add(symbol);
+          changed = true;
+        }
+        if (symbol && !launcherNamespaces.has(symbol) && aliasesNamespace(initializer)) {
+          launcherNamespaces.add(symbol);
+          changed = true;
+        }
+      }
+      node.forEachChild(visitAliases);
+    };
+    boundSource.forEachChild(visitAliases);
   }
-  return null;
+
+  type WindowsHideValue = "true" | "false" | "absent" | "unknown";
+  const windowsHideValue = (
+    expression: ts.Expression,
+    resolving = new Set<ts.Symbol>(),
+  ): WindowsHideValue => {
+    const unwrapped = unwrapAlias(expression);
+    if (ts.isIdentifier(unwrapped)) {
+      const symbol = symbolAt(unwrapped);
+      if (!symbol || resolving.has(symbol)) return "unknown";
+      const initializer = initializers.get(symbol);
+      if (!initializer) return "unknown";
+      const next = new Set(resolving);
+      next.add(symbol);
+      return windowsHideValue(initializer, next);
+    }
+    if (!ts.isObjectLiteralExpression(unwrapped)) return "unknown";
+    let value: WindowsHideValue = "absent";
+    for (const property of unwrapped.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        const spread = windowsHideValue(property.expression, resolving);
+        // An unresolved trailing spread could overwrite an earlier safe flag,
+        // so ambiguity fails closed instead of assuming the property is absent.
+        if (spread === "unknown") value = "unknown";
+        else if (spread !== "absent") value = spread;
+        continue;
+      }
+      if (!ts.isPropertyAssignment(property)) continue;
+      const name = ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)
+        ? property.name.text
+        : null;
+      if (name !== "windowsHide") continue;
+      if (property.initializer.kind === ts.SyntaxKind.TrueKeyword) value = "true";
+      else if (property.initializer.kind === ts.SyntaxKind.FalseKeyword) value = "false";
+      else return "unknown";
+    }
+    return value;
+  };
+
+  const calls: ChildProcessCall[] = [];
+  const visitCalls = (node: ts.Node) => {
+    if (ts.isCallExpression(node)) {
+      const direct = calleeReferencesLauncher(node.expression);
+      const reflected = ts.isPropertyAccessExpression(node.expression)
+        && ts.isIdentifier(node.expression.expression)
+        && node.expression.expression.text === "Reflect"
+        && node.expression.name.text === "apply"
+        && !!node.arguments[0]
+        && calleeReferencesLauncher(node.arguments[0]);
+      if (direct || reflected) {
+        const effectiveArguments = reflected
+          ? ts.isArrayLiteralExpression(node.arguments[2])
+            ? node.arguments[2].elements.filter(
+              (element): element is ts.Expression => !ts.isOmittedExpression(element),
+            )
+            : null
+          : [...node.arguments];
+        calls.push({
+          start: node.getStart(source),
+          text: node.getText(boundSource),
+          // argv arrays and prompt strings cannot satisfy this: only a real
+          // top-level object argument (or a statically resolved named/spread
+          // object) with the boolean literal true is accepted.
+          // Reflect's second argument is `thisArg`, never spawn options. If
+          // its argv is not a literal array, fail closed instead of letting a
+          // `{ windowsHide: true }` thisArg satisfy the guard accidentally.
+          hasWindowsHide: effectiveArguments?.slice(1).some((argument) =>
+            windowsHideValue(argument) === "true") ?? false,
+        });
+      }
+    }
+    node.forEachChild(visitCalls);
+  };
+  boundSource.forEachChild(visitCalls);
+  return calls;
 }
 
+const productionFiles = [
+  ...sourceFiles(SRC_ROOT).map((file) => ({
+    file,
+    relative: path.relative(SRC_ROOT, file).replace(/\\/g, "/"),
+  })),
+  { file: path.join(REPO_ROOT, "server.ts"), relative: "server.ts" },
+  { file: path.join(REPO_ROOT, "server.mjs"), relative: "server.mjs" },
+];
 const offenders: string[] = [];
 const unusedWaivers = new Set(FORWARDS_CALLER_OPTIONS.keys());
 
-for (const file of sourceFiles(SRC_ROOT)) {
+for (const { file, relative } of productionFiles) {
   const raw = readFileSync(file, "utf8");
   // Only files that actually import child_process launch anything. Without
   // this, unrelated local helpers named `spawn` (the canvas particle emitter in
   // `scry-glitch.tsx`, for one) would be flagged forever.
-  if (!/from\s+["']node:child_process["']/.test(raw)) continue;
+  if (!referencesChildProcessModule(raw)) continue;
 
-  const code = blankNonCode(raw);
-  const relative = path.relative(SRC_ROOT, file).replace(/\\/g, "/");
-  CHILD_PROCESS_CALL.lastIndex = 0;
-  let match: RegExpExecArray | null;
-  while ((match = CHILD_PROCESS_CALL.exec(code)) !== null) {
-    const open = match.index + match[0].length - 1;
-    const close = matchingParen(code, open);
-    if (close === -1) continue;
-    const call = code.slice(open, close + 1);
-    const line = raw.slice(0, match.index).split("\n").length;
+  for (const match of childProcessCalls(raw, file)) {
+    const call = match.text;
+    const line = raw.slice(0, match.start).split("\n").length;
     const site = `${relative}:${line}`;
 
-    if (/windowsHide/.test(call)) continue;
-
-    // The options object may be spread in (`{ ...spawnOptions, … }`) or passed
-    // by name. Resolve one level: a same-file object literal carrying the flag
-    // satisfies the guard.
-    const referenced = Array.from(call.matchAll(/(?:\.\.\.|,\s*)([A-Za-z_$][\w$]*)\s*[,)]/g))
-      .map((reference) => reference[1])
-      .some((name) => /windowsHide/.test(objectLiteralNamed(code, name) ?? ""));
-    if (referenced) continue;
+    if (match.hasWindowsHide) continue;
 
     if (FORWARDS_CALLER_OPTIONS.has(site)) {
       unusedWaivers.delete(site);
@@ -188,8 +476,236 @@ assert.deepEqual(
 // The scanner must actually be looking at something; an empty sweep (a moved
 // source root, a broken regex) would pass the assertions above vacuously.
 assert.ok(
-  sourceFiles(SRC_ROOT).some((file) =>
-    /from\s+["']node:child_process["']/.test(readFileSync(file, "utf8")),
+  productionFiles.some(({ file }) =>
+    referencesChildProcessModule(readFileSync(file, "utf8")),
   ),
-  "no child_process importers found under src/ — the guard is scanning the wrong tree",
+  "no child_process importers found in production sources — the guard is scanning the wrong tree",
+);
+
+const injectedAliasFixture = [
+  'import { spawn } from "node:child_process";',
+  "function launch(spawnImpl: typeof spawn) {",
+  '  return spawnImpl("codex", [], { stdio: "ignore" });',
+  "}",
+].join("\n");
+assert.equal(
+  childProcessCalls(injectedAliasFixture).length,
+  1,
+  "the guard must follow injected aliases instead of recognizing only identifiers literally named spawn",
+);
+
+const reflectedAliasFixture = [
+  'import { spawn as childSpawn } from "node:child_process";',
+  "const spawnImpl = childSpawn;",
+  'Reflect.apply(spawnImpl, undefined, ["codex", [], { windowsHide: true }]);',
+].join("\n");
+const reflectedCalls = childProcessCalls(reflectedAliasFixture);
+assert.equal(reflectedCalls.length, 1, "the guard must inspect Reflect.apply launch aliases");
+assert.equal(
+  reflectedCalls[0].hasWindowsHide,
+  true,
+  "a reflected alias with windowsHide: true satisfies the guard",
+);
+
+const dynamicReflectedArgsFixture = [
+  'import { spawn } from "node:child_process";',
+  'const args = ["codex", [], { windowsHide: true }];',
+  'Reflect.apply(spawn, { windowsHide: true }, args);',
+].join("\n");
+assert.equal(
+  childProcessCalls(dynamicReflectedArgsFixture)[0]?.hasWindowsHide,
+  false,
+  "a dynamic Reflect argv fails closed and its thisArg cannot impersonate spawn options",
+);
+
+const resolvedSpreadFixture = [
+  'import { spawn } from "node:child_process";',
+  "const spawnImpl = spawn;",
+  "const hidden = { windowsHide: true };",
+  'spawnImpl("codex", [], { ...hidden, stdio: "ignore" });',
+].join("\n");
+assert.equal(
+  childProcessCalls(resolvedSpreadFixture)[0].hasWindowsHide,
+  true,
+  "a statically resolved options spread preserves its literal true contract",
+);
+
+for (const bait of [
+  'spawnImpl("codex", [], { env: { NOTE: "windowsHide: true" } });',
+  'spawnImpl("codex", [], { /* windowsHide: true */ stdio: "ignore" });',
+  'spawnImpl("codex", [], { windowsHide: false });',
+  'spawnImpl("codex", [], { windowsHide: true, ...unknownOptions });',
+  'spawnImpl("codex", [], { windowsHide: true, windowsHide: false });',
+]) {
+  const fixture = [
+    'import { spawn } from "node:child_process";',
+    "const spawnImpl = spawn; const unknownOptions = getOptions();",
+    bait,
+  ].join("\n");
+  assert.equal(
+    childProcessCalls(fixture)[0].hasWindowsHide,
+    false,
+    "string, comment, and false-value bait cannot satisfy the AST-semantic guard",
+  );
+}
+
+const unsafeShadowedOptionsFixture = [
+  'import { spawn } from "node:child_process";',
+  "const opts = { windowsHide: true };",
+  "function launch() {",
+  '  const opts = { stdio: "ignore" };',
+  '  return spawn("codex", [], opts);',
+  "}",
+].join("\n");
+assert.equal(
+  childProcessCalls(unsafeShadowedOptionsFixture)[0].hasWindowsHide,
+  false,
+  "an outer safe options object cannot mask an unsafe shadowed binding",
+);
+
+const safeShadowedOptionsFixture = [
+  'import { spawn } from "node:child_process";',
+  'const opts = { stdio: "ignore" };',
+  "function launch() {",
+  "  const opts = { windowsHide: true };",
+  '  return spawn("codex", [], opts);',
+  "}",
+].join("\n");
+assert.equal(
+  childProcessCalls(safeShadowedOptionsFixture)[0].hasWindowsHide,
+  true,
+  "the lexical options binding at the call site can satisfy the guard",
+);
+
+const shadowedLauncherFixture = [
+  'import { spawn } from "node:child_process";',
+  "function unrelated(spawn: (name: string) => void) {",
+  '  spawn("canvas-particle");',
+  "}",
+  'spawn("codex", [], { windowsHide: true });',
+].join("\n");
+assert.equal(
+  childProcessCalls(shadowedLauncherFixture).length,
+  1,
+  "an unrelated shadowed function named spawn is not a child-process launcher",
+);
+
+for (const [label, callee] of [
+  ["nullish fallback", "(dependencies.spawnImpl ?? spawn)"],
+  ["boolean fallback", "(dependencies.spawnImpl || spawn)"],
+  ["conditional selection", "(dependencies.useInjected ? dependencies.spawnImpl : spawn)"],
+] as const) {
+  const unsafe = [
+    'import { spawn } from "node:child_process";',
+    "function launch(dependencies: { spawnImpl?: typeof spawn; useInjected?: boolean }) {",
+    `  return ${callee}("codex", [], { stdio: "ignore" });`,
+    "}",
+  ].join("\n");
+  const safe = unsafe.replace(
+    '{ stdio: "ignore" }',
+    '{ stdio: "ignore", windowsHide: true }',
+  );
+  assert.equal(childProcessCalls(unsafe)[0]?.hasWindowsHide, false, `${label} is audited when unsafe`);
+  assert.equal(childProcessCalls(safe)[0]?.hasWindowsHide, true, `${label} accepts the explicit safe option`);
+}
+
+const namespaceFixture = [
+  'import * as childProcess from "node:child_process";',
+  'childProcess.spawn("codex", [], { windowsHide: true });',
+  'childProcess["execFile"]("codex", [], { stdio: "ignore" });',
+].join("\n");
+assert.deepEqual(
+  childProcessCalls(namespaceFixture).map((call) => call.hasWindowsHide),
+  [true, false],
+  "namespace imports retain per-call windowsHide enforcement",
+);
+
+const defaultNamespaceFixture = [
+  'import childProcess from "node:child_process";',
+  "const processLauncher = childProcess;",
+  'processLauncher.spawn("codex", [], { windowsHide: true });',
+].join("\n");
+assert.equal(
+  childProcessCalls(defaultNamespaceFixture)[0]?.hasWindowsHide,
+  true,
+  "default/namespace aliases are audited rather than treated as unrelated objects",
+);
+
+const typeAliasFixture = [
+  'import { spawn } from "node:child_process";',
+  "type SpawnFunction = typeof spawn;",
+  "function launch(spawnImpl: SpawnFunction) {",
+  '  return spawnImpl("codex", [], { stdio: "ignore" });',
+  "}",
+].join("\n");
+assert.equal(
+  childProcessCalls(typeAliasFixture)[0]?.hasWindowsHide,
+  false,
+  "a launcher passed through a type alias remains audited",
+);
+
+const importTypeAliasFixture = [
+  'type SpawnFunction = typeof import("node:child_process").spawn;',
+  "function launch(spawnImpl: SpawnFunction) {",
+  '  return spawnImpl("codex", [], { windowsHide: true });',
+  "}",
+].join("\n");
+assert.equal(
+  childProcessCalls(importTypeAliasFixture)[0]?.hasWindowsHide,
+  true,
+  "an import-type launcher alias is audited without a value import",
+);
+
+const grokModelsPath = path.join(SRC_ROOT, "lib", "server", "grok-models.ts");
+const grokModelsSource = readFileSync(grokModelsPath, "utf8");
+const currentGrokCall = childProcessCalls(grokModelsSource, grokModelsPath)
+  .find((call) => call.text.includes("dependencies.spawnImpl ?? spawn"));
+assert.equal(
+  currentGrokCall?.hasWindowsHide,
+  true,
+  "the current inline Grok dependency fallback is recognized and safe",
+);
+const unsafeGrokSource = grokModelsSource.replace(/\s*windowsHide: true,/, "");
+const unsafeGrokCall = childProcessCalls(unsafeGrokSource, grokModelsPath)
+  .find((call) => call.text.includes("dependencies.spawnImpl ?? spawn"));
+assert.equal(
+  unsafeGrokCall?.hasWindowsHide,
+  false,
+  "removing windowsHide from the current inline Grok fallback is caught",
+);
+
+const rootServerPath = path.join(REPO_ROOT, "server.ts");
+const rootServerSource = readFileSync(rootServerPath, "utf8");
+const currentTailnetCall = childProcessCalls(rootServerSource, rootServerPath)
+  .find((call) => call.text.includes('"status", "--json"'));
+assert.equal(
+  currentTailnetCall?.hasWindowsHide,
+  true,
+  "the packaged root server's Tailscale refresh is included in the guard",
+);
+const unsafeRootServer = rootServerSource.replace(/, windowsHide: true(?= \})/, "");
+const unsafeTailnetCall = childProcessCalls(unsafeRootServer, rootServerPath)
+  .find((call) => call.text.includes('"status", "--json"'));
+assert.equal(
+  unsafeTailnetCall?.hasWindowsHide,
+  false,
+  "removing windowsHide from the packaged root server is caught",
+);
+
+const packagedServerPath = path.join(REPO_ROOT, "server.mjs");
+const packagedServerSource = readFileSync(packagedServerPath, "utf8");
+const currentPackagedTailnetCall = childProcessCalls(packagedServerSource, packagedServerPath)
+  .find((call) => call.text.includes('"status", "--json"'));
+assert.equal(
+  currentPackagedTailnetCall?.hasWindowsHide,
+  true,
+  "the tracked packaged server artifact is semantically audited for the hidden Tailscale subprocess option",
+);
+const unsafePackagedServer = packagedServerSource.replace(/, windowsHide: true(?= \})/, "");
+const unsafePackagedTailnetCall = childProcessCalls(unsafePackagedServer, packagedServerPath)
+  .find((call) => call.text.includes('"status", "--json"'));
+assert.equal(
+  unsafePackagedTailnetCall?.hasWindowsHide,
+  false,
+  "removing windowsHide from the executable server artifact is caught semantically",
 );

--- a/src/lib/codex-bin.ts
+++ b/src/lib/codex-bin.ts
@@ -4,22 +4,281 @@
 // directly, and using cmd.exe would re-parse project paths or resume ids as
 // shell syntax. Resolve the shim's JavaScript target and invoke Node directly.
 
-import { existsSync, statSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   covenLaunchCommandForBinary,
+  withCovenWrapperWindowPolicy,
   type CovenLaunchCommand,
 } from "./coven-bin.ts";
 
-function candidateDirs(env: NodeJS.ProcessEnv): string[] {
+const CODEX_MANAGED_BY_KEYS = [
+  "CODEX_MANAGED_BY_NPM",
+  "CODEX_MANAGED_BY_PNPM",
+  "CODEX_MANAGED_BY_BUN",
+] as const;
+
+type CodexPackageManager = "npm" | "pnpm" | "bun";
+
+export type CodexManagedPackage = {
+  root: string;
+  manager: CodexPackageManager;
+};
+
+export type CodexAutomationLaunchCommand = CovenLaunchCommand & {
+  managedPackage?: CodexManagedPackage;
+};
+
+type PackageManifest = {
+  name?: unknown;
+  version?: unknown;
+  bin?: unknown;
+  optionalDependencies?: unknown;
+  os?: unknown;
+  cpu?: unknown;
+};
+
+function readPackageManifest(root: string): PackageManifest | null {
+  try {
+    const parsed = JSON.parse(readFileSync(
+      /* turbopackIgnore: true */ path.join(root, "package.json"),
+      "utf8",
+    )) as unknown;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed as PackageManifest
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isFile(candidate: string): boolean {
+  try {
+    const value = statSync(/* turbopackIgnore: true */ candidate);
+    return value.isFile() || value.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+function canonicalFileWithin(root: string, candidate: string): string | null {
+  try {
+    const canonical = realpathSync(/* turbopackIgnore: true */ candidate);
+    const relative = path.relative(root, canonical);
+    return relative && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative) && isFile(canonical)
+      ? canonical
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function isPnpmOwnedCodexInstall(
+  nodeModulesDir: string,
+  canonicalPackageRoot: string,
+): boolean {
+  if (!existsSync(/* turbopackIgnore: true */ path.join(nodeModulesDir, ".modules.yaml"))) {
+    return false;
+  }
+  try {
+    return realpathSync(
+      /* turbopackIgnore: true */ path.join(nodeModulesDir, "@openai", "codex"),
+    ) === canonicalPackageRoot;
+  } catch {
+    return false;
+  }
+}
+
+/** Match the package-manager marker contract set by the official Codex wrapper. */
+function codexPackageManager(
+  packageRoot: string,
+  entrypoint: string,
+  env: NodeJS.ProcessEnv,
+): CodexPackageManager {
+  for (const startDir of new Set([packageRoot, path.dirname(path.resolve(entrypoint))])) {
+    const filesystemRoot = path.parse(startDir).root;
+    for (
+      let currentDir = startDir;
+      currentDir !== filesystemRoot;
+      currentDir = path.dirname(currentDir)
+    ) {
+      if (isPnpmOwnedCodexInstall(path.join(currentDir, "node_modules"), packageRoot)) {
+        return "pnpm";
+      }
+    }
+    if (isPnpmOwnedCodexInstall(path.join(filesystemRoot, "node_modules"), packageRoot)) {
+      return "pnpm";
+    }
+  }
+
+  const userAgent = env.npm_config_user_agent ?? "";
+  const execPath = env.npm_execpath ?? "";
+  if (
+    /\bbun\//.test(userAgent)
+    || execPath.toLowerCase().includes("bun")
+    || /[\\/].bun[\\/]install[\\/]global(?:[\\/]|$)/i.test(packageRoot)
+  ) {
+    return "bun";
+  }
+  return "npm";
+}
+
+function stringRecord(value: unknown): Record<string, string> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const entries = Object.entries(value);
+  return entries.every(([, item]) => typeof item === "string")
+    ? Object.fromEntries(entries) as Record<string, string>
+    : null;
+}
+
+function stringArray(value: unknown): string[] | null {
+  return Array.isArray(value) && value.every((item) => typeof item === "string")
+    ? value
+    : null;
+}
+
+/**
+ * Resolve the native executable behind the official Windows Codex npm shim.
+ *
+ * The official JS wrapper launches a console-subsystem `codex.exe` without
+ * `windowsHide`, so hiding only the Node wrapper can still allocate a visible
+ * console. We duplicate its documented package layout and managed-package env
+ * contract, but only after proving the root manifest, platform package, CPU,
+ * target triple, and executable. Anything else fails closed instead of being
+ * interpreted by cmd.exe or executed as an unverified JavaScript launcher.
+ */
+function officialWindowsCodexNativeLaunch(
+  script: string,
+  env: NodeJS.ProcessEnv,
+  arch: NodeJS.Architecture,
+): CodexAutomationLaunchCommand | null {
+  const target = arch === "x64"
+    ? { packageName: "@openai/codex-win32-x64", triple: "x86_64-pc-windows-msvc", cpu: "x64" }
+    : arch === "arm64"
+      ? { packageName: "@openai/codex-win32-arm64", triple: "aarch64-pc-windows-msvc", cpu: "arm64" }
+      : null;
+  if (!target || path.basename(script).toLowerCase() !== "codex.js") return null;
+
+  let packageRoot: string;
+  let canonicalScript: string;
+  try {
+    canonicalScript = realpathSync(/* turbopackIgnore: true */ script);
+    packageRoot = realpathSync(/* turbopackIgnore: true */ path.resolve(path.dirname(canonicalScript), ".."));
+  } catch {
+    return null;
+  }
+  if (path.basename(path.dirname(canonicalScript)).toLowerCase() !== "bin") return null;
+
+  const rootManifest = readPackageManifest(packageRoot);
+  const rootBin = stringRecord(rootManifest?.bin);
+  const optionalDependencies = stringRecord(rootManifest?.optionalDependencies);
+  if (
+    rootManifest?.name !== "@openai/codex"
+    || rootBin?.codex?.replaceAll("\\", "/") !== "bin/codex.js"
+    || typeof rootManifest.version !== "string"
+    || !optionalDependencies?.[target.packageName]
+  ) {
+    return null;
+  }
+
+  const scopedRoot = path.dirname(packageRoot);
+  const packageLeaf = target.packageName.slice("@openai/".length);
+  const platformRoots = [
+    path.join(packageRoot, "node_modules", "@openai", packageLeaf),
+    path.join(scopedRoot, packageLeaf),
+  ];
+  for (const candidateRoot of platformRoots) {
+    let platformRoot: string;
+    try {
+      platformRoot = realpathSync(/* turbopackIgnore: true */ candidateRoot);
+    } catch {
+      continue;
+    }
+    const manifest = readPackageManifest(platformRoot);
+    const supportedOs = stringArray(manifest?.os);
+    const supportedCpu = stringArray(manifest?.cpu);
+    if (
+      manifest?.name !== "@openai/codex"
+      || typeof manifest.version !== "string"
+      || manifest.version !== `${rootManifest.version}-win32-${target.cpu}`
+      || !supportedOs?.includes("win32")
+      || !supportedCpu?.includes(target.cpu)
+    ) {
+      continue;
+    }
+    const executable = canonicalFileWithin(
+      platformRoot,
+      path.join(platformRoot, "vendor", target.triple, "bin", "codex.exe"),
+    );
+    if (!executable) continue;
+    return {
+      command: executable,
+      fixedArgs: [],
+      managedPackage: {
+        root: packageRoot,
+        manager: codexPackageManager(packageRoot, script, env),
+      },
+    };
+  }
+
+  // Older official packages bundled the target under the root package. Keep
+  // that supported fallback as narrow as the wrapper: exact manifest plus
+  // exact architecture-specific vendor path.
+  const bundledExecutable = canonicalFileWithin(
+    packageRoot,
+    path.join(packageRoot, "vendor", target.triple, "bin", "codex.exe"),
+  );
+  if (!bundledExecutable) return null;
+  return {
+    command: bundledExecutable,
+    fixedArgs: [],
+    managedPackage: {
+      root: packageRoot,
+      manager: codexPackageManager(packageRoot, script, env),
+    },
+  };
+}
+
+function candidateDirs(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): string[] {
   const configured = (env.PATH ?? "")
-    .split(path.delimiter)
+    .split(platform === "win32" ? ";" : path.delimiter)
     .map((directory) => directory.trim().replace(/^"|"$/g, ""));
-  if (process.platform === "win32" && env.APPDATA) {
+  if (platform === "win32" && env.APPDATA) {
     configured.push(path.join(env.APPDATA, "npm"));
   }
-  return configured.filter((directory, index) =>
-    !!directory && configured.indexOf(directory) === index && existsSync(directory));
+  return configured
+    .filter((directory, index) => !!directory && configured.indexOf(directory) === index)
+    .filter((directory) => path.isAbsolute(directory))
+    .map((directory) => path.resolve(/* turbopackIgnore: true */ directory))
+    .filter((directory) => existsSync(/* turbopackIgnore: true */ directory));
+}
+
+export const CODEX_WINDOWS_NOT_FOUND_DIAGNOSTIC =
+  "Codex CLI was not found in Cave's launch environment. Install or repair the official @openai/codex package, restart Cave, and try again.";
+
+function verifiedAbsoluteFile(candidate: string): string | null {
+  if (!path.isAbsolute(candidate)) return null;
+  const absolute = path.resolve(/* turbopackIgnore: true */ candidate);
+  try {
+    const stat = statSync(/* turbopackIgnore: true */ absolute);
+    return stat.isFile() || stat.isSymbolicLink() ? absolute : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Windows launch plans never retain a bare or cwd-relative executable name. */
+export function verifiedCodexLaunchBinary(
+  binary: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  if (platform !== "win32") return binary;
+  const verified = verifiedAbsoluteFile(binary);
+  if (!verified) throw new Error(CODEX_WINDOWS_NOT_FOUND_DIAGNOSTIC);
+  return verified;
 }
 
 export function codexCandidateBinNames(
@@ -37,24 +296,21 @@ export function codexBin(
 ): string {
   const override = env.CODEX_BIN;
   if (override) {
-    try {
-      const stat = statSync(override);
-      if (stat.isFile() || stat.isSymbolicLink()) return override;
-    } catch {
-      // An invalid override must not make us run an arbitrary shell command.
-    }
+    const verified = verifiedAbsoluteFile(override);
+    if (verified) return verified;
   }
-  for (const directory of candidateDirs(env)) {
+  for (const directory of candidateDirs(env, platform)) {
     for (const name of codexCandidateBinNames(platform)) {
       const candidate = path.join(/* turbopackIgnore: true */ directory, name);
-      try {
-        const stat = statSync(candidate);
-        if (stat.isFile() || stat.isSymbolicLink()) return candidate;
-      } catch {
-        // Continue searching the launcher's effective PATH.
-      }
+      const verified = verifiedAbsoluteFile(candidate);
+      if (verified) return verified;
     }
   }
+  // POSIX PATH lookup does not implicitly search the child's cwd unless the
+  // user explicitly put a relative entry in PATH. Windows CreateProcess does:
+  // a bare fallback or relative PATH entry would let a Research workspace
+  // plant `codex.exe` and have Cave execute it when the real CLI is missing.
+  if (platform === "win32") throw new Error(CODEX_WINDOWS_NOT_FOUND_DIAGNOSTIC);
   return "codex";
 }
 
@@ -64,4 +320,50 @@ export function codexLaunchCommand(
   platform: NodeJS.Platform = process.platform,
 ): CovenLaunchCommand {
   return covenLaunchCommandForBinary(binary, platform);
+}
+
+/**
+ * AutoResearch-specific launcher resolution. On Windows, bypass only the
+ * verified official npm wrapper; unrecognized shims remain unlaunchable.
+ */
+export function codexAutomationLaunchCommand(
+  binary: string = codexBin(),
+  options: {
+    env?: NodeJS.ProcessEnv;
+    platform?: NodeJS.Platform;
+    arch?: NodeJS.Architecture;
+  } = {},
+): CodexAutomationLaunchCommand {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const verifiedBinary = verifiedCodexLaunchBinary(binary, platform);
+  const launch = codexLaunchCommand(verifiedBinary, platform);
+  if (platform !== "win32" || launch.unresolvedWindowsShim) return launch;
+  if (/\.(?:exe|com)$/i.test(verifiedBinary)) return launch;
+  if (!/\.(?:cmd|bat)$/i.test(verifiedBinary)) {
+    return { command: verifiedBinary, fixedArgs: [], unresolvedWindowsShim: true };
+  }
+  const script = launch.fixedArgs.length === 1 ? launch.fixedArgs[0] : null;
+  const native = script
+    ? officialWindowsCodexNativeLaunch(script, env, options.arch ?? process.arch)
+    : null;
+  return native ?? { command: verifiedBinary, fixedArgs: [], unresolvedWindowsShim: true };
+}
+
+/** Apply the official wrapper's env contract to a direct native launch. */
+export function codexManagedPackageSpawnEnv(
+  env: NodeJS.ProcessEnv,
+  managedPackage: CodexManagedPackage | undefined,
+): NodeJS.ProcessEnv {
+  const result = withCovenWrapperWindowPolicy(env, process.platform, false);
+  if (!managedPackage) return result;
+  result.CODEX_MANAGED_PACKAGE_ROOT = managedPackage.root;
+  for (const key of CODEX_MANAGED_BY_KEYS) delete result[key];
+  const managerKey = managedPackage.manager === "bun"
+    ? "CODEX_MANAGED_BY_BUN"
+    : managedPackage.manager === "pnpm"
+      ? "CODEX_MANAGED_BY_PNPM"
+      : "CODEX_MANAGED_BY_NPM";
+  result[managerKey] = "1";
+  return result;
 }

--- a/src/lib/codex-bin.ts
+++ b/src/lib/codex-bin.ts
@@ -8,6 +8,7 @@ import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   covenLaunchCommandForBinary,
+  isWindowsRemoteExecutablePath,
   withCovenWrapperWindowPolicy,
   type CovenLaunchCommand,
 } from "./coven-bin.ts";
@@ -252,6 +253,7 @@ function candidateDirs(
   return configured
     .filter((directory, index) => !!directory && configured.indexOf(directory) === index)
     .filter((directory) => path.isAbsolute(directory))
+    .filter((directory) => platform !== "win32" || !isWindowsRemoteExecutablePath(directory))
     .map((directory) => path.resolve(/* turbopackIgnore: true */ directory))
     .filter((directory) => existsSync(/* turbopackIgnore: true */ directory));
 }
@@ -259,12 +261,18 @@ function candidateDirs(
 export const CODEX_WINDOWS_NOT_FOUND_DIAGNOSTIC =
   "Codex CLI was not found in Cave's launch environment. Install or repair the official @openai/codex package, restart Cave, and try again.";
 
-function verifiedAbsoluteFile(candidate: string): string | null {
+function verifiedAbsoluteFile(
+  candidate: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
   if (!path.isAbsolute(candidate)) return null;
+  if (platform === "win32" && isWindowsRemoteExecutablePath(candidate)) return null;
   const absolute = path.resolve(/* turbopackIgnore: true */ candidate);
   try {
-    const stat = statSync(/* turbopackIgnore: true */ absolute);
-    return stat.isFile() || stat.isSymbolicLink() ? absolute : null;
+    const canonical = realpathSync(/* turbopackIgnore: true */ absolute);
+    if (platform === "win32" && isWindowsRemoteExecutablePath(canonical)) return null;
+    const stat = statSync(/* turbopackIgnore: true */ canonical);
+    return stat.isFile() ? canonical : null;
   } catch {
     return null;
   }
@@ -276,7 +284,7 @@ export function verifiedCodexLaunchBinary(
   platform: NodeJS.Platform = process.platform,
 ): string {
   if (platform !== "win32") return binary;
-  const verified = verifiedAbsoluteFile(binary);
+  const verified = verifiedAbsoluteFile(binary, platform);
   if (!verified) throw new Error(CODEX_WINDOWS_NOT_FOUND_DIAGNOSTIC);
   return verified;
 }
@@ -296,13 +304,13 @@ export function codexBin(
 ): string {
   const override = env.CODEX_BIN;
   if (override) {
-    const verified = verifiedAbsoluteFile(override);
+    const verified = verifiedAbsoluteFile(override, platform);
     if (verified) return verified;
   }
   for (const directory of candidateDirs(env, platform)) {
     for (const name of codexCandidateBinNames(platform)) {
       const candidate = path.join(/* turbopackIgnore: true */ directory, name);
-      const verified = verifiedAbsoluteFile(candidate);
+      const verified = verifiedAbsoluteFile(candidate, platform);
       if (verified) return verified;
     }
   }

--- a/src/lib/codex-runtime-availability.ts
+++ b/src/lib/codex-runtime-availability.ts
@@ -1,5 +1,8 @@
 import { spawn } from "node:child_process";
-import type { CovenLaunchCommand } from "./coven-bin.ts";
+import {
+  covenWrapperSpawnEnv,
+  type CovenLaunchCommand,
+} from "./coven-bin.ts";
 import {
   evaluateRuntimeAvailability,
   missingRunnerMessage,
@@ -106,7 +109,7 @@ export const runCovenAdapterList: CovenAdapterListProbe = (launch, env) =>
     let child;
     try {
       child = spawn(launch.command, [...launch.fixedArgs, "adapter", "list", "--json"], {
-        env,
+        env: covenWrapperSpawnEnv(env),
         stdio: ["ignore", "pipe", "pipe"],
         windowsHide: true,
       });

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -4,16 +4,73 @@
 // that shape when launched as a desktop app, otherwise /api/onboarding/status
 // can find `coven` while later spawns still fail with ENOENT.
 import assert from "node:assert/strict";
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { spawnSync } from "node:child_process";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { caveToolSpawnEnv, covenAdapterDirsEnvValue, covenLaunchCommandForBinary, covenSpawnEnv, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery } from "./coven-bin.ts";
+import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV, caveToolSpawnEnv, covenAdapterDirsEnvValue, covenBinaryFromEnvironment, covenLaunchCommandForBinary, covenSpawnEnv, covenWrapperSpawnEnv, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery, withCovenWrapperWindowPolicy } from "./coven-bin.ts";
+import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 const childSpawnEnvSource = await readFile(
   new URL("./child-spawn-env.ts", import.meta.url),
   "utf8",
 );
+
+assert.equal(
+  withCovenWrapperWindowPolicy({}, "win32")[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+  "1",
+  "every Cave-owned Coven wrapper invocation opts into hidden native Windows children",
+);
+assert.equal(
+  withCovenWrapperWindowPolicy(
+    { [COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV]: "1" },
+    "linux",
+  )[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+  undefined,
+  "the wrapper opt-in is Windows-only",
+);
+assert.deepEqual(
+  withCovenWrapperWindowPolicy(
+    { coven_windows_hide_native_window: "1" },
+    "win32",
+    false,
+  ),
+  {},
+  "user-selected project tools never inherit Cave's wrapper window policy",
+);
+assert.equal(
+  covenWrapperSpawnEnv({}, "win32")[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+  "1",
+  "the semantic helper opts one exact Coven wrapper launch into native window suppression",
+);
+
+{
+  const previous = process.env[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV];
+  process.env[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV] = "inherited";
+  try {
+    refreshCovenSpawnEnv({ discoveryDeadline: 0, now: () => 0 });
+    assert.equal(
+      covenSpawnEnv()[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+      undefined,
+      "the generic Coven-derived environment scrubs an inherited wrapper signal",
+    );
+    assert.equal(
+      harnessSpawnEnv()[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+      undefined,
+      "direct harnesses never inherit the Coven-wrapper-only signal",
+    );
+    assert.equal(
+      caveToolSpawnEnv()[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+      undefined,
+      "project tools never inherit the Coven-wrapper-only signal",
+    );
+  } finally {
+    if (previous === undefined) delete process.env[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV];
+    else process.env[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV] = previous;
+    refreshCovenSpawnEnv();
+  }
+}
 
 assert.match(
   source,
@@ -178,8 +235,13 @@ assert.match(
 );
 assert.match(
   source,
-  /return scrubSidecarInternalEnv\(env\);\s*\}/,
-  "covenSpawnEnv routes through the shared scrub, so agents/CLI probes/installers are all covered",
+  /return withCovenWrapperWindowPolicy\(\s*scrubSidecarInternalEnv\(env\),[\s\S]*process\.platform,[\s\S]*false,[\s\S]*\);/,
+  "the shared spawn baseline scrubs the wrapper-only Windows signal",
+);
+assert.match(
+  source,
+  /export function covenWrapperSpawnEnv\([\s\S]*return withCovenWrapperWindowPolicy\(env, platform, true\)/,
+  "only the exact Coven wrapper helper restores the Windows no-window opt-in",
 );
 {
   const env = scrubSidecarInternalEnv({
@@ -723,11 +785,87 @@ assert.equal(
 
 assert.equal(pickWindowsLauncher([]), null, "empty `where` output yields null");
 
+assert.doesNotMatch(
+  source,
+  /execFileSync\("where(?:\.exe)?", \["coven"\]/,
+  "Coven resolution never delegates to where.exe, whose search includes cwd",
+);
+assert.doesNotMatch(
+  source,
+  /execFileSync\("reg(?:\.exe)?"/,
+  "Windows PATH refresh never runs a cwd-searchable registry utility",
+);
 assert.match(
   source,
-  /execFileSync\("where", \["coven"\][\s\S]*pickWindowsLauncher/,
-  "covenBin falls back to `where` + launcher picking before the literal name on Windows",
+  /path\.join\([^\n]*systemRoot, "System32", "reg\.exe"\)/,
+  "Windows PATH refresh pins reg.exe to the verified system directory",
 );
+assert.match(
+  source,
+  /process\.platform === "win32"\) throw new Error\(COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC\)/,
+  "a missing Windows Coven CLI fails closed instead of returning a bare executable name",
+);
+
+if (process.platform === "win32") {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-coven-cwd-plant-"));
+  const verifiedDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-coven-path-"));
+  try {
+    await copyFile(process.execPath, path.join(directory, "coven.exe"));
+    await copyFile(process.execPath, path.join(verifiedDirectory, "coven.exe"));
+    assert.equal(
+      covenBinaryFromEnvironment({ Path: ".", COVEN_BIN: "coven.exe" }),
+      null,
+      "an explicit relative override and relative PATH never consult the process cwd",
+    );
+    assert.equal(
+      covenBinaryFromEnvironment({ Path: verifiedDirectory }),
+      path.join(verifiedDirectory, "coven.exe"),
+      "an existing launcher in an explicit absolute PATH directory is eligible",
+    );
+    assert.equal(
+      covenBinaryFromEnvironment({ Path: "\\\\remote-host\\share" }),
+      null,
+      "remote UNC search roots cannot supply Cave's owner-local Coven CLI",
+    );
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.toUpperCase() === "PATH" || key === "COVEN_BIN") delete env[key];
+    }
+    Object.assign(env, {
+      Path: ".",
+      COVEN_BIN: "coven.exe",
+      HOME: directory,
+      USERPROFILE: directory,
+      APPDATA: path.join(directory, "appdata"),
+      LOCALAPPDATA: path.join(directory, "localappdata"),
+    });
+    const moduleHref = new URL(`./coven-bin.ts?cwd-plant=${Date.now()}`, import.meta.url).href;
+    const probe = spawnSync(
+      process.execPath,
+      [
+        "--experimental-strip-types",
+        "--input-type=module",
+        "-e",
+        `import { covenBin } from ${JSON.stringify(moduleHref)}; try { console.log(covenBin()); } catch (error) { console.error(error.message); }`,
+      ],
+      { cwd: directory, env, encoding: "utf8", windowsHide: true, shell: false },
+    );
+    assert.equal(probe.status, 0, probe.stderr || probe.error?.message);
+    const selected = probe.stdout.trim();
+    assert.ok(
+      selected || /Coven CLI was not found/i.test(probe.stderr),
+      "discovery either selects a verified system/user installation or fails closed",
+    );
+    assert.notEqual(
+      selected.toLowerCase(),
+      path.join(directory, "coven.exe").toLowerCase(),
+      "neither Windows cwd search nor a relative override can select cwd-planted coven.exe",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+    await rm(verifiedDirectory, { recursive: true, force: true });
+  }
+}
 
 // Released Coven CLIs only auto-trust recipe-installed manifests inside
 // COVEN_HOME/adapters (hermes); Cave-scaffolded copilot/opencode manifests

--- a/src/lib/coven-bin.test.ts
+++ b/src/lib/coven-bin.test.ts
@@ -5,16 +5,25 @@
 // can find `coven` while later spawns still fail with ENOENT.
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { chmod, copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, copyFile, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV, caveToolSpawnEnv, covenAdapterDirsEnvValue, covenBinaryFromEnvironment, covenLaunchCommandForBinary, covenSpawnEnv, covenWrapperSpawnEnv, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery, withCovenWrapperWindowPolicy } from "./coven-bin.ts";
+import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV, caveToolSpawnEnv, covenAdapterDirsEnvValue, covenBinaryFromEnvironment, covenLaunchCommandForBinary, covenSpawnEnv, covenWrapperSpawnEnv, isWindowsRemoteExecutablePath, pickWindowsLauncher, refreshCovenSpawnEnv, runnableNodeToolchainDirs, scrubSidecarInternalEnv, windowsPathFromRegQuery, withCovenWrapperWindowPolicy } from "./coven-bin.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 
 const source = await readFile(new URL("./coven-bin.ts", import.meta.url), "utf8");
 const childSpawnEnvSource = await readFile(
   new URL("./child-spawn-env.ts", import.meta.url),
   "utf8",
+);
+
+assert.equal(isWindowsRemoteExecutablePath("\\\\server\\share\\coven.exe"), true);
+assert.equal(isWindowsRemoteExecutablePath("\\\\?\\UNC\\server\\share\\coven.exe"), true);
+assert.equal(isWindowsRemoteExecutablePath("\\\\?\\C:\\Tools\\coven.exe"), false);
+assert.match(
+  source,
+  /const canonical = realpathSync[\s\S]*isWindowsRemoteExecutablePath\(canonical\)[\s\S]*return st\.isFile\(\) \? canonical : null/,
+  "Windows launchers are canonicalized before a reparse target can cross the UNC boundary",
 );
 
 assert.equal(
@@ -809,6 +818,7 @@ assert.match(
 if (process.platform === "win32") {
   const directory = await mkdtemp(path.join(os.tmpdir(), "cave-coven-cwd-plant-"));
   const verifiedDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-coven-path-"));
+  const junctionDirectory = `${verifiedDirectory}-junction`;
   try {
     await copyFile(process.execPath, path.join(directory, "coven.exe"));
     await copyFile(process.execPath, path.join(verifiedDirectory, "coven.exe"));
@@ -826,6 +836,17 @@ if (process.platform === "win32") {
       covenBinaryFromEnvironment({ Path: "\\\\remote-host\\share" }),
       null,
       "remote UNC search roots cannot supply Cave's owner-local Coven CLI",
+    );
+    assert.equal(
+      covenBinaryFromEnvironment({ COVEN_BIN: "\\\\remote-host\\share\\coven.exe" }),
+      null,
+      "a remote UNC override cannot supply Cave's owner-local Coven CLI",
+    );
+    await symlink(verifiedDirectory, junctionDirectory, "junction");
+    assert.equal(
+      covenBinaryFromEnvironment({ Path: junctionDirectory })?.toLowerCase(),
+      (await realpath(path.join(verifiedDirectory, "coven.exe"))).toLowerCase(),
+      "a local reparse path is resolved to its canonical executable before launch",
     );
     const env = { ...process.env };
     for (const key of Object.keys(env)) {
@@ -863,6 +884,7 @@ if (process.platform === "win32") {
     );
   } finally {
     await rm(directory, { recursive: true, force: true });
+    await rm(junctionDirectory, { recursive: true, force: true });
     await rm(verifiedDirectory, { recursive: true, force: true });
   }
 }

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -24,7 +24,7 @@
 // for the env option.
 
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -356,22 +356,33 @@ function windowsRegistryPath(discovery: DiscoveryOptions): string | null {
 export const COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC =
   "Coven CLI was not found in Cave's launch environment. Install or repair @opencoven/cli, restart Cave, and try again.";
 
+/** UNC and extended-UNC paths cross Cave's owner-local executable boundary. */
+export function isWindowsRemoteExecutablePath(candidate: string): boolean {
+  const normalized = candidate.replaceAll("/", "\\");
+  return /^\\\\[^?.\\]/.test(normalized) || /^\\\\\?\\UNC\\/i.test(normalized);
+}
+
 function verifiedAbsoluteBinary(
   candidate: string,
   platform: NodeJS.Platform = process.platform,
 ): string | null {
   const pathApi = platform === "win32" ? path.win32 : path;
-  if (!pathApi.isAbsolute(candidate)) return null;
+  const crossHostAbsolute = platform !== process.platform && path.isAbsolute(candidate);
+  if (!pathApi.isAbsolute(candidate) && !crossHostAbsolute) return null;
   // A Cave-owned local daemon/CLI must not be sourced from a remote UNC share.
   // Besides crossing the local trust boundary, probing one synchronously can
   // defeat the bounded onboarding/status request when the share is offline.
-  if (platform === "win32" && /^\\\\(?!\?\\[A-Za-z]:\\)/.test(candidate)) {
+  if (platform === "win32" && isWindowsRemoteExecutablePath(candidate)) {
     return null;
   }
-  const absolute = pathApi.resolve(/* turbopackIgnore: true */ candidate);
+  const absolute = crossHostAbsolute
+    ? path.resolve(/* turbopackIgnore: true */ candidate)
+    : pathApi.resolve(/* turbopackIgnore: true */ candidate);
   try {
-    const st = statSync(/* turbopackIgnore: true */ absolute);
-    return st.isFile() || st.isSymbolicLink() ? absolute : null;
+    const canonical = realpathSync(/* turbopackIgnore: true */ absolute);
+    if (platform === "win32" && isWindowsRemoteExecutablePath(canonical)) return null;
+    const st = statSync(/* turbopackIgnore: true */ canonical);
+    return st.isFile() ? canonical : null;
   } catch {
     return null;
   }
@@ -416,7 +427,7 @@ export function covenBinaryFromEnvironment(
   for (const configuredDir of pathValue.split(pathApi.delimiter)) {
     const normalizedDir = configuredDir.trim().replace(/^"|"$/g, "");
     if (!normalizedDir || !pathApi.isAbsolute(normalizedDir)) continue;
-    if (platform === "win32" && /^\\\\(?!\?\\[A-Za-z]:\\)/.test(normalizedDir)) {
+    if (platform === "win32" && isWindowsRemoteExecutablePath(normalizedDir)) {
       continue;
     }
     const directory = pathApi.resolve(/* turbopackIgnore: true */ normalizedDir);
@@ -516,10 +527,14 @@ export function windowsShimLaunchCommandForBinary(
   if (!script) {
     return { command: binary, fixedArgs: [], unresolvedWindowsShim: true };
   }
-  if (/\.(?:exe|com)$/i.test(script)) {
-    return { command: script, fixedArgs: [] };
+  const verifiedScript = verifiedAbsoluteBinary(script, platform);
+  if (!verifiedScript) {
+    return { command: binary, fixedArgs: [], unresolvedWindowsShim: true };
   }
-  return { command: process.execPath, fixedArgs: [script] };
+  if (/\.(?:exe|com)$/i.test(verifiedScript)) {
+    return { command: verifiedScript, fixedArgs: [] };
+  }
+  return { command: process.execPath, fixedArgs: [verifiedScript] };
 }
 
 export function covenLaunchCommandForBinary(

--- a/src/lib/coven-bin.ts
+++ b/src/lib/coven-bin.ts
@@ -240,10 +240,6 @@ function candidateDirs(discovery = discoveryOptions()): string[] {
   ].filter((d): d is string => !!d && existsSync(/* turbopackIgnore: true */ d));
 }
 
-function candidateBinNames(): string[] {
-  return process.platform === "win32" ? ["coven.cmd", "coven.exe", "coven"] : ["coven"];
-}
-
 /**
  * Pick the spawnable launcher from `where` output. npm's global installs
  * write three launchers per package (an extensionless POSIX script, a .cmd
@@ -322,6 +318,15 @@ export function windowsPathFromRegQuery(
 // which already-running processes never receive. Re-reading the registry is
 // how a refresh actually picks those up without an app restart.
 function windowsRegistryPath(discovery: DiscoveryOptions): string | null {
+  const systemRoot = discovery.env.SystemRoot ?? Object.entries(discovery.env).find(
+    ([key]) => key.toUpperCase() === "SYSTEMROOT",
+  )?.[1];
+  const regExecutable = systemRoot
+    ? path.join(/* turbopackIgnore: true */ systemRoot, "System32", "reg.exe")
+    : null;
+  if (!regExecutable || !path.isAbsolute(regExecutable) || !existsSync(regExecutable)) {
+    return null;
+  }
   // Machine PATH first, then user PATH — the same order Windows itself uses
   // when it builds a process environment.
   const keys = [
@@ -333,7 +338,7 @@ function windowsRegistryPath(discovery: DiscoveryOptions): string | null {
     const timeout = remainingDiscoveryTimeout(2000, discovery.deadline, discovery.now);
     if (timeout <= 0) break;
     try {
-      const out = execFileSync("reg", ["query", key, "/v", "Path"], {
+      const out = execFileSync(regExecutable, ["query", key, "/v", "Path"], {
         windowsHide: true,
         encoding: "utf-8",
         timeout,
@@ -348,11 +353,88 @@ function windowsRegistryPath(discovery: DiscoveryOptions): string | null {
   return parts.length > 0 ? parts.join(path.delimiter) : null;
 }
 
+export const COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC =
+  "Coven CLI was not found in Cave's launch environment. Install or repair @opencoven/cli, restart Cave, and try again.";
+
+function verifiedAbsoluteBinary(
+  candidate: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const pathApi = platform === "win32" ? path.win32 : path;
+  if (!pathApi.isAbsolute(candidate)) return null;
+  // A Cave-owned local daemon/CLI must not be sourced from a remote UNC share.
+  // Besides crossing the local trust boundary, probing one synchronously can
+  // defeat the bounded onboarding/status request when the share is offline.
+  if (platform === "win32" && /^\\\\(?!\?\\[A-Za-z]:\\)/.test(candidate)) {
+    return null;
+  }
+  const absolute = pathApi.resolve(/* turbopackIgnore: true */ candidate);
+  try {
+    const st = statSync(/* turbopackIgnore: true */ absolute);
+    return st.isFile() || st.isSymbolicLink() ? absolute : null;
+  } catch {
+    return null;
+  }
+}
+
+function environmentValue(
+  env: NodeJS.ProcessEnv,
+  key: string,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (platform !== "win32") return env[key];
+  const wanted = key.toUpperCase();
+  return Object.entries(env).find(([name]) => name.toUpperCase() === wanted)?.[1];
+}
+
 /**
- * Resolve the absolute path to the `coven` binary. If nothing is found,
- * returns the literal string "coven" so callers can still spawn — the OS
- * will resolve via PATH and surface a "not found" error to the user.
+ * Resolve Coven from one explicit environment without invoking `where.exe`.
+ *
+ * Windows' executable search checks the child cwd before PATH. Research and
+ * onboarding operate inside user-controlled project/workspace directories,
+ * so a bare `where coven` or `spawn("coven")` can select a planted launcher.
+ * Only an existing absolute override or a launcher inside an absolute PATH
+ * entry is eligible here. Relative entries and remote UNC paths fail closed.
  */
+export function covenBinaryFromEnvironment(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  const override = environmentValue(env, "COVEN_BIN", platform)?.trim();
+  if (override) {
+    const verified = verifiedAbsoluteBinary(override, platform);
+    if (verified) return verified;
+  }
+
+  const pathApi = platform === "win32" ? path.win32 : path;
+  const pathValue = environmentValue(env, "PATH", platform);
+  if (!pathValue) return null;
+  const names = platform === "win32"
+    ? ["coven.cmd", "coven.exe", "coven.com", "coven.bat"]
+    : ["coven"];
+  const seen = new Set<string>();
+  for (const configuredDir of pathValue.split(pathApi.delimiter)) {
+    const normalizedDir = configuredDir.trim().replace(/^"|"$/g, "");
+    if (!normalizedDir || !pathApi.isAbsolute(normalizedDir)) continue;
+    if (platform === "win32" && /^\\\\(?!\?\\[A-Za-z]:\\)/.test(normalizedDir)) {
+      continue;
+    }
+    const directory = pathApi.resolve(/* turbopackIgnore: true */ normalizedDir);
+    const dedupeKey = platform === "win32" ? directory.toLowerCase() : directory;
+    if (seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+    for (const name of names) {
+      const verified = verifiedAbsoluteBinary(
+        pathApi.join(/* turbopackIgnore: true */ directory, name),
+        platform,
+      );
+      if (verified) return verified;
+    }
+  }
+  return null;
+}
+
+/** Resolve an existing absolute Coven launcher. Windows never returns a bare name. */
 export function covenBin(): string {
   if (cachedBin) return cachedBin;
 
@@ -360,60 +442,31 @@ export function covenBin(): string {
   // ~/.cargo/bin/coven is newer than the npm-bundled one in ~/.nvm/.../bin.
   const envBin = process.env.COVEN_BIN;
   if (envBin) {
-    try {
-      const st = statSync(/* turbopackIgnore: true */ envBin);
-      if (st.isFile() || st.isSymbolicLink()) {
-        cachedBin = envBin;
-        return cachedBin;
-      }
-    } catch {
-      /* fall through to discovery */
+    const verified = verifiedAbsoluteBinary(envBin);
+    if (verified) {
+      cachedBin = verified;
+      return cachedBin;
     }
   }
 
   const discovery = discoveryOptions();
-  for (const dir of candidateDirs(discovery)) {
-    for (const name of candidateBinNames()) {
-      const candidate = path.join(/* turbopackIgnore: true */ dir, name);
-      try {
-        const st = statSync(/* turbopackIgnore: true */ candidate);
-        if (st.isFile() || st.isSymbolicLink()) {
-          cachedBin = candidate;
-          return cachedBin;
-        }
-      } catch {
-        /* not here; keep looking */
-      }
-    }
+  const resolved = covenBinaryFromEnvironment(
+    {
+      ...discovery.env,
+      PATH: augmentedSpawnPath(false, discovery),
+    },
+    process.platform,
+  );
+  if (resolved) {
+    cachedBin = resolved;
+    return cachedBin;
   }
 
-  // Nothing in the well-known dirs. On Windows, resolve through PATH with
-  // `where` before falling back to the literal name: npm installs the CLI
-  // as coven.cmd (plus an unspawnable extensionless POSIX script), and a
-  // bare spawn("coven") only resolves .exe/.com — so the literal fallback
-  // ENOENTs even when the CLI is plainly on PATH (scoop/winget node,
-  // cave-observed on Windows 11).
-  if (process.platform === "win32") {
-    try {
-      const out = execFileSync("where", ["coven"], {
-        windowsHide: true,
-        encoding: "utf-8",
-        timeout: 1500,
-        env: {
-          ...discovery.env,
-          PATH: covenSpawnEnv({ discoveryEnv: discovery.env }).PATH,
-        },
-      });
-      const picked = pickWindowsLauncher(out.split(/\r?\n/));
-      if (picked) {
-        cachedBin = picked;
-        return cachedBin;
-      }
-    } catch {
-      /* not on PATH either — fall through to the literal fallback */
-    }
-  }
-
+  // CreateProcess searches the child cwd before PATH for bare executable
+  // names. A Research/project directory must never get to supply `coven.exe`
+  // through a bare fallback or relative PATH entry merely because the real CLI
+  // is absent from Cave's verified search path.
+  if (process.platform === "win32") throw new Error(COVEN_WINDOWS_NOT_FOUND_DIAGNOSTIC);
   cachedBin = "coven";
   return cachedBin;
 }
@@ -538,7 +591,38 @@ function augmentedSpawnPath(
   return parts.filter((part) => !!part && !seen.has(part) && (seen.add(part), true)).join(path.delimiter);
 }
 
-function spawnEnv(pathValue: string, includeManagedNode = true): NodeJS.ProcessEnv {
+export const COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV =
+  "COVEN_WINDOWS_HIDE_NATIVE_WINDOW";
+
+/**
+ * Mark only Cave-owned Coven-wrapper launches as GUI children on Windows.
+ * The npm wrapper keeps ordinary terminal invocations interactive unless this
+ * exact opt-in is present; user-selected project tools never inherit it.
+ */
+export function withCovenWrapperWindowPolicy(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform = process.platform,
+  appOwnedCovenLaunch = true,
+): NodeJS.ProcessEnv {
+  const next = { ...env };
+  for (const key of Object.keys(next)) {
+    if (
+      (platform === "win32" ? key.toUpperCase() : key)
+      === COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV
+    ) {
+      delete next[key];
+    }
+  }
+  if (appOwnedCovenLaunch && platform === "win32") {
+    next[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV] = "1";
+  }
+  return next;
+}
+
+function spawnEnv(
+  pathValue: string,
+  includeManagedNode = true,
+): NodeJS.ProcessEnv {
   const env: NodeJS.ProcessEnv = { ...process.env, PATH: pathValue };
   if (includeManagedNode) {
     const managed = managedNodeSpawnEnv(env);
@@ -558,7 +642,14 @@ function spawnEnv(pathValue: string, includeManagedNode = true): NodeJS.ProcessE
   if (env.NPM_CONFIG_LOGLEVEL === undefined && env.npm_config_loglevel === undefined) {
     env.NPM_CONFIG_LOGLEVEL = "error";
   }
-  return scrubSidecarInternalEnv(env);
+  // This is the shared baseline for Coven itself, harnesses, onboarding
+  // probes, npm, SSH, and user-selected tools. A wrapper-only control signal
+  // must never ride that generic environment into an unrelated child.
+  return withCovenWrapperWindowPolicy(
+    scrubSidecarInternalEnv(env),
+    process.platform,
+    false,
+  );
 }
 
 export function covenSpawnEnv(options: CovenSpawnEnvOptions = {}): NodeJS.ProcessEnv {
@@ -569,6 +660,18 @@ export function covenSpawnEnv(options: CovenSpawnEnvOptions = {}): NodeJS.Proces
     cachedPath = pathValue;
   }
   return spawnEnv(pathValue);
+}
+
+/**
+ * Opt one exact Cave-owned Coven CLI invocation into the npm wrapper's native
+ * no-window policy. Call this only at a call site whose resolved command is
+ * `coven`; generic harness/tool environments deliberately stay scrubbed.
+ */
+export function covenWrapperSpawnEnv(
+  env: NodeJS.ProcessEnv = covenSpawnEnv(),
+  platform: NodeJS.Platform = process.platform,
+): NodeJS.ProcessEnv {
+  return withCovenWrapperWindowPolicy(env, platform, true);
 }
 
 /**

--- a/src/lib/coven-version.ts
+++ b/src/lib/coven-version.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { covenLaunchCommand, covenSpawnEnv } from "./coven-bin.ts";
+import { covenLaunchCommand, covenWrapperSpawnEnv } from "./coven-bin.ts";
 import { exactSemver } from "./exact-semver.ts";
 
 const execFileAsync = promisify(execFile);
@@ -29,7 +29,7 @@ export async function installedCovenVersion(): Promise<string | null> {
     const { command, fixedArgs } = covenLaunchCommand();
     const { stdout, stderr } = await execFileAsync(command, [...fixedArgs, "--version"], {
       windowsHide: true,
-      env: covenSpawnEnv(),
+      env: covenWrapperSpawnEnv(),
       timeout: 2500,
     });
     return firstSemver(`${stdout}\n${stderr}`);

--- a/src/lib/daemon-endpoint-faults.test.ts
+++ b/src/lib/daemon-endpoint-faults.test.ts
@@ -209,13 +209,13 @@ test("the probe leaves no connection open on the daemon it probed", async () => 
 
 test("a supported API and matching runtime version is adopted", () => {
   const result = assessDaemonStartupCompatibility(
-    { ok: true, apiVersion: "1", covenVersion: "0.2.5" },
+    { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "0.2.5" },
     "0.2.5",
   );
   assert.equal(result.ok, true);
   if (result.ok) {
     assert.equal(result.daemonVersion, "0.2.5");
-    assert.equal(result.apiVersion, "1");
+    assert.equal(result.apiVersion, "coven.daemon.v1");
   }
 });
 
@@ -233,7 +233,7 @@ test("a daemon running a different build than the one Cave manages is refused", 
   // update can open newer persisted state before its own migration guard sees
   // it, so this fails closed.
   const result = assessDaemonStartupCompatibility(
-    { ok: true, apiVersion: "1", covenVersion: "0.2.4" },
+    { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "0.2.4" },
     "0.2.5",
   );
   assert.equal(result.ok, false);
@@ -242,7 +242,7 @@ test("a daemon running a different build than the one Cave manages is refused", 
 
 test("a health document that reports failure is not mined for a version", () => {
   const result = assessDaemonStartupCompatibility(
-    { ok: false, apiVersion: "1", covenVersion: "0.2.5" },
+    { ok: false, apiVersion: "coven.daemon.v1", covenVersion: "0.2.5" },
     "0.2.5",
   );
   assert.equal(result.ok, false);
@@ -250,7 +250,7 @@ test("a health document that reports failure is not mined for a version", () => 
 });
 
 test("a missing or malformed health document is refused, not defaulted", () => {
-  for (const health of [null, undefined, {}, { ok: true }, { ok: true, apiVersion: "1" }]) {
+  for (const health of [null, undefined, {}, { ok: true }, { ok: true, apiVersion: "coven.daemon.v1" }]) {
     const result = assessDaemonStartupCompatibility(health as never, "0.2.5");
     assert.equal(result.ok, false, `health ${JSON.stringify(health)} must not be adopted`);
     if (!result.ok) {

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -6,6 +6,7 @@ import { test } from "node:test";
 import { readFile } from "node:fs/promises";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
 import {
+  directDaemonLaunchCommand,
   parseDaemonLifecycleInspection,
   startLocalDaemon,
   terminateDaemonLaunchTree,
@@ -24,7 +25,9 @@ const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url)
 assert.match(covenDaemon, /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/);
 assert.match(daemonStart, /waitForDaemonReadiness/);
 assert.match(daemonStart, /path: "\/api\/v1\/health"/);
-assert.match(daemonStart, /detached: launchMode === "direct"/, "POSIX launch owns a process group");
+assert.match(daemonStart, /detached: platform !== "win32"/, "POSIX launch owns a process group");
+assert.match(daemonStart, /windowsHide: true/, "daemon launch suppresses Windows console allocation");
+assert.doesNotMatch(daemonStart, /shell: launch\.unresolvedWindowsShim/, "unresolved Windows shims never fall back to cmd.exe");
 assert.match(daemonStart, /taskkill/, "Windows timeout cleanup owns the shell process tree");
 assert.match(daemonStart, /const cleanup = await terminateLaunchTree\(child\)/, "timeout cleanup is executed, not merely declared");
 assert.match(readinessSource, /A final probe closes the race/);
@@ -236,6 +239,70 @@ test("automatic recovery still starts after lifecycle proves stopped", async () 
   assert.equal(result.ok, true);
 });
 
+test("daemon command resolution launches a proven shim target directly", () => {
+  assert.deepEqual(
+    directDaemonLaunchCommand({ command: process.execPath, fixedArgs: ["C:\\tools\\coven.js"] }),
+    {
+      command: process.execPath,
+      args: ["C:\\tools\\coven.js", "daemon", "start"],
+      shell: false,
+    },
+  );
+  assert.throws(
+    () => directDaemonLaunchCommand({
+      command: "C:\\Users\\example\\AppData\\Roaming\\npm\\coven.cmd",
+      fixedArgs: [],
+      unresolvedWindowsShim: true,
+    }),
+    /could not safely resolve the Coven Windows command shim/i,
+  );
+});
+
+test("Windows daemon launch is hidden, shell-free, and signals the native wrapper", async () => {
+  const child = fakeChild();
+  let seen: { command: string; args: string[]; options: Record<string, unknown> } | undefined;
+  const result = await startLocalDaemon({
+    restart: true,
+    probe: async () => ({ ok: true }),
+    platform: "win32",
+    launchCommand: () => ({ command: process.execPath, args: ["coven.js", "daemon", "start"], shell: false }),
+    spawnEnvironment: () => ({ PATH: "C:\\Windows\\System32" }),
+    spawnImpl: (command, args, options) => {
+      seen = { command, args, options: options as Record<string, unknown> };
+      return child;
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.launchMode, "direct");
+  assert.equal(seen?.options.windowsHide, true);
+  assert.equal(seen?.options.shell, false);
+  assert.equal(seen?.options.detached, false);
+  assert.equal(
+    (seen?.options.env as NodeJS.ProcessEnv).COVEN_WINDOWS_HIDE_NATIVE_WINDOW,
+    "1",
+  );
+});
+
+test("an injected shell fallback is refused before spawn", async () => {
+  let spawnCalls = 0;
+  const result = await startLocalDaemon({
+    restart: true,
+    probe: async () => ({ ok: false }),
+    platform: "win32",
+    launchCommand: () => ({ command: "coven.cmd", args: ["daemon", "start"], shell: true }),
+    spawnImpl: () => {
+      spawnCalls += 1;
+      return fakeChild();
+    },
+  });
+  assert.equal(spawnCalls, 0);
+  assert.equal(result.ok, false);
+  assert.equal(result.code, "spawn_failed");
+  assert.equal(result.launchMode, "direct");
+  assert.match(result.error, /could not safely resolve the Coven Windows command shim/i);
+});
+
 test("a readiness timeout terminates the Windows launch tree", async () => {
   const child = fakeChild();
   let cleanupCalls = 0;
@@ -261,7 +328,7 @@ test("a readiness timeout terminates the Windows launch tree", async () => {
     status: 504,
     readinessAttempts: 3,
     elapsedMs: result.elapsedMs,
-    launchMode: "shell",
+    launchMode: "direct",
     cleanup: { attempted: true, completed: true, mode: "windows-tree" },
   });
 });

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -517,7 +517,7 @@ test("a stale runtime discovered after launch is rejected and the owned tree is 
     installedVersion: async () => "1.2.3",
     readHealthDocument: async () => ({
       ok: true,
-      apiVersion: "v1",
+      apiVersion: "coven.daemon.v1",
       covenVersion: "1.2.2",
     }),
     spawnImpl: () => child,

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -1,7 +1,11 @@
 import { execFile, spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { promisify } from "node:util";
 import { callDaemonTarget, localDaemonTarget, socketPath } from "./coven-daemon.ts";
-import { covenLaunchCommand } from "./coven-bin.ts";
+import {
+  covenLaunchCommand,
+  covenWrapperSpawnEnv,
+  type CovenLaunchCommand,
+} from "./coven-bin.ts";
 import { covenCliMissingError, isMissingExecutableError } from "./coven-spawn-error.ts";
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
@@ -148,7 +152,7 @@ async function waitForProcessGroupExit(pid: number, timeoutMs: number): Promise<
 
 /**
  * Terminates only the process tree Cave started after readiness has failed a
- * final health check. Windows taskkill owns the shell and all descendants;
+ * final health check. Windows taskkill owns the launcher and all descendants;
  * POSIX launches use an isolated process group so a foreground shell cannot
  * strand its daemon child. This is intentionally not used for a healthy
  * daemon, even if its launcher is still foregrounded.
@@ -229,6 +233,28 @@ type StartLocalDaemonOptions = {
   diagnostics?: DaemonDiagnosticContext;
 };
 
+const WINDOWS_SHIM_LAUNCH_DIAGNOSTIC =
+  "Cave could not safely resolve the Coven Windows command shim. Reinstall or update Coven, then restart Cave and try again.";
+
+/**
+ * Convert Coven discovery into a daemon command that never asks a command
+ * shell to reinterpret paths or arguments. An unknown .cmd/.bat target is not
+ * launchable: cmd.exe would both reintroduce the console popup and make
+ * dynamic argv subject to shell parsing.
+ */
+export function directDaemonLaunchCommand(
+  launch: CovenLaunchCommand = covenLaunchCommand(),
+): { command: string; args: string[]; shell: false } {
+  if (launch.unresolvedWindowsShim) {
+    throw new Error(WINDOWS_SHIM_LAUNCH_DIAGNOSTIC);
+  }
+  return {
+    command: launch.command,
+    args: [...launch.fixedArgs, "daemon", "start"],
+    shell: false,
+  };
+}
+
 export type DaemonLifecycleInspection = {
   status: "running" | "stopped" | "stale" | "unknown";
 };
@@ -255,7 +281,7 @@ async function inspectDaemonLifecycle(
       [...fixedArgs, "daemon", "status", "--json"],
       {
         encoding: "utf8",
-        env: {
+        env: covenWrapperSpawnEnv({
           ...harnessSpawnEnv(),
           ...(diagnostics ? {
             COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
@@ -263,7 +289,7 @@ async function inspectDaemonLifecycle(
             ...(operation != null ? { COVEN_CAVE_DIAGNOSTIC_OPERATION: operation } : {}),
             ...(attempt != null ? { COVEN_CAVE_DIAGNOSTIC_ATTEMPT: String(attempt) } : {}),
           } : {}),
-        },
+        }),
         timeout: 2_500,
         windowsHide: true,
       },
@@ -432,17 +458,7 @@ async function runLocalDaemonStartCore({
   readHealthDocument: readHealthDocumentOverride,
   installedVersion,
   inspectAddress = () => inspectDaemonAddress({ socketPath: socketPath() }),
-  launchCommand = () => {
-    const launch = covenLaunchCommand();
-    return {
-      command: launch.command,
-      args: [...launch.fixedArgs, "daemon", "start"],
-      // An unreadable third-party batch shim cannot be safely decomposed.
-      // Preserve the legacy fallback for that one case; verified npm shims
-      // launch their target directly so paths with spaces remain one argv.
-      shell: launch.unresolvedWindowsShim === true,
-    };
-  },
+  launchCommand = directDaemonLaunchCommand,
   spawnEnvironment = harnessSpawnEnv,
   spawnImpl = spawn,
   terminateLaunchTree = terminateDaemonLaunchTree,
@@ -541,25 +557,47 @@ async function runLocalDaemonStartCore({
     }
   }
 
-  const launchMode = platform === "win32" ? "shell" : "direct";
-  const launch = launchCommand();
+  const launchMode = "direct";
+  let launch: ReturnType<NonNullable<StartLocalDaemonOptions["launchCommand"]>>;
+  try {
+    launch = launchCommand();
+    if (launch.shell) {
+      throw new Error(WINDOWS_SHIM_LAUNCH_DIAGNOSTIC);
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      code: "spawn_failed",
+      error: sanitizeDaemonStartDiagnostic(
+        error instanceof Error ? error.message : WINDOWS_SHIM_LAUNCH_DIAGNOSTIC,
+      ),
+      stdout: "",
+      stderr: "",
+      status: 500,
+      readinessAttempts: restart ? 0 : automatic ? 2 : 1,
+      elapsedMs: Date.now() - startedAt,
+      launchMode,
+    };
+  }
+  const spawnEnv = spawnEnvironment();
   const child = spawnImpl(launch.command, launch.args, {
     stdio: ["ignore", "pipe", "pipe"],
     // POSIX uses an owned process group so timeout cleanup cannot strand a
-    // foreground shell's daemon descendant. Windows owns its shell tree via
+    // foreground launcher's daemon descendant. Windows owns its launch tree via
     // taskkill /T instead, where detached process groups do not provide this.
-    detached: launchMode === "direct",
+    detached: platform !== "win32",
     // The daemon must never hold scoped vault secrets: daemon-launched
     // sessions would inherit them wholesale. Scoped keys flow only through
     // Cave's own per-familiar spawn path (cave-4nu6).
-    env: {
-      ...spawnEnvironment(),
+    env: covenWrapperSpawnEnv({
+      ...spawnEnv,
       COVEN_CAVE_CORRELATION_ID: diagnostics.correlationId,
       COVEN_CAVE_DIAGNOSTIC_GENERATION: String(diagnostics.generation),
       COVEN_CAVE_DIAGNOSTIC_OPERATION: automatic ? "daemon-recovery" : "daemon-start",
       COVEN_CAVE_DIAGNOSTIC_ATTEMPT: "1",
-    },
-    shell: launch.shell ?? false,
+    }, platform),
+    shell: false,
+    windowsHide: true,
   });
   let stdout = "";
   let stderr = "";

--- a/src/lib/daemon-startup-contract.test.ts
+++ b/src/lib/daemon-startup-contract.test.ts
@@ -1,25 +1,34 @@
 // @ts-nocheck
 import assert from "node:assert/strict";
-import { assessDaemonStartupCompatibility } from "./daemon-startup-contract.ts";
+import {
+  assessDaemonStartupCompatibility,
+  COVEN_DAEMON_API_VERSION,
+  isSupportedDaemonApiVersion,
+} from "./daemon-startup-contract.ts";
 
 const healthy = {
   ok: true,
-  apiVersion: "v1",
+  apiVersion: COVEN_DAEMON_API_VERSION,
   covenVersion: "1.2.3",
   daemon: { pid: 1234 },
 };
 
+assert.equal(isSupportedDaemonApiVersion(COVEN_DAEMON_API_VERSION), true);
+
 assert.deepEqual(assessDaemonStartupCompatibility(healthy, "1.2.3"), {
   ok: true,
   daemonVersion: "1.2.3",
-  apiVersion: "v1",
+  apiVersion: COVEN_DAEMON_API_VERSION,
 });
 
-assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion: "v2" }, "1.2.3"), {
-  ok: false,
-  code: "unsupported_api",
-  diagnostic: "The running Coven daemon uses an incompatible API. Update Coven, then restart the daemon.",
-});
+for (const apiVersion of ["1", "v1", "coven.daemon.v2", ` ${COVEN_DAEMON_API_VERSION} `, null, 1]) {
+  assert.equal(isSupportedDaemonApiVersion(apiVersion), false);
+  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion }, "1.2.3"), {
+    ok: false,
+    code: "unsupported_api",
+    diagnostic: "The running Coven daemon uses an incompatible API. Update Coven, then restart the daemon.",
+  });
+}
 
 assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "1.2.2" }, "1.2.3"), {
   ok: false,

--- a/src/lib/daemon-startup-contract.test.ts
+++ b/src/lib/daemon-startup-contract.test.ts
@@ -21,6 +21,14 @@ assert.deepEqual(assessDaemonStartupCompatibility(healthy, "1.2.3"), {
   apiVersion: COVEN_DAEMON_API_VERSION,
 });
 
+for (const ok of [undefined, false, null, 1, "true"]) {
+  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, ok }, "1.2.3"), {
+    ok: false,
+    code: "invalid_health",
+    diagnostic: "The local Coven daemon did not publish a usable readiness document. Restart Coven and try again.",
+  });
+}
+
 for (const apiVersion of ["1", "v1", "coven.daemon.v2", ` ${COVEN_DAEMON_API_VERSION} `, null, 1]) {
   assert.equal(isSupportedDaemonApiVersion(apiVersion), false);
   assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion }, "1.2.3"), {

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -35,7 +35,7 @@ export function assessDaemonStartupCompatibility(
   health: DaemonStartupHealth | null | undefined,
   installedVersion: string | null,
 ): DaemonStartupCompatibility {
-  if (!health || health.ok === false || typeof health !== "object") {
+  if (!health || typeof health !== "object" || health.ok !== true) {
     return {
       ok: false,
       code: "invalid_health",

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -1,7 +1,13 @@
 import { exactSemver } from "./exact-semver.ts";
 
-/** The named daemon API versions Cave can safely adopt. */
-export const SUPPORTED_DAEMON_API_VERSIONS = new Set(["1", "v1"]);
+/** The exact named daemon API contract Cave can safely adopt. */
+export const COVEN_DAEMON_API_VERSION = "coven.daemon.v1";
+
+export function isSupportedDaemonApiVersion(
+  value: unknown,
+): value is typeof COVEN_DAEMON_API_VERSION {
+  return value === COVEN_DAEMON_API_VERSION;
+}
 
 export type DaemonStartupHealth = {
   ok?: unknown;
@@ -37,8 +43,8 @@ export function assessDaemonStartupCompatibility(
     };
   }
 
-  const apiVersion = typeof health.apiVersion === "string" ? health.apiVersion.trim() : "";
-  if (!SUPPORTED_DAEMON_API_VERSIONS.has(apiVersion)) {
+  const apiVersion = health.apiVersion;
+  if (!isSupportedDaemonApiVersion(apiVersion)) {
     return {
       ok: false,
       code: "unsupported_api",

--- a/src/lib/harness-spawn-env.test.ts
+++ b/src/lib/harness-spawn-env.test.ts
@@ -221,7 +221,11 @@ assert.doesNotMatch(chatSendSource, /covenSpawnEnv/, "chat/send no longer forwar
 // the env by familiar, and every caller hands it a familiar id — a runner that
 // scopes correctly is worthless if a caller passes nothing.
 const oneShotSource = read("./server/coven-oneshot.ts");
-assert.match(oneShotSource, /env: harnessSpawnEnv\(familiarId\)/, "one-shot harness spawn is familiar-scoped");
+assert.match(
+  oneShotSource,
+  /env: covenWrapperSpawnEnv\(harnessSpawnEnv\(familiarId\)\)/,
+  "one-shot Coven wrapper spawn stays familiar-scoped and opts into hidden native launch",
+);
 assert.doesNotMatch(oneShotSource, /covenSpawnEnv/);
 
 const enrichSource = read("../app/api/board/enrich-steps/route.ts");
@@ -241,7 +245,11 @@ assert.match(
 assert.doesNotMatch(rewriteSource, /covenSpawnEnv/);
 
 const automationSource = read("./server/automation-runner.ts");
-assert.match(automationSource, /env: harnessSpawnEnv\(\)/, "automation runs no longer inherit the full process env");
+assert.match(
+  automationSource,
+  /env: codexManagedPackageSpawnEnv\(\s*dependencies\.env \?\? harnessSpawnEnv\(\),\s*invocation\.managedPackage/,
+  "automation runs keep the scoped harness env while adding only the validated Codex package contract",
+);
 
 const assistSource = read("./server/assist-runner.ts");
 assert.match(assistSource, /env: harnessSpawnEnv\(\)/, "assist runs no longer inherit the full process env");
@@ -249,8 +257,8 @@ assert.match(assistSource, /env: harnessSpawnEnv\(\)/, "assist runs no longer in
 const daemonStartSource = read("./daemon-start.ts");
 assert.match(
   daemonStartSource,
-  /spawnEnvironment = harnessSpawnEnv[\s\S]*?env: \{\s*\.\.\.spawnEnvironment\(\),[\s\S]*?COVEN_CAVE_CORRELATION_ID/,
-  "the daemon defaults to a scoped environment seam and adds only diagnostic metadata",
+  /spawnEnvironment = harnessSpawnEnv[\s\S]*?const spawnEnv = spawnEnvironment\(\);[\s\S]*?env: covenWrapperSpawnEnv\(\{\s*\.\.\.spawnEnv,[\s\S]*?COVEN_CAVE_CORRELATION_ID/,
+  "the daemon keeps its scoped environment seam, adds only diagnostics, and opts the Coven wrapper into hidden launch",
 );
 assert.doesNotMatch(daemonStartSource, /covenSpawnEnv/);
 

--- a/src/lib/opencoven-tools-status.test.ts
+++ b/src/lib/opencoven-tools-status.test.ts
@@ -1,11 +1,10 @@
 // @ts-nocheck
 // Packaged Cave runs the status module directly on Windows. Reproduce npm's
 // global shim layout (including its extensionless PATH shadow) and verify the
-// API reports the launcher that `where` selected and the version that launcher
-// actually executes.
+// API reports the verified launcher from explicit PATH entries and never lets
+// Windows' cwd-before-PATH search substitute a project-planted executable.
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { openCovenToolStatuses } from "./opencoven-tools-status.ts";
@@ -20,6 +19,7 @@ if (process.platform !== "win32") {
     PATH: process.env.PATH,
     npm_config_prefix: process.env.npm_config_prefix,
   };
+  const originalCwd = process.cwd();
 
   try {
     await mkdir(npmDir, { recursive: true });
@@ -35,6 +35,7 @@ if (process.platform !== "win32") {
       path.join(npmDir, "coven.cmd"),
       'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\cli\\bin\\coven.js" %*\r\n',
     );
+    await copyFile(process.execPath, path.join(root, "coven.exe"));
 
     // In the packaged-server process `npm` is not directly spawnable on
     // Windows (it is a .cmd shim), so the latest-version probe fails closed
@@ -42,16 +43,7 @@ if (process.platform !== "win32") {
     process.env.APPDATA = root;
     delete process.env.npm_config_prefix;
     process.env.PATH = [npmDir, original.PATH].filter(Boolean).join(path.delimiter);
-
-    // `where` sees npm's extensionless shadow and the .cmd launcher. The
-    // status probe must display the latter because it is the spawnable path
-    // that covenLaunchCommandForBinary then resolves without shell mode.
-    const matches = execFileSync("where", ["coven"], { encoding: "utf8", env: process.env })
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map((entry) => path.normalize(entry).toLowerCase());
-    assert.ok(matches.includes(path.join(npmDir, "coven").toLowerCase()), "coven has its npm extensionless PATH shadow");
-    assert.ok(matches.includes(path.join(npmDir, "coven.cmd").toLowerCase()), "coven has its npm .cmd PATH launcher");
+    process.chdir(root);
 
     const tools = await openCovenToolStatuses();
     assert.equal(tools.length, 1, "only coven-cli is a tracked tool after unification");
@@ -60,9 +52,10 @@ if (process.platform !== "win32") {
     assert.deepEqual(
       { binary: cli?.binary, path: cli?.path, current: cli?.current, installed: cli?.installed },
       { binary: "coven", path: path.join(npmDir, "coven.cmd"), current: "0.1.1", installed: true },
-      "Coven CLI status displays the .cmd path selected by where and its own JavaScript target version",
+      "Coven CLI status ignores cwd-planted coven.exe and probes the absolute PATH .cmd target",
     );
   } finally {
+    process.chdir(originalCwd);
     if (original.APPDATA === undefined) delete process.env.APPDATA;
     else process.env.APPDATA = original.APPDATA;
     if (original.PATH === undefined) delete process.env.PATH;

--- a/src/lib/opencoven-tools-status.ts
+++ b/src/lib/opencoven-tools-status.ts
@@ -9,8 +9,10 @@ import {
   type OpenCovenToolState,
 } from "./opencoven-tools-state.ts";
 import {
+  covenBinaryFromEnvironment,
   covenLaunchCommandForBinary,
   covenSpawnEnv,
+  covenWrapperSpawnEnv,
   pickWindowsLauncher,
   refreshCovenSpawnEnv,
 } from "./coven-bin.ts";
@@ -138,9 +140,12 @@ async function commandPath(
   binary: string,
   options: { env?: NodeJS.ProcessEnv; refresh?: boolean; timeoutMs?: number } = {},
 ): Promise<CommandPathResult> {
-  const finder = process.platform === "win32" ? "where" : "which";
   const timeout = options.timeoutMs ?? LOOKUP_TIMEOUT_MS;
   const find = async (env: NodeJS.ProcessEnv): Promise<CommandPathResult> => {
+    if (process.platform === "win32" && binary.toLowerCase() === "coven") {
+      return { path: covenBinaryFromEnvironment(env) };
+    }
+    const finder = process.platform === "win32" ? "where" : "which";
     try {
       const { stdout } = await execFileAsync(finder, [binary], { windowsHide: true, env, timeout });
       const lines = stdout.split(/\r?\n/);
@@ -286,7 +291,11 @@ export async function probeOpenCovenBinaryAt(
     const { stdout, stderr } = await execFileAsync(
       launch.command,
       [...launch.fixedArgs, ...tool.versionArgs],
-      { windowsHide: true, env, timeout: options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS },
+      {
+        windowsHide: true,
+        env: tool.binary === "coven" ? covenWrapperSpawnEnv(env) : env,
+        timeout: options.timeoutMs ?? VERSION_PROBE_TIMEOUT_MS,
+      },
     );
     const version = firstSemver(`${stdout}\n${stderr}`);
     return {
@@ -316,7 +325,11 @@ async function execLatestVersion(
   args: string[],
   options: { env: NodeJS.ProcessEnv; timeout: number; windowsHide: true },
 ): Promise<{ stdout: string }> {
-  const { stdout } = await execFileAsync(command, args, options);
+  const { stdout } = await execFileAsync(command, args, {
+    env: options.env,
+    timeout: options.timeout,
+    windowsHide: true,
+  });
   return { stdout: String(stdout) };
 }
 

--- a/src/lib/server/assist-runner.ts
+++ b/src/lib/server/assist-runner.ts
@@ -142,6 +142,7 @@ export async function runBoundedAssist(opts: {
           cwd: dir,
           stdio: ["pipe", "ignore", "pipe"],
           env: harnessSpawnEnv(),
+          windowsHide: true,
         },
       ]);
       // Keep a bounded stderr tail so a non-zero exit carries its reason

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { EventEmitter, once } from "node:events";
 import { createWriteStream, existsSync } from "node:fs";
-import { copyFile, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import { copyFile, mkdir, mkdtemp, readFile, realpath, rm, symlink, unlink, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough, Writable } from "node:stream";
@@ -310,6 +310,35 @@ test("an unproven Windows Codex shim fails closed before spawn", async () => {
       ),
       /could not safely resolve the Codex Windows command shim/i,
     );
+  }
+});
+
+test("Windows Codex discovery rejects UNC executables and canonicalizes reparse paths", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-reparse-"));
+  const targetDirectory = path.join(directory, "target");
+  const linkDirectory = path.join(directory, "link");
+  const target = path.join(targetDirectory, "codex.exe");
+  try {
+    await mkdir(targetDirectory);
+    await copyFile(process.execPath, target);
+    await symlink(targetDirectory, linkDirectory, process.platform === "win32" ? "junction" : "dir");
+    const invocation = buildCodexExecInvocation(
+      { ...base, model: null, cwds: [directory], prompt: "canonical path" },
+      {
+        env: { NODE_ENV: "test", COVEN_CODEX_BIN: path.join(linkDirectory, "codex.exe") },
+        platform: "win32",
+      },
+    );
+    assert.equal(invocation.command.toLowerCase(), (await realpath(target)).toLowerCase());
+    assert.throws(
+      () => buildCodexExecInvocation(
+        { ...base, model: null, cwds: [directory], prompt: "remote path" },
+        { env: { NODE_ENV: "test", COVEN_CODEX_BIN: "\\\\remote-host\\share\\codex.exe" }, platform: "win32" },
+      ),
+      /Codex CLI was not found/i,
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
   }
 });
 

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -1,6 +1,22 @@
 import assert from "node:assert/strict";
+import { EventEmitter, once } from "node:events";
+import { createWriteStream, existsSync } from "node:fs";
+import { copyFile, mkdir, mkdtemp, readFile, rm, unlink, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough, Writable } from "node:stream";
 import { test } from "node:test";
-import { buildCodexExecInvocation } from "./automation-runner.ts";
+import { spawn, spawnSync, type ChildProcess, type SpawnOptions } from "node:child_process";
+import {
+  buildCodexExecInvocation,
+  codexAutomationFailureSummary,
+  monitorCodexAutomationCompletion,
+  spawnCodexExecInvocation,
+  startCodexExecWithOwnedLog,
+  type CodexPromptDeliveryResult,
+} from "./automation-runner.ts";
+import { codexManagedPackageSpawnEnv } from "../codex-bin.ts";
+import { COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV } from "../coven-bin.ts";
 
 const base = {
   id: "a", name: "A", kind: "cron", status: "ACTIVE" as const, rrule: null,
@@ -8,20 +24,698 @@ const base = {
   skillPath: null, scheduleHuman: "",
 };
 
+async function writeOfficialWindowsCodexFixture(
+  directory: string,
+  arch: "x64" | "arm64" = "x64",
+): Promise<{ shim: string; script: string; native: string; packageRoot: string }> {
+  const packageRoot = path.join(directory, "node_modules", "@openai", "codex");
+  const packageLeaf = `codex-win32-${arch}`;
+  const triple = arch === "x64" ? "x86_64-pc-windows-msvc" : "aarch64-pc-windows-msvc";
+  const script = path.join(packageRoot, "bin", "codex.js");
+  const platformRoot = path.join(packageRoot, "node_modules", "@openai", packageLeaf);
+  const native = path.join(platformRoot, "vendor", triple, "bin", "codex.exe");
+  await Promise.all([
+    mkdir(path.dirname(script), { recursive: true }),
+    mkdir(path.dirname(native), { recursive: true }),
+  ]);
+  await Promise.all([
+    writeFile(script, "console.log('official Codex fixture');\n"),
+    writeFile(path.join(packageRoot, "package.json"), JSON.stringify({
+      name: "@openai/codex",
+      version: "1.2.3",
+      bin: { codex: "bin/codex.js" },
+      optionalDependencies: { [`@openai/${packageLeaf}`]: `npm:@openai/codex@1.2.3-win32-${arch}` },
+    })),
+    writeFile(path.join(platformRoot, "package.json"), JSON.stringify({
+      name: "@openai/codex",
+      version: `1.2.3-win32-${arch}`,
+      os: ["win32"],
+      cpu: [arch],
+    })),
+    writeFile(native, "native executable fixture"),
+  ]);
+  const shim = path.join(directory, "codex.cmd");
+  await writeFile(shim, '"%~dp0\\node_modules\\@openai\\codex\\bin\\codex.js" %*\r\n');
+  return { shim, script, native, packageRoot };
+}
+
+const source = await readFile(new URL("./automation-runner.ts", import.meta.url), "utf8");
+assert.match(
+  source,
+  /const launchEnv = harnessSpawnEnv\(\);[\s\S]*buildCodexExecInvocation\(auto, \{ env: launchEnv \}\)[\s\S]*startCodexExecWithOwnedLog\(inv, logPath, run\.id, \{ env: launchEnv \}\)/,
+  "production resolution and spawn share the same augmented desktop PATH",
+);
+assert.match(
+  source,
+  /const launched = spawnCodexExecInvocation\(invocation, spawnDependencies\);[\s\S]*output = createOutput\(logPath\);[\s\S]*monitorCodexAutomationCompletion/,
+  "a synchronous spawn failure occurs before the log stream exists and every created log is handed to the monitor",
+);
+assert.match(
+  source,
+  /let terminalPersisted = false;[\s\S]*if \(terminalPersisted\) return;[\s\S]*if \(terminalPersisted \|\| !closeSeen \|\| !deliveryResult \|\| !logResult\) return;[\s\S]*child\.once\("error"[\s\S]*child\.once\("close"/,
+  "spawn, prompt-delivery, log, and close outcomes share one monotonic terminal persistence gate",
+);
+
 test("invocation pipes the prompt to codex exec stdin", () => {
   const inv = buildCodexExecInvocation({ ...base, model: null, cwds: ["/repo"], prompt: "do it" });
   assert.equal(inv.args[0], "exec");
   assert.equal(inv.args[inv.args.length - 1], "-");
+  assert.deepEqual(
+    inv.args.slice(1, 7),
+    ["--skip-git-repo-check", "--config", 'approval_policy="never"', "--sandbox", "workspace-write", "-"],
+  );
   assert.equal(inv.cwd, "/repo");
   assert.equal(inv.stdinPrompt, "do it");
+  assert.ok(!inv.args.includes("do it"), "the prompt never crosses the Windows command-line boundary");
   assert.ok(!inv.args.includes("--model"));
 });
 
+test("a normal non-Git Research workspace explicitly bypasses Codex's repository preflight", async () => {
+  const workspace = await mkdtemp(path.join(os.tmpdir(), "cave-research-non-git-"));
+  try {
+    assert.equal(existsSync(path.join(workspace, ".git")), false);
+    const invocation = buildCodexExecInvocation(
+      { ...base, model: null, cwds: [workspace], prompt: "publish the research artifact" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: "/opt/codex" }, platform: "linux" },
+    );
+    assert.equal(invocation.cwd, workspace);
+    assert.deepEqual(
+      invocation.args.slice(0, 3),
+      ["exec", "--skip-git-repo-check", "--config"],
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test("model is passed as --model when set; COVEN_CODEX_BIN overrides the command", () => {
-  process.env.COVEN_CODEX_BIN = "/opt/codex";
-  const inv = buildCodexExecInvocation({ ...base, model: "gpt-5.4", cwds: [], prompt: "x" });
+  const inv = buildCodexExecInvocation(
+    { ...base, model: "gpt-5.4", cwds: [], prompt: "x" },
+    { env: { NODE_ENV: "test", COVEN_CODEX_BIN: "/opt/codex" }, platform: "linux" },
+  );
   assert.equal(inv.command, "/opt/codex");
-  assert.deepEqual(inv.args.slice(0, 3), ["exec", "--model", "gpt-5.4"]);
+  assert.deepEqual(inv.args.slice(-3), ["--model", "gpt-5.4", "-"]);
   assert.equal(typeof inv.cwd, "string");
-  delete process.env.COVEN_CODEX_BIN;
+});
+
+test("an official Windows npm Codex shim resolves directly to its architecture-specific native executable", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-shim-"));
+  const fixture = await writeOfficialWindowsCodexFixture(directory);
+
+  const inv = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [directory], prompt: "unicode \u{1F52E}" },
+    {
+      env: { NODE_ENV: "test", PATH: directory, npm_config_user_agent: "npm/11 node/v24" },
+      platform: "win32",
+      arch: "x64",
+    },
+  );
+  assert.equal(inv.command, fixture.native);
+  assert.equal(inv.args[0], "exec");
+  assert.equal(inv.stdinPrompt, "unicode \u{1F52E}");
+  assert.deepEqual(inv.managedPackage, { root: fixture.packageRoot, manager: "npm" });
+  assert.ok(!inv.args.some((arg) => /\.(?:cmd|js)$/i.test(arg)), "cmd.exe, Node, and its wrapper are not part of argv");
+});
+
+test("direct native Codex launch preserves exactly one official managed-package marker", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-env-"));
+  const fixture = await writeOfficialWindowsCodexFixture(directory);
+  const invocation = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [directory], prompt: "research" },
+    {
+      env: { NODE_ENV: "test", PATH: directory, npm_config_user_agent: "pnpm/10 npm/? node/v24" },
+      platform: "win32",
+      arch: "x64",
+    },
+  );
+  let seenEnv: NodeJS.ProcessEnv | undefined;
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(), stdout: new PassThrough(), stderr: new PassThrough(),
+    pid: 123, exitCode: null, signalCode: null, kill: () => true,
+  }) as unknown as ChildProcess;
+  spawnCodexExecInvocation(invocation, {
+    env: {
+      NODE_ENV: "test",
+      PATH: directory,
+      CODEX_MANAGED_BY_NPM: "stale",
+      CODEX_MANAGED_BY_PNPM: "stale",
+      CODEX_MANAGED_BY_BUN: "stale",
+      [COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV]: "1",
+    },
+    spawnImpl: (_command, _args, options) => {
+      seenEnv = options.env;
+      return child;
+    },
+  });
+  assert.equal(seenEnv?.CODEX_MANAGED_PACKAGE_ROOT, fixture.packageRoot);
+  assert.equal(seenEnv?.CODEX_MANAGED_BY_NPM, "1");
+  assert.equal(seenEnv?.CODEX_MANAGED_BY_PNPM, undefined);
+  assert.equal(seenEnv?.CODEX_MANAGED_BY_BUN, undefined);
+  assert.equal(
+    seenEnv?.[COVEN_WINDOWS_HIDE_NATIVE_WINDOW_ENV],
+    undefined,
+    "direct Codex never inherits Coven's wrapper-only native-window signal",
+  );
+});
+
+test("official pnpm and Bun installs retain their distinct managed-package marker", async () => {
+  const pnpmDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-pnpm-"));
+  const pnpmFixture = await writeOfficialWindowsCodexFixture(pnpmDirectory);
+  await writeFile(path.join(pnpmDirectory, "node_modules", ".modules.yaml"), "virtualStoreDir: .pnpm\n");
+  const pnpmInvocation = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [pnpmDirectory], prompt: "research" },
+    { env: { NODE_ENV: "test", PATH: pnpmDirectory }, platform: "win32", arch: "x64" },
+  );
+  assert.deepEqual(pnpmInvocation.managedPackage, { root: pnpmFixture.packageRoot, manager: "pnpm" });
+  const pnpmEnv = codexManagedPackageSpawnEnv({ NODE_ENV: "test" }, pnpmInvocation.managedPackage);
+  assert.equal(pnpmEnv.CODEX_MANAGED_BY_PNPM, "1");
+  assert.equal(pnpmEnv.CODEX_MANAGED_BY_NPM, undefined);
+  assert.equal(pnpmEnv.CODEX_MANAGED_BY_BUN, undefined);
+
+  const bunDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-bun-"));
+  const bunFixture = await writeOfficialWindowsCodexFixture(bunDirectory);
+  const bunInvocation = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [bunDirectory], prompt: "research" },
+    {
+      env: { NODE_ENV: "test", PATH: bunDirectory, npm_config_user_agent: "bun/1.3.5 npm/? node/v24" },
+      platform: "win32",
+      arch: "x64",
+    },
+  );
+  assert.deepEqual(bunInvocation.managedPackage, { root: bunFixture.packageRoot, manager: "bun" });
+  const bunEnv = codexManagedPackageSpawnEnv({ NODE_ENV: "test" }, bunInvocation.managedPackage);
+  assert.equal(bunEnv.CODEX_MANAGED_BY_BUN, "1");
+  assert.equal(bunEnv.CODEX_MANAGED_BY_NPM, undefined);
+  assert.equal(bunEnv.CODEX_MANAGED_BY_PNPM, undefined);
+});
+
+test("malformed official package layouts and unsupported Windows architectures fail closed", async () => {
+  const unsupportedDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-unsupported-"));
+  const unsupportedFixture = await writeOfficialWindowsCodexFixture(unsupportedDirectory);
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: [unsupportedDirectory], prompt: "x" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: unsupportedFixture.shim }, platform: "win32", arch: "ia32" },
+    ),
+    /could not safely resolve the Codex Windows command shim/i,
+  );
+
+  const missingDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-missing-native-"));
+  const missingFixture = await writeOfficialWindowsCodexFixture(missingDirectory);
+  await unlink(missingFixture.native);
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: [missingDirectory], prompt: "x" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: missingFixture.shim }, platform: "win32", arch: "x64" },
+    ),
+    /could not safely resolve the Codex Windows command shim/i,
+  );
+
+  const malformedDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-malformed-"));
+  const malformedFixture = await writeOfficialWindowsCodexFixture(malformedDirectory);
+  await writeFile(path.join(malformedFixture.packageRoot, "package.json"), JSON.stringify({
+    name: "@openai/codex",
+    version: "1.2.3",
+    bin: { codex: "bin/not-codex.js" },
+    optionalDependencies: { "@openai/codex-win32-x64": "1.2.3" },
+  }));
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: [malformedDirectory], prompt: "x" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: malformedFixture.shim }, platform: "win32", arch: "x64" },
+    ),
+    /could not safely resolve the Codex Windows command shim/i,
+  );
+
+  const wrongPlatformDirectory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-wrong-platform-"));
+  const wrongPlatformFixture = await writeOfficialWindowsCodexFixture(wrongPlatformDirectory);
+  const platformManifest = path.resolve(
+    wrongPlatformFixture.native,
+    "..", "..", "..", "..", "package.json",
+  );
+  await writeFile(platformManifest, JSON.stringify({
+    name: "@openai/codex",
+    version: "1.2.3-win32-x64",
+    os: ["darwin"],
+    cpu: ["arm64"],
+  }));
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: [wrongPlatformDirectory], prompt: "x" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: wrongPlatformFixture.shim }, platform: "win32", arch: "x64" },
+    ),
+    /could not safely resolve the Codex Windows command shim/i,
+  );
+});
+
+test("Finder-style macOS discovery resolves Codex from the supplied augmented PATH", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-macos-path-"));
+  const binary = path.join(directory, "codex");
+  await writeFile(binary, "#!/bin/sh\nexit 0\n");
+  const inv = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [directory], prompt: "research" },
+    { env: { NODE_ENV: "test", PATH: directory }, platform: "darwin" },
+  );
+  assert.equal(inv.command, binary);
+  assert.equal(inv.args[0], "exec");
+});
+
+test("an unproven Windows Codex shim fails closed before spawn", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-unsafe-shim-"));
+  const shim = path.join(directory, "codex.cmd");
+  await writeFile(shim, "@ECHO off\r\nREM unknown third-party launcher\r\n");
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: [directory], prompt: "x" },
+      { env: { NODE_ENV: "test", COVEN_CODEX_BIN: shim }, platform: "win32" },
+    ),
+    /could not safely resolve the Codex Windows command shim/i,
+  );
+  for (const unsafeLauncher of [
+    path.join(directory, "codex"),
+    path.join(directory, "codex.js"),
+  ]) {
+    await writeFile(unsafeLauncher, "unverified launcher");
+    assert.throws(
+      () => buildCodexExecInvocation(
+        { ...base, model: null, cwds: [directory], prompt: "x" },
+        { env: { NODE_ENV: "test", COVEN_CODEX_BIN: unsafeLauncher }, platform: "win32" },
+      ),
+      /could not safely resolve the Codex Windows command shim/i,
+    );
+  }
+});
+
+test("missing Windows discovery fails closed before spawning", () => {
+  assert.throws(
+    () => buildCodexExecInvocation(
+      { ...base, model: null, cwds: ["C:\\repo"], prompt: "x" },
+      { env: { NODE_ENV: "test", PATH: "" }, platform: "win32" },
+    ),
+    /Codex CLI was not found.*official @openai\/codex/i,
+  );
+});
+
+test("Windows never resolves a cwd-planted codex.exe when PATH discovery misses", async (t) => {
+  if (process.platform !== "win32") {
+    t.skip("requires native Windows CreateProcess search semantics");
+    return;
+  }
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-cwd-plant-"));
+  try {
+    await copyFile(process.execPath, path.join(directory, "codex.exe"));
+    assert.throws(
+      () => buildCodexExecInvocation(
+        { ...base, model: null, cwds: [directory], prompt: "x" },
+        {
+          env: { NODE_ENV: "test", PATH: ".", COVEN_CODEX_BIN: "codex.exe" },
+          platform: "win32",
+        },
+      ),
+      /Codex CLI was not found/i,
+      "neither Windows cwd search nor a relative override can select the Research cwd",
+    );
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("spawn is shell-free, hidden on Windows, and writes the complete prompt to stdin", async () => {
+  const prompt = `${"research intent ".repeat(4_500)}\u{1F52E}`;
+  const invocation = buildCodexExecInvocation(
+    { ...base, model: null, cwds: ["/repo"], prompt },
+    { env: { NODE_ENV: "test", COVEN_CODEX_BIN: "/opt/codex" }, platform: "linux" },
+  );
+  let seen: { command: string; args: string[]; options: SpawnOptions } | undefined;
+  let stdin = "";
+  const child = Object.assign(new EventEmitter(), {
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    stderr: new PassThrough(),
+    pid: 123,
+    exitCode: null,
+    signalCode: null,
+    kill: () => true,
+  }) as unknown as ChildProcess;
+  child.stdin?.on("data", (chunk) => { stdin += chunk.toString("utf8"); });
+
+  const launched = spawnCodexExecInvocation(invocation, {
+    env: { NODE_ENV: "test", PATH: "/bin" },
+    spawnImpl: (command, args, options) => {
+      seen = { command, args, options };
+      return child;
+    },
+  });
+
+  assert.equal(seen?.command, "/opt/codex");
+  assert.equal(seen?.options.shell, false);
+  assert.equal(seen?.options.windowsHide, true);
+  assert.equal(stdin, prompt);
+  assert.deepEqual(await launched.promptDelivery, { ok: true });
+  assert.equal(seen?.args.includes(prompt), false);
+  assert.ok(prompt.length > 32_767, "the fixture exceeds Windows' UTF-16 command-line limit");
+});
+
+test("a synchronous spawn failure cannot create an unowned output stream", () => {
+  let outputCreated = false;
+  assert.throws(
+    () => startCodexExecWithOwnedLog(
+      {
+        command: "missing-codex",
+        args: ["exec", "-"],
+        cwd: process.cwd(),
+        stdinPrompt: "research",
+      },
+      path.join(os.tmpdir(), "must-not-open.log"),
+      "run-sync-spawn-failure",
+      {
+        env: process.env,
+        spawnImpl: () => { throw new Error("synchronous CreateProcess failure"); },
+        createOutput: () => {
+          outputCreated = true;
+          return new PassThrough();
+        },
+      },
+    ),
+    /synchronous CreateProcess failure/,
+  );
+  assert.equal(outputCreated, false, "output ownership begins only after spawn succeeds");
+});
+
+test("an asynchronous missing executable closes prompt delivery and persists terminal failure", async () => {
+  const missing = path.join(
+    os.tmpdir(),
+    `cave-codex-does-not-exist-${process.pid}-${Date.now()}`,
+  );
+  const launched = spawnCodexExecInvocation({
+    command: missing,
+    args: ["exec", "-"],
+    cwd: process.cwd(),
+    stdinPrompt: "research",
+  }, { env: process.env });
+  const terminal = new Promise<Record<string, unknown>>((resolve) => {
+    monitorCodexAutomationCompletion(
+      launched.child,
+      launched.promptDelivery,
+      "run-async-spawn-failure",
+      {
+        updateRunImpl: async (_id, update) => {
+          resolve(update);
+          return null;
+        },
+      },
+    );
+  });
+  const timeout = new Promise<never>((_resolve, reject) => {
+    setTimeout(() => reject(new Error("async spawn failure did not settle")), 5_000).unref();
+  });
+  const delivery = await Promise.race([launched.promptDelivery, timeout]);
+  assert.equal(delivery.ok, false, "stdin close makes the failed delivery terminal");
+  const update = await Promise.race([terminal, timeout]);
+  assert.equal(update.status, "failed");
+  assert.match(String(update.summary), /Codex failed.*(?:ENOENT|not found|could not be started)/i);
+});
+
+test("an executable that closes stdin early reports large-prompt EPIPE without an unhandled stream error", async () => {
+  const prompt = "research payload\n".repeat(600_000);
+  const invocation = {
+    command: process.execPath,
+    args: [
+      "--input-type=commonjs",
+      "-e",
+      'require("node:fs").closeSync(0); setTimeout(() => process.exit(0), 150);',
+    ],
+    cwd: process.cwd(),
+    stdinPrompt: prompt,
+  };
+  const launched = spawnCodexExecInvocation(invocation, { env: process.env });
+  const close = once(launched.child, "close");
+  let deliveryTimeout: NodeJS.Timeout | undefined;
+  const delivery = await Promise.race([
+    launched.promptDelivery,
+    new Promise<never>((_resolve, reject) => {
+      deliveryTimeout = setTimeout(() => reject(new Error("prompt delivery did not settle")), 5_000);
+    }),
+  ]).finally(() => clearTimeout(deliveryTimeout));
+  assert.equal(delivery.ok, false, "closing the executable's read end rejects prompt delivery");
+  if (!delivery.ok) assert.match(delivery.error.message, /EPIPE|pipe|write|closed|EINVAL/i);
+  const [code] = await close;
+  assert.equal(code, 0, "the fixture itself exits successfully to exercise the close(0) race");
+  assert.ok(prompt.length > 8_000_000, "the executable fixture crosses the pipe buffer by a wide margin");
+});
+
+test("runtime auth failure outranks an earlier large-prompt EPIPE and preserves exit code", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-runtime-precedence-"));
+  const logPath = path.join(directory, "run.log");
+  const prompt = "research payload\n".repeat(600_000);
+  const invocation = {
+    command: process.execPath,
+    args: [
+      "--input-type=commonjs",
+      "-e",
+      [
+        'setTimeout(() => process.stderr.write("Not logged in. Run codex login.\\n"), 250);',
+        "setTimeout(() => process.exit(1), 400);",
+      ].join(" "),
+    ],
+    cwd: process.cwd(),
+    stdinPrompt: prompt,
+  };
+  const launched = spawnCodexExecInvocation(invocation, {
+    env: process.env,
+    spawnImpl: (command, args, options) => {
+      const child = spawn(command, args, options);
+      queueMicrotask(() => {
+        child.stdin?.destroy(Object.assign(new Error("write EPIPE"), { code: "EPIPE" }));
+      });
+      return child;
+    },
+  });
+  let stderrSeen = false;
+  launched.child.stderr?.once("data", () => { stderrSeen = true; });
+  const terminal = new Promise<Record<string, unknown>>((resolve) => {
+    monitorCodexAutomationCompletion(launched.child, launched.promptDelivery, "run-auth", {
+      output: createWriteStream(logPath),
+      updateRunImpl: async (_id, patch) => {
+        resolve(patch);
+        return null;
+      },
+    });
+  });
+  const delivery = await launched.promptDelivery;
+  assert.equal(delivery.ok, false);
+  assert.equal(stderrSeen, false, "the transport failure settles before the delayed runtime diagnostic");
+  const patch = await terminal;
+  assert.equal(patch.status, "failed");
+  assert.equal(patch.exitCode, 1);
+  assert.match(String(patch.summary), /Not logged in.*codex login/i);
+  assert.doesNotMatch(String(patch.summary), /could not receive the automation prompt/i);
+  assert.match(await readFile(logPath, "utf8"), /Not logged in.*codex login/i);
+});
+
+test("owned stdout/stderr fan-in finishes the complete ordered log before terminal persistence", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "cave-codex-log-fanin-"));
+  const logPath = path.join(directory, "run.log");
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = Object.assign(new EventEmitter(), { stdout, stderr }) as unknown as ChildProcess;
+  let bytesSeenInsideStatusWrite = "";
+  const terminal = new Promise<Record<string, unknown>>((resolve) => {
+    monitorCodexAutomationCompletion(child, Promise.resolve({ ok: true }), "run-fanin", {
+      output: createWriteStream(logPath),
+      updateRunImpl: async (_id, patch) => {
+        bytesSeenInsideStatusWrite = await readFile(logPath, "utf8");
+        resolve(patch);
+        return null;
+      },
+    });
+  });
+
+  stdout.write("stdout-1\n");
+  stderr.write("stderr-1\n");
+  child.emit("close", 0);
+  stdout.end("stdout-2\n");
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(bytesSeenInsideStatusWrite, "", "one finished source cannot close the shared log");
+  stderr.end("stderr-2\n");
+
+  const patch = await terminal;
+  assert.equal(patch.status, "succeeded");
+  assert.equal(
+    bytesSeenInsideStatusWrite,
+    "stdout-1\nstderr-1\nstdout-2\nstderr-2\n",
+    "the immediate post-status read observes every staggered byte in event order",
+  );
+});
+
+test("output sink errors are handled and persisted as a sanitized terminal failure", async () => {
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const child = Object.assign(new EventEmitter(), { stdout, stderr }) as unknown as ChildProcess;
+  const output = new Writable({
+    write(_chunk, _encoding, callback) {
+      callback(new Error("disk full at C:\\Users\\Example Person\\research.log"));
+    },
+  });
+  const terminal = new Promise<Record<string, unknown>>((resolve) => {
+    monitorCodexAutomationCompletion(child, Promise.resolve({ ok: true }), "run-log-error", {
+      output,
+      updateRunImpl: async (_id, patch) => {
+        resolve(patch);
+        return null;
+      },
+    });
+  });
+  stdout.end("unwritable output");
+  stderr.end();
+  child.emit("close", 0);
+  const patch = await terminal;
+  assert.equal(patch.status, "failed");
+  assert.match(String(patch.summary), /output log failed.*disk full/i);
+  assert.doesNotMatch(String(patch.summary), /Example Person/);
+});
+
+test("prompt delivery failure is terminal and a later child close(0) cannot overwrite it", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    stderr: new PassThrough(),
+  }) as unknown as ChildProcess;
+  let resolveDelivery!: (result: CodexPromptDeliveryResult) => void;
+  const promptDelivery = new Promise<CodexPromptDeliveryResult>((resolve) => {
+    resolveDelivery = resolve;
+  });
+  const updates: Array<Record<string, unknown>> = [];
+  monitorCodexAutomationCompletion(child, promptDelivery, "run-epipe", {
+    updateRunImpl: async (_id, patch) => {
+      updates.push(patch);
+      return null;
+    },
+  });
+  resolveDelivery({ ok: false, error: Object.assign(new Error("write EPIPE"), { code: "EPIPE" }) });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  child.emit("close", 0);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(updates.length, 1, "terminal persistence is monotonic across delivery/close races");
+  assert.equal(updates[0]?.status, "failed");
+  assert.match(String(updates[0]?.summary), /could not receive.*EPIPE/i);
+});
+
+test("close(0) waits for prompt delivery before deciding run success", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    stderr: new PassThrough(),
+  }) as unknown as ChildProcess;
+  let resolveDelivery!: (result: CodexPromptDeliveryResult) => void;
+  const promptDelivery = new Promise<CodexPromptDeliveryResult>((resolve) => {
+    resolveDelivery = resolve;
+  });
+  const updates: Array<Record<string, unknown>> = [];
+  monitorCodexAutomationCompletion(child, promptDelivery, "run-close-first", {
+    updateRunImpl: async (_id, patch) => {
+      updates.push(patch);
+      return null;
+    },
+  });
+  child.emit("close", 0);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(updates.length, 0, "close alone cannot claim success while stdin delivery is unresolved");
+  resolveDelivery({ ok: false, error: new Error("write EPIPE") });
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(updates.length, 1);
+  assert.equal(updates[0]?.status, "failed");
+  assert.equal(updates[0]?.exitCode, 0, "the transport failure remains distinct from the CLI exit code");
+});
+
+test("terminal persistence retries an asynchronous storage rejection without an unhandled promise", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    stderr: new PassThrough(),
+  }) as unknown as ChildProcess;
+  const calls: Array<Record<string, unknown>> = [];
+  let resolvePersisted!: () => void;
+  const persisted = new Promise<void>((resolve) => { resolvePersisted = resolve; });
+  const reports: string[] = [];
+  monitorCodexAutomationCompletion(child, Promise.resolve({ ok: true }), "run-persist-retry", {
+    updateRunImpl: async (_id, patch) => {
+      calls.push(patch);
+      if (calls.length === 1) throw new Error("temporary atomic write contention");
+      resolvePersisted();
+      return null;
+    },
+    reportPersistenceError: (error) => reports.push(error.message),
+  });
+  child.emit("close", 0);
+  await persisted;
+  assert.equal(calls.length, 2, "one bounded retry preserves the terminal update");
+  assert.deepEqual(calls[1], calls[0], "the retry preserves the authoritative runtime outcome");
+  assert.deepEqual(reports, [], "a recovered write does not emit a false persistence alarm");
+});
+
+test("terminal persistence contains synchronous throws and reports a final async rejection", async () => {
+  const child = Object.assign(new EventEmitter(), {
+    stderr: new PassThrough(),
+  }) as unknown as ChildProcess;
+  let calls = 0;
+  let resolveReported!: (message: string) => void;
+  const reported = new Promise<string>((resolve) => { resolveReported = resolve; });
+  monitorCodexAutomationCompletion(child, Promise.resolve({ ok: true }), "run-persist-failed", {
+    updateRunImpl: (_id, _patch) => {
+      calls += 1;
+      if (calls === 1) throw new Error("synchronous store failure");
+      return Promise.reject(new Error("asynchronous store failure"));
+    },
+    reportPersistenceError: (error) => resolveReported(error.message),
+  });
+  child.emit("close", 0);
+  assert.match(await reported, /asynchronous store failure/);
+  assert.equal(calls, 2, "both persistence failure forms remain inside the bounded retry owner");
+});
+
+test("runtime and authentication failures surface a bounded actionable diagnostic", () => {
+  assert.match(
+    codexAutomationFailureSummary(1, "Not logged in. Run `codex login` and try again."),
+    /Not logged in.*codex login/i,
+  );
+  assert.match(
+    codexAutomationFailureSummary(2, "error: unexpected argument '--future-runtime-flag'"),
+    /unexpected argument.*future-runtime-flag/i,
+  );
+  assert.equal(
+    codexAutomationFailureSummary(127, ""),
+    "Codex exited with code 127. Check the run log for details.",
+  );
+  assert.doesNotMatch(
+    codexAutomationFailureSummary(1, "failed at C:\\Users\\Example Person\\.codex token=synthetic-placeholder"),
+    /Example Person|synthetic-placeholder/,
+    "surfaced stderr never leaks local paths or credentials",
+  );
+});
+
+test("native Windows crosses the installed official shim boundary without launching Node or cmd", (t) => {
+  if (process.platform !== "win32" || !process.env.APPDATA) {
+    t.skip("requires native Windows and an installed official Codex package");
+    return;
+  }
+  const shim = path.join(process.env.APPDATA, "npm", "codex.cmd");
+  if (!existsSync(shim)) {
+    t.skip("official Codex npm shim is not installed");
+    return;
+  }
+  const invocation = buildCodexExecInvocation(
+    { ...base, model: null, cwds: [process.cwd()], prompt: "native boundary" },
+    {
+      env: { ...process.env, COVEN_CODEX_BIN: shim },
+      platform: "win32",
+      arch: process.arch,
+    },
+  );
+  assert.match(invocation.command, /[\\/]vendor[\\/].+[\\/]bin[\\/]codex\.exe$/i);
+  assert.equal(invocation.args[0], "exec");
+  assert.equal(invocation.managedPackage?.root.endsWith(path.join("@openai", "codex")), true);
+
+  const result = spawnSync(invocation.command, ["--version"], {
+    encoding: "utf8",
+    env: codexManagedPackageSpawnEnv(process.env, invocation.managedPackage),
+    shell: false,
+    windowsHide: true,
+  });
+  assert.equal(result.status, 0, result.stderr || result.error?.message);
+  assert.match(result.stdout, /codex/i);
 });

--- a/src/lib/server/automation-runner.test.ts
+++ b/src/lib/server/automation-runner.test.ts
@@ -77,7 +77,10 @@ assert.match(
 );
 
 test("invocation pipes the prompt to codex exec stdin", () => {
-  const inv = buildCodexExecInvocation({ ...base, model: null, cwds: ["/repo"], prompt: "do it" });
+  const inv = buildCodexExecInvocation(
+    { ...base, model: null, cwds: ["/repo"], prompt: "do it" },
+    { env: { NODE_ENV: "test", COVEN_CODEX_BIN: "/opt/codex" }, platform: "linux" },
+  );
   assert.equal(inv.args[0], "exec");
   assert.equal(inv.args[inv.args.length - 1], "-");
   assert.deepEqual(
@@ -131,7 +134,11 @@ test("an official Windows npm Codex shim resolves directly to its architecture-s
     },
   );
   assert.equal(inv.command, fixture.native);
-  assert.equal(inv.args[0], "exec");
+  assert.deepEqual(
+    inv.args.slice(0, 4),
+    ["--config", 'windows.sandbox="unelevated"', "exec", "--skip-git-repo-check"],
+    "native Windows Research enables Codex's supported unelevated workspace-write backend",
+  );
   assert.equal(inv.stdinPrompt, "unicode \u{1F52E}");
   assert.deepEqual(inv.managedPackage, { root: fixture.packageRoot, manager: "npm" });
   assert.ok(!inv.args.some((arg) => /\.(?:cmd|js)$/i.test(arg)), "cmd.exe, Node, and its wrapper are not part of argv");
@@ -707,7 +714,10 @@ test("native Windows crosses the installed official shim boundary without launch
     },
   );
   assert.match(invocation.command, /[\\/]vendor[\\/].+[\\/]bin[\\/]codex\.exe$/i);
-  assert.equal(invocation.args[0], "exec");
+  assert.deepEqual(
+    invocation.args.slice(0, 4),
+    ["--config", 'windows.sandbox="unelevated"', "exec", "--skip-git-repo-check"],
+  );
   assert.equal(invocation.managedPackage?.root.endsWith(path.join("@openai", "codex")), true);
 
   const result = spawnSync(invocation.command, ["--version"], {

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -1,9 +1,17 @@
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "node:child_process";
 import { createWriteStream } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
+import type { Readable, Writable } from "node:stream";
 import { covenHome } from "@/lib/coven-paths";
 import { harnessSpawnEnv } from "../harness-spawn-env.ts";
+import {
+  codexAutomationLaunchCommand,
+  codexBin,
+  codexManagedPackageSpawnEnv,
+  type CodexManagedPackage,
+} from "../codex-bin.ts";
+import { sanitizeAboutDiagnosticText } from "../about-diagnostics.ts";
 import type { CodexAutomation } from "@/lib/codex-automations-types";
 import {
   recordRun,
@@ -17,14 +25,394 @@ export type CodexExecInvocation = {
   args: string[];
   cwd: string;
   stdinPrompt: string;
+  managedPackage?: CodexManagedPackage;
 };
 
+type CodexExecInvocationDependencies = {
+  env?: NodeJS.ProcessEnv;
+  platform?: NodeJS.Platform;
+  arch?: NodeJS.Architecture;
+};
+
+const UNSAFE_CODEX_SHIM_DIAGNOSTIC =
+  "Cave could not safely resolve the Codex Windows command shim. Reinstall or update Codex, then restart Cave and try again.";
+const STDERR_TAIL_BYTES = 2_000;
+
+/** Keep auth/version/runtime failures visible without exposing paths or keys. */
+export function codexAutomationFailureSummary(
+  exitCode: number | null,
+  stderr: string,
+): string {
+  const diagnostic = sanitizeAboutDiagnosticText(stderr.trim());
+  return diagnostic
+    ? `Codex failed: ${diagnostic}`
+    : `Codex exited with code ${exitCode ?? "unknown"}. Check the run log for details.`;
+}
+
 /** Pure: how to invoke `codex exec` for an automation. Unit-tested. */
-export function buildCodexExecInvocation(auto: CodexAutomation): CodexExecInvocation {
-  const command = process.env.COVEN_CODEX_BIN?.trim() || "codex";
-  const args = ["exec", ...(auto.model ? ["--model", auto.model] : []), "-"];
+export function buildCodexExecInvocation(
+  auto: CodexAutomation,
+  dependencies: CodexExecInvocationDependencies = {},
+): CodexExecInvocation {
+  const env = dependencies.env ?? process.env;
+  const platform = dependencies.platform ?? process.platform;
+  const binary = env.COVEN_CODEX_BIN?.trim() || codexBin(env, platform);
+  const launch = codexAutomationLaunchCommand(binary, {
+    env,
+    platform,
+    arch: dependencies.arch,
+  });
+  if (launch.unresolvedWindowsShim) {
+    throw new Error(UNSAFE_CODEX_SHIM_DIAGNOSTIC);
+  }
+  const command = launch.command;
+  const args = [
+    ...launch.fixedArgs,
+    "exec",
+    "--skip-git-repo-check",
+    "--config",
+    'approval_policy="never"',
+    "--sandbox",
+    "workspace-write",
+    ...(auto.model ? ["--model", auto.model] : []),
+    "-",
+  ];
   const cwd = auto.cwds[0] || process.cwd();
-  return { command, args, cwd, stdinPrompt: auto.prompt };
+  return {
+    command,
+    args,
+    cwd,
+    stdinPrompt: auto.prompt,
+    ...(launch.managedPackage ? { managedPackage: launch.managedPackage } : {}),
+  };
+}
+
+type SpawnCodexExecDependencies = {
+  spawnImpl?: (command: string, args: string[], options: SpawnOptions) => ChildProcess;
+  env?: NodeJS.ProcessEnv;
+};
+
+export type CodexPromptDeliveryResult =
+  | { ok: true }
+  | { ok: false; error: Error };
+
+export type SpawnedCodexExecInvocation = {
+  child: ChildProcess;
+  promptDelivery: Promise<CodexPromptDeliveryResult>;
+};
+
+function asError(error: unknown, fallback: string): Error {
+  return error instanceof Error ? error : new Error(fallback);
+}
+
+/**
+ * Spawn one already-resolved Codex invocation without a command shell. Kept
+ * separate from run persistence so Windows launch options and stdin transport
+ * can be regression-tested with a real injected spawn alias.
+ */
+export function spawnCodexExecInvocation(
+  invocation: CodexExecInvocation,
+  dependencies: SpawnCodexExecDependencies = {},
+): SpawnedCodexExecInvocation {
+  const spawnImpl = dependencies.spawnImpl ?? spawn;
+  const child = Reflect.apply(spawnImpl, undefined, [
+    invocation.command,
+    invocation.args,
+    {
+      cwd: invocation.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+      env: codexManagedPackageSpawnEnv(
+        dependencies.env ?? harnessSpawnEnv(),
+        invocation.managedPackage,
+      ),
+      shell: false,
+      windowsHide: true,
+    },
+  ]);
+  // Install the stream error handler before the first byte is written. A
+  // fast-exiting native CLI otherwise turns a large prompt write into an
+  // unhandled EPIPE that can terminate Cave's server process.
+  const promptDelivery = new Promise<CodexPromptDeliveryResult>((resolve) => {
+    const stdin = child.stdin;
+    if (!stdin) {
+      resolve({ ok: false, error: new Error("Codex stdin is unavailable") });
+      return;
+    }
+    let settled = false;
+    const settle = (result: CodexPromptDeliveryResult) => {
+      if (settled) return;
+      settled = true;
+      resolve(result);
+    };
+    // Keep the listener attached after `finish`: a late pipe error must still
+    // be consumed even though it cannot change an already-settled result.
+    stdin.on("error", (error) => {
+      settle({ ok: false, error: asError(error, "Codex prompt delivery failed") });
+    });
+    stdin.once("finish", () => settle({ ok: true }));
+    // Async CreateProcess failures (for example ENOENT) can close the stdin
+    // pipe without emitting either `finish` or `error`. Treat that close as a
+    // failed delivery so the child error/close completion barrier cannot hang.
+    stdin.once("close", () => settle({
+      ok: false,
+      error: new Error("Codex stdin closed before the automation prompt was delivered"),
+    }));
+    try {
+      stdin.end(invocation.stdinPrompt);
+    } catch (error) {
+      settle({ ok: false, error: asError(error, "Codex prompt delivery failed") });
+    }
+  });
+  return { child, promptDelivery };
+}
+
+type UpdateRunImpl = typeof updateRun;
+
+/** Coordinate child exit and stdin delivery into one monotonic terminal run. */
+export function monitorCodexAutomationCompletion(
+  child: ChildProcess,
+  promptDelivery: Promise<CodexPromptDeliveryResult>,
+  runId: string,
+  dependencies: {
+    output?: Writable;
+    updateRunImpl?: UpdateRunImpl;
+    reportPersistenceError?: (error: Error) => void;
+  } = {},
+): void {
+  const updateRunImpl = dependencies.updateRunImpl ?? updateRun;
+  const reportPersistenceError = dependencies.reportPersistenceError ?? ((error: Error) => {
+    const detail = sanitizeAboutDiagnosticText(error.message);
+    console.error(
+      detail
+        ? `AutoResearch could not persist terminal run state: ${detail}`
+        : "AutoResearch could not persist terminal run state.",
+    );
+  });
+  let stderrTail = "";
+  let terminalPersisted = false;
+  let closeSeen = false;
+  let closeCode: number | null = null;
+  let childError: Error | null = null;
+  let deliveryResult: CodexPromptDeliveryResult | null = null;
+  let logResult: CodexPromptDeliveryResult | null = dependencies.output
+    ? null
+    : { ok: true };
+
+  const persist = (patch: Parameters<UpdateRunImpl>[1]) => {
+    if (terminalPersisted) return;
+    terminalPersisted = true;
+    // EventEmitter does not await callbacks. Contain both synchronous throws
+    // and asynchronous storage failures, retry once for transient atomic-write
+    // races, then surface one sanitized diagnostic instead of creating an
+    // unhandled rejection that can terminate Cave's server process.
+    void (async () => {
+      let lastError: Error | null = null;
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        try {
+          await updateRunImpl(runId, patch);
+          return;
+        } catch (error) {
+          lastError = asError(error, "AutoResearch terminal persistence failed");
+        }
+      }
+      try {
+        reportPersistenceError(lastError ?? new Error("AutoResearch terminal persistence failed"));
+      } catch {
+        // A diagnostic callback is observability only and must never escape a
+        // child-process event handler after the persistence error was caught.
+      }
+    })();
+  };
+  const promptFailureSummary = (error: Error) => {
+    const diagnostic = sanitizeAboutDiagnosticText(error.message);
+    return diagnostic
+      ? `Codex could not receive the automation prompt: ${diagnostic}`
+      : "Codex could not receive the automation prompt.";
+  };
+  const persistPromptFailure = (error: Error) => {
+    persist({
+      status: "failed",
+      finishedAt: new Date().toISOString(),
+      ...(closeSeen && closeCode !== null ? { exitCode: closeCode } : {}),
+      summary: promptFailureSummary(error),
+    });
+  };
+
+  const maybePersistTerminal = () => {
+    // Node guarantees `close` after either successful exit or spawn `error`.
+    // Waiting for it lets a real runtime exit code/stderr outrank an earlier
+    // secondary EPIPE without risking a later status overwrite.
+    if (terminalPersisted || !closeSeen || !deliveryResult || !logResult) return;
+    if (childError) {
+      persist({
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        ...(closeCode !== null ? { exitCode: closeCode } : {}),
+        summary: codexAutomationFailureSummary(null, childError.message),
+      });
+      return;
+    }
+    if (closeCode !== 0) {
+      persist({
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        ...(closeCode !== null ? { exitCode: closeCode } : {}),
+        summary: codexAutomationFailureSummary(closeCode, stderrTail),
+      });
+      return;
+    }
+    if (!deliveryResult.ok) {
+      persistPromptFailure(deliveryResult.error);
+      return;
+    }
+    if (!logResult.ok) {
+      const diagnostic = sanitizeAboutDiagnosticText(logResult.error.message);
+      persist({
+        status: "failed",
+        finishedAt: new Date().toISOString(),
+        exitCode: 0,
+        summary: diagnostic
+          ? `Codex output log failed: ${diagnostic}`
+          : "Codex output log failed.",
+      });
+      return;
+    }
+    persist({
+      status: "succeeded",
+      finishedAt: new Date().toISOString(),
+      exitCode: 0,
+      summary: "Run completed",
+    });
+  };
+
+  child.stderr?.on("data", (chunk: Buffer | string) => {
+    stderrTail = `${stderrTail}${chunk.toString()}`.slice(-STDERR_TAIL_BYTES);
+  });
+  child.once("error", (error) => {
+    childError = asError(error, "Codex could not be started");
+    maybePersistTerminal();
+  });
+  void promptDelivery.then(
+    (result) => {
+      deliveryResult = result;
+      maybePersistTerminal();
+    },
+    (error) => {
+      deliveryResult = {
+        ok: false,
+        error: asError(error, "Codex prompt delivery failed"),
+      };
+      maybePersistTerminal();
+    },
+  );
+  child.once("close", (code) => {
+    closeSeen = true;
+    closeCode = code;
+    maybeEndOutput();
+    maybePersistTerminal();
+  });
+
+  const output = dependencies.output;
+  const sources = [child.stdout, child.stderr]
+    .filter((source): source is Readable => source !== null);
+  const pendingSources = new Set<Readable>(sources);
+  let outputEndRequested = false;
+  let sourceError: Error | null = null;
+
+  function settleSource(source: Readable, error?: unknown): void {
+    if (!pendingSources.delete(source)) return;
+    if (error !== undefined && sourceError === null) {
+      sourceError = asError(error, "Codex output stream failed");
+    }
+    maybeEndOutput();
+  }
+
+  function maybeEndOutput(): void {
+    if (!output || outputEndRequested || logResult || !closeSeen || pendingSources.size > 0) return;
+    outputEndRequested = true;
+    try {
+      output.end();
+    } catch (error) {
+      logResult = { ok: false, error: asError(error, "Codex output log failed") };
+      maybePersistTerminal();
+    }
+  }
+
+  if (output) {
+    output.once("finish", () => {
+      logResult = sourceError
+        ? { ok: false, error: sourceError }
+        : { ok: true };
+      maybePersistTerminal();
+    });
+    output.on("error", (error) => {
+      if (!logResult) {
+        logResult = { ok: false, error: asError(error, "Codex output log failed") };
+      }
+      // Once the sink fails, drain both pipes so the child cannot block on a
+      // full stdout/stderr buffer while we wait for its authoritative close.
+      for (const source of sources) {
+        source.unpipe(output);
+        source.resume();
+      }
+      maybePersistTerminal();
+    });
+    for (const source of sources) {
+      source.once("end", () => settleSource(source));
+      source.once("close", () => settleSource(source));
+      source.once("error", (error) => settleSource(source, error));
+      if (source.readableEnded || source.destroyed) {
+        settleSource(source);
+      } else {
+        source.pipe(output, { end: false });
+      }
+    }
+    maybeEndOutput();
+  }
+}
+
+type OwnedLogLaunchDependencies = SpawnCodexExecDependencies & {
+  createOutput?: (logPath: string) => Writable;
+  updateRunImpl?: UpdateRunImpl;
+};
+
+/** Spawn first, then transfer the newly created log into the completion owner. */
+export function startCodexExecWithOwnedLog(
+  invocation: CodexExecInvocation,
+  logPath: string,
+  runId: string,
+  dependencies: OwnedLogLaunchDependencies = {},
+): SpawnedCodexExecInvocation {
+  const {
+    createOutput = (target) => createWriteStream(/* turbopackIgnore: true */ target, { flags: "a" }),
+    updateRunImpl,
+    ...spawnDependencies
+  } = dependencies;
+  // A synchronous spawn failure happens before the output factory is called,
+  // so there is no unowned stream that can leak or emit a delayed open error.
+  const launched = spawnCodexExecInvocation(invocation, spawnDependencies);
+  let output: Writable | undefined;
+  try {
+    output = createOutput(logPath);
+    monitorCodexAutomationCompletion(
+      launched.child,
+      launched.promptDelivery,
+      runId,
+      { output, ...(updateRunImpl ? { updateRunImpl } : {}) },
+    );
+    return launched;
+  } catch (error) {
+    if (output) {
+      output.on("error", () => undefined);
+      output.destroy();
+    }
+    // If output ownership setup itself fails after a successful spawn, drain
+    // and stop the child rather than leaving it blocked on an unread pipe.
+    launched.child.stdout?.resume();
+    launched.child.stderr?.resume();
+    try { launched.child.kill(); } catch { /* child already settled */ }
+    throw error;
+  }
 }
 
 function logDir(): string {
@@ -34,9 +422,8 @@ function logDir(): string {
 /**
  * Fire-and-forget: record a `running` run, spawn `codex exec` (prompt → stdin,
  * output → log file), and resolve immediately with the running record. The
- * child's close handler flips the record to succeeded/failed. Throws if a run
- * is already in flight for this automation. The spawn is verified manually
- * (CI has no codex binary); only `buildCodexExecInvocation` is unit-tested.
+ * completion barrier flips the record only after prompt delivery, child close,
+ * and durable log settlement. Throws if a run is already in flight.
  */
 export async function startAutomationRun(auto: CodexAutomation): Promise<AutomationRunRecord> {
   if (await hasRunningRun(auto.id)) {
@@ -44,7 +431,11 @@ export async function startAutomationRun(auto: CodexAutomation): Promise<Automat
   }
   await mkdir(/* turbopackIgnore: true */ logDir(), { recursive: true });
   const startedAt = new Date().toISOString();
-  const inv = buildCodexExecInvocation(auto);
+  // Resolve against the same augmented Finder/desktop-safe PATH that the
+  // child receives; otherwise discovery can choose a different Codex than
+  // CreateProcess ultimately launches.
+  const launchEnv = harnessSpawnEnv();
+  const inv = buildCodexExecInvocation(auto, { env: launchEnv });
   const run = await recordRun({
     automationId: auto.id,
     automationName: auto.name,
@@ -55,36 +446,12 @@ export async function startAutomationRun(auto: CodexAutomation): Promise<Automat
   await updateRun(run.id, { logPath });
 
   try {
-    const out = createWriteStream(/* turbopackIgnore: true */ logPath, { flags: "a" });
     // No familiar context: automations get shared vault keys only, and the
     // explicit env replaces the previous implicit full-process.env inheritance.
     // Command and cwd are runtime configuration, not repository-relative
     // bundle inputs. Reflect keeps Turbopack's child-process tracer from
     // expanding them while preserving Node's spawn contract.
-    const child = Reflect.apply(spawn, undefined, [inv.command, inv.args, {
-      cwd: inv.cwd,
-      stdio: ["pipe", "pipe", "pipe"],
-      env: harnessSpawnEnv(),
-    }]);
-    child.stdout?.pipe(out);
-    child.stderr?.pipe(out);
-    child.stdin?.write(inv.stdinPrompt);
-    child.stdin?.end();
-    child.on("error", (err) => {
-      void updateRun(run.id, {
-        status: "failed",
-        finishedAt: new Date().toISOString(),
-        summary: err instanceof Error ? err.message : "spawn error",
-      });
-    });
-    child.on("close", (code) => {
-      void updateRun(run.id, {
-        status: code === 0 ? "succeeded" : "failed",
-        finishedAt: new Date().toISOString(),
-        exitCode: code ?? undefined,
-        summary: code === 0 ? "Run completed" : `Exited with code ${code}`,
-      });
-    });
+    startCodexExecWithOwnedLog(inv, logPath, run.id, { env: launchEnv });
   } catch (err) {
     await updateRun(run.id, {
       status: "failed",

--- a/src/lib/server/automation-runner.ts
+++ b/src/lib/server/automation-runner.ts
@@ -68,6 +68,12 @@ export function buildCodexExecInvocation(
   const command = launch.command;
   const args = [
     ...launch.fixedArgs,
+    // Codex deliberately downgrades workspace-write to read-only on Windows
+    // when no Windows sandbox backend is selected. Research owns this
+    // noninteractive child, so select the supported unelevated backend
+    // explicitly; other platforms and interactive/user-owned launches keep
+    // their existing policy.
+    ...(platform === "win32" ? ["--config", 'windows.sandbox="unelevated"'] : []),
     "exec",
     "--skip-git-repo-check",
     "--config",

--- a/src/lib/server/coven-oneshot.ts
+++ b/src/lib/server/coven-oneshot.ts
@@ -12,7 +12,7 @@
 import { spawn } from "node:child_process";
 import { stat } from "node:fs/promises";
 
-import { covenLaunchCommand } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenWrapperSpawnEnv } from "@/lib/coven-bin";
 import { harnessSpawnEnv } from "@/lib/harness-spawn-env";
 import { familiarWorkspace } from "@/lib/coven-paths";
 
@@ -61,7 +61,7 @@ export function runCovenOneShot(
         windowsHide: true,
         cwd: cwd ?? process.cwd(),
         stdio: ["ignore", "pipe", "pipe"],
-        env: harnessSpawnEnv(familiarId),
+        env: covenWrapperSpawnEnv(harnessSpawnEnv(familiarId)),
       });
 
       const finish = () => {

--- a/src/lib/server/daemon-connection-snapshot.test.ts
+++ b/src/lib/server/daemon-connection-snapshot.test.ts
@@ -63,7 +63,7 @@ function explicitUnhealthyResponse(): DaemonResponse<unknown> {
 }
 
 function legacyHealthyResponse(): DaemonResponse<unknown> {
-  return { ok: true, status: 200, data: { apiVersion: "1" } };
+  return { ok: true, status: 200, data: { apiVersion: "coven.daemon.v1" } };
 }
 
 function hubUnhealthyResponse(): DaemonResponse<unknown> {

--- a/src/lib/server/daemon-probe.test.ts
+++ b/src/lib/server/daemon-probe.test.ts
@@ -59,7 +59,7 @@ test("preserves legacy healthy payloads without ok", async () => {
     call: async () => ({
       ok: true,
       status: 200,
-      data: { apiVersion: "1" },
+      data: { apiVersion: "coven.daemon.v1" },
     }),
     now: () => 10,
   });

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -1,7 +1,27 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type {
+  DaemonRequest,
+  DaemonResponse,
+  DaemonTarget,
+} from "../coven-daemon.ts";
+import {
+  INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC,
+  isOwnerLocalResearchDaemonTarget,
+  OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC,
+  dispatchResearchDaemonRequest,
+  researchSessionLaunchPolicy,
+  SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC,
+  shouldRequestResearchSessionLaunchPolicy,
+  supportsSessionLaunchPolicy,
+  validatedResearchLaunchAddDirs,
+} from "./research-launch-policy.ts";
 
 const source = readFileSync(new URL("./flow-executor.ts", import.meta.url), "utf8");
+const researchRunner = readFileSync(new URL("./research-mission-runner.ts", import.meta.url), "utf8");
 
 // A flow runs as a plain harness session. Passing `familiarId` natively to the
 // daemon makes some setups try to run the session *as* that familiar and reject
@@ -10,7 +30,7 @@ const source = readFileSync(new URL("./flow-executor.ts", import.meta.url), "utf
 // the daemon body must NOT include familiarId.
 assert.match(
   source,
-  /body: \{ projectRoot, harness: binding\.harness, prompt, launchMode: "nonInteractive" \},/,
+  /body: \{\s*projectRoot,\s*harness: binding\.harness,\s*prompt,\s*launchMode: "nonInteractive",\s*\.\.\.\(launchPolicy \? \{ launchPolicy \} : \{\}\),\s*\},/,
   "flow session spawn must not pass familiarId natively to the daemon",
 );
 assert.match(source, /launchMode: "nonInteractive"/, "flow session output should be plain assistant text, not harness TUI output");
@@ -76,6 +96,166 @@ assert.match(
   source,
   /function flowFamiliarAddDirs[\s\S]*?isValidFamiliarId\(familiarId\)[\s\S]*?realpath\(await familiarWorkspace\(familiarId\)\)/,
   "the workspace grant must be slug-validated and canonicalized before trusting",
+);
+
+assert.equal(
+  supportsSessionLaunchPolicy({ capabilities: { sessionLaunchPolicy: true } }),
+  true,
+  "the exact Coven capability admits the coordinated launch-policy contract",
+);
+for (const health of [
+  null,
+  {},
+  { capabilities: { sessionLaunchPolicy: false } },
+  { capabilities: { sessionUnattendedWorkspaceWrite: true } },
+]) {
+  assert.equal(supportsSessionLaunchPolicy(health), false, "missing, false, and stale capability names fail closed");
+}
+assert.deepEqual(
+  researchSessionLaunchPolicy(["/canonical/research-mission"]),
+  { approval: "never", sandbox: "workspace-write", addDirs: ["/canonical/research-mission"] },
+  "Research receives only the canonical artifact workspace as a secondary write grant",
+);
+assert.match(SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC, /Update Coven, restart the daemon/i);
+assert.match(INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC, /verify the Research artifact workspace/i);
+assert.match(OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC, /owner-local Coven daemon socket/i);
+for (const [socketPath, platform, expected] of [
+  ["\\\\.\\pipe\\coven-daemon-local", "win32", true],
+  ["\\\\remote-host\\pipe\\coven-daemon", "win32", false],
+  ["\\\\localhost\\pipe\\coven-daemon", "win32", false],
+  ["coven-daemon-relative", "win32", false],
+  ["/tmp/coven.sock", "linux", true],
+  ["relative/coven.sock", "linux", false],
+] as const) {
+  assert.equal(
+    isOwnerLocalResearchDaemonTarget(
+      { mode: "local", label: "Local daemon", socketPath },
+      platform,
+    ),
+    expected,
+    `${platform} owner-local classification for ${socketPath}`,
+  );
+}
+assert.match(
+  source,
+  /shouldRequestResearchSessionLaunchPolicy\(\{[\s\S]*trustedLocalResearch: options\.trustedLocalResearch === true,[\s\S]*harness: binding\.harness,[\s\S]*pinnedResearchDaemonTarget = localDaemonTarget\(\);[\s\S]*isOwnerLocalResearchDaemonTarget\(pinnedResearchDaemonTarget\)[\s\S]*OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC[\s\S]*callDaemonTarget<Record<string, unknown>>\(\s*pinnedResearchDaemonTarget,\s*daemonHealthRequest\(\),[\s\S]*supportsSessionLaunchPolicy\(health\.data\)[\s\S]*SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC/,
+  "only trusted local Research probes one pinned local daemon target and old daemons fail closed",
+);
+assert.equal(
+  shouldRequestResearchSessionLaunchPolicy({
+    trustedLocalResearch: true,
+    harness: "codex",
+    sshBound: false,
+    hubAuthority: false,
+  }),
+  true,
+  "the observed local Codex Research path requests the policy",
+);
+for (const harness of ["claude", "opencode", "grok", "hermes", "copilot"]) {
+  assert.equal(
+    shouldRequestResearchSessionLaunchPolicy({
+      trustedLocalResearch: true,
+      harness,
+      sshBound: false,
+      hubAuthority: false,
+    }),
+    false,
+    `${harness} Research preserves its existing no-policy daemon route`,
+  );
+}
+for (const boundary of [
+  { trustedLocalResearch: false, harness: "codex", sshBound: false, hubAuthority: false },
+  { trustedLocalResearch: true, harness: "codex", sshBound: true, hubAuthority: false },
+  { trustedLocalResearch: true, harness: "codex", sshBound: false, hubAuthority: true },
+]) {
+  assert.equal(
+    shouldRequestResearchSessionLaunchPolicy(boundary),
+    false,
+    "manual, SSH, and hub Codex flows preserve their existing no-policy routing",
+  );
+}
+assert.match(
+  source,
+  /validatedResearchLaunchAddDirs\(options\.addDirs \?\? \[\], projectRoot\)[\s\S]*researchSessionLaunchPolicy\(addDirs\)/,
+  "only validated Research directories enter launchPolicy",
+);
+
+{
+  const localTarget = {
+    mode: "local" as const,
+    label: "Local daemon" as const,
+    socketPath: "/tmp/coven-before.sock",
+  };
+  const hubTarget = {
+    mode: "hub" as const,
+    label: "Server hub" as const,
+    url: "https://hub.invalid",
+  };
+  let configuredTarget: DaemonTarget = localTarget;
+  const seen: DaemonTarget[] = [];
+  const launchPolicy = researchSessionLaunchPolicy(["/canonical/research-mission"]);
+  const request = {
+    method: "POST" as const,
+    path: "/api/v1/sessions",
+    body: { launchPolicy },
+  };
+  const dependencies = {
+    callDaemon: async <T>(_request: DaemonRequest): Promise<DaemonResponse<T>> => {
+      seen.push(configuredTarget);
+      return { ok: true, status: 200, data: { id: "dynamic" } as T };
+    },
+    callDaemonTarget: async <T>(
+      target: DaemonTarget,
+      _request: DaemonRequest,
+    ): Promise<DaemonResponse<T>> => {
+      seen.push(target);
+      return { ok: true, status: 200, data: { id: "pinned" } as T };
+    },
+  };
+
+  // Simulate config changing to hub after the local health response but
+  // before session creation. The policy-bearing POST must stay on the exact
+  // local socket whose capability was probed.
+  configuredTarget = hubTarget;
+  await dispatchResearchDaemonRequest(
+    request,
+    { launchPolicy, pinnedTarget: localTarget },
+    dependencies,
+  );
+  assert.deepEqual(seen, [localTarget], "a config race cannot move a policy-bearing POST to a hub");
+
+  seen.length = 0;
+  await dispatchResearchDaemonRequest(request, undefined, dependencies);
+  assert.deepEqual(seen, [hubTarget], "non-policy sessions retain config-aware daemon routing");
+}
+
+const grantRoot = await mkdtemp(path.join(os.tmpdir(), "cave-research-policy-"));
+try {
+  const projectRoot = path.join(grantRoot, "project");
+  const missionWorkspace = path.join(grantRoot, "mission");
+  const notDirectory = path.join(grantRoot, "artifact.txt");
+  await Promise.all([
+    mkdir(projectRoot),
+    mkdir(missionWorkspace),
+    writeFile(notDirectory, "not a directory"),
+  ]);
+  assert.deepEqual(
+    await validatedResearchLaunchAddDirs(
+      [missionWorkspace, missionWorkspace, projectRoot],
+      projectRoot,
+    ),
+    [await realpath(missionWorkspace)],
+    "grants are canonical, deduplicated, and omit projectRoot itself",
+  );
+  assert.equal(await validatedResearchLaunchAddDirs(["relative/path"], projectRoot), null);
+  assert.equal(await validatedResearchLaunchAddDirs([notDirectory], projectRoot), null);
+} finally {
+  await rm(grantRoot, { recursive: true, force: true });
+}
+assert.match(
+  researchRunner,
+  /startFlowSession\(flow, \{\s*projectRoot: options\.projectRoot,\s*addDirs: options\.addDirs,\s*trustedLocalResearch: true,\s*\}\)/,
+  "only the production Research mission adapter requests the internal trusted launch policy",
 );
 
 console.log("flow-executor.test.ts: ok");

--- a/src/lib/server/flow-executor.test.ts
+++ b/src/lib/server/flow-executor.test.ts
@@ -99,17 +99,28 @@ assert.match(
 );
 
 assert.equal(
-  supportsSessionLaunchPolicy({ capabilities: { sessionLaunchPolicy: true } }),
+  supportsSessionLaunchPolicy({
+    ok: true,
+    apiVersion: "coven.daemon.v1",
+    capabilities: { sessionLaunchPolicy: true },
+  }),
   true,
-  "the exact Coven capability admits the coordinated launch-policy contract",
+  "the exact named Coven contract and capability admit the coordinated launch-policy contract",
 );
 for (const health of [
   null,
   {},
-  { capabilities: { sessionLaunchPolicy: false } },
-  { capabilities: { sessionUnattendedWorkspaceWrite: true } },
+  { ok: true, apiVersion: "coven.daemon.v1", capabilities: { sessionLaunchPolicy: false } },
+  { ok: true, apiVersion: "coven.daemon.v1", capabilities: { sessionUnattendedWorkspaceWrite: true } },
+  { ok: true, apiVersion: "v1", capabilities: { sessionLaunchPolicy: true } },
+  { ok: true, apiVersion: "coven.daemon.v2", capabilities: { sessionLaunchPolicy: true } },
+  { ok: false, apiVersion: "coven.daemon.v1", capabilities: { sessionLaunchPolicy: true } },
 ]) {
-  assert.equal(supportsSessionLaunchPolicy(health), false, "missing, false, and stale capability names fail closed");
+  assert.equal(
+    supportsSessionLaunchPolicy(health),
+    false,
+    "missing, failed, legacy, future, and stale health contracts fail closed",
+  );
 }
 assert.deepEqual(
   researchSessionLaunchPolicy(["/canonical/research-mission"]),

--- a/src/lib/server/flow-executor.ts
+++ b/src/lib/server/flow-executor.ts
@@ -6,7 +6,12 @@ import {
   setSessionTitle,
   type CaveTravelQueueItem,
 } from "@/lib/cave-config";
-import { callDaemon, extractDaemonError } from "@/lib/coven-daemon";
+import {
+  callDaemon,
+  callDaemonTarget,
+  extractDaemonError,
+  localDaemonTarget,
+} from "@/lib/coven-daemon";
 import { catalogNode } from "@/lib/flow/flow-catalog";
 import {
   flowRunRedactsData,
@@ -38,6 +43,18 @@ import { isSshRuntime } from "@/lib/familiar-runtime";
 import { hermesProfileDaemonLaunchBlockReason } from "@/lib/hermes-profiles";
 import { isAllowedHarness, normalizeProjectRoot } from "@/lib/server/session-security";
 import { travelLocalQueueStatus } from "@/lib/travel-offline-queue";
+import { daemonHealthRequest } from "@/lib/server/daemon-health-request";
+import {
+  INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC,
+  isOwnerLocalResearchDaemonTarget,
+  OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC,
+  researchSessionLaunchPolicy,
+  SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC,
+  shouldRequestResearchSessionLaunchPolicy,
+  supportsSessionLaunchPolicy,
+  dispatchResearchDaemonRequest,
+  validatedResearchLaunchAddDirs,
+} from "@/lib/server/research-launch-policy";
 
 export type StartFlowSessionResult = {
   ok: boolean;
@@ -119,6 +136,12 @@ export async function startFlowSession(
      * prompt, so an untrusted workspace write hard-fails.
      */
     addDirs?: string[];
+    /**
+     * Internal trust marker set only by the Research mission runner. It is not
+     * accepted from flow API request bodies. Local daemon sessions must prove
+     * the explicit launch-policy capability before receiving the policy.
+     */
+    trustedLocalResearch?: true;
   } = {},
 ): Promise<StartFlowSessionResult> {
   const blocked = flowRunBlockReason(flow, options.targetNodeId);
@@ -304,7 +327,58 @@ export async function startFlowSession(
     };
   }
 
-  const res = await callDaemon<{ id: string; status: string }>({
+  let launchPolicy: ReturnType<typeof researchSessionLaunchPolicy> | undefined;
+  let pinnedResearchDaemonTarget: ReturnType<typeof localDaemonTarget> | undefined;
+  if (shouldRequestResearchSessionLaunchPolicy({
+    trustedLocalResearch: options.trustedLocalResearch === true,
+    harness: binding.harness,
+    sshBound,
+    hubAuthority,
+  })) {
+    const addDirs = await validatedResearchLaunchAddDirs(options.addDirs ?? [], projectRoot);
+    if (!addDirs) {
+      return {
+        ok: false,
+        status: 409,
+        error: INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC,
+      };
+    }
+    // Pin one authority before the capability probe. `callDaemon()` reloads
+    // config for every request; a concurrent local -> hub config change must
+    // never move the later policy-bearing POST across that trust boundary.
+    pinnedResearchDaemonTarget = localDaemonTarget();
+    if (!isOwnerLocalResearchDaemonTarget(pinnedResearchDaemonTarget)) {
+      return {
+        ok: false,
+        status: 409,
+        error: OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC,
+      };
+    }
+    const health = await callDaemonTarget<Record<string, unknown>>(
+      pinnedResearchDaemonTarget,
+      daemonHealthRequest(),
+    );
+    if (!health.ok) {
+      if (health.status === 0) {
+        return { ok: false, unavailable: true, error: "daemon offline" };
+      }
+      return {
+        ok: false,
+        error: extractDaemonError(health) ?? health.error ?? `daemon http ${health.status}`,
+        status: health.status || 502,
+      };
+    }
+    if (!supportsSessionLaunchPolicy(health.data)) {
+      return {
+        ok: false,
+        status: 409,
+        error: SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC,
+      };
+    }
+    launchPolicy = researchSessionLaunchPolicy(addDirs);
+  }
+
+  const sessionRequest = {
     method: "POST",
     path: "/api/v1/sessions",
     // Spawn a plain harness session (no native `familiarId`), the same way task
@@ -316,9 +390,22 @@ export async function startFlowSession(
     // harness TUI. The familiar is already described in the compiled prompt and
     // is mirrored into cave-state below via recordSessionFamiliar, so attribution
     // and the run→familiar link survive.
-    body: { projectRoot, harness: binding.harness, prompt, launchMode: "nonInteractive" },
+    body: {
+      projectRoot,
+      harness: binding.harness,
+      prompt,
+      launchMode: "nonInteractive",
+      ...(launchPolicy ? { launchPolicy } : {}),
+    },
     timeoutMs: 8000,
-  });
+  } as const;
+  const res = await dispatchResearchDaemonRequest<{ id: string; status: string }>(
+    sessionRequest,
+    launchPolicy
+      ? { launchPolicy, pinnedTarget: pinnedResearchDaemonTarget! }
+      : undefined,
+    { callDaemon, callDaemonTarget },
+  );
 
   if (!res.ok || !res.data?.id) {
     if (res.status === 0) {

--- a/src/lib/server/managed-node-toolchain.ts
+++ b/src/lib/server/managed-node-toolchain.ts
@@ -40,7 +40,7 @@ export type ManagedNodeProbe =
 type ManagedNodeProbeExec = (
   file: string,
   args: readonly string[],
-  options: { env: NodeJS.ProcessEnv; timeout: number },
+  options: { env: NodeJS.ProcessEnv; timeout: number; windowsHide: true },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 function isProbeTimeout(error: unknown): boolean {
@@ -58,7 +58,7 @@ async function runManagedNodeProbe(
   timeout: number,
 ): Promise<{ stdout: string; stderr: string }> {
   try {
-    return await run(file, args, { env, timeout });
+    return await run(file, args, { env, timeout, windowsHide: true });
   } catch (error) {
     if (!isProbeTimeout(error)) throw error;
     throw new Error(

--- a/src/lib/server/openclaw-device-credentials.ts
+++ b/src/lib/server/openclaw-device-credentials.ts
@@ -129,10 +129,10 @@ function decodePayload(secret: string): unknown {
 function defaultRunSecurity(args: string[], input?: string): SecurityResult {
   try {
     const stdout = execFileSync(SECURITY_BIN, args, {
+      ...(input === undefined ? {} : { input }),
       windowsHide: true,
       encoding: "utf8",
       stdio: ["pipe", "pipe", "pipe"],
-      ...(input === undefined ? {} : { input }),
     });
     return { status: 0, stdout };
   } catch (error) {

--- a/src/lib/server/research-launch-policy.ts
+++ b/src/lib/server/research-launch-policy.ts
@@ -5,6 +5,7 @@ import type {
   DaemonResponse,
   DaemonTarget,
 } from "@/lib/coven-daemon";
+import { isSupportedDaemonApiVersion } from "../daemon-startup-contract.ts";
 
 export const SESSION_LAUNCH_POLICY_CAPABILITY = "sessionLaunchPolicy";
 
@@ -23,10 +24,15 @@ export type ResearchSessionLaunchPolicy = {
   addDirs: string[];
 };
 
-/** Read the named opt-in defensively; missing and non-boolean values fail closed. */
+/** Require the exact daemon contract and named opt-in; every mismatch fails closed. */
 export function supportsSessionLaunchPolicy(health: unknown): boolean {
   if (!health || typeof health !== "object" || Array.isArray(health)) return false;
-  const capabilities = (health as { capabilities?: unknown }).capabilities;
+  const healthRecord = health as { ok?: unknown; apiVersion?: unknown; capabilities?: unknown };
+  if (
+    healthRecord.ok !== true
+    || !isSupportedDaemonApiVersion(healthRecord.apiVersion)
+  ) return false;
+  const capabilities = healthRecord.capabilities;
   return Boolean(
     capabilities
     && typeof capabilities === "object"

--- a/src/lib/server/research-launch-policy.ts
+++ b/src/lib/server/research-launch-policy.ts
@@ -1,0 +1,146 @@
+import { realpath, stat } from "node:fs/promises";
+import path from "node:path";
+import type {
+  DaemonRequest,
+  DaemonResponse,
+  DaemonTarget,
+} from "@/lib/coven-daemon";
+
+export const SESSION_LAUNCH_POLICY_CAPABILITY = "sessionLaunchPolicy";
+
+export const SESSION_LAUNCH_POLICY_REQUIRED_DIAGNOSTIC =
+  "This Coven daemon cannot safely run unattended Research with workspace writes. Update Coven, restart the daemon, and try again.";
+
+export const INVALID_RESEARCH_WRITE_GRANT_DIAGNOSTIC =
+  "Cave could not verify the Research artifact workspace for unattended writes. Retry in the mission workspace, or recreate the mission if its workspace was removed.";
+
+export const OWNER_LOCAL_RESEARCH_DAEMON_REQUIRED_DIAGNOSTIC =
+  "Unattended Research writes require the owner-local Coven daemon socket. Remove the remote COVEN_SOCKET override, restart Cave, and try again.";
+
+export type ResearchSessionLaunchPolicy = {
+  approval: "never";
+  sandbox: "workspace-write";
+  addDirs: string[];
+};
+
+/** Read the named opt-in defensively; missing and non-boolean values fail closed. */
+export function supportsSessionLaunchPolicy(health: unknown): boolean {
+  if (!health || typeof health !== "object" || Array.isArray(health)) return false;
+  const capabilities = (health as { capabilities?: unknown }).capabilities;
+  return Boolean(
+    capabilities
+    && typeof capabilities === "object"
+    && !Array.isArray(capabilities)
+    && (capabilities as Record<string, unknown>)[SESSION_LAUNCH_POLICY_CAPABILITY] === true,
+  );
+}
+
+export function shouldRequestResearchSessionLaunchPolicy(input: {
+  trustedLocalResearch: boolean;
+  harness: string;
+  sshBound: boolean;
+  hubAuthority: boolean;
+}): boolean {
+  return input.trustedLocalResearch
+    && input.harness === "codex"
+    && !input.sshBound
+    && !input.hubAuthority;
+}
+
+/** Canonicalize the internal Research-only write grants before daemon trust. */
+export async function validatedResearchLaunchAddDirs(
+  directories: readonly string[],
+  projectRoot: string,
+): Promise<string[] | null> {
+  let canonicalRoot = projectRoot;
+  try {
+    canonicalRoot = await realpath(projectRoot);
+  } catch {
+    // Session root validation remains authoritative if it disappears during
+    // this race. Secondary write grants themselves always fail closed.
+  }
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const directory of directories) {
+    if (typeof directory !== "string" || !path.isAbsolute(directory) || directory.includes("\0")) {
+      return null;
+    }
+    try {
+      const canonical = await realpath(directory);
+      if (!(await stat(canonical)).isDirectory()) return null;
+      if (canonical !== canonicalRoot && !seen.has(canonical)) {
+        seen.add(canonical);
+        result.push(canonical);
+      }
+    } catch {
+      return null;
+    }
+  }
+  return result;
+}
+
+/**
+ * The caller has already canonicalized each directory and proven it exists.
+ * The daemon repeats that validation before applying the sandbox policy.
+ */
+export function researchSessionLaunchPolicy(
+  addDirs: readonly string[],
+): ResearchSessionLaunchPolicy {
+  return {
+    approval: "never",
+    sandbox: "workspace-write",
+    addDirs: [...addDirs],
+  };
+}
+
+type LocalDaemonTarget = Extract<DaemonTarget, { mode: "local" }>;
+
+/**
+ * A target labelled `local` can still contain a remote Windows named-pipe UNC
+ * supplied through COVEN_SOCKET or daemon.json. Only the local-machine pipe
+ * namespace (or an absolute Unix-domain socket path) is an owner-local IPC
+ * authority suitable for the unattended write policy.
+ */
+export function isOwnerLocalResearchDaemonTarget(
+  target: LocalDaemonTarget,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  const socketPath = target.socketPath.trim();
+  if (!socketPath || socketPath.includes("\0")) return false;
+  if (platform === "win32") {
+    const prefix = "\\\\.\\pipe\\";
+    return socketPath.toLowerCase().startsWith(prefix) && socketPath.length > prefix.length;
+  }
+  return path.posix.isAbsolute(socketPath);
+}
+
+/**
+ * Dispatch a session create without allowing a policy-bearing request to
+ * re-resolve daemon authority after its local capability probe. Requests that
+ * do not carry the Research policy retain the normal config-aware route.
+ */
+export function dispatchResearchDaemonRequest<T>(
+  request: DaemonRequest,
+  policy: {
+    launchPolicy: ResearchSessionLaunchPolicy;
+    pinnedTarget: LocalDaemonTarget;
+  } | undefined,
+  dependencies: {
+    callDaemon: <R>(request: DaemonRequest) => Promise<DaemonResponse<R>>;
+    callDaemonTarget: <R>(target: DaemonTarget, request: DaemonRequest) => Promise<DaemonResponse<R>>;
+  },
+): Promise<DaemonResponse<T>> {
+  if (policy) {
+    const body = request.body;
+    if (
+      !body
+      || typeof body !== "object"
+      || Array.isArray(body)
+      || (body as { launchPolicy?: unknown }).launchPolicy !== policy.launchPolicy
+    ) {
+      throw new Error("policy-bearing Research request lost its pinned launch policy");
+    }
+    return dependencies.callDaemonTarget<T>(policy.pinnedTarget, request);
+  }
+  return dependencies.callDaemon<T>(request);
+}

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -185,18 +185,18 @@ test("the default project root is the pre-resolved mission workspace", async () 
   assert.equal(result.status, "running");
 });
 
-test("every launch grants the mission workspace as a harness trust dir", async () => {
-  // A configured project root moves the spawn cwd away from the workspace;
-  // without an --add-dir grant a non-interactive run cannot write there and
-  // the iteration ends with "completed without artifacts/primary.md".
+test("a distinct canonical mission workspace remains the narrow write grant", async () => {
   const grants: Array<string[] | undefined> = [];
+  const roots: Array<string | null> = [];
   const runner = makeResearchMissionRunner(deps({
     startFlow: async (_flow, options) => {
       grants.push(options.addDirs);
+      roots.push(options.projectRoot);
       return { ok: true, run: RUN, sessionId: "session-1", executor: "session" };
     },
   }));
   await runner.createAndStart({ ...INPUT, projectRoot: "/allowed/repo" });
+  assert.deepEqual(roots, ["/allowed/repo"]);
   assert.deepEqual(grants, [["/tmp/research-missions/mission-1"]]);
 });
 

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -564,12 +564,17 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
    */
   const missionStartTarget = async (
     mission: ResearchMission,
-  ): Promise<{ ok: true; projectRoot: string } | { ok: false; error: string }> => {
+  ): Promise<
+    { ok: true; projectRoot: string; missionWorkspace: string }
+    | { ok: false; error: string }
+  > => {
     // Standard landing access: research artifacts always land in the mission
     // workspace under the research landing root — make sure the mission's
     // familiar can reach them from later sessions before this run produces
     // anything. Best-effort by contract: implementations never throw.
     await deps.ensureResearchAccess(mission.familiarId);
+    const workspacePath = deps.missionWorkspacePath(mission.id);
+    const workspace = await deps.resolveProjectRoot(workspacePath) ?? workspacePath;
     if (mission.projectRoot) {
       const resolved = await deps.resolveProjectRoot(mission.projectRoot);
       if (!resolved) {
@@ -580,27 +585,22 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
       }
       const denied = await deps.checkFamiliarRootAccess(mission.familiarId, resolved);
       if (denied) return { ok: false, error: denied };
-      return { ok: true, projectRoot: resolved };
+      return { ok: true, projectRoot: resolved, missionWorkspace: workspace };
     }
-    const workspace = deps.missionWorkspacePath(mission.id);
-    const resolved = await deps.resolveProjectRoot(workspace);
-    return { ok: true, projectRoot: resolved ?? workspace };
+    return { ok: true, projectRoot: workspace, missionWorkspace: workspace };
   };
 
   /**
-   * Start options for one iteration: the resolved run root plus the mission
-   * workspace as a harness-level trust grant. When a configured project root
-   * makes the spawn cwd differ from the workspace, a non-interactive run
-   * cannot prompt for permission — without the grant every workspace write
-   * hard-fails and the iteration ends without artifacts/primary.md. A grant
-   * equal to the spawn cwd is dropped by the flow spawn itself.
-   */
+   * Start options for one iteration. A configured project may be the research
+   * context while artifacts still belong in Cave's canonical mission
+   * workspace, so that verified workspace is the one narrow secondary grant.
+  */
   const missionStartOptions = (
-    mission: ResearchMission,
     projectRoot: string,
+    missionWorkspace: string,
   ): { projectRoot: string; addDirs: string[] } => ({
     projectRoot,
-    addDirs: [deps.missionWorkspacePath(mission.id)],
+    addDirs: missionWorkspace === projectRoot ? [] : [missionWorkspace],
   });
 
   /**
@@ -675,7 +675,10 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     await saveMission(next);
     const target = await missionStartTarget(next);
     const result = target.ok
-      ? await deps.startFlow(buildResearchMissionFlow(next, number), missionStartOptions(next, target.projectRoot))
+      ? await deps.startFlow(
+        buildResearchMissionFlow(next, number),
+        missionStartOptions(target.projectRoot, target.missionWorkspace),
+      )
       : { ok: false, error: target.error };
     next = applyStartResult(next, result, deps.now());
     await saveMission(next);
@@ -719,7 +722,7 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
     const result = target.ok
       ? await deps.startFlow(
         buildResearchMissionFlow(retried, current.number),
-        missionStartOptions(retried, target.projectRoot),
+        missionStartOptions(target.projectRoot, target.missionWorkspace),
       )
       : { ok: false, error: target.error };
     retried = applyStartResult(retried, result, deps.now());
@@ -1304,7 +1307,10 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
         if (TERMINAL_RESEARCH_MISSION_STATUSES.includes(current.status)) return current;
         const target = await missionStartTarget(current);
         const result = target.ok
-          ? await deps.startFlow(buildResearchMissionFlow(current, 1), missionStartOptions(current, target.projectRoot))
+          ? await deps.startFlow(
+            buildResearchMissionFlow(current, 1),
+            missionStartOptions(target.projectRoot, target.missionWorkspace),
+          )
           : { ok: false, error: target.error };
         current = applyStartResult(current, result, deps.now());
         await saveMission(current);
@@ -1425,6 +1431,7 @@ export function makeProductionResearchMissionRunner() {
       return startFlowSession(flow, {
         projectRoot: options.projectRoot,
         addDirs: options.addDirs,
+        trustedLocalResearch: true,
       });
     },
     loadFlowRun: async (id) => {

--- a/src/lib/server/stuck-created-sweep.ts
+++ b/src/lib/server/stuck-created-sweep.ts
@@ -23,7 +23,7 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { sacrificeSessionLocal } from "@/lib/cave-config";
-import { covenLaunchCommand, covenSpawnEnv } from "@/lib/coven-bin";
+import { covenLaunchCommand, covenWrapperSpawnEnv } from "@/lib/coven-bin";
 import { callDaemon } from "@/lib/coven-daemon";
 
 const execFileAsync = promisify(execFile);
@@ -94,7 +94,7 @@ export async function sweepStuckCreatedSessions(opts: {
         const { command, fixedArgs } = covenLaunchCommand();
         await execFileAsync(command, [...fixedArgs, "sacrifice", id, "--yes"], {
           windowsHide: true,
-          env: covenSpawnEnv(),
+          env: covenWrapperSpawnEnv(),
           timeout: SACRIFICE_TIMEOUT_MS,
         });
       } catch {

--- a/src/lib/travel-network-drop-proof.test.ts
+++ b/src/lib/travel-network-drop-proof.test.ts
@@ -31,7 +31,7 @@ function createHubServer(): http.Server {
     const url = req.url ?? "/";
     if (method === "GET" && url === "/api/v1/health") {
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ apiVersion: "1", covenVersion: "test", daemon: { status: "ok" } }));
+      res.end(JSON.stringify({ apiVersion: "coven.daemon.v1", covenVersion: "test", daemon: { status: "ok" } }));
       return;
     }
     if (method === "POST" && url === "/api/v1/sessions") {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -356,6 +356,7 @@ function cliRead(cli: "op" | "dcli", ref: string): string | null {
       stdio: ["pipe", "pipe", "pipe"],
       timeout,
       env: resolverEnv(),
+      windowsHide: true,
     }])).trim();
 
   try {


### PR DESCRIPTION
## Summary

Repairs Cave's client-side Research Desk process-launch boundaries across Windows and macOS and consumes the coordinated Coven daemon contract from OpenCoven/coven#722.

- starts and probes the Coven daemon without a shell, hides app-owned Windows wrapper/native children, and rejects unresolved or cwd-planted launchers
- resolves official Windows Codex npm shims directly to their validated architecture-specific native executable for AutoResearch
- sends AutoResearch prompts through stdin with workspace-write / approval-never policy and supports ordinary non-Git mission workspaces
- gates trusted local Codex Research on the exact owner-local daemon capability and pins the capability probe and session POST to the same target
- adds a semantic child-process ratchet across TypeScript, JavaScript, aliases, injected launchers, Reflect.apply, server.ts, and the generated server.mjs artifact
- hides noninteractive Tauri-owned Windows system children through one tested CREATE_NO_WINDOW helper and absolute System32 paths

## Root cause

The observed Research missions bind the local `codex` familiar, so they do not use Cave's direct Copilot child. Cave submits one `launchMode: "nonInteractive"` session to the detached Coven daemon. Coven previously spawned that console-subsystem harness without `CREATE_NO_WINDOW`, causing Windows to allocate a visible console. macOS has no corresponding automatic Terminal.app allocation for this process pattern.

Cave PR #4413 fixed direct Node `child_process` call sites, but it could not cover the daemon's Rust process creation. Its source ratchet also did not follow injected aliases such as `spawnImpl`, wrapper grandchildren, root `server.ts` / generated `server.mjs`, or native Tauri `Command` calls. This PR closes those Cave-side gaps; OpenCoven/coven#722 closes the provider boundary.

## Process and trust boundaries

- `daemon-start.ts`: verified shim-to-direct launch, no `shell: true`, `windowsHide: true`, exact wrapper opt-in
- Coven wrapper callers: `COVEN_WINDOWS_HIDE_NATIVE_WINDOW=1` only for Cave-owned Coven launches; direct harnesses and generic tools remain scrubbed
- AutoResearch: official Codex package/native validation, shell-free native launch, full prompt over stdin, bounded EPIPE/log/persistence handling
- daemon Research: owner-local IPC capability gate plus exact `{ approval: "never", sandbox: "workspace-write", addDirs: [...] }`; SSH, hub, non-Codex, and untrusted/manual paths cannot opt in
- Windows discovery: only existing absolute override/PATH candidates; relative entries, cwd planting, unresolved shims, and remote UNC candidates fail closed
- Tauri: noninteractive `where.exe`, PowerShell, and shell-open helper children use absolute trusted system paths and `CREATE_NO_WINDOW`; intentional interactive PTYs are unchanged

## Cross-platform behavior

On Windows, app-owned noninteractive children are shell-free and windowless, including the wrapper-to-native boundary. On macOS, the Windows flags are inert; Finder-style PATH augmentation and direct executable discovery remain intact. No interactive PTY or user-owned terminal behavior is suppressed.

The complete daemon-backed Codex prompt moves through stdin in #722. AutoResearch also uses stdin here. GitHub Copilot CLI 1.0.76 exposes only argv prompt input, so direct Copilot's measured Windows UTF-16 bound and fail-closed oversized-input behavior live in companion PR #4524. That PR also owns direct-run cancellation, timeout, shutdown, and descendant-tree quiescence.

A successful harness exit without `artifacts/primary.md` remains a distinct fail-closed artifact error; this PR does not attribute that condition to the terminal-window defect.

## Verification

Local / WSL:

- focused daemon, AutoResearch, launch-policy, mission lifecycle/reconciliation, onboarding/status, managed-node, and launch-route tests
- semantic child-process scanner
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired` — all 1,614 tests wired
- `pnpm build:server` plus server.ts/server.mjs parity
- release-runtime suite 25/25
- `git diff --check`
- full diff secret preflight

Native Windows (Node 24.18 / current branch source):

- AutoResearch 24/24, including installed official Codex shim -> native executable, cwd-planted binary refusal, large-prompt EPIPE, log fan-in, and terminal persistence failures
- daemon start 25/25
- Coven binary/status/onboarding probes green, including cwd planting
- Tauri Windows command tests 3/3 with allocated-console positive control and CREATE_NO_WINDOW negative observation

Native packaged Research Desk verification will be appended from the exact PR head. WSL results are not represented as native proof. No native macOS machine was available; provider CI covers both macOS architectures, while a real Finder-launched Research mission remains an explicit external proof boundary.

### CI

- Provider exact head `35eee3912b9413a8a0394724c06e31fe334912af`: [OpenCoven/coven run 31428041882](https://github.com/OpenCoven/coven/actions/runs/31428041882) — 13/13 jobs green.
- This PR exact head `f3e417b7a0a8a399f1e7be206ca2587d51e236c0`: [Cave run 31432836012](https://github.com/OpenCoven/coven-cave/actions/runs/31432836012) — in progress. Superseded runs exposed two test-only cross-host contracts: 31425800670 had stale scoped-wrapper source shape, and 31427308197 compared mixed Windows/Unix path separators. Both focused signed follow-ups are covered locally.
- Direct lifecycle companion exact head `9ccd0b9502e5036289bc8d11cb6153ba11b39fcb`: [Cave run 31427608010](https://github.com/OpenCoven/coven-cave/actions/runs/31427608010) — in progress.

## Coordination

- Bead: `cave-kza`
- Provider issue: OpenCoven/coven#712
- Unattended policy issue: OpenCoven/coven#713
- Provider PR: OpenCoven/coven#722
- Direct prompt/lifecycle companion: #4524
- Intended merge order after separate authorization: provider #722, this PR, then #4524

No PR was merged, no package was published, and no tag or release was created as part of this work.