### PR TITLE
fix(worktrees): make a maintenance fence refusal actionable (cave-8zkkj)

### DIFF
--- a/scripts/fence-refusal-message.mjs
+++ b/scripts/fence-refusal-message.mjs
@@ -1,0 +1,59 @@
+/**
+ * Render a maintenance fence refusal as something the reader can act on.
+ *
+ * Lives in its own module because `worktree-lifecycle-create.ts` calls `main()`
+ * at load, so a function defined there cannot be imported by a test without
+ * running the CLI. The rendering is the part with branches worth pinning.
+ *
+ * @typedef {{
+ *   reason?: string,
+ *   holder?: string,
+ *   holderPid?: number,
+ *   holderHost?: string,
+ *   phase?: string,
+ *   expiresAt?: string,
+ * }} FenceRefusal
+ */
+
+/**
+ * @param {FenceRefusal} refusal
+ * @param {number} [now]
+ * @returns {string}
+ */
+export function fenceRefusalMessage(refusal, now = Date.now()) {
+  const lines = [`maintenance fence acquisition failed: ${refusal.reason ?? "unknown"}`];
+  if (refusal.holder) {
+    const pid = Number.isSafeInteger(refusal.holderPid) ? ` (pid ${refusal.holderPid}` : "";
+    const host = pid && refusal.holderHost ? ` on ${refusal.holderHost})` : pid ? ")" : "";
+    lines.push(`  held by: ${refusal.holder}${pid}${host}`);
+  }
+  if (refusal.phase) lines.push(`  phase: ${refusal.phase}`);
+
+  const expiresAtMs = refusal.expiresAt ? Date.parse(refusal.expiresAt) : Number.NaN;
+  if (Number.isFinite(expiresAtMs)) {
+    const remainingMs = expiresAtMs - now;
+    if (remainingMs > 0) {
+      lines.push(
+        `  lease expires: ${refusal.expiresAt} (in ~${Math.ceil(remainingMs / 1000)}s)`,
+        "  Wait for the lease to expire, then rerun this command.",
+      );
+    } else {
+      // A `gate-stale` refusal is exactly this: the lease is already past its
+      // TTL and the gate STILL refuses, because the owner is not provably gone
+      // and nothing in shipping code passes `takeoverStale`. Telling this
+      // reader to wait would be the same unactionable advice this whole change
+      // exists to remove — the wait already happened and did not help.
+      lines.push(
+        `  lease expired: ${refusal.expiresAt} (${Math.floor(-remainingMs / 1000)}s ago)`,
+        "  Waiting will NOT clear this. The lease has already lapsed and the fence",
+        "  still refuses, so check whether the holder process above is alive.",
+      );
+    }
+  }
+  lines.push(
+    "  Do NOT fall back to `git worktree add`: a worktree created that way",
+    "  carries no lifecycle metadata, reports `uncertain` permanently, and can",
+    "  never be retired automatically (cave-l52dt).",
+  );
+  return lines.join("\n");
+}

