### PR TITLE
feat(chat): global right-side Chat panel

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1009,6 +1009,7 @@ export const SUITES = {
     "src/components/backdrop-scrim.test.ts",
     "src/lib/url-safety.test.ts",
     "src/lib/use-focus-trap.test.ts",
+    "src/lib/use-focus-trap-stack.test.tsx",
     "src/lib/use-prefers-reduced-motion.test.ts",
     "src/lib/use-undo-delete-keyboard.test.ts",
     "src/lib/use-roving-tabindex.test.ts",
@@ -1669,6 +1670,7 @@ export const SUITES = {
     "src/components/mobile-handoff.test.ts",
     "src/components/shell-drawer-smoke.test.ts",
     "src/components/mobile-drawer-inert-focus-order.test.tsx",
+    "src/components/mobile-drawer-nav-list-focus.test.tsx",
     "src/app/composer-zoom-smoke.test.ts",
     "src/app/safe-area-smoke.test.ts",
     "src/lib/use-viewport.test.ts",
@@ -1975,10 +1977,12 @@ const VITEST_TESTS = new Set([
   "src/components/right-chat-panel-behavior.test.tsx",
   "src/components/chat-router-removal-race.test.tsx",
   "src/components/mobile-drawer-inert-focus-order.test.tsx",
+  "src/components/mobile-drawer-nav-list-focus.test.tsx",
   // vi.fn() for the subscriber assertions
   "src/lib/surface-history.test.ts",
   // renders the hook through react-test-renderer
   "src/lib/use-surface-history.test.tsx",
+  "src/lib/use-focus-trap-stack.test.tsx",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -502,6 +502,7 @@ export const SUITES = {
     "src/components/chat-list-collapse.test.ts",
     "src/components/chat-router-hide-archived.test.ts",
     "src/components/chat-router-switching.test.ts",
+    "src/components/chat-router-removal-race.test.tsx",
     "src/components/right-chat-panel.test.ts",
     "src/components/right-chat-panel-behavior.test.tsx",
     "src/components/chat-compose-instance.test.ts",
@@ -1971,6 +1972,7 @@ const VITEST_TESTS = new Set([
   "src/components/chat-sidebar-wiring.behavior.test.ts",
   "src/components/chat-title-sparkle-behavior.test.tsx",
   "src/components/right-chat-panel-behavior.test.tsx",
+  "src/components/chat-router-removal-race.test.tsx",
   // vi.fn() for the subscriber assertions
   "src/lib/surface-history.test.ts",
   // renders the hook through react-test-renderer

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -503,6 +503,7 @@ export const SUITES = {
     "src/components/chat-router-hide-archived.test.ts",
     "src/components/chat-router-switching.test.ts",
     "src/components/right-chat-panel.test.ts",
+    "src/components/right-chat-panel-behavior.test.tsx",
     "src/components/chat-compose-instance.test.ts",
     "src/components/chat-split-host.test.ts",
     "src/lib/chat-split.test.ts",
@@ -1969,6 +1970,7 @@ const VITEST_TESTS = new Set([
   "src/components/workspace-sidebar-attention.test.ts",
   "src/components/chat-sidebar-wiring.behavior.test.ts",
   "src/components/chat-title-sparkle-behavior.test.tsx",
+  "src/components/right-chat-panel-behavior.test.tsx",
   // vi.fn() for the subscriber assertions
   "src/lib/surface-history.test.ts",
   // renders the hook through react-test-renderer

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -34,6 +34,7 @@ export const SUITES = {
     "src/lib/chat-split.test.ts",
     "src/lib/chat-creation-refresh.test.ts",
     "src/lib/chat-session-ownership.test.ts",
+    "src/lib/right-chat-session.test.ts",
     "src/lib/chat-live-generation-identity.test.ts",
     "src/lib/chat-router-promotion.test.ts",
     "src/lib/code-rail.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -35,6 +35,7 @@ export const SUITES = {
     "src/lib/chat-creation-refresh.test.ts",
     "src/lib/chat-session-ownership.test.ts",
     "src/lib/right-chat-session.test.ts",
+    "src/lib/shell-right-chat.test.ts",
     "src/lib/chat-live-generation-identity.test.ts",
     "src/lib/chat-router-promotion.test.ts",
     "src/lib/code-rail.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1668,6 +1668,7 @@ export const SUITES = {
     "scripts/mobile-tailscale.test.mjs",
     "src/components/mobile-handoff.test.ts",
     "src/components/shell-drawer-smoke.test.ts",
+    "src/components/mobile-drawer-inert-focus-order.test.tsx",
     "src/app/composer-zoom-smoke.test.ts",
     "src/app/safe-area-smoke.test.ts",
     "src/lib/use-viewport.test.ts",
@@ -1973,6 +1974,7 @@ const VITEST_TESTS = new Set([
   "src/components/chat-title-sparkle-behavior.test.tsx",
   "src/components/right-chat-panel-behavior.test.tsx",
   "src/components/chat-router-removal-race.test.tsx",
+  "src/components/mobile-drawer-inert-focus-order.test.tsx",
   // vi.fn() for the subscriber assertions
   "src/lib/surface-history.test.ts",
   // renders the hook through react-test-renderer

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -502,6 +502,7 @@ export const SUITES = {
     "src/components/chat-list-collapse.test.ts",
     "src/components/chat-router-hide-archived.test.ts",
     "src/components/chat-router-switching.test.ts",
+    "src/components/right-chat-panel.test.ts",
     "src/components/chat-compose-instance.test.ts",
     "src/components/chat-split-host.test.ts",
     "src/lib/chat-split.test.ts",

--- a/src/components/chat-archive-nudge.test.ts
+++ b/src/components/chat-archive-nudge.test.ts
@@ -114,7 +114,7 @@ assert.match(
 // triggers the existing onSessionsChanged + onBack flow.
 assert.match(
   chatViewSrc,
-  /const archiveChat = useCallback\(async \(\) => \{[\s\S]*\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}[\s\S]*archived: true[\s\S]*onSessionsChanged\?\.\(\)[\s\S]*onBack\?\.\(\)/,
+  /const archiveChat = useCallback\(async \(\) => \{[\s\S]*\/api\/sessions\/\$\{encodeURIComponent\(sessionId\)\}[\s\S]*archived: true[\s\S]*onSessionsChanged\?\.\(\)[\s\S]*onBack\?\.\(sessionId\)/,
   "archiveChat PATCHes the session as archived and tells the host to refresh + leave",
 );
 assert.match(

--- a/src/components/chat-compose-instance.test.ts
+++ b/src/components/chat-compose-instance.test.ts
@@ -151,7 +151,7 @@ assert.doesNotMatch(
 
 assert.match(
   primaryChatViewRendering,
-  /key=\{`chat-compose-\$\{composeInstance\}`\}/,
+  /key=\{`chat-compose-\$\{composerDraftKey\}-\$\{composeInstance\}`\}/,
   "The primary ChatView key must name the stable compose lineage rather than using an opaque numeric key",
 );
 

--- a/src/components/chat-compose-instance.test.ts
+++ b/src/components/chat-compose-instance.test.ts
@@ -108,7 +108,7 @@ assert.doesNotMatch(
 // ── 7. Voice-session discard increments (returns to a fresh compose) ─────────
 
 const voiceDiscardHandler =
-  routerSource.match(/onVoiceSessionDiscarded=\{\(\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
+  routerSource.match(/onVoiceSessionDiscarded=\{\(removedSessionId\) => \{[\s\S]*?\}\}/)?.[0] ?? "";
 
 assert.ok(voiceDiscardHandler.length > 0, "onVoiceSessionDiscarded handler must be present in router");
 

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -164,8 +164,8 @@ assert.match(
 );
 assert.match(
   source,
-  /onSessionsDeleted\(\[sessionId\]\);\s*\n\s*onBack\?\.\(\);/,
-  "Successful delete reaches the shared boundary and navigates back to the list",
+  /onSessionsDeleted\(\[sessionId\]\);\s*\n\s*onSessionRemoved\?\.\(sessionId, "deleted"\);\s*\n\s*onBack\?\.\(\);/,
+  "Successful delete reaches the shared boundary, reports the narrow removal signal, and navigates back to the list",
 );
 
 // The delete is a two-step guard: the trash button arms a confirm popover
@@ -467,8 +467,8 @@ assert.match(
 );
 assert.match(
   source,
-  /onSessionsChanged\?\.\(\);\s*\/\/ Leaving mirrors delete only for archive; unarchive keeps you in place\.\s*if \(archived\) onBack\?\.\(\);/,
-  "archiving refreshes the rails and leaves the chat; unarchiving stays put",
+  /onSessionsChanged\?\.\(\);\s*\/\/ Leaving mirrors delete only for archive; unarchive keeps you in place\.\s*if \(archived\) \{\s*\n\s*onSessionRemoved\?\.\(sessionId, "archived"\);\s*\n\s*onBack\?\.\(\);\s*\n\s*\}/,
+  "archiving refreshes the rails, reports the narrow removal signal, and leaves the chat; unarchiving stays put",
 );
 assert.match(
   source,

--- a/src/components/chat-header-row.test.ts
+++ b/src/components/chat-header-row.test.ts
@@ -164,7 +164,7 @@ assert.match(
 );
 assert.match(
   source,
-  /onSessionsDeleted\(\[sessionId\]\);\s*\n\s*onSessionRemoved\?\.\(sessionId, "deleted"\);\s*\n\s*onBack\?\.\(\);/,
+  /onSessionsDeleted\(\[sessionId\]\);\s*\n\s*onSessionRemoved\?\.\(sessionId, "deleted"\);\s*\n\s*onBack\?\.\(sessionId\);/,
   "Successful delete reaches the shared boundary, reports the narrow removal signal, and navigates back to the list",
 );
 
@@ -467,7 +467,7 @@ assert.match(
 );
 assert.match(
   source,
-  /onSessionsChanged\?\.\(\);\s*\/\/ Leaving mirrors delete only for archive; unarchive keeps you in place\.\s*if \(archived\) \{\s*\n\s*onSessionRemoved\?\.\(sessionId, "archived"\);\s*\n\s*onBack\?\.\(\);\s*\n\s*\}/,
+  /onSessionsChanged\?\.\(\);\s*\/\/ Leaving mirrors delete only for archive; unarchive keeps you in place\.\s*if \(archived\) \{\s*\n\s*onSessionRemoved\?\.\(sessionId, "archived"\);\s*\n\s*onBack\?\.\(sessionId\);\s*\n\s*\}/,
   "archiving refreshes the rails, reports the narrow removal signal, and leaves the chat; unarchiving stays put",
 );
 assert.match(

--- a/src/components/chat-router-removal-race.test.tsx
+++ b/src/components/chat-router-removal-race.test.tsx
@@ -410,4 +410,249 @@ describe("ChatRouter onVoiceSessionDiscarded is conditional the same way (cave-r
   });
 });
 
+describe("stale-removal guards stay atomic even when a switch and the stale completion land in the SAME batch (fix 3, cave-rl980 Task 4 final review)", () => {
+  // The tests above prove the SEQUENTIAL ordering (switch fully commits,
+  // THEN the stale completion arrives) — viewRef.current is already correct
+  // by then, since a render landed in between. These prove the harder,
+  // previously-unguarded case: the switch and the stale completion are BOTH
+  // invoked inside the SAME act(), with no render/commit landing between
+  // them. A ref assigned during render (viewRef) only advances once per
+  // commit, so a pre-check against it would still read the PRE-batch session
+  // here — the fix threads the equality check through setView's own
+  // functional updater instead, which React resolves in enqueue order
+  // regardless of how many updates land in one batch.
+  test("thread switch: opening T and a stale onBack(S) fired in the SAME act/commit still leaves T active", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("cody-t", "cody", "2026-01-05T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    const staleOnBack = chatView.latestProps!.onBack as (sessionId: string | null) => void;
+
+    // Both calls happen inside the SAME act — no intervening render.
+    await act(async () => {
+      ref.current!.openSession("cody-t");
+      staleOnBack("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+    expect(chatView.latestProps!.sessionId).toBe("cody-t");
+  });
+
+  test("familiar switch: opening a different familiar's T and a stale onBack(S) fired in the SAME act/commit still leaves T active", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("nova-t", "nova", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody, nova]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    const staleOnBack = chatView.latestProps!.onBack as (sessionId: string | null) => void;
+
+    await act(async () => {
+      ref.current!.openSession("nova-t");
+      staleOnBack("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe("nova-t");
+    expect(chatView.latestProps!.sessionId).toBe("nova-t");
+  });
+
+  test("onVoiceSessionDiscarded: opening T and a stale discard for S fired in the SAME act/commit still leaves T active", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("cody-t", "cody", "2026-01-05T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    const staleOnVoiceSessionDiscarded =
+      chatView.latestProps!.onVoiceSessionDiscarded as (sessionId: string) => void;
+
+    await act(async () => {
+      ref.current!.openSession("cody-t");
+      staleOnVoiceSessionDiscarded("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+    expect(chatView.latestProps!.sessionId).toBe("cody-t");
+  });
+});
+
+describe("ChatRouter reports every distinct compose attempt even when sessionId stays null throughout (fix 2, cave-rl980 Task 4 review)", () => {
+  // RightChatPanel retains a stale selection while awaiting a removal's
+  // roster confirmation (pendingRemovalRef), consumed by "the very next
+  // active-session report of any kind" — but a null->null transition (list ->
+  // a fresh compose, or one blank compose replaced by another) never changed
+  // the plain session-id value on its own, so without this fix the consumer
+  // never learns a brand-new compose has already superseded what it's
+  // waiting on. composeInstance is the router's own existing, purpose-built
+  // nonce for exactly "a new blank-compose attempt" and is already bumped at
+  // every real compose-entry call site (imperative newChat, ChatList's
+  // onNewChat, the familiar-switch effect) — folding it into the reported
+  // identity while the session id stays null is what closes the gap.
+  test("a second imperative newChat() while already on a blank compose (null -> null) still fires onActiveSessionChange again", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+    const onActiveSessionChange = vi.fn();
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS]}
+          onSessionsDeleted={vi.fn()}
+          onActiveSessionChange={onActiveSessionChange}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith("cody-s");
+    const callsAfterOpen = onActiveSessionChange.mock.calls.length;
+
+    // First "new chat": null after a real session id — always reported even
+    // without this fix, since the plain value itself changes. A baseline,
+    // not the behavior under test.
+    await act(async () => {
+      ref.current!.newChat(undefined, undefined, "cody");
+    });
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith(null);
+    const callsAfterFirstNewChat = onActiveSessionChange.mock.calls.length;
+    expect(callsAfterFirstNewChat).toBe(callsAfterOpen + 1);
+
+    // Second "new chat" while ALREADY on a blank compose: sessionId is null
+    // both before and after. This IS a distinct compose attempt the fix must
+    // still surface.
+    await act(async () => {
+      ref.current!.newChat(undefined, undefined, "cody");
+    });
+    expect(onActiveSessionChange.mock.calls.length).toBe(callsAfterFirstNewChat + 1);
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith(null);
+  });
+
+  test("a promotion (null -> a real session id) still reports exactly once per actual value change — promotions do not bump composeInstance, so this fix never doubles that report", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+    const onActiveSessionChange = vi.fn();
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS]}
+          onSessionsDeleted={vi.fn()}
+          onActiveSessionChange={onActiveSessionChange}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    // A real, unambiguous baseline session — sidesteps the chat-first boot
+    // effect's own silent (unreported, "mount never notifies") auto-compose
+    // so the two transitions under test below are unambiguous.
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith("cody-s");
+
+    await act(async () => {
+      ref.current!.newChat(undefined, undefined, "cody");
+    });
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith(null);
+    const callsAfterNewChat = onActiveSessionChange.mock.calls.length;
+
+    // shouldRouterPromoteSession requires the promotion request's
+    // composeInstance to match the router's current one — read it straight
+    // off the mocked ChatView's own latest props (the real prop ChatRouter
+    // passes it) so this stays correct regardless of how many composes
+    // preceded it.
+    const currentComposeInstance = (chatView.latestProps as { composeInstance?: number }).composeInstance;
+    await act(async () => {
+      (chatView.latestProps!.onSessionStarted as (request: unknown) => void)({
+        newSessionId: "cody-promoted",
+        expectedSessionId: null,
+        composeInstance: currentComposeInstance,
+      });
+    });
+    expect(onActiveSessionChange).toHaveBeenLastCalledWith("cody-promoted");
+    expect(onActiveSessionChange.mock.calls.length).toBe(callsAfterNewChat + 1); // exactly one more report
+  });
+});
+
 console.log("chat-router-removal-race.test.tsx wired");

--- a/src/components/chat-router-removal-race.test.tsx
+++ b/src/components/chat-router-removal-race.test.tsx
@@ -1,0 +1,413 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention
+// in right-chat-panel-behavior.test.tsx and chat-title-sparkle-behavior.test.tsx.
+//
+// Behavioral proof of the cave-rl980 Task 4 final fix at the ChatRouter
+// layer: archiveChat/deleteChat/setChatArchived/discardVoiceSessionIfEmpty
+// are all async, so ChatView's onBack/onVoiceSessionDiscarded can arrive
+// after the router has ALREADY navigated to a different session (a thread
+// switch, or a familiar switch — both just move `view.sessionId` to a
+// different value from ChatRouter's point of view). Both call sites must
+// only actually navigate when the router is STILL displaying the exact
+// session the completion names; a stale completion for an abandoned session
+// must be a silent no-op instead of clobbering whatever the user is now
+// looking at.
+//
+// ChatView itself is mocked to a thin capturing stub (982 real lines, heavy
+// fetch/dictation/voice machinery unrelated to this router-level contract) —
+// this suite is about ChatRouter's OWN view-state wiring, not ChatView's
+// internals. Every other ChatRouter dependency that assumes a live `window`
+// (project overrides, the mobile-viewport hook, sidebar persistence) or hits
+// the network (useProjects) is stubbed the same way chat-sidebar-wiring.
+// behavior.test.ts already does for this codebase (vi.stubGlobal("window",
+// ...) + vi.stubGlobal("fetch", ...)), since no test here mounts jsdom.
+//
+// "Controllable promise", not a timing sleep: each scenario below opens a
+// manual resolve/reject-free Promise standing in for the in-flight PATCH/
+// DELETE request, switches the router to a different session while that
+// promise is still pending, and only THEN resolves it — deterministically
+// proving the switch truly preceded the completion, with no reliance on
+// real timers.
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const chatView = vi.hoisted(() => ({
+  latestProps: null as Record<string, unknown> | null,
+}));
+
+vi.mock("@/components/chat-view", async () => {
+  const { forwardRef, useImperativeHandle } = await import("react");
+  const ChatView = forwardRef(function MockChatView(props: Record<string, unknown>, ref: unknown) {
+    chatView.latestProps = props;
+    useImperativeHandle(ref, () => ({
+      clearTranscript: () => {},
+      runSlash: () => {},
+    }));
+    return null;
+  });
+  return { ChatView, DEFAULT_CHAT_COMPOSER_DRAFT_KEY: "cave:chat-composer-draft:v1" };
+});
+
+vi.mock("@/components/chat-list", () => ({ ChatList: () => null }));
+vi.mock("@/components/chat-project-sidebar", () => ({ ChatProjectSidebar: () => null }));
+vi.mock("@/components/new-chat-launch", () => ({ NewChatLaunch: () => null }));
+vi.mock("@/components/familiar-chatout-codex", () => ({ FamiliarChatoutCodexSurface: () => null }));
+vi.mock("@/lib/feature-flags", () => ({ caveChatoutCodex: () => false }));
+vi.mock("@/lib/use-viewport", () => ({ useIsMobile: () => false, useIsCoarsePointer: () => false }));
+// Stable (module-level, not freshly literal-constructed per call) return
+// values throughout: several of these feed useMemo/useEffect dependency
+// arrays by reference in the real hooks (useSyncExternalStore snapshots,
+// SWR-cached payloads, …), and a mock returning a brand-new object/array
+// literal on every call breaks that referential stability, which can drive
+// an effect into a render loop instead of settling.
+const noArchivedFamiliars = {};
+const noProjectOverrides = {};
+const noProjects = { projects: [] as never[] };
+vi.mock("@/lib/use-project-overrides", () => ({ useProjectOverrides: () => noProjectOverrides }));
+vi.mock("@/lib/cave-familiar-archive", () => ({ useArchivedFamiliars: () => noArchivedFamiliars }));
+vi.mock("@/lib/use-projects", () => ({ useProjects: () => noProjects }));
+vi.mock("@/lib/use-auto-expand-new-groups", () => ({ useAutoExpandNewGroups: () => {} }));
+vi.mock("@/components/ui/live-region", () => ({ useAnnouncer: () => ({ announce: vi.fn() }) }));
+
+import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function familiar(id: string, display_name = id) {
+  return { id, display_name, role: "familiar" };
+}
+
+function sessionRow(id: string, familiarId: string, iso: string) {
+  return {
+    id,
+    project_root: "/work/chat-router-removal-race",
+    harness: "codex",
+    title: id,
+    status: "completed",
+    exit_code: null,
+    archived_at: null,
+    created_at: iso,
+    updated_at: iso,
+    attention: { state: "none", since: null, reason: null },
+    origin: "chat",
+    hasLocalConversation: false,
+    familiarId,
+  };
+}
+
+/** Controllable stand-in for an in-flight PATCH/DELETE: nothing runs until
+ *  the test calls `settle()`, so the ordering (begin → switch → settle) is
+ *  explicit and deterministic rather than relying on microtask timing. */
+function deferred<T>() {
+  let settle!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, settle };
+}
+
+let renderer: ReactTestRenderer;
+
+beforeEach(() => {
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: vi.fn(() => null),
+      setItem: vi.fn(),
+      removeItem: vi.fn(),
+    },
+    location: { hash: "" },
+    history: { replaceState: vi.fn(), pushState: vi.fn() },
+    matchMedia: vi.fn(() => ({
+      matches: false,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+    })),
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: vi.fn(() => true),
+  });
+  vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("network disabled in test"))));
+  chatView.latestProps = null;
+});
+
+afterEach(async () => {
+  if (renderer) await act(async () => renderer.unmount());
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("ChatRouter onBack is conditional on the removed session still being displayed (cave-rl980 Task 4 final review)", () => {
+  test("thread switch: archiving S, then switching to T before the PATCH settles, never navigates T away once the stale onBack arrives", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("cody-t", "cody", "2026-01-05T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    // Capture the exact onBack instance ChatView's in-flight archiveChat(S)
+    // would retain right now — a controllable promise stands in for the
+    // PATCH request archiveChat awaits before ever calling this.
+    const staleOnBack = chatView.latestProps!.onBack as (sessionId: string | null) => void;
+    const archivePatch = deferred<void>();
+
+    // The user switches to a different thread (T) under the SAME familiar
+    // while the archive of S is still in flight.
+    await act(async () => {
+      ref.current!.openSession("cody-t");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+
+    // The archive PATCH settles now — late, after the user already left S —
+    // and fires the same onBack(sessionId) archiveChat always fires on
+    // success, using the closure captured before the switch.
+    await act(async () => {
+      archivePatch.settle();
+      await archivePatch.promise;
+      staleOnBack("cody-s");
+    });
+
+    // T must remain exactly where the user left it — never clobbered back
+    // to the session list by S's now-irrelevant completion.
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+    expect(chatView.latestProps!.sessionId).toBe("cody-t");
+  });
+
+  test("familiar switch: archiving S, then switching to a different familiar's thread T before the PATCH settles, never navigates T away", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("nova-t", "nova", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody, nova]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    const staleOnBack = chatView.latestProps!.onBack as (sessionId: string | null) => void;
+    const archivePatch = deferred<void>();
+
+    // The user switches to a different familiar's thread (nova/T) while the
+    // archive of cody's S is still in flight — exactly what RightChatPanel's
+    // familiar-resolution effect does via the same imperative openSession.
+    await act(async () => {
+      ref.current!.openSession("nova-t");
+    });
+    expect(ref.current!.currentSessionId()).toBe("nova-t");
+
+    await act(async () => {
+      archivePatch.settle();
+      await archivePatch.promise;
+      staleOnBack("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe("nova-t");
+    expect(chatView.latestProps!.sessionId).toBe("nova-t");
+  });
+
+  test("an onBack for the session still actually showing DOES navigate to the list — the conditional guard is not a blanket no-op", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    await act(async () => {
+      (chatView.latestProps!.onBack as (sessionId: string | null) => void)("cody-s");
+    });
+
+    // Still showing cody-s when its own onBack fires: this DOES clear —
+    // proves the fix is a targeted equality check, not an accidental no-op.
+    expect(ref.current!.currentSessionId()).toBe(null);
+  });
+});
+
+describe("ChatRouter onVoiceSessionDiscarded is conditional the same way (cave-rl980 Task 4 final review)", () => {
+  test("discarding a promoted voice session S, then switching to T before the DELETE settles, never yanks T back to a blank compose", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("cody-t", "cody", "2026-01-05T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    // Captures the onVoiceSessionDiscarded instance the discard's in-flight
+    // DELETE ?ifEmpty=1 request would retain right now.
+    const staleOnVoiceSessionDiscarded =
+      chatView.latestProps!.onVoiceSessionDiscarded as (sessionId: string) => void;
+    const discardDelete = deferred<void>();
+
+    // User switches threads while the discard is still in flight.
+    await act(async () => {
+      ref.current!.openSession("cody-t");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+
+    await act(async () => {
+      discardDelete.settle();
+      await discardDelete.promise;
+      staleOnVoiceSessionDiscarded("cody-s");
+    });
+
+    // T must survive — never reset to a fresh blank compose by S's stale
+    // discard completion.
+    expect(ref.current!.currentSessionId()).toBe("cody-t");
+    expect(chatView.latestProps!.sessionId).toBe("cody-t");
+  });
+
+  test("discarding S, then switching familiar to T before the DELETE settles, never yanks T back to a blank compose", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const sessionT = sessionRow("nova-t", "nova", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody, nova]}
+          sessions={[sessionS, sessionT]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    const staleOnVoiceSessionDiscarded =
+      chatView.latestProps!.onVoiceSessionDiscarded as (sessionId: string) => void;
+    const discardDelete = deferred<void>();
+
+    await act(async () => {
+      ref.current!.openSession("nova-t");
+    });
+    expect(ref.current!.currentSessionId()).toBe("nova-t");
+
+    await act(async () => {
+      discardDelete.settle();
+      await discardDelete.promise;
+      staleOnVoiceSessionDiscarded("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe("nova-t");
+    expect(chatView.latestProps!.sessionId).toBe("nova-t");
+  });
+
+  test("an onVoiceSessionDiscarded for the session still actually showing DOES reset to a blank compose", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessionS = sessionRow("cody-s", "cody", "2026-01-01T00:00:00.000Z");
+    const ref = { current: null as ChatRouterHandle | null };
+
+    await act(async () => {
+      renderer = create(
+        <ChatRouter
+          ref={ref as never}
+          familiar={cody}
+          familiars={[cody]}
+          sessions={[sessionS]}
+          onSessionsDeleted={vi.fn()}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+        />,
+      );
+    });
+
+    await act(async () => {
+      ref.current!.openSession("cody-s");
+    });
+    expect(ref.current!.currentSessionId()).toBe("cody-s");
+
+    await act(async () => {
+      (chatView.latestProps!.onVoiceSessionDiscarded as (sessionId: string) => void)("cody-s");
+    });
+
+    expect(ref.current!.currentSessionId()).toBe(null);
+    expect(chatView.latestProps!.sessionId).toBe(null);
+  });
+});
+
+console.log("chat-router-removal-race.test.tsx wired");

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -812,7 +812,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   ) : (
     <ChatView
       composerDraftKey={composerDraftKey}
-      key={`chat-compose-${composeInstance}`}
+      key={`chat-compose-${composerDraftKey}-${composeInstance}`}
       ref={viewHandle}
       familiar={chatFamiliar}
       familiars={familiars}
@@ -908,6 +908,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           content: (
             <ChatView
               composerDraftKey={`${composerDraftKey}:split:${paneId}`}
+              key={`${composerDraftKey}:split:${paneId}`}
               familiar={paneFamiliar}
               sessionId={paneId}
               session={paneSession}

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -58,6 +58,7 @@ import { shouldRouterPromoteSession } from "@/lib/chat-router-promotion";
 import { useAutoExpandNewGroups } from "@/lib/use-auto-expand-new-groups";
 import type { InitialCommandControls } from "@/lib/command-controls";
 import type { Familiar, SessionOrigin, SessionRow } from "@/lib/types";
+import type { SessionRemovalReason } from "@/lib/chat-session-removal";
 
 type View =
   | { kind: "list" }
@@ -72,6 +73,10 @@ type Props = {
   onSessionStarted?: () => void;
   onSessionsChanged?: () => void;
   onSessionsDeleted: (sessionIds: readonly string[]) => void;
+  /** Fires exactly when the primary chat's own session is confirmed removed
+   *  (archived, deleted, or a discarded empty voice/pre-session) — forwarded
+   *  unchanged from ChatView. See ChatView's `onSessionRemoved` doc. */
+  onSessionRemoved?: (sessionId: string, reason: SessionRemovalReason) => void;
   sessionsLoaded?: boolean;
   /** Last session-list load failed — forwarded to ChatList (cave-x6k5). */
   sessionsError?: boolean;
@@ -153,6 +158,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onSessionStarted,
     onSessionsChanged,
     onSessionsDeleted,
+    onSessionRemoved,
     sessionsLoaded,
     sessionsError,
     familiarsLoaded,
@@ -833,6 +839,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       composeInstance={composeInstance}
       onSessionsChanged={onSessionsChanged}
       onSessionsDeleted={onSessionsDeleted}
+      onSessionRemoved={onSessionRemoved}
       onBack={() => setView({ kind: "list" })}
       onSessionStarted={(request) => {
         // Match both the originating session and compose lineage. The functional

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -840,7 +840,19 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       onSessionsChanged={onSessionsChanged}
       onSessionsDeleted={onSessionsDeleted}
       onSessionRemoved={onSessionRemoved}
-      onBack={() => setView({ kind: "list" })}
+      // archiveChat/deleteChat/setChatArchived are async; ChatView passes
+      // back the exact session it just removed. Only actually navigate to
+      // the list when the router is STILL showing that session — reading
+      // viewRef (always current, see its declaration above) rather than
+      // `view` directly means this check is correct even though `onBack`
+      // itself is a fresh closure every render: by the time a slow request
+      // settles, the user may have already switched to a different thread
+      // or familiar, and that view must never be clobbered by a now-stale
+      // completion (cave-rl980 Task 4 final review).
+      onBack={(removedSessionId) => {
+        if (viewRef.current.kind !== "chat" || viewRef.current.sessionId !== removedSessionId) return;
+        setView({ kind: "list" });
+      }}
       onSessionStarted={(request) => {
         // Match both the originating session and compose lineage. The functional
         // update makes A→B atomic with navigation, while the synchronously advanced
@@ -875,7 +887,12 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         );
         setPendingVoice({ nonce: Date.now(), sessionId: sid });
       }}
-      onVoiceSessionDiscarded={() => {
+      onVoiceSessionDiscarded={(removedSessionId) => {
+        // Same async-completion guard as onBack above: the discard fetch can
+        // settle after the user has already switched threads or familiars,
+        // and a stale completion must never yank a newer view back to a
+        // blank compose (cave-rl980 Task 4 final review).
+        if (viewRef.current.kind !== "chat" || viewRef.current.sessionId !== removedSessionId) return;
         // The auto-created session was empty and got discarded while the
         // view was still parked on it — return to a fresh compose state for
         // the same familiar/project (same reset shape as the promotion
@@ -883,7 +900,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         // typing into a session that no longer exists.
         advanceComposeInstance();
         setView((prev) =>
-          prev.kind === "chat"
+          prev.kind === "chat" && prev.sessionId === removedSessionId
             ? { kind: "chat", sessionId: null, projectRoot: prev.projectRoot, familiarId: prev.familiarId }
             : prev,
         );

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -210,11 +210,30 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
   }, [onActiveSessionChange]);
   const activeSessionId = view.kind === "chat" ? view.sessionId : null;
   const lastReportedSessionRef = useRef<string | null>(activeSessionId);
+  // A null activeSessionId is ambiguous on its own: the list view and every
+  // distinct blank-compose attempt (list -> new chat, a familiar switch's
+  // fresh compose, a discarded session's fresh compose, ...) all report the
+  // SAME null, so a consumer that retains a prior selection while awaiting a
+  // removal's roster confirmation (RightChatPanel's pendingRemovalRef, see its
+  // doc) would never learn a brand-new compose has already superseded it —
+  // the plain session id value never changes. composeInstance is the
+  // existing, purpose-built nonce for exactly "a new blank-compose attempt"
+  // (see its declaration above) and is already bumped at every real
+  // compose-entry call site, so folding it into the reported identity — only
+  // while activeSessionId stays null; a promotion is deliberately excluded,
+  // mirroring advanceComposeInstance's own contract — reports a fresh
+  // transition even though the plain session id value never changes
+  // (cave-rl980 Task 4 review).
+  const lastReportedComposeInstanceRef = useRef<number>(composeInstance);
   useEffect(() => {
-    if (lastReportedSessionRef.current === activeSessionId) return;
+    const changed =
+      lastReportedSessionRef.current !== activeSessionId ||
+      (activeSessionId === null && lastReportedComposeInstanceRef.current !== composeInstance);
+    if (!changed) return;
     lastReportedSessionRef.current = activeSessionId;
+    lastReportedComposeInstanceRef.current = composeInstance;
     onActiveSessionChangeRef.current?.(activeSessionId);
-  }, [activeSessionId]);
+  }, [activeSessionId, composeInstance]);
   // ── Multi-pane split (drag a convo from the thread rail onto the chat) ────
   // The primary chat is one pane; dropped conversations open beside/above/
   // below it. Pure layout rules live in @/lib/chat-split; panes for deleted
@@ -842,16 +861,20 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
       onSessionRemoved={onSessionRemoved}
       // archiveChat/deleteChat/setChatArchived are async; ChatView passes
       // back the exact session it just removed. Only actually navigate to
-      // the list when the router is STILL showing that session — reading
-      // viewRef (always current, see its declaration above) rather than
-      // `view` directly means this check is correct even though `onBack`
-      // itself is a fresh closure every render: by the time a slow request
-      // settles, the user may have already switched to a different thread
-      // or familiar, and that view must never be clobbered by a now-stale
-      // completion (cave-rl980 Task 4 final review).
+      // the list when the router is STILL showing that session — the
+      // equality check runs INSIDE the functional setView updater, not
+      // against viewRef.current beforehand, because a ref assigned during
+      // render only advances once per commit: a same-tick switch (e.g.
+      // RightChatPanel's own openSession(T) call) and this stale completion
+      // can both fire within the same batch with no render in between, so a
+      // pre-check would still read the PRE-batch session and wrongly permit
+      // the transition, clobbering T back to the list once React folds both
+      // queued updates together. Threading the check through the updater's
+      // own `prev` instead means it always compares against whatever the
+      // OTHER queued update in this exact batch actually leaves behind,
+      // regardless of call order (cave-rl980 Task 4 final review).
       onBack={(removedSessionId) => {
-        if (viewRef.current.kind !== "chat" || viewRef.current.sessionId !== removedSessionId) return;
-        setView({ kind: "list" });
+        setView((prev) => (prev.kind === "chat" && prev.sessionId === removedSessionId ? { kind: "list" } : prev));
       }}
       onSessionStarted={(request) => {
         // Match both the originating session and compose lineage. The functional
@@ -888,17 +911,28 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
         setPendingVoice({ nonce: Date.now(), sessionId: sid });
       }}
       onVoiceSessionDiscarded={(removedSessionId) => {
-        // Same async-completion guard as onBack above: the discard fetch can
-        // settle after the user has already switched threads or familiars,
-        // and a stale completion must never yank a newer view back to a
-        // blank compose (cave-rl980 Task 4 final review).
-        if (viewRef.current.kind !== "chat" || viewRef.current.sessionId !== removedSessionId) return;
-        // The auto-created session was empty and got discarded while the
-        // view was still parked on it — return to a fresh compose state for
-        // the same familiar/project (same reset shape as the promotion
-        // above, but back to sessionId: null) instead of leaving the user
-        // typing into a session that no longer exists.
-        advanceComposeInstance();
+        // The auto-created session was empty and got discarded — return to a
+        // fresh compose state for the same familiar/project (same reset shape
+        // as the promotion above, but back to sessionId: null) instead of
+        // leaving the user typing into a session that no longer exists. Same
+        // atomic-equality-inside-the-updater guard as onBack above (a same-
+        // tick switch and this stale completion must never both land): the
+        // check runs against the updater's own `prev`, never a viewRef
+        // snapshot from before the batch, so it always yields to whatever the
+        // OTHER queued update in this exact batch actually leaves behind
+        // (cave-rl980 Task 4 final review).
+        //
+        // The compose-instance bump below is a narrower, best-effort signal,
+        // not the source of truth for whether the discard itself applies: it
+        // only needs to revoke display-run ownership for a blank compose
+        // ChatView is ACTUALLY showing right now (see composeInstance's own
+        // doc above), so gating it on a viewRef read here — rather than
+        // threading it through the same functional updater — stays
+        // deliberately conservative without risking a spurious remount of
+        // whatever the user has already switched to.
+        if (viewRef.current.kind === "chat" && viewRef.current.sessionId === removedSessionId) {
+          advanceComposeInstance();
+        }
         setView((prev) =>
           prev.kind === "chat" && prev.sessionId === removedSessionId
             ? { kind: "chat", sessionId: null, projectRoot: prev.projectRoot, familiarId: prev.familiarId }

--- a/src/components/chat-router.tsx
+++ b/src/components/chat-router.tsx
@@ -7,7 +7,7 @@ import "@/styles/cave-composer.css";
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
 import { ChatList } from "@/components/chat-list";
 import { ChatProjectSidebar } from "@/components/chat-project-sidebar";
-import { ChatView } from "@/components/chat-view";
+import { ChatView, DEFAULT_CHAT_COMPOSER_DRAFT_KEY } from "@/components/chat-view";
 import { ChatSplitHost, CHAT_SPLIT_PANE_ATTR, type ChatSplitTile } from "@/components/chat-split-host";
 import { NewChatLaunch } from "@/components/new-chat-launch";
 import { FamiliarChatoutCodexSurface } from "@/components/familiar-chatout-codex";
@@ -110,6 +110,7 @@ type Props = {
    *  full-width main chat surface opts in — the compact companion rail has no
    *  room, and two mounts must not fight over the persisted layout. */
   enableSplitPanes?: boolean;
+  composerDraftKey?: string;
   /** Workspace's current sidebar familiar filter, forwarded to every ChatView
    *  mount (primary and split panes) so attention-clear provenance uses the
    *  list scope that can actually prove absence, not each pane's own
@@ -168,6 +169,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     onOpenProjectsTab,
     onActiveSessionChange,
     enableSplitPanes = false,
+    composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY,
     activeFamiliarId,
   },
   ref,
@@ -809,6 +811,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
     <FamiliarChatoutCodexSurface />
   ) : (
     <ChatView
+      composerDraftKey={composerDraftKey}
       key={`chat-compose-${composeInstance}`}
       ref={viewHandle}
       familiar={chatFamiliar}
@@ -904,6 +907,7 @@ export const ChatRouter = forwardRef<ChatRouterHandle, Props>(function ChatRoute
           title: sessionRailTitle(paneSession),
           content: (
             <ChatView
+              composerDraftKey={`${composerDraftKey}:split:${paneId}`}
               familiar={paneFamiliar}
               sessionId={paneId}
               session={paneSession}

--- a/src/components/chat-sidebar-wiring.test.ts
+++ b/src/components/chat-sidebar-wiring.test.ts
@@ -167,12 +167,12 @@ assert.match(
 );
 assert.match(
   chatRouter,
-  /<ChatView\s*\n\s*key=\{`chat-compose-\$\{composeInstance\}`\}\s*\n\s*ref=\{viewHandle\}[\s\S]*?activeFamiliarId=\{activeFamiliarId\}/,
+  /<ChatView[\s\S]*?key=\{`chat-compose-\$\{composerDraftKey\}-\$\{composeInstance\}`\}\s*\n\s*ref=\{viewHandle\}[\s\S]*?activeFamiliarId=\{activeFamiliarId\}/,
   "the primary ChatView mount should receive Workspace's active list scope",
 );
 assert.match(
   chatRouter,
-  /<ChatView\s*\n\s*familiar=\{paneFamiliar\}[\s\S]*?activeFamiliarId=\{activeFamiliarId\}/,
+  /key=\{`\$\{composerDraftKey\}:split:\$\{paneId\}`\}[\s\S]*?familiar=\{paneFamiliar\}[\s\S]*?activeFamiliarId=\{activeFamiliarId\}/,
   "split-pane ChatView mounts must receive the same active request scope as the primary pane rather than infer request provenance from their own familiar",
 );
 assert.match(

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
 const source = readFileSync(new URL("./chat-view.tsx", import.meta.url), "utf8");
+const routerSource = readFileSync(new URL("./chat-router.tsx", import.meta.url), "utf8");
 const turnStateSource = readFileSync(new URL("../lib/chat-turn-state.ts", import.meta.url), "utf8");
 const draftHook = readFileSync(new URL("../lib/use-composer-draft.ts", import.meta.url), "utf8");
 const streamEvents = readFileSync(new URL("../lib/stream-events.ts", import.meta.url), "utf8");
@@ -680,13 +681,53 @@ assert.match(
 // these pins hold the call sites, the hook test holds the semantics.
 assert.match(
   source,
-  /const \[input, setInput\] = useState\(\(\) => readComposerDraft\(COMPOSER_DRAFT_KEY\)\)/,
-  "composer input initialises from the persisted draft",
+  /export const DEFAULT_CHAT_COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1"/,
+  "ChatView exports the existing draft key as its safe default",
 );
 assert.match(
   source,
-  /const \{ clearNow: clearDraft \} = useDraftPersistence\(COMPOSER_DRAFT_KEY, input, COMPOSER_DRAFT_WRITE_DELAY_MS\)/,
-  "the draft persists through the shared debounced hook (no per-keystroke localStorage writes)",
+  /composerDraftKey\?: string/,
+  "ChatView accepts a caller-owned draft namespace",
+);
+assert.match(
+  source,
+  /composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY/,
+  "ChatView preserves the existing draft slot when no override is provided",
+);
+assert.match(
+  source,
+  /const \[input, setInput\] = useState\(\(\) => readComposerDraft\(composerDraftKey\)\)/,
+  "composer input initialises from the selected draft namespace",
+);
+assert.match(
+  source,
+  /const \{ clearNow: clearDraft \} = useDraftPersistence\(composerDraftKey, input, COMPOSER_DRAFT_WRITE_DELAY_MS\)/,
+  "the selected draft namespace persists through the shared debounced hook",
+);
+assert.match(
+  routerSource,
+  /import \{ ChatView, DEFAULT_CHAT_COMPOSER_DRAFT_KEY \} from "@\/components\/chat-view"/,
+  "ChatRouter shares ChatView's compatibility default",
+);
+assert.match(
+  routerSource,
+  /composerDraftKey\?: string/,
+  "ChatRouter accepts an independent draft namespace",
+);
+assert.match(
+  routerSource,
+  /composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY/,
+  "ChatRouter keeps the legacy draft namespace by default",
+);
+assert.match(
+  routerSource,
+  /<ChatView[\s\S]*?composerDraftKey=\{composerDraftKey\}[\s\S]*?key=\{`chat-compose-\$\{composeInstance\}`\}/,
+  "ChatRouter forwards its namespace to the primary ChatView",
+);
+assert.match(
+  routerSource,
+  /<ChatView[\s\S]*?composerDraftKey=\{`\$\{composerDraftKey\}:split:\$\{paneId\}`\}[\s\S]*?sessionId=\{paneId\}/,
+  "ChatRouter gives every split pane a unique draft namespace",
 );
 assert.match(
   draftHook,

--- a/src/components/chat-view-lifecycle.test.ts
+++ b/src/components/chat-view-lifecycle.test.ts
@@ -721,13 +721,13 @@ assert.match(
 );
 assert.match(
   routerSource,
-  /<ChatView[\s\S]*?composerDraftKey=\{composerDraftKey\}[\s\S]*?key=\{`chat-compose-\$\{composeInstance\}`\}/,
-  "ChatRouter forwards its namespace to the primary ChatView",
+  /<ChatView[\s\S]*?composerDraftKey=\{composerDraftKey\}[\s\S]*?key=\{`chat-compose-\$\{composerDraftKey\}-\$\{composeInstance\}`\}/,
+  "ChatRouter keys the primary ChatView by draft namespace and compose lineage so namespace changes restore the matching draft",
 );
 assert.match(
   routerSource,
-  /<ChatView[\s\S]*?composerDraftKey=\{`\$\{composerDraftKey\}:split:\$\{paneId\}`\}[\s\S]*?sessionId=\{paneId\}/,
-  "ChatRouter gives every split pane a unique draft namespace",
+  /<ChatView[\s\S]*?composerDraftKey=\{`\$\{composerDraftKey\}:split:\$\{paneId\}`\}[\s\S]*?key=\{`\$\{composerDraftKey\}:split:\$\{paneId\}`\}[\s\S]*?sessionId=\{paneId\}/,
+  "ChatRouter keys every split ChatView by its draft namespace so namespace changes safely remount persisted panes",
 );
 assert.match(
   draftHook,

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -124,6 +124,7 @@ import { FamiliarInlineCard } from "@/components/familiar-inline-card";
 import { ArtifactComments } from "@/components/artifact-comments";
 import { SkillDetailPreview } from "@/components/skill-detail-preview";
 import { ChatArchiveNudge } from "@/components/chat-archive-nudge";
+import type { SessionRemovalReason } from "@/lib/chat-session-removal";
 import {
   isChatArchiveNudgeDismissed,
   markChatArchiveNudgeDismissed,
@@ -437,6 +438,13 @@ type Props = {
   onVoiceSessionDiscarded?: () => void;
   onSessionsChanged?: () => void;
   onSessionsDeleted: (sessionIds: readonly string[]) => void;
+  /** Fires exactly when THIS view's own session is confirmed removed —
+   *  archived, deleted, or a discarded empty voice/pre-session — immediately
+   *  before onBack/onVoiceSessionDiscarded navigates away. Unlike
+   *  onSessionsChanged/onSessionsDeleted (which also fire for unrelated
+   *  refreshes), a consumer can treat this as an unambiguous removal signal
+   *  for the exact session named, with no need to infer it from call order. */
+  onSessionRemoved?: (sessionId: string, reason: SessionRemovalReason) => void;
   onBack?: () => void;
   onSlashCommand?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
@@ -1880,7 +1888,7 @@ function conciseStreamError(error: unknown, fallback: string): string {
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, initialModelOverride, autoSendInitialPrompt = false, initialPromptHandoffId = null, startNewConversation = false, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, openVoiceNonce, openVoiceSessionId, daemonRunning, activeFamiliarId, familiars = [], sessions, composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY, composeInstance = 0, onSessionStarted, onVoiceSessionCreated, onVoiceSessionDiscarded, onSessionsChanged, onSessionsDeleted, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, initialModelOverride, autoSendInitialPrompt = false, initialPromptHandoffId = null, startNewConversation = false, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, openVoiceNonce, openVoiceSessionId, daemonRunning, activeFamiliarId, familiars = [], sessions, composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY, composeInstance = 0, onSessionStarted, onVoiceSessionCreated, onVoiceSessionDiscarded, onSessionsChanged, onSessionsDeleted, onSessionRemoved, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -6732,13 +6740,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
       onSessionsChanged?.();
+      onSessionRemoved?.(sessionId, "archived");
       onBack?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "archive failed");
     } finally {
       setArchivingChat(false);
     }
-  }, [sessionId, archivingChat, onSessionsChanged, onBack]);
+  }, [sessionId, archivingChat, onSessionsChanged, onSessionRemoved, onBack]);
 
   const deleteChat = async () => {
     if (!sessionId || deleting) return;
@@ -6752,6 +6761,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
         return;
       }
       onSessionsDeleted([sessionId]);
+      onSessionRemoved?.(sessionId, "deleted");
       onBack?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : "delete failed");
@@ -6857,7 +6867,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       announce(archived ? "Chat archived — it won't appear in the rail." : "Chat restored to the rail.");
       onSessionsChanged?.();
       // Leaving mirrors delete only for archive; unarchive keeps you in place.
-      if (archived) onBack?.();
+      if (archived) {
+        onSessionRemoved?.(sessionId, "archived");
+        onBack?.();
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : archived ? "archive failed" : "unarchive failed");
     } finally {
@@ -8074,7 +8087,10 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   // Only yank the view back to compose when it's still
                   // parked on the session we just discarded — if the user
                   // has already switched away, leave them where they are.
-                  if (target === sessionId) onVoiceSessionDiscarded?.();
+                  if (target === sessionId) {
+                    onSessionRemoved?.(target, "discarded");
+                    onVoiceSessionDiscarded?.();
+                  }
                 }
               });
             }

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -424,6 +424,7 @@ type Props = {
   /** Workspace-owned session list; the starting page's "Continue" row reads it
    *  so no extra fetch rides on every new chat. */
   sessions?: SessionRow[];
+  composerDraftKey?: string;
   composeInstance?: number;
   onSessionStarted?: (request: ChatSessionPromotionRequest) => void;
   /** Pre-session voice call: ChatView created a conversation for the call;
@@ -543,9 +544,9 @@ type ComposerResponseSpeed = CommandResponseSpeed;
 // the .cave-composer-input rule (13 lines: 13*24 + 20px padding).
 const COMPOSER_MAX_HEIGHT = 332;
 // Persist the in-progress composer text so a page reload doesn't eat a
-// half-written message. The composer is a single shared input (it isn’t
-// remounted per session), so one key mirrors the in-memory behaviour.
-const COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
+// half-written message. Callers can isolate mounted composers while the
+// default retains the original shared slot.
+export const DEFAULT_CHAT_COMPOSER_DRAFT_KEY = "cave:chat-composer-draft:v1";
 const COMPOSER_DRAFT_WRITE_DELAY_MS = 250;
 // Persisted ↑/↓ prompt-history recall stack for the chat composer.
 const COMPOSER_HISTORY_KEY = "cave:chat-composer-history:v1";
@@ -1879,7 +1880,7 @@ function conciseStreamError(error: unknown, fallback: string): string {
 // ── ChatView ──────────────────────────────────────────────────────────────────
 
 export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
-  { familiar, sessionId, session, projectRoot, initialPrompt, initialModelOverride, autoSendInitialPrompt = false, initialPromptHandoffId = null, startNewConversation = false, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, openVoiceNonce, openVoiceSessionId, daemonRunning, activeFamiliarId, familiars = [], sessions, composeInstance = 0, onSessionStarted, onVoiceSessionCreated, onVoiceSessionDiscarded, onSessionsChanged, onSessionsDeleted, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
+  { familiar, sessionId, session, projectRoot, initialPrompt, initialModelOverride, autoSendInitialPrompt = false, initialPromptHandoffId = null, startNewConversation = false, initialAttachments, initialControls, origin, openFindQuery, openFindNonce, openVoiceNonce, openVoiceSessionId, daemonRunning, activeFamiliarId, familiars = [], sessions, composerDraftKey = DEFAULT_CHAT_COMPOSER_DRAFT_KEY, composeInstance = 0, onSessionStarted, onVoiceSessionCreated, onVoiceSessionDiscarded, onSessionsChanged, onSessionsDeleted, onBack, onSlashCommand, onOpenOnboarding, onOpenTask, onOpenUrl, onProjectRootChange },
   ref,
 ) {
   const [turns, setTurns] = useState<Turn[]>([]);
@@ -2233,11 +2234,11 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
     return parsed?.kind === "ssh" ? parsed.host : null;
   }, [session?.runtime]);
   const composerHostValue = runtimeHost ?? sessionRuntimeHost ?? LOCAL_HOST_ID;
-  const [input, setInput] = useState(() => readComposerDraft(COMPOSER_DRAFT_KEY));
+  const [input, setInput] = useState(() => readComposerDraft(composerDraftKey));
   // Persist the composer draft so a reload restores a half-written message.
   // Cleared (key removed) when the input empties — e.g. after a send. Shared
   // hook — debounce + remove-on-empty semantics live in use-composer-draft.
-  const { clearNow: clearDraft } = useDraftPersistence(COMPOSER_DRAFT_KEY, input, COMPOSER_DRAFT_WRITE_DELAY_MS);
+  const { clearNow: clearDraft } = useDraftPersistence(composerDraftKey, input, COMPOSER_DRAFT_WRITE_DELAY_MS);
   // CHAT-D11-04: Input history navigation (↑↓) — shared hook (use-composer-history);
   // chat deliberately never records slash commands (send() returns before the push).
   const { push: pushHistory, handleArrowKey } = useComposerHistory(COMPOSER_HISTORY_KEY);

--- a/src/components/chat-view.tsx
+++ b/src/components/chat-view.tsx
@@ -434,8 +434,12 @@ type Props = {
   /** An auto-created call session was discarded (empty, hung up) while the
    *  view was still parked on it — the router returns the view to a fresh
    *  compose state instead of leaving the user composing into a deleted
-   *  session. Not called when the user had already switched away. */
-  onVoiceSessionDiscarded?: () => void;
+   *  session. Not called when the user had already switched away. Passed the
+   *  discarded session's id so the router can re-check it's still the one
+   *  showing before navigating (cave-rl980 Task 4 final review) — the discard
+   *  itself is async, and the user may have switched threads or familiars
+   *  while it was in flight. */
+  onVoiceSessionDiscarded?: (sessionId: string) => void;
   onSessionsChanged?: () => void;
   onSessionsDeleted: (sessionIds: readonly string[]) => void;
   /** Fires exactly when THIS view's own session is confirmed removed —
@@ -445,7 +449,15 @@ type Props = {
    *  refreshes), a consumer can treat this as an unambiguous removal signal
    *  for the exact session named, with no need to infer it from call order. */
   onSessionRemoved?: (sessionId: string, reason: SessionRemovalReason) => void;
-  onBack?: () => void;
+  /** Passed the session this back navigation is for — the removal call sites
+   *  below always pass their own (non-null) sessionId; the two "Back to
+   *  sessions" render buttons pass whatever is currently shown. ChatRouter
+   *  only actually navigates when it's still displaying that exact session
+   *  (cave-rl980 Task 4 final review): archiveChat/deleteChat/setChatArchived
+   *  are async, and by the time the request settles the user may have
+   *  already switched to a different thread or familiar, whose view must
+   *  never be clobbered by a now-irrelevant completion. */
+  onBack?: (sessionId: string | null) => void;
   onSlashCommand?: (command: string, args: string) => boolean;
   onOpenOnboarding?: () => void;
   /** Reverse navigation for a chat that's linked to a board task — clicking
@@ -6741,7 +6753,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       }
       onSessionsChanged?.();
       onSessionRemoved?.(sessionId, "archived");
-      onBack?.();
+      onBack?.(sessionId);
     } catch (err) {
       setError(err instanceof Error ? err.message : "archive failed");
     } finally {
@@ -6762,7 +6774,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       }
       onSessionsDeleted([sessionId]);
       onSessionRemoved?.(sessionId, "deleted");
-      onBack?.();
+      onBack?.(sessionId);
     } catch (err) {
       setError(err instanceof Error ? err.message : "delete failed");
     } finally {
@@ -6869,7 +6881,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
       // Leaving mirrors delete only for archive; unarchive keeps you in place.
       if (archived) {
         onSessionRemoved?.(sessionId, "archived");
-        onBack?.();
+        onBack?.(sessionId);
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : archived ? "archive failed" : "unarchive failed");
@@ -7790,7 +7802,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
               <FlowSessionTranscriptFallback
                 transcript={flowTranscriptFallback}
                 onRetry={retryHistory}
-                onBack={onBack}
+                onBack={onBack ? () => onBack(sessionId) : undefined}
               />
             ) : historyState === "missing" ? (
               <ChatHistoryNotice
@@ -7799,14 +7811,14 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   ? "This flow session exists, but CovenCave could not find saved chat history or flow output for it yet."
                   : "This session exists, but CovenCave could not find a saved transcript for it yet."}
                 onRetry={retryHistory}
-                onBack={onBack}
+                onBack={onBack ? () => onBack(sessionId) : undefined}
               />
             ) : historyState === "error" ? (
               <ChatHistoryNotice
                 title="Could not load chat history"
                 body="The transcript request failed. You can still continue this session."
                 onRetry={retryHistory}
-                onBack={onBack}
+                onBack={onBack ? () => onBack(sessionId) : undefined}
               />
             ) : sessionId === null ? (
               // Brand-new chat (no session yet): the 2b launcher — hero, the
@@ -8089,7 +8101,7 @@ export const ChatView = forwardRef<ChatViewHandle, Props>(function ChatView(
                   // has already switched away, leave them where they are.
                   if (target === sessionId) {
                     onSessionRemoved?.(target, "discarded");
-                    onVoiceSessionDiscarded?.();
+                    onVoiceSessionDiscarded?.(target);
                   }
                 }
               });

--- a/src/components/mobile-drawer-inert-focus-order.test.tsx
+++ b/src/components/mobile-drawer-inert-focus-order.test.tsx
@@ -1,0 +1,241 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention in
+// right-chat-panel-behavior.test.tsx and chat-router-removal-race.test.tsx.
+//
+// Behavioral regression for the cave-rl980 Task 5 spec finding: background
+// inert must be cleared before useFocusTrap restores focus to the shell
+// toggle that opened the mobile right-Chat drawer.
+//
+// CONSTRAINT (why this isn't a full MobileDrawer render): MobileDrawer's
+// backdrop/modal both mount via `createPortal(..., document.body)`, and
+// react-dom's `createPortal` refuses any container without a real DOM
+// `nodeType` ("Target container is not a DOM element") — a check that runs
+// before react-test-renderer's own tree is ever touched. react-test-renderer
+// additionally refuses a `createPortal` call inside its tree outright
+// ("ReactDOM.createPortal inside of a ReactTestRenderer tree... is not
+// supported"), independent of the container check. This repo has neither
+// jsdom nor happy-dom installed (grep the lockfile: both are optional peers
+// of vitest with no resolved package), so there is no way to mount a real
+// `document`/DOM tree for MobileDrawer itself today — that lands with the
+// real browser wiring in Task 6. Verified empirically against this repo's
+// exact react-dom/react-test-renderer versions before writing this file.
+//
+// What IS genuinely testable without jsdom: the ordering contract itself.
+// react-test-renderer's `createNodeMock` lets a host ref resolve to any
+// plain object, so this file mounts the REAL `useFocusTrap` hook (imported
+// from "@/lib/use-focus-trap", not reimplemented) alongside a mirrored copy
+// of mobile-drawer.tsx's shell-inert effect, in the same relative
+// declaration order production code uses, and drives it through React's
+// actual effect-commit machinery (act() + real mount/update/cleanup) rather
+// than hand-simulating what "should" happen. It proves two things a regex
+// match on source text cannot:
+//   1. React truly does run a component's passive-effect cleanups in
+//      top-down declaration order (not reversed) — verified here against
+//      the live React runtime, not asserted as a fact about React.
+//   2. Given that real ordering, the FIXED declaration order (inert effect
+//      before useFocusTrap) makes the shell already non-inert at the moment
+//      focus is restored, while the ORIGINAL buggy order (useFocusTrap
+//      before the inert effect) restores focus while the shell is still
+//      inert — reproducing the exact defect this task fixes.
+// shell-drawer-smoke.test.ts separately pins that mobile-drawer.tsx's real
+// source still declares the effects in the order mirrored below, so the two
+// files can't silently drift apart.
+import { useEffect, useRef } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, test } from "vitest";
+import { useFocusTrap } from "@/lib/use-focus-trap";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Order = string[];
+
+/** Stands in for `.shell-frame` — a plain object with an `inert` flag,
+ * exactly like the real DOM property mobile-drawer.tsx toggles. */
+function makeShell() {
+  return { inert: false };
+}
+
+/** Stands in for the shell toggle button that opened the drawer and should
+ * regain focus on close. Records, at the moment `.focus()` actually fires,
+ * whatever `shell.inert` currently is — that observation IS the regression
+ * check: a correct ordering observes `false`, the bug observes `true`. */
+function makeTrigger(shell: { inert: boolean }, order: Order) {
+  return {
+    focus() {
+      order.push(`trigger:focus(shellInert=${shell.inert})`);
+    },
+  };
+}
+
+/** A container ref target with no focusable descendants, so useFocusTrap's
+ * activate-time `focusFirst` fallback focuses the container itself instead
+ * — harmless and orthogonal to the deactivate-time regression under test. */
+function makeContainer(order: Order) {
+  return {
+    querySelector: () => null,
+    focus: () => order.push("container:focus"),
+  };
+}
+
+/** useFocusTrap registers its Tab/Escape keydown listener on `window` —
+ * stub just enough of it (add/removeEventListener) since there is no jsdom
+ * `window` in this repo's test environment (see the file-level constraint
+ * note above). */
+function makeWindow() {
+  return {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+}
+
+/** Mirrors mobile-drawer.tsx's FIXED effect order: the shell-inert effect is
+ * declared BEFORE useFocusTrap(...), so its cleanup (clearing `shell.inert`)
+ * runs before useFocusTrap's own cleanup (which restores focus). */
+function FixedOrderDrawer({
+  active,
+  shell,
+  order,
+}: {
+  active: boolean;
+  shell: { inert: boolean };
+  order: Order;
+}) {
+  const containerRef = useRef<unknown>(null);
+
+  useEffect(() => {
+    if (!active) return;
+    const prevInert = shell.inert;
+    shell.inert = true;
+    order.push("inert:set(true)");
+    return () => {
+      shell.inert = prevInert;
+      order.push(`inert:cleanup(restored=${prevInert})`);
+    };
+  }, [active]);
+
+  useFocusTrap(active, containerRef as never, {});
+
+  return <div ref={containerRef as never} />;
+}
+
+/** Mirrors the ORIGINAL buggy order this task fixes: useFocusTrap declared
+ * BEFORE the shell-inert effect, so its cleanup (focus restore) runs first,
+ * while the shell is still inert. */
+function BuggyOrderDrawer({
+  active,
+  shell,
+  order,
+}: {
+  active: boolean;
+  shell: { inert: boolean };
+  order: Order;
+}) {
+  const containerRef = useRef<unknown>(null);
+
+  useFocusTrap(active, containerRef as never, {});
+
+  useEffect(() => {
+    if (!active) return;
+    const prevInert = shell.inert;
+    shell.inert = true;
+    order.push("inert:set(true)");
+    return () => {
+      shell.inert = prevInert;
+      order.push(`inert:cleanup(restored=${prevInert})`);
+    };
+  }, [active]);
+
+  return <div ref={containerRef as never} />;
+}
+
+let renderer: ReactTestRenderer | null = null;
+let restoreGlobals: (() => void) | null = null;
+
+/** Stubs the minimal `document`/`window` surface useFocusTrap touches, and
+ * returns a restore function. See the file-level constraint note: no jsdom
+ * exists in this repo's test environment, so these are plain object stubs,
+ * not a real DOM. */
+function stubDomGlobals(trigger: unknown) {
+  const previousDocument = (globalThis as Record<string, unknown>).document;
+  const previousWindow = (globalThis as Record<string, unknown>).window;
+  (globalThis as Record<string, unknown>).document = { activeElement: trigger };
+  (globalThis as Record<string, unknown>).window = makeWindow();
+  return () => {
+    (globalThis as Record<string, unknown>).document = previousDocument;
+    (globalThis as Record<string, unknown>).window = previousWindow;
+  };
+}
+
+afterEach(() => {
+  if (renderer) {
+    act(() => {
+      renderer!.unmount();
+    });
+    renderer = null;
+  }
+  restoreGlobals?.();
+  restoreGlobals = null;
+});
+
+describe("mobile drawer background-inert / focus-trap cleanup ordering", () => {
+  test("FIXED order: inert clears before focus is restored to the shell toggle", () => {
+    const order: Order = [];
+    const shell = makeShell();
+    const trigger = makeTrigger(shell, order);
+    const container = makeContainer(order);
+    restoreGlobals = stubDomGlobals(trigger);
+
+    act(() => {
+      renderer = create(<FixedOrderDrawer active shell={shell} order={order} />, {
+        createNodeMock: () => container,
+      });
+    });
+    expect(shell.inert).toBe(true);
+
+    act(() => {
+      renderer!.update(<FixedOrderDrawer active={false} shell={shell} order={order} />);
+    });
+
+    // The load-bearing assertion: focus was restored (a "trigger:focus"
+    // entry exists) and, at that exact moment, the shell was NOT inert.
+    const focusEntry = order.find((entry) => entry.startsWith("trigger:focus"));
+    expect(focusEntry).toBe("trigger:focus(shellInert=false)");
+    expect(shell.inert).toBe(false);
+
+    // And the inert cleanup strictly precedes the focus-restore call.
+    const inertCleanupIndex = order.indexOf("inert:cleanup(restored=false)");
+    const focusIndex = order.indexOf(focusEntry!);
+    expect(inertCleanupIndex).toBeGreaterThanOrEqual(0);
+    expect(inertCleanupIndex).toBeLessThan(focusIndex);
+  });
+
+  test("BUGGY order reproduces the defect: focus is restored while still inert", () => {
+    const order: Order = [];
+    const shell = makeShell();
+    const trigger = makeTrigger(shell, order);
+    const container = makeContainer(order);
+    restoreGlobals = stubDomGlobals(trigger);
+
+    act(() => {
+      renderer = create(<BuggyOrderDrawer active shell={shell} order={order} />, {
+        createNodeMock: () => container,
+      });
+    });
+    expect(shell.inert).toBe(true);
+
+    act(() => {
+      renderer!.update(<BuggyOrderDrawer active={false} shell={shell} order={order} />);
+    });
+
+    // With useFocusTrap declared first, its cleanup (focus restore) runs
+    // BEFORE the inert effect's cleanup — this is the bug: `.focus()` fires
+    // while the shell subtree is still inert, so a real browser would treat
+    // it as a silent no-op.
+    const focusEntry = order.find((entry) => entry.startsWith("trigger:focus"));
+    expect(focusEntry).toBe("trigger:focus(shellInert=true)");
+
+    const focusIndex = order.indexOf(focusEntry!);
+    const inertCleanupIndex = order.indexOf("inert:cleanup(restored=false)");
+    expect(inertCleanupIndex).toBeGreaterThanOrEqual(0);
+    expect(focusIndex).toBeLessThan(inertCleanupIndex);
+  });
+});

--- a/src/components/mobile-drawer-nav-list-focus.test.tsx
+++ b/src/components/mobile-drawer-nav-list-focus.test.tsx
@@ -1,0 +1,226 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention in
+// mobile-drawer-inert-focus-order.test.tsx.
+//
+// Behavioral regression for the cave-rl980 Task 5 spec finding: nav/list
+// mobile drawers previously had NO focus management at all beyond the
+// legacy standalone Escape listener in mobile-drawer.tsx (body-scroll lock
+// and Escape-to-close only) — opening one never captured what was focused
+// beforehand, closing one never restored it, and Tab could walk straight out
+// of the drawer into content it visually covers. This proves the fix reuses
+// the SAME useFocusTrap machinery the right-Chat drawer and Modal already
+// use, for BOTH nav and list, across every dismissal path — not just
+// Escape, but the backdrop button too, since that's the ordinary way a user
+// actually closes one of these drawers.
+//
+// CONSTRAINT (same as mobile-drawer-inert-focus-order.test.tsx): MobileDrawer
+// portals via `createPortal(..., document.body)`, which react-test-renderer
+// categorically refuses ("ReactDOM.createPortal inside of a ReactTestRenderer
+// tree... is not supported"), and this repo has neither jsdom nor happy-dom
+// installed. So this file mounts a faithful MIRROR of mobile-drawer.tsx's
+// nav/list-relevant slice — the exact `document.querySelector(".shell-nav-
+// panel"/".shell-list-panel")` ref-population-in-render-body plus the exact
+// `useFocusTrap(open === "nav"/"list", ...)` call shape — driven through the
+// REAL `useFocusTrap` hook (imported from "@/lib/use-focus-trap", never
+// reimplemented) via act() + real mount/update/cleanup. right-chat-panel.test.ts
+// separately pins that mobile-drawer.tsx's actual source still matches this
+// exact shape, so the two can't silently drift apart.
+import { useRef } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, test } from "vitest";
+import { resetFocusTrapStackForTest, useFocusTrap } from "@/lib/use-focus-trap";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+type FakeElement = {
+  readonly name: string;
+  focus: () => void;
+  hasAttribute: (name: string) => boolean;
+};
+
+function makeElement(name: string, activeHolder: { current: FakeElement | null }): FakeElement {
+  const el: FakeElement = {
+    name,
+    focus: () => {
+      activeHolder.current = el;
+    },
+    hasAttribute: () => false,
+  };
+  return el;
+}
+
+function makeContainer(elements: FakeElement[]) {
+  return {
+    querySelector: () => elements[0] ?? null,
+    querySelectorAll: () => elements,
+    contains: (el: unknown) => elements.includes(el as FakeElement),
+    focus: () => {
+      /* fallback focus target when a container has no focusable child */
+    },
+  };
+}
+
+function makeWindowStub() {
+  const listeners: Array<(e: unknown) => void> = [];
+  return {
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === "keydown") listeners.push(fn);
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type !== "keydown") return;
+      const idx = listeners.indexOf(fn);
+      if (idx !== -1) listeners.splice(idx, 1);
+    },
+    dispatchKeydown(partial: { key: string; shiftKey?: boolean }) {
+      const event = { key: partial.key, shiftKey: partial.shiftKey ?? false, preventDefault: () => {} };
+      for (const fn of [...listeners]) fn(event);
+    },
+  };
+}
+
+/** Stubs `document.activeElement` (mutable) and `document.querySelector`
+ *  (returns whatever fake container is registered for a given selector) —
+ *  the exact two DOM entry points mobile-drawer.tsx's nav/list ref-population
+ *  and useFocusTrap itself touch. */
+function stubDomGlobals(
+  activeHolder: { current: FakeElement | null },
+  win: ReturnType<typeof makeWindowStub>,
+  selectorMap: Record<string, unknown>,
+) {
+  const previousDocument = (globalThis as Record<string, unknown>).document;
+  const previousWindow = (globalThis as Record<string, unknown>).window;
+  (globalThis as Record<string, unknown>).document = {
+    get activeElement() {
+      return activeHolder.current;
+    },
+    querySelector: (selector: string) => selectorMap[selector] ?? null,
+  };
+  (globalThis as Record<string, unknown>).window = win;
+  return () => {
+    (globalThis as Record<string, unknown>).document = previousDocument;
+    (globalThis as Record<string, unknown>).window = previousWindow;
+  };
+}
+
+/** Mirrors mobile-drawer.tsx's nav/list slice EXACTLY: refs populated via
+ *  `document.querySelector` directly in the render body (not an effect), so
+ *  they're always current by the time useFocusTrap's own effect reads them —
+ *  then handed, unwrapped, to useFocusTrap with no onEscape (Escape stays the
+ *  legacy listener's job in the real component; only capture/restore/Tab-
+ *  containment are reused here). */
+function MirrorNavListDrawer({ open }: { open: "nav" | "list" | null }) {
+  const navContainerRef = useRef<unknown>(null);
+  const listContainerRef = useRef<unknown>(null);
+  if (typeof document !== "undefined") {
+    navContainerRef.current = (document as { querySelector: (s: string) => unknown }).querySelector(
+      ".shell-nav-panel",
+    );
+    listContainerRef.current = (document as { querySelector: (s: string) => unknown }).querySelector(
+      ".shell-list-panel",
+    );
+  }
+  useFocusTrap(open === "nav", navContainerRef as never);
+  useFocusTrap(open === "list", listContainerRef as never);
+  return null;
+}
+
+let renderer: ReactTestRenderer | null = null;
+let restoreGlobals: (() => void) | null = null;
+
+afterEach(() => {
+  if (renderer) {
+    act(() => {
+      renderer!.unmount();
+    });
+    renderer = null;
+  }
+  restoreGlobals?.();
+  restoreGlobals = null;
+  resetFocusTrapStackForTest();
+});
+
+describe("mobile drawer nav/list focus capture/restore (cave-rl980 Task 5 finding #3)", () => {
+  test("opening the nav drawer captures the trigger and moves focus in; the backdrop button dismissing it restores the trigger", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    const navToggleTrigger = makeElement("nav-toggle-button", activeHolder);
+    const firstNavLink = makeElement("first-nav-link", activeHolder);
+    const navContainer = makeContainer([firstNavLink]);
+    restoreGlobals = stubDomGlobals(activeHolder, win, { ".shell-nav-panel": navContainer });
+
+    // The user has just activated the top-bar's nav toggle — it holds focus
+    // the instant before the drawer opens, exactly like a real <button onClick>.
+    activeHolder.current = navToggleTrigger;
+
+    act(() => {
+      renderer = create(<MirrorNavListDrawer open={null} />);
+    });
+    expect(activeHolder.current).toBe(navToggleTrigger);
+
+    act(() => {
+      renderer!.update(<MirrorNavListDrawer open="nav" />);
+    });
+    // Capture-on-open: the nav drawer moved focus to its first focusable —
+    // the previous (no focus management at all) implementation left focus
+    // exactly on navToggleTrigger here instead.
+    expect(activeHolder.current).toBe(firstNavLink);
+
+    // The backdrop BUTTON is the ordinary way a user dismisses a mobile
+    // drawer — in the real component its onClick calls the same `onClose`
+    // that flips `mobileDrawer` state to null, which is exactly what this
+    // update models: `open` flipping away from "nav" is what deactivates
+    // the trap, regardless of which specific dismissal path triggered it.
+    act(() => {
+      renderer!.update(<MirrorNavListDrawer open={null} />);
+    });
+    // Restore-on-close: focus goes back to the nav toggle that opened it —
+    // previously it stayed wherever Tab/backdrop-tap last left it.
+    expect(activeHolder.current).toBe(navToggleTrigger);
+  });
+
+  test("the list drawer gets the identical capture/restore contract, independent of nav", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    const listToggleTrigger = makeElement("list-toggle-button", activeHolder);
+    const firstListItem = makeElement("first-list-item", activeHolder);
+    const listContainer = makeContainer([firstListItem]);
+    restoreGlobals = stubDomGlobals(activeHolder, win, { ".shell-list-panel": listContainer });
+
+    activeHolder.current = listToggleTrigger;
+
+    act(() => {
+      renderer = create(<MirrorNavListDrawer open={null} />);
+    });
+
+    act(() => {
+      renderer!.update(<MirrorNavListDrawer open="list" />);
+    });
+    expect(activeHolder.current).toBe(firstListItem);
+
+    act(() => {
+      renderer!.update(<MirrorNavListDrawer open={null} />);
+    });
+    expect(activeHolder.current).toBe(listToggleTrigger);
+  });
+
+  test("Tab stays contained inside the open nav drawer", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    const trigger = makeElement("nav-toggle-button", activeHolder);
+    const onlyLink = makeElement("only-nav-link", activeHolder);
+    const navContainer = makeContainer([onlyLink]);
+    restoreGlobals = stubDomGlobals(activeHolder, win, { ".shell-nav-panel": navContainer });
+    activeHolder.current = trigger;
+
+    act(() => {
+      renderer = create(<MirrorNavListDrawer open="nav" />);
+    });
+    expect(activeHolder.current).toBe(onlyLink);
+
+    // A single focusable: Tab (non-shift) must cycle back to itself, never
+    // let focus escape the drawer onto content it visually covers.
+    act(() => {
+      win.dispatchKeydown({ key: "Tab" });
+    });
+    expect(activeHolder.current).toBe(onlyLink);
+  });
+});

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -39,6 +39,37 @@ type MobileDrawerProps = {
 export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
   const rightChatRef = useRef<HTMLElement | null>(null);
 
+  // Make the shell chrome behind the right Chat modal inert so Tab/AT users
+  // can't reach it while the dialog is up. `.shell-frame` is Shell's own
+  // root (shell.tsx) — this portal mounts to document.body, OUTSIDE that
+  // subtree, so making it inert never reaches the modal we're keeping
+  // interactive. Restores whatever inert state `.shell-frame` actually had
+  // before, rather than assuming it was false.
+  //
+  // Declared BEFORE useFocusTrap below on purpose: React runs a component's
+  // passive-effect cleanups in the same top-down order they were declared
+  // (not reversed), for both updates and unmount. useFocusTrap's own cleanup
+  // calls `returnFocusRef.current?.focus()` to return focus to the shell
+  // toggle that opened the drawer — but `.focus()` on an element inside an
+  // `inert` subtree is a silent no-op. So this effect's cleanup (clearing
+  // `shell.inert`) MUST run first, or the restored focus call lands while
+  // the shell is still inert and does nothing. Both effects intentionally
+  // stay plain `useEffect` (matching useFocusTrap's own passive-effect
+  // implementation) — mixing in `useLayoutEffect` here would just move this
+  // ahead of ALL passive effects regardless of declaration order, which
+  // works too, but decouples the ordering guarantee from something a future
+  // reader can see at a glance the way declaration order can.
+  useEffect(() => {
+    if (open !== "right-chat") return;
+    const shell = document.querySelector<HTMLElement>(".shell-frame");
+    if (!shell) return;
+    const prevInert = shell.inert;
+    shell.inert = true;
+    return () => {
+      shell.inert = prevInert;
+    };
+  }, [open]);
+
   // The right Chat modal owns Escape + focus trap/return entirely through
   // the shared hook (the same contract Modal uses) — the legacy standalone
   // listener below is scoped away from it so Escape never fires two close
@@ -69,34 +100,18 @@ export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
     };
   }, [open, onClose]);
 
-  // Make the shell chrome behind the right Chat modal inert so Tab/AT users
-  // can't reach it while the dialog is up. `.shell-frame` is Shell's own
-  // root (shell.tsx) — this portal mounts to document.body, OUTSIDE that
-  // subtree, so making it inert never reaches the modal we're keeping
-  // interactive. Restores whatever inert state `.shell-frame` actually had
-  // before, rather than assuming it was false.
-  useEffect(() => {
-    if (open !== "right-chat") return;
-    const shell = document.querySelector<HTMLElement>(".shell-frame");
-    if (!shell) return;
-    const prevInert = shell.inert;
-    shell.inert = true;
-    return () => {
-      shell.inert = prevInert;
-    };
-  }, [open]);
-
   if (typeof document === "undefined") return null;
   if (!open && !rightChat) return null;
 
   return createPortal(
     <>
       {open ? (
-        <div
+        <button
+          type="button"
           className="mobile-drawer-backdrop"
           data-drawer-slot={open}
+          aria-label="Close drawer"
           onClick={onClose}
-          role="presentation"
         />
       ) : null}
       {rightChat ? (

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -1,32 +1,57 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { useFocusTrap } from "@/lib/use-focus-trap";
 
-export type MobileDrawerSlot = "nav" | "list" | null;
+export type MobileDrawerSlot = "nav" | "list" | "right-chat" | null;
 
 type MobileDrawerProps = {
   /** Which shell panel is currently open as a drawer, or null when closed. */
   open: MobileDrawerSlot;
   onClose: () => void;
+  /**
+   * The global right Chat panel's mobile/tablet modal content. Stays
+   * portal-mounted whenever this is non-null, even while `open` is not
+   * "right-chat" — closing only hides/inerts it (aria-hidden + hidden +
+   * inert), never unmounts it, so ChatRouter's transcript/stream/scroll
+   * position/draft survive a close exactly like the desktop persistent
+   * panel. See right-chat-panel.tsx's own "truthful accessibility, not a
+   * mount gate" rationale for the same pattern on the desktop side.
+   */
+  rightChat?: ReactNode;
 };
 
 /**
  * Mobile drawer overlay. Renders a portal-mounted backdrop and handles
- * Escape / tap-outside dismissal. The actual panel slide is CSS-driven by
- * the `[data-mobile-drawer]` attribute on `.shell-root` (see globals.css);
- * this component only owns the dismiss surface and the body-scroll lock.
+ * Escape / tap-outside dismissal for the nav/list drawers, plus a dedicated
+ * accessible modal slot for the global right Chat panel. The nav/list slide
+ * itself is CSS-driven by the `[data-mobile-drawer]` attribute on
+ * `.shell-root` (see globals.css); this component owns the dismiss surface,
+ * the body-scroll lock, and — for the right Chat modal — the focus trap and
+ * background inert state.
  *
  * Mount once at shell-level — not per panel — because only one drawer is
- * open at a time and we only want one backdrop in the layer tree.
+ * open at a time and we only want one backdrop in the layer tree. The right
+ * Chat modal renders into the SAME portal so it shares that one backdrop
+ * instead of stacking a second overlay.
  */
-export function MobileDrawer({ open, onClose }: MobileDrawerProps) {
+export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
+  const rightChatRef = useRef<HTMLElement | null>(null);
+
+  // The right Chat modal owns Escape + focus trap/return entirely through
+  // the shared hook (the same contract Modal uses) — the legacy standalone
+  // listener below is scoped away from it so Escape never fires two close
+  // paths for this slot.
+  useFocusTrap(open === "right-chat", rightChatRef, { onEscape: onClose });
+
   useEffect(() => {
     if (!open) return;
+    const ownsEscape = open !== "right-chat";
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
     };
-    window.addEventListener("keydown", onKey);
+    if (ownsEscape) window.addEventListener("keydown", onKey);
     const prevRootOverflow = document.documentElement.style.overflow;
     const prevRootOverscroll = document.documentElement.style.overscrollBehavior;
     const prevOverflow = document.body.style.overflow;
@@ -36,7 +61,7 @@ export function MobileDrawer({ open, onClose }: MobileDrawerProps) {
     document.body.style.overflow = "hidden";
     document.body.style.overscrollBehavior = "none";
     return () => {
-      window.removeEventListener("keydown", onKey);
+      if (ownsEscape) window.removeEventListener("keydown", onKey);
       document.documentElement.style.overflow = prevRootOverflow;
       document.documentElement.style.overscrollBehavior = prevRootOverscroll;
       document.body.style.overflow = prevOverflow;
@@ -44,15 +69,53 @@ export function MobileDrawer({ open, onClose }: MobileDrawerProps) {
     };
   }, [open, onClose]);
 
-  if (!open || typeof document === "undefined") return null;
+  // Make the shell chrome behind the right Chat modal inert so Tab/AT users
+  // can't reach it while the dialog is up. `.shell-frame` is Shell's own
+  // root (shell.tsx) — this portal mounts to document.body, OUTSIDE that
+  // subtree, so making it inert never reaches the modal we're keeping
+  // interactive. Restores whatever inert state `.shell-frame` actually had
+  // before, rather than assuming it was false.
+  useEffect(() => {
+    if (open !== "right-chat") return;
+    const shell = document.querySelector<HTMLElement>(".shell-frame");
+    if (!shell) return;
+    const prevInert = shell.inert;
+    shell.inert = true;
+    return () => {
+      shell.inert = prevInert;
+    };
+  }, [open]);
+
+  if (typeof document === "undefined") return null;
+  if (!open && !rightChat) return null;
 
   return createPortal(
-    <div
-      className="mobile-drawer-backdrop"
-      data-drawer-slot={open}
-      onClick={onClose}
-      role="presentation"
-    />,
+    <>
+      {open ? (
+        <div
+          className="mobile-drawer-backdrop"
+          data-drawer-slot={open}
+          onClick={onClose}
+          role="presentation"
+        />
+      ) : null}
+      {rightChat ? (
+        <section
+          id="shell-right-chat-drawer"
+          ref={rightChatRef}
+          className="mobile-right-chat-drawer"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Chat panel"
+          aria-hidden={open !== "right-chat"}
+          hidden={open !== "right-chat"}
+          inert={open !== "right-chat"}
+          tabIndex={-1}
+        >
+          {rightChat}
+        </section>
+      ) : null}
+    </>,
     document.body,
   );
 }

--- a/src/components/mobile-drawer.tsx
+++ b/src/components/mobile-drawer.tsx
@@ -38,6 +38,20 @@ type MobileDrawerProps = {
  */
 export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
   const rightChatRef = useRef<HTMLElement | null>(null);
+  // nav/list panels are Shell's own persistent nav/list landmarks (rendered
+  // in shell.tsx, not by this portal) that CSS merely slides into an
+  // overlay at mobile widths — same cross-boundary reach as the `.shell-
+  // frame` query below, since this component has no direct render access to
+  // them. Refreshed on every render (not a dedicated effect) so useFocusTrap's
+  // own activation effect always reads the live node; assigning a ref's
+  // `.current` directly in the render body is the same pattern chat-router.tsx
+  // uses for its always-current `viewRef`.
+  const navContainerRef = useRef<HTMLElement | null>(null);
+  const listContainerRef = useRef<HTMLElement | null>(null);
+  if (typeof document !== "undefined") {
+    navContainerRef.current = document.querySelector<HTMLElement>(".shell-nav-panel");
+    listContainerRef.current = document.querySelector<HTMLElement>(".shell-list-panel");
+  }
 
   // Make the shell chrome behind the right Chat modal inert so Tab/AT users
   // can't reach it while the dialog is up. `.shell-frame` is Shell's own
@@ -75,6 +89,23 @@ export function MobileDrawer({ open, onClose, rightChat }: MobileDrawerProps) {
   // listener below is scoped away from it so Escape never fires two close
   // paths for this slot.
   useFocusTrap(open === "right-chat", rightChatRef, { onEscape: onClose });
+
+  // nav/list drawers previously had NO focus management beyond the legacy
+  // standalone Escape listener below — capture-on-open/restore-on-close and
+  // Tab containment reuse the SAME shared hook right-chat and Modal already
+  // use (cave-rl980 Task 5 finding). Deliberately NOT given an `onEscape`
+  // here: nav/list keep Escape owned by the legacy listener below exactly as
+  // before (unlike right-chat, which owns Escape solely through its own
+  // trap), so this addition changes nothing about WHEN nav/list dismiss —
+  // only that every dismissal path (Escape, the backdrop button, or any
+  // other programmatic close) now restores focus to whatever opened the
+  // drawer, and Tab stays contained inside it while open. Also deliberately
+  // NOT given role="dialog"/aria-modal — nav/list are persistent shell
+  // landmarks that merely slide over content at mobile widths, not
+  // transient dialogs, so only this BEHAVIORAL trap is reused, never modal
+  // semantics.
+  useFocusTrap(open === "nav", navContainerRef);
+  useFocusTrap(open === "list", listContainerRef);
 
   useEffect(() => {
     if (!open) return;

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -14,17 +14,27 @@
 //      instantly; an ordinary back with no removal signal (e.g. a
 //      transcript-load-failure "Back to sessions") clears the stale
 //      selection immediately even though the session remains eligible; a
-//      discarded pre-roster promoted/voice session — which reports the same
-//      onSessionRemoved-then-null shape as a confirmed removal, but was
-//      never observed in the eligible roster — clears instead of leaving a
-//      permanent ghost; and a generic, non-removal onSessionsChanged (a
-//      refresh unrelated to this session, e.g. a canonical-session
-//      reconcile) followed by an ordinary null must still clear — never
-//      retain — since onSessionsChanged is no longer treated as a removal
-//      signal on its own.
-//   2. a familiar change is tracked even while the panel is closed: a closed
-//      A -> B -> A sequence re-resolves A, and reopening finds the header and
-//      the router already agreeing, with no extra resolution needed.
+//      generic, non-removal onSessionsChanged (a refresh unrelated to this
+//      session, e.g. a canonical-session reconcile) followed by an ordinary
+//      null must still clear — never retain — since onSessionsChanged is no
+//      longer treated as a removal signal on its own.
+//   1c. onSessionRemoved is authoritative regardless of observed-ID
+//      membership (cave-rl980 Task 4 spec review): a promoted/voice session
+//      discarded before the roster ever caught up to it still arms removal
+//      reconciliation as long as it matches the current selection/familiar —
+//      it reopens the familiar's next newest eligible session when one
+//      exists, or a blank familiar-bound compose when none does, instead of
+//      leaving a permanent ghost. The observed-ID gate is kept only for the
+//      DIFFERENT, unsignaled case: an ordinary roster refresh where an id
+//      merely hasn't appeared yet (a promotion race with no removal signal).
+//   2. first-open semantics (cave-rl980 Task 4 spec review): a familiar
+//      transition is tracked even while the panel is closed — a closed
+//      A -> B -> A sequence is still detected as needing a fresh resolve —
+//      but the actual resolve (router call + selection) is deferred until
+//      the panel actually reopens, against then-current sessions, so a
+//      session that arrives while still closed is what first open selects,
+//      never a stale earlier snapshot. A same-familiar close/reopen (no
+//      transition) preserves a manual thread selection exactly as before.
 //   3. an open familiar switch issues exactly one imperative openSession/
 //      newChat call — never a second one caused by the outgoing familiar's
 //      stale selection being compared against the new familiar's roster.
@@ -388,7 +398,7 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(router.calls.openSession.length).toBe(openSessionCallsSoFar);
   });
 
-  test("a discarded pre-roster promoted/voice session clears instead of leaving a permanent ghost", async () => {
+  test("a discarded pre-roster promoted/voice session with no other eligible session clears to a blank compose instead of leaving a permanent ghost", async () => {
     const cody = familiar("cody", "Cody");
     // No eligible session at all: initial resolution opens a blank compose.
     let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [] });
@@ -407,25 +417,63 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     // session server-side, refreshes the list (onSessionsChanged), reports
     // the narrow onSessionRemoved("discarded") signal, and only THEN reports
     // onVoiceSessionDiscarded (surfaced here as the resulting null) — the
-    // same order a confirmed archive/delete uses. Unlike those, this id was
-    // NEVER observed in the eligible roster (sessions stays empty: the
-    // session never really existed from the roster's point of view), so
-    // handleSessionRemoved's own observed-gate refuses to arm retention at
-    // all, and it must clear immediately rather than retain — retaining
-    // would leave a permanent ghost, since the reconcile branch could never
-    // confirm removal of an id the roster never listed to begin with.
+    // same order a confirmed archive/delete uses. This id was NEVER observed
+    // in the eligible roster (sessions stays empty: the session never really
+    // existed from the roster's point of view) — but onSessionRemoved is
+    // authoritative on its own (cave-rl980 Task 4 spec review), regardless of
+    // observed-ID membership, so it still arms retention. Since there is no
+    // future "roster confirms removal" transition to wait for an id that was
+    // never eligible to begin with, handleActiveSessionChange resolves a
+    // replacement immediately instead of waiting — and here there is no
+    // other eligible session for cody, so it falls back to a blank
+    // familiar-bound compose rather than leaving a permanent ghost.
     await act(async () => {
       (router.latestProps!.onSessionsChanged as () => void)();
       (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-voice-ghost", "discarded");
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("new"); // cleared, not stuck on cody-voice-ghost
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "cody"]);
 
     // Prove there's no lingering ghost: further renders with the same
     // (still empty) roster must never resurrect or reconcile toward it.
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("new");
     expect(router.calls.openSession.some((call) => call[0] === "cody-voice-ghost")).toBe(false);
+  });
+
+  test("an explicit removal of a session promoted before ever appearing in the roster reopens an older eligible replacement instead of a permanent ghost", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [older] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-older");
+
+    // ChatRouter promotes a brand-new session the `sessions` roster prop
+    // has NOT been refetched to include yet.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)("cody-promoted");
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-promoted");
+
+    // The promoted session is discarded before the roster ever caught up to
+    // it — same onSessionRemoved-then-null order a confirmed archive/delete
+    // uses, but this id was NEVER observed eligible (`sessions` never
+    // included it). Unlike the no-other-session case above, cody's older
+    // session IS still eligible: onSessionRemoved is authoritative regardless
+    // of observed-ID membership (cave-rl980 Task 4 spec review), so the
+    // removal is trusted immediately — and since there is no future "roster
+    // confirms removal" transition to wait for an id that was never eligible
+    // to begin with, the familiar's next newest eligible session reopens
+    // right away instead of leaving the header on a ghost forever.
+    await act(async () => {
+      (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-promoted", "discarded");
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-older");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-older");
+    expect(router.calls.openSession.some((call) => call[0] === "cody-promoted")).toBe(false);
   });
 });
 
@@ -566,8 +614,8 @@ describe("async removal race: a stale archive/delete/discard completion after sw
   });
 });
 
-describe("familiar transitions are tracked deterministically even while the panel is closed (fix 2)", () => {
-  test("a closed A -> B -> A familiar sequence re-resolves A and leaves the header and router already agreeing by the time the panel reopens", async () => {
+describe("first-open semantics: transitions are tracked while closed, but resolution is deferred until the panel actually opens (fix 2, cave-rl980 Task 4 spec review)", () => {
+  test("a closed A -> B -> A familiar sequence tracks every transition without resolving, then re-resolves A fresh the instant the panel reopens", async () => {
     const cody = familiar("cody", "Cody");
     const nova = familiar("nova", "Nova");
     const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
@@ -575,6 +623,7 @@ describe("familiar transitions are tracked deterministically even while the pane
     let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession, novaSession] });
     const renderer = await renderPanel(props);
     expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const callsAfterInitialResolve = router.calls.openSession.length + router.calls.newChat.length;
 
     // Close the panel — ChatRouter/ChatView stay mounted underneath as a
     // persistent controller (per the design doc); only visibility changes.
@@ -582,24 +631,59 @@ describe("familiar transitions are tracked deterministically even while the pane
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("cody-1"); // closing alone changes nothing
 
-    // The active familiar changes twice while the panel is hidden.
+    // The active familiar changes twice while the panel is hidden. Never
+    // resolve while closed (cave-rl980 Task 4 spec review): first-open
+    // semantics require resolving against whichever session is newest at the
+    // moment the panel actually becomes visible, not whatever existed at
+    // some earlier, invisible instant — so neither transition issues a
+    // router call, even though each is still tracked (the selection clears
+    // rather than staying pointed at a now-stale familiar's session).
     props = { ...props, activeFamiliar: nova };
     await update(renderer, props);
-    expect(sessionIdAttr(renderer)).toBe("nova-1"); // tracked even while closed
-    expect(router.calls.openSession.at(-1)?.[0]).toBe("nova-1");
+    expect(sessionIdAttr(renderer)).toBe("new"); // tracked, not resolved, while closed
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve);
 
     props = { ...props, activeFamiliar: cody };
     await update(renderer, props);
-    expect(sessionIdAttr(renderer)).toBe("cody-1"); // re-resolved back to cody, still closed
-    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
+    expect(sessionIdAttr(renderer)).toBe("new"); // still tracked, still not resolved
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve);
 
-    // Reopen: the header and the router must already agree — no desync, and
-    // no extra resolution call is needed just to reveal the panel.
-    const callsBeforeReopen = router.calls.openSession.length + router.calls.newChat.length;
+    // Reopen: the closed A -> B -> A round trip must still be detected as
+    // needing a fresh resolve — never mistaken for "still the same,
+    // already-resolved cody" just because activeFamiliar reads "cody" again
+    // — so exactly one new resolution call fires now, against the CURRENT
+    // sessions, landing back on cody-1.
     props = { ...props, open: true };
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("cody-1");
-    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBeforeReopen);
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve + 1);
+  });
+
+  test("a newer session arriving before the panel's first open is what first open selects, not a stale earlier snapshot", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ open: false, activeFamiliar: cody, familiars: [cody], sessions: [older] });
+    const renderer = await renderPanel(props);
+
+    // Never opened yet: no resolution has happened at all.
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(0);
+    expect(sessionIdAttr(renderer)).toBe("new");
+
+    // A newer session arrives while the panel is still closed.
+    const newer = sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
+    props = { ...props, sessions: [older, newer] };
+    await update(renderer, props);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(0); // still closed: still no resolution
+    expect(sessionIdAttr(renderer)).toBe("new");
+
+    // First open: must resolve against the sessions that exist NOW, not
+    // whatever existed at mount — so it selects cody-newer, never cody-older.
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-newer");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-newer");
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(1);
   });
 });
 

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -1,0 +1,420 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention in
+// chat-title-sparkle-behavior.test.tsx and workspace-canonical-memory-navigation-behavior.test.tsx.
+//
+// Behavioral companion to right-chat-panel.test.ts. That file pins the source
+// contract with fast text assertions; this file actually mounts the panel
+// (ChatRouter mocked to a thin imperative-handle stub, so we exercise
+// RightChatPanel's own session-selection logic in isolation) to prove the
+// five cave-rl980 Task 4 review fixes behave, not just that certain
+// substrings exist in source:
+//   1. a promotion race never misclassifies a brand-new session as deleted,
+//      and an organic null retains the prior selection until the roster
+//      confirms removal — while an explicit New chat still clears instantly.
+//   2. a transient roster error keeps an already-resolved ChatRouter mounted,
+//      and never marks a not-yet-mounted ("null") router resolved.
+//   3. every loading/error/chooser state exposes a working Close action.
+//   4. the familiar chooser only offers the filtered, resolved roster.
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+const router = vi.hoisted(() => ({
+  calls: {
+    openSession: [] as unknown[][],
+    newChat: [] as unknown[][],
+  },
+  latestProps: null as Record<string, unknown> | null,
+  reset() {
+    this.calls.openSession = [];
+    this.calls.newChat = [];
+    this.latestProps = null;
+  },
+}));
+
+// A thin stand-in for the real (982-line) ChatRouter: exposes the same
+// imperative handle shape, records every openSession/newChat call, and hands
+// the test direct access to the latest onActiveSessionChange callback so it
+// can simulate what the real router reports (promotions, organic nulls)
+// without re-implementing its internal view state machine. This suite is
+// about RightChatPanel's own session-selection contract, not ChatRouter's.
+vi.mock("@/components/chat-router", async () => {
+  const { forwardRef, useImperativeHandle } = await import("react");
+  const ChatRouter = forwardRef(function MockChatRouter(props: Record<string, unknown>, ref: unknown) {
+    router.latestProps = props;
+    useImperativeHandle(ref, () => ({
+      goToList: () => {},
+      newChat: (...args: unknown[]) => {
+        router.calls.newChat.push(args);
+      },
+      openSession: (...args: unknown[]) => {
+        router.calls.openSession.push(args);
+      },
+      openSessionInSplit: () => {},
+      currentSessionId: () => null,
+      clearTranscript: () => {},
+      runSlash: () => {},
+    }));
+    return null;
+  });
+  return { ChatRouter };
+});
+
+vi.mock("@/components/familiar-avatar", () => ({
+  FamiliarAvatar: () => null,
+}));
+
+vi.mock("@/components/ui/live-region", () => ({
+  useAnnouncer: () => ({ announce: vi.fn() }),
+}));
+
+const archivedIds = vi.hoisted(() => new Set<string>());
+// A stand-in for the real resolver: filters out "archived" familiars exactly
+// like useResolvedFamiliars does with includeArchived defaulting to false,
+// without needing the real hook's overrides/images/order dependencies.
+vi.mock("@/lib/familiar-resolve", () => ({
+  useResolvedFamiliars: (familiars: Array<{ id: string; display_name: string }>) =>
+    familiars.filter((familiar) => !archivedIds.has(familiar.id)).map((familiar) => ({ ...familiar })),
+}));
+
+import { Button } from "@/components/ui/button";
+import { ChatRouter as MockChatRouter } from "@/components/chat-router";
+import { RightChatPanel } from "./right-chat-panel";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function familiar(id: string, display_name = id) {
+  return { id, display_name, role: "familiar" };
+}
+
+function sessionRow(
+  id: string,
+  overrides: { familiarId: string; created_at: string; updated_at: string } & Record<string, unknown>,
+) {
+  return {
+    id,
+    project_root: "/work/right-chat",
+    harness: "codex",
+    title: id,
+    status: "completed",
+    exit_code: null,
+    archived_at: null,
+    attention: { state: "none", since: null, reason: null },
+    origin: "chat",
+    hasLocalConversation: false,
+    ...overrides,
+  };
+}
+
+function baseProps(overrides: Record<string, unknown> = {}) {
+  const cody = familiar("cody", "Cody");
+  return {
+    open: true,
+    familiars: [cody],
+    activeFamiliar: cody,
+    sessions: [],
+    sessionsLoaded: true,
+    sessionsError: false,
+    familiarsLoaded: true,
+    familiarsError: null as string | null,
+    daemonRunning: true,
+    onClose: vi.fn(),
+    onSetActiveFamiliar: vi.fn(),
+    onRetryFamiliars: vi.fn(),
+    onRetrySessions: vi.fn(),
+    onSessionStarted: vi.fn(),
+    onSessionsChanged: vi.fn(),
+    onSessionsDeleted: vi.fn(),
+    onSlashFromChat: vi.fn(),
+    onOpenOnboarding: vi.fn(),
+    onOpenTask: vi.fn(),
+    onOpenUrl: vi.fn(),
+    ...overrides,
+  };
+}
+
+async function renderPanel(props: Record<string, unknown>) {
+  let renderer!: ReactTestRenderer;
+  await act(async () => {
+    renderer = create(<RightChatPanel {...(props as never)} />);
+  });
+  return renderer;
+}
+
+async function update(renderer: ReactTestRenderer, props: Record<string, unknown>) {
+  await act(async () => {
+    renderer.update(<RightChatPanel {...(props as never)} />);
+  });
+}
+
+function sessionIdAttr(renderer: ReactTestRenderer): string | null {
+  return renderer.root.findByType("aside" as never).props["data-session-id"] ?? null;
+}
+
+function findByAria(renderer: ReactTestRenderer, label: string) {
+  return renderer.root.find((node) => node.type === "button" && node.props["aria-label"] === label);
+}
+
+beforeEach(() => {
+  router.reset();
+});
+
+afterEach(() => {
+  archivedIds.clear();
+});
+
+test("initial resolve opens the active familiar's newest eligible session", async () => {
+  const cody = familiar("cody", "Cody");
+  const sessions = [
+    sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" }),
+    sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" }),
+  ];
+  const renderer = await renderPanel(baseProps({ activeFamiliar: cody, familiars: [cody], sessions }));
+
+  expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-newer");
+  expect(sessionIdAttr(renderer)).toBe("cody-newer");
+});
+
+describe("promotion race (fix 1: a newly promoted session is never misclassified as deleted)", () => {
+  test("a promoted session id absent from the sessions prop is retained, not replaced, until the roster refresh", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-old", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [older] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-old");
+
+    // ChatRouter promotes a brand-new session the `sessions` roster prop
+    // hasn't been refetched to include yet.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)("cody-promoted");
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-promoted");
+    const callsSoFar = router.calls.openSession.length + router.calls.newChat.length;
+
+    // Re-render with the *same*, still-stale roster — must not be treated as
+    // a deletion (no extra openSession/newChat, selection unchanged).
+    await update(renderer, props);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsSoFar);
+    expect(sessionIdAttr(renderer)).toBe("cody-promoted");
+
+    // Roster refreshes to include the promoted session: still no extra
+    // reconciliation call, since it is now legitimately eligible.
+    props = { ...props, sessions: [older, sessionRow("cody-promoted", { familiarId: "cody", created_at: "2026-01-02T00:00:00.000Z", updated_at: "2026-01-02T00:00:00.000Z" })] };
+    await update(renderer, props);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsSoFar);
+    expect(sessionIdAttr(renderer)).toBe("cody-promoted");
+
+    // Only *after* having been observed eligible does a genuine removal
+    // (e.g. deleted) correctly fall back to the remaining session.
+    props = { ...props, sessions: [older] };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-old");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-old");
+  });
+});
+
+describe("archive/back null retention (fix 1: organic nulls keep prior selection state)", () => {
+  test("an organic null retains the current selection, then resolves to the familiar's next session once the roster confirms removal", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const newer = sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [older, newer] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-newer");
+
+    // Simulates ChatRouter's onBack firing after an in-place archive — no
+    // explicit RightChatPanel action preceded this.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-newer"); // retained, not cleared
+    expect(router.calls.newChat.length).toBe(0);
+
+    // Roster refresh confirms cody-newer is actually gone.
+    props = { ...props, sessions: [older] };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-older");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-older");
+  });
+
+  test("an organic null resolves to a blank familiar-bound compose when no eligible session remains", async () => {
+    const cody = familiar("cody", "Cody");
+    const only = sessionRow("cody-only", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [only] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-only");
+
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-only");
+
+    props = { ...props, sessions: [] };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "cody"]);
+  });
+
+  test("an explicit New chat click still clears the selection immediately, unaffected by null retention", async () => {
+    const cody = familiar("cody", "Cody");
+    const only = sessionRow("cody-only", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [only] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-only");
+
+    const newChatButton = findByAria(renderer, "New Chat panel chat");
+    await act(async () => {
+      newChatButton.props.onClick();
+    });
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "cody"]);
+
+    // The router's own later echo of this exact transition must not disturb
+    // the already-cleared selection.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("new");
+  });
+});
+
+describe("transient roster errors keep a resolved router mounted (fix 2)", () => {
+  test("a transient sessions error keeps an already-resolved ChatRouter mounted and offers an inline retry", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
+    const renderer = await renderPanel(props);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    props = { ...props, sessionsError: true };
+    await update(renderer, props);
+
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1); // still mounted
+    expect(sessionIdAttr(renderer)).toBe("cody-1"); // selection undisturbed
+    expect(findByAria(renderer, "Close Chat panel")).toBeTruthy();
+    const retryButtons = renderer.root
+      .findAllByType(Button)
+      .filter((node) => node.props.children === "Retry" && node.props.onClick === props.onRetrySessions);
+    expect(retryButtons.length).toBeGreaterThan(0);
+
+    props = { ...props, sessionsError: false };
+    await update(renderer, props);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1);
+  });
+
+  test("a transient familiars error keeps an already-resolved ChatRouter mounted and offers an inline retry", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
+    const renderer = await renderPanel(props);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1);
+
+    props = { ...props, familiarsError: "network blip" };
+    await update(renderer, props);
+
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1); // still mounted
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const retryButtons = renderer.root
+      .findAllByType(Button)
+      .filter((node) => node.props.children === "Retry" && node.props.onClick === props.onRetryFamiliars);
+    expect(retryButtons.length).toBeGreaterThan(0);
+  });
+
+  test("a familiars error before first resolution blocks rendering and never marks a null router resolved", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions, familiarsError: "network down" });
+    const renderer = await renderPanel(props);
+
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(0);
+    expect(router.calls.openSession).toHaveLength(0);
+    expect(router.calls.newChat).toHaveLength(0);
+    expect(findByAria(renderer, "Close Chat panel")).toBeTruthy();
+
+    // Clearing the error must trigger the real first resolution — it must
+    // NOT have been silently marked resolved while the router was null.
+    props = { ...props, familiarsError: null };
+    await update(renderer, props);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1);
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
+  });
+});
+
+describe("every loading/error/chooser state exposes a discoverable Close action (fix 3)", () => {
+  test("loading", async () => {
+    const onClose = vi.fn();
+    const renderer = await renderPanel(baseProps({ familiarsLoaded: false, onClose }));
+    await act(async () => {
+      findByAria(renderer, "Close Chat panel").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("familiars error", async () => {
+    const onClose = vi.fn();
+    const renderer = await renderPanel(baseProps({ familiarsError: "boom", onClose }));
+    await act(async () => {
+      findByAria(renderer, "Close Chat panel").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("no active familiar chooser", async () => {
+    const onClose = vi.fn();
+    const renderer = await renderPanel(baseProps({ activeFamiliar: null, onClose }));
+    await act(async () => {
+      findByAria(renderer, "Close Chat panel").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("sessions error before first resolution", async () => {
+    const onClose = vi.fn();
+    const renderer = await renderPanel(baseProps({ sessionsError: true, onClose }));
+    await act(async () => {
+      findByAria(renderer, "Close Chat panel").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test("fully resolved chat", async () => {
+    const onClose = vi.fn();
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    const renderer = await renderPanel(baseProps({ activeFamiliar: cody, familiars: [cody], sessions, onClose }));
+    await act(async () => {
+      findByAria(renderer, "Close Chat panel").props.onClick();
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("the familiar chooser uses the filtered resolved roster (fix 4)", () => {
+  test("an archived/hidden familiar is absent from the chooser and cannot be selected", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    archivedIds.add("nova");
+    const onSetActiveFamiliar = vi.fn();
+    const renderer = await renderPanel(
+      baseProps({ activeFamiliar: null, familiars: [cody, nova], onSetActiveFamiliar }),
+    );
+
+    // Button renders a spinner <span> alongside its text children, so only
+    // the string entries make up the visible label.
+    const buttonText = (node: { children: unknown[] }) =>
+      node.children.filter((child): child is string => typeof child === "string").join("");
+    const chooserButtons = renderer.root.findAll(
+      (node) => node.type === "button" && node.props["aria-label"] !== "Close Chat panel",
+    );
+    const visibleNames = chooserButtons.map(buttonText);
+    expect(visibleNames).toContain("Cody");
+    expect(visibleNames).not.toContain("Nova");
+
+    const codyButton = renderer.root.find(
+      (node) => node.type === "button" && buttonText(node) === "Cody",
+    );
+    await act(async () => {
+      codyButton.props.onClick();
+    });
+    expect(onSetActiveFamiliar).toHaveBeenCalledWith("cody");
+  });
+});

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -118,6 +118,7 @@ vi.mock("@/lib/familiar-resolve", () => ({
 }));
 
 import { Button } from "@/components/ui/button";
+import { StandardSelect } from "@/components/ui/select";
 import { ChatRouter as MockChatRouter } from "@/components/chat-router";
 import { RightChatPanel } from "./right-chat-panel";
 
@@ -195,8 +196,12 @@ function findByAria(renderer: ReactTestRenderer, label: string) {
   return renderer.root.find((node) => node.type === "button" && node.props["aria-label"] === label);
 }
 
+/** The header's thread switcher. It is the design system's StandardSelect,
+ *  not a native `<select>` (`components/no-native-select`), so it is located
+ *  by component type and driven through the primitive's `onChange(value)`
+ *  contract rather than a DOM change event. */
 function threadSwitcher(renderer: ReactTestRenderer) {
-  return renderer.root.findByType("select" as never);
+  return renderer.root.findByType(StandardSelect);
 }
 
 /** The single `<aside>` root every render path shares (RightChatPanelFrame's
@@ -602,7 +607,7 @@ describe("async removal race: a stale archive/delete/discard completion after sw
     // bypasses handleSessionRemoved entirely, exactly like a real manual
     // pick (see the "explicit New chat" test above for the same bypass).
     await act(async () => {
-      threadSwitcher(renderer).props.onChange({ currentTarget: { value: "cody-t" } });
+      threadSwitcher(renderer).props.onChange("cody-t");
     });
     expect(sessionIdAttr(renderer)).toBe("cody-t");
     expect(headerTitle(renderer)).toBe("cody-t");

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -35,13 +35,27 @@
 //      session that arrives while still closed is what first open selects,
 //      never a stale earlier snapshot. A same-familiar close/reopen (no
 //      transition) preserves a manual thread selection exactly as before.
+//      Identity tracking/invalidation happens before the loading/error
+//      readiness guard, not merged with it (cave-rl980 Task 4 review): a
+//      closed A -> B -> A round trip that happens entirely while a roster
+//      error is active throughout is still tracked, so recovering and
+//      reopening re-resolves A fresh instead of retaining a stale,
+//      never-invalidated original resolution.
 //   3. an open familiar switch issues exactly one imperative openSession/
 //      newChat call — never a second one caused by the outgoing familiar's
 //      stale selection being compared against the new familiar's roster.
 //   4. a transient roster error keeps an already-resolved ChatRouter mounted,
 //      and never marks a not-yet-mounted ("null") router resolved.
-//   5. every loading/error/chooser state exposes a working Close action.
-//   6. the familiar chooser only offers the filtered, resolved roster.
+//   5. applied-session-scope contract (cave-rl980 Task 4 review): a familiar
+//      switch never resolves against another familiar's still-in-flight
+//      sessions roster (sessions/sessionsScopeFamiliarId still naming the
+//      OUTGOING familiar) — no early blank compose, no stale other-familiar
+//      session — and resolves exactly once, correctly, the instant the
+//      caller confirms the roster now corresponds to the new familiar.
+//      Omitting sessionsScopeFamiliarId entirely preserves the pre-scope-
+//      aware contract for every caller that hasn't adopted it yet.
+//   6. every loading/error/chooser state exposes a working Close action.
+//   7. the familiar chooser only offers the filtered, resolved roster.
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -685,6 +699,55 @@ describe("first-open semantics: transitions are tracked while closed, but resolu
     expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-newer");
     expect(router.calls.openSession.length + router.calls.newChat.length).toBe(1);
   });
+
+  test("closed A -> B -> A while roster errors are active throughout tracks every transition despite the errors; recovering and reopening re-resolves A fresh instead of retaining the stale, never-invalidated original resolution (cave-rl980 Task 4 review)", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const novaSession = sessionRow("nova-1", { familiarId: "nova", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession, novaSession] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const callsAfterInitialResolve = router.calls.openSession.length + router.calls.newChat.length;
+
+    // Close the panel and a sessions-roster error begins — and stays active
+    // for the ENTIRE A -> B -> A round trip below. Identity tracking must
+    // happen before the loading/error readiness guard (cave-rl980 Task 4
+    // review): if the guard suppressed the whole effect body — tracking
+    // included — for this entire stretch, trackedFamiliarIdRef would never
+    // advance past the ORIGINAL cody, and the later return to cody would be
+    // mistaken for "nothing changed".
+    props = { ...props, open: false, sessionsError: true };
+    await update(renderer, props);
+
+    // Switch to nova — still closed, still erroring.
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve); // no resolve attempted while erroring
+
+    // Switch back to cody — STILL closed, STILL erroring the entire time.
+    props = { ...props, activeFamiliar: cody };
+    await update(renderer, props);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve); // still no resolve attempted
+
+    // The error clears while still closed. The round trip must have been
+    // tracked as a real transition throughout — proven here by the
+    // selection reading as unresolved ("new"), not the ORIGINAL cody-1 a
+    // never-invalidated resolvedFamiliarRef would still (wrongly) trust.
+    props = { ...props, sessionsError: false };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new"); // invalidated, not stale cody-1 — proves the transition was tracked despite the error
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve); // still deferred: the panel is still closed
+
+    // Reopen: must re-resolve cody fresh, against the CURRENT sessions —
+    // exactly one new resolution call, never zero (zero would mean the
+    // stale, never-invalidated original resolution was silently retained).
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsAfterInitialResolve + 1);
+  });
 });
 
 describe("familiar transitions issue exactly one imperative action (fix 3: no double resolution from stale selection)", () => {
@@ -725,6 +788,101 @@ describe("familiar transitions issue exactly one imperative action (fix 3: no do
     expect(sessionIdAttr(renderer)).toBe("new");
     expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "nova"]);
     expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore + 1);
+  });
+});
+
+describe("applied-session-scope contract: a familiar switch never resolves against another familiar's still-in-flight sessions roster (fix 5, cave-rl980 Task 4 review)", () => {
+  test("switching to B while `sessions` still reflects A's scoped roster defers resolution until B's roster is applied, then resolves exactly once to B's real newest session", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    // Workspace's session list is fetched scoped to a single active familiar
+    // (loadSessions in workspace.tsx) -- `sessions` only ever holds ONE
+    // familiar's rows at a time in practice, not a combined multi-familiar
+    // array. sessionsScopeFamiliarId names which familiar it currently is.
+    let props = baseProps({
+      activeFamiliar: cody,
+      familiars: [cody, nova],
+      sessions: [codySession],
+      sessionsScopeFamiliarId: "cody",
+    });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const callsBefore = router.calls.openSession.length + router.calls.newChat.length;
+
+    // The user switches to nova. `activeFamiliar` flips immediately, but
+    // Workspace's own refetch for nova's roster hasn't resolved yet: both
+    // `sessions` and the scope prop still name cody -- the exact race the
+    // applied-scope contract exists to close.
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+
+    // No early resolution: no old cody-1 session mistakenly kept under
+    // nova's identity, and no premature blank compose opened for nova either
+    // -- the panel renders its own blocked frame (no data-session-id, no
+    // mounted router) instead of guessing.
+    expect(sessionIdAttr(renderer)).toBe(null);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(0);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore);
+
+    // A stale re-render with the SAME unconfirmed scope (e.g. the 4s poll
+    // ticking before the switch-triggered refetch resolves) must not resolve
+    // early either.
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe(null);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore);
+
+    // Workspace's refetch for nova resolves: `sessions` now reflects nova's
+    // real roster, and the scope prop confirms it.
+    const novaSession = sessionRow("nova-1", { familiarId: "nova", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    props = { ...props, sessions: [novaSession], sessionsScopeFamiliarId: "nova" };
+    await update(renderer, props);
+
+    // Exactly one resolution now fires, correctly against nova's own data --
+    // never cody's stale row, never a blank compose nova didn't need.
+    expect(sessionIdAttr(renderer)).toBe("nova-1");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("nova-1");
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore + 1);
+  });
+
+  test("opening a familiar fresh while its sessions scope is not yet applied defers the blank-compose fallback until the roster confirms it truly has no eligible chat", async () => {
+    const nova = familiar("nova", "Nova");
+    // First activation: `sessions` is empty and the scope prop explicitly
+    // names no familiar yet (`null`) -- simulating Workspace's unscoped
+    // initial state before its familiar-scoped fetch has resolved.
+    let props = baseProps({
+      activeFamiliar: nova,
+      familiars: [nova],
+      sessions: [],
+      sessionsScopeFamiliarId: null,
+    });
+    const renderer = await renderPanel(props);
+
+    // Blocked: nothing has resolved, and no blank compose has been opened
+    // early against an unconfirmed, possibly-incomplete empty roster.
+    expect(sessionIdAttr(renderer)).toBe(null);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(0);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(0);
+
+    // The roster confirms nova truly has no eligible chat.
+    props = { ...props, sessionsScopeFamiliarId: "nova" };
+    await update(renderer, props);
+
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "nova"]);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(1);
+  });
+
+  test("omitting sessionsScopeFamiliarId entirely (Task 7 not wired yet) preserves the pre-scope-aware contract: resolution proceeds immediately, exactly like every other existing caller", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    // No sessionsScopeFamiliarId override at all -- baseProps leaves it
+    // undefined, matching a caller that hasn't adopted the contract.
+    const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
+    const renderer = await renderPanel(props);
+
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
   });
 });
 

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -8,19 +8,30 @@
 // cave-rl980 Task 4 review fixes behave, not just that certain substrings
 // exist in source:
 //   1. a promotion race never misclassifies a brand-new session as deleted.
-//   1b. a confirmed archive/delete (onSessionsChanged/onSessionsDeleted then
-//      a null) retains the prior selection until the roster confirms
-//      removal; an explicit New chat still clears instantly; an ordinary
-//      back with no removal mutation (e.g. a transcript-load-failure "Back
-//      to sessions") clears the stale selection immediately even though the
-//      session remains eligible; and a discarded pre-roster promoted/voice
-//      session — which reports the same onSessionsChanged-then-null shape as
-//      a confirmed removal, but was never observed in the eligible roster —
-//      clears instead of leaving a permanent ghost.
-//   2. a transient roster error keeps an already-resolved ChatRouter mounted,
+//   1b. a confirmed archive/delete/discard (ChatView's own narrow
+//      onSessionRemoved signal, then a null) retains the prior selection
+//      until the roster confirms removal; an explicit New chat still clears
+//      instantly; an ordinary back with no removal signal (e.g. a
+//      transcript-load-failure "Back to sessions") clears the stale
+//      selection immediately even though the session remains eligible; a
+//      discarded pre-roster promoted/voice session — which reports the same
+//      onSessionRemoved-then-null shape as a confirmed removal, but was
+//      never observed in the eligible roster — clears instead of leaving a
+//      permanent ghost; and a generic, non-removal onSessionsChanged (a
+//      refresh unrelated to this session, e.g. a canonical-session
+//      reconcile) followed by an ordinary null must still clear — never
+//      retain — since onSessionsChanged is no longer treated as a removal
+//      signal on its own.
+//   2. a familiar change is tracked even while the panel is closed: a closed
+//      A -> B -> A sequence re-resolves A, and reopening finds the header and
+//      the router already agreeing, with no extra resolution needed.
+//   3. an open familiar switch issues exactly one imperative openSession/
+//      newChat call — never a second one caused by the outgoing familiar's
+//      stale selection being compared against the new familiar's roster.
+//   4. a transient roster error keeps an already-resolved ChatRouter mounted,
 //      and never marks a not-yet-mounted ("null") router resolved.
-//   3. every loading/error/chooser state exposes a working Close action.
-//   4. the familiar chooser only offers the filtered, resolved roster.
+//   5. every loading/error/chooser state exposes a working Close action.
+//   6. the familiar chooser only offers the filtered, resolved roster.
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
@@ -219,7 +230,7 @@ describe("promotion race (fix 1: a newly promoted session is never misclassified
 });
 
 describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete retain, ordinary back/discard clear)", () => {
-  test("a confirmed archive (onSessionsChanged then null) retains the current selection, then resolves to the familiar's next session once the roster confirms removal", async () => {
+  test("a confirmed archive (onSessionsChanged, then onSessionRemoved, then null) retains the current selection, then resolves to the familiar's next session once the roster confirms removal", async () => {
     const cody = familiar("cody", "Cody");
     const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
     const newer = sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
@@ -227,15 +238,18 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     const renderer = await renderPanel(props);
     expect(sessionIdAttr(renderer)).toBe("cody-newer");
 
-    // Simulates ChatView's archiveChat: onSessionsChanged() then (via
-    // ChatRouter's onBack) a null — synchronously, same as the real order.
+    // Simulates ChatView's archiveChat: onSessionsChanged(), then the narrow
+    // onSessionRemoved("archived") signal, then (via ChatRouter's onBack) a
+    // null — synchronously, same as the real order. Retention is armed by
+    // onSessionRemoved, not by onSessionsChanged firing.
     await act(async () => {
       (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-newer", "archived");
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("cody-newer"); // retained, not cleared
     expect(router.calls.newChat.length).toBe(0);
-    expect(props.onSessionsChanged).toHaveBeenCalledTimes(1); // wrapper still forwards it
+    expect(props.onSessionsChanged).toHaveBeenCalledTimes(1); // forwarded unchanged to the real consumer
 
     // Roster refresh confirms cody-newer is actually gone.
     props = { ...props, sessions: [older] };
@@ -244,21 +258,23 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-older");
   });
 
-  test("a confirmed delete (onSessionsDeleted then null) resolves to a blank familiar-bound compose when no eligible session remains", async () => {
+  test("a confirmed delete (onSessionsDeleted, then onSessionRemoved, then null) resolves to a blank familiar-bound compose when no eligible session remains", async () => {
     const cody = familiar("cody", "Cody");
     const only = sessionRow("cody-only", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
     let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [only] });
     const renderer = await renderPanel(props);
     expect(sessionIdAttr(renderer)).toBe("cody-only");
 
-    // Simulates ChatView's deleteChat: onSessionsDeleted([id]) then (via
-    // ChatRouter's onBack) a null — synchronously, same as the real order.
+    // Simulates ChatView's deleteChat: onSessionsDeleted([id]), then the
+    // narrow onSessionRemoved("deleted") signal, then (via ChatRouter's
+    // onBack) a null — synchronously, same as the real order.
     await act(async () => {
       (router.latestProps!.onSessionsDeleted as (ids: readonly string[]) => void)(["cody-only"]);
+      (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-only", "deleted");
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("cody-only"); // retained until the roster confirms it
-    expect(props.onSessionsDeleted).toHaveBeenCalledWith(["cody-only"]); // wrapper still forwards it
+    expect(props.onSessionsDeleted).toHaveBeenCalledWith(["cody-only"]); // forwarded unchanged to the real consumer
 
     props = { ...props, sessions: [] };
     await update(renderer, props);
@@ -288,7 +304,7 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(sessionIdAttr(renderer)).toBe("new");
   });
 
-  test("an ordinary back with no removal mutation (e.g. 'Back to sessions' after a transcript load failure) clears the stale header immediately, even though the session remains eligible", async () => {
+  test("an ordinary back with no removal signal (e.g. 'Back to sessions' after a transcript load failure) clears the stale header immediately, even though the session remains eligible", async () => {
     const cody = familiar("cody", "Cody");
     const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
     const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
@@ -296,9 +312,9 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(sessionIdAttr(renderer)).toBe("cody-1");
 
     // ChatRouter's onBack fires with no preceding onSessionsChanged/
-    // onSessionsDeleted call — exactly what "Back to sessions" on a
-    // ChatHistoryNotice transcript-load failure does. cody-1 is still fully
-    // present in `sessions`: nothing was archived or deleted.
+    // onSessionsDeleted/onSessionRemoved call — exactly what "Back to
+    // sessions" on a ChatHistoryNotice transcript-load failure does. cody-1
+    // is still fully present in `sessions`: nothing was archived or deleted.
     await act(async () => {
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
@@ -310,6 +326,36 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
 
     // The session's continued eligibility must never resurrect it: a stale
     // roster re-render (unchanged sessions) must not reopen cody-1.
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.openSession.length).toBe(openSessionCallsSoFar);
+  });
+
+  test("a non-removal onSessionsChanged (e.g. an unrelated canonical-session refresh) followed by an ordinary null clears the selection instead of retaining it", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    // onSessionsChanged fires for plenty of reasons that have nothing to do
+    // with THIS session's removal — a live-generation stream settling, a
+    // Board handoff refresh, a *different* thread auto-archiving on
+    // reflection. It must never be treated as a removal signal on its own:
+    // only the dedicated onSessionRemoved callback may arm retention. So an
+    // ordinary null (no onSessionRemoved) that merely happens to follow one
+    // must still clear immediately, exactly like the no-signal-at-all case
+    // above.
+    await act(async () => {
+      (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+
+    expect(sessionIdAttr(renderer)).toBe("new"); // cleared, not retained
+    expect(props.onSessionsChanged).toHaveBeenCalledTimes(1); // still forwarded to the real consumer
+    const openSessionCallsSoFar = router.calls.openSession.length;
+
+    // No lingering retention: a stale roster re-render must not reopen cody-1.
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("new");
     expect(router.calls.openSession.length).toBe(openSessionCallsSoFar);
@@ -331,16 +377,19 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(sessionIdAttr(renderer)).toBe("cody-voice-ghost");
 
     // The call ends with nothing said: discardVoiceSessionIfEmpty deletes the
-    // session server-side, refreshes the list (onSessionsChanged), and only
-    // THEN reports onVoiceSessionDiscarded — the exact same onSessionsChanged
-    // -> null order a confirmed archive/delete uses. Unlike those, this id
-    // was NEVER observed in the eligible roster (sessions stays empty: the
-    // session never really existed from the roster's point of view), so it
-    // must clear immediately rather than retain — retaining would leave a
-    // permanent ghost, since the observed-gated reconcile effect could never
+    // session server-side, refreshes the list (onSessionsChanged), reports
+    // the narrow onSessionRemoved("discarded") signal, and only THEN reports
+    // onVoiceSessionDiscarded (surfaced here as the resulting null) — the
+    // same order a confirmed archive/delete uses. Unlike those, this id was
+    // NEVER observed in the eligible roster (sessions stays empty: the
+    // session never really existed from the roster's point of view), so
+    // handleSessionRemoved's own observed-gate refuses to arm retention at
+    // all, and it must clear immediately rather than retain — retaining
+    // would leave a permanent ghost, since the reconcile branch could never
     // confirm removal of an id the roster never listed to begin with.
     await act(async () => {
       (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-voice-ghost", "discarded");
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("new"); // cleared, not stuck on cody-voice-ghost
@@ -350,6 +399,84 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("new");
     expect(router.calls.openSession.some((call) => call[0] === "cody-voice-ghost")).toBe(false);
+  });
+});
+
+describe("familiar transitions are tracked deterministically even while the panel is closed (fix 2)", () => {
+  test("a closed A -> B -> A familiar sequence re-resolves A and leaves the header and router already agreeing by the time the panel reopens", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const novaSession = sessionRow("nova-1", { familiarId: "nova", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession, novaSession] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    // Close the panel — ChatRouter/ChatView stay mounted underneath as a
+    // persistent controller (per the design doc); only visibility changes.
+    props = { ...props, open: false };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1"); // closing alone changes nothing
+
+    // The active familiar changes twice while the panel is hidden.
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("nova-1"); // tracked even while closed
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("nova-1");
+
+    props = { ...props, activeFamiliar: cody };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1"); // re-resolved back to cody, still closed
+    expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-1");
+
+    // Reopen: the header and the router must already agree — no desync, and
+    // no extra resolution call is needed just to reveal the panel.
+    const callsBeforeReopen = router.calls.openSession.length + router.calls.newChat.length;
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBeforeReopen);
+  });
+});
+
+describe("familiar transitions issue exactly one imperative action (fix 3: no double resolution from stale selection)", () => {
+  test("an open A -> B familiar switch issues exactly one resolution call, never a second one from the outgoing familiar's stale selection", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const novaSession = sessionRow("nova-1", { familiarId: "nova", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession, novaSession] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const callsBefore = router.calls.openSession.length + router.calls.newChat.length;
+
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+
+    expect(sessionIdAttr(renderer)).toBe("nova-1");
+    // Exactly one imperative action for this transition. cody-1 (the
+    // outgoing familiar's now-stale selection) is never eligible for nova's
+    // roster and was already observed under cody — precisely the shape that
+    // would cause a second, redundant reconcile call if resolution were
+    // split across two separate effects instead of one.
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore + 1);
+  });
+
+  test("an open A -> B switch to a familiar with no eligible session issues exactly one newChat call", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    const callsBefore = router.calls.openSession.length + router.calls.newChat.length;
+
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "nova"]);
+    expect(router.calls.openSession.length + router.calls.newChat.length).toBe(callsBefore + 1);
   });
 });
 

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -171,6 +171,33 @@ function findByAria(renderer: ReactTestRenderer, label: string) {
   return renderer.root.find((node) => node.type === "button" && node.props["aria-label"] === label);
 }
 
+function threadSwitcher(renderer: ReactTestRenderer) {
+  return renderer.root.findByType("select" as never);
+}
+
+/** The header's own rendered title span (`<span title={title}>{title}</span>`
+ *  inside `.right-chat__identity`) — the "header" half of "T remains
+ *  active/header" (cave-rl980 Task 4 final review tests below), distinct
+ *  from `sessionIdAttr`'s router-selection check. */
+function headerTitle(renderer: ReactTestRenderer): string {
+  const node = renderer.root.find(
+    (n) => n.type === "span" && typeof n.props.title === "string",
+  );
+  return node.props.children as string;
+}
+
+/** Controllable stand-in for an in-flight archive/delete/discard request:
+ *  nothing below runs until the test calls `settle()`, so "begin removal on
+ *  S, switch to T, then resolve" is an explicit, deterministic sequence
+ *  instead of a timing assumption. */
+function deferred<T = void>() {
+  let settle!: (value: T) => void;
+  const promise = new Promise<T>((resolve) => {
+    settle = resolve;
+  });
+  return { promise, settle };
+}
+
 beforeEach(() => {
   router.reset();
 });
@@ -399,6 +426,143 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     await update(renderer, props);
     expect(sessionIdAttr(renderer)).toBe("new");
     expect(router.calls.openSession.some((call) => call[0] === "cody-voice-ghost")).toBe(false);
+  });
+});
+
+describe("async removal race: a stale archive/delete/discard completion after switching away must never clobber the newer selection (cave-rl980 Task 4 final review)", () => {
+  // ChatView's archiveChat/deleteChat/setChatArchived/discardVoiceSessionIfEmpty
+  // are all async: the specific onSessionRemoved/onActiveSessionChange
+  // instances they retain are whichever ones were current when the request
+  // BEGAN, frozen even if the user switches to a different thread or
+  // familiar before the request settles. handleSessionRemoved must consult
+  // the LIVE current selection (currentSelectionRef), not those frozen
+  // values — each test below captures the stale callbacks BEFORE switching,
+  // then only invokes them once a controllable promise (standing in for the
+  // real fetch) is manually settled AFTER the switch, so the ordering is
+  // explicit rather than assumed.
+  test("thread switch: an archive begun on S, then a switch to T before the PATCH settles, leaves T active in both the router selection and the header once the stale completion arrives", async () => {
+    const cody = familiar("cody", "Cody");
+    const s = sessionRow("cody-s", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const t = sessionRow("cody-t", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
+    const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [s, t] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-t"); // newest-first initial resolve
+
+    // Park the panel on S — the session the archive below targets.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)("cody-s");
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-s");
+    expect(headerTitle(renderer)).toBe("cody-s");
+
+    // Capture the exact onSessionRemoved instance ChatView's in-flight
+    // archiveChat(S) would retain right now — this is the object identity
+    // check that matters: a fresh (bug-fixed) call to router.latestProps
+    // after the switch below would read a DIFFERENT closure, but the real
+    // archiveChat call only ever holds the one it captured at its own start.
+    const staleOnSessionRemoved = router.latestProps!.onSessionRemoved as (id: string, reason: string) => void;
+    const archivePatch = deferred<void>();
+
+    // The user switches to a different thread (T) under the SAME familiar
+    // while the archive of S is still in flight — the thread switcher
+    // bypasses handleSessionRemoved entirely, exactly like a real manual
+    // pick (see the "explicit New chat" test above for the same bypass).
+    await act(async () => {
+      threadSwitcher(renderer).props.onChange({ currentTarget: { value: "cody-t" } });
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-t");
+    expect(headerTitle(renderer)).toBe("cody-t");
+
+    // The archive's PATCH settles now — late, after the user already left S
+    // — and fires the same onSessionRemoved(id, reason) archiveChat always
+    // fires on success, via the closure captured before the switch.
+    await act(async () => {
+      archivePatch.settle();
+      await archivePatch.promise;
+      staleOnSessionRemoved("cody-s", "archived");
+    });
+
+    // T must remain exactly where the user left it — both the router
+    // selection and the rendered header — untouched by S's now-irrelevant
+    // completion.
+    expect(sessionIdAttr(renderer)).toBe("cody-t");
+    expect(headerTitle(renderer)).toBe("cody-t");
+
+    // No stale reconciliation: the stale signal must not have left
+    // pendingRemovalRef incorrectly armed for T. Proven by a LATER, entirely
+    // unrelated ordinary null (T's own "Back to sessions" after a
+    // transcript-load failure, say) — an incorrect arm would retain T
+    // through the reconcile branch instead of clearing immediately, exactly
+    // like the "ordinary back" test above.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("new");
+  });
+
+  test("familiar switch: an archive begun on S, then a switch to a different familiar's thread T before the PATCH settles, leaves T active once the stale completion arrives", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-s", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const novaSession = sessionRow("nova-t", { familiarId: "nova", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody, nova], sessions: [codySession, novaSession] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-s");
+    expect(headerTitle(renderer)).toBe("cody-s");
+
+    const staleOnSessionRemoved = router.latestProps!.onSessionRemoved as (id: string, reason: string) => void;
+    const archivePatch = deferred<void>();
+
+    // The user switches to a DIFFERENT familiar (nova) while cody's S is
+    // still being archived — a real familiar switch, driven the same way
+    // the app drives it: the activeFamiliar prop changes from outside.
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("nova-t");
+    expect(headerTitle(renderer)).toBe("nova-t");
+
+    await act(async () => {
+      archivePatch.settle();
+      await archivePatch.promise;
+      staleOnSessionRemoved("cody-s", "archived");
+    });
+
+    // nova/T must remain exactly where the user left it.
+    expect(sessionIdAttr(renderer)).toBe("nova-t");
+    expect(headerTitle(renderer)).toBe("nova-t");
+
+    // No stale reconciliation leaking into nova's own state: an unrelated
+    // ordinary null on nova/T must still clear immediately.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("new");
+  });
+
+  test("a stale archive completion for the session that IS still selected still correctly retains it — the ref check is not a blanket refusal", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const s = sessionRow("cody-s", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [older, s] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-s");
+
+    const staleOnSessionRemoved = router.latestProps!.onSessionRemoved as (id: string, reason: string) => void;
+    const archivePatch = deferred<void>();
+
+    // No switch this time — the panel is still on cody-s when the archive
+    // settles, exactly like the existing non-deferred archive test above.
+    await act(async () => {
+      archivePatch.settle();
+      await archivePatch.promise;
+      staleOnSessionRemoved("cody-s", "archived");
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-s"); // retained, not cleared
+
+    props = { ...props, sessions: [older] };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("cody-older");
   });
 });
 

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -199,6 +199,22 @@ function threadSwitcher(renderer: ReactTestRenderer) {
   return renderer.root.findByType("select" as never);
 }
 
+/** The single `<aside>` root every render path shares (RightChatPanelFrame's
+ *  own aside for loading/error/chooser, or the fully resolved aside) — used
+ *  to check the persistent-root accessibility contract (fix 4, cave-rl980
+ *  Task 4 final review): truthfully out of the tab order/accessibility tree
+ *  while closed, without ever unmounting. */
+function panelRoot(renderer: ReactTestRenderer) {
+  return renderer.root.findByType("aside" as never);
+}
+
+/** Whether the render-blocking Loading frame (`role="status"`,
+ *  `right-chat__loading`) is currently showing — distinct from an
+ *  ErrorState/resolved render (fix 1, cave-rl980 Task 4 final review). */
+function isLoadingFrame(renderer: ReactTestRenderer): boolean {
+  return renderer.root.findAll((node) => node.props.className === "right-chat__loading").length > 0;
+}
+
 /** The header's own rendered title span (`<span title={title}>{title}</span>`
  *  inside `.right-chat__identity`) — the "header" half of "T remains
  *  active/header" (cave-rl980 Task 4 final review tests below), distinct
@@ -488,6 +504,62 @@ describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete re
     expect(sessionIdAttr(renderer)).toBe("cody-older");
     expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-older");
     expect(router.calls.openSession.some((call) => call[0] === "cody-promoted")).toBe(false);
+  });
+});
+
+describe("starting a new compose before the roster confirms a pending removal cancels the pending replacement (fix 2, cave-rl980 Task 4 final review)", () => {
+  // The retain-until-roster-confirms branch above intentionally holds a stale
+  // selection open across renders while awaiting confirmation. If the user
+  // starts a fresh compose in that window (e.g. from the router's own list
+  // view, reachable once onBack navigates there after the archive/delete —
+  // ChatList's "New chat", or any other compact/hideRail compose entry), the
+  // fixed ChatRouter reports null again via its composeInstance-aware change
+  // detection (see the reporting effect's doc in chat-router.tsx) even
+  // though the plain session-id value never changes (null -> null). That
+  // second report is simulated directly here, exactly like every other test
+  // in this file simulates ChatRouter's real reporting via
+  // onActiveSessionChange. Once it arrives, pendingRemovalRef has already
+  // been consumed by the FIRST report, so handleActiveSessionChange treats it
+  // as an ordinary null and clears the stale retained id — the fresh compose
+  // must then survive the roster's later confirmation instead of being
+  // clobbered by a resurrected replacement.
+  test("a new compose started while a confirmed archive still awaits roster confirmation clears the stale retained id, and the later roster confirmation does not resurrect a replacement over it", async () => {
+    const cody = familiar("cody", "Cody");
+    const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    const newer = sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [older, newer] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-newer");
+
+    // Archive begins on cody-newer -- same order as the confirmed-archive
+    // test above: onSessionsChanged, then the narrow onSessionRemoved signal,
+    // then (via ChatRouter's onBack) a null.
+    await act(async () => {
+      (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onSessionRemoved as (id: string, reason: string) => void)("cody-newer", "archived");
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-newer"); // retained, awaiting roster confirmation
+    expect(router.calls.newChat.length).toBe(0);
+
+    // BEFORE the roster confirms the removal, the user starts a fresh
+    // compose. sessionId stays null throughout (list -> compose), which is
+    // exactly why the fixed router's reporting must key on composeInstance,
+    // not just the session-id value, to notify RightChatPanel at all.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("new"); // the stale retained id is gone, cleared like any ordinary null
+    expect(router.calls.newChat.length).toBe(0); // cleared via the handler, not a second imperative call
+
+    // The roster now confirms cody-newer really is gone. The same-familiar
+    // reconcile branch must NOT resurrect a replacement over the user's
+    // fresh compose -- selectedSessionId is already null, so its own
+    // `if (!selectedSessionId) return;` guard bails immediately.
+    props = { ...props, sessions: [older] };
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new"); // still the user's fresh compose, not resurrected
+    expect(router.calls.openSession.some((call) => call[0] === "cody-older")).toBe(false);
   });
 });
 
@@ -886,6 +958,61 @@ describe("applied-session-scope contract: a familiar switch never resolves again
   });
 });
 
+describe("a stale applied-session-scope must not block indefinitely once the target familiar's own fetch has failed (fix 1, cave-rl980 Task 4 final review)", () => {
+  test("switching to nova while its sessions fetch has already failed (scope still unconfirmed) shows the explicit sessions ErrorState with Retry, not indefinite Loading", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({
+      activeFamiliar: cody,
+      familiars: [cody, nova],
+      sessions: [codySession],
+      sessionsScopeFamiliarId: "cody",
+    });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    // The user switches to nova. Workspace's own refetch for nova's scope
+    // fails outright (not merely slow) -- loadSessions only ever confirms a
+    // scope it successfully fetched, so sessionsScopeFamiliarId stays "cody"
+    // (stale) forever while sessionsError flips true for the failed attempt.
+    // Without the fix, the loading gate's scope clause would hold this at an
+    // indefinite spinner no future render could ever clear.
+    props = { ...props, activeFamiliar: nova, sessionsError: true };
+    await update(renderer, props);
+
+    expect(isLoadingFrame(renderer)).toBe(false);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(0);
+    const retryButtons = renderer.root
+      .findAllByType(Button)
+      .filter((node) => node.props.children === "Retry" && node.props.onClick === props.onRetrySessions);
+    expect(retryButtons.length).toBeGreaterThan(0);
+    expect(findByAria(renderer, "Close Chat panel")).toBeTruthy();
+  });
+
+  test("switching to nova while its sessions scope is merely still pending (no error yet) keeps showing Loading -- first-resolution safety is unaffected", async () => {
+    const cody = familiar("cody", "Cody");
+    const nova = familiar("nova", "Nova");
+    const codySession = sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
+    let props = baseProps({
+      activeFamiliar: cody,
+      familiars: [cody, nova],
+      sessions: [codySession],
+      sessionsScopeFamiliarId: "cody",
+    });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    // No sessionsError this time -- the refetch simply hasn't resolved yet.
+    props = { ...props, activeFamiliar: nova };
+    await update(renderer, props);
+
+    expect(isLoadingFrame(renderer)).toBe(true);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(0);
+    expect(renderer.root.findAllByType(Button).filter((node) => node.props.children === "Retry")).toHaveLength(0);
+  });
+});
+
 describe("transient roster errors keep a resolved router mounted (fix 2)", () => {
   test("a transient sessions error keeps an already-resolved ChatRouter mounted and offers an inline retry", async () => {
     const cody = familiar("cody", "Cody");
@@ -995,6 +1122,83 @@ describe("every loading/error/chooser state exposes a discoverable Close action 
       findByAria(renderer, "Close Chat panel").props.onClick();
     });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("persistent closed roots stay truthfully out of the tab order and accessibility tree without unmounting (fix 4, cave-rl980 Task 4 final review)", () => {
+  test("loading: aria-hidden/inert follow open, and the frame itself never unmounts across the toggle", async () => {
+    let props = baseProps({ familiarsLoaded: false, open: false });
+    const renderer = await renderPanel(props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(true);
+    expect(panelRoot(renderer).props.inert).toBe(true);
+    expect(isLoadingFrame(renderer)).toBe(true); // still mounted, merely inert
+
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+    expect(isLoadingFrame(renderer)).toBe(true);
+  });
+
+  test("familiars error: aria-hidden/inert follow open without disturbing the Retry action's presence", async () => {
+    let props = baseProps({ familiarsError: "boom", open: false });
+    const renderer = await renderPanel(props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(true);
+    expect(panelRoot(renderer).props.inert).toBe(true);
+    expect(renderer.root.findAllByType(Button).some((node) => node.props.children === "Retry")).toBe(true);
+
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+  });
+
+  test("no active familiar chooser: aria-hidden/inert follow open", async () => {
+    let props = baseProps({ activeFamiliar: null, open: false });
+    const renderer = await renderPanel(props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(true);
+    expect(panelRoot(renderer).props.inert).toBe(true);
+
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+  });
+
+  test("sessions error before first resolution: aria-hidden/inert follow open", async () => {
+    let props = baseProps({ sessionsError: true, open: false });
+    const renderer = await renderPanel(props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(true);
+    expect(panelRoot(renderer).props.inert).toBe(true);
+
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+  });
+
+  test("fully resolved chat: closing after resolution makes the root aria-hidden/inert without unmounting ChatRouter, so the resolved session/transcript/stream/draft survive the close", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions }); // open: true (baseProps default)
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+
+    props = { ...props, open: false };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(true);
+    expect(panelRoot(renderer).props.inert).toBe(true);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1); // still mounted while closed
+    expect(sessionIdAttr(renderer)).toBe("cody-1"); // the resolved selection survives the close
+
+    props = { ...props, open: true };
+    await update(renderer, props);
+    expect(panelRoot(renderer).props["aria-hidden"]).toBe(false);
+    expect(panelRoot(renderer).props.inert).toBe(false);
+    expect(renderer.root.findAllByType(MockChatRouter)).toHaveLength(1);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
   });
 });
 

--- a/src/components/right-chat-panel-behavior.test.tsx
+++ b/src/components/right-chat-panel-behavior.test.tsx
@@ -5,11 +5,18 @@
 // contract with fast text assertions; this file actually mounts the panel
 // (ChatRouter mocked to a thin imperative-handle stub, so we exercise
 // RightChatPanel's own session-selection logic in isolation) to prove the
-// five cave-rl980 Task 4 review fixes behave, not just that certain
-// substrings exist in source:
-//   1. a promotion race never misclassifies a brand-new session as deleted,
-//      and an organic null retains the prior selection until the roster
-//      confirms removal — while an explicit New chat still clears instantly.
+// cave-rl980 Task 4 review fixes behave, not just that certain substrings
+// exist in source:
+//   1. a promotion race never misclassifies a brand-new session as deleted.
+//   1b. a confirmed archive/delete (onSessionsChanged/onSessionsDeleted then
+//      a null) retains the prior selection until the roster confirms
+//      removal; an explicit New chat still clears instantly; an ordinary
+//      back with no removal mutation (e.g. a transcript-load-failure "Back
+//      to sessions") clears the stale selection immediately even though the
+//      session remains eligible; and a discarded pre-roster promoted/voice
+//      session — which reports the same onSessionsChanged-then-null shape as
+//      a confirmed removal, but was never observed in the eligible roster —
+//      clears instead of leaving a permanent ghost.
 //   2. a transient roster error keeps an already-resolved ChatRouter mounted,
 //      and never marks a not-yet-mounted ("null") router resolved.
 //   3. every loading/error/chooser state exposes a working Close action.
@@ -211,8 +218,8 @@ describe("promotion race (fix 1: a newly promoted session is never misclassified
   });
 });
 
-describe("archive/back null retention (fix 1: organic nulls keep prior selection state)", () => {
-  test("an organic null retains the current selection, then resolves to the familiar's next session once the roster confirms removal", async () => {
+describe("confirmed removal vs ordinary null (fix 1 follow-up: archive/delete retain, ordinary back/discard clear)", () => {
+  test("a confirmed archive (onSessionsChanged then null) retains the current selection, then resolves to the familiar's next session once the roster confirms removal", async () => {
     const cody = familiar("cody", "Cody");
     const older = sessionRow("cody-older", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
     const newer = sessionRow("cody-newer", { familiarId: "cody", created_at: "2026-01-05T00:00:00.000Z", updated_at: "2026-01-05T00:00:00.000Z" });
@@ -220,13 +227,15 @@ describe("archive/back null retention (fix 1: organic nulls keep prior selection
     const renderer = await renderPanel(props);
     expect(sessionIdAttr(renderer)).toBe("cody-newer");
 
-    // Simulates ChatRouter's onBack firing after an in-place archive — no
-    // explicit RightChatPanel action preceded this.
+    // Simulates ChatView's archiveChat: onSessionsChanged() then (via
+    // ChatRouter's onBack) a null — synchronously, same as the real order.
     await act(async () => {
+      (router.latestProps!.onSessionsChanged as () => void)();
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("cody-newer"); // retained, not cleared
     expect(router.calls.newChat.length).toBe(0);
+    expect(props.onSessionsChanged).toHaveBeenCalledTimes(1); // wrapper still forwards it
 
     // Roster refresh confirms cody-newer is actually gone.
     props = { ...props, sessions: [older] };
@@ -235,17 +244,21 @@ describe("archive/back null retention (fix 1: organic nulls keep prior selection
     expect(router.calls.openSession.at(-1)?.[0]).toBe("cody-older");
   });
 
-  test("an organic null resolves to a blank familiar-bound compose when no eligible session remains", async () => {
+  test("a confirmed delete (onSessionsDeleted then null) resolves to a blank familiar-bound compose when no eligible session remains", async () => {
     const cody = familiar("cody", "Cody");
     const only = sessionRow("cody-only", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" });
     let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [only] });
     const renderer = await renderPanel(props);
     expect(sessionIdAttr(renderer)).toBe("cody-only");
 
+    // Simulates ChatView's deleteChat: onSessionsDeleted([id]) then (via
+    // ChatRouter's onBack) a null — synchronously, same as the real order.
     await act(async () => {
+      (router.latestProps!.onSessionsDeleted as (ids: readonly string[]) => void)(["cody-only"]);
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
-    expect(sessionIdAttr(renderer)).toBe("cody-only");
+    expect(sessionIdAttr(renderer)).toBe("cody-only"); // retained until the roster confirms it
+    expect(props.onSessionsDeleted).toHaveBeenCalledWith(["cody-only"]); // wrapper still forwards it
 
     props = { ...props, sessions: [] };
     await update(renderer, props);
@@ -273,6 +286,70 @@ describe("archive/back null retention (fix 1: organic nulls keep prior selection
       (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
     });
     expect(sessionIdAttr(renderer)).toBe("new");
+  });
+
+  test("an ordinary back with no removal mutation (e.g. 'Back to sessions' after a transcript load failure) clears the stale header immediately, even though the session remains eligible", async () => {
+    const cody = familiar("cody", "Cody");
+    const sessions = [sessionRow("cody-1", { familiarId: "cody", created_at: "2026-01-01T00:00:00.000Z", updated_at: "2026-01-01T00:00:00.000Z" })];
+    const props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("cody-1");
+
+    // ChatRouter's onBack fires with no preceding onSessionsChanged/
+    // onSessionsDeleted call — exactly what "Back to sessions" on a
+    // ChatHistoryNotice transcript-load failure does. cody-1 is still fully
+    // present in `sessions`: nothing was archived or deleted.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+
+    expect(sessionIdAttr(renderer)).toBe("new"); // cleared immediately, not stuck on cody-1
+    expect(props.onSessionsChanged).not.toHaveBeenCalled();
+    expect(props.onSessionsDeleted).not.toHaveBeenCalled();
+    const openSessionCallsSoFar = router.calls.openSession.length; // includes the legitimate initial-resolve open
+
+    // The session's continued eligibility must never resurrect it: a stale
+    // roster re-render (unchanged sessions) must not reopen cody-1.
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.openSession.length).toBe(openSessionCallsSoFar);
+  });
+
+  test("a discarded pre-roster promoted/voice session clears instead of leaving a permanent ghost", async () => {
+    const cody = familiar("cody", "Cody");
+    // No eligible session at all: initial resolution opens a blank compose.
+    let props = baseProps({ activeFamiliar: cody, familiars: [cody], sessions: [] });
+    const renderer = await renderPanel(props);
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.newChat.at(-1)).toEqual([undefined, undefined, "cody"]);
+
+    // ChatRouter's onVoiceSessionCreated promotes null -> a brand-new session
+    // id the `sessions` roster prop has NOT been refetched to include yet.
+    await act(async () => {
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)("cody-voice-ghost");
+    });
+    expect(sessionIdAttr(renderer)).toBe("cody-voice-ghost");
+
+    // The call ends with nothing said: discardVoiceSessionIfEmpty deletes the
+    // session server-side, refreshes the list (onSessionsChanged), and only
+    // THEN reports onVoiceSessionDiscarded — the exact same onSessionsChanged
+    // -> null order a confirmed archive/delete uses. Unlike those, this id
+    // was NEVER observed in the eligible roster (sessions stays empty: the
+    // session never really existed from the roster's point of view), so it
+    // must clear immediately rather than retain — retaining would leave a
+    // permanent ghost, since the observed-gated reconcile effect could never
+    // confirm removal of an id the roster never listed to begin with.
+    await act(async () => {
+      (router.latestProps!.onSessionsChanged as () => void)();
+      (router.latestProps!.onActiveSessionChange as (id: string | null) => void)(null);
+    });
+    expect(sessionIdAttr(renderer)).toBe("new"); // cleared, not stuck on cody-voice-ghost
+
+    // Prove there's no lingering ghost: further renders with the same
+    // (still empty) roster must never resurrect or reconcile toward it.
+    await update(renderer, props);
+    expect(sessionIdAttr(renderer)).toBe("new");
+    expect(router.calls.openSession.some((call) => call[0] === "cody-voice-ghost")).toBe(false);
   });
 });
 

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -384,6 +384,38 @@ assert.match(
   "the fully resolved aside applies the same truthful aria-hidden/inert pairing",
 );
 
+// cave-rl980 Task 5 finding #2: `inert` alone only reaches DOM descendants,
+// but a child Chat modal (ChatArtifactViewer's fullscreen view, ChatSpecCard,
+// ImageCarousel's lightbox) opened from within ChatRouter's transcript
+// portals to document.body directly — a DOM SIBLING of this panel, never a
+// descendant — so this panel's own `inert` never reaches it. Every one of
+// those dialogs calls the shared useFocusTrap, which consumes
+// FocusTrapOwnerHiddenContext automatically, so wrapping ChatRouter's own
+// render branch (and, defensively, every loading/error/chooser branch too)
+// in the same context is what actually closes a still-open child the
+// instant this panel becomes hidden — no DOM relocation hack, no new event
+// bus, and no change needed to any of those components themselves.
+assert.match(
+  source,
+  /import \{ FocusTrapOwnerHiddenContext \} from "@\/lib\/use-focus-trap";/,
+  "imports the shared owner-hidden context rather than inventing a parallel mechanism",
+);
+assert.match(
+  source,
+  /<FocusTrapOwnerHiddenContext\.Provider value=\{!open\}>\{children\}<\/FocusTrapOwnerHiddenContext\.Provider>/,
+  "the shared loading/error/chooser frame marks its children's owner hidden the instant it isn't open",
+);
+assert.match(
+  source,
+  /<FocusTrapOwnerHiddenContext\.Provider value=\{!open\}>\s*\n\s*\{transientErrorHeadline/,
+  "the fully resolved aside — the branch that actually mounts ChatRouter — wraps its content in the same owner-hidden boundary",
+);
+assert.match(
+  source,
+  /<\/ChatRouter>|\/>\s*\n\s*<\/div>\s*\n\s*<\/FocusTrapOwnerHiddenContext\.Provider>/,
+  "ChatRouter (and any child dialog it renders) sits INSIDE the owner-hidden boundary, not beside it",
+);
+
 // cave-rl980 Task 5: MobileDrawer grows a dedicated right-chat modal slot so
 // the global right Chat panel gets an accessible mobile/tablet presentation
 // instead of a fourth ad hoc overlay. Pinned here (not a render test): this
@@ -541,6 +573,45 @@ assert.doesNotMatch(
   drawerSource,
   /document\.body\.inert/,
   "the inert effect must never target document.body — that is the portal's own mount point",
+);
+
+// cave-rl980 Task 5 modal/focus findings: nav/list drawers previously had no
+// focus management at all beyond the legacy standalone Escape listener above
+// — they now reuse the SAME shared useFocusTrap hook for capture-on-open /
+// restore-on-close / Tab containment, without adopting Escape ownership
+// (still the legacy listener's job, unchanged above) or modal semantics
+// (no role="dialog"/aria-modal on nav/list — only right-chat is a transient
+// dialog; nav/list are persistent shell landmarks that merely slide over
+// content at mobile widths).
+assert.match(
+  drawerSource,
+  /navContainerRef\.current = document\.querySelector<HTMLElement>\("\.shell-nav-panel"\);/,
+  "nav's focus-trap container is resolved the same cross-boundary way .shell-frame is",
+);
+assert.match(
+  drawerSource,
+  /listContainerRef\.current = document\.querySelector<HTMLElement>\("\.shell-list-panel"\);/,
+  "list's focus-trap container is resolved the same cross-boundary way .shell-frame is",
+);
+assert.match(
+  drawerSource,
+  /useFocusTrap\(open === "nav", navContainerRef\);/,
+  "the nav drawer captures/restores focus and contains Tab via the shared hook",
+);
+assert.match(
+  drawerSource,
+  /useFocusTrap\(open === "list", listContainerRef\);/,
+  "the list drawer captures/restores focus and contains Tab via the shared hook",
+);
+assert.doesNotMatch(
+  drawerSource,
+  /useFocusTrap\(open === "nav", navContainerRef, \{ onEscape/,
+  "nav must not adopt Escape ownership through the trap — Escape stays the legacy listener's job",
+);
+assert.doesNotMatch(
+  drawerSource,
+  /useFocusTrap\(open === "list", listContainerRef, \{ onEscape/,
+  "list must not adopt Escape ownership through the trap — Escape stays the legacy listener's job",
 );
 
 console.log("right-chat-panel.test.ts OK");

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -39,21 +39,52 @@ assert.doesNotMatch(
   "the dedicated wrapper does not restore generic companion concepts",
 );
 
-// Resolution must be scoped to `open` + the active familiar + a loaded,
-// error-free session list. The first-resolution effect additionally gates on
-// familiars readiness/errors (cave-rl980 Task 4 review): resolving — and
-// marking resolvedFamiliarRef resolved — on a render where the router isn't
-// actually mounted would silently no-op the openSession/newChat call and
-// then permanently skip the real resolution once the router does mount.
+// Resolution must be scoped to the active familiar + a loaded, error-free
+// session list, but deliberately NOT to `open` (cave-rl980 Task 4 review): a
+// familiar transition (or a same-familiar removal) must be tracked even
+// while the panel is closed, since ChatRouter/ChatView stay mounted
+// underneath as a persistent controller — pausing resolution while hidden
+// would leave the header and the actually-mounted router desynchronized the
+// moment the panel reopens. The effect additionally gates on familiars
+// readiness/errors: resolving — and marking resolvedFamiliarRef resolved —
+// on a render where the router isn't actually mounted would silently no-op
+// the openSession/newChat call and then permanently skip the real
+// resolution once the router does mount.
 assert.match(
   source,
-  /if \(!open \|\| !activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
-  "the first-resolution effect gates on both familiar and session readiness/errors so a null router can never be marked resolved",
+  /if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
+  "the merged resolution/reconcile effect gates on familiar and session readiness/errors so a null router can never be marked resolved, but never on `open`",
+);
+// One `useLayoutEffect`, not two separate `useEffect`s (cave-rl980 Task 4
+// review): a familiar change must issue exactly one imperative openSession/
+// newChat call. Two effects race on the render the familiar changes — a
+// second, separate reconcile effect would still see the outgoing familiar's
+// stale selectedSessionId (never eligible for the new familiar, and, having
+// been observed under the old familiar, passing the observed-gate too) and
+// redundantly resolve a second time. `useLayoutEffect` also wins the
+// ordering race against ChatRouter's own internal familiar-switch effect (a
+// passive `useEffect`): every layout effect across the tree commits before
+// any passive effect runs, so ChatRouter's own effect always sees the view
+// this one already set, and its own transition becomes a no-op.
+assert.match(
+  source,
+  /useLayoutEffect\(\(\) => \{\s*\n\s*if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
+  "the merged effect is a useLayoutEffect so it always commits before ChatRouter's own internal familiar-switch effect can independently guess a second transition",
 );
 assert.match(
   source,
-  /if \(!open \|\| !activeFamiliar \|\| !sessionsLoaded \|\| sessionsError \|\| !selectedSessionId\) return;/,
-  "the ineligible-selection reconcile effect keeps its open/familiar/loaded-sessions/no-error/selected-id guard",
+  /if \(resolvedFamiliarRef\.current !== activeFamiliar\.id\) \{/,
+  "a familiar change (or first open) is handled first and returns, before any eligibility check ever sees the outgoing familiar's stale selection",
+);
+assert.match(
+  source,
+  /if \(open\) \{\s*\n\s*announce\(/,
+  "only the announcement, not the resolution itself, is gated on `open` — a hidden panel's transitions are still tracked, just not narrated to a screen reader",
+);
+assert.match(
+  source,
+  /if \(!selectedSessionId\) return;\s*\n\s*if \(eligibleSessions\.some\(\(session\) => session\.id === selectedSessionId\)\) return;\s*\n\s*if \(!observedSessionIdsRef\.current\.has\(selectedSessionId\)\) return;/,
+  "the same-familiar reconcile branch keeps its selected-id/eligibility/observed guard",
 );
 
 // A newly promoted session id (null → id, reported the instant a message
@@ -85,15 +116,15 @@ assert.match(
 // sessions" after a transcript load failure — the session is still fully
 // eligible) and a genuine removal (archive/delete's onBack, or a discarded
 // voice pre-session's onVoiceSessionDiscarded). Only the second may retain
-// the prior selectedSessionId so the reconcile effect above can resolve it
+// the prior selectedSessionId so the reconcile branch above can resolve it
 // once the roster confirms removal; the first must clear immediately.
-// pendingRemovalRef (armed by handleSessionsChanged/handleSessionsDeleted,
-// the two calls every removal path makes immediately before its null)
-// distinguishes them, gated additionally on prior observation so a
-// discarded, never-observed promotion (which also reports through
-// onSessionsChanged) clears instead of leaving a permanent ghost. Explicit
-// New chat actions bypass this handler entirely: they call
-// setSelectedSessionId(null) directly at the moment they act.
+// pendingRemovalRef distinguishes them, armed only by handleSessionRemoved
+// (ChatView's own narrow, purpose-built removal signal — see its doc in
+// chat-view.tsx — fired at the exact archive/delete/discard call sites, NOT
+// inferred from the generic onSessionsChanged/onSessionsDeleted refresh
+// callbacks, which also fire for refreshes unrelated to this session's
+// removal). Explicit New chat actions bypass this handler entirely: they
+// call setSelectedSessionId(null) directly at the moment they act.
 assert.match(
   source,
   /const pendingRemovalRef = useRef\(false\);/,
@@ -109,15 +140,17 @@ assert.match(
   /removalConfirmed && prev !== null && observedSessionIdsRef\.current\.has\(prev\) \? prev : null/,
   "an organic null only retains the prior selection when a removal was just confirmed AND that id was previously observed eligible — every other null (ordinary back, or a never-observed discarded promotion) clears immediately",
 );
+// The narrow removal signal (fix 1, cave-rl980 Task 4 review): arms
+// pendingRemovalRef only for a removal of the exact session currently
+// selected and previously observed eligible — never inferred from the
+// generic onSessionsChanged/onSessionsDeleted refresh callbacks, which also
+// fire for reasons that have nothing to do with this session's removal (a
+// canonical-session reconcile after a stream settles, a *different* thread
+// auto-archiving on reflection, a Board handoff refresh, …).
 assert.match(
   source,
-  /const handleSessionsChanged = \(\) => \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*props\.onSessionsChanged\(\);\s*\n\s*\};/,
-  "onSessionsChanged is wrapped to arm the removal flag before forwarding, never forked",
-);
-assert.match(
-  source,
-  /const handleSessionsDeleted = \(sessionIds: readonly string\[\]\) => \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*props\.onSessionsDeleted\(sessionIds\);\s*\n\s*\};/,
-  "onSessionsDeleted is wrapped to arm the removal flag before forwarding, never forked",
+  /const handleSessionRemoved = \(removedSessionId: string\) => \{\s*\n\s*if \(removedSessionId === selectedSessionId && observedSessionIdsRef\.current\.has\(removedSessionId\)\) \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*\}\s*\n\s*\};/,
+  "handleSessionRemoved arms pendingRemovalRef only for a removal of the exact selected, previously observed session",
 );
 assert.match(
   source,
@@ -131,23 +164,28 @@ assert.doesNotMatch(
 );
 assert.match(
   source,
-  /onSessionsChanged=\{handleSessionsChanged\}/,
-  "ChatRouter's onSessionsChanged is routed through the arming wrapper, not the raw prop",
+  /onSessionRemoved=\{handleSessionRemoved\}/,
+  "ChatRouter's narrow removal signal is routed through the arming handler",
 );
 assert.match(
   source,
-  /onSessionsDeleted=\{handleSessionsDeleted\}/,
-  "ChatRouter's onSessionsDeleted is routed through the arming wrapper, not the raw prop",
-);
-assert.doesNotMatch(
-  source,
   /onSessionsChanged=\{props\.onSessionsChanged\}/,
-  "ChatRouter must not wire directly into the raw onSessionsChanged prop — the wrapper needs to observe every call",
+  "ChatRouter's onSessionsChanged is forwarded to the raw prop unchanged — RightChatPanel no longer intercepts every call to guess at removal, preserving existing behavior for every other consumer",
 );
-assert.doesNotMatch(
+assert.match(
   source,
   /onSessionsDeleted=\{props\.onSessionsDeleted\}/,
-  "ChatRouter must not wire directly into the raw onSessionsDeleted prop — the wrapper needs to observe every call",
+  "ChatRouter's onSessionsDeleted is forwarded to the raw prop unchanged — RightChatPanel no longer intercepts every call to guess at removal, preserving existing behavior for every other consumer",
+);
+assert.doesNotMatch(
+  source,
+  /const handleSessionsChanged = /,
+  "onSessionsChanged must no longer be wrapped to arm the removal flag — it also fires for unrelated refreshes, which would misclassify an ordinary back as a confirmed removal",
+);
+assert.doesNotMatch(
+  source,
+  /const handleSessionsDeleted = /,
+  "onSessionsDeleted must no longer be wrapped to arm the removal flag — the narrow onSessionRemoved signal owns that job instead",
 );
 
 // Transient roster errors (a failed refresh, not a first load) must not tear

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -40,16 +40,103 @@ assert.doesNotMatch(
 );
 
 // Resolution must be scoped to `open` + the active familiar + a loaded,
-// error-free session list — the plan's four gating conditions. This pins the
-// *identical* four-way guard on both the first-open/familiar-change effect and
-// the ineligible-selection re-resolve effect, so neither one accidentally
-// resolves while the panel is closed, no familiar is active, sessions
-// haven't loaded, or the last session load failed.
-const gate = /!open \|\| !activeFamiliar \|\| !sessionsLoaded \|\| sessionsError/g;
+// error-free session list. The first-resolution effect additionally gates on
+// familiars readiness/errors (cave-rl980 Task 4 review): resolving — and
+// marking resolvedFamiliarRef resolved — on a render where the router isn't
+// actually mounted would silently no-op the openSession/newChat call and
+// then permanently skip the real resolution once the router does mount.
+assert.match(
+  source,
+  /if \(!open \|\| !activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
+  "the first-resolution effect gates on both familiar and session readiness/errors so a null router can never be marked resolved",
+);
+assert.match(
+  source,
+  /if \(!open \|\| !activeFamiliar \|\| !sessionsLoaded \|\| sessionsError \|\| !selectedSessionId\) return;/,
+  "the ineligible-selection reconcile effect keeps its open/familiar/loaded-sessions/no-error/selected-id guard",
+);
+
+// A newly promoted session id (null → id, reported the instant a message
+// starts a chat from a blank compose) can arrive before the `sessions`
+// roster prop has been refetched to include it. The reconcile effect must
+// not classify that as a deletion — it may only replace a selected id once
+// that id had previously been observed present in the eligible roster.
+assert.match(
+  source,
+  /const observedSessionIdsRef = useRef<Set<string>>\(new Set\(\)\);/,
+  "the panel tracks every session id it has actually observed in the eligible roster",
+);
+assert.match(
+  source,
+  /for \(const session of eligibleSessions\) observedSessionIdsRef\.current\.add\(session\.id\);/,
+  "every render folds the current eligible roster into the observed-ids record",
+);
+assert.match(
+  source,
+  /if \(!observedSessionIdsRef\.current\.has\(selectedSessionId\)\) return;/,
+  "the reconcile effect only replaces a selected id once it was previously observed eligible — never a just-promoted id the roster hasn't caught up to yet",
+);
+
+// ChatRouter reports a null active session organically (archive's onBack,
+// delete, a discarded voice pre-session) with no accompanying explicit
+// action. That must retain the prior selectedSessionId — not null it out —
+// so the reconcile effect above can still detect the confirmed removal once
+// the roster refreshes and resolve the same familiar's latest session or a
+// new compose. Explicit New chat actions bypass this handler entirely: they
+// call setSelectedSessionId(null) directly at the moment they act.
+assert.match(
+  source,
+  /const handleActiveSessionChange = \(sessionId: string \| null\) => \{\s*\n\s*if \(sessionId !== null\) setSelectedSessionId\(sessionId\);\s*\n\s*\};/,
+  "an organic null from ChatRouter is retained (not nulled out) so the reconcile effect can resolve it once the roster confirms removal",
+);
+assert.match(
+  source,
+  /onActiveSessionChange=\{handleActiveSessionChange\}/,
+  "ChatRouter's active-session reports are routed through the retaining handler",
+);
+assert.doesNotMatch(
+  source,
+  /onActiveSessionChange=\{setSelectedSessionId\}/,
+  "ChatRouter must not wire directly into setSelectedSessionId — an organic null would wipe the retained selection",
+);
+
+// Transient roster errors (a failed refresh, not a first load) must not tear
+// down an already-mounted ChatRouter's transcript/stream/scroll state.
+// hasResolvedRouter distinguishes "never resolved this familiar" (blocking
+// error is safe — nothing is mounted yet) from "already resolved, error is
+// transient" (keep the router mounted; surface the error inline instead).
+assert.match(
+  source,
+  /const hasResolvedRouter = activeFamiliar !== null && resolvedFamiliarRef\.current === activeFamiliar\.id;/,
+  "hasResolvedRouter tracks whether this exact familiar's router has already resolved/mounted",
+);
+assert.match(source, /familiarsError && !hasResolvedRouter/, "a familiars-roster error only blocks rendering before the router has resolved");
+assert.match(source, /sessionsError && !hasResolvedRouter/, "a sessions-roster error only blocks rendering before the router has resolved");
+
+// Every loading/error/chooser state must expose a discoverable Close action
+// — crucial in a focus-trapped mobile modal — via one shared frame instead
+// of four hand-duplicated headers.
 assert.equal(
-  (source.match(gate) ?? []).length,
-  2,
-  "both the initial-resolve and re-resolve effects gate on open, active familiar, loaded sessions, and no session error",
+  (source.match(/<RightChatPanelFrame\b/g) ?? []).length,
+  4,
+  "loading, the familiars error, the no-active-familiar chooser, and the sessions error all share one Close-carrying frame",
+);
+assert.ok(
+  (source.match(/aria-label="Close Chat panel"/g) ?? []).length >= 2,
+  "Close is rendered by both the shared frame and the fully resolved header",
+);
+
+// The familiar chooser must offer only the filtered, resolved roster —
+// archived/hidden familiars must never be selectable there.
+assert.match(
+  source,
+  /\{resolvedFamiliars\.map\(\(familiar\) => \(/,
+  "the no-active-familiar chooser iterates the filtered resolved roster",
+);
+assert.doesNotMatch(
+  source,
+  /\{familiars\.map\(/,
+  "the chooser must not iterate the raw, unfiltered familiars prop",
 );
 
 // When the active familiar becomes null, the retained resolution and manual

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -30,7 +30,15 @@ assert.match(
   /routerRef\.current\?\.newChat\(undefined, undefined, activeFamiliar\.id\)/,
   "no eligible chat opens a familiar-bound blank compose",
 );
-assert.match(source, /aria-label="Switch Chat panel thread"/, "the compact header exposes a labelled thread switcher");
+// The switcher is the design system's StandardSelect, whose `label` prop
+// becomes the trigger button's aria-label — a native <select> here would trip
+// the `components/no-native-select` drift ratchet.
+assert.match(
+  source,
+  /<StandardSelect\b[\s\S]*?label="Switch Chat panel thread"/,
+  "the compact header exposes a labelled thread switcher",
+);
+assert.doesNotMatch(source, /<select\b/, "the thread switcher never regresses to a native select");
 assert.match(source, /aria-label="New Chat panel chat"/, "the compact header exposes New chat");
 assert.match(source, /aria-label="Close Chat panel"/, "the compact header exposes Close");
 assert.doesNotMatch(

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -66,10 +66,13 @@ assert.match(
   /const observedSessionIdsRef = useRef<Set<string>>\(new Set\(\)\);/,
   "the panel tracks every session id it has actually observed in the eligible roster",
 );
+// Recorded from an effect, not inline during render (cave-rl980 Task 4
+// review): a render React abandons before commit must never leave a mark on
+// reconciliation state.
 assert.match(
   source,
-  /for \(const session of eligibleSessions\) observedSessionIdsRef\.current\.add\(session\.id\);/,
-  "every render folds the current eligible roster into the observed-ids record",
+  /useEffect\(\(\) => \{\s*\n\s*for \(const session of eligibleSessions\) observedSessionIdsRef\.current\.add\(session\.id\);\s*\n\s*\}, \[eligibleSessions\]\);/,
+  "the observed-ids record is only ever updated from an effect keyed on eligibleSessions, after a render actually commits",
 );
 assert.match(
   source,
@@ -77,27 +80,74 @@ assert.match(
   "the reconcile effect only replaces a selected id once it was previously observed eligible — never a just-promoted id the roster hasn't caught up to yet",
 );
 
-// ChatRouter reports a null active session organically (archive's onBack,
-// delete, a discarded voice pre-session) with no accompanying explicit
-// action. That must retain the prior selectedSessionId — not null it out —
-// so the reconcile effect above can still detect the confirmed removal once
-// the roster refreshes and resolve the same familiar's latest session or a
-// new compose. Explicit New chat actions bypass this handler entirely: they
-// call setSelectedSessionId(null) directly at the moment they act.
+// ChatRouter reports a null active session in two shapes that read
+// identically from here: an ordinary "list" transition (e.g. "Back to
+// sessions" after a transcript load failure — the session is still fully
+// eligible) and a genuine removal (archive/delete's onBack, or a discarded
+// voice pre-session's onVoiceSessionDiscarded). Only the second may retain
+// the prior selectedSessionId so the reconcile effect above can resolve it
+// once the roster confirms removal; the first must clear immediately.
+// pendingRemovalRef (armed by handleSessionsChanged/handleSessionsDeleted,
+// the two calls every removal path makes immediately before its null)
+// distinguishes them, gated additionally on prior observation so a
+// discarded, never-observed promotion (which also reports through
+// onSessionsChanged) clears instead of leaving a permanent ghost. Explicit
+// New chat actions bypass this handler entirely: they call
+// setSelectedSessionId(null) directly at the moment they act.
 assert.match(
   source,
-  /const handleActiveSessionChange = \(sessionId: string \| null\) => \{\s*\n\s*if \(sessionId !== null\) setSelectedSessionId\(sessionId\);\s*\n\s*\};/,
-  "an organic null from ChatRouter is retained (not nulled out) so the reconcile effect can resolve it once the roster confirms removal",
+  /const pendingRemovalRef = useRef\(false\);/,
+  "a ref tracks whether a removal mutation was just reported, for the very next active-session report to consume",
+);
+assert.match(
+  source,
+  /const removalConfirmed = pendingRemovalRef\.current;\s*\n\s*pendingRemovalRef\.current = false;/,
+  "handleActiveSessionChange reads then resets the armed removal flag exactly once per report — never leaves it to leak into a later, unrelated transition",
+);
+assert.match(
+  source,
+  /removalConfirmed && prev !== null && observedSessionIdsRef\.current\.has\(prev\) \? prev : null/,
+  "an organic null only retains the prior selection when a removal was just confirmed AND that id was previously observed eligible — every other null (ordinary back, or a never-observed discarded promotion) clears immediately",
+);
+assert.match(
+  source,
+  /const handleSessionsChanged = \(\) => \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*props\.onSessionsChanged\(\);\s*\n\s*\};/,
+  "onSessionsChanged is wrapped to arm the removal flag before forwarding, never forked",
+);
+assert.match(
+  source,
+  /const handleSessionsDeleted = \(sessionIds: readonly string\[\]\) => \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*props\.onSessionsDeleted\(sessionIds\);\s*\n\s*\};/,
+  "onSessionsDeleted is wrapped to arm the removal flag before forwarding, never forked",
 );
 assert.match(
   source,
   /onActiveSessionChange=\{handleActiveSessionChange\}/,
-  "ChatRouter's active-session reports are routed through the retaining handler",
+  "ChatRouter's active-session reports are routed through the retain-or-clear handler",
 );
 assert.doesNotMatch(
   source,
   /onActiveSessionChange=\{setSelectedSessionId\}/,
-  "ChatRouter must not wire directly into setSelectedSessionId — an organic null would wipe the retained selection",
+  "ChatRouter must not wire directly into setSelectedSessionId — an organic null needs the retain-or-clear decision",
+);
+assert.match(
+  source,
+  /onSessionsChanged=\{handleSessionsChanged\}/,
+  "ChatRouter's onSessionsChanged is routed through the arming wrapper, not the raw prop",
+);
+assert.match(
+  source,
+  /onSessionsDeleted=\{handleSessionsDeleted\}/,
+  "ChatRouter's onSessionsDeleted is routed through the arming wrapper, not the raw prop",
+);
+assert.doesNotMatch(
+  source,
+  /onSessionsChanged=\{props\.onSessionsChanged\}/,
+  "ChatRouter must not wire directly into the raw onSessionsChanged prop — the wrapper needs to observe every call",
+);
+assert.doesNotMatch(
+  source,
+  /onSessionsDeleted=\{props\.onSessionsDeleted\}/,
+  "ChatRouter must not wire directly into the raw onSessionsDeleted prop — the wrapper needs to observe every call",
 );
 
 // Transient roster errors (a failed refresh, not a first load) must not tear
@@ -139,13 +189,14 @@ assert.doesNotMatch(
   "the chooser must not iterate the raw, unfiltered familiars prop",
 );
 
-// When the active familiar becomes null, the retained resolution and manual
-// selection must both be cleared instead of quietly pointing at a stale
-// familiar's session the next time a familiar becomes active again.
+// When the active familiar becomes null, the retained resolution, any armed
+// removal flag, and the manual selection must all be cleared instead of
+// quietly pointing at a stale familiar's session (or consuming a stale
+// removal flag) the next time a familiar becomes active again.
 assert.match(
   source,
-  /if \(activeFamiliar\) return;\s*resolvedFamiliarRef\.current = null;\s*setSelectedSessionId\(null\);/,
-  "clearing the active familiar clears the retained resolution and selection",
+  /if \(activeFamiliar\) return;\s*resolvedFamiliarRef\.current = null;\s*pendingRemovalRef\.current = false;\s*setSelectedSessionId\(null\);/,
+  "clearing the active familiar clears the retained resolution, the armed removal flag, and the selection",
 );
 
 // Never default to familiars[0] when no familiar is active.

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -40,20 +40,24 @@ assert.doesNotMatch(
 );
 
 // Resolution must be scoped to the active familiar + a loaded, error-free
-// session list, but deliberately NOT to `open` (cave-rl980 Task 4 review): a
-// familiar transition (or a same-familiar removal) must be tracked even
-// while the panel is closed, since ChatRouter/ChatView stay mounted
-// underneath as a persistent controller — pausing resolution while hidden
-// would leave the header and the actually-mounted router desynchronized the
-// moment the panel reopens. The effect additionally gates on familiars
-// readiness/errors: resolving — and marking resolvedFamiliarRef resolved —
-// on a render where the router isn't actually mounted would silently no-op
-// the openSession/newChat call and then permanently skip the real
-// resolution once the router does mount.
+// session list, AND to `open` for the actual imperative resolve itself
+// (cave-rl980 Task 4 spec review): first-open semantics require resolving
+// against whichever session is newest at the moment the panel actually
+// becomes visible, never one resolved earlier while hidden. But every
+// familiar-identity TRANSITION is still tracked regardless of `open`, via
+// trackedFamiliarIdRef, since ChatRouter/ChatView stay mounted underneath as
+// a persistent controller — a closed A -> B -> A round trip must still
+// invalidate whatever was resolved for the earlier A so the panel resolves
+// fresh, against then-current sessions, the moment it reopens, rather than
+// wrongly concluding nothing had changed. The effect additionally gates on
+// familiars readiness/errors: resolving — and marking resolvedFamiliarRef
+// resolved — on a render where the router isn't actually mounted would
+// silently no-op the openSession/newChat call and then permanently skip the
+// real resolution once the router does mount.
 assert.match(
   source,
   /if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
-  "the merged resolution/reconcile effect gates on familiar and session readiness/errors so a null router can never be marked resolved, but never on `open`",
+  "the merged resolution/reconcile effect gates on familiar and session readiness/errors so a null router can never be marked resolved",
 );
 // One `useLayoutEffect`, not two separate `useEffect`s (cave-rl980 Task 4
 // review): a familiar change must issue exactly one imperative openSession/
@@ -71,6 +75,22 @@ assert.match(
   /useLayoutEffect\(\(\) => \{\s*\n\s*if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
   "the merged effect is a useLayoutEffect so it always commits before ChatRouter's own internal familiar-switch effect can independently guess a second transition",
 );
+// Every familiar-identity transition invalidates retained resolution and
+// selection ownership regardless of `open` (cave-rl980 Task 4 spec review),
+// so a closed A -> B -> A round trip is still detected as needing a fresh
+// resolve instead of being mistaken for "still on the same, already-resolved
+// A" — resolvedFamiliarRef is never touched while closed, so without this
+// separate tracking ref it would still read the ORIGINAL A's id.
+assert.match(
+  source,
+  /const trackedFamiliarIdRef = useRef<string \| null>\(null\);/,
+  "a dedicated ref tracks every familiar-identity transition independent of whether a resolve has actually happened",
+);
+assert.match(
+  source,
+  /if \(trackedFamiliarIdRef\.current !== activeFamiliar\.id\) \{/,
+  "a transition is detected by comparing against trackedFamiliarIdRef, not resolvedFamiliarRef, so a closed round trip back to a previously-resolved familiar is still caught",
+);
 assert.match(
   source,
   /if \(resolvedFamiliarRef\.current !== activeFamiliar\.id\) \{/,
@@ -78,8 +98,18 @@ assert.match(
 );
 assert.match(
   source,
+  /\/\/ First open, or a genuine familiar change: needs a fresh resolve\.\s*\n\s*\/\/ Never touch the router or the selection while the panel is closed/,
+  "the resolve is deferred, not performed, while the panel is closed",
+);
+assert.match(
+  source,
+  /if \(!open\) return;\s*\n\s*resolvedFamiliarRef\.current = activeFamiliar\.id;/,
+  "the imperative resolve itself — not just its announcement — is gated on `open`: first-open semantics require the freshest session data at the moment the panel actually becomes visible",
+);
+assert.doesNotMatch(
+  source,
   /if \(open\) \{\s*\n\s*announce\(/,
-  "only the announcement, not the resolution itself, is gated on `open` — a hidden panel's transitions are still tracked, just not narrated to a screen reader",
+  "the announcement is no longer separately gated — the surrounding `if (!open) return;` already guarantees `open` is true by the time it's reached",
 );
 assert.match(
   source,
@@ -116,8 +146,7 @@ assert.match(
 // sessions" after a transcript load failure — the session is still fully
 // eligible) and a genuine removal (archive/delete's onBack, or a discarded
 // voice pre-session's onVoiceSessionDiscarded). Only the second may retain
-// the prior selectedSessionId so the reconcile branch above can resolve it
-// once the roster confirms removal; the first must clear immediately.
+// or replace the prior selectedSessionId; the first must clear immediately.
 // pendingRemovalRef distinguishes them, armed only by handleSessionRemoved
 // (ChatView's own narrow, purpose-built removal signal — see its doc in
 // chat-view.tsx — fired at the exact archive/delete/discard call sites, NOT
@@ -135,18 +164,36 @@ assert.match(
   /const removalConfirmed = pendingRemovalRef\.current;\s*\n\s*pendingRemovalRef\.current = false;/,
   "handleActiveSessionChange reads then resets the armed removal flag exactly once per report — never leaves it to leak into a later, unrelated transition",
 );
+// A confirmed removal (fix 1/2, cave-rl980 Task 4 spec review) branches on
+// whether the removed id was ever observed eligible: a previously observed
+// id is retained until the roster itself confirms the removal (there IS a
+// future transition to wait for); a NEVER-observed id (a promoted/voice
+// session discarded before the roster ever caught up to it) has no such
+// future transition to wait for, so onSessionRemoved's confirmation is
+// trusted immediately and a replacement resolves right away instead of
+// leaving the panel on a permanent ghost.
 assert.match(
   source,
-  /removalConfirmed && prev !== null && observedSessionIdsRef\.current\.has\(prev\) \? prev : null/,
-  "an organic null only retains the prior selection when a removal was just confirmed AND that id was previously observed eligible — every other null (ordinary back, or a never-observed discarded promotion) clears immediately",
+  /const removedId = currentSelectionRef\.current\.sessionId;\s*\n\s*if \(removalConfirmed && removedId !== null\) \{/,
+  "a confirmed removal is evaluated against the CURRENT ref-read selection, not a value closed over by this function instance",
+);
+assert.match(
+  source,
+  /if \(observedSessionIdsRef\.current\.has\(removedId\)\) \{/,
+  "a previously observed removed id is retained, deferring to the same-familiar reconcile branch once the roster confirms it",
+);
+assert.match(
+  source,
+  /resolveLatestRightChatSessionId\(\s*\n\s*sessions\.filter\(\(session\) => session\.id !== removedId\),\s*\n\s*activeFamiliar\.id,\s*\n\s*\);/,
+  "a never-observed confirmed removal resolves a replacement immediately, explicitly excluding the removed id in case a stale sessions snapshot still lists it",
 );
 // The narrow removal signal (fix 1, cave-rl980 Task 4 review): arms
-// pendingRemovalRef only for a removal of the exact session currently
-// selected and previously observed eligible — never inferred from the
-// generic onSessionsChanged/onSessionsDeleted refresh callbacks, which also
-// fire for reasons that have nothing to do with this session's removal (a
-// canonical-session reconcile after a stream settles, a *different* thread
-// auto-archiving on reflection, a Board handoff refresh, …).
+// pendingRemovalRef for a removal of the exact session currently selected —
+// never inferred from the generic onSessionsChanged/onSessionsDeleted
+// refresh callbacks, which also fire for reasons that have nothing to do
+// with this session's removal (a canonical-session reconcile after a stream
+// settles, a *different* thread auto-archiving on reflection, a Board
+// handoff refresh, …).
 //
 // Reads currentSelectionRef (cave-rl980 Task 4 final review), not the
 // selectedSessionId/activeFamiliar closed over by this exact function
@@ -168,8 +215,13 @@ assert.match(
 );
 assert.match(
   source,
-  /const handleSessionRemoved = \(removedSessionId: string\) => \{\s*\n\s*const current = currentSelectionRef\.current;\s*\n\s*if \(current\.sessionId !== removedSessionId\) return;\s*\n\s*if \(!observedSessionIdsRef\.current\.has\(removedSessionId\)\) return;\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*\};/,
-  "handleSessionRemoved arms pendingRemovalRef only for a removal of the exact CURRENT (ref-read) selected, previously observed session",
+  /const handleSessionRemoved = \(removedSessionId: string\) => \{\s*\n\s*const current = currentSelectionRef\.current;\s*\n\s*if \(current\.sessionId !== removedSessionId\) return;\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*\};/,
+  "handleSessionRemoved arms pendingRemovalRef for a removal of the exact CURRENT (ref-read) selected session — authoritative regardless of observed-ID membership, since ChatView only fires it for a confirmed archive/delete/discard",
+);
+assert.doesNotMatch(
+  source,
+  /const handleSessionRemoved = \(removedSessionId: string\) => \{[\s\S]{0,200}observedSessionIdsRef/,
+  "handleSessionRemoved must not gate arming on observedSessionIdsRef — a session promoted and removed before the roster ever caught up to it is just as real a removal as one the roster had already shown",
 );
 assert.match(
   source,

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -384,4 +384,161 @@ assert.match(
   "the fully resolved aside applies the same truthful aria-hidden/inert pairing",
 );
 
+// cave-rl980 Task 5: MobileDrawer grows a dedicated right-chat modal slot so
+// the global right Chat panel gets an accessible mobile/tablet presentation
+// instead of a fourth ad hoc overlay. Pinned here (not a render test): this
+// suite's Node environment has no DOM/jsdom, matching the convention already
+// used for this hook's other consumers (see use-focus-trap.test.ts,
+// modal.test.ts) — behavior is proven by pinning the implementing source,
+// not by executing it against a real document.
+const drawerSource = await readFile(new URL("./mobile-drawer.tsx", import.meta.url), "utf8");
+
+assert.match(
+  drawerSource,
+  /export type MobileDrawerSlot = "nav" \| "list" \| "right-chat" \| null;/,
+  "the right Chat panel gets a dedicated drawer slot alongside nav/list",
+);
+assert.match(
+  drawerSource,
+  /rightChat\?: ReactNode;/,
+  "MobileDrawer accepts the right Chat panel's modal content",
+);
+assert.match(
+  drawerSource,
+  /useFocusTrap\(open === "right-chat", rightChatRef, \{ onEscape: onClose \}\)/,
+  "the right Chat drawer traps and returns focus via the shared hook, consistent with Modal's own usage",
+);
+assert.match(
+  drawerSource,
+  /role="dialog"[\s\S]{0,80}aria-modal="true"[\s\S]{0,80}aria-label="Chat panel"/,
+  "the right Chat drawer is a labelled modal dialog",
+);
+assert.match(
+  drawerSource,
+  /id="shell-right-chat-drawer"/,
+  "the right Chat drawer exposes a stable id for Shell/CSS to target",
+);
+assert.match(
+  drawerSource,
+  /className="mobile-right-chat-drawer"/,
+  "the right Chat drawer exposes a stable class hook for Task 8 styling",
+);
+assert.match(
+  drawerSource,
+  /aria-hidden=\{open !== "right-chat"\}/,
+  "closing marks the right Chat drawer aria-hidden rather than unmounting it",
+);
+assert.match(
+  drawerSource,
+  /hidden=\{open !== "right-chat"\}/,
+  "closing hides the right Chat drawer rather than unmounting it",
+);
+assert.match(
+  drawerSource,
+  /inert=\{open !== "right-chat"\}/,
+  "closing makes the right Chat drawer inert rather than unmounting it",
+);
+assert.match(
+  drawerSource,
+  /tabIndex=\{-1\}/,
+  "the right Chat drawer is a reachable focus-trap fallback container per useFocusTrap's contract",
+);
+
+// Retained mount: the drawer's presence is gated on the rightChat NODE only,
+// never on `open` — so React never unmounts/remounts the subtree (and the
+// auxiliary ChatRouter it wraps) across opens/closes, only its hidden/inert
+// state changes.
+assert.match(
+  drawerSource,
+  /\{rightChat \? \(/,
+  "the right Chat drawer's presence is gated on the rightChat node only, so it stays mounted across opens/closes",
+);
+assert.doesNotMatch(
+  drawerSource,
+  /\{open === "right-chat" && rightChat/,
+  "the right Chat drawer must not be conditionally MOUNTED on open — only hidden/inert — or the retained-router contract breaks",
+);
+assert.match(
+  drawerSource,
+  /if \(!open && !rightChat\) return null;/,
+  "the component itself stays mounted (portal included) whenever the rightChat node exists, even while every drawer is closed",
+);
+
+// Backdrop renders only while a drawer (nav, list, OR right-chat) is open —
+// never for a merely-retained, closed right-chat modal.
+assert.match(
+  drawerSource,
+  /\{open \? \(\s*\n\s*<div\s*\n\s*className="mobile-drawer-backdrop"/,
+  "the backdrop renders only while any drawer is open",
+);
+
+// Escape ownership: the legacy standalone listener must step aside for the
+// right Chat drawer, which owns Escape entirely through useFocusTrap's
+// onEscape — otherwise Escape would fire onClose twice for that slot.
+assert.match(
+  drawerSource,
+  /const ownsEscape = open !== "right-chat";/,
+  "the legacy Escape listener is scoped away from the right Chat drawer",
+);
+assert.match(
+  drawerSource,
+  /if \(ownsEscape\) window\.addEventListener\("keydown", onKey\);/,
+  "only nav/list register the legacy Escape listener — the right Chat drawer's Escape is owned solely by useFocusTrap",
+);
+assert.match(
+  drawerSource,
+  /if \(ownsEscape\) window\.removeEventListener\("keydown", onKey\);/,
+  "the legacy Escape listener teardown mirrors its scoped registration",
+);
+
+// Body/root scroll + overscroll lock must still apply for EVERY open drawer
+// (nav, list, and right-chat alike) — the lock effect's gate stays the plain
+// `if (!open) return;`, never narrowed to exclude right-chat.
+assert.match(
+  drawerSource,
+  /document\.body\.style\.overflow = "hidden"/,
+  "every open drawer (nav/list/right-chat) keeps body scroll locked",
+);
+assert.match(
+  drawerSource,
+  /document\.documentElement\.style\.overflow = "hidden"/,
+  "every open drawer (nav/list/right-chat) keeps root scroll locked",
+);
+assert.doesNotMatch(
+  drawerSource,
+  /if \(open === "right-chat"\) return;\s*\n\s*const ownsEscape/,
+  "the scroll-lock effect must never early-return before locking for the right Chat drawer",
+);
+
+// Background inert: while the right Chat modal is open, the shell chrome
+// behind it must become inert — targeting `.shell-frame` specifically
+// (Shell's own root, see shell.tsx), never `document.body`, since the
+// backdrop/modal portal mounts to document.body itself and inerting that
+// would swallow the very modal we're trying to keep interactive.
+assert.match(
+  drawerSource,
+  /const shell = document\.querySelector<HTMLElement>\("\.shell-frame"\);/,
+  "the background-inert effect targets .shell-frame, which sits outside the portal's DOM subtree",
+);
+assert.match(
+  drawerSource,
+  /const prevInert = shell\.inert;/,
+  "the effect captures .shell-frame's prior inert state before overriding it",
+);
+assert.match(
+  drawerSource,
+  /shell\.inert = true;/,
+  "the right Chat modal makes the shell background inert while open",
+);
+assert.match(
+  drawerSource,
+  /shell\.inert = prevInert;/,
+  "closing restores .shell-frame's actual prior inert state rather than hard-coding false",
+);
+assert.doesNotMatch(
+  drawerSource,
+  /document\.body\.inert/,
+  "the inert effect must never target document.body — that is the portal's own mount point",
+);
+
 console.log("right-chat-panel.test.ts OK");

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -147,10 +147,29 @@ assert.match(
 // fire for reasons that have nothing to do with this session's removal (a
 // canonical-session reconcile after a stream settles, a *different* thread
 // auto-archiving on reflection, a Board handoff refresh, …).
+//
+// Reads currentSelectionRef (cave-rl980 Task 4 final review), not the
+// selectedSessionId/activeFamiliar closed over by this exact function
+// instance: ChatView's archive/delete/discard flows are async, and the
+// specific onSessionRemoved closure a still-in-flight request retains is
+// whichever one was current when THAT request began — frozen even after the
+// user switches to a different thread or familiar while it is still
+// in-flight. Comparing against the ref instead of the closure means the
+// check always sees the CURRENT truth.
 assert.match(
   source,
-  /const handleSessionRemoved = \(removedSessionId: string\) => \{\s*\n\s*if \(removedSessionId === selectedSessionId && observedSessionIdsRef\.current\.has\(removedSessionId\)\) \{\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*\}\s*\n\s*\};/,
-  "handleSessionRemoved arms pendingRemovalRef only for a removal of the exact selected, previously observed session",
+  /const currentSelectionRef = useRef<\{ familiarId: string \| null; sessionId: string \| null \}>\(\{\s*\n\s*familiarId: null,\s*\n\s*sessionId: null,\s*\n\s*\}\);/,
+  "a ref mirrors the current selection (familiar id + session id) for handleSessionRemoved to consult instead of stale closure state",
+);
+assert.match(
+  source,
+  /useLayoutEffect\(\(\) => \{\s*\n\s*currentSelectionRef\.current = \{ familiarId: activeFamiliar\?\.id \?\? null, sessionId: selectedSessionId \};\s*\n\s*\}, \[activeFamiliar, selectedSessionId\]\);/,
+  "currentSelectionRef commits synchronously (useLayoutEffect, no early-return guard) so it never lags behind the actual rendered selection",
+);
+assert.match(
+  source,
+  /const handleSessionRemoved = \(removedSessionId: string\) => \{\s*\n\s*const current = currentSelectionRef\.current;\s*\n\s*if \(current\.sessionId !== removedSessionId\) return;\s*\n\s*if \(!observedSessionIdsRef\.current\.has\(removedSessionId\)\) return;\s*\n\s*pendingRemovalRef\.current = true;\s*\n\s*\};/,
+  "handleSessionRemoved arms pendingRemovalRef only for a removal of the exact CURRENT (ref-read) selected, previously observed session",
 );
 assert.match(
   source,

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -39,42 +39,73 @@ assert.doesNotMatch(
   "the dedicated wrapper does not restore generic companion concepts",
 );
 
-// Resolution must be scoped to the active familiar + a loaded, error-free
-// session list, AND to `open` for the actual imperative resolve itself
-// (cave-rl980 Task 4 spec review): first-open semantics require resolving
-// against whichever session is newest at the moment the panel actually
-// becomes visible, never one resolved earlier while hidden. But every
-// familiar-identity TRANSITION is still tracked regardless of `open`, via
-// trackedFamiliarIdRef, since ChatRouter/ChatView stay mounted underneath as
-// a persistent controller — a closed A -> B -> A round trip must still
-// invalidate whatever was resolved for the earlier A so the panel resolves
-// fresh, against then-current sessions, the moment it reopens, rather than
-// wrongly concluding nothing had changed. The effect additionally gates on
-// familiars readiness/errors: resolving — and marking resolvedFamiliarRef
-// resolved — on a render where the router isn't actually mounted would
-// silently no-op the openSession/newChat call and then permanently skip the
-// real resolution once the router does mount.
+// Applied-session-scope contract (cave-rl980 Task 4 review, bullet 1): the
+// narrowest explicit contract that lets a future caller (Workspace, wired in
+// Task 7) tell this panel which familiar `sessions` actually corresponds to,
+// so a familiar switch never resolves against another familiar's still-in-
+// flight roster. See right-chat-session.ts's isCurrentRightChatSessionsScope.
 assert.match(
   source,
-  /if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
-  "the merged resolution/reconcile effect gates on familiar and session readiness/errors so a null router can never be marked resolved",
+  /sessionsScopeFamiliarId\?: RightChatSessionsScope;/,
+  "the panel exposes an optional applied-session-scope prop, ready for Workspace to wire in Task 7",
 );
-// One `useLayoutEffect`, not two separate `useEffect`s (cave-rl980 Task 4
-// review): a familiar change must issue exactly one imperative openSession/
-// newChat call. Two effects race on the render the familiar changes — a
-// second, separate reconcile effect would still see the outgoing familiar's
-// stale selectedSessionId (never eligible for the new familiar, and, having
-// been observed under the old familiar, passing the observed-gate too) and
-// redundantly resolve a second time. `useLayoutEffect` also wins the
-// ordering race against ChatRouter's own internal familiar-switch effect (a
-// passive `useEffect`): every layout effect across the tree commits before
-// any passive effect runs, so ChatRouter's own effect always sees the view
-// this one already set, and its own transition becomes a no-op.
 assert.match(
   source,
-  /useLayoutEffect\(\(\) => \{\s*\n\s*if \(!activeFamiliar \|\| !familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
-  "the merged effect is a useLayoutEffect so it always commits before ChatRouter's own internal familiar-switch effect can independently guess a second transition",
+  /import \{\s*\n\s*eligibleRightChatSessions,\s*\n\s*isCurrentRightChatSessionsScope,\s*\n\s*resolveLatestRightChatSessionId,\s*\n\s*type RightChatSessionsScope,\s*\n\s*\} from "@\/lib\/right-chat-session";/,
+  "the scope check reuses the shared right-chat-session helper/type rather than inventing a parallel one",
 );
+assert.match(
+  source,
+  /const sessionsScopeCurrent =\s*\n\s*activeFamiliar === null \|\|\s*\n\s*isCurrentRightChatSessionsScope\(sessionsScopeFamiliarId, activeFamiliar\.id\);/,
+  "scope currency is derived once and reused by both the resolve effect and the render-blocking gate",
+);
+assert.match(
+  source,
+  /!sessionsScopeCurrent && !hasResolvedRouter/,
+  "an unconfirmed scope only blocks rendering (and ChatRouter's own mount) before this familiar has ever resolved -- exactly like the familiarsError/sessionsError transient-vs-first-load distinction",
+);
+
+// Resolution must be scoped to the active familiar + a loaded, error-free,
+// scope-confirmed session list, AND to `open` for the actual imperative
+// resolve itself (cave-rl980 Task 4 spec review): first-open semantics
+// require resolving against whichever session is newest at the moment the
+// panel actually becomes visible, never one resolved earlier while hidden.
+// But every familiar-identity TRANSITION is still tracked regardless of
+// `open`, readiness, errors, or scope, via trackedFamiliarIdRef, since
+// ChatRouter/ChatView stay mounted underneath as a persistent controller —
+// a closed A -> B -> A round trip, even one that happens entirely while a
+// roster error is active throughout, must still invalidate whatever was
+// resolved for the earlier A so the panel resolves fresh, against
+// then-current sessions, the moment it reopens, rather than wrongly
+// concluding nothing had changed (cave-rl980 Task 4 review: identity
+// tracking/invalidation happens BEFORE the loading/error readiness guard,
+// not merged with it). The effect additionally gates the actual resolve on
+// familiars/session readiness/errors: resolving — and marking
+// resolvedFamiliarRef resolved — on a render where the router isn't
+// actually mounted would silently no-op the openSession/newChat call and
+// then permanently skip the real resolution once the router does mount.
+assert.match(
+  source,
+  /useLayoutEffect\(\(\) => \{\s*\n\s*if \(!activeFamiliar\) return;/,
+  "the merged effect's very first statement is the plain !activeFamiliar guard, unconditional on readiness/errors/scope, so identity tracking below it always runs",
+);
+assert.match(
+  source,
+  /if \(trackedFamiliarIdRef\.current !== activeFamiliar\.id\) \{[\s\S]*?\n\s*\}\n\n\s*if \(!familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;/,
+  "familiar-identity tracking/invalidation runs BEFORE the loading/error readiness guard (cave-rl980 Task 4 review), so a transition during an active error is never missed",
+);
+// Applied-session-scope contract (cave-rl980 Task 4 review): `sessions` can
+// still be the OUTGOING familiar's roster for a render or more after
+// `activeFamiliar` itself has already changed (Workspace's session list is
+// fetched scoped to a single active familiar and refetches asynchronously
+// on every switch). The resolve/reconcile below must never run against it
+// until the caller confirms `sessions` corresponds to THIS familiar.
+assert.match(
+  source,
+  /if \(!familiarsLoaded \|\| familiarsError \|\| !sessionsLoaded \|\| sessionsError\) return;\s*\n\s*if \(!sessionsScopeCurrent\) return;/,
+  "the resolve/reconcile is additionally gated on the applied-session-scope contract, checked immediately after readiness/errors",
+);
+
 // Every familiar-identity transition invalidates retained resolution and
 // selection ownership regardless of `open` (cave-rl980 Task 4 spec review),
 // so a closed A -> B -> A round trip is still detected as needing a fresh

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -465,11 +465,13 @@ assert.match(
 );
 
 // Backdrop renders only while a drawer (nav, list, OR right-chat) is open —
-// never for a merely-retained, closed right-chat modal.
+// never for a merely-retained, closed right-chat modal. It's a real <button>
+// (cave-rl980 Task 5 spec finding), not a role="presentation" div, so it's
+// reachable from the keyboard too.
 assert.match(
   drawerSource,
-  /\{open \? \(\s*\n\s*<div\s*\n\s*className="mobile-drawer-backdrop"/,
-  "the backdrop renders only while any drawer is open",
+  /\{open \? \(\s*\n\s*<button\s*\n\s*type="button"\s*\n\s*className="mobile-drawer-backdrop"/,
+  "the backdrop renders only while any drawer is open, as a real <button>",
 );
 
 // Escape ownership: the legacy standalone listener must step aside for the

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -349,4 +349,39 @@ assert.match(source, /<ErrorState\b/, "familiar and session failures render the 
 assert.match(source, /<EmptyState\b/, "the no-active-familiar chooser uses the shared EmptyState");
 assert.match(source, /<Button\b/, "retry and chooser actions use the shared Button");
 
+// A stale applied-session-scope must never block indefinitely once the
+// caller's OWN fetch for that scope has actually failed (cave-rl980 Task 4
+// final review): the loading gate's scope clause only holds while there is
+// still something to wait for.
+assert.match(
+  source,
+  /activeFamiliar !== null && !sessionsScopeCurrent && !hasResolvedRouter && !sessionsError/,
+  "an unconfirmed scope stops blocking rendering the instant the target familiar's own sessions fetch has failed, falling through to the explicit sessions ErrorState instead of an indefinite spinner",
+);
+
+// Persistent, closed roots must be truthfully out of the tab order and the
+// accessibility tree while staying mounted (cave-rl980 Task 4 review) — see
+// RightChatPanelFrame's own doc for why a merely visually-collapsed root is
+// not enough on its own.
+assert.match(
+  source,
+  /function RightChatPanelFrame\(\{\s*open,\s*onClose,/,
+  "the shared frame takes an explicit open prop",
+);
+assert.match(
+  source,
+  /<aside className="right-chat" aria-label="Chat panel" aria-hidden=\{!open\} inert=\{!open\}>/,
+  "the shared frame applies truthful aria-hidden/inert to its own root",
+);
+assert.equal(
+  (source.match(/<RightChatPanelFrame onClose=\{props\.onClose\} open=\{open\}>/g) ?? []).length,
+  4,
+  "every one of the four shared-frame call sites forwards the panel's own open prop",
+);
+assert.match(
+  source,
+  /aria-hidden=\{!open\}\s*\n\s*inert=\{!open\}\s*\n\s*data-session-id=\{selectedSessionId \?\? "new"\}/,
+  "the fully resolved aside applies the same truthful aria-hidden/inert pairing",
+);
+
 console.log("right-chat-panel.test.ts OK");

--- a/src/components/right-chat-panel.test.ts
+++ b/src/components/right-chat-panel.test.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const source = await readFile(new URL("./right-chat-panel.tsx", import.meta.url), "utf8");
+
+assert.match(source, /<aside[^>]+aria-label="Chat panel"/, "desktop content is a named complementary landmark");
+assert.match(
+  source,
+  /compact[\s\S]*hideRail[\s\S]*syncUrlHash=\{false\}[\s\S]*enableSplitPanes=\{false\}/,
+  "the auxiliary router remains compact, hash-neutral, and single-pane",
+);
+assert.match(
+  source,
+  /composerDraftKey=\{`cave:right-chat-composer-draft:v1:\$\{activeFamiliar\.id\}`\}/,
+  "each familiar keeps an auxiliary-only draft",
+);
+assert.match(
+  source,
+  /resolveLatestRightChatSessionId\(sessions, activeFamiliar\.id\)/,
+  "initial and familiar-change resolution uses the canonical helper",
+);
+assert.match(
+  source,
+  /resolvedFamiliarRef\.current === activeFamiliar\.id/,
+  "same-familiar reopen does not replace manual thread selection",
+);
+assert.match(
+  source,
+  /routerRef\.current\?\.newChat\(undefined, undefined, activeFamiliar\.id\)/,
+  "no eligible chat opens a familiar-bound blank compose",
+);
+assert.match(source, /aria-label="Switch Chat panel thread"/, "the compact header exposes a labelled thread switcher");
+assert.match(source, /aria-label="New Chat panel chat"/, "the compact header exposes New chat");
+assert.match(source, /aria-label="Close Chat panel"/, "the compact header exposes Close");
+assert.doesNotMatch(
+  source,
+  /RightPanelKind|companionTabs|agent\?: ReactNode/,
+  "the dedicated wrapper does not restore generic companion concepts",
+);
+
+// Resolution must be scoped to `open` + the active familiar + a loaded,
+// error-free session list — the plan's four gating conditions. This pins the
+// *identical* four-way guard on both the first-open/familiar-change effect and
+// the ineligible-selection re-resolve effect, so neither one accidentally
+// resolves while the panel is closed, no familiar is active, sessions
+// haven't loaded, or the last session load failed.
+const gate = /!open \|\| !activeFamiliar \|\| !sessionsLoaded \|\| sessionsError/g;
+assert.equal(
+  (source.match(gate) ?? []).length,
+  2,
+  "both the initial-resolve and re-resolve effects gate on open, active familiar, loaded sessions, and no session error",
+);
+
+// When the active familiar becomes null, the retained resolution and manual
+// selection must both be cleared instead of quietly pointing at a stale
+// familiar's session the next time a familiar becomes active again.
+assert.match(
+  source,
+  /if \(activeFamiliar\) return;\s*resolvedFamiliarRef\.current = null;\s*setSelectedSessionId\(null\);/,
+  "clearing the active familiar clears the retained resolution and selection",
+);
+
+// Never default to familiars[0] when no familiar is active.
+assert.doesNotMatch(source, /familiars\[0\]/, "the no-active-familiar chooser never silently defaults to the first familiar");
+
+assert.match(source, /useResolvedFamiliars\(familiars\)/, "FamiliarAvatar is fed a ResolvedFamiliar via the shared resolver");
+assert.match(source, /<FamiliarAvatar\b/, "the header renders the resolved avatar");
+assert.match(source, /useAnnouncer\(\)/, "familiar/chat changes are announced via the shared live region");
+assert.match(source, /<ErrorState\b/, "familiar and session failures render the shared ErrorState");
+assert.match(source, /<EmptyState\b/, "the no-active-familiar chooser uses the shared EmptyState");
+assert.match(source, /<Button\b/, "retry and chooser actions use the shared Button");
+
+console.log("right-chat-panel.test.ts OK");

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -24,18 +24,33 @@ import type { Familiar, SessionRow } from "@/lib/types";
  * focus-trapped mobile modal, so every one of those states — not just the
  * fully resolved chat — must expose a discoverable way out instead of
  * trapping focus with no escape affordance.
+ *
+ * `open` is truthful accessibility, not a mount gate (cave-rl980 Task 4
+ * review): Shell keeps this panel mounted while closed (collapsed/hidden via
+ * CSS) so ChatRouter's transcript/stream/scroll/draft survive a close —
+ * "Keep the router mounted" per the design doc — but a persistently-mounted,
+ * merely visually-collapsed root is otherwise still in the tab order and the
+ * accessibility tree, so a sighted mouse user sees nothing while a keyboard
+ * or screen-reader user can still Tab into (and activate) hidden Retry/Close/
+ * New-chat controls or land on hidden chat content. `aria-hidden` + `inert`
+ * together (the same pair `code-terminal-drawer.tsx` uses for its own
+ * "hidden rather than unmounted" drawer) make every frame/root truthfully
+ * absent from both when `open` is false, while an `open` state stays fully
+ * accessible.
  */
 function RightChatPanelFrame({
+  open,
   onClose,
   title = "Chat",
   children,
 }: {
+  open: boolean;
   onClose: () => void;
   title?: string;
   children: ReactNode;
 }) {
   return (
-    <aside className="right-chat" aria-label="Chat panel">
+    <aside className="right-chat" aria-label="Chat panel" aria-hidden={!open} inert={!open}>
       <header className="right-chat__header">
         <strong>{title}</strong>
         <button
@@ -459,13 +474,25 @@ export function RightChatPanel(props: Props) {
   // stale-familiar flash is ever rendered. hasResolvedRouter still protects
   // a LATER, transient scope hiccup for an already-showing familiar exactly
   // like familiarsError/sessionsError below.
+  //
+  // An unconfirmed scope stops blocking the instant `sessionsError` is true
+  // (cave-rl980 Task 4 review, final finding): the caller's fetch for the
+  // scope this exact familiar needs has already failed outright — there is
+  // no future "scope applies" transition left to wait quietly for, only a
+  // real failure to report — so falling through here lets the sessionsError
+  // branch below render the explicit "Couldn't load chats" ErrorState with
+  // Retry instead of an indefinite spinner nothing will ever clear. A scope
+  // that is merely still pending (no error yet) is untouched by this and
+  // keeps rendering Loading exactly as before — first-resolution safety
+  // never resolves against a roster that hasn't actually confirmed it
+  // belongs to this familiar.
   if (
     !familiarsLoaded ||
     !sessionsLoaded ||
-    (activeFamiliar !== null && !sessionsScopeCurrent && !hasResolvedRouter)
+    (activeFamiliar !== null && !sessionsScopeCurrent && !hasResolvedRouter && !sessionsError)
   ) {
     return (
-      <RightChatPanelFrame onClose={props.onClose}>
+      <RightChatPanelFrame onClose={props.onClose} open={open}>
         <div className="right-chat__loading" role="status">
           Loading Chat…
         </div>
@@ -479,7 +506,7 @@ export function RightChatPanel(props: Props) {
   // later transient failure instead of unmounting it into this ErrorState.
   if (familiarsError && !hasResolvedRouter) {
     return (
-      <RightChatPanelFrame onClose={props.onClose}>
+      <RightChatPanelFrame onClose={props.onClose} open={open}>
         <ErrorState
           compact
           headline="Couldn't load familiars"
@@ -492,7 +519,7 @@ export function RightChatPanel(props: Props) {
 
   if (!activeFamiliar) {
     return (
-      <RightChatPanelFrame onClose={props.onClose}>
+      <RightChatPanelFrame onClose={props.onClose} open={open}>
         <EmptyState
           compact
           icon="ph:users-three"
@@ -516,10 +543,12 @@ export function RightChatPanel(props: Props) {
     );
   }
 
-  // Same transient-vs-mounted distinction as familiarsError above.
+  // Same transient-vs-mounted distinction as familiarsError above. Also the
+  // fallback for the stale-scope-plus-fetch-failure case carved out of the
+  // loading gate above: it reaches here unconditional on sessionsScopeCurrent.
   if (sessionsError && !hasResolvedRouter) {
     return (
-      <RightChatPanelFrame onClose={props.onClose}>
+      <RightChatPanelFrame onClose={props.onClose} open={open}>
         <ErrorState
           compact
           headline="Couldn't load chats"
@@ -543,7 +572,17 @@ export function RightChatPanel(props: Props) {
       : null;
 
   return (
-    <aside className="right-chat" aria-label="Chat panel" data-session-id={selectedSessionId ?? "new"}>
+    <aside
+      className="right-chat"
+      aria-label="Chat panel"
+      // Truthful accessibility for the persistently-mounted root, same
+      // rationale as RightChatPanelFrame's own doc above: closed means out of
+      // both the tab order and the accessibility tree, never merely
+      // invisible; open stays fully accessible.
+      aria-hidden={!open}
+      inert={!open}
+      data-session-id={selectedSessionId ?? "new"}
+    >
       <header className="right-chat__header">
         {resolvedActiveFamiliar ? <FamiliarAvatar familiar={resolvedActiveFamiliar} size="sm" /> : null}
         <span className="right-chat__identity">

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useLayoutEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { Button } from "@/components/ui/button";
@@ -97,29 +97,39 @@ export function RightChatPanel(props: Props) {
   // Tracks which familiar's latest session we've already resolved for, so a
   // same-familiar close/reopen never clobbers a manual thread selection —
   // only an actual familiar change (or the very first open) re-resolves.
+  // Updated by the resolution effect below regardless of `open`: a familiar
+  // switch while the panel is closed must still be tracked (cave-rl980 Task 4
+  // review) — the router beneath stays mounted while hidden, and leaving
+  // this stale would desync the header/router the moment the panel reopens.
   const resolvedFamiliarRef = useRef<string | null>(null);
   // Session ids we've actually observed appear in the eligible roster at
   // least once. A freshly promoted session (null → id, reported the instant
   // ChatRouter starts a chat from a blank compose) can arrive here before the
   // `sessions` roster prop has been refetched to include it. Without this,
-  // the ineligible-selection effect below would immediately mistake "not yet
-  // in the roster" for "removed from the roster" and stomp the brand-new
-  // session with a replacement. Gating reconciliation on prior observation
-  // fixes that promotion race with no timing/delay hack — it also lets the
-  // *same* effect correctly reconcile a genuine later removal (archive/
-  // delete) of a session it did previously observe. Committed from an effect
-  // below, never inline during render (cave-rl980 Task 4 review): a render
-  // React abandons before commit must never leave a mark here.
+  // the reconcile branch below would immediately mistake "not yet in the
+  // roster" for "removed from the roster" and stomp the brand-new session
+  // with a replacement. Gating reconciliation on prior observation fixes
+  // that promotion race with no timing/delay hack — it also lets the *same*
+  // branch correctly reconcile a genuine later removal (archive/delete) of a
+  // session it did previously observe. Committed from an effect below, never
+  // inline during render (cave-rl980 Task 4 review): a render React abandons
+  // before commit must never leave a mark here.
   const observedSessionIdsRef = useRef<Set<string>>(new Set());
-  // Armed the instant handleSessionsChanged/handleSessionsDeleted below run,
-  // consumed (read, then reset) by the very next handleActiveSessionChange
-  // report of any kind. ChatView calls exactly one of those two mutation
-  // callbacks and then, synchronously in the same tick, either onBack or
-  // onVoiceSessionDiscarded for every confirmed archive, delete, and
-  // discarded voice pre-session — never for an ordinary back navigation
-  // (e.g. "Back to sessions" on a transcript-history load failure). That
-  // order is the only signal available here for "this null follows a real
-  // roster mutation" versus "this null is just the user navigating away."
+  // Armed the instant handleSessionRemoved below runs, consumed (read, then
+  // reset) by the very next handleActiveSessionChange report of any kind.
+  // handleSessionRemoved is ChatView's own narrow, purpose-built removal
+  // signal (see its `onSessionRemoved` doc in chat-view.tsx) — fired only for
+  // a confirmed archive/delete/discard of the exact session this panel is
+  // showing, and always immediately followed, synchronously in the same
+  // tick, by the null that navigates away (onBack, or onVoiceSessionDiscarded
+  // for a discarded pre-session). Deliberately NOT armed by the generic
+  // onSessionsChanged/onSessionsDeleted refresh callbacks: those also fire
+  // for refreshes that have nothing to do with THIS session's removal (a
+  // canonical-session reconcile after a stream settles, a *different*
+  // thread auto-archiving on reflection, a Board handoff refresh, …), so
+  // treating their firing as a removal signal would misclassify an ordinary
+  // "Back to sessions" that merely happens to land after one of those
+  // unrelated refreshes (cave-rl980 Task 4 review).
   const pendingRemovalRef = useRef(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
@@ -154,29 +164,19 @@ export function RightChatPanel(props: Props) {
   // ordinary "list" transition (the ChatHistoryNotice "Back to sessions"
   // affordance after a transcript load failure — the session itself is still
   // fully eligible; only its transcript failed to fetch) and a genuine
-  // removal (archive's onBack after the PATCH, delete's onBack after the
-  // DELETE, or a discarded empty voice pre-session's onVoiceSessionDiscarded).
-  // The first must clear the stale selection immediately. The second must
-  // retain it long enough for the reconcile effect below to confirm the
-  // removal once the roster refreshes and resolve the same familiar's latest
-  // session (or a new compose) instead of flashing "New chat" the instant
-  // this fires, ahead of the roster actually catching up.
+  // removal (archive/delete's onBack, or a discarded empty voice
+  // pre-session's onVoiceSessionDiscarded). The first must clear the stale
+  // selection immediately. The second must retain it long enough for the
+  // reconcile branch below to confirm the removal once the roster refreshes
+  // and resolve the same familiar's latest session (or a new compose)
+  // instead of flashing "New chat" the instant this fires, ahead of the
+  // roster actually catching up.
   //
-  // pendingRemovalRef — armed by handleSessionsChanged/handleSessionsDeleted,
-  // exactly the two calls every removal path makes immediately before its
-  // null — distinguishes the two. That alone is not sufficient, though: a
-  // discarded voice pre-session also reports through onSessionsChanged
-  // (discardVoiceSessionIfEmpty refreshes the list once the empty session is
-  // deleted server-side) despite never having appeared in the roster to
-  // begin with. Retaining that id would leave a permanent ghost — the
-  // reconcile effect's own observed-gate can never confirm the removal of an
-  // id the roster never listed in the first place. Requiring the id to have
-  // been previously observed eligible closes that gap: only a real,
-  // previously visible session is ever retained; a discarded, never-observed
-  // promotion clears just like an ordinary back. Explicit New chat actions
-  // (the button, the thread switcher, and both resolution effects) bypass
-  // this handler entirely — they already call setSelectedSessionId(null)
-  // directly at the moment they act.
+  // pendingRemovalRef — armed only by handleSessionRemoved, below, for the
+  // exact session it names — distinguishes the two. Explicit New chat
+  // actions (the button, the thread switcher, and both resolution branches
+  // below) bypass this handler entirely — they already call
+  // setSelectedSessionId(null) directly at the moment they act.
   const handleActiveSessionChange = (sessionId: string | null) => {
     const removalConfirmed = pendingRemovalRef.current;
     pendingRemovalRef.current = false;
@@ -189,16 +189,18 @@ export function RightChatPanel(props: Props) {
     );
   };
 
-  // Arms pendingRemovalRef for the very next handleActiveSessionChange report,
-  // then forwards to the real callback unchanged — RightChatPanel observes
-  // the mutation, it never forks it.
-  const handleSessionsChanged = () => {
-    pendingRemovalRef.current = true;
-    props.onSessionsChanged();
-  };
-  const handleSessionsDeleted = (sessionIds: readonly string[]) => {
-    pendingRemovalRef.current = true;
-    props.onSessionsDeleted(sessionIds);
+  // Arms pendingRemovalRef only when the removed session is the one this
+  // panel currently has selected AND has previously observed eligible — the
+  // narrow "selected, observed session" signal cave-rl980 Task 4 review calls
+  // for. Sourced from ChatView's own onSessionRemoved (see its doc), fired
+  // only at the exact archive/delete/discard call sites, never inferred from
+  // onSessionsChanged/onSessionsDeleted — those are forwarded to ChatRouter
+  // entirely unwrapped below, preserving their existing behavior for every
+  // other consumer instead of intercepting every call to guess at removal.
+  const handleSessionRemoved = (removedSessionId: string) => {
+    if (removedSessionId === selectedSessionId && observedSessionIdsRef.current.has(removedSessionId)) {
+      pendingRemovalRef.current = true;
+    }
   };
 
   useEffect(() => {
@@ -208,45 +210,75 @@ export function RightChatPanel(props: Props) {
     setSelectedSessionId(null);
   }, [activeFamiliar]);
 
-  // First open (or a genuine familiar change): resolve that familiar's latest
-  // eligible session, or start a familiar-bound blank compose. Deliberately a
-  // no-op on same-familiar close/reopen — resolvedFamiliarRef already holds
-  // this familiar's id, so a manual mid-conversation selection survives.
-  // Gated on familiars *and* sessions readiness (loaded, error-free) so this
-  // never fires — and never marks resolvedFamiliarRef resolved — on a render
-  // where the router isn't actually mounted (routerRef would be null and the
-  // resolution would silently no-op, permanently skipping the real one).
-  useEffect(() => {
-    if (!open || !activeFamiliar || !familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
-    if (resolvedFamiliarRef.current === activeFamiliar.id) return;
-    resolvedFamiliarRef.current = activeFamiliar.id;
-    const latestId = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
-    if (latestId) routerRef.current?.openSession(latestId);
-    else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
-    setSelectedSessionId(latestId);
-    announce(
-      latestId
-        ? `${activeFamiliar.display_name} chat opened`
-        : `New chat with ${activeFamiliar.display_name}`,
-    );
-  }, [activeFamiliar, announce, familiarsError, familiarsLoaded, open, sessions, sessionsError, sessionsLoaded]);
-
-  // If the selected session stops being eligible (deleted, archived, or
-  // otherwise dropped from the visible list) re-resolve the same familiar's
-  // latest remaining session, or fall back to a familiar-bound blank compose.
-  // Never falls back to another familiar. Reconciles only ids previously
-  // observed in the eligible roster (see observedSessionIdsRef above) so a
-  // just-promoted session the roster hasn't caught up to yet is never
-  // mistaken for one that was removed.
-  useEffect(() => {
-    if (!open || !activeFamiliar || !sessionsLoaded || sessionsError || !selectedSessionId) return;
+  // Resolves the active familiar's latest eligible session (or starts a
+  // familiar-bound blank compose) on first open and on every subsequent
+  // familiar change, and reconciles the selection when it stops being
+  // eligible for the SAME familiar (archived/deleted). One `useLayoutEffect`
+  // handling both, not two separate effects, and not gated on `open` for the
+  // resolution itself (cave-rl980 Task 4 review — see the two reasons below):
+  //
+  // 1. Familiar transitions must be tracked even while the panel is closed.
+  //    ChatRouter/ChatView stay mounted underneath — a persistent controller,
+  //    per the design doc — so pausing resolution while hidden would let a
+  //    closed A -> B -> A sequence leave the header and the actually-mounted
+  //    router disagreeing about which familiar/session is showing by the
+  //    time the panel reopens. `open` still gates the *announcement* below —
+  //    a screen reader has no reason to hear about a change to a panel
+  //    nobody can currently see — but never the resolution itself.
+  // 2. A familiar change must issue EXACTLY ONE imperative openSession/
+  //    newChat call. Splitting this into two effects (one keyed on the
+  //    familiar changing, a second reconciling an ineligible selection) races
+  //    them: on the very render the familiar changes, a second, separate
+  //    effect would still see the OUTGOING familiar's stale
+  //    `selectedSessionId` — never eligible for the new familiar's
+  //    `eligibleSessions`, and (having been observed under the old familiar)
+  //    passing the observed-gate too — so it would ALSO reconcile, firing a
+  //    second, redundant action. Handling "familiar changed" first and
+  //    returning keeps that stale selection from ever reaching the
+  //    eligibility check below; only a same-familiar removal reaches it.
+  //    `useLayoutEffect`, not `useEffect`, so this also wins the ordering
+  //    race against ChatRouter's own internal familiar-switch effect (a
+  //    passive effect): every layout effect across the tree commits before
+  //    any passive effect runs, so by the time ChatRouter's own effect sees
+  //    the new familiar, the view it reads back is already the one this
+  //    effect just set — its own transition becomes a same-value no-op
+  //    instead of a second, independently guessed one.
+  useLayoutEffect(() => {
+    if (!activeFamiliar || !familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
+    if (resolvedFamiliarRef.current !== activeFamiliar.id) {
+      // First open, or a genuine familiar change: resolve fresh. The
+      // outgoing familiar's selection, if any, belongs to a different
+      // familiar entirely and must never be compared against this
+      // familiar's eligible roster below — ownership, not eligibility, is
+      // what just changed.
+      resolvedFamiliarRef.current = activeFamiliar.id;
+      const latestId = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
+      if (latestId) routerRef.current?.openSession(latestId);
+      else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+      setSelectedSessionId(latestId);
+      if (open) {
+        announce(
+          latestId
+            ? `${activeFamiliar.display_name} chat opened`
+            : `New chat with ${activeFamiliar.display_name}`,
+        );
+      }
+      return;
+    }
+    // Same familiar: only reconcile if the selected session stopped being
+    // eligible (deleted, archived, or otherwise dropped from the visible
+    // list) — and only an id previously observed in the eligible roster (see
+    // observedSessionIdsRef above), so a just-promoted session the roster
+    // hasn't caught up to yet is never mistaken for one that was removed.
+    // Never falls back to another familiar.
+    if (!selectedSessionId) return;
     if (eligibleSessions.some((session) => session.id === selectedSessionId)) return;
     if (!observedSessionIdsRef.current.has(selectedSessionId)) return;
     const replacement = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
     if (replacement) routerRef.current?.openSession(replacement);
     else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
     setSelectedSessionId(replacement);
-  }, [activeFamiliar, eligibleSessions, open, selectedSessionId, sessions, sessionsError, sessionsLoaded]);
+  }, [activeFamiliar, announce, eligibleSessions, familiarsError, familiarsLoaded, open, selectedSessionId, sessions, sessionsError, sessionsLoaded]);
 
   if (!familiarsLoaded || !sessionsLoaded) {
     return (
@@ -407,8 +439,9 @@ export function RightChatPanel(props: Props) {
           onRetryFamiliars={props.onRetryFamiliars}
           onSetActiveFamiliar={props.onSetActiveFamiliar}
           onSessionStarted={props.onSessionStarted}
-          onSessionsChanged={handleSessionsChanged}
-          onSessionsDeleted={handleSessionsDeleted}
+          onSessionsChanged={props.onSessionsChanged}
+          onSessionsDeleted={props.onSessionsDeleted}
+          onSessionRemoved={handleSessionRemoved}
           onSlashFromChat={props.onSlashFromChat}
           onOpenOnboarding={props.onOpenOnboarding}
           onOpenTask={props.onOpenTask}

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -131,6 +131,24 @@ export function RightChatPanel(props: Props) {
   // "Back to sessions" that merely happens to land after one of those
   // unrelated refreshes (cave-rl980 Task 4 review).
   const pendingRemovalRef = useRef(false);
+  // Synchronously mirrors the current selection — this panel's active
+  // familiar id and selected session id — the instant either commits (see
+  // the layout effect below, deliberately unguarded by familiarsError/
+  // sessionsError/open so it never lags behind the actual render). Read by
+  // handleSessionRemoved below INSTEAD OF the selectedSessionId/activeFamiliar
+  // closed over at that particular function instance's own creation render.
+  // archiveChat/deleteChat/setChatArchived/discardVoiceSessionIfEmpty are all
+  // async: the specific onSessionRemoved callback ChatView's in-flight
+  // request actually invokes is whichever one was current when THAT request
+  // began, frozen at whatever selectedSessionId/activeFamiliar existed then —
+  // and stays frozen even after the user switches to a different thread or
+  // familiar while the request is still in flight. Comparing against this
+  // ref instead means the check always sees the LATEST truth, regardless of
+  // how stale the invoked closure is (cave-rl980 Task 4 final review).
+  const currentSelectionRef = useRef<{ familiarId: string | null; sessionId: string | null }>({
+    familiarId: null,
+    sessionId: null,
+  });
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
   const resolvedActiveFamiliar =
@@ -147,6 +165,14 @@ export function RightChatPanel(props: Props) {
   // not-yet-mounted router from ever being marked resolved.
   const hasResolvedRouter = activeFamiliar !== null && resolvedFamiliarRef.current === activeFamiliar.id;
   const { announce } = useAnnouncer();
+
+  // Commits currentSelectionRef the instant either half changes — a plain
+  // useLayoutEffect with no early-return guard, unlike the big resolution
+  // effect below, so it can never lag behind the actual rendered selection
+  // during a familiarsError/sessionsError/closed state.
+  useLayoutEffect(() => {
+    currentSelectionRef.current = { familiarId: activeFamiliar?.id ?? null, sessionId: selectedSessionId };
+  }, [activeFamiliar, selectedSessionId]);
 
   // Fold the current eligible roster into the observed-ids record after
   // commit, not inline during render (cave-rl980 Task 4 review): an id only
@@ -189,18 +215,37 @@ export function RightChatPanel(props: Props) {
     );
   };
 
-  // Arms pendingRemovalRef only when the removed session is the one this
-  // panel currently has selected AND has previously observed eligible — the
-  // narrow "selected, observed session" signal cave-rl980 Task 4 review calls
-  // for. Sourced from ChatView's own onSessionRemoved (see its doc), fired
-  // only at the exact archive/delete/discard call sites, never inferred from
+  // Arms pendingRemovalRef only when the removed session is STILL the one
+  // this panel currently has selected, for the same familiar, AND has
+  // previously observed eligible — the narrow "current selected, observed
+  // session" signal cave-rl980 Task 4 review calls for. Sourced from
+  // ChatView's own onSessionRemoved (see its doc), fired only at the exact
+  // archive/delete/discard call sites, never inferred from
   // onSessionsChanged/onSessionsDeleted — those are forwarded to ChatRouter
   // entirely unwrapped below, preserving their existing behavior for every
   // other consumer instead of intercepting every call to guess at removal.
+  //
+  // Deliberately reads currentSelectionRef, NOT the selectedSessionId/
+  // activeFamiliar closed over by this exact function instance: this
+  // specific handleSessionRemoved is whichever one ChatView's async
+  // archive/delete/discard request captured when IT began, and by the time
+  // that request settles the user may have already switched to a different
+  // thread or familiar. Comparing the removed id against a frozen selection
+  // from before the switch would incorrectly arm retention for a session
+  // nobody is looking at anymore; the ref always reflects the CURRENT truth
+  // instead (cave-rl980 Task 4 final review). A single sessionId comparison
+  // against the ref already covers "for the same familiar" too — a session
+  // id is only ever the panel's selectedSessionId while its owning familiar
+  // is active (see the activeFamiliar-cleared effect above and the
+  // resolution effect below, which never carries a selection across a
+  // familiar change), so currentSelectionRef.sessionId can equal
+  // removedSessionId only when currentSelectionRef.familiarId is the
+  // familiar that removal actually happened under.
   const handleSessionRemoved = (removedSessionId: string) => {
-    if (removedSessionId === selectedSessionId && observedSessionIdsRef.current.has(removedSessionId)) {
-      pendingRemovalRef.current = true;
-    }
+    const current = currentSelectionRef.current;
+    if (current.sessionId !== removedSessionId) return;
+    if (!observedSessionIdsRef.current.has(removedSessionId)) return;
+    pendingRemovalRef.current = true;
   };
 
   useEffect(() => {

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -6,6 +6,7 @@ import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
+import { StandardSelect } from "@/components/ui/select";
 import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import { FocusTrapOwnerHiddenContext } from "@/lib/use-focus-trap";
@@ -606,12 +607,11 @@ export function RightChatPanel(props: Props) {
           <strong>{activeFamiliar.display_name}</strong>
           <span title={title}>{title}</span>
         </span>
-        <select
-          className="focus-ring right-chat__thread-switcher"
-          aria-label="Switch Chat panel thread"
+        <StandardSelect
+          className="right-chat__thread-switcher"
+          label="Switch Chat panel thread"
           value={selectedSessionId ?? "__new__"}
-          onChange={(event) => {
-            const nextId = event.currentTarget.value;
+          onChange={(nextId) => {
             if (nextId === "__new__") {
               routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
               setSelectedSessionId(null);
@@ -623,14 +623,14 @@ export function RightChatPanel(props: Props) {
             const nextSession = eligibleSessions.find((session) => session.id === nextId);
             announce(`${nextSession ? sessionRailTitle(nextSession) : "Chat"} opened`);
           }}
-        >
-          <option value="__new__">New chat</option>
-          {eligibleSessions.map((session) => (
-            <option key={session.id} value={session.id}>
-              {sessionRailTitle(session)}
-            </option>
-          ))}
-        </select>
+          options={[
+            { value: "__new__", label: "New chat" },
+            ...eligibleSessions.map((session) => ({
+              value: session.id,
+              label: sessionRailTitle(session),
+            })),
+          ]}
+        />
         <button
           type="button"
           className="focus-ring right-chat__icon-button"

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -8,6 +8,7 @@ import { EmptyState } from "@/components/ui/empty-state";
 import { ErrorState } from "@/components/ui/error-state";
 import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
+import { FocusTrapOwnerHiddenContext } from "@/lib/use-focus-trap";
 import {
   eligibleRightChatSessions,
   isCurrentRightChatSessionsScope,
@@ -37,6 +38,22 @@ import type { Familiar, SessionRow } from "@/lib/types";
  * "hidden rather than unmounted" drawer) make every frame/root truthfully
  * absent from both when `open` is false, while an `open` state stays fully
  * accessible.
+ *
+ * `FocusTrapOwnerHiddenContext.Provider value={!open}` (cave-rl980 Task 5
+ * finding #2) covers the gap `inert` alone leaves open: `inert` is a DOM
+ * attribute, so it only reaches DESCENDANTS in the DOM tree — but a child
+ * dialog rendered from deep inside `children` (e.g. ChatRouter's transcript
+ * opening ChatArtifactViewer's fullscreen view, ChatSpecCard, or
+ * ImageCarousel's lightbox) portals to `document.body` directly via
+ * `createPortal`, landing as a DOM SIBLING of this `<aside>`, never a
+ * descendant — so this element's own `inert` never reaches it. The context
+ * still does, because `createPortal` only relocates the DOM node; it never
+ * changes REACT ancestry. Every one of those dialogs already calls
+ * `useFocusTrap`, which consumes this context automatically, so closing this
+ * panel now asks any such still-open child to close too, through the SAME
+ * onEscape callback it already wires up for the Escape key — no DOM
+ * relocation hack, no new event bus, no changes needed to any of those
+ * components themselves.
  */
 function RightChatPanelFrame({
   open,
@@ -62,7 +79,7 @@ function RightChatPanelFrame({
           <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
         </button>
       </header>
-      {children}
+      <FocusTrapOwnerHiddenContext.Provider value={!open}>{children}</FocusTrapOwnerHiddenContext.Provider>
     </aside>
   );
 }
@@ -635,48 +652,59 @@ export function RightChatPanel(props: Props) {
           <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
         </button>
       </header>
-      {transientErrorHeadline ? (
-        <ErrorState
-          compact
-          headline={transientErrorHeadline}
-          subtitle={familiarsError ?? "Your conversations are still safe."}
-          actions={
-            <Button onClick={familiarsError ? props.onRetryFamiliars : props.onRetrySessions}>
-              Retry
-            </Button>
-          }
-        />
-      ) : null}
-      <div className="right-chat__content">
-        <ChatRouter
-          ref={routerRef}
-          familiar={activeFamiliar}
-          familiars={familiars}
-          sessions={sessions}
-          daemonRunning={daemonRunning}
-          sessionsLoaded={sessionsLoaded}
-          sessionsError={sessionsError}
-          familiarsLoaded={familiarsLoaded}
-          familiarsError={familiarsError}
-          onRetryFamiliars={props.onRetryFamiliars}
-          onSetActiveFamiliar={props.onSetActiveFamiliar}
-          onSessionStarted={props.onSessionStarted}
-          onSessionsChanged={props.onSessionsChanged}
-          onSessionsDeleted={props.onSessionsDeleted}
-          onSessionRemoved={handleSessionRemoved}
-          onSlashFromChat={props.onSlashFromChat}
-          onOpenOnboarding={props.onOpenOnboarding}
-          onOpenTask={props.onOpenTask}
-          onOpenUrl={props.onOpenUrl}
-          onActiveSessionChange={handleActiveSessionChange}
-          composerDraftKey={`cave:right-chat-composer-draft:v1:${activeFamiliar.id}`}
-          compact
-          hideRail
-          syncUrlHash={false}
-          enableSplitPanes={false}
-          activeFamiliarId={activeFamiliar.id}
-        />
-      </div>
+      {/*
+        FocusTrapOwnerHiddenContext.Provider value={!open} (cave-rl980 Task 5
+        finding #2) — see RightChatPanelFrame's doc comment above for the
+        full rationale. This is the branch that actually mounts ChatRouter,
+        so it's the one that matters most: a still-open ChatArtifactViewer
+        fullscreen view, ChatSpecCard, or ImageCarousel lightbox opened from
+        the transcript below is asked to close the instant this panel
+        becomes hidden/inert, through its own existing onEscape callback.
+      */}
+      <FocusTrapOwnerHiddenContext.Provider value={!open}>
+        {transientErrorHeadline ? (
+          <ErrorState
+            compact
+            headline={transientErrorHeadline}
+            subtitle={familiarsError ?? "Your conversations are still safe."}
+            actions={
+              <Button onClick={familiarsError ? props.onRetryFamiliars : props.onRetrySessions}>
+                Retry
+              </Button>
+            }
+          />
+        ) : null}
+        <div className="right-chat__content">
+          <ChatRouter
+            ref={routerRef}
+            familiar={activeFamiliar}
+            familiars={familiars}
+            sessions={sessions}
+            daemonRunning={daemonRunning}
+            sessionsLoaded={sessionsLoaded}
+            sessionsError={sessionsError}
+            familiarsLoaded={familiarsLoaded}
+            familiarsError={familiarsError}
+            onRetryFamiliars={props.onRetryFamiliars}
+            onSetActiveFamiliar={props.onSetActiveFamiliar}
+            onSessionStarted={props.onSessionStarted}
+            onSessionsChanged={props.onSessionsChanged}
+            onSessionsDeleted={props.onSessionsDeleted}
+            onSessionRemoved={handleSessionRemoved}
+            onSlashFromChat={props.onSlashFromChat}
+            onOpenOnboarding={props.onOpenOnboarding}
+            onOpenTask={props.onOpenTask}
+            onOpenUrl={props.onOpenUrl}
+            onActiveSessionChange={handleActiveSessionChange}
+            composerDraftKey={`cave:right-chat-composer-draft:v1:${activeFamiliar.id}`}
+            compact
+            hideRail
+            syncUrlHash={false}
+            enableSplitPanes={false}
+            activeFamiliarId={activeFamiliar.id}
+          />
+        </div>
+      </FocusTrapOwnerHiddenContext.Provider>
     </aside>
   );
 }

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -10,7 +10,9 @@ import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
 import { useAnnouncer } from "@/components/ui/live-region";
 import {
   eligibleRightChatSessions,
+  isCurrentRightChatSessionsScope,
   resolveLatestRightChatSessionId,
+  type RightChatSessionsScope,
 } from "@/lib/right-chat-session";
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
@@ -57,6 +59,21 @@ type Props = {
   sessions: SessionRow[];
   sessionsLoaded: boolean;
   sessionsError: boolean;
+  /**
+   * Applied-session-scope contract (cave-rl980 Task 4 review): the familiar
+   * id the CALLER currently guarantees `sessions` reflects. Workspace's own
+   * session list is fetched scoped to a single active familiar and refetches
+   * asynchronously on every familiar switch (see `loadSessions` in
+   * workspace.tsx), so `sessions` can still hold the OUTGOING familiar's rows
+   * for a render or more after `activeFamiliar` itself has already flipped —
+   * resolving eagerly against it would risk opening a blank compose for a
+   * familiar that actually has chats, or the reverse. Omit this prop (or
+   * pass `undefined`) until Workspace tracks and supplies its own applied
+   * scope (Task 7 wires it): `sessions` is then trusted as already current,
+   * preserving this contract exactly for every caller that hasn't adopted
+   * it yet. See `isCurrentRightChatSessionsScope` in right-chat-session.ts.
+   */
+  sessionsScopeFamiliarId?: RightChatSessionsScope;
   familiarsLoaded: boolean;
   familiarsError: string | null;
   daemonRunning: boolean;
@@ -89,6 +106,7 @@ export function RightChatPanel(props: Props) {
     sessions,
     sessionsLoaded,
     sessionsError,
+    sessionsScopeFamiliarId,
     familiarsLoaded,
     familiarsError,
     daemonRunning,
@@ -179,6 +197,14 @@ export function RightChatPanel(props: Props) {
   // (via the gate on the first-resolution effect below) keeps a null,
   // not-yet-mounted router from ever being marked resolved.
   const hasResolvedRouter = activeFamiliar !== null && resolvedFamiliarRef.current === activeFamiliar.id;
+  // True once `sessions` is confirmed to correspond to the active familiar
+  // (cave-rl980 Task 4 review — see isCurrentRightChatSessionsScope's doc in
+  // right-chat-session.ts). Always true while the caller hasn't adopted the
+  // applied-scope contract yet (sessionsScopeFamiliarId left undefined),
+  // preserving today's behavior exactly until Workspace wires it (Task 7).
+  const sessionsScopeCurrent =
+    activeFamiliar === null ||
+    isCurrentRightChatSessionsScope(sessionsScopeFamiliarId, activeFamiliar.id);
   const { announce } = useAnnouncer();
 
   // Commits currentSelectionRef the instant either half changes — a plain
@@ -313,26 +339,41 @@ export function RightChatPanel(props: Props) {
   // handling both, not two separate effects (cave-rl980 Task 4 review — see
   // the reasons below):
   //
-  // 1. Every familiar-identity TRANSITION is tracked via trackedFamiliarIdRef
-  //    regardless of `open` — ChatRouter/ChatView stay mounted underneath as
-  //    a persistent controller, per the design doc, so a familiar change must
-  //    be noticed even while hidden. A closed A -> B -> A round trip must
-  //    still invalidate whatever was resolved for the earlier A: without
-  //    this tracking, coming back to A would find resolvedFamiliarRef still
-  //    reading "A" (never touched while closed) and wrongly conclude nothing
-  //    had changed. But the actual RESOLVE — the imperative
-  //    openSession/newChat call, and setting selectedSessionId — is a
-  //    completely separate, `open`-gated step (cave-rl980 Task 4 spec
-  //    review): first-open semantics require resolving against whichever
+  // 1. Familiar-identity tracking/invalidation happens FIRST, unconditional
+  //    on familiars/sessions readiness or errors (cave-rl980 Task 4 review):
+  //    a closed A -> B -> A round trip must still be detected as a real
+  //    transition even while a roster error is active throughout, or
+  //    trackedFamiliarIdRef would never advance past the ORIGINAL A, and the
+  //    later return to A would be mistaken for "nothing changed" — silently
+  //    retaining A's stale resolution once the error clears and the panel
+  //    reopens, instead of forcing the fresh resolve a real transition
+  //    requires. Every familiar-identity TRANSITION is tracked via
+  //    trackedFamiliarIdRef regardless of `open` too — ChatRouter/ChatView
+  //    stay mounted underneath as a persistent controller, per the design
+  //    doc, so a familiar change must be noticed even while hidden. But the
+  //    actual RESOLVE — the imperative openSession/newChat call, and setting
+  //    selectedSessionId — remains a separate, readiness/scope/`open`-gated
+  //    step below: first-open semantics require resolving against whichever
   //    session is newest at the moment the panel actually becomes visible,
-  //    never one resolved earlier while hidden. So a closed transition
-  //    invalidates ownership here but issues no router call at all; this
-  //    same effect performs the real resolve — against live, then-current
-  //    `sessions` — the instant `open` flips true, since `open` is itself a
+  //    never one resolved earlier while hidden or against stale data. So a
+  //    closed, erroring, or not-yet-scoped transition invalidates ownership
+  //    here but issues no router call at all; this same effect performs the
+  //    real resolve once every gate clears, since each gate is itself a
   //    dependency below. A same-familiar close/reopen (no transition at all)
-  //    never invalidates anything, so it preserves a manual thread
-  //    selection exactly as before.
-  // 2. A familiar change must issue EXACTLY ONE imperative openSession/
+  //    never invalidates anything, so it preserves a manual thread selection
+  //    exactly as before.
+  // 2. The resolve/reconcile itself additionally requires `sessions` to be
+  //    CONFIRMED to reflect this exact familiar (cave-rl980 Task 4 review):
+  //    Workspace's own session list is fetched scoped to a single active
+  //    familiar and refetches asynchronously on every switch, so `sessions`
+  //    can still hold the OUTGOING familiar's rows for a render or more
+  //    after `activeFamiliar` itself has already changed. Resolving against
+  //    it regardless would risk opening a blank compose for a familiar that
+  //    actually has chats, or the reverse. See sessionsScopeCurrent (derived
+  //    above via isCurrentRightChatSessionsScope in right-chat-session.ts) —
+  //    omitting sessionsScopeFamiliarId (Task 7 has not wired Workspace's own
+  //    scope yet) always reports current, so this gate is a no-op until then.
+  // 3. A familiar change must issue EXACTLY ONE imperative openSession/
   //    newChat call while open. Splitting this into two effects (one keyed
   //    on the familiar changing, a second reconciling an ineligible
   //    selection) races them: on the very render the familiar changes, a
@@ -351,19 +392,23 @@ export function RightChatPanel(props: Props) {
   //    effect just set — its own transition becomes a same-value no-op
   //    instead of a second, independently guessed one.
   useLayoutEffect(() => {
-    if (!activeFamiliar || !familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
+    if (!activeFamiliar) return;
 
     if (trackedFamiliarIdRef.current !== activeFamiliar.id) {
       // A transition just occurred — possibly back to a familiar visited
-      // earlier in the same closed stretch (closed A -> B -> A) — so
+      // earlier in the same closed stretch (closed A -> B -> A), or one that
+      // happened entirely while familiars/sessions were erroring — so
       // whatever resolution/selection ownership was previously recorded
       // belongs to a different occupancy and must never be trusted for this
-      // one, regardless of `open`.
+      // one, regardless of `open`, readiness, errors, or scope.
       trackedFamiliarIdRef.current = activeFamiliar.id;
       resolvedFamiliarRef.current = null;
       pendingRemovalRef.current = false;
       setSelectedSessionId(null);
     }
+
+    if (!familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
+    if (!sessionsScopeCurrent) return;
 
     if (resolvedFamiliarRef.current !== activeFamiliar.id) {
       // First open, or a genuine familiar change: needs a fresh resolve.
@@ -398,9 +443,27 @@ export function RightChatPanel(props: Props) {
     if (replacement) routerRef.current?.openSession(replacement);
     else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
     setSelectedSessionId(replacement);
-  }, [activeFamiliar, announce, eligibleSessions, familiarsError, familiarsLoaded, open, selectedSessionId, sessions, sessionsError, sessionsLoaded]);
+  }, [activeFamiliar, announce, eligibleSessions, familiarsError, familiarsLoaded, open, selectedSessionId, sessions, sessionsError, sessionsLoaded, sessionsScopeCurrent]);
 
-  if (!familiarsLoaded || !sessionsLoaded) {
+  // Blocks rendering — including ChatRouter's own mount — while the active
+  // familiar's sessions scope hasn't been confirmed yet, for a familiar that
+  // has never resolved before (cave-rl980 Task 4 review). Merely skipping
+  // RightChatPanel's own resolve effect above is not enough on its own:
+  // ChatRouter/ChatView already flip to a fresh, familiar-bound blank
+  // compose the instant their own `familiar` prop changes (their own
+  // internal familiar-switch effect), independent of whether this component
+  // ever calls openSession/newChat. Keeping ChatRouter unmounted until scope
+  // is confirmed — the same treatment as the plain loading gate below —
+  // means it never even sees the new familiar until the effect above is
+  // ready to resolve it in the very same commit, so no early blank or
+  // stale-familiar flash is ever rendered. hasResolvedRouter still protects
+  // a LATER, transient scope hiccup for an already-showing familiar exactly
+  // like familiarsError/sessionsError below.
+  if (
+    !familiarsLoaded ||
+    !sessionsLoaded ||
+    (activeFamiliar !== null && !sessionsScopeCurrent && !hasResolvedRouter)
+  ) {
     return (
       <RightChatPanelFrame onClose={props.onClose}>
         <div className="right-chat__loading" role="status">

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
 import { FamiliarAvatar } from "@/components/familiar-avatar";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,40 @@ import {
 import { sessionRailTitle } from "@/lib/session-rail-title";
 import { useResolvedFamiliars } from "@/lib/familiar-resolve";
 import type { Familiar, SessionRow } from "@/lib/types";
+
+/**
+ * Shared frame for every loading/error/chooser state: a named `<aside>` plus
+ * a header carrying a title and a Close action. The panel can render inside a
+ * focus-trapped mobile modal, so every one of those states — not just the
+ * fully resolved chat — must expose a discoverable way out instead of
+ * trapping focus with no escape affordance.
+ */
+function RightChatPanelFrame({
+  onClose,
+  title = "Chat",
+  children,
+}: {
+  onClose: () => void;
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <aside className="right-chat" aria-label="Chat panel">
+      <header className="right-chat__header">
+        <strong>{title}</strong>
+        <button
+          type="button"
+          className="focus-ring right-chat__icon-button"
+          aria-label="Close Chat panel"
+          onClick={onClose}
+        >
+          <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
+        </button>
+      </header>
+      {children}
+    </aside>
+  );
+}
 
 type Props = {
   open: boolean;
@@ -64,6 +98,17 @@ export function RightChatPanel(props: Props) {
   // same-familiar close/reopen never clobbers a manual thread selection —
   // only an actual familiar change (or the very first open) re-resolves.
   const resolvedFamiliarRef = useRef<string | null>(null);
+  // Session ids we've actually observed appear in the eligible roster at
+  // least once. A freshly promoted session (null → id, reported the instant
+  // ChatRouter starts a chat from a blank compose) can arrive here before the
+  // `sessions` roster prop has been refetched to include it. Without this,
+  // the ineligible-selection effect below would immediately mistake "not yet
+  // in the roster" for "removed from the roster" and stomp the brand-new
+  // session with a replacement. Gating reconciliation on prior observation
+  // fixes that promotion race with no timing/delay hack — it also lets the
+  // *same* effect correctly reconcile a genuine later removal (archive/
+  // delete) of a session it did previously observe.
+  const observedSessionIdsRef = useRef<Set<string>>(new Set());
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
   const resolvedActiveFamiliar =
@@ -72,7 +117,31 @@ export function RightChatPanel(props: Props) {
     () => eligibleRightChatSessions(sessions, activeFamiliar?.id ?? null),
     [activeFamiliar?.id, sessions],
   );
+  for (const session of eligibleSessions) observedSessionIdsRef.current.add(session.id);
+  // True once this exact familiar's router has actually resolved/mounted —
+  // independent of any *current* familiarsError/sessionsError. Lets a
+  // transient roster refresh failure surface loading/error UI without
+  // unmounting the already-live ChatRouter (transcript/stream/scroll), and
+  // (via the gate on the first-resolution effect below) keeps a null,
+  // not-yet-mounted router from ever being marked resolved.
+  const hasResolvedRouter = activeFamiliar !== null && resolvedFamiliarRef.current === activeFamiliar.id;
   const { announce } = useAnnouncer();
+
+  // ChatRouter can report a null active session organically — an in-place
+  // archive (ChatView's onBack after the archive PATCH), a delete, or a
+  // discarded empty voice pre-session — with no accompanying explicit action
+  // from this panel. That null carries no session identity, so overwriting
+  // `selectedSessionId` here would drop the very id the reconcile effect
+  // below needs in order to detect the confirmed removal once the roster
+  // refreshes and resolve the same familiar's latest session (or a new
+  // compose). Every *explicit* transition to a blank compose (the New chat
+  // button, the thread switcher's New chat option, and both resolution
+  // effects when no session is left) already calls `setSelectedSessionId(null)`
+  // itself at the moment it acts, so this handler only ever needs to forward
+  // a real, non-null id.
+  const handleActiveSessionChange = (sessionId: string | null) => {
+    if (sessionId !== null) setSelectedSessionId(sessionId);
+  };
 
   useEffect(() => {
     if (activeFamiliar) return;
@@ -84,8 +153,12 @@ export function RightChatPanel(props: Props) {
   // eligible session, or start a familiar-bound blank compose. Deliberately a
   // no-op on same-familiar close/reopen — resolvedFamiliarRef already holds
   // this familiar's id, so a manual mid-conversation selection survives.
+  // Gated on familiars *and* sessions readiness (loaded, error-free) so this
+  // never fires — and never marks resolvedFamiliarRef resolved — on a render
+  // where the router isn't actually mounted (routerRef would be null and the
+  // resolution would silently no-op, permanently skipping the real one).
   useEffect(() => {
-    if (!open || !activeFamiliar || !sessionsLoaded || sessionsError) return;
+    if (!open || !activeFamiliar || !familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
     if (resolvedFamiliarRef.current === activeFamiliar.id) return;
     resolvedFamiliarRef.current = activeFamiliar.id;
     const latestId = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
@@ -97,15 +170,19 @@ export function RightChatPanel(props: Props) {
         ? `${activeFamiliar.display_name} chat opened`
         : `New chat with ${activeFamiliar.display_name}`,
     );
-  }, [activeFamiliar, announce, open, sessions, sessionsError, sessionsLoaded]);
+  }, [activeFamiliar, announce, familiarsError, familiarsLoaded, open, sessions, sessionsError, sessionsLoaded]);
 
   // If the selected session stops being eligible (deleted, archived, or
   // otherwise dropped from the visible list) re-resolve the same familiar's
   // latest remaining session, or fall back to a familiar-bound blank compose.
-  // Never falls back to another familiar.
+  // Never falls back to another familiar. Reconciles only ids previously
+  // observed in the eligible roster (see observedSessionIdsRef above) so a
+  // just-promoted session the roster hasn't caught up to yet is never
+  // mistaken for one that was removed.
   useEffect(() => {
     if (!open || !activeFamiliar || !sessionsLoaded || sessionsError || !selectedSessionId) return;
     if (eligibleSessions.some((session) => session.id === selectedSessionId)) return;
+    if (!observedSessionIdsRef.current.has(selectedSessionId)) return;
     const replacement = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
     if (replacement) routerRef.current?.openSession(replacement);
     else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
@@ -114,41 +191,34 @@ export function RightChatPanel(props: Props) {
 
   if (!familiarsLoaded || !sessionsLoaded) {
     return (
-      <aside className="right-chat" aria-label="Chat panel">
+      <RightChatPanelFrame onClose={props.onClose}>
         <div className="right-chat__loading" role="status">
           Loading Chat…
         </div>
-      </aside>
+      </RightChatPanelFrame>
     );
   }
 
-  if (familiarsError) {
+  // Only blocks on a familiars-roster failure the first time this familiar's
+  // router hasn't resolved yet — once resolved, hasResolvedRouter keeps the
+  // mounted ChatRouter (and its transcript/stream/scroll) on screen through a
+  // later transient failure instead of unmounting it into this ErrorState.
+  if (familiarsError && !hasResolvedRouter) {
     return (
-      <aside className="right-chat" aria-label="Chat panel">
+      <RightChatPanelFrame onClose={props.onClose}>
         <ErrorState
           compact
           headline="Couldn't load familiars"
           subtitle={familiarsError}
           actions={<Button onClick={props.onRetryFamiliars}>Retry</Button>}
         />
-      </aside>
+      </RightChatPanelFrame>
     );
   }
 
   if (!activeFamiliar) {
     return (
-      <aside className="right-chat" aria-label="Chat panel">
-        <header className="right-chat__header">
-          <strong>Chat</strong>
-          <button
-            type="button"
-            className="focus-ring right-chat__icon-button"
-            aria-label="Close Chat panel"
-            onClick={props.onClose}
-          >
-            <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
-          </button>
-        </header>
+      <RightChatPanelFrame onClose={props.onClose}>
         <EmptyState
           compact
           icon="ph:users-three"
@@ -156,7 +226,7 @@ export function RightChatPanel(props: Props) {
           subtitle="The Chat panel won't choose one for you."
           actions={
             <div className="right-chat__familiar-grid">
-              {familiars.map((familiar) => (
+              {resolvedFamiliars.map((familiar) => (
                 <Button
                   key={familiar.id}
                   variant="secondary"
@@ -168,25 +238,35 @@ export function RightChatPanel(props: Props) {
             </div>
           }
         />
-      </aside>
+      </RightChatPanelFrame>
     );
   }
 
-  if (sessionsError && resolvedFamiliarRef.current !== activeFamiliar.id) {
+  // Same transient-vs-mounted distinction as familiarsError above.
+  if (sessionsError && !hasResolvedRouter) {
     return (
-      <aside className="right-chat" aria-label="Chat panel">
+      <RightChatPanelFrame onClose={props.onClose}>
         <ErrorState
           compact
           headline="Couldn't load chats"
           subtitle="Your conversations are still safe."
           actions={<Button onClick={props.onRetrySessions}>Retry</Button>}
         />
-      </aside>
+      </RightChatPanelFrame>
     );
   }
 
   const title =
     eligibleSessions.find((session) => session.id === selectedSessionId)?.title ?? "New chat";
+  // Surfaced *alongside* the mounted router below rather than replacing it —
+  // familiarsError/sessionsError already passed the blocking branches above
+  // (hasResolvedRouter is true), so this is a transient refresh failure, not
+  // a first-load failure, and must not disturb the live chat.
+  const transientErrorHeadline = familiarsError
+    ? "Couldn't refresh familiars"
+    : sessionsError
+      ? "Couldn't refresh chats"
+      : null;
 
   return (
     <aside className="right-chat" aria-label="Chat panel" data-session-id={selectedSessionId ?? "new"}>
@@ -242,6 +322,18 @@ export function RightChatPanel(props: Props) {
           <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
         </button>
       </header>
+      {transientErrorHeadline ? (
+        <ErrorState
+          compact
+          headline={transientErrorHeadline}
+          subtitle={familiarsError ?? "Your conversations are still safe."}
+          actions={
+            <Button onClick={familiarsError ? props.onRetryFamiliars : props.onRetrySessions}>
+              Retry
+            </Button>
+          }
+        />
+      ) : null}
       <div className="right-chat__content">
         <ChatRouter
           ref={routerRef}
@@ -262,7 +354,7 @@ export function RightChatPanel(props: Props) {
           onOpenOnboarding={props.onOpenOnboarding}
           onOpenTask={props.onOpenTask}
           onOpenUrl={props.onOpenUrl}
-          onActiveSessionChange={setSelectedSessionId}
+          onActiveSessionChange={handleActiveSessionChange}
           composerDraftKey={`cave:right-chat-composer-draft:v1:${activeFamiliar.id}`}
           compact
           hideRail

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -94,14 +94,29 @@ export function RightChatPanel(props: Props) {
     daemonRunning,
   } = props;
   const routerRef = useRef<ChatRouterHandle | null>(null);
-  // Tracks which familiar's latest session we've already resolved for, so a
-  // same-familiar close/reopen never clobbers a manual thread selection —
-  // only an actual familiar change (or the very first open) re-resolves.
-  // Updated by the resolution effect below regardless of `open`: a familiar
-  // switch while the panel is closed must still be tracked (cave-rl980 Task 4
-  // review) — the router beneath stays mounted while hidden, and leaving
-  // this stale would desync the header/router the moment the panel reopens.
+  // Tracks which familiar's latest session has actually been RESOLVED (an
+  // imperative openSession/newChat call issued and selectedSessionId set to
+  // match), so a same-familiar close/reopen never clobbers a manual thread
+  // selection — only an actual familiar change re-resolves. Only ever set to
+  // a familiar id by an actual resolve, which only happens while `open`
+  // (cave-rl980 Task 4 spec review: first-open semantics require resolving
+  // against whichever session is newest at the moment the panel actually
+  // becomes visible, never one resolved earlier while hidden). Invalidated
+  // back to null — regardless of `open` — the instant trackedFamiliarIdRef
+  // below detects a transition, so a closed familiar change still forces a
+  // fresh resolve once the panel actually reopens.
   const resolvedFamiliarRef = useRef<string | null>(null);
+  // The familiar id this panel is currently tracking, updated on EVERY
+  // activeFamiliar change regardless of `open` or whether a resolve actually
+  // happened — its only job is detecting that a transition occurred at all,
+  // even a closed A -> B -> A round trip that lands back on a familiar id
+  // resolvedFamiliarRef would otherwise still (wrongly) appear to agree
+  // with, since resolvedFamiliarRef itself is never touched while closed.
+  // Whenever this disagrees with the incoming activeFamiliar.id, the
+  // resolution effect below invalidates resolvedFamiliarRef and the current
+  // selection — regardless of `open` — so the closed round trip is still
+  // detected the instant the panel reopens (cave-rl980 Task 4 spec review).
+  const trackedFamiliarIdRef = useRef<string | null>(null);
   // Session ids we've actually observed appear in the eligible roster at
   // least once. A freshly promoted session (null → id, reported the instant
   // ChatRouter starts a chat from a blank compose) can arrive here before the
@@ -193,10 +208,14 @@ export function RightChatPanel(props: Props) {
   // removal (archive/delete's onBack, or a discarded empty voice
   // pre-session's onVoiceSessionDiscarded). The first must clear the stale
   // selection immediately. The second must retain it long enough for the
-  // reconcile branch below to confirm the removal once the roster refreshes
-  // and resolve the same familiar's latest session (or a new compose)
-  // instead of flashing "New chat" the instant this fires, ahead of the
-  // roster actually catching up.
+  // roster itself to confirm the removal (the same-familiar reconcile branch
+  // below replaces it once `sessions` actually drops it) instead of flashing
+  // "New chat" the instant this fires, ahead of the roster actually catching
+  // up — UNLESS the removed session was never observed in the eligible
+  // roster at all (a promoted/voice session discarded before the roster ever
+  // caught up to it), in which case there is no future "roster confirms
+  // removal" transition to wait for, so a replacement is resolved
+  // immediately instead (cave-rl980 Task 4 spec review).
   //
   // pendingRemovalRef — armed only by handleSessionRemoved, below, for the
   // exact session it names — distinguishes the two. Explicit New chat
@@ -210,20 +229,53 @@ export function RightChatPanel(props: Props) {
       setSelectedSessionId(sessionId);
       return;
     }
-    setSelectedSessionId((prev) =>
-      removalConfirmed && prev !== null && observedSessionIdsRef.current.has(prev) ? prev : null,
-    );
+    const removedId = currentSelectionRef.current.sessionId;
+    if (removalConfirmed && removedId !== null) {
+      if (observedSessionIdsRef.current.has(removedId)) {
+        // Previously observed eligible: retain the stale selection until the
+        // roster itself confirms the removal — there IS a real future
+        // transition to wait for here.
+        return;
+      }
+      // Confirmed removed by ChatView's own onSessionRemoved signal, but
+      // NEVER observed in the eligible roster: there is no future "roster
+      // confirms removal" transition to wait for (it was never eligible to
+      // begin with), so resolve a replacement immediately instead of leaving
+      // the panel stuck on a ghost session forever. Excludes the removed id
+      // explicitly in case a stale `sessions` snapshot still lists it.
+      if (activeFamiliar) {
+        const replacement = resolveLatestRightChatSessionId(
+          sessions.filter((session) => session.id !== removedId),
+          activeFamiliar.id,
+        );
+        if (replacement) routerRef.current?.openSession(replacement);
+        else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+        setSelectedSessionId(replacement);
+        return;
+      }
+    }
+    setSelectedSessionId(null);
   };
 
-  // Arms pendingRemovalRef only when the removed session is STILL the one
-  // this panel currently has selected, for the same familiar, AND has
-  // previously observed eligible — the narrow "current selected, observed
-  // session" signal cave-rl980 Task 4 review calls for. Sourced from
+  // Arms pendingRemovalRef whenever the removed session is STILL the one
+  // this panel currently has selected, for the same familiar. Sourced from
   // ChatView's own onSessionRemoved (see its doc), fired only at the exact
   // archive/delete/discard call sites, never inferred from
   // onSessionsChanged/onSessionsDeleted — those are forwarded to ChatRouter
   // entirely unwrapped below, preserving their existing behavior for every
   // other consumer instead of intercepting every call to guess at removal.
+  //
+  // Deliberately NOT gated on observedSessionIdsRef (cave-rl980 Task 4 spec
+  // review): onSessionRemoved is authoritative on its own — ChatView only
+  // ever fires it for a CONFIRMED archive/delete/discard of the exact
+  // session named, so a session promoted and removed before the `sessions`
+  // roster prop ever caught up to include it is just as real a removal as
+  // one the roster had already shown. handleActiveSessionChange above is
+  // what decides HOW to react to that confirmation (retain-and-wait vs.
+  // resolve-immediately) based on whether the id was ever observed; the
+  // observed gate still protects the DIFFERENT, unsignaled case there — an
+  // ordinary roster refresh where an id merely hasn't appeared yet (a
+  // promotion race with no removal signal at all).
   //
   // Deliberately reads currentSelectionRef, NOT the selectedSessionId/
   // activeFamiliar closed over by this exact function instance: this
@@ -244,7 +296,6 @@ export function RightChatPanel(props: Props) {
   const handleSessionRemoved = (removedSessionId: string) => {
     const current = currentSelectionRef.current;
     if (current.sessionId !== removedSessionId) return;
-    if (!observedSessionIdsRef.current.has(removedSessionId)) return;
     pendingRemovalRef.current = true;
   };
 
@@ -259,22 +310,33 @@ export function RightChatPanel(props: Props) {
   // familiar-bound blank compose) on first open and on every subsequent
   // familiar change, and reconciles the selection when it stops being
   // eligible for the SAME familiar (archived/deleted). One `useLayoutEffect`
-  // handling both, not two separate effects, and not gated on `open` for the
-  // resolution itself (cave-rl980 Task 4 review — see the two reasons below):
+  // handling both, not two separate effects (cave-rl980 Task 4 review — see
+  // the reasons below):
   //
-  // 1. Familiar transitions must be tracked even while the panel is closed.
-  //    ChatRouter/ChatView stay mounted underneath — a persistent controller,
-  //    per the design doc — so pausing resolution while hidden would let a
-  //    closed A -> B -> A sequence leave the header and the actually-mounted
-  //    router disagreeing about which familiar/session is showing by the
-  //    time the panel reopens. `open` still gates the *announcement* below —
-  //    a screen reader has no reason to hear about a change to a panel
-  //    nobody can currently see — but never the resolution itself.
+  // 1. Every familiar-identity TRANSITION is tracked via trackedFamiliarIdRef
+  //    regardless of `open` — ChatRouter/ChatView stay mounted underneath as
+  //    a persistent controller, per the design doc, so a familiar change must
+  //    be noticed even while hidden. A closed A -> B -> A round trip must
+  //    still invalidate whatever was resolved for the earlier A: without
+  //    this tracking, coming back to A would find resolvedFamiliarRef still
+  //    reading "A" (never touched while closed) and wrongly conclude nothing
+  //    had changed. But the actual RESOLVE — the imperative
+  //    openSession/newChat call, and setting selectedSessionId — is a
+  //    completely separate, `open`-gated step (cave-rl980 Task 4 spec
+  //    review): first-open semantics require resolving against whichever
+  //    session is newest at the moment the panel actually becomes visible,
+  //    never one resolved earlier while hidden. So a closed transition
+  //    invalidates ownership here but issues no router call at all; this
+  //    same effect performs the real resolve — against live, then-current
+  //    `sessions` — the instant `open` flips true, since `open` is itself a
+  //    dependency below. A same-familiar close/reopen (no transition at all)
+  //    never invalidates anything, so it preserves a manual thread
+  //    selection exactly as before.
   // 2. A familiar change must issue EXACTLY ONE imperative openSession/
-  //    newChat call. Splitting this into two effects (one keyed on the
-  //    familiar changing, a second reconciling an ineligible selection) races
-  //    them: on the very render the familiar changes, a second, separate
-  //    effect would still see the OUTGOING familiar's stale
+  //    newChat call while open. Splitting this into two effects (one keyed
+  //    on the familiar changing, a second reconciling an ineligible
+  //    selection) races them: on the very render the familiar changes, a
+  //    second, separate effect would still see the OUTGOING familiar's stale
   //    `selectedSessionId` — never eligible for the new familiar's
   //    `eligibleSessions`, and (having been observed under the old familiar)
   //    passing the observed-gate too — so it would ALSO reconcile, firing a
@@ -290,32 +352,45 @@ export function RightChatPanel(props: Props) {
   //    instead of a second, independently guessed one.
   useLayoutEffect(() => {
     if (!activeFamiliar || !familiarsLoaded || familiarsError || !sessionsLoaded || sessionsError) return;
+
+    if (trackedFamiliarIdRef.current !== activeFamiliar.id) {
+      // A transition just occurred — possibly back to a familiar visited
+      // earlier in the same closed stretch (closed A -> B -> A) — so
+      // whatever resolution/selection ownership was previously recorded
+      // belongs to a different occupancy and must never be trusted for this
+      // one, regardless of `open`.
+      trackedFamiliarIdRef.current = activeFamiliar.id;
+      resolvedFamiliarRef.current = null;
+      pendingRemovalRef.current = false;
+      setSelectedSessionId(null);
+    }
+
     if (resolvedFamiliarRef.current !== activeFamiliar.id) {
-      // First open, or a genuine familiar change: resolve fresh. The
-      // outgoing familiar's selection, if any, belongs to a different
-      // familiar entirely and must never be compared against this
-      // familiar's eligible roster below — ownership, not eligibility, is
-      // what just changed.
+      // First open, or a genuine familiar change: needs a fresh resolve.
+      // Never touch the router or the selection while the panel is closed
+      // (cave-rl980 Task 4 spec review) — leave ownership unresolved and let
+      // this same effect resolve it, against live sessions data, the moment
+      // `open` flips true.
+      if (!open) return;
       resolvedFamiliarRef.current = activeFamiliar.id;
       const latestId = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
       if (latestId) routerRef.current?.openSession(latestId);
       else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
       setSelectedSessionId(latestId);
-      if (open) {
-        announce(
-          latestId
-            ? `${activeFamiliar.display_name} chat opened`
-            : `New chat with ${activeFamiliar.display_name}`,
-        );
-      }
+      announce(
+        latestId
+          ? `${activeFamiliar.display_name} chat opened`
+          : `New chat with ${activeFamiliar.display_name}`,
+      );
       return;
     }
-    // Same familiar: only reconcile if the selected session stopped being
-    // eligible (deleted, archived, or otherwise dropped from the visible
-    // list) — and only an id previously observed in the eligible roster (see
-    // observedSessionIdsRef above), so a just-promoted session the roster
-    // hasn't caught up to yet is never mistaken for one that was removed.
-    // Never falls back to another familiar.
+    // Same, already-resolved familiar: only reconcile if the selected
+    // session stopped being eligible (deleted, archived, or otherwise
+    // dropped from the visible list) — and only an id previously observed in
+    // the eligible roster (see observedSessionIdsRef above), so a
+    // just-promoted session the roster hasn't caught up to yet is never
+    // mistaken for one that was removed. Never falls back to another
+    // familiar.
     if (!selectedSessionId) return;
     if (eligibleSessions.some((session) => session.id === selectedSessionId)) return;
     if (!observedSessionIdsRef.current.has(selectedSessionId)) return;

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChatRouter, type ChatRouterHandle } from "@/components/chat-router";
+import { FamiliarAvatar } from "@/components/familiar-avatar";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { Icon, CAVE_ICON_SIZE } from "@/lib/icon";
+import { useAnnouncer } from "@/components/ui/live-region";
+import {
+  eligibleRightChatSessions,
+  resolveLatestRightChatSessionId,
+} from "@/lib/right-chat-session";
+import { sessionRailTitle } from "@/lib/session-rail-title";
+import { useResolvedFamiliars } from "@/lib/familiar-resolve";
+import type { Familiar, SessionRow } from "@/lib/types";
+
+type Props = {
+  open: boolean;
+  familiars: Familiar[];
+  activeFamiliar: Familiar | null;
+  sessions: SessionRow[];
+  sessionsLoaded: boolean;
+  sessionsError: boolean;
+  familiarsLoaded: boolean;
+  familiarsError: string | null;
+  daemonRunning: boolean;
+  onClose: () => void;
+  onSetActiveFamiliar: (id: string | null) => void;
+  onRetryFamiliars: () => void;
+  onRetrySessions: () => void;
+  onSessionStarted: () => void;
+  onSessionsChanged: () => void;
+  onSessionsDeleted: (sessionIds: readonly string[]) => void;
+  onSlashFromChat: (command: string, args: string) => boolean;
+  onOpenOnboarding: () => void;
+  onOpenTask: (cardId: string) => void;
+  onOpenUrl: (url: string) => void;
+};
+
+/**
+ * Persistent, focused wrapper around the shared ChatRouter for the global
+ * right Chat panel. Owns *only* which session the auxiliary router shows —
+ * transcript, streaming, composer, attachments, send, citations, and tool
+ * rendering all remain ChatRouter/ChatView's responsibility. Never forks that
+ * logic; never restores generic companion-rail concepts such as a variant
+ * "kind" enum, multiple tab surfaces, or a bare arbitrary-content slot.
+ */
+export function RightChatPanel(props: Props) {
+  const {
+    open,
+    familiars,
+    activeFamiliar,
+    sessions,
+    sessionsLoaded,
+    sessionsError,
+    familiarsLoaded,
+    familiarsError,
+    daemonRunning,
+  } = props;
+  const routerRef = useRef<ChatRouterHandle | null>(null);
+  // Tracks which familiar's latest session we've already resolved for, so a
+  // same-familiar close/reopen never clobbers a manual thread selection —
+  // only an actual familiar change (or the very first open) re-resolves.
+  const resolvedFamiliarRef = useRef<string | null>(null);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+  const resolvedFamiliars = useResolvedFamiliars(familiars);
+  const resolvedActiveFamiliar =
+    resolvedFamiliars.find((familiar) => familiar.id === activeFamiliar?.id) ?? null;
+  const eligibleSessions = useMemo(
+    () => eligibleRightChatSessions(sessions, activeFamiliar?.id ?? null),
+    [activeFamiliar?.id, sessions],
+  );
+  const { announce } = useAnnouncer();
+
+  useEffect(() => {
+    if (activeFamiliar) return;
+    resolvedFamiliarRef.current = null;
+    setSelectedSessionId(null);
+  }, [activeFamiliar]);
+
+  // First open (or a genuine familiar change): resolve that familiar's latest
+  // eligible session, or start a familiar-bound blank compose. Deliberately a
+  // no-op on same-familiar close/reopen — resolvedFamiliarRef already holds
+  // this familiar's id, so a manual mid-conversation selection survives.
+  useEffect(() => {
+    if (!open || !activeFamiliar || !sessionsLoaded || sessionsError) return;
+    if (resolvedFamiliarRef.current === activeFamiliar.id) return;
+    resolvedFamiliarRef.current = activeFamiliar.id;
+    const latestId = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
+    if (latestId) routerRef.current?.openSession(latestId);
+    else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+    setSelectedSessionId(latestId);
+    announce(
+      latestId
+        ? `${activeFamiliar.display_name} chat opened`
+        : `New chat with ${activeFamiliar.display_name}`,
+    );
+  }, [activeFamiliar, announce, open, sessions, sessionsError, sessionsLoaded]);
+
+  // If the selected session stops being eligible (deleted, archived, or
+  // otherwise dropped from the visible list) re-resolve the same familiar's
+  // latest remaining session, or fall back to a familiar-bound blank compose.
+  // Never falls back to another familiar.
+  useEffect(() => {
+    if (!open || !activeFamiliar || !sessionsLoaded || sessionsError || !selectedSessionId) return;
+    if (eligibleSessions.some((session) => session.id === selectedSessionId)) return;
+    const replacement = resolveLatestRightChatSessionId(sessions, activeFamiliar.id);
+    if (replacement) routerRef.current?.openSession(replacement);
+    else routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+    setSelectedSessionId(replacement);
+  }, [activeFamiliar, eligibleSessions, open, selectedSessionId, sessions, sessionsError, sessionsLoaded]);
+
+  if (!familiarsLoaded || !sessionsLoaded) {
+    return (
+      <aside className="right-chat" aria-label="Chat panel">
+        <div className="right-chat__loading" role="status">
+          Loading Chat…
+        </div>
+      </aside>
+    );
+  }
+
+  if (familiarsError) {
+    return (
+      <aside className="right-chat" aria-label="Chat panel">
+        <ErrorState
+          compact
+          headline="Couldn't load familiars"
+          subtitle={familiarsError}
+          actions={<Button onClick={props.onRetryFamiliars}>Retry</Button>}
+        />
+      </aside>
+    );
+  }
+
+  if (!activeFamiliar) {
+    return (
+      <aside className="right-chat" aria-label="Chat panel">
+        <header className="right-chat__header">
+          <strong>Chat</strong>
+          <button
+            type="button"
+            className="focus-ring right-chat__icon-button"
+            aria-label="Close Chat panel"
+            onClick={props.onClose}
+          >
+            <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
+          </button>
+        </header>
+        <EmptyState
+          compact
+          icon="ph:users-three"
+          headline="Choose a familiar"
+          subtitle="The Chat panel won't choose one for you."
+          actions={
+            <div className="right-chat__familiar-grid">
+              {familiars.map((familiar) => (
+                <Button
+                  key={familiar.id}
+                  variant="secondary"
+                  onClick={() => props.onSetActiveFamiliar(familiar.id)}
+                >
+                  {familiar.display_name}
+                </Button>
+              ))}
+            </div>
+          }
+        />
+      </aside>
+    );
+  }
+
+  if (sessionsError && resolvedFamiliarRef.current !== activeFamiliar.id) {
+    return (
+      <aside className="right-chat" aria-label="Chat panel">
+        <ErrorState
+          compact
+          headline="Couldn't load chats"
+          subtitle="Your conversations are still safe."
+          actions={<Button onClick={props.onRetrySessions}>Retry</Button>}
+        />
+      </aside>
+    );
+  }
+
+  const title =
+    eligibleSessions.find((session) => session.id === selectedSessionId)?.title ?? "New chat";
+
+  return (
+    <aside className="right-chat" aria-label="Chat panel" data-session-id={selectedSessionId ?? "new"}>
+      <header className="right-chat__header">
+        {resolvedActiveFamiliar ? <FamiliarAvatar familiar={resolvedActiveFamiliar} size="sm" /> : null}
+        <span className="right-chat__identity">
+          <strong>{activeFamiliar.display_name}</strong>
+          <span title={title}>{title}</span>
+        </span>
+        <select
+          className="focus-ring right-chat__thread-switcher"
+          aria-label="Switch Chat panel thread"
+          value={selectedSessionId ?? "__new__"}
+          onChange={(event) => {
+            const nextId = event.currentTarget.value;
+            if (nextId === "__new__") {
+              routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+              setSelectedSessionId(null);
+              announce(`New chat with ${activeFamiliar.display_name}`);
+              return;
+            }
+            routerRef.current?.openSession(nextId);
+            setSelectedSessionId(nextId);
+            const nextSession = eligibleSessions.find((session) => session.id === nextId);
+            announce(`${nextSession ? sessionRailTitle(nextSession) : "Chat"} opened`);
+          }}
+        >
+          <option value="__new__">New chat</option>
+          {eligibleSessions.map((session) => (
+            <option key={session.id} value={session.id}>
+              {sessionRailTitle(session)}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="focus-ring right-chat__icon-button"
+          aria-label="New Chat panel chat"
+          onClick={() => {
+            routerRef.current?.newChat(undefined, undefined, activeFamiliar.id);
+            setSelectedSessionId(null);
+            announce(`New chat with ${activeFamiliar.display_name}`);
+          }}
+        >
+          <Icon name="ph:plus" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
+        </button>
+        <button
+          type="button"
+          className="focus-ring right-chat__icon-button"
+          aria-label="Close Chat panel"
+          onClick={props.onClose}
+        >
+          <Icon name="ph:x" width={CAVE_ICON_SIZE.sidePanelAction} aria-hidden />
+        </button>
+      </header>
+      <div className="right-chat__content">
+        <ChatRouter
+          ref={routerRef}
+          familiar={activeFamiliar}
+          familiars={familiars}
+          sessions={sessions}
+          daemonRunning={daemonRunning}
+          sessionsLoaded={sessionsLoaded}
+          sessionsError={sessionsError}
+          familiarsLoaded={familiarsLoaded}
+          familiarsError={familiarsError}
+          onRetryFamiliars={props.onRetryFamiliars}
+          onSetActiveFamiliar={props.onSetActiveFamiliar}
+          onSessionStarted={props.onSessionStarted}
+          onSessionsChanged={props.onSessionsChanged}
+          onSessionsDeleted={props.onSessionsDeleted}
+          onSlashFromChat={props.onSlashFromChat}
+          onOpenOnboarding={props.onOpenOnboarding}
+          onOpenTask={props.onOpenTask}
+          onOpenUrl={props.onOpenUrl}
+          onActiveSessionChange={setSelectedSessionId}
+          composerDraftKey={`cave:right-chat-composer-draft:v1:${activeFamiliar.id}`}
+          compact
+          hideRail
+          syncUrlHash={false}
+          enableSplitPanes={false}
+          activeFamiliarId={activeFamiliar.id}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/src/components/right-chat-panel.tsx
+++ b/src/components/right-chat-panel.tsx
@@ -107,8 +107,20 @@ export function RightChatPanel(props: Props) {
   // session with a replacement. Gating reconciliation on prior observation
   // fixes that promotion race with no timing/delay hack — it also lets the
   // *same* effect correctly reconcile a genuine later removal (archive/
-  // delete) of a session it did previously observe.
+  // delete) of a session it did previously observe. Committed from an effect
+  // below, never inline during render (cave-rl980 Task 4 review): a render
+  // React abandons before commit must never leave a mark here.
   const observedSessionIdsRef = useRef<Set<string>>(new Set());
+  // Armed the instant handleSessionsChanged/handleSessionsDeleted below run,
+  // consumed (read, then reset) by the very next handleActiveSessionChange
+  // report of any kind. ChatView calls exactly one of those two mutation
+  // callbacks and then, synchronously in the same tick, either onBack or
+  // onVoiceSessionDiscarded for every confirmed archive, delete, and
+  // discarded voice pre-session — never for an ordinary back navigation
+  // (e.g. "Back to sessions" on a transcript-history load failure). That
+  // order is the only signal available here for "this null follows a real
+  // roster mutation" versus "this null is just the user navigating away."
+  const pendingRemovalRef = useRef(false);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const resolvedFamiliars = useResolvedFamiliars(familiars);
   const resolvedActiveFamiliar =
@@ -117,7 +129,6 @@ export function RightChatPanel(props: Props) {
     () => eligibleRightChatSessions(sessions, activeFamiliar?.id ?? null),
     [activeFamiliar?.id, sessions],
   );
-  for (const session of eligibleSessions) observedSessionIdsRef.current.add(session.id);
   // True once this exact familiar's router has actually resolved/mounted —
   // independent of any *current* familiarsError/sessionsError. Lets a
   // transient roster refresh failure surface loading/error UI without
@@ -127,25 +138,73 @@ export function RightChatPanel(props: Props) {
   const hasResolvedRouter = activeFamiliar !== null && resolvedFamiliarRef.current === activeFamiliar.id;
   const { announce } = useAnnouncer();
 
-  // ChatRouter can report a null active session organically — an in-place
-  // archive (ChatView's onBack after the archive PATCH), a delete, or a
-  // discarded empty voice pre-session — with no accompanying explicit action
-  // from this panel. That null carries no session identity, so overwriting
-  // `selectedSessionId` here would drop the very id the reconcile effect
-  // below needs in order to detect the confirmed removal once the roster
-  // refreshes and resolve the same familiar's latest session (or a new
-  // compose). Every *explicit* transition to a blank compose (the New chat
-  // button, the thread switcher's New chat option, and both resolution
-  // effects when no session is left) already calls `setSelectedSessionId(null)`
-  // itself at the moment it acts, so this handler only ever needs to forward
-  // a real, non-null id.
+  // Fold the current eligible roster into the observed-ids record after
+  // commit, not inline during render (cave-rl980 Task 4 review): an id only
+  // ever needs to be *in* this set once its owning render has actually
+  // landed, since the reconcile effects below only ever consult it for an id
+  // that is absent from the *current* eligibleSessions — which, if it was
+  // ever eligible, was necessarily recorded by an earlier, already-committed
+  // render's copy of this same effect.
+  useEffect(() => {
+    for (const session of eligibleSessions) observedSessionIdsRef.current.add(session.id);
+  }, [eligibleSessions]);
+
+  // ChatRouter reports a null active session in two shapes that read
+  // identically from here (both simply become `activeSessionId: null`): an
+  // ordinary "list" transition (the ChatHistoryNotice "Back to sessions"
+  // affordance after a transcript load failure — the session itself is still
+  // fully eligible; only its transcript failed to fetch) and a genuine
+  // removal (archive's onBack after the PATCH, delete's onBack after the
+  // DELETE, or a discarded empty voice pre-session's onVoiceSessionDiscarded).
+  // The first must clear the stale selection immediately. The second must
+  // retain it long enough for the reconcile effect below to confirm the
+  // removal once the roster refreshes and resolve the same familiar's latest
+  // session (or a new compose) instead of flashing "New chat" the instant
+  // this fires, ahead of the roster actually catching up.
+  //
+  // pendingRemovalRef — armed by handleSessionsChanged/handleSessionsDeleted,
+  // exactly the two calls every removal path makes immediately before its
+  // null — distinguishes the two. That alone is not sufficient, though: a
+  // discarded voice pre-session also reports through onSessionsChanged
+  // (discardVoiceSessionIfEmpty refreshes the list once the empty session is
+  // deleted server-side) despite never having appeared in the roster to
+  // begin with. Retaining that id would leave a permanent ghost — the
+  // reconcile effect's own observed-gate can never confirm the removal of an
+  // id the roster never listed in the first place. Requiring the id to have
+  // been previously observed eligible closes that gap: only a real,
+  // previously visible session is ever retained; a discarded, never-observed
+  // promotion clears just like an ordinary back. Explicit New chat actions
+  // (the button, the thread switcher, and both resolution effects) bypass
+  // this handler entirely — they already call setSelectedSessionId(null)
+  // directly at the moment they act.
   const handleActiveSessionChange = (sessionId: string | null) => {
-    if (sessionId !== null) setSelectedSessionId(sessionId);
+    const removalConfirmed = pendingRemovalRef.current;
+    pendingRemovalRef.current = false;
+    if (sessionId !== null) {
+      setSelectedSessionId(sessionId);
+      return;
+    }
+    setSelectedSessionId((prev) =>
+      removalConfirmed && prev !== null && observedSessionIdsRef.current.has(prev) ? prev : null,
+    );
+  };
+
+  // Arms pendingRemovalRef for the very next handleActiveSessionChange report,
+  // then forwards to the real callback unchanged — RightChatPanel observes
+  // the mutation, it never forks it.
+  const handleSessionsChanged = () => {
+    pendingRemovalRef.current = true;
+    props.onSessionsChanged();
+  };
+  const handleSessionsDeleted = (sessionIds: readonly string[]) => {
+    pendingRemovalRef.current = true;
+    props.onSessionsDeleted(sessionIds);
   };
 
   useEffect(() => {
     if (activeFamiliar) return;
     resolvedFamiliarRef.current = null;
+    pendingRemovalRef.current = false;
     setSelectedSessionId(null);
   }, [activeFamiliar]);
 
@@ -348,8 +407,8 @@ export function RightChatPanel(props: Props) {
           onRetryFamiliars={props.onRetryFamiliars}
           onSetActiveFamiliar={props.onSetActiveFamiliar}
           onSessionStarted={props.onSessionStarted}
-          onSessionsChanged={props.onSessionsChanged}
-          onSessionsDeleted={props.onSessionsDeleted}
+          onSessionsChanged={handleSessionsChanged}
+          onSessionsDeleted={handleSessionsDeleted}
           onSlashFromChat={props.onSlashFromChat}
           onOpenOnboarding={props.onOpenOnboarding}
           onOpenTask={props.onOpenTask}

--- a/src/components/shell-drawer-smoke.test.ts
+++ b/src/components/shell-drawer-smoke.test.ts
@@ -129,4 +129,44 @@ assert.match(
   "MobileDrawer disables body overscroll while open",
 );
 
+// The backdrop must be a real, keyboard-reachable <button> (cave-rl980 Task 5
+// spec finding), not a role="presentation" <div> that only a pointer can
+// dismiss. Match the exact prop order/shape the spec calls for.
+assert.match(
+  mobileDrawer,
+  /<button\s*\n\s*type="button"\s*\n\s*className="mobile-drawer-backdrop"\s*\n\s*data-drawer-slot=\{open\}\s*\n\s*aria-label="Close drawer"\s*\n\s*onClick=\{onClose\}\s*\n\s*\/>/,
+  "the backdrop renders as <button type=\"button\" className=\"mobile-drawer-backdrop\" data-drawer-slot={open} aria-label=\"Close drawer\" onClick={onClose} />",
+);
+assert.doesNotMatch(
+  mobileDrawer,
+  /<div\s*\n\s*className="mobile-drawer-backdrop"/,
+  "the backdrop is no longer a div (a div backdrop is pointer-only and unreachable from the keyboard)",
+);
+assert.doesNotMatch(
+  mobileDrawer,
+  /role="presentation"/,
+  "role=\"presentation\" was the div-only escape hatch; the button backdrop needs no such override",
+);
+
+// Background-inert cleanup ordering (cave-rl980 Task 5 spec finding): React
+// runs a component's passive-effect cleanups in top-down declaration order
+// (verified against the actual React runtime in
+// mobile-drawer-inert-focus-order.test.tsx, which exercises this exact
+// ordering through react-test-renderer + the real useFocusTrap hook — this
+// file only pins the SOURCE shape so the two can't silently drift apart).
+// The inert-toggling effect's cleanup (which clears `shell.inert`) must run
+// BEFORE useFocusTrap's own cleanup (which calls `.focus()` to return focus
+// to the shell toggle) — focusing an element inside an inert subtree is a
+// silent no-op, so the inert effect must be declared first.
+const inertEffectIndex = mobileDrawer.indexOf("shell.inert = true;");
+const focusTrapCallIndex = mobileDrawer.indexOf("useFocusTrap(open ===");
+assert.ok(
+  inertEffectIndex !== -1 && focusTrapCallIndex !== -1,
+  "both the inert effect and the useFocusTrap(...) call are present",
+);
+assert.ok(
+  inertEffectIndex < focusTrapCallIndex,
+  "the inert-toggling effect is declared BEFORE useFocusTrap(...) so its cleanup (clearing shell.inert) runs before useFocusTrap's cleanup (which restores focus) — see mobile-drawer.tsx's comment above the inert effect",
+);
+
 console.log("shell-drawer-smoke.test.ts OK");

--- a/src/components/voice-new-chat.test.ts
+++ b/src/components/voice-new-chat.test.ts
@@ -239,10 +239,12 @@ test("chat-view: closing an auto-created call discards exactly the session it wa
   assert.match(startVoiceChat, /method: "DELETE"/);
   // Finding 2: the view is only yanked back to compose when the discarded
   // session is still the active one — if the user already switched away,
-  // the discard happens silently in the background with no view reset.
+  // the discard happens silently in the background with no view reset. The
+  // narrow onSessionRemoved("discarded") signal (cave-rl980 Task 4 review)
+  // fires in that same branch, immediately before onVoiceSessionDiscarded.
   assert.match(
     chatView,
-    /if \(deleted\) \{[\s\S]*?onSessionsChanged\?\.\(\);[\s\S]*?if \(target === sessionId\) onVoiceSessionDiscarded\?\.\(\);/,
+    /if \(deleted\) \{[\s\S]*?onSessionsChanged\?\.\(\);[\s\S]*?if \(target === sessionId\) \{\s*\n\s*onSessionRemoved\?\.\(target, "discarded"\);\s*\n\s*onVoiceSessionDiscarded\?\.\(\);\s*\n\s*\}/,
   );
   // Finding 4: the call item can't fork a streaming first send by
   // minting a second, unrelated session underneath it (pre-session only —

--- a/src/components/voice-new-chat.test.ts
+++ b/src/components/voice-new-chat.test.ts
@@ -244,7 +244,7 @@ test("chat-view: closing an auto-created call discards exactly the session it wa
   // fires in that same branch, immediately before onVoiceSessionDiscarded.
   assert.match(
     chatView,
-    /if \(deleted\) \{[\s\S]*?onSessionsChanged\?\.\(\);[\s\S]*?if \(target === sessionId\) \{\s*\n\s*onSessionRemoved\?\.\(target, "discarded"\);\s*\n\s*onVoiceSessionDiscarded\?\.\(\);\s*\n\s*\}/,
+    /if \(deleted\) \{[\s\S]*?onSessionsChanged\?\.\(\);[\s\S]*?if \(target === sessionId\) \{\s*\n\s*onSessionRemoved\?\.\(target, "discarded"\);\s*\n\s*onVoiceSessionDiscarded\?\.\(target\);\s*\n\s*\}/,
   );
   // Finding 4: the call item can't fork a streaming first send by
   // minting a second, unrelated session underneath it (pre-session only —
@@ -258,7 +258,7 @@ test("chat-view: closing an auto-created call discards exactly the session it wa
   // but back to sessionId: null.
   assert.match(
     chatRouter,
-    /onVoiceSessionDiscarded=\{\(\) => \{[\s\S]*?prev\.kind === "chat"[\s\S]*?sessionId: null, projectRoot: prev\.projectRoot, familiarId: prev\.familiarId/,
+    /onVoiceSessionDiscarded=\{\(removedSessionId\) => \{[\s\S]*?prev\.kind === "chat"[\s\S]*?sessionId: null, projectRoot: prev\.projectRoot, familiarId: prev\.familiarId/,
   );
 });
 

--- a/src/lib/chat-session-removal.ts
+++ b/src/lib/chat-session-removal.ts
@@ -1,0 +1,15 @@
+/**
+ * Confirmed removal of the session a ChatView is currently displaying —
+ * archived, deleted, or a discarded empty voice/compose pre-session. A
+ * consumer's `onSessionRemoved` fires from the exact call site that performed
+ * the mutation, always immediately before the view navigates away (`onBack`
+ * for archive/delete, `onVoiceSessionDiscarded` for a discarded pre-session).
+ *
+ * Deliberately distinct from `onSessionsChanged`/`onSessionsDeleted`, which
+ * also fire for refreshes that have nothing to do with THIS session being
+ * removed (a canonical-session reconcile after a stream settles, a *different*
+ * thread auto-archiving on reflection, a Board handoff refresh, …). Inferring
+ * removal from those firing is unsound; this is the narrow, purpose-built
+ * signal instead (cave-rl980 Task 4 review).
+ */
+export type SessionRemovalReason = "archived" | "deleted" | "discarded";

--- a/src/lib/right-chat-session.test.ts
+++ b/src/lib/right-chat-session.test.ts
@@ -119,4 +119,25 @@ function row(
   );
 }
 
+{
+  const sessions = [
+    row("empty-string", {
+      familiarId: "",
+      created_at: "2026-06-16T00:00:00.000Z",
+      updated_at: "2026-06-16T00:00:00.000Z",
+    }),
+  ];
+
+  assert.deepEqual(
+    eligibleRightChatSessions(sessions, ""),
+    filterVisibleChatSessions(sessions, ""),
+    "an empty string must still delegate to the canonical filter instead of short-circuiting like null",
+  );
+  assert.deepEqual(
+    eligibleRightChatSessions(sessions, "").map((session) => session.id),
+    ["empty-string"],
+    "an empty-string familiar id should keep matching sessions instead of returning an empty list",
+  );
+}
+
 console.log("right-chat-session.test.ts: ok");

--- a/src/lib/right-chat-session.test.ts
+++ b/src/lib/right-chat-session.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { filterVisibleChatSessions } from "./chat-projects.ts";
+import {
+  eligibleRightChatSessions,
+  resolveLatestRightChatSessionId,
+} from "./right-chat-session.ts";
+import type { SessionRow } from "./types.ts";
+
+function row(
+  id: string,
+  overrides: Partial<SessionRow> & Pick<SessionRow, "created_at" | "updated_at" | "familiarId">,
+): SessionRow {
+  return {
+    id,
+    project_root: "/work/right-chat",
+    harness: "codex",
+    title: id,
+    status: "completed",
+    exit_code: null,
+    archived_at: null,
+    attention: { state: "none", since: null, reason: null },
+    origin: "chat",
+    hasLocalConversation: false,
+    ...overrides,
+  };
+}
+
+{
+  const sessions = [
+    row("cody-older", {
+      familiarId: "cody",
+      created_at: "2026-06-03T00:00:00.000Z",
+      updated_at: "2026-06-03T00:00:00.000Z",
+    }),
+    row("nova-newer", {
+      familiarId: "nova",
+      created_at: "2026-06-07T00:00:00.000Z",
+      updated_at: "2026-06-07T00:00:00.000Z",
+    }),
+    row("cody-newest", {
+      familiarId: "cody",
+      created_at: "2026-06-06T00:00:00.000Z",
+      updated_at: "2026-06-06T00:00:00.000Z",
+    }),
+  ];
+
+  assert.equal(
+    resolveLatestRightChatSessionId(sessions, "cody"),
+    "cody-newest",
+    "the resolver should choose the exact familiar's newest visible chat, not another familiar's newer row",
+  );
+}
+
+{
+  const sessions = [
+    row("visible", {
+      familiarId: "cody",
+      created_at: "2026-06-10T00:00:00.000Z",
+      updated_at: "2026-06-10T00:00:00.000Z",
+    }),
+    row("archived", {
+      familiarId: "cody",
+      status: "archived",
+      created_at: "2026-06-11T00:00:00.000Z",
+      updated_at: "2026-06-11T00:00:00.000Z",
+    }),
+    row("generated", {
+      familiarId: "cody",
+      generated: true,
+      created_at: "2026-06-12T00:00:00.000Z",
+      updated_at: "2026-06-12T00:00:00.000Z",
+    }),
+    row("killed-transcript-less", {
+      familiarId: "cody",
+      status: "killed",
+      hasLocalConversation: false,
+      created_at: "2026-06-13T00:00:00.000Z",
+      updated_at: "2026-06-13T00:00:00.000Z",
+    }),
+    row("killed-recoverable", {
+      familiarId: "cody",
+      status: "killed",
+      hasLocalConversation: true,
+      created_at: "2026-06-14T00:00:00.000Z",
+      updated_at: "2026-06-14T00:00:00.000Z",
+    }),
+  ];
+
+  assert.deepEqual(
+    eligibleRightChatSessions(sessions, "cody"),
+    filterVisibleChatSessions(sessions, "cody"),
+    "the right-chat adapter should reuse the canonical chat visibility policy",
+  );
+  assert.deepEqual(
+    eligibleRightChatSessions(sessions, "cody").map((session) => session.id),
+    ["killed-recoverable", "visible"],
+    "visible rows stay available while archived, generated, and transcript-less dead runs stay out",
+  );
+}
+
+{
+  const sessions = [
+    row("nova-only", {
+      familiarId: "nova",
+      created_at: "2026-06-15T00:00:00.000Z",
+      updated_at: "2026-06-15T00:00:00.000Z",
+    }),
+  ];
+
+  assert.equal(
+    resolveLatestRightChatSessionId(sessions, "cody"),
+    null,
+    "the resolver must not fall back to another familiar when the exact familiar has no eligible chats",
+  );
+  assert.equal(
+    resolveLatestRightChatSessionId(sessions, null),
+    null,
+    "the resolver must return null when no familiar is selected",
+  );
+}
+
+console.log("right-chat-session.test.ts: ok");

--- a/src/lib/right-chat-session.test.ts
+++ b/src/lib/right-chat-session.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { filterVisibleChatSessions } from "./chat-projects.ts";
 import {
   eligibleRightChatSessions,
+  isCurrentRightChatSessionsScope,
   resolveLatestRightChatSessionId,
 } from "./right-chat-session.ts";
 import type { SessionRow } from "./types.ts";
@@ -137,6 +138,49 @@ function row(
     eligibleRightChatSessions(sessions, "").map((session) => session.id),
     ["empty-string"],
     "an empty-string familiar id should keep matching sessions instead of returning an empty list",
+  );
+}
+
+// isCurrentRightChatSessionsScope (cave-rl980 Task 4 review): `undefined`
+// always reports current so a caller that has not adopted the applied-scope
+// contract yet (Workspace's own wiring lands in Task 7) keeps today's
+// behavior, trusting `sessions` unconditionally.
+{
+  assert.equal(
+    isCurrentRightChatSessionsScope(undefined, "cody"),
+    true,
+    "an unset scope (the pre-scope-aware contract) is always treated as current",
+  );
+  assert.equal(
+    isCurrentRightChatSessionsScope(undefined, null),
+    true,
+    "an unset scope is current even when no familiar is active",
+  );
+}
+
+// A concrete applied scope is compared directly against the familiar being
+// resolved -- a match is current, anything else (including the still-in-
+// flight OUTGOING familiar) is not.
+{
+  assert.equal(
+    isCurrentRightChatSessionsScope("cody", "cody"),
+    true,
+    "a scope naming the exact active familiar is current",
+  );
+  assert.equal(
+    isCurrentRightChatSessionsScope("cody", "nova"),
+    false,
+    "a scope still naming the OUTGOING familiar (sessions hasn't caught up to the switch yet) is not current",
+  );
+  assert.equal(
+    isCurrentRightChatSessionsScope(null, "cody"),
+    false,
+    "an explicit null scope (e.g. an unscoped/all-familiars load) never matches a specific active familiar",
+  );
+  assert.equal(
+    isCurrentRightChatSessionsScope(null, null),
+    true,
+    "an explicit null scope matches no active familiar",
   );
 }
 

--- a/src/lib/right-chat-session.ts
+++ b/src/lib/right-chat-session.ts
@@ -1,0 +1,17 @@
+import type { SessionRow } from "./types.ts";
+import { filterVisibleChatSessions } from "./chat-projects.ts";
+
+export function eligibleRightChatSessions(
+  sessions: SessionRow[],
+  familiarId: string | null,
+): SessionRow[] {
+  if (!familiarId) return [];
+  return filterVisibleChatSessions(sessions, familiarId);
+}
+
+export function resolveLatestRightChatSessionId(
+  sessions: SessionRow[],
+  familiarId: string | null,
+): string | null {
+  return eligibleRightChatSessions(sessions, familiarId)[0]?.id ?? null;
+}

--- a/src/lib/right-chat-session.ts
+++ b/src/lib/right-chat-session.ts
@@ -15,3 +15,36 @@ export function resolveLatestRightChatSessionId(
 ): string | null {
   return eligibleRightChatSessions(sessions, familiarId)[0]?.id ?? null;
 }
+
+/**
+ * Applied-session-scope contract for RightChatPanel (cave-rl980 Task 4
+ * review). Workspace's own session list is fetched scoped to a single
+ * active familiar (`loadSessions` in workspace.tsx re-fires on every
+ * `activeId` change and requests `?familiarId=<id>`) but its `sessions`
+ * state only catches up once that fetch actually resolves — `activeFamiliar`
+ * itself flips synchronously on a switch, `sessionsLoaded` never resets to
+ * `false` in between (it is a one-time latch), and `sessions` keeps holding
+ * the OUTGOING familiar's scoped rows in the meantime. Without an explicit
+ * scope signal, a panel resolving eagerly against `sessions` the instant
+ * `activeFamiliar` changes can mistake "this familiar has no chats" for
+ * "the roster hasn't caught up yet" and wrongly open a blank compose, or
+ * mistake a leftover row for one of the new familiar's own sessions.
+ *
+ * `appliedSessionsFamiliarId` names whichever familiar the CALLER currently
+ * guarantees `sessions` reflects. `undefined` means the caller does not
+ * track this yet — Workspace's own wiring lands in cave-rl980 Task 7 — so
+ * `sessions` is trusted as already current, preserving the pre-scope-aware
+ * contract exactly for every caller that has not adopted it. A concrete
+ * value (a familiar id, or `null` for an explicit "no familiar"/
+ * all-familiars scope) is compared directly against the familiar being
+ * resolved, mirroring `isCurrentProjectScope` in project-scope.ts, which
+ * solves the identical staleness problem for the projects list.
+ */
+export type RightChatSessionsScope = string | null | undefined;
+
+export function isCurrentRightChatSessionsScope(
+  appliedSessionsFamiliarId: RightChatSessionsScope,
+  familiarId: string | null,
+): boolean {
+  return appliedSessionsFamiliarId === undefined || appliedSessionsFamiliarId === familiarId;
+}

--- a/src/lib/right-chat-session.ts
+++ b/src/lib/right-chat-session.ts
@@ -5,7 +5,7 @@ export function eligibleRightChatSessions(
   sessions: SessionRow[],
   familiarId: string | null,
 ): SessionRow[] {
-  if (!familiarId) return [];
+  if (familiarId === null) return [];
   return filterVisibleChatSessions(sessions, familiarId);
 }
 

--- a/src/lib/shell-right-chat.test.ts
+++ b/src/lib/shell-right-chat.test.ts
@@ -12,16 +12,16 @@ import {
 test("normalizes corrupt open preference to closed", () => {
   assert.equal(normalizeRightChatOpen("1"), true);
   assert.equal(normalizeRightChatOpen("0"), false);
-  assert.equal(normalizeRightChatOpen("garbage"), false);
+  assert.equal(normalizeRightChatOpen("yes"), false);
   assert.equal(normalizeRightChatOpen(null), false);
 });
 
 test("normalizes width fallback and clamping", () => {
   assert.equal(normalizeRightChatWidth(null), RIGHT_CHAT_DEFAULT_PX);
-  assert.equal(normalizeRightChatWidth("garbage"), RIGHT_CHAT_DEFAULT_PX);
-  assert.equal(normalizeRightChatWidth("319.4"), RIGHT_CHAT_MIN_PX);
-  assert.equal(normalizeRightChatWidth("640.6"), RIGHT_CHAT_MAX_PX);
-  assert.equal(normalizeRightChatWidth("481.2"), 481);
+  assert.equal(normalizeRightChatWidth("nope"), RIGHT_CHAT_DEFAULT_PX);
+  assert.equal(normalizeRightChatWidth("200"), RIGHT_CHAT_MIN_PX);
+  assert.equal(normalizeRightChatWidth("900"), RIGHT_CHAT_MAX_PX);
+  assert.equal(normalizeRightChatWidth("480"), 480);
 });
 
 test("auto-collapses only when nav plus chat plus detail cannot fit", () => {

--- a/src/lib/shell-right-chat.test.ts
+++ b/src/lib/shell-right-chat.test.ts
@@ -18,6 +18,8 @@ test("normalizes corrupt open preference to closed", () => {
 
 test("normalizes width fallback and clamping", () => {
   assert.equal(normalizeRightChatWidth(null), RIGHT_CHAT_DEFAULT_PX);
+  assert.equal(normalizeRightChatWidth(""), RIGHT_CHAT_DEFAULT_PX);
+  assert.equal(normalizeRightChatWidth(" \t\n"), RIGHT_CHAT_DEFAULT_PX);
   assert.equal(normalizeRightChatWidth("nope"), RIGHT_CHAT_DEFAULT_PX);
   assert.equal(normalizeRightChatWidth("200"), RIGHT_CHAT_MIN_PX);
   assert.equal(normalizeRightChatWidth("900"), RIGHT_CHAT_MAX_PX);
@@ -48,5 +50,22 @@ test("auto-collapses only when nav plus chat plus detail cannot fit", () => {
       rightChatWidth: 360,
     }),
     false,
+  );
+});
+
+test("accounts for an optional list pane when deciding whether to collapse nav", () => {
+  const noListSurface = {
+    viewportWidth: 1210,
+    navWidth: 240,
+    rightChatWidth: 360,
+  };
+
+  assert.equal(shouldAutoCollapseNavForRightChat(noListSurface), false);
+  assert.equal(
+    shouldAutoCollapseNavForRightChat({
+      ...noListSurface,
+      listWidth: 280,
+    }),
+    true,
   );
 });

--- a/src/lib/shell-right-chat.test.ts
+++ b/src/lib/shell-right-chat.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  RIGHT_CHAT_DEFAULT_PX,
+  RIGHT_CHAT_MAX_PX,
+  RIGHT_CHAT_MIN_PX,
+  normalizeRightChatOpen,
+  normalizeRightChatWidth,
+  shouldAutoCollapseNavForRightChat,
+} from "./shell-right-chat.ts";
+
+test("normalizes corrupt open preference to closed", () => {
+  assert.equal(normalizeRightChatOpen("1"), true);
+  assert.equal(normalizeRightChatOpen("0"), false);
+  assert.equal(normalizeRightChatOpen("garbage"), false);
+  assert.equal(normalizeRightChatOpen(null), false);
+});
+
+test("normalizes width fallback and clamping", () => {
+  assert.equal(normalizeRightChatWidth(null), RIGHT_CHAT_DEFAULT_PX);
+  assert.equal(normalizeRightChatWidth("garbage"), RIGHT_CHAT_DEFAULT_PX);
+  assert.equal(normalizeRightChatWidth("319.4"), RIGHT_CHAT_MIN_PX);
+  assert.equal(normalizeRightChatWidth("640.6"), RIGHT_CHAT_MAX_PX);
+  assert.equal(normalizeRightChatWidth("481.2"), 481);
+});
+
+test("auto-collapses only when nav plus chat plus detail cannot fit", () => {
+  assert.equal(
+    shouldAutoCollapseNavForRightChat({
+      viewportWidth: 1180,
+      navWidth: 240,
+      rightChatWidth: 640,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldAutoCollapseNavForRightChat({
+      viewportWidth: 1440,
+      navWidth: 240,
+      rightChatWidth: 640,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldAutoCollapseNavForRightChat({
+      viewportWidth: 1024,
+      navWidth: 56,
+      rightChatWidth: 360,
+    }),
+    false,
+  );
+});

--- a/src/lib/shell-right-chat.ts
+++ b/src/lib/shell-right-chat.ts
@@ -5,14 +5,21 @@ export const RIGHT_CHAT_MIN_PX = 320;
 export const RIGHT_CHAT_MAX_PX = 640;
 export const SHELL_DETAIL_MIN_PX = 320;
 
-const SHELL_SEPARATOR_ALLOWANCE_PX = 8;
+const SHELL_SEPARATOR_PX = 4;
+
+export interface RightChatFitInput {
+  viewportWidth: number;
+  navWidth: number;
+  listWidth?: number;
+  rightChatWidth: number;
+}
 
 export function normalizeRightChatOpen(raw: string | null): boolean {
   return raw === "1";
 }
 
 export function normalizeRightChatWidth(raw: string | null): number {
-  const parsed = raw === null ? Number.NaN : Number(raw);
+  const parsed = raw === null || raw.trim() === "" ? Number.NaN : Number(raw);
   if (!Number.isFinite(parsed)) return RIGHT_CHAT_DEFAULT_PX;
 
   const rounded = Math.round(parsed);
@@ -22,11 +29,16 @@ export function normalizeRightChatWidth(raw: string | null): number {
 export function shouldAutoCollapseNavForRightChat({
   viewportWidth,
   navWidth,
+  listWidth = 0,
   rightChatWidth,
-}: {
-  viewportWidth: number;
-  navWidth: number;
-  rightChatWidth: number;
-}): boolean {
-  return navWidth + rightChatWidth + SHELL_DETAIL_MIN_PX + SHELL_SEPARATOR_ALLOWANCE_PX > viewportWidth;
+}: RightChatFitInput): boolean {
+  const separatorCount = listWidth > 0 ? 3 : 2;
+  return (
+    navWidth +
+      listWidth +
+      rightChatWidth +
+      SHELL_DETAIL_MIN_PX +
+      separatorCount * SHELL_SEPARATOR_PX >
+    viewportWidth
+  );
 }

--- a/src/lib/shell-right-chat.ts
+++ b/src/lib/shell-right-chat.ts
@@ -1,0 +1,32 @@
+export const RIGHT_CHAT_OPEN_PREF_KEY = "cave:shell:right-chat-open";
+export const RIGHT_CHAT_WIDTH_PREF_KEY = "cave:shell:right-chat-width";
+export const RIGHT_CHAT_DEFAULT_PX = 360;
+export const RIGHT_CHAT_MIN_PX = 320;
+export const RIGHT_CHAT_MAX_PX = 640;
+export const SHELL_DETAIL_MIN_PX = 320;
+
+const SHELL_SEPARATOR_ALLOWANCE_PX = 8;
+
+export function normalizeRightChatOpen(raw: string | null): boolean {
+  return raw === "1";
+}
+
+export function normalizeRightChatWidth(raw: string | null): number {
+  const parsed = raw === null ? Number.NaN : Number(raw);
+  if (!Number.isFinite(parsed)) return RIGHT_CHAT_DEFAULT_PX;
+
+  const rounded = Math.round(parsed);
+  return Math.min(RIGHT_CHAT_MAX_PX, Math.max(RIGHT_CHAT_MIN_PX, rounded));
+}
+
+export function shouldAutoCollapseNavForRightChat({
+  viewportWidth,
+  navWidth,
+  rightChatWidth,
+}: {
+  viewportWidth: number;
+  navWidth: number;
+  rightChatWidth: number;
+}): boolean {
+  return navWidth + rightChatWidth + SHELL_DETAIL_MIN_PX + SHELL_SEPARATOR_ALLOWANCE_PX > viewportWidth;
+}

--- a/src/lib/use-focus-trap-stack.test.tsx
+++ b/src/lib/use-focus-trap-stack.test.tsx
@@ -1,0 +1,510 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention in
+// mobile-drawer-inert-focus-order.test.tsx and use-surface-history.test.tsx.
+//
+// Behavioral companion to use-focus-trap.test.ts. That file pins the source
+// contract with fast text assertions; this file actually mounts the REAL
+// `useFocusTrap` hook (imported from "@/lib/use-focus-trap", never
+// reimplemented) through React's genuine effect-commit machinery (act() +
+// real mount/update/cleanup, including a StrictMode pass) to prove the
+// cave-rl980 Task 5 modal/focus findings behave, not just that certain
+// substrings exist in source:
+//
+//   1. Nested traps: when a body-portaled child dialog (e.g. an artifact
+//      fullscreen viewer) opens on top of an already-active trap (e.g. the
+//      right-Chat drawer), only the TOPMOST trap acts on Escape and Tab.
+//      Escape closes only the child; the drawer's own onEscape never fires
+//      while the child is open. Tab containment is likewise owned solely by
+//      the topmost trap — the parent's Tab handler never touches its own
+//      focusables while a child sits above it (previously it would: seeing
+//      focus inside the child, `!container.contains(activeEl)` was true for
+//      the PARENT's own container, so the parent's "recapture" branch would
+//      forcibly yank focus back into the parent's own focusables).
+//   2. When the child trap deactivates (closes), the parent "resumes" —
+//      the very next Escape now reaches the parent — with no extra
+//      bookkeeping on either side.
+//   3. hadTrapAbove safety: if the PARENT deactivates while the child is
+//      STILL active (the pathological "drawer closes out from under an open
+//      child" ordering — the rare case FocusTrapOwnerHiddenContext exists to
+//      avoid, but the stack itself must still degrade safely if it happens),
+//      the parent's own focus-restore is skipped rather than fighting the
+//      still-active child's containment. The child's own eventual
+//      deactivation still restores focus correctly.
+//   4. StrictMode's dev mount→cleanup→mount double-invoke never leaves a
+//      duplicated stack entry: escape routing after a StrictMode-wrapped
+//      mount is identical to a normal mount.
+//   5. FocusTrapOwnerHiddenContext: an active trap nested under a boundary
+//      that flips to `hidden` is asked to close through the same onEscape
+//      callback Escape already uses — the mechanism behind "closing the
+//      retained right-Chat drawer must not leave an independently portaled
+//      child Chat modal visible/interactive" (finding #2).
+import { StrictMode, useEffect, useRef, useState, type ReactNode } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, describe, expect, test } from "vitest";
+import {
+  FocusTrapOwnerHiddenContext,
+  resetFocusTrapStackForTest,
+  useFocusTrap,
+} from "@/lib/use-focus-trap";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** A fake focusable DOM node: focusing it updates the shared activeElement
+ *  holder, exactly like a real element updates `document.activeElement`. */
+type FakeElement = {
+  readonly name: string;
+  focus: () => void;
+  hasAttribute: (name: string) => boolean;
+};
+
+function makeElement(name: string, activeHolder: { current: FakeElement | null }): FakeElement {
+  const el: FakeElement = {
+    name,
+    focus: () => {
+      activeHolder.current = el;
+    },
+    hasAttribute: () => false,
+  };
+  return el;
+}
+
+/** A fake dialog container: just enough of the DOM surface useFocusTrap
+ *  touches (querySelector/querySelectorAll/contains/focus). querySelectorAll
+ *  calls are counted so tests can prove a BACKGROUND trap's Tab handler
+ *  never even inspects its own focusables while a trap above it is topmost. */
+function makeContainer(elements: FakeElement[], activeHolder: { current: FakeElement | null }) {
+  let querySelectorAllCalls = 0;
+  return {
+    elements,
+    get querySelectorAllCalls() {
+      return querySelectorAllCalls;
+    },
+    querySelector: () => elements[0] ?? null,
+    querySelectorAll: () => {
+      querySelectorAllCalls += 1;
+      return elements;
+    },
+    contains: (el: unknown) => elements.includes(el as FakeElement),
+    focus: () => {
+      /* fallback focus target when a container has no focusable child */
+    },
+  };
+}
+
+/** useFocusTrap reads `document.activeElement` and registers on `window` —
+ *  stub just enough of both since there is no jsdom in this repo (see the
+ *  file-level constraint note in mobile-drawer-inert-focus-order.test.tsx). */
+function makeWindowStub() {
+  const listeners: Array<(e: unknown) => void> = [];
+  return {
+    listeners,
+    addEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type === "keydown") listeners.push(fn);
+    },
+    removeEventListener: (type: string, fn: (e: unknown) => void) => {
+      if (type !== "keydown") return;
+      const idx = listeners.indexOf(fn);
+      if (idx !== -1) listeners.splice(idx, 1);
+    },
+    /** Dispatches to every currently-registered listener, in registration
+     *  order — exactly how a real `window` fires multiple keydown listeners.
+     *  Snapshots the list first: a handler reacting synchronously (e.g.
+     *  onEscape triggering a state update inside the same act() call) must
+     *  not perturb the iteration. */
+    dispatchKeydown(partial: { key: string; shiftKey?: boolean }) {
+      const event = {
+        key: partial.key,
+        shiftKey: partial.shiftKey ?? false,
+        preventDefault: () => {},
+      };
+      for (const fn of [...listeners]) fn(event);
+    },
+  };
+}
+
+function stubDomGlobals(activeHolder: { current: FakeElement | null }, win: ReturnType<typeof makeWindowStub>) {
+  const previousDocument = (globalThis as Record<string, unknown>).document;
+  const previousWindow = (globalThis as Record<string, unknown>).window;
+  (globalThis as Record<string, unknown>).document = {
+    get activeElement() {
+      return activeHolder.current;
+    },
+  };
+  (globalThis as Record<string, unknown>).window = win;
+  return () => {
+    (globalThis as Record<string, unknown>).document = previousDocument;
+    (globalThis as Record<string, unknown>).window = previousWindow;
+  };
+}
+
+/** Mounts a single useFocusTrap instance against whatever fake container
+ *  `createNodeMock` resolves for its `data-probe-id`. */
+function TrapProbe({
+  probeId,
+  active,
+  onEscape,
+}: {
+  probeId: string;
+  active: boolean;
+  onEscape: () => void;
+}) {
+  const containerRef = useRef<unknown>(null);
+  useFocusTrap(active, containerRef as never, { onEscape });
+  return <div data-probe-id={probeId} ref={containerRef as never} />;
+}
+
+let renderer: ReactTestRenderer | null = null;
+let restoreGlobals: (() => void) | null = null;
+
+afterEach(() => {
+  if (renderer) {
+    act(() => {
+      renderer!.unmount();
+    });
+    renderer = null;
+  }
+  restoreGlobals?.();
+  restoreGlobals = null;
+  // Belt-and-suspenders: a test that throws before unmounting must not leak
+  // a stray registration into a later test in this same file/process.
+  resetFocusTrapStackForTest();
+});
+
+describe("useFocusTrap stack-awareness (cave-rl980 Task 5 nested modal findings)", () => {
+  test("Escape closes only the topmost (child) trap while both are active, then the parent resumes", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const parentTrigger = makeElement("parent-trigger", activeHolder);
+    const parentFocusable = makeElement("parent-focusable", activeHolder);
+    const childFocusable = makeElement("child-focusable", activeHolder);
+    const parentContainer = makeContainer([parentFocusable], activeHolder);
+    const childContainer = makeContainer([childFocusable], activeHolder);
+
+    activeHolder.current = parentTrigger;
+
+    let parentEscapeCount = 0;
+    let childEscapeCount = 0;
+
+    function Scene({ showChild }: { showChild: boolean }) {
+      return (
+        <>
+          <TrapProbe probeId="parent" active onEscape={() => (parentEscapeCount += 1)} />
+          {showChild ? (
+            <TrapProbe probeId="child" active onEscape={() => (childEscapeCount += 1)} />
+          ) : null}
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene showChild={false} />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "parent" ? parentContainer : childContainer,
+      });
+    });
+    // Parent activation captured the trigger and moved focus to its own
+    // focusable (focusFirst defaults true).
+    expect(activeHolder.current).toBe(parentFocusable);
+
+    // The child dialog opens ON TOP of the already-active parent trap — a
+    // SEPARATE update, matching the real "modal opened later from within
+    // already-open content" timeline (not a same-commit sibling mount).
+    act(() => {
+      renderer!.update(<Scene showChild />);
+    });
+    expect(activeHolder.current).toBe(childFocusable);
+
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(childEscapeCount).toBe(1);
+    expect(parentEscapeCount).toBe(0);
+
+    // Close the child (active flips false, component stays mounted — the
+    // same "hidden rather than unmounted" shape ChatArtifactViewer's own
+    // `fullscreen` toggle uses).
+    function SceneChildInactive() {
+      return (
+        <>
+          <TrapProbe probeId="parent" active onEscape={() => (parentEscapeCount += 1)} />
+          <TrapProbe probeId="child" active={false} onEscape={() => (childEscapeCount += 1)} />
+        </>
+      );
+    }
+    act(() => {
+      renderer!.update(<SceneChildInactive />);
+    });
+
+    // The parent resumes: the very next Escape reaches it, with no extra
+    // bookkeeping required on either side.
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+    expect(parentEscapeCount).toBe(1);
+    expect(childEscapeCount).toBe(1);
+  });
+
+  test("Tab containment is owned solely by the topmost trap — the background trap never inspects its own focusables", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const parentFocusable = makeElement("parent-focusable", activeHolder);
+    const childOnlyFocusable = makeElement("child-focusable", activeHolder);
+    const parentContainer = makeContainer([parentFocusable], activeHolder);
+    const childContainer = makeContainer([childOnlyFocusable], activeHolder);
+
+    function Scene() {
+      return (
+        <>
+          <TrapProbe probeId="parent" active onEscape={() => {}} />
+          <TrapProbe probeId="child" active onEscape={() => {}} />
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "parent" ? parentContainer : childContainer,
+      });
+    });
+    expect(activeHolder.current).toBe(childOnlyFocusable);
+
+    const parentQueriesBeforeTab = parentContainer.querySelectorAllCalls;
+
+    // Tab (non-shift) with the single child focusable already active should
+    // cycle back to itself (first === last) and must never reach into the
+    // PARENT's container at all — the previous, non-stack-aware bug would
+    // see `!parentContainer.contains(childOnlyFocusable)` (true, since they
+    // are unrelated fake containers) and forcibly steal focus into the
+    // parent's own focusable.
+    act(() => {
+      win.dispatchKeydown({ key: "Tab" });
+    });
+
+    expect(activeHolder.current).toBe(childOnlyFocusable);
+    expect(parentContainer.querySelectorAllCalls).toBe(parentQueriesBeforeTab);
+  });
+
+  test("hadTrapAbove safety: a parent deactivating while a child is still active skips its own focus restore", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const outerTrigger = makeElement("outer-trigger", activeHolder);
+    const parentFocusable = makeElement("parent-focusable", activeHolder);
+    const childFocusable = makeElement("child-focusable", activeHolder);
+    const parentContainer = makeContainer([parentFocusable], activeHolder);
+    const childContainer = makeContainer([childFocusable], activeHolder);
+    activeHolder.current = outerTrigger;
+
+    function Scene({ parentActive, childActive }: { parentActive: boolean; childActive: boolean }) {
+      return (
+        <>
+          <TrapProbe probeId="parent" active={parentActive} onEscape={() => {}} />
+          <TrapProbe probeId="child" active={childActive} onEscape={() => {}} />
+        </>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene parentActive childActive={false} />, {
+        createNodeMock: (element) =>
+          element.props["data-probe-id"] === "parent" ? parentContainer : childContainer,
+      });
+    });
+    expect(activeHolder.current).toBe(parentFocusable);
+
+    act(() => {
+      renderer!.update(<Scene parentActive childActive />);
+    });
+    expect(activeHolder.current).toBe(childFocusable);
+
+    // Pathological ordering: the parent (drawer) deactivates while the
+    // child (an independently portaled dialog) is STILL active — the exact
+    // shape "closing the right-Chat drawer must not leave a child Chat
+    // modal visible/interactive" describes when nothing has told the child
+    // to close yet. The parent's cleanup must NOT yank focus away from the
+    // still-active, still-topmost child.
+    act(() => {
+      renderer!.update(<Scene parentActive={false} childActive />);
+    });
+    expect(activeHolder.current).toBe(childFocusable);
+
+    // The child's own eventual deactivation restores focus to whatever WAS
+    // focused when the child itself activated — parentFocusable, since the
+    // parent's trap was still the active one at that moment. That target is
+    // exactly what a REAL browser would treat as a no-op: the parent's own
+    // container is presumably already closed (unmounted, detached, or, per
+    // finding #4, marked `inert`), and `.focus()` on a detached/inert
+    // element is a spec-guaranteed no-op, not a crash or a stuck state. A
+    // single trap's cleanup is only ever responsible for restoring ITS OWN
+    // saved focus, never for walking further back to find some earlier
+    // still-live ancestor — this pathological "parent closes out from under
+    // an open child" ordering is precisely what FocusTrapOwnerHiddenContext
+    // (see the dedicated test below) exists to make the rare case rather
+    // than the one every trap must defend against unaided.
+    act(() => {
+      renderer!.update(<Scene parentActive={false} childActive={false} />);
+    });
+    expect(activeHolder.current).toBe(parentFocusable);
+  });
+
+  test("StrictMode's dev double-invoke does not duplicate the stack registration", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const focusable = makeElement("focusable", activeHolder);
+    const container = makeContainer([focusable], activeHolder);
+    let escapeCount = 0;
+
+    function Scene() {
+      return (
+        <StrictMode>
+          <TrapProbe probeId="only" active onEscape={() => (escapeCount += 1)} />
+        </StrictMode>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene />, {
+        createNodeMock: () => container,
+      });
+    });
+
+    act(() => {
+      win.dispatchKeydown({ key: "Escape" });
+    });
+
+    // A duplicated registration would still deliver exactly one Escape here
+    // (there's only ever one trap in this scene), so the load-bearing check
+    // is that exactly ONE keydown listener answers a single dispatch — a
+    // leaked duplicate registration from a broken mount→cleanup→mount cycle
+    // would otherwise silently double-count.
+    expect(escapeCount).toBe(1);
+  });
+
+  test("FocusTrapOwnerHiddenContext asks a still-active nested trap to close through its own onEscape", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const focusable = makeElement("focusable", activeHolder);
+    const container = makeContainer([focusable], activeHolder);
+    let escapeCount = 0;
+
+    function Scene({ hidden }: { hidden: boolean }) {
+      return (
+        <FocusTrapOwnerHiddenContext.Provider value={hidden}>
+          <TrapProbe probeId="child" active onEscape={() => (escapeCount += 1)} />
+        </FocusTrapOwnerHiddenContext.Provider>
+      );
+    }
+
+    act(() => {
+      renderer = create(<Scene hidden={false} />, {
+        createNodeMock: () => container,
+      });
+    });
+    expect(escapeCount).toBe(0);
+
+    // The owner (e.g. RightChatPanel) becomes hidden/inert while this trap
+    // is still active — nothing dispatched a real Escape keydown.
+    act(() => {
+      renderer!.update(<Scene hidden />);
+    });
+    expect(escapeCount).toBe(1);
+  });
+
+  test("a component with no owner boundary above it is completely unaffected by the context (default false)", () => {
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+
+    const focusable = makeElement("focusable", activeHolder);
+    const container = makeContainer([focusable], activeHolder);
+    let escapeCount = 0;
+
+    act(() => {
+      renderer = create(<TrapProbe probeId="only" active onEscape={() => (escapeCount += 1)} />, {
+        createNodeMock: () => container,
+      });
+    });
+
+    // No provider anywhere above — the context default (false) applies, so
+    // merely re-rendering (or existing at all) never triggers onEscape.
+    act(() => {
+      renderer!.update(<TrapProbe probeId="only" active onEscape={() => (escapeCount += 1)} />);
+    });
+    expect(escapeCount).toBe(0);
+  });
+
+  test("closing the retained right-Chat drawer closes a still-open child Chat modal (finding #2 integration)", () => {
+    // Mirrors the REAL shape end to end: RightChatPanelFrame/the resolved
+    // <aside> wrap ChatRouter's render branch in
+    // FocusTrapOwnerHiddenContext.Provider value={!open}; ChatArtifactViewer
+    // (unchanged, not reimplemented here beyond its exact useFocusTrap call
+    // shape) owns its own `fullscreen` boolean and calls
+    // `useFocusTrap(fullscreen, shellRef, { onEscape: () => setFullscreen(false) })`.
+    // This proves the full round trip — not just that onEscape was invoked,
+    // but that the CHILD's own state genuinely flips closed — with nothing
+    // ever telling ChatArtifactViewer directly to exit fullscreen.
+    const activeHolder: { current: FakeElement | null } = { current: null };
+    const win = makeWindowStub();
+    restoreGlobals = stubDomGlobals(activeHolder, win);
+    const container = makeContainer([], activeHolder);
+
+    function ChatArtifactViewerLike({
+      onFullscreenChange,
+    }: {
+      onFullscreenChange: (value: boolean) => void;
+    }) {
+      // Opened before the drawer starts closing — the exact "independently
+      // portaled child Chat modal" left visible/interactive by the bug.
+      const [fullscreen, setFullscreen] = useState(true);
+      const shellRef = useRef<unknown>(null);
+      useFocusTrap(fullscreen, shellRef as never, { onEscape: () => setFullscreen(false) });
+      useEffect(() => {
+        onFullscreenChange(fullscreen);
+      }, [fullscreen, onFullscreenChange]);
+      return null;
+    }
+
+    function RightChatDrawerLike({ open, children }: { open: boolean; children: ReactNode }) {
+      return (
+        <FocusTrapOwnerHiddenContext.Provider value={!open}>{children}</FocusTrapOwnerHiddenContext.Provider>
+      );
+    }
+
+    let latestFullscreen = true;
+    const onFullscreenChange = (value: boolean) => {
+      latestFullscreen = value;
+    };
+
+    act(() => {
+      renderer = create(
+        <RightChatDrawerLike open>
+          <ChatArtifactViewerLike onFullscreenChange={onFullscreenChange} />
+        </RightChatDrawerLike>,
+        { createNodeMock: () => container },
+      );
+    });
+    expect(latestFullscreen).toBe(true);
+
+    // The drawer closes/hides (a mobile backdrop tap, the desktop panel
+    // collapsing, or any other dismissal) — nothing tells the artifact
+    // viewer directly to leave fullscreen.
+    act(() => {
+      renderer!.update(
+        <RightChatDrawerLike open={false}>
+          <ChatArtifactViewerLike onFullscreenChange={onFullscreenChange} />
+        </RightChatDrawerLike>,
+      );
+    });
+
+    expect(latestFullscreen).toBe(false);
+  });
+});

--- a/src/lib/use-focus-trap.test.ts
+++ b/src/lib/use-focus-trap.test.ts
@@ -71,4 +71,112 @@ assert.match(
   "trap focuses the container as a fallback when no focusable child exists",
 );
 
+// --- Stack-awareness (cave-rl980 Task 5 modal/focus findings) ---
+//
+// Every active trap registers on a shared module-level stack so a
+// body-portaled child dialog opened above another active trap (e.g. an
+// artifact fullscreen viewer opened from inside the right-Chat drawer's
+// transcript) can layer correctly: only the TOPMOST trap owns Escape and Tab
+// containment; a background trap "resumes" the instant the trap above it
+// deactivates, with no extra bookkeeping.
+
+// A module-level stack, not per-hook-instance state — this is what lets
+// unrelated hook instances coordinate ordering at all.
+assert.match(
+  source,
+  /const trapStack:\s*TrapEntry\[\]\s*=\s*\[\];/,
+  "a module-level stack tracks every currently-active trap",
+);
+
+// Stable per-hook-instance identity (not object identity) survives a
+// StrictMode mount→cleanup→mount cycle without duplicating or losing the
+// registration.
+assert.match(
+  source,
+  /const idRef = useRef\(0\);/,
+  "each hook instance gets a stable id ref",
+);
+assert.match(
+  source,
+  /if \(idRef\.current === 0\) idRef\.current = nextTrapId\+\+;/,
+  "the id is assigned once via lazy ref init, not re-created on every render",
+);
+
+// register/unregister are id-keyed and defensively de-duplicate, so a
+// StrictMode double-invoke (register → unregister → register) can never
+// leave two entries for the same logical trap.
+assert.match(
+  source,
+  /function registerTrap\(id: number\): void \{/,
+  "registerTrap is keyed by the stable id",
+);
+assert.match(
+  source,
+  /const stale = trapStack\.findIndex\(\(entry\) => entry\.id === id\);\s*\n\s*if \(stale !== -1\) trapStack\.splice\(stale, 1\);/,
+  "registerTrap removes any stale entry for the same id before pushing (StrictMode safety)",
+);
+assert.match(
+  source,
+  /function unregisterTrap\(id: number\): \{ hadTrapAbove: boolean \} \{/,
+  "unregisterTrap is keyed by the stable id, not stack position",
+);
+assert.match(
+  source,
+  /function isTopmostTrap\(id: number\): boolean \{/,
+  "isTopmostTrap checks the id against the top of the stack",
+);
+
+// Only the topmost trap acts on a keydown — everything below it is a
+// complete no-op.
+assert.match(
+  source,
+  /function onKey\(e: KeyboardEvent\) \{\s*\n(?:\s*\/\/[^\n]*\n)*\s*if \(!isTopmostTrap\(trapId\)\) return;/,
+  "the keydown handler is gated on being the topmost trap before touching Escape or Tab",
+);
+
+// Deactivating skips its own focus restore when a still-active nested trap
+// sits above it (ancestor-closes-under-open-child safety), deferring to that
+// trap's own eventual restoration instead of fighting its containment.
+assert.match(
+  source,
+  /const \{ hadTrapAbove \} = unregisterTrap\(trapId\);/,
+  "cleanup captures whether a trap was layered above before restoring focus",
+);
+assert.match(
+  source,
+  /if \(!hadTrapAbove\) \{\s*\n\s*returnFocusRef\.current\?\.focus\(\);\s*\n\s*\}/,
+  "focus restoration on deactivate is skipped while a nested trap is still active above it",
+);
+
+// Test seam: a stray trap left registered by a failed test must not leak
+// into a later one in the same file/process.
+assert.match(
+  source,
+  /export function resetFocusTrapStackForTest\(\): void \{/,
+  "exports a test-only stack reset",
+);
+
+// --- Owner-hidden auto-dismiss (cave-rl980 Task 5 finding #2) ---
+//
+// An ancestor "modal owner" (e.g. RightChatPanel) that stays mounted but
+// becomes hidden/inert must be able to ask a still-active, body-portaled
+// descendant trap to close — since createPortal moves the dialog's DOM node
+// outside the owner's subtree, the owner's own `inert` never reaches it, but
+// React context still does regardless of portal target.
+assert.match(
+  source,
+  /export const FocusTrapOwnerHiddenContext = createContext\(false\);/,
+  "exports a context ancestors use to signal they've become hidden, defaulting to false (unaffected) everywhere it isn't provided",
+);
+assert.match(
+  source,
+  /const ownerHidden = useContext\(FocusTrapOwnerHiddenContext\);/,
+  "the hook consumes the owner-hidden context automatically",
+);
+assert.match(
+  source,
+  /if \(!active \|\| !ownerHidden\) return;\s*\n\s*onEscapeRef\.current\?\.\(\);/,
+  "an active trap whose owner becomes hidden is asked to close through the SAME onEscape callback Escape uses",
+);
+
 console.log("use-focus-trap.test.ts OK");

--- a/src/lib/use-focus-trap.ts
+++ b/src/lib/use-focus-trap.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, type RefObject } from "react";
+import { createContext, useContext, useEffect, useRef, type RefObject } from "react";
 
 export const FOCUSABLE = [
   "button:not([disabled])",
@@ -22,10 +22,88 @@ type Options = {
 };
 
 /**
+ * One entry per currently-ACTIVE trap, in activation order — the
+ * module-level stack every useFocusTrap instance in the app shares. Keyed by
+ * a stable per-hook-instance `id` (see `idRef` below), never by object
+ * identity, so a React StrictMode mount→cleanup→mount cycle registers and
+ * unregisters the SAME logical trap without ever leaving a duplicate behind:
+ * `registerTrap` removes any existing entry for `id` before pushing, and
+ * `unregisterTrap` finds and removes `id` from wherever it sits — not just
+ * the top — because an ancestor trap can legitimately deactivate while a
+ * still-active nested trap remains above it (e.g. a drawer closing out from
+ * under an open child dialog; see FocusTrapOwnerHiddenContext below, which
+ * exists to make that the rare case rather than the normal one).
+ */
+type TrapEntry = { readonly id: number };
+
+const trapStack: TrapEntry[] = [];
+let nextTrapId = 1;
+
+function registerTrap(id: number): void {
+  const stale = trapStack.findIndex((entry) => entry.id === id);
+  if (stale !== -1) trapStack.splice(stale, 1);
+  trapStack.push({ id });
+}
+
+/** Removes `id` (wherever it sits) and reports whether a still-active trap
+ *  was layered above it — the caller uses this to decide whether restoring
+ *  its own saved focus is safe right now, or whether the trap still on top
+ *  owns focus until IT deactivates and performs its own restoration. */
+function unregisterTrap(id: number): { hadTrapAbove: boolean } {
+  const index = trapStack.findIndex((entry) => entry.id === id);
+  if (index === -1) return { hadTrapAbove: false };
+  const hadTrapAbove = index < trapStack.length - 1;
+  trapStack.splice(index, 1);
+  return { hadTrapAbove };
+}
+
+function isTopmostTrap(id: number): boolean {
+  return trapStack.length > 0 && trapStack[trapStack.length - 1].id === id;
+}
+
+/** Test seam — drops every registered trap. Prevents a test that mounts a
+ *  trap and errors before unmounting from leaking a stale entry into a
+ *  later test in the same file/process. */
+export function resetFocusTrapStackForTest(): void {
+  trapStack.length = 0;
+}
+
+/**
+ * Signals that an ancestor "modal owner" has become hidden while remaining
+ * mounted — e.g. RightChatPanel's persistent panel/drawer, which stays
+ * mounted-but-`aria-hidden`/`inert` when closed rather than unmounting (see
+ * its "truthful accessibility, not a mount gate" contract) so ChatRouter's
+ * transcript/stream survive a close. `createPortal` moves a dialog's DOM
+ * node OUTSIDE its owner's subtree — so the owner's own `inert` never
+ * reaches a body-portaled child — but never changes its REACT ancestry, so
+ * this context still reaches every descendant regardless of where it
+ * portals to. Every useFocusTrap call consumes it automatically below: a
+ * trap whose owner disappears is asked to close through the SAME onEscape
+ * callback it already wires up for the Escape key, so a hidden/inert owner
+ * never leaves a body-portaled child dialog visible or interactive with
+ * nothing left to contain it. Default `false` (not hidden) — every existing
+ * useFocusTrap call site has no owner boundary above it and behaves exactly
+ * as before.
+ */
+export const FocusTrapOwnerHiddenContext = createContext(false);
+
+/**
  * Trap focus inside `containerRef` while `active` is true. Saves the
  * previously-focused element on activate→deactivate and restores it on
  * deactivate. Tab/Shift+Tab cycle through focusable descendants. Escape
  * calls onEscape.
+ *
+ * Stack-aware: every active trap in the app registers on a shared
+ * module-level stack (see trapStack above), and only the TOPMOST one ever
+ * acts on a keydown or restores focus on deactivation — everything below it
+ * is a complete no-op until the trap above it deactivates, at which point it
+ * "resumes" (the very next keydown routes to it again; no explicit re-focus
+ * step is needed). This is what lets a body-portaled child dialog opened
+ * from inside another active trap's content — e.g. an artifact fullscreen
+ * viewer opened from the chat transcript hosted inside the right-Chat
+ * drawer — layer correctly above it: Escape closes only the child, Tab stays
+ * contained to the child, and the parent regains both the moment the child
+ * closes, instead of both traps fighting over the same keydown.
  *
  * `onEscape` is stored in a ref so the effect deps don't include it — that
  * prevents tear-down/re-run loops when callers pass an inline arrow each
@@ -39,6 +117,12 @@ export function useFocusTrap(
 ) {
   const returnFocusRef = useRef<HTMLElement | null>(null);
   const onEscapeRef = useRef(onEscape);
+  // Stable per-hook-instance identity for the trap stack — assigned once
+  // (lazy ref init) and unaffected by StrictMode's double render/effect
+  // invocation, which reuses this same ref cell rather than re-creating it.
+  const idRef = useRef(0);
+  if (idRef.current === 0) idRef.current = nextTrapId++;
+  const ownerHidden = useContext(FocusTrapOwnerHiddenContext);
 
   // Keep the latest callback reachable from the keydown handler without
   // making it a useEffect dep.
@@ -64,7 +148,16 @@ export function useFocusTrap(
       }
     }
 
+    const trapId = idRef.current;
+    registerTrap(trapId);
+
     function onKey(e: KeyboardEvent) {
+      // Only the topmost active trap owns the keyboard (see trapStack doc
+      // comment above) — a background trap is a silent no-op here, and
+      // "resumes" on its own once the trap above it deactivates and
+      // unregisters, with no extra bookkeeping needed on this side.
+      if (!isTopmostTrap(trapId)) return;
+
       if (e.key === "Escape") {
         onEscapeRef.current?.();
         return;
@@ -104,7 +197,27 @@ export function useFocusTrap(
     window.addEventListener("keydown", onKey);
     return () => {
       window.removeEventListener("keydown", onKey);
-      returnFocusRef.current?.focus();
+      const { hadTrapAbove } = unregisterTrap(trapId);
+      // Skip restoring focus if a still-active nested trap sits above where
+      // we were: an ancestor closing out from under an open child must not
+      // fight that child's own containment. That trap owns focus until IT
+      // deactivates, at which point ITS OWN cleanup restores focus — either
+      // back to us (if we're still mounted and active) or, chaining
+      // outward, to whatever was focused before the outermost trap ever
+      // activated.
+      if (!hadTrapAbove) {
+        returnFocusRef.current?.focus();
+      }
     };
   }, [active, containerRef, focusFirst]); // intentionally no onEscape
+
+  // If an ancestor "modal owner" becomes hidden while this trap is still
+  // active, ask it to close through the SAME callback Escape already uses
+  // (see FocusTrapOwnerHiddenContext above). A no-op when onEscape is
+  // undefined (e.g. gated behind an in-flight submit), matching Escape's own
+  // no-op contract in that case.
+  useEffect(() => {
+    if (!active || !ownerHidden) return;
+    onEscapeRef.current?.();
+  }, [active, ownerHidden]);
 }

--- a/src/styles/globals/shell-responsive.css
+++ b/src/styles/globals/shell-responsive.css
@@ -1323,11 +1323,20 @@
 }
 
 /* Backdrop sibling rendered by <MobileDrawer/> via portal whenever a
-   drawer is open. Covers the detail pane and dismisses on tap. */
+   drawer is open. Covers the detail pane and dismisses on tap. A real
+   <button> (not a role="presentation" div) so Escape-independent dismissal
+   is reachable from the keyboard too — the resets below strip the native
+   button chrome (border/padding/font/cursor) so it still reads as a plain
+   full-viewport scrim. */
 .mobile-drawer-backdrop {
   position: fixed;
   inset: 0;
   z-index: 199;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font: inherit;
+  cursor: default;
   background: var(--backdrop-scrim);
   touch-action: none;
   animation: mobile-drawer-fade-in var(--duration-base) var(--ease-decelerate);


### PR DESCRIPTION
Opens the long-standing `feat/cave-rl980-right-chat-panel` branch for review. **The work was completed on 2026-08-09 and a PR was never opened**, so the feature has never shipped: zero right-chat source files exist in `main`, `v0.3.2`, or `v0.3.3` — all seven live only on this branch.

Beads: `cave-rl980` (implementation) and `cave-ltl38.4` (the epic unit), both still `in_progress`.

## What it delivers

The approved design in [`superpowers/specs/2026-08-08-global-right-chat-panel-design.md`](docs/superpowers/specs/2026-08-08-global-right-chat-panel-design.md) and TDD plan in [`superpowers/plans/2026-08-08-global-right-chat-panel.md`](docs/superpowers/plans/2026-08-08-global-right-chat-panel.md): a shell-owned resizable right Chat panel driven by an independent `ChatRouter`, kept mounted while closed and across workspace navigation, with isolated composer drafts, active-familiar session resolution without cross-familiar fallback, persisted desktop width/open state, and the same instance rendered in an accessible mobile drawer.

New source:

```
src/components/right-chat-panel.tsx
src/lib/right-chat-session.ts
src/lib/shell-right-chat.ts
+ 4 test files
```

## State — read before merging

- **19 commits ahead, 139 behind `main`.** `git merge-tree --write-tree` reports a **clean merge** (no textual conflicts), but 139 commits is five days of drift in a busy tree, so CI on the merge result is the real test. Branch protection sets `strict: false`, so being behind is not itself a blocker.
- Its worktree has been retired, so no live session owns the branch.
- The last three review rounds are documented in detail on `cave-rl980` — focus-trap stacking, archive/delete session retention, familiar-transition resolution — each with the tests that pin them.
- One known adjacent issue: `cave-zu7ta` (P3) tracks a stale `composerDraftKey` pin in `chat-compose-instance.test.ts` / `chat-sidebar-wiring.test.ts`, which the bead notes were already failing on clean `main` at the time, independently of this branch.

## Why now

A user on macOS reported not having the right-side Chat panel that a colleague appeared to have on Windows. Investigation found no platform gate — the feature simply is not in any released build. This PR is the actual path to "it shows up everywhere".