### PR TITLE
docs(changelog): cover the merges that landed after the v0.3.3 stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,51 @@ breaking config changes; patch releases stay additive.
 
 ## [0.3.3] - 2026-08-12
 
-> A maintenance patch for the worktree lifecycle tooling: retention now counts a
-> pushed tag, a refused maintenance fence says what to do about it, and project
-> deletion cleans up after itself.
+> Closes an access-gate bypass on mobile, keeps chat attachments and skills
+> inside their runtime boundaries, revives Research Desk missions that had been
+> failing at their first iteration, and dresses every surface in the Coven crown.
 
-Patch release on top of v0.3.2. No user-facing surface changed; this is operator
-tooling plus one API correctness fix.
+Patch release on top of v0.3.2. Headline: the mobile access gate is restored
+without locking the desktop webview out, and the chat runtime no longer stages
+files or resolves resume roots outside the boundaries it grants.
+
+### Added
+
+- The Coven crown is now the app icon on every surface — the Tauri desktop set,
+  Windows tiles, Android mipmaps, the iOS asset catalog, the PWA icons, the
+  macOS tray glyph, and the Tauri startup splash, all regenerated from the
+  brand art as rounded-rect tiles with transparent corners (#4577).
+- Familiar avatars are now stored host-authoritatively in the desktop host
+  workspace and refresh from it, replacing the split model where desktop
+  uploads lived in IndexedDB while host avatars lived in the workspace (#4579).
+- Research Desk short videos now default to the ElevenLabs Rachel voice (#4581).
+
+### Security
+
+- Restored the mobile access gates that had been removed, closing an auth
+  bypass, and fixed the gate's own blind spot in the same change: a document
+  navigation is not a fetch, so it never carried the sidecar token and could
+  not exchange it for a cookie. The gate now admits that one request shape
+  rather than refusing the desktop webview outright (#4571).
+- Chat attachments and advertised skills now stay inside runtime boundaries.
+  Per-turn image files stage beneath the familiar workspace instead of
+  `os.tmpdir`, which sat outside every runtime grant; narrow skill roots are
+  granted read-only; and staged files a crashed turn stranded are swept on the
+  next delivery, matched strictly against the names Cave itself writes (#4576).
+- A hidden generation's resume root is now authorized rather than exempted.
+  Canvas, enhance, and journal turns skipped the project-launch check because
+  they run in the familiar's own workspace — but with no Cave conversation
+  record the resume root falls back to the daemon's global session list, which
+  is not the familiar's directory (#4582).
 
 ### Fixed
 
+- Chat sandboxes now refresh after grant changes instead of holding the
+  boundaries they were created with (#4580).
+- Research missions fall back to a direct Copilot spawn when Coven's native
+  process supervisor is absent. Every mission had failed at its first iteration
+  since #4524 with advice — update the Coven CLI — that no published CLI could
+  satisfy, so the feature was dead for every user (#4578).
 - The worktree auto-lock now counts a **pushed tag** as retention, matching the
   guard it claimed to mirror. It had used `git rev-list --count HEAD --not
   --remotes`, which consults only remote-tracking *branches* — git keeps no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ files or resolves resume roots outside the boundaries it grants.
   workspace and refresh from it, replacing the split model where desktop
   uploads lived in IndexedDB while host avatars lived in the workspace (#4579).
 - Research Desk short videos now default to the ElevenLabs Rachel voice (#4581).
+- Research diagnostics now carry a fuller trace (#4585).
+- Release automation can publish an authenticated TestFlight build (#4587).
 
 ### Security
 
@@ -50,6 +52,10 @@ files or resolves resume roots outside the boundaries it grants.
 
 - Chat sandboxes now refresh after grant changes instead of holding the
   boundaries they were created with (#4580).
+- Both chat expand lightboxes — attachment and carousel — now sit above the
+  reader overlay band. They portal to `body`, which puts them in the root
+  stacking context competing with every other portalled overlay rather than
+  with the transcript (#4584).
 - Research missions fall back to a direct Copilot spawn when Coven's native
   process supervisor is absent. Every mission had failed at its first iteration
   since #4524 with advice — update the Coven CLI — that no published CLI could


### PR DESCRIPTION
## Why

The v0.3.3 stamp (#4574) merged, its signed tag was pushed, and the release run was **cancelled mid-build** with the tag deleted — so v0.3.3 was never published. Meanwhile the work kept landing.

The notes as written describe three operator-tooling fixes. A v0.3.3 tag cut today would additionally ship an access-gate auth bypass fix, three runtime-boundary fixes, and both features — none of them mentioned.

## What this changes

`CHANGELOG.md` only. **Every manifest already reads `0.3.3`**, so nothing is bumped; this brings the entry in line with the commits the tag will actually cover.

| Section | Entry |
| --- | --- |
| Added | Coven crown app icon on every surface (#4577) |
| Added | Host-authoritative Familiar avatar storage and refresh (#4579) |
| Added | ElevenLabs Rachel default for Research Desk short videos (#4581) |
| Added | Research diagnostics trace (#4585) |
| Added | Authenticated TestFlight release automation (#4587) |
| Security | Restored mobile access gates, closing the auth bypass (#4571) |
| Security | Chat attachments and skills held inside runtime boundaries (#4576) |
| Security | Gated daemon-derived resume roots in the projectless branch (#4582) |
| Fixed | Sandbox refresh after grant changes (#4580) |
| Fixed | Direct Copilot spawn fallback reviving Research missions (#4578) |
| Fixed | Chat expand lightboxes above the reader overlay band (#4584) |

The last three rows arrived in a second commit: #4584, #4585 and #4587 merged to `main` after this branch was cut, and will be inside the tag.

## Verification

`pnpm release:verify --version 0.3.3` — *"Verified release source 0.3.3 across five manifests and the finalized changelog."*

## Order

Merges after #4590, which restores `main` to green.