### PR TITLE
fix(chat): lift expand lightboxes above the reader overlay band

### DIFF
--- a/src/components/chat-attachment-cards.test.ts
+++ b/src/components/chat-attachment-cards.test.ts
@@ -81,3 +81,26 @@ assert.match(
 );
 
 console.log("chat-attachment-cards.test.ts: ok");
+
+// ── cave-yin71: both expand overlays portal to body, which puts them in the
+// ROOT stacking context alongside the message reader (.cave-reader-backdrop,
+// z-index 60), the research reader (70) and .rr-kroverlay / the daily-report PR
+// modal (80). At z-50 an image expanded from inside a reader rendered behind
+// the reader's own scrim. Pin the cleared band so a future edit cannot quietly
+// drop either overlay back under it.
+const carousel = await readFile(new URL("./image-carousel.tsx", import.meta.url), "utf8");
+for (const [name, source] of [
+  ["attachment lightbox", cards],
+  ["carousel lightbox", carousel],
+]) {
+  const overlay = source.match(/className="fixed inset-0 z-\[?(\d+)\]?/);
+  assert.ok(overlay, `${name} keeps a full-viewport fixed overlay`);
+  assert.ok(
+    Number(overlay[1]) > 80,
+    `${name} must sit above the reader/modal overlay band (found z-${overlay[1]})`,
+  );
+  assert.ok(
+    Number(overlay[1]) < 100,
+    `${name} must stay below inspector-pane (100) and the directory picker (200)`,
+  );
+}

--- a/src/components/chat-attachment-cards.test.ts
+++ b/src/components/chat-attachment-cards.test.ts
@@ -89,18 +89,37 @@ console.log("chat-attachment-cards.test.ts: ok");
 // the reader's own scrim. Pin the cleared band so a future edit cannot quietly
 // drop either overlay back under it.
 const carousel = await readFile(new URL("./image-carousel.tsx", import.meta.url), "utf8");
+// Match the classes independently of their order inside the attribute: a
+// harmless reorder or an inserted class must not fail this, only a z-index that
+// drops back under the reader.
+function overlayZIndex(source) {
+  for (const attr of source.matchAll(/className="([^"]*)"/g)) {
+    const classes = attr[1].split(/\s+/);
+    if (!classes.includes("fixed") || !classes.includes("inset-0")) continue;
+    const z = classes.find((cls) => /^z-\[?\d+\]?$/.test(cls));
+    if (z) return Number(z.replace(/\D/g, ""));
+  }
+  return null;
+}
 for (const [name, source] of [
   ["attachment lightbox", cards],
   ["carousel lightbox", carousel],
 ]) {
-  const overlay = source.match(/className="fixed inset-0 z-\[?(\d+)\]?/);
-  assert.ok(overlay, `${name} keeps a full-viewport fixed overlay`);
-  assert.ok(
-    Number(overlay[1]) > 80,
-    `${name} must sit above the reader/modal overlay band (found z-${overlay[1]})`,
-  );
-  assert.ok(
-    Number(overlay[1]) < 100,
-    `${name} must stay below inspector-pane (100) and the directory picker (200)`,
+  const z = overlayZIndex(source);
+  assert.ok(z !== null, `${name} keeps a full-viewport fixed overlay with an explicit z-index`);
+  assert.ok(z > 80, `${name} must sit above the reader/modal overlay band (found z-${z})`);
+  assert.ok(z < 100, `${name} must stay below inspector-pane (100) and the directory picker (200)`);
+}
+
+// The scrim is a token, not a literal — both lightboxes share the one the
+// reader and every other full-viewport overlay use.
+for (const [name, source] of [
+  ["attachment lightbox", cards],
+  ["carousel lightbox", carousel],
+]) {
+  assert.match(
+    source,
+    /bg-\[var\(--backdrop-scrim\)\]/,
+    `${name} scrims with the shared --backdrop-scrim token`,
   );
 }

--- a/src/components/chat-attachment-cards.tsx
+++ b/src/components/chat-attachment-cards.tsx
@@ -27,10 +27,14 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
   // chip trigger on dismissal, including Escape.
   useFocusTrap(true, dialogRef, { onEscape: onClose });
   // The transcript establishes containing blocks, so the preview must portal
-  // to body for a viewport-sized fixed overlay.
+  // to body for a viewport-sized fixed overlay. That places it in the root
+  // stacking context next to the other portalled overlays, so it carries the
+  // same z-index as the carousel lightbox and for the same reason — an
+  // attachment expanded inside the message reader must not land under the
+  // reader's scrim (cave-yin71).
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 backdrop-blur-sm"
       onClick={onClose}
       role="presentation"
     >

--- a/src/components/chat-attachment-cards.tsx
+++ b/src/components/chat-attachment-cards.tsx
@@ -34,7 +34,7 @@ function AttachmentLightbox({ attachment, onClose }: { attachment: ChatAttachmen
   // reader's scrim (cave-yin71).
   return createPortal(
     <div
-      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/80 backdrop-blur-sm"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-[var(--backdrop-scrim)] backdrop-blur-sm"
       onClick={onClose}
       role="presentation"
     >

--- a/src/components/image-carousel.tsx
+++ b/src/components/image-carousel.tsx
@@ -74,9 +74,17 @@ function ImageLightbox({
 
   // The transcript establishes containing blocks, so a viewport-sized fixed
   // overlay has to portal to body (same reason as the attachment lightbox).
+  // Portalling puts this in the ROOT stacking context, alongside every other
+  // portalled overlay, so the z-index competes with them directly. It has to
+  // clear the surfaces an image can be expanded from underneath: the message
+  // reader backdrop (60), the research-studio backdrops (65-70), the research
+  // reader (70), and .rr-kroverlay / the daily-report PR modal (80). At z-50 an
+  // image expanded inside the reader rendered BEHIND the reader's scrim
+  // (cave-yin71). Kept below the full-surface layers that should still cover a
+  // lightbox — inspector-pane (100) and directory-picker-modal (200).
   return createPortal(
     <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--backdrop-scrim)] backdrop-blur-sm"
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-[var(--backdrop-scrim)] backdrop-blur-sm"
       onClick={onClose}
       role="presentation"
     >


### PR DESCRIPTION
Expanding an image from markdown inside the message reader put the lightbox
**behind** the reader's own scrim.

## Why

Both expand overlays portal to `document.body` — the transcript establishes
containing blocks, so a viewport-sized `fixed` overlay cannot live inside one.
That also places them in the **root stacking context**, as siblings of every
other portalled overlay, so their `z-index` competes with those directly rather
than with anything in the transcript.

At `z-50` they lost that competition:

| overlay | z-index |
| --- | --- |
| `.cave-reader-backdrop` (message reader) | 60 |
| `.research-studio-modal__backdrop--config` / `--editor` | 65 / 70 |
| research reader | 70 |
| `.rr-kroverlay`, daily-report PR modal | 80 |
| **attachment + carousel lightbox** | **50** |

`message-bubble.tsx:1398` renders the reader with the markdown content as its
children, so an image expanded inside a reader is the ordinary path. The image
was rendering — under a blurred backdrop.

## The change

Both overlays move to `z-[90]`: above the whole band, and still below the
full-surface layers that *should* cover a lightbox — `inspector-pane` (100) and
`directory-picker-modal` (200).

Two sites, because both are reachable from reader content:
- `AttachmentLightbox` (`chat-attachment-cards.tsx`) — single attachment preview.
- `ImageCarousel`'s zoom overlay (`image-carousel.tsx`) — two or more images.

This repo has no z-index token scale to express that ordering, so each site
carries a comment naming the layers it has to clear rather than an unexplained
number.

## Verification

- New assertion in `chat-attachment-cards.test.ts` reads both sources and pins
  the band (`> 80` and `< 100`) rather than the literal value, so a future edit
  cannot quietly drop either overlay back under the reader. Confirmed
  non-vacuous: the same matcher against the old `z-50` string fails the `> 80`
  check.
- `image-carousel-wiring.test.ts` passes unchanged.
- `pnpm typecheck` and `pnpm lint` (design codemod + eslint) clean.