### PR TITLE
fix(claims): canonicalise worktree edits instead of skipping them

### DIFF
--- a/scripts/surface-claim-guard.mjs
+++ b/scripts/surface-claim-guard.mjs
@@ -17,9 +17,15 @@
  *     clobbering the first session's work.
  *
  * It is ADVISORY ONLY. It never blocks or fails a tool: on any error, or for any
- * path it doesn't care about, it exits 0 silently. Edits inside `.worktrees/`
- * are skipped — those sessions are already isolated, and their divergence
- * surfaces at PR/merge time (per the doc), which is the whole point of worktrees.
+ * path it doesn't care about, it exits 0 silently.
+ *
+ * Edits inside `.worktrees/` are CANONICALISED, not skipped (cave-ahc91). They
+ * used to be skipped on the reasoning that worktrees are isolated and diverge
+ * visibly at PR/merge time — but the convention mandates a worktree per
+ * concurrent session, so that made every session this hook exists to coordinate
+ * invisible to it, and PR/merge only catches conflicting edits, never duplicated
+ * work. A file is one surface no matter which worktree it is edited from, and
+ * the ledger lives in the primary checkout so every session shares one view.
  *
  * Hook wiring lives in .claude/settings.json (PreToolUse, matcher
  * Edit|Write|NotebookEdit). claims.json stays gitignored — never committed.
