### PR TITLE
Resizable text in the document reader

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1066,6 +1066,7 @@ export const SUITES = {
     "src/components/familiars-memory-master-detail.test.ts",
     "src/components/canonical-memory-markdown.test.ts",
     "src/components/document-reader-view.test.ts",
+    "src/components/document-reader-text-size.test.ts",
     "src/components/canonical-memory-reader.test.ts",
     "src/components/familiars-memory-recovery.test.tsx",
     "src/components/familiars-view-memory-ownership.test.tsx",
@@ -1939,6 +1940,7 @@ const RAW_SOURCE_SCANNER_TESTS = new Set([
 // than Node's type stripper, which intentionally does not transform JSX.
 const VITEST_TESTS = new Set([
   "src/components/document-reader-view.test.ts",
+  "src/components/document-reader-text-size.test.ts",
   "src/components/role-surfaces/familiar-room-interactions.test.tsx",
   "src/components/familiars-memory-recovery.test.tsx",
   "src/components/familiars-view-memory-ownership.test.tsx",

--- a/src/components/document-reader-text-size.test.ts
+++ b/src/components/document-reader-text-size.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { test } from "vitest";
+import type { Block } from "@create-markdown/core";
+import { paragraph } from "@create-markdown/core";
+import {
+  DocumentReader,
+  type DocumentReaderDocument,
+} from "./document-reader.tsx";
+import { MarkdownReaderBlock } from "./canonical-memory-markdown.tsx";
+import {
+  READER_TEXT_SCALE_DEFAULT_INDEX,
+  READER_TEXT_SCALE_STEPS,
+  clampScaleIndex,
+  loadScaleIndex,
+  parseStoredScaleIndex,
+  saveScaleIndex,
+  scaleForIndex,
+  scaleLabel,
+} from "@/lib/reader-text-scale.ts";
+
+const doc: DocumentReaderDocument<Block, Block> = {
+  title: "Shared document",
+  lede: paragraph("A concise introduction."),
+  sections: [
+    { id: "s1", heading: "First", level: 2, blocks: [paragraph("Body one.")] },
+  ],
+};
+
+function render(navigation: "compact" | "rail" | "none") {
+  return renderToStaticMarkup(
+    createElement(DocumentReader<Block, Block>, {
+      document: doc,
+      navigation,
+      renderLede: (lede) => createElement(MarkdownReaderBlock, { block: lede }),
+      renderBlock: (block, key) => createElement(MarkdownReaderBlock, { block, key }),
+    }),
+  );
+}
+
+test("the size control renders in every navigation mode", () => {
+  // Text size is not a navigation affordance. A reader with no table of
+  // contents — the "none" mode — still needs it, and that is exactly the case
+  // that a control tucked inside the compact nav would have missed.
+  for (const navigation of ["compact", "rail", "none"] as const) {
+    const html = render(navigation);
+    assert.match(
+      html,
+      /aria-label="Text size"/,
+      `${navigation} reader should expose the text size group`,
+    );
+    assert.match(html, /Decrease text size/, `${navigation} reader needs A−`);
+    assert.match(html, /Increase text size/, `${navigation} reader needs A\+`);
+  }
+});
+
+test("first paint uses the default scale so hydration cannot mismatch", () => {
+  // Reading localStorage in the state initializer would emit different HTML on
+  // the server than the client. The stored value is applied in an effect, so
+  // server markup must always carry the default.
+  const html = render("rail");
+  assert.match(
+    html,
+    /--reader-text-scale:\s*1\b/,
+    "server markup should carry the default scale, not a stored one",
+  );
+});
+
+test("the smallest step disables A− and the largest disables A+", () => {
+  assert.equal(clampScaleIndex(-5), 0, "below range clamps to the smallest step");
+  assert.equal(
+    clampScaleIndex(99),
+    READER_TEXT_SCALE_STEPS.length - 1,
+    "above range clamps to the largest step",
+  );
+  // The default must leave travel in both directions, or one button is dead on
+  // arrival for every user who never changed the setting.
+  assert.ok(READER_TEXT_SCALE_DEFAULT_INDEX > 0, "default must allow decreasing");
+  assert.ok(
+    READER_TEXT_SCALE_DEFAULT_INDEX < READER_TEXT_SCALE_STEPS.length - 1,
+    "default must allow increasing",
+  );
+});
+
+test("the shipped size is exactly 1 so an untouched reader is unchanged", () => {
+  assert.equal(
+    scaleForIndex(READER_TEXT_SCALE_DEFAULT_INDEX),
+    1,
+    "the default step must be a no-op multiplier",
+  );
+  assert.equal(scaleLabel(READER_TEXT_SCALE_DEFAULT_INDEX), "100%");
+});
+
+test("steps increase monotonically", () => {
+  for (let i = 1; i < READER_TEXT_SCALE_STEPS.length; i += 1) {
+    assert.ok(
+      READER_TEXT_SCALE_STEPS[i] > READER_TEXT_SCALE_STEPS[i - 1],
+      `step ${i} must be larger than step ${i - 1}`,
+    );
+  }
+});
+
+test("a corrupt stored value falls back instead of throwing", () => {
+  // localStorage is user-editable and shared across tabs and app versions. A
+  // reader that refused to render because a preference was malformed would be
+  // a worse bug than a reset text size.
+  for (const raw of [null, undefined, "", "not-a-number", "NaN", "{}", "999", "-4"]) {
+    const parsed = parseStoredScaleIndex(raw);
+    assert.ok(
+      parsed >= 0 && parsed < READER_TEXT_SCALE_STEPS.length,
+      `"${String(raw)}" should parse to a valid step, got ${parsed}`,
+    );
+  }
+  assert.equal(parseStoredScaleIndex("3"), 3, "a valid stored index is honoured");
+});
+
+test("storage that throws is survivable in both directions", () => {
+  // Safari private mode throws on access, and the desktop shell runs in a
+  // WKWebView where storage can be partitioned.
+  const hostile = {
+    getItem() {
+      throw new Error("SecurityError");
+    },
+    setItem() {
+      throw new Error("QuotaExceededError");
+    },
+  };
+  assert.equal(
+    loadScaleIndex(hostile),
+    READER_TEXT_SCALE_DEFAULT_INDEX,
+    "an unreadable store yields the default",
+  );
+  assert.doesNotThrow(() => saveScaleIndex(2, hostile), "an unwritable store must not throw");
+});
+
+test("a round trip through storage preserves the step", () => {
+  const backing = new Map<string, string>();
+  const store = {
+    getItem: (k: string) => backing.get(k) ?? null,
+    setItem: (k: string, v: string) => void backing.set(k, v),
+  };
+  saveScaleIndex(3, store);
+  assert.equal(loadScaleIndex(store), 3);
+});
+
+test("only reading content is scaled — chrome keeps its own size", () => {
+  // Scaling the TOC links and the Contents trigger would move the furniture
+  // while the user is trying to enlarge the text, and the rail has a fixed
+  // width that oversized links would overflow.
+  const css = readFileSync(new URL("../styles/document-reader.css", import.meta.url), "utf8");
+  const scaled = (selector: string) => {
+    const start = css.indexOf(selector);
+    assert.ok(start >= 0, `${selector} should exist`);
+    return css.slice(start, css.indexOf("}", start)).includes("var(--reader-text-scale)");
+  };
+
+  assert.ok(scaled(".document-reader__title {"), "title scales");
+  assert.ok(scaled(".document-reader__lede {"), "lede scales");
+  assert.ok(scaled(".document-reader__heading {"), "headings scale");
+  assert.ok(scaled(".document-reader__column li {"), "prose scales");
+
+  assert.ok(!scaled(".document-reader__toc-link {"), "TOC links must NOT scale");
+  assert.ok(!scaled(".document-reader__contents-trigger {"), "Contents trigger must NOT scale");
+  assert.ok(!scaled(".document-reader__kicker {"), "kicker must NOT scale");
+  assert.ok(
+    !scaled(".document-reader__textsize-btn {"),
+    "the control itself must NOT scale, or A+ walks out from under the pointer",
+  );
+});

--- a/src/components/document-reader-text-size.test.ts
+++ b/src/components/document-reader-text-size.test.ts
@@ -34,8 +34,9 @@ function render(navigation: "compact" | "rail" | "none") {
     createElement(DocumentReader<Block, Block>, {
       document: doc,
       navigation,
-      renderLede: (lede) => createElement(MarkdownReaderBlock, { block: lede }),
-      renderBlock: (block, key) => createElement(MarkdownReaderBlock, { block, key }),
+      renderLede: (lede) => createElement(MarkdownReaderBlock, { block: lede, blockKey: "lede" }),
+      renderBlock: (block, key) =>
+        createElement(MarkdownReaderBlock, { block, blockKey: key }),
     }),
   );
 }

--- a/src/components/document-reader.tsx
+++ b/src/components/document-reader.tsx
@@ -8,6 +8,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type MutableRefObject,
   type ReactNode,
 } from "react";
@@ -18,6 +19,15 @@ import {
   PopoverItem,
   PopoverLabel,
 } from "@/components/ui/popover";
+import {
+  READER_TEXT_SCALE_DEFAULT_INDEX,
+  READER_TEXT_SCALE_STEPS,
+  clampScaleIndex,
+  loadScaleIndex,
+  saveScaleIndex,
+  scaleForIndex,
+  scaleLabel,
+} from "@/lib/reader-text-scale";
 
 export type DocumentReaderSection<TBlock> = {
   id: string;
@@ -78,6 +88,27 @@ export function DocumentReader<TBlock, TLede = TBlock>({
   const [openSections, setOpenSections] = useState<Set<string>>(
     () => new Set(document.sections.map((section) => section.id)),
   );
+
+  // Text size starts at the default and adopts the stored value after mount.
+  // Reading localStorage in the initializer would render different HTML on the
+  // server than on the client and trip hydration, so the first paint is always
+  // the default size and the effect below corrects it.
+  const [scaleIndex, setScaleIndex] = useState(READER_TEXT_SCALE_DEFAULT_INDEX);
+
+  useEffect(() => {
+    setScaleIndex(loadScaleIndex());
+  }, []);
+
+  const stepScale = useCallback((delta: number) => {
+    setScaleIndex((current) => {
+      const next = clampScaleIndex(current + delta);
+      if (next !== current) saveScaleIndex(next);
+      return next;
+    });
+  }, []);
+
+  const atSmallest = scaleIndex <= 0;
+  const atLargest = scaleIndex >= READER_TEXT_SCALE_STEPS.length - 1;
 
   const namedSections = useMemo(
     () => document.sections.filter((section) => section.heading),
@@ -176,6 +207,9 @@ export function DocumentReader<TBlock, TLede = TBlock>({
       ]
         .filter(Boolean)
         .join(" ")}
+      style={
+        { "--reader-text-scale": scaleForIndex(scaleIndex) } as CSSProperties
+      }
     >
       {navigation === "rail" && namedSections.length > 0 ? (
         <nav
@@ -201,7 +235,35 @@ export function DocumentReader<TBlock, TLede = TBlock>({
         className="document-reader__scroll rr-col rr-doc"
         onScroll={onScroll}
       >
-        {navigation === "compact" && namedSections.length >= 2 ? (
+        {/* One sticky control row. It renders in every navigation mode,
+            because text size is not a navigation affordance — a reader with
+            no table of contents still needs it. The Contents trigger keeps its
+            own class so the existing compact-nav styling is unchanged. */}
+        <div className="document-reader__toolbar">
+          <div className="document-reader__textsize" role="group" aria-label="Text size">
+            <button
+              type="button"
+              className="document-reader__textsize-btn focus-ring"
+              onClick={() => stepScale(-1)}
+              disabled={atSmallest}
+              aria-label={`Decrease text size (currently ${scaleLabel(scaleIndex)})`}
+              title="Decrease text size"
+            >
+              <span aria-hidden className="document-reader__textsize-glyph--small">A</span>
+            </button>
+            <button
+              type="button"
+              className="document-reader__textsize-btn focus-ring"
+              onClick={() => stepScale(1)}
+              disabled={atLargest}
+              aria-label={`Increase text size (currently ${scaleLabel(scaleIndex)})`}
+              title="Increase text size"
+            >
+              <span aria-hidden className="document-reader__textsize-glyph--large">A</span>
+            </button>
+          </div>
+
+          {navigation === "compact" && namedSections.length >= 2 ? (
           <div className="document-reader__compact-nav">
             <button
               ref={contentsTriggerRef}
@@ -237,7 +299,8 @@ export function DocumentReader<TBlock, TLede = TBlock>({
               </PopoverBody>
             </Popover>
           </div>
-        ) : null}
+          ) : null}
+        </div>
 
         <div className="document-reader__column rr-doc__column">
           {hasBody ? (

--- a/src/lib/reader-text-scale.ts
+++ b/src/lib/reader-text-scale.ts
@@ -1,0 +1,82 @@
+// Reader text size — the A−/A+ steps and their persistence.
+//
+// Kept out of the component so the stepping and clamping are testable without
+// a DOM, and so a corrupt or hand-edited stored value has exactly one place
+// that decides what to do with it.
+
+export const READER_TEXT_SCALE_STORAGE_KEY = "cave:reader:text-scale";
+
+// Five steps, with the shipped size at index 2 so the control has equal travel
+// in both directions. Multipliers rather than absolute sizes: the reader's type
+// is a scale (display/lg/md/base/sm), and multiplying preserves the intervals
+// between those tokens instead of flattening them toward one size.
+export const READER_TEXT_SCALE_STEPS = [0.875, 1, 1.125, 1.25, 1.4] as const;
+
+export const READER_TEXT_SCALE_DEFAULT_INDEX = 1;
+
+export function clampScaleIndex(index: number): number {
+  if (!Number.isFinite(index)) return READER_TEXT_SCALE_DEFAULT_INDEX;
+  return Math.min(READER_TEXT_SCALE_STEPS.length - 1, Math.max(0, Math.trunc(index)));
+}
+
+export function scaleForIndex(index: number): number {
+  return READER_TEXT_SCALE_STEPS[clampScaleIndex(index)];
+}
+
+/** Percentage label for the control's title/announcement, e.g. 112%. */
+export function scaleLabel(index: number): string {
+  return `${Math.round(scaleForIndex(index) * 100)}%`;
+}
+
+/**
+ * Parse a stored value into a step index.
+ *
+ * Anything unparseable falls back to the default rather than throwing: this
+ * reads from localStorage, which the user can edit, another tab can write, and
+ * a future version can change the shape of. A reader that refuses to render
+ * because a preference is malformed would be a worse bug than a reset size.
+ */
+export function parseStoredScaleIndex(raw: string | null | undefined): number {
+  if (raw == null) return READER_TEXT_SCALE_DEFAULT_INDEX;
+  const parsed = Number.parseInt(raw, 10);
+  if (Number.isNaN(parsed)) return READER_TEXT_SCALE_DEFAULT_INDEX;
+  return clampScaleIndex(parsed);
+}
+
+/**
+ * Read the persisted index. Returns the default when storage is unavailable —
+ * Safari private mode throws on access, and the desktop shell runs the app in a
+ * WKWebView where storage can be partitioned.
+ */
+export function loadScaleIndex(storage?: Pick<Storage, "getItem"> | null): number {
+  const store = storage ?? safeLocalStorage();
+  if (!store) return READER_TEXT_SCALE_DEFAULT_INDEX;
+  try {
+    return parseStoredScaleIndex(store.getItem(READER_TEXT_SCALE_STORAGE_KEY));
+  } catch {
+    return READER_TEXT_SCALE_DEFAULT_INDEX;
+  }
+}
+
+/** Persist the index. Silently a no-op when storage is unavailable or full. */
+export function saveScaleIndex(
+  index: number,
+  storage?: Pick<Storage, "setItem"> | null,
+): void {
+  const store = storage ?? safeLocalStorage();
+  if (!store) return;
+  try {
+    store.setItem(READER_TEXT_SCALE_STORAGE_KEY, String(clampScaleIndex(index)));
+  } catch {
+    // Quota or a partitioned store — the size still applies for this session.
+  }
+}
+
+function safeLocalStorage(): Storage | null {
+  try {
+    if (typeof window === "undefined") return null;
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/src/styles/document-reader.css
+++ b/src/styles/document-reader.css
@@ -5,6 +5,17 @@
     color-mix(in oklch, var(--document-reader-accent) 14%, transparent)
   );
 
+  /* Reader text scale (A−/A+). The component sets this inline from the
+     persisted preference; 1 is the shipped size, so a reader rendered without
+     the control — or before the stored value loads — is unchanged.
+
+     Applied ONLY to reading content (title, lede, headings, prose, tables,
+     code), never to chrome. The contents trigger, TOC links and kicker keep
+     their own sizes: scaling those would move the furniture around while the
+     user is trying to make the *text* bigger, and the rail has a fixed width
+     that oversized links would overflow. */
+  --reader-text-scale: 1;
+
   display: grid;
   min-height: 0;
   height: 100%;
@@ -81,14 +92,68 @@
   scroll-behavior: smooth;
 }
 
-.document-reader__compact-nav {
+/* Sticky control row: text size on the left, Contents (when present) on the
+   right. `pointer-events: none` lets the prose scroll under the gap between
+   them; each control re-enables its own hits. */
+.document-reader__toolbar {
   position: sticky;
   top: 0;
   z-index: 2;
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
   padding: 0 var(--space-4) var(--space-2);
   pointer-events: none;
+}
+
+.document-reader__compact-nav {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.document-reader__textsize {
+  display: inline-flex;
+  gap: var(--space-1);
+  pointer-events: auto;
+}
+
+/* Deliberately NOT scaled by --reader-text-scale: the control must stay put
+   while the text it resizes grows, or pressing A+ walks the button out from
+   under the pointer. */
+.document-reader__textsize-btn {
+  display: inline-grid;
+  place-items: center;
+  width: var(--space-8);
+  height: var(--space-8);
+  padding: 0;
+  border: 1px solid var(--border-hairline);
+  border-radius: var(--radius-control);
+  background: var(--bg-elevated);
+  color: var(--text-secondary);
+  font-family: var(--font-serif);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.document-reader__textsize-btn:hover:not(:disabled) {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.document-reader__textsize-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+/* The two glyphs differ in size, which is the whole affordance — a small A and
+   a large A read as "smaller/larger" without a label in any language. */
+.document-reader__textsize-glyph--small {
+  font-size: var(--text-xs);
+}
+
+.document-reader__textsize-glyph--large {
+  font-size: var(--text-md);
 }
 
 .document-reader__contents-trigger {
@@ -134,7 +199,7 @@
   margin: 0 0 var(--space-3);
   color: var(--text-primary);
   font-family: var(--font-serif);
-  font-size: var(--text-display);
+  font-size: calc(var(--text-display) * var(--reader-text-scale));
   font-weight: 600;
   line-height: 1.15;
 }
@@ -145,7 +210,7 @@
   border-left: var(--ring-width) solid var(--border-strong);
   color: var(--text-muted);
   font-family: var(--font-serif);
-  font-size: var(--text-lg);
+  font-size: calc(var(--text-lg) * var(--reader-text-scale));
   font-style: italic;
   line-height: 1.5;
 }
@@ -162,7 +227,7 @@
   margin: var(--space-8) 0 var(--space-3);
   color: var(--text-primary);
   font-family: var(--font-sans);
-  font-size: var(--text-lg);
+  font-size: calc(var(--text-lg) * var(--reader-text-scale));
   font-weight: 600;
   line-height: 1.3;
   scroll-margin-top: var(--space-5);
@@ -172,7 +237,7 @@
    headings must step down or every section reads as a sibling of the last. */
 h3.document-reader__heading {
   margin-top: var(--space-6);
-  font-size: var(--text-md);
+  font-size: calc(var(--text-md) * var(--reader-text-scale));
 }
 
 h4.document-reader__heading,
@@ -180,7 +245,7 @@ h5.document-reader__heading,
 h6.document-reader__heading {
   margin-top: var(--space-5);
   color: var(--text-secondary);
-  font-size: var(--text-base);
+  font-size: calc(var(--text-base) * var(--reader-text-scale));
 }
 
 .document-reader__section-toggle {
@@ -227,7 +292,7 @@ h6.document-reader__heading {
 .document-reader__column p,
 .document-reader__column li {
   color: var(--text-secondary);
-  font-size: var(--text-md);
+  font-size: calc(var(--text-md) * var(--reader-text-scale));
   line-height: 1.65;
 }
 
@@ -263,7 +328,7 @@ h6.document-reader__heading {
   border-radius: var(--radius-card);
   background: var(--code-surface);
   color: var(--text-primary);
-  font-size: var(--text-sm);
+  font-size: calc(var(--text-sm) * var(--reader-text-scale));
 }
 
 .document-reader__column code {
@@ -274,7 +339,7 @@ h6.document-reader__heading {
   width: 100%;
   margin: 0 0 var(--space-4);
   border-collapse: collapse;
-  font-size: var(--text-base);
+  font-size: calc(var(--text-base) * var(--reader-text-scale));
 }
 
 .document-reader__column th,
@@ -322,7 +387,7 @@ h6.document-reader__heading {
   }
 
   .document-reader__title {
-    font-size: var(--text-xl);
+    font-size: calc(var(--text-xl) * var(--reader-text-scale));
   }
 }
 


### PR DESCRIPTION
A−/A+ controls on the document reader overlay, persisted across reloads.

## Shape

Five steps — `0.875 → 1 → 1.125 → 1.25 → 1.4` — with the shipped size at index 2 so the control has **equal travel in both directions**. A default at either end leaves one button dead on arrival for every user who never changes the setting.

Steps are **multipliers, not absolute sizes**. The reader's type is a scale (`display`/`lg`/`md`/`base`/`sm`); multiplying preserves the intervals between those tokens, where setting absolute sizes would flatten a document's hierarchy toward one size as the user scaled up.

## What scales, and what deliberately doesn't

Applied through a `--reader-text-scale` custom property the component sets inline, and consumed only by reading content:

| Scales | Does not scale |
| --- | --- |
| title, lede, headings (h2–h6) | TOC links |
| prose (`p`, `li`), tables, code blocks | Contents trigger, kicker |
| | the A−/A+ buttons themselves |

Chrome is excluded on purpose. Scaling the TOC and triggers would move the furniture around while the user is trying to enlarge the *text*, and the rail is a fixed `13rem` that oversized links would overflow. The buttons are excluded for a sharper reason: if they grew, pressing A+ would walk the control out from under the pointer.

## The control renders in every navigation mode

Text size is not a navigation affordance. Putting it inside the existing compact nav would have hidden it from the `rail` and `none` readers — and from any document with fewer than two headings, since `namedSections.length >= 2` is the compact nav's own render condition. The toolbar row now always renders; Contents joins it when applicable.

## Persistence is deliberately forgiving

Two failure modes worth naming, both handled:

- **Hydration.** The stored value is applied in an effect rather than the state initializer. Reading `localStorage` during render emits different HTML on the server than the client, so first paint is always the default size and the effect corrects it.
- **Hostile storage.** Every read and write is guarded. `localStorage` is user-editable, shared across tabs and app versions, and throws outright in Safari private mode and some WKWebView partitions — which is the desktop shell. A malformed preference resets the size rather than refusing to render the document.

## Verification

- `tsc --noEmit` clean, `pnpm lint` clean, `check:tests-wired` 1631
- Both reader specs pass — 13 tests, including the pre-existing 4
- New spec covers all three navigation modes, default-scale hydration safety, monotonic steps, clamping, corrupt stored values (`null`/`""`/`"NaN"`/`"{}"`/`"999"`/`"-4"`), throwing storage in both directions, and a storage round trip
- Mutation-verified: scaling `.document-reader__toc-link` fails the chrome-scoping assertion