### PR TITLE
fix(worktree): stop a stale tracking ref masking a deleted branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -688,6 +688,19 @@ a server-side deletion — it removes the local tracking ref too — and if a
 `fetch --prune` has already run the signal is gone, in which case the hook falls
 back to its previous behaviour: a resurrected branch, never a lost commit.
 
+⚠️ **That same surviving tracking ref is what made this path unreachable for a
+day.** The at-risk test was `rev-list HEAD --not --remotes`, and `--remotes`
+trusts every `refs/remotes/*` to still exist on the remote. So the instant a
+squash merge auto-deleted the branch, the stale ref satisfied `--remotes`, the
+head read as *fully retained*, and the unit was skipped before the
+deleted-branch check above was ever consulted — the archive fired only if a
+`fetch --prune` happened to have run first. Verified on 2026-08-14: two
+worktrees retired minutes after their PRs merged, and the hook logged nothing
+for either. The skip test now recounts while ignoring the branch's **own**
+tracking ref, and only then asks the remote whether the branch is really gone —
+so a head still covered by any other ref costs no network call, and a pass with
+nothing genuinely at risk stays offline as before.
+
 Throttled to once a minute (`.claude/worktree-retention-push.stamp`) and capped
 at 3 pushes per pass to bound the latency added to one tool call; pushed
 worktrees drop out of the at-risk set, so successive passes reach the rest.

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -85,6 +85,35 @@ export function unpushedCount(worktreePath) {
   }
 }
 
