### PR TITLE
fix(chat): expose Cave image attachments to familiar image tools (cave-cxwgy)

### DIFF
--- a/docs/familiar-identity-context.md
+++ b/docs/familiar-identity-context.md
@@ -1,8 +1,8 @@
 # Familiar identity context
 
-How a familiar's declared identity — `SOUL.md`, `IDENTITY.md`, and (for voice)
-`MEMORY.md` — reaches the model, and what that injection is explicitly *not*
-allowed to do.
+How a familiar's declared identity — `SOUL.md`, `IDENTITY.md`, familiar-local
+skill entrypoints, and (for voice) `MEMORY.md` — reaches the model, and what
+that injection is explicitly *not* allowed to do.
 
 Implementation: [`src/lib/server/familiar-contract-context.ts`](../src/lib/server/familiar-contract-context.ts).
 Consumers: the chat route (`src/app/api/chat/send/route.ts`) and voice
@@ -38,6 +38,7 @@ Both surfaces now share one builder, so the two cannot drift apart again.
 | --- | --- | --- |
 | `SOUL.md` | yes | yes |
 | `IDENTITY.md` | yes | yes |
+| `skills/*/SKILL.md` entrypoint index | yes | yes |
 | `MEMORY.md` | **no** | yes (`includeMemory: true`) |
 | `ward.toml` | never | never |
 
@@ -52,6 +53,12 @@ Both surfaces now share one builder, so the two cannot drift apart again.
 - **`ward.toml` is never inlined.** It is policy configuration carrying the
   `[protected]` file list and the invariants that bound self-modification.
   Injecting it hands the familiar the rules written to constrain it.
+- **Familiar-local skills are indexed, not inlined.** The block lists only
+  real `skills/<id>/SKILL.md` files contained by the familiar workspace and
+  states that a familiar-local same-name skill outranks a generic copy. This
+  lets the harness load the declared procedure from an already-granted root
+  without flooding every turn with every skill body. Symlink escapes are
+  omitted.
 
 ### Placement in the prompt
 

