### PR TITLE
fix: retarget stale sweep reference and surface open beads on retired units

### DIFF
--- a/scripts/worktree-lifecycle-patrol.ts
+++ b/scripts/worktree-lifecycle-patrol.ts
@@ -450,7 +450,10 @@ function formatItemIdentity(item: PatrolItem): string {
 }
 
 function formatRetiredItem(item: PatrolItem): string {
-  return `- ${formatItemIdentity(item)} (oid ${item.head})`;
+  const beadHint = item.metadata?.beadId
+    ? ` — bead ${item.metadata.beadId} may still be open; close it if acceptance criteria landed`
+    : "";
+  return `- ${formatItemIdentity(item)} (oid ${item.head})${beadHint}`;
 }
 
 function formatBlockedItem(item: RetirementBlock): string {
@@ -587,7 +590,7 @@ export function runRetirementApply(
     //
     // The reservation is one slot, not a second budget: total mutations still
     // cannot exceed maxRetire, which is what bounds an unattended sweep's blast
-    // radius (scripts/worktree-sweep-prompt.md pins --max-retire 3 and says not
+    // radius (scripts/worktree-sweep.sh pins --max-retire 3 and says not
     // to raise it). It is taken only when something is actually retirable, so a
     // run with nothing to retire still spends the whole allowance on repair,
     // exactly as before.


### PR DESCRIPTION
## Summary

Two follow-ups from PR #4542 (removed the unattended LLM sweep agent):

- **Stale reference**: a comment in `worktree-lifecycle-patrol.ts` cited the deleted `scripts/worktree-sweep-prompt.md` — retarget to `scripts/worktree-sweep.sh`
- **Open beads on retired units**: the lifecycle tool retires worktrees but never closes their beads. Rather than re-automating a judgement call, surface a hint in the patrol report so a human can action it from the sweep log

Closes cave-i2vsc.

## Test plan

- [x] Existing patrol test pins use `includes()` on the retired-item format, so the appended hint does not break them (the fixture has no metadata, so the hint is empty)
- [ ] CI Frontend build