### PR TITLE
Improve research diagnostics trace

### DIFF
--- a/src/components/role-surfaces/research-mission-detail.tsx
+++ b/src/components/role-surfaces/research-mission-detail.tsx
@@ -37,6 +37,7 @@ import {
   researchIntentAddsContext,
   researchPhaseMeta,
   researchPhaseStatuses,
+  researchDiagnosticTrace,
   researchSourceStatusCounts,
   type ResearchMission,
   type ResearchMissionAction,
@@ -125,12 +126,16 @@ export function ResearchMissionDetail({
   const [direction, setDirection] = useState("");
   const [actionError, setActionError] = useState<string | null>(null);
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const [diagnosticsCopiedFor, setDiagnosticsCopiedFor] = useState<string | null>(null);
   // null = untouched; the retry payload then adapts to the failure instead.
   const [retryRoot, setRetryRoot] = useState<string | null>(null);
-  // Toggles the "Saved" summary's copy-workspace-path button label; reverted
-  // by copyTimer below.
+  // Toggles the "Saved" summary's copy-workspace-path button label.
   const [workspaceCopied, setWorkspaceCopied] = useState(false);
   const missionId = mission?.id ?? null;
+  // Associate the transient confirmation with the copied mission at render time.
+  // Effects run after a new mission has rendered, so a bare boolean would
+  // briefly label mission B as copied when the operator switches from A.
+  const diagnosticsCopied = diagnosticsCopiedFor === missionId;
   // Which rail pane opens on a fresh mission: a run still gathering or waiting
   // on triage opens on Sources; a settled run opens on what it produced.
   const missionStatus = mission?.status ?? null;
@@ -152,7 +157,8 @@ export function ResearchMissionDetail({
   // the user switched missions is discarded instead of applying its
   // busy/error/announce state to the wrong mission's view.
   const missionIdRef = useRef(missionId);
-  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const workspaceCopyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const diagnosticsCopyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // A mission switch resets every piece of per-mission action state — the
   // in-flight action belongs to the previous mission (its settle handlers
@@ -170,16 +176,17 @@ export function ResearchMissionDetail({
   // selection.
   useEffect(() => {
     setDiagnosticsOpen(false);
+    setDiagnosticsCopiedFor(null);
   }, [missionId]);
 
-  // The copied-path confirmation is per-mission UI state too. Its cleanup
-  // clears any pending revert timer before the next mission's effect runs
-  // (or on unmount) so a stale timer from mission A can never flip mission
-  // B's confirmation back off early.
+  // Copy confirmations are per-mission UI state. Clear both pending reverts
+  // before the next mission's effect runs (or on unmount), so a stale timer
+  // from mission A can never flip mission B's confirmation back off early.
   useEffect(() => {
     setWorkspaceCopied(false);
     return () => {
-      if (copyTimer.current) clearTimeout(copyTimer.current);
+      if (workspaceCopyTimer.current) clearTimeout(workspaceCopyTimer.current);
+      if (diagnosticsCopyTimer.current) clearTimeout(diagnosticsCopyTimer.current);
     };
   }, [missionId]);
 
@@ -246,6 +253,7 @@ export function ResearchMissionDetail({
     ],
     ["Sources", `${mission.sources.length} recorded · ${sourceCounts.used} used`],
   ] as const;
+  const traceJson = diagnosticsOpen ? JSON.stringify(researchDiagnosticTrace(mission), null, 2) : "";
   const isCheckpointLike = mission.status === "checkpoint" || mission.status === "paused";
   const isLive = LIVE_STATUSES.has(mission.status);
   // One line of run context above the open pane — the state the two stacked
@@ -363,8 +371,25 @@ export function ResearchMissionDetail({
     }
     setWorkspaceCopied(true);
     announce("Workspace path copied.");
-    if (copyTimer.current) clearTimeout(copyTimer.current);
-    copyTimer.current = setTimeout(() => setWorkspaceCopied(false), 2000);
+    if (workspaceCopyTimer.current) clearTimeout(workspaceCopyTimer.current);
+    workspaceCopyTimer.current = setTimeout(() => setWorkspaceCopied(false), 2000);
+  };
+
+  const copyDiagnosticTrace = async () => {
+    const startedFor = mission.id;
+    setActionError(null);
+    const copied = await copyText(traceJson);
+    if (missionIdRef.current !== startedFor) return;
+    if (!copied) {
+      const message = "Diagnostic JSON could not be copied.";
+      setActionError(message);
+      announce(message);
+      return;
+    }
+    setDiagnosticsCopiedFor(startedFor);
+    announce("Diagnostic JSON copied to clipboard.");
+    if (diagnosticsCopyTimer.current) clearTimeout(diagnosticsCopyTimer.current);
+    diagnosticsCopyTimer.current = setTimeout(() => setDiagnosticsCopiedFor(null), 2000);
   };
 
   // Evidence-delta triage reuses the ledger's exact source-update mechanism:
@@ -546,13 +571,25 @@ export function ResearchMissionDetail({
             onClose={() => setDiagnosticsOpen(false)}
             breadcrumb={["Research", "Diagnostics"]}
             footerActions={(
-              <Button variant="secondary" onClick={() => setDiagnosticsOpen(false)}>
-                Close
-              </Button>
+              <>
+                <Button variant="ghost" leadingIcon={diagnosticsCopied ? "ph:check" : "ph:copy"} onClick={copyDiagnosticTrace}>
+                  {diagnosticsCopied ? "Copied JSON" : "Copy trace JSON"}
+                </Button>
+                <Button variant="secondary" onClick={() => setDiagnosticsOpen(false)}>Close</Button>
+              </>
             )}
           >
             <div className="research-mission-diagnostics">
-              <p>Run details are local to this research mission.</p>
+              <div className="research-mission-diagnostics__intro">
+                <span className="research-mission-diagnostics__eyebrow"><Icon name="ph:terminal-window" width={14} height={14} aria-hidden />Trace record</span>
+                <p>Persisted run state, ordered for incident review. Copying produces a privacy-bounded JSON report; it excludes workspace paths, source URLs, and the research brief.</p>
+              </div>
+              {actionError ? <p className="research-mission-error" role="alert">{actionError}</p> : null}
+              <section className="research-mission-diagnostics__finding" aria-labelledby="research-diagnostics-finding">
+                <span id="research-diagnostics-finding">Current finding</span>
+                <strong>{mission.lastError ?? "No failure is persisted for this mission."}</strong>
+                <p>{iteration?.steps?.some((step) => step.status === "failed") ? "A failed phase is recorded below." : "No failed phase detail was persisted; use the run and session references to continue investigation."}</p>
+              </section>
               <dl>
                 {diagnostics.map(([label, value]) => (
                   <div key={label}>
@@ -561,6 +598,13 @@ export function ResearchMissionDetail({
                   </div>
                 ))}
               </dl>
+              <section className="research-mission-diagnostics__timeline" aria-labelledby="research-diagnostics-timeline">
+                <div><h3 id="research-diagnostics-timeline">Phase trace</h3><span>{iteration?.steps?.length ?? 0} recorded</span></div>
+                {iteration?.steps?.length ? <ol>{iteration.steps.map((step) => (
+                  <li key={`${step.id}-${step.type}`}><span className={`research-mission-diagnostics__phase research-mission-diagnostics__phase--${step.status}`}>{step.status}</span><strong>{step.type}</strong><p>{step.detail ?? "No phase detail recorded."}</p></li>
+                ))}</ol> : <p className="research-mission-diagnostics__empty">No phase trace was persisted for this run.</p>}
+              </section>
+              <p className="research-mission-diagnostics__availability"><Icon name="ph:info" width={14} height={14} aria-hidden />Daemon trace: not recorded. This report is mission-state evidence, not a reconstructed process log.</p>
             </div>
           </Modal>
 
@@ -788,7 +832,7 @@ export function ResearchMissionDetail({
             </section>
           ) : null}
 
-          {actionError ? <p className="research-mission-error" role="alert">{actionError}</p> : null}
+          {actionError && !diagnosticsOpen ? <p className="research-mission-error" role="alert">{actionError}</p> : null}
 
           {/* ── Sticky action bar: main actions left, end actions right.
                 No kbd chip — the desk has no registered shortcut to claim. ── */}

--- a/src/components/role-surfaces/research-tab-desk.test.ts
+++ b/src/components/role-surfaces/research-tab-desk.test.ts
@@ -78,13 +78,28 @@ test("running and completed blocks stay honest about their data", () => {
 test("run failures disclose persisted diagnostics without fabricating a cause", () => {
   assert.match(detail, /View diagnostics/);
   assert.match(detail, /<Modal[\s\S]*?breadcrumb=\{\["Research", "Diagnostics"\]\}/);
+  assert.match(detail, /researchDiagnosticTrace\(mission\)/);
+  assert.match(detail, /Copy trace JSON/);
+  assert.match(detail, /copyDiagnosticTrace/);
+  // Bind the transient copy confirmation to its mission at render time: an
+  // effect-only reset would paint the next mission as copied for one frame.
+  assert.match(detail, /const diagnosticsCopied = diagnosticsCopiedFor === missionId/);
+  assert.match(detail, /setDiagnosticsCopiedFor\(startedFor\)/);
+  assert.match(detail, /setActionError\(null\);\n    const copied = await copyText\(traceJson\)/);
+  assert.match(detail, /\{actionError \? <p className="research-mission-error" role="alert">\{actionError\}<\/p> : null\}/);
+  assert.match(detail, /actionError && !diagnosticsOpen/);
+  assert.match(detail, /Daemon trace: not recorded/);
   assert.match(detail, /\["Error", mission\.lastError \?\? "No current error"\]/);
   assert.match(detail, /\["Flow run", iteration\?\.flowRunId \?\? "No flow run recorded"\]/);
   assert.match(detail, /\["Session", sessionId \?\? "No session recorded"\]/);
   assert.match(detail, /primaryArtifact\.relativePath/);
   assert.match(detail, /\["Sources", `\$\{mission\.sources\.length\} recorded/);
   assert.match(css, /\.research-mission-diagnostics/);
+  assert.match(css, /\.research-mission-diagnostics__timeline/);
+  assert.match(css, /\.research-mission-diagnostics__finding/);
   assert.match(css, /var\(--bg-sunken\)/);
+  assert.match(css, /research-mission-diagnostics__phase[^\n]*var\(--radius-pill\)/);
+  assert.doesNotMatch(css, /--radius-full/);
 });
 
 // ── Evidence triage: exact ledger source-update mechanism ──────────────────

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -111,7 +111,7 @@ test("diagnostic trace keeps the clipboard record bounded to non-content state",
     number: 1,
     status: "failed",
     flowRunId: "file:C:private-workspace-run-1",
-    sessionId: "Private research brief",
+    sessionId: "private-research-brief",
     automationRunId: "private research brief",
     summary: "private source https://example.test/secret",
     decisionReason: "private brief detail",
@@ -152,6 +152,7 @@ test("diagnostic trace keeps the clipboard record bounded to non-content state",
   assert.equal(trace.latestIteration?.phases.captured, 50);
   assert.equal(trace.latestIteration?.phases.truncated, true);
   assert.equal(trace.latestIteration?.phases.statuses.length, 50);
+  assert.deepEqual(trace.latestIteration?.session, { value: null, redacted: true });
   assert.deepEqual(trace.evidence.artifacts, {
     recorded: 1,
     byState: { working: 0, published: 0, rejected: 1 },
@@ -160,6 +161,7 @@ test("diagnostic trace keeps the clipboard record bounded to non-content state",
   for (const privateValue of [
     "Private research brief",
     "private research brief",
+    "private-research-brief",
     "file:C:private-workspace-run-1",
     "https://example.test/secret",
     "/private/workspace",
@@ -167,6 +169,29 @@ test("diagnostic trace keeps the clipboard record bounded to non-content state",
     "private-step-id",
     "private-key",
   ]) assert.doesNotMatch(json, new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+});
+
+test("diagnostic trace retains UUID run references for support correlation", () => {
+  const mission = validMission();
+  mission.iterations = [{
+    number: 1,
+    status: "failed",
+    flowRunId: "0f8fad5b-d9cb-469f-a165-70867728950e",
+    sessionId: "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    automationRunId: "550e8400-e29b-41d4-a716-446655440000",
+  }];
+
+  assert.deepEqual(researchDiagnosticTrace(mission).latestIteration, {
+    number: 1,
+    status: "failed",
+    flowRun: { value: "0f8fad5b-d9cb-469f-a165-70867728950e", redacted: false },
+    session: { value: "7c9e6679-7425-40de-944b-e07fc1f90ae7", redacted: false },
+    automationRun: { value: "550e8400-e29b-41d4-a716-446655440000", redacted: false },
+    startedAt: null,
+    finishedAt: null,
+    costUsd: null,
+    phases: { recorded: 0, captured: 0, truncated: false, statuses: [] },
+  });
 });
 
 test("Auto-routing is explainable and ambiguous work never loops", () => {

--- a/src/lib/research-missions.test.ts
+++ b/src/lib/research-missions.test.ts
@@ -24,6 +24,7 @@ import {
   researchArtifactKindForMode,
   researchBoundReadings,
   researchContinueLabel,
+  researchDiagnosticTrace,
   researchIntentAddsContext,
   researchPhaseMeta,
   researchPhaseStatuses,
@@ -99,6 +100,73 @@ test("mission parser strips private process-owner provenance from public state",
   }]);
   assert.equal("sessionAuthority" in (parsed?.iterations[0] ?? {}), false);
   assert.equal("sessionOwnerKind" in (parsed?.iterations[0] ?? {}), false);
+});
+
+test("diagnostic trace keeps the clipboard record bounded to non-content state", () => {
+  const mission = validMission();
+  mission.intent = "Private research brief: https://example.test/secret";
+  mission.projectRoot = "/private/workspace";
+  mission.lastError = "Failed reading /private/workspace/source.md";
+  mission.iterations = [{
+    number: 1,
+    status: "failed",
+    flowRunId: "file:C:private-workspace-run-1",
+    sessionId: "Private research brief",
+    automationRunId: "private research brief",
+    summary: "private source https://example.test/secret",
+    decisionReason: "private brief detail",
+    steps: Array.from({ length: 51 }, () => ({
+      id: "private-step-id",
+      type: "private phase name",
+      status: "failed" as const,
+      detail: "failed at /private/workspace/source.md",
+    })),
+  }];
+  mission.artifacts = [{
+    key: "private-key",
+    kind: "brief",
+    title: "Private artifact",
+    relativePath: "/private/workspace/artifact.md",
+    iteration: 1,
+    state: "rejected",
+    rejectionReason: "private source https://example.test/secret",
+    updatedAt: mission.updatedAt,
+  }];
+  mission.sources = [{
+    id: "source-1",
+    title: "Private source",
+    url: "https://example.test/secret",
+    localPath: "/private/workspace/source.md",
+    sourceType: "web",
+    status: "rejected",
+  }];
+
+  const trace = researchDiagnosticTrace(mission);
+  const json = JSON.stringify(trace);
+
+  assert.equal(trace.outcome.hasError, true);
+  assert.deepEqual(trace.latestIteration?.flowRun, { value: null, redacted: true });
+  assert.deepEqual(trace.latestIteration?.session, { value: null, redacted: true });
+  assert.deepEqual(trace.latestIteration?.automationRun, { value: null, redacted: true });
+  assert.equal(trace.latestIteration?.phases.recorded, 51);
+  assert.equal(trace.latestIteration?.phases.captured, 50);
+  assert.equal(trace.latestIteration?.phases.truncated, true);
+  assert.equal(trace.latestIteration?.phases.statuses.length, 50);
+  assert.deepEqual(trace.evidence.artifacts, {
+    recorded: 1,
+    byState: { working: 0, published: 0, rejected: 1 },
+    byKind: { brief: 1, report: 0, paper: 0, findings: 0, "source-ledger": 0, "research-log": 0, presentation: 0 },
+  });
+  for (const privateValue of [
+    "Private research brief",
+    "private research brief",
+    "file:C:private-workspace-run-1",
+    "https://example.test/secret",
+    "/private/workspace",
+    "private phase name",
+    "private-step-id",
+    "private-key",
+  ]) assert.doesNotMatch(json, new RegExp(privateValue.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
 });
 
 test("Auto-routing is explainable and ambiguous work never loops", () => {

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -204,6 +204,7 @@ export type ResearchMission = {
 };
 
 const DIAGNOSTIC_REFERENCE_MAX_LENGTH = 256;
+const DIAGNOSTIC_REFERENCE_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 function diagnosticReference(value: string | undefined) {
   if (value === undefined) return { value: null, redacted: false } as const;
@@ -212,12 +213,11 @@ function diagnosticReference(value: string | undefined) {
   // clipboard into a path or URL disclosure channel.
   if (
     value.length > DIAGNOSTIC_REFERENCE_MAX_LENGTH
-    // Persisted IDs are not schema-bound. Only retain opaque identifier
-    // shapes: a human-readable value could otherwise be a copied brief even
-    // when it has no URL or filesystem separator.
-    || !/^[a-z\d][a-z\d._:-]*$/i.test(value)
-    || /^[a-z][a-z\d+.-]*:/i.test(value)
-    || /(?:^|[._-])www(?:[._-]|$)/i.test(value)
+    // These fields are persisted as unrestricted strings. A permissive slug
+    // check still accepts a hyphenated research brief, so retain only the UUID
+    // references minted by the flow/session stores; redact legacy or malformed
+    // values rather than turning the support record into a content channel.
+    || !DIAGNOSTIC_REFERENCE_UUID_RE.test(value)
   ) {
     return { value: null, redacted: true } as const;
   }

--- a/src/lib/research-missions.ts
+++ b/src/lib/research-missions.ts
@@ -203,6 +203,105 @@ export type ResearchMission = {
   lastError?: string;
 };
 
+const DIAGNOSTIC_REFERENCE_MAX_LENGTH = 256;
+
+function diagnosticReference(value: string | undefined) {
+  if (value === undefined) return { value: null, redacted: false } as const;
+  // Run references are useful support correlators, but the persisted schema
+  // does not constrain them. Do not let a malformed runtime value turn the
+  // clipboard into a path or URL disclosure channel.
+  if (
+    value.length > DIAGNOSTIC_REFERENCE_MAX_LENGTH
+    // Persisted IDs are not schema-bound. Only retain opaque identifier
+    // shapes: a human-readable value could otherwise be a copied brief even
+    // when it has no URL or filesystem separator.
+    || !/^[a-z\d][a-z\d._:-]*$/i.test(value)
+    || /^[a-z][a-z\d+.-]*:/i.test(value)
+    || /(?:^|[._-])www(?:[._-]|$)/i.test(value)
+  ) {
+    return { value: null, redacted: true } as const;
+  }
+  return { value, redacted: false } as const;
+}
+
+/**
+ * A deliberately bounded, shareable support record. It is derived entirely
+ * from persisted mission state: it never claims to be a daemon log, and it
+ * omits local paths, source URLs, the research brief, and other content that
+ * would make a clipboard handoff unexpectedly disclose workspace data.
+ */
+export function researchDiagnosticTrace(mission: ResearchMission) {
+  const latestIteration = mission.iterations.at(-1) ?? null;
+  const sourceCounts = researchSourceStatusCounts(mission.sources);
+  const steps = latestIteration?.steps ?? [];
+  // Iteration fields are persisted free text, so never put their contents in a
+  // clipboard report. Keep a small, ordered status trace instead: it is enough
+  // to locate the failed phase without turning support copy into a channel for
+  // a prompt, source, filesystem path, or daemon output.
+  const capturedPhases = steps.slice(0, 50).map((step) => step.status);
+  const artifactStates = { working: 0, published: 0, rejected: 0 };
+  const artifactKinds = Object.fromEntries(
+    RESEARCH_ARTIFACT_KINDS.map((kind) => [kind, 0]),
+  ) as Record<ResearchArtifactKind, number>;
+  for (const artifact of mission.artifacts) {
+    artifactStates[artifact.state] += 1;
+    artifactKinds[artifact.kind] += 1;
+  }
+  return {
+    schema: "coven-cave.research-diagnostic.v1",
+    // The record is a snapshot of persisted state, not a live daemon event.
+    // Keeping this deterministic also prevents a server/client hydration drift
+    // when the diagnostics dialog is rendered in a Client Component.
+    generatedAt: mission.updatedAt,
+    mission: {
+      id: mission.id,
+      mode: mission.mode,
+      status: mission.status,
+      createdAt: mission.createdAt,
+      startedAt: mission.startedAt ?? null,
+      updatedAt: mission.updatedAt,
+      finishedAt: mission.finishedAt ?? null,
+      hasProjectRoot: Boolean(mission.projectRoot),
+    },
+    bounds: mission.bounds,
+    outcome: {
+      hasError: Boolean(mission.lastError),
+      decision: latestIteration?.decision ?? null,
+    },
+    latestIteration: latestIteration ? {
+      number: latestIteration.number,
+      status: latestIteration.status,
+      flowRun: diagnosticReference(latestIteration.flowRunId),
+      session: diagnosticReference(latestIteration.sessionId),
+      automationRun: diagnosticReference(latestIteration.automationRunId),
+      startedAt: latestIteration.startedAt ?? null,
+      finishedAt: latestIteration.finishedAt ?? null,
+      costUsd: latestIteration.costUsd ?? null,
+      phases: {
+        recorded: steps.length,
+        captured: capturedPhases.length,
+        truncated: steps.length > capturedPhases.length,
+        statuses: capturedPhases,
+      },
+    } : null,
+    evidence: {
+      sources: {
+        recorded: mission.sources.length,
+        byStatus: sourceCounts,
+      },
+      artifacts: {
+        recorded: mission.artifacts.length,
+        byState: artifactStates,
+        byKind: artifactKinds,
+      },
+    },
+    availability: {
+      daemonTrace: "not-recorded",
+      note: "This report contains persisted research-mission state only; no daemon trace was recorded for this run.",
+    },
+  } as const;
+}
+
 /**
  * Runtime the mission's iterations execute on, chosen per mission.
  *

--- a/src/styles/globals/surface-research-desk.css
+++ b/src/styles/globals/surface-research-desk.css
@@ -735,11 +735,31 @@
 .research-mission-stop > span { min-width: 0; }
 .research-mission-stop__diagnostics { flex: none; margin-left: auto; }
 .research-mission-diagnostics { display: grid; gap: var(--space-4); }
-.research-mission-diagnostics > p { margin: 0; color: var(--text-secondary); font-size: var(--text-xs); }
+.research-mission-diagnostics__intro { display: grid; gap: var(--space-1); }
+.research-mission-diagnostics__intro p { margin: 0; color: var(--text-secondary); font-size: var(--text-xs); line-height: var(--leading-relaxed); }
+.research-mission-diagnostics__eyebrow { display: inline-flex; align-items: center; gap: var(--space-1); color: var(--research-accent); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+.research-mission-diagnostics__finding { display: grid; gap: var(--space-1); padding: var(--space-3); border-left: var(--ring-width) solid var(--danger-text); background: var(--danger-bg); }
+.research-mission-diagnostics__finding > span, .research-mission-diagnostics__timeline > div > span { color: var(--text-muted); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
+.research-mission-diagnostics__finding strong { color: var(--danger-text); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.research-mission-diagnostics__finding p { margin: 0; color: var(--text-secondary); font-size: var(--text-xs); }
 .research-mission-diagnostics dl { display: grid; grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr)); gap: var(--space-2); margin: 0; }
 .research-mission-diagnostics dl > div { display: grid; gap: var(--space-1); min-width: 0; padding: var(--space-3); border: 1px solid var(--border-hairline); border-radius: var(--radius-control); background: var(--bg-sunken); }
 .research-mission-diagnostics dt { color: var(--text-muted); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-2xs); font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; }
 .research-mission-diagnostics dd { margin: 0; color: var(--text-primary); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.research-mission-diagnostics__timeline { display: grid; gap: var(--space-2); padding-top: var(--space-2); border-top: 1px solid var(--border-hairline); }
+.research-mission-diagnostics__timeline > div { display: flex; align-items: baseline; justify-content: space-between; gap: var(--space-2); }
+.research-mission-diagnostics__timeline h3 { margin: 0; color: var(--text-primary); font-size: var(--text-sm); }
+.research-mission-diagnostics__timeline ol { display: grid; gap: var(--space-2); margin: 0; padding: 0; list-style: none; }
+.research-mission-diagnostics__timeline li { display: grid; grid-template-columns: auto 1fr; column-gap: var(--space-2); row-gap: var(--space-1); align-items: baseline; padding: var(--space-2) 0; border-bottom: 1px solid var(--border-hairline); }
+.research-mission-diagnostics__timeline li:last-child { border-bottom: 0; }
+.research-mission-diagnostics__phase { padding: var(--space-1) var(--space-2); border-radius: var(--radius-pill); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-2xs); font-weight: 600; text-transform: uppercase; }
+.research-mission-diagnostics__phase--failed { color: var(--danger-text); background: var(--danger-bg); }
+.research-mission-diagnostics__phase--succeeded, .research-mission-diagnostics__phase--running { color: var(--research-accent); background: color-mix(in oklch, var(--research-accent) 14%, transparent); }
+.research-mission-diagnostics__phase--pending, .research-mission-diagnostics__phase--skipped { color: var(--text-secondary); background: var(--bg-sunken); }
+.research-mission-diagnostics__timeline li strong { color: var(--text-primary); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.research-mission-diagnostics__timeline li p { grid-column: 2; margin: 0; color: var(--text-secondary); font-family: var(--font-mono, ui-monospace, monospace); font-size: var(--text-xs); overflow-wrap: anywhere; }
+.research-mission-diagnostics__empty { margin: 0; color: var(--text-muted); font-size: var(--text-xs); }
+.research-mission-diagnostics__availability { display: flex; gap: var(--space-1); align-items: flex-start; margin: 0; color: var(--text-muted); font-size: var(--text-2xs); line-height: var(--leading-relaxed); }
 .research-desk-activity {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Improves failed Research mission diagnostics with a structured phase trace, clear current finding, and a copyable privacy-bounded JSON support record.

The copied record contains persisted mission state only and explicitly reports when no daemon trace was recorded; it excludes workspace paths, source URLs, and the research brief.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `git diff --check`

## Notes

- Draft PR; no merge performed.
- Beads was unavailable in this shell, so the isolated fallback worktree has no lifecycle metadata.