### PR TITLE
test: normalize macOS shim target paths

### DIFF
--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -17,7 +17,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -150,7 +150,7 @@ function skip(reason: string): void {
   );
   assert.deepEqual(
     covenLaunchCommandForBinary(shim, "win32"),
-    { command: process.execPath, fixedArgs: [shimScript] },
+    { command: process.execPath, fixedArgs: [realpathSync(shimScript)] },
     "win32 .cmd shims launch through node + the resolved script (never spawned directly — CVE-2024-27980 EINVAL)",
   );
 


### PR DESCRIPTION
## Summary
- canonicalize the npm shim target fixture before asserting command resolution
- avoid macOS `/var` versus `/private/var` symlink-spelling failures

## Verification
- `pnpm test:conformance` reaches the repaired shim assertion; the suite later fails on the host-only Tailscale discovery precondition because no local Tailscale serve/MagicDNS fixture is present
- `git diff --check`

Release recovery for v0.3.0: this must merge before the signed tag is re-created from the updated `main`.