### PR TITLE
docs(readme): space the startup-diagnostics answer off its summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Running DevCommand (`cargo run --no-default-features --color always --`)
 <details>
 <summary><strong>Startup looks stuck? Diagnose it here</strong></summary>
 
+<br>
+
 - **First launch is slow by design.** Cargo downloads and compiles Rust crates
   before the window appears. `Compiling ...` lines are progress, not a hang.
 - **No `port ... is free` line + an error** → every port in `3000..3010` is


### PR DESCRIPTION
Follow-up to #4583, which gave the eight FAQ `<details>` blocks a leading `<br>` so the answer body is not flush against the summary row. GitHub's `markdown-body` sets `margin-top: 0` on a details block's first child, so expanded text butts right up against the disclosure triangle.

The ninth `<details>` block — the startup diagnostics under the desktop-shell section — was left out of that PR because its body is a bulleted list rather than a paragraph, and the FAQ's inline form does not transfer. `- <br>**First launch` puts the break *inside* the first `<li>`, offsetting that bullet's text from its own marker. A standalone `<br>` line between `</summary>` and the list renders as a sibling of the `<ul>` instead, which is the effect the FAQ blocks get.

## Verification

Rendered the exact block through the GitHub Markdown API in GFM mode. The `<br>` lands between the summary and the `<ul>`, and all four bullets keep their bold and inline code:

```html
<details>
<summary><strong>Startup looks stuck? Diagnose it here</strong></summary>
<br>
<ul dir="auto">
<li><strong>First launch is slow by design.</strong> Cargo downloads and compiles Rust crates<br>
before the window appears. <code class="notranslate">Compiling ...</code> lines are progress, not a hang.</li>
...
</ul>
</details>
```

Also worth recording, since it came up on #4583: a leading `<br>` cannot open an HTML block, because `br` is not in CommonMark's HTML-block tag list. It is parsed as inline HTML and Markdown parsing continues — which the render above confirms.

Docs-only change; no source or test files touched.