### PR TITLE
fix(analytics): stop redaction collapsing self-reports and crashing the view

### DIFF
--- a/src/app/api/familiars/[id]/self-reports/route.ts
+++ b/src/app/api/familiars/[id]/self-reports/route.ts
@@ -19,5 +19,14 @@ export async function GET(req: Request, ctx: { params: Promise<{ id: string }> }
     : limitRaw ? Number.parseInt(limitRaw, 10) : undefined;
   const before = url.searchParams.get("before") ?? undefined;
   const result = await listSelfReports(id, { limit, before });
-  return NextResponse.json({ ok: true, reports: redactSecretsDeep(result.reports), total: result.total });
+  // Redact per report, never the whole collection. redactSecretsDeep carries a
+  // traversal budget (MAX_REDACTION_ENTRIES) and returns the *scalar* string
+  // "[redacted]" for the entire value once it is exceeded — so redacting the
+  // array wholesale turned `reports` into a string as self-report history grew
+  // past the ceiling, which `?limit=all` reaches first. The client then spread
+  // that string into characters and crashed on `b.id.localeCompare` inside
+  // aggregateThreadSignals (cave-p9dsb). Per-report redaction keeps the array
+  // an array: an oversized report degrades on its own and its siblings survive.
+  const reports = result.reports.map((report) => redactSecretsDeep(report));
+  return NextResponse.json({ ok: true, reports, total: result.total });
 }

--- a/src/components/familiar-analytics-data.ts
+++ b/src/components/familiar-analytics-data.ts
@@ -212,7 +212,10 @@ export async function loadFamiliarAnalyticsData(familiarId: string): Promise<Fam
     memoryAvailability:
       memoryJson.state === "ready" ? "ready" : "unavailable",
     retroSnapshot: retroJson.snapshot ?? EMPTY_SNAPSHOT,
-    threadReports: selfReportsJson.ok ? selfReportsJson.reports : [],
+    // `ok: true` says the request succeeded, not that the payload has the shape
+    // its type claims — SelfReportsResponse is erased at runtime. Check it here
+    // rather than let a non-array reach the aggregation (cave-p9dsb).
+    threadReports: Array.isArray(selfReportsJson.reports) ? selfReportsJson.reports : [],
     metricSnapshots: metricSnapshotsJson.ok ? metricSnapshotsJson.snapshots : [],
     modelFeedback: feedbackJson.ok ? feedbackJson.rollup : EMPTY_FEEDBACK_ROLLUP,
     errors,

--- a/src/lib/thread-confidence.test.ts
+++ b/src/lib/thread-confidence.test.ts
@@ -114,3 +114,38 @@ describe("empty-state copy", () => {
     assert.match(THREAD_CONFIDENCE_EMPTY_STATE, /Enable response self-reporting/);
   });
 });
+
+// ── The Analytics crash: a wire payload that is not an array (cave-p9dsb) ────
+// The self-reports route redacted the whole collection, and redactSecretsDeep
+// returns the scalar string "[redacted]" once its traversal budget is spent —
+// so `reports` arrived as a string. Spreading it yielded characters, whose
+// reportedAt parses to NaN, so the comparator fell through to
+// `b.id.localeCompare(a.id)` and threw inside Array.sort, taking the whole
+// Familiar Analytics surface down through its error boundary.
+describe("deriveThreadConfidence with a malformed payload", () => {
+  it("treats a redacted (non-array) payload as unmeasured instead of throwing", () => {
+    const redacted = "[redacted]" as unknown as ThreadSelfReport[];
+    const confidence = deriveThreadConfidence(redacted);
+    assert.equal(confidence.hasData, false);
+    assert.equal(confidence.score, 0);
+    assert.equal(confidence.reportCount, 0);
+  });
+
+  it("skips rows missing an id rather than crashing the sort", () => {
+    const rows = [
+      report({ id: "r-2", overallConfidence: 90 }),
+      { reportedAt: "2026-06-25T13:00:00.000Z" } as unknown as ThreadSelfReport,
+      report({ id: "r-1", overallConfidence: 70 }),
+    ];
+    const confidence = deriveThreadConfidence(rows);
+    assert.equal(confidence.hasData, true);
+    // Only the two well-formed rows count toward the aggregate.
+    assert.equal(confidence.reportCount, 2);
+  });
+
+  it("still reports normally for a well-formed array", () => {
+    const confidence = deriveThreadConfidence([report({ id: "r-1" }), report({ id: "r-2" })]);
+    assert.equal(confidence.hasData, true);
+    assert.equal(confidence.reportCount, 2);
+  });
+});

