### PR TITLE
fix(chat): gate daemon-derived resume roots in the projectless branch

### DIFF
--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -514,6 +514,27 @@ assert.match(
   /const generationOrigin = existingConversation\?\.origin \?\? body\.origin/,
   "a request must not relabel an existing user chat as a projectless hidden generation",
 );
+// cave-o3nq7: the hidden-generation exemption must be decided by the shared
+// helper, which admits only the familiar's own workspace. The old inline
+// `resumeCwd ?? resolvedFamiliarWorkspace` adopted a daemon session's
+// project_root — from a list that is global and carries no familiar id — with
+// authorizeChatProjectLaunch skipped entirely.
+assert.match(
+  chatRoute,
+  /const projectlessLaunch = projectlessGenerationLaunch\(\{[\s\S]*?origin: generationOrigin,[\s\S]*?resumeCwd,[\s\S]*?familiarWorkspace: resolvedFamiliarWorkspace,[\s\S]*?\}\)/,
+  "the projectless branch should delegate to the shared launch decision",
+);
+assert.doesNotMatch(
+  chatRoute,
+  /generationRoot = sshRuntime \? homedir\(\) : \(resumeCwd \?\? resolvedFamiliarWorkspace\)/,
+  "a hidden generation must not adopt a resume cwd without the launch gate",
+);
+const projectlessDecisionIndex = chatRoute.indexOf('projectlessLaunch.kind === "workspace"');
+const projectlessGateIndex = chatRoute.indexOf("await authorizeChatProjectLaunch");
+assert.ok(
+  projectlessDecisionIndex >= 0 && projectlessDecisionIndex < projectlessGateIndex,
+  "the auth-free workspace case must be the only branch that skips the launch gate",
+);
 
 const authorizeLaunchIndex = chatRoute.indexOf("await authorizeChatProjectLaunch");
 const offlineLaunchIndex = chatRoute.indexOf("const offlineChatResponse = await maybeQueueOfflineChat");

--- a/src/app/api/chat/send/harness-routing-host-session.test.ts
+++ b/src/app/api/chat/send/harness-routing-host-session.test.ts
@@ -770,3 +770,19 @@ assert.match(
   /isTrustedChatHarness\(binding\.harness\)/,
   "Board step enrichment should enforce the same trusted Coven harness gate",
 );
+
+// cave-o3nq7 review (#4582): the exemption's containment test must run on a
+// symlink-RESOLVED resume root. resolveLocalRuntimeCwd realpaths the root it is
+// handed and enforces only "inside $HOME", so a lexical check on the raw string
+// would let a symlink inside the familiar's own workspace resolve into another
+// project with authorizeChatProjectLaunch skipped.
+assert.match(
+  chatRoute,
+  /const resumeCwdResolved = resumeCwd\s*\?\s*await realpath\(resumeCwd\)\.catch\(\(\) => undefined\)\s*:\s*undefined/,
+  "the resume root is symlink-resolved, and an unresolvable root yields undefined",
+);
+assert.match(
+  chatRoute,
+  /projectlessGenerationLaunch\(\{[\s\S]*?resumeCwdResolved,[\s\S]*?\}\)/,
+  "the launch decision receives the resolved resume root",
+);

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -175,7 +175,7 @@ import { chatProjectAccessId, taskWorktreeProjectAccessId } from "@/lib/chat-pro
 import {
   authorizeChatProjectLaunch,
   ChatProjectLaunchError,
-  isProjectlessGenerationOrigin,
+  projectlessGenerationLaunch,
 } from "@/lib/server/chat-project-launch";
 import { validateCaveProjectRoot } from "@/lib/server/project-paths";
 import { resolveRuntimeSkillRoots } from "@/lib/server/skill-scan";
