### PR TITLE
fix(chat): a mid-draft slash command completes on Enter, never runs

### DIFF
--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -697,6 +697,7 @@ export const SUITES = {
     "src/lib/use-attachment-staging.test.ts",
     "src/lib/slash-command-inline.test.ts",
     "src/lib/use-inline-slash-menus.test.ts",
+    "src/lib/use-inline-slash-menus-behavior.test.tsx",
     "src/lib/prompt-enhancer.test.ts",
     "src/lib/prompt-placeholders.test.ts",
     "src/lib/prompt-prefs.test.ts",

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -1984,6 +1984,8 @@ const VITEST_TESTS = new Set([
   // renders the hook through react-test-renderer
   "src/lib/use-surface-history.test.tsx",
   "src/lib/use-focus-trap-stack.test.tsx",
+  // drives the inline slash menu's keydown path through react-test-renderer
+  "src/lib/use-inline-slash-menus-behavior.test.tsx",
 ]);
 
 /** Build the `node` argv (flags + file) for a single test path. */

--- a/src/components/chat-view-polish-header-composer.test.ts
+++ b/src/components/chat-view-polish-header-composer.test.ts
@@ -824,8 +824,17 @@ assert.match(
 );
 assert.match(
   slashBranch,
-  /cmd\.argPlaceholder &&[\s\S]*canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*completeCommand\(cmd\.name, true\)/,
+  /cmd\.argPlaceholder &&[\s\S]*canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*completeCommand\(cmd\.name, Boolean\(cmd\.argPlaceholder\)\)/,
   "Slash-menu Enter autocompletes argument-taking commands (like Tab) instead of running them bare",
+);
+// cave-y7rg0: and a slash typed after prose completes too, whatever the
+// command — running an intent there discards the draft, and /clear wipes the
+// transcript with it. Behavior is covered in
+// src/lib/use-inline-slash-menus-behavior.test.tsx.
+assert.match(
+  slashBranch,
+  /const commandOwnsDraft = \(activeInvocation\?\.start \?\? 0\) === 0;[\s\S]*\(!commandOwnsDraft \|\|/,
+  "Slash-menu Enter only runs a command that owns the draft; mid-draft it completes",
 );
 assert.match(
   menusHookSource,

--- a/src/lib/use-inline-slash-menus-behavior.test.tsx
+++ b/src/lib/use-inline-slash-menus-behavior.test.tsx
@@ -1,0 +1,95 @@
+// @ts-nocheck — react-test-renderer ships no types; matches the convention in
+// use-surface-history.test.tsx.
+//
+// cave-y7rg0: a slash command typed AFTER prose must complete on Enter, never
+// run. inlineSlashInvocation deliberately opens the menu mid-draft, and
+// running an intent from there throws the draft away — /clear also calls
+// setTurns([]) and wipes the whole transcript. A source pin can prove the
+// guard's shape but not that Enter takes the harmless branch, so this drives
+// the real keydown path.
+import { act, create } from "react-test-renderer";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { useInlineSlashMenus } from "./use-inline-slash-menus";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+beforeEach(() => {
+  // The hook fetches skills and prompts on mount; neither matters here.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async () => ({ ok: true, json: async () => [] })),
+  );
+  // This repo's vitest runs in the node environment (no jsdom/happy-dom), and
+  // the hook's only DOM touchpoint is the `cave:prompts-refresh` listener — so
+  // stub that rather than pull in a DOM implementation for two calls.
+  vi.stubGlobal("window", { addEventListener: () => {}, removeEventListener: () => {} });
+});
+afterEach(() => vi.unstubAllGlobals());
+
+/** Mount the hook over a fixed draft and expose its return to the test. */
+function mount(text: string, caret = text.length) {
+  const calls = { run: [] as string[], completed: [] as { text: string; caret: number }[] };
+  const latest = { current: null as ReturnType<typeof useInlineSlashMenus> | null };
+  function Probe() {
+    latest.current = useInlineSlashMenus({
+      text,
+      setText: () => {},
+      caret,
+      onCompleteText: (nextText, nextCaret) => calls.completed.push({ text: nextText, caret: nextCaret }),
+      modelHarness: "claude",
+      modelOptionsOverride: [],
+      onPickModel: () => {},
+      onPickSkill: () => {},
+      onInsertPrompt: () => {},
+      onRunCommand: (cmd) => calls.run.push(cmd.name),
+    });
+    return null;
+  }
+  act(() => {
+    create(<Probe />);
+  });
+  return { calls, latest };
+}
+
+function pressEnter(latest: { current: { handleKeyDown: (e: unknown) => boolean } | null }) {
+  let consumed = false;
+  act(() => {
+    consumed = latest.current.handleKeyDown({
+      key: "Enter",
+      shiftKey: false,
+      preventDefault: () => {},
+    });
+  });
+  return consumed;
+}
+
+test("a slash command typed after prose completes on Enter instead of running", () => {
+  const { calls, latest } = mount("please summarise this /clear");
+
+  expect(pressEnter(latest)).toBe(true);
+
+  // The destructive intent must never fire from a mid-draft slash.
+  expect(calls.run).toEqual([]);
+  // …and the prose the user typed has to survive the completion.
+  expect(calls.completed).toHaveLength(1);
+  expect(calls.completed[0].text).toBe("please summarise this /clear");
+});
+
+test("the same command still runs when it owns the whole draft", () => {
+  const { calls, latest } = mount("/clear");
+
+  expect(pressEnter(latest)).toBe(true);
+
+  expect(calls.run).toEqual(["/clear"]);
+  expect(calls.completed).toEqual([]);
+});
+
+test("an argument-taking command mid-draft also completes rather than running", () => {
+  const { calls, latest } = mount("switch it for me /model");
+
+  expect(pressEnter(latest)).toBe(true);
+
+  expect(calls.run).toEqual([]);
+  expect(calls.completed).toHaveLength(1);
+  expect(calls.completed[0].text).toBe("switch it for me /model ");
+});

--- a/src/lib/use-inline-slash-menus.test.ts
+++ b/src/lib/use-inline-slash-menus.test.ts
@@ -82,8 +82,22 @@ assert.match(
 // ── Enter on a command: autocomplete-then-run ────────────────────────────────
 assert.match(
   src,
-  /canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*?completeCommand\(cmd\.name, true\);[\s\S]*?\} else if \(cmd\) \{[\s\S]*?cbRef\.current\.onRunCommand\(cmd\);/,
+  /canonicalize\(activeInvocation\?\.commandToken \?\? ""\) !== cmd\.name[\s\S]*?completeCommand\(cmd\.name, Boolean\(cmd\.argPlaceholder\)\);[\s\S]*?\} else if \(cmd\) \{[\s\S]*?cbRef\.current\.onRunCommand\(cmd\);/,
   "Enter autocompletes argument-taking commands, runs exact ones, picks skills, and defers no-match to the caller (home submits; chat consumes)",
+);
+
+// ── A mid-draft slash completes, it never runs (cave-y7rg0) ──────────────────
+// Running an intent from a slash that follows prose discards the draft, and
+// /clear also wipes the transcript. Only a command that owns the draft runs.
+assert.match(
+  src,
+  /const commandOwnsDraft = \(activeInvocation\?\.start \?\? 0\) === 0;/,
+  "Enter distinguishes a command that owns the draft from one typed after prose",
+);
+assert.match(
+  src,
+  /if \(\s*\n?\s*cmd &&\s*\n?\s*\(!commandOwnsDraft \|\|/,
+  "a slash that does not own the draft takes the completion branch, never onRunCommand",
 );
 
 // ── Shared listbox id + fetches ──────────────────────────────────────────────

--- a/src/lib/use-inline-slash-menus.ts
+++ b/src/lib/use-inline-slash-menus.ts
@@ -295,15 +295,26 @@ export function useInlineSlashMenus(opts: {
           e.preventDefault();
           const cmd = slashSuggestions[slashIdx];
           const s = skillAt(slashIdx);
-          // If the highlighted command takes an argument and the input isn't
-          // the exact command yet, autocomplete first (like Tab) so the user
-          // can fill in args; otherwise run the highlighted suggestion.
+          // A slash that follows prose completes; only a slash that OWNS the
+          // draft runs. inlineSlashInvocation deliberately opens this menu
+          // mid-draft ("commands after prose or on later lines"), and running
+          // an intent from there throws away everything the user typed —
+          // /clear additionally wipes the whole transcript, and 19 of the 31
+          // commands declare no argPlaceholder, so they skipped the
+          // autocomplete guard below and executed on the first Enter
+          // (cave-y7rg0). Completing instead keeps Enter non-destructive
+          // wherever the draft is more than the command itself.
+          const commandOwnsDraft = (activeInvocation?.start ?? 0) === 0;
+          // Within a command-owned draft, autocomplete first when the command
+          // takes an argument and the token isn't already that command (like
+          // Tab), so the user can fill in args; otherwise run it.
           if (
             cmd &&
-            cmd.argPlaceholder &&
-            canonicalize(activeInvocation?.commandToken ?? "") !== cmd.name
+            (!commandOwnsDraft ||
+              (cmd.argPlaceholder &&
+                canonicalize(activeInvocation?.commandToken ?? "") !== cmd.name))
           ) {
-            completeCommand(cmd.name, true);
+            completeCommand(cmd.name, Boolean(cmd.argPlaceholder));
           } else if (cmd) {
             cbRef.current.onRunCommand(cmd);
           } else if (s) {


### PR DESCRIPTION
Typing a slash command **after prose** and pressing Enter executed the command instead of completing it. For `/clear` that destroyed the conversation — `intentFromSlash` runs `cancelSend()`, `setTurns([])`, `setActiveLeafId("")` and `setInput("")`, so the transcript and the draft both vanish with no confirmation and nothing to undo.

Bead: `cave-y7rg0`.

## How it happened

Three things lined up:

1. **The menu opens mid-draft by design.** `inlineSlashInvocation` matches a slash that begins the draft *or* follows whitespace — its own comment says this allows "commands after prose or on later lines".
2. **The autocomplete guard only covered argument-taking commands.** Enter completed instead of running only when `cmd.argPlaceholder` was truthy. **19 of the 31 commands declare no `argPlaceholder`**, so they skipped the guard entirely and fell through to `onRunCommand` on the first Enter — including `/clear`, `/quit` and `/new`.
3. **The run path never sees the draft.** It passes `cmd.name`, so `intentFromSlash`'s own `startsWith("/")` guard — which would have rejected `"please summarise this /clear"` — never got the chance.

## The fix

An inline slash that follows prose is a *completion* affordance, not an *execution* one. Enter now runs the intent only when the invocation owns the draft (`start === 0`); otherwise it completes the token like Tab, which splices only the invocation range and leaves the prose intact. The ordinary "`/clear` as the whole draft" path is untouched.

## Verification

Covered **behaviorally**, not just by shape — a source pin can prove the guard exists but not which branch Enter takes. The new `use-inline-slash-menus-behavior.test.tsx` drives the real keydown path:

| Case | Asserts |
|---|---|
| `"please summarise this /clear"` | `onRunCommand` never fires; the prose survives |
| `"/clear"` | still runs — existing behavior unchanged |
| `"switch it for me /model"` | argument-taking command mid-draft also completes |

**Mutation-verified.** Reverting the guard fails exactly the two mid-draft tests while the draft-owning control keeps passing:

```
=== with the fix reverted ===
   × a slash command typed after prose completes on Enter instead of running
   × an argument-taking command mid-draft also completes rather than running
      Tests  2 failed | 1 passed (3)
=== restored ===
      Tests  3 passed (3)
```

Also: `check-tests-wired` (1,639 files), `tsc --noEmit` clean, lint clean including the design tokenizer.

Note this repo's vitest runs in the node environment with no jsdom or happy-dom installed, so the test stubs the hook's only `window` touchpoint — the `cave:prompts-refresh` listener — rather than adding a DOM dependency for two calls.