### PR TITLE
fix: treat hook-written .claude/ artifacts as disposable during worktree retirement

### DIFF
--- a/src/lib/worktree-lifecycle.test.ts
+++ b/src/lib/worktree-lifecycle.test.ts
@@ -103,6 +103,24 @@ assert.equal(
     process.platform === "win32",
     "backslashes are path separators only on platforms that define them that way",
   );
+  for (const hookArtifact of [
+    ".claude/worktree-autolock.stamp",
+    ".claude/worktree-autolock.log",
+    ".claude/worktree-retention-push.stamp",
+    ".claude/worktree-retention-push.log",
+    ".claude/worktree-guard-bypass.log",
+  ]) {
+    assert.equal(
+      isDisposableIgnoredPath(hookArtifact),
+      true,
+      `${hookArtifact} is a hook artifact that must not block retirement`,
+    );
+  }
+  assert.equal(
+    isDisposableIgnoredPath(".claude/settings.json"),
+    false,
+    "tracked .claude files are not disposable",
+  );
 }
 
 function metadata(overrides = {}) {

--- a/src/lib/worktree-lifecycle.ts
+++ b/src/lib/worktree-lifecycle.ts
@@ -272,6 +272,16 @@ const DISPOSABLE_IGNORED_ROOTS = [
   "target",
   "test-results",
 ];
+
+/** Hook artifacts written under `.claude/` that are machine-local bookkeeping,
+ *  gitignored, and safe to discard during worktree retirement. */
+const DISPOSABLE_HOOK_ARTIFACTS = new Set([
+  ".claude/worktree-autolock.stamp",
+  ".claude/worktree-autolock.log",
+  ".claude/worktree-retention-push.stamp",
+  ".claude/worktree-retention-push.log",
+  ".claude/worktree-guard-bypass.log",
+]);
 const HUMAN_LANE_LABELS: Record<WorktreeLifecycleLane, string> = {
   active: "active",
   recovery: "recovery",
@@ -289,6 +299,9 @@ export function isDisposableIgnoredPath(candidate: string): boolean {
     normalized === "next-env.d.ts" ||
     normalized.endsWith(".tsbuildinfo")
   ) {
+    return true;
+  }
+  if (DISPOSABLE_HOOK_ARTIFACTS.has(normalized)) {
     return true;
   }
   return DISPOSABLE_IGNORED_ROOTS.some(


### PR DESCRIPTION
## Summary

- Add five hook-written `.claude/` files (autolock stamp/log, retention-push stamp/log, guard-bypass log) to `isDisposableIgnoredPath` so they no longer block worktree retirement
- Pin the contract with test assertions, including a negative case for `.claude/settings.json` (tracked, must stay non-disposable)

Closes cave-o16u7.

## Context

The repo's PreToolUse/PostToolUse hooks write throttle stamps and JSON-lines logs under `.claude/` in every worktree they touch. These are gitignored, machine-local, and regenerated on the next hook pass. But the patrol's disposable set did not include them, so a clean, fully-merged worktree with nothing but these artifacts read as "active" with non-disposable ignored paths — blocking retirement invisibly.

## Test plan

- [x] `worktree-lifecycle.test.ts` passes — all five hook artifacts classified disposable, `.claude/settings.json` stays non-disposable
- [x] `worktree-lifecycle-retirement.test.mjs` passes
- [ ] CI Frontend build