### PR TITLE
fix(worktrees): count a pushed tag as retention in autolock (cave-qbr34)

### DIFF
--- a/scripts/worktree-autolock.mjs
+++ b/scripts/worktree-autolock.mjs
@@ -63,10 +63,26 @@ export function parseWorktrees(porcelain) {
 
 // At risk = a removal would destroy something unrecoverable.
 //   dirty            → uncommitted edits exist nowhere else
-//   commits off-remote → committed but not yet on any remote
-// `rev-list HEAD --not --remotes` counts commits absent from every remote ref,
-// which is the same "retained on a remote" test the guard applies.
-export function riskOf(worktreePath) {
+//   commits off-remote → committed but on neither a remote branch nor a
+//                        remote tag
+//
+// `rev-list HEAD --not --remotes` alone is NOT the test the guard applies, and
+// the comment that claimed it was is how this hook came to fight the
+// documented retirement route (cave-qbr34). `--remotes` is refs/remotes/*,
+// which is remote-tracking BRANCHES; git keeps no remote-tracking refs for tags
+// at all. So a branch retired the recommended way — archived as a pushed tag,
+// then deleted — read as unretained, was re-locked on the next tool call, and
+// could never be removed. Two `beads:worktrees:apply` runs were defeated by
+// exactly this, and WT_AUTOLOCK_DISABLE=1 does not help: the hook fires per
+// tool call, so a unit unlocked in one call is re-locked before the next.
+//
+// The missing half is `remoteTagCommits`, which asks the remote what tags it
+// actually has — the same helper `worktree-retention-push.mjs` already uses for
+// this exact blind spot (cave-nw3hq, where it re-created twelve branches it had
+// just been asked to retire). Note what is deliberately NOT used: `--tags`
+// would count LOCAL tags, and a local-only tag is not retention — it dies with
+// the checkout, which is the hole the guard exists to close.
+export function riskOf(worktreePath, tagRetained = () => false) {
   let dirty = 0;
   let unpushed = 0;
   try {
@@ -82,8 +98,48 @@ export function riskOf(worktreePath) {
   } catch {
     unpushed = 0; // detached/unborn HEAD — dirtiness alone decides
   }
+  // Only asked once the branch test already says "unretained", so a pass with
+  // nothing at risk stays offline. An unreachable remote leaves `unpushed`
+  // standing and the tree locked: a lock is reversible, while treating an
+  // unanswerable question as "retained" hands out the one verdict that permits
+  // destruction.
+  if (unpushed > 0 && tagRetained(worktreePath)) unpushed = 0;
   if (dirty === 0 && unpushed === 0) return null;
   return { dirty, unpushed };
+}
+
+// Commit oids the REMOTE holds under a tag, HEAD included when a tag points at
+// it. `ls-remote` prints both the tag object and its peeled `^{}` commit on
+// separate lines; collecting every oid covers annotated and lightweight tags
+// without having to tell them apart.
+//
+// Deliberately duplicated from `worktree-retention-push.mjs` rather than
+// imported. Every hook in this directory loads standalone — none imports a
+// sibling — and the symlink test copies THIS FILE ALONE into a temp directory
+// to prove the hook still fires. An unresolvable import would throw at load,
+// and a guard that silently never runs is the worst outcome available here
+// (see the isDirectRun comment below). Keep the two in step by hand; both name
+// each other.
+export function remoteTagCommits(worktreePath) {
+  try {
+    const output = git(["ls-remote", "--tags", "origin"], worktreePath);
+    const oids = new Set();
+    for (const line of output.split("\n")) {
+      const oid = line.slice(0, 40);
+      if (/^[0-9a-f]{40}$/.test(oid)) oids.add(oid);
+    }
+    return oids;
+  } catch {
+    return null; // offline or no remote — the caller keeps the tree locked
+  }
+}
+
+export function headShaOf(worktreePath) {
+  try {
+    return git(["rev-parse", "HEAD"], worktreePath).trim() || null;
+  } catch {
+    return null;
+  }
 }
 
 export function reasonFor({ dirty, unpushed }, today) {
@@ -135,10 +191,21 @@ function main() {
     return; // not a git repo, or git unavailable — nothing to do
   }
 
+  // Resolved lazily and at most once per pass, matching the retention-push
+  // hook: only a worktree the branch test already calls unretained needs it, so
+  // a pass where everything is pushed never touches the network.
+  let tagCommits;
+  const tagRetained = (worktreePath) => {
+    if (tagCommits === undefined) tagCommits = remoteTagCommits(root);
+    if (!tagCommits || tagCommits.size === 0) return false;
+    const head = headShaOf(worktreePath);
+    return head !== null && tagCommits.has(head);
+  };
+
   // The first record is the main working tree; git refuses to lock it.
   for (const wt of worktrees.slice(1)) {
     if (wt.locked || wt.bare) continue;
-    const risk = riskOf(wt.path);
+    const risk = riskOf(wt.path, tagRetained);
     if (!risk) continue;
     const today = new Date().toISOString().slice(0, 10);
     try {

--- a/scripts/worktree-autolock.test.mjs
+++ b/scripts/worktree-autolock.test.mjs
@@ -13,7 +13,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseWorktrees, reasonFor, riskOf } from "./worktree-autolock.mjs";
+import {
+  headShaOf,
+  parseWorktrees,
+  reasonFor,
+  remoteTagCommits,
+  riskOf,
+} from "./worktree-autolock.mjs";
 
 const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
 
@@ -205,6 +211,125 @@ try {
     );
   } finally {
     rmSync(box, { recursive: true, force: true });
+  }
+}
+
+// --- a pushed tag is retention, exactly as the guard counts it ---------------
+// cave-qbr34. `--remotes` is remote-tracking BRANCHES; git keeps no
+// remote-tracking refs for tags. So a branch retired the RECOMMENDED way —
+// archived as a pushed tag, then deleted — read as unretained and was re-locked
+// on every tool call, which is what defeated two `beads:worktrees:apply` runs.
+{
+  const scratch = mkdtempSync(path.join(tmpdir(), "autolock-tag-"));
+  try {
+    const origin = path.join(scratch, "origin.git");
+    git(["init", "--quiet", "--bare", "-b", "main", origin], scratch);
+
+    const repo = path.join(scratch, "repo");
+    git(["init", "--quiet", "-b", "main", repo], scratch);
+    writeFileSync(path.join(repo, "seed.txt"), "seed\n");
+    git(["add", "."], repo);
+    git(["commit", "--quiet", "--no-gpg-sign", "-m", "seed"], repo);
+    git(["remote", "add", "origin", origin], repo);
+    git(["push", "--quiet", "origin", "main"], repo);
+
+    git(["checkout", "--quiet", "-b", "fix/archived"], repo);
+    writeFileSync(path.join(repo, "work.txt"), "shipped\n");
+    git(["add", "."], repo);
+    git(["commit", "--quiet", "--no-gpg-sign", "-m", "work"], repo);
+    git(["push", "--quiet", "origin", "fix/archived"], repo);
+    const head = git(["rev-parse", "HEAD"], repo).trim();
+
+    // Retire it the way the docs prescribe: archive tag pushed, branch deleted.
+    git(["tag", "-a", "archive/fix-archived-2026-08-12", "-m", "archive", head], repo);
+    git(["push", "--quiet", "origin", "archive/fix-archived-2026-08-12"], repo);
+    git(["push", "--quiet", "origin", "--delete", "fix/archived"], repo);
+    git(["fetch", "--quiet", "--prune", "origin"], repo);
+
+    // Precondition: the branch-only test still calls this unretained. If this
+    // ever stops holding, the bug is gone for another reason and the assertion
+    // below would be passing vacuously.
+    const branchOnly = riskOf(repo);
+    assert.ok(branchOnly, "precondition: --remotes alone calls a tag-archived head unretained");
+    assert.equal(branchOnly.unpushed, 1);
+
+    // The real lookup, against real `ls-remote` output — the parsing is where
+    // this class of bug lives, so a stub alone would not prove much.
+    const live = remoteTagCommits(repo);
+    assert.ok(live instanceof Set, "the remote answered");
+    assert.equal(headShaOf(repo), head);
+    assert.ok(live.has(head), "ls-remote's peeled ^{} line puts the commit oid in the set");
+    assert.equal(
+      riskOf(repo, (p) => {
+        const oids = remoteTagCommits(p);
+        const h = headShaOf(p);
+        return Boolean(oids && h && oids.has(h));
+      }),
+      null,
+      "wired end to end, a tag-archived head is not locked",
+    );
+
+    // The fix: a tag the REMOTE actually has counts as retention.
+    const remoteTags = new Set([head]);
+    assert.equal(
+      riskOf(repo, () => remoteTags.has(head)),
+      null,
+      "a head held by a pushed tag is retained, so the hook must not lock it",
+    );
+
+    // A LOCAL-only tag must NOT count — it dies with the checkout, which is the
+    // hole the guard exists to close, and is why `--tags` is the wrong fix.
+    git(["tag", "-a", "archive/local-only", "-m", "local", head], repo);
+    const localOnly = riskOf(repo, () => false);
+    assert.ok(localOnly, "a local-only tag is not retention");
+    assert.equal(localOnly.unpushed, 1);
+
+    // An unreachable remote must fail CLOSED: still locked. A lock is
+    // reversible; "retained" is the verdict that permits destruction.
+    //
+    // Break the remote for real. Passing `() => false` here would only restate
+    // the local-only-tag case above and would never touch remoteTagCommits'
+    // failure path, so a regression treating an ls-remote ERROR as "retained"
+    // would sail straight through.
+    const reachable = git(["remote", "get-url", "origin"], repo).trim();
+    git(["remote", "set-url", "origin", path.join(scratch, "no-such-remote.git")], repo);
+    assert.equal(
+      remoteTagCommits(repo),
+      null,
+      "an unreachable remote yields null, not an empty set that could read as 'no tags, so unretained' or worse",
+    );
+    const offline = riskOf(repo, (p) => {
+      const oids = remoteTagCommits(p);
+      const h = headShaOf(p);
+      return Boolean(oids && h && oids.has(h));
+    });
+    assert.ok(offline, "an unanswerable remote leaves the tree locked rather than declaring it safe");
+    assert.equal(offline.unpushed, 1, "the commits stay counted while the answer is unknown");
+    git(["remote", "set-url", "origin", reachable], repo);
+
+    // ...and the same wiring goes back to "retained" once the remote answers,
+    // so the fail-closed branch above is the offline case and not a permanent
+    // lock.
+    assert.equal(
+      riskOf(repo, (p) => {
+        const oids = remoteTagCommits(p);
+        const h = headShaOf(p);
+        return Boolean(oids && h && oids.has(h));
+      }),
+      null,
+      "restoring the remote restores the tag-retained verdict",
+    );
+
+    // Dirtiness is still decisive even when the head is tag-retained: the
+    // uncommitted content exists nowhere else.
+    writeFileSync(path.join(repo, "seed.txt"), "edited\n");
+    touchForward(path.join(repo, "seed.txt"));
+    const dirtyButRetained = riskOf(repo, () => remoteTags.has(head));
+    assert.ok(dirtyButRetained, "uncommitted work is at risk regardless of tag retention");
+    assert.equal(dirtyButRetained.dirty, 1);
+    assert.equal(dirtyButRetained.unpushed, 0);
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
   }
 }
 


### PR DESCRIPTION
## What

`worktree-autolock.mjs` decided "at risk" with

```
git rev-list --count HEAD --not --remotes
```

and a comment claiming this was *"the same 'retained on a remote' test the guard
applies"*. It was not. `--remotes` is `refs/remotes/*` — remote-tracking
**branches**. Git keeps no remote-tracking refs for tags at all. The guard counts
a remote branch **or** a tag pushed to a remote, and archiving as a pushed tag is
this repository's *recommended* way to retire a branch while keeping its commits.

So a worktree retired the documented way read as unretained, was re-locked on the
next tool call, and could never be removed. The hook was fighting the exact route
the docs prescribe. Two `beads:worktrees:apply` runs were defeated by it, and
`WT_AUTOLOCK_DISABLE=1` is no workaround — the hook fires per tool call, so a unit
unlocked in one call is re-locked before the next.

## Changes

`riskOf` takes a `tagRetained` predicate; the hook resolves remote tags lazily,
at most once per pass, so a pass where nothing is at risk stays offline.

## Three judgement calls

**Not `--not --remotes --tags`,** which the bead suggested. `--tags` counts
**local** tags, and a local-only tag is not retention — it dies with the
checkout, and accepting it opens the hole the guard exists to close. A test pins
that case.

**Fails closed.** An unreachable remote leaves the commits counted and the tree
locked. A lock is reversible; "retained" is the verdict that permits destruction,
so it is not the one to guess.

**Duplicated, not imported.** The remote-tag lookup already exists in
`worktree-retention-push.mjs`, and importing it was my first attempt. The
symlink test caught it: every hook in `scripts/` loads standalone, none imports a
sibling, and that test copies `worktree-autolock.mjs` **alone** into a temp
directory to prove the hook still fires. An unresolvable import throws at load,
and — per this file's own comment — a guard that silently never runs is the worst
outcome available. Both copies now name each other.

## Audit

The bead asked whether any other surface makes the same `--remotes`-only
assumption while claiming guard parity. The only other site is
`worktree-retention-push.mjs`, and it is **already correct**: its `unpushedCount`
is `--remotes`-only *on purpose* and composed with `remoteTagCommits`, with a
test citing cave-nw3hq — the incident where this blind spot made that hook
re-create twelve branches it had just been asked to retire.

## Testing

- `worktree-autolock.test.mjs` — ok. New case walks the archive-tag retirement
  route end to end against real `ls-remote` output, and covers the local-only-tag
  rejection, fail-closed behaviour on an unreachable remote, and that dirtiness
  still wins over tag retention.
- `worktree-retention-push.test.mjs` — 10/10
- `worktree-guard.test.mjs` — 10/10
- `tsc --noEmit` — clean

Closes cave-qbr34.