### PR TITLE
test: compare shim targets by file identity

### DIFF
--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -17,7 +17,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, mkdirSync, rmSync, statSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -148,10 +148,16 @@ function skip(reason: string): void {
       "",
     ].join("\r\n"),
   );
+  const resolvedShim = covenLaunchCommandForBinary(shim, "win32");
+  assert.equal(
+    resolvedShim.command,
+    process.execPath,
+    "win32 .cmd shims launch through node (never spawned directly — CVE-2024-27980 EINVAL)",
+  );
   assert.deepEqual(
-    covenLaunchCommandForBinary(shim, "win32"),
-    { command: process.execPath, fixedArgs: [realpathSync(shimScript)] },
-    "win32 .cmd shims launch through node + the resolved script (never spawned directly — CVE-2024-27980 EINVAL)",
+    resolvedShim.fixedArgs?.map((target) => statSync(target).ino),
+    [statSync(shimScript).ino],
+    "win32 .cmd shims launch their resolved script, including through equivalent macOS /var paths",
   );
 
   // Host branch — the genuinely per-OS assertion.


### PR DESCRIPTION
## Summary
- assert the Windows npm shim resolves to Node and to the intended target file
- compare file identity rather than macOS `/var` and `/private/var` path spelling

## Verification
- `pnpm test:conformance` passes the repaired shim assertion and then reaches the unrelated host-only Tailscale discovery precondition
- `git diff --check`

Release recovery for v0.3.0: merge before the signed tag is re-created from updated `main`.