### PR TITLE
fix(canvas): lock artifact previews to an offline CSP

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -643,6 +643,8 @@ export const SUITES = {
     "src/lib/canvas-inspector.test.ts",
     "src/lib/canvas-inspector-channel.test.ts",
     "src/lib/canvas-inspector-chromium.test.ts",
+    "src/lib/canvas-preview-csp.test.ts",
+    "src/lib/canvas-preview-csp-chromium.test.ts",
     "src/lib/arcade/glitter-crypt.test.ts",
     "src/lib/arcade/glitter-crypt-chromium.test.ts",
     "src/lib/artifact-open.test.ts",

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -5,6 +5,7 @@
 // unit-tested without a DOM, a daemon, or React Flow.
 
 import { injectCanvasInspector } from "./canvas-inspector.ts";
+import { injectPreviewCsp } from "./canvas-preview-csp.ts";
 
 // An artifact is either a self-contained HTML document or a single React
 // component (transpiled + rendered by the sandbox runtime). Older records
@@ -157,12 +158,23 @@ export function isFullDocument(code: string): boolean {
  * bare fragment is wrapped in a minimal document with neutral base styling so
  * it renders sensibly on its own. The result is fed to `<iframe srcdoc>` and
  * runs under `sandbox="allow-scripts"` (no same-origin) — isolation comes from
- * the sandbox, so we intentionally do NOT strip scripts here.
+ * the sandbox, so we intentionally do NOT strip scripts here. The offline CSP
+ * from canvas-preview-csp.ts is stamped on top: the artifact still runs its own
+ * scripts, it just cannot reach the network to do it.
+ *
+ * `assetOrigin` defaults to the app's own origin; see buildPreviewCsp for why
+ * an opaque-origin document can't express that as `'self'`.
  */
-export function buildPreviewSrcDoc(code: string, inspectorGeneration = ""): string {
+export function buildPreviewSrcDoc(
+  code: string,
+  inspectorGeneration = "",
+  assetOrigin?: string,
+): string {
   const src = typeof code === "string" ? code : "";
-  if (isFullDocument(src)) return injectCanvasInspector(src, inspectorGeneration);
-  return injectCanvasInspector([
+  if (isFullDocument(src)) {
+    return injectPreviewCsp(injectCanvasInspector(src, inspectorGeneration), assetOrigin);
+  }
+  return injectPreviewCsp(injectCanvasInspector([
     "<!doctype html>",
     '<html lang="en">',
     "<head>",
@@ -175,7 +187,7 @@ export function buildPreviewSrcDoc(code: string, inspectorGeneration = ""): stri
     "</head>",
     `<body>${src}</body>`,
     "</html>",
-  ].join("\n"), inspectorGeneration);
+  ].join("\n"), inspectorGeneration), assetOrigin);
 }
 
 /** A compact title from a prompt: first line, collapsed, clamped. */

--- a/src/lib/canvas-artifacts.ts
+++ b/src/lib/canvas-artifacts.ts
@@ -160,7 +160,8 @@ export function isFullDocument(code: string): boolean {
  * runs under `sandbox="allow-scripts"` (no same-origin) — isolation comes from
  * the sandbox, so we intentionally do NOT strip scripts here. The offline CSP
  * from canvas-preview-csp.ts is stamped on top: the artifact still runs its own
- * scripts, it just cannot reach the network to do it.
+ * inline scripts, but the only URL it can fetch is a sandbox asset under
+ * `/sandbox/` — no fetch, no remote image, font, frame, or stylesheet.
  *
  * `assetOrigin` defaults to the app's own origin; see buildPreviewCsp for why
  * an opaque-origin document can't express that as `'self'`.

--- a/src/lib/canvas-preview-csp-chromium.test.ts
+++ b/src/lib/canvas-preview-csp-chromium.test.ts
@@ -32,6 +32,14 @@ if (!existsSync(executablePath)) {
     } catch (err) {
       parent.postMessage({ type: "eval-blocked", message: String(err) }, "*");
     }
+    // Same-origin script beacon. script-src has to name our origin for the
+    // runtime to load at all, so scoping it to /sandbox/ is the only thing
+    // standing between an artifact and a working GET channel back to the app.
+    const beaconScript = document.createElement("script");
+    beaconScript.onload = () => parent.postMessage({ type: "script-beacon-loaded" }, "*");
+    beaconScript.onerror = () => parent.postMessage({ type: "script-beacon-failed" }, "*");
+    beaconScript.src = ORIGIN + "/beacon-script?leak=secret";
+    document.head.append(beaconScript);
     const img = new Image();
     img.onload = () => parent.postMessage({ type: "img-loaded" }, "*");
     img.onerror = () => parent.postMessage({ type: "img-failed" }, "*");
@@ -105,6 +113,7 @@ if (!existsSync(executablePath)) {
     assert.ok(controlEvents.some((e) => e?.type === "img-loaded"), "control: a remote image load succeeds");
     assert.ok(hits.includes("/beacon-img"), "control: the beacon reached the server — the probe can observe egress");
     assert.ok(hits.includes("/beacon-fetch"), "control: the fetch reached the server too");
+    assert.ok(hits.includes("/beacon-script"), "control: the same-origin script beacon reached the server as well");
 
     // ── Policy on: the runtime still loads, the beacons never leave ─────────
     hits.length = 0;
@@ -123,6 +132,14 @@ if (!existsSync(executablePath)) {
     assert.ok(guardedEvents.some((e) => e?.type === "img-failed"), "the remote image is refused");
     assert.ok(!hits.includes("/beacon-img"), "and the request never reached the network");
     assert.ok(!hits.includes("/beacon-fetch"), "connect-src 'none' stops fetch before it is sent");
+    assert.ok(
+      !hits.includes("/beacon-script"),
+      "scoping script-src to /sandbox/ closes the same-origin script channel that naming the bare origin would leave open",
+    );
+    assert.ok(
+      guardedEvents.some((e) => e?.type === "script-beacon-failed"),
+      "and the artifact sees it refused rather than silently pending",
+    );
 
     // ── The HTML path gets the same treatment ──────────────────────────────
     const htmlArtifact = [

--- a/src/lib/canvas-preview-csp-chromium.test.ts
+++ b/src/lib/canvas-preview-csp-chromium.test.ts
@@ -1,0 +1,160 @@
+// @ts-nocheck
+// Behavioural pin for the preview CSP: a policy is only worth having if the
+// browser both HONORS it (no egress) and doesn't over-apply it (our own offline
+// runtime still loads). String assertions in canvas-preview-csp.test.ts can't
+// tell either way — `'self'` from an opaque origin looks perfectly reasonable
+// in a string and blanks every React preview in practice.
+//
+// Every probe runs twice: once with the policy and once without (the control).
+// The control is what proves the harness can actually observe egress, so a
+// green run means "blocked", not "the request was never attempted".
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { existsSync } from "node:fs";
+import { chromium } from "@playwright/test";
+
+import { buildPreviewSrcDoc } from "./canvas-artifacts.ts";
+import { buildReactSrcDoc, SANDBOX_RUNTIME_SRC, SANDBOX_TAILWIND_SRC } from "./canvas-react-harness.ts";
+
+const executablePath = chromium.executablePath();
+if (!existsSync(executablePath)) {
+  console.log(`canvas-preview-csp-chromium.test.ts skipped: browser not installed at ${executablePath}`);
+} else {
+  /** Everything the sandbox document tries to pull from us, in order. */
+  const hits = [];
+
+  // A stand-in for the real sandbox runtime: proves script-src admits our
+  // origin, then attempts the two cheapest exfil channels a sketch has.
+  const runtimeStub = `
+    parent.postMessage({ type: "runtime-loaded" }, "*");
+    try {
+      parent.postMessage({ type: "eval-ok", value: new Function("return 21 * 2")() }, "*");
+    } catch (err) {
+      parent.postMessage({ type: "eval-blocked", message: String(err) }, "*");
+    }
+    const img = new Image();
+    img.onload = () => parent.postMessage({ type: "img-loaded" }, "*");
+    img.onerror = () => parent.postMessage({ type: "img-failed" }, "*");
+    img.src = ORIGIN + "/beacon-img";
+    fetch(ORIGIN + "/beacon-fetch", { mode: "no-cors" })
+      .then(() => parent.postMessage({ type: "fetch-settled" }, "*"))
+      .catch(() => parent.postMessage({ type: "fetch-failed" }, "*"));
+  `;
+
+  const server = createServer((req, res) => {
+    const path = (req.url ?? "").split("?")[0];
+    if (path !== "/") hits.push(path);
+    if (path === SANDBOX_RUNTIME_SRC || path === SANDBOX_TAILWIND_SRC) {
+      res.writeHead(200, { "content-type": "text/javascript" });
+      res.end(path === SANDBOX_RUNTIME_SRC ? runtimeStub.replace(/ORIGIN/g, JSON.stringify(origin)) : ";");
+      return;
+    }
+    if (path === "/beacon-img") {
+      res.writeHead(200, { "content-type": "image/gif" });
+      // 1x1 transparent GIF, so a successful load fires onload rather than onerror.
+      res.end(Buffer.from("R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7", "base64"));
+      return;
+    }
+    res.writeHead(200, { "content-type": "text/html" });
+    res.end("<!doctype html><html><body><h1>host</h1></body></html>");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const origin = `http://127.0.0.1:${server.address().port}`;
+
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(`${origin}/`);
+    await page.evaluate(() => {
+      window.events = [];
+      window.addEventListener("message", (event) => window.events.push(event.data));
+    });
+
+    /** Mount `srcdoc` in the same opaque-origin sandbox the app uses and
+     *  collect what the document managed to do. */
+    const run = async (srcdoc, label) => {
+      await page.evaluate(({ doc, id }) => {
+        const frame = document.createElement("iframe");
+        frame.id = id;
+        frame.sandbox.add("allow-scripts");
+        frame.srcdoc = doc;
+        document.body.append(frame);
+      }, { doc: srcdoc, id: label });
+      await page.waitForFunction(
+        () => window.events.some((e) => e?.type === "img-loaded" || e?.type === "img-failed"),
+        undefined,
+        { timeout: 10_000 },
+      ).catch(() => {});
+      // Give the fetch probe a beat to settle either way.
+      await page.waitForTimeout(300);
+      const events = await page.evaluate(() => {
+        const seen = window.events;
+        window.events = [];
+        return seen;
+      });
+      return events;
+    };
+
+    // ── Control: the same document with NO policy (no origin supplied) ──────
+    hits.length = 0;
+    const controlEvents = await run(buildReactSrcDoc("export default function App(){return null}", "", ""), "control");
+    assert.ok(
+      controlEvents.some((e) => e?.type === "runtime-loaded"),
+      "control: the sandbox runtime loads from our origin",
+    );
+    assert.ok(controlEvents.some((e) => e?.type === "img-loaded"), "control: a remote image load succeeds");
+    assert.ok(hits.includes("/beacon-img"), "control: the beacon reached the server — the probe can observe egress");
+    assert.ok(hits.includes("/beacon-fetch"), "control: the fetch reached the server too");
+
+    // ── Policy on: the runtime still loads, the beacons never leave ─────────
+    hits.length = 0;
+    const guardedEvents = await run(
+      buildReactSrcDoc("export default function App(){return null}", "", origin),
+      "guarded",
+    );
+    assert.ok(
+      guardedEvents.some((e) => e?.type === "runtime-loaded"),
+      "the policy names our origin, so the offline runtime still loads — this is what 'self' would have broken",
+    );
+    assert.ok(
+      guardedEvents.some((e) => e?.type === "eval-ok" && e.value === 42),
+      "'unsafe-eval' survives: the JSX transpiler mounts components through new Function",
+    );
+    assert.ok(guardedEvents.some((e) => e?.type === "img-failed"), "the remote image is refused");
+    assert.ok(!hits.includes("/beacon-img"), "and the request never reached the network");
+    assert.ok(!hits.includes("/beacon-fetch"), "connect-src 'none' stops fetch before it is sent");
+
+    // ── The HTML path gets the same treatment ──────────────────────────────
+    const htmlArtifact = [
+      "<!doctype html>",
+      "<html><head></head><body>",
+      "<script>",
+      '  const img = new Image();',
+      '  img.onload = () => parent.postMessage({ type: "img-loaded" }, "*");',
+      '  img.onerror = () => parent.postMessage({ type: "img-failed" }, "*");',
+      `  img.src = ${JSON.stringify(`${origin}/beacon-img`)};`,
+      '  parent.postMessage({ type: "inline-ran" }, "*");',
+      "</script>",
+      "</body></html>",
+    ].join("\n");
+
+    hits.length = 0;
+    const htmlControl = await run(buildPreviewSrcDoc(htmlArtifact, "", ""), "html-control");
+    assert.ok(htmlControl.some((e) => e?.type === "img-loaded"), "control: an HTML artifact can beacon out today");
+    assert.ok(hits.includes("/beacon-img"), "control: that beacon reaches the server");
+
+    hits.length = 0;
+    const htmlGuarded = await run(buildPreviewSrcDoc(htmlArtifact, "", origin), "html-guarded");
+    assert.ok(
+      htmlGuarded.some((e) => e?.type === "inline-ran"),
+      "'unsafe-inline' survives: an artifact's own inline script still runs",
+    );
+    assert.ok(htmlGuarded.some((e) => e?.type === "img-failed"), "the HTML artifact's beacon is refused");
+    assert.ok(!hits.includes("/beacon-img"), "and never reaches the network");
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+
+  console.log("canvas-preview-csp-chromium.test.ts ✓");
+}

--- a/src/lib/canvas-preview-csp.test.ts
+++ b/src/lib/canvas-preview-csp.test.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+
+import {
+  PREVIEW_CSP_MARKER,
+  buildPreviewCsp,
+  injectPreviewCsp,
+  previewCspMetaTag,
+  resolveSandboxAssetOrigin,
+} from "./canvas-preview-csp.ts";
+import { buildPreviewSrcDoc } from "./canvas-artifacts.ts";
+import { buildReactSrcDoc, SANDBOX_RUNTIME_SRC } from "./canvas-react-harness.ts";
+
+const ORIGIN = "http://127.0.0.1:3000";
+
+// ── The policy itself ───────────────────────────────────────────────────────
+
+const policy = buildPreviewCsp(ORIGIN);
+assert.match(policy, /(^|; )default-src 'none'(;|$)/, "unnamed fetch directives fail closed");
+assert.ok(
+  policy.includes(`script-src ${ORIGIN} 'unsafe-inline' 'unsafe-eval'`),
+  "the sandbox runtime's origin, inline artifact scripts, and the JSX transpiler's eval are allowed",
+);
+assert.ok(policy.includes(`style-src ${ORIGIN} 'unsafe-inline'`), "Tailwind's injected <style> elements are allowed");
+// Every practical egress channel a sketch could reach for.
+assert.ok(policy.includes("connect-src 'none'"), "no fetch/XHR/WebSocket/beacon");
+assert.ok(policy.includes("img-src data: blob:"), "no remote image URL as a GET beacon");
+assert.ok(policy.includes("font-src data:"), "no remote font fetch");
+assert.ok(policy.includes("form-action 'none'"), "a form POST navigates, so connect-src alone wouldn't stop it");
+assert.ok(policy.includes("frame-src 'none'"), "no nested browsing context with its own policy scope");
+assert.ok(policy.includes("worker-src 'none'"), "no worker with its own policy scope");
+assert.ok(policy.includes("object-src 'none'"), "no plugin content");
+assert.ok(policy.includes("base-uri 'none'"), "a <base href> could re-point the runtime path at another host");
+
+// `'self'` is meaningless from the preview's opaque origin — naming it would
+// block the very runtime the React path loads. The origin must appear literally.
+assert.doesNotMatch(policy, /'self'/, "'self' never appears: the preview origin is opaque");
+
+// ── Origin handling ─────────────────────────────────────────────────────────
+
+assert.equal(buildPreviewCsp(""), "", "no origin ⇒ no policy (never a policy that blanks the preview)");
+assert.equal(buildPreviewCsp("   "), "", "whitespace is not an origin");
+assert.equal(buildPreviewCsp("null"), "", "a sandboxed document's own \"null\" origin is unusable");
+assert.equal(buildPreviewCsp("not an origin"), "", "a non-origin string is rejected rather than inlined");
+assert.equal(
+  buildPreviewCsp("http://evil.example\" onload=\"alert(1)"),
+  "",
+  "an origin carrying a quote can't break out of the meta attribute",
+);
+assert.equal(buildPreviewCsp("http://a.example; script-src *"), "", "an origin can't smuggle a second directive");
+assert.ok(buildPreviewCsp("tauri://localhost").includes("script-src tauri://localhost"), "the desktop shell's origin works");
+assert.ok(buildPreviewCsp("https://cave.example").includes("script-src https://cave.example"), "https origins work");
+
+// In Node there is no location, so the default resolves to "" — which is what
+// keeps the pure builders' existing unit tests policy-free.
+assert.equal(resolveSandboxAssetOrigin(), "", "no browser location ⇒ no origin");
+assert.equal(previewCspMetaTag(), "", "and therefore no meta tag");
+
+// ── Injection placement ─────────────────────────────────────────────────────
+
+const meta = previewCspMetaTag(ORIGIN);
+assert.match(meta, /^<meta http-equiv="Content-Security-Policy" content="/, "stamped as an http-equiv meta");
+assert.ok(meta.includes(`data-${PREVIEW_CSP_MARKER}="1"`), "carries the identifying marker");
+
+const withDoctype = injectPreviewCsp('<!doctype html>\n<html><head><script>x()</script></head></html>', ORIGIN);
+assert.ok(
+  withDoctype.indexOf("Content-Security-Policy") < withDoctype.indexOf("x()"),
+  "the policy precedes the document's own scripts — http-equiv only governs what follows it",
+);
+assert.match(withDoctype, /^<!doctype html>/i, "the doctype stays first, so the document is not quirks-mode");
+
+const commented = injectPreviewCsp("<!-- lead -->\n<!doctype html><html></html>", ORIGIN);
+assert.ok(
+  commented.indexOf("Content-Security-Policy") > commented.indexOf("<!doctype html>"),
+  "a comment before the doctype doesn't push the meta ahead of it",
+);
+
+const noDoctype = injectPreviewCsp("<html><body>hi</body></html>", ORIGIN);
+assert.match(noDoctype, /^<meta http-equiv="Content-Security-Policy"/, "a doctype-less document gets the meta first");
+assert.equal(injectPreviewCsp("<html></html>", ""), "<html></html>", "no origin ⇒ document is untouched");
+
+// ── Both preview builders carry it ──────────────────────────────────────────
+
+const reactDoc = buildReactSrcDoc("export default function App(){return <b>hi</b>}", "gen-1", ORIGIN);
+assert.ok(reactDoc.includes("Content-Security-Policy"), "React previews are stamped");
+assert.ok(
+  reactDoc.indexOf("Content-Security-Policy") < reactDoc.indexOf("cave-canvas-inspector"),
+  "the policy precedes the inspector, which is itself an inline script",
+);
+assert.ok(
+  reactDoc.indexOf("Content-Security-Policy") < reactDoc.indexOf(SANDBOX_RUNTIME_SRC),
+  "the policy precedes the runtime it explicitly permits",
+);
+
+const htmlDoc = buildPreviewSrcDoc("<!doctype html><html><body>hi</body></html>", "gen-2", ORIGIN);
+assert.ok(htmlDoc.includes("Content-Security-Policy"), "full-document HTML previews are stamped");
+const fragmentDoc = buildPreviewSrcDoc("<p>fragment</p>", "gen-3", ORIGIN);
+assert.ok(fragmentDoc.includes("Content-Security-Policy"), "wrapped fragments are stamped");
+assert.ok(fragmentDoc.includes("<p>fragment</p>"), "and still carry the artifact");
+
+// Omitting the origin keeps the previous output verbatim, so no caller that
+// hasn't been updated silently loses its preview.
+assert.doesNotMatch(
+  buildReactSrcDoc("export default function App(){return null}"),
+  /Content-Security-Policy/,
+  "no origin ⇒ the React document is unchanged",
+);
+assert.doesNotMatch(
+  buildPreviewSrcDoc("<!doctype html><html></html>"),
+  /Content-Security-Policy/,
+  "no origin ⇒ the HTML document is unchanged",
+);
+
+console.log("canvas-preview-csp.test.ts ✓");

--- a/src/lib/canvas-preview-csp.test.ts
+++ b/src/lib/canvas-preview-csp.test.ts
@@ -18,10 +18,19 @@ const ORIGIN = "http://127.0.0.1:3000";
 const policy = buildPreviewCsp(ORIGIN);
 assert.match(policy, /(^|; )default-src 'none'(;|$)/, "unnamed fetch directives fail closed");
 assert.ok(
-  policy.includes(`script-src ${ORIGIN} 'unsafe-inline' 'unsafe-eval'`),
-  "the sandbox runtime's origin, inline artifact scripts, and the JSX transpiler's eval are allowed",
+  policy.includes(`script-src ${ORIGIN}/sandbox/ 'unsafe-inline' 'unsafe-eval'`),
+  "scripts are scoped to the sandbox asset path, plus inline artifact code and the transpiler's eval",
 );
-assert.ok(policy.includes(`style-src ${ORIGIN} 'unsafe-inline'`), "Tailwind's injected <style> elements are allowed");
+// Scoping to /sandbox/ rather than the bare origin is the point: an artifact
+// would otherwise have `<script src="<origin>/anything?leak=…">` as a working
+// same-origin GET channel.
+assert.doesNotMatch(
+  policy,
+  new RegExp(`script-src ${ORIGIN}[ ;]`),
+  "the bare origin is never a script source",
+);
+assert.ok(policy.includes("style-src 'unsafe-inline'"), "Tailwind's injected <style> elements are allowed");
+assert.doesNotMatch(policy, new RegExp(`style-src[^;]*${ORIGIN}`), "no stylesheet URL channel either");
 // Every practical egress channel a sketch could reach for.
 assert.ok(policy.includes("connect-src 'none'"), "no fetch/XHR/WebSocket/beacon");
 assert.ok(policy.includes("img-src data: blob:"), "no remote image URL as a GET beacon");
@@ -48,8 +57,25 @@ assert.equal(
   "an origin carrying a quote can't break out of the meta attribute",
 );
 assert.equal(buildPreviewCsp("http://a.example; script-src *"), "", "an origin can't smuggle a second directive");
-assert.ok(buildPreviewCsp("tauri://localhost").includes("script-src tauri://localhost"), "the desktop shell's origin works");
-assert.ok(buildPreviewCsp("https://cave.example").includes("script-src https://cave.example"), "https origins work");
+// A URL is not an origin. Accepting one would narrow the emitted source to that
+// path prefix, which blocks /sandbox/ and blanks every React preview.
+assert.equal(buildPreviewCsp("https://cave.example/app"), "", "a path is rejected");
+assert.equal(buildPreviewCsp("https://cave.example/"), "", "even a bare trailing slash is rejected");
+assert.equal(buildPreviewCsp("https://cave.example?q=1"), "", "a query is rejected");
+assert.equal(buildPreviewCsp("https://cave.example#frag"), "", "a fragment is rejected");
+assert.equal(buildPreviewCsp("https://user@cave.example"), "", "userinfo is rejected");
+assert.ok(
+  buildPreviewCsp("tauri://localhost").includes("script-src tauri://localhost/sandbox/"),
+  "the desktop shell's origin works",
+);
+assert.ok(
+  buildPreviewCsp("https://cave.example").includes("script-src https://cave.example/sandbox/"),
+  "https origins work",
+);
+assert.ok(
+  buildPreviewCsp("http://[::1]:3000").includes("script-src http://[::1]:3000/sandbox/"),
+  "an IPv6 authority survives the origin check",
+);
 
 // In Node there is no location, so the default resolves to "" — which is what
 // keeps the pure builders' existing unit tests policy-free.

--- a/src/lib/canvas-preview-csp.ts
+++ b/src/lib/canvas-preview-csp.ts
@@ -9,6 +9,13 @@
 // asks for a self-contained, network-free document; this makes the browser
 // enforce it rather than trusting a model to have complied.
 //
+// What the policy actually guarantees, stated exactly: the ONLY URL a preview
+// can fetch is a script under `<app origin>/sandbox/` — the offline runtime and
+// Tailwind engine it needs to render. Not "no network at all": that path stays
+// open by necessity, and the sandbox assets are static first-party files.
+// Everything else — fetch/XHR/WebSocket/beacon, remote images, fonts, media,
+// stylesheets, frames, workers, form posts — is denied.
+//
 // Two properties are load-bearing:
 //
 // 1. `'self'` is USELESS here. The preview document's own origin is opaque, so
@@ -26,10 +33,17 @@
 export const PREVIEW_CSP_MARKER = "cave-canvas-preview-csp";
 
 /** True for a source expression we can safely inline into a policy: a real
- *  scheme://host origin with no quote, whitespace, or delimiter that could
- *  break out of the directive (or out of the meta tag's attribute). */
+ *  `scheme://host[:port]` and nothing else.
+ *
+ *  The authority may not carry a path, query, fragment, or userinfo. A URL like
+ *  `https://example.com/app` is not an origin, and accepting one would silently
+ *  narrow the emitted source to that path prefix — blocking `/sandbox/` and
+ *  blanking every React preview. `[` and `]` stay legal so an IPv6 authority
+ *  (`http://[::1]:3000`) still passes; quotes, whitespace, and angle brackets
+ *  are excluded so a value can never break out of the directive or the meta
+ *  tag's attribute. */
 function isUsableOrigin(value: string): boolean {
-  return /^[a-z][a-z0-9+.-]*:\/\/[^\s'";<>]+$/i.test(value);
+  return /^[a-z][a-z0-9+.-]*:\/\/[^\s'";<>/?#@]+$/i.test(value);
 }
 
 /**
@@ -58,14 +72,19 @@ export function buildPreviewCsp(assetOrigin: string = resolveSandboxAssetOrigin(
     // Everything not named below is denied outright, so a fetch directive we
     // forget fails closed instead of staying wide open.
     "default-src 'none'",
-    // The offline runtime + Tailwind engine load from our origin; the
-    // artifact's own inline <script> needs 'unsafe-inline', and the JSX
-    // transpiler evaluates the component through `new Function` ('unsafe-eval').
-    // Both are inherent to running untrusted code in the sandbox — the opaque
-    // origin, not the script policy, is what contains it.
-    `script-src ${origin} 'unsafe-inline' 'unsafe-eval'`,
-    // Tailwind's browser engine injects <style> elements as it scans the DOM.
-    `style-src ${origin} 'unsafe-inline'`,
+    // Scoped to the SANDBOX ASSET PATH, not the whole origin. Allowing the
+    // bare origin would leave `<script src="<origin>/anything?leak=…">` as a
+    // working GET channel — the artifact's own scripts are inline, so nothing
+    // legitimate loads a script by URL except our runtime and Tailwind engine.
+    // 'unsafe-inline' covers the artifact's inline <script> and event handlers;
+    // 'unsafe-eval' covers the JSX transpiler's `new Function`. Both are
+    // inherent to running untrusted code at all — the opaque origin, not the
+    // script policy, is what contains it.
+    `script-src ${origin}/sandbox/ 'unsafe-inline' 'unsafe-eval'`,
+    // Tailwind's browser engine injects <style> elements as it scans the DOM,
+    // which 'unsafe-inline' covers. No origin here at all: a stylesheet URL is
+    // another GET channel, and no artifact loads one.
+    "style-src 'unsafe-inline'",
     // Inline art only. A remote image URL is a GET beacon in disguise, which is
     // the cheapest exfil channel a generated sketch has.
     "img-src data: blob:",

--- a/src/lib/canvas-preview-csp.ts
+++ b/src/lib/canvas-preview-csp.ts
@@ -1,0 +1,131 @@
+// The offline Content-Security-Policy stamped into every Canvas artifact
+// preview (HTML and React alike).
+//
+// The `<iframe sandbox="allow-scripts">` around a preview is an ORIGIN
+// boundary: the frame is opaque, so artifact code cannot touch Cave's DOM,
+// cookies, or storage. It is not a NETWORK boundary — until this module, a
+// sketch could still `fetch()` an arbitrary host, pull a remote script into its
+// own sandbox, or beacon out through an `<img>` URL. Every generation prompt
+// asks for a self-contained, network-free document; this makes the browser
+// enforce it rather than trusting a model to have complied.
+//
+// Two properties are load-bearing:
+//
+// 1. `'self'` is USELESS here. The preview document's own origin is opaque, so
+//    a `'self'` source expression matches nothing and would block the very
+//    runtime the React path loads from `/sandbox/`. The app's real origin has
+//    to be named explicitly, which is why the builders take one.
+// 2. No origin ⇒ NO POLICY. When the origin can't be resolved (a unit test, a
+//    non-browser caller), we emit nothing rather than a policy that would blank
+//    every React preview. A half-applied lockdown that silently breaks the
+//    surface is worse than the status quo it replaces; the app itself is fully
+//    client-rendered (`lazy-surfaces.tsx` mounts these with `ssr: false`), so
+//    the origin is always available where it matters.
+
+/** Marker attribute so a stamped policy is identifiable in tests and DevTools. */
+export const PREVIEW_CSP_MARKER = "cave-canvas-preview-csp";
+
+/** True for a source expression we can safely inline into a policy: a real
+ *  scheme://host origin with no quote, whitespace, or delimiter that could
+ *  break out of the directive (or out of the meta tag's attribute). */
+function isUsableOrigin(value: string): boolean {
+  return /^[a-z][a-z0-9+.-]*:\/\/[^\s'";<>]+$/i.test(value);
+}
+
+/**
+ * The origin the sandbox assets (`/sandbox/react-runtime.js`, `tailwind.js`)
+ * are served from — the app's own origin, since a `srcdoc` document resolves
+ * absolute paths against its parent's base URL. Returns "" when there's no
+ * usable origin (Node, an opaque context), which callers read as "no policy".
+ */
+export function resolveSandboxAssetOrigin(): string {
+  const origin = (globalThis as { location?: { origin?: string } }).location?.origin;
+  if (typeof origin !== "string") return "";
+  const trimmed = origin.trim();
+  // A sandboxed document reports its own origin as the literal "null".
+  if (!trimmed || trimmed === "null") return "";
+  return isUsableOrigin(trimmed) ? trimmed : "";
+}
+
+/**
+ * Build the policy for a preview served alongside `assetOrigin`. Returns "" for
+ * an unusable origin (see the module comment — that means "stamp nothing").
+ */
+export function buildPreviewCsp(assetOrigin: string = resolveSandboxAssetOrigin()): string {
+  const origin = typeof assetOrigin === "string" ? assetOrigin.trim() : "";
+  if (!origin || !isUsableOrigin(origin)) return "";
+  return [
+    // Everything not named below is denied outright, so a fetch directive we
+    // forget fails closed instead of staying wide open.
+    "default-src 'none'",
+    // The offline runtime + Tailwind engine load from our origin; the
+    // artifact's own inline <script> needs 'unsafe-inline', and the JSX
+    // transpiler evaluates the component through `new Function` ('unsafe-eval').
+    // Both are inherent to running untrusted code in the sandbox — the opaque
+    // origin, not the script policy, is what contains it.
+    `script-src ${origin} 'unsafe-inline' 'unsafe-eval'`,
+    // Tailwind's browser engine injects <style> elements as it scans the DOM.
+    `style-src ${origin} 'unsafe-inline'`,
+    // Inline art only. A remote image URL is a GET beacon in disguise, which is
+    // the cheapest exfil channel a generated sketch has.
+    "img-src data: blob:",
+    "font-src data:",
+    "media-src data: blob:",
+    // No fetch/XHR/WebSocket/sendBeacon to anywhere, including our own origin:
+    // a preview has nothing legitimate to ask Cave's API for.
+    "connect-src 'none'",
+    // A form POST navigates, so it escapes connect-src; deny it separately.
+    "form-action 'none'",
+    // Nested browsing contexts and workers would each get their own policy
+    // scope, so they stay off the table entirely.
+    "frame-src 'none'",
+    "child-src 'none'",
+    "worker-src 'none'",
+    "object-src 'none'",
+    "manifest-src 'none'",
+    // Without this, a `<base href>` in the artifact could re-point every
+    // relative URL — including the sandbox runtime path — at another host.
+    "base-uri 'none'",
+  ].join("; ");
+}
+
+/** The meta tag carrying `policy`, or "" when there's no policy to stamp. */
+export function previewCspMetaTag(assetOrigin?: string): string {
+  const policy = buildPreviewCsp(assetOrigin);
+  if (!policy) return "";
+  return `<meta http-equiv="Content-Security-Policy" content="${policy}" data-${PREVIEW_CSP_MARKER}="1" />`;
+}
+
+/** Offset just past a leading `<!doctype …>` (comments allowed before it), or
+ *  null when the document doesn't start with one. Mirrors the inspector's own
+ *  placement rule so the two injections agree on where a document begins. */
+function leadingDoctypeEnd(source: string): number | null {
+  let offset = 0;
+  while (offset < source.length) {
+    while (offset < source.length && source[offset].trim() === "") offset += 1;
+    if (!source.startsWith("<!--", offset)) break;
+    const commentEnd = source.indexOf("-->", offset + 4);
+    if (commentEnd === -1) return null;
+    offset = commentEnd + 3;
+  }
+  if (source.slice(offset, offset + 9).toLowerCase() !== "<!doctype") return null;
+  const doctypeEnd = source.indexOf(">", offset + 9);
+  return doctypeEnd === -1 ? null : doctypeEnd + 1;
+}
+
+/**
+ * Stamp the policy into `html`, immediately after any leading doctype.
+ *
+ * A `http-equiv` policy only governs what the parser meets AFTER it, so this
+ * must run LAST — after the inspector injection — to stay ahead of every other
+ * script in the document. Markup before `<html>` is hoisted into the implicit
+ * `<head>` by the parser, which is exactly where the meta needs to land.
+ */
+export function injectPreviewCsp(html: string, assetOrigin?: string): string {
+  const source = typeof html === "string" ? html : "";
+  const meta = previewCspMetaTag(assetOrigin);
+  if (!meta) return source;
+  const splitAt = leadingDoctypeEnd(source);
+  if (splitAt === null) return `${meta}${source}`;
+  return `${source.slice(0, splitAt)}${meta}${source.slice(splitAt)}`;
+}

--- a/src/lib/canvas-react-harness.ts
+++ b/src/lib/canvas-react-harness.ts
@@ -8,9 +8,12 @@
 // Isolation is unchanged from the HTML path: the result runs in an
 // <iframe sandbox="allow-scripts"> (no allow-same-origin). The assets are
 // same-origin to our server but the iframe stays an opaque origin — loading a
-// script is allowed; reaching Cave's DOM/cookies is not.
+// script is allowed; reaching Cave's DOM/cookies is not. The document also
+// carries the offline CSP from canvas-preview-csp.ts, which keeps a component
+// from reaching the network at all.
 
 import { injectCanvasInspector } from "./canvas-inspector.ts";
+import { injectPreviewCsp } from "./canvas-preview-csp.ts";
 
 /** Absolute paths (resolved against the parent's base URL inside about:srcdoc). */
 export const SANDBOX_RUNTIME_SRC = "/sandbox/react-runtime.js";
@@ -26,9 +29,18 @@ export function escapeForScriptTag(code: string): string {
   return (typeof code === "string" ? code : "").replace(/<\/(script>)/gi, "<\\/$1");
 }
 
-/** Frame React component source into a full preview document. */
-export function buildReactSrcDoc(code: string, inspectorGeneration = ""): string {
-  return injectCanvasInspector([
+/** Frame React component source into a full preview document.
+ *
+ *  `assetOrigin` names the origin the sandbox assets are served from, since the
+ *  CSP cannot express it as `'self'` from an opaque origin. It defaults to the
+ *  app's own origin; omit it outside a browser and the document ships without a
+ *  policy rather than with one that would block its own runtime. */
+export function buildReactSrcDoc(
+  code: string,
+  inspectorGeneration = "",
+  assetOrigin?: string,
+): string {
+  return injectPreviewCsp(injectCanvasInspector([
     "<!doctype html>",
     '<html lang="en">',
     "<head>",
@@ -49,5 +61,5 @@ export function buildReactSrcDoc(code: string, inspectorGeneration = ""): string
     `<script src="${SANDBOX_RUNTIME_SRC}"></script>`,
     "</body>",
     "</html>",
-  ].join("\n"), inspectorGeneration);
+  ].join("\n"), inspectorGeneration), assetOrigin);
 }

--- a/src/lib/canvas-react-harness.ts
+++ b/src/lib/canvas-react-harness.ts
@@ -9,8 +9,9 @@
 // <iframe sandbox="allow-scripts"> (no allow-same-origin). The assets are
 // same-origin to our server but the iframe stays an opaque origin — loading a
 // script is allowed; reaching Cave's DOM/cookies is not. The document also
-// carries the offline CSP from canvas-preview-csp.ts, which keeps a component
-// from reaching the network at all.
+// carries the offline CSP from canvas-preview-csp.ts: the component can load
+// the sandbox assets under `/sandbox/` and nothing else — no fetch, no remote
+// media, no third-party script.
 
 import { injectCanvasInspector } from "./canvas-inspector.ts";
 import { injectPreviewCsp } from "./canvas-preview-csp.ts";


### PR DESCRIPTION
## What

Canvas artifact previews (the Sketch gallery, the preview modal, the editor stage, and the inline chat viewer) run untrusted, model-generated code in an `<iframe sandbox="allow-scripts">`. That is an **origin** boundary — the frame is opaque, so artifact code cannot touch Cave's DOM, cookies, or storage — but it is not a **network** boundary. Until this change a sketch could still `fetch()` any host, pull a remote script into its own sandbox, or beacon out through an `<img>` URL. Every generation prompt asks for a self-contained, network-free document (`buildSketchPrompt`: *"no CDN, no network access of any kind"*); nothing made the browser enforce it.

`src/lib/canvas-preview-csp.ts` stamps a policy into both preview builders, injected after the inspector so it precedes every script in the document. It allows exactly what a self-contained sketch needs and denies the rest.

## Two details worth reviewing carefully

**`'self'` is useless here.** The preview document's origin is opaque, so a `'self'` source expression matches nothing — it would have blocked `/sandbox/react-runtime.js` and blanked every React preview. The app's real origin is named literally instead (`resolveSandboxAssetOrigin`).

**No resolvable origin means no policy at all**, not a partial one. A lockdown that silently blanks the surface would be worse than the gap it closes. The app is fully client-rendered (`lazy-surfaces.tsx` mounts these with `ssr: false`), so the origin is always available where it matters; the `""` path exists for Node and unit tests.

`'unsafe-inline'` and `'unsafe-eval'` are deliberate: the artifact's own inline `<script>` and the JSX transpiler's `new Function` are inherent to running a sketch. The opaque origin, not the script policy, is what contains it — the CSP's job here is egress.

## Verification

`canvas-preview-csp-chromium.test.ts` runs every probe **twice**, once without the policy, because a control is the only thing that distinguishes *blocked* from *never attempted*:

- Control: the `img` and `fetch` beacons reach the test server.
- Guarded: the runtime still loads, `new Function` still works, an artifact's own inline script still runs, and neither beacon reaches the network.

Live check against the real canvas store (19 saved sketches, React and HTML): every sketch renders unchanged, every frame carries the policy ahead of its first script, and the page logs no CSP violations. Audited the store first — no saved artifact references a remote script, image, or font, so nothing there regresses.

`typecheck`, `lint`, and `check:tests-wired` are green. The `app` suite passes apart from two failures that reproduce on an untouched `main` checkout and are unrelated to this change: `scripts/sync-marketplace.test.mjs` (stale `coven-memory` manifests, from `7a2c6cbfc`) and `src/lib/server/automation-runner.test.ts` (macOS `/private/var` vs `/var` realpath).

Bead: `cave-vutkj`.