### PR TITLE
fix: fetch remote-tracking refs before the scheduled sweep

### DIFF
--- a/scripts/worktree-sweep.sh
+++ b/scripts/worktree-sweep.sh
@@ -106,6 +106,40 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
   exit 1
 fi
 
+# Refresh remote-tracking refs BEFORE the lifecycle tool builds its inventory.
+#
+# The inventory compares refs/remotes/origin/main against the authoritative ref
+# on the remote, and a mismatch is a probe error stamped on EVERY unit, which
+# pushes all of them out of the retirable lanes. So one stale tracking ref
+# degrades the whole sweep to a no-op — and to a no-op that reads as healthy,
+# because "no change (39 -> 39)" looks exactly like a sweep with nothing to do.
+#
+# This was not an occasional race. The wrapper never fetched, so it read
+# whatever tracking refs the checkout happened to hold, and on a repository
+# this busy those go stale within minutes of any human `git pull <refspec>` —
+# which moves refs/heads/main without necessarily syncing the tracking ref.
+# Four consecutive scheduled runs on 2026-08-11 retired nothing with units
+# sitting past their cooldowns, and a single `git fetch --prune origin` fixed
+# it immediately.
+#
+# Deliberately a fetch and NOT a fast-forward of local main: other sessions
+# share this checkout, and moving their branch under them is not the scheduled
+# job's business. Only the tracking ref has to be current.
+#
+# Tags come along on purpose — `--prune` drops stale remote-tracking branches,
+# but retention proof reads pushed archive tags, so this must not use
+# --no-tags or --prune-tags.
+echo "[sweep] fetching remote-tracking refs from origin"
+fetch_failed=""
+if ! git fetch --prune --quiet origin; then
+  fetch_failed=1
+  echo "[sweep] WARNING: git fetch failed. The inventory will compare a stale"
+  echo "[sweep] tracking ref against the remote and is likely to stamp a probe"
+  echo "[sweep] error on every unit, retiring nothing. Treat any 'no change'"
+  echo "[sweep] below as unproven rather than as a clean sweep."
+fi
+echo "[sweep] main: local $(git rev-parse --short refs/heads/main 2>/dev/null), tracking $(git rev-parse --short refs/remotes/origin/main 2>/dev/null)"
+
 before=$(git worktree list | wc -l | tr -d ' ')
 echo "[sweep] repo: $REPO"
 echo "[sweep] repo HEAD: $(git rev-parse --short HEAD 2>/dev/null) on $(git rev-parse --abbrev-ref HEAD 2>/dev/null)"
@@ -130,6 +164,14 @@ if [[ "$status" -ne 0 ]]; then
 elif [[ "$after" -lt "$before" ]]; then
   notify "Worktree sweep: $(( before - after )) retired" \
     "$before -> $after worktrees. Log: $LOG"
+elif [[ -n "$fetch_failed" ]]; then
+  # A no-op after a failed fetch is the exact state this wrapper used to report
+  # as healthy: the tool exits 0 having refused every unit over a tracking ref
+  # nothing refreshed. Say so, because silence here is indistinguishable from a
+  # sweep that genuinely had nothing to do.
+  echo "[sweep] no change ($before -> $after) but the fetch failed; result is unproven"
+  notify "Worktree sweep: result unproven" \
+    "git fetch failed, so nothing was retired on possibly stale refs. Log: $LOG"
 else
   echo "[sweep] no change ($before -> $after); no notification sent"
 fi


### PR DESCRIPTION
Fixes `cave-ra0hk`.

## The defect

`scripts/worktree-sweep.sh` never ran `git fetch`. It read whatever
remote-tracking refs the checkout happened to hold.

The lifecycle inventory compares `refs/remotes/origin/main` against the
authoritative ref on the remote. A mismatch is a probe error; a probe error is
stamped on **every** unit; and that pushes all of them out of the retirable
lanes. So a single stale ref degrades the entire sweep to a no-op.

The no-op then reads as healthy — `no change (39 -> 39)` is exactly what a
sweep with nothing to do prints. Four consecutive scheduled runs on 2026-08-11
(03:30, 05:45, 06:20, 06:55) retired nothing while units sat past their
cooldowns, each unit carrying:

```
default branch inventory tracking ref refs/remotes/origin/main is stale or
mismatched with authoritative refs/heads/main
```

measured at the time as a three-way split:

```
local  refs/heads/main           19e6ec72
track  refs/remotes/origin/main  23bf5dcf
remote main (authoritative)      fd5a52bb
```

This is systemic, not a rare race. On a repository this busy the tracking ref
goes stale within minutes of any human `git pull <refspec>`, which moves
`refs/heads/main` without necessarily syncing it. The recorded log holds **117**
stale-ref warnings across **14** runs.

## The change

Fetch before invoking the lifecycle tool. It is a read-only network operation
and it is the one thing that makes the inventory's default-branch comparison
mean anything.

Two deliberate non-changes, both because the alternative would reach past this
job's business:

- **No fast-forward of local `main`.** Other sessions share this checkout;
  moving their branch under them is not the scheduled job's job. Only the
  tracking ref has to be current.
- **Tags are left alone** — no `--no-tags`, no `--prune-tags`. Retention proof
  reads pushed archive tags, and `--prune-tags` would delete local-only ones.

A failed fetch no longer disappears either. It logs what the consequence will
be, and a run that retires nothing *after* a failed fetch notifies as "result
unproven" rather than staying quiet — that being precisely the state this
wrapper used to report as a clean sweep. A successful fetch with nothing to
retire stays silent, so the existing "a correct no-op should not banner you"
policy is unchanged.

## Verification

`bash -n` clean. (`shellcheck` is not installed on this machine.)

**1. The fetch repairs the exact failure state.** Scratch repo, tracking ref
aged one commit behind the remote:

```
=== STALE: the state four scheduled sweeps ran in ===
  local    15bab04
  tracking 789ff4d     <- behind
  remote   15bab04
=== the wrapper's fetch ===  fetch ok
=== AFTER ===
  local    15bab04
  tracking 15bab04     <- repaired
  remote   15bab04
RESULT: tracking ref now matches the remote — PASS
```

Local `main` is untouched across the fetch, as intended.

**2. Both new branches of the wrapper, driven end-to-end** against a scratch
repo with a stubbed `pnpm`/`osascript`:

- *fetch succeeds, nothing retired* → `no change (1 -> 1); no notification sent`, **0 notifications**
- *fetch fails, nothing retired* → the warning block, `no change (1 -> 1) but the fetch failed; result is unproven`, and **1 notification**: `Worktree sweep: result unproven`

## Follow-up left alone

The bead also raises reporting this as a single global error rather than
stamping it per unit — one stale ref is currently indistinguishable, per unit,
from 39 genuinely uncertain ones. The inventory already has a `globalErrors`
bucket for exactly this shape of problem, so it looks tractable, but it changes
patrol classification and belongs in its own change rather than riding along
with the wrapper fix.

## Note

This commit is unsigned; the ssh-agent on this machine holds no identities, so
`-S` fails with `Couldn't find key in agent?`. Signatures are not required on
`main`.