+/**
+ * The same count, but ignoring ONE remote-tracking ref.
+ *
+ * `--remotes` believes every `refs/remotes/*` still exists on the remote, and a
+ * remote-tracking ref survives the remote deleting its branch until something
+ * prunes. So after a squash merge under `delete_branch_on_merge` the stale
+ * `refs/remotes/origin/<branch>` still satisfies `--not --remotes`, the head
+ * reads as fully retained, and the unit is skipped — which is why the
+ * deleted-branch archive path below could never fire for the case it was
+ * written for (cave-fud4p, round two).
+ *
+ * Enumerating the refs explicitly is what lets one be left out; `--not` has no
+ * "except" form. With no refs left, `rev-list HEAD --not` counts everything
+ * reachable from HEAD, which is the correct answer for a head nothing retains.
+ */
+export function unpushedCountIgnoring(worktreePath, ignoredRef) {
+  try {
+    const refs = git(["for-each-ref", "--format=%(refname)", "refs/remotes/"], worktreePath)
+      .split("\n")
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .filter((ref) => ref !== ignoredRef);
+    const n = Number(git(["rev-list", "--count", "HEAD", "--not", ...refs], worktreePath).trim());
+    return Number.isFinite(n) ? n : 0;
+  } catch {
+    return 0; // same posture as unpushedCount: unreadable means leave it alone
+  }
+}
+
 export function headSha(worktreePath) {
   try {
     return git(["rev-parse", "HEAD"], worktreePath).trim() || null;
@@ -285,12 +314,24 @@ function main() {
   for (const wt of worktrees) {
     if (pushes >= MAX_PUSHES_PER_PASS) break;
     if (wt.bare) continue;
-    const unpushed = unpushedCount(wt.path);
-    if (unpushed === 0) continue;
+    let unpushed = unpushedCount(wt.path);
     const branch = branchOf(wt.path);
     // `main` is protected and never the thing at risk; pushing it is exactly
     // the direct-to-main move the repository forbids.
     if (branch === "main") continue;
+
+    // A head can read as retained purely because of its OWN stale tracking ref
+    // — the exact state a squash merge plus `delete_branch_on_merge` leaves
+    // behind, and the moment a session turns to retiring the worktree. Recheck
+    // before believing "0", cheapest signal first: recount locally without that
+    // one ref, and only ask the remote when the answer actually depends on it.
+    // A head still covered by any other ref needs no network call at all, so a
+    // pass with nothing genuinely at risk stays offline as before.
+    if (unpushed === 0 && branch) {
+      const withoutOwnRef = unpushedCountIgnoring(wt.path, `refs/remotes/origin/${branch}`);
+      if (withoutOwnRef > 0 && deletedUpstream(wt.path, branch)) unpushed = withoutOwnRef;
+    }
+    if (unpushed === 0) continue;
 
     // Already archived: the remote advertises a tag at exactly this HEAD, which
     // is the guard's own definition of retained. Re-creating the branch here is

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -16,6 +16,7 @@ import {
   retain,
   retentionTag,
   unpushedCount,
+  unpushedCountIgnoring,
 } from "./worktree-retention-push.mjs";
 
 // Fixtures must not inherit machine-level git config. A global
@@ -104,6 +105,127 @@ test("unpushedCount counts only commits absent from every remote", () => {
     commit(work, "one");
     commit(work, "two");
     assert.equal(unpushedCount(work), 2);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The regression that made the deleted-branch archive path unreachable in the
+// exact case it was written for (cave-fud4p, round two). `--remotes` trusts
+// every refs/remotes/* to still exist on the remote, and a remote-tracking ref
+// outlives the remote deleting its branch, so a squash-merged head reads as
+// fully retained and the hook skips it before ever consulting deletedUpstream.
+//
+// The fixture reproduces the real sequence rather than asserting on a mock: a
+// pushed branch, a squash merge landing a DIFFERENT commit on main, then the
+// server-side branch deletion `delete_branch_on_merge` performs. Deleting the
+// ref inside the bare remote is what makes it server-side — `git push
+// --delete` would also drop the local tracking ref, which is precisely the
+// signal that must survive.
+test("a squash-merged, remote-deleted head is at risk even though --remotes says otherwise", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/topic"], work);
+    commit(work, "one");
+    git(["push", "-q", "-u", "origin", "feat/topic"], work);
+    const head = git(["rev-parse", "HEAD"], work).trim();
+
+    // Squash merge: a different commit for the same tree lands on main, so the
+    // branch tip is an ancestor of nothing the remote keeps.
+    const mainWork = path.join(root, "mainwork");
+    git(["clone", "-q", remote, mainWork], root);
+    configure(mainWork);
+    git(["merge", "-q", "--squash", "origin/feat/topic"], mainWork);
+    git(["commit", "-q", "-m", "squashed topic (#1)"], mainWork);
+    git(["push", "-q", "origin", "main"], mainWork);
+
+    // delete_branch_on_merge, server-side.
+    bare(["update-ref", "-d", "refs/heads/feat/topic"], remote);
+    git(["fetch", "-q", "origin", "main"], work); // a normal fetch: prunes nothing
+
+    // The state the hook has to read correctly.
+    assert.equal(hadRemoteTracking(work, "feat/topic"), true, "the tracking ref survives the deletion");
+    assert.ok(!remoteBranchNames(work).has("feat/topic"), "the remote no longer advertises the branch");
+    assert.equal(
+      bare(["rev-list", "--count", "--all"], remote).trim() !== "0" &&
+        bare(["branch", "--contains", head], remote).trim(),
+      "",
+      "and no remote branch contains the head — the commit is on no remote ref",
+    );
+
+    assert.equal(
+      unpushedCount(work),
+      0,
+      "the stale tracking ref makes --remotes report the head as fully retained (the bug)",
+    );
+    assert.ok(
+      unpushedCountIgnoring(work, "refs/remotes/origin/feat/topic") > 0,
+      "ignoring that one ref reveals the head is retained by nothing",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// End-to-end through the hook's own entry point, because the helpers above
+// cannot show what the hook DECIDED. The masking bug lived in main()'s skip
+// test, so a fix proven only at helper level would leave the actual behaviour
+// untested — the same shape of gap that let this ship the first time.
+test("the hook archives a squash-merged, remote-deleted worktree instead of ignoring it", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    // `work` plays the primary checkout; the unit at risk is a worktree of it.
+    const unit = path.join(work, ".worktrees", "topic");
+    git(["worktree", "add", "-q", "-b", "feat/topic", unit], work);
+    configure(unit);
+    commit(unit, "one");
+    git(["push", "-q", "-u", "origin", "feat/topic"], unit);
+    const head = git(["rev-parse", "HEAD"], unit).trim();
+
+    const mainWork = path.join(root, "mainwork");
+    git(["clone", "-q", remote, mainWork], root);
+    configure(mainWork);
+    git(["merge", "-q", "--squash", "origin/feat/topic"], mainWork);
+    git(["commit", "-q", "-m", "squashed topic (#1)"], mainWork);
+    git(["push", "-q", "origin", "main"], mainWork);
+    bare(["update-ref", "-d", "refs/heads/feat/topic"], remote);
+
+    execFileSync(process.execPath, [path.join(import.meta.dirname, "worktree-retention-push.mjs")], {
+      cwd: work,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...ISOLATED, CLAUDE_PROJECT_DIR: work },
+    });
+
+    // Retained as a TAG at the exact head — not resurrected as a branch.
+    const tag = retentionTag("feat/topic", head);
+    assert.equal(bare(["rev-parse", `refs/tags/${tag}`], remote).trim(), head, "the head is archived on the remote");
+    assert.equal(
+      bare(["for-each-ref", "--format=%(refname)", "refs/heads/feat/topic"], remote).trim(),
+      "",
+      "and the deliberately deleted branch stays deleted",
+    );
+
+    const log = readFileSync(path.join(work, ".claude", "worktree-retention-push.log"), "utf8")
+      .split("\n").filter(Boolean).map((line) => JSON.parse(line));
+    const entry = log.find((row) => row.branch === "feat/topic");
+    assert.equal(entry.verdict, "pushed-tag");
+    assert.equal(entry.reason, "branch-deleted-upstream", "and the record says WHY it was archived");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("unpushedCountIgnoring still counts every OTHER remote ref", () => {
+  const { root, work } = scaffold();
+  try {
+    // HEAD is on main, which the remote has; ignoring an unrelated branch's ref
+    // must not turn that into "at risk".
+    assert.equal(unpushedCountIgnoring(work, "refs/remotes/origin/feat/unrelated"), 0);
+    commit(work, "one");
+    assert.equal(unpushedCountIgnoring(work, "refs/remotes/origin/feat/unrelated"), 1);
+    // Ignoring a ref that does not exist is a no-op, not an error.
+    assert.equal(unpushedCountIgnoring(work, "refs/remotes/origin/nope"), unpushedCount(work));
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -231,6 +231,35 @@ test("unpushedCountIgnoring still counts every OTHER remote ref", () => {
   }
 });
 
+// The empty-refs edge, pinned because it is the one that would fail SILENTLY in
+// the unsafe direction: if `rev-list HEAD --not` (nothing after `--not`) threw,
+// the catch would return 0 and an at-risk head would read as fully retained —
+// the exact misclassification this whole change exists to remove. It does not
+// throw: `--not` only flips the sense of the args that FOLLOW it, and with none
+// following it is a no-op, so every commit reachable from HEAD is counted.
+test("unpushedCountIgnoring counts everything when the ignored ref was the only one", () => {
+  const { root, work } = scaffold();
+  try {
+    git(["checkout", "-q", "-b", "feat/topic"], work);
+    commit(work, "one");
+    git(["push", "-q", "-u", "origin", "feat/topic"], work);
+    // Leave exactly one remote-tracking ref — the one we are about to ignore.
+    git(["update-ref", "-d", "refs/remotes/origin/main"], work);
+    assert.deepEqual(
+      git(["for-each-ref", "--format=%(refname)", "refs/remotes/"], work).split("\n").filter(Boolean),
+      ["refs/remotes/origin/feat/topic"],
+    );
+
+    assert.equal(unpushedCount(work), 0, "the sole tracking ref still covers HEAD");
+    assert.ok(
+      unpushedCountIgnoring(work, "refs/remotes/origin/feat/topic") > 0,
+      "ignoring it leaves no refs at all, and the head must read as retained by nothing",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("retain pushes the branch, and the commit really lands on the remote", () => {
   const { root, remote, work } = scaffold();
   try {


### PR DESCRIPTION
## The bug

#4593 taught the retention hook to **archive** a head whose branch the remote had deleted rather than resurrect it. That path could not fire for the case it was written for.

The at-risk test is `rev-list HEAD --not --remotes`, and `--remotes` trusts every `refs/remotes/*` to still exist on the remote. A remote-tracking ref **outlives** the remote deleting its branch — that survival is exactly the signal `hadRemoteTracking` depends on. So the instant a squash merge triggers `delete_branch_on_merge`, the stale `refs/remotes/origin/<branch>` still satisfies `--not --remotes`, the head reads as *fully retained*, and the unit is skipped at

```js
const unpushed = unpushedCount(wt.path);
if (unpushed === 0) continue;          // ← here, long before deletedUpstream()
```

The archive fired only when a `fetch --prune` happened to have run first. The one setting the feature exists for guaranteed it would not.

## Observed

2026-08-14, PRs #4606 and #4608. Both worktrees were retired minutes after merge, and `.claude/worktree-retention-push.log` names neither branch afterwards — not pushed, not tagged, not even skipped. Their commits were on no remote ref at all; a hand-written archive tag is the only reason they still exist. The log shows the hook happily servicing *other* worktrees throughout that window, which is what makes the silence diagnostic rather than ambiguous.

## The fix

The skip test recounts while ignoring the branch's **own** tracking ref, and asks the remote whether the branch is really gone only when the answer depends on it:

```js
if (unpushed === 0 && branch) {
  const withoutOwnRef = unpushedCountIgnoring(wt.path, `refs/remotes/origin/${branch}`);
  if (withoutOwnRef > 0 && deletedUpstream(wt.path, branch)) unpushed = withoutOwnRef;
}
```

Cheapest signal first: a head still covered by any other ref is settled locally and costs no network call, so a pass with nothing genuinely at risk stays offline exactly as before. `deletedUpstream` is already memoised per pass, so the later call is free.

## Verification

Proven **end-to-end through the hook's entry point**, not just its helpers — the masking lived in `main()`'s skip test, so helper-level assertions would have left the real behaviour untested, which is the same shape of gap that let this ship the first time.

The fixture reproduces the actual sequence against a real bare remote: push a branch, squash-merge it so a *different* commit lands on `main`, then delete the ref **inside the bare repo** — server-side, so the tracking ref survives (`git push --delete` would drop it locally and not reproduce the state). Then it runs `worktree-retention-push.mjs` via `CLAUDE_PROJECT_DIR` and asserts the head is archived as a `retention/…` tag, the deliberately deleted branch stays deleted, and the log records `reason: "branch-deleted-upstream"`.

**Reverting the fix fails that test** (confirmed — `✖ the hook archives a squash-merged, remote-deleted worktree instead of ignoring it`). All 18 tests pass with it; `typecheck` and `check:tests-wired` green.

## Blast radius

Inert until a worktree enters that window: a read-only sweep of the live checkout finds **0 of 14** worktrees newly detected today. No tag storm on merge.

Bead: `cave-fud4p`.