### PR TITLE
test(docs): ratchet the docs index, and make it run on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       rust: ${{ steps.paths.outputs.rust }}
       e2e: ${{ steps.paths.outputs.e2e }}
       ios: ${{ steps.paths.outputs.ios }}
+      docs: ${{ steps.paths.outputs.docs }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -105,6 +106,13 @@ jobs:
           node-version: 24
           cache: pnpm
 
+      # Runs without pnpm install: the test imports only node builtins, so a
+      # documentation-only PR — which skips the frontend step entirely — still
+      # gets the docs index checked. That is the case the ratchet exists for.
+      - name: Validate docs
+        if: needs.paths.outputs.docs == 'true'
+        run: node scripts/docs-index.test.mjs
+
       - name: Install JavaScript dependencies
         if: needs.paths.outputs.frontend == 'true' || needs.paths.outputs.e2e == 'true'
         run: pnpm install --frozen-lockfile
@@ -173,9 +181,10 @@ jobs:
         run: pnpm exec playwright test
 
       - name: Report skipped suites
-        if: needs.paths.outputs.frontend != 'true' || needs.paths.outputs.rust != 'true' || needs.paths.outputs.e2e != 'true' || needs.paths.outputs.ios != 'true'
+        if: needs.paths.outputs.frontend != 'true' || needs.paths.outputs.rust != 'true' || needs.paths.outputs.e2e != 'true' || needs.paths.outputs.ios != 'true' || needs.paths.outputs.docs != 'true'
         run: |
           echo "frontend=${{ needs.paths.outputs.frontend }}"
           echo "rust=${{ needs.paths.outputs.rust }}"
           echo "e2e=${{ needs.paths.outputs.e2e }}"
           echo "ios=${{ needs.paths.outputs.ios }} (${{ needs.ios.result }})"
+          echo "docs=${{ needs.paths.outputs.docs }}"

--- a/scripts/ci-paths.mjs
+++ b/scripts/ci-paths.mjs
@@ -11,6 +11,11 @@ const E2E_PATH =
   /^(?:src\/(?:app|components|lib|styles)\/|tests\/|server\.(?:mjs|ts)$|playwright\.config|package\.json$|pnpm-lock\.yaml$)/;
 const IOS_PATH =
   /^(?:apps\/ios\/|scripts\/(?:ios-xcodegen\.sh|build-ios-(?:markdown|terminal)\.mjs|ci-paths(?:\.test)?\.mjs)$|package\.json$|pnpm-lock\.yaml$|\.github\/workflows\/ci\.yml$)/;
+// docs/ is deliberately absent from FRONTEND_PATH — a documentation change
+// should not pay for lint, typecheck, and build. But that also meant the docs
+// index ratchet, which only fires when a doc is added or renamed, never ran on
+// the change it guards. This class gates one cheap builtins-only check instead.
+const DOCS_PATH = /^docs\//;
 
 export function classifyCiPaths(paths) {
   const normalized = paths
@@ -21,6 +26,7 @@ export function classifyCiPaths(paths) {
     rust: normalized.some((file) => RUST_PATH.test(file)),
     e2e: normalized.some((file) => E2E_PATH.test(file) || ROOT_RUNTIME_PATH.test(file)),
     ios: normalized.some((file) => IOS_PATH.test(file)),
+    docs: normalized.some((file) => DOCS_PATH.test(file)),
   };
 }
 
@@ -50,7 +56,7 @@ function main() {
   const paths = changedPaths(base, head);
   const result = paths
     ? classifyCiPaths(paths)
-    : { frontend: true, rust: true, e2e: true, ios: true };
+    : { frontend: true, rust: true, e2e: true, ios: true, docs: true };
   for (const [name, enabled] of Object.entries(result)) {
     process.stdout.write(`${name}=${enabled}\n`);
   }

--- a/scripts/ci-paths.test.mjs
+++ b/scripts/ci-paths.test.mjs
@@ -3,13 +3,16 @@ import test from "node:test";
 
 import { classifyCiPaths } from "./ci-paths.mjs";
 
-test("documentation-only changes run only the baseline CI contract", () => {
+test("documentation changes run the docs contract and nothing heavier", () => {
   assert.deepEqual(classifyCiPaths(["docs/ci.md", "README.md"]), {
     frontend: false,
     rust: false,
     e2e: false,
     ios: false,
+    docs: true,
   });
+  // A root markdown file is not under docs/, so it stays fully baseline.
+  assert.equal(classifyCiPaths(["README.md"]).docs, false);
 });
 
 test("workflow and script changes run frontend validation", () => {
@@ -18,6 +21,7 @@ test("workflow and script changes run frontend validation", () => {
     rust: false,
     e2e: false,
     ios: true,
+    docs: false,
   });
   assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).frontend, true);
   assert.equal(classifyCiPaths(["scripts/run-tests.mjs"]).ios, false);
@@ -29,6 +33,7 @@ test("Rust-only changes avoid frontend and E2E work", () => {
     rust: true,
     e2e: false,
     ios: false,
+    docs: false,
   });
 });
 
@@ -38,6 +43,7 @@ test("user-facing frontend changes include E2E", () => {
     rust: false,
     e2e: true,
     ios: false,
+    docs: false,
   });
 });
 
