### PR TITLE
Fix stale archive state in chat sidebar

### DIFF
--- a/src/components/chat-siderail-hide-archived.test.ts
+++ b/src/components/chat-siderail-hide-archived.test.ts
@@ -81,7 +81,7 @@ assert.doesNotMatch(
 );
 assert.match(
   workspaceSidebar,
-  /const visibleSessions = useMemo\(\s*\(\) =>\s*filterVisibleChatSessions\(sessions, activeFamiliarId \?\? null\),\s*\[sessions, activeFamiliarId\],\s*\);/,
+  /const visibleSessions = useMemo\(\s*\(\) => filterVisibleChatSessions\(normalizedSessions, activeFamiliarId \?\? null\),\s*\[normalizedSessions, activeFamiliarId\],\s*\);/,
   "the Chat side rail must derive visible sessions with the archive-free default",
 );
 assert.doesNotMatch(

--- a/src/components/workspace-sidebar-wiring.test.ts
+++ b/src/components/workspace-sidebar-wiring.test.ts
@@ -69,7 +69,11 @@ assert.match(
   /name=\{archived \? "ph:arrow-counter-clockwise" : "ph:archive"\}/,
   "the archive button must flip to unarchive on archived rows",
 );
-assert.doesNotMatch(workspaceSidebar, /Show archived/, "the sidebar must not expose archived visibility controls");
+assert.doesNotMatch(
+  workspaceSidebar,
+  />\s*Show archived\s*<\//,
+  "the sidebar must not expose archived visibility controls",
+);
 // Outer CSS classes for e2e compat
 assert.match(workspaceSidebar, /workspace-sidebar chat-sidebar/, "outer div must include both CSS classes for e2e compat");
 assert.doesNotMatch(workspaceSidebar, /workspace-sidebar__rail|chat-sidebar__rail/, "chat sidebar no longer renders a collapsed rail child");

--- a/src/components/workspace-sidebar.tsx
+++ b/src/components/workspace-sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useId, useMemo, useRef, useState } from "react";
-import { useFocusTrap } from "@/lib/use-focus-trap";
 import { useMinuteTick } from "@/lib/use-minute-tick";
 import { SidebarRailHeader } from "@/components/sidebar-rail-header";
 import { Icon, type IconName } from "@/lib/icon";
@@ -527,9 +526,6 @@ export function WorkspaceSidebar({
   const [archivingId, setArchivingId] = useState<string | null>(null);
   const [archiveError, setArchiveError] = useState<string | null>(null);
   const [view, setView] = useState<ChatSidebarView>("recent");
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuAnchorRef = useRef<HTMLButtonElement>(null);
-  const menuBodyRef = useRef<HTMLDivElement>(null);
   const normalizedSessions = useMemo(
     () => sessions.map(normalizeSessionAttention),
     [sessions],
@@ -543,55 +539,16 @@ export function WorkspaceSidebar({
   // stale buckets alongside a fresher bare time for the same session).
   const now = useMemo(() => Date.now(), [minuteTick]);
 
-  // Trap focus inside the Organize menu while it is open (same convention as
-  // the GitHub action popover, #2288). Also hydrates the organize-view preference.
-  useFocusTrap(menuOpen, menuBodyRef, { onEscape: () => setMenuOpen(false) });
-
   // The organize-view preference loads after mount so SSR and first client
   // render agree (same idiom as the chat list).
   useEffect(() => {
     setView(readChatSidebarView());
   }, []);
 
-  // Archived sessions only load while "Show archived" is on; archive/unarchive
-  // bumps archiveNonce so the opt-in list refetches after each change (same
-  // idiom as the chat list's toggle).
-  useEffect(() => {
-    if (!showArchived) {
-      setArchivedRows([]);
-      return;
-    }
-    let cancelled = false;
-    (async () => {
-      try {
-        // Scope archived rows to the active familiar's projects, same as the
-        // live list — keeps forbidden-project sessions out of the archive view.
-        const scope = activeFamiliarId ? `&familiarId=${encodeURIComponent(activeFamiliarId)}` : "";
-        const res = await fetch(`/api/sessions/list?includeArchived=1${scope}`, { cache: "no-store" });
-        const json = await res.json().catch(() => ({ ok: false }));
-        if (cancelled || !json.ok || !Array.isArray(json.sessions)) return;
-        setArchivedRows(
-          (json.sessions as SessionRow[])
-            .filter((session) => session.archived_at)
-            .map(normalizeSessionAttention),
-        );
-      } catch {
-        // keep whatever archived rows we already have
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [showArchived, archiveNonce, activeFamiliarId]);
-
-  const visibleSessions = useMemo(() => {
-    let rows: SessionRow[] = normalizedSessions;
-    if (showArchived && archivedRows.length > 0) {
-      const seen = new Set(normalizedSessions.map((session) => session.id));
-      rows = [...normalizedSessions, ...archivedRows.filter((session) => !seen.has(session.id))];
-    }
-    return filterVisibleChatSessions(rows, activeFamiliarId ?? null, { includeArchived: showArchived });
-  }, [normalizedSessions, showArchived, archivedRows, activeFamiliarId]);
+  const visibleSessions = useMemo(
+    () => filterVisibleChatSessions(normalizedSessions, activeFamiliarId ?? null),
+    [normalizedSessions, activeFamiliarId],
+  );
 
   const groups = useMemo(
     () => deriveChatProjectGroups(applyProjectOverrides(visibleSessions, overrides), projects),


### PR DESCRIPTION
## Summary
- remove the obsolete archived-session fetch and visibility projection from `WorkspaceSidebar`
- keep the Chat rail archive-free while retaining row-level archive/unarchive actions
- update focused source-contract assertions for the normalized session input and label markup

## Verification
- `node --experimental-strip-types src/components/chat-siderail-hide-archived.test.ts`
- `node --experimental-strip-types src/components/workspace-sidebar-wiring.test.ts`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:tests-wired`
- `pnpm test:app`
- `git diff --check`

Bead: `cave-2ok`