### PR TITLE
fix(copilot): reject clients without session ID support

### DIFF
--- a/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
+++ b/src/app/api/chat/send/harness-routing-copilot-jsonl.test.ts
@@ -65,7 +65,7 @@ assert.deepEqual(
   "the direct full-mode routing decision keeps its approval flag before the reviewed JSONL launch contract",
 );
 
-for (const capabilityVersion of ["1.0.70.1", "0.9.9", "2.0.0", "2.0.0-rc.1"]) {
+for (const capabilityVersion of ["1.0.70.1", "1.0.64-1", "0.9.9", "2.0.0", "2.0.0-rc.1"]) {
   const routing = resolveCopilotChatRouting({
     harness: "copilot",
     isSshRuntime: false,

--- a/src/lib/copilot-stream.test.ts
+++ b/src/lib/copilot-stream.test.ts
@@ -85,13 +85,14 @@ assert.equal(
   "ASCII SemVer ordering keeps B below a instead of locale-sorting it above",
 );
 assert.equal(selectRuntimeEventProtocol("1.0.0-b", [prereleaseBoundarySchema])?.id, prereleaseBoundarySchema.id);
+assert.equal(selectRuntimeEventProtocol("1.0.64-1"), null, "clients that reject --session-id fail closed");
 assert.equal(selectRuntimeEventProtocol("0.9.9"), null, "pre-protocol clients fail closed");
 assert.equal(selectRuntimeEventProtocol("1.0.70")?.id, "copilot-jsonl-v1");
 assert.equal(selectRuntimeEventProtocol("2.0.0"), null, "an unknown future major fails closed");
 assert.equal(selectRuntimeEventProtocol("2.0.0-rc.1"), null, "future-major prereleases fail closed");
 assert.equal(selectRuntimeEventProtocol("not-a-version"), null, "unparseable clients fail closed");
 assert.equal(
-  copilotStreamSpec("0.9.9"),
+  copilotStreamSpec("1.0.64-1"),
   null,
   "a caller that has an incompatible client version must retain the generic plain-chat path",
 );

--- a/src/lib/copilot-stream.ts
+++ b/src/lib/copilot-stream.ts
@@ -93,7 +93,11 @@ export const COPILOT_EVENT_PROTOCOL_SCHEMAS: RuntimeEventProtocolSchema[] = [
     runtime: "copilot",
     eventTypeFields: ["type"],
     diagnosticEventPrefixes: ["tool.", "assistant.tool"],
-    minClientVersion: "1.0.0",
+    // 1.0.64 advertises --session-id in --help but rejects it at runtime.
+    // Cave requires that flag to pre-assign durable chat/Research ownership;
+    // 1.0.70 is the first version whose complete launch + JSONL contract we
+    // have verified end to end.
+    minClientVersion: "1.0.70",
     // A future major must opt in with a separately reviewed registry schema.
     // Never guess that an incompatible 2.x frame still has the 1.x shape.
     maxClientVersionExclusive: "2.0.0",


### PR DESCRIPTION
Require Copilot CLI 1.0.70 or newer for the direct JSONL transport in Cave.

Cave preassigns session IDs so chat and Research runs have durable ownership. Copilot CLI 1.0.64-1 advertises `--session-id` in help but exits with `unknown option` when Cave launches it, causing Research to fail before its first phase. The prior protocol range admitted every 1.x client.

This raises the built-in protocol floor to the first version whose session-ID and JSONL contract was verified end to end, and adds regression coverage at the protocol-selection and chat-routing boundaries. Older clients now fail the compatibility gate with an actionable update path instead of starting a doomed run.

Focused E2E validation reproduced the old-client exit and verified the same mission reached a Research checkpoint on Copilot 1.0.79 with all six phases completed. Lint, test wiring, typecheck, targeted tests, and all 1,180 app test files pass. The full API suite reaches an unrelated environment-dependent fixture failure: `route-claude-availability.integration.test.ts` expects `runtime_coven_missing` but receives `runtime_process_failed` when a real Homebrew Coven CLI is present; the same failure reproduces on clean base `5b61ea412`.