### PR TITLE
Default Research Desk short videos to ElevenLabs Rachel

### DIFF
--- a/src/components/role-surfaces/research-tab-studio.tsx
+++ b/src/components/role-surfaces/research-tab-studio.tsx
@@ -265,6 +265,10 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
     setCreateError(null);
     setDirections("");
     if (!isResearchGenerationKind(kind) && readiness) {
+      const elevenLabsShortVideoDefaultIsReady =
+        kind === "short-video" &&
+        readiness.providers.elevenlabs.ready &&
+        readiness.providers.elevenlabs.defaultVoiceId.trim().length > 0;
       const localSelectionIsValid =
         mediaProvider === "local" &&
         readiness.providers.local.ready &&
@@ -275,7 +279,10 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
         mediaProvider === "elevenlabs" &&
         readiness.providers.elevenlabs.ready &&
         mediaVoice.trim().length > 0;
-      if (!localSelectionIsValid && !elevenLabsSelectionIsValid) {
+      if (elevenLabsShortVideoDefaultIsReady) {
+        setMediaProvider("elevenlabs");
+        setMediaVoice(readiness.providers.elevenlabs.defaultVoiceId);
+      } else if (!localSelectionIsValid && !elevenLabsSelectionIsValid) {
         const firstLocalVoice = readiness.providers.local.voices[0];
         if (readiness.providers.local.ready && firstLocalVoice) {
           setMediaProvider("local");
@@ -285,7 +292,7 @@ export function ResearchTabStudio({ research, context, onNavigate }: ResearchTab
           setMediaVoice(readiness.providers.elevenlabs.defaultVoiceId);
         }
       }
-      if (kind === "short-video" && mediaLength === "extended") {
+      if (kind === "short-video") {
         setMediaLength("standard");
       }
     }

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test, type Page } from "@playwright/test";
+import { DEFAULT_ELEVENLABS_VOICE_ID } from "../src/lib/voice/elevenlabs-shared";
 
 const FAMILIAR_ID = "rida";
 const MISSION_ID = "m-media";
-const ELEVENLABS_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
+const ELEVENLABS_VOICE_ID = DEFAULT_ELEVENLABS_VOICE_ID;
 const now = new Date().toISOString();
 
 const MISSION = {

--- a/tests/research-studio-media.spec.ts
+++ b/tests/research-studio-media.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, type Page } from "@playwright/test";
 
 const FAMILIAR_ID = "rida";
 const MISSION_ID = "m-media";
+const ELEVENLABS_VOICE_ID = "21m00Tcm4TlvDq8ikWAM";
 const now = new Date().toISOString();
 
 const MISSION = {
@@ -249,7 +250,7 @@ async function boot(
               },
               elevenlabs: {
                 ready,
-                defaultVoiceId: "eleven-default",
+                defaultVoiceId: ELEVENLABS_VOICE_ID,
                 hint: ready ? undefined : "Configure ElevenLabs in Vault.",
               },
             },
@@ -412,7 +413,7 @@ test.describe("Research Studio media honesty and playback", () => {
     await expect(config.getByLabel("Local voice")).toHaveValue("piper-amy");
     await provider.selectOption("elevenlabs");
     await expect(config.getByLabel("ElevenLabs voice ID")).toHaveValue(
-      "eleven-default",
+      ELEVENLABS_VOICE_ID,
     );
     await expect(config.getByLabel("Length").locator("option")).toHaveCount(3);
     await expect(config.getByLabel("Style").locator("option")).toHaveText([
@@ -435,9 +436,9 @@ test.describe("Research Studio media honesty and playback", () => {
     await config.getByRole("button", { name: /Draft for review Podcast/ }).click();
     expect(controls.createBodies.at(-1)?.renderConfig).toEqual({
       provider: "elevenlabs",
-      voice: "eleven-default",
+      voice: ELEVENLABS_VOICE_ID,
       length: "standard",
-      voices: { host: "eleven-default", guest: "eleven-guest" },
+      voices: { host: ELEVENLABS_VOICE_ID, guest: "eleven-guest" },
       style: "debate",
     });
     let review = page.getByRole("dialog", {
@@ -468,6 +469,35 @@ test.describe("Research Studio media honesty and playback", () => {
       "href",
       /download=1/,
     );
+  });
+
+  test("defaults short videos to ElevenLabs Rachel at standard length", async ({
+    page,
+  }) => {
+    const controls = await boot(page, { ready: true });
+    const studio = page.locator(".research-studio");
+    await studio.locator('button[data-kind="short-video"]').click();
+
+    const config = page.getByRole("dialog", { name: "Generate Short video" });
+    await expect(config.getByLabel("Voice provider")).toHaveValue("elevenlabs");
+    await expect(config.getByLabel("ElevenLabs voice ID")).toHaveValue(
+      ELEVENLABS_VOICE_ID,
+    );
+    await expect(config.getByLabel("Length")).toHaveValue("standard");
+
+    await config
+      .getByRole("button", { name: /Draft for review Short video/ })
+      .click();
+    expect(controls.createBodies.at(-1)).toEqual({
+      familiarId: FAMILIAR_ID,
+      kind: "short-video",
+      sourceMissionId: MISSION_ID,
+      renderConfig: {
+        provider: "elevenlabs",
+        voice: ELEVENLABS_VOICE_ID,
+        length: "standard",
+      },
+    });
   });
 
   test("resumes drafts, retries failures, cancels progress, and opens both video players", async ({


### PR DESCRIPTION
## Summary
- default new short-video drafts to the readiness-backed ElevenLabs Rachel voice
- reset short-video length to standard while preserving local-provider fallback
- assert the complete Research Desk generation payload in Playwright

## Verification
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:app` (1178 passed)
- `pnpm test:api` (372 passed)
- `pnpm check:tests-wired`
- `COVEN_CAVE_PORT=3101 pnpm test:e2e` (205 passed)

Bead: `cave-golnf`