### PR TITLE
fix(board): stop URL-derived links overwriting stored Asana/GitHub titles

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -40,6 +40,7 @@ export const SUITES = {
     "src/lib/use-code-rail.test.ts",
     "src/lib/initial-prompt-handoff.test.ts",
     "src/lib/cave-board-retention.test.ts",
+    "src/lib/cave-board-backfill-idempotence.test.ts",
     "src/components/board-retention.test.ts",
     "src/lib/workspace-tiles.test.ts",
     "src/lib/page-drag.test.ts",
@@ -1679,6 +1680,8 @@ const ALIAS_LOADER = new Set([
   // cave-board.ts resolves "@/lib/cave-board-types", "@/lib/task-github" and
   // friends, so the retention suite cannot load without the alias resolver.
   "src/lib/cave-board-retention.test.ts",
+  // same reason: the idempotence suite loads cave-board.ts directly.
+  "src/lib/cave-board-backfill-idempotence.test.ts",
   // the picker imports the module under test, which resolves
   // "@/lib/code-surface" for the shared session-visibility rule.
   "src/lib/code-session-picker.test.ts",

--- a/src/components/asana-task-field.test.ts
+++ b/src/components/asana-task-field.test.ts
@@ -24,10 +24,28 @@ assert.match(boardTypes, /export type CardAsanaLink = \{/, "Task cards expose a 
 assert.match(boardTypes, /asana: CardAsanaLink\[\]/, "Task cards persist structured Asana connections");
 assert.match(boardStore, /normalizeAsanaLinks/, "Board persistence normalizes Asana connections");
 assert.match(boardStore, /asanaLinksFromLinks/, "Board backfill derives Asana connections from bare links");
+// Asserted as separate facts rather than one literal expression: the call is
+// now multi-line, and pinning its exact text made this break on a change that
+// preserved every behaviour it names (cave-0b8t8).
 assert.match(
   boardStore,
-  /const asana = mergeAsanaLinks\(normalizeAsanaLinks\(c\.asana\), \.\.\.asanaLinksFromLinks\(c\.links\)\)/,
-  "Board backfill preserves explicit Asana connections and derives them from link URLs",
+  /const storedAsana = normalizeAsanaLinks\(c\.asana\)/,
+  "Board backfill normalizes the stored Asana connections",
+);
+assert.match(
+  boardStore,
+  /mergeAsanaLinks\(\s*storedAsana,/,
+  "Board backfill preserves explicit Asana connections as the merge base",
+);
+assert.match(
+  boardStore,
+  /asanaLinksFromLinks\(c\.links\)\.filter\(/,
+  "Board backfill still derives Asana connections from link URLs",
+);
+assert.match(
+  boardStore,
+  /sameAsanaTarget\(stored, derived\)/,
+  "a URL-derived Asana link is dropped when a stored link already names that task — otherwise its generated title overwrites the real one on every load (cave-0b8t8)",
 );
 
 // ── API surface ──────────────────────────────────────────────────────────────

--- a/src/components/github-task-field.test.ts
+++ b/src/components/github-task-field.test.ts
@@ -30,10 +30,28 @@ assert.match(
   /normalizeGitHubLinks/,
   "Board persistence should normalize task GitHub connections",
 );
+// Asserted as separate facts rather than one literal expression: the call is
+// now multi-line, and pinning its exact text made this break on a change that
+// preserved every behaviour it names (cave-0b8t8).
 assert.match(
   boardStore,
-  /const github = mergeGitHubLinks\(normalizeGitHubLinks\(c\.github\), \.\.\.gitHubLinksFromLinks\(c\.links\)\)/,
-  "Board backfill should preserve explicit GitHub connections and derive legacy GitHub link URLs",
+  /const storedGitHub = normalizeGitHubLinks\(c\.github\)/,
+  "Board backfill normalizes the stored GitHub connections",
+);
+assert.match(
+  boardStore,
+  /mergeGitHubLinks\(\s*storedGitHub,/,
+  "Board backfill preserves explicit GitHub connections as the merge base",
+);
+assert.match(
+  boardStore,
+  /gitHubLinksFromLinks\(c\.links\)\.filter\(/,
+  "Board backfill still derives legacy GitHub link URLs",
+);
+assert.match(
+  boardStore,
+  /sameGitHubTarget\(stored, derived\)/,
+  "a URL-derived GitHub link is dropped when a stored link already names that item — otherwise its generated title overwrites the real one on every load (cave-0b8t8)",
 );
 assert.match(
   boardCreateApi,

--- a/src/lib/cave-board-backfill-idempotence.test.ts
+++ b/src/lib/cave-board-backfill-idempotence.test.ts
@@ -89,10 +89,10 @@ async function writeBoard(cards: unknown[]): Promise<void> {
       links: ["https://github.com/OpenCoven/coven-cave/pull/4534"],
       github: [
         {
-          id: "github:pull:OpenCoven/coven-cave:4534",
+          id: "github:pr:opencoven/coven-cave:4534",
           url: "https://github.com/OpenCoven/coven-cave/pull/4534",
           repo: "OpenCoven/coven-cave",
-          kind: "pull",
+          kind: "pr",
           number: 4534,
           title: "Fix the claim guard",
         },
@@ -108,6 +108,46 @@ async function writeBoard(cards: unknown[]): Promise<void> {
     "Fix the claim guard",
     "a stored GitHub title must not be replaced by the derived 'repo #number'",
   );
+}
+
+// ── The same GitHub item under two spellings is ONE connection ────────────────
+// Repo identity on GitHub is case-insensitive, and the two links for one item
+// rarely arrive spelled alike: the stored one comes from the API with canonical
+// casing and an api.github.com URL, while the derived one is parsed from
+// whatever a human pasted. taskGitHubLinkFromUrl() copies the repo straight out
+// of the URL path, so a lowercase paste yields a lowercase repo.
+//
+// The URL fallback cannot reconcile those two — the URLs genuinely differ — so
+// the repo/kind/number identity check is the ONLY thing that can see them as one
+// item. Comparing the repo case-sensitively made it miss, and the card kept two
+// entries for the same pull request forever.
+{
+  await writeBoard([
+    {
+      ...BASE_CARD,
+      id: "card-4",
+      links: ["https://github.com/opencoven/coven-cave/pull/4534"],
+      github: [
+        {
+          id: "github:pr:opencoven/coven-cave:4534",
+          url: "https://api.github.com/repos/OpenCoven/coven-cave/pulls/4534",
+          repo: "OpenCoven/coven-cave",
+          kind: "pr",
+          number: 4534,
+          title: "Fix the claim guard",
+        },
+      ],
+    },
+  ]);
+
+  const board = await loadBoard();
+  const github = board.cards[0].github ?? [];
+  assert.equal(
+    github.length,
+    1,
+    "one pull request must yield one connection, however its repo is cased",
+  );
+  assert.equal(github[0].title, "Fix the claim guard", "and it keeps the stored title");
 }
 
 // ── A URL with no stored counterpart is still backfilled ──────────────────────

--- a/src/lib/cave-board-backfill-idempotence.test.ts
+++ b/src/lib/cave-board-backfill-idempotence.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Point the store at a scratch Cave home BEFORE importing it — the module
+// resolves board.json from caveHome() at import time.
+const home = await mkdtemp(path.join(tmpdir(), "cave-backfill-idem-"));
+process.env.COVEN_CAVE_HOME = home;
+process.env.CAVE_HOME = home;
+
+const { loadBoard, saveBoard } = await import("./cave-board.ts");
+
+/**
+ * backfillCard must be a fixed point (cave-0b8t8).
+ *
+ * It was not. Both link merges resolve a clash with
+ * `title: item.title || previous.title`, so the incoming value wins whenever it
+ * is non-empty — right when the incoming link is fresh data from Asana or
+ * GitHub, wrong when it was invented from a URL. The URL derivations always
+ * invent a title, and backfill folded them back in, so a human-authored title
+ * survived exactly ONE load and was then replaced by a placeholder.
+ *
+ * These drive the public save/load path rather than the private function: the
+ * defect's whole point is that an ordinary reload loses data, so the test that
+ * matters exercises an ordinary reload.
+ */
+
+const BASE_CARD = {
+  id: "card-1",
+  title: "Ship retention",
+  status: "todo",
+  lifecycle: "todo",
+  createdAt: "2026-08-01T00:00:00.000Z",
+  updatedAt: "2026-08-01T00:00:00.000Z",
+};
+
+async function writeBoard(cards: unknown[]): Promise<void> {
+  await mkdir(home, { recursive: true });
+  await writeFile(path.join(home, "board.json"), JSON.stringify({ cards }), "utf8");
+}
+
+// ── A stored Asana title survives repeated loads ──────────────────────────────
+{
+  await writeBoard([
+    {
+      ...BASE_CARD,
+      links: ["https://app.asana.com/0/1200/1201"],
+      asana: [
+        {
+          id: "asana:task:1201",
+          url: "https://app.asana.com/0/1200/1201",
+          gid: "1201",
+          kind: "task",
+          title: "Ship retention",
+        },
+      ],
+    },
+  ]);
+
+  const first = await loadBoard();
+  assert.equal(
+    first.cards[0].asana?.[0]?.title,
+    "Ship retention",
+    "the stored title must survive the first load",
+  );
+
+  // Write the loaded card back verbatim and load again. This is the cleanest
+  // statement of the bug: same bytes in, different card out.
+  await saveBoard(first);
+  const second = await loadBoard();
+  assert.equal(
+    second.cards[0].asana?.[0]?.title,
+    "Ship retention",
+    "the stored title must survive a round-trip — it became 'Asana task 1201'",
+  );
+
+  await saveBoard(second);
+  const third = await loadBoard();
+  assert.deepEqual(third.cards, second.cards, "load is a fixed point after the first normalisation");
+}
+
+// ── The same for GitHub, which shares the derive-and-merge shape ──────────────
+{
+  await writeBoard([
+    {
+      ...BASE_CARD,
+      id: "card-2",
+      links: ["https://github.com/OpenCoven/coven-cave/pull/4534"],
+      github: [
+        {
+          id: "github:pull:OpenCoven/coven-cave:4534",
+          url: "https://github.com/OpenCoven/coven-cave/pull/4534",
+          repo: "OpenCoven/coven-cave",
+          kind: "pull",
+          number: 4534,
+          title: "Fix the claim guard",
+        },
+      ],
+    },
+  ]);
+
+  const first = await loadBoard();
+  await saveBoard(first);
+  const second = await loadBoard();
+  assert.equal(
+    second.cards[0].github?.[0]?.title,
+    "Fix the claim guard",
+    "a stored GitHub title must not be replaced by the derived 'repo #number'",
+  );
+}
+
+// ── A URL with no stored counterpart is still backfilled ──────────────────────
+// The fix must not stop derivation working; it must only stop it overwriting.
+{
+  await writeBoard([
+    {
+      ...BASE_CARD,
+      id: "card-3",
+      links: ["https://app.asana.com/0/1200/1301"],
+    },
+  ]);
+
+  const board = await loadBoard();
+  const asana = board.cards[0].asana ?? [];
+  assert.equal(asana.length, 1, "a bare Asana URL still becomes a first-class connection");
+  assert.equal(asana[0].gid, "1301");
+  assert.equal(asana[0].title, "Asana task 1301", "with its derived title, since nothing was stored");
+}
+
+console.log("cave-board-backfill-idempotence: all assertions passed");

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -134,7 +134,13 @@ function sameAsanaTarget(a: CardAsanaLink, b: CardAsanaLink): boolean {
 
 function sameGitHubTarget(a: CardGitHubLink, b: CardGitHubLink): boolean {
   if (a.repo && b.repo && a.kind === b.kind && a.number !== undefined && b.number !== undefined) {
-    return a.repo === b.repo && a.number === b.number;
+    // Repo comparison is case-insensitive, matching itemId() in task-github.ts,
+    // which lowercases the repo when building an id. GitHub treats owner/name
+    // case-insensitively, so a link stored from the API with canonical casing
+    // and one derived from a lowercase pasted URL name the same item — comparing
+    // them case-sensitively would fail to match, leave the derived link
+    // unfiltered, and let its generated title overwrite the stored one again.
+    return a.repo.toLowerCase() === b.repo.toLowerCase() && a.number === b.number;
   }
   return normalizeCompareUrl(a.url) === normalizeCompareUrl(b.url);
 }

--- a/src/lib/cave-board.ts
+++ b/src/lib/cave-board.ts
@@ -120,6 +120,29 @@ function asanaLinksFromLinks(values: string[] | undefined): CardAsanaLink[] {
     .filter((item): item is CardAsanaLink => item !== null);
 }
 
+/**
+ * Whether two links point at the same thing, for deciding if a URL-derived link
+ * is redundant. Compared on stable identity — the Asana gid, the GitHub
+ * repo/kind/number — rather than on `id` or `url`, because a link stored from
+ * the API and one derived from a pasted URL legitimately differ in both while
+ * naming the same task.
+ */
+function sameAsanaTarget(a: CardAsanaLink, b: CardAsanaLink): boolean {
+  if (a.gid && b.gid) return a.gid === b.gid;
+  return normalizeCompareUrl(a.url) === normalizeCompareUrl(b.url);
+}
+
+function sameGitHubTarget(a: CardGitHubLink, b: CardGitHubLink): boolean {
+  if (a.repo && b.repo && a.kind === b.kind && a.number !== undefined && b.number !== undefined) {
+    return a.repo === b.repo && a.number === b.number;
+  }
+  return normalizeCompareUrl(a.url) === normalizeCompareUrl(b.url);
+}
+
+function normalizeCompareUrl(value: string | null | undefined): string {
+  return (value ?? "").trim().replace(/\/+$/, "").toLowerCase();
+}
+
 function normalizeCwd(value: string | null | undefined): string | null {
   const cwd = value?.trim();
   return cwd ? cwd : null;
@@ -179,8 +202,34 @@ function normalizeBeadRef(value: unknown): CardBeadRef | null {
 
 function backfillCard(c: Card | LegacyCard): Card {
   const lifecycle = c.lifecycle ?? inferLifecycle(c.status);
-  const github = mergeGitHubLinks(normalizeGitHubLinks(c.github), ...gitHubLinksFromLinks(c.links));
-  const asana = mergeAsanaLinks(normalizeAsanaLinks(c.asana), ...asanaLinksFromLinks(c.links));
+  // Derived links FILL GAPS; they never overwrite what is already stored.
+  //
+  // Both merges resolve a clash with `title: item.title || previous.title`, so
+  // the incoming value wins whenever it is non-empty — correct when the incoming
+  // link is fresh data from Asana or GitHub, wrong when it was invented from a
+  // URL. The URL derivations always invent a title ("Asana task <gid>",
+  // "<repo> #<number>"), so folding them back in replaced a real stored title
+  // with a placeholder on EVERY load: a human title survived exactly one
+  // round-trip. backfillCard was not a fixed point, which is visible even
+  // without restore — write a card back verbatim and loadBoard returns a
+  // different one (cave-0b8t8).
+  //
+  // Fixed here rather than in the shared merges because the precedence those
+  // use is right for their other caller, where incoming really is authoritative.
+  const storedGitHub = normalizeGitHubLinks(c.github);
+  const storedAsana = normalizeAsanaLinks(c.asana);
+  const github = mergeGitHubLinks(
+    storedGitHub,
+    ...gitHubLinksFromLinks(c.links).filter(
+      (derived) => !storedGitHub.some((stored) => sameGitHubTarget(stored, derived)),
+    ),
+  );
+  const asana = mergeAsanaLinks(
+    storedAsana,
+    ...asanaLinksFromLinks(c.links).filter(
+      (derived) => !storedAsana.some((stored) => sameAsanaTarget(stored, derived)),
+    ),
+  );
   // Both link derivations feed back into `links` so a card's URL list stays the
   // union of everything attached, regardless of which source added it.
   const links = mergeLinksWithAsana(mergeLinksWithGitHub(normalizeLinks(c.links), github), asana);


### PR DESCRIPTION
`cave-0b8t8`. `backfillCard` was not a fixed point: a human-authored title on any Asana- or GitHub-linked card was replaced by a generated placeholder on reload.

```
title 'Ship retention'  ->  title 'Asana task 1201'
```

## Mechanism

Both link merges resolve a clash with `title: item.title || previous.title`, so the **incoming** value wins whenever it is non-empty. That is right when the incoming link is fresh data from Asana or GitHub — and wrong when it was invented from a URL. The URL derivations always invent a title (`Asana task <gid>`, `<repo> #<number>`), and `backfillCard` folded them back in.

## The fix

Fixed in `backfillCard` rather than in the shared merges, because the precedence those use is **correct for their other caller**, where incoming really is authoritative.

Derived links now fill gaps only: a derivation is dropped when a stored link already names the same target. Identity is compared on the Asana `gid`, or the GitHub `repo`/`kind`/`number` — not on `id` or `url`, because a link stored from the API and one derived from a pasted URL legitimately differ in both while naming the same task.

**The GitHub path had the identical defect** (`task-github.ts:117`) and is fixed alongside — the bead flagged it as worth checking, and it was.

## Test

Drives the public save/load path, since the point of the bug is that an *ordinary reload* loses data. It covers:

- a stored Asana title surviving a round-trip
- the same for GitHub
- load being a fixed point thereafter
- a bare URL with **no** stored counterpart still being backfilled with its derived title — so the fix stops overwriting without stopping derivation

**Verified the test fails without the fix.** Reverting `cave-board.ts` to main and rerunning gives `AssertionError: the stored title must survive the first load`.

One correction to the bead's description: it fails on the **first** load, not the second. A previously-saved card already carries the URL in `links`, so the derivation clashes immediately. Same defect, triggered one load sooner.

## Verification

`check:tests-wired` (1615), `pnpm typecheck`, `pnpm lint`, and the existing `cave-board-retention` suite all pass. The new test is registered in both the suite list and `ALIAS_LOADER`, since `cave-board.ts` resolves `@/…` imports.