@@ -2082,8 +2082,19 @@ export async function POST(req: Request) {
   // A persisted conversation owns its provenance. Never let a request relabel
   // an existing user chat as a hidden generator to bypass project checks.
   const generationOrigin = existingConversation?.origin ?? body.origin;
-  const projectlessGeneration =
-    !body.projectRoot && isProjectlessGenerationOrigin(generationOrigin);
+  // A hidden generation is exempt from the launch gate only for the familiar's
+  // OWN workspace. A resume root — the conversation's persisted runtime, or a
+  // daemon session's project_root (cave-yjnr) — names a real project and is
+  // gated like every other root, because the daemon's session list is global
+  // and its rows carry no familiar id to scope it by (cave-o3nq7).
+  const projectlessLaunch = projectlessGenerationLaunch({
+    origin: generationOrigin,
+    hasRequestedProjectRoot: Boolean(body.projectRoot),
+    sshRuntime: Boolean(sshRuntime),
+    sshHome: homedir(),
+    resumeCwd,
+    familiarWorkspace: resolvedFamiliarWorkspace,
+  });
   // A Board task may be isolated in a worktree below its registered project.
   // The worktree itself is intentionally not a separate project record, so
   // its first native-chat turn must authorize against the card's server-owned
@@ -2093,16 +2104,15 @@ export async function POST(req: Request) {
   // when the symlink-resolved runtime cwd remains inside the task project.
   let authorizedProjectRoot: string;
   try {
-    if (projectlessGeneration) {
-      const generationRoot = sshRuntime ? homedir() : (resumeCwd ?? resolvedFamiliarWorkspace);
-      if (!generationRoot) {
-        throw new ChatProjectLaunchError(
-          "project_root_required",
-          400,
-          "This hidden generation has no safe familiar workspace.",
-        );
-      }
-      authorizedProjectRoot = generationRoot;
+    if (projectlessLaunch.kind === "unavailable") {
+      throw new ChatProjectLaunchError(
+        "project_root_required",
+        400,
+        "This hidden generation has no safe familiar workspace.",
+      );
+    }
+    if (projectlessLaunch.kind === "workspace") {
+      authorizedProjectRoot = projectlessLaunch.root;
     } else {
       const authorized = await authorizeChatProjectLaunch(
         {

--- a/src/app/api/chat/send/route.ts
+++ b/src/app/api/chat/send/route.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcessByStdio, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { realpath } from "node:fs/promises";
 import { homedir } from "node:os";
 import type { Readable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
@@ -2087,12 +2088,21 @@ export async function POST(req: Request) {
   // daemon session's project_root (cave-yjnr) — names a real project and is
   // gated like every other root, because the daemon's session list is global
   // and its rows carry no familiar id to scope it by (cave-o3nq7).
+  // Resolve symlinks before the containment test. The spawn below realpaths the
+  // root and enforces only "inside $HOME", so a lexical check on the raw string
+  // would let a symlink inside the familiar's own workspace — a directory the
+  // familiar can write to — resolve into another project with the gate skipped.
+  // An unresolvable root yields undefined, which the helper treats as gated.
+  const resumeCwdResolved = resumeCwd
+    ? await realpath(resumeCwd).catch(() => undefined)
+    : undefined;
   const projectlessLaunch = projectlessGenerationLaunch({
     origin: generationOrigin,
     hasRequestedProjectRoot: Boolean(body.projectRoot),
     sshRuntime: Boolean(sshRuntime),
     sshHome: homedir(),
     resumeCwd,
+    resumeCwdResolved,
     familiarWorkspace: resolvedFamiliarWorkspace,
   });
   // A Board task may be isolated in a worktree below its registered project.

--- a/src/lib/server/chat-project-launch.test.ts
+++ b/src/lib/server/chat-project-launch.test.ts
@@ -14,7 +14,19 @@ const {
   authorizeChatProjectLaunch,
   ChatProjectLaunchError,
   isProjectlessGenerationOrigin,
+  projectlessGenerationLaunch,
 } = await import(moduleUrl.href);
+
+function launch(overrides = {}) {
+  return projectlessGenerationLaunch({
+    origin: "canvas",
+    hasRequestedProjectRoot: false,
+    sshRuntime: false,
+    sshHome: "/home/val",
+    familiarWorkspace: "/home/val/.coven/workspaces/familiars/milo",
+    ...overrides,
+  });
+}
 
 function harness(overrides = {}) {
   const calls = {
@@ -179,4 +191,76 @@ test("a registered worktree authorizes through its parent project id", async () 
     projectId: "parent-project",
   });
   assert.deepEqual(calls.access, [["milo", "parent-project", "chat"]]);
+});
+
+// ── cave-o3nq7: the projectless exemption covers the familiar's own workspace
+// and nothing else. A resume root reaches the branch from the conversation
+// runtime OR from the daemon's global session list, and that list is not
+// scoped to the requesting familiar — adopting one unchecked launched a
+// familiar in another session's project with no grant for it.
+
+test("a hidden generation with no resume root runs auth-free in its own workspace", () => {
+  assert.deepEqual(launch(), {
+    kind: "workspace",
+    root: "/home/val/.coven/workspaces/familiars/milo",
+  });
+});
+
+test("an ssh hidden generation keeps its remote home runtime", () => {
+  assert.deepEqual(launch({ sshRuntime: true }), { kind: "workspace", root: "/home/val" });
+});
+
+test("a hidden generation with no workspace at all is refused, not launched", () => {
+  assert.deepEqual(launch({ familiarWorkspace: undefined }), { kind: "unavailable" });
+});
+
+test("a resume root inside the familiar's own workspace stays auth-free", () => {
+  // Multi-turn canvas: turn 1 ran auth-free in the workspace and persisted it
+  // as the conversation runtime, so turn 2 must not start demanding a grant
+  // for a directory that is not a registered project.
+  for (const resume of [
+    "/home/val/.coven/workspaces/familiars/milo",
+    "/home/val/.coven/workspaces/familiars/milo/scratch",
+  ]) {
+    assert.deepEqual(
+      launch({ resumeCwd: resume }),
+      { kind: "workspace", root: resume },
+      `${resume} is the familiar's own workspace`,
+    );
+  }
+});
+
+test("a daemon-derived resume root outside the workspace is gated", () => {
+  for (const resume of [
+    "/home/val/code/someone-elses-project",
+    "/home/val/.coven/workspaces/familiars/milo/../nyx",
+    "/home/val/.coven/workspaces/familiars/nyx",
+  ]) {
+    assert.deepEqual(
+      launch({ resumeCwd: resume }),
+      { kind: "gated" },
+      `${resume} must pass the launch gate`,
+    );
+  }
+});
+
+test("a resume root is gated when the familiar has no workspace to compare against", () => {
+  assert.deepEqual(
+    launch({ resumeCwd: "/home/val/code/project", familiarWorkspace: undefined }),
+    { kind: "gated" },
+  );
+});
+
+test("every non-hidden origin is gated regardless of resume root", () => {
+  for (const origin of [undefined, "chat", "mention", "board", "call", "cron", "heartbeat"]) {
+    assert.deepEqual(
+      launch({ origin, resumeCwd: undefined }),
+      { kind: "gated" },
+      `${origin ?? "missing"} origin is project-gated`,
+    );
+  }
+});
+
+test("a request that names its own project root is always gated", () => {
+  assert.deepEqual(launch({ hasRequestedProjectRoot: true }), { kind: "gated" });
 });

--- a/src/lib/server/chat-project-launch.test.ts
+++ b/src/lib/server/chat-project-launch.test.ts
@@ -18,14 +18,20 @@ const {
 } = await import(moduleUrl.href);
 
 function launch(overrides = {}) {
-  return projectlessGenerationLaunch({
+  const input = {
     origin: "canvas",
     hasRequestedProjectRoot: false,
     sshRuntime: false,
     sshHome: "/home/val",
     familiarWorkspace: "/home/val/.coven/workspaces/familiars/milo",
     ...overrides,
-  });
+  };
+  // Most cases have no symlink in play, so default the resolved form to the raw
+  // one. A case that cares about symlinks passes resumeCwdResolved explicitly.
+  if (input.resumeCwd !== undefined && !("resumeCwdResolved" in overrides)) {
+    input.resumeCwdResolved = input.resumeCwd;
+  }
+  return projectlessGenerationLaunch(input);
 }
 
 function harness(overrides = {}) {
@@ -263,4 +269,39 @@ test("every non-hidden origin is gated regardless of resume root", () => {
 
 test("a request that names its own project root is always gated", () => {
   assert.deepEqual(launch({ hasRequestedProjectRoot: true }), { kind: "gated" });
+});
+
+// ── cave-o3nq7 review (#4582): the containment test runs on the SYMLINK-RESOLVED
+// resume root. The spawn realpaths the root and enforces only "inside $HOME", so
+// a lexical check on the raw string would let a symlink planted in the familiar's
+// own workspace — a directory the familiar can write to — resolve into another
+// project with the launch gate skipped.
+
+test("a workspace path that resolves outside the workspace is gated", () => {
+  assert.deepEqual(
+    launch({
+      resumeCwd: "/home/val/.coven/workspaces/familiars/milo/link",
+      resumeCwdResolved: "/home/val/code/someone-elses-project",
+    }),
+    { kind: "gated" },
+    "a symlink out of the workspace must not inherit the exemption",
+  );
+});
+
+test("an exempt resume root launches at its resolved path, not the raw one", () => {
+  assert.deepEqual(
+    launch({
+      resumeCwd: "/home/val/.coven/workspaces/familiars/milo/link",
+      resumeCwdResolved: "/home/val/.coven/workspaces/familiars/milo/real",
+    }),
+    { kind: "workspace", root: "/home/val/.coven/workspaces/familiars/milo/real" },
+    "the decision and the launched root must be the same path",
+  );
+});
+
+test("an unresolvable resume root is gated, never dropped back to the workspace", () => {
+  assert.deepEqual(
+    launch({ resumeCwd: "/home/val/code/gone", resumeCwdResolved: undefined }),
+    { kind: "gated" },
+  );
 });

--- a/src/lib/server/chat-project-launch.ts
+++ b/src/lib/server/chat-project-launch.ts
@@ -45,6 +45,16 @@ export type ProjectlessGenerationLaunchInput = {
    * daemon-spawned thread, from the daemon's session list.
    */
   resumeCwd?: string;
+  /**
+   * `resumeCwd` with symlinks resolved, or undefined when it could not be
+   * resolved. The containment test below MUST run on this rather than on the
+   * raw string: the spawn later realpaths the root and enforces only "inside
+   * $HOME", so a symlink planted in the familiar's own workspace — which the
+   * familiar can write to — would otherwise pass a lexical check here and land
+   * the run in a different project entirely, with the gate skipped.
+   */
+  resumeCwdResolved?: string;
+  /** Already symlink-resolved by resolveFamiliarWorkspace. */
   familiarWorkspace?: string;
 };
 
@@ -85,8 +95,13 @@ export function projectlessGenerationLaunch(
   if (!resume) {
     return workspace ? { kind: "workspace", root: workspace } : { kind: "unavailable" };
   }
-  if (workspace && isInsideRoot(workspace, resume)) {
-    return { kind: "workspace", root: resume };
+  // A resume root that would not resolve is gated rather than dropped back to
+  // the workspace: falling back would hand an auth-free run to a caller who
+  // named an unresolvable root.
+  const resolved = input.resumeCwdResolved?.trim();
+  if (!resolved) return { kind: "gated" };
+  if (workspace && isInsideRoot(workspace, resolved)) {
+    return { kind: "workspace", root: resolved };
   }
   return { kind: "gated" };
 }

--- a/src/lib/server/chat-project-launch.ts
+++ b/src/lib/server/chat-project-launch.ts
@@ -1,3 +1,5 @@
+import path from "node:path";
+
 import type { ProjectPermissionSurface } from "../project-access-levels.ts";
 import type { SessionOrigin } from "../types.ts";
 
@@ -16,6 +18,77 @@ export function isProjectlessGenerationOrigin(
   origin: SessionOrigin | null | undefined,
 ): boolean {
   return Boolean(origin && PROJECTLESS_GENERATION_ORIGINS.has(origin));
+}
+
+function isInsideRoot(root: string, candidate: string): boolean {
+  const rel = path.relative(root, candidate);
+  return (
+    rel === "" ||
+    (
+      rel !== ".." &&
+      !rel.startsWith(".." + path.sep) &&
+      !path.isAbsolute(rel) &&
+      !rel.split(path.sep).includes("..")
+    )
+  );
+}
+
+export type ProjectlessGenerationLaunchInput = {
+  origin: SessionOrigin | null | undefined;
+  /** True when the request named a project root of its own. */
+  hasRequestedProjectRoot: boolean;
+  sshRuntime: boolean;
+  /** Remote home directory used for the ssh generation runtime. */
+  sshHome: string;
+  /**
+   * Resume root recovered from the conversation's persisted runtime or, for a
+   * daemon-spawned thread, from the daemon's session list.
+   */
+  resumeCwd?: string;
+  familiarWorkspace?: string;
+};
+
+export type ProjectlessGenerationLaunchDecision =
+  /** Auth-free: the familiar's own workspace (or its ssh equivalent). */
+  | { kind: "workspace"; root: string }
+  /** A hidden generation with no safe workspace to fall back to. */
+  | { kind: "unavailable" }
+  /** Must pass authorizeChatProjectLaunch like any other root. */
+  | { kind: "gated" };
+
+/**
+ * Decide whether a hidden generation may skip the project launch gate.
+ *
+ * A hidden generation is exempt because it runs in the familiar's OWN
+ * workspace, which is not a registered project and carries no grant to check.
+ * That exemption never extended to a resume root: the conversation runtime and
+ * the daemon session list (cave-yjnr) both name real project directories, and
+ * the daemon's list is global — it is not scoped to the requesting familiar,
+ * and its rows carry no familiar id to scope it by. Adopting one unchecked let
+ * a caller name any session's id with a hidden origin and be launched in that
+ * session's project without holding a grant for it (cave-o3nq7).
+ *
+ * So a resume root is gated exactly like the typed-chat path already gates it,
+ * unless it resolves inside the familiar's own workspace — the multi-turn
+ * canvas case, where turn 1 legitimately ran auth-free in that workspace and
+ * persisted it as the conversation runtime.
+ */
+export function projectlessGenerationLaunch(
+  input: ProjectlessGenerationLaunchInput,
+): ProjectlessGenerationLaunchDecision {
+  if (input.hasRequestedProjectRoot) return { kind: "gated" };
+  if (!isProjectlessGenerationOrigin(input.origin)) return { kind: "gated" };
+  if (input.sshRuntime) return { kind: "workspace", root: input.sshHome };
+
+  const workspace = input.familiarWorkspace?.trim();
+  const resume = input.resumeCwd?.trim();
+  if (!resume) {
+    return workspace ? { kind: "workspace", root: workspace } : { kind: "unavailable" };
+  }
+  if (workspace && isInsideRoot(workspace, resume)) {
+    return { kind: "workspace", root: resume };
+  }
+  return { kind: "gated" };
 }
 
 export type ChatProjectLaunchErrorCode =


### PR DESCRIPTION
Closes the turn-1 project-grant bypass traced on `cave-o3nq7`.

## The defect

A hidden generation (`canvas` / `enhance` / `journal`) skips
`authorizeChatProjectLaunch` because it runs in the familiar's **own workspace** —
not a registered project, so there is no grant to check. That exemption also
covered the *resume root*, and a resume root is not always the familiar's own
directory.

With no Cave conversation record for the submitted `sessionId`, `resumeCwd` falls
back to `daemonSessionCwd`, which matches the id against the daemon's **global**
session list (`callDaemon({path: "/api/v1/sessions"})`, no familiar filter) and
returns that row's `project_root`.

So a **first** turn of the shape

```
POST /api/chat/send { familiarId: A, sessionId: <any daemon session id>,
                      origin: "enhance", no projectRoot }
```

took `authorizedProjectRoot` from a foreign session and launched there with the
gate skipped — `assertProjectAccess` never ran. Not a re-authorization gap on
turns 2..n: turn 1 *is* the bypass, so there is no prior authorization to lean on.

Both ownership guards upstream are conditional on a record this path does not
have — `existingConversation.familiarId !== body.familiarId` and
`taskCard.familiarId !== body.familiarId`. A daemon-spawned session with neither
trips neither, and that is exactly the class the fallback was added for
(`cave-yjnr`, analytics-opened `/#chat-<id>` threads).

An ownership check is not available: the daemon's rows carry no familiar id —
`session-list-merge.ts` omits `familiarId` and `origin` from `DaemonSessionRow`
because both are Cave-local attributes merged in from the conversation store. The
check therefore has to be on the **root**, not the session.

## The fix

`projectlessGenerationLaunch()` — pure, in `chat-project-launch.ts` — decides the
exemption and returns one of three outcomes:

- `workspace` — auth-free: the familiar's own workspace, or its ssh home.
- `unavailable` — the pre-existing 400 for a hidden generation with no safe workspace.
- `gated` — everything else goes through `authorizeChatProjectLaunch`.

A resume root that resolves **inside** the familiar workspace stays auth-free, so
the multi-turn canvas case still works: turn 1 legitimately ran there and
persisted it as the conversation runtime, and that directory is not a registered
project to hold a grant for.

## Behavior change worth knowing

A hidden generation resuming a daemon session whose `project_root` is **not** a
registered project the familiar can access now refuses with
`project_not_registered` instead of launching. That is what a normal (`origin:
"chat"`) resume of the same thread already does today — `projectRootForLaunch`
feeds the same gate — and `chat-view`'s `cave-yjnr` flow already handles that
refusal by prompting for a project and retrying there.

## Verification

- 12 new unit tests on the helper (both directions, including a `..` traversal out
  of the workspace) — pass.
- 3 added source-contract assertions in `harness-routing-host-session.test.ts`
  pinning the delegation and forbidding the old inline
  `resumeCwd ?? resolvedFamiliarWorkspace` fallback — pass.
- `pnpm typecheck` clean; `pnpm lint` (design codemod + eslint) clean.
- Full `test:app` and `test:api`. Five failures, **all reproduced on unmodified
  `main`** and all macOS-only path assertions (`/private/var` vs `/var`, Windows
  npm-shim argv): `automation-runner`, `coven-bin`, `codex-compatibility`,
  `copilot-bin`, `copilot-runtime-launch`. The suite runner exits at the first
  failure, so the files after each were run separately — zero further failures.