### PR TITLE
fix: preserve task handoff through effect replay

### DIFF
--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -75,11 +75,18 @@ assert.match(
   "a resumed task has no handoff to latch",
 );
 // The latch is module-scoped on purpose, so leaving the task must release it —
-// otherwise reopening the card sits on a claimed id and never sends.
+// otherwise reopening the card sits on a claimed id and never sends. React's
+// development effect replay calls cleanup before immediately mounting again,
+// so the release is deferred one turn and cancelled by that remount.
 assert.match(
   source,
-  /return \(\) => releaseInitialPromptHandoff\(CHAT_VIEW_HANDOFF_SCOPE, handoffId\)/,
-  "the cockpit releases its handoff latch on unmount",
+  /handoffReleaseTimerRef\.current = window\.setTimeout\(\(\) => \{\s*releaseInitialPromptHandoff\(CHAT_VIEW_HANDOFF_SCOPE, handoffId\)/,
+  "the cockpit defers its handoff release so development effect replay cannot re-send the first prompt",
+);
+assert.match(
+  source,
+  /clearTimeout\(handoffReleaseTimerRef\.current\)/,
+  "the replayed cockpit mount cancels the deferred handoff release",
 );
 // The rail mounts for BOTH paths now; gating it on the ready branch is what
 // made the reopen strip a dead end during a bridge-start session.

--- a/src/components/task-work-cockpit.tsx
+++ b/src/components/task-work-cockpit.tsx
@@ -61,6 +61,7 @@ export function TaskWorkCockpit({
   // session id after starting. Keep the first key for this live prompt: a
   // changing key would look like a new handoff and send the prompt twice.
   const initialPromptHandoffIdRef = useRef<string | null>(null);
+  const handoffReleaseTimerRef = useRef<number | null>(null);
   if (initialPrompt) {
     initialPromptHandoffIdRef.current ??= card.sessionId ?? card.id;
   } else {
@@ -163,8 +164,21 @@ export function TaskWorkCockpit({
   // the same card would sit on a claimed id and never send its first prompt.
   const handoffId = conversation?.handoffId ?? null;
   useEffect(() => {
+    if (handoffReleaseTimerRef.current !== null) {
+      clearTimeout(handoffReleaseTimerRef.current);
+      handoffReleaseTimerRef.current = null;
+    }
     if (!handoffId) return;
-    return () => releaseInitialPromptHandoff(CHAT_VIEW_HANDOFF_SCOPE, handoffId);
+    return () => {
+      // React's development effect replay runs a cleanup before immediately
+      // mounting the same cockpit again. Delay the release one turn so that
+      // replay can cancel it; a real unmount still releases the handoff for a
+      // later, genuinely new task launch.
+      handoffReleaseTimerRef.current = window.setTimeout(() => {
+        releaseInitialPromptHandoff(CHAT_VIEW_HANDOFF_SCOPE, handoffId);
+        handoffReleaseTimerRef.current = null;
+      }, 0);
+    };
   }, [handoffId]);
 
   const unlinkMissingSession = async () => {


### PR DESCRIPTION
## Summary
- defer Task Work handoff-latch release by one turn
- cancel that release if React replays the same cockpit effect
- retain release on a genuine unmount for a later task launch

## Verification
- `git diff --check`
- targeted Playwright invocation was unavailable locally because this isolated worktree has no Playwright binary; required CI covers the failing desktop spec

Release recovery for v0.3.0.