### PR TITLE
test: make Windows daemon shim target parseable

### DIFF
--- a/scripts/sidecar-runtime-smoke.mjs
+++ b/scripts/sidecar-runtime-smoke.mjs
@@ -229,7 +229,7 @@ async function writeHangingDaemonFixture(rootDir, marker) {
         "@ECHO off",
         "SETLOCAL",
         "CALL :find_dp0",
-        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%hanging-daemon-child.cjs" %*',
+        'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\hanging-daemon-child.cjs" %*',
         "",
       ].join("\r\n"),
       "utf8",


### PR DESCRIPTION
## Summary
- include the required separator after `%dp0%` in the Windows daemon smoke fixture
- allow the hardened npm-shim resolver to launch the intentional hanging-daemon test

## Verification
- `node --check scripts/sidecar-runtime-smoke.mjs`
- `git diff --check`

Release recovery for v0.3.0.