### PR TITLE
chore(release): stamp v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ breaking config changes; patch releases stay additive.
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-08-12
+
+> A maintenance patch for the worktree lifecycle tooling: retention now counts a
+> pushed tag, a refused maintenance fence says what to do about it, and project
+> deletion cleans up after itself.
+
+Patch release on top of v0.3.2. No user-facing surface changed; this is operator
+tooling plus one API correctness fix.
+
+### Fixed
+
+- The worktree auto-lock now counts a **pushed tag** as retention, matching the
+  guard it claimed to mirror. It had used `git rev-list --count HEAD --not
+  --remotes`, which consults only remote-tracking *branches* — git keeps no
+  remote-tracking refs for tags — so a branch archived as a pushed tag was still
+  treated as at-risk (#4573).
+- A refused maintenance fence now explains itself and prints the admissible
+  rerun instead of failing with an opaque message (#4572).
+- Deleting a project now cascades correctly, the worktree lifecycle patrol
+  reports managed-creation exceptions, and a flaky standalone-budget assertion
+  was stabilised (#4567).
+
 ## [0.3.2] - 2026-08-12
 
 > A maintenance patch: worktree-lifecycle reporting states a repository-wide

--- a/apps/ios/CovenCave/project.yml
+++ b/apps/ios/CovenCave/project.yml
@@ -7,7 +7,7 @@ options:
   groupSortPosition: top
 settings:
   base:
-    MARKETING_VERSION: "0.3.2"
+    MARKETING_VERSION: "0.3.3"
     # Build number, YYYYMMDDHH in UTC. App Store Connect requires this to be
     # unique and increasing for the app, and a hand-kept "1" collides on every
     # upload after the first (it rejected the v0.2.3 upload on 2026-08-03).
@@ -15,7 +15,7 @@ settings:
     # `scripts/stamp-release.mjs` refreshes this alongside MARKETING_VERSION on
     # every cut — a release stamp that moved only the marketing version is how
     # v0.2.3 shipped a build number App Store Connect had already seen.
-    CURRENT_PROJECT_VERSION: "2026081209"
+    CURRENT_PROJECT_VERSION: "2026081213"
     SWIFT_VERSION: "5.0"
     DEVELOPMENT_TEAM: "9LR8Z8UQ9X"
     CODE_SIGN_STYLE: Automatic

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "coven-cave",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "description": "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions.",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,7 +77,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "block2",
  "discord-rich-presence",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.2"
+version = "0.3.3"
 description = "Desktop control room for OpenCoven familiars, workflows, memory, and local agent sessions."
 authors = ["OpenCoven contributors"]
 license = "MIT OR AGPL-3.0-only"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "CovenCave",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "ai.opencoven.cave",
   "build": {
     "frontendDist": "../src-tauri/frontend-stub",


### PR DESCRIPTION
Stamps v0.3.3 across the five version manifests and finalizes the CHANGELOG section.

Patch release on top of v0.3.2, carrying three ops-hygiene fixes:

- #4573 — worktree auto-lock counts a pushed tag as retention
- #4572 — maintenance fence refusal is actionable
- #4567 — project DELETE cascade, patrol exception report, flake fix

Publishes nothing on its own. The `v0.3.3` tag push is a separate, explicit step.

## Verification

- `pnpm release:verify --version 0.3.3` — verified across five manifests and the finalized changelog
- `src/lib/app-version.test.ts` — ok

## Settings access check (v0.3.0 regression guard)

Confirmed on this commit's base that Settings is **not** access-token gated:

- `src/proxy.ts` has no `mobileAccessGate` / `ACCESS_TOKEN_COOKIE` / `ACCESS_TOKEN_QUERY_PARAM` (all present in v0.3.0)
- `GET /settings` returns 200 with no token or cookie; no `<form>`, no access-token markers in the HTML
- Real browser load of `/settings` renders every section with zero 401/403 responses

The only remaining gate is passkey presence, which requires `COVEN_CAVE_PASSKEY_REQUIRED=1` **and** remote ingress, so loopback/desktop is unaffected.