### PR TITLE
fix(dev): allow the access-gated local origin to start Tauri

### DIFF
--- a/scripts/dev-app-origin-health.mjs
+++ b/scripts/dev-app-origin-health.mjs
@@ -61,7 +61,13 @@ export async function loopbackOriginResponds({
         redirect: "manual",
         signal: AbortSignal.timeout(remainingMs),
       });
-      if (response.status >= 200 && response.status < 400) return true;
+      // A persisted mobile-access secret deliberately protects direct browser
+      // navigation with the access gate (401).  The native WebView receives
+      // server.ts's loopback-peer stamp and therefore renders the document;
+      // this unauthenticated probe cannot.  A 401 still proves that Next has
+      // compiled and answered the root document, whereas a transport failure
+      // or 5xx response does not.
+      if ((response.status >= 200 && response.status < 400) || response.status === 401) return true;
       await awaitByDeadline(response.body?.cancel(), deadline);
     } catch {}
 

--- a/scripts/dev-app-origin-health.test.mjs
+++ b/scripts/dev-app-origin-health.test.mjs
@@ -55,6 +55,21 @@ try {
   await close(redirect);
 }
 
+const mobileAccessGate = http.createServer((_, response) => {
+  response.writeHead(401, { "content-type": "text/html; charset=utf-8" });
+  response.end("local access gate");
+});
+const mobileAccessGatePort = await listen(mobileAccessGate);
+try {
+  assert.equal(
+    await loopbackOriginResponds({ port: mobileAccessGatePort, timeoutMs: 500 }),
+    true,
+    "the mobile access gate proves the root document compiled for a native loopback WebView",
+  );
+} finally {
+  await close(mobileAccessGate);
+}
+
 let transientAttempts = 0;
 assert.equal(
   await loopbackOriginResponds({

--- a/src/lib/chat-session-grouping.test.ts
+++ b/src/lib/chat-session-grouping.test.ts
@@ -207,11 +207,11 @@ test("chat-list: activity bands head the default recency order", () => {
   );
 });
 
-test("chat-list: group-by buttons + persisted key + count line", () => {
+test("chat-list: group-by select + persisted key + count line", () => {
   assert.match(
     chatList,
-    /role="group"[\s\S]{0,300}aria-label="Group sessions by"[\s\S]{0,500}CHAT_GROUP_BY_OPTIONS\.map\(\(option\) => \{[\s\S]{0,500}<button[\s\S]{0,300}aria-pressed=\{groupBy === option\.id\}[\s\S]{0,300}title=\{option\.title\}/,
-    "the group-by control is an accessible button group driven by the shared options",
+    /aria-label="Group sessions by"[\s\S]{0,400}<option value="none">No grouping<\/option>\s*\n\s*<option value="project">Group by project<\/option>\s*\n\s*<option value="date">Group by date<\/option>/,
+    "the group-by select offers none / project / date",
   );
   assert.match(
     chatList,

--- a/src/lib/chat-session-grouping.test.ts
+++ b/src/lib/chat-session-grouping.test.ts
@@ -207,11 +207,11 @@ test("chat-list: activity bands head the default recency order", () => {
   );
 });
 
-test("chat-list: group-by select + persisted key + count line", () => {
+test("chat-list: group-by buttons + persisted key + count line", () => {
   assert.match(
     chatList,
-    /aria-label="Group sessions by"[\s\S]{0,400}<option value="none">No grouping<\/option>\s*\n\s*<option value="project">Group by project<\/option>\s*\n\s*<option value="date">Group by date<\/option>/,
-    "the group-by select offers none / project / date",
+    /role="group"[\s\S]{0,300}aria-label="Group sessions by"[\s\S]{0,500}CHAT_GROUP_BY_OPTIONS\.map\(\(option\) => \{[\s\S]{0,500}<button[\s\S]{0,300}aria-pressed=\{groupBy === option\.id\}[\s\S]{0,300}title=\{option\.title\}/,
+    "the group-by control is an accessible button group driven by the shared options",
   );
   assert.match(
     chatList,


### PR DESCRIPTION
Summary: recognize Cave local access-gate 401 as readiness while retaining transport and server-failure rejection. Tests: node scripts/dev-app-origin-health.test.mjs; node scripts/dev-app.test.mjs; git diff --check.