--- a/src/lib/thread-confidence.ts
+++ b/src/lib/thread-confidence.ts
@@ -83,7 +83,15 @@ export function threadConfidenceLabel(score: number): ThreadConfidenceLabel {
  * (hasData false, score 0) — never a fake "Low".
  */
 export function deriveThreadConfidence(reports: ThreadSelfReport[]): ThreadConfidence {
-  const aggregate = aggregateThreadSignals(reports);
+  // Sanitize once, here, and count from the same set the aggregate scores.
+  // `reports` crosses the wire, so its type is a claim rather than a fact: a
+  // redaction budget once delivered the string "[redacted]", whose `.length`
+  // of 10 would otherwise read as ten reports' worth of data (cave-p9dsb).
+  const usable = (Array.isArray(reports) ? reports : []).filter(
+    (report): report is ThreadSelfReport =>
+      Boolean(report) && typeof report === "object" && typeof report.id === "string",
+  );
+  const aggregate = aggregateThreadSignals(usable);
   const values: Record<ThreadMetricKey, number> = {
     confidence: clampScore(aggregate.averageConfidence),
     toolReliability: clampScore(aggregate.averageToolReliability),
@@ -96,7 +104,7 @@ export function deriveThreadConfidence(reports: ThreadSelfReport[]): ThreadConfi
     value: values[key],
     weight: THREAD_METRIC_WEIGHTS[key],
   }));
-  const hasData = reports.length > 0;
+  const hasData = usable.length > 0;
   const score = hasData
     ? clampScore(metrics.reduce((sum, metric) => sum + metric.value * metric.weight, 0))
     : 0;