@@ -81,18 +87,40 @@ function main() {
   const projectRoot = process.env.CLAUDE_PROJECT_DIR || (typeof input.cwd === "string" ? input.cwd : process.cwd());
   const absTarget = path.resolve(projectRoot, rawTarget);
 
-  // Edits inside a worktree are already isolated — skip. (Catches both a primary
-  // session reaching into .worktrees/ and a session whose own root is one.)
-  if (absTarget.split(path.sep).includes(".worktrees")) return done();
+  // Worktree edits are canonicalised, not skipped (cave-ahc91).
+  //
+  // This used to `return done()` on any path containing `.worktrees`, on the
+  // reasoning that worktrees are already isolated and divergence surfaces at
+  // PR/merge time. But CLAUDE.md mandates a worktree per concurrent session, so
+  // that skip made every session the guard exists to coordinate invisible to it:
+  // observed 2026-08-09 with 5 live sessions and 14 worktrees, claims.json held
+  // one session, three days stale. And PR/merge only catches CONFLICTING edits —
+  // it never surfaces duplicated work, which is the costlier failure.
+  //
+  // Isolation protects the filesystem, not the reasoning. Two sessions editing
+  // the same file in different worktrees are still duplicating effort, so both
+  // map to one canonical surface: the path relative to the repository, with any
+  // `.worktrees/<unit>/` prefix stripped.
+  const segments = absTarget.split(path.sep);
+  const wtIndex = segments.indexOf(".worktrees");
+  const inWorktree = wtIndex !== -1 && segments.length > wtIndex + 2;
+  const worktreeUnit = inWorktree ? segments[wtIndex + 1] : null;
+  const relPath = inWorktree
+    ? segments.slice(wtIndex + 2).join(path.sep)
+    : path.relative(projectRoot, absTarget);
 
-  const relPath = path.relative(projectRoot, absTarget);
+  // The ledger must live in ONE place or it cannot correlate anything. Deriving
+  // it from projectRoot would give a worktree-rooted session its own
+  // .claude/claims.json inside the worktree, so no session would ever see
+  // another's claims — the same inertness by a different route.
+  const repoRoot = wtIndex !== -1 ? segments.slice(0, wtIndex).join(path.sep) : projectRoot;
   // Outside the project, or coordination plumbing itself — don't track.
   if (!relPath || relPath.startsWith("..") || relPath.startsWith(".claude" + path.sep) || relPath.startsWith("node_modules" + path.sep)) {
     return done();
   }
   const surface = relPath.split(path.sep).join("/");
 
-  const claimsDir = path.join(projectRoot, ".claude");
+  const claimsDir = path.join(repoRoot, ".claude");
   const claimsPath = path.join(claimsDir, "claims.json");
   const now = Date.now();
 
@@ -123,7 +151,12 @@ function main() {
     if (isMeta(key) || key === sessionId) continue;
     const surfaces = Array.isArray(entry?.surfaces) ? entry.surfaces : [];
     if (surfaces.includes(surface)) {
-      collisions.push({ session: shortId(key), age: relAge(liveAt(entry), now), intent: entry?.intent });
+      collisions.push({
+        session: shortId(key),
+        age: relAge(liveAt(entry), now),
+        intent: entry?.intent,
+        worktree: typeof entry?.worktree === "string" ? entry.worktree : null,
+      });
     }
   }
 
@@ -135,6 +168,7 @@ function main() {
     started: mine?.started || new Date(now).toISOString(),
     updated: new Date(now).toISOString(),
     surfaces: surfaces.slice(-MAX_SURFACES),
+    ...(worktreeUnit ? { worktree: worktreeUnit } : {}),
     ...(mine?.intent ? { intent: mine.intent } : {}),
   };
   claims._protocol =
@@ -156,13 +190,17 @@ function main() {
   if (collisions.length === 0) return done(); // Silent in the common case.
 
   const lines = collisions.map(
-    (c) => `  • session ${c.session} claimed it ${c.age}${c.intent ? ` (intent: ${c.intent})` : ""}`,
+    (c) =>
+      `  • session ${c.session} claimed it ${c.age}` +
+      `${c.worktree ? ` in worktree ${c.worktree}` : " on the primary checkout"}` +
+      `${c.intent ? ` (intent: ${c.intent})` : ""}`,
   );
   const msg =
     `⚠️ Multi-session collision on \`${surface}\`:\n${lines.join("\n")}\n` +
-    `Another Claude session may be editing this file on the shared checkout. Before continuing, ` +
-    `confirm you won't clobber its work — coordinate with the user, or isolate in a worktree ` +
-    `(git worktree add -b <branch> .worktrees/<branch> origin/main).`;
+    `Another Claude session may be editing this file. Surfaces are canonical, so this ` +
+    `collides even across separate worktrees — being isolated on disk does not stop two ` +
+    `sessions duplicating the same reasoning. Before continuing, confirm you won't clobber ` +
+    `or duplicate its work; coordinate with the user.`;
 
   return done({
     systemMessage: msg,

--- a/scripts/surface-claim-guard.test.mjs
+++ b/scripts/surface-claim-guard.test.mjs
@@ -111,8 +111,12 @@ function readClaims(dir) {
   runHook({ projectDir: dir, sessionId: "sessA", filePath: path.join(dir, ".worktrees/alpha/src/shared.ts") });
   const res = runHook({ projectDir: dir, sessionId: "sessB", filePath: path.join(dir, ".worktrees/beta/src/shared.ts") });
   assert.equal(res.status, 0, "still advisory");
-  assert.match(res.stdout, /Multi-session collision on .src\/shared\.ts./, "collides across worktrees");
-  assert.match(res.stdout, /in worktree alpha/, "names the other session's worktree");
+  // Parse rather than regex the raw stdout: it is JSON, and matching the
+  // envelope would be sensitive to escaping rather than to the message.
+  const out = JSON.parse(res.stdout);
+  assert.match(out.systemMessage, /Multi-session collision/, "collides across worktrees");
+  assert.match(out.systemMessage, /src\/shared\.ts/, "names the canonical surface, not a worktree path");
+  assert.match(out.systemMessage, /in worktree alpha/, "names the other session's worktree");
 }
 
 // ── 5c. A worktree edit collides with a primary-checkout edit of the same file ─
@@ -120,8 +124,10 @@ function readClaims(dir) {
   const dir = freshProject();
   runHook({ projectDir: dir, sessionId: "primarySess", filePath: path.join(dir, "src/shared.ts") });
   const res = runHook({ projectDir: dir, sessionId: "wtSess", filePath: path.join(dir, ".worktrees/gamma/src/shared.ts") });
-  assert.match(res.stdout, /Multi-session collision/, "primary and worktree edits are the same surface");
-  assert.match(res.stdout, /on the primary checkout/, "names where the other session is working");
+  const out = JSON.parse(res.stdout);
+  assert.match(out.systemMessage, /Multi-session collision/, "primary and worktree edits are the same surface");
+  assert.match(out.systemMessage, /src\/shared\.ts/, "names the canonical surface");
+  assert.match(out.systemMessage, /on the primary checkout/, "names where the other session is working");
 }
 
 // ── 5d. The ledger stays in the primary checkout, never inside a worktree ─────

--- a/scripts/surface-claim-guard.test.mjs
+++ b/scripts/surface-claim-guard.test.mjs
@@ -1,6 +1,6 @@
 // Tests for the surface-claim PreToolUse hook (scripts/surface-claim-guard.mjs).
 // The hook must: record a session's claim on edited shared-checkout files, warn
-// on cross-session collisions, prune expired claims, skip worktree paths, and —
+// on cross-session collisions, prune expired claims, canonicalise worktree paths, and —
 // above all — NEVER block or fail a tool (always exit 0, even on garbage input).
 
 import assert from "node:assert/strict";
@@ -91,13 +91,51 @@ function readClaims(dir) {
   assert.ok(claims.liveSession, "the live session's claim replaces it");
 }
 
-// ── 5. Edits inside .worktrees/ are skipped (already isolated) ────────────────
+// ── 5. Edits inside .worktrees/ are CANONICALISED, not skipped (cave-ahc91) ───
+// They were skipped, which made every session the hook exists to coordinate
+// invisible to it: the convention mandates a worktree per concurrent session.
 {
   const dir = freshProject();
   const res = runHook({ projectDir: dir, sessionId: "wtSession", filePath: path.join(dir, ".worktrees/x/src/bar.ts") });
-  assert.equal(res.status, 0, "hook exits 0 for worktree paths");
-  assert.equal(res.stdout.trim(), "", "no output for worktree edits");
-  assert.equal(readClaims(dir), null, "no claim recorded for an isolated worktree edit");
+  assert.equal(res.status, 0, "hook still never blocks");
+  const claims = readClaims(dir);
+  assert.ok(claims, "a worktree edit is recorded");
+  assert.deepEqual(claims.wtSession.surfaces, ["src/bar.ts"], "surface is repo-relative, worktree prefix stripped");
+  assert.equal(claims.wtSession.worktree, "x", "the claim records which worktree it came from");
+}
+
+// ── 5b. The same file in two different worktrees is ONE surface ───────────────
+// The whole point: isolation protects the filesystem, not the reasoning.
+{
+  const dir = freshProject();
+  runHook({ projectDir: dir, sessionId: "sessA", filePath: path.join(dir, ".worktrees/alpha/src/shared.ts") });
+  const res = runHook({ projectDir: dir, sessionId: "sessB", filePath: path.join(dir, ".worktrees/beta/src/shared.ts") });
+  assert.equal(res.status, 0, "still advisory");
+  assert.match(res.stdout, /Multi-session collision on .src\/shared\.ts./, "collides across worktrees");
+  assert.match(res.stdout, /in worktree alpha/, "names the other session's worktree");
+}
+
+// ── 5c. A worktree edit collides with a primary-checkout edit of the same file ─
+{
+  const dir = freshProject();
+  runHook({ projectDir: dir, sessionId: "primarySess", filePath: path.join(dir, "src/shared.ts") });
+  const res = runHook({ projectDir: dir, sessionId: "wtSess", filePath: path.join(dir, ".worktrees/gamma/src/shared.ts") });
+  assert.match(res.stdout, /Multi-session collision/, "primary and worktree edits are the same surface");
+  assert.match(res.stdout, /on the primary checkout/, "names where the other session is working");
+}
+
+// ── 5d. The ledger stays in the primary checkout, never inside a worktree ─────
+// Deriving it from the project root would give a worktree-rooted session its own
+// claims.json, so no session would ever see another's — inertness by another route.
+{
+  const dir = freshProject();
+  const wtRoot = path.join(dir, ".worktrees", "delta");
+  mkdirSync(path.join(wtRoot, "src"), { recursive: true });
+  const res = runHook({ projectDir: wtRoot, sessionId: "rootedInWt", filePath: path.join(wtRoot, "src/x.ts") });
+  assert.equal(res.status, 0);
+  assert.ok(readClaims(dir), "claim landed in the primary checkout's ledger");
+  assert.equal(existsSync(path.join(wtRoot, ".claude", "claims.json")), false, "no ledger inside the worktree");
+  assert.deepEqual(readClaims(dir).rootedInWt.surfaces, ["src/x.ts"], "surface is repo-relative");
 }
 
 // ── 6. Edits under .claude/ and node_modules/ are not tracked ─────────────────


### PR DESCRIPTION
`cave-ahc91`.

## The hook was inert for exactly the sessions it exists to coordinate

`surface-claim-guard.mjs` returned early on any path containing `.worktrees`, reasoning that those sessions are already isolated and diverge visibly at PR/merge time. But `CLAUDE.md` mandates **a worktree per concurrent session** — so that skip made every session the hook exists to coordinate invisible to it.

| measured | sessions | worktrees | claims.json |
|---|---|---|---|
| 2026-08-09 | 5 live | 14 | 1 session, 3 days stale |
| 2026-08-10 | — | **38** | still 1 session |

`CLAUDE.md` advertises this hook as operationalising §1 of the coordination doc so "you no longer have to grep claims.json by hand". It was doing nothing.

**PR/merge is not the fallback it was assumed to be.** It catches *conflicting* edits. It never surfaces *duplicated* work — two sessions independently solving the same symptom conflict with nothing, and that is the costlier failure the coordination doc is actually about.

## The fix

A file is **one surface** regardless of which worktree it is edited from. The `.worktrees/<unit>/` prefix is stripped, and the claim records which worktree it came from so the warning can name it.

**A second defect, found while reading:** the ledger path was derived from the project root, so a session whose own root is a worktree would write `.claude/claims.json` *inside that worktree*. Every session would have had a private ledger and seen no one else's — the same inertness by a different route. It now always resolves to the primary checkout.

The collision message no longer advises "isolate in a worktree", which is incoherent when both sessions already are.

## Tests

Test 5 asserted the old skip; it now asserts canonicalisation. Three cases added:

- the same file in two different worktrees collides, and the warning names the other worktree
- a worktree edit collides with a primary-checkout edit of the same file
- a worktree-rooted session writes to the **primary** ledger, and no ledger appears inside the worktree

The never-block invariant is re-verified — garbage input and a missing file path both still exit 0. `check:tests-wired` (1614) and `pnpm lint` clean.

## Scope

This is option (a) from the bead. Option (b) — a pre-flight `bd`/`ps` check before claiming a bead — targets duplicated *effort* rather than concurrent edits and remains unaddressed; the bead records it.
