### PR TITLE
fix(chat): require operator approval for familiar handoffs

### DIFF
--- a/src/components/group-chat-view.test.ts
+++ b/src/components/group-chat-view.test.ts
@@ -267,7 +267,7 @@ test("completed @mentions close autocomplete and render as standout targets", ()
   );
 });
 
-test("completed familiar delegation trailers route bounded, attributable follow-up work", () => {
+test("completed familiar delegation trailers require approval before bounded, attributable follow-up work", () => {
   assert.match(view, /extractCovenDelegations\(withoutNextPaths\)/, "parses only the tested structured trailer after removing next-path controls");
   assert.match(view, /source\.status !== "done"/, "never routes a partial or failed familiar reply");
   assert.match(view, /!group\.familiarIds\.includes\(targetId\)/, "rejects out-of-coven targets");
@@ -281,6 +281,14 @@ test("completed familiar delegation trailers route bounded, attributable follow-
   assert.match(view, /targetId === source\.familiarId/, "rejects self-delegation");
   assert.match(view, /lineage\.has\(targetId\)/, "rejects delegation cycles");
   assert.match(view, /delivered\.has\(dedupeKey\)/, "deduplicates source-to-target deliveries");
+  assert.match(view, /const approved = await Promise\.race\(\[\s*\n\s*confirm\(\{/, "requires an operator decision before accepting assistant-proposed work");
+  assert.match(view, /title: `Approve handoff to \$\{target\.display_name\}\?`/, "the approval names the receiving familiar");
+  assert.match(view, /proposed this task/, "shows the exact proposed task during approval");
+  assert.match(view, /if \(!approved \|\| controller\.signal\.aborted\) return;/, "never sends a declined or stopped handoff");
+  assert.ok(
+    view.indexOf("const approved = await Promise.race([") < view.indexOf("const child = await streamOne("),
+    "approval happens before the delegated request is streamed",
+  );
   assert.match(view, /MAX_COVEN_DELEGATION_DEPTH/, "bounds delegation depth");
   assert.match(view, /MAX_COVEN_DELEGATIONS_PER_TURN/, "bounds total delegated sends per human turn");
   assert.match(view, /controller\.signal\.aborted/, "Stop prevents queued delegated sends from starting");

--- a/src/components/group-chat-view.tsx
+++ b/src/components/group-chat-view.tsx
@@ -1001,8 +1001,10 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
           return streamOne(group, reply, prompt, projectRoot, scopeId, controller.signal);
         },
       });
-      // A familiar can perform an explicit human-requested handoff by emitting
-      // a validated delegation trailer. Plain assistant @mentions remain prose.
+      // A familiar can PROPOSE a handoff by emitting a validated delegation
+      // trailer, but assistant output is never sufficient authority to execute
+      // it — every handoff waits on an operator decision. Plain assistant
+      // @mentions remain prose.
       // Process the small delegation tree sequentially so Stop prevents queued
       // work from starting and each target keeps its resumable familiar session.
       const delivered = new Set(
@@ -1038,6 +1040,32 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
             ) continue;
             const target = byId.get(targetId);
             if (!target) continue;
+            const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
+            // Assistant output is a PROPOSAL, never authority. A familiar can
+            // emit a delegation trailer for any in-coven target, so executing
+            // one unprompted lets a model start work — with the operator's
+            // grants, in another familiar's session — that the human never
+            // asked for. Race the decision against Stop so aborting mid-prompt
+            // does not leave the dialog waiting on a run that is already over.
+            const abortPromise = new Promise<false>((resolve) => {
+              if (controller.signal.aborted) { resolve(false); return; }
+              controller.signal.addEventListener("abort", () => resolve(false), { once: true });
+            });
+            const approved = await Promise.race([
+              confirm({
+                title: `Approve handoff to ${target.display_name}?`,
+                body: (
+                  <div className="[white-space:pre-wrap]!">
+                    {`${delegatedBy} proposed this task:\n\n${delegation.task}`}
+                  </div>
+                ),
+                confirmLabel: "Approve handoff",
+              }),
+              abortPromise,
+            ]);
+            // Declining stops the whole delegation tree rather than walking on
+            // to more prompts emitted by the same untrusted reply.
+            if (!approved || controller.signal.aborted) return;
             const at = nowIso();
             const delegatedTurn: GroupUserTurn = {
               id: newId(),
@@ -1062,7 +1090,6 @@ export function GroupChatView({ familiars, onSessionStarted, onOpenUrl, onDebugS
             delivered.add(dedupeKey);
             delegationCount += 1;
             setTranscript((prev) => [...prev, delegatedTurn, delegatedReply]);
-            const delegatedBy = byId.get(source.familiarId)?.display_name ?? source.familiarId;
             const child = await streamOne(
               group,
               delegatedReply,


### PR DESCRIPTION
Re-lands #4547 on current `main`. That branch is **2089 commits behind** and `git merge-tree origin/main HEAD` conflicts; the gap it closes is still open on `main` today (verified: `group-chat-view.tsx` runs the delegation loop straight into `streamOne` with no operator decision).

## The gap

A familiar could emit a validated delegation trailer and the coven surface executed it directly — a model starting work for another familiar, in that familiar's resumable session and under the operator's grants, with no human in the loop.

The existing guards bound the blast radius well (depth, per-turn count, in-coven targets, no self-delegation, no cycles, dedupe) but none of them asks whether the handoff was *wanted*.

## The change

The trailer becomes a proposal. Each handoff waits on a confirm dialog naming the receiving familiar and showing the exact proposed task; declining stops the whole delegation tree rather than walking on to more prompts emitted by the same untrusted reply. The decision races the abort signal, so pressing Stop mid-prompt resolves the dialog instead of leaving it waiting on a run that is already over.

## Verification

- `node --experimental-strip-types src/components/group-chat-view.test.ts` — 13/13 pass, including 5 new assertions on the approval, its copy, the decline path, and its ordering before `streamOne`
- **The guard was proven to fail without the fix**: reverting only `group-chat-view.tsx` to `origin/main` drops it to 12 pass / 1 fail
- `pnpm typecheck` — clean
- `pnpm lint` — clean (the design gate caught a static inline style on the dialog body; rewritten through `tokenize-tsx-design` to `className="[white-space:pre-wrap]!"`)