### PR TITLE
test: compare Coven Code shim target by file identity

### DIFF
--- a/scripts/cross-environment.test.ts
+++ b/scripts/cross-environment.test.ts
@@ -171,9 +171,11 @@ function skip(reason: string): void {
     codeShim,
     'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\@opencoven\\coven-code\\bin\\coven-code" %*\r\n',
   );
+  const resolvedCodeShim = covenLaunchCommandForBinary(codeShim, "win32");
+  assert.equal(resolvedCodeShim.command, process.execPath, "win32 Coven Code shims launch through node");
   assert.deepEqual(
-    covenLaunchCommandForBinary(codeShim, "win32"),
-    { command: process.execPath, fixedArgs: [codeShimScript] },
+    resolvedCodeShim.fixedArgs?.map((target) => statSync(target).ino),
+    [statSync(codeShimScript).ino],
     "win32 npm shims resolve extensionless Coven Code targets from their own package",
   );
 


### PR DESCRIPTION
## Summary
- use file identity for the extensionless Coven Code npm-shim target assertion
- tolerate macOS `/var` and `/private/var` equivalent path spellings

## Verification
- `pnpm test:conformance` reaches the unrelated local Tailscale discovery precondition after both shim assertions
- `git diff --check`

Release recovery for v0.3.0.