--- a/scripts/fence-refusal-message.test.mjs
+++ b/scripts/fence-refusal-message.test.mjs
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { fenceRefusalMessage } from "./fence-refusal-message.mjs";
+
+const NOW = Date.parse("2026-08-12T10:00:00.000Z");
+
+test("a held lease names the holder, its process, and how long the wait is", () => {
+  const message = fenceRefusalMessage(
+    {
+      reason: "local-acquire-failed: gate-held",
+      holder: "worktree-lifecycle-create:cave-123",
+      holderPid: 4242,
+      holderHost: "somehost",
+      phase: "held",
+      expiresAt: "2026-08-12T10:05:00.000Z",
+    },
+    NOW,
+  );
+
+  assert.match(message, /^maintenance fence acquisition failed: local-acquire-failed: gate-held$/m);
+  assert.match(message, /held by: worktree-lifecycle-create:cave-123 \(pid 4242 on somehost\)/);
+  assert.match(message, /phase: held/);
+  assert.match(message, /lease expires: 2026-08-12T10:05:00\.000Z \(in ~300s\)/);
+  assert.match(message, /Wait for the lease to expire, then rerun this command\./);
+  assert.match(message, /Do NOT fall back to `git worktree add`/);
+});
+
+// The bug this file exists for. `gate-stale` refuses an ALREADY-EXPIRED lease:
+// the TTL lapsed but the owner is not provably gone, and nothing in shipping
+// code passes `takeoverStale`. Telling that reader to wait is the same
+// unactionable advice cave-8zkkj set out to remove — the wait already happened.
+test("an already-expired lease never advises waiting", () => {
+  const message = fenceRefusalMessage(
+    {
+      reason: "local-acquire-failed: gate-stale",
+      holder: "worktree-lifecycle-create:cave-999",
+      holderPid: 4242,
+      phase: "held",
+      expiresAt: "2026-08-12T09:58:00.000Z",
+    },
+    NOW,
+  );
+
+  assert.doesNotMatch(message, /Wait for the lease to expire/);
+  assert.doesNotMatch(message, /in ~0s/, "an expired lease is not reported as a zero-second wait");
+  assert.match(message, /lease expired: 2026-08-12T09:58:00\.000Z \(120s ago\)/);
+  assert.match(message, /Waiting will NOT clear this/);
+  assert.match(message, /check whether the holder process above is alive/);
+  assert.match(message, /Do NOT fall back to `git worktree add`/);
+});
+
+// The Coven plane refuses without any lease at all, so neither the wait advice
+// nor the expiry line can be supported — but the fallback warning still can.
+test("a refusal with no lease reports neither an expiry nor a wait", () => {
+  const message = fenceRefusalMessage({ reason: "coven-acquire-failed" }, NOW);
+
+  assert.equal(message.includes("lease expires"), false);
+  assert.equal(message.includes("lease expired"), false);
+  assert.doesNotMatch(message, /Wait for the lease/);
+  assert.doesNotMatch(message, /Waiting will NOT/);
+  assert.match(message, /Do NOT fall back to `git worktree add`/);
+});
+
+test("missing detail degrades instead of rendering undefined", () => {
+  const bare = fenceRefusalMessage({}, NOW);
+  assert.match(bare, /^maintenance fence acquisition failed: unknown$/m);
+  assert.equal(bare.includes("undefined"), false);
+  assert.equal(bare.includes("held by"), false);
+
+  // A record predating host recording carries a pid but no host: the pid is
+  // still worth printing, and the parenthesis must still close.
+  const noHost = fenceRefusalMessage({ reason: "gate-held", holder: "owner", holderPid: 7 }, NOW);
+  assert.match(noHost, /held by: owner \(pid 7\)$/m);
+
+  // A malformed expiry is dropped rather than rendered as "Invalid Date".
+  const badExpiry = fenceRefusalMessage({ reason: "gate-held", expiresAt: "not-a-date" }, NOW);
+  assert.equal(badExpiry.includes("lease expir"), false);
+  assert.equal(badExpiry.includes("NaN"), false);
+});

--- a/scripts/local-maintenance-gate.mjs
+++ b/scripts/local-maintenance-gate.mjs
@@ -242,6 +242,26 @@ function gateExpired(gate, now) {
   return now > Date.parse(gate.heartbeatAt) + gate.ttlMs;
 }
 
+/**
+ * Everything a refused acquirer needs to choose what to do next, rather than
+ * only that it lost. `reason` alone named neither the holder's process nor the
+ * instant the lease lapses, so the natural reaction to a refusal was to retry
+ * blind or reach for an unmanaged fallback (cave-8zkkj).
+ *
+ * `holder` keeps its original name and meaning; the rest is additive, so any
+ * caller reading only `reason`/`holder` is unaffected. `holderHost` is omitted
+ * rather than emitted as undefined when the record predates host recording.
+ */
+function refusalDetail(gate) {
+  return {
+    holder: gate.ownerId,
+    holderPid: gate.pid,
+    ...(gate.host === undefined ? {} : { holderHost: gate.host }),
+    phase: gate.phase,
+    expiresAt: new Date(Date.parse(gate.heartbeatAt) + gate.ttlMs).toISOString(),
+  };
+}
+
 function clockRegressed(lease, now) {
   return now < Date.parse(lease.heartbeatAt);
 }