@@ -104,7 +112,7 @@ export function deriveThreadConfidence(reports: ThreadSelfReport[]): ThreadConfi
   return {
     score,
     label: threadConfidenceLabel(score),
-    reportCount: reports.length,
+    reportCount: usable.length,
     hasData,
     metrics,
     contextCounts: aggregate.contextCounts,

--- a/src/lib/thread-self-report.ts
+++ b/src/lib/thread-self-report.ts
@@ -668,7 +668,19 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
   const blockerFreq = new Map<string, number>();
   const blockerData = new Map<string, ThreadSelfReport["persistentBlockers"][number]>();
 
-  const sorted = [...reports].sort(
+  // Defensive at the boundary, not because storage is untrusted — listSelfReports
+  // already drops rows failing isThreadSelfReport — but because this value
+  // arrives over the wire, where a type annotation is erased and cannot hold.
+  // A redaction budget once replaced the whole array with the string
+  // "[redacted]"; spreading that yields characters, whose `reportedAt` parses
+  // to NaN, so the comparator fell through to `b.id.localeCompare` and threw
+  // inside Array.sort — taking the entire Analytics surface down (cave-p9dsb).
+  // Unmeasured is a legitimate result here; a thrown comparator is not.
+  const usable = (Array.isArray(reports) ? reports : []).filter(
+    (report): report is ThreadSelfReport =>
+      Boolean(report) && typeof report === "object" && typeof report.id === "string",
+  );
+  const sorted = [...usable].sort(
     (a, b) =>
       new Date(b.reportedAt).getTime() - new Date(a.reportedAt).getTime() ||
       b.id.localeCompare(a.id),
@@ -720,7 +732,7 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
     }
   }
 
-  const total = reports.length || 1;
+  const total = usable.length || 1;
   const rankedBlockers: RankedBlocker[] = [...blockerFreq.entries()]
     .map(([id, frequency]) => {
       const data = blockerData.get(id)!;
@@ -729,10 +741,10 @@ export function aggregateThreadSignals(reports: ThreadSelfReport[]): ThreadSigna
     .sort((a, b) => b.rankScore - a.rankScore);
 
   return {
-    averageConfidence: libAvg(reports.map((r) => r.overallConfidence)),
-    averageToolReliability: libAvg(reports.map((r) => r.toolReliability.score)),
-    averageMemoryRecall: libAvg(reports.map((r) => r.memoryRecallScore)),
-    averageFileLocatability: libAvg(reports.map((r) => r.fileLocatabilityScore)),
+    averageConfidence: libAvg(usable.map((r) => r.overallConfidence)),
+    averageToolReliability: libAvg(usable.map((r) => r.toolReliability.score)),
+    averageMemoryRecall: libAvg(usable.map((r) => r.memoryRecallScore)),
+    averageFileLocatability: libAvg(usable.map((r) => r.fileLocatabilityScore)),
     contextCounts,
     skillsUsedMost: [...skillsUsed.entries()]
       .sort((a, b) => b[1] - a[1])


### PR DESCRIPTION
Familiar Analytics throws `Cannot read properties of undefined (reading 'localeCompare')` from inside `Array.sort` and the whole surface goes down through its error boundary. Reported live from a dev session; bead `cave-p9dsb`.

## No malformed row is involved

The storage boundary **already validates** — `listSelfReports` drops anything failing `isThreadSelfReport`, which requires `id`. That matters because the bead originally prescribed adding validation there, which would have changed nothing.

## The API destroys the collection in transit

The route serialized `redactSecretsDeep(result.reports)`. `redactSecretsDeep` carries a traversal budget, `MAX_REDACTION_ENTRIES`. Once exceeded, `readContainer` returns `undefined` and the caller does:

```js
if (!container || !frame.assign(container.output)) return REDACTED_SECRET as T;
```

That is **not** partial truncation — the entire value becomes the scalar string `"[redacted]"`. Analytics fetches with `?limit=all`, which reaches that ceiling first, so the crash appears as self-report history grows and differs between machines. Nothing to do with corrupt data.

From there it's mechanical: `[...reports]` spreads the string into **characters**, whose `reportedAt` parses to `NaN`, so the comparator falls through to `b.id.localeCompare(a.id)` — and a character has no `id`.

## Fixed at four points, root first

| Where | Change |
|---|---|
| `self-reports/route.ts` | Redact **per report** — the array stays an array; an oversized record degrades alone |
| `deriveThreadConfidence` | Sanitize once, and count from the same set it scores |
| `aggregateThreadSignals` | Tolerate a non-array; skip rows with no `id` |
| `familiar-analytics-data.ts` | `Array.isArray` instead of trusting `ok: true` |

Two of those exist because the first attempt was insufficient, and the tests caught it:

- `hasData` and `reportCount` read the **raw** value, so `"[redacted]".length` of 10 reported ten reports' worth of data. Guarding only the sort would have traded a crash for a **silent lie** on the dashboard.
- `aggregateThreadSignals` also calls `reports.map()` four times, and `.map` on a string throws exactly as the spread did — guarding just the spread would have moved the crash three lines down.

## Verification

New regression tests assert the redacted payload reads as unmeasured, that id-less rows are skipped rather than fatal, and that a well-formed array is unaffected.

**Mutation-verified** — reverting the guards fails exactly the two new cases and leaves the control passing:

```
--- with guards reverted ---   ℹ pass 9   ℹ fail 2
--- restored ---              ℹ pass 11  ℹ fail 0
```

Seven affected suites pass: `thread-confidence`, `thread-self-report`, `familiar-analytics-{navigation,view,insight}`, `secret-redaction`, `familiar-self-reports`. `tsc --noEmit` clean.

Note the bead's description still prescribes the storage-boundary fix; the corrected diagnosis is recorded in a comment on it and should replace the description when this lands.