### PR TITLE
fix: state a repository-wide probe failure once, not once per unit

### DIFF
--- a/scripts/worktree-lifecycle-inventory.ts
+++ b/scripts/worktree-lifecycle-inventory.ts
@@ -3088,7 +3088,17 @@ function collectInventory(
     ...initialHistoryOverrides.errors,
     initialGrafts.error,
     originIdentity.error,
-
+    // remoteDefaultBranch(root) reads only the checkout root, so its failure is
+    // repository-wide by construction, exactly like originIdentity.error above.
+    // It reached every unit anyway — via ancestry.error, which falls back to it
+    // whenever defaultBranch.oid is null — but it never reached this bucket, so
+    // `globalErrors` in the inventory output did not mention it at all. A
+    // consumer then saw N identical per-unit probe errors with no global signal
+    // and could not tell that ONE checkout-level fact had disqualified
+    // everything. Listing it here changes no unit's classification: the
+    // identical string is already stamped per unit, and both this list and
+    // probeErrors dedup through a Set.
+    defaultBranch.error,
     ...prs.globalErrors,
     workflows.error,
     claims.error,

--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -229,7 +229,7 @@ function errorMessage(error: unknown): string {
 }
 
 function summarizeInventory(inventory: PatrolInventory): PatrolSummary {
-  return summarizeWorktreeLifecycle(inventory.items, inventory.budgets);
+  return summarizeWorktreeLifecycle(inventory.items, inventory.budgets, inventory.globalErrors);
 }
 
 /**

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -938,10 +938,35 @@ function legacyObservation(overrides = {}) {
     "the repository-wide failure is printed exactly once, not once per unit",
   );
   assert.match(text, /Repository-wide probe failures \(1\)/);
+  assert.doesNotMatch(
+    text,
+    /every unit below/,
+    "the heading must not claim every unit: a protected unit never reads probe errors at all",
+  );
   assert.match(
     text,
     /1 repository-wide probe failure \(listed above\)/,
     "a unit left with no reason of its own still says why it is held",
+  );
+  // The pointer is a fallback for an otherwise-empty unit, not a per-unit echo
+  // of the heading. The active unit here keeps its own "active claim" reason,
+  // so adding a pointer to it would reintroduce the per-unit repetition this
+  // change removes.
+  assert.equal(
+    text.split("repository-wide probe failure (listed above)").length - 1,
+    1,
+    "only the unit with nothing else to say gets the pointer",
+  );
+  // Just this unit's block — up to the blank line before the next lane, or the
+  // slice runs on into other units and asserts about the wrong one.
+  const activeStart = text.indexOf("- feat/b");
+  const activeEnd = text.indexOf("\n\n", activeStart);
+  const activeBlock = text.slice(activeStart, activeEnd === -1 ? undefined : activeEnd);
+  assert.match(activeBlock, /active claim/, "the active unit still shows its own reason");
+  assert.doesNotMatch(
+    activeBlock,
+    /listed above/,
+    "a unit that still has a reason of its own gets no pointer line",
   );
   assert.doesNotMatch(
     text,

--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -897,6 +897,66 @@ function legacyObservation(overrides = {}) {
   );
 }
 
+// cave-we34s: a checkout-level probe failure is stated once, not once per unit.
+// It still fails every unit closed; what changes is that the report can no
+// longer be misread as N independent problems.
+{
+  const stale =
+    "default branch inventory tracking ref refs/remotes/origin/main is stale or mismatched with authoritative refs/heads/main";
+  const budgets = {
+    worktrees: { count: 3, registered: 3, detached: 0, warning: 28, exceeded: false },
+    branches: { count: 3, warning: 38, exceeded: false },
+    exceptions: { active: 0, expired: 0 },
+  };
+  // Two units disqualified by the SAME repository-wide fact, one of which is
+  // also independently active — so it takes the "probe warning: " spelling.
+  const uncertainUnit = classifyLifecycleUnit(
+    observation({ branch: "feat/a", probeErrors: [stale] }),
+    NOW,
+  );
+  const activeUnit = classifyLifecycleUnit(
+    observation({ branch: "feat/b", claimOwners: ["buns@coven-cave"], probeErrors: [stale] }),
+    NOW,
+  );
+  assert.equal(uncertainUnit.lane, "uncertain", "the unit still fails closed on the global fact");
+  assert.ok(
+    uncertainUnit.reasons.includes(stale),
+    "the item keeps the full reason list; suppression is presentation only",
+  );
+  assert.ok(
+    activeUnit.reasons.includes(`probe warning: ${stale}`),
+    "an active unit carries the prefixed spelling",
+  );
+
+  const summary = summarizeWorktreeLifecycle([uncertainUnit, activeUnit], budgets, [stale, stale]);
+  assert.deepEqual(summary.globalErrors, [stale], "the summary dedupes repository-wide failures");
+
+  const text = renderWorktreeLifecycleReport(summary);
+  assert.equal(
+    text.split(stale).length - 1,
+    1,
+    "the repository-wide failure is printed exactly once, not once per unit",
+  );
+  assert.match(text, /Repository-wide probe failures \(1\)/);
+  assert.match(
+    text,
+    /1 repository-wide probe failure \(listed above\)/,
+    "a unit left with no reason of its own still says why it is held",
+  );
+  assert.doesNotMatch(
+    text,
+    /probe warning: default branch inventory/,
+    "the prefixed spelling is suppressed too, or active units keep repeating it",
+  );
+
+  // Absent any global failure the report gains nothing at all — no empty
+  // heading, no stray pointer line.
+  const clean = renderWorktreeLifecycleReport(summarizeWorktreeLifecycle([uncertainUnit], budgets));
+  assert.doesNotMatch(clean, /Repository-wide probe failures/);
+  assert.doesNotMatch(clean, /listed above/);
+  assert.match(clean, /default branch inventory tracking ref/, "and the unit still states it");
+}
+
 // cave-oenag: the exclusion is reported, not silent — otherwise the assessed
 // number and the registered one differ with nothing to explain the gap.
 {

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -885,9 +885,13 @@ export function renderWorktreeLifecycleReport(
   const globalErrors = summary.globalErrors;
   const globalErrorSet = new Set(globalErrors);
   if (globalErrors.length > 0) {
+    // Deliberately does NOT claim every unit is affected: a protected unit
+    // returns from classification before probe errors are read, so it carries
+    // none of these. Overclaiming here would be the same kind of error this
+    // section exists to correct, one direction over.
     lines.push(
       "",
-      `Repository-wide probe failures (${globalErrors.length}) — these describe the checkout, not any one unit, and every unit below fails closed on them:`,
+      `Repository-wide probe failures (${globalErrors.length}) — these describe the checkout rather than any one unit. Each affected unit fails closed on them and does not repeat them below:`,
     );
     for (const error of globalErrors) lines.push(`- ${error}`);
   }
@@ -918,10 +922,13 @@ export function renderWorktreeLifecycleReport(
       );
       const suppressed = item.reasons.length - ownReasons.length;
       for (const reason of ownReasons) lines.push(`  ${humanReason(item, reason)}`);
-      // A unit whose ONLY reason was repository-wide would otherwise render as
-      // a bare line with no explanation at all, which reads like a bug in the
-      // report rather than a deliberate omission.
-      if (suppressed > 0) {
+      // Only when suppression would otherwise leave the unit with NO
+      // explanation at all: a bare line reads like a bug in the report rather
+      // than a deliberate omission. A unit that still shows a reason of its own
+      // needs no pointer — the heading above already accounts for the
+      // repository-wide failures, and repeating that per unit is the noise this
+      // whole change exists to remove.
+      if (suppressed > 0 && ownReasons.length === 0) {
         lines.push(
           `  ${suppressed} repository-wide probe failure${suppressed === 1 ? "" : "s"} (listed above)`,
         );

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -162,6 +162,20 @@ export type WorktreeLifecycleSummary = {
   items: WorktreeLifecycleItem[];
   counts: Record<WorktreeLifecycleLane, number>;
   budgets: WorktreeLifecycleBudgets;
+  /**
+   * Probe failures that describe the CHECKOUT rather than any single unit — a
+   * stale default-branch tracking ref, an unreadable origin identity, a Beads
+   * or workflow query that did not answer.
+   *
+   * Every unit still fails closed on these, and each one still carries the
+   * string in its own `probeErrors`; that is what stops a unit being retired
+   * while the fact it depends on is unverified, and it must not be traded away
+   * for a tidier report. What this field buys is the ability to SAY SO ONCE.
+   * Without it, one stale tracking ref is indistinguishable from N genuinely
+   * uncertain units: on 2026-08-11 that produced 39 uncertain units all
+   * carrying the same sentence, with nothing to indicate it was a single fact.
+   */
+  globalErrors: string[];
 };
 
 export type WorktreeLifecycleRenderOptions = {
@@ -282,6 +296,16 @@ const DISPOSABLE_HOOK_ARTIFACTS = new Set([
   ".claude/worktree-retention-push.log",
   ".claude/worktree-guard-bypass.log",
 ]);
+
+/**
+ * Prefix an `active` unit's probe errors carry in its reason list, where an
+ * `uncertain` unit carries them verbatim. Shared so the renderer can recognise
+ * a repository-wide failure in either spelling — matching only the bare form
+ * left every active unit repeating a fact the report had already stated.
+ */
+const PROBE_WARNING_PREFIX = "probe warning: ";
+
+
 const HUMAN_LANE_LABELS: Record<WorktreeLifecycleLane, string> = {
   active: "active",
   recovery: "recovery",
@@ -473,7 +497,7 @@ function classifyLifecycleUnitInternal(
   if (live.length > 0) {
     return withReasons(observation, "active", [
       ...live,
-      ...observation.probeErrors.map((error) => `probe warning: ${error}`),
+      ...observation.probeErrors.map((error) => `${PROBE_WARNING_PREFIX}${error}`),
     ]);
   }
 
@@ -706,13 +730,14 @@ const LANE_ORDER: WorktreeLifecycleLane[] = [
 export function summarizeWorktreeLifecycle(
   items: WorktreeLifecycleItem[],
   budgets: WorktreeLifecycleBudgets,
+  globalErrors: string[] = [],
 ): WorktreeLifecycleSummary {
   const counts = Object.fromEntries(LANE_ORDER.map((lane) => [lane, 0])) as Record<
     WorktreeLifecycleLane,
     number
   >;
   for (const item of items) counts[item.lane] += 1;
-  return { items, counts, budgets };
+  return { items, counts, budgets, globalErrors: [...new Set(globalErrors)] };
 }
 
 function assertNonnegativeInteger(name: string, value: number): void {
@@ -852,6 +877,21 @@ export function renderWorktreeLifecycleReport(
     `Managed exceptions: ${summary.budgets.exceptions.active} active | ${summary.budgets.exceptions.expired} expired`,
   ];
 
+  // State the checkout-level failures ONCE, before the lanes. Each affected
+  // unit still fails closed on them and still carries them in probeErrors —
+  // this only stops the report repeating one fact N times, where N is however
+  // many units the checkout happens to hold, and where the repetition is
+  // indistinguishable from N independent problems.
+  const globalErrors = summary.globalErrors;
+  const globalErrorSet = new Set(globalErrors);
+  if (globalErrors.length > 0) {
+    lines.push(
+      "",
+      `Repository-wide probe failures (${globalErrors.length}) — these describe the checkout, not any one unit, and every unit below fails closed on them:`,
+    );
+    for (const error of globalErrors) lines.push(`- ${error}`);
+  }
+
   for (const lane of LANE_ORDER) {
     const items = summary.items.filter((item) => item.lane === lane);
     if (items.length === 0) continue;
@@ -860,7 +900,32 @@ export function renderWorktreeLifecycleReport(
       const location = item.kind === "branch-only" || !item.path ? "" : ` @ ${item.path}`;
       const kind = item.kind === "branch-only" ? " [branch-only]" : "";
       lines.push(`- ${labelFor(item)}${kind}${location}`);
-      for (const reason of item.reasons) lines.push(`  ${humanReason(item, reason)}`);
+      // Drop the copies of a checkout-level failure that were already stated
+      // above. `reasons` keeps them — this is presentation, not classification,
+      // and every consumer reading the item still sees the full list.
+      //
+      // Both spellings have to be matched: an `uncertain` unit carries the
+      // probe error verbatim, while an `active` unit carries it prefixed with
+      // "probe warning: " (classifyLifecycleUnitInternal). Matching only the
+      // bare form would leave every active unit still repeating it.
+      const ownReasons = item.reasons.filter(
+        (reason) =>
+          !globalErrorSet.has(reason) &&
+          !(
+            reason.startsWith(PROBE_WARNING_PREFIX) &&
+            globalErrorSet.has(reason.slice(PROBE_WARNING_PREFIX.length))
+          ),
+      );
+      const suppressed = item.reasons.length - ownReasons.length;
+      for (const reason of ownReasons) lines.push(`  ${humanReason(item, reason)}`);
+      // A unit whose ONLY reason was repository-wide would otherwise render as
+      // a bare line with no explanation at all, which reads like a bug in the
+      // report rather than a deliberate omission.
+      if (suppressed > 0) {
+        lines.push(
+          `  ${suppressed} repository-wide probe failure${suppressed === 1 ? "" : "s"} (listed above)`,
+        );
+      }
       // Informational, never a lane input: these beads name the unit without
       // claiming it. Printed so the reader can still find the conversation.
       if (item.mentionTaskIds.length > 0) {


### PR DESCRIPTION
Fixes `cave-we34s`. Follow-up split out of `cave-ra0hk`, which fixed the cause
(the sweep never fetched) and deliberately left the reporting question alone.

## Two problems, only one of them cosmetic

**Substantive.** `remoteDefaultBranch(root)` reads only the checkout root, so
its failure is repository-wide *by construction* — exactly like
`originIdentity.error`, which is in the global bucket. But `defaultBranch.error`
was **not** in `branchGlobalErrors`, so it never reached the inventory's
`globalErrors` field at all. It reached every unit anyway, by another path:

```
defaultBranch.error → ancestry.error (when defaultBranch.oid is null)
                    → probeErrors → lane `uncertain`, that string as the reason
```

So a JSON consumer saw N identical per-unit probe errors and no global signal,
and could not tell that one checkout-level fact had disqualified everything.
That was an inconsistency, not a design decision.

**Cosmetic — the cost that inconsistency imposed on a reader.** On 2026-08-11 a
single stale tracking ref produced 39 uncertain units all carrying the same
sentence, indistinguishable from 39 independent problems.

## What did NOT change

Classification. Every unit still fails closed on these errors and still carries
each string in its own `probeErrors`. That is what stops a unit being retired
while a fact it depends on is unverified, and it must not be traded away for a
tidier report — so this PR does not remove the per-unit stamping, it only stops
the *report* repeating it.

The existing metadata code already models the right shape, and this follows it:
`globalErrors` is a **subset** of `errors`, not an alternative to them. Adding
`defaultBranch.error` to `branchGlobalErrors` changes no unit's outcome, because
the identical string is already stamped per unit and both sites dedup through a
`Set`.

## Before / after

Rendered by the real functions over a 12-unit checkout with one stale ref:

**Before**
```
uncertain
- feat/unit-1 @ /repo/.worktrees/unit-1
  default branch inventory tracking ref refs/remotes/origin/main is stale or mismatched with authoritative refs/heads/main
- feat/unit-2 @ /repo/.worktrees/unit-2
  default branch inventory tracking ref refs/remotes/origin/main is stale or mismatched with authoritative refs/heads/main
- feat/unit-3 @ /repo/.worktrees/unit-3
  ...
```
→ the sentence appears **12 times**

**After**
```
Repository-wide probe failures (1) — these describe the checkout, not any one unit, and every unit below fails closed on them:
- default branch inventory tracking ref refs/remotes/origin/main is stale or mismatched with authoritative refs/heads/main

uncertain
- feat/unit-1 @ /repo/.worktrees/unit-1
  1 repository-wide probe failure (listed above)
- feat/unit-2 @ /repo/.worktrees/unit-2
  1 repository-wide probe failure (listed above)
```
→ the sentence appears **once**, and `lanes identical: true`

## One subtlety worth reviewing

Both spellings had to be suppressed. An `uncertain` unit carries the probe error
verbatim; an **`active`** unit carries it prefixed with `"probe warning: "`
(`classifyLifecycleUnitInternal`). Matching only the bare form would have left
every active unit still repeating it. That prefix is now a shared constant so
the producer and the renderer cannot drift apart.

The pointer line exists for the same class of reason: a unit whose only reason
was repository-wide would otherwise render as a bare line with no explanation,
which reads as a bug in the report rather than a deliberate omission.

## Verification

- `tsc --noEmit` clean, eslint clean.
- `worktree-lifecycle.test.ts` — pass, with a new block asserting: the unit
  still lands `uncertain`; `item.reasons` still contains the full string
  (suppression is presentation only); the summary dedupes; the sentence renders
  exactly once; the prefixed spelling is suppressed; and with **no** global
  failure the report gains no empty heading and no stray pointer, while the unit
  still states its reason itself.
- `worktree-lifecycle-retirement.test.mjs` — pass.
- `worktree-lifecycle-patrol.test.mjs` — **ok**, 1 pass / 0 fail (full ~7.5 min run).

## Note

Commit is unsigned (ssh-agent holds no identities). Signatures are not required
on `main`.