### PR TITLE
fix(ci): warn before the branch cap bites, and explain a rollback

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,25 @@
   in-flight edits from a worktree **wedged** in an abandoned merge or rebase —
   a state that otherwise reads as ordinary dirtiness and gets stepped around
   indefinitely. See the `pnpm wt:status` section of [`CLAUDE.md`](CLAUDE.md).
+- **If a branch you pushed disappears from `origin`, there are exactly two
+  causes — neither of them lost your work.** Nothing local explains either, which
+  is why they are named here (`cave-iy3l7`).
+  1. **The PR merged.** `delete_branch_on_merge` is on, so GitHub drops the head
+     branch. A squash merge lands a *different* commit on `main`, so the branch's
+     own tip is then on no remote ref — retire the worktree through the
+     archive-tag route, and expect the guard to block until a tag exists.
+  2. **The 40-branch cap rolled it back.** `.github/workflows/branch-cap.yml`
+     deletes a *newly created* branch when the repository exceeds 40
+     (`scripts/enforce-branch-cap.mjs`). The deletion is **remote-only** — your
+     local branch and worktree still hold every commit — and the workflow run
+     now says so in its error and its run summary. Push again after freeing
+     capacity; a `retention/<branch>-<sha>` tag may already hold the head, and
+     tags are exempt from the cap.
+
+  Tell them apart with `gh pr list --head <branch> --state all`: a merged PR is
+  cause 1, no PR at all is cause 2. Check the headroom before it bites with
+  `git ls-remote --heads origin | wc -l` — the workflow warns from three
+  creations out, but only on the run page.
 - Do not push directly to `main`; use the protected PR path for repository changes.
 - Before release or TestFlight work, reconcile through clean `main`, then verify from that state.
 

