### PR TITLE
docs: freeze docs/specs and point per-surface design at superpowers/specs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -112,7 +112,7 @@ Point-in-time records. Read for intent, not for current behavior.
 ## Other trees under `docs/`
 
 - [`superpowers/`](superpowers) — the approved spec and plan store beads cite (133 files)
-- [`specs/`](specs) — an earlier spec store (55 files) that overlapped `superpowers/` from 2026-06-30 to 2026-08-06. Nothing outside it references it except `coven-design-language.md`. **Write new specs to `superpowers/specs`.** It also holds three undated standing contracts — `double-blind-eval`, `ios-new-chat-project-contract`, `research-generations-media-contract-v2` — which are not point-in-time records
+- [`specs/`](specs) — **frozen** (55 files). The earlier flat convention, which overlapped `superpowers/` from 2026-06-30 to 2026-08-06. Closed to new files, and deliberately not migrated: beads cite these by path, including one open unit. See [`specs/README.md`](specs/README.md) for the reasoning and for the three undated standing contracts it holds
 - [`plans/`](plans), [`audits/`](audits) — small point-in-time sets predating the `superpowers/` store
 - [`design-handoff/`](design-handoff), [`diagrams/`](diagrams), [`screenshots/`](screenshots), [`familiar-chatout-codex/`](familiar-chatout-codex) — supporting material
 

--- a/docs/coven-design-language.md
+++ b/docs/coven-design-language.md
@@ -6,7 +6,8 @@ token contract itself lives in code — `src/styles/globals/foundations.css` (th
 annotated token contract) plus per-theme overrides in
 `src/styles/globals/themes.css`; `src/app/globals.css` is only the import
 facade over the `src/styles/globals/*` modules — and on the live reference page
-at `/aesthetic`; per-surface decisions live in `docs/specs/`. This document
+at `/aesthetic`; per-surface decisions live in `docs/superpowers/specs/`
+(`docs/specs/` is the frozen predecessor — see its README). This document
 ties them together and codifies the rules that were previously only implicit.
 Factual claims below (palette counts, token values, cited paths) are pinned by
 `scripts/ui-consistency.test.mjs`, so drift fails CI instead of accumulating.
@@ -424,7 +425,8 @@ placeholder.
 ---
 
 *Related: `/aesthetic` (live tokens) · `src/lib/theme-palettes.ts` (theme
-roster + voice samples) · `docs/specs/` (per-surface `*-design.md` decisions) ·
+roster + voice samples) · `docs/superpowers/specs/` (per-surface `*-design.md`
+decisions; `docs/specs/` holds the frozen predecessors) ·
 `src/styles/globals/foundations.css` (the annotated token contract) ·
 `src/styles/globals/themes.css` (per-theme palettes) ·
 `src/styles/globals/primitives.css` (shared `.ui-*` classes).*

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,47 @@
+# Frozen — closed to new files
+
+New design and plan documents go in [`../superpowers/specs`](../superpowers/specs)
+and [`../superpowers/plans`](../superpowers/plans). Nothing new belongs here.
+
+The 55 files already in this directory **stay where they are**, permanently.
+They are not scheduled for migration and should not be moved.
+
+## Why frozen rather than migrated
+
+Beads cite these files **by path**, and one of those citations is on live work:
+`cave-ltl38.6` ("Connect conversation checkpoints to exact code evidence")
+carries a structured `Spec:` field pointing at
+[`2026-07-03-unified-chat-code-workspace-design.md`](2026-07-03-unified-chat-code-workspace-design.md).
+It is open, sits under the `cave-ltl38` epic, and blocks two further units.
+Moving that file breaks the field.
+
+Fifteen more of these files are cited by closed beads, where the path is the
+provenance trail for work that already shipped. Moving them severs that trail
+for no benefit: the two stores hold **disjoint** content — not one slug appears
+in both — so there is nothing here to deduplicate. A migration would buy
+tidiness and cost correctness.
+
+## What changed, and when
+
+This directory is the earlier convention: design and plan documents interleaved
+in one flat tree, 28 `*-design.md` beside 22 `*-plan.md`. The `superpowers/`
+store that replaced it separates the two — `specs/` holds the design, `plans/`
+holds the implementation plan derived from it — and states that contract in
+[its README](../superpowers/README.md). `AGENTS.md` cites `superpowers/` as
+authoritative; nothing in `AGENTS.md`, `CLAUDE.md`, or `CONTRIBUTING.md`
+mentions this directory at all.
+
+The two ran in parallel from 2026-06-30 to 2026-08-06. That overlap is why the
+boundary needed writing down.
+
+## Three files here are not point-in-time records
+
+These are standing contracts with no date in the name, and they do not expire
+the way a dated spec does:
+
+- [`double-blind-eval.md`](double-blind-eval.md)
+- [`ios-new-chat-project-contract.md`](ios-new-chat-project-contract.md)
+- [`research-generations-media-contract-v2.md`](research-generations-media-contract-v2.md)
+
+They stay here for the same path-stability reason as everything else. Read them
+as current unless the contract they describe has been superseded in code.


### PR DESCRIPTION
Follow-up to #4605, which flagged the two-spec-store situation but deliberately left the decision open. This resolves it: **freeze, don't migrate.**

## The live problem

`coven-design-language.md` was the last thing in the repo still directing writers to `docs/specs` — twice, in its intro and its references line — while `AGENTS.md` and every recent bead treat `docs/superpowers/specs` as authoritative. Nothing in `AGENTS.md`, `CLAUDE.md`, or `CONTRIBUTING.md` mentions `docs/specs` at all, so that doc was the **sole surviving instruction** to write there. It's also one of the three docs the root README sends newcomers to.

## Why freeze rather than migrate

Of 1,833 beads, 16 cite `docs/specs` and exactly **one is open**:

- `cave-ltl38.6` — "Connect conversation checkpoints to exact code evidence" — carries a structured `Spec:` field pointing at `2026-07-03-unified-chat-code-workspace-design.md`. It sits under the `cave-ltl38` epic and blocks two further units. **Moving that file breaks the field.**

The other 15 are provenance on closed work. And the two stores hold **disjoint** content — not one slug appears in both — so there is nothing to deduplicate. Migration would buy tidiness and cost correctness.

The underlying difference is conventions, not duplication: `docs/specs` is the earlier flat tree (28 `*-design.md` beside 22 `*-plan.md`); `superpowers/` separates design from the plan derived from it.

## Changes

| File | Change |
|---|---|
| `docs/specs/README.md` | **New.** Marks the store frozen, records why migration is wrong, names the three undated standing contracts that are not point-in-time records |
| `docs/coven-design-language.md` | Both pointers redirected to `superpowers/specs`, noting `docs/specs` as the frozen predecessor |
| `docs/README.md` | The `specs/` entry now says frozen and links the new README |

## Verification

`scripts/ui-consistency.test.mjs` asserts that **every backticked repo path** in the design doc exists, so the redirect had to name a real directory — this is exactly the sort of edit that rots a citation silently. Run clean:

```
ui-consistency.test.mjs: contract, scanner, and baseline ok (12 palettes, 334 icons)
```

Links checked in both indexes: 56 and 7 respectively, zero broken. `2026-07-03-unified-chat-code-workspace-design.md` is untouched and still in place.

Docs-only; no source or test files changed.