### PR TITLE
fix(worktree): stop resurrecting branches this hook itself pushed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,14 +679,30 @@ only covers heads that already carry an archive tag. So the hook archives the
 head as its `retention/…` tag instead, and the log entry carries
 `reason: "branch-deleted-upstream"`.
 
-Deleted is distinguished from never-pushed by the local remote-tracking ref:
-`refs/remotes/origin/<branch>` is written by a push and survives the remote
-dropping the branch, so tracking-ref-present + absent-from-`ls-remote` means
-deleted. A branch that never left the machine has no such ref and is still
-retained as a readable branch. Note `git push --delete` is **not** equivalent to
-a server-side deletion — it removes the local tracking ref too — and if a
-`fetch --prune` has already run the signal is gone, in which case the hook falls
-back to its previous behaviour: a resurrected branch, never a lost commit.
+Deleted is distinguished from never-pushed by **three** signals, any one of
+which proves the branch was once on the remote — because each survives
+something the others do not (`cave-xjuup`):
+
+- `refs/remotes/origin/<branch>`, written by a push. Survives the remote
+  dropping the branch, but **not** a `fetch --prune`.
+- `branch.<name>.remote`, written only by `push -u`. Lives in `.git/config`, so
+  a prune cannot touch it — but plenty of branches never get one.
+- **the hook's own log**, which records that *it* pushed the branch. Survives
+  everything short of deleting the file.
+
+Absence of all three still means branch-first, so a branch that never left the
+machine is still retained as a readable branch. Note `git push --delete` is
+**not** equivalent to a server-side deletion — it removes the local tracking ref
+too.
+
+⚠️ **One signal was not enough, and the shortfall was measurable.** GitHub
+Desktop prunes routinely here, so by the time the hook looked the tracking ref
+was gone, the branch read as "never pushed", and the hook re-created a head
+GitHub had deliberately deleted at merge. Measured 2026-08-14: **9 of 36 remote
+branches were resurrected merged heads**, 29 pushes across them, one branch
+re-created three separate times — a quarter of the 40-branch cap consumed by
+branches that should not exist, and hand-deleting them would not have stayed
+bought.
 
 ⚠️ **That same surviving tracking ref is what made this path unreachable for a
 day.** The at-risk test was `rev-list HEAD --not --remotes`, and `--remotes`

--- a/scripts/worktree-retention-push.mjs
+++ b/scripts/worktree-retention-push.mjs
@@ -21,7 +21,7 @@
 // Advisory only: this never blocks a tool call and always exits 0.
 
 import { execFileSync } from "node:child_process";
