### PR TITLE
fix(daemon): avoid leaking hub token during probes

### DIFF
--- a/src/app/api/daemon/probe/route.test.ts
+++ b/src/app/api/daemon/probe/route.test.ts
@@ -15,6 +15,41 @@ test("probe helper accepts a stubbed daemon caller for route-level outcomes", as
   assert.equal(result.reason, "hub unhealthy: maintenance");
 });
 
+test("probe helper omits stored hub credentials for candidate URLs", async () => {
+  const previous = process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+  process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = "stored-secret";
+  try {
+    let authorization: string | undefined;
+    await probeDaemonUrl("http://candidate.tailnet:8787", async (target) => {
+      authorization = target.mode === "hub" ? target.accessToken : undefined;
+      return { ok: true, status: 200, data: { ok: true } };
+    });
+    assert.equal(authorization, undefined);
+  } finally {
+    if (previous === undefined) delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+    else process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = previous;
+  }
+});
+
+test("probe helper keeps an explicitly supplied candidate token", async () => {
+  const previous = process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+  process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = "stored-secret";
+  try {
+    let authorization: string | undefined;
+    await probeDaemonUrl(
+      "http://candidate.tailnet:8787?coven_access_token=explicit-secret",
+      async (target) => {
+        authorization = target.mode === "hub" ? target.accessToken : undefined;
+        return { ok: true, status: 200, data: { ok: true } };
+      },
+    );
+    assert.equal(authorization, "explicit-secret");
+  } finally {
+    if (previous === undefined) delete process.env.COVEN_CAVE_HUB_ACCESS_TOKEN;
+    else process.env.COVEN_CAVE_HUB_ACCESS_TOKEN = previous;
+  }
+});
+
 const route = readFileSync(new URL("./route.ts", import.meta.url), "utf8");
 assert.match(route, /export const runtime = "nodejs"/);
 assert.match(route, /export const dynamic = "force-dynamic"/);

--- a/src/lib/server/daemon-probe.ts
+++ b/src/lib/server/daemon-probe.ts
@@ -42,7 +42,8 @@ export async function probeDaemonUrl(
   if (target.mode !== "hub") {
     throw new Error(target.mode === "unconfigured-hub" ? target.error : "invalid hub URL");
   }
-  const probeTarget = explicitHubAccessToken(url) ? target : { ...target, accessToken: undefined };
+  const { accessToken: _accessToken, ...targetWithoutToken } = target;
+  const probeTarget = explicitHubAccessToken(url) ? target : targetWithoutToken;
   const startedAt = now();
   const response = await call(probeTarget, { path: "/api/v1/health", timeoutMs: 1500 });
   const latencyMs = Math.max(0, now() - startedAt);

--- a/src/lib/server/daemon-probe.ts
+++ b/src/lib/server/daemon-probe.ts
@@ -2,6 +2,7 @@ import {
   callDaemonTarget,
   daemonTargetForConfig,
   extractDaemonError,
+  normalizeHubUrl,
   type DaemonRequest,
   type DaemonResponse,
   type DaemonTarget,
@@ -16,6 +17,14 @@ export type DaemonProbeResult = {
 };
 
 type CallDaemonTarget = (target: DaemonTarget, request: DaemonRequest) => Promise<DaemonResponse<unknown>>;
+
+function explicitHubAccessToken(rawUrl: string): string | undefined {
+  try {
+    return new URL(normalizeHubUrl(rawUrl)).searchParams.get("coven_access_token")?.trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export function classifyHubFailure(res: DaemonResponse<unknown>): string {
   const detail = extractDaemonError(res) ?? `http ${res.status}`;
@@ -33,8 +42,9 @@ export async function probeDaemonUrl(
   if (target.mode !== "hub") {
     throw new Error(target.mode === "unconfigured-hub" ? target.error : "invalid hub URL");
   }
+  const probeTarget = explicitHubAccessToken(url) ? target : { ...target, accessToken: undefined };
   const startedAt = now();
-  const response = await call(target, { path: "/api/v1/health", timeoutMs: 1500 });
+  const response = await call(probeTarget, { path: "/api/v1/health", timeoutMs: 1500 });
   const latencyMs = Math.max(0, now() - startedAt);
   if (response.ok && response.data) {
     return { ok: true, reachable: true, status: response.status, latencyMs };


### PR DESCRIPTION
### Motivation
- The `/api/daemon/probe` helper accepted an attacker-controlled URL and could reuse the globally stored Server Hub access token when the candidate URL did not include its own token, enabling SSRF + credential exfiltration.
- Probing arbitrary candidate URLs must not send the stored hub credential unless the candidate explicitly supplies a token.

### Description
- Change `probeDaemonUrl` to avoid sending the stored hub `accessToken` for candidate probes by default, only preserving an access token when the candidate URL explicitly includes `coven_access_token` (via a new `explicitHubAccessToken` helper and use of `normalizeHubUrl`).
- Call the probe with a sanitized `probeTarget` that omits `accessToken` unless the candidate carried an explicit token. (`src/lib/server/daemon-probe.ts`)
- Add regression tests that assert stored credentials are omitted for candidate probes and that an explicitly supplied candidate token is preserved. (`src/app/api/daemon/probe/route.test.ts`)

### Testing
- Ran `pnpm typecheck` and it completed successfully. 
- Ran `node --test src/app/api/daemon/probe/route.test.ts` and the new and existing probe tests passed. 
- Ran `pnpm test:api`: many API tests ran and the new probe tests passed, but the full `test:api` run aborted after 209 tests due to an external environment dependency (`zstd`) required by `scripts/sidecar-archive-manifest.test.mjs`, unrelated to the probe change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6032543f8483278ae136357fcf2d37)