@@ -47,6 +53,7 @@ test("shared dependency changes exercise every relevant web gate", () => {
     rust: true,
     e2e: true,
     ios: true,
+    docs: false,
   });
 });
 
@@ -56,6 +63,7 @@ test("root runtime hooks receive frontend and end-to-end validation", () => {
     rust: false,
     e2e: true,
     ios: false,
+    docs: false,
   });
 });
 
@@ -65,6 +73,7 @@ test("iOS sources and generators request the macOS build", () => {
     rust: false,
     e2e: false,
     ios: true,
+    docs: false,
   });
   for (const path of [
     "scripts/ios-xcodegen.sh",

--- a/scripts/docs-index.test.mjs
+++ b/scripts/docs-index.test.mjs
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// docs/README.md classifies every document in docs/ as living, program,
+// historical, or tombstone. That classification is only worth trusting if it
+// stays complete, so this pins it: a doc added, renamed, or removed without
+// touching the index fails here instead of rotting silently.
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const docsDir = path.join(repoRoot, "docs");
+const indexPath = path.join(docsDir, "README.md");
+const index = readFileSync(indexPath, "utf8");
+
+// Markdown link targets, minus anchors and any title suffix.
+const linkTargets = [...index.matchAll(/\]\(([^)\s]+)(?:\s+"[^"]*")?\)/g)].map(
+  ([, target]) => target.split("#")[0],
+);
+
+// 1. Every path the index cites exists. Catches a rename that updated the
+//    prose but not the link, and a deletion that left the entry behind.
+for (const target of linkTargets) {
+  if (!target || /^[a-z]+:/i.test(target)) continue; // skip external URLs
+  const resolved = path.resolve(docsDir, target);
+  assert.ok(
+    existsSync(resolved),
+    `docs/README.md links ${target}, but ${path.relative(repoRoot, resolved)} does not exist — update the link`,
+  );
+}
+
+// 2. The set of top-level docs the index lists matches the set on disk.
+const onDisk = readdirSync(docsDir)
+  .filter((name) => name.endsWith(".md") && name !== "README.md")
+  .sort();
+
+const listed = linkTargets.filter((target) => /^[^/]+\.md$/.test(target) && target !== "README.md");
+const listedSet = new Set(listed);
+
+const missing = onDisk.filter((name) => !listedSet.has(name));
+assert.deepEqual(
+  missing,
+  [],
+  `docs/*.md missing from the docs/README.md index: ${missing.join(", ")} — add each under Living, Program, Historical, or Tombstone`,
+);
+
+const stale = [...listedSet].filter((name) => !onDisk.includes(name)).sort();
+assert.deepEqual(
+  stale,
+  [],
+  `docs/README.md indexes files that no longer exist: ${stale.join(", ")} — remove or repoint the entry`,
+);
+
+// 3. Each document is listed once. Two entries mean two classifications, and
+//    the second one is the one nobody updates.
+const duplicated = [...listedSet]
+  .filter((name) => listed.filter((entry) => entry === name).length > 1)
+  .sort();
+assert.deepEqual(
+  duplicated,
+  [],
+  `docs/README.md lists these more than once: ${duplicated.join(", ")} — a document has exactly one state`,
+);
+
+// 4. The four states the index promises are all still present as headings.
+//    Renaming one silently strands every document filed beneath it.
+for (const state of ["## Living", "## Program", "## Historical", "## Tombstone"]) {
+  assert.ok(
+    index.includes(state),
+    `docs/README.md no longer has a "${state}" section — the index contract names four states`,
+  );
+}
+
+console.log(
+  `docs-index.test.mjs: index ok (${onDisk.length} documents classified, ${linkTargets.length} links resolved)`,
+);

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1102,6 +1102,7 @@ export const SUITES = {
     "src/components/minimalism-invariants.test.ts",
     "src/components/dead-ui-removal.test.ts",
     "scripts/ui-consistency.test.mjs",
+    "scripts/docs-index.test.mjs",
     "src/components/ui/select.test.ts",
     "src/components/ui/context-menu.test.ts",
     "src/components/ui/undo-toast.test.ts",


### PR DESCRIPTION
Follow-up to #4605. `docs/README.md` classifies all 43 documents as living / program / historical / tombstone, but nothing enforced it — the index would rot the first time someone added or renamed a file.

## The test

`scripts/docs-index.test.mjs` pins four things:

1. Every `docs/*.md` appears in the index
2. Every index link resolves to a file that exists
3. No document is listed twice — two entries means two classifications, and the second is the one nobody updates
4. All four state headings still exist

**Each assertion was mutation-tested**, not trusted because it went green:

| Mutation | Failure |
|---|---|
| Added an unlisted doc | `missing from the docs/README.md index: … — add each under Living, Program, Historical, or Tombstone` |
| Repointed an entry at a deleted file | `links no-such-doc.md, but docs/no-such-doc.md does not exist` |
| Listed a doc twice | `lists these more than once: … — a document has exactly one state` |
| Renamed `## Tombstone` | `no longer has a "## Tombstone" section — the index contract names four states` |

## The wiring is the load-bearing half

`ci-paths.mjs` deliberately excludes `docs/` from `FRONTEND_PATH`, so a documentation change doesn't pay for lint, typecheck, and build. That's correct — but it also meant the entire **Validate frontend** step, `pnpm test:app` included, is skipped on exactly the PRs this ratchet guards.

**Four docs PRs merged today** (#4583, #4601, #4605, #4607) under a green `Frontend build` without executing a single test. A test that can't run on the change it checks is decoration.

So this adds a narrow `docs` path class and one gated step:

```yaml
- name: Validate docs
  if: needs.paths.outputs.docs == 'true'
  run: node scripts/docs-index.test.mjs
```

It sits **before** the dependency install and imports only node builtins, so a docs-only PR pays no `pnpm install`. When `frontend` is true the test also runs inside `test:app` via its `SUITES` registration; the duplicate costs milliseconds and keeps the failure legible either way.

## Verification

```
docs-index.test.mjs: index ok (43 documents classified, 56 links resolved)
node --test scripts/ci-paths.test.mjs   → 7 pass, 0 fail
check-tests-wired                       → all 1636 test files wired into CI
classifyCiPaths(['docs/new-thing.md'])  → {frontend:false, …, docs:true}
classifyCiPaths(['src/lib/x.ts'])       → {frontend:true,  …, docs:false}
```

`ci-paths.test.mjs` pins classification by `deepEqual`, so every case gained the new field, and the documentation-only case now asserts `docs: true`. Its name claimed docs changes "run only the baseline CI contract", which is no longer what happens — renamed.

This PR touches `scripts/` and `.github/workflows/`, so it sets `frontend: true` and validates itself against the full suite.

## Note on concurrency

`scripts/run-tests.mjs` was concurrently claimed by another session working in `cave-vutkj-canvas-preview-csp`. I checked before proceeding: their commit `342914cad` adds two `src/lib/canvas-preview-csp*` entries around line 553–637; mine adds one line at 1104. Pure additions ~500 lines apart, so they merge without conflict. Their worktree was read, never modified.