### PR TITLE
fix(chat): require operator approval for familiar handoffs

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -78,7 +78,7 @@ test("@mentions target a subset of the coven", () => {
   assert.match(view, /applyMention\(draft, mention\.start, mention\.query/, "inserts the chosen familiar");
 });
 
-test("completed familiar delegation trailers route bounded, attributable follow-up work", () => {
+test("completed familiar delegation trailers require approval before bounded, attributable follow-up work", () => {
   assert.match(view, /extractCovenDelegations\(withoutNextPaths\)/, "parses only the tested structured trailer after removing next-path controls");
   assert.match(view, /source\.status !== "done"/, "never routes a partial or failed familiar reply");
   assert.match(view, /!group\.familiarIds\.includes\(targetId\)/, "rejects out-of-coven targets");
@@ -87,6 +87,13 @@ test("completed familiar delegation trailers route bounded, attributable follow-
   assert.match(view, /targetId === source\.familiarId/, "rejects self-delegation");
   assert.match(view, /lineage\.has\(targetId\)/, "rejects delegation cycles");
   assert.match(view, /delivered\.has\(dedupeKey\)/, "deduplicates source-to-target deliveries");
+  assert.match(view, /const approved = await confirm\(\{/, "requires an operator decision before accepting assistant-proposed work");
+  assert.match(view, /body: `\$\{delegatedBy\} proposed this task:\\n\\n\$\{delegation\.task\}`/, "shows the exact proposed task during approval");
+  assert.match(view, /if \(!approved \|\| controller\.signal\.aborted\) return;/, "never sends a declined or stopped handoff");
+  assert.ok(
+    view.indexOf("const approved = await confirm({") < view.indexOf("const child = await streamOne("),
+    "approval happens before the delegated request is streamed",
+  );
   assert.match(view, /MAX_COVEN_DELEGATION_DEPTH/, "bounds delegation depth");
   assert.match(view, /MAX_COVEN_DELEGATIONS_PER_TURN/, "bounds total delegated sends per human turn");
   assert.match(view, /controller\.signal\.aborted/, "Stop prevents queued delegated sends from starting");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -531,10 +531,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
           ),
         ),
       );
-      // A familiar can perform an explicit human-requested handoff by emitting
-      // a validated delegation trailer. Plain assistant @mentions remain prose.
-      // Process the small delegation tree sequentially so Stop prevents queued
-      // work from starting and each target keeps its resumable familiar session.
+      // A familiar can propose a handoff by emitting a validated delegation
+      // trailer, but assistant output is never sufficient authority to execute
+      // it. Process approved handoffs sequentially so Stop prevents queued work
+      // from starting and each target keeps its resumable familiar session.
       const delivered = new Set(
         transcriptRef.current
           .filter((turn): turn is GroupUserTurn => turn.role === "user" && Boolean(turn.delegationSourceReplyId))
@@ -567,6 +567,16 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             ) continue;
             const target = byId.get(targetId);
             if (!target) continue;
+            const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
+            const approved = await confirm({
+              title: `Approve handoff to ${target.display_name}?`,
+              body: `${delegatedBy} proposed this task:\n\n${delegation.task}`,
+              confirmLabel: "Approve handoff",
+            });
+            // A model cannot authorize work for another familiar. Declining
+            // stops the delegation tree rather than presenting more prompts
+            // emitted by the same untrusted reply.
+            if (!approved || controller.signal.aborted) return;
             const at = nowIso();
             const delegatedTurn: GroupUserTurn = {
               id: newId(),
@@ -591,7 +601,6 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             delivered.add(dedupeKey);
             delegationCount += 1;
             setTranscript((prev) => [...prev, delegatedTurn, delegatedReply]);
-            const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
             const child = await streamOne(
               group,
               delegatedReply,
@@ -629,7 +638,7 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
         announce(`${total - failed} of ${total} familiars replied; ${failed} failed.`, "assertive");
       }
     },
-    [busy, streamOne, byId, announce, operatorDisplayName],
+    [busy, streamOne, byId, announce, operatorDisplayName, confirm],
   );
 
   // Composer sends and suggestion chips share the stream path, but a suggestion

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -568,11 +568,22 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl }: Props)
             const target = byId.get(targetId);
             if (!target) continue;
             const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
-            const approved = await confirm({
-              title: `Approve handoff to ${target.display_name}?`,
-              body: `${delegatedBy} proposed this task:\n\n${delegation.task}`,
-              confirmLabel: "Approve handoff",
+            const abortPromise = new Promise<false>((resolve) => {
+              if (controller.signal.aborted) { resolve(false); return; }
+              controller.signal.addEventListener("abort", () => resolve(false), { once: true });
             });
+            const approved = await Promise.race([
+              confirm({
+                title: `Approve handoff to ${target.display_name}?`,
+                body: (
+                  <div style={{ whiteSpace: "pre-wrap" }}>
+                    {`${delegatedBy} proposed this task:\n\n${delegation.task}`}
+                  </div>
+                ),
+                confirmLabel: "Approve handoff",
+              }),
+              abortPromise,
+            ]);
             // A model cannot authorize work for another familiar. Declining
             // stops the delegation tree rather than presenting more prompts
             // emitted by the same untrusted reply.


### PR DESCRIPTION
### Motivation

- Prevent assistant-controlled `<coven:delegation>` trailers from automatically triggering another familiar's run without an explicit operator decision.

### Description

- Added an explicit approval step using `confirm = useConfirm()` in `src/components/group-chat-view.tsx` before creating or sending any delegated `GroupUserTurn` so assistant-proposed handoffs require operator consent.
- The approval dialog shows the source familiar and the exact proposed task, and declining or aborting stops the delegation tree instead of streaming to the target familiar.
- Kept existing guards (visible @mention, task mentions, membership, cycle/dedupe/depth bounds, session reuse) and preserved the existing `streamOne` execution path for approved handoffs.
- Updated `src/components/group-chat-view.test.ts` to assert that approval is requested before the delegated `/api/chat/send` path and that declined/aborted handoffs are not sent.

### Testing

- Ran `git diff --check` with no issues.
- Ran unit tests: `node --experimental-strip-types --test src/lib/group-chat.test.ts src/components/group-chat-view.test.ts` and observed 64 tests passing.
- Typechecked with `pnpm typecheck` (`tsc --noEmit`) and it succeeded.
- Environment notes: `bd prime` / `bd ready --json` could not run because `bd` is not installed, and `git fetch origin main` could not run because this checkout has no `origin` remote.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5ab3780ebc8327b1a29a5c62fc27e5)