### PR TITLE
fix(security): validate resolved worktree cwd

### DIFF
--- a/src/lib/chat-project-access.test.ts
+++ b/src/lib/chat-project-access.test.ts
@@ -165,6 +165,17 @@ assert.equal(
   "a traversal escape below .worktrees/ resolves outside and fails closed",
 );
 
+
+assert.equal(
+  chatProjectAccessId({
+    projects,
+    requestedProjectRoot: "/Users/me/dev/cave/.worktrees/evil",
+    resolvedCwd: "/Users/me/victim-ungranted-project",
+  }),
+  "unregistered:/Users/me/dev/cave/.worktrees/evil",
+  "a symlinked worktree request whose real cwd escapes the parent project fails closed",
+);
+
 assert.equal(
   chatProjectAccessId({
     projects,

--- a/src/lib/chat-project-access.ts
+++ b/src/lib/chat-project-access.ts
@@ -24,13 +24,26 @@ function samePath(a: string, b: string): boolean {
  * any. Separator-exact and traversal-safe: the candidate is `path.resolve`d
  * (collapsing `..` escapes) and must sit strictly BELOW
  * `<project>/.worktrees/`, so `/proj-evil/...`, `/proj/.worktrees` itself,
- * and `/proj/.worktrees/../..` all miss.
+ * and `/proj/.worktrees/../..` all miss. The runtime cwd must also resolve
+ * there so symlinked worktree paths cannot grant access to another directory.
  */
-function worktreeParentProject(root: string, projects: CaveProject[]): CaveProject | null {
-  const resolved = path.resolve(root);
+function worktreeParentProject(
+  root: string,
+  resolvedCwd: string,
+  projects: CaveProject[],
+): CaveProject | null {
+  const requested = path.resolve(root);
+  const realCwd = path.resolve(resolvedCwd);
   for (const project of projects) {
     const prefix = path.resolve(project.root) + path.sep + ".worktrees" + path.sep;
-    if (resolved.startsWith(prefix) && resolved.length > prefix.length) return project;
+    if (
+      requested.startsWith(prefix) &&
+      requested.length > prefix.length &&
+      realCwd.startsWith(prefix) &&
+      realCwd.length > prefix.length
+    ) {
+      return project;
+    }
   }
   return null;
 }
@@ -75,7 +88,7 @@ export function chatProjectAccessId(args: ChatProjectAccessArgs): string | null 
     return null;
   }
 
-  const worktreeParent = worktreeParentProject(explicitRoot, args.projects);
+  const worktreeParent = worktreeParentProject(explicitRoot, args.resolvedCwd, args.projects);
   if (worktreeParent) return worktreeParent.id;
 
   return `unregistered:${projectRoot}`;


### PR DESCRIPTION
### Motivation
- Close a security gap where a requested `.worktrees/<branch>` path was authorized lexically but the actual runtime cwd could resolve (via symlink) outside the parent project, allowing a worktree grant to be used for an unrelated directory.
- Ensure worktree-based authorization only maps to the parent project when both the requested path and the runtime-resolved cwd are actually inside the parent project's `.worktrees/` containment.

### Description
- Change `worktreeParentProject` to accept the runtime `resolvedCwd` and require that both the requested path and the resolved cwd are strictly below the parent project's `.worktrees/` directory before returning the parent project.  
- Update `chatProjectAccessId` to pass `args.resolvedCwd` into `worktreeParentProject`.  
- Tighten the function comment to document the runtime-cwd requirement to prevent symlink escapes.  
- Add a regression test in `src/lib/chat-project-access.test.ts` that asserts a requested `.worktrees/evil` path whose `resolvedCwd` points to an unregistered victim directory fails closed as `unregistered:<requested root>`.

### Testing
- Ran the unit regression with `node --experimental-strip-types src/lib/chat-project-access.test.ts`, which passed.  
- Ran the TypeScript checker with `pnpm typecheck` (`tsc --noEmit`), which completed with no errors.  
- Ran `git diff --check` to validate whitespace/patch issues, which reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a62a118a58c83278f659c71f96d1432)