### PR TITLE
fix(worktrees): renew the fence during reprobe's inventory

### DIFF
--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -1468,6 +1468,51 @@ process.stdout.write(JSON.stringify(output) + "\\n");
   }
 });
 
+test("adapter reprobe renews the maintenance fence while its inventory runs", () => {
+  // reprobe() rebuilds the WHOLE lifecycle inventory to re-verify one unit.
+  // On a real checkout that measured 134s for 47 units, against a 120s Coven
+  // lease, and it runs inside the fence between two retirement checkpoints. With
+  // no renewal the lease was always dead by the next checkpoint, so every
+  // retirement blocked with "maintenance lease expired" and nothing was ever
+  // retired. See cave-wsayy.
+  //
+  // The renewal factory is injected unthrottled AND non-forwarding: it counts
+  // invocations without calling the wrapped renew, so this test never spawns
+  // `coven`. The real factory would throttle every call away against a fixture
+  // inventory this small, which is exactly the case where a missing hook and a
+  // working one are indistinguishable.
+  const fixture = createGitFixture();
+  try {
+    let renewals = 0;
+    const operations = createGitRetirementOperations({
+      root: fixture.repo,
+      repo: "OpenCoven/coven-cave",
+      gateHandle: { generation: 1, token: "tok", ownerId: "owner", root: "/gate" },
+      nowMs: 1_754_000_000_000,
+      createFenceRenewal: () => () => {
+        renewals += 1;
+      },
+    });
+
+    const item = {
+      ref: "refs/heads/feat/absent-from-this-fixture",
+      branch: "feat/absent-from-this-fixture",
+      head: "0".repeat(40),
+    };
+    withPathPrefix(fixture.bin, () => operations.reprobe(item));
+
+    // The probe's verdict is beside the point — this pins that the inventory it
+    // runs is given a progress hook and that the hook actually fires, which is
+    // the whole difference between holding a live fence and an expired one.
+    assert.ok(
+      renewals > 0,
+      "reprobe's inventory must drive fence renewal; it ran with no hook at all before this fix",
+    );
+  } finally {
+    cleanupFixture(fixture.fixtureRoot);
+  }
+});
+
 test("adapter reprobe catches inventory exceptions and returns a blocked result", () => {
   const fixture = createGitFixture();
   try {

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/lib/worktree-lifecycle.ts";
 import { collectWorktreeLifecycleInventory } from "./worktree-lifecycle-inventory.ts";
 import {
+  createFenceRenewal,
   heartbeatMaintenanceGate,
   MAX_FENCED_MUTATION_TIMEOUT_MS,
   verifyMaintenanceGateOwnership,
@@ -418,17 +419,55 @@ export function createGitRetirementOperations({
   repo,
   gateHandle,
   nowMs,
+  // Injected so a test can observe renewal without waiting out the throttle.
+  // The real factory skips its first call and then renews at most every
+  // FENCE_RENEWAL_INTERVAL_MS, so against a small fixture inventory every call
+  // is throttled and a missing hook looks exactly like a working one.
+  createFenceRenewal: makeFenceRenewal = createFenceRenewal,
 }: {
   root: string;
   repo: string;
   gateHandle: GitRetirementHandle;
   nowMs?: number | (() => number);
+  createFenceRenewal?: typeof createFenceRenewal;
 }): RetirementOperations {
   const normalizedRoot = realpathSync(root);
   const maintenanceHandle = gateHandle;
 
   const readNowMs = (): number =>
     typeof nowMs === "function" ? nowMs() : (nowMs ?? Date.now());
+
+  // Renew the fence while reprobe's inventory runs.
+  //
+  // reprobe() below rebuilds the WHOLE lifecycle inventory to re-verify one
+  // unit, and that is not a quick read: 134s for 47 units when measured on the
+  // checkout this was found on, against a COVEN_OWNER_LEASE_MS of 120s. It runs
+  // inside the fence, between the "before retirement" and "before ignored
+  // cleanup" checkpoints, so without renewal the lease is always dead by the
+  // time retirement takes its next step — every retirement blocked with
+  // "maintenance lease expired", and no worktree on that checkout had ever been
+  // retired. Traced by pointing COVEN_BIN at a logging shim: 129 seconds passed
+  // between two heartbeats with no coven call of any kind in between.
+  //
+  // One renewal is shared by both reprobe call sites (the pre-retirement probe
+  // and the post-cleanup one) so the 30s throttle is applied across the whole
+  // retirement rather than reset per probe.
+  //
+  // Progress-anchored rather than timed, because the inventory is synchronous
+  // throughout and never yields — see createFenceRenewal. A failed heartbeat
+  // throws, which is its documented fail-closed contract; reprobe's own
+  // try/catch turns that into a probe failure, so the unit is reported as
+  // blocked instead of being retired behind a fence nobody holds.
+  const renewFenceDuringProbe = makeFenceRenewal(() => {
+    const renewed = heartbeatMaintenanceGate(maintenanceHandle);
+    if (!renewed.ok) {
+      throw new Error(
+        `failed to heartbeat maintenance gate during retirement probe: ${
+          renewed.reason ?? "unknown heartbeat error"
+        }`,
+      );
+    }
+  });
 
   return {
     verifyGate() {
@@ -462,6 +501,7 @@ export function createGitRetirementOperations({
           repo,
           root: normalizedRoot,
           nowMs: readNowMs(),
+          onProgress: renewFenceDuringProbe,
         });
       } catch (error) {
         return {


### PR DESCRIPTION
Retirement's `reprobe` rebuilds the **whole** lifecycle inventory to re-verify a single unit, inside the maintenance fence, with nothing renewing the lease while it runs.

Measured on the checkout this was found on: **134 s for 47 units** against a `COVEN_OWNER_LEASE_MS` of **120 s**. So the lease was always dead by the time retirement reached its next checkpoint — every candidate blocked with `maintenance lease expired`, and no worktree there had ever been retired.

## How it was found

Pointing `COVEN_BIN` at a logging shim traces every `coven` invocation. Times are relative to the first call of the fenced phase (the pre-apply inventory runs ahead of this, unfenced, which is correct):

```
T+  0.2s  maintenance acquire
T+  0.4s … T+12.6s   heartbeat+status ×7      ← repairs, renewing every ~1.5s
T+ 12.6s … T+141.7s  ***129s, ZERO coven calls***  ← reprobe's inventory
T+141.8s  heartbeat → maintenance lease expired
T+142.2s  release   → maintenance lease expired
```

The 129 s gap matches the independently measured inventory time. Each heartbeat/status pair is one `heartbeatThenVerify`, which is how the repair and retirement checkpoints appear.

This also explains why **cave-ykj47 did not help on its own**: that fix renews during the *post-apply* inventory, but that inventory never even starts — the heartbeat guarding it has already been killed here. The renewal landed one step too late in the sequence.

## The fix

The same pattern already used for the create path (**cave-cs9g1**) and the post-apply inventory (**cave-ykj47**). `createGitRetirementOperations` already holds the gate handle, so it builds one progress-anchored renewal and passes it as the inventory's `onProgress`.

- **Progress-anchored, not timed** — the inventory is synchronous throughout and never yields, so no timer callback could run. `createFenceRenewal` exists for exactly this.
- **One renewal shared by both reprobe call sites** (the pre-retirement probe and the post-cleanup one at line 271), so the 30 s throttle spans the whole retirement rather than resetting per probe.
- **Fail-closed** — a failed heartbeat throws, matching `createFenceRenewal`'s documented contract. `reprobe`'s existing try/catch turns that into a blocked unit rather than a retirement proceeding behind a fence nobody holds.

## Test

One test, and it fails without the fix:

```
not ok - adapter reprobe renews the maintenance fence while its inventory runs
AssertionError: reprobe's inventory must drive fence renewal; it ran with no hook at all before this fix
```

The renewal factory is injectable purely so renewal is observable: the real one skips its first call and then renews at most every 30 s, so against a fixture inventory every call is throttled and a missing hook is indistinguishable from a working one. The injected factory counts invocations **without forwarding**, so the test never spawns `coven`.

## Deliberately not fixed here

`reprobe` rebuilding the entire inventory to check one unit is O(units) per retirement, and a retirement can do it twice — up to six full inventories in a `--max-retire 3` run. Renewal makes it *correct*, not *cheap*. That belongs in its own change; it is the same "the inventory is the cost" shape as cave-yzpgl.

## Verification

- `scripts/worktree-lifecycle-retirement.test.mjs` — passes (11 tests), and the new one fails without the fix
- `pnpm typecheck` — exit 0
- `pnpm lint` — exit 0