@@ -565,7 +585,7 @@ export function acquireMaintenanceGate({
     // test produced three simultaneous winners when this was tried, because
     // each short-lived winner's exit let the next acquirer straight in.
     if (existing.ok && !gateExpired(existing.value, now)) {
-      return { ok: false, reason: "gate-held", holder: existing.value.ownerId };
+      return { ok: false, reason: "gate-held", ...refusalDetail(existing.value) };
     }
     if (!existing.ok && existing.malformed) {
       audit(root, "acquire-rejected", { ownerId, reason: "malformed-gate" });
@@ -583,7 +603,7 @@ export function acquireMaintenanceGate({
     // explicit opt-in requirement.
     const abandoned = existing.ok && ownerProcessGone(existing.value);
     if (existing.ok && !takeoverStale && !abandoned) {
-      return { ok: false, reason: "gate-stale", holder: existing.value.ownerId };
+      return { ok: false, reason: "gate-stale", ...refusalDetail(existing.value) };
     }
 
     const advanced = nextGeneration(root, existing.ok ? existing.value.generation : 0);

--- a/scripts/local-maintenance-gate.test.mjs
+++ b/scripts/local-maintenance-gate.test.mjs
@@ -1185,3 +1185,57 @@ test("every transition lands in the audit log with its generation", () => {
   );
   rmSync(repo, { recursive: true, force: true });
 });
+
+// cave-8zkkj. A refusal named only that the caller had lost, so the reaction to
+// it was to retry blind or reach for the unmanaged `git worktree add` fallback
+// — which produces a worktree that can never be retired (cave-l52dt). The
+// holder's identity, its process, and the instant the lease lapses were all
+// already known at the refusal site and thrown away.
+test("a gate-held refusal names the holder, its process, and the lease expiry", () => {
+  const repo = makeRepo();
+  const acquired = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(acquired.ok, true);
+
+  const refused = acquireMaintenanceGate({ ownerId: "second", repoDir: repo });
+  assert.equal(refused.ok, false);
+  assert.equal(refused.reason, "gate-held", "the reason stays the stable contract");
+  assert.equal(refused.holder, "first");
+  assert.equal(refused.holderPid, process.pid, "the refusal names the holding process");
+  assert.equal(refused.holderHost, hostname());
+  assert.equal(refused.phase, "held");
+
+  // The expiry must be a real future instant, not a placeholder: the whole
+  // point is that the reader can decide whether waiting is worth it.
+  const expiresAtMs = Date.parse(refused.expiresAt);
+  assert.ok(Number.isFinite(expiresAtMs), "expiresAt parses as an instant");
+  assert.ok(expiresAtMs > Date.now(), "an unexpired gate reports a future expiry");
+
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});
+
+// The same detail has to survive the composite wrapper. It previously
+// interpolated `reason` into a string and dropped every other field, so the
+// CLI — which only ever sees the composite result — could not have rendered
+// the holder even after the local fence started reporting it.
+test("the composite fence carries local refusal detail through local-acquire-failed", async () => {
+  const { acquireMaintenanceGate: acquireComposite } = await import("./maintenance-gate.mjs");
+  const repo = makeRepo();
+  const acquired = acquireMaintenanceGate({ ownerId: "first", repoDir: repo });
+  assert.equal(acquired.ok, true);
+
+  const refused = acquireComposite({
+    ownerId: "second",
+    purpose: "cave-8zkkj detail propagation",
+    repoDir: repo,
+    quiesceTimeoutMs: 0,
+  });
+  assert.equal(refused.ok, false);
+  assert.match(refused.reason, /^local-acquire-failed: gate-held$/);
+  assert.equal(refused.holder, "first", "the wrapper no longer discards the holder");
+  assert.equal(refused.holderPid, process.pid);
+  assert.ok(Number.isFinite(Date.parse(refused.expiresAt)));
+
+  assert.equal(releaseMaintenanceGate(acquired.handle).ok, true);
+  rmSync(repo, { recursive: true, force: true });
+});

--- a/scripts/maintenance-gate.mjs
+++ b/scripts/maintenance-gate.mjs
@@ -400,7 +400,16 @@ export function createRepositoryMaintenanceCoordinator({
         quiesceTimeoutMs,
       });
       if (!local.ok) {
-        return { ok: false, reason: `local-acquire-failed: ${local.reason ?? "unknown"}` };
+        // Carry the local fence's refusal detail (holder, pid, expiry) through
+        // the wrapper. Interpolating only `reason` discarded every field a
+        // caller could have acted on, which is what made the composite
+        // refusal unactionable at the CLI (cave-8zkkj).
+        const { ok: _ok, reason: _reason, ...detail } = local;
+        return {
+          ok: false,
+          reason: `local-acquire-failed: ${local.reason ?? "unknown"}`,
+          ...detail,
+        };
       }
 
       const coven = covenClient.acquire({

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -64,6 +64,7 @@ export const SUITES = {
     "scripts/test-alias-loader.test.mjs",
     "scripts/maintenance-gate.test.mjs",
     "scripts/local-maintenance-gate.test.mjs",
+    "scripts/fence-refusal-message.test.mjs",
     "scripts/check-beads-jsonl-duplicates.test.mjs",
     "scripts/check-conflict-markers.test.mjs",
     "scripts/beads-jsonl-merge-driver.test.mjs",

--- a/scripts/worktree-lifecycle-create.ts
+++ b/scripts/worktree-lifecycle-create.ts
@@ -18,6 +18,7 @@ import {
   type OrphanedWorktreeMetadataRecord,
   type WorktreeMetadataClaimError,
 } from "./worktree-lifecycle-inventory.ts";
+import { fenceRefusalMessage } from "./fence-refusal-message.mjs";
 import {
   acquireMaintenanceGate,
   createFenceRenewal,
@@ -1056,6 +1057,15 @@ function createdOutcome(
   };
 }
 
+type FenceRefusal = {
+  reason?: string;
+  holder?: string;
+  holderPid?: number;
+  holderHost?: string;
+  phase?: string;
+  expiresAt?: string;
+};
+
 function heartbeatBoth(leases: MaintenanceFence[], stage: string): void {
   if (leases.length !== 1) {
     throw new CliError(`maintenance fence unavailable during ${stage}`);
@@ -1700,7 +1710,7 @@ function execute(
     quiesceTimeoutMs: 30_000,
   });
   if (!acquired.ok) {
-    throw new CliError(`maintenance fence acquisition failed: ${acquired.reason}`);
+    throw new CliError(fenceRefusalMessage(acquired as FenceRefusal));
   }
   leases.push(acquired.handle as MaintenanceFence);
   // The preflight above reduces needless drain time; this second proof is the


### PR DESCRIPTION
## What

A refused `pnpm beads:worktrees:create` said only that it had lost:

```
maintenance fence acquisition failed: local-acquire-failed: gate-held
```

It named neither the holder, nor its process, nor when the lease lapses. I hit
this exact line earlier today and retried blind, which is the mild version of
the failure — the documented one is reaching for `git worktree add`, producing a
worktree with no lifecycle metadata that the patrol reports `uncertain` forever
and `--apply` can never retire (cave-l52dt).

Every one of those facts was already known at the refusal site and thrown away.

## Why it was invisible

Two independent drops, which is why adding detail in one place alone would not
have surfaced anything:

1. `acquireLocalMaintenanceGate` returned `holder` and nothing else.
2. The composite wrapper interpolated `local.reason` into a string and dropped
   every remaining field — and the CLI only ever sees the composite result.

## Changes

- **`local-maintenance-gate.mjs`** — `refusalDetail()` attaches `holder`,
  `holderPid`, `holderHost`, `phase`, `expiresAt` to the `gate-held` and
  `gate-stale` refusals. `reason` and `holder` keep their names and meanings, so
  existing callers and assertions are untouched; `holderHost` is omitted rather
  than emitted as `undefined` on records predating host recording.
- **`maintenance-gate.mjs`** — carry that detail through the
  `local-acquire-failed:` wrapper.
- **`worktree-lifecycle-create.ts`** — `fenceRefusalMessage()` renders it:
  holder, pid/host, phase, expiry with a seconds-remaining estimate, and the
  warning against the fallback.

Sample of the new output:

```
maintenance fence acquisition failed: local-acquire-failed: gate-held
  held by: worktree-lifecycle-create:cave-123 (pid 41547 on hostname)
  phase: held
  lease expires: 2026-08-12T10:14:22.000Z (in ~412s)
  Wait for the lease to expire, then rerun this command.
  Do NOT fall back to `git worktree add`: a worktree created that way
  carries no lifecycle metadata, reports `uncertain` permanently, and can
  never be retired automatically (cave-l52dt).
```

## Judgement calls

**The wait line is conditional.** It prints only when an expiry is actually
known. A Coven-plane refusal (`coven-acquire-failed`) carries no lease, so
telling that reader to wait it out would be advice this change cannot support.
The fallback warning, which is always correct, always prints. The seconds figure
clamps at zero so an already-lapsed lease reads as due now rather than as a
negative wait.

**Two of the bead's three suggestions are deliberately not implemented.**

- *"Treat an intent whose pid is gone as expired"* is already true where it is
  safe: `ownerProcessGone` reclaims an EXPIRED gate whose owner is provably
  gone. It is deliberately refused for an UNEXPIRED one, because reclaiming on
  liveness alone breaks mutual exclusion — an earlier draft did exactly that and
  the concurrent-acquirer test produced three simultaneous winners. Implementing
  the suggestion as written would reintroduce that.
- *The 10-minute `INTENT_TTL_MS` vs the module's 2-minute default* is a
  contention-policy change with blast radius beyond this bead, and `heartbeatBoth`
  already keeps a long create's lease alive. Recorded on the bead rather than
  bundled into a message-clarity fix.

## Testing

- `local-maintenance-gate.test.mjs` — 31/31, two new cases: one pinning the
  refusal detail at the source, one pinning that it survives the composite
  wrapper (the drop that made this invisible).
- `maintenance-gate.test.mjs` — 17/17
- `worktree-lifecycle-create.test.mjs` — ok
- `tsc --noEmit` — clean

Closes cave-8zkkj.