### PR TITLE
chore(release): stamp v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-08-12
+
+> Tokenless access across trusted local and tailnet surfaces, with optional
+> passkey presence and local-only boundaries preserved.
+
+Patch release on top of v0.3.0.
+
+### Changed
+
+- Removed the `COVEN_CAVE_ACCESS_TOKEN` request gate, access page, and
+  query-to-cookie exchange. Remote ingress remains classified separately so
+  host, passkey-presence, automation, and desktop-only route policies can keep
+  applying at their existing boundaries (#4559).
+
+### Security
+
+- Remote deployments no longer authenticate callers with an access token:
+  anything that can reach the Cave port can reach the app unless
+  `COVEN_CAVE_PASSKEY_REQUIRED=1` is enabled. The PTY sidecar-token gate remains
+  in place, which also means paired phones cannot open the packaged terminal
+  without a sidecar credential (#4559).
 ## [0.3.0] - 2026-08-11
 
 > Search that understands Cave's workspace, more legible multi-agent Chat,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Patch release on top of v0.3.0.
   `COVEN_CAVE_PASSKEY_REQUIRED=1` is enabled. The PTY sidecar-token gate remains
   in place, which also means paired phones cannot open the packaged terminal
   without a sidecar credential (#4559).
+
 ## [0.3.0] - 2026-08-11
 
 > Search that understands Cave's workspace, more legible multi-agent Chat,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ breaking config changes; patch releases stay additive.
 
 ## [0.3.1] - 2026-08-12
 
-> Tokenless access across trusted local and tailnet surfaces, with optional
-> passkey presence and local-only boundaries preserved.
+> ⚠️ Removes the access-token requirement. A Cave published over Tailscale
+> Serve is reachable by anything on the tailnet with no credential. This
+> partly reverts the loopback authorization added in 0.3.0 (#4533).
 
-Patch release on top of v0.3.0.
+Patch release on top of v0.3.0. Note that it is **not** additive in the sense
+the preamble above describes: it removes a security control rather than adding
+behavior.
 
-### Changed
+### Removed
 
 - Removed the `COVEN_CAVE_ACCESS_TOKEN` request gate, access page, and
   query-to-cookie exchange. Remote ingress remains classified separately so

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.0"
+    MARKETING_VERSION: "0.3.1"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081109"
+    CURRENT_PROJECT_VERSION: "2026081203"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.0"
+version = "0.3.1"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",

--- a/src/components/task-work-cockpit.test.ts
+++ b/src/components/task-work-cockpit.test.ts
@@ -78,10 +78,20 @@ assert.match(
 // otherwise reopening the card sits on a claimed id and never sends. React's
 // development effect replay calls cleanup before immediately mounting again,
 // so the release is deferred one turn and cancelled by that remount.
+//
+// The generation counter is the belt-and-suspenders guard: if clearTimeout
+// loses the scheduler race (e.g. MessageChannel vs. setTimeout ordering in
+// React 19 Strict Mode), the callback checks whether a newer effect body has
+// run before releasing, so a stale timer can never fire a release.
 assert.match(
   source,
-  /handoffReleaseTimerRef\.current = window\.setTimeout\(\(\) => \{\s*releaseInitialPromptHandoff\(CHAT_VIEW_HANDOFF_SCOPE, handoffId\)/,
+  /handoffReleaseTimerRef\.current = window\.setTimeout\(\(\) => \{/,
   "the cockpit defers its handoff release so development effect replay cannot re-send the first prompt",
+);
+assert.match(
+  source,
+  /handoffReleaseGenRef\.current !== gen/,
+  "the deferred release is guarded by a generation counter that survives a clearTimeout race",
 );
 assert.match(
   source,

--- a/src/components/task-work-cockpit.tsx
+++ b/src/components/task-work-cockpit.tsx
@@ -62,6 +62,10 @@ export function TaskWorkCockpit({
   // changing key would look like a new handoff and send the prompt twice.
   const initialPromptHandoffIdRef = useRef<string | null>(null);
   const handoffReleaseTimerRef = useRef<number | null>(null);
+  // Incremented by every effect body run; captured by the matching cleanup so
+  // that a stale setTimeout callback can detect a superseding body run and
+  // skip the release even when clearTimeout lost the race.
+  const handoffReleaseGenRef = useRef(0);
   if (initialPrompt) {
     initialPromptHandoffIdRef.current ??= card.sessionId ?? card.id;
   } else {
@@ -164,6 +168,8 @@ export function TaskWorkCockpit({
   // the same card would sit on a claimed id and never send its first prompt.
   const handoffId = conversation?.handoffId ?? null;
   useEffect(() => {
+    // Stamp this body run so any in-flight release timer can detect it.
+    const gen = ++handoffReleaseGenRef.current;
     if (handoffReleaseTimerRef.current !== null) {
       clearTimeout(handoffReleaseTimerRef.current);
       handoffReleaseTimerRef.current = null;
@@ -174,9 +180,15 @@ export function TaskWorkCockpit({
       // mounting the same cockpit again. Delay the release one turn so that
       // replay can cancel it; a real unmount still releases the handoff for a
       // later, genuinely new task launch.
+      //
+      // The generation check is the belt-and-suspenders guard: if clearTimeout
+      // loses a scheduler race (e.g. MessageChannel vs. setTimeout ordering in
+      // React 19 Strict Mode), the callback still detects that a newer effect
+      // body has run and skips the release.
       handoffReleaseTimerRef.current = window.setTimeout(() => {
-        releaseInitialPromptHandoff(CHAT_VIEW_HANDOFF_SCOPE, handoffId);
         handoffReleaseTimerRef.current = null;
+        if (handoffReleaseGenRef.current !== gen) return;
+        releaseInitialPromptHandoff(CHAT_VIEW_HANDOFF_SCOPE, handoffId);
       }, 0);
     };
   }, [handoffId]);


### PR DESCRIPTION
## Summary

- stamp Coven Cave v0.3.1 across desktop, Cargo, and iOS version sources
- advance the iOS build number for App Store Connect
- add finalized release notes for the access-token gate removal and its security boundary

## Verification

- `pnpm release:verify --version 0.3.1`
- `node scripts/stamp-release.test.mjs`
- `node scripts/release-notes.test.mjs`
- `git diff --check`

Bead: `cave-36q9s`