### PR TITLE
feat(auth): remove the access-token requirement

### DIFF
--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -102,13 +102,18 @@ pnpm mobile:tailscale:invite
 The agent should verify that the invite redirects, stores the cookie, and loads the app shell before reporting success. It should not paste the raw invite into chat by default. If a fresh invite expires while you are away from the laptop, ask the agent to run `pnpm mobile:tailscale:invite`; the command refreshes the invite without restarting the dev server.
 
 > ⚠️ **The access-token requirement was removed at the owner's direction
-> (`cave-f4emr`).** `COVEN_CAVE_ACCESS_TOKEN` no longer gates anything: there is
-> no access page, no 401 for a missing credential, and no cookie/query
-> exchange. Whatever can reach the Serve URL reaches the app. The pairing flow
-> below still mints signed invites — the desktop signs them from that secret
-> and the phone still carries one — but nothing verifies them any more, so an
-> invite is a convenience link rather than a credential. **Publishing a Serve
-> route now publishes the whole app to everything on the tailnet.** If you want
+> (`cave-f4emr`).** `COVEN_CAVE_ACCESS_TOKEN` no longer gates anything: the
+> proxy/middleware no longer serves an access page, no longer 401s a request
+> for missing a credential, and no longer performs the access-gate
+> cookie/query-token exchange. Whatever can reach the Serve URL reaches the
+> app.
+>
+> The pairing machinery below is **unchanged** — `/api/mobile-handoff` and
+> `/api/mobile-token/refresh` still mint signed invite URLs, still set the
+> access cookie, and the phone still carries a token. What changed is that
+> nothing verifies any of it, so an invite is now a convenience link (it
+> carries the host) rather than a credential. **Publishing a Serve route
+> therefore publishes the whole app to everything on the tailnet.** If you want
 > a control back, the one that survives is the passkey-presence requirement
 > (`COVEN_CAVE_PASSKEY_REQUIRED=1`, see below), which binds remote `/api/*`
 > access to a WebAuthn assertion on an allowlisted tailnet device.

--- a/docs/mobile-tailscale.md
+++ b/docs/mobile-tailscale.md
@@ -101,21 +101,34 @@ pnpm mobile:tailscale:invite
 
 The agent should verify that the invite redirects, stores the cookie, and loads the app shell before reporting success. It should not paste the raw invite into chat by default. If a fresh invite expires while you are away from the laptop, ask the agent to run `pnpm mobile:tailscale:invite`; the command refreshes the invite without restarting the dev server.
 
-Do not open the Serve URL without the invite query. When `COVEN_CAVE_ACCESS_TOKEN` is set, CovenCave rejects requests until a valid signed `coven_access_token` invite is supplied by query, cookie, bearer header, or the equivalent internal request path. A loopback-looking `Host` header is not treated as proof of a local connection because remote clients can spoof it.
+> ⚠️ **The access-token requirement was removed at the owner's direction
+> (`cave-f4emr`).** `COVEN_CAVE_ACCESS_TOKEN` no longer gates anything: there is
+> no access page, no 401 for a missing credential, and no cookie/query
+> exchange. Whatever can reach the Serve URL reaches the app. The pairing flow
+> below still mints signed invites — the desktop signs them from that secret
+> and the phone still carries one — but nothing verifies them any more, so an
+> invite is a convenience link rather than a credential. **Publishing a Serve
+> route now publishes the whole app to everything on the tailnet.** If you want
+> a control back, the one that survives is the passkey-presence requirement
+> (`COVEN_CAVE_PASSKEY_REQUIRED=1`, see below), which binds remote `/api/*`
+> access to a WebAuthn assertion on an allowlisted tailnet device.
 
-Independent of the mobile token, every `/api/*` request also has to satisfy loopback/same-origin/referer/content-type checks — those guards apply in plain browser dev too, not just in bundled mode. A valid mobile token lets Tailscale Serve satisfy the host/origin/referer gates while it proxies to the loopback dev server; anything else (LAN scanners, accidental `-H 0.0.0.0`, mismatched origins without the token) hits a 403 before any handler runs.
+Every `/api/*` request still has to satisfy loopback/same-origin/referer/content-type checks — those guards apply in plain browser dev too, not just in bundled mode. Remote (Serve-forwarded) ingress satisfies the host gate on the strength of being classified remote rather than by presenting anything; mismatched origins still hit a 403 before any handler runs.
 
 Next.js dev internals are separately origin-checked. `next.config.ts` allowlists `**.ts.net` for development so Tailscale Serve can load HMR/runtime resources while the actual server remains bound to loopback.
 
 ## Manual Equivalent
 
-Use a strong random token and keep the Next.js server bound to loopback so only Tailscale Serve can proxy it. In one terminal, start Cave:
+Keep the Next.js server bound to loopback so only Tailscale Serve can proxy it. In one terminal, start Cave:
 
 ```bash
-TOKEN=$(node -e "console.log(require('node:crypto').randomBytes(32).toString('base64url'))")
-echo "$TOKEN"
-COVEN_CAVE_ACCESS_TOKEN="$TOKEN" pnpm exec next dev -H 127.0.0.1 -p 3000
+pnpm exec next dev -H 127.0.0.1 -p 3000
 ```
+
+`COVEN_CAVE_ACCESS_TOKEN` used to belong here and no longer does: setting it
+gates nothing (`cave-f4emr`). It is still read by the pairing flow to sign
+invite URLs, so the Tauri app keeps providing one, but it is not a credential
+any request is checked against.
 
 In another terminal, publish the loopback server:
 
