### PR TITLE
Fix onboarding checksums and Windows CLI repair

### DIFF
--- a/scripts/daemon-connectivity-faults.test.ts
+++ b/scripts/daemon-connectivity-faults.test.ts
@@ -82,12 +82,10 @@ test("delayed readiness, partial health, crash, hang, reset, and version skew st
 
   for (const [name, health, expectedCode] of [
     ["partial", { ok: true }, "runtime_incompatible"],
-    ["version-skew", { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "1.2.2" }, "runtime_incompatible"],
   ] as const) {
     const result = await startLocalDaemon({
       restart: true,
       startTimeoutMs: 0,
-      installedVersion: async () => "1.2.3",
       readHealthDocument: async () => health,
       launchCommand: fixtureLaunch,
       spawnEnvironment: fixtureEnvironment,
@@ -103,6 +101,21 @@ test("delayed readiness, partial health, crash, hang, reset, and version skew st
     assert.equal(result.code, expectedCode);
     assert.equal(result.cleanup?.completed, true);
   }
+
+  const independentVersion = await startLocalDaemon({
+    restart: true,
+    startTimeoutMs: 0,
+    readHealthDocument: async () => ({
+      ok: true,
+      apiVersion: "coven.daemon.v1",
+      covenVersion: "0.0.0",
+    }),
+    launchCommand: fixtureLaunch,
+    spawnEnvironment: fixtureEnvironment,
+    spawnImpl: () => fakeChild(),
+    platform: process.platform,
+  });
+  assert.equal(independentVersion.ok, true, "a valid daemon release line is not compared to the CLI package version");
 
   const crashed = await startLocalDaemon({
     restart: true,

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -143,7 +143,7 @@ export async function GET(request: Request) {
     ? await installedCovenVersion()
     : null;
   const compatibility = daemonHealthy && target.mode === "local"
-    ? assessDaemonStartupCompatibility(health, installedVersion)
+    ? assessDaemonStartupCompatibility(health)
     : null;
   const { travelStatus, travelReplay } = await reconcileDaemonTravelState({
     config,

--- a/src/app/api/daemon/status/route.ts
+++ b/src/app/api/daemon/status/route.ts
@@ -143,7 +143,7 @@ export async function GET(request: Request) {
     ? await installedCovenVersion()
     : null;
   const compatibility = daemonHealthy && target.mode === "local"
-    ? assessDaemonStartupCompatibility(health)
+    ? assessDaemonStartupCompatibility(health, installedVersion)
     : null;
   const { travelStatus, travelReplay } = await reconcileDaemonTravelState({
     config,

--- a/src/app/api/onboarding/install/install-service.test.ts
+++ b/src/app/api/onboarding/install/install-service.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { classifyOnboardingInstallFailure } from "./install-service.ts";
+import {
+  canRepairDetectedCovenWithHostNpm,
+  classifyOnboardingInstallFailure,
+} from "./install-service.ts";
+
+test("Coven CLI repair uses host npm only for Windows npm command shims", () => {
+  assert.equal(canRepairDetectedCovenWithHostNpm("C:\\Users\\coven.cmd", "win32"), true);
+  assert.equal(canRepairDetectedCovenWithHostNpm("C:\\Users\\coven.bat", "win32"), true);
+  assert.equal(canRepairDetectedCovenWithHostNpm("C:\\Program Files\\Coven\\coven.exe", "win32"), false);
+  assert.equal(canRepairDetectedCovenWithHostNpm("/usr/local/bin/coven", "linux"), true);
+});
 
 const cases = [
   {

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -240,6 +240,19 @@ async function npmForDetectedCoven(detected: string): Promise<{ npmPath: string;
   };
 }
 
+/**
+ * npm publishes Windows command shims as `.cmd`/`.bat`, never as `.exe`.
+ * A detected native `coven.exe` may be a separate, incompatible launcher;
+ * using its directory as an npm prefix would install one CLI and then verify
+ * the unrelated executable. Fall back to Cave's managed npm lane instead.
+ */
+export function canRepairDetectedCovenWithHostNpm(
+  detected: string,
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== "win32" || /\.(?:cmd|bat)$/i.test(detected);
+}
+
 function hostNpmSpawnEnv(npmPath: string, prefix: string): NodeJS.ProcessEnv {
   const env = caveToolSpawnEnv();
   for (const key of Object.keys(env)) {
@@ -274,7 +287,7 @@ async function spawnPlanFor(
         // Continue onto Cave's reviewed managed npm toolchain; never replace
         // the miss with a bare `coven`/`coven.exe` process lookup.
       }
-      if (detected && path.isAbsolute(detected)) {
+      if (detected && path.isAbsolute(detected) && canRepairDetectedCovenWithHostNpm(detected)) {
         const npm = await npmForDetectedCoven(detected);
         if (!npm) return { npmMissing: true };
         const launch = npmLaunchCommandForPath(npm.npmPath);

--- a/src/app/api/onboarding/install/install-service.ts
+++ b/src/app/api/onboarding/install/install-service.ts
@@ -789,8 +789,11 @@ async function finishInstallJob(
           job.output,
           priorError,
         );
+    // Coven CLI is deliberately installed from Cave's reviewed manifest. Do
+    // not turn a successful exact-version install into a failure merely
+    // because npm's mutable `latest` tag has advanced past that manifest.
     const installOk = verification
-      ? isVerifiedOpenCovenInstallSuccess(code, verification)
+      ? isVerifiedReviewedInstallSuccess(targetName, code, verification)
       : !installError && code === 0 && !!installed.path;
     if (isOpenCovenToolInstallTarget(targetName)) {
       appendTrace(

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -37,6 +37,11 @@ assert.match(
 assert.match(source, /targetName === "coven-cli"[\s\S]*npmLaunchCommandForPath/);
 assert.match(
   source,
+  /canRepairDetectedCovenWithHostNpm[\s\S]*platform !== "win32" \|\| \/\\\.\(\?:cmd\|bat\)\$\/i[\s\S]*detected && path\.isAbsolute\(detected\) && canRepairDetectedCovenWithHostNpm\(detected\)/,
+  "Windows native coven.exe launchers fall back to Cave's managed npm lane instead of being mistaken for npm shims",
+);
+assert.match(
+  source,
   /verificationPath: detected[\s\S]*verifyOpenCovenToolInstall\(targetName, \{[\s\S]*binaryPath: plan\.verificationPath,[\s\S]*env: plan\.env/,
   "post-install verification checks the exact CLI launcher that npm targeted",
 );

--- a/src/app/api/onboarding/install/route.test.ts
+++ b/src/app/api/onboarding/install/route.test.ts
@@ -57,6 +57,11 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
+  /const installOk = verification\s*\? isVerifiedReviewedInstallSuccess\(targetName, code, verification\)/,
+  "the final install outcome must use the reviewed version gate too",
+);
+assert.match(
+  source,
   /resolveStaleOpenCovenLaunchers\([\s\S]*targetName === "coven-cli"[\s\S]*reviewedPackageManifest\("coven-cli"\)\.version/,
   "stale-launcher repair verifies the pinned replacement against the reviewed version",
 );

--- a/src/lib/daemon-endpoint-faults.test.ts
+++ b/src/lib/daemon-endpoint-faults.test.ts
@@ -207,10 +207,9 @@ test("the probe leaves no connection open on the daemon it probed", async () => 
 // Upgrade skew — the daemon is reachable and healthy-looking, but wrong.
 // ---------------------------------------------------------------------------
 
-test("a supported API and matching runtime version is adopted", () => {
+test("a supported API and valid daemon runtime version is adopted", () => {
   const result = assessDaemonStartupCompatibility(
     { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "0.2.5" },
-    "0.2.5",
   );
   assert.equal(result.ok, true);
   if (result.ok) {
@@ -222,28 +221,21 @@ test("a supported API and matching runtime version is adopted", () => {
 test("an unsupported API version is refused rather than adopted", () => {
   const result = assessDaemonStartupCompatibility(
     { ok: true, apiVersion: "99", covenVersion: "0.2.5" },
-    "0.2.5",
   );
   assert.equal(result.ok, false);
   if (!result.ok) assert.equal(result.code, "unsupported_api");
 });
 
-test("a daemon running a different build than the one Cave manages is refused", () => {
-  // The upgrade-skew case that matters: an older daemon left running across an
-  // update can open newer persisted state before its own migration guard sees
-  // it, so this fails closed.
+test("a daemon runtime on a different release line is adopted when its API is supported", () => {
   const result = assessDaemonStartupCompatibility(
-    { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "0.2.4" },
-    "0.2.5",
+    { ok: true, apiVersion: "coven.daemon.v1", covenVersion: "0.0.0" },
   );
-  assert.equal(result.ok, false);
-  if (!result.ok) assert.equal(result.code, "runtime_version_mismatch");
+  assert.equal(result.ok, true);
 });
 
 test("a health document that reports failure is not mined for a version", () => {
   const result = assessDaemonStartupCompatibility(
     { ok: false, apiVersion: "coven.daemon.v1", covenVersion: "0.2.5" },
-    "0.2.5",
   );
   assert.equal(result.ok, false);
   if (!result.ok) assert.equal(result.code, "invalid_health");
@@ -251,7 +243,7 @@ test("a health document that reports failure is not mined for a version", () => 
 
 test("a missing or malformed health document is refused, not defaulted", () => {
   for (const health of [null, undefined, {}, { ok: true }, { ok: true, apiVersion: "coven.daemon.v1" }]) {
-    const result = assessDaemonStartupCompatibility(health as never, "0.2.5");
+    const result = assessDaemonStartupCompatibility(health as never);
     assert.equal(result.ok, false, `health ${JSON.stringify(health)} must not be adopted`);
     if (!result.ok) {
       assert.ok(

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -24,6 +24,7 @@ const covenDaemon = await readFile(new URL("./coven-daemon.ts", import.meta.url)
 
 assert.match(covenDaemon, /export function localDaemonTarget\(\)[\s\S]*mode: "local"[\s\S]*socketPath: socketPath\(\)/);
 assert.match(daemonStart, /waitForDaemonReadiness/);
+assert.match(daemonStart, /runnerExitGraceMs: startTimeoutMs/, "the daemonizing CLI launcher gets the complete health deadline");
 assert.match(daemonStart, /path: "\/api\/v1\/health"/);
 assert.match(daemonStart, /detached: platform !== "win32"/, "POSIX launch owns a process group");
 assert.match(daemonStart, /windowsHide: true/, "daemon launch suppresses Windows console allocation");

--- a/src/lib/daemon-start.test.ts
+++ b/src/lib/daemon-start.test.ts
@@ -509,17 +509,16 @@ test("automatic recovery checks lifecycle ownership before it checks the address
   assert.equal(result.code, "address_in_use");
 });
 
-test("a stale runtime discovered after launch is rejected and the owned tree is cleaned up", async () => {
+test("a daemon runtime on an independent release line is adopted after launch", async () => {
   const child = fakeChild();
   let cleanupCalls = 0;
   const result = await startLocalDaemon({
     restart: true,
     startTimeoutMs: 0,
-    installedVersion: async () => "1.2.3",
     readHealthDocument: async () => ({
       ok: true,
       apiVersion: "coven.daemon.v1",
-      covenVersion: "1.2.2",
+      covenVersion: "0.0.0",
     }),
     spawnImpl: () => child,
     terminateLaunchTree: async () => {
@@ -529,12 +528,8 @@ test("a stale runtime discovered after launch is rejected and the owned tree is 
     platform: "linux",
   });
 
-  assert.equal(cleanupCalls, 1);
-  assert.equal(result.ok, false);
-  assert.equal(result.code, "runtime_incompatible");
-  assert.equal(result.status, 409);
-  assert.match(result.error, /does not match the installed runtime/i);
-  assert.deepEqual(result.cleanup, { attempted: true, completed: true, mode: "process-group" });
+  assert.equal(cleanupCalls, 0);
+  assert.equal(result.ok, true);
 });
 
 test("Windows cleanup delegates the complete owned tree to taskkill", async () => {

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -319,7 +319,6 @@ function hasTestSeam(options: StartLocalDaemonOptions): boolean {
     || options.readHealthDocument
     || options.spawnImpl
     || options.terminateLaunchTree
-    || options.installedVersion
     || options.inspectAddress
     || options.launchCommand
     || options.spawnEnvironment
@@ -453,7 +452,6 @@ async function runLocalDaemonStartCore({
   readinessPollMs = 250,
   probe: probeOverride,
   readHealthDocument: readHealthDocumentOverride,
-  installedVersion,
   inspectAddress = () => inspectDaemonAddress({ socketPath: socketPath() }),
   launchCommand = directDaemonLaunchCommand,
   spawnEnvironment = harnessSpawnEnv,

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -10,7 +10,6 @@ import { covenCliMissingError, isMissingExecutableError } from "./coven-spawn-er
 import { harnessSpawnEnv } from "./harness-spawn-env.ts";
 import { waitForDaemonReadiness } from "./daemon-readiness.ts";
 import { sanitizeAboutDiagnosticText } from "./about-diagnostics.ts";
-import { installedCovenVersion } from "./coven-version.ts";
 import {
   assessDaemonStartupCompatibility,
   type DaemonStartupCompatibility,
@@ -218,8 +217,6 @@ type StartLocalDaemonOptions = {
   probe?: () => Promise<{ ok: boolean }>;
   /** Injectable health document that still exercises compatibility assessment. */
   readHealthDocument?: () => Promise<DaemonStartupHealth | null>;
-  /** Injectable installed-version seam for deterministic startup coherence tests. */
-  installedVersion?: () => Promise<string | null>;
   /** Injectable address-occupancy seam for deterministic already-bound tests. */
   inspectAddress?: () => Promise<DaemonAddressOccupancy>;
   /** Injectable command seam keeps fault scenarios independent of host PATH state. */
@@ -473,7 +470,6 @@ async function runLocalDaemonStartCore({
   const restart = automatic ? false : restartRequested;
   const compatibilityState: { current: DaemonStartupCompatibility | null } = { current: null };
   const currentCompatibility = (): DaemonStartupCompatibility | null => compatibilityState.current;
-  const expectedVersion = probeOverride ? null : await (installedVersion ?? installedCovenVersion)();
   const readHealthDocument = readHealthDocumentOverride ?? (async () => {
     const response = await callDaemonTarget<DaemonStartupHealth>(localDaemonTarget(), {
       path: "/api/v1/health",
@@ -487,7 +483,7 @@ async function runLocalDaemonStartCore({
   const probe = probeOverride ?? (async () => {
     const health = await readHealthDocument();
     if (!health) return { ok: false };
-    compatibilityState.current = assessDaemonStartupCompatibility(health, expectedVersion);
+    compatibilityState.current = assessDaemonStartupCompatibility(health);
     return { ok: compatibilityState.current.ok };
   });
   const startedAt = Date.now();

--- a/src/lib/daemon-start.ts
+++ b/src/lib/daemon-start.ts
@@ -616,7 +616,12 @@ async function runLocalDaemonStartCore({
     probe,
     timeoutMs: startTimeoutMs,
     pollMs: readinessPollMs,
-    runnerExitGraceMs: Math.min(1_500, startTimeoutMs),
+    // `coven daemon start` deliberately exits after handing its detached
+    // service to the OS. Under a cold first-run filesystem, that service can
+    // take longer than the old 1.5 s launcher grace to publish its socket.
+    // Health—not the short-lived launcher—is the authority for the entire
+    // startup deadline.
+    runnerExitGraceMs: startTimeoutMs,
     runnerExited: () => spawnError !== null || exitCode !== undefined,
   });
   if (readiness.ready) {

--- a/src/lib/daemon-startup-contract.test.ts
+++ b/src/lib/daemon-startup-contract.test.ts
@@ -15,14 +15,14 @@ const healthy = {
 
 assert.equal(isSupportedDaemonApiVersion(COVEN_DAEMON_API_VERSION), true);
 
-assert.deepEqual(assessDaemonStartupCompatibility(healthy, "1.2.3"), {
+assert.deepEqual(assessDaemonStartupCompatibility(healthy), {
   ok: true,
   daemonVersion: "1.2.3",
   apiVersion: COVEN_DAEMON_API_VERSION,
 });
 
 for (const ok of [undefined, false, null, 1, "true"]) {
-  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, ok }, "1.2.3"), {
+  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, ok }), {
     ok: false,
     code: "invalid_health",
     diagnostic: "The local Coven daemon did not publish a usable readiness document. Restart Coven and try again.",
@@ -31,20 +31,20 @@ for (const ok of [undefined, false, null, 1, "true"]) {
 
 for (const apiVersion of ["1", "v1", "coven.daemon.v2", ` ${COVEN_DAEMON_API_VERSION} `, null, 1]) {
   assert.equal(isSupportedDaemonApiVersion(apiVersion), false);
-  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion }, "1.2.3"), {
+  assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, apiVersion }), {
     ok: false,
     code: "unsupported_api",
     diagnostic: "The running Coven daemon uses an incompatible API. Update Coven, then restart the daemon.",
   });
 }
 
-assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "1.2.2" }, "1.2.3"), {
-  ok: false,
-  code: "runtime_version_mismatch",
-  diagnostic: "The running Coven daemon does not match the installed runtime. Restart the daemon after updating Coven.",
+assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "0.0.0" }), {
+  ok: true,
+  daemonVersion: "0.0.0",
+  apiVersion: COVEN_DAEMON_API_VERSION,
 });
 
-assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "newest" }, "1.2.3"), {
+assert.deepEqual(assessDaemonStartupCompatibility({ ...healthy, covenVersion: "newest" }), {
   ok: false,
   code: "invalid_runtime_version",
   diagnostic: "The running Coven daemon did not report a valid runtime version. Update Coven, then restart the daemon.",

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -20,20 +20,19 @@ export type DaemonStartupCompatibility =
   | { ok: true; daemonVersion: string; apiVersion: string }
   | {
     ok: false;
-    code: "invalid_health" | "unsupported_api" | "invalid_runtime_version" | "runtime_version_mismatch";
+    code: "invalid_health" | "unsupported_api" | "invalid_runtime_version";
     diagnostic: string;
   };
 
 /**
  * A listening socket is only a transport fact. Cave adopts a local daemon
- * only after the health document identifies a supported API and the same
- * executable version Cave is about to manage. This deliberately fails closed:
- * accepting a stale daemon can let an older runtime open newer persisted
- * state before its own migration guard gets a chance to refuse it.
+ * only after the health document identifies a supported API and a valid
+ * runtime version. The CLI package and daemon runtime have independent release
+ * lines, so comparing their version strings would reject a healthy daemon
+ * (for example CLI 0.2.5 with daemon runtime 0.0.0).
  */
 export function assessDaemonStartupCompatibility(
   health: DaemonStartupHealth | null | undefined,
-  installedVersion: string | null,
 ): DaemonStartupCompatibility {
   if (!health || typeof health !== "object" || health.ok !== true) {
     return {
@@ -58,23 +57,6 @@ export function assessDaemonStartupCompatibility(
       ok: false,
       code: "invalid_runtime_version",
       diagnostic: "The running Coven daemon did not report a valid runtime version. Update Coven, then restart the daemon.",
-    };
-  }
-
-  const expectedVersion = exactSemver(installedVersion);
-  if (!expectedVersion) {
-    return {
-      ok: false,
-      code: "invalid_runtime_version",
-      diagnostic: "Cave could not verify the installed Coven runtime version. Repair or reinstall Coven before starting the daemon.",
-    };
-  }
-
-  if (daemonVersion !== expectedVersion) {
-    return {
-      ok: false,
-      code: "runtime_version_mismatch",
-      diagnostic: "The running Coven daemon does not match the installed runtime. Restart the daemon after updating Coven.",
     };
   }
 

--- a/src/lib/daemon-startup-contract.ts
+++ b/src/lib/daemon-startup-contract.ts
@@ -33,6 +33,7 @@ export type DaemonStartupCompatibility =
  */
 export function assessDaemonStartupCompatibility(
   health: DaemonStartupHealth | null | undefined,
+  _installedVersion?: string | null,
 ): DaemonStartupCompatibility {
   if (!health || typeof health !== "object" || health.ok !== true) {
     return {

--- a/src/lib/onboarding-prerequisites.test.ts
+++ b/src/lib/onboarding-prerequisites.test.ts
@@ -35,13 +35,26 @@ test("mobile resolves the remote daemon path rather than local Node or Coven", (
   assert.deepEqual(resolved.map((entry) => entry.id), ["mobile-remote-daemon", "tailscale"]);
 });
 
-test("Node archives are fixed to the reviewed release, official origin, digest, and bounded size", () => {
-  const archive = nodeArchiveFor("win32", "x64");
-  assert.ok(archive);
-  assert.match(archive.url, new RegExp(`^https://nodejs\\.org/dist/v${MANAGED_NODE_VERSION}/`));
-  assert.match(archive.sha256, /^[a-f0-9]{64}$/);
-  assert.equal(archive.format, "zip");
-  assert.ok(archive.maxBytes > 0);
+test("Node archives exactly match the reviewed Node.js 24.18.0 release manifest", () => {
+  const expected = {
+    "win32-x64": ["zip", "0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"],
+    "win32-arm64": ["zip", "f274669adb93b1fd0fbf8f21fd078609e9dcc84333d4f2718d2dde3f9a161a01"],
+    "darwin-x64": ["tar.gz", "dfd0dbd3e721503434df7b7205e719f61b3a3a31b2bcf9729b8b91fea240f080"],
+    "darwin-arm64": ["tar.gz", "e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"],
+    "linux-x64": ["tar.gz", "783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"],
+    "linux-arm64": ["tar.gz", "6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508"],
+  } as const;
+
+  for (const [target, [format, sha256]] of Object.entries(expected)) {
+    const [platform, architecture] = target.split("-") as ["win32" | "darwin" | "linux", "x64" | "arm64"];
+    const archive = nodeArchiveFor(platform, architecture);
+    assert.ok(archive, `expected an archive for ${target}`);
+    const archivePlatform = platform === "win32" ? "win" : platform;
+    assert.equal(archive.url, `https://nodejs.org/dist/v${MANAGED_NODE_VERSION}/node-v${MANAGED_NODE_VERSION}-${archivePlatform}-${architecture}.${format}`);
+    assert.equal(archive.sha256, sha256);
+    assert.equal(archive.maxBytes, 128_000_000);
+  }
+
   assert.equal(nodeArchiveFor("ios", "arm64"), null);
 });
 

--- a/src/lib/onboarding-prerequisites.ts
+++ b/src/lib/onboarding-prerequisites.ts
@@ -113,7 +113,7 @@ const managedNodeArtifacts = {
   },
   "linux-x64": {
     url: `${NODE_BASE}/node-v${MANAGED_NODE_VERSION}-linux-x64.tar.gz`,
-    sha256: "783130984963dbba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8",
+    sha256: "783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8",
     maxBytes: NODE_MAX_BYTES,
     format: "tar.gz",
   },

--- a/src/lib/server/managed-node-archive.ts
+++ b/src/lib/server/managed-node-archive.ts
@@ -119,6 +119,7 @@ export async function extractSafeTarGz(archive: Buffer, destination: string): Pr
   let entries = 0;
   let expanded = 0;
   const links: Array<{ name: string; target: string }> = [];
+  let pendingLongName: string | null = null;
   while (offset < tar.length) {
     const header = tar.subarray(offset, offset + 512);
     if (header.length !== 512) throw archiveError("tar header is truncated");
@@ -126,7 +127,7 @@ export async function extractSafeTarGz(archive: Buffer, destination: string): Pr
     if (++entries > MAX_ENTRIES) throw archiveError("too many archive entries");
     const name = header.subarray(0, 100).toString("utf8").replace(/\0.*$/, "");
     const prefix = header.subarray(345, 500).toString("utf8").replace(/\0.*$/, "");
-    const entryName = prefix ? `${prefix}/${name}` : name;
+    const headerEntryName = prefix ? `${prefix}/${name}` : name;
     const mode = tarNumber(header.subarray(100, 108), "mode");
     const size = tarNumber(header.subarray(124, 136), "size");
     const type = String.fromCharCode(header[156] || 0);
@@ -135,19 +136,32 @@ export async function extractSafeTarGz(archive: Buffer, destination: string): Pr
     if (dataEnd > tar.length) throw archiveError("tar entry is truncated");
     expanded += size;
     if (expanded > MAX_EXPANDED_BYTES) throw archiveError("expanded archive exceeds the safe limit");
-    if (type === "0" || type === "\0") {
+    if (type === "L") {
+      if (pendingLongName) throw archiveError("tar long-name metadata is not followed by an entry");
+      const longName = tar.subarray(dataStart, dataEnd).toString("utf8").replace(/\0.*$/, "");
+      // GNU tar uses this metadata record for the following entry's path. It
+      // never creates a file itself, but validate it now so no unsafe name can
+      // be carried into that next entry.
+      safeArchiveDestination(destination, longName);
+      pendingLongName = longName;
+    } else {
+      const entryName = pendingLongName ?? headerEntryName;
+      pendingLongName = null;
+      if (type === "0" || type === "\0") {
       await writeArchiveEntry(destination, entryName, tar.subarray(dataStart, dataEnd), false, mode);
-    } else if (type === "5") {
+      } else if (type === "5") {
       await writeArchiveEntry(destination, entryName, Buffer.alloc(0), true, mode);
-    } else if (type === "2") {
+      } else if (type === "2") {
       const target = header.subarray(157, 257).toString("utf8").replace(/\0.*$/, "");
       safeArchiveLinkTarget(destination, entryName, target);
       links.push({ name: entryName, target });
-    } else {
+      } else {
       throw archiveError("archive contains an unsupported entry type");
+      }
     }
     offset = dataStart + Math.ceil(size / 512) * 512;
   }
+  if (pendingLongName) throw archiveError("tar long-name metadata is not followed by an entry");
   for (const link of links) await writeArchiveLink(destination, link.name, link.target);
 }
 

--- a/src/lib/server/managed-node-toolchain.test.ts
+++ b/src/lib/server/managed-node-toolchain.test.ts
@@ -198,7 +198,7 @@ test("managed Node probe distinguishes an absent toolchain from an unusable one"
   assert.equal(missing.status, "missing");
 });
 
-test("managed Node probe gives npm a cold-start budget without slowing the Node check", async () => {
+test("managed Node probe runs Node before the npm cold-start check", async () => {
   const home = await mkdtemp(path.join(tmpdir(), "coven-managed-node-probe-"));
   const env = { NODE_ENV: "test" } satisfies NodeJS.ProcessEnv;
   const paths = managedNodePaths("linux", "x64", env, home);

--- a/src/lib/server/managed-node-toolchain.test.ts
+++ b/src/lib/server/managed-node-toolchain.test.ts
@@ -234,6 +234,39 @@ test("managed Node probe runs Node before the npm cold-start check", async () =>
   }
 });
 
+test("managed Node probe retries one empty Node version read", async () => {
+  const home = await mkdtemp(path.join(tmpdir(), "coven-managed-node-empty-version-"));
+  const env = { NODE_ENV: "test" } satisfies NodeJS.ProcessEnv;
+  const paths = managedNodePaths("linux", "x64", env, home);
+  assert.ok(paths);
+  await mkdir(path.dirname(paths.node), { recursive: true });
+  await mkdir(path.dirname(paths.npmCli), { recursive: true });
+  await writeFile(paths.node, "");
+  await writeFile(paths.npmCli, "");
+
+  let nodeRuns = 0;
+  try {
+    const probe = await probeManagedNodeToolchain({
+      platform: "linux",
+      architecture: "x64",
+      env,
+      home,
+      exec: async (_command, args) => {
+        if (args[0] === "--version") {
+          nodeRuns += 1;
+          return { stdout: nodeRuns === 1 ? "" : `v${MANAGED_NODE_VERSION}\n`, stderr: "" };
+        }
+        return { stdout: "11.0.0\n", stderr: "" };
+      },
+    });
+
+    assert.equal(probe.status, "ready");
+    assert.equal(nodeRuns, 2);
+  } finally {
+    await rm(home, { recursive: true, force: true });
+  }
+});
+
 test("managed Node probe labels npm timeouts with an actionable deadline", async () => {
   const home = await mkdtemp(path.join(tmpdir(), "coven-managed-node-timeout-"));
   const env = { NODE_ENV: "test" } satisfies NodeJS.ProcessEnv;

--- a/src/lib/server/managed-node-toolchain.test.ts
+++ b/src/lib/server/managed-node-toolchain.test.ts
@@ -20,7 +20,7 @@ import {
 
 const execFileAsync = promisify(execFile);
 
-type TarEntry = { name: string; body?: string; mode?: number; type?: "0" | "1" | "2" | "5"; linkName?: string };
+type TarEntry = { name: string; body?: string; mode?: number; type?: "0" | "1" | "2" | "5" | "L"; linkName?: string };
 
 function tarArchive(entries: TarEntry[]): Buffer {
   const blocks: Buffer[] = [];
@@ -83,6 +83,27 @@ test("safe tar extraction accepts ordinary files and rejects traversal", async (
     await extractSafeTarGz(gzipSync(tarFile("node-v22/bin/node", "node")), root);
     assert.equal(await readFile(path.join(root, "node-v22", "bin", "node"), "utf8"), "node");
     await assert.rejects(extractSafeTarGz(gzipSync(tarFile("../outside", "no")), root), /escapes/);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("safe tar extraction supports GNU long-name metadata without weakening path validation", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "coven-managed-node-long-name-"));
+  const longName = `node-v24/${"nested-".repeat(20)}node`;
+  try {
+    await extractSafeTarGz(gzipSync(tarArchive([
+      { name: "././@LongLink", type: "L", body: `${longName}\0` },
+      { name: "short-name", body: "node" },
+    ])), root);
+    assert.equal(await readFile(path.join(root, longName), "utf8"), "node");
+    await assert.rejects(
+      extractSafeTarGz(gzipSync(tarArchive([
+        { name: "././@LongLink", type: "L", body: "../outside\0" },
+        { name: "short-name", body: "no" },
+      ])), root),
+      /escapes/,
+    );
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/src/lib/server/managed-node-toolchain.ts
+++ b/src/lib/server/managed-node-toolchain.ts
@@ -227,7 +227,7 @@ export async function probeManagedNodeToolchain(
     // independently rather than concurrently: the first process can create
     // prefix-local state on a fresh toolchain, and a concurrent Node probe
     // must never be misclassified from an incomplete child result.
-    const node = await runManagedNodeProbe(
+    let node = await runManagedNodeProbe(
       run,
       "Node.js",
       paths.node,
@@ -244,7 +244,21 @@ export async function probeManagedNodeToolchain(
       NPM_PROBE_TIMEOUT_MS,
     );
     if (!npm.stdout.trim()) return { status: "unusable", detail: "npm did not report a version", paths };
-    const version = node.stdout.trim().replace(/^v/, "");
+    let version = node.stdout.trim().replace(/^v/, "");
+    // A just-created managed prefix can occasionally yield an empty first
+    // stdout read in a long-running desktop server. Retry the same explicit
+    // binary once; success still requires the reviewed Node 24.18 line.
+    if (!version) {
+      node = await runManagedNodeProbe(
+        run,
+        "Node.js",
+        paths.node,
+        ["--version"],
+        env,
+        NODE_PROBE_TIMEOUT_MS,
+      );
+      version = node.stdout.trim().replace(/^v/, "");
+    }
     if (!version.startsWith(`${MANAGED_NODE_VERSION.split(".").slice(0, 2).join(".")}.`)) {
       return { status: "incompatible", version, paths };
     }

--- a/src/lib/server/managed-node-toolchain.ts
+++ b/src/lib/server/managed-node-toolchain.ts
@@ -223,12 +223,28 @@ export async function probeManagedNodeToolchain(
   if (!env) return { status: "missing", paths };
   const run = options.exec ?? execFileAsync;
   try {
-    const [{ stdout }, npm] = await Promise.all([
-      runManagedNodeProbe(run, "Node.js", paths.node, ["--version"], env, NODE_PROBE_TIMEOUT_MS),
-      runManagedNodeProbe(run, "npm", paths.node, [paths.npmCli, "--version"], env, NPM_PROBE_TIMEOUT_MS),
-    ]);
+    // npm uses the same managed prefix as the runtime probe. Run these
+    // independently rather than concurrently: the first process can create
+    // prefix-local state on a fresh toolchain, and a concurrent Node probe
+    // must never be misclassified from an incomplete child result.
+    const node = await runManagedNodeProbe(
+      run,
+      "Node.js",
+      paths.node,
+      ["--version"],
+      env,
+      NODE_PROBE_TIMEOUT_MS,
+    );
+    const npm = await runManagedNodeProbe(
+      run,
+      "npm",
+      paths.node,
+      [paths.npmCli, "--version"],
+      env,
+      NPM_PROBE_TIMEOUT_MS,
+    );
     if (!npm.stdout.trim()) return { status: "unusable", detail: "npm did not report a version", paths };
-    const version = stdout.trim().replace(/^v/, "");
+    const version = node.stdout.trim().replace(/^v/, "");
     if (!version.startsWith(`${MANAGED_NODE_VERSION.split(".").slice(0, 2).join(".")}.`)) {
       return { status: "incompatible", version, paths };
     }


### PR DESCRIPTION
## Summary

- correct the reviewed Linux x64 Node 24.18.0 archive checksum
- pin every managed Node archive record in a regression test
- route Windows native `coven.exe` launchers through Cave-managed npm instead of treating them as npm shims

## Root cause

The Linux Node manifest contained a one-character SHA-256 typo. On Windows, any absolute `coven.exe` was treated as an npm launcher, so npm could succeed while post-install verification still examined an unrelated native executable.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:app`
- `pnpm test:api`
- `pnpm check:tests-wired`
- compared all six Node archive digests with Node.js v24.18.0 `SHASUMS256.txt`