### PR TITLE
chore(release): stamp v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-08-12
+
+> A maintenance patch: worktree-lifecycle reporting states a repository-wide
+> failure once rather than once per unit, and the Coven brand assets now live
+> in the repository.
+
+Patch release on top of v0.3.1. Headline: a single checkout-level probe failure
+no longer reads as N independent problems in the worktree lifecycle report.
+
+### Added
+
+- Added the Coven brand assets under `assets/brand` — logo, Discord banner, and
+  a wordmark banner variant.
+
+### Fixed
+
+- The worktree lifecycle inventory now reports a repository-wide default-branch
+  probe failure in its global errors, and the patrol states it once under its
+  own heading instead of stamping the identical sentence onto every affected
+  unit. Classification is deliberately unchanged: each unit still fails closed
+  on the error and still carries it in its own probe errors (#4565).
+- Retargeted a stale comment that cited the removed
+  `scripts/worktree-sweep-prompt.md` to `scripts/worktree-sweep.sh`, and the
+  patrol report now hints that a retired worktree's bead may still be open so a
+  human can close it from the sweep log (#4568).
+
 ## [0.3.1] - 2026-08-12
 
 > ⚠️ Removes the access-token requirement. A Cave published over Tailscale

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ no longer reads as N independent problems in the worktree lifecycle report.
   `scripts/worktree-sweep-prompt.md` to `scripts/worktree-sweep.sh`, and the
   patrol report now hints that a retired worktree's bead may still be open so a
   human can close it from the sweep log (#4568).
+- Resolved Chat model application state when the downstream harness echoes the
+  request, so the applied model is reported from the harness response rather
+  than assumed from what was sent (#4569).
 
 ## [0.3.1] - 2026-08-12
 

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.1"
+    MARKETING_VERSION: "0.3.2"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081203"
+    CURRENT_PROJECT_VERSION: "2026081209"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.1"
+version = "0.3.2"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.3.2 across the five version manifests and finalizes the CHANGELOG section.

Patch release on top of v0.3.1, carrying three commits:

- Coven brand assets under `assets/brand`
- #4565 — worktree lifecycle reports a repository-wide probe failure once, not once per unit
- #4568 — retargeted stale sweep reference, and the patrol hints when a retired unit's bead may still be open

Publishes nothing on its own. The `v0.3.2` tag push is a separate, explicit step.

Verification:

- `pnpm release:verify --version 0.3.2` — verified across five manifests and the finalized changelog
- `src/lib/app-version.test.ts` — ok
- `scripts/stamp-release.test.mjs` — 1 pass, 0 fail

Note: the stamp commit is unsigned — the signing key is not loadable in this
non-interactive session. `required_signatures` is false on `main`.