### PR TITLE
test: use a valid Windows daemon shim fixture

### DIFF
--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -225,7 +225,13 @@ async function writeHangingDaemonFixture(rootDir, marker) {
   if (process.platform === "win32") {
     await writeFile(
       fixture,
-      `@echo off\r\n"${bundledNode}" "${daemonScript}"\r\n`,
+      [
+        "@ECHO off",
+        "SETLOCAL",
+        "CALL :find_dp0",
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%hanging-daemon-child.cjs" %*',
+        "",
+      ].join("\r\n"),
       "utf8",
     );
   } else {


### PR DESCRIPTION
## Summary
- make the Windows hanging-daemon smoke fixture follow the standard npm `.cmd` target shape
- preserve the timeout and owned-tree-cleanup scenario under Cave command-shim hardening

## Verification
- `node --check scripts/sidecar-runtime-smoke.mjs`
- `git diff --check`

Release recovery for v0.3.0.