### PR TITLE
fix(worktree): archive a remote-deleted branch instead of resurrecting it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -656,6 +656,27 @@ immutable and unique, so it never force-updates, never collides, and
 never opens a PR, never deletes or rewrites a ref, and **skips `main`** —
 pushing that is the direct-to-main move this file forbids.
 
+**One case skips the branch push entirely: a branch the remote has deleted**
+(`cave-fud4p`). The repository sets `delete_branch_on_merge: true`, so a merged
+PR head disappears from origin — and because a squash merge lands a *different*
+commit on `main`, the branch's own tip is then on no remote ref at all. That is
+exactly when a session turns to retiring the worktree, so retention matters
+most precisely when it has just evaporated. Pushing the branch here would
+*succeed* and resurrect it, which undoes a deliberate deletion and pushes back
+against the 40-branch cap — the `cave-nw3hq` resurrection, whose existing fix
+only covers heads that already carry an archive tag. So the hook archives the
+head as its `retention/…` tag instead, and the log entry carries
+`reason: "branch-deleted-upstream"`.
+
+Deleted is distinguished from never-pushed by the local remote-tracking ref:
+`refs/remotes/origin/<branch>` is written by a push and survives the remote
+dropping the branch, so tracking-ref-present + absent-from-`ls-remote` means
+deleted. A branch that never left the machine has no such ref and is still
+retained as a readable branch. Note `git push --delete` is **not** equivalent to
+a server-side deletion — it removes the local tracking ref too — and if a
+`fetch --prune` has already run the signal is gone, in which case the hook falls
+back to its previous behaviour: a resurrected branch, never a lost commit.
+
 Throttled to once a minute (`.claude/worktree-retention-push.stamp`) and capped
 at 3 pushes per pass to bound the latency added to one tool call; pushed
 worktrees drop out of the at-risk set, so successive passes reach the rest.

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -128,6 +128,54 @@ export function remoteTagCommits(worktreePath) {
   }
 }
 
