### PR TITLE
perf(worktrees): scope reprobe's inventory to the candidate it asks about

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -42,6 +42,34 @@ export interface WorktreeLifecycleInventoryOptions {
    * throw.
    */
   onProgress?: () => void;
+
+  /**
+   * Restrict the per-unit GitHub probing to these full local refs.
+   *
+   * The pull-request probe costs one GraphQL round trip per head oid and
+   * another per branch — measured at ~2 calls and ~2s per unit, so ~104 calls
+   * and ~95s of a ~134s inventory on a 47-unit checkout. Retirement's reprobe
+   * pays all of it to re-verify ONE candidate and then discards every other
+   * unit, twice per retirement (cave-imhf0).
+   *
+   * Scoping narrows ONLY that GitHub probing. Every unit is still enumerated
+   * locally, so cross-unit checks that do not need the network — conflicting
+   * structured paths, duplicate branch claims, orphaned metadata — see exactly
+   * what they see in a full inventory, and the focused unit's own
+   * classification is unchanged.
+   *
+   * Units outside the scope FAIL CLOSED: each is given an explicit
+   * "not probed" probe error, so it classifies `uncertain` rather than
+   * appearing to have no pull request. That direction is not optional. The
+   * absence of a PR association is precisely what makes a unit look landed and
+   * retirable, so treating "not asked" as "no PR" would turn a cost
+   * optimisation into a gate that offers up live worktrees for destruction.
+   *
+   * A unit whose head oid or branch is shared with a focused unit keeps its
+   * real answer: the probe result is keyed by oid and branch, not by unit, so
+   * poisoning it would corrupt the focused unit's own data.
+   */
+  focusRefs?: string[];
 }
 
 export interface WorktreeLifecycleInventory {
@@ -2956,13 +2984,45 @@ function collectInventory(
           oid: null,
           error: originIdentity.error,
         };
+  const focusRefs = options.focusRefs ? new Set(options.focusRefs) : null;
+  const probedUnits =
+    focusRefs === null ? units : units.filter((unit) => unit.ref !== null && focusRefs.has(unit.ref));
   const prs = fetchPullRequests(
     options.repo,
     root,
-    units.map((unit) => unit.head),
-    units.flatMap((unit) => (unit.branch ? [unit.branch] : [])),
+    probedUnits.map((unit) => unit.head),
+    probedUnits.flatMap((unit) => (unit.branch ? [unit.branch] : [])),
     defaultBranch.branch,
   );
+  if (focusRefs !== null) {
+    // Fail closed for everything that was not asked about. Without this the
+    // unprobed units would read as "no pull request", which is the signal that
+    // makes a unit look landed and retirable — a scoped inventory would then
+    // offer live worktrees up for destruction.
+    //
+    // Keyed by oid and branch rather than by unit, because that is how the
+    // probe result is keyed: two units can share a head oid, and marking it
+    // unprobed on behalf of an unfocused unit would corrupt the focused unit's
+    // own answer. So skip any key a focused unit depends on.
+    const probedHeads = new Set(probedUnits.map((unit) => unit.head));
+    const probedBranches = new Set(
+      probedUnits.flatMap((unit) => (unit.branch ? [unit.branch] : [])),
+    );
+    const scopedError =
+      "pull request association not probed: inventory was scoped to the retirement candidate";
+    for (const unit of units) {
+      if (!probedHeads.has(unit.head) && !prs.errorsByOid.has(unit.head)) {
+        prs.errorsByOid.set(unit.head, scopedError);
+      }
+      if (
+        unit.branch !== null &&
+        !probedBranches.has(unit.branch) &&
+        !prs.errorsByBranch.has(unit.branch)
+      ) {
+        prs.errorsByBranch.set(unit.branch, scopedError);
+      }
+    }
+  }
   const workflows = fetchWorkflows(options.repo, root);
   const claims = fetchClaims(root);
   const sessions = fetchSessions(root);

--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -3008,8 +3008,12 @@ function collectInventory(
     const probedBranches = new Set(
       probedUnits.flatMap((unit) => (unit.branch ? [unit.branch] : [])),
     );
+    // Describes the MECHANISM, not whoever happens to call it today. focusRefs
+    // is a general inventory option, and this string surfaces in unit reasons
+    // and CLI diagnostics — naming one caller would misdescribe the next one.
     const scopedError =
-      "pull request association not probed: inventory was scoped to the retirement candidate";
+      `pull request association not probed: this unit was outside the inventory's ` +
+      `focusRefs scope (${focusRefs.size} ref${focusRefs.size === 1 ? "" : "s"})`;
     for (const unit of units) {
       if (!probedHeads.has(unit.head) && !prs.errorsByOid.has(unit.head)) {
         prs.errorsByOid.set(unit.head, scopedError);

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -1468,6 +1468,154 @@ process.stdout.write(JSON.stringify(output) + "\\n");
   }
 });
 
+test("a scoped inventory keeps the focused unit's verdict and fails every other unit closed", () => {
+  // reprobe asks about ONE candidate but used to probe every unit's pull
+  // request association: ~2 GraphQL round trips per unit, ~104 calls and ~95s
+  // of a ~134s inventory on a 47-unit checkout, all but one result discarded.
+  // focusRefs narrows that probing (cave-imhf0).
+  //
+  // The danger is not the saving, it is the direction of the error. A unit with
+  // no pull request association looks landed, and landed is what makes a unit
+  // retirable — so "we did not ask" must never be recorded as "there is no PR".
+  // This pins both halves: the focused unit's verdict is identical to a full
+  // run, and a unit that a full run calls retirable becomes `uncertain` when it
+  // is out of scope.
+  const fixture = createGitFixture();
+  try {
+    const agedEnv = {
+      GIT_AUTHOR_DATE: "2026-07-20T12:00:00Z",
+      GIT_COMMITTER_DATE: "2026-07-20T12:00:00Z",
+    };
+    const focused = "fix/scoped-focused";
+    const other = "fix/scoped-other";
+    const worktrees = {};
+    // Both branches must be LANDED (an ancestor of the pushed default tip) and
+    // must have DISTINCT head oids. Cutting both from one commit satisfies
+    // "landed" but gives them the same oid, and the pull-request probe is keyed
+    // by oid — one association shared by two units is its own ambiguity, which
+    // classifies both `uncertain` for a reason unrelated to scoping. Committing
+    // ON each branch gives distinct oids but stops them being ancestors of main.
+    // So advance main between the two cuts: each branch is a distinct earlier
+    // point of the default branch's own history.
+    for (const branch of [focused, other]) {
+      // Under fixture.repo, which is already realpath'd. Basing this on
+      // fixture.fixtureRoot instead yields /var/... while git reports
+      // /private/var/..., and the metadata path check rejects the mismatch.
+      worktrees[branch] = path.join(
+        fixture.repo,
+        ".worktrees",
+        branch.replace(/[^A-Za-z0-9]/g, "-"),
+      );
+      git(["commit", "-q", "--allow-empty", "-m", `base for ${branch}`], fixture.repo, {
+        env: agedEnv,
+      });
+      git(["branch", branch, "HEAD"], fixture.repo, { env: agedEnv });
+      git(["push", "-q", "-u", "origin", branch], fixture.repo);
+      git(["worktree", "add", worktrees[branch], branch], fixture.repo, { env: agedEnv });
+    }
+    // Advance and push main past both, so each branch is strictly behind the
+    // default tip and its landing time is provable.
+    git(["commit", "-q", "--allow-empty", "-m", "land scoped fixtures"], fixture.repo, {
+      env: agedEnv,
+    });
+    git(["push", "-q", "origin", "main"], fixture.repo);
+
+    const beadFor = (id, branch) => ({
+      id,
+      status: "closed",
+      title: "Scoped inventory fixture",
+      description: "",
+      notes: "",
+      external_ref: null,
+      metadata: {
+        coven: {
+          worktree: {
+            branch,
+            path: worktrees[branch],
+            owner: "retirement-test",
+            purpose: "managed fixture",
+            disposition: "pr",
+            createdAt: "2026-07-20T12:00:00Z",
+          },
+        },
+      },
+    });
+    executable(
+      path.join(fixture.bin, "bd"),
+      `#!/usr/bin/env node
+console.log(JSON.stringify(${JSON.stringify([
+        beadFor("cave-scoped-focused", focused),
+        beadFor("cave-scoped-other", other),
+      ])}));
+`,
+    );
+
+    const nowMs = Date.parse("2026-08-01T12:00:00Z");
+    const focusedRef = `refs/heads/${focused}`;
+    const otherRef = `refs/heads/${other}`;
+    const run = (focusRefs) =>
+      withPathPrefix(fixture.bin, () =>
+        collectWorktreeLifecycleInventory({
+          repo: "OpenCoven/coven-cave",
+          root: fixture.repo,
+          nowMs,
+          ...(focusRefs ? { focusRefs } : {}),
+        }),
+      );
+
+    const full = run(null);
+    const fullFocused = findItem(full.items, focusedRef);
+    const fullOther = findItem(full.items, otherRef);
+
+    const scoped = run([focusedRef]);
+    const scopedFocused = findItem(scoped.items, focusedRef);
+    const scopedOther = findItem(scoped.items, otherRef);
+
+    // The verdict the retirement gate acts on must be untouched by scoping.
+    assert.equal(
+      scopedFocused.lane,
+      fullFocused.lane,
+      `focused lane changed under scoping: ${fullFocused.lane} -> ${scopedFocused.lane}`,
+    );
+    assert.deepEqual(
+      scopedFocused.reasons,
+      fullFocused.reasons,
+      "the focused unit's reasons must be identical to a full run",
+    );
+    assert.ok(
+      !scopedFocused.probeErrors.some((error) => error.includes("not probed")),
+      "the focused unit must actually be probed",
+    );
+
+    // And the other unit must move only in the safe direction.
+    assert.ok(
+      scopedOther.probeErrors.some((error) => error.includes("not probed")),
+      "an out-of-scope unit must record that its association was never asked for",
+    );
+    assert.equal(
+      scopedOther.lane,
+      "uncertain",
+      `an out-of-scope unit must fail closed; it was ${scopedOther.lane}`,
+    );
+    assert.notEqual(
+      scopedOther.lane,
+      "retire-after-gate",
+      "scoping must never be able to present an unprobed unit as retirable",
+    );
+    // Guard the guard: if the fixture stopped making this unit retirable, the
+    // assertion above would pass for the wrong reason and this test would quietly
+    // stop covering the hazard it exists for.
+    assert.equal(
+      fullOther.lane,
+      "retire-after-gate",
+      `fixture no longer produces a second retirable unit (was ${fullOther.lane}); ` +
+        "the fail-closed assertion above is only meaningful against one",
+    );
+  } finally {
+    cleanupFixture(fixture.fixtureRoot);
+  }
+});
+
 test("adapter reprobe renews the maintenance fence while its inventory runs", () => {
   // reprobe() rebuilds the WHOLE lifecycle inventory to re-verify one unit.
   // On a real checkout that measured 134s for 47 units, against a 120s Coven

--- a/scripts/worktree-lifecycle-retirement.ts
+++ b/scripts/worktree-lifecycle-retirement.ts
@@ -502,6 +502,19 @@ export function createGitRetirementOperations({
           root: normalizedRoot,
           nowMs: readNowMs(),
           onProgress: renewFenceDuringProbe,
+          // Only this candidate needs a fresh GitHub answer. Probing all of
+          // them cost ~2 GraphQL round trips per unit — ~104 calls and ~95s of
+          // a ~134s inventory on a 47-unit checkout — and every result but one
+          // was discarded by the ref filter below. Retirement reprobes twice
+          // per unit, so a --max-retire 3 run paid it up to six times
+          // (cave-imhf0).
+          //
+          // Scoping does not weaken the check this probe exists to perform.
+          // The candidate itself is probed exactly as before, so its lane and
+          // reasons are unchanged; every other unit fails closed to
+          // `uncertain`, which is the safe direction and is asserted by the
+          // inventory's own tests.
+          focusRefs: [item.ref],
         });
       } catch (error) {
         return {


### PR DESCRIPTION
Retirement's `reprobe` rebuilds the **whole** lifecycle inventory to re-verify **one** unit, then discards every other result with a ref filter.

Follow-up to cave-wsayy, which made that probe *correct* (it renews the maintenance fence now) and deliberately left it *expensive*.

## Where the cost is

Traced with a logging shim over every subprocess — 687 of them in a single inventory on a 47-unit checkout:

| | calls | time |
|---|---:|---:|
| `gh` | 104 | **~95 s** |
| `git` | 583 | ~3 s |

`fetchPullRequests` makes one GraphQL round trip per head oid and another per branch — ~2 per unit. So ~95 s of a ~134 s inventory answers a question about 46 units nobody asked about. A retirement reprobes **twice**, and `--max-retire 3` can retire three, so one apply run could pay it six times.

## The change

`collectWorktreeLifecycleInventory` takes a new `focusRefs` option that narrows **only** the GitHub probing. Every unit is still enumerated locally, so the cross-unit checks that need no network — conflicting structured paths, duplicate branch claims, orphaned metadata — see exactly what a full inventory shows.

### Units outside the scope fail closed

Each unprobed unit gets an explicit `not probed` error and therefore classifies `uncertain`.

This direction is the entire safety argument, so it is worth being blunt about: **a missing pull-request association is exactly what makes a unit look landed, and landed is what makes it retirable.** Recording "we did not ask" as "there is no PR" would convert a cost optimisation into a gate that offers live worktrees up for destruction. Keys shared with a focused unit are left untouched, because the probe result is keyed by oid and branch rather than by unit, and two units can share a head.

## Measured, same repository, fixed `nowMs`

| | time | candidate lane | reasons | probe errors |
|---|---:|---|---|---|
| full | 134.4 s | `retire-after-gate` | 2 | none |
| scoped | **57.6 s** | `retire-after-gate` | same 2 | none |

**2.3×, not the order of magnitude the call counts imply.** Removing ~102 of 104 `gh` calls does not collapse the runtime, because the remaining ~58 s is local git enumeration and JS work that scoping deliberately keeps. Roughly 150 s saved per retirement.

## Test

It pins both halves — the focused unit's lane and reasons identical to a full run, and a unit that a full run calls `retire-after-gate` becoming `uncertain` when out of scope.

It also asserts the fixture still produces a second **retirable** unit. That guard is load-bearing: it failed first, revealing the fail-closed assertion was passing for the wrong reason, and behind it were three fixture bugs (a `\n` escaping error that broke the `bd` stub outright, `/var` vs `/private/var` path mismatch, and branches that were either sharing an oid or not landed). Without it the test would have been green and covered nothing.

The fixture cuts each branch from a different point in main's history — the only way to get both *landed* and *distinctly-oid'd*, since the PR probe is keyed by oid.

## Verification

- `worktree-lifecycle-retirement.test.mjs` — passes
- `worktree-lifecycle-fence-renewal.test.mjs` — passes
- `worktree-lifecycle-patrol.test.mjs` — passes
- `pnpm typecheck`, `pnpm lint` — exit 0

The patrol suite needs a local workaround for **cave-a7kqf** (it pins the coven CLI version while its own stub is bypassed, so it aborts on any machine with a real `coven` installed). I ran it with that worked around and reverted the workaround before committing; it is not in this diff, and CI is unaffected since CI has no `coven` on PATH.
