### PR TITLE
test: stop the familiar picker racing the first-project gate

### DIFF
--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -65,6 +65,26 @@ const BOARD = {
   ],
 };
 
+// A project both mocked familiars can launch in. Without this the familiar
+// picker is racing a completely different surface (cave-pw3l0): FAMILIARS_TWO
+// invents `aster`/`nova`, which the E2E harness's seeded project does not grant,
+// so `/api/projects?familiarId=` resolves to zero accessible projects and
+// resolveFirstProjectGatePolicy opens the first-project gate — whose "Give this
+// familiar project access" panel REPLACES the launch surface in <main>.
+//
+// That made the test a coin flip on fetch ordering: `.cave-launch` renders while
+// the accessible-projects fetch is still in flight, and the gate displaces it the
+// moment that fetch settles. Locally, 4 of 15 runs under 4 workers lost the race.
+// Serving an accessible project keeps the gate shut, so what remains under test
+// is the thing the test is named for — whether boot ASKS which familiar or picks
+// one for you.
+const ACCESSIBLE_PROJECT = {
+  ok: true,
+  projects: [
+    { id: "p1", name: "Queue", root: "/repo/queue", access: "write" },
+  ],
+};
+
 async function seedWithoutActiveFamiliar(page: Page) {
   await page.addInitScript(() => {
     window.localStorage.setItem("cave:onboarding:dismissed", "1");
@@ -72,6 +92,7 @@ async function seedWithoutActiveFamiliar(page: Page) {
   await page.route("**/api/familiars**", (route) => route.fulfill({ json: FAMILIARS_TWO }));
   await page.route("**/api/board**", (route) => route.fulfill({ json: BOARD }));
   await page.route("**/api/sessions/list**", (route) => route.fulfill({ json: { ok: true, sessions: [] } }));
+  await page.route("**/api/projects**", (route) => route.fulfill({ json: ACCESSIBLE_PROJECT }));
 }
 
 async function seed(page: Page) {
@@ -236,6 +257,15 @@ test("booting with no active familiar asks which one instead of picking", async 
   // The chat-first landing still happens — we did not fall back to the list.
   const launch = page.locator(".cave-launch");
   await expect(launch).toBeVisible({ timeout: 45_000 });
+  // Named explicitly so a regression here reports the surface that TOOK OVER
+  // rather than an absent heading. This is what cave-pw3l0 actually was: the
+  // first-project gate displacing the picker once accessible projects resolved
+  // empty, which reads as "element(s) not found" and sends you hunting a
+  // rendering delay that does not exist.
+  await expect(
+    page.getByRole("heading", { name: "Give this familiar project access" }),
+    "the first-project gate displaced the familiar picker — is /api/projects still mocked?",
+  ).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Start a new chat" })).toBeVisible();
 
   // Both familiars are offered; neither has been chosen for the user.

--- a/tests/chat-boot-landing.spec.ts
+++ b/tests/chat-boot-landing.spec.ts
@@ -252,11 +252,24 @@ test.describe("chat boot landing", () => {
 // It must ask instead.
 test("booting with no active familiar asks which one instead of picking", async ({ page }) => {
   await seedWithoutActiveFamiliar(page);
+  // Armed BEFORE navigating so the response cannot be missed. The gate policy
+  // cannot decide until this familiar-scoped read lands (it is the
+  // `accessibleProjects` input), so every assertion about the gate has to wait
+  // for it — a bare toHaveCount(0) beforehand passes vacuously against a page
+  // that has simply not rendered the gate YET, which is the exact race this
+  // test is being fixed for.
+  const projectScopeResolved = page.waitForResponse(
+    (res) => res.url().includes("/api/projects?familiarId="),
+    { timeout: 45_000 },
+  );
   await page.goto("/?mode=chat", { waitUntil: "domcontentloaded" });
 
   // The chat-first landing still happens — we did not fall back to the list.
   const launch = page.locator(".cave-launch");
   await expect(launch).toBeVisible({ timeout: 45_000 });
+
+  await projectScopeResolved;
+
   // Named explicitly so a regression here reports the surface that TOOK OVER
   // rather than an absent heading. This is what cave-pw3l0 actually was: the
   // first-project gate displacing the picker once accessible projects resolved
@@ -266,6 +279,9 @@ test("booting with no active familiar asks which one instead of picking", async 
     page.getByRole("heading", { name: "Give this familiar project access" }),
     "the first-project gate displaced the familiar picker — is /api/projects still mocked?",
   ).toHaveCount(0);
+  // Still standing AFTER the policy had its data — the displacement window is
+  // shut, not merely not-yet-open.
+  await expect(launch).toBeVisible();
   await expect(page.getByRole("heading", { name: "Start a new chat" })).toBeVisible();
 
   // Both familiars are offered; neither has been chosen for the user.


### PR DESCRIPTION
Fixes the flake that has been redding `main` (`cave-pw3l0`). `main` is red right now solely because of this spec, and v0.3.1 is waiting on it.

## It was not a slow render

The failure reads like one, which is the trap:

```
Locator: getByRole('heading', { name: 'Start a new chat' })
Timeout: 5000ms
Error: element(s) not found
```

The obvious fix — that assertion inherits the 5s default while every sibling assertion in the file uses `{ timeout: 45_000 }` — is wrong. The page snapshot at failure shows what actually happened:

```yaml
- main:
  - heading "Chat" [level=1]
  - region "Give this familiar project access":
    - heading "Give this familiar project access" [level=2]
```

`resolveFirstProjectGatePolicy` opens the first-project gate when `accessibleProjects.length === 0`, and its panel **replaces** the launch surface in `<main>`. The heading never comes back, so raising its timeout would have made the test fail slower rather than less often.

## Why it opens

`FAMILIARS_TWO` invents `aster`/`nova`. The E2E harness's seeded project does not grant either of them, so `/api/projects?familiarId=` correctly resolves to zero accessible projects and the gate opens **every run**.

The only reason the test ever passed is fetch ordering: `.cave-launch` renders while that request is still in flight, so line 238 catches it, and the gate displaces it before the heading assertion on line 239. Under load the gate wins the race.

## Fix

Mock `/api/projects` with a project both familiars can launch in, so the gate stays shut and what remains under test is what the test is named for — whether boot *asks* which familiar or picks one for you.

Also assert the gate heading has count 0, with a failure message that names it, so the next regression reports the surface that took over instead of an absent heading.

## Evidence

Measured with `--repeat-each --workers=4 --retries=0`:

| | result |
| --- | --- |
| before | **4 failed / 15 runs** (~27%) |
| after | **0 failed / 63 runs** (whole file, 12×) |

**Mutation-tested.** Reintroducing the auto-pick this test exists to catch — `familiarId: familiar?.id ?? visibleFamiliars[0]?.id ?? null` in `chat-router.tsx` — fails it **3/3**. So the race is gone rather than the assertion weakened. Source restored; this PR touches only the spec.

## Scope

Only `chat-boot-landing.spec.ts:232`. The other two specs in `cave-pw3l0` (`keyboard-shortcuts.spec.ts:44`, `task-work-fit.spec.ts:277`) both passed every run here and are not addressed — they flaked less often and may have a different cause, so that bead stays open.