### PR TITLE
fix(security): scope research grants to individual mission workspaces

### DIFF
--- a/src/lib/server/research-landing.test.ts
+++ b/src/lib/server/research-landing.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm, stat } from "node:fs/promises";
+import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -10,136 +10,51 @@ process.env.CAVE_PERMISSION_CONFIG_PATH_OVERRIDE = path.join(tmp, "permission-co
 process.env.CAVE_PROJECTS_PATH_OVERRIDE = path.join(tmp, "projects.json");
 process.env.COVEN_RESEARCH_MISSIONS_DIR = path.join(tmp, "research-missions");
 
-const {
-  ensureResearchLandingAccess,
-  ensureResearchLandingProject,
-  migrateAdHocMissionGrants,
-  RESEARCH_LANDING_PROJECT_NAME,
-} = await import("./research-landing.ts");
+const { ensureResearchLandingAccess } = await import("./research-landing.ts");
 const { createProject, loadProjects } = await import("../cave-projects.ts");
 const {
-  createAccessGroup,
   effectiveProjectAccess,
   grantProjectToFamiliar,
   listProjectGrants,
   loadProjectPermissions,
 } = await import("../project-permissions.ts");
-const { researchMissionsRoot } = await import("./research-mission-store.ts");
+const { researchMissionWorkspacePath, researchMissionsRoot } = await import(
+  "./research-mission-store.ts"
+);
 
-test.after(async () => {
-  await rm(tmp, { recursive: true, force: true });
-});
+test.after(async () => rm(tmp, { recursive: true, force: true }));
 
-test("the research landing root is registered as a Cave project exactly once", async () => {
-  const project = await ensureResearchLandingProject();
-  assert.equal(project.name, RESEARCH_LANDING_PROJECT_NAME);
-  assert.equal(project.root, researchMissionsRoot());
-  // The root exists on disk — a registered-but-missing directory would be
-  // dropped by savedCaveProjectRoots' validation and stay unusable.
-  assert.ok((await stat(researchMissionsRoot())).isDirectory());
-
-  const again = await ensureResearchLandingProject();
-  assert.equal(again.id, project.id, "re-ensuring returns the same project");
-  const projects = await loadProjects();
-  assert.equal(
-    projects.filter((entry) => entry.root === researchMissionsRoot()).length,
-    1,
-    "one project per landing root",
-  );
-});
-
-test("run-start access check grants the landing project to a familiar without access", async () => {
-  const first = await ensureResearchLandingAccess("sage");
-  assert.equal(first.granted, true, "missing access is granted");
+test("run-start grants only the current mission workspace", async () => {
+  const first = await ensureResearchLandingAccess("sage", "research-sage-one");
+  assert.equal(first.granted, true);
+  assert.equal(first.project.root, researchMissionWorkspacePath("research-sage-one"));
   const permissions = await loadProjectPermissions();
-  const effective = effectiveProjectAccess(permissions, "sage", first.project.id);
-  assert.equal(effective.level, "write");
-  const grant = (await listProjectGrants()).find(
-    (entry) => entry.familiarId === "sage" && entry.projectId === first.project.id,
-  );
-  assert.equal(grant?.source, "bootstrap");
+  assert.equal(effectiveProjectAccess(permissions, "sage", first.project.id).level, "write");
+  assert.ok(!(await loadProjects()).some((project) => project.root === researchMissionsRoot()));
+
+  const second = await ensureResearchLandingAccess("sage", "research-sage-one");
+  assert.equal(second.granted, false, "an existing mission grant is unchanged");
+  assert.equal(second.project.id, first.project.id);
 });
 
-test("an existing grant is left untouched on later runs", async () => {
-  const before = await listProjectGrants();
-  const second = await ensureResearchLandingAccess("sage");
-  assert.equal(second.granted, false, "effective access short-circuits the grant");
-  assert.deepEqual(await listProjectGrants(), before, "no grant record changed");
+test("a familiar cannot inherit access to another mission", async () => {
+  const sage = await ensureResearchLandingAccess("sage", "research-sage-two");
+  const echo = await ensureResearchLandingAccess("echo", "research-echo-one");
+  const permissions = await loadProjectPermissions();
+  assert.equal(effectiveProjectAccess(permissions, "sage", echo.project.id).level, null);
+  assert.equal(effectiveProjectAccess(permissions, "echo", sage.project.id).level, null);
 });
 
-test("ad-hoc per-mission grants migrate onto the landing project", async () => {
-  const landing = await ensureResearchLandingProject();
-  const missionRoot = path.join(researchMissionsRoot(), "research-legacy-mission");
-  const outside = await createProject({ name: "Unrelated", root: path.join(tmp, "unrelated") });
-  const adHoc = await createProject({ name: "research-legacy-mission", root: missionRoot });
+test("an insecure shared landing project from an older release is removed", async () => {
+  const shared = await createProject({ name: "Research Missions", root: researchMissionsRoot() });
   await grantProjectToFamiliar({
-    familiarId: "echo",
-    projectId: adHoc.id,
-    source: "human",
-    access: "read",
-  });
-  await grantProjectToFamiliar({
-    familiarId: "echo",
-    projectId: outside.id,
-    source: "human",
+    familiarId: "legacy",
+    projectId: shared.id,
+    source: "bootstrap",
     access: "write",
   });
-  // A group grant on the ad-hoc project must migrate its members too.
-  await createAccessGroup({
-    name: "Researchers",
-    memberFamiliarIds: ["astra"],
-    projectGrants: [{ projectId: adHoc.id, access: "write" }],
-  });
 
-  const result = await migrateAdHocMissionGrants(landing);
-  assert.equal(result.removedProjects, 1);
-  assert.deepEqual([...result.migratedFamiliarIds].sort(), ["astra", "echo"]);
-
-  const permissions = await loadProjectPermissions();
-  assert.equal(
-    effectiveProjectAccess(permissions, "echo", landing.id).level,
-    "read",
-    "the direct ad-hoc level carries over",
-  );
-  assert.equal(
-    effectiveProjectAccess(permissions, "astra", landing.id).level,
-    "write",
-    "the group ad-hoc level carries over",
-  );
-  const projects = await loadProjects();
-  assert.ok(!projects.some((entry) => entry.id === adHoc.id), "ad-hoc project removed");
-  assert.ok(projects.some((entry) => entry.id === outside.id), "unrelated project kept");
-  assert.ok(
-    !(await listProjectGrants()).some((entry) => entry.projectId === adHoc.id),
-    "no grant still points at the removed project",
-  );
-  assert.ok(
-    (await listProjectGrants()).some(
-      (entry) => entry.familiarId === "echo" && entry.projectId === outside.id,
-    ),
-    "grants outside the landing root are untouched",
-  );
-
-  const again = await migrateAdHocMissionGrants(landing);
-  assert.deepEqual(again, { removedProjects: 0, migratedFamiliarIds: [] }, "idempotent");
-});
-
-test("migration never downgrades an existing landing grant", async () => {
-  const landing = await ensureResearchLandingProject();
-  // sage already holds write on the landing project from the earlier test.
-  const adHoc = await createProject({
-    name: "research-old-mission",
-    root: path.join(researchMissionsRoot(), "research-old-mission"),
-  });
-  await grantProjectToFamiliar({
-    familiarId: "sage",
-    projectId: adHoc.id,
-    source: "human",
-    access: "read",
-  });
-  const result = await migrateAdHocMissionGrants(landing);
-  assert.equal(result.removedProjects, 1);
-  assert.deepEqual(result.migratedFamiliarIds, [], "write already satisfies read");
-  const permissions = await loadProjectPermissions();
-  assert.equal(effectiveProjectAccess(permissions, "sage", landing.id).level, "write");
+  await ensureResearchLandingAccess("legacy", "research-legacy-one");
+  assert.ok(!(await loadProjects()).some((project) => project.id === shared.id));
+  assert.ok(!(await listProjectGrants()).some((grant) => grant.projectId === shared.id));
 });

--- a/src/lib/server/research-landing.ts
+++ b/src/lib/server/research-landing.ts
@@ -17,6 +17,15 @@ export async function ensureResearchLandingAccess(
   familiarId: string,
   missionId: string,
 ): Promise<{ project: CaveProject; granted: boolean }> {
+  // Remove the insecure project created by older releases first. Keeping even
+  // one grant on this shared parent makes every mission workspace accessible,
+  // and this cleanup must run regardless of whether the per-mission grant succeeds.
+  const shared = projectForRoot(researchMissionsRoot(), await loadProjects());
+  if (shared) {
+    await revokeAllGrantsForProject(shared.id);
+    await deleteProject(shared.id);
+  }
+
   const root = researchMissionWorkspacePath(missionId);
   await mkdir(/* turbopackIgnore: true */ root, { recursive: true });
   const existing = projectForRoot(root, await loadProjects());
@@ -31,14 +40,6 @@ export async function ensureResearchLandingAccess(
       access: "write",
       actor: "system",
     });
-  }
-
-  // Remove the insecure project created by older releases. Keeping even one
-  // grant on this shared parent makes every mission workspace accessible.
-  const shared = projectForRoot(researchMissionsRoot(), await loadProjects());
-  if (shared) {
-    await revokeAllGrantsForProject(shared.id);
-    await deleteProject(shared.id);
   }
   return { project, granted: !effective.level };
 }

--- a/src/lib/server/research-landing.ts
+++ b/src/lib/server/research-landing.ts
@@ -2,154 +2,43 @@ import { mkdir } from "node:fs/promises";
 import type { CaveProject } from "../cave-projects.ts";
 import { createProject, deleteProject, loadProjects, projectForRoot } from "../cave-projects.ts";
 import {
-  accessLevelSatisfies,
-  maxAccessLevel,
-  normalizeAccessLevel,
-  type ProjectAccessLevel,
-} from "../project-access-levels.ts";
-import {
   effectiveProjectAccess,
   grantProjectToFamiliar,
   loadProjectPermissions,
   revokeAllGrantsForProject,
 } from "../project-permissions.ts";
-import { researchMissionsRoot } from "./research-mission-store.ts";
+import { researchMissionWorkspacePath, researchMissionsRoot } from "./research-mission-store.ts";
 
 /**
- * research-landing.ts
- *
- * The standard place research lands: every mission workspace lives under
- * researchMissionsRoot() (~/.coven/cave/research-missions). This module makes
- * that landing root a first-class Cave project so the normal grant machinery
- * covers it — a familiar granted the landing project sees ALL of its research
- * output in later chat sessions (the chat boundary is built from registered
- * projects via filterProjectsForFamiliar), instead of relying on ad-hoc
- * per-mission grants that nobody remembers to add.
- */
-
-export const RESEARCH_LANDING_PROJECT_NAME = "Research Missions";
-
-/**
- * Idempotently register the research landing root as a Cave project. The
- * directory is created first: project-paths' savedCaveProjectRoots() drops
- * roots that fail statSync, so a registered-but-missing directory would be
- * silently unusable.
- */
-export async function ensureResearchLandingProject(): Promise<CaveProject> {
-  const root = researchMissionsRoot();
-  await mkdir(/* turbopackIgnore: true */ root, { recursive: true });
-  const existing = projectForRoot(root, await loadProjects());
-  if (existing) return existing;
-  // createProject is idempotent per root — a concurrent registration returns
-  // the already-persisted record.
-  return createProject({ name: RESEARCH_LANDING_PROJECT_NAME, root });
-}
-
-export type ResearchLandingAccess = {
-  project: CaveProject;
-  /** True when this call added the grant (vs. already effective). */
-  granted: boolean;
-};
-
-/**
- * Ensure the familiar can reach the research landing root: register the
- * landing project if needed, fold any legacy ad-hoc per-mission grants into
- * it, and add a write grant when the familiar has no effective access. An
- * existing grant (direct or via group) is left untouched — this never
- * upgrades or downgrades a level a human chose.
+ * Register and grant only one mission workspace. The parent research root is
+ * deliberately never granted: it contains workspaces owned by other familiars.
  */
 export async function ensureResearchLandingAccess(
   familiarId: string,
-): Promise<ResearchLandingAccess> {
-  const project = await ensureResearchLandingProject();
-  await migrateAdHocMissionGrants(project);
+  missionId: string,
+): Promise<{ project: CaveProject; granted: boolean }> {
+  const root = researchMissionWorkspacePath(missionId);
+  await mkdir(/* turbopackIgnore: true */ root, { recursive: true });
+  const existing = projectForRoot(root, await loadProjects());
+  const project = existing ?? (await createProject({ name: missionId, root }));
   const permissions = await loadProjectPermissions();
   const effective = effectiveProjectAccess(permissions, familiarId, project.id);
-  if (effective.level) return { project, granted: false };
-  await grantProjectToFamiliar({
-    familiarId,
-    projectId: project.id,
-    source: "bootstrap",
-    access: "write",
-    actor: "system",
-  });
-  return { project, granted: true };
-}
-
-export type AdHocMissionGrantMigration = {
-  /** Ad-hoc per-mission projects removed from the registry. */
-  removedProjects: number;
-  /** Familiars whose ad-hoc access was folded into the landing project. */
-  migratedFamiliarIds: string[];
-};
-
-/** Registered project roots use forward slashes with no trailing separator. */
-function normalizeRegisteredRoot(root: string): string {
-  const normalized = root.replace(/\\/g, "/");
-  let end = normalized.length;
-  while (end > 0 && normalized[end - 1] === "/") end--;
-  return normalized.slice(0, end) || "/";
-}
-
-/**
- * Fold legacy ad-hoc grants into the standard landing project. Before the
- * landing project existed, reaching a mission's output from chat required
- * registering the individual mission directory as its own project and
- * granting THAT — leaving one narrow, easily-forgotten grant per mission.
- * Every registered project strictly inside the landing root is such a relic:
- * each familiar with access (direct or via group) gets at least the same
- * level on the landing project, then the per-mission project and all of its
- * grants are removed. Idempotent and cheap when no ad-hoc project exists.
- */
-export async function migrateAdHocMissionGrants(
-  landing: CaveProject,
-): Promise<AdHocMissionGrantMigration> {
-  const landingRoot = normalizeRegisteredRoot(landing.root);
-  const adHoc = (await loadProjects()).filter((project) =>
-    project.id !== landing.id &&
-    normalizeRegisteredRoot(project.root).startsWith(landingRoot + "/"),
-  );
-  if (adHoc.length === 0) return { removedProjects: 0, migratedFamiliarIds: [] };
-
-  // Highest access each familiar held on any ad-hoc mission project, from
-  // direct grants and group grants alike — the landing grant must not be
-  // weaker than what the migration removes.
-  const permissions = await loadProjectPermissions();
-  const adHocIds = new Set(adHoc.map((project) => project.id));
-  const levels = new Map<string, ProjectAccessLevel>();
-  const record = (familiarId: string, access: unknown) => {
-    const level = normalizeAccessLevel(access);
-    levels.set(familiarId, maxAccessLevel(levels.get(familiarId) ?? null, level) ?? level);
-  };
-  for (const grant of permissions.projectGrants) {
-    if (adHocIds.has(grant.projectId)) record(grant.familiarId, grant.access);
-  }
-  for (const group of permissions.accessGroups ?? []) {
-    for (const grant of group.projectGrants) {
-      if (!adHocIds.has(grant.projectId)) continue;
-      for (const familiarId of group.memberFamiliarIds) record(familiarId, grant.access);
-    }
-  }
-
-  const migratedFamiliarIds: string[] = [];
-  for (const [familiarId, level] of levels) {
-    const effective = effectiveProjectAccess(permissions, familiarId, landing.id);
-    if (accessLevelSatisfies(effective.level, level)) continue;
+  if (!effective.level) {
     await grantProjectToFamiliar({
       familiarId,
-      projectId: landing.id,
+      projectId: project.id,
       source: "bootstrap",
-      access: level,
+      access: "write",
       actor: "system",
     });
-    migratedFamiliarIds.push(familiarId);
   }
 
-  for (const project of adHoc) {
-    // Grants first: a crash between the two operations must leave the grants
-    // pointing at a still-registered project, never orphaned records.
-    await revokeAllGrantsForProject(project.id);
-    await deleteProject(project.id);
+  // Remove the insecure project created by older releases. Keeping even one
+  // grant on this shared parent makes every mission workspace accessible.
+  const shared = projectForRoot(researchMissionsRoot(), await loadProjects());
+  if (shared) {
+    await revokeAllGrantsForProject(shared.id);
+    await deleteProject(shared.id);
   }
-  return { removedProjects: adHoc.length, migratedFamiliarIds };
+  return { project, granted: !effective.level };
 }

--- a/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
+++ b/src/lib/server/research-mission-runner-lifecycle-actions.test.ts
@@ -217,15 +217,15 @@ test("an unallowed configured project root fails fast with an actionable error",
   assert.ok(allowedResearchActions(result).includes("retry"));
 });
 
-test("run start ensures the familiar's standard research landing access", async () => {
-  const ensured: string[] = [];
+test("run start ensures the familiar's mission-scoped research access", async () => {
+  const ensured: Array<[string, string]> = [];
   const runner = makeResearchMissionRunner(deps({
-    ensureResearchAccess: async (familiarId) => {
-      ensured.push(familiarId);
+    ensureResearchAccess: async (familiarId, missionId) => {
+      ensured.push([familiarId, missionId]);
     },
   }));
   const result = await runner.createAndStart(INPUT);
-  assert.deepEqual(ensured, ["sage"]);
+  assert.deepEqual(ensured, [["sage", "mission-1"]]);
   assert.equal(result.status, "running");
 });
 

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -1579,7 +1579,7 @@ export function makeProductionResearchMissionRunner() {
         await ensureResearchLandingAccess(familiarId, missionId);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
-        console.error(`research landing grant for ${familiarId} failed: ${message}`);
+        console.error(`research landing grant for ${familiarId} / ${missionId} failed: ${message}`);
       }
     },
     checkFamiliarRootAccess: async (familiarId, projectRoot) => {

--- a/src/lib/server/research-mission-runner.ts
+++ b/src/lib/server/research-mission-runner.ts
@@ -134,12 +134,12 @@ export type ResearchMissionRunnerDeps = {
   resolveProjectRoot(root: string): Promise<string | null>;
   /**
    * Run-start preflight: make sure the mission's familiar can reach the
-   * standard research landing root (where every mission workspace lives), so
-   * finished research is visible from the familiar's later sessions without a
-   * manual grant. Best-effort by contract — implementations MUST NOT throw; a
-   * failed grant degrades to results that land but aren't chat-reachable.
+   * mission's own workspace, so finished research is visible from the
+   * familiar's later sessions without exposing sibling mission workspaces.
+   * Best-effort by contract — implementations MUST NOT throw; a failed grant
+   * degrades to results that land but aren't chat-reachable.
    */
-  ensureResearchAccess(familiarId: string): Promise<void>;
+  ensureResearchAccess(familiarId: string, missionId: string): Promise<void>;
   /**
    * Familiar-level access check for a configured project root at run start.
    * Returns an actionable error message when the root is a registered project
@@ -558,18 +558,16 @@ export function makeResearchMissionRunner(deps: ResearchMissionRunnerDeps) {
    * message (the flow executor would only say "invalid project root"); the
    * default mission workspace always resolves. Every start path (create,
    * next iteration, retry) routes through here, so this is also where run
-   * preflight lives: the familiar's standard-landing grant is ensured, and a
+   * preflight lives: the familiar's mission-workspace grant is ensured, and a
    * configured registered root the familiar cannot use is refused before a
    * session is spent.
    */
   const missionStartTarget = async (
     mission: ResearchMission,
   ): Promise<{ ok: true; projectRoot: string } | { ok: false; error: string }> => {
-    // Standard landing access: research artifacts always land in the mission
-    // workspace under the research landing root — make sure the mission's
-    // familiar can reach them from later sessions before this run produces
-    // anything. Best-effort by contract: implementations never throw.
-    await deps.ensureResearchAccess(mission.familiarId);
+    // Grant only this mission workspace so the familiar can reach its output
+    // later without receiving access to sibling missions.
+    await deps.ensureResearchAccess(mission.familiarId, mission.id);
     if (mission.projectRoot) {
       const resolved = await deps.resolveProjectRoot(mission.projectRoot);
       if (!resolved) {
@@ -1571,14 +1569,14 @@ export function makeProductionResearchMissionRunner() {
       const { normalizeProjectRoot } = await import("./session-security.ts");
       return normalizeProjectRoot(root);
     },
-    ensureResearchAccess: async (familiarId) => {
+    ensureResearchAccess: async (familiarId, missionId) => {
       // Never let a landing-grant failure block the run itself: the mission
       // workspace stays writable through builtInProjectRoots either way, so
       // the worst outcome of a failure here is today's status quo (results
       // land but need a manual grant to be chat-reachable).
       try {
         const { ensureResearchLandingAccess } = await import("./research-landing.ts");
-        await ensureResearchLandingAccess(familiarId);
+        await ensureResearchLandingAccess(familiarId, missionId);
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         console.error(`research landing grant for ${familiarId} failed: ${message}`);


### PR DESCRIPTION
### Motivation

- A recent change made the shared `researchMissionsRoot()` a single registered Cave project and auto-granted familiars write access, which broadened per-mission grants to the entire research tree and broke mission isolation.  
- The intent of this change is to restore isolation by ensuring grants are created only for the active mission's workspace so familiars cannot access sibling missions' files.

### Description

- Restrict landing grants to a mission-scoped project by changing `ensureResearchLandingAccess` to register/grant the specific mission workspace via `researchMissionWorkspacePath(missionId)` instead of the shared root.  
- Remove the unsafe behavior that folded/widened legacy ad-hoc mission grants into a global landing project and instead remove any insecure shared-root project and its grants if present.  
- Wire mission identity through run-start preflight by passing `mission.id` into `ensureResearchAccess` and `missionStartTarget` so the runner ensures a mission-scoped grant only for the active workspace.  
- Add and update regression tests: `src/lib/server/research-landing.test.ts` to verify mission-scoped grants, legacy shared-root cleanup, and non-inheritance between familiars; and `src/lib/server/research-mission-runner-lifecycle-actions.test.ts` to assert that the mission id is passed to the access preflight.

### Testing

- Ran `node --experimental-strip-types --test src/lib/server/research-landing.test.ts` and the three isolation tests passed.  
- Ran `node --experimental-strip-types --test src/lib/server/research-mission-runner-lifecycle-actions.test.ts` and the updated runner preflight test passed.  
- Ran `pnpm typecheck` (TypeScript) and `pnpm check:tests-wired`; both completed (the typecheck run printed a Node engine warning for the environment but completed).  
- Ran the full API test suite via `pnpm test:api`, which exited due to an unrelated `scripts/dev-app-teardown.test.mjs` assertion failure; the targeted research tests pass independently and the change is limited to research grant scoping.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a784ed3a5488327a5d2ed19bf79abd2)