### PR TITLE
fix(marketplace): generate the skills field the runtime requires

### DIFF
--- a/marketplace/plugins/1password/plugin.json
+++ b/marketplace/plugins/1password/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/1password",
   "x-coven": {
     "displayName": "1Password Secret Management",

--- a/marketplace/plugins/activepieces/plugin.json
+++ b/marketplace/plugins/activepieces/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/activepieces",
   "x-coven": {
     "displayName": "Activepieces",

--- a/marketplace/plugins/alchemists-crucible/plugin.json
+++ b/marketplace/plugins/alchemists-crucible/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/alchemists-crucible",
   "x-coven": {
     "displayName": "Alchemist's Crucible",

--- a/marketplace/plugins/apify/plugin.json
+++ b/marketplace/plugins/apify/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/apify",
   "x-coven": {
     "displayName": "Apify",

--- a/marketplace/plugins/archivists-index/plugin.json
+++ b/marketplace/plugins/archivists-index/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/archivists-index",
   "x-coven": {
     "displayName": "Archivist's Index",

--- a/marketplace/plugins/artificers-codex/plugin.json
+++ b/marketplace/plugins/artificers-codex/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/artificers-codex",
   "x-coven": {
     "displayName": "Artificer's Codex",

--- a/marketplace/plugins/asana/plugin.json
+++ b/marketplace/plugins/asana/plugin.json
@@ -18,6 +18,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/asana",
   "x-coven": {
     "displayName": "Asana",

--- a/marketplace/plugins/ask-curl/plugin.json
+++ b/marketplace/plugins/ask-curl/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/ask-curl",
   "x-coven": {
     "displayName": "Ask cURL",

--- a/marketplace/plugins/atlassian/plugin.json
+++ b/marketplace/plugins/atlassian/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/atlassian",
   "x-coven": {
     "displayName": "Atlassian Rovo",

--- a/marketplace/plugins/azure-devops/plugin.json
+++ b/marketplace/plugins/azure-devops/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/azure-devops",
   "x-coven": {
     "displayName": "Azure DevOps",

--- a/marketplace/plugins/azure/plugin.json
+++ b/marketplace/plugins/azure/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/azure",
   "x-coven": {
     "displayName": "Azure MCP Server",

--- a/marketplace/plugins/board/plugin.json
+++ b/marketplace/plugins/board/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/board",
   "x-coven": {
     "displayName": "BOARD \u2014 Shared Task Board",

--- a/marketplace/plugins/brand-voice-generator/plugin.json
+++ b/marketplace/plugins/brand-voice-generator/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/brand-voice-generator",
   "x-coven": {
     "displayName": "Brand & Voice Generator",

--- a/marketplace/plugins/brightdata/plugin.json
+++ b/marketplace/plugins/brightdata/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/brightdata",
   "x-coven": {
     "displayName": "Bright Data",

--- a/marketplace/plugins/browserbase/plugin.json
+++ b/marketplace/plugins/browserbase/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/browserbase",
   "x-coven": {
     "displayName": "Browserbase",

--- a/marketplace/plugins/canva/plugin.json
+++ b/marketplace/plugins/canva/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/canva",
   "x-coven": {
     "displayName": "Canva",

--- a/marketplace/plugins/charms-loom/plugin.json
+++ b/marketplace/plugins/charms-loom/plugin.json
@@ -18,6 +18,7 @@
   "capabilities": [
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/charms-loom",
   "x-coven": {
     "displayName": "Charm's Loom",

--- a/marketplace/plugins/chrome-devtools/plugin.json
+++ b/marketplace/plugins/chrome-devtools/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/chrome-devtools",
   "x-coven": {
     "displayName": "Chrome DevTools",

--- a/marketplace/plugins/cleanup-unused-files/plugin.json
+++ b/marketplace/plugins/cleanup-unused-files/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/cleanup-unused-files",
   "x-coven": {
     "displayName": "Cleanup Unused Files",

--- a/marketplace/plugins/cloudflare-docs/plugin.json
+++ b/marketplace/plugins/cloudflare-docs/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/cloudflare-docs",
   "x-coven": {
     "displayName": "Cloudflare Docs",

--- a/marketplace/plugins/codeflow-maintainer/plugin.json
+++ b/marketplace/plugins/codeflow-maintainer/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/codeflow-maintainer",
   "x-coven": {
     "displayName": "CodeFlow Maintainer Skill",

--- a/marketplace/plugins/codex-session-manager/plugin.json
+++ b/marketplace/plugins/codex-session-manager/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/codex-session-manager",
   "x-coven": {
     "displayName": "Codex Session Manager",

--- a/marketplace/plugins/command-palette-keyboard-ux/plugin.json
+++ b/marketplace/plugins/command-palette-keyboard-ux/plugin.json
@@ -24,6 +24,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/command-palette-keyboard-ux",
   "x-coven": {
     "displayName": "Command Palette & Keyboard UX (\u2318K)",

--- a/marketplace/plugins/context7/plugin.json
+++ b/marketplace/plugins/context7/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/context7",
   "x-coven": {
     "displayName": "Context7",

--- a/marketplace/plugins/coven-automations/plugin.json
+++ b/marketplace/plugins/coven-automations/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-automations",
   "x-coven": {
     "displayName": "Coven Automations",

--- a/marketplace/plugins/coven-canvas/plugin.json
+++ b/marketplace/plugins/coven-canvas/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-canvas",
   "x-coven": {
     "displayName": "Coven Canvas",

--- a/marketplace/plugins/coven-evals/plugin.json
+++ b/marketplace/plugins/coven-evals/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-evals",
   "x-coven": {
     "displayName": "Coven Evals",

--- a/marketplace/plugins/coven-familiars/plugin.json
+++ b/marketplace/plugins/coven-familiars/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-familiars",
   "x-coven": {
     "displayName": "Coven Familiars",

--- a/marketplace/plugins/coven-flows/plugin.json
+++ b/marketplace/plugins/coven-flows/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-flows",
   "x-coven": {
     "displayName": "Coven Flows",

--- a/marketplace/plugins/coven-memory/.codex-plugin/plugin.json
+++ b/marketplace/plugins/coven-memory/.codex-plugin/plugin.json
@@ -5,9 +5,7 @@
   "author": {
     "name": "OpenCoven"
   },
-  "skills": [
-    "skills/"
-  ],
+  "skills": "./skills/",
   "interface": {
     "displayName": "Coven Memory & Knowledge",
     "shortDescription": "Persist and recall cross-session memory and curated knowledge-vault references for your familiars.",

--- a/marketplace/plugins/coven-memory/plugin.json
+++ b/marketplace/plugins/coven-memory/plugin.json
@@ -19,9 +19,7 @@
     "read_files",
     "write_files"
   ],
-  "skills": [
-    "skills/"
-  ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-memory",
   "x-coven": {
     "displayName": "Coven Memory & Knowledge",

--- a/marketplace/plugins/coven-parallel-work/plugin.json
+++ b/marketplace/plugins/coven-parallel-work/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/coven-parallel-work",
   "x-coven": {
     "displayName": "Coven Parallel Work Protocol",

--- a/marketplace/plugins/daily-dev-agentic/plugin.json
+++ b/marketplace/plugins/daily-dev-agentic/plugin.json
@@ -21,6 +21,7 @@
     "write_files",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/daily-dev-agentic",
   "x-coven": {
     "displayName": "daily.dev Agentic Learning",

--- a/marketplace/plugins/dataviz-dashboard-ux/plugin.json
+++ b/marketplace/plugins/dataviz-dashboard-ux/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/dataviz-dashboard-ux",
   "x-coven": {
     "displayName": "Data-Viz & Dashboard UX",

--- a/marketplace/plugins/dbhub/plugin.json
+++ b/marketplace/plugins/dbhub/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/dbhub",
   "x-coven": {
     "displayName": "DBHub",

--- a/marketplace/plugins/design-system-landscape/plugin.json
+++ b/marketplace/plugins/design-system-landscape/plugin.json
@@ -21,6 +21,7 @@
   "capabilities": [
     "read_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/design-system-landscape",
   "x-coven": {
     "displayName": "Design-System Landscape",

--- a/marketplace/plugins/desktop-commander/plugin.json
+++ b/marketplace/plugins/desktop-commander/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/desktop-commander",
   "x-coven": {
     "displayName": "Desktop Commander",

--- a/marketplace/plugins/discrawl/plugin.json
+++ b/marketplace/plugins/discrawl/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/discrawl",
   "x-coven": {
     "displayName": "Discrawl",

--- a/marketplace/plugins/disk-space-optimizer/plugin.json
+++ b/marketplace/plugins/disk-space-optimizer/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/disk-space-optimizer",
   "x-coven": {
     "displayName": "Disk Space Optimization",

--- a/marketplace/plugins/e2b/plugin.json
+++ b/marketplace/plugins/e2b/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/e2b",
   "x-coven": {
     "displayName": "E2B Code Sandbox",

--- a/marketplace/plugins/elevenlabs/plugin.json
+++ b/marketplace/plugins/elevenlabs/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/elevenlabs",
   "x-coven": {
     "displayName": "ElevenLabs",

--- a/marketplace/plugins/empty-loading-error-states/plugin.json
+++ b/marketplace/plugins/empty-loading-error-states/plugin.json
@@ -21,6 +21,7 @@
   "capabilities": [
     "read_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/empty-loading-error-states",
   "x-coven": {
     "displayName": "Empty, Loading & Error States",

--- a/marketplace/plugins/epub-to-pdf/plugin.json
+++ b/marketplace/plugins/epub-to-pdf/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/epub-to-pdf",
   "x-coven": {
     "displayName": "EPUB to PDF",

--- a/marketplace/plugins/exa/plugin.json
+++ b/marketplace/plugins/exa/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/exa",
   "x-coven": {
     "displayName": "Exa Search",

--- a/marketplace/plugins/fabric/plugin.json
+++ b/marketplace/plugins/fabric/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/fabric",
   "x-coven": {
     "displayName": "Microsoft Fabric",

--- a/marketplace/plugins/fetch/plugin.json
+++ b/marketplace/plugins/fetch/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/fetch",
   "x-coven": {
     "displayName": "Fetch",

--- a/marketplace/plugins/figma/plugin.json
+++ b/marketplace/plugins/figma/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/figma",
   "x-coven": {
     "displayName": "Figma",

--- a/marketplace/plugins/filesystem/plugin.json
+++ b/marketplace/plugins/filesystem/plugin.json
@@ -19,6 +19,7 @@
     "write_files",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/filesystem",
   "x-coven": {
     "displayName": "Filesystem",

--- a/marketplace/plugins/firecrawl/plugin.json
+++ b/marketplace/plugins/firecrawl/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/firecrawl",
   "x-coven": {
     "displayName": "Firecrawl",

--- a/marketplace/plugins/form-ux-patterns/plugin.json
+++ b/marketplace/plugins/form-ux-patterns/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/form-ux-patterns",
   "x-coven": {
     "displayName": "Form UX Patterns",

--- a/marketplace/plugins/framer-motion-patterns/plugin.json
+++ b/marketplace/plugins/framer-motion-patterns/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/framer-motion-patterns",
   "x-coven": {
     "displayName": "Motion (Framer Motion) Patterns",

--- a/marketplace/plugins/git/plugin.json
+++ b/marketplace/plugins/git/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/git",
   "x-coven": {
     "displayName": "Git",

--- a/marketplace/plugins/github/plugin.json
+++ b/marketplace/plugins/github/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/github",
   "x-coven": {
     "displayName": "GitHub",

--- a/marketplace/plugins/gmail/plugin.json
+++ b/marketplace/plugins/gmail/plugin.json
@@ -18,6 +18,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/gmail",
   "x-coven": {
     "displayName": "Gmail",

--- a/marketplace/plugins/google-calendar/plugin.json
+++ b/marketplace/plugins/google-calendar/plugin.json
@@ -18,6 +18,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/google-calendar",
   "x-coven": {
     "displayName": "Google Calendar",

--- a/marketplace/plugins/grand-research-ritual/plugin.json
+++ b/marketplace/plugins/grand-research-ritual/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/grand-research-ritual",
   "x-coven": {
     "displayName": "Grand Research Ritual",

--- a/marketplace/plugins/heygen-skills/plugin.json
+++ b/marketplace/plugins/heygen-skills/plugin.json
@@ -22,6 +22,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/heygen-skills",
   "x-coven": {
     "displayName": "HeyGen Skills",

--- a/marketplace/plugins/higgsfield-generate/plugin.json
+++ b/marketplace/plugins/higgsfield-generate/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/higgsfield-generate",
   "x-coven": {
     "displayName": "Higgsfield Generate",

--- a/marketplace/plugins/huggingface/plugin.json
+++ b/marketplace/plugins/huggingface/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/huggingface",
   "x-coven": {
     "displayName": "Hugging Face",

--- a/marketplace/plugins/linear-issue-management/plugin.json
+++ b/marketplace/plugins/linear-issue-management/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/linear-issue-management",
   "x-coven": {
     "displayName": "Linear Issue Management",

--- a/marketplace/plugins/linear/plugin.json
+++ b/marketplace/plugins/linear/plugin.json
@@ -18,6 +18,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/linear",
   "x-coven": {
     "displayName": "Linear",

--- a/marketplace/plugins/lit-ui-designer/plugin.json
+++ b/marketplace/plugins/lit-ui-designer/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/lit-ui-designer",
   "x-coven": {
     "displayName": "Lit UI Designer",

--- a/marketplace/plugins/lobster/plugin.json
+++ b/marketplace/plugins/lobster/plugin.json
@@ -22,6 +22,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/lobster",
   "x-coven": {
     "displayName": "Lobster \u2014 Workflow Shell",

--- a/marketplace/plugins/maintainer-bar/plugin.json
+++ b/marketplace/plugins/maintainer-bar/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/maintainer-bar",
   "x-coven": {
     "displayName": "MaintainerBar \u2014 Maintainer Menu Bar Skill",

--- a/marketplace/plugins/markitdown/plugin.json
+++ b/marketplace/plugins/markitdown/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/markitdown",
   "x-coven": {
     "displayName": "Markitdown",

--- a/marketplace/plugins/mcp-client/plugin.json
+++ b/marketplace/plugins/mcp-client/plugin.json
@@ -21,6 +21,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/mcp-client",
   "x-coven": {
     "displayName": "Universal MCP Client",

--- a/marketplace/plugins/memory-timeline-manager/plugin.json
+++ b/marketplace/plugins/memory-timeline-manager/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/memory-timeline-manager",
   "x-coven": {
     "displayName": "Memory Timeline Manager",

--- a/marketplace/plugins/memory/plugin.json
+++ b/marketplace/plugins/memory/plugin.json
@@ -19,6 +19,7 @@
     "write_files",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/memory",
   "x-coven": {
     "displayName": "Memory",

--- a/marketplace/plugins/microsoft-learn/plugin.json
+++ b/marketplace/plugins/microsoft-learn/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/microsoft-learn",
   "x-coven": {
     "displayName": "Microsoft Learn",

--- a/marketplace/plugins/ml-engineer/plugin.json
+++ b/marketplace/plugins/ml-engineer/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/ml-engineer",
   "x-coven": {
     "displayName": "ML Engineer",

--- a/marketplace/plugins/mobile-touch-ux/plugin.json
+++ b/marketplace/plugins/mobile-touch-ux/plugin.json
@@ -26,6 +26,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/mobile-touch-ux",
   "x-coven": {
     "displayName": "Mobile Touch UX & Responsive Patterns",

--- a/marketplace/plugins/mongodb/plugin.json
+++ b/marketplace/plugins/mongodb/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/mongodb",
   "x-coven": {
     "displayName": "MongoDB",

--- a/marketplace/plugins/netdata/plugin.json
+++ b/marketplace/plugins/netdata/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/netdata",
   "x-coven": {
     "displayName": "Netdata",

--- a/marketplace/plugins/next-devtools/plugin.json
+++ b/marketplace/plugins/next-devtools/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/next-devtools",
   "x-coven": {
     "displayName": "Next.js DevTools",

--- a/marketplace/plugins/nodriver/plugin.json
+++ b/marketplace/plugins/nodriver/plugin.json
@@ -22,6 +22,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/nodriver",
   "x-coven": {
     "displayName": "nodriver",

--- a/marketplace/plugins/notion/plugin.json
+++ b/marketplace/plugins/notion/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/notion",
   "x-coven": {
     "displayName": "Notion",

--- a/marketplace/plugins/nuget/plugin.json
+++ b/marketplace/plugins/nuget/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/nuget",
   "x-coven": {
     "displayName": "NuGet",

--- a/marketplace/plugins/nuxt-dev/plugin.json
+++ b/marketplace/plugins/nuxt-dev/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/nuxt-dev",
   "x-coven": {
     "displayName": "Nuxt Dev",

--- a/marketplace/plugins/ocr/plugin.json
+++ b/marketplace/plugins/ocr/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/ocr",
   "x-coven": {
     "displayName": "OCR",

--- a/marketplace/plugins/openclaw-dev/plugin.json
+++ b/marketplace/plugins/openclaw-dev/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/openclaw-dev",
   "x-coven": {
     "displayName": "OpenClaw Dev Agent",

--- a/marketplace/plugins/openclaw-trust/plugin.json
+++ b/marketplace/plugins/openclaw-trust/plugin.json
@@ -18,6 +18,7 @@
   "capabilities": [
     "read_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/openclaw-trust",
   "x-coven": {
     "displayName": "OpenClaw Trust",

--- a/marketplace/plugins/opencoven-design/plugin.json
+++ b/marketplace/plugins/opencoven-design/plugin.json
@@ -19,6 +19,7 @@
   "capabilities": [
     "read_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/opencoven-design",
   "x-coven": {
     "displayName": "OpenCoven Design Skill",

--- a/marketplace/plugins/opencoven-role-creation-process/plugin.json
+++ b/marketplace/plugins/opencoven-role-creation-process/plugin.json
@@ -21,6 +21,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/opencoven-role-creation-process",
   "x-coven": {
     "displayName": "OpenCoven Role Creation Process",

--- a/marketplace/plugins/oracles-measure/plugin.json
+++ b/marketplace/plugins/oracles-measure/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/oracles-measure",
   "x-coven": {
     "displayName": "Oracle's Measure",

--- a/marketplace/plugins/playwright/plugin.json
+++ b/marketplace/plugins/playwright/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/playwright",
   "x-coven": {
     "displayName": "Playwright",

--- a/marketplace/plugins/postgres/plugin.json
+++ b/marketplace/plugins/postgres/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/postgres",
   "x-coven": {
     "displayName": "PostgreSQL",

--- a/marketplace/plugins/pptx-generator/plugin.json
+++ b/marketplace/plugins/pptx-generator/plugin.json
@@ -22,6 +22,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/pptx-generator",
   "x-coven": {
     "displayName": "PPTX Generator",

--- a/marketplace/plugins/pr-agent/plugin.json
+++ b/marketplace/plugins/pr-agent/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/pr-agent",
   "x-coven": {
     "displayName": "PR Agent \u2014 Maintainer Workflow Orchestrator",

--- a/marketplace/plugins/pretext/plugin.json
+++ b/marketplace/plugins/pretext/plugin.json
@@ -24,6 +24,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/pretext",
   "x-coven": {
     "displayName": "Pretext \u2014 Text Measurement & Layout",

--- a/marketplace/plugins/project-manager/plugin.json
+++ b/marketplace/plugins/project-manager/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/project-manager",
   "x-coven": {
     "displayName": "Project Manager",

--- a/marketplace/plugins/prompt-engineer/plugin.json
+++ b/marketplace/plugins/prompt-engineer/plugin.json
@@ -19,6 +19,7 @@
   "capabilities": [
     "read_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/prompt-engineer",
   "x-coven": {
     "displayName": "Prompt Engineer",

--- a/marketplace/plugins/prompt-vault/plugin.json
+++ b/marketplace/plugins/prompt-vault/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/prompt-vault",
   "x-coven": {
     "displayName": "Prompt Vault",

--- a/marketplace/plugins/remotion/plugin.json
+++ b/marketplace/plugins/remotion/plugin.json
@@ -21,6 +21,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/remotion",
   "x-coven": {
     "displayName": "Remotion Video",

--- a/marketplace/plugins/research-ingestion/plugin.json
+++ b/marketplace/plugins/research-ingestion/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/research-ingestion",
   "x-coven": {
     "displayName": "Research Ingestion",

--- a/marketplace/plugins/ritual-dapp-frontend/plugin.json
+++ b/marketplace/plugins/ritual-dapp-frontend/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/ritual-dapp-frontend",
   "x-coven": {
     "displayName": "Ritual dApp Frontend",

--- a/marketplace/plugins/scribes-quill/plugin.json
+++ b/marketplace/plugins/scribes-quill/plugin.json
@@ -16,6 +16,7 @@
     "research",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/scribes-quill",
   "x-coven": {
     "displayName": "Scribe's Quill",

--- a/marketplace/plugins/searxng/plugin.json
+++ b/marketplace/plugins/searxng/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/searxng",
   "x-coven": {
     "displayName": "SearXNG Search",

--- a/marketplace/plugins/security-agent/plugin.json
+++ b/marketplace/plugins/security-agent/plugin.json
@@ -21,6 +21,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/security-agent",
   "x-coven": {
     "displayName": "Security Agent",

--- a/marketplace/plugins/seekers-lens/plugin.json
+++ b/marketplace/plugins/seekers-lens/plugin.json
@@ -20,6 +20,7 @@
     "ideation",
     "workflows"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/seekers-lens",
   "x-coven": {
     "displayName": "Seeker's Lens",

--- a/marketplace/plugins/sentry/plugin.json
+++ b/marketplace/plugins/sentry/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/sentry",
   "x-coven": {
     "displayName": "Sentry",

--- a/marketplace/plugins/sequential-thinking/plugin.json
+++ b/marketplace/plugins/sequential-thinking/plugin.json
@@ -17,6 +17,7 @@
   "capabilities": [
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/sequential-thinking",
   "x-coven": {
     "displayName": "Sequential Thinking",

--- a/marketplace/plugins/serena/plugin.json
+++ b/marketplace/plugins/serena/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/serena",
   "x-coven": {
     "displayName": "Serena",

--- a/marketplace/plugins/shadcn-ui-and-radix/plugin.json
+++ b/marketplace/plugins/shadcn-ui-and-radix/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/shadcn-ui-and-radix",
   "x-coven": {
     "displayName": "shadcn/ui + Radix + Tailwind",

--- a/marketplace/plugins/skill-creator/plugin.json
+++ b/marketplace/plugins/skill-creator/plugin.json
@@ -21,6 +21,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/skill-creator",
   "x-coven": {
     "displayName": "Skill Creator",

--- a/marketplace/plugins/skill-scanner/plugin.json
+++ b/marketplace/plugins/skill-scanner/plugin.json
@@ -20,6 +20,7 @@
     "write_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/skill-scanner",
   "x-coven": {
     "displayName": "Skill Scanner",

--- a/marketplace/plugins/slack/plugin.json
+++ b/marketplace/plugins/slack/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/slack",
   "x-coven": {
     "displayName": "Slack",

--- a/marketplace/plugins/sop-creator/plugin.json
+++ b/marketplace/plugins/sop-creator/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/sop-creator",
   "x-coven": {
     "displayName": "SOP & Runbook Creator",

--- a/marketplace/plugins/sqlite/plugin.json
+++ b/marketplace/plugins/sqlite/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/sqlite",
   "x-coven": {
     "displayName": "SQLite",

--- a/marketplace/plugins/stackql/plugin.json
+++ b/marketplace/plugins/stackql/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/stackql",
   "x-coven": {
     "displayName": "StackQL",

--- a/marketplace/plugins/stripe/plugin.json
+++ b/marketplace/plugins/stripe/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/stripe",
   "x-coven": {
     "displayName": "Stripe",

--- a/marketplace/plugins/supabase/plugin.json
+++ b/marketplace/plugins/supabase/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/supabase",
   "x-coven": {
     "displayName": "Supabase",

--- a/marketplace/plugins/tailwind-design-tokens/plugin.json
+++ b/marketplace/plugins/tailwind-design-tokens/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tailwind-design-tokens",
   "x-coven": {
     "displayName": "Tailwind Design Tokens & Theming",

--- a/marketplace/plugins/tauri-apple-release/plugin.json
+++ b/marketplace/plugins/tauri-apple-release/plugin.json
@@ -19,6 +19,7 @@
     "read_files",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tauri-apple-release",
   "x-coven": {
     "displayName": "Tauri Apple Release",

--- a/marketplace/plugins/tavily/plugin.json
+++ b/marketplace/plugins/tavily/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tavily",
   "x-coven": {
     "displayName": "Tavily",

--- a/marketplace/plugins/terraform/plugin.json
+++ b/marketplace/plugins/terraform/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/terraform",
   "x-coven": {
     "displayName": "Terraform",

--- a/marketplace/plugins/threejs-animation/plugin.json
+++ b/marketplace/plugins/threejs-animation/plugin.json
@@ -20,6 +20,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/threejs-animation",
   "x-coven": {
     "displayName": "Three.js Animation",

--- a/marketplace/plugins/time/plugin.json
+++ b/marketplace/plugins/time/plugin.json
@@ -17,6 +17,7 @@
   "capabilities": [
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/time",
   "x-coven": {
     "displayName": "Time",

--- a/marketplace/plugins/tinyfish-agent-run/plugin.json
+++ b/marketplace/plugins/tinyfish-agent-run/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tinyfish-agent-run",
   "x-coven": {
     "displayName": "TinyFish Agent Run",

--- a/marketplace/plugins/tinyfish-browser/plugin.json
+++ b/marketplace/plugins/tinyfish-browser/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tinyfish-browser",
   "x-coven": {
     "displayName": "TinyFish Browser",

--- a/marketplace/plugins/tinyfish-fetch/plugin.json
+++ b/marketplace/plugins/tinyfish-fetch/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tinyfish-fetch",
   "x-coven": {
     "displayName": "TinyFish Fetch",

--- a/marketplace/plugins/tinyfish-search/plugin.json
+++ b/marketplace/plugins/tinyfish-search/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tinyfish-search",
   "x-coven": {
     "displayName": "TinyFish Search",

--- a/marketplace/plugins/tinyfish-web-agent/plugin.json
+++ b/marketplace/plugins/tinyfish-web-agent/plugin.json
@@ -21,6 +21,7 @@
     "shell",
     "network"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/tinyfish-web-agent",
   "x-coven": {
     "displayName": "TinyFish Web Agent",

--- a/marketplace/plugins/unity/plugin.json
+++ b/marketplace/plugins/unity/plugin.json
@@ -20,6 +20,7 @@
     "shell",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/unity",
   "x-coven": {
     "displayName": "Unity",

--- a/marketplace/plugins/vercel/plugin.json
+++ b/marketplace/plugins/vercel/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "mcp"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/vercel",
   "x-coven": {
     "displayName": "Vercel",

--- a/marketplace/plugins/wcag-a11y-audit/plugin.json
+++ b/marketplace/plugins/wcag-a11y-audit/plugin.json
@@ -22,6 +22,7 @@
     "read_files",
     "write_files"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/wcag-a11y-audit",
   "x-coven": {
     "displayName": "WCAG 2.2 AA Accessibility Audit",

--- a/marketplace/plugins/worldbuilding/plugin.json
+++ b/marketplace/plugins/worldbuilding/plugin.json
@@ -20,6 +20,7 @@
     "skills",
     "prompts"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/worldbuilding",
   "x-coven": {
     "displayName": "Worldbuilding",

--- a/marketplace/plugins/xurl/plugin.json
+++ b/marketplace/plugins/xurl/plugin.json
@@ -19,6 +19,7 @@
     "network",
     "shell"
   ],
+  "skills": "./skills/",
   "marketplaceId": "opencoven/xurl",
   "x-coven": {
     "displayName": "xurl",

--- a/scripts/sync-marketplace.py
+++ b/scripts/sync-marketplace.py
@@ -437,6 +437,19 @@ def craft_notice(plugin: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def bundles_skills(plugin: dict[str, Any]) -> bool:
+    """True when packaging writes a skills/ directory for this plugin.
+
+    Crafts and Knowledge Packs bundle their pinned upstream skills; a plain
+    plugin gets one generated (or hand-authored) skills/<name>/SKILL.md from
+    its catalog `skill` block. Prompt-only packs carry no skill at all, so
+    their manifest must not advertise a directory that does not exist.
+    """
+    if plugin.get("kind") in {"craft", "knowledge-pack"}:
+        return True
+    return bool(plugin.get("skill"))
+
+
 def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
     manifest: dict[str, Any] = {
         "name": plugin["name"],
@@ -448,6 +461,13 @@ def coven_manifest(plugin: dict[str, Any]) -> dict[str, Any]:
         "license": plugin.get("license", "GPL-3.0"),
         "keywords": plugin.get("keywords", []),
         "capabilities": plugin.get("capabilities", []),
+        # The runtime contract, not decoration: resolveBundledCopilotPluginDirs
+        # (src/lib/server/bundled-copilot-plugins.ts) loads an app-bundled
+        # plugin ONLY when its plugin.json advertises a skills directory and
+        # carries no agents/hooks/mcpServers. Omitting this silently drops the
+        # bundle from Copilot chats, which is how the coven-memory `recall`
+        # registration ended up hand-edited into this generated file.
+        **({"skills": "./skills/"} if bundles_skills(plugin) else {}),
         "marketplaceId": f"opencoven/{plugin['name']}",
         "x-coven": {
             "displayName": plugin["displayName"],

--- a/scripts/sync-marketplace.test.mjs
+++ b/scripts/sync-marketplace.test.mjs
@@ -384,6 +384,39 @@ const productionCodexBrowse = JSON.parse(readFileSync(path.join(ROOT, "marketpla
 const codexSeeker = productionCodexBrowse.plugins.find((plugin) => plugin.name === "seekers-lens");
 assert.ok(codexSeeker, "public Crafts are installable through the Codex marketplace export");
 assert.equal(codexSeeker.source, "./plugins/seekers-lens", "Codex plugin sources stay inside the registered marketplace root");
+// Generated manifests must satisfy the runtime contract in
+// src/lib/server/bundled-copilot-plugins.ts (isSkillOnlyManifest): an
+// app-bundled plugin loads ONLY when its plugin.json advertises a skills
+// directory and carries no agents/hooks/mcpServers. That field was previously
+// absent from the generator and hand-edited into the generated file, so a
+// routine `sync-marketplace.py` run would have deleted it and silently dropped
+// Coven recall from Copilot chats. Pin it on the generated output.
+const bundledMemory = JSON.parse(
+  readFileSync(path.join(ROOT, "marketplace", "plugins", "coven-memory", "plugin.json"), "utf8"),
+);
+const bundledSkills = Array.isArray(bundledMemory.skills) ? bundledMemory.skills : [bundledMemory.skills];
+assert.ok(
+  bundledSkills.length > 0 && bundledSkills.every((entry) => entry === "skills/" || entry === "./skills/"),
+  "coven-memory advertises its skills directory, or the app stops loading the bundle",
+);
+for (const key of ["agents", "hooks", "mcpServers"]) {
+  assert.ok(!(key in bundledMemory), `coven-memory stays skill-only (no ${key})`);
+}
+assert.ok(
+  existsSync(path.join(ROOT, "marketplace", "plugins", "coven-memory", "skills", "recall", "SKILL.md")),
+  "the advertised directory actually holds the recall skill",
+);
+// A prompt-only plugin has no skills/ directory, so it must not claim one.
+const promptOnly = productionCatalog.plugins.find(
+  (plugin) => !plugin.skill && plugin.kind !== "craft" && plugin.kind !== "knowledge-pack",
+);
+if (promptOnly) {
+  const promptManifest = JSON.parse(
+    readFileSync(path.join(ROOT, "marketplace", "plugins", promptOnly.name, "plugin.json"), "utf8"),
+  );
+  assert.ok(!("skills" in promptManifest), `${promptOnly.name} carries no skill, so it advertises no skills directory`);
+}
+
 const productionCheck = spawnSync("python3", [SYNC, "--check"], { cwd: ROOT, encoding: "utf8" });
 assert.equal(productionCheck.status, 0, productionCheck.stderr);
 


### PR DESCRIPTION
## Why this is urgent

`scripts/sync-marketplace.test.mjs` has been failing on `main` since `7a2c6cbfc`. It sits inside the `app` suite, which aborts at the first failure, so the required **Frontend build** check fails on **every PR in the repo** — 276 files pass, then it stops. Nothing can merge until this lands.

## The staleness is a symptom, not the bug

`resolveBundledCopilotPluginDirs` (`src/lib/server/bundled-copilot-plugins.ts`) loads an app-bundled plugin **only** when its `plugin.json` advertises a skills directory and carries no `agents`/`hooks`/`mcpServers`:

```ts
const skills = Array.isArray(manifest.skills) ? manifest.skills : [manifest.skills];
return skills.length > 0 && skills.every((entry) => entry === "skills/" || entry === "./skills/");
```

`coven_manifest()` never emitted that field. So registering Coven recall meant hand-editing a **generated** file — and the obvious remedy for the red test, running `python3 scripts/sync-marketplace.py`, would have deleted the field again and **silently dropped `coven-memory` from Copilot chats**. Trap worth naming: the failure message invites exactly that command.

The generator has to know the contract, not the file.

## What changed

`coven_manifest()` now emits `"skills": "./skills/"`, gated on the plugin actually shipping a `skills/` directory:

- **crafts** and **knowledge packs** bundle pinned upstream skills → yes
- a **plain plugin** gets `skills/<name>/SKILL.md` from its catalog `skill` block → yes
- a **prompt-only pack** carries no skill → no, it must not advertise a directory that does not exist

127 of 128 manifests gain the field; `prompt-pack-essentials` and `prompt-pack-shipping` correctly do not. `codex_manifest()` already emitted exactly this for the same plugins, so this makes the two generators agree.

The two hand-edited manifests move from `["skills/"]` to the canonical `"./skills/"` — `isSkillOnlyManifest` accepts both forms.

## Verification

- `sync-marketplace.py --check` → `marketplace_ok files=582 plugins=128`
- `scripts/sync-marketplace.test.mjs` → ok
- **The thing a naive regeneration would have broken**, checked live against the regenerated tree: `resolveBundledCopilotPluginDirs(["coven-memory"])` still resolves `plugins/coven-memory`.
- New assertions pin the contract on the *generated* output — skills advertised, plugin stays skill-only, `skills/recall/SKILL.md` really exists behind the claim, and a prompt-only pack claims nothing — so the next sync cannot quietly drop it.
- `bundled-copilot-plugins`, `knowledge-packs`, and the three `api/marketplace` route tests pass; `check:tests-wired` green.

Bead: `cave-hty2r`. Unblocks #4606.