### PR TITLE
fix: a Bead that mentions a worktree no longer blocks its retirement

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -2413,12 +2413,47 @@ function remoteDefaultBranch(root: string): RemoteDefaultBranch {
   };
 }
 
+/**
+ * Split the non-closed beads touching a unit into the ones that OWN it and the
+ * ones that merely MENTION it.
+ *
+ * Only ownership blocks retirement. The distinction matters because the two
+ * signals have opposite reliability:
+ *
+ *   - `owns` — a structured lifecycle record naming this branch or path, or a
+ *     bead id embedded in the branch name. Both are claims of ownership; the
+ *     record is written by the creation script and the branch name is chosen by
+ *     the owner.
+ *   - `mentions` — the bead's free TEXT happens to contain the branch string or
+ *     the head OID. That is not a claim of anything. It is what writing a bug
+ *     report, a post-mortem, or a handoff note looks like.
+ *
+ * Treating a mention as open work made the failure self-perpetuating and
+ * inverted: the better you documented a retirement problem, the less retirable
+ * the unit became, and a bead explaining why worktrees cannot be retired was
+ * itself a reason a worktree could not be retired. Demonstrated in two
+ * consecutive apply runs on 2026-08-10 — a unit classified `cleanup-ready`,
+ * then `active, non-closed Beads: <the bug report filed about it>` once that
+ * report quoted its branch name and head OID as evidence. It punished exactly
+ * the behaviour this repository asks for everywhere else.
+ *
+ * Measured over the live checkout before this change: of 42 units, 9 picked up
+ * blockers from the free-text clauses and 6 had no other blocker at all. One
+ * cross-session coordination report blocked three units purely by naming the
+ * branches it existed to compare. Of those 6, four had their structured record
+ * on a CLOSED bead — the owner was done and only someone else's prose still
+ * held them — and the remaining two carry no record at all, so the metadata
+ * gate holds them regardless of what this function returns.
+ *
+ * Mentions are still reported, because "who is talking about this unit" is
+ * genuinely useful; they are just no longer mistaken for a claim on it.
+ */
 function matchingTasks(
   branch: string | null,
   worktreePath: string | null,
   head: string,
   tasks: BeadTask[],
-): string[] {
+): { owns: string[]; mentions: string[] } {
   const matchedBranch =
     branch !== null && !PROTECTED_BRANCHES.has(branch) ? branch : null;
   const branchBeadIds = new Set(matchedBranch ? beadIdsInText(matchedBranch) : []);
@@ -2426,24 +2461,30 @@ function matchingTasks(
     worktreePath === null ? null : normalizeAbsoluteWorktreePath(worktreePath);
 
   const exactOid = new RegExp(`(?:^|[^0-9a-f])${head}(?:$|[^0-9a-f])`, "i");
-  return tasks
-    .filter((task) => task.status !== "closed")
-    .filter(
-      (task) =>
-        task.structured.some(
-          (record) =>
-            (matchedBranch !== null && record.branch === matchedBranch) ||
-            (normalizedWorktreePath !== null &&
-              normalizeAbsoluteWorktreePath(record.path) === normalizedWorktreePath),
-        ) ||
-        branchBeadIds.has(task.id.toLowerCase()) ||
-        exactOid.test(task.text) ||
-        (matchedBranch !== null && task.text.includes(matchedBranch)) ||
-        (matchedBranch !== null &&
-          worktreePath !== null &&
-          task.text.includes(worktreePath)),
-    )
-    .map((task) => task.id);
+  const owns: string[] = [];
+  const mentions: string[] = [];
+  for (const task of tasks) {
+    if (task.status === "closed") continue;
+    const ownsUnit =
+      task.structured.some(
+        (record) =>
+          (matchedBranch !== null && record.branch === matchedBranch) ||
+          (normalizedWorktreePath !== null &&
+            normalizeAbsoluteWorktreePath(record.path) === normalizedWorktreePath),
+      ) || branchBeadIds.has(task.id.toLowerCase());
+    if (ownsUnit) {
+      owns.push(task.id);
+      continue;
+    }
+    const mentionsUnit =
+      exactOid.test(task.text) ||
+      (matchedBranch !== null && task.text.includes(matchedBranch)) ||
+      (matchedBranch !== null &&
+        worktreePath !== null &&
+        task.text.includes(worktreePath));
+    if (mentionsUnit) mentions.push(task.id);
+  }
+  return { owns, mentions };
 }
 
 /**
@@ -3150,6 +3191,7 @@ function collectInventory(
       ),
     ];
 
+    const unitTasks = matchingTasks(unit.branch, unit.path, unit.head, tasks.tasks);
 
     return {
       kind: unit.kind,
@@ -3177,7 +3219,8 @@ function collectInventory(
             .map((claim) => claim.agent_id),
         ),
       ],
-      taskIds: matchingTasks(unit.branch, unit.path, unit.head, tasks.tasks),
+      taskIds: unitTasks.owns,
+      mentionTaskIds: unitTasks.mentions,
       openPrs,
       mergedPr: exactMerged
         ? {

--- a/scripts/worktree-lifecycle-patrol.test.mjs
+++ b/scripts/worktree-lifecycle-patrol.test.mjs
@@ -1564,6 +1564,25 @@ process.exit(2);
       },
     ]),
   );
+  // The scenario cave-p6wkk demonstrated on 2026-08-10: a bug report is filed
+  // about a unit, quotes its branch name as evidence, and the unit flips from
+  // cleanup-ready to active on the next run — so the better the documentation,
+  // the less retirable the unit.
+  writeFileSync(
+    path.join(fixtureRoot, "tasks-branch-mention.json"),
+    JSON.stringify([
+      branchOnlyMetadataTask,
+      {
+        id: "cave-branch-mention",
+        status: "open",
+        title: "Post-mortem: retirement stalled",
+        description:
+          "The unit on feat/branch-only sat past its cooldown. Quoting the branch here as evidence.",
+        notes: "",
+        external_ref: null,
+      },
+    ]),
+  );
   writeFileSync(
     path.join(fixtureRoot, "tasks-nul-metadata-path.json"),
     JSON.stringify([
@@ -2421,6 +2440,8 @@ if [ "\${LIFECYCLE_OID_ONLY_TASK:-0}" = "1" ]; then
   cat ${JSON.stringify(path.join(fixtureRoot, "tasks-oid-only.json"))}
 elif [ "\${LIFECYCLE_SHORT_OID_TASK:-0}" = "1" ]; then
   cat ${JSON.stringify(path.join(fixtureRoot, "tasks-short-oid.json"))}
+elif [ "\${LIFECYCLE_BRANCH_MENTION_TASK:-0}" = "1" ]; then
+  cat ${JSON.stringify(path.join(fixtureRoot, "tasks-branch-mention.json"))}
 elif [ "\${LIFECYCLE_NUL_METADATA_PATH:-0}" = "1" ]; then
   cat ${JSON.stringify(path.join(fixtureRoot, "tasks-nul-metadata-path.json"))}
 elif [ "\${LIFECYCLE_NUL_EXCEPTION_PATH:-0}" = "1" ]; then
@@ -3216,15 +3237,41 @@ exit 0
   }
 
 
-  verifySafetyRegression("exact OID Bead ownership", () => {
+  verifySafetyRegression("exact OID in Bead text is a mention, not ownership", () => {
+    // The fixture bead is titled "Investigate captured commit" and carries the
+    // head OID in external_ref. That is a bead ABOUT the unit, not a claim on
+    // it, and treating it as open work is what made documenting a unit enough
+    // to make the unit unretirable. It is now reported and does not block.
     const oidOwnerReport = JSON.parse(
       patrol(["--json"], { LIFECYCLE_OID_ONLY_TASK: "1" }),
     );
     const oidOwnedBranch = oidOwnerReport.items.find(
       (item) => item.branch === "feat/branch-only",
     );
-    assert.equal(oidOwnedBranch.lane, "active");
-    assert.deepEqual(oidOwnedBranch.taskIds, ["cave-oid-owner"]);
+    assert.equal(oidOwnedBranch.lane, "retire-after-gate");
+    assert.deepEqual(oidOwnedBranch.taskIds, []);
+    assert.deepEqual(oidOwnedBranch.mentionTaskIds, ["cave-oid-owner"]);
+    assert.doesNotMatch(
+      oidOwnedBranch.reasons.join("\n"),
+      /cave-oid-owner/,
+      "a mention must not appear among the reasons that hold a unit active",
+    );
+  });
+
+  verifySafetyRegression("quoting a branch name does not make the unit active", () => {
+    const mentionReport = JSON.parse(
+      patrol(["--json"], { LIFECYCLE_BRANCH_MENTION_TASK: "1" }),
+    );
+    const mentionedBranch = mentionReport.items.find(
+      (item) => item.branch === "feat/branch-only",
+    );
+    assert.equal(
+      mentionedBranch.lane,
+      "retire-after-gate",
+      "filing a post-mortem about a unit must not reclassify it as in-flight work",
+    );
+    assert.deepEqual(mentionedBranch.taskIds, []);
+    assert.deepEqual(mentionedBranch.mentionTaskIds, ["cave-branch-mention"]);
   });
 
   verifySafetyRegression("abbreviated OID is not Bead ownership", () => {
@@ -3236,6 +3283,11 @@ exit 0
     );
     assert.equal(shortOidBranch.lane, "retire-after-gate");
     assert.deepEqual(shortOidBranch.taskIds, []);
+    assert.deepEqual(
+      shortOidBranch.mentionTaskIds,
+      [],
+      "an abbreviated OID is not even a mention — the match must stay exact",
+    );
   });
 
   verifySafetyRegression("duplicate registered local branch ref", () => {

--- a/scripts/worktree-lifecycle-retirement.test.mjs
+++ b/scripts/worktree-lifecycle-retirement.test.mjs
@@ -75,6 +75,7 @@ function makeItem(overrides = {}) {
     processOwners: [],
     claimOwners: [],
     taskIds: [],
+    mentionTaskIds: [],
     openPrs: [],
     mergedPr: null,
     activeWorkflowUrls: [],

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -133,6 +133,7 @@ function observation(overrides = {}) {
     processOwners: [],
     claimOwners: [],
     taskIds: [],
+    mentionTaskIds: [],
     openPrs: [],
     mergedPr: null,
     activeWorkflowUrls: [],

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -654,7 +654,7 @@ function normalizeWorktreeObservation(
       processOwners: observation.processOwners,
       claimOwners: observation.claimOwners,
       taskIds: observation.taskIds,
-      mentionTaskIds: observation.mentionTaskIds,
+      mentionTaskIds: observation.mentionTaskIds ?? [],
       openPrs: observation.openPrs,
       mergedPr: observation.mergedPr,
       activeWorkflowUrls: observation.activeWorkflowUrls,

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -67,7 +67,19 @@ export type WorktreeLifecycleObservation = {
   indexFlags: string[];
   processOwners: WorktreeProcessOwner[];
   claimOwners: string[];
+  /**
+   * Non-closed beads that OWN this unit — a structured lifecycle record naming
+   * its branch or path, or a bead id embedded in the branch name. These block
+   * retirement.
+   */
   taskIds: string[];
+  /**
+   * Non-closed beads whose free text merely NAMES this unit's branch or head
+   * OID. Reported so the reader can see who is discussing the unit, never
+   * treated as a claim on it — see matchingTasks in
+   * scripts/worktree-lifecycle-inventory.ts for why a mention is not ownership.
+   */
+  mentionTaskIds: string[];
   openPrs: WorktreePrRef[];
   mergedPr: WorktreeMergedPrRef | null;
   activeWorkflowUrls: string[];
@@ -110,6 +122,7 @@ type LegacyWorktreeObservation = Pick<
   | "processOwners"
   | "claimOwners"
   | "taskIds"
+  | "mentionTaskIds"
   | "openPrs"
   | "mergedPr"
   | "activeWorkflowUrls"
@@ -313,7 +326,12 @@ function activeReasons(observation: WorktreeLifecycleObservation): string[] {
     reasons.push(`active claim: ${observation.claimOwners.join(", ")}`);
   }
   if (observation.taskIds.length > 0) {
-    reasons.push(`non-closed Beads: ${observation.taskIds.join(", ")}`);
+    // Say what the relationship IS. "non-closed Beads: <id>" could not
+    // distinguish "this bead owns the unit" from "this bead mentions it", so a
+    // false blocker read exactly like genuine in-flight work and the next
+    // operator correctly preserved the unit. Mentions are deliberately absent
+    // from this list: they are rendered separately and block nothing.
+    reasons.push(`non-closed Beads (owns): ${observation.taskIds.join(", ")}`);
   }
   if (observation.openPrs.length > 0) {
     reasons.push(`open PR ${observation.openPrs.map((pr) => `#${pr.number}`).join(", ")}`);
@@ -636,6 +654,7 @@ function normalizeWorktreeObservation(
       processOwners: observation.processOwners,
       claimOwners: observation.claimOwners,
       taskIds: observation.taskIds,
+      mentionTaskIds: observation.mentionTaskIds,
       openPrs: observation.openPrs,
       mergedPr: observation.mergedPr,
       activeWorkflowUrls: observation.activeWorkflowUrls,
@@ -829,6 +848,11 @@ export function renderWorktreeLifecycleReport(
       const kind = item.kind === "branch-only" ? " [branch-only]" : "";
       lines.push(`- ${labelFor(item)}${kind}${location}`);
       for (const reason of item.reasons) lines.push(`  ${humanReason(item, reason)}`);
+      // Informational, never a lane input: these beads name the unit without
+      // claiming it. Printed so the reader can still find the conversation.
+      if (item.mentionTaskIds.length > 0) {
+        lines.push(`  mentions (not blocking): ${item.mentionTaskIds.join(", ")}`);
+      }
       for (const change of item.changes) lines.push(`  change: ${change}`);
       for (const ignoredPath of item.nonDisposableIgnoredPaths) {
         lines.push(`  non-disposable ignored: ${ignoredPath}`);


### PR DESCRIPTION
Fixes `cave-p6wkk`.

## The defect

`matchingTasks` treated any non-closed bead as open work for a unit when the
bead's free **text** merely contained the unit's branch name or head OID. Three
of its clauses were structured and precise; two were plain substring tests.

So writing a bug report, a post-mortem, or a handoff note that quoted a real
identifier silently reclassified that worktree from `cleanup-ready` to
`active`. Demonstrated in two consecutive apply runs on 2026-08-10 — a unit
classified `cleanup-ready`, then `active, non-closed Beads: <the bug report
filed about it>` once that report quoted its branch name and head OID.

The failure is self-perpetuating and inverted: **the better you document a
retirement problem, the less retirable the unit becomes**, and a bead
explaining why worktrees cannot be retired is itself a reason a worktree
cannot be retired. It punishes exactly the behaviour this repository asks for
everywhere else — recording evidence, quoting real identifiers, leaving a
trail. And it is invisible at the point of harm: nothing warns at filing time,
and `active, non-closed Beads: <id>` is indistinguishable from genuine
in-flight work, so the next operator correctly preserves the unit.

## The change

Split the match into **ownership** and **mention**:

| signal | meaning | blocks? |
|---|---|---|
| structured lifecycle record naming the branch or path | a claim, written by the creation script | yes |
| bead id embedded in the branch name | a claim, chosen by the owner | yes |
| branch string or exact head OID appearing in free text | not a claim of anything | **no** |

Mentions are still reported — who is discussing a unit is genuinely useful —
they are simply no longer mistaken for a claim on it.

The patrol can also now say *why* a bead is attached, which the bead asked for
and which `non-closed Beads: <id>` could not express:

```
active
- feat/example @ …
  non-closed Beads (owns): cave-qshvl
  mentions (not blocking): cave-ykj47, cave-1859b
```

## Confirming the fallback against history first

The bead explicitly asked for this rather than a quick patch, since the loose
clauses looked like a fallback for units whose structured record is missing. I
replicated the matcher clause-by-clause over the live checkout (42 units, 201
non-closed beads):

- **9** units picked up blockers from the free-text clauses
- **6** had no other blocker at all
- `cave-1859b` — a cross-session coordination report whose whole job is to name
  the branches that are diverging — blocked **three** units purely by naming
  them

Of those 6: **four** have their structured record on a **closed** bead (the
owner is done; only someone else's prose still held them), and the remaining
**two** carry no record at all, so `allowLegacyMissingMetadata: false` holds
them as `uncertain` regardless of what this function returns. The fallback was
not load-bearing.

## Verification

- `tsc --noEmit` clean; eslint clean on the covered files.
- `worktree-lifecycle.test.ts`, `worktree-lifecycle-retirement.test.mjs`: pass.
- `worktree-lifecycle-patrol.test.mjs`: **ok**, 1 pass / 0 fail (full ~7.5 min run).

Test changes worth reviewing closely — one existing safety regression encoded
the old behaviour:

- `exact OID Bead ownership` asserted `lane: active` for a fixture bead titled
  *"Investigate captured commit"* carrying the head OID in `external_ref`. That
  is a bead **about** the unit. It is now
  `exact OID in Bead text is a mention, not ownership`, asserting
  `lane: retire-after-gate`, empty `taskIds`, the id in `mentionTaskIds`, and
  that the id appears in no reason string.
- New fixture + test `quoting a branch name does not make the unit active`,
  reproducing the exact 2026-08-10 scenario: a post-mortem quoting a branch
  name must not reclassify that unit.
- `abbreviated OID is not Bead ownership` gained an assertion that a short OID
  is not even a *mention* — the match stays exact.

**End-to-end on the real checkout** (`pnpm beads:worktrees`, read-only):

- `chore/cave-58eoq-8-path-aware-ci` now reports **cleanup-ready** with
  `mentions (not blocking): cave-58eoq.8.1` — previously held `active` by that
  mention alone.
- `test/cave-58eoq-4-daemon-fault-injection` stays **uncertain**
  (*"structured lifecycle metadata backfill required"*) with its mention noted
  — confirming the metadata gate, not the free-text clause, is what holds a
  record-less unit.

## Note

Commit is unsigned; the ssh-agent on this machine holds no identities. Same
reason `git rebase` needed `commit.gpgsign=false` to continue. Signatures are
not required on `main`.