@@ -296,7 +309,7 @@ Expose the daemon over Tailscale Serve and print a pairing URL for the app:
 pnpm mobile:tailscale:app      # tailscale serve + a QR/pairing URL carrying the access token
 ```
 
-Scan or paste that URL in the app. The `coven_access_token` query param authorizes the client against the gated API (tailnet membership alone is not sufficient — Serve exposes every `/api` route).
+Scan or paste that URL in the app. The `coven_access_token` query param it carries is no longer checked (`cave-f4emr`) — the URL's value is now the host it points at, not the credential it carries. Serve exposes every `/api` route to anything on the tailnet.
 
 ### Building / running the app
 

--- a/server.mjs
+++ b/server.mjs
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { createHmac, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer } from "node:http";
 import { createRequire } from "node:module";
@@ -35,25 +35,6 @@ function cavePort() {
   const channelDefault = process.env.COVEN_CAVE_BUNDLE === "1" ? CAVE_PRODUCTION_PORT : CAVE_DEV_PORT;
   return parseCavePort(process.env.COVEN_CAVE_PORT) ?? parseCavePort(process.env.PORT) ?? channelDefault;
 }
-function persistedMobileAccessSecretFile() {
-  const port2 = String(cavePort());
-  const stateRoot = process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() || join(
-    process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"),
-    "coven-cave"
-  );
-  const stateDir = process.env.COVEN_CAVE_MOBILE_STATE_DIR?.trim() || join(stateRoot, `mobile-tailscale-${port2}`);
-  return join(stateDir, "access-token");
-}
-if (process.env.COVEN_CAVE_BUNDLE !== "1" && process.env.COVEN_CAVE_E2E !== "1" && !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()) {
-  try {
-    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
-    if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
-  } catch {
-  }
-}
-function accessToken() {
-  return process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
-}
 const SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN ?? "";
 const LOCAL_PEER_HEADER = "x-coven-cave-local-peer";
 const LOCAL_PEER_SECRET = randomUUID();
@@ -65,9 +46,6 @@ const FORWARDING_HEADERS = [
   "x-forwarded-proto",
   "via"
 ];
-const ACCESS_COOKIE = "coven_cave_access";
-const LEGACY_ACCESS_COOKIE = "coven_access_token";
-const ACCESS_QUERY_PARAM = "coven_access_token";
 const SIDECAR_QUERY_PARAM = "covenCaveToken";
 const sessions = /* @__PURE__ */ new Map();
 const PACKAGED_CHILD_SHUTDOWN_BUDGET_MS = 1200;
@@ -161,17 +139,6 @@ function scrollbackFrom(session, cursor) {
   }
   return output;
 }
-function getTokensFromCookie(header) {
-  if (!header) return [];
-  const tokens = [];
-  for (const part of header.split(";")) {
-    const [key, ...rest] = part.trim().split("=");
-    if (key === ACCESS_COOKIE || key === LEGACY_ACCESS_COOKIE) {
-      tokens.push(decodeURIComponent(rest.join("=") ?? ""));
-    }
-  }
-  return tokens;
-}
 function timingSafeEqualString(a, b) {
   const aBytes = Buffer.from(a);
   const bBytes = Buffer.from(b);
@@ -182,26 +149,8 @@ function timingSafeEqualString(a, b) {
   }
   return diff === 0;
 }
-function isExpectedAccessToken(value) {
-  const secret = accessToken();
-  if (!secret || !value) return false;
-  if (timingSafeEqualString(value, secret)) return true;
-  return isValidSignedAccessToken(value, secret);
-}
-function isExpectedSidecarToken(value) {
-  return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
-}
 function isExpectedPtyToken(value) {
-  return isExpectedAccessToken(value) || isExpectedSidecarToken(value);
-}
-function isValidSignedAccessToken(value, secret) {
-  const parts = value.split(".");
-  if (parts.length !== 4 || parts[0] !== "v1") return false;
-  const expiresAt = Number(parts[1]);
-  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) return false;
-  if (!parts[2] || !parts[3]) return false;
-  const expected = createHmac("sha256", secret).update(`v1.${parts[1]}.${parts[2]}`).digest("base64url");
-  return timingSafeEqualString(parts[3], expected);
+  return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
 }
 function bearerToken(req) {
   const auth = req.headers.authorization ?? "";
@@ -369,21 +318,19 @@ function parseUpgradeTarget(rawUrl) {
   return { pathname, query };
 }
 function isPtyAuthRequired() {
-  return Boolean(accessToken() || SIDECAR_TOKEN);
+  return Boolean(SIDECAR_TOKEN);
 }
 function shouldRejectUnauthenticatedPtyUpgrade({
   sidecarTokenConfigured = false,
-  accessTokenConfigured = false,
   tokenAuthenticated = false
 } = {}) {
   if (tokenAuthenticated) return false;
-  return sidecarTokenConfigured || accessTokenConfigured;
+  return sidecarTokenConfigured;
 }
 function isAuthorized(req, query) {
   if (!isPtyAuthRequired()) return false;
-  const queryToken = firstQueryValue(query[ACCESS_QUERY_PARAM]);
   const sidecarQueryToken = firstQueryValue(query[SIDECAR_QUERY_PARAM]);
-  const candidates = [bearerToken(req), queryToken, sidecarQueryToken, ...getTokensFromCookie(req.headers.cookie)];
+  const candidates = [bearerToken(req), sidecarQueryToken];
   return candidates.some(isExpectedPtyToken);
 }
 function defaultShell() {
@@ -743,7 +690,6 @@ server.on("upgrade", (req, socket, head) => {
   }
   if (shouldRejectUnauthenticatedPtyUpgrade({
     sidecarTokenConfigured: Boolean(SIDECAR_TOKEN),
-    accessTokenConfigured: Boolean(accessToken()),
     tokenAuthenticated
   })) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { createHmac, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { mkdirSync, readdirSync, readFileSync, statSync, unlinkSync } from "node:fs";
 import { createServer, type IncomingMessage } from "node:http";
 import { createRequire } from "node:module";
@@ -33,15 +33,8 @@ if (process.env.COVEN_CAVE_BUNDLE === "1" && !process.env.__NEXT_PRIVATE_STANDAL
   }
 }
 
-// Boot re-arm (cave-os73): a tokenless dev boot outside the packaged bundle
-// re-arms COVEN_CAVE_ACCESS_TOKEN from the pairing secret that Settings ·
-// Phone (or scripts/mobile-tailscale.sh — same state file) provisioned, so
-// paired phones survive dev-server restarts and a still-configured Tailscale
-// Serve route stays token-gated. Mirrors src/lib/server/mobile-access-
-// provision.ts, inlined because the standalone server.mjs cannot import from
-// src/.
-// The port contract, inlined for the same reason as everything else in this
-// block: `build:server` runs esbuild with `--bundle=false`, so any import here
+// The port contract, inlined because the standalone server.mjs cannot import
+// from src/: `build:server` runs esbuild with `--bundle=false`, so any import here
 // must still resolve at runtime from wherever server.mjs is unpacked — and the
 // packaged bundle ships server.mjs without scripts/. scripts/ports.mjs is the
 // source of truth and scripts/port-contract.test.mjs fails if this copy drifts.
@@ -72,42 +65,10 @@ function cavePort(): number {
   );
 }
 
-function persistedMobileAccessSecretFile(): string {
-  // Keyed by the port on purpose (it mirrors scripts/mobile-tailscale.sh), which
-  // is precisely why the port had to stop moving: a per-launch port meant a
-  // per-launch secret directory, so every desktop restart re-paired every phone.
-  const port = String(cavePort());
-  const stateRoot =
-    process.env.COVEN_CAVE_MOBILE_STATE_ROOT?.trim() ||
-    join(
-      process.env.XDG_STATE_HOME?.trim() || join(homedir(), ".local", "state"),
-      "coven-cave",
-    );
-  const stateDir =
-    process.env.COVEN_CAVE_MOBILE_STATE_DIR?.trim() ||
-    join(stateRoot, `mobile-tailscale-${port}`);
-  return join(stateDir, "access-token");
-}
-
-if (
-  process.env.COVEN_CAVE_BUNDLE !== "1" &&
-  process.env.COVEN_CAVE_E2E !== "1" &&
-  !process.env.COVEN_CAVE_ACCESS_TOKEN?.trim()
-) {
-  try {
-    const persisted = readFileSync(persistedMobileAccessSecretFile(), "utf8").trim();
-    if (persisted) process.env.COVEN_CAVE_ACCESS_TOKEN = persisted;
-  } catch {
-    // No provisioned secret — stay tokenless, exactly as before.
-  }
-}
-
-// Read lazily, not snapshotted: Settings · Phone can provision and arm the
-// pairing secret mid-session (cave-os73), and the PTY upgrade gate must honor
-// tokens signed with it without a server restart.
-function accessToken(): string {
-  return process.env.COVEN_CAVE_ACCESS_TOKEN ?? "";
-}
+// The boot re-arm that read a persisted pairing secret back into
+// COVEN_CAVE_ACCESS_TOKEN is gone with the access-token requirement itself
+// (cave-f4emr). Nothing consults that variable any more, so re-arming it would
+// only resurrect a credential no gate reads.
 const SIDECAR_TOKEN = process.env.COVEN_CAVE_AUTH_TOKEN ?? "";
 
 // Local-peer stamp (cave-vn2r): only this file sees the raw TCP socket, so
@@ -131,9 +92,6 @@ const FORWARDING_HEADERS = [
   "via",
 ] as const;
 
-const ACCESS_COOKIE = "coven_cave_access";
-const LEGACY_ACCESS_COOKIE = "coven_access_token";
-const ACCESS_QUERY_PARAM = "coven_access_token";
 const SIDECAR_QUERY_PARAM = "covenCaveToken";
 
 type PtySession = {
@@ -297,18 +255,6 @@ function scrollbackFrom(session: PtySession, cursor: number): Buffer[] {
   return output;
 }
 
-function getTokensFromCookie(header: string | undefined): string[] {
-  if (!header) return [];
-  const tokens: string[] = [];
-  for (const part of header.split(";")) {
-    const [key, ...rest] = part.trim().split("=");
-    if (key === ACCESS_COOKIE || key === LEGACY_ACCESS_COOKIE) {
-      tokens.push(decodeURIComponent(rest.join("=") ?? ""));
-    }
-  }
-  return tokens;
-}
-
 function timingSafeEqualString(a: string, b: string): boolean {
   const aBytes = Buffer.from(a);
   const bBytes = Buffer.from(b);
@@ -321,36 +267,12 @@ function timingSafeEqualString(a: string, b: string): boolean {
   return diff === 0;
 }
 
-function isExpectedAccessToken(value: string | undefined | null): boolean {
-  const secret = accessToken();
-  if (!secret || !value) return false;
-  if (timingSafeEqualString(value, secret)) return true;
-  return isValidSignedAccessToken(value, secret);
-}
-
-function isExpectedSidecarToken(value: string | undefined | null): boolean {
-  return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
-}
-
+// The per-launch sidecar credential is the only PTY token left (cave-f4emr):
+// the mobile access token it used to sit beside — raw secret or signed
+// `v1.<expiresAtMs>.<nonce>.<sig>` invite — no longer exists, so neither the
+// access cookie nor its query parameter is read here any more.
 function isExpectedPtyToken(value: string | undefined | null): boolean {
-  return isExpectedAccessToken(value) || isExpectedSidecarToken(value);
-}
-
-// Mirrors src/lib/mobile-access-token.ts (server.mjs is transpiled standalone,
-// so it can't import from src/): `v1.<expiresAtMs>.<nonce>.<sig>` where
-// sig = base64url(HMAC-SHA256(secret, "v1.<expiresAtMs>.<nonce>")). Paired
-// phones and QR-paired browsers hold these SIGNED tokens — not the raw secret
-// — so the PTY upgrade must honour them or every paired terminal 401s.
-function isValidSignedAccessToken(value: string, secret: string): boolean {
-  const parts = value.split(".");
-  if (parts.length !== 4 || parts[0] !== "v1") return false;
-  const expiresAt = Number(parts[1]);
-  if (!Number.isFinite(expiresAt) || expiresAt <= Date.now()) return false;
-  if (!parts[2] || !parts[3]) return false;
-  const expected = createHmac("sha256", secret)
-    .update(`v1.${parts[1]}.${parts[2]}`)
-    .digest("base64url");
-  return timingSafeEqualString(parts[3], expected);
+  return Boolean(SIDECAR_TOKEN && value && timingSafeEqualString(value, SIDECAR_TOKEN));
 }
 
 function bearerToken(req: IncomingMessage): string | null {
@@ -657,24 +579,32 @@ function parseUpgradeTarget(rawUrl: string): { pathname: string; query: UpgradeQ
 }
 
 function isPtyAuthRequired(): boolean {
-  return Boolean(accessToken() || SIDECAR_TOKEN);
+  return Boolean(SIDECAR_TOKEN);
 }
 
+/**
+ * A configured sidecar token closes the credential-less path.
+ *
+ * The access token used to be the second credential accepted here; removing it
+ * (cave-f4emr) narrows this to the sidecar token alone. Deliberately NOT
+ * replaced with a direct-loopback exemption: cave-ruw4z removed exactly that
+ * escape hatch because TCP loopback proves the caller is on this machine, never
+ * which OS user it is, and server-pty-ws.test.ts pins its absence. Plain
+ * development stays credential-less because no sidecar token exists there.
+ */
 function shouldRejectUnauthenticatedPtyUpgrade({
   sidecarTokenConfigured = false,
-  accessTokenConfigured = false,
   tokenAuthenticated = false,
 } = {}) {
   if (tokenAuthenticated) return false;
-  return sidecarTokenConfigured || accessTokenConfigured;
+  return sidecarTokenConfigured;
 }
 
 function isAuthorized(req: IncomingMessage, query: Record<string, string | string[] | undefined>): boolean {
   if (!isPtyAuthRequired()) return false;
 
-  const queryToken = firstQueryValue(query[ACCESS_QUERY_PARAM]);
   const sidecarQueryToken = firstQueryValue(query[SIDECAR_QUERY_PARAM]);
-  const candidates = [bearerToken(req), queryToken, sidecarQueryToken, ...getTokensFromCookie(req.headers.cookie)];
+  const candidates = [bearerToken(req), sidecarQueryToken];
   return candidates.some(isExpectedPtyToken);
 }
 
@@ -1148,14 +1078,12 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  // Verify credentials before the host gate: a valid signed access token
-  // (paired iOS terminal / handoff browser over `tailscale serve`, which
-  // forwards the `<host>.ts.net` Host) legitimately arrives with a
-  // non-loopback Host and must pass the source gate on the strength of its
-  // token — mirroring proxy.ts's isAllowedApiHost relaxation on REST.
-  // Forwarding headers are not credentials at this boundary: a local process
-  // can forge them, so allowlisted tailnet identity alone must never authorize
-  // spawning or adopting a shell.
+  // Verify credentials before the host gate: a caller holding the sidecar
+  // token may legitimately arrive with a non-loopback Host and passes the
+  // source gate on the strength of that token. Forwarding headers are not
+  // credentials at this boundary: a local process can forge them, so
+  // allowlisted tailnet identity alone must never authorize spawning or
+  // adopting a shell.
   const tokenAuthenticated = isPtyAuthRequired() ? isAuthorized(req, query) : false;
 
   if (!isAllowedUpgradeSource(req, tokenAuthenticated)) {
@@ -1164,20 +1092,14 @@ server.on("upgrade", (req, socket, head) => {
     return;
   }
 
-  // Any configured PTY credential closes the credential-less path, including
+  // A configured sidecar token closes the credential-less path, including for
   // direct loopback: another local account or process is not the paired app.
-  // Plain development remains credential-less only when neither token exists.
-  //
-  // Keep the credential-less case exactly that narrow. #714 removed it and
-  // 401'd every local terminal, reintroducing the v0.0.72 "Terminal connection
-  // failed" regression that server-pty-ws.test.ts still guards. What makes
-  // closing it safe HERE is that both peers now have a credential to present:
-  // the Tauri shell its per-launch sidecar token, and a local browser the
-  // access gate. TCP loopback proves only that the caller is on this machine,
-  // never which OS user it is.
+  // Plain development remains credential-less only because no sidecar token
+  // exists there. Removing the access token (cave-f4emr) narrowed the accepted
+  // credentials to one; it did not reopen the loopback escape hatch that
+  // cave-ruw4z closed.
   if (shouldRejectUnauthenticatedPtyUpgrade({
     sidecarTokenConfigured: Boolean(SIDECAR_TOKEN),
-    accessTokenConfigured: Boolean(accessToken()),
     tokenAuthenticated,
   })) {
     socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");

--- a/src/lib/pty-upgrade-auth.test.ts
+++ b/src/lib/pty-upgrade-auth.test.ts
@@ -13,6 +13,12 @@ const shouldRejectUnauthenticatedPtyUpgrade = new Function(
   `${helperSource}; return shouldRejectUnauthenticatedPtyUpgrade;`,
 )();
 
+// The access token was removed from this decision (cave-f4emr), so the sidecar
+// credential is the only thing left that can close the credential-less path.
+// `directLoopback` is deliberately still passed in every case below even though
+// the helper ignores it: cave-ruw4z removed the direct-loopback escape hatch —
+// TCP loopback proves the machine, not the OS user — and these cases are what
+// would catch it being reintroduced.
 for (const [name, input, expected] of [
   [
     "packaged sidecar rejects credential-less loopback clients",
@@ -42,6 +48,24 @@ for (const [name, input, expected] of [
     false,
   ],
   [
+    "a server with no sidecar token no longer rejects anyone: the access token that used to close this path is gone",
+    {
+      sidecarTokenConfigured: false,
+      tokenAuthenticated: false,
+      directLoopback: false,
+    },
+    false,
+  ],
+  [
+    "packaged sidecar rejects credential-less forwarded clients",
+    {
+      sidecarTokenConfigured: true,
+      tokenAuthenticated: false,
+      directLoopback: false,
+    },
+    true,
+  ],
+  [
     "token-authenticated forwarded clients are accepted",
     {
       sidecarTokenConfigured: true,
@@ -53,5 +77,17 @@ for (const [name, input, expected] of [
 ] as const) {
   assert.equal(shouldRejectUnauthenticatedPtyUpgrade(input), expected, name);
 }
+
+// An access-token argument must never come back and start closing this path
+// again — that credential no longer exists anywhere in the server.
+assert.equal(
+  shouldRejectUnauthenticatedPtyUpgrade({
+    sidecarTokenConfigured: false,
+    accessTokenConfigured: true,
+    tokenAuthenticated: false,
+  }),
+  false,
+  "a stray accessTokenConfigured argument has no effect on the decision",
+);
 
 console.log("pty-upgrade-auth.test.ts: ok");

--- a/src/lib/pty-upgrade-auth.test.ts
+++ b/src/lib/pty-upgrade-auth.test.ts
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 
 const serverSource = readFileSync(new URL("../../server.ts", import.meta.url), "utf8");
 const helperSource = serverSource.match(
-  /function shouldRejectUnauthenticatedPtyUpgrade\([\s\S]*?return sidecarTokenConfigured \|\| accessTokenConfigured;\n}/,
+  /function shouldRejectUnauthenticatedPtyUpgrade\([\s\S]*?return sidecarTokenConfigured;\n}/,
 )?.[0];
 
 assert.ok(helperSource, "server defines one testable PTY upgrade authentication decision");
@@ -18,7 +18,6 @@ for (const [name, input, expected] of [
     "packaged sidecar rejects credential-less loopback clients",
     {
       sidecarTokenConfigured: true,
-      accessTokenConfigured: false,
       tokenAuthenticated: false,
       directLoopback: true,
     },
@@ -28,7 +27,6 @@ for (const [name, input, expected] of [
     "packaged sidecar accepts its authenticated webview",
     {
       sidecarTokenConfigured: true,
-      accessTokenConfigured: false,
       tokenAuthenticated: true,
       directLoopback: true,
     },
@@ -38,37 +36,15 @@ for (const [name, input, expected] of [
     "plain local development remains credential-less",
     {
       sidecarTokenConfigured: false,
-      accessTokenConfigured: false,
       tokenAuthenticated: false,
       directLoopback: true,
     },
     false,
   ],
   [
-    "access-token-only servers reject credential-less loopback clients",
-    {
-      sidecarTokenConfigured: false,
-      accessTokenConfigured: true,
-      tokenAuthenticated: false,
-      directLoopback: true,
-    },
-    true,
-  ],
-  [
-    "access-token-only forwarded clients still need authentication",
-    {
-      sidecarTokenConfigured: false,
-      accessTokenConfigured: true,
-      tokenAuthenticated: false,
-      directLoopback: false,
-    },
-    true,
-  ],
-  [
-    "allowlisted or token-authenticated forwarded clients are accepted",
+    "token-authenticated forwarded clients are accepted",
     {
       sidecarTokenConfigured: true,
-      accessTokenConfigured: true,
       tokenAuthenticated: true,
       directLoopback: false,
     },

--- a/src/lib/server/mobile-access-provision.test.ts
+++ b/src/lib/server/mobile-access-provision.test.ts
@@ -122,5 +122,20 @@ test("mobile-handoff route provisions, arms, cookies the session, and retires on
   );
 });
 
-// cave-f4emr removed the boot re-arm and the accessToken() gate from server.ts;
-// the wiring-pin test that checked for them is no longer applicable.
+// The custom server used to re-arm COVEN_CAVE_ACCESS_TOKEN from the persisted
+// state file at boot, so a provisioned secret survived a dev-server restart and
+// kept the PTY gate armed. Removing the access-token requirement (cave-f4emr)
+// removed that gate, so the re-arm went with it: nothing in server.ts reads the
+// variable any more, and re-arming it would resurrect a credential no gate
+// consults. The provisioning seams above still work — they are what the pairing
+// flow signs invites with — they simply no longer arm anything.
+test("the custom server no longer re-arms or reads the access token", () => {
+  const server = readFileSync(path.join(process.cwd(), "server.ts"), "utf8");
+  assert.doesNotMatch(server, /persistedMobileAccessSecretFile/, "the boot re-arm is gone");
+  assert.doesNotMatch(
+    server,
+    /process\.env\.COVEN_CAVE_ACCESS_TOKEN/,
+    "the server neither reads nor writes the access-token secret",
+  );
+  assert.doesNotMatch(server, /function accessToken\(\)/, "no lazy access-token accessor remains");
+});

--- a/src/lib/server/mobile-access-provision.test.ts
+++ b/src/lib/server/mobile-access-provision.test.ts
@@ -122,18 +122,5 @@ test("mobile-handoff route provisions, arms, cookies the session, and retires on
   );
 });
 
-test("custom server re-arms at boot and reads the token lazily", () => {
-  const server = readFileSync(path.join(process.cwd(), "server.ts"), "utf8");
-  assert.match(server, /persistedMobileAccessSecretFile/, "boot re-arm reads the persisted state file");
-  assert.match(
-    server,
-    /COVEN_CAVE_BUNDLE !== "1"[\s\S]{0,200}COVEN_CAVE_E2E !== "1"/,
-    "re-arm is guarded off in the packaged bundle and e2e",
-  );
-  assert.match(server, /function accessToken\(\)/, "PTY gate reads the access token lazily");
-  assert.doesNotMatch(
-    server,
-    /const ACCESS_TOKEN = process\.env\.COVEN_CAVE_ACCESS_TOKEN/,
-    "no boot-time snapshot — mid-session arming must reach the PTY gate",
-  );
-});
+// cave-f4emr removed the boot re-arm and the accessToken() gate from server.ts;
+// the wiring-pin test that checked for them is no longer applicable.

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -22,19 +22,38 @@ assert.match(source, /export async function proxy\(req: NextRequest\)/, "Next 16
 assert.match(source, /matcher:\s*\["\/\(\(\?!_next\/static\|_next\/image\|favicon\.ico\)\.\*\)"\]/, "proxy should guard API and mobile browser routes");
 assert.match(source, /process\.env\.COVEN_CAVE_AUTH_TOKEN/, "proxy should require the per-launch sidecar token");
 assert.match(source, /process\.env\.COVEN_CAVE_BUNDLE === "1"[\s\S]*missing sidecar auth token/, "bundled sidecar mode should fail closed when its auth token is missing");
-assert.match(
-  source,
-  /forbidden peer: missing trusted local peer or verified remote ingress/,
-  "tokenless peer failures should identify the missing authorization proof",
-);
+
+// ── The access-token requirement is gone (cave-f4emr) ─────────────────────
+// Removed at the owner's direction. Nothing may reintroduce a credential
+// demand on the request path: no gate, no HTML access page, no cookie/query
+// exchange, and no 401 for a caller that simply presented nothing.
+assert.doesNotMatch(source, /COVEN_CAVE_ACCESS_TOKEN/, "the proxy must not read the access-token secret");
+assert.doesNotMatch(source, /mobileAccessGate|accessGatePage|isValidMobileAccessCredential/, "the access gate and its page must stay deleted");
+assert.doesNotMatch(source, /ACCESS_TOKEN_COOKIE|ACCESS_TOKEN_QUERY_PARAM/, "the proxy must not consult the access cookie or its query parameter");
+assert.doesNotMatch(source, /jsonError\(401, "unauthorized"\)/, "no request path may 401 for a missing credential");
+// The one 401 left is the armed passkey-presence requirement, which is opt-in
+// (COVEN_CAVE_PASSKEY_REQUIRED) and about proving a human, not a shared secret.
+assert.match(source, /jsonError\(401, "passkey presence required"\)/, "an armed passkey-presence requirement still fails closed");
 assert.match(source, /req\.headers\.get\("origin"\)/, "middleware should reject unsafe origins");
 assert.match(source, /req\.headers\.get\("host"\)/, "middleware should reject unsafe hosts");
 assert.match(source, /const requestHost = req\.headers\.get\("host"\)/, "proxy should capture the forwarded request host once");
-// Remote ingress is a verified mobile invite OR an allowlisted tailnet device
-// Tailnet forwarding metadata is not a credential: a local process can forge
-// it. Remote ingress requires a bearer credential (mobile or sidecar).
-assert.match(source, /const remoteIngress =\s*mobileAccessAuthenticated \|\| \(sidecarAuthenticatedAtGate && !trustedLocalPeer\)/, "remote ingress requires a verified bearer credential");
-assert.match(source, /isAllowedApiHost\(requestHost, remoteIngress\)/, "verified remote ingress should satisfy the API host gate");
+// Remote ingress is now CLASSIFICATION, not authentication (cave-f4emr): with
+// no credential left to present, anything server.ts did not stamp as a direct
+// loopback peer is treated as remote — admitted, but held to the mobile side
+// of every local-vs-remote split. Gated on the stamp secret existing so a bare
+// `next dev` (nothing stamps anything) does not read its own silence as "every
+// request is a phone" and 403 desktop-only routes for a local user.
+assert.match(
+  source,
+  /const localPeerStampActive = Boolean\(process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET\)/,
+  "remote-ingress classification must know whether server.ts is stamping at all",
+);
+assert.match(
+  source,
+  /const remoteIngress = localPeerStampActive && !trustedLocalPeer/,
+  "remote ingress is every non-direct-loopback peer once the stamp is active",
+);
+assert.match(source, /isAllowedApiHost\(requestHost, remoteIngress\)/, "remote ingress should satisfy the API host gate");
 assert.doesNotMatch(source, /isAllowedApiHost\([^)]*tailnetTrusted[^)]*\)/, "tailnet membership alone must not relax the API host gate");
 assert.match(source, /const tailnetTrusted = process\.env\.COVEN_CAVE_TAILNET_TRUST === "1"/, "the tailnet-trust flag should survive only as a taint marker that further restricts automation ingress");
 // The tailnet half of remoteIngress must come from the server.ts-minted stamp
@@ -44,11 +63,6 @@ assert.match(
   source,
   /const tailnetNodeId = verifiedTailnetNode\(\s*req\.headers\.get\(TAILNET_PEER_HEADER\),\s*process\.env\.COVEN_CAVE_TAILNET_PEER_SECRET,\s*\)/,
   "tailnet ingress is authorized by the verified per-boot stamp, not by a client-controlled header",
-);
-assert.match(
-  source,
-  /const tailnetPeerVerified = tailnetNodeId !== null/,
-  "tailnet verification is derived from a resolved node id",
 );
 assert.match(
   source,
@@ -90,19 +104,20 @@ assert.match(source, /isProductionWebhookGet\(req\.nextUrl\.pathname, req\.metho
 assert.match(source, /isLocalOnlyAutomationRun\(req\.nextUrl\.pathname, req\.method\)/, "run-now automation execution should have a dedicated local-only proxy guard");
 assert.match(source, /remoteIngress \|\| tailnetTrusted \|\| !isLoopbackHost\(requestHost\)/, "run-now automation execution must deny mobile, tailnet-device, tailnet-flagged, and non-loopback proxy ingress");
 assert.match(source, /missing request source/, "tokenless GET webhooks should reject absent Origin and Referer headers");
-// cave-gzje: a verified signed mobile invite is the paired phone's credential.
-// The final sidecar gate must admit it (the phone can never learn the
-// webview's per-launch token), and the webhook-GET missing-source guard must
-// extend to mobile-cookie-authenticated requests in exchange.
-assert.match(
+// The final sidecar gate is gone with the access token (cave-f4emr): the
+// sidecar credential still identifies the desktop webview for the CSRF
+// relaxation, but is no longer demanded of anyone. In exchange the webhook-GET
+// missing-source guard now covers ALL remote ingress, which after this change
+// carries no credential at all.
+assert.doesNotMatch(
   source,
-  /if \(!sidecarAuthenticated && !mobileAccessVerified\) \{/,
-  "the final sidecar gate must independently admit a verified access token",
+  /const sidecarAuthenticated = /,
+  "no request may be turned away for failing to present the sidecar token",
 );
 assert.match(
   source,
-  /\(!sidecarToken \|\| mobileAccessVerified\) &&\s*isProductionWebhookGet/,
-  "the webhook-GET missing-source guard must cover tokenless servers and mobile-cookie-authenticated requests",
+  /\(!sidecarToken \|\| remoteIngress\) &&\s*isProductionWebhookGet/,
+  "the webhook-GET missing-source guard must cover tokenless servers and every remote caller",
 );
 
 // Tailscale Serve fix (re-applies #618; #716 reverted it): a request bearing the
@@ -120,11 +135,6 @@ assert.match(
   source,
   /const sidecarTokenMatches = \(supplied: string \| null \| undefined\) => \{\s*if \(!sidecarToken \|\| !supplied\) return false;\s*return timingSafeEqualString\(supplied, sidecarToken\);\s*\}/,
   "sidecar auth must compare the supplied token with timingSafeEqualString",
-);
-assert.match(
-  source,
-  /const sidecarAuthenticated = sidecarTokenMatches\(suppliedToken\)/,
-  "sidecarAuthenticated must use the shared timing-safe matcher",
 );
 assert.match(
   source,
@@ -170,20 +180,10 @@ assert.doesNotMatch(
     "dev-mode token bypass must run AFTER host/origin/referer/content-type guards",
   );
 }
-assert.match(source, /isValidMobileAccessCredential/, "mobile token bootstrap should verify signed or legacy credentials");
-assert.match(
-  source,
-  /isValidMobileAccessCredential\(\{\s*supplied:\s*queryToken,\s*expectedSecret:\s*expected,\s*\}\)/,
-  "mobile token bootstrap should validate the query token before writing cookie state",
-);
-assert.match(source, /if \(queryVerification\.ok\)/, "invalid query tokens should not overwrite the access cookie");
-assert.match(source, /maxAge/, "signed mobile cookie lifetime should track token expiry");
-assert.match(source, /req\.method === "GET" \|\| req\.method === "HEAD"/, "mobile token bootstrap should avoid redirects for mutating requests");
-
-// ── User-bound local authentication (cave-ruw4z) ──────────────────────────
-// The local-peer stamp still distinguishes direct from forwarded ingress, but
-// cannot bypass authentication because TCP loopback does not identify an OS
-// user. Only the per-launch sidecar credential exempts the owning Tauri app.
+// ── Local-peer classification (cave-ruw4z, repurposed by cave-f4emr) ──────
+// The stamp no longer decides admission — nothing does — but it is still the
+// only trustworthy local/remote signal, and it must keep coming from the
+// server-minted per-boot secret rather than a client-settable marker.
 assert.match(
   source,
   /isTrustedLocalPeer\(\s*req\.headers\.get\(LOCAL_PEER_HEADER\),\s*process\.env\.COVEN_CAVE_LOCAL_PEER_SECRET,?\s*\)/,
@@ -193,50 +193,6 @@ assert.doesNotMatch(
   source,
   /LOCAL_PEER_HEADER\)\s*===\s*"1"/,
   "a bare marker value must never satisfy local-peer classification",
-);
-assert.match(
-  source,
-  /shouldRequireMobileAccessCredential\(\s*req\.headers\.get\("host"\),\s*suppliedTokens\.length > 0,\s*trustedLocalPeer,\s*tailnetPeerVerified,\s*sidecarAuthenticated,?\s*\)/,
-  "the mobile gate must require user-bound sidecar or mobile credentials even for local peers",
-);
-assert.match(
-  source,
-  /const sidecarAuthenticatedAtGate = sidecarTokenMatches\(\s*req\.headers\.get\(TOKEN_HEADER\) \?\? req\.nextUrl\.searchParams\.get\(TOKEN_PARAM\),?\s*\)/,
-  "the Tauri bypass must validate its per-launch sidecar credential",
-);
-// The marker classifies mobile INGRESS, not credential possession: a mobile
-// invite cookie in a local desktop browser (auto-sent after a pairing link
-// was once opened there) must not reclassify a trusted local peer as a
-// phone — that marker makes isLocalOrigin() 403 every desktop-only route
-// (research missions/links, automations) for a genuinely local user.
-assert.match(
-  source,
-  /const mobileAccessVerified = mobileAccessToken\s*\?[\s\S]*?const mobileAccessAuthenticated = !trustedLocalPeer && mobileAccessVerified/,
-  "a trusted local peer must never be marked as mobile ingress, even when a mobile access cookie rides along",
-);
-assert.match(
-  source,
-  /mobileAccessGate\(\s*req,\s*trustedLocalPeer,\s*tailnetPeerVerified,\s*sidecarAuthenticatedAtGate,?\s*\)/,
-  "the local-peer, tailnet, and sidecar evidence is shared with the mobile gate",
-);
-
-// ── HTML access gate for unauthenticated browser navigations ──────────────
-// Same 401 fail-closed posture; only the body differs by client. The page's
-// form re-enters the query-token exchange above — no new auth logic.
-assert.match(
-  source,
-  /isHtmlNavigationRequest\(req\.method, req\.nextUrl\.pathname, req\.headers\.get\("accept"\)\)/,
-  "unauthenticated browser page navigations should get the HTML access gate",
-);
-assert.match(
-  source,
-  /if \(!verification\) \{[\s\S]*?accessGatePage\(\{ invalidToken: suppliedTokens\.length > 0 \}\)[\s\S]*?status: 401[\s\S]*?return jsonError\(401, "unauthorized"\);[\s\S]*?\}/,
-  "the HTML gate must live inside the failed-verification branch, still 401, with the JSON envelope retained for non-navigations",
-);
-assert.match(
-  source,
-  /"cache-control": "no-store"/,
-  "the access gate page must never be cached",
 );
 assert.match(
   sidecarBridgeSource,

--- a/src/proxy-behavior.test.ts
+++ b/src/proxy-behavior.test.ts
@@ -24,13 +24,8 @@ import {
   expectedRequestOrigins,
   bearerFromReferer,
   bearerFromRefererAny,
-  shouldRequireMobileAccessCredential,
-  isTokenlessApiPeerAllowed,
   isTrustedLocalPeer,
   timingSafeEqualString,
-  isHtmlNavigationRequest,
-  accessGatePage,
-  ACCESS_TOKEN_QUERY_PARAM,
 } from "./proxy-helpers.ts";
 
 // ─── isLoopbackHost ────────────────────────────────────────────────────────
@@ -110,23 +105,6 @@ assert.equal(isTailscaleServeHost("cave.tailnet.example.ts.net"), true);
 assert.equal(isTailscaleServeHost("cave.tailnet.example.ts.net:8443"), true);
 assert.equal(isTailscaleServeHost("localhost:3000"), false);
 assert.equal(isTailscaleServeHost("127.0.0.1:3000"), false);
-
-// ─── tokenless API peer proof ─────────────────────────────────────────────
-assert.equal(
-  isTokenlessApiPeerAllowed(false, false),
-  false,
-  "a spoofed loopback Host cannot replace server-verified peer identity",
-);
-assert.equal(
-  isTokenlessApiPeerAllowed(true, false),
-  true,
-  "the custom server's direct-loopback stamp preserves tokenless development",
-);
-assert.equal(
-  isTokenlessApiPeerAllowed(false, true),
-  true,
-  "verified remote ingress remains available through its authenticated path",
-);
 
 // ─── sameOrigin ────────────────────────────────────────────────────────────
 const expected = "http://localhost:3000";
@@ -360,43 +338,6 @@ assert.equal(
   "native app: absent Referer still passes the source helper",
 );
 
-// ─── shouldRequireMobileAccessCredential ──────────────────────────────────
-assert.equal(
-  shouldRequireMobileAccessCredential("localhost:3000", false),
-  true,
-  "Host headers are spoofable and must not exempt requests from the mobile gate",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("127.0.0.1:3000", false),
-  true,
-  "loopback-looking Host headers still require a valid invite",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false),
-  true,
-  "non-loopback mobile entrypoints still require a valid invite",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("localhost:3000", true),
-  true,
-  "supplied credentials should still be verified and redirected on loopback",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("localhost:3000", false, true),
-  true,
-  "a direct loopback peer still needs user-bound credentials on a shared machine",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("localhost:3000", false, true, false, true),
-  false,
-  "the Tauri app's verified per-launch sidecar credential bypasses the mobile gate",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false, false),
-  true,
-  "without the server's local-peer stamp the gate stays armed for every host",
-);
-
 // ─── isTrustedLocalPeer ───────────────────────────────────────────────────
 // The local-peer stamp still distinguishes direct from forwarded traffic, but
 // it is not user identity and cannot bypass an armed credential gate.
@@ -457,45 +398,6 @@ assert.equal(timingSafeEqualString("12345", "12346"), false);
   const right = "a".repeat(1023) + "b";
   assert.equal(timingSafeEqualString(left, right), false);
   assert.equal(timingSafeEqualString(left, left), true);
-}
-
-// ─── isHtmlNavigationRequest ───────────────────────────────────────────────
-// Only browser PAGE navigations (HTML-accepting GET outside /api/) qualify
-// for the HTML access gate; everything else must keep the JSON 401 envelope.
-const BROWSER_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
-assert.equal(isHtmlNavigationRequest("GET", "/", BROWSER_ACCEPT), true);
-assert.equal(isHtmlNavigationRequest("GET", "/dashboard/familiars/growth", BROWSER_ACCEPT), true);
-assert.equal(
-  isHtmlNavigationRequest("GET", "/api/familiars", BROWSER_ACCEPT),
-  false,
-  "API routes keep JSON even for HTML-accepting clients",
-);
-assert.equal(isHtmlNavigationRequest("GET", "/api", BROWSER_ACCEPT), false, "bare /api is an API path");
-assert.equal(
-  isHtmlNavigationRequest("GET", "/apidocs", BROWSER_ACCEPT),
-  true,
-  "prefix match must not swallow non-API paths that merely start with 'api'",
-);
-assert.equal(isHtmlNavigationRequest("POST", "/", BROWSER_ACCEPT), false, "mutations keep JSON");
-assert.equal(isHtmlNavigationRequest("HEAD", "/", BROWSER_ACCEPT), false, "HEAD keeps JSON");
-assert.equal(isHtmlNavigationRequest("GET", "/", "application/json"), false, "fetch/curl keep JSON");
-assert.equal(isHtmlNavigationRequest("GET", "/", null), false, "no Accept header keeps JSON");
-
-// ─── accessGatePage ────────────────────────────────────────────────────────
-{
-  const page = accessGatePage();
-  assert.match(page, /Access token required/);
-  // The form re-enters the audited query-token exchange — the input MUST be
-  // named exactly ACCESS_TOKEN_QUERY_PARAM and submit via GET.
-  assert.match(page, new RegExp(`name="${ACCESS_TOKEN_QUERY_PARAM}"`));
-  assert.match(page, /method="get"/);
-  assert.match(page, /type="password"/, "token input must not echo on screen");
-  assert.doesNotMatch(page, /<script/i, "gate page must be script-free (CSP-immune, no new surface)");
-  assert.doesNotMatch(page, /didn&rsquo;t verify/, "neutral prompt shows no failure note");
-
-  const invalid = accessGatePage({ invalidToken: true });
-  assert.match(invalid, /didn&rsquo;t verify/, "supplied-but-invalid tokens get the expiry hint");
-  assert.match(invalid, /role="alert"/);
 }
 
 console.log("proxy-behavior.test.ts: ok");

--- a/src/proxy-helpers.ts
+++ b/src/proxy-helpers.ts
@@ -51,18 +51,11 @@ export function isTailscaleServeHost(host: string | null) {
 
 export function isAllowedApiHost(
   host: string | null,
-  mobileAccessAuthenticated = false,
+  remoteIngress = false,
   tailnetTrusted = false,
 ) {
-  if (mobileAccessAuthenticated) return true;
+  if (remoteIngress) return true;
   return isLoopbackHost(host) || (tailnetTrusted && isTailscaleServeHost(host));
-}
-
-export function isTokenlessApiPeerAllowed(
-  trustedLocalPeer: boolean,
-  remoteIngress: boolean,
-) {
-  return trustedLocalPeer || remoteIngress;
 }
 
 export function sameOrigin(value: string | null, expectedOrigin: string) {
@@ -129,22 +122,6 @@ export function isAllowedRequestSourceAny(value: string | null, expectedOrigins:
   return expectedOrigins.some((origin) => isAllowedRequestSource(value, origin));
 }
 
-export function shouldRequireMobileAccessCredential(
-  _host: string | null,
-  _hasSuppliedCredential: boolean,
-  _trustedLocalPeer = false,
-  tailnetPeerVerified = false,
-  sidecarAuthenticated = false,
-) {
-  // Forwarded tailnet identity is context for presence policy, not a bearer
-  // credential: a local process can forge proxy headers on a loopback socket.
-  void tailnetPeerVerified;
-  // The Tauri sidecar credential is minted per launch and delivered only to
-  // the owning app. Unlike TCP loopback, it distinguishes the intended local
-  // user from other OS users on a shared machine.
-  return !sidecarAuthenticated;
-}
-
 /**
  * True when the request's LOCAL_PEER_HEADER value equals the per-boot
  * local-peer secret minted by server.ts. The custom server deletes any
@@ -199,114 +176,6 @@ export function bearerFromRefererAny(value: string | null, expectedOrigins: stri
     if (token) return token;
   }
   return null;
-}
-
-/**
- * True when an unauthenticated request is a browser PAGE navigation (an
- * HTML-accepting GET outside /api/). Only these get the HTML access-gate
- * page; API routes, mutations, and non-browser clients (curl, fetch) keep
- * the machine-readable JSON 401 envelope.
- */
-export function isHtmlNavigationRequest(
-  method: string,
-  pathname: string,
-  accept: string | null,
-) {
-  if (method !== "GET") return false;
-  if (pathname === "/api" || pathname.startsWith("/api/")) return false;
-  return Boolean(accept && accept.toLowerCase().includes("text/html"));
-}
-
-/**
- * The access-gate page served (with a 401) to unauthenticated browser
- * navigations when COVEN_CAVE_ACCESS_TOKEN is configured. Deliberately
- * static — nothing from the request is interpolated — and script-free.
- * The form submits the token as the existing ACCESS_TOKEN_QUERY_PARAM GET
- * parameter, so verification and the cookie exchange reuse the audited
- * query-token path in the proxy; this page adds no new auth logic.
- */
-export function accessGatePage({ invalidToken = false }: { invalidToken?: boolean } = {}) {
-  const note = invalidToken
-    ? '<p class="note" role="alert">That token didn&rsquo;t verify &mdash; it may have expired. Mint a new pairing link and try again.</p>'
-    : "";
-  return `<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="robots" content="noindex">
-<title>Access required · Coven Cave</title>
-<style>
-  :root { color-scheme: dark; }
-  body {
-    margin: 0;
-    display: grid;
-    place-items: center;
-    min-height: 100vh;
-    background: oklch(0.24 0.006 291);
-    color: oklch(0.93 0.004 291);
-    font: 14px/1.5 ui-sans-serif, system-ui, -apple-system, sans-serif;
-  }
-  main {
-    width: min(360px, calc(100vw - 48px));
-    padding: 28px;
-    border: 1px solid oklch(0.93 0.004 291 / 12%);
-    border-radius: 16px;
-    background: oklch(0.26 0.007 291);
-  }
-  .dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 999px;
-    background: #9386d0;
-    box-shadow: 0 0 0 4px oklch(0.62 0.09 291 / 16%);
-    margin-bottom: 16px;
-  }
-  h1 { margin: 0 0 6px; font-size: 16px; font-weight: 650; }
-  p { margin: 0 0 16px; color: oklch(0.66 0.010 291); font-size: 13px; }
-  .note { color: oklch(0.72 0.14 78); }
-  form { display: flex; gap: 8px; }
-  input {
-    flex: 1;
-    min-width: 0;
-    padding: 8px 12px;
-    border: 1px solid oklch(0.93 0.004 291 / 22%);
-    border-radius: 999px;
-    background: oklch(0.22 0.006 291);
-    color: inherit;
-    font: inherit;
-  }
-  input:focus-visible, button:focus-visible {
-    outline: 2px solid oklch(0.62 0.09 291 / 55%);
-    outline-offset: 1px;
-  }
-  button {
-    padding: 8px 16px;
-    border: 1px solid oklch(0.93 0.004 291 / 22%);
-    border-radius: 999px;
-    background: oklch(0.29 0.008 291);
-    color: inherit;
-    font: inherit;
-    font-weight: 600;
-    cursor: pointer;
-  }
-  button:hover { background: oklch(0.32 0.009 291); }
-</style>
-</head>
-<body>
-<main>
-  <div class="dot" aria-hidden="true"></div>
-  <h1>Access token required</h1>
-  <p>This Cave is protected. Open your pairing link, or paste an access token below.</p>
-  ${note}
-  <form method="get" action="">
-    <input type="password" name="${ACCESS_TOKEN_QUERY_PARAM}" autocomplete="off" required aria-label="Access token" placeholder="Access token">
-    <button type="submit">Unlock</button>
-  </form>
-</main>
-</body>
-</html>
-`;
 }
 
 export const ACCESS_TOKEN_COOKIE = "coven_cave_access";

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,9 +1,6 @@
 import { NextResponse, type NextRequest } from "next/server";
 
 import {
-  ACCESS_TOKEN_COOKIE,
-  ACCESS_TOKEN_QUERY_PARAM,
-  TOKEN_PARAM,
   TOKEN_HEADER,
   MOBILE_ACCESS_HEADER,
   LOCAL_PEER_HEADER,
@@ -11,22 +8,16 @@ import {
   timingSafeEqualString,
   isLoopbackHost,
   isAllowedApiHost,
-  isTokenlessApiPeerAllowed,
   sameOrigin,
   isAllowedRequestSource,
   isAllowedRequestSourceAny,
   expectedRequestOrigins,
   bearerFromReferer,
-  bearerFromRefererAny,
-  shouldRequireMobileAccessCredential,
   isTrustedLocalPeer,
-  isHtmlNavigationRequest,
-  accessGatePage,
   TAILNET_PEER_HEADER,
   verifiedTailnetNode,
   requiresPasskeyPresence,
 } from "./proxy-helpers";
-import { isValidMobileAccessCredential } from "./lib/mobile-access-token.ts";
 import { PRESENCE_COOKIE, verifyPresenceToken } from "./lib/passkey-presence.ts";
 
 // Re-exported here so existing call sites (and tests) that imported these
@@ -38,115 +29,11 @@ export {
   sameOrigin,
   isAllowedRequestSource,
   bearerFromReferer,
-  shouldRequireMobileAccessCredential,
   MOBILE_ACCESS_HEADER,
 };
 
 function jsonError(status: number, error: string) {
   return NextResponse.json({ ok: false, error }, { status });
-}
-
-function configuredMobileAccessToken() {
-  const token = process.env.COVEN_CAVE_ACCESS_TOKEN?.trim();
-  return token && token.length > 0 ? token : null;
-}
-
-function bearerToken(req: NextRequest) {
-  const header = req.headers.get("authorization");
-  const prefix = "Bearer ";
-  if (!header?.startsWith(prefix)) return null;
-  return header.slice(prefix.length).trim();
-}
-
-function mobileAccessSuppliedTokens(req: NextRequest) {
-  return [
-    bearerToken(req),
-    req.cookies.get(ACCESS_TOKEN_COOKIE)?.value,
-    req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM),
-  ].filter((token): token is string => Boolean(token));
-}
-
-async function mobileAccessVerification(
-  req: NextRequest,
-  expected: string,
-  suppliedTokens = mobileAccessSuppliedTokens(req),
-) {
-  for (const token of suppliedTokens) {
-    const result = await isValidMobileAccessCredential({
-      supplied: token,
-      expectedSecret: expected,
-    });
-    if (result.ok) return result;
-  }
-  return null;
-}
-
-async function mobileAccessGate(
-  req: NextRequest,
-  trustedLocalPeer: boolean,
-  tailnetPeerVerified: boolean,
-  sidecarAuthenticated: boolean,
-) {
-  const expected = configuredMobileAccessToken();
-  if (!expected) return null;
-
-  const suppliedTokens = mobileAccessSuppliedTokens(req);
-  if (
-    !shouldRequireMobileAccessCredential(
-      req.headers.get("host"),
-      suppliedTokens.length > 0,
-      trustedLocalPeer,
-      tailnetPeerVerified,
-      sidecarAuthenticated,
-    )
-  ) {
-    return null;
-  }
-
-  const queryToken = req.nextUrl.searchParams.get(ACCESS_TOKEN_QUERY_PARAM);
-  const verification = await mobileAccessVerification(req, expected, suppliedTokens);
-  if (!verification) {
-    // Browser page navigations get an HTML access page instead of a raw JSON
-    // dead end. Same 401, same fail-closed posture — the page's form submits
-    // the token as ACCESS_TOKEN_QUERY_PARAM, re-entering the audited
-    // query-token exchange below. API routes and non-browser clients keep the
-    // machine-readable envelope.
-    if (isHtmlNavigationRequest(req.method, req.nextUrl.pathname, req.headers.get("accept"))) {
-      return new NextResponse(accessGatePage({ invalidToken: suppliedTokens.length > 0 }), {
-        status: 401,
-        headers: {
-          "content-type": "text/html; charset=utf-8",
-          "cache-control": "no-store",
-        },
-      });
-    }
-    return jsonError(401, "unauthorized");
-  }
-
-  if (queryToken && (req.method === "GET" || req.method === "HEAD")) {
-    const url = req.nextUrl.clone();
-    url.searchParams.delete(ACCESS_TOKEN_QUERY_PARAM);
-    const res = NextResponse.redirect(url);
-    const queryVerification = await isValidMobileAccessCredential({
-      supplied: queryToken,
-      expectedSecret: expected,
-    });
-    if (queryVerification.ok) {
-      const maxAge = queryVerification.legacy
-        ? undefined
-        : Math.max(1, Math.floor((queryVerification.expiresAt - Date.now()) / 1000));
-      res.cookies.set(ACCESS_TOKEN_COOKIE, queryToken, {
-        httpOnly: true,
-        sameSite: "lax",
-        secure: req.nextUrl.protocol === "https:",
-        path: "/",
-        maxAge,
-      });
-    }
-    return res;
-  }
-
-  return null;
 }
 
 function hasSafeContentType(req: NextRequest) {
@@ -189,39 +76,28 @@ function nextWithMobileAccessMarker(req: NextRequest, mobileAccessAuthenticated:
 }
 
 export async function proxy(req: NextRequest) {
-  const mobileAccessToken = configuredMobileAccessToken();
   const sidecarToken = process.env.COVEN_CAVE_AUTH_TOKEN;
   const sidecarTokenMatches = (supplied: string | null | undefined) => {
     if (!sidecarToken || !supplied) return false;
     return timingSafeEqualString(supplied, sidecarToken);
   };
-  const sidecarAuthenticatedAtGate = sidecarTokenMatches(
-    req.headers.get(TOKEN_HEADER) ?? req.nextUrl.searchParams.get(TOKEN_PARAM),
-  );
-  // The local-peer stamp distinguishes direct from forwarded traffic, but TCP
-  // loopback is not OS-user identity. When mobile access is armed, the Tauri
-  // app must also present its per-launch sidecar credential and a plain local
-  // browser must use the same access-token gate as remote browsers.
+  // The local-peer stamp distinguishes direct (this machine) from forwarded
+  // traffic. It is the only ingress classification left now that the
+  // access-token requirement is gone: nothing is asked to prove a credential,
+  // so this decides which side of the local/remote route split a caller lands
+  // on rather than whether it is admitted at all.
   const trustedLocalPeer = isTrustedLocalPeer(
     req.headers.get(LOCAL_PEER_HEADER),
     process.env.COVEN_CAVE_LOCAL_PEER_SECRET,
   );
-  // Tailnet device context behind a Tailscale-Serve-forwarded request. This is
-  // never sufficient authentication because direct loopback clients can forge
-  // forwarding headers; it is consumed only after bearer authentication for
-  // optional passkey-presence binding.
+  // Tailnet device context behind a Tailscale-Serve-forwarded request. Still
+  // never treated as authentication — direct loopback clients can forge
+  // forwarding headers — and consumed only for optional passkey-presence
+  // binding.
   const tailnetNodeId = verifiedTailnetNode(
     req.headers.get(TAILNET_PEER_HEADER),
     process.env.COVEN_CAVE_TAILNET_PEER_SECRET,
   );
-  const tailnetPeerVerified = tailnetNodeId !== null;
-  const mobileRes = await mobileAccessGate(
-    req,
-    trustedLocalPeer,
-    tailnetPeerVerified,
-    sidecarAuthenticatedAtGate,
-  );
-  if (mobileRes) return mobileRes;
 
   if (!req.nextUrl.pathname.startsWith("/api/")) {
     return NextResponse.next();
@@ -232,8 +108,9 @@ export async function proxy(req: NextRequest) {
   // historically returned NextResponse.next() before these checks ran, which
   // would have left every workspace-driving route open to non-loopback
   // callers if the dev server were ever bound to anything other than
-  // 127.0.0.1. The token equality check below is the only thing
-  // legitimately optional in browser-dev mode.
+  // 127.0.0.1. These are now the whole of the request gate: with the
+  // access-token requirement removed (cave-f4emr) nothing below turns a
+  // request away for failing to present a credential.
   const requestHost = req.headers.get("host");
   // Accept the Origin/Referer against the configured-port origin (nextUrl,
   // which the Serve/forwarded-host path relies on) AND the port the browser
@@ -244,29 +121,25 @@ export async function proxy(req: NextRequest) {
     req.nextUrl.protocol,
     requestHost,
   );
-  // The mobile-access marker classifies MOBILE INGRESS, not merely "a valid
-  // mobile credential was presented". A trusted local peer is this machine's
-  // desktop app or a local browser; a mobile invite cookie riding along
-  // (e.g. a pairing link once opened in the desktop browser writes the
-  // auto-sent access cookie) must not reclassify it as a phone — that marker
-  // makes isLocalOrigin() 403 every desktop-only route (research missions,
-  // links, automations) for a genuinely local user.
-  const mobileAccessVerified = mobileAccessToken
-    ? Boolean(await mobileAccessVerification(req, mobileAccessToken))
-    : false;
-  const mobileAccessAuthenticated = !trustedLocalPeer && mobileAccessVerified;
-  // Tailscale app mode (`pnpm mobile:tailscale:app`) now always provisions the
-  // mobile access credential, so a remote-looking (Tailscale Serve) Host is
-  // accepted only when that credential verifies. COVEN_CAVE_TAILNET_TRUST no
-  // longer relaxes this gate — tailnet membership alone is not authorization —
-  // but the flag still marks tailnet ingress below so local-only automation
-  // runs stay off that path.
+  // COVEN_CAVE_TAILNET_TRUST no longer decides admission — nothing does — but
+  // the flag still marks tailnet ingress below so local-only automation runs
+  // stay off that path.
   const tailnetTrusted = process.env.COVEN_CAVE_TAILNET_TRUST === "1";
-  // Forwarded tailnet identity alone is spoofable by another local process.
-  // Remote ingress therefore requires a bearer credential; the tailnet node
-  // remains useful only as additional device context for passkey presence.
-  const remoteIngress =
-    mobileAccessAuthenticated || (sidecarAuthenticatedAtGate && !trustedLocalPeer);
+  // Remote ingress is now classification, not authentication (cave-f4emr).
+  // With the access-token requirement removed there is no credential left for
+  // a phone or any other forwarded caller to present, so anything server.ts
+  // did NOT classify as a direct loopback peer is treated as remote:
+  // admitted, but held to the mobile side of every local-vs-remote split below
+  // (host allowlist, passkey-presence policy, local-only automation, and the
+  // MOBILE_ACCESS_HEADER marker that makes isLocalOrigin() refuse desktop-only
+  // routes).
+  //
+  // Gated on the stamp secret being present, not merely on the stamp being
+  // absent: without server.ts in front (a bare `next dev`, the E2E harness)
+  // nothing stamps anything, and reading that silence as "every request is a
+  // phone" would 403 every desktop-only route for a purely local user.
+  const localPeerStampActive = Boolean(process.env.COVEN_CAVE_LOCAL_PEER_SECRET);
+  const remoteIngress = localPeerStampActive && !trustedLocalPeer;
   if (!isAllowedApiHost(requestHost, remoteIngress)) {
     return jsonError(403, "forbidden host");
   }
@@ -342,12 +215,11 @@ export async function proxy(req: NextRequest) {
     // there is nothing to prove the caller is first-party, and browsers can
     // issue cross-site GET navigations/subresources with both Origin and
     // Referer omitted (for example via Referrer-Policy: no-referrer). The same
-    // applies to a request authenticated only by the mobile-access cookie
-    // (SameSite=Lax still rides top-level GET navigations). Require a
-    // same-origin source header for that narrow state-changing GET surface so
-    // absent headers cannot bypass the CSRF gate.
+    // applies to remote ingress, which now carries no credential at all.
+    // Require a same-origin source header for that narrow state-changing GET
+    // surface so absent headers cannot bypass the CSRF gate.
     if (
-      (!sidecarToken || mobileAccessVerified) &&
+      (!sidecarToken || remoteIngress) &&
       isProductionWebhookGet(req.nextUrl.pathname, req.method) &&
       !origin &&
       !referer
@@ -359,33 +231,17 @@ export async function proxy(req: NextRequest) {
     return jsonError(415, "unsupported content-type");
   }
 
-  const suppliedToken =
-    req.headers.get(TOKEN_HEADER) ??
-    req.nextUrl.searchParams.get(TOKEN_PARAM) ??
-    bearerFromRefererAny(req.headers.get("referer"), expectedOrigins);
-  const sidecarAuthenticated = sidecarTokenMatches(suppliedToken);
-
-  if (!sidecarToken) {
-    if (process.env.COVEN_CAVE_BUNDLE === "1") {
-      return jsonError(500, "missing sidecar auth token");
-    }
-    if (!isTokenlessApiPeerAllowed(trustedLocalPeer, remoteIngress)) {
-      return jsonError(403, "forbidden peer: missing trusted local peer or verified remote ingress");
-    }
-    return nextWithMobileAccessMarker(req, remoteIngress);
+  if (!sidecarToken && process.env.COVEN_CAVE_BUNDLE === "1") {
+    return jsonError(500, "missing sidecar auth token");
   }
 
-  if (!sidecarAuthenticated && !mobileAccessVerified) {
-    // A verified signed mobile invite is the paired phone's credential: the
-    // token is minted by this desktop from its access secret and already
-    // passed mobileAccessGate above. Requiring the webview's per-launch
-    // sidecar token ON TOP would 401 every native REST call in the packaged
-    // bundle — the phone can never learn that token — which is exactly the
-    // "packaged app cannot pair" failure (cave-gzje). CSRF stays covered: the
-    // Origin/Referer gates above ran for every non-header-trusted request.
-    return jsonError(401, "unauthorized");
-  }
-
+  // No credential is required to reach an API route (cave-f4emr). The sidecar
+  // token remains the desktop webview's identifier — it is what relaxes the
+  // CSRF source gate for the mobile-capable paths above — but it is no longer
+  // demanded of anyone, because the access token that let a phone answer that
+  // demand is gone. What still applies to every request: the host allowlist,
+  // the Origin/Referer gates, the content-type gate, the local-only
+  // automation guard, and any armed passkey-presence requirement.
   return nextWithMobileAccessMarker(req, remoteIngress);
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -239,9 +239,14 @@ export async function proxy(req: NextRequest) {
   // token remains the desktop webview's identifier — it is what relaxes the
   // CSRF source gate for the mobile-capable paths above — but it is no longer
   // demanded of anyone, because the access token that let a phone answer that
-  // demand is gone. What still applies to every request: the host allowlist,
-  // the Origin/Referer gates, the content-type gate, the local-only
-  // automation guard, and any armed passkey-presence requirement.
+  // demand is gone.
+  //
+  // What still applies to EVERY request: the Origin/Referer gates, the
+  // content-type gate, and any armed passkey-presence requirement. What
+  // applies only to LOCAL ingress: the Host allowlist (remote ingress
+  // satisfies isAllowedApiHost outright, so a forwarded caller's Host is not
+  // allow-listed at all) and the local-only automation guard, which remote
+  // ingress fails by construction rather than passes.
   return nextWithMobileAccessMarker(req, remoteIngress);
 }
 

--- a/src/server-pty-ws.test.ts
+++ b/src/server-pty-ws.test.ts
@@ -45,23 +45,23 @@ assert.match(
   /try \{\s*\(\{ pathname, query \} = parseUpgradeTarget\(req\.url \?\? "\/"\)\);\s*\} catch \{\s*socket\.write\("HTTP\/1\.1 400 Bad Request\\r\\n\\r\\n"\);\s*socket\.destroy\(\);\s*return;/,
   "malformed upgrade targets fail with HTTP 400 and a closed socket",
 );
-assert.match(src, /COVEN_CAVE_ACCESS_TOKEN/, "server checks sidecar access token");
-assert.match(src, /ACCESS_COOKIE = "coven_cave_access"/, "server accepts the same access cookie as REST middleware");
-assert.match(src, /ACCESS_QUERY_PARAM = "coven_access_token"/, "server accepts the mobile access token query param for WebSocket auth");
+// ── The access token is gone from this gate too (cave-f4emr) ──────────────
+// It was removed from the whole request path at the owner's direction, so the
+// server must neither read the secret nor honour the cookie/query credential
+// derived from it. The per-launch sidecar token is the only PTY credential
+// left.
+assert.doesNotMatch(src, /process\.env\.COVEN_CAVE_ACCESS_TOKEN/, "the server must not read the access-token secret");
+assert.doesNotMatch(src, /ACCESS_COOKIE|ACCESS_QUERY_PARAM/, "the access cookie and its query parameter are no longer credentials");
+assert.doesNotMatch(src, /isValidSignedAccessToken|isExpectedAccessToken/, "signed mobile invites are no longer verified here");
+// The 401 applies when the sidecar credential is configured. Without it (plain
+// local development) the loopback host+origin gate is the protection. Once it
+// exists, even loopback callers must prove they hold it before the server will
+// spawn or adopt a shell.
+assert.match(src, /function isPtyAuthRequired\(\): boolean \{\s*return Boolean\(SIDECAR_TOKEN\);\s*\}/, "PTY auth is required exactly when the sidecar token is configured");
 assert.match(
   src,
-  /const secret = accessToken\(\);\s*if \(!secret \|\| !value\) return false/,
-  "PTY WebSocket access-token auth fails closed when no access token is configured, reading the token lazily so mid-session arming (cave-os73) reaches the gate",
-);
-// The 401 applies when a remote/mobile credential is configured. With neither
-// token (plain local development) the loopback host+origin gate is the
-// protection. Once either credential exists, even loopback callers must prove
-// they hold it before the server will spawn or adopt a shell.
-assert.match(src, /function isPtyAuthRequired\(\): boolean \{\s*return Boolean\(accessToken\(\) \|\| SIDECAR_TOKEN\);\s*\}/, "PTY auth is required when either the mobile access token or sidecar token is configured");
-assert.match(
-  src,
-  /sidecarTokenConfigured: Boolean\(SIDECAR_TOKEN\),\s*accessTokenConfigured: Boolean\(accessToken\(\)\),\s*tokenAuthenticated,/,
-  "PTY upgrade authentication closes the credential-less path whenever either token is configured",
+  /sidecarTokenConfigured: Boolean\(SIDECAR_TOKEN\),\s*tokenAuthenticated,/,
+  "PTY upgrade authentication closes the credential-less path whenever the sidecar token is configured",
 );
 // ...and it decides that WITHOUT consulting loopback at all. The positive
 // assertion above would still pass if someone re-introduced a direct-loopback
@@ -145,39 +145,12 @@ assert.match(
   "origin gate accepts a scheme-agnostic same-host Origin (Serve-terminated TLS)",
 );
 assert.match(src, /Bearer /, "server accepts bearer auth for non-cookie clients");
-// Paired devices hold SIGNED tokens (v1.<expiresAt>.<nonce>.<sig> — see
-// src/lib/mobile-access-token.ts), not the raw secret: the QR/deep-link
-// pairing flow mints them and the phone renews them monthly. The WS gate must
-// verify those or every paired terminal 401s while REST works fine.
-assert.match(
+// Signed mobile invites (v1.<expiresAt>.<nonce>.<sig>) are no longer a PTY
+// credential: the secret that signed them is not read here any more.
+assert.doesNotMatch(
   src,
-  /function isValidSignedAccessToken\(value: string, secret: string\): boolean/,
-  "PTY WebSocket auth verifies signed mobile access tokens, not only the raw secret",
-);
-assert.match(
-  src,
-  /if \(timingSafeEqualString\(value, secret\)\) return true;\s*\n\s*return isValidSignedAccessToken\(value, secret\);/,
-  "isExpectedAccessToken accepts the raw secret OR a valid signed token",
-);
-assert.match(
-  src,
-  /parts\.length !== 4 \|\| parts\[0\] !== "v1"/,
-  "signed-token verification pins the v1 wire format",
-);
-assert.match(
-  src,
-  /expiresAt <= Date\.now\(\)/,
-  "signed-token verification rejects expired tokens",
-);
-assert.match(
-  src,
-  /createHmac\("sha256", secret\)[\s\S]{0,120}digest\("base64url"\)/,
-  "signed-token verification recomputes the HMAC-SHA256 base64url signature",
-);
-assert.match(
-  src,
-  /timingSafeEqualString\(parts\[3\], expected\)/,
-  "signed-token signatures compare in constant time",
+  /createHmac/,
+  "no token signature is verified at the PTY boundary any more",
 );
 assert.match(src, /isAllowedUpgradeSource/, "server validates WebSocket upgrade host and origin");
 assert.match(src, /if \(!isLoopbackHost\(host\)\)/, "server classifies loopback WebSocket hosts");
@@ -511,7 +484,7 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
 // actual socket. This protects both the one-large-chunk memory cap and exact
 // cursor slicing used for reconnect replay.
 {
-  const ringBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  const ringBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction timingSafeEqualString)/);
   assert.ok(ringBlock, "scrollback helpers are available for behavioral coverage");
   const { transformSync } = await import("esbuild");
   const transformed = transformSync(
@@ -555,7 +528,7 @@ assert.match(src, /server\.headersTimeout = 80_000/, "headersTimeout exceeds kee
 // source-pattern test cannot: small bursts must become one frame, every frame
 // stays capped, and a slow consumer is detached without killing its PTY.
 {
-  const stateBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction getTokensFromCookie)/);
+  const stateBlock = src.match(/type PtySession[\s\S]+?(?=\nfunction timingSafeEqualString)/);
   const streamingBlock = src.match(/function sendPtyData[\s\S]+?(?=\nfunction sendPtyExit)/);
   assert.ok(stateBlock && streamingBlock, "streaming helpers are available for behavioral coverage");
   const { transformSync } = await import("esbuild");

--- a/src/tailnet-identity.test.ts
+++ b/src/tailnet-identity.test.ts
@@ -4,9 +4,9 @@
 // Tailscale identity instead of a shared pairing secret. Two halves are tested
 // here:
 //
-//   1. Behavior — verifiedTailnetNode / shouldRequireMobileAccessCredential,
-//      exercised with concrete inputs so a refactor that keeps the source text
-//      but breaks the gate is still caught.
+//   1. Behavior — verifiedTailnetNode, exercised with concrete inputs so a
+//      refactor that keeps the source text but breaks the stamp is still
+//      caught.
 //   2. Source pinning of server.ts, which is the ONLY component that can mint
 //      the stamp (it alone sees the raw socket) and which cannot import from
 //      src/ — esbuild emits server.mjs with --bundle=false — so the invariants
@@ -16,7 +16,6 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import {
   verifiedTailnetNode,
-  shouldRequireMobileAccessCredential,
   TAILNET_PEER_HEADER,
 } from "./proxy-helpers.ts";
 
@@ -75,31 +74,6 @@ assert.equal(
   verifiedTailnetNode(`${SECRET}:node:with:colons`, SECRET),
   "node:with:colons",
   "only the first colon separates secret from node id",
-);
-
-// ─── shouldRequireMobileAccessCredential ───────────────────────────────────
-// Forwarded addresses are useful only after bearer authentication; a direct
-// loopback process can forge forwarding headers, so identity alone cannot
-// bypass the shared invite token.
-assert.equal(
-  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false, false, true),
-  true,
-  "a tailnet identity still needs a user-bound credential",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("cave.tailnet.example.ts.net", false, false, false),
-  true,
-  "an unverified tailnet-looking host is still challenged",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("127.0.0.1:3000", false, true, false),
-  true,
-  "socket-verified loopback is not OS-user identity",
-);
-assert.equal(
-  shouldRequireMobileAccessCredential("127.0.0.1:3000", false, false, false),
-  true,
-  "a loopback Host alone still proves nothing (the header is client-controlled)",
 );
 
 // ─── server.ts source pinning ──────────────────────────────────────────────


### PR DESCRIPTION
Removes the `COVEN_CAVE_ACCESS_TOKEN` gate from the request path, at the owner's direction. The 401 **"Access token required"** page is gone, along with everything whose only job was to enforce or satisfy that demand.

Bead: `cave-f4emr`

## What was removed

| File | Removed |
| --- | --- |
| `src/proxy.ts` | `mobileAccessGate`, the HTML access page, the query-token→cookie exchange, and the final `!sidecarAuthenticated && !mobileAccessVerified` → 401 |
| `src/proxy-helpers.ts` | `accessGatePage`, `isHtmlNavigationRequest`, `shouldRequireMobileAccessCredential`, `isTokenlessApiPeerAllowed` |
| `server.ts` | the boot re-arm that reloaded the secret from `~/.local/state/coven-cave/mobile-tailscale-<port>/access-token`, plus the access cookie, its query parameter, and signed-invite verification at the PTY upgrade |

Nothing on the request path now turns a caller away for presenting no credential. The only 401 left is the opt-in passkey-presence requirement.

## `remoteIngress` becomes classification, not authentication

With no credential left for a phone or any other forwarded caller to present, anything `server.ts` did not stamp as a direct loopback peer is treated as remote — **admitted**, but held to the mobile side of every local-vs-remote split: host allowlist, passkey-presence policy, local-only automation, and the `MOBILE_ACCESS_HEADER` marker that makes `isLocalOrigin()` refuse desktop-only routes.

It is gated on the stamp secret *existing* rather than merely on the stamp being absent. Without `server.ts` in front (a bare `next dev`, the E2E harness) nothing stamps anything, and reading that silence as "every request is a phone" would 403 every desktop-only route for a purely local user.

## ⚠️ Two consequences

Both follow directly from removing the only credential a remote client had:

1. **Anything that can reach the port reaches the whole app** — including every tailnet node once Tailscale Serve is published.
2. **In the packaged bundle, a paired phone can no longer open the terminal.** Its access token was what relaxed the PTY host gate, and it can never learn the sidecar token. REST and page loads are unaffected; the terminal tab will 403.

The surviving control for remote access is `COVEN_CAVE_PASSKEY_REQUIRED=1`, which binds remote `/api/*` to a WebAuthn assertion on an allowlisted tailnet device.

## Deliberately not changed

- **The PTY sidecar-token gate.** I first added a direct-loopback exemption so a local non-webview browser could still open a terminal, then reverted it: `cave-ruw4z` removed exactly that escape hatch because TCP loopback proves the *machine*, not the *OS user*, and `server-pty-ws.test.ts` pins its absence. Reversing a separate security invariant as a side effect of this one is out of scope.
- **The mobile pairing/handoff apparatus** (~2k lines plus Settings · Phone, iOS, and `mobile-tailscale.sh`). It sets up Tailscale Serve and device listing, not just tokens. Invites are still minted and signed — they are simply no longer checked. `docs/mobile-tailscale.md` now says that plainly rather than leaving the doc claiming a protection that no longer exists.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` — clean (0 design drift, eslint `--max-warnings=0`)
- `pnpm build:server` — regenerated the checked-in `server.mjs`
- **`test:app`: 1174 of 1176 files pass.** The three that fail were each reproduced on an unmodified `main` checkout and are environmental:
  - `scripts/local-maintenance-gate.test.mjs` — the local gpg agent cannot sign, so its `git commit` fixture dies
  - `scripts/worktree-lifecycle-patrol.test.mjs` — asserts `@opencoven/cli@0.2.5`, machine has `v0.3.1`
  - `src/lib/server/automation-runner.test.ts` — macOS `/var` → `/private/var` symlink resolution

Tests updated rather than deleted: `middleware.test.ts` now pins the *absence* of the gate (no `COVEN_CAVE_ACCESS_TOKEN` read, no `mobileAccessGate`/`accessGatePage`, no `jsonError(401, "unauthorized")`), and `server-pty-ws.test.ts` pins that the access cookie, its query parameter, and signature verification are all gone from the upgrade path.