### PR TITLE
test(e2e): compile lazy surface chunks once in a serial warmup project

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,6 +37,8 @@ const PERSISTED_SCREEN_SCALE_TEST = /persisted screen magnification scales the a
 const SETUP_FOCUS_VISIBILITY_TEST =
   /keeps setup (?:controls focus-visible|diagnostics focus contained) in WebKit$/;
 const MOBILE_FOUNDATIONS_SPEC = /mobile\/foundations\.spec\.ts/;
+// Not a `.spec.ts`, so no ordinary project's testMatch picks it up.
+const WARMUP_SETUP = /warmup\.setup\.ts/;
 
 // Most existing specs exercise an already-onboarded workspace. Seed that
 // baseline explicitly now that chat/home correctly block an empty registry;
@@ -119,8 +121,19 @@ export default defineConfig({
     // prior value, then release the normal fully-parallel projects. This keeps
     // the desktop/Chromium-mobile/WebKit coverage without leaking scale=125
     // into unrelated tests or racing another project's cleanup.
+    // Under `next dev` a `next/dynamic` chunk is COMPILED on first open, so the
+    // first test to open a lazy surface pays that cold compile inside its own
+    // assertion budget — 28.3s cold vs 2-3s warm, against 30s timeouts, which
+    // is exactly why keyboard-shortcuts and task-work-fit rotated between
+    // "flaky" and "failed" on CI (cave-ct2k7). Pay it once here instead.
+    {
+      name: "warmup",
+      testMatch: WARMUP_SETUP,
+      use: { ...devices["Desktop Chrome"] },
+    },
     {
       name: "preferences-desktop",
+      dependencies: ["warmup"],
       testMatch: MOBILE_FOUNDATIONS_SPEC,
       grep: PERSISTED_SCREEN_SCALE_TEST,
       use: { ...devices["Desktop Chrome"] },

--- a/tests/warmup.setup.ts
+++ b/tests/warmup.setup.ts
@@ -1,0 +1,155 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// Compile the code-split surface chunks ONCE, serially, before the parallel
+// projects run (cave-ct2k7).
+//
+// WHY THIS EXISTS. The heavy surfaces in `@/components/lazy-surfaces` are
+// `next/dynamic` chunks, so the browser fetches each one on FIRST open — and
+// under `next dev` that fetch is a Turbopack compile, not a static file read.
+// The first test to open such a surface therefore pays the whole cold compile
+// inside its own assertion budget, and whichever test that happens to be is
+// the one that flakes:
+//
+//   keyboard-shortcuts.spec.ts:44  — ⌘K, waiting on the `command-palette` chunk
+//   task-work-fit.spec.ts:277      — reopen strip, waiting on `workspace-rail`
+//
+// Measured in this worktree (2026-08-12, M-series laptop):
+//
+//   warm .next, any worker count     — 2-3s     (passes comfortably)
+//   cold .next, 1 worker             — 28.3s    (passes; the poll budget is 30s)
+//   cold .next, 4 workers            — >30s     (fails)
+//
+// CI is cold on every run, so those tests sit right at the boundary and rotate
+// between "flaky" (saved by the retry, which runs warm) and "failed". Note the
+// cost is NOT the surface under test: `command-palette` renders `loading: null`
+// while its chunk compiles, so the page looks exactly as it does when the
+// shortcut never fired. That is why this reads as a mysterious dead keybinding
+// rather than a slow one.
+//
+// Raising the individual timeouts would only make each spec fail slower and
+// leave the next lazy surface to rediscover the same cliff. Paying the compile
+// once, here, in a serial project every other project depends on, removes the
+// racing input instead: by the time the parallel projects start, every chunk
+// below is already built.
+//
+// This file is `.setup.ts`, not `.spec.ts`, so the ordinary projects' testMatch
+// (`/.*\.spec\.ts/`) never picks it up as a test of its own.
+
+const ISO = "2026-06-12T10:00:00.000Z";
+
+const FAMILIAR = {
+  id: "nova",
+  display_name: "Nova",
+  role: "Orchestrator",
+  status: "active",
+  icon: "ph:sparkle-fill",
+};
+
+// A repo-linked session is what makes the code rail available at all.
+const REPO_SESSION = {
+  id: "s-repo",
+  title: "Warmup session",
+  status: "running",
+  origin: "chat",
+  harness: "claude",
+  familiarId: "nova",
+  model: "openclaw-local",
+  runtime: "local",
+  project_root: "/repo/alpha",
+  exit_code: null,
+  archived_at: null,
+  created_at: ISO,
+  updated_at: ISO,
+};
+
+const REPO_PROJECT = {
+  id: "repo-alpha",
+  name: "alpha",
+  root: "/repo/alpha",
+  access: "write",
+  createdAt: ISO,
+  updatedAt: ISO,
+};
+
+// Four times the cold serial measurement above. A chunk that cannot compile in
+// two minutes is a genuine dev-server problem, and failing here says so once
+// rather than leaving every spec to time out on its own.
+const CHUNK_TIMEOUT = 120_000;
+
+async function boot(page: Page) {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("cave:active-familiar", "nova");
+    window.localStorage.setItem("cave:onboarding:dismissed", "1");
+    window.localStorage.setItem("cave:code-rail:pinned:v1", "false");
+    // Nav is minimized-by-default; keep it expanded so the rail keeps its room.
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3", "1");
+    window.localStorage.setItem("cave:shell:min-applied:cave.shell.widths.v3.two-pane", "1");
+  });
+  await page.route("**/api/familiars**", (route) =>
+    route.fulfill({ json: { ok: true, familiars: [FAMILIAR] } }),
+  );
+  await page.route("**/api/sessions/list**", (route) =>
+    route.fulfill({ json: { ok: true, sessions: [REPO_SESSION] } }),
+  );
+  await page.route("**/api/projects**", (route) =>
+    route.fulfill({ json: { ok: true, projects: [REPO_PROJECT] } }),
+  );
+  await page.route("**/api/changes**", (route) =>
+    route.fulfill({ json: { ok: true, repo: true, repoRoot: "/repo/alpha", files: [] } }),
+  );
+  await page.route("**/api/chat/conversation/**", (route) =>
+    route.fulfill({
+      json: {
+        ok: true,
+        conversation: { turns: [{ id: "t1", role: "assistant", text: "On it.", createdAt: ISO }] },
+        context: {},
+      },
+    }),
+  );
+
+  await page.goto("/?mode=chat");
+  await page.keyboard.press("Meta+2");
+  await page.waitForSelector(".chat-surface", { timeout: CHUNK_TIMEOUT });
+}
+
+test("warm the code-split surface chunks", async ({ page }) => {
+  // The whole point is to absorb a cold compile, so this one test gets a budget
+  // no ordinary spec should ever need.
+  test.setTimeout(600_000);
+
+  await boot(page);
+
+  // `command-palette` — the chunk keyboard-shortcuts.spec.ts waits on through
+  // its ⌘K readiness poll. Poll rather than press once: before the Workspace
+  // effect attaches, the keypress lands on nothing at all.
+  const palette = page.getByRole("dialog", { name: "Command palette" });
+  await page.mouse.click(5, 5);
+  await expect
+    .poll(
+      async () => {
+        await page.keyboard.press("Meta+k");
+        return palette.isVisible();
+      },
+      { timeout: CHUNK_TIMEOUT, message: "command-palette chunk should compile and open" },
+    )
+    .toBe(true);
+  await page.keyboard.press("Escape");
+  await expect(palette).toBeHidden();
+
+  // `shortcuts-sheet` — the surface those specs actually assert on.
+  await page.mouse.click(5, 5);
+  await page.keyboard.press("?");
+  const sheet = page.getByRole("dialog", { name: /Keyboard shortcuts/ });
+  await expect(sheet).toBeVisible({ timeout: CHUNK_TIMEOUT });
+  await page.keyboard.press("Escape");
+  await expect(sheet).toBeHidden();
+
+  // `workspace-rail` — the chunk task-work-fit.spec.ts waits on after clicking
+  // the reopen strip. Reached here from chat rather than the board cockpit;
+  // it is the same lazy component either way, and this path needs no bridge.
+  await page.locator(".chat-sidebar").getByText("Warmup session", { exact: false }).first().click();
+  const reopen = page.locator(".workspace-rail-reopen");
+  await expect(reopen).toBeVisible({ timeout: CHUNK_TIMEOUT });
+  await reopen.click();
+  await expect(page.locator(".workspace-rail")).toBeVisible({ timeout: CHUNK_TIMEOUT });
+});


### PR DESCRIPTION
## Summary

`keyboard-shortcuts.spec.ts:44` and `task-work-fit.spec.ts:277` rotated between `flaky` and `failed` across CI runs (cave-ct2k7). Neither is a product bug.

The surfaces those tests open are `next/dynamic` chunks from `src/components/lazy-surfaces.tsx` — `command-palette` and `workspace-rail`. Under `next dev` the first fetch of a chunk is a Turbopack **compile**, not a static file read, so whichever test opens a lazy surface first pays that cold compile inside its own assertion budget.

It reads as a dead keybinding rather than a slow one because `CommandPalette` is declared `loading: () => null`: while the chunk compiles, a fully hydrated, fully interactive page renders no dialog at all — identical to a page where the shortcut never fired. The captured failure snapshot shows exactly that.

## Measurements

Same two tests, `--project=desktop --retries=0`, on this branch:

| condition | result |
|---|---|
| warm `.next`, any worker count | 2-3s, passes |
| cold `.next`, 1 worker | 28.3s, passes — against a 30s poll budget |
| cold `.next`, 4 workers | over 30s, **fails** |

CI is cold on every run, which puts both specs on that boundary. It also explains why only the *first* test in `keyboard-shortcuts.spec.ts` was flaky while its two siblings share the same `gotoApp` helper — the siblings run warm.

## The fix

Pay the compile once, serially, in a `warmup` project every other project depends on. Raising the two timeouts would only make each spec fail slower and leave the next lazy surface to rediscover the same cliff.

`tests/warmup.setup.ts` is `.setup.ts` rather than `.spec.ts`, so no ordinary project's `testMatch` (`/.*\.spec\.ts/`) picks it up as a test of its own.

## Verification

Cold `.next` (`rm -rf .next`), 4 workers, `--repeat-each=2`, full dependency chain:

```
✓ [warmup] warm the code-split surface chunks (38.7s)
✓ [preferences-desktop] / [preferences-pixel-5] / [preferences-iphone-13]
✓ [desktop] keyboard shortcuts sheet … (3.6s)
✓ [desktop] keyboard shortcuts sheet … (4.1s)
✓ [desktop] Task Work cockpit fit … (6.8s)
✓ [desktop] Task Work cockpit fit … (6.9s)
8 passed (57.2s)
```

The identical cold 4-worker run **without** the warmup fails `keyboard-shortcuts` 2 out of 2. The warmup absorbs 38.7s once and the previously-flaky test drops to under four seconds.

Bead: `cave-ct2k7`