### PR TITLE
fix(chat): prevent client origin from bypassing project authorization

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -485,6 +485,11 @@ assert.doesNotMatch(
   /isProjectlessGenerationOrigin\([^)]*body\.origin/,
   "client-supplied origin must never decide whether project authorization is required",
 );
+assert.match(
+  chatRoute,
+  /const persistedOrigin = persistedConversationOrigin\(body\.origin\)/,
+  "projectless origins from request JSON should be stripped before transcript persistence",
+);
 
 const authorizeLaunchIndex = chatRoute.indexOf("await authorizeChatProjectLaunch");
 const offlineLaunchIndex = chatRoute.indexOf("const offlineChatResponse = await maybeQueueOfflineChat");

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -477,8 +477,13 @@ assert.doesNotMatch(
 );
 assert.match(
   chatRoute,
-  /const generationOrigin = existingConversation\?\.origin \?\? body\.origin/,
-  "a request must not relabel an existing user chat as a projectless hidden generation",
+  /Boolean\(existingConversation\)[\s\S]*isProjectlessGenerationOrigin\(existingConversation\?\.origin\)/,
+  "only persisted hidden-generation provenance may bypass project authorization",
+);
+assert.doesNotMatch(
+  chatRoute,
+  /isProjectlessGenerationOrigin\([^)]*body\.origin/,
+  "client-supplied origin must never decide whether project authorization is required",
 );
 
 const authorizeLaunchIndex = chatRoute.indexOf("await authorizeChatProjectLaunch");

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1103,11 +1103,13 @@ export async function POST(req: Request) {
   const resolvedFamiliarWorkspace = !sshRuntime
     ? await resolveFamiliarWorkspace(body.familiarId)
     : undefined;
-  // A persisted conversation owns its provenance. Never let a request relabel
-  // an existing user chat as a hidden generator to bypass project checks.
-  const generationOrigin = existingConversation?.origin ?? body.origin;
+  // Only persisted provenance may select the legacy projectless generation
+  // lane. `body.origin` is untrusted request metadata: it may label a newly
+  // created conversation, but it must never bypass project authorization.
   const projectlessGeneration =
-    !body.projectRoot && isProjectlessGenerationOrigin(generationOrigin);
+    !body.projectRoot &&
+    Boolean(existingConversation) &&
+    isProjectlessGenerationOrigin(existingConversation?.origin);
   // A Board task may be isolated in a worktree below its registered project.
   // The worktree itself is intentionally not a separate project record, so
   // its first native-chat turn must authorize against the card's server-owned

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -274,6 +274,15 @@ type OfflineChatQueuePayload = Pick<
   responseMetadata: ChatResponseMetadata;
 };
 
+function persistedConversationOrigin(
+  origin: SessionOrigin | null | undefined,
+): SessionOrigin | undefined {
+  // `origin` arrives from request JSON. Projectless generation origins may only
+  // come from server-owned provenance, never directly from a client payload.
+  if (isProjectlessGenerationOrigin(origin)) return undefined;
+  return origin ?? undefined;
+}
+
 
 // Hook-line shapes emitted by codex/claude harnesses while a tool runs.
 // Examples:
@@ -389,6 +398,7 @@ async function maybeQueueOfflineChat(args: {
   if (travelStatus.authority !== "travel-local") return null;
 
   const sessionId = args.body.sessionId ?? crypto.randomUUID();
+  const persistedOrigin = persistedConversationOrigin(args.body.origin);
   const payload: OfflineChatQueuePayload = {
     familiarId: args.body.familiarId,
     prompt: args.promptText,
@@ -402,7 +412,7 @@ async function maybeQueueOfflineChat(args: {
     mentionedFiles: args.body.mentionedFiles,
     mentionedFilesRoot: args.body.mentionedFilesRoot,
     parentTurnId: args.body.parentTurnId,
-    origin: args.body.origin,
+    origin: persistedOrigin,
     responseMetadata: args.responseMetadata,
   };
   const queued = await enqueueOfflineTravelItem({
@@ -642,6 +652,7 @@ function openClawChatResponse(args: {
       // chats. The close handler strips the stub turn and re-appends the
       // authoritative one under the same id.
       const pendingUserTurnId = crypto.randomUUID();
+      const persistedOrigin = persistedConversationOrigin(args.body.origin);
       const stubTitle =
         chatTitleFromPrompt(args.promptText) ?? defaultChatTitleForSession(conversationId);
       void setDefaultSessionTitleIfMissing(conversationId, stubTitle).catch(() => undefined);
@@ -652,7 +663,7 @@ function openClawChatResponse(args: {
         ...(responseMetadata.model ? { model: responseMetadata.model } : {}),
         ...(responseMetadata.runtime ? { runtime: responseMetadata.runtime } : {}),
         title: stubTitle,
-        ...(args.body.origin ? { origin: args.body.origin } : {}),
+        ...(persistedOrigin ? { origin: persistedOrigin } : {}),
         userTurn: {
           id: pendingUserTurnId,
           text: args.promptText,
@@ -795,7 +806,7 @@ function openClawChatResponse(args: {
             model: responseMetadata.model,
             runtime: responseMetadata.runtime,
             title: chatTitle,
-            ...(args.body.origin ? { origin: args.body.origin } : {}),
+            ...(persistedOrigin ? { origin: persistedOrigin } : {}),
             createdAt: now,
             updatedAt: now,
             turns: [],
@@ -881,6 +892,7 @@ export async function POST(req: Request) {
     );
   }
   const attachments = normalizeChatAttachments(body.attachments);
+  const persistedOrigin = persistedConversationOrigin(body.origin);
   const promptText = body.prompt?.trim() ?? "";
   if (!body.familiarId || (!promptText && attachments.length === 0)) {
     return new Response(
@@ -1908,7 +1920,7 @@ export async function POST(req: Request) {
           ...(responseMetadata.model ? { model: responseMetadata.model } : {}),
           ...(responseMetadata.runtime ? { runtime: responseMetadata.runtime } : {}),
           title: chatTitleFromPrompt(promptText) ?? defaultChatTitleForSession(announcedId),
-          ...(body.origin ? { origin: body.origin } : {}),
+          ...(persistedOrigin ? { origin: persistedOrigin } : {}),
           userTurn: {
             id: pendingUserTurnId,
             text: promptText,
@@ -3424,7 +3436,7 @@ export async function POST(req: Request) {
           model: responseMetadata.model,
           runtime: responseMetadata.runtime,
           title: chatTitle,
-          ...(body.origin ? { origin: body.origin } : {}),
+          ...(persistedOrigin ? { origin: persistedOrigin } : {}),
           createdAt: now,
           updatedAt: now,
           turns: [],


### PR DESCRIPTION
### Motivation

- Close an authorization bypass where an untrusted `body.origin` allowed fresh requests to enter the legacy projectless hidden-generation lane and skip project registration and familiar-access checks. 
- Ensure project gating remains server-authoritative while preserving existing persisted hidden-generation resume behavior.

### Description

- Change the projectless-generation decision in `src/app/api/chat/send/route.ts` to require persisted conversation provenance by checking `Boolean(existingConversation)` and using `existingConversation.origin` instead of trusting `body.origin` for authorization. 
- Keep `body.origin` available as conversation metadata but remove its use as an authorization input so fresh requests cannot spoof hidden-generation origins. 
- Add regression assertions in `src/app/api/chat/send/harness-routing-host-session.test.ts` to ensure the route source no longer matches patterns that would let `body.origin` influence authorization and to assert that only persisted provenance may bypass project authorization.

### Testing

- Ran `git diff --check` to validate there are no whitespace or diff errors and it passed. 
- Ran unit tests with `node --experimental-strip-types --test src/app/api/chat/send/harness-routing-host-session.test.ts src/lib/server/chat-project-launch.test.ts` and all tests passed. 
- Ran type checking with `pnpm typecheck` (`tsc --noEmit`) and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6648e8b22883278d79b05d68ef7bfc)