### PR TITLE
fix(worktrees): make `--apply` actually retire — renew the fence, reserve a slot

### DIFF
--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -4624,6 +4624,264 @@ exit 0
     "runRetirementApply preserves both retirement and release failures",
   );
 
+  // ── Metadata repair must not eat the whole retirement budget (cave-1si7i) ───
+  //
+  // --max-retire is one allowance shared by repair and retirement, and repair
+  // is served first. With at least maxRetire repairable records, repair took
+  // all of it and retireLifecycleUnits was never called, so a run reported
+  // "Locally retired (0)" beside the units it could have retired. Two
+  // consecutive real runs did exactly that: 3 repaired, 0 retired.
+  {
+    const retirableInventory = {
+      ...applyInventory,
+      // Enough repairable records to consume maxRetire several times over.
+      orphanedMetadata: Array.from({ length: 12 }, (_, index) => ({
+        beadId: `cave-fixture-${index}`,
+        location: "primary",
+        branch: `feat/fixture-${index}`,
+        path: `${repo}/.worktrees/fixture-${index}`,
+        repairable: true,
+      })),
+      orphanedMetadataErrors: [],
+    };
+    assert.ok(
+      retirableInventory.items.some((item) => item.lane === "retire-after-gate"),
+      "fixture inventory must contain a unit retirement would actually select",
+    );
+
+    let repairBudget = null;
+    let retireBudget = null;
+    runRetirementApply(applyOptions, retirableInventory, {
+      createMetadataRepairOperations: () => ({ fixture: "metadata-ops" }),
+      repairOrphanedWorktreeMetadata: ({ maxRepairs }) => {
+        repairBudget = maxRepairs;
+        return emptyMetadataRepair;
+      },
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      heartbeatMaintenanceGate: () => ({ ok: true }),
+      verifyMaintenanceGateOwnership: () => ({ ok: true }),
+      releaseMaintenanceGate: () => ({ ok: true }),
+      createGitRetirementOperations: () => ({ fixture: "ops" }),
+      retireLifecycleUnits: ({ maxRetire }) => {
+        retireBudget = Number(maxRetire);
+        return fakeRetirement;
+      },
+      collectWorktreeLifecycleInventory: () => fakePostInventory,
+    });
+
+    assert.equal(
+      retireBudget,
+      1,
+      "retirement must get a slot even when repairable records outnumber the budget — it used to get none",
+    );
+    assert.equal(
+      repairBudget,
+      applyOptions.maxRetire - 1,
+      "repair takes the remainder, not the whole allowance",
+    );
+    assert.ok(
+      repairBudget + retireBudget <= applyOptions.maxRetire,
+      "the reservation must not widen the blast radius --max-retire exists to bound",
+    );
+  }
+
+  // A single-slot run still spends it on repair. Reserving out of a budget of
+  // one would not share it, it would only move the starvation onto repair --
+  // the same defect wearing the other hat. Pinned here because it is a
+  // deliberate choice rather than a fallout of the arithmetic.
+  {
+    let repairBudget = null;
+    let retirementRan = false;
+    runRetirementApply(
+      { ...applyOptions, maxRetire: 1 },
+      {
+        ...applyInventory,
+        orphanedMetadata: [
+          {
+            beadId: "cave-fixture-single",
+            location: "primary",
+            branch: "feat/fixture-single",
+            path: `${repo}/.worktrees/fixture-single`,
+            repairable: true,
+          },
+        ],
+        orphanedMetadataErrors: [],
+      },
+      {
+        createMetadataRepairOperations: () => ({ fixture: "metadata-ops" }),
+        repairOrphanedWorktreeMetadata: ({ maxRepairs }) => {
+          repairBudget = maxRepairs;
+          return emptyMetadataRepair;
+        },
+        acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+        heartbeatMaintenanceGate: () => ({ ok: true }),
+        verifyMaintenanceGateOwnership: () => ({ ok: true }),
+        releaseMaintenanceGate: () => ({ ok: true }),
+        createGitRetirementOperations: () => ({ fixture: "ops" }),
+        retireLifecycleUnits: () => {
+          retirementRan = true;
+          return fakeRetirement;
+        },
+        collectWorktreeLifecycleInventory: () => fakePostInventory,
+      },
+    );
+
+    assert.equal(repairBudget, 1, "a single slot goes to repair, as it did before the reservation");
+    assert.equal(retirementRan, false, "and retirement is not invoked with no slot left");
+  }
+
+  // With nothing retirable, the whole allowance still goes to repair: the
+  // reservation is for work that can actually happen, not a standing tax.
+  {
+    const nothingRetirable = {
+      ...applyInventory,
+      items: applyInventory.items.filter((item) => item.lane !== "retire-after-gate"),
+      orphanedMetadata: Array.from({ length: 12 }, (_, index) => ({
+        beadId: `cave-fixture-${index}`,
+        location: "primary",
+        branch: `feat/fixture-${index}`,
+        path: `${repo}/.worktrees/fixture-${index}`,
+        repairable: true,
+      })),
+      orphanedMetadataErrors: [],
+    };
+
+    let repairBudget = null;
+    let retirementRan = false;
+    runRetirementApply(applyOptions, nothingRetirable, {
+      createMetadataRepairOperations: () => ({ fixture: "metadata-ops" }),
+      repairOrphanedWorktreeMetadata: ({ maxRepairs }) => {
+        repairBudget = maxRepairs;
+        return emptyMetadataRepair;
+      },
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      heartbeatMaintenanceGate: () => ({ ok: true }),
+      verifyMaintenanceGateOwnership: () => ({ ok: true }),
+      releaseMaintenanceGate: () => ({ ok: true }),
+      createGitRetirementOperations: () => ({ fixture: "ops" }),
+      retireLifecycleUnits: () => {
+        retirementRan = true;
+        return fakeRetirement;
+      },
+      collectWorktreeLifecycleInventory: () => fakePostInventory,
+    });
+
+    assert.equal(
+      repairBudget,
+      applyOptions.maxRetire,
+      "no reservation is taken when nothing is retirable",
+    );
+    assert.equal(retirementRan, false, "and retirement is not invoked for an empty candidate set");
+  }
+
+  // ── The post-apply inventory renews the fence AS it works (cave-ykj47) ──────
+  //
+  // The inventory is the longest operation inside the fence and on a real
+  // checkout outruns the 120s Coven lease by itself (measured 141s). Before the
+  // fix it ran with no progress hook: the gate was heartbeated once before it
+  // and verified after, so the lease was already gone by the time it returned
+  // and the release failed with "maintenance lease expired".
+  //
+  // The renewal factory is injected unthrottled here on purpose. The real
+  // createFenceRenewal skips its first call and then renews at most every
+  // FENCE_RENEWAL_INTERVAL_MS, so in a test that finishes in milliseconds every
+  // call is throttled and a missing hook is indistinguishable from a working
+  // one.
+  {
+    const heartbeats = [];
+    let sawProgressHook = null;
+    const result = runRetirementApply(applyOptions, applyInventory, {
+      ...metadataApplyDependencies,
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      heartbeatMaintenanceGate: (handle) => {
+        heartbeats.push(handle);
+        return { ok: true };
+      },
+      verifyMaintenanceGateOwnership: () => ({ ok: true }),
+      releaseMaintenanceGate: () => ({ ok: true }),
+      createGitRetirementOperations: () => ({ fixture: "ops" }),
+      retireLifecycleUnits: () => fakeRetirement,
+      createFenceRenewal: (renew) => renew,
+      collectWorktreeLifecycleInventory: (options) => {
+        sawProgressHook = options.onProgress;
+        // Stand in for the inventory's own progress reporting.
+        for (let index = 0; index < 4; index += 1) options.onProgress?.();
+        return fakePostInventory;
+      },
+    });
+
+    assert.equal(
+      typeof sawProgressHook,
+      "function",
+      "the post-apply inventory must receive a progress hook — without one nothing renews the fence while it runs",
+    );
+    assert.equal(
+      heartbeats.length,
+      5,
+      "one heartbeat before the inventory plus one per progress report",
+    );
+    assert.ok(
+      heartbeats.every((handle) => handle === acquiredHandle),
+      "every renewal renews the fence this run actually holds",
+    );
+    assert.deepEqual(result.postInventory, fakePostInventory);
+    assert.equal(result.postInventoryError, undefined);
+    assert.equal(result.warning, undefined, "the release succeeds when the fence is still held");
+  }
+
+  // A fence that dies mid-inventory must stop the inventory, not be ridden out.
+  // createFenceRenewal is documented fail-closed: work continuing past a lost
+  // fence is no longer excluding the writers it believes it is. The retirement
+  // above has already happened, so this surfaces as a reported error rather
+  // than an abort.
+  {
+    let heartbeatCalls = 0;
+    let progressCalls = 0;
+    const result = runRetirementApply(applyOptions, applyInventory, {
+      ...metadataApplyDependencies,
+      acquireMaintenanceGate: () => ({ ok: true, handle: acquiredHandle }),
+      heartbeatMaintenanceGate: () => {
+        heartbeatCalls += 1;
+        // Succeed for the pre-inventory heartbeat, then lose the fence.
+        return heartbeatCalls === 1
+          ? { ok: true }
+          : { ok: false, reason: "maintenance lease expired" };
+      },
+      verifyMaintenanceGateOwnership: () => ({ ok: true }),
+      releaseMaintenanceGate: () => ({ ok: true }),
+      createGitRetirementOperations: () => ({ fixture: "ops" }),
+      retireLifecycleUnits: () => fakeRetirement,
+      createFenceRenewal: (renew) => renew,
+      collectWorktreeLifecycleInventory: (options) => {
+        for (let index = 0; index < 4; index += 1) {
+          progressCalls += 1;
+          options.onProgress?.();
+        }
+        return fakePostInventory;
+      },
+    });
+
+    assert.equal(
+      progressCalls,
+      1,
+      "the inventory stops at the first progress report after the fence is lost",
+    );
+    assert.match(
+      result.postInventoryError,
+      /failed to heartbeat maintenance gate during post-apply inventory: maintenance lease expired/,
+    );
+    assert.equal(
+      result.postInventory,
+      undefined,
+      "an inventory collected behind a dead fence is never reported as authoritative",
+    );
+    assert.deepEqual(
+      result.retirement,
+      fakeRetirement,
+      "retirement already completed before the fence was lost and is still reported",
+    );
+  }
+
   const gateRoot = maintenanceGateRoot(repo);
   const applyResult = patrolResult(["--apply", "--json"]);
   assert.equal(applyResult.status, 2);

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -7,6 +7,7 @@ import {
 } from "../src/lib/worktree-lifecycle.ts";
 import {
   acquireMaintenanceGate,
+  createFenceRenewal,
   heartbeatMaintenanceGate,
   releaseMaintenanceGate,
   repositoryMaintenanceCapabilities,
@@ -85,6 +86,23 @@ type RetirementApplyDependencies = {
   createMetadataRepairOperations: typeof createMetadataRepairOperations;
   repairOrphanedWorktreeMetadata: typeof repairOrphanedWorktreeMetadata;
   collectWorktreeLifecycleInventory: typeof collectWorktreeLifecycleInventory;
+  /**
+   * Optional, and injected so a test can observe renewal without waiting out
+   * the throttle.
+   *
+   * Optional because the existing apply tests build explicit dependency
+   * literals rather than spreading the defaults, so a required field would
+   * arrive undefined in every one of them and fail as a TypeError inside the
+   * inventory try/catch — which surfaces as a confusing postInventoryError
+   * rather than as the missing wiring it actually is.
+   *
+   * The real {@link createFenceRenewal} deliberately skips the first call and
+   * then renews at most every FENCE_RENEWAL_INTERVAL_MS, which is correct in
+   * production and invisible in a test that finishes in milliseconds — every
+   * call would be throttled, so a missing renewal and a working one look
+   * identical. Injecting the factory lets a test supply an unthrottled one.
+   */
+  createFenceRenewal?: typeof createFenceRenewal;
 };
 
 const APPLY_OWNER_ID = "worktree-lifecycle-patrol";
@@ -99,6 +117,7 @@ const defaultRetirementApplyDependencies: RetirementApplyDependencies = {
   createMetadataRepairOperations,
   repairOrphanedWorktreeMetadata,
   collectWorktreeLifecycleInventory,
+  createFenceRenewal,
 };
 
 type RetirementApplyResult = {
@@ -553,7 +572,42 @@ export function runRetirementApply(
     const repairableOrphans = (inventory.orphanedMetadata ?? []).filter(
       (candidate) => candidate.repairable,
     );
-    const repairLimit = Math.min(options.maxRetire, repairableOrphans.length);
+    // Reserve a retirement slot before metadata repair spends the budget.
+    //
+    // --max-retire is one allowance shared by two jobs, and repair is served
+    // first. Whenever there were at least maxRetire repairable records, repair
+    // took all of it, gitLimit fell to 0, and retireLifecycleUnits was never
+    // called — so the run retired nothing while still listing the units it
+    // could have retired, which reads as "considered and declined" rather than
+    // "never got a slot". Measured on two consecutive runs against this
+    // checkout: 3 repaired, 0 retired, with 15 records pending; at three
+    // repairs a run it would take five clean runs before a single worktree
+    // became eligible, and hand-retirement keeps adding residue faster than
+    // that (cave-xbc87). See cave-1si7i.
+    //
+    // The reservation is one slot, not a second budget: total mutations still
+    // cannot exceed maxRetire, which is what bounds an unattended sweep's blast
+    // radius (scripts/worktree-sweep-prompt.md pins --max-retire 3 and says not
+    // to raise it). It is taken only when something is actually retirable, so a
+    // run with nothing to retire still spends the whole allowance on repair,
+    // exactly as before.
+    //
+    // The lane test matches retireLifecycleUnits' own eligibility filter
+    // (worktree-lifecycle-retirement.ts:161); anything else would reserve a
+    // slot for work that cannot happen.
+    const retirableAtGate = inventory.items.some(
+      (item) => item.lane === "retire-after-gate",
+    );
+    // Only reserve when there is more than one slot to divide. With
+    // --max-retire 1 a reservation would not share the budget, it would just
+    // move the starvation onto repair — which is the same defect wearing the
+    // other hat, and it would contradict the established behaviour that a
+    // single-slot run spends it on repair.
+    const retirementReservation = retirableAtGate && options.maxRetire >= 2 ? 1 : 0;
+    const repairLimit = Math.min(
+      Math.max(0, options.maxRetire - retirementReservation),
+      repairableOrphans.length,
+    );
     metadataRepair = dependencies.repairOrphanedWorktreeMetadata({
       candidates: inventory.orphanedMetadata ?? [],
       maxRepairs: repairLimit,
@@ -603,11 +657,47 @@ export function runRetirementApply(
           }`;
       } else {
         try {
+          // Renew the fence AS the inventory works, not merely before it.
+          //
+          // This is the longest operation inside the fence — on a large
+          // checkout it outlives the 120s Coven lease on its own (measured at
+          // 141s against COVEN_OWNER_LEASE_MS), so heartbeating once above and
+          // verifying ownership afterwards is not enough: the lease is already
+          // gone by the time the inventory returns, the ownership check below
+          // cannot pass, and the release at the end of this function fails with
+          // "maintenance lease expired".
+          //
+          // createFenceRenewal anchors renewal to progress rather than to a
+          // timer, which is the only thing that works here: the inventory is
+          // synchronous throughout (spawnSync for git and gh), so it never
+          // yields and no timer callback would ever run. The create path solved
+          // exactly this for its own inventory in cave-cs9g1; this call site
+          // was left behind. See cave-ykj47.
+          //
+          // Throwing on a failed heartbeat is deliberate and matches
+          // createFenceRenewal's fail-closed contract: if the fence is gone,
+          // continuing would do unexcluded work while believing otherwise. The
+          // catch below turns that into a reported postInventoryError rather
+          // than an abort, because the retirement above has already happened
+          // and its result must still be reported.
+          const makeFenceRenewal =
+            dependencies.createFenceRenewal ?? createFenceRenewal;
+          const renewFenceDuringPostInventory = makeFenceRenewal(() => {
+            const renewed = dependencies.heartbeatMaintenanceGate(acquired.handle);
+            if (!renewed.ok) {
+              throw new Error(
+                `failed to heartbeat maintenance gate during post-apply inventory: ${
+                  renewed.reason ?? "unknown heartbeat error"
+                }`,
+              );
+            }
+          });
           const candidatePostInventory =
             dependencies.collectWorktreeLifecycleInventory({
               repo: options.repo!,
               root: options.root,
               nowMs: options.nowMs,
+              onProgress: renewFenceDuringPostInventory,
             });
           const ownershipAfter =
             dependencies.verifyMaintenanceGateOwnership(acquired.handle);


### PR DESCRIPTION
Two independent defects stopped `pnpm beads:worktrees:apply` from retiring anything on a large checkout. Both showed up in the same run, which is how I initially conflated them; the report's section counts are what tell them apart.

## cave-1si7i — metadata repair consumed the whole `--max-retire` budget

`repairLimit` was taken first as `min(maxRetire, repairableOrphans.length)`, so whenever there were at least `maxRetire` repairable records it claimed the entire allowance, `gitLimit` fell to `0`, and `retireLifecycleUnits` was **never called**. The run still listed the units it could have retired, so it reads as "considered and declined" rather than "never got a slot".

Measured across two consecutive real runs on this checkout:

| run | repaired | pending | locally retired | cleanup-ready but not processed |
|----:|---------:|--------:|----------------:|--------------------------------:|
| 1   | 3        | 12      | **0**           | 1                               |
| 2   | 3        | 9       | **0**           | 0                               |

At three repairs a run with 15 records pending, five clean runs would pass before a single worktree became eligible — and hand-retirement keeps adding residue (cave-xbc87) faster than that.

**Fix.** Reserve one retirement slot when any unit is in lane `retire-after-gate` — the same predicate `retireLifecycleUnits` filters on, so the slot is never held for work that cannot happen. Repair takes the remainder.

It is a *reservation, not a second budget*: total mutations still cannot exceed `maxRetire`, which is what bounds an unattended sweep (`worktree-sweep-prompt.md` pins `--max-retire 3` and says not to raise it). It applies only when `maxRetire >= 2`, because reserving out of a budget of one does not share it — it moves the starvation onto repair, the same defect wearing the other hat, and contradicts the established single-slot behaviour.

## cave-ykj47 — the post-apply inventory ran inside the fence without renewing it

That inventory is the only unbounded operation inside the fence and outlives the 120 s Coven lease on its own (measured **141 s** against `COVEN_OWNER_LEASE_MS`). The gate was heartbeated once *before* it and ownership verified *after*, but nothing renewed it *during*, so the lease was already gone by the time it returned:

```
Warning: failed to release maintenance gate: coven-release-failed:
coven-release-unavailable: Error: maintenance lease expired; acquire a new fence
```

Ownership could not be verified, the reconciliation proving the repairs landed was skipped, the release failed, and the command exited 1.

**Fix — the one the create path already uses.** `createFenceRenewal` exists for exactly this and anchors renewal to *progress* rather than to a timer; its own doc explains why a timer cannot work here, since the inventory is synchronous throughout and never yields. `collectWorktreeLifecycleInventory` already accepts `onProgress`, and `worktree-lifecycle-create.ts` wired it up in **cave-cs9g1**. This call site was simply left behind.

A failed heartbeat throws, matching `createFenceRenewal`'s documented fail-closed contract, and is reported rather than aborting — the retirement above it has already happened and must still be reported.

To be explicit: this fixes the release, the ownership verification and the exit code. It does **not** fix the empty retirement — that was cave-1si7i.

## Tests

Five, all driving `runRetirementApply` through its injected dependencies, so none add to this file's spawn count:

- the progress hook is passed, and the fence renews once per progress report
- a fence lost mid-inventory stops the inventory at the first report, reports the error, never treats that inventory as authoritative, and still reports the completed retirement
- retirement gets a slot when repairable records outnumber the budget
- no reservation is taken when nothing is retirable, so a repair-only run still spends the full allowance
- a single-slot run still goes to repair

The renewal factory is injectable because the real one skips its first call and then renews at most every 30 s — in a test finishing in milliseconds every call is throttled, so a missing hook and a working one would look identical. It is *optional* rather than required: the existing apply tests build explicit dependency literals instead of spreading the defaults, so a required field would arrive `undefined` in all of them and fail as a `TypeError` inside the inventory's try/catch, surfacing as a misleading `postInventoryError`.

## Verification

- `scripts/worktree-lifecycle-patrol.test.mjs` — passes (`worktree-lifecycle-patrol.test.mjs: ok`)
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0

One caveat on the local run, since it affects anyone reproducing it: this file currently aborts partway on any machine with a real `coven` installed, because it pins the CLI version while its own stub is bypassed (**cave-a7kqf**, unrelated to this PR). I ran it with that worked around locally and reverted the workaround before committing — it is not in this diff. CI is unaffected, since CI has no `coven` on PATH and therefore does get the stub.
