### PR TITLE
fix(worktrees): make a deferred sweep distinguishable from a clean one

### DIFF
--- a/scripts/worktree-sweep-prompt.md
+++ b/scripts/worktree-sweep-prompt.md
@@ -19,6 +19,17 @@ always preserve.
 - Check GraphQL quota first: `gh api rate_limit --jq .resources.graphql`. If it is
   nearly exhausted, STOP and report — the patrol will exit 1 with an incomplete
   inventory, and an incomplete inventory must never be treated as "nothing to do".
+
+  **If you stop here, say so unmistakably.** Begin your report with the literal
+  line `SWEEP DEFERRED: quota` and do not describe what a later run might find as
+  though you will still be here to run it — you will not; this process ends when
+  you finish writing. A deferred run is otherwise invisible: the wrapper counts
+  worktrees before and after, sees no change, logs `no change (N -> N)` and exits
+  0, which reads exactly like a healthy sweep that found nothing retirable. That
+  happened on 2026-08-10T15:10 and the run looked clean.
+
+  Do not wait for the reset either. Waiting burns the run, and the scheduler will
+  come back on its own; the next scheduled sweep is the retry.
 - Run `pnpm beads:worktrees:json` (takes several minutes). Skip the pnpm banner
   before the first `{` when parsing. Each item's `lane` field is the
   classification; `counts` is the tally.

--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -124,6 +124,9 @@ echo "[sweep] repo: $REPO"
 echo "[sweep] repo HEAD: $(git rev-parse --short HEAD 2>/dev/null) on $(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
 echo "[sweep] registered worktrees: $before"
 echo "[sweep] --- agent output follows ---"
+# Byte offset of the agent's output, so its report can be inspected afterwards
+# without teeing (stdout is already redirected to the log).
+agent_offset=$(wc -c <"$LOG")
 
 # Tools are scoped deliberately: no Write, no Edit. This job inspects, retires
 # worktrees, and closes beads. It has no business editing source files.
@@ -136,9 +139,21 @@ after=$(git worktree list | wc -l | tr -d ' ')
 echo "[sweep] --- agent exited with status $status ---"
 echo "[sweep] worktrees remaining: $after"
 
+# A run that never assessed anything must not read as one that assessed and
+# found nothing. Both leave the worktree count unchanged, so without this the
+# log line and the (absent) notification are identical — which is how a quota
+# deferral looked like a clean sweep on 2026-08-10T15:10.
+deferred=""
+if tail -c "+$((agent_offset + 1))" "$LOG" | grep -q "^SWEEP DEFERRED"; then
+  deferred="$(tail -c "+$((agent_offset + 1))" "$LOG" | grep -m1 "^SWEEP DEFERRED")"
+fi
+
 # Count the worktrees here rather than trusting the agent's summary — a
 # retirement is a filesystem fact, not a claim.
-if [[ "$status" -ne 0 ]]; then
+if [[ -n "$deferred" ]]; then
+  echo "[sweep] DEFERRED — the patrol did not run: $deferred"
+  echo "[sweep] this run assessed nothing; the next scheduled sweep is the retry"
+elif [[ "$status" -ne 0 ]]; then
   notify "Worktree sweep errored" "Agent exited $status. Check the log."
 elif [[ "$after" -lt "$before" ]]; then
   notify "Worktree sweep: $(( before - after )) retired" \

--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -143,18 +143,27 @@ echo "[sweep] worktrees remaining: $after"
 # found nothing. Both leave the worktree count unchanged, so without this the
 # log line and the (absent) notification are identical — which is how a quota
 # deferral looked like a clean sweep on 2026-08-10T15:10.
+# Only the FIRST non-empty line counts, because the prompt requires the marker
+# there. Matching it anywhere would misread a normal report that merely quotes
+# the phrase — and now that the marker is documented, a report explaining why it
+# did NOT defer is a realistic way to trip that.
 deferred=""
-if tail -c "+$((agent_offset + 1))" "$LOG" | grep -q "^SWEEP DEFERRED"; then
-  deferred="$(tail -c "+$((agent_offset + 1))" "$LOG" | grep -m1 "^SWEEP DEFERRED")"
-fi
+first_line="$(tail -c "+$((agent_offset + 1))" "$LOG" | grep -m1 -v '^[[:space:]]*$' || true)"
+case "$first_line" in
+  "SWEEP DEFERRED"*) deferred="$first_line" ;;
+esac
 
 # Count the worktrees here rather than trusting the agent's summary — a
 # retirement is a filesystem fact, not a claim.
-if [[ -n "$deferred" ]]; then
+# A non-zero exit is checked FIRST and always notifies. Letting the deferral
+# branch swallow it would hide a real failure behind the marker — the same
+# silent-success shape this whole guard exists to close.
+if [[ "$status" -ne 0 ]]; then
+  notify "Worktree sweep errored" "Agent exited $status. Check the log."
+  [[ -n "$deferred" ]] && echo "[sweep] (the run also reported: $deferred)"
+elif [[ -n "$deferred" ]]; then
   echo "[sweep] DEFERRED — the patrol did not run: $deferred"
   echo "[sweep] this run assessed nothing; the next scheduled sweep is the retry"
-elif [[ "$status" -ne 0 ]]; then
-  notify "Worktree sweep errored" "Agent exited $status. Check the log."
 elif [[ "$after" -lt "$before" ]]; then
   notify "Worktree sweep: $(( before - after )) retired" \
     "$before -> $after worktrees. Log: $LOG"


### PR DESCRIPTION
Found on the **first run of the newly versioned sweep** (#4529), 2026-08-10T15:10.

## What happened

The agent checked GraphQL quota, found it nearly exhausted, and correctly declined to run the patrol on a thin pool — exactly what the prompt asks for. The run then logged:

```
[sweep] worktrees remaining: 38
[sweep] no change (38 -> 38); no notification sent
[sweep] end 2026-08-10T15:13:57-05:00
```

Exit 0. No notification. **Identical to a healthy sweep that assessed everything and found nothing retirable.**

The patrol never ran — the run's output contains no lane tally, no `cleanup-ready` count, and no `DEGRADED APPLY` banner. A reader had no way to tell the difference, which is the same silent-success shape as the TCC gap and the stale lock this script already guards against.

## Two changes

Prompt discipline alone would not survive a future agent phrasing its refusal differently, so both sides are covered:

**Prompt** — stopping at the quota check now requires the literal first line `SWEEP DEFERRED: quota`, and explains why: the wrapper measures worktrees before and after, and a deferral is invisible in that measure. It also tells the agent **not** to wait for the reset and **not** to promise a later report — the process ends when it stops writing, and the scheduler is the retry. The observed run said *"I'll report once the patrol returns"*, which it could not.

**Script** — reads the agent's own output back from a recorded byte offset and, on finding the marker, logs `DEFERRED` with the reason instead of `no change`.

## Verification

Exercised the branch both ways: a deferred report is flagged, and an ordinary "nothing was retired" report is **not** false-positived. `pnpm lint` exits 0.

The wrapper still counts worktrees itself for the retirement case — a retirement is a filesystem fact, not a claim — so this adds a signal rather than starting to trust the agent's summary.