+/**
+ * Branch names the remote currently advertises.
+ *
+ * Collected so this hook can tell a branch that was never pushed from one the
+ * remote has since DELETED. Both are absent from `ls-remote`; only the second
+ * must not be re-created.
+ *
+ * Returns null when the remote cannot be reached, which the caller treats as
+ * "no proof of deletion" and falls back to the branch-first path — the same
+ * safe direction remoteTagCommits takes.
+ */
+export function remoteBranchNames(worktreePath) {
+  try {
+    const output = git(["ls-remote", "--heads", "origin"], worktreePath, PUSH_TIMEOUT_MS);
+    const names = new Set();
+    for (const line of output.split("\n")) {
+      const ref = line.slice(41).trim();
+      if (ref.startsWith("refs/heads/")) names.add(ref.slice("refs/heads/".length));
+    }
+    return names;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Did this branch ever exist on the remote?
+ *
+ * `refs/remotes/origin/<branch>` is written by a push or fetch of that branch
+ * and survives the remote deleting it, until something prunes. So a local
+ * remote-tracking ref plus an absence from `ls-remote --heads` is a branch the
+ * remote deleted — a merged-and-auto-deleted PR head, in practice.
+ *
+ * A branch that has never been pushed has no such ref, so it stays on the
+ * branch-first path and is still retained as a branch. If a prune has already
+ * run, this reads false and the branch is pushed as before: a resurrected
+ * branch, which is the pre-existing behaviour, never a lost commit.
+ */
+export function hadRemoteTracking(worktreePath, branch) {
+  if (!branch) return false;
+  try {
+    git(["rev-parse", "--verify", "--quiet", `refs/remotes/origin/${branch}`], worktreePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 function branchOf(worktreePath) {
   try {
     const name = git(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath).trim();
@@ -170,9 +218,12 @@ function record(root, entry) {
 // created branch above 40 — fall back to a tag named for the exact commit.
 // The tag is immutable and unique, so it never force-updates and never
 // collides, and `branch-cap.yml` ignores it (`ref_type == 'branch'` only).
-export function retain(worktreePath, root, branch) {
+// `preferTag` skips the branch push entirely rather than letting it fail into
+// the fallback: when the remote deleted the branch, pushing it SUCCEEDS and
+// re-creates it, so there is no failure to fall back from.
+export function retain(worktreePath, root, branch, { preferTag = false } = {}) {
   const sha = git(["rev-parse", "HEAD"], worktreePath).trim();
-  if (branch) {
+  if (branch && !preferTag) {
     try {
       git(["push", "origin", `refs/heads/${branch}:refs/heads/${branch}`], worktreePath, PUSH_TIMEOUT_MS);
       return { verdict: "pushed-branch", branch, sha };
@@ -187,7 +238,13 @@ export function retain(worktreePath, root, branch) {
   }
   const tag = retentionTag(branch ?? "detached", sha);
   git(["push", "origin", `${sha}:refs/tags/${tag}`], worktreePath, PUSH_TIMEOUT_MS);
-  return { verdict: "pushed-tag", branch, sha, tag };
+  return {
+    verdict: "pushed-tag",
+    branch,
+    sha,
+    tag,
+    ...(preferTag ? { reason: "branch-deleted-upstream" } : {}),
+  };
 }
 
 function main() {
@@ -210,6 +267,17 @@ function main() {
     if (!tagCommits || tagCommits.size === 0) return false;
     const head = headSha(worktreePath);
     return head !== null && tagCommits.has(head);
+  };
+
+  // Same lazy-once-per-pass shape as tagRetained: a pass where nothing is at
+  // risk never reaches the network.
+  let branchNames;
+  const deletedUpstream = (worktreePath, branch) => {
+    if (!branch) return false;
+    if (branchNames === undefined) branchNames = remoteBranchNames(root);
+    if (!branchNames) return false; // remote unreachable — no proof, stay branch-first
+    if (branchNames.has(branch)) return false;
+    return hadRemoteTracking(worktreePath, branch);
   };
 
   let pushes = 0;
@@ -237,9 +305,21 @@ function main() {
       continue;
     }
 
+    // The remote deleted this branch — a squash-merged PR head under
+    // `delete_branch_on_merge`, in practice. Pushing the branch here SUCCEEDS
+    // and resurrects it, which undoes a deliberate deletion, puts the branch
+    // back against `branch-cap.yml`'s 40-branch ceiling, and can then lose the
+    // retention again when the cap rolls it back. Retain as a tag instead: the
+    // guard already reads a pushed tag as retention, and `branch-cap.yml`
+    // ignores tags (`ref_type == 'branch'` only).
+    //
+    // The commits still need retaining — a squash merge puts a DIFFERENT
+    // commit on main, so this head is on no remote ref at all (cave-fud4p).
+    const preferTag = deletedUpstream(wt.path, branch);
+
     pushes += 1;
     try {
-      record(root, { worktree: wt.path, unpushed, ...retain(wt.path, root, branch) });
+      record(root, { worktree: wt.path, unpushed, ...retain(wt.path, root, branch, { preferTag }) });
     } catch (error) {
       record(root, {
         verdict: "retention-failed",

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -8,8 +8,10 @@ import test from "node:test";
 const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
 
 import {
+  hadRemoteTracking,
   headSha,
   parseWorktrees,
+  remoteBranchNames,
   remoteTagCommits,
   retain,
   retentionTag,
@@ -232,6 +234,134 @@ test("remoteTagCommits returns null when the remote cannot be reached", () => {
   try {
     git(["remote", "set-url", "origin", path.join(root, "does-not-exist.git")], work);
     assert.equal(remoteTagCommits(work), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("remoteBranchNames reads the heads the remote advertises", () => {
+  const { root, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/live"], work);
+    commit(work, "one");
+    git(["push", "-q", "origin", "feat/live"], work);
+
+    const names = remoteBranchNames(work);
+    assert.ok(names instanceof Set);
+    assert.ok(names.has("feat/live"), "a pushed branch is advertised");
+    assert.ok(names.has("main"));
+    assert.ok(!names.has("feat/never-pushed"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("remoteBranchNames returns null when the remote cannot be reached", () => {
+  // Null is "no proof of deletion", which keeps the branch-first path — the
+  // same safe direction remoteTagCommits takes.
+  const { root, work } = scaffold();
+  try {
+    git(["remote", "set-url", "origin", path.join(root, "does-not-exist.git")], work);
+    assert.equal(remoteBranchNames(work), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("hadRemoteTracking separates a deleted branch from one never pushed", () => {
+  // This is the whole distinction the deleted-upstream rule rests on: both are
+  // absent from `ls-remote --heads`, and only one must not be re-created.
+  //
+  // The branch is dropped ON THE REMOTE rather than with `git push --delete`,
+  // because that is what GitHub's delete_branch_on_merge does — and the two are
+  // not equivalent locally: `push --delete` also removes this clone's
+  // refs/remotes/origin/<branch>, while a server-side deletion leaves it until
+  // something prunes. Deleting through the clone here would test a shape that
+  // never occurs and would report the rule broken when it is not.
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/was-pushed"], work);
+    commit(work, "one");
+    git(["push", "-q", "origin", "feat/was-pushed"], work);
+    bare(["update-ref", "-d", "refs/heads/feat/was-pushed"], remote);
+
+    assert.equal(
+      hadRemoteTracking(work, "feat/was-pushed"),
+      true,
+      "the remote-tracking ref survives the remote deleting the branch",
+    );
+
+    git(["checkout", "-q", "-b", "feat/fresh"], work);
+    commit(work, "two");
+    assert.equal(
+      hadRemoteTracking(work, "feat/fresh"),
+      false,
+      "a branch that never left the machine has no remote-tracking ref",
+    );
+    assert.equal(hadRemoteTracking(work, null), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("retain with preferTag archives the head WITHOUT resurrecting the deleted branch", () => {
+  // The cave-fud4p case end to end: squash-merge + delete_branch_on_merge. The
+  // branch is gone from the remote and the squash put a DIFFERENT commit on
+  // main, so this head is on no remote ref at all. Pushing the branch would
+  // succeed and undo the deletion, so retention has to be the tag.
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "fix/merged-topic"], work);
+    commit(work, "one");
+    git(["push", "-q", "origin", "fix/merged-topic"], work);
+    const sha = git(["rev-parse", "HEAD"], work).trim();
+
+    // Squash the work onto main as a different commit, exactly as GitHub does.
+    git(["checkout", "-q", "main"], work);
+    git(["merge", "-q", "--squash", "fix/merged-topic"], work);
+    git(["commit", "-q", "-m", "squashed topic (#1)"], work);
+    git(["push", "-q", "origin", "main"], work);
+    // ...then auto-delete the head branch, server-side as GitHub does.
+    bare(["update-ref", "-d", "refs/heads/fix/merged-topic"], remote);
+    git(["checkout", "-q", "fix/merged-topic"], work);
+
+    assert.ok(
+      !remoteBranchNames(work).has("fix/merged-topic"),
+      "precondition: the remote no longer has the branch",
+    );
+    assert.notEqual(
+      bare(["rev-parse", "refs/heads/main"], remote).trim(),
+      sha,
+      "precondition: the squash landed a different commit, so this head is unretained",
+    );
+
+    const result = retain(work, root, "fix/merged-topic", { preferTag: true });
+
+    assert.equal(result.verdict, "pushed-tag");
+    assert.equal(result.reason, "branch-deleted-upstream");
+    assert.equal(bare(["rev-parse", `refs/tags/${result.tag}^{commit}`], remote).trim(), sha);
+    assert.throws(
+      () => bare(["rev-parse", "--verify", "refs/heads/fix/merged-topic"], remote),
+      "the deleted branch must NOT come back",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("retain still pushes the branch when preferTag is not set", () => {
+  // Guards the default: only a proven upstream deletion diverts to a tag, so
+  // ordinary in-progress work is still retained as a readable branch.
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/in-progress"], work);
+    commit(work, "one");
+    const sha = git(["rev-parse", "HEAD"], work).trim();
+
+    const result = retain(work, root, "feat/in-progress");
+
+    assert.equal(result.verdict, "pushed-branch");
+    assert.equal(bare(["rev-parse", "refs/heads/feat/in-progress"], remote).trim(), sha);
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## The gap

This repository sets `delete_branch_on_merge: true` (verified live) alongside squash merges. Together they mean a merged PR head is reachable from **no remote ref at all**:

- the squash lands a *different* commit on `main`, so the branch's own tip is not an ancestor of it
- GitHub then deletes the branch that held that tip

And that is precisely the moment a session turns to retiring its worktree — retention evaporates exactly when it is about to be relied on.

The retention hook made this worse rather than better. Its branch-first push **succeeds** against a deleted branch, so it *resurrected* the head: undoing a deliberate deletion, putting the branch back against `branch-cap.yml`'s 40-branch ceiling, and potentially losing retention again when the cap rolls it back. That is the `cave-nw3hq` resurrection — whose existing fix only covers heads that already carry an archive tag, so an unarchived merged head had nothing protecting it.

## Observed

On `cave-ct2k7` today: PR #4592 merged, `gh pr merge` was deliberately run **without** `--delete-branch` per the repo rule, and origin lost the branch anyway. `834107a674` was unreachable from any remote ref until an archive tag was pushed by hand. Without that step, removing the worktree would have been lossy — and the guard's own suggested unblock is `WT_GUARD_BYPASS=1`, i.e. it teaches the bypass at the moment the bypass is unsafe.

## The change

Retain such a head as its `retention/<flattened-branch>-<sha>` tag instead of pushing the branch. The guard already reads a pushed tag as retention, `branch-cap.yml` ignores tags (`ref_type == 'branch'` only), and a tag outlives a branch because merging never deletes it.

**Deleted vs never-pushed** is the whole distinction, since both are absent from `ls-remote --heads`. It is drawn on the local remote-tracking ref: `refs/remotes/origin/<branch>` is written by a push and survives the remote dropping the branch, so tracking-ref-present + absent-from-`ls-remote` means deleted. A branch that never left the machine has no such ref and keeps the branch-first path, still retained as a readable branch.

Both new probes **fail safe**: an unreachable remote is "no proof of deletion" and stays branch-first, matching how `remoteTagCommits` already behaves. The lookup is lazy once per pass, so a pass with nothing at risk still never touches the network.

## Verification

`node --test scripts/worktree-retention-push.test.mjs` — 15 pass, 0 fail (6 new).

The new cases cover the end-to-end shape (push branch → squash onto main as a different commit → delete the head → assert the tag lands on the exact sha **and** the branch does not come back), the never-pushed branch keeping branch-first, and both probes returning null on an unreachable remote.

⚠️ Worth knowing if you extend these tests: `git push --delete` is **not** equivalent to a server-side deletion — it also removes the local tracking ref. My first fixture used it and the rule looked broken when it was not. The fixtures now drop the branch on the bare remote directly, which is what GitHub does.

Bead: `cave-fud4p` (discovered-from `cave-ct2k7`)