--- a/src/app/api/chat/send/chat-send-attachments.ts
+++ b/src/app/api/chat/send/chat-send-attachments.ts
@@ -1,5 +1,4 @@
-import { mkdir, realpath, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { chmod, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   cleanMediaDataUrl,
@@ -12,7 +11,6 @@ import {
   sweepChatImageAttachments,
 } from "@/lib/server/chat-attachment-store";
 
-const ATTACHMENT_TMP_DIR = path.join(tmpdir(), "coven-cave-attachments");
 const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
   jpeg: "jpg",
   "svg+xml": "svg",
@@ -25,29 +23,57 @@ function imageExtension(mimeType?: string): string {
   return /^[a-z0-9]{1,8}$/.test(mapped) ? mapped : "img";
 }
 
-/** Write validated image payloads to owner-only files for local harnesses. */
-export async function writeImageAttachmentsToTemp(
+export type ImageAttachmentDelivery = {
+  filePaths: Map<number, string>;
+  stagingDir: string | null;
+};
+
+/**
+ * Write validated image payloads to an owner-only directory inside a root the
+ * runtime already grants. A path in the OS temp directory is not enough: the
+ * chat boundary and harness sandbox both reject it, even if Cave can write it.
+ */
+export async function writeImageAttachmentsToWorkspace(
   attachments: ChatAttachment[],
-): Promise<Map<number, string>> {
+  deliveryRoot: string,
+): Promise<ImageAttachmentDelivery> {
   const filePaths = new Map<number, string>();
+  const eligible = attachments.some(
+    (attachment) => attachment.dataUrl && attachment.mimeType?.startsWith("image/"),
+  );
+  if (!eligible) return { filePaths, stagingDir: null };
+
+  let stagingDir: string | null = null;
+  try {
+    const root = await realpath(deliveryRoot);
+    if (!(await stat(root)).isDirectory()) return { filePaths, stagingDir: null };
+    stagingDir = await mkdtemp(path.join(root, ".coven-cave-attachments-"));
+    await chmod(stagingDir, 0o700);
+  } catch {
+    return { filePaths, stagingDir: null };
+  }
+
   for (const [index, attachment] of attachments.entries()) {
     if (!attachment.dataUrl || !attachment.mimeType?.startsWith("image/")) continue;
     const base64 = attachment.dataUrl.slice(attachment.dataUrl.indexOf(",") + 1);
     const payload = Buffer.from(base64, "base64");
     if (payload.byteLength === 0 || payload.byteLength > MAX_ATTACHMENT_IMAGE_BYTES) continue;
     try {
-      await mkdir(ATTACHMENT_TMP_DIR, { recursive: true, mode: 0o700 });
       const filePath = path.join(
-        ATTACHMENT_TMP_DIR,
+        stagingDir,
         `${crypto.randomUUID()}.${imageExtension(attachment.mimeType)}`,
       );
-      await writeFile(filePath, payload, { mode: 0o600 });
+      await writeFile(filePath, payload, { mode: 0o600, flag: "wx" });
       filePaths.set(index, filePath);
     } catch {
       // Best effort: callers render a not-delivered attachment notice instead.
     }
   }
-  return filePaths;
+  if (filePaths.size === 0) {
+    await rm(stagingDir, { recursive: true, force: true }).catch(() => undefined);
+    return { filePaths, stagingDir: null };
+  }
+  return { filePaths, stagingDir };
 }
 
 /**
@@ -88,10 +114,9 @@ export async function persistImageAttachments(
   return stored;
 }
 
-export function cleanupImageTempFiles(filePaths: ReadonlyMap<number, string>) {
-  for (const filePath of filePaths.values()) {
-    void rm(filePath, { force: true }).catch(() => undefined);
-  }
+export async function cleanupImageAttachmentDelivery(delivery: ImageAttachmentDelivery) {
+  if (!delivery.stagingDir) return;
+  await rm(delivery.stagingDir, { recursive: true, force: true }).catch(() => undefined);
 }
 
 /**

--- a/src/app/api/chat/send/chat-send-attachments.ts
+++ b/src/app/api/chat/send/chat-send-attachments.ts
@@ -1,4 +1,4 @@
-import { chmod, mkdtemp, realpath, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, lstat, mkdtemp, readdir, realpath, rm, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   cleanMediaDataUrl,
@@ -16,6 +16,47 @@ const IMAGE_EXT_BY_SUBTYPE: Record<string, string> = {
   "svg+xml": "svg",
 };
 const MAX_MENTIONED_FILES = 10;
+const STAGING_PREFIX = ".coven-cave-attachments-";
+/** Old enough that no live turn could still be reading it. */
+const STAGING_MAX_AGE_MS = 60 * 60 * 1000;
+const STAGING_SWEEP_SCAN_LIMIT = 200;
+
+/**
+ * Remove staging directories a previous turn left behind.
+ *
+ * `cleanupImageAttachmentDelivery` runs at ONE site, near the end of the chat
+ * stream callback, and nothing wraps that callback in `finally` — so a throw
+ * anywhere above it skips cleanup. That used to be harmless because the copies
+ * lived in OS temp storage, which the system reaps; now they live inside the
+ * familiar's granted workspace, where they are user-visible, readable by the
+ * familiar, and reaped by nobody. `sweepChatImageAttachments` does not cover
+ * them: it matches FILES named like an attachment id in the persistent store,
+ * never directories in a workspace.
+ *
+ * Sweeping on the next delivery is self-healing and stays local to this module,
+ * rather than restructuring a 2,700-line stream callback around a try/finally.
+ */
+async function sweepStaleStagingDirs(root: string, now = Date.now()): Promise<void> {
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    for (const entry of entries.slice(0, STAGING_SWEEP_SCAN_LIMIT)) {
+      if (!entry.isDirectory() || !entry.name.startsWith(STAGING_PREFIX)) continue;
+      const target = path.join(root, entry.name);
+      try {
+        const meta = await lstat(target);
+        // A symlink wearing the staging prefix is not ours; following it would
+        // delete whatever it points at.
+        if (meta.isSymbolicLink()) continue;
+        if (now - meta.mtimeMs <= STAGING_MAX_AGE_MS) continue;
+        await rm(target, { recursive: true, force: true });
+      } catch {
+        // Skip anything that races us.
+      }
+    }
+  } catch {
+    // Unreadable root — the delivery below will fail closed on its own.
+  }
+}
 
 function imageExtension(mimeType?: string): string {
   const subtype = mimeType?.split("/")[1]?.toLowerCase() ?? "";
@@ -47,7 +88,8 @@ export async function writeImageAttachmentsToWorkspace(
   try {
     const root = await realpath(deliveryRoot);
     if (!(await stat(root)).isDirectory()) return { filePaths, stagingDir: null };
-    stagingDir = await mkdtemp(path.join(root, ".coven-cave-attachments-"));
+    await sweepStaleStagingDirs(root);
+    stagingDir = await mkdtemp(path.join(root, STAGING_PREFIX));
     await chmod(stagingDir, 0o700);
   } catch {
     return { filePaths, stagingDir: null };

--- a/src/app/api/chat/send/chat-send-image-persistence.test.ts
+++ b/src/app/api/chat/send/chat-send-image-persistence.test.ts
@@ -4,19 +4,23 @@
 // behind a durable copy whose id the transcript keeps.
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, readdirSync, rmSync } from "node:fs";
-import { readFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, relative } from "node:path";
 
 const ROOT = mkdtempSync(join(tmpdir(), "chat-send-image-persistence-"));
+const DELIVERY_ROOT = mkdtempSync(join(tmpdir(), "chat-send-image-delivery-root-"));
 process.env.COVEN_CAVE_CHAT_ATTACHMENTS_DIR = ROOT;
 
-const { persistImageAttachments } = await import("./chat-send-attachments.ts");
+const attachmentDelivery = await import("./chat-send-attachments.ts");
+const { persistImageAttachments } = attachmentDelivery;
 const { normalizeChatAttachments, stripPreviewOnlyAttachmentFields, chatAttachmentSrc } =
   await import("@/lib/chat-attachments");
 
-after(() => rmSync(ROOT, { recursive: true, force: true }));
+after(() => {
+  rmSync(ROOT, { recursive: true, force: true });
+  rmSync(DELIVERY_ROOT, { recursive: true, force: true });
+});
 
 const PIXEL_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
@@ -28,6 +32,29 @@ const IMAGE = {
   dataUrl: `data:image/png;base64,${PIXEL_B64}`,
 };
 const TEXT_FILE = { name: "notes.txt", type: "text/plain", size: 12, text: "hello there" };
+
+test("image-tool delivery stays inside the explicitly granted workspace root", async () => {
+  assert.equal(
+    typeof attachmentDelivery.writeImageAttachmentsToWorkspace,
+    "function",
+    "the delivery helper must accept a granted root instead of choosing OS temp storage",
+  );
+  assert.equal(typeof attachmentDelivery.cleanupImageAttachmentDelivery, "function");
+
+  const delivery = await attachmentDelivery.writeImageAttachmentsToWorkspace(
+    normalizeChatAttachments([IMAGE, TEXT_FILE]),
+    DELIVERY_ROOT,
+  );
+  const imagePath = delivery.filePaths.get(0);
+  assert.ok(imagePath, "the image receives a file path");
+  const rel = relative(realpathSync(DELIVERY_ROOT), imagePath);
+  assert.ok(rel && rel !== ".." && !rel.startsWith(`..${process.platform === "win32" ? "\\" : "/"}`));
+  assert.deepEqual(readFileSync(imagePath), Buffer.from(PIXEL_B64, "base64"));
+  assert.equal(statSync(imagePath).mode & 0o777, 0o600, "the staged image stays owner-only");
+
+  await attachmentDelivery.cleanupImageAttachmentDelivery(delivery);
+  assert.equal(existsSync(delivery.stagingDir), false, "cleanup removes the private staging directory");
+});
 
 test("an image gains a storedId while its payload stays out of the transcript", async () => {
   const attachments = normalizeChatAttachments([IMAGE, TEXT_FILE]);

--- a/src/app/api/chat/send/chat-send-image-persistence.test.ts
+++ b/src/app/api/chat/send/chat-send-image-persistence.test.ts
@@ -4,7 +4,18 @@
 // behind a durable copy whose id the transcript keeps.
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative } from "node:path";
 
@@ -139,6 +150,48 @@ test("a turn with no images does no store work", async () => {
   );
   assert.deepEqual(persisted, stripPreviewOnlyAttachmentFields(attachments));
   assert.equal(readdirSync(ROOT).length, before, "nothing was written");
+});
+
+// A staging directory that a previous turn failed to clean up must not survive
+// in the familiar's workspace. `cleanupImageAttachmentDelivery` runs at ONE site
+// near the end of the chat stream callback with no `finally` around it, so any
+// throw above that line skips it. The old code leaked into OS temp storage,
+// which the system reaps; this leaks into a granted workspace, which nothing
+// reaps -- `sweepChatImageAttachments` only matches FILES named like an
+// attachment id in the persistent store, never directories in a workspace.
+test("a stale staging directory from a crashed turn is swept on the next delivery", async () => {
+  const root = realpathSync(DELIVERY_ROOT);
+
+  // Old enough to be unambiguously abandoned, and holding a real payload so the
+  // assertion is about user content rather than an empty husk.
+  const stale = join(root, ".coven-cave-attachments-stale");
+  mkdirSync(stale, { recursive: true, mode: 0o700 });
+  writeFileSync(join(stale, "leaked.png"), Buffer.from(PIXEL_B64, "base64"), { mode: 0o600 });
+  const twoHoursAgo = new Date(Date.now() - 2 * 60 * 60 * 1000);
+  utimesSync(stale, twoHoursAgo, twoHoursAgo);
+
+  // A directory from a turn that could still be running must be left alone.
+  const fresh = join(root, ".coven-cave-attachments-fresh");
+  mkdirSync(fresh, { recursive: true, mode: 0o700 });
+
+  // An unrelated dot-directory must never be touched, however old.
+  const bystander = join(root, ".git-ish");
+  mkdirSync(bystander, { recursive: true });
+  utimesSync(bystander, twoHoursAgo, twoHoursAgo);
+
+  const delivery = await attachmentDelivery.writeImageAttachmentsToWorkspace(
+    normalizeChatAttachments([IMAGE]),
+    DELIVERY_ROOT,
+  );
+
+  assert.equal(existsSync(stale), false, "the abandoned staging directory is swept");
+  assert.equal(existsSync(fresh), true, "a recent staging directory is left for its live turn");
+  assert.equal(existsSync(bystander), true, "unrelated directories are never swept");
+  assert.ok(delivery.stagingDir, "the sweep does not prevent this turn's delivery");
+
+  await attachmentDelivery.cleanupImageAttachmentDelivery(delivery);
+  rmSync(fresh, { recursive: true, force: true });
+  rmSync(bystander, { recursive: true, force: true });
 });
 
 console.log("chat-send-image-persistence.test.ts: ok");

--- a/src/app/api/chat/send/harness-routing-attachments.test.ts
+++ b/src/app/api/chat/send/harness-routing-attachments.test.ts
@@ -52,8 +52,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /imagesSupported\s*\?\s*await writeImageAttachmentsToTemp\(attachments\)/,
-  "Image payloads should be written to temp files before the harness prompt is built",
+  /imagesSupported\s*\?\s*await writeImageAttachmentsToWorkspace\(\s*attachments,\s*resolvedFamiliarWorkspace \?\? cwd,\s*\)/,
+  "Image payloads should be written inside a root the runtime already grants",
 );
 
 assert.match(
@@ -110,8 +110,8 @@ assert.match(
 
 assert.match(
   attachmentDelivery,
-  /await writeFile\(filePath, payload, \{ mode: 0o600 \}\)/,
-  "Saved image payloads should be private temp files (mode 0600)",
+  /await writeFile\(filePath, payload, \{ mode: 0o600, flag: "wx" \}\)/,
+  "Saved image payloads should be private, exclusively-created files (mode 0600)",
 );
 
 assert.match(
@@ -122,8 +122,8 @@ assert.match(
 
 assert.match(
   chatRoute,
-  /cleanupImageTempFiles\(imageFilePaths\);/,
-  "Image temp files should be best-effort deleted after the harness child has exited",
+  /cleanupImageAttachmentDelivery\(imageDelivery\);/,
+  "The workspace-local staging directory should be deleted after the harness child has exited",
 );
 
 // The transcript still never receives a base64 payload. Since cave-cysu4 the
@@ -176,7 +176,7 @@ const smallPng = `data:image/png;base64,${Buffer.from("png-payload-bytes").toStr
   const attachments = normalizeChatAttachments([
     { name: "shot.png", type: "image/png", mimeType: "image/png", size: 17, dataUrl: smallPng },
   ]);
-  const savedPath = "/tmp/coven-cave-attachments/00000000-0000-0000-0000-000000000000.png";
+  const savedPath = "/workspace/.coven-cave-attachments-000000/00000000-0000-0000-0000-000000000000.png";
   const withPath = buildPromptWithAttachments("Look at this.", attachments, {
     imagesSupported: true,
     imageFilePaths: new Map([[0, savedPath]]),

--- a/src/app/api/chat/send/offline-queue.test.ts
+++ b/src/app/api/chat/send/offline-queue.test.ts
@@ -59,15 +59,23 @@ const queueIndex = chatRoute.indexOf(
   "const offlineChatResponse = await maybeQueueOfflineChat",
   postIndex,
 );
-const imageWriteIndex = chatRoute.indexOf("writeImageAttachmentsToTemp", queueIndex);
+const imageWriteIndex = chatRoute.indexOf("writeImageAttachmentsToWorkspace", queueIndex);
 const harnessPromptIndex = chatRoute.indexOf("const harnessPrompt =", queueIndex);
 
 assert.ok(postIndex >= 0, "Chat send POST handler should exist");
 assert.ok(accessIndex >= 0, "Chat send should still run the project launch gate");
 assert.ok(queueIndex > accessIndex, "Offline queueing must run after project launch authorization");
+// Checked separately from the ordering below: `indexOf` returns -1 when the
+// symbol is renamed, and `queueIndex < -1` then fails as an ORDERING violation,
+// which sends the next reader looking for a reordered handler that is fine.
+// cave-cxwgy renamed this helper and cost exactly that detour.
+assert.ok(
+  imageWriteIndex >= 0,
+  "Image staging call not found in the chat route — if it was renamed, update this probe",
+);
 assert.ok(
   queueIndex < imageWriteIndex,
-  "Offline queueing should run before image temp-file writes",
+  "Offline queueing should run before image staging writes",
 );
 assert.ok(
   queueIndex < harnessPromptIndex,

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -266,10 +266,10 @@ import type { StreamEvent } from "@/lib/stream-events";
 import { deriveTravelClientStatus } from "@/lib/travel-client-state";
 import {
   appendMentionedFilesBlock,
-  cleanupImageTempFiles,
+  cleanupImageAttachmentDelivery,
   persistImageAttachments,
   resolveMentionedFiles,
-  writeImageAttachmentsToTemp,
+  writeImageAttachmentsToWorkspace,
 } from "./chat-send-attachments";
 import {
   covenRunSupportsAddDir,
@@ -2486,14 +2486,20 @@ export async function POST(req: Request) {
   });
   if (offlineChatResponse) return offlineChatResponse;
 
-  // Image delivery channel: only harnesses that can read Cave's local temp
-  // files may receive image paths. Remote Hermes Responses endpoints cannot,
+  // Image delivery channel: only harnesses that can read Cave's local files
+  // may receive image paths. Remote Hermes Responses endpoints cannot,
   // so they receive the same explicit unsupported notice as bridge/SSH runs.
   const imagesSupported = !sshRuntime && binding.harness !== "openclaw" &&
     !(hermesApi && !hermesApiCanAccessLocalFiles(hermesApi));
-  const imageFilePaths = imagesSupported
-    ? await writeImageAttachmentsToTemp(attachments)
-    : new Map<number, string>();
+  // The copy must live inside a root already present in the runtime boundary.
+  // OS temp storage is Cave-readable but denied to the familiar and its tools.
+  const imageDelivery = imagesSupported
+    ? await writeImageAttachmentsToWorkspace(
+        attachments,
+        resolvedFamiliarWorkspace ?? cwd,
+      )
+    : { filePaths: new Map<number, string>(), stagingDir: null };
+  const imageFilePaths = imageDelivery.filePaths;
   // @-mentioned files share the image-delivery constraint: only local
   // coven-run harnesses can Read this machine's filesystem, so bridges and
   // SSH runtimes never get a block of unreachable absolute paths.
@@ -5609,10 +5615,11 @@ export async function POST(req: Request) {
         ...(result.costUsd !== undefined ? { costUsd: result.costUsd } : {}),
         responseMetadata,
       });
-      // Best-effort temp cleanup: the harness child process has already
+      // Best-effort staging cleanup: the harness child process has already
       // exited (including any resume retry), so nothing can still be reading
-      // the saved images. Failures just leave files in tmpdir.
-      cleanupImageTempFiles(imageFilePaths);
+      // the saved images. Await it so a successful turn leaves no transient
+      // directory behind in the familiar workspace.
+      await cleanupImageAttachmentDelivery(imageDelivery);
       if (detachKillTimer != null) clearTimeout(detachKillTimer);
       unregisterChatRun(runHandle);
       runBuffer?.finish();

--- a/src/lib/server/familiar-contract-context.test.ts
+++ b/src/lib/server/familiar-contract-context.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync, symlinkSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -26,8 +26,9 @@ const FAMILIAR_ID = "milo";
 
 function writeContractFile(name: string, content: string, familiarId = FAMILIAR_ID) {
   const dir = join(TMP, ".coven", "workspaces", "familiars", familiarId);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, name), content);
+  const target = join(dir, name);
+  mkdirSync(join(target, ".."), { recursive: true });
+  writeFileSync(target, content);
 }
 
 function repoFile(relative: string): string {
@@ -49,6 +50,38 @@ test("SOUL.md and IDENTITY.md are inlined under FAMILIAR_CONTRACT", async () => 
   assert.match(block, /My purpose is scouting\./);
   assert.match(block, /## IDENTITY\.md/);
   assert.match(block, /\*\*Creature:\*\* fox/);
+});
+
+test("familiar-local skill entrypoints outrank generic same-name skills", async () => {
+  writeContractFile("SOUL.md", "## I am Milo", "skilled");
+  writeContractFile(
+    "skills/imagegen/SKILL.md",
+    "---\nname: imagegen\ndescription: Milo's boundary-safe image workflow.\n---\n",
+    "skilled",
+  );
+
+  const block = await buildFamiliarContractBlock("skilled");
+  assert.match(block, /## Familiar-local skills/);
+  assert.match(block, /skills\/imagegen\/SKILL\.md/);
+  assert.match(block, /local same-name skill takes precedence over a generic skill/);
+});
+
+test("a symlinked skills root cannot advertise entrypoints outside the familiar workspace", async (t) => {
+  writeContractFile("SOUL.md", "## I am Milo", "skill-escape");
+  const workspace = join(TMP, ".coven", "workspaces", "familiars", "skill-escape");
+  const outside = join(TMP, "outside-familiar-skills");
+  mkdirSync(join(outside, "imagegen"), { recursive: true });
+  writeFileSync(join(outside, "imagegen", "SKILL.md"), "---\nname: imagegen\n---\n");
+  try {
+    symlinkSync(outside, join(workspace, "skills"), process.platform === "win32" ? "junction" : "dir");
+  } catch (error) {
+    t.skip(`symlink unavailable: ${error instanceof Error ? error.message : String(error)}`);
+    return;
+  }
+
+  const block = await buildFamiliarContractBlock("skill-escape");
+  assert.doesNotMatch(block, /outside-familiar-skills/);
+  assert.doesNotMatch(block, /## Familiar-local skills/);
 });
 
 test("chat omits MEMORY.md by default; voice opts in", async () => {

--- a/src/lib/server/familiar-contract-context.ts
+++ b/src/lib/server/familiar-contract-context.ts
@@ -47,11 +47,15 @@ import {
   isValidFamiliarId,
   readFamiliarContractFiles,
 } from "@/lib/server/familiar-contract-files";
+import { readdir, realpath, stat } from "node:fs/promises";
+import path from "node:path";
 
 /** Per-file clamp for SOUL.md / IDENTITY.md — core identity, kept generous. */
 export const FAMILIAR_CONTRACT_FILE_CHARS = 6_000;
 /** Clamp for MEMORY.md, which drifts and can grow without bound. */
 export const FAMILIAR_CONTRACT_MEMORY_CHARS = 4_000;
+const MAX_FAMILIAR_LOCAL_SKILLS = 64;
+const SAFE_SKILL_ID = /^[a-z0-9][a-z0-9._-]{0,79}$/i;
 
 export const FAMILIAR_CONTRACT_OPEN = "<FAMILIAR_CONTRACT>";
 export const FAMILIAR_CONTRACT_CLOSE = "</FAMILIAR_CONTRACT>";
@@ -138,6 +142,61 @@ function section(heading: string, body: string, cap: number): string {
   return `## ${heading}\n${defangContractSentinels(clampContractBlock(body, cap))}`;
 }
 
+async function familiarLocalSkillsSection(workspace: string): Promise<{
+  section: string | null;
+  loaded: string[];
+}> {
+  const skillsRoot = path.join(workspace, "skills");
+  let root: string;
+  let entries;
+  try {
+    const workspaceRoot = await realpath(workspace);
+    root = await realpath(skillsRoot);
+    const relativeRoot = path.relative(workspaceRoot, root);
+    if (
+      !relativeRoot ||
+      relativeRoot === ".." ||
+      relativeRoot.startsWith(`..${path.sep}`) ||
+      path.isAbsolute(relativeRoot)
+    ) {
+      return { section: null, loaded: [] };
+    }
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return { section: null, loaded: [] };
+  }
+
+  const rows: string[] = [];
+  const loaded: string[] = [];
+  for (const entry of entries
+    .filter((candidate) => SAFE_SKILL_ID.test(candidate.name))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .slice(0, MAX_FAMILIAR_LOCAL_SKILLS)) {
+    const declaredPath = path.join(root, entry.name, "SKILL.md");
+    try {
+      const resolved = await realpath(declaredPath);
+      const relative = path.relative(root, resolved);
+      if (!relative || relative === ".." || relative.startsWith(`..${path.sep}`) || path.isAbsolute(relative)) {
+        continue;
+      }
+      if (!(await stat(resolved)).isFile()) continue;
+      rows.push(`- ${entry.name}: ${resolved}`);
+      loaded.push(`skills/${entry.name}/SKILL.md`);
+    } catch {
+      // Missing, unreadable, or out-of-boundary skill entrypoints are omitted.
+    }
+  }
+  if (rows.length === 0) return { section: null, loaded: [] };
+  return {
+    section: [
+      "## Familiar-local skills",
+      "These are this familiar's declared skill entrypoints. When a task matches one, load this workspace-local copy before acting; a local same-name skill takes precedence over a generic skill unless the user explicitly requests the generic copy.",
+      ...rows,
+    ].join("\n"),
+    loaded,
+  };
+}
+
 export type FamiliarContractBlockOptions = {
   /**
    * Include MEMORY.md. Voice sets this: a realtime brain has no other memory
@@ -174,12 +233,13 @@ export async function buildFamiliarContractContext(
 ): Promise<FamiliarContractContext> {
   const empty: FamiliarContractContext = { block: null, loaded: [], clamped: [] };
   if (!familiarId || !isValidFamiliarId(familiarId)) return empty;
-  let files: Awaited<ReturnType<typeof readFamiliarContractFiles>>["files"];
+  let contract: Awaited<ReturnType<typeof readFamiliarContractFiles>>;
   try {
-    ({ files } = await readFamiliarContractFiles(familiarId));
+    contract = await readFamiliarContractFiles(familiarId);
   } catch {
     return empty;
   }
+  const { files, workspace } = contract;
 
   const sections: string[] = [];
   const loaded: string[] = [];
@@ -194,6 +254,11 @@ export async function buildFamiliarContractContext(
   if (files.identity?.trim()) add("IDENTITY.md", files.identity, FAMILIAR_CONTRACT_FILE_CHARS);
   if (options.includeMemory && files.memory?.trim()) {
     add("MEMORY.md", files.memory, FAMILIAR_CONTRACT_MEMORY_CHARS);
+  }
+  const localSkills = await familiarLocalSkillsSection(workspace);
+  if (localSkills.section) {
+    sections.push(localSkills.section);
+    loaded.push(...localSkills.loaded);
   }
   if (sections.length === 0) return empty;
 


### PR DESCRIPTION
## The bug

An uploaded Cave image was written to the OS temp directory, but the familiar
runtime boundary denies tmp. The bytes existed at a path the harness was never
granted, so a familiar's image tools could not read the user's own attachment.

A second cause compounded it: Charm's workspace-local imagegen skill already
existed, but familiar-local skill entrypoints were never surfaced in the chat
prompt, so the generic out-of-boundary copy won every time.

## Changes

**Staging moves inside the boundary.** `writeImageAttachmentsToWorkspace`
replaces `writeImageAttachmentsToTemp` and stages owner-only copies under a root
the runtime already grants (`resolvedFamiliarWorkspace ?? cwd`), removing the
directory once the harness exits. `mkdtemp` under a realpathed root, `0o700` on
the directory, `0o600` plus the `wx` exclusive flag per file so a pre-planted
symlink cannot be written through.

**Familiar-local skills become visible.** The familiar contract now indexes
contained `SKILL.md` entrypoints with local-over-generic precedence and
symlink-escape rejection.

**A leak path found in review, fixed here.** See below — it is the reason for
the second commit.

## The review finding

Moving staging out of tmp fixed delivery but changed what a leak costs, and the
leak path was still open.

`cleanupImageAttachmentDelivery` runs at exactly ONE site near the end of the
chat stream callback, and nothing wraps that callback in `finally`, so a throw
above that line skips it. That used to be harmless: abandoned copies sat in OS
temp storage, which the system reaps and no user sees. After this change they
sit in the familiar's granted workspace as `.coven-cave-attachments-*`
directories — user-visible, readable by the familiar, holding the user's images,
and reaped by nobody. `sweepChatImageAttachments` does not cover them: it matches
FILES named like an attachment id in the persistent store, so both of its filters
miss a directory in a workspace.

Fixed by sweeping stale staging directories at the start of the next delivery,
rather than restructuring a 2,700-line callback around a try/finally. Self-healing
and local to the module that creates them. Conservative by construction: same
realpathed root, staging prefix only, directories only, never a symlink wearing
the prefix, only past a one-hour age so a live turn's directory survives, capped
scan, all failures swallowed so a sweep can never break a turn.

## Provenance

The first commit preserves a prior session's work, which was complete and
verified but left **uncommitted on a local-only branch** — one `rm -rf` from
gone, in a checkout where a sweep destroyed a live worktree earlier the same day.
Committing and pushing it came before reviewing it, deliberately. The review then
produced the second commit.

## Testing

Re-run rather than inherited from the prior session's report:

- `chat-send-image-persistence` — 7/7, including the new sweep case (abandoned
  directory swept, fresh one kept, unrelated dot-directory untouched, delivery
  still succeeds). Mutation-checked: removing the sweep call fails it.
- `familiar-contract-context` — 26/26
- `harness-routing-attachments` — exit 0
- `tsc --noEmit` — clean
- `pnpm lint` — clean
- `pnpm check:tests-wired` — all 1625 wired
- `git diff --check` — clean

Known unrelated baseline failure, reported by the prior session and not
re-investigated here: `src/lib/use-surface-history.test.tsx` fails 12/12 with
`TypeError: act is not a function`, with zero diff from `origin/main` in that
test, its hook, `package.json`, or the lockfile.

Closes cave-cxwgy.