--- a/scripts/enforce-branch-cap.mjs
+++ b/scripts/enforce-branch-cap.mjs
@@ -1,6 +1,14 @@
+import { appendFileSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 export const BRANCH_CAP = 40;
+
+// How close to the cap counts as "warn now". A rollback is only surprising
+// because nothing says it is coming: the count is invisible from a checkout,
+// six concurrent sessions each create branches, and the first sign of trouble
+// is a branch that silently stopped existing. Three creations of notice is
+// enough to retire something before it bites (cave-iy3l7).
+export const NEAR_CAP_HEADROOM = 3;
 
 export function decideBranchCap({
   branchCount,
@@ -18,7 +26,14 @@ export function decideBranchCap({
   if (!defaultBranch) throw new Error("default branch is required");
 
   if (branchCount <= maxBranches) {
-    return { action: "allow", branchCount, maxBranches };
+    const headroom = maxBranches - branchCount;
+    return {
+      action: "allow",
+      branchCount,
+      maxBranches,
+      headroom,
+      nearCap: headroom <= NEAR_CAP_HEADROOM,
+    };
   }
   if (createdBranch === defaultBranch) {
     return {
@@ -85,6 +100,18 @@ export async function runBranchCap({
 
   if (decision.action === "allow") {
     log(`Branch count ${decision.branchCount}/${decision.maxBranches}; creation allowed.`);
+    if (decision.nearCap) {
+      // A warning while there is still room to act. Once the cap trips, the
+      // branch is already gone and the advice arrives too late to be advice.
+      const notice =
+        `Branch cap: ${decision.branchCount}/${decision.maxBranches} — ` +
+        `${decision.headroom} ${decision.headroom === 1 ? "creation" : "creations"} of headroom left. ` +
+        `The next branch created past the cap is DELETED automatically. ` +
+        `Free capacity by retiring merged worktrees (\`pnpm wt:status\`, then the archive-tag route ` +
+        `in CLAUDE.md) rather than waiting for the rollback.`;
+      log(`::warning::${notice}`);
+      writeSummary(env, `⚠️ ${notice}`);
+    }
     return 0;
   }
 
@@ -105,11 +132,46 @@ export async function runBranchCap({
     );
   }
 
-  error(
-    `::error::Deleted '${decision.branch}': repository branch cap ` +
-      `${decision.maxBranches} exceeded (${decision.branchCount} branches).`,
-  );
+  // Say what happened, that the work is safe, and what to do — in the message
+  // itself. A session that loses a branch sees only that it stopped existing;
+  // before this it had to know branch-cap.yml existed to explain that
+  // (cave-iy3l7). The deletion is REMOTE ONLY, which is the part that stops
+  // the panic, so it leads.
+  const explanation = [
+    `Deleted the remote branch '${decision.branch}': the repository is at its ` +
+      `${decision.maxBranches}-branch cap (${describeCount(decision)}), and this workflow rolls back ` +
+      `the newly created branch rather than letting the count grow.`,
+    `Your commits are NOT lost — the deletion is remote-only, so your local branch and worktree ` +
+      `still hold them. In a Claude Code session the retention hook also archives an unreachable head ` +
+      `as a \`retention/<branch>-<sha>\` tag, and tags are exempt from the cap.`,
+    `To land the work: free capacity first (retire merged worktrees — \`pnpm wt:status\`, then the ` +
+      `archive-tag route in CLAUDE.md), then push the branch again.`,
+  ].join(" ");
+  error(`::error::${explanation}`);
+  writeSummary(env, `❌ ${explanation}`);
   return 1;
+}
+
+/** The count, honest about the API page limit rather than quietly understating.
+ *  `per_page=100` means a repository past 100 branches reports exactly 100; the
+ *  decision is unaffected (the cap is capped at 99) but the NUMBER would read
+ *  as fact when it is a floor. */
+function describeCount({ branchCount }) {
+  return branchCount >= 100 ? "100+ branches" : `${branchCount} branches`;
+}
+
+/** Mirror a message into the workflow run summary. The `::error::`/`::warning::`
+ *  annotations are easy to miss under a collapsed step; the summary is the part
+ *  of the run page someone actually reads. Best-effort by design — a failure to
+ *  write a summary must never change the enforcement outcome. */
+function writeSummary(env, message) {
+  const target = env.GITHUB_STEP_SUMMARY;
+  if (!target) return;
+  try {
+    appendFileSync(target, `${message}\n`);
+  } catch {
+    // Non-fatal: the annotation above already carries the message.
+  }
 }
 
 function requiredEnv(env, name) {

--- a/scripts/enforce-branch-cap.test.mjs
+++ b/scripts/enforce-branch-cap.test.mjs
@@ -1,6 +1,10 @@
 import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import {
   BRANCH_CAP,
+  NEAR_CAP_HEADROOM,
   decideBranchCap,
   encodeBranchRef,
   runBranchCap,
@@ -18,8 +22,23 @@ assert.deepEqual(
     action: "allow",
     branchCount: 40,
     maxBranches: 40,
+    headroom: 0,
+    nearCap: true,
   },
+  "the last admissible branch is still allowed, but it is the one most worth warning about",
 );
+
+// The warning has to arrive while there is still room to act on it.
+assert.deepEqual(
+  decideBranchCap({ branchCount: 37, createdBranch: "feat/x", defaultBranch: "main" }),
+  { action: "allow", branchCount: 37, maxBranches: 40, headroom: 3, nearCap: true },
+);
+assert.deepEqual(
+  decideBranchCap({ branchCount: 36, createdBranch: "feat/x", defaultBranch: "main" }),
+  { action: "allow", branchCount: 36, maxBranches: 40, headroom: 4, nearCap: false },
+  "comfortable headroom stays quiet — a warning on every creation would be ignored by the time it mattered",
+);
+assert.equal(NEAR_CAP_HEADROOM, 3, "the warning threshold stays explicit and reviewable");
 
 assert.deepEqual(
   decideBranchCap({
@@ -79,7 +98,35 @@ assert.equal(
   assert.equal(calls.length, 1, "an allowed branch only lists repository branches");
   assert.match(calls[0].url, /branches\?per_page=100$/);
   assert.equal(calls[0].options.headers.authorization, "Bearer test-token");
-  assert.deepEqual(messages, ["Branch count 40/40; creation allowed."]);
+  assert.equal(messages[0], "Branch count 40/40; creation allowed.");
+  // At the cap the creation succeeds, so nothing else would tell the session it
+  // is one branch from a silent rollback.
+  assert.match(messages[1], /^::warning::Branch cap: 40\/40 — 0 creations of headroom left\./);
+  assert.match(messages[1], /is DELETED automatically/);
+  assert.match(messages[1], /pnpm wt:status/, "the warning names the way out, not just the problem");
+  assert.equal(messages.length, 2);
+}
+
+// A comfortable count says nothing beyond the count itself.
+{
+  const messages = [];
+  const status = await runBranchCap({
+    env: {
+      CREATED_BRANCH: "feat/roomy",
+      DEFAULT_BRANCH: "main",
+      GITHUB_API_URL: "https://api.github.test",
+      GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+      GITHUB_TOKEN: "test-token",
+      MAX_BRANCHES: "40",
+    },
+    fetchImpl: async () =>
+      jsonResponse(Array.from({ length: 20 }, (_, index) => ({ name: `branch-${index}` }))),
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  });
+
+  assert.equal(status, 0);
+  assert.deepEqual(messages, ["Branch count 20/40; creation allowed."]);
 }
 
 {
@@ -107,9 +154,96 @@ assert.equal(
   assert.equal(calls.length, 2);
   assert.equal(calls[1].options.method, "DELETE");
   assert.match(calls[1].url, /git\/refs\/heads%2Ffeat%2Fover-cap$/);
-  assert.deepEqual(messages, [
-    "::error::Deleted 'feat/over-cap': repository branch cap 40 exceeded (41 branches).",
-  ]);
+  // The message is the whole point of cave-iy3l7: a session that loses a branch
+  // must not have to know branch-cap.yml exists to explain it. Assert the three
+  // things it has to carry — what happened, that the work survives, what to do.
+  assert.equal(messages.length, 1);
+  assert.match(messages[0], /^::error::Deleted the remote branch 'feat\/over-cap'/);
+  assert.match(messages[0], /40-branch cap \(41 branches\)/, "names the cap and the count");
+  assert.match(messages[0], /commits are NOT lost/, "leads with the part that stops the panic");
+  assert.match(messages[0], /deletion is remote-only/, "and says why: the local branch still holds them");
+  assert.match(messages[0], /retention\/<branch>-<sha>/, "points at the archived head");
+  assert.match(messages[0], /then push the branch again/, "and ends with the recovery");
+}
+
+// The run summary carries the same message: an annotation under a collapsed
+// step is easy to miss, and this workflow's whole failure mode is "nobody knew
+// why".
+{
+  const dir = mkdtempSync(path.join(tmpdir(), "branch-cap-summary-"));
+  const summaryPath = path.join(dir, "summary.md");
+  try {
+    const status = await runBranchCap({
+      env: {
+        CREATED_BRANCH: "feat/over-cap",
+        DEFAULT_BRANCH: "main",
+        GITHUB_API_URL: "https://api.github.test",
+        GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+        GITHUB_TOKEN: "test-token",
+        GITHUB_STEP_SUMMARY: summaryPath,
+        MAX_BRANCHES: "40",
+      },
+      fetchImpl: async (url, options = {}) => {
+        if (options.method === "DELETE") return emptyResponse(204);
+        return jsonResponse(Array.from({ length: 41 }, (_, index) => ({ name: `branch-${index}` })));
+      },
+      log: () => {},
+      error: () => {},
+    });
+    assert.equal(status, 1);
+    const summary = readFileSync(summaryPath, "utf8");
+    assert.match(summary, /Deleted the remote branch 'feat\/over-cap'/);
+    assert.match(summary, /commits are NOT lost/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+// An unwritable summary path must never change the enforcement outcome.
+{
+  const messages = [];
+  const status = await runBranchCap({
+    env: {
+      CREATED_BRANCH: "feat/over-cap",
+      DEFAULT_BRANCH: "main",
+      GITHUB_API_URL: "https://api.github.test",
+      GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+      GITHUB_TOKEN: "test-token",
+      GITHUB_STEP_SUMMARY: path.join(tmpdir(), "no-such-dir-branch-cap", "summary.md"),
+      MAX_BRANCHES: "40",
+    },
+    fetchImpl: async (url, options = {}) => {
+      if (options.method === "DELETE") return emptyResponse(204);
+      return jsonResponse(Array.from({ length: 41 }, (_, index) => ({ name: `branch-${index}` })));
+    },
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  });
+  assert.equal(status, 1, "the rollback still reports as a failure");
+  assert.match(messages[0], /Deleted the remote branch/, "and the annotation still carries the message");
+}
+
+// `per_page=100` makes the count a floor past 100 branches. The decision is
+// unaffected (the cap tops out at 99) but the number must not read as fact.
+{
+  const messages = [];
+  await runBranchCap({
+    env: {
+      CREATED_BRANCH: "feat/over-cap",
+      DEFAULT_BRANCH: "main",
+      GITHUB_API_URL: "https://api.github.test",
+      GITHUB_REPOSITORY: "OpenCoven/coven-cave",
+      GITHUB_TOKEN: "test-token",
+      MAX_BRANCHES: "99",
+    },
+    fetchImpl: async (url, options = {}) => {
+      if (options.method === "DELETE") return emptyResponse(204);
+      return jsonResponse(Array.from({ length: 100 }, (_, index) => ({ name: `branch-${index}` })));
+    },
+    log: (message) => messages.push(message),
+    error: (message) => messages.push(message),
+  });
+  assert.match(messages[0], /99-branch cap \(100\+ branches\)/, "a full page reports as a floor");
 }
 
 {


### PR DESCRIPTION
## What this fixes

`branch-cap.yml` deletes a newly created branch once the repository passes 40 (`scripts/enforce-branch-cap.mjs`). The rollback works. The **diagnosis** does not: a session sees a branch it pushed stop existing, and nothing local explains it — the only account lives in a workflow file you have to already know about. That is the durable half of `cave-iy3l7`'s acceptance criteria:

> a session losing a branch to the rollback should find the reason without needing to read branch-cap.yml

## Three changes, all about the moment it happens

**Warn from three creations out.** The count is invisible from a checkout and several concurrent sessions each create branches, so the first sign of trouble was the rollback itself. At 37/40 the warning still buys time to retire something; on every creation it would be noise by the time it mattered, so a comfortable count stays silent (`NEAR_CAP_HEADROOM = 3`, exported and pinned).

**Say what happened in the failure itself.** The old message was `Deleted 'X': repository branch cap 40 exceeded (41 branches).` — accurate and useless to the person it happened to. It now leads with the part that stops the panic: the deletion is **remote-only**, the local branch and worktree still hold every commit. Then that an unreachable head is archived as a `retention/<branch>-<sha>` tag which the cap exempts, and that landing the work means freeing capacity and pushing again.

**Mirror both into the run summary.** An annotation under a collapsed step is easy to miss, and "nobody knew why" is this workflow's entire failure mode. `GITHUB_STEP_SUMMARY` is a default Actions variable, so no workflow change was needed. Best-effort by construction: a summary that cannot be written never changes the enforcement outcome, and there is a test for exactly that.

**AGENTS.md gets the other half**, because the session looking for an explanation is local, not on the run page. It now names the two causes of a branch vanishing from `origin` — merged auto-delete vs. the cap — how to tell them apart with one `gh pr list --head <branch> --state all`, and how to read the headroom before it bites. AGENTS.md previously never mentioned the cap at all.

## Also

`per_page=100` makes the count a floor: a repository past 100 branches reports exactly 100. The decision was never affected (the cap tops out at 99), but the number read as fact — it now says `100+`.

## Verification

`scripts/enforce-branch-cap.test.mjs` covers each claim: the near-cap warning fires at 40/40 and names the way out, a comfortable 20/40 stays quiet, the rollback message carries all four required parts, the summary file receives it, an unwritable summary path still reports the failure, and a full page reports `100+`. `typecheck` and `check:tests-wired` green.

## What this does NOT do

It does not reduce the branch count or raise the cap — the other limb of the acceptance criteria. Remote deletion is proposal-only per `CLAUDE.md`, so that stays your call. Measured while writing this: **35/40 remote branches, five creations of headroom** (up from 31 at the last recount on 2026-08-12, so it is tightening, not easing).

Bead: `cave-iy3l7`.