-import { appendFileSync, mkdirSync, realpathSync, statSync, writeFileSync } from "node:fs";
+import { appendFileSync, mkdirSync, readFileSync, realpathSync, statSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -29,6 +29,10 @@ const THROTTLE_MS = 60_000;
 // Bounds worst-case latency added to one tool call. Pushed worktrees drop out
 // of the at-risk set, so successive passes reach the rest.
 const MAX_PUSHES_PER_PASS = 3;
+
+// Ceiling on the log scan below, so an unbounded log can never stall a tool
+// call. At roughly 360 bytes a line this still covers a six-figure entry count.
+const MAX_LOG_SCAN_BYTES = 32 * 1024 * 1024;
 const PUSH_TIMEOUT_MS = 20_000;
 
 function projectRoot() {
@@ -205,6 +209,63 @@ export function hadRemoteTracking(worktreePath, branch) {
   }
 }
 
+/**
+ * Did a push ever configure an upstream for this branch?
+ *
+ * `branch.<name>.remote` lives in `.git/config`, not in the ref store, so
+ * unlike the remote-tracking ref it SURVIVES `fetch --prune`. Only `push -u`
+ * (or an explicit `--set-upstream`) writes it, so it is a partial signal —
+ * present for some branches and not others — which is exactly why it is one of
+ * several rather than the answer.
+ */
+export function hasUpstreamConfig(worktreePath, branch) {
+  if (!branch) return false;
+  try {
+    return git(["config", "--get", `branch.${branch}.remote`], worktreePath).trim().length > 0;
+  } catch {
+    return false; // `config --get` exits 1 when unset
+  }
+}
+
+/**
+ * Branch names this hook has previously pushed, read back from its own log.
+ *
+ * The durable half of the fix. Every other "was this on the remote?" signal
+ * lives in the ref store or the config and can be pruned, rewritten, or never
+ * written; the log is this hook's own append-only record that it PUT the branch
+ * there, and it survives everything short of deleting the file.
+ *
+ * Absence proves nothing (the log is gitignored, rotatable, and empty on a
+ * fresh checkout), so this only ever ADDS proof — it can turn a branch push
+ * into an archive, never the reverse.
+ *
+ * Returns an empty set rather than null on failure: an unreadable log means no
+ * evidence, which lands on the pre-existing behaviour.
+ */
+export function previouslyPushedBranches(root) {
+  const logPath = path.join(root, ".claude", "worktree-retention-push.log");
+  const pushed = new Set();
+  try {
+    // Bounded so a pathological log can never stall a tool call. At ~360 bytes
+    // a line this still covers a six-figure entry count.
+    if (statSync(logPath).size > MAX_LOG_SCAN_BYTES) return pushed;
+    for (const line of readFileSync(logPath, "utf8").split("\n")) {
+      if (!line || !line.includes('"pushed-branch"')) continue;
+      try {
+        const entry = JSON.parse(line);
+        if (entry?.verdict === "pushed-branch" && typeof entry.branch === "string") {
+          pushed.add(entry.branch);
+        }
+      } catch {
+        // a truncated final line is normal for an append-only log
+      }
+    }
+  } catch {
+    // no log yet, or unreadable — no evidence either way
+  }
+  return pushed;
+}
+
 function branchOf(worktreePath) {
   try {
     const name = git(["rev-parse", "--abbrev-ref", "HEAD"], worktreePath).trim();
@@ -301,12 +362,35 @@ function main() {
   // Same lazy-once-per-pass shape as tagRetained: a pass where nothing is at
   // risk never reaches the network.
   let branchNames;
+  // Read once per pass, like the two lookups above, and only when something is
+  // actually at risk.
+  let pushedBefore;
   const deletedUpstream = (worktreePath, branch) => {
     if (!branch) return false;
     if (branchNames === undefined) branchNames = remoteBranchNames(root);
     if (!branchNames) return false; // remote unreachable — no proof, stay branch-first
     if (branchNames.has(branch)) return false;
-    return hadRemoteTracking(worktreePath, branch);
+    // Absent from the remote. Deleted, or never pushed? Three signals, ANY of
+    // which proves it was once there — and each survives something the others
+    // do not (cave-xjuup):
+    //
+    //   - the remote-tracking ref, which a `fetch --prune` erases;
+    //   - `branch.<name>.remote`, which only `push -u` writes;
+    //   - this hook's own log, which records that IT pushed the branch.
+    //
+    // One signal was not enough. GitHub Desktop prunes routinely here, so the
+    // tracking ref was gone by the time the hook looked, the branch read as
+    // "never pushed", and the hook re-created a head GitHub had deliberately
+    // deleted at merge: 9 of 36 remote branches were resurrected merged heads,
+    // 29 pushes across them, one branch re-created three separate times.
+    //
+    // Each signal only ever ADDS proof, so this can turn a branch push into an
+    // archive and never the reverse. No signal at all still means branch-first
+    // — a never-pushed branch is still retained as a readable branch.
+    if (hadRemoteTracking(worktreePath, branch)) return true;
+    if (hasUpstreamConfig(worktreePath, branch)) return true;
+    if (pushedBefore === undefined) pushedBefore = previouslyPushedBranches(root);
+    return pushedBefore.has(branch);
   };
 
   let pushes = 0;

--- a/scripts/worktree-retention-push.test.mjs
+++ b/scripts/worktree-retention-push.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -9,8 +9,10 @@ const NULL_DEVICE = process.platform === "win32" ? "NUL" : "/dev/null";
 
 import {
   hadRemoteTracking,
+  hasUpstreamConfig,
   headSha,
   parseWorktrees,
+  previouslyPushedBranches,
   remoteBranchNames,
   remoteTagCommits,
   retain,
@@ -257,6 +259,132 @@ test("unpushedCountIgnoring counts everything when the ignored ref was the only 
     );
   } finally {
     rmSync(root, { recursive: true, force: true });
+  }
+});
+
+// The resurrection this fixes (cave-xjuup). A merged branch is deleted by
+// GitHub, a routine `fetch --prune` erases the tracking ref, and the hook then
+// reads the branch as "never pushed" and re-creates a head that was deleted on
+// purpose. Measured before the fix: 9 of 36 remote branches were resurrected
+// merged heads, 29 pushes across them, one branch re-created three times.
+test("the hook archives rather than resurrects a merged branch whose tracking ref was pruned", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    const unit = path.join(work, ".worktrees", "topic");
+    git(["worktree", "add", "-q", "-b", "feat/topic", unit], work);
+    configure(unit);
+    commit(unit, "one");
+    git(["push", "-q", "-u", "origin", "feat/topic"], unit);
+    const head = git(["rev-parse", "HEAD"], unit).trim();
+
+    const mainWork = path.join(root, "mainwork");
+    git(["clone", "-q", remote, mainWork], root);
+    configure(mainWork);
+    git(["merge", "-q", "--squash", "origin/feat/topic"], mainWork);
+    git(["commit", "-q", "-m", "squashed topic (#1)"], mainWork);
+    git(["push", "-q", "origin", "main"], mainWork);
+    bare(["update-ref", "-d", "refs/heads/feat/topic"], remote);
+
+    // The prune that erases the evidence — and, with it, every ref-based signal.
+    git(["fetch", "-q", "--prune", "origin"], work);
+    assert.equal(
+      hadRemoteTracking(work, "feat/topic"),
+      false,
+      "the tracking ref is gone: this is the state that used to read as 'never pushed'",
+    );
+    // The upstream config survives the prune, so clear it too — otherwise this
+    // fixture proves the weaker signal rather than the log-based one.
+    git(["config", "--unset", "branch.feat/topic.remote"], work);
+    git(["config", "--unset", "branch.feat/topic.merge"], work);
+    assert.equal(hasUpstreamConfig(work, "feat/topic"), false);
+
+    // What remains is this hook's own record that it pushed the branch.
+    mkdirSync(path.join(work, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(work, ".claude", "worktree-retention-push.log"),
+      `${JSON.stringify({ at: "2026-08-13T04:11:15.000Z", verdict: "pushed-branch", branch: "feat/topic", sha: head })}\n`,
+    );
+    assert.ok(previouslyPushedBranches(work).has("feat/topic"), "the log is the surviving evidence");
+
+    execFileSync(process.execPath, [path.join(import.meta.dirname, "worktree-retention-push.mjs")], {
+      cwd: work,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...ISOLATED, CLAUDE_PROJECT_DIR: work },
+    });
+
+    assert.equal(
+      bare(["for-each-ref", "--format=%(refname)", "refs/heads/feat/topic"], remote).trim(),
+      "",
+      "the deliberately deleted branch is NOT resurrected",
+    );
+    assert.equal(
+      bare(["rev-parse", `refs/tags/${retentionTag("feat/topic", head)}`], remote).trim(),
+      head,
+      "and the head is retained as a tag instead",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a branch that genuinely never left the machine is still retained as a branch", () => {
+  const { root, remote, work } = scaffold();
+  try {
+    const unit = path.join(work, ".worktrees", "fresh");
+    git(["worktree", "add", "-q", "-b", "feat/fresh", unit], work);
+    configure(unit);
+    commit(unit, "one");
+    // No push, no tracking ref, no upstream config, and nothing in the log.
+    execFileSync(process.execPath, [path.join(import.meta.dirname, "worktree-retention-push.mjs")], {
+      cwd: work,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...ISOLATED, CLAUDE_PROJECT_DIR: work },
+    });
+    assert.equal(
+      bare(["rev-parse", "refs/heads/feat/fresh"], remote).trim(),
+      git(["rev-parse", "HEAD"], unit).trim(),
+      "no evidence of a previous push means branch-first, exactly as before",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("previouslyPushedBranches reads only real pushed-branch records", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "retention-log-"));
+  try {
+    mkdirSync(path.join(dir, ".claude"), { recursive: true });
+    writeFileSync(
+      path.join(dir, ".claude", "worktree-retention-push.log"),
+      [
+        JSON.stringify({ verdict: "pushed-branch", branch: "feat/pushed" }),
+        JSON.stringify({ verdict: "pushed-tag", branch: "feat/tagged" }),
+        JSON.stringify({ verdict: "retention-failed", branch: "feat/failed" }),
+        JSON.stringify({ verdict: "skipped-tag-retained", count: 2, branches: ["feat/skipped"] }),
+        "{ this line is truncated",
+      ].join("\n") + "\n",
+    );
+    const pushed = previouslyPushedBranches(dir);
+    assert.ok(pushed.has("feat/pushed"));
+    // A tag push proves nothing about the BRANCH ever existing on the remote,
+    // and a failure proves the opposite.
+    assert.ok(!pushed.has("feat/tagged"));
+    assert.ok(!pushed.has("feat/failed"));
+    assert.ok(!pushed.has("feat/skipped"), "the summary line names branches it did not push");
+    assert.equal(pushed.size, 1, "a truncated final line is survivable, not fatal");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("previouslyPushedBranches is empty when there is no log at all", () => {
+  const dir = mkdtempSync(path.join(tmpdir(), "retention-nolog-"));
+  try {
+    assert.equal(previouslyPushedBranches(dir).size, 0, "absence is no evidence, never an error");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
## The measurement

**9 of 36 remote branches have MERGED PRs and are still on origin**, despite `delete_branch_on_merge: true`. They are back because this hook re-created them — **29** `pushed-branch` log entries across the nine. `docs/cave-qayaq-release-v033-changelog` merged on 08-13 and was pushed back at 04:11, at 07:04, and again the next morning at 07:49.

That is a quarter of the 40-branch cap (`cave-iy3l7`) held by branches that should not exist. Deleting them by hand does not stay bought: the next prune plus the next hook pass brings them back. It also silently undoes deliberate archive-and-delete retirements — the `cave-nw3hq` regression arriving by a new route.

## Why it happened

The hook decides branch-first vs archive by asking whether the branch was ever on the remote, and it asked with exactly one signal — `refs/remotes/origin/<branch>`. That ref survives the remote deleting the branch, which is what made it a good signal, but **not** a `fetch --prune`. GitHub Desktop prunes routinely here, so by the time the hook looked the ref was usually gone, the branch read as "never pushed", and the branch-first path re-created a head GitHub had deliberately deleted at merge.

`CLAUDE.md` documented this as an accepted fallback — *"a resurrected branch, never a lost commit"*. The commit safety was right; what nobody had measured was the cost at volume.

## The fix

Ask three ways, each surviving what the others do not:

| signal | survives | limitation |
|---|---|---|
| `refs/remotes/origin/<branch>` | remote deletion | erased by `fetch --prune` |
| `branch.<name>.remote` | pruning (it is in `.git/config`) | only `push -u` writes it |
| this hook's own log | everything short of deleting the file | absent on a fresh checkout |

Every signal only ever **adds** proof, so this can turn a branch push into an archive and never the reverse. No signal at all is still branch-first — a branch that never left the machine is still retained as a readable branch, pinned by its own test which passes with the fix reverted, precisely because nothing on that path changed.

The log scan is bounded (32 MiB, so an unbounded log cannot stall a tool call), tolerates a truncated final line, and reads only `pushed-branch` records — a tag push proves nothing about the branch, and a failed push proves the opposite.

## Verification

End-to-end through the hook's entry point on the real sequence: push a branch, squash-merge it so a different commit lands on `main`, delete the ref **inside the bare remote** (server-side, as GitHub does), then `fetch --prune` *and* clear the upstream config so the log is the only surviving evidence. Result: the deleted branch stays deleted, and the head is retained as a `retention/…` tag.

**Reverting the fix fails that test** (confirmed: `✖ the hook archives rather than resurrects a merged branch whose tracking ref was pruned`), while the never-pushed test passes either way. 23 tests green; `typecheck` and `check:tests-wired` green.

## Note on the nine

This stops new resurrections; it does not delete the nine that already exist. Remote deletion is proposal-only, so that stays a maintainer call — but it is now worth doing, because after this lands the headroom holds.

Bead: `cave-xjuup`.